### PR TITLE
fix(build): route platform code-gen at public sensitivity so connected cloud dev tools are eligible (BI-0DBDCB77)

### DIFF
--- a/apps/web/lib/explore/build-process-matrix.test.ts
+++ b/apps/web/lib/explore/build-process-matrix.test.ts
@@ -6,6 +6,7 @@ import {
   deriveBuildProcessSize,
   deriveBuildProcessType,
   deriveDeliverableSensitivity,
+  mapBuildDeliverableToRoutingSensitivity,
   describePolicy,
   getModelTier,
   getProcessPolicy,
@@ -460,3 +461,18 @@ const _typeCheck = (): BuildProcessType => "feature";
 const _sizeCheck = (): BuildProcessSize => "medium";
 void _typeCheck;
 void _sizeCheck;
+
+describe("mapBuildDeliverableToRoutingSensitivity", () => {
+  // Founder ruling (2026-08-12): platform source-code generation is development
+  // work, not internal business data. Ordinary builds route at the least-
+  // sensitive `public` tier so connected frontier cloud dev tools (cleared for
+  // public, never internal business data) are eligible; builds whose brief
+  // signals real business-data sensitivity keep the internal/confidential gates.
+  it("maps low deliverable sensitivity to public (unblocks cloud dev tools)", () => {
+    expect(mapBuildDeliverableToRoutingSensitivity("low")).toBe("public");
+  });
+  it("escalates elevated to internal and high to confidential", () => {
+    expect(mapBuildDeliverableToRoutingSensitivity("elevated")).toBe("internal");
+    expect(mapBuildDeliverableToRoutingSensitivity("high")).toBe("confidential");
+  });
+});

--- a/apps/web/lib/explore/build-process-matrix.ts
+++ b/apps/web/lib/explore/build-process-matrix.ts
@@ -476,6 +476,29 @@ export function deriveDeliverableSensitivity(
   return SENSITIVITY_RANK[keyword] >= SENSITIVITY_RANK[postureFloor] ? keyword : postureFloor;
 }
 
+/**
+ * Map a derived deliverable sensitivity to the ROUTING data-sensitivity for a
+ * Build Studio dispatch. Founder ruling (2026-08-12): platform source-code
+ * generation is development work, not business data — ordinary builds (low) route
+ * at `public` so connected cloud dev tools are eligible; elevated/high escalate to
+ * internal/confidential. Content-based payload screening still runs on every
+ * request. Interim to BI-0DBDCB77 (a dedicated `development` class needs the
+ * duplicated 4-value sensitivity literal consolidated first).
+ */
+export function mapBuildDeliverableToRoutingSensitivity(
+  d: DeliverableSensitivity,
+): "public" | "internal" | "confidential" {
+  switch (d) {
+    case "high":
+      return "confidential";
+    case "elevated":
+      return "internal";
+    case "low":
+    default:
+      return "public";
+  }
+}
+
 // ─── Public API ─────────────────────────────────────────────────────────────
 
 /**

--- a/apps/web/lib/integrate/build-engine-selection-runtime.ts
+++ b/apps/web/lib/integrate/build-engine-selection-runtime.ts
@@ -212,7 +212,8 @@ export async function resolveBuildEngineSelection(
     try {
       const preview = await previewRoute(
         [{ role: "user", content: "Generate and modify source code for a Build Studio task." }],
-        opts.sensitivity ?? "internal",
+        // Code-gen is dev work, not business data — default `public` (BI-0DBDCB77).
+        opts.sensitivity ?? "public",
         {
           taskType: "code-gen",
           tools: [{ name: "edit_sandbox_file" }, { name: "run_sandbox_tests" }],

--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -963,7 +963,7 @@ async function dispatchSpecialist(params: {
     lastResult = await runAgenticLoop({
       chatHistory: [{ role: "user", content: taskPrompt }],
       systemPrompt,
-      sensitivity: "internal",
+      sensitivity: "public", // code-gen is dev work, not business data (BI-0DBDCB77)
       tools: scopedTools,
       toolsForProvider,
       userId,
@@ -1147,10 +1147,11 @@ export async function runBuildOrchestrator(params: {
   // ─── Pre-flight check: select one policy-qualified healthy engine ─────────
   // The shared selector owns auth, health, capacity, residency, sensitivity,
   // capability, and hard-pin gates before any specialist side effect begins.
-  const { deriveDeliverableSensitivity } = await import("@/lib/explore/build-process-matrix");
+  const { deriveDeliverableSensitivity, mapBuildDeliverableToRoutingSensitivity } = await import("@/lib/explore/build-process-matrix");
   const buildSensitivity = deriveDeliverableSensitivity({ text: buildContext });
   const preflightConfig = await getBuildStudioConfig({
-    sensitivity: buildSensitivity === "high" ? "confidential" : "internal",
+    // low→public, elevated→internal, high→confidential (BI-0DBDCB77).
+    sensitivity: mapBuildDeliverableToRoutingSensitivity(buildSensitivity),
   });
 
   if (preflightConfig.selection) {

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -598,7 +598,7 @@ async function stepGenerateCode(
   const result = await runAgenticLoop({
     chatHistory: [{ role: "user", content: userMessage }],
     systemPrompt,
-    sensitivity: "internal",
+    sensitivity: "public", // code-gen is dev work, not business data (BI-0DBDCB77)
     tools,
     toolsForProvider,
     userId: "system",

--- a/apps/web/lib/integrate/ideate-dispatch.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.ts
@@ -487,7 +487,7 @@ export async function dispatchIdeateResearch(params: {
         "You are a senior software architect producing a structured design document. Respond with the design document content only — no preamble.";
       const { designDoc, rawOutput } = await runLocalIdeateWithRetry(
         async (messages) => {
-          const response = await routeAndCall(messages, systemPrompt, params.sensitivity ?? "internal", {
+          const response = await routeAndCall(messages, systemPrompt, params.sensitivity ?? "public", {
             budgetClass: "quality_first",
             ...(providerId ? { allowedProviders: [providerId] } : {}),
             ...(params.modelTier ? { modelTier: params.modelTier } : {}),

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -32,12 +32,12 @@ apps/web/lib/actions/tax-remittance.test.ts	1080
 apps/web/lib/actions/tax-remittance.ts	978
 apps/web/lib/ai-operations-map/load-map-data.test.ts	928
 apps/web/lib/deliberation/orchestrator.ts	808
-apps/web/lib/explore/build-process-matrix.ts	811
+apps/web/lib/explore/build-process-matrix.ts	834
 apps/web/lib/explore/feature-build-types.ts	1098
 apps/web/lib/finance/ai-provider-finance.ts	1309
 apps/web/lib/inference/ai-provider-internals.ts	1266
 apps/web/lib/integrate/build-agent-prompts.ts	1075
-apps/web/lib/integrate/build-orchestrator.ts	1800
+apps/web/lib/integrate/build-orchestrator.ts	1801
 apps/web/lib/integrate/sandbox/build-branch.ts	949
 apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp-tools-backlog.test.ts	874


### PR DESCRIPTION
## What & why

Build Studio hardcoded the **routing data-sensitivity** of development/code-gen work to `"internal"` (business-data clearance) in `build-pipeline.ts`, `build-orchestrator.ts`, `ideate-dispatch.ts`, and `build-engine-selection-runtime.ts`. That demanded a model cleared for **internal business data** to generate **platform source code**.

On a local-preferred install no engine satisfies both bars at once:
- the bundled local model is `internal`-cleared but **not frontier-tier** for code-gen;
- the connected frontier cloud dev tools (Claude Code / Codex / Grok) are frontier-tier but cleared for **public/approved-cloud, never internal business data**.

Result: **no eligible code-gen engine → every build dies at ideate** ("AI call failed"), producing a large backlog of stuck builds. This was the top finding of the Build Studio robustness campaign (BI-C43C5492).

Founder ruling (2026-08-12): *"code isn't sensitive, the business data is sensitive."* Generating platform source code is **development work**, not the processing of internal business data.

## Change

- Route ordinary platform code-gen at the existing **`public`** tier (the platform source is open; generating it is no more sensitive than public data), so the operator's connected frontier cloud dev tools become eligible.
- New `mapBuildDeliverableToRoutingSensitivity` **escalates** business-data-heavy builds: low→`public`, elevated→`internal`, high→`confidential` — keeping the business-data gates intact.
- **Safety unchanged:** content-based payload screening (`classifyInferencePayload`) still inspects every request, so a build that carries real business data is still caught. This relaxes only the *declared-clearance floor*, never the data-leak safety net.
- **No type changes** — uses only existing sensitivity values.

## Verification

- New unit tests: `mapBuildDeliverableToRoutingSensitivity` (low→public, elevated→internal, high→confidential).
- Local-CI merged-code gate **PASS** (typecheck + full vitest suite + production build; evidence `cmspo81b60ccn01nvxgsnbc6s`).
- Module-size ratchet re-baselined for the new helper; repo guards green.

## Scope note

This is the **interim** fix. A dedicated `development` sensitivity *class* is the cleaner taxonomy but requires first consolidating the 4-value sensitivity literal currently duplicated across ~9+ files (each a security-relevant gate) — tracked as the follow-up on BI-0DBDCB77.

Fixes BI-0DBDCB77. Related: BI-2C88CD53 (operator-facing message still reads "transient / just retry" when there genuinely is no engine — separate defense-in-depth follow-up). Found during Build Studio robustness campaign BI-C43C5492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Docs-Impact-Decision: Internal Build Studio routing-sensitivity fix — changes only which clearance tier the code-gen dispatch requests (so builds can find an eligible engine). No change to the documented Build Studio UX or user-guide flow; users create and supervise builds exactly as before.
