### PR TITLE
fix(self-upgrade): stop the candidate build OOM-bricking upgrades on lean hosts (SUR-BF75ED2A)

### DIFF
--- a/Dockerfile.promoter.dockerignore
+++ b/Dockerfile.promoter.dockerignore
@@ -1,0 +1,44 @@
+# Build context allowlist for the promoter image (Dockerfile.promoter).
+#
+# BuildKit prefers `<dockerfile>.dockerignore` over the root `.dockerignore`, so
+# this file governs the promoter build's context — WITHOUT changing the root
+# `.dockerignore` that the portal/release images rely on.
+#
+# WHY: the candidate promoter build (self-upgrade preflight) handed Docker the
+# entire upgrade workspace as build context. On a memory-pressured host buildkit's
+# context sender OOMs while enumerating that tree — SUR-BF75ED2A (2026-08-11):
+# `readdirent /host-dpf/.upgrade-workspace/scripts: cannot allocate memory`. The
+# image COPYs only ~20 files, so there is no reason to walk/transfer the whole
+# repo. Ignore everything, then re-include exactly the Dockerfile.promoter COPY
+# sources. This keeps the context tiny (apps/, packages/, docs/, tests/, node_modules
+# are never sent), so the build fits a lean customer host.
+#
+# GUARD: scripts/promoter-build-context.test.mjs asserts this allowlist matches the
+# Dockerfile.promoter COPY sources exactly — add a COPY, add its `!` line here.
+
+# Ignore the entire context first.
+**
+
+# Re-include only what Dockerfile.promoter COPYs.
+!promoter-contract.json
+!Dockerfile
+!Dockerfile.promoter
+!scripts/promote.sh
+!scripts/apply-runtime-capability-transition.mjs
+!scripts/runtime-transition-authority.mjs
+!scripts/rotate-runtime-transition-secret.mjs
+!scripts/lib/transition-signing.mjs
+!scripts/promoter-migration-envelope.mjs
+!scripts/installer/validate-install-state.mjs
+!scripts/installer/migrate-install-state.mjs
+!scripts/installer/resolve-host-identity.mjs
+!scripts/installer/install-state-transaction.mjs
+!scripts/installer/install-state-lock-contract.json
+!scripts/installer/install-state-schema-registry.mjs
+!scripts/installer/install-state.schema.json
+!scripts/installer/install-state.v1.schema.json
+!scripts/installer/install-state.v2.schema.json
+!scripts/lib/resolve-capability-compose-profiles.mjs
+!scripts/lib/govern-capability-compose-args.mjs
+!scripts/lib/capability-state-hash.mjs
+!scripts/capability-service-catalog.generated.json

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -909,6 +909,9 @@
     "apps/web/lib/security/safe-log.ts": [
       "docs/security/codeql-advanced-setup.md"
     ],
+    "apps/web/lib/self-upgrade/host-memory-preflight.ts": [
+      "docs/runbooks/bet5-windows-self-upgrade.md"
+    ],
     "apps/web/lib/self-upgrade/local-changes-ledger.ts": [
       "docs/architecture/branch-and-worktree-runbook.md"
     ],
@@ -2492,6 +2495,7 @@
       "packages/db/src/migrations/exact-key-repair.ts"
     ],
     "docs/runbooks/bet5-windows-self-upgrade.md": [
+      "apps/web/lib/self-upgrade/host-memory-preflight.ts",
       "scripts/promote.sh"
     ],
     "docs/security/2026-05-24-shift-left-rollout.md": [

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -7890,6 +7890,7 @@
         "step-3-monitor-the-chain",
         "step-4-verify-postgres-only-done-criteria",
         "if-it-fails-anyway-recovery",
+        "failure-class-host-out-of-memory-candidate-build-enomem",
         "failure-class-migration-unique-violation-p3018-23505",
         "references"
       ]

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -1,9 +1,6 @@
 import { cron } from "inngest";
 import { inngest } from "../inngest-client";
-import { getSelfUpgradeConfig, resolveSelfUpgradeHostIdentity } from "@/lib/self-upgrade/config";
-import { readFile } from "node:fs/promises";
-import { createHash } from "node:crypto";
-import { verifyInstallStateMigrationEnvelope } from "../../../../../scripts/lib/transition-signing.mjs";
+import { getSelfUpgradeConfig } from "@/lib/self-upgrade/config";
 import { isUpgradeWindowOpen } from "@/lib/self-upgrade/window";
 import { resolveAutoUpgradeWindow } from "@/lib/self-upgrade/auto-window";
 import { getActiveSelfUpgradeBlackout } from "@/lib/self-upgrade/blackout";
@@ -19,7 +16,13 @@ import { prepareUpgradeSource, defaultGitRunner } from "@/lib/self-upgrade/prepa
 // NOT be statically imported into this server bundle entrypoint (BI-98AF1066);
 // that is what the dynamic loadPromoterRuntime() below is for.
 import { PROMOTER_ALREADY_RUNNING_EXIT_CODE } from "@/lib/self-upgrade/promoter-exit-codes";
-import { resolveReadinessBackupHostPath, runCandidatePreflight } from "@/lib/self-upgrade/preflight";
+import {
+  resolveReadinessBackupHostPath,
+  runCandidatePreflight,
+  loadInstallStateSigningContext,
+  verifyMigrationHandoff,
+} from "@/lib/self-upgrade/preflight";
+import { evaluateHostMemoryGuard } from "@/lib/self-upgrade/host-memory-preflight";
 import { getDeployedSha, isFeatureBuildDeployed } from "@/lib/self-upgrade/completion";
 import {
   classifyBuildFailure,
@@ -466,6 +469,18 @@ export async function runSelfUpgrade(
     return await skipAttempt("up-to-date", `up-to-date: ${builtStamp}`, { builtStamp });
   }
 
+  // Host-memory-headroom guard (SUR-BF75ED2A, 2026-08-11). The candidate promoter
+  // `docker build` is memory-heavy; under host exhaustion buildkit's context
+  // sender OOMs and the run dies at preflight. DEFER (skip + cooldown) rather than
+  // fail — the next cron tick retries once memory recovers. See host-memory-preflight.
+  if (!params.dryRun && !params.force) {
+    const guard = await evaluateHostMemoryGuard();
+    if (guard.defer) {
+      await recordCooldown(now, cooldownMinutes);
+      return await skipAttempt("host-memory-pressure", guard.reason, guard.extra);
+    }
+  }
+
   const run = params.runId
     ? await updateRunPlan(params.runId, {
         fromVersion: deployedSha ?? undefined,
@@ -489,21 +504,12 @@ export async function runSelfUpgrade(
   // Candidate-owned preflight. Resolve once, validate the embedded contract,
   // run readiness against that digest, persist evidence, and only then drain.
   // Undefined mode is the post-floor default; legacy-bootstrap is explicit.
-  let runtimeTransitionSecret: string | undefined;
-  let hostIdentity: ReturnType<typeof resolveSelfUpgradeHostIdentity> | undefined;
-  try {
-    if (!params.dryRun) {
-      const installStateBytes = await readFile("/dpf-state/install-state.json", "utf8");
-      runtimeTransitionSecret = (await readFile("/dpf-state/runtime-transition.secret", "utf8")).trim();
-      if (!runtimeTransitionSecret) throw new Error("runtime_transition_secret_empty");
-      hostIdentity = resolveSelfUpgradeHostIdentity(process.env, JSON.parse(installStateBytes.replace(/^\uFEFF/, "")));
-    }
-  } catch (error) {
-    const reason = `installer-state-repair-required: ${error instanceof Error ? error.message : "install_state_preparation_failed"}`;
-    await failRun(run.runId, reason);
-    await emitUpgradeEvent({ type: "upgrade.failed", runId: run.runId });
-    return { ok: false, status: "failed", runId: run.runId, reason: "installer-state-repair-required", excerpt: reason };
-  }
+  const emitFailure = (runId: string) => emitUpgradeEvent({ type: "upgrade.failed", runId });
+  const signingContext = await loadInstallStateSigningContext({
+    dryRun: params.dryRun, runId: run.runId, failRun, emitFailure,
+  });
+  if (!signingContext.ok) return { ok: false, status: "failed", runId: run.runId, reason: "installer-state-repair-required", excerpt: signingContext.reason };
+  const { runtimeTransitionSecret, hostIdentity } = signingContext;
   const preflight = await runCandidatePreflight({
     dryRun: params.dryRun, readinessMode: config.readinessMode, readinessOwner: config.readinessOwner,
     promoterImage: config.promoterImage, callerProtocolVersion: config.callerProtocolVersion,
@@ -513,29 +519,22 @@ export async function runSelfUpgrade(
     runId: run.runId, composeFiles: composeFiles ?? [], composeProject,
     healthUrl: config.healthUrl ?? process.env.PROMOTE_HEALTH_URL ?? "",
     runtime: loadPromoterRuntime, recordReadiness: recordPromoterReadiness, failRun,
-    emitFailure: async (runId) => emitUpgradeEvent({ type: "upgrade.failed", runId }),
+    emitFailure,
     hostIdentity, runtimeTransitionSecret,
   });
   if (!preflight.ok) {
+    // Back off so a residual preflight failure (an OOM under the guard floor, or a
+    // readiness refusal) doesn't re-attempt the heavy build every cron tick.
+    await recordCooldown(now, cooldownMinutes);
     return { ok: false, status: "failed", runId: run.runId, reason: preflight.reason };
   }
   const resolvedPromoterDigest = preflight.resolvedPromoterDigest;
   const migrationHandoff = preflight.migrationHandoff;
-  if (!params.dryRun) {
-    try {
-      if (!migrationHandoff || !resolvedPromoterDigest || !runtimeTransitionSecret || !hostIdentity) throw new Error("install_state_migration_handoff_missing");
-      const currentStateBytes = await readFile("/dpf-state/install-state.json", "utf8");
-      verifyInstallStateMigrationEnvelope(migrationHandoff.envelope, migrationHandoff.signature, runtimeTransitionSecret, {
-        runId: run.runId, promoterDigest: resolvedPromoterDigest,
-        sourceHash: createHash("sha256").update(currentStateBytes).digest("hex"), hostIdentity, now: Date.now(),
-      });
-    } catch (error) {
-      const reason = `installer-state-repair-required: ${error instanceof Error ? error.message : "install_state_migration_handoff_invalid"}`;
-      await failRun(run.runId, reason);
-      await emitUpgradeEvent({ type: "upgrade.failed", runId: run.runId });
-      return { ok: false, status: "failed", runId: run.runId, reason: "installer-state-repair-required", excerpt: reason };
-    }
-  }
+  const handoff = await verifyMigrationHandoff({
+    dryRun: params.dryRun, runId: run.runId, migrationHandoff, resolvedPromoterDigest,
+    runtimeTransitionSecret, hostIdentity, failRun, emitFailure,
+  });
+  if (!handoff.ok) return { ok: false, status: "failed", runId: run.runId, reason: "installer-state-repair-required", excerpt: handoff.reason };
 
   // BI-QUIESCE-010 keystone integration: replaces the single-signal
   // getPortalActivity check with the full Activity Quiescence Protocol

--- a/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
@@ -290,6 +290,34 @@ describe("classifyBuildFailure", () => {
     expect(c.summary).toContain("lockfile");
   });
 
+  it("classifies the SUR-BF75ED2A host-OOM candidate build as retryable environment, beating the readiness wrapper", () => {
+    // Verbatim shape of the persisted failureLog: the pipeline prepends
+    // `promoter-readiness-failed: promoter_candidate_build_failed:` — which the
+    // readiness-extraction branch would otherwise claim first, mislabeling a
+    // pure host-OOM as the generic unactionable readiness class.
+    const log = `promoter-readiness-failed: promoter_candidate_build_failed:  DONE 0.1s
+
+#5 [internal] load build context
+#5 transferring context: 22.62kB 0.3s done
+#5 ERROR: error from sender: readdirent /host-dpf/.upgrade-workspace/scripts: cannot allocate memory
+
+#6 [ 2/25] RUN apk add --no-cache bash docker-cli docker-cli-buildx
+#6 CANCELED
+ERROR: failed to build: failed to solve: error from sender: readdirent /host-dpf/.upgrade-workspace/scripts: cannot allocate memory`;
+    const c = classifyBuildFailure({ log });
+    expect(c.class).toBe("host-out-of-memory");
+    expect(c.isMainDefectVsEnvironment).toBe("environment");
+    expect(c.failingTrace).toContain("cannot allocate memory");
+  });
+
+  it("classifies an OOMKilled container as host-out-of-memory", () => {
+    const c = classifyBuildFailure({
+      log: "#12 [build 4/8] RUN pnpm --filter web build\nnext build worker terminated: OOMKilled (exit 137)",
+    });
+    expect(c.class).toBe("host-out-of-memory");
+    expect(c.isMainDefectVsEnvironment).toBe("environment");
+  });
+
   it("classifies a promoter timeout as retryable environment, superseding earlier build noise", () => {
     // The kill happened because nothing completed, so a half-emitted NFT trace
     // above the marker is noise — the timeout must win.

--- a/apps/web/lib/self-upgrade/build-failure-classifier.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.ts
@@ -103,6 +103,16 @@ export type BuildFailureClass =
   // install cannot self-upgrade INTO #3282 — the fix is the documented
   // out-of-band crossing bootstrap, never a rebuild or a retry (BI-BE8BBDE9).
   | "install-state-migration-handoff-missing"
+  // The build/host step failed because the host (or the Docker VM) ran OUT OF
+  // MEMORY: buildkit's context sender OOMs on `readdirent … cannot allocate
+  // memory` (ENOMEM), or a container is OOMKilled, or Node's heap exhausts.
+  // Canonical case SUR-BF75ED2A (2026-08-11): the WSL2 VM (hard-capped 24GB) was
+  // thrashing during the candidate promoter build and the context load failed
+  // ENOMEM. Transient host pressure, NOT a main defect — the candidate build
+  // runs BEFORE any portal swap, so nothing was deployed. The governed path now
+  // DEFERS on a host-memory-headroom guard and retries after reclaim; a run that
+  // still reaches here should be retried once the host frees memory.
+  | "host-out-of-memory"
   | "unknown";
 
 export type BuildFailureClassification = {
@@ -158,6 +168,11 @@ const PNPM_OUTDATED_LOCKFILE = /ERR_PNPM_(OUTDATED_)?LOCKFILE|specifiers in the 
 // failures (e.g. prisma migrate unable to reach postgres) and must stay
 // unclassified rather than misdiagnosed as a dependency fetch.
 const PNPM_FETCH_ERROR = /ERR_PNPM_FETCH|ERR_PNPM_META_FETCH_FAIL|GET https:\/\/registry\.npmjs\.org\/[^\s]+: (?:ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENETUNREACH|socket hang up)/i;
+// Host / Docker-VM out-of-memory. buildkit's context sender fails a getdents64
+// with `readdirent … cannot allocate memory` (ENOMEM); Docker kills an OOM
+// container with `OOMKilled`; Node exhausts its heap. Deliberately anchored on
+// these decisive OOM phrasings so an unrelated failure never gets swept in.
+const HOST_OUT_OF_MEMORY = /cannot allocate memory|OOMKilled|\bENOMEM\b|JavaScript heap out of memory/i;
 // runPromoter's marker when it kills a promoter that blew its wall-clock budget.
 const PROMOTER_TIMEOUT = /\[promoter-timeout\]/i;
 // Production wraps the terminal machine code in a human-readable diagnostic:
@@ -224,6 +239,24 @@ export function classifyBuildFailure(
   input: BuildFailureInput,
 ): BuildFailureClassification {
   const log = input.log ?? "";
+
+  // Host / VM out-of-memory FIRST. An OOM is a decisive environmental cause: it
+  // cancels whatever step was running, so any half-emitted trace — or the
+  // `promoter-readiness-failed:` / `promoter_candidate_build_failed:` wrapper the
+  // pipeline prepends — is noise, not the cause. Checked ahead of the readiness
+  // extraction below (which would otherwise short-circuit an OOM'd candidate
+  // build into the generic, unactionable `promoter-readiness-failed` class — the
+  // exact SUR-BF75ED2A mislabel this class fixes).
+  if (HOST_OUT_OF_MEMORY.test(log)) {
+    return {
+      class: "host-out-of-memory",
+      summary:
+        "The build failed because the host / Docker VM ran out of memory (`cannot allocate memory` / OOMKilled) — buildkit's context sender could not allocate a buffer to read the build context. Transient host pressure, NOT a main defect: the candidate build runs before any portal swap, so nothing was deployed and the running portal is untouched. Free host memory (WSL2 autoMemoryReclaim, or shed heavy consumers) and retry — the self-upgrade's host-memory-headroom guard now DEFERS instead of failing when MemAvailable is below the build floor, so a healthy retry happens automatically on the next cron tick.",
+      playbookLink: SPEC,
+      failingTrace: traceAround(log, HOST_OUT_OF_MEMORY),
+      isMainDefectVsEnvironment: "environment",
+    };
+  }
 
   const readinessFailure = log.match(PROMOTER_READINESS_FAILED);
   if (readinessFailure) {

--- a/apps/web/lib/self-upgrade/host-memory-preflight.test.ts
+++ b/apps/web/lib/self-upgrade/host-memory-preflight.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MIN_BUILD_MEMORY_BYTES,
+  checkHostMemoryHeadroom,
+  formatGiB,
+  parseMemAvailableBytes,
+  readHostAvailableMemory,
+} from "./host-memory-preflight";
+
+const GiB = 1024 * 1024 * 1024;
+
+// A realistic /proc/meminfo where MemFree is tiny (page cache) but MemAvailable
+// is large — the exact Linux shape that makes MemFree a useless build-headroom
+// signal. Gating on MemFree here would defer a perfectly healthy host.
+function meminfo({ memFreeKb, memAvailableKb }: { memFreeKb: number; memAvailableKb: number }): string {
+  return [
+    "MemTotal:       24610000 kB",
+    `MemFree:        ${memFreeKb} kB`,
+    "Buffers:          123456 kB",
+    `MemAvailable:   ${memAvailableKb} kB`,
+    "SwapTotal:       6291456 kB",
+  ].join("\n");
+}
+
+describe("parseMemAvailableBytes", () => {
+  it("extracts MemAvailable in bytes, not MemFree", () => {
+    const bytes = parseMemAvailableBytes(meminfo({ memFreeKb: 226392, memAvailableKb: 16154028 }));
+    expect(bytes).toBe(16154028 * 1024);
+  });
+
+  it("returns undefined when MemAvailable is absent (very old kernels)", () => {
+    expect(parseMemAvailableBytes("MemTotal: 100 kB\nMemFree: 50 kB")).toBeUndefined();
+  });
+});
+
+describe("readHostAvailableMemory", () => {
+  it("prefers /proc/meminfo MemAvailable over os.freemem()", async () => {
+    const reading = await readHostAvailableMemory({
+      readMeminfo: async () => meminfo({ memFreeKb: 200000, memAvailableKb: 16000000 }),
+      osFreeMemoryBytes: () => 999 * GiB, // must be ignored
+    });
+    expect(reading.source).toBe("meminfo");
+    expect(reading.availableBytes).toBe(16000000 * 1024);
+  });
+
+  it("falls back to os.freemem() when meminfo is unreadable (non-Linux dev host)", async () => {
+    const reading = await readHostAvailableMemory({
+      readMeminfo: async () => {
+        throw new Error("ENOENT");
+      },
+      osFreeMemoryBytes: () => 8 * GiB,
+    });
+    expect(reading.source).toBe("os-freemem");
+    expect(reading.availableBytes).toBe(8 * GiB);
+  });
+
+  it("reports unmeasurable when neither source yields a finite value", async () => {
+    const reading = await readHostAvailableMemory({
+      readMeminfo: async () => "garbage with no MemAvailable line",
+      osFreeMemoryBytes: () => Number.NaN,
+    });
+    expect(reading.source).toBe("unmeasurable");
+    expect(reading.availableBytes).toBeUndefined();
+  });
+});
+
+describe("checkHostMemoryHeadroom", () => {
+  it("passes when MemAvailable clears the floor even though MemFree is tiny (the SUR-BF75ED2A steady state)", async () => {
+    const headroom = await checkHostMemoryHeadroom({
+      deps: { readMeminfo: async () => meminfo({ memFreeKb: 226392, memAvailableKb: 16154028 }) },
+    });
+    expect(headroom.ok).toBe(true);
+    expect(headroom.source).toBe("meminfo");
+  });
+
+  it("defers when MemAvailable is below the floor (the thrashing state that OOMs the build)", async () => {
+    const headroom = await checkHostMemoryHeadroom({
+      deps: { readMeminfo: async () => meminfo({ memFreeKb: 15000, memAvailableKb: 400000 }) },
+    });
+    expect(headroom.ok).toBe(false);
+    expect(headroom.availableBytes).toBe(400000 * 1024);
+    expect(headroom.requiredBytes).toBe(DEFAULT_MIN_BUILD_MEMORY_BYTES);
+  });
+
+  it("respects a custom required floor", async () => {
+    const headroom = await checkHostMemoryHeadroom({
+      requiredBytes: 1 * GiB,
+      deps: { readMeminfo: async () => meminfo({ memFreeKb: 15000, memAvailableKb: 1_500_000 }) },
+    });
+    expect(headroom.ok).toBe(true); // 1.43 GiB available >= 1 GiB required
+  });
+
+  it("fails OPEN when memory is unmeasurable — never wedges upgrades on an unreadable host", async () => {
+    const headroom = await checkHostMemoryHeadroom({
+      deps: {
+        readMeminfo: async () => {
+          throw new Error("ENOENT");
+        },
+        osFreeMemoryBytes: () => Number.NaN,
+      },
+    });
+    expect(headroom.ok).toBe(true);
+    expect(headroom.source).toBe("unmeasurable");
+    expect(headroom.availableBytes).toBeUndefined();
+  });
+});
+
+describe("formatGiB", () => {
+  it("renders bytes as two-decimal GiB", () => {
+    expect(formatGiB(2 * GiB)).toBe("2.00GiB");
+    expect(formatGiB(400000 * 1024)).toBe("0.38GiB");
+  });
+});

--- a/apps/web/lib/self-upgrade/host-memory-preflight.ts
+++ b/apps/web/lib/self-upgrade/host-memory-preflight.ts
@@ -1,0 +1,145 @@
+// Host-memory-headroom guard for the self-upgrade candidate build.
+//
+// SUR-BF75ED2A (2026-08-11): a self-upgrade died at the candidate promoter
+// `docker build` with `error from sender: readdirent
+// /host-dpf/.upgrade-workspace/scripts: cannot allocate memory`. The WSL2 VM
+// (hard-capped at 24GB) was thrashing — swap in use, MemFree ~467MB — and
+// buildkit's context sender could not allocate a kernel buffer to enumerate the
+// build context, so the build aborted. It failed at the PREFLIGHT stage, before
+// any portal swap, so nothing was deployed; the run was nevertheless marked
+// terminally `failed` with no memory check preceding the build.
+//
+// This guard lets the pipeline DEFER (skip + cooldown, retryable) instead of
+// launching a build the host cannot afford. The next hourly cron retries once
+// memory recovers (WSL2 autoMemoryReclaim=gradual, or load subsiding).
+//
+// Critically the floor is measured against MemAvailable (reclaimable-inclusive),
+// NOT MemFree: Linux keeps MemFree low by design (idle RAM becomes page cache),
+// so gating on MemFree would defer almost every run on a busy-but-healthy host.
+// MemAvailable only approaches this floor under genuine exhaustion, so the guard
+// fires rarely and never starves a merely lean host.
+
+import { readFile } from "node:fs/promises";
+import { freemem } from "node:os";
+
+/**
+ * Minimum genuinely-available host memory (bytes) required before launching the
+ * memory-heavy candidate promoter `docker build`. 2 GiB of MemAvailable clears
+ * buildkit's context-load + `apk add` layer comfortably; below it the sender is
+ * at risk of the ENOMEM readdirent that produced SUR-BF75ED2A.
+ */
+export const DEFAULT_MIN_BUILD_MEMORY_BYTES = 2 * 1024 * 1024 * 1024;
+
+export type HostMemorySource = "meminfo" | "os-freemem" | "unmeasurable";
+
+export type HostMemoryReading = {
+  availableBytes: number | undefined;
+  source: HostMemorySource;
+};
+
+/** Parse `MemAvailable` (kB) out of /proc/meminfo contents into bytes. */
+export function parseMemAvailableBytes(meminfo: string): number | undefined {
+  const match = /^MemAvailable:\s+(\d+)\s*kB/im.exec(meminfo);
+  if (!match) return undefined;
+  const kb = Number(match[1]);
+  return Number.isFinite(kb) && kb >= 0 ? kb * 1024 : undefined;
+}
+
+/**
+ * Read the host's genuinely-available memory. Prefers /proc/meminfo MemAvailable
+ * (the real deployment target is Linux/WSL2); falls back to os.freemem() when
+ * meminfo is unreadable (a non-Linux dev host), and reports "unmeasurable" when
+ * neither yields a finite value.
+ */
+export async function readHostAvailableMemory(deps?: {
+  readMeminfo?: () => Promise<string>;
+  osFreeMemoryBytes?: () => number;
+}): Promise<HostMemoryReading> {
+  const readMeminfo = deps?.readMeminfo ?? (() => readFile("/proc/meminfo", "utf8"));
+  try {
+    const available = parseMemAvailableBytes(await readMeminfo());
+    if (available !== undefined) return { availableBytes: available, source: "meminfo" };
+  } catch {
+    // /proc/meminfo not present/readable (non-Linux dev host) — fall through.
+  }
+  try {
+    const free = (deps?.osFreeMemoryBytes ?? freemem)();
+    if (typeof free === "number" && Number.isFinite(free) && free >= 0) {
+      return { availableBytes: free, source: "os-freemem" };
+    }
+  } catch {
+    // os.freemem() should never throw, but never let a probe wedge the upgrade.
+  }
+  return { availableBytes: undefined, source: "unmeasurable" };
+}
+
+export type HostMemoryHeadroom = {
+  ok: boolean;
+  availableBytes: number | undefined;
+  requiredBytes: number;
+  source: HostMemorySource;
+};
+
+/**
+ * Decide whether the host has enough available memory to launch the candidate
+ * promoter build. Fails OPEN when memory is unmeasurable: the guard is an
+ * optimization to skip a doomed build, never a hard gate that could permanently
+ * wedge upgrades on a host whose meminfo cannot be read. Only a CONFIRMED
+ * below-floor reading defers.
+ */
+export async function checkHostMemoryHeadroom(params?: {
+  requiredBytes?: number;
+  deps?: Parameters<typeof readHostAvailableMemory>[0];
+}): Promise<HostMemoryHeadroom> {
+  const requiredBytes = params?.requiredBytes ?? DEFAULT_MIN_BUILD_MEMORY_BYTES;
+  const { availableBytes, source } = await readHostAvailableMemory(params?.deps);
+  const ok = availableBytes === undefined ? true : availableBytes >= requiredBytes;
+  return { ok, availableBytes, requiredBytes, source };
+}
+
+/** Human-readable GiB, for run reasons / operator surfaces. */
+export function formatGiB(bytes: number): string {
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)}GiB`;
+}
+
+export type HostMemoryGuardDecision =
+  | { defer: false }
+  | {
+      defer: true;
+      /** Persisted skip reason for the SelfUpgradeRun / operator surface. */
+      reason: string;
+      /** Structured fields echoed on the skip result. */
+      extra: {
+        availableBytes: number | undefined;
+        requiredBytes: number;
+        memorySource: HostMemorySource;
+      };
+    };
+
+/**
+ * The self-upgrade orchestrator's single call: should the candidate build be
+ * deferred for host memory pressure? Keeps the reason/formatting here so the
+ * orchestrator stays a thin `if (decision.defer)` at the call site.
+ */
+export async function evaluateHostMemoryGuard(params?: {
+  requiredBytes?: number;
+  deps?: Parameters<typeof readHostAvailableMemory>[0];
+}): Promise<HostMemoryGuardDecision> {
+  const headroom = await checkHostMemoryHeadroom(params);
+  if (headroom.ok) return { defer: false };
+  // availableBytes is defined whenever ok is false (an unmeasurable reading
+  // fails OPEN in checkHostMemoryHeadroom, so it never reaches here).
+  const available = formatGiB(headroom.availableBytes ?? 0);
+  const required = formatGiB(headroom.requiredBytes);
+  return {
+    defer: true,
+    reason:
+      `host-memory-pressure: ${available} available < ${required} required for the ` +
+      `candidate promoter build (source: ${headroom.source})`,
+    extra: {
+      availableBytes: headroom.availableBytes,
+      requiredBytes: headroom.requiredBytes,
+      memorySource: headroom.source,
+    },
+  };
+}

--- a/apps/web/lib/self-upgrade/preflight.ts
+++ b/apps/web/lib/self-upgrade/preflight.ts
@@ -1,8 +1,12 @@
+import { readFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import type { ReadinessOwner } from "./promoter";
 import { signTransitionPayload } from "@/lib/platform-runtime/transition-protocol";
 import { verifyInstallStateMigrationEnvelope } from "../../../../scripts/lib/transition-signing.mjs";
-import type { SelfUpgradeHostIdentity } from "./config";
+import { resolveSelfUpgradeHostIdentity, type SelfUpgradeHostIdentity } from "./config";
+
+type EmitFailure = (runId: string) => Promise<unknown>;
 
 type PromoterRuntime = Pick<
   typeof import("./promoter"),
@@ -159,3 +163,69 @@ export type InstallStateMigrationEnvelope = {
 export type InstallStateMigrationHandoff = { envelope: InstallStateMigrationEnvelope; signature: string };
 function requireHash(value: unknown, error: string): string { if (typeof value !== "string" || !/^[a-f0-9]{64}$/.test(value)) throw new Error(error); return value; }
 function requireVersion(value: unknown): number { if (!Number.isInteger(value) || (value as number) < 1) throw new Error("schema_version_missing"); return value as number; }
+
+export type InstallStateSigningContext =
+  | { ok: true; runtimeTransitionSecret: string | undefined; hostIdentity: SelfUpgradeHostIdentity | undefined }
+  | { ok: false; reason: string };
+
+/**
+ * Load the runtime-transition secret + host identity the swap must sign the
+ * install-state migration handoff with. dryRun carries no signing context. On
+ * any read/parse failure it records the run failed and returns a repair reason —
+ * the orchestrator just returns it. Extracted from the self-upgrade orchestrator
+ * to keep this install-state concern beside the signing/verify logic it feeds.
+ */
+export async function loadInstallStateSigningContext(params: {
+  dryRun?: boolean;
+  runId: string;
+  failRun: FailRun;
+  emitFailure: EmitFailure;
+}): Promise<InstallStateSigningContext> {
+  if (params.dryRun) return { ok: true, runtimeTransitionSecret: undefined, hostIdentity: undefined };
+  try {
+    const installStateBytes = await readFile("/dpf-state/install-state.json", "utf8");
+    const runtimeTransitionSecret = (await readFile("/dpf-state/runtime-transition.secret", "utf8")).trim();
+    if (!runtimeTransitionSecret) throw new Error("runtime_transition_secret_empty");
+    const hostIdentity = resolveSelfUpgradeHostIdentity(process.env, JSON.parse(installStateBytes.replace(/^\uFEFF/, "")));
+    return { ok: true, runtimeTransitionSecret, hostIdentity };
+  } catch (error) {
+    const reason = `installer-state-repair-required: ${error instanceof Error ? error.message : "install_state_preparation_failed"}`;
+    await params.failRun(params.runId, reason);
+    await params.emitFailure(params.runId);
+    return { ok: false, reason };
+  }
+}
+
+/**
+ * Re-verify the signed migration handoff against the CURRENT install-state hash
+ * immediately before the swap (the state may have moved since preflight signed
+ * it). On failure it records the run failed and returns a repair reason.
+ */
+export async function verifyMigrationHandoff(params: {
+  dryRun?: boolean;
+  runId: string;
+  migrationHandoff?: InstallStateMigrationHandoff;
+  resolvedPromoterDigest?: string;
+  runtimeTransitionSecret?: string;
+  hostIdentity?: SelfUpgradeHostIdentity;
+  failRun: FailRun;
+  emitFailure: EmitFailure;
+}): Promise<{ ok: true } | { ok: false; reason: string }> {
+  if (params.dryRun) return { ok: true };
+  try {
+    if (!params.migrationHandoff || !params.resolvedPromoterDigest || !params.runtimeTransitionSecret || !params.hostIdentity) {
+      throw new Error("install_state_migration_handoff_missing");
+    }
+    const currentStateBytes = await readFile("/dpf-state/install-state.json", "utf8");
+    verifyInstallStateMigrationEnvelope(params.migrationHandoff.envelope, params.migrationHandoff.signature, params.runtimeTransitionSecret, {
+      runId: params.runId, promoterDigest: params.resolvedPromoterDigest,
+      sourceHash: createHash("sha256").update(currentStateBytes).digest("hex"), hostIdentity: params.hostIdentity, now: Date.now(),
+    });
+    return { ok: true };
+  } catch (error) {
+    const reason = `installer-state-repair-required: ${error instanceof Error ? error.message : "install_state_migration_handoff_invalid"}`;
+    await params.failRun(params.runId, reason);
+    await params.emitFailure(params.runId);
+    return { ok: false, reason };
+  }
+}

--- a/docs/runbooks/bet5-windows-self-upgrade.md
+++ b/docs/runbooks/bet5-windows-self-upgrade.md
@@ -147,6 +147,41 @@ These should not occur once the promoter is rebuilt from current `main`, but for
   `bet5_pgvector_foundation` record; if you need to do it by hand,
   `docker exec ... prisma migrate resolve --rolled-back 20260714110000_bet5_pgvector_foundation`.
 
+## Failure class: host-out-of-memory (candidate build ENOMEM)
+
+The candidate promoter `docker build` — run at the **preflight** stage, *before* quiescence, while the
+portal is still fully active — fails during build-context load with:
+
+```
+error from sender: readdirent /host-dpf/.upgrade-workspace/scripts: cannot allocate memory
+```
+
+Canonical case **SUR-BF75ED2A (2026-08-11)**: the WSL2 VM (hard-capped 24 GB in `.wslconfig`) was
+thrashing — swap in use, `MemFree` ~467 MB — so buildkit's context sender could not allocate a kernel
+buffer to enumerate the build context and the build aborted (`promoter_candidate_build_failed` →
+`promoter-readiness-failed` → run `failed`). It died **before any portal swap**, so the running portal
+was never touched — a **safe** failure, not a bad deploy.
+
+**This is host pressure, not a code defect.** The candidate build is the most memory-intensive step and
+it runs *hot* (portal live) by design, so that a failed build never causes pointless downtime — but that
+means it competes for memory with all 30 active surfaces. Quiescence (which stops activity for the
+swap/migrate) happens *after* this build and does not free memory for it.
+
+**Prevention (shipped):** a **host-memory-headroom guard** now runs before the candidate build
+(`apps/web/lib/self-upgrade/host-memory-preflight.ts`, wired in `runSelfUpgrade`). When genuinely-available
+memory is below the build floor (default 2 GiB) it **DEFERS the run** — `skipped` with reason
+`host-memory-pressure`, plus a cooldown — instead of launching a doomed build; the next hourly cron retries
+once memory recovers (WSL2 `autoMemoryReclaim=gradual`). The floor is measured against **MemAvailable**
+(reclaimable-inclusive), *not* MemFree, so a busy-but-healthy host with large page cache is never starved —
+the guard fires only under real exhaustion. It fails **open** when memory is unmeasurable, so it can never
+wedge upgrades on a host whose meminfo cannot be read.
+
+**Recovery for a run that already failed this way:** none needed — nothing was deployed. Free host memory
+(let `autoMemoryReclaim` run, or shed heavy consumers / parallel Build Studio load) and re-trigger, or just
+let the next cron tick retry. The `build-failure-classifier` now labels this class `host-out-of-memory`
+(environment), so the failure surfaces as retryable rather than the old generic
+`promoter-readiness-failed (unclassified)`.
+
 ## Failure class: migration-unique-violation (P3018 + 23505)
 
 A data migration's bulk UPDATE/INSERT hits `duplicate key value violates unique constraint` and the

--- a/scripts/promoter-build-context.test.mjs
+++ b/scripts/promoter-build-context.test.mjs
@@ -91,3 +91,32 @@ test("portal-baked JIT context includes every local Dockerfile.promoter COPY sou
     "JIT build must clean up its temp directory on success and failure",
   );
 });
+
+test("Dockerfile.promoter.dockerignore allowlist matches the promoter COPY sources exactly", async () => {
+  const [promoterDockerfile, dockerignore] = await Promise.all([
+    readFile(join(root, "Dockerfile.promoter"), "utf8"),
+    readFile(join(root, "Dockerfile.promoter.dockerignore"), "utf8"),
+  ]);
+  const copySources = new Set(parseSimpleLocalCopySources(promoterDockerfile));
+  const allowlisted = new Set(
+    dockerignore
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith("!"))
+      .map((line) => line.slice(1).trim()),
+  );
+  // The context must be ignored-by-default so ONLY the allowlist is sent — this is
+  // what keeps the candidate build's context off the whole repo (SUR-BF75ED2A).
+  assert.match(dockerignore, /^\*\*$/m, "dockerignore must ignore ** before re-including");
+  // The dockerignore also re-includes Dockerfile.promoter itself (read via -f;
+  // harmless in-context). Everything else it re-includes MUST be a real COPY
+  // source, and every COPY source MUST be re-included — drift either way breaks
+  // the promoter build (missing file) or reintroduces the OOM (extra tree).
+  allowlisted.delete("Dockerfile.promoter");
+  for (const source of copySources) {
+    assert.ok(allowlisted.has(source), `dockerignore must re-include COPY source ${source}`);
+  }
+  for (const included of allowlisted) {
+    assert.ok(copySources.has(included), `dockerignore re-includes ${included}, not a Dockerfile.promoter COPY source`);
+  }
+});


### PR DESCRIPTION
## What happened

The last self-upgrade (**SUR-BF75ED2A**, 2026-08-11) failed at the candidate promoter `docker build`:

```
error from sender: readdirent /host-dpf/.upgrade-workspace/scripts: cannot allocate memory
```

The WSL2 VM (hard-capped 24 GB) was thrashing (MemFree ~467 MB), so buildkit's context sender couldn't allocate a buffer to enumerate the build context. It died at **preflight, before any portal swap** — nothing was deployed, the running portal was untouched — but the run was marked terminally `failed` with **no memory check, no backoff, and no classifier class** (it surfaced as a generic, unactionable `promoter-readiness-failed`).

## Root cause

Two compounding design issues on the critical shipping path:
1. The candidate build ships the **entire upgrade workspace** as Docker build context to build an image that COPYs **~20 files** — so buildkit walks/transfers the whole repo.
2. That build runs **"hot"** (portal fully active, *before* quiescence) by design, so the heaviest step competes for RAM with all 30 live surfaces. On a lean customer host this can brick the ability to receive updates.

## Fix — structural + safety net + legibility

- **`Dockerfile.promoter.dockerignore`** — allowlists only the `Dockerfile.promoter` COPY sources, so buildkit stops walking `apps/`, `packages/`, `docs/`, etc. Context drops from the whole repo to ~20 files → fits a memory-constrained host. Drift-guarded by `promoter-build-context.test.mjs`.
- **`host-memory-preflight.ts`** — `evaluateHostMemoryGuard()` reads **MemAvailable** from `/proc/meminfo` (not MemFree — Linux keeps MemFree low via page cache, so gating on it would defer nearly every run). Fails **open** when unmeasurable so it can never wedge upgrades. The orchestrator **defers** (skip + cooldown) below the 2 GiB floor instead of launching a doomed build; the next hourly cron retries after reclaim.
- **Backoff** on the preflight-failed path so a residual failure doesn't re-attempt the heavy build every tick.
- **`host-out-of-memory` classifier class** (checked first, beats the readiness wrapper), marked environment/retryable.
- **De-bloat:** extracted the install-state signing-context load + migration-handoff verify into `preflight.ts` (`loadInstallStateSigningContext`, `verifyMigrationHandoff`), keeping `self-upgrade.ts` under the 800-LOC module ceiling.
- **Runbook** documents the class, the guard, and the build-before-quiesce ordering.

### Follow-up (tracked separately)
Unify the candidate build onto the **minimal tar-context** the JIT rebuild path already uses, so Docker never sees the big tree at all (belt-and-suspenders beyond the dockerignore).

## Verification
Run in the root clone against the live install `node_modules` (the worktree is source-only/unprovisionable):
- `promoter-build-context.test.mjs` — 5/5
- all 45 self-upgrade vitest suites — 678/678
- full `apps/web` `tsc --noEmit` — 0 errors
- `check-module-size` — OK (self-upgrade.ts 798 LOC)
- derived-artifacts — fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)