### PR TITLE
fix(restaurant): unify booking timezone

### DIFF
--- a/apps/web/app/(shell)/storefront/inbox/page.tsx
+++ b/apps/web/app/(shell)/storefront/inbox/page.tsx
@@ -5,10 +5,13 @@ import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/finance/currency-symbol";
 import { formatReservationWhen, nextActionForReservation } from "@/lib/storefront/booking-summary";
 import { nextActionForOrder, summarizeOrderItems } from "@/lib/storefront/order-lifecycle";
+import { loadStorefrontOperatingTimezone } from "@/lib/storefront/storefront-operating-timezone.server";
 
 export default async function InboxPage() {
-  const config = await prisma.storefrontConfig.findFirst({ select: { id: true, timezone: true } });
+  const config = await prisma.storefrontConfig.findFirst({ select: { id: true } });
   if (!config) redirect("/storefront/setup");
+
+  const operatingTimezone = await loadStorefrontOperatingTimezone(prisma);
 
   const [inquiries, bookings, orders, donations, providerList, digitalProducts, orgSettings] = await Promise.all([
     prisma.storefrontInquiry.findMany({
@@ -154,7 +157,7 @@ export default async function InboxPage() {
         ) ?? null,
     })),
     ...bookings.map((booking) => {
-      const when = formatReservationWhen(booking.scheduledAt, config.timezone);
+      const when = formatReservationWhen(booking.scheduledAt, operatingTimezone);
       return {
         id: booking.id,
         ref: booking.bookingRef,

--- a/apps/web/lib/release/storefront-actions.test.ts
+++ b/apps/web/lib/release/storefront-actions.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/lib/actions/finance", () => ({
 }));
 vi.mock("@dpf/db", () => {
   const prisma = {
+    businessProfile: { findFirst: vi.fn() },
     storefrontConfig: { findFirst: vi.fn() },
     storefrontInquiry: { create: vi.fn() },
     storefrontBooking: { create: vi.fn() },
@@ -382,6 +383,9 @@ describe("submitBooking (enhanced)", () => {
   });
 
   it("writes the structured hospitality resource and allocation in the booking transaction", async () => {
+    vi.mocked(prisma.businessProfile.findFirst).mockResolvedValue({
+      timezone: "America/Chicago",
+    } as never);
     vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue(
       mockPublishedStorefront as never,
     );
@@ -415,6 +419,10 @@ describe("submitBooking (enhanced)", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(prisma.businessProfile.findFirst).toHaveBeenCalledWith({
+      where: { isActive: true },
+      select: { timezone: true },
+    });
     expect(prisma.storefrontBooking.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({

--- a/apps/web/lib/release/storefront-data.ts
+++ b/apps/web/lib/release/storefront-data.ts
@@ -1,7 +1,7 @@
 import { cache } from "react";
 import { prisma } from "@dpf/db";
 import type { FormField } from "@dpf/storefront-templates";
-import { resolveOperatingHoursTimezone } from "@/lib/operating-hours-types";
+import { loadStorefrontOperatingTimezone } from "@/lib/storefront/storefront-operating-timezone.server";
 import { listOwnerMedia, mediaAssetUrl } from "@/lib/media";
 import { getCurrencySymbol } from "@/lib/finance/currency-symbol";
 import type {
@@ -206,11 +206,7 @@ export const getPublicStorefront = cache(async function getPublicStorefront(
   // Resolve through the same helper the Operating Hours settings page uses so the
   // calendar label always matches what the operator sees there (UTC on a fresh
   // install), never the stale config default.
-  const businessProfile = await prisma.businessProfile.findFirst({
-    where: { isActive: true },
-    select: { timezone: true },
-  });
-  const resolvedTimezone = resolveOperatingHoursTimezone(businessProfile?.timezone);
+  const resolvedTimezone = await loadStorefrontOperatingTimezone(prisma);
 
   // Confirmed regulatory display obligations for the "disclosures" section
   // (BI-5D9DCDE6 spec §9.3). D5 honesty rule: only obligations whose parent

--- a/apps/web/lib/storefront/hospitality-capacity-repository.server.test.ts
+++ b/apps/web/lib/storefront/hospitality-capacity-repository.server.test.ts
@@ -13,6 +13,9 @@ import {
 
 function database(overrides: Record<string, unknown> = {}) {
   return {
+    businessProfile: {
+      findFirst: vi.fn(async () => ({ timezone: "UTC" })),
+    },
     hospitalityResource: {
       findFirst: vi.fn(async () => ({
         id: "table-1",
@@ -162,6 +165,62 @@ describe("hospitality capacity repository", () => {
       }),
     ).rejects.toBeInstanceOf(HospitalityCapacityConflictError);
     expect(create).not.toHaveBeenCalled();
+  });
+
+  it("evaluates a Restaurant table schedule in the operator's Chicago timezone", async () => {
+    const create = vi.fn(async ({ data }: { data: Record<string, unknown> }) => ({
+      id: "allocation-row",
+      version: 1,
+      ...data,
+    }));
+    const db = database({
+      businessProfile: {
+        findFirst: vi.fn(async () => ({ timezone: "America/Chicago" })),
+      },
+      hospitalityResource: {
+        findFirst: vi.fn(async () => ({
+          id: "table-1",
+          legacyServiceProviderId: "provider-1",
+          status: "active",
+          capacity: 4,
+          availability: [
+            {
+              kind: "available",
+              days: [3],
+              startTime: "11:00",
+              endTime: "22:00",
+              date: null,
+            },
+          ],
+          storefront: { timezone: "Europe/London" },
+        })),
+      },
+      hospitalityCapacityAllocation: {
+        findFirst: vi.fn(async () => null),
+        findMany: vi.fn(async () => []),
+        create,
+        updateMany: vi.fn(async () => ({ count: 0 })),
+      },
+    });
+
+    await expect(
+      allocateHospitalityCapacity(db, {
+        organizationId: "org-1",
+        storefrontId: "storefront-1",
+        resourceId: "table-1",
+        poolId: null,
+        demandType: "booking",
+        demandRef: "BK-CHICAGO",
+        bookingId: "booking-chicago",
+        bookingHoldId: null,
+        startsAt: new Date("2026-08-13T00:31:27.615Z"),
+        // clock-bomb-guard: allow pure interval fixture has no wall-clock dependency
+        endsAt: new Date("2026-08-13T02:01:27.615Z"),
+        quantity: 1,
+        idempotencyKey: "booking:booking-chicago",
+      }),
+    ).resolves.toEqual(expect.objectContaining({ demandRef: "BK-CHICAGO" }));
+    expect(create).toHaveBeenCalledTimes(1);
   });
 
   it("rejects party demand above a discrete resource's seat capacity", async () => {

--- a/apps/web/lib/storefront/hospitality-capacity-repository.server.ts
+++ b/apps/web/lib/storefront/hospitality-capacity-repository.server.ts
@@ -1,4 +1,5 @@
 import { newId } from "@/lib/shared/new-id";
+import { loadStorefrontOperatingTimezone } from "./storefront-operating-timezone.server";
 
 import {
   evaluatePoolCapacity,
@@ -13,6 +14,9 @@ import {
 } from "./hospitality-capacity";
 
 interface HospitalityCapacityDatabase {
+  businessProfile: {
+    findFirst(args: unknown): Promise<{ timezone: string } | null>;
+  };
   hospitalityResource: {
     findFirst(args: unknown): Promise<{
       id: string;
@@ -20,7 +24,6 @@ interface HospitalityCapacityDatabase {
       status: string;
       capacity?: number;
       availability?: HospitalityAvailabilityWindow[];
-      storefront?: { timezone: string };
     } | null>;
   };
   hospitalityCapacityPool: {
@@ -132,7 +135,6 @@ export async function allocateHospitalityCapacity(
             date: true,
           },
         },
-        storefront: { select: { timezone: true } },
       },
     });
     if (!resource) {
@@ -155,7 +157,7 @@ export async function allocateHospitalityCapacity(
         availability: resource.availability ?? [],
         startsAt: input.startsAt,
         endsAt: input.endsAt,
-        timeZone: resource.storefront?.timezone ?? "UTC",
+        timeZone: await loadStorefrontOperatingTimezone(database),
       })
     ) {
       throw new HospitalityCapacityConflictError(

--- a/apps/web/lib/storefront/storefront-operating-timezone.server.test.ts
+++ b/apps/web/lib/storefront/storefront-operating-timezone.server.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { loadStorefrontOperatingTimezone } from "./storefront-operating-timezone.server";
+
+describe("loadStorefrontOperatingTimezone", () => {
+  it("uses the operator-pinned BusinessProfile timezone instead of the stale storefront default", async () => {
+    const findFirst = vi.fn(async () => ({ timezone: "America/Chicago" }));
+
+    await expect(
+      loadStorefrontOperatingTimezone({ businessProfile: { findFirst } }),
+    ).resolves.toBe("America/Chicago");
+    expect(findFirst).toHaveBeenCalledWith({
+      where: { isActive: true },
+      select: { timezone: true },
+    });
+  });
+
+  it("uses the same UTC fallback as Operating Hours when no active profile exists", async () => {
+    const findFirst = vi.fn(async () => null);
+
+    await expect(
+      loadStorefrontOperatingTimezone({ businessProfile: { findFirst } }),
+    ).resolves.toBe("UTC");
+  });
+});

--- a/apps/web/lib/storefront/storefront-operating-timezone.server.ts
+++ b/apps/web/lib/storefront/storefront-operating-timezone.server.ts
@@ -1,0 +1,24 @@
+import { resolveOperatingHoursTimezone } from "@/lib/operating-hours-types";
+
+interface StorefrontOperatingTimezoneDatabase {
+  businessProfile: {
+    findFirst(args: unknown): Promise<{ timezone: string } | null>;
+  };
+}
+
+/**
+ * Canonical storefront and hospitality clock.
+ *
+ * Operating Hours owns the business timezone. StorefrontConfig.timezone is a
+ * legacy default and must not independently drive calendars, confirmations,
+ * owner handoffs, or capacity enforcement.
+ */
+export async function loadStorefrontOperatingTimezone(
+  database: StorefrontOperatingTimezoneDatabase,
+): Promise<string> {
+  const profile = await database.businessProfile.findFirst({
+    where: { isActive: true },
+    select: { timezone: true },
+  });
+  return resolveOperatingHoursTimezone(profile?.timezone);
+}

--- a/apps/web/lib/storefront/submission-result.ts
+++ b/apps/web/lib/storefront/submission-result.ts
@@ -24,6 +24,7 @@ import {
   type SubmissionResultModel,
   type SubmissionType,
 } from "./submission-result-content";
+import { loadStorefrontOperatingTimezone } from "./storefront-operating-timezone.server";
 
 export {
   isSubmissionType,
@@ -70,7 +71,6 @@ export async function loadSubmissionResult(
     where: { organization: { slug } },
     select: {
       id: true,
-      timezone: true,
       contactEmail: true,
       contactPhone: true,
       organization: { select: { name: true, slug: true } },
@@ -79,6 +79,7 @@ export async function loadSubmissionResult(
   if (!config) return null;
 
   const storefrontId = config.id;
+  const operatingTimezone = await loadStorefrontOperatingTimezone(prisma);
   const orgName = config.organization.name;
   const orgSlug = config.organization.slug;
   const { heading, icon } = resultHeading(type);
@@ -131,7 +132,7 @@ export async function loadSubmissionResult(
     customerEmail = row.customerEmail;
     const name = await itemName(row.itemId);
     if (name) context.push({ label: "Reservation", value: name });
-    context.push({ label: "When", value: formatWhen(row.scheduledAt, config.timezone) });
+    context.push({ label: "When", value: formatWhen(row.scheduledAt, operatingTimezone) });
     context.push({ label: "For", value: `${row.durationMinutes} minutes` });
     context.push({ label: "Name", value: row.customerName });
     context.push({ label: "Email", value: row.customerEmail });

--- a/docs/superpowers/plans/2026-08-12-restaurant-booking-timezone-consistency.md
+++ b/docs/superpowers/plans/2026-08-12-restaurant-booking-timezone-consistency.md
@@ -1,0 +1,30 @@
+# Restaurant booking timezone consistency
+
+Backlog: BI-EFF5F220  
+Capsule: WC-615F9773
+
+## Outcome
+
+Use the operator-pinned Operating Hours timezone for every Restaurant booking
+surface and capacity decision. A selected 11:00 America/Chicago reservation
+must remain 11:00 on confirmation and in the owner inbox, and an available
+table must not be rejected because a legacy storefront default evaluates its
+schedule in Europe/London.
+
+## Implementation
+
+1. Introduce one server-side resolver over `BusinessProfile.timezone`, composed
+   with the existing pure Operating Hours timezone policy.
+2. Route public calendar data, booking confirmation, owner inbox, and discrete
+   hospitality capacity enforcement through that resolver.
+3. Preserve fail-closed behavior for genuinely unavailable schedules and add a
+   regression for the canonical 7:31 PM Chicago seating interval.
+4. Run focused tests, guards, typecheck, semantic review, one governed pregate,
+   protected PR/merge, normal self-upgrade, and live booking plus host seating
+   reconciliation.
+
+## Design grounding
+
+The Operating Hours setting and `resolveOperatingHoursTimezone` are the
+existing source of truth. This change removes parallel interpretation; it adds
+no UI controls, copy, schema, migration, or visual styling.


### PR DESCRIPTION
## Summary
- make `BusinessProfile.timezone` the canonical server-side Restaurant operating timezone
- use the same timezone for capacity checks, public availability, guest confirmation, and the owner inbox
- cover the live 19:31 America/Chicago seating regression and the booking transaction contract

## Design grounding
- Existing plan reviewed: `docs/superpowers/plans/2026-08-12-restaurant-booking-timezone-consistency.md`
- Existing substrate reviewed: `apps/web/lib/operating-hours-types.ts` and `apps/web/lib/release/storefront-data.ts`
- Source of truth: `BusinessProfile.timezone` through `resolveOperatingHoursTimezone`
- Decision: reuse one server resolver across calendar, capacity, confirmation, and owner inbox

## Verification
- RED live runtime evidence: `cmsqscv3c007u01lgwraf4k16`
- Fresh semantic review: `cmsqtxr61006801qcclqn4qu9` (zero issues, publishable shadow receipt)
- Focused Vitest: 33/33 passed
- Exact preflight: 37/37 guards clean
- Exact local-CI: `cmsquennj012y01qc73fh9gwu` — gate passed for `8dfa032e1f76` (typecheck, exhaustive tests, production Docker build, OCI/smoke)
- UX: no new controls or copy; live Restaurant seating and 11:00 Chicago booking acceptance will run after deployment
- Migration: not applicable; no schema or data changes

## Documentation impact
- Added the governed implementation plan; no user-facing docs change because this restores existing Restaurant time semantics.

Docs-Impact-Decision: Internal timezone consistency repair; no user-facing controls, copy, or documented workflow changed.