### PR TITLE
fix(edge): report ambiguous installer enrollment

### DIFF
--- a/apps/web/app/(shell)/platform/federation-links/page.tsx
+++ b/apps/web/app/(shell)/platform/federation-links/page.tsx
@@ -13,7 +13,6 @@ import { resolveFounderDemandEnvironment } from "@dpf/db/founder-shared-portfoli
 import {
   FederationLinksAdminClient,
   type FederationLinkRow,
-  type NearbyDiscoveryHealth,
   type NearbyPairingRow,
 } from "@/components/platform/federation-links/FederationLinksAdminClient";
 import {
@@ -23,6 +22,7 @@ import {
 import { OrganizationJoinPanel } from "@/components/platform/federation-links/OrganizationJoinPanel";
 import { getOrganizationJoinNodeSummariesAction } from "@/lib/actions/organization-join";
 import {
+  deriveNearbyDiscoveryHealth,
   deriveEdgeNodeReadiness,
   selectMainInstallationNode,
   type EdgeReadinessNode,
@@ -105,36 +105,11 @@ export default async function FederationLinksPage() {
   const readiness = mainNode.node
     ? deriveEdgeNodeReadiness(mainNode.node, { requiredCapabilities: ["federation.discovery"] })
     : null;
-  const nearbyDiscoveryHealth: NearbyDiscoveryHealth =
-    mainNode.status !== "found" || !readiness || !discoveryCapability
-      ? {
-          status: "unavailable",
-          label: "Not set up",
-          detail: "The native Edge Node has not registered nearby discovery.",
-        }
-      : discoveryCapability.mode !== "enabled" && discoveryCapability.mode !== "reporting-only"
-        ? {
-            status: "disabled",
-            label: "Paused",
-            detail: "Nearby discovery is disabled by the Authority.",
-          }
-        : readiness.health === "healthy"
-          ? {
-              status: "healthy",
-              label: "Listening",
-              detail: "This installation is announcing and looking for nearby DPF installations.",
-            }
-          : readiness.health === "starting"
-            ? {
-                status: "waiting",
-                label: "Starting",
-                detail: "Nearby discovery is enabled and waiting for its first health report.",
-              }
-            : {
-                status: "degraded",
-                label: "Needs attention",
-                detail: "Nearby discovery or its host service is stale or failing. Check the Edge fleet for the specific failed readiness check.",
-              };
+  const nearbyDiscoveryHealth = deriveNearbyDiscoveryHealth({
+    selection: mainNode,
+    readiness,
+    discoveryCapability: discoveryCapability ?? null,
+  });
 
   const rows: FederationLinkRow[] = links.map((l) => {
     // What crosses this link to the peer: the minimum-necessary projection the

--- a/apps/web/components/platform/edge-nodes/EdgeFleetReadiness.tsx
+++ b/apps/web/components/platform/edge-nodes/EdgeFleetReadiness.tsx
@@ -144,10 +144,10 @@ export function MainInstallationReadiness({
   status: MainInstallationStatus;
 }) {
   const health: EdgeHealth = node?.health ?? "setup-required";
-  const setupDetail = !edgeEnabled
-    ? "Edge is not enabled for this installation. Re-run the governed installer with Edge enabled."
-    : status === "ambiguous"
-      ? "More than one installer-managed node claims this installation. Review the fleet before relying on discovery."
+  const setupDetail = status === "ambiguous"
+    ? "More than one installer-managed node claims this installation. Review the fleet before relying on discovery."
+    : !edgeEnabled
+      ? "Edge is not enabled for this installation. Re-run the governed installer with Edge enabled."
       : "Edge is enabled, but its supervised host service has not enrolled. Run the governed repair or self-upgrade path.";
 
   return (

--- a/apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.test.tsx
+++ b/apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.test.tsx
@@ -187,6 +187,25 @@ describe("HostAddressCell", () => {
   });
 });
 
+describe("main installation readiness", () => {
+  it("shows an enrollment conflict before a disabled-install message", () => {
+    render(
+      <EdgeNodesAdminClient
+        nodes={[]}
+        tokens={[]}
+        customerAccounts={[]}
+        edgeEnabled={false}
+        mainInstallationStatus="ambiguous"
+      />,
+    );
+
+    expect(
+      screen.getByText(/More than one installer-managed node claims this installation/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Edge is not enabled for this installation/)).not.toBeInTheDocument();
+  });
+});
+
 describe("EdgeNodesAdminClient customer/site scope", () => {
   it("shows this installation readiness before the fleet registry", () => {
     render(

--- a/apps/web/components/platform/federation-links/FederationLinksAdminClient.tsx
+++ b/apps/web/components/platform/federation-links/FederationLinksAdminClient.tsx
@@ -23,6 +23,7 @@ import {
   startNearbyPairingAction,
 } from "@/lib/actions/federation-links";
 import type { NearbyFederationCandidate } from "@/lib/federation/nearby-candidates";
+import type { NearbyDiscoveryHealth } from "@/lib/edge-node/readiness";
 import { normalizeRecoveryAuthority } from "@/lib/federation/recovery-authority";
 import { FederationLinksTable } from "./FederationLinksTable";
 
@@ -43,12 +44,6 @@ export interface FederationLinkRow {
   offersIntroductions: boolean;
   acceptsIntroductions: boolean;
   createdAtISO: string;
-}
-
-export interface NearbyDiscoveryHealth {
-  status: "healthy" | "degraded" | "waiting" | "disabled" | "unavailable";
-  label: string;
-  detail: string;
 }
 
 export interface NearbyPairingRow {

--- a/apps/web/lib/edge-node/readiness.test.ts
+++ b/apps/web/lib/edge-node/readiness.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   EDGE_HEARTBEAT_DEGRADED_AFTER_MS,
   EDGE_HEARTBEAT_OFFLINE_AFTER_MS,
+  deriveNearbyDiscoveryHealth,
   deriveEdgeNodeReadiness,
   selectMainInstallationNode,
   type EdgeReadinessNode,
@@ -173,5 +174,34 @@ describe("selectMainInstallationNode", () => {
     ]);
 
     expect(result.status).toBe("missing");
+  });
+});
+
+describe("deriveNearbyDiscoveryHealth", () => {
+  it("reports an installer enrollment conflict instead of claiming discovery was never registered", () => {
+    const nodes = [
+      node({ id: "current", nodeId: "edge_current" }),
+      node({
+        id: "historical",
+        nodeId: "edge_historical",
+        platform: "linux",
+        installMode: "container-host",
+        lastSeenAt: new Date("2026-07-20T12:00:00.000Z"),
+      }),
+    ];
+    const selection = selectMainInstallationNode(nodes);
+
+    const result = deriveNearbyDiscoveryHealth({
+      selection,
+      readiness: null,
+      discoveryCapability: null,
+    });
+
+    expect(result).toEqual({
+      status: "unavailable",
+      label: "Enrollment conflict",
+      detail:
+        "Multiple installer-managed Edge Nodes claim this installation. Review Edge Nodes before relying on nearby discovery.",
+    });
   });
 });

--- a/apps/web/lib/edge-node/readiness.ts
+++ b/apps/web/lib/edge-node/readiness.ts
@@ -238,6 +238,64 @@ export interface MainInstallationNodeSelection {
   candidateNodeIds: string[];
 }
 
+export interface NearbyDiscoveryHealth {
+  status: "healthy" | "degraded" | "waiting" | "disabled" | "unavailable";
+  label: string;
+  detail: string;
+}
+
+export function deriveNearbyDiscoveryHealth({
+  selection,
+  readiness,
+  discoveryCapability,
+}: {
+  selection: MainInstallationNodeSelection;
+  readiness: EdgeNodeReadiness | null;
+  discoveryCapability: EdgeReadinessCapability | null;
+}): NearbyDiscoveryHealth {
+  if (selection.status === "ambiguous") {
+    return {
+      status: "unavailable",
+      label: "Enrollment conflict",
+      detail:
+        "Multiple installer-managed Edge Nodes claim this installation. Review Edge Nodes before relying on nearby discovery.",
+    };
+  }
+  if (selection.status !== "found" || !readiness || !discoveryCapability) {
+    return {
+      status: "unavailable",
+      label: "Not set up",
+      detail: "The native Edge Node has not registered nearby discovery.",
+    };
+  }
+  if (discoveryCapability.mode !== "enabled" && discoveryCapability.mode !== "reporting-only") {
+    return {
+      status: "disabled",
+      label: "Paused",
+      detail: "Nearby discovery is disabled by the Authority.",
+    };
+  }
+  if (readiness.health === "healthy") {
+    return {
+      status: "healthy",
+      label: "Listening",
+      detail: "This installation is announcing and looking for nearby DPF installations.",
+    };
+  }
+  if (readiness.health === "starting") {
+    return {
+      status: "waiting",
+      label: "Starting",
+      detail: "Nearby discovery is enabled and waiting for its first health report.",
+    };
+  }
+  return {
+    status: "degraded",
+    label: "Needs attention",
+    detail: "Nearby discovery or its host service is stale or failing. Check the Edge fleet for the specific failed readiness check.",
+  };
+}
+
 function selection(
   candidates: EdgeReadinessNode[],
   basis: MainInstallationNodeSelection["basis"],

--- a/docs/user-guide/platform/edge-nodes.md
+++ b/docs/user-guide/platform/edge-nodes.md
@@ -24,7 +24,7 @@ The card checks the supervised service, enrollment, trust, heartbeat freshness, 
 
 | Health | Meaning | Operator response |
 | --- | --- | --- |
-| **Setup required** | Edge was not enabled, or no local supervised service is enrolled. | Use the governed install or repair workflow with Edge enabled. |
+| **Setup required** | Edge was not enabled, no local supervised service is enrolled, or more than one installer-managed enrollment claims this installation. | Follow the card detail. For an enrollment conflict, review the fleet and retire or repair the obsolete enrollment before relying on nearby discovery. |
 | **Starting** | Enrollment or the first heartbeat/approval is still completing. | Wait briefly, then review the named waiting check. |
 | **Healthy** | Trust, heartbeat, version, and required capabilities are current. | No action. |
 | **Degraded** | The node is reachable but a version, capability, or freshness check needs attention. | Follow the failed check; open **Connections** for nearby discovery. |
@@ -32,6 +32,8 @@ The card checks the supervised service, enrollment, trust, heartbeat freshness, 
 | **Quarantined / Revoked** | Trust policy intentionally blocks or permanently retires the node. | Review the recorded trust decision before restoring or replacing it. |
 
 Health and trust are different axes. A node can be trusted yet offline, or alive yet quarantined. The fleet table therefore shows both columns, plus the first failed readiness check and its next action, and derives health from live evidence rather than `EdgeNode.status` alone.
+
+If **Connections** reports an **Enrollment conflict**, discovery may still be running, but the Authority cannot safely prove which installer-managed node belongs to this installation. DPF does not guess from the newest heartbeat or hostname; open **Edge Nodes**, identify the obsolete enrollment, and retire or repair it through the governed lifecycle.
 
 Once Edge is enabled, each governed install or self-upgrade refreshes the checksum-bound native binary and its supervisor while preserving the enrolled machine identity. Replacement bytes are staged before the service stops, and a failed restart restores the prior binary. A platform version change does not issue a new bootstrap token.
 

--- a/docs/user-guide/platform/index.md
+++ b/docs/user-guide/platform/index.md
@@ -37,7 +37,7 @@ Use the Platform area to supervise AI operations, Edge Nodes, integrations, iden
 
 Open **Platform > Connections** to find nearby DPF installations or connect by invitation. A nearby result is only a setup suggestion: it never creates trust or shares backlog data by itself. Both installations must approve a connection before any shared demand or disposition can cross it.
 
-The page reports whether the native Edge Node is listening for nearby installations. If discovery is not set up, paused, or unhealthy, use the Edge Nodes link to review its authority and network status. Invitation-based setup remains available when local-network discovery cannot be used.
+The page reports whether the native Edge Node is listening for nearby installations. If discovery is not set up, paused, unhealthy, or blocked by an **Enrollment conflict**, use the Edge Nodes link to review its authority and network status. An enrollment conflict means that more than one installer-managed node claims this installation; DPF will not guess which node is authoritative. Invitation-based setup remains available when local-network discovery cannot be used.
 
 For another installation owned by the same organization, choose **Set up this
 DPF**. Automatic setup is available only when both installations advertise a

--- a/docs/ux-fit/2026-08-13-edge-enrollment-conflict.ux-fit.json
+++ b/docs/ux-fit/2026-08-13-edge-enrollment-conflict.ux-fit.json
@@ -1,0 +1,49 @@
+{
+  "version": "1",
+  "decidedOption": "explicit-enrollment-conflict",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/platform/federation-links/page.tsx",
+      "apps/web/components/platform/edge-nodes/EdgeFleetReadiness.tsx",
+      "apps/web/lib/edge-node/readiness.ts"
+    ]
+  },
+  "evidence": {
+    "kind": "sweep-measurement",
+    "baselineComparison": "maintained",
+    "measurementRun": "governed contributor preview at http://localhost:3001",
+    "measured": {
+      "/platform/edge-nodes": {
+        "defaultVisibleWords": 159,
+        "leadBandWords": 0,
+        "primaryActions": 1,
+        "visibleFields": 0,
+        "maxChoicesPerControl": 0,
+        "subLegibleControls": 0,
+        "buriedPrimaryAction": 0,
+        "axeViolations": 2
+      },
+      "/platform/federation-links": {
+        "defaultVisibleWords": 335,
+        "leadBandWords": 0,
+        "primaryActions": 1,
+        "visibleFields": 0,
+        "maxChoicesPerControl": 0,
+        "subLegibleControls": 0,
+        "buriedPrimaryAction": 0,
+        "axeViolations": 2
+      }
+    },
+    "fitDecision": "fits-with-guardrails",
+    "owningArea": "Platform",
+    "routeFamily": "/platform/edge-nodes and /platform/federation-links",
+    "primaryPersona": "founder or platform operator diagnosing local Edge enrollment without needing to infer which machine the Authority selected",
+    "navigationLayer": "local status and recovery guidance inside existing Platform routes",
+    "reuseConvergence": "reuses the existing main-installation readiness card, discovery health panel, StatusBadge, and Edge Nodes recovery link; the shared readiness projection is now the single source for discovery copy",
+    "sourceTruth": "EdgeNode, BootstrapToken installer-managed enrollment evidence, EdgeNodeCapability, and the no-guess main-installation selector",
+    "emptyFailureBehavior": "an ambiguous installer-managed selection is named as an enrollment conflict before disabled or missing-discovery fallbacks, with a direct path to inspect the fleet",
+    "aiBoundary": "no coworker action or AI-generated decision",
+    "accessibility": "the conflict is expressed in text with an explicit recovery link and is not conveyed by color alone",
+    "responsive": "no layout or control changes; the existing wrapping status surfaces and recovery link remain responsive"
+  }
+}


### PR DESCRIPTION
## Summary

- preserve the Authority's no-guess main-installation selector when multiple installer-managed Edge Nodes claim one installation
- show an explicit enrollment conflict on Edge Nodes and Connections instead of reporting Edge as disabled or discovery as unregistered
- centralize the discovery-health projection, add regression coverage, and document the recovery path

## Why

Arcamanus currently has a healthy Mac native Edge Node and a stale Linux-container enrollment that both carry installer-managed evidence. The platform correctly refuses to guess which node is authoritative, but the UI collapsed that ambiguity into two false diagnoses. Operators need to see the enrollment conflict before they can safely repair or retire the obsolete node.

## Design grounding

- Existing specs/plans reviewed: the Edge fleet operational-visibility work under `EP-DELIVERY-FLOW` and the existing Edge Nodes user guide.
- Current code substrate reviewed: `apps/web/lib/edge-node/readiness.ts`, `apps/web/app/(shell)/platform/federation-links/page.tsx`, and `apps/web/components/platform/edge-nodes/EdgeFleetReadiness.tsx`.
- Source of truth: installer-managed `EdgeNode` selection evidence plus `EdgeNodeCapability` readiness.
- Decision: preserve the no-guess selector and project ambiguity explicitly before disabled or missing-enrollment fallbacks.

## Verification

- Focused Vitest: 3 files, 39 tests passed
- Web typecheck: passed
- Production web build: passed
- Pregate preflight: 38 guards passed
- Governed contributor preview: `/platform/edge-nodes` showed the multiple-enrollment setup conflict; `/platform/federation-links` showed **Enrollment conflict** with the **Open Edge Nodes** recovery link; the false disabled/unregistered messages were absent
- Peer reachability: the Windows-hosted installation at `192.168.0.200:3000` returned healthy status and release `be38fff516cc8efcce56821330515775507d47ff`; native Windows Edge enrollment remains a separate operational step
- Migration: not applicable

## Backlog

- `BI-C6F3DD77`
- Work Capsule `WC-D1F4E34D`

Local-CI-Evidence: cmssbfgps062101p26obsummp (fix/edge-ambiguous-selection-visibility@c5454cd246d0e7d6a1b5fde9382be9dcd0a2735a)
