### PR TITLE
fix(ci): reconcile dead slot fences

### DIFF
--- a/scripts/lib/local-ci-host-pressure.mjs
+++ b/scripts/lib/local-ci-host-pressure.mjs
@@ -1,7 +1,9 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { statfs } from "node:fs/promises";
 import { cpus, freemem } from "node:os";
+
+import { reconcileDeadLocalSandboxFence } from "./local-sandbox-fence.mjs";
 
 function finiteValues(values) {
   return values.filter((value) => typeof value === "number" && Number.isFinite(value));
@@ -44,26 +46,12 @@ function defaultConvergenceActive(paths = []) {
   return paths.some((path) => existsSync(path));
 }
 
-function processIsAlive(pid) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return error?.code === "EPERM";
-  }
-}
-
 function defaultFencesHealthy(paths = []) {
   for (const path of paths) {
     if (!existsSync(path)) continue;
     try {
-      const fence = JSON.parse(readFileSync(path, "utf8"));
-      if (
-        !fence
-        || typeof fence.token !== "string"
-        || !Number.isInteger(fence.pid)
-        || !processIsAlive(fence.pid)
-      ) {
+      const result = reconcileDeadLocalSandboxFence({ path });
+      if (!["absent", "live", "reconciled"].includes(result.status)) {
         return false;
       }
     } catch {

--- a/scripts/lib/local-ci-host-pressure.test.mjs
+++ b/scripts/lib/local-ci-host-pressure.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -79,12 +79,18 @@ test("probe failures remain unmeasurable instead of becoming optimistic defaults
   assert.equal(observed.evidenceIsolationHealthy, false);
 });
 
-test("a stale fence whose owner process is dead contracts host safety", async () => {
+test("a valid stale fence whose owner process is dead is reconciled", async () => {
   const directory = mkdtempSync(join(tmpdir(), "dpf-pressure-fence-"));
   const fencePath = join(directory, "slot-0.json");
   writeFileSync(fencePath, JSON.stringify({
+    schema: "dpf-local-sandbox-fence/v1",
     token: "stale-owner",
     pid: 2_147_483_000,
+    processIdentity: "win32:1",
+    ownerSessionId: "dead-owner",
+    branch: "feat/dead",
+    acquiredAt: "2026-07-30T04:59:00.000Z",
+    heartbeatAt: "2026-07-30T04:59:30.000Z",
   }));
 
   const sample = await sampleLocalCiHostPressure({
@@ -106,7 +112,8 @@ test("a stale fence whose owner process is dead contracts host safety", async ()
     },
   });
 
-  assert.equal(sample.fencesHealthy, false);
+  assert.equal(sample.fencesHealthy, true);
+  assert.equal(existsSync(fencePath), false);
 });
 
 test("summarizes pilot peaks and integrity observations without branch labels", () => {

--- a/scripts/lib/local-sandbox-fence.mjs
+++ b/scripts/lib/local-sandbox-fence.mjs
@@ -21,6 +21,64 @@ function readFence(path) {
   }
 }
 
+function isVersionedFenceRecord(record) {
+  return record?.schema === "dpf-local-sandbox-fence/v1"
+    && typeof record.token === "string"
+    && record.token.length > 0
+    && Number.isInteger(record.pid)
+    && record.pid > 0
+    && typeof record.processIdentity === "string"
+    && record.processIdentity.length > 0;
+}
+
+/**
+ * Reconcile only fences whose recorded process can no longer be the owner.
+ * Live owners and records we cannot measure remain fail-closed.
+ */
+export function reconcileDeadLocalSandboxFence({
+  path,
+  processAlive = isProcessAlive,
+  processIdentity = readProcessIdentity,
+}) {
+  const record = readFence(path);
+  if (!record) return { status: "absent", record: null };
+  if (!isVersionedFenceRecord(record)) return { status: "invalid", record };
+
+  if (processAlive(record.pid)) {
+    const identity = processIdentity(record.pid);
+    if (!identity) return { status: "unmeasurable", record };
+    if (identity === record.processIdentity) return { status: "live", record };
+  }
+
+  const orphanPath = `${path}.orphan-${process.pid}-${Date.now()}`;
+  try {
+    renameSync(path, orphanPath);
+  } catch (error) {
+    if (["ENOENT", "EACCES", "EPERM"].includes(error?.code)) {
+      return { status: "contended", record };
+    }
+    throw error;
+  }
+
+  const moved = readFence(orphanPath);
+  if (
+    moved?.token !== record.token
+    || moved?.pid !== record.pid
+    || moved?.processIdentity !== record.processIdentity
+  ) {
+    try {
+      renameSync(orphanPath, path);
+    } catch {
+      // Another owner won the path. Leave the unexpected record quarantined;
+      // admission remains fail-closed for this observation.
+    }
+    return { status: "contended", record: moved };
+  }
+
+  unlinkSync(orphanPath);
+  return { status: "reconciled", record };
+}
+
 export function inspectLocalSandboxFence({
   path,
   processAlive = isProcessAlive,
@@ -31,13 +89,7 @@ export function inspectLocalSandboxFence({
   const record = readFence(path);
   if (!record) return { status: "absent", record: null };
   if (
-    record.schema !== "dpf-local-sandbox-fence/v1"
-    || !Number.isInteger(record.pid)
-    || record.pid <= 0
-    || typeof record.token !== "string"
-    || !record.token
-    || typeof record.processIdentity !== "string"
-    || !record.processIdentity
+    !isVersionedFenceRecord(record)
     || typeof record.heartbeatAt !== "string"
   ) {
     return { status: "invalid", record };

--- a/scripts/lib/local-sandbox-fence.test.mjs
+++ b/scripts/lib/local-sandbox-fence.test.mjs
@@ -8,6 +8,7 @@ import {
   acquireLocalSandboxFence,
   heartbeatLocalSandboxFence,
   inspectLocalSandboxFence,
+  reconcileDeadLocalSandboxFence,
   readProcessIdentity,
   releaseLocalSandboxFence,
 } from "./local-sandbox-fence.mjs";
@@ -131,6 +132,92 @@ test("inspection rejects a reused pid whose process-start identity changed", () 
     processIdentity: () => "test:new-start",
     now: () => new Date("2026-07-30T12:01:00.000Z"),
   }).status, "stale");
+});
+
+test("reconciliation removes only a valid fence whose original process is gone", () => {
+  const path = fencePath();
+  writeFileSync(path, JSON.stringify({
+    schema: "dpf-local-sandbox-fence/v1",
+    token: "dead-owner",
+    pid: 717,
+    processIdentity: "test:717",
+    ownerSessionId: "dead-owner",
+    branch: "feat/dead",
+    acquiredAt: "2026-07-30T12:00:00.000Z",
+    heartbeatAt: "2026-07-30T12:00:30.000Z",
+  }));
+
+  assert.equal(reconcileDeadLocalSandboxFence({
+    path,
+    processAlive: () => false,
+  }).status, "reconciled");
+  assert.equal(existsSync(path), false);
+});
+
+test("reconciliation preserves live and malformed fences fail-closed", () => {
+  const livePath = fencePath();
+  writeFileSync(livePath, JSON.stringify({
+    schema: "dpf-local-sandbox-fence/v1",
+    token: "live-owner",
+    pid: 727,
+    processIdentity: "test:727",
+    ownerSessionId: "live-owner",
+    branch: "feat/live",
+    acquiredAt: "2026-07-30T12:00:00.000Z",
+    heartbeatAt: "2026-07-30T12:00:30.000Z",
+  }));
+  assert.equal(reconcileDeadLocalSandboxFence({
+    path: livePath,
+    processAlive: () => true,
+    processIdentity: (pid) => `test:${pid}`,
+  }).status, "live");
+  assert.equal(existsSync(livePath), true);
+
+  const malformedPath = fencePath();
+  writeFileSync(malformedPath, JSON.stringify({ pid: 737 }));
+  assert.equal(reconcileDeadLocalSandboxFence({
+    path: malformedPath,
+    processAlive: () => false,
+  }).status, "invalid");
+  assert.equal(existsSync(malformedPath), true);
+});
+
+test("reconciliation reaps PID reuse but preserves an unmeasurable live process", () => {
+  const reusedPath = fencePath();
+  writeFileSync(reusedPath, JSON.stringify({
+    schema: "dpf-local-sandbox-fence/v1",
+    token: "old-owner",
+    pid: 747,
+    processIdentity: "test:old-start",
+    ownerSessionId: "old-owner",
+    branch: "feat/old",
+    acquiredAt: "2026-07-30T12:00:00.000Z",
+    heartbeatAt: "2026-07-30T12:00:30.000Z",
+  }));
+  assert.equal(reconcileDeadLocalSandboxFence({
+    path: reusedPath,
+    processAlive: () => true,
+    processIdentity: () => "test:new-start",
+  }).status, "reconciled");
+  assert.equal(existsSync(reusedPath), false);
+
+  const unmeasurablePath = fencePath();
+  writeFileSync(unmeasurablePath, JSON.stringify({
+    schema: "dpf-local-sandbox-fence/v1",
+    token: "unknown-owner",
+    pid: 757,
+    processIdentity: "test:757",
+    ownerSessionId: "unknown-owner",
+    branch: "feat/unknown",
+    acquiredAt: "2026-07-30T12:00:00.000Z",
+    heartbeatAt: "2026-07-30T12:00:30.000Z",
+  }));
+  assert.equal(reconcileDeadLocalSandboxFence({
+    path: unmeasurablePath,
+    processAlive: () => true,
+    processIdentity: () => "",
+  }).status, "unmeasurable");
+  assert.equal(existsSync(unmeasurablePath), true);
 });
 
 test("inspection rejects a live pid whose fence heartbeat is stale", () => {


### PR DESCRIPTION
## Summary

Repair local-CI admission when a valid slot fence outlives its owner process. Dead or PID-reused owners are reconciled atomically; live owners and unmeasurable or malformed records remain fail-closed.

## Changes

- Centralize versioned fence validation in the canonical local sandbox-fence module.
- Add token/identity-checked reconciliation for a dead owner or reused PID.
- Let host-pressure sampling count an absent or safely reconciled fence as healthy without weakening live-owner isolation.
- Add regression coverage for dead owners, live owners, PID reuse, malformed records, and unmeasurable live processes.

## Test plan

- [x] RED reproduced the missing reconciliation and `slot-fence-unhealthy` admission outcome.
- [x] Focused fence/pressure contracts: 16 passed, 0 failed.
- [x] Local-CI fence, lease, and pool-policy contracts: 53 passed, 0 failed, 1 expected Windows signal-handler skip.
- [x] `git diff --check` clean.
- [x] `pnpm run pregate:preflight` reported 37 guards clean; three source-only missing-runtime checks remain enforced by hosted CI.
- [x] Fresh high-assurance semantic review ran on the immutable commit with zero findings; it was infrastructure-inconclusive because the established local-CI queue was reserved. Shadow policy permits publication while retaining the receipt.
- [ ] Hosted PR and merge-group CI pass for this exact head.

## Related work

- BI-68F5493D
- EP-0DFF753B

## Overlap sweep

No open PR touches the two corrected runtime modules. Foreign leases, processes, and the stale fence were not manually altered.

## Notes for the reviewer

This is an internal control-plane correction with no migration or user-facing UI. Post-merge acceptance will use the normal `/ops/self-upgrade`, deterministic CAN-TEST preflight, and a preserved FIFO waiter to prove dead-fence reconciliation while retaining fail-closed live-owner behavior.

Process-Spine-Decision: isolated bugfix restoring the existing local-CI fence lifecycle; no new process substrate
Design-Grounding-Decision: grounded in the canonical fence, host-pressure, pool-policy, and live FIFO evidence
Docs-Impact-Decision: internal local-CI correctness change; no user, route, install, or operations documentation changes
Local-CI-Override: install-bootstrap-recovery: dead slot fence blocks all exact local-CI admission; hosted CI is the bootstrap evidence