### PR TITLE
fix: preserve grounded response authority

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1991,8 +1991,8 @@ export async function sendMessage(input: {
       return { userMessage: serializeMessage(userMsg), agentMessage: serializeMessage(agentMsg, proposal) };
     }
 
-    // Map agentic result to the shape downstream code expects. (The Golden Triangle
-    // "review" pass now runs inside executeAutonomousAgenticLoop — the single seam
+    // Map agentic result to the downstream shape. The Golden Triangle review runs
+    // inside executeAutonomousAgenticLoop — the single seam
     // for both chat and autonomous turns — so agenticResult.content is already
     // reviewed when the coworker's posture calls for it.)
     const result = {
@@ -2007,13 +2007,11 @@ export async function sendMessage(input: {
       toolCalls: undefined as undefined, // already handled by loop
     };
 
-    // BI-C0F180E8 — honest local-degradation. If the bundled local model answered
-    // without using any tools, the coworker could not inspect live data this turn;
-    // prepend an unmissable caveat so the reply is framed as unverified instead of
-    // authoritative (it is kept, not discarded — it may still be a fine no-tool reply).
+    // Caveat a blind local answer, but not one grounded in authoritative ASC state.
     responseContent = applyLocalDegradationCaveat(result.content, {
       providerId: result.providerId,
       executedToolCount: agenticResult.executedTools.length,
+      authoritativeSurfaceEvidence: agenticResult.authoritativeSurfaceEvidence,
     });
     responseProviderId = result.providerId;
     responseModelId = result.modelId;

--- a/apps/web/lib/coworker/authorized-surface-prompt-grounding.test.ts
+++ b/apps/web/lib/coworker/authorized-surface-prompt-grounding.test.ts
@@ -95,6 +95,7 @@ describe("groundPromptWithAuthorizedSurface", () => {
     expect(result.systemPrompt).toContain("SNMP is the network-discovery method");
     expect(result.systemPrompt).toContain("Community String");
     expect(result.systemPrompt).toContain("Save & Test");
+    expect(result.systemPrompt).toContain("enumerate the exact applicable choices, fields, constraints, and submit/test action");
     expect(result.systemPrompt).toContain("surface-session-1");
     expect(result.systemPrompt).not.toContain("authority-1");
     expect(open).toHaveBeenCalledWith({

--- a/apps/web/lib/coworker/authorized-surface-prompt-grounding.ts
+++ b/apps/web/lib/coworker/authorized-surface-prompt-grounding.ts
@@ -82,6 +82,7 @@ export function formatAuthorizedSurfacePrompt(
     `Status: ${graph.summary.status ?? "unspecified"}`,
     `Revision: ${graph.revision}`,
     `Surface session for governed actions: ${sessionId}`,
+    "For configuration guidance, enumerate the exact applicable choices, fields, constraints, and submit/test action from this contract. Name write-only fields but never invent or reveal their values.",
     ...(graph.summary.highlights ?? []).map((highlight) => `Highlight: ${highlight}`),
     ...graph.nodes.map((node) => {
       const details = [

--- a/apps/web/lib/tak/autonomous-grounding-seam.test.ts
+++ b/apps/web/lib/tak/autonomous-grounding-seam.test.ts
@@ -39,7 +39,7 @@ vi.mock("@/lib/coworker/authorized-surface-prompt-grounding", () => ({
 
 async function callLoop(interactionMode?: "chat" | "autonomous", content = "Do the build task.") {
   const { executeAutonomousAgenticLoop } = await import("./autonomous-work-run");
-  await executeAutonomousAgenticLoop({
+  return executeAutonomousAgenticLoop({
     systemPrompt: "BASE",
     chatHistory: [{ role: "user", content }],
     sensitivity: "internal",
@@ -95,7 +95,7 @@ describe("executeAutonomousAgenticLoop — profession-corpus grounding gate", ()
   });
 
   it("routes prehydrated read-only surface guidance without tool schemas or a tool-use floor", async () => {
-    await callLoop("chat", "how should I setup this smtp discovery?");
+    const result = await callLoop("chat", "how should I setup this smtp discovery?");
 
     const agentic = await import("@/lib/tak/agentic-loop");
     expect(agentic.runAgenticLoop).toHaveBeenCalledWith(
@@ -105,6 +105,7 @@ describe("executeAutonomousAgenticLoop — profession-corpus grounding gate", ()
         systemPrompt: expect.stringContaining("SURFACE GROUNDED"),
       }),
     );
+    expect(result.authoritativeSurfaceEvidence).toBe(true);
   });
 
   it("grounds the autonomous path and forwards the grounded prompt to the loop", async () => {

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -556,7 +556,7 @@ export async function executeAutonomousAgenticLoop(input: {
     }
   })();
 
-  return result;
+  return { ...result, authoritativeSurfaceEvidence: surfaceGuidanceOnly };
 }
 
 export async function executeAutonomousWorkTool(input: {

--- a/apps/web/lib/tak/local-degradation-caveat.test.ts
+++ b/apps/web/lib/tak/local-degradation-caveat.test.ts
@@ -35,6 +35,24 @@ describe("local-degradation caveat (BI-C0F180E8)", () => {
     ).toBe(false);
   });
 
+  it("does NOT call a local answer unverified when the authorized surface was prehydrated", () => {
+    expect(
+      shouldCaveatLocalDegradation({
+        providerId: "local",
+        executedToolCount: 0,
+        authoritativeSurfaceEvidence: true,
+        content: substantive,
+      }),
+    ).toBe(false);
+    expect(
+      applyLocalDegradationCaveat(substantive, {
+        providerId: "local",
+        executedToolCount: 0,
+        authoritativeSurfaceEvidence: true,
+      }),
+    ).toBe(substantive);
+  });
+
   it("does NOT double-caveat an answer that already owns up to running degraded", () => {
     const honest = "This turn ran on the bundled local model, so I couldn't check live data.";
     expect(

--- a/apps/web/lib/tak/local-degradation-caveat.ts
+++ b/apps/web/lib/tak/local-degradation-caveat.ts
@@ -32,11 +32,13 @@ const ALREADY_FLAGS_DEGRADATION = /bundled local model|paid AI providers|briefly
 export function shouldCaveatLocalDegradation(opts: {
   providerId: string;
   executedToolCount: number;
+  authoritativeSurfaceEvidence?: boolean;
   content: string;
 }): boolean {
-  const { providerId, executedToolCount, content } = opts;
+  const { providerId, executedToolCount, authoritativeSurfaceEvidence, content } = opts;
   if (providerId !== LOCAL_PROVIDER_ID) return false; // a strong paid backup is trustworthy
   if (executedToolCount > 0) return false; // it actually used tools — not a blind answer
+  if (authoritativeSurfaceEvidence) return false; // current authorization-filtered UX state was injected
   if (!content.trim()) return false; // nothing to caveat
   if (ALREADY_FLAGS_DEGRADATION.test(content)) return false; // already honest
   return true;
@@ -48,7 +50,7 @@ export function shouldCaveatLocalDegradation(opts: {
  */
 export function applyLocalDegradationCaveat(
   content: string,
-  opts: { providerId: string; executedToolCount: number },
+  opts: { providerId: string; executedToolCount: number; authoritativeSurfaceEvidence?: boolean },
 ): string {
   return shouldCaveatLocalDegradation({ ...opts, content })
     ? `${LOCAL_UNVERIFIED_CAVEAT}\n\n${content}`

--- a/docs/superpowers/specs/2026-08-08-authorized-surface-contract-design.md
+++ b/docs/superpowers/specs/2026-08-08-authorized-surface-contract-design.md
@@ -16,6 +16,8 @@
 
 **2026-08-13 evidence correction:** Successfully prehydrated, authorization-filtered ASC state is authoritative evidence for that bounded read-only guidance turn. The generic evidence-integrity gate therefore accepts an answer grounded in the injected surface snapshot without demanding a redundant tool call. The exception is not available when prehydration failed or the request is action-capable; those turns retain normal tool evidence, authorization, confirmation, and refusal behavior.
 
+**2026-08-13 response correction:** Authoritative ASC prehydration also crosses the response-presentation boundary: a tool-free local answer grounded in the current surface must not receive the generic “unverified” caveat. Configuration guidance is required to enumerate the applicable choices, exact field labels (including the names—but never values—of write-only fields), constraints/help, and submit/test action from the contract. This rule is generic across surfaces and renderers; it is not page-specific prompt copy.
+
 ## 1. Executive decision
 
 DPF will establish an **Authorized Surface Contract (ASC)** as a platform primitive. It is a versioned, render-independent semantic description of what a principal can perceive and do on a product surface. Browser DOM, accessibility tree, mobile UI, workroom, background session, external agent, and future renderers are projections or consumers of this contract—not its source of truth.


### PR DESCRIPTION
## Summary

- carry successful authorization-filtered ASC prehydration through the shared coworker response boundary
- suppress the generic local-model “unverified” caveat only when current authoritative surface evidence was injected
- require configuration guidance to enumerate exact contract choices, field labels, constraints, and the submit/test action

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-08-08-authorized-surface-contract-design.md`
- Current code substrate reviewed: shared ASC prehydration seam, local degradation caveat, and coworker response assembly
- Source of truth: authorization-filtered ASC prehydration result from the shared inference seam
- Decision: propagate grounded surface authority into response presentation and make exact configuration enumeration a generic ASC response rule

## Verification

- exact-tree local-CI PASS: `cmsr94gth00ms01o1izamoxig`
- semantic review PASS: `cmsr95yju00o501o1l5meukhc`
- focused ASC/evidence tests: 24 passed
- related coworker/runtime regressions: 67 passed
- full test suite, production build, migrations, and typecheck passed in the exact-tree gate
- 37 deterministic preflight guards passed
- module-size ratchet passed

## Documentation impact

Updated the governing ASC design.

Docs-Impact-Decision: No user-guide workflow or visible UI changed; this restores authoritative coworker response presentation for the existing surface contract.