### PR TITLE
fix(restaurant): align floor confirmation versions

### DIFF
--- a/apps/web/lib/storefront/restaurant-seating.test.ts
+++ b/apps/web/lib/storefront/restaurant-seating.test.ts
@@ -153,6 +153,7 @@ describe("restaurant seating decision", () => {
       id: "overlapping",
       resourceId: "t1",
       startsAt: new Date("2026-07-31T18:30:00.000Z"),
+      // clock-bomb-guard: allow pure interval-overlap test has no wall-clock dependency
       endsAt: new Date("2026-07-31T19:30:00.000Z"),
       lifecycle: "reserved" as const,
       version: 1,
@@ -164,6 +165,7 @@ describe("restaurant seating decision", () => {
           ...overlapping,
           id: "later",
           startsAt: new Date("2026-07-31T20:00:00.000Z"),
+          // clock-bomb-guard: allow pure interval-overlap test has no wall-clock dependency
           endsAt: new Date("2026-07-31T21:00:00.000Z"),
         },
         { ...overlapping, id: "released", lifecycle: "released" },

--- a/apps/web/lib/storefront/restaurant-seating.test.ts
+++ b/apps/web/lib/storefront/restaurant-seating.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   evaluateRestaurantSeating,
   findRestaurantSeatingAlternatives,
+  restaurantSeatingAllocationsForInterval,
   restaurantSeatingVersion,
   type RestaurantSeatingAllocationFact,
   type RestaurantSeatingResourceFact,
@@ -145,6 +146,31 @@ describe("restaurant seating decision", () => {
         demandRef: "BOOK-1",
       }),
     ).toEqual({ ok: true, capacity: 2 });
+  });
+
+  it("keeps only live allocations that overlap the command interval", () => {
+    const overlapping = {
+      id: "overlapping",
+      resourceId: "t1",
+      startsAt: new Date("2026-07-31T18:30:00.000Z"),
+      endsAt: new Date("2026-07-31T19:30:00.000Z"),
+      lifecycle: "reserved" as const,
+      version: 1,
+    };
+    expect(restaurantSeatingAllocationsForInterval({
+      allocations: [
+        overlapping,
+        {
+          ...overlapping,
+          id: "later",
+          startsAt: new Date("2026-07-31T20:00:00.000Z"),
+          endsAt: new Date("2026-07-31T21:00:00.000Z"),
+        },
+        { ...overlapping, id: "released", lifecycle: "released" },
+      ],
+      startsAt,
+      endsAt,
+    })).toEqual([overlapping]);
   });
 
   it("derives a stable concurrency token independent of query order", () => {

--- a/apps/web/lib/storefront/restaurant-seating.ts
+++ b/apps/web/lib/storefront/restaurant-seating.ts
@@ -47,6 +47,23 @@ function intervalsOverlap(
   );
 }
 
+export function restaurantSeatingAllocationsForInterval(input: {
+  allocations: readonly RestaurantSeatingAllocationFact[];
+  startsAt: Date;
+  endsAt: Date;
+}): RestaurantSeatingAllocationFact[] {
+  return input.allocations.filter(
+    (allocation) =>
+      LIVE_ALLOCATION_LIFECYCLES.has(allocation.lifecycle) &&
+      intervalsOverlap(
+        allocation.startsAt,
+        allocation.endsAt,
+        input.startsAt,
+        input.endsAt,
+      ),
+  );
+}
+
 function pairCanCombine(
   left: RestaurantSeatingResourceFact,
   right: RestaurantSeatingResourceFact,
@@ -109,20 +126,13 @@ export function evaluateRestaurantSeating(input: {
   }
 
   const selectedIds = new Set(input.resources.map((resource) => resource.id));
-  const conflict = input.allocations.find(
+  const conflict = restaurantSeatingAllocationsForInterval(input).find(
     (allocation) =>
       allocation.resourceId != null &&
       selectedIds.has(allocation.resourceId) &&
       !(
         input.demandRef !== undefined &&
         allocation.demandRef === input.demandRef
-      ) &&
-      LIVE_ALLOCATION_LIFECYCLES.has(allocation.lifecycle) &&
-      intervalsOverlap(
-        allocation.startsAt,
-        allocation.endsAt,
-        input.startsAt,
-        input.endsAt,
       ),
   );
   if (conflict) {

--- a/apps/web/lib/twin/restaurant-floor-loader.server.test.ts
+++ b/apps/web/lib/twin/restaurant-floor-loader.server.test.ts
@@ -220,6 +220,37 @@ describe("restaurant floor operational loader", () => {
     ]);
   });
 
+  it("excludes a later reservation from the immediate seating version", async () => {
+    const db = database();
+    db.hospitalityCapacityAllocation.findMany.mockResolvedValue([
+      {
+        id: "allocation-later",
+        resourceId: "table-2",
+        startsAt: new Date("2026-07-31T20:00:00.000Z"),
+        endsAt: new Date("2026-07-31T21:00:00.000Z"),
+        lifecycle: "reserved",
+        version: 1,
+        demandRef: "BOOK-LATER",
+        serviceTurn: null,
+      },
+    ]);
+
+    const view = await loadRestaurantFloorOperationalView(db, {
+      organizationId: "org-1",
+      storefrontId: "store-1",
+      now,
+    });
+
+    const tableTwo = view.commands
+      .find((candidate) => candidate.demandId === "booking-waiting")
+      ?.options.find((option) => option.resourceIds.join(",") === "table-2");
+    expect(tableTwo?.expectedVersion).toBe(restaurantSeatingVersion({
+      demand: waitingBooking,
+      resources: [resources[1]],
+      allocations: [],
+    }));
+  });
+
   it("keeps active-turn booking context outside the ordinary demand horizon", async () => {
     const db = database();
     db.storefrontBooking.findMany.mockImplementation(

--- a/apps/web/lib/twin/restaurant-floor-loader.server.ts
+++ b/apps/web/lib/twin/restaurant-floor-loader.server.ts
@@ -1,5 +1,6 @@
 import {
   findRestaurantSeatingAlternatives,
+  restaurantSeatingAllocationsForInterval,
   restaurantSeatingVersion,
   type RestaurantSeatingAllocationFact,
   type RestaurantSeatingResourceFact,
@@ -489,19 +490,26 @@ export async function loadRestaurantFloorOperationalView(
         return resource && floorTable?.state === "available" ? [resource] : [];
       });
       if (optionResources.length !== resourceIds.length) return [];
-      const resourceAllocations = allocations.filter(
-        (allocation) =>
-          allocation.resourceId !== null &&
-          resourceIds.includes(allocation.resourceId),
-      );
+      const interval = {
+        startsAt: now,
+        endsAt: new Date(
+          now.getTime() + demand.durationMinutes * 60_000,
+        ),
+      };
+      const resourceAllocations = restaurantSeatingAllocationsForInterval({
+        allocations: allocations.filter(
+          (allocation) =>
+            allocation.resourceId !== null &&
+            resourceIds.includes(allocation.resourceId),
+        ),
+        ...interval,
+      });
       return [{
         resourceIds,
         label: optionResources.map((resource) => resource.label).join(" + "),
         interval: {
-          startsAt: now.toISOString(),
-          endsAt: new Date(
-            now.getTime() + demand.durationMinutes * 60_000,
-          ).toISOString(),
+          startsAt: interval.startsAt.toISOString(),
+          endsAt: interval.endsAt.toISOString(),
         },
         expectedVersion: restaurantSeatingVersion({
           demand,
@@ -583,11 +591,15 @@ export async function loadRestaurantFloorOperationalView(
         const optionResources = resources.filter((resource) =>
           alternative.resourceIds.includes(resource.id),
         );
-        const optionAllocations = allocations.filter(
-          (allocation) =>
-            allocation.resourceId !== null &&
-            alternative.resourceIds.includes(allocation.resourceId),
-        );
+        const optionAllocations = restaurantSeatingAllocationsForInterval({
+          allocations: allocations.filter(
+            (allocation) =>
+              allocation.resourceId !== null &&
+              alternative.resourceIds.includes(allocation.resourceId),
+          ),
+          startsAt: now,
+          endsAt,
+        });
         return {
           resourceIds: alternative.resourceIds,
           label: alternative.label,

--- a/docs/superpowers/plans/2026-08-12-restaurant-floor-version-confirmation.md
+++ b/docs/superpowers/plans/2026-08-12-restaurant-floor-version-confirmation.md
@@ -1,0 +1,20 @@
+# Restaurant floor confirmation version repair
+
+Backlog: BI-4D076907
+
+## Live evidence
+
+On canonical served bytes `0aa6437438a266c8a3926777d99984e91e566a18`, the host stand recommended Quinn Doyle (3) at Aster 1 (4). Three confirmations from freshly rendered choices failed closed as `Floor changed before confirmation`; reload preserved the waiting party and available table. Aster 1 had one live reservation allocation for the following day, outside the immediate seating interval.
+
+## Contract
+
+The optimistic seating token covers exactly the demand, resource, and live allocation facts the atomic command rechecks for the proposed interval. A non-overlapping earlier or later reservation remains visible to planning but cannot make an immediate command stale. An overlapping allocation must continue to reject without partial writes.
+
+## Delivery plan
+
+1. Reproduce the false conflict with a loader regression containing a later reservation.
+2. Centralize the live-overlap filter used by seating evaluation and command-token projection.
+3. Apply the same token boundary to seat and move options.
+4. Run focused tests, typecheck, independent exact-tree review, governed pregate, protected merge, canonical upgrade, and the same seat-plus-reload acceptance.
+
+No schema migration or new UI copy is required. The existing conflict notice and authored spatial layout remain unchanged.


### PR DESCRIPTION
## Summary
- exclude non-overlapping future reservations from immediate host-stand seating concurrency tokens
- share the live interval filter between seating validation and seat/move option projection
- add the canonical Quinn/Aster false-conflict regression and delivery plan

## Verification
- focused Restaurant tests: 23/23 passed
- web typecheck passed with repository 8 GiB heap envelope
- policy guards: 25/25 passed
- prose lint passed
- exact governed pregate passed for 97412f6c1545 under NPEL-43D576A0A5, evidence cmsqqscn5029201megh8wruv1 (9:31 / 30,749 lines)
- semantic receipt cmsqq18j000pl01mevu9tlarf permits publication

## UX and migration
- UX: fixes the false stale-floor rejection without changing the existing authored host-stand layout or conflict messaging; live seat + reload acceptance follows deployment
- Migration: not applicable; no schema change

Backlog: BI-4D076907
Capsule: WC-797BC7AB