### PR TITLE
fix: trust grounded surface evidence

### DIFF
--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -2005,11 +2005,8 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
 
       // Evidence-integrity gate (INV-1). When this turn's answer depends on live
       // operational state and NO authoritative tool ran, the model's factual
-      // prose is unverifiable (the Scrum Master fabrication). Nudge once for a
-      // tool, then refuse rather than surface a guess. The nudge re-runs the
-      // normal iteration (no tool_choice/fallback-chain change), so recovery can
-      // never silently escalate to a paid provider (INV-4). load_tools is a
-      // meta-tool, not evidence.
+      // prose is unverifiable. Nudge once for a tool, then refuse rather than
+      // guess. Recovery cannot escalate providers (INV-4); load_tools is not evidence.
       if (evidenceRequirement.required && trimmed.length > 0) {
         const authoritativeToolExecutions = executedTools.filter(
           (t) => t.result?.success && t.name !== LOAD_TOOLS_TOOL_NAME,
@@ -2017,6 +2014,7 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
         const recovery = resolveEvidenceRecovery({
           required: true,
           authoritativeToolExecutions,
+          authoritativeSurfaceEvidence: params.allowToolFreeInference,
           content: trimmed,
           recoveryNudgesUsed: evidenceRecoveryNudges,
         });

--- a/apps/web/lib/tak/evidence-requirement.test.ts
+++ b/apps/web/lib/tak/evidence-requirement.test.ts
@@ -132,4 +132,16 @@ describe("resolveEvidenceRecovery", () => {
       resolveEvidenceRecovery({ required: false, authoritativeToolExecutions: 0, content: fabricated, recoveryNudgesUsed: 0 }).kind,
     ).toBe("pass");
   });
+
+  it("accepts prehydrated authorized-surface evidence without requiring a second tool call", () => {
+    expect(
+      resolveEvidenceRecovery({
+        required: true,
+        authoritativeToolExecutions: 0,
+        authoritativeSurfaceEvidence: true,
+        content: fabricated,
+        recoveryNudgesUsed: 0,
+      }).kind,
+    ).toBe("pass");
+  });
 });

--- a/apps/web/lib/tak/evidence-requirement.ts
+++ b/apps/web/lib/tak/evidence-requirement.ts
@@ -148,13 +148,15 @@ export type EvidenceRecoveryAction =
 export function resolveEvidenceRecovery(params: {
   required: boolean;
   authoritativeToolExecutions: number;
+  authoritativeSurfaceEvidence?: boolean;
   content: string;
   recoveryNudgesUsed: number;
   maxRecoveryNudges?: number;
 }): EvidenceRecoveryAction {
   const guard = enforceEvidenceIntegrity({
     required: params.required,
-    authoritativeToolExecutions: params.authoritativeToolExecutions,
+    authoritativeToolExecutions:
+      params.authoritativeToolExecutions + (params.authoritativeSurfaceEvidence ? 1 : 0),
     content: params.content,
   });
   if (!guard.blocked) return { kind: "pass" };

--- a/docs/superpowers/specs/2026-08-08-authorized-surface-contract-design.md
+++ b/docs/superpowers/specs/2026-08-08-authorized-surface-contract-design.md
@@ -14,6 +14,8 @@
 
 **2026-08-13 routing correction:** A prehydrated, read-only ASC guidance turn is a bounded factual lookup over authoritative surface state, even when the generic utterance classifier labels wording such as “how should I set up...” as reasoning. At the shared inference seam, that turn routes through the existing `status-query` task contract with the existing `adequate` quality floor. This permits a residency-required local model to answer from the supplied contract instead of being rejected by a coworker's static frontier reasoning floor. The relaxation is turn-scoped: action-capable, non-prehydrated, image, and other turns retain the coworker's configured task, quality floor, tools, grants, and confirmation policy.
 
+**2026-08-13 evidence correction:** Successfully prehydrated, authorization-filtered ASC state is authoritative evidence for that bounded read-only guidance turn. The generic evidence-integrity gate therefore accepts an answer grounded in the injected surface snapshot without demanding a redundant tool call. The exception is not available when prehydration failed or the request is action-capable; those turns retain normal tool evidence, authorization, confirmation, and refusal behavior.
+
 ## 1. Executive decision
 
 DPF will establish an **Authorized Surface Contract (ASC)** as a platform primitive. It is a versioned, render-independent semantic description of what a principal can perceive and do on a product surface. Browser DOM, accessibility tree, mobile UI, workroom, background session, external agent, and future renderers are projections or consumers of this contract—not its source of truth.


### PR DESCRIPTION
## Summary

- treat successfully prehydrated, authorization-filtered Authorized Surface Contract state as authoritative evidence for bounded read-only surface guidance
- preserve tool evidence, authorization, confirmation, and refusal behavior for action-capable, non-prehydrated, and operational turns
- document the evidence-boundary correction in the governing ASC design

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-08-08-authorized-surface-contract-design.md`
- Current code substrate reviewed: agentic-loop evidence recovery and the shared authorized-surface grounding seam
- Source of truth: authorization-filtered ASC prehydration at the shared inference seam
- Decision: count successful ASC prehydration as evidence only for the bounded read-only guidance tier

## Verification

- exact-tree local-CI PASS: `cmsr6cw5j00kg01qnnbpge31y`
- semantic review PASS: `cmsr6fc8l00lx01qnn8gyfl08`
- 22,985 tests passed (17 skipped, 18 todo)
- production Next.js build passed
- all migrations applied
- focused 146-test regression passed
- web typecheck passed
- 37 deterministic preflight guards passed
- module-size ratchet passed

## Documentation impact

Updated the governing ASC design with the authoritative-evidence boundary. No user-guide copy changes: this restores the existing coworker contract rather than introducing a new user workflow.

Docs-Impact-Decision: The governing ASC design was updated; no user-guide workflow or visible UI changed because this restores the existing coworker response contract.