### PR TITLE
fix(ui): guard crypto.randomUUID on LAN-hosted HTTP installs (BI-2C956715)

### DIFF
--- a/apps/web/components/employee/EmployeeFormPanel.tsx
+++ b/apps/web/components/employee/EmployeeFormPanel.tsx
@@ -13,6 +13,7 @@ import {
 import type { WorkforceStatus, EmployeeProfileRecord, EmployeeProfileInput } from "@/lib/workforce-types";
 import type { AddressWithHierarchy } from "@/lib/address-types";
 import AddressSection from "@/components/employee/AddressSection";
+import { createClientOperationId } from "@/lib/client-operation-id";
 import { DatePicker } from "@/components/ui/DatePicker";
 import { EmailInput } from "@/components/ui/EmailInput";
 import { PhoneInput } from "@/components/ui/PhoneInput";
@@ -35,13 +36,15 @@ type Props = {
 
 function generateEmployeeId(): string {
   const ts = Date.now().toString(36).toUpperCase();
-  // CodeQL alert #72 (js/insecure-randomness): Math.random() is not
-  // cryptographically secure. The employee ID is a display string, not
-  // a secret — but using crypto.randomUUID() removes the alert AND
-  // prevents accidental copy-paste of this generator into a security
-  // context later. The 4-char slice keeps the same human-readable ID
-  // shape ("EMP-LXAB123-WXYZ").
-  const rand = globalThis.crypto.randomUUID().replace(/-/g, "").slice(0, 4).toUpperCase();
+  // Secure randomness without a secure-context requirement. The bare
+  // globalThis.crypto.randomUUID() used to throw ("randomUUID is not a
+  // function") on the LAN-hosted HTTP installs DPF supports — randomUUID is
+  // secure-context-only, so opening the portal over http://<lan-ip> crashed the
+  // whole People page. createClientOperationId() prefers randomUUID and falls
+  // back to getRandomValues (still cryptographically secure, no CodeQL
+  // js/insecure-randomness alert). The 4-char slice keeps the same
+  // human-readable ID shape ("EMP-LXAB123-WXYZ").
+  const rand = createClientOperationId().replace(/-/g, "").slice(0, 4).toUpperCase();
   return `EMP-${ts}-${rand}`;
 }
 

--- a/apps/web/components/healthcare/PatientIntakeRunner.tsx
+++ b/apps/web/components/healthcare/PatientIntakeRunner.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react
 import Link from "next/link";
 
 import { Notice, StatusBadge } from "@/components/ui/report-kit";
+import { createClientOperationId } from "@/lib/client-operation-id";
 import type { FormFieldDefinition } from "@dpf/types";
 
 type IntakeForm = {
@@ -179,7 +180,7 @@ export function PatientIntakeRunner({ packetId }: { packetId: string }) {
         method: "PUT",
         headers: { "content-type": "application/json", "x-intake-resume-token": grant.token },
         body: JSON.stringify({
-          idempotencyKey: crypto.randomUUID(), expectedVersion: versions[form.formId] ?? null,
+          idempotencyKey: createClientOperationId(), expectedVersion: versions[form.formId] ?? null,
           sourceMode: "patient-web", answers: formAnswers, dataCategories: form.dataCategories,
         }),
       });


### PR DESCRIPTION
## What

`globalThis.crypto.randomUUID()` is **secure-context-only**. Two client components called it unguarded, so opening the portal over a non-localhost HTTP origin (`http://<lan-ip>:3000` — an insecure context where `crypto` exists but `randomUUID` does not) threw `globalThis.crypto.randomUUID is not a function` and dropped the whole page into the error boundary.

Reported from the live install: the **People** (`/employee`) page showing *"Something went wrong — globalThis.crypto.randomUUID is not a function"*.

- `EmployeeFormPanel.generateEmployeeId()` → crashed the entire People page (runs when the new-employee form initializes).
- `PatientIntakeRunner` `idempotencyKey` → crashed patient-intake submit.

## Fix

Both sites now reuse **`createClientOperationId()`** (`apps/web/lib/client-operation-id.ts`), which prefers `randomUUID` and falls back to `getRandomValues` — still a cryptographically secure RNG, available **without** a secure context (so no CodeQL `js/insecure-randomness` alert). That helper was built for exactly "the LAN-hosted HTTP installs DPF supports" and is already used by `SlotBookingFlow`; these two sites were simply missed. Sibling call sites (`EaCanvas`, `Grid`) were already guarded.

## Scope / provenance

Pre-existing since **2026-05-22** (`9df95fafc85`); **unrelated to #4210** — surfaced only because the portal was opened over a non-localhost origin.

## Verification

- `pnpm --filter web typecheck` — green (after `prisma generate`).
- Helper already has unit coverage including the insecure-context `getRandomValues` path (`apps/web/lib/client-operation-id.test.ts`).

## Design grounding

Design-Grounding-Decision: no-contract-change (routes two client call sites through the existing createClientOperationId helper; no routing, UX, or contract change; source of truth is apps/web/lib/client-operation-id.ts)

Closes BI-2C956715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)