### PR TITLE
fix(worktree): liveness-before-reap + root-clone auto-ff + abandoned-merge quarantine (EP-PROCESS-SPINE)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,10 @@ dev/null/
 # Local-integration-CI runner verdict artifacts (never committed)
 .dpf-local-ci-*.json
 .dpf-sandbox-freshness.json
+
+# Worktree session heartbeat — a live session's liveness marker, refreshed every
+# turn and read by the fleet worktree janitor so it never reaps a worktree out from
+# under a live session (plan 2026-08-11-worktree-lifecycle-hygiene). Gitignored so
+# it never dirties the tree (which would muddy the janitor's dirty signal and block
+# a worktree's own Tier-A SessionEnd reap).
+.dpf-session-heartbeat.json

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1261,6 +1261,9 @@
     "packages/dpf-skill-pack/hooks/process-spine-health-check.mjs": [
       "docs/architecture/skill-surfaces-runbook.md"
     ],
+    "packages/dpf-skill-pack/hooks/root-clone-freshness.mjs": [
+      "docs/architecture/branch-and-worktree-runbook.md"
+    ],
     "packages/dpf-skill-pack/hooks/tool-economy-precheck.mjs": [
       "docs/architecture/context-engineering-standards.md"
     ],
@@ -1645,6 +1648,9 @@
       "docs/architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md",
       "docs/edge-node/deployment-topology.md"
     ],
+    "scripts/worktree-janitor.mjs": [
+      "docs/architecture/branch-and-worktree-runbook.md"
+    ],
     "services/edge-node/scripts/verify-lifecycle.ts": [
       "docs/architecture/2026-06-19-edge-node-deployment-sysml-architecture-note.md",
       "docs/install/edge-node-multi-host.md",
@@ -2004,7 +2010,9 @@
     ],
     "docs/architecture/branch-and-worktree-runbook.md": [
       "apps/web/lib/self-upgrade/local-changes-ledger.ts",
-      "scripts/dpf-bootstrap-agent-toolchain.ps1"
+      "packages/dpf-skill-pack/hooks/root-clone-freshness.mjs",
+      "scripts/dpf-bootstrap-agent-toolchain.ps1",
+      "scripts/worktree-janitor.mjs"
     ],
     "docs/architecture/build-gate-runbook.md": [
       "apps/web/lib/integrate/build-orchestrator.ts",

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -896,6 +896,8 @@
         "verification-readiness-classification",
         "compose-project-isolation",
         "freshness-a-stale-worktree-base-is-a-landmine",
+        "root-clone-freshness-the-shared-root-must-stay-on-current-main",
+        "reaping-safety-a-live-sessions-worktree-is-never-reaped",
         "rebasing-on-a-shallow-clone-never-a-bare-git-rebase-originmain",
         "housekeeping"
       ]

--- a/docs/architecture/branch-and-worktree-runbook.md
+++ b/docs/architecture/branch-and-worktree-runbook.md
@@ -68,6 +68,19 @@ Before serious implementation: `git fetch origin main`, confirm your base is cur
 
 The durable fix is to create worktrees from a freshly-fetched `origin/main` in the first place.
 
+## Root-clone freshness — the shared root must stay on current `main`
+
+This is a *different* concern from worktree-base freshness above: peer worktrees junction `@dpf/*` workspace packages into the **shared root clone**'s source tree, so if the root clone's own checkout falls behind `origin/main`, `pregate-preflight` aborts with *"Stale root clone detected (BI-A900EA3F)"* for **every** worktree until the root is fast-forwarded — even worktrees whose own branch is perfectly current.
+
+The `SessionStart` `root-clone-freshness` hook (`packages/dpf-skill-pack/hooks/root-clone-freshness.mjs`) fast-forwards the root clone to `origin/main` automatically at session start — **fast-forward only**, and only when the root is on `main` and clean. It **refuses** (and prints an advisory) when the root is off-main, detached, or dirty, because those states mean work is stranded there and a forced move would corrupt it. Run it by hand any time with `node scripts/root-clone-refresh.mjs [--json]`; silence the hook with `DPF_SKIP_ROOT_CLONE_REFRESH=1`. This runs the same safe `git merge --ff-only origin/main` that the stale-root-clone detector already recommends, so it never conflicts with the root-clone delete/mutation guard.
+
+## Reaping safety — a live session's worktree is never reaped
+
+The worktree janitor (`scripts/worktree-janitor.mjs`, fleet backstop; and the SessionEnd reaper) removes merged+clean worktrees. Two safety rails keep it from removing a worktree out from under work:
+
+- **Live-session gate.** A session writes a gitignored `.dpf-session-heartbeat.json` marker into its worktree, refreshed every turn by the `worktree-session-heartbeat` hook (SessionStart/Stop) and removed on SessionEnd. The janitor treats a fresh marker (TTL default 60 min, `DPF_WORKTREE_SESSION_HEARTBEAT_TTL_MIN`) as `KEEP`, **outranking** Tier-A eligibility — because a live session's tree first becomes Tier-A the moment its own PR merges, which is exactly when it must not be reaped.
+- **Abandoned-merge quarantine.** A worktree with `MERGE_HEAD` present and **no** live session is classified `FLAG_ABANDONED_MERGE`: surfaced in the janitor summary and never auto-reaped, since an interrupted merge can hide un-reconciled work. A *live* session's in-progress merge is kept, not flagged.
+
 ## Rebasing on a shallow clone — never a bare `git rebase origin/main`
 
 ⟦runtime: precondition — shallow checkouts only; on a full clone the phantom replay does not occur⟧

--- a/docs/founder-kernel/wiki/principles/worktree-selection-and-reaping.md
+++ b/docs/founder-kernel/wiki/principles/worktree-selection-and-reaping.md
@@ -39,6 +39,8 @@ On 2026-06-05 the live install carried 119 worktrees in two conflicting conventi
 - Configure both clients (Claude Code worktree base, Codex worktree trust base) to point at the canonical sibling location.
 - Seed MCP + toolchain immediately after creation; claim a capsule before doing work.
 - Let the worktree/runtime janitor reap `idle`/`done` worktrees, branches, CI images, and stray compose projects. Do not hoard worktrees "for reference."
+- The `active` liveness signal is a real, gitignored session heartbeat (`.dpf-session-heartbeat.json`, refreshed every turn), and it **outranks** reap eligibility: the janitor keeps any worktree with a fresh heartbeat even when it is otherwise merged+clean (Tier-A) — never reap a worktree out from under a live session. A worktree mid-merge (`MERGE_HEAD`) with no live heartbeat is quarantined and flagged, not silently left or reaped.
+- Keep the shared **root clone** fast-forwarded to `origin/main` (the `root-clone-freshness` SessionStart hook does this, ff-only): a stale root blocks every junctioned worktree's pregate, so root freshness is fleet hygiene, not a per-worktree concern.
 
 ## Decision Dimensions
 

--- a/docs/superpowers/plans/2026-08-11-worktree-lifecycle-hygiene.md
+++ b/docs/superpowers/plans/2026-08-11-worktree-lifecycle-hygiene.md
@@ -1,0 +1,118 @@
+# Worktree lifecycle hygiene — liveness-before-reap, root-clone freshness, abandoned-merge quarantine
+
+**Date:** 2026-08-11
+**Epic:** EP-PROCESS-SPINE
+**Status:** implemented (this PR)
+**Surface:** host worktree governance (scripts + dpf-skill-pack hooks)
+
+> **Backlog note.** This work was surfaced during a stuck-PR sweep, not from a
+> pre-filed BI. The DPF MCP connector was not reachable from the authoring session
+> (source-only worktree, no portal/DB view), so the live `BacklogItem` could not be
+> filed from here. **Action for an MCP-connected operator/Build Studio:** file a BI
+> under EP-PROCESS-SPINE — *"Worktree janitor liveness gate + root-clone auto-ff +
+> abandoned-merge quarantine"* — and back-link this plan. This file deliberately
+> carries **no** `**Backlog item:**` line so it is not mistaken for coverage
+> evidence that does not yet exist.
+
+## Problem
+
+Two worktree-lifecycle failures observed during the sweep:
+
+1. **A janitor reaped an active session's worktree mid-session.** A worktree had
+   its `.git` linkage removed and was marked `prunable` while a session was still
+   working in it. Git then silently fell through to the shared **root clone**
+   (`D:/DPF`), so a subsequent `git checkout -B …` mutated the root clone's checked-
+   out branch instead of the worktree — the documented "deleted-worktree → root-
+   clone" trap, and a near-miss root-clone corruption.
+
+2. **The root clone was left 18 commits behind `origin/main`.** Because peer
+   worktrees junction `@dpf/*` workspace packages into the root tree, a stale root
+   makes `pregate-preflight` abort with *"Stale root clone detected (BI-A900EA3F)"*
+   for **every** worktree until someone fast-forwards the root.
+
+## Design grounding
+
+- **Source of truth:** the `worktree-selection-and-reaping` kernel principle and
+  the multi-client governance-parity spec
+  (`docs/superpowers/specs/2026-07-26-multi-client-governance-parity-design.md` §D4).
+  The principle *already* names a worktree's lifecycle as `active` (**"claimed
+  capsule, live heartbeat"**) / `idle` (**"no heartbeat past threshold"**) / `done`.
+  This work makes that heartbeat real and feeds it to the reaper — extending the
+  existing lifecycle, not inventing a new one.
+- **Existing substrate reused:** `scripts/lib/worktree-janitor-core.mjs` (the pure
+  reaping classifier), `scripts/worktree-janitor.mjs` (the fleet backstop CLI),
+  `scripts/lib/stale-root-clone.mjs` (BI-A900EA3F **detector** — this plan adds the
+  **remedy**), `scripts/lib/junction-safe-worktree-remove.mjs`, and the session-
+  lifecycle hook plane in `packages/dpf-skill-pack/hooks/`.
+- **Why files, not DB/MCP, for liveness:** the fleet janitor is a host Node script
+  that may have no portal/DB view, and every CLI surface (Claude/Codex/Grok) shares
+  the same host filesystem. A gitignored marker is the liveness signal all of them
+  can read without coordination.
+
+### Research & benchmarking
+
+Git itself has no "is a session using this worktree" signal — `git worktree prune`
+keys only on whether the working directory / `.git` file still exists, which is
+exactly what made the incident silent. Common practice (tmux/VS Code liveness, PID
+files, lockfiles) uses a refreshed heartbeat file with a TTL; DPF's own edge-node
+service and the WorkCapsule lease already follow the "renew-on-activity, expire ==
+dead" pattern. We adopt the same shape (marker refreshed every turn, TTL window)
+rather than OS-specific open-handle probing, which is brittle on Windows.
+
+## Fixes
+
+### 1. Liveness gate — never reap an in-use worktree (safety)
+
+- New `scripts/lib/worktree-session-heartbeat.mjs`: a live session writes a
+  gitignored `.dpf-session-heartbeat.json` marker (refreshed every turn), read as a
+  TTL-bounded liveness signal (default 60 min; `DPF_WORKTREE_SESSION_HEARTBEAT_TTL_MIN`).
+- New hook `packages/dpf-skill-pack/hooks/worktree-session-heartbeat.mjs`, wired on
+  **SessionStart + Stop** (write/refresh) and **SessionEnd** (remove). It is
+  non-destructive by construction (only ever writes/deletes one marker), which is
+  why it is safe on the per-turn `Stop` event — unlike the destructive reaper, which
+  stays confined to SessionEnd (BI-E5D810B8).
+- `classifyWorktree` gains a `hasLiveSession` fact that returns `KEEP` **above** the
+  merged/Tier-A check — because a live session's tree first becomes Tier-A eligible
+  the moment its own PR merges, which is exactly when it must **not** be reaped. The
+  fleet janitor (`worktree-janitor.mjs`) reads the heartbeat per worktree.
+- The marker is gitignored so it never dirties the tree (which would both muddy the
+  janitor's `dirty` signal and block a worktree's own SessionEnd reap).
+
+### 2. Root-clone freshness — keep the root fast-forwarded to origin/main
+
+- New `scripts/lib/root-clone-refresh.mjs` + CLI `scripts/root-clone-refresh.mjs`:
+  **fast-forward only**, and only when the root is on `main` and clean. It **refuses**
+  (loudly, never forcing) when the root is off-main, detached, or dirty — those are
+  the "root stranded on a feature branch / mid-edit" states a forced move would
+  corrupt (the exact states `root-clone-guard.mjs` blocks for the agent).
+- New SessionStart hook `packages/dpf-skill-pack/hooks/root-clone-freshness.mjs`
+  runs the safe `git merge --ff-only origin/main` directly (not via the Bash tool),
+  which is precisely the remedy the stale-root-clone detector already prints — so it
+  complements `root-clone-guard.mjs` rather than fighting it. A SessionStart hook is
+  the robust cross-surface plane; a portal cron can go dark or not see host worktrees.
+
+### 3. Abandoned-merge quarantine — flag, don't silently leave
+
+- `classifyWorktree` gains a `midMerge` fact (`MERGE_HEAD` present). A mid-merge with
+  **no live session** is an abandoned merge; it is classified `FLAG_ABANDONED_MERGE`
+  — surfaced in the janitor summary and **never** reap-eligible (an interrupted merge
+  can hide un-reconciled work). A *live* session's in-progress merge is `KEEP` (the
+  liveness gate wins), so only genuinely abandoned merges are flagged.
+
+## Verification
+
+`node --test` (source-only, no workspace install needed):
+`worktree-janitor-core`, `worktree-session-heartbeat` (lib + hook, incl. a real
+linked-worktree write/remove integration case), `root-clone-refresh` (lib), and
+`root-clone-freshness` (hook). New tests are registered in
+`scripts/lib/ci-policy-guards.mjs` (the hand-enumerated inventory) so CI runs them.
+`worktree-janitor-core.test.mjs` was promoted from the deliberate-exclusion allowlist
+into the inventory since its new liveness/abandoned-merge assertions must run.
+
+## Rollout / safety
+
+All new behavior fails open. The heartbeat and root-freshness hooks have skip envs
+(`DPF_SKIP_WORKTREE_SESSION_HEARTBEAT=1`, `DPF_SKIP_ROOT_CLONE_REFRESH=1`). No change
+to the reaper's default posture: it is still dry-run/observe unless
+`DPF_WORKTREE_JANITOR_AUTO_REAP=1`; this plan only makes auto-reap *safer* by adding
+the liveness gate and the abandoned-merge quarantine on top of it.

--- a/packages/dpf-skill-pack/hooks/hooks.json
+++ b/packages/dpf-skill-pack/hooks/hooks.json
@@ -104,6 +104,22 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-heartbeat.mjs\""
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/root-clone-freshness.mjs\""
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-readiness-banner.mjs\""
           }
         ]
@@ -122,6 +138,14 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-heartbeat.mjs\""
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-hygiene.mjs\""
           }
         ]
@@ -133,6 +157,14 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/uncommitted-work-guard.mjs\""
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-session-heartbeat.mjs\""
           }
         ]
       }

--- a/packages/dpf-skill-pack/hooks/root-clone-freshness.mjs
+++ b/packages/dpf-skill-pack/hooks/root-clone-freshness.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// packages/dpf-skill-pack/hooks/root-clone-freshness.mjs
+//
+// SessionStart hook (EP-PROCESS-SPINE, plan 2026-08-11-worktree-lifecycle-hygiene).
+//
+// Keep the shared root clone fast-forwarded to origin/main at the start of every
+// session, on every surface (Claude/Codex/Grok) — because all peer worktrees
+// junction @dpf/* workspace packages into the root tree, so a stale root makes
+// `pregate-preflight` abort with "Stale root clone detected (BI-A900EA3F)" for
+// EVERY worktree until someone fast-forwards the root. A SessionStart hook is the
+// robust cross-surface remediation: session hooks fire wherever dpf-platform is
+// installed, whereas a portal cron can go dark or not see host worktrees.
+//
+// Fast-forward ONLY, and only when the root is on main + clean (see
+// scripts/lib/root-clone-refresh.mjs). It runs the SAFE `git merge --ff-only`
+// directly (not via the Bash tool), which is exactly the remedy root-clone-guard.mjs
+// tells the operator to run — so it complements that guard rather than fighting it.
+//
+// Fail-open. Escape hatch: DPF_SKIP_ROOT_CLONE_REFRESH=1.
+
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { inDpfWorkspace } from "./lib/hook-io.mjs";
+
+const hooksDir = dirname(fileURLToPath(import.meta.url));
+const skillPackRoot = resolve(hooksDir, "..");
+const repoRootGuess = resolve(skillPackRoot, "../..");
+
+function loadRefreshLib() {
+  const candidates = [
+    join(repoRootGuess, "scripts/lib/root-clone-refresh.mjs"),
+    join(skillPackRoot, "../../scripts/lib/root-clone-refresh.mjs"),
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return import(pathToFileURL(p).href);
+  }
+  return null;
+}
+
+function runGit(args, cwd) {
+  const r = spawnSync("git", args, {
+    cwd: cwd || undefined,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 15_000,
+  });
+  return { ok: r.status === 0, stdout: (r.stdout || "").trim() };
+}
+
+function readPayload() {
+  try {
+    const raw = readFileSync(0, "utf8");
+    if (!raw.trim()) return {};
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+function sessionCwd(payload) {
+  return payload.cwd || payload.workspaceRoot || payload.workspace_root || process.cwd();
+}
+
+/** The root/main clone that owns this cwd's git-common-dir. */
+function resolveRootClone(cwd) {
+  const common = runGit(["rev-parse", "--path-format=absolute", "--git-common-dir"], cwd);
+  if (!common.ok || !common.stdout) return null;
+  return common.stdout.replace(/[/\\]\.git$/, "");
+}
+
+function emitContext(text) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: text },
+    }),
+  );
+}
+
+async function main() {
+  if (process.env.DPF_SKIP_ROOT_CLONE_REFRESH === "1") process.exit(0);
+
+  const payload = readPayload();
+  const cwd = sessionCwd(payload);
+  if (!inDpfWorkspace(cwd)) process.exit(0);
+
+  const rootClone = resolveRootClone(cwd);
+  if (!rootClone) process.exit(0);
+
+  const lib = await loadRefreshLib();
+  if (!lib?.refreshRootClone) process.exit(0);
+
+  let result;
+  try {
+    result = lib.refreshRootClone({ rootClonePath: rootClone });
+  } catch {
+    process.exit(0); // fail-open
+  }
+
+  // Only speak up when it did something or when it REFUSED because the root is in a
+  // state that blocks every worktree's pregate (off-main / dirty) — that is
+  // actionable. A clean "already current" skip stays silent.
+  if (result.action === "ff") {
+    emitContext(
+      `Root-clone freshness: ${result.reason} at ${rootClone}. Junctioned worktrees now see current main.`,
+    );
+  } else if (result.action === "refuse") {
+    emitContext(
+      `Root-clone freshness: ${result.reason} at ${rootClone}. ` +
+        `While the root is behind/off-main, every junctioned worktree's pregate can abort with ` +
+        `"Stale root clone detected (BI-A900EA3F)". Return the root clone to a clean 'main' so it can fast-forward.`,
+    );
+  } else if (result.action === "failed") {
+    emitContext(`Root-clone freshness: ${result.reason} at ${rootClone}.`);
+  }
+  process.exit(0);
+}
+
+const invokedPath = process.argv[1] ? process.argv[1].replace(/\\/g, "/") : "";
+if (invokedPath.endsWith("root-clone-freshness.mjs")) {
+  main().catch(() => process.exit(0));
+}

--- a/packages/dpf-skill-pack/hooks/root-clone-freshness.test.mjs
+++ b/packages/dpf-skill-pack/hooks/root-clone-freshness.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const script = join(here, "root-clone-freshness.mjs");
+
+function hookCommandsFor(eventName) {
+  const wiring = JSON.parse(readFileSync(join(here, "hooks.json"), "utf8"));
+  const events = wiring.hooks ?? wiring;
+  return (events[eventName] ?? []).flatMap((entry) =>
+    (entry.hooks ?? []).map((h) => String(h.command ?? "")),
+  );
+}
+
+describe("root-clone-freshness wiring", () => {
+  it("is wired on SessionStart via the plugin root", () => {
+    const cmds = hookCommandsFor("SessionStart").filter((c) => c.includes("root-clone-freshness.mjs"));
+    assert.ok(cmds.length > 0, "root-clone-freshness must run on SessionStart");
+    for (const c of cmds) {
+      assert.ok(c.includes("CLAUDE_PLUGIN_ROOT"), `command must use CLAUDE_PLUGIN_ROOT: ${c}`);
+    }
+  });
+
+  it("is NOT wired to Stop or SessionEnd — root freshness is a session-start concern only", () => {
+    for (const event of ["Stop", "SessionEnd"]) {
+      assert.ok(
+        !hookCommandsFor(event).some((c) => c.includes("root-clone-freshness.mjs")),
+        `root-clone-freshness must not run on ${event}`,
+      );
+    }
+  });
+});
+
+describe("root-clone-freshness behavior", () => {
+  it("no-ops with the skip env and emits nothing", () => {
+    const r = spawnSync(process.execPath, [script], {
+      encoding: "utf8",
+      env: { ...process.env, DPF_SKIP_ROOT_CLONE_REFRESH: "1" },
+      input: JSON.stringify({ hookEventName: "SessionStart", cwd: process.cwd() }),
+      windowsHide: true,
+      timeout: 15_000,
+    });
+    assert.equal(r.status, 0);
+    assert.equal((r.stdout || "").trim(), "");
+  });
+
+  it("no-ops outside a DPF workspace", () => {
+    const r = spawnSync(process.execPath, [script], {
+      encoding: "utf8",
+      env: { ...process.env },
+      input: JSON.stringify({ hookEventName: "SessionStart", cwd: dirname(process.cwd()) + "/definitely-not-dpf-xyz" }),
+      windowsHide: true,
+      timeout: 15_000,
+    });
+    assert.equal(r.status, 0);
+  });
+
+  it("exits 0 fast on a SessionStart against the current checkout (never blocks a session)", () => {
+    // A clean root or an unmeasurable state must resolve to exit 0 with at most an
+    // advisory on stdout — it must never throw or hang session startup.
+    const r = spawnSync(process.execPath, [script], {
+      encoding: "utf8",
+      cwd: join(here, "../../.."),
+      // Do not fetch in the test — avoid any network dependency / latency.
+      env: { ...process.env, DPF_SKIP_ROOT_CLONE_REFRESH: "1" },
+      input: JSON.stringify({ hookEventName: "SessionStart", cwd: join(here, "../../..") }),
+      windowsHide: true,
+      timeout: 15_000,
+    });
+    assert.equal(r.status, 0);
+  });
+});

--- a/packages/dpf-skill-pack/hooks/worktree-session-heartbeat.mjs
+++ b/packages/dpf-skill-pack/hooks/worktree-session-heartbeat.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// packages/dpf-skill-pack/hooks/worktree-session-heartbeat.mjs
+//
+// Worktree session heartbeat (EP-PROCESS-SPINE, plan 2026-08-11-worktree-lifecycle-hygiene).
+//
+// Writes/refreshes a GITIGNORED liveness marker in THIS session's worktree so the
+// fleet worktree janitor never reaps a worktree out from under a live session (the
+// "janitor reaped an active session's worktree mid-session" near-miss).
+//
+//   SessionStart, Stop  → write/refresh the marker (Stop fires every turn, so the
+//                         marker stays fresh throughout a live session).
+//   SessionEnd          → remove the marker (the session is over; the worktree is
+//                         now eligible for its normal Tier-A reap).
+//
+// This hook is NON-DESTRUCTIVE by construction — it only ever writes or deletes a
+// single marker file. That is exactly why it is safe on `Stop` (a per-turn event),
+// unlike worktree-session-hygiene.mjs, whose destructive reap is confined to
+// SessionEnd (BI-E5D810B8). Keep the two concerns separate: never add reaping here.
+//
+// Fail-open always. Skips the root/main clone (never reaped) and anything outside a
+// DPF workspace. Escape hatch: DPF_SKIP_WORKTREE_SESSION_HEARTBEAT=1.
+
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { inDpfWorkspace } from "./lib/hook-io.mjs";
+
+const hooksDir = dirname(fileURLToPath(import.meta.url));
+const skillPackRoot = resolve(hooksDir, "..");
+const repoRootGuess = resolve(skillPackRoot, "../..");
+
+function loadHeartbeatLib() {
+  const candidates = [
+    join(repoRootGuess, "scripts/lib/worktree-session-heartbeat.mjs"),
+    join(skillPackRoot, "../../scripts/lib/worktree-session-heartbeat.mjs"),
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return import(pathToFileURL(p).href);
+  }
+  return null;
+}
+
+function runGit(args, cwd) {
+  const r = spawnSync("git", args, {
+    cwd: cwd || undefined,
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 15_000,
+  });
+  return { ok: r.status === 0, stdout: (r.stdout || "").trim() };
+}
+
+function readPayload() {
+  try {
+    const raw = readFileSync(0, "utf8");
+    if (!raw.trim()) return {};
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+function hookEventName(payload) {
+  const n = payload.hookEventName ?? payload.hook_event_name ?? "";
+  if (/sessionstart/i.test(n) || n === "SessionStart") return "SessionStart";
+  if (/^stop$/i.test(n) || n === "Stop") return "Stop";
+  if (/sessionend/i.test(n) || n === "SessionEnd") return "SessionEnd";
+  // Unknown → treat as a refresh (write), never as a remove, so a mislabeled
+  // event can only KEEP a worktree alive, never strand a live one.
+  return "Stop";
+}
+
+function sessionCwd(payload) {
+  return payload.cwd || payload.workspaceRoot || payload.workspace_root || process.cwd();
+}
+
+/** The worktree toplevel to heartbeat, or null when this is the root/main clone. */
+function resolveLinkedWorktreeTop(cwd) {
+  const top = runGit(["rev-parse", "--show-toplevel"], cwd);
+  if (!top.ok || !top.stdout) return null;
+  const common = runGit(["rev-parse", "--path-format=absolute", "--git-common-dir"], cwd);
+  if (!common.ok || !common.stdout) return null;
+  const commonRoot = common.stdout.replace(/[/\\]\.git$/, "");
+  // Linked worktree ⇔ its git-common-dir parent differs from its own toplevel.
+  if (resolve(commonRoot) === resolve(top.stdout)) return null; // root/main clone — skip
+  return top.stdout;
+}
+
+function sessionIdOf(payload) {
+  const id = payload.sessionId ?? payload.session_id ?? payload.transcriptSessionId;
+  return typeof id === "string" && id ? id : undefined;
+}
+
+async function main() {
+  if (process.env.DPF_SKIP_WORKTREE_SESSION_HEARTBEAT === "1") process.exit(0);
+
+  const payload = readPayload();
+  const cwd = sessionCwd(payload);
+  if (!inDpfWorkspace(cwd)) process.exit(0);
+
+  const top = resolveLinkedWorktreeTop(cwd);
+  if (!top) process.exit(0); // not a linked worktree (root clone or non-git) — nothing to heartbeat
+
+  const lib = await loadHeartbeatLib();
+  if (!lib?.writeHeartbeat) process.exit(0);
+
+  const event = hookEventName(payload);
+  if (event === "SessionEnd") {
+    lib.removeHeartbeat(top);
+  } else {
+    lib.writeHeartbeat(top, { sessionId: sessionIdOf(payload), event });
+  }
+  process.exit(0);
+}
+
+// Run only when invoked directly (not when imported by the test).
+const invokedPath = process.argv[1] ? process.argv[1].replace(/\\/g, "/") : "";
+if (invokedPath.endsWith("worktree-session-heartbeat.mjs")) {
+  main().catch(() => process.exit(0));
+}

--- a/packages/dpf-skill-pack/hooks/worktree-session-heartbeat.test.mjs
+++ b/packages/dpf-skill-pack/hooks/worktree-session-heartbeat.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const script = join(here, "worktree-session-heartbeat.mjs");
+
+function hookCommandsFor(eventName) {
+  const wiring = JSON.parse(readFileSync(join(here, "hooks.json"), "utf8"));
+  const events = wiring.hooks ?? wiring;
+  return (events[eventName] ?? []).flatMap((entry) =>
+    (entry.hooks ?? []).map((h) => String(h.command ?? "")),
+  );
+}
+
+function runHook(payload, env = {}) {
+  return spawnSync(process.execPath, [script], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    input: JSON.stringify(payload),
+    windowsHide: true,
+    timeout: 30_000,
+  });
+}
+
+describe("worktree-session-heartbeat wiring", () => {
+  it("refreshes on SessionStart AND Stop, and is removed on SessionEnd", () => {
+    for (const event of ["SessionStart", "Stop", "SessionEnd"]) {
+      assert.ok(
+        hookCommandsFor(event).some((c) => c.includes("worktree-session-heartbeat.mjs")),
+        `heartbeat must be wired to ${event}`,
+      );
+    }
+  });
+
+  it("loads from the plugin root, not a repo path", () => {
+    for (const event of ["SessionStart", "Stop", "SessionEnd"]) {
+      for (const c of hookCommandsFor(event).filter((c) => c.includes("worktree-session-heartbeat.mjs"))) {
+        assert.ok(c.includes("CLAUDE_PLUGIN_ROOT"), `heartbeat ${event} command must use CLAUDE_PLUGIN_ROOT: ${c}`);
+      }
+    }
+  });
+});
+
+describe("worktree-session-heartbeat behavior", () => {
+  it("no-ops with the skip env and emits nothing", () => {
+    const r = runHook(
+      { hookEventName: "Stop", cwd: process.cwd() },
+      { DPF_SKIP_WORKTREE_SESSION_HEARTBEAT: "1" },
+    );
+    assert.equal(r.status, 0);
+    assert.equal((r.stdout || "").trim(), "");
+  });
+
+  it("does NOT write a marker at the root/main clone (only linked worktrees get one)", () => {
+    // The repo root here is not a linked worktree; the hook must skip it.
+    const root = join(here, "../../..");
+    const marker = join(root, ".dpf-session-heartbeat.json");
+    const preexisting = existsSync(marker);
+    const r = runHook({ hookEventName: "Stop", cwd: root });
+    assert.equal(r.status, 0);
+    if (!preexisting) {
+      assert.equal(existsSync(marker), false, "must not heartbeat the root/main clone");
+    }
+  });
+
+  it("writes on Stop and removes on SessionEnd inside a real linked worktree", (t) => {
+    // Build a throwaway repo + linked worktree. Skip if git is unavailable.
+    let base;
+    try {
+      base = mkdtempSync(join(tmpdir(), "dpf-hb-"));
+      const git = (args, cwd) => {
+        const r = spawnSync("git", args, { cwd, encoding: "utf8", windowsHide: true, timeout: 30_000 });
+        if (r.status !== 0) throw new Error(`git ${args.join(" ")}: ${r.stderr}`);
+        return r;
+      };
+      git(["init", "-q", "-b", "main"], base);
+      git(["config", "user.email", "t@example.com"], base);
+      git(["config", "user.name", "t"], base);
+      writeFileSync(join(base, "f.txt"), "x\n");
+      git(["add", "-A"], base);
+      git(["commit", "-q", "-m", "init"], base);
+      const wt = join(base, "wt");
+      git(["worktree", "add", "-q", "-b", "feat/hb", wt], base);
+
+      const marker = join(wt, ".dpf-session-heartbeat.json");
+      const env = { DPF_GUARDS_WORKSPACE_ANY: "1" }; // temp dir is not a DPF checkout
+
+      const beat = runHook({ hookEventName: "Stop", cwd: wt }, env);
+      assert.equal(beat.status, 0);
+      assert.ok(existsSync(marker), "Stop must write the heartbeat marker in a linked worktree");
+      const rec = JSON.parse(readFileSync(marker, "utf8"));
+      assert.equal(typeof rec.beatAt, "number");
+
+      const end = runHook({ hookEventName: "SessionEnd", cwd: wt }, env);
+      assert.equal(end.status, 0);
+      assert.equal(existsSync(marker), false, "SessionEnd must remove the heartbeat marker");
+    } catch (err) {
+      t.skip(`git worktree setup unavailable: ${err.message}`);
+    } finally {
+      if (base) {
+        try {
+          rmSync(base, { recursive: true, force: true });
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    }
+  });
+});

--- a/packages/dpf-skill-pack/hooks/worktree-session-hygiene.mjs
+++ b/packages/dpf-skill-pack/hooks/worktree-session-hygiene.mjs
@@ -176,6 +176,13 @@ function gatherThisWorktreeFacts(cwd, mainRoot) {
     merged,
     dirty,
     ageDays,
+    // This is the ENDING session's OWN worktree; its own heartbeat liveness is
+    // irrelevant to whether SessionEnd may reap it (the session is over). The
+    // heartbeat gate exists for the FLEET janitor protecting OTHER live sessions.
+    hasLiveSession: false,
+    // A mid-merge in the ending session's own tree is left to that session's
+    // dirty check (KEEP), not quarantined here.
+    midMerge: false,
   };
 }
 

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -1487,6 +1487,8 @@ HOOK_PURPOSES = {
     "governance-freshness-check.mjs": "SessionStart: warns if governance guard wiring is stale",
     "grok-session-start.mjs": "Grok SessionStart: process-spine exposure probe + governance-freshness (global hook plane)",
     "worktree-session-hygiene.mjs": "SessionStart observe worktree sprawl; SessionEnd reaps THIS worktree when Tier-A (merged+clean) — primary reaper, not cron",
+    "worktree-session-heartbeat.mjs": "SessionStart/Stop write + SessionEnd remove a gitignored session heartbeat so the janitor never reaps a worktree with a live session (non-destructive)",
+    "root-clone-freshness.mjs": "SessionStart: fast-forwards the shared root clone to origin/main (ff-only, on-main+clean) so junctioned worktrees never inherit a stale root",
     "uncommitted-work-guard.mjs": "SessionEnd/Stop/post-checkout: warns before uncommitted spec/plan loss",
 }
 

--- a/scripts/ci-policy-test-inventory-allowlist.txt
+++ b/scripts/ci-policy-test-inventory-allowlist.txt
@@ -98,7 +98,6 @@ scripts/lib/resolve-compose-install-context.test.mjs
 scripts/lib/scratch-first-run-walkthrough-options.test.mjs
 scripts/lib/stale-root-clone.test.mjs
 scripts/lib/transition-signing.test.mjs
-scripts/lib/worktree-janitor-core.test.mjs
 scripts/lifecycle-surface-policy.test.mjs
 scripts/local-ci-bounded-build.test.mjs
 scripts/local-ci-capacity-broker.test.mjs

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -232,6 +232,12 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         // BI-C85D1B0A: managed BuildKit cool-down / obsolete policy reap planner.
         "scripts/lib/local-ci-builder-lifecycle.test.mjs",
         "scripts/lib/junction-safe-worktree-remove.test.mjs",
+        // Worktree lifecycle hygiene (plan 2026-08-11): the reaping classifier
+        // (now with the liveness + abandoned-merge verdicts), the session
+        // heartbeat liveness signal, and the root-clone fast-forward remedy.
+        "scripts/lib/worktree-janitor-core.test.mjs",
+        "scripts/lib/worktree-session-heartbeat.test.mjs",
+        "scripts/lib/root-clone-refresh.test.mjs",
         "scripts/lib/compose-safety.test.mjs",
         "scripts/lib/local-integration-ci.test.mjs",
         "scripts/lib/sandbox-freshness.test.mjs",
@@ -320,6 +326,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "--test",
         "packages/dpf-skill-pack/hooks/pregate-invocation-guard.test.mjs",
         "packages/dpf-skill-pack/hooks/worktree-readiness-banner.test.mjs",
+        // Worktree lifecycle hygiene hooks (plan 2026-08-11): the session
+        // heartbeat (liveness marker) and the SessionStart root-clone
+        // fast-forward. Hand-enumerated like every entry here — unlisted = unrun.
+        "packages/dpf-skill-pack/hooks/worktree-session-heartbeat.test.mjs",
+        "packages/dpf-skill-pack/hooks/root-clone-freshness.test.mjs",
       ),
       node(
         "--test",

--- a/scripts/lib/root-clone-refresh.mjs
+++ b/scripts/lib/root-clone-refresh.mjs
@@ -1,0 +1,127 @@
+// scripts/lib/root-clone-refresh.mjs
+//
+// Keep the root clone fast-forwarded to origin/main (EP-PROCESS-SPINE,
+// plan 2026-08-11-worktree-lifecycle-hygiene).
+//
+// stale-root-clone.mjs (BI-A900EA3F) DETECTS a root clone behind origin/main and
+// tells the operator to run `git merge --ff-only origin/main`. This is the REMEDY:
+// because every peer worktree junctions @dpf/* workspace packages into the root
+// tree, a stale root makes `pregate-preflight` abort for EVERY worktree until the
+// root is fast-forwarded. Keeping the root current is therefore fleet hygiene, not
+// a per-worktree concern.
+//
+// SAFETY: fast-forward ONLY. Refuse when the root is not on main, is detached, or
+// is dirty — those are the "root stranded on a feature branch / mid-edit" states a
+// forced move would corrupt (the exact thing root-clone-guard.mjs blocks for the
+// agent). A ff-only merge can never discard commits; it only advances a strictly
+// behind, clean main to its already-fetched upstream.
+
+import { spawnSync } from "node:child_process";
+
+import { gitText, measureRootBehindOriginMain } from "./stale-root-clone.mjs";
+
+/**
+ * Pure remediation decision from the root's current state.
+ * @param {{ detached: boolean, onMain: boolean, clean: boolean, behind: number }} state
+ * @returns {{ action: "ff" | "skip" | "refuse", reason: string }}
+ */
+export function planRootRefresh({ detached, onMain, clean, behind }) {
+  if (detached) {
+    return { action: "refuse", reason: "root clone is in detached HEAD — not fast-forwarding" };
+  }
+  if (!onMain) {
+    return {
+      action: "refuse",
+      reason: "root clone is not on main (active work may be stranded there) — not fast-forwarding",
+    };
+  }
+  if (!clean) {
+    return {
+      action: "refuse",
+      reason: "root clone has uncommitted changes — not fast-forwarding",
+    };
+  }
+  if (!(behind > 0)) {
+    return { action: "skip", reason: "root clone is already at origin/main" };
+  }
+  return { action: "ff", reason: `root clone is ${behind} commit(s) behind origin/main` };
+}
+
+/**
+ * Read the root clone's current state relative to origin/main. Injectable spawn.
+ * @param {string} rootClonePath
+ * @param {{ spawnSyncImpl?: typeof spawnSync }} [opts]
+ */
+export function gatherRootState(rootClonePath, { spawnSyncImpl = spawnSync } = {}) {
+  const branch = gitText(rootClonePath, ["rev-parse", "--abbrev-ref", "HEAD"], { spawnSyncImpl });
+  const detached = branch === "" || branch === "HEAD";
+  const onMain = branch === "main";
+  const clean = gitText(rootClonePath, ["status", "--porcelain"], { spawnSyncImpl }) === "";
+  const measure = measureRootBehindOriginMain(rootClonePath, { spawnSyncImpl });
+  return {
+    branch,
+    detached,
+    onMain,
+    clean,
+    behind: measure?.behind ?? 0,
+    rootSha: measure?.rootSha ?? "",
+    originMainSha: measure?.originMainSha ?? "",
+  };
+}
+
+/**
+ * Fetch origin/main (best-effort), then fast-forward the root clone when safe.
+ * Never throws; returns a structured result.
+ * @param {{
+ *   rootClonePath: string,
+ *   spawnSyncImpl?: typeof spawnSync,
+ *   doFetch?: boolean,
+ * }} input
+ * @returns {{
+ *   action: "ff" | "skip" | "refuse" | "failed",
+ *   reason: string,
+ *   changed: boolean,
+ *   branch: string,
+ *   behind: number,
+ *   rootSha: string,
+ *   originMainSha: string,
+ * }}
+ */
+export function refreshRootClone({ rootClonePath, spawnSyncImpl = spawnSync, doFetch = true }) {
+  if (doFetch) {
+    // Best-effort; offline just leaves us measuring against the last-known origin/main.
+    spawnSyncImpl("git", ["-C", rootClonePath, "fetch", "origin", "main", "--quiet"], {
+      encoding: "utf8",
+      windowsHide: true,
+      timeout: 60_000,
+    });
+  }
+
+  const state = gatherRootState(rootClonePath, { spawnSyncImpl });
+  const plan = planRootRefresh(state);
+
+  if (plan.action !== "ff") {
+    return { ...plan, changed: false, ...state };
+  }
+
+  const res = spawnSyncImpl("git", ["-C", rootClonePath, "merge", "--ff-only", "origin/main"], {
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 60_000,
+  });
+  const ok = !res.error && res.status === 0;
+  if (ok) {
+    return {
+      action: "ff",
+      reason: `fast-forwarded root clone ${state.behind} commit(s) to origin/main`,
+      changed: true,
+      ...state,
+    };
+  }
+  return {
+    action: "failed",
+    reason: `ff-only merge failed: ${(res.stderr || res.error?.message || "").toString().trim().slice(0, 300)}`,
+    changed: false,
+    ...state,
+  };
+}

--- a/scripts/lib/root-clone-refresh.test.mjs
+++ b/scripts/lib/root-clone-refresh.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  planRootRefresh,
+  gatherRootState,
+  refreshRootClone,
+} from "./root-clone-refresh.mjs";
+
+describe("planRootRefresh", () => {
+  it("fast-forwards a clean, on-main, behind root", () => {
+    assert.deepEqual(
+      planRootRefresh({ detached: false, onMain: true, clean: true, behind: 3 }).action,
+      "ff",
+    );
+  });
+
+  it("skips when already current", () => {
+    assert.equal(planRootRefresh({ detached: false, onMain: true, clean: true, behind: 0 }).action, "skip");
+  });
+
+  it("refuses when off-main, dirty, or detached — never force-moves the root", () => {
+    assert.equal(planRootRefresh({ detached: false, onMain: false, clean: true, behind: 5 }).action, "refuse");
+    assert.equal(planRootRefresh({ detached: false, onMain: true, clean: false, behind: 5 }).action, "refuse");
+    assert.equal(planRootRefresh({ detached: true, onMain: false, clean: true, behind: 5 }).action, "refuse");
+  });
+});
+
+/**
+ * Scripted fake git: maps a joined-args key to stdout. Any unmatched call returns
+ * a non-zero status so gitText/measure treat it as empty.
+ */
+function fakeGit(map) {
+  const calls = [];
+  const impl = (_bin, args) => {
+    calls.push(args.join(" "));
+    const key = args.join(" ");
+    for (const [pattern, out] of Object.entries(map)) {
+      if (key.includes(pattern)) return { status: 0, stdout: out, stderr: "" };
+    }
+    return { status: 1, stdout: "", stderr: "" };
+  };
+  return { impl, calls };
+}
+
+describe("gatherRootState", () => {
+  it("reads branch, cleanliness, and behind-count", () => {
+    const { impl } = fakeGit({
+      "rev-parse --abbrev-ref HEAD": "main",
+      "status --porcelain": "",
+      "rev-parse HEAD": "aaa",
+      "rev-parse origin/main": "bbb",
+      "rev-list --count aaa..bbb": "4",
+    });
+    const state = gatherRootState("/root", { spawnSyncImpl: impl });
+    assert.equal(state.branch, "main");
+    assert.equal(state.onMain, true);
+    assert.equal(state.detached, false);
+    assert.equal(state.clean, true);
+    assert.equal(state.behind, 4);
+  });
+
+  it("flags a dirty, off-main root", () => {
+    const { impl } = fakeGit({
+      "rev-parse --abbrev-ref HEAD": "feat/x",
+      "status --porcelain": " M file.ts",
+      "rev-parse HEAD": "aaa",
+      "rev-parse origin/main": "bbb",
+      "rev-list --count aaa..bbb": "2",
+    });
+    const state = gatherRootState("/root", { spawnSyncImpl: impl });
+    assert.equal(state.onMain, false);
+    assert.equal(state.clean, false);
+  });
+});
+
+describe("refreshRootClone", () => {
+  it("runs a ff-only merge when safe and reports changed", () => {
+    const { impl, calls } = fakeGit({
+      "fetch origin main": "",
+      "rev-parse --abbrev-ref HEAD": "main",
+      "status --porcelain": "",
+      "rev-parse HEAD": "aaa",
+      "rev-parse origin/main": "bbb",
+      "rev-list --count aaa..bbb": "2",
+      "merge --ff-only origin/main": "Updating aaa..bbb",
+    });
+    const r = refreshRootClone({ rootClonePath: "/root", spawnSyncImpl: impl });
+    assert.equal(r.action, "ff");
+    assert.equal(r.changed, true);
+    assert.ok(calls.some((c) => c.includes("merge --ff-only origin/main")));
+  });
+
+  it("does NOT merge a dirty root", () => {
+    const { impl, calls } = fakeGit({
+      "fetch origin main": "",
+      "rev-parse --abbrev-ref HEAD": "main",
+      "status --porcelain": " M x",
+      "rev-parse HEAD": "aaa",
+      "rev-parse origin/main": "bbb",
+      "rev-list --count aaa..bbb": "2",
+    });
+    const r = refreshRootClone({ rootClonePath: "/root", spawnSyncImpl: impl });
+    assert.equal(r.action, "refuse");
+    assert.equal(r.changed, false);
+    assert.ok(!calls.some((c) => c.includes("merge --ff-only")));
+  });
+
+  it("reports failed when the ff-only merge itself fails", () => {
+    const impl = (_bin, args) => {
+      const key = args.join(" ");
+      if (key.includes("rev-parse --abbrev-ref HEAD")) return { status: 0, stdout: "main", stderr: "" };
+      if (key.includes("status --porcelain")) return { status: 0, stdout: "", stderr: "" };
+      if (key.endsWith("rev-parse HEAD")) return { status: 0, stdout: "aaa", stderr: "" };
+      if (key.includes("rev-parse origin/main")) return { status: 0, stdout: "bbb", stderr: "" };
+      if (key.includes("rev-list --count")) return { status: 0, stdout: "2", stderr: "" };
+      if (key.includes("merge --ff-only")) return { status: 1, stdout: "", stderr: "not possible to fast-forward" };
+      return { status: 0, stdout: "", stderr: "" };
+    };
+    const r = refreshRootClone({ rootClonePath: "/root", spawnSyncImpl: impl, doFetch: false });
+    assert.equal(r.action, "failed");
+    assert.equal(r.changed, false);
+    assert.match(r.reason, /fast-forward/);
+  });
+});

--- a/scripts/lib/worktree-janitor-core.mjs
+++ b/scripts/lib/worktree-janitor-core.mjs
@@ -1,16 +1,25 @@
 // scripts/lib/worktree-janitor-core.mjs
 //
-// Pure worktree reaping classification (BI-42FA7DD8).
+// Pure worktree reaping classification (BI-42FA7DD8; liveness + abandoned-merge
+// quarantine added under EP-PROCESS-SPINE, plan 2026-08-11-worktree-lifecycle-hygiene).
 //
+// KEEP (live session): a session heartbeat is fresh in the worktree — NEVER reap
+//   it out from under a live session, even when it is otherwise Tier-A eligible.
+//   This is the safety fix for the "janitor reaped an active session's worktree"
+//   near-miss: a merged+clean tree that a peer session is still working in.
+// FLAG_ABANDONED_MERGE (quarantine / observe): a merge is in progress (MERGE_HEAD
+//   present) but no live session heartbeat — the merge was abandoned mid-flight.
+//   Surfaced, never auto-deleted (an interrupted merge can hide un-reconciled work).
 // Tier A (safe auto-reap when DPF_WORKTREE_JANITOR_AUTO_REAP=1):
-//   merged (ancestry OR squash-merged PR) + clean + no open PR + no lease + not pinned
+//   merged (ancestry OR squash-merged PR) + clean + no open PR + no lease + not
+//   pinned + no live session + not mid-merge
 // Tier B (observe / propose only — never auto-delete):
 //   unmerged + clean + age > graceDays
 //
 // Side-effecting removal stays in scripts/worktree-janitor.mjs via
 // junction-safe-worktree-remove.mjs.
 
-/** @typedef {"PRUNE_TIER_A" | "PRUNE_TIER_B" | "KEEP" | "SKIP" | "PINNED"} WorktreeVerdict */
+/** @typedef {"PRUNE_TIER_A" | "PRUNE_TIER_B" | "KEEP" | "SKIP" | "PINNED" | "FLAG_ABANDONED_MERGE"} WorktreeVerdict */
 
 /**
  * @typedef {object} WorktreeFacts
@@ -23,6 +32,8 @@
  * @property {boolean} merged        ancestor of origin/main OR has merged PR
  * @property {boolean} dirty         porcelain non-empty
  * @property {number} ageDays        days since last commit (0 if unknown)
+ * @property {boolean} [hasLiveSession]  a fresh session heartbeat is present
+ * @property {boolean} [midMerge]        a merge is in progress (MERGE_HEAD present)
  */
 
 /**
@@ -55,6 +66,31 @@ export function classifyWorktree(facts, opts = {}) {
   }
   if (facts.hasOpenPr) {
     return { verdict: "KEEP", reason: `branch=${facts.branch} open PR`, tier: null };
+  }
+
+  // Liveness gate — the safety fix. A fresh session heartbeat means a session is
+  // actively working in this tree; removing its .git linkage now is the near-miss
+  // that stranded a live session onto the root clone. This must sit ABOVE the
+  // merged/Tier-A check: the moment a live session's PR merges, its clean tree
+  // first becomes Tier-A eligible — exactly when it must NOT be reaped.
+  if (facts.hasLiveSession) {
+    return {
+      verdict: "KEEP",
+      reason: `branch=${facts.branch} live session heartbeat — refuse to reap an in-use worktree`,
+      tier: null,
+    };
+  }
+
+  // Abandoned mid-merge quarantine. A merge in progress with no live session was
+  // interrupted; it can hide un-reconciled work, so flag it for review rather than
+  // silently leaving it (or reaping it). Reached only when NOT live (live returned
+  // KEEP above), so the heartbeat's absence supplies the "stale" half.
+  if (facts.midMerge) {
+    return {
+      verdict: "FLAG_ABANDONED_MERGE",
+      reason: `branch=${facts.branch} MERGE_HEAD present with no live session — abandoned mid-merge; quarantined for review, never auto-reaped`,
+      tier: null,
+    };
   }
 
   if (facts.merged) {
@@ -110,7 +146,14 @@ export function isLiveReapEligible(policy, verdict) {
  * @param {Array<{ path: string, branch: string | null, verdict: WorktreeVerdict, reason: string, tier: string | null }>} decisions
  */
 export function summarizeDecisions(decisions) {
-  const counts = { PRUNE_TIER_A: 0, PRUNE_TIER_B: 0, KEEP: 0, SKIP: 0, PINNED: 0 };
+  const counts = {
+    PRUNE_TIER_A: 0,
+    PRUNE_TIER_B: 0,
+    KEEP: 0,
+    SKIP: 0,
+    PINNED: 0,
+    FLAG_ABANDONED_MERGE: 0,
+  };
   for (const d of decisions) {
     if (counts[d.verdict] !== undefined) counts[d.verdict] += 1;
   }
@@ -118,5 +161,8 @@ export function summarizeDecisions(decisions) {
     counts,
     tierAPaths: decisions.filter((d) => d.verdict === "PRUNE_TIER_A").map((d) => d.path),
     tierBPaths: decisions.filter((d) => d.verdict === "PRUNE_TIER_B").map((d) => d.path),
+    flaggedPaths: decisions
+      .filter((d) => d.verdict === "FLAG_ABANDONED_MERGE")
+      .map((d) => d.path),
   };
 }

--- a/scripts/lib/worktree-janitor-core.test.mjs
+++ b/scripts/lib/worktree-janitor-core.test.mjs
@@ -41,6 +41,29 @@ describe("classifyWorktree", () => {
     assert.equal(r.tier, "A");
   });
 
+  it("live session KEEPS a merged+clean worktree that would otherwise be Tier-A", () => {
+    // The safety fix: a live session heartbeat outranks Tier-A eligibility, so
+    // the janitor never reaps a worktree out from under an active session.
+    const r = classifyWorktree({ ...base, merged: true, dirty: false, hasLiveSession: true });
+    assert.equal(r.verdict, "KEEP");
+    assert.equal(r.tier, null);
+    assert.match(r.reason, /live session/);
+  });
+
+  it("abandoned mid-merge (no live session) is FLAGGED, never reaped", () => {
+    const r = classifyWorktree({ ...base, midMerge: true, hasLiveSession: false });
+    assert.equal(r.verdict, "FLAG_ABANDONED_MERGE");
+    assert.equal(r.tier, null);
+    assert.equal(isLiveReapEligible("all", r.verdict), false);
+    assert.equal(isLiveReapEligible("tier-a-only", r.verdict), false);
+  });
+
+  it("a live session's in-progress merge is KEPT, not flagged as abandoned", () => {
+    const r = classifyWorktree({ ...base, midMerge: true, hasLiveSession: true });
+    assert.equal(r.verdict, "KEEP");
+    assert.match(r.reason, /live session/);
+  });
+
   it("Tier B: stale unmerged clean", () => {
     const r = classifyWorktree({ ...base, ageDays: 20 }, { graceDays: 14 });
     assert.equal(r.verdict, "PRUNE_TIER_B");
@@ -67,10 +90,13 @@ describe("summarizeDecisions", () => {
       { path: "/a", branch: "a", verdict: "PRUNE_TIER_A", reason: "", tier: "A" },
       { path: "/b", branch: "b", verdict: "PRUNE_TIER_B", reason: "", tier: "B" },
       { path: "/c", branch: "c", verdict: "KEEP", reason: "", tier: null },
+      { path: "/d", branch: "d", verdict: "FLAG_ABANDONED_MERGE", reason: "", tier: null },
     ]);
     assert.equal(s.counts.PRUNE_TIER_A, 1);
     assert.equal(s.counts.PRUNE_TIER_B, 1);
+    assert.equal(s.counts.FLAG_ABANDONED_MERGE, 1);
     assert.deepEqual(s.tierAPaths, ["/a"]);
     assert.deepEqual(s.tierBPaths, ["/b"]);
+    assert.deepEqual(s.flaggedPaths, ["/d"]);
   });
 });

--- a/scripts/lib/worktree-session-heartbeat.mjs
+++ b/scripts/lib/worktree-session-heartbeat.mjs
@@ -1,0 +1,148 @@
+// scripts/lib/worktree-session-heartbeat.mjs
+//
+// Worktree session heartbeat (EP-PROCESS-SPINE, plan 2026-08-11-worktree-lifecycle-hygiene).
+//
+// A live session writes a small, GITIGNORED marker into its worktree and refreshes
+// it every turn (SessionStart + Stop) and removes it on SessionEnd. The fleet
+// worktree janitor reads it as a liveness signal so it never reaps a worktree out
+// from under a session that is still working in it — the "janitor reaped an active
+// session's worktree mid-session" near-miss.
+//
+// It is deliberately a FILE, not a DB/MCP record: the janitor is a host Node script
+// that may have no portal/DB view, and every CLI surface (Claude/Codex/Grok) shares
+// the same host filesystem. The marker is gitignored so it never dirties the tree —
+// which would otherwise both muddy the janitor's `dirty` signal and block a
+// worktree's own Tier-A SessionEnd reap.
+//
+// Pure helpers + injectable fs so the janitor and the session hook share one
+// contract and it stays exhaustively unit-testable.
+
+import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+/** Gitignored marker filename written into each live worktree. */
+export const HEARTBEAT_FILENAME = ".dpf-session-heartbeat.json";
+
+/** Default liveness window. A session that has not had a turn (Stop) in this long
+ *  is treated as idle and its worktree becomes reap-eligible again. Generous on
+ *  purpose: erring toward NOT reaping a live session is the safe direction, and a
+ *  truly dead session's clean+merged worktree is low-harm to keep for an hour. */
+export const DEFAULT_TTL_MS = 60 * 60_000;
+
+/** Small forward-clock tolerance so a marker written on a host whose clock is a
+ *  little ahead of the janitor's is still read as live, not discarded. */
+const FUTURE_SKEW_MS = 5 * 60_000;
+
+/** @param {string} worktreePath */
+export function heartbeatPath(worktreePath) {
+  return join(worktreePath, HEARTBEAT_FILENAME);
+}
+
+/**
+ * Resolve the liveness TTL in ms, honoring DPF_WORKTREE_SESSION_HEARTBEAT_TTL_MIN.
+ * @param {Record<string, string | undefined>} [env]
+ */
+export function heartbeatTtlMs(env = process.env) {
+  const raw = env?.DPF_WORKTREE_SESSION_HEARTBEAT_TTL_MIN;
+  const mins = Number(raw);
+  if (Number.isFinite(mins) && mins > 0) return mins * 60_000;
+  return DEFAULT_TTL_MS;
+}
+
+/**
+ * Parse raw marker text into a heartbeat record, or null when unreadable.
+ * @param {string} raw
+ * @returns {{ beatAt: number, pid?: number, sessionId?: string, startedAt?: number, event?: string } | null}
+ */
+export function parseHeartbeat(raw) {
+  try {
+    const obj = JSON.parse(raw);
+    if (obj && typeof obj === "object" && typeof obj.beatAt === "number") {
+      return obj;
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+/**
+ * Is this heartbeat record live at `now`? Pure.
+ * @param {{ beatAt: number } | null | undefined} hb
+ * @param {number} now  epoch ms
+ * @param {number} [ttlMs]
+ */
+export function isHeartbeatLive(hb, now, ttlMs = DEFAULT_TTL_MS) {
+  if (!hb || typeof hb.beatAt !== "number" || !Number.isFinite(hb.beatAt)) return false;
+  if (hb.beatAt > now + FUTURE_SKEW_MS) return false; // implausibly future — ignore
+  return now - hb.beatAt <= ttlMs;
+}
+
+/**
+ * Read a worktree's heartbeat record, or null. Injectable fs for tests.
+ * @param {string} worktreePath
+ * @param {{ fs?: { existsSync: typeof existsSync, readFileSync: typeof readFileSync } }} [deps]
+ */
+export function readHeartbeat(worktreePath, deps = {}) {
+  const fs = deps.fs ?? { existsSync, readFileSync };
+  const p = heartbeatPath(worktreePath);
+  if (!fs.existsSync(p)) return null;
+  try {
+    return parseHeartbeat(fs.readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when a worktree currently holds a fresh session heartbeat.
+ * @param {string} worktreePath
+ * @param {{ now?: number, ttlMs?: number, fs?: object }} [deps]
+ */
+export function isWorktreeSessionLive(worktreePath, deps = {}) {
+  const now = deps.now ?? Date.now();
+  const ttlMs = deps.ttlMs ?? DEFAULT_TTL_MS;
+  return isHeartbeatLive(readHeartbeat(worktreePath, deps), now, ttlMs);
+}
+
+/**
+ * Write/refresh a worktree's heartbeat. Preserves `startedAt` across beats when a
+ * prior marker exists. Never throws — returns false on failure. Injectable fs.
+ * @param {string} worktreePath
+ * @param {{ now?: number, pid?: number, sessionId?: string, event?: string, fs?: object }} [deps]
+ * @returns {boolean}
+ */
+export function writeHeartbeat(worktreePath, deps = {}) {
+  const fs = deps.fs ?? { existsSync, readFileSync, writeFileSync };
+  const now = deps.now ?? Date.now();
+  const prior = readHeartbeat(worktreePath, { fs });
+  const record = {
+    beatAt: now,
+    startedAt: prior?.startedAt ?? now,
+    pid: deps.pid ?? (typeof process !== "undefined" ? process.pid : undefined),
+    sessionId: deps.sessionId,
+    event: deps.event,
+  };
+  try {
+    fs.writeFileSync(heartbeatPath(worktreePath), `${JSON.stringify(record)}\n`, "utf8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Remove a worktree's heartbeat (SessionEnd). Never throws.
+ * @param {string} worktreePath
+ * @param {{ fs?: { rmSync: typeof rmSync } }} [deps]
+ * @returns {boolean}
+ */
+export function removeHeartbeat(worktreePath, deps = {}) {
+  const fs = deps.fs ?? { rmSync };
+  try {
+    fs.rmSync(heartbeatPath(worktreePath), { force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/scripts/lib/worktree-session-heartbeat.test.mjs
+++ b/scripts/lib/worktree-session-heartbeat.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  HEARTBEAT_FILENAME,
+  DEFAULT_TTL_MS,
+  heartbeatPath,
+  heartbeatTtlMs,
+  parseHeartbeat,
+  isHeartbeatLive,
+  readHeartbeat,
+  isWorktreeSessionLive,
+  writeHeartbeat,
+  removeHeartbeat,
+} from "./worktree-session-heartbeat.mjs";
+
+/** Minimal in-memory fs stub matching the subset the lib uses. */
+function memFs(initial = {}) {
+  const files = new Map(Object.entries(initial));
+  return {
+    files,
+    existsSync: (p) => files.has(p),
+    readFileSync: (p) => {
+      if (!files.has(p)) throw new Error(`ENOENT ${p}`);
+      return files.get(p);
+    },
+    writeFileSync: (p, data) => files.set(p, data),
+    rmSync: (p) => files.delete(p),
+  };
+}
+
+describe("heartbeat path + ttl", () => {
+  it("marker filename is the gitignored session heartbeat", () => {
+    assert.equal(HEARTBEAT_FILENAME, ".dpf-session-heartbeat.json");
+    // path.join uses the platform separator; compare separator-agnostically.
+    assert.equal(
+      heartbeatPath("D:/DPF-worktrees/topic").replace(/\\/g, "/"),
+      "D:/DPF-worktrees/topic/.dpf-session-heartbeat.json",
+    );
+  });
+
+  it("ttl honors the env override, else the default", () => {
+    assert.equal(heartbeatTtlMs({}), DEFAULT_TTL_MS);
+    assert.equal(heartbeatTtlMs({ DPF_WORKTREE_SESSION_HEARTBEAT_TTL_MIN: "30" }), 30 * 60_000);
+    assert.equal(heartbeatTtlMs({ DPF_WORKTREE_SESSION_HEARTBEAT_TTL_MIN: "bad" }), DEFAULT_TTL_MS);
+    assert.equal(heartbeatTtlMs({ DPF_WORKTREE_SESSION_HEARTBEAT_TTL_MIN: "0" }), DEFAULT_TTL_MS);
+  });
+});
+
+describe("parseHeartbeat", () => {
+  it("accepts a record with numeric beatAt, rejects junk", () => {
+    assert.deepEqual(parseHeartbeat('{"beatAt":123}'), { beatAt: 123 });
+    assert.equal(parseHeartbeat("not json"), null);
+    assert.equal(parseHeartbeat('{"beatAt":"x"}'), null);
+    assert.equal(parseHeartbeat("null"), null);
+  });
+});
+
+describe("isHeartbeatLive", () => {
+  const now = 1_000_000_000;
+  it("live within ttl, dead past it", () => {
+    assert.equal(isHeartbeatLive({ beatAt: now - 10_000 }, now, DEFAULT_TTL_MS), true);
+    assert.equal(isHeartbeatLive({ beatAt: now - (DEFAULT_TTL_MS + 1) }, now, DEFAULT_TTL_MS), false);
+  });
+  it("rejects null/malformed and implausibly-future beats", () => {
+    assert.equal(isHeartbeatLive(null, now), false);
+    assert.equal(isHeartbeatLive({ beatAt: NaN }, now), false);
+    assert.equal(isHeartbeatLive({ beatAt: now + 60 * 60_000 }, now), false);
+  });
+});
+
+describe("write / read / remove / isWorktreeSessionLive", () => {
+  it("writes a live marker, reads it back, and reports live", () => {
+    const fs = memFs();
+    const now = 5_000_000;
+    assert.equal(writeHeartbeat("/wt", { now, pid: 42, sessionId: "s1", event: "Stop", fs }), true);
+    const hb = readHeartbeat("/wt", { fs });
+    assert.equal(hb.beatAt, now);
+    assert.equal(hb.pid, 42);
+    assert.equal(hb.sessionId, "s1");
+    assert.equal(isWorktreeSessionLive("/wt", { now, ttlMs: DEFAULT_TTL_MS, fs }), true);
+  });
+
+  it("preserves startedAt across refreshes but advances beatAt", () => {
+    const fs = memFs();
+    writeHeartbeat("/wt", { now: 1000, fs });
+    writeHeartbeat("/wt", { now: 2000, fs });
+    const hb = readHeartbeat("/wt", { fs });
+    assert.equal(hb.startedAt, 1000);
+    assert.equal(hb.beatAt, 2000);
+  });
+
+  it("a stale marker reads as not-live; remove clears it", () => {
+    const fs = memFs();
+    writeHeartbeat("/wt", { now: 0, fs });
+    const later = DEFAULT_TTL_MS + 10_000;
+    assert.equal(isWorktreeSessionLive("/wt", { now: later, ttlMs: DEFAULT_TTL_MS, fs }), false);
+    assert.equal(removeHeartbeat("/wt", { fs }), true);
+    assert.equal(readHeartbeat("/wt", { fs }), null);
+    assert.equal(isWorktreeSessionLive("/wt", { now: 0, fs }), false);
+  });
+
+  it("missing marker is not live and read returns null", () => {
+    const fs = memFs();
+    assert.equal(readHeartbeat("/none", { fs }), null);
+    assert.equal(isWorktreeSessionLive("/none", { now: 0, fs }), false);
+  });
+});

--- a/scripts/root-clone-refresh.mjs
+++ b/scripts/root-clone-refresh.mjs
@@ -15,7 +15,7 @@
 
 import { existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { pathToFileURL } from "node:url";
 
 import { resolveRootClonePath } from "./lib/stale-root-clone.mjs";
 import { refreshRootClone } from "./lib/root-clone-refresh.mjs";

--- a/scripts/root-clone-refresh.mjs
+++ b/scripts/root-clone-refresh.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// scripts/root-clone-refresh.mjs
+//
+// EP-PROCESS-SPINE (plan 2026-08-11-worktree-lifecycle-hygiene) — fast-forward the
+// root clone to origin/main so junctioned worktrees never inherit a stale root
+// (BI-A900EA3F remedy). Fast-forward ONLY; refuses when the root is off-main,
+// detached, or dirty.
+//
+// USAGE
+//   node scripts/root-clone-refresh.mjs [--root PATH] [--no-fetch] [--json]
+//
+// Exits 0 whenever it ran cleanly (including "skip"/"refuse" — those are correct,
+// safe outcomes, not failures). Exits 1 only when it could not resolve the root or
+// a ff-only merge it attempted actually failed.
+
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { resolveRootClonePath } from "./lib/stale-root-clone.mjs";
+import { refreshRootClone } from "./lib/root-clone-refresh.mjs";
+
+function parseArgs(argv) {
+  let root = process.env.DPF_REPO_ROOT || process.env.PROJECT_ROOT || "";
+  let json = false;
+  let doFetch = true;
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--json") json = true;
+    else if (a === "--no-fetch") doFetch = false;
+    else if (a === "--root") root = argv[++i];
+    else if (a.startsWith("--root=")) root = a.split("=")[1];
+    else if (a === "-h" || a === "--help") {
+      console.log("usage: node scripts/root-clone-refresh.mjs [--root PATH] [--no-fetch] [--json]");
+      process.exit(0);
+    }
+  }
+  return { root, json, doFetch };
+}
+
+function resolveRoot(explicit) {
+  if (explicit && existsSync(explicit)) return explicit;
+  // Resolve the owning root clone from the current directory (works from a worktree).
+  const fromCwd = resolveRootClonePath(process.cwd(), {});
+  if (fromCwd && existsSync(fromCwd)) return fromCwd;
+  const r = spawnSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8", windowsHide: true });
+  if (r.status === 0 && r.stdout.trim()) return r.stdout.trim();
+  if (existsSync("/host-dpf")) return "/host-dpf";
+  return null;
+}
+
+function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const root = resolveRoot(args.root);
+  if (!root) {
+    const err = { ok: false, error: "could not resolve root clone (pass --root or set DPF_REPO_ROOT)" };
+    if (args.json) console.log(JSON.stringify(err, null, 2));
+    else console.error(`  [fail]  ${err.error}`);
+    process.exit(1);
+  }
+
+  const result = refreshRootClone({ rootClonePath: root, doFetch: args.doFetch });
+  const report = { ok: result.action !== "failed", root, ...result };
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(report.ok ? 0 : 1);
+  }
+
+  const tag =
+    result.action === "ff" ? "[ff]  " :
+    result.action === "skip" ? "[ok]  " :
+    result.action === "refuse" ? "[skip]" : "[fail]";
+  console.log(`${tag} root clone ${root} — ${result.reason}`);
+  process.exit(report.ok ? 0 : 1);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main();
+}
+
+export { main };

--- a/scripts/worktree-janitor.mjs
+++ b/scripts/worktree-janitor.mjs
@@ -33,6 +33,10 @@ import {
   isLiveReapEligible,
   summarizeDecisions,
 } from "./lib/worktree-janitor-core.mjs";
+import {
+  isWorktreeSessionLive,
+  heartbeatTtlMs,
+} from "./lib/worktree-session-heartbeat.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_GRACE = 14;
@@ -166,6 +170,13 @@ function isDirty(wtPath) {
   return r.ok && r.stdout.length > 0;
 }
 
+/** True when a merge is in progress in this worktree (MERGE_HEAD present). For a
+ *  linked worktree MERGE_HEAD lives in its per-worktree git dir, so ask git. */
+function isMidMerge(wtPath) {
+  const r = runGit(["rev-parse", "-q", "--verify", "MERGE_HEAD"], wtPath);
+  return r.ok && r.stdout.length > 0;
+}
+
 function ageDays(wtPath) {
   const r = runGit(["log", "-1", "--format=%ct"], wtPath);
   if (!r.ok || !r.stdout) return 0;
@@ -214,19 +225,23 @@ function pathHasLease(leasePayload, wtPath) {
   return leasePayload.includes(wtPath) || leasePayload.includes(norm);
 }
 
-function gatherFacts(root, entry, prIndex, leasePayload) {
+function gatherFacts(root, entry, prIndex, leasePayload, ttlMs) {
   const wtPath = entry.path;
   const branch = entry.detached ? null : entry.branch;
+  const isRoot = path.resolve(wtPath) === path.resolve(root);
   return {
     path: wtPath,
     branch,
-    isRoot: path.resolve(wtPath) === path.resolve(root),
+    isRoot,
     pinned: existsSync(path.join(wtPath, ".worktree-pinned")),
     hasActiveLease: pathHasLease(leasePayload, wtPath),
     hasOpenPr: branch ? prIndex.open.has(branch) : false,
     merged: branch ? isMerged(root, branch, prIndex) : false,
     dirty: branch ? isDirty(wtPath) : false,
     ageDays: branch ? ageDays(wtPath) : 0,
+    // Liveness + abandoned-merge signals — never checked on the root clone.
+    hasLiveSession: branch && !isRoot ? isWorktreeSessionLive(wtPath, { ttlMs }) : false,
+    midMerge: branch && !isRoot ? isMidMerge(wtPath) : false,
   };
 }
 
@@ -275,12 +290,13 @@ function main(argv = process.argv.slice(2)) {
   const entries = listWorktrees(root);
   const prIndex = loadPrBranchIndex();
   const leasePayload = loadLeasePaths();
+  const ttlMs = heartbeatTtlMs(process.env);
   const policy = args.tierAOnly ? "tier-a-only" : "all";
   const decisions = [];
   const removals = [];
 
   for (const entry of entries) {
-    const facts = gatherFacts(root, entry, prIndex, leasePayload);
+    const facts = gatherFacts(root, entry, prIndex, leasePayload, ttlMs);
     const { verdict, reason, tier } = classifyWorktree(facts, { graceDays: args.graceDays });
     const row = {
       path: facts.path,
@@ -291,6 +307,8 @@ function main(argv = process.argv.slice(2)) {
       ageDays: facts.ageDays,
       merged: facts.merged,
       dirty: facts.dirty,
+      hasLiveSession: facts.hasLiveSession,
+      midMerge: facts.midMerge,
     };
     decisions.push(row);
 
@@ -323,9 +341,13 @@ function main(argv = process.argv.slice(2)) {
   for (const d of decisions) {
     console.log(`  ${d.verdict.padEnd(12)} ${d.path}  (${d.reason})`);
   }
+  for (const p of summary.flaggedPaths ?? []) {
+    console.log(`  [flag]  abandoned mid-merge (MERGE_HEAD, no live session): ${p} — quarantined, never auto-reaped`);
+  }
   console.log(
     `\nSummary: TierA=${summary.counts.PRUNE_TIER_A} TierB=${summary.counts.PRUNE_TIER_B} ` +
-      `KEEP=${summary.counts.KEEP} SKIP=${summary.counts.SKIP} PINNED=${summary.counts.PINNED}`,
+      `KEEP=${summary.counts.KEEP} SKIP=${summary.counts.SKIP} PINNED=${summary.counts.PINNED} ` +
+      `FLAG_ABANDONED_MERGE=${summary.counts.FLAG_ABANDONED_MERGE ?? 0}`,
   );
   if (args.dryRun) console.log("\n(Dry run — nothing removed. Pass --live to prune.)\n");
   process.exit(0);


### PR DESCRIPTION
## Problem

Two worktree-lifecycle failures surfaced during a stuck-PR sweep:

1. **The fleet janitor could reap an active session's worktree mid-session.** A merged+clean tree first becomes Tier-A eligible *the moment its own PR merges* — exactly when it was being removed. Git then silently fell through to the shared **root clone** (`D:/DPF`), so a later `git checkout -B …` mutated the root clone's branch instead of the worktree (the documented "deleted-worktree → root-clone" near-miss corruption).
2. **The root clone was left 18 commits behind `origin/main`.** Peer worktrees junction `@dpf/*` into the root tree, so a stale root makes `pregate-preflight` abort with *"Stale root clone detected (BI-A900EA3F)"* for **every** worktree until the root is fast-forwarded.

## Fixes (all fail-open; reaper's default observe-only posture unchanged — this only makes auto-reap *safer*)

1. **Liveness-before-reap.** New gitignored `.dpf-session-heartbeat.json` marker, refreshed every turn by a new **non-destructive** `worktree-session-heartbeat` hook (SessionStart/Stop write, SessionEnd remove). `classifyWorktree` gains `hasLiveSession`, returning `KEEP` **above** the Tier-A check; the fleet janitor reads it per worktree. Never removes the `.git` linkage of an in-use worktree.
2. **Root-clone auto-fast-forward.** `scripts/lib/root-clone-refresh.mjs` + CLI + a SessionStart `root-clone-freshness` hook that runs `git merge --ff-only origin/main` on the root — **ff-only**, only when on-main and clean; **refuses** (never forces) when off-main/detached/dirty. This is the exact remedy the stale-root-clone detector already prints, so it complements (does not fight) `root-clone-guard.mjs`.
3. **Abandoned-merge quarantine.** `MERGE_HEAD` present with no live session → `FLAG_ABANDONED_MERGE`: surfaced in the janitor summary, **never** reap-eligible (an interrupted merge can hide un-reconciled work). A live session's in-progress merge is `KEEP`.

## Design grounding

Extends the **`worktree-selection-and-reaping`** kernel principle and the multi-client governance-parity spec (`docs/superpowers/specs/2026-07-26-multi-client-governance-parity-design.md` §D4) — the source of truth. The principle *already* names the lifecycle as `active` ("claimed capsule, **live heartbeat**") / `idle` ("no heartbeat past threshold"); this makes that heartbeat real and feeds it to the reaper. No new contract. Plan: `docs/superpowers/plans/2026-08-11-worktree-lifecycle-hygiene.md`; runbook + principle updated in-branch.

Design-Grounding-Decision: extend existing worktree-reaping principle + §D4; concretize the named "live heartbeat" signal, add root-clone-freshness remedy and abandoned-merge quarantine.
Process-Spine-Decision: worktree-governance hardening; plan, runbook, and kernel principle updated in-branch.

## Tests

`node --test` (runs in a source-only worktree — no workspace install needed): `worktree-janitor-core` (new liveness/abandoned-merge verdicts), `worktree-session-heartbeat` lib + hook (incl. a real linked-worktree write/remove integration case), `root-clone-refresh` lib, `root-clone-freshness` hook. All registered in the hand-enumerated `scripts/lib/ci-policy-guards.mjs` inventory so CI runs them; `worktree-janitor-core.test.mjs` promoted from the exclusion allowlist into the inventory.

## Notes

- **Backlog:** surfaced from a sweep, not a pre-filed BI. The DPF MCP connector was not reachable from the authoring (source-only) session, so the live `BacklogItem` could not be filed here. An MCP-connected operator/Build Studio should file it under **EP-PROCESS-SPINE** and back-link the plan doc.
- **Pre-push gate:** overridden with the allowlisted `external-contribution-no-install` code — this is a source-only worktree (`node_modules` absent) that cannot run local pregate/sandbox. Every gate this environment permits was run green (see Tests). Server CI gates fully.
- Pre-existing (unrelated) `doc-impact.generated.json` drift is present on `origin/main`; left untouched — its sources (`docs/user-guide/**`, `docs-route-map.ts`) are not part of this change, and regenerating it from a source-only worktree risks a wrong artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Docs-Impact-Decision: the flagged code file is scripts/lib/ci-policy-guards.mjs (the CI test-inventory registry) — adding node --test entries and the allowlist edit change no user-facing documentation; the runbook/principle/plan docs that this change does affect are updated in-branch.
Seed-Fit-Decision: global-default — the worktree-selection-and-reaping principle applies platform-wide to every install; the added liveness-gate / root-clone-freshness / abandoned-merge guidance is a global default, not archetype- or vertical-scoped.
