### PR TITLE
fix(tak): retain human principal on action receipts

### DIFF
--- a/apps/web/lib/tak/gaid-actor-envelope.test.ts
+++ b/apps/web/lib/tak/gaid-actor-envelope.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    principalAlias: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { resolveGaidActorEnvelope } from "./gaid-actor-envelope";
+
+const baseArgs = {
+  toolName: "create_digital_product",
+  rawParams: { name: "Self-host support subscription" },
+  userId: "user-1",
+  userContext: { platformRole: "ceo", isSuperuser: true },
+  source: "rest" as const,
+};
+
+describe("resolveGaidActorEnvelope", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("keeps a direct human action Principal-bound without inventing an agent GAID", async () => {
+    vi.mocked(prisma.principalAlias.findFirst).mockResolvedValue({
+      principal: {
+        principalId: "PRN-HUMAN",
+        aliases: [],
+      },
+    } as never);
+
+    await expect(resolveGaidActorEnvelope(baseArgs as never)).resolves.toEqual({
+      principalId: "PRN-HUMAN",
+      gaid: null,
+      actorKind: "owner",
+      actorRef: "user-1",
+    });
+  });
+
+  it("still fails closed when a coworker has no GAID identity", async () => {
+    vi.mocked(prisma.principalAlias.findFirst).mockResolvedValue({
+      principal: {
+        principalId: "PRN-COWORKER",
+        aliases: [],
+      },
+    } as never);
+
+    await expect(resolveGaidActorEnvelope({
+      ...baseArgs,
+      context: { agentId: "AGT-100" },
+      source: "agentic-loop",
+    } as never)).resolves.toBeNull();
+  });
+
+  it("binds a coworker action to its registered GAID", async () => {
+    vi.mocked(prisma.principalAlias.findFirst).mockResolvedValue({
+      principal: {
+        principalId: "PRN-COWORKER",
+        aliases: [{ aliasType: "gaid", aliasValue: "gaid:priv:dpf.internal:agt-100" }],
+      },
+    } as never);
+
+    await expect(resolveGaidActorEnvelope({
+      ...baseArgs,
+      context: { agentId: "AGT-100" },
+      source: "agentic-loop",
+    } as never)).resolves.toEqual({
+      principalId: "PRN-COWORKER",
+      gaid: "gaid:priv:dpf.internal:agt-100",
+      actorKind: "coworker",
+      actorRef: "AGT-100",
+    });
+  });
+});

--- a/apps/web/lib/tak/gaid-actor-envelope.ts
+++ b/apps/web/lib/tak/gaid-actor-envelope.ts
@@ -4,7 +4,9 @@ import type { GovernedExecuteArgs } from "@/lib/mcp-governed-execute";
 
 export type GaidActorEnvelope = {
   principalId: string;
-  gaid: string;
+  /** GAID identifies an AI-agent subject. Direct human actors remain bound to
+   * their canonical Principal and MUST NOT receive a fabricated agent id. */
+  gaid: string | null;
   actorKind: "owner" | "employee" | "coworker" | "human";
   actorRef: string;
 };
@@ -33,12 +35,15 @@ export async function resolveGaidActorEnvelope(args: GovernedExecuteArgs): Promi
     },
   });
   const gaid = alias?.principal.aliases.find((entry) => entry.aliasType === "gaid")?.aliasValue;
-  if (!alias?.principal.principalId || !gaid) return null;
+  if (!alias?.principal.principalId) return null;
+  // A coworker cannot act without its GAID identity. Humans are the delegating
+  // principals in the GAID chain-of-custody and are identified by Principal.
+  if (args.context?.agentId && !gaid) return null;
   const employee = alias.principal.aliases.find((entry) => entry.aliasType === "employee")?.aliasValue;
   const owner = !args.context?.agentId && args.userContext.platformRole?.toLowerCase() === "ceo";
   return {
     principalId: alias.principal.principalId,
-    gaid,
+    gaid: gaid ?? null,
     actorKind: args.context?.agentId ? "coworker" : owner ? "owner" : employee ? "employee" : "human",
     actorRef: args.context?.agentId ?? employee ?? args.userId,
   };


### PR DESCRIPTION
## Summary

- preserve the canonical human `Principal` on TAK consequential-action receipts when the actor has no agent GAID
- keep coworker execution fail-closed when the coworker lacks a registered GAID
- add regression coverage for direct-human, missing-coworker-GAID, and registered-coworker-GAID paths

Linked work: BI-238E46C1 under EP-1C37C089. Follow-up to #4281 after canonical Arcamanus acceptance exposed a null human actor envelope on an otherwise valid consequential-action receipt.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/plans/2026-08-13-tak-alignment-gate-p2-completion.md`
- Current code substrate reviewed: `apps/web/lib/tak/gaid-actor-envelope.ts`, `apps/web/lib/tak/tool-execution-receipt.ts`, and `apps/web/lib/work-management/receipt-envelope.ts`
- Source of truth: GAID identifies AI-agent subjects; canonical `Principal` identity remains the human chain-of-custody anchor.
- Decision: retain Principal-bound human receipts without fabricating GAIDs, while continuing to refuse coworkers without a registered GAID.

## Verification

- RED observed: direct-human resolver test returned `null` instead of the expected Principal-bound envelope.
- GREEN: `pnpm --filter web exec vitest run lib/tak/gaid-actor-envelope.test.ts lib/mcp-governed-execute-alignment.test.ts lib/work-management/receipt-envelope.test.ts` — 18/18 passed.
- Production build: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web build` — passed.
- Exact merged-code local CI: passed in 4:02, evidence `cmstmy7e201as01t6rg8tkj3y`.
- Semantic review: infrastructure-inconclusive with zero reported findings; shadow policy permits publication.
- UX: not applicable; no rendered UI or workflow presentation changed.

Local-CI-Evidence: cmstmy7e201as01t6rg8tkj3y (fix/tak-human-principal-receipts@fdab7c00b18cd881f6c130c73f1fb74e0f62270e)

Process-Spine-Decision: BI-238E46C1 follow-up within the existing TAK execution and receipt process; no new work carrier, lifecycle, route, or contributor contract.
