### PR TITLE
fix: enforce grounded surface coverage

### DIFF
--- a/apps/web/lib/coworker/authorized-surface-prompt-grounding.test.ts
+++ b/apps/web/lib/coworker/authorized-surface-prompt-grounding.test.ts
@@ -2,6 +2,7 @@ import type { SemanticSurfaceGraph, SurfacePrincipalContext } from "@dpf/types";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  enforceAuthorizedSurfaceGuidanceCoverage,
   groundPromptWithAuthorizedSurface,
   isAuthorizedSurfaceGuidanceRequest,
 } from "./authorized-surface-prompt-grounding";
@@ -50,6 +51,25 @@ const graph: SemanticSurfaceGraph = {
 };
 
 describe("groundPromptWithAuthorizedSurface", () => {
+  it("appends exact authorized highlights when a model paraphrases away required UX labels", () => {
+    const response = enforceAuthorizedSurfaceGuidanceCoverage(
+      "Choose SNMP and enter the device IP and required credentials, then save and test it.",
+      graph.summary.highlights ?? [],
+    );
+
+    expect(response).toContain("AUTHORIZED SURFACE DETAILS");
+    expect(response).toContain(
+      "For SNMP choose SNMP (Generic), enter Target IP or Hostname and the write-only Community String, then use Save & Test.",
+    );
+  });
+
+  it("does not duplicate an exact authorized highlight already present in the answer", () => {
+    const exact = graph.summary.highlights?.[1] ?? "";
+    const response = enforceAuthorizedSurfaceGuidanceCoverage(exact, [exact]);
+
+    expect(response).toBe(exact);
+  });
+
   it("distinguishes read-only setup guidance from a request to operate the surface", () => {
     expect(isAuthorizedSurfaceGuidanceRequest("how should I setup this smtp discovery?")).toBe(true);
     expect(isAuthorizedSurfaceGuidanceRequest("what does Save & Test do here?")).toBe(true);
@@ -91,6 +111,7 @@ describe("groundPromptWithAuthorizedSurface", () => {
 
     expect(result.grounded).toBe(true);
     expect(result.sessionId).toBe("surface-session-1");
+    expect(result.guidanceHighlights).toEqual(graph.summary.highlights);
     expect(result.systemPrompt).toContain("CURRENT AUTHORIZED SURFACE — TRUSTED UX STATE");
     expect(result.systemPrompt).toContain("SNMP is the network-discovery method");
     expect(result.systemPrompt).toContain("Community String");

--- a/apps/web/lib/coworker/authorized-surface-prompt-grounding.ts
+++ b/apps/web/lib/coworker/authorized-surface-prompt-grounding.ts
@@ -60,6 +60,32 @@ export function isAuthorizedSurfaceGuidanceRequest(content: string): boolean {
   return true;
 }
 
+/**
+ * Preserve exact, authorization-filtered UX facts at the response boundary.
+ * Models may summarize prompt context and silently drop field/action labels;
+ * those labels are part of the user-facing surface contract, not optional
+ * prose. Missing highlights are appended verbatim after generation so every
+ * renderer and coworker path gets the same deterministic coverage without a
+ * page-specific response patch.
+ */
+export function enforceAuthorizedSurfaceGuidanceCoverage(
+  content: string,
+  guidanceHighlights: readonly string[],
+): string {
+  const exactHighlights = [...new Set(
+    guidanceHighlights.map((highlight) => highlight.trim()).filter(Boolean),
+  )];
+  const missing = exactHighlights.filter((highlight) => !content.includes(highlight));
+  if (missing.length === 0) return content;
+
+  const base = content.trimEnd();
+  const details = [
+    "AUTHORIZED SURFACE DETAILS",
+    ...missing.map((highlight) => `- ${highlight}`),
+  ].join("\n");
+  return base ? `${base}\n\n${details}` : details;
+}
+
 function json(value: unknown): string {
   return JSON.stringify(value);
 }
@@ -112,7 +138,13 @@ export async function groundPromptWithAuthorizedSurface(
     maxChars?: number;
   },
   deps: AuthorizedSurfacePromptGroundingDeps = defaultDeps,
-): Promise<{ systemPrompt: string; grounded: boolean; sessionId?: string; surfaceId?: string }> {
+): Promise<{
+  systemPrompt: string;
+  grounded: boolean;
+  sessionId?: string;
+  surfaceId?: string;
+  guidanceHighlights?: string[];
+}> {
   const selector = {
     route: input.context.route,
     workroomType: input.context.workContext?.workroomType,
@@ -145,6 +177,7 @@ export async function groundPromptWithAuthorizedSurface(
       grounded: true,
       sessionId: opened.session.sessionId,
       surfaceId: snapshot.graph.surfaceId,
+      guidanceHighlights: [...(snapshot.graph.summary.highlights ?? [])],
     };
   } catch (error) {
     console.warn(

--- a/apps/web/lib/tak/autonomous-grounding-seam.test.ts
+++ b/apps/web/lib/tak/autonomous-grounding-seam.test.ts
@@ -32,7 +32,15 @@ vi.mock("@/lib/coworker/authorized-surface-prompt-grounding", () => ({
     systemPrompt: `${systemPrompt}\n\nSURFACE GROUNDED`,
     grounded: true,
     sessionId: "surface-session-1",
+    guidanceHighlights: [
+      "For SNMP choose SNMP (Generic), enter Target IP or Hostname and the write-only Community String, then use Save & Test.",
+    ],
   })),
+  enforceAuthorizedSurfaceGuidanceCoverage: vi.fn((content: string, highlights: string[]) =>
+    highlights.every((highlight) => content.includes(highlight))
+      ? content
+      : `${content}\n\nAUTHORIZED SURFACE DETAILS\n${highlights.map((highlight) => `- ${highlight}`).join("\n")}`,
+  ),
   isAuthorizedSurfaceGuidanceRequest: vi.fn((content: string) => /how should i setup/i.test(content)),
   closeAuthorizedSurfacePromptGrounding: vi.fn(async () => undefined),
 }));
@@ -106,6 +114,10 @@ describe("executeAutonomousAgenticLoop — profession-corpus grounding gate", ()
       }),
     );
     expect(result.authoritativeSurfaceEvidence).toBe(true);
+    expect(result.content).toContain("SNMP (Generic)");
+    expect(result.content).toContain("Target IP or Hostname");
+    expect(result.content).toContain("Community String");
+    expect(result.content).toContain("Save & Test");
   });
 
   it("grounds the autonomous path and forwards the grounded prompt to the loop", async () => {

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -413,6 +413,9 @@ export async function executeAutonomousAgenticLoop(input: {
   );
   const surfaceGuidanceOnly = surfaceGrounding.grounded
     && isAuthorizedSurfaceGuidanceRequest(lastUserRequest(input.chatHistory));
+  const authorizedGuidanceHighlights = "guidanceHighlights" in surfaceGrounding
+    ? surfaceGrounding.guidanceHighlights ?? []
+    : [];
   const toolsForProvider = surfaceGuidanceOnly ? undefined : input.toolsForProvider;
 
   // This is the single seam both interactive chat (interactionMode "chat") and
@@ -488,6 +491,20 @@ export async function executeAutonomousAgenticLoop(input: {
     } catch (err) {
       console.warn("[golden-triangle] coworker deliberation (unified seam) failed (fail-open):", err);
     }
+  }
+
+  // Prompt instructions are advisory; exact UX labels are contractual. A
+  // model can answer correctly in substance while paraphrasing away a field
+  // or composite action. Enforce the authorization-filtered surface summary
+  // after any deliberation pass so the final response cannot lose those facts.
+  if (surfaceGuidanceOnly && result.content) {
+    const { enforceAuthorizedSurfaceGuidanceCoverage } = await import(
+      "@/lib/coworker/authorized-surface-prompt-grounding"
+    );
+    result.content = enforceAuthorizedSurfaceGuidanceCoverage(
+      result.content,
+      authorizedGuidanceHighlights,
+    );
   }
 
   // Governed Hermes learning Slice 2: fire-and-forget reflection trigger.

--- a/docs/superpowers/specs/2026-08-08-authorized-surface-contract-design.md
+++ b/docs/superpowers/specs/2026-08-08-authorized-surface-contract-design.md
@@ -18,6 +18,8 @@
 
 **2026-08-13 response correction:** Authoritative ASC prehydration also crosses the response-presentation boundary: a tool-free local answer grounded in the current surface must not receive the generic “unverified” caveat. Configuration guidance is required to enumerate the applicable choices, exact field labels (including the names—but never values—of write-only fields), constraints/help, and submit/test action from the contract. This rule is generic across surfaces and renderers; it is not page-specific prompt copy.
 
+**2026-08-13 deterministic coverage correction:** Prompt instructions alone do not satisfy the response contract: live acceptance showed a grounded model could still paraphrase `Target IP or Hostname` as “device IP” and omit the write-only `Community String`. For read-only ASC guidance, the shared inference seam now carries the authorization-filtered `SurfaceSummary.highlights` through generation and any deliberation pass, then appends any missing highlight verbatim. This is a generic response-boundary invariant for every surface and renderer; it neither exposes secret values nor adds page-specific coworker logic.
+
 ## 1. Executive decision
 
 DPF will establish an **Authorized Surface Contract (ASC)** as a platform primitive. It is a versioned, render-independent semantic description of what a principal can perceive and do on a product surface. Browser DOM, accessibility tree, mobile UI, workroom, background session, external agent, and future renderers are projections or consumers of this contract—not its source of truth.


### PR DESCRIPTION
## Summary

- preserve exact authorization-filtered surface highlights through the shared coworker inference seam
- append only missing UX contract details after generation and deliberation, without exposing write-only values
- enforce the invariant generically across browser, workroom, scheduled, background, mobile, and external surface consumers

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-08-08-authorized-surface-contract-design.md`
- Current code substrate reviewed: authorized surface prompt grounding and the shared autonomous/chat inference seam
- Source of truth: authorization-filtered `SurfaceSummary.highlights` produced by the Authorized Surface Contract runtime
- Decision: enforce exact-label coverage at the shared response boundary; do not add page-specific coworker prompts or response templates

Docs-Impact-Decision: the ASC design spec was updated as the owning contract; the mapped long-running-process architecture remains accurate because lifecycle behavior did not change

## Verification

- 32 affected Vitest tests passed
- production web build passed with zero errors
- exhaustive exact-tree local merged-code CI passed against current `main`
- independent semantic review passed with no blocking findings

## Tracking

- WC-3E2CF5AA
- BI-008E7969
- BI-3E872DFB
