### PR TITLE
fix(work-capsules): WS9 reaper flag survives self-upgrade (base-compose passthrough, BI-06B462E2)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,6 +253,17 @@ services:
       # explicit per-install operator opt-in after a clean observe soak.
       DPF_WORKTREE_JANITOR_ENABLED: ${DPF_WORKTREE_JANITOR_ENABLED:-1}
       DPF_SANDBOX_BUILD_GC_ENABLED: ${DPF_SANDBOX_BUILD_GC_ENABLED:-1}
+      # WS9 governed WorkCapsule reaper (BI-CBAAEA94): transitions dead capsules
+      # (lease-expired / linked-build-terminal / idle-past-floor) working->abandoned
+      # so abandoned work stops reading as active on the board and jamming the WIP
+      # cap. Delivered HERE (base compose), not override-only: an override-only flag
+      # is dropped when the self-upgrade promoter recreates the portal, which is why
+      # the WS9 sprawl re-accumulated after it first shipped. Same soak model as the
+      # janitors above — ENABLED defaults ON = observe-only (logs would-reap, no DB
+      # writes); AUTO_REAP is the live/reversible actuation and stays OFF until a
+      # per-install operator opt-in via .env.
+      DPF_WORKCAPSULE_REAPER_ENABLED: ${DPF_WORKCAPSULE_REAPER_ENABLED:-1}
+      DPF_WORKCAPSULE_REAPER_AUTO_REAP: ${DPF_WORKCAPSULE_REAPER_AUTO_REAP:-0}
       # Runtime-artifact janitor (BI-DBF3F426 / BI-A55BE432): reaps orphaned
       # per-branch CI images + stray compose projects INCLUDING their named
       # volumes — the dominant local-disk leak (dead dpf-<topic> dev stacks


### PR DESCRIPTION
## What & why

Follow-up to WS9 (BI-CBAAEA94, PR #4056 merged). The governed WorkCapsule reaper works when enabled, but its `DPF_WORKCAPSULE_REAPER_*` flags were delivered **only** via `docker-compose.override.yml`. The self-upgrade **promoter recreates the portal without the override**, so the flags were dropped on the next upgrade and the reaper went dormant — the stale-WIP sprawl **re-accumulated** (observed 2026-08-12: **74 of 78 `working` + 2 `blocked` reapable**, reaper not running in the live container even though the override still carried the flags).

**Root cause:** override-only env vars don't survive the promoter recreate, while base `docker-compose.yml` passthroughs delivered from `.env` do — which is exactly why `DPF_WORKTREE_JANITOR_ENABLED` survived but `..._AUTO_REAP` did not.

## Change

One base-compose passthrough on the portal service, mirroring the janitor convention:
```
DPF_WORKCAPSULE_REAPER_ENABLED: ${DPF_WORKCAPSULE_REAPER_ENABLED:-1}   # observe-only default ON (logs would-reap, no DB writes)
DPF_WORKCAPSULE_REAPER_AUTO_REAP: ${DPF_WORKCAPSULE_REAPER_AUTO_REAP:-0} # live/reversible actuation, per-install opt-in via .env
```
An install now enables actuation durably via `.env`, and it survives self-upgrades.

## Interim (already done on this install)

Portal recreated from the override to re-activate + sweep: **`working` 78→4 (all live), `blocked`→1 (live), 0 reapable**. This install's `.env` carries the opt-in for when this passthrough deploys.

Backlog: BI-06B462E2 (EP-PROCESS-SPINE).

Docs-Impact-Decision: infra/compose env passthrough only; no user-facing behaviour or user-guide page changes.
Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
