### PR TITLE
fix(self-upgrade): stage a minimal candidate promoter build context (docker never enumerates the workspace)

### DIFF
--- a/apps/web/lib/self-upgrade/promoter-artifact.ts
+++ b/apps/web/lib/self-upgrade/promoter-artifact.ts
@@ -1,6 +1,10 @@
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
+import {
+  PROMOTER_DOCKERFILE,
+  stageMinimalPromoterBuildContext,
+} from "./promoter-build-context";
 
 export const SELF_UPGRADE_CALLER_PROTOCOL_VERSION = 1;
 export const PROMOTER_CONTRACT_SCHEMA_VERSION = 1;
@@ -48,13 +52,26 @@ export async function buildCandidatePromoterArtifactImage(
   const manifest = await readFile(join(params.sourcePath, "promoter-contract.json"));
   const contractDigest = `sha256:${createHash("sha256").update(manifest).digest("hex")}`;
   const targetImage = `${DEFAULT_PROMOTER_IMAGE}:${params.targetSha}`;
-  requireDockerSuccess(await runDocker([
-    "buildx", "build", "--load",
-    "-f", join(params.sourcePath, "Dockerfile.promoter"), "-t", targetImage,
-    "--build-arg", `DPF_PROMOTER_SOURCE_SHA=${params.targetSha}`,
-    "--build-arg", `DPF_PROMOTER_CONTRACT_DIGEST=${contractDigest}`,
-    params.sourcePath,
-  ]), "promoter_candidate_build");
+  // Stage ONLY the promoter build inputs into a throwaway minimal context so
+  // `docker build` never enumerates the whole upgrade workspace (apps/packages/
+  // docs) — the `readdirent … cannot allocate memory` OOM that bricked
+  // SUR-BF75ED2A on a lean host (PR #4199). The staged file list is the shared
+  // PROMOTER_BUILD_CONTEXT_* source-of-truth, so it can't drift from
+  // Dockerfile.promoter's COPY list. This mirrors the JIT rebuild's tar-context
+  // (PROMOTER_JIT_BUILD_SCRIPT); it just sources from the target-sha checkout
+  // instead of the portal's baked-in /promoter/ layout.
+  const contextDir = await stageMinimalPromoterBuildContext(params.sourcePath);
+  try {
+    requireDockerSuccess(await runDocker([
+      "buildx", "build", "--load",
+      "-f", join(contextDir, PROMOTER_DOCKERFILE), "-t", targetImage,
+      "--build-arg", `DPF_PROMOTER_SOURCE_SHA=${params.targetSha}`,
+      "--build-arg", `DPF_PROMOTER_CONTRACT_DIGEST=${contractDigest}`,
+      contextDir,
+    ]), "promoter_candidate_build");
+  } finally {
+    await rm(contextDir, { recursive: true, force: true });
+  }
   return targetImage;
 }
 

--- a/apps/web/lib/self-upgrade/promoter-build-context.ts
+++ b/apps/web/lib/self-upgrade/promoter-build-context.ts
@@ -1,0 +1,94 @@
+import { cp, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+/**
+ * Single source of truth for the MINIMAL Docker build context that
+ * `Dockerfile.promoter` needs — exactly its local `COPY <src> <dest>` sources
+ * (repo-relative paths). This is a tiny ~21-file set, NOT the whole workspace.
+ *
+ * Both promoter build paths stage ONLY these files (plus the Dockerfile itself)
+ * so `docker build` never enumerates apps/packages/docs:
+ *   - the just-in-time rebuild inside the portal (`PROMOTER_JIT_BUILD_SCRIPT` in
+ *     ./promoter.ts), staging from the portal's baked-in `/promoter/` layout;
+ *   - the candidate build during self-upgrade
+ *     (`buildCandidatePromoterArtifactImage` in ./promoter-artifact.ts), staging
+ *     from the target-sha source checkout.
+ *
+ * Walking the whole upgrade workspace to build a 21-file image was the
+ * `readdirent … cannot allocate memory` OOM that bricked SUR-BF75ED2A on a lean
+ * host (PR #4199). Trimming via `Dockerfile.promoter.dockerignore` is
+ * belt-and-suspenders; staging a minimal context is the root-cause fix — docker
+ * never sees the big tree at all.
+ *
+ * `scripts/promoter-build-context.test.mjs` parses `Dockerfile.promoter` and
+ * asserts this list equals its COPY sources exactly, so the two can never drift.
+ */
+export const PROMOTER_BUILD_CONTEXT_SOURCES: readonly string[] = [
+  "promoter-contract.json",
+  "Dockerfile",
+  "scripts/promote.sh",
+  "scripts/apply-runtime-capability-transition.mjs",
+  "scripts/runtime-transition-authority.mjs",
+  "scripts/rotate-runtime-transition-secret.mjs",
+  "scripts/lib/transition-signing.mjs",
+  "scripts/promoter-migration-envelope.mjs",
+  "scripts/installer/validate-install-state.mjs",
+  "scripts/installer/migrate-install-state.mjs",
+  "scripts/installer/resolve-host-identity.mjs",
+  "scripts/installer/install-state-transaction.mjs",
+  "scripts/installer/install-state-lock-contract.json",
+  "scripts/installer/install-state-schema-registry.mjs",
+  "scripts/installer/install-state.schema.json",
+  "scripts/installer/install-state.v1.schema.json",
+  "scripts/installer/install-state.v2.schema.json",
+  "scripts/lib/resolve-capability-compose-profiles.mjs",
+  "scripts/lib/govern-capability-compose-args.mjs",
+  "scripts/lib/capability-state-hash.mjs",
+  "scripts/capability-service-catalog.generated.json",
+] as const;
+
+/**
+ * The Dockerfile that builds the promoter image. It is passed to
+ * `docker buildx build -f <ctx>/Dockerfile.promoter`, so it must also live in
+ * the staged context. It is NOT a COPY source (nothing copies it into the
+ * image), so it is kept separate from `PROMOTER_BUILD_CONTEXT_SOURCES` above.
+ */
+export const PROMOTER_DOCKERFILE = "Dockerfile.promoter";
+
+/**
+ * The complete file set staged into a minimal promoter build context: every
+ * `Dockerfile.promoter` COPY source plus the Dockerfile itself.
+ */
+export const PROMOTER_BUILD_CONTEXT_FILES: readonly string[] = [
+  ...PROMOTER_BUILD_CONTEXT_SOURCES,
+  PROMOTER_DOCKERFILE,
+];
+
+/**
+ * Stage the minimal promoter build context from a source tree into a fresh
+ * throwaway directory, preserving each file's repo-relative path. Returns the
+ * context directory; the caller owns cleanup (delete it after the build).
+ *
+ * Only the ~22 files in `PROMOTER_BUILD_CONTEXT_FILES` are copied, so a
+ * subsequent `docker build <contextDir>` transfers a tiny context and never
+ * walks the source tree's apps/packages/docs. A missing input fails loudly here
+ * (and the temp dir is removed) rather than deep inside `docker build`, since a
+ * candidate checkout that lacks a promoter COPY source could not build anyway.
+ */
+export async function stageMinimalPromoterBuildContext(
+  sourcePath: string,
+): Promise<string> {
+  const contextDir = await mkdtemp(join(tmpdir(), "dpf-promoter-ctx-"));
+  try {
+    for (const file of PROMOTER_BUILD_CONTEXT_FILES) {
+      const dest = join(contextDir, file);
+      await mkdir(dirname(dest), { recursive: true });
+      await cp(join(sourcePath, file), dest);
+    }
+  } catch (err) {
+    await rm(contextDir, { recursive: true, force: true });
+    throw err;
+  }
+  return contextDir;
+}

--- a/apps/web/lib/self-upgrade/promoter.test.ts
+++ b/apps/web/lib/self-upgrade/promoter.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { readFileSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { PROMOTER_BUILD_CONTEXT_FILES } from "./promoter-build-context";
 import {
   buildPromoterCommand,
   buildCandidatePromoterImage,
@@ -140,24 +141,56 @@ describe("resolvePromoterArtifact", () => {
 });
 
 describe("buildCandidatePromoterImage", () => {
-  it("builds and labels an offline target-SHA image from prepared candidate source", async () => {
+  it("builds an offline target-SHA image from a minimal staged context, never the whole workspace", async () => {
     const sourcePath = await mkdtemp(join(tmpdir(), "dpf-promoter-candidate-"));
     try {
-      await mkdir(join(sourcePath, "scripts"));
-      await writeFile(join(sourcePath, "promoter-contract.json"), "{\"schemaVersion\":1}\n");
+      // A real candidate checkout contains every promoter build input…
+      for (const file of PROMOTER_BUILD_CONTEXT_FILES) {
+        const dest = join(sourcePath, file);
+        await mkdir(dirname(dest), { recursive: true });
+        await writeFile(
+          dest,
+          file === "promoter-contract.json" ? '{"schemaVersion":1}\n' : `// ${file}\n`,
+        );
+      }
+      // …plus a large decoy tree that must NOT be walked into the docker context
+      // (walking it was the readdirent OOM that bricked SUR-BF75ED2A).
+      await mkdir(join(sourcePath, "apps", "web"), { recursive: true });
+      await writeFile(join(sourcePath, "apps", "web", "huge.txt"), "x".repeat(4096));
+
       const calls: string[][] = [];
+      let stagedFiles: string[] = [];
       const image = await buildCandidatePromoterImage(
         { sourcePath, targetSha: "abc1234" },
         async (args) => {
           calls.push(args);
+          // The staged context still exists here (cleaned up in a finally after).
+          const contextDir = String(args.at(-1));
+          stagedFiles = readdirSync(contextDir, { recursive: true })
+            .map((p) => String(p).replaceAll("\\", "/"))
+            .filter((p) => !statSync(join(contextDir, p)).isDirectory())
+            .sort();
           return { exitCode: 0, stdout: "", stderr: "" };
         },
       );
+
       expect(image).toBe("dpf-promoter:abc1234");
       expect(calls).toHaveLength(1);
       expect(calls[0]?.slice(0, 4)).toEqual(["buildx", "build", "--load", "-f"]);
       expect(calls[0]).toContain("DPF_PROMOTER_SOURCE_SHA=abc1234");
-      expect(calls[0]?.at(-1)).toBe(sourcePath);
+
+      // Context is the throwaway staged dir, not the source workspace.
+      const contextDir = String(calls[0]?.at(-1));
+      expect(contextDir).not.toBe(sourcePath);
+      expect(contextDir).toContain("dpf-promoter-ctx-");
+      // The staged dir is removed once the build returns.
+      expect(existsSync(contextDir)).toBe(false);
+      // -f resolves inside that staged context.
+      expect(calls[0]?.[4]).toBe(join(contextDir, "Dockerfile.promoter"));
+
+      // Exactly the promoter inputs are staged — the apps/web decoy is absent.
+      expect(stagedFiles).toEqual([...PROMOTER_BUILD_CONTEXT_FILES].sort());
+      expect(stagedFiles.some((p) => p.startsWith("apps/"))).toBe(false);
     } finally {
       await rm(sourcePath, { recursive: true, force: true });
     }

--- a/docs/superpowers/plans/2026-08-11-unify-candidate-promoter-build-context.md
+++ b/docs/superpowers/plans/2026-08-11-unify-candidate-promoter-build-context.md
@@ -1,0 +1,100 @@
+# Unify the candidate promoter build onto a minimal staged context
+
+**Date:** 2026-08-11
+**Epic:** governed-platform-upgrade-lifecycle (BI-UPGRADE-011/012 family)
+**Status:** implemented (this PR)
+**Surface:** self-upgrade promoter build (`apps/web/lib/self-upgrade/`)
+**Follows:** PR #4199 (SUR-BF75ED2A candidate-build OOM — `Dockerfile.promoter.dockerignore` + MemAvailable defer-guard + `host-out-of-memory` classifier)
+
+> **Backlog note.** This is the tracked follow-up to PR #4199. The DPF MCP
+> connector was not reachable from the authoring session (source-only worktree,
+> no portal/DB view), so the live `BacklogItem` could not be filed from here.
+> **Action for an MCP-connected operator/Build Studio:** file a BI under the
+> governed-platform-upgrade-lifecycle epic — *"Unify candidate promoter build
+> onto the minimal tar-context (docker never enumerates the workspace)"* — and
+> back-link this plan. This file deliberately carries **no** `**Backlog item:**`
+> line so it is not mistaken for coverage evidence that does not yet exist.
+
+## Problem
+
+The promoter image is a tiny ~22-file image (docker CLI + compose + git +
+`promote.sh` and its helpers). Two code paths build it, and until now they
+disagreed on how they assemble the Docker build context:
+
+1. **JIT rebuild** (`PROMOTER_JIT_BUILD_SCRIPT`, `promoter.ts`) — stages ONLY the
+   `Dockerfile.promoter` COPY sources into a temp `$BDIR` and pipes
+   `tar -C $BDIR -c . | docker buildx build -f Dockerfile.promoter -`. Docker
+   never sees the big tree. Correct.
+
+2. **Candidate build** (`buildCandidatePromoterArtifactImage`,
+   `promoter-artifact.ts`) — ran `docker buildx build … <sourcePath>` where
+   `sourcePath` is the **whole upgrade workspace**. BuildKit's context sender
+   walked/transferred the entire repo just to build a 22-file image. On a lean
+   host (WSL2 capped at 24 GB, thrashing) the context sender could not allocate a
+   buffer to enumerate the tree and died with
+   `error from sender: readdirent … cannot allocate memory` — the OOM that failed
+   SUR-BF75ED2A at preflight (before any portal swap). This build also runs
+   **hot** (portal fully active, before quiescence, by design), so the heaviest
+   step competes with all live surfaces.
+
+PR #4199 trimmed the candidate context with `Dockerfile.promoter.dockerignore`
+(an allowlist buildkit honours). That helps, but buildkit still *roots the
+context at the whole tree* and applies the ignore during the walk. This plan is
+the **root-cause fix**: stage a minimal context so docker never roots at, nor
+enumerates, `apps/packages/docs` at all — belt-and-suspenders beyond the
+dockerignore.
+
+## Design grounding
+
+- **Source of truth:** `Dockerfile.promoter`'s local `COPY <src> <dest>` list is
+  the ground truth for what the image needs. The JIT path already mirrors it (a
+  drift test in `scripts/promoter-build-context.test.mjs` enforces equality). The
+  candidate path previously side-stepped the list by shipping the whole tree.
+- **Kernel:** `evidence-before-diagnosis` (the OOM was read from the
+  `SelfUpgradeRun.failureLog`, not guessed) and `proper-fix-over-quick-fix`
+  (address the whole-tree context, not just its symptom).
+
+## Change
+
+1. **New `apps/web/lib/self-upgrade/promoter-build-context.ts`** — the single
+   shared source-of-truth:
+   - `PROMOTER_BUILD_CONTEXT_SOURCES` — the 21 `Dockerfile.promoter` COPY sources
+     (repo-relative).
+   - `PROMOTER_DOCKERFILE` (`"Dockerfile.promoter"`) — not a COPY source, but must
+     be staged so `-f <ctx>/Dockerfile.promoter` resolves inside the context.
+   - `PROMOTER_BUILD_CONTEXT_FILES` = sources + Dockerfile.
+   - `stageMinimalPromoterBuildContext(sourcePath)` — copies only those files into
+     a fresh temp dir (preserving repo-relative paths) and returns it; caller
+     owns cleanup. Node built-ins only (no docker spawn) so importing it from the
+     bundled orchestrator path stays safe (cf. BI-98AF1066).
+
+2. **`promoter-artifact.ts`** — `buildCandidatePromoterArtifactImage` now stages
+   the minimal context from the target-sha `sourcePath` and builds from that temp
+   dir (`-f <ctx>/Dockerfile.promoter … <ctx>`), removing it in a `finally`.
+   Docker transfers ~22 files, never the workspace.
+
+3. **Drift + staging tests** (`scripts/promoter-build-context.test.mjs`) — assert
+   the shared `PROMOTER_BUILD_CONTEXT_SOURCES` equals `Dockerfile.promoter`'s COPY
+   sources exactly, and that the candidate build stages exactly those (plus the
+   Dockerfile) and never passes the raw `sourcePath` as the docker context.
+   `promoter.test.ts`'s candidate-build unit test now stages a real fixture tree
+   with an `apps/web` decoy and asserts the staged context contains exactly the
+   promoter inputs and not the decoy.
+
+## Non-goals / boundary
+
+- Does not change the JIT path (already correct; kept untouched to avoid churn on
+  a security-reviewed, image-baked shell string). The shared constant is bound to
+  `Dockerfile.promoter` by test, and the JIT path is bound to the same Dockerfile
+  by the existing test — so both paths transitively track one list.
+- Does not remove `Dockerfile.promoter.dockerignore` (PR #4199); it remains a
+  cheap second layer.
+
+## Verification
+
+- `promoter-build-context.test.mjs` (node:test) + `promoter.test.ts` +
+  `promoter-artifact` typecheck under `tsc`; full `apps/web` vitest.
+- The `docker build` itself cannot be exercised by unit tests; functional proof
+  is a real self-upgrade trigger on a live install (candidate preflight must
+  build the promoter image without walking the workspace). Tracked as the
+  post-merge functional check.

--- a/scripts/promoter-build-context.test.mjs
+++ b/scripts/promoter-build-context.test.mjs
@@ -29,6 +29,18 @@ function parseSimpleLocalCopySources(dockerfile) {
   });
 }
 
+/** Extract the quoted entries of an exported `readonly string[]` array literal. */
+function parseExportedStringArray(source, exportName) {
+  const start = source.indexOf(exportName);
+  assert.ok(start >= 0, `${exportName} not found`);
+  // Skip the `: readonly string[]` type annotation and open at the `= [` literal.
+  const eq = source.indexOf("=", start);
+  const open = source.indexOf("[", eq);
+  const close = source.indexOf("]", open);
+  assert.ok(eq >= 0 && open >= 0 && close > open, `${exportName} array literal malformed`);
+  return [...source.slice(open + 1, close).matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+}
+
 test("promoter COPY parser fails closed on forms the contract does not support", () => {
   assert.throws(
     () => parseSimpleLocalCopySources('COPY ["one", "two", "/dest/"]'),
@@ -119,4 +131,69 @@ test("Dockerfile.promoter.dockerignore allowlist matches the promoter COPY sourc
   for (const included of allowlisted) {
     assert.ok(copySources.has(included), `dockerignore re-includes ${included}, not a Dockerfile.promoter COPY source`);
   }
+});
+
+test("shared PROMOTER_BUILD_CONTEXT_SOURCES equals Dockerfile.promoter's local COPY sources exactly", async () => {
+  const [promoterDockerfile, contextSource] = await Promise.all([
+    readFile(join(root, "Dockerfile.promoter"), "utf8"),
+    readFile(join(root, "apps", "web", "lib", "self-upgrade", "promoter-build-context.ts"), "utf8"),
+  ]);
+  const copySources = parseSimpleLocalCopySources(promoterDockerfile);
+  const shared = parseExportedStringArray(contextSource, "PROMOTER_BUILD_CONTEXT_SOURCES");
+
+  assert.ok(shared.length > 0, "PROMOTER_BUILD_CONTEXT_SOURCES must not be empty");
+  assert.deepEqual(
+    [...shared].sort(),
+    [...copySources].sort(),
+    "the shared build-context source-of-truth must match Dockerfile.promoter's COPY sources exactly (no drift)",
+  );
+  // The Dockerfile that builds the image is not a COPY source but must also be
+  // staged so `-f <ctx>/Dockerfile.promoter` resolves inside the minimal context.
+  assert.ok(
+    /PROMOTER_DOCKERFILE\s*=\s*"Dockerfile\.promoter"/.test(contextSource),
+    "PROMOTER_DOCKERFILE must be the Dockerfile.promoter filename",
+  );
+  assert.ok(
+    /PROMOTER_BUILD_CONTEXT_FILES[\s\S]*\.\.\.PROMOTER_BUILD_CONTEXT_SOURCES[\s\S]*PROMOTER_DOCKERFILE/.test(contextSource),
+    "PROMOTER_BUILD_CONTEXT_FILES must stage every COPY source plus the Dockerfile",
+  );
+});
+
+test("candidate promoter build stages exactly the COPY sources, never the whole workspace", async () => {
+  const artifactSource = await readFile(
+    join(root, "apps", "web", "lib", "self-upgrade", "promoter-artifact.ts"),
+    "utf8",
+  );
+
+  // It must derive its context from the shared source-of-truth staging helper…
+  assert.ok(
+    /import\s*\{[\s\S]*stageMinimalPromoterBuildContext[\s\S]*\}\s*from\s*"\.\/promoter-build-context"/.test(artifactSource),
+    "candidate build must import the shared staging helper",
+  );
+  assert.ok(
+    artifactSource.includes("stageMinimalPromoterBuildContext(params.sourcePath)"),
+    "candidate build must stage the minimal context from the target-sha sourcePath",
+  );
+  assert.ok(
+    /rm\(contextDir,\s*\{\s*recursive:\s*true,\s*force:\s*true\s*\}\)/.test(artifactSource),
+    "candidate build must clean up the staged context directory",
+  );
+
+  // …and the docker build must use that staged directory as its context, never
+  // the raw whole-tree sourcePath (the readdirent OOM that bricked SUR-BF75ED2A).
+  const buildCall = /"buildx",\s*"build",\s*"--load",([\s\S]*?)\]\)/.exec(artifactSource);
+  assert.ok(buildCall, "candidate build must issue a buildx build invocation");
+  const buildArgs = buildCall[1];
+  assert.ok(
+    buildArgs.includes("contextDir,"),
+    "candidate build context must be the staged contextDir",
+  );
+  assert.ok(
+    buildArgs.includes("join(contextDir, PROMOTER_DOCKERFILE)"),
+    "candidate build -f must resolve inside the staged context",
+  );
+  assert.ok(
+    !buildArgs.includes("params.sourcePath"),
+    "candidate build must NOT pass the whole workspace sourcePath as the docker context",
+  );
 });


### PR DESCRIPTION
## Follow-up to #4199 — the root-cause fix for the candidate-build OOM

PR #4199 fixed the SUR-BF75ED2A candidate-build OOM defensively (a `Dockerfile.promoter.dockerignore` allowlist, a `MemAvailable` defer-guard, and a `host-out-of-memory` classifier). This is the tracked **root-cause** follow-up.

### Problem

The promoter image is tiny (~22 files: docker CLI + compose + git + `promote.sh` and helpers). Two paths build it, and they disagreed on the build context:

- **JIT rebuild** (`PROMOTER_JIT_BUILD_SCRIPT`) stages ONLY the `Dockerfile.promoter` COPY sources into a temp dir and `tar | docker buildx build -f Dockerfile.promoter -`. Docker never sees the big tree. ✅
- **Candidate build** (`buildCandidatePromoterArtifactImage`) ran `docker buildx build … <sourcePath>` where `sourcePath` = the **whole upgrade workspace**. BuildKit's context sender walked/transferred the entire repo to build a 22-file image. On a lean host (WSL2 thrashing) it died with `error from sender: readdirent … cannot allocate memory` — the OOM that failed SUR-BF75ED2A at preflight.

A dockerignore trims the walk but buildkit still *roots the context at the whole tree*. This change makes docker never root at, nor enumerate, `apps/packages/docs` at all.

### Change

1. **New `apps/web/lib/self-upgrade/promoter-build-context.ts`** — the single shared source-of-truth:
   - `PROMOTER_BUILD_CONTEXT_SOURCES` — the 21 `Dockerfile.promoter` COPY sources.
   - `PROMOTER_DOCKERFILE` + `PROMOTER_BUILD_CONTEXT_FILES` (sources + Dockerfile).
   - `stageMinimalPromoterBuildContext(sourcePath)` — copies only those files into a fresh temp dir; caller owns cleanup. Node built-ins only (no docker spawn → safe to import on the bundled orchestrator path, cf. BI-98AF1066).
2. **`promoter-artifact.ts`** — the candidate build stages the minimal context from the target-sha `sourcePath`, builds from that dir (`-f <ctx>/Dockerfile.promoter … <ctx>`), and removes it in a `finally`.
3. **Tests** — `scripts/promoter-build-context.test.mjs` asserts the shared list **equals `Dockerfile.promoter`'s COPY sources exactly** (drift guard) and that the candidate build stages exactly those, never the raw `sourcePath`. `promoter.test.ts`'s candidate-build unit test stages a fixture tree with an `apps/web` decoy and asserts the staged context contains exactly the promoter inputs and not the decoy.

The JIT path is intentionally left untouched (already correct; a security-reviewed, image-baked shell string). Both paths are bound to `Dockerfile.promoter` by test, so they track one list.

### Verification (root clone — this worktree is source-only)

- `promoter-build-context.test.mjs` node:test — **6/6 pass** (drift test confirms the 21-source list matches the Dockerfile exactly).
- `apps/web` vitest `promoter.test.ts` — **51/51**; `preflight.test.ts` — **6/6**.
- `tsc --noEmit` — my files clean (pre-existing federation-links errors from a stale root-clone Prisma client are unrelated).
- `check-module-size.mjs` — clean.
- The `docker build` itself can't be unit-tested; functional proof is a **real self-upgrade trigger on a live install** (candidate preflight must build the promoter without walking the workspace) — tracked as a post-merge check.

### Notes

- **BI:** the governed MCP connector was unreachable from this source-only worktree, so the `BacklogItem` could not be filed here. The plan doc (`docs/superpowers/plans/2026-08-11-unify-candidate-promoter-build-context.md`) carries the BI intent for an MCP-connected operator to file under the governed-platform-upgrade-lifecycle epic.
- **Overlap with #4199:** both append distinct `test()` blocks to `scripts/promoter-build-context.test.mjs` — a trivial merge either way. This PR does not remove #4199's dockerignore; it remains a cheap second layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)