### PR TITLE
fix(discovery): calibrate AI auto-identify gate + proactive self-diagnosis (BI-DEC1C7BF)

### DIFF
--- a/apps/web/lib/asset-intelligence/identity-inference-runner.ts
+++ b/apps/web/lib/asset-intelligence/identity-inference-runner.ts
@@ -9,7 +9,12 @@
 // passes a per-run token budget + hard call cap so a 10k+-entity estate cannot blow
 // the AI budget in one pass.
 
-import type { IdentityInferenceResult, ProposedIdentity, UnresolvedEntityRow } from "@dpf/db";
+import type {
+  IdentityInferenceDiagnostic,
+  IdentityInferenceResult,
+  ProposedIdentity,
+  UnresolvedEntityRow,
+} from "@dpf/db";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import {
   IDENTITY_INFERENCE_JOB_ID,
@@ -21,7 +26,7 @@ import {
 } from "./identity-inference-constants";
 
 export type IdentityInferenceRunOutcome =
-  | ({ skipped: false } & IdentityInferenceResult)
+  | ({ skipped: false; diagnostic?: IdentityInferenceDiagnostic } & IdentityInferenceResult)
   | { skipped: true; reason: string };
 
 const SYSTEM_PROMPT =
@@ -105,11 +110,27 @@ export function parseProposals(content: string, batchIds: Set<string>): Proposed
  * row. Never throws — inference/DB errors are reflected in the row's lastStatus and a
  * failure count in the result.
  */
+/**
+ * Optional operator override for the AI auto-apply confidence gate. Parsed from
+ * IDENTITY_INFERENCE_AUTO_APPLY_THRESHOLD (0..1); invalid/unset falls back to the
+ * engine default. The default itself is already tuned for cheap/local models — this
+ * exists so a high-precision-model install can RAISE the bar, not so operators must
+ * tune it to get a working baseline.
+ */
+function resolveAutoApplyThresholdOverride(): number | undefined {
+  const raw = process.env.IDENTITY_INFERENCE_AUTO_APPLY_THRESHOLD;
+  if (!raw) return undefined;
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 1) return undefined;
+  return parsed;
+}
+
 export async function runIdentityInferenceFallbackJob(
   options: { scanLimit?: number } = {},
 ): Promise<IdentityInferenceRunOutcome> {
-  const { prisma, runIdentityInferenceFallback } = await import("@dpf/db");
+  const { prisma, runIdentityInferenceFallback, diagnoseIdentityInference } = await import("@dpf/db");
   const { computeNextRunAt } = await import("@/lib/ai-provider-types");
+  const autoApplyThreshold = resolveAutoApplyThresholdOverride();
 
   const job = await prisma.scheduledJob.upsert({
     where: { jobId: IDENTITY_INFERENCE_JOB_ID },
@@ -170,8 +191,19 @@ export async function runIdentityInferenceFallbackJob(
         batchSize: IDENTITY_INFERENCE_BATCH_SIZE,
         maxInferenceTokens: IDENTITY_INFERENCE_TOKEN_BUDGET,
         maxInferenceCalls: IDENTITY_INFERENCE_MAX_CALLS,
+        ...(autoApplyThreshold !== undefined ? { autoApplyThreshold } : {}),
       },
     );
+
+    // Proactive self-diagnosis: if the run resolved devices but applied almost
+    // none, the confidence gate is starving identifications — surface it instead
+    // of silently discarding correct results (operator feedback: no user would
+    // ever know to look for this).
+    const effectiveThreshold = autoApplyThreshold ?? 0.9;
+    const diagnostic = diagnoseIdentityInference(result, effectiveThreshold);
+    if (diagnostic) {
+      console.warn(`[identity-inference] ${diagnostic.message}`);
+    }
 
     const now = new Date();
     await prisma.scheduledJob
@@ -180,13 +212,17 @@ export async function runIdentityInferenceFallbackJob(
         data: {
           lastRunAt: now,
           lastStatus: result.failures > 0 ? "partial" : "ok",
-          lastError: result.failures > 0 ? `${result.failures} failure(s)` : null,
+          lastError: result.failures > 0
+            ? `${result.failures} failure(s)`
+            : diagnostic
+              ? `advisory: ${diagnostic.message}`
+              : null,
           nextRunAt: computeNextRunAt(job.schedule, now),
         },
       })
       .catch(() => {});
 
-    return { skipped: false, ...result };
+    return { skipped: false, ...result, ...(diagnostic ? { diagnostic } : {}) };
   } catch (err: unknown) {
     const message = getErrorMessage(err);
     await prisma.scheduledJob

--- a/docs/superpowers/plans/2026-08-11-auto-identify-calibration-plan.md
+++ b/docs/superpowers/plans/2026-08-11-auto-identify-calibration-plan.md
@@ -1,0 +1,55 @@
+# Auto-identify calibration + proactive self-diagnosis
+
+**Backlog item:** BI-DEC1C7BF
+**Date:** 2026-08-11
+**Follows:** #4198 (fingerprint-layer wiring). Extends the AI identity-inference
+engine (`packages/db/src/catalog-identity-inference.ts`, EP-ASSET-INTELLIGENCE
+spec §4.2/§8); no new contract, table, or enum.
+
+## Problem (measured on a live install)
+
+The AI identity fallback correctly identifies real network devices with no
+hand-written rules (Whirlpool appliance 0.96, Reolink camera 0.96, Nest 0.94,
+Ubiquiti 0.95, TP-Link 0.91), but the hardcoded `autoApplyThreshold` of 0.97 sits
+above the cheap/local-model confidence band (0.90–0.96). `IdentityResolutionLog`
+held 55 `ai_resolved` rows; **0 were applied** — the estate stayed blank. A hidden
+miscalibration no operator could diagnose, and one the AI coworkers should catch
+themselves (operator feedback).
+
+## Design grounding
+
+- Searched substrate: the engine already writes a non-authoritative
+  `identityStatus='ai_resolved'`, guards `human_confirmed`, and gates rule
+  PROMOTION separately via `shadowPromotionThreshold`. So lowering the *apply*
+  bar is safe and does not weaken rule authority.
+- Decision: calibrate the existing engine + add a self-diagnostic; do not add a
+  new identification pathway.
+
+## Changes
+
+1. Default `autoApplyThreshold` 0.97 → 0.90; add `IDENTITY_INFERENCE_AUTO_APPLY_THRESHOLD`
+   env override (to RAISE it for high-precision-model installs). Rule promotion
+   stays gated by `shadowPromotionThreshold` (≥3 identical).
+2. Exclude DPF-internal (`isDockerOriginEntityKey`) entities from the AI candidate
+   scan so inference budget targets real estate (`dpfInternalSkipped`).
+3. `diagnoseIdentityInference()` — detects "resolved many, applied ~none" and
+   surfaces an operator-facing advisory on the ScheduledJob + logs + run outcome,
+   so the platform surfaces the miscalibration instead of discarding results silently.
+
+## Verification
+
+- 23 db-engine tests (incl. new: 0.90 applies, 0.85 withheld, docker-internal
+  skipped, diagnostic fires/silent), 8 runner tests, db typecheck, all 37 guards,
+  full sandbox local-CI gate — green.
+
+## Out of scope → follow-up
+
+- Fuller proactive loop: inventory-specialist coworker reads the advisory and
+  auto-mitigates (tune threshold / humanized alert), per tell-don't-act.
+
+## Backlog coverage
+- Decision: atomic
+- Parent: BI-DEC1C7BF
+- Receipt: cmsp5dgn103ne01s51t3w6xnw
+- Rationale: The three changes are one calibration fix — the scan exclusion and the diagnostic both read the same run the lowered gate governs; shipping the gate change without the diagnostic re-buries the failure mode, and shipping the diagnostic without the gate change leaves the estate blank. None is independently shippable.
+- Dependencies: none

--- a/packages/db/src/catalog-identity-inference.test.ts
+++ b/packages/db/src/catalog-identity-inference.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   runIdentityInferenceFallback,
   demoteHumanContradictedShadowRules,
+  diagnoseIdentityInference,
   identityKeyForProposal,
   type IdentityInferenceClient,
   type IdentityInferenceFn,
@@ -62,6 +63,7 @@ function makeDb(seed: {
           .slice(0, take ?? entities.length)
           .map((e) => ({
             id: e.id,
+            entityKey: e.entityKey,
             name: e.name,
             entityType: e.entityType,
             manufacturer: e.manufacturer,
@@ -170,6 +172,7 @@ function makeDb(seed: {
 function entity(id: string, over: Partial<EntityRow> = {}): EntityRow {
   return {
     id,
+    entityKey: over.entityKey ?? `entity:${id}`,
     name: over.name ?? `entity-${id}`,
     entityType: over.entityType ?? "application",
     manufacturer: over.manufacturer ?? null,
@@ -264,7 +267,68 @@ describe("runIdentityInferenceFallback — shadow window", () => {
   });
 });
 
-// ─── auto-apply at >= 0.97 ───────────────────────────────────────────────────
+// ─── calibrated default: a correct cheap-model identification reaches the estate ──
+
+describe("runIdentityInferenceFallback — calibrated auto-apply default", () => {
+  it("auto-applies a 0.95 identification under the default gate (regression: cheap-model band)", async () => {
+    // The live failure: a local model correctly identified Whirlpool/Nest/Ubiquiti
+    // devices at 0.91-0.96, and the old 0.97 gate discarded 100% of them. The
+    // calibrated 0.90 default must apply them.
+    const { db, entities } = makeDb({ entities: [entity("e1")] });
+    const result = await runIdentityInferenceFallback(
+      db,
+      inferAll(() => ({ manufacturer: "Whirlpool", product: "Connected Appliance", confidence: 0.95 })),
+    );
+    expect(result.autoApplied).toBe(1);
+    expect(entities[0].catalogIdentityId).not.toBeNull();
+    expect(entities[0].identityStatus).toBe("ai_resolved");
+  });
+
+  it("still withholds a genuinely low-confidence (0.85) identification", async () => {
+    const { db, entities } = makeDb({ entities: [entity("e1")] });
+    const result = await runIdentityInferenceFallback(
+      db,
+      inferAll(() => ({ manufacturer: "Acme", product: "Mystery", confidence: 0.85 })),
+    );
+    expect(result.autoApplied).toBe(0);
+    expect(entities[0].catalogIdentityId).toBeNull();
+  });
+
+  it("skips DPF-internal (docker-origin) candidates so budget targets real estate", async () => {
+    const { db } = makeDb({
+      entities: [
+        entity("c1", { entityKey: "container:bd02d3f03235", name: "bd02d3f03235" }),
+        entity("h1", { entityKey: "organization:internal:host:arp:88E712000091", name: "Whirlpool 192.168.0.91" }),
+      ],
+    });
+    const result = await runIdentityInferenceFallback(
+      db,
+      inferAll(() => ({ manufacturer: "X", product: "Y", confidence: 0.95 })),
+    );
+    expect(result.dpfInternalSkipped).toBe(1);
+    // Only the real device was inferred; the container was never sent to the model.
+    expect(result.entitiesInferred).toBe(1);
+  });
+});
+
+describe("diagnoseIdentityInference", () => {
+  it("fires when the run resolved many but applied almost none (gate too high)", () => {
+    const d = diagnoseIdentityInference({ aiResolutionsLogged: 20, autoApplied: 1 }, 0.97);
+    expect(d).not.toBeNull();
+    expect(d?.code).toBe("auto_apply_gate_starving_identifications");
+    expect(d?.message).toContain("0.97");
+  });
+
+  it("stays silent on a healthy run (most identifications applied)", () => {
+    expect(diagnoseIdentityInference({ aiResolutionsLogged: 20, autoApplied: 18 }, 0.9)).toBeNull();
+  });
+
+  it("stays silent when there is too little signal to judge", () => {
+    expect(diagnoseIdentityInference({ aiResolutionsLogged: 2, autoApplied: 0 }, 0.97)).toBeNull();
+  });
+});
+
+// ─── auto-apply at high confidence ───────────────────────────────────────────
 
 describe("runIdentityInferenceFallback — auto-apply", () => {
   it("writes catalogIdentityId + identityStatus at confidence >= 0.97", async () => {

--- a/packages/db/src/catalog-identity-inference.ts
+++ b/packages/db/src/catalog-identity-inference.ts
@@ -14,8 +14,11 @@
 //   - During the shadow window it does NOT write InventoryEntity.catalogIdentityId.
 //   - Repeated identical AI resolutions of the same entity promote a status='shadow'
 //     DiscoveryFingerprintRule (append-only lineage; the rule generalizes the signal).
-//   - Only a confidence >= autoApplyThreshold (0.97) resolution auto-applies the
-//     identity (writes catalogIdentityId + identityStatus='ai_resolved').
+//   - Only a confidence >= autoApplyThreshold (default 0.90) resolution auto-applies
+//     the identity (writes catalogIdentityId + identityStatus='ai_resolved'). The
+//     visible ai_resolved apply is deliberately a LOWER bar than rule promotion so a
+//     cheap/local model's correct-but-not-0.97 identifications reach the operator;
+//     promotion to a durable layer-0 rule stays gated by shadowPromotionThreshold.
 //   - A contradicting human_confirmed / human_corrected resolution demotes the shadow
 //     rule to 'rejected', and a human_confirmed InventoryEntity identity is NEVER
 //     overwritten (spec §4.1 / §6.3.1) — the scan excludes it and the auto-apply
@@ -27,6 +30,7 @@
 // request, the same governed-loop shape as catalog-enrichment-sweep.ts.
 //
 import { INVENTORY_ENTITY_CANONICAL_WHERE } from "./inventory-entity-lifecycle";
+import { isDockerOriginEntityKey } from "./docker-origin";
 // Pure orchestration over an injectable inference fn + client (no prisma import), so
 // it stays unit-testable with mocks — the governed apps/web runner wires the real
 // prisma + a routeAndCall(minimize_cost) inference fn (dynamic model discovery, no
@@ -35,6 +39,7 @@ import { INVENTORY_ENTITY_CANONICAL_WHERE } from "./inventory-entity-lifecycle";
 /** One unresolved InventoryEntity the AI fallback will attempt to identify. */
 export type UnresolvedEntityRow = {
   id: string;
+  entityKey: string;
   name: string;
   entityType: string;
   manufacturer: string | null;
@@ -102,8 +107,71 @@ const DEFAULTS = {
   maxInferenceTokens: 200_000,
   maxInferenceCalls: 25,
   shadowPromotionThreshold: 3,
-  autoApplyThreshold: 0.97,
+  // Auto-apply an AI identity (as the NON-authoritative `identityStatus='ai_resolved'`,
+  // recoverable and never overwriting a human_confirmed row) at this self-reported
+  // confidence. Lowered from 0.97 to 0.90 (BI: auto-identify calibration): cheap/local
+  // models — the common self-hosted default — correctly identify devices (Whirlpool
+  // appliance, Nest thermostat, Reolink camera, Ubiquiti AP…) but cluster their
+  // self-reported confidence at 0.90–0.96, so a 0.97 gate discarded ~100% of correct
+  // identifications and the estate stayed blank. Crucially this only governs the
+  // VISIBLE, reversible ai_resolved apply; promoting a finding into a durable layer-0
+  // rule stays gated by shadowPromotionThreshold (≥3 identical resolutions), so a
+  // lower apply bar cannot mint an authoritative rule from a single guess. Operators
+  // running a high-precision model can raise it via IDENTITY_INFERENCE_AUTO_APPLY_THRESHOLD.
+  autoApplyThreshold: 0.9,
 } as const;
+
+/**
+ * A proactive, operator-facing diagnostic derived from a run's own counters.
+ * The point (per operator feedback): a confidence-gate miscalibration is invisible
+ * — the identifier does its job, resolves devices, and silently discards them
+ * because their self-reported confidence sits just under the auto-apply bar. No
+ * user would ever know to inspect IdentityResolutionLog and compare a histogram to
+ * a threshold constant. So the run TELLS on itself.
+ */
+export type IdentityInferenceDiagnostic = {
+  code: "auto_apply_gate_starving_identifications";
+  severity: "warn";
+  message: string;
+  /** Machine-readable so a coworker/health surface can act, not just render prose. */
+  resolved: number;
+  applied: number;
+  applyRate: number;
+  autoApplyThreshold: number;
+};
+
+/**
+ * Detect the "resolving but not applying" signature: the model produced real
+ * identifications this run, yet almost none cleared the auto-apply gate. That is
+ * the fingerprint of a threshold set above the model's confidence band — exactly
+ * the hidden failure that leaves an estate blank while the identifier "works".
+ * Returns null when the run is healthy or too small to judge.
+ */
+export function diagnoseIdentityInference(
+  result: Pick<IdentityInferenceResult, "aiResolutionsLogged" | "autoApplied">,
+  autoApplyThreshold: number,
+  opts: { minResolutions?: number; lowApplyRate?: number } = {},
+): IdentityInferenceDiagnostic | null {
+  const minResolutions = opts.minResolutions ?? 5;
+  const lowApplyRate = opts.lowApplyRate ?? 0.2;
+  const { aiResolutionsLogged: resolved, autoApplied: applied } = result;
+  if (resolved < minResolutions) return null;
+  const applyRate = resolved === 0 ? 0 : applied / resolved;
+  if (applyRate >= lowApplyRate) return null;
+  return {
+    code: "auto_apply_gate_starving_identifications",
+    severity: "warn",
+    resolved,
+    applied,
+    applyRate,
+    autoApplyThreshold,
+    message:
+      `Device identifier resolved ${resolved} device(s) this run but auto-applied only ${applied} ` +
+      `(${Math.round(applyRate * 100)}%). Most identifications fell just below the auto-apply ` +
+      `confidence gate (${autoApplyThreshold}). Your model's confidence band is likely under that ` +
+      `bar — lower IDENTITY_INFERENCE_AUTO_APPLY_THRESHOLD so correct identifications reach the estate.`,
+  };
+}
 
 export type IdentityInferenceResult = {
   /** Total unresolved entities (for coverage reporting — a bounded run is not full coverage). */
@@ -120,6 +188,8 @@ export type IdentityInferenceResult = {
   shadowRulesPromoted: number;
   /** Entities auto-applied (confidence >= threshold → catalogIdentityId written). */
   autoApplied: number;
+  /** DPF-internal (docker-origin) candidates skipped so budget targets real estate. */
+  dpfInternalSkipped: number;
   /** Shadow rules demoted to 'rejected' by a contradicting human resolution. */
   shadowRulesDemoted: number;
   inferenceCalls: number;
@@ -305,6 +375,7 @@ export async function runIdentityInferenceFallback(
     aiResolutionsLogged: 0,
     shadowRulesPromoted: 0,
     autoApplied: 0,
+    dpfInternalSkipped: 0,
     shadowRulesDemoted: 0,
     inferenceCalls: 0,
     inferenceTokensSpent: 0,
@@ -340,6 +411,7 @@ export async function runIdentityInferenceFallback(
     take: scanLimit,
     select: {
       id: true,
+      entityKey: true,
       name: true,
       entityType: true,
       manufacturer: true,
@@ -359,6 +431,15 @@ export async function runIdentityInferenceFallback(
   const priorLogsByEntity = new Map<string, AiResolvedLogRow[]>();
   const toInfer: UnresolvedEntityRow[] = [];
   for (const entity of candidates) {
+    // The DPF install's own self-scan footprint (its Docker containers, bridge
+    // hosts, runtime) is not managed estate — it is the platform itself. Spending
+    // scarce inference budget identifying our own plumbing (redis, postgres, …)
+    // starves the real devices the operator cares about, so skip it here exactly
+    // as the estate views contain it. (Auto-identify calibration.)
+    if (entity.entityKey && isDockerOriginEntityKey(entity.entityKey, entity.name)) {
+      result.dpfInternalSkipped += 1;
+      continue;
+    }
     let priorLogs: AiResolvedLogRow[] = [];
     try {
       priorLogs = await db.identityResolutionLog.findMany({


### PR DESCRIPTION
## Summary

Makes automatic device identification actually reach the estate, and makes the platform **detect this class of miscalibration itself**. Closes **BI-DEC1C7BF**. Follows #4198 (fingerprint-layer wiring).

## The hidden failure (measured on a live install)

The AI identity fallback (`runIdentityInferenceFallback`) already identifies real network devices with **no hand-written rules** — verified on live data:

| Device | AI identified as | Confidence |
|---|---|---|
| `Whirlpool 192.168.0.91` | Whirlpool connected appliance | 0.96 |
| `Reolink 192.168.0.172` | Reolink IP camera | 0.96 |
| `Nest Labs …` | Nest thermostat | 0.94 |
| `Ubiquiti …` | Ubiquiti network device | 0.95 |
| `TP-LINK …` | TP-Link Kasa smart plug | 0.91 |

`IdentityResolutionLog` held **55 `ai_resolved` rows; 0 were applied.** The auto-apply gate is hardcoded at **0.97**, and this install's cheap/local model self-reports confidence in the **0.90–0.96** band — so ~100% of correct identifications were computed and discarded, and the estate stayed blank. No operator could ever know to inspect a resolution-log histogram against a threshold constant.

## Changes

1. **Calibrate the gate.** Default `autoApplyThreshold` 0.97 → **0.90**, with a new `IDENTITY_INFERENCE_AUTO_APPLY_THRESHOLD` env override to *raise* it for high-precision-model installs. The apply writes the **non-authoritative, recoverable** `identityStatus='ai_resolved'` — and promotion to a durable layer-0 rule stays gated by `shadowPromotionThreshold` (≥3 identical), so a lower apply bar cannot mint an authoritative rule from one guess.
2. **Focus the budget.** The AI candidate scan now excludes DPF-internal (`isDockerOriginEntityKey`) entities — the identifier stops spending inference on our own containers (redis/postgres) and targets real estate (`dpfInternalSkipped`).
3. **Proactive self-diagnosis.** New `diagnoseIdentityInference()` detects the "resolved many, applied ~none" signature and raises an operator-facing advisory on the `ScheduledJob` + logs + run outcome — so the platform surfaces this hidden class of miscalibration instead of silently discarding results. (Operator feedback: the AI coworkers should proactively mitigate this, not depend on someone spelunking the DB.)

## Verification
- 23 db-engine tests (incl. new: 0.90 default applies, 0.85 withheld, docker-internal skipped, diagnostic fires/silent), 8 runner tests, db typecheck, all 37 guards, and the full sandbox local-CI gate — green.

## Follow-up
Fuller proactive loop: the inventory-specialist coworker reads the advisory and auto-mitigates (tune threshold / humanized alert), per the tell-don't-act health pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
