### PR TITLE
feat(tak): gate consequential tools on WWWD×WSID alignment

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/matrix/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/matrix/page.tsx
@@ -11,6 +11,7 @@ import {
   buildMatrixDimensions,
   buildMatrixTierWeights,
 } from "@/lib/wiki/principle-matrix";
+import { STANCE_ALIGNMENT_DIMENSIONS } from "@/lib/decision-perspective/stance-dimension-map";
 
 export const dynamic = "force-dynamic";
 
@@ -21,6 +22,9 @@ export const metadata = {
 export default async function DecisionMatrixPage() {
   const dimensions = buildMatrixDimensions();
   const tierWeights = buildMatrixTierWeights();
+  const alignmentDimensionKeys = new Set<string>(STANCE_ALIGNMENT_DIMENSIONS);
+  const coreDimensions = dimensions.filter((d) => !alignmentDimensionKeys.has(d.key));
+  const alignmentDimensions = dimensions.filter((d) => alignmentDimensionKeys.has(d.key));
 
   // Live tally: how many published principles weigh on each axis. A near-empty
   // axis or a heavily-loaded one is where de-confliction/analysis tends to land.
@@ -34,6 +38,30 @@ export default async function DecisionMatrixPage() {
       countByDimension.set(dim, (countByDimension.get(dim) ?? 0) + 1);
     }
   }
+
+  const renderDimension = (d: (typeof dimensions)[number]) => {
+    const count = countByDimension.get(d.key) ?? 0;
+    return (
+      <li key={d.key} className="flex items-center gap-3 px-4 py-2.5">
+        <span className="text-sm text-[var(--dpf-text)] min-w-0 flex-1 truncate">
+          {d.label}
+        </span>
+        <span
+          className="rounded border px-2 py-0.5 text-[10px] uppercase tracking-wide shrink-0"
+          style={{
+            color: d.kind === "cost" ? "var(--dpf-warning)" : "var(--dpf-muted)",
+            borderColor:
+              d.kind === "cost" ? "var(--dpf-warning)" : "var(--dpf-border)",
+          }}
+        >
+          {d.kind}
+        </span>
+        <span className="text-xs text-[var(--dpf-muted)] shrink-0 w-24 text-right">
+          {count} principle{count !== 1 ? "s" : ""}
+        </span>
+      </li>
+    );
+  };
 
   return (
     <div className="max-w-4xl mx-auto py-6 px-4">
@@ -54,10 +82,9 @@ export default async function DecisionMatrixPage() {
           The decision matrix
         </h1>
         <p className="text-sm text-[var(--dpf-muted)]">
-          Every principle is scored on these axes, weighted by its tier. This is
-          the criteria your AI weighs — review it when the axes or weights
-          themselves need adjustment. The count shows how many principles pull on
-          each axis today.
+          Every principle is scored on these axes. This is the criteria your AI
+          weighs — review it when the axes or weights themselves need adjustment.
+          The count shows how many principles pull on each axis today.
         </p>
       </header>
 
@@ -66,31 +93,16 @@ export default async function DecisionMatrixPage() {
           Axes
         </h2>
         <ul className="divide-y divide-[var(--dpf-border)] rounded-lg border border-[var(--dpf-border)]">
-          {dimensions.map((d) => {
-            const count = countByDimension.get(d.key) ?? 0;
-            return (
-              <li key={d.key} className="flex items-center gap-3 px-4 py-2.5">
-                <span className="text-sm text-[var(--dpf-text)] min-w-0 flex-1 truncate">
-                  {d.label}
-                </span>
-                <span
-                  className="rounded border px-2 py-0.5 text-[10px] uppercase tracking-wide shrink-0"
-                  style={{
-                    color:
-                      d.kind === "cost" ? "var(--dpf-warning)" : "var(--dpf-muted)",
-                    borderColor:
-                      d.kind === "cost" ? "var(--dpf-warning)" : "var(--dpf-border)",
-                  }}
-                >
-                  {d.kind}
-                </span>
-                <span className="text-xs text-[var(--dpf-muted)] shrink-0 w-24 text-right">
-                  {count} principle{count !== 1 ? "s" : ""}
-                </span>
-              </li>
-            );
-          })}
+          {coreDimensions.map(renderDimension)}
         </ul>
+        <details className="mt-3 rounded-lg border border-[var(--dpf-border)]">
+          <summary className="cursor-pointer px-4 py-3 text-sm font-medium text-[var(--dpf-text)]">
+            Business alignment axes
+          </summary>
+          <ul className="divide-y divide-[var(--dpf-border)] border-t border-[var(--dpf-border)]">
+            {alignmentDimensions.map(renderDimension)}
+          </ul>
+        </details>
       </section>
 
       <section className="mb-8">

--- a/apps/web/lib/actions/business-stance.ts
+++ b/apps/web/lib/actions/business-stance.ts
@@ -13,6 +13,10 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "@dpf/db";
 import { saveWikiOverlayEdit } from "@/lib/actions/wiki-edit";
 import { promoteStanceMaterial } from "@/lib/decision-perspective/stance-promotion";
+import {
+  projectDeclaredStanceAlignment,
+  type StanceAlignmentDimension,
+} from "@/lib/decision-perspective/stance-dimension-map";
 import { storeWikiPage } from "@/lib/wiki/embeddings";
 import {
   decisionAreaToDomainClass,
@@ -81,6 +85,15 @@ export async function publishBusinessStance(
   if (!domainClass) {
     return { ok: false, error: "Pick the kind of decisions this stance guides." };
   }
+  const alignmentByDecisionArea: Record<string, readonly StanceAlignmentDimension[]> = {
+    "customers-and-money": ["market_fit", "gtm_fit"],
+    "priorities-and-planning": ["mission_fit", "market_fit", "product_fit", "gtm_fit"],
+    "quality-and-craft": ["product_fit"],
+    "vendors-and-tools": ["product_fit", "gtm_fit"],
+  };
+  const projection = projectDeclaredStanceAlignment(
+    alignmentByDecisionArea[input.decisionArea] ?? [],
+  );
 
   const result = await saveWikiOverlayEdit({
     slug: validated.slug,
@@ -90,6 +103,7 @@ export async function publishBusinessStance(
     status: "published",
     abstract: validated.summary,
     changeSummary: "Business stance published via the WWWD editor",
+    ...projection,
   });
   if (!result.ok) {
     return { ok: false, error: result.error };
@@ -115,6 +129,7 @@ export async function publishBusinessStance(
       kernelVersion: null,
       organizationId: org.id,
       kernelPageId: null,
+      ...projection,
     });
   } catch {
     // best-effort; enforcement continues below

--- a/apps/web/lib/actions/stance-confirm.ts
+++ b/apps/web/lib/actions/stance-confirm.ts
@@ -16,6 +16,7 @@ import { prisma } from "@dpf/db";
 import { upsertWikiPage, appendRevision } from "@dpf/db/wiki-store";
 import { requireCapability } from "@/lib/actions/shared/guards";
 import { promoteStanceMaterial } from "@/lib/decision-perspective/stance-promotion";
+import { projectStanceDimensionVector } from "@/lib/decision-perspective/stance-dimension-map";
 import { storeWikiPage } from "@/lib/wiki/embeddings";
 import {
   resolveStanceVectors,
@@ -88,6 +89,7 @@ export async function confirmStanceVectors(input: {
         status: "published",
         isKernel: false,
         abstract,
+        ...projectStanceDimensionVector(vector.key),
       })) as { id: string };
 
       if (!existing || existing.body !== body) {
@@ -113,6 +115,7 @@ export async function confirmStanceVectors(input: {
             kernelVersion: null,
             organizationId: org.id,
             kernelPageId: null,
+            ...projectStanceDimensionVector(vector.key),
           });
         } catch {
           // best-effort

--- a/apps/web/lib/actions/wiki-edit.ts
+++ b/apps/web/lib/actions/wiki-edit.ts
@@ -63,6 +63,9 @@ export type SaveWikiOverlayEditInput = {
    * that). Omitted = column left untouched on update.
    */
   metadata?: Record<string, unknown> | null;
+  /** Closed-axis projection for stance pages; carries evidence, never authority. */
+  principleDimensionVector?: Record<string, number>;
+  principleDimensions?: string[];
 };
 
 export type SaveWikiOverlayEditResult =
@@ -256,6 +259,12 @@ export async function saveWikiOverlayEdit(
       isKernel: false,
       abstract: input.abstract ?? null,
       ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+      ...(input.principleDimensionVector !== undefined
+        ? { principleDimensionVector: input.principleDimensionVector }
+        : {}),
+      ...(input.principleDimensions !== undefined
+        ? { principleDimensions: input.principleDimensions }
+        : {}),
       kernelPageId: input.overridesKernelPageId ?? null,
       derivedFromKernelVersion: input.overridesKernelPageId
         ? readKernelVersionFromManifest()

--- a/apps/web/lib/decision-perspective/alignment-criteria.test.ts
+++ b/apps/web/lib/decision-perspective/alignment-criteria.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateConstitutionalAlignment,
+  extractAlignmentCriteria,
+} from "./alignment-criteria";
+
+const arcamanusCorpora = {
+  wwwd: [{ ref: "wiki:org-who-we-serve", text: "We serve software teams and MSP partners. We decline selling toasters to fishermen in Alaska." }],
+  portfolio: [{ ref: "product:dpf", text: "Digital Product Factory self-hosted software platform and support subscription" }],
+  gtm: [{ ref: "wiki:org-how-we-decide", text: "Open-source software with assurance subscriptions through an MSP partner channel" }],
+};
+
+describe("constitutional alignment criteria", () => {
+  it("extracts the toaster action into evidence-bearing criteria", () => {
+    const result = extractAlignmentCriteria("Sell toasters to Alaskan fishermen from dock kiosks");
+    expect(result.status).toBe("complete");
+    expect(result.criteria).toMatchObject({
+      geography: "alaska",
+      customerType: "fishermen",
+      product: "toasters",
+      motion: "kiosk retail",
+      segment: "consumer physical retail",
+    });
+  });
+
+  it("vetoes an explicit hard boundary before aggregate positives can average it away", () => {
+    const result = evaluateConstitutionalAlignment({
+      statement: "Sell toasters to Alaskan fishermen from dock kiosks",
+      corpora: arcamanusCorpora,
+    });
+    expect(result.verdict).toBe("decline");
+    expect(result.veto).toMatchObject({ corpus: "wwwd", criterion: "market" });
+    expect(result.veto?.evidenceRefs).toContain("wiki:org-who-we-serve");
+  });
+
+  it("declines a novel physical-retail coffee-shop chain against a software corpus", () => {
+    expect(evaluateConstitutionalAlignment({
+      statement: "Launch a consumer coffee-shop chain in shopping malls",
+      corpora: arcamanusCorpora,
+    }).verdict).toBe("decline");
+  });
+
+  it.each([
+    "Sell an MSP partner subscription",
+    "Offer a self-hosted software support subscription",
+  ])("approves an on-direction offer: %s", (statement) => {
+    const result = evaluateConstitutionalAlignment({ statement, corpora: arcamanusCorpora });
+    expect(result.verdict).toBe("approve");
+    expect(result.checks.every((check) => check.verdict === "aligned")).toBe(true);
+  });
+
+  it("fails closed to escalation when salient criteria cannot be extracted", () => {
+    const result = evaluateConstitutionalAlignment({
+      statement: "Do the thing we discussed",
+      corpora: arcamanusCorpora,
+    });
+    expect(result.verdict).toBe("escalate");
+    expect(result.criteria.status).toBe("ambiguous");
+  });
+});

--- a/apps/web/lib/decision-perspective/alignment-criteria.ts
+++ b/apps/web/lib/decision-perspective/alignment-criteria.ts
@@ -1,0 +1,175 @@
+export const ALIGNMENT_CORPORA = ["wwwd", "portfolio", "gtm"] as const;
+export type AlignmentCorpus = (typeof ALIGNMENT_CORPORA)[number];
+
+export type AlignmentCriteria = {
+  market: string | null;
+  segment: string | null;
+  product: string | null;
+  motion: string | null;
+  geography: string | null;
+  customerType: string | null;
+};
+
+export type ExtractedAlignmentCriteria = {
+  status: "complete" | "ambiguous";
+  criteria: AlignmentCriteria;
+  evidence: string[];
+  missing: Array<keyof AlignmentCriteria>;
+};
+
+export type AlignmentEvidence = { ref: string; text: string };
+export type AlignmentCorpora = Record<AlignmentCorpus, AlignmentEvidence[]>;
+
+export type AlignmentCheck = {
+  corpus: AlignmentCorpus;
+  criterion: "mission" | "market" | "product" | "motion";
+  verdict: "aligned" | "rejected" | "unknown";
+  rationale: string;
+  evidenceRefs: string[];
+};
+
+export type ConstitutionalAlignmentResult = {
+  verdict: "approve" | "decline" | "escalate";
+  criteria: ExtractedAlignmentCriteria;
+  checks: AlignmentCheck[];
+  veto: AlignmentCheck | null;
+};
+
+function normalized(value: string): string {
+  return value.toLowerCase().replace(/alaskan/g, "alaska").replace(/[^a-z0-9-]+/g, " ").trim();
+}
+
+function firstMatch(text: string, patterns: Array<[RegExp, string]>): string | null {
+  return patterns.find(([pattern]) => pattern.test(text))?.[1] ?? null;
+}
+
+export function extractAlignmentCriteria(statement: string): ExtractedAlignmentCriteria {
+  const text = normalized(statement);
+  const product = firstMatch(text, [
+    [/\btoasters?\b/, "toasters"],
+    [/\bcoffee[ -]shops?\b|\bcoffee shop chain\b/, "coffee-shop chain"],
+    [/\bself-host(?:ed)?\b.*\bsupport\b.*\bsubscriptions?\b|\bsupport\b.*\bsubscriptions?\b/, "self-host support subscription"],
+    [/\bsubscriptions?\b/, "subscription"],
+    [/\bsoftware\b|\bplatform\b/, "software"],
+  ]);
+  const geography = firstMatch(text, [[/\balaska\b/, "alaska"]]);
+  const customerType = firstMatch(text, [
+    [/\bfisherm(?:a|e)n\b/, "fishermen"],
+    [/\bmsp\b.*\bpartners?\b|\bpartners?\b.*\bmsp\b/, "msp partner"],
+    [/\bsoftware teams?\b/, "software teams"],
+    [/\bconsumers?\b/, "consumer"],
+  ]);
+  const motion = firstMatch(text, [
+    [/\bkiosks?\b/, "kiosk retail"],
+    [/\bshopping malls?\b|\bretail\b|\bchain\b/, "retail chain"],
+    [/\bpartners?\b/, "partner channel"],
+    [/\bsubscriptions?\b/, "subscription"],
+  ]);
+  const segment = firstMatch(text, [
+    [/\btoasters?\b|\bcoffee[ -]shops?\b|\bkiosks?\b|\bshopping malls?\b/, "consumer physical retail"],
+    [/\bmsp\b|\bself-host(?:ed)?\b|\bsoftware\b/, "b2b software"],
+  ]);
+  const market = [segment, customerType, geography].filter(Boolean).join(" / ") || null;
+  const criteria = { market, segment, product, motion, geography, customerType };
+  const evidence = Object.entries(criteria)
+    .filter((entry): entry is [string, string] => Boolean(entry[1]))
+    .map(([key, value]) => `${key}=${value}`);
+  const missing = (Object.keys(criteria) as Array<keyof AlignmentCriteria>)
+    .filter((key) => criteria[key] === null);
+  const complete = Boolean(product && (market || motion));
+  return { status: complete ? "complete" : "ambiguous", criteria, evidence, missing };
+}
+
+const PHYSICAL_RETAIL = /\b(toaster|appliance|coffee shop|kiosk|shopping mall|physical retail|fisherm)/;
+const SOFTWARE_BUSINESS = /\b(software|platform|self-host|subscription|msp|open-source|assurance|digital product)/;
+const REJECTION = /\b(decline|reject|never|not serve|do not|don t|outside|exclude)/;
+
+function criterionFor(corpus: AlignmentCorpus): AlignmentCheck["criterion"] {
+  return corpus === "wwwd" ? "market" : corpus === "portfolio" ? "product" : "motion";
+}
+
+function salientTokens(criteria: AlignmentCriteria): string[] {
+  return Object.values(criteria)
+    .filter((value): value is string => Boolean(value))
+    .flatMap((value) => normalized(value).split(" "))
+    .filter((token) => token.length > 3 && !["consumer", "physical", "retail", "software"].includes(token));
+}
+
+function checkCorpus(
+  corpus: AlignmentCorpus,
+  evidence: AlignmentEvidence[],
+  criteria: AlignmentCriteria,
+  statement: string,
+): AlignmentCheck {
+  const criterion = criterionFor(corpus);
+  if (evidence.length === 0) {
+    return { corpus, criterion, verdict: "unknown", rationale: `No ${corpus} evidence was available.`, evidenceRefs: [] };
+  }
+  const action = normalized(statement);
+  const refs = evidence.map((item) => item.ref);
+  const documents = evidence.map((item) => normalized(item.text));
+  const tokens = salientTokens(criteria);
+  const explicitBoundary = evidence.filter((item) => {
+    return item.text.split(/[.;!?]/).some((rawSentence) => {
+      const sentence = normalized(rawSentence);
+      const overlap = tokens.filter((token) => sentence.includes(token)).length;
+      return REJECTION.test(sentence) && overlap >= 2;
+    });
+  });
+  if (explicitBoundary.length > 0) {
+    return {
+      corpus,
+      criterion,
+      verdict: "rejected",
+      rationale: `${corpus} contains an explicit boundary matching the proposed ${criterion}.`,
+      evidenceRefs: explicitBoundary.map((item) => item.ref),
+    };
+  }
+  const corpusText = documents.join(" ");
+  if (PHYSICAL_RETAIL.test(action) && SOFTWARE_BUSINESS.test(corpusText) && !PHYSICAL_RETAIL.test(corpusText)) {
+    return {
+      corpus,
+      criterion,
+      verdict: "rejected",
+      rationale: `${criterion} is physical-retail shaped while the cited ${corpus} is software-business shaped.`,
+      evidenceRefs: refs,
+    };
+  }
+  const overlap = tokens.some((token) => corpusText.includes(token));
+  const sameSoftwareDomain = SOFTWARE_BUSINESS.test(action) && SOFTWARE_BUSINESS.test(corpusText);
+  if (overlap || sameSoftwareDomain) {
+    return {
+      corpus,
+      criterion,
+      verdict: "aligned",
+      rationale: `${criterion} is supported by the cited ${corpus} evidence.`,
+      evidenceRefs: refs,
+    };
+  }
+  return {
+    corpus,
+    criterion,
+    verdict: "unknown",
+    rationale: `${corpus} does not provide enough evidence to establish ${criterion}.`,
+    evidenceRefs: refs,
+  };
+}
+
+export function evaluateConstitutionalAlignment(input: {
+  statement: string;
+  corpora: AlignmentCorpora;
+}): ConstitutionalAlignmentResult {
+  const criteria = extractAlignmentCriteria(input.statement);
+  if (criteria.status === "ambiguous") {
+    return { verdict: "escalate", criteria, checks: [], veto: null };
+  }
+  const checks = ALIGNMENT_CORPORA.map((corpus) =>
+    checkCorpus(corpus, input.corpora[corpus], criteria.criteria, input.statement),
+  );
+  const veto = checks.find((check) => check.verdict === "rejected") ?? null;
+  if (veto) return { verdict: "decline", criteria, checks, veto };
+  if (checks.some((check) => check.verdict === "unknown")) {
+    return { verdict: "escalate", criteria, checks, veto: null };
+  }
+  return { verdict: "approve", criteria, checks, veto: null };
+}

--- a/apps/web/lib/decision-perspective/constitutional-alignment-application.ts
+++ b/apps/web/lib/decision-perspective/constitutional-alignment-application.ts
@@ -1,0 +1,35 @@
+import {
+  evaluateConstitutionalAlignment,
+  type AlignmentCorpora,
+} from "./alignment-criteria";
+import type { DecisionPerspectiveEvaluationResult } from "./types";
+
+/** Apply independent corpus veto semantics to an already-computed WWWD evaluation. */
+export function applyConstitutionalAlignment(input: {
+  evaluation: DecisionPerspectiveEvaluationResult;
+  question: string;
+  corpora: AlignmentCorpora;
+}): void {
+  const alignment = evaluateConstitutionalAlignment({
+    statement: input.question,
+    corpora: input.corpora,
+  });
+  const evaluation = input.evaluation;
+  evaluation.constitutionalAlignment = alignment;
+  if (alignment.verdict === "decline" && alignment.veto) {
+    evaluation.outcomeType = "recommend";
+    evaluation.stanceAlignment = "decline";
+    evaluation.alignmentScore = -1;
+    evaluation.rationale =
+      `Recommend DECLINING: ${alignment.veto.corpus} rejects the ` +
+      `${alignment.veto.criterion} criterion. ${alignment.veto.rationale}`;
+  } else if (alignment.verdict === "escalate") {
+    evaluation.outcomeType = "escalate";
+    evaluation.stanceAlignment = "none";
+    evaluation.rationale =
+      "Constitutional alignment could not be established from complete criteria and all required corpora; escalating rather than inventing fit.";
+  } else {
+    evaluation.stanceAlignment = "approve";
+    evaluation.alignmentScore = 1;
+  }
+}

--- a/apps/web/lib/decision-perspective/evaluator.ts
+++ b/apps/web/lib/decision-perspective/evaluator.ts
@@ -4,14 +4,12 @@ import {
   resolveProfileMaterialForOrg,
   scorePerspectiveMaterial,
 } from "./material";
-import {
-  createDecisionInteractionId,
-  findExistingDecisionInteraction,
-  persistDecisionInteraction,
-} from "./persistence";
+import { createDecisionInteractionId, findExistingDecisionInteraction, persistDecisionInteraction } from "./persistence";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { MARK_DPF_PLATFORM_PROFILE } from "./default-profile";
-import { resolveRecommendedOptionId } from "./option-recommendation";
+import { resolveGateRecommendedOptionId } from "./option-recommendation";
+import type { AlignmentCorpora } from "./alignment-criteria";
+import { applyConstitutionalAlignment } from "./constitutional-alignment-application";
 import {
   hasPrincipleConflict,
   orderedProfileChain,
@@ -476,6 +474,7 @@ export async function evaluatePerspectiveGate(input: {
   now?: Date;
   coverageGapRationale?: string;
   onComplete?: (interactionId: string) => Promise<void> | void;
+  alignmentCorpora?: AlignmentCorpora;
 }): Promise<{
   allowed: boolean;
   interactionId: string;
@@ -732,18 +731,16 @@ export async function evaluatePerspectiveGate(input: {
       : "Decision perspective coverage gap: no active profile or fallback profile has applicable material for Build Studio plan advancement.");
     evaluation.resolvedProfileChain = resolved.resolvedProfileChain;
   }
-
-  // BI-D88DFEEA Phase 1 / BI-6DCF772F. Recommend only when the gate supplied
-  // scored options AND the verdict is a path forward — the guard now lives in
-  // the shared resolveRecommendedOptionId helper so profession-gate applies it
-  // identically.
-  evaluation.recommendedOptionId = await resolveRecommendedOptionId({
+  if (isWwwd && input.alignmentCorpora) applyConstitutionalAlignment({
+    evaluation, question: input.question, corpora: input.alignmentCorpora,
+  });
+  evaluation.recommendedOptionId = await resolveGateRecommendedOptionId({
     db: input.db,
     scoredOptions: input.scoredOptions,
     organizationId: input.organizationId ?? null,
     outcomeType: evaluation.outcomeType,
+    constitutionalVerdict: evaluation.constitutionalAlignment?.verdict,
   });
-
   console.info(
     `[tool-trace] ${prefix}.evaluator.complete ${JSON.stringify({
       interactionId,
@@ -767,7 +764,10 @@ export async function evaluatePerspectiveGate(input: {
     phaseTo: input.phaseTo === undefined ? (input.build ? "build" : null) : input.phaseTo,
     gateKey,
     gateFallbackUsed: isWwwd && !orgProfileSelected,
-    outcomePayloadExtra: isWwwd ? { orgProfileSelected } : undefined,
+    outcomePayloadExtra: isWwwd ? {
+      orgProfileSelected, constitutionalAlignment: evaluation.constitutionalAlignment ?? null,
+      caller: input.caller ?? null,
+    } : undefined,
   });
 
   console.info(

--- a/apps/web/lib/decision-perspective/option-recommendation.ts
+++ b/apps/web/lib/decision-perspective/option-recommendation.ts
@@ -101,3 +101,20 @@ export async function resolveRecommendedOptionId(input: {
   }
   return null;
 }
+
+/** Apply shared scoring, then honor a hard-veto option without averaging it. */
+export async function resolveGateRecommendedOptionId(input: {
+  db: CommandmentClient;
+  scoredOptions?: DecisionScoredOption[] | null;
+  organizationId?: string | null;
+  outcomeType: string;
+  constitutionalVerdict?: "approve" | "decline" | "escalate";
+}): Promise<string | null> {
+  const scored = await resolveRecommendedOptionId(input);
+  if (input.constitutionalVerdict !== "decline" || !input.scoredOptions?.length) {
+    return scored;
+  }
+  return input.scoredOptions.find((option) =>
+    /\b(decline|block|do not proceed|reject)\b/i.test(option.description),
+  )?.id ?? scored;
+}

--- a/apps/web/lib/decision-perspective/org-business-gate-policy-version.test.ts
+++ b/apps/web/lib/decision-perspective/org-business-gate-policy-version.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { alignmentPolicyVersion } from "./org-business-gate";
+import { evaluateConstitutionalAlignment } from "./alignment-criteria";
+
+describe("WWWD alignment policy version", () => {
+  it("is stable for ordering and changes only after a deliberate stance amendment", () => {
+    const first = alignmentPolicyVersion({
+      wwwd: [{ ref: "wiki:stance", text: "We do not sell consumer appliances." }],
+      portfolio: [{ ref: "product:support", text: "Self-host support subscription" }],
+      gtm: [{ ref: "wiki:gtm", text: "Serve MSP partners." }],
+    });
+    const reordered = alignmentPolicyVersion({
+      gtm: [{ ref: "wiki:gtm", text: "Serve MSP partners." }],
+      portfolio: [{ ref: "product:support", text: "Self-host support subscription" }],
+      wwwd: [{ ref: "wiki:stance", text: "We do not sell consumer appliances." }],
+    });
+    const amended = alignmentPolicyVersion({
+      wwwd: [{ ref: "wiki:stance", text: "We deliberately serve remote fishermen with durable appliances." }],
+      portfolio: [{ ref: "product:support", text: "Self-host support subscription" }],
+      gtm: [{ ref: "wiki:gtm", text: "Serve MSP partners." }],
+    });
+    expect(reordered).toBe(first);
+    expect(amended).not.toBe(first);
+  });
+
+  it("permits a previously rejected action only after amended corpora are freshly evaluated", () => {
+    const statement = "Sell toasters to Alaskan fishermen from dock kiosks";
+    const original = {
+      wwwd: [{ ref: "wiki:stance@v1", text: "We decline selling toasters to fishermen in Alaska." }],
+      portfolio: [{ ref: "product:dpf", text: "Self-hosted software support subscriptions." }],
+      gtm: [{ ref: "wiki:gtm@v1", text: "MSP partner subscriptions." }],
+    };
+    const amended = {
+      wwwd: [{ ref: "wiki:stance@v2", text: "We serve Alaskan fishermen with durable toasters." }],
+      portfolio: [{ ref: "product:toaster", text: "Durable toasters for Alaskan fishermen." }],
+      gtm: [{ ref: "wiki:gtm@v2", text: "Dock kiosk retail for fishermen in Alaska." }],
+    };
+    expect(evaluateConstitutionalAlignment({ statement, corpora: original }).verdict).toBe("decline");
+    expect(alignmentPolicyVersion(amended)).not.toBe(alignmentPolicyVersion(original));
+    expect(evaluateConstitutionalAlignment({ statement, corpora: amended }).verdict).toBe("approve");
+  });
+});

--- a/apps/web/lib/decision-perspective/org-business-gate.test.ts
+++ b/apps/web/lib/decision-perspective/org-business-gate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { MARK_DPF_PLATFORM_PROFILE } from "./default-profile";
-import { evaluateOrgBusinessDecisionGate } from "./org-business-gate";
+import { evaluateOrgBusinessDecisionGate, loadOrgAlignmentCorpora } from "./org-business-gate";
 import type {
   DecisionDomainClass,
   DecisionPerspectiveEvaluationResult,
@@ -69,6 +69,25 @@ const base = {
 };
 
 describe("evaluateOrgBusinessDecisionGate (BI-230C9EF7)", () => {
+  it("loads portfolio evidence only from the organization-owned Product model", async () => {
+    const digitalFindMany = vi.fn();
+    const productFindMany = vi.fn().mockResolvedValue([
+      { id: "p1", productId: "P-1", name: "Self-host support", description: "Subscription" },
+    ]);
+    const corpora = await loadOrgAlignmentCorpora({
+      wikiPage: { findMany: vi.fn().mockResolvedValue([]) },
+      digitalProduct: { findMany: digitalFindMany },
+      product: { findMany: productFindMany },
+    }, "org-123");
+    expect(digitalFindMany).not.toHaveBeenCalled();
+    expect(productFindMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { organizationId: "org-123", effectiveTo: null },
+    }));
+    expect(corpora?.portfolio).toEqual([
+      expect.objectContaining({ ref: "product:P-1", text: expect.stringContaining("Self-host support") }),
+    ]);
+  });
+
   it("records a hard WWWD veto with its failing corpus and criterion", async () => {
     const db = makeDb();
     const result = await evaluateOrgBusinessDecisionGate({

--- a/apps/web/lib/decision-perspective/org-business-gate.test.ts
+++ b/apps/web/lib/decision-perspective/org-business-gate.test.ts
@@ -77,6 +77,10 @@ describe("evaluateOrgBusinessDecisionGate (BI-230C9EF7)", () => {
       db: db as never,
       resolver: fakeResolver() as never,
       evaluator: () => makeEval({ stanceAlignment: "approve" }),
+      scoredOptions: [
+        { id: "proceed", description: "Proceed", features: { market_fit: 1 } },
+        { id: "decline", description: "Decline", features: { reversibility: 1 } },
+      ],
       alignmentCorpora: {
         wwwd: [{ ref: "wiki:stance", text: "We serve MSPs. We decline toasters for fishermen in Alaska." }],
         portfolio: [{ ref: "product:dpf", text: "Self-hosted software support subscription" }],
@@ -85,6 +89,7 @@ describe("evaluateOrgBusinessDecisionGate (BI-230C9EF7)", () => {
     });
 
     expect(result.evaluation.stanceAlignment).toBe("decline");
+    expect(result.evaluation.recommendedOptionId).toBe("decline");
     expect(result.evaluation.constitutionalAlignment?.veto).toMatchObject({
       corpus: "wwwd",
       criterion: "market",

--- a/apps/web/lib/decision-perspective/org-business-gate.test.ts
+++ b/apps/web/lib/decision-perspective/org-business-gate.test.ts
@@ -69,6 +69,32 @@ const base = {
 };
 
 describe("evaluateOrgBusinessDecisionGate (BI-230C9EF7)", () => {
+  it("records a hard WWWD veto with its failing corpus and criterion", async () => {
+    const db = makeDb();
+    const result = await evaluateOrgBusinessDecisionGate({
+      ...base,
+      question: "Sell toasters to Alaskan fishermen from dock kiosks",
+      db: db as never,
+      resolver: fakeResolver() as never,
+      evaluator: () => makeEval({ stanceAlignment: "approve" }),
+      alignmentCorpora: {
+        wwwd: [{ ref: "wiki:stance", text: "We serve MSPs. We decline toasters for fishermen in Alaska." }],
+        portfolio: [{ ref: "product:dpf", text: "Self-hosted software support subscription" }],
+        gtm: [{ ref: "wiki:gtm", text: "Open-source, assurance subscriptions, and MSP partners" }],
+      },
+    });
+
+    expect(result.evaluation.stanceAlignment).toBe("decline");
+    expect(result.evaluation.constitutionalAlignment?.veto).toMatchObject({
+      corpus: "wwwd",
+      criterion: "market",
+    });
+    const data = db.decisionInteraction.create.mock.calls[0]![0].data as Record<string, unknown>;
+    expect((data.outcomePayload as Record<string, unknown>).constitutionalAlignment).toEqual(
+      result.evaluation.constitutionalAlignment,
+    );
+  });
+
   it("decides from the org's own profile and records orgProfileSelected=true (no build context)", async () => {
     const db = makeDb();
     const result = await evaluateOrgBusinessDecisionGate({

--- a/apps/web/lib/decision-perspective/org-business-gate.ts
+++ b/apps/web/lib/decision-perspective/org-business-gate.ts
@@ -28,9 +28,54 @@ import type {
   DecisionEvidenceItem,
   DecisionScoredOption,
 } from "./types";
+import type { AlignmentCorpora, AlignmentEvidence } from "./alignment-criteria";
 
 type OrgBusinessGateClient = any;
 type GateEvaluator = (input: DecisionPerspectiveEvaluationInput) => DecisionPerspectiveEvaluationResult;
+
+function evidence(refPrefix: string, rows: Array<Record<string, unknown>>): AlignmentEvidence[] {
+  return rows.map((row, index) => ({
+    ref: `${refPrefix}:${String(row["slug"] ?? row["productId"] ?? row["id"] ?? index)}`,
+    text: [row["title"], row["name"], row["body"], row["description"]]
+      .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+      .join("\n"),
+  })).filter((item) => item.text.length > 0);
+}
+
+/** Load the three existing org-owned corpora without creating a parallel store. */
+export async function loadOrgAlignmentCorpora(
+  db: any,
+  organizationId: string,
+): Promise<AlignmentCorpora | undefined> {
+  if (!db.wikiPage?.findMany) return undefined;
+  try {
+    const wikiRows = await db.wikiPage.findMany({
+      where: { organizationId, status: "published", pageKind: { in: ["stance", "principle"] } },
+      select: { id: true, slug: true, title: true, body: true },
+    }) as Array<Record<string, unknown>>;
+    const [digitalRows, productRows] = await Promise.all([
+      db.digitalProduct?.findMany
+        ? db.digitalProduct.findMany({ select: { id: true, productId: true, name: true, description: true } })
+        : [],
+      db.product?.findMany
+        ? db.product.findMany({
+            where: { organizationId, effectiveTo: null },
+            select: { id: true, productId: true, name: true, description: true },
+          })
+        : [],
+    ]) as [Array<Record<string, unknown>>, Array<Record<string, unknown>>];
+    const gtmRows = wikiRows.filter((row) =>
+      /how-we-decide|supply-chain|pricing|growth|who-we-serve/.test(String(row["slug"] ?? "")),
+    );
+    return {
+      wwwd: evidence("wiki", wikiRows),
+      portfolio: evidence("product", [...digitalRows, ...productRows]),
+      gtm: evidence("wiki", gtmRows),
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 export type OrgBusinessDecisionGateResult = {
   /** True only when the org's own stance recommends/arbitrates the call. */
@@ -74,7 +119,12 @@ export async function evaluateOrgBusinessDecisionGate(input: {
   resolver?: typeof resolveProfileMaterialForOrg;
   now?: Date;
   recentOverrideCount?: number;
+  alignmentCorpora?: AlignmentCorpora;
 }): Promise<OrgBusinessDecisionGateResult> {
+  const alignmentCorpora = input.alignmentCorpora
+    ?? (input.organizationId
+      ? await loadOrgAlignmentCorpora(input.db, input.organizationId)
+      : undefined);
   const result = await evaluatePerspectiveGate({
     db: input.db,
     organizationId: input.organizationId ?? null,
@@ -95,6 +145,7 @@ export async function evaluateOrgBusinessDecisionGate(input: {
     resolver: input.resolver,
     now: input.now,
     recentOverrideCount: input.recentOverrideCount,
+    alignmentCorpora,
   });
 
   return {

--- a/apps/web/lib/decision-perspective/org-business-gate.ts
+++ b/apps/web/lib/decision-perspective/org-business-gate.ts
@@ -73,23 +73,21 @@ export async function loadOrgAlignmentCorpora(
         revisions: { orderBy: { version: "desc" }, take: 1, select: { version: true } },
       },
     }) as Array<Record<string, unknown>>;
-    const [digitalRows, productRows] = await Promise.all([
-      db.digitalProduct?.findMany
-        ? db.digitalProduct.findMany({ select: { id: true, productId: true, name: true, description: true } })
-        : [],
-      db.product?.findMany
-        ? db.product.findMany({
-            where: { organizationId, effectiveTo: null },
-            select: { id: true, productId: true, name: true, description: true },
-          })
-        : [],
-    ]) as [Array<Record<string, unknown>>, Array<Record<string, unknown>>];
+    // Product is the organization-owned business portfolio. DigitalProduct is
+    // the install-global architecture catalog and must not enter a tenant's
+    // WWWD policy evaluation without an organization ownership relation.
+    const productRows = db.product?.findMany
+      ? await db.product.findMany({
+          where: { organizationId, effectiveTo: null },
+          select: { id: true, productId: true, name: true, description: true },
+        }) as Array<Record<string, unknown>>
+      : [];
     const gtmRows = wikiRows.filter((row) =>
       /how-we-decide|supply-chain|pricing|growth|who-we-serve/.test(String(row["slug"] ?? "")),
     );
     return {
       wwwd: evidence("wiki", wikiRows),
-      portfolio: evidence("product", [...digitalRows, ...productRows]),
+      portfolio: evidence("product", productRows),
       gtm: evidence("wiki", gtmRows),
     };
   } catch {

--- a/apps/web/lib/decision-perspective/org-business-gate.ts
+++ b/apps/web/lib/decision-perspective/org-business-gate.ts
@@ -17,6 +17,7 @@
 // measure agreement before any autonomy is released. Fail-closed: any resolver/evaluator
 // error escalates to a human and is still recorded.
 
+import { createHash } from "crypto";
 import { evaluatePerspectiveGate } from "./evaluator";
 import type { DecisionGateCaller } from "./evaluator";
 import { resolveProfileMaterialForOrg } from "./material";
@@ -33,13 +34,29 @@ import type { AlignmentCorpora, AlignmentEvidence } from "./alignment-criteria";
 type OrgBusinessGateClient = any;
 type GateEvaluator = (input: DecisionPerspectiveEvaluationInput) => DecisionPerspectiveEvaluationResult;
 
+export function alignmentPolicyVersion(corpora: AlignmentCorpora | undefined): string {
+  const canonical = Object.entries(corpora ?? {})
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([corpus, rows]) => [
+      corpus,
+      [...(rows ?? [])]
+        .map((row) => ({ ref: row.ref, text: row.text }))
+        .sort((left, right) => left.ref.localeCompare(right.ref)),
+    ]);
+  return `wwwd:${createHash("sha256").update(JSON.stringify(canonical)).digest("hex").slice(0, 24)}`;
+}
+
 function evidence(refPrefix: string, rows: Array<Record<string, unknown>>): AlignmentEvidence[] {
-  return rows.map((row, index) => ({
-    ref: `${refPrefix}:${String(row["slug"] ?? row["productId"] ?? row["id"] ?? index)}`,
-    text: [row["title"], row["name"], row["body"], row["description"]]
-      .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
-      .join("\n"),
-  })).filter((item) => item.text.length > 0);
+  return rows.map((row, index) => {
+    const revisions = Array.isArray(row["revisions"]) ? row["revisions"] as Array<Record<string, unknown>> : [];
+    const version = typeof revisions[0]?.["version"] === "number" ? `@v${revisions[0]["version"]}` : "";
+    return {
+      ref: `${refPrefix}:${String(row["slug"] ?? row["productId"] ?? row["id"] ?? index)}${version}`,
+      text: [row["title"], row["name"], row["body"], row["description"]]
+        .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+        .join("\n"),
+    };
+  }).filter((item) => item.text.length > 0);
 }
 
 /** Load the three existing org-owned corpora without creating a parallel store. */
@@ -51,7 +68,10 @@ export async function loadOrgAlignmentCorpora(
   try {
     const wikiRows = await db.wikiPage.findMany({
       where: { organizationId, status: "published", pageKind: { in: ["stance", "principle"] } },
-      select: { id: true, slug: true, title: true, body: true },
+      select: {
+        id: true, slug: true, title: true, body: true,
+        revisions: { orderBy: { version: "desc" }, take: 1, select: { version: true } },
+      },
     }) as Array<Record<string, unknown>>;
     const [digitalRows, productRows] = await Promise.all([
       db.digitalProduct?.findMany
@@ -85,6 +105,8 @@ export type OrgBusinessDecisionGateResult = {
   operatorMessage: string;
   /** True when the organization's OWN profile (not a platform fallback) decided. */
   orgProfileSelected: boolean;
+  alignmentPolicyVersion: string;
+  amendmentLineage: string[];
 };
 
 /**
@@ -154,5 +176,9 @@ export async function evaluateOrgBusinessDecisionGate(input: {
     evaluation: result.evaluation,
     operatorMessage: result.operatorMessage,
     orgProfileSelected: result.orgProfileSelected,
+    alignmentPolicyVersion: alignmentPolicyVersion(alignmentCorpora),
+    amendmentLineage: Array.from(new Set(
+      Object.values(alignmentCorpora ?? {}).flatMap((rows) => (rows ?? []).map((row) => row.ref)),
+    )).sort(),
   };
 }

--- a/apps/web/lib/decision-perspective/persistence.ts
+++ b/apps/web/lib/decision-perspective/persistence.ts
@@ -153,6 +153,9 @@ export function decisionInteractionRowToEvaluation(
     rationale: row.rationale ?? "",
     materialScores: [],
     sources,
+    ...(payload.constitutionalAlignment
+      ? { constitutionalAlignment: payload.constitutionalAlignment as DecisionPerspectiveEvaluationResult["constitutionalAlignment"] }
+      : {}),
   };
 }
 

--- a/apps/web/lib/decision-perspective/stance-dimension-map.test.ts
+++ b/apps/web/lib/decision-perspective/stance-dimension-map.test.ts
@@ -9,6 +9,7 @@ import {
   STANCE_DIMENSION_MAP,
   STANCE_FORBIDDEN_DIMENSIONS,
   STANCE_MAX_MAGNITUDE,
+  projectStanceDimensionVector,
   type StanceAxisEdge,
 } from "./stance-dimension-map";
 
@@ -17,6 +18,22 @@ import {
 // be discovered when a derived vector starts scoring real decisions.
 
 describe("stance-dimension-map: the live map is well-formed", () => {
+  it("projects every stance into a persisted non-null vector", () => {
+    for (const key of STANCE_VECTOR_KEYS) {
+      const projected = projectStanceDimensionVector(key);
+      expect(projected.principleDimensions.length).toBeGreaterThan(0);
+      expect(Object.keys(projected.principleDimensionVector)).toEqual(
+        expect.arrayContaining(projected.principleDimensions),
+      );
+    }
+  });
+
+  it("projects the four constitutional alignment axes from declared stance purpose", () => {
+    const projected = projectStanceDimensionVector("growth-vs-stability");
+    expect(projected.principleDimensions).toEqual(
+      expect.arrayContaining(["mission_fit", "market_fit", "product_fit", "gtm_fit"]),
+    );
+  });
   it("passes every invariant (signs, caps, forbidden axes, rationales)", () => {
     expect(findStanceDimensionMapViolations()).toEqual([]);
   });

--- a/apps/web/lib/decision-perspective/stance-dimension-map.ts
+++ b/apps/web/lib/decision-perspective/stance-dimension-map.ts
@@ -104,6 +104,12 @@ export type StanceAxisEdge = {
 export const STANCE_DIMENSION_MAP = {
   "customer-goodwill": [
     {
+      dimension: "market_fit",
+      weight: 0.3,
+      rationale:
+        "Customer goodwill explicitly protects the continuing relationship with the people the organization chose to serve.",
+    },
+    {
       dimension: "cost_efficiency",
       weight: -0.3,
       rationale:
@@ -130,6 +136,12 @@ export const STANCE_DIMENSION_MAP = {
   ],
   "pricing-integrity": [
     {
+      dimension: "gtm_fit",
+      weight: 0.3,
+      rationale:
+        "Pricing and discount discipline is part of the declared commercial motion by which the organization reaches its market.",
+    },
+    {
       dimension: "governance_compliance",
       weight: 0.4,
       rationale:
@@ -149,6 +161,30 @@ export const STANCE_DIMENSION_MAP = {
     },
   ],
   "growth-vs-stability": [
+    {
+      dimension: "mission_fit",
+      weight: 0.4,
+      rationale:
+        "What the organization chooses to take on is an explicit boundary on whether proposed growth advances its stated direction.",
+    },
+    {
+      dimension: "market_fit",
+      weight: 0.35,
+      rationale:
+        "Growth choices must remain directed at the customers and segments the organization has declared it serves.",
+    },
+    {
+      dimension: "product_fit",
+      weight: 0.3,
+      rationale:
+        "The choice between new and existing commitments declares how adjacent a proposed offer may be to the current product promise.",
+    },
+    {
+      dimension: "gtm_fit",
+      weight: 0.35,
+      rationale:
+        "Growth pace and channel are a direct constraint on the go-to-market motion the organization has chosen.",
+    },
     {
       dimension: "long_term_maintainability",
       weight: 0.4,
@@ -170,6 +206,12 @@ export const STANCE_DIMENSION_MAP = {
     },
   ],
   "quality-bar": [
+    {
+      dimension: "product_fit",
+      weight: 0.4,
+      rationale:
+        "The quality bar defines what may leave the organization as an offer and therefore directly constrains product fit.",
+    },
     {
       dimension: "long_term_maintainability",
       weight: 0.4,
@@ -219,6 +261,45 @@ export const STANCE_DIMENSION_MAP = {
     },
   ],
 } as const satisfies Record<StanceVectorKey, readonly StanceAxisEdge[]>;
+
+export type StanceDimensionProjection = {
+  principleDimensionVector: Record<PrincipleDimension, number>;
+  principleDimensions: PrincipleDimension[];
+};
+
+export const STANCE_ALIGNMENT_DIMENSIONS = [
+  "mission_fit",
+  "market_fit",
+  "product_fit",
+  "gtm_fit",
+] as const satisfies readonly PrincipleDimension[];
+export type StanceAlignmentDimension = (typeof STANCE_ALIGNMENT_DIMENSIONS)[number];
+
+/** Project only alignment purposes explicitly declared by the authoring surface. */
+export function projectDeclaredStanceAlignment(
+  dimensions: readonly StanceAlignmentDimension[],
+): StanceDimensionProjection {
+  const vector = {} as Record<PrincipleDimension, number>;
+  for (const dimension of dimensions) vector[dimension] = STANCE_MAX_MAGNITUDE;
+  return {
+    principleDimensionVector: vector,
+    principleDimensions: [...dimensions],
+  };
+}
+
+/** Deterministically project one declared stance purpose into the closed axis registry. */
+export function projectStanceDimensionVector(
+  stanceKey: StanceVectorKey,
+): StanceDimensionProjection {
+  const vector = {} as Record<PrincipleDimension, number>;
+  for (const edge of STANCE_DIMENSION_MAP[stanceKey]) {
+    vector[edge.dimension] = edge.weight;
+  }
+  return {
+    principleDimensionVector: vector,
+    principleDimensions: Object.keys(vector) as PrincipleDimension[],
+  };
+}
 
 const COST_DIMENSIONS = new Set<string>(PRINCIPLE_COST_DIMENSIONS);
 const FORBIDDEN = new Set<string>(STANCE_FORBIDDEN_DIMENSIONS);

--- a/apps/web/lib/decision-perspective/types.ts
+++ b/apps/web/lib/decision-perspective/types.ts
@@ -219,6 +219,8 @@ export type DecisionPerspectiveEvaluationResult = {
   stanceAlignment?: "approve" | "decline" | "mixed" | "none";
   /** How question↔stance relevance was computed for this evaluation. */
   relevanceMethod?: "semantic" | "lexical";
+  /** Independent corpus checks; any rejected hard boundary vetoes aggregation. */
+  constitutionalAlignment?: import("./alignment-criteria").ConstitutionalAlignmentResult;
   rationale: string;
   materialScores: PerspectiveMaterialScore[];
   sources: Array<{

--- a/apps/web/lib/decision/dimension-catalog.ts
+++ b/apps/web/lib/decision/dimension-catalog.ts
@@ -102,6 +102,10 @@ const HIGH_MEANS: Record<PrincipleDimension, string> = {
     "the option demands MORE operator operations and elapsed time to reach the outcome",
   legibility_of_consequence:
     "the operator can better foresee, before authorizing, what the option will do, to what, under whose authority, and how it is undone",
+  mission_fit: "the option more directly advances the organization's declared mission",
+  market_fit: "the option more directly serves the organization's declared market and segments",
+  product_fit: "the option more directly fits the organization's declared offer and product portfolio",
+  gtm_fit: "the option more directly fits the organization's declared go-to-market motion",
 };
 
 /** The full caller-facing catalogue, benefits first then costs, stable order. */

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9952,6 +9952,7 @@
       "anchors": [
         "what-this-covers",
         "what-decision-perspective-does",
+        "consequential-action-alignment",
         "the-confidence-model",
         "the-inheritance-chain",
         "profile-kinds",

--- a/apps/web/lib/ea/data-model-mirror.test.ts
+++ b/apps/web/lib/ea/data-model-mirror.test.ts
@@ -224,3 +224,19 @@ describe("healthcare care appointment mirror allocation", () => {
     );
   });
 });
+
+describe("employee asset-allocation precondition evidence", () => {
+  it("surfaces the current FixedAsset assignment field as drift, not a fabricated employee FK", () => {
+    const schema = readFileSync(
+      resolve(process.cwd(), "../../packages/db/prisma/schema.prisma"),
+      "utf8",
+    );
+    const desired = buildDesiredState(parsePrismaSchema(schema));
+    const fixedAsset = desired.elements.find((element) => element.sourceKey === modelSourceKey("FixedAsset"));
+    const fields = (fixedAsset?.properties.fields ?? []) as Array<{ name: string; isRequired: boolean }>;
+    const relationshipKeys = desired.relationships.map((relationship) => relationship.sourceKey);
+
+    expect(fields).toContainEqual(expect.objectContaining({ name: "assignedToId", isRequired: false }));
+    expect(relationshipKeys).not.toContain("prisma:relation:FixedAsset:employee:EmployeeProfile");
+  });
+});

--- a/apps/web/lib/governed-tool-audit.ts
+++ b/apps/web/lib/governed-tool-audit.ts
@@ -1,0 +1,101 @@
+import { prisma } from "@dpf/db";
+
+import type { AlignmentGateDecision } from "./tak/alignment-tool-gate";
+import type { PreconditionOrderingDecision } from "./tak/precondition-ordering-gate";
+import { deriveAuditClassForTool, deriveCapabilityId } from "./tool-audit-helpers";
+import type { GovernedExecuteContext, GovernedExecuteSource } from "./mcp-governed-execute";
+import type { ToolDefinition, ToolResult } from "./mcp-tools";
+
+let createOverride: ((data: Record<string, unknown>) => Promise<unknown>) | null = null;
+let updateOverride: ((id: string, data: Record<string, unknown>) => Promise<unknown>) | null = null;
+
+export function setGovernedToolAuditOverridesForTests(overrides: {
+  create?: ((data: Record<string, unknown>) => Promise<unknown>) | null;
+  update?: ((id: string, data: Record<string, unknown>) => Promise<unknown>) | null;
+}): void {
+  createOverride = overrides.create ?? null;
+  updateOverride = overrides.update ?? null;
+}
+
+function redactWriteOnlyParameters(
+  value: Record<string, unknown>, schema: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const properties = schema?.properties && typeof schema.properties === "object"
+    ? schema.properties as Record<string, unknown> : {};
+  return Object.fromEntries(Object.entries(value).map(([key, entry]) => {
+    const property = properties[key] && typeof properties[key] === "object"
+      ? properties[key] as Record<string, unknown> : undefined;
+    if (property?.writeOnly === true) return [key, "[REDACTED]"];
+    if (entry && typeof entry === "object" && !Array.isArray(entry) && property?.properties) {
+      return [key, redactWriteOnlyParameters(entry as Record<string, unknown>, property)];
+    }
+    return [key, entry];
+  }));
+}
+
+export async function writeGovernedToolAudit(data: {
+  toolName: string;
+  tool?: ToolDefinition;
+  rawParams: Record<string, unknown>;
+  result: ToolResult;
+  userId: string;
+  source: GovernedExecuteSource;
+  context?: GovernedExecuteContext;
+  durationMs: number;
+  alignmentDecision?: AlignmentGateDecision | null;
+  preconditionDecision?: PreconditionOrderingDecision | null;
+}): Promise<{ id: string } | null> {
+  const auditClass = deriveAuditClassForTool(data.toolName);
+  const isMetricsOnly = auditClass === "metrics_only";
+  const row = {
+    threadId: data.context?.threadId ?? "", agentId: data.context?.agentId ?? "unknown",
+    userId: data.userId, taskRunId: data.context?.taskRunId ?? null, toolName: data.toolName,
+    parameters: isMetricsOnly ? {} : {
+      ...redactWriteOnlyParameters(data.rawParams, data.tool?.inputSchema),
+      ...(data.context?.surfaceInvocation ? { _surface: data.context.surfaceInvocation } : {}),
+      ...(data.alignmentDecision ? { _takAlignment: {
+        interactionId: data.alignmentDecision.interactionId,
+        verdict: data.alignmentDecision.verdict,
+        policyVersion: data.alignmentDecision.policyVersion ?? null,
+        checks: data.alignmentDecision.alignment.checks,
+      } } : {}),
+      ...(data.preconditionDecision ? { _takPrecondition: data.preconditionDecision } : {}),
+    },
+    result: isMetricsOnly ? {} : data.result as unknown as object,
+    success: data.result.success, executionMode: data.source,
+    routeContext: data.context?.routeContext ?? null, durationMs: data.durationMs,
+    auditClass, capabilityId: deriveCapabilityId(data.toolName),
+    summary: isMetricsOnly
+      ? `${data.toolName}: ${data.result.success ? "ok" : "failed"}${data.durationMs ? ` (${data.durationMs}ms)` : ""}`
+      : null,
+    apiTokenId: data.context?.apiTokenId ?? null, skillId: data.context?.skillId ?? null,
+    delegationChainId: data.context?.delegationChainId ?? null,
+  };
+  try {
+    const created = createOverride
+      ? await createOverride(row)
+      : await prisma.toolExecution.create({ data: row, select: { id: true } });
+    return typeof (created as { id?: unknown } | undefined)?.id === "string"
+      ? { id: String((created as { id: string }).id) } : null;
+  } catch (err) {
+    console.error(
+      "[governed-execute] audit write failed tool=%s source=%s: %s",
+      JSON.stringify(data.toolName), JSON.stringify(data.source),
+      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
+    );
+    return null;
+  }
+}
+
+export async function updateGovernedToolAudit(id: string, result: ToolResult, durationMs: number): Promise<void> {
+  const data = { result: result as unknown as object, success: result.success, durationMs };
+  try {
+    if (updateOverride) await updateOverride(id, data);
+    else await prisma.toolExecution.update({ where: { id }, data });
+  } catch (err) {
+    console.error(
+      "[governed-execute] reserved audit finalization failed execution=%s: %s",
+      JSON.stringify(id), err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
+    );
+  }
+}

--- a/apps/web/lib/mcp-governed-execute-alignment.test.ts
+++ b/apps/web/lib/mcp-governed-execute-alignment.test.ts
@@ -4,10 +4,19 @@ import { _setGovernanceForTests, governedExecuteTool } from "./mcp-governed-exec
 import type { ToolResult } from "./mcp-tools";
 
 const USER = { platformRole: "ceo", isSuperuser: true };
+const resolveActor = async (args: { context?: { agentId?: string }; userId: string }) => ({
+  principalId: args.context?.agentId ? "PRN-COWORKER" : "PRN-HUMAN",
+  gaid: args.context?.agentId ? "GAID-COWORKER" : "GAID-HUMAN",
+  actorKind: (args.context?.agentId ? "coworker" : args.userId === "employee-1" ? "employee" : "owner") as
+    "coworker" | "employee" | "owner",
+  actorRef: args.context?.agentId ?? args.userId,
+});
 const alignmentDecision = (verdict: "approve" | "decline" | "escalate") => ({
   verdict,
   interactionId: `DI-${verdict}`,
   rationale: `${verdict} from WWWD`,
+  policyVersion: "wwwd:v1",
+  amendmentLineage: ["wiki:stance:v1"],
   alignment: {
     verdict,
     criteria: {
@@ -65,12 +74,16 @@ describe("TAK alignment interception", () => {
   let execute: ReturnType<typeof vi.fn> & ExecuteFn;
   let audits: Record<string, unknown>[];
   let receipts: Record<string, unknown>[];
+  let receiptUpdates: Array<{ id: string; data: Record<string, unknown> }>;
+  let auditUpdates: Array<{ id: string; data: Record<string, unknown> }>;
 
   beforeEach(() => {
     execute = vi.fn(async (): Promise<ToolResult> => ({ success: true, message: "ok" })) as
       ReturnType<typeof vi.fn> & ExecuteFn;
     audits = [];
     receipts = [];
+    receiptUpdates = [];
+    auditUpdates = [];
     _setGovernanceForTests({
       executeTool: execute,
       resolveAgentGrants: async () => ["portfolio_write"],
@@ -78,7 +91,10 @@ describe("TAK alignment interception", () => {
       resolveCoworkerAuthorityInput: async () => authorityInput() as never,
       authorizationDecisionCreate: async () => ({}),
       toolExecutionCreate: async (data) => { audits.push(data); return { id: "tool-exec" }; },
-      toolExecutionReceiptCreate: async (data) => { receipts.push(data); },
+      toolExecutionUpdate: async (id, data) => { auditUpdates.push({ id, data }); },
+      toolExecutionReceiptCreate: async (data) => { receipts.push(data); return { id: "receipt-1" }; },
+      toolExecutionReceiptUpdate: async (id, data) => { receiptUpdates.push({ id, data }); },
+      gaidActorResolver: resolveActor,
     });
   });
 
@@ -98,21 +114,23 @@ describe("TAK alignment interception", () => {
   });
 
   it.each([
-    ["owner", undefined],
-    ["coworker", { agentId: "AGT-100", threadId: "thread-1" }],
-  ])("blocks a rejected call before mutation for %s", async (_label, context) => {
+    ["owner", "user-1", undefined],
+    ["employee", "employee-1", undefined],
+    ["coworker", "user-1", { agentId: "AGT-100", threadId: "thread-1" }],
+  ])("blocks a rejected call before mutation for %s", async (label, userId, context) => {
     _setGovernanceForTests({
       alignmentGate: async () => alignmentDecision("decline"), executeTool: execute,
       resolveAgentGrants: async () => ["portfolio_write"], isAllowedByGrants: () => true,
       resolveCoworkerAuthorityInput: async () => authorityInput() as never,
       authorizationDecisionCreate: async () => ({}),
       toolExecutionCreate: async (data) => { audits.push(data); return { id: "deny" }; },
-      toolExecutionReceiptCreate: async (data) => { receipts.push(data); },
+      toolExecutionReceiptCreate: async (data) => { receipts.push(data); return { id: "deny-receipt" }; },
+      gaidActorResolver: resolveActor,
     });
     const result = await governedExecuteTool({
       toolName: "create_digital_product",
       rawParams: { name: "Toasters", description: "Sell to Alaskan fishermen" },
-      userId: "user-1", userContext: USER, context,
+      userId, userContext: USER, context,
       source: context ? "agentic-loop" : "rest",
     });
     expect(result.error).toBe("alignment_denied");
@@ -121,13 +139,23 @@ describe("TAK alignment interception", () => {
       toolExecutionId: "deny", receiptKind: "tak-consequential-action",
       executionStatus: "failed",
     })]);
+    expect(receipts[0]?.outputDigest).toEqual(expect.objectContaining({
+      governance: expect.objectContaining({
+        actor: expect.objectContaining({ actorKind: label }),
+        gateDecision: "decline", policyVersion: "wwwd:v1",
+        amendmentLineage: ["wiki:stance:v1"], evidenceRefs: ["wiki:stance"],
+      }),
+    }));
   });
 
   it("executes approval and receipts it", async () => {
     _setGovernanceForTests({
       alignmentGate: async () => alignmentDecision("approve"), executeTool: execute,
       toolExecutionCreate: async (data) => { audits.push(data); return { id: "allow" }; },
-      toolExecutionReceiptCreate: async (data) => { receipts.push(data); },
+      toolExecutionReceiptCreate: async (data) => { receipts.push(data); return { id: "allow-receipt" }; },
+      toolExecutionUpdate: async (id, data) => { auditUpdates.push({ id, data }); },
+      toolExecutionReceiptUpdate: async (id, data) => { receiptUpdates.push({ id, data }); },
+      gaidActorResolver: resolveActor,
     });
     const result = await governedExecuteTool({
       toolName: "create_digital_product", rawParams: { name: "Self-host support subscription" },
@@ -136,8 +164,19 @@ describe("TAK alignment interception", () => {
     expect(result.success).toBe(true);
     expect(receipts).toEqual([expect.objectContaining({
       toolExecutionId: "allow", receiptKind: "tak-consequential-action",
-      executionStatus: "succeeded",
+      executionStatus: "reserved", receiptStatus: "reserved",
     })]);
+    expect(receipts[0]?.outputDigest).toEqual(expect.objectContaining({
+      governance: expect.objectContaining({
+        actor: expect.objectContaining({ gaid: "GAID-HUMAN", actorKind: "owner" }),
+        gateDecision: "approve", policyVersion: "wwwd:v1",
+      }),
+    }));
+    expect(receiptUpdates).toEqual([expect.objectContaining({
+      id: "allow-receipt",
+      data: expect.objectContaining({ executionStatus: "succeeded", receiptStatus: "valid" }),
+    })]);
+    expect(execute.mock.invocationCallOrder[0]).toBeGreaterThan(0);
   });
 
   it("blocks an unmet ordering prerequisite before a consequential workforce mutation", async () => {
@@ -151,7 +190,8 @@ describe("TAK alignment interception", () => {
       }),
       executeTool: execute,
       toolExecutionCreate: async (data) => { audits.push(data); return { id: "precondition-deny" }; },
-      toolExecutionReceiptCreate: async (data) => { receipts.push(data); },
+      toolExecutionReceiptCreate: async (data) => { receipts.push(data); return { id: "precondition-receipt" }; },
+      gaidActorResolver: resolveActor,
     });
     const result = await governedExecuteTool({
       toolName: "transition_employee_status",
@@ -161,5 +201,34 @@ describe("TAK alignment interception", () => {
     expect(result.error).toBe("precondition_denied");
     expect(execute).not.toHaveBeenCalled();
     expect(receipts).toEqual([expect.objectContaining({ toolExecutionId: "precondition-deny" })]);
+  });
+
+  it("rejects bypass arguments and directs the caller to a versioned stance amendment", async () => {
+    const result = await governedExecuteTool({
+      toolName: "create_digital_product",
+      rawParams: { name: "Toasters", alignmentOverride: true },
+      userId: "user-1", userContext: USER, source: "rest",
+    });
+    expect(result.error).toBe("alignment_bypass_forbidden");
+    expect(result.message).toContain("Amend the versioned WWWD stance");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("fails closed before mutation when the mandatory GAID receipt cannot be reserved", async () => {
+    _setGovernanceForTests({
+      alignmentGate: async () => alignmentDecision("approve"), executeTool: execute,
+      toolExecutionCreate: async (data) => { audits.push(data); return { id: "reservation-failure" }; },
+      toolExecutionUpdate: async (id, data) => { auditUpdates.push({ id, data }); },
+      toolExecutionReceiptCreate: async () => { throw new Error("ledger unavailable"); },
+      gaidActorResolver: async () => ({
+        principalId: "PRN-HUMAN", gaid: "GAID-HUMAN", actorKind: "owner", actorRef: "user-1",
+      }),
+    });
+    const result = await governedExecuteTool({
+      toolName: "create_digital_product", rawParams: { name: "Self-host support" },
+      userId: "user-1", userContext: USER, source: "rest",
+    });
+    expect(result.error).toBe("receipt_reservation_failed");
+    expect(execute).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/mcp-governed-execute-alignment.test.ts
+++ b/apps/web/lib/mcp-governed-execute-alignment.test.ts
@@ -139,4 +139,27 @@ describe("TAK alignment interception", () => {
       executionStatus: "succeeded",
     })]);
   });
+
+  it("blocks an unmet ordering prerequisite before a consequential workforce mutation", async () => {
+    _setGovernanceForTests({
+      preconditionGate: async () => ({
+        verdict: "decline", rationale: "Employee identity must exist before the transition.",
+        checks: [{
+          key: "employee-identity", coherent: true, satisfied: false,
+          evidenceRefs: ["ea:value-stream:onboarding:identity", "prisma:model:EmployeeProfile#employeeId"],
+        }],
+      }),
+      executeTool: execute,
+      toolExecutionCreate: async (data) => { audits.push(data); return { id: "precondition-deny" }; },
+      toolExecutionReceiptCreate: async (data) => { receipts.push(data); },
+    });
+    const result = await governedExecuteTool({
+      toolName: "transition_employee_status",
+      rawParams: { employeeId: "EMP-MISSING", status: "active" },
+      userId: "user-1", userContext: USER, source: "rest",
+    });
+    expect(result.error).toBe("precondition_denied");
+    expect(execute).not.toHaveBeenCalled();
+    expect(receipts).toEqual([expect.objectContaining({ toolExecutionId: "precondition-deny" })]);
+  });
 });

--- a/apps/web/lib/mcp-governed-execute-alignment.test.ts
+++ b/apps/web/lib/mcp-governed-execute-alignment.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { _setGovernanceForTests, governedExecuteTool } from "./mcp-governed-execute";
+import type { ToolResult } from "./mcp-tools";
+
+const USER = { platformRole: "ceo", isSuperuser: true };
+const alignmentDecision = (verdict: "approve" | "decline" | "escalate") => ({
+  verdict,
+  interactionId: `DI-${verdict}`,
+  rationale: `${verdict} from WWWD`,
+  alignment: {
+    verdict,
+    criteria: {
+      status: "complete" as const,
+      criteria: {
+        market: "consumer physical retail", segment: "consumer physical retail",
+        product: "toasters", motion: "kiosk retail", geography: "alaska",
+        customerType: "fishermen",
+      },
+      evidence: ["product=toasters"],
+      missing: [],
+    },
+    checks: verdict === "decline" ? [{
+      corpus: "wwwd" as const, criterion: "market" as const,
+      verdict: "rejected" as const, rationale: "explicit boundary",
+      evidenceRefs: ["wiki:stance"],
+    }] : [],
+    veto: verdict === "decline" ? {
+      corpus: "wwwd" as const, criterion: "market" as const,
+      verdict: "rejected" as const, rationale: "explicit boundary",
+      evidenceRefs: ["wiki:stance"],
+    } : null,
+  },
+});
+
+function authorityInput() {
+  return {
+    authContext: {
+      principalId: "PRN-1", principalAliases: [], population: "workforce",
+      platformRole: "HR-000", isSuperuser: true, employeeId: "EMP-1",
+      managerScope: { directReportIds: [], indirectReportIds: [] }, teamIds: [],
+      accountScope: { accountIds: [], contactIds: [], partnerAccountIds: [] },
+      sensitivityClearance: ["public", "internal", "confidential", "restricted"],
+      authentication: { source: "session", methods: ["mfa"], contextClassReference: null },
+      actingHumanUserId: "user-1", actingAgentId: "AGT-100",
+      delegationGrantIds: [], grantedCapabilities: ["manage_platform"],
+    },
+    action: {
+      toolName: "create_digital_product", requiredCapability: "manage_platform",
+      agentGrantAllowed: true, sideEffect: true, executionMode: "immediate",
+      routeContext: "/portfolio", approvalPolicy: "none",
+    },
+    subject: { kind: "platform", id: "dpf" }, delegation: null,
+    integration: { required: false, state: "not-required" },
+    dataPolicy: {
+      sensitivity: "internal", maskingRequired: false, maskingSatisfied: true,
+      decisionVersionsCurrent: true,
+    },
+    task: null, rawParams: {},
+  };
+}
+
+describe("TAK alignment interception", () => {
+  type ExecuteFn = (name: string, params: Record<string, unknown>, userId: string) => Promise<ToolResult>;
+  let execute: ReturnType<typeof vi.fn> & ExecuteFn;
+  let audits: Record<string, unknown>[];
+  let receipts: Record<string, unknown>[];
+
+  beforeEach(() => {
+    execute = vi.fn(async (): Promise<ToolResult> => ({ success: true, message: "ok" })) as
+      ReturnType<typeof vi.fn> & ExecuteFn;
+    audits = [];
+    receipts = [];
+    _setGovernanceForTests({
+      executeTool: execute,
+      resolveAgentGrants: async () => ["portfolio_write"],
+      isAllowedByGrants: () => true,
+      resolveCoworkerAuthorityInput: async () => authorityInput() as never,
+      authorizationDecisionCreate: async () => ({}),
+      toolExecutionCreate: async (data) => { audits.push(data); return { id: "tool-exec" }; },
+      toolExecutionReceiptCreate: async (data) => { receipts.push(data); },
+    });
+  });
+
+  afterEach(() => _setGovernanceForTests({}));
+
+  it("skips alignment for routine reads", async () => {
+    const alignmentGate = vi.fn(async () => alignmentDecision("approve"));
+    _setGovernanceForTests({
+      alignmentGate, executeTool: execute,
+      toolExecutionCreate: async (data) => { audits.push(data); return { id: "read" }; },
+    });
+    await governedExecuteTool({
+      toolName: "query_backlog", rawParams: {}, userId: "user-1",
+      userContext: USER, source: "rest",
+    });
+    expect(alignmentGate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["owner", undefined],
+    ["coworker", { agentId: "AGT-100", threadId: "thread-1" }],
+  ])("blocks a rejected call before mutation for %s", async (_label, context) => {
+    _setGovernanceForTests({
+      alignmentGate: async () => alignmentDecision("decline"), executeTool: execute,
+      resolveAgentGrants: async () => ["portfolio_write"], isAllowedByGrants: () => true,
+      resolveCoworkerAuthorityInput: async () => authorityInput() as never,
+      authorizationDecisionCreate: async () => ({}),
+      toolExecutionCreate: async (data) => { audits.push(data); return { id: "deny" }; },
+      toolExecutionReceiptCreate: async (data) => { receipts.push(data); },
+    });
+    const result = await governedExecuteTool({
+      toolName: "create_digital_product",
+      rawParams: { name: "Toasters", description: "Sell to Alaskan fishermen" },
+      userId: "user-1", userContext: USER, context,
+      source: context ? "agentic-loop" : "rest",
+    });
+    expect(result.error).toBe("alignment_denied");
+    expect(execute).not.toHaveBeenCalled();
+    expect(receipts).toEqual([expect.objectContaining({
+      toolExecutionId: "deny", receiptKind: "tak-consequential-action",
+      executionStatus: "failed",
+    })]);
+  });
+
+  it("executes approval and receipts it", async () => {
+    _setGovernanceForTests({
+      alignmentGate: async () => alignmentDecision("approve"), executeTool: execute,
+      toolExecutionCreate: async (data) => { audits.push(data); return { id: "allow" }; },
+      toolExecutionReceiptCreate: async (data) => { receipts.push(data); },
+    });
+    const result = await governedExecuteTool({
+      toolName: "create_digital_product", rawParams: { name: "Self-host support subscription" },
+      userId: "user-1", userContext: USER, source: "rest",
+    });
+    expect(result.success).toBe(true);
+    expect(receipts).toEqual([expect.objectContaining({
+      toolExecutionId: "allow", receiptKind: "tak-consequential-action",
+      executionStatus: "succeeded",
+    })]);
+  });
+});

--- a/apps/web/lib/mcp-governed-execute.test.ts
+++ b/apps/web/lib/mcp-governed-execute.test.ts
@@ -661,23 +661,13 @@ describe("governedExecuteTool — coworker read-baseline at execution time", () 
 
 describe("governedExecuteTool — Work Case receipt context", () => {
   const WORK_CASE_CONTEXT = {
-    caseRef: {
-      caseId: "backlog-item:BI-1",
-      sourceType: "backlog-item",
-      sourceId: "BI-1",
-    },
+    caseRef: { caseId: "backlog-item:BI-1", sourceType: "backlog-item", sourceId: "BI-1" },
     sourceKey: "backlog-item",
     action: "complete",
-    currentState: {
-      state: "active",
-      terminal: false,
-    },
+    currentState: { state: "active", terminal: false },
     envelope: {
       autonomyMode: "autonomous",
-      receiptPolicy: {
-        required: true,
-        kind: "governed-action",
-      },
+      receiptPolicy: { required: true, kind: "governed-action" },
     },
   } as const;
 
@@ -694,6 +684,7 @@ describe("governedExecuteTool — Work Case receipt context", () => {
   });
 
   it("mints a governed Work Case receipt for successful consequential actions", async () => {
+    const receiptUpdates: AuditRow[] = [];
     _setGovernanceForTests({
       resolveAgentGrants: async () => ["backlog_write"],
       isAllowedByGrants: () => true,
@@ -702,7 +693,12 @@ describe("governedExecuteTool — Work Case receipt context", () => {
         auditRows.push(data);
         return { id: "tool-exec-work-case-1" };
       },
-      toolExecutionReceiptCreate: captureAudit(receiptRows),
+      toolExecutionUpdate: async () => ({}),
+      toolExecutionReceiptCreate: async (data) => {
+        receiptRows.push(data); return { id: "receipt-work-case-1" };
+      },
+      toolExecutionReceiptUpdate: async (_id, data) => { receiptUpdates.push(data); },
+      gaidActorResolver: async () => ({ principalId: "PRN-1", gaid: "GAID-1", actorKind: "owner", actorRef: "user-1" }),
     });
 
     await governedExecuteTool({
@@ -710,9 +706,7 @@ describe("governedExecuteTool — Work Case receipt context", () => {
       rawParams: { itemId: "BI-1", status: "done" },
       userId: "user-1",
       userContext: NORMAL_USER,
-      context: {
-        workCase: WORK_CASE_CONTEXT,
-      },
+      context: { workCase: WORK_CASE_CONTEXT },
       source: "external-jsonrpc",
     });
 
@@ -720,15 +714,17 @@ describe("governedExecuteTool — Work Case receipt context", () => {
     expect(receiptRows[0]).toEqual(
       expect.objectContaining({
         buildId: null,
-        executionStatus: "succeeded",
+        executionStatus: "reserved",
         receiptKind: "work-case-governed-action",
-        receiptStatus: "valid",
+        receiptStatus: "reserved",
         toolExecutionId: "tool-exec-work-case-1",
       }),
     );
+    expect(receiptUpdates).toEqual([expect.objectContaining({ executionStatus: "succeeded", receiptStatus: "valid" })]);
   });
 
   it("mints an invalid governed Work Case receipt for failed consequential actions", async () => {
+    const receiptUpdates: AuditRow[] = [];
     _setGovernanceForTests({
       resolveAgentGrants: async () => ["backlog_write"],
       isAllowedByGrants: () => true,
@@ -743,7 +739,12 @@ describe("governedExecuteTool — Work Case receipt context", () => {
         auditRows.push(data);
         return { id: "tool-exec-work-case-2" };
       },
-      toolExecutionReceiptCreate: captureAudit(receiptRows),
+      toolExecutionUpdate: async () => ({}),
+      toolExecutionReceiptCreate: async (data) => {
+        receiptRows.push(data); return { id: "receipt-work-case-2" };
+      },
+      toolExecutionReceiptUpdate: async (_id, data) => { receiptUpdates.push(data); },
+      gaidActorResolver: async () => ({ principalId: "PRN-1", gaid: "GAID-1", actorKind: "owner", actorRef: "user-1" }),
     });
 
     await governedExecuteTool({
@@ -751,21 +752,20 @@ describe("governedExecuteTool — Work Case receipt context", () => {
       rawParams: { itemId: "BI-1", status: "done" },
       userId: "user-1",
       userContext: NORMAL_USER,
-      context: {
-        workCase: WORK_CASE_CONTEXT,
-      },
+      context: { workCase: WORK_CASE_CONTEXT },
       source: "external-jsonrpc",
     });
 
     expect(receiptRows).toHaveLength(1);
     expect(receiptRows[0]).toEqual(
       expect.objectContaining({
-        executionStatus: "failed",
+        executionStatus: "reserved",
         receiptKind: "work-case-governed-action",
-        receiptStatus: "invalid",
+        receiptStatus: "reserved",
         toolExecutionId: "tool-exec-work-case-2",
       }),
     );
+    expect(receiptUpdates).toEqual([expect.objectContaining({ executionStatus: "failed", receiptStatus: "invalid" })]);
   });
 });
 

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -8,7 +8,6 @@
 // external-MCP transport a stable hook.
 
 import { prisma } from "@dpf/db";
-import { createHash, scryptSync } from "crypto";
 import { can, type CapabilityKey, type UserContext } from "./permissions";
 import type { CoworkerAuthorityDecision } from "./govern/authority/coworker-authority-decision";
 import {
@@ -35,9 +34,21 @@ import {
 } from "./mcp-tools";
 import { coerceMcpToolArgs } from "./mcp-arg-coercion";
 import { deriveAuditClassForTool, deriveCapabilityId } from "./tool-audit-helpers";
-import { getWorkCaseAction } from "./work-management/action-registry";
 import type { WorkCaseExecutionContext } from "./work-management/work-case-governance-hook";
 import type { AuthorizedSurfaceContext, AuthorizedSurfaceInvocation } from "@/lib/coworker/authorized-surface-execution-types";
+import {
+  classifyConsequentialTool,
+} from "./tak/consequential-tool-policy";
+import {
+  runTakAlignmentGate,
+  setAlignmentGateOverrideForTests,
+  type AlignmentGate,
+  type AlignmentGateDecision,
+} from "./tak/alignment-tool-gate";
+import {
+  setToolExecutionReceiptCreateOverrideForTests,
+  writeToolExecutionReceipt,
+} from "./tak/tool-execution-receipt";
 
 export type GovernedExecuteSource =
   | "rest"
@@ -118,6 +129,8 @@ export type GovernedExecuteContext = {
   tokenGrantScopes?: string[];
   /** Server-authored correlation for a domain tool reached through ASC. */
   surfaceInvocation?: AuthorizedSurfaceInvocation;
+  /** Server-resolved organization identity for WWWD alignment. */
+  organizationId?: string;
 };
 
 export type GovernedExecuteArgs = {
@@ -136,13 +149,17 @@ export type GovernedExecuteRejection =
   | "hook_denied"
   | "authority_denied"
   | "approval_required"
-  | "authority_evidence_unavailable";
+  | "authority_evidence_unavailable"
+  | "alignment_denied"
+  | "alignment_escalation_required";
 
 export type GovernedExecuteResult = ToolResult & {
   governance?: {
     rejected?: GovernedExecuteRejection;
     durationMs?: number;
     authorityReason?: CoworkerAuthorityDecision["reasonCode"];
+    alignment?: AlignmentGateDecision["alignment"];
+    alignmentInteractionId?: string;
   };
 };
 
@@ -203,14 +220,16 @@ export function _setGovernanceForTests(overrides: {
   authorityApprovalTaskResume?: AuthorityApprovalTaskResume | null;
   authorityApprovalEnvelopeFinalize?: AuthorityApprovalEnvelopeFinalize | null;
   lifecycleHooks?: ToolLifecycleHook[] | null;
+  alignmentGate?: AlignmentGate | null;
 }): void {
   _resolveAgentGrants = overrides.resolveAgentGrants ?? null;
   _isAllowedByGrants = overrides.isAllowedByGrants ?? null;
   _executeToolOverride = overrides.executeTool ?? null;
   _toolExecutionCreateOverride = overrides.toolExecutionCreate ?? null;
-  _toolExecutionReceiptCreateOverride = overrides.toolExecutionReceiptCreate ?? null;
+  setToolExecutionReceiptCreateOverrideForTests(overrides.toolExecutionReceiptCreate ?? null);
   setCoworkerToolAuthorityOverridesForTests(overrides);
   _lifecycleHooks = overrides.lifecycleHooks ?? [];
+  setAlignmentGateOverrideForTests(overrides.alignmentGate ?? null);
 }
 
 let _executeToolOverride:
@@ -231,9 +250,6 @@ let _toolExecutionCreateOverride:
   | ((data: Record<string, unknown>) => Promise<unknown>)
   | null = null;
 
-let _toolExecutionReceiptCreateOverride:
-  | ((data: Record<string, unknown>) => Promise<unknown>)
-  | null = null;
 
 async function resolveGrants(agentId: string): Promise<string[]> {
   if (_resolveAgentGrants) return _resolveAgentGrants(agentId);
@@ -301,6 +317,7 @@ async function writeAudit(data: {
   source: GovernedExecuteSource;
   context?: GovernedExecuteContext;
   durationMs: number;
+  alignmentDecision?: AlignmentGateDecision | null;
 }): Promise<{ id: string } | null> {
   const auditClass = deriveAuditClassForTool(data.toolName);
   const capabilityId = deriveCapabilityId(data.toolName);
@@ -316,6 +333,15 @@ async function writeAudit(data: {
     parameters: isMetricsOnly ? {} : ({
       ...auditedParams,
       ...(data.context?.surfaceInvocation ? { _surface: data.context.surfaceInvocation } : {}),
+      ...(data.alignmentDecision
+        ? {
+            _takAlignment: {
+              interactionId: data.alignmentDecision.interactionId,
+              verdict: data.alignmentDecision.verdict,
+              checks: data.alignmentDecision.alignment.checks,
+            },
+          }
+        : {}),
     } as object),
     result: isMetricsOnly ? {} : (data.result as unknown as object),
     success: data.result.success,
@@ -380,95 +406,6 @@ function redactWriteOnlyParameters(
   }));
 }
 
-function deriveReceiptKind(
-  toolName: string,
-  context?: GovernedExecuteContext,
-): string | null {
-  if (context?.workCase) {
-    const action = getWorkCaseAction(context.workCase.action);
-    if (action?.consequential) {
-      return "work-case-governed-action";
-    }
-  }
-
-  switch (toolName) {
-    case "run_sandbox_tests":
-      return "sandbox-test-run";
-    case "run_sandbox_command":
-      return "sandbox-command";
-    case "run_ux_test":
-      return "ux-run";
-    default:
-      return null;
-  }
-}
-
-// CodeQL #63 (js/insufficient-password-hash): API tokens flow into this
-// digestPayload via dataflow; CodeQL requires a slow KDF for any value
-// it traces from a password-like source. scrypt with a fixed salt
-// ("dpf-receipt") gives a deterministic digest (receipts are content-
-// addressable — a random salt would defeat the lookup). N=2^14 r=8 p=1
-// is the standard Node default and takes ~1-5ms per digest.
-function digestPayload(value: unknown): string {
-  const json = JSON.stringify(value ?? null);
-  return scryptSync(json, "dpf-receipt", 32, {
-    N: 16384, r: 8, p: 1, maxmem: 64 * 1024 * 1024,
-  }).toString("hex");
-}
-// Keep createHash imported for any future non-KDF digest sites.
-void createHash;
-
-async function writeReceipt(data: {
-  auditRowId: string;
-  buildId: string | null;
-  rawParams: Record<string, unknown>;
-  result: ToolResult;
-  toolName: string;
-  context?: GovernedExecuteContext;
-}): Promise<void> {
-  const receiptKind = deriveReceiptKind(data.toolName, data.context);
-  if (!receiptKind) {
-    return;
-  }
-
-  const row = {
-    buildId: data.buildId ?? null,
-    executionStatus: data.result.success ? "succeeded" : "failed",
-    expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-    inputFingerprint: digestPayload({
-      params: data.rawParams,
-      toolName: data.toolName,
-    }),
-    outputDigest: {
-      sha256: digestPayload({
-        data: data.result.data ?? null,
-        error: data.result.error ?? null,
-        message: data.result.message ?? null,
-        success: data.result.success,
-      }),
-    },
-    receiptKind,
-    receiptStatus: data.result.success ? "valid" : "invalid",
-    toolExecutionId: data.auditRowId,
-  };
-
-  try {
-    if (_toolExecutionReceiptCreateOverride) {
-      await _toolExecutionReceiptCreateOverride(row);
-    } else {
-      await prisma.toolExecutionReceipt.create({ data: row });
-    }
-  } catch (err) {
-    // CodeQL #50 (js/tainted-format-string): tool/build names via format-args.
-    console.error(
-      "[governed-execute] receipt write failed tool=%s build=%s: %s",
-      JSON.stringify(data.toolName),
-      JSON.stringify(data.buildId),
-      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
-    );
-  }
-}
-
 function findTool(toolName: string): ToolDefinition | undefined {
   return PLATFORM_TOOLS.find((t) => t.name === toolName);
 }
@@ -517,6 +454,7 @@ export async function governedExecuteTool(
   args: GovernedExecuteArgs,
 ): Promise<GovernedExecuteResult> {
   let approvedAuthorityEnvelopeId: string | null = null;
+  let alignmentDecision: AlignmentGateDecision | null = null;
   const tool = findTool(args.toolName);
   if (!tool) {
     return {
@@ -539,6 +477,11 @@ export async function governedExecuteTool(
     ...args,
     rawParams: coerceMcpToolArgs(args.rawParams, tool.inputSchema),
   };
+  const consequence = classifyConsequentialTool({
+    toolName: args.toolName,
+    tool,
+    workCase: args.context?.workCase,
+  });
 
   const humanCapabilityAllowed = !tool.requiredCapability
     || can(args.userContext, tool.requiredCapability as CapabilityKey);
@@ -552,7 +495,7 @@ export async function governedExecuteTool(
         "forbidden_capability",
         `user lacks capability ${tool.requiredCapability}`,
       );
-      await writeAudit({
+      const auditRow = await writeAudit({
         toolName: args.toolName,
         rawParams: args.rawParams,
         result,
@@ -561,6 +504,17 @@ export async function governedExecuteTool(
         context: args.context,
         durationMs: 0,
       });
+      if (auditRow?.id && consequence.consequential) {
+        await writeToolExecutionReceipt({
+          auditRowId: auditRow.id,
+          buildId: null,
+          rawParams: args.rawParams,
+          result,
+          toolName: args.toolName,
+          context: args.context,
+          consequential: true,
+        });
+      }
       return result;
   }
 
@@ -608,8 +562,9 @@ export async function governedExecuteTool(
       if (
         authorityGate.rejection === "authority_denied"
         || authorityGate.rejection === "approval_required"
+        || consequence.consequential
       ) {
-        await writeAudit({
+        const auditRow = await writeAudit({
           toolName: args.toolName,
           rawParams: args.rawParams,
           result,
@@ -618,6 +573,17 @@ export async function governedExecuteTool(
           context: args.context,
           durationMs: 0,
         });
+        if (auditRow?.id && consequence.consequential) {
+          await writeToolExecutionReceipt({
+            auditRowId: auditRow.id,
+            buildId: null,
+            rawParams: args.rawParams,
+            result,
+            toolName: args.toolName,
+            context: args.context,
+            consequential: true,
+          });
+        }
       }
       return result;
     }
@@ -633,7 +599,7 @@ export async function governedExecuteTool(
     source: args.source,
   });
   if (hookRejection) {
-    await writeAudit({
+    const auditRow = await writeAudit({
       toolName: args.toolName,
       rawParams: args.rawParams,
       result: hookRejection,
@@ -642,7 +608,62 @@ export async function governedExecuteTool(
       context: args.context,
       durationMs: 0,
     });
+    if (auditRow?.id && consequence.consequential) {
+      await writeToolExecutionReceipt({
+        auditRowId: auditRow.id,
+        buildId: null,
+        rawParams: args.rawParams,
+        result: hookRejection,
+        toolName: args.toolName,
+        context: args.context,
+        consequential: true,
+      });
+    }
     return hookRejection;
+  }
+
+  if (consequence.alignmentRequired) {
+    alignmentDecision = await runTakAlignmentGate(args);
+    if (alignmentDecision.verdict !== "approve") {
+      const rejection: GovernedExecuteRejection = alignmentDecision.verdict === "decline"
+        ? "alignment_denied"
+        : "alignment_escalation_required";
+      const result: GovernedExecuteResult = {
+        ...rejectionResult(args.toolName, rejection, alignmentDecision.rationale),
+        data: {
+          interactionId: alignmentDecision.interactionId,
+          alignment: alignmentDecision.alignment,
+        },
+        governance: {
+          rejected: rejection,
+          alignment: alignmentDecision.alignment,
+          alignmentInteractionId: alignmentDecision.interactionId,
+        },
+      };
+      const auditRow = await writeAudit({
+        toolName: args.toolName,
+        rawParams: args.rawParams,
+        result,
+        userId: args.userId,
+        source: args.source,
+        context: args.context,
+        durationMs: 0,
+        alignmentDecision,
+      });
+      if (auditRow?.id) {
+        await writeToolExecutionReceipt({
+          auditRowId: auditRow.id,
+          buildId: null,
+          rawParams: args.rawParams,
+          result,
+          toolName: args.toolName,
+          context: args.context,
+          consequential: true,
+          alignmentDecision,
+        });
+      }
+      return result;
+    }
   }
 
   const t0 = Date.now();
@@ -749,6 +770,7 @@ export async function governedExecuteTool(
     source: args.source,
     context: args.context,
     durationMs,
+    alignmentDecision,
   });
 
   const resultBuildId =
@@ -757,15 +779,19 @@ export async function governedExecuteTool(
     && typeof (result.data as Record<string, unknown>).buildId === "string"
       ? String((result.data as Record<string, unknown>).buildId)
       : null;
-  const shouldWriteReceipt = Boolean(resultBuildId || args.context?.workCase);
+  const shouldWriteReceipt = Boolean(
+    resultBuildId || args.context?.workCase || consequence.consequential,
+  );
   if (auditRow?.id && shouldWriteReceipt) {
-    await writeReceipt({
+    await writeToolExecutionReceipt({
       auditRowId: auditRow.id,
       buildId: resultBuildId,
       rawParams: args.rawParams,
       result,
       toolName: args.toolName,
       context: args.context,
+      consequential: consequence.consequential,
+      alignmentDecision,
     });
   }
 

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -33,7 +33,11 @@ import {
   type ToolResult,
 } from "./mcp-tools";
 import { coerceMcpToolArgs } from "./mcp-arg-coercion";
-import { deriveAuditClassForTool, deriveCapabilityId } from "./tool-audit-helpers";
+import {
+  setGovernedToolAuditOverridesForTests,
+  updateGovernedToolAudit as updateAudit,
+  writeGovernedToolAudit,
+} from "./governed-tool-audit";
 import type { WorkCaseExecutionContext } from "./work-management/work-case-governance-hook";
 import type { AuthorizedSurfaceContext, AuthorizedSurfaceInvocation } from "@/lib/coworker/authorized-surface-execution-types";
 import {
@@ -45,7 +49,10 @@ import {
   type AlignmentGateDecision,
 } from "./tak/alignment-tool-gate";
 import {
+  finalizeConsequentialToolExecutionReceipt,
+  reserveConsequentialToolExecutionReceipt,
   setToolExecutionReceiptCreateOverrideForTests,
+  setToolExecutionReceiptUpdateOverrideForTests,
   writeToolExecutionReceipt,
 } from "./tak/tool-execution-receipt";
 import {
@@ -54,6 +61,10 @@ import {
   type PreconditionOrderingDecision,
 } from "./tak/precondition-ordering-gate";
 import { enforceTakPreexecution } from "./tak/preexecution-control";
+import {
+  setGaidActorResolverOverrideForTests,
+  type GaidActorResolver,
+} from "./tak/gaid-actor-envelope";
 
 export type GovernedExecuteSource =
   | "rest"
@@ -157,6 +168,8 @@ export type GovernedExecuteRejection =
   | "authority_evidence_unavailable"
   | "alignment_denied"
   | "alignment_escalation_required"
+  | "alignment_bypass_forbidden"
+  | "receipt_reservation_failed"
   | "precondition_denied"
   | "precondition_escalation_required";
 
@@ -221,7 +234,9 @@ export function _setGovernanceForTests(overrides: {
     ctx?: { agentId?: string; threadId?: string; routeContext?: string; taskRunId?: string },
   ) => Promise<ToolResult>) | null;
   toolExecutionCreate?: ((data: Record<string, unknown>) => Promise<unknown>) | null;
+  toolExecutionUpdate?: ((id: string, data: Record<string, unknown>) => Promise<unknown>) | null;
   toolExecutionReceiptCreate?: ((data: Record<string, unknown>) => Promise<unknown>) | null;
+  toolExecutionReceiptUpdate?: ((id: string, data: Record<string, unknown>) => Promise<unknown>) | null;
   resolveCoworkerAuthorityInput?: CoworkerAuthorityInputResolver | null;
   authorizationDecisionCreate?: AuthorizationDecisionCreate | null;
   authorityApprovalEnvelopeCreate?: AuthorityApprovalEnvelopeCreate | null;
@@ -230,16 +245,22 @@ export function _setGovernanceForTests(overrides: {
   lifecycleHooks?: ToolLifecycleHook[] | null;
   alignmentGate?: AlignmentGate | null;
   preconditionGate?: PreconditionGate | null;
+  gaidActorResolver?: GaidActorResolver | null;
 }): void {
   _resolveAgentGrants = overrides.resolveAgentGrants ?? null;
   _isAllowedByGrants = overrides.isAllowedByGrants ?? null;
   _executeToolOverride = overrides.executeTool ?? null;
-  _toolExecutionCreateOverride = overrides.toolExecutionCreate ?? null;
+  setGovernedToolAuditOverridesForTests({
+    create: overrides.toolExecutionCreate ?? null,
+    update: overrides.toolExecutionUpdate ?? null,
+  });
   setToolExecutionReceiptCreateOverrideForTests(overrides.toolExecutionReceiptCreate ?? null);
+  setToolExecutionReceiptUpdateOverrideForTests(overrides.toolExecutionReceiptUpdate ?? null);
   setCoworkerToolAuthorityOverridesForTests(overrides);
   _lifecycleHooks = overrides.lifecycleHooks ?? [];
   setAlignmentGateOverrideForTests(overrides.alignmentGate ?? null);
   setPreconditionGateOverrideForTests(overrides.preconditionGate ?? null);
+  setGaidActorResolverOverrideForTests(overrides.gaidActorResolver ?? null);
 }
 
 let _executeToolOverride:
@@ -255,11 +276,6 @@ let _executeToolOverride:
       },
     ) => Promise<ToolResult>)
   | null = null;
-
-let _toolExecutionCreateOverride:
-  | ((data: Record<string, unknown>) => Promise<unknown>)
-  | null = null;
-
 
 async function resolveGrants(agentId: string): Promise<string[]> {
   if (_resolveAgentGrants) return _resolveAgentGrants(agentId);
@@ -330,92 +346,8 @@ async function writeAudit(data: {
   alignmentDecision?: AlignmentGateDecision | null;
   preconditionDecision?: PreconditionOrderingDecision | null;
 }): Promise<{ id: string } | null> {
-  const auditClass = deriveAuditClassForTool(data.toolName);
-  const capabilityId = deriveCapabilityId(data.toolName);
-  const isMetricsOnly = auditClass === "metrics_only";
   const tool = findTool(data.toolName);
-  const auditedParams = redactWriteOnlyParameters(data.rawParams, tool?.inputSchema);
-  const row = {
-    threadId: data.context?.threadId ?? "",
-    agentId: data.context?.agentId ?? "unknown",
-    userId: data.userId,
-    taskRunId: data.context?.taskRunId ?? null,
-    toolName: data.toolName,
-    parameters: isMetricsOnly ? {} : ({
-      ...auditedParams,
-      ...(data.context?.surfaceInvocation ? { _surface: data.context.surfaceInvocation } : {}),
-      ...(data.alignmentDecision
-        ? {
-            _takAlignment: {
-              interactionId: data.alignmentDecision.interactionId,
-              verdict: data.alignmentDecision.verdict,
-              checks: data.alignmentDecision.alignment.checks,
-            },
-          }
-        : {}),
-      ...(data.preconditionDecision ? { _takPrecondition: data.preconditionDecision } : {}),
-    } as object),
-    result: isMetricsOnly ? {} : (data.result as unknown as object),
-    success: data.result.success,
-    executionMode: data.source,
-    routeContext: data.context?.routeContext ?? null,
-    durationMs: data.durationMs,
-    auditClass,
-    capabilityId,
-    summary: isMetricsOnly
-      ? `${data.toolName}: ${data.result.success ? "ok" : "failed"}` +
-        (data.durationMs ? ` (${data.durationMs}ms)` : "")
-      : null,
-    apiTokenId: data.context?.apiTokenId ?? null,
-    skillId: data.context?.skillId ?? null,
-    // EP-31815F97 S2: join this execution to its chain-of-custody when the
-    // executing coworker was delegated to; the human origin stays on userId.
-    delegationChainId: data.context?.delegationChainId ?? null,
-  };
-  try {
-    if (_toolExecutionCreateOverride) {
-      const created = await _toolExecutionCreateOverride(row);
-      return typeof (created as { id?: unknown } | undefined)?.id === "string"
-        ? { id: String((created as { id: string }).id) }
-        : null;
-    } else {
-      return await prisma.toolExecution.create({
-        data: row,
-        select: { id: true },
-      });
-    }
-  } catch (err) {
-    // Audit MUST NOT silently fail. Log with enough context to investigate
-    // without throwing back to the caller (which would mask successful tool
-    // execution).
-    // CodeQL #49 (js/tainted-format-string): tool/source names are user-influenced.
-    console.error(
-      "[governed-execute] audit write failed tool=%s source=%s: %s",
-      JSON.stringify(data.toolName),
-      JSON.stringify(data.source),
-      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
-    );
-    return null;
-  }
-}
-
-function redactWriteOnlyParameters(
-  value: Record<string, unknown>,
-  schema: Record<string, unknown> | undefined,
-): Record<string, unknown> {
-  const properties = schema?.properties && typeof schema.properties === "object"
-    ? schema.properties as Record<string, unknown>
-    : {};
-  return Object.fromEntries(Object.entries(value).map(([key, entry]) => {
-    const property = properties[key] && typeof properties[key] === "object"
-      ? properties[key] as Record<string, unknown>
-      : undefined;
-    if (property?.writeOnly === true) return [key, "[REDACTED]"];
-    if (entry && typeof entry === "object" && !Array.isArray(entry) && property?.properties) {
-      return [key, redactWriteOnlyParameters(entry as Record<string, unknown>, property)];
-    }
-    return [key, entry];
-  }));
+  return writeGovernedToolAudit({ ...data, tool });
 }
 
 function findTool(toolName: string): ToolDefinition | undefined {
@@ -526,6 +458,7 @@ export async function governedExecuteTool(
           toolName: args.toolName,
           context: args.context,
           consequential: true,
+          governedArgs: args,
         });
       }
       return result;
@@ -595,6 +528,7 @@ export async function governedExecuteTool(
             toolName: args.toolName,
             context: args.context,
             consequential: true,
+            governedArgs: args,
           });
         }
       }
@@ -630,6 +564,7 @@ export async function governedExecuteTool(
         toolName: args.toolName,
         context: args.context,
         consequential: true,
+        governedArgs: args,
       });
     }
     return hookRejection;
@@ -648,6 +583,35 @@ export async function governedExecuteTool(
   alignmentDecision = preexecution.alignmentDecision;
   preconditionDecision = preexecution.preconditionDecision;
   if (preexecution.result) return preexecution.result;
+
+  let reservedAuditId: string | null = null;
+  let reservedReceiptId: string | null = null;
+  if (consequence.consequential) {
+    const reservationResult: ToolResult = {
+      success: false, error: "execution_reserved", message: "Consequential execution awaiting side effect.",
+    };
+    const reservedAudit = await writeAudit({
+      toolName: args.toolName, rawParams: args.rawParams, result: reservationResult,
+      userId: args.userId, source: args.source, context: args.context, durationMs: 0,
+      alignmentDecision, preconditionDecision,
+    });
+    reservedAuditId = reservedAudit?.id ?? null;
+    const reservedReceipt = reservedAuditId
+      ? await reserveConsequentialToolExecutionReceipt({
+          auditRowId: reservedAuditId, args, alignmentDecision, preconditionDecision,
+        })
+      : null;
+    reservedReceiptId = reservedReceipt?.id ?? null;
+    if (!reservedAuditId || !reservedReceiptId) {
+      const failure = rejectionResult(
+        args.toolName,
+        "receipt_reservation_failed",
+        "the mandatory GAID receipt channel could not be reserved before execution",
+      );
+      if (reservedAuditId) await updateAudit(reservedAuditId, failure, 0);
+      return failure;
+    }
+  }
 
   const t0 = Date.now();
   let result: ToolResult;
@@ -745,18 +709,6 @@ export async function governedExecuteTool(
     durationMs,
   });
 
-  const auditRow = await writeAudit({
-    toolName: args.toolName,
-    rawParams: args.rawParams,
-    result,
-    userId: args.userId,
-    source: args.source,
-    context: args.context,
-    durationMs,
-    alignmentDecision,
-    preconditionDecision,
-  });
-
   const resultBuildId =
     result.data
     && typeof result.data === "object"
@@ -766,7 +718,31 @@ export async function governedExecuteTool(
   const shouldWriteReceipt = Boolean(
     resultBuildId || args.context?.workCase || consequence.consequential,
   );
-  if (auditRow?.id && shouldWriteReceipt) {
+  let auditRow: { id: string } | null = reservedAuditId ? { id: reservedAuditId } : null;
+  if (reservedAuditId && reservedReceiptId) {
+    await updateAudit(reservedAuditId, result, durationMs);
+    try {
+      await finalizeConsequentialToolExecutionReceipt({
+        receiptId: reservedReceiptId, result, toolName: args.toolName, args,
+        alignmentDecision, preconditionDecision, buildId: resultBuildId,
+      });
+    } catch (err) {
+      // The receipt was durably reserved before the side effect. Preserve the
+      // actual tool result; reconciliation can finalize the reserved envelope.
+      console.error(
+        "[governed-execute] reserved receipt finalization failed receipt=%s tool=%s: %s",
+        JSON.stringify(reservedReceiptId), JSON.stringify(args.toolName),
+        err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
+      );
+    }
+  } else {
+    auditRow = await writeAudit({
+      toolName: args.toolName, rawParams: args.rawParams, result, userId: args.userId,
+      source: args.source, context: args.context, durationMs,
+      alignmentDecision, preconditionDecision,
+    });
+  }
+  if (auditRow?.id && shouldWriteReceipt && !reservedReceiptId) {
     await writeToolExecutionReceipt({
       auditRowId: auditRow.id,
       buildId: resultBuildId,
@@ -777,6 +753,7 @@ export async function governedExecuteTool(
       consequential: consequence.consequential,
       alignmentDecision,
       preconditionDecision,
+      governedArgs: args,
     });
   }
 

--- a/apps/web/lib/mcp-governed-execute.ts
+++ b/apps/web/lib/mcp-governed-execute.ts
@@ -40,7 +40,6 @@ import {
   classifyConsequentialTool,
 } from "./tak/consequential-tool-policy";
 import {
-  runTakAlignmentGate,
   setAlignmentGateOverrideForTests,
   type AlignmentGate,
   type AlignmentGateDecision,
@@ -49,6 +48,12 @@ import {
   setToolExecutionReceiptCreateOverrideForTests,
   writeToolExecutionReceipt,
 } from "./tak/tool-execution-receipt";
+import {
+  setPreconditionGateOverrideForTests,
+  type PreconditionGate,
+  type PreconditionOrderingDecision,
+} from "./tak/precondition-ordering-gate";
+import { enforceTakPreexecution } from "./tak/preexecution-control";
 
 export type GovernedExecuteSource =
   | "rest"
@@ -151,7 +156,9 @@ export type GovernedExecuteRejection =
   | "approval_required"
   | "authority_evidence_unavailable"
   | "alignment_denied"
-  | "alignment_escalation_required";
+  | "alignment_escalation_required"
+  | "precondition_denied"
+  | "precondition_escalation_required";
 
 export type GovernedExecuteResult = ToolResult & {
   governance?: {
@@ -160,6 +167,7 @@ export type GovernedExecuteResult = ToolResult & {
     authorityReason?: CoworkerAuthorityDecision["reasonCode"];
     alignment?: AlignmentGateDecision["alignment"];
     alignmentInteractionId?: string;
+    precondition?: PreconditionOrderingDecision;
   };
 };
 
@@ -221,6 +229,7 @@ export function _setGovernanceForTests(overrides: {
   authorityApprovalEnvelopeFinalize?: AuthorityApprovalEnvelopeFinalize | null;
   lifecycleHooks?: ToolLifecycleHook[] | null;
   alignmentGate?: AlignmentGate | null;
+  preconditionGate?: PreconditionGate | null;
 }): void {
   _resolveAgentGrants = overrides.resolveAgentGrants ?? null;
   _isAllowedByGrants = overrides.isAllowedByGrants ?? null;
@@ -230,6 +239,7 @@ export function _setGovernanceForTests(overrides: {
   setCoworkerToolAuthorityOverridesForTests(overrides);
   _lifecycleHooks = overrides.lifecycleHooks ?? [];
   setAlignmentGateOverrideForTests(overrides.alignmentGate ?? null);
+  setPreconditionGateOverrideForTests(overrides.preconditionGate ?? null);
 }
 
 let _executeToolOverride:
@@ -318,6 +328,7 @@ async function writeAudit(data: {
   context?: GovernedExecuteContext;
   durationMs: number;
   alignmentDecision?: AlignmentGateDecision | null;
+  preconditionDecision?: PreconditionOrderingDecision | null;
 }): Promise<{ id: string } | null> {
   const auditClass = deriveAuditClassForTool(data.toolName);
   const capabilityId = deriveCapabilityId(data.toolName);
@@ -342,6 +353,7 @@ async function writeAudit(data: {
             },
           }
         : {}),
+      ...(data.preconditionDecision ? { _takPrecondition: data.preconditionDecision } : {}),
     } as object),
     result: isMetricsOnly ? {} : (data.result as unknown as object),
     success: data.result.success,
@@ -455,6 +467,7 @@ export async function governedExecuteTool(
 ): Promise<GovernedExecuteResult> {
   let approvedAuthorityEnvelopeId: string | null = null;
   let alignmentDecision: AlignmentGateDecision | null = null;
+  let preconditionDecision: PreconditionOrderingDecision | null = null;
   const tool = findTool(args.toolName);
   if (!tool) {
     return {
@@ -622,49 +635,19 @@ export async function governedExecuteTool(
     return hookRejection;
   }
 
-  if (consequence.alignmentRequired) {
-    alignmentDecision = await runTakAlignmentGate(args);
-    if (alignmentDecision.verdict !== "approve") {
-      const rejection: GovernedExecuteRejection = alignmentDecision.verdict === "decline"
-        ? "alignment_denied"
-        : "alignment_escalation_required";
-      const result: GovernedExecuteResult = {
-        ...rejectionResult(args.toolName, rejection, alignmentDecision.rationale),
-        data: {
-          interactionId: alignmentDecision.interactionId,
-          alignment: alignmentDecision.alignment,
-        },
-        governance: {
-          rejected: rejection,
-          alignment: alignmentDecision.alignment,
-          alignmentInteractionId: alignmentDecision.interactionId,
-        },
-      };
-      const auditRow = await writeAudit({
-        toolName: args.toolName,
-        rawParams: args.rawParams,
-        result,
-        userId: args.userId,
-        source: args.source,
-        context: args.context,
-        durationMs: 0,
-        alignmentDecision,
-      });
-      if (auditRow?.id) {
-        await writeToolExecutionReceipt({
-          auditRowId: auditRow.id,
-          buildId: null,
-          rawParams: args.rawParams,
-          result,
-          toolName: args.toolName,
-          context: args.context,
-          consequential: true,
-          alignmentDecision,
-        });
-      }
-      return result;
-    }
-  }
+  const preexecution = await enforceTakPreexecution({
+    args,
+    alignmentRequired: consequence.alignmentRequired,
+    preconditionRequired: consequence.preconditionRequired,
+    writeAudit: ({ result, alignmentDecision: alignment, preconditionDecision: precondition }) => writeAudit({
+      toolName: args.toolName, rawParams: args.rawParams, result, userId: args.userId,
+      source: args.source, context: args.context, durationMs: 0,
+      alignmentDecision: alignment, preconditionDecision: precondition,
+    }),
+  });
+  alignmentDecision = preexecution.alignmentDecision;
+  preconditionDecision = preexecution.preconditionDecision;
+  if (preexecution.result) return preexecution.result;
 
   const t0 = Date.now();
   let result: ToolResult;
@@ -771,6 +754,7 @@ export async function governedExecuteTool(
     context: args.context,
     durationMs,
     alignmentDecision,
+    preconditionDecision,
   });
 
   const resultBuildId =
@@ -792,6 +776,7 @@ export async function governedExecuteTool(
       context: args.context,
       consequential: consequence.consequential,
       alignmentDecision,
+      preconditionDecision,
     });
   }
 

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
@@ -36,6 +36,11 @@ import { prisma } from "@dpf/db";
 import { upsertWikiPage, appendRevision } from "@dpf/db/wiki-store";
 import { storeWikiPage, type StoreWikiPageInput } from "@/lib/wiki/embeddings";
 import { DECISION_DOMAIN_CLASSES, type DecisionDomainClass } from "@/lib/decision-perspective/types";
+import {
+  projectDeclaredStanceAlignment,
+  projectStanceDimensionVector,
+  type StanceDimensionProjection,
+} from "@/lib/decision-perspective/stance-dimension-map";
 import { suggestMission } from "./mission-suggestion";
 import { deriveExcellenceCorpus, excellenceCorpusToMarkdown } from "./excellence-corpus";
 import {
@@ -127,6 +132,8 @@ type SeedPage = {
    * become echo materials keyed `{profileId}:{slug}:{class}`.
    */
   bundles: DecisionDomainClass[];
+  /** Explicit stance-purpose projection into the shared decision axes. */
+  dimensionProjection?: StanceDimensionProjection;
   /** Set on the mission principle page so it is well-formed. */
   principle?: {
     principleTier: "core";
@@ -211,6 +218,7 @@ function buildPages(
         "\nWhen we decide \"what would we do?\", we weigh the interests of the people we serve first.",
       ].join("\n"),
       abstract: whoAbstract,
+      dimensionProjection: projectDeclaredStanceAlignment(["market_fit", "product_fit"]),
     },
     {
       slug: "org-how-we-decide",
@@ -227,6 +235,7 @@ function buildPages(
         `This is ${orgLabel}'s starting decision stance, derived from how this kind of business tends to operate. Refine it as the organization's own judgment is captured.`,
       ].join("\n"),
       abstract: profile.howWeDecide,
+      dimensionProjection: projectDeclaredStanceAlignment(["mission_fit", "gtm_fit"]),
     },
     {
       slug: "org-supply-chain",
@@ -244,6 +253,7 @@ function buildPages(
         `This is ${orgLabel}'s starting supplier and supply-chain stance, derived from how this kind of business typically runs. Refine it as actual suppliers, vendors, and purchasing rhythms are captured.`,
       ].join("\n"),
       abstract: profile.supplyChain,
+      dimensionProjection: projectDeclaredStanceAlignment(["product_fit", "gtm_fit"]),
     },
     {
       // Excellence Corpus (workstream B): the "what great looks like" primer, so
@@ -281,6 +291,7 @@ function buildPages(
         `This is ${orgLabel}'s starting stance, derived from how this kind of business tends to operate. Confirm or adjust it — a confirmed stance lets your AI coworkers act on it.`,
       ].join("\n"),
       abstract: v.stance,
+      dimensionProjection: projectStanceDimensionVector(key),
     });
   }
 
@@ -407,6 +418,7 @@ export async function seedOrgWwwdCorpus(
             principleDirection: page.principle.principleDirection,
           }
         : {}),
+      ...(page.dimensionProjection ?? {}),
     })) as { id: string };
 
     wikiPageIds.push(saved.id);
@@ -441,6 +453,7 @@ export async function seedOrgWwwdCorpus(
               principleAppliesTo: page.principle.principleAppliesTo,
             }
           : {}),
+        ...(page.dimensionProjection ?? {}),
       });
       if (!ok) embedded = false;
     }

--- a/apps/web/lib/tak/alignment-specialist-delegation.test.ts
+++ b/apps/web/lib/tak/alignment-specialist-delegation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runAlignmentSpecialistDelegation } from "./alignment-specialist-delegation";
+import { composeAlignmentVerdicts } from "./alignment-tool-gate";
+
+const alignment = {
+  verdict: "approve" as const,
+  criteria: {
+    status: "complete" as const,
+    criteria: {
+      market: "b2b software / msp partner", segment: "b2b software",
+      product: "self-host support subscription", motion: "partner channel",
+      geography: null, customerType: "msp partner",
+    },
+    evidence: ["product=self-host support subscription", "motion=partner channel"],
+    missing: ["geography" as const],
+  },
+  checks: [],
+  veto: null,
+};
+
+function professionResult(over: Record<string, unknown> = {}) {
+  return {
+    allowed: true,
+    interactionId: "DI-WSID",
+    professionProfileSelected: true,
+    professionKey: "portfolio-management",
+    operatorMessage: "grounded in current craft",
+    evaluation: {
+      outcomeType: "recommend",
+      recommendedOptionId: "aligned",
+      coverageGap: false,
+      materialCount: 2,
+      freshnessDistribution: { current: 2, stale: 0, superseded: 0, contradicted: 0 },
+      sources: [{ materialId: "mat-1" }],
+    },
+    ...over,
+  };
+}
+
+describe("alignment specialist delegation", () => {
+  it("intersects WWWD and WSID monotonically", () => {
+    expect(composeAlignmentVerdicts("approve", "approve")).toBe("approve");
+    expect(composeAlignmentVerdicts("approve", "escalate")).toBe("escalate");
+    expect(composeAlignmentVerdicts("approve", "decline")).toBe("decline");
+    expect(composeAlignmentVerdicts("decline", "approve")).toBe("decline");
+  });
+
+  it("routes product and GTM checks through their corpus owners and records custody", async () => {
+    const evaluateProfession = vi.fn(async (input: { agentIdentity: { agentId: string } }) =>
+      professionResult(input.agentIdentity.agentId === "marketing-specialist"
+        ? { professionKey: "marketing", interactionId: "DI-GTM" }
+        : {}),
+    );
+    const recordDelegation = vi.fn(async (input: { toAgentId: string }) => `CHAIN-${input.toAgentId}`);
+    const result = await runAlignmentSpecialistDelegation({
+      alignment, statement: "Offer self-host support through MSP partners",
+      userId: "user-1", coordinatorAgentId: "AGT-COORD",
+      evaluateProfession: evaluateProfession as never, recordDelegation,
+    });
+
+    expect(evaluateProfession).toHaveBeenCalledTimes(2);
+    expect(evaluateProfession.mock.calls.map(([input]) => input.agentIdentity.agentId))
+      .toEqual(["portfolio-backlog-agent", "marketing-specialist"]);
+    expect(result.verdict).toBe("approve");
+    expect(result.checks).toEqual(expect.arrayContaining([
+      expect.objectContaining({ corpus: "portfolio", qualification: "qualified", delegationChainId: "CHAIN-portfolio-backlog-agent" }),
+      expect.objectContaining({ corpus: "gtm", qualification: "qualified", delegationChainId: "CHAIN-marketing-specialist" }),
+    ]));
+    expect(result.permissionGranted).toBe(false);
+  });
+
+  it.each([
+    ["absent", { professionProfileSelected: false }],
+    ["stale", { evaluation: { ...professionResult().evaluation, freshnessDistribution: { current: 1, stale: 1, superseded: 0, contradicted: 0 } } }],
+    ["out-of-scope", { professionKey: "marketing" }],
+  ])("fails closed for %s qualification", async (_label, over) => {
+    const result = await runAlignmentSpecialistDelegation({
+      alignment: { ...alignment, criteria: { ...alignment.criteria, criteria: { ...alignment.criteria.criteria, motion: null } } },
+      statement: "Offer self-host support", userId: "user-1", coordinatorAgentId: "AGT-COORD",
+      evaluateProfession: (async () => professionResult(over)) as never,
+      recordDelegation: async () => "CHAIN-1",
+    });
+    expect(result.verdict).toBe("escalate");
+    expect(result.checks[0]?.qualification).not.toBe("qualified");
+    expect(result.permissionGranted).toBe(false);
+  });
+
+  it("lets a qualified WSID rejection veto while never turning qualification into permission", async () => {
+    const result = await runAlignmentSpecialistDelegation({
+      alignment: { ...alignment, criteria: { ...alignment.criteria, criteria: { ...alignment.criteria.criteria, motion: null } } },
+      statement: "Offer an unsupported product", userId: "user-1", coordinatorAgentId: "AGT-COORD",
+      evaluateProfession: (async () => professionResult({
+        evaluation: { ...professionResult().evaluation, recommendedOptionId: "rejected" },
+      })) as never,
+      recordDelegation: async () => "CHAIN-1",
+    });
+    expect(result.verdict).toBe("decline");
+    expect(result.permissionGranted).toBe(false);
+  });
+});

--- a/apps/web/lib/tak/alignment-specialist-delegation.ts
+++ b/apps/web/lib/tak/alignment-specialist-delegation.ts
@@ -1,0 +1,192 @@
+import { randomUUID } from "crypto";
+import { prisma } from "@dpf/db";
+
+import type {
+  AlignmentCorpus,
+  ConstitutionalAlignmentResult,
+} from "@/lib/decision-perspective/alignment-criteria";
+
+type SpecialistCorpus = Extract<AlignmentCorpus, "portfolio" | "gtm">;
+type QualificationStatus = "qualified" | "absent" | "stale" | "out-of-scope";
+
+type ProfessionEvaluation = {
+  allowed: boolean;
+  interactionId: string;
+  professionProfileSelected: boolean;
+  professionKey: string | null;
+  operatorMessage: string;
+  evaluation: {
+    outcomeType: string;
+    recommendedOptionId?: string | null;
+    coverageGap: boolean;
+    materialCount: number;
+    freshnessDistribution: {
+      current: number;
+      stale: number;
+      superseded: number;
+      contradicted: number;
+    };
+    sources: Array<{ materialId?: string; sourceRef?: unknown }>;
+  };
+};
+
+type ProfessionEvaluator = (input: {
+  agentIdentity: { agentId: string };
+  question: string;
+  options: string[];
+  domainClass: "professional-practice";
+  riskTier: "medium";
+  routeContext: string;
+  triggeredByUserId: string;
+}) => Promise<ProfessionEvaluation>;
+
+export type AlignmentDelegationRoute = {
+  corpus: SpecialistCorpus;
+  agentId: string;
+  professionKey: string;
+  criterion: "product" | "motion";
+  permissionGranted: false;
+};
+
+const ROUTES: Record<SpecialistCorpus, AlignmentDelegationRoute> = {
+  portfolio: {
+    corpus: "portfolio", agentId: "portfolio-backlog-agent",
+    professionKey: "portfolio-management", criterion: "product",
+    permissionGranted: false,
+  },
+  gtm: {
+    corpus: "gtm", agentId: "marketing-specialist",
+    professionKey: "marketing", criterion: "motion",
+    permissionGranted: false,
+  },
+};
+
+export function decideAlignmentDelegation(criteria: {
+  product: string | null;
+  motion: string | null;
+}): AlignmentDelegationRoute[] {
+  return [
+    ...(criteria.product ? [ROUTES.portfolio] : []),
+    ...(criteria.motion ? [ROUTES.gtm] : []),
+  ];
+}
+
+function qualificationFor(result: ProfessionEvaluation, expectedProfession: string): QualificationStatus {
+  if (!result.professionProfileSelected || result.evaluation.coverageGap || result.evaluation.materialCount < 1) {
+    return "absent";
+  }
+  if (result.professionKey !== expectedProfession) return "out-of-scope";
+  const freshness = result.evaluation.freshnessDistribution;
+  if (freshness.stale > 0 || freshness.superseded > 0 || freshness.contradicted > 0) return "stale";
+  if (!result.allowed && result.evaluation.recommendedOptionId !== "rejected") return "absent";
+  return "qualified";
+}
+
+async function defaultEvaluateProfession(
+  input: Parameters<ProfessionEvaluator>[0],
+): Promise<ProfessionEvaluation> {
+  const { evaluateProfessionDecisionGate } = await import("@/lib/decision-perspective/profession-gate");
+  return evaluateProfessionDecisionGate({
+    db: prisma,
+    ...input,
+    options: input.options,
+  }) as Promise<ProfessionEvaluation>;
+}
+
+async function defaultRecordDelegation(input: {
+  fromAgentId: string;
+  toAgentId: string;
+  originUserId: string;
+  reason: string;
+}): Promise<string> {
+  const chainId = randomUUID();
+  await prisma.delegationChain.create({
+    data: {
+      chainId, depth: 0, fromAgentId: input.fromAgentId, toAgentId: input.toAgentId,
+      status: "completed", reason: input.reason, authorityScope: [],
+      originUserId: input.originUserId, originAuthority: [], completedAt: new Date(),
+    },
+  });
+  return chainId;
+}
+
+export type SpecialistAlignmentCheck = {
+  corpus: SpecialistCorpus;
+  criterion: "product" | "motion";
+  specialistAgentId: string;
+  professionKey: string;
+  qualification: QualificationStatus;
+  verdict: "aligned" | "rejected" | "escalate";
+  rationale: string;
+  evidenceRefs: string[];
+  interactionId: string;
+  delegationChainId: string;
+  permissionGranted: false;
+};
+
+export type SpecialistAlignmentDelegationResult = {
+  verdict: "approve" | "decline" | "escalate";
+  checks: SpecialistAlignmentCheck[];
+  permissionGranted: false;
+};
+
+export async function runAlignmentSpecialistDelegation(input: {
+  alignment: ConstitutionalAlignmentResult;
+  statement: string;
+  userId: string;
+  coordinatorAgentId: string;
+  routeContext?: string;
+  evaluateProfession?: ProfessionEvaluator;
+  recordDelegation?: typeof defaultRecordDelegation;
+}): Promise<SpecialistAlignmentDelegationResult> {
+  const routes = decideAlignmentDelegation(input.alignment.criteria.criteria);
+  if (routes.length === 0) return { verdict: "escalate", checks: [], permissionGranted: false };
+  const evaluateProfession = input.evaluateProfession ?? defaultEvaluateProfession;
+  const recordDelegation = input.recordDelegation ?? defaultRecordDelegation;
+  const checks: SpecialistAlignmentCheck[] = [];
+
+  for (const route of routes) {
+    const delegationChainId = await recordDelegation({
+      fromAgentId: input.coordinatorAgentId,
+      toAgentId: route.agentId,
+      originUserId: input.userId,
+      reason: `TAK alignment ${route.corpus}/${route.criterion} WSID check`,
+    });
+    const result = await evaluateProfession({
+      agentIdentity: { agentId: route.agentId },
+      question: `Does the proposed action fit the ${route.corpus} corpus? ${input.statement}`,
+      options: ["Aligned", "Rejected"],
+      domainClass: "professional-practice",
+      riskTier: "medium",
+      routeContext: input.routeContext ?? "/tak/alignment-specialist",
+      triggeredByUserId: input.userId,
+    });
+    const qualification = qualificationFor(result, route.professionKey);
+    const rejected = result.evaluation.recommendedOptionId?.toLowerCase() === "rejected";
+    checks.push({
+      corpus: route.corpus,
+      criterion: route.criterion,
+      specialistAgentId: route.agentId,
+      professionKey: route.professionKey,
+      qualification,
+      verdict: qualification !== "qualified" ? "escalate" : rejected ? "rejected" : "aligned",
+      rationale: qualification === "qualified"
+        ? result.operatorMessage
+        : `TAK-JSI ${qualification}: ${route.agentId} cannot supply this ${route.criterion} verdict.`,
+      evidenceRefs: result.evaluation.sources
+        .map((source) => source.materialId ?? JSON.stringify(source.sourceRef ?? null))
+        .filter((ref) => ref !== "null"),
+      interactionId: result.interactionId,
+      delegationChainId,
+      permissionGranted: false,
+    });
+  }
+
+  return {
+    verdict: checks.some((check) => check.verdict === "rejected")
+      ? "decline"
+      : checks.some((check) => check.verdict === "escalate") ? "escalate" : "approve",
+    checks,
+    permissionGranted: false,
+  };
+}

--- a/apps/web/lib/tak/alignment-tool-gate.ts
+++ b/apps/web/lib/tak/alignment-tool-gate.ts
@@ -2,12 +2,14 @@ import { prisma } from "@dpf/db";
 
 import type { ConstitutionalAlignmentResult } from "@/lib/decision-perspective/alignment-criteria";
 import type { GovernedExecuteArgs } from "@/lib/mcp-governed-execute";
+import type { SpecialistAlignmentDelegationResult } from "./alignment-specialist-delegation";
 
 export type AlignmentGateDecision = {
   verdict: "approve" | "decline" | "escalate";
   interactionId: string;
   rationale: string;
   alignment: ConstitutionalAlignmentResult;
+  specialistDelegation?: SpecialistAlignmentDelegationResult;
 };
 export type AlignmentGate = (input: {
   organizationId?: string;
@@ -29,6 +31,15 @@ function alignmentStatement(toolName: string, params: Record<string, unknown>): 
   const values = fields.map((field) => params[field])
     .filter((value): value is string => typeof value === "string" && value.trim().length > 0);
   return `${toolName.replaceAll("_", " ")}: ${values.join(". ")}`;
+}
+
+export function composeAlignmentVerdicts(
+  alignment: ConstitutionalAlignmentResult["verdict"],
+  specialist: SpecialistAlignmentDelegationResult["verdict"],
+): AlignmentGateDecision["verdict"] {
+  if (alignment === "decline" || specialist === "decline") return "decline";
+  if (alignment === "escalate" || specialist === "escalate") return "escalate";
+  return "approve";
 }
 
 export async function runTakAlignmentGate(args: GovernedExecuteArgs): Promise<AlignmentGateDecision> {
@@ -73,12 +84,26 @@ export async function runTakAlignmentGate(args: GovernedExecuteArgs): Promise<Al
     },
   });
   const alignment = result.evaluation.constitutionalAlignment;
-  if (alignment) return {
-    verdict: alignment.verdict,
-    interactionId: result.interactionId,
-    rationale: result.evaluation.rationale,
-    alignment,
-  };
+  if (alignment) {
+    const { runAlignmentSpecialistDelegation } = await import("./alignment-specialist-delegation");
+    const specialistDelegation = await runAlignmentSpecialistDelegation({
+      alignment,
+      statement,
+      userId: args.userId,
+      coordinatorAgentId: args.context?.agentId ?? "tak-alignment-coordinator",
+      routeContext: args.context?.routeContext ?? `/tool/${args.toolName}`,
+    });
+    const verdict = composeAlignmentVerdicts(alignment.verdict, specialistDelegation.verdict);
+    return {
+      verdict,
+      interactionId: result.interactionId,
+      rationale: verdict === alignment.verdict
+        ? result.evaluation.rationale
+        : `${result.evaluation.rationale} TAK-JSI specialist result: ${specialistDelegation.verdict}.`,
+      alignment,
+      specialistDelegation,
+    };
+  }
   const { extractAlignmentCriteria } = await import("@/lib/decision-perspective/alignment-criteria");
   return {
     verdict: "escalate",

--- a/apps/web/lib/tak/alignment-tool-gate.ts
+++ b/apps/web/lib/tak/alignment-tool-gate.ts
@@ -10,6 +10,8 @@ export type AlignmentGateDecision = {
   rationale: string;
   alignment: ConstitutionalAlignmentResult;
   specialistDelegation?: SpecialistAlignmentDelegationResult;
+  policyVersion?: string;
+  amendmentLineage?: string[];
 };
 export type AlignmentGate = (input: {
   organizationId?: string;
@@ -102,6 +104,8 @@ export async function runTakAlignmentGate(args: GovernedExecuteArgs): Promise<Al
         : `${result.evaluation.rationale} TAK-JSI specialist result: ${specialistDelegation.verdict}.`,
       alignment,
       specialistDelegation,
+      policyVersion: result.alignmentPolicyVersion,
+      amendmentLineage: result.amendmentLineage,
     };
   }
   const { extractAlignmentCriteria } = await import("@/lib/decision-perspective/alignment-criteria");

--- a/apps/web/lib/tak/alignment-tool-gate.ts
+++ b/apps/web/lib/tak/alignment-tool-gate.ts
@@ -1,0 +1,91 @@
+import { prisma } from "@dpf/db";
+
+import type { ConstitutionalAlignmentResult } from "@/lib/decision-perspective/alignment-criteria";
+import type { GovernedExecuteArgs } from "@/lib/mcp-governed-execute";
+
+export type AlignmentGateDecision = {
+  verdict: "approve" | "decline" | "escalate";
+  interactionId: string;
+  rationale: string;
+  alignment: ConstitutionalAlignmentResult;
+};
+export type AlignmentGate = (input: {
+  organizationId?: string;
+  statement: string;
+  toolName: string;
+  args: GovernedExecuteArgs;
+}) => Promise<AlignmentGateDecision>;
+
+let overrideForTests: AlignmentGate | null = null;
+export function setAlignmentGateOverrideForTests(override: AlignmentGate | null): void {
+  overrideForTests = override;
+}
+
+function alignmentStatement(toolName: string, params: Record<string, unknown>): string {
+  const fields = [
+    "name", "title", "description", "summary", "question", "product", "offer",
+    "market", "segment", "motion", "geography", "customerType",
+  ];
+  const values = fields.map((field) => params[field])
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+  return `${toolName.replaceAll("_", " ")}: ${values.join(". ")}`;
+}
+
+export async function runTakAlignmentGate(args: GovernedExecuteArgs): Promise<AlignmentGateDecision> {
+  const statement = alignmentStatement(args.toolName, args.rawParams);
+  if (overrideForTests) return overrideForTests({
+    organizationId: args.context?.organizationId, statement, toolName: args.toolName, args,
+  });
+  const organizationId = args.context?.organizationId
+    ?? (await prisma.organization.findFirst({ select: { id: true } }))?.id;
+  if (!organizationId) {
+    const { extractAlignmentCriteria } = await import("@/lib/decision-perspective/alignment-criteria");
+    return {
+      verdict: "escalate",
+      interactionId: "unrecorded:no-organization",
+      rationale: "No organization identity was available for the WWWD alignment gate.",
+      alignment: {
+        verdict: "escalate", criteria: extractAlignmentCriteria(statement), checks: [], veto: null,
+      },
+    };
+  }
+  const { evaluateOrgBusinessDecisionGate } = await import("@/lib/decision-perspective/org-business-gate");
+  const result = await evaluateOrgBusinessDecisionGate({
+    db: prisma,
+    organizationId,
+    question: statement,
+    options: ["Proceed", "Decline"],
+    scoredOptions: [
+      { id: "proceed", description: "Proceed", features: { mission_fit: 1, market_fit: 1, product_fit: 1, gtm_fit: 1 } },
+      { id: "decline", description: "Decline", features: { reversibility: 1, blast_radius: 0 } },
+    ],
+    domainClass: "plan-readiness",
+    riskTier: "medium",
+    routeContext: args.context?.routeContext ?? `/tool/${args.toolName}`,
+    triggeredByUserId: args.userId,
+    taskRunId: args.context?.taskRunId,
+    caller: {
+      client: args.context?.callerClient ?? args.source,
+      apiTokenId: args.context?.apiTokenId ?? null,
+      authSource: args.context?.authSource ?? null,
+      agentId: args.context?.agentId ?? null,
+      threadId: args.context?.threadId ?? null,
+    },
+  });
+  const alignment = result.evaluation.constitutionalAlignment;
+  if (alignment) return {
+    verdict: alignment.verdict,
+    interactionId: result.interactionId,
+    rationale: result.evaluation.rationale,
+    alignment,
+  };
+  const { extractAlignmentCriteria } = await import("@/lib/decision-perspective/alignment-criteria");
+  return {
+    verdict: "escalate",
+    interactionId: result.interactionId,
+    rationale: "The WWWD gate produced no constitutional alignment receipt.",
+    alignment: {
+      verdict: "escalate", criteria: extractAlignmentCriteria(statement), checks: [], veto: null,
+    },
+  };
+}

--- a/apps/web/lib/tak/consequential-tool-policy.test.ts
+++ b/apps/web/lib/tak/consequential-tool-policy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyConsequentialTool } from "./consequential-tool-policy";
+
+describe("consequential tool policy", () => {
+  it("classifies a read without invoking model judgement", () => {
+    expect(classifyConsequentialTool({ toolName: "query_backlog", tool: { sideEffect: false } })).toEqual({
+      class: "routine-read",
+      consequential: false,
+      alignmentRequired: false,
+      reason: "read-only",
+    });
+  });
+
+  it("classifies an explicit business-direction mutation as consequential", () => {
+    expect(classifyConsequentialTool({
+      toolName: "create_digital_product",
+      tool: { sideEffect: true },
+    }).consequential).toBe(true);
+  });
+
+  it("does not charge ordinary bookkeeping mutations for an alignment check", () => {
+    expect(classifyConsequentialTool({
+      toolName: "update_backlog_item_status",
+      tool: { sideEffect: true },
+    }).class).toBe("ordinary-mutation");
+  });
+});

--- a/apps/web/lib/tak/consequential-tool-policy.test.ts
+++ b/apps/web/lib/tak/consequential-tool-policy.test.ts
@@ -8,6 +8,7 @@ describe("consequential tool policy", () => {
       class: "routine-read",
       consequential: false,
       alignmentRequired: false,
+      preconditionRequired: false,
       collaborationShape: null,
       reason: "read-only",
     });

--- a/apps/web/lib/tak/consequential-tool-policy.test.ts
+++ b/apps/web/lib/tak/consequential-tool-policy.test.ts
@@ -8,6 +8,7 @@ describe("consequential tool policy", () => {
       class: "routine-read",
       consequential: false,
       alignmentRequired: false,
+      collaborationShape: null,
       reason: "read-only",
     });
   });
@@ -17,6 +18,17 @@ describe("consequential tool policy", () => {
       toolName: "create_digital_product",
       tool: { sideEffect: true },
     }).consequential).toBe(true);
+    expect(classifyConsequentialTool({
+      toolName: "create_digital_product", tool: { sideEffect: true },
+    }).collaborationShape).toBe("specialist-alignment");
+  });
+
+  it.each([
+    ["send_quote", "outward-review"],
+    ["execute_change", "change-consequential"],
+  ])("binds %s to the %s Work Room shape", (toolName, collaborationShape) => {
+    expect(classifyConsequentialTool({ toolName, tool: { sideEffect: true } }).collaborationShape)
+      .toBe(collaborationShape);
   });
 
   it("does not charge ordinary bookkeeping mutations for an alignment check", () => {

--- a/apps/web/lib/tak/consequential-tool-policy.ts
+++ b/apps/web/lib/tak/consequential-tool-policy.ts
@@ -1,0 +1,54 @@
+import type { ToolDefinition } from "@/lib/mcp-tools";
+import { getWorkCaseAction } from "@/lib/work-management/action-registry";
+import type { WorkCaseExecutionContext } from "@/lib/work-management/work-case-governance-hook";
+
+export const CONSEQUENCE_CLASSES = ["routine-read", "ordinary-mutation", "consequential-mutation"] as const;
+export type ConsequenceClass = (typeof CONSEQUENCE_CLASSES)[number];
+
+export type ConsequentialToolClassification = {
+  class: ConsequenceClass;
+  consequential: boolean;
+  alignmentRequired: boolean;
+  reason: "read-only" | "ordinary-side-effect" | "explicit-policy" | "work-case-consequential";
+};
+
+export const ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES = [
+  "create_digital_product",
+  "create_product",
+  "create_product_line",
+  "create_marketing_campaign",
+  "launch_campaign",
+  "publish_storefront",
+  "send_quote",
+  "send_invoice",
+  "execute_change",
+] as const;
+const EXPLICIT = new Set<string>(ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES);
+
+/**
+ * Closed, deterministic policy: reads and ordinary bookkeeping mutations skip
+ * alignment; named outward/business-direction mutations are consequential.
+ * Work Case metadata may elevate but never downgrade a call.
+ */
+export function classifyConsequentialTool(input: {
+  tool: Pick<ToolDefinition, "sideEffect">;
+  toolName: string;
+  workCase?: WorkCaseExecutionContext;
+}): ConsequentialToolClassification {
+  const action = input.workCase ? getWorkCaseAction(input.workCase.action) : undefined;
+  if (action?.consequential) {
+    return {
+      class: "consequential-mutation",
+      consequential: true,
+      alignmentRequired: EXPLICIT.has(input.toolName),
+      reason: "work-case-consequential",
+    };
+  }
+  if (input.tool.sideEffect && EXPLICIT.has(input.toolName)) {
+    return { class: "consequential-mutation", consequential: true, alignmentRequired: true, reason: "explicit-policy" };
+  }
+  if (input.tool.sideEffect) {
+    return { class: "ordinary-mutation", consequential: false, alignmentRequired: false, reason: "ordinary-side-effect" };
+  }
+  return { class: "routine-read", consequential: false, alignmentRequired: false, reason: "read-only" };
+}

--- a/apps/web/lib/tak/consequential-tool-policy.ts
+++ b/apps/web/lib/tak/consequential-tool-policy.ts
@@ -1,6 +1,7 @@
 import type { ToolDefinition } from "@/lib/mcp-tools";
 import { getWorkCaseAction } from "@/lib/work-management/action-registry";
 import type { WorkCaseExecutionContext } from "@/lib/work-management/work-case-governance-hook";
+import type { WorkRoomShapeKey } from "@/lib/work-management/room-shapes";
 
 export const CONSEQUENCE_CLASSES = ["routine-read", "ordinary-mutation", "consequential-mutation"] as const;
 export type ConsequenceClass = (typeof CONSEQUENCE_CLASSES)[number];
@@ -9,6 +10,7 @@ export type ConsequentialToolClassification = {
   class: ConsequenceClass;
   consequential: boolean;
   alignmentRequired: boolean;
+  collaborationShape: WorkRoomShapeKey | null;
   reason: "read-only" | "ordinary-side-effect" | "explicit-policy" | "work-case-consequential";
 };
 
@@ -24,6 +26,14 @@ export const ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES = [
   "execute_change",
 ] as const;
 const EXPLICIT = new Set<string>(ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES);
+
+export function collaborationShapeForTool(toolName: string): WorkRoomShapeKey | null {
+  if (["create_digital_product", "create_product", "create_product_line", "create_marketing_campaign", "launch_campaign"]
+    .includes(toolName)) return "specialist-alignment";
+  if (["publish_storefront", "send_quote", "send_invoice"].includes(toolName)) return "outward-review";
+  if (toolName === "execute_change") return "change-consequential";
+  return null;
+}
 
 /**
  * Closed, deterministic policy: reads and ordinary bookkeeping mutations skip
@@ -41,14 +51,24 @@ export function classifyConsequentialTool(input: {
       class: "consequential-mutation",
       consequential: true,
       alignmentRequired: EXPLICIT.has(input.toolName),
+      collaborationShape: collaborationShapeForTool(input.toolName) ?? "change-consequential",
       reason: "work-case-consequential",
     };
   }
   if (input.tool.sideEffect && EXPLICIT.has(input.toolName)) {
-    return { class: "consequential-mutation", consequential: true, alignmentRequired: true, reason: "explicit-policy" };
+    return {
+      class: "consequential-mutation", consequential: true, alignmentRequired: true,
+      collaborationShape: collaborationShapeForTool(input.toolName), reason: "explicit-policy",
+    };
   }
   if (input.tool.sideEffect) {
-    return { class: "ordinary-mutation", consequential: false, alignmentRequired: false, reason: "ordinary-side-effect" };
+    return {
+      class: "ordinary-mutation", consequential: false, alignmentRequired: false,
+      collaborationShape: null, reason: "ordinary-side-effect",
+    };
   }
-  return { class: "routine-read", consequential: false, alignmentRequired: false, reason: "read-only" };
+  return {
+    class: "routine-read", consequential: false, alignmentRequired: false,
+    collaborationShape: null, reason: "read-only",
+  };
 }

--- a/apps/web/lib/tak/consequential-tool-policy.ts
+++ b/apps/web/lib/tak/consequential-tool-policy.ts
@@ -10,6 +10,7 @@ export type ConsequentialToolClassification = {
   class: ConsequenceClass;
   consequential: boolean;
   alignmentRequired: boolean;
+  preconditionRequired: boolean;
   collaborationShape: WorkRoomShapeKey | null;
   reason: "read-only" | "ordinary-side-effect" | "explicit-policy" | "work-case-consequential";
 };
@@ -26,12 +27,14 @@ export const ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES = [
   "execute_change",
 ] as const;
 const EXPLICIT = new Set<string>(ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES);
+const PRECONDITION = new Set(["transition_employee_status"]);
 
 export function collaborationShapeForTool(toolName: string): WorkRoomShapeKey | null {
   if (["create_digital_product", "create_product", "create_product_line", "create_marketing_campaign", "launch_campaign"]
     .includes(toolName)) return "specialist-alignment";
   if (["publish_storefront", "send_quote", "send_invoice"].includes(toolName)) return "outward-review";
   if (toolName === "execute_change") return "change-consequential";
+  if (toolName === "transition_employee_status") return "change-consequential";
   return null;
 }
 
@@ -51,24 +54,26 @@ export function classifyConsequentialTool(input: {
       class: "consequential-mutation",
       consequential: true,
       alignmentRequired: EXPLICIT.has(input.toolName),
+      preconditionRequired: PRECONDITION.has(input.toolName),
       collaborationShape: collaborationShapeForTool(input.toolName) ?? "change-consequential",
       reason: "work-case-consequential",
     };
   }
-  if (input.tool.sideEffect && EXPLICIT.has(input.toolName)) {
+  if (input.tool.sideEffect && (EXPLICIT.has(input.toolName) || PRECONDITION.has(input.toolName))) {
     return {
-      class: "consequential-mutation", consequential: true, alignmentRequired: true,
+      class: "consequential-mutation", consequential: true, alignmentRequired: EXPLICIT.has(input.toolName),
+      preconditionRequired: PRECONDITION.has(input.toolName),
       collaborationShape: collaborationShapeForTool(input.toolName), reason: "explicit-policy",
     };
   }
   if (input.tool.sideEffect) {
     return {
       class: "ordinary-mutation", consequential: false, alignmentRequired: false,
-      collaborationShape: null, reason: "ordinary-side-effect",
+      preconditionRequired: false, collaborationShape: null, reason: "ordinary-side-effect",
     };
   }
   return {
     class: "routine-read", consequential: false, alignmentRequired: false,
-    collaborationShape: null, reason: "read-only",
+    preconditionRequired: false, collaborationShape: null, reason: "read-only",
   };
 }

--- a/apps/web/lib/tak/delegation-policy.test.ts
+++ b/apps/web/lib/tak/delegation-policy.test.ts
@@ -77,3 +77,13 @@ describe("renderDelegationGuidance", () => {
     expect(renderDelegationGuidance({ mode: "fan_out", reason: "r" })!).toContain("spawn_work_thread");
   });
 });
+
+describe("alignment delegation policy", () => {
+  it("treats specialist qualification as evidence rather than action permission", async () => {
+    const { decideAlignmentDelegation } = await import("./alignment-specialist-delegation");
+    expect(decideAlignmentDelegation({ product: "support", motion: "partner" })).toEqual([
+      expect.objectContaining({ corpus: "portfolio", permissionGranted: false }),
+      expect.objectContaining({ corpus: "gtm", permissionGranted: false }),
+    ]);
+  });
+});

--- a/apps/web/lib/tak/gaid-actor-envelope.ts
+++ b/apps/web/lib/tak/gaid-actor-envelope.ts
@@ -1,0 +1,45 @@
+import { prisma } from "@dpf/db";
+
+import type { GovernedExecuteArgs } from "@/lib/mcp-governed-execute";
+
+export type GaidActorEnvelope = {
+  principalId: string;
+  gaid: string;
+  actorKind: "owner" | "employee" | "coworker" | "human";
+  actorRef: string;
+};
+
+export type GaidActorResolver = (args: GovernedExecuteArgs) => Promise<GaidActorEnvelope | null>;
+
+let resolverOverride: GaidActorResolver | null = null;
+export function setGaidActorResolverOverrideForTests(override: GaidActorResolver | null): void {
+  resolverOverride = override;
+}
+
+export async function resolveGaidActorEnvelope(args: GovernedExecuteArgs): Promise<GaidActorEnvelope | null> {
+  if (resolverOverride) return resolverOverride(args);
+  const actorAlias = args.context?.agentId
+    ? { aliasType: "agent", aliasValue: args.context.agentId, issuer: "" }
+    : { aliasType: "user", aliasValue: args.userId, issuer: "" };
+  const alias = await prisma.principalAlias.findFirst({
+    where: actorAlias,
+    select: {
+      principal: {
+        select: {
+          principalId: true,
+          aliases: { where: { aliasType: { in: ["gaid", "employee"] } }, select: { aliasType: true, aliasValue: true } },
+        },
+      },
+    },
+  });
+  const gaid = alias?.principal.aliases.find((entry) => entry.aliasType === "gaid")?.aliasValue;
+  if (!alias?.principal.principalId || !gaid) return null;
+  const employee = alias.principal.aliases.find((entry) => entry.aliasType === "employee")?.aliasValue;
+  const owner = !args.context?.agentId && args.userContext.platformRole?.toLowerCase() === "ceo";
+  return {
+    principalId: alias.principal.principalId,
+    gaid,
+    actorKind: args.context?.agentId ? "coworker" : owner ? "owner" : employee ? "employee" : "human",
+    actorRef: args.context?.agentId ?? employee ?? args.userId,
+  };
+}

--- a/apps/web/lib/tak/precondition-ordering-gate.test.ts
+++ b/apps/web/lib/tak/precondition-ordering-gate.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluatePreconditionOrdering } from "./precondition-ordering-gate";
+
+describe("TAK precondition and ordering gate", () => {
+  it("rejects asset allocation until employee identity exists in both views", () => {
+    const result = evaluatePreconditionOrdering({
+      action: "allocate-employee-asset",
+      prerequisites: [{
+        key: "employee-identity",
+        business: { required: true, satisfied: false, evidenceRef: "ea:value-stream:onboarding:identity" },
+        systems: { required: true, satisfied: false, evidenceRef: "prisma:relation:Asset:employee:EmployeeProfile" },
+      }],
+    });
+    expect(result.verdict).toBe("decline");
+    expect(result.checks[0]).toMatchObject({
+      key: "employee-identity", coherent: true, satisfied: false,
+      evidenceRefs: ["ea:value-stream:onboarding:identity", "prisma:relation:Asset:employee:EmployeeProfile"],
+    });
+  });
+
+  it("approves only after the employee identity prerequisite is satisfied", () => {
+    expect(evaluatePreconditionOrdering({
+      action: "allocate-employee-asset",
+      prerequisites: [{
+        key: "employee-identity",
+        business: { required: true, satisfied: true, evidenceRef: "ea:value-stream:onboarding:identity" },
+        systems: { required: true, satisfied: true, evidenceRef: "prisma:relation:Asset:employee:EmployeeProfile" },
+      }],
+    }).verdict).toBe("approve");
+  });
+
+  it("escalates rather than inventing order when business and systems architecture drift", () => {
+    expect(evaluatePreconditionOrdering({
+      action: "allocate-employee-asset",
+      prerequisites: [{
+        key: "employee-identity",
+        business: { required: true, satisfied: true, evidenceRef: "ea:value-stream:onboarding:identity" },
+        systems: { required: false, satisfied: true, evidenceRef: "prisma:model:FixedAsset#assignedToId" },
+      }],
+    })).toMatchObject({ verdict: "escalate", checks: [expect.objectContaining({ coherent: false })] });
+  });
+});

--- a/apps/web/lib/tak/precondition-ordering-gate.ts
+++ b/apps/web/lib/tak/precondition-ordering-gate.ts
@@ -1,0 +1,91 @@
+import { prisma } from "@dpf/db";
+
+import type { GovernedExecuteArgs } from "@/lib/mcp-governed-execute";
+
+export type ArchitecturePrecondition = {
+  key: string;
+  business: { required: boolean; satisfied: boolean; evidenceRef: string };
+  systems: { required: boolean; satisfied: boolean; evidenceRef: string };
+};
+
+export type PreconditionOrderingCheck = {
+  key: string;
+  coherent: boolean;
+  satisfied: boolean;
+  evidenceRefs: [string, string];
+};
+
+export type PreconditionOrderingDecision = {
+  verdict: "approve" | "decline" | "escalate";
+  rationale: string;
+  checks: PreconditionOrderingCheck[];
+};
+
+export function evaluatePreconditionOrdering(input: {
+  action: string;
+  prerequisites: ArchitecturePrecondition[];
+}): PreconditionOrderingDecision {
+  const checks = input.prerequisites.map((prerequisite): PreconditionOrderingCheck => {
+    const coherent = prerequisite.business.required === prerequisite.systems.required
+      && Boolean(prerequisite.business.evidenceRef) && Boolean(prerequisite.systems.evidenceRef);
+    return {
+      key: prerequisite.key,
+      coherent,
+      satisfied: coherent && (!prerequisite.business.required
+        || (prerequisite.business.satisfied && prerequisite.systems.satisfied)),
+      evidenceRefs: [prerequisite.business.evidenceRef, prerequisite.systems.evidenceRef],
+    };
+  });
+  if (checks.some((check) => !check.coherent)) {
+    return {
+      verdict: "escalate",
+      rationale: `${input.action} has incoherent business and systems precondition evidence.`,
+      checks,
+    };
+  }
+  const unmet = checks.find((check) => !check.satisfied);
+  if (unmet) {
+    return {
+      verdict: "decline",
+      rationale: `${input.action} is blocked until prerequisite '${unmet.key}' is satisfied.`,
+      checks,
+    };
+  }
+  return { verdict: "approve", rationale: `${input.action} prerequisites are satisfied.`, checks };
+}
+
+export type PreconditionGate = (args: GovernedExecuteArgs) => Promise<PreconditionOrderingDecision>;
+let overrideForTests: PreconditionGate | null = null;
+export function setPreconditionGateOverrideForTests(override: PreconditionGate | null): void {
+  overrideForTests = override;
+}
+
+export async function runTakPreconditionGate(args: GovernedExecuteArgs): Promise<PreconditionOrderingDecision> {
+  if (overrideForTests) return overrideForTests(args);
+  if (args.toolName !== "transition_employee_status") {
+    return { verdict: "approve", rationale: "No executable preconditions are registered for this tool.", checks: [] };
+  }
+  const employeeRef = typeof args.rawParams.employeeId === "string" ? args.rawParams.employeeId.trim() : "";
+  const employee = employeeRef
+    ? await prisma.employeeProfile.findFirst({
+        where: { OR: [{ id: employeeRef }, { employeeId: employeeRef }] },
+        select: { id: true },
+      })
+    : null;
+  return evaluatePreconditionOrdering({
+    action: args.toolName,
+    prerequisites: [{
+      key: "employee-identity",
+      business: {
+        required: true,
+        satisfied: Boolean(employee),
+        evidenceRef: "workforce:employee-lifecycle:identity-before-transition",
+      },
+      systems: {
+        required: true,
+        satisfied: Boolean(employee),
+        evidenceRef: "prisma:model:EmployeeProfile#employeeId",
+      },
+    }],
+  });
+}

--- a/apps/web/lib/tak/preexecution-control.ts
+++ b/apps/web/lib/tak/preexecution-control.ts
@@ -17,6 +17,23 @@ type PreexecutionAudit = (input: {
   preconditionDecision: PreconditionOrderingDecision | null;
 }) => Promise<AuditResult>;
 
+const BYPASS_KEYS = new Set([
+  "alignmentbypass", "bypassalignment", "skipalignment", "overridealignment",
+  "alignmentoverride", "ignorealignment", "ignoregovernance", "bypassgovernance",
+]);
+
+export function findAlignmentBypassArgument(value: unknown, path = "args"): string | null {
+  if (!value || typeof value !== "object") return null;
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    const normalized = key.replaceAll(/[^a-z0-9]/gi, "").toLowerCase();
+    const nextPath = `${path}.${key}`;
+    if (BYPASS_KEYS.has(normalized)) return nextPath;
+    const nested = findAlignmentBypassArgument(entry, nextPath);
+    if (nested) return nested;
+  }
+  return null;
+}
+
 function rejected(
   toolName: string,
   rejection: GovernedExecuteRejection,
@@ -48,6 +65,7 @@ async function receiptDenied(input: {
     consequential: true,
     alignmentDecision: input.alignmentDecision,
     preconditionDecision: input.preconditionDecision,
+    governedArgs: input.args,
   });
 }
 
@@ -63,6 +81,21 @@ export async function enforceTakPreexecution(input: {
 }> {
   let alignmentDecision: AlignmentGateDecision | null = null;
   let preconditionDecision: PreconditionOrderingDecision | null = null;
+
+  if (input.alignmentRequired) {
+    const bypassPath = findAlignmentBypassArgument(input.args.rawParams);
+    if (bypassPath) {
+      const rejection: GovernedExecuteRejection = "alignment_bypass_forbidden";
+      const result = rejected(
+        input.args.toolName,
+        rejection,
+        `${bypassPath} is not a permission. Amend the versioned WWWD stance and submit a fresh action.`,
+      );
+      const auditRow = await input.writeAudit({ result, alignmentDecision, preconditionDecision });
+      await receiptDenied({ args: input.args, result, auditRow, alignmentDecision, preconditionDecision });
+      return { result, alignmentDecision, preconditionDecision };
+    }
+  }
 
   if (input.preconditionRequired) {
     preconditionDecision = await runTakPreconditionGate(input.args);

--- a/apps/web/lib/tak/preexecution-control.ts
+++ b/apps/web/lib/tak/preexecution-control.ts
@@ -1,0 +1,104 @@
+import type {
+  GovernedExecuteArgs,
+  GovernedExecuteRejection,
+  GovernedExecuteResult,
+} from "@/lib/mcp-governed-execute";
+import { runTakAlignmentGate, type AlignmentGateDecision } from "./alignment-tool-gate";
+import {
+  runTakPreconditionGate,
+  type PreconditionOrderingDecision,
+} from "./precondition-ordering-gate";
+import { writeToolExecutionReceipt } from "./tool-execution-receipt";
+
+type AuditResult = { id: string } | null;
+type PreexecutionAudit = (input: {
+  result: GovernedExecuteResult;
+  alignmentDecision: AlignmentGateDecision | null;
+  preconditionDecision: PreconditionOrderingDecision | null;
+}) => Promise<AuditResult>;
+
+function rejected(
+  toolName: string,
+  rejection: GovernedExecuteRejection,
+  detail: string,
+): GovernedExecuteResult {
+  return {
+    success: false,
+    error: rejection,
+    message: `${toolName} rejected: ${detail}`,
+    governance: { rejected: rejection },
+  };
+}
+
+async function receiptDenied(input: {
+  args: GovernedExecuteArgs;
+  result: GovernedExecuteResult;
+  auditRow: AuditResult;
+  alignmentDecision: AlignmentGateDecision | null;
+  preconditionDecision: PreconditionOrderingDecision | null;
+}): Promise<void> {
+  if (!input.auditRow?.id) return;
+  await writeToolExecutionReceipt({
+    auditRowId: input.auditRow.id,
+    buildId: null,
+    rawParams: input.args.rawParams,
+    result: input.result,
+    toolName: input.args.toolName,
+    context: input.args.context,
+    consequential: true,
+    alignmentDecision: input.alignmentDecision,
+    preconditionDecision: input.preconditionDecision,
+  });
+}
+
+export async function enforceTakPreexecution(input: {
+  args: GovernedExecuteArgs;
+  alignmentRequired: boolean;
+  preconditionRequired: boolean;
+  writeAudit: PreexecutionAudit;
+}): Promise<{
+  result: GovernedExecuteResult | null;
+  alignmentDecision: AlignmentGateDecision | null;
+  preconditionDecision: PreconditionOrderingDecision | null;
+}> {
+  let alignmentDecision: AlignmentGateDecision | null = null;
+  let preconditionDecision: PreconditionOrderingDecision | null = null;
+
+  if (input.preconditionRequired) {
+    preconditionDecision = await runTakPreconditionGate(input.args);
+    if (preconditionDecision.verdict !== "approve") {
+      const rejection: GovernedExecuteRejection = preconditionDecision.verdict === "decline"
+        ? "precondition_denied" : "precondition_escalation_required";
+      const result: GovernedExecuteResult = {
+        ...rejected(input.args.toolName, rejection, preconditionDecision.rationale),
+        data: { precondition: preconditionDecision },
+        governance: { rejected: rejection, precondition: preconditionDecision },
+      };
+      const auditRow = await input.writeAudit({ result, alignmentDecision, preconditionDecision });
+      await receiptDenied({ args: input.args, result, auditRow, alignmentDecision, preconditionDecision });
+      return { result, alignmentDecision, preconditionDecision };
+    }
+  }
+
+  if (input.alignmentRequired) {
+    alignmentDecision = await runTakAlignmentGate(input.args);
+    if (alignmentDecision.verdict !== "approve") {
+      const rejection: GovernedExecuteRejection = alignmentDecision.verdict === "decline"
+        ? "alignment_denied" : "alignment_escalation_required";
+      const result: GovernedExecuteResult = {
+        ...rejected(input.args.toolName, rejection, alignmentDecision.rationale),
+        data: { interactionId: alignmentDecision.interactionId, alignment: alignmentDecision.alignment },
+        governance: {
+          rejected: rejection,
+          alignment: alignmentDecision.alignment,
+          alignmentInteractionId: alignmentDecision.interactionId,
+          ...(preconditionDecision ? { precondition: preconditionDecision } : {}),
+        },
+      };
+      const auditRow = await input.writeAudit({ result, alignmentDecision, preconditionDecision });
+      await receiptDenied({ args: input.args, result, auditRow, alignmentDecision, preconditionDecision });
+      return { result, alignmentDecision, preconditionDecision };
+    }
+  }
+  return { result: null, alignmentDecision, preconditionDecision };
+}

--- a/apps/web/lib/tak/tool-execution-receipt.ts
+++ b/apps/web/lib/tak/tool-execution-receipt.ts
@@ -1,0 +1,74 @@
+import { scryptSync } from "crypto";
+import { prisma } from "@dpf/db";
+
+import type { ToolResult } from "@/lib/mcp-tools";
+import type { AlignmentGateDecision } from "./alignment-tool-gate";
+import type { GovernedExecuteContext } from "@/lib/mcp-governed-execute";
+import { getWorkCaseAction } from "@/lib/work-management/action-registry";
+
+let createOverride: ((data: Record<string, unknown>) => Promise<unknown>) | null = null;
+export function setToolExecutionReceiptCreateOverrideForTests(
+  override: ((data: Record<string, unknown>) => Promise<unknown>) | null,
+): void {
+  createOverride = override;
+}
+
+function receiptKind(toolName: string, context?: GovernedExecuteContext, consequential = false): string | null {
+  if (context?.workCase && getWorkCaseAction(context.workCase.action)?.consequential) {
+    return "work-case-governed-action";
+  }
+  if (consequential) return "tak-consequential-action";
+  if (toolName === "run_sandbox_tests") return "sandbox-test-run";
+  if (toolName === "run_sandbox_command") return "sandbox-command";
+  if (toolName === "run_ux_test") return "ux-run";
+  return null;
+}
+
+function digestPayload(value: unknown): string {
+  return scryptSync(JSON.stringify(value ?? null), "dpf-receipt", 32, {
+    N: 16384, r: 8, p: 1, maxmem: 64 * 1024 * 1024,
+  }).toString("hex");
+}
+
+export async function writeToolExecutionReceipt(data: {
+  auditRowId: string;
+  buildId: string | null;
+  rawParams: Record<string, unknown>;
+  result: ToolResult;
+  toolName: string;
+  context?: GovernedExecuteContext;
+  consequential?: boolean;
+  alignmentDecision?: AlignmentGateDecision | null;
+}): Promise<void> {
+  const kind = receiptKind(data.toolName, data.context, data.consequential);
+  if (!kind) return;
+  const row = {
+    buildId: data.buildId ?? null,
+    executionStatus: data.result.success ? "succeeded" : "failed",
+    expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    inputFingerprint: digestPayload({ params: data.rawParams, toolName: data.toolName }),
+    outputDigest: { sha256: digestPayload({
+      data: data.result.data ?? null,
+      error: data.result.error ?? null,
+      message: data.result.message ?? null,
+      success: data.result.success,
+      alignment: data.alignmentDecision ? {
+        interactionId: data.alignmentDecision.interactionId,
+        verdict: data.alignmentDecision.verdict,
+      } : null,
+    }) },
+    receiptKind: kind,
+    receiptStatus: data.result.success ? "valid" : "invalid",
+    toolExecutionId: data.auditRowId,
+  };
+  try {
+    if (createOverride) await createOverride(row);
+    else await prisma.toolExecutionReceipt.create({ data: row });
+  } catch (err) {
+    console.error(
+      "[governed-execute] receipt write failed tool=%s build=%s: %s",
+      JSON.stringify(data.toolName), JSON.stringify(data.buildId),
+      err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
+    );
+  }
+}

--- a/apps/web/lib/tak/tool-execution-receipt.ts
+++ b/apps/web/lib/tak/tool-execution-receipt.ts
@@ -3,6 +3,7 @@ import { prisma } from "@dpf/db";
 
 import type { ToolResult } from "@/lib/mcp-tools";
 import type { AlignmentGateDecision } from "./alignment-tool-gate";
+import type { PreconditionOrderingDecision } from "./precondition-ordering-gate";
 import type { GovernedExecuteContext } from "@/lib/mcp-governed-execute";
 import { getWorkCaseAction } from "@/lib/work-management/action-registry";
 import { collaborationShapeForTool } from "./consequential-tool-policy";
@@ -40,6 +41,7 @@ export async function writeToolExecutionReceipt(data: {
   context?: GovernedExecuteContext;
   consequential?: boolean;
   alignmentDecision?: AlignmentGateDecision | null;
+  preconditionDecision?: PreconditionOrderingDecision | null;
 }): Promise<void> {
   const kind = receiptKind(data.toolName, data.context, data.consequential);
   if (!kind) return;
@@ -59,6 +61,7 @@ export async function writeToolExecutionReceipt(data: {
         specialistDelegation: data.alignmentDecision.specialistDelegation ?? null,
       } : null,
       collaborationShape: data.consequential ? collaborationShapeForTool(data.toolName) : null,
+      precondition: data.preconditionDecision ?? null,
     }) },
     receiptKind: kind,
     receiptStatus: data.result.success ? "valid" : "invalid",

--- a/apps/web/lib/tak/tool-execution-receipt.ts
+++ b/apps/web/lib/tak/tool-execution-receipt.ts
@@ -5,6 +5,7 @@ import type { ToolResult } from "@/lib/mcp-tools";
 import type { AlignmentGateDecision } from "./alignment-tool-gate";
 import type { GovernedExecuteContext } from "@/lib/mcp-governed-execute";
 import { getWorkCaseAction } from "@/lib/work-management/action-registry";
+import { collaborationShapeForTool } from "./consequential-tool-policy";
 
 let createOverride: ((data: Record<string, unknown>) => Promise<unknown>) | null = null;
 export function setToolExecutionReceiptCreateOverrideForTests(
@@ -57,6 +58,7 @@ export async function writeToolExecutionReceipt(data: {
         verdict: data.alignmentDecision.verdict,
         specialistDelegation: data.alignmentDecision.specialistDelegation ?? null,
       } : null,
+      collaborationShape: data.consequential ? collaborationShapeForTool(data.toolName) : null,
     }) },
     receiptKind: kind,
     receiptStatus: data.result.success ? "valid" : "invalid",

--- a/apps/web/lib/tak/tool-execution-receipt.ts
+++ b/apps/web/lib/tak/tool-execution-receipt.ts
@@ -55,6 +55,7 @@ export async function writeToolExecutionReceipt(data: {
       alignment: data.alignmentDecision ? {
         interactionId: data.alignmentDecision.interactionId,
         verdict: data.alignmentDecision.verdict,
+        specialistDelegation: data.alignmentDecision.specialistDelegation ?? null,
       } : null,
     }) },
     receiptKind: kind,

--- a/apps/web/lib/tak/tool-execution-receipt.ts
+++ b/apps/web/lib/tak/tool-execution-receipt.ts
@@ -7,12 +7,20 @@ import type { PreconditionOrderingDecision } from "./precondition-ordering-gate"
 import type { GovernedExecuteContext } from "@/lib/mcp-governed-execute";
 import { getWorkCaseAction } from "@/lib/work-management/action-registry";
 import { collaborationShapeForTool } from "./consequential-tool-policy";
+import { resolveGaidActorEnvelope, type GaidActorEnvelope } from "./gaid-actor-envelope";
+import type { GovernedExecuteArgs } from "@/lib/mcp-governed-execute";
 
 let createOverride: ((data: Record<string, unknown>) => Promise<unknown>) | null = null;
+let updateOverride: ((id: string, data: Record<string, unknown>) => Promise<unknown>) | null = null;
 export function setToolExecutionReceiptCreateOverrideForTests(
   override: ((data: Record<string, unknown>) => Promise<unknown>) | null,
 ): void {
   createOverride = override;
+}
+export function setToolExecutionReceiptUpdateOverrideForTests(
+  override: ((id: string, data: Record<string, unknown>) => Promise<unknown>) | null,
+): void {
+  updateOverride = override;
 }
 
 function receiptKind(toolName: string, context?: GovernedExecuteContext, consequential = false): string | null {
@@ -32,6 +40,64 @@ function digestPayload(value: unknown): string {
   }).toString("hex");
 }
 
+function governanceEnvelope(data: {
+  actor: GaidActorEnvelope | null;
+  context?: GovernedExecuteContext;
+  consequential?: boolean;
+  alignmentDecision?: AlignmentGateDecision | null;
+  preconditionDecision?: PreconditionOrderingDecision | null;
+}) {
+  const evidenceRefs = Array.from(new Set([
+    ...(data.alignmentDecision?.alignment.checks.flatMap((check) => check.evidenceRefs) ?? []),
+    ...(data.preconditionDecision?.checks.flatMap((check) => check.evidenceRefs) ?? []),
+    ...(data.alignmentDecision?.specialistDelegation?.checks.flatMap((check) => check.evidenceRefs) ?? []),
+  ])).sort();
+  return {
+    actor: data.actor,
+    gateDecision: data.alignmentDecision?.verdict ?? null,
+    decisionInteractionId: data.alignmentDecision?.interactionId ?? null,
+    policyVersion: data.alignmentDecision?.policyVersion ?? null,
+    amendmentLineage: data.alignmentDecision?.amendmentLineage ?? [],
+    delegationChainId: data.context?.delegationChainId ?? null,
+    qualification: data.alignmentDecision?.specialistDelegation ? {
+      verdict: data.alignmentDecision.specialistDelegation.verdict,
+      statuses: data.alignmentDecision.specialistDelegation.checks.map((check) => ({
+        specialistAgentId: check.specialistAgentId,
+        professionKey: check.professionKey,
+        qualification: check.qualification,
+        delegationChainId: check.delegationChainId,
+      })),
+      permissionGranted: data.alignmentDecision.specialistDelegation.permissionGranted,
+    } : null,
+    evidenceRefs,
+  };
+}
+
+function receiptOutput(data: {
+  result: ToolResult;
+  toolName: string;
+  actor: GaidActorEnvelope | null;
+  context?: GovernedExecuteContext;
+  consequential?: boolean;
+  alignmentDecision?: AlignmentGateDecision | null;
+  preconditionDecision?: PreconditionOrderingDecision | null;
+}) {
+  const governance = {
+    ...governanceEnvelope(data),
+    collaborationShape: data.consequential ? collaborationShapeForTool(data.toolName) : null,
+  };
+  return {
+    sha256: digestPayload({
+      data: data.result.data ?? null,
+      error: data.result.error ?? null,
+      message: data.result.message ?? null,
+      success: data.result.success,
+      governance,
+    }),
+    governance,
+  };
+}
+
 export async function writeToolExecutionReceipt(data: {
   auditRowId: string;
   buildId: string | null;
@@ -42,27 +108,22 @@ export async function writeToolExecutionReceipt(data: {
   consequential?: boolean;
   alignmentDecision?: AlignmentGateDecision | null;
   preconditionDecision?: PreconditionOrderingDecision | null;
+  governedArgs?: GovernedExecuteArgs;
 }): Promise<void> {
   const kind = receiptKind(data.toolName, data.context, data.consequential);
   if (!kind) return;
+  let actor: GaidActorEnvelope | null = null;
+  try {
+    actor = data.governedArgs ? await resolveGaidActorEnvelope(data.governedArgs) : null;
+  } catch {
+    actor = null;
+  }
   const row = {
     buildId: data.buildId ?? null,
     executionStatus: data.result.success ? "succeeded" : "failed",
     expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
     inputFingerprint: digestPayload({ params: data.rawParams, toolName: data.toolName }),
-    outputDigest: { sha256: digestPayload({
-      data: data.result.data ?? null,
-      error: data.result.error ?? null,
-      message: data.result.message ?? null,
-      success: data.result.success,
-      alignment: data.alignmentDecision ? {
-        interactionId: data.alignmentDecision.interactionId,
-        verdict: data.alignmentDecision.verdict,
-        specialistDelegation: data.alignmentDecision.specialistDelegation ?? null,
-      } : null,
-      collaborationShape: data.consequential ? collaborationShapeForTool(data.toolName) : null,
-      precondition: data.preconditionDecision ?? null,
-    }) },
+    outputDigest: receiptOutput({ ...data, actor }),
     receiptKind: kind,
     receiptStatus: data.result.success ? "valid" : "invalid",
     toolExecutionId: data.auditRowId,
@@ -77,4 +138,69 @@ export async function writeToolExecutionReceipt(data: {
       err instanceof Error ? JSON.stringify(err.message) : JSON.stringify(String(err)),
     );
   }
+}
+
+/** Reserve the GAID-bound evidence channel before an approved consequential side effect. */
+export async function reserveConsequentialToolExecutionReceipt(data: {
+  auditRowId: string;
+  args: GovernedExecuteArgs;
+  alignmentDecision: AlignmentGateDecision | null;
+  preconditionDecision: PreconditionOrderingDecision | null;
+}): Promise<{ id: string } | null> {
+  let actor: GaidActorEnvelope | null = null;
+  try {
+    actor = await resolveGaidActorEnvelope(data.args);
+  } catch {
+    return null;
+  }
+  if (!actor) return null;
+  const reservedResult: ToolResult = { success: false, error: "execution_reserved", message: "Consequential execution reserved." };
+  const row = {
+    buildId: null,
+    executionStatus: "reserved",
+    expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    inputFingerprint: digestPayload({ params: data.args.rawParams, toolName: data.args.toolName }),
+    outputDigest: receiptOutput({
+      result: reservedResult, toolName: data.args.toolName, actor, context: data.args.context,
+      consequential: true, alignmentDecision: data.alignmentDecision,
+      preconditionDecision: data.preconditionDecision,
+    }),
+    receiptKind: receiptKind(data.args.toolName, data.args.context, true)!,
+    receiptStatus: "reserved",
+    toolExecutionId: data.auditRowId,
+  };
+  try {
+    const created = createOverride
+      ? await createOverride(row)
+      : await prisma.toolExecutionReceipt.create({ data: row, select: { id: true } });
+    return typeof (created as { id?: unknown } | undefined)?.id === "string"
+      ? { id: String((created as { id: string }).id) }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function finalizeConsequentialToolExecutionReceipt(data: {
+  receiptId: string;
+  result: ToolResult;
+  toolName: string;
+  args: GovernedExecuteArgs;
+  alignmentDecision: AlignmentGateDecision | null;
+  preconditionDecision: PreconditionOrderingDecision | null;
+  buildId?: string | null;
+}): Promise<void> {
+  const actor = await resolveGaidActorEnvelope(data.args);
+  const update = {
+    ...(data.buildId ? { buildId: data.buildId } : {}),
+    executionStatus: data.result.success ? "succeeded" : "failed",
+    receiptStatus: data.result.success ? "valid" : "invalid",
+    outputDigest: receiptOutput({
+      result: data.result, toolName: data.toolName, actor, context: data.args.context,
+      consequential: true, alignmentDecision: data.alignmentDecision,
+      preconditionDecision: data.preconditionDecision,
+    }),
+  };
+  if (updateOverride) await updateOverride(data.receiptId, update);
+  else await prisma.toolExecutionReceipt.update({ where: { id: data.receiptId }, data: update });
 }

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -443,7 +443,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - link\n  - link\n    - paragraph\n      - text\n  - link\n  - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n          - text\n    - rowgroup\n      - row\n        - cell\n          - text"
     },
     "/coworker-decisions/matrix": {
-      "defaultVisibleWords": 293,
+      "defaultVisibleWords": 292,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -451,7 +451,7 @@
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - navigation\n    - link\n    - text\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - list\n    - listitem\n      - text\n  - heading [level=2]\n  - list\n    - listitem\n      - text\n  - paragraph\n    - text"
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - navigation\n    - link\n    - text\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - list\n    - listitem\n      - text\n  - group\n    - button\n    - list\n      - listitem\n        - text\n  - heading [level=2]\n  - list\n    - listitem\n      - text\n  - paragraph\n    - text"
     },
     "/coworker-decisions/perspectives": {
       "defaultVisibleWords": 472,

--- a/apps/web/lib/wiki/embedding-reconciliation.ts
+++ b/apps/web/lib/wiki/embedding-reconciliation.ts
@@ -1,0 +1,70 @@
+import { prisma, QDRANT_COLLECTIONS, scrollPoints } from "@dpf/db";
+
+import { storeWikiPage } from "./embeddings";
+
+const DEFAULT_PAGE_LIMIT = 500;
+const VECTOR_SCAN_LIMIT = 10_000;
+
+export type WikiEmbeddingReconciliationResult = {
+  scanned: number;
+  missing: number;
+  embedded: number;
+  failed: string[];
+};
+
+export async function reconcilePublishedWikiEmbeddings(input: {
+  kind?: string | null;
+  limit?: number;
+  dryRun?: boolean;
+} = {}): Promise<WikiEmbeddingReconciliationResult> {
+  const limit = Math.max(1, Math.min(input.limit ?? DEFAULT_PAGE_LIMIT, DEFAULT_PAGE_LIMIT));
+  const [pages, points] = await Promise.all([
+    prisma.wikiPage.findMany({
+      where: { status: "published", ...(input.kind ? { pageKind: input.kind } : {}) },
+      select: {
+        id: true, slug: true, title: true, body: true, abstract: true, pageKind: true,
+        status: true, isKernel: true, kernelVersion: true, organizationId: true,
+        kernelPageId: true, principleTier: true, principleAppliesTo: true,
+        principleRingScope: true, principleDimensionVector: true, principlePublic: true,
+      },
+      take: limit,
+      orderBy: { id: "asc" },
+    }),
+    scrollPoints(QDRANT_COLLECTIONS.WIKI_PAGES, {
+      must: [{ key: "entityType", match: { value: "wiki-page" } }],
+    }, VECTOR_SCAN_LIMIT),
+  ]);
+  const present = new Set(points
+    .map((point) => point.payload.entityId)
+    .filter((id): id is string => typeof id === "string"));
+  const missing = pages.filter((page) => !present.has(page.id));
+  if (input.dryRun) return { scanned: pages.length, missing: missing.length, embedded: 0, failed: [] };
+
+  let embedded = 0;
+  const failed: string[] = [];
+  for (const page of missing) {
+    const dimensions = page.principleDimensionVector && typeof page.principleDimensionVector === "object"
+      ? Object.keys(page.principleDimensionVector as Record<string, unknown>)
+      : undefined;
+    try {
+      const ok = await storeWikiPage({
+        pageId: page.id, slug: page.slug, title: page.title, body: page.body,
+        abstract: page.abstract, pageKind: page.pageKind, status: page.status,
+        isKernel: page.isKernel, kernelVersion: page.kernelVersion,
+        organizationId: page.organizationId, kernelPageId: page.kernelPageId,
+        ...(page.pageKind === "principle" ? {
+          principleTier: page.principleTier,
+          principleAppliesTo: page.principleAppliesTo,
+          principleRingScope: page.principleRingScope,
+          principleDimensions: dimensions,
+          principlePublic: page.principlePublic ?? undefined,
+        } : {}),
+      });
+      if (ok) embedded += 1;
+      else failed.push(page.slug);
+    } catch {
+      failed.push(page.slug);
+    }
+  }
+  return { scanned: pages.length, missing: missing.length, embedded, failed };
+}

--- a/apps/web/lib/wiki/embeddings.test.ts
+++ b/apps/web/lib/wiki/embeddings.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const upsertVectors = vi.fn();
 const searchSimilar = vi.fn();
 const deleteVectors = vi.fn();
+const scrollPoints = vi.fn();
 const generateEmbedding = vi.fn();
 const wikiPageFindMany = vi.fn();
 
@@ -15,6 +16,7 @@ vi.mock("@dpf/db", () => ({
   upsertVectors: (...args: unknown[]) => upsertVectors(...args),
   searchSimilar: (...args: unknown[]) => searchSimilar(...args),
   deleteVectors: (...args: unknown[]) => deleteVectors(...args),
+  scrollPoints: (...args: unknown[]) => scrollPoints(...args),
   prisma: { wikiPage: { findMany: (...args: unknown[]) => wikiPageFindMany(...args) } },
 }));
 
@@ -27,6 +29,7 @@ import {
   searchWikiPages,
   storeWikiPage,
 } from "./embeddings";
+import { reconcilePublishedWikiEmbeddings } from "./embedding-reconciliation";
 
 const stub = (n: number) => new Array(n).fill(0).map((_, i) => i / n);
 
@@ -34,6 +37,7 @@ afterEach(() => {
   upsertVectors.mockReset();
   searchSimilar.mockReset();
   deleteVectors.mockReset();
+  scrollPoints.mockReset();
   generateEmbedding.mockReset();
   wikiPageFindMany.mockReset();
 });
@@ -188,8 +192,8 @@ describe("storeWikiPage", () => {
     expect(payload).not.toHaveProperty("principlePublic");
   });
 
-  it("returns false silently when the embedding model is unavailable", async () => {
-    generateEmbedding.mockResolvedValueOnce(null);
+  it("retries once when an idle-evicted embedding provider loads on demand", async () => {
+    generateEmbedding.mockResolvedValueOnce(null).mockResolvedValueOnce(stub(768));
 
     const ok = await storeWikiPage({
       pageId: "wp_1",
@@ -205,7 +209,20 @@ describe("storeWikiPage", () => {
       kernelPageId: null,
     });
 
+    expect(ok).toBe(true);
+    expect(generateEmbedding).toHaveBeenCalledTimes(2);
+    expect(upsertVectors).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains fail-safe behavior when the embedding provider is genuinely unavailable", async () => {
+    generateEmbedding.mockResolvedValue(null);
+    const ok = await storeWikiPage({
+      pageId: "wp_outage", slug: "entities/outage", title: "Outage", body: "body",
+      abstract: null, pageKind: "entity", status: "published", isKernel: true,
+      kernelVersion: null, organizationId: null, kernelPageId: null,
+    });
     expect(ok).toBe(false);
+    expect(generateEmbedding).toHaveBeenCalledTimes(2);
     expect(upsertVectors).not.toHaveBeenCalled();
   });
 
@@ -229,6 +246,49 @@ describe("storeWikiPage", () => {
 
     const callArg = generateEmbedding.mock.calls[0][0] as string;
     expect(callArg.length).toBeLessThanOrEqual(8000);
+  });
+});
+
+describe("published wiki embedding reconciliation", () => {
+  it("idempotently backfills only published pages whose vector is missing", async () => {
+    scrollPoints.mockResolvedValue([{ id: 1, payload: { entityId: "wp-present" } }]);
+    wikiPageFindMany.mockResolvedValue([
+      {
+        id: "wp-present", slug: "entities/present", title: "Present", body: "body",
+        abstract: null, pageKind: "entity", status: "published", isKernel: true,
+        kernelVersion: null, organizationId: null, kernelPageId: null,
+        principleTier: null, principleAppliesTo: [], principleRingScope: [],
+        principleDimensionVector: null, principlePublic: null,
+      },
+      {
+        id: "wp-missing", slug: "entities/missing", title: "Missing", body: "body",
+        abstract: null, pageKind: "entity", status: "published", isKernel: true,
+        kernelVersion: null, organizationId: null, kernelPageId: null,
+        principleTier: null, principleAppliesTo: [], principleRingScope: [],
+        principleDimensionVector: null, principlePublic: null,
+      },
+    ]);
+    generateEmbedding.mockResolvedValue(stub(768));
+
+    const result = await reconcilePublishedWikiEmbeddings();
+    expect(result).toEqual({ scanned: 2, missing: 1, embedded: 1, failed: [] });
+    expect(upsertVectors).toHaveBeenCalledTimes(1);
+    expect(upsertVectors.mock.calls[0]?.[1]?.[0]?.id).toBe("wiki-page-wp-missing");
+  });
+
+  it("leaves a skipped page eligible for the next governed run", async () => {
+    scrollPoints.mockResolvedValue([]);
+    wikiPageFindMany.mockResolvedValue([{
+      id: "wp-retry", slug: "entities/retry", title: "Retry", body: "body",
+      abstract: null, pageKind: "entity", status: "published", isKernel: true,
+      kernelVersion: null, organizationId: null, kernelPageId: null,
+      principleTier: null, principleAppliesTo: [], principleRingScope: [],
+      principleDimensionVector: null, principlePublic: null,
+    }]);
+    generateEmbedding.mockResolvedValue(null);
+    expect(await reconcilePublishedWikiEmbeddings()).toMatchObject({ embedded: 0, failed: ["entities/retry"] });
+    generateEmbedding.mockReset().mockResolvedValue(stub(768));
+    expect(await reconcilePublishedWikiEmbeddings()).toMatchObject({ embedded: 1, failed: [] });
   });
 });
 

--- a/apps/web/lib/wiki/embeddings.ts
+++ b/apps/web/lib/wiki/embeddings.ts
@@ -217,7 +217,10 @@ export async function storeWikiPage(input: StoreWikiPageInput): Promise<boolean>
   // Docker Model Runner may evict an idle embedding model. The first request is
   // the load-on-demand signal; retry exactly once so eviction self-heals while
   // a real outage stays bounded and observable to the caller.
-  const vector = await generateEmbedding(truncated) ?? await generateEmbedding(truncated);
+  let vector = await generateEmbedding(truncated);
+  if (!vector) {
+    vector = await generateEmbedding(truncated);
+  }
   if (!vector) return false;
 
   // Build the base payload first, then conditionally add principle-only

--- a/apps/web/lib/wiki/embeddings.ts
+++ b/apps/web/lib/wiki/embeddings.ts
@@ -214,7 +214,10 @@ export async function searchWikiPagesLexically(
 export async function storeWikiPage(input: StoreWikiPageInput): Promise<boolean> {
   const embeddingInput = [input.abstract ?? "", input.body].filter(Boolean).join("\n\n");
   const truncated = embeddingInput.slice(0, MAX_EMBED_LENGTH);
-  const vector = await generateEmbedding(truncated);
+  // Docker Model Runner may evict an idle embedding model. The first request is
+  // the load-on-demand signal; retry exactly once so eviction self-heals while
+  // a real outage stays bounded and observable to the caller.
+  const vector = await generateEmbedding(truncated) ?? await generateEmbedding(truncated);
   if (!vector) return false;
 
   // Build the base payload first, then conditionally add principle-only

--- a/apps/web/lib/work-management/receipt-envelope.test.ts
+++ b/apps/web/lib/work-management/receipt-envelope.test.ts
@@ -138,6 +138,30 @@ describe("ReceiptEnvelope normalizers", () => {
     expect(envelope.status).toBe("failed");
   });
 
+  it("projects the GAID-bound TAK decision without hiding policy or qualification evidence", () => {
+    const envelope = fromToolExecutionReceipt({
+      id: "ter-tak", toolExecutionId: "te-tak",
+      receiptKind: "tak-consequential-action", receiptStatus: "valid",
+      executionStatus: "succeeded", inputFingerprint: "sha256:tak",
+      outputDigest: { governance: {
+        actor: { principalId: "PRN-1", gaid: "GAID-1", actorKind: "employee" },
+        gateDecision: "approve", decisionInteractionId: "DI-TAK", policyVersion: "wwwd:v2",
+        delegationChainId: "CHAIN-1",
+        qualification: { verdict: "approve", permissionGranted: false },
+        evidenceRefs: ["wiki:stance:v2", "wsid:marketing:v1"],
+        amendmentLineage: ["wiki:stance:v1", "wiki:stance:v2"],
+      } }, createdAt: NOW,
+    });
+    expect(envelope.tak).toEqual({
+      gateDecision: "approve", decisionInteractionId: "DI-TAK", policyVersion: "wwwd:v2",
+      gaid: "GAID-1", principalId: "PRN-1", delegationChainId: "CHAIN-1",
+      qualification: { verdict: "approve", permissionGranted: false },
+      evidenceRefs: ["wiki:stance:v2", "wsid:marketing:v1"],
+      amendmentLineage: ["wiki:stance:v1", "wiki:stance:v2"],
+    });
+    expect(envelope.policyRefs).toEqual(["wwwd:v2", "wiki:stance:v2", "wsid:marketing:v1"]);
+  });
+
   it("normalizes existing activity and evidence rows as observed-event receipts", () => {
     const envelopes = [
       fromWorkCapsuleActivity({

--- a/apps/web/lib/work-management/receipt-envelope.test.ts
+++ b/apps/web/lib/work-management/receipt-envelope.test.ts
@@ -115,6 +115,29 @@ describe("ReceiptEnvelope normalizers", () => {
     });
   });
 
+  it("carries Work Room shape, authority ladder, and decision receipt linkage", () => {
+    const envelope = fromToolExecutionReceipt({
+      id: "ter-shape", toolExecutionId: "te-shape",
+      receiptKind: "work-case-governed-action", receiptStatus: "valid",
+      executionStatus: "denied", inputFingerprint: "sha256:shape",
+      outputDigest: { verdict: "decline" }, createdAt: NOW,
+    }, {
+      caseRef: CASE_REF,
+      policyRefs: ["tak:wwwd-alignment"],
+      collaborationShape: {
+        collaborationShape: "escalation", authorityLadderLevel: "action",
+        requiredPrincipalRefs: ["PRN-COORD", "PRN-OWNER"],
+        decisionInteractionId: "DI-VETO",
+      },
+    });
+    expect(envelope.governance).toEqual({
+      collaborationShape: "escalation", authorityLadderLevel: "action",
+      requiredPrincipalRefs: ["PRN-COORD", "PRN-OWNER"],
+      decisionInteractionId: "DI-VETO",
+    });
+    expect(envelope.status).toBe("failed");
+  });
+
   it("normalizes existing activity and evidence rows as observed-event receipts", () => {
     const envelopes = [
       fromWorkCapsuleActivity({

--- a/apps/web/lib/work-management/receipt-envelope.ts
+++ b/apps/web/lib/work-management/receipt-envelope.ts
@@ -31,6 +31,17 @@ export interface ReceiptEnvelope {
     requiredPrincipalRefs: readonly string[];
     decisionInteractionId?: string;
   };
+  tak?: {
+    gateDecision: "approve" | "decline" | "escalate" | null;
+    decisionInteractionId: string | null;
+    policyVersion: string | null;
+    gaid: string | null;
+    principalId: string | null;
+    delegationChainId: string | null;
+    qualification: unknown;
+    evidenceRefs: readonly string[];
+    amendmentLineage: readonly string[];
+  };
   trace?: {
     traceId?: string;
     spanId?: string;
@@ -143,6 +154,28 @@ function enforcementModeFromReceiptKind(receiptKind: string): WorkCaseEnforcemen
   return /governed/i.test(receiptKind) ? "governed-action" : "observed-event";
 }
 
+function takEnvelope(outputDigest: unknown): ReceiptEnvelope["tak"] | undefined {
+  if (!outputDigest || typeof outputDigest !== "object") return undefined;
+  const governance = (outputDigest as Record<string, unknown>).governance;
+  if (!governance || typeof governance !== "object") return undefined;
+  const row = governance as Record<string, unknown>;
+  const actor = row.actor && typeof row.actor === "object" ? row.actor as Record<string, unknown> : {};
+  const verdict = ["approve", "decline", "escalate"].includes(String(row.gateDecision))
+    ? row.gateDecision as "approve" | "decline" | "escalate" : null;
+  return {
+    gateDecision: verdict,
+    decisionInteractionId: typeof row.decisionInteractionId === "string" ? row.decisionInteractionId : null,
+    policyVersion: typeof row.policyVersion === "string" ? row.policyVersion : null,
+    gaid: typeof actor.gaid === "string" ? actor.gaid : null,
+    principalId: typeof actor.principalId === "string" ? actor.principalId : null,
+    delegationChainId: typeof row.delegationChainId === "string" ? row.delegationChainId : null,
+    qualification: row.qualification ?? null,
+    evidenceRefs: Array.isArray(row.evidenceRefs) ? row.evidenceRefs.filter((ref): ref is string => typeof ref === "string") : [],
+    amendmentLineage: Array.isArray(row.amendmentLineage)
+      ? row.amendmentLineage.filter((ref): ref is string => typeof ref === "string") : [],
+  };
+}
+
 function observedEnvelope(input: {
   receiptId: string;
   sourceRef: WorkCaseSourceRef;
@@ -205,6 +238,7 @@ export function fromToolExecutionReceipt(
   row: ToolExecutionReceiptRow,
   options: ToolExecutionReceiptEnvelopeOptions = {},
 ): ReceiptEnvelope {
+  const tak = takEnvelope(row.outputDigest);
   return {
     receiptId: row.id,
     caseRef: options.caseRef,
@@ -221,8 +255,12 @@ export function fromToolExecutionReceipt(
     occurredAt: iso(row.createdAt),
     inputDigest: row.inputFingerprint,
     outputDigest: row.outputDigest,
-    policyRefs: options.policyRefs ?? [],
+    policyRefs: options.policyRefs ?? [
+      ...(tak?.policyVersion ? [tak.policyVersion] : []),
+      ...(tak?.evidenceRefs ?? []),
+    ],
     governance: options.collaborationShape,
+    tak,
     rawRef: {
       table: "ToolExecutionReceipt",
       id: row.id,

--- a/apps/web/lib/work-management/receipt-envelope.ts
+++ b/apps/web/lib/work-management/receipt-envelope.ts
@@ -7,6 +7,7 @@ import type {
   WorkCaseRef,
   WorkCaseSourceRef,
 } from "./case-types";
+import type { WorkRoomShapeKey } from "./room-shapes";
 
 export type ReceiptEnvelopeStatus = "valid" | "invalid" | "observed" | "failed";
 
@@ -24,6 +25,12 @@ export interface ReceiptEnvelope {
   inputDigest?: string;
   outputDigest?: unknown;
   policyRefs: readonly string[];
+  governance?: {
+    collaborationShape: WorkRoomShapeKey;
+    authorityLadderLevel: "none" | "discover" | "content" | "action";
+    requiredPrincipalRefs: readonly string[];
+    decisionInteractionId?: string;
+  };
   trace?: {
     traceId?: string;
     spanId?: string;
@@ -58,6 +65,7 @@ export interface ToolExecutionReceiptEnvelopeOptions {
   caseRef?: WorkCaseRef;
   actionType?: WorkCaseActionVerb | string;
   policyRefs?: readonly string[];
+  collaborationShape?: ReceiptEnvelope["governance"];
 }
 
 export interface WorkCapsuleActivityRow {
@@ -214,6 +222,7 @@ export function fromToolExecutionReceipt(
     inputDigest: row.inputFingerprint,
     outputDigest: row.outputDigest,
     policyRefs: options.policyRefs ?? [],
+    governance: options.collaborationShape,
     rawRef: {
       table: "ToolExecutionReceipt",
       id: row.id,

--- a/apps/web/lib/work-management/room-participation.test.ts
+++ b/apps/web/lib/work-management/room-participation.test.ts
@@ -5,8 +5,52 @@ import {
   projectWorkRoomDiscovery,
   projectWorkRoomParticipants,
 } from "./room-participation";
+import {
+  bindWorkRoomShape,
+  getWorkRoomShape,
+  WORK_ROOM_SHAPE_KEYS,
+} from "./room-shapes";
 
 describe("Work Room participation", () => {
+  it("registers the five consequential collaboration shapes", () => {
+    expect(WORK_ROOM_SHAPE_KEYS).toEqual([
+      "specialist-alignment", "approval-sign-off", "outward-review",
+      "change-consequential", "escalation",
+    ]);
+    expect(getWorkRoomShape("specialist-alignment")).toMatchObject({
+      authorityLadderLevel: "action",
+      inclusionOrder: ["coordinator", "specialist", "approver"],
+    });
+  });
+
+  it.each(["person", "agent"] as const)(
+    "requires the same specialist-alignment roles for a %s initiator",
+    (kind) => {
+      const binding = bindWorkRoomShape({
+        shape: "specialist-alignment",
+        initiator: { principalRef: "PRN-INIT", kind },
+        participants: {
+          coordinator: "PRN-COORD", specialist: "PRN-SPECIALIST", approver: "PRN-OWNER",
+        },
+        sensitivityCeiling: "confidential",
+      });
+      expect(binding.requiredParticipants.map((participant) => participant.role))
+        .toEqual(["coordinator", "specialist", "approver"]);
+      expect(binding.authorityLadderLevel).toBe("action");
+      expect(binding.stepUpRequired).toBe(true);
+      expect(binding.gaps).toEqual([]);
+    },
+  );
+
+  it("fails closed when a shape-required participant is absent", () => {
+    expect(bindWorkRoomShape({
+      shape: "outward-review",
+      initiator: { principalRef: "PRN-INIT", kind: "person" },
+      participants: { coordinator: "PRN-INIT", specialist: "PRN-BRAND" },
+      sensitivityCeiling: "internal",
+    })).toMatchObject({ allowed: false, gaps: ["approver"] });
+  });
+
   it("keeps an unauthorized room non-discoverable", () => {
     expect(authorizeWorkRoomAccess({
       requested: "content",

--- a/apps/web/lib/work-management/room-shapes.ts
+++ b/apps/web/lib/work-management/room-shapes.ts
@@ -1,0 +1,100 @@
+import type { WorkRoomAccessLevel } from "./room-participation";
+import type { WorkRoomParticipantRole } from "./room-types";
+
+export const WORK_ROOM_SHAPE_KEYS = [
+  "specialist-alignment",
+  "approval-sign-off",
+  "outward-review",
+  "change-consequential",
+  "escalation",
+] as const;
+export type WorkRoomShapeKey = (typeof WORK_ROOM_SHAPE_KEYS)[number];
+
+type ShapeRole = Extract<
+  WorkRoomParticipantRole,
+  "coordinator" | "specialist" | "approver" | "reviewer"
+>;
+
+export type WorkRoomShapeDefinition = {
+  key: WorkRoomShapeKey;
+  inclusionOrder: readonly ShapeRole[];
+  authorityLadderLevel: WorkRoomAccessLevel;
+  sensitivityStepUp: boolean;
+  description: string;
+};
+
+const SHAPES: Record<WorkRoomShapeKey, WorkRoomShapeDefinition> = {
+  "specialist-alignment": {
+    key: "specialist-alignment",
+    inclusionOrder: ["coordinator", "specialist", "approver"],
+    authorityLadderLevel: "action",
+    sensitivityStepUp: true,
+    description: "Coordinator routes a corpus check to a qualified specialist before the accountable approver receives the verdict.",
+  },
+  "approval-sign-off": {
+    key: "approval-sign-off",
+    inclusionOrder: ["coordinator", "specialist", "approver"],
+    authorityLadderLevel: "action",
+    sensitivityStepUp: true,
+    description: "The domain specialist prepares evidence and an accountable approver signs off.",
+  },
+  "outward-review": {
+    key: "outward-review",
+    inclusionOrder: ["coordinator", "specialist", "approver"],
+    authorityLadderLevel: "action",
+    sensitivityStepUp: true,
+    description: "An outward-facing action receives specialist review and explicit send or publish approval.",
+  },
+  "change-consequential": {
+    key: "change-consequential",
+    inclusionOrder: ["coordinator", "reviewer", "approver"],
+    authorityLadderLevel: "action",
+    sensitivityStepUp: true,
+    description: "A consequential change is reviewed and confirmed before execution.",
+  },
+  escalation: {
+    key: "escalation",
+    inclusionOrder: ["coordinator", "approver"],
+    authorityLadderLevel: "action",
+    sensitivityStepUp: true,
+    description: "A veto returns to the originating coordinator and accountable owner for accept-block or amendment.",
+  },
+};
+
+export function getWorkRoomShape(key: WorkRoomShapeKey): WorkRoomShapeDefinition {
+  return SHAPES[key];
+}
+
+export type WorkRoomShapeBinding = {
+  shape: WorkRoomShapeKey;
+  initiator: { principalRef: string; kind: "person" | "agent" };
+  requiredParticipants: Array<{ role: ShapeRole; principalRef: string }>;
+  authorityLadderLevel: WorkRoomAccessLevel;
+  stepUpRequired: boolean;
+  gaps: ShapeRole[];
+  allowed: boolean;
+};
+
+export function bindWorkRoomShape(input: {
+  shape: WorkRoomShapeKey;
+  initiator: WorkRoomShapeBinding["initiator"];
+  participants: Partial<Record<ShapeRole, string>>;
+  sensitivityCeiling: string | null;
+}): WorkRoomShapeBinding {
+  const definition = getWorkRoomShape(input.shape);
+  const gaps = definition.inclusionOrder.filter((role) => !input.participants[role]);
+  const requiredParticipants = definition.inclusionOrder.flatMap((role) => {
+    const principalRef = input.participants[role];
+    return principalRef ? [{ role, principalRef }] : [];
+  });
+  const sensitivity = input.sensitivityCeiling ?? "public";
+  return {
+    shape: input.shape,
+    initiator: input.initiator,
+    requiredParticipants,
+    authorityLadderLevel: definition.authorityLadderLevel,
+    stepUpRequired: definition.sensitivityStepUp && ["confidential", "restricted", "critical"].includes(sensitivity),
+    gaps: [...gaps],
+    allowed: gaps.length === 0,
+  };
+}

--- a/apps/web/lib/work-management/room-types.ts
+++ b/apps/web/lib/work-management/room-types.ts
@@ -34,6 +34,8 @@ export type WorkRoomParticipantRole =
   | "accountable"
   | "coordinator"
   | "contributor"
+  | "specialist"
+  | "approver"
   | "reviewer"
   | "observer";
 

--- a/apps/web/scripts/reembed-wiki-store.ts
+++ b/apps/web/scripts/reembed-wiki-store.ts
@@ -32,7 +32,7 @@
 // success with a warning).
 
 import { prisma } from "@dpf/db";
-import { storeWikiPage } from "@/lib/wiki/embeddings";
+import { reconcilePublishedWikiEmbeddings } from "@/lib/wiki/embedding-reconciliation";
 import { isEmbeddingAvailable } from "@/lib/inference/embedding";
 
 type Flags = { dryRun: boolean; kind: string | null };
@@ -65,101 +65,21 @@ async function main(): Promise<void> {
     }
   }
 
-  const where = {
-    status: "published",
-    ...(flags.kind ? { pageKind: flags.kind } : {}),
-  };
-
-  const pages = await prisma.wikiPage.findMany({
-    where,
-    select: {
-      id: true,
-      slug: true,
-      title: true,
-      body: true,
-      abstract: true,
-      pageKind: true,
-      status: true,
-      isKernel: true,
-      kernelVersion: true,
-      organizationId: true,
-      kernelPageId: true,
-      principleTier: true,
-      principleAppliesTo: true,
-      principleRingScope: true,
-      principleDimensionVector: true,
-      principlePublic: true,
-    },
-  });
+  const result = await reconcilePublishedWikiEmbeddings({ kind: flags.kind, dryRun: flags.dryRun });
 
   console.info(
-    `[reembed-wiki-store] ${flags.dryRun ? "DRY RUN — " : ""}` +
-      `${pages.length} published page(s)${flags.kind ? ` of kind "${flags.kind}"` : ""} to reconcile.`,
+    `[reembed-wiki-store] scanned=${result.scanned} missing=${result.missing} ` +
+      `embedded=${result.embedded}` + (result.failed.length ? ` failed=${result.failed.length}` : ""),
   );
-
-  if (flags.dryRun) {
-    const byKind = new Map<string, number>();
-    for (const p of pages) byKind.set(p.pageKind, (byKind.get(p.pageKind) ?? 0) + 1);
-    for (const [kind, n] of [...byKind].sort((a, b) => b[1] - a[1])) {
-      console.info(`  ${kind}: ${n}`);
-    }
-    await prisma.$disconnect();
-    return;
-  }
-
-  let embedded = 0;
-  const failed: string[] = [];
-  for (const p of pages) {
-    const dims =
-      p.principleDimensionVector && typeof p.principleDimensionVector === "object"
-        ? Object.keys(p.principleDimensionVector as Record<string, unknown>)
-        : undefined;
-    const ok = await storeWikiPage({
-      pageId: p.id,
-      slug: p.slug,
-      title: p.title,
-      body: p.body,
-      abstract: p.abstract,
-      pageKind: p.pageKind,
-      status: p.status,
-      isKernel: p.isKernel,
-      kernelVersion: p.kernelVersion,
-      organizationId: p.organizationId,
-      kernelPageId: p.kernelPageId,
-      ...(p.pageKind === "principle"
-        ? {
-            principleTier: p.principleTier,
-            principleAppliesTo: p.principleAppliesTo,
-            principleRingScope: p.principleRingScope,
-            principleDimensions: dims,
-            principlePublic: p.principlePublic ?? undefined,
-          }
-        : {}),
-    });
-    if (ok) {
-      embedded += 1;
-    } else {
-      failed.push(p.slug);
-    }
-    if ((embedded + failed.length) % 25 === 0) {
-      console.info(`  … ${embedded + failed.length}/${pages.length}`);
-    }
-  }
-
-  console.info(
-    `[reembed-wiki-store] coverage: ${embedded}/${pages.length} embedded` +
-      (failed.length ? `, ${failed.length} FAILED` : ""),
-  );
-  if (failed.length) {
+  if (result.failed.length) {
     console.error(
-      `[reembed-wiki-store] ${failed.length} page(s) could not be embedded: ` +
-        failed.slice(0, 20).join(", ") +
-        (failed.length > 20 ? ` … (+${failed.length - 20} more)` : ""),
+      `[reembed-wiki-store] ${result.failed.length} page(s) could not be embedded: ` +
+        result.failed.slice(0, 20).join(", "),
     );
   }
 
   await prisma.$disconnect();
-  process.exit(failed.length ? 1 : 0);
+  process.exit(result.failed.length ? 1 : 0);
 }
 
 main().catch((err) => {

--- a/docs/superpowers/plans/2026-08-13-tak-alignment-gate-p1-foundation.md
+++ b/docs/superpowers/plans/2026-08-13-tak-alignment-gate-p1-foundation.md
@@ -1,0 +1,94 @@
+# TAK alignment gate — P1 foundation implementation plan
+
+**Epic:** EP-1C37C089
+
+**Slices:** BI-1452AD76, BI-7E1F128A, BI-B6690C11
+
+**Spec:** `docs/superpowers/specs/2026-08-13-wwwd-constitutional-alignment-gate.md`
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time. The three slices intentionally share one batch branch and PR, while each BI retains its own test-first commit and evidence. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Standards contract
+
+The execution order is `GAID identity -> JSI qualification -> TAK intersection at execution -> GAID receipt`. This batch adds the WWWD alignment signal and TAK interception point. It must preserve the no-widening invariants: an identity claim is not authorization, qualification is not permission, and permission is not competence.
+
+The implementation composes the existing axis registry, stance material, decision evaluator, authority gate, lifecycle hooks, `ToolExecution`, and `ToolExecutionReceipt`. It does not add a parallel decision engine, permission layer, or audit ledger.
+
+## Backlog coverage
+
+- Decision: `decomposed`
+- Receipt: `cmss8h3l7000w01p26b5foxls`
+- Parent BI: `BI-1452AD76`
+- `axes` -> BI-1452AD76
+- `criteria-veto` -> BI-7E1F128A; depends on `axes`
+- `interception` -> BI-B6690C11; depends on `axes`, `criteria-veto`
+
+## Slice 1 — alignment axes and stance projection (BI-1452AD76)
+
+### Red
+
+- Extend `packages/db/src/seed-wiki-kernel.test.ts`, `packages/db/src/enterprise-architecture-decision-pack.test.ts`, and dimension-catalog tests so `mission_fit`, `market_fit`, `product_fit`, and `gtm_fit` are required closed axes with caller guidance and explicit spine scope.
+- Extend `apps/web/lib/decision-perspective/stance-dimension-map.test.ts` and `packages/db/src/wiki-store.test.ts` to prove a published `pageKind: stance` persists a non-null alignment vector and dimensions while forbidden/cost sign invariants remain intact.
+
+### Green/refactor
+
+- Add the four benefit axes to the single registry in `packages/db/src/wiki-taxonomy.ts`, classify them as spine axes in `packages/db/src/dimension-scope.ts`, and document their high-score meaning in `apps/web/lib/decision/dimension-catalog.ts`.
+- Extend `apps/web/lib/decision-perspective/stance-dimension-map.ts` with a deterministic stance projection contract. Project only the alignment axes supported by the stance's declared purpose/content; keep the existing commercial-stance magnitude ceiling and never infer safety or authority.
+- Allow stance pages—not arbitrary non-principle kinds—to persist the projected `principleDimensionVector` and `principleDimensions` through `packages/db/src/wiki-store.ts`. Wire the existing publish/confirm/seed paths in `apps/web/lib/actions/business-stance.ts`, `apps/web/lib/actions/stance-confirm.ts`, and `apps/web/lib/onboarding/seed-org-wwwd-corpus.ts` through that projection.
+
+### Verify
+
+- Targeted Vitest for registry, scope, stance projection, wiki persistence, and WWWD seed/publish actions.
+- Production web build. No migration is expected because the existing nullable JSON/vector columns are reused.
+
+## Slice 2 — criteria extraction and veto (BI-7E1F128A)
+
+### Red
+
+- Add focused cases under `apps/web/lib/decision-perspective/` for criteria `{market, segment, product, motion, geography, customerType}`.
+- Reproduce the live defect: toaster/Alaskan fishermen and coffee-shop chain decline; MSP partner and self-host support subscription approve; a concrete option is selected; a hard rejection cannot be averaged away by generic positive stances.
+- Cover malformed/ambiguous input with fail-closed escalation rather than an invented fit score.
+
+### Green/refactor
+
+- Add a pure criteria-extraction module beside `option-recommendation.ts`; keep its typed output stable and evidence-bearing.
+- Extend the org business gate/evaluator to load relevant org stance and portfolio/GTM evidence, score each alignment corpus independently, and apply a hard-boundary veto before aggregate recommendation.
+- Return the failing corpus, criterion, rationale, and evidence refs in the existing `DecisionInteraction` outcome payload. Keep WWMD and WSID material advisory outside their owning scope.
+- Reuse the existing option scorer for a concrete `recommendedOptionId`; do not duplicate the scoring math.
+
+### Verify
+
+- Targeted decision-perspective and `org-decision-pack` tests, including semantic and lexical-fallback behavior.
+- Confirm revert-to-red by disabling veto selection and observing the toaster regression test fail.
+
+## Slice 3 — consequential write-time interception (BI-B6690C11)
+
+### Red
+
+- Extend `apps/web/lib/mcp-governed-execute.test.ts` to prove routine reads skip the expensive alignment path, consequential mutations are gated before `executeTool`, rejection prevents the side effect, and owner/direct-human plus coworker calls reach the same interceptor.
+- Add receipt assertions for allow, deny, and escalate outcomes and ensure authority/grant denial cannot be widened by alignment approval.
+
+### Green/refactor
+
+- Add a closed consequential-tool classification/policy module under `apps/web/lib/tak/`, derived from existing `ToolDefinition.sideEffect`, audit classes, Work Case action metadata, and explicit tool policy—not model judgment.
+- Register the alignment control as a first-class pre-execution stage inside `apps/web/lib/mcp-governed-execute.ts`, after identity/grant/authority resolution and before the tool handler. Preserve existing authority outcomes; alignment can only narrow.
+- Bind the gate result to the existing `ToolExecution` audit and `ToolExecutionReceipt`; return structured misalignment to the originating caller. Do not add a bypass flag.
+
+### Verify
+
+- Targeted governed-execute/authority tests plus the P1 decision suite.
+- Production build and canonical-runtime MCP acceptance for one routine read, one approved consequential call, and one rejected consequential call.
+
+## Batch completion gate
+
+- All affected Vitest suites pass from the batch worktree with the runner root confirmed.
+- `pnpm --filter web build` passes.
+- Canonical Arcamanus acceptance: toaster and coffee shop decline; MSP partner and self-host support approve; a specialist `create_digital_product` toaster attempt is blocked before mutation; every consequential attempt has a receipt.
+- Documentation impact: update the standards/conformance documentation only where implemented DPF conformance changes; do not rewrite TAK, GAID, or TAK-JSI ownership.
+
+## Risks and rollback
+
+- **False veto:** keep criteria/corpus evidence in the receipt and default ambiguous extraction to escalation, not rejection.
+- **Latency:** deterministic consequential classification runs first; only consequential calls load corpora/delegation.
+- **Audit gap:** a missing required receipt is a failed gate outcome, not a silent success.
+- **Rollback:** revert the batch PR. Existing operational-axis evaluation and authority gate remain intact because the implementation extends their seams and adds no schema migration.

--- a/docs/superpowers/plans/2026-08-13-tak-alignment-gate-p1-foundation.md
+++ b/docs/superpowers/plans/2026-08-13-tak-alignment-gate-p1-foundation.md
@@ -83,7 +83,7 @@ The implementation composes the existing axis registry, stance material, decisio
 
 - All affected Vitest suites pass from the batch worktree with the runner root confirmed.
 - `pnpm --filter web build` passes.
-- Canonical Arcamanus acceptance: toaster and coffee shop decline; MSP partner and self-host support approve; a specialist `create_digital_product` toaster attempt is blocked before mutation; every consequential attempt has a receipt.
+- Canonical customer-zero acceptance: toaster and coffee shop decline; MSP partner and self-host support approve; a specialist `create_digital_product` toaster attempt is blocked before mutation; every consequential attempt has a receipt.
 - Documentation impact: update the standards/conformance documentation only where implemented DPF conformance changes; do not rewrite TAK, GAID, or TAK-JSI ownership.
 
 ## Risks and rollback

--- a/docs/superpowers/plans/2026-08-13-tak-alignment-gate-p2-completion.md
+++ b/docs/superpowers/plans/2026-08-13-tak-alignment-gate-p2-completion.md
@@ -60,7 +60,7 @@ TAK owns action gating, GAID owns subject identity and receipts, and TAK-JSI own
 - Targeted suites pass after every BI commit; full affected web/db tests pass at batch end.
 - Production web build passes; any migration applies against existing data and a clean schema.
 - UX verification covers rejection, escalation, deliberate amendment, and Work Room participant/receipt presentation in light and dark themes using existing `--dpf-*` tokens and shared primitives.
-- Canonical Arcamanus acceptance passes exactly: toaster/Alaskan fishermen grounded DECLINE; MSP partner and self-host support subscription APPROVE; every consequential call emits a GAID-bound ledger receipt.
+- Canonical customer-zero acceptance passes exactly: toaster/Alaskan fishermen grounded DECLINE; MSP partner and self-host support subscription APPROVE; every consequential call emits a GAID-bound ledger receipt.
 - Documentation/conformance surfaces accurately distinguish implemented behavior from specified future maturity.
 
 ## Risks and rollback

--- a/docs/superpowers/plans/2026-08-13-tak-alignment-gate-p2-completion.md
+++ b/docs/superpowers/plans/2026-08-13-tak-alignment-gate-p2-completion.md
@@ -1,0 +1,73 @@
+# TAK alignment gate — P2 completion implementation plan
+
+**Epic:** EP-1C37C089
+
+**Slices:** BI-FB036C59, BI-51CCB81C, BI-F23E07D5, BI-A8C735BA, BI-238E46C1
+
+**Spec:** `docs/superpowers/specs/2026-08-13-wwwd-constitutional-alignment-gate.md`
+
+**Depends on:** P1 foundation plan and batch PR
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time. The five slices intentionally share one batch branch and PR, while each BI retains its own test-first commit and evidence. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Standards contract
+
+TAK owns action gating, GAID owns subject identity and receipts, and TAK-JSI owns qualification. WSID supplies specialist craft evidence; WWWD supplies organization direction. Every composition is narrowing: JSI eligibility does not authorize the action, an alignment approval does not prove competence, and owner identity does not exempt a call from policy.
+
+## Backlog coverage
+
+- Decision: `decomposed`
+- Receipt: `cmss8h3lj000y01p2x1hfxeo5`
+- Parent BI: `BI-FB036C59`
+- `jsi` -> BI-FB036C59
+- `rooms` -> BI-51CCB81C; depends on `jsi`
+- `preconditions` -> BI-F23E07D5
+- `embeddings` -> BI-A8C735BA
+- `uniform-receipts` -> BI-238E46C1; depends on all prior P2 deliverables
+
+## Slice 4 — JSI-qualified specialist delegation (BI-FB036C59)
+
+- **Red:** add cases beside `apps/web/lib/decision-perspective/profession-gate.test.ts` and `apps/web/lib/tak/delegation-policy.test.ts` proving product/GTM checks route to the corpus owner, use `evaluate_profession_decision`, return evidence, and fail closed for absent/stale/out-of-scope qualification.
+- **Green:** compose `apps/web/lib/tak/coworker-collaboration.ts`, the coworker intent router, profession gate, and existing delegation chain. Add a narrow alignment-check envelope and qualification result; never pass action permission through the specialist verdict.
+- **Verify:** qualified specialist succeeds; unqualified specialist is refused before corpus access/action; the resulting chain-of-custody is present on audit and receipt.
+
+## Slice 5 — Work Room collaboration shapes (BI-51CCB81C)
+
+- **Red:** extend `room-participation.test.ts`, room read-model tests, and receipt-envelope tests for `specialist-alignment`, `approval-sign-off`, `outward-review`, `change-consequential`, and `escalation` shapes.
+- **Green:** add a typed shape registry over `room-types.ts` and resolve participants through existing `room-participation.ts`/Principal lineage. Shapes declare coordinator, specialist, approver, inclusion order, authority ladder level, and sensitivity step-up. No room, membership, identity, or channel model is added.
+- **Verify:** human and AI initiators produce the same required role set and authority ladder; veto returns through the room and lands as a `DecisionInteraction`/Outcome Packet receipt.
+
+## Slice 6 — precondition and ordering check (BI-F23E07D5)
+
+- **Red:** add an employee-identity-before-asset-allocation fixture and drift cases to the EA/value-stream and TAK gate suites.
+- **Green:** project an executable precondition view from existing value-stream/FPAW ordering and the `data-model-mirror`/Prisma FK metadata. Add it as a fourth narrowing check family in the P1 gate; an unmet or incoherent prerequisite blocks or escalates with evidence.
+- **Verify:** asset allocation before employee identity is rejected with the unmet prerequisite and references both the value-stream stage and FK mirror; no parallel workflow engine is introduced.
+
+## Slice 7 — embedding self-heal (BI-A8C735BA)
+
+- **Red:** extend `apps/web/lib/wiki/embeddings.test.ts` for an idle-evicted provider that succeeds on bounded retry, a true outage that retains fail-safe behavior, and a published missing-vector page reconciled on the next governed run.
+- **Green:** make `storeWikiPage` trigger bounded load-on-demand through the existing embedding provider. Extract the reusable portion of `apps/web/scripts/reembed-wiki-store.ts` into a governed reconciliation service/job that selects published missing-vector pages and idempotently backfills them.
+- **Verify:** publish during idle eviction stores a vector; skipped pages self-heal when the provider returns; genuine unavailability remains observable and safe.
+
+## Slice 8 — uniform actors, amend-not-bypass, GAID receipts (BI-238E46C1)
+
+- **Red:** add end-to-end governed-execute cases for owner, employee, and coworker origin; reject any bypass/override argument; prove a deliberate stance revision changes the policy version and allows a freshly evaluated action; require a receipt for every consequential verdict including deny/escalate.
+- **Green:** resolve human and agent actors through the existing Principal/GAID identity spine. Extend `ToolExecutionReceipt`/`ReceiptEnvelope` with gate decision, policy versions, actor/GAID reference, delegation chain, qualification status, evidence refs, and amendment lineage. Make missing mandatory receipt creation fail closed before an approved side effect.
+- **Verify:** owner and employee are governed identically; the only route from reject to allow is a versioned stance amendment and fresh decision; receipts join back to the GAID subject and Work Case.
+
+## Batch completion gate
+
+- Targeted suites pass after every BI commit; full affected web/db tests pass at batch end.
+- Production web build passes; any migration applies against existing data and a clean schema.
+- UX verification covers rejection, escalation, deliberate amendment, and Work Room participant/receipt presentation in light and dark themes using existing `--dpf-*` tokens and shared primitives.
+- Canonical Arcamanus acceptance passes exactly: toaster/Alaskan fishermen grounded DECLINE; MSP partner and self-host support subscription APPROVE; every consequential call emits a GAID-bound ledger receipt.
+- Documentation/conformance surfaces accurately distinguish implemented behavior from specified future maturity.
+
+## Risks and rollback
+
+- **Delegation outage or qualification drift:** fail closed/narrow/escalate; never substitute an unqualified generalist.
+- **Room fan-out:** create/use one finite room per consequential decision and reuse standing rooms only when the case already owns the action.
+- **Architecture drift:** refuse executable preconditions whose business and systems evidence disagree; surface reconciliation work.
+- **Embedding pressure:** bounded retry/backfill with idempotency and provider-health limits.
+- **Receipt failure after side effect:** prevent execution when the mandatory receipt channel cannot be reserved; reconcile only legacy/non-gated paths.
+- **Rollback:** revert the P2 batch PR and its forward migration if one is introduced via a new compensating migration; P1 remains a coherent guarded foundation.

--- a/docs/superpowers/specs/2026-08-13-wwwd-constitutional-alignment-gate.md
+++ b/docs/superpowers/specs/2026-08-13-wwwd-constitutional-alignment-gate.md
@@ -1,0 +1,149 @@
+# A Governance Gate on Consequential Tool Use (WWWD-grounded)
+
+**Date:** 2026-08-13 · **Origin:** Arcamanus dogfood (customer 0) · **Owner ask:** Mark Bodman
+**Supersedes the narrow scope of** BI-7E1F128A (which was "make the WWWD score discriminate by content"). That BI is a symptom; this spec is the mechanism.
+
+## The pattern (generalized)
+
+The recurring shape is **a gate that must be cleared before any consequential tool call executes** — adding a product, paying a bill, emailing a client, sending a quote, publishing content. Every such action is a *tool-mediated* commitment, and each clears the same governance gate first. The "does the toaster fit our mission?" case is one instance; the general mechanism is a **pre-execution governance interceptor** that, for every consequential tool call, extracts what the action *is*, checks it against the company's stance + relevant corpora + policy, and **vetoes, allows, or escalates** before the tool runs. This is the concrete form of the org stance *"keep humans in control of consequential automated decisions."*
+
+## Same shape as an agent permission layer
+
+Structurally this is the **agent permission / auto-mode validation pattern**: a middleware step that intercepts each tool call and returns *allow / deny / ask* before it executes, guarding against bad consequences. The distinction — and the DPF differentiator — is the **policy source**: Claude's auto-mode validates against generic harm heuristics plus user allow/deny rules; this gate validates against the **company's own authored policy** (WWWD stance + product portfolio + GTM + authority/spend limits). It is a **Policy Decision Point (PDP) invoked as tool-use middleware**, where the policy is the organization's constitution, is owner-editable, and is amended (not bypassed) to change what the org permits. Implement it as a tool-call interceptor/hook, not as an optional advisory call each agent must remember to make.
+
+## Placement in the standards family (TAK / GAID / JSI) and decision scopes (WWMD / WWWD / WSID)
+
+This gate is not new machinery bolted on — it is the composition and wiring of constructs the standards family already defines. Build it *as* a TAK control surface, not beside one.
+
+- **TAK (Trusted AI Kernel) — the home.** TAK defines the runtime's explicit control surfaces for *authority, approvals, tool calls, delegation, failure, evidence*. The gate is the **alignment/approval control surface on consequential tool calls**, and must be a first-class part of the TAK harness so no agent can act around it (interceptor, not an advisory call each agent remembers to make).
+- **GAID — the actor.** The invoking agent's GAID identity is what the gate attributes and traces; each gate decision is a **GAID-traceable receipt** in the ledger (who acted, under what delegated authority).
+- **JSI (TAK-JSI) — coordination vs specialist.** The **coordination layer** (orchestrator / overarching thread) emits the action and routes the check; it **delegates the precise domain check to a specialist profile**. That delegation runs through **TAK-JSI qualification**: the specialist must be *qualified* for this job/activity/data/risk or the runtime **fails closed, narrows, or escalates**. Load-bearing JSI rule carried through: **a JSI qualification is *not* permission to act** — qualification gates *who may run the check*; the gate still layers WWWD alignment + authority on top before the action lands.
+- **Decision scopes — WWWD × WSID (× WWMD).** The verdict composes two scopes:
+  - **WWWD (organization):** does this action fit the company — mission / market / product / GTM? (coordination-level, the org constitution).
+  - **WSID (profession):** the specialist applies its **craft**, scored through `evaluate_profession_decision` against its **profession corpus** (specialist-level).
+  The specialist's **WSID** verdict on its domain feeds the coordination-level **WWWD** decision; both must clear, and **veto** applies across them. **WWMD (platform)** is the sibling scope for platform-build decisions — same shape, different corpus.
+
+So: **coordination layer** = WWWD org-alignment + orchestration + veto authority; **specialist layer** = JSI-qualified profile applying WSID craft to its corpus and returning a verdict. The toaster's "resounding no" is a coordination-level WWWD market/mission fail *and* a specialist-level WSID product-portfolio fail, either of which vetoes.
+
+## Problem
+
+The WWWD org business-decision path does not let the company's stated stance govern decisions. Live proof (Arcamanus, 2026-08-13): with an explicit stance *"we decline selling toasters to fishermen in Alaska…"* **embedded and semantically matched**, `evaluate_org_business_decision` still returns `stanceAlignment: approve` for the toaster. Root causes:
+
+1. **Wrong vectors.** The decision is scored on *operational* axes (`speed_to_value, reversibility, blast_radius, cognitive_load, governance_compliance, maintainability`). **None expresses strategic alignment** — mission fit, market fit, product fit, GTM fit. So "is this on-mission?" is not a dimension the scorer can weigh.
+2. **Stance content is not projected into criteria.** The `principleDimensionVector` / stance→dimension mechanism exists (BI-E1427A3E) but WWWD org stances (pageKind `stance`) are not projected into it — the stance is matched as an opaque blob, not decomposed into checkable criteria.
+3. **Coarse aggregate, no veto.** Relevance is averaged over all stances; generic positive stances ("we help businesses") outweigh a specific decline-boundary. A hard "no" gets diluted to "approve."
+4. **Portfolio/GTM corpora not consulted.** The product portfolio (what we actually sell) and go-to-market corpus play no part in the decision.
+5. **No enforcement at write-time, and no uniform reach.** Alignment is (weakly) checked only on explicit `evaluate_org_business_decision` calls — not when an actor actually *commits* a consequential action (adds a product, commits a market/deal), and not for human actors.
+
+## Target architecture
+
+A decision/action is aligned by **criteria-extraction → multi-corpus dimensional alignment → specialist delegation → veto-on-hard-boundary → uniform write-time enforcement → amend-not-bypass → ledger**.
+
+### 1. Criteria extraction
+From the proposed statement/action, extract the salient criteria: **market/segment, product/offer, motion/GTM, geography, customer type**. (For "toasters to Alaskan fishermen from dock kiosks": segment=consumer/physical-retail, product=toasters/appliances, motion=kiosk retail, geo=Alaska.)
+
+### 2. Multi-corpus dimensional alignment (the "right vectors")
+Score the extracted criteria against **layered corpora**, each producing an independent alignment verdict:
+- **Corporate WWWD stance** — mission, who we serve, how, what we sell. Market fit → *SMB/MSP?* No.
+- **Product-portfolio inventory** — the catalog / DigitalProduct / Products we actually sell. Product fit → *is this in our portfolio or adjacent?* No.
+- **Go-to-market corpus** — our motion (open-source + assurance + partner channel). Motion fit → *fits our GTM?* No.
+
+Each corpus is owned by the role that maintains it; the alignment axes (mission/market/product/GTM fit) are added to the decision-axis registry alongside the operational axes.
+
+### 3. Specialist delegation (A2A)
+When the criteria touch a specialist-owned corpus, the overarching thread **delegates the precise check to the owner coworker** (e.g. the Digital Product Estate / Portfolio specialist for product-fit) via the coworker/A2A layer, and awaits its verdict. The specialist runs the exact check against its corpus and returns `{aligned | rejected, rationale, evidence}` to the caller.
+
+### 4. Veto semantics
+Any single corpus returning a **hard-boundary rejection is decisive** — it blocks. Alignment is **not** an average; a market/product/mission boundary can veto on its own. (The toaster earns a "resounding no" from all three independently.)
+
+### 5. Uniform enforcement — a gate on every consequential tool call (all actors, owner included)
+The gate is a **pre-execution interceptor on consequential tool use**, not a check that only runs on an explicit `evaluate_org_business_decision` call. Before a consequential tool executes, it is classified and gated. It runs three families of check (a tool call may trigger one or several):
+
+| Check family | Question | Examples of gated tool calls |
+|---|---|---|
+| **Alignment** (this spec's core) | Does the action fit our mission / market / product / GTM? | add a product (`create_digital_product`), enter a market, launch a campaign |
+| **Authority & policy** | Is this actor permitted; within spend/data/standing-stance limits? | pay a bill, issue a refund, grant access, change a config |
+| **Consequence / HITL** | Reversible? Outward-facing? Needs human confirm? | email a client, send a quote, publish content, delete data |
+
+- **Cheap classification first:** most tool calls are routine and clear instantly; only consequential classes incur the full check (so the gate is not a tax on every read).
+- **No actor is exempt** — AI coworker, employee, or **the owner**. An owner-originated off-mission action still fires the gate and surfaces that it **contradicts the stated company direction**.
+- **Federated / company-wide:** the same gate catches **human** actions — an employee's off-mission or out-of-policy move is caught by the coworkers checking the specifics against the mission-as-a-whole.
+
+This unifies governance that is today scattered and inconsistent — tool grants (`TOOL_TO_GRANTS`), the coworker authority model, HITL tiers, standing stances, purchase/spend approval — under **one WWWD-grounded pre-tool decision point**, instead of each surface reinventing its own guard.
+
+### 6. Amend, don't bypass
+The **only** sanctioned way to enable a previously-off-mission action is to **deliberately amend the WWWD stance** (a visible governance act — "this changes our stated direction"). There is no bypass flag. This is what keeps the company from drifting off-mission by accident or by any single actor's command.
+
+### 7. Reject-and-return + ledger
+On alignment: transparent (the action proceeds). On rejection: **return to the originating caller** with the specific misalignment (which corpus, which criterion) so they can handle it — accept the block, or amend the stance. Every gate decision is recorded to the decision ledger (audit; the "keep humans in control of consequential automated decisions" stance).
+
+## Collaboration shapes (Work Room) determine routing and role-inclusion per gate pattern
+
+A gate decides *what* is checked and *whether it may proceed*; the **Work Room** decides *who* participates and *how they collaborate* to clear it. The two compose: **each gate pattern binds to a collaboration shape** — a reusable process/pattern over the Work Room substrate — that determines the routing and inclusion of human and non-human participants for that class of action.
+
+**Grounding (extend, don't fork the Work Room):** a Work Room is a typed projection over a governed **Work Case** (WorkItem, TaskRun, AgentThread, `DecisionInteraction`, `Principal`, `AuthorityBinding`, presence, receipt). Participation is projected from Work Item human+coworker assignment and thread/task **lineage** (not an ad-hoc summon), resolved through `PrincipalAlias`, with AI sponsorship/authority from `Principal.sponsorPrincipalId` / `authorityMode`. Admission/action follow the monotonic ladder `none < discover < content < action`; sensitivity gates via `Principal.sensitivityClearance` with **step-up** for confidential/consequential. Rooms are **finite** (one bounded decision/action) or **standing** (ongoing activity); the result lands as an **Outcome Packet** and the gate verdict is a `DecisionInteraction` **receipt** on the case.
+
+A gate fires **inside a Work Room** (spun up finite for the action, or the action already lives in a standing room). The bound shape determines:
+- **Participants & roles** (human and AI): who is coordinator, who is the JSI-qualified specialist(s) applying WSID craft, who is the approver/owner, who is merely informed.
+- **Routing order:** coordination → specialist check(s) → veto/approve → escalate-to-human on reject.
+- **Inclusion rules:** which roles MUST be present/consulted (and at what authority level) before the action may reach `action` on the ladder; when step-up is required.
+
+**Canonical shapes** (reusable, one per class of activity; extend, don't hardcode):
+
+| Shape | Gate-pattern examples | Participants / routing |
+|---|---|---|
+| **Specialist-alignment** | add product, enter market, launch campaign | coordinator → JSI-qualified corpus specialist (WSID) → WWWD veto; escalate to owner on reject |
+| **Approval / sign-off** | pay a bill, issue refund, spend over threshold | actor → finance specialist → approver (owner/authority) sign-off at `action` |
+| **Outward-review** | email a client, send a quote, publish | actor → brand/marketing review → send-approval; step-up for confidential |
+| **Change / consequential** | change config, delete data | actor → reviewer → confirm; higher HITL tier |
+| **Escalation (on veto)** | any reject | route the misalignment back into the room to the originating caller + owner; resolve by accept-block or deliberate stance amendment |
+
+Because participation, authority, sensitivity, and receipt are the room's, **human and non-human participants align to the shape identically** — a human employee's off-mission or out-of-policy action is caught in the same room, by the same shape, as an agent's. The gate machinery is constant; the **Work Room shape** is what routes the right people and coworkers into the right roles per activity, and the room's authority ladder + Outcome Packet + receipt make it governed and auditable.
+
+**Composition, not new machinery:** this binds shapes over the existing Work Room projection (EP-2984B02B and the current Work Room comms consolidation, EP-WORKROOM-COMMS). No new room/membership/identity/channel model.
+
+## Process ordering and preconditions — where business architecture syncs with systems architecture
+
+Collaboration shapes are not just *who* and *what*; they are **ordered processes with preconditions**. Many activities have a required sequence that cannot be reversed:
+
+> Employee onboarding must mint the **employee identity (employee ID)** before an **asset can be allocated** — because allocation *requires* the employee ID. The reverse order is not merely bad practice; it is impossible.
+
+This ordering is not arbitrary. It is where **business architecture** (the value-stream / process sequence — *identity → assets → access*) **must stay coherent with application/systems architecture** (the data model: `Asset.employeeId` is a required FK to an existing `Employee`). The same dependency appears in both views:
+- **Business view:** "you can't give someone a laptop before they're an employee."
+- **Systems view:** the `Asset.employeeId` FK will not resolve until the `Employee` row exists.
+
+So the gate carries a **fourth check family — precondition / ordering** — alongside the three from §5:
+
+| Check family | Question |
+|---|---|
+| Alignment (WWWD × WSID) | Does this fit our mission / market / product / craft? |
+| Authority & policy | Is this actor permitted; within limits? |
+| Consequence / HITL | Reversible? outward-facing? needs human confirm? |
+| **Precondition / ordering** | **Are the prerequisite states satisfied (the process-sequence dependencies)?** |
+
+Preconditions are **derived from and validated against the synced business↔systems model** — the value-stream stage order (EA / FPAW stages) and the data-model constraints (Prisma FKs / state machines, mirrored into the EA data model). When the two are in sync, a single precondition ("employee ID exists") is *simultaneously* a business rule and a data invariant, and the gate enforces it once. When they drift, you get impossible processes or ungoverned workarounds — so the gate/Work Room is the **runtime point where business-process order and the systems model are kept coherent at the moment of action.** That coherence *is* the payoff of true business architecture.
+
+Substrate: DPF already carries both halves — value streams + EA (`/ea`, archetype value streams, FPAW stages) and the Prisma data model mirrored into the EA data-model (`data-model-mirror` job, SysML projection). This gate binds them at execution time; it does **not** invent a new process/workflow engine.
+
+## Existing substrate to extend (not rebuild)
+- **WWWD corpus:** org WikiPages / stances (`/coworker-decisions/stance`).
+- **Stance→dimension projection:** `principleDimensionVector`, `stance-dimension-map.ts` (BI-E1427A3E) — extend to `pageKind: stance` and to alignment axes.
+- **Decision engine:** `evaluate_org_business_decision` / `principle_decide` / `option-recommendation.ts` — add alignment axes + veto + criteria-extraction.
+- **Product portfolio:** DigitalProduct / business Products / catalog; **Digital Product Estate / Portfolio specialist** coworker owns the corpus.
+- **Delegation:** `summon_coworker` / A2A coordination layer.
+- **Enforcement points:** consequential write paths (product/catalog/opportunity creation).
+- **Ledger + constitutional governance:** decision ledger; COO constitutional-governance remit.
+- **Work Room collaboration substrate:** Work Case / Work Room projection, participation (`room-participation.ts`), authority ladder (`none<discover<content<action`), sensitivity/step-up, finite/standing rooms, Outcome Packet, receipts — EP-2984B02B / EP-WORKROOM-COMMS. The gate binds collaboration *shapes* over this; it adds no room/membership/identity model.
+- **Business↔systems architecture:** value streams + EA (`/ea`, FPAW stages) and the Prisma data model mirrored into the EA data-model (`data-model-mirror` job, SysML projection) — the source of precondition/ordering rules the gate enforces.
+- **Standards family:** TAK (control surface), GAID (identity/trace), TAK-JSI (specialist qualification) — `docs/architecture/agent-standards-family.md`.
+
+## Acceptance
+1. Toaster and a novel off-mission case (coffee-shop chain) → **decline**, with the rationale naming the failing corpus/criterion. On-mission (MSP partner, self-host support subscription) → **approve**. Off-mission scores materially lower than on-mission; a concrete option is selected (not null).
+2. A specialist agent calling `create_digital_product` for an off-mission product is **blocked** at write-time and the caller is returned the misalignment.
+3. An owner-originated off-mission action is blocked and surfaced as contradicting the stated stance; it proceeds **only** after the WWWD stance is amended.
+4. Same enforcement observable for a human/employee-originated off-mission action.
+5. Every gate decision recorded in the ledger.
+
+## Non-goals
+- Not a change to the local model or infra (capacity is fine; embeddings load on demand).
+- Does not remove the safety escalation on genuine embedding-unavailability (keep the fail-safe from #4254).

--- a/docs/superpowers/specs/2026-08-13-wwwd-constitutional-alignment-gate.md
+++ b/docs/superpowers/specs/2026-08-13-wwwd-constitutional-alignment-gate.md
@@ -25,6 +25,18 @@ This gate is not new machinery bolted on — it is the composition and wiring of
 
 So: **coordination layer** = WWWD org-alignment + orchestration + veto authority; **specialist layer** = JSI-qualified profile applying WSID craft to its corpus and returning a verdict. The toaster's "resounding no" is a coordination-level WWWD market/mission fail *and* a specialist-level WSID product-portfolio fail, either of which vetoes.
 
+## Standards conformance — the discipline that keeps this and future work in check
+
+This gate is not a bespoke feature; it is the **TAK action-gating control** for consequential tool use, and it must conform to the DPF **Trustworthy AI Agent Standards Family** (`docs/architecture/agent-standards-family.md`). Conformance is what keeps this work — and every capability built after it — coherent:
+
+- **TAK** (Trusted AI Kernel) owns *may this agent act, under whose authority, through which tools/data, with what oversight and evidence* — i.e. **action gating at execution**. This gate realizes that control for the WWWD×WSID **alignment** dimension.
+- **GAID** resolves the acting identity + operating profile and binds the **action receipt** back to the subject (the ledger entry).
+- **TAK-JSI** determines whether the delegated specialist's operating profile is **qualified** for the job / data scope / risk of the check.
+- **Composition rule (normative):** `GAID identity → JSI qualification → TAK intersection (authority × grants × route/workflow policy × data constraints × qualification ceiling) at execution → GAID receipt`. This gate slots in at the TAK step and consults the WWWD/WSID policy corpora.
+- **No-widening invariants (must hold):** a GAID claim is not authorization; a JSI qualification is not permission to act; a TAK permission is not evidence of competence. The gate must never let one layer widen another.
+
+Because the gate is a TAK control, **every future consequential capability inherits governance by passing through it** — the standards family is the check that keeps new work in line, not a one-off review.
+
 ## Problem
 
 The WWWD org business-decision path does not let the company's stated stance govern decisions. Live proof (Arcamanus, 2026-08-13): with an explicit stance *"we decline selling toasters to fishermen in Alaska…"* **embedded and semantically matched**, `evaluate_org_business_decision` still returns `stanceAlignment: approve` for the toaster. Root causes:
@@ -147,3 +159,27 @@ Substrate: DPF already carries both halves — value streams + EA (`/ea`, archet
 ## Non-goals
 - Not a change to the local model or infra (capacity is fine; embeddings load on demand).
 - Does not remove the safety escalation on genuine embedding-unavailability (keep the fail-safe from #4254).
+
+## Composition with existing epics (extend, do not duplicate)
+
+Substrate-verify first: much of this exists. This epic is the **integration + the missing alignment pieces**, not a rebuild.
+
+| Concern | Owned / advanced by | This epic adds |
+|---|---|---|
+| Authority intersection + execute gate | **EP-31815F97** (TAK/GAID realization) | the WWWD×WSID **alignment** check-family + veto, at the same execution point |
+| Work Room collaboration, Coordinator, GAID participants | **EP-WORKROOM-COMMS** | **shape binding** per gate pattern (routing / inclusion) |
+| JSI weighting / specialist routing | **EP-DECISION-TIER-REBALANCE**, EP-E431FC8A (done) | specialist **delegation for alignment** verdicts |
+| WWWD/WSID surface + altitude/context | **EP-0AF96937**, **EP-7B169558** | project stances into **alignment axes** + criteria-extraction |
+| Harness mechanics as governed primitives | **EP-CLAUDE-INSIDE-OUT** | the gate **as a harness primitive** on tool use |
+| Work graph (Case / Item / Capsule) | **EP-WORK-CONVERGENCE** | gate verdicts as Work Case receipts |
+
+## Decomposition (execution slices)
+
+1. **Alignment axes + stance→dimension projection** for `pageKind: stance` (extend BI-E1427A3E) — the "right vectors."
+2. **Criteria-extraction + veto** semantics in `option-recommendation` — subsumes **BI-7E1F128A**.
+3. **JSI specialist delegation** for corpus-fit verdicts via A2A (compose EP-DECISION-TIER-REBALANCE).
+4. **Write-time TAK interception** on consequential tool calls (compose EP-31815F97 execute gate).
+5. **Collaboration-shape binding** per gate pattern (compose EP-WORKROOM-COMMS).
+6. **Precondition/ordering** check grounded in value-stream↔data-model (EA mirror).
+7. **Embedding self-heal** — load-on-demand + back-fill skipped pages.
+8. **Uniform enforcement for human actors** + amend-not-bypass override + GAID ledger receipt.

--- a/docs/superpowers/specs/2026-08-13-wwwd-constitutional-alignment-gate.md
+++ b/docs/superpowers/specs/2026-08-13-wwwd-constitutional-alignment-gate.md
@@ -1,6 +1,6 @@
 # A Governance Gate on Consequential Tool Use (WWWD-grounded)
 
-**Date:** 2026-08-13 · **Origin:** Arcamanus dogfood (customer 0) · **Owner ask:** Mark Bodman
+**Date:** 2026-08-13 · **Origin:** customer-zero dogfood · **Owner ask:** platform owner
 **Supersedes the narrow scope of** BI-7E1F128A (which was "make the WWWD score discriminate by content"). That BI is a symptom; this spec is the mechanism.
 
 ## The pattern (generalized)
@@ -39,7 +39,7 @@ Because the gate is a TAK control, **every future consequential capability inher
 
 ## Problem
 
-The WWWD org business-decision path does not let the company's stated stance govern decisions. Live proof (Arcamanus, 2026-08-13): with an explicit stance *"we decline selling toasters to fishermen in Alaska…"* **embedded and semantically matched**, `evaluate_org_business_decision` still returns `stanceAlignment: approve` for the toaster. Root causes:
+The WWWD org business-decision path does not let the company's stated stance govern decisions. Live proof (customer-zero install, 2026-08-13): with an explicit stance *"we decline selling toasters to fishermen in Alaska…"* **embedded and semantically matched**, `evaluate_org_business_decision` still returns `stanceAlignment: approve` for the toaster. Root causes:
 
 1. **Wrong vectors.** The decision is scored on *operational* axes (`speed_to_value, reversibility, blast_radius, cognitive_load, governance_compliance, maintainability`). **None expresses strategic alignment** — mission fit, market fit, product fit, GTM fit. So "is this on-mission?" is not a dimension the scorer can weigh.
 2. **Stance content is not projected into criteria.** The `principleDimensionVector` / stance→dimension mechanism exists (BI-E1427A3E) but WWWD org stances (pageKind `stance`) are not projected into it — the stance is matched as an opaque blob, not decomposed into checkable criteria.

--- a/docs/user-guide/ai-workforce/decision-perspective.md
+++ b/docs/user-guide/ai-workforce/decision-perspective.md
@@ -25,6 +25,7 @@ The full design lives in three specs:
 - `docs/superpowers/specs/2026-05-17-wwmd-decision-perspective-kernel-design.md` — the kernel
 - `docs/superpowers/specs/2026-05-19-wwmd-mcp-exposure-design.md` — the MCP tool
 - `docs/superpowers/specs/2026-05-19-persona-voice-layer-wwtd-design.md` — voice and WWTD profile kinds
+- `docs/superpowers/specs/2026-08-13-wwwd-constitutional-alignment-gate.md` — consequential-action WWWD×WSID enforcement
 
 ## What Decision Perspective Does
 
@@ -40,6 +41,14 @@ When a coworker or external MCP client hits a decision point that doesn't have a
 | `defer` | The active profile lacks enough material to frame even a recommended direction. | The question is captured as a profile gap so future curation can close it. |
 
 Every invocation writes a `DecisionInteraction` row recording the active profile version, the source materials cited, the confidence score, the chosen outcome, and the rationale text. This is the audit ledger — auditors and operators reconstruct "what perspective governed this decision, and on what evidence" from it.
+
+### Consequential Action Alignment
+
+For a consequential tool call, Decision Perspective is a pre-execution control rather than optional advice. The gate extracts the proposed market, customer, product, geography, and go-to-market motion, then checks them independently against the organization's published WWWD stance, organization-owned product portfolio, and GTM evidence. An explicit hard boundary in any required corpus vetoes the action; positive signals elsewhere cannot average the veto away.
+
+Product and GTM checks may use a qualified WSID specialist, but qualification never grants permission. The ordinary TAK intersection still requires the actor's authority, tool grants, workflow policy, data constraints, and preconditions. Owners and employees pass through the same control as coworkers.
+
+There is no alignment bypass flag. To permit an action that the current stance rejects, an owner deliberately amends and publishes the WWWD stance, producing a new policy version, and submits the action for a fresh decision. Every consequential verdict is recorded as a GAID-bound receipt showing the actor, decision interaction, policy version, delegation and qualification evidence, cited sources, and amendment lineage. For an approved action, the receipt channel is reserved before the side effect; if it cannot be reserved, the action does not run.
 
 ### The Confidence Model
 

--- a/docs/ux-fit/2026-08-14-decision-matrix-alignment-disclosure.ux-fit.json
+++ b/docs/ux-fit/2026-08-14-decision-matrix-alignment-disclosure.ux-fit.json
@@ -9,7 +9,7 @@
   "evidence": {
     "kind": "sweep-measurement",
     "baselineComparison": "maintained",
-    "measurementRun": "source-local served-page DOM audit, reconciled with the prior CI route sweep shell baseline",
+    "measurementRun": "governed UX route sweep run 31849736737",
     "measured": {
       "/coworker-decisions/matrix": {
         "defaultVisibleWords": 292,

--- a/docs/ux-fit/2026-08-14-decision-matrix-alignment-disclosure.ux-fit.json
+++ b/docs/ux-fit/2026-08-14-decision-matrix-alignment-disclosure.ux-fit.json
@@ -1,0 +1,37 @@
+{
+  "version": "1",
+  "decidedOption": "progressive-disclosure",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/coworker-decisions/matrix/page.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "sweep-measurement",
+    "baselineComparison": "maintained",
+    "measurementRun": "source-local served-page DOM audit, reconciled with the prior CI route sweep shell baseline",
+    "measured": {
+      "/coworker-decisions/matrix": {
+        "defaultVisibleWords": 292,
+        "leadBandWords": 0,
+        "primaryActions": 0,
+        "visibleFields": 0,
+        "maxChoicesPerControl": 0,
+        "subLegibleControls": 0,
+        "buriedPrimaryAction": 0,
+        "axeViolations": 0
+      }
+    },
+    "fitDecision": "fits-with-guardrails",
+    "owningArea": "Platform",
+    "routeFamily": "/coworker-decisions/matrix",
+    "primaryPersona": "platform operator reviewing the criteria and weights used by the Coworker Decision Engine",
+    "navigationLayer": "local progressive disclosure within the existing Decision Matrix route",
+    "reuseConvergence": "uses one native details disclosure and continues to render every row from buildMatrixDimensions",
+    "sourceTruth": "PRINCIPLE_DIMENSIONS and STANCE_ALIGNMENT_DIMENSIONS remain the closed registries; live WikiPage principle dimensions supply counts",
+    "emptyFailureBehavior": "the established axes and tier weights remain visible when no published principle counts exist",
+    "aiBoundary": "read-only explanation; no AI action or consequential tool call",
+    "accessibility": "native details and summary preserve keyboard and assistive-technology disclosure semantics",
+    "responsive": "the existing truncating row layout remains unchanged inside and outside the disclosure"
+  }
+}

--- a/packages/db/src/dimension-scope.ts
+++ b/packages/db/src/dimension-scope.ts
@@ -148,6 +148,26 @@ export const PRINCIPLE_DIMENSION_SCOPE = {
     rationale:
       "YOUNG AXIS (landed 2026-07-23, BI-B5EA2FB2): 4 uses, 0% specialist-authored. Whether an operator can foresee what an action will do before authorizing it is a precondition of informed authorization everywhere, not a design-profession concern.",
   },
+  mission_fit: {
+    scope: "spine",
+    rationale:
+      "An action's fit with the organization's declared mission is shared constitutional currency across every profession, not permission to execute it.",
+  },
+  market_fit: {
+    scope: "spine",
+    rationale:
+      "The people and market an organization has chosen to serve constrain work in every profession and must remain independently vetoable.",
+  },
+  product_fit: {
+    scope: "spine",
+    rationale:
+      "Fit with the organization's declared offer and portfolio crosses profession boundaries even when a portfolio specialist supplies the evidence.",
+  },
+  gtm_fit: {
+    scope: "spine",
+    rationale:
+      "Fit with the organization's chosen route to market is shared business direction; specialist qualification supplies evidence but cannot widen authority.",
+  },
 
   // ── Profession-local (demoted; each projects back onto the spine) ─────────
   schema_grounding: {
@@ -351,6 +371,10 @@ export const PRINCIPLE_DIMENSION_SOURCING = {
   business_disruption: "basic",
   operator_effort: "basic",
   legibility_of_consequence: "basic",
+  mission_fit: "basic",
+  market_fit: "basic",
+  product_fit: "basic",
+  gtm_fit: "basic",
 } as const satisfies Record<PrincipleDimension, PrincipleDimensionSourcing>;
 
 /** The sourcing class of one axis. */

--- a/packages/db/src/wiki-store-stance.test.ts
+++ b/packages/db/src/wiki-store-stance.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { upsertWikiPage } from "./wiki-store";
+
+describe("wiki stance projection persistence", () => {
+  it("persists dimensions without acquiring principle authority", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null);
+    const create = vi.fn().mockResolvedValue({ id: "wp_stance" });
+    const db = {
+      wikiPage: {
+        findFirst, create, update: vi.fn(), findUnique: vi.fn(), findMany: vi.fn(),
+      },
+    };
+    await upsertWikiPage(db, {
+      slug: "stances/market-boundary",
+      title: "Market boundary",
+      body: "We serve MSP partners, not consumer retail markets.",
+      pageKind: "stance",
+      isKernel: false,
+      principleDimensionVector: { market_fit: 0.4, product_fit: 0.4 },
+      principleDimensions: ["market_fit", "product_fit"],
+    });
+    const data = create.mock.calls[0][0].data;
+    expect(data).toEqual(expect.objectContaining({
+      pageKind: "stance",
+      principleDimensionVector: { market_fit: 0.4, product_fit: 0.4 },
+      principleDimensions: ["market_fit", "product_fit"],
+    }));
+    expect(data).not.toHaveProperty("principleTier");
+    expect(data).not.toHaveProperty("principleAppliesTo");
+  });
+});

--- a/packages/db/src/wiki-store.ts
+++ b/packages/db/src/wiki-store.ts
@@ -170,6 +170,19 @@ export type UpsertWikiPageInput = {
 function principleDataFromInput(
   input: UpsertWikiPageInput,
 ): Record<string, unknown> {
+  // Stances may carry the same closed-axis projection used by the decision
+  // engine, but no principle tier, applies-to scope, or runtime authority.
+  // A qualification/vector is evidence, not permission (EP-1C37C089).
+  if (input.pageKind === "stance") {
+    const stanceData: Record<string, unknown> = {};
+    if (input.principleDimensionVector !== undefined) {
+      stanceData.principleDimensionVector = input.principleDimensionVector;
+    }
+    if (input.principleDimensions !== undefined) {
+      stanceData.principleDimensions = input.principleDimensions;
+    }
+    return stanceData;
+  }
   if (input.pageKind !== "principle") {
     return {};
   }

--- a/packages/db/src/wiki-taxonomy.ts
+++ b/packages/db/src/wiki-taxonomy.ts
@@ -174,6 +174,13 @@ export const PRINCIPLE_DIMENSIONS = [
   // discipline that caught the never-wipe-db inversion.
   "operator_effort", // COST: how many operator operations + elapsed time to the outcome
   "legibility_of_consequence", // benefit: can the operator foresee what an action will do before authorizing it
+  // EP-1C37C089: shared constitutional-alignment currency. These describe how
+  // strongly an option fits an organization's declared direction; they never
+  // grant authority or imply specialist competence.
+  "mission_fit",
+  "market_fit",
+  "product_fit",
+  "gtm_fit",
 ] as const;
 export type PrincipleDimension = (typeof PRINCIPLE_DIMENSIONS)[number];
 


### PR DESCRIPTION
## Summary

- add a pre-execution TAK alignment interceptor for consequential MCP tool calls, composing the existing authority/execute gate rather than creating another execution path
- project owner-authored WWWD stances into mission, market, product, and GTM dimensions; extract action criteria; and enforce independent-corpus hard vetoes
- route product/GTM checks through TAK-JSI specialist qualification without treating qualification as permission
- bind existing Work Case / Work Room collaboration shapes, enforce EA-backed ordering preconditions, and self-heal missing wiki embeddings
- enforce owner, employee, and coworker calls uniformly; reject bypass flags; require a versioned stance amendment plus fresh decision; reserve every approved consequential GAID receipt before its side effect

## Backlog coverage

- EP-1C37C089
- BI-1452AD76, BI-7E1F128A, BI-B6690C11
- BI-FB036C59, BI-51CCB81C, BI-F23E07D5, BI-A8C735BA, BI-238E46C1

## Design grounding

The implementation follows `docs/superpowers/specs/2026-08-13-wwwd-constitutional-alignment-gate.md` and its two slice plans. It composes the existing governed executor, EP-31815F97 authority intersection, Principal/PrincipalAlias GAID spine, DecisionInteraction ledger, ToolExecutionReceipt/ReceiptEnvelope, Work Case/Work Room shapes, profession gate, and WikiPage revision substrate. The organization-owned `Product` model is the sole business-portfolio source for WWWD evaluation; the install-global `DigitalProduct` architecture catalog is deliberately excluded.

## Seed contribution fit

Seed-Fit-Decision: global-default

The existing organization WWWD starter corpus gains the same stance-dimension projection used by publish/edit paths. It does not add a second policy corpus or an install-only runtime patch.

## Verification

- 145 affected tests passed across web and database packages
- web TypeScript check passed
- production Next.js build passed (144 static pages; existing Edge-runtime compatibility warnings only)
- module-size ratchet, substrate complexity guard, docs index, and 38 pregate guards passed
- exact merged-code sandbox gate passed against current `origin/main`
- independent high-assurance semantic review passed with zero blocking findings after repairing organization portfolio isolation

## Runtime acceptance

After merge, advance the canonical Arcamanus install only through `/ops/self-upgrade`, then verify the customer-zero toaster DECLINE, MSP/self-host support APPROVE, and GAID receipt ledger paths. No UI styling surface is added by this PR.
