### PR TITLE
fix(ci): calibrate builder admission reserve

### DIFF
--- a/apps/web/lib/nonprod/local-ci-pool-policy.ts
+++ b/apps/web/lib/nonprod/local-ci-pool-policy.ts
@@ -96,6 +96,27 @@ export function localCiBuildHeadroomCapacity(input: {
 }
 
 /**
+ * Admission reserves measured demand plus margin. The builder's memoryBytes
+ * remains the hard runtime ceiling; an absent or invalid calibration falls
+ * back to that ceiling so incomplete evidence can never make admission looser.
+ */
+export function localCiBuilderAdmissionReserveBytes(input: {
+  hardCeilingBytes: number;
+  calibratedReserveBytes: number;
+}): number {
+  if (!Number.isFinite(input.hardCeilingBytes) || input.hardCeilingBytes <= 0) {
+    return 0;
+  }
+  if (
+    !Number.isFinite(input.calibratedReserveBytes)
+    || input.calibratedReserveBytes <= 0
+  ) {
+    return input.hardCeilingBytes;
+  }
+  return Math.min(input.hardCeilingBytes, input.calibratedReserveBytes);
+}
+
+/**
  * Number of host-native stage slots that can start without spending the
  * configured continuation floor. The floor is the active-stage safety fence;
  * the stage envelope is predictable Node/TypeScript/Vitest growth that must be
@@ -352,7 +373,11 @@ export function resolveLocalCiPoolPolicy(input: {
   }
 
   if (input.reserveAdmissionHeadroom) {
-    const builderMemoryBytes = localCiSlotResources.builderPolicy.memoryBytes;
+    const builderMemoryBytes = localCiBuilderAdmissionReserveBytes({
+      hardCeilingBytes: localCiSlotResources.builderPolicy.memoryBytes,
+      calibratedReserveBytes:
+        localCiSlotResources.builderPolicy.admissionReserveBytes,
+    });
     const hostBuildCapacity = localCiBuildHeadroomCapacity({
       dockerAvailableMemoryBytes:
         input.host.dockerAvailableMemoryBytes ?? Number.NaN,

--- a/apps/web/lib/nonprod/local-ci-slot-resources.json
+++ b/apps/web/lib/nonprod/local-ci-slot-resources.json
@@ -3,6 +3,12 @@
   "builderPolicy": {
     "version": 2,
     "memoryBytes": 17179869184,
+    "admissionReserveBytes": 10737418240,
+    "admissionCalibration": {
+      "version": 1,
+      "observedHighWaterBytes": 8589934592,
+      "safetyMarginBytes": 2147483648
+    },
     "cpuQuota": 800000,
     "cpuPeriod": 100000,
     "maxParallelism": 4

--- a/scripts/local-ci-pool-policy.test.mjs
+++ b/scripts/local-ci-pool-policy.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
   LOCAL_CI_POOL_CONFIG_KEY,
   localCiBuildHeadroomCapacity,
+  localCiBuilderAdmissionReserveBytes,
   localCiHostStageHeadroomCapacity,
   loadLocalCiPoolConfig,
   resolveLocalCiPoolPolicy,
@@ -34,6 +36,11 @@ const PILOT_CONFIG = Object.freeze({
     evidenceMismatchTolerance: 0,
   },
 });
+
+const SLOT_RESOURCES = JSON.parse(readFileSync(new URL(
+  "../apps/web/lib/nonprod/local-ci-slot-resources.json",
+  import.meta.url,
+), "utf8"));
 
 test("uses one versioned PlatformConfig key and defaults absent policy to singleton", () => {
   assert.equal(LOCAL_CI_POOL_CONFIG_KEY, "local_ci.sandbox_pool");
@@ -99,7 +106,7 @@ test("admission reserves the canonical bounded-build memory above the host safet
     host: {
       ...SAFE_HOST,
       availableMemoryBytes: 11 * 1024 ** 3,
-      dockerAvailableMemoryBytes: 11 * 1024 ** 3,
+      dockerAvailableMemoryBytes: 9 * 1024 ** 3,
       builderMemoryUsageBytes: [0, 0],
     },
     manifestSlotCount: 2,
@@ -110,6 +117,33 @@ test("admission reserves the canonical bounded-build memory above the host safet
   assert.equal(resolved.effectiveCapacity, 0);
   assert.equal(resolved.rollbackReason, "host-build-headroom-low");
   assert.deepEqual(resolved.slotKeys, []);
+});
+
+test("admission uses the calibrated build high-water reserve without weakening the builder ceiling", () => {
+  const gib = 1024 ** 3;
+  const resolved = resolveLocalCiPoolPolicy({
+    configValue: {
+      ...PILOT_CONFIG,
+      requestedCapacity: 1,
+      ceilings: {
+        ...PILOT_CONFIG.ceilings,
+        minAvailableMemoryBytes: 8 * gib,
+      },
+    },
+    host: {
+      ...SAFE_HOST,
+      availableMemoryBytes: 24 * gib,
+      dockerAvailableMemoryBytes: 12 * gib,
+      builderMemoryUsageBytes: [0, 0],
+    },
+    manifestSlotCount: 2,
+    reserveAdmissionHeadroom: true,
+  });
+
+  assert.equal(resolved.hostSafeCapacity, 1);
+  assert.equal(resolved.effectiveCapacity, 1);
+  assert.equal(resolved.rollbackReason, "requested-singleton");
+  assert.deepEqual(resolved.slotKeys, ["slot-0"]);
 });
 
 test("admission reserves the host-native stage envelope above the safety floor", () => {
@@ -236,6 +270,32 @@ test("bounded-build headroom arithmetic fails closed for invalid resource policy
     dockerAvailableMemoryBytes: 11 * 1024 ** 3,
     builderMemoryUsageBytes: [0, 0],
   }), 0);
+});
+
+test("builder admission calibration is capped by and falls back to the hard ceiling", () => {
+  const gib = 1024 ** 3;
+  assert.equal(localCiBuilderAdmissionReserveBytes({
+    hardCeilingBytes: 16 * gib,
+    calibratedReserveBytes: 10 * gib,
+  }), 10 * gib);
+  assert.equal(localCiBuilderAdmissionReserveBytes({
+    hardCeilingBytes: 16 * gib,
+    calibratedReserveBytes: 20 * gib,
+  }), 16 * gib);
+  assert.equal(localCiBuilderAdmissionReserveBytes({
+    hardCeilingBytes: 16 * gib,
+    calibratedReserveBytes: Number.NaN,
+  }), 16 * gib);
+});
+
+test("builder admission calibration declares high-water plus margin below the hard ceiling", () => {
+  const builder = SLOT_RESOURCES.builderPolicy;
+  const calibration = builder.admissionCalibration;
+  assert.equal(
+    calibration.observedHighWaterBytes + calibration.safetyMarginBytes,
+    builder.admissionReserveBytes,
+  );
+  assert.ok(builder.admissionReserveBytes < builder.memoryBytes);
 });
 
 test("host-stage headroom arithmetic keeps the configured floor unconsumed", () => {


### PR DESCRIPTION
## Summary
- separate the BuildKit 16 GiB hard runtime ceiling from its 10 GiB admission reserve
- calibrate admission to an 8 GiB observed high-water envelope plus a 2 GiB safety margin
- fail closed to the hard ceiling whenever calibration is missing or invalid

## Verification
- 32/32 focused pool-policy, slot-manifest, and capacity-broker contracts pass
- style drift and diff checks pass
- pregate preflight: 37 guards clean (3 source-only environment skips)
- fresh high-assurance semantic receipt: reviewed, zero findings, infrastructure-inconclusive while local CI owns capacity, shadow mayPublish=true

## Governance
- BI-184D4DBD
- WC-6E3A60D0
- Exact commit: 2cd5bcbc8cc904dc50482fbe16a5153b00bf4857

The deployed 16 GiB admission reserve is the shared sandbox patient: it keeps all exact candidates queued before the correction can verify itself. The correction retains the 16 GiB runtime cap and changes only pre-admission reservation.

Local-CI-Override: install-bootstrap-recovery