### PR TITLE
feat(performance): seed governed acceptance fixture

### DIFF
--- a/apps/web/lib/demo/performance-acceptance-fixture.test.ts
+++ b/apps/web/lib/demo/performance-acceptance-fixture.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { seedPerformanceAcceptanceFixture } from "./performance-acceptance-fixture";
+
+function fakeDb(input: { demoBookings?: number; ownerOrg?: string | null } = {}) {
+  const rollups = new Map<string, any>();
+  const tasks = new Map<string, any>();
+  const db: any = {
+    storefrontConfig: {
+      findUnique: vi.fn(async () => ({
+        id: "sf-1",
+        organizationId: "org-1",
+        timezone: "America/Chicago",
+        archetype: { archetypeId: "restaurant" },
+      })),
+    },
+    storefrontBooking: { count: vi.fn(async () => input.demoBookings ?? 7) },
+    platformSetupProgress: {
+      findUnique: vi.fn(async () => ({ organizationId: input.ownerOrg === undefined ? "org-1" : input.ownerOrg })),
+    },
+    businessMetricRollup: {
+      upsert: vi.fn(async ({ where, create, update }: any) => {
+        const key = JSON.stringify(where);
+        rollups.set(key, rollups.has(key) ? { ...rollups.get(key), ...update } : create);
+        return rollups.get(key);
+      }),
+    },
+    scheduledAgentTask: {
+      upsert: vi.fn(async ({ where, create, update }: any) => {
+        const key = where.taskId;
+        tasks.set(key, tasks.has(key) ? { ...tasks.get(key), ...update } : create);
+        return tasks.get(key);
+      }),
+    },
+  };
+  return { db, rollups, tasks };
+}
+
+describe("seedPerformanceAcceptanceFixture", () => {
+  it("idempotently seeds two populated periods and one org-scoped watched question", async () => {
+    const { db, rollups, tasks } = fakeDb();
+    const now = new Date("2026-08-12T18:00:00.000Z");
+
+    const first = await seedPerformanceAcceptanceFixture({
+      database: db,
+      organizationId: "org-1",
+      storefrontId: "sf-1",
+      ownerUserId: "owner-1",
+      now,
+    });
+    const second = await seedPerformanceAcceptanceFixture({
+      database: db,
+      organizationId: "org-1",
+      storefrontId: "sf-1",
+      ownerUserId: "owner-1",
+      now,
+    });
+
+    expect(first).toEqual(second);
+    expect(first).toMatchObject({ rollups: 14, watchedQuestions: 1 });
+    expect(rollups).toHaveLength(14);
+    expect(tasks).toHaveLength(1);
+    const current = [...rollups.values()].filter((row) => row.periodEnd > now);
+    expect(current.find((row) => row.metricKey === "covers")).toMatchObject({
+      value: 96,
+      availability: "available",
+      definitionVersion: "restaurant-v1",
+      dimensions: { storefrontId: "sf-1" },
+      sourceLineage: { fixture: true },
+    });
+    expect(current.find((row) => row.metricKey === "sales")).toMatchObject({ value: null, availability: "unavailable" });
+    expect(Math.min(...current.map((row) => row.sourceWatermark.getTime())))
+      .toBe(now.getTime() - 90 * 60_000);
+    expect([...tasks.values()][0]).toMatchObject({
+      ownerUserId: "owner-1",
+      organizationId: "org-1",
+      taskKind: "business-analysis-watch",
+      routeContext: "/performance",
+    });
+    expect([...tasks.values()][0].taskConfig.lastEvaluation.status).toBe("material-change");
+  });
+
+  it("refuses a non-demo or cross-organization target before writes", async () => {
+    const noDemo = fakeDb({ demoBookings: 0 });
+    await expect(seedPerformanceAcceptanceFixture({
+      database: noDemo.db, organizationId: "org-1", storefrontId: "sf-1", ownerUserId: "owner-1",
+    })).rejects.toThrow(/seeded restaurant demo/i);
+    expect(noDemo.db.businessMetricRollup.upsert).not.toHaveBeenCalled();
+
+    const wrongOwner = fakeDb({ ownerOrg: "org-2" });
+    await expect(seedPerformanceAcceptanceFixture({
+      database: wrongOwner.db, organizationId: "org-1", storefrontId: "sf-1", ownerUserId: "owner-1",
+    })).rejects.toThrow(/current organization/i);
+    expect(wrongOwner.db.businessMetricRollup.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/demo/performance-acceptance-fixture.ts
+++ b/apps/web/lib/demo/performance-acceptance-fixture.ts
@@ -1,0 +1,222 @@
+import { createHash } from "node:crypto";
+
+import {
+  DEMO_REF_PREFIX,
+  getPerformanceMetricDefinition,
+  validateBusinessAnalysisPlan,
+} from "@dpf/storefront-templates";
+
+import { BUSINESS_ANALYSIS_WATCH_TASK_KIND } from "@/lib/operate/scheduled-jobs/agent-task-kind";
+import {
+  RESTAURANT_METRIC_DEFINITION_VERSION,
+  restaurantMetricWindow,
+} from "@/lib/performance/business-metric-rollup";
+import { parseBusinessAnalysisWatchConfig } from "@/lib/performance/business-analysis-watch";
+
+export type PerformanceAcceptanceFixtureDatabase = {
+  storefrontConfig: {
+    findUnique(input: unknown): Promise<{
+      id: string;
+      organizationId: string;
+      timezone: string;
+      archetype: { archetypeId: string };
+    } | null>;
+  };
+  storefrontBooking: { count(input: unknown): Promise<number> };
+  platformSetupProgress: {
+    findUnique(input: unknown): Promise<{ organizationId: string | null } | null>;
+  };
+  businessMetricRollup: { upsert(input: unknown): Promise<unknown> };
+  scheduledAgentTask: { upsert(input: unknown): Promise<unknown> };
+};
+
+type SeedPerformanceAcceptanceFixtureInput = {
+  database: PerformanceAcceptanceFixtureDatabase;
+  organizationId: string;
+  storefrontId: string;
+  ownerUserId: string;
+  now?: Date;
+};
+
+const METRICS = [
+  { key: "covers", previous: 80, current: 96, watermarkMinutes: 15 },
+  { key: "turn-time", previous: 88, current: 82, watermarkMinutes: 30 },
+  { key: "table-utilization", previous: 0.52, current: 0.61, watermarkMinutes: 90 },
+  { key: "wait-no-show-rate", previous: 0.12, current: 0.08, watermarkMinutes: 45 },
+  { key: "sales", previous: null, current: null, watermarkMinutes: 20 },
+  { key: "average-check", previous: null, current: null, watermarkMinutes: 20 },
+  { key: "labor-percentage", previous: null, current: null, watermarkMinutes: 20 },
+] as const;
+
+const UNAVAILABLE_REASONS: Record<string, string> = {
+  sales: "Recognized restaurant sales are not linked in this demo fixture.",
+  "average-check": "Average check remains unavailable until recognized sales are linked.",
+  "labor-percentage": "Labor percentage remains unavailable until canonical labor cost is linked.",
+};
+
+function fixtureTaskId(organizationId: string, ownerUserId: string): string {
+  const digest = createHash("sha256")
+    .update(`${organizationId}:${ownerUserId}`)
+    .digest("hex")
+    .slice(0, 20);
+  return `demo-performance-watch-${digest}`;
+}
+
+export async function seedPerformanceAcceptanceFixture(
+  input: SeedPerformanceAcceptanceFixtureInput,
+) {
+  const now = input.now ?? new Date();
+  const storefront = await input.database.storefrontConfig.findUnique({
+    where: { id: input.storefrontId },
+    select: {
+      id: true,
+      organizationId: true,
+      timezone: true,
+      archetype: { select: { archetypeId: true } },
+    },
+  });
+  if (!storefront
+    || storefront.organizationId !== input.organizationId
+    || storefront.archetype.archetypeId !== "restaurant") {
+    throw new Error("Performance acceptance requires an exact organization-scoped restaurant storefront.");
+  }
+  const [demoBookings, ownerContext] = await Promise.all([
+    input.database.storefrontBooking.count({
+      where: {
+        organizationId: input.organizationId,
+        storefrontId: input.storefrontId,
+        bookingRef: { startsWith: DEMO_REF_PREFIX },
+      },
+    }),
+    input.database.platformSetupProgress.findUnique({
+      where: { userId: input.ownerUserId },
+      select: { organizationId: true },
+    }),
+  ]);
+  if (demoBookings < 1) {
+    throw new Error("Performance acceptance requires the seeded restaurant demo before it can write.");
+  }
+  if (ownerContext?.organizationId !== input.organizationId) {
+    throw new Error("Performance acceptance owner must have this organization as their current organization.");
+  }
+
+  const current = restaurantMetricWindow(now, storefront.timezone);
+  const previous = restaurantMetricWindow(new Date(current.start.getTime() - 1), storefront.timezone);
+  // Use the production projection identity so the fixture cannot leave a
+  // competing row for the same metric and period. Demo provenance belongs in
+  // lineage, not in a second metric definition or dimension.
+  const dimensions = { storefrontId: storefront.id };
+  const dimensionsHash = createHash("sha256").update(JSON.stringify(dimensions)).digest("hex");
+
+  for (const window of [previous, current]) {
+    for (const metric of METRICS) {
+      const definition = getPerformanceMetricDefinition(metric.key);
+      if (!definition) throw new Error(`Missing performance metric definition: ${metric.key}`);
+      const value = window === current ? metric.current : metric.previous;
+      const sourceWatermark = window === current
+        ? new Date(now.getTime() - metric.watermarkMinutes * 60_000)
+        : new Date(previous.end.getTime() - metric.watermarkMinutes * 60_000);
+      const identity = {
+        organizationId: input.organizationId,
+        metricKey: metric.key,
+        periodStart: window.start,
+        periodEnd: window.end,
+        dimensionsHash,
+        definitionVersion: RESTAURANT_METRIC_DEFINITION_VERSION,
+      };
+      const row = {
+        ...identity,
+        timezone: storefront.timezone,
+        dimensions,
+        value,
+        unit: definition.unit,
+        availability: value === null ? "unavailable" : "available",
+        unavailableReason: value === null ? UNAVAILABLE_REASONS[metric.key] : null,
+        sourceWatermark,
+        sourceLineage: {
+          sourceModels: ["StorefrontBooking", "HospitalityServiceTurn"],
+          sourceRows: demoBookings,
+          storefrontId: storefront.id,
+          fixture: true,
+        },
+        computedAt: now,
+      };
+      await input.database.businessMetricRollup.upsert({
+        where: {
+          organizationId_metricKey_periodStart_periodEnd_dimensionsHash_definitionVersion: identity,
+        },
+        create: row,
+        update: row,
+      });
+    }
+  }
+
+  const planResult = validateBusinessAnalysisPlan({
+    schemaVersion: 1,
+    question: "Did covers move enough to deserve attention?",
+    intent: "change",
+    metrics: [{ key: "covers" }],
+    dimensions: [],
+    filters: [],
+    period: {
+      start: current.periodKey,
+      end: current.periodKey,
+      timezone: storefront.timezone,
+      grain: "day",
+    },
+    comparison: { basis: "prior-period" },
+    sources: [{ owner: "restaurant-service", maximumAge: "PT2H" }],
+    checks: [{ kind: "completeness" }, { kind: "comparison-baseline" }],
+  });
+  if (planResult.status !== "accepted") {
+    throw new Error("The fixture's governed business-analysis plan was refused.");
+  }
+  const coversWatermark = new Date(now.getTime() - 15 * 60_000).toISOString();
+  const taskConfig = parseBusinessAnalysisWatchConfig({
+    schemaVersion: 1,
+    plan: planResult.plan,
+    fingerprint: planResult.fingerprint,
+    materiality: { mode: "relative", direction: "either", value: 0.1 },
+    baseline: { value: 80, sourceWatermark: previous.end.toISOString() },
+    lastEvaluation: {
+      status: "material-change",
+      fingerprint: planResult.fingerprint,
+      metricKey: "covers",
+      baselineValue: 80,
+      currentValue: 96,
+      delta: 0.2,
+      evaluatedAt: now.toISOString(),
+      sourceWatermark: coversWatermark,
+    },
+  });
+  const taskId = fixtureTaskId(input.organizationId, input.ownerUserId);
+  const task = {
+    taskId,
+    agentId: "operations-manager",
+    title: "Watch covers for a material change",
+    prompt: "Evaluate the accepted business analysis plan deterministically.",
+    routeContext: "/performance",
+    schedule: "0 9 * * 1",
+    timezone: "UTC",
+    isActive: true,
+    ownerUserId: input.ownerUserId,
+    organizationId: input.organizationId,
+    taskKind: BUSINESS_ANALYSIS_WATCH_TASK_KIND,
+    taskConfig,
+  };
+  await input.database.scheduledAgentTask.upsert({
+    where: { taskId },
+    create: task,
+    update: task,
+  });
+
+  return {
+    organizationId: input.organizationId,
+    storefrontId: input.storefrontId,
+    ownerUserId: input.ownerUserId,
+    rollups: METRICS.length * 2,
+    watchedQuestions: 1,
+    taskId,
+    fingerprint: planResult.fingerprint,
+  };
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 632,
+  "pageCount": 633,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -9641,6 +9641,15 @@
         "pbi-inv-02-phase-2-third-party-e-signature",
         "pbi-inv-03-remove-dead-invoiceactionstsx",
         "pbi-inv-04-near-zero-config-email-ai-assisted-own-provider-setup-bundled-relay-tier"
+      ]
+    },
+    "docs/testing/performance-live-acceptance.md": {
+      "publicHref": "/testing/performance-live-acceptance/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "populated-performance-live-acceptance"
       ]
     },
     "docs/testing/pr-health.md": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "demo:performance-acceptance": "tsx scripts/seed-performance-acceptance-fixture.ts",
     "build:route-manifest": "tsx scripts/build-route-manifest.ts",
     "check:route-manifest": "tsx scripts/build-route-manifest.ts --check",
     "build:route-audience": "tsx scripts/build-route-audience.ts",

--- a/apps/web/scripts/seed-performance-acceptance-fixture.ts
+++ b/apps/web/scripts/seed-performance-acceptance-fixture.ts
@@ -1,0 +1,60 @@
+import { prisma } from "@dpf/db";
+
+import {
+  seedPerformanceAcceptanceFixture,
+  type PerformanceAcceptanceFixtureDatabase,
+} from "../lib/demo/performance-acceptance-fixture";
+
+function option(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] ?? null : null;
+}
+
+async function main() {
+  const ownerEmail = option("--owner-email");
+  if (!ownerEmail) {
+    throw new Error("Usage: pnpm --filter web demo:performance-acceptance -- --owner-email <seeded-owner-email>");
+  }
+  const owner = await prisma.user.findUnique({
+    where: { email: ownerEmail },
+    select: {
+      id: true,
+      platformSetupProgress: { select: { organizationId: true } },
+    },
+  });
+  const organizationId = owner?.platformSetupProgress?.organizationId;
+  if (!owner || !organizationId) {
+    throw new Error("The named owner does not have an authenticated current organization.");
+  }
+  const storefronts = await prisma.storefrontConfig.findMany({
+    where: {
+      organizationId,
+      archetype: { archetypeId: "restaurant" },
+    },
+    select: { id: true },
+    take: 2,
+  });
+  if (storefronts.length === 0) {
+    throw new Error("The owner's current organization has no restaurant storefront.");
+  }
+  if (storefronts.length > 1) {
+    throw new Error("The owner's current organization has multiple restaurant storefronts; refusing an ambiguous fixture target.");
+  }
+
+  const result = await seedPerformanceAcceptanceFixture({
+    database: prisma as unknown as PerformanceAcceptanceFixtureDatabase,
+    organizationId,
+    storefrontId: storefronts[0]!.id,
+    ownerUserId: owner.id,
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+main()
+  .catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/docs/superpowers/plans/2026-08-12-performance-acceptance-fixture.md
+++ b/docs/superpowers/plans/2026-08-12-performance-acceptance-fixture.md
@@ -1,0 +1,32 @@
+# Governed Performance Acceptance Fixture
+
+Backlog coverage: `BI-721DE20F` · Work capsule: `WC-5D2111A2`
+
+## Objective
+
+Make populated `/performance` acceptance repeatable without fabricating production state. Extend the existing restaurant demo path with deterministic metric history and a watched-analysis example owned by the authenticated user's current organization.
+
+## Existing substrate
+
+- `demo-business-load` and the restaurant demo-floor loader own demo identity and reversible `demo-` references.
+- `BusinessMetricRollup` is the canonical metric-history projection.
+- `ScheduledAgentTask` with `business-analysis-watch` is the canonical watched-analysis projection.
+- The existing Performance read model owns owner-brief language, comparison, evidence limits, and the oldest metric watermark.
+
+No new model, route, scheduler, metric catalogue, or dashboard is justified.
+
+## Delivery plan
+
+1. Define failing contracts for idempotency, populated current/prior periods, oldest-watermark evidence, material-change watch state, and pre-write tenant/demo refusal.
+2. Add a source-owned seed function that verifies exact organization, restaurant storefront, demo reference, and owner current-org context before upserting canonical projections.
+3. Add an explicit operator command that resolves organization scope from the named seeded owner; never accept a free-form organization override.
+4. Document safe use and the populated live acceptance assertions.
+5. Run focused tests, typecheck/build checks, architecture and UX-fit review, exact semantic review, one governed pregate, and the governed release path.
+
+## Architecture and UX constraints
+
+- All writes are idempotent and scoped to the verified demo organization.
+- The fixture labels its lineage and upserts the canonical restaurant metric identity; it never creates a competing projection or claims unavailable sales or labor evidence.
+- Different current metric watermarks exercise aggregate freshness as the oldest watermark.
+- The scheduled watch contains a validated accepted plan and deterministic material-change evidence.
+- No UI is added: the fixture exercises the existing owner-first Performance and watched-analysis surfaces.

--- a/docs/testing/performance-live-acceptance.md
+++ b/docs/testing/performance-live-acceptance.md
@@ -1,0 +1,19 @@
+# Populated Performance live acceptance
+
+Use this fixture only after the restaurant demo loader has populated the target owner's current organization. It refuses to write unless the exact storefront belongs to that organization, contains `demo-` bookings, and the named owner currently belongs to the same organization.
+
+```text
+pnpm --filter web demo:performance-acceptance -- --owner-email <seeded-owner-email>
+```
+
+The command is idempotent. It writes two daily periods for the seven restaurant metrics and one accepted watched-analysis plan. Sales, average check, and labor percentage intentionally remain unavailable because the demo substrate does not provide authoritative inputs.
+
+After a governed deployment, authenticate as the same seeded owner and verify `/performance`:
+
+- the owner brief reports the covers change and keeps evidence limits neutral;
+- aggregate freshness reflects the oldest current metric watermark;
+- the accepted covers plan is inspectable and the material change carries evidence;
+- quiet, clarification/refusal, and stale-source behavior remain available through their existing deterministic contracts;
+- another organization's owner cannot read or operate this fixture.
+
+This command is an acceptance-data tool, not a production-data repair path. It has no organization override and must not be run against a real operating tenant.


### PR DESCRIPTION
## Summary  - add an idempotent, demo-only Performance acceptance fixture for the authenticated owner's current organization - populate the canonical restaurant metric projection across current and prior periods, including deliberately different watermarks and honest unavailable metrics - seed one validated watched-analysis plan with material-change evidence and expose a refusal-first owner-email command - document the governed populated `/performance` acceptance path  Backlog: BI-721DE20F  ## Architecture and UX fit  The fixture composes the existing `BusinessMetricRollup`, restaurant metric catalogue, accepted analysis-plan contract, and `ScheduledAgentTask` watch substrate. It adds no table, route, scheduler, metric definition, or parallel UI. Exact organization/storefront/demo/current-owner checks complete before any write, and ambiguous storefront selection is refused.  ## Verification  - 17 related Vitest tests passed - web TypeScript compile passed - web production build passed - 37 pregate preflight guards passed - exact semantic receipt `cmsqrgbz802uq01me0q6e1ujg` is fresh with zero findings - governed exhaustive local-CI passed against current main  Local-CI-Evidence: cmsqsmqsg00q601lgju97mt93 (feat/performance-acceptance-fixture@cd3c33be51c916f5344a83287053dfddea575a05) 