### PR TITLE
fix(web): make inventory triage times hydration-safe

### DIFF
--- a/apps/web/components/inventory/InventoryExceptionQueue.test.tsx
+++ b/apps/web/components/inventory/InventoryExceptionQueue.test.tsx
@@ -22,6 +22,11 @@ vi.mock("@/lib/actions/inventory", () => ({
   reassignTaxonomy: vi.fn(),
   requestDiscoveryEvidence: vi.fn(),
 }));
+vi.mock("@/components/ui/LocalTime", () => ({
+  LocalTime: ({ value, mode = "datetime" }: { value: string; mode?: string }) => (
+    <span data-mode={mode}>{value}</span>
+  ),
+}));
 
 import { InventoryExceptionQueue } from "./InventoryExceptionQueue";
 
@@ -140,7 +145,7 @@ describe("InventoryExceptionQueue", () => {
     );
 
     expect(html).toContain("Triage Workbench");
-    expect(html).toContain("Employee review");
+    expect(html).toContain("Review");
     expect(html).toContain("Needs More Evidence");
     expect(html).toContain("Taxonomy Gaps");
     expect(html).toContain("Auto Attributed");
@@ -151,6 +156,9 @@ describe("InventoryExceptionQueue", () => {
     expect(html).toContain("job: mystery-engine | instance: srv-01");
     expect(html).toContain("Accept recommendation");
     expect(html).toContain("Request evidence");
+    expect(html).toContain('data-mode="datetime"');
+    expect(html).toContain("2026-04-25T13:00:00Z");
+    expect(html).toContain("2026-04-25T12:00:00Z");
   });
 
   it("uses theme-aware classes instead of hardcoded gray or white utility colors", () => {

--- a/apps/web/components/inventory/InventoryExceptionQueue.tsx
+++ b/apps/web/components/inventory/InventoryExceptionQueue.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { LocalTime } from "@/components/ui/LocalTime";
 import {
   acceptTriageRecommendation,
   dismissEntity,
@@ -66,7 +67,7 @@ type QueueSectionConfig = {
 const SECTIONS: QueueSectionConfig[] = [
   {
     key: "humanReview",
-    title: "Employee review",
+    title: "Review",
     description: "Ambiguous items with enough evidence to review, but not enough certainty to act on automatically.",
     emptyLabel: "No items are waiting on employee review.",
   },
@@ -93,18 +94,6 @@ const SECTIONS: QueueSectionConfig[] = [
 function formatPercent(value: number | null | undefined): string {
   if (typeof value !== "number") return "n/a";
   return `${Math.round(value * 100)}%`;
-}
-
-function formatDate(value: string): string {
-  const date = new Date(value);
-  return Number.isNaN(date.getTime())
-    ? value
-    : date.toLocaleString("en-US", {
-        month: "short",
-        day: "numeric",
-        hour: "numeric",
-        minute: "2-digit",
-      });
 }
 
 function getEvidenceSummary(row: TriageRow): string {
@@ -177,7 +166,7 @@ export function InventoryExceptionQueue({ queues }: Props) {
           </p>
           <div>
             <h2 className="text-lg font-semibold text-[var(--dpf-text)]">
-              Discovery taxonomy review
+              Taxonomy review
             </h2>
             <p className="mt-1 max-w-3xl text-sm text-[var(--dpf-muted)]">
               Review what discovery can place automatically, what needs more signals, and where the taxonomy itself needs to grow.
@@ -187,7 +176,7 @@ export function InventoryExceptionQueue({ queues }: Props) {
         <div className="grid min-w-[16rem] grid-cols-2 gap-2 self-stretch text-sm">
           <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2">
             <div className="text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
-              Active gaps
+              Gaps
             </div>
             <div className="mt-1 text-lg font-semibold text-[var(--dpf-text)]">
               {queues.metrics.total}
@@ -195,7 +184,7 @@ export function InventoryExceptionQueue({ queues }: Props) {
           </div>
           <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2">
             <div className="text-[10px] uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
-              With decisions
+              Decided
             </div>
             <div className="mt-1 text-lg font-semibold text-[var(--dpf-text)]">
               {queues.metrics.withDecision}
@@ -303,8 +292,8 @@ export function InventoryExceptionQueue({ queues }: Props) {
                                 {decision?.outcome?.replace(/-/g, " ") ?? "untriaged"}
                               </span>
                             </div>
-                            <div>Last seen: {formatDate(row.lastSeenAt)}</div>
-                            <div>First seen: {formatDate(row.firstSeenAt)}</div>
+                            <div>Last seen: <LocalTime value={row.lastSeenAt} /></div>
+                            <div>First seen: <LocalTime value={row.firstSeenAt} /></div>
                           </div>
 
                           <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- route Inventory triage instants through the canonical hydration-safe `LocalTime` surface
- remove the route-local `toLocaleString` formatter that diverged between container UTC and browser America/Chicago
- tighten four redundant triage labels while keeping the prose baseline flat

## Verification
- live RED: `VRF-AUTH-SHELL-HYDRATION-20260813-2` on served `86b659e6c5a0`
- focused TDD: 2/2 passed
- web typecheck passed
- pregate preflight: 37/37 guards passed
- exact local-CI: `cmsr6h3az015v01mpcg988x5b` (`gate passed`, 30,814 lines)

## Design grounding
- Existing specs/plans reviewed: `docs/superpowers/`
- Current code substrate reviewed: `apps/web/components/ui/LocalTime.tsx`, `apps/web/components/inventory/InventoryExceptionQueue.tsx`
- Source of truth: shared `LocalTime`
- Decision: remove the parallel locale formatter; no route or workflow contract changes