### PR TITLE
fix(inference): keep Anthropic prompt cache alive across tool failures (BI-56804810)

### DIFF
--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -41,6 +41,11 @@ const mocks = vi.hoisted(() => ({
   getCooldownUntil: vi.fn().mockResolvedValue(null),
   recordCooldown: vi.fn().mockResolvedValue(undefined),
   clearCooldown: vi.fn().mockResolvedValue(undefined),
+  // Host-memory-headroom guard (BI-EFA383AA): mock so the unit test never reads
+  // real host memory. The real guard calls os.freemem(), which under-reports on
+  // macOS (cache-heavy) and defers the whole suite on any memory-constrained
+  // host. Default to "enough headroom"; the defer path is exercised via override.
+  evaluateHostMemoryGuard: vi.fn().mockResolvedValue({ defer: false }),
   emitUpgradeEvent: vi.fn(),
   createSelfUpgradeRecoveryPoint: vi.fn(),
   summarizeRecoveryPointFailure: vi.fn(),
@@ -155,6 +160,14 @@ vi.mock("@/lib/self-upgrade/cooldown", () => ({
   isInCooldown: (until: Date | null, now: Date) =>
     !!until && now.getTime() < until.getTime(),
   DEFAULT_COOLDOWN_MINUTES: 30,
+}));
+
+// BI-EFA383AA: override only evaluateHostMemoryGuard (real impl reads os.freemem);
+// keep every other export real via importActual so formatGiB / checkHostMemoryHeadroom
+// / constants are unaffected.
+vi.mock("@/lib/self-upgrade/host-memory-preflight", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/self-upgrade/host-memory-preflight")>()),
+  evaluateHostMemoryGuard: mocks.evaluateHostMemoryGuard,
 }));
 
 vi.mock("@/lib/self-upgrade/notifications", () => ({
@@ -1295,6 +1308,32 @@ describe("skip-before-drain guards", () => {
         targetBundleHash: "abc1234deadbeef",
       }),
     );
+  });
+
+  // BI-EFA383AA: host-memory defer path, driven by the mocked guard so the
+  // assertion is host-independent (the real guard reads os.freemem and would
+  // otherwise flip this test on macOS/low-memory hosts). Defers BEFORE draining
+  // and records a cooldown so the next tick retries once memory recovers.
+  it("defers with host-memory-pressure BEFORE draining and records a cooldown", async () => {
+    mocks.evaluateHostMemoryGuard.mockResolvedValueOnce({
+      defer: true,
+      reason: "host memory 1.50GiB < required 2.00GiB",
+      extra: { availableBytes: 1_610_612_736, requiredBytes: 2_147_483_648, memorySource: "os-freemem" },
+    });
+
+    const result = await runSelfUpgrade({ triggeredBy: "scheduled", scheduled: true });
+
+    expect(result).toMatchObject({ skipped: true, reason: "host-memory-pressure" });
+    expect(mocks.recordCooldown).toHaveBeenCalled();
+    // Deferred before the drain — the guard sits right before startQuiescence.
+    expect(mocks.startQuiescence).not.toHaveBeenCalled();
+  });
+
+  it("proceeds to drain when the host-memory guard reports enough headroom", async () => {
+    // Default mock is { defer: false }; the happy path must reach the drain.
+    await runSelfUpgrade({ triggeredBy: "ops" });
+    expect(mocks.evaluateHostMemoryGuard).toHaveBeenCalled();
+    expect(mocks.startQuiescence).toHaveBeenCalled();
   });
 });
 

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -11,10 +11,12 @@ import {
   detectToolRefusedDespiteAvailability,
   phaseRequiresToolCall,
   detectUnsavedEvidence,
-  enrichToolDescriptions,
+  buildToolSessionHintMessage,
   buildUnsavedAdviceNote,
   HARD_COMPLETION_CLAIM_PATTERN,
 } from "./agentic-loop";
+import { buildAnthropicSystem } from "../routing/anthropic-cache";
+import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY } from "./prompt-boundary";
 
 vi.mock("@dpf/db", () => ({
   prisma: {
@@ -343,72 +345,135 @@ describe("buildMaxIterationsExhaustedMessage (BI-F4D3B9E9d)", () => {
   });
 });
 
-describe("enrichToolDescriptions — review-fail veto on write tool", () => {
-  const baseTools = [
-    { type: "function", name: "saveBuildEvidence", description: "Save evidence", inputSchema: {} },
-    { type: "function", name: "reviewDesignDoc", description: "Review design doc", inputSchema: {} },
-  ];
+describe("buildToolSessionHintMessage — review-fail veto + tool-error notes in the messages tail", () => {
+  // BI-56804810: these notes now ride in a per-turn user message (not tool
+  // descriptions), so the Anthropic tools→system cache prefix stays stable.
+  // The failure/veto semantics are unchanged from the prior in-description hint.
 
-  it("annotates saveBuildEvidence when reviewDesignDoc returned decision:fail", () => {
-    const enriched = enrichToolDescriptions(baseTools, [
+  it("names saveBuildEvidence + REVIEW REJECTION when reviewDesignDoc returned decision:fail", () => {
+    const hint = buildToolSessionHintMessage([
       { name: "saveBuildEvidence", args: { field: "designDoc", value: "v1" }, result: { success: true, message: "Evidence saved." } },
       { name: "reviewDesignDoc", args: {}, result: { success: true, message: "Design review: fail.", data: { review: { decision: "fail", rationale: "Missing codebase research section." } } } },
     ]);
-    const save = enriched.find((t) => t.name === "saveBuildEvidence")!;
-    expect(save.description).toContain("REVIEW REJECTION");
-    expect(save.description).toContain("Missing codebase research section.");
-    expect(save.description).toContain("submitting identical arguments will be rejected");
+    expect(hint).not.toBeNull();
+    expect(hint!).toContain("saveBuildEvidence");
+    expect(hint!).toContain("REVIEW REJECTION");
+    expect(hint!).toContain("Missing codebase research section.");
+    expect(hint!).toContain("submitting identical arguments will be rejected");
   });
 
-  it("clears the veto on a later passing review", () => {
-    const enriched = enrichToolDescriptions(baseTools, [
+  it("clears the veto on a later passing review (returns null)", () => {
+    const hint = buildToolSessionHintMessage([
       { name: "saveBuildEvidence", args: { field: "designDoc", value: "v1" }, result: { success: true, message: "Evidence saved." } },
       { name: "reviewDesignDoc", args: {}, result: { success: true, data: { review: { decision: "fail", rationale: "Missing research." } } } },
       { name: "saveBuildEvidence", args: { field: "designDoc", value: "v2" }, result: { success: true, message: "Evidence saved." } },
       { name: "reviewDesignDoc", args: {}, result: { success: true, data: { review: { decision: "pass" } } } },
     ]);
-    const save = enriched.find((t) => t.name === "saveBuildEvidence")!;
-    expect(save.description).toBe("Save evidence");
+    expect(hint).toBeNull();
   });
 
   it("keeps the veto sticky across a subsequent saveBuildEvidence success (intermediate save still rejected)", () => {
-    // This is the FB-C26D5B50 scenario: the next saveBuildEvidence succeeds at
-    // the protocol level but the review veto from the prior failed review
-    // must remain visible until a passing review clears it.
-    const enriched = enrichToolDescriptions(baseTools, [
+    // FB-C26D5B50 scenario: the next saveBuildEvidence succeeds at the protocol
+    // level but the review veto from the prior failed review must remain visible
+    // until a passing review clears it.
+    const hint = buildToolSessionHintMessage([
       { name: "saveBuildEvidence", args: { field: "designDoc", value: "v1" }, result: { success: true, message: "Evidence saved." } },
       { name: "reviewDesignDoc", args: {}, result: { success: true, data: { review: { decision: "fail", rationale: "Missing codebase research." } } } },
       { name: "saveBuildEvidence", args: { field: "designDoc", value: "v1-again" }, result: { success: true, message: "Evidence saved." } },
     ]);
-    const save = enriched.find((t) => t.name === "saveBuildEvidence")!;
-    expect(save.description).toContain("REVIEW REJECTION");
-    expect(save.description).toContain("Missing codebase research.");
+    expect(hint).not.toBeNull();
+    expect(hint!).toContain("REVIEW REJECTION");
+    expect(hint!).toContain("Missing codebase research.");
   });
 
   it("treats data.blocked=true as a veto even without decision:fail", () => {
-    const enriched = enrichToolDescriptions(baseTools, [
+    const hint = buildToolSessionHintMessage([
       { name: "reviewDesignDoc", args: {}, result: { success: true, data: { review: { decision: "pass" }, blocked: true } } },
     ]);
-    const save = enriched.find((t) => t.name === "saveBuildEvidence")!;
-    expect(save.description).toContain("REVIEW REJECTION");
+    expect(hint).not.toBeNull();
+    expect(hint!).toContain("REVIEW REJECTION");
   });
 
-  it("does nothing when there are no review failures and no tool errors", () => {
-    const enriched = enrichToolDescriptions(baseTools, [
+  it("returns null when there are no review failures and no tool errors", () => {
+    const hint = buildToolSessionHintMessage([
       { name: "saveBuildEvidence", args: { field: "designDoc", value: "v1" }, result: { success: true, message: "Evidence saved." } },
       { name: "reviewDesignDoc", args: {}, result: { success: true, data: { review: { decision: "pass" } } } },
     ]);
-    expect(enriched.find((t) => t.name === "saveBuildEvidence")!.description).toBe("Save evidence");
-    expect(enriched.find((t) => t.name === "reviewDesignDoc")!.description).toBe("Review design doc");
+    expect(hint).toBeNull();
   });
 
-  it("preserves the existing error-warning path when a tool itself failed", () => {
-    const enriched = enrichToolDescriptions(baseTools, [
+  it("returns null with no executed tools yet (first turn)", () => {
+    expect(buildToolSessionHintMessage([])).toBeNull();
+  });
+
+  it("preserves the error-warning path when a tool itself failed", () => {
+    const hint = buildToolSessionHintMessage([
       { name: "saveBuildEvidence", args: { field: "designDoc", value: "v1" }, result: { success: false, error: "Network timeout on persistence layer" } },
     ]);
-    const save = enriched.find((t) => t.name === "saveBuildEvidence")!;
-    expect(save.description).toContain("WARNING");
-    expect(save.description).toContain("Network timeout on persistence layer");
+    expect(hint).not.toBeNull();
+    expect(hint!).toContain("saveBuildEvidence");
+    expect(hint!).toContain("WARNING");
+    expect(hint!).toContain("Network timeout on persistence layer");
+  });
+
+  it("clears a tool's warning once it later succeeds", () => {
+    const hint = buildToolSessionHintMessage([
+      { name: "search_code_graph", args: {}, result: { success: false, error: "index cold" } },
+      { name: "search_code_graph", args: {}, result: { success: true, message: "ok" } },
+    ]);
+    expect(hint).toBeNull();
+  });
+});
+
+describe("Anthropic cache-prefix stability across a tool failure (BI-56804810)", () => {
+  // Functional proof that the fix keeps Anthropic prompt caching alive. Anthropic
+  // hashes its cache prefix as tools → system → messages, so the tools+system
+  // bytes ARE the cache key that gates usage.cache_read_input_tokens. This asserts
+  // those bytes are stable turn-over-turn once a tool has failed.
+
+  // Mirrors chat-adapter.ts: OpenAI-format function tools → Anthropic tool shape.
+  const toAnthropicTools = (
+    tools: Array<{ function: { name: string; description: string; parameters: unknown } }>,
+  ) => tools.map((t) => ({ name: t.function.name, description: t.function.description, input_schema: t.function.parameters }));
+
+  const TOOLS = [
+    { function: { name: "search_code_graph", description: "Search the code graph.", parameters: { type: "object" } } },
+    { function: { name: "saveBuildEvidence", description: "Save build evidence.", parameters: { type: "object" } } },
+  ];
+  const SYSTEM =
+    "You are DPF. Identity, mode, and mission are fixed for this session." +
+    SYSTEM_PROMPT_DYNAMIC_BOUNDARY +
+    "Today is 2026-08-12.";
+
+  // The exact bytes Anthropic hashes for the cached prefix: tools then system.
+  const cachePrefixSurface = (tools: unknown) => JSON.stringify({ tools, system: buildAnthropicSystem(SYSTEM) });
+
+  it("keeps the tools+system prefix byte-identical after a tool failure (the fix → cache HIT)", () => {
+    // Turn 1: nothing executed yet.
+    const turn1 = cachePrefixSurface(toAnthropicTools(TOOLS));
+
+    // Turn 2: a tool failed. Under the fix, tools pass through unchanged and the
+    // note is routed to the messages tail instead of a tool description.
+    const hint = buildToolSessionHintMessage([
+      { name: "search_code_graph", result: { success: false, error: "index cold" } },
+    ]);
+    const turn2 = cachePrefixSurface(toAnthropicTools(TOOLS));
+
+    expect(hint).not.toBeNull(); // the model still receives the "don't blindly retry" signal…
+    expect(turn2).toBe(turn1); // …but the cached tools+system prefix is unchanged → cache hits
+  });
+
+  it("documents the retired defect: annotating a tool description changes the prefix → cache MISS", () => {
+    const before = cachePrefixSurface(toAnthropicTools(TOOLS));
+    // Reproduce the old in-description mutation that busted the cache every turn.
+    const mutated = toAnthropicTools(TOOLS).map((t) =>
+      t.name === "search_code_graph"
+        ? { ...t, description: `${t.description} [WARNING: This tool failed earlier in this session with: "index cold". Consider a different approach or different arguments.]` }
+        : t,
+    );
+    const after = cachePrefixSurface(mutated);
+    // Regression guard — never route session hints back into tool descriptions.
+    expect(after).not.toBe(before);
   });
 });
 
@@ -1859,8 +1924,12 @@ describe("runAgenticLoop", () => {
     expect(result.executedTools).toHaveLength(2);
     expect(result.content).toContain("Added initial complaint severity enum scaffolding");
     const thirdCallMessages = mockRoute.mock.calls[2]?.[0] ?? [];
-    const lastUserMessage = [...thirdCallMessages].reverse().find((m: any) => m.role === "user");
-    expect(lastUserMessage?.content).toContain("Do not pause after a failed read");
+    // The stall nudge must reach the model. It is no longer guaranteed to be the
+    // LAST user message: BI-56804810 routes session tool-notes into a message at
+    // the tail (a failed run_sandbox_command yields such a note here), so assert
+    // the nudge is present among the delivered user messages rather than last.
+    const userMessages = thirdCallMessages.filter((m: any) => m.role === "user");
+    expect(userMessages.some((m: any) => typeof m.content === "string" && m.content.includes("Do not pause after a failed read"))).toBe(true);
   });
 
   // ─── Infra-aware fabrication guard (routing-resilience Slice D) ───────────

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -988,17 +988,21 @@ function reviewFailMessage(t: { name: string; result: { success: boolean; data?:
   return `Your previous ${artifact} was REJECTED by ${t.name}. Reason: ${detail.slice(0, 200)}. Regenerate the content addressing this specific gap before calling saveBuildEvidence again — submitting identical arguments will be rejected the same way and the run will be stopped.`;
 }
 
-/**
- * Annotate tool descriptions with session-aware hints based on what the agent
- * has already tried. Inspired by Claude Code's dynamic tool description system.
- * Mutates nothing — returns a new array.
- */
-export function enrichToolDescriptions(
-  toolsForProvider: Array<Record<string, unknown>>,
-  executedTools: Array<{ name: string; args?: Record<string, unknown>; result: { success: boolean; error?: string; data?: Record<string, unknown>; message?: string } }>,
-): Array<Record<string, unknown>> {
-  if (executedTools.length === 0) return toolsForProvider;
+type ExecutedToolRecord = {
+  name: string;
+  args?: Record<string, unknown>;
+  result: { success: boolean; error?: string; data?: Record<string, unknown>; message?: string };
+};
 
+/**
+ * Compute session-aware tool signals from what the agent has already tried:
+ * a per-tool last-error map (cleared once that tool later succeeds) and a
+ * sticky content-level review-veto map (cleared only by a passing review).
+ * Pure — mutates nothing.
+ */
+function computeToolSessionSignals(
+  executedTools: Array<ExecutedToolRecord>,
+): { failures: Map<string, string>; reviewVetoes: Map<string, string> } {
   // Build failure map: tool name → last error. If a tool succeeded after
   // failing, clear the warning — the tool recovered.
   const failures = new Map<string, string>();
@@ -1025,24 +1029,55 @@ export function enrichToolDescriptions(
       failures.delete(t.name);
     }
   }
+  return { failures, reviewVetoes };
+}
 
-  if (failures.size === 0 && reviewVetoes.size === 0) return toolsForProvider;
+/**
+ * Build a per-turn "session tool notes" user message from what the agent has
+ * already tried, or null when there is nothing to warn about.
+ *
+ * BI-56804810 — this REPLACES annotating tool `description` fields in place.
+ * Anthropic's prompt-cache prefix is ordered tools → system → messages, so the
+ * stable system-prefix cache breakpoint (see routing/anthropic-cache.ts) also
+ * covers the tools block. The previous approach appended
+ * `[WARNING …]` / `[REVIEW REJECTION …]` strings into tool descriptions every
+ * turn, so once any tool failed or was review-vetoed the tools block changed on
+ * nearly every subsequent turn — busting the cached tools+system prefix and
+ * re-billing it at full input rate (vs ~0.1x cache reads) for the rest of the
+ * session. Emitting the identical signal as a message keeps the tools block
+ * byte-identical turn-over-turn so the cache actually hits; the message sits
+ * AFTER the cached prefix, where its per-turn churn carries no cache cost, and
+ * the model still gets the "don't blindly retry" guidance just as well.
+ *
+ * Provider-agnostic: the hint reaches every provider through the messages tail,
+ * so no per-provider branching is needed; only Anthropic gets the extra cache
+ * benefit, and the local served-model path is unaffected.
+ */
+export function buildToolSessionHintMessage(
+  executedTools: Array<ExecutedToolRecord>,
+): string | null {
+  if (executedTools.length === 0) return null;
 
-  return toolsForProvider.map((tool) => {
-    const name = tool.name as string;
-    const lastError = failures.get(name);
-    const veto = reviewVetoes.get(name);
-    if (!lastError && !veto) return tool;
+  const { failures, reviewVetoes } = computeToolSessionSignals(executedTools);
+  if (failures.size === 0 && reviewVetoes.size === 0) return null;
 
-    const desc = tool.description as string;
-    const warning = veto
-      ? `[REVIEW REJECTION: ${veto}]`
-      : `[WARNING: This tool failed earlier in this session with: "${lastError}". Consider a different approach or different arguments.]`;
-    return {
-      ...tool,
-      description: `${desc} ${warning}`,
-    };
-  });
+  const lines: string[] = [];
+  for (const [name, veto] of reviewVetoes) {
+    lines.push(`- ${name}: [REVIEW REJECTION: ${veto}]`);
+  }
+  for (const [name, lastError] of failures) {
+    lines.push(
+      `- ${name}: [WARNING: This tool failed earlier in this session with: "${lastError}". ` +
+        `Consider a different approach or different arguments.]`,
+    );
+  }
+
+  return (
+    "[Session tool notes — based on tool calls you already made this session. " +
+    "Do not blindly re-issue the same call with the same arguments; address the note first:\n" +
+    lines.join("\n") +
+    "]"
+  );
 }
 
 function truncateMessageContent(content: string, maxChars: number, label: string): string {
@@ -1697,13 +1732,6 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
       messages = [...messages, { role: "user" as const, content: buildNoProgressNudgeMessage(approaching) }];
     }
 
-    // Dynamic tool descriptions: annotate tools that failed earlier in this session
-    // Inspired by Claude Code's session-aware tool description system.
-    const enrichedRouteOptions = {
-      ...routeOptions,
-      ...(routeOptions.tools ? { tools: enrichToolDescriptions(routeOptions.tools as Array<Record<string, unknown>>, executedTools) } : {}),
-    };
-
     // EP-INF-009b: All inference goes through V2 routing pipeline
     inferenceCallCount++;
     // Assemble the compacted, plan-reminded context once (it was built twice,
@@ -1732,6 +1760,14 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
         ),
       );
     }
+    // Session tool notes ride in the messages tail — AFTER the cached
+    // tools→system prefix — instead of mutating tool descriptions, so the
+    // Anthropic prompt-cache prefix stays byte-identical turn-over-turn even
+    // after a tool fails or is review-vetoed. See buildToolSessionHintMessage.
+    const toolSessionHint = buildToolSessionHintMessage(executedTools);
+    const messagesForCall = toolSessionHint
+      ? [...assembledMessages, { role: "user" as const, content: toolSessionHint }]
+      : assembledMessages;
     let result: RoutedInferenceResult;
     try {
       // BI-e299d4d3 — wrap the slow inference with withHeartbeatTicker.
@@ -1744,18 +1780,18 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
         const { withHeartbeatTicker } = await import("@/lib/observability/heartbeat");
         result = await withHeartbeatTicker(taskRunId, () =>
           routeAndCall(
-            assembledMessages,
+            messagesForCall,
             systemPrompt,
             sensitivity,
-            { ...enrichedRouteOptions, previousResponseId },
+            { ...routeOptions, previousResponseId },
           ),
         );
       } else {
         result = await routeAndCall(
-          assembledMessages,
+          messagesForCall,
           systemPrompt,
           sensitivity,
-          { ...enrichedRouteOptions, previousResponseId },
+          { ...routeOptions, previousResponseId },
         );
       }
     } catch (routeErr) {

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -56,8 +56,8 @@ apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	914
 apps/web/lib/tak/agent-grants.ts	921
 apps/web/lib/tak/agent-routing.ts	1053
-apps/web/lib/tak/agentic-loop.test.ts	2435
-apps/web/lib/tak/agentic-loop.ts	2775
+apps/web/lib/tak/agentic-loop.test.ts	2504
+apps/web/lib/tak/agentic-loop.ts	2811
 apps/web/lib/tak/route-context-map.ts	1273
 apps/web/lib/work-capsules/mcp-handlers.ts	901
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1085

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -47,7 +47,7 @@ apps/web/lib/mcp/packs/contribution-hive-pack.ts	854
 apps/web/lib/mcp/packs/sandbox-pack.ts	920
 apps/web/lib/navigation/portal-navigation-model.ts	965
 apps/web/lib/operate/coworker-regression-detector.ts	935
-apps/web/lib/queue/functions/self-upgrade.test.ts	1383
+apps/web/lib/queue/functions/self-upgrade.test.ts	1422
 apps/web/lib/routing/chat-adapter.test.ts	996
 apps/web/lib/routing/fallback.test.ts	1140
 apps/web/lib/self-upgrade/quiescence.test.ts	951


### PR DESCRIPTION
## Summary
On the Anthropic cloud route, prompt caching stopped paying off for the rest of most sessions. Anthropic caches its prefix in the canonical order **tools → system → messages**, so the stable system-prefix cache breakpoint (`apps/web/lib/routing/anthropic-cache.ts`, BI-79A5C00F) also covers the **tools** block. The agentic loop called `enrichToolDescriptions` **every turn**, appending `[WARNING …]` / `[REVIEW REJECTION …]` strings **into tool `description` fields** once any tool failed or was review-vetoed. That mutated the tools block on nearly every subsequent turn → the cached tools+system prefix was busted and re-billed at full input rate (vs ~0.1× cache reads) for the remainder of the session.

**Fix (zero capability cost):** relocate the per-turn session tool-notes out of tool descriptions and into a synthetic user message appended to the **messages tail** — *after* the cached prefix in Anthropic's ordering — via the new `buildToolSessionHintMessage`. The model still gets the identical "don't blindly retry" signal, but the tools block stays byte-identical turn-over-turn so the existing breakpoint actually gets cache hits. Failure/veto semantics (sticky review veto, clear-on-passing-review, per-tool error warning, no-op when clean) are unchanged and re-tested against the message form.

Backlog item: **BI-56804810** (portfolio/bug, EP-CLAUDE-INSIDE-OUT, size small, triaged build).

## Scope
Anthropic cloud route **only**. The local served-model path (DMR/llama.cpp, OpenAI-compatible) never sees `cache_control` and is unaffected. Delivery via the messages tail is provider-agnostic, so no per-provider branching.

## Verification
- `apps/web/lib/tak/agentic-loop.test.ts` + `apps/web/lib/routing/anthropic-cache.test.ts`: **121 passed**.
- **Functional cache-key proof** (new): the `tools`+`system` cache-prefix surface is **byte-identical** across a tool failure under the fix (cache hit); a regression guard documents that the retired in-description mutation **changed** that surface (cache miss) — so the exact bytes Anthropic hashes to gate `usage.cache_read_input_tokens` are now stable.
- Typecheck clean (`run-tsc --noEmit`, 8 GB heap); tool-description-hygiene guard passes; module-size ratchet re-baselined; local-CI merged gate **passed** for this HEAD.
- **Remaining step (needs an Anthropic-configured provider):** the live `usage.cache_read_input_tokens` before/after A/B — drive a multi-turn loop that induces a tool failure and assert cache reads stay ~full on later turns instead of dropping to ~0. Cannot run in this session (no live Anthropic inference); tracked on the BI.

## Secondary (measure, not changed here)
Progressive tool loading (`load_tools`, auto-load-on-direct-call) grows `routeOptions.tools` mid-loop, which also mutates position 0 and invalidates the prefix on the next turn. On Anthropic, front-loading the full authorized tool set once may net cheaper for long loops — worth a measurement; out of scope for this fix. Noted on the BI.

## Design grounding
- Specs/plans reviewed: `docs/superpowers/specs/2026-06-20-context-engineering-tool-efficiency-design.md` (line 81 confirms the cached prefix is *tools+system*; line 181 documents the `enrichToolDescriptions`-onto-descriptions pattern as a P11 retention win, never reconciled against P8 prefix stability — this PR resolves that tension), `docs/superpowers/specs/2026-05-19-ai-cost-governance.md`.
- Source of truth: `docs/architecture/context-engineering-standards.md` P8 ("Cache the stable prefix") + the `anthropic-cache.ts` breakpoint contract (BI-79A5C00F).
- Decision: move the sticky failure/veto signal from tool descriptions (kept P11, broke P8 for tools) to the messages tail — preserving P11 while restoring P8. Delivery channel only; no spec/schema/tool-surface contract change.
- `Design-Grounding-Decision: no-contract-change`

## Notes
- DCO: commit is `Signed-off-by` (dpf-ci).
- The pre-push semantic-review-gate reported `missing-receipt` as a **shadow observation** (non-blocking; publication allowed). An independent semantic-review receipt for the stable commit is still owed per DPF process before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)