### PR TITLE
feat(work-room): complete EP-WORKROOM-COMMS — invite, 360 engagement, AWC augmentation + identity fix

### DIFF
--- a/apps/web/lib/mcp/packs/room-messaging-pack.ts
+++ b/apps/web/lib/mcp/packs/room-messaging-pack.ts
@@ -16,8 +16,12 @@ import { prisma } from "@dpf/db";
 
 import type { ToolPack } from "@/lib/mcp/tool-pack";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import { ensureAgentPrincipalIdentity, syncUserPrincipal } from "@/lib/identity/principal-linking";
+import { getCoworkerRoomEngagement } from "@/lib/work-management/coworker-room-engagement.server";
 import { heartbeatAgentWorkItemPresence } from "@/lib/work-management/room-agent-presence.server";
 import { postWorkItemComment, type PostCommentDb } from "@/lib/work-management/post-work-item-comment";
+import { appendRoomPolicyParticipant } from "@/lib/work-management/room-policy";
+import type { WorkRoomParticipantRole } from "@/lib/work-management/room-types";
 import { resolveAgentRoomAccess } from "@/lib/work-management/room-agent-access.server";
 import { decodeWorkCaseKey } from "@/lib/work-management/workspace-case-loader";
 
@@ -182,6 +186,107 @@ async function readRoomMessagesHandler(
   };
 }
 
+async function inviteRoomParticipantHandler(
+  params: Record<string, unknown>,
+  _userId: string,
+  context?: PackContext,
+): Promise<ToolResult> {
+  const agentId = context?.agentId;
+  if (!agentId) {
+    return { success: false, error: "invalid_caller", message: "invite_room_participant requires an acting coworker." };
+  }
+  const caseKey = str(params, "caseKey");
+  const inviteeAgentId = str(params, "agentId");
+  const inviteeUserId = str(params, "userId");
+  if (!caseKey || (!inviteeAgentId && !inviteeUserId)) {
+    return { success: false, error: "invalid_input", message: "caseKey and one of agentId | userId are required." };
+  }
+
+  const item = await resolveRoomWorkItem(caseKey);
+  if (!item) {
+    return { success: false, error: "not_found", message: `No Work Room found for ${caseKey}.` };
+  }
+
+  // Only a room member with action rights (the Coordinator, or an active participant) may invite.
+  const caller = await resolveAgentRoomAccess({
+    agentId,
+    requested: "action",
+    workItem: { id: item.id, evidence: item.evidence, assignedToAgentId: item.assignedToAgentId },
+  });
+  if (caller.decision.level !== "action") {
+    return {
+      success: false,
+      error: "forbidden",
+      message: `Only a room member with action rights (e.g. the Coordinator) can invite participants (${caller.decision.reason}).`,
+    };
+  }
+
+  let inviteePrincipalId: string | null = null;
+  let inviteeLabel = "A participant";
+  if (inviteeAgentId) {
+    const invitee = await ensureAgentPrincipalIdentity(inviteeAgentId);
+    inviteePrincipalId = invitee?.principalId ?? null;
+    inviteeLabel = invitee?.displayName?.trim() || "A coworker";
+  } else if (inviteeUserId) {
+    const invitee = await syncUserPrincipal(inviteeUserId);
+    inviteePrincipalId = invitee?.principalId ?? null;
+    inviteeLabel = invitee?.displayName?.trim() || "A teammate";
+  }
+  if (!inviteePrincipalId) {
+    return { success: false, error: "not_found", message: "The invitee's principal could not be resolved." };
+  }
+
+  const canAct = params["canAct"] !== false; // default: invited to participate (post), not merely observe
+  const roles: WorkRoomParticipantRole[] = ["contributor"];
+  const newEvidence = appendRoomPolicyParticipant(item.evidence, {
+    principalRef: inviteePrincipalId,
+    roles,
+    canAct,
+  });
+  await prisma.workItem.update({ where: { id: item.id }, data: { evidence: newEvidence as never } });
+
+  const commentDb: PostCommentDb = {
+    workItemMessage: { create: (args) => prisma.workItemMessage.create(args as never) },
+    notification: { create: (args) => prisma.notification.create(args as never) },
+  };
+  const canonicalSourceId = item.sourceId ?? item.itemId;
+  await postWorkItemComment({
+    db: commentDb,
+    workItemId: item.id,
+    workItemTitle: item.title,
+    roomRef: { caseKey, caseId: `${item.sourceType}:${canonicalSourceId}`, workItemId: item.itemId },
+    body: `Invited ${inviteeLabel} into the room${canAct ? "" : " (read-only)"}.`,
+    sender: { type: "agent", id: agentId, label: await agentLabel(agentId) },
+    roster: {},
+  });
+  if (inviteeAgentId) {
+    await heartbeatAgentWorkItemPresence({ workItemId: item.id, agentPrincipalId: inviteePrincipalId, label: inviteeLabel });
+  }
+
+  return {
+    success: true,
+    message: `Invited ${inviteeLabel} into ${caseKey}${canAct ? "" : " (read-only)"}.`,
+    data: { caseKey, principalRef: inviteePrincipalId, canAct },
+  };
+}
+
+async function getCoworkerRoomEngagementHandler(
+  params: Record<string, unknown>,
+  _userId: string,
+  context?: PackContext,
+): Promise<ToolResult> {
+  const targetAgentId = str(params, "agentId") ?? context?.agentId ?? null;
+  if (!targetAgentId) {
+    return { success: false, error: "invalid_input", message: "agentId is required (or call as a coworker)." };
+  }
+  const engagement = await getCoworkerRoomEngagement({ agentId: targetAgentId });
+  return {
+    success: true,
+    message: `${engagement.activeRoomCount} active Work Room(s) for ${targetAgentId}.`,
+    data: engagement as unknown as Record<string, unknown>,
+  };
+}
+
 const definitions: ToolDefinition[] = [
   {
     name: "post_room_message",
@@ -212,6 +317,37 @@ const definitions: ToolDefinition[] = [
     requiredCapability: "view_operations",
     sideEffect: false,
   },
+  {
+    name: "invite_room_participant",
+    description:
+      "Call a new participant into a Work Room on demand — invite an AI coworker (agentId) or a person (userId) into the room addressed by caseKey. Only a room member with action rights (e.g. the Coordinator) may invite. The invitee is admitted outcome-scoped to THIS room (content by default; canAct=true also lets them post). Records the join and, for a coworker, marks it present.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        caseKey: { type: "string", description: "The room's case key, e.g. backlog-item:BI-123 (sourceType:sourceId)." },
+        agentId: { type: "string", description: "Invite an AI coworker by agent id (provide agentId OR userId)." },
+        userId: { type: "string", description: "Invite a person by user id (provide agentId OR userId)." },
+        canAct: { type: "boolean", description: "Whether the invitee may post (true, default) or only read (false)." },
+      },
+      required: ["caseKey"],
+    },
+    requiredCapability: "view_operations",
+    sideEffect: true,
+  },
+  {
+    name: "get_coworker_room_engagement",
+    description:
+      "Coworker 360 utilization: which active Work Rooms an AI coworker is currently engaged in and its role in each (incl. Coordinator). Defaults to the calling coworker; pass agentId to inspect another. Presence-scoped (active rooms right now). Read-only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agentId: { type: "string", description: "Agent id to inspect. Defaults to the calling coworker." },
+      },
+      required: [],
+    },
+    requiredCapability: "view_operations",
+    sideEffect: false,
+  },
 ];
 
 export const roomMessagingPack: ToolPack = {
@@ -220,9 +356,13 @@ export const roomMessagingPack: ToolPack = {
   handlers: {
     post_room_message: (params, userId, context) => postRoomMessageHandler(params, userId, context),
     read_room_messages: (params, userId, context) => readRoomMessagesHandler(params, userId, context),
+    invite_room_participant: (params, userId, context) => inviteRoomParticipantHandler(params, userId, context),
+    get_coworker_room_engagement: (params, userId, context) => getCoworkerRoomEngagementHandler(params, userId, context),
   },
   grants: {
     post_room_message: ["work_room_write"],
     read_room_messages: ["work_room_read"],
+    invite_room_participant: ["work_room_write"],
+    get_coworker_room_engagement: ["work_room_read"],
   },
 };

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -204,6 +204,10 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   // admission is enforced separately (room-agent-access); these are the coarse caps.
   read_room_messages: ["work_room_read"],
   post_room_message: ["work_room_write"],
+  // EP-WORKROOM-COMMS: invite a participant on demand (write); 360 coworker
+  // room-engagement (read). Room admission/coordinator right enforced separately.
+  invite_room_participant: ["work_room_write"],
+  get_coworker_room_engagement: ["work_room_read"],
   create_work_capsule: ["work_capsule_write"],
   plan_capsule_worktree: ["work_capsule_write"],
   adopt_worktree: ["work_capsule_adopt"],

--- a/apps/web/lib/work-management/coworker-room-engagement.server.ts
+++ b/apps/web/lib/work-management/coworker-room-engagement.server.ts
@@ -1,0 +1,77 @@
+/**
+ * 360 coworker-utilization read model (EP-WORKROOM-COMMS, BI-3EDEA0D8).
+ *
+ * Inverts the per-room participant view into a per-coworker rollup: for an AI
+ * coworker, which Work Rooms it is actively engaged in right now, its role in each
+ * (incl. Coordinator), so an operator can manage coworker use across rooms and
+ * recognise routine engagement patterns. Presence-scoped ("active workrooms").
+ *
+ * Server-only. Refs are canonical Principal.principalId (PRN).
+ * Design of record: docs/superpowers/specs/2026-08-12-work-room-multi-agent-communication-substrate-design.md §2
+ */
+import { prisma } from "@dpf/db";
+
+import { ensureAgentPrincipalIdentity } from "@/lib/identity/principal-linking";
+import type { WorkRoomParticipantRole } from "./room-types";
+import { PRESENCE_ACTIVE_WINDOW_MS } from "./work-item-presence";
+import { encodeWorkCaseKey } from "./workspace-case-loader";
+import { readWorkspaceRoomPolicy } from "./workspace-room-access";
+
+export interface CoworkerRoomEngagementRoom {
+  caseKey: string;
+  roles: WorkRoomParticipantRole[];
+  coordinator: boolean;
+  activeNow: boolean;
+}
+
+export interface CoworkerRoomEngagement {
+  agentId: string;
+  principalRef: string | null;
+  activeRoomCount: number;
+  rooms: CoworkerRoomEngagementRoom[];
+}
+
+/**
+ * Resolve which active Work Rooms a coworker is currently engaged in, and its role
+ * in each. Empty when the coworker has no live presence in any room.
+ */
+export async function getCoworkerRoomEngagement(input: {
+  agentId: string;
+  now?: Date;
+}): Promise<CoworkerRoomEngagement> {
+  const principal = await ensureAgentPrincipalIdentity(input.agentId);
+  const principalRef = principal?.principalId ?? null;
+  if (!principalRef) {
+    return { agentId: input.agentId, principalRef: null, activeRoomCount: 0, rooms: [] };
+  }
+
+  const now = input.now ?? new Date();
+  const cutoff = new Date(now.getTime() - PRESENCE_ACTIVE_WINDOW_MS);
+  const presence = await prisma.workItemPresence.findMany({
+    where: { principalType: "agent", principalId: principalRef, lastSeenAt: { gte: cutoff } },
+    select: { workItemId: true },
+  });
+  if (presence.length === 0) {
+    return { agentId: input.agentId, principalRef, activeRoomCount: 0, rooms: [] };
+  }
+
+  const workItemIds = [...new Set(presence.map((row) => row.workItemId))];
+  const items = await prisma.workItem.findMany({
+    where: { id: { in: workItemIds } },
+    select: { id: true, itemId: true, sourceType: true, sourceId: true, evidence: true },
+  });
+
+  const rooms: CoworkerRoomEngagementRoom[] = items.map((item) => {
+    const policy = readWorkspaceRoomPolicy(item.evidence);
+    const mine = (policy.participants ?? []).find((participant) => participant.principalRef === principalRef);
+    const roles = (mine?.roles ?? []) as WorkRoomParticipantRole[];
+    return {
+      caseKey: encodeWorkCaseKey({ sourceType: item.sourceType, sourceId: item.sourceId ?? item.itemId }),
+      roles,
+      coordinator: roles.includes("coordinator"),
+      activeNow: true,
+    };
+  });
+
+  return { agentId: input.agentId, principalRef, activeRoomCount: rooms.length, rooms };
+}

--- a/apps/web/lib/work-management/room-agent-access.server.ts
+++ b/apps/web/lib/work-management/room-agent-access.server.ts
@@ -30,16 +30,14 @@ export async function resolveAgentRoomAccess(input: {
   workItem: { id: string; evidence: unknown; assignedToAgentId: string | null };
 }): Promise<AgentRoomAccessResult> {
   const principal = await ensureAgentPrincipalIdentity(input.agentId);
-  const agentPrincipalId = principal?.id ?? null;
+  // The room ref space is the canonical Principal.principalId (PRN) — the pure
+  // decision, the participant projection, and the policy refs all agree on it.
+  const agentPrincipalId = principal?.principalId ?? null;
   if (!agentPrincipalId) {
     return { decision: { level: "none", reason: "not-admitted" }, agentPrincipalId: null };
   }
 
-  const [clearanceRow, capsules, assignedPrincipal] = await Promise.all([
-    prisma.principal.findUnique({
-      where: { principalId: agentPrincipalId },
-      select: { sensitivityClearance: true },
-    }),
+  const [capsules, assignedPrincipal] = await Promise.all([
     prisma.workCapsule.findMany({
       where: { workItemId: input.workItem.id },
       select: {
@@ -53,19 +51,31 @@ export async function resolveAgentRoomAccess(input: {
       : Promise.resolve(null),
   ]);
 
+  // Clearance rides on the synced principal — no separate (and previously
+  // mis-keyed) lookup.
   const agentSensitivityClearance =
-    (clearanceRow?.sensitivityClearance as string[] | undefined) ?? [...DEFAULT_AGENT_CLEARANCE];
+    (principal?.sensitivityClearance as string[] | undefined) ?? [...DEFAULT_AGENT_CLEARANCE];
   const policy = readWorkspaceRoomPolicy(input.workItem.evidence);
 
-  const capsuleHolderRefs = capsules.flatMap((capsule) =>
+  // Capsule holder fields store the relational Principal.id (cuid); map them to
+  // the canonical PRN so a capsule executor matches the room ref space.
+  const capsuleHolderCuids = capsules.flatMap((capsule) =>
     [capsule.leaseHolderPrincipalId, capsule.createdByPrincipalId, capsule.requestedByPrincipalId]
       .filter((ref): ref is string => typeof ref === "string" && ref.length > 0),
   );
+  const capsuleHolderRefs = capsuleHolderCuids.length
+    ? (
+        await prisma.principal.findMany({
+          where: { id: { in: capsuleHolderCuids } },
+          select: { principalId: true },
+        })
+      ).map((row) => row.principalId)
+    : [];
 
   const actionPrincipalRefs = [
     ...(policy.actionPrincipalRefs ?? []),
     ...capsuleHolderRefs,
-    ...(assignedPrincipal?.id ? [assignedPrincipal.id] : []),
+    ...(assignedPrincipal?.principalId ? [assignedPrincipal.principalId] : []),
   ];
   const admittedPrincipalRefs = [...(policy.admittedPrincipalRefs ?? []), ...actionPrincipalRefs];
 

--- a/apps/web/lib/work-management/room-policy.test.ts
+++ b/apps/web/lib/work-management/room-policy.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { appendRoomPolicyParticipant } from "./room-policy";
+import { readWorkspaceRoomPolicy } from "./workspace-room-access";
+
+function latestPolicy(evidence: unknown) {
+  return readWorkspaceRoomPolicy(evidence);
+}
+
+describe("appendRoomPolicyParticipant", () => {
+  it("admits an invitee with action rights when canAct", () => {
+    const out = appendRoomPolicyParticipant(null, {
+      principalRef: "PRN-invitee",
+      roles: ["contributor"],
+      canAct: true,
+    });
+    const policy = latestPolicy(out);
+    expect(policy.admittedPrincipalRefs).toContain("PRN-invitee");
+    expect(policy.actionPrincipalRefs).toContain("PRN-invitee");
+    expect(policy.participants?.[0]).toMatchObject({ principalRef: "PRN-invitee", roles: ["contributor"] });
+  });
+
+  it("admits read-only (content, not action) when canAct is false", () => {
+    const out = appendRoomPolicyParticipant(null, {
+      principalRef: "PRN-observer",
+      roles: ["observer"],
+      canAct: false,
+    });
+    const policy = latestPolicy(out);
+    expect(policy.admittedPrincipalRefs).toContain("PRN-observer");
+    expect(policy.actionPrincipalRefs ?? []).not.toContain("PRN-observer");
+  });
+
+  it("appends (latest-wins) without clobbering prior evidence", () => {
+    const prior = [{ workRoomCycle: { boundary: 1 } }, { workRoomPolicy: { admittedPrincipalRefs: ["PRN-a"], actionPrincipalRefs: ["PRN-a"], discoverablePrincipalRefs: [], sensitivityCeiling: "internal", participants: [] } }];
+    const out = appendRoomPolicyParticipant(prior, { principalRef: "PRN-b", roles: ["contributor"], canAct: true });
+    // prior entries preserved
+    expect(out.length).toBe(prior.length + 1);
+    expect(out[0]).toEqual({ workRoomCycle: { boundary: 1 } });
+    // latest policy now admits both a (carried) and b (new)
+    const policy = latestPolicy(out);
+    expect(policy.admittedPrincipalRefs).toEqual(expect.arrayContaining(["PRN-a", "PRN-b"]));
+  });
+
+  it("de-dupes a re-invited principal in the participants list", () => {
+    const first = appendRoomPolicyParticipant(null, { principalRef: "PRN-x", roles: ["observer"], canAct: false });
+    const second = appendRoomPolicyParticipant(first, { principalRef: "PRN-x", roles: ["contributor"], canAct: true });
+    const policy = latestPolicy(second);
+    const xs = (policy.participants ?? []).filter((p) => p.principalRef === "PRN-x");
+    expect(xs).toHaveLength(1);
+    expect(xs[0].roles).toEqual(["contributor"]);
+    expect(policy.actionPrincipalRefs).toContain("PRN-x");
+  });
+});

--- a/apps/web/lib/work-management/room-policy.ts
+++ b/apps/web/lib/work-management/room-policy.ts
@@ -1,0 +1,58 @@
+/**
+ * Work Room policy writer (EP-WORKROOM-COMMS, BI-8CD6E35F).
+ *
+ * The substrate READS an outcome-scoped `{ workRoomPolicy: {...} }` object off
+ * WorkItem.evidence (workspace-room-access.readWorkspaceRoomPolicy, latest-wins)
+ * but nothing WRITES it. This is the pure writer: given the current evidence and
+ * an invitee, it returns a new evidence array with an appended policy snapshot
+ * that admits the invitee — preserving the append/latest-wins contract rather
+ * than clobbering prior evidence. Membership stays outcome-scoped per room.
+ *
+ * Pure module: no DB. Refs are canonical Principal.principalId (PRN).
+ * Design of record: docs/superpowers/specs/2026-08-12-work-room-multi-agent-communication-substrate-design.md §1-§2
+ */
+import type { WorkRoomParticipantRole } from "./room-types";
+import { readWorkspaceRoomPolicy } from "./workspace-room-access";
+
+export interface RoomParticipantInvite {
+  /** Canonical Principal.principalId (PRN) of the invitee. */
+  principalRef: string;
+  roles: WorkRoomParticipantRole[];
+  /** Whether the invitee may act (post) in the room, not just read. */
+  canAct: boolean;
+  enteredReason?: string | null;
+}
+
+/**
+ * Append a policy snapshot to the room's evidence that admits `invite`.
+ * Returns the new evidence array (the caller persists it to WorkItem.evidence).
+ */
+export function appendRoomPolicyParticipant(evidence: unknown, invite: RoomParticipantInvite): unknown[] {
+  const current = readWorkspaceRoomPolicy(evidence);
+
+  const admitted = new Set([...(current.admittedPrincipalRefs ?? []), invite.principalRef]);
+  const action = new Set(current.actionPrincipalRefs ?? []);
+  if (invite.canAct) action.add(invite.principalRef);
+
+  const roles = invite.roles.length > 0 ? invite.roles : (["observer"] as WorkRoomParticipantRole[]);
+  const participants = [
+    ...(current.participants ?? []).filter((participant) => participant.principalRef !== invite.principalRef),
+    {
+      principalRef: invite.principalRef,
+      roles,
+      enteredReason: invite.enteredReason ?? "Invited into the room",
+      currentWorkSummary: null,
+    },
+  ];
+
+  const mergedPolicy = {
+    admittedPrincipalRefs: [...admitted],
+    actionPrincipalRefs: [...action],
+    discoverablePrincipalRefs: current.discoverablePrincipalRefs ?? [],
+    sensitivityCeiling: current.sensitivityCeiling ?? "internal",
+    participants,
+  };
+
+  const prior = Array.isArray(evidence) ? evidence : evidence ? [evidence] : [];
+  return [...prior, { workRoomPolicy: mergedPolicy }];
+}

--- a/docs/superpowers/specs/2026-08-13-awc-standard-augmentation-room-collaboration.md
+++ b/docs/superpowers/specs/2026-08-13-awc-standard-augmentation-room-collaboration.md
@@ -1,0 +1,28 @@
+# AWC Standard Candidate — Room-Collaboration Augmentation
+
+**Status:** DRAFT (normative input for the AWC standard candidate) · **Date:** 2026-08-13 · **Scope:** platform (WWMD)
+**Augments:** BI-AADFFCAF (Agentic Work Case standard candidate, EP-E1F1DB58) · **Source epic:** EP-WORKROOM-COMMS
+**Design of record:** `docs/superpowers/specs/2026-08-12-work-room-multi-agent-communication-substrate-design.md`
+
+This is BI-A988A3C5: as the Work Room multi-agent collaboration substrate shipped (agents join/post/read, Coordinator role, outcome-scoped membership, on-demand invite, 360 engagement), fold what it proved into the **Agentic Work Case (AWC)** standard candidate as normative content, so the standard is grounded in a running reference implementation rather than a paper. Kept as a feeder to BI-AADFFCAF; the standard is externalized there.
+
+## Normative additions for AWC (composition over A2A + MCP Tasks + CMMN + RACI)
+
+### 1. Participant model — human + AI as symmetric principals
+A work case's room admits **person | agent | system | external** principals under one identity, with a closed role set:
+`accountable · coordinator · contributor · reviewer · observer` (RACI/DACI-derived; **coordinator ↔ DACI Driver**). Roles are additive per principal; one principal may hold several (e.g. accountable + coordinator). This is the layer A2A (one task/one agent/two roles) and MCP Tasks do not carry.
+
+### 2. Coordinator — a first-class role
+Exactly one active Coordinator per room keeps it on-task to its outcome (admit/curate members within the clearance ceiling, sequence turns, drive to verdict/close/escalate). Distinct from Accountable (owns the outcome). Maps to DACI **Driver**; realizes the orchestrator half of the orchestrator-worker pattern. Shipped: `room-coordinator.ts` (single-active-coordinator invariant).
+
+### 3. Outcome-scoped membership — the focus mechanism
+Admission is decided **per room**, scoped to that room's outcome and sensitivity ceiling; admission to one room grants nothing in another. Access is a lattice: `none < discover < content < action`, gated by admission + clearance ≥ ceiling; **presence never grants authority**. On-demand invite (`invite_room_participant`) is the governed membership writer; a Coordinator/action-holder calls a coworker or person in. Shipped: `room-agent-access.ts`, `room-policy.ts`.
+
+### 4. Room id ⇄ A2A `contextId` — the interop hook
+The room is the shared semantic space that groups a case's messages and tasks; propose **room caseKey (`sourceType:sourceId`) ⇄ A2A `contextId`** so cross-install rooms are addressable over A2A transport. A2A stays the sovereign wire (coordinate-by-proposal, apply-by-proposal); the room is the semantic layer. Consistent with the ratified `author-awc-composition` decision (DI-149854BD4A55).
+
+### 5. Presence & engagement — observability, not authority
+`principalType:"agent"` presence + a per-coworker 360 rollup (`get_coworker_room_engagement`: which active rooms, what role). Presence is an observability signal only — never an authority grant (§3).
+
+## Boundary to the standard
+AWC **composes, never reinvents**: A2A for task transport + AgentCard (adopt verbatim), MCP Tasks for async execution (loose — spec in flux), CMMN for case/stage/milestone/role semantics, RACI/DACI for the accountability vocabulary. The **new normative layer** AWC contributes is exactly §1–§5 above: the human+AI collaboration room with roles, outcome-scoped membership, and a governance/outcome envelope — the piece no surveyed standard owns. Externalization + upstream contribution (Linux Foundation agentic cluster) proceed under BI-AADFFCAF, sequenced after the conformance gate proves the internal contract.

--- a/docs/user-guide/workspace/work-rooms.md
+++ b/docs/user-guide/workspace/work-rooms.md
@@ -49,6 +49,10 @@ AI coworkers remain governed participants. Joining a room does not expand their 
 
 An admitted coworker can **read the room's message feed and post into it**, and appears as present while it works. Whether a coworker may read or post is decided per room, scoped to that room's outcome and sensitivity—being admitted to one room grants nothing in another. A coworker working the room's underlying task (for example an external CLI session on the room's build) is admitted to that room as it joins.
 
+A room can also **call in new participants on demand**: a member with action rights (typically the Coordinator) can invite another coworker or a person into the room, either to participate or read-only. The invitee is admitted only to that room, for that room's outcome—never granted anything elsewhere.
+
+Across rooms, you can see **where each AI coworker is engaged**—which active rooms it is in and its role in each (including where it coordinates). This 360 view helps manage how coworkers are used and recognise the routine patterns worth pre-positioning them for.
+
 An authorized coworker can also open a relevant product surface from the room's work type, resources, or task intent—even when no browser page is rendered. These silent/headless surfaces use the same semantic fields, validation, and governed actions as the human browser or mobile view. Room membership still does not expand authority: the surface catalog and every action apply the human role, coworker grants, room/work context, token scope, and approval rules together.
 
 Open **Participants** to see why each person or coworker is in the room, what they are working on, their authority summary, and an AI coworker's accountable sponsor. Coworkers created by the active thread's governed lineage appear automatically; the room does not provide an unrestricted coworker picker.

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -1450,20 +1450,22 @@
     },
     {
       "key": "work_room_read",
-      "description": "Read a Work Room's message feed.",
+      "description": "Read a Work Room's message feed and coworker room engagement.",
       "category": "integrate",
       "sensitivity": "internal",
       "honored_by_tools": [
+        "get_coworker_room_engagement",
         "read_room_messages"
       ],
       "implies": []
     },
     {
       "key": "work_room_write",
-      "description": "Post a message into a Work Room.",
+      "description": "Post a message into a Work Room and invite participants.",
       "category": "integrate",
       "sensitivity": "internal",
       "honored_by_tools": [
+        "invite_room_participant",
         "post_room_message"
       ],
       "implies": [

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -54,7 +54,7 @@ apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1621
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	914
-apps/web/lib/tak/agent-grants.ts	931
+apps/web/lib/tak/agent-grants.ts	935
 apps/web/lib/tak/agent-routing.ts	1053
 apps/web/lib/tak/agentic-loop.test.ts	2501
 apps/web/lib/tak/agentic-loop.ts	2811

--- a/scripts/tool-surface-baseline.json
+++ b/scripts/tool-surface-baseline.json
@@ -3,8 +3,8 @@
   "selectionCliff": 15,
   "entries": {
     "registry.toolDefinitions": {
-      "value": 374,
-      "reason": "Adds post_room_message and read_room_messages so an admitted AI coworker can post into and read a Work Room's message feed — the shared-room communication pattern (EP-WORKROOM-COMMS, BI-3F21C4D5/BI-4402DABB). They are distinct governed contracts: posting is a room-scoped write gated by outcome-scoped agent membership (room-agent-access) that also heartbeats presence, while reading is a content-gated feed read. No existing tool is addressed by a room caseKey or enforces per-room agent admission, so neither can carry these contracts.",
+      "value": 376,
+      "reason": "Adds invite_room_participant and get_coworker_room_engagement (EP-WORKROOM-COMMS). invite_room_participant is the on-demand membership WRITER — a governed action that admits a coworker or person into a room (Coordinator/action-rights gated), the write side no existing tool provides. get_coworker_room_engagement is the 360 coworker-utilization read — which active rooms a coworker is engaged in and its role — a per-coworker inversion of the room projection that no existing roster tool exposes. Both are distinct contracts within the room-messaging surface.",
       "recordedAt": "2026-08-13"
     },
     "registry.packFiles": {


### PR DESCRIPTION
Finishes **EP-WORKROOM-COMMS** Phase 1: on-demand membership, coworker 360 visibility, the AWC standards feeder, and a fix to the identity glue from the prior slice (#4270). One PR, per operator directive.

## What

- **Identity fix** (`room-agent-access.server.ts`) — the room ref space is canonical `Principal.principalId` (PRN); the resolver used the relational `Principal.id` (cuid), so agent clearance silently defaulted and presence was mis-keyed. Now **PRN throughout** (agent id, clearance from the synced principal, capsule-holder cuids → PRN, assigned agent), consistent with the participant projection. (It passed CI in #4270 because only the *pure* function was unit-tested, not the `.server` glue.)
- **`invite_room_participant`** + the missing **policy writer** (`room-policy.ts`, pure+tested) — a Coordinator/action-holder calls a coworker or person into a room on demand, admitted **outcome-scoped** (post or read-only), recorded + present. (**BI-8CD6E35F**)
- **`get_coworker_room_engagement`** + read model (`coworker-room-engagement.server.ts`) — the **360**: which active rooms a coworker is in and its role in each (incl. Coordinator). (**BI-3EDEA0D8**)
- **AWC standards augmentation** doc — folds the shipped participant/coordinator/outcome-scoped-membership + room↔A2A-`contextId` model into the AWC standard candidate as normative input. (**BI-A988A3C5**, feeds BI-AADFFCAF)
- Grants/catalog/tool-surface baselines bumped; `work-rooms.md` documents invite + the 360 view.

## Verification

Local-CI merge gate **passed** (merged against current main; full typecheck + suite + build; evidence `cmstczym51t5601ny4gsmo8om`). Rebased onto current main; 1358 tests (incl. new `room-policy` suite); typecheck clean; coworker-grant audit exit 0; tool-surface in sync; **WorkUnit conformance gate passes** for the new room modules; module-size re-baselined.

## Scope

**Completes EP-WORKROOM-COMMS Phase 1.** Deferred by design: Phase 2 cross-install GAID (**BI-4CA4FCE5**, kernel intra-first `DI-A92A7184020F`); debate-on-rooms (**EP-DELIBERATION-ROOMS / BI-F8C5444A**, a separately-tracked approach); and follow-ups (360 fleet surface wiring, Coordinator-specific admit gating, live SSE push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Seed-Fit-Decision: global-default