### PR TITLE
fix(upgrade): canonicalize legacy image identities

### DIFF
--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -27,17 +27,13 @@ const mocks = vi.hoisted(() => ({
   getLatestRun: vi.fn(),
   getLatestSucceededRun: vi.fn(),
   runPromoter: vi.fn(),
-  // Retained for back-compat; the precheck no longer calls it (it always rebuilds).
   isPromoterAvailable: vi.fn().mockResolvedValue(true),
-  // The precheck ALWAYS rebuilds the promoter before a swap, so the default is a
-  // successful rebuild; a test opts into failure to exercise the skip path.
   ensurePromoterImage: vi
     .fn()
     .mockResolvedValue({ ok: true, alreadyPresent: false, built: true }),
   buildCandidatePromoterImage: vi.fn().mockResolvedValue("dpf-promoter:abc1234deadbeef"),
   resolvePromoterArtifact: vi.fn(),
   runPromoterReadiness: vi.fn(),
-  // Cooldown backoff (this fix): no active cooldown by default.
   getCooldownUntil: vi.fn().mockResolvedValue(null),
   recordCooldown: vi.fn().mockResolvedValue(undefined),
   clearCooldown: vi.fn().mockResolvedValue(undefined),
@@ -49,17 +45,12 @@ const mocks = vi.hoisted(() => ({
   emitUpgradeEvent: vi.fn(),
   createSelfUpgradeRecoveryPoint: vi.fn(),
   summarizeRecoveryPointFailure: vi.fn(),
-  // BI-QUIESCE-010 — caller API consumed by runSelfUpgrade.
   startQuiescence: vi.fn(),
   signalSwapStarting: vi.fn(),
   signalSwapComplete: vi.fn(),
   failQuiescenceSwap: vi.fn(),
-  // Activity precheck snapshot (BI-F36E7510). Default empty so existing tests
-  // proceed to the drain exactly as before; the new skip-path test overrides it.
   captureActiveSessionBlockers: vi.fn().mockResolvedValue({ surfaces: [] }),
-  // 24/7 auto-window resolution (BI-A6382FB9). Default "operating-hours" so the
-  // gate behaves exactly as before (falls through to the mocked isUpgradeWindowOpen);
-  // the 24/7 tests override it.
+  // 24/7 auto-window resolution defaults to operating hours.
   resolveAutoUpgradeWindow: vi.fn().mockReturnValue({ kind: "operating-hours" }),
   // Operator blackout gate (BI-59591B14). Default null = no active blackout, so
   // every existing scheduled test proceeds exactly as before.
@@ -476,12 +467,21 @@ describe("success path", () => {
     );
   });
 
-  it("skips with up-to-date when the running build already contains the upstream SHA", async () => {
+  it("skips only when both upstream lineage and deployed identity match", async () => {
     mocks.getLatestSucceededRun.mockResolvedValue({ targetSha: "abc1234deadbeef" });
+    mocks.getDeployedSha.mockResolvedValue("abc1234deadbeef");
     const result = await runSelfUpgrade({ triggeredBy: "scheduled" });
     expect(result).toMatchObject({ skipped: true, reason: "up-to-date" });
     expect(mocks.prepareUpgradeSource).not.toHaveBeenCalled();
     expect(mocks.runPromoter).not.toHaveBeenCalled();
+    vi.clearAllMocks();
+    setupSourceReady();
+    setupQuiescenceReady();
+    mocks.getLatestSucceededRun.mockResolvedValue({ targetSha: "abc1234deadbeef" });
+    mocks.getDeployedSha.mockResolvedValue("synthetic-local-merge-sha");
+    await runSelfUpgrade({ triggeredBy: "ops" });
+    expect(mocks.prepareUpgradeSource).toHaveBeenCalled();
+    expect(mocks.runPromoter).toHaveBeenCalled();
   });
 
   it("skips BEFORE draining when activity is in flight — no drain/defer/cooldown cycle (BI-F36E7510)", async () => {

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -342,12 +342,13 @@ export async function runSelfUpgrade(
     const head = await gitRun(buildRemoteHeadCommand({ hostSourcePath, remote, branch }).slice(1));
     upstreamSha = head.code === 0 ? head.stdout.trim() : null;
     if (!upstreamSha) return await skipAttempt("no-target");
-
     const lastOk = await getLatestSucceededRun();
     if (!params.dryRun && !params.force && lastOk?.targetSha === upstreamSha) {
-      return await skipAttempt("up-to-date", `up-to-date: ${upstreamSha}`, { upstreamSha });
+      const deployedSha = await getDeployedSha();
+      if (deployedSha?.toLowerCase() === upstreamSha.toLowerCase()) {
+        return await skipAttempt("up-to-date", `up-to-date: ${upstreamSha}`, { upstreamSha });
+      }
     }
-
     // Release-batching gate — ROUTINE triggers only (the scheduled cron and
     // agent-requested runs; see SelfUpgradeRunEventData.routine). Every upgrade
     // drains the portal, so upgrading on any single new commit costs one full


### PR DESCRIPTION
## Summary

Allow a standard Windows installation carrying one legacy synthetic image identity to run the canonicalizing self-upgrade even when its last successful upstream lineage already equals the current upstream SHA.

## Changes

- require both the recorded upstream lineage and the actually served image SHA to match before returning `up-to-date`
- proceed through normal source preparation and promoter safeguards when the served identity is synthetic or otherwise differs
- cover both the true up-to-date skip and legacy-identity repair paths in the orchestrator regression test

## Test plan

- [x] Focused Vitest suite passed: 3 files, 106 tests
- [x] Module-size, substrate-complexity, style, and token-drift guards passed
- [x] Production web build passed
- [x] `pnpm run pregate:preflight` passed all 37 guards
- [x] `pnpm run pregate` passed the exact merged tree in the governed shared local-CI environment
- [x] No UI path, schema, or migration changed; UX and migration gates are not applicable

### Verification evidence

- exact commit: `9179d01ac136cda3af1ccf50ccde3e2992d6effd`
- exact-tree local-CI: lease `NPEL-5B90D46A6D`, evidence `cmsrlppwj0i3s01o1oksda4jx`
- semantic gate: stale-receipt shadow observation; the MCP server loaded `review_semantic_change`, but the current Codex host did not refresh it into the callable registry. This is disclosed and is non-blocking under the active shadow policy.

## Pre-PR readiness

- [x] Branch contains one concern and one DCO-signed commit
- [x] Open-PR and recent-main overlap sweep found no competing upgrade-provenance fix
- [x] Exact-tree local-CI receipt is fresh

Local-CI-Evidence: cmsrlppwj0i3s01o1oksda4jx (fix/windows-image-provenance-canonicalization@9179d01ac136cda3af1ccf50ccde3e2992d6effd)

## Related issues / Epic

- Backlog: BI-C6C92EE4
- Epic: EP-DELIVERY-FLOW
- Unblocks physical federation acceptance for BI-05EB708F

## Notes for the reviewer

This does not bypass quiescence, source preparation, or promoter verification. It only tightens the early skip predicate so canonical repair remains reachable through the normal governed upgrade path.
