### PR TITLE
fix(upgrade): recover principal backfill collision

### DIFF
--- a/apps/web/lib/self-upgrade/promote-script-contract.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-contract.test.ts
@@ -368,6 +368,32 @@ describe.skipIf(!BASH_AVAILABLE)("promote.sh --self-upgrade contract", () => {
         scriptSource.indexOf(deployCommand),
       );
       expect(scriptSource).not.toContain(`${resolveCommand}' >/dev/null 2>&1 || true`);
+      expect(scriptSource).not.toContain(`${verifyCommand}' || true`);
+    });
+
+    it("guards the exact human-principal alias collision before normal migration deploy", () => {
+      const scriptSource = readFileSync(join(REPO_ROOT, "scripts", "promote.sh"), "utf8");
+      const recoveryCommand =
+        "node packages/db/scripts/recover-human-principal-backfill-migration.mjs";
+      const resolveCommand =
+        "prisma migrate resolve --rolled-back 20260812110000_backfill_missing_human_principals";
+      const verifyCommand =
+        "recover-human-principal-backfill-migration.mjs --verify-rolled-back";
+      const deployCommand =
+        "-c 'cd /app && pnpm --filter @dpf/db exec prisma migrate deploy'";
+
+      expect(scriptSource).toContain(recoveryCommand);
+      expect(scriptSource).toContain(resolveCommand);
+      expect(scriptSource.indexOf(recoveryCommand)).toBeLessThan(
+        scriptSource.indexOf(resolveCommand),
+      );
+      expect(scriptSource.indexOf(resolveCommand)).toBeLessThan(
+        scriptSource.indexOf(verifyCommand),
+      );
+      expect(scriptSource.indexOf(verifyCommand)).toBeLessThan(
+        scriptSource.indexOf(deployCommand),
+      );
+      expect(scriptSource).not.toContain(`${resolveCommand}' >/dev/null 2>&1 || true`);
     });
 
     it("emits docker-up step", () => {

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -88,6 +88,21 @@ for arg in "$@"; do
 done
 [ -n "$DOCKER_LOG" ] && printf '%s\\n' "$*" >> "$DOCKER_LOG"
 case "$*" in
+  *"recover-human-principal-backfill-migration.mjs --verify-rolled-back"*)
+    [ "\${DPF_TEST_PRINCIPAL_VERIFY_FAIL:-no}" = "yes" ] && exit 1
+    printf "verified"
+    ;;
+  *"prisma migrate resolve --rolled-back 20260812110000_backfill_missing_human_principals"*)
+    [ "\${DPF_TEST_PRINCIPAL_RESOLVE_FAIL:-no}" = "yes" ] && exit 1
+    ;;
+  *"recover-human-principal-backfill-migration.mjs"*)
+    [ "\${DPF_TEST_PRINCIPAL_RECOVERY_DECISION:-not-needed}" = "blocked" ] && exit 1
+    if [ "\${DPF_TEST_PRINCIPAL_RECOVERY_DECISION:-not-needed}" = "recover" ]; then
+      printf "recover:11111111-1111-4111-8111-111111111111"
+    else
+      printf "not-needed"
+    fi
+    ;;
   *"recover-inventory-snapshot-migration.mjs --verify-rolled-back"*) printf "verified" ;;
   *"recover-inventory-snapshot-migration.mjs"*)
     [ "\${DPF_TEST_RECOVERY_DECISION:-not-needed}" = "blocked" ] && exit 1
@@ -129,6 +144,9 @@ function runPromote(opts: {
   composeEnvFile?: string;
   dockerLog?: string;
   recoveryDecision?: "recover" | "not-needed" | "blocked";
+  principalRecoveryDecision?: "recover" | "not-needed" | "blocked";
+  principalResolveFails?: boolean;
+  principalVerifyFails?: boolean;
 }): { status: number | null; stdout: string; stderr: string } {
   const stateDir = join(opts.backup, "state");
   const secret = "s".repeat(32);
@@ -168,6 +186,11 @@ function runPromote(opts: {
     ...(opts.recoveryDecision
       ? [`export DPF_TEST_RECOVERY_DECISION=${shellQuote(opts.recoveryDecision)}`]
       : []),
+    ...(opts.principalRecoveryDecision
+      ? [`export DPF_TEST_PRINCIPAL_RECOVERY_DECISION=${shellQuote(opts.principalRecoveryDecision)}`]
+      : []),
+    ...(opts.principalResolveFails ? ["export DPF_TEST_PRINCIPAL_RESOLVE_FAIL=yes"] : []),
+    ...(opts.principalVerifyFails ? ["export DPF_TEST_PRINCIPAL_VERIFY_FAIL=yes"] : []),
     ...(opts.composeEnvFile
       ? [`export PROMOTE_COMPOSE_ENV_FILE=${shellQuote(toBashPath(opts.composeEnvFile))}`]
       : []),
@@ -303,7 +326,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       mkdirSync(emptyShaBin, { recursive: true });
       writeFileSync(
         join(emptyShaBin, "docker"),
-        '#!/bin/sh\ncase "$*" in\n  *"recover-inventory-snapshot-migration.mjs"*) printf "not-needed" ;;\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
+        '#!/bin/sh\ncase "$*" in\n  *"recover-human-principal-backfill-migration.mjs"*) printf "not-needed" ;;\n  *"recover-inventory-snapshot-migration.mjs"*) printf "not-needed" ;;\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
       );
       // /sha → empty (the bug); other probes → ok.
       writeFileSync(
@@ -391,6 +414,117 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
     }
   }, PROMOTE_TEST_TIMEOUT_MS);
 
+  it("resolves the allowlisted human-principal failure before normal migrate deploy", () => {
+    const { root, source, backup, fakeBin, head } = makeScratch();
+    const dockerLog = join(root, "docker.log");
+    try {
+      const r = runPromote({
+        source,
+        backup,
+        targetSha: head,
+        fakeBin,
+        dockerLog,
+        principalRecoveryDecision: "recover",
+      });
+
+      expect(r.status).toBe(0);
+      const calls = readFileSync(dockerLog, "utf8");
+      const check = calls.indexOf("recover-human-principal-backfill-migration.mjs");
+      const resolve = calls.indexOf(
+        "prisma migrate resolve --rolled-back 20260812110000_backfill_missing_human_principals",
+      );
+      const verify = calls.indexOf(
+        "recover-human-principal-backfill-migration.mjs --verify-rolled-back",
+      );
+      const deploy = calls.indexOf("prisma migrate deploy");
+      expect(check).toBeGreaterThanOrEqual(0);
+      expect(resolve).toBeGreaterThan(check);
+      expect(verify).toBeGreaterThan(resolve);
+      expect(deploy).toBeGreaterThan(verify);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, PROMOTE_TEST_TIMEOUT_MS);
+
+  it("stops before verification and deployment when principal rollback resolution fails", () => {
+    const { root, source, backup, fakeBin, head } = makeScratch();
+    const dockerLog = join(root, "docker.log");
+    try {
+      const r = runPromote({
+        source,
+        backup,
+        targetSha: head,
+        fakeBin,
+        dockerLog,
+        principalRecoveryDecision: "recover",
+        principalResolveFails: true,
+      });
+
+      expect(r.status).not.toBe(0);
+      const calls = readFileSync(dockerLog, "utf8");
+      expect(calls).toContain(
+        "prisma migrate resolve --rolled-back 20260812110000_backfill_missing_human_principals",
+      );
+      expect(calls).not.toContain(
+        "recover-human-principal-backfill-migration.mjs --verify-rolled-back",
+      );
+      expect(calls).not.toContain("prisma migrate deploy");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, PROMOTE_TEST_TIMEOUT_MS);
+
+  it("stops before deployment when principal post-rollback verification fails", () => {
+    const { root, source, backup, fakeBin, head } = makeScratch();
+    const dockerLog = join(root, "docker.log");
+    try {
+      const r = runPromote({
+        source,
+        backup,
+        targetSha: head,
+        fakeBin,
+        dockerLog,
+        principalRecoveryDecision: "recover",
+        principalVerifyFails: true,
+      });
+
+      expect(r.status).not.toBe(0);
+      const calls = readFileSync(dockerLog, "utf8");
+      expect(calls).toContain(
+        "recover-human-principal-backfill-migration.mjs --verify-rolled-back",
+      );
+      expect(calls).not.toContain("prisma migrate deploy");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, PROMOTE_TEST_TIMEOUT_MS);
+
+  it("fails before migrate deploy when human-principal recovery cannot prove safety", () => {
+    const { root, source, backup, fakeBin, head } = makeScratch();
+    const dockerLog = join(root, "docker.log");
+    try {
+      const r = runPromote({
+        source,
+        backup,
+        targetSha: head,
+        fakeBin,
+        dockerLog,
+        principalRecoveryDecision: "blocked",
+      });
+
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toContain(
+        "human-principal migration recovery did not prove a safe state",
+      );
+      const calls = readFileSync(dockerLog, "utf8");
+      expect(calls).toContain("recover-human-principal-backfill-migration.mjs");
+      expect(calls).not.toContain("prisma migrate deploy");
+      expect(calls).not.toContain("up -d --no-deps --force-recreate portal");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, PROMOTE_TEST_TIMEOUT_MS);
+
   it("fails before migrate deploy when snapshot recovery cannot prove safety", () => {
     const { root, source, backup, fakeBin, head } = makeScratch();
     const dockerLog = join(root, "docker.log");
@@ -430,7 +564,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       mkdirSync(bin, { recursive: true });
       writeFileSync(
         join(bin, "docker"),
-        '#!/bin/sh\n[ -n "$DOCKER_LOG" ] && printf "%s\\n" "$*" >> "$DOCKER_LOG"\ncase "$*" in\n  *"recover-inventory-snapshot-migration.mjs"*) printf "not-needed" ;;\n  *"build sandbox"*) exit 1 ;;\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
+        '#!/bin/sh\n[ -n "$DOCKER_LOG" ] && printf "%s\\n" "$*" >> "$DOCKER_LOG"\ncase "$*" in\n  *"recover-human-principal-backfill-migration.mjs"*) printf "not-needed" ;;\n  *"recover-inventory-snapshot-migration.mjs"*) printf "not-needed" ;;\n  *"build sandbox"*) exit 1 ;;\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
       );
       writeFileSync(
         join(bin, "curl"),
@@ -466,7 +600,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       // present ("1"); everything else behaves like the default fake.
       writeFileSync(
         join(bin, "docker"),
-        '#!/bin/sh\n[ -n "$DOCKER_LOG" ] && printf "%s\\n" "$*" >> "$DOCKER_LOG"\ncase "$*" in\n  *"recover-inventory-snapshot-migration.mjs"*) printf "not-needed" ;;\n  *pg_available_extensions*) printf "1" ;;\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
+        '#!/bin/sh\n[ -n "$DOCKER_LOG" ] && printf "%s\\n" "$*" >> "$DOCKER_LOG"\ncase "$*" in\n  *"recover-human-principal-backfill-migration.mjs"*) printf "not-needed" ;;\n  *"recover-inventory-snapshot-migration.mjs"*) printf "not-needed" ;;\n  *pg_available_extensions*) printf "1" ;;\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
       );
       writeFileSync(
         join(bin, "curl"),

--- a/docs/runbooks/bet5-windows-self-upgrade.md
+++ b/docs/runbooks/bet5-windows-self-upgrade.md
@@ -205,6 +205,15 @@ columns/indexes exist in the DB):
   `_dpfObservationSnapshot` exists, and the candidate carries the exact committed `11:58`
   quarantine migration. It verifies that same row after resolution before normal deploy. Any
   mismatch fails closed before the portal swap and requires the evidence-led decision below.
+- **Exact human-principal alias collision**
+  (`20260812110000_backfill_missing_human_principals`): the promoter automatically marks the row
+  rolled back only when it is the sole unresolved migration, the row id and immutable migration
+  checksum match, the failure is SQLSTATE `23505` on
+  `PrincipalAlias_aliasType_aliasValue_issuer_key`, `applied_steps_count = 0`, and the candidate
+  carries the exact preceding collision-preparation migration. It verifies the same ledger row
+  after resolution, then normal deploy applies the preparation migration before retrying the
+  immutable backfill. A different migration, checksum, constraint, SQLSTATE, step count, or
+  corrective file fails closed before the portal swap.
 - **Schema half-applied** (columns/index present): `prisma migrate resolve --applied <name>` — NOT
   `--rolled-back`, which would re-run the `ADD COLUMN` and fail `already exists`.
 - **Nothing applied** (`applied_steps_count = 0`, no DDL landed): fix the root cause (de-duplicate,

--- a/docs/superpowers/plans/2026-08-12-human-principal-failed-migration-recovery.md
+++ b/docs/superpowers/plans/2026-08-12-human-principal-failed-migration-recovery.md
@@ -1,0 +1,41 @@
+# Human-principal failed-migration recovery
+
+Backlog coverage: `BI-2BD99239` · Work capsule: `WC-D6CE3874`
+
+## Runtime evidence
+
+The first canonical upgrade attempt failed the immutable migration
+`20260812110000_backfill_missing_human_principals` with PostgreSQL SQLSTATE
+`23505` on `PrincipalAlias_aliasType_aliasValue_issuer_key`. The corrective
+preparation migration subsequently merged, but Prisma correctly retained the
+original zero-step failed row and blocked every later migration. Canonical run
+`SUR-BADF2B34` then built both images successfully and stopped before migration
+deployment because the promoter only allowed recovery of the older inventory
+snapshot migration.
+
+## Delivery plan
+
+1. Reproduce the missing allowlist path with DB policy and promoter contract
+   tests before implementation.
+2. Extract the common read-only unresolved-ledger inspection and exact
+   post-resolution verification into one shared helper.
+3. Add a migration-specific, fail-closed policy that authorizes only the exact
+   human-principal migration checksum, zero applied steps, SQLSTATE `23505`,
+   alias constraint, UUID row identity, and exact corrective migration bytes.
+4. Run that policy before the existing inventory recovery and normal
+   `prisma migrate deploy`; resolve only the returned row, then verify that row
+   is rolled back and no unresolved migration remains.
+5. Verify unit, PostgreSQL, shell contract, and functional promoter behavior;
+   then complete semantic review, exact local CI, protected merge, canonical
+   self-upgrade, and the deferred Restaurant seating acceptance.
+
+## Safety and data impact
+
+This change adds no schema migration and does not edit application data. It may
+change one `_prisma_migrations` ledger row only after the candidate proves the
+full allowlisted failure tuple. Every mismatch fails before the portal swap and
+before normal migration deployment. The already-merged forward preparation
+migration remains the sole repair of business identity data.
+
+Documentation impact is limited to this recovery plan and inline promoter
+contract comments; no user-facing or coworker-facing workflow changes.

--- a/packages/db/scripts/lib/failed-migration-ledger.mjs
+++ b/packages/db/scripts/lib/failed-migration-ledger.mjs
@@ -1,0 +1,42 @@
+export async function inspectUnresolvedMigrations(client) {
+  try {
+    const result = await client.query(
+      `SELECT
+         id,
+         migration_name AS "migrationName",
+         checksum,
+         applied_steps_count AS "appliedStepsCount",
+         logs
+       FROM "_prisma_migrations"
+       WHERE finished_at IS NULL
+         AND rolled_back_at IS NULL
+       ORDER BY started_at, id`,
+    );
+    return result.rows;
+  } catch (error) {
+    if (error?.code === "42P01") return [];
+    throw error;
+  }
+}
+
+export async function verifyExactMigrationRolledBack(client, migrationId, migrationName) {
+  const result = await client.query(
+    `SELECT
+       count(*) FILTER (
+         WHERE id = $1
+           AND migration_name = $2
+           AND rolled_back_at IS NOT NULL
+           AND finished_at IS NULL
+       )::int AS "verifiedRows",
+       count(*) FILTER (
+         WHERE finished_at IS NULL
+           AND rolled_back_at IS NULL
+       )::int AS "unresolvedRows"
+     FROM "_prisma_migrations"`,
+    [migrationId, migrationName],
+  );
+  return (
+    Number(result.rows[0]?.verifiedRows ?? 0) === 1
+    && Number(result.rows[0]?.unresolvedRows ?? 0) === 0
+  );
+}

--- a/packages/db/scripts/lib/human-principal-migration-recovery.mjs
+++ b/packages/db/scripts/lib/human-principal-migration-recovery.mjs
@@ -1,0 +1,49 @@
+export const HUMAN_PRINCIPAL_BACKFILL_MIGRATION =
+  "20260812110000_backfill_missing_human_principals";
+export const HUMAN_PRINCIPAL_BACKFILL_SHA256 =
+  "d4451208128e3c56b011f47125b0f08664f6ba4cadd3a9ee1c877c34ce03f1ee";
+export const HUMAN_PRINCIPAL_PREPARATION_SHA256 =
+  "28c6ad778bb41dda1a87b1f90d9e06d907c56cd683c17c1bc6a847f0d0fc7faf";
+
+const MIGRATION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function blocked(reason) {
+  return { action: "blocked", reason };
+}
+
+export function classifyHumanPrincipalMigrationRecovery({
+  unresolvedMigrations,
+  preparationChecksum,
+}) {
+  if (preparationChecksum !== HUMAN_PRINCIPAL_PREPARATION_SHA256) {
+    return blocked("candidate collision-preparation checksum does not match");
+  }
+  if (unresolvedMigrations.length === 0) return { action: "not-needed" };
+  if (unresolvedMigrations.length !== 1) {
+    return blocked("expected exactly one unresolved migration");
+  }
+
+  const migration = unresolvedMigrations[0];
+  if (migration.migrationName !== HUMAN_PRINCIPAL_BACKFILL_MIGRATION) {
+    return blocked("migration identity does not match the allowlist");
+  }
+  if (!MIGRATION_ID.test(String(migration.id ?? ""))) {
+    return blocked("migration row id is not a UUID");
+  }
+  if (migration.checksum !== HUMAN_PRINCIPAL_BACKFILL_SHA256) {
+    return blocked("failed migration checksum does not match");
+  }
+  if (migration.appliedStepsCount !== 0) {
+    return blocked("failed migration has applied steps");
+  }
+
+  const logs = String(migration.logs ?? "");
+  if (!logs.includes("23505")) {
+    return blocked("failed migration does not report SQLSTATE 23505");
+  }
+  if (!logs.includes("PrincipalAlias_aliasType_aliasValue_issuer_key")) {
+    return blocked("failed migration does not name the allowlisted constraint");
+  }
+
+  return { action: "recover", migrationId: migration.id };
+}

--- a/packages/db/scripts/recover-human-principal-backfill-migration.mjs
+++ b/packages/db/scripts/recover-human-principal-backfill-migration.mjs
@@ -10,46 +10,31 @@ import {
   inspectUnresolvedMigrations,
   verifyExactMigrationRolledBack,
 } from "./lib/failed-migration-ledger.mjs";
-
 import {
-  classifyInventorySnapshotRecovery,
-  INVENTORY_SNAPSHOT_MIGRATION,
-} from "./lib/inventory-snapshot-migration-recovery.mjs";
+  classifyHumanPrincipalMigrationRecovery,
+  HUMAN_PRINCIPAL_BACKFILL_MIGRATION,
+} from "./lib/human-principal-migration-recovery.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const indexQuarantinePath = resolve(
+const preparationPath = resolve(
   here,
-  "../prisma/migrations/20260728115800_quarantine_damaged_inventory_unique_index/migration.sql",
+  "../prisma/migrations/20260812105900_prepare_human_principal_backfill/migration.sql",
 );
 
 function fail(message) {
-  process.stderr.write(`inventory-snapshot-recovery: ${message}\n`);
+  process.stderr.write(`human-principal-recovery: ${message}\n`);
   process.exit(1);
 }
 
 export async function inspectRecoveryState(client) {
-  const unresolvedMigrations = await inspectUnresolvedMigrations(client);
-
-  if (unresolvedMigrations.length === 0) {
-    return { unresolvedMigrations, snapshotEffectCount: 0 };
-  }
-
-  const effects = await client.query(
-    `SELECT count(*)::int AS count
-       FROM "InventoryEntity"
-      WHERE properties ? '_dpfObservationSnapshot'`,
-  );
-  return {
-    unresolvedMigrations,
-    snapshotEffectCount: Number(effects.rows[0]?.count ?? 0),
-  };
+  return { unresolvedMigrations: await inspectUnresolvedMigrations(client) };
 }
 
 export async function verifyRolledBackMigration(client, migrationId) {
   return verifyExactMigrationRolledBack(
     client,
     migrationId,
-    INVENTORY_SNAPSHOT_MIGRATION,
+    HUMAN_PRINCIPAL_BACKFILL_MIGRATION,
   );
 }
 
@@ -72,16 +57,14 @@ async function main() {
     }
 
     const state = await inspectRecoveryState(client);
-    const indexQuarantineChecksum = createHash("sha256")
-      .update(readFileSync(indexQuarantinePath))
+    const preparationChecksum = createHash("sha256")
+      .update(readFileSync(preparationPath))
       .digest("hex");
-    const decision = classifyInventorySnapshotRecovery({
+    const decision = classifyHumanPrincipalMigrationRecovery({
       ...state,
-      indexQuarantineChecksum,
+      preparationChecksum,
     });
-    if (decision.action === "blocked") {
-      fail(decision.reason);
-    }
+    if (decision.action === "blocked") fail(decision.reason);
     process.stdout.write(
       decision.action === "recover"
         ? `recover:${decision.migrationId}\n`
@@ -95,6 +78,4 @@ async function main() {
 const invokedDirectly =
   process.argv[1]
   && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
-if (invokedDirectly) {
-  main().catch((error) => fail(error.message ?? String(error)));
-}
+if (invokedDirectly) main().catch((error) => fail(error.message ?? String(error)));

--- a/packages/db/src/human-principal-migration-recovery.test.ts
+++ b/packages/db/src/human-principal-migration-recovery.test.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from "node:crypto";
+import pg from "pg";
+import { afterAll, describe, expect, it } from "vitest";
+// @ts-expect-error - production helper is intentionally runtime-native ESM.
+import * as recovery from "../scripts/lib/human-principal-migration-recovery.mjs";
+// @ts-expect-error - production helper is intentionally runtime-native ESM.
+import * as runner from "../scripts/recover-human-principal-backfill-migration.mjs";
+
+const {
+  classifyHumanPrincipalMigrationRecovery,
+  HUMAN_PRINCIPAL_BACKFILL_MIGRATION,
+  HUMAN_PRINCIPAL_BACKFILL_SHA256,
+  HUMAN_PRINCIPAL_PREPARATION_SHA256,
+} = recovery;
+const { inspectRecoveryState, verifyRolledBackMigration } = runner;
+
+const exactFailure = {
+  id: "11111111-1111-4111-8111-111111111111",
+  migrationName: HUMAN_PRINCIPAL_BACKFILL_MIGRATION,
+  checksum: HUMAN_PRINCIPAL_BACKFILL_SHA256,
+  appliedStepsCount: 0,
+  logs: [
+    "Database error code: 23505",
+    'duplicate key value violates unique constraint "PrincipalAlias_aliasType_aliasValue_issuer_key"',
+  ].join("\n"),
+};
+
+describe("human-principal migration recovery policy", () => {
+  it("recovers only the exact zero-step alias-collision failure with the corrective bytes present", () => {
+    expect(classifyHumanPrincipalMigrationRecovery({
+      unresolvedMigrations: [exactFailure],
+      preparationChecksum: HUMAN_PRINCIPAL_PREPARATION_SHA256,
+    })).toEqual({ action: "recover", migrationId: exactFailure.id });
+  });
+
+  it("does nothing when no migration is unresolved", () => {
+    expect(classifyHumanPrincipalMigrationRecovery({
+      unresolvedMigrations: [],
+      preparationChecksum: HUMAN_PRINCIPAL_PREPARATION_SHA256,
+    })).toEqual({ action: "not-needed" });
+  });
+
+  it.each([
+    ["different migration", [{ ...exactFailure, migrationName: "20260812120000_other" }], HUMAN_PRINCIPAL_PREPARATION_SHA256],
+    ["different SQLSTATE", [{ ...exactFailure, logs: "Database error code: 23503" }], HUMAN_PRINCIPAL_PREPARATION_SHA256],
+    ["different constraint", [{ ...exactFailure, logs: "23505 Other_unique_key" }], HUMAN_PRINCIPAL_PREPARATION_SHA256],
+    ["wrong migration checksum", [{ ...exactFailure, checksum: "0".repeat(64) }], HUMAN_PRINCIPAL_PREPARATION_SHA256],
+    ["partially applied history", [{ ...exactFailure, appliedStepsCount: 1 }], HUMAN_PRINCIPAL_PREPARATION_SHA256],
+    ["multiple unresolved migrations", [exactFailure, { ...exactFailure, id: "22222222-2222-4222-8222-222222222222" }], HUMAN_PRINCIPAL_PREPARATION_SHA256],
+    ["wrong corrective bytes", [exactFailure], "0".repeat(64)],
+  ])("blocks %s", (_label, unresolvedMigrations, preparationChecksum) => {
+    expect(classifyHumanPrincipalMigrationRecovery({
+      unresolvedMigrations,
+      preparationChecksum,
+    })).toMatchObject({ action: "blocked" });
+  });
+
+  it("blocks a malformed migration id before it reaches the shell", () => {
+    expect(classifyHumanPrincipalMigrationRecovery({
+      unresolvedMigrations: [{ ...exactFailure, id: "not-a-uuid" }],
+      preparationChecksum: HUMAN_PRINCIPAL_PREPARATION_SHA256,
+    })).toMatchObject({ action: "blocked" });
+  });
+});
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+const schemas: string[] = [];
+
+async function recoveryFixture({ attempts = 0 }: { attempts?: number } = {}) {
+  const schema = `human_principal_recovery_${randomUUID().replaceAll("-", "")}`;
+  schemas.push(schema);
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  await client.query(`CREATE SCHEMA "${schema}"; SET search_path TO "${schema}"`);
+  await client.query(`
+    CREATE TABLE "_prisma_migrations" (
+      id VARCHAR(36) PRIMARY KEY,
+      checksum VARCHAR(64) NOT NULL,
+      finished_at TIMESTAMPTZ,
+      migration_name VARCHAR(255) NOT NULL,
+      logs TEXT,
+      rolled_back_at TIMESTAMPTZ,
+      started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      applied_steps_count INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  for (let index = 0; index < attempts; index += 1) {
+    await client.query(
+      `INSERT INTO "_prisma_migrations" (id, checksum, migration_name, logs, applied_steps_count)
+       VALUES ($1, $2, $3, $4, 0)`,
+      [
+        index === 0 ? exactFailure.id : "22222222-2222-4222-8222-222222222222",
+        HUMAN_PRINCIPAL_BACKFILL_SHA256,
+        HUMAN_PRINCIPAL_BACKFILL_MIGRATION,
+        exactFailure.logs,
+      ],
+    );
+  }
+  return client;
+}
+
+describeDatabase("human-principal recovery SQL inspection", () => {
+  afterAll(async () => {
+    if (!databaseUrl || schemas.length === 0) return;
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+      for (const schema of schemas) await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    } finally {
+      await client.end();
+    }
+  });
+
+  it("treats an absent Prisma ledger as a clean install", async () => {
+    const schema = `human_principal_recovery_${randomUUID().replaceAll("-", "")}`;
+    schemas.push(schema);
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+      await client.query(`CREATE SCHEMA "${schema}"; SET search_path TO "${schema}"`);
+      await expect(inspectRecoveryState(client)).resolves.toEqual({ unresolvedMigrations: [] });
+    } finally {
+      await client.end();
+    }
+  });
+
+  it("returns all unresolved rows so policy can fail closed", async () => {
+    const client = await recoveryFixture({ attempts: 2 });
+    try {
+      const state = await inspectRecoveryState(client);
+      expect(state.unresolvedMigrations).toHaveLength(2);
+      expect(state.unresolvedMigrations[0]).toMatchObject({ migrationName: HUMAN_PRINCIPAL_BACKFILL_MIGRATION });
+    } finally {
+      await client.end();
+    }
+  });
+
+  it("verifies only the authorized row was rolled back and no unresolved row remains", async () => {
+    const client = await recoveryFixture({ attempts: 1 });
+    try {
+      await client.query(`UPDATE "_prisma_migrations" SET rolled_back_at = now() WHERE id = $1`, [exactFailure.id]);
+      await expect(verifyRolledBackMigration(client, exactFailure.id)).resolves.toBe(true);
+    } finally {
+      await client.end();
+    }
+  });
+});

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -404,6 +404,38 @@ if [[ $_dry_run -eq 0 ]]; then
     "${_f_args[@]}" run --rm -T --no-deps --entrypoint sh portal \
     -c 'cd /app && pnpm --filter @dpf/db exec prisma migrate resolve --rolled-back 20260714110000_bet5_pgvector_foundation' >/dev/null 2>&1 || true
 
+  # BI-2BD99239: a pre-fix upgrade can leave the human-principal backfill
+  # failed at zero steps on the PrincipalAlias uniqueness collision. The
+  # candidate-owned checker proves the exact migration bytes, SQLSTATE,
+  # constraint, zero-step ledger state, and the exact preceding corrective
+  # migration bytes. Only that state may be rolled back so normal deploy can
+  # apply the preparation migration first and then retry the immutable backfill.
+  _human_principal_recovery="$(
+    docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+      "${_f_args[@]}" run --rm -T --no-deps --entrypoint sh portal \
+      -c 'cd /app && node packages/db/scripts/recover-human-principal-backfill-migration.mjs'
+  )" || {
+    printf 'error: human-principal migration recovery did not prove a safe state\n' >&2
+    exit 1
+  }
+  case "$_human_principal_recovery" in
+    recover:*)
+      _human_principal_migration_id="${_human_principal_recovery#recover:}"
+      docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+        "${_f_args[@]}" run --rm -T --no-deps --entrypoint sh portal \
+        -c 'cd /app && pnpm --filter @dpf/db exec prisma migrate resolve --rolled-back 20260812110000_backfill_missing_human_principals'
+      docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+        "${_f_args[@]}" run --rm -T --no-deps --entrypoint sh portal \
+        -c 'cd /app && node packages/db/scripts/recover-human-principal-backfill-migration.mjs --verify-rolled-back "$1"' \
+        sh "$_human_principal_migration_id"
+      ;;
+    not-needed) ;;
+    *)
+      printf 'error: human-principal migration recovery returned an unknown decision\n' >&2
+      exit 1
+      ;;
+  esac
+
   # BI-B92CFED7: a pre-fix self-upgrade can leave the 11:59 observation
   # snapshot failed at its first UPDATE because a corrupted unique index still
   # contains duplicate heap keys. The candidate-owned checker proves the exact


### PR DESCRIPTION
## Summary
- authorize recovery only for the exact zero-step human-principal alias-collision migration failure
- verify the corrective migration bytes and exact rolled-back ledger row before normal migration deployment
- share fail-closed Prisma ledger inspection with the existing inventory recovery path

## Verification
- governed local CI: cmsqno7fr08uj01qk1w8r4a7u (gate passed, exact 5db8671b400)
- critical semantic review: cmsqn4por07x801qkah4mvsi2 (pass, zero findings)
- PostgreSQL recovery suites: 29/29
- promoter contract + functional suites: 46/46
- full typecheck, policy guards, prose lint

## Runtime evidence
- SUR-BADF2B34 built successfully and stopped before migrate deploy because the unresolved principal migration was outside the prior recovery allowlist
- the failed row is exact migration 20260812110000_backfill_missing_human_principals, SQLSTATE 23505, applied_steps_count=0

Signed-off-by: dpf-ci <dpf-ci@users.noreply.github.com>