### PR TITLE
fix(work-capsules): resume abandoned branch identity

### DIFF
--- a/apps/web/lib/mcp-tools-work-capsules.test.ts
+++ b/apps/web/lib/mcp-tools-work-capsules.test.ts
@@ -295,6 +295,39 @@ describe("work capsule MCP tools", () => {
     }));
   });
 
+  it("adopt_worktree returns an actionable branch conflict instead of a raw tool failure", async () => {
+    mockPrisma.workCapsule.findFirst.mockResolvedValue({
+      id: "row-existing",
+      capsuleId: "WC-EXISTING",
+      status: "abandoned",
+      backlogItemId: "BI-OTHER",
+      headBranch: "fix/recovery",
+    });
+
+    const { executeTool } = await import("./mcp-tools");
+    const result = await executeTool("adopt_worktree", {
+      title: "Adopt recovery branch",
+      objective: "Recover useful work.",
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      headBranch: "fix/recovery",
+      worktreePath: "D:/DPF-recovery",
+      executorKind: "codex-desktop",
+    }, "user-1", { agentId: "codex" });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "branch_occupied",
+      data: {
+        capsuleId: "WC-EXISTING",
+        status: "abandoned",
+        backlogItemId: "BI-OTHER",
+      },
+    });
+    expect(result.message).toMatch(/Resume that capsule.*or use a different branch/i);
+    expect(mockPrisma.workCapsule.create).not.toHaveBeenCalled();
+    expect(mockPrisma.workCapsule.update).not.toHaveBeenCalled();
+  });
+
   it("plan_capsule_worktree persists the planned workspace", async () => {
     mockPrisma.workCapsule.findUnique.mockResolvedValue({
       id: "row-1",

--- a/apps/web/lib/mcp/packs/work-capsules-pack.ts
+++ b/apps/web/lib/mcp/packs/work-capsules-pack.ts
@@ -112,7 +112,7 @@ const definitions: ToolDefinition[] = [
   },
   {
     name: "adopt_worktree",
-    description: "Adopt an existing local branch/worktree pair into a Work Capsule without creating a new worktree.",
+    description: "Adopt an existing local branch/worktree pair into a Work Capsule without creating a new worktree. A branch has one durable capsule identity; an incompatible terminal or foreign binding returns branch_occupied instead of overwriting history.",
     inputSchema: {
       type: "object",
       properties: {
@@ -135,7 +135,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "claim_backlog_item_for_work",
     description:
-      "Claim a BacklogItem for work by binding it to the worktree + branch + session you are starting in (soft claim-at-start). Creates or reuses+late-binds the WorkCapsule for the branch and stamps the BI claim so a directly-working agent's BI no longer looks unclaimed to a parallel session. Advisory, NOT a lock: if the BI already has active work elsewhere the call still binds this location but returns a non-blocking conflict — it does not steal the existing claim. Multiple branches per BI are expected and are not a conflict.",
+      "Claim a BacklogItem for work by binding it to the worktree + branch + session you are starting in (soft claim-at-start). Creates, reuses+late-binds, or resumes the durable abandoned WorkCapsule for the same BI and branch, then stamps the BI claim so a directly-working agent's BI no longer looks unclaimed to a parallel session. A branch bound to a different BI returns branch_occupied and preserves its history. Advisory, NOT a lock: if the BI already has active work elsewhere the call still binds this location but returns a non-blocking conflict — it does not steal the existing claim. Multiple branches per BI are expected and are not a conflict.",
     inputSchema: {
       type: "object",
       properties: {

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -46,7 +46,7 @@ import {
 } from "./work-capsule-store";
 import { listLocalBranches } from "./git-scanner";
 import { providerToExecutorKind, ensureExternalSessionCapsule } from "./external-session-capture";
-
+import { branchOccupiedResult, invalidScopeResult } from "./mcp-result-errors";
 type ToolContext = {
   routeContext?: string;
   agentId?: string;
@@ -112,18 +112,9 @@ function parseScopeInput(params: Record<string, unknown>): WorkCapsuleScopeInput
   };
 }
 
-function invalidScopeResult(error: unknown): ToolResult {
-  return {
-    success: false,
-    error: "invalid_scope",
-    message: error instanceof Error ? error.message : "Invalid Work Capsule scope metadata.",
-  };
-}
-
 function workCapsuleDb(): CapsuleDb {
   return prisma as unknown as CapsuleDb;
 }
-
 async function renewLeaseAfterCapsuleWrite(capsuleId: string, currentActor: WorkCapsuleActor) {
   return heartbeatWorkCapsule({
     db: workCapsuleDb(),
@@ -300,22 +291,29 @@ export async function adoptWorktreeTool(
     return invalidScopeResult(error);
   }
 
-  const capsule = await adoptWorktreeCapsule({
-    db: workCapsuleDb(),
-    input: {
-      title,
-      objective,
-      repositoryFullName,
-      headBranch,
-      worktreePath,
-      baseBranch: stringParam(params, "baseBranch") ?? null,
-      baseSha: stringParam(params, "baseSha") ?? null,
-      headSha: stringParam(params, "headSha") ?? null,
-      executorKind: validatedExecutorKind,
-      scope: parseScopeInput(params),
-    },
-    actor: await actor(userId, context),
-  });
+  let capsule;
+  try {
+    capsule = await adoptWorktreeCapsule({
+      db: workCapsuleDb(),
+      input: {
+        title,
+        objective,
+        repositoryFullName,
+        headBranch,
+        worktreePath,
+        baseBranch: stringParam(params, "baseBranch") ?? null,
+        baseSha: stringParam(params, "baseSha") ?? null,
+        headSha: stringParam(params, "headSha") ?? null,
+        executorKind: validatedExecutorKind,
+        scope: parseScopeInput(params),
+      },
+      actor: await actor(userId, context),
+    });
+  } catch (error) {
+    const occupied = branchOccupiedResult(error);
+    if (occupied) return occupied;
+    throw error;
+  }
 
   return {
     success: true,
@@ -395,6 +393,8 @@ export async function claimBacklogItemForWorkTool(
       data: result,
     };
   } catch (error) {
+    const occupied = branchOccupiedResult(error);
+    if (occupied) return occupied;
     const detail = error instanceof Error ? error.message : "Unknown failure";
     if (/not found/i.test(detail)) {
       return { success: false, error: "not_found", message: detail };

--- a/apps/web/lib/work-capsules/mcp-result-errors.ts
+++ b/apps/web/lib/work-capsules/mcp-result-errors.ts
@@ -1,0 +1,24 @@
+import type { ToolResult } from "@/lib/mcp-tools";
+import { CapsuleBranchOccupiedError } from "./work-capsule-branch-identity";
+
+export function branchOccupiedResult(error: unknown): ToolResult | null {
+  if (!(error instanceof CapsuleBranchOccupiedError)) return null;
+  return {
+    success: false,
+    error: "branch_occupied",
+    message: error.message,
+    data: {
+      capsuleId: error.capsuleId,
+      status: error.status,
+      backlogItemId: error.backlogItemId,
+    },
+  };
+}
+
+export function invalidScopeResult(error: unknown): ToolResult {
+  return {
+    success: false,
+    error: "invalid_scope",
+    message: error instanceof Error ? error.message : "Invalid Work Capsule scope metadata.",
+  };
+}

--- a/apps/web/lib/work-capsules/work-capsule-adoption.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-adoption.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/portal-context/invalidation", () => ({
+  revalidatePortalContext: vi.fn(),
+}));
+
+import {
+  adoptWorktreeCapsule,
+  CapsuleBranchOccupiedError,
+  type CapsuleDb,
+} from "./work-capsule-store";
+
+const db = {
+  workCapsule: {
+    create: vi.fn(),
+    findFirst: vi.fn(),
+    update: vi.fn(),
+  },
+  workCapsuleActivity: { create: vi.fn() },
+  $transaction: vi.fn(async (fn: (tx: typeof db) => Promise<unknown>) => fn(db)),
+};
+
+function capsuleDb(): CapsuleDb {
+  return db as unknown as CapsuleDb;
+}
+
+describe("work capsule branch adoption", () => {
+  beforeEach(() => {
+    db.workCapsule.create.mockReset();
+    db.workCapsule.findFirst.mockReset();
+    db.workCapsule.update.mockReset();
+    db.workCapsuleActivity.create.mockReset();
+    db.$transaction.mockReset();
+    db.$transaction.mockImplementation(async (fn: (tx: typeof db) => Promise<unknown>) => fn(db));
+  });
+
+  it("persists backlogItemId + epicId on a fresh adoption", async () => {
+    db.workCapsule.findFirst.mockResolvedValueOnce(null);
+    db.workCapsule.create.mockResolvedValueOnce({ id: "row-1", capsuleId: "WC-BOUND01" });
+
+    const result = await adoptWorktreeCapsule({
+      db: capsuleDb(),
+      input: {
+        title: "Bound branch",
+        objective: "Work an item.",
+        repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+        headBranch: "feat/bound",
+        worktreePath: "D:/DPF-bound",
+        backlogItemId: "BI-7D20BFDF",
+        epicId: "EP-XYZ",
+        executorRef: "session-1",
+      },
+      actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
+    });
+
+    expect(result.capsuleId).toBe("WC-BOUND01");
+    expect(db.workCapsule.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        backlogItemId: "BI-7D20BFDF",
+        epicId: "EP-XYZ",
+        executorRef: "session-1",
+      }),
+    }));
+  });
+
+  it("late-binds an existing unbound capsule", async () => {
+    db.workCapsule.findFirst.mockResolvedValueOnce({
+      id: "row-1",
+      capsuleId: "WC-EXISTING",
+      status: "ready",
+      backlogItemId: null,
+      epicId: null,
+      executorRef: null,
+    });
+    db.workCapsule.update.mockResolvedValueOnce({
+      id: "row-1",
+      capsuleId: "WC-EXISTING",
+      backlogItemId: "BI-7D20BFDF",
+    });
+
+    const result = await adoptWorktreeCapsule({
+      db: capsuleDb(),
+      input: {
+        title: "Reuse",
+        objective: "Reuse existing branch.",
+        repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+        headBranch: "feat/existing",
+        worktreePath: "D:/DPF-existing",
+        backlogItemId: "BI-7D20BFDF",
+      },
+      actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
+    });
+
+    expect(result.capsuleId).toBe("WC-EXISTING");
+    expect(db.workCapsule.create).not.toHaveBeenCalled();
+    expect(db.workCapsule.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ backlogItemId: "BI-7D20BFDF" }),
+    }));
+    expect(db.workCapsuleActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ kind: "adopted", payload: expect.objectContaining({ lateBind: true }) }),
+    }));
+  });
+
+  it("reuses a live capsule already bound to the same backlog item", async () => {
+    db.workCapsule.findFirst.mockResolvedValueOnce({
+      id: "row-1",
+      capsuleId: "WC-EXISTING",
+      status: "working",
+      backlogItemId: "BI-7D20BFDF",
+      executorRef: null,
+    });
+
+    const result = await adoptWorktreeCapsule({
+      db: capsuleDb(),
+      input: {
+        title: "Reuse",
+        objective: "Reuse existing branch.",
+        repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+        headBranch: "feat/existing",
+        worktreePath: "D:/DPF-existing",
+        backlogItemId: "BI-7D20BFDF",
+      },
+      actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
+    });
+
+    expect(result.capsuleId).toBe("WC-EXISTING");
+    expect(db.workCapsule.update).not.toHaveBeenCalled();
+    expect(db.workCapsule.create).not.toHaveBeenCalled();
+  });
+
+  it("reactivates the same abandoned capsule when the BI and branch still match", async () => {
+    db.workCapsule.findFirst.mockResolvedValueOnce({
+      id: "row-abandoned",
+      capsuleId: "WC-RESUME01",
+      status: "abandoned",
+      archivedAt: null,
+      backlogItemId: "BI-RESUME",
+      epicId: "EP-PROCESS-SPINE",
+      executorKind: "codex-desktop",
+      executorRef: "session-old",
+      baseBranch: "main",
+      headBranch: "fix/resume",
+    });
+    db.workCapsule.update.mockResolvedValueOnce({
+      id: "row-abandoned",
+      capsuleId: "WC-RESUME01",
+      status: "ready",
+      backlogItemId: "BI-RESUME",
+      executorRef: "session-new",
+    });
+
+    const result = await adoptWorktreeCapsule({
+      db: capsuleDb(),
+      input: {
+        title: "Resume BI-RESUME",
+        objective: "Resume the preserved branch.",
+        repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+        headBranch: "fix/resume",
+        worktreePath: "D:/DPF-worktrees/resume",
+        backlogItemId: "BI-RESUME",
+        executorRef: "session-new",
+        executorKind: "codex-desktop",
+        headSha: "abc123",
+      },
+      actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
+    });
+
+    expect(result).toMatchObject({ capsuleId: "WC-RESUME01", status: "ready" });
+    expect(db.workCapsule.create).not.toHaveBeenCalled();
+    expect(db.workCapsule.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { capsuleId: "WC-RESUME01" },
+      data: expect.objectContaining({
+        status: "ready",
+        executorRef: "session-new",
+        leaseHolderPrincipalId: "principal-1",
+        headSha: "abc123",
+        worktreePath: "D:/DPF-worktrees/resume",
+      }),
+    }));
+    expect(db.workCapsuleActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        kind: "adopted",
+        payload: expect.objectContaining({ resumed: true, previousStatus: "abandoned" }),
+      }),
+    }));
+  });
+
+  it("refuses to overwrite capsule history when the branch belongs to a different BI", async () => {
+    db.workCapsule.findFirst.mockResolvedValueOnce({
+      id: "row-1",
+      capsuleId: "WC-OTHERBI",
+      status: "abandoned",
+      backlogItemId: "BI-OTHER",
+      executorRef: "session-other",
+      headBranch: "fix/shared",
+    });
+
+    await expect(adoptWorktreeCapsule({
+      db: capsuleDb(),
+      input: {
+        title: "Mine",
+        objective: "Different BI on same branch.",
+        repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+        headBranch: "fix/shared",
+        worktreePath: "D:/DPF-worktrees/shared",
+        backlogItemId: "BI-MINE",
+        executorRef: "session-mine",
+      },
+      actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
+    })).rejects.toBeInstanceOf(CapsuleBranchOccupiedError);
+
+    expect(db.workCapsule.create).not.toHaveBeenCalled();
+    expect(db.workCapsule.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/work-capsules/work-capsule-branch-identity.ts
+++ b/apps/web/lib/work-capsules/work-capsule-branch-identity.ts
@@ -1,0 +1,141 @@
+import {
+  LEASE_TTL_MS,
+  type WorkCapsuleExecutorKind,
+  type WorkCapsuleScopeInput,
+  type WorkCapsuleStatus,
+} from "@/lib/work-capsules";
+import type { WorkCapsuleActor } from "./work-capsule-store-types";
+
+export type CapsuleAdoptionInput = {
+  title: string;
+  objective: string;
+  repositoryFullName: string;
+  headBranch: string;
+  worktreePath: string;
+  baseBranch?: string | null;
+  baseSha?: string | null;
+  headSha?: string | null;
+  executorKind?: WorkCapsuleExecutorKind | null;
+  executorRef?: string | null;
+  backlogItemId?: string | null;
+  epicId?: string | null;
+  scope?: WorkCapsuleScopeInput | null;
+};
+
+type BranchCapsuleRecord = {
+  id: string;
+  capsuleId: string;
+  status?: string | null;
+  archivedAt?: Date | string | null;
+  backlogItemId?: string | null;
+  executorKind?: WorkCapsuleExecutorKind | null;
+  executorRef?: string | null;
+  baseBranch?: string | null;
+  baseSha?: string | null;
+  headSha?: string | null;
+  headBranch?: string | null;
+};
+
+export const TERMINAL_CAPSULE_STATUSES: WorkCapsuleStatus[] = ["complete", "abandoned", "archived"];
+
+export function isTerminalCapsuleStatus(status: unknown): boolean {
+  return typeof status === "string" && (TERMINAL_CAPSULE_STATUSES as string[]).includes(status);
+}
+
+export function isExternalLeaseExecutor(
+  executorKind: WorkCapsuleExecutorKind | null | undefined,
+): boolean {
+  return (
+    executorKind === "codex-desktop" ||
+    executorKind === "claude-desktop" ||
+    executorKind === "grok-desktop" ||
+    executorKind === "antigravity-desktop" ||
+    executorKind === "human"
+  );
+}
+
+export function leaseUntil(now = new Date()): Date {
+  return new Date(now.getTime() + LEASE_TTL_MS);
+}
+
+export function isReusableLiveCapsule(
+  existing: Pick<BranchCapsuleRecord, "status" | "backlogItemId" | "executorRef">,
+  input: Pick<CapsuleAdoptionInput, "backlogItemId" | "executorRef">,
+): boolean {
+  if (isTerminalCapsuleStatus(existing.status)) return false;
+  const existingBi = existing.backlogItemId ?? null;
+  const incomingBi = input.backlogItemId ?? null;
+  if (existingBi == null) return true;
+  if (incomingBi != null && existingBi !== incomingBi) return false;
+  const existingSession = existing.executorRef ?? null;
+  const incomingSession = input.executorRef ?? null;
+  return existingSession == null || incomingSession == null || existingSession === incomingSession;
+}
+
+export class CapsuleBranchOccupiedError extends Error {
+  readonly capsuleId: string;
+  readonly status: string;
+  readonly backlogItemId: string | null;
+
+  constructor(existing: Pick<BranchCapsuleRecord, "capsuleId" | "status" | "backlogItemId" | "headBranch">) {
+    const status = existing.status ?? "unknown";
+    const backlogItemId = existing.backlogItemId ?? null;
+    super(
+      `Branch ${existing.headBranch ?? "unknown"} is already bound to Work Capsule ` +
+        `${existing.capsuleId} (${status}${backlogItemId ? `, ${backlogItemId}` : ""}). ` +
+        "Resume that capsule for the same backlog item or use a different branch.",
+    );
+    this.name = "CapsuleBranchOccupiedError";
+    this.capsuleId = existing.capsuleId;
+    this.status = status;
+    this.backlogItemId = backlogItemId;
+  }
+}
+
+export function planAbandonedCapsuleResume(args: {
+  existing: BranchCapsuleRecord | null;
+  input: CapsuleAdoptionInput;
+  actor: WorkCapsuleActor;
+  now: Date;
+}) {
+  const { existing, input, actor, now } = args;
+  if (
+    existing?.status !== "abandoned" ||
+    existing.archivedAt != null ||
+    existing.backlogItemId == null ||
+    existing.backlogItemId !== (input.backlogItemId ?? null)
+  ) {
+    return null;
+  }
+
+  return {
+    update: {
+      where: { capsuleId: existing.capsuleId },
+      data: {
+        status: "ready" as const,
+        title: input.title,
+        objective: input.objective,
+        baseBranch: input.baseBranch ?? existing.baseBranch ?? "main",
+        baseSha: input.baseSha ?? existing.baseSha ?? null,
+        headSha: input.headSha ?? existing.headSha ?? null,
+        worktreePath: input.worktreePath,
+        executorKind: input.executorKind ?? existing.executorKind ?? null,
+        executorRef: input.executorRef ?? existing.executorRef ?? null,
+        leaseHolderPrincipalId: isExternalLeaseExecutor(input.executorKind) ? actor.principalId : null,
+        leaseExpiresAt: isExternalLeaseExecutor(input.executorKind) ? leaseUntil(now) : null,
+        lastSyncedAt: now,
+      },
+    },
+    activity: {
+      workCapsuleId: existing.id,
+      kind: "adopted" as const,
+      summary: `Resumed ${existing.capsuleId} on ${input.headBranch}`,
+      payload: {
+        resumed: true,
+        previousStatus: "abandoned",
+        worktreePath: input.worktreePath,
+        executorRef: input.executorRef ?? null,
+      },
+    },
+  };
+}

--- a/apps/web/lib/work-capsules/work-capsule-store.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.test.ts
@@ -529,175 +529,6 @@ describe("work capsule store", () => {
     });
   });
 
-  describe("adoptWorktreeCapsule backlog binding", () => {
-    it("persists backlogItemId + epicId on a fresh adoption", async () => {
-      db.workCapsule.findFirst.mockResolvedValueOnce(null);
-      db.workCapsule.create.mockResolvedValueOnce({ id: "row-1", capsuleId: "WC-BOUND01" });
-
-      const result = await adoptWorktreeCapsule({
-        db: capsuleDb(),
-        input: {
-          title: "Bound branch",
-          objective: "Work an item.",
-          repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
-          headBranch: "feat/bound",
-          worktreePath: "D:/DPF-bound",
-          backlogItemId: "BI-7D20BFDF",
-          epicId: "EP-XYZ",
-          executorRef: "session-1",
-        },
-        actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
-      });
-
-      expect(result.capsuleId).toBe("WC-BOUND01");
-      expect(db.workCapsule.create).toHaveBeenCalledWith(expect.objectContaining({
-        data: expect.objectContaining({
-          backlogItemId: "BI-7D20BFDF",
-          epicId: "EP-XYZ",
-          executorRef: "session-1",
-        }),
-      }));
-    });
-
-    it("late-binds backlogItemId onto an existing capsule that had none", async () => {
-      db.workCapsule.findFirst.mockResolvedValueOnce({
-        id: "row-1",
-        capsuleId: "WC-EXISTING",
-        status: "ready",
-        backlogItemId: null,
-        epicId: null,
-        executorRef: null,
-      });
-      db.workCapsule.update.mockResolvedValueOnce({
-        id: "row-1",
-        capsuleId: "WC-EXISTING",
-        backlogItemId: "BI-7D20BFDF",
-      });
-
-      const result = await adoptWorktreeCapsule({
-        db: capsuleDb(),
-        input: {
-          title: "Reuse",
-          objective: "Reuse existing branch.",
-          repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
-          headBranch: "feat/existing",
-          worktreePath: "D:/DPF-existing",
-          backlogItemId: "BI-7D20BFDF",
-        },
-        actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
-      });
-
-      expect(result.capsuleId).toBe("WC-EXISTING");
-      expect(db.workCapsule.create).not.toHaveBeenCalled();
-      expect(db.workCapsule.update).toHaveBeenCalledWith(expect.objectContaining({
-        data: expect.objectContaining({ backlogItemId: "BI-7D20BFDF" }),
-      }));
-      expect(db.workCapsuleActivity.create).toHaveBeenCalledWith(expect.objectContaining({
-        data: expect.objectContaining({ kind: "adopted", payload: expect.objectContaining({ lateBind: true }) }),
-      }));
-    });
-
-    it("does not late-bind (or write) when the existing capsule already has the same backlogItemId", async () => {
-      db.workCapsule.findFirst.mockResolvedValueOnce({
-        id: "row-1",
-        capsuleId: "WC-EXISTING",
-        status: "working",
-        backlogItemId: "BI-7D20BFDF",
-        epicId: null,
-        executorRef: null,
-      });
-
-      const result = await adoptWorktreeCapsule({
-        db: capsuleDb(),
-        input: {
-          title: "Reuse",
-          objective: "Reuse existing branch.",
-          repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
-          headBranch: "feat/existing",
-          worktreePath: "D:/DPF-existing",
-          backlogItemId: "BI-7D20BFDF",
-        },
-        actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
-      });
-
-      expect(result.capsuleId).toBe("WC-EXISTING");
-      expect(result.backlogItemId).toBe("BI-7D20BFDF");
-      expect(db.workCapsule.update).not.toHaveBeenCalled();
-      expect(db.workCapsule.create).not.toHaveBeenCalled();
-    });
-
-    // BI-95E37EA1 — abandoned main capsule must not be returned as a successful bind.
-    it("creates a fresh capsule when the only (repo, branch) hit is abandoned for another BI", async () => {
-      // findFirst with status notIn terminal returns null (abandoned filtered out).
-      db.workCapsule.findFirst.mockResolvedValueOnce(null);
-      db.workCapsule.create.mockResolvedValueOnce({
-        id: "row-new",
-        capsuleId: "WC-FRESH01",
-        status: "ready",
-        backlogItemId: "BI-NEWITEM",
-        headBranch: "main",
-        worktreePath: "D:/DPF",
-        executorRef: "session-new",
-      });
-
-      const result = await adoptWorktreeCapsule({
-        db: capsuleDb(),
-        input: {
-          title: "Work on BI-NEWITEM",
-          objective: "Claim-at-start binding for BI-NEWITEM",
-          repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
-          headBranch: "main",
-          worktreePath: "D:/DPF",
-          backlogItemId: "BI-NEWITEM",
-          executorRef: "session-new",
-          executorKind: "codex-desktop",
-        },
-        actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
-      });
-
-      expect(result.capsuleId).toBe("WC-FRESH01");
-      expect(result.backlogItemId).toBe("BI-NEWITEM");
-      expect(db.workCapsule.create).toHaveBeenCalledTimes(1);
-      expect(db.workCapsule.update).not.toHaveBeenCalled();
-    });
-
-    it("creates a fresh capsule when a live capsule on the branch is bound to a different BI", async () => {
-      db.workCapsule.findFirst.mockResolvedValueOnce({
-        id: "row-1",
-        capsuleId: "WC-OTHERBI",
-        status: "working",
-        backlogItemId: "BI-OTHER",
-        executorRef: "session-other",
-        epicId: null,
-      });
-      db.workCapsule.create.mockResolvedValueOnce({
-        id: "row-new",
-        capsuleId: "WC-MINE001",
-        status: "ready",
-        backlogItemId: "BI-MINE",
-        executorRef: "session-mine",
-      });
-
-      const result = await adoptWorktreeCapsule({
-        db: capsuleDb(),
-        input: {
-          title: "Mine",
-          objective: "Different BI on same branch.",
-          repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
-          headBranch: "main",
-          worktreePath: "D:/DPF",
-          backlogItemId: "BI-MINE",
-          executorRef: "session-mine",
-        },
-        actor: { userId: "user-1", agentId: "codex", principalId: "principal-1" },
-      });
-
-      expect(result.capsuleId).toBe("WC-MINE001");
-      expect(db.workCapsule.create).toHaveBeenCalledTimes(1);
-      expect(db.workCapsule.update).not.toHaveBeenCalled();
-    });
-  });
-
   describe("claimBacklogItemWorkspace", () => {
     const baseInput = {
       backlogItemId: "BI-7D20BFDF",
@@ -746,6 +577,55 @@ describe("work capsule store", () => {
           claimStatus: "active",
           claimedById: "user-1",
           claimedByAgentId: "agent-1",
+        }),
+      }));
+    });
+
+    it("resumes the durable abandoned capsule when the same BI reclaims its branch", async () => {
+      db.backlogItem.findFirst.mockResolvedValueOnce({
+        id: "bi-row-1",
+        itemId: "BI-7D20BFDF",
+        epicId: "EP-1",
+        claimStatus: "active",
+        claimedById: "user-1",
+        claimedByAgentId: "agent-1",
+        claimedAt: new Date(),
+      });
+      db.workCapsule.findFirst.mockResolvedValueOnce({
+        id: "row-abandoned",
+        capsuleId: "WC-CLAIM01",
+        status: "abandoned",
+        archivedAt: null,
+        backlogItemId: "BI-7D20BFDF",
+        epicId: "EP-1",
+        executorKind: "codex-desktop",
+        executorRef: "session-old",
+        baseBranch: "main",
+        headBranch: baseInput.headBranch,
+        worktreePath: baseInput.worktreePath,
+      });
+      db.workCapsule.update.mockResolvedValueOnce({
+        id: "row-abandoned",
+        capsuleId: "WC-CLAIM01",
+        status: "ready",
+        backlogItemId: "BI-7D20BFDF",
+        headBranch: baseInput.headBranch,
+        worktreePath: baseInput.worktreePath,
+      });
+      db.workCapsule.findMany.mockResolvedValueOnce([]);
+      db.backlogItem.update.mockResolvedValueOnce({ id: "bi-row-1" });
+
+      const result = await claimBacklogItemWorkspace({ db: capsuleDb(), input: baseInput, actor });
+
+      expect(result.capsuleId).toBe("WC-CLAIM01");
+      expect(result.claimed).toBe(true);
+      expect(db.workCapsule.create).not.toHaveBeenCalled();
+      expect(db.workCapsule.update).toHaveBeenCalledWith(expect.objectContaining({
+        where: { capsuleId: "WC-CLAIM01" },
+        data: expect.objectContaining({
+          status: "ready",
+          executorRef: "session-A",
+          leaseHolderPrincipalId: "PRN-1",
         }),
       }));
     });

--- a/apps/web/lib/work-capsules/work-capsule-store.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import {
-  LEASE_TTL_MS,
   STATUS_OVERRIDE_TTL_MS,
   buildCapsuleBranchName,
   buildCapsuleSlug,
@@ -28,9 +27,20 @@ import { revalidatePortalContext } from "@/lib/portal-context/invalidation";
 import { publishRecordedWorkCapsuleActivity } from "@/lib/work-capsules/activity-events";
 import { admitRuntimeGuardedWork } from "@/lib/platform-runtime/work-admission";
 import { planCapsuleChangeImpact, type CapsuleChangeImpactContract } from "./change-impact-contract";
+import {
+  CapsuleBranchOccupiedError,
+  isExternalLeaseExecutor,
+  isReusableLiveCapsule,
+  isTerminalCapsuleStatus,
+  leaseUntil,
+  planAbandonedCapsuleResume,
+  TERMINAL_CAPSULE_STATUSES,
+  type CapsuleAdoptionInput,
+} from "./work-capsule-branch-identity";
 import type { CapsuleDb, WorkCapsuleActor } from "./work-capsule-store-types";
 
 export type { CapsuleDb, WorkCapsuleActor } from "./work-capsule-store-types";
+export { CapsuleBranchOccupiedError } from "./work-capsule-branch-identity";
 
 type CapsuleCreateInput = {
   title: string;
@@ -48,22 +58,6 @@ type CapsuleCreateInput = {
   // BI-B24F96D0: principal who commissioned the work (Requester), distinct from
   // the creating actor. Optional.
   requestedByPrincipalId?: string | null;
-};
-
-type CapsuleAdoptionInput = {
-  title: string;
-  objective: string;
-  repositoryFullName: string;
-  headBranch: string;
-  worktreePath: string;
-  baseBranch?: string | null;
-  baseSha?: string | null;
-  headSha?: string | null;
-  executorKind?: WorkCapsuleExecutorKind | null;
-  executorRef?: string | null;
-  backlogItemId?: string | null;
-  epicId?: string | null;
-  scope?: WorkCapsuleScopeInput | null;
 };
 
 type CapsuleEvidenceInput = {
@@ -91,20 +85,6 @@ type CapsuleWorkspacePlanInput = {
 
 function nextCapsuleId(): string {
   return `WC-${randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase()}`;
-}
-
-function leaseUntil(now = new Date()): Date {
-  return new Date(now.getTime() + LEASE_TTL_MS);
-}
-
-function isExternalLeaseExecutor(executorKind: WorkCapsuleExecutorKind | null | undefined): boolean {
-  return (
-    executorKind === "codex-desktop" ||
-    executorKind === "claude-desktop" ||
-    executorKind === "grok-desktop" ||
-    executorKind === "antigravity-desktop" ||
-    executorKind === "human"
-  );
 }
 
 function isUniqueViolation(error: unknown): boolean {
@@ -219,44 +199,6 @@ export async function createWorkCapsule(args: {
   }
 }
 
-// Statuses that end a capsule's reuse eligibility for (repo, branch) adoption.
-// BI-95E37EA1: an abandoned/complete/archived capsule must NOT be returned as a
-// successful bind for a new BI/session — that poisoned claim-at-start with a
-// false-success pointing at stale ownership.
-const TERMINAL_CAPSULE_STATUSES: WorkCapsuleStatus[] = ["complete", "abandoned", "archived"];
-
-function isTerminalCapsuleStatus(status: unknown): boolean {
-  return typeof status === "string" && (TERMINAL_CAPSULE_STATUSES as string[]).includes(status);
-}
-
-/**
- * Whether an existing live capsule on (repo, branch) is compatible with a new
- * adopt/claim request. Same BI + same executor session is idempotent reuse;
- * unbound (null BI) is late-bind eligible; a different BI or session requires a
- * fresh capsule so history on the prior capsule stays intact.
- */
-function isReusableLiveCapsule(
-  existing: {
-    status?: string | null;
-    backlogItemId?: string | null;
-    executorRef?: string | null;
-  },
-  input: { backlogItemId?: string | null; executorRef?: string | null },
-): boolean {
-  if (isTerminalCapsuleStatus(existing.status)) return false;
-  const existingBi = existing.backlogItemId ?? null;
-  const incomingBi = input.backlogItemId ?? null;
-  // Unbound capsule can be late-bound to any BI.
-  if (existingBi == null) return true;
-  // Bound to a different BI → never silently re-home.
-  if (incomingBi != null && existingBi !== incomingBi) return false;
-  // Same BI: reuse when session matches or either side has no session stamp yet.
-  const existingSession = existing.executorRef ?? null;
-  const incomingSession = input.executorRef ?? null;
-  if (existingSession == null || incomingSession == null) return true;
-  return existingSession === incomingSession;
-}
-
 export async function adoptWorktreeCapsule(args: {
   db: CapsuleDb;
   input: CapsuleAdoptionInput;
@@ -267,17 +209,29 @@ export async function adoptWorktreeCapsule(args: {
   }
   const scope = normalizeWorkCapsuleScopeInput(args.input.scope);
 
-  // Prefer a non-terminal capsule on this branch. Terminal capsules keep their
-  // audit trail; a new adopt creates a new WC rather than rewriting them.
+  // The schema deliberately owns one capsule identity per (repository, branch).
+  // Read that row regardless of lifecycle: an abandoned same-BI capsule is the
+  // durable identity to resume, while a foreign/terminal identity must refuse
+  // instead of falling through to an impossible duplicate create (BI-E363A524).
   const existing = await args.db.workCapsule.findFirst({
     where: {
       repositoryFullName: args.input.repositoryFullName,
       headBranch: args.input.headBranch,
-      archivedAt: null,
-      status: { notIn: TERMINAL_CAPSULE_STATUSES },
     },
     orderBy: { updatedAt: "desc" },
   });
+
+  const now = new Date();
+  const resumePlan = planAbandonedCapsuleResume({ existing, input: args.input, actor: args.actor, now });
+  if (resumePlan) {
+    return inTransaction(args.db, async (tx) => {
+      await admitCapsuleWork(tx, "work-capsule:external-adoption");
+      const resumed = await tx.workCapsule.update(resumePlan.update);
+      await recordActivity(tx, { ...resumePlan.activity, actor: args.actor });
+      return resumed;
+    });
+  }
+
   if (existing && isReusableLiveCapsule(existing, args.input)) {
     // Late-bind (BI-7D20BFDF): a branch adopted before its BacklogItem was known
     // has a null backlogItemId. When a claim now supplies one, bind the existing
@@ -311,10 +265,10 @@ export async function adoptWorktreeCapsule(args: {
     }
     return existing;
   }
-  // existing is null, terminal-only on this branch, or live-but-incompatible
-  // (different BI/session) — fall through to create a fresh capsule.
+  if (existing) {
+    throw new CapsuleBranchOccupiedError(existing);
+  }
 
-  const now = new Date();
   try {
     return await inTransaction(args.db, async (tx) => {
       await admitCapsuleWork(tx, "work-capsule:external-adoption");
@@ -366,12 +320,11 @@ export async function adoptWorktreeCapsule(args: {
         where: {
           repositoryFullName: args.input.repositoryFullName,
           headBranch: args.input.headBranch,
-          archivedAt: null,
-          status: { notIn: TERMINAL_CAPSULE_STATUSES },
         },
         orderBy: { updatedAt: "desc" },
       });
       if (winner && isReusableLiveCapsule(winner, args.input)) return winner;
+      if (winner) throw new CapsuleBranchOccupiedError(winner);
     }
     throw error;
   }

--- a/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
+++ b/docs/superpowers/specs/2026-05-14-portal-work-capsule-control-harness-design.md
@@ -387,7 +387,7 @@ Field notes:
 - **Principal resolution at write time.** Implementations MUST resolve the writer to a Principal using the existing `apps/web/lib/identity/principal-linking.ts` primitives  -  `resolvePrincipalIdForUser(userId)` for human writers and `ensureAgentPrincipalIdentity(agentId)` for agent writers. If resolution fails (no alias yet, principal-linking outage), the column is written as `null` rather than fabricating a non-Principal FK. A null `*PrincipalId` is a known intermediate state; a User.id or Agent.id stuffed into a Principal column is a data-integrity defect that requires migration to undo.
 - `contributionMode` is `private` (default; PR targets the install's own repo) or `hive-public` (PR targets the public hive fork; goes through `contribute_to_hive` plumbing). The two modes require different DCO/signing surfaces; capsule must declare its mode at creation so downstream tools route correctly.
 - `branchTaxonomy` records the AGENTS.md section 4 prefix (`feat`, `fix`, `chore`, `doc`, `clean`). Capsule creation enforces this; adoption infers it from branch name and warns if absent.
-- `idempotencyKey` allows safe retry of `create_work_capsule` and `adopt_worktree`. Server returns the existing capsule on conflict rather than creating a duplicate.
+- `idempotencyKey` allows safe retry of `create_work_capsule` and `adopt_worktree`. The branch natural key owns one durable capsule identity: a live compatible capsule is reused, an abandoned capsule is resumed only for the same BacklogItem, and an incompatible terminal or foreign binding returns `branch_occupied` without overwriting history or attempting an impossible duplicate insert.
 - `leaseHolderPrincipalId` + `leaseExpiresAt` implement the external executor heartbeat in section 9.5. Build Studio capsules do not use the lease; they rely on `FeatureBuild` lifecycle directly.
 - Cached git/PR/sandbox fields (`baseSha`, `headSha`, `pullRequestNumber`, `sandboxId`, etc.) follow section 7.4: refresh through the reconciler, never authoritative.
 
@@ -521,7 +521,7 @@ Required MCP tools:
 | `list_work_capsules` | find assigned or open capsules | read-only |
 | `get_work_capsule` | hydrate context before acting | read-only |
 | `create_work_capsule` | create a governed work unit | `idempotencyKey` required; conflict returns existing capsule |
-| `adopt_worktree` | attach an existing path/branch | natural key `(repositoryFullName, headBranch)` returns existing capsule |
+| `adopt_worktree` | attach an existing path/branch | natural key `(repositoryFullName, headBranch)` reuses a compatible live capsule, resumes an abandoned same-BI capsule, and refuses foreign history with `branch_occupied` |
 | `plan_capsule_worktree` | generate deterministic branch name, worktree path, and taxonomy; display operator-paste launch commands | idempotent re-plan; collision with existing branch adds numeric suffix; issues initial lease on external-executor assignment |
 | `claim_capsule_scope` | declare intended files/modules | merging set on `(capsuleId, kind, value)` |
 | `record_capsule_evidence` | persist tests, builds, screenshots, notes | append-only |


### PR DESCRIPTION
## Summary

Preserve a work capsule's repository-and-branch identity when intentionally paused work resumes. A same-backlog abandoned capsule is reactivated in place with its history and evidence intact, while a foreign or incompatible terminal occupant returns a structured conflict instead of attempting a duplicate insert.

## Changes

- Centralize branch-identity adoption policy and structured MCP conflict results in focused shared modules.
- Resume an abandoned same-BI capsule in place while refreshing executor, worktree, head SHA, status, and lease fields.
- Refuse branch reuse across backlog items or incompatible terminal states without overwriting durable history.
- Add regression coverage across store, adoption-policy, and MCP handler boundaries.
- Update the Work Capsule control-harness design with the durable branch-identity contract.

## Test plan

- [x] **Source-only change** (types, isolated unit logic, doc, schema-only)
  - [x] Scoped typecheck passed in governed local CI
  - [x] Targeted unit tests: 3 files, 67 tests passed

- [x] **Runtime-bound change** (server route, MCP tool, build/runtime wiring, compose, installer, prisma migration, UX surface)
  - [x] Source checks above passed where they can run in the worktree
  - [x] Functional verification ran against the **canonical runtime**:
        - [x] governed shared nonprod env (lease id: NPEL-C82F8310B0)
  - [x] Evidence captured below

- [ ] **Verification-harness limitation acknowledged**

### Verification evidence

- `pnpm run pregate` passed exact `683ebfcae1f3b643afa0f9b523747e5213de6381` in 10:44.
- Local-CI evidence: `cmsq01u3z03cj01qefkyfi08q`.
- Focused Vitest: 3 files, 67 tests passed.
- Module-size ratchet, design-grounding guard, and `git diff --check` passed.
- Fresh semantic review receipt `cmspylmo100kg01qeap5kowir` recorded zero findings; its inference branch was infrastructure-inconclusive and shadow policy allowed publication.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and against the final diff
- [x] `pnpm run pregate:preflight` passed before requesting the shared-sandbox lease
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` returned `PR readiness: READY`

Local-CI-Evidence: cmsq01u3z03cj01qefkyfi08q (fix/capsule-claim-abandoned-reuse@683ebfcae1f3b643afa0f9b523747e5213de6381)

## Related issues / Epic

- Backlog: BI-E363A524

## Overlap sweep

- Open PRs #4221, #4215, and #4211 cover unrelated performance, graph projection, and reaper configuration concerns.

## Notes for the reviewer

- No schema migration or user-facing UI change.
- The preserved stash is recovery-only and is not part of this branch.
- Design-Grounding-Decision: preserve the existing repository-and-branch capsule natural key as the durable identity; resume abandoned work only for the same backlog item and refuse foreign history.
- Docs-Impact-Decision: work-capsule resume semantics are documented in the updated control-harness design; the generic tool-pack architecture page and its generated staleness report do not change.
