### PR TITLE
fix(inference): treat max_tokens-truncated responses as incomplete, not final (BI-1D144CC1)

### DIFF
--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -119,6 +119,8 @@ export type InferenceResult = {
   toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
   /** Responses API: chain subsequent calls with this ID for conversation state. */
   responseId?: string;
+  /** True when the provider stopped at the output-token ceiling (BI-1D144CC1). */
+  truncated?: boolean;
   /**
    * Verbatim provider response body (matches AdapterResult.raw). Optional —
    * adapters may leave it undefined when nothing useful exists beyond `content`.
@@ -701,6 +703,7 @@ export async function callProvider(
     inferenceMs: result.inferenceMs,
     ...(result.toolCalls.length > 0 && { toolCalls: result.toolCalls }),
     responseId: result.responseId,
+    truncated: result.truncated ?? false,
     // Adapters may set result.raw (e.g. transcription adapter for Whisper
     // verbose_json segments). Passed through verbatim; undefined when absent.
     ...(result.raw !== undefined && { raw: result.raw }),

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -80,6 +80,13 @@ export interface RoutedInferenceResult {
   downgradeReason: "provider-unavailable" | "not-eligible" | null;
   /** True when tools were stripped due to capability degradation (local model). */
   toolsStripped: boolean;
+  /**
+   * True when the provider stopped generation at the output-token ceiling
+   * (Anthropic max_tokens / OpenAI length / Gemini MAX_TOKENS / Responses
+   * incomplete). The agentic loop continues generation on a truncated turn
+   * rather than returning the partial as a final answer (BI-1D144CC1).
+   */
+  truncated?: boolean;
   /** Responses API: the response ID for chaining subsequent calls. */
   responseId?: string;
   /** The V2 route decision that selected this endpoint (for audit/metadata). */
@@ -644,6 +651,7 @@ export async function routeAndCall(
       // Background path: only a real dispatch failure downgrades here.
       downgradeReason: result.downgraded ? "provider-unavailable" : null,
       toolsStripped,
+      truncated: result.truncated ?? false,
       routeDecision: decision,
       ...routedRehydrationHandle(prepared.rehydrationHandle),
     };
@@ -730,6 +738,7 @@ export async function routeAndCall(
         ? "not-eligible"
         : null,
     toolsStripped,
+    truncated: result.truncated ?? false,
     routeDecision: decision,
     responseId: result.responseId,
     resolvedMaxContextTokens: selectedManifest?.maxContextTokens ?? null,

--- a/apps/web/lib/routing/adapter-types.ts
+++ b/apps/web/lib/routing/adapter-types.ts
@@ -69,6 +69,15 @@ export interface AdapterResult {
   raw?: Record<string, unknown>;
   /** Responses API: the response ID for chaining subsequent calls. */
   responseId?: string;
+  /**
+   * True when the provider stopped generation because it hit the output-token
+   * ceiling (Anthropic `stop_reason: "max_tokens"`, OpenAI `finish_reason:
+   * "length"`, Gemini `finishReason: "MAX_TOKENS"`, Responses `status:
+   * "incomplete"` with `max_output_tokens`). The agentic loop MUST NOT treat a
+   * truncated reply as a natural end_turn — it continues generation rather than
+   * returning the fragment (BI-1D144CC1). Absent/false means a clean stop.
+   */
+  truncated?: boolean;
 }
 
 /** Contract every execution adapter implements */

--- a/apps/web/lib/routing/chat-adapter.test.ts
+++ b/apps/web/lib/routing/chat-adapter.test.ts
@@ -254,6 +254,36 @@ describe("chatAdapter", () => {
     expect(result.toolCalls).toEqual([]);
   });
 
+  // ── 1b. OpenAI-compat: finish_reason captured as `truncated` (BI-1D144CC1) ──
+
+  it("OpenAI-compat: finish_reason=length is captured as truncated=true", async () => {
+    stubFetchOk({
+      choices: [{ message: { content: "The first three steps are" }, finish_reason: "length" }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+
+    const result = await chatAdapter.execute(makeRequest({
+      providerId: "ollama",
+      modelId: "llama3.1",
+    }));
+
+    expect(result.truncated).toBe(true);
+  });
+
+  it("OpenAI-compat: finish_reason=stop is not truncated", async () => {
+    stubFetchOk({
+      choices: [{ message: { content: "Done." }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+
+    const result = await chatAdapter.execute(makeRequest({
+      providerId: "ollama",
+      modelId: "llama3.1",
+    }));
+
+    expect(result.truncated).toBe(false);
+  });
+
   // ── 2. OpenAI-compat: reasoning_effort from providerSettings ──
 
   it("OpenAI-compat: reasoning_effort from providerSettings", async () => {
@@ -394,6 +424,48 @@ describe("chatAdapter", () => {
     expect(result.text).toBe("Hello from Claude");
     expect(result.usage.inputTokens).toBe(12);
     expect(result.usage.outputTokens).toBe(8);
+  });
+
+  // ── 3b. Anthropic: stop_reason captured as `truncated` (BI-1D144CC1) ──
+
+  it("Anthropic: stop_reason=max_tokens is captured as truncated=true", async () => {
+    stubFetchOk({
+      content: [{ type: "text", text: "Here is the first part of the answer" }],
+      stop_reason: "max_tokens",
+      usage: { input_tokens: 12, output_tokens: 8 },
+    });
+
+    const result = await chatAdapter.execute(makeRequest({
+      providerId: "anthropic",
+      modelId: "claude-sonnet-4-20250514",
+      plan: makePlan({ providerId: "anthropic", modelId: "claude-sonnet-4-20250514" }),
+      provider: {
+        baseUrl: "https://api.anthropic.com/v1",
+        headers: { "x-api-key": "sk-ant-test", "anthropic-version": "2023-06-01" },
+      },
+    }));
+
+    expect(result.truncated).toBe(true);
+  });
+
+  it("Anthropic: stop_reason=end_turn is not truncated", async () => {
+    stubFetchOk({
+      content: [{ type: "text", text: "Complete answer." }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 12, output_tokens: 8 },
+    });
+
+    const result = await chatAdapter.execute(makeRequest({
+      providerId: "anthropic",
+      modelId: "claude-sonnet-4-20250514",
+      plan: makePlan({ providerId: "anthropic", modelId: "claude-sonnet-4-20250514" }),
+      provider: {
+        baseUrl: "https://api.anthropic.com/v1",
+        headers: { "x-api-key": "sk-ant-test", "anthropic-version": "2023-06-01" },
+      },
+    }));
+
+    expect(result.truncated).toBe(false);
   });
 
   // ── 4. Anthropic: providerTools merged into tools array (computer use) ──

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -463,12 +463,17 @@ export const chatAdapter: ExecutionAdapterHandler = {
     let outputTokens: number;
     let cacheCreationInputTokens: number | undefined;
     let cacheReadInputTokens: number | undefined;
+    // Provider stop signal → normalized truncation flag. The agentic loop reads
+    // this to avoid returning a max_tokens-truncated fragment as a final answer
+    // (BI-1D144CC1). Each branch below maps its provider-specific value.
+    let truncated = false;
 
     if (isAnthropic(providerId)) {
       // Anthropic response
       const contentBlocks = data.content as Array<{ type?: string; text?: string; id?: string; name?: string; input?: Record<string, unknown> }> | undefined;
       text = contentBlocks?.filter((b) => b.type === "text").map((b) => b.text ?? "").join("") ?? "";
       toolCalls = extractAnthropicToolCalls(contentBlocks ?? []);
+      truncated = data.stop_reason === "max_tokens";
 
       const usage = (data.usage as Record<string, number>) ?? {};
       inputTokens = usage.input_tokens ?? 0;
@@ -503,6 +508,9 @@ export const chatAdapter: ExecutionAdapterHandler = {
       }
       text = textParts.join("\n");
 
+      truncated = candidates?.[0] != null
+        && (candidates[0] as { finishReason?: string }).finishReason === "MAX_TOKENS";
+
       const usageMetadata = (data.usageMetadata as Record<string, number>) ?? {};
       inputTokens = usageMetadata.promptTokenCount ?? 0;
       outputTokens = usageMetadata.candidatesTokenCount ?? 0;
@@ -516,6 +524,10 @@ export const chatAdapter: ExecutionAdapterHandler = {
       }> | undefined;
       const outputText = typeof data.output_text === "string" ? data.output_text : undefined;
       text = extractResponsesText(output, outputText);
+      // Responses API signals truncation via status="incomplete" +
+      // incomplete_details.reason="max_output_tokens".
+      truncated = data.status === "incomplete"
+        && (data.incomplete_details as { reason?: string } | undefined)?.reason === "max_output_tokens";
 
       const usage = typeof data.usage === "object" && data.usage !== null
         ? data.usage as Record<string, number>
@@ -525,14 +537,17 @@ export const chatAdapter: ExecutionAdapterHandler = {
 
     } else {
       // OpenAI-compatible response
-      const msg = (data.choices as Array<{
+      const choice = (data.choices as Array<{
+        finish_reason?: string;
         message?: {
           content?: string;
           reasoning?: string;
           tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: string } }>;
         };
-      }>)?.[0]?.message;
+      }>)?.[0];
+      const msg = choice?.message;
       text = msg?.content || msg?.reasoning || "";
+      truncated = choice?.finish_reason === "length";
 
       if (msg?.tool_calls && msg.tool_calls.length > 0) {
         // Structured tool calls (standard OpenAI format)
@@ -577,6 +592,7 @@ export const chatAdapter: ExecutionAdapterHandler = {
       toolCalls,
       usage: { inputTokens, outputTokens, cacheCreationInputTokens, cacheReadInputTokens },
       inferenceMs,
+      truncated,
       ...(openRouterRoutingEvidence
         ? { raw: { openRouterRoutingEvidence } }
         : {}),

--- a/apps/web/lib/routing/fallback.ts
+++ b/apps/web/lib/routing/fallback.ts
@@ -111,6 +111,8 @@ export interface FallbackResult {
   downgraded: boolean;
   downgradeMessage: string | null;
   responseId?: string;
+  /** True when the provider stopped at the output-token ceiling (BI-1D144CC1). */
+  truncated?: boolean;
   /** Policy-safe router receipt; never includes prompts or model output. */
   routingEvidence?: import("./provider-suitability/openrouter-policy").OpenRouterRoutingEvidence;
 }
@@ -372,6 +374,7 @@ export async function callWithFallbackChain(
             ? { inputTokens: result.inputTokens, outputTokens: result.outputTokens }
             : undefined,
         inferenceMs: result.inferenceMs,
+        truncated: result.truncated,
         downgraded,
         downgradeMessage: downgraded
           ? preferenceMiss

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -65,6 +65,8 @@ function mockResult(overrides: {
   downgraded?: boolean;
   downgradeMessage?: string | null;
   downgradeReason?: "provider-unavailable" | "not-eligible" | null;
+  /** True when the provider cut generation off at max_tokens/length (BI-1D144CC1). */
+  truncated?: boolean;
 }) {
   return {
     content: overrides.content,
@@ -77,6 +79,7 @@ function mockResult(overrides: {
     downgradeReason: overrides.downgradeReason
       ?? (overrides.downgraded ? "provider-unavailable" as const : null),
     toolsStripped: overrides.toolsStripped ?? false,
+    truncated: overrides.truncated ?? false,
     inputTokens: overrides.inputTokens ?? 100,
     outputTokens: overrides.outputTokens ?? 50,
     toolCalls: overrides.toolCalls ?? [],
@@ -714,6 +717,51 @@ describe("runAgenticLoop", () => {
 
     expect(result.content).toContain("try again in about 30 seconds");
     expect(result.content).not.toContain("Model Assignment");
+  });
+
+  it("does not accept a max_tokens-truncated response as a complete answer — continues generation (BI-1D144CC1)", async () => {
+    // Regression: a response cut off by the provider's max_tokens/length limit that
+    // happens to end without a tool call was returned verbatim as the final answer.
+    // The provider stop signal (stop_reason/finish_reason) was discarded before the
+    // loop could see it, so a truncated fragment masqueraded as a natural end_turn.
+    // A truncation stop is NOT "done": the loop must continue generation and return
+    // the completed answer, never the fragment.
+    const mockRoute = vi.mocked(routeAndCall);
+    const PARTIAL =
+      "Here is the onboarding overview. First, the customer signs in and we provision " +
+      "their workspace. Second, the guided setup tour walks them through connecting their " +
+      "first data source and inviting a teammate. Third, the coworker introduces itself and";
+    const COMPLETE =
+      "Customer onboarding has three stages. First, the customer signs in and we provision " +
+      "their workspace. Second, the guided setup tour connects their first data source and " +
+      "invites a teammate. Third, the coworker introduces itself and offers to draft the " +
+      "first task, so the customer sees value on day one.";
+
+    // First dispatch: substantive but truncated (no tool call). On a conversational
+    // route with no tools, shouldNudge cannot fire (hasTools=false) — so the ONLY
+    // reason to make a second call is the truncation branch under test. Pre-fix the
+    // loop returns PARTIAL after ONE call; post-fix it continues and returns COMPLETE.
+    mockRoute
+      .mockResolvedValueOnce(
+        mockResult({ content: PARTIAL, toolCalls: [], truncated: true }) as never,
+      )
+      .mockResolvedValueOnce(
+        mockResult({ content: COMPLETE, toolCalls: [], truncated: false }) as never,
+      );
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      chatHistory: [{ role: "user" as const, content: "Give me an overview of customer onboarding." }],
+      routeContext: "/coworker/chat",
+      agentId: "market-research-analyst",
+      interactionMode: "chat" as const,
+      tools: [],
+      toolsForProvider: [],
+    });
+
+    expect(mockRoute.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(result.content).toBe(COMPLETE);
+    expect(result.content).not.toBe(PARTIAL);
   });
 
   it("executes tools through the governed lifecycle path", async () => {

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -1433,6 +1433,11 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
   const noProgressNudgedSigs = new Set<string>();
   let fabricationRetries = 0;
   let frustrationCount = 0;
+  // BI-1D144CC1: bounded continue-generation budget for max_tokens-truncated
+  // turns. A truncation stop is not a natural end_turn; we ask the model to
+  // finish (up to this many times) before falling through to the best partial.
+  const MAX_TRUNCATION_CONTINUES = 2;
+  let truncationContinues = 0;
   // Evidence-integrity gate (INV-1). Decide once whether this turn's answer
   // depends on live operational state (a route with authoritative domain tools +
   // a live-state question); the terminal guard in the zero-tool branch enforces
@@ -1813,6 +1818,39 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
         `toolCalls=0 contentLen=${trimmed.length} nudges=${continuationNudges} ` +
         `executedTools=${executedTools.length} content=${JSON.stringify(trimmed.slice(0, 200))}`,
       );
+
+      // BI-1D144CC1: truncation stop. The provider cut generation off at the
+      // output-token ceiling (stop_reason=max_tokens / finish_reason=length /
+      // MAX_TOKENS / Responses incomplete). A reply that ends without a tool call
+      // because it RAN OUT OF TOKENS is not a natural end_turn — returning its
+      // partial text as the final answer is the defect this guards. Ask the model
+      // to finish (bounded) BEFORE the "why did you stop" contract/fabrication/
+      // nudge guards run: we already know why it stopped, so those diagnostics
+      // would misfire. This realizes the stop_reason==="end_turn" contract the
+      // loop's own header comment claims but never enforced.
+      if (result.truncated && truncationContinues < MAX_TRUNCATION_CONTINUES) {
+        truncationContinues++;
+        // Never regress below today's behaviour: keep the longest partial as the
+        // fallback answer in case a continuation returns empty.
+        if (trimmed.length > bestPreNudgeContent.length) bestPreNudgeContent = trimmed;
+        console.warn(
+          `[agentic-loop] response truncated at output-token ceiling with no tool call; ` +
+          `continuing generation (${truncationContinues}/${MAX_TRUNCATION_CONTINUES}). ` +
+          `thread=${JSON.stringify(threadId)} iter=${iteration}`,
+        );
+        messages = [
+          ...messages,
+          { role: "assistant" as const, content: result.content },
+          {
+            role: "user" as const,
+            content:
+              "Your previous response was cut off because it reached the output length limit " +
+              "before you finished. Provide the COMPLETE answer now in a single response — be " +
+              "more concise so it fits within the limit. Do not rely on the truncated version.",
+          },
+        ];
+        continue;
+      }
 
       // Build-specialist Operator Contract clause 2.6 — platform-side guards.
       // Detect contract violations the LLM cannot self-report. Each guard

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -48,7 +48,7 @@ apps/web/lib/mcp/packs/sandbox-pack.ts	920
 apps/web/lib/navigation/portal-navigation-model.ts	965
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1383
-apps/web/lib/routing/chat-adapter.test.ts	924
+apps/web/lib/routing/chat-adapter.test.ts	996
 apps/web/lib/routing/fallback.test.ts	1140
 apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1621
@@ -56,8 +56,8 @@ apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	914
 apps/web/lib/tak/agent-grants.ts	921
 apps/web/lib/tak/agent-routing.ts	1053
-apps/web/lib/tak/agentic-loop.test.ts	2387
-apps/web/lib/tak/agentic-loop.ts	2737
+apps/web/lib/tak/agentic-loop.test.ts	2435
+apps/web/lib/tak/agentic-loop.ts	2775
 apps/web/lib/tak/route-context-map.ts	1273
 apps/web/lib/work-capsules/mcp-handlers.ts	901
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1085


### PR DESCRIPTION
## What & why

The agentic loop returned a `max_tokens`-truncated model response as if it were a complete answer. The provider stop signal (`stop_reason` / `finish_reason`) was discarded at the inference-adapter layer before the loop could see it, so a reply cut off mid-generation that ended **without a tool call** was treated as a natural `end_turn` and its partial text returned as the final answer — no retry, continuation, or escalation. Fixes **BI-1D144CC1**.

## The fix

Thread a normalized `truncated` flag through the full inference chain that previously dropped it at all six hops:

- **Capture** (`chat-adapter.ts`): every provider branch maps its own stop signal — Anthropic `stop_reason=max_tokens`, OpenAI `finish_reason=length`, Gemini `finishReason=MAX_TOKENS`, Responses `status=incomplete`/`max_output_tokens`.
- **Thread**: `AdapterResult → InferenceResult → FallbackResult → RoutedInferenceResult` each carry `truncated`.
- **Act** (`agentic-loop.ts`): the no-tool-call path branches on it *before* the "why did you stop" contract/fabrication/nudge guards (we already know why it stopped). A truncation stop triggers bounded continue-generation (ask the model to finish, concisely) rather than accepting the fragment, preserving the longest partial as a never-worse-than-today fallback. This realizes the `stop_reason==="end_turn"` contract the loop header comment already claimed but never enforced.

Scope note: continues by asking for a complete re-answer rather than stitching, because the loop returns only the *last* `result.content` — stitching would need multi-site prefix accumulation across every return path. CLI-subprocess adapters are out of scope (they leave `truncated` undefined → falsy → unchanged behavior). Temporary-provider-*unavailability* (rate-limit/outage) is a different stop class, tracked separately.

## Tests (dpf-tdd, failing-first)

- `agentic-loop.test.ts`: a truncated text-only turn continues generation and returns the completed answer, not the fragment — reproduced red (1 dispatch pre-fix → ≥2 post-fix).
- `chat-adapter.test.ts`: `finish_reason=length` and `stop_reason=max_tokens` captured as `truncated=true`; clean stops as `false`.

All affected suites green (agentic-loop + chat-adapter: 139 pass; fallback / routed-inference / adapters: 139 pass). Full `tsc --noEmit`: exit 0.

## Design grounding

Trivial no-contract-change correctness edit; source of truth is the loop's own stated `stop_reason` termination contract (the `agentic-loop.ts` header comment). No spec/plan artifact changed. `Design-Grounding-Decision: reconcile-code-to-stated-contract`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Docs-Impact-Decision: internal inference-loop correctness fix — threads a normalized `truncated` flag through existing result types; no new route, setting, or user-documented contract changed. The routing-resilience spec work (durable failover) is tracked separately as BI-F6AD1E18.
