### PR TITLE
fix(restaurant): retain active turn booking context

### DIFF
--- a/apps/web/lib/twin/restaurant-floor-loader.server.test.ts
+++ b/apps/web/lib/twin/restaurant-floor-loader.server.test.ts
@@ -220,6 +220,41 @@ describe("restaurant floor operational loader", () => {
     ]);
   });
 
+  it("keeps active-turn booking context outside the ordinary demand horizon", async () => {
+    const db = database();
+    db.storefrontBooking.findMany.mockImplementation(
+      async (args: unknown) =>
+        JSON.stringify(args).includes("hospitalityServiceTurn")
+          ? [
+              {
+                ...seatedBooking,
+                scheduledAt: new Date("2026-07-28T18:00:00.000Z"),
+              },
+              waitingBooking,
+            ]
+          : [waitingBooking],
+    );
+
+    const view = await loadRestaurantFloorOperationalView(db, {
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      now,
+    });
+
+    expect(view.floor.tables[0]).toEqual(
+      expect.objectContaining({
+        party: { id: "booking-seated", name: "Morgan Lee", covers: 2 },
+      }),
+    );
+    expect(view.moves).toEqual([
+      expect.objectContaining({
+        demandId: "booking-seated",
+        serviceTurnId: "turn-1",
+        options: [expect.objectContaining({ resourceIds: ["table-2"] })],
+      }),
+    ]);
+  });
+
   it("reports the bounded read count, elapsed time, and exact payload size", async () => {
     const ticks = [100, 112.5];
     const view = await loadRestaurantFloorOperationalView(database(), {

--- a/apps/web/lib/twin/restaurant-floor-loader.server.ts
+++ b/apps/web/lib/twin/restaurant-floor-loader.server.ts
@@ -277,6 +277,11 @@ export async function loadRestaurantFloorOperationalView(
           OR: [
             { status: "waiting" },
             {
+              hospitalityServiceTurn: {
+                is: { stage: { in: [...ACTIVE_TURN_STAGES] } },
+              },
+            },
+            {
               scheduledAt: {
                 gte: horizonStart,
                 lt: horizonEnd,


### PR DESCRIPTION
## Summary

- keep bookings referenced by active hospitality service turns in the Restaurant floor read model even when their scheduled time is outside the ordinary demand horizon
- preserve the seated party identity/covers and generate safe Move party options for long-wait walk-ins
- add a functional regression that simulates the database horizon filter and proves the party/move projection

## Verification

- TDD red: occupied table projected `party: null` and no move command
- focused loader suite: 8/8 passed
- scoped TypeScript pre-commit: passed with 8 GiB heap
- exact merged-code pregate: `gate passed` in 9:56
- exhaustive Vitest: 2,652 files / 22,721 tests passed
- production Docker build/import: `sha256:ed444536c2dc8744f72b56ce03b756b716d676c8f2a15762f088849837bc84f7`
- evidence: `cmspvn6ga01ur01mjwmbnboiv`
- accepted base: `114b94400f62d45a536297d2d82ffd378be853ba`
- candidate: `853b9bf714e3525844fd84ad5d64edf5b8ad2c0e`

## UX and migration

- UX: restores the existing Host stand → Move party journey; canonical live repetition follows deployment
- migration: not applicable; no schema change
- docs: not needed; this restores an already documented contract

Backlog: BI-287AA5F7
Capsule: WC-0CB5863C
