### PR TITLE
feat(performance): add governed business metric rollups

### DIFF
--- a/apps/web/app/(shell)/performance/page.test.tsx
+++ b/apps/web/app/(shell)/performance/page.test.tsx
@@ -1,22 +1,44 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import { loadBusinessPerformance } from "@/lib/performance/business-performance-provider";
+import { auth } from "@/lib/auth";
 import PerformancePage, { metadata } from "./page";
 
+vi.mock("@/lib/performance/business-performance-provider", () => ({
+  loadBusinessPerformance: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
 describe("PerformancePage", () => {
+  beforeEach(() => {
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-owner" } } as never);
+    vi.mocked(loadBusinessPerformance).mockResolvedValue({
+      status: "not-configured",
+      reason: "The first historical performance snapshot has not been computed yet.",
+      asOf: null,
+      metricValues: [],
+      source: "business-performance-read-model",
+    });
+  });
+
   it("states its owner/manager purpose and renders a truthful setup state", async () => {
     const html = renderToStaticMarkup(await PerformancePage());
 
     expect(metadata.title).toBe("Performance");
     expect(html).toContain(">Performance<");
-    expect(html).toContain("Review how the business is doing over time.");
-    expect(html).toContain("Connect a source to see performance");
+    expect(html).toContain("Review results, trends, and the operating evidence behind them.");
+    expect(html).toContain("Performance history is not ready yet");
     expect(html).toContain("We will not show made-up numbers.");
     expect(html).toContain('href="/workspace"');
     expect(html).toContain("data-dpf-lead");
     expect(html).toContain("data-owner-first-next-action");
     expect(html).toContain("data-dpf-primary-action");
     expect(html).not.toContain(">0<");
+    expect(loadBusinessPerformance).toHaveBeenCalledWith({ userId: "user-owner" });
   });
 
   it("does not add a second primary or local navigation component", async () => {

--- a/apps/web/app/(shell)/performance/page.test.tsx
+++ b/apps/web/app/(shell)/performance/page.test.tsx
@@ -30,7 +30,7 @@ describe("PerformancePage", () => {
 
     expect(metadata.title).toBe("Performance");
     expect(html).toContain(">Performance<");
-    expect(html).toContain("Review results, trends, and the operating evidence behind them.");
+    expect(html).toContain("Review results, trends, and their operating evidence.");
     expect(html).toContain("Performance history is not ready yet");
     expect(html).toContain("We will not show made-up numbers.");
     expect(html).toContain('href="/workspace"');

--- a/apps/web/app/(shell)/performance/page.tsx
+++ b/apps/web/app/(shell)/performance/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 
+import { auth } from "@/lib/auth";
 import { EmptyState } from "@/components/ui/report-kit";
+import { BusinessPerformanceDashboard } from "@/components/performance/BusinessPerformanceDashboard";
 import { loadBusinessPerformance } from "@/lib/performance/business-performance-provider";
 
 export const metadata: Metadata = {
@@ -11,8 +14,18 @@ export const metadata: Metadata = {
 
 export const dynamic = "force-dynamic";
 
-export default async function PerformancePage() {
-  const performance = await loadBusinessPerformance();
+export default async function PerformancePage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ period?: string }>;
+} = {}) {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/login");
+
+  const query = await searchParams;
+  const performance = await loadBusinessPerformance(
+    { userId: session.user.id, ...(query?.period ? { period: query.period } : {}) },
+  );
 
   return (
     <main
@@ -23,24 +36,28 @@ export default async function PerformancePage() {
       <header className="space-y-1" data-dpf-lead>
         <h1 className="text-xl font-semibold text-[var(--dpf-text)]">Performance</h1>
         <p className="max-w-3xl text-sm text-[var(--dpf-text-secondary)]">
-          Review how the business is doing over time.
+          Review results, trends, and the operating evidence behind them.
         </p>
       </header>
 
-      <EmptyState
-        title="Connect a source to see performance"
-        description="No history source is connected. We will not show made-up numbers."
-        action={
-          <Link
-            href="/workspace"
-            data-dpf-primary-action
-            data-owner-first-next-action
-            className="inline-flex min-h-11 items-center rounded-md px-3 text-sm font-medium text-[var(--dpf-accent)] hover:bg-[var(--dpf-surface-2)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
-          >
-            Open Operations
-          </Link>
-        }
-      />
+      {performance.status === "ready" ? (
+        <BusinessPerformanceDashboard performance={performance} />
+      ) : (
+        <EmptyState
+          title="Performance history is not ready yet"
+          description={`${performance.reason} We will not show made-up numbers.`}
+          action={
+            <Link
+              href="/workspace"
+              data-dpf-primary-action
+              data-owner-first-next-action
+              className="inline-flex min-h-11 items-center rounded-md px-3 text-sm font-medium text-[var(--dpf-accent)] hover:bg-[var(--dpf-surface-2)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+            >
+              Open Operations
+            </Link>
+          }
+        />
+      )}
     </main>
   );
 }

--- a/apps/web/app/(shell)/performance/page.tsx
+++ b/apps/web/app/(shell)/performance/page.tsx
@@ -36,7 +36,7 @@ export default async function PerformancePage({
       <header className="space-y-1" data-dpf-lead>
         <h1 className="text-xl font-semibold text-[var(--dpf-text)]">Performance</h1>
         <p className="max-w-3xl text-sm text-[var(--dpf-text-secondary)]">
-          Review results, trends, and the operating evidence behind them.
+          Review results, trends, and their operating evidence.
         </p>
       </header>
 

--- a/apps/web/components/performance/BusinessPerformanceDashboard.test.tsx
+++ b/apps/web/components/performance/BusinessPerformanceDashboard.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("@/components/ui/report-kit/Chart", () => ({
+  Chart: () => <div data-component="trend-chart" />,
+}));
+
+import type { ReadyBusinessPerformance } from "@/lib/performance/business-performance-provider";
+import { BusinessPerformanceDashboard } from "./BusinessPerformanceDashboard";
+
+const performance: ReadyBusinessPerformance = {
+  status: "ready",
+  archetypeId: "restaurant",
+  periodLabel: "Jul 31, 2026",
+  periodStart: new Date("2026-07-31T05:00:00.000Z"),
+  periodEnd: new Date("2026-08-01T05:00:00.000Z"),
+  timezone: "America/Chicago",
+  asOf: new Date("2026-08-01T01:30:00.000Z"),
+  freshness: "fresh",
+  periodState: "in-progress",
+  availablePeriods: [
+    { key: "2026-07-31", label: "Jul 31, 2026", selected: true },
+    { key: "2026-07-30", label: "Jul 30, 2026", selected: false },
+  ],
+  source: "business-performance-read-model",
+  trendPoints: [
+    { periodKey: "2026-07-30", periodLabel: "Jul 30, 2026", values: { covers: 80, "turn-time": 70 } },
+    { periodKey: "2026-07-31", periodLabel: "Jul 31, 2026", values: { covers: 100, "turn-time": null } },
+  ],
+  sections: {
+    headline: ["covers", "turn-time"],
+    operating: ["turn-time"],
+    financial: [],
+    customer: [],
+    workforce: [],
+  },
+  metricValues: [
+    {
+      key: "covers",
+      label: "Covers",
+      unit: "count",
+      value: 100,
+      comparisonValue: 80,
+      comparisonDelta: 0.25,
+      availability: "available",
+      unavailableReason: null,
+      definition: "count seated guests",
+      definitionVersion: "restaurant-v1",
+      sourceOwner: "restaurant-service",
+      sourceWatermark: new Date("2026-08-01T01:30:00.000Z"),
+      sourceLineage: { sourceModels: ["HospitalityServiceTurn"], sourceRows: 20 },
+      drilldownRoute: "/workspace",
+    },
+    {
+      key: "turn-time",
+      label: "Turn time",
+      unit: "duration",
+      value: null,
+      comparisonValue: null,
+      comparisonDelta: null,
+      availability: "unavailable",
+      unavailableReason: "No completed service turns exist in this period.",
+      definition: "median seated-to-available duration",
+      definitionVersion: "restaurant-v1",
+      sourceOwner: "restaurant-floor",
+      sourceWatermark: new Date("2026-08-01T01:30:00.000Z"),
+      sourceLineage: { sourceModels: ["HospitalityServiceTurn"], sourceRows: 0 },
+      drilldownRoute: "/workspace",
+    },
+  ],
+};
+
+describe("BusinessPerformanceDashboard", () => {
+  it("renders comparisons, unavailable reasons, lineage, drilldown, and scoped export", () => {
+    const html = renderToStaticMarkup(
+      <BusinessPerformanceDashboard performance={performance} />,
+    );
+
+    expect(html).toContain("Jul 31, 2026");
+    expect(html).toContain("100");
+    expect(html).toContain("+25%");
+    expect(html).toContain("Not available");
+    expect(html).toContain("No completed service turns exist in this period.");
+    expect(html).toContain("How this is calculated");
+    expect(html).toContain("HospitalityServiceTurn");
+    expect(html).toContain('href="/workspace"');
+    expect(html).toContain("Export this period");
+    expect(html).toContain("Oldest source update");
+    expect(html).toContain("Source updated");
+    expect(html).toContain("What changed");
+    expect(html).toContain("Why it changed");
+    expect(html).toContain("What deserves review");
+    expect(html).toContain("Observation, not a recommendation");
+    expect(html).toContain("do not yet prove what caused the change");
+    expect(html.indexOf("Headline performance")).toBeLessThan(html.indexOf("Owner brief"));
+    expect(html).toContain('href="/performance?period=2026-07-30"');
+    expect(html).toContain("Trends");
+    expect(html).toContain("View trend as a table");
+  });
+});

--- a/apps/web/components/performance/BusinessPerformanceDashboard.tsx
+++ b/apps/web/components/performance/BusinessPerformanceDashboard.tsx
@@ -181,7 +181,7 @@ export function BusinessPerformanceDashboard({
               Owner brief
             </h2>
             <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-              Observed facts for this period, with evidence limits kept visible.
+              Observed facts with visible evidence limits.
             </p>
           </div>
           <StatusBadge intent="neutral" label="Observation, not a recommendation" />

--- a/apps/web/components/performance/BusinessPerformanceDashboard.tsx
+++ b/apps/web/components/performance/BusinessPerformanceDashboard.tsx
@@ -1,0 +1,248 @@
+import Link from "next/link";
+
+import {
+  ExportButton,
+  Notice,
+  StatCard,
+  StatusBadge,
+} from "@/components/ui/report-kit";
+import { LocalTime } from "@/components/ui/LocalTime";
+import type {
+  BusinessPerformanceMetricValue,
+  ReadyBusinessPerformance,
+} from "@/lib/performance/business-performance-provider";
+import {
+  formatComparisonDelta,
+  formatComparisonMagnitude,
+  formatMetricValue,
+} from "@/lib/performance/performance-format";
+import { buildPerformanceExportRows } from "@/lib/performance/performance-export";
+import { buildPerformanceDecisionSummary } from "@/lib/performance/performance-decision-summary";
+import { PerformanceTrendPanel } from "./PerformanceTrendPanel";
+
+function sourceModels(lineage: unknown): string[] {
+  if (!lineage || typeof lineage !== "object" || !("sourceModels" in lineage)) return [];
+  const models = (lineage as { sourceModels?: unknown }).sourceModels;
+  return Array.isArray(models) ? models.filter((model): model is string => typeof model === "string") : [];
+}
+
+function MetricCard({ metric }: { metric: BusinessPerformanceMetricValue }) {
+  const delta = metric.comparisonDelta;
+  const deltaLabel = delta === null
+    ? undefined
+    : formatComparisonDelta(delta);
+  const lineage = sourceModels(metric.sourceLineage);
+
+  return (
+    <article className="space-y-2" data-metric-key={metric.key}>
+      <StatCard
+        label={metric.label}
+        value={formatMetricValue(metric.value, metric.unit)}
+        intent={metric.availability === "available" ? "info" : "neutral"}
+        hint={metric.unavailableReason ?? `Compared with the prior period${metric.comparisonValue === null ? " when available" : ""}.`}
+        {...(metric.drilldownRoute ? { href: metric.drilldownRoute } : {})}
+        {...(deltaLabel && delta !== null ? {
+          delta: {
+            label: deltaLabel,
+            direction: delta > 0 ? "up" as const : delta < 0 ? "down" as const : "flat" as const,
+            intent: "neutral" as const,
+          },
+        } : {})}
+      />
+      <details className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-xs text-[var(--dpf-text-secondary)]">
+        <summary className="cursor-pointer font-medium text-[var(--dpf-text)]">
+          How this is calculated
+        </summary>
+        <dl className="mt-2 grid gap-1 sm:grid-cols-[8rem_1fr]">
+          <dt className="text-[var(--dpf-muted)]">Definition</dt>
+          <dd>{metric.definition}</dd>
+          <dt className="text-[var(--dpf-muted)]">Source owner</dt>
+          <dd>{metric.sourceOwner}</dd>
+          <dt className="text-[var(--dpf-muted)]">Definition version</dt>
+          <dd>{metric.definitionVersion ?? "Not computed"}</dd>
+          <dt className="text-[var(--dpf-muted)]">Source models</dt>
+          <dd>{lineage.length > 0 ? lineage.join(", ") : "No source lineage recorded"}</dd>
+          <dt className="text-[var(--dpf-muted)]">Source updated</dt>
+          <dd><LocalTime value={metric.sourceWatermark} mode="time" /></dd>
+        </dl>
+        {metric.drilldownRoute ? (
+          <Link className="mt-2 inline-flex min-h-11 items-center font-medium text-[var(--dpf-accent)]" href={metric.drilldownRoute}>
+            Open source operations
+          </Link>
+        ) : null}
+      </details>
+    </article>
+  );
+}
+
+function MetricSection({
+  title,
+  keys,
+  metrics,
+}: {
+  title: string;
+  keys: readonly string[];
+  metrics: ReadonlyMap<string, BusinessPerformanceMetricValue>;
+}) {
+  if (keys.length === 0) return null;
+  return (
+    <section className="space-y-3" aria-labelledby={`performance-${title.toLowerCase()}`}>
+      <h2 id={`performance-${title.toLowerCase()}`} className="text-base font-semibold text-[var(--dpf-text)]">
+        {title}
+      </h2>
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {keys.flatMap((key) => {
+          const metric = metrics.get(key);
+          return metric ? [<MetricCard key={key} metric={metric} />] : [];
+        })}
+      </div>
+    </section>
+  );
+}
+
+export function BusinessPerformanceDashboard({
+  performance,
+}: {
+  performance: ReadyBusinessPerformance;
+}) {
+  const metrics = new Map(performance.metricValues.map((metric) => [metric.key, metric]));
+  const decisionSummary = buildPerformanceDecisionSummary({
+    metrics: performance.metricValues,
+    headlineKeys: performance.sections.headline,
+  });
+  const exportRows = buildPerformanceExportRows(performance);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.14em] text-[var(--dpf-muted)]">Reporting period</p>
+          <p className="mt-1 text-lg font-semibold text-[var(--dpf-text)]">{performance.periodLabel}</p>
+          <p className="text-xs text-[var(--dpf-muted)]">{performance.timezone}</p>
+          {performance.availablePeriods.length > 1 ? (
+            <nav aria-label="Performance period" className="mt-2 flex flex-wrap gap-2">
+              {performance.availablePeriods.map((period) =>
+                period.selected ? (
+                  <span key={period.key} aria-current="date" className="rounded-md bg-[var(--dpf-surface-2)] px-2 py-1 text-xs font-medium text-[var(--dpf-text)]">
+                    {period.label}
+                  </span>
+                ) : (
+                  <Link key={period.key} href={`/performance?period=${period.key}`} className="inline-flex min-h-11 items-center rounded-md px-2 text-xs font-medium text-[var(--dpf-accent)] hover:bg-[var(--dpf-surface-2)]">
+                    {period.label}
+                  </Link>
+                ),
+              )}
+            </nav>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <StatusBadge
+            intent={performance.freshness === "fresh" ? "success" : "warning"}
+            label={
+              performance.freshness === "stale"
+                ? "Snapshot delayed"
+                : performance.periodState === "finalized"
+                  ? "Finalized snapshot"
+                  : "Fresh snapshot"
+            }
+          />
+          <ExportButton
+            rows={exportRows}
+            filename={`business-performance-${performance.periodLabel.replaceAll(" ", "-").replaceAll(",", "").toLowerCase()}.csv`}
+            label="Export this period"
+          />
+          <span className="text-xs text-[var(--dpf-muted)]">
+            Oldest source update <LocalTime value={performance.asOf} mode="time" />
+          </span>
+        </div>
+      </div>
+
+      {performance.freshness === "stale" ? (
+        <Notice variant="warn" title="The latest valid snapshot is delayed">
+          The dashboard is preserving the last successful rollup. Operational work can continue while the next refresh retries.
+        </Notice>
+      ) : null}
+
+      <section aria-label="Headline performance" className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {performance.sections.headline.flatMap((key) => {
+          const metric = metrics.get(key);
+          return metric ? [<MetricCard key={key} metric={metric} />] : [];
+        })}
+      </section>
+
+      <section
+        aria-labelledby="performance-owner-brief"
+        className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+        data-dpf-lead
+      >
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div>
+            <h2 id="performance-owner-brief" className="text-base font-semibold text-[var(--dpf-text)]">
+              Owner brief
+            </h2>
+            <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+              Observed facts for this period, with evidence limits kept visible.
+            </p>
+          </div>
+          <StatusBadge intent="neutral" label="Observation, not a recommendation" />
+        </div>
+        <div className="mt-4 grid gap-4 lg:grid-cols-3 lg:divide-x lg:divide-[var(--dpf-border)]">
+          <div>
+            <h3 className="text-sm font-semibold text-[var(--dpf-text)]">What changed</h3>
+            {decisionSummary.observedChanges.length > 0 ? (
+              <ul className="mt-2 space-y-2 text-sm text-[var(--dpf-text-secondary)]">
+                {decisionSummary.observedChanges.slice(0, 3).map((change) => (
+                  <li key={change.key}>
+                    <span className="font-medium text-[var(--dpf-text)]">{change.label}</span>{" "}
+                    {change.direction} {formatComparisonMagnitude(change.delta)} versus the prior period.
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-2 text-sm text-[var(--dpf-text-secondary)]">
+                No comparable prior-period values are available yet.
+              </p>
+            )}
+          </div>
+          <div className="lg:pl-4">
+            <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Why it changed</h3>
+            <p className="mt-2 text-sm text-[var(--dpf-text-secondary)]">
+              {decisionSummary.driverEvidence.message}
+            </p>
+            <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+              Open a metric’s calculation details to inspect its source lineage.
+            </p>
+          </div>
+          <div className="lg:pl-4">
+            <h3 className="text-sm font-semibold text-[var(--dpf-text)]">What deserves review</h3>
+            {decisionSummary.reviewItems.length > 0 ? (
+              <ul className="mt-2 space-y-2 text-sm text-[var(--dpf-text-secondary)]">
+                {decisionSummary.reviewItems.map((item) => (
+                  <li key={`${item.kind}-${item.key}`}>
+                    <span className="font-medium text-[var(--dpf-text)]">{item.label}:</span>{" "}
+                    {item.reason}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-2 text-sm text-[var(--dpf-text-secondary)]">
+                No headline gaps or comparable movements require review from this snapshot.
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <PerformanceTrendPanel
+        points={performance.trendPoints}
+        metrics={performance.metricValues.map(({ key, label, unit }) => ({ key, label, unit }))}
+        preferredKeys={performance.sections.headline}
+      />
+
+      <MetricSection title="Operations" keys={performance.sections.operating} metrics={metrics} />
+      <MetricSection title="Financial" keys={performance.sections.financial} metrics={metrics} />
+      <MetricSection title="Customer" keys={performance.sections.customer} metrics={metrics} />
+      <MetricSection title="Workforce" keys={performance.sections.workforce} metrics={metrics} />
+    </div>
+  );
+}

--- a/apps/web/components/performance/PerformanceTrendPanel.tsx
+++ b/apps/web/components/performance/PerformanceTrendPanel.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import {
+  DataTable,
+  FilterBar,
+  Notice,
+  type Column,
+} from "@/components/ui/report-kit";
+import { Chart } from "@/components/ui/report-kit/Chart";
+import type {
+  BusinessPerformanceTrendPoint,
+} from "@/lib/performance/business-performance-provider";
+import {
+  chartMetricValue,
+  formatMetricValue,
+  type MetricUnit,
+} from "@/lib/performance/performance-format";
+
+interface TrendTableRow {
+  periodKey: string;
+  periodLabel: string;
+  value: number | null;
+  formattedValue: string;
+}
+
+interface TrendMetricOption {
+  key: string;
+  label: string;
+  unit: MetricUnit;
+}
+
+export function PerformanceTrendPanel({
+  points,
+  metrics,
+  preferredKeys,
+}: {
+  points: readonly BusinessPerformanceTrendPoint[];
+  metrics: readonly TrendMetricOption[];
+  preferredKeys: readonly string[];
+}) {
+  const options = preferredKeys
+    .map((key) => metrics.find((metric) => metric.key === key))
+    .filter((metric): metric is TrendMetricOption => Boolean(metric))
+    .slice(0, 4);
+  const [selectedKey, setSelectedKey] = useState(options[0]?.key ?? "");
+  const selected = metrics.find((metric) => metric.key === selectedKey) ?? options[0];
+
+  const rows = useMemo<TrendTableRow[]>(() => {
+    if (!selected) return [];
+    return points.map((point) => {
+      const value = point.values[selected.key] ?? null;
+      return {
+        periodKey: point.periodKey,
+        periodLabel: point.periodLabel,
+        value,
+        formattedValue: formatMetricValue(value, selected.unit),
+      };
+    });
+  }, [points, selected]);
+
+  if (!selected) {
+    return (
+      <Notice title="Trend history is not ready">
+        No metric definitions are available for this archetype.
+      </Notice>
+    );
+  }
+
+  const columns: Column<TrendTableRow>[] = [
+    {
+      key: "period",
+      header: "Period",
+      cell: (row) => row.periodLabel,
+      sortAccessor: (row) => row.periodKey,
+    },
+    {
+      key: "value",
+      header: selected.label,
+      cell: (row) => row.formattedValue,
+      align: "right",
+      sortAccessor: (row) => row.value ?? Number.NEGATIVE_INFINITY,
+    },
+  ];
+  const chartRows = rows.map((row) => ({
+    period: row.periodLabel,
+    value: chartMetricValue(row.value, selected.unit),
+  }));
+
+  return (
+    <section className="space-y-3" aria-labelledby="performance-trends">
+      <div>
+        <h2 id="performance-trends" className="text-base font-semibold text-[var(--dpf-text)]">
+          Trends
+        </h2>
+        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+          Historical snapshots use the same versioned definition as the selected metric.
+        </p>
+      </div>
+      <FilterBar
+        facets={[{
+          kind: "pills",
+          key: "metric",
+          label: "Metric",
+          options: options.map((metric) => ({ value: metric.key, label: metric.label })),
+        }]}
+        value={{ metric: selected.key }}
+        onChange={(next) => setSelectedKey(next.metric || options[0]!.key)}
+      />
+      <div className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+        <Chart
+          type="line"
+          data={chartRows}
+          xKey="period"
+          series={[{ key: "value", label: selected.label, intent: "info" }]}
+          height={220}
+        />
+      </div>
+      <details className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+        <summary className="cursor-pointer text-sm font-medium text-[var(--dpf-text)]">
+          View trend as a table
+        </summary>
+        <DataTable
+          className="mt-3"
+          columns={columns}
+          rows={rows}
+          getRowKey={(row) => row.periodKey}
+          initialSort={{ key: "period", dir: "desc" }}
+          dense
+        />
+      </details>
+    </section>
+  );
+}

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -785,6 +785,9 @@
     "apps/web/lib/operate/sole-platform-readiness.ts": [
       "docs/architecture/2026-07-27-platform-adequacy-roadmap-backlog-map.md"
     ],
+    "apps/web/lib/performance/business-performance-provider.ts": [
+      "docs/architecture/operations-hot-path.md"
+    ],
     "apps/web/lib/platform-runtime/capability-service-projection.ts": [
       "docs/architecture/capability-driven-runtime-profiles.md"
     ],
@@ -1302,6 +1305,9 @@
     ],
     "packages/storefront-templates/src/archetypes/trades-maintenance.ts": [
       "docs/personas/dale-hvac.md"
+    ],
+    "packages/storefront-templates/src/business-view-profile.ts": [
+      "docs/architecture/operations-hot-path.md"
     ],
     "packages/storefront-templates/src/twin-profile.ts": [
       "docs/architecture/operational-precedent-corpus.md"
@@ -2181,6 +2187,10 @@
       "apps/web/lib/design-intelligence.ts",
       "packages/db/src/portfolio-sources/vertical-incumbents-manifest.ts",
       "packages/storefront-templates/src/twin-profile.ts"
+    ],
+    "docs/architecture/operations-hot-path.md": [
+      "apps/web/lib/performance/business-performance-provider.ts",
+      "packages/storefront-templates/src/business-view-profile.ts"
     ],
     "docs/architecture/orientation.md": [
       ".github/workflows/migration-safety-guard.yml",

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1704,7 +1704,9 @@
         "read-contract",
         "command-contract",
         "performance-and-evidence",
-        "reuse-boundary"
+        "reuse-boundary",
+        "historical-performance-boundary",
+        "design-grounding"
       ]
     },
     "docs/architecture/orientation.md": {

--- a/apps/web/lib/govern/data/assets.test.ts
+++ b/apps/web/lib/govern/data/assets.test.ts
@@ -191,6 +191,17 @@ describe("seeded registry", () => {
     }
   });
 
+  it("registers business performance rollups as local tenant-scoped derived analytics", () => {
+    expect(lookupAsset(DATA_ASSET_REGISTRY, "data:business-metric-rollup")).toMatchObject({
+      physical: { prismaModel: "BusinessMetricRollup" },
+      domain: "business-performance",
+      sensitivity: "confidential",
+      categories: expect.arrayContaining(["derived-analytic"]),
+      residencyClass: "local-only",
+      subjectLocators: [{ role: "organization", fieldPath: "organization" }],
+    });
+  });
+
   it("builds without invariant violations and carries the BI-DG-001 worked asset", () => {
     expect(DATA_ASSET_REGISTRY.assets.length).toBeGreaterThan(0);
     const conv = lookupAsset(DATA_ASSET_REGISTRY, "data:agent-conversation");

--- a/apps/web/lib/govern/data/assets.ts
+++ b/apps/web/lib/govern/data/assets.ts
@@ -35,7 +35,7 @@ import { RECRUITING_ASSETS } from "./recruiting-assets";
 import { DECISION_TRUST_ENVELOPE_ASSETS } from "./decision-trust-envelope-assets";
 import { MCP_ASSETS } from "./mcp-assets";
 import { FEDERATION_INTRODUCTION_ASSETS } from "./federation-introduction-assets";
-// ─── Definitions (spec §6.1) ─────────────────────────────────────────────────
+import { BUSINESS_PERFORMANCE_ASSETS } from "./business-performance-assets";
 export type FieldResolution = "inherited" | "governed" | "not-applicable";
 
 export type DataFieldDefinition = {
@@ -721,7 +721,7 @@ const SEED_ASSETS: readonly DataAssetDefinition[] = [
   ...BEAUTY_CAPACITY_ASSETS,
   ...LIFECYCLE_GOVERNANCE_ASSETS,
   ...STOCK_COVERAGE_ASSETS,
-  ...FINANCE_INVOICE_DOCUMENT_ASSETS,
+  ...FINANCE_INVOICE_DOCUMENT_ASSETS, ...BUSINESS_PERFORMANCE_ASSETS,
   ...PROCESSING_GOVERNANCE_ASSETS,
   ...RECRUITING_ASSETS,
   ...DECISION_TRUST_ENVELOPE_ASSETS, ...MCP_ASSETS, ...FEDERATION_INTRODUCTION_ASSETS,

--- a/apps/web/lib/govern/data/business-performance-assets.ts
+++ b/apps/web/lib/govern/data/business-performance-assets.ts
@@ -1,0 +1,26 @@
+import type { DataAssetDefinition } from "./assets";
+
+/** Aggregated owner/manager analytics; source records remain in their domains. */
+export const BUSINESS_PERFORMANCE_ASSETS: readonly DataAssetDefinition[] = [
+  {
+    id: "data:business-metric-rollup",
+    physical: { prismaModel: "BusinessMetricRollup" },
+    domain: "business-performance",
+    ownerRole: "founder-business-owner",
+    stewardRole: "data-steward",
+    categories: ["derived-analytic", "operational", "financial"],
+    sensitivity: "confidential",
+    criticality: "high",
+    subjectLocators: [{ role: "organization", fieldPath: "organization" }],
+    lifecycleClass: "business-record",
+    purposeCapabilities: ["product-analytics", "service-delivery"],
+    residencyClass: "local-only",
+    projectionClass: "metadata",
+    classification: {
+      state: "confirmed",
+      source: "manual",
+      effectiveFrom: "2026-08-01",
+    },
+    fields: [],
+  },
+];

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -554,6 +554,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     runNowEvent: null,
   },
   {
+    jobId: "business-metrics-aggregator",
+    inngestId: "business/metrics-aggregator",
+    name: "Business metrics aggregator",
+    purpose:
+      "Builds tenant-scoped owner/manager performance snapshots from canonical operational evidence. The Performance view stays fast and preserves its last valid snapshot when a refresh fails.",
+    cron: "17 * * * *",
+    cadence: "Hourly at :17",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
     jobId: "skill-curator",
     inngestId: "skills/curator",
     name: "Skill curator",

--- a/apps/web/lib/performance/business-metric-rollup.server.test.ts
+++ b/apps/web/lib/performance/business-metric-rollup.server.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  storefrontFindMany: vi.fn(),
+  profileFindFirst: vi.fn(),
+  resourceFindMany: vi.fn(),
+  turnFindMany: vi.fn(),
+  allocationFindMany: vi.fn(),
+  bookingFindMany: vi.fn(),
+  rollupUpsert: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    storefrontConfig: { findMany: mocks.storefrontFindMany },
+    businessProfile: { findFirst: mocks.profileFindFirst },
+    hospitalityResource: { findMany: mocks.resourceFindMany },
+    hospitalityServiceTurn: { findMany: mocks.turnFindMany },
+    hospitalityCapacityAllocation: { findMany: mocks.allocationFindMany },
+    storefrontBooking: { findMany: mocks.bookingFindMany },
+    businessMetricRollup: { upsert: mocks.rollupUpsert },
+  },
+}));
+
+import { defaultBusinessMetricRollupDeps } from "./business-metric-rollup.server";
+
+describe("defaultBusinessMetricRollupDeps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.storefrontFindMany.mockResolvedValue([
+      { id: "sf-1", organizationId: "org-1", timezone: "America/Chicago" },
+    ]);
+    mocks.profileFindFirst.mockResolvedValue({
+      businessHours: { friday: { open: "17:00", close: "23:00" } },
+      hoursConfirmedAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    mocks.resourceFindMany.mockResolvedValue([]);
+    mocks.turnFindMany.mockResolvedValue([]);
+    mocks.allocationFindMany.mockResolvedValue([]);
+    mocks.bookingFindMany.mockResolvedValue([]);
+    mocks.rollupUpsert.mockResolvedValue({});
+  });
+
+  it("discovers only restaurant contexts and scopes every source query to the tenant", async () => {
+    const deps = defaultBusinessMetricRollupDeps();
+    const [context] = await deps.listRestaurantContexts();
+    const window = {
+      periodKey: "2026-07-31",
+      start: new Date("2026-07-31T05:00:00.000Z"),
+      end: new Date("2026-08-01T05:00:00.000Z"),
+      timezone: "America/Chicago",
+    };
+    await deps.loadRestaurantSource(context!, window, window.end);
+
+    expect(mocks.storefrontFindMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { archetype: { archetypeId: "restaurant" } },
+    }));
+    for (const sourceMock of [
+      mocks.resourceFindMany,
+      mocks.turnFindMany,
+      mocks.allocationFindMany,
+      mocks.bookingFindMany,
+    ]) {
+      expect(sourceMock).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({ organizationId: "org-1", storefrontId: "sf-1" }),
+      }));
+    }
+  });
+
+  it("upserts by the complete reproducible projection identity", async () => {
+    const deps = defaultBusinessMetricRollupDeps();
+    const computedAt = new Date("2026-08-01T02:00:00.000Z");
+    await deps.upsert({
+      organizationId: "org-1",
+      metricKey: "covers",
+      periodStart: new Date("2026-07-31T05:00:00.000Z"),
+      periodEnd: new Date("2026-08-01T05:00:00.000Z"),
+      timezone: "America/Chicago",
+      dimensionsHash: "hash",
+      dimensions: { storefrontId: "sf-1" },
+      value: 42,
+      unit: "count",
+      availability: "available",
+      unavailableReason: null,
+      definitionVersion: "restaurant-v1",
+      sourceWatermark: computedAt,
+      sourceLineage: { sourceModels: ["HospitalityServiceTurn"], sourceRows: 10, storefrontId: "sf-1" },
+    }, computedAt);
+
+    expect(mocks.rollupUpsert).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        organizationId_metricKey_periodStart_periodEnd_dimensionsHash_definitionVersion:
+          expect.objectContaining({
+            organizationId: "org-1",
+            metricKey: "covers",
+            dimensionsHash: "hash",
+            definitionVersion: "restaurant-v1",
+          }),
+      },
+      update: expect.objectContaining({ value: 42, computedAt }),
+    }));
+  });
+});

--- a/apps/web/lib/performance/business-metric-rollup.server.ts
+++ b/apps/web/lib/performance/business-metric-rollup.server.ts
@@ -1,0 +1,123 @@
+import { prisma } from "@dpf/db";
+
+import type {
+  BusinessMetricRollupDeps,
+  RestaurantMetricContext,
+} from "./business-metric-rollup";
+
+/** Prisma adapter kept separate from the deterministic projection math. */
+export function defaultBusinessMetricRollupDeps(): BusinessMetricRollupDeps {
+  return {
+    async listRestaurantContexts() {
+      const [storefronts, profile] = await Promise.all([
+        prisma.storefrontConfig.findMany({
+          where: { archetype: { archetypeId: "restaurant" } },
+          select: { id: true, organizationId: true, timezone: true },
+        }),
+        prisma.businessProfile.findFirst({
+          where: { isActive: true },
+          select: { businessHours: true, hoursConfirmedAt: true },
+        }),
+      ]);
+      const businessHours = profile?.businessHours as RestaurantMetricContext["businessHours"];
+      return storefronts.map((storefront) => ({
+        organizationId: storefront.organizationId,
+        storefrontId: storefront.id,
+        timezone: storefront.timezone || "UTC",
+        hoursConfirmedAt: profile?.hoursConfirmedAt ?? null,
+        businessHours: businessHours ?? null,
+      }));
+    },
+    async loadRestaurantSource(context, window, computedAt) {
+      const [resources, turns, allocations, bookings] = await Promise.all([
+        prisma.hospitalityResource.findMany({
+          where: { organizationId: context.organizationId, storefrontId: context.storefrontId },
+          select: { id: true, kind: true, status: true },
+        }),
+        prisma.hospitalityServiceTurn.findMany({
+          where: {
+            organizationId: context.organizationId,
+            storefrontId: context.storefrontId,
+            startedAt: { gte: window.start, lt: window.end },
+          },
+          select: {
+            id: true,
+            startedAt: true,
+            closedAt: true,
+            booking: { select: { covers: true } },
+          },
+        }),
+        prisma.hospitalityCapacityAllocation.findMany({
+          where: {
+            organizationId: context.organizationId,
+            storefrontId: context.storefrontId,
+            serviceTurnId: { not: null },
+            startsAt: { lt: window.end },
+            endsAt: { gt: window.start },
+          },
+          select: { resourceId: true, serviceTurnId: true, startsAt: true, endsAt: true },
+        }),
+        prisma.storefrontBooking.findMany({
+          where: {
+            organizationId: context.organizationId,
+            storefrontId: context.storefrontId,
+            scheduledAt: { gte: window.start, lt: window.end },
+          },
+          select: {
+            id: true,
+            scheduledAt: true,
+            status: true,
+            hospitalityServiceTurn: { select: { id: true } },
+          },
+        }),
+      ]);
+
+      return {
+        ...context,
+        window,
+        computedAt,
+        resources,
+        serviceTurns: turns.map((turn) => ({
+          id: turn.id,
+          startedAt: turn.startedAt,
+          closedAt: turn.closedAt,
+          covers: turn.booking?.covers ?? null,
+        })),
+        allocations,
+        bookings: bookings.map((booking) => ({
+          id: booking.id,
+          scheduledAt: booking.scheduledAt,
+          status: booking.status,
+          hasServiceTurn: booking.hospitalityServiceTurn !== null,
+        })),
+      };
+    },
+    async upsert(row, computedAt) {
+      const {
+        organizationId,
+        metricKey,
+        periodStart,
+        periodEnd,
+        dimensionsHash,
+        definitionVersion,
+        ...values
+      } = row;
+      const identity = {
+        organizationId,
+        metricKey,
+        periodStart,
+        periodEnd,
+        dimensionsHash,
+        definitionVersion,
+      };
+      await prisma.businessMetricRollup.upsert({
+        where: {
+          organizationId_metricKey_periodStart_periodEnd_dimensionsHash_definitionVersion:
+            identity,
+        },
+        create: { ...identity, ...values, computedAt },
+        update: { ...values, computedAt },
+      });
+    },
+  };
+}

--- a/apps/web/lib/performance/business-metric-rollup.test.ts
+++ b/apps/web/lib/performance/business-metric-rollup.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  aggregateBusinessMetrics,
+  buildRestaurantMetricRows,
+  restaurantMetricWindow,
+} from "./business-metric-rollup";
+
+const at = new Date("2026-08-01T02:00:00.000Z");
+
+beforeAll(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-01T03:00:00.000Z"));
+});
+
+afterAll(() => vi.useRealTimers());
+
+describe("restaurantMetricWindow", () => {
+  it("uses the business timezone rather than UTC day boundaries", () => {
+    expect(restaurantMetricWindow(at, "America/Chicago")).toEqual({
+      periodKey: "2026-07-31",
+      start: new Date("2026-07-31T05:00:00.000Z"),
+      end: new Date("2026-08-01T05:00:00.000Z"),
+      timezone: "America/Chicago",
+    });
+  });
+
+  it("preserves a local business date across a daylight-saving transition", () => {
+    const window = restaurantMetricWindow(
+      new Date("2026-03-08T18:00:00.000Z"),
+      "America/Chicago",
+    );
+    expect(window).toMatchObject({
+      periodKey: "2026-03-08",
+      start: new Date("2026-03-08T06:00:00.000Z"),
+      end: new Date("2026-03-09T05:00:00.000Z"),
+    });
+    expect(window.end.getTime() - window.start.getTime()).toBe(23 * 60 * 60 * 1000);
+  });
+});
+
+describe("buildRestaurantMetricRows", () => {
+  it("derives only metrics supported by canonical restaurant evidence", () => {
+    const window = restaurantMetricWindow(at, "America/Chicago");
+    const rows = buildRestaurantMetricRows({
+      organizationId: "org-1",
+      storefrontId: "sf-1",
+      window,
+      computedAt: at,
+      hoursConfirmedAt: new Date("2026-01-01T00:00:00.000Z"),
+      businessHours: {
+        friday: { open: "17:00", close: "23:00" },
+      },
+      resources: [
+        { id: "table-1", kind: "table", status: "active" },
+        { id: "table-2", kind: "table", status: "active" },
+      ],
+      serviceTurns: [
+        {
+          id: "turn-1",
+          startedAt: new Date("2026-07-31T23:00:00.000Z"),
+          closedAt: new Date("2026-08-01T00:00:00.000Z"),
+          covers: 4,
+        },
+        {
+          id: "turn-2",
+          startedAt: new Date("2026-08-01T00:30:00.000Z"),
+          closedAt: new Date("2026-08-01T02:00:00.000Z"),
+          covers: 2,
+        },
+      ],
+      allocations: [
+        {
+          resourceId: "table-1",
+          serviceTurnId: "turn-1",
+          startsAt: new Date("2026-07-31T23:00:00.000Z"),
+          endsAt: new Date("2026-08-01T00:00:00.000Z"),
+        },
+        {
+          resourceId: "table-2",
+          serviceTurnId: "turn-2",
+          startsAt: new Date("2026-08-01T00:30:00.000Z"),
+          endsAt: new Date("2026-08-01T02:00:00.000Z"),
+        },
+      ],
+      bookings: [
+        { id: "b-1", scheduledAt: new Date("2026-07-31T23:00:00.000Z"), status: "confirmed", hasServiceTurn: true },
+        { id: "b-2", scheduledAt: new Date("2026-08-01T00:30:00.000Z"), status: "no_show", hasServiceTurn: false },
+      ],
+    });
+
+    const byKey = new Map(rows.map((row) => [row.metricKey, row]));
+    expect(byKey.get("covers")).toMatchObject({ availability: "available", value: 6, unit: "count" });
+    expect(byKey.get("turn-time")).toMatchObject({ availability: "available", value: 75, unit: "duration" });
+    expect(byKey.get("table-utilization")).toMatchObject({
+      availability: "available",
+      value: 0.20833333333333334,
+      unit: "percent",
+    });
+    expect(byKey.get("wait-no-show-rate")).toMatchObject({ availability: "available", value: 0.5, unit: "rate" });
+    expect(byKey.get("sales")).toMatchObject({ availability: "unavailable", value: null });
+    expect(byKey.get("average-check")).toMatchObject({ availability: "unavailable", value: null });
+    expect(byKey.get("labor-percentage")).toMatchObject({ availability: "unavailable", value: null });
+    expect(rows.every((row) => row.definitionVersion === "restaurant-v1")).toBe(true);
+    expect(rows.every((row) => row.sourceWatermark?.toISOString() === at.toISOString())).toBe(true);
+  });
+
+  it("marks partial cover evidence and unconfirmed capacity denominators unavailable", () => {
+    const window = restaurantMetricWindow(at, "UTC");
+    const rows = buildRestaurantMetricRows({
+      organizationId: "org-1",
+      storefrontId: "sf-1",
+      window,
+      computedAt: at,
+      hoursConfirmedAt: null,
+      businessHours: null,
+      resources: [{ id: "table-1", kind: "table", status: "active" }],
+      serviceTurns: [{ id: "turn-1", startedAt: window.start, closedAt: null, covers: null }],
+      allocations: [],
+      bookings: [],
+    });
+    const byKey = new Map(rows.map((row) => [row.metricKey, row]));
+
+    expect(byKey.get("covers")?.unavailableReason).toContain("party size");
+    expect(byKey.get("table-utilization")?.unavailableReason).toContain("confirmed business hours");
+    expect(byKey.get("turn-time")?.unavailableReason).toContain("completed service turns");
+    expect(byKey.get("wait-no-show-rate")?.unavailableReason).toContain("eligible bookings");
+  });
+});
+
+describe("aggregateBusinessMetrics", () => {
+  it("recomputes current and prior periods through idempotent upserts", async () => {
+    const upserted: string[] = [];
+    const result = await aggregateBusinessMetrics({
+      async listRestaurantContexts() {
+        return [{
+          organizationId: "org-1",
+          storefrontId: "sf-1",
+          timezone: "UTC",
+          hoursConfirmedAt: null,
+          businessHours: null,
+        }];
+      },
+      async loadRestaurantSource(context, window, computedAt) {
+        return {
+          ...context,
+          window,
+          computedAt,
+          resources: [],
+          serviceTurns: [],
+          allocations: [],
+          bookings: [],
+        };
+      },
+      async upsert(row) {
+        upserted.push(`${row.metricKey}:${row.periodStart.toISOString()}`);
+      },
+    }, at);
+
+    expect(result).toEqual({ organizations: 1, periods: 2, upserted: 14 });
+    expect(new Set(upserted).size).toBe(14);
+  });
+});

--- a/apps/web/lib/performance/business-metric-rollup.ts
+++ b/apps/web/lib/performance/business-metric-rollup.ts
@@ -1,0 +1,411 @@
+import { createHash } from "node:crypto";
+
+import {
+  getPerformanceMetricDefinition,
+  type PerformanceMetricDefinition,
+} from "@dpf/storefront-templates";
+
+export const RESTAURANT_METRIC_DEFINITION_VERSION = "restaurant-v1";
+
+export interface MetricWindow {
+  periodKey: string;
+  start: Date;
+  end: Date;
+  timezone: string;
+}
+
+export interface RestaurantMetricSource {
+  organizationId: string;
+  storefrontId: string;
+  window: MetricWindow;
+  computedAt: Date;
+  hoursConfirmedAt: Date | null;
+  businessHours: Record<string, { open: string; close: string } | null> | null;
+  resources: readonly { id: string; kind: string; status: string }[];
+  serviceTurns: readonly {
+    id: string;
+    startedAt: Date;
+    closedAt: Date | null;
+    covers: number | null;
+  }[];
+  allocations: readonly {
+    resourceId: string | null;
+    serviceTurnId: string | null;
+    startsAt: Date;
+    endsAt: Date;
+  }[];
+  bookings: readonly {
+    id: string;
+    scheduledAt: Date;
+    status: string;
+    hasServiceTurn: boolean;
+  }[];
+}
+
+export interface BusinessMetricRollupInput {
+  organizationId: string;
+  metricKey: string;
+  periodStart: Date;
+  periodEnd: Date;
+  timezone: string;
+  dimensionsHash: string;
+  dimensions: Record<string, string>;
+  value: number | null;
+  unit: PerformanceMetricDefinition["unit"];
+  availability: "available" | "unavailable";
+  unavailableReason: string | null;
+  definitionVersion: string;
+  sourceWatermark: Date;
+  sourceLineage: {
+    sourceModels: readonly string[];
+    sourceRows: number;
+    storefrontId: string;
+  };
+}
+
+export interface RestaurantMetricContext {
+  organizationId: string;
+  storefrontId: string;
+  timezone: string;
+  hoursConfirmedAt: Date | null;
+  businessHours: Record<string, { open: string; close: string } | null> | null;
+}
+
+export interface BusinessMetricRollupDeps {
+  listRestaurantContexts(): Promise<readonly RestaurantMetricContext[]>;
+  loadRestaurantSource(
+    context: RestaurantMetricContext,
+    window: MetricWindow,
+    computedAt: Date,
+  ): Promise<RestaurantMetricSource>;
+  upsert(row: BusinessMetricRollupInput, computedAt: Date): Promise<void>;
+}
+
+function zonedParts(date: Date, timezone: string) {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+  const value = (type: Intl.DateTimeFormatPartTypes) =>
+    Number(parts.find((part) => part.type === type)?.value ?? "0");
+  return {
+    year: value("year"),
+    month: value("month"),
+    day: value("day"),
+    hour: value("hour"),
+    minute: value("minute"),
+    second: value("second"),
+  };
+}
+
+function localMidnightUtc(periodKey: string, timezone: string): Date {
+  const [year, month, day] = periodKey.split("-").map(Number);
+  const target = Date.UTC(year!, month! - 1, day!);
+  let candidate = new Date(target);
+  // Two passes cover offsets that change around a DST boundary.
+  for (let pass = 0; pass < 2; pass += 1) {
+    const parts = zonedParts(candidate, timezone);
+    const represented = Date.UTC(
+      parts.year,
+      parts.month - 1,
+      parts.day,
+      parts.hour,
+      parts.minute,
+      parts.second,
+    );
+    candidate = new Date(candidate.getTime() + (target - represented));
+  }
+  return candidate;
+}
+
+function localTimeUtc(periodKey: string, hhmm: string, timezone: string): Date | null {
+  const minute = minuteOfDay(hhmm);
+  if (minute === null) return null;
+  const [year, month, day] = periodKey.split("-").map(Number);
+  const target = Date.UTC(
+    year!,
+    month! - 1,
+    day!,
+    Math.floor(minute / 60),
+    minute % 60,
+  );
+  let candidate = new Date(target);
+  for (let pass = 0; pass < 2; pass += 1) {
+    const parts = zonedParts(candidate, timezone);
+    const represented = Date.UTC(
+      parts.year,
+      parts.month - 1,
+      parts.day,
+      parts.hour,
+      parts.minute,
+      parts.second,
+    );
+    candidate = new Date(candidate.getTime() + (target - represented));
+  }
+  return candidate;
+}
+
+function shiftPeriodKey(periodKey: string, days: number): string {
+  const [year, month, day] = periodKey.split("-").map(Number);
+  return new Date(Date.UTC(year!, month! - 1, day! + days)).toISOString().slice(0, 10);
+}
+
+export function restaurantMetricWindow(at: Date, timezone: string): MetricWindow {
+  const parts = zonedParts(at, timezone);
+  const periodKey = [parts.year, parts.month, parts.day]
+    .map((value, index) => (index === 0 ? String(value) : String(value).padStart(2, "0")))
+    .join("-");
+  return {
+    periodKey,
+    start: localMidnightUtc(periodKey, timezone),
+    end: localMidnightUtc(shiftPeriodKey(periodKey, 1), timezone),
+    timezone,
+  };
+}
+
+function minuteOfDay(value: string): number | null {
+  const match = /^(\d{2}):(\d{2})$/.exec(value);
+  if (!match) return null;
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (hour > 23 || minute > 59) return null;
+  return hour * 60 + minute;
+}
+
+function operatingInterval(source: RestaurantMetricSource): [Date, Date] | null {
+  if (!source.hoursConfirmedAt || !source.businessHours) return null;
+  const weekday = new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    timeZone: "UTC",
+  })
+    .format(new Date(`${source.window.periodKey}T12:00:00.000Z`))
+    .toLowerCase();
+  const hours = source.businessHours[weekday];
+  if (!hours) return null;
+  const start = minuteOfDay(hours.open);
+  const end = minuteOfDay(hours.close);
+  // The first definition version deliberately rejects overnight intervals:
+  // assigning the post-midnight tail to a business date needs an explicit
+  // cross-day policy, and guessing would corrupt utilization.
+  if (start === null || end === null || end <= start) return null;
+  const startsAt = localTimeUtc(source.window.periodKey, hours.open, source.window.timezone);
+  const endsAt = localTimeUtc(source.window.periodKey, hours.close, source.window.timezone);
+  return startsAt && endsAt ? [startsAt, endsAt] : null;
+}
+
+function median(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  const ordered = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(ordered.length / 2);
+  return ordered.length % 2 === 0
+    ? (ordered[middle - 1]! + ordered[middle]!) / 2
+    : ordered[middle]!;
+}
+
+function occupiedMinutes(
+  source: RestaurantMetricSource,
+  interval: readonly [Date, Date],
+): number {
+  const byResource = new Map<string, Array<[number, number]>>();
+  for (const allocation of source.allocations) {
+    if (!allocation.resourceId || !allocation.serviceTurnId) continue;
+    const start = Math.max(
+      allocation.startsAt.getTime(),
+      source.window.start.getTime(),
+      interval[0].getTime(),
+    );
+    const end = Math.min(
+      allocation.endsAt.getTime(),
+      source.window.end.getTime(),
+      interval[1].getTime(),
+    );
+    if (end <= start) continue;
+    const intervals = byResource.get(allocation.resourceId) ?? [];
+    intervals.push([start, end]);
+    byResource.set(allocation.resourceId, intervals);
+  }
+
+  let totalMs = 0;
+  for (const intervals of byResource.values()) {
+    intervals.sort((a, b) => a[0] - b[0]);
+    let [currentStart, currentEnd] = intervals[0]!;
+    for (const [start, end] of intervals.slice(1)) {
+      if (start <= currentEnd) currentEnd = Math.max(currentEnd, end);
+      else {
+        totalMs += currentEnd - currentStart;
+        currentStart = start;
+        currentEnd = end;
+      }
+    }
+    totalMs += currentEnd - currentStart;
+  }
+  return totalMs / 60_000;
+}
+
+function row(
+  source: RestaurantMetricSource,
+  metricKey: string,
+  value: number | null,
+  unavailableReason: string | null,
+  sourceModels: readonly string[],
+  sourceRows: number,
+): BusinessMetricRollupInput {
+  const definition = getPerformanceMetricDefinition(metricKey);
+  if (!definition) throw new Error(`Unknown performance metric definition: ${metricKey}`);
+  const dimensions = { storefrontId: source.storefrontId };
+  return {
+    organizationId: source.organizationId,
+    metricKey,
+    periodStart: source.window.start,
+    periodEnd: source.window.end,
+    timezone: source.window.timezone,
+    dimensionsHash: createHash("sha256").update(JSON.stringify(dimensions)).digest("hex"),
+    dimensions,
+    value,
+    unit: definition.unit,
+    availability: unavailableReason ? "unavailable" : "available",
+    unavailableReason,
+    definitionVersion: RESTAURANT_METRIC_DEFINITION_VERSION,
+    sourceWatermark: source.computedAt,
+    sourceLineage: { sourceModels, sourceRows, storefrontId: source.storefrontId },
+  };
+}
+
+export function buildRestaurantMetricRows(
+  source: RestaurantMetricSource,
+): BusinessMetricRollupInput[] {
+  const coverValues = source.serviceTurns.map((turn) => turn.covers);
+  const coversMissing = coverValues.some((value) => value === null);
+  const covers = coversMissing
+    ? null
+    : coverValues.reduce<number>((sum, value) => sum + (value ?? 0), 0);
+
+  const completedMinutes = source.serviceTurns.flatMap((turn) =>
+    turn.closedAt
+      ? [(turn.closedAt.getTime() - turn.startedAt.getTime()) / 60_000]
+      : [],
+  );
+  const turnTime = median(completedMinutes);
+
+  const activeTables = source.resources.filter(
+    (resource) => resource.kind === "table" && resource.status === "active",
+  ).length;
+  const openInterval = operatingInterval(source);
+  const availableMinutes = openInterval
+    ? (openInterval[1].getTime() - openInterval[0].getTime()) / 60_000
+    : null;
+  const utilizationDenominator =
+    availableMinutes !== null && availableMinutes > 0 && activeTables > 0
+      ? availableMinutes * activeTables
+      : null;
+
+  const eligibleBookings = source.bookings.filter(
+    (booking) =>
+      booking.scheduledAt <= source.computedAt &&
+      !["cancelled", "canceled", "void"].includes(booking.status),
+  );
+  const missedBookings = eligibleBookings.filter(
+    (booking) =>
+      ["no_show", "no-show"].includes(booking.status) || !booking.hasServiceTurn,
+  );
+
+  return [
+    row(
+      source,
+      "covers",
+      covers,
+      coversMissing ? "One or more seated parties has no recorded party size." : null,
+      ["HospitalityServiceTurn", "StorefrontBooking"],
+      source.serviceTurns.length,
+    ),
+    row(
+      source,
+      "turn-time",
+      turnTime,
+      turnTime === null ? "No completed service turns exist in this period." : null,
+      ["HospitalityServiceTurn"],
+      completedMinutes.length,
+    ),
+    row(
+      source,
+      "table-utilization",
+      utilizationDenominator === null || openInterval === null
+        ? null
+        : occupiedMinutes(source, openInterval) / utilizationDenominator,
+      !source.hoursConfirmedAt
+        ? "Table utilization requires confirmed business hours."
+        : availableMinutes === null || availableMinutes <= 0
+          ? "No valid open interval exists for this period."
+          : activeTables === 0
+            ? "No active table resources exist for this storefront."
+            : null,
+      ["HospitalityCapacityAllocation", "HospitalityResource", "BusinessProfile"],
+      source.allocations.length + source.resources.length,
+    ),
+    row(
+      source,
+      "wait-no-show-rate",
+      eligibleBookings.length > 0 ? missedBookings.length / eligibleBookings.length : null,
+      eligibleBookings.length === 0 ? "No eligible bookings exist in this period." : null,
+      ["StorefrontBooking", "HospitalityServiceTurn"],
+      eligibleBookings.length,
+    ),
+    row(
+      source,
+      "sales",
+      null,
+      "Recognized restaurant sales are not yet linked to service turns.",
+      ["StorefrontOrder"],
+      0,
+    ),
+    row(
+      source,
+      "average-check",
+      null,
+      "Average check requires recognized sales linked to closed restaurant checks.",
+      ["StorefrontOrder", "HospitalityServiceTurn"],
+      0,
+    ),
+    row(
+      source,
+      "labor-percentage",
+      null,
+      "Labor percentage requires canonical labor cost linked to restaurant sales.",
+      ["StaffingAssignment", "StorefrontOrder"],
+      0,
+    ),
+  ];
+}
+
+export async function aggregateBusinessMetrics(
+  deps: BusinessMetricRollupDeps,
+  at = new Date(),
+): Promise<{ organizations: number; periods: number; upserted: number }> {
+  const contexts = await deps.listRestaurantContexts();
+  let periods = 0;
+  let upserted = 0;
+
+  for (const context of contexts) {
+    const current = restaurantMetricWindow(at, context.timezone);
+    const previous = restaurantMetricWindow(
+      new Date(current.start.getTime() - 1),
+      context.timezone,
+    );
+    for (const window of [previous, current]) {
+      const source = await deps.loadRestaurantSource(context, window, at);
+      for (const rollup of buildRestaurantMetricRows(source)) {
+        await deps.upsert(rollup, at);
+        upserted += 1;
+      }
+      periods += 1;
+    }
+  }
+
+  return { organizations: contexts.length, periods, upserted };
+}

--- a/apps/web/lib/performance/business-performance-provider.test.ts
+++ b/apps/web/lib/performance/business-performance-provider.test.ts
@@ -1,14 +1,219 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { loadBusinessPerformance } from "./business-performance-provider";
+import {
+  buildBusinessPerformanceReadModel,
+  createBusinessPerformanceProvider,
+  loadBusinessPerformance,
+  type PersistedMetricRow,
+} from "./business-performance-provider";
+
+const row = (
+  metricKey: string,
+  periodStart: string,
+  value: number | null,
+  availability: "available" | "unavailable" = value === null ? "unavailable" : "available",
+  overrides: Partial<PersistedMetricRow> = {},
+): PersistedMetricRow => ({
+  metricKey,
+  periodStart: new Date(periodStart),
+  periodEnd: new Date(new Date(periodStart).getTime() + 86_400_000),
+  timezone: "America/Chicago",
+  value,
+  unit: metricKey === "covers" ? "count" : "duration",
+  availability,
+  unavailableReason: availability === "unavailable" ? "Canonical source is not connected." : null,
+  definitionVersion: "restaurant-v1",
+  sourceWatermark: new Date("2026-08-01T01:30:00.000Z"),
+  computedAt: new Date("2026-08-01T01:30:00.000Z"),
+  sourceLineage: { sourceModels: ["HospitalityServiceTurn"], sourceRows: 3 },
+  ...overrides,
+});
+
+describe("buildBusinessPerformanceReadModel", () => {
+  it("selects the latest period, joins prior-period comparisons, and retains unavailable truth", () => {
+    const model = buildBusinessPerformanceReadModel({
+      archetypeId: "restaurant",
+      rows: [
+        row("covers", "2026-07-30T05:00:00.000Z", 80),
+        row("covers", "2026-07-31T05:00:00.000Z", 100),
+        row("turn-time", "2026-07-31T05:00:00.000Z", null),
+      ],
+      now: new Date("2026-08-01T02:00:00.000Z"),
+    });
+
+    expect(model.status).toBe("ready");
+    if (model.status !== "ready") return;
+    expect(model.periodLabel).toBe("Jul 31, 2026");
+    expect(model.freshness).toBe("fresh");
+    expect(model.availablePeriods).toEqual([
+      { key: "2026-07-31", label: "Jul 31, 2026", selected: true },
+      { key: "2026-07-30", label: "Jul 30, 2026", selected: false },
+    ]);
+    expect(model.trendPoints).toEqual([
+      { periodKey: "2026-07-30", periodLabel: "Jul 30, 2026", values: expect.objectContaining({ covers: 80 }) },
+      { periodKey: "2026-07-31", periodLabel: "Jul 31, 2026", values: expect.objectContaining({ covers: 100 }) },
+    ]);
+    expect(model.metricValues.find((metric) => metric.key === "covers")).toMatchObject({
+      value: 100,
+      comparisonValue: 80,
+      comparisonDelta: 0.25,
+      availability: "available",
+    });
+    expect(model.metricValues.find((metric) => metric.key === "turn-time")).toMatchObject({
+      value: null,
+      availability: "unavailable",
+      unavailableReason: "Canonical source is not connected.",
+    });
+  });
+
+  it("classifies an old snapshot as stale without discarding it", () => {
+    const model = buildBusinessPerformanceReadModel({
+      archetypeId: "restaurant",
+      rows: [row("covers", "2026-07-31T05:00:00.000Z", 100)],
+      now: new Date("2026-08-01T05:00:01.000Z"),
+    });
+    expect(model).toMatchObject({ status: "ready", freshness: "stale" });
+  });
+
+  it("uses the oldest metric watermark so one fresh metric cannot hide a stale sibling", () => {
+    const model = buildBusinessPerformanceReadModel({
+      archetypeId: "restaurant",
+      rows: [
+        row("covers", "2026-07-31T05:00:00.000Z", 100),
+        row("turn-time", "2026-07-31T05:00:00.000Z", 70, "available", {
+          sourceWatermark: new Date("2026-07-31T20:00:00.000Z"),
+        }),
+      ],
+      now: new Date("2026-08-01T02:00:00.000Z"),
+    });
+
+    expect(model).toMatchObject({
+      status: "ready",
+      freshness: "stale",
+      asOf: new Date("2026-07-31T20:00:00.000Z"),
+    });
+  });
+
+  it("honors a valid requested period and compares it with the next earlier period", () => {
+    const model = buildBusinessPerformanceReadModel({
+      archetypeId: "restaurant",
+      selectedPeriod: "2026-07-30",
+      rows: [
+        row("covers", "2026-07-29T05:00:00.000Z", 70),
+        row("covers", "2026-07-30T05:00:00.000Z", 80),
+        row("covers", "2026-07-31T05:00:00.000Z", 100),
+      ],
+    });
+    expect(model).toMatchObject({ status: "ready", periodLabel: "Jul 30, 2026" });
+    if (model.status !== "ready") return;
+    expect(model.metricValues.find((metric) => metric.key === "covers")).toMatchObject({
+      value: 80,
+      comparisonValue: 70,
+    });
+  });
+});
 
 describe("loadBusinessPerformance", () => {
   it("returns an attributed setup state without fabricated metric values", async () => {
-    await expect(loadBusinessPerformance()).resolves.toEqual({
+    await expect(
+      loadBusinessPerformance({ userId: "user-owner" }, {
+        async load() {
+          return {
+            status: "not-configured",
+            reason: "No rollup exists yet.",
+            asOf: null,
+            metricValues: [],
+            source: "business-performance-read-model",
+          };
+        },
+      }),
+    ).resolves.toMatchObject({
       status: "not-configured",
-      asOf: null,
+      reason: "No rollup exists yet.",
       metricValues: [],
-      source: "business-performance-read-model",
     });
+  });
+
+  it("loads only the authenticated user's current organization when multiple organizations exist", async () => {
+    const db = {
+      platformSetupProgress: {
+        findUnique: vi.fn(async () => ({ organizationId: "org-current" })),
+      },
+      storefrontConfig: {
+        findUnique: vi.fn(async () => ({
+          organizationId: "org-current",
+          archetype: { archetypeId: "restaurant" },
+        })),
+        findMany: vi.fn(),
+      },
+      businessMetricRollup: {
+        findMany: vi.fn(async () => []),
+      },
+    };
+
+    await createBusinessPerformanceProvider(db as never).load({ userId: "user-owner" });
+
+    expect(db.platformSetupProgress.findUnique).toHaveBeenCalledWith({
+      where: { userId: "user-owner" },
+      select: { organizationId: true },
+    });
+    expect(db.storefrontConfig.findUnique).toHaveBeenCalledWith(expect.objectContaining({
+      where: { organizationId: "org-current" },
+    }));
+    expect(db.storefrontConfig.findMany).not.toHaveBeenCalled();
+    expect(db.businessMetricRollup.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { organizationId: "org-current" },
+    }));
+  });
+
+  it("refuses an unmapped user in a multi-organization install without reading any rollups", async () => {
+    const db = {
+      platformSetupProgress: {
+        findUnique: vi.fn(async () => null),
+      },
+      storefrontConfig: {
+        findUnique: vi.fn(),
+        findMany: vi.fn(async () => [
+          { organizationId: "org-a", archetype: { archetypeId: "restaurant" } },
+          { organizationId: "org-b", archetype: { archetypeId: "restaurant" } },
+        ]),
+      },
+      businessMetricRollup: {
+        findMany: vi.fn(),
+      },
+    };
+
+    const result = await createBusinessPerformanceProvider(db as never).load({ userId: "user-unmapped" });
+
+    expect(result).toMatchObject({
+      status: "not-configured",
+      reason: expect.stringContaining("current organization"),
+    });
+    expect(db.storefrontConfig.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 2 }));
+    expect(db.storefrontConfig.findUnique).not.toHaveBeenCalled();
+    expect(db.businessMetricRollup.findMany).not.toHaveBeenCalled();
+  });
+
+  it("keeps the legacy fallback only when exactly one storefront organization exists", async () => {
+    const db = {
+      platformSetupProgress: {
+        findUnique: vi.fn(async () => ({ organizationId: null })),
+      },
+      storefrontConfig: {
+        findUnique: vi.fn(),
+        findMany: vi.fn(async () => [
+          { organizationId: "org-only", archetype: { archetypeId: "restaurant" } },
+        ]),
+      },
+      businessMetricRollup: {
+        findMany: vi.fn(async () => []),
+      },
+    };
+
+    await createBusinessPerformanceProvider(db as never).load({ userId: "legacy-owner" });
+
+    expect(db.businessMetricRollup.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { organizationId: "org-only" },
+    }));
   });
 });

--- a/apps/web/lib/performance/business-performance-provider.ts
+++ b/apps/web/lib/performance/business-performance-provider.ts
@@ -1,35 +1,366 @@
-/**
- * Truthful read boundary for the owner/manager Performance view.
- *
- * The historical read model lands in BI-PLAN-005. Until then this provider
- * returns an explicit setup state, never fabricated zeroes or demo metrics.
- */
+import {
+  getPerformanceMetricDefinition,
+  resolvePerformanceMetricPack,
+  type PerformanceMetricDefinition,
+} from "@dpf/storefront-templates";
+
 export interface UnconfiguredBusinessPerformance {
   status: "not-configured";
+  reason: string;
   asOf: null;
   metricValues: readonly [];
   source: "business-performance-read-model";
 }
 
-export type BusinessPerformanceReadModel = UnconfiguredBusinessPerformance;
-
-export interface BusinessPerformanceProvider {
-  load(): Promise<BusinessPerformanceReadModel>;
+export interface PersistedMetricRow {
+  metricKey: string;
+  periodStart: Date;
+  periodEnd: Date;
+  timezone: string;
+  value: number | null;
+  unit: string;
+  availability: "available" | "unavailable";
+  unavailableReason: string | null;
+  definitionVersion: string;
+  sourceWatermark: Date;
+  computedAt: Date;
+  sourceLineage: unknown;
 }
 
-const unconfiguredProvider: BusinessPerformanceProvider = {
-  async load() {
-    return {
-      status: "not-configured",
-      asOf: null,
-      metricValues: [],
-      source: "business-performance-read-model",
-    };
+export interface BusinessPerformanceMetricValue {
+  key: string;
+  label: string;
+  unit: PerformanceMetricDefinition["unit"];
+  value: number | null;
+  comparisonValue: number | null;
+  comparisonDelta: number | null;
+  availability: "available" | "unavailable";
+  unavailableReason: string | null;
+  definition: string;
+  definitionVersion: string | null;
+  sourceOwner: string;
+  sourceWatermark: Date | null;
+  sourceLineage: unknown;
+  drilldownRoute?: string;
+}
+
+export interface BusinessPerformanceTrendPoint {
+  periodKey: string;
+  periodLabel: string;
+  values: Readonly<Record<string, number | null>>;
+}
+
+export interface ReadyBusinessPerformance {
+  status: "ready";
+  archetypeId: string;
+  periodLabel: string;
+  periodStart: Date;
+  periodEnd: Date;
+  timezone: string;
+  asOf: Date;
+  freshness: "fresh" | "stale";
+  periodState: "in-progress" | "finalized";
+  availablePeriods: readonly { key: string; label: string; selected: boolean }[];
+  metricValues: readonly BusinessPerformanceMetricValue[];
+  trendPoints: readonly BusinessPerformanceTrendPoint[];
+  sections: {
+    headline: readonly string[];
+    operating: readonly string[];
+    financial: readonly string[];
+    customer: readonly string[];
+    workforce: readonly string[];
+  };
+  source: "business-performance-read-model";
+}
+
+export type BusinessPerformanceReadModel =
+  | UnconfiguredBusinessPerformance
+  | ReadyBusinessPerformance;
+
+export interface BusinessPerformanceLoadInput {
+  userId: string;
+  period?: string;
+}
+
+export interface BusinessPerformanceProvider {
+  load(input: BusinessPerformanceLoadInput): Promise<BusinessPerformanceReadModel>;
+}
+
+type StorefrontPerformanceContext = {
+  organizationId: string;
+  archetype: { archetypeId: string };
+};
+
+type PersistedMetricDbRow = Omit<PersistedMetricRow, "value" | "availability"> & {
+  value: unknown;
+  availability: string;
+};
+
+export interface BusinessPerformanceDataSource {
+  platformSetupProgress: {
+    findUnique(args: unknown): Promise<{ organizationId: string | null } | null>;
+  };
+  storefrontConfig: {
+    findUnique(args: unknown): Promise<StorefrontPerformanceContext | null>;
+    findMany(args: unknown): Promise<StorefrontPerformanceContext[]>;
+  };
+  businessMetricRollup: {
+    findMany(args: unknown): Promise<PersistedMetricDbRow[]>;
+  };
+}
+
+function unconfigured(reason: string): UnconfiguredBusinessPerformance {
+  return {
+    status: "not-configured",
+    reason,
+    asOf: null,
+    metricValues: [],
+    source: "business-performance-read-model",
+  };
+}
+
+function periodLabel(periodStart: Date, timezone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(periodStart);
+}
+
+function periodKey(periodStart: Date, timezone: string): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(periodStart);
+  const value = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? "";
+  return `${value("year")}-${value("month")}-${value("day")}`;
+}
+
+function uniqueMetricKeys(archetypeId: string): string[] {
+  const pack = resolvePerformanceMetricPack(archetypeId);
+  return [...new Set([
+    ...pack.headline,
+    ...pack.operating,
+    ...pack.financial,
+    ...pack.customer,
+    ...pack.workforce,
+  ])];
+}
+
+export function buildBusinessPerformanceReadModel(input: {
+  archetypeId: string;
+  rows: readonly PersistedMetricRow[];
+  now?: Date;
+  selectedPeriod?: string;
+}): BusinessPerformanceReadModel {
+  if (input.rows.length === 0) {
+    return unconfigured("The first historical performance snapshot has not been computed yet.");
+  }
+
+  const periods = [...new Set(input.rows.map((row) => row.periodStart.getTime()))].sort(
+    (a, b) => b - a,
+  );
+  const selectedStart = input.selectedPeriod
+    ? periods.find((start) => {
+        const candidate = input.rows.find((row) => row.periodStart.getTime() === start);
+        return candidate ? periodKey(candidate.periodStart, candidate.timezone) === input.selectedPeriod : false;
+      })
+    : undefined;
+  const currentStart = selectedStart ?? periods[0]!;
+  const currentIndex = periods.indexOf(currentStart);
+  const priorStart = periods[currentIndex + 1] ?? null;
+  const currentRows = input.rows.filter((row) => row.periodStart.getTime() === currentStart);
+  const priorRows = input.rows.filter((row) => row.periodStart.getTime() === priorStart);
+  const currentByKey = new Map(currentRows.map((row) => [row.metricKey, row]));
+  const priorByKey = new Map(priorRows.map((row) => [row.metricKey, row]));
+  const reference = currentRows[0]!;
+  // The dashboard-wide freshness boundary is the least-current contributing
+  // metric. Using the newest watermark would let one fresh source conceal a
+  // stale sibling while still labelling the whole snapshot fresh.
+  const asOf = new Date(
+    Math.min(...currentRows.map((row) => row.sourceWatermark.getTime())),
+  );
+  const now = input.now ?? new Date();
+  const isFinalizedPeriod = asOf.getTime() >= reference.periodEnd.getTime();
+
+  const metricValues = uniqueMetricKeys(input.archetypeId).flatMap((key) => {
+    const definition = getPerformanceMetricDefinition(key);
+    if (!definition) return [];
+    const current = currentByKey.get(key);
+    const prior = priorByKey.get(key);
+    const currentValue = current?.availability === "available" ? current.value : null;
+    const priorValue = prior?.availability === "available" ? prior.value : null;
+    return [{
+      key,
+      label: definition.label,
+      unit: definition.unit,
+      value: currentValue,
+      comparisonValue: priorValue,
+      comparisonDelta:
+        currentValue !== null && priorValue !== null && priorValue !== 0
+          ? (currentValue - priorValue) / Math.abs(priorValue)
+          : null,
+      availability: current?.availability ?? "unavailable",
+      unavailableReason:
+        current?.unavailableReason ?? "No snapshot exists for this metric and period.",
+      definition: definition.aggregation,
+      definitionVersion: current?.definitionVersion ?? null,
+      sourceOwner: definition.sourceOwner,
+      sourceWatermark: current?.sourceWatermark ?? null,
+      sourceLineage: current?.sourceLineage ?? null,
+      ...(definition.drilldownRoute ? { drilldownRoute: definition.drilldownRoute } : {}),
+    } satisfies BusinessPerformanceMetricValue];
+  });
+  const trendPoints = [...periods]
+    .slice(0, 14)
+    .reverse()
+    .map((start) => {
+      const periodRows = input.rows.filter((row) => row.periodStart.getTime() === start);
+      const periodReference = periodRows[0]!;
+      return {
+        periodKey: periodKey(periodReference.periodStart, periodReference.timezone),
+        periodLabel: periodLabel(periodReference.periodStart, periodReference.timezone),
+        values: Object.fromEntries(
+          uniqueMetricKeys(input.archetypeId).map((key) => {
+            const metric = periodRows.find((row) => row.metricKey === key);
+            return [key, metric?.availability === "available" ? metric.value : null];
+          }),
+        ),
+      };
+    });
+
+  return {
+    status: "ready",
+    archetypeId: input.archetypeId,
+    periodLabel: periodLabel(reference.periodStart, reference.timezone),
+    periodStart: reference.periodStart,
+    periodEnd: reference.periodEnd,
+    timezone: reference.timezone,
+    asOf,
+    freshness:
+      isFinalizedPeriod || now.getTime() - asOf.getTime() <= 2 * 60 * 60 * 1000
+        ? "fresh"
+        : "stale",
+    periodState: isFinalizedPeriod ? "finalized" : "in-progress",
+    availablePeriods: [
+      ...new Set([...periods.slice(0, 3), currentStart]),
+    ].sort((a, b) => b - a).map((start) => {
+      const row = input.rows.find((candidate) => candidate.periodStart.getTime() === start)!;
+      return {
+        key: periodKey(row.periodStart, row.timezone),
+        label: periodLabel(row.periodStart, row.timezone),
+        selected: start === currentStart,
+      };
+    }),
+    metricValues,
+    trendPoints,
+    sections: resolvePerformanceMetricPack(input.archetypeId),
+    source: "business-performance-read-model",
+  };
+}
+
+async function resolvePerformanceContext(
+  db: BusinessPerformanceDataSource,
+  userId: string,
+): Promise<StorefrontPerformanceContext | UnconfiguredBusinessPerformance> {
+  const progress = await db.platformSetupProgress.findUnique({
+    where: { userId },
+    select: { organizationId: true },
+  });
+
+  if (progress?.organizationId) {
+    const config = await db.storefrontConfig.findUnique({
+      where: { organizationId: progress.organizationId },
+      select: {
+        organizationId: true,
+        archetype: { select: { archetypeId: true } },
+      },
+    });
+    return config ?? unconfigured("Finish storefront setup before performance is calculated.");
+  }
+
+  // Legacy single-organization installs may predate the user-to-organization
+  // setup link. Inspect at most two configuration identities: one is a safe,
+  // deterministic compatibility fallback; two means the current organization
+  // is ambiguous and no tenant-owned rollup may be read.
+  const configs = await db.storefrontConfig.findMany({
+    orderBy: { organizationId: "asc" },
+    take: 2,
+    select: {
+      organizationId: true,
+      archetype: { select: { archetypeId: true } },
+    },
+  });
+  if (configs.length === 0) {
+    return unconfigured("Finish storefront setup before performance is calculated.");
+  }
+  if (configs.length > 1) {
+    return unconfigured(
+      "We could not determine your current organization, so no performance data was loaded.",
+    );
+  }
+  return configs[0]!;
+}
+
+export function createBusinessPerformanceProvider(
+  db: BusinessPerformanceDataSource,
+): BusinessPerformanceProvider {
+  return {
+    async load(input) {
+      const context = await resolvePerformanceContext(db, input.userId);
+      if ("status" in context) return context;
+
+      const rows = await db.businessMetricRollup.findMany({
+        where: { organizationId: context.organizationId },
+        orderBy: [{ periodStart: "desc" }, { metricKey: "asc" }],
+        // Seven restaurant metrics × ~35 local-business days. The page still
+        // reads one bounded indexed projection query, never source history.
+        take: 250,
+        select: {
+          metricKey: true,
+          periodStart: true,
+          periodEnd: true,
+          timezone: true,
+          value: true,
+          unit: true,
+          availability: true,
+          unavailableReason: true,
+          definitionVersion: true,
+          sourceWatermark: true,
+          computedAt: true,
+          sourceLineage: true,
+        },
+      });
+
+      return buildBusinessPerformanceReadModel({
+        archetypeId: context.archetype.archetypeId,
+        ...(input.period ? { selectedPeriod: input.period } : {}),
+        rows: rows.map((row) => ({
+          ...row,
+          value: row.value === null ? null : Number(row.value),
+          availability: row.availability === "available" ? "available" : "unavailable",
+        })),
+      });
+    },
+  };
+}
+
+const defaultProvider: BusinessPerformanceProvider = {
+  async load(input) {
+    const { prisma } = await import("@dpf/db");
+    return createBusinessPerformanceProvider(
+      prisma as unknown as BusinessPerformanceDataSource,
+    ).load(input);
   },
 };
 
 export async function loadBusinessPerformance(
-  provider: BusinessPerformanceProvider = unconfiguredProvider,
+  input: BusinessPerformanceLoadInput,
+  provider: BusinessPerformanceProvider = defaultProvider,
 ): Promise<BusinessPerformanceReadModel> {
-  return provider.load();
+  return provider.load(input);
 }

--- a/apps/web/lib/performance/performance-decision-summary.test.ts
+++ b/apps/web/lib/performance/performance-decision-summary.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import type { BusinessPerformanceMetricValue } from "./business-performance-provider";
+import { buildPerformanceDecisionSummary } from "./performance-decision-summary";
+
+function metric(
+  key: string,
+  comparisonDelta: number | null,
+  overrides: Partial<BusinessPerformanceMetricValue> = {},
+): BusinessPerformanceMetricValue {
+  return {
+    key,
+    label: key,
+    unit: "count",
+    value: 10,
+    comparisonValue: comparisonDelta === null ? null : 8,
+    comparisonDelta,
+    availability: "available",
+    unavailableReason: null,
+    definition: `definition for ${key}`,
+    definitionVersion: "v1",
+    sourceOwner: "test-source",
+    sourceWatermark: new Date("2026-08-01T01:30:00.000Z"),
+    sourceLineage: { sourceModels: ["TestFact"] },
+    ...overrides,
+  };
+}
+
+describe("buildPerformanceDecisionSummary", () => {
+  it("ranks observed changes by magnitude instead of storage order", () => {
+    const summary = buildPerformanceDecisionSummary({
+      metrics: [metric("small", 0.05), metric("largest", -0.4), metric("medium", 0.2)],
+      headlineKeys: ["small", "largest", "medium"],
+    });
+
+    expect(summary.observedChanges.map((item) => item.key)).toEqual([
+      "largest",
+      "medium",
+      "small",
+    ]);
+  });
+
+  it("calls unavailable headline metrics out for review without inventing desirability", () => {
+    const summary = buildPerformanceDecisionSummary({
+      metrics: [
+        metric("covers", 0.25),
+        metric("sales", null, {
+          availability: "unavailable",
+          value: null,
+          unavailableReason: "No payment source is connected.",
+        }),
+      ],
+      headlineKeys: ["covers", "sales"],
+    });
+
+    expect(summary.reviewItems).toEqual([
+      {
+        key: "sales",
+        label: "sales",
+        reason: "No payment source is connected.",
+        kind: "missing-headline",
+      },
+      {
+        key: "covers",
+        label: "covers",
+        reason: "Moved 25% versus the prior period; review context before acting.",
+        kind: "observed-change",
+      },
+    ]);
+    expect(JSON.stringify(summary)).not.toMatch(/good|bad|better|worse|favorable|unfavorable/i);
+  });
+
+  it("refuses to claim a cause when the read model contains lineage but no driver analysis", () => {
+    const summary = buildPerformanceDecisionSummary({
+      metrics: [metric("covers", 0.25)],
+      headlineKeys: ["covers"],
+    });
+
+    expect(summary.driverEvidence).toEqual({
+      status: "not-available",
+      message: "Connected sources explain where each number came from, but they do not yet prove what caused the change.",
+    });
+  });
+});

--- a/apps/web/lib/performance/performance-decision-summary.ts
+++ b/apps/web/lib/performance/performance-decision-summary.ts
@@ -1,0 +1,79 @@
+import type { BusinessPerformanceMetricValue } from "./business-performance-provider";
+import { formatComparisonMagnitude } from "./performance-format";
+
+export interface PerformanceObservedChange {
+  key: string;
+  label: string;
+  delta: number;
+  direction: "increased" | "decreased" | "unchanged";
+}
+
+export interface PerformanceReviewItem {
+  key: string;
+  label: string;
+  reason: string;
+  kind: "missing-headline" | "observed-change";
+}
+
+export interface PerformanceDecisionSummary {
+  observedChanges: readonly PerformanceObservedChange[];
+  reviewItems: readonly PerformanceReviewItem[];
+  driverEvidence: {
+    status: "not-available";
+    message: string;
+  };
+}
+
+function direction(delta: number): PerformanceObservedChange["direction"] {
+  if (delta > 0) return "increased";
+  if (delta < 0) return "decreased";
+  return "unchanged";
+}
+
+/**
+ * Projects owner-facing observations from governed metric facts. The read model
+ * does not yet carry targets or causal-driver evidence, so this helper keeps
+ * movement neutral and makes the evidence boundary explicit.
+ */
+export function buildPerformanceDecisionSummary(input: {
+  metrics: readonly BusinessPerformanceMetricValue[];
+  headlineKeys: readonly string[];
+}): PerformanceDecisionSummary {
+  const headline = new Set(input.headlineKeys);
+  const observedChanges = input.metrics
+    .filter((metric): metric is BusinessPerformanceMetricValue & { comparisonDelta: number } =>
+      metric.comparisonDelta !== null)
+    .map((metric) => ({
+      key: metric.key,
+      label: metric.label,
+      delta: metric.comparisonDelta,
+      direction: direction(metric.comparisonDelta),
+    }))
+    .sort((left, right) => Math.abs(right.delta) - Math.abs(left.delta));
+
+  const missingHeadline: PerformanceReviewItem[] = input.metrics
+    .filter((metric) => headline.has(metric.key) && metric.availability === "unavailable")
+    .map((metric) => ({
+      key: metric.key,
+      label: metric.label,
+      reason: metric.unavailableReason ?? "No snapshot is available for this headline metric.",
+      kind: "missing-headline",
+    }));
+  const changedHeadline: PerformanceReviewItem[] = observedChanges
+    .filter((change) => headline.has(change.key))
+    .map((change) => ({
+      key: change.key,
+      label: change.label,
+      reason: `Moved ${formatComparisonMagnitude(change.delta)} versus the prior period; review context before acting.`,
+      kind: "observed-change",
+    }));
+
+  return {
+    observedChanges,
+    reviewItems: [...missingHeadline, ...changedHeadline].slice(0, 3),
+    driverEvidence: {
+      status: "not-available",
+      message: "Connected sources explain where each number came from, but they do not yet prove what caused the change.",
+    },
+  };
+}

--- a/apps/web/lib/performance/performance-export.test.ts
+++ b/apps/web/lib/performance/performance-export.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import type { ReadyBusinessPerformance } from "./business-performance-provider";
+import { buildPerformanceExportRows } from "./performance-export";
+
+describe("buildPerformanceExportRows", () => {
+  it("exports only selected-period aggregates and excludes source lineage identifiers", () => {
+    const performance = {
+      status: "ready",
+      periodLabel: "Jul 31, 2026",
+      metricValues: [{
+        label: "Covers",
+        value: 42,
+        unit: "count",
+        availability: "available",
+        unavailableReason: null,
+        comparisonValue: 40,
+        definitionVersion: "restaurant-v1",
+        sourceWatermark: new Date("2026-08-01T01:00:00.000Z"),
+        sourceLineage: {
+          storefrontId: "sf-sensitive",
+          customerId: "customer-never-export",
+          sourceModels: ["HospitalityServiceTurn"],
+        },
+      }],
+    } as unknown as ReadyBusinessPerformance;
+
+    const rows = buildPerformanceExportRows(performance);
+    expect(rows).toEqual([{
+      period: "Jul 31, 2026",
+      metric: "Covers",
+      value: 42,
+      unit: "count",
+      availability: "available",
+      unavailable_reason: "",
+      prior_period_value: 40,
+      definition_version: "restaurant-v1",
+      source_watermark: "2026-08-01T01:00:00.000Z",
+    }]);
+    expect(JSON.stringify(rows)).not.toContain("customer-never-export");
+    expect(JSON.stringify(rows)).not.toContain("sf-sensitive");
+  });
+});

--- a/apps/web/lib/performance/performance-export.ts
+++ b/apps/web/lib/performance/performance-export.ts
@@ -1,0 +1,16 @@
+import type { ReadyBusinessPerformance } from "./business-performance-provider";
+
+/** Aggregate-only export projection. No source-row identifiers cross this boundary. */
+export function buildPerformanceExportRows(performance: ReadyBusinessPerformance) {
+  return performance.metricValues.map((metric) => ({
+    period: performance.periodLabel,
+    metric: metric.label,
+    value: metric.value,
+    unit: metric.unit,
+    availability: metric.availability,
+    unavailable_reason: metric.unavailableReason ?? "",
+    prior_period_value: metric.comparisonValue,
+    definition_version: metric.definitionVersion ?? "",
+    source_watermark: metric.sourceWatermark?.toISOString() ?? "",
+  }));
+}

--- a/apps/web/lib/performance/performance-format.test.ts
+++ b/apps/web/lib/performance/performance-format.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  chartMetricValue,
+  formatComparisonDelta,
+  formatComparisonMagnitude,
+  formatMetricValue,
+} from "./performance-format";
+
+describe("performance metric formatting", () => {
+  it("formats business units consistently", () => {
+    expect(formatMetricValue(0.125, "percent")).toBe("12.5%");
+    expect(formatMetricValue(75, "duration")).toBe("1h 15m");
+    expect(formatMetricValue(null, "count")).toBe("Not available");
+    expect(formatComparisonDelta(0.25)).toBe("+25%");
+    expect(formatComparisonMagnitude(-0.25)).toBe("25%");
+  });
+
+  it("scales ratio-based chart values to human percentages", () => {
+    expect(chartMetricValue(0.25, "rate")).toBe(25);
+    expect(chartMetricValue(75, "duration")).toBe(75);
+  });
+});

--- a/apps/web/lib/performance/performance-format.ts
+++ b/apps/web/lib/performance/performance-format.ts
@@ -1,0 +1,45 @@
+import type { PerformanceMetricDefinition } from "@dpf/storefront-templates";
+
+export type MetricUnit = PerformanceMetricDefinition["unit"];
+
+export function formatMetricValue(value: number | null, unit: MetricUnit): string {
+  if (value === null) return "Not available";
+  switch (unit) {
+    case "currency":
+      return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+      }).format(value);
+    case "percent":
+    case "rate":
+      return new Intl.NumberFormat("en-US", {
+        style: "percent",
+        maximumFractionDigits: 1,
+      }).format(value);
+    case "duration": {
+      const hours = Math.floor(value / 60);
+      const minutes = Math.round(value % 60);
+      return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+    }
+    default:
+      return new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(value);
+  }
+}
+
+export function formatComparisonDelta(delta: number): string {
+  return `${delta > 0 ? "+" : ""}${new Intl.NumberFormat("en-US", {
+    style: "percent",
+    maximumFractionDigits: 1,
+  }).format(delta)}`;
+}
+
+export function formatComparisonMagnitude(delta: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "percent",
+    maximumFractionDigits: 1,
+  }).format(Math.abs(delta));
+}
+
+export function chartMetricValue(value: number | null, unit: MetricUnit): number | null {
+  return value !== null && (unit === "percent" || unit === "rate") ? value * 100 : value;
+}

--- a/apps/web/lib/queue/functions/business-metrics-aggregator.ts
+++ b/apps/web/lib/queue/functions/business-metrics-aggregator.ts
@@ -1,0 +1,38 @@
+import { cron } from "inngest";
+
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+/**
+ * Owner/manager metrics are refreshed off the request path. Recomputing the
+ * current and prior local-business day makes the job idempotent and lets a
+ * missed run self-heal without deleting the last valid snapshot.
+ */
+export const businessMetricsAggregator = inngest.createFunction(
+  {
+    id: "business/metrics-aggregator",
+    retries: 2,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron("17 * * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return step.run("aggregate-business-metrics", async () => {
+      const { aggregateBusinessMetrics } = await import(
+        "@/lib/performance/business-metric-rollup"
+      );
+      const { defaultBusinessMetricRollupDeps } = await import(
+        "@/lib/performance/business-metric-rollup.server"
+      );
+      const result = await aggregateBusinessMetrics(
+        defaultBusinessMetricRollupDeps(),
+      );
+      console.log(
+        `[business-metrics] refreshed ${result.upserted} rollups across ${result.organizations} organization(s)`,
+      );
+      return result;
+    });
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -41,6 +41,7 @@ import { wikiLint } from "./wiki-lint";
 import { gitPromotionSandboxVerification } from "./git-promotion-sandbox-verification";
 import { skillMetricsAggregator } from "./skill-metrics-aggregator";
 import { queueMetricsAggregator } from "./queue-metrics-aggregator";
+import { businessMetricsAggregator } from "./business-metrics-aggregator";
 import { skillCurator } from "./skill-curator";
 import { mcpCallEfficiencyScan } from "./mcp-call-efficiency-scan";
 import { a2aCollaborationHealthScan } from "./a2a-collaboration-health-scan";
@@ -127,6 +128,7 @@ export const scheduledFunctions = [
   wikiLint,
   skillMetricsAggregator,
   queueMetricsAggregator, // EP-3516E23D P1: hourly QueueTelemetryEvent → QueueMetricSnapshot rollup
+  businessMetricsAggregator, // BI-PLAN-005: hourly operational sources → owner/manager BusinessMetricRollup
   skillCurator,
   mcpCallEfficiencyScan, // BI-A08EBAEC: daily ToolExecution thrash/volume/failure findings → PlatformNotification
   a2aCollaborationHealthScan, // BI-3003EE63: daily A2A edge health (failed/blocked/stuck/orphan) — slice 1 analyze+log

--- a/docs/architecture/operations-hot-path.md
+++ b/docs/architecture/operations-hot-path.md
@@ -82,3 +82,38 @@ constraints; they do not fork this hot-path contract.
 
 Historical metric providers and reporting modules are forbidden dependencies of
 the Operations hot path. A static boundary test enforces that separation.
+
+## Historical Performance boundary
+
+`BusinessMetricRollup` is the inverse side of that boundary: a tenant-scoped,
+definition-versioned projection keyed by metric, local-business period, and
+dimensions. An hourly idempotent job recomputes the current and prior business
+day from canonical domain sources. The `/performance` request reads only this
+bounded indexed projection; it never aggregates bookings, service turns,
+allocations, or resources on demand.
+
+Metric definitions and archetype packs remain code-owned in
+`packages/storefront-templates`; the database stores values, availability,
+definition version, source watermark, model-level lineage, and computation time.
+Unavailable source contracts are persisted as unavailable with a reason, never
+as zero. A failed job writes nothing, so the prior valid snapshot remains visible
+with a delayed-freshness state. Client boundaries receive only aggregate trend or
+export projections; source lineage and tenant identifiers stay server-side.
+
+## Design grounding
+
+- Existing specs/plans reviewed:
+  - `docs/superpowers/specs/2026-07-28-business-operations-and-performance-views-design.md`
+  - `docs/superpowers/plans/2026-07-28-business-operations-and-performance-views-plan.md`
+- Current code substrate reviewed:
+  - `apps/web/lib/performance/business-performance-provider.ts`
+  - `packages/storefront-templates/src/business-view-profile.ts`
+  - `apps/web/components/ui/report-kit/README.md`
+- Source of truth:
+  - `BusinessMetricRollup` is the bounded historical read model;
+    `PERFORMANCE_METRIC_DEFINITIONS` owns metric semantics and source owners.
+- Decision:
+  - extend the existing `/performance` route with report-kit progressive
+    disclosure and preserve the hard dependency boundary from Operations;
+    do not create another dashboard home or perform source aggregation during
+    an owner request.

--- a/docs/data-impact/2026-08-01-business-metric-rollup.data-impact.json
+++ b/docs/data-impact/2026-08-01-business-metric-rollup.data-impact.json
@@ -1,0 +1,70 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "BusinessMetricRollup is a tenant-scoped derived read model over canonical bookings, hospitality service turns, allocations, resources, and confirmed business hours; none of those operational authorities move into the rollup.",
+    "The owner/manager dashboard and CSV export contain aggregate metric values, availability reasons, definition versions, freshness, and model-level lineage only. Customer, staff, booking, table, demand, and actor identifiers are excluded.",
+    "A failed refresh preserves the prior valid rows. Re-running the current and prior local-business day replaces only the identical organization/metric/period/dimensions/definition-version projection.",
+    "The Performance route resolves Organization from the authenticated user's setup context. A legacy single-organization install may use its sole configured storefront; an unmapped user in a multi-organization install is refused before any rollup query."
+  ],
+  "migration": {
+    "name": "20260801010000_add_business_metric_rollup + 20260812020500_type_business_metric_rollup_closed_sets",
+    "backfill": "The first migration is additive and creates an empty rollup table. The forward-only follow-up converts unit and availability to their closed Prisma/PostgreSQL enums without changing values. The hourly idempotent aggregator populates current and prior periods after deploy. Rollback disables the aggregator and Performance reader while retaining canonical operational evidence; removing derived rows is safe only through the organization lifecycle or an explicit projection rebuild."
+  },
+  "tests": [
+    "apps/web/lib/performance/business-metric-rollup.test.ts",
+    "apps/web/lib/performance/business-metric-rollup.server.test.ts",
+    "apps/web/lib/performance/business-performance-provider.test.ts",
+    "apps/web/lib/performance/performance-decision-summary.test.ts",
+    "apps/web/lib/performance/performance-export.test.ts",
+    "apps/web/lib/performance/performance-format.test.ts",
+    "apps/web/components/performance/BusinessPerformanceDashboard.test.tsx",
+    "apps/web/app/(shell)/performance/page.test.tsx",
+    "apps/web/lib/govern/data/assets.test.ts",
+    "apps/web/lib/govern/data/coverage.live.test.ts",
+    "packages/db/scripts/migration-safety-guard.mjs",
+    "scripts/check-data-impact.mjs"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:business-metric-rollup",
+      "prismaModel": "BusinessMetricRollup",
+      "lifecycleDisposition": "derived business record — retained under the owning organization for historical comparison, rebuilt idempotently from source authorities, and removed only with the owning organization or an explicit governed projection rebuild",
+      "fields": [
+        {
+          "fieldId": "data:business-metric-rollup#identity-and-scope",
+          "resolution": "inherited",
+          "reason": "id, organizationId, metricKey, period bounds, timezone, dimensionsHash, dimensions, and definitionVersion form the tenant-scoped reproducible projection identity",
+          "provenance": "Prisma identity plus the code-owned archetype metric catalog"
+        },
+        {
+          "fieldId": "data:business-metric-rollup#value-and-availability",
+          "resolution": "governed",
+          "reason": "aggregate values and explicit unavailable reasons can reveal confidential operating and financial performance even though they exclude row-level subjects",
+          "provenance": "idempotent business-metrics aggregator over canonical organization-owned sources",
+          "flags": [
+            "sensitive"
+          ],
+          "fieldPolicy": "owner/manager capability only, organization-scoped, local-only, and exported only as aggregate values for the selected period"
+        },
+        {
+          "fieldId": "data:business-metric-rollup#lineage-and-freshness",
+          "resolution": "governed",
+          "reason": "sourceWatermark, sourceLineage, computedAt, createdAt, and updatedAt make metric freshness and provenance auditable without copying source-row identifiers",
+          "provenance": "hourly rollup receipt and allow-listed model-level lineage",
+          "flags": [
+            "sensitive"
+          ],
+          "fieldPolicy": "organization-scoped audit metadata; lineage is restricted to source model names, aggregate row counts, and storefront scope"
+        },
+        {
+          "fieldId": "data:business-metric-rollup#organization",
+          "resolution": "inherited",
+          "reason": "the owning relation enforces tenant lifecycle and cascade semantics",
+          "provenance": "Prisma foreign key to Organization"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/user-guide/workspace/index.md
+++ b/docs/user-guide/workspace/index.md
@@ -23,8 +23,22 @@ The main rail separates two different decisions:
   layout alone.
 - **Performance** answers “how is the business doing over time, and what is
   driving the result?” It is available only to authorized owners and operations
-  managers. If historical sources are not configured, it says so instead of
-  displaying placeholder zeroes.
+  managers. The dashboard reads precomputed local-business-day snapshots so it
+  does not slow current Operations work. Use the period choices to compare days,
+  open a metric's **How this is calculated** disclosure to inspect its definition,
+  version, source owner, and model-level lineage, or follow **Open source
+  operations** to investigate the underlying work. The **Trends** section lets
+  you switch among the headline measures; its chart has a **View trend as a
+  table** alternative with the same period values. The **Owner brief** ranks the
+  largest observed changes, identifies headline gaps that deserve review, and
+  says plainly when connected lineage cannot yet prove why a result changed. It
+  never labels movement good or bad without a target and business context. The
+  freshness badge uses the oldest contributing source update, so one current
+  metric cannot hide a stale sibling; a failed refresh keeps the previous valid
+  result instead of replacing it with zeroes. Metrics whose canonical source is
+  not connected say **Not available** and explain what is missing. **Export this
+  period** downloads only aggregate metrics for the selected period, not customer,
+  employee, booking, or physical-resource records.
 
 Performance is a separate main destination, not a tab inside Operations. Simple
 navigation keeps the day-to-day Operations surface and hides the manager view;

--- a/docs/ux-fit/2026-08-01-business-performance.ux-fit.json
+++ b/docs/ux-fit/2026-08-01-business-performance.ux-fit.json
@@ -1,0 +1,20 @@
+{
+  "version": "1",
+  "decidedOption": "progressive-disclosure",
+  "decisionInteractionId": "DI-073C131559E8",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/performance/page.tsx",
+      "apps/web/components/performance/BusinessPerformanceDashboard.tsx",
+      "apps/web/components/performance/PerformanceTrendPanel.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "progressive-disclosure",
+      "dense-grid",
+      "separate-audit-route"
+    ]
+  }
+}

--- a/packages/db/prisma/migrations/20260801010000_add_business_metric_rollup/migration.sql
+++ b/packages/db/prisma/migrations/20260801010000_add_business_metric_rollup/migration.sql
@@ -1,0 +1,37 @@
+-- CreateTable
+CREATE TABLE "BusinessMetricRollup" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "metricKey" TEXT NOT NULL,
+    "periodStart" TIMESTAMP(3) NOT NULL,
+    "periodEnd" TIMESTAMP(3) NOT NULL,
+    "timezone" TEXT NOT NULL,
+    "dimensionsHash" TEXT NOT NULL,
+    "dimensions" JSONB NOT NULL,
+    "value" DECIMAL(20,6),
+    "unit" TEXT NOT NULL,
+    "availability" TEXT NOT NULL,
+    "unavailableReason" TEXT,
+    "definitionVersion" TEXT NOT NULL,
+    "sourceWatermark" TIMESTAMP(3) NOT NULL,
+    "sourceLineage" JSONB NOT NULL,
+    "computedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BusinessMetricRollup_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "BusinessMetricRollup_period_check" CHECK ("periodEnd" > "periodStart"),
+    CONSTRAINT "BusinessMetricRollup_availability_check" CHECK (
+      ("availability" = 'available' AND "value" IS NOT NULL AND "unavailableReason" IS NULL)
+      OR
+      ("availability" = 'unavailable' AND "value" IS NULL AND "unavailableReason" IS NOT NULL)
+    )
+);
+
+-- @migration-safety: data-safe: BusinessMetricRollup is created empty in this migration, so its tenant/metric/period/dimensions/version identity cannot conflict with existing rows.
+CREATE UNIQUE INDEX "business_metric_rollup_identity" ON "BusinessMetricRollup"("organizationId", "metricKey", "periodStart", "periodEnd", "dimensionsHash", "definitionVersion");
+
+CREATE INDEX "BusinessMetricRollup_organizationId_periodStart_periodEnd_idx" ON "BusinessMetricRollup"("organizationId", "periodStart", "periodEnd");
+CREATE INDEX "BusinessMetricRollup_organizationId_metricKey_sourceWatermark_idx" ON "BusinessMetricRollup"("organizationId", "metricKey", "sourceWatermark");
+
+ALTER TABLE "BusinessMetricRollup" ADD CONSTRAINT "BusinessMetricRollup_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260812020000_prepare_business_metric_rollup_closed_sets/migration.sql
+++ b/packages/db/prisma/migrations/20260812020000_prepare_business_metric_rollup_closed_sets/migration.sql
@@ -1,0 +1,5 @@
+-- PostgreSQL reparses dependent CHECK expressions while changing a column's
+-- type. Remove the text-typed expression before the following migration turns
+-- availability into an enum; the invariant is restored immediately afterward.
+ALTER TABLE "BusinessMetricRollup"
+  DROP CONSTRAINT "BusinessMetricRollup_availability_check";

--- a/packages/db/prisma/migrations/20260812020500_type_business_metric_rollup_closed_sets/migration.sql
+++ b/packages/db/prisma/migrations/20260812020500_type_business_metric_rollup_closed_sets/migration.sql
@@ -1,0 +1,11 @@
+-- BusinessMetricRollup is introduced by the immediately preceding unpublished
+-- migration. Keep that committed migration immutable and tighten its two closed
+-- axes forward-only so Prisma and PostgreSQL enforce the canonical value sets.
+CREATE TYPE "BusinessMetricAvailability" AS ENUM ('available', 'unavailable');
+CREATE TYPE "PerformanceMetricUnit" AS ENUM ('count', 'currency', 'percent', 'rate', 'duration');
+
+ALTER TABLE "BusinessMetricRollup"
+  ALTER COLUMN "availability" TYPE "BusinessMetricAvailability"
+  USING ("availability"::"BusinessMetricAvailability"),
+  ALTER COLUMN "unit" TYPE "PerformanceMetricUnit"
+  USING ("unit"::"PerformanceMetricUnit");

--- a/packages/db/prisma/migrations/20260812021000_restore_business_metric_rollup_availability_check/migration.sql
+++ b/packages/db/prisma/migrations/20260812021000_restore_business_metric_rollup_availability_check/migration.sql
@@ -1,0 +1,7 @@
+-- @migration-safety: data-safe: BusinessMetricRollup is created empty earlier in this same unapplied migration sequence, and no application traffic can write rows before migrate deploy completes.
+ALTER TABLE "BusinessMetricRollup"
+  ADD CONSTRAINT "BusinessMetricRollup_availability_check" CHECK (
+    ("availability" = 'available' AND "value" IS NOT NULL AND "unavailableReason" IS NULL)
+    OR
+    ("availability" = 'unavailable' AND "value" IS NULL AND "unavailableReason" IS NOT NULL)
+  );

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4677,6 +4677,7 @@ model Organization {
   storefrontConfig                  StorefrontConfig?
   stockItems                        StockItem[]
   operationalSceneLayouts           OperationalSceneLayout[]
+  businessMetricRollups              BusinessMetricRollup[]            @relation("BusinessMetricRollupOrganization")
   hospitalityResources              HospitalityResource[]              @relation("HospitalityResourceOrganization")
   hospitalityCapacityPools          HospitalityCapacityPool[]          @relation("HospitalityCapacityPoolOrganization")
   hospitalityResourceAvailability   HospitalityResourceAvailability[]  @relation("HospitalityAvailabilityOrganization")
@@ -13846,6 +13847,49 @@ model QueueMetricSnapshot {
   @@unique([queueKey, period])
   @@index([queueKey, period])
   @@index([period])
+}
+
+enum BusinessMetricAvailability {
+  available
+  unavailable
+}
+
+enum PerformanceMetricUnit {
+  count
+  currency
+  percent
+  rate
+  duration
+}
+
+/// Tenant-scoped, definition-versioned historical metric read model. Source
+/// systems remain authoritative; this table exists so owner/manager reads never
+/// run historical aggregation on the operational hot path.
+model BusinessMetricRollup {
+  id                  String   @id @default(cuid())
+  organizationId      String
+  metricKey           String
+  periodStart         DateTime
+  periodEnd           DateTime
+  timezone            String
+  dimensionsHash      String
+  dimensions          Json
+  value               Decimal? @db.Decimal(20, 6)
+  unit                PerformanceMetricUnit
+  availability        BusinessMetricAvailability
+  unavailableReason   String?
+  definitionVersion   String
+  sourceWatermark     DateTime
+  sourceLineage       Json
+  computedAt          DateTime @default(now())
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  organization Organization @relation("BusinessMetricRollupOrganization", fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@unique([organizationId, metricKey, periodStart, periodEnd, dimensionsHash, definitionVersion], map: "business_metric_rollup_identity")
+  @@index([organizationId, periodStart, periodEnd])
+  @@index([organizationId, metricKey, sourceWatermark])
 }
 
 // ─── Prompt Templates ─────────────────────────────────────────────────────────

--- a/packages/db/src/business-metric-rollup-migration.test.ts
+++ b/packages/db/src/business-metric-rollup-migration.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const prepareMigrationSql = readFileSync(
+  new URL(
+    "../prisma/migrations/20260812020000_prepare_business_metric_rollup_closed_sets/migration.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const conversionMigrationSql = readFileSync(
+  new URL(
+    "../prisma/migrations/20260812020500_type_business_metric_rollup_closed_sets/migration.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const restoreMigrationSql = readFileSync(
+  new URL(
+    "../prisma/migrations/20260812021000_restore_business_metric_rollup_availability_check/migration.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe("BusinessMetricRollup closed-set migration", () => {
+  it("removes and restores the availability check around the enum conversion", () => {
+    expect(prepareMigrationSql).toContain(
+      'DROP CONSTRAINT "BusinessMetricRollup_availability_check"',
+    );
+    expect(conversionMigrationSql).toContain(
+      'ALTER COLUMN "availability" TYPE "BusinessMetricAvailability"',
+    );
+    expect(restoreMigrationSql).toContain(
+      'ADD CONSTRAINT "BusinessMetricRollup_availability_check"',
+    );
+  });
+});

--- a/packages/db/src/table-classification.ts
+++ b/packages/db/src/table-classification.ts
@@ -151,6 +151,9 @@ export const TABLE_CLASSIFICATION: Record<string, TableSensitivity> = {
   BeautyResource: "internal",
   BeautyResourceService: "internal",
   BeautyResourceAvailability: "internal",
+  // Tenant-scoped aggregate values and model-level lineage only; the
+  // projection contract forbids customer, workforce, and financial records.
+  BusinessMetricRollup: "internal",
   ProviderService: "internal",
   ProviderAvailability: "internal",
   OnboardingChecklist: "internal",

--- a/scripts/platform-substrate-baseline.json
+++ b/scripts/platform-substrate-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-08-08T15:02:06.570Z",
-  "gitSha": "3524c91ae3df19559eab572e8159cda9432a21d1",
+  "generatedAt": "2026-08-12T02:36:02.434Z",
+  "gitSha": "fffdeec798ae0f74b9c3295b061ed7ad9f4fb525",
   "manifestVersion": 2,
   "metrics": {
     "defaultRequiredServiceCount": {
@@ -17,11 +17,11 @@
     },
     "prismaModelCount": {
       "direction": "non-increasing",
-      "value": 589
+      "value": 590
     },
     "prismaSchemaLines": {
       "direction": "informational",
-      "value": 16735
+      "value": 16837
     },
     "productionModuleHotspotCount": {
       "direction": "non-increasing",

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1278,7 +1278,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 37
+    "textMass": 27
   },
   "apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx": {
     "vocabulary": 0,
@@ -6081,6 +6081,20 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 19
+  },
+  "apps/web/components/performance/BusinessPerformanceDashboard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 112
+  },
+  "apps/web/components/performance/PerformanceTrendPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
   },
   "apps/web/components/platform/ActivityRoutingPresentation.tsx": {
     "vocabulary": 0,

--- a/scripts/stewardship-exemptions.txt
+++ b/scripts/stewardship-exemptions.txt
@@ -80,6 +80,7 @@ BeautyResourceAvailability  domain-lifecycle-managed  # Physical availability wi
 BeautyCapacityAllocation  domain-lifecycle-managed  # Append-preserving beauty capacity follows booking/hold and explicit release lifecycles; age-based deletion could erase live conflict and utilization evidence.
 HospitalityServiceTurn  domain-lifecycle-managed  # A turn closes through explicit service-stage transitions and follows its organization/booking lifecycle; an age sweep could remove a live or still-auditable dining-room turn.
 HospitalityServiceTurnEvent  domain-lifecycle-managed  # Append-only transition evidence follows its HospitalityServiceTurn cascade; independent aging would make seating, movement, and closure decisions unexplainable.
+BusinessMetricRollup  derived-projection  # Recomputed from canonical operational sources and cascaded with its organization; it is replaceable projection state, not an independently aged record.
 ProductOffering  domain-lifecycle-managed  # Organization-owned commercial packaging follows explicit offering status/effective-date actions and product cascade, never an age-based sweep.
 CatalogItem  domain-lifecycle-managed  # Canonical ways-to-buy follow explicit catalog status/effective-date actions and offering cascade, never an age-based sweep.
 ProductConfiguration  domain-lifecycle-managed  # Reusable configurations follow explicit publish/retire actions and catalog-item cascade, never an age-based sweep.


### PR DESCRIPTION
## Summary

- Add governed owner/manager business-performance rollups for the four operating questions: what happened, why, what is likely next, and what should I inspect.
- Resolve all performance data through the authenticated current organization, refuse ambiguous multi-organization context, and preserve an honest connected-source empty state.
- Add trend, decision-summary, export, lineage, aggregation, and scheduled-job contracts using shared performance and governance primitives.
- Add forward-only typed-enum migrations with an ordered compatibility sequence that applies safely across existing database states.

## Backlog

- BI-PLAN-005

## Verification

- Fresh independent high-assurance semantic review recorded for the immutable candidate; zero findings, shadow publication permitted.
- Governed exhaustive local-CI passed on the exact candidate merged with current `main`: Prisma generation and full migration deploy, documentation checks, architecture guards, web typecheck, full Vitest suite, and production Docker build.
- Focused Performance coverage: 8 files / 24 tests, including authenticated current-org isolation and multi-org refusal.
- Migration regression coverage verifies the ordered drop / enum conversion / restored-check contract.
- UX-fit and data-impact records are included; user and operations documentation is updated.

## Design grounding

- Reviewed the existing Performance route/provider, shared report primitives, governance asset registry, scheduled-job catalog, Organization identity contract, and the merged verified-analysis-plan contract.
- `Organization` plus authenticated current-org context remains the identity source of truth; no unscoped storefront lookup or parallel identity store is introduced.
- The connected-source empty state remains explicit rather than synthesizing business history; populated archetypes receive decision-oriented rollups with source lineage.

Docs-Impact-Decision: The user-facing Performance workflow is documented in `docs/user-guide/workspace/index.md`; generated related-code edges also flag broad architecture pages for the shared queue, schema, classification, and substrate-baseline files, but this feature does not change those platform-wide contracts.
