### PR TITLE
feat(crm): proactive, permissioned CRM enrichment with governed write-back (BI-B2497DFB)

### DIFF
--- a/apps/web/lib/crm/enrichment/completeness.test.ts
+++ b/apps/web/lib/crm/enrichment/completeness.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COMPLETENESS_OFFER_THRESHOLD,
+  scoreAccountCompleteness,
+  scoreContactCompleteness,
+} from "./completeness";
+
+describe("completeness / gap detection (AC1)", () => {
+  it("flags a name-only prospect as below threshold (the worked-example shape)", () => {
+    const result = scoreAccountCompleteness({ name: "TeamLogic IT" });
+    expect(result.belowThreshold).toBe(true);
+    expect(result.missing).toContain("website");
+    expect(result.missing).toContain("industry");
+    expect(result.filled).toEqual(["name"]);
+  });
+
+  it("does NOT nag a name+website account (exactly at threshold — matches the docstring)", () => {
+    const result = scoreAccountCompleteness({ name: "TeamLogic IT", website: "https://teamlogicit.com" });
+    expect(result.score).toBe(0.5);
+    expect(result.belowThreshold).toBe(false);
+  });
+
+  it("does NOT nag a well-filled account", () => {
+    const result = scoreAccountCompleteness({
+      name: "TeamLogic IT of Round Rock",
+      website: "https://teamlogicit.com/rrtx",
+      industry: "Managed IT Services",
+      employeeCount: 12,
+      location: "Round Rock, TX",
+      notes: "MSP serving north Austin metro",
+    });
+    expect(result.belowThreshold).toBe(false);
+    expect(result.missing).toHaveLength(0);
+    expect(result.score).toBe(1);
+  });
+
+  it("treats blank/whitespace/zero as unfilled", () => {
+    const result = scoreAccountCompleteness({
+      name: "  ",
+      website: "",
+      employeeCount: 0,
+    });
+    expect(result.filled).toHaveLength(0);
+    expect(result.score).toBe(0);
+  });
+
+  it("derives location from city/region aliases", () => {
+    const filled = scoreAccountCompleteness({ name: "X", city: "Austin" });
+    expect(filled.filled).toContain("location");
+  });
+
+  it("scores a contact and flags a name-only contact", () => {
+    const result = scoreContactCompleteness({ firstName: "Greg" });
+    expect(result.recordKind).toBe("customer-contact");
+    expect(result.belowThreshold).toBe(true);
+    expect(result.missing).toContain("jobTitle");
+    expect(result.missing).toContain("linkedinUrl");
+  });
+
+  it("threshold is a fraction in (0,1)", () => {
+    expect(COMPLETENESS_OFFER_THRESHOLD).toBeGreaterThan(0);
+    expect(COMPLETENESS_OFFER_THRESHOLD).toBeLessThan(1);
+  });
+});

--- a/apps/web/lib/crm/enrichment/completeness.ts
+++ b/apps/web/lib/crm/enrichment/completeness.ts
@@ -1,0 +1,112 @@
+/**
+ * CRM record completeness / gap detection (BI-B2497DFB, AC1).
+ *
+ * Pure, DB-free. Scores how much of a record's enrichable surface is filled so
+ * the enrichment offer can fire only on genuinely thin intake. "Thin" is not
+ * "any field blank" — a record can be legitimately sparse; the threshold is
+ * tuned so a bare name+website account does NOT nag, but a name-only prospect
+ * (the worked-example shape: "Greg Torosian — franchise owner, TeamLogic IT,
+ * Austin") does.
+ */
+import {
+  ACCOUNT_ENRICHABLE_FIELDS,
+  CONTACT_ENRICHABLE_FIELDS,
+  type CompletenessResult,
+  type EnrichableField,
+  type EnrichmentRecordKind,
+} from "./types";
+
+/**
+ * Field weights — identity/anchor fields count more than colour. A record is
+ * "complete enough" when its filled weight clears the threshold; missing
+ * low-weight fields alone will not drop it below.
+ */
+const ACCOUNT_WEIGHTS: Record<string, number> = {
+  name: 2,
+  website: 2,
+  industry: 1,
+  employeeCount: 1,
+  location: 1,
+  notes: 1,
+};
+
+const CONTACT_WEIGHTS: Record<string, number> = {
+  firstName: 2,
+  lastName: 1,
+  jobTitle: 1,
+  phone: 1,
+  linkedinUrl: 1,
+};
+
+/** At or below this filled-weight fraction the record warrants an offer. */
+export const COMPLETENESS_OFFER_THRESHOLD = 0.5;
+
+function isFilled(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (typeof value === "number") return Number.isFinite(value) && value > 0;
+  return true;
+}
+
+function score(
+  recordKind: EnrichmentRecordKind,
+  fields: readonly EnrichableField[],
+  weights: Record<string, number>,
+  record: Record<string, unknown>,
+): CompletenessResult {
+  const filled: EnrichableField[] = [];
+  const missing: EnrichableField[] = [];
+  let totalWeight = 0;
+  let filledWeight = 0;
+  for (const field of fields) {
+    const weight = weights[field] ?? 1;
+    totalWeight += weight;
+    if (isFilled(record[field])) {
+      filled.push(field);
+      filledWeight += weight;
+    } else {
+      missing.push(field);
+    }
+  }
+  const ratio = totalWeight === 0 ? 1 : filledWeight / totalWeight;
+  return {
+    recordKind,
+    score: Math.round(ratio * 100) / 100,
+    filled,
+    missing,
+    // Strict `<`: a name+website account (exactly at the threshold) does not
+    // nag; a name-only prospect (below it) does.
+    belowThreshold: ratio < COMPLETENESS_OFFER_THRESHOLD,
+  };
+}
+
+/**
+ * Score a customer account. Accepts a loose record so callers can pass either a
+ * Prisma row or the create-tool input. `location` is derived from any of
+ * city/region/location fields the caller supplies.
+ */
+export function scoreAccountCompleteness(
+  account: Record<string, unknown> & { location?: unknown; city?: unknown },
+): CompletenessResult {
+  const normalized: Record<string, unknown> = {
+    ...account,
+    location: account["location"] ?? account["city"] ?? account["region"],
+  };
+  return score("customer-account", ACCOUNT_ENRICHABLE_FIELDS, ACCOUNT_WEIGHTS, normalized);
+}
+
+/** Score a customer contact. */
+export function scoreContactCompleteness(
+  contact: Record<string, unknown>,
+): CompletenessResult {
+  return score("customer-contact", CONTACT_ENRICHABLE_FIELDS, CONTACT_WEIGHTS, contact);
+}
+
+export function scoreCompleteness(
+  recordKind: EnrichmentRecordKind,
+  record: Record<string, unknown>,
+): CompletenessResult {
+  return recordKind === "customer-account"
+    ? scoreAccountCompleteness(record)
+    : scoreContactCompleteness(record);
+}

--- a/apps/web/lib/crm/enrichment/enrichment-offer.test.ts
+++ b/apps/web/lib/crm/enrichment/enrichment-offer.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveProactivityPlan } from "@/lib/proactivity/proactivity-resolver";
+import { resolveProactivityPlanForLevel } from "@/lib/proactivity/proactivity-resolver";
+import { buildEnrichmentOffer } from "./enrichment-offer";
+import { scoreAccountCompleteness, scoreContactCompleteness } from "./completeness";
+
+const THIN = scoreAccountCompleteness({ name: "TeamLogic IT" });
+const COMPLETE = scoreAccountCompleteness({
+  name: "TeamLogic IT of Round Rock",
+  website: "https://teamlogicit.com/rrtx",
+  industry: "Managed IT Services",
+  employeeCount: 12,
+  location: "Round Rock, TX",
+  notes: "MSP",
+});
+
+function plan(level: "quiet" | "balanced" | "assertive") {
+  return resolveProactivityPlanForLevel({ activityFamily: "crm-record-enrichment" }, level);
+}
+
+describe("enrichment offer — proactivity binding (AC1/AC8)", () => {
+  it("offers on a thin record at balanced", () => {
+    const offer = buildEnrichmentOffer({
+      recordKind: "customer-account",
+      recordId: "ACCT-1",
+      recordLabel: "TeamLogic IT",
+      completeness: THIN,
+      plan: plan("balanced"),
+    });
+    expect(offer).not.toBeNull();
+    expect(offer?.proposedFields).toContain("industry");
+    expect(offer?.proposedSources).toContain("website");
+    expect(offer?.message).toMatch(/want me to/i);
+  });
+
+  it("is SILENT at quiet (AC1 — silent at quiet, AC8 — level binds)", () => {
+    const offer = buildEnrichmentOffer({
+      recordKind: "customer-account",
+      recordId: "ACCT-1",
+      recordLabel: "TeamLogic IT",
+      completeness: THIN,
+      plan: plan("quiet"),
+    });
+    expect(offer).toBeNull();
+  });
+
+  it("offers more eagerly context still gated — assertive still returns an offer", () => {
+    const offer = buildEnrichmentOffer({
+      recordKind: "customer-account",
+      recordId: "ACCT-1",
+      recordLabel: "TeamLogic IT",
+      completeness: THIN,
+      plan: plan("assertive"),
+    });
+    expect(offer).not.toBeNull();
+  });
+
+  it("never offers on an already-complete record, at any level", () => {
+    for (const level of ["balanced", "assertive"] as const) {
+      const offer = buildEnrichmentOffer({
+        recordKind: "customer-account",
+        recordId: "ACCT-1",
+        recordLabel: "TeamLogic IT of Round Rock",
+        completeness: COMPLETE,
+        plan: plan(level),
+      });
+      expect(offer).toBeNull();
+    }
+  });
+
+  it("a contact offer targets linkedin + web-search (no own website)", () => {
+    const contactThin = scoreContactCompleteness({ firstName: "Greg" });
+    const offer = buildEnrichmentOffer({
+      recordKind: "customer-contact",
+      recordId: "CT-1",
+      recordLabel: "Greg Torosian",
+      completeness: contactThin,
+      plan: plan("balanced"),
+    });
+    expect(offer?.proposedSources).toEqual(["linkedin", "web-search"]);
+  });
+
+  it("the default resolver puts crm-record-enrichment at balanced (offers by default)", () => {
+    const p = resolveProactivityPlan({ activityFamily: "crm-record-enrichment" });
+    expect(p.resolvedLevel).toBe("balanced");
+    expect(p.actionBoundary).toBe("propose");
+  });
+});

--- a/apps/web/lib/crm/enrichment/enrichment-offer.ts
+++ b/apps/web/lib/crm/enrichment/enrichment-offer.ts
@@ -1,0 +1,100 @@
+/**
+ * Proactive enrichment offer (BI-B2497DFB, AC1/AC2/AC8).
+ *
+ * Pure. Given a record's completeness and the resolved proactivity plan,
+ * decides whether to OFFER enrichment and, if so, states which sources + fields
+ * it would touch (the scope the human confirms before any research runs).
+ *
+ * Proactivity binding (AC8): the offer follows the resolved plan end-to-end —
+ *   - quiet (`actionBoundary: "advise"`, maxAttempts 0) → suppressed (null);
+ *   - balanced/assertive → an offer is returned.
+ * A complete record never triggers an offer regardless of level.
+ */
+import type { ProactivityPlan } from "@/lib/proactivity/proactivity-types";
+import { scoreCompleteness } from "./completeness";
+import {
+  ENRICHMENT_SOURCE_KINDS,
+  type CompletenessResult,
+  type EnrichableField,
+  type EnrichmentOffer,
+  type EnrichmentRecordKind,
+  type EnrichmentSourceKind,
+} from "./types";
+
+export type BuildOfferInput = {
+  recordKind: EnrichmentRecordKind;
+  recordId: string;
+  recordLabel: string;
+  completeness: CompletenessResult;
+  plan: ProactivityPlan;
+};
+
+/**
+ * Contacts have no own-website to fetch, so a contact offer defaults to
+ * linkedin + web-search; accounts default to all three (own website + public).
+ */
+function defaultSourcesFor(recordKind: EnrichmentRecordKind): EnrichmentSourceKind[] {
+  if (recordKind === "customer-contact") {
+    return ["linkedin", "web-search"];
+  }
+  return [...ENRICHMENT_SOURCE_KINDS];
+}
+
+export function buildEnrichmentOffer(input: BuildOfferInput): EnrichmentOffer | null {
+  const { recordKind, recordId, recordLabel, completeness, plan } = input;
+
+  // Suppressed at quiet (advise boundary = never volunteers an action) or when
+  // the coworker has explicitly muted this suggestion.
+  if (plan.actionBoundary === "advise" || plan.suggestionSuppressed) {
+    return null;
+  }
+  // Nothing to offer on an already-complete record.
+  if (!completeness.belowThreshold || completeness.missing.length === 0) {
+    return null;
+  }
+
+  const proposedFields: EnrichableField[] = completeness.missing;
+  const proposedSources = defaultSourcesFor(recordKind);
+  const sourceLabel = proposedSources
+    .map((s) => (s === "web-search" ? "web search" : s === "website" ? "their website" : "LinkedIn"))
+    .join(", ");
+  const fieldLabel = proposedFields.join(", ");
+
+  const message =
+    `"${recordLabel}" looks thin (${Math.round(completeness.score * 100)}% complete). ` +
+    `I can research public sources (${sourceLabel}) to fill in ${fieldLabel} — ` +
+    `want me to? I'll cite every source, leave anything I can't verify blank, and show you ` +
+    `the changes before they're saved.`;
+
+  return {
+    recordKind,
+    recordId,
+    message,
+    proposedSources,
+    proposedFields,
+    proactivityLevel: plan.resolvedLevel,
+    policyId: plan.policyId,
+  };
+}
+
+/**
+ * Convenience for the create/import path (AC1): score the just-created record's
+ * intake and build the offer in one step. `intake` is the raw create input or
+ * the new row. Returns null when suppressed or complete.
+ */
+export function buildEnrichmentOfferForIntake(input: {
+  recordKind: EnrichmentRecordKind;
+  recordId: string;
+  recordLabel: string;
+  intake: Record<string, unknown>;
+  plan: ProactivityPlan;
+}): EnrichmentOffer | null {
+  const completeness = scoreCompleteness(input.recordKind, input.intake);
+  return buildEnrichmentOffer({
+    recordKind: input.recordKind,
+    recordId: input.recordId,
+    recordLabel: input.recordLabel,
+    completeness,
+    plan: input.plan,
+  });
+}

--- a/apps/web/lib/crm/enrichment/enrichment-proposal.test.ts
+++ b/apps/web/lib/crm/enrichment/enrichment-proposal.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { buildEnrichmentProposal, type BuildProposalInput } from "./enrichment-proposal";
+import type { EnrichmentFinding, EnrichmentScope } from "./types";
+
+const ACCOUNT_SCOPE: EnrichmentScope = {
+  sources: ["website", "linkedin", "web-search"],
+  fields: ["name", "website", "industry", "employeeCount", "location", "notes"],
+};
+
+function base(findings: EnrichmentFinding[], current: Record<string, unknown> = {}): BuildProposalInput {
+  return {
+    recordKind: "customer-account",
+    recordId: "ACCT-1",
+    current: { name: "TeamLogic IT", ...current },
+    findings,
+    scope: ACCOUNT_SCOPE,
+  };
+}
+
+describe("enrichment proposal builder (AC3/AC5/AC6)", () => {
+  it("builds a scant→enriched diff with per-field provenance (AC3/AC5)", () => {
+    const proposal = buildEnrichmentProposal(
+      base([
+        { field: "industry", value: "Managed IT Services", source: "website", sourceRef: "https://teamlogicit.com" },
+        { field: "location", value: "Round Rock, TX", source: "web-search", sourceRef: "serp:1" },
+      ]),
+    );
+    expect(proposal.changes).toHaveLength(2);
+    const industry = proposal.changes.find((c) => c.field === "industry");
+    expect(industry).toMatchObject({
+      current: null,
+      proposed: "Managed IT Services",
+      source: "website",
+      sourceRef: "https://teamlogicit.com",
+    });
+  });
+
+  it("corrects an incorrect scant field and shows the before value (AC5)", () => {
+    const proposal = buildEnrichmentProposal(
+      base(
+        [{ field: "name", value: "TeamLogic IT of Round Rock", source: "website", sourceRef: "https://teamlogicit.com/rrtx" }],
+        { name: "TeamLogic IT" },
+      ),
+    );
+    const change = proposal.changes.find((c) => c.field === "name");
+    expect(change).toMatchObject({ current: "TeamLogic IT", proposed: "TeamLogic IT of Round Rock" });
+  });
+
+  it("drops a masked value and surfaces it as a confirm-what's-needed gap (AC4/AC6)", () => {
+    const proposal = buildEnrichmentProposal({
+      recordKind: "customer-contact",
+      recordId: "CT-1",
+      current: { firstName: "Greg" },
+      findings: [
+        // masked work email — must be rejected, never written
+        { field: "jobTitle", value: "j***@teamlogicit.com", source: "web-search", sourceRef: "zoominfo" },
+      ],
+      scope: { sources: ["web-search"], fields: ["jobTitle"] },
+    });
+    expect(proposal.changes).toHaveLength(0);
+    expect(proposal.rejected).toHaveLength(1);
+    expect(proposal.unresolvedGaps.some((g) => g.field === "jobTitle")).toBe(true);
+  });
+
+  it("enforces scope: findings outside confirmed sources/fields are ignored (AC2)", () => {
+    const proposal = buildEnrichmentProposal({
+      recordKind: "customer-account",
+      recordId: "ACCT-1",
+      current: {},
+      findings: [
+        { field: "industry", value: "MSP", source: "linkedin", sourceRef: "li:1" }, // source not in scope
+        { field: "website", value: "https://x.com", source: "website", sourceRef: "w:1" }, // field not in scope
+      ],
+      scope: { sources: ["website"], fields: ["industry"] },
+    });
+    expect(proposal.changes).toHaveLength(0);
+  });
+
+  it("treats a finding equal to the current value as a no-op", () => {
+    const proposal = buildEnrichmentProposal(
+      base([{ field: "name", value: "teamlogic it", source: "website", sourceRef: "w" }], { name: "TeamLogic IT" }),
+    );
+    expect(proposal.changes.find((c) => c.field === "name")).toBeUndefined();
+  });
+
+  it("picks the highest-confidence finding when a field has several", () => {
+    const proposal = buildEnrichmentProposal(
+      base([
+        { field: "industry", value: "IT", source: "web-search", sourceRef: "a", confidence: 0.4 },
+        { field: "industry", value: "Managed IT Services", source: "website", sourceRef: "b", confidence: 0.9 },
+      ]),
+    );
+    expect(proposal.changes.find((c) => c.field === "industry")?.proposed).toBe("Managed IT Services");
+  });
+
+  it("does not raise a gap for a field that already had a value", () => {
+    const proposal = buildEnrichmentProposal(
+      base([], { name: "TeamLogic IT", website: "https://teamlogicit.com" }),
+    );
+    expect(proposal.unresolvedGaps.some((g) => g.field === "website")).toBe(false);
+  });
+});

--- a/apps/web/lib/crm/enrichment/enrichment-proposal.ts
+++ b/apps/web/lib/crm/enrichment/enrichment-proposal.ts
@@ -1,0 +1,119 @@
+/**
+ * Enrichment proposal builder (BI-B2497DFB, AC3/AC5/AC6).
+ *
+ * Pure. Turns researched findings into a governed proposal:
+ *   - drops findings outside the human-confirmed scope (AC2 enforcement here);
+ *   - routes every in-scope finding through the no-fabrication guard, moving
+ *     rejects to `rejected` (never written) — AC4;
+ *   - computes the scant→enriched diff (current → proposed) — AC5;
+ *   - surfaces requested fields that no source could verify as
+ *     `unresolvedGaps` — the confirm-what's-needed loop (AC6).
+ *
+ * No field is written here; this only shapes the proposal. The service layer
+ * files it to the steward queue and (on approval) applies it with provenance.
+ */
+import { evaluateMaterializability } from "./no-fabrication";
+import {
+  type EnrichableField,
+  type EnrichmentFieldChange,
+  type EnrichmentFinding,
+  type EnrichmentGap,
+  type EnrichmentProposal,
+  type EnrichmentRecordKind,
+  type EnrichmentScope,
+  enrichableFieldsFor,
+} from "./types";
+
+export type BuildProposalInput = {
+  recordKind: EnrichmentRecordKind;
+  recordId: string;
+  /** Current record values (Prisma row or equivalent). */
+  current: Record<string, unknown>;
+  findings: EnrichmentFinding[];
+  scope: EnrichmentScope;
+};
+
+function currentString(current: Record<string, unknown>, field: EnrichableField): string | null {
+  const value = current[field];
+  if (value === null || value === undefined) return null;
+  const str = String(value).trim();
+  return str.length > 0 ? str : null;
+}
+
+function sameValue(a: string | null, b: string): boolean {
+  if (a === null) return false;
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/**
+ * Build the proposal. Multiple findings for one field are resolved by highest
+ * confidence, then first-seen; a finding equal to the current value is a no-op
+ * (not a change). A scoped field left with no materializable value becomes a
+ * gap only when the record is currently empty for it.
+ */
+export function buildEnrichmentProposal(input: BuildProposalInput): EnrichmentProposal {
+  const { recordKind, recordId, current, scope } = input;
+  const allowedFields = new Set<EnrichableField>(
+    scope.fields.filter((f) => (enrichableFieldsFor(recordKind) as readonly string[]).includes(f)),
+  );
+  const allowedSources = new Set(scope.sources);
+
+  const rejected: EnrichmentProposal["rejected"] = [];
+  // field -> best candidate finding
+  const bestByField = new Map<EnrichableField, EnrichmentFinding>();
+
+  for (const finding of input.findings) {
+    if (!allowedFields.has(finding.field)) continue; // out of confirmed field scope
+    if (!allowedSources.has(finding.source)) continue; // out of confirmed source scope
+
+    const verdict = evaluateMaterializability(finding.field, finding.value);
+    if (!verdict.materializable) {
+      rejected.push({ field: finding.field, value: finding.value, reason: verdict.reason });
+      continue;
+    }
+
+    const incumbent = bestByField.get(finding.field);
+    if (!incumbent) {
+      bestByField.set(finding.field, finding);
+      continue;
+    }
+    const incumbentConf = incumbent.confidence ?? 0;
+    const challengerConf = finding.confidence ?? 0;
+    if (challengerConf > incumbentConf) {
+      bestByField.set(finding.field, finding);
+    }
+  }
+
+  const changes: EnrichmentFieldChange[] = [];
+  for (const [field, finding] of bestByField) {
+    const current_ = currentString(current, field);
+    if (sameValue(current_, finding.value)) continue; // no-op, already correct
+    changes.push({
+      field,
+      current: current_,
+      proposed: finding.value.trim(),
+      source: finding.source,
+      sourceRef: finding.sourceRef,
+    });
+  }
+  changes.sort((a, b) => a.field.localeCompare(b.field));
+
+  // Confirm-what's-needed: a scoped field that is currently empty and got no
+  // materializable value. Fields that were rejected as masked/partial are the
+  // canonical case (the worked example's masked work email).
+  const unresolvedGaps: EnrichmentGap[] = [];
+  for (const field of allowedFields) {
+    if (bestByField.has(field)) continue; // filled by a change
+    if (currentString(current, field) !== null) continue; // already had a value
+    const wasRejected = rejected.find((r) => r.field === field);
+    unresolvedGaps.push({
+      field,
+      reason: wasRejected
+        ? `only a masked/partial value was public (${wasRejected.reason}) — left blank; please confirm`
+        : "no public source verified this — left blank; please confirm",
+    });
+  }
+  unresolvedGaps.sort((a, b) => a.field.localeCompare(b.field));
+
+  return { recordKind, recordId, changes, unresolvedGaps, rejected, scope };
+}

--- a/apps/web/lib/crm/enrichment/enrichment-service.test.ts
+++ b/apps/web/lib/crm/enrichment/enrichment-service.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    mdmStewardTask: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    customerAccount: { findUnique: vi.fn(), update: vi.fn() },
+    customerContact: { findUnique: vi.fn(), update: vi.fn() },
+    activity: { create: vi.fn() },
+    $transaction: vi.fn((ops: unknown[]) => Promise.all(ops)),
+  },
+}));
+
+vi.mock("@/lib/mdm/crosswalk", () => ({
+  registerCustomerAccountSource: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { prisma } from "@dpf/db";
+import { registerCustomerAccountSource } from "@/lib/mdm/crosswalk";
+import {
+  applyEnrichmentProposal,
+  fileEnrichmentProposal,
+  ENRICHMENT_RESOLUTION,
+  ENRICHMENT_TASK_KIND,
+} from "./enrichment-service";
+import type { EnrichmentProposal } from "./types";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(prisma.mdmStewardTask.findUnique).mockResolvedValue(null as never);
+  vi.mocked(prisma.mdmStewardTask.create).mockResolvedValue({} as never);
+  vi.mocked(prisma.mdmStewardTask.update).mockResolvedValue({} as never);
+  vi.mocked(prisma.customerAccount.update).mockResolvedValue({} as never);
+  vi.mocked(prisma.customerAccount.findUnique).mockResolvedValue({ notes: null } as never);
+  vi.mocked(prisma.customerContact.update).mockResolvedValue({} as never);
+  vi.mocked(prisma.customerContact.findUnique).mockResolvedValue({ accountId: "ACCT-1" } as never);
+  vi.mocked(prisma.activity.create).mockResolvedValue({} as never);
+});
+
+const PROPOSAL: EnrichmentProposal = {
+  recordKind: "customer-account",
+  recordId: "ACCT-1",
+  changes: [
+    { field: "industry", current: null, proposed: "Managed IT Services", source: "website", sourceRef: "https://teamlogicit.com" },
+    { field: "employeeCount", current: null, proposed: "12 employees", source: "web-search", sourceRef: "serp:1" },
+    { field: "location", current: null, proposed: "Round Rock, TX", source: "web-search", sourceRef: "serp:2" },
+  ],
+  unresolvedGaps: [{ field: "notes", reason: "left blank; please confirm" }],
+  rejected: [],
+  scope: { sources: ["website", "web-search"], fields: ["industry", "employeeCount", "location", "notes"] },
+};
+
+describe("fileEnrichmentProposal (AC7 — propose-to-queue, no direct write)", () => {
+  it("creates an open enrichment steward task and writes nothing to the record", async () => {
+    const taskId = await fileEnrichmentProposal(PROPOSAL, {
+      proactivity: { level: "balanced", policyId: "proactivity:crm-record-enrichment:balanced" },
+    });
+    expect(taskId).toMatch(/^STEW-/);
+    expect(prisma.mdmStewardTask.create).toHaveBeenCalledOnce();
+    const arg = vi.mocked(prisma.mdmStewardTask.create).mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(arg.data["kind"]).toBe(ENRICHMENT_TASK_KIND);
+    expect(arg.data["domain"]).toBe("customer-account");
+    // No record write happened at file time.
+    expect(prisma.customerAccount.update).not.toHaveBeenCalled();
+  });
+
+  it("returns null when there is nothing to propose", async () => {
+    const empty = { ...PROPOSAL, changes: [], unresolvedGaps: [] };
+    expect(await fileEnrichmentProposal(empty)).toBeNull();
+    expect(prisma.mdmStewardTask.create).not.toHaveBeenCalled();
+  });
+
+  it("refreshes an existing open task instead of duplicating", async () => {
+    vi.mocked(prisma.mdmStewardTask.findUnique).mockResolvedValue({ id: "row1", taskId: "STEW-OLD" } as never);
+    const taskId = await fileEnrichmentProposal(PROPOSAL);
+    expect(taskId).toBe("STEW-OLD");
+    expect(prisma.mdmStewardTask.update).toHaveBeenCalledOnce();
+    expect(prisma.mdmStewardTask.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("applyEnrichmentProposal (AC5/AC7 — governed write, provenance, diff)", () => {
+  function openTask(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "row1",
+      taskId: "STEW-1",
+      kind: ENRICHMENT_TASK_KIND,
+      domain: "customer-account",
+      subjectId: "ACCT-1",
+      status: "open",
+      reasons: { changes: PROPOSAL.changes, unresolvedGaps: PROPOSAL.unresolvedGaps, scope: PROPOSAL.scope },
+      ...overrides,
+    };
+  }
+
+  it("writes scalar columns, folds columnless fields into notes, registers provenance, resolves the task", async () => {
+    vi.mocked(prisma.mdmStewardTask.findUnique).mockResolvedValue(openTask() as never);
+    const res = await applyEnrichmentProposal("STEW-1", { resolvedBy: "user-1" });
+    expect(res.ok).toBe(true);
+
+    const update = vi.mocked(prisma.customerAccount.update).mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(update.data["industry"]).toBe("Managed IT Services");
+    expect(update.data["employeeCount"]).toBe(12); // "12 employees" → 12
+    expect(update.data["sourceSystem"]).toBe("coworker-tool");
+    // location has no column → annotated into notes
+    expect(String(update.data["notes"])).toMatch(/location: Round Rock, TX/);
+
+    expect(registerCustomerAccountSource).toHaveBeenCalledOnce();
+    // Diff recorded on the timeline (AC5).
+    expect(prisma.activity.create).toHaveBeenCalledOnce();
+    // Task resolved (AC7).
+    const taskUpdate = vi.mocked(prisma.mdmStewardTask.update).mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(taskUpdate.data["status"]).toBe(ENRICHMENT_RESOLUTION);
+  });
+
+  it("refuses a non-open task", async () => {
+    vi.mocked(prisma.mdmStewardTask.findUnique).mockResolvedValue(openTask({ status: "resolved_enriched" }) as never);
+    const res = await applyEnrichmentProposal("STEW-1", { resolvedBy: null });
+    expect(res.ok).toBe(false);
+    expect(prisma.customerAccount.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses a non-enrichment task kind", async () => {
+    vi.mocked(prisma.mdmStewardTask.findUnique).mockResolvedValue(openTask({ kind: "duplicate" }) as never);
+    const res = await applyEnrichmentProposal("STEW-1", { resolvedBy: null });
+    expect(res.ok).toBe(false);
+  });
+
+  it("errors clearly for an unknown task", async () => {
+    vi.mocked(prisma.mdmStewardTask.findUnique).mockResolvedValue(null as never);
+    const res = await applyEnrichmentProposal("STEW-x", { resolvedBy: null });
+    expect(res.ok).toBe(false);
+  });
+
+  it("REGRESSION: an employeeCount RANGE is not mangled into the Int column (HIGH-1)", async () => {
+    vi.mocked(prisma.mdmStewardTask.findUnique).mockResolvedValue(
+      openTask({
+        reasons: {
+          changes: [
+            { field: "employeeCount", current: null, proposed: "11-50 employees", source: "linkedin", sourceRef: "li" },
+          ],
+          unresolvedGaps: [],
+          scope: { sources: ["linkedin"], fields: ["employeeCount"] },
+        },
+      }) as never,
+    );
+    const res = await applyEnrichmentProposal("STEW-1", { resolvedBy: "u" });
+    expect(res.ok).toBe(true);
+    const update = vi.mocked(prisma.customerAccount.update).mock.calls[0]![0] as { data: Record<string, unknown> };
+    // Must NOT write 1150 (the digit-strip bug) — the range is kept as a note.
+    expect(update.data["employeeCount"]).toBeUndefined();
+    expect(String(update.data["notes"])).toMatch(/employeeCount: 11-50 employees/);
+  });
+
+  it("writes the timeline activity as system-generated (createdById null, FK-safe)", async () => {
+    vi.mocked(prisma.mdmStewardTask.findUnique).mockResolvedValue(openTask() as never);
+    await applyEnrichmentProposal("STEW-1", { resolvedBy: "agent-not-a-user" });
+    const activity = vi.mocked(prisma.activity.create).mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(activity.data["createdById"]).toBeNull();
+  });
+
+  it("REGRESSION: applying to a contact does NOT clobber its original source (HIGH-2)", async () => {
+    vi.mocked(prisma.mdmStewardTask.findUnique).mockResolvedValue(
+      openTask({
+        domain: "customer-contact",
+        subjectId: "CT-1",
+        reasons: {
+          changes: [{ field: "jobTitle", current: null, proposed: "Owner & President", source: "linkedin", sourceRef: "li" }],
+          unresolvedGaps: [],
+          scope: { sources: ["linkedin"], fields: ["jobTitle"] },
+        },
+      }) as never,
+    );
+    const res = await applyEnrichmentProposal("STEW-1", { resolvedBy: "u" });
+    expect(res.ok).toBe(true);
+    const update = vi.mocked(prisma.customerContact.update).mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(update.data["jobTitle"]).toBe("Owner & President");
+    expect("source" in update.data).toBe(false); // original provenance preserved
+  });
+});

--- a/apps/web/lib/crm/enrichment/enrichment-service.ts
+++ b/apps/web/lib/crm/enrichment/enrichment-service.ts
@@ -1,0 +1,367 @@
+/**
+ * Enrichment service — the governed write path (BI-B2497DFB, AC5/AC7).
+ *
+ * The pure builders (completeness/offer/proposal/no-fabrication) never touch
+ * the DB. This module is the thin prisma layer:
+ *   - `loadRecordForEnrichment` reads current field values for proposal-building;
+ *   - `fileEnrichmentProposal` files the proposal to the steward queue
+ *     (`MdmStewardTask` kind `enrichment`) — nothing written to the record yet,
+ *     preserving the platform invariant (propose-to-queue, human/authority
+ *     applies);
+ *   - `applyEnrichmentProposal` writes the accepted fields WITH provenance
+ *     (`registerCustomerAccountSource` / the record's `source`), records the
+ *     scant→enriched diff on the account timeline, and resolves the task.
+ *
+ * `applyEnrichmentProposal` is surfaced only through the `crm_write`-granted
+ * `apply_crm_enrichment` tool, so it routes through `governedExecuteTool`
+ * (user-cap → grant → coworker authority → audit) — the consequential-write
+ * gate, per EP-1C37C089's existing enforcement path.
+ */
+import * as crypto from "crypto";
+import { prisma } from "@dpf/db";
+import { registerCustomerAccountSource } from "@/lib/mdm/crosswalk";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+import {
+  type EnrichableField,
+  type EnrichmentProposal,
+  type EnrichmentRecordKind,
+  type EnrichmentTaskReasons,
+} from "./types";
+
+export const ENRICHMENT_TASK_KIND = "enrichment";
+export const ENRICHMENT_RESOLUTION = "resolved_enriched";
+
+/**
+ * Fields written to a real scalar column. Anything enrichable but not listed
+ * here (e.g. `location`) is folded into a provenance-tagged `notes` annotation
+ * rather than dropped, so a researched-but-columnless fact still lands.
+ */
+const ACCOUNT_SCALAR_COLUMNS: Partial<Record<EnrichableField, "string" | "int">> = {
+  name: "string",
+  website: "string",
+  industry: "string",
+  employeeCount: "int",
+};
+const CONTACT_SCALAR_COLUMNS: Partial<Record<EnrichableField, "string" | "int">> = {
+  firstName: "string",
+  lastName: "string",
+  jobTitle: "string",
+  phone: "string",
+  linkedinUrl: "string",
+};
+
+function newTaskId(): string {
+  return `STEW-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
+}
+
+export type LoadedRecord = {
+  recordKind: EnrichmentRecordKind;
+  recordId: string;
+  label: string;
+  /** account id for timeline attribution (self for accounts, parent for contacts). */
+  accountId: string | null;
+  current: Record<string, unknown>;
+};
+
+/** Load current field values for proposal-building. Returns null if not found. */
+export async function loadRecordForEnrichment(
+  recordKind: EnrichmentRecordKind,
+  recordId: string,
+): Promise<LoadedRecord | null> {
+  if (recordKind === "customer-account") {
+    const acct = await prisma.customerAccount.findUnique({
+      where: { id: recordId },
+      select: {
+        id: true,
+        name: true,
+        website: true,
+        industry: true,
+        employeeCount: true,
+        notes: true,
+        status: true,
+      },
+    });
+    if (!acct || acct.status === "superseded") return null;
+    return {
+      recordKind,
+      recordId,
+      label: acct.name,
+      accountId: acct.id,
+      current: {
+        name: acct.name,
+        website: acct.website,
+        industry: acct.industry,
+        employeeCount: acct.employeeCount,
+        notes: acct.notes,
+      },
+    };
+  }
+  const contact = await prisma.customerContact.findUnique({
+    where: { id: recordId },
+    select: {
+      id: true,
+      accountId: true,
+      name: true,
+      firstName: true,
+      lastName: true,
+      jobTitle: true,
+      phone: true,
+      linkedinUrl: true,
+      email: true,
+      mergedIntoId: true,
+    },
+  });
+  if (!contact || contact.mergedIntoId) return null;
+  const composedName = [contact.firstName, contact.lastName].filter(Boolean).join(" ");
+  return {
+    recordKind,
+    recordId,
+    label: contact.name || composedName || contact.email,
+    accountId: contact.accountId,
+    current: {
+      firstName: contact.firstName,
+      lastName: contact.lastName,
+      jobTitle: contact.jobTitle,
+      phone: contact.phone,
+      linkedinUrl: contact.linkedinUrl,
+    },
+  };
+}
+
+/**
+ * File the proposal to the steward queue as an open `enrichment` task
+ * (idempotent per record — re-proposing refreshes the open task). Returns the
+ * task id, or null if there is nothing to propose (no changes and no gaps).
+ */
+export async function fileEnrichmentProposal(
+  proposal: EnrichmentProposal,
+  meta?: { proactivity?: { level: string; policyId: string } },
+): Promise<string | null> {
+  if (proposal.changes.length === 0 && proposal.unresolvedGaps.length === 0) {
+    return null;
+  }
+  const reasons: EnrichmentTaskReasons = {
+    changes: proposal.changes,
+    unresolvedGaps: proposal.unresolvedGaps,
+    scope: proposal.scope,
+    ...(meta?.proactivity ? { proactivity: meta.proactivity } : {}),
+  };
+  const note =
+    `Enrichment: ${proposal.changes.length} proposed change(s), ` +
+    `${proposal.unresolvedGaps.length} unverified gap(s). Apply with apply_crm_enrichment ` +
+    `or from /admin/data-stewardship — nothing written yet.`;
+
+  const existing = await prisma.mdmStewardTask.findUnique({
+    where: {
+      domain_kind_subjectId_candidateId: {
+        domain: proposal.recordKind,
+        kind: ENRICHMENT_TASK_KIND,
+        subjectId: proposal.recordId,
+        candidateId: "",
+      },
+    },
+  });
+  if (existing) {
+    await prisma.mdmStewardTask.update({
+      where: { id: existing.id },
+      data: { reasons: reasons as unknown as object, note, status: "open" },
+    });
+    return existing.taskId;
+  }
+  const taskId = newTaskId();
+  await prisma.mdmStewardTask.create({
+    data: {
+      taskId,
+      domain: proposal.recordKind,
+      kind: ENRICHMENT_TASK_KIND,
+      subjectId: proposal.recordId,
+      candidateId: "",
+      reasons: reasons as unknown as object,
+      note,
+    },
+  });
+  return taskId;
+}
+
+/**
+ * Parse a value into a single integer for an Int column. Accepts a lone number
+ * with optional thousands separators and a trailing word ("12", "1,200",
+ * "12 employees"). REJECTS ranges/buckets ("11-50", "50–100", "1,001-5,000")
+ * — digit-stripping those produces a fabricated headcount ("11-50" → 1150), so
+ * the caller keeps the researched value as a text note instead of writing junk
+ * to the column. Returns null when the value is not a single clean integer.
+ */
+function parseSingleInt(value: string): number | null {
+  const trimmed = value.trim();
+  // A range/bucket (two number groups joined by a dash/"to") is not a single int.
+  if (/\d[\s]*(?:[-–—]|to)[\s]*\d/.test(trimmed)) return null;
+  const match = trimmed.replace(/,/g, "").match(/\d+/g);
+  if (!match || match.length !== 1) return null;
+  const n = Number.parseInt(match[0]!, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+export type ApplyResult = {
+  taskId: string;
+  recordKind: EnrichmentRecordKind;
+  recordId: string;
+  applied: Array<{ field: EnrichableField; value: string; source: string; sourceRef: string }>;
+  annotatedToNotes: EnrichableField[];
+};
+
+/**
+ * Apply an open enrichment task: write the accepted fields, register provenance,
+ * record the diff on the timeline, resolve the task. Governed by the caller's
+ * `crm_write` grant (via `governedExecuteTool`).
+ */
+export async function applyEnrichmentProposal(
+  taskId: string,
+  opts: { resolvedBy: string | null },
+): Promise<{ ok: true; result: ApplyResult } | { ok: false; message: string }> {
+  const task = await prisma.mdmStewardTask.findUnique({ where: { taskId } });
+  if (!task) return { ok: false, message: `No steward task ${taskId}.` };
+  if (task.kind !== ENRICHMENT_TASK_KIND) {
+    return { ok: false, message: `${taskId} is a ${task.kind} task, not an enrichment proposal.` };
+  }
+  if (task.status !== "open") return { ok: false, message: `${taskId} is already ${task.status}.` };
+
+  const reasons = (task.reasons ?? {}) as EnrichmentTaskReasons;
+  const changes = Array.isArray(reasons.changes) ? reasons.changes : [];
+  if (changes.length === 0) {
+    return { ok: false, message: `${taskId} has no proposed changes to apply.` };
+  }
+  const recordKind = task.domain as EnrichmentRecordKind;
+  const scalarMap = recordKind === "customer-account" ? ACCOUNT_SCALAR_COLUMNS : CONTACT_SCALAR_COLUMNS;
+
+  const columnData: Record<string, string | number> = {};
+  const noteAnnotations: string[] = [];
+  const annotatedToNotes: EnrichableField[] = [];
+  const applied: ApplyResult["applied"] = [];
+
+  for (const change of changes) {
+    // Defensive: a malformed persisted task could carry a non-string value.
+    if (typeof change.proposed !== "string" || change.proposed.trim().length === 0) continue;
+    const columnKind = scalarMap[change.field];
+    let toNote = false;
+    if (columnKind === "string") {
+      columnData[change.field] = change.proposed.trim();
+    } else if (columnKind === "int") {
+      const parsed = parseSingleInt(change.proposed);
+      if (parsed !== null) {
+        columnData[change.field] = parsed;
+      } else {
+        // A range/bucket ("11-50 employees") — keep the researched value as a
+        // text note rather than fabricating a precise integer for the column.
+        toNote = true;
+      }
+    } else {
+      toNote = true; // no scalar column (e.g. location)
+    }
+    if (toNote) {
+      noteAnnotations.push(`${change.field}: ${change.proposed.trim()} [${change.source}: ${change.sourceRef}]`);
+      annotatedToNotes.push(change.field);
+    }
+    applied.push({
+      field: change.field,
+      value: change.proposed.trim(),
+      source: change.source,
+      sourceRef: change.sourceRef,
+    });
+  }
+
+  if (applied.length === 0) {
+    return { ok: false, message: `${taskId}: no applicable field values after validation.` };
+  }
+
+  try {
+    // Reads first (outside the write transaction): current notes for the
+    // append-merge, and the account id for the timeline attribution.
+    let accountId: string | null = null;
+    let recordUpdate: unknown;
+    if (recordKind === "customer-account") {
+      const existing = await prisma.customerAccount.findUnique({
+        where: { id: task.subjectId },
+        select: { notes: true },
+      });
+      const notes = mergeNotes(existing?.notes ?? null, noteAnnotations);
+      accountId = task.subjectId;
+      recordUpdate = prisma.customerAccount.update({
+        where: { id: task.subjectId },
+        data: {
+          ...columnData,
+          ...(notes !== null ? { notes } : {}),
+          sourceSystem: "coworker-tool",
+        },
+      });
+    } else {
+      accountId =
+        (await prisma.customerContact.findUnique({
+          where: { id: task.subjectId },
+          select: { accountId: true },
+        }))?.accountId ?? null;
+      // Do NOT clobber the contact's original `source` (web/referral/import);
+      // enrichment provenance is carried by the timeline activity + the diff.
+      recordUpdate = prisma.customerContact.update({
+        where: { id: task.subjectId },
+        data: { ...columnData },
+      });
+    }
+
+    // Diff on the account timeline (AC5 — visible scant→enriched record).
+    // `createdById` stays null (system-generated): the acting MCP identity may
+    // be a coworker/agent id, not a real User row, and Activity.createdById FKs
+    // to User — a bad id would throw here after the record was already written.
+    const body = applied.map((a) => `${a.field} ← "${a.value}" (${a.source}: ${a.sourceRef})`).join("\n");
+    const writes: unknown[] = [recordUpdate];
+    if (accountId) {
+      writes.push(
+        prisma.activity.create({
+          data: {
+            activityId: `ACT-${crypto.randomUUID()}`,
+            type: "system",
+            subject: `Record enriched from public sources (${applied.length} field(s))`,
+            body,
+            accountId,
+            contactId: recordKind === "customer-contact" ? task.subjectId : null,
+            createdById: null,
+          },
+        }),
+      );
+    }
+    writes.push(
+      prisma.mdmStewardTask.update({
+        where: { id: task.id },
+        data: { status: ENRICHMENT_RESOLUTION, resolvedBy: opts.resolvedBy, resolvedAt: new Date() },
+      }),
+    );
+
+    // Atomic: record write + timeline + task resolution land together, so a
+    // failure cannot leave the record mutated while the task stays re-appliable.
+    await prisma.$transaction(writes as never);
+
+    // Provenance crosswalk is best-effort (own try/catch inside) and must never
+    // fail the applied write, so it runs after the transaction commits.
+    if (recordKind === "customer-account") {
+      await registerCustomerAccountSource({
+        accountId: task.subjectId,
+        sourceSystem: "coworker-tool",
+        sourceEntityId: `enrichment:${taskId}`,
+        sourceEntityType: "enrichment-proposal",
+      });
+    }
+  } catch (err) {
+    return { ok: false, message: `Enrichment apply failed: ${getErrorMessage(err)}` };
+  }
+
+  return {
+    ok: true,
+    result: { taskId, recordKind, recordId: task.subjectId, applied, annotatedToNotes },
+  };
+}
+
+/** Append provenance annotations to notes without clobbering existing content. */
+function mergeNotes(existing: string | null, annotations: string[]): string | null {
+  if (annotations.length === 0) return null;
+  const block = annotations.join("\n");
+  return existing && existing.trim().length > 0 ? `${existing.trim()}\n${block}` : block;
+}

--- a/apps/web/lib/crm/enrichment/no-fabrication.test.ts
+++ b/apps/web/lib/crm/enrichment/no-fabrication.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateMaterializability, isMaterializableValue } from "./no-fabrication";
+
+describe("no-fabrication guard (AC4)", () => {
+  it("REGRESSION: a masked email pattern must NOT be materialized", () => {
+    // The worked example: only `g***@teamlogicit.com` was public. It must be
+    // rejected and left blank — never synthesized into a real address.
+    const verdict = evaluateMaterializability("email", "g***@teamlogicit.com");
+    expect(verdict.materializable).toBe(false);
+    expect(isMaterializableValue("email", "g***@teamlogicit.com")).toBe(false);
+  });
+
+  it("rejects other masked identity values", () => {
+    expect(isMaterializableValue("phone", "(512) ***-1234")).toBe(false);
+    expect(isMaterializableValue("phone", "512-xxx-1234")).toBe(false);
+    expect(isMaterializableValue("firstName", "J•••")).toBe(false);
+  });
+
+  it("rejects placeholders and empties", () => {
+    for (const v of ["", "  ", "N/A", "unknown", "not found", "redacted", "-", "todo", "greg@example.com"]) {
+      expect(isMaterializableValue("jobTitle", v)).toBe(false);
+    }
+  });
+
+  it("accepts complete, real values", () => {
+    expect(isMaterializableValue("email", "greg@teamlogicit.com")).toBe(true);
+    expect(isMaterializableValue("phone", "(512) 555-1234")).toBe(true);
+    expect(isMaterializableValue("firstName", "Greg")).toBe(true);
+    expect(isMaterializableValue("jobTitle", "Owner & President")).toBe(true);
+    expect(isMaterializableValue("industry", "Managed IT Services")).toBe(true);
+    expect(isMaterializableValue("linkedinUrl", "https://linkedin.com/in/greg-t")).toBe(true);
+  });
+
+  it("rejects an incomplete email even if unmasked", () => {
+    expect(isMaterializableValue("email", "greg@teamlogicit")).toBe(false);
+    expect(isMaterializableValue("email", "just-a-name")).toBe(false);
+  });
+
+  it("rejects a phone stub with too few real digits", () => {
+    expect(isMaterializableValue("phone", "512")).toBe(false);
+  });
+
+  it("does NOT reject a bulleted notes value (bullet not adjacent to alnum)", () => {
+    expect(isMaterializableValue("notes", "• MSP • north Austin metro")).toBe(true);
+    expect(isMaterializableValue("industry", "IT · Managed Services")).toBe(true);
+  });
+
+  it("does NOT reject a real surname that collides with a placeholder token", () => {
+    expect(isMaterializableValue("lastName", "Na")).toBe(true);
+    expect(isMaterializableValue("lastName", "None")).toBe(true);
+    // but a non-name field still rejects the placeholder token
+    expect(isMaterializableValue("industry", "unknown")).toBe(false);
+  });
+
+  it("catches non-ASCII mask glyphs adjacent to text", () => {
+    expect(isMaterializableValue("email", "greg●●●@teamlogicit.com")).toBe(false);
+  });
+});

--- a/apps/web/lib/crm/enrichment/no-fabrication.ts
+++ b/apps/web/lib/crm/enrichment/no-fabrication.ts
@@ -1,0 +1,122 @@
+/**
+ * No-fabrication invariant (BI-B2497DFB, AC4).
+ *
+ * The load-bearing safety rule: enrichment NEVER synthesizes an identity value.
+ * If a source only exposes a masked/partial value (a public directory showing
+ * `g***@teamlogicit.com`, a `(512) ***-1234` phone), the coworker must leave the
+ * field blank and surface it as a confirm-what's-needed gap — it must NOT
+ * materialize the masked pattern into a real-looking value. This guard is the
+ * single decision point; the proposal builder routes every finding through it,
+ * and the regression test (masked email MUST NOT be materialized) pins it.
+ */
+import type { EnrichableField } from "./types";
+
+export type MaterializabilityVerdict =
+  | { materializable: true }
+  | { materializable: false; reason: string };
+
+/**
+ * A run of 2+ mask glyphs (`*`, `•`, `●`, `∗`, `＊`, `#`) or a standalone `xxx`
+ * mask word. Kept to runs so ordinary punctuation does not trip it.
+ */
+const MASK_RUN = /[*•●∗＊#]{2,}|(?:\bx{3,}\b)/i;
+/**
+ * A mask glyph adjacent to an alphanumeric (e.g. `g***@`, `j.d***`) — the
+ * partial-identity case. Adjacency (not bare presence) so a bulleted `notes`
+ * value like "• MSP • Austin" is not misread as masked.
+ */
+const EMBEDDED_MASK = /[A-Za-z0-9][*•●∗＊]|[*•●∗＊][A-Za-z0-9]/;
+
+/** Name fields where common surnames collide with placeholder tokens ("Na"). */
+const NAME_FIELDS = new Set(["firstName", "lastName", "name"]);
+
+const PLACEHOLDER_TOKENS = [
+  "n/a",
+  "na",
+  "none",
+  "unknown",
+  "not found",
+  "notfound",
+  "not available",
+  "redacted",
+  "tbd",
+  "todo",
+  "null",
+  "undefined",
+  "-",
+  "—",
+  "example.com",
+  "test@test.com",
+  "no email",
+  "no phone",
+];
+
+function looksMasked(value: string): boolean {
+  return MASK_RUN.test(value) || EMBEDDED_MASK.test(value);
+}
+
+function isPlaceholder(value: string): boolean {
+  const lowered = value.trim().toLowerCase();
+  if (PLACEHOLDER_TOKENS.includes(lowered)) return true;
+  // Placeholder emails / domains commonly used to signal "unknown".
+  if (/@(?:example|test|placeholder)\.(?:com|org|net)$/i.test(lowered)) return true;
+  return false;
+}
+
+function digitsOnly(value: string): string {
+  return value.replace(/\D+/g, "");
+}
+
+/**
+ * Decide whether a researched value may be written to a field. Rejects empty,
+ * placeholder, and masked/partial values. Field-specific checks: emails must be
+ * a full unmasked address; phones must carry enough real digits to be a number,
+ * not a masked stub.
+ */
+export function evaluateMaterializability(
+  field: EnrichableField | "email" | (string & {}),
+  rawValue: string,
+): MaterializabilityVerdict {
+  const value = (rawValue ?? "").trim();
+  if (value.length === 0) {
+    return { materializable: false, reason: "empty" };
+  }
+  // Name fields skip the placeholder-token list: real surnames ("Na", "None")
+  // collide with it. Empty/masked are still caught above/below.
+  if (!NAME_FIELDS.has(field) && isPlaceholder(value)) {
+    return { materializable: false, reason: "placeholder value, not a real datum" };
+  }
+  if (looksMasked(value)) {
+    return {
+      materializable: false,
+      reason: "masked/partial value — the source hid part of it; never synthesize the rest",
+    };
+  }
+
+  // Field-specific identity guards.
+  if (/email/i.test(field)) {
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+      return { materializable: false, reason: "not a complete, unmasked email address" };
+    }
+  }
+  if (field === "phone") {
+    if (digitsOnly(value).length < 7) {
+      return { materializable: false, reason: "too few real digits to be a phone number" };
+    }
+  }
+  if (field === "linkedinUrl" || field === "website") {
+    if (!/[a-z0-9]/i.test(value)) {
+      return { materializable: false, reason: "no usable url content" };
+    }
+  }
+
+  return { materializable: true };
+}
+
+/** Convenience boolean for callers that only need the verdict. */
+export function isMaterializableValue(
+  field: EnrichableField | "email" | (string & {}),
+  value: string,
+): boolean {
+  return evaluateMaterializability(field, value).materializable;
+}

--- a/apps/web/lib/crm/enrichment/types.ts
+++ b/apps/web/lib/crm/enrichment/types.ts
@@ -1,0 +1,144 @@
+/**
+ * Proactive, permissioned CRM enrichment — shared types (BI-B2497DFB).
+ *
+ * When a prospect/account/contact is created with scant detail, the coworker
+ * offers (permission + scope confirmed) to enrich it from public sources, then
+ * writes the augmented fields back WITH provenance and WITHOUT fabrication.
+ * These types are the contract the deterministic core (completeness → offer →
+ * proposal → apply) shares with the MCP tool layer.
+ */
+
+/** The record kinds enrichment understands. */
+export type EnrichmentRecordKind = "customer-account" | "customer-contact";
+
+/**
+ * Public sources the coworker may research. `website` is the record's own
+ * stored site (fetched by the platform, inside the egress boundary); the other
+ * two are gathered by the coworker via its granted web-research tools.
+ */
+export type EnrichmentSourceKind = "website" | "linkedin" | "web-search";
+
+export const ENRICHMENT_SOURCE_KINDS: readonly EnrichmentSourceKind[] = [
+  "website",
+  "linkedin",
+  "web-search",
+] as const;
+
+/**
+ * Enrichable fields, per record kind. Deliberately a closed set — the coworker
+ * can only propose values for fields the platform knows how to store, and each
+ * carries provenance. Values are strings as written to the record.
+ */
+export const ACCOUNT_ENRICHABLE_FIELDS = [
+  "name",
+  "website",
+  "industry",
+  "employeeCount",
+  "location",
+  "notes",
+] as const;
+
+export const CONTACT_ENRICHABLE_FIELDS = [
+  "firstName",
+  "lastName",
+  "jobTitle",
+  "phone",
+  "linkedinUrl",
+] as const;
+
+export type AccountEnrichableField = (typeof ACCOUNT_ENRICHABLE_FIELDS)[number];
+export type ContactEnrichableField = (typeof CONTACT_ENRICHABLE_FIELDS)[number];
+export type EnrichableField = AccountEnrichableField | ContactEnrichableField;
+
+/**
+ * A single researched fact the coworker proposes to write. `value` is the raw
+ * researched value; the no-fabrication guard decides whether it is
+ * materializable. `sourceRef` is the citation (URL or search result id).
+ */
+export type EnrichmentFinding = {
+  field: EnrichableField;
+  value: string;
+  source: EnrichmentSourceKind;
+  sourceRef: string;
+  /** 0..1 self-reported confidence; informational, not a gate. */
+  confidence?: number;
+};
+
+/**
+ * The human-confirmed scope of an enrichment run: which sources may be
+ * consulted and which fields may be touched. A finding outside the scope is
+ * dropped (AC2 — no research/write beyond what the human confirmed).
+ */
+export type EnrichmentScope = {
+  sources: EnrichmentSourceKind[];
+  fields: EnrichableField[];
+};
+
+/** Result of scoring how complete a record is. */
+export type CompletenessResult = {
+  recordKind: EnrichmentRecordKind;
+  /** 0..1 — filled weighted fields over total weighted fields. */
+  score: number;
+  filled: EnrichableField[];
+  missing: EnrichableField[];
+  /** True when the record is thin enough to warrant an enrichment offer. */
+  belowThreshold: boolean;
+};
+
+/**
+ * The proactive offer surfaced to the human. `null` offer = suppressed (quiet
+ * proactivity or an already-complete record). Names the sources + fields so the
+ * human can confirm scope before any research runs.
+ */
+export type EnrichmentOffer = {
+  recordKind: EnrichmentRecordKind;
+  recordId: string;
+  /** Human-facing one-liner: "I can enrich this from public sources — want me to?" */
+  message: string;
+  proposedSources: EnrichmentSourceKind[];
+  proposedFields: EnrichableField[];
+  proactivityLevel: string;
+  policyId: string;
+};
+
+/** One field the proposal will change, with before/after and provenance. */
+export type EnrichmentFieldChange = {
+  field: EnrichableField;
+  current: string | null;
+  proposed: string;
+  source: EnrichmentSourceKind;
+  sourceRef: string;
+};
+
+/** A field the human asked to fill that could not be verified from any source. */
+export type EnrichmentGap = {
+  field: EnrichableField;
+  reason: string;
+};
+
+/**
+ * The built enrichment proposal: the scant→enriched diff (changes), the
+ * confirm-what's-needed gaps, and the findings that were rejected as
+ * non-materializable (kept for transparency/audit, never written).
+ */
+export type EnrichmentProposal = {
+  recordKind: EnrichmentRecordKind;
+  recordId: string;
+  changes: EnrichmentFieldChange[];
+  unresolvedGaps: EnrichmentGap[];
+  /** Findings dropped by the no-fabrication guard (field + why). */
+  rejected: Array<{ field: EnrichableField; value: string; reason: string }>;
+  scope: EnrichmentScope;
+};
+
+/** Structured `reasons` payload persisted on the enrichment MdmStewardTask. */
+export type EnrichmentTaskReasons = {
+  changes: EnrichmentFieldChange[];
+  unresolvedGaps: EnrichmentGap[];
+  scope: EnrichmentScope;
+  proactivity?: { level: string; policyId: string };
+};
+
+export function enrichableFieldsFor(kind: EnrichmentRecordKind): readonly EnrichableField[] {
+  return kind === "customer-account" ? ACCOUNT_ENRICHABLE_FIELDS : CONTACT_ENRICHABLE_FIELDS;
+}

--- a/apps/web/lib/mcp/pack-registry.ts
+++ b/apps/web/lib/mcp/pack-registry.ts
@@ -42,6 +42,7 @@ import { coworkerGoalPack } from "./packs/coworker-goal-pack";
 import { subagentFanoutPack } from "./packs/subagent-fanout-pack";
 import { mdmStewardshipPack } from "./packs/mdm-stewardship-pack";
 import { crmContactsPack } from "./packs/crm-contacts-pack";
+import { crmEnrichmentPack } from "./packs/crm-enrichment-pack";
 import { storefrontActivityPack } from "./packs/storefront-activity-pack";
 import { stockCoveragePack } from "./packs/stock-coverage-pack";
 import { queueAwarenessPack } from "./packs/queue-awareness-pack";
@@ -127,6 +128,7 @@ export const TOOL_PACK_REGISTRY = composeToolPacks([
   subagentFanoutPack,
   mdmStewardshipPack,
   crmContactsPack,
+  crmEnrichmentPack,
   storefrontActivityPack,
   stockCoveragePack,
   queueAwarenessPack,

--- a/apps/web/lib/mcp/packs/crm-contacts-pack.ts
+++ b/apps/web/lib/mcp/packs/crm-contacts-pack.ts
@@ -37,8 +37,41 @@ const definitions: ToolDefinition[] = [
   },
 ];
 
+/** Proactive enrichment offer on thin contact intake (BI-B2497DFB, AC1). */
+async function buildCreatedContactEnrichmentOffer(
+  contact: { id: string; name: string | null; email: string },
+  params: Record<string, unknown>,
+  context?: { agentId?: string | null; routeContext?: string | null },
+) {
+  try {
+    const { buildEnrichmentOfferForIntake } = await import("@/lib/crm/enrichment/enrichment-offer");
+    const { resolveProactivityPlan } = await import("@/lib/proactivity/proactivity-resolver");
+    const plan = resolveProactivityPlan({
+      activityFamily: "crm-record-enrichment",
+      agentId: context?.agentId ?? null,
+      routeContext: context?.routeContext ?? null,
+    });
+    return buildEnrichmentOfferForIntake({
+      recordKind: "customer-contact",
+      recordId: contact.id,
+      recordLabel: contact.name ?? contact.email,
+      intake: {
+        firstName: params["firstName"],
+        lastName: params["lastName"],
+        jobTitle: params["jobTitle"],
+        phone: params["phone"],
+      },
+      plan,
+    });
+  } catch {
+    return null;
+  }
+}
+
 async function createCustomerContactTool(
   params: Record<string, unknown>,
+  _userId?: string,
+  context?: { agentId?: string | null; routeContext?: string | null },
 ): Promise<ToolResult> {
   const { createCustomerContact } = await import("@/lib/actions/customer-contacts");
   const str = (k: string) => (typeof params[k] === "string" ? (params[k] as string) : undefined);
@@ -75,13 +108,22 @@ async function createCustomerContactTool(
   }
 
   const c = result.contact;
+  const enrichmentOffer =
+    result.outcome === "existing" ? null : await buildCreatedContactEnrichmentOffer(c, params, context);
+  const offerMsg = enrichmentOffer ? ` ${enrichmentOffer.message}` : "";
   return {
     success: true,
     message:
       result.outcome === "existing"
         ? `Contact already exists: ${c.name ?? c.email} (${c.email}).`
-        : `Created contact ${c.name ?? c.email} (${c.email}).`,
-    data: { id: c.id, email: c.email, name: c.name, outcome: result.outcome },
+        : `Created contact ${c.name ?? c.email} (${c.email}).${offerMsg}`,
+    data: {
+      id: c.id,
+      email: c.email,
+      name: c.name,
+      outcome: result.outcome,
+      ...(enrichmentOffer ? { enrichmentOffer } : {}),
+    },
   };
 }
 

--- a/apps/web/lib/mcp/packs/crm-enrichment-pack.ts
+++ b/apps/web/lib/mcp/packs/crm-enrichment-pack.ts
@@ -1,0 +1,231 @@
+// Proactive CRM enrichment tool pack (BI-B2497DFB).
+//
+// Two governed doors on top of the deterministic core in lib/crm/enrichment:
+//   - propose_crm_enrichment: after the human confirms scope, the coworker
+//     hands the facts it researched (via its granted web tools) to this tool,
+//     which drops fabrications, computes the scant→enriched diff, and FILES the
+//     proposal to the steward queue — nothing is written to the record yet.
+//   - apply_crm_enrichment: writes an approved proposal to the record WITH
+//     provenance and records the diff — the consequential write, gated by
+//     crm_write through governedExecuteTool.
+//
+// The split keeps the platform invariant: research/propose is non-destructive;
+// the record change is a separate, approved, governed step.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack, ToolPackHandler } from "../tool-pack";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+import {
+  ENRICHMENT_SOURCE_KINDS,
+  enrichableFieldsFor,
+  type EnrichableField,
+  type EnrichmentFinding,
+  type EnrichmentRecordKind,
+  type EnrichmentScope,
+  type EnrichmentSourceKind,
+} from "@/lib/crm/enrichment/types";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "propose_crm_enrichment",
+    description:
+      "File a proactive enrichment proposal for a thin customer account or contact. Call this AFTER the human has agreed to enrichment and confirmed scope (which sources, which fields). Pass the facts you researched from public sources (each with its source + citation) as `findings`; the tool drops anything masked/partial/placeholder (never fabricates), computes the before→after diff, cites every field, and files the proposal to the data-steward queue. Nothing is written to the record here — apply it with apply_crm_enrichment after the human reviews the diff. Unverifiable fields are returned as gaps to confirm.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        recordKind: {
+          type: "string",
+          enum: ["customer-account", "customer-contact"],
+          description: "Which record is being enriched. Defaults to customer-account.",
+        },
+        recordId: { type: "string", description: "CustomerAccount.id or CustomerContact.id." },
+        scope: {
+          type: "object",
+          description: "The human-confirmed scope: which public sources and which fields you may touch.",
+          properties: {
+            sources: {
+              type: "array",
+              items: { type: "string", enum: ["website", "linkedin", "web-search"] },
+            },
+            fields: { type: "array", items: { type: "string" } },
+          },
+          required: ["sources", "fields"],
+        },
+        findings: {
+          type: "array",
+          description: "Researched facts to propose. Each: field, value, source (website|linkedin|web-search), sourceRef (URL/citation), optional confidence 0..1.",
+          items: {
+            type: "object",
+            properties: {
+              field: { type: "string" },
+              value: { type: "string" },
+              source: { type: "string", enum: ["website", "linkedin", "web-search"] },
+              sourceRef: { type: "string" },
+              confidence: { type: "number" },
+            },
+            required: ["field", "value", "source", "sourceRef"],
+          },
+        },
+      },
+      required: ["recordId", "scope", "findings"],
+    },
+    requiredCapability: "operate_customer",
+    sideEffect: true,
+  },
+  {
+    name: "apply_crm_enrichment",
+    description:
+      "Apply an enrichment proposal filed by propose_crm_enrichment: write the accepted fields to the customer record WITH provenance, record the before→after diff on the account timeline, and resolve the steward task. This is the consequential write — call it only after the human has reviewed the proposed diff. Pass the steward task id (STEW-…) returned by propose_crm_enrichment.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        taskId: { type: "string", description: "The enrichment steward task id (STEW-…) to apply." },
+      },
+      required: ["taskId"],
+    },
+    requiredCapability: "operate_customer",
+    sideEffect: true,
+  },
+];
+
+function parseScope(raw: unknown, recordKind: EnrichmentRecordKind): EnrichmentScope | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const validSources = new Set<string>(ENRICHMENT_SOURCE_KINDS);
+  const validFields = new Set<string>(enrichableFieldsFor(recordKind));
+  const sources = Array.isArray(obj["sources"])
+    ? (obj["sources"].filter((s) => typeof s === "string" && validSources.has(s)) as EnrichmentSourceKind[])
+    : [];
+  const fields = Array.isArray(obj["fields"])
+    ? (obj["fields"].filter((f) => typeof f === "string" && validFields.has(f)) as EnrichableField[])
+    : [];
+  if (sources.length === 0 || fields.length === 0) return null;
+  return { sources, fields };
+}
+
+function parseFindings(raw: unknown): EnrichmentFinding[] {
+  if (!Array.isArray(raw)) return [];
+  const validSources = new Set<string>(ENRICHMENT_SOURCE_KINDS);
+  const out: EnrichmentFinding[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const o = item as Record<string, unknown>;
+    const field = typeof o["field"] === "string" ? o["field"] : "";
+    const value = typeof o["value"] === "string" ? o["value"] : "";
+    const source = typeof o["source"] === "string" ? o["source"] : "";
+    const sourceRef = typeof o["sourceRef"] === "string" ? o["sourceRef"] : "";
+    if (!field || !value || !validSources.has(source) || !sourceRef) continue;
+    out.push({
+      field: field as EnrichableField,
+      value,
+      source: source as EnrichmentSourceKind,
+      sourceRef,
+      ...(typeof o["confidence"] === "number" ? { confidence: o["confidence"] } : {}),
+    });
+  }
+  return out;
+}
+
+const proposeCrmEnrichmentTool: ToolPackHandler = async (params, _userId, context) => {
+  const recordKind: EnrichmentRecordKind =
+    params["recordKind"] === "customer-contact" ? "customer-contact" : "customer-account";
+  const recordId = typeof params["recordId"] === "string" ? params["recordId"].trim() : "";
+  if (!recordId) {
+    return { success: false, error: "missing_fields", message: "recordId is required." };
+  }
+  const scope = parseScope(params["scope"], recordKind);
+  if (!scope) {
+    return {
+      success: false,
+      error: "missing_scope",
+      message: "scope.sources and scope.fields are required (the human-confirmed enrichment scope). Confirm scope before researching.",
+    };
+  }
+  const findings = parseFindings(params["findings"]);
+
+  const { loadRecordForEnrichment, fileEnrichmentProposal } = await import("@/lib/crm/enrichment/enrichment-service");
+  const { buildEnrichmentProposal } = await import("@/lib/crm/enrichment/enrichment-proposal");
+  const { resolveProactivityPlan } = await import("@/lib/proactivity/proactivity-resolver");
+
+  const record = await loadRecordForEnrichment(recordKind, recordId);
+  if (!record) {
+    return { success: false, error: "record_not_found", message: `No ${recordKind} ${recordId}.` };
+  }
+
+  const proposal = buildEnrichmentProposal({
+    recordKind,
+    recordId,
+    current: record.current,
+    findings,
+    scope,
+  });
+
+  const plan = resolveProactivityPlan({
+    activityFamily: "crm-record-enrichment",
+    agentId: context?.agentId ?? null,
+    routeContext: context?.routeContext ?? null,
+  });
+
+  try {
+    const taskId = await fileEnrichmentProposal(proposal, {
+      proactivity: { level: plan.resolvedLevel, policyId: plan.policyId },
+    });
+    const diff = proposal.changes.map((c) => `${c.field}: ${c.current ?? "∅"} → "${c.proposed}" (${c.source})`).join("; ");
+    const gaps = proposal.unresolvedGaps.map((g) => g.field).join(", ");
+    if (!taskId) {
+      return {
+        success: true,
+        message: `Nothing to propose for "${record.label}" — no new verifiable values.${gaps ? ` Still unverified: ${gaps}.` : ""}`,
+        data: { proposal, taskId: null },
+      };
+    }
+    return {
+      success: true,
+      message:
+        `Filed enrichment proposal ${taskId} for "${record.label}": ${proposal.changes.length} change(s)` +
+        `${diff ? ` [${diff}]` : ""}` +
+        `${proposal.rejected.length ? `; dropped ${proposal.rejected.length} unverifiable/masked value(s)` : ""}` +
+        `${gaps ? `; confirm-what's-needed: ${gaps}` : ""}. ` +
+        `Review the diff, then apply with apply_crm_enrichment taskId "${taskId}" — nothing written yet.`,
+      data: { proposal, taskId },
+    };
+  } catch (err) {
+    return { success: false, error: "propose_failed", message: `propose_crm_enrichment failed: ${getErrorMessage(err)}` };
+  }
+};
+
+const applyCrmEnrichmentTool: ToolPackHandler = async (params, userId) => {
+  const taskId = typeof params["taskId"] === "string" ? params["taskId"].trim() : "";
+  if (!taskId) {
+    return { success: false, error: "missing_fields", message: "taskId is required (STEW-… from propose_crm_enrichment)." };
+  }
+  const { applyEnrichmentProposal } = await import("@/lib/crm/enrichment/enrichment-service");
+  const result = await applyEnrichmentProposal(taskId, { resolvedBy: userId || null });
+  if (!result.ok) {
+    return { success: false, error: "apply_failed", message: result.message };
+  }
+  const applied = result.result.applied
+    .map((a) => `${a.field}="${a.value}" (${a.source}: ${a.sourceRef})`)
+    .join("; ");
+  return {
+    success: true,
+    message: `Applied enrichment ${taskId} to ${result.result.recordKind} ${result.result.recordId}: ${applied}. Provenance recorded; diff on the account timeline.`,
+    data: result.result,
+  };
+};
+
+export const crmEnrichmentPack: ToolPack = {
+  packId: "crm-enrichment",
+  definitions,
+  handlers: {
+    propose_crm_enrichment: proposeCrmEnrichmentTool,
+    apply_crm_enrichment: applyCrmEnrichmentTool,
+  },
+  grants: {
+    // Mirrors agent-grants.ts TOOL_TO_GRANTS (the gating source): proposing is
+    // web-research stewardship inside the CRM-read envelope; applying is the
+    // consequential CRM write.
+    propose_crm_enrichment: ["web_search", "crm_read"],
+    apply_crm_enrichment: ["crm_write"],
+  },
+};

--- a/apps/web/lib/mcp/packs/crm-sales-pipeline-pack.ts
+++ b/apps/web/lib/mcp/packs/crm-sales-pipeline-pack.ts
@@ -257,7 +257,46 @@ async function listQuotesTool(params: Record<string, unknown>): Promise<ToolResu
   return { success: true, message: `${quotes.length} quote(s):\n${lines.join("\n")}`, data: { quotes } };
 }
 
-async function createCustomerAccountTool(params: Record<string, unknown>): Promise<ToolResult> {
+/**
+ * Proactive enrichment offer on thin account intake (BI-B2497DFB, AC1). Pure +
+ * proactivity-bound: silent at quiet, offers at balanced/assertive. Never
+ * throws — an offer is a nicety, not part of the create contract.
+ */
+async function buildCreatedAccountEnrichmentOffer(
+  account: { id: string; name: string },
+  params: Record<string, unknown>,
+  context?: { agentId?: string | null; routeContext?: string | null },
+) {
+  try {
+    const { buildEnrichmentOfferForIntake } = await import("@/lib/crm/enrichment/enrichment-offer");
+    const { resolveProactivityPlan } = await import("@/lib/proactivity/proactivity-resolver");
+    const plan = resolveProactivityPlan({
+      activityFamily: "crm-record-enrichment",
+      agentId: context?.agentId ?? null,
+      routeContext: context?.routeContext ?? null,
+    });
+    return buildEnrichmentOfferForIntake({
+      recordKind: "customer-account",
+      recordId: account.id,
+      recordLabel: account.name,
+      intake: {
+        name: account.name,
+        website: params["website"],
+        industry: params["industry"],
+        notes: params["notes"],
+      },
+      plan,
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function createCustomerAccountTool(
+  params: Record<string, unknown>,
+  _userId?: string,
+  context?: { agentId?: string | null; routeContext?: string | null },
+): Promise<ToolResult> {
   const name = typeof params["name"] === "string" ? params["name"].trim() : "";
   if (!name) return { success: false, error: "missing_name", message: "name is required to create a customer account." };
   const { createCustomerAccount } = await import("@/lib/actions/crm");
@@ -299,7 +338,9 @@ async function createCustomerAccountTool(params: Record<string, unknown>): Promi
     if (result.outcome === "existing") {
       return { success: true, message: `Reused existing customer account "${account.name}" (${account.accountId}) instead of creating a duplicate. Use its id ${account.id} as accountId downstream.`, data: { accountId: account.id, accountRef: account.accountId, reusedExisting: true } };
     }
-    return { success: true, message: `Created customer account "${account.name}" (${account.accountId}). Use its id ${account.id} as accountId when creating an opportunity.`, data: { accountId: account.id, accountRef: account.accountId } };
+    const enrichmentOffer = await buildCreatedAccountEnrichmentOffer(account, params, context);
+    const offerMsg = enrichmentOffer ? ` ${enrichmentOffer.message}` : "";
+    return { success: true, message: `Created customer account "${account.name}" (${account.accountId}). Use its id ${account.id} as accountId when creating an opportunity.${offerMsg}`, data: { accountId: account.id, accountRef: account.accountId, ...(enrichmentOffer ? { enrichmentOffer } : {}) } };
   } catch (err) {
     const msg = getErrorMessage(err);
     return { success: false, error: "create_failed", message: `create_customer_account failed: ${msg}` };

--- a/apps/web/lib/mdm/steward.ts
+++ b/apps/web/lib/mdm/steward.ts
@@ -18,11 +18,12 @@ import * as crypto from "crypto";
 import { scanCustomerAccountDuplicates, scanCustomerContactDuplicates } from "./batch-scan";
 import { loadMatchConfig } from "./match-config";
 
-export type StewardTaskKind = "duplicate" | "stale";
+export type StewardTaskKind = "duplicate" | "stale" | "enrichment";
 export type StewardResolution =
   | "resolved_merged"
   | "resolved_distinct"
   | "resolved_refreshed"
+  | "resolved_enriched"
   | "dismissed";
 
 export type SweepSummary = {

--- a/apps/web/lib/proactivity/proactivity-resolver.ts
+++ b/apps/web/lib/proactivity/proactivity-resolver.ts
@@ -159,6 +159,13 @@ function explanationFor(input: ProactivityResolverInput, level: ProactivityLevel
     return "A compliance deadline is close enough to justify assertive reminders while keeping advice and filing approval-gated.";
   }
 
+  if (input.activityFamily === "crm-record-enrichment") {
+    if (level === "quiet") {
+      return "Quiet: store the record as entered and never volunteer enrichment — the human asks if they want it.";
+    }
+    return "A thin CRM record can be strengthened from public sources; offer to enrich (permission + scope confirmed) while the write stays governed and non-fabricating.";
+  }
+
   if (level === "balanced") {
     return "Balanced is the default proactivity level for useful follow-up without noisy repeated interruption.";
   }

--- a/apps/web/lib/proactivity/proactivity-types.ts
+++ b/apps/web/lib/proactivity/proactivity-types.ts
@@ -16,6 +16,10 @@ export const PROACTIVITY_ACTIVITY_FAMILIES = [
   // EP-3516E23D: queue backpressure — a scarce-resource queue backing up past
   // its thresholds warrants a more assertive nudge to whoever manages it.
   "queue-health",
+  // BI-B2497DFB: thin prospect/account/contact intake — the coworker offers to
+  // enrich from public sources (permission + scope confirmed). Cadence only;
+  // the write still routes through the governed apply step.
+  "crm-record-enrichment",
 ] as const;
 export type ProactivityActivityFamily = (typeof PROACTIVITY_ACTIVITY_FAMILIES)[number];
 

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -612,6 +612,10 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   list_mdm_steward_tasks: ["crm_read"],
   enrich_customer_account: ["web_search"],
   run_data_steward: ["crm_write"],
+  // Proactive CRM enrichment (BI-B2497DFB): propose is web-research stewardship
+  // inside the CRM-read envelope; apply is the consequential CRM write.
+  propose_crm_enrichment: ["web_search", "crm_read"],
+  apply_crm_enrichment: ["crm_write"],
 
   // Security Operations / SIEM (EP-SOVEREIGN-SOC). Writes are propose-only +
   // coworkerArtifact; siem_investigate/siem_tune/incident_respond imply siem_read.

--- a/docs/superpowers/plans/2026-08-14-proactive-crm-enrichment-plan.md
+++ b/docs/superpowers/plans/2026-08-14-proactive-crm-enrichment-plan.md
@@ -1,0 +1,109 @@
+# Plan — Proactive, permissioned CRM enrichment
+
+Date: 2026-08-14. BI: BI-B2497DFB. Composes with BI-6D10EB1F (CI/market-research),
+BI-2D435AFC (v1 own-website enrichment), EP-1C37C089 (consequential-tool governance gate).
+
+## Why
+
+When a new prospect/account/contact is created with scant detail, the coworker should not
+silently store the thin record (nor fabricate). It should recognize the gaps, proactively
+OFFER to enrich from public sources, ASK permission + CONFIRM scope, research, and write the
+augmented fields back **with provenance and no fabrication** — the proactivity setting made
+concrete for the CRM intake path. The owner demonstrated the behavior by hand
+(Greg Torosian → TeamLogic IT of Round Rock, account `ACCT-F6AF3F95`); the build must
+reproduce it natively.
+
+## Substrate this builds on (verified 2026-08-14)
+
+- **Enrichment v1** — `apps/web/lib/mdm/enrichment.ts` `proposeAccountEnrichment` fetches the
+  account's OWN stored website and files an `MdmStewardTask`; the load-bearing invariant is
+  **propose-to-steward-queue, never direct-write; a human applies**. Surfaced as MCP
+  `enrich_customer_account` (grant `web_search`). Gap: resolving a stale task only touches
+  `updatedAt` — **no path writes suggested values back to the record**. This plan adds that
+  apply-with-provenance-and-diff.
+- **Proactivity** — `apps/web/lib/proactivity/`: `resolveProactivityPlan({activityFamily})`
+  → `ProactivityPlan{ actionBoundary, maxAttempts, suggestionSuppressed, … }`. Levels are
+  `quiet | balanced | assertive` (the BI's "proactive" = `assertive`). `quiet` →
+  `actionBoundary:"advise"`, `maxAttempts:0` = silent. Read per turn via
+  `getCoworkerProactivityPreference(agentId)`.
+- **CRM** — `CustomerAccount` / `CustomerContact` (`packages/db/prisma/schema.prisma`).
+  Provenance via `registerCustomerAccountSource({sourceSystem:"coworker-tool"})`
+  (`apps/web/lib/mdm/crosswalk.ts`) → `MasterDataSourceRef`.
+- **Governance** — every consequential write routes through `governedExecuteTool`
+  (`apps/web/lib/mcp-governed-execute.ts`): user-cap → agent-grant → coworker authority
+  (allow / deny / require-approval envelope) → audit/receipt. EP-1C37C089 is the future
+  unifier (spec only, unmerged); `governedExecuteTool` is today's enforcement path.
+- **Web research** — public-web-design pack: `search_public_web`, `fetch_public_website`,
+  `analyze_public_website_branding` (grant `web_search`, `requiresExternalAccess`). These are
+  the coworker's multi-source research surface; each records `recordExternalEvidence`.
+- **Steward queue** — `MdmStewardTask` (kind is a free String; code comments already
+  anticipate a single-record `enrichment` kind). No new Prisma model → no migration cascade.
+
+## Scope (one PR)
+
+New module `apps/web/lib/crm/enrichment/` (deterministic, DB-free cores + thin service):
+
+1. `types.ts` — `EnrichmentField`, `EnrichmentFinding{field,value,source,sourceRef,confidence}`,
+   `EnrichmentSourceKind` (`website|linkedin|web-search`), `CompletenessResult`,
+   `EnrichmentScope{sources,fields}`, `EnrichmentOffer`, `EnrichmentProposal`.
+2. `completeness.ts` — `scoreAccountCompleteness` / `scoreContactCompleteness` →
+   `{score, filled, missing, belowThreshold}` with a threshold constant. **(AC1, AC5 basis)**
+3. `no-fabrication.ts` — `isMaterializableValue(field,value)`: rejects masked/placeholder
+   values (email `g***@…`, `x***`, `redacted`, empty). The AC4 heart. **(AC4)**
+4. `enrichment-proposal.ts` — pure `buildEnrichmentProposal({record, findings, scope,
+   proactivity})`: drop findings failing the no-fab guard, keep only findings inside the
+   confirmed scope, compute the scant→enriched diff, attach per-field provenance, split
+   remaining requested-but-unfound fields into `unresolvedGaps` (confirm-what's-needed).
+   **(AC3, AC5, AC6)**
+5. `enrichment-offer.ts` — `buildEnrichmentOffer({recordKind, completeness, plan})` →
+   `EnrichmentOffer | null`; returns `null` (suppressed) when the plan is `advise`/quiet or the
+   record is complete; names the sources + fields it would touch. **(AC1, AC2, AC8)**
+6. `enrichment-service.ts` — prisma: `fileEnrichmentProposal` (upsert `MdmStewardTask`
+   kind `enrichment`, structured `reasons`), and `applyEnrichmentProposal(taskId, {resolvedBy})`
+   which writes accepted fields to the record, registers provenance
+   (`sourceSystem:"coworker-tool"`), records the diff on the account activity timeline, and
+   resolves the task `resolved_enriched`. **(AC5, AC7)**
+
+Wiring:
+
+7. `proactivity-types.ts` + `proactivity-resolver.ts` — add `crm-record-enrichment` family
+   (balanced default; explanation). **(AC8)**
+8. `apps/web/lib/mdm/steward.ts` — `StewardTaskKind` += `enrichment`; `StewardResolution`
+   += `resolved_enriched`.
+9. New pack `apps/web/lib/mcp/packs/crm-enrichment-pack.ts`: `propose_crm_enrichment`
+   (grant `web_search`,`crm_read`; fetches own website + accepts coworker-gathered findings
+   for linkedin/web-search, builds + files the governed proposal, returns the diff +
+   confirm-gaps) and `apply_crm_enrichment` (grant `crm_write`; applies an approved proposal).
+   Register in `pack-registry.ts`; add `TOOL_TO_GRANTS` entries in `agent-grants.ts`. **(AC2, AC7)**
+10. `crm-sales-pipeline-pack.ts` / `crm-contacts-pack.ts` — additive `enrichmentOffer` in the
+    create-tool success `data` so the coworker sees the offer immediately post-create. **(AC1)**
+
+## Acceptance-criteria → artifact map
+
+- AC1 gap detection / silent-at-quiet → `completeness.ts` + `enrichment-offer.ts` + create-handler offer.
+- AC2 permission + scope confirm → `EnrichmentScope`; `propose_crm_enrichment` only touches
+  scoped sources/fields; write requires the separate approved `apply_crm_enrichment`.
+- AC3 multi-source + provenance → `EnrichmentFinding.source/sourceRef`; own-website fetch +
+  coworker web-research findings; `registerCustomerAccountSource`.
+- AC4 no-fabrication → `no-fabrication.ts` + masked-email regression test.
+- AC5 intake correction + visible diff → proposal diff + steward task `reasons` + apply timeline note.
+- AC6 confirm-what's-needed → `unresolvedGaps` surfaced in tool result + steward task.
+- AC7 governed write-back → `apply_crm_enrichment` routes through `governedExecuteTool` (crm_write);
+  provenance audited.
+- AC8 proactivity binding → `crm-record-enrichment` family; offer eagerness follows the level end-to-end.
+
+## Non-goals
+
+- Live crawling of LinkedIn/search inside the tool: the coworker gathers findings with its
+  granted `search_public_web`/`fetch_public_website` tools and hands structured findings to
+  `propose_crm_enrichment`; the tool owns the governed write, not the crawl.
+- New admin UI apply button (apply is exposed as the governed MCP tool for this slice).
+- The EP-1C37C089 unified constitutional gate (separate epic); this routes through the
+  existing `governedExecuteTool` authority path.
+
+## Verification
+
+Unit tests per module (completeness, no-fabrication incl. masked-email regression, proposal
+builder, offer suppression by proactivity level, service apply with mocked prisma) + proactivity
+resolver family test. `tsc` + vitest green on touched files; local merged-CI gate before push;
+DCO PR against origin/main.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -54,7 +54,7 @@ apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1621
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	914
-apps/web/lib/tak/agent-grants.ts	935
+apps/web/lib/tak/agent-grants.ts	939
 apps/web/lib/tak/agent-routing.ts	1053
 apps/web/lib/tak/agentic-loop.test.ts	2501
 apps/web/lib/tak/agentic-loop.ts	2811

--- a/scripts/tool-surface-baseline.json
+++ b/scripts/tool-surface-baseline.json
@@ -3,14 +3,14 @@
   "selectionCliff": 15,
   "entries": {
     "registry.toolDefinitions": {
-      "value": 376,
-      "reason": "Adds invite_room_participant and get_coworker_room_engagement (EP-WORKROOM-COMMS). invite_room_participant is the on-demand membership WRITER — a governed action that admits a coworker or person into a room (Coordinator/action-rights gated), the write side no existing tool provides. get_coworker_room_engagement is the 360 coworker-utilization read — which active rooms a coworker is engaged in and its role — a per-coworker inversion of the room projection that no existing roster tool exposes. Both are distinct contracts within the room-messaging surface.",
-      "recordedAt": "2026-08-13"
+      "value": 378,
+      "reason": "Adds propose_crm_enrichment and apply_crm_enrichment (BI-B2497DFB) — the two governed doors of proactive CRM enrichment (raise from the 376 that already includes EP-WORKROOM-COMMS's room tools). They are distinct contracts: propose is a non-destructive, scope-confirmed web-research stewardship step (grants web_search+crm_read) that files a steward proposal with the scant→enriched diff and no fabricated values; apply is the separate consequential CRM write (grant crm_write) that materializes an approved proposal with provenance. No existing tool carries either: enrich_customer_account is single-source own-website-only and files-but-never-applies, and the merge/steward tools resolve duplicates, not gap-fill enrichment.",
+      "recordedAt": "2026-08-14"
     },
     "registry.packFiles": {
-      "value": 90,
-      "reason": "Adds one focused room-messaging pack so the two Work Room communication tools, their work_room_read/work_room_write grants, and the outcome-scoped admission contract stay one bounded MCP surface. Reusing the work-capsules pack would conflate coding-carrier lifecycle with generic cross-work-type room messaging and blur the per-room agent-admission boundary. EP-WORKROOM-COMMS.",
-      "recordedAt": "2026-08-13"
+      "value": 91,
+      "reason": "Adds one focused crm-enrichment pack (BI-B2497DFB) so the propose/apply pair, their web_search/crm_read/crm_write grants, and the propose-vs-apply governance boundary stay one bounded MCP surface. Folding into mdm-stewardship (duplicate resolution) or crm-sales-pipeline (deal/quote lifecycle) would blur the distinct proactive-enrichment contract and its two-step permission model.",
+      "recordedAt": "2026-08-14"
     },
     "tier.coreToolNames": {
       "value": 30,


### PR DESCRIPTION
## What & why (BI-B2497DFB)

When a prospect/account/contact is created with **scant** detail, the coworker should not silently store the thin record (nor fabricate). It now recognizes the gaps, proactively **offers** to enrich from public sources (respecting the proactivity level — **silent at quiet**), **asks permission + confirms scope**, researches, and writes the augmented fields back **with provenance** and **without fabrication**. This reproduces natively the behavior the owner demonstrated by hand (Greg Torosian → *TeamLogic IT of Round Rock*).

It extends the enrichment v1 substrate (`mdm/enrichment.ts` — the **propose-to-steward-queue, never direct-write** invariant) into a proactivity-bound, multi-source, scope-confirmed pipeline, and adds the previously-missing **apply-with-provenance-and-diff** write-back (today, resolving a stale enrichment task only touched `updatedAt`).

## Design grounding

Plan: `docs/superpowers/plans/2026-08-14-proactive-crm-enrichment-plan.md` (coverage receipt recorded, atomic). Extends `apps/web/lib/mdm/enrichment.ts` + the `apps/web/lib/proactivity` substrate; reuses `MdmStewardTask` (new `enrichment` kind — **no new Prisma model, no migration**). The consequential write routes through the existing `governedExecuteTool` authority path; the EP-1C37C089 unified constitutional gate stays a separate epic.

## Acceptance criteria → artifact

| AC | Where |
|----|-------|
| AC1 gap detection / silent-at-quiet | `crm/enrichment/completeness.ts`, `enrichment-offer.ts`, create-handler offer |
| AC2 permission + scope confirm | `EnrichmentScope`; `propose_crm_enrichment` drops out-of-scope sources/fields; write is a separate approved `apply_crm_enrichment` |
| AC3 multi-source + provenance | `EnrichmentFinding.source/sourceRef`; `registerCustomerAccountSource(sourceSystem: coworker-tool)` |
| AC4 no-fabrication | `crm/enrichment/no-fabrication.ts` + masked-email regression test |
| AC5 intake correction + visible diff | proposal diff + steward `reasons` + apply timeline note |
| AC6 confirm-what's-needed | `unresolvedGaps` in tool result + steward task |
| AC7 governed write-back | `apply_crm_enrichment` (crm_write) via `governedExecuteTool`; provenance audited |
| AC8 proactivity binding | `crm-record-enrichment` activity family; offer eagerness follows the level |

## Verification

- 39 new unit tests (completeness incl. name+website no-nag, no-fabrication incl. **masked-email regression** + bullet/surname false-positive guards, proposal scope/diff/gaps, offer suppression by proactivity level, service apply with mocked prisma incl. **employeeCount-range and contact-source regressions**) — green; 142 across all touched files.
- Registry + grants coverage tests green; `tsc --noEmit` clean.
- Independent semantic review of the committed tree performed; all HIGH/MEDIUM findings (employeeCount range coercion, contact `source` clobber, apply atomicity + FK-safe `createdById`, no-fabrication false-positives, completeness threshold) fixed with regression tests.
- Local merged-code gate green against `origin/main` (exhaustive tier).

## Non-goals

Live LinkedIn/search crawling inside the tool (the coworker gathers findings with its granted `search_public_web`/`fetch_public_website` tools and hands structured findings to `propose_crm_enrichment`; the tool owns the governed write, not the crawl); a new admin apply button (apply is the governed MCP tool for this slice).

Docs-Impact-Decision: the only change to `apps/web/lib/tak/agent-grants.ts` is two additive `TOOL_TO_GRANTS` entries (`propose_crm_enrichment`, `apply_crm_enrichment`) mapping the new tools onto existing grant categories (`web_search`/`crm_read`/`crm_write`). It does not alter the grant/authority model, the read-baseline, or the implication rules that the linked architecture pages (long-running-agentic-process-architecture, agent-standards-dpf-conformance, contributor-procedure-runbook) describe — so no user-facing documentation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
