### PR TITLE
fix(restaurant): keep the authored floor ready for a busy shift

### DIFF
--- a/apps/web/components/storefront/SlotBookingFlow.mobile.test.tsx
+++ b/apps/web/components/storefront/SlotBookingFlow.mobile.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@/lib/storefront-actions", () => ({
 }));
 
 import { SlotBookingFlow } from "./SlotBookingFlow";
+import { submitBooking } from "@/lib/storefront-actions";
 
 // Tomorrow in local time — a clickable (non-past) calendar day. If tomorrow
 // rolls into the next month the test clicks "Next month" first.
@@ -115,5 +116,27 @@ describe("public booking mobile contract (390px floor)", () => {
     expect(screen.queryByLabelText(/preferred time/i)).toBeNull();
     expect(document.querySelector('input[type="date"]')).toBeNull();
     expect(document.querySelector('input[type="time"]')).toBeNull();
+  });
+
+  it("submits on LAN HTTP when randomUUID is unavailable", async () => {
+    vi.stubGlobal("crypto", {
+      getRandomValues: (bytes: Uint8Array) => bytes.fill(9),
+    });
+    vi.mocked(submitBooking).mockResolvedValueOnce({
+      success: false,
+      error: "Synthetic stop after idempotency assertion",
+    });
+
+    const dayButton = await renderFlowAtSlotStep();
+    fireEvent.click(dayButton);
+    fireEvent.click(await screen.findByRole("button", { name: `6:30 PM to 8:00 PM on ${tomorrowLabel}` }));
+    fireEvent.change(await screen.findByLabelText("Full name *"), { target: { value: "Taylor Guest" } });
+    fireEvent.change(screen.getByLabelText("Email address *"), { target: { value: "taylor@example.test" } });
+    fireEvent.click(screen.getByRole("button", { name: "Confirm booking" }));
+
+    await waitFor(() => expect(submitBooking).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(submitBooking).mock.calls[0]?.[1].idempotencyKey).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
   });
 });

--- a/apps/web/components/storefront/SlotBookingFlow.tsx
+++ b/apps/web/components/storefront/SlotBookingFlow.tsx
@@ -9,7 +9,7 @@ import { slotFlowExtraFields, type FormField } from "./slot-booking-fields";
 // booking-summary owns the structured-role mapping + handoff vocabulary;
 // slot-booking-fields (above) owns which schema fields the flow still renders.
 import { parseCovers, structuredBookingFieldRole } from "@/lib/storefront/booking-summary";
-
+import { createClientOperationId } from "@/lib/client-operation-id";
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 type AvailableSlot = {
@@ -394,7 +394,7 @@ export function SlotBookingFlow({
       covers,
       dietaryNotes,
       notes: notes || undefined,
-      idempotencyKey: crypto.randomUUID(),
+      idempotencyKey: createClientOperationId(),
     });
 
     if (!result.success) {

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
@@ -349,7 +349,10 @@ describe("RestaurantFloorOperations", () => {
     fireEvent.click(screen.getByRole("button", { name: "Confirm seating" }));
 
     await waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(1));
-    expect(screen.getByText("Floor changed before confirmation")).toBeTruthy();
+    const status = screen.getByRole("status");
+    expect(status.getAttribute("aria-live")).toBe("polite");
+    expect(status.textContent).toContain("Floor changed before confirmation");
+    expect(status.textContent).toContain("Review the refreshed choices and confirm again");
     expect(screen.queryByRole("button", { name: "Confirm seating" })).toBeNull();
     expect(screen.getByText("Choose a party to see the safest live seating choice.")).toBeTruthy();
   });

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
@@ -335,6 +335,25 @@ describe("RestaurantFloorOperations", () => {
     expect(screen.getByText("Party seated")).toBeTruthy();
   });
 
+  it("refreshes the floor and clears stale seating choices after a conflict", async () => {
+    mocks.execute.mockResolvedValueOnce({
+      status: "conflict",
+      idempotencyKey: "seat-conflict",
+      replayed: false,
+      message: "The floor changed before confirmation.",
+      currentVersion: "restaurant-seat.v1-newer",
+      changedFacts: [],
+    });
+
+    render(<RestaurantFloorOperations {...props} />);
+    fireEvent.click(screen.getByRole("button", { name: "Confirm seating" }));
+
+    await waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("Floor changed before confirmation")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Confirm seating" })).toBeNull();
+    expect(screen.getByText("Choose a party to see the safest live seating choice.")).toBeTruthy();
+  });
+
   it("submits host commands when randomUUID is unavailable on an HTTP install", async () => {
     vi.stubGlobal("crypto", {
       getRandomValues: (bytes: Uint8Array) => bytes.fill(7),

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
@@ -349,10 +349,11 @@ describe("RestaurantFloorOperations", () => {
     fireEvent.click(screen.getByRole("button", { name: "Confirm seating" }));
 
     await waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(1));
-    const status = screen.getByRole("status");
-    expect(status.getAttribute("aria-live")).toBe("polite");
-    expect(status.textContent).toContain("Floor changed before confirmation");
-    expect(status.textContent).toContain("Review the refreshed choices and confirm again");
+    const alert = screen.getByRole("alert");
+    expect(alert.getAttribute("aria-live")).toBe("assertive");
+    expect(alert.textContent).toContain("Floor changed before confirmation");
+    expect(alert.textContent).toContain("Review the refreshed choices and confirm again");
+    expect(document.activeElement).toBe(alert);
     expect(screen.queryByRole("button", { name: "Confirm seating" })).toBeNull();
     expect(screen.getByText("Choose a party to see the safest live seating choice.")).toBeTruthy();
   });

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
@@ -352,10 +352,10 @@ describe("RestaurantFloorOperations", () => {
     const alert = screen.getByRole("alert");
     expect(alert.getAttribute("aria-live")).toBe("assertive");
     expect(alert.textContent).toContain("Floor changed before confirmation");
-    expect(alert.textContent).toContain("Review the refreshed choices and confirm again");
+    expect(alert.textContent).toContain("Review refreshed choices, then retry");
     expect(document.activeElement).toBe(alert);
     expect(screen.queryByRole("button", { name: "Confirm seating" })).toBeNull();
-    expect(screen.getByText("Choose a party to see the safest live seating choice.")).toBeTruthy();
+    expect(screen.getByText("Choose a party for a safe seating choice.")).toBeTruthy();
   });
 
   it("submits host commands when randomUUID is unavailable on an HTTP install", async () => {

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
@@ -386,7 +386,9 @@ export function RestaurantFloorOperations({
         </dl>
       </header>
 
-      {resultNotice(result)}
+      <div role="status" aria-live="polite" aria-atomic="true">
+        {resultNotice(result)}
+      </div>
 
       <div
         className="grid min-h-0 gap-dpf-sm lg:flex-1"

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
@@ -190,6 +190,14 @@ export function RestaurantFloorOperations({
     }
   };
 
+  const refreshAfterConflict = () => {
+    setSelectedDemandId(null);
+    setSelectedOption(null);
+    setSelectedMoveTurnId(null);
+    setSelectedMoveOption(null);
+    router.refresh();
+  };
+
   const bindings = useMemo(
     () => Object.fromEntries(view.floor.tables.map((table) => [
       `table:${table.id}`,
@@ -281,6 +289,8 @@ export function RestaurantFloorOperations({
         setSelectedDemandId(null);
         setSelectedOption(null);
         router.refresh();
+      } else if (next.status === "conflict") {
+        refreshAfterConflict();
       }
     });
   };
@@ -298,6 +308,7 @@ export function RestaurantFloorOperations({
       });
       setResult(nextResult);
       if (nextResult.status === "confirmed") router.refresh();
+      else if (nextResult.status === "conflict") refreshAfterConflict();
     });
   };
 
@@ -317,6 +328,8 @@ export function RestaurantFloorOperations({
         setSelectedMoveTurnId(null);
         setSelectedMoveOption(null);
         router.refresh();
+      } else if (nextResult.status === "conflict") {
+        refreshAfterConflict();
       }
     });
   };

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useTransition, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, useTransition, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 
 import { LocalTime } from "@/components/ui/LocalTime";
@@ -141,6 +141,7 @@ export function RestaurantFloorOperations({
   const [queueFilter, setQueueFilter] = useState<QueueFilter>("all");
   const [centerView, setCenterView] = useState<CenterView>("floor");
   const [result, setResult] = useState<OperationalCommandResult | null>(null);
+  const conflictNoticeRef = useRef<HTMLDivElement>(null);
   const [selectedMoveTurnId, setSelectedMoveTurnId] = useState<string | null>(null);
   const [selectedMoveOption, setSelectedMoveOption] =
     useState<RestaurantFloorCommandOption | null>(null);
@@ -197,6 +198,10 @@ export function RestaurantFloorOperations({
     setSelectedMoveOption(null);
     router.refresh();
   };
+
+  useEffect(() => {
+    if (result?.status === "conflict") conflictNoticeRef.current?.focus();
+  }, [result]);
 
   const bindings = useMemo(
     () => Object.fromEntries(view.floor.tables.map((table) => [
@@ -386,7 +391,13 @@ export function RestaurantFloorOperations({
         </dl>
       </header>
 
-      <div role="status" aria-live="polite" aria-atomic="true">
+      <div
+        ref={conflictNoticeRef}
+        role={result?.status === "conflict" ? "alert" : "status"}
+        aria-live={result?.status === "conflict" ? "assertive" : "polite"}
+        aria-atomic="true"
+        tabIndex={result?.status === "conflict" ? -1 : undefined}
+      >
         {resultNotice(result)}
       </div>
 

--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.tsx
@@ -87,7 +87,7 @@ function resultNotice(result: OperationalCommandResult | null) {
   if (result.status === "conflict") {
     return (
       <Notice variant="warn" title="Floor changed before confirmation">
-        Nothing changed. Review the refreshed choices and confirm again.
+        Nothing changed. Review refreshed choices, then retry.
       </Notice>
     );
   }
@@ -506,13 +506,13 @@ export function RestaurantFloorOperations({
                 {selectedDemand.recommendation.warning ? (
                   <p className="mt-dpf-xs text-dpf-caption text-dpf-warning">Check: {selectedDemand.recommendation.warning}</p>
                 ) : (
-                  <p className="mt-dpf-xs text-dpf-caption text-dpf-muted">Best safe fit from live capacity, timing, and server load.</p>
+                  <p className="mt-dpf-xs text-dpf-caption text-dpf-muted">Best fit by capacity, timing, and server load.</p>
                 )}
                 <p className="mt-dpf-sm text-dpf-body text-dpf-text">Seat {selectedDemand.name} ({selectedDemand.covers}) at {selectedOption.label}.</p>
                 <button aria-busy={pending} type="button" className="dpf-tap-target mt-dpf-sm w-full rounded-dpf-md bg-dpf-accent px-dpf-md font-dpf-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))] disabled:opacity-60" data-dpf-primary-action="true" data-owner-first-next-action="restaurant-confirm-seating" disabled={pending} onClick={confirm}>{pending ? <InlineBusy label="Confirming…" tone="current" /> : "Confirm seating"}</button>
               </>
             ) : (
-              <p className="mt-dpf-sm text-dpf-body text-dpf-muted">Choose a party to see the safest live seating choice.</p>
+              <p className="mt-dpf-sm text-dpf-body text-dpf-muted">Choose a party for a safe seating choice.</p>
             )}
           </section>
 

--- a/apps/web/lib/actions/operating-hours.test.ts
+++ b/apps/web/lib/actions/operating-hours.test.ts
@@ -107,8 +107,11 @@ describe("getOperatingHours", () => {
       hoursConfirmedAt: null,
     } as never);
     vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue({
-      archetypeId: "restaurant",
-      archetype: { category: "food-hospitality" },
+      archetypeId: "cmpims3xf090p6ymggadp4075",
+      archetype: {
+        archetypeId: "restaurant",
+        category: "food-hospitality",
+      },
     } as never);
 
     const result = await getOperatingHours();

--- a/apps/web/lib/actions/operating-hours.ts
+++ b/apps/web/lib/actions/operating-hours.ts
@@ -204,7 +204,7 @@ export async function getOperatingHours(opts?: {
   const config = await prisma.storefrontConfig.findFirst({
     select: {
       archetypeId: true,
-      archetype: { select: { category: true } },
+      archetype: { select: { archetypeId: true, category: true } },
     },
   });
   // Use storefront archetype if available, otherwise fall back to suggested industry from URL
@@ -214,7 +214,7 @@ export async function getOperatingHours(opts?: {
     return {
       schedule: await getDefaultHoursForArchetype(
         categoryForDefaults,
-        config?.archetypeId,
+        config?.archetype?.archetypeId,
       ),
       timezone: resolvedTimezone,
       isConfirmed: false,

--- a/apps/web/lib/demo/restaurant-demo-floor.test.ts
+++ b/apps/web/lib/demo/restaurant-demo-floor.test.ts
@@ -68,10 +68,11 @@ describe("buildRestaurantDemoFloorPlan", () => {
   });
 
   it("creates two published server sections with every table assigned once", () => {
+    const now = new Date("2026-08-08T18:00:00.000Z");
     const plan = buildRestaurantDemoFloorPlan({
       bookings,
       employees,
-      now: new Date("2026-08-08T18:00:00.000Z"),
+      now,
       timezone: "America/Chicago",
     });
 
@@ -82,5 +83,10 @@ describe("buildRestaurantDemoFloorPlan", () => {
     ]);
     expect(plan.serverSections.flatMap((section) => section.tableKeys).sort())
       .toEqual(plan.tables.map((table) => table.key).sort());
+    expect(
+      plan.serverSections.every(
+        (section) => section.endAt.getTime() - now.getTime() > 365 * 24 * 60 * 60_000,
+      ),
+    ).toBe(true);
   });
 });

--- a/apps/web/lib/demo/restaurant-demo-floor.ts
+++ b/apps/web/lib/demo/restaurant-demo-floor.ts
@@ -1,6 +1,11 @@
 import type { RestaurantTableAttributes } from "@/lib/storefront/restaurant-table-attributes";
 
 const MINUTE = 60_000;
+// Demo sections represent an always-ready sample roster, not a scheduled shift
+// owned by a real employee. Keep that synthetic coverage stable across long-lived
+// demo installs; real restaurant shifts continue to use bounded intervals.
+const DEMO_SECTION_START = new Date("2020-01-01T00:00:00.000Z");
+const DEMO_SECTION_END = new Date("2100-01-01T00:00:00.000Z");
 
 export interface RestaurantDemoBookingInput {
   id: string;
@@ -145,8 +150,8 @@ export function buildRestaurantDemoFloorPlan(input: {
     assignmentId: `demo-restaurant-assignment-${index + 1}`,
     employeeId: server.id,
     employeeName: server.displayName,
-    startAt: at(input.now, -240),
-    endAt: at(input.now, 240),
+    startAt: DEMO_SECTION_START,
+    endAt: DEMO_SECTION_END,
     timezone: input.timezone,
     tableKeys,
   }));

--- a/docs/data-impact/2026-08-12-restaurant-demo-busy-shift-refresh.data-impact.json
+++ b/docs/data-impact/2026-08-12-restaurant-demo-busy-shift-refresh.data-impact.json
@@ -1,4 +1,5 @@
 {
+  "processSpineDecision": "Localized Restaurant demo data repair and existing-contract bugfix; no process-spine, route, or operator-documentation contract changed.",
   "version": "1",
   "accountableOwner": "data-steward",
   "affectedCopies": [

--- a/docs/data-impact/2026-08-12-restaurant-demo-busy-shift-refresh.data-impact.json
+++ b/docs/data-impact/2026-08-12-restaurant-demo-busy-shift-refresh.data-impact.json
@@ -1,0 +1,43 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "The platform-owned Restaurant demo's existing StorefrontBooking, StaffingShift, StaffingAssignment, HospitalityServiceTurn, HospitalityServiceTurnEvent, and HospitalityCapacityAllocation rows are refreshed into a recognizable busy shift using exact reserved demo identifiers.",
+    "The Workspace host stand continues to read the canonical Restaurant floor projection. No parallel fixture store, schema field, relationship, or derived persistence copy is introduced.",
+    "The guard migrations fail closed before any write when a reserved booking, staffing, turn, allocation, table-resource, provider, storefront, organization, or Restaurant-archetype identity does not match the exact platform demo corpus.",
+    "Operator-owned restaurant resources, bookings, staffing, layouts, service turns, allocations, availability, and customer data remain outside every selector."
+  ],
+  "migration": {
+    "name": "20260812102900_guard_restaurant_demo_busy_shift + 20260812102930_guard_restaurant_demo_resources + 20260812103000_refresh_restaurant_demo_busy_shift",
+    "backfill": "Data-only and demo-scoped. Two guard migrations first validate that all reserved demo identifiers resolve to the expected canonical Restaurant organization and table-resource graph and that no real booking, staffing, turn, or allocation row occupies a reserved id. The refresh then advances the existing reversible demo corpus to waiting, reserved, ordered, dirty, paid, and combined-table states, preserves released allocation history rather than deleting it, and recreates the two named server-section assignments. Reapplication is idempotent; no schema or operator-owned row is changed."
+  },
+  "tests": [
+    "packages/db/src/restaurant-demo-floor-migration.test.ts",
+    "apps/web/lib/demo/restaurant-demo-floor.test.ts",
+    "apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx",
+    "apps/web/lib/actions/operating-hours.test.ts",
+    "apps/web/components/storefront/SlotBookingFlow.mobile.test.tsx"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:hospitality-service-turn#restaurant-demo-busy-shift-refresh",
+      "prismaModel": "HospitalityServiceTurn",
+      "lifecycleDisposition": "Existing service-turn lifecycle. Exact demo turns are refreshed in place, their versions advance, and prior active demo allocations transition to released with disposition evidence instead of being deleted.",
+      "fields": [
+        {
+          "fieldId": "data:hospitality-service-turn#demo-stage-assignment-and-allocation",
+          "resolution": "inherited",
+          "reason": "party stage, staffing assignment, service-turn events, and capacity allocations remain in their established canonical authorities",
+          "provenance": "authored Restaurant demo busy-shift plan, bounded by exact reserved demo identifiers and fail-closed guards"
+        }
+      ]
+    },
+    {
+      "kind": "projection",
+      "derivedContractId": "projection:restaurant-demo-live-floor-busy-shift",
+      "cleanupTest": "restaurant-demo-floor-migration.test.ts asserts the exact demo-only identity guards and retained allocation-history boundary.",
+      "reconciliationTest": "restaurant-demo-floor.test.ts and RestaurantFloorOperations.test.tsx prove the refreshed canonical state reaches the authored floor, server sections, action recommendations, and stale-conflict recovery."
+    }
+  ]
+}

--- a/packages/db/prisma/migrations/20260812102900_guard_restaurant_demo_busy_shift/migration.sql
+++ b/packages/db/prisma/migrations/20260812102900_guard_restaurant_demo_busy_shift/migration.sql
@@ -1,0 +1,107 @@
+-- Fail closed before refreshing reserved Restaurant demo identifiers. This guard
+-- runs immediately before 20260812103000 and leaves installs without the demo
+-- corpus untouched. A reserved identifier collision must be resolved explicitly;
+-- it must never turn a demo refresh into an operator-data mutation.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "StorefrontBooking" booking
+    WHERE booking."bookingRef" ~ '^demo-restaurant-bk-[0-6]$'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "StorefrontConfig" config
+        JOIN "StorefrontArchetype" archetype ON archetype.id = config."archetypeId"
+        WHERE config.id = booking."storefrontId"
+          AND config."organizationId" = booking."organizationId"
+          AND archetype."archetypeId" = 'restaurant'
+      )
+  ) THEN
+    RAISE EXCEPTION 'Reserved Restaurant demo booking identifiers are attached to non-demo data';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "StaffingShift" shift
+    WHERE shift."shiftId" IN ('demo-restaurant-shift-1', 'demo-restaurant-shift-2')
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "StorefrontBooking" booking
+        JOIN "StorefrontConfig" config ON config.id = booking."storefrontId"
+        JOIN "StorefrontArchetype" archetype ON archetype.id = config."archetypeId"
+        WHERE booking."organizationId" = shift."organizationId"
+          AND booking."bookingRef" ~ '^demo-restaurant-bk-[0-6]$'
+          AND archetype."archetypeId" = 'restaurant'
+      )
+  ) THEN
+    RAISE EXCEPTION 'Reserved Restaurant demo shift identifiers are attached to non-demo data';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "StaffingAssignment" assignment
+    WHERE assignment."assignmentId" IN (
+      'demo-restaurant-assignment-1',
+      'demo-restaurant-assignment-2'
+    )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "StorefrontBooking" booking
+        JOIN "StorefrontConfig" config ON config.id = booking."storefrontId"
+        JOIN "StorefrontArchetype" archetype ON archetype.id = config."archetypeId"
+        WHERE booking."organizationId" = assignment."organizationId"
+          AND booking."bookingRef" ~ '^demo-restaurant-bk-[0-6]$'
+          AND archetype."archetypeId" = 'restaurant'
+      )
+  ) THEN
+    RAISE EXCEPTION 'Reserved Restaurant demo assignment identifiers are attached to non-demo data';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "HospitalityServiceTurn" turn
+    WHERE turn."turnId" ~ '^demo-restaurant-turn-[2-6]$'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "StorefrontBooking" booking
+        JOIN "StorefrontConfig" config ON config.id = booking."storefrontId"
+        JOIN "StorefrontArchetype" archetype ON archetype.id = config."archetypeId"
+        WHERE booking.id = turn."bookingId"
+          AND booking."organizationId" = turn."organizationId"
+          AND booking."storefrontId" = turn."storefrontId"
+          AND booking."bookingRef" = replace(turn."turnId", 'demo-restaurant-turn-', 'demo-restaurant-bk-')
+          AND archetype."archetypeId" = 'restaurant'
+      )
+  ) THEN
+    RAISE EXCEPTION 'Reserved Restaurant demo turn identifiers are attached to non-demo data';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "HospitalityCapacityAllocation" allocation
+    JOIN (VALUES
+      ('demo-restaurant-turn-2-table-2', 'demo-restaurant-bk-2'),
+      ('demo-restaurant-turn-3-table-3', 'demo-restaurant-bk-3'),
+      ('demo-restaurant-turn-4-table-5', 'demo-restaurant-bk-4'),
+      ('demo-restaurant-turn-4-table-6', 'demo-restaurant-bk-4'),
+      ('demo-restaurant-turn-5-table-7', 'demo-restaurant-bk-5'),
+      ('demo-restaurant-turn-6-table-8', 'demo-restaurant-bk-6'),
+      ('demo-restaurant-reservation-table-9', 'demo-restaurant-bk-1')
+    ) AS expected(allocation_ref, booking_ref)
+      ON expected.allocation_ref = allocation."allocationId"
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM "StorefrontBooking" booking
+      JOIN "StorefrontConfig" config ON config.id = booking."storefrontId"
+      JOIN "StorefrontArchetype" archetype ON archetype.id = config."archetypeId"
+      WHERE booking."bookingRef" = expected.booking_ref
+        AND booking.id = allocation."bookingId"
+        AND booking."organizationId" = allocation."organizationId"
+        AND booking."storefrontId" = allocation."storefrontId"
+        AND archetype."archetypeId" = 'restaurant'
+    )
+  ) THEN
+    RAISE EXCEPTION 'Reserved Restaurant demo allocation identifiers are attached to non-demo data';
+  END IF;
+END $$;

--- a/packages/db/prisma/migrations/20260812102930_guard_restaurant_demo_resources/migration.sql
+++ b/packages/db/prisma/migrations/20260812102930_guard_restaurant_demo_resources/migration.sql
@@ -1,0 +1,37 @@
+-- Fail closed before the busy-shift refresh if a reserved demo table identifier
+-- is not backed by its exact platform-owned demo provider in a Restaurant
+-- storefront. This migration intentionally sits between the aggregate guard
+-- and the refresh; committed migrations remain immutable.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "HospitalityResource" resource
+    JOIN (VALUES
+      ('demo-restaurant-table-1', 'demo-restaurant-prov-res-0'),
+      ('demo-restaurant-table-2', 'demo-restaurant-prov-res-1'),
+      ('demo-restaurant-table-3', 'demo-restaurant-prov-res-2'),
+      ('demo-restaurant-table-4', 'demo-restaurant-prov-res-3'),
+      ('demo-restaurant-table-5', 'demo-restaurant-prov-res-4'),
+      ('demo-restaurant-table-6', 'demo-restaurant-prov-res-5'),
+      ('demo-restaurant-table-7', 'demo-restaurant-prov-res-6'),
+      ('demo-restaurant-table-8', 'demo-restaurant-prov-res-7'),
+      ('demo-restaurant-table-9', 'demo-restaurant-prov-res-8')
+    ) AS expected(resource_ref, provider_ref)
+      ON expected.resource_ref = resource."resourceId"
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM "ServiceProvider" provider
+      JOIN "StorefrontConfig" config ON config.id = resource."storefrontId"
+      JOIN "StorefrontArchetype" archetype ON archetype.id = config."archetypeId"
+        WHERE provider.id = resource."legacyServiceProviderId"
+        AND provider."providerId" = expected.provider_ref
+        AND provider."storefrontId" = resource."storefrontId"
+        AND config."organizationId" = resource."organizationId"
+        AND archetype."archetypeId" = 'restaurant'
+    )
+  ) THEN
+    RAISE EXCEPTION 'Reserved Restaurant demo table identifiers are attached to non-demo data';
+  END IF;
+END $$;

--- a/packages/db/prisma/migrations/20260812103000_refresh_restaurant_demo_busy_shift/migration.sql
+++ b/packages/db/prisma/migrations/20260812103000_refresh_restaurant_demo_busy_shift/migration.sql
@@ -1,0 +1,154 @@
+-- Keep the platform-owned Restaurant demo usable after the original one-time
+-- fixture window has elapsed. Real restaurant shifts and bookings are excluded
+-- by the stable demo identifiers and the Restaurant archetype join.
+
+UPDATE "StaffingShift" shift
+SET
+  "startAt" = TIMESTAMPTZ '2020-01-01 00:00:00+00',
+  "endAt" = TIMESTAMPTZ '2100-01-01 00:00:00+00',
+  lifecycle = 'published',
+  "publicationVersion" = shift."publicationVersion" + 1,
+  version = shift.version + 1,
+  "updatedAt" = CURRENT_TIMESTAMP
+WHERE shift."shiftId" IN ('demo-restaurant-shift-1', 'demo-restaurant-shift-2')
+  AND EXISTS (
+    SELECT 1
+    FROM "StorefrontConfig" config
+    JOIN "StorefrontArchetype" archetype ON archetype.id = config."archetypeId"
+    WHERE config."organizationId" = shift."organizationId"
+      AND archetype."archetypeId" = 'restaurant'
+  );
+
+WITH demo_state AS (
+  SELECT * FROM (VALUES
+    (0, 'waiting',   INTERVAL '0 minutes',    INTERVAL '-14 minutes'),
+    (1, 'confirmed', INTERVAL '9 minutes',    INTERVAL '-120 minutes'),
+    (2, 'seated',    INTERVAL '-55 minutes',  INTERVAL '-180 minutes'),
+    (3, 'seated',    INTERVAL '-100 minutes', INTERVAL '-108 minutes'),
+    (4, 'seated',    INTERVAL '-50 minutes',  INTERVAL '-240 minutes'),
+    (5, 'seated',    INTERVAL '-84 minutes',  INTERVAL '-91 minutes'),
+    (6, 'seated',    INTERVAL '-102 minutes', INTERVAL '-210 minutes')
+  ) AS state(booking_index, status, scheduled_offset, created_offset)
+)
+UPDATE "StorefrontBooking" booking
+SET
+  "demandKind" = CASE WHEN state.booking_index IN (0, 3, 5) THEN 'walk-in' ELSE 'reservation' END,
+  covers = CASE state.booking_index
+    WHEN 0 THEN 3 WHEN 1 THEN 4 WHEN 2 THEN 4 WHEN 3 THEN 2
+    WHEN 4 THEN 8 WHEN 5 THEN 2 ELSE 4 END,
+  status = state.status,
+  "scheduledAt" = CURRENT_TIMESTAMP + state.scheduled_offset,
+  "createdAt" = CURRENT_TIMESTAMP + state.created_offset,
+  "durationMinutes" = 90,
+  "dietaryNotes" = NULL,
+  "updatedAt" = CURRENT_TIMESTAMP
+FROM demo_state state, "StorefrontConfig" config, "StorefrontArchetype" archetype
+WHERE booking."bookingRef" = 'demo-restaurant-bk-' || state.booking_index
+  AND config.id = booking."storefrontId"
+  AND archetype.id = config."archetypeId"
+  AND archetype."archetypeId" = 'restaurant';
+
+WITH turn_state AS (
+  SELECT * FROM (VALUES
+    (2, 'ordered', INTERVAL '-55 minutes',  INTERVAL '35 minutes', 1),
+    (3, 'dirty',   INTERVAL '-100 minutes', INTERVAL '-10 minutes', 1),
+    (4, 'ordered', INTERVAL '-50 minutes',  INTERVAL '40 minutes', 1),
+    (5, 'paid',    INTERVAL '-84 minutes',  INTERVAL '6 minutes',  2),
+    (6, 'seated',  INTERVAL '-102 minutes', INTERVAL '-12 minutes', 1)
+  ) AS state(booking_index, stage, started_offset, end_offset, section_index)
+)
+UPDATE "HospitalityServiceTurn" turn
+SET
+  "staffingAssignmentId" = assignment.id,
+  stage = state.stage,
+  "startedAt" = CURRENT_TIMESTAMP + state.started_offset,
+  "expectedEndAt" = CURRENT_TIMESTAMP + state.end_offset,
+  "closedAt" = NULL,
+  version = turn.version + 1,
+  "updatedAt" = CURRENT_TIMESTAMP
+FROM turn_state state
+JOIN "StaffingAssignment" assignment
+  ON assignment."assignmentId" = 'demo-restaurant-assignment-' || state.section_index
+WHERE turn."turnId" = 'demo-restaurant-turn-' || state.booking_index;
+
+UPDATE "HospitalityCapacityAllocation" allocation
+SET
+  lifecycle = 'released',
+  "releasedAt" = CURRENT_TIMESTAMP,
+  "releaseReason" = 'Restaurant demo busy shift refreshed',
+  version = allocation.version + 1,
+  "updatedAt" = CURRENT_TIMESTAMP
+FROM "StorefrontBooking" booking
+WHERE allocation."bookingId" = booking.id
+  AND booking."bookingRef" ~ '^demo-restaurant-bk-[0-6]$'
+  AND allocation.lifecycle IN ('reserved', 'active');
+
+WITH turn_tables AS (
+  SELECT * FROM (VALUES
+    (2, 'demo-restaurant-table-2'),
+    (3, 'demo-restaurant-table-3'),
+    (4, 'demo-restaurant-table-5'),
+    (4, 'demo-restaurant-table-6'),
+    (5, 'demo-restaurant-table-7'),
+    (6, 'demo-restaurant-table-8')
+  ) AS mapping(booking_index, resource_ref)
+)
+INSERT INTO "HospitalityCapacityAllocation" (
+  id, "allocationId", "organizationId", "storefrontId", "resourceId",
+  "bookingId", "serviceTurnId", "demandType", "demandRef", "startsAt",
+  "endsAt", quantity, lifecycle, "idempotencyKey", version, "createdAt", "updatedAt"
+)
+SELECT
+  'demo_restaurant_allocation_' || mapping.booking_index || '_' || resource."resourceId",
+  'demo-restaurant-turn-' || mapping.booking_index || '-' || replace(resource."resourceId", 'demo-restaurant-', ''),
+  booking."organizationId", booking."storefrontId", resource.id,
+  booking.id, turn.id, 'booking', booking."bookingRef",
+  turn."startedAt", turn."expectedEndAt", 1, 'active',
+  'demo-restaurant-turn-' || mapping.booking_index || '-' || resource."resourceId" || ':active',
+  1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM turn_tables mapping
+JOIN "StorefrontBooking" booking
+  ON booking."bookingRef" = 'demo-restaurant-bk-' || mapping.booking_index
+JOIN "HospitalityServiceTurn" turn
+  ON turn."turnId" = 'demo-restaurant-turn-' || mapping.booking_index
+JOIN "HospitalityResource" resource
+  ON resource."storefrontId" = booking."storefrontId"
+  AND resource."resourceId" = mapping.resource_ref
+ON CONFLICT ("allocationId") DO UPDATE SET
+  "resourceId" = EXCLUDED."resourceId",
+  "serviceTurnId" = EXCLUDED."serviceTurnId",
+  "startsAt" = EXCLUDED."startsAt",
+  "endsAt" = EXCLUDED."endsAt",
+  lifecycle = 'active',
+  "releasedAt" = NULL,
+  "releaseReason" = NULL,
+  version = "HospitalityCapacityAllocation".version + 1,
+  "updatedAt" = CURRENT_TIMESTAMP;
+
+INSERT INTO "HospitalityCapacityAllocation" (
+  id, "allocationId", "organizationId", "storefrontId", "resourceId",
+  "bookingId", "demandType", "demandRef", "startsAt", "endsAt",
+  quantity, lifecycle, "idempotencyKey", version, "createdAt", "updatedAt"
+)
+SELECT
+  'demo_restaurant_reservation_table_9',
+  'demo-restaurant-reservation-table-9',
+  booking."organizationId", booking."storefrontId", resource.id,
+  booking.id, 'booking', booking."bookingRef", booking."scheduledAt",
+  booking."scheduledAt" + INTERVAL '90 minutes', 1, 'reserved',
+  'demo-restaurant-reservation-table-9:reserved', 1,
+  CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM "StorefrontBooking" booking
+JOIN "HospitalityResource" resource
+  ON resource."storefrontId" = booking."storefrontId"
+  AND resource."resourceId" = 'demo-restaurant-table-9'
+WHERE booking."bookingRef" = 'demo-restaurant-bk-1'
+ON CONFLICT ("allocationId") DO UPDATE SET
+  "resourceId" = EXCLUDED."resourceId",
+  "startsAt" = EXCLUDED."startsAt",
+  "endsAt" = EXCLUDED."endsAt",
+  lifecycle = 'reserved',
+  "releasedAt" = NULL,
+  "releaseReason" = NULL,
+  version = "HospitalityCapacityAllocation".version + 1,
+  "updatedAt" = CURRENT_TIMESTAMP;

--- a/packages/db/src/restaurant-demo-floor-migration.test.ts
+++ b/packages/db/src/restaurant-demo-floor-migration.test.ts
@@ -99,7 +99,13 @@ describe("restaurant demo floor migration", () => {
 
   it("fails closed before the refresh when a reserved demo identifier belongs to other data", () => {
     expect(busyShiftGuardPath).toContain("20260812102900_guard_restaurant_demo_busy_shift");
+    expect(busyShiftGuardPath.localeCompare(busyShiftRefreshPath)).toBeLessThan(0);
     expect(busyShiftGuardSql.match(/RAISE EXCEPTION/g)).toHaveLength(5);
+    for (const reservedKind of ["booking", "shift", "assignment", "turn", "allocation"]) {
+      expect(busyShiftGuardSql).toContain(
+        `Reserved Restaurant demo ${reservedKind} identifiers are attached to non-demo data`,
+      );
+    }
     expect(busyShiftGuardSql).toContain("^demo-restaurant-bk-[0-6]$");
     expect(busyShiftGuardSql).toContain("^demo-restaurant-turn-[2-6]$");
     expect(busyShiftGuardSql).toContain("archetype.\"archetypeId\" = 'restaurant'");

--- a/packages/db/src/restaurant-demo-floor-migration.test.ts
+++ b/packages/db/src/restaurant-demo-floor-migration.test.ts
@@ -24,6 +24,13 @@ const bookingCapacityMigrationPath = fileURLToPath(
   ),
 );
 const bookingCapacitySql = readFileSync(bookingCapacityMigrationPath, "utf8");
+const busyShiftRefreshPath = fileURLToPath(
+  new URL(
+    "../prisma/migrations/20260812103000_refresh_restaurant_demo_busy_shift/migration.sql",
+    import.meta.url,
+  ),
+);
+const busyShiftRefreshSql = readFileSync(busyShiftRefreshPath, "utf8");
 
 describe("restaurant demo floor migration", () => {
   it("targets only platform-owned demo restaurant rows", () => {
@@ -66,5 +73,15 @@ describe("restaurant demo floor migration", () => {
     expect(bookingCapacitySql).toContain("^demo-restaurant-prov-res-[0-8]$");
     expect(bookingCapacitySql).toContain("archetype.\"archetypeId\" = 'restaurant'");
     expect(bookingCapacitySql).toContain('DELETE FROM "ProviderService"');
+  });
+
+  it("keeps only the Restaurant demo roster durable and restores its busy-shift state", () => {
+    expect(busyShiftRefreshSql).toContain("TIMESTAMPTZ '2100-01-01 00:00:00+00'");
+    expect(busyShiftRefreshSql).toContain("^demo-restaurant-bk-[0-6]$");
+    expect(busyShiftRefreshSql).toContain("archetype.\"archetypeId\" = 'restaurant'");
+    expect(busyShiftRefreshSql).toContain("Restaurant demo busy shift refreshed");
+    expect(busyShiftRefreshSql).toContain("(4, 'demo-restaurant-table-5')");
+    expect(busyShiftRefreshSql).toContain("(4, 'demo-restaurant-table-6')");
+    expect(busyShiftRefreshSql).not.toMatch(/DELETE FROM \"HospitalityCapacityAllocation\"/);
   });
 });

--- a/packages/db/src/restaurant-demo-floor-migration.test.ts
+++ b/packages/db/src/restaurant-demo-floor-migration.test.ts
@@ -31,6 +31,13 @@ const busyShiftRefreshPath = fileURLToPath(
   ),
 );
 const busyShiftRefreshSql = readFileSync(busyShiftRefreshPath, "utf8");
+const busyShiftGuardPath = fileURLToPath(
+  new URL(
+    "../prisma/migrations/20260812102900_guard_restaurant_demo_busy_shift/migration.sql",
+    import.meta.url,
+  ),
+);
+const busyShiftGuardSql = readFileSync(busyShiftGuardPath, "utf8");
 
 describe("restaurant demo floor migration", () => {
   it("targets only platform-owned demo restaurant rows", () => {
@@ -80,8 +87,23 @@ describe("restaurant demo floor migration", () => {
     expect(busyShiftRefreshSql).toContain("^demo-restaurant-bk-[0-6]$");
     expect(busyShiftRefreshSql).toContain("archetype.\"archetypeId\" = 'restaurant'");
     expect(busyShiftRefreshSql).toContain("Restaurant demo busy shift refreshed");
+    expect(busyShiftRefreshSql).toContain("(0, 'waiting',   INTERVAL '0 minutes',    INTERVAL '-14 minutes')");
+    expect(busyShiftRefreshSql).toContain("(1, 'confirmed', INTERVAL '9 minutes',    INTERVAL '-120 minutes')");
+    expect(busyShiftRefreshSql).toContain("(3, 'dirty',   INTERVAL '-100 minutes', INTERVAL '-10 minutes', 1)");
+    expect(busyShiftRefreshSql).toContain("(5, 'paid',    INTERVAL '-84 minutes',  INTERVAL '6 minutes',  2)");
     expect(busyShiftRefreshSql).toContain("(4, 'demo-restaurant-table-5')");
     expect(busyShiftRefreshSql).toContain("(4, 'demo-restaurant-table-6')");
+    expect(busyShiftRefreshSql).toContain("'demo-restaurant-reservation-table-9'");
     expect(busyShiftRefreshSql).not.toMatch(/DELETE FROM \"HospitalityCapacityAllocation\"/);
+  });
+
+  it("fails closed before the refresh when a reserved demo identifier belongs to other data", () => {
+    expect(busyShiftGuardPath).toContain("20260812102900_guard_restaurant_demo_busy_shift");
+    expect(busyShiftGuardSql.match(/RAISE EXCEPTION/g)).toHaveLength(5);
+    expect(busyShiftGuardSql).toContain("^demo-restaurant-bk-[0-6]$");
+    expect(busyShiftGuardSql).toContain("^demo-restaurant-turn-[2-6]$");
+    expect(busyShiftGuardSql).toContain("archetype.\"archetypeId\" = 'restaurant'");
+    expect(busyShiftGuardSql).toContain("booking.\"organizationId\" = allocation.\"organizationId\"");
+    expect(busyShiftGuardSql).toContain("booking.\"storefrontId\" = allocation.\"storefrontId\"");
   });
 });

--- a/packages/db/src/restaurant-demo-floor-migration.test.ts
+++ b/packages/db/src/restaurant-demo-floor-migration.test.ts
@@ -38,6 +38,13 @@ const busyShiftGuardPath = fileURLToPath(
   ),
 );
 const busyShiftGuardSql = readFileSync(busyShiftGuardPath, "utf8");
+const busyShiftResourceGuardPath = fileURLToPath(
+  new URL(
+    "../prisma/migrations/20260812102930_guard_restaurant_demo_resources/migration.sql",
+    import.meta.url,
+  ),
+);
+const busyShiftResourceGuardSql = readFileSync(busyShiftResourceGuardPath, "utf8");
 
 describe("restaurant demo floor migration", () => {
   it("targets only platform-owned demo restaurant rows", () => {
@@ -111,5 +118,18 @@ describe("restaurant demo floor migration", () => {
     expect(busyShiftGuardSql).toContain("archetype.\"archetypeId\" = 'restaurant'");
     expect(busyShiftGuardSql).toContain("booking.\"organizationId\" = allocation.\"organizationId\"");
     expect(busyShiftGuardSql).toContain("booking.\"storefrontId\" = allocation.\"storefrontId\"");
+  });
+
+  it("fails closed before refresh when a reserved table is not the exact demo provider resource", () => {
+    expect(busyShiftGuardPath.localeCompare(busyShiftResourceGuardPath)).toBeLessThan(0);
+    expect(busyShiftResourceGuardPath.localeCompare(busyShiftRefreshPath)).toBeLessThan(0);
+    expect(busyShiftResourceGuardSql).toContain("'demo-restaurant-table-1', 'demo-restaurant-prov-res-0'");
+    expect(busyShiftResourceGuardSql).toContain("'demo-restaurant-table-9', 'demo-restaurant-prov-res-8'");
+    expect(busyShiftResourceGuardSql).toContain("provider.\"storefrontId\" = resource.\"storefrontId\"");
+    expect(busyShiftResourceGuardSql).toContain("config.\"organizationId\" = resource.\"organizationId\"");
+    expect(busyShiftResourceGuardSql).toContain("archetype.\"archetypeId\" = 'restaurant'");
+    expect(busyShiftResourceGuardSql).toContain(
+      "Reserved Restaurant demo table identifiers are attached to non-demo data",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- keep the authored Restaurant demo floor busy beyond a one-year date horizon and refresh it forward-only with realistic waiting, reserved, ordered, dirty, paid, combined-table, and server-section state
- fail closed when reserved demo IDs collide with customer data or table/provider/storefront/archetype relationships drift
- refresh stale seating/move choices after conflicts with an accessible assertive notice
- use the semantic archetype key for Restaurant operating hours and the shared client operation ID fallback for LAN guest bookings

## Design grounding
- Design-Grounding-Decision: existing-substrate
- Operational-Precedent: restaurant-floor
- Plan: `docs/superpowers/plans/2026-08-12-restaurant-live-acceptance-defects.md`
- Reuses the Restaurant floor host-console and shared client-operation-id contracts; no parallel navigation or interaction substrate.

## Verification
- Fresh semantic review: `cmsq46hiv003801rirqhrybly` (zero findings, shadow `mayPublish=true`)
- Exact local-CI: `ed00a912b974ae09dc41d01a5e83ffacf71d5613`
- Evidence: `cmsq50y7p015t01o0egyckpb4`
- 2,681 test files passed; 22,875 tests passed (4 files / 20 tests skipped, 18 todo)
- typecheck passed
- all migrations applied cleanly
- docs and 25 policy guards passed
- production OCI build and smoke passed (`sha256:76d99e618cfd27e853975c5e4db9e7310b54990e91dcfef6a239b03d0282ae41`)

## Documentation impact
No user documentation change is needed: this repairs the seeded Restaurant runtime state, conflict recovery behavior, and existing operating-hours/booking contracts without changing routes or operator workflow.

Signed-off-by: dpf-ci <dpf-ci@users.noreply.github.com>