### PR TITLE
fix(wwwd): make org business-decision confidence discriminate by content (BI-7E1F128A)

### DIFF
--- a/apps/web/lib/decision-perspective/coverage-scoring.ts
+++ b/apps/web/lib/decision-perspective/coverage-scoring.ts
@@ -1,0 +1,180 @@
+// Pure scoring primitives for the decision-perspective evaluator. Extracted from
+// evaluator.ts to keep that module focused (module-size / substrate-regression
+// guards). No IO — the async gate resolves material + relevance upstream and
+// hands them to these synchronous functions.
+
+import { isMaterialApplicable, scorePerspectiveMaterial } from "./material";
+import type {
+  DecisionDomainClass,
+  DecisionPerspectiveProfile,
+  DecisionRiskTier,
+  PerspectiveMaterial,
+  PerspectiveMaterialScore,
+} from "./types";
+
+export const RISK_RANK: Record<DecisionRiskTier, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+
+export const RISK_PENALTY: Record<DecisionRiskTier, number> = {
+  low: 0,
+  medium: 0.1,
+  high: 0.25,
+  critical: 0.5,
+};
+
+export function roundConfidence(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Number(Math.max(0, Math.min(1, value)).toFixed(4));
+}
+
+export function riskWithin(candidate: DecisionRiskTier, max: DecisionRiskTier): boolean {
+  return RISK_RANK[candidate] <= RISK_RANK[max];
+}
+
+export function orderedProfileChain(
+  profile: DecisionPerspectiveProfile,
+  fallbackProfiles: DecisionPerspectiveProfile[] | undefined,
+): DecisionPerspectiveProfile[] {
+  const fallbacks = new Map((fallbackProfiles ?? []).map((entry) => [entry.profileId, entry]));
+  const chain: DecisionPerspectiveProfile[] = [profile];
+  let nextId = profile.fallbackProfileId;
+
+  while (nextId) {
+    const next = fallbacks.get(nextId);
+    if (!next || chain.some((entry) => entry.profileId === next.profileId)) {
+      break;
+    }
+    chain.push(next);
+    nextId = next.fallbackProfileId;
+  }
+
+  return chain;
+}
+
+// A relevant stance whose support and oppose mass are within this band of each
+// other counts as a CONFLICT (mixed), not a directional verdict.
+export const ALIGNMENT_CONFLICT_BAND = 0.2;
+
+export type ProfileCoverage = {
+  profile: DecisionPerspectiveProfile;
+  applicableMaterials: PerspectiveMaterial[];
+  materialScores: PerspectiveMaterialScore[];
+  confidence: number;
+  /** Present only on the content-aware (WWWD) path (BI-7E1F128A). */
+  contentAware: boolean;
+  alignmentScore?: number;
+  stanceAlignment?: "approve" | "decline" | "mixed" | "none";
+};
+
+function materialDirection(material: PerspectiveMaterial): "support" | "oppose" | "neutral" {
+  const direction = material.direction ?? material.principleDirection ?? "neutral";
+  return direction === "support" || direction === "oppose" ? direction : "neutral";
+}
+
+export function scoreProfileCoverage(input: {
+  profile: DecisionPerspectiveProfile;
+  materials: PerspectiveMaterial[];
+  questionDomain: DecisionDomainClass;
+  riskTier: DecisionRiskTier;
+  recentOverrideCount: number;
+  /** Per-material relevance ∈ [0,1]. Presence switches on the directional model. */
+  relevanceByMaterialId?: Map<string, number>;
+}): ProfileCoverage {
+  const applicableMaterials = input.materials.filter(
+    (material) =>
+      material.profileId === input.profile.profileId
+      && isMaterialApplicable(material, input.questionDomain),
+  );
+  const materialScores = applicableMaterials.map(scorePerspectiveMaterial);
+  const overridePenalty = Math.min(0.3, input.recentOverrideCount * 0.1);
+
+  // ── Legacy coverage path (WWMD, or when no relevance was supplied) ──────────
+  // Confidence is the average effective weight of applicable material. Kept
+  // verbatim so the build-studio gate is unchanged.
+  if (!input.relevanceByMaterialId) {
+    const positiveScores = materialScores.filter((score) => score.effectiveWeight > 0);
+    const baseScore = positiveScores.length === 0
+      ? 0
+      : positiveScores.reduce((total, score) => total + score.effectiveWeight, 0) / positiveScores.length;
+    const confidence = roundConfidence(baseScore - RISK_PENALTY[input.riskTier] - overridePenalty);
+    return { profile: input.profile, applicableMaterials, materialScores, confidence, contentAware: false };
+  }
+
+  // ── Content-aware directional path (WWWD, BI-7E1F128A) ──────────────────────
+  // Weight each material by how RELEVANT it is to this question, then read its
+  // direction. Confidence is the decisiveness of the strongest relevant
+  // directional stance scaled by how one-sided the relevant stance is, so an
+  // off-mission decision (a relevant `oppose` stance) and an on-mission one (a
+  // relevant `support` stance) produce materially different, directional
+  // verdicts instead of an identical coverage constant.
+  let supportMass = 0;
+  let opposeMass = 0;
+  let bestDirectionalWeight = 0;
+  applicableMaterials.forEach((material, index) => {
+    const effectiveWeight = materialScores[index]!.effectiveWeight;
+    if (effectiveWeight <= 0) return;
+    const relevance = input.relevanceByMaterialId!.get(material.materialId) ?? 0;
+    const weighted = effectiveWeight * relevance;
+    const direction = materialDirection(material);
+    if (direction === "support") {
+      supportMass += weighted;
+      bestDirectionalWeight = Math.max(bestDirectionalWeight, weighted);
+    } else if (direction === "oppose") {
+      opposeMass += weighted;
+      bestDirectionalWeight = Math.max(bestDirectionalWeight, weighted);
+    }
+  });
+
+  const directionalMass = supportMass + opposeMass;
+  const alignmentScore = directionalMass > 0 ? (supportMass - opposeMass) / directionalMass : 0;
+  const confidence = roundConfidence(
+    bestDirectionalWeight * Math.abs(alignmentScore) - RISK_PENALTY[input.riskTier] - overridePenalty,
+  );
+
+  let stanceAlignment: ProfileCoverage["stanceAlignment"];
+  if (directionalMass <= 0) {
+    stanceAlignment = "none";
+  } else if (Math.abs(alignmentScore) < ALIGNMENT_CONFLICT_BAND) {
+    stanceAlignment = "mixed";
+  } else {
+    stanceAlignment = alignmentScore > 0 ? "approve" : "decline";
+  }
+
+  return {
+    profile: input.profile,
+    applicableMaterials,
+    materialScores,
+    confidence,
+    contentAware: true,
+    alignmentScore,
+    stanceAlignment,
+  };
+}
+
+export function summarizeFreshness(scores: PerspectiveMaterialScore[]) {
+  return scores.reduce(
+    (counts, score) => {
+      counts[score.freshness] += 1;
+      return counts;
+    },
+    { current: 0, stale: 0, superseded: 0, contradicted: 0 },
+  );
+}
+
+export function hasPrincipleConflict(materials: PerspectiveMaterial[]): boolean {
+  const activeDirections = new Set(
+    materials
+      .filter((material) => material.sourceType === "principle")
+      .filter((material) => material.freshness === "current")
+      .filter((material) => material.reviewStatus === "approved")
+      .filter((material) => material.promotionState === "promoted")
+      .map((material) => material.direction ?? material.principleDirection)
+      .filter((direction): direction is "support" | "oppose" => direction === "support" || direction === "oppose"),
+  );
+
+  return activeDirections.has("support") && activeDirections.has("oppose");
+}

--- a/apps/web/lib/decision-perspective/evaluator.test.ts
+++ b/apps/web/lib/decision-perspective/evaluator.test.ts
@@ -318,3 +318,92 @@ describe("evaluateDecisionPerspective", () => {
     expect(result.domainClass).toBe("professional-practice");
   });
 });
+
+// BI-7E1F128A: the WWWD evaluator must discriminate by decision CONTENT. With a
+// per-material relevance map (computed upstream from question↔stance similarity),
+// an off-mission decision (a relevant `oppose` stance) yields a confident DECLINE
+// and an on-mission one (a relevant `support` stance) a confident APPROVE — where
+// the legacy coverage path returned an identical confidence + escalate for both.
+describe("content-aware directional scoring (BI-7E1F128A)", () => {
+  const declineStance = material({
+    materialId: "markets-we-decline",
+    summary: "We decline off-mission consumer-hardware ventures outside our software focus.",
+    direction: "oppose",
+    confidenceWeight: 0.9,
+  });
+  const supportStance = material({
+    materialId: "partner-network",
+    summary: "We go to market through a certified reseller and MSP partner network.",
+    direction: "support",
+    confidenceWeight: 0.7,
+  });
+  const twoStances = baseInput({
+    materials: [declineStance, supportStance],
+    riskTier: "medium",
+  });
+
+  it("recommends DECLINING when the relevant stance opposes the decision", () => {
+    const result = evaluateDecisionPerspective({
+      ...twoStances,
+      question: "Should we sell toasters to fishermen from kiosks on Alaskan docks?",
+      relevanceByMaterialId: new Map([["markets-we-decline", 1], ["partner-network", 0]]),
+      relevanceMethod: "semantic",
+    });
+    expect(result.stanceAlignment).toBe("decline");
+    expect(result.outcomeType).toBe("recommend");
+    expect(result.alignmentScore).toBeLessThan(0);
+    expect(result.confidenceScore).toBeGreaterThan(0);
+  });
+
+  it("recommends APPROVING when the relevant stance supports the decision", () => {
+    const result = evaluateDecisionPerspective({
+      ...twoStances,
+      question: "Should we onboard an MSP as a certified reseller partner?",
+      relevanceByMaterialId: new Map([["markets-we-decline", 0], ["partner-network", 1]]),
+      relevanceMethod: "semantic",
+    });
+    expect(result.stanceAlignment).toBe("approve");
+    expect(result.outcomeType).toBe("recommend");
+    expect(result.alignmentScore).toBeGreaterThan(0);
+  });
+
+  it("produces OPPOSITE verdicts and different confidence for the two decisions (the core fix)", () => {
+    const decline = evaluateDecisionPerspective({
+      ...twoStances,
+      relevanceByMaterialId: new Map([["markets-we-decline", 1], ["partner-network", 0]]),
+    });
+    const approve = evaluateDecisionPerspective({
+      ...twoStances,
+      relevanceByMaterialId: new Map([["markets-we-decline", 0], ["partner-network", 1]]),
+    });
+    expect(decline.stanceAlignment).toBe("decline");
+    expect(approve.stanceAlignment).toBe("approve");
+    expect(decline.confidenceScore).not.toEqual(approve.confidenceScore);
+  });
+
+  it("escalates when relevant support and oppose material conflict (mixed)", () => {
+    const result = evaluateDecisionPerspective({
+      ...twoStances,
+      relevanceByMaterialId: new Map([["markets-we-decline", 1], ["partner-network", 1]]),
+    });
+    expect(result.stanceAlignment).toBe("mixed");
+    expect(result.outcomeType).toBe("escalate");
+  });
+
+  it("escalates when no stance is relevant to the question", () => {
+    const result = evaluateDecisionPerspective({
+      ...twoStances,
+      relevanceByMaterialId: new Map([["markets-we-decline", 0], ["partner-network", 0]]),
+    });
+    expect(result.outcomeType).toBe("defer");
+  });
+
+  it("LEGACY path (no relevance) returns the SAME confidence + escalate for both — the bug this fixes", () => {
+    const a = evaluateDecisionPerspective({ ...twoStances, question: "off-mission?" });
+    const b = evaluateDecisionPerspective({ ...twoStances, question: "on-mission?" });
+    expect(a.confidenceScore).toEqual(b.confidenceScore);
+    expect(a.outcomeType).toBe("escalate");
+    expect(b.outcomeType).toBe("escalate");
+    expect(a.stanceAlignment).toBeUndefined();
+  });
+});

--- a/apps/web/lib/decision-perspective/evaluator.ts
+++ b/apps/web/lib/decision-perspective/evaluator.ts
@@ -12,6 +12,14 @@ import {
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { MARK_DPF_PLATFORM_PROFILE } from "./default-profile";
 import { resolveRecommendedOptionId } from "./option-recommendation";
+import {
+  hasPrincipleConflict,
+  orderedProfileChain,
+  RISK_PENALTY,
+  riskWithin,
+  scoreProfileCoverage,
+  summarizeFreshness,
+} from "./coverage-scoring";
 import type {
   DecisionPerspectiveEvaluationInput,
   DecisionPerspectiveEvaluationResult,
@@ -29,106 +37,6 @@ export { scorePerspectiveMaterial } from "./material";
 
 export const RECENT_OVERRIDE_WINDOW_DAYS = 30;
 
-const RISK_RANK: Record<DecisionRiskTier, number> = {
-  low: 1,
-  medium: 2,
-  high: 3,
-  critical: 4,
-};
-
-const RISK_PENALTY: Record<DecisionRiskTier, number> = {
-  low: 0,
-  medium: 0.1,
-  high: 0.25,
-  critical: 0.5,
-};
-
-function roundConfidence(value: number): number {
-  if (!Number.isFinite(value)) return 0;
-  return Number(Math.max(0, Math.min(1, value)).toFixed(4));
-}
-
-function riskWithin(candidate: DecisionRiskTier, max: DecisionRiskTier): boolean {
-  return RISK_RANK[candidate] <= RISK_RANK[max];
-}
-
-function orderedProfileChain(
-  profile: DecisionPerspectiveProfile,
-  fallbackProfiles: DecisionPerspectiveProfile[] | undefined,
-): DecisionPerspectiveProfile[] {
-  const fallbacks = new Map((fallbackProfiles ?? []).map((entry) => [entry.profileId, entry]));
-  const chain: DecisionPerspectiveProfile[] = [profile];
-  let nextId = profile.fallbackProfileId;
-
-  while (nextId) {
-    const next = fallbacks.get(nextId);
-    if (!next || chain.some((entry) => entry.profileId === next.profileId)) {
-      break;
-    }
-    chain.push(next);
-    nextId = next.fallbackProfileId;
-  }
-
-  return chain;
-}
-
-function scoreProfileCoverage(input: {
-  profile: DecisionPerspectiveProfile;
-  materials: PerspectiveMaterial[];
-  questionDomain: DecisionDomainClass;
-  riskTier: DecisionRiskTier;
-  recentOverrideCount: number;
-}): {
-  profile: DecisionPerspectiveProfile;
-  applicableMaterials: PerspectiveMaterial[];
-  materialScores: PerspectiveMaterialScore[];
-  confidence: number;
-} {
-  const applicableMaterials = input.materials.filter(
-    (material) =>
-      material.profileId === input.profile.profileId
-      && isMaterialApplicable(material, input.questionDomain),
-  );
-  const materialScores = applicableMaterials.map(scorePerspectiveMaterial);
-  const positiveScores = materialScores.filter((score) => score.effectiveWeight > 0);
-  const baseScore = positiveScores.length === 0
-    ? 0
-    : positiveScores.reduce((total, score) => total + score.effectiveWeight, 0) / positiveScores.length;
-  const overridePenalty = Math.min(0.3, input.recentOverrideCount * 0.1);
-  const confidence = roundConfidence(baseScore - RISK_PENALTY[input.riskTier] - overridePenalty);
-
-  return {
-    profile: input.profile,
-    applicableMaterials,
-    materialScores,
-    confidence,
-  };
-}
-
-function summarizeFreshness(scores: PerspectiveMaterialScore[]) {
-  return scores.reduce(
-    (counts, score) => {
-      counts[score.freshness] += 1;
-      return counts;
-    },
-    { current: 0, stale: 0, superseded: 0, contradicted: 0 },
-  );
-}
-
-function hasPrincipleConflict(materials: PerspectiveMaterial[]): boolean {
-  const activeDirections = new Set(
-    materials
-      .filter((material) => material.sourceType === "principle")
-      .filter((material) => material.freshness === "current")
-      .filter((material) => material.reviewStatus === "approved")
-      .filter((material) => material.promotionState === "promoted")
-      .map((material) => material.direction ?? material.principleDirection)
-      .filter((direction): direction is "support" | "oppose" => direction === "support" || direction === "oppose"),
-  );
-
-  return activeDirections.has("support") && activeDirections.has("oppose");
-}
-
 export function evaluateDecisionPerspective(
   input: DecisionPerspectiveEvaluationInput,
 ): DecisionPerspectiveEvaluationResult {
@@ -142,6 +50,7 @@ export function evaluateDecisionPerspective(
       questionDomain: input.questionDomain,
       riskTier: input.riskTier,
       recentOverrideCount,
+      relevanceByMaterialId: input.relevanceByMaterialId,
     }),
   );
   const selectedCoverage = coverageByProfile.find((coverage) => coverage.confidence > 0);
@@ -216,9 +125,100 @@ export function evaluateDecisionPerspective(
     // below is known — this evaluator is synchronous and the commandment
     // lookup is not.
     recommendedOptionId: null,
+    ...(selectedCoverage.contentAware
+      ? {
+          alignmentScore: selectedCoverage.alignmentScore,
+          stanceAlignment: selectedCoverage.stanceAlignment,
+          relevanceMethod: input.relevanceMethod,
+        }
+      : {}),
     materialScores: selectedCoverage.materialScores,
     sources,
   };
+
+  // ── Content-aware directional outcome (WWWD, BI-7E1F128A) ────────────────────
+  // The org's OWN recorded stance is its standing decision for this class, so a
+  // clear, relevant stance governs — instead of every medium-risk business call
+  // bouncing back to the owner. Declining is inherently safe (saying "no" to an
+  // off-mission idea), so a relevant `oppose` stance recommends declining at any
+  // non-critical risk; approving carries consequence, so a `support` stance
+  // governs at low/medium risk but a high-risk approval still escalates.
+  if (selectedCoverage.contentAware) {
+    const alignment = selectedCoverage.stanceAlignment ?? "none";
+
+    // Conflict is judged by RELEVANCE-WEIGHTED direction (`mixed`), not the
+    // coarse content-blind `principleConflict` — otherwise a domain that merely
+    // *contains* an opposing principle would escalate every decision even when
+    // only one side is relevant to the question. `principleConflict` is still
+    // recorded on the result for audit.
+    if (alignment === "mixed") {
+      return {
+        ...baseResult,
+        outcomeType: "escalate",
+        rationale:
+          "Your recorded stance points in conflicting directions on this decision. Escalating to your call, and the resolution becomes candidate stance material.",
+      };
+    }
+
+    if (input.riskTier === "critical") {
+      return {
+        ...baseResult,
+        outcomeType: "escalate",
+        rationale:
+          `This is a critical-risk decision, so it goes to your call even though your recorded stance leans ${alignment} at confidence ${confidence}.`,
+      };
+    }
+
+    if (
+      alignment === "none"
+      || confidence < selectedProfile.autonomyPolicy.minimumConfidenceForRecommendation
+    ) {
+      return {
+        ...baseResult,
+        outcomeType: "escalate",
+        rationale:
+          `Your recorded stance does not clearly speak to this decision (alignment ${alignment}, confidence ${confidence} below the ${selectedProfile.autonomyPolicy.minimumConfidenceForRecommendation} threshold). Escalating to your call.`,
+        gapReason: "material-below-confidence",
+      };
+    }
+
+    if (alignment === "decline") {
+      return {
+        ...baseResult,
+        outcomeType: "recommend",
+        rationale:
+          `Recommend DECLINING: your recorded stance opposes this decision at confidence ${confidence}. Declining an off-stance option is low-consequence, so this does not require your live call.`,
+      };
+    }
+
+    // alignment === "approve"
+    if (input.riskTier === "high") {
+      return {
+        ...baseResult,
+        outcomeType: "escalate",
+        rationale:
+          `Your recorded stance supports this at confidence ${confidence}, but approving a high-risk decision still needs your live call.`,
+      };
+    }
+    if (
+      selectedProfile.autonomyPolicy.allowArbitration
+      && riskWithin(input.riskTier, selectedProfile.autonomyPolicy.maxRiskForArbitration)
+      && confidence >= selectedProfile.autonomyPolicy.minimumConfidenceForArbitration
+    ) {
+      return {
+        ...baseResult,
+        outcomeType: "arbitrate",
+        rationale:
+          `Arbitrate and proceed: your recorded stance supports this at confidence ${confidence} and the autonomy policy allows arbitration at ${input.riskTier} risk.`,
+      };
+    }
+    return {
+      ...baseResult,
+      outcomeType: "recommend",
+      rationale:
+        `Recommend APPROVING: your recorded stance supports this decision at confidence ${confidence}.`,
+    };
+  }
 
   if (principleConflict) {
     return {
@@ -382,15 +382,25 @@ export function operatorMessageFor(
     const scope = orgProfileSelected
       ? "your organization's recorded stance"
       : "platform defaults (your organization has not recorded a stance here yet)";
+    const direction =
+      evaluation.stanceAlignment === "approve"
+        ? "approving"
+        : evaluation.stanceAlignment === "decline"
+          ? "declining"
+          : null;
     switch (evaluation.outcomeType) {
       case "defer":
         return `No applicable business stance found via ${scope}. ${evaluation.rationale}`;
       case "escalate":
         return `This business decision needs your call (${scope}). ${evaluation.rationale}`;
       case "arbitrate":
-        return `Decided from ${scope} at ${evaluation.confidenceScore} confidence.`;
+        return direction
+          ? `Decided ${direction} from ${scope} at ${evaluation.confidenceScore} confidence.`
+          : `Decided from ${scope} at ${evaluation.confidenceScore} confidence.`;
       default:
-        return `Recommended from ${scope} at ${evaluation.confidenceScore} confidence.`;
+        return direction
+          ? `Recommended ${direction} from ${scope} at ${evaluation.confidenceScore} confidence.`
+          : `Recommended from ${scope} at ${evaluation.confidenceScore} confidence.`;
     }
   }
 
@@ -631,6 +641,33 @@ export async function evaluatePerspectiveGate(input: {
     ];
   }
 
+  // Content-aware WWWD scoring (BI-7E1F128A): compute how relevant each stance
+  // material is to THIS question, so the verdict discriminates by decision
+  // content instead of returning a per-domain coverage constant. WWMD (the build
+  // gate) keeps its coverage-only path — relevance is only computed when the
+  // caller supplied an organizationId. Fail-soft: a relevance error falls through
+  // to coverage-only rather than breaking the fail-closed gate.
+  let relevanceByMaterialId: Map<string, number> | undefined;
+  let relevanceMethod: "semantic" | "lexical" | undefined;
+  if (isWwwd && resolved.materials.length > 0) {
+    try {
+      const { computeStanceRelevance } = await import("./stance-relevance");
+      const relevance = await computeStanceRelevance({
+        question: input.question,
+        materials: resolved.materials,
+      });
+      relevanceByMaterialId = relevance.relevanceByMaterialId;
+      relevanceMethod = relevance.method;
+    } catch (error) {
+      console.info(
+        `[tool-trace] ${prefix}.relevance.failed ${JSON.stringify({
+          interactionId,
+          errorClass: errorClass(error),
+        })}`,
+      );
+    }
+  }
+
   const evaluator = input.evaluator ?? evaluateDecisionPerspective;
   let evaluation: DecisionPerspectiveEvaluationResult;
 
@@ -646,6 +683,8 @@ export async function evaluatePerspectiveGate(input: {
       riskTier: input.riskTier,
       recentOverrideCount: overrides,
       evidence,
+      relevanceByMaterialId,
+      relevanceMethod,
     });
   } catch (error) {
     evaluation = failClosedEvaluation({

--- a/apps/web/lib/decision-perspective/evaluator.ts
+++ b/apps/web/lib/decision-perspective/evaluator.ts
@@ -15,7 +15,6 @@ import { resolveRecommendedOptionId } from "./option-recommendation";
 import {
   hasPrincipleConflict,
   orderedProfileChain,
-  RISK_PENALTY,
   riskWithin,
   scoreProfileCoverage,
   summarizeFreshness,

--- a/apps/web/lib/decision-perspective/stance-relevance.test.ts
+++ b/apps/web/lib/decision-perspective/stance-relevance.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { computeStanceRelevance, cosineSimilarity } from "./stance-relevance";
+import type { DecisionDomainClass, PerspectiveMaterial } from "./types";
+
+const RISK_ASSESSMENT_DOMAIN_CLASS: DecisionDomainClass = "risk-assessment";
+
+function material(overrides: Partial<PerspectiveMaterial>): PerspectiveMaterial {
+  return {
+    materialId: "m",
+    profileId: "p",
+    sourceType: "stance",
+    sourceRef: {},
+    summary: "",
+    domainClass: RISK_ASSESSMENT_DOMAIN_CLASS,
+    direction: "neutral",
+    domains: [],
+    freshness: "current",
+    evidenceGrade: "A",
+    confidenceWeight: 0.9,
+    reviewStatus: "approved",
+    promotionState: "promoted",
+    lastValidatedAt: null,
+    ...overrides,
+  };
+}
+
+describe("cosineSimilarity", () => {
+  it("is 1 for identical vectors and 0 for orthogonal", () => {
+    expect(cosineSimilarity([1, 0], [1, 0])).toBeCloseTo(1);
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0);
+  });
+});
+
+describe("computeStanceRelevance", () => {
+  const declineStance = material({ materialId: "decline", summary: "We decline off-mission consumer hardware ventures.", direction: "oppose" });
+  const supportStance = material({ materialId: "support", summary: "We go to market through a reseller and MSP partner network.", direction: "support" });
+
+  it("semantic: the on-point stance dominates (min-max normalised)", async () => {
+    // Embed the question like the decline stance ([1,0]) and unlike the support one ([0,1]).
+    const vectors: Record<string, number[]> = {
+      "toaster question": [1, 0],
+      "We decline off-mission consumer hardware ventures.": [1, 0],
+      "We go to market through a reseller and MSP partner network.": [0, 1],
+    };
+    const result = await computeStanceRelevance({
+      question: "toaster question",
+      materials: [declineStance, supportStance],
+      embed: async (text) => vectors[text] ?? [0, 0],
+    });
+    expect(result.method).toBe("semantic");
+    expect(result.relevanceByMaterialId.get("decline")).toBe(1);
+    expect(result.relevanceByMaterialId.get("support")).toBe(0);
+  });
+
+  it("falls back to lexical overlap when embeddings are unavailable", async () => {
+    const result = await computeStanceRelevance({
+      question: "should we onboard a reseller MSP partner",
+      materials: [declineStance, supportStance],
+      embed: async () => null,
+    });
+    expect(result.method).toBe("lexical");
+    // The support stance shares 'reseller'/'partner'/'msp' with the question.
+    expect(result.relevanceByMaterialId.get("support")!).toBeGreaterThan(
+      result.relevanceByMaterialId.get("decline")!,
+    );
+  });
+
+  it("gives a lone applicable stance full relevance", async () => {
+    const result = await computeStanceRelevance({
+      question: "anything",
+      materials: [supportStance],
+      embed: async () => null,
+    });
+    expect(result.relevanceByMaterialId.get("support")).toBe(1);
+  });
+
+  it("returns an empty map for no materials", async () => {
+    const result = await computeStanceRelevance({ question: "q", materials: [] });
+    expect(result.relevanceByMaterialId.size).toBe(0);
+  });
+});

--- a/apps/web/lib/decision-perspective/stance-relevance.ts
+++ b/apps/web/lib/decision-perspective/stance-relevance.ts
@@ -1,0 +1,139 @@
+// Question ↔ stance relevance for the WWWD/WWMD decision gate (BI-7E1F128A).
+//
+// The evaluator used to score confidence purely from domain-coverage — the
+// AVERAGE effective weight of every material whose `domainClass` matched, with
+// the QUESTION TEXT never read. So two opposite decisions in the same domain
+// (a blatantly off-mission one and a core on-mission one) resolved to the SAME
+// applicable materials and produced an identical confidence + escalate verdict.
+// The recorded stance was selected but could not discriminate.
+//
+// This module supplies the missing signal: how RELEVANT each applicable stance
+// material is to THIS question. Relevance is semantic (cosine over embeddings of
+// the question vs each material's summary) with a lexical token-overlap fallback
+// when the embedding model is unavailable — the gate is fail-closed, so it must
+// still produce a content signal on a cold install. Scores are min-max
+// normalised WITHIN the applicable set so the most-on-point stance dominates
+// regardless of the embedding model's absolute-similarity baseline; the least
+// on-point stance falls away. The evaluator then weights each material by
+// relevance and reads its `direction` to produce a directional, content-aware
+// verdict.
+
+import type { PerspectiveMaterial } from "./types";
+
+/** Cosine similarity of two equal-length numeric vectors. */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length === 0 || a.length !== b.length) return 0;
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i]! * b[i]!;
+    normA += a[i]! * a[i]!;
+    normB += b[i]! * b[i]!;
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+const STOP_WORDS = new Set([
+  "the", "a", "an", "and", "or", "but", "of", "to", "in", "on", "for", "with",
+  "is", "are", "be", "we", "our", "should", "do", "does", "did", "can", "could",
+  "would", "will", "shall", "how", "what", "which", "that", "this", "these",
+  "those", "from", "by", "at", "as", "it", "its", "into", "than", "then",
+]);
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]+/g, " ")
+      .split(/\s+/)
+      .filter((token) => token.length > 2 && !STOP_WORDS.has(token)),
+  );
+}
+
+/** Jaccard-style overlap of the question against a material's summary + domains. */
+function lexicalRelevance(questionTokens: Set<string>, material: PerspectiveMaterial): number {
+  const materialTokens = tokenize(`${material.summary} ${material.domains.join(" ")}`);
+  if (materialTokens.size === 0 || questionTokens.size === 0) return 0;
+  let shared = 0;
+  for (const token of materialTokens) {
+    if (questionTokens.has(token)) shared += 1;
+  }
+  // Overlap relative to the material's own token count — a short, on-topic stance
+  // should not be penalised for being short.
+  return shared / materialTokens.size;
+}
+
+/** Min-max normalise a list of raw scores into [0,1]. A degenerate set (one
+ *  entry, or all-equal) maps every entry to 1 — with a single applicable stance
+ *  there is nothing to discriminate against, so it carries full relevance. */
+function normalise(raw: number[]): number[] {
+  if (raw.length <= 1) return raw.map(() => 1);
+  const min = Math.min(...raw);
+  const max = Math.max(...raw);
+  if (max - min < 1e-9) return raw.map(() => 1);
+  return raw.map((value) => (value - min) / (max - min));
+}
+
+export type StanceRelevanceResult = {
+  /** relevance ∈ [0,1] keyed by materialId (higher = more on-point for the question). */
+  relevanceByMaterialId: Map<string, number>;
+  /** How the signal was produced, for the audit trail. */
+  method: "semantic" | "lexical";
+};
+
+/**
+ * Compute how relevant each applicable stance material is to the question.
+ *
+ * Prefers semantic similarity (embeddings); falls back to lexical token overlap
+ * when the embedding model is unavailable so the gate never loses its content
+ * signal. Scores are min-max normalised within the applicable set. `embed` is
+ * injectable for tests; it defaults to the platform embedding provider and may
+ * return null when embeddings are unavailable (then we fall back to lexical).
+ */
+export async function computeStanceRelevance(input: {
+  question: string;
+  materials: PerspectiveMaterial[];
+  embed?: (text: string) => Promise<number[] | null>;
+}): Promise<StanceRelevanceResult> {
+  const { question, materials } = input;
+  const relevanceByMaterialId = new Map<string, number>();
+  if (materials.length === 0) {
+    return { relevanceByMaterialId, method: "lexical" };
+  }
+
+  const embed =
+    input.embed ??
+    (async (text: string) => {
+      const { generateEmbedding } = await import("@/lib/inference/embedding");
+      return generateEmbedding(text);
+    });
+
+  // Try semantic first: embed the question and every material summary.
+  let method: "semantic" | "lexical" = "lexical";
+  const questionEmbedding = await embed(question).catch(() => null);
+  let rawScores: number[] | null = null;
+
+  if (questionEmbedding && questionEmbedding.length > 0) {
+    const materialEmbeddings = await Promise.all(
+      materials.map((m) => embed(m.summary || m.domains.join(" ")).catch(() => null)),
+    );
+    if (materialEmbeddings.every((e) => e && e.length === questionEmbedding.length)) {
+      method = "semantic";
+      rawScores = materialEmbeddings.map((e) =>
+        // cosine in [-1,1] → clamp negatives to 0; opposite-meaning text is "not relevant", not "negatively relevant".
+        Math.max(0, cosineSimilarity(questionEmbedding, e as number[])),
+      );
+    }
+  }
+
+  if (!rawScores) {
+    const questionTokens = tokenize(question);
+    rawScores = materials.map((m) => lexicalRelevance(questionTokens, m));
+  }
+
+  const normalised = normalise(rawScores);
+  materials.forEach((m, i) => relevanceByMaterialId.set(m.materialId, normalised[i]!));
+  return { relevanceByMaterialId, method };
+}

--- a/apps/web/lib/decision-perspective/types.ts
+++ b/apps/web/lib/decision-perspective/types.ts
@@ -163,6 +163,17 @@ export type DecisionPerspectiveEvaluationInput = {
   riskTier: DecisionRiskTier;
   evidence?: DecisionEvidenceItem[];
   recentOverrideCount?: number;
+  /**
+   * Per-material relevance ∈ [0,1] to `question` (BI-7E1F128A), keyed by
+   * materialId. Computed async upstream (semantic embeddings with lexical
+   * fallback) and passed into this synchronous evaluator so scoring is
+   * content-aware without the evaluator itself doing IO. When omitted, every
+   * applicable material is treated as fully relevant (legacy coverage-only
+   * behaviour).
+   */
+  relevanceByMaterialId?: Map<string, number>;
+  /** How `relevanceByMaterialId` was computed, echoed onto the result. */
+  relevanceMethod?: "semantic" | "lexical";
 };
 
 export type DecisionPerspectiveEvaluationResult = {
@@ -192,6 +203,22 @@ export type DecisionPerspectiveEvaluationResult = {
    * recommending a path forward.
    */
   recommendedOptionId?: string | null;
+  /**
+   * Net directional pull of the stance material that is RELEVANT to this
+   * question (BI-7E1F128A), in [-1, 1]: +1 = the relevant stance wholly supports
+   * the decision, -1 = it wholly opposes it, 0 = no directional signal or a
+   * support/oppose conflict. Undefined on the legacy coverage-only path.
+   */
+  alignmentScore?: number;
+  /**
+   * The directional verdict derived from `alignmentScore`: `approve` when the
+   * org's relevant stance supports the decision, `decline` when it opposes it,
+   * `mixed` when relevant support and oppose material conflict, `none` when no
+   * relevant stance speaks to it.
+   */
+  stanceAlignment?: "approve" | "decline" | "mixed" | "none";
+  /** How question↔stance relevance was computed for this evaluation. */
+  relevanceMethod?: "semantic" | "lexical";
   rationale: string;
   materialScores: PerspectiveMaterialScore[];
   sources: Array<{

--- a/apps/web/lib/inference/jit-retrieval-discipline.test.ts
+++ b/apps/web/lib/inference/jit-retrieval-discipline.test.ts
@@ -31,6 +31,7 @@ const ALLOWED_EMBEDDING_CALLERS: ReadonlySet<string> = new Set([
   "apps/web/lib/wiki/principle-similarity.ts", // principle-vector similarity
   "apps/web/lib/mcp/packs/principle-decide-pack.ts", // principle-direction + semantic-decision knowledge
   "apps/web/lib/decision/evidence-grounding.ts", // embeds the option DESCRIPTION (transient decision input) for principle_decide's semantic fallback — same purpose as the pack entry, extracted here for module size; embeds no operational record (EP-VERIFICATION-INTEGRITY)
+  "apps/web/lib/decision-perspective/stance-relevance.ts", // embeds the decision QUESTION (transient input) + WWWD stance SUMMARIES (durable knowledge corpus) to score question↔stance relevance for the org business-decision gate; nothing is persisted to the vector store, no operational record (BI-7E1F128A)
 ]);
 
 function repoRoot(): string {

--- a/apps/web/lib/mcp/packs/org-decision-pack.ts
+++ b/apps/web/lib/mcp/packs/org-decision-pack.ts
@@ -152,6 +152,12 @@ async function evaluateOrgBusinessDecision(
       allowed: decision.allowed,
       outcomeType: decision.evaluation.outcomeType,
       confidenceScore: decision.evaluation.confidenceScore,
+      // Content-aware directional verdict (BI-7E1F128A): approve/decline/mixed/none
+      // and the [-1,1] alignment behind it, so an off-mission decision surfaces a
+      // confident decline and an on-mission one a confident approve.
+      stanceAlignment: decision.evaluation.stanceAlignment ?? null,
+      alignmentScore: decision.evaluation.alignmentScore ?? null,
+      relevanceMethod: decision.evaluation.relevanceMethod ?? null,
       orgProfileSelected: decision.orgProfileSelected,
       recommendedOptionId: decision.evaluation.recommendedOptionId ?? null,
       rationale: rationale.length > 500 ? `${rationale.slice(0, 500)}...` : rationale,

--- a/docs/superpowers/plans/2026-08-12-wwwd-content-discrimination.md
+++ b/docs/superpowers/plans/2026-08-12-wwwd-content-discrimination.md
@@ -1,0 +1,72 @@
+# WWWD decision content discrimination — 2026-08-12 (BI-7E1F128A)
+
+## Problem
+
+`evaluate_org_business_decision` returned an identical confidence (0.6333) and
+`escalate` outcome for opposite decisions — a blatantly off-mission one and a core
+on-mission one — even after the org published directly-relevant WWWD stances. The
+recorded stance was selected but did not change the verdict, so the headline
+promise ("your coworkers decide per your business") was not delivered.
+
+## Root cause (confirmed)
+
+`apps/web/lib/decision-perspective/evaluator.ts` → `scoreProfileCoverage`:
+confidence was `average(effectiveWeight)` of every material whose `domainClass`
+matched, minus risk/override penalties. `scorePerspectiveMaterial` reads only
+weight/freshness/evidence/review/promotion; the QUESTION TEXT was passed through
+but never read; `resolveProfileMaterial` fetched materials by `profileId +
+domainClass` only. So two decisions in the same domain (both `risk-assessment`,
+`medium` risk) pulled the same materials → identical confidence + escalate.
+
+## Fix — content-aware directional scoring
+
+Source of truth: the existing WWWD substrate (`org-business-gate` → `evaluator` →
+`material`). No new contract; a relevance signal is composed in. WWMD (the
+build-studio gate, which shares `evaluateDecisionPerspective`) is untouched — the
+new path activates ONLY when a relevance map is supplied, which happens only on
+the WWWD (organizationId) path.
+
+- **`stance-relevance.ts`** (new): `computeStanceRelevance(question, materials)`
+  scores how relevant each stance is to the question — semantic cosine over
+  embeddings of the question vs each material `summary`, min-max normalised within
+  the applicable set (robust to the embedding model's absolute-similarity
+  baseline), with a lexical token-overlap fallback when the embedding model is
+  unavailable (the gate is fail-closed, so it must keep a content signal on a cold
+  install). Injectable `embed` for tests.
+- **`evaluator.ts`**: the async gate computes relevance for WWWD (fail-soft) and
+  passes a `relevanceByMaterialId` map into the synchronous evaluator. When
+  present, `scoreProfileCoverage` weights each material by relevance and reads its
+  `direction`: `supportMass`/`opposeMass`, `alignmentScore = (support − oppose) /
+  (support + oppose)` ∈ [-1,1], and confidence = strongest-relevant-directional-
+  weight × |alignment| − penalties. Outcome is directional and asymmetric on
+  safety: a relevant `oppose` stance recommends DECLINING at any non-critical risk
+  (saying "no" to an off-stance idea is low-consequence); a relevant `support`
+  stance governs at low/medium risk (the published stance IS the owner's standing
+  decision) but a high-risk approval still escalates; `mixed`/`none`/below-
+  threshold escalates.
+- **`types.ts`**: result gains `alignmentScore`, `stanceAlignment`
+  (approve/decline/mixed/none), `relevanceMethod`.
+- **`org-decision-pack.ts`**: the MCP response surfaces the directional verdict.
+
+## Verification
+
+- New tests: `stance-relevance.test.ts` (semantic + lexical fallback +
+  normalisation) and `evaluator.test.ts` directional cases — a relevant `oppose`
+  stance → confident DECLINE, a relevant `support` stance → confident APPROVE,
+  opposite verdicts with different confidence; and the legacy (no-relevance) path
+  still returns the identical-confidence + escalate it did before (the documented
+  bug), proving WWMD is unchanged.
+- Full `lib/decision-perspective/` suite green (253 tests).
+- Live: after deploy, re-run `evaluate_org_business_decision` for the toaster
+  (off-mission → confident decline) and MSP-partner (on-mission → confident
+  approve) and confirm materially different scores + directions.
+
+## Follow-ups (out of scope, noted)
+
+The taxonomy mismatch the BI also flags (stance categories vs the `domainClass`
+enum; no mission/market-alignment axis) is a separate concern — this fix makes the
+existing domain content-discriminating; a dedicated market-alignment axis can
+layer on later.
+
+Design-Grounding-Decision: extends the existing decision-perspective evaluator; no
+new contract.


### PR DESCRIPTION
## The bug (P1)
`evaluate_org_business_decision` returned an **identical 0.6333 confidence + `escalate`** for opposite decisions — a blatantly off-mission one (toasters to Alaskan fishermen) and a core on-mission one (onboard an MSP reseller) — even after the org published directly-relevant WWWD stances. Recorded stance was selected but did not change the verdict, so the headline promise ("your coworkers decide per your business") was not delivered.

## Root cause
WWWD confidence was `average(effectiveWeight)` of every material whose `domainClass` matched, minus risk/override penalties. The **question text was never read**, and `resolveProfileMaterial` fetched materials by `profileId + domainClass` only — so two decisions in the same domain pulled the same materials and scored identically.

## Fix — content-aware directional scoring (WWWD only; WWMD's shared evaluator untouched)
- **`stance-relevance.ts`** (new): scores how relevant each stance is to the question — semantic cosine over embeddings of the question vs each stance `summary`, **min-max normalised within the applicable set** (robust to embedding baseline), with a **lexical token-overlap fallback** when the embedding model is down (the gate is fail-closed).
- **`coverage-scoring.ts`** (extracted from `evaluator.ts`): when a relevance map is supplied, weights each material by relevance and reads its `direction` — `alignmentScore = (support − oppose)/(support + oppose)`, confidence = strongest-relevant-directional-weight × |alignment| − penalties.
- **Directional, safety-asymmetric outcome:** a relevant `oppose` stance → confident **DECLINE** at any non-critical risk (declining an off-stance idea is low-consequence); a relevant `support` stance governs at low/medium risk (the published stance *is* the owner's standing decision) while a high-risk approval still escalates; `mixed`/`none`/below-threshold escalate. The MCP response surfaces `stanceAlignment` + `alignmentScore`.

The new path activates **only when an organizationId is present** (WWWD). WWMD keeps its coverage-only path verbatim — a regression test proves the legacy no-relevance path still returns the identical-confidence + escalate it did before.

## Verification
- New tests: `stance-relevance` (semantic + lexical fallback + normalisation) and directional `evaluator` cases — opposite `oppose`/`support` stances → confident DECLINE vs confident APPROVE, opposite verdicts, different confidence.
- Full `lib/decision-perspective/` suite green (253 tests); JIT-retrieval discipline allowlist updated (transient question + durable stance knowledge, nothing persisted).
- Local-CI gate passed against merged `main`. Evidence `cmsqsgjbu02k401qaqsjjx85t`.
- Live (post-deploy): re-run for the toaster (→ confident decline) and MSP-partner (→ confident approve) and confirm materially different scores + directions.

Design-Grounding-Decision: extends the existing decision-perspective evaluator; no new contract. Plan: `docs/superpowers/plans/2026-08-12-wwwd-content-discrimination.md`.
Docs-Impact-Decision: internal decision-engine scoring change; the MCP tool gains directional fields but no user-guide route/page changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)