### PR TITLE
feat(edge): make fleet readiness operational

### DIFF
--- a/apps/web/app/(shell)/platform/edge-nodes/page.tsx
+++ b/apps/web/app/(shell)/platform/edge-nodes/page.tsx
@@ -20,6 +20,12 @@ import { EXCLUDE_TOMBSTONED } from "@dpf/db/customer-lifecycle";
 
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
+import { loadPlatformVersion } from "@/lib/platform/version";
+import {
+  deriveEdgeNodeReadiness,
+  selectMainInstallationNode,
+  type EdgeReadinessNode,
+} from "@/lib/edge-node/readiness";
 
 import { EdgeNodesAdminClient } from "@/components/platform/edge-nodes/EdgeNodesAdminClient";
 
@@ -54,6 +60,11 @@ type EdgeNodeRow = {
   customerAccountName: string | null;
   customerSiteId: string | null;
   customerSiteName: string | null;
+  health: ReturnType<typeof deriveEdgeNodeReadiness>["health"];
+  heartbeatAgeMs: number | null;
+  nextAction: ReturnType<typeof deriveEdgeNodeReadiness>["nextAction"];
+  isMainInstallation: boolean;
+  readinessChecks: ReturnType<typeof deriveEdgeNodeReadiness>["checks"];
 };
 
 /**
@@ -137,6 +148,10 @@ export default async function EdgeNodesAdminPage() {
       principal: { select: { displayName: true } },
       customerAccount: { select: { name: true } },
       customerSite: { select: { name: true } },
+      capabilityRows: {
+        select: { capability: true, mode: true, status: true, reportedAt: true },
+      },
+      consumedTokens: { select: { autoApprove: true } },
     },
   });
 
@@ -176,8 +191,38 @@ export default async function EdgeNodesAdminPage() {
     },
   });
 
-  const nodeRows: EdgeNodeRow[] = nodes.map((n) => {
+  const readinessNodes: EdgeReadinessNode[] = nodes.map((node) => ({
+    id: node.id,
+    nodeId: node.nodeId,
+    platform: node.platform,
+    installMode: node.installMode,
+    version: node.version,
+    storedStatus: node.status,
+    trustState: node.trustState,
+    lastSeenAt: node.lastSeenAt,
+    enrolledAt: node.enrolledAt,
+    customerAccountId: node.customerAccountId,
+    customerSiteId: node.customerSiteId,
+    installerManaged: node.consumedTokens.some((token) => token.autoApprove),
+    capabilities: node.capabilityRows,
+  }));
+  const mainInstallation = selectMainInstallationNode(readinessNodes);
+  const edgeEnabled =
+    process.env.DPF_EDGE_ENABLED === "1" || mainInstallation.status === "found";
+  const platformVersion = await loadPlatformVersion();
+
+  const nodeRows: EdgeNodeRow[] = nodes.map((n, index) => {
     const hostMetadata = readHostMetadata(n.metadata);
+    const readinessNode = readinessNodes[index];
+    if (!readinessNode) {
+      throw new Error(`Missing readiness projection for Edge Node ${n.nodeId}`);
+    }
+    const isMainInstallation = mainInstallation.node?.id === n.id;
+    const readiness = deriveEdgeNodeReadiness(readinessNode, {
+      edgeEnabled,
+      currentVersion: isMainInstallation ? platformVersion.version : null,
+      requiredCapabilities: isMainInstallation ? ["federation.discovery"] : [],
+    });
     return {
       id: n.id,
       nodeId: n.nodeId,
@@ -203,6 +248,11 @@ export default async function EdgeNodesAdminPage() {
       customerAccountName: n.customerAccount?.name ?? null,
       customerSiteId: n.customerSiteId,
       customerSiteName: n.customerSite?.name ?? null,
+      health: readiness.health,
+      heartbeatAgeMs: readiness.heartbeatAgeMs,
+      nextAction: readiness.nextAction,
+      isMainInstallation,
+      readinessChecks: readiness.checks,
     };
   });
 
@@ -241,9 +291,8 @@ export default async function EdgeNodesAdminPage() {
       <div>
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Edge Nodes</h1>
         <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
-          Host-resident agents that enroll against this Authority Core and submit discovery
-          observations. Issue one-time bootstrap tokens to onboard new nodes; approve,
-          quarantine, or revoke existing ones from the table below.
+          See this installation&apos;s readiness and manage Edge Nodes enrolled with its Authority
+          Core.
         </p>
       </div>
 
@@ -251,6 +300,8 @@ export default async function EdgeNodesAdminPage() {
         nodes={nodeRows}
         tokens={tokenRows}
         customerAccounts={customerAccountOptions}
+        edgeEnabled={edgeEnabled}
+        mainInstallationStatus={mainInstallation.status}
       />
     </div>
   );

--- a/apps/web/app/(shell)/platform/federation-links/page.tsx
+++ b/apps/web/app/(shell)/platform/federation-links/page.tsx
@@ -22,6 +22,11 @@ import {
 } from "@/components/platform/federation-links/PartnerBusinessPanel";
 import { OrganizationJoinPanel } from "@/components/platform/federation-links/OrganizationJoinPanel";
 import { getOrganizationJoinNodeSummariesAction } from "@/lib/actions/organization-join";
+import {
+  deriveEdgeNodeReadiness,
+  selectMainInstallationNode,
+  type EdgeReadinessNode,
+} from "@/lib/edge-node/readiness";
 
 export const dynamic = "force-dynamic";
 
@@ -40,21 +45,22 @@ export default async function FederationLinksPage() {
     redirect("/403");
   }
 
-  const [links, discoveryCapabilities, partnerAccounts, nearbyPairingSessions, organizationJoinNodes, introducedCandidates] = await Promise.all([
+  const [links, edgeNodes, partnerAccounts, nearbyPairingSessions, organizationJoinNodes, introducedCandidates] = await Promise.all([
     prisma.federationLink.findMany({
       include: { principal: { select: { displayName: true } } },
       orderBy: { createdAt: "desc" },
       take: 100,
     }),
-    prisma.edgeNodeCapability.findMany({
-      where: { capability: "federation.discovery" },
+    prisma.edgeNode.findMany({
       select: {
-        mode: true,
-        status: true,
-        reportedAt: true,
-        node: { select: { trustState: true, status: true } },
+        id: true, nodeId: true, platform: true, installMode: true, version: true,
+        status: true, trustState: true, lastSeenAt: true, enrolledAt: true,
+        customerAccountId: true, customerSiteId: true,
+        consumedTokens: { select: { autoApprove: true } },
+        capabilityRows: {
+          select: { capability: true, mode: true, status: true, reportedAt: true },
+        },
       },
-      orderBy: { reportedAt: "desc" },
     }),
     prisma.partnerAccount.findMany({
       include: {
@@ -86,42 +92,48 @@ export default async function FederationLinksPage() {
     }),
   ]);
 
-  const enabledDiscovery = discoveryCapabilities.filter(
-    (row) =>
-      (row.mode === "enabled" || row.mode === "reporting-only") &&
-      row.node.trustState === "trusted",
+  const readinessNodes: EdgeReadinessNode[] = edgeNodes.map((node) => ({
+    ...node,
+    storedStatus: node.status,
+    installerManaged: node.consumedTokens.some((token) => token.autoApprove),
+    capabilities: node.capabilityRows,
+  }));
+  const mainNode = selectMainInstallationNode(readinessNodes);
+  const discoveryCapability = mainNode.node?.capabilities.find(
+    (row) => row.capability === "federation.discovery",
   );
+  const readiness = mainNode.node
+    ? deriveEdgeNodeReadiness(mainNode.node, { requiredCapabilities: ["federation.discovery"] })
+    : null;
   const nearbyDiscoveryHealth: NearbyDiscoveryHealth =
-    discoveryCapabilities.length === 0
+    mainNode.status !== "found" || !readiness || !discoveryCapability
       ? {
           status: "unavailable",
           label: "Not set up",
           detail: "The native Edge Node has not registered nearby discovery.",
         }
-      : enabledDiscovery.length === 0
+      : discoveryCapability.mode !== "enabled" && discoveryCapability.mode !== "reporting-only"
         ? {
             status: "disabled",
             label: "Paused",
             detail: "Nearby discovery is disabled by the Authority.",
           }
-        : enabledDiscovery.some((row) => row.status === "healthy")
+        : readiness.health === "healthy"
           ? {
               status: "healthy",
               label: "Listening",
               detail: "This installation is announcing and looking for nearby DPF installations.",
             }
-          : enabledDiscovery.some(
-                (row) => row.status === "degraded" || row.status === "failing",
-              )
+          : readiness.health === "starting"
             ? {
-                status: "degraded",
-                label: "Needs attention",
-                detail: "Nearby discovery is enabled but cannot advertise or browse. Check the endpoint configuration, multicast network, and host firewall.",
-              }
-            : {
                 status: "waiting",
                 label: "Starting",
                 detail: "Nearby discovery is enabled and waiting for its first health report.",
+              }
+            : {
+                status: "degraded",
+                label: "Needs attention",
+                detail: "Nearby discovery or its host service is stale or failing. Check the Edge fleet for the specific failed readiness check.",
               };
 
   const rows: FederationLinkRow[] = links.map((l) => {

--- a/apps/web/components/platform/edge-nodes/EdgeFleetReadiness.tsx
+++ b/apps/web/components/platform/edge-nodes/EdgeFleetReadiness.tsx
@@ -1,0 +1,199 @@
+import Link from "next/link";
+
+import { StatusBadge, intentStyle, resolveIntent } from "@/components/ui/report-kit";
+import type {
+  EdgeHealth,
+  EdgeReadinessCheck,
+  EdgeReadinessNextAction,
+} from "@/lib/edge-node/readiness";
+
+export type EdgeFleetNode = {
+  platform: string;
+  installMode: string;
+  version: string;
+  trustState: string;
+  health: EdgeHealth;
+  heartbeatAgeMs: number | null;
+  nextAction: EdgeReadinessNextAction;
+  readinessChecks: EdgeReadinessCheck[];
+};
+
+export type MainInstallationStatus = "found" | "missing" | "ambiguous";
+
+export const NEXT_ACTION_LABELS: Record<EdgeReadinessNextAction, string> = {
+  "activate-edge": "Enable Edge",
+  "repair-service": "Repair service",
+  "approve-node": "Approve node",
+  "investigate-node": "Investigate node",
+  "repair-capability": "Repair capability",
+  "review-quarantine": "Review quarantine",
+  "replace-node": "Replace node",
+  "upgrade-node": "Upgrade node",
+  none: "Ready",
+};
+
+function titleCase(value: string): string {
+  return value
+    .split("-")
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+export function HealthBadge({ health }: { health: EdgeHealth }) {
+  return (
+    <StatusBadge
+      domain="edgeHealth"
+      status={health}
+      label={health === "setup-required" ? "Setup required" : titleCase(health)}
+      variant="soft"
+      uppercase={false}
+    />
+  );
+}
+
+export function formatHeartbeatAge(ageMs: number | null): string {
+  if (ageMs === null) return "No heartbeat";
+  if (ageMs < 60_000) return "Just now";
+  const minutes = Math.floor(ageMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function formatCount(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+export function FleetHealthSummary({ nodes }: { nodes: EdgeFleetNode[] }) {
+  const trusted = nodes.filter((node) => node.trustState === "trusted").length;
+  const pending = nodes.filter((node) => node.trustState === "pending").length;
+  const healthCounts = new Map<EdgeHealth, number>();
+  for (const node of nodes) {
+    healthCounts.set(node.health, (healthCounts.get(node.health) ?? 0) + 1);
+  }
+  const runtimeModes = Array.from(
+    new Set(nodes.map((node) => `${node.platform} / ${node.installMode}`)),
+  ).sort();
+  const hasContainerRuntime = nodes.some(
+    (node) => node.installMode === "container-host" || node.installMode === "container-vm",
+  );
+
+  return (
+    <section
+      className="rounded border p-4"
+      style={{ borderColor: "var(--dpf-border)", backgroundColor: "var(--dpf-surface-1)" }}
+    >
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h2 className="text-base font-semibold text-[var(--dpf-text)]">Fleet health</h2>
+          <div className="mt-2 flex flex-wrap gap-2 text-xs">
+            {Array.from(healthCounts.entries()).map(([health, count]) => (
+              <span
+                key={health}
+                className="rounded border px-2 py-1 text-[var(--dpf-text)]"
+                style={{ borderColor: intentStyle(resolveIntent("edgeHealth", health)).border }}
+              >
+                {formatCount(count, health, health)}
+              </span>
+            ))}
+            <span className="rounded border px-2 py-1 text-[var(--dpf-text)]" style={{ borderColor: "var(--dpf-border)" }}>
+              {formatCount(trusted, "trusted", "trusted")}
+            </span>
+            <span className="rounded border px-2 py-1 text-[var(--dpf-text)]" style={{ borderColor: "var(--dpf-border)" }}>
+              {formatCount(pending, "pending", "pending")}
+            </span>
+          </div>
+        </div>
+        <div className="min-w-0 lg:max-w-xl">
+          <p className="text-xs font-medium uppercase text-[var(--dpf-muted)]">Runtime modes</p>
+          <div className="mt-1 flex flex-wrap gap-2">
+            {runtimeModes.length > 0 ? (
+              runtimeModes.map((mode) => (
+                <span key={mode} className="rounded border px-2 py-1 font-mono text-xs text-[var(--dpf-muted)]" style={{ borderColor: "var(--dpf-border)" }}>
+                  {mode}
+                </span>
+              ))
+            ) : (
+              <span className="text-sm text-[var(--dpf-muted)]">No enrolled nodes</span>
+            )}
+          </div>
+        </div>
+      </div>
+      {hasContainerRuntime && (
+        <p
+          className="mt-3 rounded border px-3 py-2 text-sm text-[var(--dpf-text)]"
+          style={{ borderColor: "var(--dpf-warning)", backgroundColor: "var(--dpf-surface-2)" }}
+        >
+          Container runtime is connected to Authority Core, but can have limited host-LAN
+          visibility on Docker Desktop. Native Windows/macOS service mode is the full host-LAN
+          discovery target.
+        </p>
+      )}
+    </section>
+  );
+}
+
+export function MainInstallationReadiness({
+  node,
+  edgeEnabled,
+  status,
+}: {
+  node: EdgeFleetNode | null;
+  edgeEnabled: boolean;
+  status: MainInstallationStatus;
+}) {
+  const health: EdgeHealth = node?.health ?? "setup-required";
+  const setupDetail = !edgeEnabled
+    ? "Edge is not enabled for this installation. Re-run the governed installer with Edge enabled."
+    : status === "ambiguous"
+      ? "More than one installer-managed node claims this installation. Review the fleet before relying on discovery."
+      : "Edge is enabled, but its supervised host service has not enrolled. Run the governed repair or self-upgrade path.";
+
+  return (
+    <section
+      className="rounded border p-4"
+      style={{
+        borderColor: intentStyle(resolveIntent("edgeHealth", health)).border,
+        backgroundColor: "var(--dpf-surface-1)",
+      }}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-[var(--dpf-text)]">This DPF installation</h2>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <HealthBadge health={health} />
+            {node && (
+              <span className="text-sm text-[var(--dpf-muted)]">
+                {node.platform} / {node.installMode} · {node.version} · {formatHeartbeatAge(node.heartbeatAgeMs)}
+              </span>
+            )}
+          </div>
+        </div>
+        <Link
+          href="/platform/federation-links"
+          className="rounded border px-3 py-1.5 text-sm font-medium text-[var(--dpf-accent)]"
+          style={{ borderColor: "var(--dpf-accent)" }}
+        >
+          Open Connections
+        </Link>
+      </div>
+
+      {node ? (
+        <ul className="mt-4 grid gap-2 md:grid-cols-2">
+          {node.readinessChecks.map((check) => (
+            <li key={check.key} className="rounded border p-3" style={{ borderColor: "var(--dpf-border)", backgroundColor: "var(--dpf-surface-2)" }}>
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-medium text-[var(--dpf-text)]">{check.label}</span>
+                <span className="text-xs text-[var(--dpf-muted)]">{titleCase(check.status)}</span>
+              </div>
+              <p className="mt-1 text-xs text-[var(--dpf-muted)]">{check.detail}</p>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-3 text-sm text-[var(--dpf-muted)]">{setupDetail}</p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.test.tsx
+++ b/apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.test.tsx
@@ -24,6 +24,11 @@ import {
   EdgeNodesAdminClient,
   __test_HostAddressCell as HostAddressCell,
 } from "./EdgeNodesAdminClient";
+import type {
+  EdgeHealth,
+  EdgeReadinessCheck,
+  EdgeReadinessNextAction,
+} from "@/lib/edge-node/readiness";
 
 afterEach(() => {
   cleanup();
@@ -53,6 +58,16 @@ const BASE_NODE = {
   customerAccountName: "Acme Dental",
   customerSiteId: "site_hq",
   customerSiteName: "Headquarters",
+  health: "healthy" as EdgeHealth,
+  heartbeatAgeMs: 60_000,
+  nextAction: "none" as EdgeReadinessNextAction,
+  isMainInstallation: true,
+  readinessChecks: [
+    { key: "service", label: "Host service", status: "pass", detail: "Supervised host service is enrolled." },
+    { key: "trust", label: "Trust", status: "pass", detail: "Submissions are accepted." },
+    { key: "heartbeat", label: "Heartbeat", status: "pass", detail: "Heartbeat is current." },
+    { key: "capability:federation.discovery", label: "Nearby DPF discovery", status: "pass", detail: "Capability is enabled and healthy." },
+  ] as EdgeReadinessCheck[],
 };
 
 const BASE_TOKEN = {
@@ -173,7 +188,27 @@ describe("HostAddressCell", () => {
 });
 
 describe("EdgeNodesAdminClient customer/site scope", () => {
-  it("summarizes runtime mode and warns about container LAN visibility", () => {
+  it("shows this installation readiness before the fleet registry", () => {
+    render(
+      <EdgeNodesAdminClient
+        nodes={[BASE_NODE]}
+        tokens={[]}
+        customerAccounts={CUSTOMER_ACCOUNTS}
+        edgeEnabled
+        mainInstallationStatus="found"
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "This DPF installation" })).toBeInTheDocument();
+    expect(screen.getAllByText("Healthy").length).toBeGreaterThan(0);
+    expect(screen.getByText("Nearby DPF discovery")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open connections/i })).toHaveAttribute(
+      "href",
+      "/platform/federation-links",
+    );
+  });
+
+  it("summarizes derived health instead of the stored active field", () => {
     render(
       <EdgeNodesAdminClient
         nodes={[
@@ -183,6 +218,71 @@ describe("EdgeNodesAdminClient customer/site scope", () => {
             installMode: "container-vm",
             trustState: "trusted",
             status: "active",
+            health: "offline",
+            heartbeatAgeMs: 64 * 24 * 60 * 60 * 1000,
+            nextAction: "repair-service",
+            readinessChecks: [
+              { key: "heartbeat", label: "Heartbeat", status: "fail", detail: "The host service has missed the offline threshold." },
+            ],
+          },
+        ]}
+        tokens={[]}
+        customerAccounts={CUSTOMER_ACCOUNTS}
+        edgeEnabled
+        mainInstallationStatus="found"
+      />,
+    );
+
+    expect(screen.getByText("Fleet health")).toBeInTheDocument();
+    expect(screen.getByText("1 offline")).toBeInTheDocument();
+    expect(screen.queryByText("1 active")).not.toBeInTheDocument();
+    expect(screen.getByText("1 trusted")).toBeInTheDocument();
+    expect(screen.getAllByText("linux / container-vm").length).toBeGreaterThan(0);
+    expect(screen.getByText(/limited host-LAN visibility/i)).toBeInTheDocument();
+  });
+
+  it("keeps node health and trust visible as separate fleet columns", () => {
+    render(
+      <EdgeNodesAdminClient
+        nodes={[{ ...BASE_NODE, health: "degraded", trustState: "trusted" }]}
+        tokens={[]}
+        customerAccounts={CUSTOMER_ACCOUNTS}
+        edgeEnabled
+        mainInstallationStatus="found"
+      />,
+    );
+
+    expect(screen.getByRole("columnheader", { name: "Health" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Trust" })).toBeInTheDocument();
+    expect(screen.getAllByText("Degraded").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("trusted").length).toBeGreaterThan(0);
+  });
+
+  it("shows readiness failures and next actions for multiple customer sites", () => {
+    render(
+      <EdgeNodesAdminClient
+        nodes={[
+          { ...BASE_NODE, isMainInstallation: false },
+          {
+            ...BASE_NODE,
+            id: "edge_2",
+            nodeId: "dpf-edge-2",
+            displayName: "Contoso Main Edge",
+            customerAccountId: "cust_contoso",
+            customerAccountName: "Contoso Clinic",
+            customerSiteId: "site_contoso_hq",
+            customerSiteName: "Main Office",
+            health: "degraded",
+            nextAction: "upgrade-node",
+            isMainInstallation: false,
+            readinessChecks: [
+              {
+                key: "version",
+                label: "Version",
+                status: "warning",
+                detail: "Node 0.1.0 differs from the current installation 0.2.0.",
+              },
+            ],
           },
         ]}
         tokens={[]}
@@ -190,10 +290,27 @@ describe("EdgeNodesAdminClient customer/site scope", () => {
       />,
     );
 
-    expect(screen.getByText("Runtime summary")).toBeInTheDocument();
-    expect(screen.getByText("1 trusted")).toBeInTheDocument();
-    expect(screen.getAllByText("linux / container-vm").length).toBeGreaterThan(0);
-    expect(screen.getByText(/limited host-LAN visibility/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Edge fleet (2)" })).toBeInTheDocument();
+    expect(screen.getByText("Acme Dental / Headquarters")).toBeInTheDocument();
+    expect(screen.getByText("Contoso Clinic / Main Office")).toBeInTheDocument();
+    expect(screen.getByText("Node 0.1.0 differs from the current installation 0.2.0.")).toBeInTheDocument();
+    expect(screen.getByText("Upgrade node")).toBeInTheDocument();
+  });
+
+  it("shows a governed setup state when no main-installation node is proven", () => {
+    render(
+      <EdgeNodesAdminClient
+        nodes={[]}
+        tokens={[]}
+        customerAccounts={CUSTOMER_ACCOUNTS}
+        edgeEnabled={false}
+        mainInstallationStatus="missing"
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "This DPF installation" })).toBeInTheDocument();
+    expect(screen.getByText("Setup required")).toBeInTheDocument();
+    expect(screen.getByText(/not enabled/i)).toBeInTheDocument();
   });
 
   it("renders customer/site scope badges for nodes and bootstrap tokens", () => {

--- a/apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx
+++ b/apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx
@@ -2,6 +2,17 @@
 
 import { useState, useTransition } from "react";
 import { confirmDialog, promptDialog } from "@/components/ui/Dialog";
+import { StatusBadge } from "@/components/ui/report-kit";
+
+import {
+  FleetHealthSummary,
+  HealthBadge,
+  MainInstallationReadiness,
+  NEXT_ACTION_LABELS,
+  formatHeartbeatAge,
+  type EdgeFleetNode,
+  type MainInstallationStatus,
+} from "./EdgeFleetReadiness";
 
 import {
   approveEdgeNodeAction,
@@ -14,8 +25,7 @@ import type {
   EdgeHostOs,
   RemoteProvisioningPlan,
 } from "@/lib/edge-node/remote-provisioning";
-
-type EdgeNodeRow = {
+type EdgeNodeRow = EdgeFleetNode & {
   id: string;
   nodeId: string;
   platform: string;
@@ -38,6 +48,7 @@ type EdgeNodeRow = {
   customerAccountName: string | null;
   customerSiteId: string | null;
   customerSiteName: string | null;
+  isMainInstallation: boolean;
 };
 
 type BootstrapTokenRow = {
@@ -74,6 +85,8 @@ type Props = {
   nodes: EdgeNodeRow[];
   tokens: BootstrapTokenRow[];
   customerAccounts: CustomerAccountOption[];
+  edgeEnabled?: boolean;
+  mainInstallationStatus?: MainInstallationStatus;
 };
 
 type FlashMessage = {
@@ -88,21 +101,6 @@ type IssuedTokenView = {
   prefix: string;
   expiresAt: string;
 };
-
-function trustStateBadgeColor(trustState: string): string {
-  switch (trustState) {
-    case "trusted":
-      return "var(--dpf-success)";
-    case "pending":
-      return "var(--dpf-warning)";
-    case "quarantined":
-      return "var(--dpf-danger)";
-    case "revoked":
-      return "var(--dpf-muted)";
-    default:
-      return "var(--dpf-muted)";
-  }
-}
 
 function formatTimestamp(iso: string | null): string {
   if (!iso) return "—";
@@ -143,93 +141,6 @@ function ScopeBadge({ scope }: { scope: ScopeBadgeInput }) {
     >
       <span className="truncate">{formatScopeLabel(scope)}</span>
     </span>
-  );
-}
-
-function formatCount(count: number, singular: string, plural = `${singular}s`): string {
-  return `${count} ${count === 1 ? singular : plural}`;
-}
-
-function RuntimeSummary({ nodes }: { nodes: EdgeNodeRow[] }) {
-  const trusted = nodes.filter((node) => node.trustState === "trusted").length;
-  const pending = nodes.filter((node) => node.trustState === "pending").length;
-  const active = nodes.filter((node) => node.status === "active").length;
-  const runtimeModes = Array.from(
-    new Set(nodes.map((node) => `${node.platform} / ${node.installMode}`)),
-  ).sort();
-  const hasContainerRuntime = nodes.some((node) =>
-    node.installMode === "container-host" || node.installMode === "container-vm",
-  );
-
-  return (
-    <section
-      className="rounded border p-4"
-      style={{
-        borderColor: "var(--dpf-border)",
-        backgroundColor: "var(--dpf-surface-1)",
-      }}
-    >
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-        <div>
-          <h2 className="text-base font-semibold text-[var(--dpf-text)]">
-            Runtime summary
-          </h2>
-          <div className="mt-2 flex flex-wrap gap-2 text-xs">
-            <span
-              className="rounded border px-2 py-1 text-[var(--dpf-text)]"
-              style={{ borderColor: "var(--dpf-border)" }}
-            >
-              {formatCount(active, "active", "active")}
-            </span>
-            <span
-              className="rounded border px-2 py-1 text-[var(--dpf-text)]"
-              style={{ borderColor: "var(--dpf-border)" }}
-            >
-              {formatCount(trusted, "trusted", "trusted")}
-            </span>
-            <span
-              className="rounded border px-2 py-1 text-[var(--dpf-text)]"
-              style={{ borderColor: "var(--dpf-border)" }}
-            >
-              {formatCount(pending, "pending", "pending")}
-            </span>
-          </div>
-        </div>
-        <div className="min-w-0 lg:max-w-xl">
-          <p className="text-xs font-medium uppercase text-[var(--dpf-muted)]">
-            Runtime modes
-          </p>
-          <div className="mt-1 flex flex-wrap gap-2">
-            {runtimeModes.length > 0 ? (
-              runtimeModes.map((mode) => (
-                <span
-                  key={mode}
-                  className="rounded border px-2 py-1 font-mono text-xs text-[var(--dpf-muted)]"
-                  style={{ borderColor: "var(--dpf-border)" }}
-                >
-                  {mode}
-                </span>
-              ))
-            ) : (
-              <span className="text-sm text-[var(--dpf-muted)]">No enrolled nodes</span>
-            )}
-          </div>
-        </div>
-      </div>
-      {hasContainerRuntime && (
-        <p
-          className="mt-3 rounded border px-3 py-2 text-sm text-[var(--dpf-text)]"
-          style={{
-            borderColor: "var(--dpf-warning)",
-            backgroundColor: "var(--dpf-surface-2)",
-          }}
-        >
-          Container runtime is connected to Authority Core, but can have limited
-          host-LAN visibility on Docker Desktop. Native Windows/macOS service mode is
-          the full host-LAN discovery target.
-        </p>
-      )}
-    </section>
   );
 }
 
@@ -282,7 +193,13 @@ function HostAddressCell({
 // above; this is not part of the public component API.
 export { HostAddressCell as __test_HostAddressCell };
 
-export function EdgeNodesAdminClient({ nodes, tokens, customerAccounts }: Props) {
+export function EdgeNodesAdminClient({
+  nodes,
+  tokens,
+  customerAccounts,
+  edgeEnabled = false,
+  mainInstallationStatus = "missing",
+}: Props) {
   const [flash, setFlash] = useState<FlashMessage | null>(null);
   const [issuedToken, setIssuedToken] = useState<IssuedTokenView | null>(null);
   const [ttlMinutes, setTtlMinutes] = useState<number>(15);
@@ -476,7 +393,7 @@ export function EdgeNodesAdminClient({ nodes, tokens, customerAccounts }: Props)
               className="rounded px-3 py-1 text-xs font-medium"
               style={{
                 backgroundColor: "var(--dpf-accent)",
-                color: "white",
+                color: "var(--dpf-on-accent, var(--dpf-surface-1))",
               }}
             >
               Copy
@@ -571,7 +488,10 @@ export function EdgeNodesAdminClient({ nodes, tokens, customerAccounts }: Props)
                   type="button"
                   onClick={() => navigator.clipboard?.writeText(cmd.command)}
                   className="rounded px-3 py-1 text-xs font-medium"
-                  style={{ backgroundColor: "var(--dpf-accent)", color: "white" }}
+                  style={{
+                    backgroundColor: "var(--dpf-accent)",
+                    color: "var(--dpf-on-accent, var(--dpf-surface-1))",
+                  }}
                 >
                   Copy
                 </button>
@@ -592,23 +512,27 @@ export function EdgeNodesAdminClient({ nodes, tokens, customerAccounts }: Props)
         </div>
       )}
 
-      <RuntimeSummary nodes={nodes} />
+      <MainInstallationReadiness
+        node={nodes.find((node) => node.isMainInstallation) ?? null}
+        edgeEnabled={edgeEnabled}
+        status={mainInstallationStatus}
+      />
 
-      <section
+      <FleetHealthSummary nodes={nodes} />
+
+      <details
         className="rounded border p-4"
         style={{
           borderColor: "var(--dpf-border)",
           backgroundColor: "var(--dpf-surface-1)",
         }}
       >
-        <h2 className="mb-1 text-base font-semibold text-[var(--dpf-text)]">
+        <summary className="cursor-pointer text-base font-semibold text-[var(--dpf-text)]">
           Add a node on another machine
-        </h2>
-        <p className="mb-3 text-sm text-[var(--dpf-muted)]">
-          The portal builds a ready-to-run command — no repo to clone, no file to edit. Pick the
-          host&apos;s operating system; we mint a one-time token and bake in this portal&apos;s
-          address. The node arrives <strong>pending</strong> and submits nothing until you
-          approve it below.
+        </summary>
+        <p className="mb-3 mt-2 text-sm text-[var(--dpf-muted)]">
+          Prepare a one-time install command for a remote Edge host. Remote nodes need approval
+          before the Authority accepts their evidence.
         </p>
         <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
           <div className="flex flex-col gap-1">
@@ -757,7 +681,7 @@ export function EdgeNodesAdminClient({ nodes, tokens, customerAccounts }: Props)
             className="rounded px-4 py-1.5 text-sm font-medium disabled:opacity-50"
             style={{
               backgroundColor: "var(--dpf-accent)",
-              color: "white",
+              color: "var(--dpf-on-accent, var(--dpf-surface-1))",
             }}
           >
             {isPending ? "Preparing…" : "Generate install command"}
@@ -775,11 +699,11 @@ export function EdgeNodesAdminClient({ nodes, tokens, customerAccounts }: Props)
             Issue raw token only
           </button>
         </div>
-      </section>
+      </details>
 
       <section>
         <h2 className="mb-2 text-base font-semibold text-[var(--dpf-text)]">
-          Enrolled nodes ({nodes.length})
+          Edge fleet ({nodes.length})
         </h2>
         {nodes.length === 0 ? (
           <p className="text-sm text-[var(--dpf-muted)]">
@@ -801,8 +725,10 @@ export function EdgeNodesAdminClient({ nodes, tokens, customerAccounts }: Props)
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Platform / mode</th>
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Host / LAN address</th>
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Scope</th>
-                  <th className="p-2 text-left text-[var(--dpf-muted)]">Trust state</th>
-                  <th className="p-2 text-left text-[var(--dpf-muted)]">Last seen</th>
+                  <th className="p-2 text-left text-[var(--dpf-muted)]">Health</th>
+                  <th className="p-2 text-left text-[var(--dpf-muted)]">Readiness</th>
+                  <th className="p-2 text-left text-[var(--dpf-muted)]">Trust</th>
+                  <th className="p-2 text-left text-[var(--dpf-muted)]">Last heartbeat</th>
                   <th className="p-2 text-left text-[var(--dpf-muted)]">Actions</th>
                 </tr>
               </thead>
@@ -836,18 +762,30 @@ export function EdgeNodesAdminClient({ nodes, tokens, customerAccounts }: Props)
                       />
                     </td>
                     <td className="p-2">
-                      <span
-                        className="inline-block rounded px-2 py-0.5 text-xs font-medium"
-                        style={{
-                          backgroundColor: trustStateBadgeColor(n.trustState),
-                          color: "white",
-                        }}
-                      >
-                        {n.trustState}
+                      <HealthBadge health={n.health} />
+                    </td>
+                    <td className="max-w-72 p-2 text-xs">
+                      <span className="block font-medium text-[var(--dpf-text)]">
+                        {NEXT_ACTION_LABELS[n.nextAction]}
+                      </span>
+                      <span className="block text-[var(--dpf-muted)]">
+                        {n.readinessChecks.find((check) => check.status !== "pass")?.detail ??
+                          `Version ${n.version}; required checks pass.`}
                       </span>
                     </td>
+                    <td className="p-2">
+                      <StatusBadge
+                        domain="edgeTrust"
+                        status={n.trustState}
+                        variant="soft"
+                        uppercase={false}
+                      />
+                    </td>
                     <td className="p-2 text-xs text-[var(--dpf-muted)]">
-                      {formatTimestamp(n.lastSeenAt)}
+                      <span className="block text-[var(--dpf-text)]">
+                        {formatHeartbeatAge(n.heartbeatAgeMs)}
+                      </span>
+                      <span>{formatTimestamp(n.lastSeenAt)}</span>
                     </td>
                     <td className="p-2">
                       <div className="flex flex-wrap gap-1">
@@ -859,7 +797,7 @@ export function EdgeNodesAdminClient({ nodes, tokens, customerAccounts }: Props)
                             className="rounded px-2 py-1 text-xs font-medium disabled:opacity-50"
                             style={{
                               backgroundColor: "var(--dpf-success)",
-                              color: "white",
+                              color: "var(--dpf-on-accent, var(--dpf-surface-1))",
                             }}
                           >
                             Approve
@@ -873,7 +811,7 @@ export function EdgeNodesAdminClient({ nodes, tokens, customerAccounts }: Props)
                             className="rounded px-2 py-1 text-xs font-medium disabled:opacity-50"
                             style={{
                               backgroundColor: "var(--dpf-success)",
-                              color: "white",
+                              color: "var(--dpf-on-accent, var(--dpf-surface-1))",
                             }}
                           >
                             Restore (clear quarantine)
@@ -887,7 +825,7 @@ export function EdgeNodesAdminClient({ nodes, tokens, customerAccounts }: Props)
                             className="rounded px-2 py-1 text-xs font-medium disabled:opacity-50"
                             style={{
                               backgroundColor: "var(--dpf-warning)",
-                              color: "white",
+                              color: "var(--dpf-on-accent, var(--dpf-surface-1))",
                             }}
                           >
                             Quarantine
@@ -901,7 +839,7 @@ export function EdgeNodesAdminClient({ nodes, tokens, customerAccounts }: Props)
                             className="rounded px-2 py-1 text-xs font-medium disabled:opacity-50"
                             style={{
                               backgroundColor: "var(--dpf-danger)",
-                              color: "white",
+                              color: "var(--dpf-on-accent, var(--dpf-surface-1))",
                             }}
                           >
                             Revoke

--- a/apps/web/components/ui/report-kit/statusColors.test.ts
+++ b/apps/web/components/ui/report-kit/statusColors.test.ts
@@ -61,6 +61,13 @@ describe("statusColors", () => {
     expect(resolveIntent("complaintStatus", "resolved")).toBe("success");
   });
 
+  it("keeps Edge health and trust as separate shared status domains", () => {
+    expect(resolveIntent("edgeHealth", "healthy")).toBe("success");
+    expect(resolveIntent("edgeHealth", "offline")).toBe("danger");
+    expect(resolveIntent("edgeTrust", "trusted")).toBe("success");
+    expect(resolveIntent("edgeTrust", "quarantined")).toBe("danger");
+  });
+
   it("maps owner decision impact tags through the shared intent registry", () => {
     expect(resolveIntent("ownerDecisionImpact", "money")).toBe("warning");
     expect(resolveIntent("ownerDecisionImpact", "public")).toBe("danger");

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -56,6 +56,23 @@ export function intentStyle(intent: Intent): IntentStyle {
  * (e.g. complaints) so each gets its own namespace.
  */
 export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
+  // Edge operational health and operator-governed trust are deliberately
+  // separate axes. Both Edge Nodes and Connections consume these semantics.
+  edgeHealth: {
+    "setup-required": "neutral",
+    starting: "info",
+    healthy: "success",
+    degraded: "warning",
+    offline: "danger",
+    quarantined: "danger",
+    revoked: "neutral",
+  },
+  edgeTrust: {
+    pending: "warning",
+    trusted: "success",
+    quarantined: "danger",
+    revoked: "neutral",
+  },
   // Restaurant table capacity state (BI-7C95A586). Tables & Capacity page,
   // Workspace chips, and public booking all resolve here — one registry.
   restaurantCapacity: {

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -10920,6 +10920,7 @@
       "anchors": [
         "use-this-doc-for",
         "what-an-edge-node-does",
+        "start-with-this-dpf-installation",
         "deployment-modes",
         "when-a-container-looks-like-it-works-but-doesnt",
         "adapters-and-what-they-discover",

--- a/apps/web/lib/edge-node/readiness.test.ts
+++ b/apps/web/lib/edge-node/readiness.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EDGE_HEARTBEAT_DEGRADED_AFTER_MS,
+  EDGE_HEARTBEAT_OFFLINE_AFTER_MS,
+  deriveEdgeNodeReadiness,
+  selectMainInstallationNode,
+  type EdgeReadinessNode,
+} from "./readiness";
+
+const NOW = new Date("2026-08-13T18:00:00.000Z");
+
+function node(overrides: Partial<EdgeReadinessNode> = {}): EdgeReadinessNode {
+  return {
+    id: "row-local",
+    nodeId: "edge_local",
+    platform: "darwin",
+    installMode: "native",
+    version: "1.2.3",
+    storedStatus: "active",
+    trustState: "trusted",
+    lastSeenAt: new Date(NOW.getTime() - 60_000),
+    enrolledAt: new Date(NOW.getTime() - 3_600_000),
+    customerAccountId: null,
+    customerSiteId: null,
+    installerManaged: true,
+    capabilities: [
+      {
+        capability: "federation.discovery",
+        mode: "enabled",
+        status: "healthy",
+        reportedAt: new Date(NOW.getTime() - 60_000),
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("deriveEdgeNodeReadiness", () => {
+  it("does not report a months-stale stored active row as healthy", () => {
+    const result = deriveEdgeNodeReadiness(
+      node({ lastSeenAt: new Date("2026-06-10T12:00:00.000Z") }),
+      { now: NOW, requiredCapabilities: ["federation.discovery"] },
+    );
+
+    expect(result.health).toBe("offline");
+    expect(result.heartbeatAgeMs).toBeGreaterThan(EDGE_HEARTBEAT_OFFLINE_AFTER_MS);
+    expect(result.nextAction).toBe("repair-service");
+    expect(result.checks.find((check) => check.key === "heartbeat")?.status).toBe("fail");
+  });
+
+  it("reports a fresh trusted node with healthy accepted discovery as healthy", () => {
+    const result = deriveEdgeNodeReadiness(node(), {
+      now: NOW,
+      requiredCapabilities: ["federation.discovery"],
+    });
+
+    expect(result.health).toBe("healthy");
+    expect(result.nextAction).toBe("none");
+    expect(result.checks.every((check) => check.status === "pass")).toBe(true);
+  });
+
+  it("keeps trust separate from health and asks for approval", () => {
+    const result = deriveEdgeNodeReadiness(node({ trustState: "pending" }), {
+      now: NOW,
+      requiredCapabilities: ["federation.discovery"],
+    });
+
+    expect(result.health).toBe("starting");
+    expect(result.trust).toBe("pending");
+    expect(result.nextAction).toBe("approve-node");
+    expect(result.checks.find((check) => check.key === "trust")?.status).toBe("waiting");
+  });
+
+  it("marks a heartbeat in the soft-fail window as degraded", () => {
+    const result = deriveEdgeNodeReadiness(
+      node({ lastSeenAt: new Date(NOW.getTime() - EDGE_HEARTBEAT_DEGRADED_AFTER_MS - 1) }),
+      { now: NOW, requiredCapabilities: ["federation.discovery"] },
+    );
+
+    expect(result.health).toBe("degraded");
+    expect(result.nextAction).toBe("investigate-node");
+  });
+
+  it("marks missing, disabled, failing, and stale required capability evidence as degraded", () => {
+    const cases: EdgeReadinessNode["capabilities"][] = [
+      [],
+      [{ capability: "federation.discovery", mode: "disabled", status: "healthy", reportedAt: NOW }],
+      [{ capability: "federation.discovery", mode: "enabled", status: "failing", reportedAt: NOW }],
+      [{
+        capability: "federation.discovery",
+        mode: "enabled",
+        status: "healthy",
+        reportedAt: new Date(NOW.getTime() - EDGE_HEARTBEAT_OFFLINE_AFTER_MS - 1),
+      }],
+    ];
+
+    for (const capabilities of cases) {
+      const result = deriveEdgeNodeReadiness(node({ capabilities }), {
+        now: NOW,
+        requiredCapabilities: ["federation.discovery"],
+      });
+      expect(result.health).toBe("degraded");
+      expect(result.nextAction).toBe("repair-capability");
+    }
+  });
+
+  it("gives quarantine and revocation precedence without calling either healthy", () => {
+    const quarantined = deriveEdgeNodeReadiness(node({ trustState: "quarantined" }), { now: NOW });
+    const revoked = deriveEdgeNodeReadiness(node({ trustState: "revoked" }), { now: NOW });
+
+    expect(quarantined.health).toBe("quarantined");
+    expect(quarantined.nextAction).toBe("review-quarantine");
+    expect(revoked.health).toBe("revoked");
+    expect(revoked.nextAction).toBe("replace-node");
+  });
+
+  it("returns setup-required when the enabled installation has no node", () => {
+    const result = deriveEdgeNodeReadiness(null, {
+      now: NOW,
+      edgeEnabled: true,
+      requiredCapabilities: ["federation.discovery"],
+    });
+
+    expect(result.health).toBe("setup-required");
+    expect(result.nextAction).toBe("repair-service");
+  });
+
+  it("returns an explicit activation action when Edge was not enabled", () => {
+    const result = deriveEdgeNodeReadiness(null, { now: NOW, edgeEnabled: false });
+
+    expect(result.health).toBe("setup-required");
+    expect(result.nextAction).toBe("activate-edge");
+  });
+});
+
+describe("selectMainInstallationNode", () => {
+  it("selects the single installer-managed node ahead of remote nodes", () => {
+    const result = selectMainInstallationNode([
+      node({ id: "remote", nodeId: "edge_remote", installerManaged: false, customerAccountId: "customer-1" }),
+      node(),
+    ]);
+
+    expect(result.status).toBe("found");
+    expect(result.node?.nodeId).toBe("edge_local");
+    expect(result.basis).toBe("installer-managed");
+  });
+
+  it("uses one unscoped legacy node only when it is unambiguous", () => {
+    const result = selectMainInstallationNode([node({ installerManaged: false })]);
+
+    expect(result.status).toBe("found");
+    expect(result.basis).toBe("legacy-unscoped");
+  });
+
+  it("refuses to guess between multiple installer-managed or legacy candidates", () => {
+    const managed = selectMainInstallationNode([
+      node({ id: "one", nodeId: "one" }),
+      node({ id: "two", nodeId: "two" }),
+    ]);
+    const legacy = selectMainInstallationNode([
+      node({ id: "one", nodeId: "one", installerManaged: false }),
+      node({ id: "two", nodeId: "two", installerManaged: false }),
+    ]);
+
+    expect(managed.status).toBe("ambiguous");
+    expect(legacy.status).toBe("ambiguous");
+  });
+
+  it("does not treat customer-scoped nodes as the main installation", () => {
+    const result = selectMainInstallationNode([
+      node({ installerManaged: false, customerAccountId: "customer-1", customerSiteId: "site-1" }),
+    ]);
+
+    expect(result.status).toBe("missing");
+  });
+});

--- a/apps/web/lib/edge-node/readiness.ts
+++ b/apps/web/lib/edge-node/readiness.ts
@@ -1,0 +1,265 @@
+export const EDGE_HEARTBEAT_DEGRADED_AFTER_MS = 3 * 60 * 1000;
+export const EDGE_HEARTBEAT_OFFLINE_AFTER_MS = 10 * 60 * 1000;
+
+export type EdgeHealth =
+  | "setup-required"
+  | "starting"
+  | "healthy"
+  | "degraded"
+  | "offline"
+  | "quarantined"
+  | "revoked";
+
+export type EdgeTrust = "pending" | "trusted" | "quarantined" | "revoked";
+
+export type EdgeReadinessNextAction =
+  | "activate-edge"
+  | "repair-service"
+  | "approve-node"
+  | "investigate-node"
+  | "repair-capability"
+  | "review-quarantine"
+  | "replace-node"
+  | "upgrade-node"
+  | "none";
+
+export type EdgeReadinessCheckStatus = "pass" | "warning" | "waiting" | "fail";
+
+export interface EdgeReadinessCapability {
+  capability: string;
+  mode: string;
+  status: string;
+  reportedAt: Date | string;
+}
+
+export interface EdgeReadinessNode {
+  id: string;
+  nodeId: string;
+  platform: string;
+  installMode: string;
+  version: string;
+  storedStatus: string;
+  trustState: string;
+  lastSeenAt: Date | string | null;
+  enrolledAt: Date | string | null;
+  customerAccountId: string | null;
+  customerSiteId: string | null;
+  installerManaged: boolean;
+  capabilities: EdgeReadinessCapability[];
+}
+
+export interface EdgeReadinessCheck {
+  key: "service" | "enrollment" | "trust" | "heartbeat" | "version" | `capability:${string}`;
+  label: string;
+  status: EdgeReadinessCheckStatus;
+  detail: string;
+}
+
+export interface EdgeNodeReadiness {
+  health: EdgeHealth;
+  trust: EdgeTrust | "unknown";
+  heartbeatAgeMs: number | null;
+  checks: EdgeReadinessCheck[];
+  nextAction: EdgeReadinessNextAction;
+}
+
+export interface DeriveEdgeReadinessOptions {
+  now?: Date;
+  edgeEnabled?: boolean;
+  requiredCapabilities?: string[];
+  currentVersion?: string | null;
+}
+
+function asDate(value: Date | string | null): Date | null {
+  if (value === null) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isFinite(date.getTime()) ? date : null;
+}
+
+function ageMs(value: Date | string | null, now: Date): number | null {
+  const date = asDate(value);
+  return date ? Math.max(0, now.getTime() - date.getTime()) : null;
+}
+
+function normalizeTrust(value: string): EdgeTrust | "unknown" {
+  return value === "pending" || value === "trusted" || value === "quarantined" || value === "revoked"
+    ? value
+    : "unknown";
+}
+
+function missingNodeReadiness(edgeEnabled: boolean): EdgeNodeReadiness {
+  return {
+    health: "setup-required",
+    trust: "unknown",
+    heartbeatAgeMs: null,
+    nextAction: edgeEnabled ? "repair-service" : "activate-edge",
+    checks: [
+      {
+        key: "service",
+        label: "Host service",
+        status: "fail",
+        detail: edgeEnabled
+          ? "Edge is enabled, but this installation has not enrolled a host service."
+          : "Edge has not been enabled for this installation.",
+      },
+    ],
+  };
+}
+
+export function deriveEdgeNodeReadiness(
+  node: EdgeReadinessNode | null,
+  options: DeriveEdgeReadinessOptions = {},
+): EdgeNodeReadiness {
+  const now = options.now ?? new Date();
+  if (!node) return missingNodeReadiness(options.edgeEnabled ?? false);
+
+  const trust = normalizeTrust(node.trustState);
+  const heartbeatAgeMs = ageMs(node.lastSeenAt, now);
+  const enrollmentAgeMs = ageMs(node.enrolledAt, now);
+  const checks: EdgeReadinessCheck[] = [
+    {
+      key: "service",
+      label: "Host service",
+      status: "pass",
+      detail: `${node.platform} / ${node.installMode} enrolled as ${node.nodeId}.`,
+    },
+    {
+      key: "enrollment",
+      label: "Enrollment",
+      status: node.enrolledAt ? "pass" : "warning",
+      detail: node.enrolledAt ? "The Authority recognizes this node." : "Enrollment time is missing on this legacy row.",
+    },
+    {
+      key: "trust",
+      label: "Trust",
+      status: trust === "trusted" ? "pass" : trust === "pending" ? "waiting" : "fail",
+      detail:
+        trust === "trusted"
+          ? "Submissions from this node are accepted."
+          : trust === "pending"
+            ? "This node is waiting for operator approval."
+            : trust === "quarantined"
+              ? "The node may heartbeat, but its submissions are blocked."
+              : trust === "revoked"
+                ? "This node's credentials have been revoked."
+                : "The node has an unrecognized trust state.",
+    },
+  ];
+
+  let heartbeatStatus: EdgeReadinessCheckStatus;
+  let heartbeatDetail: string;
+  if (heartbeatAgeMs === null) {
+    const recentlyEnrolled = enrollmentAgeMs !== null && enrollmentAgeMs <= EDGE_HEARTBEAT_OFFLINE_AFTER_MS;
+    heartbeatStatus = recentlyEnrolled ? "waiting" : "fail";
+    heartbeatDetail = recentlyEnrolled
+      ? "Waiting for the first heartbeat."
+      : "No heartbeat has been recorded.";
+  } else if (heartbeatAgeMs > EDGE_HEARTBEAT_OFFLINE_AFTER_MS) {
+    heartbeatStatus = "fail";
+    heartbeatDetail = "The host service has missed the offline threshold.";
+  } else if (heartbeatAgeMs > EDGE_HEARTBEAT_DEGRADED_AFTER_MS) {
+    heartbeatStatus = "warning";
+    heartbeatDetail = "The latest heartbeat is outside the healthy window.";
+  } else {
+    heartbeatStatus = "pass";
+    heartbeatDetail = "Heartbeat is current.";
+  }
+  checks.push({ key: "heartbeat", label: "Heartbeat", status: heartbeatStatus, detail: heartbeatDetail });
+
+  let versionProblem = false;
+  if (options.currentVersion) {
+    versionProblem = node.version !== options.currentVersion;
+    checks.push({
+      key: "version",
+      label: "Version",
+      status: versionProblem ? "warning" : "pass",
+      detail: versionProblem
+        ? `Node ${node.version} differs from the current installation ${options.currentVersion}.`
+        : `Node version ${node.version} matches this installation.`,
+    });
+  }
+
+  let capabilityProblem = false;
+  for (const required of options.requiredCapabilities ?? []) {
+    const capability = node.capabilities.find((row) => row.capability === required);
+    const reportAge = capability ? ageMs(capability.reportedAt, now) : null;
+    const accepted = capability?.mode === "enabled" || capability?.mode === "reporting-only";
+    const fresh = reportAge !== null && reportAge <= EDGE_HEARTBEAT_OFFLINE_AFTER_MS;
+    const healthy = capability?.status === "healthy";
+    const passed = Boolean(capability && accepted && fresh && healthy);
+    capabilityProblem ||= !passed;
+    checks.push({
+      key: `capability:${required}`,
+      label: required === "federation.discovery" ? "Nearby DPF discovery" : required,
+      status: passed ? "pass" : capability?.status === "unknown" ? "waiting" : "fail",
+      detail: !capability
+        ? "The node has not registered this required capability."
+        : !accepted
+          ? "The Authority has not enabled this capability."
+          : !fresh
+            ? "The capability health report is stale."
+            : !healthy
+              ? `The node reports ${capability.status}.`
+              : "Capability is enabled and healthy.",
+    });
+  }
+
+  if (trust === "revoked") {
+    return { health: "revoked", trust, heartbeatAgeMs, checks, nextAction: "replace-node" };
+  }
+  if (trust === "quarantined") {
+    return { health: "quarantined", trust, heartbeatAgeMs, checks, nextAction: "review-quarantine" };
+  }
+  if (heartbeatStatus === "fail") {
+    return { health: "offline", trust, heartbeatAgeMs, checks, nextAction: "repair-service" };
+  }
+  if (trust === "pending") {
+    return { health: "starting", trust, heartbeatAgeMs, checks, nextAction: "approve-node" };
+  }
+  if (capabilityProblem) {
+    return { health: "degraded", trust, heartbeatAgeMs, checks, nextAction: "repair-capability" };
+  }
+  if (versionProblem) {
+    return { health: "degraded", trust, heartbeatAgeMs, checks, nextAction: "upgrade-node" };
+  }
+  if (heartbeatStatus === "warning" || trust === "unknown") {
+    return { health: "degraded", trust, heartbeatAgeMs, checks, nextAction: "investigate-node" };
+  }
+  if (heartbeatStatus === "waiting") {
+    return { health: "starting", trust, heartbeatAgeMs, checks, nextAction: "investigate-node" };
+  }
+  return { health: "healthy", trust, heartbeatAgeMs, checks, nextAction: "none" };
+}
+
+export interface MainInstallationNodeSelection {
+  status: "found" | "missing" | "ambiguous";
+  basis: "installer-managed" | "legacy-unscoped" | "none";
+  node: EdgeReadinessNode | null;
+  candidateNodeIds: string[];
+}
+
+function selection(
+  candidates: EdgeReadinessNode[],
+  basis: MainInstallationNodeSelection["basis"],
+): MainInstallationNodeSelection {
+  if (candidates.length === 1) {
+    return { status: "found", basis, node: candidates[0] ?? null, candidateNodeIds: candidates.map((node) => node.nodeId) };
+  }
+  if (candidates.length > 1) {
+    return { status: "ambiguous", basis, node: null, candidateNodeIds: candidates.map((node) => node.nodeId) };
+  }
+  return { status: "missing", basis: "none", node: null, candidateNodeIds: [] };
+}
+
+export function selectMainInstallationNode(nodes: EdgeReadinessNode[]): MainInstallationNodeSelection {
+  const installerManaged = nodes.filter((node) => node.installerManaged && node.trustState !== "revoked");
+  if (installerManaged.length > 0) return selection(installerManaged, "installer-managed");
+
+  const legacyUnscoped = nodes.filter(
+    (node) =>
+      node.customerAccountId === null &&
+      node.customerSiteId === null &&
+      node.trustState !== "revoked",
+  );
+  return selection(legacyUnscoped, "legacy-unscoped");
+}

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1620,15 +1620,15 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n    - strong\n      - text\n    - text\n    - strong\n      - text\n    - text\n    - code\n      - text\n    - text\n  - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/platform/edge-nodes": {
-      "defaultVisibleWords": 235,
+      "defaultVisibleWords": 159,
       "leadBandWords": 0,
       "primaryActions": 1,
-      "visibleFields": 5,
-      "maxChoicesPerControl": 3,
+      "visibleFields": 0,
+      "maxChoicesPerControl": 0,
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - heading [level=2]\n  - paragraph\n    - text\n    - strong\n      - text\n    - text\n  - text\n  - combobox\n    - option [selected]\n    - option\n  - text\n  - textbox\n  - text\n  - spinbutton\n  - text\n  - combobox\n    - option [selected]\n  - text\n  - combobox [disabled]\n    - option [selected]\n  - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - link\n  - paragraph\n    - text\n  - heading [level=2]\n  - text\n  - paragraph\n    - text\n  - text\n  - group\n    - button\n    - paragraph\n      - text\n    - text\n    - combobox\n      - option [selected]\n      - option\n    - text\n    - textbox\n    - text\n    - spinbutton\n    - text\n    - combobox\n      - option [selected]\n    - text\n    - combobox [disabled]\n      - option [selected]\n    - button\n  - heading [level=2]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text"
     },
     "/platform/federation-links": {
       "defaultVisibleWords": 335,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,6 +196,10 @@ services:
       DPF_HOST_INSTALL_PATH: ${DPF_HOST_INSTALL_PATH:-}
       DPF_HOST_PLATFORM: ${DPF_HOST_PLATFORM:-}
       DPF_HOST_ARCH: ${DPF_HOST_ARCH:-}
+      # Authoritative installer opt-in state for the main installation's
+      # supervised host Edge service. The portal combines this intent with
+      # live enrollment/heartbeat evidence; it never treats the flag as health.
+      DPF_EDGE_ENABLED: ${DPF_INCLUDE_EDGE:-0}
       DPF_STATE_DIR_HOST: ${DPF_STATE_DIR:-${HOME}/.dpf}
       DPF_RUNTIME_TRANSITION_SECRET_FILE_HOST: ${DPF_STATE_DIR:-${HOME}/.dpf}/runtime-transition.secret
       # Portal-side live-readiness checks run inside the container, where

--- a/docs/edge-node/fleet-operations.md
+++ b/docs/edge-node/fleet-operations.md
@@ -19,18 +19,14 @@ into a bottleneck or the edge into a second management platform.
 
 ## Node operational lifecycle
 
-A node's *operational* lifecycle is wider than its trust state:
+The portal keeps health and trust as independent axes:
 
-```
-created → pending → trusted → degraded → quarantined → revoked → retired
-```
+- **Health:** `setup-required`, `starting`, `healthy`, `degraded`, `offline`, `quarantined`, or `revoked`. Health is derived server-side from heartbeat age, capability reports, version compatibility, and trust; a stale stored `active` value never wins.
+- **Trust:** `pending`, `trusted`, `quarantined`, or `revoked`. These are durable, operator-governed `EdgeNode.trustState` values.
 
-- **pending / trusted / quarantined / revoked** are real `EdgeNode.trustState` values — operator-driven.
-- **degraded** is a health/observability concept (not a DB trust value): a node that is *trusted*
-  yet behind on version, missing a capability, failing a collector, over its cardinality budget, or
-  running on stale policy. Surface it on the fleet view; act on it before it becomes an incident.
-- **created → retired** bracket the row: a decommissioned node is revoked, then its row retained
-  for audit (its evidence stays scoped) or archived per retention policy.
+That distinction matters: a trusted node may be offline, and a quarantined node may still heartbeat. The Authority retains revoked rows and their scoped evidence for audit.
+
+The first fleet member is **This DPF installation**. Installer-issued auto-approval is its identity evidence. On Windows and macOS, every governed install/repair stages the verified native artifact, converges Task Scheduler/launchd supervision, restores the prior binary if restart fails, and reuses the existing machine enrollment. Remote MSP/customer nodes remain separately scoped by customer and site; each fleet row names its first failed readiness check and next action.
 
 ## Rollout (adding nodes at scale)
 

--- a/docs/superpowers/plans/2026-08-13-main-instance-edge-lifecycle-and-fleet-visibility.md
+++ b/docs/superpowers/plans/2026-08-13-main-instance-edge-lifecycle-and-fleet-visibility.md
@@ -1,0 +1,165 @@
+# Main-instance Edge lifecycle and fleet visibility implementation plan
+
+**Backlog item:** BI-6CE3D92B  
+**Epic:** EP-DELIVERY-FLOW  
+**Decision ledger:** DI-675613EFAC5D (`atomic-foundation`, high confidence)  
+**Delivery shape:** one atomic BI, one branch, one PR
+
+> **For agentic workers:** execute this plan as one independently reviewable backlog item. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the completion gate below before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Outcome
+
+Make the Edge Node supporting the current DPF installation understandable and trustworthy before extending the same model into the MSP fleet cockpit. The operator should see whether the local host component is installed, supervised, enrolled, trusted, fresh, compatible, and capable of federation discovery; failures should identify the next governed repair action without asking the operator to run commands.
+
+This work supports backlog federation but does not couple backlog synchronization to Edge availability. Federation remains the transport and reconciliation path after pairing; the local Edge Node supplies discovery, readiness evidence, and operational visibility.
+
+## Existing substrate to extend
+
+- `EdgeNode`, `EdgeNodeCapability`, and `BootstrapToken` remain the only durable node, capability, and enrollment records (`packages/db/prisma/schema.prisma`). No new fleet registry is introduced.
+- `/platform/edge-nodes` remains the administrative route, composed from `apps/web/app/(shell)/platform/edge-nodes/page.tsx` and `apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx`.
+- `install-state.json.edge`, `Resolve-DpfEdgeEnabled`, `Install-DPFNativeEdgeNode`, and `dpf_native_edge_install` remain the install/upgrade authority. The portal does not become a second host-service manager.
+- The Go Edge runtime remains the heartbeat and `federation.discovery` capability source.
+- The federation Connections page remains the pairing surface; it links to Edge readiness instead of reimplementing Edge diagnosis.
+- Existing deployment, fleet, security, and customer/site scope contracts remain binding:
+  - `docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md`
+  - `docs/superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md`
+  - `docs/superpowers/specs/2026-06-24-managed-services-delivery-and-cross-org-federation-design.md`
+  - `docs/edge-node/fleet-operations.md`
+
+## Internal implementation phases
+
+These phases are sequencing inside one atomic delivery. None is independently releasable: lifecycle convergence without truthful visibility repeats the current mystery, while a readiness UI without converged host behavior is knowingly misleading.
+
+### Phase 1 — Define server-owned current health
+
+Create a pure Edge lifecycle/readiness projection under `apps/web/lib/edge-node/` and begin with failing tests.
+
+The projection must:
+
+- derive `setup-required`, `starting`, `healthy`, `degraded`, `offline`, `quarantined`, and `revoked` from current time, `lastSeenAt`, trust, accepted capability rows, version posture, installation mode, and local-host identity evidence;
+- keep trust and health as separate axes;
+- define explicit freshness thresholds in one named contract rather than interpreting raw `status` in components;
+- make missing or stale capability evidence visible;
+- return failed checks and a stable next-action key suitable for both the Edge and Connections pages;
+- tolerate legacy rows with incomplete metadata without treating them as healthy.
+
+Verification:
+
+- focused Vitest cases for heartbeat boundaries, stale stored `active`, pending enrollment, trust transitions, capability degradation, legacy rows, and local-host selection;
+- typecheck through the web production build.
+
+### Phase 2 — Identify “This DPF installation” without a parallel identity store
+
+Extend the server page query/projection to select the current installation's node using existing host/install identity and Edge metadata. Where legacy data is ambiguous, report `setup-required` or `degraded`; do not guess by display name.
+
+The first viewport must show:
+
+- one local installation card when identity is proven;
+- a setup-required card when Edge is enabled/needed but no local node can be proven;
+- the readiness checks for service supervision, enrollment, trust, heartbeat freshness, supported version, and `federation.discovery`;
+- a plain-language explanation that the local Edge component discovers nearby installations but backlog synchronization continues through Federation after pairing.
+
+Verification:
+
+- page/projection tests for zero, one, stale, and ambiguous local candidates;
+- no direct host filesystem reads from the portal container are treated as proof of a host service.
+
+### Phase 3 — Converge the opted-in host-native lifecycle
+
+Preserve the existing consent boundary: Edge remains governed by the recorded `install-state.json.edge.enabled` choice or an explicit platform activation. Do not silently enable network discovery on installations that opted out.
+
+For an enabled installation:
+
+- make fresh install and governed self-upgrade idempotently install or refresh the checksum-bound native Edge artifact on Windows/macOS;
+- preserve enrollment state and avoid minting a replacement identity on every upgrade;
+- converge Windows Scheduled Task / firewall state and macOS launchd state;
+- restart the native service after artifact/config changes and retain the prior known-good artifact for rollback;
+- stop or disable an obsolete Docker Desktop Edge container so it cannot masquerade as LAN truth;
+- record a machine-readable install outcome that the portal/readiness projection can correlate with heartbeat evidence;
+- fail visibly without making the portal unavailable.
+
+This phase absorbs the implementation and physical acceptance of BI-0C326236.
+
+Verification:
+
+- extend `scripts/installer/native-edge-host-contract.test.mjs` and Windows installer tests;
+- cover fresh, already-current, missing-service, stale-binary, and failed-start paths;
+- verify self-upgrade sensitive-path coverage and rollback behavior;
+- apply against physical Windows and macOS hosts through the governed install/self-upgrade path.
+
+### Phase 4 — Turn the registry into an understandable fleet view
+
+Refactor `EdgeNodesAdminClient` using existing shared UI/report primitives:
+
+- local installation readiness first;
+- fleet summary based on derived current health, never raw stored `status` counts;
+- clear separation of Health and Trust;
+- customer → site → node grouping when scope exists, with unscoped nodes explicit;
+- last heartbeat expressed as age plus timestamp;
+- version, runtime mode, accepted capabilities, failed readiness check, and one next action visible without opening raw metadata;
+- pending approval, quarantine, and revoke actions retained with their existing authority gates;
+- remote enrollment moved behind an “Add remote node” workflow so raw token issuance is advanced detail rather than the page's primary job.
+
+Verification:
+
+- component tests for multiple customers/sites, mixed health/trust states, stale nodes, empty state, and accessible action labels;
+- light/dark theme verification with only `--dpf-*` tokens;
+- first viewport answers “is this installation's Edge working?” and “which nodes need attention?”
+
+### Phase 5 — Connect federation diagnosis and update documentation
+
+- Change Connections' `Not set up` state to consume the shared readiness projection/action contract and link directly to the local Edge readiness card.
+- Keep the two concepts explicit: Edge discovers nearby DPF installations; Federation owns trust, pairing, and backlog exchange.
+- Update `docs/user-guide/platform/edge-nodes.md`, `docs/edge-node/fleet-operations.md`, Windows/macOS install guidance, and the platform-support watchlist if a new host-specific defect is fixed.
+- Explain managed-estate Edge Nodes versus sovereign DPF peers and reserve the MSP customer-health cockpit for the later archetype-specific slice.
+
+Verification:
+
+- focused Connections tests for healthy, setup-required, degraded, and offline discovery states;
+- live happy-path verification from Edge readiness to Connections and back;
+- confirm an established federation link continues synchronizing while local discovery is intentionally stopped.
+
+## Completion gate
+
+1. All affected Vitest and installer contract tests pass from this worktree.
+2. `pnpm --filter web build` passes with zero errors.
+3. The exact merged-code candidate passes the governed local-integration-CI gate.
+4. UI behavior is exercised against the leased shared nonproduction runtime in light and dark themes.
+5. Physical Windows and macOS verification proves install, restart, self-upgrade persistence, heartbeat freshness, and nearby discovery.
+6. Existing paired backlog synchronization is verified to remain operational independently of discovery availability.
+7. Documentation impact is complete and both BI-6CE3D92B and BI-0C326236 receive canonical evidence before status changes.
+
+## UX fit review
+
+- **Decision:** fits-with-guardrails; `DI-0E22008385C8` selected `readiness-first-progressive-disclosure` with high confidence (composite 9.296, margin 4.872, no commandment conflict).
+- **Owning area / route family:** Platform; `/platform/edge-nodes` is canonical and `/platform/federation-links` is the contextual next step. No new dashboard or global navigation entry.
+- **Primary persona:** founder/platform operator first, with the same fleet vocabulary extending to the MSP operator later. The first viewport answers whether this installation is ready without requiring service, token, or container knowledge.
+- **Navigation layer:** contextual action only (`Open Connections`); existing section navigation remains unchanged.
+- **Reuse and source truth:** `StatusBadge` plus shared `edgeHealth`/`edgeTrust` intent domains; server projection from `EdgeNode`, `EdgeNodeCapability`, `BootstrapToken`, heartbeat time, and platform version. No second registry or health store.
+- **Empty/failure behavior:** setup-required, ambiguous, stale, offline, quarantined, and revoked states name the failed check. Remote enrollment remains available behind disclosure.
+- **AI boundary:** no coworker prompt or automated trust decision.
+- **Evidence before merge:** focused component/projection tests, production build, style/prose/UX-fit gates, browser verification in the shared nonproduction runtime, and physical macOS/Windows lifecycle evidence.
+- **Captured in:** `docs/ux-fit/2026-08-13-edge-fleet-readiness.ux-fit.json`.
+
+## Risks and rollback
+
+- **Consent regression:** automatically enabling collectors could scan a network without approval. Preserve the recorded Edge-enabled gate and make activation explicit.
+- **Identity duplication:** reissuing bootstrap material can create a second node for the same host. Reuse enrolled state and fail closed when local identity is ambiguous.
+- **False health:** combining trust with liveness recreates the current defect. Keep the axes separate and derive health at read time from freshness and capability evidence.
+- **Upgrade disruption:** host service mutation can fail while the portal is healthy. Treat Edge convergence as bounded/nonfatal, retain the previous artifact, and expose the failure.
+- **Platform-specific drift:** Windows Task Scheduler and macOS launchd need contract and physical verification; record new watchlist rows for newly discovered host differences.
+- **Federation coupling:** discovery failure must not disable an established link. Regression-test synchronization with discovery stopped.
+
+Rollback is a normal PR revert plus governed self-upgrade to the previous canonical image/artifact. Existing Edge rows and enrollment evidence remain retained; no destructive migration or node-row deletion is part of this delivery.
+
+## Backlog coverage
+
+Coverage is recorded as **atomic** because the health projection, host convergence, operator readiness surface, and federation diagnosis form one truth contract and are misleading if released independently. The MCP coverage receipt is added here immediately after it is issued.
+
+- Decision: atomic
+- Parent: `BI-6CE3D92B`
+- Receipt: `cmss3wvbb00lh01qe7i60i2bx`
+- Dependencies: none
+- Rationale: The health projection, native-host convergence, readiness UX, and federation diagnosis are misleading unless they ship as one truth contract.
+- Internal dependency order: current health contract → host lifecycle convergence → fleet readiness UX → federation diagnosis and physical evidence
+- Existing overlapping defect: `BI-0C326236` is closed by this delivery's Windows acceptance evidence; it is not a separate successor.

--- a/docs/user-guide/platform/edge-nodes.md
+++ b/docs/user-guide/platform/edge-nodes.md
@@ -16,6 +16,25 @@ order: 6
 
 An Edge Node is the host-resident trust and discovery component. It enrolls with the platform's Authority Core, heartbeats freshness, runs local collectors against the network it can reach, and submits results as governed evidence. Two surfaces matter to an operator: **enrollment / trust state** (managed in the portal) and **what the node can see from where it runs** (decided by the deployment mode below).
 
+## Start With This DPF Installation
+
+The first card on **Platform > Edge Nodes** answers whether the host component belonging to the current DPF installation is ready. It is intentionally separate from remote or customer nodes. The installer-issued enrollment identifies that node; hostnames and stored `active` labels do not.
+
+The card checks the supervised service, enrollment, trust, heartbeat freshness, platform version, and nearby-DPF discovery capability. Its health states mean:
+
+| Health | Meaning | Operator response |
+| --- | --- | --- |
+| **Setup required** | Edge was not enabled, or no local supervised service is enrolled. | Use the governed install or repair workflow with Edge enabled. |
+| **Starting** | Enrollment or the first heartbeat/approval is still completing. | Wait briefly, then review the named waiting check. |
+| **Healthy** | Trust, heartbeat, version, and required capabilities are current. | No action. |
+| **Degraded** | The node is reachable but a version, capability, or freshness check needs attention. | Follow the failed check; open **Connections** for nearby discovery. |
+| **Offline** | No heartbeat arrived inside the offline window. | Use the governed repair/self-upgrade workflow; do not trust recent discovery as current. |
+| **Quarantined / Revoked** | Trust policy intentionally blocks or permanently retires the node. | Review the recorded trust decision before restoring or replacing it. |
+
+Health and trust are different axes. A node can be trusted yet offline, or alive yet quarantined. The fleet table therefore shows both columns, plus the first failed readiness check and its next action, and derives health from live evidence rather than `EdgeNode.status` alone.
+
+Once Edge is enabled, each governed install or self-upgrade refreshes the checksum-bound native binary and its supervisor while preserving the enrolled machine identity. Replacement bytes are staged before the service stops, and a failed restart restores the prior binary. A platform version change does not issue a new bootstrap token.
+
 ## Deployment Modes
 
 The Edge Node ships in two runtimes. Pick the one that matches the host substrate — the installer auto-selects based on platform detection, and the choice can be overridden with `--mode=native|container|macvlan`.
@@ -62,7 +81,7 @@ What is **not** in place yet: the detector framework on the edge (Slice 1 of the
 
 ## Workflow
 
-1. Start from `/platform/edge-nodes` and confirm which nodes are enrolled, pending trust, stale, or rejected.
+1. Start from `/platform/edge-nodes` and confirm **This DPF installation** is healthy before relying on nearby discovery or the wider fleet.
 2. Approve trust only when the node identity, host, network placement, and intended collector scope are understood. Trust is one-way — once approved, the node's submissions become platform evidence.
 3. Review heartbeat and freshness before treating a discovery run as current. A stale heartbeat means the run is stale, regardless of how recent the row looks.
 4. For the host-level setup, follow the runbooks under `docs/install/`:

--- a/docs/ux-fit/2026-08-13-edge-fleet-readiness.ux-fit.json
+++ b/docs/ux-fit/2026-08-13-edge-fleet-readiness.ux-fit.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "decidedOption": "readiness-first-progressive-disclosure",
+  "decisionInteractionId": "DI-0E22008385C8",
+  "scope": {
+    "files": [
+      "apps/web/components/platform/edge-nodes/EdgeFleetReadiness.tsx",
+      "apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "readiness-first-progressive-disclosure",
+      "registry-first-technical-form",
+      "new-edge-dashboard"
+    ]
+  }
+}

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -654,14 +654,14 @@ function Set-DPFEnvFileValue {
     Set-Content -Path $Path -Value $envText -Encoding UTF8 -NoNewline
 }
 
-function Invoke-DPFEdgeNodeBootstrap {
+function Invoke-DPFEdgeNodeConvergence {
     param([Parameter(Mandatory)][string]$InstallDir)
 
     $edgeModule = Resolve-DPFNativeEdgeModulePath -InstallDir $InstallDir
     . $edgeModule
     $edgeComposeArgs = Get-DPFComposeArgs -InstallDir $InstallDir -IncludeEdge:$false
 
-    Write-Action "Bootstrapping bundled Edge Node..."
+    Write-Action "Converging this installation's Edge Node..."
     $portalReady = $false
     for ($i = 0; $i -lt 60; $i++) {
         try {
@@ -680,30 +680,38 @@ function Invoke-DPFEdgeNodeBootstrap {
         $portalContainer = "dpf-portal-1"
     }
 
-    $edgeToken = $null
-    try {
-        $tokenOutput = docker exec $portalContainer sh -c 'cd /app/apps/web-src && /app/node_modules/.pnpm/node_modules/.bin/tsx scripts/issue-edge-bootstrap-token.ts --ttl-minutes 30 --auto-approve' 2>$null
-        if ($LASTEXITCODE -eq 0 -and $tokenOutput) {
-            $lines = @($tokenOutput) | ForEach-Object { $_.ToString().Trim() } | Where-Object { $_ -ne "" }
-            $candidate = if ($lines.Count -gt 0) { $lines[-1] } else { "" }
-            if ($candidate -match "^dpfboot_") {
-                $edgeToken = $candidate
+    $stateRoot = if ($env:DPF_STATE_DIR) { $env:DPF_STATE_DIR } else { Join-Path $env:USERPROFILE ".dpf" }
+    $existingEnrollment = Test-Path -LiteralPath (Join-Path $stateRoot "edge-node\state.json")
+    $edgeToken = ""
+    if (-not $existingEnrollment) {
+        try {
+            $tokenOutput = docker exec $portalContainer sh -c 'cd /app/apps/web-src && /app/node_modules/.pnpm/node_modules/.bin/tsx scripts/issue-edge-bootstrap-token.ts --ttl-minutes 30 --auto-approve' 2>$null
+            if ($LASTEXITCODE -eq 0 -and $tokenOutput) {
+                $lines = @($tokenOutput) | ForEach-Object { $_.ToString().Trim() } | Where-Object { $_ -ne "" }
+                $candidate = if ($lines.Count -gt 0) { $lines[-1] } else { "" }
+                if ($candidate -match "^dpfboot_") {
+                    $edgeToken = $candidate
+                }
             }
+        } catch {
+            $edgeToken = ""
         }
-    } catch {
-        $edgeToken = $null
+
+        if (-not $edgeToken) {
+            Write-Warn "Bootstrap token issuance failed. Skipping Edge Node enrollment wiring."
+            Write-Warn "Use the portal Edge Nodes page to issue a token if you need to enroll this node manually."
+            return $false
+        }
     }
 
-    if (-not $edgeToken) {
-        Write-Warn "Bootstrap token issuance failed. Skipping Edge Node enrollment wiring."
-        Write-Warn "Use the portal Edge Nodes page to issue a token if you need to enroll this node manually."
-        return $false
+    if ($edgeToken) {
+        $envPath = Join-Path $InstallDir ".env"
+        Set-DPFEnvFileValue -Path $envPath -Key "DPF_BOOTSTRAP_TOKEN" -Value $edgeToken
+        Set-DPFEnvFileValue -Path $envPath -Key "DPF_EDGE_NODE_NAME" -Value ([System.Net.Dns]::GetHostName())
+        Write-OK "Bootstrap token wired into .env (auto-approve)"
+    } else {
+        Write-OK "Existing Edge enrollment found; preserving its machine identity"
     }
-
-    $envPath = Join-Path $InstallDir ".env"
-    Set-DPFEnvFileValue -Path $envPath -Key "DPF_BOOTSTRAP_TOKEN" -Value $edgeToken
-    Set-DPFEnvFileValue -Path $envPath -Key "DPF_EDGE_NODE_NAME" -Value ([System.Net.Dns]::GetHostName())
-    Write-OK "Bootstrap token wired into .env (auto-approve)"
     if (Install-DPFNativeEdgeNode -InstallDir $InstallDir -BootstrapToken $edgeToken -Version $Version) {
         $legacyComposeArgs = Get-DPFComposeArgs -InstallDir $InstallDir -IncludeEdge:$true
         docker compose @legacyComposeArgs stop edge-node 2>&1 | Out-Null
@@ -1620,6 +1628,11 @@ if (-not (Test-StepDone "started")) {
     $stateLib = Join-Path $DPF_DIR "scripts\installer\lib\state.ps1"
     if (-not (Test-Path -LiteralPath $stateLib)) { throw "capability_state_helper_missing" }
     . $stateLib
+    if ($WithEdge) { $env:DPF_INCLUDE_EDGE = '1' }
+    elseif ($NoEdge) { $env:DPF_INCLUDE_EDGE = '0' }
+    $resolvedEdgeEnabled = Resolve-DpfEdgeEnabled -InstallDir $DPF_DIR
+    $env:DPF_INCLUDE_EDGE = if ($resolvedEdgeEnabled) { '1' } else { '0' }
+    Set-DpfStateValue -Key "edge" -Value @{ enabled = $resolvedEdgeEnabled; mode = $(if ($resolvedEdgeEnabled) { "local" } else { $null }) }
     $capabilityProjection = Resolve-DpfCapabilityComposeProfiles -InstallDir $DPF_DIR
     $env:COMPOSE_PROFILES = (@($capabilityProjection.composeProfiles) -join ',')
     $coreComposeArgs = Get-DPFComposeArgs -InstallDir $DPF_DIR -IncludeEdge:$false -IncludeRelease:($InstallMode -eq "consumer")
@@ -1849,25 +1862,21 @@ if (-not (Test-StepDone "mcp_seed")) {
     Write-OK "Already running"
 }
 
-# Edge Node deploy gate (opt-in; BI-72CFF89D / edge-topology design section 5).
-# A local Edge Node is bundled + auto-enrolled ONLY when -WithEdge is passed
-# (or a prior install already enabled it -- .env carries the bootstrap token);
-# -NoEdge forces it off. Default OFF. Map a network from a different machine
-# instead via Admin > Platform Development > Edge Nodes.
-$dpfEdgeOptIn = $false
-if ($WithEdge) {
-    $dpfEdgeOptIn = $true
-} elseif (-not $NoEdge) {
-    $dpfEnvPath = Join-Path $DPF_DIR ".env"
-    if ((Test-Path -LiteralPath $dpfEnvPath) -and (Select-String -Path $dpfEnvPath -Pattern '^DPF_BOOTSTRAP_TOKEN=dpf' -Quiet)) {
-        $dpfEdgeOptIn = $true
-    }
-}
-if ($dpfEdgeOptIn -and (-not (Test-StepDone "edge_bootstrap"))) {
-    if (Invoke-DPFEdgeNodeBootstrap -InstallDir $DPF_DIR) {
+# Edge is an explicit, persistent capability choice. Once enabled, every
+# governed install/repair converges the native service and verified binary;
+# the progress marker is evidence of a past success, not a skip condition.
+$edgeStateLib = Join-Path $DPF_DIR "scripts\installer\lib\state.ps1"
+if (-not (Test-Path -LiteralPath $edgeStateLib)) { throw "capability_state_helper_missing" }
+. $edgeStateLib
+if ($WithEdge) { $env:DPF_INCLUDE_EDGE = '1' }
+elseif ($NoEdge) { $env:DPF_INCLUDE_EDGE = '0' }
+$dpfEdgeOptIn = Resolve-DpfEdgeEnabled -InstallDir $DPF_DIR
+Set-DpfStateValue -Key "edge" -Value @{ enabled = $dpfEdgeOptIn; mode = $(if ($dpfEdgeOptIn) { "local" } else { $null }) }
+if ($dpfEdgeOptIn) {
+    if (Invoke-DPFEdgeNodeConvergence -InstallDir $DPF_DIR) {
         Save-Progress "edge_bootstrap"
     } else {
-        Write-Warn "Bundled Edge Node bootstrap did not complete. The portal remains usable."
+        Write-Warn "Bundled Edge Node convergence did not complete. The portal remains usable."
     }
 } elseif (-not $dpfEdgeOptIn) {
     Write-OK "Edge Node not bundled (opt-in). Re-run with -WithEdge to add a local node, or add a node on another machine from Admin > Platform Development > Edge Nodes."

--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -987,8 +987,33 @@ fi
 #     Per spec § Approval policy: tokens issued by the local installer
 #     auto-approve at enrollment, so the operator doesn't have to click
 #     Approve in Admin > Platform Development for the host's own node.
+dpf_native_edge_converge() {
+  local token="${1:-}"
+  if [ "$(uname -s 2>/dev/null || true)" = "Darwin" ]; then
+    dpf_native_edge_install "$REPO_ROOT" "$token" "${HOSTNAME:-$(hostname -s 2>/dev/null || echo dpf-macos)}"
+  else
+    docker compose "${DPF_COMPOSE_FILES[@]}" up -d --no-deps --force-recreate edge-node >/dev/null 2>&1
+  fi
+}
+
 if [ "$DPF_INCLUDE_EDGE" = "1" ]; then
-  step "Edge Node bootstrap"
+  step "Edge Node convergence"
+
+  # Machine identity lives in the protected native state directory. Once it
+  # exists, upgrades reuse it and never mint another one-time enrollment token.
+  # A missing state file is the only condition that enters bootstrap issuance.
+  EDGE_NATIVE_STATE="${DPF_STATE_DIR:-$HOME/.dpf}/edge-node/state.json"
+  if [ "$(uname -s 2>/dev/null || true)" = "Darwin" ] && [ -f "$EDGE_NATIVE_STATE" ]; then
+    if dpf_native_edge_converge ""; then
+      if [ -f "$REPO_ROOT/docker-compose.edge.yml" ]; then
+        docker compose -f docker-compose.yml -f docker-compose.edge.yml stop edge-node >/dev/null 2>&1 || true
+      fi
+      ok "Native Edge Node converged; existing machine identity preserved"
+      info "  Check this installation's readiness in Platform > Edge Nodes."
+    else
+      warn "Native Edge Node convergence failed; the portal remains healthy."
+    fi
+  else
 
   # Mint a single-use auto-approve token. The script connects to
   # DATABASE_URL=postgresql://...@postgres:5432/dpf, which is only
@@ -1040,7 +1065,7 @@ if [ "$DPF_INCLUDE_EDGE" = "1" ]; then
       # Linux VM. Install the Go Edge Node as a supervised host process there;
       # Linux retains the container runtime.
       if [ "$(uname -s 2>/dev/null || true)" = "Darwin" ]; then
-        if dpf_native_edge_install "$REPO_ROOT" "$EDGE_TOKEN" "${HOSTNAME:-$(hostname -s 2>/dev/null || echo dpf-macos)}"; then
+        if dpf_native_edge_converge "$EDGE_TOKEN"; then
           if [ -f "$REPO_ROOT/docker-compose.edge.yml" ]; then
             docker compose -f docker-compose.yml -f docker-compose.edge.yml stop edge-node >/dev/null 2>&1 || true
           fi
@@ -1049,7 +1074,7 @@ if [ "$DPF_INCLUDE_EDGE" = "1" ]; then
         else
           warn "Native Edge Node installation failed; the portal remains healthy."
         fi
-      elif docker compose "${DPF_COMPOSE_FILES[@]}" up -d --no-deps --force-recreate edge-node >/dev/null 2>&1; then
+      elif dpf_native_edge_converge "$EDGE_TOKEN"; then
         ok "Edge Node bootstrapped — auto-approve token wired into .env"
         info "  The node enrolls within ~10s; check Admin > Platform Development > Edge Nodes."
       else
@@ -1068,6 +1093,7 @@ if [ "$DPF_INCLUDE_EDGE" = "1" ]; then
   # exhausted.
   if [ -n "${EDGE_TOKEN:-}" ] && [[ "$EDGE_TOKEN" == dpfboot_* ]]; then
     rm -f "$EDGE_TOKEN_LOG" 2>/dev/null || true
+  fi
   fi
 else
   info "Edge Node not bundled (opt-in; pass --with-edge to add a local node). Map a network from another machine via Admin > Platform Development > Edge Nodes (docker-compose.edge-standalone.yml)."

--- a/scripts/installer/native-edge-host-contract.test.mjs
+++ b/scripts/installer/native-edge-host-contract.test.mjs
@@ -70,6 +70,53 @@ test("Docker Desktop installers retire the legacy container after native host in
   assert.match(windowsInstaller, /stop\s+edge-node/);
 });
 
+test("opted-in native Edge services converge on every governed install instead of a one-time progress marker", async () => {
+  const shellInstaller = await read("install-dpf.sh");
+  const windowsInstaller = await read("install-dpf.ps1");
+
+  assert.match(shellInstaller, /dpf_native_edge_converge/);
+  assert.match(shellInstaller, /edge-node\/state\.json/);
+  assert.match(windowsInstaller, /Invoke-DPFEdgeNodeConvergence/);
+  assert.match(windowsInstaller, /Resolve-DpfEdgeEnabled/);
+  assert.doesNotMatch(windowsInstaller, /\$dpfEdgeOptIn\s+-and\s+\(-not \(Test-StepDone "edge_bootstrap"\)\)/);
+});
+
+test("native host upgrades stop the supervisor before replacing its executable", async () => {
+  const shellInstaller = await read("scripts/installer/native-edge-host.sh");
+  const windowsInstaller = await read("scripts/installer/native-edge-host.ps1");
+
+  assert.ok(
+    shellInstaller.lastIndexOf('_dpf_native_edge_acquire_macos') <
+      shellInstaller.indexOf('launchctl bootout "gui/$UID/local.dpf-edge-node"') &&
+      shellInstaller.indexOf('launchctl bootout "gui/$UID/local.dpf-edge-node"') <
+        shellInstaller.indexOf('mv "$binary_candidate" "$binary"'),
+    "launchd must stay online during acquisition and release the old binary before replacement",
+  );
+  assert.ok(
+    windowsInstaller.indexOf('Copy-Item -LiteralPath $sourceBinary -Destination $binaryCandidate -Force') <
+      windowsInstaller.indexOf('Stop-ScheduledTask -TaskName "DPF-Native-Edge-Node"') &&
+      windowsInstaller.indexOf('Stop-ScheduledTask -TaskName "DPF-Native-Edge-Node"') <
+        windowsInstaller.indexOf('Move-Item -LiteralPath $binaryCandidate -Destination $binary -Force'),
+    "Task Scheduler must stay online during acquisition and release the old binary before replacement",
+  );
+});
+
+test("native host upgrades stage new bytes and retain a restorable prior binary", async () => {
+  const shellInstaller = await read("scripts/installer/native-edge-host.sh");
+  const windowsInstaller = await read("scripts/installer/native-edge-host.ps1");
+
+  assert.match(shellInstaller, /binary_candidate=.*\.next/);
+  assert.match(shellInstaller, /binary_backup=.*\.previous/);
+  assert.match(shellInstaller, /_dpf_native_edge_acquire_macos[^\n]+\$binary_candidate/);
+  assert.match(shellInstaller, /mv\s+"\$binary_candidate"\s+"\$binary"/);
+  assert.match(shellInstaller, /mv\s+"\$binary_backup"\s+"\$binary"/);
+
+  assert.match(windowsInstaller, /\$binaryCandidate\s*=.*\.next/);
+  assert.match(windowsInstaller, /\$binaryBackup\s*=.*\.previous/);
+  assert.match(windowsInstaller, /Move-Item\s+-LiteralPath\s+\$binaryCandidate\s+-Destination\s+\$binary/);
+  assert.match(windowsInstaller, /Copy-Item\s+-LiteralPath\s+\$binaryBackup\s+-Destination\s+\$binary/);
+});
+
 test("native host enrollment uses a LAN Authority URL and never silently claims trusted HTTPS", async () => {
   const shellInstaller = await read("scripts/installer/native-edge-host.sh");
   const windowsInstaller = await read("scripts/installer/native-edge-host.ps1");

--- a/scripts/installer/native-edge-host.ps1
+++ b/scripts/installer/native-edge-host.ps1
@@ -32,19 +32,24 @@ function Install-DPFNativeEdgeNode {
         Write-Warn "Nearby discovery will work at $AuthorityUrl, but automatic pairing remains blocked until DPF_LAN_AUTHORITY_URL is certificate-valid HTTPS."
     }
 
-    $stateRoot = Join-Path $env:USERPROFILE ".dpf"
+    $stateRoot = if ($env:DPF_STATE_DIR) { $env:DPF_STATE_DIR } else { Join-Path $env:USERPROFILE ".dpf" }
     $binDir = Join-Path $stateRoot "bin"
     $stateDir = Join-Path $stateRoot "edge-node"
     $logDir = Join-Path $stateRoot "logs"
     $binary = Join-Path $binDir "dpf-edge-node.exe"
+    $binaryCandidate = "$binary.next"
+    $binaryBackup = "$binary.previous"
     $runner = Join-Path $stateRoot "run-edge-node.ps1"
     $asset = "dpf-edge-node-windows-amd64.exe"
     $checksumsAsset = "dpf-edge-node-checksums.sha256"
     $sourceBinary = Join-Path $InstallDir "services\edge-node-go\bin\$asset"
     New-Item -ItemType Directory -Force -Path $binDir, $stateDir, $logDir | Out-Null
 
+    # Acquire and verify the replacement while the current service stays online.
+    Remove-Item -LiteralPath $binaryCandidate -Force -ErrorAction SilentlyContinue
+
     if (Test-Path -LiteralPath $sourceBinary) {
-        Copy-Item -LiteralPath $sourceBinary -Destination $binary -Force
+        Copy-Item -LiteralPath $sourceBinary -Destination $binaryCandidate -Force
     } elseif ((Get-Command go.exe -ErrorAction SilentlyContinue) -and (Test-Path (Join-Path $InstallDir "services\edge-node-go\go.mod"))) {
         $oldGoos = $env:GOOS
         $oldGoarch = $env:GOARCH
@@ -54,7 +59,7 @@ function Install-DPFNativeEdgeNode {
             $env:GOARCH = "amd64"
             $env:CGO_ENABLED = "0"
             Push-Location (Join-Path $InstallDir "services\edge-node-go")
-            go build -trimpath -ldflags "-s -w -X main.Version=$Version" -o $binary ./cmd/dpf-edge-node
+            go build -trimpath -ldflags "-s -w -X main.Version=$Version" -o $binaryCandidate ./cmd/dpf-edge-node
             if ($LASTEXITCODE -ne 0) { throw "native_edge_build_failed" }
         } finally {
             Pop-Location
@@ -75,11 +80,20 @@ function Install-DPFNativeEdgeNode {
             $expected = ($checksumLine -split '\s+')[0].ToLowerInvariant()
             $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $downloadedBinary).Hash.ToLowerInvariant()
             if ($actual -cne $expected) { throw "native_edge_checksum_mismatch" }
-            Copy-Item -LiteralPath $downloadedBinary -Destination $binary -Force
+            Copy-Item -LiteralPath $downloadedBinary -Destination $binaryCandidate -Force
         } finally {
             Remove-Item -LiteralPath $temporary -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
+
+    if (-not (Test-Path -LiteralPath $binaryCandidate -PathType Leaf)) { throw "native_edge_candidate_missing" }
+    # A running process holds the executable open on Windows. Release it only
+    # after the replacement is ready; registration/start below is idempotent.
+    Stop-ScheduledTask -TaskName "DPF-Native-Edge-Node" -ErrorAction SilentlyContinue
+    if (Test-Path -LiteralPath $binary -PathType Leaf) {
+        Copy-Item -LiteralPath $binary -Destination $binaryBackup -Force
+    }
+    Move-Item -LiteralPath $binaryCandidate -Destination $binary -Force
 
     $nodeName = [System.Net.Dns]::GetHostName()
     $escapedBinary = $binary.Replace("'", "''")
@@ -141,8 +155,17 @@ $actionEnvironment& '$escapedBinary' *>> '$($logDir.Replace("'", "''"))\edge-nod
     $trigger = New-ScheduledTaskTrigger -AtLogOn
     $principal = New-ScheduledTaskPrincipal -UserId ([System.Security.Principal.WindowsIdentity]::GetCurrent().Name) -LogonType Interactive
     $settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)
-    Register-ScheduledTask -TaskName "DPF-Native-Edge-Node" -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description "Run the DPF native Edge Node on host network interfaces." -Force | Out-Null
-    Start-ScheduledTask -TaskName "DPF-Native-Edge-Node"
+    try {
+        Register-ScheduledTask -TaskName "DPF-Native-Edge-Node" -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description "Run the DPF native Edge Node on host network interfaces." -Force | Out-Null
+        Start-ScheduledTask -TaskName "DPF-Native-Edge-Node"
+    } catch {
+        if (Test-Path -LiteralPath $binaryBackup -PathType Leaf) {
+            Copy-Item -LiteralPath $binaryBackup -Destination $binary -Force
+            Start-ScheduledTask -TaskName "DPF-Native-Edge-Node" -ErrorAction SilentlyContinue
+            Write-Warn "Native Edge Node could not start after upgrade; the prior binary was restored."
+        }
+        throw
+    }
     Write-OK "Native Edge Node installed and supervised by Windows Task Scheduler"
     return $true
 }

--- a/scripts/installer/native-edge-host.sh
+++ b/scripts/installer/native-edge-host.sh
@@ -67,6 +67,8 @@ dpf_native_edge_install() {
   local env_file="$state_root/edge-node.env"
   local launch_script="$state_root/run-edge-node.sh"
   local binary="$bin_dir/dpf-edge-node"
+  local binary_candidate="$binary.next"
+  local binary_backup="$binary.previous"
   local plist="$HOME/Library/LaunchAgents/local.dpf-edge-node.plist"
   local template="$repo_root/scripts/installer/macos-edge-node.plist.tmpl"
   local version="${DPF_NATIVE_EDGE_VERSION:-$(git -C "$repo_root" describe --tags --abbrev=0 2>/dev/null || echo latest)}"
@@ -102,13 +104,22 @@ dpf_native_edge_install() {
 
   mkdir -p "$bin_dir" "$edge_state_dir" "$log_dir" "$HOME/Library/LaunchAgents"
   chmod 0700 "$state_root" "$edge_state_dir"
-  _dpf_native_edge_acquire_macos "$repo_root" "$binary" "$version"
+  # Acquire and verify the replacement while the current service stays online.
+  rm -f "$binary_candidate"
+  _dpf_native_edge_acquire_macos "$repo_root" "$binary_candidate" "$version"
   # Integrity is checked before this host-local mutation. Clearing quarantine
   # and applying an ad-hoc signature lets launchd execute contributor builds
   # and unsigned community release artifacts; official Developer ID signing
   # can replace the ad-hoc signature without changing the installer contract.
-  xattr -d com.apple.quarantine "$binary" 2>/dev/null || true
-  codesign --force --sign - "$binary" >/dev/null
+  xattr -d com.apple.quarantine "$binary_candidate" 2>/dev/null || true
+  codesign --force --sign - "$binary_candidate" >/dev/null
+  # Release the running image only after the replacement is ready.
+  launchctl bootout "gui/$UID/local.dpf-edge-node" 2>/dev/null || true
+  if [ -f "$binary" ]; then
+    cp "$binary" "$binary_backup"
+    chmod 0755 "$binary_backup"
+  fi
+  mv "$binary_candidate" "$binary"
 
   {
     printf 'DPF_AUTHORITY_URL=%s\n' "$authority_url"
@@ -141,11 +152,16 @@ dpf_native_edge_install() {
   sed -e "s|@@DPF_EDGE_LAUNCH_SCRIPT@@|$launch_script|g" \
       -e "s|@@DPF_EDGE_LOG_DIR@@|$log_dir|g" "$template" > "$plist"
   chmod 0644 "$plist"
-  launchctl bootout "gui/$UID/local.dpf-edge-node" 2>/dev/null || true
   if launchctl bootstrap "gui/$UID" "$plist" 2>/dev/null; then
     ok "Native Edge Node installed and supervised by launchd"
   else
-    warn "Native Edge Node was installed but launchd could not start it. See $log_dir/edge-node.err.log."
+    if [ -f "$binary_backup" ]; then
+      mv "$binary_backup" "$binary"
+      launchctl bootstrap "gui/$UID" "$plist" 2>/dev/null || true
+      warn "Native Edge Node could not start after upgrade; the prior binary was restored. See $log_dir/edge-node.err.log."
+    else
+      warn "Native Edge Node was installed but launchd could not start it. See $log_dir/edge-node.err.log."
+    fi
     return 1
   fi
 }

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1488,7 +1488,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 32
+    "textMass": 27
   },
   "apps/web/app/(shell)/platform/federation-links/page.tsx": {
     "vocabulary": 0,
@@ -3868,7 +3868,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 8
+    "textMass": 6
   },
   "apps/web/components/build/BuildPhaseCostCard.tsx": {
     "vocabulary": 0,
@@ -3903,7 +3903,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 1,
-    "textMass": 395
+    "textMass": 390
   },
   "apps/web/components/build/BuildStudioCustodianCallout.tsx": {
     "vocabulary": 0,
@@ -5632,7 +5632,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 108
+    "textMass": 105
   },
   "apps/web/components/inventory/PortfolioQualityIssuesPanel.tsx": {
     "vocabulary": 0,
@@ -6873,12 +6873,19 @@
     "longSentences": 0,
     "textMass": 13
   },
+  "apps/web/components/platform/edge-nodes/EdgeFleetReadiness.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 56
+  },
   "apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 1,
-    "textMass": 339
+    "textMass": 272
   },
   "apps/web/components/platform/federation-links/FederationLinksAdminClient.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Summary

- derive Edge health from current heartbeat, trust, version, and accepted capability evidence instead of the stored status field
- make **This DPF installation** the first readiness surface, with separate health/trust, failed checks, next actions, and multi-customer/site fleet visibility
- converge opted-in Windows and macOS native Edge services on every governed install while preserving enrollment identity and restoring the prior binary after a failed restart
- make Connections use the same discovery-readiness truth and document the operator/MSP lifecycle

Backlog: BI-6CE3D92B  
Work Capsule: WC-D275D2F3

## Design grounding

- Existing specs/plans reviewed: Edge deployment model, fleet operations contract, federation connection design, and `2026-08-13-main-instance-edge-lifecycle-and-fleet-visibility.md`.
- Current code substrate reviewed: `EdgeNode`, `EdgeNodeCapability`, installer-issued `BootstrapToken`, existing native host installers, federation discovery presentation, and report-kit status domains.
- Source of truth: PostgreSQL node/capability/enrollment records plus current time and the running platform version; no second registry or persisted health projection.
- Decision: readiness-first progressive disclosure (DI-0E22008385C8). Keep local-install readiness first, expose remote provisioning second, and keep health independent from trust. UX evidence is recorded in `docs/ux-fit/2026-08-13-edge-fleet-readiness.ux-fit.json`.

## Verification

- 68 affected web tests passed
- 13 native installer lifecycle contracts passed
- scoped TypeScript typecheck passed
- production Next.js build passed
- pregate preflight: 37/37 guards passed
- exact-SHA merged-code pregate passed: 2,702 test files / 23,033 tests, production build, runtime and policy gates
- independent high-assurance semantic review passed: three review branches, zero blocking findings
- migration: not applicable; no schema change
- Windows PowerShell physical execution remains a post-merge acceptance check on the Windows installation; static contract coverage is included here

## Documentation

- updated the Edge Nodes operator guide and fleet-operations contract
- regenerated the documentation index; doc-impact and diagram generators were also checked

Docs-Impact-Decision: Edge operator and fleet guides were updated; platform routing, shared report-kit contracts, compose topology, platform overview, and disaster-recovery procedures are unchanged.

## Rollout and rollback

- Edge remains opt-in through the governed installer intent
- new native bytes are acquired and verified while the current service remains online
- the prior binary is retained and restored if Task Scheduler or launchd cannot restart the replacement

Local-CI-Evidence: cmss7dh4v02wt01qwga2nspw5 (feat/edge-fleet-foundation@4cc9a27e11cea044ae3247c1f6d6c8cf7af16e1d)
