### PR TITLE
fix(mcp): tasks capability value must be object, not boolean

### DIFF
--- a/apps/web/app/api/mcp/v1/route.test.ts
+++ b/apps/web/app/api/mcp/v1/route.test.ts
@@ -662,7 +662,9 @@ describe("POST — tools/list", () => {
     const body = await res.json();
     expect(typeof body.result.serverInfo.description).toBe("string");
     expect(body.result.serverInfo.description.length).toBeGreaterThan(0);
-    expect(body.result.capabilities.tasks).toEqual({ list: true, cancel: true });
+    // Spec shape: tasks.list/.cancel are `object`, not boolean (a boolean
+    // fails strict client capability validation — Claude Code rejects init).
+    expect(body.result.capabilities.tasks).toEqual({ list: {}, cancel: {} });
   });
 
   it("rejects an unsupported MCP-Protocol-Version header with 400 (Slice 1)", async () => {

--- a/apps/web/app/api/mcp/v1/route.ts
+++ b/apps/web/app/api/mcp/v1/route.ts
@@ -520,8 +520,12 @@ async function handleInitialize(id: JsonRpcId, params?: Record<string, unknown>)
       // Advertising on 2024-11-05 / 2025-03-26 breaks clients that reject
       // unknown capability keys at initialize (Grok Build 1.0.0 → CustomResult
       // handshake failure). Methods remain routable; discovery is gated.
+      // Value shape is spec-load-bearing: tasks.list/.cancel are `object`
+      // (present-if-supported), NOT boolean. A boolean fails strict client
+      // capability validation — Claude Code rejects the whole initialize and
+      // loads zero tools. Empty object = supported (cf. logging/completions).
       ...(shouldAdvertiseTasksCapability(negotiated)
-        ? { tasks: { list: true, cancel: true } }
+        ? { tasks: { list: {}, cancel: {} } }
         : {}),
     },
     serverInfo: {

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -1,5 +1,5 @@
-apps/web/app/api/mcp/v1/route.test.ts	1425
-apps/web/app/api/mcp/v1/route.ts	872
+apps/web/app/api/mcp/v1/route.test.ts	1427
+apps/web/app/api/mcp/v1/route.ts	876
 apps/web/app/api/v1/edge/discovery-runs/route.test.ts	982
 apps/web/components/admin/BusinessModelBuilder.tsx	821
 apps/web/components/admin/McpTokenManager.tsx	1326


### PR DESCRIPTION
## Problem

The DPF MCP server shows **✘ Failed to connect** in Claude Code, even though the server is healthy and every JSON-RPC call succeeds when probed directly. No DPF tools load into the session.

## Root cause

The `initialize` response advertises `capabilities.tasks` as `{ list: true, cancel: true }`. Per the `2025-11-25` `ServerCapabilities` schema (`docs/Reference/mcp/spec/schema.mdx`), `tasks.list` and `tasks.cancel` are **`object`** (present-if-supported), not boolean. Claude Code 2.1.197 validates the server's advertised capabilities with a strict Zod schema and rejects the boolean form:

```
capabilities.tasks.list   → Invalid input
capabilities.tasks.cancel → Invalid input
```

The client aborts the entire `initialize` and loads zero tools. `tasks` is advertised only on negotiated protocol `2025-11-25`, which that client negotiates — so it hits the broken branch. Clients that validate loosely (or predate the `tasks` capability) tolerated it, which is why this surfaced only recently.

## Fix

Emit empty objects: `{ tasks: { list: {}, cancel: {} } }`, matching the spec's present-if-supported pattern (same as `logging` / `completions`).

## Verification

End-to-end against Claude Code 2.1.197 (stub reproducing DPF's `initialize`):

| Advertised `tasks` shape | Client result |
|---|---|
| `{ list: true, cancel: true }` (before) | ✘ Failed to connect |
| `{ list: {}, cancel: {} }` (after) | ✔ Connected |

- `apps/web/app/api/mcp/v1/route.test.ts` — 58/58 pass, including the updated tasks-capability assertion.
- Local-CI merged-code gate: passed (evidence recorded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Docs-Impact-Decision: Wire-format spec-conformance fix — the MCP `initialize` capabilities.tasks value shape (boolean -> object). No user-facing behavior, authorization model, or agent meta-model semantics change; the flagged pages (ai-agent-meta-model.md, mcp-tool-authorization-runbook.md) describe governance/authorization, not the transport capability wire shape.
