### PR TITLE
fix(restaurant): preserve completed demo turns

### DIFF
--- a/apps/web/lib/twin/restaurant-floor-command.server.test.ts
+++ b/apps/web/lib/twin/restaurant-floor-command.server.test.ts
@@ -198,6 +198,35 @@ describe("restaurant floor command adapter", () => {
     });
   });
 
+  it("fails closed when a refreshed demand still owns a terminal service turn", async () => {
+    const { database, tx } = fixture();
+    const allocateCapacity = vi.fn();
+    const adapter = createRestaurantFloorCommandAdapter({
+      database,
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      actorRef: "employee-1",
+      dependencies: {
+        createTurn: vi.fn().mockResolvedValue({
+          id: "turn-closed",
+          turnId: "HT-CLOSED",
+          stage: "closed",
+          version: 6,
+        }),
+        allocateCapacity,
+        transitionCapacity: vi.fn(),
+      },
+    });
+
+    await expect(adapter.executeAtomically(command())).resolves.toEqual({
+      status: "rejected",
+      reasonCode: "demand-turn-terminal",
+      message: "This party already completed service. Refresh the floor before seating another party.",
+    });
+    expect(allocateCapacity).not.toHaveBeenCalled();
+    expect(tx.storefrontBooking.updateMany).not.toHaveBeenCalled();
+  });
+
   it("returns a version conflict before any write when facts changed", async () => {
     const { database } = fixture();
     const createTurn = vi.fn();

--- a/apps/web/lib/twin/restaurant-floor-command.server.ts
+++ b/apps/web/lib/twin/restaurant-floor-command.server.ts
@@ -96,6 +96,7 @@ const SEATABLE_DEMAND_STATUSES = new Set([
   "pending",
 ]);
 const ACTIVE_STAFFING_LIFECYCLES = new Set(["confirmed", "on_site"]);
+const TERMINAL_SERVICE_TURN_STAGES = new Set(["closed", "cancelled"]);
 
 function fingerprint(command: OperationalAssignmentCommand): string {
   return JSON.stringify({
@@ -226,6 +227,7 @@ class RestaurantCommandRollback extends Error {
 function serviceTurnRecord(value: unknown): {
   id: string;
   turnId: string;
+  stage: string;
   version: number;
 } {
   if (
@@ -233,9 +235,11 @@ function serviceTurnRecord(value: unknown): {
     value === null ||
     !("id" in value) ||
     !("turnId" in value) ||
+    !("stage" in value) ||
     !("version" in value) ||
     typeof value.id !== "string" ||
     typeof value.turnId !== "string" ||
+    typeof value.stage !== "string" ||
     typeof value.version !== "number"
   ) {
     throw new Error("Hospitality service turn persistence returned no identity");
@@ -243,6 +247,7 @@ function serviceTurnRecord(value: unknown): {
   return {
     id: value.id,
     turnId: value.turnId,
+    stage: value.stage,
     version: value.version,
   };
 }
@@ -516,6 +521,12 @@ export function createRestaurantFloorCommandAdapter(input: {
               },
             }),
           );
+          if (TERMINAL_SERVICE_TURN_STAGES.has(turn.stage)) {
+            return rejected(
+              "demand-turn-terminal",
+              "This party already completed service. Refresh the floor before seating another party.",
+            );
+          }
 
           for (const resourceId of assignmentCommand.entityRefs.resourceIds) {
             const existing = allocations.find(

--- a/docs/data-impact/2026-08-12-restaurant-demo-actionable-walk-in.data-impact.json
+++ b/docs/data-impact/2026-08-12-restaurant-demo-actionable-walk-in.data-impact.json
@@ -1,0 +1,27 @@
+{
+  "processSpineDecision": "Localized Restaurant demo integrity repair and command fail-closed guard; no process-spine, route, or operator-documentation contract changed.",
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "The platform-owned Restaurant demo preserves its completed demo walk-in service-turn and event history while releasing only allocations that still point at that terminal turn.",
+    "A fresh demo-only walk-in demand is derived from the existing Restaurant fixture so the canonical host stand remains actionable without reopening a completed service-turn aggregate.",
+    "The seating command rejects a demand whose canonical service turn is already closed or cancelled before allocating capacity or updating its booking.",
+    "Operator-owned bookings, turns, events, allocations, tables, staffing, and customer data remain outside the exact reserved demo identifiers and Restaurant-archetype guard."
+  ],
+  "migration": {
+    "name": "20260812152000_repair_restaurant_demo_actionable_walk_in",
+    "backfill": "Data-only and demo-scoped. The migration fails closed if either new reserved identifier is attached to non-demo data, releases any active allocation linked to the terminal demo walk-in turn, preserves that turn and its events, and inserts one fresh waiting demand only when the original demo walk-in has a closed or cancelled turn."
+  },
+  "tests": [
+    "packages/db/src/restaurant-demo-floor-migration.test.ts",
+    "apps/web/lib/twin/restaurant-floor-command.server.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "projection",
+      "derivedContractId": "projection:restaurant-demo-actionable-walk-in",
+      "cleanupTest": "restaurant-demo-floor-migration.test.ts asserts terminal history is retained, stale terminal allocation is released, and a fresh waiting booking is inserted behind exact demo guards.",
+      "reconciliationTest": "restaurant-floor-command.server.test.ts proves a terminal service turn cannot receive new seating capacity or booking writes."
+    }
+  ]
+}

--- a/packages/db/prisma/migrations/20260812152000_repair_restaurant_demo_actionable_walk_in/migration.sql
+++ b/packages/db/prisma/migrations/20260812152000_repair_restaurant_demo_actionable_walk_in/migration.sql
@@ -1,0 +1,99 @@
+-- A previously exercised demo walk-in can have a terminal service turn. The
+-- busy-shift refresh must not reopen that historical aggregate or attach new
+-- capacity to it. Preserve the history, release any stale terminal allocation,
+-- and mint one fresh demo demand for the canonical host-stand acceptance path.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "StorefrontBooking" booking
+    WHERE (
+      booking.id = 'demo_restaurant_booking_live_1'
+      OR booking."bookingRef" = 'demo-restaurant-bk-live-1'
+    )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "StorefrontConfig" config
+        JOIN "StorefrontArchetype" archetype ON archetype.id = config."archetypeId"
+        WHERE config.id = booking."storefrontId"
+          AND config."organizationId" = booking."organizationId"
+          AND archetype."archetypeId" = 'restaurant'
+          AND booking.id = 'demo_restaurant_booking_live_1'
+          AND booking."bookingRef" = 'demo-restaurant-bk-live-1'
+      )
+  ) THEN
+    RAISE EXCEPTION 'Reserved Restaurant demo live walk-in identifiers are attached to non-demo data';
+  END IF;
+END $$;
+
+UPDATE "HospitalityCapacityAllocation" allocation
+SET
+  lifecycle = 'released',
+  "releasedAt" = CURRENT_TIMESTAMP,
+  "releaseReason" = 'Restaurant demo stale terminal allocation released',
+  version = allocation.version + 1,
+  "updatedAt" = CURRENT_TIMESTAMP
+FROM "StorefrontBooking" booking
+JOIN "HospitalityServiceTurn" turn
+  ON turn."bookingId" = booking.id
+  AND turn."organizationId" = booking."organizationId"
+WHERE booking."bookingRef" = 'demo-restaurant-bk-0'
+  AND turn.stage IN ('closed', 'cancelled')
+  AND allocation."bookingId" = booking.id
+  AND allocation."serviceTurnId" = turn.id
+  AND allocation.lifecycle IN ('reserved', 'active');
+
+INSERT INTO "StorefrontBooking" (
+  id, "bookingRef", "storefrontId", "itemId", "customerContactId",
+  "customerEmail", "customerName", "customerPhone", "scheduledAt",
+  "durationMinutes", notes, status, "createdAt", "updatedAt",
+  "assignmentMode", "cancellationReason", "cancelledAt", "fromReschedule",
+  "idempotencyKey", "parentBookingId", "providerId", "recurrenceEndDate",
+  "recurrenceRule", "overlapQuarantinedAt", "organizationId", covers,
+  "dietaryNotes", "hospitalityResourceId", "demandKind"
+)
+SELECT
+  'demo_restaurant_booking_live_1',
+  'demo-restaurant-bk-live-1',
+  booking."storefrontId",
+  booking."itemId",
+  booking."customerContactId",
+  booking."customerEmail",
+  booking."customerName",
+  booking."customerPhone",
+  CURRENT_TIMESTAMP,
+  90,
+  NULL,
+  'waiting',
+  CURRENT_TIMESTAMP - INTERVAL '14 minutes',
+  CURRENT_TIMESTAMP,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  booking."organizationId",
+  3,
+  NULL,
+  NULL,
+  'walk-in'
+FROM "StorefrontBooking" booking
+JOIN "StorefrontConfig" config ON config.id = booking."storefrontId"
+JOIN "StorefrontArchetype" archetype ON archetype.id = config."archetypeId"
+WHERE booking."bookingRef" = 'demo-restaurant-bk-0'
+  AND config."organizationId" = booking."organizationId"
+  AND archetype."archetypeId" = 'restaurant'
+  AND EXISTS (
+    SELECT 1
+    FROM "HospitalityServiceTurn" turn
+    WHERE turn."bookingId" = booking.id
+      AND turn."organizationId" = booking."organizationId"
+      AND turn.stage IN ('closed', 'cancelled')
+  )
+ON CONFLICT ("bookingRef") DO NOTHING;

--- a/packages/db/src/restaurant-demo-floor-migration.test.ts
+++ b/packages/db/src/restaurant-demo-floor-migration.test.ts
@@ -45,6 +45,13 @@ const busyShiftResourceGuardPath = fileURLToPath(
   ),
 );
 const busyShiftResourceGuardSql = readFileSync(busyShiftResourceGuardPath, "utf8");
+const actionableWalkInRepairPath = fileURLToPath(
+  new URL(
+    "../prisma/migrations/20260812152000_repair_restaurant_demo_actionable_walk_in/migration.sql",
+    import.meta.url,
+  ),
+);
+const actionableWalkInRepairSql = readFileSync(actionableWalkInRepairPath, "utf8");
 
 describe("restaurant demo floor migration", () => {
   it("targets only platform-owned demo restaurant rows", () => {
@@ -131,5 +138,14 @@ describe("restaurant demo floor migration", () => {
     expect(busyShiftResourceGuardSql).toContain(
       "Reserved Restaurant demo table identifiers are attached to non-demo data",
     );
+  });
+
+  it("preserves a completed demo turn and creates a fresh actionable walk-in", () => {
+    expect(actionableWalkInRepairSql).toContain("demo-restaurant-bk-live-1");
+    expect(actionableWalkInRepairSql).toContain("stage IN ('closed', 'cancelled')");
+    expect(actionableWalkInRepairSql).toContain("Restaurant demo stale terminal allocation released");
+    expect(actionableWalkInRepairSql).toContain("INSERT INTO \"StorefrontBooking\"");
+    expect(actionableWalkInRepairSql).toContain("'waiting'");
+    expect(actionableWalkInRepairSql).not.toMatch(/DELETE FROM \"HospitalityServiceTurn(?:Event)?\"/);
   });
 });


### PR DESCRIPTION
## Summary
- preserve completed Restaurant demo service-turn and event history
- release stale allocations attached to a terminal demo turn and create a fresh actionable walk-in
- fail closed before capacity or booking writes when a refreshed demand resolves to a closed/cancelled turn

## Verification
- exact governed pregate: `4291d9371bbc4f2e69ee1f1c98caab7d0eed7e6e`
- evidence: `cmsqgnpnn01lc01p3yxt913fx`
- migrations, policy guards, typecheck, exhaustive Vitest, production OCI build, and smoke passed
- fresh semantic review: `cmsqd0rv4005d01o6nnrdkfza` (zero issues; shadow mayPublish)

## Live finding addressed
The canonical Restaurant host stand seated a fresh party into a reused closed service-turn. This change preserves the historical turn and gives the demo a new demand rather than reopening terminal history.

Process-Spine-Decision: localized Restaurant demo-state repair; no public contract or operator documentation changed