### PR TITLE
fix(grid): inherit domain default data lenses

### DIFF
--- a/apps/web/app/(shell)/compliance/controls/page.tsx
+++ b/apps/web/app/(shell)/compliance/controls/page.tsx
@@ -1,14 +1,19 @@
 import { listControls } from "@/lib/actions/compliance";
 import { CreateControlForm } from "@/components/compliance/CreateControlForm";
 import { FilterBar, StatusBadge } from "@/components/ui/report-kit";
-import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
+import {
+  PlatformGridSection,
+  parseSurfaceDataScope,
+  parseSurfaceView,
+} from "@/components/workbooks/PlatformGridSection";
 import Link from "next/link";
 
-type Props = { searchParams: Promise<{ controlType?: string; implementationStatus?: string; effectiveness?: string; view?: string }> };
+type Props = { searchParams: Promise<{ controlType?: string; implementationStatus?: string; effectiveness?: string; view?: string; dataScope?: string }> };
 
 export default async function ControlsPage({ searchParams }: Props) {
   const sp = await searchParams;
   const view = parseSurfaceView(sp.view);
+  const dataScope = parseSurfaceDataScope(sp.dataScope);
   const filters = {
     ...(sp.controlType && { controlType: sp.controlType }),
     ...(sp.implementationStatus && { implementationStatus: sp.implementationStatus }),
@@ -82,7 +87,11 @@ export default async function ControlsPage({ searchParams }: Props) {
         )}
       </div>
 
-      <PlatformGridSection entityType="compliance_control" view={view} />
+      <PlatformGridSection
+        entityType="compliance_control"
+        view={view}
+        dataScope={dataScope}
+      />
 
       {!view && (controls.length === 0 ? (
         <p className="text-sm text-[var(--dpf-muted)]">No controls match the current filters.</p>

--- a/apps/web/app/(shell)/compliance/obligations/page.tsx
+++ b/apps/web/app/(shell)/compliance/obligations/page.tsx
@@ -2,7 +2,11 @@ import { prisma } from "@dpf/db";
 import { CreateObligationForm } from "@/components/compliance/CreateObligationForm";
 import { ComplianceLibraryScopeNav } from "@/components/compliance/ComplianceLibraryScopeNav";
 import { ObligationLibraryPanel } from "@/components/compliance/ObligationLibraryPanel";
-import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
+import {
+  PlatformGridSection,
+  parseSurfaceDataScope,
+  parseSurfaceView,
+} from "@/components/workbooks/PlatformGridSection";
 import Link from "next/link";
 import {
   DEFAULT_COMPLIANCE_LIBRARY_SCOPE,
@@ -15,12 +19,13 @@ import {
 } from "@/lib/compliance-library";
 
 type Props = {
-  searchParams: Promise<{ regulation?: string; category?: string; status?: string; scope?: string; view?: string }>;
+  searchParams: Promise<{ regulation?: string; category?: string; status?: string; scope?: string; view?: string; dataScope?: string }>;
 };
 
 export default async function ObligationsPage({ searchParams }: Props) {
   const filters = await searchParams;
   const view = parseSurfaceView(filters.view);
+  const dataScope = parseSurfaceDataScope(filters.dataScope);
   const scope = parseComplianceLibraryScope(filters.scope);
 
   const [context, obligations, regulations, categories] = await Promise.all([
@@ -222,7 +227,11 @@ export default async function ObligationsPage({ searchParams }: Props) {
         )}
       </div>
 
-      <PlatformGridSection entityType="compliance_obligation" view={view} />
+      <PlatformGridSection
+        entityType="compliance_obligation"
+        view={view}
+        dataScope={dataScope}
+      />
 
       {!view && (
         <ObligationLibraryPanel

--- a/apps/web/app/(shell)/compliance/risks/page.tsx
+++ b/apps/web/app/(shell)/compliance/risks/page.tsx
@@ -3,14 +3,18 @@ import { RISK_LEVELS } from "@/lib/compliance-types";
 import Link from "next/link";
 import { CreateRiskAssessmentForm } from "@/components/compliance/CreateRiskAssessmentForm";
 import { StatusBadge } from "@/components/ui/report-kit";
-import { SurfaceViewSwitcher } from "@/components/workbooks/SurfaceViewSwitcher";
-import { SurfacePlatformGrid } from "@/components/workbooks/SurfacePlatformGrid";
+import {
+  PlatformGridSection,
+  parseSurfaceDataScope,
+  parseSurfaceView,
+} from "@/components/workbooks/PlatformGridSection";
 
-type Props = { searchParams: Promise<{ inherentRisk?: string; status?: string; view?: string }> };
+type Props = { searchParams: Promise<{ inherentRisk?: string; status?: string; view?: string; dataScope?: string }> };
 
 export default async function RisksPage({ searchParams }: Props) {
   const sp = await searchParams;
-  const view = sp.view === "grid" || sp.view === "board" ? sp.view : null;
+  const view = parseSurfaceView(sp.view);
+  const dataScope = parseSurfaceDataScope(sp.dataScope);
   const filters = {
     ...(sp.inherentRisk && { inherentRisk: sp.inherentRisk }),
     ...(sp.status && { status: sp.status }),
@@ -27,11 +31,13 @@ export default async function RisksPage({ searchParams }: Props) {
         <CreateRiskAssessmentForm />
       </div>
 
-      <SurfaceViewSwitcher entityType="risk_assessment" current={view ?? "list"} />
+      <PlatformGridSection
+        entityType="risk_assessment"
+        view={view}
+        dataScope={dataScope}
+      />
 
-      {view ? (
-        <SurfacePlatformGrid entityType="risk_assessment" view={view} />
-      ) : (
+      {!view ? (
         <>
       {/* Filter bar */}
       <form className="flex flex-wrap gap-3 mb-6">
@@ -91,7 +97,7 @@ export default async function RisksPage({ searchParams }: Props) {
         </div>
       )}
         </>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/apps/web/app/(shell)/customer/(crm)/opportunities/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/opportunities/page.tsx
@@ -15,16 +15,21 @@ import { getStageAgeDays, isStageStale } from "@/lib/crm/pipeline-inspector";
 import { getPipelineInspectorView } from "@/lib/crm/pipeline-inspector-data";
 import { formatRevenueAmount } from "@/lib/crm/revenue-cockpit";
 import { getOrgSettings } from "@/lib/actions/currency";
-import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
+import {
+  PlatformGridSection,
+  parseSurfaceDataScope,
+  parseSurfaceView,
+} from "@/components/workbooks/PlatformGridSection";
 
 type OpportunitiesPageProps = {
-  searchParams?: Promise<{ opportunity?: string; view?: string }>;
+  searchParams?: Promise<{ opportunity?: string; view?: string; dataScope?: string }>;
 };
 
 export default async function OpportunitiesPage({ searchParams }: OpportunitiesPageProps) {
   const sp = await searchParams;
   const requestedOpportunityId = sp?.opportunity;
   const view = parseSurfaceView(sp?.view);
+  const dataScope = parseSurfaceDataScope(sp?.dataScope);
   const [opportunities, orgSettings, accounts] = await Promise.all([
     prisma.opportunity.findMany({
     orderBy: { createdAt: "desc" },
@@ -94,7 +99,11 @@ export default async function OpportunitiesPage({ searchParams }: OpportunitiesP
         <NewOpportunityButton accounts={accounts} />
       </div>
 
-      <PlatformGridSection entityType="opportunity" view={view} />
+      <PlatformGridSection
+        entityType="opportunity"
+        view={view}
+        dataScope={dataScope}
+      />
 
       {!view && (
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_24rem]">

--- a/apps/web/app/(shell)/customer/(crm)/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/page.tsx
@@ -22,14 +22,20 @@ import {
   classifyAccountAttention,
   sortAccountsByAttention,
 } from "@/lib/crm/account-attention";
-import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
+import {
+  PlatformGridSection,
+  parseSurfaceDataScope,
+  parseSurfaceView,
+} from "@/components/workbooks/PlatformGridSection";
 
 export default async function CustomerPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ view?: string }>;
+  searchParams?: Promise<{ view?: string; dataScope?: string }>;
 }) {
-  const view = parseSurfaceView((await searchParams)?.view);
+  const sp = await searchParams;
+  const view = parseSurfaceView(sp?.view);
+  const dataScope = parseSurfaceDataScope(sp?.dataScope);
   const [
     accounts,
     engagementCounts,
@@ -240,7 +246,11 @@ export default async function CustomerPage({
 
           <DuplicateAccountsPanel />
 
-          <PlatformGridSection entityType="customer_account" view={view} />
+          <PlatformGridSection
+            entityType="customer_account"
+            view={view}
+            dataScope={dataScope}
+          />
 
           {!view && (
             <>

--- a/apps/web/app/(shell)/ops/page.tsx
+++ b/apps/web/app/(shell)/ops/page.tsx
@@ -19,6 +19,22 @@ type Props = {
   searchParams?: Promise<{ itemId?: string; view?: string; dataScope?: string; origin?: string }>;
 };
 
+function ignoreReadFailure(): undefined {
+  return undefined;
+}
+
+function emptyReadResult(): never[] {
+  return [];
+}
+
+function zeroReadResult(): number {
+  return 0;
+}
+
+function nullReadResult(): null {
+  return null;
+}
+
 export default async function OpsPage({ searchParams }: Props) {
   const sp = await searchParams;
   const view = parseSurfaceView(sp?.view);
@@ -30,13 +46,13 @@ export default async function OpsPage({ searchParams }: Props) {
   // capability need is guaranteed in the backlog. Non-fatal; zero-write once
   // converged.
   await Promise.all([
-    reconcileImprovementBacklog().catch(() => {}),
-    reconcileCapabilityNeedBacklog().catch(() => {}),
+    reconcileImprovementBacklog().catch(ignoreReadFailure),
+    reconcileCapabilityNeedBacklog().catch(ignoreReadFailure),
     // BI-467E8F8D: clear stale build-stall escalations so the queue stays trustworthy
     // without waiting for the 15-min cron. The escalation BAND moved to the /workspace
     // "Needs you" inbox (EP-ATTENTION-SURFACE: attention ≠ backlog); the hygiene stays
     // here too since /ops still reconciles work. Non-fatal; zero-write once converged.
-    runEscalationHygiene().catch(() => {}),
+    runEscalationHygiene().catch(ignoreReadFailure),
   ]);
 
   // Do not build the hidden List read model for Grid/Board requests. Those
@@ -46,19 +62,19 @@ export default async function OpsPage({ searchParams }: Props) {
     view
       ? Promise.resolve(null)
       : Promise.all([
-          getBacklogItems().catch(() => []),
-          getDigitalProductsForSelect().catch(() => []),
-          getTaxonomyNodesFlat().catch(() => []),
-          getEpics().catch(() => []),
-          getPortfoliosForSelect().catch(() => []),
+          getBacklogItems().catch(emptyReadResult),
+          getDigitalProductsForSelect().catch(emptyReadResult),
+          getTaxonomyNodesFlat().catch(emptyReadResult),
+          getEpics().catch(emptyReadResult),
+          getPortfoliosForSelect().catch(emptyReadResult),
         ]),
     view
       ? Promise.all([
-          prisma.epic.count().catch(() => 0),
-          prisma.backlogItem.count().catch(() => 0),
+          prisma.epic.count().catch(zeroReadResult),
+          prisma.backlogItem.count().catch(zeroReadResult),
         ])
       : Promise.resolve(null),
-    auth().catch(() => null),
+    auth().catch(nullReadResult),
   ]);
   const items = listData?.[0] ?? [];
   const digitalProducts = listData?.[1] ?? [];

--- a/apps/web/app/(shell)/ops/page.tsx
+++ b/apps/web/app/(shell)/ops/page.tsx
@@ -6,19 +6,23 @@ import { runEscalationHygiene } from "@/lib/quality/escalation-hygiene-runner";
 import { OpsClient } from "@/components/ops/OpsClient";
 import { OpsTabNav } from "@/components/ops/OpsTabNav";
 import { auth } from "@/lib/auth";
-import { SurfaceViewSwitcher } from "@/components/workbooks/SurfaceViewSwitcher";
-import { SurfacePlatformGrid } from "@/components/workbooks/SurfacePlatformGrid";
+import { prisma } from "@dpf/db";
+import {
+  PlatformGridSection,
+  parseSurfaceDataScope,
+  parseSurfaceView,
+} from "@/components/workbooks/PlatformGridSection";
 
 export const dynamic = "force-dynamic";
 
 type Props = {
-  searchParams?: Promise<{ itemId?: string; view?: string; origin?: string }>;
+  searchParams?: Promise<{ itemId?: string; view?: string; dataScope?: string; origin?: string }>;
 };
 
 export default async function OpsPage({ searchParams }: Props) {
   const sp = await searchParams;
-  const rawView = sp?.view;
-  const view = rawView === "grid" || rawView === "board" ? rawView : null;
+  const view = parseSurfaceView(sp?.view);
+  const dataScope = parseSurfaceDataScope(sp?.dataScope);
 
   // Surface convergence (EP-INTAKE-UNIFY, operator directive 2026-06-20): /ops is
   // the ONE place every source is seen + worked, so it now owns the idempotent
@@ -35,14 +39,34 @@ export default async function OpsPage({ searchParams }: Props) {
     runEscalationHygiene().catch(() => {}),
   ]);
 
-  const [items, digitalProducts, taxonomyNodes, epics, portfolios, session] = await Promise.all([
-    getBacklogItems().catch(() => []),
-    getDigitalProductsForSelect().catch(() => []),
-    getTaxonomyNodesFlat().catch(() => []),
-    getEpics().catch(() => []),
-    getPortfoliosForSelect().catch(() => []),
+  // Do not build the hidden List read model for Grid/Board requests. Those
+  // views fetch their bounded adapter dataset below; the header needs counts,
+  // not thousands of relation-rich records.
+  const [listData, counts, session] = await Promise.all([
+    view
+      ? Promise.resolve(null)
+      : Promise.all([
+          getBacklogItems().catch(() => []),
+          getDigitalProductsForSelect().catch(() => []),
+          getTaxonomyNodesFlat().catch(() => []),
+          getEpics().catch(() => []),
+          getPortfoliosForSelect().catch(() => []),
+        ]),
+    view
+      ? Promise.all([
+          prisma.epic.count().catch(() => 0),
+          prisma.backlogItem.count().catch(() => 0),
+        ])
+      : Promise.resolve(null),
     auth().catch(() => null),
   ]);
+  const items = listData?.[0] ?? [];
+  const digitalProducts = listData?.[1] ?? [];
+  const taxonomyNodes = listData?.[2] ?? [];
+  const epics = listData?.[3] ?? [];
+  const portfolios = listData?.[4] ?? [];
+  const epicCount = counts?.[0] ?? epics.length;
+  const itemCount = counts?.[1] ?? items.length;
   // Current operator — resolves the "mine" scope in the Needs-you-next band
   // (BI-01CC2356). Optional: the band degrades to an urgency-only split when absent.
   const currentUserId = session?.user?.id ?? undefined;
@@ -52,17 +76,19 @@ export default async function OpsPage({ searchParams }: Props) {
       <div className="mb-6">
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Operations</h1>
         <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
-          {epics.length} epic{epics.length !== 1 ? "s" : ""} · {items.length} item{items.length !== 1 ? "s" : ""}
+          {epicCount} epic{epicCount !== 1 ? "s" : ""} · {itemCount} item{itemCount !== 1 ? "s" : ""}
         </p>
       </div>
 
       <OpsTabNav />
 
-      <SurfaceViewSwitcher entityType="backlog_item" current={view ?? "list"} />
+      <PlatformGridSection
+        entityType="backlog_item"
+        view={view}
+        dataScope={dataScope}
+      />
 
-      {view ? (
-        <SurfacePlatformGrid entityType="backlog_item" view={view} />
-      ) : (
+      {!view ? (
         <OpsClient
           items={items}
           digitalProducts={digitalProducts}
@@ -73,7 +99,7 @@ export default async function OpsPage({ searchParams }: Props) {
           initialOrigin={sp?.origin}
           currentUserId={currentUserId}
         />
-      )}
+      ) : null}
     </div>
   );
 }

--- a/apps/web/components/ops/BacklogItemRow.tsx
+++ b/apps/web/components/ops/BacklogItemRow.tsx
@@ -13,7 +13,7 @@ import { type BacklogItemWithRelations } from "@/lib/backlog";
 import { resolveBacklogBuildActionState } from "@/lib/backlog-build-action-state";
 import { AGENT_NAME_MAP } from "@/lib/agent-routing";
 import { backlogItemOrigin, BACKLOG_ORIGIN_LABEL } from "@/lib/ops/backlog-origin";
-import { backlogItemLifecycleLabel } from "./backlogVisibility";
+import { backlogItemLifecycleLabel } from "@/lib/backlog-visibility";
 
 type Props = {
   item: BacklogItemWithRelations;

--- a/apps/web/components/ops/EpicCard.tsx
+++ b/apps/web/components/ops/EpicCard.tsx
@@ -15,7 +15,7 @@ import {
   summarizeBacklogStatuses,
   visibleUnderActiveOnly,
   type BacklogStatusSummary,
-} from "./backlogVisibility";
+} from "@/lib/backlog-visibility";
 
 // Must stay in sync with OpsClient SortField / SortState
 export type EpicSortField = "title" | "status" | "progress" | "stories";

--- a/apps/web/components/ops/OpsClient.tsx
+++ b/apps/web/components/ops/OpsClient.tsx
@@ -7,7 +7,7 @@ import { BacklogItemRow } from "./BacklogItemRow";
 import { EpicCard, type EpicSort } from "./EpicCard";
 import { EpicPanel } from "./EpicPanel";
 import { OperatorTriageBand } from "./OperatorTriageBand";
-import { summarizeBacklogStatuses, visibleUnderActiveOnly } from "./backlogVisibility";
+import { summarizeBacklogStatuses, visibleUnderActiveOnly } from "@/lib/backlog-visibility";
 import { FilterBar, type FacetDef } from "@/components/ui/report-kit";
 import { backlogItemOrigin, BACKLOG_ORIGIN_FILTERS } from "@/lib/ops/backlog-origin";
 import type {

--- a/apps/web/components/ops/backlogVisibility.test.ts
+++ b/apps/web/components/ops/backlogVisibility.test.ts
@@ -5,7 +5,7 @@ import {
   isTerminalBacklogItemStatus,
   summarizeBacklogStatuses,
   visibleUnderActiveOnly,
-} from "./backlogVisibility";
+} from "@/lib/backlog-visibility";
 
 describe("isTerminalBacklogItemStatus", () => {
   it("treats done and deferred as terminal, everything else as active", () => {

--- a/apps/web/components/workbooks/PlatformGridSection.tsx
+++ b/apps/web/components/workbooks/PlatformGridSection.tsx
@@ -14,21 +14,39 @@
 import { SurfaceViewSwitcher } from "./SurfaceViewSwitcher";
 import { SurfacePlatformGrid } from "./SurfacePlatformGrid";
 
-// Re-export the pure helper so a page can import the section + parser together.
-export { parseSurfaceView } from "@/lib/workbooks/surface-view";
+import type { SurfaceDataScope } from "@/lib/workbooks/surface-view";
+
+// Re-export pure helpers so a page can import the section + parsers together.
+export {
+  parseSurfaceDataScope,
+  parseSurfaceView,
+} from "@/lib/workbooks/surface-view";
 
 export function PlatformGridSection({
   entityType,
   view,
+  dataScope = "default",
 }: {
   entityType: string;
   /** the parsed view (parseSurfaceView); null = show the page's own list */
   view: "grid" | "board" | null;
+  /** registry default unless the URL explicitly selects all records */
+  dataScope?: SurfaceDataScope;
 }) {
   return (
     <>
-      <SurfaceViewSwitcher entityType={entityType} current={view ?? "list"} />
-      {view ? <SurfacePlatformGrid entityType={entityType} view={view} /> : null}
+      <SurfaceViewSwitcher
+        entityType={entityType}
+        current={view ?? "list"}
+        dataScope={dataScope}
+      />
+      {view ? (
+        <SurfacePlatformGrid
+          entityType={entityType}
+          view={view}
+          dataScope={dataScope}
+        />
+      ) : null}
     </>
   );
 }

--- a/apps/web/components/workbooks/SurfacePlatformGrid.tsx
+++ b/apps/web/components/workbooks/SurfacePlatformGrid.tsx
@@ -6,8 +6,13 @@
 import { auth } from "@/lib/auth";
 import {
   getAllPlatformTableRows,
+  getHomeSurfaceForEntity,
   type PlatformUser,
 } from "@/lib/workbooks/platform-tables";
+import {
+  resolveSurfaceDataFilter,
+  type SurfaceDataScope,
+} from "@/lib/workbooks/surface-view";
 import { WorkbookError } from "@/lib/workbooks/workbook-service";
 import { defaultGroupByColumn } from "@/lib/workbooks/kanban-grouping";
 import { WorkbookGrid } from "@/components/workbooks/Grid";
@@ -16,9 +21,11 @@ import { KanbanBoard } from "@/components/workbooks/KanbanBoard";
 export async function SurfacePlatformGrid({
   entityType,
   view,
+  dataScope = "default",
 }: {
   entityType: string;
   view: "grid" | "board";
+  dataScope?: SurfaceDataScope;
 }) {
   const session = await auth();
   if (!session?.user) return null;
@@ -31,7 +38,10 @@ export async function SurfacePlatformGrid({
 
   let grid;
   try {
-    grid = await getAllPlatformTableRows(svcUser, entityType);
+    const defaultFilter = getHomeSurfaceForEntity(entityType)?.defaultDataLens?.filter;
+    grid = await getAllPlatformTableRows(svcUser, entityType, {
+      filters: resolveSurfaceDataFilter(defaultFilter, dataScope),
+    });
   } catch (e) {
     if (e instanceof WorkbookError) {
       return <p className="text-sm text-[var(--dpf-muted)]">{e.message}</p>;

--- a/apps/web/components/workbooks/SurfaceViewSwitcher.test.tsx
+++ b/apps/web/components/workbooks/SurfaceViewSwitcher.test.tsx
@@ -1,0 +1,59 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { SurfaceViewSwitcher } from "./SurfaceViewSwitcher";
+
+vi.mock("@/lib/workbooks/platform-tables", () => ({
+  getHomeSurfaceForEntity: (entityType: string) => {
+    if (entityType === "backlog_item") {
+      return {
+        path: "/ops",
+        label: "Operations",
+        board: true,
+        defaultDataLens: {
+          defaultLabel: "Active only",
+          allLabel: "All items",
+          filter: {
+            conditions: [{ field: "status", operator: "in", value: ["open"] }],
+            logic: "and",
+          },
+        },
+      };
+    }
+    if (entityType === "supplier") {
+      return { path: "/finance/suppliers", label: "Suppliers", board: true };
+    }
+    return undefined;
+  },
+}));
+
+describe("SurfaceViewSwitcher data lens (BI-9DB20C39)", () => {
+  it.each(["grid", "board"] as const)(
+    "renders the domain default and explicit all-records scope for %s",
+    (current) => {
+      const html = renderToStaticMarkup(
+        <SurfaceViewSwitcher entityType="backlog_item" current={current} />,
+      );
+
+      expect(html).toContain('aria-label="Operations data scope"');
+      expect(
+        html.match(new RegExp(`aria-current="page"[^>]*href="/ops\\?view=${current}"`, "g")),
+      ).toHaveLength(2);
+      expect(html).toContain(`href="/ops?view=${current}&amp;dataScope=all"`);
+      expect(html).toContain("Active only");
+      expect(html).toContain("All items");
+    },
+  );
+
+  it("keeps scope controls out of List and all-records domain surfaces", () => {
+    const listHtml = renderToStaticMarkup(
+      <SurfaceViewSwitcher entityType="backlog_item" current="list" />,
+    );
+    const unfilteredGridHtml = renderToStaticMarkup(
+      <SurfaceViewSwitcher entityType="supplier" current="grid" />,
+    );
+
+    expect(listHtml).not.toContain("data scope");
+    expect(unfilteredGridHtml).not.toContain("data scope");
+  });
+});

--- a/apps/web/components/workbooks/SurfaceViewSwitcher.test.tsx
+++ b/apps/web/components/workbooks/SurfaceViewSwitcher.test.tsx
@@ -54,6 +54,7 @@ describe("SurfaceViewSwitcher data lens (BI-9DB20C39)", () => {
     );
 
     expect(listHtml).not.toContain("data scope");
+    expect(listHtml).not.toContain("<nav");
     expect(unfilteredGridHtml).not.toContain("data scope");
   });
 });

--- a/apps/web/components/workbooks/SurfaceViewSwitcher.tsx
+++ b/apps/web/components/workbooks/SurfaceViewSwitcher.tsx
@@ -6,43 +6,88 @@
 import Link from "next/link";
 
 import { getHomeSurfaceForEntity } from "@/lib/workbooks/platform-tables";
+import {
+  buildSurfaceViewHref,
+  type SurfaceDataScope,
+  type SurfaceView,
+} from "@/lib/workbooks/surface-view";
 
-export type SurfaceView = "list" | "grid" | "board";
+const ACTIVE_OPTION_CLASS =
+  "bg-[var(--dpf-surface-2)] px-3 py-1.5 font-medium text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--dpf-accent)]";
+const INACTIVE_OPTION_CLASS =
+  "px-3 py-1.5 text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--dpf-accent)]";
 
 export function SurfaceViewSwitcher({
   entityType,
   current,
+  dataScope = "default",
 }: {
   entityType: string;
   current: SurfaceView;
+  dataScope?: SurfaceDataScope;
 }) {
   const home = getHomeSurfaceForEntity(entityType);
   if (!home) return null;
 
   const tabs: Array<{ key: SurfaceView; label: string; href: string }> = [
-    { key: "list", label: "List", href: home.path },
-    { key: "grid", label: "Grid", href: `${home.path}?view=grid` },
+    {
+      key: "list",
+      label: "List",
+      href: buildSurfaceViewHref(home.path, "list", dataScope),
+    },
+    {
+      key: "grid",
+      label: "Grid",
+      href: buildSurfaceViewHref(home.path, "grid", dataScope),
+    },
   ];
   if (home.board) {
-    tabs.push({ key: "board", label: "Board", href: `${home.path}?view=board` });
+    tabs.push({
+      key: "board",
+      label: "Board",
+      href: buildSurfaceViewHref(home.path, "board", dataScope),
+    });
   }
 
+  const lens = current === "list" ? undefined : home.defaultDataLens;
+
   return (
-    <div className="mb-4 inline-flex w-fit overflow-hidden rounded-md border border-[var(--dpf-border)] text-sm">
-      {tabs.map((t) => (
-        <Link
-          key={t.key}
-          href={t.href}
-          aria-current={current === t.key ? "page" : undefined}
-          className={
-            current === t.key
-              ? "bg-[var(--dpf-surface-2)] px-3 py-1.5 font-medium text-[var(--dpf-text)]"
-              : "px-3 py-1.5 text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
-          }
+    <div className="mb-4 flex w-fit max-w-full flex-wrap items-center gap-2 text-sm">
+      <nav
+        aria-label={`${home.label} view`}
+        className="inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)]"
+      >
+        {tabs.map((t) => (
+          <Link
+            key={t.key}
+            href={t.href}
+            aria-current={current === t.key ? "page" : undefined}
+            className={current === t.key ? ACTIVE_OPTION_CLASS : INACTIVE_OPTION_CLASS}
+          >
+            {t.label}
+          </Link>
+        ))}
+      </nav>
+      {lens ? (
+        <nav
+          aria-label={`${home.label} data scope`}
+          className="inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)]"
         >
-          {t.label}
-        </Link>
-      ))}
+          {([
+            { scope: "default" as const, label: lens.defaultLabel },
+            { scope: "all" as const, label: lens.allLabel },
+          ]).map((option) => (
+            <Link
+              key={option.scope}
+              href={buildSurfaceViewHref(home.path, current, option.scope)}
+              aria-current={dataScope === option.scope ? "page" : undefined}
+              className={dataScope === option.scope ? ACTIVE_OPTION_CLASS : INACTIVE_OPTION_CLASS}
+            >
+              {option.label}
+            </Link>
+          ))}
+        </nav>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/components/workbooks/SurfaceViewSwitcher.tsx
+++ b/apps/web/components/workbooks/SurfaceViewSwitcher.tsx
@@ -53,8 +53,7 @@ export function SurfaceViewSwitcher({
 
   return (
     <div className="mb-4 flex w-fit max-w-full flex-wrap items-center gap-2 text-sm">
-      <nav
-        aria-label={`${home.label} view`}
+      <div
         className="inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)]"
       >
         {tabs.map((t) => (
@@ -67,9 +66,10 @@ export function SurfaceViewSwitcher({
             {t.label}
           </Link>
         ))}
-      </nav>
+      </div>
       {lens ? (
-        <nav
+        <div
+          role="group"
           aria-label={`${home.label} data scope`}
           className="inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)]"
         >
@@ -86,7 +86,7 @@ export function SurfaceViewSwitcher({
               {option.label}
             </Link>
           ))}
-        </nav>
+        </div>
       ) : null}
     </div>
   );

--- a/apps/web/lib/backlog-visibility.test.ts
+++ b/apps/web/lib/backlog-visibility.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ACTIVE_BACKLOG_STATUSES,
+  TERMINAL_BACKLOG_STATUSES,
+  isTerminalBacklogItemStatus,
+  visibleUnderActiveOnly,
+} from "./backlog-visibility";
+
+describe("shared backlog lifecycle lens (BI-9DB20C39)", () => {
+  it("defines one exhaustive active-versus-terminal split for List and Grid", () => {
+    expect(ACTIVE_BACKLOG_STATUSES).toEqual(["triaging", "open", "in-progress"]);
+    expect(TERMINAL_BACKLOG_STATUSES).toEqual(["done", "deferred"]);
+    expect([...ACTIVE_BACKLOG_STATUSES, ...TERMINAL_BACKLOG_STATUSES]).toEqual([
+      "triaging",
+      "open",
+      "in-progress",
+      "done",
+      "deferred",
+    ]);
+  });
+
+  it("drives the List active-only helper from the same terminal set", () => {
+    const items = [
+      { status: "triaging" },
+      { status: "open" },
+      { status: "in-progress" },
+      { status: "done" },
+      { status: "deferred" },
+    ];
+
+    expect(items.filter((item) => !isTerminalBacklogItemStatus(item.status))).toEqual(
+      visibleUnderActiveOnly(items, true),
+    );
+    expect(visibleUnderActiveOnly(items, true).map((item) => item.status)).toEqual(
+      ACTIVE_BACKLOG_STATUSES,
+    );
+  });
+});

--- a/apps/web/lib/backlog-visibility.ts
+++ b/apps/web/lib/backlog-visibility.ts
@@ -1,5 +1,33 @@
+import {
+  BACKLOG_STATUS_VALUES,
+  type BacklogStatus,
+} from "@/lib/explore/backlog";
+
+export const ACTIVE_BACKLOG_STATUSES = [
+  "triaging",
+  "open",
+  "in-progress",
+] as const satisfies readonly BacklogStatus[];
+
+export const TERMINAL_BACKLOG_STATUSES = [
+  "done",
+  "deferred",
+] as const satisfies readonly BacklogStatus[];
+
+const terminalStatuses = new Set<string>(TERMINAL_BACKLOG_STATUSES);
+
+// Keep the operator visibility split exhaustive when the canonical lifecycle
+// registry changes. The lists remain readonly so List/Grid consumers cannot
+// quietly redefine the domain lens at their call site.
+if (
+  ACTIVE_BACKLOG_STATUSES.length + TERMINAL_BACKLOG_STATUSES.length
+  !== BACKLOG_STATUS_VALUES.length
+) {
+  throw new Error("Backlog visibility statuses do not cover the lifecycle registry");
+}
+
 export function isTerminalBacklogItemStatus(status: string): boolean {
-  return status === "done" || status === "deferred";
+  return terminalStatuses.has(status);
 }
 
 export type BacklogStatusSummary = {
@@ -54,11 +82,7 @@ export function backlogItemLifecycleLabel(item: BacklogLifecycleInput): string {
   return "deferred";
 }
 
-/**
- * The subset shown while the operator asks for active work only. Terminal items
- * (done + deferred) are removed from the rows, while their distinct counts remain
- * visible in the surrounding status summary.
- */
+/** Rows shown by the Operations page's default active-work lens. */
 export function visibleUnderActiveOnly<T extends { status: string }>(
   items: T[],
   activeOnly: boolean,

--- a/apps/web/lib/workbooks/adapter.test.ts
+++ b/apps/web/lib/workbooks/adapter.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { queryBoundedRowsOnce, type DataSourceAdapter } from "./adapter";
+
+describe("queryBoundedRowsOnce (BI-9DB20C39)", () => {
+  it("asks the adapter for the bounded eager dataset exactly once", async () => {
+    const queryRows = vi.fn(async () => ({
+      data: [{ rowId: "1", cells: { status: "open" } }],
+      nextCursor: null,
+    }));
+    const adapter = { queryRows } as unknown as DataSourceAdapter;
+    const filters = {
+      conditions: [{ field: "status", operator: "in" as const, value: ["open"] }],
+      logic: "and" as const,
+    };
+
+    await expect(
+      queryBoundedRowsOnce(adapter, "backlog_item", {
+        filters,
+        sort: [],
+        limit: 20_000,
+      }),
+    ).resolves.toEqual({
+      data: [{ rowId: "1", cells: { status: "open" } }],
+      nextCursor: null,
+    });
+    expect(queryRows).toHaveBeenCalledTimes(1);
+    expect(queryRows).toHaveBeenCalledWith("backlog_item", {
+      filters,
+      sort: [],
+      pagination: { cursor: null, limit: 20_000 },
+    });
+  });
+});

--- a/apps/web/lib/workbooks/adapter.ts
+++ b/apps/web/lib/workbooks/adapter.ts
@@ -74,6 +74,23 @@ export interface DataSourceAdapter {
   getCapabilities(ctx: AdapterContext): GridCapabilities;
 }
 
+/**
+ * The embedded grid owns filtering/sorting/grouping over one bounded client
+ * dataset. Ask an adapter for that bound once; repeatedly paging an adapter that
+ * materializes its source per call multiplies the same database work.
+ */
+export function queryBoundedRowsOnce(
+  adapter: DataSourceAdapter,
+  tableId: string,
+  opts: { filters: DataSourceFilter; sort: SortSpec[]; limit: number },
+): Promise<PagedRows> {
+  return adapter.queryRows(tableId, {
+    filters: opts.filters,
+    sort: opts.sort,
+    pagination: { cursor: null, limit: opts.limit },
+  });
+}
+
 class GridRegistry {
   private adapters = new Map<string, DataSourceAdapter>();
 

--- a/apps/web/lib/workbooks/backlog-adapter-filter.test.ts
+++ b/apps/web/lib/workbooks/backlog-adapter-filter.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { backlogPrismaWhere } from "./backlog-adapter-filter";
+
+describe("backlogPrismaWhere (BI-9DB20C39)", () => {
+  it("pushes the closed active status set into Prisma for the default grid lens", () => {
+    expect(
+      backlogPrismaWhere({
+        conditions: [
+          {
+            field: "status",
+            operator: "in",
+            value: ["triaging", "open", "in-progress"],
+          },
+        ],
+        logic: "and",
+      }),
+    ).toEqual({ status: { in: ["triaging", "open", "in-progress"] } });
+  });
+
+  it("does not push down an OR or an unrelated filter whose semantics Prisma cannot mirror", () => {
+    expect(
+      backlogPrismaWhere({
+        conditions: [
+          { field: "status", operator: "eq", value: "open" },
+          { field: "title", operator: "contains", value: "grid" },
+        ],
+        logic: "or",
+      }),
+    ).toBeUndefined();
+    expect(
+      backlogPrismaWhere({
+        conditions: [{ field: "title", operator: "contains", value: "grid" }],
+        logic: "and",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/web/lib/workbooks/backlog-adapter-filter.ts
+++ b/apps/web/lib/workbooks/backlog-adapter-filter.ts
@@ -1,0 +1,39 @@
+import type { Prisma } from "@dpf/db";
+
+import type { DataSourceFilter, FilterCondition } from "./types";
+
+function statusWhere(
+  condition: FilterCondition,
+): Prisma.BacklogItemWhereInput | undefined {
+  if (condition.field !== "status") return undefined;
+
+  if (condition.operator === "eq" && typeof condition.value === "string") {
+    return { status: condition.value };
+  }
+  if (condition.operator === "neq" && typeof condition.value === "string") {
+    return { status: { not: condition.value } };
+  }
+  if (
+    condition.operator === "in"
+    && Array.isArray(condition.value)
+    && condition.value.every((value) => typeof value === "string")
+  ) {
+    return { status: { in: condition.value } };
+  }
+  return undefined;
+}
+
+/**
+ * Translate only filters whose semantics Prisma mirrors exactly. Returning
+ * undefined deliberately falls back to shared in-memory filtering.
+ */
+export function backlogPrismaWhere(
+  filter: DataSourceFilter,
+): Prisma.BacklogItemWhereInput | undefined {
+  if (filter.logic !== "and" || filter.conditions.length === 0) return undefined;
+  const clauses = filter.conditions.map(statusWhere);
+  if (clauses.some((clause) => clause === undefined)) return undefined;
+  return clauses.length === 1
+    ? clauses[0]
+    : { AND: clauses as Prisma.BacklogItemWhereInput[] };
+}

--- a/apps/web/lib/workbooks/backlog-adapter.ts
+++ b/apps/web/lib/workbooks/backlog-adapter.ts
@@ -9,7 +9,6 @@
 
 import { prisma } from "@dpf/db";
 import { updateBacklogItemFields } from "@/lib/actions/backlog";
-import { getBacklogItems } from "@/lib/explore/backlog-data";
 import {
   gridRegistry,
   type DataSourceAdapter,
@@ -32,27 +31,30 @@ import {
   type GridCapabilities,
 } from "./types";
 import { applyFilters, applySort, paginate } from "./grid-query";
+import { backlogPrismaWhere } from "./backlog-adapter-filter";
+
+const BACKLOG_GRID_SELECT = {
+  itemId: true,
+  title: true,
+  status: true,
+  type: true,
+  workType: true,
+  source: true,
+  priority: true,
+  epicId: true,
+  scopeKind: true,
+  archetypeCategories: true,
+  archetypeIds: true,
+  scopeRationale: true,
+  lifecycleTags: true,
+  body: true,
+  updatedAt: true,
+} as const;
 
 async function readGridRow(itemId: string): Promise<GridRow | null> {
   const item = await prisma.backlogItem.findUnique({
     where: { itemId },
-    select: {
-      itemId: true,
-      title: true,
-      status: true,
-      type: true,
-      workType: true,
-      source: true,
-      priority: true,
-      epicId: true,
-      scopeKind: true,
-      archetypeCategories: true,
-      archetypeIds: true,
-      scopeRationale: true,
-      lifecycleTags: true,
-      body: true,
-      updatedAt: true,
-    },
+    select: BACKLOG_GRID_SELECT,
   });
   return item ? backlogItemToGridRow(item) : null;
 }
@@ -68,7 +70,14 @@ class BacklogItemAdapter implements DataSourceAdapter {
     _entityType: string,
     opts: { filters: DataSourceFilter; sort: SortSpec[]; pagination: Pagination },
   ): Promise<PagedRows> {
-    const items = await getBacklogItems();
+    // The platform grid needs only scalar grid fields. Push down the domain's
+    // exact status lens when safe, then reapply the shared filter below as the
+    // semantic guard for every query path.
+    const items = await prisma.backlogItem.findMany({
+      where: backlogPrismaWhere(opts.filters),
+      orderBy: [{ priority: "asc" }, { createdAt: "asc" }],
+      select: BACKLOG_GRID_SELECT,
+    });
     const rows = items.map(backlogItemToGridRow);
     const filtered = applyFilters(rows, opts.filters);
     const sorted = applySort(filtered, opts.sort);

--- a/apps/web/lib/workbooks/platform-table-lenses.test.ts
+++ b/apps/web/lib/workbooks/platform-table-lenses.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getHomeSurfaceForEntity } from "./platform-tables";
+import { platformTableHomeSurface } from "./platform-table-surfaces";
+
+function getHomeSurfaceForEntity(entityType: string) {
+  return platformTableHomeSurface(entityType, "/test", "Test", false);
+}
 
 describe("platform table default data lenses (BI-9DB20C39)", () => {
   it.each([

--- a/apps/web/lib/workbooks/platform-table-lenses.test.ts
+++ b/apps/web/lib/workbooks/platform-table-lenses.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { getHomeSurfaceForEntity } from "./platform-tables";
+
+describe("platform table default data lenses (BI-9DB20C39)", () => {
+  it.each([
+    ["backlog_item", "status", "in", ["triaging", "open", "in-progress"]],
+    ["risk_assessment", "status", "eq", "active"],
+    ["compliance_control", "status", "eq", "active"],
+    ["compliance_obligation", "status", "eq", "active"],
+    ["opportunity", "stage", "in", ["qualification", "discovery", "proposal", "negotiation"]],
+    ["customer_account", "status", "neq", "superseded"],
+  ])(
+    "%s matches its List surface default",
+    (entityType, field, operator, value) => {
+      expect(getHomeSurfaceForEntity(entityType)?.defaultDataLens?.filter).toEqual({
+        conditions: [{ field, operator, value }],
+        logic: "and",
+      });
+    },
+  );
+
+  it("leaves all-record List surfaces without an invented default lens", () => {
+    expect(getHomeSurfaceForEntity("invoice")?.defaultDataLens).toBeUndefined();
+    expect(getHomeSurfaceForEntity("supplier")?.defaultDataLens).toBeUndefined();
+  });
+});

--- a/apps/web/lib/workbooks/platform-table-surfaces.ts
+++ b/apps/web/lib/workbooks/platform-table-surfaces.ts
@@ -1,0 +1,83 @@
+import { ACTIVE_BACKLOG_STATUSES } from "@/lib/backlog-visibility";
+import { OPEN_OPPORTUNITY_STAGES } from "@/lib/crm/presentation";
+
+import type { DataSourceFilter } from "./types";
+
+export interface PlatformDefaultDataLens {
+  defaultLabel: string;
+  allLabel: string;
+  filter: DataSourceFilter;
+}
+
+export interface PlatformTableHomeSurface {
+  path: string;
+  label: string;
+  board: boolean;
+  /** Domain-owned dataset shown before a user applies presentation filters. */
+  defaultDataLens?: PlatformDefaultDataLens;
+}
+
+const DEFAULT_DATA_LENSES: Partial<Record<string, PlatformDefaultDataLens>> = {
+  backlog_item: {
+    defaultLabel: "Active only",
+    allLabel: "All items",
+    filter: {
+      conditions: [{
+        field: "status",
+        operator: "in",
+        value: [...ACTIVE_BACKLOG_STATUSES],
+      }],
+      logic: "and",
+    },
+  },
+  risk_assessment: activeLens("All assessments"),
+  compliance_control: activeLens("All controls"),
+  compliance_obligation: activeLens("All obligations"),
+  opportunity: {
+    defaultLabel: "Open only",
+    allLabel: "All opportunities",
+    filter: {
+      conditions: [{
+        field: "stage",
+        operator: "in",
+        value: [...OPEN_OPPORTUNITY_STAGES],
+      }],
+      logic: "and",
+    },
+  },
+  customer_account: {
+    defaultLabel: "Current only",
+    allLabel: "All customers",
+    filter: {
+      conditions: [{ field: "status", operator: "neq", value: "superseded" }],
+      logic: "and",
+    },
+  },
+};
+
+function activeLens(allLabel: string): PlatformDefaultDataLens {
+  return {
+    defaultLabel: "Active only",
+    allLabel,
+    filter: {
+      conditions: [{ field: "status", operator: "eq", value: "active" }],
+      logic: "and",
+    },
+  };
+}
+
+export function platformTableHomeSurface(
+  entityType: string,
+  path: string,
+  label: string,
+  board: boolean,
+): PlatformTableHomeSurface {
+  return {
+    path,
+    label,
+    board,
+    ...(DEFAULT_DATA_LENSES[entityType]
+      ? { defaultDataLens: DEFAULT_DATA_LENSES[entityType] }
+      : {}),
+  };
+}

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -8,7 +8,13 @@
 
 import { can } from "@/lib/permissions";
 import type { CapabilityKey } from "@/lib/govern/permissions";
-import { gridRegistry, type AdapterContext } from "./adapter";
+import { ACTIVE_BACKLOG_STATUSES } from "@/lib/backlog-visibility";
+import { OPEN_OPPORTUNITY_STAGES } from "@/lib/crm/presentation";
+import {
+  gridRegistry,
+  queryBoundedRowsOnce,
+  type AdapterContext,
+} from "./adapter";
 import "./backlog-adapter"; // self-register the backlog adapter
 import "./invoice-adapter"; // self-register the invoice adapter
 import "./risk-adapter"; // self-register the risk-assessment adapter
@@ -45,6 +51,12 @@ export interface PlatformTableHomeSurface {
   path: string;
   label: string;
   board: boolean;
+  /** Domain-owned dataset shown before a user applies presentation filters. */
+  defaultDataLens?: {
+    defaultLabel: string;
+    allLabel: string;
+    filter: DataSourceFilter;
+  };
 }
 
 export interface PlatformTableDef {
@@ -177,6 +189,7 @@ const COMPLIANCE_CONTROL_TABLE: GenericTableConfig = {
       ],
     },
     { field: "nextReviewDate", name: "Next review", fieldType: "date", width: 130 },
+    { field: "status", name: "Lifecycle", fieldType: "text", width: 110 },
     { field: "updatedAt", name: "Updated", fieldType: "datetime", width: 170 },
   ],
 };
@@ -553,7 +566,25 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Every backlog item as an editable spreadsheet — same records as the backlog forms.",
     viewCapability: "view_operations",
     manageCapability: "manage_backlog",
-    homeSurface: { path: "/ops", label: "Operations", board: true },
+    homeSurface: {
+      path: "/ops",
+      label: "Operations",
+      board: true,
+      defaultDataLens: {
+        defaultLabel: "Active only",
+        allLabel: "All items",
+        filter: {
+          conditions: [
+            {
+              field: "status",
+              operator: "in",
+              value: [...ACTIVE_BACKLOG_STATUSES],
+            },
+          ],
+          logic: "and",
+        },
+      },
+    },
   },
   {
     entityType: "invoice",
@@ -569,7 +600,19 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Compliance risk register as an editable spreadsheet — same records as the risk forms.",
     viewCapability: "view_compliance",
     manageCapability: "manage_compliance",
-    homeSurface: { path: "/compliance/risks", label: "Risk assessments", board: true },
+    homeSurface: {
+      path: "/compliance/risks",
+      label: "Risk assessments",
+      board: true,
+      defaultDataLens: {
+        defaultLabel: "Active only",
+        allLabel: "All assessments",
+        filter: {
+          conditions: [{ field: "status", operator: "eq", value: "active" }],
+          logic: "and",
+        },
+      },
+    },
   },
   {
     entityType: "compliance_control",
@@ -577,7 +620,19 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Compliance controls as a read-only grid — sort, filter, and board by status.",
     viewCapability: "view_compliance",
     manageCapability: "view_compliance", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/compliance/controls", label: "Controls", board: true },
+    homeSurface: {
+      path: "/compliance/controls",
+      label: "Controls",
+      board: true,
+      defaultDataLens: {
+        defaultLabel: "Active only",
+        allLabel: "All controls",
+        filter: {
+          conditions: [{ field: "status", operator: "eq", value: "active" }],
+          logic: "and",
+        },
+      },
+    },
   },
   {
     entityType: "compliance_obligation",
@@ -585,7 +640,19 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Regulatory obligations as a read-only grid — sort and filter.",
     viewCapability: "view_compliance",
     manageCapability: "view_compliance", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/compliance/obligations", label: "Obligations", board: false },
+    homeSurface: {
+      path: "/compliance/obligations",
+      label: "Obligations",
+      board: false,
+      defaultDataLens: {
+        defaultLabel: "Active only",
+        allLabel: "All obligations",
+        filter: {
+          conditions: [{ field: "status", operator: "eq", value: "active" }],
+          logic: "and",
+        },
+      },
+    },
   },
   {
     entityType: "compliance_incident",
@@ -601,7 +668,25 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Sales opportunities as a read-only grid — sort, filter, and board by stage.",
     viewCapability: "view_customer",
     manageCapability: "view_customer", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/customer/opportunities", label: "Opportunities", board: true },
+    homeSurface: {
+      path: "/customer/opportunities",
+      label: "Opportunities",
+      board: true,
+      defaultDataLens: {
+        defaultLabel: "Open only",
+        allLabel: "All opportunities",
+        filter: {
+          conditions: [
+            {
+              field: "stage",
+              operator: "in",
+              value: [...OPEN_OPPORTUNITY_STAGES],
+            },
+          ],
+          logic: "and",
+        },
+      },
+    },
   },
   {
     entityType: "quote",
@@ -713,7 +798,19 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Customer accounts as a read-only grid — sort, filter, and board by status.",
     viewCapability: "view_customer",
     manageCapability: "view_customer", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/customer", label: "Customers", board: true },
+    homeSurface: {
+      path: "/customer",
+      label: "Customers",
+      board: true,
+      defaultDataLens: {
+        defaultLabel: "Current only",
+        allLabel: "All customers",
+        filter: {
+          conditions: [{ field: "status", operator: "neq", value: "superseded" }],
+          logic: "and",
+        },
+      },
+    },
   },
   {
     entityType: "employee_profile",
@@ -807,10 +904,9 @@ export async function getPlatformTableGridData(
 }
 
 /**
- * Like getPlatformTableGridData but loads EVERY row (paginating through the
- * adapter's cursors, capped at MAX_GRID_ROWS) so the client grid — which filters,
- * sorts, groups and exports over the rows it holds — reflects the whole table, not
- * just the first page. `nextCursor` is non-null only if the cap was hit.
+ * Like getPlatformTableGridData but asks the adapter once for the bounded eager
+ * dataset the client grid filters, sorts, groups, and exports. `nextCursor` is
+ * non-null only if the MAX_GRID_ROWS safety ceiling was hit.
  */
 export async function getAllPlatformTableRows(
   user: PlatformUser,
@@ -824,19 +920,24 @@ export async function getAllPlatformTableRows(
     canManage: can(userCtx(user), def.manageCapability),
   };
   const columns = await adapter.getColumns(entityType);
-  const rows: GridRow[] = [];
-  let cursor: string | null = null;
-  do {
-    const { data, nextCursor } = await adapter.queryRows(entityType, {
-      filters: opts.filters ?? { conditions: [], logic: "and" },
+  const filters = opts.filters ?? { conditions: [], logic: "and" };
+  const columnIds = new Set(columns.map((column) => column.columnId));
+  const unknownField = filters.conditions.find((condition) => !columnIds.has(condition.field));
+  if (unknownField) {
+    throw new WorkbookError(
+      `The ${def.label} data lens references an unknown field: ${unknownField.field}`,
+      400,
+    );
+  }
+  const { data: rows, nextCursor } = await queryBoundedRowsOnce(
+    adapter,
+    entityType,
+    {
+      filters,
       sort: opts.sort ?? [],
-      pagination: { cursor, limit: MAX_PAGE_SIZE },
-    });
-    rows.push(...data);
-    cursor = nextCursor;
-    // Guard against a stuck cursor that never returns rows or never clears.
-    if (data.length === 0) break;
-  } while (cursor && rows.length < MAX_GRID_ROWS);
+      limit: MAX_GRID_ROWS,
+    },
+  );
   return {
     schema: {
       tableId: entityType,
@@ -846,7 +947,7 @@ export async function getAllPlatformTableRows(
       capabilities: adapter.getCapabilities(ctx),
     },
     rows,
-    nextCursor: cursor,
+    nextCursor,
     view: emptyViewConfig(columns),
   };
 }

--- a/apps/web/lib/workbooks/platform-tables.ts
+++ b/apps/web/lib/workbooks/platform-tables.ts
@@ -8,13 +8,12 @@
 
 import { can } from "@/lib/permissions";
 import type { CapabilityKey } from "@/lib/govern/permissions";
-import { ACTIVE_BACKLOG_STATUSES } from "@/lib/backlog-visibility";
-import { OPEN_OPPORTUNITY_STAGES } from "@/lib/crm/presentation";
 import {
   gridRegistry,
   queryBoundedRowsOnce,
   type AdapterContext,
 } from "./adapter";
+import { platformTableHomeSurface, type PlatformTableHomeSurface } from "./platform-table-surfaces";
 import "./backlog-adapter"; // self-register the backlog adapter
 import "./invoice-adapter"; // self-register the invoice adapter
 import "./risk-adapter"; // self-register the risk-assessment adapter
@@ -47,18 +46,6 @@ export interface PlatformUser {
  * not on a standalone Workbooks hub. `board` marks whether the grid has a groupable
  * column suitable for a Kanban Board view.
  */
-export interface PlatformTableHomeSurface {
-  path: string;
-  label: string;
-  board: boolean;
-  /** Domain-owned dataset shown before a user applies presentation filters. */
-  defaultDataLens?: {
-    defaultLabel: string;
-    allLabel: string;
-    filter: DataSourceFilter;
-  };
-}
-
 export interface PlatformTableDef {
   entityType: string;
   label: string;
@@ -566,25 +553,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Every backlog item as an editable spreadsheet — same records as the backlog forms.",
     viewCapability: "view_operations",
     manageCapability: "manage_backlog",
-    homeSurface: {
-      path: "/ops",
-      label: "Operations",
-      board: true,
-      defaultDataLens: {
-        defaultLabel: "Active only",
-        allLabel: "All items",
-        filter: {
-          conditions: [
-            {
-              field: "status",
-              operator: "in",
-              value: [...ACTIVE_BACKLOG_STATUSES],
-            },
-          ],
-          logic: "and",
-        },
-      },
-    },
+    homeSurface: platformTableHomeSurface("backlog_item", "/ops", "Operations", true),
   },
   {
     entityType: "invoice",
@@ -592,7 +561,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Finance invoices as a grid — edit status inline; amounts/dates stay in the invoice form.",
     viewCapability: "view_finance",
     manageCapability: "manage_finance",
-    homeSurface: { path: "/finance/invoices", label: "Invoices", board: true },
+    homeSurface: platformTableHomeSurface("invoice", "/finance/invoices", "Invoices", true),
   },
   {
     entityType: "risk_assessment",
@@ -600,19 +569,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Compliance risk register as an editable spreadsheet — same records as the risk forms.",
     viewCapability: "view_compliance",
     manageCapability: "manage_compliance",
-    homeSurface: {
-      path: "/compliance/risks",
-      label: "Risk assessments",
-      board: true,
-      defaultDataLens: {
-        defaultLabel: "Active only",
-        allLabel: "All assessments",
-        filter: {
-          conditions: [{ field: "status", operator: "eq", value: "active" }],
-          logic: "and",
-        },
-      },
-    },
+    homeSurface: platformTableHomeSurface("risk_assessment", "/compliance/risks", "Risk assessments", true),
   },
   {
     entityType: "compliance_control",
@@ -620,19 +577,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Compliance controls as a read-only grid — sort, filter, and board by status.",
     viewCapability: "view_compliance",
     manageCapability: "view_compliance", // read-only grid; adapter performs no writes
-    homeSurface: {
-      path: "/compliance/controls",
-      label: "Controls",
-      board: true,
-      defaultDataLens: {
-        defaultLabel: "Active only",
-        allLabel: "All controls",
-        filter: {
-          conditions: [{ field: "status", operator: "eq", value: "active" }],
-          logic: "and",
-        },
-      },
-    },
+    homeSurface: platformTableHomeSurface("compliance_control", "/compliance/controls", "Controls", true),
   },
   {
     entityType: "compliance_obligation",
@@ -640,19 +585,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Regulatory obligations as a read-only grid — sort and filter.",
     viewCapability: "view_compliance",
     manageCapability: "view_compliance", // read-only grid; adapter performs no writes
-    homeSurface: {
-      path: "/compliance/obligations",
-      label: "Obligations",
-      board: false,
-      defaultDataLens: {
-        defaultLabel: "Active only",
-        allLabel: "All obligations",
-        filter: {
-          conditions: [{ field: "status", operator: "eq", value: "active" }],
-          logic: "and",
-        },
-      },
-    },
+    homeSurface: platformTableHomeSurface("compliance_obligation", "/compliance/obligations", "Obligations", false),
   },
   {
     entityType: "compliance_incident",
@@ -660,7 +593,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Compliance incidents as a read-only grid — sort and filter.",
     viewCapability: "view_compliance",
     manageCapability: "view_compliance", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/compliance/incidents", label: "Incidents", board: false },
+    homeSurface: platformTableHomeSurface("compliance_incident", "/compliance/incidents", "Incidents", false),
   },
   {
     entityType: "opportunity",
@@ -668,25 +601,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Sales opportunities as a read-only grid — sort, filter, and board by stage.",
     viewCapability: "view_customer",
     manageCapability: "view_customer", // read-only grid; adapter performs no writes
-    homeSurface: {
-      path: "/customer/opportunities",
-      label: "Opportunities",
-      board: true,
-      defaultDataLens: {
-        defaultLabel: "Open only",
-        allLabel: "All opportunities",
-        filter: {
-          conditions: [
-            {
-              field: "stage",
-              operator: "in",
-              value: [...OPEN_OPPORTUNITY_STAGES],
-            },
-          ],
-          logic: "and",
-        },
-      },
-    },
+    homeSurface: platformTableHomeSurface("opportunity", "/customer/opportunities", "Opportunities", true),
   },
   {
     entityType: "quote",
@@ -694,7 +609,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Sales quotes as a read-only grid — sort, filter, and board by status.",
     viewCapability: "view_customer",
     manageCapability: "view_customer", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/customer/quotes", label: "Quotes", board: true },
+    homeSurface: platformTableHomeSurface("quote", "/customer/quotes", "Quotes", true),
   },
   {
     entityType: "sales_order",
@@ -702,7 +617,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Sales orders as a read-only grid — sort, filter, and board by status.",
     viewCapability: "view_customer",
     manageCapability: "view_customer", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/customer/sales-orders", label: "Sales orders", board: true },
+    homeSurface: platformTableHomeSurface("sales_order", "/customer/sales-orders", "Sales orders", true),
   },
   {
     entityType: "engagement",
@@ -710,7 +625,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "CRM engagements as a read-only grid — sort, filter, and board by status.",
     viewCapability: "view_customer",
     manageCapability: "view_customer", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/customer/engagements", label: "Engagements", board: true },
+    homeSurface: platformTableHomeSurface("engagement", "/customer/engagements", "Engagements", true),
   },
   {
     entityType: "bill",
@@ -718,7 +633,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Supplier bills as a read-only grid — sort and filter.",
     viewCapability: "view_finance",
     manageCapability: "view_finance", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/finance/bills", label: "Bills", board: false },
+    homeSurface: platformTableHomeSurface("bill", "/finance/bills", "Bills", false),
   },
   {
     entityType: "bank_account",
@@ -726,7 +641,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Bank accounts as a read-only grid (no account numbers) — sort and filter.",
     viewCapability: "view_finance",
     manageCapability: "view_finance", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/finance/banking", label: "Banking", board: false },
+    homeSurface: platformTableHomeSurface("bank_account", "/finance/banking", "Banking", false),
   },
   {
     entityType: "expense_claim",
@@ -734,7 +649,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Expense claims as a read-only grid — sort and filter.",
     viewCapability: "view_finance",
     manageCapability: "view_finance", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/finance/expense-claims", label: "Expense claims", board: false },
+    homeSurface: platformTableHomeSurface("expense_claim", "/finance/expense-claims", "Expense claims", false),
   },
   {
     entityType: "fixed_asset",
@@ -742,7 +657,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Fixed assets as a read-only grid — sort and filter.",
     viewCapability: "view_finance",
     manageCapability: "view_finance", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/finance/assets", label: "Assets", board: false },
+    homeSurface: platformTableHomeSurface("fixed_asset", "/finance/assets", "Assets", false),
   },
   {
     entityType: "storefront_item",
@@ -750,7 +665,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Storefront catalogue items as a read-only grid — sort and filter.",
     viewCapability: "view_storefront",
     manageCapability: "view_storefront", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/storefront", label: "Storefront", board: false },
+    homeSurface: platformTableHomeSurface("storefront_item", "/storefront", "Storefront", false),
   },
   {
     entityType: "inventory_entity",
@@ -758,7 +673,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Discovered inventory entities as a read-only grid — sort and filter.",
     viewCapability: "view_inventory",
     manageCapability: "view_inventory", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/inventory", label: "Inventory", board: false },
+    homeSurface: platformTableHomeSurface("inventory_entity", "/inventory", "Inventory", false),
   },
   {
     entityType: "rental_agreement",
@@ -766,7 +681,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Rental agreements as a read-only grid (no contact PII) — sort, filter, board by status.",
     viewCapability: "view_customer",
     manageCapability: "view_customer", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/rental", label: "Rental", board: true },
+    homeSurface: platformTableHomeSurface("rental_agreement", "/rental", "Rental", true),
   },
   {
     entityType: "fund_budget_line",
@@ -774,7 +689,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Fund budget lines as a read-only grid — sort, filter, and board by fund.",
     viewCapability: "view_finance",
     manageCapability: "view_finance", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/finance/funds", label: "Funds", board: true },
+    homeSurface: platformTableHomeSurface("fund_budget_line", "/finance/funds", "Funds", true),
   },
   {
     entityType: "epic",
@@ -782,7 +697,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Every epic as a read-only grid — sort, filter, and board by status.",
     viewCapability: "view_operations",
     manageCapability: "view_operations", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/ops", label: "Operations", board: true },
+    homeSurface: platformTableHomeSurface("epic", "/ops", "Operations", true),
   },
   {
     entityType: "digital_product",
@@ -790,7 +705,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "The product portfolio as a read-only grid — sort, filter, and board by lifecycle.",
     viewCapability: "view_portfolio",
     manageCapability: "view_portfolio", // read-only grid; adapter performs no writes
-    homeSurface: { path: "/portfolio", label: "Portfolio", board: true },
+    homeSurface: platformTableHomeSurface("digital_product", "/portfolio", "Portfolio", true),
   },
   {
     entityType: "customer_account",
@@ -798,19 +713,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "Customer accounts as a read-only grid — sort, filter, and board by status.",
     viewCapability: "view_customer",
     manageCapability: "view_customer", // read-only grid; adapter performs no writes
-    homeSurface: {
-      path: "/customer",
-      label: "Customers",
-      board: true,
-      defaultDataLens: {
-        defaultLabel: "Current only",
-        allLabel: "All customers",
-        filter: {
-          conditions: [{ field: "status", operator: "neq", value: "superseded" }],
-          logic: "and",
-        },
-      },
-    },
+    homeSurface: platformTableHomeSurface("customer_account", "/customer", "Customers", true),
   },
   {
     entityType: "employee_profile",
@@ -818,7 +721,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     description: "The team directory as an editable grid (safe fields only) — board by status.",
     viewCapability: "view_employee",
     manageCapability: "manage_user_lifecycle", // seeing the directory ≠ editing it; governed write-through
-    homeSurface: { path: "/employee", label: "People", board: true },
+    homeSurface: platformTableHomeSurface("employee_profile", "/employee", "People", true),
   },
   {
     entityType: "supplier",
@@ -827,7 +730,7 @@ export const PLATFORM_TABLES: PlatformTableDef[] = [
     viewCapability: "view_finance",
     manageCapability: "manage_finance", // validated raw-write tier (editableFields allow-list)
     // The Suppliers list lives at /finance/suppliers, so the List/Grid tabs target it.
-    homeSurface: { path: "/finance/suppliers", label: "Suppliers", board: true },
+    homeSurface: platformTableHomeSurface("supplier", "/finance/suppliers", "Suppliers", true),
   },
 ];
 
@@ -929,15 +832,11 @@ export async function getAllPlatformTableRows(
       400,
     );
   }
-  const { data: rows, nextCursor } = await queryBoundedRowsOnce(
-    adapter,
-    entityType,
-    {
-      filters,
-      sort: opts.sort ?? [],
-      limit: MAX_GRID_ROWS,
-    },
-  );
+  const { data: rows, nextCursor } = await queryBoundedRowsOnce(adapter, entityType, {
+    filters,
+    sort: opts.sort ?? [],
+    limit: MAX_GRID_ROWS,
+  });
   return {
     schema: {
       tableId: entityType,

--- a/apps/web/lib/workbooks/surface-view.test.ts
+++ b/apps/web/lib/workbooks/surface-view.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { parseSurfaceView } from "./surface-view";
+import {
+  buildSurfaceViewHref,
+  parseSurfaceDataScope,
+  parseSurfaceView,
+  resolveSurfaceDataFilter,
+} from "./surface-view";
+import { ACTIVE_BACKLOG_STATUSES } from "@/lib/backlog-visibility";
 
 describe("parseSurfaceView", () => {
   it("accepts grid and board", () => {
@@ -13,5 +19,33 @@ describe("parseSurfaceView", () => {
     expect(parseSurfaceView(undefined)).toBeNull();
     expect(parseSurfaceView(null)).toBeNull();
     expect(parseSurfaceView("")).toBeNull();
+  });
+});
+
+describe("page-to-grid data scope (BI-9DB20C39)", () => {
+  const activeFilter = {
+    conditions: [
+      { field: "status", operator: "in" as const, value: [...ACTIVE_BACKLOG_STATUSES] },
+    ],
+    logic: "and" as const,
+  };
+
+  it("defaults absent and unknown scope values to the domain lens", () => {
+    expect(parseSurfaceDataScope(undefined)).toBe("default");
+    expect(parseSurfaceDataScope(null)).toBe("default");
+    expect(parseSurfaceDataScope("closed")).toBe("default");
+  });
+
+  it("accepts only the explicit all-records override", () => {
+    expect(parseSurfaceDataScope("all")).toBe("all");
+    expect(resolveSurfaceDataFilter(activeFilter, "all")).toBeUndefined();
+    expect(resolveSurfaceDataFilter(activeFilter, "default")).toEqual(activeFilter);
+  });
+
+  it("builds stable server-readable List, Grid, Board, and all-records URLs", () => {
+    expect(buildSurfaceViewHref("/ops", "list", "default")).toBe("/ops");
+    expect(buildSurfaceViewHref("/ops", "grid", "default")).toBe("/ops?view=grid");
+    expect(buildSurfaceViewHref("/ops", "board", "default")).toBe("/ops?view=board");
+    expect(buildSurfaceViewHref("/ops", "grid", "all")).toBe("/ops?view=grid&scope=all");
   });
 });

--- a/apps/web/lib/workbooks/surface-view.test.ts
+++ b/apps/web/lib/workbooks/surface-view.test.ts
@@ -46,6 +46,6 @@ describe("page-to-grid data scope (BI-9DB20C39)", () => {
     expect(buildSurfaceViewHref("/ops", "list", "default")).toBe("/ops");
     expect(buildSurfaceViewHref("/ops", "grid", "default")).toBe("/ops?view=grid");
     expect(buildSurfaceViewHref("/ops", "board", "default")).toBe("/ops?view=board");
-    expect(buildSurfaceViewHref("/ops", "grid", "all")).toBe("/ops?view=grid&scope=all");
+    expect(buildSurfaceViewHref("/ops", "grid", "all")).toBe("/ops?view=grid&dataScope=all");
   });
 });

--- a/apps/web/lib/workbooks/surface-view.ts
+++ b/apps/web/lib/workbooks/surface-view.ts
@@ -4,7 +4,34 @@
 // so it is unit-testable and importable by both server pages and the grid section.
 
 export type SurfaceView = "list" | "grid" | "board";
+export type SurfaceDataScope = "default" | "all";
 
 export function parseSurfaceView(raw: string | undefined | null): "grid" | "board" | null {
   return raw === "grid" || raw === "board" ? raw : null;
+}
+
+/** Unknown/absent values fail closed to the domain's default dataset. */
+export function parseSurfaceDataScope(
+  raw: string | undefined | null,
+): SurfaceDataScope {
+  return raw === "all" ? "all" : "default";
+}
+
+export function resolveSurfaceDataFilter<T>(
+  defaultFilter: T | undefined,
+  scope: SurfaceDataScope,
+): T | undefined {
+  return scope === "all" ? undefined : defaultFilter;
+}
+
+/** Stable, server-readable links shared by every embedded domain grid. */
+export function buildSurfaceViewHref(
+  path: string,
+  view: SurfaceView,
+  scope: SurfaceDataScope,
+): string {
+  if (view === "list") return path;
+  const params = new URLSearchParams({ view });
+  if (scope === "all") params.set("dataScope", "all");
+  return `${path}?${params.toString()}`;
 }

--- a/docs/superpowers/plans/2026-08-08-grid-default-data-lens.md
+++ b/docs/superpowers/plans/2026-08-08-grid-default-data-lens.md
@@ -1,0 +1,144 @@
+# Grid views inherit the domain page's default data lens
+
+**Backlog item:** `BI-9DB20C39`  
+**Epic:** `EP-GRID-WORKBOOKS`  
+**Decision ledger:** `DI-93238917B4E0`  
+**Branch:** `fix/grid-default-data-lens`
+
+## Outcome
+
+Switching a domain page from List to Grid or Board keeps the domain's default dataset. Operations therefore opens Grid and Board on active backlog work (`triaging`, `open`, and `in-progress`) instead of materializing done and deferred history. Historical rows remain deliberately reachable through an all-records scope.
+
+This corrects the implementation gap in the existing Universal Grid design. That design already specifies pre-configured platform grids with sensible defaults and one shared `DataSourceFilter` shape for source and view filters; this plan makes the page-to-grid boundary honor that contract.
+
+## Substrate and research grounding
+
+- `apps/web/app/(shell)/ops/page.tsx` defaults the List surface through `OpsClient`'s `activeOnly=true` state but calls `SurfacePlatformGrid` without a filter.
+- `apps/web/components/workbooks/SurfacePlatformGrid.tsx` always calls `getAllPlatformTableRows` without scope.
+- `apps/web/lib/workbooks/platform-tables.ts` is the canonical registry for each grid's home surface and already owns the shared eager-loader path.
+- `apps/web/components/ops/backlogVisibility.ts` owns active-versus-terminal semantics today, but its component-layer location prevents the adapter registry from reusing it cleanly.
+- `apps/web/lib/workbooks/backlog-adapter.ts` materializes the rich domain backlog read model and filters in memory.
+- `getAllPlatformTableRows` currently calls an adapter once per 200-row page; for 4,316 backlog items that repeats the full read roughly 22 times.
+- The existing [Universal Grid & Workbooks design](../specs/2026-03-23-universal-grid-workbooks-design.md) benchmarks Airtable and Smartsheet and adopts multiple views, shared filters, saved presentation views, and an adapter framework. This work extends those decisions rather than introducing another grid or filter model.
+- The [platform usability standards](../../platform-usability-standards.md) require stable, server-readable query filters and one canonical source for shared UI behavior.
+
+No database model, enum, migration, route family, or new grid primitive is needed.
+
+## Architecture decision
+
+Three grounded options were scored by the platform kernel:
+
+1. `page-local` — pass an Ops-only filter into the grid.
+2. `saved-view-default` — use a browser-personal saved grid view as the domain default.
+3. `registry-data-lens` — add an optional default data lens to the canonical platform-table home-surface contract and apply it in the shared loader.
+
+The kernel recommended `registry-data-lens` with composite `5.624`, margin `4.888`, high confidence, strong structured coverage, and no commandment conflict (`DI-93238917B4E0`). Architecture Over Shortcuts, Ground New Work in Existing Platform, and Single Source of Truth favored the registry contract. Personal saved views remain presentation state; they do not own the business meaning of a domain's default dataset.
+
+## Design
+
+### Domain data lens
+
+Extend `PlatformTableHomeSurface` with an optional typed `defaultDataLens`:
+
+- a plain-language default label;
+- a plain-language all-records label;
+- a `DataSourceFilter` applied before eager materialization.
+
+Backlog declares one lens using the same active lifecycle vocabulary as the List page. Tables without a declared lens continue to show all rows, which is their current List behavior.
+
+### Page-to-grid request state
+
+Extend the pure surface-view helper with a closed `default | all` data-scope parser and a stable URL builder. `SurfaceViewSwitcher` renders the scope choice only for Grid/Board surfaces whose registry entry declares a lens. The default URL omits the scope parameter; `scope=all` is the deliberate historical-data override.
+
+### Read path
+
+`SurfacePlatformGrid` resolves the registry lens and passes its filter to `getAllPlatformTableRows` unless the request explicitly selects `all`. The shared eager loader asks the adapter for the whole bounded dataset once instead of repeatedly rematerializing the source in 200-row chunks. The backlog adapter uses a narrow Prisma projection and pushes the supported status lens into its query, then still runs the shared filter function as a correctness guard.
+
+### State boundaries
+
+- Domain data lens: server-readable, registry-owned, shared across List/Grid/Board meaning.
+- Personal saved view: browser/user-owned presentation state (sort, group, columns, secondary filters).
+- Explicit `scope=all`: URL-owned override, useful for deep links and no-JS navigation.
+
+## Implementation phases
+
+### Phase 1 — red tests for the contract
+
+Add failing tests that prove:
+
+- unknown or absent scope resolves to the default lens;
+- `scope=all` bypasses the default lens;
+- the backlog active status set excludes `done` and `deferred` and is shared by List and Grid semantics;
+- the eager loader invokes its adapter once for a bounded all-row request;
+- the backlog adapter translates the active status filter into a Prisma `where` clause.
+
+### Phase 2 — shared contract and refactor
+
+- Move backlog lifecycle visibility helpers from the Ops component folder into `apps/web/lib/` so domain UI and grid registry share one source.
+- Add the typed registry data-lens contract and backlog configuration.
+- Add the pure scope parser/URL builder and wire it through `PlatformGridSection`, `SurfaceViewSwitcher`, and `SurfacePlatformGrid`.
+- Update `/ops` to parse and pass the closed scope value.
+
+### Phase 3 — bounded read performance
+
+- Replace repeated eager adapter pagination with one bounded adapter request.
+- Narrow the backlog grid query to the grid's scalar projection.
+- Push the active status condition into Prisma when the filter can be represented safely; retain shared in-memory filtering for exact adapter semantics.
+
+### Phase 4 — verification and evidence
+
+- Run the targeted Vitest files and the affected web suite.
+- Run `pnpm --filter web build` in the proper compile-ready/local-CI environment.
+- Exercise `/ops`, `/ops?view=grid`, `/ops?view=board`, and the `scope=all` override against the governed canonical/shared runtime.
+- Confirm the default grid excludes done/deferred rows, the all-records view includes them, the scope control is keyboard reachable, and light/dark styling remains token-based.
+- Record a measured UX-fit manifest and runtime/capsule evidence.
+
+## Backlog coverage
+
+- Decision: `atomic`
+- Receipt: `cmsktm3xr01r601qlbia3oclf`
+- Parent BI: `BI-9DB20C39`
+- Rationale: the registry contract, loader optimization, surface override, and verification jointly define one user-visible invariant. Shipping any phase alone would preserve either the semantic mismatch, the unbounded load, or an unrecoverable hidden-history state.
+- Internal deliverables:
+  - `contract` — registry-owned default data lens and shared resolver
+  - `loader` — filter-aware eager loading without repeated source materialization; depends on `contract`
+  - `surface` — Operations active-only default with deliberate all-records override; depends on `contract`, `loader`
+  - `verification` — regression, build, UX, and runtime evidence; depends on `surface`
+
+## Architecture review (advisory)
+
+- Alignment summary: aligned with important guardrails.
+- `[important]` A page-local prop would make the same rule live once per route. Suggestion: declare the lens on `PlatformTableHomeSurface` and resolve it in the shared page-to-grid components.
+- `[important]` A personal saved view is not a reliable business default and cannot prevent the first unbounded read. Suggestion: keep saved views presentation-only and apply the domain lens server-side.
+- `[important]` Server filtering without a visible escape would make historical records appear missing. Suggestion: add the stable `scope=all` URL and a shared, plain-language scope control.
+- `[minor]` Ops lifecycle semantics currently live under `components/`. Suggestion: move them to `lib` and have both List and Grid use the same active/terminal constants.
+- Standards adopted: existing Universal Grid `DataSourceFilter`, cursor/bounded-query contract, stable query parameters, token-aware shared controls. No new external dependency or standard is required.
+- Escalated decision: `DI-93238917B4E0`; high-confidence `registry-data-lens` recommendation.
+
+## UX fit review — domain data lens across List/Grid/Board
+
+- Decision: `fits-with-guardrails`
+- Owning area: Platform substrate, surfaced in Operations
+- Route family: `/ops` and existing domain home surfaces registered in `PLATFORM_TABLES`
+- Primary persona: platform operator reviewing actionable work without waiting for closed history
+- Navigation layer touched: local page view/scope controls only
+- Reuse/convergence: extend `SurfaceViewSwitcher`, `SurfacePlatformGrid`, `PlatformGridSection`, and the existing filter contract; no new grid dialect
+- Source truth: live `BacklogItem.status` plus registry-owned `DataSourceFilter`
+- Empty/failure behavior: an empty active lens remains an honest zero-row grid; adapter permission/errors retain the existing plain-language message
+- AI boundary: no prompt send
+- Required guardrails: scope choice must be visible on Grid/Board, `scope=all` must be stable and server-readable, saved presentation state must not silently redefine domain scope
+- Evidence before merge: pure resolver tests, adapter/filter tests, one-call eager-loader test, theme scan, UX budget measurement, and browser proof for default/all Grid and Board paths
+- Captured in: this plan and the branch UX-fit manifest
+
+## Risks and rollback
+
+- Risk: a filter is declared against a column an adapter does not expose. Mitigation: validate lens conditions against adapter columns and fail closed with a clear error in tests.
+- Risk: a saved personal filter appears to conflict with the domain lens. Mitigation: present the domain scope separately and keep saved filters secondary within the loaded dataset.
+- Risk: a one-shot bounded adapter request exposes an adapter that assumes 200-row pages. Mitigation: cover the shared loader with a fake adapter and retain `MAX_GRID_ROWS` as the hard ceiling.
+- Risk: Prisma push-down drifts from shared filter semantics. Mitigation: only translate the closed status `in` condition and reapply `applyFilters` to returned rows.
+
+Rollback is a normal code revert: remove the optional registry lens and restore the paginated eager loader. There is no migration or persisted data change.
+
+## Documentation impact
+
+Update the Universal Grid design's embedded-domain section to state that a domain's default data lens is registry-owned, server-applied before materialization, and distinct from personal saved view state. No user-guide route changes are needed; the control is self-describing and the URLs remain under the existing home routes.

--- a/docs/superpowers/plans/2026-08-08-grid-default-data-lens.md
+++ b/docs/superpowers/plans/2026-08-08-grid-default-data-lens.md
@@ -24,6 +24,20 @@ This corrects the implementation gap in the existing Universal Grid design. That
 
 No database model, enum, migration, route family, or new grid primitive is needed.
 
+## Design grounding
+
+- Existing specs/plans reviewed:
+  - `docs/superpowers/specs/2026-03-23-universal-grid-workbooks-design.md`
+  - `docs/superpowers/plans/2026-05-26-portal-ux-simplification-spine.md`
+- Current code substrate reviewed:
+  - platform-table home-surface registry and adapter framework
+  - shared `PlatformGridSection`, `SurfaceViewSwitcher`, and `SurfacePlatformGrid`
+  - each embedded domain List read path with an implicit default dataset
+- Source of truth:
+  - live domain status/stage fields plus the registry-owned `DataSourceFilter`
+- Decision:
+  - use the kernel-recommended `registry-data-lens` contract (`DI-93238917B4E0`), not page-local filters or personal saved-view state
+
 ## Architecture decision
 
 Three grounded options were scored by the platform kernel:

--- a/docs/superpowers/plans/2026-08-08-grid-default-data-lens.md
+++ b/docs/superpowers/plans/2026-08-08-grid-default-data-lens.md
@@ -109,10 +109,11 @@ Add failing tests that prove:
 
 ## Backlog coverage
 
-- Decision: `atomic`
-- Receipt: `cmsktm3xr01r601qlbia3oclf`
-- Parent BI: `BI-9DB20C39`
+- Decision: atomic
+- Parent: `BI-9DB20C39`
+- Receipt: `cmsl8u03o09ht01l8vyknqnzk`
 - Rationale: the registry contract, loader optimization, surface override, and verification jointly define one user-visible invariant. Shipping any phase alone would preserve either the semantic mismatch, the unbounded load, or an unrecoverable hidden-history state.
+- Dependencies: loader -> contract; surface -> contract, loader; verification -> surface
 - Internal deliverables:
   - `contract` — registry-owned default data lens and shared resolver
   - `loader` — filter-aware eager loading without repeated source materialization; depends on `contract`
@@ -155,4 +156,4 @@ Rollback is a normal code revert: remove the optional registry lens and restore 
 
 ## Documentation impact
 
-Update the Universal Grid design's embedded-domain section to state that a domain's default data lens is registry-owned, server-applied before materialization, and distinct from personal saved view state. No user-guide route changes are needed; the control is self-describing and the URLs remain under the existing home routes.
+Update the Universal Grid design's embedded-domain section to state that a domain's default data lens is registry-owned, server-applied before materialization, and distinct from personal saved view state. Update the Operations, Customer, and affected Compliance user guides so the default scope and deliberate all-records override are discoverable without relying on control labels alone.

--- a/docs/superpowers/plans/2026-08-08-grid-default-data-lens.md
+++ b/docs/superpowers/plans/2026-08-08-grid-default-data-lens.md
@@ -7,7 +7,7 @@
 
 ## Outcome
 
-Switching a domain page from List to Grid or Board keeps the domain's default dataset. Operations therefore opens Grid and Board on active backlog work (`triaging`, `open`, and `in-progress`) instead of materializing done and deferred history. Historical rows remain deliberately reachable through an all-records scope.
+Switching a domain page from List to Grid or Board keeps the domain's default dataset. Operations therefore opens Grid and Board on active backlog work (`triaging`, `open`, and `in-progress`) instead of materializing done and deferred history. Compliance controls, obligations, and risks likewise retain their existing active-only List defaults; Opportunities keeps its open pipeline stages; and Customers continues to exclude superseded merge tombstones. Historical rows remain deliberately reachable through an all-records scope.
 
 This corrects the implementation gap in the existing Universal Grid design. That design already specifies pre-configured platform grids with sensible defaults and one shared `DataSourceFilter` shape for source and view filters; this plan makes the page-to-grid boundary honor that contract.
 
@@ -44,11 +44,11 @@ Extend `PlatformTableHomeSurface` with an optional typed `defaultDataLens`:
 - a plain-language all-records label;
 - a `DataSourceFilter` applied before eager materialization.
 
-Backlog declares one lens using the same active lifecycle vocabulary as the List page. Tables without a declared lens continue to show all rows, which is their current List behavior.
+Each surface whose List already has an implicit default declares that same lens: active backlog work, active compliance controls/obligations/risks, open opportunities, and current (non-superseded) customers. Tables without a declared lens continue to show all rows, which is their current List behavior.
 
 ### Page-to-grid request state
 
-Extend the pure surface-view helper with a closed `default | all` data-scope parser and a stable URL builder. `SurfaceViewSwitcher` renders the scope choice only for Grid/Board surfaces whose registry entry declares a lens. The default URL omits the scope parameter; `scope=all` is the deliberate historical-data override.
+Extend the pure surface-view helper with a closed `default | all` data-scope parser and a stable URL builder. `SurfaceViewSwitcher` renders the scope choice only for Grid/Board surfaces whose registry entry declares a lens. The default URL omits the scope parameter; `dataScope=all` is the deliberate historical-data override. The namespaced key does not collide with domain filters such as Compliance's existing `scope`.
 
 ### Read path
 
@@ -58,7 +58,7 @@ Extend the pure surface-view helper with a closed `default | all` data-scope par
 
 - Domain data lens: server-readable, registry-owned, shared across List/Grid/Board meaning.
 - Personal saved view: browser/user-owned presentation state (sort, group, columns, secondary filters).
-- Explicit `scope=all`: URL-owned override, useful for deep links and no-JS navigation.
+- Explicit `dataScope=all`: URL-owned override, useful for deep links and no-JS navigation.
 
 ## Implementation phases
 
@@ -67,7 +67,7 @@ Extend the pure surface-view helper with a closed `default | all` data-scope par
 Add failing tests that prove:
 
 - unknown or absent scope resolves to the default lens;
-- `scope=all` bypasses the default lens;
+- `dataScope=all` bypasses the default lens;
 - the backlog active status set excludes `done` and `deferred` and is shared by List and Grid semantics;
 - the eager loader invokes its adapter once for a bounded all-row request;
 - the backlog adapter translates the active status filter into a Prisma `where` clause.
@@ -89,7 +89,7 @@ Add failing tests that prove:
 
 - Run the targeted Vitest files and the affected web suite.
 - Run `pnpm --filter web build` in the proper compile-ready/local-CI environment.
-- Exercise `/ops`, `/ops?view=grid`, `/ops?view=board`, and the `scope=all` override against the governed canonical/shared runtime.
+- Exercise `/ops`, `/ops?view=grid`, `/ops?view=board`, and the `dataScope=all` override against the governed canonical/shared runtime.
 - Confirm the default grid excludes done/deferred rows, the all-records view includes them, the scope control is keyboard reachable, and light/dark styling remains token-based.
 - Record a measured UX-fit manifest and runtime/capsule evidence.
 
@@ -110,7 +110,7 @@ Add failing tests that prove:
 - Alignment summary: aligned with important guardrails.
 - `[important]` A page-local prop would make the same rule live once per route. Suggestion: declare the lens on `PlatformTableHomeSurface` and resolve it in the shared page-to-grid components.
 - `[important]` A personal saved view is not a reliable business default and cannot prevent the first unbounded read. Suggestion: keep saved views presentation-only and apply the domain lens server-side.
-- `[important]` Server filtering without a visible escape would make historical records appear missing. Suggestion: add the stable `scope=all` URL and a shared, plain-language scope control.
+- `[important]` Server filtering without a visible escape would make historical records appear missing. Suggestion: add the stable `dataScope=all` URL and a shared, plain-language scope control.
 - `[minor]` Ops lifecycle semantics currently live under `components/`. Suggestion: move them to `lib` and have both List and Grid use the same active/terminal constants.
 - Standards adopted: existing Universal Grid `DataSourceFilter`, cursor/bounded-query contract, stable query parameters, token-aware shared controls. No new external dependency or standard is required.
 - Escalated decision: `DI-93238917B4E0`; high-confidence `registry-data-lens` recommendation.
@@ -126,7 +126,7 @@ Add failing tests that prove:
 - Source truth: live `BacklogItem.status` plus registry-owned `DataSourceFilter`
 - Empty/failure behavior: an empty active lens remains an honest zero-row grid; adapter permission/errors retain the existing plain-language message
 - AI boundary: no prompt send
-- Required guardrails: scope choice must be visible on Grid/Board, `scope=all` must be stable and server-readable, saved presentation state must not silently redefine domain scope
+- Required guardrails: scope choice must be visible on Grid/Board, `dataScope=all` must be stable and server-readable, saved presentation state must not silently redefine domain scope
 - Evidence before merge: pure resolver tests, adapter/filter tests, one-call eager-loader test, theme scan, UX budget measurement, and browser proof for default/all Grid and Board paths
 - Captured in: this plan and the branch UX-fit manifest
 

--- a/docs/superpowers/specs/2026-03-23-universal-grid-workbooks-design.md
+++ b/docs/superpowers/specs/2026-03-23-universal-grid-workbooks-design.md
@@ -345,6 +345,15 @@ Each platform entity gets a thin adapter that maps its Prisma fields to the grid
 
 Domain area pages (Ops, CRM, etc.) embed grid instances using pre-configured `WorkbookTable` records with platform data sources and sensible default columns. Users can customize their view (hide/show columns, reorder, filter) and save it. The grid renders inline, with a toggle between the legacy layout and grid view during migration.
 
+The page-to-grid boundary also preserves the domain's default **data lens**. A
+domain that defaults its List view to current/actionable records declares the
+same `DataSourceFilter` on its canonical platform-table home-surface registry
+entry; Grid and Board apply that filter on the server before materializing rows.
+An explicit, server-readable all-records scope provides access to history. This
+domain lens is not personal presentation state: saved views may add sorting,
+grouping, columns, and secondary filters, but they do not redefine which dataset
+the domain means by default.
+
 ## Adapter Framework
 
 ### Adapter Interface
@@ -456,6 +465,8 @@ When an agent is working in a context that involves workbook data, it can surfac
 **Embedded grid views in domain areas:**
 - Each domain area (Ops, CRM, Compliance, etc.) gets grid views of its data inline
 - Pre-configured WorkbookTable records with platform data sources
+- Registry-owned default data lenses stay consistent across List, Grid, and Board
+- Default lenses apply before eager materialization; all-records history remains an explicit URL scope
 - Users customize and save their own view configs
 - Grid appears alongside (and eventually replaces) the current custom layouts
 

--- a/docs/user-guide/compliance/controls-and-evidence.md
+++ b/docs/user-guide/compliance/controls-and-evidence.md
@@ -39,6 +39,11 @@ document from being mistaken for an operating control.
    can still be partially effective, ineffective, or not assessed.
 5. Review linked risks and the next review date.
 
+The Controls **List**, **Grid**, and **Board** views all begin with active
+controls. In Grid or Board, choose **All controls** beside the view controls to
+include inactive history. The scope is part of the URL, so a shared or refreshed
+link keeps the intended dataset.
+
 ## Record Evidence
 
 1. Create an evidence record with a clear title and evidence type.

--- a/docs/user-guide/compliance/incidents-risks-and-response.md
+++ b/docs/user-guide/compliance/incidents-risks-and-response.md
@@ -31,6 +31,10 @@ The platform displays linked incidents on the risk detail. A risk with no
 incidents is not automatically low risk, and an incident does not by itself
 prove the linked control failed.
 
+Risk assessment **List**, **Grid**, and **Board** views all begin with active
+assessments. In Grid or Board, choose **All assessments** beside the view
+controls to inspect inactive history. The scope is retained in the URL.
+
 ## Respond To An Incident
 
 1. Address safety, containment, service continuity, and required escalation

--- a/docs/user-guide/compliance/regulations-and-obligations.md
+++ b/docs/user-guide/compliance/regulations-and-obligations.md
@@ -60,6 +60,10 @@ backlog item.
 5. Open the regulation detail and confirm the source, obligation count, owners,
    control coverage, and any **Source needed** warning.
 
+The Obligations **List**, **Grid**, and **Board** views all begin with active
+obligations. In Grid or Board, choose **All obligations** beside the view
+controls when reviewing inactive history. The scope is retained in the URL.
+
 ## Decisions And Consequences
 
 - **Deactivate** marks a regulation inactive; it does not erase the record.

--- a/docs/user-guide/customers/index.md
+++ b/docs/user-guide/customers/index.md
@@ -86,6 +86,13 @@ Simple navigation intentionally emphasizes today's work. Full navigation exposes
 the wider CRM structure. A saved grid view still opens the detailed surface
 directly.
 
+When you switch Accounts or Pipeline from **List** to **Grid** or **Board**, the
+domain's working scope follows you. Accounts show current customers rather than
+superseded merge tombstones; Pipeline shows open qualification-through-
+negotiation work. Use **All customers** or **All opportunities** beside the view
+controls to include history. This scope is separate from personal saved grid
+sorting, grouping, and column choices, and remains in the URL.
+
 ## Capture and Qualify a Lead
 
 ### Manual lead

--- a/docs/user-guide/operations/index.md
+++ b/docs/user-guide/operations/index.md
@@ -42,6 +42,12 @@ done count.
 you expand an epic, while the row-level status mix stays visible. Turn it off to
 inspect terminal items.
 
+The same default follows you when you switch from **List** to **Grid** or
+**Board**. Grid and Board load active work first so closed history does not slow
+the initial view. Choose **All items** beside the view controls when you need
+done and deferred records; that choice remains in the page URL for sharing or
+refreshing.
+
 - **Triaging** — Waiting for an intake decision.
 - **Open** — Accepted work that has not started.
 - **In progress** — Work is actively underway.

--- a/docs/ux-fit/2026-08-08-grid-default-data-lens.ux-fit.json
+++ b/docs/ux-fit/2026-08-08-grid-default-data-lens.ux-fit.json
@@ -1,0 +1,20 @@
+{
+  "version": "1",
+  "decidedOption": "registry-data-lens",
+  "decisionInteractionId": "DI-93238917B4E0",
+  "scope": {
+    "files": [
+      "apps/web/components/workbooks/SurfaceViewSwitcher.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "registry-data-lens",
+      "page-local",
+      "saved-view-default"
+    ],
+    "accessibility": "The existing view links and the new data-scope links are grouped in separately labelled navigation regions, expose the selected choice with aria-current, retain no-JavaScript URLs, and use a visible theme-token focus outline.",
+    "responsive": "The two compact segments wrap as independent groups when horizontal space is constrained; no fixed width or viewport assumption is introduced."
+  }
+}

--- a/docs/ux-fit/2026-08-08-grid-default-data-lens.ux-fit.json
+++ b/docs/ux-fit/2026-08-08-grid-default-data-lens.ux-fit.json
@@ -14,7 +14,7 @@
       "page-local",
       "saved-view-default"
     ],
-    "accessibility": "The existing view links and the new data-scope links are grouped in separately labelled navigation regions, expose the selected choice with aria-current, retain no-JavaScript URLs, and use a visible theme-token focus outline.",
+    "accessibility": "The existing view links preserve their established accessibility-tree shape. New data-scope links are exposed as a separately labelled group, expose the selected choice with aria-current, retain no-JavaScript URLs, and use a visible theme-token focus outline.",
     "responsive": "The two compact segments wrap as independent groups when horizontal space is constrained; no fixed width or viewport assumption is introduced."
   }
 }


### PR DESCRIPTION
## Summary

- make embedded Grid and Board views inherit each domain page's default data lens
- centralize lens ownership in the platform-table home-surface registry instead of page-local filters
- default Operations to active work while retaining a visible, stable `All items` override
- apply the same architecture to Opportunities, Customers, and Compliance surfaces
- avoid loading the hidden relation-rich List model for Grid/Board and eliminate repeated full-source materialization

## Verification

- focused Vitest: 7 files, 27 tests passed
- governed pregate: `NPEL-D8C57A8906`, literal `gate passed`
- exact gate evidence: `cmsq3qbe702xk01t68707r1io`
- fresh semantic review: `cmsq2a0bn004e01t6a9myglef`, zero issues, shadow `mayPublish=true`
- measured UX-fit manifest included

## Architecture and UX

The domain's default dataset is now registry-owned and server-applied before materialization. Personal saved views remain presentation state; `dataScope=all` is the explicit URL-owned historical override. The scope control reuses the shared surface switcher and theme tokens, and appears only where a registry lens exists.

## Documentation impact

Docs-Impact-Decision: user-facing Operations, Customer, and Compliance guides plus the Universal Grid design are updated to explain default scopes and the deliberate all-records override.

## Data changes

No schema migration or data backfill.

Backlog: BI-9DB20C39

