### PR TITLE
fix(restaurant): distinguish host seating capacity

### DIFF
--- a/apps/web/lib/storefront/hospitality-capacity-repository.server.test.ts
+++ b/apps/web/lib/storefront/hospitality-capacity-repository.server.test.ts
@@ -167,6 +167,61 @@ describe("hospitality capacity repository", () => {
     expect(create).not.toHaveBeenCalled();
   });
 
+  it("allows an authenticated service turn to extend beyond the last public bookable start", async () => {
+    const create = vi.fn(async ({ data }: { data: Record<string, unknown> }) => ({
+      id: "allocation-row",
+      version: 1,
+      ...data,
+    }));
+    const db = database({
+      businessProfile: {
+        findFirst: vi.fn(async () => ({ timezone: "America/Chicago" })),
+      },
+      hospitalityResource: {
+        findFirst: vi.fn(async () => ({
+          id: "table-1",
+          legacyServiceProviderId: "provider-1",
+          status: "active",
+          capacity: 4,
+          availability: [{
+            kind: "available",
+            days: [3],
+            startTime: "11:00",
+            endTime: "22:00",
+            date: null,
+          }],
+        })),
+      },
+      hospitalityCapacityAllocation: {
+        findFirst: vi.fn(async () => null),
+        findMany: vi.fn(async () => []),
+        create,
+        updateMany: vi.fn(async () => ({ count: 0 })),
+      },
+    });
+
+    await expect(
+      allocateHospitalityCapacity(db, {
+        organizationId: "org-1",
+        storefrontId: "storefront-1",
+        resourceId: "table-1",
+        poolId: null,
+        demandType: "booking",
+        demandRef: "BK-WALK-IN",
+        bookingId: "booking-walk-in",
+        bookingHoldId: null,
+        serviceTurnId: "turn-1",
+        startsAt: new Date("2026-08-13T02:17:00.000Z"),
+        // clock-bomb-guard: allow pure historical interval fixture has no wall-clock dependency
+        endsAt: new Date("2026-08-13T03:47:00.000Z"),
+        quantity: 1,
+        idempotencyKey: "seat:booking-walk-in:table-1",
+        enforceResourceAvailability: false,
+      }),
+    ).resolves.toEqual(expect.objectContaining({ demandRef: "BK-WALK-IN" }));
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
   it("evaluates a Restaurant table schedule in the operator's Chicago timezone", async () => {
     const create = vi.fn(async ({ data }: { data: Record<string, unknown> }) => ({
       id: "allocation-row",

--- a/apps/web/lib/storefront/hospitality-capacity-repository.server.ts
+++ b/apps/web/lib/storefront/hospitality-capacity-repository.server.ts
@@ -80,6 +80,13 @@ export async function allocateHospitalityCapacity(
     endsAt: Date;
     quantity: number;
     idempotencyKey: string;
+    /**
+     * Public holds and bookings must fit the resource's bookable schedule.
+     * Authenticated host operations may extend an in-progress service turn
+     * beyond the last public bookable start while retaining every occupancy,
+     * capacity, version, and idempotency guard.
+     */
+    enforceResourceAvailability?: boolean;
   },
 ) {
   validateAllocationRequest(input);
@@ -153,6 +160,7 @@ export async function allocateHospitalityCapacity(
       );
     }
     if (
+      input.enforceResourceAvailability !== false &&
       !isHospitalityResourceAvailableForInterval({
         availability: resource.availability ?? [],
         startsAt: input.startsAt,

--- a/apps/web/lib/twin/restaurant-floor-command.server.test.ts
+++ b/apps/web/lib/twin/restaurant-floor-command.server.test.ts
@@ -173,6 +173,7 @@ describe("restaurant floor command adapter", () => {
       expect.objectContaining({
         resourceId: "table-1",
         serviceTurnId: "turn-1",
+        enforceResourceAvailability: false,
       }),
     );
     expect(allocateCapacity).toHaveBeenNthCalledWith(
@@ -181,6 +182,7 @@ describe("restaurant floor command adapter", () => {
       expect.objectContaining({
         resourceId: "table-2",
         serviceTurnId: "turn-1",
+        enforceResourceAvailability: false,
       }),
     );
     expect(transitionCapacity).toHaveBeenCalledTimes(2);

--- a/apps/web/lib/twin/restaurant-floor-command.server.ts
+++ b/apps/web/lib/twin/restaurant-floor-command.server.ts
@@ -577,6 +577,7 @@ export function createRestaurantFloorCommandAdapter(input: {
                 quantity: 1,
                 idempotencyKey:
                   `${assignmentCommand.idempotencyKey}:${resourceId}`,
+                enforceResourceAvailability: false,
               }),
             );
             await dependencies.transitionCapacity(transaction as never, {

--- a/apps/web/lib/twin/restaurant-move-command.server.test.ts
+++ b/apps/web/lib/twin/restaurant-move-command.server.test.ts
@@ -141,6 +141,7 @@ describe("restaurant party move command", () => {
         resourceId: "table-2",
         serviceTurnId: "turn-1",
         demandRef: "BOOK-1",
+        enforceResourceAvailability: false,
       }),
     );
     expect(tx.hospitalityServiceTurn.updateMany).toHaveBeenCalledWith({

--- a/apps/web/lib/twin/restaurant-move-command.server.ts
+++ b/apps/web/lib/twin/restaurant-move-command.server.ts
@@ -482,6 +482,7 @@ export async function executeRestaurantMoveCommand(input: {
             endsAt,
             quantity: 1,
             idempotencyKey: `${command.idempotencyKey}:${resourceId}`,
+            enforceResourceAvailability: false,
           }),
         );
         await dependencies.transitionCapacity(transaction as never, {

--- a/docs/superpowers/plans/2026-08-12-restaurant-host-operational-capacity.md
+++ b/docs/superpowers/plans/2026-08-12-restaurant-host-operational-capacity.md
@@ -1,0 +1,24 @@
+# Restaurant host operational capacity repair
+
+Backlog: BI-4D076907  
+Capsule: WC-DB2D7D60
+
+## Evidence and boundary
+
+On canonical lineage `f0ba454875921ed909d11f7f6ab50440941137c4`, the host stand recommended Aster 1 for Quinn Doyle at 21:17 America/Chicago, then rejected the command because the estimated 90-minute service turn extended beyond the table's public booking schedule. Runtime evidence `cmsqw4h5i006p01s0c8ln572w` proves that the floor was unchanged and the table was physically unoccupied.
+
+The shared capacity repository correctly enforces resource schedules for public holds and bookings. An authenticated host seating or moving an already-present party is a distinct operational action: it must still enforce table status, seat capacity, overlapping allocations, idempotency, and optimistic versions, but a service-turn estimate may extend beyond the last public bookable start.
+
+## Implementation
+
+1. Add an explicit, default-on resource-schedule enforcement option to the canonical capacity allocation boundary.
+2. Set the option off only for authenticated host seating and table-move commands.
+3. Preserve default enforcement for guest holds and booking submission.
+4. Prove the live closing-interval regression in repository and command tests, then run the governed exact-tree delivery and repeat the authenticated seating/reload acceptance.
+
+## Non-goals
+
+- No schema or migration.
+- No change to public operating hours or reservation availability.
+- No weakening of occupancy, capacity, version, staffing, or transaction checks.
+- No new UI control or copy.


### PR DESCRIPTION
## Summary
- keep public holds and bookings constrained to resource availability windows
- let authenticated host seat/move operations extend an active service turn beyond the last public bookable start
- retain occupancy, seat capacity, version, staffing, idempotency, and transaction guards

## Live evidence
- Canonical failure: `cmsqw4h5i006p01s0c8ln572w`
- Quinn Doyle (3) → Aster 1 at 21:17 CDT was recommended, then rejected after 5,291ms because a 90-minute turn crossed the 22:00 public availability end

## Verification
- TDD RED: 3 failures across repository, seat command, and move command
- GREEN: 17/17 focused tests
- 8 GiB web typecheck passed
- Style/token drift passed
- Exact preflight: 37/37 guards clean
- Exact semantic review: `cmsqwgmsm00p501s06plrlgf9` — pass, two independent branches, zero findings
- Exact local-CI: `cmsqxvwhw01kw01s0dhvu7oy8` — literal gate passed for `0aa382846556`
- Migration: not applicable; no schema/data change
- UX: no new controls, copy, or layout; post-deploy authenticated seating/reload acceptance remains required

## Design grounding
- Plan: `docs/superpowers/plans/2026-08-12-restaurant-host-operational-capacity.md`
- Source of truth: canonical hospitality capacity allocation
- Decision: schedule enforcement remains default-on; only authenticated host seat/move explicitly disable the booking-window check

Docs-Impact-Decision: Internal Restaurant host allocation semantics repair; no user-facing control, copy, route, or documented workflow changed.