### PR TITLE
fix(graph): stop the code-graph projection deleting rows it does not own (BI-EC5FF1A0)

### DIFF
--- a/apps/web/lib/integrate/code-graph/neo4j-projection.ts
+++ b/apps/web/lib/integrate/code-graph/neo4j-projection.ts
@@ -55,7 +55,17 @@ export function buildCodeFileKey(graphKey: string, filePath: string): string {
 
 // ─── Graph-mirror primitives ──────────────────────────────────────────────────
 
-/** UPSERT a node; props shallow-merged (parity with Cypher `SET n.x = …` / `n += map`). */
+/** UPSERT a node; props shallow-merged (parity with Cypher `SET n.x = …` / `n += map`).
+ *
+ *  Labels are UNION-merged, not replaced. A node in this mirror can carry ADDITIVE
+ *  markers owned by another projection — `DocImpactSource`, stamped by the doc-impact
+ *  projection onto files it shares with the code graph. `SET labels = excluded.labels`
+ *  silently erased every one of them on the next re-index: 504 markers on the live
+ *  install went to zero, and the projection that owns them has no way to notice.
+ *
+ *  This matches `upsertGraphNode` in packages/db/src/graph-sync.ts, which already
+ *  union-merges for exactly this reason. The two implementations had diverged, and
+ *  this one held the unsafe half. */
 async function upsertGraphNode(
   key: string,
   labels: string[],
@@ -65,7 +75,11 @@ async function upsertGraphNode(
     `INSERT INTO graph_node (key, labels, props)
      VALUES ($1, $2::text[], $3::jsonb)
      ON CONFLICT (key) DO UPDATE
-       SET labels = excluded.labels,
+       SET labels = graph_node.labels || COALESCE((
+             SELECT array_agg(l ORDER BY ord)
+               FROM unnest(excluded.labels) WITH ORDINALITY AS t(l, ord)
+              WHERE NOT (l = ANY(graph_node.labels))
+           ), '{}'),
            props  = graph_node.props || excluded.props`,
     key,
     labels,
@@ -93,12 +107,21 @@ async function upsertGraphEdge(
 }
 
 export async function clearCodeGraph(graphKey: string): Promise<void> {
-  // DETACH DELETE equivalent for every node in this graphKey (all labels).
+  // DETACH DELETE equivalent for every node in this graphKey (all labels), scoped to
+  // the edges THIS PROJECTION OWNS.
+  //
+  // A full clear is followed by a re-sync that recreates the same nodes under the same
+  // deterministic keys (`source-code:<path>`), so a foreign edge pointing at a code node
+  // is dangling only for the duration of the rebuild and resolves again afterwards.
+  // Deleting it instead is permanent and silent: that is how a code-graph rebuild
+  // destroyed all 616 doc-impact IMPACTS edges, leaving 183 DocPage nodes orphaned but
+  // still counted in the explorer census.
   await prisma.$executeRawUnsafe(
     `DELETE FROM graph_edge
       WHERE props->>'graphKey' = $1
-         OR src_key IN (SELECT key FROM graph_node WHERE props->>'graphKey' = $1)
-         OR dst_key IN (SELECT key FROM graph_node WHERE props->>'graphKey' = $1)`,
+         OR (props ? 'graphKey'
+             AND (src_key IN (SELECT key FROM graph_node WHERE props->>'graphKey' = $1)
+               OR dst_key IN (SELECT key FROM graph_node WHERE props->>'graphKey' = $1)))`,
     graphKey,
   );
   await prisma.$executeRawUnsafe(
@@ -120,17 +143,27 @@ async function clearStructuralFactsForFile(graphKey: string, filePath: string): 
     graphKey,
     filePath,
   );
-  // 2. DETACH the structural nodes at this path: drop any remaining incident edges…
+  // 2. DETACH the structural nodes at this path: drop any remaining incident edges
+  //    THIS PROJECTION OWNS. `props ? 'graphKey'` is the ownership discriminator, and
+  //    it is exact rather than approximate: on the live install every code-graph edge
+  //    carries it (IMPORTS 10764/10764, DEFINES 7665/7665, TESTED_BY 1986/1986,
+  //    IMPLEMENTS_ROUTE 481/481) and no foreign edge does (ASSOCIATED_WITH, BELONGS_TO,
+  //    LINKS_TO, CHILD_OF, DEPENDS_ON, MEMBER_OF all 0).
+  //
+  //    Without the predicate this deleted every incident edge regardless of owner, which
+  //    is how a routine re-index destroyed all 616 doc-impact IMPACTS edges and left 183
+  //    orphaned DocPage nodes still counted in the census.
   await prisma.$executeRawUnsafe(
     `DELETE FROM graph_edge
-      WHERE src_key IN (
+      WHERE props ? 'graphKey'
+        AND (src_key IN (
               SELECT key FROM graph_node
                WHERE props->>'graphKey' = $1 AND props->>'path' = $2 AND labels && $3::text[]
             )
          OR dst_key IN (
               SELECT key FROM graph_node
                WHERE props->>'graphKey' = $1 AND props->>'path' = $2 AND labels && $3::text[]
-            )`,
+            ))`,
     graphKey,
     filePath,
     STRUCTURAL_NODE_LABELS,
@@ -270,9 +303,14 @@ export async function syncTrackedFile(
     }
     await projectStructuralFacts(await extractStructuralFacts(graphKey, filePath, content));
   } catch {
-    // DETACH DELETE the CodeFile node (drop incident edges first, then the node).
+    // DETACH DELETE the CodeFile node: drop the incident edges THIS PROJECTION OWNS
+    // first, then the node. Scoped by `props ? 'graphKey'` for the same reason as
+    // clearStructuralFactsForFile — an unscoped delete here takes foreign edges
+    // (doc-impact IMPACTS, and anything added later) down with a file that merely
+    // failed to parse.
     await prisma.$executeRawUnsafe(
-      `DELETE FROM graph_edge WHERE src_key = $1 OR dst_key = $1`,
+      `DELETE FROM graph_edge
+        WHERE (src_key = $1 OR dst_key = $1) AND props ? 'graphKey'`,
       codeFileKey,
     );
     await prisma.$executeRawUnsafe(

--- a/apps/web/lib/integrate/code-graph/projection-edge-ownership.test.ts
+++ b/apps/web/lib/integrate/code-graph/projection-edge-ownership.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The code-graph projection shares graph_node / graph_edge with several other
+// projections (doc-impact, EA, infra, portfolio, knowledge). It owns only the rows it
+// stamps with `props.graphKey`; everything else belongs to someone else.
+//
+// This is a regression suite for a measured production incident: a routine re-index
+// destroyed ALL 616 doc-impact IMPACTS edges and every one of the 504 DocImpactSource
+// markers, leaving 183 DocPage nodes orphaned in the mirror but still counted in the
+// explorer census. Nothing failed and nothing logged — the projection simply deleted
+// rows it did not own, and the projection that DID own them has no way to notice.
+//
+// The assertions below are on the emitted SQL rather than on a live database, which is
+// what the other suites in this directory do, and is enough to pin the two properties
+// that were violated: labels must be UNION-merged, and edge deletes must be scoped to
+// owned rows.
+
+const { mockExecuteRawUnsafe } = vi.hoisted(() => ({
+  mockExecuteRawUnsafe: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    $executeRawUnsafe: mockExecuteRawUnsafe,
+    $queryRawUnsafe: vi.fn().mockResolvedValue([]),
+    codeGraphIndexState: { findUnique: vi.fn(), upsert: vi.fn() },
+    codeGraphFileHash: { upsert: vi.fn(), deleteMany: vi.fn() },
+  },
+}));
+
+import { clearCodeGraph, syncTrackedFile } from "./neo4j-projection";
+
+/** Every statement the projection issued, whitespace-collapsed for matching. */
+function statements(): string[] {
+  return mockExecuteRawUnsafe.mock.calls
+    .map(([sql]) => (typeof sql === "string" ? sql.replace(/\s+/g, " ").trim() : ""))
+    .filter(Boolean);
+}
+
+function edgeDeletes(): string[] {
+  return statements().filter((s) => /^DELETE FROM graph_edge/i.test(s));
+}
+
+beforeEach(() => {
+  mockExecuteRawUnsafe.mockReset();
+  mockExecuteRawUnsafe.mockResolvedValue(undefined);
+});
+
+describe("code-graph projection edge ownership", () => {
+  it("scopes the detach delete on the per-file failure path", async () => {
+    // Distinct code path from clearCodeGraph: when a tracked file fails to parse,
+    // syncTrackedFile DETACH-deletes its CodeFile node. That delete targeted the node
+    // key directly (`src_key = $1 OR dst_key = $1`) with no edge predicate, so a single
+    // unparseable file silently removed every foreign edge pointing at it.
+    //
+    // An earlier version of this test asserted only that the SQL mentioned "graphKey"
+    // anywhere. That PASSED against the unfixed code — the broken statement still
+    // contained the string in an unrelated clause — so it proved nothing. Asserting the
+    // key-targeting shape carries the predicate is what actually pins the behaviour.
+    await syncTrackedFile("repo", process.cwd(), "does-not-exist-here.ts");
+
+    const keyTargeted = edgeDeletes().filter((s) => /src_key = \$1|dst_key = \$1/i.test(s));
+    expect(keyTargeted.length).toBeGreaterThan(0);
+    for (const sql of keyTargeted) {
+      expect(sql).toMatch(/props \? 'graphKey'/);
+    }
+  });
+
+  it("scopes the incident-edge sweep to owned edges, not merely to owned nodes", async () => {
+    await clearCodeGraph("repo");
+
+    // The dangerous shape is `src_key IN (owned nodes) OR dst_key IN (owned nodes)`
+    // with no predicate on the EDGE itself: it matches every foreign edge that happens
+    // to touch a code node. Wherever the statement reaches for incident edges, it must
+    // also carry the ownership test.
+    const incident = edgeDeletes().filter((s) => /src_key IN|dst_key IN/i.test(s));
+    expect(incident.length).toBeGreaterThan(0);
+    for (const sql of incident) {
+      expect(sql).toMatch(/props \? 'graphKey'/);
+    }
+  });
+});
+
+describe("code-graph node upsert", () => {
+  it("UNION-merges labels instead of replacing them", async () => {
+    // `SET labels = excluded.labels` erases additive markers owned by another
+    // projection — this is what took all 504 DocImpactSource markers to zero.
+    // packages/db/src/graph-sync.ts already union-merges for exactly this reason;
+    // this projection held a divergent private copy with the unsafe semantics.
+    //
+    // Driven through a real sync so the assertion is on emitted SQL, not source text:
+    // package.json exists, is not TypeScript, and so exercises the node upsert without
+    // dragging in the structural extractor.
+    await syncTrackedFile("repo", process.cwd(), "package.json", { skipStructuralClear: true });
+
+    const upserts = statements().filter((s) => /INSERT INTO graph_node/i.test(s));
+    expect(upserts.length).toBeGreaterThan(0);
+
+    for (const sql of upserts) {
+      expect(sql).not.toMatch(/SET labels = excluded\.labels/);
+      expect(sql).toMatch(/labels = graph_node\.labels \|\|/);
+    }
+  });
+});


### PR DESCRIPTION
A routine code re-index destroyed the entire doc-impact projection on the live install. Measured before and after:

| | After the projection ran | After a code re-index |
| --- | --- | --- |
| `IMPACTS` edges | 616 | **0** |
| `DocImpactSource` markers | 504 | **0** |
| `DocPage` nodes | 183 connected | 183, **every one orphaned** |

The route → file → governing-document traversal shipped in #4079 stopped resolving within two days. Nothing failed and nothing logged — the projection that owns those rows has no way to notice.

The wreckage is **worse than never having run it**: a never-run projection reads as "nothing documents this route"; this reads as "183 documents exist and connect to nothing", and those orphans still inflate the explorer's Knowledge tile from 359 to 542.

Advances BI-EC5FF1A0.

## Root cause: the projection treated every row touching its nodes as its own

`graph_node` / `graph_edge` is shared by six projections. The code graph owns exactly the rows it stamps with `props.graphKey`. Three statements ignored that:

1. `upsertGraphNode` used `SET labels = excluded.labels`, **replacing** the label array and erasing additive markers owned by other projections. `packages/db/src/graph-sync.ts` already UNION-merges for precisely this reason — the two implementations had diverged and this one held the unsafe half.
2. `clearStructuralFactsForFile` deleted every edge incident to its structural nodes with **no predicate on the edge**.
3. `syncTrackedFile`'s failure path DETACH-deleted a `CodeFile` with `src_key = $1 OR dst_key = $1`, so a single unparseable file removed every foreign edge pointing at it.

## The ownership signal already existed in the data

No schema change, no backfill. `props ? 'graphKey'` separates the two sets **exactly**, measured live:

- **owned** — IMPORTS 10764/10764, DEFINES 7665/7665, TESTED_BY 1986/1986, IMPLEMENTS_ROUTE 481/481, HAS_FIELD 6540/6540, RELATES_TO 1075/1075
- **foreign** — ASSOCIATED_WITH 0/1758, BELONGS_TO 0/1190, LINKS_TO 0/640, CHILD_OF 0/487, DEPENDS_ON 0/711, MEMBER_OF 0/688

## Why scoping `clearCodeGraph` beats leaving dangling edges

A full clear is followed by a re-sync that recreates the same nodes under the same deterministic keys (`<graphKey>:<path>`), so a foreign edge dangles only for the rebuild and resolves afterwards. Deleting it is permanent and silent; leaving it is recoverable. That asymmetry is the whole argument.

## Verification

Three regression tests, each verified to **fail** against the unfixed projection by stashing it and re-running — 3 failed / 0 passed unfixed, 3 passed fixed.

Also green: 34 repo guards clean, 129 tests across `lib/integrate/code-graph` and `lib/graph`, local-CI gate **PASS** at `dddaca078e1d` (pushed on that record, no override code).

### A fourth vacuous test, caught the same way

The first version of the detach-path test asserted only that the emitted SQL *mentioned* `graphKey`. It **passed against the unfixed code** — the broken statement still contained that string in an unrelated clause — so it proved nothing. It now asserts the key-targeting shape itself carries the predicate. Same failure mode as the inert tests found in BI-C2B6396B and BI-E104FBCC.

## Not fixed here

The live mirror still holds 183 orphaned `DocPage` nodes. Re-running the doc-impact projection repairs them, and **nothing invokes it** (BI-FEDFABF6). This change stops the destruction; it does not schedule the repair. Freshness/reconciliation so an empty or destroyed domain is visible is BI-A73954F7.

## Pre-existing, not caused by this change

`pnpm --filter web typecheck` fails in `lib/federation/demand-read-model.ts` (bigint vs number, from #4116). Reproduced with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
