### PR TITLE
fix: persist initial hospitality turn events

### DIFF
--- a/apps/web/lib/storefront/hospitality-service-turn-repository.server.test.ts
+++ b/apps/web/lib/storefront/hospitality-service-turn-repository.server.test.ts
@@ -46,7 +46,6 @@ describe("hospitality service turn repository", () => {
       version: 1,
       events: {
         create: {
-          organizationId: "org-1",
           idempotencyKey: "seat-booking-1",
           eventType: "stage-transition",
           fromStage: null,
@@ -60,6 +59,9 @@ describe("hospitality service turn repository", () => {
     expect(
       create.mock.calls[0][0].data.events.create.eventId,
     ).toMatch(/^HTE-/);
+    expect(
+      create.mock.calls[0][0].data.events.create,
+    ).not.toHaveProperty("organizationId");
   });
 
   it("returns the existing demand turn instead of creating a duplicate", async () => {

--- a/apps/web/lib/storefront/hospitality-service-turn-repository.server.ts
+++ b/apps/web/lib/storefront/hospitality-service-turn-repository.server.ts
@@ -123,10 +123,11 @@ export async function createHospitalityServiceTurn(
         startedAt: input.startedAt,
         expectedEndAt: input.expectedEndAt,
         version: 1,
+        // The nested relation inherits both serviceTurnId and organizationId
+        // from this parent. Supplying either relation scalar is invalid here.
         events: {
           create: {
             eventId: `HTE-${newId(12).toUpperCase()}`,
-            organizationId: input.organizationId,
             idempotencyKey: input.idempotencyKey,
             eventType: "stage-transition",
             fromStage: null,


### PR DESCRIPTION
## Summary

Allow the Restaurant host-stand seating command to create its initial hospitality service-turn event atomically. Prisma already supplies both relation scalars for this nested write; sending `organizationId` again caused the live command to be rejected before any state changed.

## Changes

- Keep `organizationId` on the parent hospitality service turn.
- Omit the inherited relation scalar from the nested initial event payload.
- Add a regression assertion that the nested payload does not contain `organizationId`.

## Test plan

- [x] Focused repository tests pass: 5 tests.
- [x] Exact merged-tree local CI passed: policy guards, Prisma generation and migrations, typecheck, exhaustive Vitest, production Docker build/import, and clean lease release.
- [x] Fresh exact-tree semantic review returned zero findings; infrastructure deferred the reviewer branch and shadow policy permitted publication.
- [x] Canonical live reproduction confirmed the prior failure was customer-safe: the command was rejected and no partial state changed.

## Related work

- BI-9257B747
- WC-66EDAC91

## Overlap sweep

No open PR duplicates this fix. A broader Restaurant acceptance branch has explicitly deferred to this PR and will drop its overlapping hunk after protected merge.

## Notes for the reviewer

This is a two-file persistence-boundary repair. It does not change the schema, authorization, route, UI, or service-turn transition behavior.

Process-Spine-Decision: reuse the canonical hospitality service-turn repository and governed pregate; no parallel persistence path
Design-Grounding-Decision: grounded in the live Prisma nested-create rejection and the existing composite parent-child relation
Docs-Impact-Decision: no user-facing or operator contract changes; live acceptance follows deployment
Local-CI-Evidence: cmspsayyq078y01moodmioovo (fix/restaurant-service-turn-nested-event@c60714fcc6d6677c31a51361de4367aa3900c60a)
