### PR TITLE
fix(wwwd): fail safe when stance relevance falls back to lexical (BI-7E1F128A)

### DIFF
--- a/apps/web/lib/decision-perspective/evaluator.test.ts
+++ b/apps/web/lib/decision-perspective/evaluator.test.ts
@@ -406,4 +406,39 @@ describe("content-aware directional scoring (BI-7E1F128A)", () => {
     expect(b.outcomeType).toBe("escalate");
     expect(a.stanceAlignment).toBeUndefined();
   });
+
+  // BI-7E1F128A follow-up: when the embedding layer is down, relevance is scored
+  // by coarse lexical overlap. That signal is too imprecise to drive a confident
+  // directional verdict — on the live install it spuriously matched a support
+  // stance and confidently APPROVED an off-mission decision, strictly worse than
+  // escalating. On the lexical fallback the gate must revert to escalate (the
+  // safe pre-fix behavior) regardless of the apparent direction.
+  it("FAIL-SAFE: lexical relevance escalates even when the apparent stance APPROVES", () => {
+    const semantic = evaluateDecisionPerspective({
+      ...twoStances,
+      question: "Should we onboard an MSP as a certified reseller partner?",
+      relevanceByMaterialId: new Map([["markets-we-decline", 0], ["partner-network", 1]]),
+      relevanceMethod: "semantic",
+    });
+    const lexical = evaluateDecisionPerspective({
+      ...twoStances,
+      question: "Should we onboard an MSP as a certified reseller partner?",
+      relevanceByMaterialId: new Map([["markets-we-decline", 0], ["partner-network", 1]]),
+      relevanceMethod: "lexical",
+    });
+    // Same inputs, only the relevance METHOD differs: semantic acts, lexical asks.
+    expect(semantic.outcomeType).toBe("recommend");
+    expect(lexical.outcomeType).toBe("escalate");
+    expect(lexical.relevanceMethod).toBe("lexical");
+  });
+
+  it("FAIL-SAFE: lexical relevance escalates even when the apparent stance DECLINES", () => {
+    const lexical = evaluateDecisionPerspective({
+      ...twoStances,
+      question: "Should we sell toasters to fishermen from kiosks on Alaskan docks?",
+      relevanceByMaterialId: new Map([["markets-we-decline", 1], ["partner-network", 0]]),
+      relevanceMethod: "lexical",
+    });
+    expect(lexical.outcomeType).toBe("escalate");
+  });
 });

--- a/apps/web/lib/decision-perspective/evaluator.ts
+++ b/apps/web/lib/decision-perspective/evaluator.ts
@@ -145,6 +145,25 @@ export function evaluateDecisionPerspective(
   if (selectedCoverage.contentAware) {
     const alignment = selectedCoverage.stanceAlignment ?? "none";
 
+    // Lexical-fallback fail-safe (BI-7E1F128A follow-up). When the embedding
+    // layer is unavailable, `computeStanceRelevance` scores relevance by coarse
+    // lexical token-overlap. That signal is too imprecise to drive a confident
+    // directional verdict: on a live install it spuriously matched a `support`
+    // stance and confidently APPROVED a blatantly off-mission decision — strictly
+    // worse than the pre-fix escalate, because it replaced "ask the owner" with
+    // "act wrongly". So when relevance is lexical we do NOT act autonomously in
+    // either direction; we escalate, exactly as the gate did before content
+    // discrimination existed. Confident directional outcomes require semantic
+    // relevance. (Restoring the embedding layer re-enables discrimination.)
+    if (input.relevanceMethod === "lexical") {
+      return {
+        ...baseResult,
+        outcomeType: "escalate",
+        rationale:
+          `Your recorded stance leans ${alignment} on this decision, but relevance was scored without the semantic embedding layer (lexical fallback) — too coarse to decide this on your behalf. Escalating to your call; restore embeddings to re-enable autonomous stance-grounded verdicts.`,
+      };
+    }
+
     // Conflict is judged by RELEVANCE-WEIGHTED direction (`mixed`), not the
     // coarse content-blind `principleConflict` — otherwise a domain that merely
     // *contains* an opposing principle would escalate every decision even when


### PR DESCRIPTION
## Live verification surfaced a safety regression
After BI-7E1F128A deployed, I re-ran the two verification decisions against the live instance. The content-blindness was gone (the engine now reads stances directionally), **but** both an off-mission decision (toaster line) and an on-mission one (MSP reseller) returned `recommend APPROVE` at an identical `0.7` — the off-mission one was **wrongly, confidently approved**. The response showed why: `relevanceMethod: "lexical"`.

When the embedding layer is unavailable, `computeStanceRelevance` scores relevance by coarse lexical token-overlap. That signal is too imprecise to drive a confident directional verdict — it spuriously matched a `support` stance and approved an off-mission venture. That is **strictly worse than the pre-fix escalate**: it replaced "ask the owner" with "act wrongly."

## Fix
In the content-aware branch, when `relevanceMethod === "lexical"` the gate now **escalates in both directions** instead of emitting a confident recommend — restoring the safe pre-content-discrimination behavior whenever embeddings are down. Confident directional outcomes (approve/decline) now require **semantic** relevance; restoring the embedding layer re-enables autonomous stance-grounded verdicts. WWMD (the shared build-studio path) is unaffected — it never sets `relevanceMethod`.

## Tests
- New: same inputs, only `relevanceMethod` differing — **semantic recommends, lexical escalates** (both approve- and decline-leaning stances).
- Full `lib/decision-perspective` + `lib/decision` suite green (458 tests). Module-size OK (evaluator.ts 798 LOC). Local-CI gate passed (evidence `cmsr1dasa01sx01pdgsiqjij9`).

## Related
The underlying embedding outage (why relevance fell back to lexical on this install) is a separate infra issue — most likely the `ai/nomic-embed-text-v1.5` model not being served by the Docker Model Runner (evicted under GPU pressure). This PR makes the decision gate degrade *safely* under that condition rather than fixing the outage.

Design-Grounding-Decision: hardens the existing BI-7E1F128A evaluator; no new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Docs-Impact-Decision: internal decision-engine safety guard (lexical-fallback → escalate); no user-facing route, page, or user-guide change.
