### PR TITLE
fix(db): make principal backfill collision-safe

### DIFF
--- a/changes/prepare-human-principal-backfill.data-impact.json
+++ b/changes/prepare-human-principal-backfill.data-impact.json
@@ -1,0 +1,35 @@
+{
+  "version": "1",
+  "accountableOwner": "Mark Bodman (markdbodman@gmail.com)",
+  "summary": "BI-2BD99239. Migration 20260812105900_prepare_human_principal_backfill projects the same existing User and EmployeeProfile identity data as the immutable 20260812110000 backfill, but correlates each source row by its stable identifier so shared email/displayName values cannot fan out into duplicate PrincipalAlias keys. It collects no new information, changes no source data, and is idempotent through the canonical alias key.",
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "Principal",
+      "lifecycleDisposition": "retain-for-party-lifetime",
+      "fields": [
+        {
+          "name": "displayName",
+          "resolution": "inherited",
+          "reason": "Copied from the existing User.email or EmployeeProfile.displayName for the same human; the repair changes correlation, not collection or governance.",
+          "provenance": "Existing install-local User or EmployeeProfile row selected by stable source identity.",
+          "flags": []
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "PrincipalAlias",
+      "lifecycleDisposition": "retain-for-party-lifetime",
+      "fields": [
+        {
+          "name": "aliasValue",
+          "resolution": "inherited",
+          "reason": "Canonical typed bridge to an existing User.id or EmployeeProfile.employeeId; no new identifier is introduced.",
+          "provenance": "Existing install-local User.id or EmployeeProfile.employeeId.",
+          "flags": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-08-12-human-principal-backfill-collision-repair.md
+++ b/docs/superpowers/plans/2026-08-12-human-principal-backfill-collision-repair.md
@@ -1,0 +1,18 @@
+# Human principal backfill collision repair
+
+Backlog coverage: `BI-2BD99239` · capsule `WC-53395A2B`.
+
+## Outcome
+
+Allow the canonical upgrade to apply the immutable human-principal backfill on installs where multiple people share an email label or display name, without deleting or rewriting source identity data.
+
+## Delivery
+
+1. Add a migration ordered immediately before the immutable failing migration. Project each missing `User` and unlinked `EmployeeProfile` by its stable source identifier, and attach linked employees to their user's principal.
+2. Add a database regression with duplicate email and display-name fixtures, then execute both the preparation and immutable migration to prove four unique aliases and preserved superuser clearance.
+3. Run focused tests, migration/data-impact guards, exact review and governed pregate; merge through the protected queue.
+4. Perform one normal self-upgrade, obtain exact `CAN-TEST`, then resume the blocked Restaurant deployment and live seating acceptance.
+
+## Documentation impact
+
+No user-facing workflow changes. The plan and data-impact manifest carry the operational and governance record; platform support documentation needs no new host-specific entry because this is data-shape independent.

--- a/packages/db/prisma/migrations/20260812105900_prepare_human_principal_backfill/migration.sql
+++ b/packages/db/prisma/migrations/20260812105900_prepare_human_principal_backfill/migration.sql
@@ -1,0 +1,134 @@
+-- @migration-safety: data-safe: additive identity projection only; no source
+-- row, existing Principal, alias, or sensitivity value is changed or removed.
+--
+-- BI-2BD99239. The immutable 20260812110000 backfill originally correlated
+-- inserted principals back to source rows through email/displayName. Those are
+-- labels, not stable identity: two valid people can share either value, making
+-- the join fan out and violate PrincipalAlias's canonical alias key. Prepare
+-- every missing alias one source row at a time, keyed by User.id or
+-- EmployeeProfile.employeeId, so the original migration becomes an idempotent
+-- no-op for these sections when it runs next.
+
+DO $$
+DECLARE
+  missing_user RECORD;
+  created_principal_id TEXT;
+  alias_rows INTEGER;
+BEGIN
+  FOR missing_user IN
+    SELECT app_user.id, app_user.email, app_user."isActive"
+    FROM "User" app_user
+    LEFT JOIN "PrincipalAlias" alias
+      ON alias."aliasType" = 'user'
+      AND alias."aliasValue" = app_user.id
+      AND alias.issuer = ''
+    WHERE alias.id IS NULL
+    ORDER BY app_user.id
+  LOOP
+    created_principal_id := gen_random_uuid()::text;
+
+    INSERT INTO "Principal" (
+      id, "principalId", kind, status, "displayName", "createdAt", "updatedAt"
+    ) VALUES (
+      created_principal_id,
+      'PRN-' || gen_random_uuid()::text,
+      'human',
+      CASE WHEN missing_user."isActive" THEN 'active' ELSE 'inactive' END,
+      missing_user.email,
+      now(),
+      now()
+    );
+
+    INSERT INTO "PrincipalAlias" (
+      id, "principalId", "aliasType", "aliasValue", issuer, "createdAt"
+    ) VALUES (
+      gen_random_uuid()::text,
+      created_principal_id,
+      'user',
+      missing_user.id,
+      '',
+      now()
+    )
+    ON CONFLICT ("aliasType", "aliasValue", issuer) DO NOTHING;
+
+    GET DIAGNOSTICS alias_rows = ROW_COUNT;
+    IF alias_rows = 0 THEN
+      DELETE FROM "Principal" WHERE id = created_principal_id;
+    END IF;
+  END LOOP;
+END $$;
+
+-- Employee profiles linked to a User inherit that User's Principal. Conflict
+-- handling makes a concurrent or already-complete alias harmless.
+INSERT INTO "PrincipalAlias" (
+  id, "principalId", "aliasType", "aliasValue", issuer, "createdAt"
+)
+SELECT
+  gen_random_uuid()::text,
+  user_alias."principalId",
+  'employee',
+  employee."employeeId",
+  '',
+  now()
+FROM "EmployeeProfile" employee
+JOIN "PrincipalAlias" user_alias
+  ON user_alias."aliasType" = 'user'
+  AND user_alias."aliasValue" = employee."userId"
+  AND user_alias.issuer = ''
+LEFT JOIN "PrincipalAlias" existing
+  ON existing."aliasType" = 'employee'
+  AND existing."aliasValue" = employee."employeeId"
+  AND existing.issuer = ''
+WHERE employee."userId" IS NOT NULL
+  AND existing.id IS NULL
+ON CONFLICT ("aliasType", "aliasValue", issuer) DO NOTHING;
+
+DO $$
+DECLARE
+  missing_employee RECORD;
+  created_principal_id TEXT;
+  alias_rows INTEGER;
+BEGIN
+  FOR missing_employee IN
+    SELECT employee."employeeId", employee."displayName", employee.status
+    FROM "EmployeeProfile" employee
+    LEFT JOIN "PrincipalAlias" alias
+      ON alias."aliasType" = 'employee'
+      AND alias."aliasValue" = employee."employeeId"
+      AND alias.issuer = ''
+    WHERE employee."userId" IS NULL
+      AND alias.id IS NULL
+    ORDER BY employee.id
+  LOOP
+    created_principal_id := gen_random_uuid()::text;
+
+    INSERT INTO "Principal" (
+      id, "principalId", kind, status, "displayName", "createdAt", "updatedAt"
+    ) VALUES (
+      created_principal_id,
+      'PRN-' || gen_random_uuid()::text,
+      'human',
+      CASE WHEN missing_employee.status = 'inactive' THEN 'inactive' ELSE 'active' END,
+      missing_employee."displayName",
+      now(),
+      now()
+    );
+
+    INSERT INTO "PrincipalAlias" (
+      id, "principalId", "aliasType", "aliasValue", issuer, "createdAt"
+    ) VALUES (
+      gen_random_uuid()::text,
+      created_principal_id,
+      'employee',
+      missing_employee."employeeId",
+      '',
+      now()
+    )
+    ON CONFLICT ("aliasType", "aliasValue", issuer) DO NOTHING;
+
+    GET DIAGNOSTICS alias_rows = ROW_COUNT;
+    IF alias_rows = 0 THEN
+      DELETE FROM "Principal" WHERE id = created_principal_id;
+    END IF;
+  END LOOP;
+END $$;

--- a/packages/db/src/human-principal-backfill-migration.test.ts
+++ b/packages/db/src/human-principal-backfill-migration.test.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+const schema = `human_principal_backfill_${randomUUID().replaceAll("-", "")}`;
+let client: Client;
+
+const collisionGuardPath = new URL(
+  "../prisma/migrations/20260812105900_prepare_human_principal_backfill/migration.sql",
+  import.meta.url,
+);
+const originalBackfillPath = new URL(
+  "../prisma/migrations/20260812110000_backfill_missing_human_principals/migration.sql",
+  import.meta.url,
+);
+
+describe("human principal backfill ordering", () => {
+  it("places an identity-safe preparation before the immutable live migration", async () => {
+    const collisionGuard = await readFile(collisionGuardPath, "utf8");
+
+    expect(collisionGuardPath.pathname).toContain("20260812105900_");
+    expect(collisionGuardPath.pathname.localeCompare(originalBackfillPath.pathname)).toBeLessThan(0);
+    expect(collisionGuard).toContain("FOR missing_user IN");
+    expect(collisionGuard).toContain("FOR missing_employee IN");
+    expect(collisionGuard).not.toMatch(/JOIN\s+"User"\s+\w+\s+ON\s+\w+\.email\s*=/i);
+    expect(collisionGuard).not.toMatch(/JOIN\s+"EmployeeProfile"\s+\w+\s+ON\s+\w+\."displayName"\s*=/i);
+  });
+});
+
+describeDatabase("human principal backfill migration", () => {
+  beforeAll(async () => {
+    client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+    await client.query(`CREATE SCHEMA "${schema}"`);
+    await client.query(`SET search_path TO "${schema}", public`);
+    await client.query(`
+      CREATE TYPE "PrincipalSensitivity" AS ENUM ('public', 'internal', 'confidential', 'restricted');
+      CREATE TABLE "User" (
+        id TEXT PRIMARY KEY,
+        email TEXT NOT NULL,
+        "isActive" BOOLEAN NOT NULL,
+        "isSuperuser" BOOLEAN NOT NULL
+      );
+      CREATE TABLE "EmployeeProfile" (
+        id TEXT PRIMARY KEY,
+        "employeeId" TEXT NOT NULL,
+        "displayName" TEXT NOT NULL,
+        status TEXT NOT NULL,
+        "userId" TEXT
+      );
+      CREATE TABLE "Principal" (
+        id TEXT PRIMARY KEY,
+        "principalId" TEXT NOT NULL UNIQUE,
+        kind TEXT NOT NULL,
+        status TEXT NOT NULL,
+        "displayName" TEXT NOT NULL,
+        "sensitivityClearance" "PrincipalSensitivity"[] NOT NULL DEFAULT ARRAY['public']::"PrincipalSensitivity"[],
+        "createdAt" TIMESTAMP NOT NULL,
+        "updatedAt" TIMESTAMP NOT NULL
+      );
+      CREATE TABLE "PrincipalAlias" (
+        id TEXT PRIMARY KEY,
+        "principalId" TEXT NOT NULL REFERENCES "Principal"(id),
+        "aliasType" TEXT NOT NULL,
+        "aliasValue" TEXT NOT NULL,
+        issuer TEXT NOT NULL,
+        "createdAt" TIMESTAMP NOT NULL
+      );
+      CREATE UNIQUE INDEX "PrincipalAlias_aliasType_aliasValue_issuer_key"
+        ON "PrincipalAlias"("aliasType", "aliasValue", issuer);
+
+      INSERT INTO "User" VALUES
+        ('user-a', 'shared@example.com', true, false),
+        ('user-b', 'shared@example.com', true, true);
+      INSERT INTO "EmployeeProfile" VALUES
+        ('employee-row-a', 'EMP-A', 'Shared Name', 'active', NULL),
+        ('employee-row-b', 'EMP-B', 'Shared Name', 'active', NULL);
+    `);
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+    await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await client.end();
+  });
+
+  it("prepares every duplicate-named source row before the immutable backfill runs", async () => {
+    const collisionGuard = await readFile(collisionGuardPath, "utf8");
+    const originalBackfill = await readFile(originalBackfillPath, "utf8");
+
+    await client.query(collisionGuard);
+    await client.query(originalBackfill);
+
+    const aliases = await client.query<{
+      aliasType: string;
+      aliasValue: string;
+      principalId: string;
+    }>(`
+      SELECT "aliasType", "aliasValue", "principalId"
+      FROM "PrincipalAlias"
+      ORDER BY "aliasType", "aliasValue"
+    `);
+
+    expect(aliases.rows).toHaveLength(4);
+    expect(new Set(aliases.rows.map((row) => row.principalId)).size).toBe(4);
+    expect(aliases.rows.map((row) => `${row.aliasType}:${row.aliasValue}`)).toEqual([
+      "employee:EMP-A",
+      "employee:EMP-B",
+      "user:user-a",
+      "user:user-b",
+    ]);
+
+    const superuserClearance = await client.query<{ sensitivityClearance: string[] }>(`
+      SELECT principal."sensitivityClearance"
+      FROM "Principal" principal
+      JOIN "PrincipalAlias" alias ON alias."principalId" = principal.id
+      WHERE alias."aliasType" = 'user' AND alias."aliasValue" = 'user-b'
+    `);
+    expect(superuserClearance.rows[0]?.sensitivityClearance).toEqual([
+      "public",
+      "internal",
+      "confidential",
+    ]);
+  });
+});

--- a/packages/db/src/human-principal-backfill-migration.test.ts
+++ b/packages/db/src/human-principal-backfill-migration.test.ts
@@ -114,7 +114,7 @@ describeDatabase("human principal backfill migration", () => {
     ]);
 
     const superuserClearance = await client.query<{ sensitivityClearance: string[] }>(`
-      SELECT principal."sensitivityClearance"
+      SELECT array_to_json(principal."sensitivityClearance") AS "sensitivityClearance"
       FROM "Principal" principal
       JOIN "PrincipalAlias" alias ON alias."principalId" = principal.id
       WHERE alias."aliasType" = 'user' AND alias."aliasValue" = 'user-b'


### PR DESCRIPTION
## Summary
- prepare missing human principals one source row at a time before the immutable backfill
- correlate by stable User/EmployeeProfile identifiers so duplicate labels cannot fan out
- add a live-database regression and data-impact/implementation records

## Verification
- exact semantic review: cmsql0mz4051701qkbpr1qjlf (0 findings)
- exact pregate: cmsqlirp205y701qkjxrgspy0 (gate passed)
- PostgreSQL regression: 2/2 passed
- full migrations, guards, typechecks, exhaustive tests, OCI build and smoke passed

## Process
Process-Spine-Decision: narrow forward-migration prerequisite for a canonical upgrade blocker; no public contract or UI change.

## Docs
No user-facing workflow changes. Plan and data-impact manifest added; no platform-support row because the defect is data-shape independent.