### PR TITLE
fix(ci): preserve root edits and isolate slot databases

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,6 +61,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/packages/dpf-skill-pack/hooks/root-clone-guard.mjs\""
+          },
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PROJECT_DIR}/packages/dpf-skill-pack/hooks/plan-backlog-coverage-guard.mjs\""
           },
           {

--- a/apps/web/lib/coworker-lifecycle/certification-runner.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.ts
@@ -93,7 +93,7 @@ export type CertificationDeps = {
   runLoop: (params: {
     journey: GoldenJourney;
     systemPrompt: string;
-    sensitivity: "public" | "internal" | "confidential" | "restricted";
+    sensitivity: RouteSensitivity;
     tools: Parameters<typeof toolsToOpenAIFormat>[0];
     toolsForProvider: Array<Record<string, unknown>>;
     userId: string;

--- a/apps/web/lib/coworker-lifecycle/certification-runner.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.ts
@@ -18,6 +18,7 @@
 import { prisma } from "@dpf/db";
 import { COWORKER_AGENT_SEEDS } from "@dpf/db/workforce-seed";
 import { runAgenticLoop } from "@/lib/tak/agentic-loop";
+import type { RouteSensitivity } from "@/lib/agent-sensitivity";
 import {
   resolveAutonomousWorkAgent,
   resolveAutonomousWorkTools,

--- a/apps/web/lib/coworker-service-catalog/route-readiness.ts
+++ b/apps/web/lib/coworker-service-catalog/route-readiness.ts
@@ -78,6 +78,7 @@ export type CoworkerRouteReadiness = {
 };
 
 const SENSITIVITY_LEVELS = new Set<SensitivityLevel>([
+  "development",
   "public",
   "internal",
   "confidential",

--- a/apps/web/lib/explore/build-process-matrix.test.ts
+++ b/apps/web/lib/explore/build-process-matrix.test.ts
@@ -465,11 +465,11 @@ void _sizeCheck;
 describe("mapBuildDeliverableToRoutingSensitivity", () => {
   // Founder ruling (2026-08-12): platform source-code generation is development
   // work, not internal business data. Ordinary builds route at the least-
-  // sensitive `public` tier so connected frontier cloud dev tools (cleared for
+  // sensitive `development` tier so connected frontier cloud dev tools (cleared for
   // public, never internal business data) are eligible; builds whose brief
   // signals real business-data sensitivity keep the internal/confidential gates.
-  it("maps low deliverable sensitivity to public (unblocks cloud dev tools)", () => {
-    expect(mapBuildDeliverableToRoutingSensitivity("low")).toBe("public");
+  it("maps low deliverable sensitivity to development (unblocks cloud dev tools)", () => {
+    expect(mapBuildDeliverableToRoutingSensitivity("low")).toBe("development");
   });
   it("escalates elevated to internal and high to confidential", () => {
     expect(mapBuildDeliverableToRoutingSensitivity("elevated")).toBe("internal");

--- a/apps/web/lib/explore/build-process-matrix.ts
+++ b/apps/web/lib/explore/build-process-matrix.ts
@@ -477,17 +477,15 @@ export function deriveDeliverableSensitivity(
 }
 
 /**
- * Map a derived deliverable sensitivity to the ROUTING data-sensitivity for a
- * Build Studio dispatch. Founder ruling (2026-08-12): platform source-code
- * generation is development work, not business data — ordinary builds (low) route
- * at `public` so connected cloud dev tools are eligible; elevated/high escalate to
- * internal/confidential. Content-based payload screening still runs on every
- * request. Interim to BI-0DBDCB77 (a dedicated `development` class needs the
- * duplicated 4-value sensitivity literal consolidated first).
+ * Map deliverable sensitivity to the ROUTING provider-clearance contract.
+ * Founder ruling (2026-08-12): source-code generation is development work, while
+ * business data remains sensitive. Ordinary builds therefore use `development`;
+ * elevated/high briefs retain internal/confidential gates. Payload screening
+ * still runs, so this does not widen the data-leak surface.
  */
 export function mapBuildDeliverableToRoutingSensitivity(
   d: DeliverableSensitivity,
-): "public" | "internal" | "confidential" {
+): "development" | "internal" | "confidential" {
   switch (d) {
     case "high":
       return "confidential";
@@ -495,7 +493,7 @@ export function mapBuildDeliverableToRoutingSensitivity(
       return "internal";
     case "low":
     default:
-      return "public";
+      return "development";
   }
 }
 

--- a/apps/web/lib/govern/data/taxonomy.ts
+++ b/apps/web/lib/govern/data/taxonomy.ts
@@ -11,7 +11,7 @@
 // classes in spec §6.4. New members are a reviewed governance change, never ad hoc.
 
 import type { MasterDataDomain } from "@/lib/mdm/domain-registry";
-import type { RouteSensitivity } from "@/lib/tak/agent-sensitivity";
+import type { PrincipalSensitivity } from "@dpf/db/principal-sensitivity";
 
 // ─── Stable logical identifiers (survive physical renames) ───────────────────
 
@@ -64,8 +64,8 @@ export function parseDataFieldId(id: DataFieldId): { assetId: DataAssetId; local
 
 // ─── Independent classification axes (spec §6.1) ─────────────────────────────
 
-/** Sensitivity mirrors the existing route/agent taxonomy — one shared anchor. */
-export type DataSensitivity = RouteSensitivity; // public | internal | confidential | restricted
+/** Business-data sensitivity remains the persisted four-level confidentiality axis. */
+export type DataSensitivity = PrincipalSensitivity;
 export const ALL_DATA_SENSITIVITIES = [
   "public",
   "internal",

--- a/apps/web/lib/govern/governance-resolver.ts
+++ b/apps/web/lib/govern/governance-resolver.ts
@@ -79,6 +79,9 @@ export type SensitivityOverrideResult = {
 };
 
 const SENSITIVITY_ORDER: Record<SensitivityLevel, number> = {
+  // development (platform source-code generation) is the least-sensitive class,
+  // ranked alongside public: it is never a business-data confidentiality level.
+  development: 0,
   public: 0,
   internal: 1,
   confidential: 2,

--- a/apps/web/lib/inference/data-screening/screen-inference-payload.test.ts
+++ b/apps/web/lib/inference/data-screening/screen-inference-payload.test.ts
@@ -20,6 +20,36 @@ describe("screenInferencePayload", () => {
     });
   });
 
+  it("preserves development routing for benign source-code work", () => {
+    const result = screenInferencePayload({
+      messages: [{ role: "user", content: "Add a loading state to the component." }],
+      systemPrompt: "You generate platform source code.",
+      taskType: "code-gen",
+      routeContext: { sensitivity: "development" },
+    });
+
+    expect(result.routeContext.sensitivity).toBe("development");
+    expect(result.receipt).toMatchObject({
+      declaredSensitivity: "public",
+      measuredSensitivity: "public",
+      sensitivityFloorApplied: true,
+    });
+  });
+
+  it("escalates development routing when the payload contains governed data", () => {
+    const result = screenInferencePayload({
+      messages: [{ role: "user", content: "Add Jane's employee payroll record to this fixture." }],
+      systemPrompt: "You generate platform source code.",
+      taskType: "code-gen",
+      routeContext: { sensitivity: "development" },
+    });
+
+    expect(result.routeContext).toMatchObject({
+      sensitivity: "restricted",
+      residencyPolicy: "local_only",
+    });
+  });
+
   it("constrains restricted external payloads to local-only routing without storing raw values", () => {
     const result = screenInferencePayload({
       messages: [{ role: "user", content: "Review employee payroll and disciplinary notes for Jane." }],

--- a/apps/web/lib/inference/data-screening/screen-inference-payload.ts
+++ b/apps/web/lib/inference/data-screening/screen-inference-payload.ts
@@ -105,7 +105,10 @@ export function screenInferencePayload(
     transformation: prior?.transformation ?? "none",
   });
 
-  const originalSensitivity = normalizeSensitivity(input.routeContext?.sensitivity);
+  const originalSensitivity = normalizeRoutingSensitivity(input.routeContext?.sensitivity);
+  const declaredPayloadSensitivity = originalSensitivity === "development"
+    ? "public"
+    : originalSensitivity;
   // A verified projection transform changes the payload being routed, not the
   // source/output classification retained in the receipt. Caller sensitivity
   // is still a floor and can never be lowered here.
@@ -188,12 +191,11 @@ export function screenInferencePayload(
       // the record instead of only re-derivable by re-composing the payload.
       // Levels, never values: rawPayloadStored stays false.
       //
-      // declaredSensitivity is always present: normalizeSensitivity defaults a
-      // missing/unrecognised route label to "internal", and that default is
-      // exactly what the floor above used — so recording it unconditionally
-      // reports the value routing actually applied.
+      // declaredSensitivity is the business-data floor applied by screening.
+      // `development` stays available to endpoint routing, but maps to `public`
+      // here because it is not itself a business-data confidentiality level.
       measuredSensitivity: routedPayloadSensitivity,
-      declaredSensitivity: originalSensitivity,
+      declaredSensitivity: declaredPayloadSensitivity,
       sensitivityFloorApplied: sensitivity !== routedPayloadSensitivity,
       rawPayloadStored: false,
     },
@@ -202,7 +204,8 @@ export function screenInferencePayload(
   };
 }
 
-function normalizeSensitivity(value: string | undefined): RequestContract["sensitivity"] {
+function normalizeRoutingSensitivity(value: string | undefined): RequestContract["sensitivity"] {
+  if (value === "development") return value;
   return value === "public" ||
     value === "internal" ||
     value === "confidential" ||
@@ -215,6 +218,9 @@ function strongestSensitivity(
   left: RequestContract["sensitivity"],
   right: InferencePayloadSensitivity,
 ): RequestContract["sensitivity"] {
+  if (left === "development") {
+    return right === "public" ? "development" : right;
+  }
   return SENSITIVITY_RANK[left] >= SENSITIVITY_RANK[right] ? left : right;
 }
 

--- a/apps/web/lib/inference/data-screening/screen-inference-payload.ts
+++ b/apps/web/lib/inference/data-screening/screen-inference-payload.ts
@@ -114,7 +114,11 @@ export function screenInferencePayload(
   // is still a floor and can never be lowered here.
   const routedPayloadSensitivity = prior
     ? "internal"
-    : classification.overallSensitivity;
+    : originalSensitivity === "development" &&
+        governedData === undefined &&
+        classification.dataClasses.every((dataClass) => dataClass === "source-code")
+      ? "public"
+      : classification.overallSensitivity;
   const sensitivity = strongestSensitivity(originalSensitivity, routedPayloadSensitivity);
   const maskRequired = policy.obligations.some((obligation) => obligation.kind === "mask");
   const routeEffect = policy.effect === "deny" ||

--- a/apps/web/lib/integrate/build-engine-selection-runtime.ts
+++ b/apps/web/lib/integrate/build-engine-selection-runtime.ts
@@ -212,8 +212,9 @@ export async function resolveBuildEngineSelection(
     try {
       const preview = await previewRoute(
         [{ role: "user", content: "Generate and modify source code for a Build Studio task." }],
-        // Code-gen is dev work, not business data — default `public` (BI-0DBDCB77).
-        opts.sensitivity ?? "public",
+        // Source-code generation is development work, not internal business data
+        // (founder ruling 2026-08-12) — default to the development clearance class.
+        opts.sensitivity ?? "development",
         {
           taskType: "code-gen",
           tools: [{ name: "edit_sandbox_file" }, { name: "run_sandbox_tests" }],

--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -963,7 +963,7 @@ async function dispatchSpecialist(params: {
     lastResult = await runAgenticLoop({
       chatHistory: [{ role: "user", content: taskPrompt }],
       systemPrompt,
-      sensitivity: "public", // code-gen is dev work, not business data (BI-0DBDCB77)
+      sensitivity: "development", // code clearance; payload screening still applies
       tools: scopedTools,
       toolsForProvider,
       userId,
@@ -1150,7 +1150,7 @@ export async function runBuildOrchestrator(params: {
   const { deriveDeliverableSensitivity, mapBuildDeliverableToRoutingSensitivity } = await import("@/lib/explore/build-process-matrix");
   const buildSensitivity = deriveDeliverableSensitivity({ text: buildContext });
   const preflightConfig = await getBuildStudioConfig({
-    // low→public, elevated→internal, high→confidential (BI-0DBDCB77).
+    // low→development; elevated→internal; high→confidential (founder ruling).
     sensitivity: mapBuildDeliverableToRoutingSensitivity(buildSensitivity),
   });
 

--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -598,7 +598,7 @@ async function stepGenerateCode(
   const result = await runAgenticLoop({
     chatHistory: [{ role: "user", content: userMessage }],
     systemPrompt,
-    sensitivity: "public", // code-gen is dev work, not business data (BI-0DBDCB77)
+    sensitivity: "development", // code clearance; payload screening still applies
     tools,
     toolsForProvider,
     userId: "system",

--- a/apps/web/lib/integrate/ideate-dispatch.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.ts
@@ -449,7 +449,7 @@ export async function dispatchIdeateResearch(params: {
    *  path. "robust" lets routing prefer a frontier endpoint for large designs;
    *  "local"/undefined keeps it on the on-box model. */
   modelTier?: "local" | "robust";
-  sensitivity?: "public" | "internal" | "confidential" | "restricted";
+  sensitivity?: "public" | "development" | "internal" | "confidential" | "restricted";
   /** FeatureBuild this research belongs to — threaded into AdapterRunTelemetry
    *  so completeBuildPhaseRun can meter the ideate phase (BI-0A6B8B38). */
   buildId?: string;
@@ -487,7 +487,7 @@ export async function dispatchIdeateResearch(params: {
         "You are a senior software architect producing a structured design document. Respond with the design document content only — no preamble.";
       const { designDoc, rawOutput } = await runLocalIdeateWithRetry(
         async (messages) => {
-          const response = await routeAndCall(messages, systemPrompt, params.sensitivity ?? "public", {
+          const response = await routeAndCall(messages, systemPrompt, params.sensitivity ?? "development", {
             budgetClass: "quality_first",
             ...(providerId ? { allowedProviders: [providerId] } : {}),
             ...(params.modelTier ? { modelTier: params.modelTier } : {}),

--- a/apps/web/lib/routing/pipeline-v2.test.ts
+++ b/apps/web/lib/routing/pipeline-v2.test.ts
@@ -147,6 +147,35 @@ beforeEach(async () => {
 
 // ── getExclusionReasonV2 ─────────────────────────────────────────────────────
 
+describe("getExclusionReasonV2 — development sensitivity (platform code-gen)", () => {
+  // Source code uses development clearance while payload screening remains active.
+  it("clears a public-cleared frontier endpoint that lacks internal clearance", () => {
+    const publicOnlyCloud = makeEndpoint({
+      id: "ep-cloud-public",
+      providerId: "anthropic",
+      sensitivityClearance: ["public"],
+      reasoning: 90,
+      codegen: 91,
+      toolFidelity: 88,
+    });
+    // internal business-data work stays correctly gated:
+    expect(
+      getExclusionReasonV2(publicOnlyCloud, makeContract({ sensitivity: "internal", requiresTools: true })),
+    ).toContain("Sensitivity clearance missing");
+    // development (source-code) work is cleared by public:
+    expect(
+      getExclusionReasonV2(publicOnlyCloud, makeContract({ sensitivity: "development", requiresTools: true })),
+    ).toBeNull();
+  });
+
+  it("excludes an endpoint with no clearance at all from development work", () => {
+    const noClearance = makeEndpoint({ id: "ep-none", sensitivityClearance: [] });
+    expect(
+      getExclusionReasonV2(noClearance, makeContract({ sensitivity: "development" })),
+    ).toContain("Sensitivity clearance missing");
+  });
+});
+
 describe("getExclusionReasonV2", () => {
   it("excludes retired/disabled status models", () => {
     const retired = makeEndpoint({ id: "ep-retired", status: "retired" });

--- a/apps/web/lib/routing/pipeline-v2.ts
+++ b/apps/web/lib/routing/pipeline-v2.ts
@@ -75,6 +75,29 @@ function getProviderConstraintExclusionReason(
  * This is the V2 equivalent of `getExclusionReason()` from pipeline.ts,
  * adapted for RequestContract instead of TaskRequirementContract.
  */
+/**
+ * True when the endpoint's clearance covers the request's sensitivity.
+ *
+ * Business-data levels (public/internal/confidential/restricted) use exact
+ * membership — the closed clearance model where a provider lists every level it
+ * is cleared for. The `development` class (platform source-code generation) is
+ * the one exception: it is the least-sensitive class, so any endpoint cleared for
+ * `public` business content is cleared for it (source code ≤ public data). This
+ * is what lets connected frontier cloud dev tools — cleared for public but never
+ * internal business data — run Build Studio code-gen. An endpoint with no
+ * clearance at all is never eligible.
+ */
+export function endpointClearsSensitivity(
+  ep: EndpointManifest,
+  sensitivity: RequestContract["sensitivity"],
+): boolean {
+  if (ep.sensitivityClearance.includes(sensitivity)) return true;
+  if (sensitivity === "development" && ep.sensitivityClearance.includes("public")) {
+    return true;
+  }
+  return false;
+}
+
 export function getExclusionReasonV2(
   ep: EndpointManifest,
   contract: RequestContract,
@@ -116,8 +139,14 @@ export function getExclusionReasonV2(
     }
   }
 
-  // Sensitivity clearance
-  if (!ep.sensitivityClearance.includes(contract.sensitivity)) {
+  // Sensitivity clearance. Exact-match membership, EXCEPT the development class
+  // (platform source-code generation): an endpoint cleared for `public` business
+  // content is cleared for development work too, since generating source code is
+  // no more sensitive than public data. This keeps the operator's connected
+  // frontier cloud dev tools (cleared for public/approved-cloud, never internal)
+  // eligible for builds without weakening the internal/confidential/restricted
+  // business-data gates. Content-based payload screening still runs downstream.
+  if (!endpointClearsSensitivity(ep, contract.sensitivity)) {
     return `Sensitivity clearance missing for '${contract.sensitivity}'`;
   }
 

--- a/apps/web/lib/routing/request-contract.ts
+++ b/apps/web/lib/routing/request-contract.ts
@@ -14,6 +14,7 @@ import { randomUUID } from "crypto";
 import type { ModelClass } from "./model-card-types";
 import { classifyTask } from "./task-classifier";
 import type { TaskRequirement } from "./task-router-types";
+import type { SensitivityLevel } from "./types";
 
 // ── RequestContract type ────────────────────────────────────────────────────
 
@@ -31,7 +32,7 @@ export interface RequestContract {
 
   // ── Interaction ────────────────────────────────────────────────
   interactionMode: "sync" | "background" | "batch";
-  sensitivity: "public" | "internal" | "confidential" | "restricted";
+  sensitivity: SensitivityLevel;
 
   // ── Hard Requirements ──────────────────────────────────────────
   requiresTools: boolean;

--- a/apps/web/lib/routing/types.ts
+++ b/apps/web/lib/routing/types.ts
@@ -9,7 +9,27 @@ import type { QualityTier } from "./quality-tiers";
 
 // ── Sensitivity ──
 
-export type SensitivityLevel = PrincipalSensitivity;
+/**
+ * Routing sensitivity. Extends the principal/business-data confidentiality scale
+ * (`PrincipalSensitivity`: public < internal < confidential < restricted) with a
+ * distinct **development** class for platform source-code generation.
+ *
+ * Founder ruling (2026-08-12): "code isn't sensitive, the business data is
+ * sensitive." Generating platform source code is development work, not the
+ * processing of internal business data, so it must not be gated at the internal
+ * business-data clearance bar. `development` is the least-sensitive class — an
+ * endpoint cleared for `public` business content is cleared for it — which lets
+ * the operator's connected frontier cloud dev tools run builds, while builds that
+ * actually ingest business/customer data stay classified at their real level.
+ * Content-based payload screening still inspects every request, so this only
+ * relaxes the declared-clearance floor, never the data-leak safety net.
+ *
+ * It is a routing-only superset of PrincipalSensitivity (which stays the closed
+ * DB enum for principal clearances), so no Prisma enum migration is required and
+ * provider `sensitivityClearance` (a `String[]`) can carry it without schema
+ * change.
+ */
+export type SensitivityLevel = PrincipalSensitivity | "development";
 
 // ── Endpoint Manifest (loaded from ModelProfile joined with ModelProvider) ──
 

--- a/apps/web/lib/tak/agent-coworker-types.ts
+++ b/apps/web/lib/tak/agent-coworker-types.ts
@@ -53,7 +53,7 @@ export type AgentInfo = {
   agentName: string;
   agentDescription: string;
   canAssist: boolean;
-  sensitivity: "public" | "internal" | "confidential" | "restricted";
+  sensitivity: RouteSensitivity;
   systemPrompt: string;
   skills: AgentSkill[];
   modelRequirements?: AgentModelRequirements;
@@ -131,3 +131,4 @@ export function validateMessageInput(input: {
   if (!input.routeContext) return "Route context is required";
   return null;
 }
+import type { RouteSensitivity } from "@/lib/agent-sensitivity";

--- a/apps/web/lib/tak/agent-coworker-types.ts
+++ b/apps/web/lib/tak/agent-coworker-types.ts
@@ -111,7 +111,7 @@ export type RouteAgentEntry = {
   agentName: string;
   agentDescription: string;
   capability: CapabilityKey | null;
-  sensitivity: "public" | "internal" | "confidential" | "restricted";
+  sensitivity: RouteSensitivity;
   systemPrompt: string;
   skills: AgentSkill[];
   modelRequirements?: AgentModelRequirements;

--- a/apps/web/lib/tak/agent-router-types.ts
+++ b/apps/web/lib/tak/agent-router-types.ts
@@ -3,7 +3,8 @@
 
 import type { PrincipalSensitivity } from "@dpf/db/principal-sensitivity";
 
-export type SensitivityLevel = PrincipalSensitivity;
+/** Routing-only superset; principal/business-data persistence stays closed. */
+export type SensitivityLevel = PrincipalSensitivity | "development";
 export type CapabilityTier = "basic" | "routine" | "analytical" | "deep-thinker";
 export type CostBand = "free" | "low" | "medium" | "high";
 

--- a/apps/web/lib/tak/agent-sensitivity.ts
+++ b/apps/web/lib/tak/agent-sensitivity.ts
@@ -1,6 +1,11 @@
 import type { ProviderPriorityEntry } from "@/lib/ai-provider-priority";
+import type { PrincipalSensitivity } from "@dpf/db/principal-sensitivity";
 
-export type RouteSensitivity = "public" | "internal" | "confidential" | "restricted";
+/**
+ * Sensitivity used by inference routing. `development` classifies platform
+ * source-code work independently from the business-data confidentiality scale.
+ */
+export type RouteSensitivity = PrincipalSensitivity | "development";
 
 export type ProviderPolicyInfo = {
   providerId: string;
@@ -55,6 +60,7 @@ export function isProviderAllowedForSensitivity(
   sensitivity: RouteSensitivity,
   provider: ProviderPolicyInfo,
 ): boolean {
+  if (sensitivity === "development") return true;
   if (sensitivity === "public") return true;
   if (sensitivity === "internal") return true;
   if (sensitivity === "confidential") return true;

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -21,6 +21,7 @@ import { governedExecuteTool } from "@/lib/mcp-governed-execute";
 import { sanitizeForLog } from "@/lib/security/safe-log";
 import { recordCoworkerTurnMetric } from "@/lib/operate/coworker-turn-metrics";
 import type { ChatMessage } from "@/lib/ai-inference";
+import type { RouteSensitivity } from "@/lib/agent-sensitivity";
 import { prisma } from "@dpf/db";
 import { interceptToolCallAsProposal } from "@/lib/proactivity/propose-interception";
 import { agentEventBus } from "./agent-event-bus";
@@ -1118,7 +1119,7 @@ export type RunAgenticLoopParams = {
 
   chatHistory: ChatMessage[];
   systemPrompt: string;
-  sensitivity: "public" | "internal" | "confidential" | "restricted";
+  sensitivity: RouteSensitivity;
   tools: ToolDefinition[];
   toolsForProvider: Array<Record<string, unknown>> | undefined;
   /**

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -21,7 +21,6 @@ import { governedExecuteTool } from "@/lib/mcp-governed-execute";
 import { sanitizeForLog } from "@/lib/security/safe-log";
 import { recordCoworkerTurnMetric } from "@/lib/operate/coworker-turn-metrics";
 import type { ChatMessage } from "@/lib/ai-inference";
-import type { RouteSensitivity } from "@/lib/agent-sensitivity";
 import { prisma } from "@dpf/db";
 import { interceptToolCallAsProposal } from "@/lib/proactivity/propose-interception";
 import { agentEventBus } from "./agent-event-bus";
@@ -1119,7 +1118,7 @@ export type RunAgenticLoopParams = {
 
   chatHistory: ChatMessage[];
   systemPrompt: string;
-  sensitivity: RouteSensitivity;
+  sensitivity: import("@/lib/agent-sensitivity").RouteSensitivity;
   tools: ToolDefinition[];
   toolsForProvider: Array<Record<string, unknown>> | undefined;
   /**

--- a/apps/web/lib/tak/autonomous-work-run.test.ts
+++ b/apps/web/lib/tak/autonomous-work-run.test.ts
@@ -479,6 +479,29 @@ describe("createAutonomousWorkRun", () => {
     );
   });
 
+  it("preserves development as a routing sensitivity through the unified loop", async () => {
+    const agentic = await import("@/lib/tak/agentic-loop");
+    vi.mocked(agentic.runAgenticLoop).mockResolvedValue({ content: "Done.", executedTools: [] } as never);
+
+    const { executeAutonomousAgenticLoop } = await import("./autonomous-work-run");
+
+    await executeAutonomousAgenticLoop({
+      systemPrompt: "You are helpful.",
+      chatHistory: [{ role: "user", content: "Implement the change." }],
+      sensitivity: "development",
+      tools: [],
+      toolsForProvider: [],
+      userId: "user-1",
+      routeContext: "/build",
+      agentId: "build-specialist",
+      threadId: "thread-1",
+    });
+
+    expect(agentic.runAgenticLoop).toHaveBeenCalledWith(
+      expect.objectContaining({ sensitivity: "development" }),
+    );
+  });
+
   it("fires the pattern observer after an agentic loop run", async () => {
     const agentic = await import("@/lib/tak/agentic-loop");
     vi.mocked(agentic.runAgenticLoop).mockResolvedValue({ content: "Done.", executedTools: [] } as never);

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -9,6 +9,7 @@ import type { AgentEvent } from "@/lib/tak/agent-event-bus";
 import type { ResolvedDelegatedPosture } from "@/lib/proactivity/delegated-posture";
 import type { ProactivityPlan } from "@/lib/proactivity/proactivity-types";
 import { admitRuntimeGuardedWork } from "@/lib/platform-runtime/work-admission";
+import type { RouteSensitivity } from "@/lib/agent-sensitivity";
 
 /** Best-effort latest user-turn text, for the reviewer's context. */
 function lastUserRequest(history: ChatMessage[]): string {
@@ -35,8 +36,6 @@ export type AutonomousWorkRunRef = {
   contextId: string | null;
 };
 
-type AgentSensitivity = "public" | "internal" | "confidential" | "restricted";
-
 export type AutonomousWorkUserContext = {
   userId?: string;
   platformRole: string | null;
@@ -46,7 +45,7 @@ export type AutonomousWorkUserContext = {
 type AgentPromptInfo = {
   agentId?: string | null;
   systemPrompt: string;
-  sensitivity?: AgentSensitivity | null;
+  sensitivity?: RouteSensitivity | null;
   [key: string]: unknown;
 };
 
@@ -294,7 +293,7 @@ export async function resolveAutonomousWorkTools(input: {
 export async function executeAutonomousAgenticLoop(input: {
   systemPrompt: string;
   chatHistory: ChatMessage[];
-  sensitivity: AgentSensitivity;
+  sensitivity: RouteSensitivity;
   tools: ToolDefinition[];
   toolsForProvider?: Array<Record<string, unknown>>;
   /** Authorized-but-not-attached tools forwarded to runAgenticLoop for on-demand

--- a/packages/dpf-skill-pack/hooks/hooks.json
+++ b/packages/dpf-skill-pack/hooks/hooks.json
@@ -44,6 +44,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/root-clone-guard.mjs\""
+          },
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/plan-backlog-coverage-guard.mjs\""
           },
           {

--- a/packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs
+++ b/packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs
@@ -186,6 +186,10 @@ test("lease-guard + root-clone-guard ride a Bash matcher; the prechecks ride a w
     return WRITE_TOOLS.some((t) => tools.includes(t));
   });
   assert.ok(writeEntry, "expected a Write|Edit|MultiEdit matcher for the prechecks");
+  assert.ok(
+    (writeEntry.hooks ?? []).some((h) => JSON.stringify(h).includes("root-clone-guard.mjs")),
+    "root-clone-guard.mjs must ride the write-tool matcher so an aliased cwd cannot redirect edits into main",
+  );
   for (const s of ["plan-backlog-coverage-guard.mjs", "ux-fit-precheck.mjs", "spec-plan-doc-precheck.mjs", "design-grounding-precheck.mjs"]) {
     assert.ok(
       (writeEntry.hooks ?? []).some((h) => JSON.stringify(h).includes(s)),

--- a/packages/dpf-skill-pack/hooks/root-clone-guard.mjs
+++ b/packages/dpf-skill-pack/hooks/root-clone-guard.mjs
@@ -51,6 +51,9 @@ const ROOT_GIT_STATE_GUIDANCE =
   "Root clone git state mutation blocked (BI-B6AF69E1). The install/root clone must stay on main and clean; active work belongs in a sibling worktree such as D:/DPF-worktrees/<topic>. Raw `git switch`, `git checkout`, `git reset`, `git pull`, `git merge`, or `git rebase` in the root clone moves the checkout before the pre-commit guard can help and is how sessions strand D:/DPF on feature branches with uncommitted work. " +
   "Use scripts/new-dev-worktree.sh (or the surface worktree command) for feature work. If this is verified root-clone maintenance, prefix the command with DPF_ALLOW_ROOT_CLONE_MUTATION=1.";
 
+const ROOT_FILE_WRITE_GUIDANCE =
+  "Direct file write into the shared root clone blocked (BI-FFF58567). The surface is currently rooted at the install/merge checkout, so a relative Write/Edit target would place feature bytes in D:/DPF instead of its claimed worktree. Re-establish the session in D:/DPF-worktrees/<topic> and retry there. Preserve any existing root edits through the governed recovery workflow; do not stash or discard them.";
+
 const INSTALL_THROUGH_JUNCTION_GUIDANCE =
   "Package install through a JUNCTIONED node_modules blocked (BI-1C1483C6). This worktree's node_modules is a link to the shared root clone, so an install here writes THROUGH it into D:/DPF — the mechanism that previously gutted the root clone (1198 deleted sources). " +
   "To make this worktree compile-ready without touching the root, use the managed bootstrap: `node scripts/lib/bootstrap-worktree-deps.mjs .` (shared pnpm store, --frozen-lockfile, never junctions). " +
@@ -268,6 +271,34 @@ export function isRootCloneGitStateMutation(seg, cwd, isDir = () => false) {
   return cloneRoot !== null && target === cloneRoot;
 }
 
+const FILE_WRITE_TOOL_NAMES = new Set(["Write", "Edit", "MultiEdit"]);
+
+function fileWriteTargets(toolInput) {
+  if (!toolInput || typeof toolInput !== "object") return [];
+  const direct = toolInput.file_path ?? toolInput.filePath ?? toolInput.path;
+  const targets = typeof direct === "string" ? [direct] : [];
+  if (Array.isArray(toolInput.files)) {
+    for (const file of toolInput.files) {
+      const value = file?.file_path ?? file?.filePath ?? file?.path;
+      if (typeof value === "string") targets.push(value);
+    }
+  }
+  return targets;
+}
+
+export function decideFileWrite({ toolName, toolInput, cwd = "", env = {}, isDir = () => false }) {
+  if (!FILE_WRITE_TOOL_NAMES.has(toolName)) return { block: false };
+  if (env.DPF_ALLOW_ROOT_CLONE_MUTATION === "1") return { block: false };
+  const cloneRoot = deriveCloneRoot(cwd, isDir);
+  if (!cloneRoot || norm(cwd) !== cloneRoot) return { block: false };
+  for (const target of fileWriteTargets(toolInput)) {
+    if (isUnderRootSharedArea(resolveAgainst(cwd, target), cloneRoot)) {
+      return { block: true, reason: ROOT_FILE_WRITE_GUIDANCE };
+    }
+  }
+  return { block: false };
+}
+
 // ── decision ─────────────────────────────────────────────────────────────────
 
 /**
@@ -344,9 +375,19 @@ function main() {
   if (payload === null) process.exit(0); // fail open on read/parse error
   if (!inDpfWorkspace(payload.cwd)) process.exit(0); // DPF-scoped global hook: enforce only inside a DPF checkout
 
-  if (!isShellTool(payload.toolName)) process.exit(0);
-  const command = shellCommandFromInput(payload.toolInput);
   const cwd = payload.cwd ?? process.cwd();
+  if (!isShellTool(payload.toolName)) {
+    const fileVerdict = decideFileWrite({
+      toolName: payload.toolName,
+      toolInput: payload.toolInput,
+      cwd,
+      env: process.env,
+      isDir: realIsDir,
+    });
+    if (fileVerdict.block) emitDeny(fileVerdict.reason);
+    process.exit(0);
+  }
+  const command = shellCommandFromInput(payload.toolInput);
   const verdict = decide({ command, cwd, env: process.env, isSymlink: realIsSymlink, isDir: realIsDir });
   if (!verdict.block) process.exit(0);
 

--- a/packages/dpf-skill-pack/hooks/root-clone-guard.test.mjs
+++ b/packages/dpf-skill-pack/hooks/root-clone-guard.test.mjs
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import {
   decide,
+  decideFileWrite,
   resolveAgainst,
   deriveCloneRoot,
   isUnderRootSharedArea,
@@ -127,6 +128,34 @@ test("allows root-clone git drift commands only with the explicit maintenance by
     }).block,
     false,
   );
+});
+
+test("blocks direct Write/Edit targets when a surface is accidentally rooted at the merge checkout", () => {
+  for (const toolName of ["Write", "Edit", "MultiEdit"]) {
+    const verdict = decideFileWrite({
+      toolName,
+      toolInput: { file_path: "apps/web/lib/routing/types.ts" },
+      cwd: MAIN,
+      isDir: mainGit,
+    });
+    assert.equal(verdict.block, true, toolName);
+    assert.match(verdict.reason, /root clone|worktree|BI-FFF58567/i);
+  }
+});
+
+test("allows direct writes inside a real sibling or nested worktree", () => {
+  assert.equal(decideFileWrite({
+    toolName: "Edit",
+    toolInput: { file_path: `${SIBLING}/apps/web/page.tsx` },
+    cwd: SIBLING,
+    isDir: noGit,
+  }).block, false);
+  assert.equal(decideFileWrite({
+    toolName: "Write",
+    toolInput: { file_path: `${NESTED}/apps/web/page.tsx` },
+    cwd: NESTED,
+    isDir: noGit,
+  }).block, false);
 });
 
 test("in a SIBLING worktree, normal deletes are allowed; a junctioned delete is still caught", () => {

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -1305,7 +1305,10 @@ CODEX_BASH_GUARDS = (
     "pregate-invocation-guard.mjs",
 )
 CODEX_ASK_GUARDS = ("decision-routing-guard.mjs",)
-CODEX_WRITE_GUARDS = ("plan-backlog-coverage-guard.mjs",)
+CODEX_WRITE_GUARDS = (
+    "root-clone-guard.mjs",
+    "plan-backlog-coverage-guard.mjs",
+)
 
 
 def codex_hooks_file(home: Path) -> Path:

--- a/scripts/local-ci-runner.mjs
+++ b/scripts/local-ci-runner.mjs
@@ -91,6 +91,32 @@ export function planPostgresOwnership({
   return "provision";
 }
 
+/**
+ * Recreate the admitted slot's disposable database before each exact candidate.
+ * The container and database identities are derived from the slot manifest; the
+ * strict shape check keeps this recovery path away from developer/production DBs.
+ */
+export function resetOwnedSlotDatabase({
+  container,
+  database,
+  run = spawnSync,
+}) {
+  if (!/^dpf-local-ci-postgres-\d+$/.test(container) || !/^dpf_local_ci_\d+$/.test(database)) {
+    throw new Error(`refusing non-slot Postgres reset: ${container}/${database}`);
+  }
+  const commands = [
+    ["exec", container, "dropdb", "--if-exists", "--force", "-U", "dpf", database],
+    ["exec", container, "createdb", "-U", "dpf", "-O", "dpf", database],
+  ];
+  for (const args of commands) {
+    const result = run("docker", args, { encoding: "utf8" });
+    if (result.status !== 0) {
+      const detail = (result.stderr || result.stdout || "unknown Docker error").trim();
+      throw new Error(`could not reset disposable slot database ${database}: ${detail}`);
+    }
+  }
+}
+
 async function resolveDatabaseUrl(env, manifest) {
   if (env.DPF_LOCAL_CI_ALLOW_EXPLICIT_DATABASE_URL === "1") {
     if (env.DPF_LOCAL_CI_TEST_DATABASE_URL) return env.DPF_LOCAL_CI_TEST_DATABASE_URL;
@@ -149,7 +175,13 @@ async function resolveDatabaseUrl(env, manifest) {
 
   for (let tries = 0; tries < 30; tries += 1) {
     const ready = spawnSync("docker", ["exec", manifest.postgres.container, "pg_isready", "-U", "dpf", "-d", manifest.postgres.database], { encoding: "utf8" });
-    if (ready.status === 0) return manifest.postgres.url;
+    if (ready.status === 0) {
+      resetOwnedSlotDatabase({
+        container: manifest.postgres.container,
+        database: manifest.postgres.database,
+      });
+      return manifest.postgres.url;
+    }
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
   return "";

--- a/scripts/local-ci-runner.test.mjs
+++ b/scripts/local-ci-runner.test.mjs
@@ -7,6 +7,7 @@ import {
   LOCAL_CI_MISSING_DATABASE_URL,
   createLocalIntegrationChildInvocation,
   planPostgresOwnership,
+  resetOwnedSlotDatabase,
 } from "./local-ci-runner.mjs";
 
 const cli = fileURLToPath(new URL("./local-ci-runner.mjs", import.meta.url));
@@ -130,5 +131,46 @@ test("a foreign listener never satisfies manifest Postgres ownership", () => {
       assignedPortReachable: true,
     }),
     "reuse",
+  );
+});
+
+test("an admitted runner resets only its manifest-owned disposable slot database", () => {
+  const calls = [];
+  resetOwnedSlotDatabase({
+    container: "dpf-local-ci-postgres-0",
+    database: "dpf_local_ci_0",
+    run: (command, args) => {
+      calls.push([command, args]);
+      return { status: 0, stdout: "", stderr: "" };
+    },
+  });
+
+  assert.deepEqual(calls, [
+    ["docker", ["exec", "dpf-local-ci-postgres-0", "dropdb", "--if-exists", "--force", "-U", "dpf", "dpf_local_ci_0"]],
+    ["docker", ["exec", "dpf-local-ci-postgres-0", "createdb", "-U", "dpf", "-O", "dpf", "dpf_local_ci_0"]],
+  ]);
+});
+
+test("slot database reset rejects non-manifest identities before invoking Docker", () => {
+  let called = false;
+  assert.throws(
+    () => resetOwnedSlotDatabase({
+      container: "postgres",
+      database: "production",
+      run: () => { called = true; return { status: 0 }; },
+    }),
+    /refusing non-slot Postgres reset/,
+  );
+  assert.equal(called, false);
+});
+
+test("slot database reset fails closed when drop or create fails", () => {
+  assert.throws(
+    () => resetOwnedSlotDatabase({
+      container: "dpf-local-ci-postgres-1",
+      database: "dpf_local_ci_1",
+      run: () => ({ status: 1, stdout: "", stderr: "database busy" }),
+    }),
+    /could not reset disposable slot database.*database busy/,
   );
 });


### PR DESCRIPTION
## Summary  Preserves the recovered Build Studio routing work in a governed worktree, prevents direct file edits when a coding surface is accidentally rooted at the merge checkout, and makes each admitted local-CI candidate start from a clean manifest-owned disposable slot database.

## Changes  - add the `development` routing sensitivity for source-code work while retaining business-data clearance gates - guard Write/Edit/MultiEdit against the root merge checkout while allowing real sibling and nested worktrees - force-drop and recreate only `dpf_local_ci_N` inside the exact manifest-owned local-CI Postgres container before each candidate - fail closed for non-slot identities or Docker reset errors - preserve all recovered peer edits with their original byte content and add regression contracts

## Test plan  - [x] `node --test scripts/local-ci-runner.test.mjs packages/dpf-skill-pack/hooks/root-clone-guard.test.mjs packages/dpf-skill-pack/hooks/plugin-hooks-wired.test.mjs` (57/57) - [x] `node scripts/check-module-size.mjs` - [x] `git diff --check` - [x] `pnpm run pregate:preflight` (37/37; three source-only runtime warnings) - [x] Fresh high-assurance semantic review passed with zero findings - [x] Four independent exact candidates reproduced the poisoned disposable slot database before product stages

Local-CI-Override: install-bootstrap-recovery: the shared disposable local-CI database lifecycle is the patient; existing slot state rejects every candidate before the correction can run

## Design grounding  - Existing specs/plans reviewed: BI-FFF58567 acceptance, the worktree-per-session contract, and the local-CI pre-PR runbook. - Current code substrate reviewed: `apps/web/lib/routing/pipeline-v2.ts`, `packages/dpf-skill-pack/hooks/root-clone-guard.mjs`, `scripts/local-ci-runner.mjs`, and both hook manifests. - Source of truth: governed sibling worktrees own feature edits; `D:/DPF` remains the merge/release checkout; the slot manifest owns disposable database identity. - Decision: block accidental root writes and recreate only the admitted manifest-owned disposable database for exact candidate isolation.

## Related issues / Epic  Refs BI-FFF58567. Refs BI-E535485F. Parent: EP-0DFF753B.

## Overlap sweep  No open PR with overlapping root-write or local-CI slot-database scope was found before publication.   Docs-Impact-Decision: provider clearance, root-write protection, and disposable CI isolation are internal routing/testing contracts; no user workflow or copy changes.