### PR TITLE
fix(build-studio): reconcile owner-visible progress

### DIFF
--- a/apps/web/components/build/BuildListItem.test.tsx
+++ b/apps/web/components/build/BuildListItem.test.tsx
@@ -113,6 +113,26 @@ describe("BuildListItem", () => {
 });
 
 describe("BuildListItem fleet density", () => {
+  it("uses the reconciled owner state for the selected row instead of a contradictory queue label", () => {
+    const html = renderToStaticMarkup(
+      <BuildListItem
+        build={makeBuild()}
+        active
+        index={0}
+        lifecycleLabel={null}
+        isDevEnvironment={false}
+        density="fleet"
+        queueState={{ kind: "running", stepLabel: null }}
+        ownerState="not-started"
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("Preparing");
+    expect(html).not.toContain(">Working<");
+  });
+
   it("renders the compact fleet row instead of the comfortable card", () => {
     const html = renderToStaticMarkup(
       <BuildListItem

--- a/apps/web/components/build/BuildListItem.tsx
+++ b/apps/web/components/build/BuildListItem.tsx
@@ -7,6 +7,10 @@ import {
 } from "./build-studio-layout";
 import { FleetDensityBar } from "./FleetDensityBar";
 import type { BuildQueueState } from "./QueueStateBadge";
+import {
+  ownerStateBadgeLabel,
+  type BuildStudioOwnerState,
+} from "@/lib/build/owner-status-reconciliation";
 
 export type BuildListItemDensity = "comfortable" | "fleet";
 
@@ -25,6 +29,8 @@ type BuildListItemProps = {
   queueState?: BuildQueueState;
   /** Render "Needs you" as the row status when true. Fleet density only. */
   needsAttention?: boolean;
+  /** Canonical selected-build owner state; takes priority over queue heuristics. */
+  ownerState?: BuildStudioOwnerState | null;
 };
 
 function formatUpdatedAt(value: Date | string) {
@@ -46,6 +52,7 @@ export function BuildListItem({
   density = "comfortable",
   queueState,
   needsAttention = false,
+  ownerState = null,
 }: BuildListItemProps) {
   if (density === "fleet") {
     return (
@@ -58,6 +65,7 @@ export function BuildListItem({
         onDelete={onDelete}
         queueState={queueState ?? { kind: "idle" }}
         needsAttention={needsAttention}
+        ownerState={ownerState}
       />
     );
   }
@@ -135,6 +143,7 @@ type FleetRowProps = {
   onDelete: () => void;
   queueState: BuildQueueState;
   needsAttention: boolean;
+  ownerState: BuildStudioOwnerState | null;
 };
 
 type FleetRowStatus = {
@@ -159,11 +168,34 @@ function statusClassName(intent: "info" | "warning" | "danger" | "success" | "ne
   return `${base} border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]`;
 }
 
+function ownerStateIntent(
+  state: BuildStudioOwnerState,
+): "info" | "warning" | "danger" | "success" | "neutral" {
+  switch (state) {
+    case "working": return "info";
+    case "complete": return "success";
+    case "failed":
+    case "blocked": return "danger";
+    case "waiting-capacity":
+    case "waiting-owner":
+    case "inconclusive": return "warning";
+    case "not-started": return "neutral";
+  }
+}
+
 function deriveFleetRowStatus(
   build: FeatureBuildRow,
   queueState: BuildQueueState,
   needsAttention: boolean,
+  ownerState: BuildStudioOwnerState | null,
 ): FleetRowStatus {
+  if (ownerState) {
+    return {
+      label: ownerStateBadgeLabel(ownerState),
+      className: statusClassName(ownerStateIntent(ownerState)),
+    };
+  }
+
   if (needsAttention) {
     return { label: "Needs you", className: statusClassName("danger") };
   }
@@ -207,8 +239,9 @@ function FleetDensityRow({
   onDelete,
   queueState,
   needsAttention,
+  ownerState,
 }: FleetRowProps) {
-  const status = deriveFleetRowStatus(build, queueState, needsAttention);
+  const status = deriveFleetRowStatus(build, queueState, needsAttention, ownerState);
   return (
     <div
       data-testid={BUILD_STUDIO_TEST_IDS.buildListItem}

--- a/apps/web/components/build/BuildOperatorOverview.test.tsx
+++ b/apps/web/components/build/BuildOperatorOverview.test.tsx
@@ -106,4 +106,19 @@ describe("BuildOperatorOverview", () => {
     expect(html).toContain("Work stopped");
     expect(html).not.toContain("Building the solution");
   });
+
+  it("removes DPF-internal record identifiers from owner-visible outcome copy", () => {
+    const html = renderToStaticMarkup(
+      <BuildOperatorOverview
+        title="Improve BI-62075FF9 without exposing WC-12345678"
+        outcome="Depends on FB-ABC12345 and BI-DR-105 before release."
+        phase="plan"
+        status={null}
+      />,
+    );
+
+    expect(html).toContain("Improve this backlog item without exposing this work record");
+    expect(html).toContain("Depends on this build and this backlog item before release.");
+    expect(html).not.toMatch(/\b(?:BI|WC|FB)-[A-Z0-9-]+\b/);
+  });
 });

--- a/apps/web/components/build/BuildOperatorOverview.test.tsx
+++ b/apps/web/components/build/BuildOperatorOverview.test.tsx
@@ -55,4 +55,31 @@ describe("BuildOperatorOverview", () => {
     expect(html).toContain("Needs you");
     expect(html).toContain("Choose the preferred delivery policy.");
   });
+
+  it("shows capacity, elapsed time, and the leave-and-return expectation as one owner state", () => {
+    const html = renderToStaticMarkup(
+      <BuildOperatorOverview
+        title="Improve Build Studio progress"
+        outcome="Make long-running work understandable."
+        phase="ideate"
+        status={{
+          whatIsBeingBuilt: "Improve Build Studio progress",
+          lifecyclePosition: "Waiting for AI capacity",
+          worker: "The AI service is briefly unavailable",
+          evidence: "Build Studio did not receive a usable response.",
+          nextAction: "Retry when convenient.",
+          owner: "owner",
+          needsYou: true,
+          ownerState: "waiting-capacity",
+          elapsedLabel: "Waiting for 2 minutes",
+          expectation: "You can leave this page and return. Build Studio will show the latest result.",
+        }}
+      />,
+    );
+
+    expect(html).toContain("Capacity wait");
+    expect(html).toContain("Waiting for 2 minutes");
+    expect(html).toContain("You can leave this page and return");
+    expect(html).not.toContain(">Needs you<");
+  });
 });

--- a/apps/web/components/build/BuildOperatorOverview.test.tsx
+++ b/apps/web/components/build/BuildOperatorOverview.test.tsx
@@ -82,4 +82,28 @@ describe("BuildOperatorOverview", () => {
     expect(html).toContain("You can leave this page and return");
     expect(html).not.toContain(">Needs you<");
   });
+
+  it("renders terminal activity when the capsule stopped before the FeatureBuild phase caught up", () => {
+    const html = renderToStaticMarkup(
+      <BuildOperatorOverview
+        title="Reconcile stopped work"
+        outcome="Keep the owner state honest."
+        phase="build"
+        status={{
+          whatIsBeingBuilt: "Reconcile stopped work",
+          lifecyclePosition: "Stopped",
+          worker: "Stopped",
+          evidence: "Work capsule was abandoned.",
+          nextAction: "Restart only if the priority still stands.",
+          owner: "owner",
+          needsYou: true,
+          ownerState: "failed",
+        }}
+      />,
+    );
+
+    expect(html).toContain(">Stopped<");
+    expect(html).toContain("Work stopped");
+    expect(html).not.toContain("Building the solution");
+  });
 });

--- a/apps/web/components/build/BuildOperatorOverview.tsx
+++ b/apps/web/components/build/BuildOperatorOverview.tsx
@@ -32,6 +32,8 @@ export function BuildOperatorOverview({
   phase: BuildPhase;
   status?: BuildStudioCustomerStatus | null;
 }) {
+  const ownerTitle = ownerSafeBuildText(title);
+  const ownerOutcome = outcome ? ownerSafeBuildText(outcome) : outcome;
   const activityPhase = status?.ownerState === "complete"
     ? "complete"
     : status?.ownerState === "failed"
@@ -62,11 +64,11 @@ export function BuildOperatorOverview({
           id="build-outcome-heading"
           className="m-0 mt-1 max-w-4xl text-balance text-xl font-semibold leading-7 text-[var(--dpf-text)] sm:text-2xl"
         >
-          {title}
+          {ownerTitle}
         </h2>
-        {outcome ? (
+        {ownerOutcome ? (
           <p className="m-0 mt-2 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">
-            {outcome}
+            {ownerOutcome}
           </p>
         ) : null}
       </section>
@@ -168,6 +170,14 @@ export function BuildOperatorOverview({
       </section>
     </div>
   );
+}
+
+/** Keep governed record keys available in technical details, not owner copy. */
+export function ownerSafeBuildText(value: string): string {
+  return value
+    .replace(/\bBI-[A-Z0-9-]+\b/g, "this backlog item")
+    .replace(/\bWC-[A-Z0-9-]+\b/g, "this work record")
+    .replace(/\bFB-[A-Z0-9-]+\b/g, "this build");
 }
 
 function fallbackStatus(phase: BuildPhase): string {

--- a/apps/web/components/build/BuildOperatorOverview.tsx
+++ b/apps/web/components/build/BuildOperatorOverview.tsx
@@ -32,7 +32,12 @@ export function BuildOperatorOverview({
   phase: BuildPhase;
   status?: BuildStudioCustomerStatus | null;
 }) {
-  const activity = deriveBuildActivityStory(phase);
+  const activityPhase = status?.ownerState === "complete"
+    ? "complete"
+    : status?.ownerState === "failed"
+      ? (phase === "failed" ? "failed" : "abandoned")
+      : phase;
+  const activity = deriveBuildActivityStory(activityPhase);
   const lifecyclePosition = status?.lifecyclePosition ?? fallbackStatus(phase);
   const nextAction = status?.nextAction ?? fallbackNextAction(phase);
   const ownerBadge = status?.ownerState

--- a/apps/web/components/build/BuildOperatorOverview.tsx
+++ b/apps/web/components/build/BuildOperatorOverview.tsx
@@ -1,6 +1,18 @@
 import type { BuildStudioCustomerStatus } from "@/lib/build/customer-status-projection";
+import { ownerStateBadgeLabel } from "@/lib/build/owner-status-reconciliation";
 import type { BuildPhase } from "@/lib/feature-build-types";
 import { deriveBuildActivityStory } from "./build-studio-operator-view";
+
+const OWNER_STATE_BADGE = {
+  working: "border-[var(--dpf-info)] bg-[var(--dpf-state-info)] text-[var(--dpf-info)]",
+  "waiting-capacity": "border-[var(--dpf-warning)] bg-[var(--dpf-state-warning)] text-[var(--dpf-warning)]",
+  "waiting-owner": "border-[var(--dpf-warning)] bg-[var(--dpf-state-warning)] text-[var(--dpf-warning)]",
+  blocked: "border-[var(--dpf-error)] bg-[var(--dpf-state-error)] text-[var(--dpf-error)]",
+  inconclusive: "border-[var(--dpf-warning)] bg-[var(--dpf-state-warning)] text-[var(--dpf-warning)]",
+  failed: "border-[var(--dpf-error)] bg-[var(--dpf-state-error)] text-[var(--dpf-error)]",
+  complete: "border-[var(--dpf-success)] bg-[var(--dpf-state-success)] text-[var(--dpf-success)]",
+  "not-started": "border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-muted)]",
+} as const;
 
 const STEP_TONE = {
   complete: "border-[var(--dpf-success)] bg-[var(--dpf-state-success)] text-[var(--dpf-success)]",
@@ -23,6 +35,17 @@ export function BuildOperatorOverview({
   const activity = deriveBuildActivityStory(phase);
   const lifecyclePosition = status?.lifecyclePosition ?? fallbackStatus(phase);
   const nextAction = status?.nextAction ?? fallbackNextAction(phase);
+  const ownerBadge = status?.ownerState
+    ? {
+        label: ownerStateBadgeLabel(status.ownerState),
+        className: OWNER_STATE_BADGE[status.ownerState],
+      }
+    : status?.needsYou
+      ? {
+          label: ownerStateBadgeLabel("waiting-owner"),
+          className: OWNER_STATE_BADGE["waiting-owner"],
+        }
+      : null;
 
   return (
     <div className="space-y-5 px-5 py-5 sm:px-7 sm:py-6">
@@ -56,15 +79,20 @@ export function BuildOperatorOverview({
             >
               Now
             </p>
-            {status?.needsYou ? (
-              <span className="rounded-full border border-[var(--dpf-warning)] bg-[var(--dpf-state-warning)] px-2 py-1 text-dpf-caption font-semibold text-[var(--dpf-warning)]">
-                Needs you
+            {ownerBadge ? (
+              <span className={`rounded-full border px-2 py-1 text-dpf-caption font-semibold ${ownerBadge.className}`}>
+                {ownerBadge.label}
               </span>
             ) : null}
           </div>
           <p className="m-0 mt-2 text-base font-semibold text-[var(--dpf-text)]">
             {lifecyclePosition}
           </p>
+          {status?.worker || status?.elapsedLabel ? (
+            <p className="m-0 mt-1 text-xs font-medium leading-5 text-[var(--dpf-text)]">
+              {[status?.worker, status?.elapsedLabel].filter(Boolean).join(" · ")}
+            </p>
+          ) : null}
           {status?.evidence ? (
             <p className="m-0 mt-1 text-xs leading-5 text-[var(--dpf-muted)]">
               {status.evidence}
@@ -86,6 +114,11 @@ export function BuildOperatorOverview({
           <p className="m-0 mt-2 text-sm font-medium leading-6 text-[var(--dpf-text)]">
             {nextAction}
           </p>
+          {status?.expectation ? (
+            <p className="m-0 mt-1 text-xs leading-5 text-[var(--dpf-muted)]">
+              {status.expectation}
+            </p>
+          ) : null}
         </section>
       </div>
 

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -38,7 +38,13 @@ import { BuildDecisionLedgerBand } from "./BuildDecisionLedgerBand";
 import { BuildChangeSummaryBand } from "./BuildChangeSummaryBand";
 import { BuildSolutionSummaryBand } from "./BuildSolutionSummaryBand";
 import { BuildWorkWarrantBand } from "./BuildWorkWarrantBand";
-import type { BuildStudioCustomerStatus } from "@/lib/build/customer-status-projection";
+import {
+  type BuildStudioCustomerStatus,
+} from "@/lib/build/customer-status-projection";
+import {
+  reconcileBuildStudioCustomerStatus,
+  type BuildStudioOwnerState,
+} from "@/lib/build/owner-status-reconciliation";
 import { projectAutonomousBuildCustody } from "@/lib/build/autonomous-build-custody";
 import { BuildOperatorHeaderDetails, formatOperatorPhaseLabel } from "./BuildOperatorContext";
 import { BuildOperatorOverview } from "./BuildOperatorOverview";
@@ -46,7 +52,7 @@ import { groupOperatorBuilds } from "./build-studio-operator-view";
 import { resolveBuildStudioBranchBadge } from "./build-studio-branch-badge";
 import { deleteFeatureBuild } from "@/lib/actions/build";
 import { createBuildStudioBacklogIntake, startBacklogBuild } from "@/lib/actions/backlog-build";
-import { getFeatureBuild } from "@/lib/actions/build-read";
+import { getFeatureBuild, getFeatureBuildCustomerStatus } from "@/lib/actions/build-read";
 import { getBuildDecisionLedgerAction } from "@/lib/actions/build-decision-ledger";
 import { getBuildChangeNarrativeAction } from "@/lib/actions/build-change-narrative";
 import { getBuildFlowStateAction } from "@/lib/actions/build-flow";
@@ -122,6 +128,7 @@ const MISSING_BOM_SUMMARY: BomSummary = {
 
 const MAX_OPERATOR_FLEET_ITEMS = 4;
 const BUILD_CUSTODIAN_SNOOZE_KEY = "dpf:build-studio-custodian-snoozed";
+const EMPTY_CUSTOMER_STATUSES: Record<string, BuildStudioCustomerStatus> = {};
 
 type BuildStudioPendingIntake = {
   itemId: string;
@@ -180,7 +187,7 @@ export function BuildStudio({
   initialBuildId,
   portalContext,
   initialActiveBuild,
-  customerStatuses = {},
+  customerStatuses = EMPTY_CUSTOMER_STATUSES,
 }: Props) {
   const router = useRouter();
   const buildRows = Array.isArray(builds) ? builds : [];
@@ -188,6 +195,12 @@ export function BuildStudio({
   const portfolioRows = Array.isArray(portfolios) ? portfolios : [];
   const [activeBuild, setActiveBuild] = useState<FeatureBuildRow | null>(
     () => initialActiveBuild ?? resolveInitialActiveBuild(buildRows, initialBuildId),
+  );
+  const [activeCustomerStatus, setActiveCustomerStatus] = useState<BuildStudioCustomerStatus | null>(
+    () => {
+      const initial = initialActiveBuild ?? resolveInitialActiveBuild(buildRows, initialBuildId);
+      return initial ? customerStatuses[initial.id] ?? null : null;
+    },
   );
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
@@ -290,6 +303,13 @@ export function BuildStudio({
       progressVisibility,
     })
     : null;
+  const ownerStatus = activeBuild && activeCustomerStatus
+    ? reconcileBuildStudioCustomerStatus({
+        phase: activeBuild.phase,
+        status: activeCustomerStatus,
+        progress: progressVisibility,
+      })
+    : null;
   const custodianPromptRaw = activeBuild && workflowAction
     ? deriveBuildStudioCustodianPrompt({
       build: activeBuild,
@@ -317,8 +337,9 @@ export function BuildStudio({
   }, [activeBuild?.buildId, initialBuildId, router]);
 
   const refreshActiveBuildState = useCallback(async (buildId: string) => {
-    const [freshResult, flowResult, progressResult, bomResult, findingsResult] = await Promise.allSettled([
+    const [freshResult, customerStatusResult, flowResult, progressResult, bomResult, findingsResult] = await Promise.allSettled([
       getFeatureBuild(buildId),
+      getFeatureBuildCustomerStatus(buildId),
       getBuildFlowStateAction(buildId),
       getBuildProgressVisibilityAction(buildId),
       getBuildBomSummary(buildId),
@@ -331,6 +352,9 @@ export function BuildStudio({
     const nextFindings = findingsResult.status === "fulfilled" ? findingsResult.value : [];
 
     if (fresh) setActiveBuild(fresh);
+    if (customerStatusResult.status === "fulfilled" && customerStatusResult.value) {
+      setActiveCustomerStatus(customerStatusResult.value);
+    }
     setFlowState(nextFlow);
     setProgressVisibility(nextProgress);
     setBomSummary(nextBomSummary);
@@ -340,6 +364,7 @@ export function BuildStudio({
     const existing = buildRows.find((build) => build.buildId === buildId);
     if (existing) {
       setActiveBuild(existing);
+      setActiveCustomerStatus(customerStatuses[existing.id] ?? null);
       setSidebarOpen(true);
       return;
     }
@@ -347,9 +372,10 @@ export function BuildStudio({
     const fresh = await getFeatureBuild(buildId);
     if (fresh) {
       setActiveBuild(fresh);
+      setActiveCustomerStatus(customerStatuses[fresh.id] ?? null);
       setSidebarOpen(true);
     }
-  }, [buildRows]);
+  }, [buildRows, customerStatuses]);
   const debouncedRefetch = useCallback(async () => {
     if (!activeBuild) return;
     const now = Date.now();
@@ -371,6 +397,7 @@ export function BuildStudio({
   // updates.
   useEffect(() => {
     if (!activeBuild) {
+      setActiveCustomerStatus(null);
       setFlowState(null);
       setProgressVisibility(null);
       setBomSummary(MISSING_BOM_SUMMARY);
@@ -379,12 +406,18 @@ export function BuildStudio({
     }
     let cancelled = false;
     Promise.allSettled([
+      getFeatureBuildCustomerStatus(activeBuild.buildId),
       getBuildFlowStateAction(activeBuild.buildId),
       getBuildProgressVisibilityAction(activeBuild.buildId),
       getBuildBomSummary(activeBuild.buildId),
       getBuildAssuranceFindings(activeBuild.buildId, 25),
-    ]).then(([flowResult, progressResult, bomResult, findingsResult]) => {
+    ]).then(([customerStatusResult, flowResult, progressResult, bomResult, findingsResult]) => {
       if (!cancelled) {
+        setActiveCustomerStatus(
+          customerStatusResult.status === "fulfilled"
+            ? customerStatusResult.value
+            : customerStatuses[activeBuild.id] ?? null,
+        );
         setFlowState(flowResult.status === "fulfilled" ? flowResult.value : null);
         setProgressVisibility(progressResult.status === "fulfilled" ? progressResult.value : null);
         setBomSummary(bomResult.status === "fulfilled" ? bomResult.value : MISSING_BOM_SUMMARY);
@@ -392,6 +425,7 @@ export function BuildStudio({
       }
     }).catch(() => {
       if (!cancelled) {
+        setActiveCustomerStatus(customerStatuses[activeBuild.id] ?? null);
         setFlowState(null);
         setProgressVisibility(null);
         setBomSummary(MISSING_BOM_SUMMARY);
@@ -399,7 +433,7 @@ export function BuildStudio({
       }
     });
     return () => { cancelled = true; };
-  }, [activeBuild?.buildId]);
+  }, [activeBuild?.buildId, customerStatuses]);
 
   useEffect(() => {
     let cancelled = false;
@@ -548,16 +582,16 @@ export function BuildStudio({
     },
   );
 
-  // ─── Ultimate fallback: DB poll when panel is closed AND no threadId ───
-  // Only runs when we have no other update channel. 10-second interval
-  // to avoid hammering the DB. Covers: external agent builds, panel closed
-  // before first message.
+  // ─── Durable reconciliation poll ────────────────────────────────────────
+  // SSE is a fast notification channel, not durable state. Reconcile every
+  // active build from the DB even when a thread exists so a dropped stream,
+  // closed panel, or leave-and-return journey cannot freeze owner status.
   useEffect(() => {
     if (!activeBuild) return;
-    if (activeBuild.threadId) return; // SSE fallback will handle it
+    if (activeBuild.phase === "complete" || activeBuild.phase === "failed" || activeBuild.phase === "abandoned") return;
     const interval = setInterval(debouncedRefetch, 10_000);
     return () => clearInterval(interval);
-  }, [activeBuild?.buildId, activeBuild?.threadId, debouncedRefetch]);
+  }, [activeBuild?.buildId, activeBuild?.phase, debouncedRefetch]);
 
   async function handleCreate() {
     if (!newTitle.trim()) return;
@@ -704,7 +738,7 @@ export function BuildStudio({
                       type="button"
                       onClick={handleCreate}
                       disabled={creating || !newTitle.trim() || !newPortfolioId}
-                      className="inline-flex items-center gap-1.5 rounded-md border-none bg-[var(--dpf-accent)] px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+                      className="inline-flex items-center gap-1.5 rounded-md border-none bg-[var(--dpf-accent)] px-4 py-2 text-sm font-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))] transition-opacity hover:opacity-90 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {creating && <Spinner size="xs" tone="current" presentational />}
                       {creating ? "Saving..." : "Continue"}
@@ -725,7 +759,7 @@ export function BuildStudio({
                         type="button"
                         onClick={handlePromotePendingIntake}
                         disabled={promotingItemId === pendingIntake.itemId}
-                        className="mt-3 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] px-3 py-2 text-sm font-semibold text-[var(--dpf-accent)] transition-colors hover:bg-[var(--dpf-accent)] hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+                        className="mt-3 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] px-3 py-2 text-sm font-semibold text-[var(--dpf-accent)] transition-colors hover:bg-[var(--dpf-accent)] hover:text-[var(--dpf-on-accent,var(--dpf-surface-1))] disabled:cursor-not-allowed disabled:opacity-60"
                       >
                         {promotingItemId === pendingIntake.itemId && (
                           <Spinner size="xs" tone="current" presentational />
@@ -752,6 +786,7 @@ export function BuildStudio({
             buildRows={buildRows}
             epicRollups={rollupRows}
             activeBuildId={activeBuild?.buildId ?? null}
+            activeOwnerState={ownerStatus?.ownerState ?? null}
             governedBacklogEnabled={governedBacklogEnabled}
             isDevEnvironment={isDevEnvironment}
             onSelectBuild={(build) => {
@@ -800,7 +835,7 @@ export function BuildStudio({
                   ?? activeBuild.originator?.resolution
                 }
                 phase={activeBuild.phase}
-                status={customerStatuses[activeBuild.id]}
+                status={ownerStatus}
               />
 
               {/* Error banner for failed builds */}
@@ -1035,10 +1070,12 @@ export function BuildStudio({
       {/* Footer — single shared OpenSandboxButton (sandbox is shared across
           all in-flight builds; surfacing one link labeled with the current
           driver replaces the dishonest per-build Preview tab). */}
-      <BuildStudioFooter
-        builds={supervisedBuildRows}
-        showDrivingBuildCode={engineerView}
-      />
+      {engineerView ? (
+        <BuildStudioFooter
+          builds={supervisedBuildRows}
+          showDrivingBuildCode
+        />
+      ) : null}
     </div>
   );
 }
@@ -1443,7 +1480,7 @@ function BuildFailedBanner({ execState }: { execState: BuildExecutionState | nul
   return (
     <div className="mx-4 mt-3 p-3 rounded-lg border border-[var(--dpf-error)] bg-[color-mix(in_srgb,var(--dpf-error)_8%,var(--dpf-surface-1))] animate-dpf-fade-in" role="alert">
       <div className="flex items-start gap-2">
-        <span className="w-5 h-5 rounded-full bg-[var(--dpf-error)] text-white text-xs font-bold grid place-items-center shrink-0 mt-0.5">!</span>
+        <span className="mt-0.5 grid h-5 w-5 shrink-0 place-items-center rounded-full bg-[var(--dpf-state-error)] text-xs font-bold text-[var(--dpf-error)]">!</span>
         <div className="flex-1 min-w-0">
           <p className="text-sm font-semibold text-[var(--dpf-error)]">Build failed at: {stepLabel}</p>
           {errorMsg && (
@@ -1460,6 +1497,7 @@ function FleetRailZone({
   buildRows,
   epicRollups,
   activeBuildId,
+  activeOwnerState,
   governedBacklogEnabled,
   isDevEnvironment,
   onSelectBuild,
@@ -1470,6 +1508,7 @@ function FleetRailZone({
   buildRows: FeatureBuildRow[];
   epicRollups: EpicRollupView[];
   activeBuildId: string | null;
+  activeOwnerState: BuildStudioOwnerState | null;
   governedBacklogEnabled: boolean;
   isDevEnvironment: boolean;
   onSelectBuild: (build: FeatureBuildRow) => void;
@@ -1646,7 +1685,7 @@ function FleetRailZone({
             </span>
           ) : activeCount > 0 ? (
             <span className="text-dpf-caption font-normal text-[var(--dpf-muted)]">
-              {activeCount} active
+              {activeCount} open
             </span>
           ) : null}
         </span>
@@ -1676,6 +1715,7 @@ function FleetRailZone({
               density="fleet"
               queueState={entry.queueState}
               needsAttention={entry.needsAttention}
+              ownerState={activeBuildId === entry.build.buildId ? activeOwnerState : null}
               onSelect={() => onSelectBuild(entry.build)}
               onDelete={() => onDeleteBuild(entry.build)}
             />
@@ -1753,6 +1793,7 @@ function FleetRailZone({
                         density="fleet"
                         queueState={entry.queueState}
                         needsAttention={entry.needsAttention}
+                        ownerState={activeBuildId === entry.build.buildId ? activeOwnerState : null}
                         onSelect={() => onSelectBuild(entry.build)}
                         onDelete={() => onDeleteBuild(entry.build)}
                       />
@@ -1771,7 +1812,7 @@ function FleetRailZone({
 function Step({ n, text }: { n: number; text: string }) {
   return (
     <div className="flex items-start gap-3">
-      <span className="w-5 h-5 rounded-full bg-[var(--dpf-accent)] text-[10px] font-bold text-white grid place-items-center shrink-0 mt-0.5">
+      <span className="mt-0.5 grid h-5 w-5 shrink-0 place-items-center rounded-full bg-[var(--dpf-accent)] text-[10px] font-bold text-[var(--dpf-on-accent,var(--dpf-surface-1))]">
         {n}
       </span>
       <span className="text-sm leading-snug text-[var(--dpf-text)]">{text}</span>

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -822,11 +822,13 @@ export function BuildStudio({
 
         {/* Right: Preview or Brief */}
         <div className="flex min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto bg-[var(--dpf-surface-1)]">
-          <PortalContextStrip
-            envelope={portalContext ?? null}
-            contextLabel="Build context"
-            showInternalIds={engineerView}
-          />
+          {engineerView ? (
+            <PortalContextStrip
+              envelope={portalContext ?? null}
+              contextLabel="Build context"
+              showInternalIds
+            />
+          ) : null}
           {activeBuild ? (
             <>
               <BuildOperatorOverview

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -296,19 +296,21 @@ export function BuildStudio({
       buildExecState: activeBuild.buildExecState,
     })
     : null;
-  const workflowAction = activeBuild
-    ? deriveBuildStudioWorkflowAction({
-      build: activeBuild,
-      governedBacklogEnabled,
-      progressVisibility,
-    })
-    : null;
   const ownerStatus = activeBuild && activeCustomerStatus
     ? reconcileBuildStudioCustomerStatus({
         phase: activeBuild.phase,
         status: activeCustomerStatus,
         progress: progressVisibility,
       })
+    : null;
+  const ownerStateIsTerminal = ownerStatus?.ownerState === "complete"
+    || ownerStatus?.ownerState === "failed";
+  const workflowAction = activeBuild && !ownerStateIsTerminal
+    ? deriveBuildStudioWorkflowAction({
+      build: activeBuild,
+      governedBacklogEnabled,
+      progressVisibility,
+    })
     : null;
   const custodianPromptRaw = activeBuild && workflowAction
     ? deriveBuildStudioCustodianPrompt({

--- a/apps/web/components/build/BuildStudioDetailsDrawer.test.tsx
+++ b/apps/web/components/build/BuildStudioDetailsDrawer.test.tsx
@@ -40,6 +40,7 @@ vi.mock("@/lib/actions/build", () => ({
 
 vi.mock("@/lib/actions/build-read", () => ({
   getFeatureBuild: vi.fn(),
+  getFeatureBuildCustomerStatus: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/lib/actions/build-flow", () => ({

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { BuildStudio } from "./BuildStudio";
 import {
@@ -23,11 +23,20 @@ const backlogBuildMocks = vi.hoisted(() => ({
   startBacklogBuild: vi.fn(),
 }));
 
+const buildReadMocks = vi.hoisted(() => ({
+  getFeatureBuild: vi.fn(),
+  getFeatureBuildCustomerStatus: vi.fn(),
+}));
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     refresh: routerMocks.refresh,
     replace: routerMocks.replace,
   }),
+}));
+
+vi.mock("@/lib/hooks/useResilientEventSource", () => ({
+  useResilientEventSource: vi.fn(),
 }));
 
 vi.mock("@/lib/actions/build", () => ({
@@ -45,7 +54,8 @@ vi.mock("@/lib/actions/backlog-build", () => ({
 }));
 
 vi.mock("@/lib/actions/build-read", () => ({
-  getFeatureBuild: vi.fn(),
+  getFeatureBuild: buildReadMocks.getFeatureBuild,
+  getFeatureBuildCustomerStatus: buildReadMocks.getFeatureBuildCustomerStatus,
 }));
 
 vi.mock("@/lib/actions/build-flow", () => ({
@@ -223,6 +233,7 @@ function makeEpicRollup(overrides: Partial<EpicRollupView> = {}): EpicRollupView
 describe("BuildStudio active-build header layout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   it("names the intake around the operator's outcome", () => {
@@ -419,6 +430,45 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).not.toContain('data-testid="process-graph"');
     expect(html).not.toContain('data-testid="build-studio-details-drawer-pill"');
     expect(html).not.toContain('data-testid="build-studio-details-drawer"');
+    expect(html).not.toContain('data-testid="build-studio-footer"');
+    expect(html).not.toContain("Sandbox is shared");
+    expect(html).not.toContain("Open sandbox");
+  });
+
+  it("reconciles persisted progress even when the build already has a thread stream", async () => {
+    vi.useFakeTimers();
+    try {
+      buildReadMocks.getFeatureBuild.mockResolvedValue(
+        makeBuild({ threadId: "thread-1", phase: "build" }),
+      );
+      buildReadMocks.getFeatureBuildCustomerStatus.mockResolvedValue({
+        whatIsBeingBuilt: "Fix Build Studio header/content overlap in workflow view",
+        lifecyclePosition: "Building the change",
+        worker: "Build Studio",
+        evidence: "Implementation is active.",
+        nextAction: "No action needed.",
+        owner: "Build Studio",
+        needsYou: false,
+      });
+      render(
+        <BuildStudio
+          builds={[makeBuild({ threadId: "thread-1", phase: "build" })]}
+          portfolios={[]}
+          governedBacklogEnabled
+          projectBranch="main"
+          submissionBranchShortId="fb8783b9"
+        />,
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_100);
+      });
+
+      expect(buildReadMocks.getFeatureBuild).toHaveBeenCalledWith("FB-9B19098C");
+      expect(buildReadMocks.getFeatureBuildCustomerStatus).toHaveBeenCalledWith("FB-9B19098C");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("presents one outcome, one status, one next action, and one activity story before technical details", () => {
@@ -672,11 +722,9 @@ describe("BuildStudio active-build header layout", () => {
     expect(html).not.toContain('data-testid="build-studio-action-banner"');
   });
 
-  it("mounts the footer OpenSandboxButton — single shared sandbox link", () => {
-    // Footer surfaces the shared sandbox without resorting to a per-build
-    // Preview tab. When a build has a live sandboxPort, the footer button
-    // labels itself with the driving build code.
-    const html = renderToStaticMarkup(
+  it("mounts the shared preview footer only in Technical details", async () => {
+    localStorage.setItem("dpf:build-studio-engineer-view", "true");
+    const { container, findByTestId } = render(
       <BuildStudio
         builds={[makeBuild({
           phase: "build",
@@ -689,17 +737,19 @@ describe("BuildStudio active-build header layout", () => {
         submissionBranchShortId="fb8783b9"
       />,
     );
+    await findByTestId("build-studio-footer");
+    const html = container.innerHTML;
     expect(html).toContain('data-testid="build-studio-footer"');
     expect(html).toContain('data-testid="build-studio-open-sandbox"');
     expect(html).toContain('data-driving="FB-9B19098C"');
-    expect(html).toContain("Open live preview · current build");
-    expect(html).not.toContain("driving: FB-9B19098C");
+    expect(html).toContain("Open live preview · driving: FB-9B19098C");
     expect(html).toContain('href="http://localhost:5555"');
     expect(html).toMatch(/rel="noopener noreferrer"/);
   });
 
-  it("footer OpenSandboxButton shows 'idle' when no build has a live sandboxPort", () => {
-    const html = renderToStaticMarkup(
+  it("Technical details shows an idle preview state when no build has a live preview", async () => {
+    localStorage.setItem("dpf:build-studio-engineer-view", "true");
+    const { container, findByTestId } = render(
       <BuildStudio
         builds={[makeBuild({ phase: "ideate", sandboxPort: null })]}
         portfolios={[]}
@@ -708,6 +758,8 @@ describe("BuildStudio active-build header layout", () => {
         submissionBranchShortId="fb8783b9"
       />,
     );
+    await findByTestId("build-studio-open-sandbox");
+    const html = container.innerHTML;
     expect(html).toContain('data-testid="build-studio-open-sandbox"');
     expect(html).toContain('data-driving="idle"');
     // Disabled span renders (no anchor when sandboxUrl is empty).

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -515,15 +515,18 @@ describe("BuildStudio active-build header layout", () => {
         governedBacklogEnabled
         projectBranch="main"
         submissionBranchShortId="fb8783b9"
+        portalContext={makePortalContextEnvelope()}
       />,
     );
 
     const assuranceGate = await findByTestId("build-assurance-gate-card");
     expect(assuranceGate.textContent).toContain("Assurance Gate");
     expect(assuranceGate.textContent).toContain("No BOM generated");
+    expect(document.body.textContent).toContain("Build context");
+    expect(document.body.textContent).toContain("WC-123");
   });
 
-  it("renders the portal context strip when a server envelope is provided", () => {
+  it("keeps portal context mechanics out of the default owner viewport", () => {
     const html = renderToStaticMarkup(
       <BuildStudio
         builds={[makeBuild()]}
@@ -535,9 +538,8 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toContain("Build context");
-    expect(html).toContain("Build Studio");
-    expect(html).toContain("Portal overlay");
+    expect(html).not.toContain("Build context");
+    expect(html).not.toContain("Portal overlay");
     expect(html).not.toContain("WC-123");
   });
 

--- a/apps/web/components/build/BuildStudioNodeInspector.test.tsx
+++ b/apps/web/components/build/BuildStudioNodeInspector.test.tsx
@@ -45,6 +45,7 @@ vi.mock("@/lib/actions/build", () => ({
 
 vi.mock("@/lib/actions/build-read", () => ({
   getFeatureBuild: vi.fn(),
+  getFeatureBuildCustomerStatus: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/lib/actions/build-flow", () => ({

--- a/apps/web/components/build/build-studio-workflow-actions.test.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.test.ts
@@ -1261,6 +1261,28 @@ describe("deriveBuildStudioWorkflowAction — escalate-to-human (BI-A2F3FA9D)", 
   });
 });
 
+describe("deriveBuildStudioOperatorGuidance — terminal owner state", () => {
+  it("never presents a completed build as Working", () => {
+    const build = makeBuild({ phase: "complete" });
+    const action = deriveBuildStudioWorkflowAction({
+      build,
+      governedBacklogEnabled: true,
+    });
+    const guidance = deriveBuildStudioOperatorGuidance(action, build);
+
+    expect(guidance.status).toEqual({
+      kind: "complete",
+      label: "Complete",
+      intent: "success",
+    });
+    expect(guidance.nextSentence).toBe(
+      "The result and its evidence are ready to review.",
+    );
+    expect(guidance.nextLabel).toBeNull();
+    expect(guidance.useCoworkerForNext).toBe(false);
+  });
+});
+
 describe("deriveBuildStudioWorkflowAction — failed inference (BI-F0005EB0)", () => {
   function progressWithInferenceFailure(
     failure: BuildProgressVisibility["inferenceFailure"],
@@ -1286,7 +1308,7 @@ describe("deriveBuildStudioWorkflowAction — failed inference (BI-F0005EB0)", (
     } satisfies BuildProgressVisibility;
   }
 
-  it("surfaces retry-inference (danger) for a failed ideate inference instead of Waiting on evidence", () => {
+  it("surfaces transient inference failure as a capacity wait with an optional retry", () => {
     const action = deriveBuildStudioWorkflowAction({
       // designDoc null => the advance gate would otherwise fire with a disabledReason.
       build: makeBuild({ phase: "ideate", draftApprovedAt: new Date("2026-04-25T13:00:00Z"), designDoc: null, designReview: null }),
@@ -1297,9 +1319,26 @@ describe("deriveBuildStudioWorkflowAction — failed inference (BI-F0005EB0)", (
     expect(action.kind).toBe("retry-inference");
     expect(action.primaryLabel).toBe("Retry the AI call");
     expect(action.disabledReason).toBeNull();
-    expect(action.title).toMatch(/AI call failed/i);
+    expect(action.title).toMatch(/waiting for AI capacity/i);
     // Never leak the raw provider string into user-facing copy.
     expect(action.message).not.toMatch(/ECONNREFUSED|ConnectionRefused|API Error:/);
+    expect(deriveBuildStudioOperatorGuidance(action).status).toEqual({
+      kind: "waiting-capacity",
+      label: "Capacity wait",
+      intent: "info",
+    });
+    expect(deriveBuildStudioOperatorGuidance(action).nextSentence).toMatch(/retry when convenient/i);
+  });
+
+  it("keeps configuration failures distinct from transient capacity waits", () => {
+    const action = deriveBuildStudioWorkflowAction({
+      build: makeBuild({ phase: "ideate", draftApprovedAt: new Date("2026-04-25T13:00:00Z"), designDoc: null, designReview: null }),
+      governedBacklogEnabled: true,
+      progressVisibility: progressWithInferenceFailure({ failed: true, kind: "config", observedAt: "2026-07-05T11:59:00.000Z" }),
+    });
+
+    expect(action.kind).toBe("retry-inference");
+    expect(action.title).toMatch(/setup needs attention/i);
     expect(deriveBuildStudioOperatorGuidance(action).status.intent).toBe("danger");
   });
 

--- a/apps/web/components/build/build-studio-workflow-actions.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.ts
@@ -23,6 +23,7 @@ import type {
 } from "@/lib/build/progress-visibility-types";
 import {
   friendlyInferenceFailureMessage,
+  isTransientInferenceFailure,
   type InferenceFailureKind,
 } from "@/lib/build/inference-failure";
 
@@ -35,12 +36,18 @@ type BuildStudioWorkflowActionMetadata = {
   inferenceFailureKind?: InferenceFailureKind | null;
 };
 
-export type BuildOperatorStatusKind = "waiting-on-you" | "working" | "blocked-technical" | "escalated";
+export type BuildOperatorStatusKind =
+  | "waiting-on-you"
+  | "waiting-capacity"
+  | "working"
+  | "blocked-technical"
+  | "escalated"
+  | "complete";
 
 export type BuildOperatorStatus = {
   kind: BuildOperatorStatusKind;
-  label: "Waiting on you" | "Working" | "Blocked (technical)" | "Escalated to you";
-  intent: "accent" | "info" | "danger";
+  label: "Waiting on you" | "Capacity wait" | "Working" | "Blocked (technical)" | "Escalated to you" | "Complete";
+  intent: "accent" | "info" | "danger" | "success";
 };
 
 export type BuildStudioOperatorGuidance = {
@@ -398,6 +405,17 @@ function statusForAction(
   action: BuildStudioWorkflowAction,
   build?: OperatorGuidanceBuildContext,
 ): BuildOperatorStatus {
+  // The workflow action falls back to review-only after the terminal phase,
+  // but terminal truth outranks that generic action classification. Without
+  // this guard a completed build rendered a green banner labelled "Working".
+  if (build?.phase === "complete") {
+    return {
+      kind: "complete",
+      label: "Complete",
+      intent: "success",
+    };
+  }
+
   // BI-A2F3FA9D — terminal handoff: the build is a human's now, not "Working".
   if (action.kind === "escalated-to-human") {
     return {
@@ -411,13 +429,18 @@ function statusForAction(
     action.kind === "retry-build"
     || action.kind === "reset-build"
     || action.kind === "resume-implementation"
-    || action.kind === "retry-inference"
   ) {
     return {
       kind: "blocked-technical",
       label: "Blocked (technical)",
       intent: "danger",
     };
+  }
+
+  if (action.kind === "retry-inference") {
+    return isTransientInferenceFailure(action.inferenceFailureKind ?? null)
+      ? { kind: "waiting-capacity", label: "Capacity wait", intent: "info" }
+      : { kind: "blocked-technical", label: "Blocked (technical)", intent: "danger" };
   }
 
   const exec = build?.buildExecState as { step?: string | null; error?: string | null } | null | undefined;
@@ -471,7 +494,9 @@ function nextSentenceForAction(action: BuildStudioWorkflowAction): string {
     case "retry-build":
       return "Next: retry the sandbox launch.";
     case "retry-inference":
-      return "Next: retry the AI call. I will keep watching and pick it up if it fails again.";
+      return isTransientInferenceFailure(action.inferenceFailureKind ?? null)
+        ? "Next: retry when convenient. Your change will stay here while capacity recovers."
+        : "Next: retry the AI call after the issue is resolved.";
     case "reset-build":
       return "Next: reset the build pipeline and start it again.";
     case "resume-implementation":
@@ -495,12 +520,18 @@ export function deriveBuildStudioOperatorGuidance(
   action: BuildStudioWorkflowAction,
   build?: OperatorGuidanceBuildContext,
 ): BuildStudioOperatorGuidance {
-  const useCoworkerForNext = action.disabledReason != null || action.primaryLabel == null;
+  const terminalComplete = build?.phase === "complete";
+  const useCoworkerForNext = !terminalComplete
+    && (action.disabledReason != null || action.primaryLabel == null);
   const guidedRecovery = action.kind === "rerun-plan-review" || action.kind === "resume-implementation";
   return {
     status: statusForAction(action, build),
-    nextLabel: useCoworkerForNext ? action.coworkerLabel : action.primaryLabel,
-    nextSentence: nextSentenceForAction(action),
+    nextLabel: terminalComplete
+      ? null
+      : useCoworkerForNext ? action.coworkerLabel : action.primaryLabel,
+    nextSentence: terminalComplete
+      ? "The result and its evidence are ready to review."
+      : nextSentenceForAction(action),
     useCoworkerForNext,
     guidedRecovery,
     recoveryHint: guidedRecovery
@@ -601,9 +632,14 @@ function buildRetryInferenceAction(
     ? friendlyInferenceFailureMessage(kind)
     : "The AI call did not complete. Retry to try the request again.";
   const phaseNoun = phase === "ideate" ? "define this feature" : "plan this build";
+  const title = isTransientInferenceFailure(kind)
+    ? "Waiting for AI capacity"
+    : kind === "config"
+      ? "AI setup needs attention"
+      : "No usable AI response";
   return {
     kind: "retry-inference",
-    title: "The AI call failed.",
+    title,
     message: `${friendly} Next: click Retry the AI call to run it again.`,
     primaryLabel: "Retry the AI call",
     targetPhase: null,

--- a/apps/web/lib/actions/build-read.test.ts
+++ b/apps/web/lib/actions/build-read.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  featureBuildFindUnique: vi.fn(),
+  loadStatuses: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    featureBuild: { findUnique: mocks.featureBuildFindUnique },
+    workCapsule: { findMany: vi.fn() },
+    buildActivity: { groupBy: vi.fn() },
+  },
+}));
+vi.mock("@/lib/build/customer-status-loader", () => ({
+  loadBuildStudioCustomerStatuses: mocks.loadStatuses,
+}));
+
+import { getFeatureBuildCustomerStatus } from "@/lib/actions/build-read";
+
+describe("getFeatureBuildCustomerStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auth.mockResolvedValue({ user: { id: "user-1" } });
+  });
+
+  it("reloads the capsule-backed owner status for one build", async () => {
+    const build = {
+      id: "build-row-1",
+      buildId: "FB-9B19098C",
+      title: "Fix Build Studio status",
+      phase: "build",
+      updatedAt: new Date("2026-08-12T13:00:00.000Z"),
+    };
+    const status = {
+      whatIsBeingBuilt: build.title,
+      lifecyclePosition: "Building the change",
+      worker: "Build Studio",
+      evidence: "Implementation is active.",
+      nextAction: "No action needed.",
+      owner: "Build Studio",
+      needsYou: false,
+    };
+    mocks.featureBuildFindUnique.mockResolvedValue(build);
+    mocks.loadStatuses.mockResolvedValue({ [build.id]: status });
+
+    await expect(getFeatureBuildCustomerStatus(build.buildId)).resolves.toEqual(status);
+    expect(mocks.featureBuildFindUnique).toHaveBeenCalledWith({
+      where: { buildId: build.buildId },
+      select: { id: true, buildId: true, title: true, phase: true, updatedAt: true },
+    });
+    expect(mocks.loadStatuses).toHaveBeenCalledWith(expect.anything(), [build]);
+  });
+
+  it("does not query build state without an authenticated user", async () => {
+    mocks.auth.mockResolvedValue(null);
+
+    await expect(getFeatureBuildCustomerStatus("FB-9B19098C")).resolves.toBeNull();
+    expect(mocks.featureBuildFindUnique).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/actions/build-read.ts
+++ b/apps/web/lib/actions/build-read.ts
@@ -9,6 +9,31 @@ import {
   DECISION_INTERACTION_GATE_SELECT,
   decisionInteractionRowToGateView,
 } from "@/lib/decision-perspective/view-model";
+import {
+  loadBuildStudioCustomerStatuses,
+  type CapsuleFindManyDelegate,
+  type CustomerStatusBuild,
+} from "@/lib/build/customer-status-loader";
+import type { BuildStudioCustomerStatus } from "@/lib/build/customer-status-projection";
+
+export async function getFeatureBuildCustomerStatus(
+  buildId: string,
+): Promise<BuildStudioCustomerStatus | null> {
+  const session = await auth();
+  if (!session?.user?.id) return null;
+
+  const build = await prisma.featureBuild.findUnique({
+    where: { buildId },
+    select: { id: true, buildId: true, title: true, phase: true, updatedAt: true },
+  });
+  if (!build) return null;
+
+  const statuses = await loadBuildStudioCustomerStatuses(
+    prisma as unknown as CapsuleFindManyDelegate,
+    [{ ...build, phase: build.phase as CustomerStatusBuild["phase"] }],
+  );
+  return statuses[build.id] ?? null;
+}
 
 export async function getFeatureBuild(buildId: string): Promise<FeatureBuildRow | null> {
   const session = await auth();

--- a/apps/web/lib/build/customer-status-projection.test.ts
+++ b/apps/web/lib/build/customer-status-projection.test.ts
@@ -308,6 +308,48 @@ describe("reconcileBuildStudioCustomerStatus — canonical owner state", () => {
     expect(`${status.lifecyclePosition} ${status.worker} ${status.evidence}`).not.toMatch(/actively executing/i);
   });
 
+  it("keeps an abandoned capsule terminal when the FeatureBuild phase and dispatch history are stale", () => {
+    const status = reconcileBuildStudioCustomerStatus({
+      phase: "build",
+      status: {
+        ...base,
+        lifecyclePosition: "Stopped",
+        worker: "Stopped",
+        evidence: "Work capsule was abandoned.",
+        nextAction: "restart the work only if the business priority still stands.",
+        owner: "owner",
+        needsYou: false,
+      },
+      progress: progress({
+        dispatchHistory: [{
+          id: "stale-attempt",
+          buildId: "FB-OWNER",
+          taskTitle: "Old work",
+          specialist: "software-engineer",
+          providerId: "chatgpt",
+          model: "gpt-5.3-codex",
+          attemptNumber: 1,
+          startedAt: "2026-08-12T12:01:00.000Z",
+          completedAt: null,
+          durationMs: null,
+          exitCode: null,
+          success: false,
+          failureAxis: "unknown",
+          stdoutExcerpt: null,
+          stderrExcerpt: null,
+          rootCauseSummary: null,
+          rootCauseHash: null,
+        }],
+      }),
+    });
+
+    expect(status.ownerState).toBe("failed");
+    expect(status.lifecyclePosition).toBe("Stopped");
+    expect(status.evidence).toBe("Work capsule was abandoned.");
+    expect(status.nextAction).toMatch(/restart the work/i);
+    expect(status.worker).not.toMatch(/working/i);
+  });
+
   it.each([
     ["config", "blocked", true],
     ["empty-response", "inconclusive", true],

--- a/apps/web/lib/build/customer-status-projection.test.ts
+++ b/apps/web/lib/build/customer-status-projection.test.ts
@@ -345,7 +345,8 @@ describe("reconcileBuildStudioCustomerStatus — canonical owner state", () => {
 
     expect(status.ownerState).toBe("failed");
     expect(status.lifecyclePosition).toBe("Stopped");
-    expect(status.evidence).toBe("Work capsule was abandoned.");
+    expect(status.evidence).toBe("This work was stopped.");
+    expect(status.evidence).not.toMatch(/capsule/i);
     expect(status.nextAction).toMatch(/restart the work/i);
     expect(status.worker).not.toMatch(/working/i);
   });

--- a/apps/web/lib/build/customer-status-projection.test.ts
+++ b/apps/web/lib/build/customer-status-projection.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import { projectBuildStudioCustomerStatus } from "./customer-status-projection";
+import { reconcileBuildStudioCustomerStatus } from "./owner-status-reconciliation";
+import type { BuildProgressVisibility } from "./progress-visibility";
 import { STALLED_BUILD_REAP_MS } from "./inert-build-reaper";
 import { createBuildPrDeliveryState, writeBuildPrDeliveryState } from "./build-pr-delivery-state";
 
@@ -197,5 +199,128 @@ describe("projectBuildStudioCustomerStatus (BI-BB13B599)", () => {
       expect(status.lifecyclePosition).toBe("Building it");
       expect(status.needsYou).toBe(false);
     });
+  });
+});
+
+describe("reconcileBuildStudioCustomerStatus — canonical owner state", () => {
+  const base = projectBuildStudioCustomerStatus({
+    build,
+    capsule: { capsuleId: "WC-1", status: "working" },
+  });
+
+  function progress(
+    overrides: Partial<BuildProgressVisibility> = {},
+  ): BuildProgressVisibility {
+    return {
+      buildId: "FB-OWNER",
+      generatedAt: "2026-08-12T12:10:00.000Z",
+      statusHeading: { operatorAction: "Monitor build progress", failureAxis: null },
+      progress: {
+        primary: { source: "db-task-results", completed: 0, total: 0, observedAt: null },
+        conflicts: [],
+      },
+      tasks: {
+        completedTasks: 0,
+        totalTasks: 0,
+        source: { source: "db-task-results", completed: 0, total: 0, observedAt: null },
+        tasks: [],
+      },
+      staleChatSnapshots: [],
+      sandbox: null,
+      dispatchHistory: [],
+      verification: null,
+      quietAgent: {
+        quiet: false,
+        minutesQuiet: 0,
+        lastObservableSignalAt: "2026-08-12T12:09:30.000Z",
+      },
+      inferenceFailure: { failed: false, kind: null, observedAt: null },
+      phaseRuns: [],
+      ...overrides,
+    };
+  }
+
+  it("shows a real in-flight dispatch with persisted elapsed time and a bounded expectation", () => {
+    const status = reconcileBuildStudioCustomerStatus({
+      phase: "build",
+      status: base,
+      progress: progress({
+        dispatchHistory: [{
+          id: "attempt-1",
+          buildId: "FB-OWNER",
+          taskTitle: "Build the owner state",
+          specialist: "software-engineer",
+          providerId: "chatgpt",
+          model: "gpt-5.3-codex",
+          attemptNumber: 1,
+          startedAt: "2026-08-12T12:01:00.000Z",
+          completedAt: null,
+          durationMs: null,
+          exitCode: null,
+          success: false,
+          failureAxis: "unknown",
+          stdoutExcerpt: null,
+          stderrExcerpt: null,
+          rootCauseSummary: null,
+          rootCauseHash: null,
+        }],
+      }),
+    });
+
+    expect(status.ownerState).toBe("working");
+    expect(status.lifecyclePosition).toBe("Building the change");
+    expect(status.elapsedLabel).toBe("Working for 9 minutes");
+    expect(status.expectation).toMatch(/several minutes/i);
+    expect(status.expectation).toMatch(/leave this page/i);
+    expect(status.needsYou).toBe(false);
+  });
+
+  it("distinguishes provider capacity from generic work and preserves the retry action", () => {
+    const status = reconcileBuildStudioCustomerStatus({
+      phase: "ideate",
+      status: base,
+      progress: progress({
+        inferenceFailure: {
+          failed: true,
+          kind: "provider-unavailable",
+          observedAt: "2026-08-12T12:08:00.000Z",
+        },
+      }),
+    });
+
+    expect(status.ownerState).toBe("waiting-capacity");
+    expect(status.lifecyclePosition).toBe("Waiting for AI capacity");
+    expect(status.evidence).not.toMatch(/providerId|engine|dispatch/i);
+    expect(status.nextAction).toMatch(/retry/i);
+    expect(status.needsYou).toBe(true);
+  });
+
+  it("does not call a zero-task, never-dispatched build active execution", () => {
+    const status = reconcileBuildStudioCustomerStatus({
+      phase: "build",
+      status: base,
+      progress: progress(),
+    });
+
+    expect(status.ownerState).toBe("not-started");
+    expect(status.lifecyclePosition).toBe("Preparing the build");
+    expect(status.evidence).toMatch(/has not dispatched implementation work/i);
+    expect(`${status.lifecyclePosition} ${status.worker} ${status.evidence}`).not.toMatch(/actively executing/i);
+  });
+
+  it.each([
+    ["config", "blocked", true],
+    ["empty-response", "inconclusive", true],
+  ] as const)("maps %s inference failure to %s", (kind, ownerState, needsYou) => {
+    const status = reconcileBuildStudioCustomerStatus({
+      phase: "plan",
+      status: base,
+      progress: progress({
+        inferenceFailure: { failed: true, kind, observedAt: "2026-08-12T12:08:00.000Z" },
+      }),
+    });
+
+    expect(status.ownerState).toBe(ownerState);
+    expect(status.needsYou).toBe(needsYou);
   });
 });

--- a/apps/web/lib/build/customer-status-projection.ts
+++ b/apps/web/lib/build/customer-status-projection.ts
@@ -26,6 +26,7 @@ import type { WorkCaseState } from "@/lib/work-management/case-types";
 import type { BuildPhase } from "@/lib/explore/feature-build-types";
 import { STALLED_BUILD_REAP_MS } from "@/lib/build/inert-build-reaper";
 import { readBuildPrDeliveryState } from "@/lib/build/build-pr-delivery-state";
+import type { BuildStudioOwnerState } from "@/lib/build/owner-status-reconciliation";
 
 export interface BuildStudioCustomerStatus {
   /** Plain restatement of what is being built (the build title). */
@@ -44,6 +45,12 @@ export interface BuildStudioCustomerStatus {
   owner: string;
   /** True when the work is waiting on the human (surfaces "Needs you"). */
   needsYou: boolean;
+  /** Canonical cause-oriented state for the owner-facing first viewport. */
+  ownerState?: BuildStudioOwnerState;
+  /** Persisted-duration copy; never an ETA. */
+  elapsedLabel?: string;
+  /** Bounded expectation and safe leave/return guidance. */
+  expectation?: string;
 }
 
 const NEEDS_YOU_STATES: ReadonlySet<WorkCaseState> = new Set([

--- a/apps/web/lib/build/owner-status-reconciliation.ts
+++ b/apps/web/lib/build/owner-status-reconciliation.ts
@@ -39,6 +39,29 @@ export function reconcileBuildStudioCustomerStatus(args: {
 }): BuildStudioCustomerStatus {
   const { phase, status, progress } = args;
 
+  // The WorkCapsule projection is the durable authority when it has already
+  // reached a terminal state. FeatureBuild.phase and dispatch rows can lag that
+  // transition, so stale in-flight evidence must never resurrect stopped work.
+  const projectedOwnerState = ownerStateFromStatus(status);
+  if (projectedOwnerState === "complete") {
+    return {
+      ...status,
+      ownerState: "complete",
+      needsYou: false,
+      expectation: status.expectation
+        ?? "The result and its evidence will remain here when you return.",
+    };
+  }
+  if (projectedOwnerState === "failed") {
+    return {
+      ...status,
+      ownerState: "failed",
+      needsYou: true,
+      expectation: status.expectation
+        ?? "You can leave this page and return; Build Studio will keep this stopped state recorded.",
+    };
+  }
+
   if (phase === "complete") {
     return {
       ...status,
@@ -60,7 +83,7 @@ export function reconcileBuildStudioCustomerStatus(args: {
   }
 
   if (!progress) {
-    return { ...status, ownerState: ownerStateFromStatus(status) };
+    return { ...status, ownerState: projectedOwnerState };
   }
 
   const failure = progress.inferenceFailure;
@@ -182,7 +205,12 @@ export function reconcileBuildStudioCustomerStatus(args: {
 }
 
 function ownerStateFromStatus(status: BuildStudioCustomerStatus): BuildStudioOwnerState {
-  if (/\b(done|deployed|closed)\b/i.test(status.lifecyclePosition)) return "complete";
+  const durableSummary = [
+    status.lifecyclePosition,
+    status.worker,
+  ].filter(Boolean).join(" ");
+  if (/\b(done|deployed|closed|completed|finished)\b/i.test(durableSummary)) return "complete";
+  if (/\b(stopped|cancelled|abandoned)\b/i.test(durableSummary)) return "failed";
   if (isWaitingForOwner(status)) return "waiting-owner";
   if (status.needsYou) return "blocked";
   return "working";

--- a/apps/web/lib/build/owner-status-reconciliation.ts
+++ b/apps/web/lib/build/owner-status-reconciliation.ts
@@ -37,7 +37,11 @@ export function reconcileBuildStudioCustomerStatus(args: {
   status: BuildStudioCustomerStatus;
   progress: BuildProgressVisibility | null | undefined;
 }): BuildStudioCustomerStatus {
-  const { phase, status, progress } = args;
+  const { phase, progress } = args;
+  const status = {
+    ...args.status,
+    evidence: ownerSafeStatusEvidence(args.status.evidence),
+  };
 
   // The WorkCapsule projection is the durable authority when it has already
   // reached a terminal state. FeatureBuild.phase and dispatch rows can lag that
@@ -202,6 +206,15 @@ export function reconcileBuildStudioCustomerStatus(args: {
       ? { expectation: "You can leave this page and return; Build Studio will show the latest recorded state." }
       : {}),
   };
+}
+
+function ownerSafeStatusEvidence(value: string): string {
+  if (/^Work capsule was abandoned\.$/i.test(value)) return "This work was stopped.";
+  if (/^Work capsule reached a completed execution state\.$/i.test(value)) return "This work is complete.";
+  if (/^Work capsule is actively executing\.$/i.test(value)) {
+    return "Build Studio is working on this change.";
+  }
+  return value.replace(/\bWork capsule\b/gi, "This work");
 }
 
 function ownerStateFromStatus(status: BuildStudioCustomerStatus): BuildStudioOwnerState {

--- a/apps/web/lib/build/owner-status-reconciliation.ts
+++ b/apps/web/lib/build/owner-status-reconciliation.ts
@@ -1,0 +1,230 @@
+import type { BuildPhase } from "@/lib/feature-build-types";
+import type { BuildStudioCustomerStatus } from "@/lib/build/customer-status-projection";
+import type { BuildProgressVisibility } from "@/lib/build/progress-visibility";
+import { isTransientInferenceFailure } from "@/lib/build/inference-failure";
+
+export type BuildStudioOwnerState =
+  | "working"
+  | "waiting-capacity"
+  | "waiting-owner"
+  | "blocked"
+  | "inconclusive"
+  | "failed"
+  | "complete"
+  | "not-started";
+
+/** Compact badge copy kept with the canonical state vocabulary. */
+export function ownerStateBadgeLabel(state: BuildStudioOwnerState): string {
+  switch (state) {
+    case "working": return "Working";
+    case "waiting-capacity": return "Capacity wait";
+    case "waiting-owner": return "Needs you";
+    case "blocked": return "Needs attention";
+    case "inconclusive": return "Needs review";
+    case "failed": return "Stopped";
+    case "complete": return "Complete";
+    case "not-started": return "Preparing";
+  }
+}
+
+/**
+ * Reconcile the server-projected capsule/phase status with the live progress
+ * read model. This client-safe module is the one seam for Build Studio owner
+ * state; it adds no persisted status machine and imports server models as types.
+ */
+export function reconcileBuildStudioCustomerStatus(args: {
+  phase: BuildPhase;
+  status: BuildStudioCustomerStatus;
+  progress: BuildProgressVisibility | null | undefined;
+}): BuildStudioCustomerStatus {
+  const { phase, status, progress } = args;
+
+  if (phase === "complete") {
+    return {
+      ...status,
+      ownerState: "complete",
+      lifecyclePosition: "Done",
+      worker: "Finished",
+      needsYou: false,
+      expectation: "The result and its evidence will remain here when you return.",
+    };
+  }
+  if (phase === "failed" || phase === "abandoned") {
+    return {
+      ...status,
+      ownerState: "failed",
+      lifecyclePosition: phase === "failed" ? "The build stopped" : "Work stopped",
+      worker: "Build Studio is not working on this change",
+      needsYou: true,
+    };
+  }
+
+  if (!progress) {
+    return { ...status, ownerState: ownerStateFromStatus(status) };
+  }
+
+  const failure = progress.inferenceFailure;
+  if (failure?.failed) {
+    const elapsedLabel = formatElapsedLabel(failure.observedAt, progress.generatedAt, "Waiting");
+    if (isTransientInferenceFailure(failure.kind)) {
+      return {
+        ...status,
+        ownerState: "waiting-capacity",
+        lifecyclePosition: "Waiting for AI capacity",
+        worker: "The AI service is briefly unavailable",
+        evidence: "Build Studio did not receive a usable response after its automatic retries.",
+        nextAction: "Retry when convenient. Build Studio will show any new result here.",
+        owner: "owner",
+        needsYou: true,
+        ...(elapsedLabel ? { elapsedLabel } : {}),
+        expectation: "Brief interruptions are retried automatically before this status appears. You can leave this page and return.",
+      };
+    }
+    if (failure.kind === "config") {
+      return {
+        ...status,
+        ownerState: "blocked",
+        lifecyclePosition: "AI setup needs attention",
+        worker: "Build Studio cannot reach an eligible AI service",
+        evidence: "No configured AI service can handle this request.",
+        nextAction: "Ask a platform administrator to check AI provider setup, then retry.",
+        owner: "platform administrator",
+        needsYou: true,
+        ...(elapsedLabel ? { elapsedLabel } : {}),
+      };
+    }
+    return {
+      ...status,
+      ownerState: "inconclusive",
+      lifecyclePosition: "No usable AI response",
+      worker: "Build Studio could not confirm a result",
+      evidence: "The AI service returned no usable response.",
+      nextAction: "Retry the AI call. If it happens again, review the technical details.",
+      owner: "owner",
+      needsYou: true,
+      ...(elapsedLabel ? { elapsedLabel } : {}),
+    };
+  }
+
+  if (isWaitingForOwner(status)) {
+    return { ...status, ownerState: "waiting-owner" };
+  }
+
+  const inFlight = latestInflightDispatch(progress);
+  if (inFlight) {
+    const elapsedLabel = formatElapsedLabel(inFlight.startedAt, progress.generatedAt, "Working");
+    return {
+      ...status,
+      ownerState: "working",
+      lifecyclePosition: workingStageLabel(phase),
+      worker: "Build Studio is working on this change",
+      evidence: "A build step is running and no owner decision is needed.",
+      nextAction: "No action needed unless Build Studio asks for a decision.",
+      owner: "Build Studio",
+      needsYou: false,
+      ...(elapsedLabel ? { elapsedLabel } : {}),
+      expectation: "Long steps can take several minutes. You can leave this page and return; the latest result will appear here.",
+    };
+  }
+
+  if (
+    (phase === "build" || phase === "review")
+    && progress.tasks.totalTasks === 0
+    && progress.dispatchHistory.length === 0
+  ) {
+    return {
+      ...status,
+      ownerState: "not-started",
+      lifecyclePosition: phase === "build" ? "Preparing the build" : "Preparing the checks",
+      worker: phase === "build" ? "No implementation task has started" : "No verification check has started",
+      evidence: phase === "build"
+        ? "Build Studio has not dispatched implementation work yet."
+        : "Build Studio has not dispatched verification work yet.",
+      nextAction: "No action needed unless Build Studio asks for a decision.",
+      owner: "Build Studio",
+      needsYou: false,
+      expectation: "This page will update when work starts. You can leave and return.",
+    };
+  }
+
+  const failureAxis = progress.statusHeading.failureAxis;
+  if (failureAxis) {
+    const inconclusive = failureAxis === "unknown" || failureAxis === "out-of-scope-noise";
+    return {
+      ...status,
+      ownerState: inconclusive ? "inconclusive" : "blocked",
+      lifecyclePosition: inconclusive ? "Checks need review" : "Work is blocked",
+      worker: "Build Studio needs attention before it can continue",
+      needsYou: true,
+    };
+  }
+
+  if (progress.quietAgent.quiet) {
+    return {
+      ...status,
+      ownerState: "blocked",
+      lifecyclePosition: "No recent progress",
+      worker: "Build Studio may be stuck",
+      evidence: `No meaningful progress has been recorded for ${progress.quietAgent.minutesQuiet} minutes.`,
+      nextAction: "Review the current step and resume it if needed.",
+      owner: "owner",
+      needsYou: true,
+    };
+  }
+
+  return {
+    ...status,
+    ownerState: ownerStateFromStatus(status),
+    ...(!status.needsYou
+      ? { expectation: "You can leave this page and return; Build Studio will show the latest recorded state." }
+      : {}),
+  };
+}
+
+function ownerStateFromStatus(status: BuildStudioCustomerStatus): BuildStudioOwnerState {
+  if (/\b(done|deployed|closed)\b/i.test(status.lifecyclePosition)) return "complete";
+  if (isWaitingForOwner(status)) return "waiting-owner";
+  if (status.needsYou) return "blocked";
+  return "working";
+}
+
+function isWaitingForOwner(status: BuildStudioCustomerStatus): boolean {
+  return status.needsYou
+    && /waiting for (?:you|your decision)|needs your decision/i.test(status.lifecyclePosition);
+}
+
+function latestInflightDispatch(progress: BuildProgressVisibility) {
+  return [...progress.dispatchHistory]
+    .filter((attempt) => attempt.completedAt == null)
+    .sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime())[0] ?? null;
+}
+
+function workingStageLabel(phase: BuildPhase): string {
+  switch (phase) {
+    case "ideate": return "Understanding the change";
+    case "plan": return "Planning the change";
+    case "build": return "Building the change";
+    case "review": return "Checking the change";
+    case "ship": return "Preparing the release";
+    default: return "Working on the change";
+  }
+}
+
+function formatElapsedLabel(
+  startedAt: string | null,
+  generatedAt: string,
+  verb: "Working" | "Waiting",
+): string | undefined {
+  if (!startedAt) return undefined;
+  const startMs = new Date(startedAt).getTime();
+  const nowMs = new Date(generatedAt).getTime();
+  if (!Number.isFinite(startMs) || !Number.isFinite(nowMs)) return undefined;
+  const minutes = Math.max(0, Math.floor((nowMs - startMs) / 60_000));
+  if (minutes < 1) return `${verb} for less than a minute`;
+  if (minutes < 60) return `${verb} for ${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return remainder === 0
+    ? `${verb} for ${hours} ${hours === 1 ? "hour" : "hours"}`
+    : `${verb} for ${hours}h ${remainder}m`;
+}

--- a/apps/web/lib/build/progress-visibility.test.ts
+++ b/apps/web/lib/build/progress-visibility.test.ts
@@ -119,6 +119,7 @@ describe("buildProgressProjectionFromParts", () => {
       quiet: true,
       minutesQuiet: 10,
       lastObservableSignalAt: "2026-05-18T12:00:00.000Z",
+      lastMeaningfulSignalAt: "2026-05-18T12:00:00.000Z",
     });
   });
 
@@ -208,20 +209,63 @@ describe("buildProgressProjectionFromParts — inferenceFailure (BI-F0005EB0)", 
     });
   });
 
-  it("does not flag when a fresher observable signal superseded the failed turn", () => {
+  it("does not let generic activity erase a persisted inference failure", () => {
     const projection = buildProgressProjectionFromParts(
       partsWithLastAssistant(
         {
           content: "API Error: Unable to connect to API (ConnectionRefused)",
           createdAt: "2026-07-05T11:59:00.000Z",
         },
-        // Activity landed AFTER the failed turn — pipeline moved on.
+        // A generic BuildActivity row landed AFTER the failed turn. That is
+        // liveness evidence, not proof that the failed inference recovered.
         "2026-07-05T11:59:30.000Z",
       ),
     );
 
-    expect(projection.inferenceFailure?.failed).toBe(false);
+    expect(projection.inferenceFailure?.failed).toBe(true);
     expect(projection.inferenceFailure?.kind).toBe("connection");
+  });
+
+  it("clears a persisted inference failure after newer task progress proves recovery", () => {
+    const projection = buildProgressProjectionFromParts({
+      ...partsWithLastAssistant(
+        {
+          content: "API Error: Unable to connect to API (ConnectionRefused)",
+          createdAt: "2026-07-05T11:59:00.000Z",
+        },
+        "2026-07-05T11:59:30.000Z",
+      ),
+      dbTasks: normalizeTaskResults({
+        completedTasks: 1,
+        totalTasks: 2,
+        timestamp: "2026-07-05T11:59:45.000Z",
+      }),
+    });
+
+    expect(projection.inferenceFailure).toEqual({
+      failed: false,
+      kind: "connection",
+      observedAt: "2026-07-05T11:59:00.000Z",
+    });
+  });
+
+  it("does not treat a newer zero-task snapshot as recovered work", () => {
+    const projection = buildProgressProjectionFromParts({
+      ...partsWithLastAssistant(
+        {
+          content: "API Error: Unable to connect to API (ConnectionRefused)",
+          createdAt: "2026-07-05T11:59:00.000Z",
+        },
+        "2026-07-05T11:59:30.000Z",
+      ),
+      dbTasks: normalizeTaskResults({
+        completedTasks: 0,
+        totalTasks: 0,
+        timestamp: "2026-07-05T11:59:45.000Z",
+      }),
+    });
+
+    expect(projection.inferenceFailure?.failed).toBe(true);
   });
 
   it("does not flag a normal assistant turn", () => {

--- a/apps/web/lib/build/progress-visibility.ts
+++ b/apps/web/lib/build/progress-visibility.ts
@@ -58,6 +58,12 @@ export type BuildProgressVisibility = {
     quiet: boolean;
     minutesQuiet: number;
     lastObservableSignalAt: string | null;
+    /**
+     * Newest signal that proves the build actually advanced. Generic
+     * BuildActivity is intentionally excluded: a heartbeat or status note can
+     * prove liveness, but it cannot clear a persisted provider failure.
+     */
+    lastMeaningfulSignalAt?: string | null;
   };
   /**
    * BI-F0005EB0 (EP-BS-UX-HARDENING) — whether the most recent assistant turn in
@@ -123,8 +129,13 @@ export function buildProgressProjectionFromParts(args: {
     dispatchHistory: args.dispatchHistory,
     lastActivityAt: args.lastActivityAt,
   });
+  const lastMeaningfulSignalAt = getLastMeaningfulSignalAt({
+    taskResultsAt: args.dbTasks.totalTasks > 0 ? args.dbTasks.source.observedAt : null,
+    verificationAt: args.verification?.observedAt ?? null,
+    dispatchHistory: args.dispatchHistory,
+  });
   const minutesQuiet = getMinutesQuiet(lastObservableSignalAt, now);
-  const inferenceFailure = deriveInferenceFailure(args.lastAssistant, lastObservableSignalAt);
+  const inferenceFailure = deriveInferenceFailure(args.lastAssistant, lastMeaningfulSignalAt);
 
   return {
     buildId: args.buildId,
@@ -158,6 +169,7 @@ export function buildProgressProjectionFromParts(args: {
       quiet: !hasInflightDispatch(args.dispatchHistory) && minutesQuiet >= 5,
       minutesQuiet,
       lastObservableSignalAt,
+      lastMeaningfulSignalAt,
     },
     inferenceFailure,
     engineSelection: args.engineSelection
@@ -173,14 +185,13 @@ export function buildProgressProjectionFromParts(args: {
 
 /**
  * BI-F0005EB0 — classify the newest assistant turn. Only reports `failed` when
- * the failing turn is at least as recent as the last observable non-chat signal:
- * a task result, dispatch, or activity landing AFTER the failed turn means the
- * pipeline moved on (e.g. the user retried and work resumed), so the stale error
- * must not keep the build parked in a danger state.
+ * the failing turn is at least as recent as the last meaningful non-chat
+ * signal. A newer task result, verification result, or dispatch proves the
+ * pipeline moved on; a generic activity row does not.
  */
 function deriveInferenceFailure(
   lastAssistant: { content: string | null; createdAt: Date | string | null } | null | undefined,
-  lastObservableSignalAt: string | null,
+  lastMeaningfulSignalAt: string | null,
 ): BuildProgressVisibility["inferenceFailure"] {
   const none: BuildProgressVisibility["inferenceFailure"] = { failed: false, kind: null, observedAt: null };
   if (!lastAssistant) {
@@ -193,8 +204,8 @@ function deriveInferenceFailure(
   const observedAt = normalizeObservedAt(lastAssistant.createdAt);
   if (
     observedAt != null
-    && lastObservableSignalAt != null
-    && new Date(lastObservableSignalAt).getTime() > new Date(observedAt).getTime()
+    && lastMeaningfulSignalAt != null
+    && new Date(lastMeaningfulSignalAt).getTime() > new Date(observedAt).getTime()
   ) {
     // A fresher observable signal superseded the failed turn — not stalled here.
     return { failed: false, kind, observedAt };
@@ -389,6 +400,22 @@ function getLastObservableSignalAt(args: {
     args.taskResultsAt,
     args.verificationAt,
     args.lastActivityAt,
+    ...args.dispatchHistory.flatMap((attempt) => [attempt.completedAt, attempt.startedAt]),
+  ];
+
+  return candidates
+    .filter((value): value is string => Boolean(value))
+    .sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0] ?? null;
+}
+
+function getLastMeaningfulSignalAt(args: {
+  taskResultsAt: string | null;
+  verificationAt: string | null;
+  dispatchHistory: BuildDispatchAttemptView[];
+}): string | null {
+  const candidates = [
+    args.taskResultsAt,
+    args.verificationAt,
     ...args.dispatchHistory.flatMap((attempt) => [attempt.completedAt, attempt.startedAt]),
   ];
 

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -212,7 +212,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - text\n  - link\n  - paragraph\n    - text"
     },
     "/build": {
-      "defaultVisibleWords": 171,
+      "defaultVisibleWords": 145,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 1,
@@ -220,7 +220,7 @@
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - button [expanded]\n    - text\n  - text\n  - textbox\n  - group\n    - button\n    - text\n    - combobox\n      - option [selected]\n      - option\n  - text\n  - button [disabled]\n  - text\n  - paragraph\n    - text\n  - text\n  - link\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - text\n  - link [disabled]"
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - button [expanded]\n    - text\n  - text\n  - textbox\n  - group\n    - button\n    - text\n    - combobox\n      - option [selected]\n      - option\n  - text\n  - button [disabled]\n  - text\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - text"
     },
     "/build/work": {
       "defaultVisibleWords": 179,

--- a/docs/superpowers/plans/2026-08-12-build-studio-owner-state-reconciliation.md
+++ b/docs/superpowers/plans/2026-08-12-build-studio-owner-state-reconciliation.md
@@ -75,3 +75,10 @@ Decision: refactor the existing customer-status projection into the single owner
 - Documentation: this execution plan and the required UX-fit record are the affected contributor surfaces. No user guide changes are required because the route and workflow remain the same; the UI becomes the implementation of the already-approved owner-change design.
 - Database migration: none. This is a projection and presentation repair over existing persisted records.
 - Deployment contracts: unchanged.
+
+## Verification outcome
+
+- Nine focused Build Studio test files pass: 157 tests covering the canonical owner projection, durable progress reads, queue/overview/workflow convergence, and disclosure boundaries.
+- The production web build passes. Existing Edge-runtime compatibility diagnostics remain warnings and do not block the build.
+- The style-drift and prose-lint guards pass with no new hardcoded colors, off-scale values, or owner-copy issues.
+- The governed shared preview confirms one stable owner state for stopped and completed work, persistence after leaving and returning, collapsed technical detail by default, no internal build/capsule identifiers in owner chrome, and no horizontal overflow at a 390 px viewport.

--- a/docs/superpowers/plans/2026-08-12-build-studio-owner-state-reconciliation.md
+++ b/docs/superpowers/plans/2026-08-12-build-studio-owner-state-reconciliation.md
@@ -1,0 +1,77 @@
+# Build Studio owner-state reconciliation
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-08-12 |
+| Umbrella | `BI-A40C8A70` |
+| Deliverables | `BI-78499309`, `BI-62075FF9` |
+| Branch | `fix/build-studio-owner-state` |
+| Work Capsule | `WC-67DC0E31` |
+| Decision | `DI-A170A7EBA1D7` — converge on one canonical owner-state projection |
+
+## Outcome
+
+Build Studio's first viewport will answer one question: **what is happening with my change now?** It will distinguish active work, provider capacity, an owner decision, a product block, inconclusive verification, failure, and completion without exposing engine, sandbox, task-count, model, or code-intelligence detail by default.
+
+This is one concern-focused change because both defects are produced by the same split ownership: runtime signals are interpreted independently by the progress read model, owner copy, workflow actions, and page chrome. Shipping only the long-running signal or only the chrome cleanup would leave the other projections free to contradict it.
+
+## Live backlog coverage
+
+The plan keeps the two independently testable outcomes mapped to their existing live backlog items:
+
+| Deliverable | Backlog item | Depends on |
+| --- | --- | --- |
+| Durable long-running and return-to-page state | `BI-78499309` | — |
+| Owner-safe status strip and progressive disclosure | `BI-62075FF9` | `BI-78499309` |
+
+Governed coverage receipt: `cmsq3c8qo02aw01t6y2lj28v4` (`decomposed`), recorded against `BI-A40C8A70` before implementation.
+
+## Design grounding
+
+Reviewed specifications and standards:
+
+- `docs/superpowers/specs/2026-06-12-build-studio-owner-improvement-experience-design.md`
+- `docs/superpowers/plans/2026-07-31-build-studio-owner-change-convergence.md`
+- `docs/platform-usability-standards.md`
+- `docs/superpowers/plans/2026-05-26-portal-ux-simplification-spine.md`
+- `apps/web/components/ui/report-kit/README.md`
+
+Reviewed code substrate:
+
+- `apps/web/lib/build/progress-visibility.ts` owns persisted build-signal reconciliation.
+- `apps/web/lib/build/customer-status-projection.ts` owns business-facing now/next copy.
+- `apps/web/components/build/BuildOperatorOverview.tsx` renders the owner summary.
+- `apps/web/components/build/BuildStudio.tsx` owns refresh behavior and disclosure boundaries.
+- `apps/web/components/build/build-studio-workflow-actions.ts` derives the owner's next action.
+
+Source of truth: persisted task results, verification runs, dispatch history, phase state, inference failure, and owner-decision records. Generic activity is supporting liveness evidence; it must not erase a persisted provider failure or fabricate progress.
+
+Decision: refactor the existing customer-status projection into the single owner-state seam and make every owner-facing consumer use it. Do not add a second status machine, table, route, or provider-specific UI.
+
+## UX feature-fit gate
+
+| Gate | Answer |
+| --- | --- |
+| Owning area | Platform |
+| Route family | Canonical `/build`; no new route or tab |
+| Primary persona | Business owner/contributor checking whether a change is moving or needs them |
+| Navigation layer | Local page state only; global and section navigation do not change |
+| Component convergence | Reuse `BuildOperatorOverview`, `BuildStudioWorkflowActionCard`, `StatusBadge`, `Notice`, and existing disclosure; retire duplicated status interpretations |
+| Source truth | Existing build progress read model plus owner status projection |
+| Empty/failure state | Honest not-started, waiting-capacity, owner-decision, blocked, inconclusive, failed, and complete states |
+| AI action boundary | No new automatic AI action from a click; existing confirmed workflow actions remain unchanged |
+| Verification evidence | Focused projection/component tests, production build, owner-mode `/build` journey, capacity failure, leave/return reconciliation, light/dark and narrow/desktop screenshots |
+
+## Implementation sequence
+
+1. **Red — signal truth.** Add regression tests proving generic activity cannot clear a newer provider failure and that meaningful persisted progress can supersede it.
+2. **Green — canonical owner state.** Extend the existing projection with a closed owner-state union, plain stage/summary/expectation copy, persisted timing anchors, and an explicit owner-action flag.
+3. **Red/green — consumer convergence.** Make the overview, selected queue row, and workflow action tests prove that owner copy and actions derive from the same state, including capacity and long-running work.
+4. **Refactor budget.** Remove duplicated transient-failure classification, refresh the capsule-backed owner projection with the durable poll, and move unconditional progress reconciliation into one hook path. Remove technical footer copy from the default owner viewport; keep diagnostics under the existing engineer disclosure.
+5. **Verify.** Run all graph-linked or colocated tests, prose/style guards, the production build, governed merged-code CI, and the live owner journey. Record the UX-fit measurement without co-claiming another active capsule's broad `docs/ux-fit` scope.
+
+## Documentation and migration impact
+
+- Documentation: this execution plan and the required UX-fit record are the affected contributor surfaces. No user guide changes are required because the route and workflow remain the same; the UI becomes the implementation of the already-approved owner-change design.
+- Database migration: none. This is a projection and presentation repair over existing persisted records.
+- Deployment contracts: unchanged.


### PR DESCRIPTION
## Summary

- reconcile Build Studio owner status from persisted Work Capsule and FeatureBuild state through one canonical projection
- preserve terminal and provider-failure truth across refreshes, durable polling, and leave/return navigation
- keep owner chrome business-safe by default while retaining diagnostics under the existing technical-details disclosure

Resolves BI-78499309.
Resolves BI-62075FF9.
Relates to umbrella BI-A40C8A70.

## Why

Build Studio could present stale transient activity as current progress, contradict a terminal capsule state, and expose capsule, lease, worktree, provider, and code-intelligence details in the owner journey. The affected consumers now converge on one persisted owner-state projection, so the queue, overview, workflow action, and activity story cannot disagree after a refresh or return visit.

## Design grounding

- Reviewed `docs/superpowers/specs/2026-06-12-build-studio-owner-improvement-experience-design.md`, the owner-change convergence plan, platform usability standards, and shared report/UI primitives.
- Reused the existing progress visibility, customer status projection, workflow action/card, overview, status badge, notice, and technical disclosure substrate.
- Kept persisted Work Capsule, FeatureBuild, task-result, verification, dispatch, inference-failure, and owner-decision records as the source of truth; no second state machine, route, table, or migration was added.
- Followed `DI-A170A7EBA1D7`: converge all owner-visible consumers on one canonical owner-state projection.

## Verification

- 9 focused Build Studio test files: 157 tests passed.
- `pnpm --filter web build`: passed; existing Edge-runtime compatibility diagnostics remain warnings.
- `node scripts/check-style-drift.mjs`: passed.
- `pnpm run check:prose-lint:test` and `pnpm run check:prose-lint`: passed.
- Governed shared-preview UX: stopped and completed records remain stable; leave/return preserves status; technical details are collapsed by default; owner chrome contains no raw BI/WC/FB IDs or infrastructure detail; 390 px viewport has no horizontal overflow.
- Governed UX baseline regeneration workflow `31660570585`: passed; only `/build` was spliced, reducing default-visible words from 171 to 145 and recording the intentionally simplified accessibility structure.
- Fresh semantic review for the final tree: infrastructure-inconclusive in shadow mode because local CI held host capacity; no issues, publication allowed, evidence `cmsqwohbl016g01s0vz0aso1d`.
- Exact merged-tree local CI for the final tree: pass, evidence `cmsqxojy101ey01s0z2di3ppt`.
- Database migration: not applicable.

## Documentation impact

The execution plan records the final verification outcome. No user guide changes are needed because the `/build` route and workflow are unchanged and this implements the already-approved owner-change design in place.

Docs-Impact-Decision: Owner status wording and default disclosure change in place on the existing `/build` workflow; the linked long-running-process architecture remains accurate and no user procedure changed.

Local-CI-Evidence: cmsqxojy101ey01s0z2di3ppt
