### PR TITLE
fix(ci): ignore stopped builder stats

### DIFF
--- a/apps/web/lib/nonprod/local-ci-capacity-broker.ts
+++ b/apps/web/lib/nonprod/local-ci-capacity-broker.ts
@@ -116,6 +116,20 @@ function dockerBuilderContainerName(ordinal: number): string {
   return `buildx_buildkit_dpf-local-ci-buildkit-v${version}-${ordinal}0`;
 }
 
+type DockerGet = (path: string) => Promise<unknown>;
+
+type DockerContainerSummary = {
+  Id?: unknown;
+  Names?: unknown;
+  State?: unknown;
+};
+
+function builderIsStopped(container: DockerContainerSummary): boolean {
+  return container.State === "created"
+    || container.State === "exited"
+    || container.State === "dead";
+}
+
 export function dockerMemoryWorkingSetBytes(value: unknown): number {
   if (!value || typeof value !== "object") return Number.NaN;
   const memoryStats = (value as { memory_stats?: unknown }).memory_stats;
@@ -136,11 +150,12 @@ export function dockerMemoryWorkingSetBytes(value: unknown): number {
   return Math.max(0, usage - Math.max(0, inactiveFile));
 }
 
-async function defaultBuilderMemoryUsageBytes(): Promise<number[]> {
-  const containers = await dockerSocketGet("/containers/json?all=1") as Array<{
-    Id?: unknown;
-    Names?: unknown;
-  }>;
+export async function builderMemoryUsageBytesFromDocker(
+  dockerGet: DockerGet,
+): Promise<number[]> {
+  const containers = await dockerGet(
+    "/containers/json?all=1",
+  ) as DockerContainerSummary[];
   if (!Array.isArray(containers)) throw new Error("docker_container_list_invalid");
 
   return Promise.all(Object.values(localCiSlotResources.slots).map(
@@ -151,7 +166,8 @@ async function defaultBuilderMemoryUsageBytes(): Promise<number[]> {
         && candidate.Names.includes(expectedName)
       ));
       if (typeof container?.Id !== "string") return 0;
-      const stats = await dockerSocketGet(
+      if (builderIsStopped(container)) return 0;
+      const stats = await dockerGet(
         `/containers/${encodeURIComponent(container.Id)}/stats?stream=false`,
       );
       const workingSet = dockerMemoryWorkingSetBytes(stats);
@@ -161,6 +177,10 @@ async function defaultBuilderMemoryUsageBytes(): Promise<number[]> {
       return workingSet;
     },
   ));
+}
+
+async function defaultBuilderMemoryUsageBytes(): Promise<number[]> {
+  return builderMemoryUsageBytesFromDocker(dockerSocketGet);
 }
 
 const DEFAULT_PROBES: LocalCiServerPressureProbes = {

--- a/scripts/local-ci-capacity-broker.test.mjs
+++ b/scripts/local-ci-capacity-broker.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  builderMemoryUsageBytesFromDocker,
   dockerMemoryWorkingSetBytes,
   mergeLocalCiHostPressure,
   observeLocalCiServerPressure,
@@ -100,4 +101,62 @@ test("Docker builder usage excludes reclaimable inactive file cache", () => {
     },
   }), 1.5 * 1024 ** 3);
   assert.equal(Number.isNaN(dockerMemoryWorkingSetBytes({})), true);
+});
+
+test("an exited builder with empty stats is absent from current memory usage", async () => {
+  const requestedPaths = [];
+  const dockerGet = async (path) => {
+    requestedPaths.push(path);
+    if (path === "/containers/json?all=1") {
+      return [{
+        Id: "stopped-builder",
+        Names: ["/buildx_buildkit_dpf-local-ci-buildkit-v2-00"],
+        State: "exited",
+      }];
+    }
+    if (path.includes("/stats?stream=false")) return { memory_stats: {} };
+    throw new Error(`unexpected Docker path: ${path}`);
+  };
+
+  const builderMemoryUsageBytes = await builderMemoryUsageBytesFromDocker(
+    dockerGet,
+  );
+  const pressure = await observeLocalCiServerPressure({
+    now: () => new Date("2026-08-12T01:33:09.145Z"),
+    availableMemoryBytes: () => 18 * 1024 ** 3,
+    builderMemoryUsageBytes: () => builderMemoryUsageBytes,
+    sustainedCpuPercent: () => 21,
+    diskFreeBytes: async () => 1.5 * 1024 ** 4,
+    dockerHealthy: async () => true,
+    convergenceActive: async () => false,
+    fencesHealthy: async () => true,
+    evidenceIsolationHealthy: async () => true,
+  });
+
+  assert.deepEqual(builderMemoryUsageBytes, [0, 0]);
+  assert.deepEqual(requestedPaths, ["/containers/json?all=1"]);
+  assert.equal(pressure.sustainedCpuPercent, 21);
+  assert.equal(pressure.dockerHealthy, true);
+  assert.deepEqual(pressure.builderMemoryUsageBytes, [0, 0]);
+});
+
+test("a running builder with empty stats remains fail-closed", async () => {
+  const dockerGet = async (path) => {
+    if (path === "/containers/json?all=1") {
+      return [{
+        Id: "running-builder",
+        Names: ["/buildx_buildkit_dpf-local-ci-buildkit-v2-00"],
+        State: "running",
+      }];
+    }
+    if (path === "/containers/running-builder/stats?stream=false") {
+      return { memory_stats: {} };
+    }
+    throw new Error(`unexpected Docker path: ${path}`);
+  };
+
+  await assert.rejects(
+    builderMemoryUsageBytesFromDocker(dockerGet),
+    /docker_builder_memory_unmeasurable/,
+  );
 });


### PR DESCRIPTION
## Summary

Fix local-CI pressure observation so a stopped BuildKit container is treated as absent instead of erasing an otherwise valid server sample. Running builders remain fail-closed when Docker cannot measure their stats.

## Changes

- Treat `created`, `exited`, and `dead` builder containers as zero current memory use without requesting `/stats`.
- Preserve the existing unmeasurable error for a running builder whose memory stats are empty or invalid.
- Add regression coverage for the stopped-builder and running-unmeasurable cases while retaining the existing capacity, FIFO, and telemetry contracts.

## Test plan

- [x] Source-local contract tests: `node --test scripts/local-ci-capacity-broker.test.mjs scripts/local-ci-pool-policy.test.mjs` — 21 passed, 0 failed.
- [x] `git diff --check origin/main...HEAD` — clean.
- [x] `node scripts/pregate-preflight.mjs` — 37 guards clean; 3 source-only environment skips remain enforced by hosted CI.
- [x] High-assurance semantic review ran on the immutable commit with zero findings; it was infrastructure-inconclusive because the deployed broken broker reserved local-provider capacity. The repository's shadow policy permits publication while keeping that outcome visible.
- [x] The normal exact-tree pregate was attempted and queued behind valid FIFO claims, proving the deployed broker cannot admit its own repair. This uses the same `install-bootstrap-recovery` precedent as PR #4142; hosted GitHub checks are the exact-tree bootstrap evidence.
- [ ] Hosted CI passes for this PR head.

## Related issues / Epic

- BI-7B9C9376
- Evidence: cmspf0ja10c0101o6q4txudlq
- Epic: EP-0DFF753B

## Overlap sweep

No overlapping open PR or recent main-branch change touches this stopped-builder correction. Foreign worktrees and live claims were not modified.

## Notes for the reviewer

This is an internal control-plane fix with no migration and no user-facing UI. Post-merge acceptance will advance only through `/ops/self-upgrade`, then run `verify:preflight` to a CAN-TEST verdict and prove the FIFO head can admit with the stopped builder still stopped.

Process-Spine-Decision: isolated bugfix restoring the existing local-CI pressure-observation contract; no new process substrate
Design-Grounding-Decision: reviewed BI-7B9C9376 evidence and the canonical capacity-broker/pool-policy code; localized observation correction
Docs-Impact-Decision: internal local-CI broker correctness change; no user, coworker, route, install, or operations documentation surface changes
Local-CI-Override: install-bootstrap-recovery: deployed stopped-builder observation prevents the exact repair from admission; hosted CI is the bootstrap evidence
