### PR TITLE
fix(coworker): prehydrate authorized surface context

### DIFF
--- a/apps/web/lib/build/inference-failure.test.ts
+++ b/apps/web/lib/build/inference-failure.test.ts
@@ -52,7 +52,7 @@ describe("classifyInferenceFailure", () => {
     ).toBe("config");
     expect(
       classifyInferenceFailure(
-        "No AI model can handle this request right now. This usually means your cloud AI providers are disconnected or their sign-in has expired, and the built-in local model can't fit this assistant's larger requests on its own. Open Platform > AI Operations > Providers & Routing to reconnect a provider — waiting won't clear this on its own.",
+        "No AI model can handle this request right now. No eligible model met this turn's routing requirements. The cause can be provider availability, data-policy or residency limits, capability requirements, or context size — not necessarily a disconnected provider. Open Platform > AI Operations > Providers & Routing to review the active route and provider status.",
       ),
     ).toBe("config");
   });

--- a/apps/web/lib/coworker/authorized-surface-prompt-grounding.test.ts
+++ b/apps/web/lib/coworker/authorized-surface-prompt-grounding.test.ts
@@ -1,0 +1,129 @@
+import type { SemanticSurfaceGraph, SurfacePrincipalContext } from "@dpf/types";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  groundPromptWithAuthorizedSurface,
+  isAuthorizedSurfaceGuidanceRequest,
+} from "./authorized-surface-prompt-grounding";
+
+const graph: SemanticSurfaceGraph = {
+  contractVersion: "1.0",
+  surfaceId: "platform.estate-discovery",
+  revision: "rev-1",
+  generatedAt: "2026-08-12T12:00:00.000Z",
+  summary: {
+    label: "Estate Discovery",
+    purpose: "Resolve discovery evidence and configure network collectors.",
+    status: "attention-needed",
+    highlights: [
+      "SNMP is the network-discovery method on this surface; SMTP configures outbound email elsewhere.",
+      "For SNMP choose SNMP (Generic), enter Target IP or Hostname and the write-only Community String, then use Save & Test.",
+    ],
+  },
+  nodes: [
+    {
+      nodeId: "connection.method",
+      kind: "field",
+      accessibleName: "Discovery Method",
+      value: "snmp",
+      state: { labels: ["Ubiquiti UniFi", "SNMP (Generic)"] },
+      help: "SNMP discovers network devices. SMTP sends outbound email.",
+      provenance: { source: "estate-discovery.view-model", trust: "trusted-system", sensitivity: "internal" },
+    },
+    {
+      nodeId: "connection.community",
+      kind: "field",
+      accessibleName: "Community String",
+      help: "Write-only and never returned.",
+      provenance: { source: "estate-discovery.view-model", trust: "trusted-system", sensitivity: "secret" },
+    },
+  ],
+  actions: [{
+    actionId: "connection.save-and-test",
+    label: "Save & Test",
+    actionClass: "domain",
+    risk: "medium",
+    confirmation: "policy",
+  }],
+  continuations: [],
+  provenance: { source: "estate-discovery.view-model", trust: "trusted-system", sensitivity: "internal" },
+};
+
+describe("groundPromptWithAuthorizedSurface", () => {
+  it("distinguishes read-only setup guidance from a request to operate the surface", () => {
+    expect(isAuthorizedSurfaceGuidanceRequest("how should I setup this smtp discovery?")).toBe(true);
+    expect(isAuthorizedSurfaceGuidanceRequest("what does Save & Test do here?")).toBe(true);
+    expect(isAuthorizedSurfaceGuidanceRequest("enter the SNMP target and click Save & Test")).toBe(false);
+    expect(isAuthorizedSurfaceGuidanceRequest("configure and test this connection for me")).toBe(false);
+  });
+
+  it("prehydrates current authorized UX truth without exposing secret values", async () => {
+    const context: SurfacePrincipalContext = {
+      delegatingUserId: "user-1",
+      actingAgentId: "estate-specialist",
+      mode: "browser",
+      locale: "en-US",
+      timezone: "America/Chicago",
+      route: "/platform/tools/discovery",
+    };
+    const open = vi.fn(async () => ({
+      ok: true as const,
+      session: {
+        sessionId: "surface-session-1",
+        surfaceId: graph.surfaceId,
+        delegatingUserId: context.delegatingUserId,
+        actingAgentId: context.actingAgentId,
+        mode: context.mode,
+        authorityDigest: "authority-1",
+        revision: graph.revision,
+        expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+      },
+      summary: graph.summary,
+      actions: graph.actions,
+    }));
+    const snapshot = vi.fn(async () => ({ ok: true as const, graph }));
+
+    const result = await groundPromptWithAuthorizedSurface({
+      systemPrompt: "BASE PROMPT",
+      context,
+      authorizedToolNames: new Set(["surface_open", "surface_snapshot", "surface_act"]),
+    }, { open, snapshot });
+
+    expect(result.grounded).toBe(true);
+    expect(result.sessionId).toBe("surface-session-1");
+    expect(result.systemPrompt).toContain("CURRENT AUTHORIZED SURFACE — TRUSTED UX STATE");
+    expect(result.systemPrompt).toContain("SNMP is the network-discovery method");
+    expect(result.systemPrompt).toContain("Community String");
+    expect(result.systemPrompt).toContain("Save & Test");
+    expect(result.systemPrompt).toContain("surface-session-1");
+    expect(result.systemPrompt).not.toContain("authority-1");
+    expect(open).toHaveBeenCalledWith({
+      context: expect.objectContaining({ route: "/platform/tools/discovery" }),
+      selector: { route: "/platform/tools/discovery" },
+    });
+  });
+
+  it("fails open when no authorized surface matches the route", async () => {
+    const result = await groundPromptWithAuthorizedSurface({
+      systemPrompt: "BASE PROMPT",
+      context: {
+        delegatingUserId: "user-1",
+        actingAgentId: "estate-specialist",
+        mode: "browser",
+        locale: "en-US",
+        timezone: "America/Chicago",
+        route: "/uncovered",
+      },
+      authorizedToolNames: new Set(),
+    }, {
+      open: vi.fn(async () => ({
+        ok: false as const,
+        code: "surface_not_found" as const,
+        message: "none",
+      })),
+      snapshot: vi.fn(),
+    });
+
+    expect(result).toEqual({ systemPrompt: "BASE PROMPT", grounded: false });
+  });
+});

--- a/apps/web/lib/coworker/authorized-surface-prompt-grounding.ts
+++ b/apps/web/lib/coworker/authorized-surface-prompt-grounding.ts
@@ -1,0 +1,169 @@
+import type {
+  SemanticSurfaceGraph,
+  SurfaceFailure,
+  SurfacePrincipalContext,
+  SurfaceSession,
+  SurfaceSummary,
+} from "@dpf/types";
+
+import { authorizedSurfaceRuntime, createServerSurfaceContext } from "./authorized-surface-registry";
+
+type OpenResult =
+  | { ok: true; session: SurfaceSession; summary: SurfaceSummary }
+  | SurfaceFailure;
+type SnapshotResult =
+  | { ok: true; graph: SemanticSurfaceGraph }
+  | { ok: true; delta: unknown }
+  | SurfaceFailure;
+
+export type AuthorizedSurfacePromptGroundingDeps = {
+  createContext?: (
+    context: SurfacePrincipalContext,
+    authorizedToolNames: ReadonlySet<string>,
+  ) => SurfacePrincipalContext;
+  open: (input: {
+    context: SurfacePrincipalContext;
+    selector: {
+      route?: string;
+      workroomType?: string;
+      resourceType?: string;
+      taskIntent?: string;
+    };
+  }) => Promise<OpenResult>;
+  snapshot: (input: {
+    sessionId: string;
+    caller: Pick<SurfacePrincipalContext, "delegatingUserId" | "actingAgentId">;
+  }) => Promise<SnapshotResult>;
+};
+
+const defaultDeps: AuthorizedSurfacePromptGroundingDeps = {
+  createContext: (context, authorizedToolNames) =>
+    createServerSurfaceContext(context, { authorizedToolNames }),
+  open: (input) => authorizedSurfaceRuntime.open({ context: input.context, selector: input.selector }),
+  snapshot: (input) => authorizedSurfaceRuntime.snapshot(input),
+};
+
+const ACTION_REQUEST =
+  /(?:^\s*(?:please\s+)?|\b(?:can|could|will|would)\s+you\s+)(?:configure|setup|set up|enter|fill|set|select|choose|click|press|save|submit|run|execute|perform|create|update|change|delete|remove|connect|test)\b/i;
+const OPERATE_FOR_ME =
+  /\b(?:configure|setup|set up|operate|do)\b.{0,80}\bfor me\b/i;
+const GUIDANCE_REQUEST =
+  /(?:\?|\b(?:how|what|why|where|which|explain|guide|walk me through|help me understand|should i|do i need)\b)/i;
+
+/** True only for questions that can be answered from a prehydrated surface
+ * without mutating it. Imperative/action language keeps the governed tools. */
+export function isAuthorizedSurfaceGuidanceRequest(content: string): boolean {
+  const text = content.trim();
+  if (!text || !GUIDANCE_REQUEST.test(text)) return false;
+  if (ACTION_REQUEST.test(text)) return false;
+  if (OPERATE_FOR_ME.test(text)) return false;
+  return true;
+}
+
+function json(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+/**
+ * Render a compact, model-readable form of the semantic graph. The graph has
+ * already applied the principal's surface/action authorization and omits
+ * write-only, password, and secret values in the runtime projection.
+ */
+export function formatAuthorizedSurfacePrompt(
+  graph: SemanticSurfaceGraph,
+  sessionId: string,
+  maxChars = 8_000,
+): string {
+  const lines = [
+    "CURRENT AUTHORIZED SURFACE — TRUSTED UX STATE",
+    "This is the current UX contract for the human/coworker principal pair. It includes rendered and authorized non-rendered state. Answer page/workroom questions from it even when tool use is unavailable. Do not guess beyond it.",
+    `Surface: ${graph.summary.label} (${graph.surfaceId})`,
+    `Purpose: ${graph.summary.purpose}`,
+    `Status: ${graph.summary.status ?? "unspecified"}`,
+    `Revision: ${graph.revision}`,
+    `Surface session for governed actions: ${sessionId}`,
+    ...(graph.summary.highlights ?? []).map((highlight) => `Highlight: ${highlight}`),
+    ...graph.nodes.map((node) => {
+      const details = [
+        node.value !== undefined ? `value=${json(node.value)}` : "",
+        node.state ? `state=${json(node.state)}` : "",
+        node.help ? `help=${json(node.help)}` : "",
+        node.error ? `error=${json(node.error)}` : "",
+      ].filter(Boolean).join("; ");
+      return `Node ${node.nodeId} [${node.kind}] ${json(node.accessibleName)}${details ? ` — ${details}` : ""}`;
+    }),
+    ...graph.actions.map((action) =>
+      `Action ${action.actionId}: ${json(action.label)}; class=${action.actionClass}; risk=${action.risk}; confirmation=${action.confirmation}`,
+    ),
+    "For a requested state change, use surface_act with the session id and current revision. Ordinary tool grants, policy checks, confirmation, and domain validation still apply.",
+    "END CURRENT AUTHORIZED SURFACE",
+  ];
+  const block = lines.join("\n");
+  if (block.length <= maxChars) return block;
+  return `${block.slice(0, Math.max(0, maxChars - 72))}\n[Authorized surface context truncated to the bounded prompt budget.]`;
+}
+
+export async function groundPromptWithAuthorizedSurface(
+  input: {
+    systemPrompt: string;
+    context: SurfacePrincipalContext;
+    authorizedToolNames: ReadonlySet<string>;
+    maxChars?: number;
+  },
+  deps: AuthorizedSurfacePromptGroundingDeps = defaultDeps,
+): Promise<{ systemPrompt: string; grounded: boolean; sessionId?: string; surfaceId?: string }> {
+  const selector = {
+    route: input.context.route,
+    workroomType: input.context.workContext?.workroomType,
+    resourceType: input.context.workContext?.resourceType,
+    taskIntent: input.context.workContext?.taskIntent,
+  };
+  if (!Object.values(selector).some(Boolean)) return { systemPrompt: input.systemPrompt, grounded: false };
+
+  let openedSessionId: string | undefined;
+  try {
+    const context = deps.createContext
+      ? deps.createContext(input.context, input.authorizedToolNames)
+      : input.context;
+    const opened = await deps.open({ context, selector });
+    if (!opened.ok) return { systemPrompt: input.systemPrompt, grounded: false };
+    openedSessionId = opened.session.sessionId;
+    const snapshot = await deps.snapshot({
+      sessionId: opened.session.sessionId,
+      caller: {
+        delegatingUserId: input.context.delegatingUserId,
+        actingAgentId: input.context.actingAgentId,
+      },
+    });
+    if (!snapshot.ok || !("graph" in snapshot)) {
+      return { systemPrompt: input.systemPrompt, grounded: false, sessionId: openedSessionId };
+    }
+    const block = formatAuthorizedSurfacePrompt(snapshot.graph, opened.session.sessionId, input.maxChars);
+    return {
+      systemPrompt: `${input.systemPrompt}\n\n${block}`,
+      grounded: true,
+      sessionId: opened.session.sessionId,
+      surfaceId: snapshot.graph.surfaceId,
+    };
+  } catch (error) {
+    console.warn(
+      "[authorized-surface-grounding] failed open:",
+      error instanceof Error ? error.message : error,
+    );
+    return {
+      systemPrompt: input.systemPrompt,
+      grounded: false,
+      ...(openedSessionId ? { sessionId: openedSessionId } : {}),
+    };
+  }
+}
+
+/** Close the short-lived prehydration session after the model turn. Actions may
+ * use it during the agentic loop; it must not accumulate after the turn ends. */
+export async function closeAuthorizedSurfacePromptGrounding(
+  sessionId: string | undefined,
+  caller: Pick<SurfacePrincipalContext, "delegatingUserId" | "actingAgentId">,
+): Promise<void> {
+  if (!sessionId) return;
+  await authorizedSurfaceRuntime.close(sessionId, caller).catch(() => false);
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -10895,6 +10895,7 @@
         "use-this-doc-for",
         "what-discovery-does",
         "configure-a-connection-safely",
+        "work-with-the-discovery-coworker",
         "review-a-run",
         "promotion-and-follow-up",
         "what-to-watch"

--- a/apps/web/lib/routing/agent-capability-types.test.ts
+++ b/apps/web/lib/routing/agent-capability-types.test.ts
@@ -3,6 +3,7 @@ import {
   satisfiesMinimumCapabilities,
   DEFAULT_MINIMUM_CAPABILITIES,
   PASSIVE_AGENT_CAPABILITIES,
+  resolveTurnMinimumCapabilities,
 } from "./agent-capability-types";
 import type { EndpointManifest } from "./types";
 
@@ -69,5 +70,21 @@ describe("satisfiesMinimumCapabilities", () => {
       { toolUse: true, imageInput: true },
     );
     expect(result).toEqual({ satisfied: true });
+  });
+});
+
+describe("resolveTurnMinimumCapabilities", () => {
+  it("drops only tool use for prehydrated read-only guidance", () => {
+    expect(resolveTurnMinimumCapabilities(
+      { toolUse: true, imageInput: true },
+      { allowToolFreeInference: true, hasProviderTools: false, requireTools: false },
+    )).toEqual({ imageInput: true });
+  });
+
+  it("retains tool use when tools are attached or required", () => {
+    expect(resolveTurnMinimumCapabilities(
+      { toolUse: true },
+      { allowToolFreeInference: true, hasProviderTools: true, requireTools: false },
+    )).toEqual({ toolUse: true });
   });
 });

--- a/apps/web/lib/routing/agent-capability-types.ts
+++ b/apps/web/lib/routing/agent-capability-types.ts
@@ -27,6 +27,16 @@ export const PASSIVE_AGENT_CAPABILITIES: AgentMinimumCapabilities = {};
 /** System default minimum context window for RAG/L2 context injection (tokens). */
 export const DEFAULT_MINIMUM_CONTEXT_TOKENS = 16_000;
 
+/** Resolve the floor for a turn whose authorized state may already be prehydrated. */
+export function resolveTurnMinimumCapabilities(
+  configured: AgentMinimumCapabilities | null | undefined,
+  options: { allowToolFreeInference: boolean; hasProviderTools: boolean; requireTools: boolean },
+): AgentMinimumCapabilities {
+  const floor = { ...(configured ?? DEFAULT_MINIMUM_CAPABILITIES) };
+  if (options.allowToolFreeInference && !options.hasProviderTools && !options.requireTools) delete floor.toolUse;
+  return floor;
+}
+
 /**
  * Check whether an endpoint satisfies an agent's minimum capability floor.
  *

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -651,7 +651,8 @@ describe("runAgenticLoop", () => {
 
     expect(result.content).toContain("No AI model can handle this request right now");
     expect(result.content).toContain("Providers & Routing");
-    expect(result.content).toContain("waiting won't clear this");
+    expect(result.content).toContain("not necessarily a disconnected provider");
+    expect(result.content).toContain("data-policy or residency limits");
     expect(result.content).not.toContain("try again in about 30 seconds");
     expect(result.providerId).toBe("unknown");
     expect(result.modelId).toBe("unknown");
@@ -1159,7 +1160,6 @@ describe("runAgenticLoop", () => {
       }),
     );
   });
-
   it("keeps a hard local-only residency boundary in every agentic route call", async () => {
     const mockRoute = vi.mocked(routeAndCall);
     mockRoute.mockResolvedValueOnce(mockResult({

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -26,8 +26,8 @@ import { interceptToolCallAsProposal } from "@/lib/proactivity/propose-intercept
 import { agentEventBus } from "./agent-event-bus";
 import { TIER_MINIMUM_DIMENSIONS, type QualityTier } from "../routing/quality-tiers";
 import {
-  DEFAULT_MINIMUM_CAPABILITIES,
   DEFAULT_MINIMUM_CONTEXT_TOKENS,
+  resolveTurnMinimumCapabilities,
 } from "@/lib/routing/agent-capability-types";
 import { extractToolCalls } from "@/lib/routing/extract-tool-calls";
 import type { AgentMinimumCapabilities } from "@/lib/routing/agent-capability-types";
@@ -190,16 +190,13 @@ export function describeToolRouteFailure(
   // "No eligible endpoints for task type '…'" with no `toolUse` token, so the
   // branch above misses it and — before this fix — it fell through to the generic
   // "temporarily unavailable, try again in 30 seconds" below. That is a LIE for a
-  // config gap: nothing changes on retry. Tell the operator the truth and the one
-  // lever that actually clears it. Check AFTER the tool-capability branch so its
-  // more specific wording still wins for the capability-floor case.
   if (/No eligible endpoints/i.test(msg)) {
     return (
-      "No AI model can handle this request right now. This usually means your cloud " +
-      "AI providers are disconnected or their sign-in has expired, and the built-in " +
-      "local model can't fit this assistant's larger requests on its own. Open " +
-      "Platform > AI Operations > Providers & Routing to reconnect a provider — " +
-      "waiting won't clear this on its own."
+      "No AI model can handle this request right now. No eligible model met this " +
+      "turn's routing requirements. The cause can be provider availability, data-policy " +
+      "or residency limits, capability requirements, or context size — not necessarily " +
+      "a disconnected provider. Open Platform > AI Operations > Providers & Routing " +
+      "to review the active route and provider status."
     );
   }
 
@@ -1121,6 +1118,8 @@ export type RunAgenticLoopParams = {
   sensitivity: import("@/lib/agent-sensitivity").RouteSensitivity;
   tools: ToolDefinition[];
   toolsForProvider: Array<Record<string, unknown>> | undefined;
+  /** Read-only turn already grounded in authorized semantic state. */
+  allowToolFreeInference?: boolean;
   /**
    * Authorized-but-not-attached tools (EP-COWORKER-INTERACTIVITY, BI-6A745E3C).
    * The chat coworker path right-sizes the per-turn attached set and passes the
@@ -1294,12 +1293,13 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
   // DB config takes precedence over code defaults in modelRequirements.
   const agentModelConfig = await prisma.agentModelConfig.findUnique({ where: { agentId } }).catch(() => null);
 
-  // EP-AGENT-CAP-002: Read capability floor from agent config.
-  // Null DB value = use system default { toolUse: true }.
-  // {} DB value = passive agent, no floor.
+  // EP-AGENT-CAP-002: resolve the configured capability floor for this turn.
   const rawMinCaps = agentModelConfig?.minimumCapabilities as AgentMinimumCapabilities | null | undefined;
-  const baseMinimumCapabilities: AgentMinimumCapabilities =
-    rawMinCaps !== null && rawMinCaps !== undefined ? rawMinCaps : DEFAULT_MINIMUM_CAPABILITIES;
+  const baseMinimumCapabilities = resolveTurnMinimumCapabilities(rawMinCaps, {
+    allowToolFreeInference: params.allowToolFreeInference === true,
+    hasProviderTools: Boolean(toolsForProvider?.length),
+    requireTools: Boolean(requireTools),
+  });
   // When the turn carries an image (a pasted/attached screenshot becomes an
   // `image_url` content block on the user message), require a vision-capable
   // endpoint so routing never lands the image on a text-only model. Mirrors the

--- a/apps/web/lib/tak/autonomous-grounding-seam.test.ts
+++ b/apps/web/lib/tak/autonomous-grounding-seam.test.ts
@@ -27,12 +27,21 @@ vi.mock("@/lib/tak/profession-grounding", () => ({
   groundPromptWithProfessionCorpus: vi.fn(async () => ({ systemPrompt: "GROUNDED", grounded: true })),
   defaultProfessionGroundingDeps: {},
 }));
+vi.mock("@/lib/coworker/authorized-surface-prompt-grounding", () => ({
+  groundPromptWithAuthorizedSurface: vi.fn(async ({ systemPrompt }: { systemPrompt: string }) => ({
+    systemPrompt: `${systemPrompt}\n\nSURFACE GROUNDED`,
+    grounded: true,
+    sessionId: "surface-session-1",
+  })),
+  isAuthorizedSurfaceGuidanceRequest: vi.fn((content: string) => /how should i setup/i.test(content)),
+  closeAuthorizedSurfacePromptGrounding: vi.fn(async () => undefined),
+}));
 
-async function callLoop(interactionMode?: "chat" | "autonomous") {
+async function callLoop(interactionMode?: "chat" | "autonomous", content = "Do the build task.") {
   const { executeAutonomousAgenticLoop } = await import("./autonomous-work-run");
   await executeAutonomousAgenticLoop({
     systemPrompt: "BASE",
-    chatHistory: [{ role: "user", content: "Do the build task." }],
+    chatHistory: [{ role: "user", content }],
     sensitivity: "internal",
     tools: [],
     toolsForProvider: [],
@@ -51,6 +60,51 @@ describe("executeAutonomousAgenticLoop — profession-corpus grounding gate", ()
     vi.mocked(agentic.runAgenticLoop).mockResolvedValue({ content: "ok", executedTools: [] } as never);
     const grounding = await import("@/lib/tak/profession-grounding");
     vi.mocked(grounding.groundPromptWithProfessionCorpus).mockClear();
+    const surfaceGrounding = await import("@/lib/coworker/authorized-surface-prompt-grounding");
+    vi.mocked(surfaceGrounding.groundPromptWithAuthorizedSurface).mockClear();
+    vi.mocked(surfaceGrounding.closeAuthorizedSurfacePromptGrounding).mockClear();
+  });
+
+  it("prehydrates the authorized surface at the shared chat and autonomous seam", async () => {
+    await callLoop("chat");
+    await callLoop("autonomous");
+
+    const surfaceGrounding = await import("@/lib/coworker/authorized-surface-prompt-grounding");
+    const agentic = await import("@/lib/tak/agentic-loop");
+    expect(surfaceGrounding.groundPromptWithAuthorizedSurface).toHaveBeenCalledTimes(2);
+    expect(surfaceGrounding.groundPromptWithAuthorizedSurface).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        context: expect.objectContaining({
+          delegatingUserId: "user-1",
+          actingAgentId: "build-qa-engineer",
+          mode: "browser",
+          route: "build",
+        }),
+        authorizedToolNames: expect.any(Set),
+      }),
+    );
+    expect(surfaceGrounding.groundPromptWithAuthorizedSurface).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ context: expect.objectContaining({ mode: "background" }) }),
+    );
+    expect(agentic.runAgenticLoop).toHaveBeenLastCalledWith(
+      expect.objectContaining({ systemPrompt: expect.stringContaining("SURFACE GROUNDED") }),
+    );
+    expect(surfaceGrounding.closeAuthorizedSurfacePromptGrounding).toHaveBeenCalledTimes(2);
+  });
+
+  it("routes prehydrated read-only surface guidance without tool schemas or a tool-use floor", async () => {
+    await callLoop("chat", "how should I setup this smtp discovery?");
+
+    const agentic = await import("@/lib/tak/agentic-loop");
+    expect(agentic.runAgenticLoop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolsForProvider: undefined,
+        allowToolFreeInference: true,
+        systemPrompt: expect.stringContaining("SURFACE GROUNDED"),
+      }),
+    );
   });
 
   it("grounds the autonomous path and forwards the grounded prompt to the loop", async () => {
@@ -59,7 +113,7 @@ describe("executeAutonomousAgenticLoop — profession-corpus grounding gate", ()
     const agentic = await import("@/lib/tak/agentic-loop");
     expect(grounding.groundPromptWithProfessionCorpus).toHaveBeenCalledTimes(1);
     expect(agentic.runAgenticLoop).toHaveBeenCalledWith(
-      expect.objectContaining({ systemPrompt: "GROUNDED" }),
+      expect.objectContaining({ systemPrompt: expect.stringContaining("GROUNDED") }),
     );
   });
 
@@ -69,7 +123,7 @@ describe("executeAutonomousAgenticLoop — profession-corpus grounding gate", ()
     const agentic = await import("@/lib/tak/agentic-loop");
     expect(grounding.groundPromptWithProfessionCorpus).not.toHaveBeenCalled();
     expect(agentic.runAgenticLoop).toHaveBeenCalledWith(
-      expect.objectContaining({ systemPrompt: "BASE" }),
+      expect.objectContaining({ systemPrompt: expect.stringContaining("BASE") }),
     );
   });
 });

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -10,6 +10,7 @@ import type { ResolvedDelegatedPosture } from "@/lib/proactivity/delegated-postu
 import type { ProactivityPlan } from "@/lib/proactivity/proactivity-types";
 import { admitRuntimeGuardedWork } from "@/lib/platform-runtime/work-admission";
 import type { RouteSensitivity } from "@/lib/agent-sensitivity";
+import type { SurfaceMode, SurfacePrincipalContext } from "@dpf/types";
 
 /** Best-effort latest user-turn text, for the reviewer's context. */
 function lastUserRequest(history: ChatMessage[]): string {
@@ -334,6 +335,15 @@ export async function executeAutonomousAgenticLoop(input: {
    * replies. See agentic-loop.ts param doc.
    */
   interactionMode?: "chat" | "autonomous";
+  /** Optional renderer-neutral surface identity for workroom/resource/task
+   * callers. Route-only browser and background callers are derived by default. */
+  surfaceContext?: {
+    mode?: SurfaceMode;
+    locale?: string;
+    timezone?: string;
+    organizationId?: string;
+    workContext?: SurfacePrincipalContext["workContext"];
+  };
   /** BI-80532D5C — divert side-effecting non-artifact tool calls to proposals
    *  (propose boundary). Forwarded verbatim to runAgenticLoop. */
   proposeSideEffects?: boolean;
@@ -371,6 +381,40 @@ export async function executeAutonomousAgenticLoop(input: {
     systemPrompt = grounding.systemPrompt;
   }
 
+  // Authorized Surface Contract: prehydrate the current semantic UX at the one
+  // seam shared by chat, workroom, scheduled, background, and external turns.
+  // This makes page truth available even when the selected model cannot call
+  // tools. The runtime applies the same principal/action authorization first;
+  // failures and uncovered routes leave the original prompt unchanged.
+  const { groundPromptWithAuthorizedSurface } = await import(
+    "@/lib/coworker/authorized-surface-prompt-grounding"
+  );
+  const authorizedToolNames = new Set([
+    ...input.tools.map((tool) => tool.name),
+    ...(input.deferredTools ?? []).map((tool) => tool.name),
+  ]);
+  const surfaceGrounding = await groundPromptWithAuthorizedSurface({
+    systemPrompt,
+    context: {
+      delegatingUserId: input.userId,
+      actingAgentId: input.agentId,
+      mode: input.surfaceContext?.mode ?? (input.interactionMode === "chat" ? "browser" : "background"),
+      locale: input.surfaceContext?.locale ?? "en-US",
+      timezone: input.surfaceContext?.timezone ?? "UTC",
+      route: input.routeContext,
+      ...(input.surfaceContext?.organizationId ? { organizationId: input.surfaceContext.organizationId } : {}),
+      ...(input.surfaceContext?.workContext ? { workContext: input.surfaceContext.workContext } : {}),
+    },
+    authorizedToolNames,
+  }).catch(() => ({ systemPrompt, grounded: false as const }));
+  systemPrompt = surfaceGrounding.systemPrompt;
+  const { isAuthorizedSurfaceGuidanceRequest } = await import(
+    "@/lib/coworker/authorized-surface-prompt-grounding"
+  );
+  const surfaceGuidanceOnly = surfaceGrounding.grounded
+    && isAuthorizedSurfaceGuidanceRequest(lastUserRequest(input.chatHistory));
+  const toolsForProvider = surfaceGuidanceOnly ? undefined : input.toolsForProvider;
+
   // This is the single seam both interactive chat (interactionMode "chat") and
   // autonomous work (scheduled self-tasks, build phases, system tasks) flow
   // through. Tag the inference origin here so the admission gate in callProvider
@@ -378,33 +422,48 @@ export async function executeAutonomousAgenticLoop(input: {
   // interactive; everything else → autonomous (matching the "autonomous" default).
   const inferenceOrigin = input.interactionMode === "chat" ? "interactive" : "autonomous";
 
-  const result = await withInferenceOrigin(inferenceOrigin, () =>
-    runAgenticLoop({
-      systemPrompt,
-      chatHistory: input.chatHistory,
-      sensitivity: input.sensitivity,
-      tools: input.tools,
-      toolsForProvider: input.toolsForProvider,
-      deferredTools: input.deferredTools,
-      userId: input.userId,
-      routeContext: input.routeContext,
-      agentId: input.agentId,
-      threadId: input.threadId,
-      taskRunId: input.taskRunId,
-      apiTokenId: input.apiTokenId,
-      taskType: input.taskType,
-      effortWarrant: input.effortWarrant,
-      agentDisplayName: input.agentDisplayName,
-      buildPhase: input.buildPhase,
-      featureBuildId: input.featureBuildId,
-      activeSkillId: input.activeSkillId ?? null,
-      agentMessageId: input.agentMessageId ?? null,
-      interactionMode: input.interactionMode,
-      proposeSideEffects: input.proposeSideEffects ?? false,
-      ...(input.modelRequirements ? { modelRequirements: input.modelRequirements } : {}),
-      onProgress: input.onProgress,
-    }),
-  );
+  let result: Awaited<ReturnType<typeof runAgenticLoop>>;
+  try {
+    result = await withInferenceOrigin(inferenceOrigin, () =>
+      runAgenticLoop({
+        systemPrompt,
+        chatHistory: input.chatHistory,
+        sensitivity: input.sensitivity,
+        tools: input.tools,
+        toolsForProvider,
+        deferredTools: input.deferredTools,
+        userId: input.userId,
+        routeContext: input.routeContext,
+        agentId: input.agentId,
+        threadId: input.threadId,
+        taskRunId: input.taskRunId,
+        apiTokenId: input.apiTokenId,
+        taskType: input.taskType,
+        effortWarrant: input.effortWarrant,
+        agentDisplayName: input.agentDisplayName,
+        buildPhase: input.buildPhase,
+        featureBuildId: input.featureBuildId,
+        activeSkillId: input.activeSkillId ?? null,
+        agentMessageId: input.agentMessageId ?? null,
+        interactionMode: input.interactionMode,
+        proposeSideEffects: input.proposeSideEffects ?? false,
+        allowToolFreeInference: surfaceGuidanceOnly,
+        ...(input.modelRequirements ? { modelRequirements: input.modelRequirements } : {}),
+        onProgress: input.onProgress,
+      }),
+    );
+  } finally {
+    const { closeAuthorizedSurfacePromptGrounding } = await import(
+      "@/lib/coworker/authorized-surface-prompt-grounding"
+    );
+    await closeAuthorizedSurfacePromptGrounding(
+      "sessionId" in surfaceGrounding ? surfaceGrounding.sessionId : undefined,
+      {
+        delegatingUserId: input.userId,
+        actingAgentId: input.agentId,
+      },
+    );
+  }
 
   // EP-GOLDEN-TRIANGLE: leverage the rigor ladder. This is the SINGLE seam for both
   // chat and autonomous coworker turns. When the coworker's posture sits high on

--- a/docs/superpowers/specs/2026-08-08-authorized-surface-contract-design.md
+++ b/docs/superpowers/specs/2026-08-08-authorized-surface-contract-design.md
@@ -10,6 +10,8 @@
 
 **Incident:** the Discovery-page coworker guessed at SMTP setup because it neither received the rendered workflow nor possessed a governed way to inspect or operate it.
 
+**2026-08-12 implementation correction:** ASC semantic state is prehydrated at the shared coworker inference seam for browser, workroom, scheduled, background, mobile, and external modes. This is required in addition to the generic `surface_*` tools: a local or otherwise tool-incapable model must still receive the current authorized UX contract for read-only guidance. Prehydration uses the already-filtered tool authority, creates a principal-bound session, omits write-only/secret values, is bounded to 8,000 prompt characters, and fails open on uncovered surfaces. A read-only surface question sheds tool schemas and the default `toolUse` routing floor; any request to enter data or execute an action keeps governed tools and confirmation.
+
 ## 1. Executive decision
 
 DPF will establish an **Authorized Surface Contract (ASC)** as a platform primitive. It is a versioned, render-independent semantic description of what a principal can perceive and do on a product surface. Browser DOM, accessibility tree, mobile UI, workroom, background session, external agent, and future renderers are projections or consumers of this contract—not its source of truth.
@@ -325,7 +327,7 @@ Backlog ownership:
 
 The design is accepted when all of the following are demonstrable in the canonical runtime:
 
-- On Discovery, the coworker can explain SMTP setup from current semantic state, identify exact missing fields/connections, populate permitted values, test/save through governed actions, and report evidence—without asking the user to transcribe the UI.
+- On Discovery, the coworker corrects an employee's “SMTP discovery” wording to SNMP, explains setup from current semantic state, identifies exact missing fields/connections, populates permitted values, tests/saves through governed actions, and reports evidence—without asking the user to transcribe the UI.
 - The same journey succeeds headlessly with no rendered page.
 - Browser and headless graph digests match for semantic content under the same principal/fixture.
 - A different role, tenant, clearance, or AuthorityBinding sees the correct narrower graph/actions.

--- a/docs/user-guide/platform/discovery-operations.md
+++ b/docs/user-guide/platform/discovery-operations.md
@@ -58,6 +58,26 @@ Allow a self-signed UniFi certificate only for a controller on a trusted,
 closed LAN. A TLS error is not a reason to disable validation for a public or
 untrusted endpoint.
 
+## Work With The Discovery Coworker
+
+The Digital Product Estate Specialist receives the current, authorized
+Discovery surface before answering. That context includes the form's available
+methods, visible values and status, help text, and authorized actions—even when
+the selected AI model cannot inspect a browser or call tools. Password and
+write-only values, including API keys and SNMP community strings, are never
+included in that readable context.
+
+You can ask the coworker what the page means or how to complete the current
+form. For example, if you ask about “SMTP discovery,” it should correct the term
+to **SNMP**: SMTP is for outbound email, while this surface offers **SNMP
+(Generic)** for network-device discovery. For SNMP, choose that method, enter
+the **Target IP or Hostname** and the write-only **Community String**, then use
+**Save & Test**.
+
+When you ask the coworker to make a change, it acts through the same authorized
+surface contract. Your normal permissions, confirmation policy, validation,
+and audit trail still apply; page knowledge does not grant extra authority.
+
 ## Review A Run
 
 1. Check when the latest run started and whether its status and failure count


### PR DESCRIPTION
## Summary

Prehydrate every AI coworker turn with the current authorization-filtered semantic UX for its route/workroom/resource before inference. This closes the platform-wide gap where a coworker could be a named page specialist yet guess at rendered or silent surface state, and it preserves governed surface tools for authorized actions.

## Changes

- Add one shared Authorized Surface prompt-grounding seam used by browser chat, workrooms, scheduled/background work, and other autonomous execution modes.
- Snapshot current semantic nodes/actions under the delegated principal, omit write-only/secret values, bound prompt size, and close the surface session after the turn.
- Let read-only, already-grounded guidance use a text-capable local route without falsely requiring tool-use; action requests retain the normal tool capability floor.
- Correct generic inference diagnostics so an ineligible route is not misreported as a disconnected cloud provider without evidence.
- Extend the Authorized Surface Contract design with prehydration and the exact Discovery acceptance: `smtp discovery` must be corrected to SNMP and explained from current form state.

## Test plan

- [ ] **Source-only change** (types, isolated unit logic, doc, schema-only)
  - [x] TypeScript no-emit with an 8 GiB heap
  - [x] Targeted Vitest selection: 7 files / 164 tests

- [x] **Runtime-bound change** (server route, MCP tool, build/runtime wiring, compose, installer, prisma migration, UX surface)
  - [x] Source checks above passed where they can run in the worktree
  - [x] Functional verification ran against the **canonical runtime** — pick one:
        - [ ] root local install (`http://localhost:3000`)
        - [x] governed shared nonprod env (lease id: NPEL-43ECCCD2AF)
        - [ ] CI workflow run
  - [x] Evidence captured below

- [x] **Verification-harness limitation acknowledged**

### Verification evidence

- TDD: exact SMTP wording, semantic SNMP/form grounding, secret omission, shared browser/background seam, surface-session cleanup, and tool-floor policy are covered.
- Module-size, clock-bomb, design-grounding, and diff guards pass.
- `pnpm --filter web build` passes; it retains 26 pre-existing Edge Runtime warnings unrelated to this diff.
- Exact-tree merged-code pregate passed for `f9bb444b22d294c2ab01049110f2727844fa298e` with evidence `cmsr2w1l507s801pdwtyqkjdk`.
- Governed contributor preview opened the exact Discovery route on code-equivalent pre-doc-amend commit `9615dbf331fc39a3a467de8a72d1fe2644b4716f` and submitted `how should I setup this smtp discovery?`. Runtime trace proves `grounded: true`, surface `platform.estate-discovery`, guidance-only provider tools removed, and a 9,813-token peak context.
- The sanitized preview database had zero active endpoint manifests, so generation could not run there. This is recorded as skipped UX verification `asc-discovery-preview-9615dbf-20260813` (`cmsr2p52z07lz01pd0zjmvt6i`); the exact generated-answer acceptance remains required after the canonical install advances.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and again against the final diff
- [x] `pnpm run pregate:preflight` passed before requesting a shared-sandbox lease
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`
- [x] `pnpm pr:ready --pr-body-file <this-body-file>` returned `PR readiness: READY` after the final push

Local-CI-Evidence: cmsr2w1l507s801pdwtyqkjdk (fix/authorized-surface-local-fallback@f9bb444b22d294c2ab01049110f2727844fa298e)

## Related issues / Epic

- Parent: Authorized Surface Contract / `WC-3E2CF5AA`
- Covers reopened acceptance gaps `BI-008E7969` and `BI-3E872DFB`.

## Epic / Backlog linkage (for multi-BI work)

This is the implementation correction to the existing Authorized Surface Contract delivery: automatic semantic prehydration is required in addition to surface tools.

## Overlap sweep

- Open PRs #4254, #4255, and #4256 do not implement Authorized Surface prehydration.
- PR #4251 also touches `agentic-loop.ts`, but only for Anthropic prompt-cache continuity. The concerns are independent; exact-tree pregate proves this branch with current `main`, and CI/merge queue will arbitrate later overlap.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-08-08-authorized-surface-contract-design.md`
  - `docs/superpowers/plans/2026-08-08-authorized-surface-contract.md`
- Current code substrate reviewed:
  - Authorized Surface runtime and Discovery projection
  - shared autonomous coworker execution seam
  - agent routing capability-floor policy
- Source of truth: the authorization-filtered semantic surface graph, not DOM scraping or coworker-specific prompt copies.
- Decision: prehydrate current semantic UX automatically in every execution mode and retain governed tools as the only action path.

## Notes for the reviewer

- No schema migration or dependency change.
- The independent semantic reviewer returned infrastructure-inconclusive because its required response could not be parsed; exact-tree evidence `cmsr2z3wz084w01pdihxnj0wa` is recorded in shadow mode and publication is allowed. Deterministic merged-code verification passed.
- Documentation impact is handled in the canonical ASC design and the Discovery user guide; no per-coworker prompt/setup copy is introduced.

Docs-Impact-Decision: Updated the Discovery user guide for the user-visible coworker contract; the agentic-loop related Golden Triangle and long-running-process pages do not change because this is bounded pre-inference context hydration, not a deliberation pattern or process-lifecycle change.
