### PR TITLE
fix(storefront): make inbox dates hydration-safe

### DIFF
--- a/apps/web/app/(shell)/storefront/inbox/page.tsx
+++ b/apps/web/app/(shell)/storefront/inbox/page.tsx
@@ -3,7 +3,11 @@ import { redirect } from "next/navigation";
 import { StorefrontInbox } from "@/components/storefront-admin/StorefrontInbox";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/finance/currency-symbol";
-import { formatReservationWhen, nextActionForReservation } from "@/lib/storefront/booking-summary";
+import {
+  formatInboxCreatedDate,
+  formatReservationWhen,
+  nextActionForReservation,
+} from "@/lib/storefront/booking-summary";
 import { nextActionForOrder, summarizeOrderItems } from "@/lib/storefront/order-lifecycle";
 import { loadStorefrontOperatingTimezone } from "@/lib/storefront/storefront-operating-timezone.server";
 
@@ -113,6 +117,7 @@ export default async function InboxPage() {
     type: string;
     detail: string;
     createdAt: string;
+    createdLabel: string;
     providerName: string | null;
     status: string;
     backlogItemId?: string | null;
@@ -149,6 +154,7 @@ export default async function InboxPage() {
       type: "inquiry",
       detail: inquiry.message ?? "",
       createdAt: inquiry.createdAt.toISOString(),
+      createdLabel: formatInboxCreatedDate(inquiry.createdAt, operatingTimezone),
       providerName: null,
       status: "",
       backlogItemId:
@@ -166,6 +172,7 @@ export default async function InboxPage() {
         type: "booking",
         detail: when.whenLabel,
         createdAt: booking.createdAt.toISOString(),
+        createdLabel: formatInboxCreatedDate(booking.createdAt, operatingTimezone),
         providerName: booking.provider?.name ?? null,
         status: booking.status,
         itemName: itemNameById.get(booking.itemId) ?? null,
@@ -189,6 +196,7 @@ export default async function InboxPage() {
         type: "order",
         detail: `${currencySymbol}${order.totalAmount.toString()}`,
         createdAt: order.createdAt.toISOString(),
+        createdLabel: formatInboxCreatedDate(order.createdAt, operatingTimezone),
         providerName: null,
         status: order.status,
         itemName: itemSummary,
@@ -203,6 +211,7 @@ export default async function InboxPage() {
       type: "donation",
       detail: `${currencySymbol}${donation.amount.toString()}`,
       createdAt: donation.createdAt.toISOString(),
+      createdLabel: formatInboxCreatedDate(donation.createdAt, operatingTimezone),
       providerName: null,
       status: "",
     })),

--- a/apps/web/components/storefront-admin/StorefrontInbox.test.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.test.tsx
@@ -22,6 +22,7 @@ function inquiry(overrides: Record<string, unknown> = {}) {
     type: "inquiry",
     detail: "I want to run product ops on DPF.",
     createdAt: "2026-07-20T10:00:00.000Z",
+    createdLabel: "20/07/2026",
     providerName: null,
     status: "",
     backlogItemId: null,
@@ -45,6 +46,7 @@ function booking(overrides: Record<string, unknown> = {}) {
     type: "booking",
     detail: "Wednesday, July 22",
     createdAt: "2026-07-20T10:00:00.000Z",
+    createdLabel: "20/07/2026",
     providerName: null,
     status: "pending",
     backlogItemId: null,
@@ -56,6 +58,24 @@ function booking(overrides: Record<string, unknown> = {}) {
     ...overrides,
   };
 }
+
+describe("StorefrontInbox hydration-safe dates", () => {
+  it("renders the server-projected business date without client locale formatting", () => {
+    const entry = booking({
+      createdAt: "2026-08-13T03:53:56.000Z",
+      createdLabel: "12/08/2026",
+    });
+    render(
+      <StorefrontInbox
+        entries={[entry]}
+        defaultDigitalProduct={defaultDigitalProduct}
+      />,
+    );
+
+    expect(screen.getByText("12/08/2026")).toBeTruthy();
+    expect(screen.queryByText("13/08/2026")).toBeNull();
+  });
+});
 
 function stubFetch(response: { ok: boolean; body?: Record<string, unknown> }) {
   const fetchMock = vi.fn(async () => ({
@@ -233,6 +253,7 @@ function order(overrides: Record<string, unknown> = {}) {
     type: "order",
     detail: "$32",
     createdAt: "2026-07-29T10:00:00.000Z",
+    createdLabel: "29/07/2026",
     providerName: null,
     status: "pending",
     backlogItemId: null,

--- a/apps/web/components/storefront-admin/StorefrontInbox.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.tsx
@@ -15,6 +15,7 @@ type Entry = {
   type: string;
   detail: string;
   createdAt: string;
+  createdLabel: string;
   providerName: string | null;
   status: string;
   backlogItemId?: string | null;
@@ -335,7 +336,7 @@ export function StorefrontInbox({
                 </span>
               )}
               <span className="text-[var(--dpf-muted)]" style={{ fontSize: 11, marginLeft: "auto" }}>
-                {new Date(e.createdAt).toLocaleDateString("en-GB")}
+                {e.createdLabel}
               </span>
             </div>
             <div style={{ fontSize: 13 }}>{e.name ?? "Anonymous"} · {e.email}</div>

--- a/apps/web/lib/storefront/booking-summary.test.ts
+++ b/apps/web/lib/storefront/booking-summary.test.ts
@@ -1,11 +1,25 @@
 import { describe, it, expect } from "vitest";
 import {
+  formatInboxCreatedDate,
   formatReservationWhen,
   nextActionForReservation,
   parseCovers,
   reservationActionLabel,
   structuredBookingFieldRole,
 } from "./booking-summary";
+
+describe("formatInboxCreatedDate", () => {
+  it("uses the storefront timezone instead of the rendering host timezone", () => {
+    // This instant is already August 13 in UTC, but still August 12 for the
+    // America/Chicago business. Server and browser must receive one label.
+    expect(
+      formatInboxCreatedDate(
+        new Date("2026-08-13T03:53:56.000Z"),
+        "America/Chicago",
+      ),
+    ).toBe("12/08/2026");
+  });
+});
 
 describe("structuredBookingFieldRole", () => {
   it("maps covers + dietary field names to their structured roles", () => {

--- a/apps/web/lib/storefront/booking-summary.ts
+++ b/apps/web/lib/storefront/booking-summary.ts
@@ -53,6 +53,18 @@ export type ReservationStatus =
   | "cancelled"
   | "needs-reschedule";
 
+/** Format an inbox intake instant in the business timezone before it crosses
+ *  the server/client boundary. Rendering the ISO value with the browser's
+ *  locale can disagree with the server near midnight and break hydration. */
+export function formatInboxCreatedDate(createdAt: Date, timezone: string): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: timezone,
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(createdAt);
+}
+
 /** Format a booking's scheduled instant for owner-facing surfaces, in the
  *  storefront's own timezone so "6:30 PM" is the guest's local slot. Pure given a
  *  fixed timezone (Intl is deterministic). */


### PR DESCRIPTION
## Outcome

- projects owner-inbox intake dates on the server in the canonical storefront operating timezone
- removes browser-locale date rendering that caused deterministic React hydration error #418 near UTC/business-day boundaries
- keeps booking, filtering, action, and route behavior unchanged

## Verification

- TDD RED reproduced the America/Chicago midnight boundary
- focused Vitest: 27/27 passed
- web typecheck passed
- prose, style, and token guards passed
- preflight: 37/37 guards passed
- exact governed local-CI: d179d9344b9, evidence cmsr0dr3v01m501qq5ucn862o, literal gate passed after migrations, typecheck, exhaustive tests, production OCI build/import, and smoke
- fresh semantic receipt cmsqzvs5q010f01qqdtefilq1: pass, zero findings, publication allowed

## Design grounding

- Existing specs/plans reviewed: BI-5B02A163 and its authenticated-shell hydration acceptance criteria.
- Current code substrate reviewed: apps/web/app/(shell)/storefront/inbox/page.tsx, apps/web/components/storefront-admin/StorefrontInbox.tsx, and apps/web/lib/storefront/booking-summary.ts.
- Source of truth: the server-resolved storefront operating timezone and server-projected createdLabel.
- Decision: cross the server/client boundary with deterministic display text; do not suppress React warnings or infer a browser timezone.

## UX

No controls, navigation, workflow, copy, layout, or styling changed. The visible date remains en-GB, now deterministically aligned with the business timezone. Canonical live acceptance will reload /storefront/inbox and require zero console warnings/errors after deployment.

## Docs impact

Docs-Impact-Decision: no user, operator, route, install, or architecture documentation changes are needed; this is a localized runtime correctness repair with the contract documented in code and regression tests.

## Migration

Not applicable: no schema or data migration.