### PR TITLE
fix(test): unbreak portal-migrate-boot portable watchdog on macOS

### DIFF
--- a/apps/web/lib/self-upgrade/portal-migrate-boot.test.ts
+++ b/apps/web/lib/self-upgrade/portal-migrate-boot.test.ts
@@ -24,6 +24,21 @@ const BASH_PROBE = spawnSync("bash", ["-lc", "printf '%s' \"$PWD\""], {
 const BASH_OK = BASH_PROBE.status === 0;
 const BASH_PWD = BASH_PROBE.stdout?.trim() ?? "";
 
+// The portable process-group watchdog (used when GNU `timeout` is absent, e.g.
+// stock macOS) times itself with its own `sleep`. But makeFakeBin() puts an
+// instant fake `sleep` on PATH to neutralize the SCRIPT's retry `sleep 3`, and
+// that fake shadows the watchdog's `sleep` too — so the watchdog fires at 0s and
+// SIGTERMs a healthy boot before it can exit. Resolve the REAL `sleep` once (in
+// an unmodified PATH) and invoke it by absolute path in the watchdog so the fake
+// only affects the script it was meant for. On Linux/Git Bash the native
+// `timeout` path runs instead, so this value is unused there.
+const SLEEP_PROBE = spawnSync("sh", ["-lc", "command -v sleep"], {
+  encoding: "utf8",
+  timeout: 2_000,
+});
+const REAL_SLEEP =
+  SLEEP_PROBE.status === 0 && SLEEP_PROBE.stdout?.trim() ? SLEEP_PROBE.stdout.trim() : "/bin/sleep";
+
 function toBashPath(value: string): string {
   if (process.platform !== "win32") return value;
   const normalized = value.replace(/\\/g, "/");
@@ -86,9 +101,12 @@ function run(opts: {
     "else",
     "  set -m",
     `  ${bootCommand} & boot_pid=$!`,
-    `  ( sleep ${timeoutSeconds}; kill -TERM -$boot_pid 2>/dev/null || kill -TERM $boot_pid 2>/dev/null; sleep 1; kill -KILL -$boot_pid 2>/dev/null || true ) & watchdog_pid=$!`,
+    `  ( ${q(toBashPath(REAL_SLEEP))} ${timeoutSeconds}; kill -TERM -$boot_pid 2>/dev/null || kill -TERM $boot_pid 2>/dev/null; ${q(toBashPath(REAL_SLEEP))} 1; kill -KILL -$boot_pid 2>/dev/null || true ) & watchdog_pid=$!`,
     "  wait $boot_pid; boot_status=$?",
-    "  kill $watchdog_pid 2>/dev/null || true",
+    // Kill the watchdog's whole process group (set -m gave it its own), not just
+    // the subshell: otherwise its real `sleep` is orphaned, keeps the stdout pipe
+    // open, and stalls spawnSync for the full timeout after a healthy boot exits.
+    "  kill -TERM -$watchdog_pid 2>/dev/null || kill -TERM $watchdog_pid 2>/dev/null || true",
     "  wait $watchdog_pid 2>/dev/null || true",
     '  [ "$boot_status" -ge 128 ] && exit 124',
     '  exit "$boot_status"',


### PR DESCRIPTION
## Problem

`apps/web/lib/self-upgrade/portal-migrate-boot.test.ts` failed **deterministically (5/8 cases)** on macOS local-CI hosts, blocking the pre-push local-CI gate for any macOS contributor whose branch is current with `origin/main`. Introduced by #4232.

## Real root cause (deeper than the symptom)

The symptom points at the GNU-`timeout` watchdog line, but **stock macOS has no `timeout` binary at all**, so the test actually runs the *portable process-group watchdog* branch.

`makeFakeBin()` installs an instant fake `sleep` on `PATH` to neutralize the **script's** retry `sleep 3`. But that fake also shadows the **watchdog's own** timing `sleep` — so the watchdog fires at **0s** and SIGTERMs a healthy boot subprocess before it can exit 0. Assertions like `expect(r.status).toBe(0)` and `toContain("BOOT_MARKER")` then fail with status 124/143.

Linux and Git Bash never hit this: they have GNU `timeout`, which does its own internal timing and ignores the fake `sleep`. That's why #4232 merged green on Linux CI — this is a host-portability bug, not a logic bug.

Proof the fake `sleep` shadows the watchdog:
```
$ export PATH=/fakebin-with-instant-sleep:$PATH
$ ( sleep 3; echo "fired at $(date +%s)" ) &   # fires at the same second it starts
```

Note: none of the originally-proposed fixes would have worked — (a) and (b) route *to* the broken portable path, and (c) only drops macOS coverage.

## Fix (test-only, native `timeout` branch untouched)

1. Resolve the **real** `sleep` once in an unmodified PATH (mirrors the existing `BASH_PROBE`) and invoke it by absolute path in the watchdog, so the fake `sleep` only affects the script it was meant for.
2. Kill the watchdog's **whole process group** (`set -m` already gives it one) on healthy-boot cleanup — otherwise its real `sleep` is orphaned, holds the stdout pipe open, and stalls `spawnSync` for the full timeout (a healthy run would take ~64s instead of ~3s).

## Verification

Ran `pnpm --filter web exec vitest run lib/self-upgrade/portal-migrate-boot.test.ts` on macOS:

- **Before:** `5 failed | 3 passed (8)`
- **After:** `8 passed (8)` in ~3s, **deterministic across 3 repeated runs**

Full `apps/web` typecheck passes clean; local-CI merge gate passed against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)