### PR TITLE
feat(work-room): Coordinator as a first-class participant role (EP-WORKROOM-COMMS)

### DIFF
--- a/apps/web/lib/work-management/room-coordinator.test.ts
+++ b/apps/web/lib/work-management/room-coordinator.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveRoomCoordinator,
+  selectRoomCoordinator,
+  WorkRoomParticipantError,
+} from "./room-coordinator";
+import type { WorkRoomParticipantRole, WorkRoomParticipantView } from "./room-types";
+
+function participant(
+  principalRef: string,
+  roles: WorkRoomParticipantRole[],
+  kind: WorkRoomParticipantView["kind"] = "person",
+): WorkRoomParticipantView {
+  return {
+    principalRef,
+    displayName: principalRef,
+    kind,
+    roles,
+    workState: "unknown",
+    presence: "unknown",
+    currentWorkSummary: null,
+    enteredReason: null,
+    sponsorPrincipalRef: null,
+    authoritySummary: "",
+    sourceRefs: [],
+  };
+}
+
+describe("selectRoomCoordinator", () => {
+  it("returns null when no coordinator is named", () => {
+    expect(selectRoomCoordinator([participant("user:1", ["accountable"])])).toBeNull();
+  });
+
+  it("returns the single coordinator", () => {
+    const coord = participant("agent:9", ["coordinator"], "agent");
+    expect(selectRoomCoordinator([participant("user:1", ["accountable"]), coord])).toBe(coord);
+  });
+
+  it("throws on more than one active coordinator", () => {
+    const two = [participant("user:1", ["coordinator"]), participant("agent:9", ["coordinator"], "agent")];
+    expect(() => selectRoomCoordinator(two)).toThrow(WorkRoomParticipantError);
+    try {
+      selectRoomCoordinator(two);
+    } catch (error) {
+      expect((error as WorkRoomParticipantError).reason).toBe("multiple_active_coordinators");
+    }
+  });
+});
+
+describe("deriveRoomCoordinator", () => {
+  it("defaults the sole accountable principal to coordinator", () => {
+    const out = deriveRoomCoordinator([
+      participant("user:1", ["accountable"]),
+      participant("agent:9", ["contributor"], "agent"),
+    ]);
+    expect(out.find((p) => p.principalRef === "user:1")?.roles).toEqual(["accountable", "coordinator"]);
+    expect(out.find((p) => p.principalRef === "agent:9")?.roles).toEqual(["contributor"]);
+    expect(selectRoomCoordinator(out)?.principalRef).toBe("user:1");
+  });
+
+  it("keeps an explicitly named coordinator (may differ from accountable)", () => {
+    const out = deriveRoomCoordinator([
+      participant("user:1", ["accountable"]),
+      participant("agent:9", ["coordinator"], "agent"),
+    ]);
+    // Accountable is NOT promoted when a coordinator is already named.
+    expect(out.find((p) => p.principalRef === "user:1")?.roles).toEqual(["accountable"]);
+    expect(selectRoomCoordinator(out)?.principalRef).toBe("agent:9");
+  });
+
+  it("does not invent a coordinator when accountability is ambiguous", () => {
+    const out = deriveRoomCoordinator([
+      participant("user:1", ["accountable"]),
+      participant("user:2", ["accountable"]),
+    ]);
+    expect(selectRoomCoordinator(out)).toBeNull();
+  });
+
+  it("leaves a room with no accountable and no coordinator unchanged", () => {
+    const out = deriveRoomCoordinator([participant("agent:9", ["contributor"], "agent")]);
+    expect(selectRoomCoordinator(out)).toBeNull();
+    expect(out[0].roles).toEqual(["contributor"]);
+  });
+
+  it("does not duplicate the role when accountable already coordinates", () => {
+    const out = deriveRoomCoordinator([participant("user:1", ["accountable", "coordinator"])]);
+    expect(out[0].roles).toEqual(["accountable", "coordinator"]);
+  });
+});

--- a/apps/web/lib/work-management/room-coordinator.ts
+++ b/apps/web/lib/work-management/room-coordinator.ts
@@ -1,0 +1,81 @@
+/**
+ * Work Room Coordinator — the first-class role that keeps a room on-task to its
+ * outcome (admit/curate members, sequence turns, drive to verdict/close/escalate).
+ *
+ * EP-WORKROOM-COMMS (BI-5A7BC4B3). Distinct from `accountable` (who owns the
+ * outcome): a room has exactly one active Coordinator, which may be the same
+ * principal as the accountable or a different one (e.g. an accountable human who
+ * delegates coordination to a facilitator coworker). Maps to DACI "Driver".
+ *
+ * Pure module: no DB, no imports beyond the participant view type.
+ *
+ * Design of record: docs/superpowers/specs/2026-08-12-work-room-multi-agent-communication-substrate-design.md §2
+ */
+import type { WorkRoomParticipantView } from "./room-types";
+
+export type WorkRoomParticipantErrorReason = "multiple_active_coordinators";
+
+export class WorkRoomParticipantError extends Error {
+  constructor(readonly reason: WorkRoomParticipantErrorReason, message: string) {
+    super(message);
+    this.name = "WorkRoomParticipantError";
+  }
+}
+
+function isCoordinator(participant: WorkRoomParticipantView): boolean {
+  return participant.roles.includes("coordinator");
+}
+
+function isAccountable(participant: WorkRoomParticipantView): boolean {
+  return participant.roles.includes("accountable");
+}
+
+/**
+ * Resolve the single active Coordinator, or null if the room has none yet.
+ * Mirrors the single-active-cycle invariant: a room may name at most one
+ * Coordinator; more than one is a defect, not a merge.
+ */
+export function selectRoomCoordinator(
+  participants: readonly WorkRoomParticipantView[],
+): WorkRoomParticipantView | null {
+  const coordinators = participants.filter(isCoordinator);
+  if (coordinators.length > 1) {
+    throw new WorkRoomParticipantError(
+      "multiple_active_coordinators",
+      "A Work Room can have only one active Coordinator.",
+    );
+  }
+  return coordinators[0] ?? null;
+}
+
+/**
+ * Ensure the room has a Coordinator. If one is already named (by policy or
+ * lineage) it is kept; otherwise the accountable principal coordinates by
+ * default — the Coordinator role is added to the (single) accountable
+ * participant, keeping the role distinct while defaulting sensibly. A room with
+ * no accountable and no named coordinator is left as-is (nothing to derive).
+ *
+ * Pure: returns a new array; participant objects are copied only when changed.
+ */
+export function deriveRoomCoordinator(
+  participants: readonly WorkRoomParticipantView[],
+): WorkRoomParticipantView[] {
+  // Validates single-coordinator and short-circuits when one is already named.
+  if (selectRoomCoordinator(participants)) {
+    return [...participants];
+  }
+
+  const accountable = participants.filter(isAccountable);
+  // Only default when there is exactly one accountable to promote; ambiguous or
+  // absent accountability leaves the room without a derived coordinator.
+  if (accountable.length !== 1) {
+    return [...participants];
+  }
+
+  const target = accountable[0];
+  return participants.map((participant) =>
+    participant.principalRef === target.principalRef
+      ? { ...participant, roles: [...new Set([...participant.roles, "coordinator" as const])] }
+      : participant,
+  );
+}

--- a/apps/web/lib/work-management/room-participation.ts
+++ b/apps/web/lib/work-management/room-participation.ts
@@ -1,4 +1,5 @@
 import type { ActiveViewer } from "./work-item-presence";
+import { deriveRoomCoordinator } from "./room-coordinator";
 import type {
   WorkRoomParticipantRole,
   WorkRoomParticipantView,
@@ -145,5 +146,7 @@ export function projectWorkRoomParticipants(input: {
     });
   }
 
-  return [...projected.values()];
+  // EP-WORKROOM-COMMS (BI-5A7BC4B3): ensure the room has a single Coordinator —
+  // kept if named by policy/lineage, otherwise the accountable principal by default.
+  return deriveRoomCoordinator([...projected.values()]);
 }

--- a/apps/web/lib/work-management/room-types.ts
+++ b/apps/web/lib/work-management/room-types.ts
@@ -32,6 +32,7 @@ export type WorkRoomActivityKind =
 
 export type WorkRoomParticipantRole =
   | "accountable"
+  | "coordinator"
   | "contributor"
   | "reviewer"
   | "observer";

--- a/apps/web/lib/work-management/workspace-room-access.ts
+++ b/apps/web/lib/work-management/workspace-room-access.ts
@@ -10,7 +10,7 @@ export type WorkspaceRoomPolicyMetadata = {
 
 export type WorkspaceRoomPolicyParticipant = {
   principalRef: string;
-  roles: Array<"accountable" | "contributor" | "reviewer" | "observer">;
+  roles: Array<"accountable" | "coordinator" | "contributor" | "reviewer" | "observer">;
   enteredReason: string | null;
   currentWorkSummary: string | null;
 };
@@ -35,7 +35,7 @@ export function readWorkspaceRoomPolicy(evidence: unknown): Partial<WorkspaceRoo
             ? participant.principalRef.trim()
             : "";
           if (!principalRef) return [];
-          const validRoles = ["accountable", "contributor", "reviewer", "observer"];
+          const validRoles = ["accountable", "coordinator", "contributor", "reviewer", "observer"];
           const roles = Array.isArray(participant.roles)
             ? participant.roles.filter(
                 (role): role is WorkspaceRoomPolicyParticipant["roles"][number] =>

--- a/docs/user-guide/workspace/work-rooms.md
+++ b/docs/user-guide/workspace/work-rooms.md
@@ -40,7 +40,8 @@ The **Activity** stream distinguishes messages, asks, coworker handoffs, work ch
 People and AI coworkers appear together as named participants. Their room role and current work state are separate:
 
 - **Accountable** owns the room outcome.
-- **Contributor** performs or coordinates work.
+- **Coordinator** keeps the room on-task to its outcome—curating who is in the room, sequencing turns, and driving to a decision, close, or escalation. A room has exactly one Coordinator; it may be the same person or coworker as the Accountable, or a different one. When no one is named, the Accountable coordinates by default.
+- **Contributor** performs work in the room.
 - **Reviewer** verifies work or an outcome.
 - **Observer** follows the room without changing it.
 


### PR DESCRIPTION
First slice of EP-WORKROOM-COMMS (the room-as-multi-agent-communication-substrate). Implements the **Coordinator** role from the merged design (#4247).

## What

- **`room-types.ts`** — `coordinator` added to `WorkRoomParticipantRole`.
- **`room-coordinator.ts`** (pure) — `selectRoomCoordinator` (single-active guard; throws `multiple_active_coordinators` on >1, mirroring the single-active-cycle invariant) + `deriveRoomCoordinator` (keep a named Coordinator; else the sole Accountable coordinates by default). Wired into `projectWorkRoomParticipants` so every room resolves a Coordinator.
- **`workspace-room-access.ts`** — a room policy may declare a Coordinator participant (role union + `validRoles` widened so it is retained, not dropped to `observer`).
- **Surfaces automatically** — the participants rail's generic role label renders "Coordinator"; no read-model or UI change needed.
- **`docs/user-guide/workspace/work-rooms.md`** — documents the Coordinator role.

The Coordinator keeps a room on-task to its outcome, and is deliberately **distinct from Accountable** (who owns the outcome) — the two may be the same principal or different, per the design.

## Design grounding

Implements `docs/superpowers/specs/2026-08-12-work-room-multi-agent-communication-substrate-design.md` §2 (merged #4247). Kernel-ratified `DI-1C65C5205848` (coordinator = first-class role). No new contract beyond that spec.

## Verification

Local-CI merge gate **passed** (merged against main; full typecheck + suite + build; evidence `cmss3xoqv00sw01qebna4ayj4`). Locally: 230 tests across `lib/work-management` + `components/workspace` (incl. the new `room-coordinator` suite); typecheck clean; module-size / docs-impact / seed-fit / data-impact gates pass.

## Follow-ups (same BI, deliberately scoped out)

Governed admit/turn/close action verbs for the Coordinator, and a boundary `coordinatorPrincipalRef` field. The rest of EP-WORKROOM-COMMS Phase 1 (agent membership rights, `post_room_message` + subscribe/presence, CLI-joins-room) remains filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)