### PR TITLE
fix(ci): preserve bounded queued gate survival

### DIFF
--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -40,6 +40,7 @@ import {
 const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
 export const WINDOWS_WRAPPER_TERMINATED_STATUS = 4294967295;
+const DEFAULT_LEASE_WAIT_SECONDS = 7200;
 
 // Host-side guard parity preflight (BI-D35433FB): run the deterministic CI
 // policy guards before lease admission so a doomed gate never occupies a
@@ -74,6 +75,46 @@ function argValue(args, flag) {
   const index = args.indexOf(flag);
   if (index < 0) return "";
   return args[index + 1] || "";
+}
+
+function leaseWaitSeconds(args, env) {
+  const configured = argValue(args, "--lease-wait-seconds")
+    || env.DPF_GATE_LEASE_WAIT_SECONDS
+    || String(DEFAULT_LEASE_WAIT_SECONDS);
+  const seconds = Number(configured);
+  return Number.isFinite(seconds) && seconds >= 0
+    ? seconds
+    : DEFAULT_LEASE_WAIT_SECONDS;
+}
+
+export function createQueuedGateRevivalWindow({
+  args = [],
+  env = process.env,
+  nowMs = Date.now(),
+} = {}) {
+  return {
+    startedAtMs: nowMs,
+    deadlineMs: nowMs + leaseWaitSeconds(args, env) * 1000,
+  };
+}
+
+export function gateArgsForQueuedRevivalWindow({
+  args = [],
+  window,
+  nowMs = Date.now(),
+} = {}) {
+  const remainingMs = window?.deadlineMs - nowMs;
+  if (!Number.isFinite(remainingMs) || remainingMs <= 0) return null;
+
+  const remainingSeconds = String(Math.ceil(remainingMs / 1000));
+  const nextArgs = [...args];
+  const flagIndex = nextArgs.indexOf("--lease-wait-seconds");
+  if (flagIndex >= 0) {
+    nextArgs[flagIndex + 1] = remainingSeconds;
+  } else {
+    nextArgs.push("--lease-wait-seconds", remainingSeconds);
+  }
+  return nextArgs;
 }
 
 function gitText(gitArgs, { cwd, spawnSyncImpl = spawnSync } = {}) {
@@ -471,6 +512,62 @@ export async function recoverInterruptedGate({
   return { recovered: false, reason: "no-running-state" };
 }
 
+export async function runGateWithQueuedRevival({
+  args = [],
+  useShell = false,
+  env = process.env,
+  now = () => Date.now(),
+  spawnSyncImpl = spawnSync,
+  reviveInterruptedQueuedGateImpl = reviveInterruptedQueuedGate,
+  recoverInterruptedGateImpl = recoverInterruptedGate,
+  stderr = process.stderr,
+} = {}) {
+  let result;
+  let queuedRevivals = 0;
+  const queueRevivalWindow = createQueuedGateRevivalWindow({
+    args,
+    env,
+    nowMs: now(),
+  });
+
+  for (;;) {
+    const invocationArgs = queuedRevivals === 0
+      ? args
+      : gateArgsForQueuedRevivalWindow({
+        args,
+        window: queueRevivalWindow,
+        nowMs: now(),
+      });
+    if (!invocationArgs) {
+      await recoverInterruptedGateImpl({ args, result });
+      stderr.write("pregate: original bounded local-CI admission window elapsed; no further queued gate revival will be started.\n");
+      return { result, queuedRevivals, timedOut: true };
+    }
+
+    if (useShell) {
+      stderr.write("pregate: DPF_PREGATE_FORCE_SH=1 set — routing through compatibility shell entry point.\n");
+      result = spawnSyncImpl("sh", [join(SCRIPT_DIR, "gate-worktree.sh"), ...invocationArgs], { stdio: "inherit" });
+    } else {
+      stderr.write("pregate: routing through the Node-native gate (scripts/gate-worktree.mjs).\n");
+      result = spawnSyncImpl(process.execPath, [join(SCRIPT_DIR, "gate-worktree.mjs"), ...invocationArgs], { stdio: "inherit" });
+    }
+
+    if (result.error || (result.status ?? 1) === 0) {
+      return { result, queuedRevivals, timedOut: false };
+    }
+    if (now() < queueRevivalWindow.deadlineMs) {
+      const revived = await reviveInterruptedQueuedGateImpl({ args, result });
+      if (revived.revived) {
+        queuedRevivals += 1;
+        stderr.write(`pregate: queued gate revival ${queuedRevivals}; continuing within the original bounded admission window without losing FIFO position.\n`);
+        continue;
+      }
+    }
+    await recoverInterruptedGateImpl({ args, result });
+    return { result, queuedRevivals, timedOut: false };
+  }
+}
+
 async function main() {
   // BI-B1065D41: `pnpm run pregate | head -5` must survive head exiting. Both
   // this wrapper and the gate it spawns need the tolerance — the gate inherits
@@ -523,37 +620,12 @@ async function main() {
   }
 
   const useShell = shouldUseShell();
-
-  let result;
-  let queuedRevivals = 0;
-  const maxQueuedRevivals = Number.parseInt(process.env.DPF_PREGATE_MAX_QUEUE_REVIVALS || "6", 10);
-  for (;;) {
-    if (useShell) {
-      process.stderr.write("pregate: DPF_PREGATE_FORCE_SH=1 set — routing through compatibility shell entry point.\n");
-      result = spawnSync("sh", [join(SCRIPT_DIR, "gate-worktree.sh"), ...args], { stdio: "inherit" });
-    } else {
-      process.stderr.write("pregate: routing through the Node-native gate (scripts/gate-worktree.mjs).\n");
-      result = spawnSync(process.execPath, [join(SCRIPT_DIR, "gate-worktree.mjs"), ...args], { stdio: "inherit" });
-    }
-
-    if (result.error) {
-      process.stderr.write(`pregate: failed to launch gate: ${result.error.message}\n`);
-      process.exit(1);
-    }
-    const status = result.status ?? 1;
-    if (status === 0) break;
-    if (queuedRevivals < maxQueuedRevivals) {
-      const revived = await reviveInterruptedQueuedGate({ args, result });
-      if (revived.revived) {
-        queuedRevivals += 1;
-        process.stderr.write(`pregate: queued gate revival ${queuedRevivals}/${maxQueuedRevivals}; continuing without losing FIFO position.\n`);
-        continue;
-      }
-    }
-    await recoverInterruptedGate({ args, result });
-    process.exit(status);
+  const { result } = await runGateWithQueuedRevival({ args, useShell });
+  if (result?.error) {
+    process.stderr.write(`pregate: failed to launch gate: ${result.error.message}\n`);
+    process.exit(1);
   }
-  process.exit(0);
+  process.exit(result?.status ?? 1);
 }
 
 // Guard against side effects on import (e.g. from tests importing routing

--- a/scripts/pregate.test.mjs
+++ b/scripts/pregate.test.mjs
@@ -3,11 +3,76 @@ import test from "node:test";
 
 import {
   WINDOWS_WRAPPER_TERMINATED_STATUS,
+  createQueuedGateRevivalWindow,
+  gateArgsForQueuedRevivalWindow,
+  runGateWithQueuedRevival,
   detectWorkingShell,
   recoverInterruptedGateState,
   reviveInterruptedQueuedGateState,
   shouldUseShell,
 } from "./pregate.mjs";
+
+test("queued gate revivals share the original bounded admission deadline", () => {
+  const startedAtMs = Date.parse("2026-08-12T03:00:00.000Z");
+  const window = createQueuedGateRevivalWindow({
+    args: ["--branch", "fix/local-ci-survival", "--lease-wait-seconds", "7200"],
+    env: {},
+    nowMs: startedAtMs,
+  });
+
+  assert.equal(window.deadlineMs, startedAtMs + 7_200_000);
+  assert.deepEqual(
+    gateArgsForQueuedRevivalWindow({
+      args: ["--branch", "fix/local-ci-survival", "--lease-wait-seconds", "7200"],
+      window,
+      nowMs: startedAtMs + 1_800_123,
+    }),
+    ["--branch", "fix/local-ci-survival", "--lease-wait-seconds", "5400"],
+  );
+  assert.deepEqual(
+    gateArgsForQueuedRevivalWindow({
+      args: ["--branch", "fix/local-ci-survival"],
+      window,
+      nowMs: window.deadlineMs,
+    }),
+    null,
+  );
+});
+
+test("queued gate survival is bounded by time rather than an arbitrary revival count", async () => {
+  const wrapperExit = { status: WINDOWS_WRAPPER_TERMINATED_STATUS, signal: null };
+  const results = Array.from({ length: 7 }, () => wrapperExit).concat({ status: 0, signal: null });
+  const invocations = [];
+  const revivals = [];
+  let recovered = false;
+  let nowMs = Date.parse("2026-08-12T03:00:00.000Z");
+
+  const outcome = await runGateWithQueuedRevival({
+    args: ["--lease-wait-seconds", "7200"],
+    useShell: false,
+    now: () => nowMs,
+    spawnSyncImpl: (_command, args) => {
+      invocations.push(args);
+      nowMs += 300_000;
+      return results.shift();
+    },
+    reviveInterruptedQueuedGateImpl: async ({ result }) => {
+      revivals.push(result.status);
+      return { revived: true, leaseId: "NPEL-STABLE" };
+    },
+    recoverInterruptedGateImpl: async () => {
+      recovered = true;
+    },
+    stderr: { write() {} },
+  });
+
+  assert.equal(outcome.result.status, 0);
+  assert.equal(outcome.queuedRevivals, 7);
+  assert.equal(invocations.length, 8);
+  assert.equal(revivals.length, 7);
+  assert.equal(recovered, false);
+  assert.equal(invocations.at(-1).at(-1), "5100");
+});
 
 function shellProbe(status = 0) {
   return () => ({


### PR DESCRIPTION
## Summary

Keep a queued local-CI gate alive for its original bounded admission window when the Windows child observer exits with `0xFFFFFFFF`. The parent now preserves the same lease and FIFO position across any number of child revivals until the existing two-hour deadline, instead of failing after an arbitrary six-process budget.

## Changes

- Derive one parent-owned admission deadline from the canonical `--lease-wait-seconds` contract.
- Pass only the remaining wait duration to each replacement child, so revivals cannot extend the original bound.
- Extract the child orchestration loop behind an injectable seam for deterministic contract testing.
- Preserve fail-closed recovery for non-queued states, non-wrapper exits, launch failures, and elapsed deadlines.

## Test plan

- [x] RED: the deadline/orchestration seam did not exist before the correction.
- [x] Focused pregate tests and Node gate contracts: 34 passed, 0 failed, 1 expected platform shell skip.
- [x] Regression simulates seven consecutive Windows `0xFFFFFFFF` exits—past the former limit—and reaches success on the same bounded FIFO cycle.
- [x] Exact merged-tree local-CI passed: guards, typecheck, exhaustive Vitest, production Docker build, OCI import, and clean lease release.
- [x] Fresh high-assurance semantic review ran on the immutable commit with zero findings; infrastructure deferred the review branch, and shadow policy explicitly permitted publication.

## Related work

- BI-F4103BFB
- WC-592C1F01
- EP-0DFF753B

## Overlap sweep

No open PR touches `scripts/pregate.mjs` or `scripts/pregate.test.mjs`.

## Notes for the reviewer

This changes the durability boundary, not the lease-authority or FIFO contract. The server remains authoritative, the queue wait remains time-bounded, and the parent releases/marks failed when that original deadline is exhausted.

Process-Spine-Decision: reuse the canonical pregate parent and lease lifecycle; no parallel queue or observer substrate
Design-Grounding-Decision: grounded in repeated durable `0xFFFFFFFF` reproductions and the existing 7200-second gate admission contract
Docs-Impact-Decision: internal runner correctness change; existing contributor commands and time bounds are unchanged
Local-CI-Evidence: cmspowtez0dkb01nvcqm6je1j (fix/local-ci-windows-child-survival@655cdb5238eaa3a166aefa71de3976be26ee9cf5)
