### PR TITLE
fix(wiki): fall back when semantic search is empty

### DIFF
--- a/apps/web/lib/wiki/embeddings.test.ts
+++ b/apps/web/lib/wiki/embeddings.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const upsertVectors = vi.fn();
 const searchSimilar = vi.fn();
@@ -29,6 +29,10 @@ import {
 } from "./embeddings";
 
 const stub = (n: number) => new Array(n).fill(0).map((_, i) => i / n);
+
+beforeEach(() => {
+  wikiPageFindMany.mockResolvedValue([]);
+});
 
 afterEach(() => {
   upsertVectors.mockReset();
@@ -484,6 +488,42 @@ describe("searchWikiPages: two-pass overlay-aware retrieval", () => {
       source: "kernel",
     })]);
     expect(searchSimilar).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Postgres when semantic search misses an existing published page", async () => {
+    generateEmbedding.mockResolvedValueOnce(stub(768));
+    searchSimilar.mockResolvedValueOnce([]);
+    wikiPageFindMany.mockResolvedValueOnce([{
+      id: "wp-universal-work",
+      slug: "principles/universal-work-formula",
+      title: "Universal Work Formula",
+      body: "All work runs one invariant formula.",
+      abstract: "Vary context, temporal shape, and participants only.",
+      pageKind: "principle",
+      isKernel: true,
+      organizationId: null,
+      kernelPageId: null,
+      principleTier: "core",
+      principleAppliesTo: ["external_coding_agent"],
+      principleRingScope: [],
+      principleDimensions: ["architecture_alignment"],
+      principlePublic: true,
+    }]);
+
+    const results = await searchWikiPages({
+      query: "Universal Work Formula",
+      organizationId: null,
+      pageKind: "principle",
+      principleAppliesTo: "external_coding_agent",
+    });
+
+    expect(searchSimilar).toHaveBeenCalledTimes(1);
+    expect(wikiPageFindMany).toHaveBeenCalledTimes(1);
+    expect(results).toEqual([expect.objectContaining({
+      pageId: "wp-universal-work",
+      slug: "principles/universal-work-formula",
+      source: "kernel",
+    })]);
   });
 
   it("includes pageKind filter when provided", async () => {

--- a/apps/web/lib/wiki/embeddings.ts
+++ b/apps/web/lib/wiki/embeddings.ts
@@ -436,7 +436,14 @@ export async function searchWikiPages(input: SearchWikiPagesInput): Promise<Wiki
   );
   const kernelResults = kernelRaw.map((r) => projectResult(r, "kernel"));
 
-  return [...orgResults, ...kernelResults].slice(0, limit);
+  const semanticResults = [...orgResults, ...kernelResults].slice(0, limit);
+  if (semanticResults.length === 0) {
+    // A healthy embedding provider does not prove the vector index contains
+    // every published Postgres row. Preserve Postgres as doctrine truth when
+    // Qdrant is stale, partially ingested, or missing an individual page.
+    return searchWikiPagesLexically(input);
+  }
+  return semanticResults;
 }
 
 // ─── Internal ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- preserve published Postgres wiki pages as retrieval truth when embedding succeeds but the Qdrant result set is empty
- reuse the existing tenant-aware, overlay-masking lexical fallback only after the complete semantic pass returns no result
- add the exact regression observed on the Arcamanus live install for `Universal Work Formula`

## Backlog validity

`BI-321FA58B` remains in progress because live validation on canonical lineage `be38fff516cc8efcce56821330515775507d47ff` found the published page in Postgres but an exact-title `wiki_query` returned no result. The historical `work-formula` branch was already merged as PR #4242 and contains the doctrine source, not this retrieval correction; no active PR or worktree supersedes this defect.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-05-09-platform-kernel-wiki-design.md` and the Work Formula convergence design already linked from the BI.
- Current code substrate reviewed: `apps/web/lib/wiki/embeddings.ts` already owns both two-pass vector retrieval and the Postgres lexical fallback.
- Source of truth: published `WikiPage` rows in Postgres remain doctrine truth; Qdrant is a best-effort retrieval index.
- Decision: extend the existing fallback phase boundary for a completely empty semantic result set; preserve non-empty semantic ranking and every existing tenant, page-kind, principle, and overlay filter.

Design-Grounding-Decision: Extend the existing wiki fallback on an empty semantic result; do not add a parallel retrieval path or store.

Process-Spine-Decision: Preserve the existing wiki retrieval contract and tenant-aware lexical fallback; no new process, store, route, or lifecycle is introduced.

## Verification

- TDD regression: observed red failure before implementation, then focused Vitest 18/18 passed
- web typecheck: passed
- production web build: passed with zero errors (26 pre-existing Edge-runtime warnings)
- style drift and `git diff --check`: passed
- preflight: all 38 deterministic guards passed
- semantic review: fresh pass for commit `31f609179670`
- exact-tree local integration: PASS on `31f609179670` — evidence `cmsscqkvu08z001p2cgcsnsko`
- migration: not applicable; no schema or data migration changed
- UX: not applicable; no visual route or interaction changed

## Documentation impact

No user-facing workflow, route, API, prompt, skill, migration, or coworker instruction changed. The existing wiki kernel design already defines Postgres as durable page storage and the vector index as retrieval support.

Docs-Impact-Decision: no user-facing documentation change; this restores the documented retrieval contract under partial vector-index state.
