### PR TITLE
fix(federation): null-safe origin-marker exclusion so null-body items still project (BI-8A7E3E56)

### DIFF
--- a/apps/web/lib/federation/demand-reconciliation.test.ts
+++ b/apps/web/lib/federation/demand-reconciliation.test.ts
@@ -148,10 +148,40 @@ describe("runDemandReconciliation", () => {
 
     expect(db.backlogItem.findMany).toHaveBeenCalledWith(expect.objectContaining({
       where: expect.objectContaining({
-        NOT: { body: { contains: "[origin:federatedDemand:" } },
+        // Origin-marked items are excluded — but NULL-SAFE, so a null-body item
+        // (no marker) is KEPT rather than silently dropped (BI-8A7E3E56).
+        OR: [
+          { body: null },
+          { NOT: { body: { contains: "[origin:federatedDemand:" } } },
+        ],
       }),
     }));
     expect(queueProjection).not.toHaveBeenCalled();
+  });
+
+  it("keeps NULL-body items eligible — a bare NOT-contains would drop them (BI-8A7E3E56)", async () => {
+    const db = {
+      federationLink: { findMany: vi.fn().mockResolvedValue(links) },
+      backlogItem: { findMany: vi.fn().mockResolvedValue([]) },
+      federatedRecordMirror: { findMany: vi.fn().mockResolvedValue([]) },
+    } as unknown as DemandReconciliationDb;
+
+    await runDemandReconciliation(db, {
+      resolveIdentity: vi.fn().mockResolvedValue({ installationId: `inst_${"a".repeat(32)}`, projectionSecret: "b".repeat(64) }),
+      queueProjection: vi.fn(),
+      queueWithdrawal: vi.fn(),
+      reconcileDigests: vi.fn().mockResolvedValue({ linksChecked: 0, requeued: 0, confirmed: 0, failedLinks: 0 }),
+      dispatch: vi.fn().mockResolvedValue({ attempted: 0, delivered: 0, deferred: 0, deadLettered: 0 }),
+    });
+
+    const where = (db.backlogItem.findMany as unknown as { mock: { calls: Array<[{ where: Record<string, unknown> }]> } }).mock.calls[0][0].where;
+    // The origin-marker exclusion must be null-safe (an OR with `{ body: null }`),
+    // never a top-level `NOT: { body: { contains } }` that SQL drops NULL bodies from.
+    expect(where.OR).toEqual([
+      { body: null },
+      { NOT: { body: { contains: "[origin:federatedDemand:" } } },
+    ]);
+    expect(where).not.toHaveProperty("NOT");
   });
 
   it("queues withdrawal when a previously projected item is no longer policy-eligible", async () => {

--- a/apps/web/lib/federation/demand-reconciliation.ts
+++ b/apps/web/lib/federation/demand-reconciliation.ts
@@ -108,7 +108,15 @@ export async function runDemandReconciliation(
         // Open work only. A closed item is excluded here, drops out of
         // eligibleIds below, and is withdrawn from the peer. See BI-8A8C1D3A.
         status: { in: [...FEDERATION_SYNCABLE_BACKLOG_STATUSES] },
-        NOT: { body: { contains: "[origin:federatedDemand:" } },
+        // Exclude items RECEIVED from federation (they carry the origin marker in
+        // their body). NULL-SAFE: a NULL body has no marker, so it must be KEPT —
+        // a bare `NOT: { body: { contains } }` drops NULL-body rows via SQL
+        // three-valued logic (`NULL NOT LIKE …` = NULL = excluded), silently
+        // stranding every eligible item with no body. See BI-8A7E3E56.
+        OR: [
+          { body: null },
+          { NOT: { body: { contains: "[origin:federatedDemand:" } } },
+        ],
       },
       select: {
         itemId: true, title: true, body: true, workType: true, occurrenceCount: true,


### PR DESCRIPTION
**The last ~12 stragglers, named and root-caused:** they all have a **NULL body**. The projection excluded received-from-federation items via `NOT: { body: { contains: "[origin:…" } }` — but SQL `NULL NOT LIKE '%marker%'` = NULL (not TRUE), so Prisma silently **drops every null-body row**. A null body has no marker and must project.

**Proven live:** `body NOT LIKE …` → 278; null-safe `body IS NULL OR body NOT LIKE …` → 289. The 11-item gap = exactly the null-body items (Subscription billing, Draft-quote UI, Lead convert flow…).

**Fix:** `OR: [{ body: null }, { NOT: { body: { contains } } }]` — keep null bodies, exclude only genuine (always non-null) origin-marked items. A query-correctness bug, not delivery/policy. TDD asserts the where-clause is null-safe. After deploy, the ~11 project next cycle → Mac→Windows at 100% of eligible. BI-8A7E3E56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)