### PR TITLE
fix(local-ci): sandbox-freshness self-heals a stale bin that fails the install (BI-675D9085)

### DIFF
--- a/scripts/lib/sandbox-freshness.mjs
+++ b/scripts/lib/sandbox-freshness.mjs
@@ -294,6 +294,65 @@ export function shouldForceConvergenceAfterInstall(evaluation) {
   ].includes(failure.kind));
 }
 
+/**
+ * Decide whether the convergence ladder should escalate to a heavier repair
+ * (force install -> node_modules reset -> fresh store). Two independent signals:
+ *
+ *  1. the freshness re-check still shows tracked dependency drift
+ *     (shouldForceConvergenceAfterInstall), OR
+ *  2. the convergence install itself FAILED (non-zero exit). A frozen-lockfile
+ *     install that exits non-zero after a dependency-version bump is the
+ *     stale-bin / broken-postinstall signature (BI-675D9085): e.g. a
+ *     node_modules/.bin/prisma symlink left pointing at a removed 7.9.0 build
+ *     after a 7.9.0->7.9.1 bump. The critical-package links can ALL resolve to
+ *     the locked version (so signal 1 is silent and the re-check is green) while
+ *     the install can't complete — the exact gap that stranded the old ladder at
+ *     sandbox_drift and demanded a manual `rm -rf node_modules`. Escalating on a
+ *     failed install lets the clean reset self-heal it. This subsumes the
+ *     optional "MODULE_NOT_FOUND on a *.bin target" signature without parsing
+ *     installer stderr, which the inherited-stdio install does not capture.
+ */
+export function shouldEscalateConvergence(evaluation, lastAttempt) {
+  if (shouldForceConvergenceAfterInstall(evaluation)) return true;
+  return Boolean(lastAttempt) && lastAttempt.attempted === true && (lastAttempt.exitCode ?? 0) !== 0;
+}
+
+/**
+ * Parse the `packages:` list out of a pnpm-workspace.yaml. Returns the raw
+ * glob/literal entries (e.g. "apps/*", "packages/*", "services/adp"). Pure text
+ * parsing — no YAML dependency — matching the rest of this module. The preflight
+ * expands these against the filesystem to find each workspace package's
+ * node_modules for the clean-reset escalation (root + package node_modules).
+ */
+export function parseWorkspacePackageGlobs(workspaceYamlText) {
+  if (!workspaceYamlText) return [];
+  const lines = workspaceYamlText.split("\n");
+  const globs = [];
+  let inPackages = false;
+  for (const line of lines) {
+    if (/^packages:\s*$/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (!inPackages) continue;
+    // Blank lines and full-line comments are not the end of the block — a
+    // comment at column 0 between two entries must NOT drop the rest of the
+    // list (that would leave those packages' node_modules un-reset — a partial
+    // recurrence of the very drift this repairs).
+    if (/^\s*$/.test(line) || /^\s*#/.test(line)) continue;
+    // Any other non-indented line is a new top-level key: end of the block.
+    if (/^\S/.test(line)) break;
+    const entry = line.match(/^\s+-\s+(.+?)\s*$/);
+    if (!entry) continue;
+    let raw = entry[1].trim();
+    // Strip an inline trailing comment on an unquoted entry ("apps/* # note").
+    if (!/^['"]/.test(raw)) raw = raw.replace(/\s+#.*$/, "").trim();
+    const value = raw.replace(/^['"]|['"]$/g, "").trim();
+    if (value && !value.startsWith("!")) globs.push(value);
+  }
+  return globs;
+}
+
 /** Exit codes for the preflight CLI — deliberately distinct from a product build failure (1). */
 export const EXIT_GREEN = 0;
 export const EXIT_USAGE = 2;

--- a/scripts/lib/sandbox-freshness.test.mjs
+++ b/scripts/lib/sandbox-freshness.test.mjs
@@ -16,6 +16,8 @@ import {
   isPnpmInstallCommand,
   parseEtimeMinutes,
   parseLockedVersion,
+  parseWorkspacePackageGlobs,
+  shouldEscalateConvergence,
   shouldForceConvergenceAfterInstall,
   stalePackagePathsForRelink,
 } from "./sandbox-freshness.mjs";
@@ -236,6 +238,34 @@ test("shouldForceConvergenceAfterInstall is limited to dependency drift after in
     verdict: "sandbox_not_ready",
     failures: [{ kind: "install_in_progress" }],
   }), false);
+});
+
+test("shouldEscalateConvergence also escalates on a failed install with a green re-check (stale bin, BI-675D9085)", () => {
+  // The old gate only saw tracked drift; a stale .bin fails the install while
+  // every link resolves to the locked version, so the re-check is green.
+  const green = { verdict: "green", failures: [] };
+  assert.equal(shouldEscalateConvergence(green, { attempted: true, exitCode: 1 }), true);
+  // A clean install (exit 0) that reached green must NOT escalate — the ladder stops.
+  assert.equal(shouldEscalateConvergence(green, { attempted: true, exitCode: 0 }), false);
+  // Tracked drift still escalates regardless of the install's exit code.
+  const drift = { verdict: "sandbox_drift", failures: [{ kind: "version_drift", package: "prisma" }] };
+  assert.equal(shouldEscalateConvergence(drift, { attempted: true, exitCode: 0 }), true);
+  // A skipped/absent attempt on a green re-check is not an escalation signal.
+  assert.equal(shouldEscalateConvergence(green, { attempted: false, exitCode: 1 }), false);
+  assert.equal(shouldEscalateConvergence(green, null), false);
+  assert.equal(shouldEscalateConvergence(green, undefined), false);
+});
+
+test("parseWorkspacePackageGlobs reads the pnpm-workspace.yaml package list", () => {
+  const yaml = `packages:\n  - "apps/*"\n  - "packages/*"\n  - services/adp\n  - '!**/__fixtures__/**'\noverrides:\n  react: 19.2.3\n`;
+  assert.deepEqual(parseWorkspacePackageGlobs(yaml), ["apps/*", "packages/*", "services/adp"]);
+  assert.deepEqual(parseWorkspacePackageGlobs(""), []);
+  assert.deepEqual(parseWorkspacePackageGlobs("overrides:\n  react: 19.2.3\n"), []);
+  // A column-0 comment or a blank line inside the block must NOT drop the
+  // entries after it, and an inline trailing comment on an entry is stripped —
+  // otherwise those packages' node_modules would go un-reset (partial drift).
+  const withComments = `packages:\n  - "apps/*"\n# a comment at column 0\n\n  - packages/* # inline note\n  - services/adp\noverrides:\n  react: 19.2.3\n`;
+  assert.deepEqual(parseWorkspacePackageGlobs(withComments), ["apps/*", "packages/*", "services/adp"]);
 });
 
 test("evaluateFreshness flags a whole-lockfile mismatch the sentinels can't see (new dep added)", () => {

--- a/scripts/sandbox-freshness-preflight.mjs
+++ b/scripts/sandbox-freshness-preflight.mjs
@@ -34,7 +34,8 @@ import {
   evaluateFreshness,
   exitCodeForVerdict,
   parseLockedVersion,
-  shouldForceConvergenceAfterInstall,
+  parseWorkspacePackageGlobs,
+  shouldEscalateConvergence,
   stalePackagePathsForRelink,
 } from "./lib/sandbox-freshness.mjs";
 
@@ -318,22 +319,70 @@ function canResetNodeModules() {
     || process.env.DPF_ALLOW_SANDBOX_NODE_MODULES_RESET === "1";
 }
 
-function resetSandboxNodeModules() {
-  if (!canResetNodeModules()) return false;
-  const target = path.join(rootDir, "node_modules");
-  const resolved = path.resolve(target);
-  if (path.relative(rootDir, resolved) !== "node_modules") return false;
-  try {
-    const stat = fs.lstatSync(resolved);
-    if (stat.isSymbolicLink()) {
-      console.error(`[sandbox-freshness] refusing full node_modules reset because ${resolved} is a symlink/junction`);
-      return false;
+// Enumerate the workspace-package node_modules dirs (apps/web/node_modules,
+// packages/db/node_modules, ...) so the clean reset clears BOTH the root store
+// AND the per-package .bin trees a stale bin can hide in — the "root + package
+// node_modules" wipe the incident (BI-675D9085) required by hand. Globs come
+// from pnpm-workspace.yaml; only real directories INSIDE the slot are returned.
+function workspacePackageNodeModulesDirs() {
+  const workspaceYaml = readFileIfExists(path.join(rootDir, "pnpm-workspace.yaml"));
+  const dirs = new Set();
+  for (const glob of parseWorkspacePackageGlobs(workspaceYaml)) {
+    let packageDirs = [];
+    if (glob.endsWith("/*")) {
+      const parent = path.join(rootDir, glob.slice(0, -2));
+      try {
+        packageDirs = fs
+          .readdirSync(parent, { withFileTypes: true })
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => path.join(parent, entry.name));
+      } catch {
+        packageDirs = [];
+      }
+    } else {
+      packageDirs = [path.join(rootDir, glob)];
     }
+    for (const packageDir of packageDirs) {
+      const candidate = path.resolve(packageDir, "node_modules");
+      const displacement = path.relative(rootDir, candidate);
+      if (!displacement || displacement.startsWith("..") || path.isAbsolute(displacement)) continue;
+      dirs.add(candidate);
+    }
+  }
+  return [...dirs];
+}
+
+// Remove one node_modules dir if it is a real directory inside the slot (never a
+// symlink/junction, whose target could live outside the sandbox). Returns true
+// when the path is absent or was removed; false only when refused.
+function removeNodeModulesDir(resolved) {
+  if (path.basename(resolved) !== "node_modules") return false;
+  const displacement = path.relative(rootDir, resolved);
+  if (!displacement || displacement.startsWith("..") || path.isAbsolute(displacement)) return false;
+  let stat;
+  try {
+    stat = fs.lstatSync(resolved);
   } catch {
-    return true;
+    return true; // already gone.
+  }
+  if (stat.isSymbolicLink()) {
+    console.error(`[sandbox-freshness] refusing node_modules reset because ${resolved} is a symlink/junction`);
+    return false;
   }
   fs.rmSync(resolved, { recursive: true, force: true });
-  log("reset scratch sandbox node_modules after package-level convergence could not repair dependency drift");
+  return true;
+}
+
+function resetSandboxNodeModules() {
+  if (!canResetNodeModules()) return false;
+  const rootNodeModules = path.resolve(rootDir, "node_modules");
+  if (path.relative(rootDir, rootNodeModules) !== "node_modules") return false;
+  if (!removeNodeModulesDir(rootNodeModules)) return false;
+  let clearedPackages = 0;
+  for (const packageNodeModules of workspacePackageNodeModulesDirs()) {
+    if (removeNodeModulesDir(packageNodeModules)) clearedPackages += 1;
+  }
+  log(`reset scratch sandbox node_modules (root + ${clearedPackages} workspace package trees) after package-level convergence could not repair dependency drift`);
   return true;
 }
 
@@ -391,24 +440,29 @@ try {
   state = collectState();
   evaluation = evaluateFreshness(state);
 
-  if (shouldForceConvergenceAfterInstall(evaluation)) {
-    log("first convergence left dependency drift; retrying once with --force to refresh the sandbox store/link graph");
+  // Escalate on tracked drift OR a failed install (the stale-bin signature,
+  // BI-675D9085): a frozen-lockfile install that exits non-zero after a dep bump
+  // can leave every link resolving to the locked version (re-check green) while
+  // the install itself never completed. Each rung runs at most once, so the
+  // whole ladder is bounded.
+  if (shouldEscalateConvergence(evaluation, attempts[attempts.length - 1])) {
+    log("first convergence did not settle (drift or failed install); retrying once with --force to refresh the sandbox store/link graph");
     attempts.push(runConvergenceAttempt(state, { force: true }));
     convergence = { ...attempts[attempts.length - 1], attempts };
     state = collectState();
     evaluation = evaluateFreshness(state);
   }
 
-  if (shouldForceConvergenceAfterInstall(evaluation) && canResetNodeModules()) {
-    log("forced convergence left dependency drift; resetting scratch node_modules once and reinstalling from the lockfile");
+  if (shouldEscalateConvergence(evaluation, attempts[attempts.length - 1]) && canResetNodeModules()) {
+    log("forced convergence did not settle; resetting scratch node_modules once (root + package trees) and reinstalling from the lockfile");
     attempts.push(runConvergenceAttempt(state, { resetNodeModules: true }));
     convergence = { ...attempts[attempts.length - 1], attempts };
     state = collectState();
     evaluation = evaluateFreshness(state);
   }
 
-  if (shouldForceConvergenceAfterInstall(evaluation) && canResetNodeModules()) {
-    log("scratch node_modules reset still left dependency drift; retrying once with a scratch-local pnpm store");
+  if (shouldEscalateConvergence(evaluation, attempts[attempts.length - 1]) && canResetNodeModules()) {
+    log("scratch node_modules reset still did not settle; retrying once with a scratch-local pnpm store");
     attempts.push(runConvergenceAttempt(state, { freshStore: true }));
     convergence = { ...attempts[attempts.length - 1], attempts };
     state = collectState();

--- a/scripts/sandbox-freshness-preflight.test.mjs
+++ b/scripts/sandbox-freshness-preflight.test.mjs
@@ -89,6 +89,72 @@ function prependPathEnv(dir) {
   return `${dir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`;
 }
 
+/**
+ * Reproduce the stale-bin incident (BI-675D9085): after a dependency-version
+ * bump, node_modules keeps a stale `.bin/<pkg>` symlink at a removed build, so
+ * `pnpm install --frozen-lockfile` FAILS (non-zero exit) on the postinstall/bin
+ * step even though every workspace link now resolves to the locked version (the
+ * freshness re-check is green). The only recovery is a clean node_modules reset.
+ * This fake fails every install while the root node_modules directory still
+ * exists, and only succeeds once the preflight has wiped it — modelling "a stale
+ * bin the incremental/force install can't clear, healed by the clean reset".
+ */
+function writeFakePnpmThatSucceedsOnlyAfterNodeModulesReset(binDir) {
+  mkdirSync(binDir, { recursive: true });
+  const fake = join(binDir, "fake-pnpm-stale-bin.mjs");
+  writeFileSync(fake, `#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const args = process.argv.slice(2);
+const root = process.cwd();
+writeFileSync(join(root, "pnpm-invocations.log"), args.join(" ") + "\\n", { flag: "a" });
+
+// The preflight wipes root node_modules on its clean-reset escalation. Before
+// that happens node_modules (and its stale .bin) still exists, so the install
+// cannot complete; after the wipe it can.
+const staleBinPresent = existsSync(join(root, "node_modules"));
+
+// Whether it exits 0 or not, pnpm relinks the workspace to the locked versions,
+// so the freshness re-check is green either way — that's the incident: green
+// links, failed install.
+const lockfile = readFileSync(join(root, "pnpm-lock.yaml"), "utf8");
+mkdirSync(join(root, "node_modules", ".pnpm"), { recursive: true });
+writeFileSync(join(root, "node_modules", ".pnpm", "lock.yaml"), lockfile);
+const packages = [
+  ["next", "apps/web", "16.2.9"],
+  ["react", "apps/web", "19.2.7"],
+  ["react-dom", "apps/web", "19.2.7"],
+  ["typescript", ".", "5.9.3"],
+  ["prisma", "packages/db", "6.19.1"],
+  ["vitest", "apps/web", "4.1.10"],
+];
+for (const [name, importer, version] of packages) {
+  const storeDir = join(root, "node_modules", ".pnpm", name + "@" + version + "_healed", "node_modules", name);
+  mkdirSync(storeDir, { recursive: true });
+  writeFileSync(join(storeDir, "package.json"), JSON.stringify({ name, version }));
+  if (name === "vitest") {
+    mkdirSync(join(storeDir, "dist", "chunks"), { recursive: true });
+    writeFileSync(join(storeDir, "dist", "cli.js"), "import './chunks/cac.ok.js';\\n");
+    writeFileSync(join(storeDir, "dist", "chunks", "cac.ok.js"), "export default {};\\n");
+  }
+  const importerNodeModules = importer === "." ? join(root, "node_modules") : join(root, importer, "node_modules");
+  const linkPath = join(importerNodeModules, name);
+  rmSync(linkPath, { recursive: true, force: true });
+  mkdirSync(importerNodeModules, { recursive: true });
+  symlinkSync(storeDir, linkPath, process.platform === "win32" ? "junction" : "dir");
+}
+process.exit(staleBinPresent ? 1 : 0);
+`);
+  chmodSync(fake, 0o755);
+  if (process.platform === "win32") {
+    writeFileSync(join(binDir, "pnpm.cmd"), `@echo off\r\nnode "%~dp0fake-pnpm-stale-bin.mjs" %*\r\n`);
+  } else {
+    writeFileSync(join(binDir, "pnpm"), `#!/bin/sh\nexec node "${fake}" "$@"\n`);
+    chmodSync(join(binDir, "pnpm"), 0o755);
+  }
+}
+
 function writeFakePnpmThatRepairsOnlyWithFreshStore(binDir) {
   mkdirSync(binDir, { recursive: true });
   const fake = join(binDir, "fake-pnpm.mjs");
@@ -316,6 +382,90 @@ test("--converge honors the admitted slot's explicit convergence lock", () => {
   assert.equal(result.status, 4, `${result.stdout}\n${result.stderr}`);
   assert.equal(report.convergence.reason, "convergence_lock_held");
   assert.equal(existsSync(join(root, "pnpm-invocations.log")), false);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("--converge self-heals a stale bin that fails the frozen-lockfile install (BI-675D9085)", () => {
+  // Prisma bump on main left a stale node_modules/.bin/prisma symlink: the
+  // install fails (non-zero exit) on the bin/postinstall step while every
+  // workspace link resolves to the locked version, so the freshness re-check is
+  // green. The old escalation ladder only fired on *tracked drift*, so it never
+  // reset node_modules — it fell straight through to sandbox_drift (exit 3) and
+  // demanded a manual `rm -rf node_modules`. It must now escalate to the clean
+  // reset and heal on its own.
+  const root = scaffold({
+    installedVersions: { prisma: "6.19.0" },
+    lockedVersions: { prisma: "6.19.1" },
+    installedLockVersions: { prisma: "6.19.0" },
+  });
+  // The clean reset enumerates workspace packages from pnpm-workspace.yaml.
+  writeFileSync(join(root, "pnpm-workspace.yaml"), 'packages:\n  - "apps/*"\n  - "packages/*"\n');
+  // Sentinels proving the clean reset wiped BOTH the root and the workspace
+  // package node_modules (the manual recovery the platform must automate).
+  writeFileSync(join(root, "node_modules", ".stale-bin-root"), "x");
+  writeFileSync(join(root, "packages", "db", "node_modules", ".stale-bin-pkg"), "x");
+  const binDir = join(root, "fake-bin");
+  writeFakePnpmThatSucceedsOnlyAfterNodeModulesReset(binDir);
+
+  const { result, report } = runPreflight(root, ["--converge"], {
+    env: {
+      DPF_ALLOW_SANDBOX_NODE_MODULES_RESET: "1",
+      PATH: prependPathEnv(binDir),
+    },
+  });
+
+  assert.equal(result.status, 0, `expected self-heal to green, got ${result.status}\n${result.stdout}\n${result.stderr}`);
+  assert.equal(report.verdict, "green");
+  assert.ok(
+    report.convergence.attempts.some((attempt) => attempt.resetNodeModules === true),
+    `expected a node_modules-reset escalation, got ${JSON.stringify(report.convergence)}`,
+  );
+  // The clean reset removed root + package node_modules before the healing install.
+  assert.equal(existsSync(join(root, "node_modules", ".stale-bin-root")), false, "root node_modules must be reset");
+  assert.equal(existsSync(join(root, "packages", "db", "node_modules", ".stale-bin-pkg")), false, "package node_modules must be reset");
+  const prisma = report.packages.find((p) => p.name === "prisma");
+  assert.equal(prisma.resolvedVersion, "6.19.1");
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("--converge stays bounded: a stale bin that never heals reports drift without looping (BI-675D9085)", () => {
+  // If even the clean reset can't produce a working install, the ladder must
+  // stop (bounded) and report sandbox_drift — never loop resets forever.
+  const root = scaffold({
+    installedVersions: { prisma: "6.19.0" },
+    lockedVersions: { prisma: "6.19.1" },
+    installedLockVersions: { prisma: "6.19.0" },
+  });
+  const binDir = join(root, "fake-bin");
+  // A pnpm that always exits non-zero and never relinks: nothing heals it.
+  mkdirSync(binDir, { recursive: true });
+  const fake = join(binDir, "always-fail.mjs");
+  writeFileSync(fake, `#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+writeFileSync(join(process.cwd(), "pnpm-invocations.log"), process.argv.slice(2).join(" ") + "\\n", { flag: "a" });
+process.exit(1);
+`);
+  chmodSync(fake, 0o755);
+  writeFileSync(join(binDir, "pnpm"), `#!/bin/sh\nexec node "${fake}" "$@"\n`);
+  chmodSync(join(binDir, "pnpm"), 0o755);
+
+  const { result, report } = runPreflight(root, ["--converge"], {
+    env: {
+      DPF_ALLOW_SANDBOX_NODE_MODULES_RESET: "1",
+      PATH: prependPathEnv(binDir),
+    },
+  });
+
+  // Terminal non-green (drift or not-ready) — it must never report a false green
+  // when the install never succeeded.
+  assert.notEqual(result.status, 0, `must not report green when nothing heals\n${result.stderr}`);
+  assert.notEqual(report.verdict, "green");
+  // Bounded: the ladder is a fixed sequence, so the node_modules reset ran at
+  // most once and the whole convergence took at most the four ladder rungs.
+  const resetAttempts = report.convergence.attempts.filter((attempt) => attempt.resetNodeModules === true);
+  assert.ok(resetAttempts.length <= 1, `reset must be bounded, saw ${resetAttempts.length}`);
+  assert.ok(report.convergence.attempts.length <= 4, `ladder must be bounded, saw ${report.convergence.attempts.length}`);
   rmSync(root, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## What

The local-CI sandbox-freshness `--converge` gate now auto-recovers from a stale `node_modules/.bin/<pkg>` symlink left behind by a dependency-version bump, instead of returning exit-3 `SANDBOX_DRIFT` and demanding a manual `rm -rf node_modules`.

## Why (BI-675D9085)

When `origin/main` bumped Prisma 7.9.0 → 7.9.1, the shared `.local-ci-runner` sandbox kept a stale `.bin/prisma` symlink pointing at 7.9.0's removed `build/index.js`. `pnpm install --frozen-lockfile` then exited **non-zero** on the bin/postinstall step — but every critical-package link still resolved to the locked version, so the freshness re-check came back **green**.

The old escalation ladder only escalated to the `node_modules` reset on *tracked dependency drift* (`shouldForceConvergenceAfterInstall`). A green-re-check-but-failed-install fell straight through to `SANDBOX_DRIFT` and blocked **all** local gating on that machine until hand-repaired — exactly the cognitive load the platform is meant to eliminate.

**Field impact: none.** Customer self-upgrade builds images in a fresh Docker layer (clean install, no incremental relink), health-gated with rollback. This is a contributor dev-tooling gap only.

## Fix

- **`shouldEscalateConvergence(evaluation, lastAttempt)`** — escalate the ladder (`--force` → `node_modules` reset → fresh store) on tracked drift **OR a non-zero install exit** (the stale-bin / broken-postinstall signature). Subsumes the optional "MODULE_NOT_FOUND on a `*.bin` target" detection without parsing inherited-stdio installer output.
- **`resetSandboxNodeModules()`** now clears the slot's **root + each workspace-package `node_modules`** (enumerated from `pnpm-workspace.yaml` via `parseWorkspacePackageGlobs`), matching the manual "root + package node_modules" recovery. Every removal is guarded: real directory, inside the slot, `node_modules` basename, never a symlink/junction.

The ladder stays **bounded** (each rung runs at most once — max 4 install attempts, reset at most once) and every escalation is **logged**. Reset stays gated by `canResetNodeModules()`, so it only fires in the admitted scratch sandbox/slot — never a developer's own worktree.

## Acceptance

- ✅ A dependency-version bump on main that leaves stale bins self-heals on the next `pnpm run pregate` with no manual `node_modules` wipe.
- ✅ The clean-reset path is logged and bounded.

## Tests

- Reproduction test drives a fake pnpm that fails while `node_modules` exists and succeeds only after the clean reset (green re-check + failed install); asserts self-heal to green and that both root + `packages/db` node_modules were wiped. Verified genuinely **red on the parent commit** (`expected self-heal to green, got 3`), green after the fix.
- Bounded-no-loop test: an always-failing pnpm reports drift without looping (≤1 reset, ≤4 attempts, never a false green).
- Unit tests for both new pure helpers, incl. `pnpm-workspace.yaml` parsing with column-0 comments / blank lines / inline comments (hardened so a comment can't silently drop entries → partial reset).

41/41 `node --test` cases pass across the two suites.

_Note: verified in a source-only worktree; install/compile-dependent repo guards run in required CI._

Signed-off-by: dpf-ci <dpf-ci@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)