### PR TITLE
fix(platform): harden backlog reliability controls

### DIFF
--- a/apps/web/app/api/a2a/tasks/[taskId]/route.test.ts
+++ b/apps/web/app/api/a2a/tasks/[taskId]/route.test.ts
@@ -2,16 +2,30 @@ import { describe, expect, it, vi } from "vitest";
 
 import { GET } from "./route";
 
-const { mockReadCoworkerA2aTask } = vi.hoisted(() => ({
+const { mockAuth, mockReadCoworkerA2aTask } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
   mockReadCoworkerA2aTask: vi.fn(),
 }));
 
+vi.mock("@/lib/auth", () => ({ auth: mockAuth }));
 vi.mock("@/lib/coworker-service-catalog/a2a-tasks", () => ({
   readCoworkerA2aTask: mockReadCoworkerA2aTask,
 }));
 
 describe("A2A coworker task route", () => {
+  it("rejects an unauthenticated task read before revealing whether it exists", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const response = await GET(new Request("http://test/api/a2a/tasks/CE-A2A"), {
+      params: Promise.resolve({ taskId: "CE-A2A" }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(mockReadCoworkerA2aTask).not.toHaveBeenCalled();
+  });
+
   it("returns a task lifecycle projection", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } });
     mockReadCoworkerA2aTask.mockResolvedValue({
       id: "CE-A2A",
       contextId: "ctx-1",
@@ -37,6 +51,7 @@ describe("A2A coworker task route", () => {
   });
 
   it("returns 404 for missing tasks", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } });
     mockReadCoworkerA2aTask.mockResolvedValue(null);
 
     const response = await GET(new Request("http://test/api/a2a/tasks/missing"), {

--- a/apps/web/app/api/a2a/tasks/[taskId]/route.ts
+++ b/apps/web/app/api/a2a/tasks/[taskId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { auth } from "@/lib/auth";
 import { apiErrorResponse } from "@/lib/api/error";
 import { readCoworkerA2aTask } from "@/lib/coworker-service-catalog/a2a-tasks";
 
@@ -12,6 +13,8 @@ type RouteContext = {
 };
 
 export async function GET(_request: Request, context: RouteContext): Promise<Response> {
+  const session = await auth();
+  if (!session?.user) return apiErrorResponse("UNAUTHORIZED", "Unauthorized", 401);
   const { taskId } = await context.params;
   const task = await readCoworkerA2aTask(taskId);
   if (!task) return apiErrorResponse("NOT_FOUND", "Task not found", 404);

--- a/apps/web/lib/backlog/duplicate-resolution.test.ts
+++ b/apps/web/lib/backlog/duplicate-resolution.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveDuplicateBacklogRowId } from "./duplicate-resolution";
+
+describe("resolveDuplicateBacklogRowId", () => {
+  it("maps a semantic BI id to the internal FK id", async () => {
+    const findUnique = vi.fn().mockResolvedValue({ id: "canonical-row-1" });
+
+    await expect(resolveDuplicateBacklogRowId({ backlogItem: { findUnique } }, "BI-CANON")).resolves.toBe(
+      "canonical-row-1",
+    );
+    expect(findUnique).toHaveBeenCalledWith({ where: { itemId: "BI-CANON" }, select: { id: true } });
+  });
+
+  it("returns null when the semantic target does not exist", async () => {
+    const findUnique = vi.fn().mockResolvedValue(null);
+    await expect(resolveDuplicateBacklogRowId({ backlogItem: { findUnique } }, "BI-MISSING")).resolves.toBeNull();
+  });
+});

--- a/apps/web/lib/backlog/duplicate-resolution.ts
+++ b/apps/web/lib/backlog/duplicate-resolution.ts
@@ -1,0 +1,11 @@
+type BacklogLookup = {
+  backlogItem: {
+    findUnique(args: { where: { itemId: string }; select: { id: true } }): Promise<{ id: string } | null>;
+  };
+};
+
+/** Resolve the public BI-* contract to the internal FK stored by duplicateOfId. */
+export async function resolveDuplicateBacklogRowId(db: BacklogLookup, itemId: string): Promise<string | null> {
+  const row = await db.backlogItem.findUnique({ where: { itemId }, select: { id: true } });
+  return row?.id ?? null;
+}

--- a/apps/web/lib/mcp/packs/backlog-pack.test.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack.test.ts
@@ -151,6 +151,23 @@ describe("backlog pack — handler behavior (delegation preserved)", () => {
     expect(db.backlogItemUpdate).not.toHaveBeenCalled();
   });
 
+  it("triage_backlog_item resolves a semantic duplicate target before writing the FK", async () => {
+    db.backlogItemFindUnique
+      .mockResolvedValueOnce({ id: "duplicate-row", itemId: "BI-DUP", status: "triaging" })
+      .mockResolvedValueOnce({ id: "canonical-row" });
+    db.backlogItemUpdate.mockResolvedValue({ itemId: "BI-DUP" });
+
+    const res = await backlogPack.handlers.triage_backlog_item(
+      { itemId: "BI-DUP", outcome: "duplicate", duplicateOfId: "BI-CANON", rationale: "Same work." },
+      "u1",
+    );
+
+    expect(res.success).toBe(true);
+    expect(db.backlogItemUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ duplicateOfId: "canonical-row" }),
+    }));
+  });
+
   it("size_backlog_item errors when the item is not found", async () => {
     db.backlogItemFindUnique.mockResolvedValue(null);
     const res = await backlogPack.handlers.size_backlog_item(

--- a/apps/web/lib/mcp/packs/backlog-pack.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack.ts
@@ -19,11 +19,7 @@
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { handleUpdateBacklogItem } from "@/lib/mcp-handlers/update-backlog-item";
 import { updateBuildHappyPathState } from "@/lib/mcp/build-tool-helpers";
-import {
-  optionalStringParam,
-  stringArrayParam,
-  validScopeKind,
-} from "./backlog-scope-metadata";
+import { optionalStringParam, stringArrayParam, validScopeKind } from "./backlog-scope-metadata";
 import { getBacklogItem, listBacklogItems, listEpics, queryBacklog } from "./backlog-pack-read-tools";
 import type { BacklogIngestInput } from "@/lib/operate/backlog-ingest";
 import type { ToolResult } from "@/lib/mcp-tools";
@@ -31,6 +27,7 @@ import type { ToolPack, ToolPackHandler } from "../tool-pack";
 import { tryAcquireBacklogClaimAtomic } from "@/lib/backlog/claim-on-start";
 import { normalizeCompletionEvidenceManifest } from "@/lib/backlog/completion-evidence-policy";
 import { backlogPackDefinitions as definitions } from "./backlog-pack-definitions";
+import { resolveDuplicateBacklogRowId } from "@/lib/backlog/duplicate-resolution";
 // ── Handlers (case bodies moved verbatim) ───────────────────────────────────
 
 async function createBacklogItem(
@@ -172,10 +169,13 @@ async function triageBacklogItem(params: Record<string, unknown>): Promise<ToolR
     return { success: false, error: "reason is required for defer/discard outcomes", message: "reason is required for defer/discard outcomes" };
   }
 
-  const nextStatus =
-    outcome === "build" || outcome === "runbook" || outcome === "coworker-task"
-      ? "open"
-      : "deferred";
+  const duplicateRef = typeof params["duplicateOfId"] === "string" ? params["duplicateOfId"] : "";
+  const duplicateRowId = outcome === "duplicate" ? await resolveDuplicateBacklogRowId(prisma, duplicateRef) : null;
+  if (outcome === "duplicate" && !duplicateRowId) {
+    return { success: false, error: "duplicate_not_found", message: `Canonical item ${duplicateRef} not found` };
+  }
+
+  const nextStatus = outcome === "build" || outcome === "runbook" || outcome === "coworker-task" ? "open" : "deferred";
 
   await prisma.backlogItem.update({
     where: { itemId },
@@ -183,7 +183,7 @@ async function triageBacklogItem(params: Record<string, unknown>): Promise<ToolR
       status: nextStatus,
       triageOutcome: outcome,
       effortSize: typeof params["effortSize"] === "string" ? params["effortSize"] : null,
-      duplicateOfId: typeof params["duplicateOfId"] === "string" ? params["duplicateOfId"] : null,
+      duplicateOfId: duplicateRowId,
       resolution: rationale,
       abandonReason: typeof params["reason"] === "string" ? params["reason"] : null,
     },
@@ -237,15 +237,14 @@ async function retireBacklogItem(
 
     let canonicalRowId: string | null = null;
     if (outcome === "duplicate") {
-      const canonical = await tx.backlogItem.findUnique({ where: { itemId: duplicateOfId } });
-      if (!canonical) {
+      canonicalRowId = await resolveDuplicateBacklogRowId(tx, duplicateOfId);
+      if (!canonicalRowId) {
         return {
           success: false,
           error: "duplicate_not_found",
           message: `Canonical item ${duplicateOfId} not found`,
         } satisfies ToolResult;
       }
-      canonicalRowId = canonical.id;
     }
 
     const updated = await tx.backlogItem.update({

--- a/apps/web/lib/mcp/packs/coworker-goal-pack.ts
+++ b/apps/web/lib/mcp/packs/coworker-goal-pack.ts
@@ -147,6 +147,5 @@ export const coworkerGoalPack: ToolPack = {
     list_task_goals: (params, userId, context) => listTaskGoalsHandler(params, userId, context),
     evaluate_task_goal: (params, userId, context) => evaluateTaskGoalHandler(params, userId, context),
   },
-  // Ungated (self-scoped): no agent-grant gating, mirroring coworker-memory.
-  grants: {},
+  grants: { set_task_goal: [], list_task_goals: [], evaluate_task_goal: [] },
 };

--- a/apps/web/lib/mcp/packs/coworker-memory-pack.test.ts
+++ b/apps/web/lib/mcp/packs/coworker-memory-pack.test.ts
@@ -27,7 +27,7 @@ describe("coworkerMemoryPack shape", () => {
       "list_working_notes",
       "record_working_note",
     ]);
-    expect(coworkerMemoryPack.grants).toEqual({});
+    expect(coworkerMemoryPack.grants).toEqual({ record_working_note: [], list_working_notes: [] });
     expect(Object.keys(coworkerMemoryPack.handlers).sort()).toEqual([
       "list_working_notes",
       "record_working_note",

--- a/apps/web/lib/mcp/packs/coworker-memory-pack.ts
+++ b/apps/web/lib/mcp/packs/coworker-memory-pack.ts
@@ -123,6 +123,5 @@ export const coworkerMemoryPack: ToolPack = {
     record_working_note: (params, userId, context) => recordWorkingNoteHandler(params, userId, context),
     list_working_notes: (params, userId, context) => listWorkingNotesHandler(params, userId, context),
   },
-  // Ungated (self-scoped): no agent-grant gating, mirroring propose_improvement.
-  grants: {},
+  grants: { record_working_note: [], list_working_notes: [] },
 };

--- a/apps/web/lib/mcp/packs/effort-context-pack.test.ts
+++ b/apps/web/lib/mcp/packs/effort-context-pack.test.ts
@@ -23,7 +23,7 @@ describe("effortContextPack shape", () => {
       "read_effort_context",
       "record_effort_context",
     ]);
-    expect(effortContextPack.grants).toEqual({});
+    expect(effortContextPack.grants).toEqual({ record_effort_context: [], read_effort_context: [] });
     for (const def of effortContextPack.definitions) {
       expect(effortContextPack.handlers[def.name], def.name).toBeTypeOf("function");
     }

--- a/apps/web/lib/mcp/packs/effort-context-pack.ts
+++ b/apps/web/lib/mcp/packs/effort-context-pack.ts
@@ -140,5 +140,5 @@ export const effortContextPack: ToolPack = {
     record_effort_context: (params, userId, context) => recordEffortContextHandler(params, userId, context),
     read_effort_context: (params, userId, context) => readEffortContextHandler(params, userId, context),
   },
-  grants: {},
+  grants: { record_effort_context: [], read_effort_context: [] },
 };

--- a/apps/web/lib/mcp/tool-registry.test.ts
+++ b/apps/web/lib/mcp/tool-registry.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import { DELIBERATION_TOOLS } from "@/lib/mcp-tools-deliberation";
 import { SIEM_TOOLS } from "@/lib/mcp-tools-siem";
 import { PLATFORM_TOOLS } from "@/lib/mcp-tools";
-import { TOOL_TO_GRANTS } from "@/lib/tak/agent-grants";
+import { isToolAllowedByGrants, TOOL_TO_GRANTS } from "@/lib/tak/agent-grants";
 
 import { TOOL_PACK_REGISTRY } from "./pack-registry";
 
@@ -266,8 +266,7 @@ describe("coworker memory pack", () => {
   });
 
   it("mirrors the agent-grant gating source exactly (R3 no-drift)", () => {
-    // Ungated (self-scoped) — grants is empty, so nothing to drift against.
-    expect(coworkerMemoryPack.grants).toEqual({});
+    expect(coworkerMemoryPack.grants).toEqual({ record_working_note: [], list_working_notes: [] });
     for (const [name, grants] of Object.entries(coworkerMemoryPack.grants)) {
       expect(TOOL_TO_GRANTS[name], name).toEqual(grants);
     }
@@ -413,23 +412,10 @@ describe("executeTool inline-case ratchet", () => {
 // This sweep is registry-driven rather than hand-listed, so it covers packs
 // that do not exist yet.
 describe("tool-pack grant coverage (registry-wide)", () => {
-  // Shrinking baseline — BI-F998BCE8. These seven are the same defect, but
-  // their packs declare `grants: {}` with an "Ungated (self-scoped)" intent
-  // the gating layer cannot currently express (there is no "no grant needed"
-  // value, only listed-or-denied). Resolving that is a deliberate call on the
-  // gating contract, not a drive-by; until then they are quarantined here so a
-  // NEW ungated tool still fails loudly.
-  //
-  // This list may only shrink. Closing BI-F998BCE8 means emptying it and
-  // deleting the allowance below.
+  // Two host-surface telemetry tools remain outside coworker identity scope.
+  // Self-scoped coworker tools must carry an explicit [] mapping: present and
+  // intentionally universal, rather than absent and denied by default.
   const KNOWN_UNGATED_BI_F998BCE8 = [
-    "coworker-goal:evaluate_task_goal",
-    "coworker-goal:list_task_goals",
-    "coworker-goal:set_task_goal",
-    "coworker-memory:list_working_notes",
-    "coworker-memory:record_working_note",
-    "effort-context:read_effort_context",
-    "effort-context:record_effort_context",
     // BI-D6DFC0E7: benign self-report telemetry — a surface reporting its OWN
     // toolchain readiness (and reading the fleet roll-up) cannot exceed its
     // authority or affect anyone else, mirroring propose_improvement.
@@ -468,5 +454,10 @@ describe("tool-pack grant coverage (registry-wide)", () => {
       }
     }
     expect(drifted, `pack grant metadata drifted from TOOL_TO_GRANTS: ${drifted.join(", ")}`).toEqual([]);
+  });
+
+  it("allows explicitly self-scoped tools while unknown tools remain denied", () => {
+    expect(isToolAllowedByGrants("record_working_note", ["registry_read"])).toBe(true);
+    expect(isToolAllowedByGrants("unknown_self_scoped_tool", ["registry_read"])).toBe(false);
   });
 });

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -81,6 +81,18 @@ export interface ScheduledJobCatalogEntry {
 // Ordered roughly by operational prominence. core-locked jobs first.
 export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   {
+    jobId: "index-integrity-sweep",
+    inngestId: "ops/index-integrity-sweep",
+    name: "Live database index integrity sweep",
+    purpose:
+      "Checks the persistent install database for btree-to-heap disagreement and blocking collation drift, then raises one deduplicated platform issue before ghost records reach users.",
+    cron: "30 5 * * *",
+    cadence: "Daily at 05:30",
+    category: "core",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
     jobId: "build-pr-delivery-reconcile",
     inngestId: "build/pr-delivery-reconcile",
     name: "Build Studio PR delivery reconcile",

--- a/apps/web/lib/queue/functions/index-integrity-sweep.test.ts
+++ b/apps/web/lib/queue/functions/index-integrity-sweep.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runIndexIntegritySweep } from "./index-integrity-sweep";
+
+function deps(overrides: Record<string, unknown> = {}) {
+  return {
+    connect: vi.fn(),
+    end: vi.fn(),
+    checkCollationStability: vi.fn().mockResolvedValue({ findings: [] }),
+    checkIndexIntegrity: vi.fn().mockResolvedValue({ indexesChecked: 12, corrupted: [], failed: false }),
+    createPlatformIssueReport: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("runIndexIntegritySweep", () => {
+  it("checks the live client and stays quiet when indexes are healthy", async () => {
+    const d = deps();
+    await expect(runIndexIntegritySweep(d as never)).resolves.toMatchObject({ failed: false, indexesChecked: 12 });
+    expect(d.checkIndexIntegrity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ amcheckMode: "provision" }));
+    expect(d.createPlatformIssueReport).not.toHaveBeenCalled();
+    expect(d.end).toHaveBeenCalled();
+  });
+
+  it("raises one deduplicated platform issue for corruption", async () => {
+    const d = deps({
+      checkIndexIntegrity: vi.fn().mockResolvedValue({
+        indexesChecked: 12,
+        failed: true,
+        corrupted: [{ table: "Agent", index: "Agent_agentId_key", isUnique: true, error: "heap tuple missing" }],
+      }),
+    });
+
+    await expect(runIndexIntegritySweep(d as never)).resolves.toMatchObject({ failed: true, issueRaised: true });
+    expect(d.createPlatformIssueReport).toHaveBeenCalledWith(expect.objectContaining({
+      type: "index-integrity-drift",
+      dedupeKey: "index-integrity-sweep:live-database",
+      severity: "critical",
+    }));
+  });
+});

--- a/apps/web/lib/queue/functions/index-integrity-sweep.ts
+++ b/apps/web/lib/queue/functions/index-integrity-sweep.ts
@@ -1,0 +1,86 @@
+import pg from "pg";
+import { cron } from "inngest";
+
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+import type { CreatePlatformIssueReportInput } from "@/lib/quality/platform-issue-reports";
+import {
+  checkCollationStability,
+  checkIndexIntegrity,
+} from "../../../../../packages/db/scripts/index-integrity-core.mjs";
+
+type SweepDeps = {
+  client?: { query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }> };
+  connect: () => Promise<void>;
+  end: () => Promise<void>;
+  checkCollationStability: typeof checkCollationStability;
+  checkIndexIntegrity: typeof checkIndexIntegrity;
+  createPlatformIssueReport: (input: CreatePlatformIssueReportInput) => Promise<unknown>;
+};
+
+async function liveDeps(): Promise<SweepDeps> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) throw new Error("DATABASE_URL is not set");
+  const client = new pg.Client({ connectionString });
+  const { createPlatformIssueReport } = await import("@/lib/quality/platform-issue-reports");
+  return {
+    client,
+    connect: async () => { await client.connect(); },
+    end: () => client.end(),
+    checkCollationStability,
+    checkIndexIntegrity,
+    createPlatformIssueReport,
+  };
+}
+
+export async function runIndexIntegritySweep(injected?: SweepDeps) {
+  const deps = injected ?? await liveDeps();
+  const client = deps.client ?? deps;
+  await deps.connect();
+  try {
+    const collation = await deps.checkCollationStability(client);
+    const integrity = await deps.checkIndexIntegrity(client, {
+      amcheckMode: "provision",
+      schema: "public",
+      uniqueOnly: false,
+    });
+    const blocking = collation.findings.filter((finding: { severity: string }) => finding.severity === "error");
+    const failed = integrity.corrupted.length > 0 || blocking.length > 0;
+    if (failed) {
+      await deps.createPlatformIssueReport({
+        type: "index-integrity-drift",
+        source: "index-integrity-sweep",
+        severity: "critical",
+        title: "Live database index integrity drift detected",
+        description: JSON.stringify({ corrupted: integrity.corrupted, collationFindings: blocking }),
+        routeContext: "/ops",
+        triggerKind: "scheduled-integrity-sweep",
+        dedupeKey: "index-integrity-sweep:live-database",
+        selfFixClass: "needs-human",
+      });
+    }
+    return {
+      failed,
+      issueRaised: failed,
+      indexesChecked: integrity.indexesChecked,
+      corrupted: integrity.corrupted.length,
+      blockingCollationFindings: blocking.length,
+    };
+  } finally {
+    await deps.end();
+  }
+}
+
+export const indexIntegritySweep = inngest.createFunction(
+  {
+    id: "ops/index-integrity-sweep",
+    retries: 1,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron("30 5 * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+    return step.run("check-live-index-integrity", () => runIndexIntegritySweep());
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -107,6 +107,7 @@ import {
   dataControlOperationRecoveryRequested,
   dataControlOperationRecoveryScheduled,
 } from "./data-control-operation";
+import { indexIntegritySweep } from "./index-integrity-sweep";
 
 export const scheduledFunctions = [
   prometheusPoll,
@@ -168,6 +169,7 @@ export const scheduledFunctions = [
   demandReconciliationScheduled, // BI-44AA45BF: trusted-link demand projection, retry, and reconciliation every five minutes
   buildPrDeliveryReconcile, // BI-7C4FDBF5: exact-SHA Build Studio PR readiness, queue enrollment, and restart recovery
   dataControlOperationRecoveryScheduled, // BI-DG-014: durable cross-store data mutation recovery and reconciliation
+  indexIntegritySweep, // BI-D9C20A97: daily live-database btree/collation integrity sweep
   postmarkCallbackDispatchSweep,
 ];
 

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -97,17 +97,15 @@ export const COWORKER_READ_BASELINE_GRANTS: readonly string[] = [
   "code_graph_read",
   "work_capsule_read",
 ];
-/**
- * Maps platform tool names to agent grant categories.
- * A tool is allowed if the agent has ANY of the grants it maps to —
- * directly OR via GRANT_IMPLICATIONS expansion (see expandGrants).
- * Tools not in this map are DENIED by default — every tool must have an entry.
- *
- * Exported so the MCP-authority SysML reconcile (apps/web/lib/ea/reconcile-mcp-authority.ts)
- * can project this authority surface into the EA graph at runtime without parsing
- * source. The coworker-tool-grant audit still regex-parses the source form.
- */
+/** Maps tools to grants. [] means identity-scoped universal access; absence means deny. */
 export const TOOL_TO_GRANTS: Record<string, string[]> = {
+  record_working_note: [],
+  list_working_notes: [],
+  record_effort_context: [],
+  read_effort_context: [],
+  set_task_goal: [],
+  list_task_goals: [],
+  evaluate_task_goal: [],
   // Browser-driving (namespaced MCP, server slug `mcp-browser-use`) —
   // EP-BROWSER-DRIVE, spec 2026-06-05 §8.2 (Verdict 5). These are the
   // platform-visible `<serverId>__<toolName>` names (see mcp-server-tools.ts
@@ -843,6 +841,7 @@ export function isToolAllowedByGrants(
     console.warn(`[agent-grants] Tool ${JSON.stringify(toolName)} has no TOOL_TO_GRANTS entry — denied by default`);
     return false;
   }
+  if (requiredGrants.length === 0) return true;
   // Expand the agent's grants through GRANT_IMPLICATIONS, then check that the
   // expanded set includes at least one of the required grants.
   const expanded = expandGrants(agentGrants);

--- a/docs/superpowers/plans/2026-08-13-backlog-reliability-batch-6.md
+++ b/docs/superpowers/plans/2026-08-13-backlog-reliability-batch-6.md
@@ -1,0 +1,47 @@
+# Backlog Reliability Batch 6 Implementation Plan
+
+**Goal:** Complete ten architecturally related platform reliability and security backlog items in one governed batch: six source fixes and four evidence-backed reconciliations of work already delivered on `main`.
+
+**Work Capsule:** `WC-437EEE15`
+
+**Branch:** `fix/backlog-reliability-batch-6`
+
+## Design grounding
+
+- Existing specs/plans reviewed: `docs/superpowers/plans/2026-08-13-backlog-reliability-batch-6.md` plus the live backlog and plan-coverage receipt for all ten selected items.
+- Current code substrate reviewed: `apps/web/lib/mcp/packs/backlog-pack.ts`, `apps/web/lib/tak/agent-grants.ts`, the established Inngest queue/catalog, A2A sibling routes, and the existing index-integrity core.
+- Source of truth: the live PostgreSQL backlog for lifecycle, the canonical grant registry for tool authority, the established queue catalog for schedules, and existing shared helpers for duplicate resolution and issue reporting.
+- Decision: extend those existing contracts in place and add no parallel identity, scheduling, authorization, or evidence store.
+- The live PostgreSQL backlog remains the status authority; the four reconciliation items close only after their merged source and current regression tests are re-verified.
+- Existing coordination-plane, queue, authentication, and grant-registry substrates are extended in place. This batch adds no parallel identity, scheduling, authorization, or evidence store.
+- The six code changes are independently testable but form one reliability concern: prevent platform-control paths from silently exposing data, killing concurrent work, corrupting references, hiding intended tools, or failing to detect/verify integrity drift.
+- No user-facing UI is added. Documentation impact is this execution plan plus source-local contract comments where needed.
+
+## Deliverables
+
+1. **BI-D9C20A97 — live index-integrity sweep.** Wrap the existing exact-key guard in the established Inngest scheduled-function substrate, register it in the scheduled-jobs catalog and function export list, and route failures to the existing platform quality/attention sink. Add unit tests for success and drift/failure behavior.
+2. **BI-DBAD1A1B — session-reaper boundary safety.** Replace raw worktree substring matching with a boundary-aware matcher that admits the worktree itself and true descendants but rejects sibling prefixes. Add shell-level regression coverage for root clone, sibling worktree, and shared local-CI paths.
+3. **BI-F998BCE8 — self-scoped coworker grants.** Represent the seven intentionally self-scoped tools explicitly in the single grant registry, preserving deny-by-default for genuinely unknown tools. Extend the registry-wide coverage tests.
+4. **BI-DC6BE37C — large semantic diff handling.** Give binary `git diff` a bounded 256 MiB buffer and surface spawn/ENOBUFS failures distinctly from nonzero git exits. Unit-test a payload over Node's historical 1 MiB default without creating a giant repository fixture.
+5. **BI-C1FCFAA3 — semantic duplicate resolution.** Resolve a triage duplicate target from `BI-*` to the canonical internal row id before writing the foreign key, matching the already-correct retirement path. Add success and missing-target tests without growing the baselined modules.
+6. **BI-07BD42FC — authenticated A2A task reads.** Reuse the sibling A2A offer-route authentication/authorization boundary and reject anonymous task reads. Audit sibling A2A routes and add route tests for anonymous and authorized requests.
+7. **BI-F8808EDA — time-bomb detector false-positive contract.** Re-run the merged detector/shim tests and confirm the documentation now names subprocess clock skew instead of promising a judgment-free result.
+8. **BI-32426CA0 — endpoint auto-retire guard.** Re-run the merged endpoint-retirement regression tests and verify the current source preserves the last eligible data-class endpoint.
+9. **BI-46544737 — quarantine visibility.** Re-run the merged quarantine-filter tests and inspect the live installation's workforce projection before marking done.
+10. **BI-108602C0 — legacy install-state migration.** Re-run the merged v1 `antigravityWired` migration regression and schema validation before marking done.
+
+BI-321FA58B was considered and rejected from this batch: the page is present in the live database, but focused `wiki_query` calls cannot retrieve it, so its stated acceptance contract is not complete.
+
+## TDD and verification sequence
+
+1. Add focused failing tests for each of the six source changes and capture Red output.
+2. Implement the smallest substrate-aligned change for each failure, then run focused Green tests.
+3. Run all graph-linked and colocated tests found by repository search for the affected source paths; the MCP related-test helper was unavailable after dynamic loading, so verification is intentionally expanded.
+4. Run the impact-contract guards: prose lint tests/check and style-drift check.
+5. Run `pnpm run pregate:preflight`, the affected package unit suites, and `pnpm --filter web build`.
+6. Run the governed exact-tree local merge gate before publication, obtain independent semantic review for the stable commit, push, open a ready PR, and verify `pnpm pr:health` before merge-queue enrollment.
+7. After merge and canonical deployment, attach typed evidence and close only BIs whose complete acceptance criteria are demonstrated. Items with partial or superseded acceptance remain open with the evidence recorded.
+
+## Rollback
+
+The six changes are source-local and migration-free. Revert the squash commit if any control path regresses; no data rollback is required.

--- a/scripts/hooks/lib/session-reaper-path.sh
+++ b/scripts/hooks/lib/session-reaper-path.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Return success only when a process command line names the exact worktree or a
+# true descendant. A raw substring check lets `/dpf` capture `/dpf-worktrees`.
+dpf_process_line_matches_worktree() {
+  _dpf_line=$1
+  _dpf_worktree=$2
+  case "$_dpf_line" in
+    *"$_dpf_worktree"|*"$_dpf_worktree/"*|*"$_dpf_worktree "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}

--- a/scripts/hooks/session-reaper.sh
+++ b/scripts/hooks/session-reaper.sh
@@ -36,6 +36,7 @@ if [ -n "$HOOK_EVENT" ] && [ "$HOOK_EVENT" != "SessionEnd" ]; then exit 0; fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+. "$SCRIPT_DIR/lib/session-reaper-path.sh"
 WORKTREE_PATH="${CWD:-$INSTALL_ROOT}"
 # Trim trailing slash for substring matching.
 WORKTREE_PATH="${WORKTREE_PATH%/}"
@@ -75,8 +76,10 @@ if command -v ps >/dev/null 2>&1; then
   # one of the sidecar binaries. Self-PID is excluded.
   SELF_PID=$$
   PIDS="$(ps -ww -eo pid=,args= 2>/dev/null \
-    | grep -F -- "$WORKTREE_PATH" \
     | grep -E '(^| )([^ ]*/)?(node|node_repl|npx)( |$)' \
+    | while IFS= read -r _line; do
+        dpf_process_line_matches_worktree "$_line" "$WORKTREE_PATH" && printf '%s\n' "$_line"
+      done \
     | awk '{print $1}')"
   for _pid in $PIDS; do
     [ "$_pid" = "$SELF_PID" ] && continue

--- a/scripts/hooks/session-reaper.test.mjs
+++ b/scripts/hooks/session-reaper.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const matcher = join(here, "lib", "session-reaper-path.sh");
+
+function matches(line, worktree = "/Users/example/dpf") {
+  const script = `. "$1"; dpf_process_line_matches_worktree "$2" "$3"`;
+  try {
+    execFileSync("sh", ["-c", script, "test", matcher, line, worktree], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test("matches the ending worktree and true descendants", () => {
+  assert.equal(matches("101 node /Users/example/dpf/server.js"), true);
+  assert.equal(matches("102 node --cwd /Users/example/dpf"), true);
+});
+
+test("rejects canonical sibling worktrees and the shared local-CI runner", () => {
+  assert.equal(matches("201 node /Users/example/dpf-worktrees/topic/server.js"), false);
+  assert.equal(matches("202 node /Users/example/dpf-worktrees/.local-ci-runner/check.mjs"), false);
+});

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -225,6 +225,9 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         // heartbeat liveness signal, and the root-clone fast-forward remedy.
         "scripts/lib/worktree-janitor-core.test.mjs",
         "scripts/lib/worktree-session-heartbeat.test.mjs",
+        // BI-DBAD1A1B: SessionEnd process matching accepts only the canonical
+        // worktree itself or descendants, never sibling worktrees/CI runners.
+        "scripts/hooks/session-reaper.test.mjs",
         "scripts/lib/root-clone-refresh.test.mjs",
         "scripts/lib/compose-safety.test.mjs",
         "scripts/lib/local-integration-ci.test.mjs",

--- a/scripts/lib/semantic-review-gate.mjs
+++ b/scripts/lib/semantic-review-gate.mjs
@@ -1,4 +1,21 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+
 export const LOCAL_SEMANTIC_REVIEW_GATE_SCHEMA_VERSION = "semantic-change-review-local-gate.v1";
+export const SEMANTIC_DIFF_MAX_BUFFER = 256 * 1024 * 1024;
+
+export function readGitDiffDigest(mergeBase, spawn = spawnSync) {
+  const diff = spawn("git", ["diff", "--binary", mergeBase, "HEAD"], {
+    encoding: null,
+    maxBuffer: SEMANTIC_DIFF_MAX_BUFFER,
+  });
+  if (diff.error?.code === "ENOBUFS") {
+    throw new Error("git diff exceeded the 256 MiB safety limit; split or remove oversized artifacts before review");
+  }
+  if (diff.error) throw new Error(`git diff could not start: ${diff.error.message ?? String(diff.error)}`);
+  if (diff.status !== 0) throw new Error(diff.stderr?.toString().trim() || `git diff exited ${diff.status}`);
+  return createHash("sha256").update(diff.stdout).digest("hex");
+}
 
 const IDENTITY_FIELDS = [
   "branch",

--- a/scripts/semantic-review-gate.mjs
+++ b/scripts/semantic-review-gate.mjs
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
-import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { spawnSync } from "node:child_process";
 
-import { LOCAL_SEMANTIC_REVIEW_GATE_SCHEMA_VERSION, validateLocalSemanticReviewGate } from "./lib/semantic-review-gate.mjs";
+import { LOCAL_SEMANTIC_REVIEW_GATE_SCHEMA_VERSION, readGitDiffDigest, validateLocalSemanticReviewGate } from "./lib/semantic-review-gate.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const policy = JSON.parse(readFileSync(join(here, "semantic-review-policy.json"), "utf8"));
@@ -27,9 +26,7 @@ function currentIdentity(receipt = null) {
   const mergeBase = git("merge-base", "HEAD", "origin/main");
   const baseTreeHash = git("rev-parse", `${mergeBase}^{tree}`);
   const headTreeHash = git("rev-parse", "HEAD^{tree}");
-  const diff = spawnSync("git", ["diff", "--binary", mergeBase, "HEAD"], { encoding: null });
-  if (diff.status !== 0) throw new Error(diff.stderr?.toString().trim() || "git diff failed");
-  const diffDigest = createHash("sha256").update(diff.stdout).digest("hex");
+  const diffDigest = readGitDiffDigest(mergeBase);
   return {
     branch,
     sha,

--- a/scripts/semantic-review-gate.test.mjs
+++ b/scripts/semantic-review-gate.test.mjs
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { validateLocalSemanticReviewGate } from "./lib/semantic-review-gate.mjs";
+import { createHash } from "node:crypto";
+
+import { readGitDiffDigest, validateLocalSemanticReviewGate } from "./lib/semantic-review-gate.mjs";
 
 const current = {
   branch: "feat/change-reviewer-enforcement",
@@ -40,4 +42,23 @@ test("rejects missing, stale, expired, and infrastructure-inconclusive state dis
   assert.equal(validateLocalSemanticReviewGate({ ...state, sha: "e".repeat(40) }, current, Date.parse("2026-08-01T16:30:00Z")).reason, "stale-receipt");
   assert.equal(validateLocalSemanticReviewGate(state, current, Date.parse("2026-08-01T18:00:00Z")).reason, "expired-receipt");
   assert.equal(validateLocalSemanticReviewGate({ ...state, receiptDecision: "inconclusive" }, current, Date.parse("2026-08-01T16:30:00Z")).reason, "infrastructure-inconclusive");
+});
+
+test("hashes diffs above Node's historical 1 MiB spawn buffer", () => {
+  const diff = Buffer.alloc(2 * 1024 * 1024, 7);
+  let options;
+  const digest = readGitDiffDigest("merge-base", (_command, _args, received) => {
+    options = received;
+    return { status: 0, stdout: diff, stderr: Buffer.alloc(0) };
+  });
+
+  assert.equal(options.maxBuffer, 256 * 1024 * 1024);
+  assert.equal(digest, createHash("sha256").update(diff).digest("hex"));
+});
+
+test("reports an exhausted diff buffer distinctly from a git exit", () => {
+  assert.throws(
+    () => readGitDiffDigest("merge-base", () => ({ status: null, stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), error: { code: "ENOBUFS" } })),
+    /exceeded the 256 MiB safety limit/,
+  );
 });


### PR DESCRIPTION
## Summary

- add a daily live-database btree/collation integrity sweep that raises one deduplicated critical platform issue on drift
- harden control-plane boundaries: authenticated A2A task reads, boundary-safe session reaping, semantic duplicate FK resolution, and bounded large-diff review hashing
- make seven identity-scoped coworker tools explicitly reachable while preserving deny-by-default for unknown tools
- revalidate four already-merged reliability contracts before closing their live backlog records

Linked backlog items: BI-D9C20A97, BI-DBAD1A1B, BI-F998BCE8, BI-DC6BE37C, BI-C1FCFAA3, BI-07BD42FC, BI-F8808EDA, BI-32426CA0, BI-46544737, BI-108602C0.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/plans/2026-08-13-backlog-reliability-batch-6.md` plus the live PostgreSQL backlog and its ten-item plan-coverage receipt.
- Current code substrate reviewed: `apps/web/lib/mcp/packs/backlog-pack.ts`, `apps/web/lib/tak/agent-grants.ts`, the existing Inngest queue/catalog, sibling A2A routes, and the shared index-integrity core.
- Source of truth: the live backlog owns lifecycle; the canonical grant registry owns coworker authority; the queue catalog owns schedules; existing shared helpers own duplicate resolution and platform issue reporting.
- Decision: extend those contracts in place. This adds no parallel identity, scheduling, authorization, or evidence store.

The ten items are one platform-reliability concern selected for MSP/install relevance: preventing control paths from exposing task data, terminating sibling work, writing invalid backlog references, hiding intended tools, or silently missing database integrity drift. Four items required fresh verification rather than duplicate implementation.

## Verification

- `pnpm run pregate:preflight` — 37/37 guards passed
- affected web Vitest suite — 10 files, 104 assertions passed
- Node regressions — 6/6 passed
- database guard suite — 10 passed; 5 environment-gated integration cases skipped and compensated by fresh live-state verification
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web exec tsc --noEmit` — passed
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web build` — passed, 623 routes
- governed exact-tree local CI — exhaustive/full-suite gate passed against current `origin/main`
- independent high-assurance semantic review — two review branches, zero blocking findings

## Delivery impact

- UX: not applicable; no user-facing page or workflow UI changes
- migration: not applicable; no schema or data migration
- documentation: execution plan added; route-derived artifacts regenerated and confirmed current
- live verification: implementation BIs will be closed only after merge, canonical self-upgrade, and Arcamanus validation

Docs-Impact-Decision: internal control-plane reliability and authentication hardening; no end-user workflow or user-guide behavior changes.
