### PR TITLE
feat(lifecycle): canonical lifecycle grammar — stages + in-stage states + gates (BI-E55991E9)

### DIFF
--- a/apps/web/lib/crm/pipeline-inspector.ts
+++ b/apps/web/lib/crm/pipeline-inspector.ts
@@ -7,46 +7,26 @@ import {
   OPEN_OPPORTUNITY_STAGES,
 } from "./presentation";
 import { formatRevenueAmount } from "./revenue-cockpit";
+import { OPPORTUNITY_GRAMMAR } from "../lifecycle-grammars";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-const STAGE_STALE_THRESHOLDS_DAYS: Record<string, number> = {
-  qualification: 7,
-  discovery: 10,
-  proposal: 14,
-  negotiation: 10,
-};
+// Per-stage exit criteria + stale thresholds are the canonical lifecycle grammar's now
+// (BI-E55991E9): the opportunity grammar (lib/lifecycle-grammars.ts) is the single source, so
+// the CRM and any future lifecycle board read the same definitions. Derived here into the same
+// record shape this module has always used, preserving behaviour exactly (the default fallbacks
+// below in getStageExitCriteria/isStageStale are unchanged).
+const STAGE_STALE_THRESHOLDS_DAYS: Record<string, number> = Object.fromEntries(
+  OPPORTUNITY_GRAMMAR.stages
+    .filter((stage) => stage.staleAfterDays !== undefined)
+    .map((stage) => [stage.key, stage.staleAfterDays as number]),
+);
 
-const STAGE_EXIT_CRITERIA: Record<string, string[]> = {
-  qualification: [
-    "Buyer problem is clear",
-    "Account and primary contact are known",
-    "Value hypothesis is recorded",
-  ],
-  discovery: [
-    "Needs and success criteria captured",
-    "Stakeholders and blockers identified",
-    "Commercial fit is plausible",
-  ],
-  proposal: [
-    "Quote or proposal sent",
-    "Commercial owner identified",
-    "Budget and timeline confirmed",
-  ],
-  negotiation: [
-    "Decision process confirmed",
-    "Commercial objections resolved",
-    "Signature or close step scheduled",
-  ],
-  closed_won: [
-    "Order or onboarding path confirmed",
-    "Handoff owner recorded",
-  ],
-  closed_lost: [
-    "Lost reason recorded",
-    "Reusable learning captured",
-  ],
-};
+const STAGE_EXIT_CRITERIA: Record<string, string[]> = Object.fromEntries(
+  OPPORTUNITY_GRAMMAR.stages
+    .filter((stage) => stage.exitCriteria !== undefined)
+    .map((stage) => [stage.key, [...(stage.exitCriteria as readonly string[])]]),
+);
 
 const CRM_ADVISOR_BOUNDARY =
   "Do not create CRM records, update stages, send, or schedule anything. Return review notes or draft copy for operator approval.";

--- a/apps/web/lib/lifecycle-grammar.test.ts
+++ b/apps/web/lib/lifecycle-grammar.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+  canAdvance,
+  getState,
+  summarizeLifecycle,
+  validateGrammar,
+  type LifecycleGrammar,
+} from "./lifecycle-grammar";
+import {
+  CUSTOMER_ACCOUNT_GRAMMAR,
+  LIFECYCLE_GRAMMARS,
+  OPPORTUNITY_GRAMMAR,
+  grammarKeyForKind,
+  resolveCustomerAccountPoint,
+  resolveOpportunityPoint,
+} from "./lifecycle-grammars";
+
+describe("validateGrammar", () => {
+  it("accepts every declared grammar", () => {
+    for (const grammar of Object.values(LIFECYCLE_GRAMMARS)) {
+      expect(() => validateGrammar(grammar)).not.toThrow();
+    }
+  });
+
+  it("rejects a stage with no entry state", () => {
+    const bad: LifecycleGrammar = {
+      key: "bad",
+      label: "Bad",
+      stages: [{ key: "s1", label: "S1", advancesTo: [], isTerminal: true, states: [{ key: "x", label: "X", band: "on-track" }] }],
+    };
+    expect(() => validateGrammar(bad)).toThrow(/exactly one entry state/);
+  });
+
+  it("rejects a non-terminal stage with no exit-ready state", () => {
+    const bad: LifecycleGrammar = {
+      key: "bad",
+      label: "Bad",
+      stages: [
+        { key: "s1", label: "S1", advancesTo: ["s2"], states: [{ key: "x", label: "X", band: "on-track", isEntry: true }] },
+        { key: "s2", label: "S2", advancesTo: [], isTerminal: true, states: [{ key: "y", label: "Y", band: "on-track", isEntry: true }] },
+      ],
+    };
+    expect(() => validateGrammar(bad)).toThrow(/exit-ready/);
+  });
+
+  it("rejects an advancesTo pointing at an unknown stage", () => {
+    const bad: LifecycleGrammar = {
+      key: "bad",
+      label: "Bad",
+      stages: [{ key: "s1", label: "S1", advancesTo: ["nope"], states: [{ key: "x", label: "X", band: "ready", isEntry: true, isExitReady: true }] }],
+    };
+    expect(() => validateGrammar(bad)).toThrow(/unknown stage "nope"/);
+  });
+
+  it("rejects isTerminal with a non-empty advancesTo", () => {
+    const bad: LifecycleGrammar = {
+      key: "bad",
+      label: "Bad",
+      stages: [
+        { key: "s1", label: "S1", advancesTo: ["s2"], isTerminal: true, states: [{ key: "x", label: "X", band: "ready", isEntry: true, isExitReady: true }] },
+        { key: "s2", label: "S2", advancesTo: [], isTerminal: true, states: [{ key: "y", label: "Y", band: "on-track", isEntry: true }] },
+      ],
+    };
+    expect(() => validateGrammar(bad)).toThrow(/isTerminal is true but advancesTo is non-empty/);
+  });
+
+  it("rejects a self-referential advancesTo", () => {
+    const bad: LifecycleGrammar = {
+      key: "bad",
+      label: "Bad",
+      stages: [{ key: "s1", label: "S1", advancesTo: ["s1"], states: [{ key: "x", label: "X", band: "ready", isEntry: true, isExitReady: true }] }],
+    };
+    expect(() => validateGrammar(bad)).toThrow(/may not reference itself/);
+  });
+});
+
+describe("canAdvance gate", () => {
+  it("allows advance only from an exit-ready state to a legal target", () => {
+    expect(canAdvance(CUSTOMER_ACCOUNT_GRAMMAR, { stage: "prospect", state: "prospect" }, "qualified")).toEqual({ allowed: true });
+  });
+
+  it("allows exit to a terminal stage from a blocked (non-exit-ready) in-stage state", () => {
+    // Involuntary churn / termination: an at_risk or suspended account may close from that state.
+    expect(canAdvance(CUSTOMER_ACCOUNT_GRAMMAR, { stage: "active", state: "at_risk" }, "closed")).toEqual({ allowed: true });
+    expect(canAdvance(CUSTOMER_ACCOUNT_GRAMMAR, { stage: "active", state: "suspended" }, "closed")).toEqual({ allowed: true });
+  });
+
+  it("refuses forward advance to a NON-terminal stage from a non-exit-ready state", () => {
+    const g: LifecycleGrammar = {
+      key: "t",
+      label: "T",
+      stages: [
+        {
+          key: "s1",
+          label: "S1",
+          advancesTo: ["s2", "done"],
+          states: [
+            { key: "ready", label: "Ready", band: "ready", isEntry: true, isExitReady: true },
+            { key: "stuck", label: "Stuck", band: "blocked" },
+          ],
+        },
+        { key: "s2", label: "S2", advancesTo: ["done"], states: [{ key: "e", label: "E", band: "ready", isEntry: true, isExitReady: true }] },
+        { key: "done", label: "Done", advancesTo: [], isTerminal: true, states: [{ key: "x", label: "X", band: "on-track", isEntry: true }] },
+      ],
+    };
+    // stuck → s2 (non-terminal) is refused; stuck → done (terminal exit) is allowed.
+    expect(canAdvance(g, { stage: "s1", state: "stuck" }, "s2").allowed).toBe(false);
+    expect(canAdvance(g, { stage: "s1", state: "stuck" }, "done")).toEqual({ allowed: true });
+  });
+
+  it("refuses advance to a stage not in advancesTo", () => {
+    const check = canAdvance(CUSTOMER_ACCOUNT_GRAMMAR, { stage: "prospect", state: "prospect" }, "active");
+    expect(check.allowed).toBe(false);
+    expect(check.reason).toMatch(/does not advance to/);
+  });
+
+  it("refuses unknown stage/state", () => {
+    expect(canAdvance(CUSTOMER_ACCOUNT_GRAMMAR, { stage: "nope", state: "x" }, "qualified").allowed).toBe(false);
+    expect(canAdvance(CUSTOMER_ACCOUNT_GRAMMAR, { stage: "active", state: "nope" }, "closed").allowed).toBe(false);
+  });
+});
+
+describe("summarizeLifecycle two-axis rollup", () => {
+  it("counts by stage and by band, with per-stage bands", () => {
+    const points = [
+      { stage: "active", state: "active" },
+      { stage: "active", state: "at_risk" },
+      { stage: "prospect", state: "prospect" },
+    ];
+    const summary = summarizeLifecycle(CUSTOMER_ACCOUNT_GRAMMAR, points);
+    expect(summary.byStage.active).toBe(2);
+    expect(summary.byStage.prospect).toBe(1);
+    expect(summary.byBand.blocked).toBe(1); // at_risk
+    expect(summary.byBand["on-track"]).toBe(2); // active + prospect
+    expect(summary.byStageBand.active).toEqual({ "on-track": 1, blocked: 1, ready: 0 });
+    expect(summary.unresolved).toBe(0);
+  });
+
+  it("counts unresolved points that do not map into the grammar", () => {
+    const summary = summarizeLifecycle(CUSTOMER_ACCOUNT_GRAMMAR, [{ stage: "ghost", state: "x" }]);
+    expect(summary.unresolved).toBe(1);
+  });
+});
+
+describe("customer-account native decomposition (all 9 statuses)", () => {
+  const cases: Array<[string, string, string]> = [
+    ["prospect", "prospect", "prospect"],
+    ["qualified", "qualified", "qualified"],
+    ["onboarding", "onboarding", "onboarding"],
+    ["active", "active", "active"],
+    ["at_risk", "active", "at_risk"],
+    ["suspended", "active", "suspended"],
+    ["closed", "closed", "closed"],
+    ["superseded", "closed", "superseded"],
+    ["archived", "closed", "archived"],
+  ];
+  it.each(cases)("maps status %s → stage %s / state %s that resolves in the grammar", (status, stage, state) => {
+    const point = resolveCustomerAccountPoint(status);
+    expect(point).toEqual({ stage, state });
+    expect(getState(CUSTOMER_ACCOUNT_GRAMMAR, point.stage, point.state)).not.toBeNull();
+  });
+});
+
+describe("opportunity grammar mirrors the pre-existing pipeline-inspector data", () => {
+  it("carries the same per-stage exit criteria and stale thresholds", () => {
+    const qualification = OPPORTUNITY_GRAMMAR.stages.find((s) => s.key === "qualification")!;
+    expect(qualification.staleAfterDays).toBe(7);
+    expect(qualification.exitCriteria).toEqual([
+      "Buyer problem is clear",
+      "Account and primary contact are known",
+      "Value hypothesis is recorded",
+    ]);
+    expect(OPPORTUNITY_GRAMMAR.stages.find((s) => s.key === "proposal")!.staleAfterDays).toBe(14);
+  });
+
+  it("resolves every open + closed opportunity stage to a valid point", () => {
+    for (const stage of ["qualification", "discovery", "proposal", "negotiation", "closed_won", "closed_lost"]) {
+      const point = resolveOpportunityPoint(stage);
+      expect(getState(OPPORTUNITY_GRAMMAR, point.stage, point.state)).not.toBeNull();
+    }
+  });
+});
+
+describe("grammar kind registry", () => {
+  it("maps grammar-driven entity kinds to their grammar key", () => {
+    expect(grammarKeyForKind("CustomerAccount")).toBe("customer-account");
+    expect(grammarKeyForKind("Opportunity")).toBe("opportunity");
+    expect(grammarKeyForKind("EaElement")).toBeNull(); // EA governed things are not grammar-driven
+  });
+});

--- a/apps/web/lib/lifecycle-grammar.ts
+++ b/apps/web/lib/lifecycle-grammar.ts
@@ -1,0 +1,220 @@
+// Pure utility library — no server imports. Safe in tests and client components.
+//
+// CANONICAL LIFECYCLE GRAMMAR — the CSDM Stage → in-stage State → advancement-gate layer
+// that sits ABOVE the Unified Lifecycle Backbone (apps/web/lib/lifecycle.ts).
+// Spec: docs/superpowers/specs/2026-08-15-canonical-lifecycle-grammar-design.md.
+//
+// The backbone gives one ordered stage axis (plan…retirement) and a flat operational
+// condition (draft/active/inactive). It cannot express "in this stage, but is it ready to
+// move forward?" This module adds that: each Stage declares States (incl. an entry state and
+// an exit-ready gate), advancement Stage N → N+1 is gated on reaching an exit-ready state and
+// a legal target, and every (stage,state) point rolls up to a canonical health band so
+// count-by-stage AND state-within-stage report uniformly across every lifecycle.
+//
+// This module is a SHAPE that multiple lifecycles instantiate (customer-account, opportunity,
+// backbone, tech-currency, ovsm — declared in ./lifecycle-grammars.ts). It does not define a
+// single global stage list, and it does not replace LifecycleStatus — the grammar State is a
+// finer axis layered above it.
+
+// ─── Canonical health bands (the cross-lifecycle roll-up) ───────────────────────────
+// Individual state keys are lifecycle-specific; every state names one of these bands so
+// "% ready to advance" / "% blocked" is one query across every lifecycle. Closed union.
+export const LIFECYCLE_HEALTH_BANDS = ["on-track", "blocked", "ready"] as const;
+export type LifecycleHealthBand = (typeof LIFECYCLE_HEALTH_BANDS)[number];
+
+// ─── Grammar shape ──────────────────────────────────────────────────────────────────
+
+export type StageState = {
+  // Hyphenated per AGENTS.md §3 — EXCEPT keys that mirror an already-stored union value,
+  // which retain the stored spelling so native decomposition round-trips (e.g. `at_risk`,
+  // `closed_won`; see the historical-spelling exemption in packages/db/src/customer-lifecycle.ts).
+  key: string;
+  label: string;
+  band: LifecycleHealthBand;
+  /** Exactly one state per stage is the entry state (assigned on stage entry). */
+  isEntry?: boolean;
+  /** At least one state per non-terminal stage is exit-ready (the advancement gate is open). */
+  isExitReady?: boolean;
+};
+
+export type LifecycleStageDef = {
+  key: string;
+  label: string;
+  states: readonly StageState[];
+  /** Stages legally reachable from here; terminal stages declare []. */
+  advancesTo: readonly string[];
+  isTerminal?: boolean;
+  // Exit criteria + the stale clock are PER-STAGE (the generalised STAGE_EXIT_CRITERIA /
+  // STAGE_STALE_THRESHOLDS_DAYS in crm/pipeline-inspector.ts are keyed by stage, and staleness
+  // is time-in-stage, not time-in-state).
+  /** Operator-facing checklist that justifies leaving this stage. */
+  exitCriteria?: readonly string[];
+  /** Days-in-stage before the stage is flagged stale. */
+  staleAfterDays?: number;
+};
+
+export type LifecycleGrammar = {
+  key: string;
+  label: string;
+  stages: readonly LifecycleStageDef[];
+};
+
+/** A resolved (stage, state) point for one governed entity under a grammar. */
+export type LifecyclePoint = {
+  stage: string;
+  state: string;
+};
+
+// ─── Validation (run at module load in dev + test; a malformed grammar throws) ───────
+
+export function validateGrammar(grammar: LifecycleGrammar): void {
+  const where = `grammar "${grammar.key}"`;
+  if (grammar.stages.length === 0) throw new Error(`${where}: has no stages`);
+  const stageKeys = new Set<string>();
+  for (const stage of grammar.stages) {
+    if (stageKeys.has(stage.key)) throw new Error(`${where}: duplicate stage "${stage.key}"`);
+    stageKeys.add(stage.key);
+
+    const entries = stage.states.filter((s) => s.isEntry);
+    if (entries.length !== 1) {
+      throw new Error(`${where} stage "${stage.key}": must declare exactly one entry state, found ${entries.length}`);
+    }
+    const stateKeys = new Set<string>();
+    for (const state of stage.states) {
+      if (stateKeys.has(state.key)) {
+        throw new Error(`${where} stage "${stage.key}": duplicate state "${state.key}"`);
+      }
+      stateKeys.add(state.key);
+      if (!(LIFECYCLE_HEALTH_BANDS as readonly string[]).includes(state.band)) {
+        throw new Error(`${where} stage "${stage.key}" state "${state.key}": unknown band "${state.band}"`);
+      }
+    }
+    if (stage.isTerminal && stage.advancesTo.length > 0) {
+      throw new Error(`${where} stage "${stage.key}": isTerminal is true but advancesTo is non-empty`);
+    }
+    const terminal = stage.isTerminal || stage.advancesTo.length === 0;
+    if (!terminal && !stage.states.some((s) => s.isExitReady)) {
+      throw new Error(`${where} stage "${stage.key}": non-terminal stage must declare ≥1 exit-ready state`);
+    }
+  }
+  // Every advancesTo target must resolve to a declared stage, be unique, and not self-refer.
+  for (const stage of grammar.stages) {
+    const seen = new Set<string>();
+    for (const target of stage.advancesTo) {
+      if (target === stage.key) {
+        throw new Error(`${where} stage "${stage.key}": advancesTo may not reference itself`);
+      }
+      if (seen.has(target)) {
+        throw new Error(`${where} stage "${stage.key}": duplicate advancesTo target "${target}"`);
+      }
+      seen.add(target);
+      if (!stageKeys.has(target)) {
+        throw new Error(`${where} stage "${stage.key}": advancesTo references unknown stage "${target}"`);
+      }
+    }
+  }
+}
+
+// ─── Lookups ─────────────────────────────────────────────────────────────────────────
+
+export function getStage(grammar: LifecycleGrammar, stageKey: string): LifecycleStageDef | null {
+  return grammar.stages.find((s) => s.key === stageKey) ?? null;
+}
+
+export function getState(grammar: LifecycleGrammar, stageKey: string, stateKey: string): StageState | null {
+  return getStage(grammar, stageKey)?.states.find((s) => s.key === stateKey) ?? null;
+}
+
+/** The health band for a (stage, state) point; null if the point is unknown. */
+export function resolveBand(
+  grammar: LifecycleGrammar,
+  point: LifecyclePoint,
+): LifecycleHealthBand | null {
+  return getState(grammar, point.stage, point.state)?.band ?? null;
+}
+
+// ─── The advancement gate ─────────────────────────────────────────────────────────────
+
+export type AdvanceCheck = { allowed: boolean; reason?: string };
+
+/** A stage with no onward advancement is terminal (an exit/close/end stage). */
+export function isTerminalStage(stage: LifecycleStageDef): boolean {
+  return Boolean(stage.isTerminal) || stage.advancesTo.length === 0;
+}
+
+/**
+ * May an entity at (from.stage, from.state) advance to `toStage` right now? Legal only when
+ * `toStage` is declared in the current stage's advancesTo AND either the target is a terminal
+ * (exit/close/end) stage — reachable from ANY in-stage state — or the current state is an
+ * exit-ready state (forward advancement to a non-terminal stage requires readiness). Returns a
+ * typed reason on refusal.
+ *
+ * The terminal carve-out is deliberate: closing or churning an account is an *exit*, not a
+ * forward skip, so it must be reachable from `blocked` states like `at_risk`/`suspended` — not
+ * only from the exit-ready state. Without it the writer would silently reject involuntary churn.
+ */
+export function canAdvance(
+  grammar: LifecycleGrammar,
+  from: LifecyclePoint,
+  toStage: string,
+): AdvanceCheck {
+  const stage = getStage(grammar, from.stage);
+  if (!stage) return { allowed: false, reason: `unknown stage "${from.stage}"` };
+  const state = getState(grammar, from.stage, from.state);
+  if (!state) return { allowed: false, reason: `unknown state "${from.state}" in stage "${from.stage}"` };
+  const target = getStage(grammar, toStage);
+  if (!target) return { allowed: false, reason: `unknown target stage "${toStage}"` };
+  if (!stage.advancesTo.includes(toStage)) {
+    return { allowed: false, reason: `"${from.stage}" does not advance to "${toStage}"` };
+  }
+  if (!isTerminalStage(target) && !state.isExitReady) {
+    return { allowed: false, reason: `state "${from.state}" is not exit-ready for stage "${from.stage}"` };
+  }
+  return { allowed: true };
+}
+
+// ─── Two-axis reporting projection ────────────────────────────────────────────────────
+
+export type LifecycleSummary = {
+  byStage: Record<string, number>;
+  byBand: Record<LifecycleHealthBand, number>;
+  byStageBand: Record<string, Record<LifecycleHealthBand, number>>;
+  /** Points whose (stage,state) did not resolve in the grammar. */
+  unresolved: number;
+};
+
+function emptyBands(): Record<LifecycleHealthBand, number> {
+  return { "on-track": 0, blocked: 0, ready: 0 };
+}
+
+/**
+ * Roll a set of resolved (stage,state) points up into count-by-stage AND state-within-stage
+ * (by health band). Pure: callers fetch the points; this never touches the DB.
+ */
+export function summarizeLifecycle(
+  grammar: LifecycleGrammar,
+  points: readonly LifecyclePoint[],
+): LifecycleSummary {
+  const byStage: Record<string, number> = {};
+  const byBand = emptyBands();
+  const byStageBand: Record<string, Record<LifecycleHealthBand, number>> = {};
+  let unresolved = 0;
+
+  for (const stage of grammar.stages) {
+    byStage[stage.key] = 0;
+    byStageBand[stage.key] = emptyBands();
+  }
+
+  for (const point of points) {
+    const band = resolveBand(grammar, point);
+    if (band === null || byStage[point.stage] === undefined) {
+      unresolved += 1;
+      continue;
+    }
+    byStage[point.stage] += 1;
+    byBand[band] += 1;
+    byStageBand[point.stage][band] += 1;
+  }
+
+  return { byStage, byBand, byStageBand, unresolved };
+}

--- a/apps/web/lib/lifecycle-grammars.ts
+++ b/apps/web/lib/lifecycle-grammars.ts
@@ -1,0 +1,296 @@
+// Pure utility library — no server imports. Safe in tests and client components.
+//
+// DECLARED LIFECYCLE GRAMMARS — the concrete lifecycles expressed in the canonical grammar
+// (apps/web/lib/lifecycle-grammar.ts). Each is a SHAPE instance; declaring one here does not
+// rewrite its surfaces (that is the downstream BIs' work). validateGrammar() runs over all of
+// them at module load so a malformed grammar fails tests, not production.
+//
+// Spec: docs/superpowers/specs/2026-08-15-canonical-lifecycle-grammar-design.md §5.
+
+import {
+  LIFECYCLE_STAGES,
+  LIFECYCLE_STAGE_TRANSITIONS,
+  type LifecycleStage,
+} from "./lifecycle";
+import {
+  type LifecycleGrammar,
+  type LifecyclePoint,
+  validateGrammar,
+} from "./lifecycle-grammar";
+
+// ─── customer-account ────────────────────────────────────────────────────────────────
+// Native decomposition of the 9-state CustomerAccount.status union (packages/db/src/
+// customer-lifecycle.ts). Stored spellings kept (`at_risk` is exempted from hyphenation there).
+// All 9 statuses are placed: prospect·qualified·onboarding·active·at_risk·suspended·closed·
+// superseded·archived.
+export const CUSTOMER_ACCOUNT_GRAMMAR: LifecycleGrammar = {
+  key: "customer-account",
+  label: "Customer account relationship",
+  stages: [
+    {
+      key: "prospect",
+      label: "Prospect",
+      advancesTo: ["qualified", "closed"],
+      exitCriteria: ["Contact and account identified", "Fit hypothesis recorded"],
+      states: [{ key: "prospect", label: "Prospect", band: "on-track", isEntry: true, isExitReady: true }],
+    },
+    {
+      key: "qualified",
+      label: "Qualified",
+      advancesTo: ["onboarding", "closed"],
+      exitCriteria: ["Qualification confirmed", "Commercial path agreed"],
+      states: [{ key: "qualified", label: "Qualified", band: "ready", isEntry: true, isExitReady: true }],
+    },
+    {
+      key: "onboarding",
+      label: "Onboarding",
+      advancesTo: ["active", "closed"],
+      exitCriteria: ["Onboarding milestones complete", "First value delivered"],
+      states: [{ key: "onboarding", label: "Onboarding", band: "on-track", isEntry: true, isExitReady: true }],
+    },
+    {
+      key: "active",
+      label: "Active",
+      advancesTo: ["closed"],
+      // The recurring back-half. Within `active`, three stored statuses collapse: `active`
+      // (healthy, on-track), `at_risk` (blocked — a churn-risk signal), `suspended` (blocked —
+      // service paused). `at_risk`/`suspended` keep stored spelling for native round-trip.
+      states: [
+        { key: "active", label: "Active", band: "on-track", isEntry: true, isExitReady: true },
+        { key: "at_risk", label: "At risk", band: "blocked" },
+        { key: "suspended", label: "Suspended", band: "blocked" },
+      ],
+    },
+    {
+      key: "closed",
+      label: "Closed",
+      advancesTo: [],
+      isTerminal: true,
+      // Relationship end + the two data-lifecycle tombstones (merged / operator-archived).
+      states: [
+        { key: "closed", label: "Closed", band: "on-track", isEntry: true },
+        { key: "superseded", label: "Superseded (merged)", band: "on-track" },
+        { key: "archived", label: "Archived", band: "on-track" },
+      ],
+    },
+  ],
+};
+
+/** Map a stored CustomerAccount.status → its (stage, state) point in the grammar. */
+export function resolveCustomerAccountPoint(status: string): LifecyclePoint {
+  switch (status) {
+    case "prospect":
+      return { stage: "prospect", state: "prospect" };
+    case "qualified":
+      return { stage: "qualified", state: "qualified" };
+    case "onboarding":
+      return { stage: "onboarding", state: "onboarding" };
+    case "active":
+      return { stage: "active", state: "active" };
+    case "at_risk":
+      return { stage: "active", state: "at_risk" };
+    case "suspended":
+      return { stage: "active", state: "suspended" };
+    case "closed":
+      return { stage: "closed", state: "closed" };
+    case "superseded":
+      return { stage: "closed", state: "superseded" };
+    case "archived":
+      return { stage: "closed", state: "archived" };
+    default:
+      // Unknown stored value → treat as prospect entry (conservative; surfaces as the earliest stage).
+      return { stage: "prospect", state: "prospect" };
+  }
+}
+
+// ─── opportunity ──────────────────────────────────────────────────────────────────────
+// Lifts STAGE_EXIT_CRITERIA + STAGE_STALE_THRESHOLDS_DAYS verbatim from crm/pipeline-inspector.ts
+// into the per-stage exitCriteria/staleAfterDays; stored underscore spellings kept
+// (closed_won/closed_lost). pipeline-inspector re-imports these from here (behaviour-preserving).
+// Default fallbacks (14-day stale, 2-item criteria) stay in pipeline-inspector's accessor funcs.
+export const OPPORTUNITY_GRAMMAR: LifecycleGrammar = {
+  key: "opportunity",
+  label: "Sales opportunity",
+  stages: [
+    {
+      key: "qualification",
+      label: "Qualification",
+      advancesTo: ["discovery", "closed_won", "closed_lost"],
+      staleAfterDays: 7,
+      exitCriteria: ["Buyer problem is clear", "Account and primary contact are known", "Value hypothesis is recorded"],
+      states: [{ key: "open", label: "Open", band: "on-track", isEntry: true, isExitReady: true }],
+    },
+    {
+      key: "discovery",
+      label: "Discovery",
+      advancesTo: ["proposal", "closed_won", "closed_lost"],
+      staleAfterDays: 10,
+      exitCriteria: ["Needs and success criteria captured", "Stakeholders and blockers identified", "Commercial fit is plausible"],
+      states: [{ key: "open", label: "Open", band: "on-track", isEntry: true, isExitReady: true }],
+    },
+    {
+      key: "proposal",
+      label: "Proposal",
+      advancesTo: ["negotiation", "closed_won", "closed_lost"],
+      staleAfterDays: 14,
+      exitCriteria: ["Quote or proposal sent", "Commercial owner identified", "Budget and timeline confirmed"],
+      states: [{ key: "open", label: "Open", band: "on-track", isEntry: true, isExitReady: true }],
+    },
+    {
+      key: "negotiation",
+      label: "Negotiation",
+      advancesTo: ["closed_won", "closed_lost"],
+      staleAfterDays: 10,
+      exitCriteria: ["Decision process confirmed", "Commercial objections resolved", "Signature or close step scheduled"],
+      states: [{ key: "open", label: "Open", band: "on-track", isEntry: true, isExitReady: true }],
+    },
+    {
+      key: "closed_won",
+      label: "Won",
+      advancesTo: [],
+      isTerminal: true,
+      exitCriteria: ["Order or onboarding path confirmed", "Handoff owner recorded"],
+      states: [{ key: "won", label: "Won", band: "ready", isEntry: true }],
+    },
+    {
+      key: "closed_lost",
+      label: "Lost",
+      advancesTo: [],
+      isTerminal: true,
+      exitCriteria: ["Lost reason recorded", "Reusable learning captured"],
+      states: [{ key: "lost", label: "Lost", band: "on-track", isEntry: true }],
+    },
+  ],
+};
+
+/** Map a stored opportunity stage → its (stage, state) point. Opportunity has no separately
+ *  stored in-stage state; the entry state stands in (staleness/blocked is derived at read time). */
+export function resolveOpportunityPoint(stage: string): LifecyclePoint {
+  switch (stage) {
+    case "closed_won":
+      return { stage: "closed_won", state: "won" };
+    case "closed_lost":
+      return { stage: "closed_lost", state: "lost" };
+    case "qualification":
+    case "discovery":
+    case "proposal":
+    case "negotiation":
+      return { stage, state: "open" };
+    default:
+      return { stage: "qualification", state: "open" };
+  }
+}
+
+// ─── backbone (EaElement / DigitalProduct / Agent) ────────────────────────────────────
+// advancesTo DERIVES from LIFECYCLE_STAGE_TRANSITIONS so the legal map has one source and the
+// two cannot drift. Flat LifecycleStatus maps to a band per stage entry state.
+function backboneStageDef(stage: LifecycleStage) {
+  const advancesTo = LIFECYCLE_STAGE_TRANSITIONS[stage];
+  const isTerminal = advancesTo.length === 0;
+  return {
+    key: stage,
+    label: stage.charAt(0).toUpperCase() + stage.slice(1),
+    advancesTo,
+    isTerminal,
+    states: [
+      // `active` is the exit-ready operational condition; `draft` is on-track pre-activation;
+      // `inactive` (retirement) is terminal within the stage.
+      { key: "active", label: "Active", band: "ready" as const, isEntry: true, isExitReady: !isTerminal },
+      { key: "draft", label: "Draft", band: "on-track" as const },
+      { key: "inactive", label: "Inactive", band: "on-track" as const },
+    ],
+  };
+}
+
+export const BACKBONE_GRAMMAR: LifecycleGrammar = {
+  key: "backbone",
+  label: "Governed-thing backbone",
+  stages: LIFECYCLE_STAGES.map(backboneStageDef),
+};
+
+// ─── tech-currency ─────────────────────────────────────────────────────────────────────
+// Each currency value is both a stage and its own band. Consumed by BI-6328BCA6.
+export const TECH_CURRENCY_GRAMMAR: LifecycleGrammar = {
+  key: "tech-currency",
+  label: "Technology currency (EOL)",
+  stages: [
+    {
+      key: "current",
+      label: "Current",
+      advancesTo: ["approaching-eol"],
+      states: [{ key: "current", label: "Current", band: "on-track", isEntry: true, isExitReady: true }],
+    },
+    {
+      key: "approaching-eol",
+      label: "Approaching EOL",
+      advancesTo: ["unsupported", "end-of-life"],
+      states: [{ key: "approaching-eol", label: "Approaching EOL", band: "blocked", isEntry: true, isExitReady: true }],
+    },
+    {
+      key: "unsupported",
+      label: "Unsupported",
+      advancesTo: ["end-of-life"],
+      states: [{ key: "unsupported", label: "Unsupported", band: "blocked", isEntry: true, isExitReady: true }],
+    },
+    {
+      key: "end-of-life",
+      label: "End of life",
+      advancesTo: [],
+      isTerminal: true,
+      states: [{ key: "end-of-life", label: "End of life", band: "blocked", isEntry: true }],
+    },
+  ],
+};
+
+// ─── ovsm ──────────────────────────────────────────────────────────────────────────────
+// The six primary OVSM stages (packages/storefront-templates/src/operational-value-stream.ts).
+// Minimal states; consumed/enriched by BI-9078F4EE + BI-A72D29BE.
+const OVSM_PRIMARY_STAGES = ["attract", "capture", "qualify", "deliver", "settle", "retain"] as const;
+export const OVSM_GRAMMAR: LifecycleGrammar = {
+  key: "ovsm",
+  label: "Operational value stream",
+  stages: OVSM_PRIMARY_STAGES.map((stage, index) => {
+    const next = OVSM_PRIMARY_STAGES[index + 1];
+    return {
+      key: stage,
+      label: stage.charAt(0).toUpperCase() + stage.slice(1),
+      advancesTo: next ? [next] : [],
+      isTerminal: !next,
+      states: [{ key: "in-stage", label: "In stage", band: "on-track" as const, isEntry: true, isExitReady: Boolean(next) }],
+    };
+  }),
+};
+
+// ─── Registry ────────────────────────────────────────────────────────────────────────
+export const LIFECYCLE_GRAMMARS: Record<string, LifecycleGrammar> = {
+  [CUSTOMER_ACCOUNT_GRAMMAR.key]: CUSTOMER_ACCOUNT_GRAMMAR,
+  [OPPORTUNITY_GRAMMAR.key]: OPPORTUNITY_GRAMMAR,
+  [BACKBONE_GRAMMAR.key]: BACKBONE_GRAMMAR,
+  [TECH_CURRENCY_GRAMMAR.key]: TECH_CURRENCY_GRAMMAR,
+  [OVSM_GRAMMAR.key]: OVSM_GRAMMAR,
+};
+
+/**
+ * Entity kinds each grammar applies to. This is the grammar's OWN kind vocabulary for the
+ * LifecycleEvent write path (recordLifecycleTransition), kept SEPARATE from the closed EA
+ * GOVERNED_THING_KINDS allowlist in governed-thing-ref.ts so grammar entities can log events
+ * without being dragged into the resolveLifecycle cascade. See spec §4.2.
+ */
+export const LIFECYCLE_GRAMMAR_KINDS: Record<string, string> = {
+  CustomerAccount: "customer-account",
+  Opportunity: "opportunity",
+};
+
+export function getGrammar(key: string): LifecycleGrammar | null {
+  return LIFECYCLE_GRAMMARS[key] ?? null;
+}
+
+/** Grammar key for a governed-thing kind, if that kind is grammar-driven. */
+export function grammarKeyForKind(kind: string): string | null {
+  return LIFECYCLE_GRAMMAR_KINDS[kind] ?? null;
+}
+
+// Fail fast: every declared grammar is validated at module load (dev + test).
+for (const grammar of Object.values(LIFECYCLE_GRAMMARS)) {
+  validateGrammar(grammar);
+}

--- a/apps/web/lib/lifecycle/lifecycle-transition.test.ts
+++ b/apps/web/lib/lifecycle/lifecycle-transition.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { isRecordableKind, recordLifecycleTransition } from "./lifecycle-transition";
+
+// These exercise the pure guard paths of the writer — both return before any prisma query, so
+// no test DB is needed. The DB round-trip is covered by the integration suite / live verification.
+
+describe("isRecordableKind — widened write-path vocabulary (F1)", () => {
+  it("accepts EA governed things", () => {
+    expect(isRecordableKind("EaElement")).toBe(true);
+    expect(isRecordableKind("DigitalProduct")).toBe(true);
+  });
+  it("accepts grammar entity kinds not in the EA allowlist", () => {
+    expect(isRecordableKind("CustomerAccount")).toBe(true);
+    expect(isRecordableKind("Opportunity")).toBe(true);
+  });
+  it("rejects an unknown kind", () => {
+    expect(isRecordableKind("Banana")).toBe(false);
+  });
+});
+
+describe("recordLifecycleTransition guard paths (no DB hit)", () => {
+  it("refuses an unrecordable kind", async () => {
+    const result = await recordLifecycleTransition({
+      governedThingKind: "Banana",
+      governedThingId: "x",
+    });
+    expect(result).toEqual({ ok: false, reason: expect.stringContaining("not a recordable lifecycle kind") });
+  });
+
+  it("refuses an illegal grammar advancement before writing", async () => {
+    const result = await recordLifecycleTransition({
+      governedThingKind: "CustomerAccount",
+      governedThingId: "acct-1",
+      // prospect → active is illegal (prospect only advances to qualified/closed).
+      from: { stage: "prospect", state: "prospect" },
+      to: { stage: "active", state: "active" },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/does not advance to/);
+  });
+
+  it("refuses a point whose state does not exist in the grammar (no unresolved rows written)", async () => {
+    const result = await recordLifecycleTransition({
+      governedThingKind: "CustomerAccount",
+      governedThingId: "acct-1",
+      from: { stage: "prospect", state: "prospect" },
+      to: { stage: "qualified", state: "garbage" },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/not a valid state in grammar/);
+  });
+});

--- a/apps/web/lib/lifecycle/lifecycle-transition.ts
+++ b/apps/web/lib/lifecycle/lifecycle-transition.ts
@@ -1,0 +1,133 @@
+// Server lib — grammar-aware LifecycleEvent writer + two-axis reporting read-model.
+// Spec: docs/superpowers/specs/2026-08-15-canonical-lifecycle-grammar-design.md §4.3.
+//
+// This is the funnel for GRAMMAR-driven lifecycle transitions (customer-account, opportunity, …).
+// It coexists with lib/lifecycle/baseline-projector.ts, which logs backbone/estate transitions to
+// the same universal LifecycleEvent ledger. Both append; neither is the sole producer.
+
+import { prisma } from "@dpf/db";
+import { GOVERNED_THING_KINDS } from "../governed-thing-ref";
+import {
+  canAdvance,
+  getState,
+  summarizeLifecycle,
+  type LifecyclePoint,
+  type LifecycleSummary,
+} from "../lifecycle-grammar";
+import {
+  getGrammar,
+  grammarKeyForKind,
+  LIFECYCLE_GRAMMAR_KINDS,
+  resolveCustomerAccountPoint,
+  resolveOpportunityPoint,
+} from "../lifecycle-grammars";
+
+const GOVERNED_THING_KIND_SET = new Set<string>(GOVERNED_THING_KINDS);
+const GRAMMAR_KIND_SET = new Set<string>(Object.keys(LIFECYCLE_GRAMMAR_KINDS));
+
+/** governedThingKind accepted by the write path: EA governed things OR grammar entities (spec §4.2). */
+export function isRecordableKind(kind: string): boolean {
+  return GOVERNED_THING_KIND_SET.has(kind) || GRAMMAR_KIND_SET.has(kind);
+}
+
+export type RecordLifecycleTransitionInput = {
+  /** An EA GovernedThingKind or a LIFECYCLE_GRAMMAR_KINDS entity kind (e.g. "CustomerAccount"). */
+  governedThingKind: string;
+  governedThingId: string;
+  /** Grammar-state transition (finer axis). Provide when the entity is grammar-driven. */
+  from?: LifecyclePoint;
+  to?: LifecyclePoint;
+  /** Backbone-condition transition (closed LifecycleStatus). Null for native-decomposition entities. */
+  fromStatus?: string | null;
+  toStatus?: string | null;
+  fromStage?: string | null;
+  toStage?: string | null;
+  reason?: string | null;
+  evidenceRef?: string | null;
+  actorPrincipalId?: string | null;
+  toolExecutionId?: string | null;
+};
+
+export type RecordLifecycleTransitionResult =
+  | { ok: true; eventId: string }
+  | { ok: false; reason: string };
+
+/**
+ * Validate (when a grammar stage changes, the advancement must be legal) and append one
+ * LifecycleEvent carrying the state axis. Returns a typed refusal rather than throwing so
+ * callers can surface an operator-fixable message (not a redacted server error).
+ */
+export async function recordLifecycleTransition(
+  input: RecordLifecycleTransitionInput,
+): Promise<RecordLifecycleTransitionResult> {
+  if (!isRecordableKind(input.governedThingKind)) {
+    return { ok: false, reason: `"${input.governedThingKind}" is not a recordable lifecycle kind` };
+  }
+
+  // Validate (and gate) grammar entities. Both from/to points must resolve to real
+  // (stage,state) pairs in the grammar — otherwise a bogus state would persist into the open
+  // fromState/toState columns and silently resolve to `unresolved` in summarizeLifecycle,
+  // corrupting the two-axis report. And when the stage changes, the advance must be legal.
+  const grammarKey = grammarKeyForKind(input.governedThingKind);
+  if (grammarKey) {
+    const grammar = getGrammar(grammarKey);
+    if (grammar) {
+      for (const [label, point] of [["from", input.from], ["to", input.to]] as const) {
+        if (point && getState(grammar, point.stage, point.state) === null) {
+          return {
+            ok: false,
+            reason: `${label} point (${point.stage}/${point.state}) is not a valid state in grammar "${grammarKey}"`,
+          };
+        }
+      }
+      if (input.from && input.to && input.from.stage !== input.to.stage) {
+        const check = canAdvance(grammar, input.from, input.to.stage);
+        if (!check.allowed) {
+          return { ok: false, reason: check.reason ?? "illegal lifecycle advancement" };
+        }
+      }
+    }
+  }
+
+  const event = await prisma.lifecycleEvent.create({
+    data: {
+      governedThingKind: input.governedThingKind,
+      governedThingId: input.governedThingId,
+      fromStage: input.fromStage ?? input.from?.stage ?? null,
+      toStage: input.toStage ?? input.to?.stage ?? null,
+      fromStatus: input.fromStatus ?? null,
+      toStatus: input.toStatus ?? null,
+      fromState: input.from?.state ?? null,
+      toState: input.to?.state ?? null,
+      reason: input.reason ?? null,
+      evidenceRef: input.evidenceRef ?? null,
+      actorPrincipalId: input.actorPrincipalId ?? null,
+      toolExecutionId: input.toolExecutionId ?? null,
+    },
+    select: { id: true },
+  });
+  return { ok: true, eventId: event.id };
+}
+
+/**
+ * Resolve the live (stage,state) points for a grammar-driven entity kind and roll them up into
+ * the two-axis summary (count-by-stage AND state-within-stage). Supports the two wired grammars;
+ * other grammars are populated by their downstream BIs.
+ */
+export async function getLifecycleSummary(grammarKey: string): Promise<LifecycleSummary | null> {
+  const grammar = getGrammar(grammarKey);
+  if (!grammar) return null;
+
+  let points: LifecyclePoint[] = [];
+  if (grammarKey === "customer-account") {
+    const rows = await prisma.customerAccount.findMany({ select: { status: true } });
+    points = rows.map((r) => resolveCustomerAccountPoint(r.status));
+  } else if (grammarKey === "opportunity") {
+    const rows = await prisma.opportunity.findMany({ select: { stage: true } });
+    points = rows.map((r) => resolveOpportunityPoint(r.stage));
+  } else {
+    // Grammar declared but not yet wired to a live entity source (owned by a downstream BI).
+    return summarizeLifecycle(grammar, []);
+  }
+  return summarizeLifecycle(grammar, points);
+}

--- a/changes/lifecycle-event-state-axis.data-impact.json
+++ b/changes/lifecycle-event-state-axis.data-impact.json
@@ -1,0 +1,28 @@
+{
+  "version": "1",
+  "accountableOwner": "Mark Bodman (markdbodman@gmail.com)",
+  "summary": "BI-E55991E9 (EP-VSL-SURFACE foundational grammar). Add two nullable columns fromState/toState to the existing universal append-only LifecycleEvent ledger so it records the in-stage STATE axis of the canonical lifecycle grammar (apps/web/lib/lifecycle-grammar.ts), enabling two-axis reporting (count-by-stage AND state-within-stage). Additive, non-destructive: two new nullable columns only, no changes to existing rows and no backfill — existing rows keep NULL state and remain valid. The columns hold an open per-grammar StageState.key (not a canonical enum), never personal data: a StageState.key is a platform lifecycle-stage identifier (e.g. 'at_risk', 'qualified', 'open'), not tenant or subject data. The row's actor is already an opaque Principal id via the pre-existing actorPrincipalId column (unchanged). Migration: 20260815000000_add_lifecycle_event_state_axis (ADD COLUMN ... TEXT, both nullable).",
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "LifecycleEvent",
+      "lifecycleDisposition": "domain-lifecycle-managed",
+      "fields": [
+        {
+          "name": "fromState",
+          "resolution": "not-applicable",
+          "reason": "In-stage StageState.key at the start of a lifecycle transition. A platform lifecycle-stage-state identifier (open per-grammar string, e.g. 'at_risk'), not personal data and not tied to a data subject. Nullable and backfill-free; existing rows keep NULL.",
+          "provenance": "Set by recordLifecycleTransition (apps/web/lib/lifecycle/lifecycle-transition.ts) from the grammar-resolved (stage,state) point of the entity before the transition. No external source of data.",
+          "flags": []
+        },
+        {
+          "name": "toState",
+          "resolution": "not-applicable",
+          "reason": "In-stage StageState.key after a lifecycle transition. Same platform-identifier nature as fromState; not personal data. Nullable and backfill-free.",
+          "provenance": "Set by recordLifecycleTransition from the grammar-resolved (stage,state) point of the entity after the transition. No external source of data.",
+          "flags": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-08-15-canonical-lifecycle-grammar.md
+++ b/docs/superpowers/plans/2026-08-15-canonical-lifecycle-grammar.md
@@ -1,0 +1,29 @@
+# Plan — Canonical Lifecycle Grammar (BI-E55991E9)
+
+**BI:** `BI-E55991E9` (Workstream 0, FOUNDATIONAL) · **Epic:** `EP-VSL-SURFACE`
+**Spec:** [2026-08-15-canonical-lifecycle-grammar-design.md](../specs/2026-08-15-canonical-lifecycle-grammar-design.md)
+**Date:** 2026-08-15 · **Branch:** `feat/vsl-lifecycle-grammar`
+
+## Goal
+
+Add the CSDM Stage → in-stage State → advancement-gate layer on top of the existing Unified Lifecycle Backbone, so every lifecycle reports two-axis (count-by-stage AND state-within-stage) and gates advancement on an exit-ready state — without inventing a parallel lifecycle machine. This is the foundation the other four EP-VSL-SURFACE BIs express their stages through.
+
+## Phases (all landed in this one atomic BI — see spec Backlog Coverage)
+
+1. **Pure engine** — `apps/web/lib/lifecycle-grammar.ts`: `StageState`/`LifecycleStageDef`/`LifecycleGrammar` types, `LIFECYCLE_HEALTH_BANDS`, `validateGrammar`, `canAdvance` (the gate), `summarizeLifecycle` (two-axis rollup). No server imports.
+2. **Declared grammars + resolvers** — `apps/web/lib/lifecycle-grammars.ts`: `customer-account` (9-status native decomposition), `opportunity` (lifts `STAGE_EXIT_CRITERIA`/`STAGE_STALE_THRESHOLDS_DAYS`), plus `backbone` (advancesTo derived from `LIFECYCLE_STAGE_TRANSITIONS`), `tech-currency`, `ovsm` declared and validated. `LIFECYCLE_GRAMMAR_KINDS` registry (F1 write-path vocabulary).
+3. **Event-ledger state axis** — migration `20260815000000_add_lifecycle_event_state_axis` adds nullable `LifecycleEvent.fromState/toState` (open per-grammar key, not a canonical enum).
+4. **Grammar-aware writer + read-model** — `apps/web/lib/lifecycle/lifecycle-transition.ts`: `recordLifecycleTransition` (validates via `canAdvance`, widened kind vocabulary, coexists with `baseline-projector`) + `getLifecycleSummary`.
+5. **Behaviour-preserving CRM rewire** — `pipeline-inspector.ts` now sources exit-criteria/stale-thresholds from `OPPORTUNITY_GRAMMAR`; existing tests unchanged and green.
+6. **Tests** — `lifecycle-grammar.test.ts` (22), `lifecycle-transition.test.ts` (5, DB-free guard paths), `pipeline-inspector.test.ts` (regression, unchanged).
+
+## Verification
+
+- Unit: `pnpm exec vitest run lib/lifecycle-grammar.test.ts lib/lifecycle/lifecycle-transition.test.ts lib/crm/pipeline-inspector.test.ts` — all green (27 + 5).
+- Typecheck: `pnpm typecheck` clean.
+- Migration applies cleanly (additive nullable; backfill-free).
+- Local merged-CI gate before push.
+
+## Backlog Coverage
+
+Atomic: engine + grammars + migration + writer/read-model + the two proving resolvers are one indivisible substrate slice (spec §Backlog Coverage). The other four EP-VSL-SURFACE BIs consume this and ship independently.

--- a/docs/superpowers/specs/2026-08-15-canonical-lifecycle-grammar-design.md
+++ b/docs/superpowers/specs/2026-08-15-canonical-lifecycle-grammar-design.md
@@ -1,0 +1,202 @@
+# Canonical Lifecycle Grammar — Stages + In-Stage States + Advancement Gates (CSDM-aligned)
+
+**Status:** Design candidate — foundational workstream of EP-VSL-SURFACE
+**Date:** 2026-08-15
+**Track:** Enterprise-architecture / platform-data-model design
+**Backlog:** `BI-E55991E9` (Workstream 0, FOUNDATIONAL) under `EP-VSL-SURFACE`
+**Primary audience:** Platform architects wiring every governed entity's lifecycle onto one reportable grammar
+**Depends on / extends (do NOT duplicate):**
+- [2026-06-07-unified-lifecycle-backbone-design.md](2026-06-07-unified-lifecycle-backbone-design.md) — the canonical axes (`LifecycleStage`, `LifecycleStatus`, realization, freshness, currency), `resolveLifecycle`, `LifecycleEvent`, legal-transition maps. This spec **adds the in-stage State + advancement-gate layer on top of that backbone**; it does not re-found lifecycle.
+- [2026-03-21-csdm6-digital-product-metamodel-and-ontology-design.md](2026-03-21-csdm6-digital-product-metamodel-and-ontology-design.md) — CSDM realization axis this grammar aligns to.
+
+---
+
+## 1. Problem
+
+The Unified Lifecycle Backbone (`apps/web/lib/lifecycle.ts`, live) gave the platform **one set of ordered stages** (`plan → design → build → production → retirement`) and a **flat 3-value operational condition** (`draft · active · inactive`) with legal-transition maps and a universal append-only log (`LifecycleEvent`). That reconciled *which stage* every governed thing is in.
+
+What it does **not** give us is the thing the owner actually asked for (2026-08-14), which is the **CSDM stage/state distinction**:
+
+> A standardized way to articulate lifecycles as **Stages** and, within each stage, **States** — so we can (a) report on which stage every managed thing is in, and (b) within a stage, know the state that says whether it is *ready to move forward*.
+
+Three concrete symptoms of the missing layer:
+
+1. **`LifecycleStatus` is too coarse to gate advancement.** `draft/active/inactive` cannot express "in the `qualify` stage, but blocked" vs "in the `qualify` stage and ready to advance." Every surface that needs "is this ready to move forward?" has had to invent its own answer.
+
+2. **The one place that *does* model stage-exit is hard-coded and un-reusable.** `apps/web/lib/crm/pipeline-inspector.ts` has `STAGE_EXIT_CRITERIA` (per-stage checklists) and `STAGE_STALE_THRESHOLDS_DAYS`, but only for CRM opportunity stages (`qualification/discovery/proposal/…`). It is exactly the canonical stage-gate the whole platform needs, trapped in one feature.
+
+3. **`LifecycleEvent` records stage and status, but not state, so two-axis reporting is impossible.** The log has `fromStage/toStage/fromStatus/toStatus` — there is no `fromState/toState`, so "count-by-stage AND state-within-stage" cannot be computed from the ledger.
+
+The result: the four other EP-VSL-SURFACE workstreams (CRM wiring, retain instrumentation, partner lifecycle, tech-stack board) would each re-invent "what are this thing's in-stage states and when may it advance." This spec exists so they don't — they declare a `LifecycleGrammar` and inherit gating, transition validation, event logging, and two-axis reporting for free.
+
+## 2. Non-goals
+
+- **Not** re-founding the backbone axes. `LifecycleStage`, realization, freshness, currency, `resolveLifecycle`, and `deriveTemporalPerspective` stay exactly as they are.
+- **Not** collapsing OVSM stages, CRM opportunity stages, and `CustomerAccount.status` into one enum. The grammar is a *shape* multiple lifecycles instantiate, not a single global stage list. (Re-expressing each existing lifecycle in the grammar is acceptance criterion work, done without inventing new parallel machines.)
+- **Not** a UI epic. This delivers the grammar (types + storage + reporting API) plus a minimal reporting read-model; rich per-lifecycle boards are the downstream BIs.
+
+## 3. The grammar
+
+### 3.1 Definitions
+
+- A **Lifecycle** is an ordered set of **Stages** (the existing progression axis — e.g. backbone `plan…retirement`, OVSM `attract…retain`, an account's relationship arc).
+- Each **Stage** declares a set of **States** — the *internal condition within that stage*. Every stage has exactly one **entry state** (assigned on stage entry) and at least one **exit-ready state** (the gate is open). States between them are stage-local (`on-track`, `blocked`, `waiting`, …).
+- **Advancement** `Stage N → Stage N+1` is **gated**: it is legal only when the current state is an exit-ready state of Stage N **and** the target stage is reachable under the lifecycle's legal-transition map.
+- **Two-axis reporting** is intrinsic: every governed entity resolves to *(stage, state)*. Reports project **count-by-stage** and **state-within-stage** (roll up each stage's states to a health band: `on-track` / `blocked` / `ready-to-advance`).
+
+### 3.2 Canonical health bands (the roll-up)
+
+Individual states are lifecycle-specific, but every state maps to one **health band** so cross-lifecycle reporting is uniform:
+
+| Band | Meaning | Example states |
+|---|---|---|
+| `ready` | exit-ready; the gate is open | `qualified`, `quote-accepted`, `renewal-secured` |
+| `on-track` | progressing normally, gate not yet open | `entered`, `in-discovery`, `active-use` |
+| `blocked` | needs intervention to progress | `blocked`, `objection-open`, `at-risk` |
+
+`ready`/`on-track`/`blocked` are the canonical band union; each declared state names its band. This is what lets "% of accounts ready to advance" be one query across every lifecycle.
+
+### 3.3 Type shape (`apps/web/lib/lifecycle-grammar.ts`, new; pure, no server imports)
+
+```ts
+export const LIFECYCLE_HEALTH_BANDS = ["on-track", "blocked", "ready"] as const;
+export type LifecycleHealthBand = (typeof LIFECYCLE_HEALTH_BANDS)[number];
+
+export type StageState = {
+  // Hyphenated per AGENTS.md §3 — EXCEPT keys that mirror an already-stored union value,
+  // which retain the stored spelling so native decomposition round-trips (e.g. `at_risk`,
+  // `closed_won`; see §5, and the historical-spelling exemption in customer-lifecycle.ts).
+  key: string;
+  label: string;
+  band: LifecycleHealthBand;
+  isEntry?: boolean;              // exactly one per stage
+  isExitReady?: boolean;         // ≥1 per non-terminal stage
+};
+
+export type LifecycleStageDef = {
+  key: string;                    // the Stage identifier within this lifecycle
+  label: string;
+  states: readonly StageState[];
+  /** Stages legally reachable from here; terminal stages declare []. */
+  advancesTo: readonly string[];
+  isTerminal?: boolean;
+  // Exit criteria + the stale clock are PER-STAGE (F3): the pattern generalised —
+  // STAGE_EXIT_CRITERIA / STAGE_STALE_THRESHOLDS_DAYS in pipeline-inspector.ts — is keyed
+  // by stage, and staleness is measured as time-in-stage (opportunity.stageChangedAt), not
+  // time-in-state. Preserve the existing fallbacks on re-import: getStageExitCriteria's
+  // default 2-item list and isStageStale's default of 14 days.
+  /** Operator-facing checklist that justifies exit-ready (generalises STAGE_EXIT_CRITERIA). */
+  exitCriteria?: readonly string[];
+  /** Days-in-stage before the stage is flagged stale (generalises STAGE_STALE_THRESHOLDS_DAYS). */
+  staleAfterDays?: number;
+};
+
+export type LifecycleGrammar = {
+  key: string;                    // e.g. "customer-account", "ovsm", "tech-currency"
+  label: string;
+  stages: readonly LifecycleStageDef[];
+};
+```
+
+### 3.4 Pure engine (same file)
+
+```ts
+// Validation performed once at module load (dev + test) — a malformed grammar throws.
+export function validateGrammar(g: LifecycleGrammar): void;   // one entry state/stage, ≥1 exit-ready/non-terminal, advancesTo keys resolve
+
+export function getStage(g, stageKey): LifecycleStageDef | null;
+export function getState(g, stageKey, stateKey): StageState | null;
+
+/** The gate: may this entity advance to `toStage` right now? */
+export function canAdvance(
+  g: LifecycleGrammar,
+  from: { stage: string; state: string },
+  toStage: string,
+): { allowed: boolean; reason?: string };
+//   false + reason when: state not exit-ready | toStage not in advancesTo | unknown keys.
+
+/** Reporting projection over a set of (stage,state) points → two-axis rollup. */
+export function summarizeLifecycle(
+  g: LifecycleGrammar,
+  points: readonly { stage: string; state: string }[],
+): {
+  byStage: Record<string, number>;
+  byBand: Record<LifecycleHealthBand, number>;
+  byStageBand: Record<string, Record<LifecycleHealthBand, number>>;
+};
+```
+
+`canAdvance` is the single gate every lifecycle transition calls. `summarizeLifecycle` is the single reporting projection every board calls. Neither touches the DB.
+
+## 4. Storage & the event ledger
+
+### 4.1 Where the (stage, state) point lives
+
+The grammar is a *shape*, not a new table of instances. Each governed entity keeps storing its own stage on its own column (`CustomerAccount.status`, `EaElement.lifecycleStage`, `DigitalProduct.lifecycleStage`, …). The **new** requirement is a home for the **in-stage State**. Two mechanisms, and **exactly one applies per entity** — an entity must not use both, or the (stage, state) source of truth becomes ambiguous:
+
+- **Native decomposition** where the entity already conflates stage+state in one union (e.g. `CustomerAccount.status`'s `at_risk` is really `active`-stage + `at-risk`-state): the grammar's `resolve` mapper decomposes the stored value into `(stage, state)`. No new column. **Limit:** native decomposition can only express the states the stored union already encodes — you cannot represent `active`-stage + `blocked`-state unless the union carries an `at_risk`-like value. Where a native union is too coarse for the states a downstream BI needs to gate, that BI adopts the companion column instead.
+- **`grammarStateKey` companion column** (nullable `String`) on entities whose stage column is a pure stage and needs a separate state. Named `grammarStateKey` (not `lifecycleState`) deliberately: `lifecycleState` is already a live column with unrelated semantics — `SkillDefinition.lifecycleState` (the `SkillLifecycleState` union) and `buildCustomerConfigurationItemLifecycleState` in `crm.ts` — so a generic `lifecycleState` would overload an existing name. Added only for entities the downstream BIs actually gate (introduced by those BIs, not pre-emptively here).
+
+A per-entity **resolver** (mirroring `resolveLifecycle`'s kind-switch) maps each model's stored fields → `{ grammar, stage, state }`. This is the seam that keeps "no new parallel machine": one place per entity, referencing the shared grammar.
+
+### 4.2 `LifecycleEvent` gains the state axis (migration)
+
+`LifecycleEvent` (schema.prisma:8454) already logs stage+status transitions. Add two nullable columns so it records the state axis too:
+
+```prisma
+model LifecycleEvent {
+  // … existing fields …
+  fromState  String?   // StageState.key | null  (in-stage state at start)
+  toState    String?   // StageState.key | null  (in-stage state after transition)
+  // existing fromStage/toStage/fromStatus/toStatus retained unchanged
+}
+```
+
+- Additive, nullable → backfill-free, safe migration. Existing rows keep `null` state.
+- `fromStatus/toStatus` (the flat backbone condition) are **retained**, not repurposed — the grammar State is a finer axis layered above `LifecycleStatus`, not a replacement. A transition may set both (e.g. `toStatus:"active"`, `toState:"renewal-secured"`).
+- **Open vocabulary (unlike the other four columns).** `fromStatus/toStatus` reference the *closed* `LifecycleStatus` enum; `fromState/toState` store an **arbitrary per-grammar `StageState.key`** (an open set, no single canonical enum). The DB column comment for `fromState/toState` must say so — "open per-grammar state key, not a canonical enum" — so it is not mistaken for a closed-enum mirror.
+- **`toStatus` may legitimately be null for native-decomposition entities.** A `CustomerAccount`/`Opportunity` transition carries `toStage`+`toState` but its stored column is not a `LifecycleStatus`, so `toStatus` is null by design — not a data defect.
+
+**Resolving `governedThingKind` for grammar entities (F1 — the blocking seam).** `LifecycleEvent.governedThingKind` is a plain `String` column, but the app-layer `parseGovernedThingRef` (`governed-thing-ref.ts`) validates it against the **closed** `GOVERNED_THING_KINDS` allowlist (`EaElement · DigitalProduct · InventoryEntity · ServiceOffering · Document · Agent · BusinessCapability`), whose header mandates that adding a kind also adds a `resolveLifecycle` branch + row-shape mapper in the same commit. `CustomerAccount` and `Opportunity` are **not** in it — and forcing them in would wrongly couple them to `resolveLifecycle` (the backbone-axis descriptor), a concern orthogonal to grammar state. Resolution: the grammar owns its **own** entity-kind registry — `LIFECYCLE_GRAMMAR_KINDS`, the set of entity kinds each declared grammar applies to (`customer-account`→`CustomerAccount`, `opportunity`→`Opportunity`, …). `recordLifecycleTransition` validates `governedThingKind` against `GOVERNED_THING_KINDS ∪ LIFECYCLE_GRAMMAR_KINDS` and does **not** route grammar-entity writes through `parseGovernedThingRef`'s closed check. The EA allowlist and its `resolveLifecycle` cascade stay closed; grammar entities log events through the widened write-path vocabulary. (Reads that need to know "is this an EA governed thing?" keep using the closed allowlist.)
+
+### 4.3 A small writer + reporting read-model
+
+- `recordLifecycleTransition(...)` (server lib) — validates via `canAdvance` when the stage changes, writes the `LifecycleEvent` row (with the state axis + actor Principal + optional evidence/toolExecution) for **grammar-driven** transitions. It is the funnel for grammar transitions, but **not** the only `LifecycleEvent` producer: `apps/web/lib/lifecycle/baseline-projector.ts:139` already emits `LifecycleEvent` rows (e.g. `toStatus:"inactive"` when a thing leaves the current-state estate). The two coexist — the projector logs backbone/estate transitions, `recordLifecycleTransition` logs grammar state/stage transitions; both append to the one universal ledger. (So the ledger is not "at 0" today; this BI adds the state axis and a second, grammar-aware writer.)
+- `getLifecycleSummary(grammarKey)` (server lib) — resolves the live entities for a grammar, runs `summarizeLifecycle`, returns the two-axis rollup for any board. One query source of truth for count-by-stage + state-within-stage.
+
+## 5. Re-expressing existing lifecycles (acceptance-criterion coverage)
+
+The grammar ships with the following grammars declared and their resolvers wired — proving the shape holds without new parallel enums:
+
+| Lifecycle | Stages source | State decomposition |
+|---|---|---|
+| **customer-account** | the 9-state `CustomerAccount.status` (`customer-lifecycle.ts`) | all 9 placed: stage arc `prospect → qualified → onboarding → active → closed`; within `active`, states `active` (on-track), `at_risk` (blocked, stored spelling kept), `suspended` (blocked); tombstones `superseded`/`archived` map to a single terminal `closed`-family stage as terminal states. No status left unplaced. |
+| **opportunity** | CRM opportunity stages (`qualification/discovery/proposal/negotiation/closed_won/closed_lost`, stored underscore spelling kept) | lift `STAGE_EXIT_CRITERIA` + `STAGE_STALE_THRESHOLDS_DAYS` verbatim into each **stage's** `exitCriteria`/`staleAfterDays`; preserve the default 2-item criteria list and default 14-day stale fallback. `pipeline-inspector.ts` re-imports these from the grammar (behaviour-preserving). |
+| **backbone** (`EaElement`/`DigitalProduct`/`Agent`) | `plan…retirement` | each stage's `advancesTo` **derives from `LIFECYCLE_STAGE_TRANSITIONS`** (single source — the grammar must not restate the legal map, or the two drift); map flat `LifecycleStatus` → band: `active`=on-track/ready, `draft`=on-track, `inactive`=terminal. |
+| **tech-currency** | Currency axis (`current · approaching-eol · unsupported · end-of-life`) | each currency value is both stage and its own band (`current`=on-track, `approaching-eol`=blocked, `unsupported`/`end-of-life`=blocked/terminal). Consumed by BI-6328BCA6. |
+| **ovsm** | the six primary OVSM stages (`attract · capture · qualify · deliver · settle · retain`; the cross-cut `trust-compliance`/`operate-improve` and conditional `return-inspect`/`receive-store` stages in `operational-value-stream.ts` are out of scope here) | states per stage declared minimally; consumed/enriched by BI-9078F4EE + BI-A72D29BE. |
+
+Only `opportunity` and `customer-account` need their resolvers *and* a consuming surface touched in this BI (to prove the round-trip and de-duplicate `STAGE_EXIT_CRITERIA`). The others declare their grammar here and are consumed by their own downstream BIs — this BI does not rewrite those surfaces. `validateGrammar` runs against all declared grammars at test time, so even the un-wired ones are shape-proofed.
+
+## 6. CSDM mapping (documented, acceptance criterion)
+
+CSDM models a service/CI lifecycle as **stages** (Design → Build → Operate → Retire family) each carrying an **operational status/substate**. The grammar realizes that exactly: Stage = CSDM lifecycle stage, StageState = CSDM substate, `isExitReady` = CSDM "ready for next stage" gate, `LifecycleEvent` = the CSDM lifecycle-transition audit. Section 6 of the spec tabulates each declared grammar's stages/states against the CSDM stage/substate vocabulary.
+
+## 7. Blast radius & safety
+
+- **Additive migration only** (`LifecycleEvent.fromState/toState`, nullable). No column drops, no backfill, no enum column value removed. Per memory *new-prisma-model-gate-cascade* this is a column-add not a model-add, so the lighter migration path applies. Note the enum-mirror discipline differs per column: the *closed* union `LIFECYCLE_HEALTH_BANDS` (which no column stores directly) and the closed `LifecycleStatus` follow the canonical-enum comment rule, but `fromState/toState` hold **open per-grammar keys** — their column comment states "open per-grammar state key, not a canonical enum" so a reviewer does not expect an MCP enum mirror for them.
+- **Write-path vocabulary widened, EA allowlist unchanged** (F1). `recordLifecycleTransition` accepts `GOVERNED_THING_KINDS ∪ LIFECYCLE_GRAMMAR_KINDS`; `GOVERNED_THING_KINDS` and its `resolveLifecycle` cascade are untouched, so no EA-governed-thing reader regresses.
+- **`pipeline-inspector.ts`** changes from *owning* `STAGE_EXIT_CRITERIA` to *importing* it from the `opportunity` grammar — behaviour-preserving; existing `pipeline-inspector.test.ts` must stay green (regression guard).
+- **No new global enum on `LifecycleStatus`.** The grammar sits above it. Existing `resolveLifecycle` callers are untouched.
+- Pure engine (`lifecycle-grammar.ts`) is fully unit-testable with no DB; `validateGrammar` runs on every declared grammar at test time so a malformed grammar fails CI, not production.
+
+## 8. Testing
+
+- `lifecycle-grammar.test.ts` — `validateGrammar` rejects (no entry / no exit-ready / dangling `advancesTo`); `canAdvance` allows only from exit-ready to legal targets and returns typed reasons otherwise; `summarizeLifecycle` two-axis rollup arithmetic.
+- Resolver tests — `customer-account` decomposition (esp. `at_risk` → active+at-risk, tombstones → terminal) and `opportunity` criteria parity with the pre-existing `STAGE_EXIT_CRITERIA`.
+- `pipeline-inspector.test.ts` stays green after the re-import (behaviour-preserving refactor).
+- Migration applies cleanly; a `recordLifecycleTransition` round-trip writes a row carrying both `toStatus` and `toState`.
+
+## Backlog Coverage
+
+Atomic plan rationale: this is one independently useful, self-contained substrate BI (`BI-E55991E9`). The grammar types + pure engine, the `LifecycleEvent` state-axis migration, the writer/reporting libs, and the two proving resolvers (`customer-account`, `opportunity`) are not separately shippable — the engine without the event-log axis cannot record two-axis reporting, the migration without a writer accumulates nothing, and the grammar without at least one wired resolver is an unproven shape. The other four EP-VSL-SURFACE BIs each declare/consume their own grammar and ship independently on top of this one.

--- a/packages/db/prisma/migrations/20260815000000_add_lifecycle_event_state_axis/migration.sql
+++ b/packages/db/prisma/migrations/20260815000000_add_lifecycle_event_state_axis/migration.sql
@@ -1,0 +1,11 @@
+-- Canonical lifecycle grammar (BI-E55991E9): the LifecycleEvent ledger gains the in-stage
+-- STATE axis so it records both stage transitions and in-stage state transitions, enabling
+-- two-axis reporting (count-by-stage AND state-within-stage).
+--
+-- Additive + nullable → backfill-free and safe. Existing rows keep NULL state. The existing
+-- fromStatus/toStatus (the closed LifecycleStatus enum) are retained unchanged; fromState/toState
+-- hold an OPEN per-grammar StageState.key (apps/web/lib/lifecycle-grammar.ts), not a canonical enum,
+-- so no MCP enum mirror applies to them.
+ALTER TABLE "LifecycleEvent"
+  ADD COLUMN "fromState" TEXT,
+  ADD COLUMN "toState" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -8457,8 +8457,10 @@ model LifecycleEvent {
   governedThingId   String
   fromStage         String? // LifecycleStage | null
   toStage           String? // LifecycleStage | null
-  fromStatus        String? // LifecycleStatus | null
-  toStatus          String? // LifecycleStatus | null
+  fromStatus        String? // LifecycleStatus | null (closed canonical enum)
+  toStatus          String? // LifecycleStatus | null (closed canonical enum)
+  fromState         String? // open per-grammar StageState.key, NOT a canonical enum (lifecycle-grammar.ts)
+  toState           String? // open per-grammar StageState.key, NOT a canonical enum (lifecycle-grammar.ts)
   reason            String?        @db.Text
   evidenceRef       String? // pointer to corroborating evidence (discovery run, probe, etc.)
   actorPrincipalId  String?


### PR DESCRIPTION
## Canonical lifecycle grammar — Stages + in-stage States + advancement gates (BI-E55991E9)

Foundational workstream (Workstream 0) of **EP-VSL-SURFACE**. Adds the CSDM **Stage → in-stage State → advancement-gate** layer on top of the existing Unified Lifecycle Backbone (`apps/web/lib/lifecycle.ts`), so every lifecycle reports **two-axis** (count-by-stage AND state-within-stage) and gates advancement on an exit-ready state — **without inventing a parallel lifecycle machine**. The other four EP-VSL-SURFACE BIs express their stages through this grammar.

### What changed
- **`apps/web/lib/lifecycle-grammar.ts`** — pure engine: `StageState`/`LifecycleStageDef`/`LifecycleGrammar` types, `LIFECYCLE_HEALTH_BANDS` (`on-track`/`blocked`/`ready`), `validateGrammar`, `canAdvance` (the gate), `summarizeLifecycle` (two-axis rollup). No server imports.
- **`apps/web/lib/lifecycle-grammars.ts`** — five declared grammars: `customer-account` (native decomposition of the 9-state `CustomerAccount.status`), `opportunity` (lifts the CRM `STAGE_EXIT_CRITERIA`/`STAGE_STALE_THRESHOLDS_DAYS`), `backbone` (its legal map **derived from `LIFECYCLE_STAGE_TRANSITIONS`** so the two can't drift), `tech-currency`, `ovsm`; plus `LIFECYCLE_GRAMMAR_KINDS` write-path registry. All validated at module load.
- **Migration `20260815000000_add_lifecycle_event_state_axis`** — adds nullable `LifecycleEvent.fromState`/`toState` (open per-grammar key — **not** a canonical enum). Additive, backfill-free.
- **`apps/web/lib/lifecycle/lifecycle-transition.ts`** — `recordLifecycleTransition` (validates via `canAdvance`; widened kind vocabulary `GOVERNED_THING_KINDS ∪ LIFECYCLE_GRAMMAR_KINDS`; **coexists with** the existing `baseline-projector` producer) + `getLifecycleSummary` read-model.
- **`apps/web/lib/crm/pipeline-inspector.ts`** — now sources its exit-criteria/stale-thresholds from the opportunity grammar. Behaviour-preserving; existing tests unchanged and green.

### Why this shape
An independent architecture review confirmed the state layer does **not** duplicate the backbone (which has only a flat `draft/active/inactive` condition, no substate/gate concept), and surfaced the blocking seam that `LifecycleEvent.governedThingKind` enforces a **closed** EA allowlist excluding `CustomerAccount`/`Opportunity` — resolved by giving the grammar its own write-path kind vocabulary rather than dragging those entities into the `resolveLifecycle` cascade.

### Verification
- **Unit:** 32 tests green — grammar engine (22), writer guard-paths (5), pipeline-inspector regression (5).
- **Typecheck:** `apps/web` clean.
- **Local merged-CI (against `origin/main`):** passed — typecheck + vitest + production build; gate evidence `cmstn8ag1025c01t6o552nijf`.
- **Migration:** additive nullable; migration-safety guard clean.

### Docs
- Spec: `docs/superpowers/specs/2026-08-15-canonical-lifecycle-grammar-design.md`
- Plan: `docs/superpowers/plans/2026-08-15-canonical-lifecycle-grammar.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
