### PR TITLE
fix(web): make authenticated time labels hydration-safe

### DIFF
--- a/apps/web/components/inventory/SavedConnectionRow.tsx
+++ b/apps/web/components/inventory/SavedConnectionRow.tsx
@@ -17,6 +17,7 @@
 //   - Delete button with confirm step
 
 import { useState, useTransition } from "react";
+import { RelativeTime } from "@/components/ui/RelativeTime";
 import {
   deleteDiscoveryConnection,
   rerunDiscoveryConnection,
@@ -44,19 +45,6 @@ const TONE_STYLES: Record<"ok" | "warn" | "err" | "muted", { bg: string; fg: str
   err:   { bg: "var(--dpf-state-error)",   fg: "var(--dpf-error)" },
   muted: { bg: "var(--dpf-surface-2)",     fg: "var(--dpf-muted)" },
 };
-
-function formatTimestamp(iso: string | null): string {
-  if (!iso) return "never";
-  const date = new Date(iso);
-  const diffMs = Date.now() - date.getTime();
-  const diffMin = Math.floor(diffMs / 60_000);
-  if (diffMin < 1) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
-  const diffDay = Math.floor(diffHr / 24);
-  return `${diffDay}d ago`;
-}
 
 export function SavedConnectionRow({ connection }: Props) {
   const [mode, setMode] = useState<"view" | "editing" | "confirming-delete">("view");
@@ -160,7 +148,7 @@ export function SavedConnectionRow({ connection }: Props) {
             {connection.collectorType} · {connection.endpointUrl}
           </p>
           <p className="mt-1 text-[11px] text-[var(--dpf-muted)]">
-            Last tested {formatTimestamp(connection.lastTestedAt)}
+            Last tested <RelativeTime value={connection.lastTestedAt} />
             {connection.lastTestMessage && (
               <span className="ml-1">— {connection.lastTestMessage}</span>
             )}

--- a/apps/web/components/inventory/__tests__/SavedConnectionRow.test.tsx
+++ b/apps/web/components/inventory/__tests__/SavedConnectionRow.test.tsx
@@ -39,9 +39,24 @@ const BASE_CONNECTION: DiscoveryConnectionSummary = {
 afterEach(() => {
   cleanup();
   vi.resetAllMocks();
+  vi.useRealTimers();
 });
 
 describe("SavedConnectionRow Re-run button", () => {
+  it("renders last-tested evidence through a semantic time element", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-13T05:00:00.000Z"));
+
+    render(
+      <SavedConnectionRow
+        connection={{ ...BASE_CONNECTION, lastTestedAt: "2026-08-13T04:18:00.000Z" }}
+      />,
+    );
+
+    expect(screen.getByText("42m ago")).toBeInTheDocument();
+    expect(screen.getByText("42m ago").tagName).toBe("TIME");
+  });
+
   it("renders the Re-run button", () => {
     render(<SavedConnectionRow connection={BASE_CONNECTION} />);
     expect(screen.getByRole("button", { name: /re-run/i })).toBeInTheDocument();

--- a/apps/web/components/platform/ScheduledJobsTable.test.tsx
+++ b/apps/web/components/platform/ScheduledJobsTable.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock("@/lib/actions/ai-providers", () => ({
+  runScheduledJobNow: vi.fn(),
+  updateScheduledJob: vi.fn(),
+}));
+vi.mock("@/components/ui/LocalTime", () => ({
+  LocalTime: ({ value, mode }: { value: Date | null; mode: string }) => (
+    <span data-mode={mode}>{value?.toISOString() ?? "empty"}</span>
+  ),
+}));
+
+import { ScheduledJobsTable } from "./ScheduledJobsTable";
+
+describe("ScheduledJobsTable", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-13T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders job instants through the hydration-safe date surface", () => {
+    render(
+      <ScheduledJobsTable
+        canWrite={false}
+        jobs={[{
+          id: "job-row-1",
+          jobId: "provider-registry-sync",
+          name: "Provider registry sync",
+          schedule: "daily",
+          lastRunAt: new Date("2026-08-13T00:30:00.000Z"),
+          nextRunAt: new Date("2026-08-14T00:30:00.000Z"),
+          lastStatus: "ok",
+          lastError: null,
+        }]}
+      />,
+    );
+
+    expect(screen.getByText("2026-08-13T00:30:00.000Z")).toHaveAttribute("data-mode", "date");
+    expect(screen.getByText("2026-08-14T00:30:00.000Z")).toHaveAttribute("data-mode", "date");
+  });
+});

--- a/apps/web/components/platform/ScheduledJobsTable.tsx
+++ b/apps/web/components/platform/ScheduledJobsTable.tsx
@@ -4,15 +4,11 @@ import { useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { updateScheduledJob, runScheduledJobNow } from "@/lib/actions/ai-providers";
 import type { ScheduledJobRow } from "@/lib/ai-provider-types";
+import { LocalTime } from "@/components/ui/LocalTime";
 
 type Props = { jobs: ScheduledJobRow[]; canWrite: boolean };
 
 const SCHEDULES = ["daily", "weekly", "monthly", "disabled"] as const;
-
-function formatDate(d: Date | null): string {
-  if (!d) return "—";
-  return new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" });
-}
 
 export function ScheduledJobsTable({ jobs, canWrite }: Props) {
   const router = useRouter();
@@ -62,8 +58,12 @@ export function ScheduledJobsTable({ jobs, canWrite }: Props) {
                 <span style={{ color: "var(--dpf-accent)" }}>{job.schedule}</span>
               )}
             </td>
-            <td style={{ padding: "6px 8px", color: "var(--dpf-muted)" }}>{formatDate(job.lastRunAt)}</td>
-            <td style={{ padding: "6px 8px", color: "var(--dpf-muted)" }}>{formatDate(job.nextRunAt)}</td>
+            <td style={{ padding: "6px 8px", color: "var(--dpf-muted)" }}>
+              <LocalTime value={job.lastRunAt} mode="date" />
+            </td>
+            <td style={{ padding: "6px 8px", color: "var(--dpf-muted)" }}>
+              <LocalTime value={job.nextRunAt} mode="date" />
+            </td>
             <td style={{ padding: "6px 8px" }}>
               {job.lastStatus === "ok"    && <span style={{ color: "var(--dpf-success)" }}>✓ ok</span>}
               {job.lastStatus === "error" && <span style={{ color: "var(--dpf-error)" }}>✗ error</span>}

--- a/apps/web/components/ui/RelativeTime.test.tsx
+++ b/apps/web/components/ui/RelativeTime.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { renderToString } from "react-dom/server";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RelativeTime } from "./RelativeTime";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("RelativeTime", () => {
+  it("hydrates without a recoverable text mismatch when the minute changes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-13T04:59:59.000Z"));
+
+    const value = "2026-08-13T04:59:00.000Z";
+    const serverMarkup = renderToString(<RelativeTime value={value} />);
+    const container = document.createElement("div");
+    container.innerHTML = serverMarkup;
+    document.body.appendChild(container);
+
+    vi.setSystemTime(new Date("2026-08-13T05:00:01.000Z"));
+    const recoverableErrors: unknown[] = [];
+
+    render(<RelativeTime value={value} />, {
+      container,
+      hydrate: true,
+      onRecoverableError: (error) => recoverableErrors.push(error),
+    });
+
+    expect(recoverableErrors).toEqual([]);
+    expect(container).toHaveTextContent("1m ago");
+    expect(container.querySelector("time")).toHaveAttribute("aria-label", "1m ago");
+  });
+
+  it("updates an ordinary client render to a compact relative label", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-13T05:00:00.000Z"));
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    render(<RelativeTime value="2026-08-13T03:00:00.000Z" />, { container });
+
+    expect(container).toHaveTextContent("2h ago");
+  });
+});

--- a/apps/web/components/ui/RelativeTime.tsx
+++ b/apps/web/components/ui/RelativeTime.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type Props = {
+  value: string | number | Date | null | undefined;
+  className?: string;
+  fallback?: string;
+};
+
+function parseInstant(value: Props["value"]): Date | null {
+  if (value == null || value === "") return null;
+  const instant = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(instant.getTime()) ? null : instant;
+}
+
+function deterministicUtcLabel(instant: Date): string {
+  return instant.toISOString().replace("T", " ").slice(0, 16) + " UTC";
+}
+
+export function formatRelativeTime(value: string | number | Date, nowMs = Date.now()): string {
+  const instant = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(instant.getTime())) return "";
+
+  const minutes = Math.max(0, Math.floor((nowMs - instant.getTime()) / 60_000));
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/**
+ * Hydration-safe relative time for server-rendered client components.
+ *
+ * The first server and browser renders share one deterministic UTC label. Once
+ * hydration completes, the label becomes relative to the viewer's clock. This
+ * keeps compact operator copy without letting a minute boundary change the
+ * text React is reconciling.
+ */
+export function RelativeTime({ value, className, fallback = "never" }: Props) {
+  const instant = useMemo(() => parseInstant(value), [value]);
+  const iso = instant?.toISOString() ?? null;
+  const initialText = instant ? deterministicUtcLabel(instant) : fallback;
+  const [text, setText] = useState(initialText);
+
+  useEffect(() => {
+    setText(instant ? formatRelativeTime(instant) : fallback);
+  }, [fallback, instant]);
+
+  if (!instant || !iso) return <span className={className}>{fallback}</span>;
+
+  return (
+    <time
+      aria-label={text}
+      className={className}
+      dateTime={iso}
+      title={deterministicUtcLabel(instant)}
+    >
+      {text}
+    </time>
+  );
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -5653,7 +5653,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 10
+    "textMass": 12
   },
   "apps/web/components/inventory/SavedConnectionsPanel.tsx": {
     "vocabulary": 0,
@@ -7894,6 +7894,13 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 54
+  },
+  "apps/web/components/ui/RelativeTime.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
   },
   "apps/web/components/ui/Spinner.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Summary
- replace client-rendered discovery relative time with a shared hydration-safe `RelativeTime` primitive
- route scheduled-job dates through the existing hydration-safe `LocalTime` primitive
- add minute-boundary hydration and route-component regressions

## Design grounding
- Existing specs/plans reviewed: `docs/superpowers/specs/2026-03-18-ai-routing-and-profiling-design.md` and `docs/superpowers/specs/2026-04-25-discovery-taxonomy-gap-triage-design.md`
- Current code substrate reviewed: `apps/web/components/ui/LocalTime.tsx`, `apps/web/lib/datetime.ts`, `apps/web/components/platform/ScheduledJobsTable.tsx`, and `apps/web/components/inventory/SavedConnectionRow.tsx`
- Source of truth: shared time primitives own deterministic server text and post-hydration viewer formatting
- Decision: reuse `LocalTime` for absolute dates and centralize relative labels in `RelativeTime`; do not suppress React hydration diagnostics

## Verification
- 3 focused test files / 9 tests passed
- web typecheck passed
- pregate preflight 37/37 passed
- exact governed gate passed for `ec60014eced5` against remote-current main: `cmsr3fros039y01qfynfxv8gb` (9:40, 30,800 log lines, production image import passed)
- fresh high-assurance semantic review passed with zero findings

## Documentation and data
- No user documentation change: visible wording and workflows are unchanged; this corrects render determinism
- No schema or migration change

Closes BI-5B02A163 after canonical deployment and live hydration acceptance.