### PR TITLE
feat(deliberation): seal deliberation verdicts onto finite Work Rooms (EP-DELIBERATION-ROOMS)

### DIFF
--- a/apps/web/lib/deliberation/deliberation-room-bridge.server.ts
+++ b/apps/web/lib/deliberation/deliberation-room-bridge.server.ts
@@ -1,0 +1,79 @@
+/**
+ * Server bridge: seal a completed deliberation onto a finite Work Room
+ * (EP-DELIBERATION-ROOMS, BI-F8C5444A). Materializes the adjudicator TaskNode as a
+ * `task-node` room (idempotent) and persists the verdict as a durable
+ * work-room-outcome-packet message. Called NON-FATALLY from the deliberation
+ * runner after synthesis — the deliberation stands even if room-sealing fails.
+ * See deliberation-room.ts for the pure core.
+ */
+import { prisma } from "@dpf/db";
+
+import { bridgeTaskNodeToWorkItem } from "@/lib/queue/bridges/task-node-bridge";
+import { WORK_ROOM_OUTCOME_MESSAGE_TYPE } from "@/lib/work-management/room-cycle-adapter";
+import { buildDeliberationOutcomeSeal, verdictNeedsEscalation } from "./deliberation-room";
+
+/** Accountable ref for a machine-sealed deliberation verdict (a system record; a human reviews the room). */
+const DELIBERATION_ACCOUNTABLE_REF = "system:deliberation";
+
+export interface SealDeliberationOnRoomResult {
+  workItemId: string;
+  outcomeState: string;
+  needsEscalation: boolean;
+}
+
+/**
+ * Seal a completed deliberation's verdict onto its room. Returns null when there
+ * is nothing to seal (no synthesized outcome, or no adjudicator node).
+ */
+export async function sealDeliberationOnRoom(input: {
+  deliberationRunId: string;
+  adjudicatorTaskNodeId: string;
+  consensusState: string;
+  completedAt?: Date;
+}): Promise<SealDeliberationOnRoomResult | null> {
+  const outcome = await prisma.deliberationOutcome.findUnique({
+    where: { deliberationRunId: input.deliberationRunId },
+    select: { id: true, mergedRecommendation: true },
+  });
+  if (!outcome) return null;
+
+  // Materialize (idempotently) the adjudicator TaskNode as a finite task-node room.
+  const itemId = await bridgeTaskNodeToWorkItem(input.adjudicatorTaskNodeId);
+  const workItem = await prisma.workItem.findUnique({ where: { itemId }, select: { id: true } });
+  if (!workItem) return null;
+
+  // Idempotent: don't re-seal a room that already carries an outcome packet.
+  const existing = await prisma.workItemMessage.findFirst({
+    where: { workItemId: workItem.id, messageType: WORK_ROOM_OUTCOME_MESSAGE_TYPE },
+    select: { messageId: true },
+  });
+
+  const { packet, storedPayload } = buildDeliberationOutcomeSeal({
+    deliberationRunId: input.deliberationRunId,
+    adjudicatorTaskNodeId: input.adjudicatorTaskNodeId,
+    deliberationOutcomeId: outcome.id,
+    consensusState: input.consensusState,
+    mergedRecommendation: outcome.mergedRecommendation,
+    accountablePrincipalRef: DELIBERATION_ACCOUNTABLE_REF,
+    completedAt: input.completedAt ?? new Date(),
+  });
+
+  if (!existing) {
+    await prisma.workItemMessage.create({
+      data: {
+        workItemId: workItem.id,
+        senderType: "system",
+        messageType: WORK_ROOM_OUTCOME_MESSAGE_TYPE,
+        body: packet.summary,
+        structuredPayload: storedPayload as never,
+        channel: "in-app",
+      },
+    });
+  }
+
+  return {
+    workItemId: workItem.id,
+    outcomeState: packet.outcomeState,
+    needsEscalation: verdictNeedsEscalation(input.consensusState),
+  };
+}

--- a/apps/web/lib/deliberation/deliberation-room.test.ts
+++ b/apps/web/lib/deliberation/deliberation-room.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { parseStoredWorkRoomOutcome } from "../work-management/room-cycle-adapter";
+import {
+  buildDeliberationOutcomeSeal,
+  mapConsensusToOutcomeState,
+  verdictNeedsEscalation,
+} from "./deliberation-room";
+
+const BASE = {
+  deliberationRunId: "DRUN-1",
+  adjudicatorTaskNodeId: "dnode-DRUN-1-summarizer-0",
+  deliberationOutcomeId: "DOUT-1",
+  mergedRecommendation: "Adopt option B; the objection is mitigated.",
+  accountablePrincipalRef: "system:deliberation",
+  completedAt: new Date("2026-08-14T00:00:00.000Z"),
+};
+
+describe("mapConsensusToOutcomeState", () => {
+  it("maps consensus states to outcome states", () => {
+    expect(mapConsensusToOutcomeState("consensus")).toBe("achieved");
+    expect(mapConsensusToOutcomeState("partial-consensus")).toBe("partially-achieved");
+    expect(mapConsensusToOutcomeState("no-consensus")).toBe("not-achieved");
+    expect(mapConsensusToOutcomeState("insufficient-evidence")).toBe("not-achieved");
+    expect(mapConsensusToOutcomeState("anything-else")).toBe("not-achieved");
+  });
+});
+
+describe("verdictNeedsEscalation", () => {
+  it("escalates only when consensus was not reached", () => {
+    expect(verdictNeedsEscalation("consensus")).toBe(false);
+    expect(verdictNeedsEscalation("partial-consensus")).toBe(false);
+    expect(verdictNeedsEscalation("no-consensus")).toBe(true);
+    expect(verdictNeedsEscalation("insufficient-evidence")).toBe(true);
+  });
+});
+
+describe("buildDeliberationOutcomeSeal", () => {
+  it("seals a consensus verdict as an achieved packet referencing the canonical outcome", () => {
+    const { packet, storedPayload } = buildDeliberationOutcomeSeal({ ...BASE, consensusState: "consensus" });
+    expect(packet.outcomeState).toBe("achieved");
+    expect(packet.summary).toContain("option B");
+    // Canonical evidence ref → satisfies raw_chat_not_durable + the task-node evidence requirement.
+    expect(packet.evidenceRefs).toEqual([{ kind: "evidence", id: "DOUT-1" }]);
+    expect(packet.accountablePrincipalRef).toBe("system:deliberation");
+    // The stored payload round-trips through the room-outcome message parser.
+    expect(parseStoredWorkRoomOutcome(storedPayload)?.packet.outcomeState).toBe("achieved");
+    expect(storedPayload.carrierId).toBe(BASE.adjudicatorTaskNodeId);
+    expect(storedPayload.cycleKey).toBe("DRUN-1");
+  });
+
+  it("seals a no-consensus verdict as not-achieved (the review/escalation signal)", () => {
+    const { packet } = buildDeliberationOutcomeSeal({ ...BASE, consensusState: "no-consensus" });
+    expect(packet.outcomeState).toBe("not-achieved");
+  });
+
+  it("falls back to a generated summary when the recommendation is empty", () => {
+    const { packet } = buildDeliberationOutcomeSeal({ ...BASE, mergedRecommendation: "  ", consensusState: "consensus" });
+    expect(packet.summary).toContain("DRUN-1");
+  });
+});

--- a/apps/web/lib/deliberation/deliberation-room.ts
+++ b/apps/web/lib/deliberation/deliberation-room.ts
@@ -1,0 +1,100 @@
+/**
+ * Deliberation → Work Room verdict sealing (EP-DELIBERATION-ROOMS, BI-F8C5444A).
+ *
+ * Harmonizes the deliberation/debate pattern onto the Work Room substrate: a
+ * finished deliberation becomes a finite `task-node` room whose verdict is sealed
+ * as a durable WorkRoomOutcomePacket, referencing the canonical DeliberationOutcome
+ * (satisfies raw_chat_not_durable). A real consensus seals `achieved`/
+ * `partially-achieved`; no-consensus/insufficient-evidence seals `not-achieved` —
+ * the signal an operator reviews (and the alternate close = escalation).
+ *
+ * Pure module: no DB. The server bridge (deliberation-room-bridge.server.ts)
+ * materializes the room and persists the packet as a work-room-outcome-packet
+ * message. Design of record:
+ * docs/superpowers/specs/2026-08-12-work-room-multi-agent-communication-substrate-design.md §3
+ */
+import { WORK_ROOM_OUTCOME_MESSAGE_TYPE } from "../work-management/room-cycle-adapter";
+import { buildWorkRoomOutcomePacket } from "../work-management/outcome-packet";
+import type { WorkRoomOutcomePacket } from "../work-management/room-types";
+
+/** The registry sourceKey a deliberation room projects through (finite, evidence-only). */
+export const DELIBERATION_ROOM_SOURCE_KEY = "task-node";
+
+/** Map a deliberation consensus state to a room outcome state. */
+export function mapConsensusToOutcomeState(consensusState: string): WorkRoomOutcomePacket["outcomeState"] {
+  switch (consensusState) {
+    case "consensus":
+      return "achieved";
+    case "partial-consensus":
+      return "partially-achieved";
+    default:
+      // no-consensus | insufficient-evidence | anything unrecognized → not achieved.
+      return "not-achieved";
+  }
+}
+
+/** True when the verdict did not reach consensus — the escalation / needs-review signal. */
+export function verdictNeedsEscalation(consensusState: string): boolean {
+  return consensusState !== "consensus" && consensusState !== "partial-consensus";
+}
+
+export interface DeliberationRoomSealInput {
+  deliberationRunId: string;
+  /** The adjudicator TaskNode id — the room's sourceId (sourceType "task-node"). */
+  adjudicatorTaskNodeId: string;
+  /** Canonical DeliberationOutcome record id — the durable evidence ref. */
+  deliberationOutcomeId: string;
+  consensusState: string;
+  mergedRecommendation: string;
+  accountablePrincipalRef: string;
+  completedAt: Date | string;
+}
+
+export interface StoredDeliberationOutcome {
+  kind: typeof WORK_ROOM_OUTCOME_MESSAGE_TYPE;
+  version: 1;
+  cycleKey: string;
+  carrierId: string;
+  packet: WorkRoomOutcomePacket;
+}
+
+/**
+ * Build the sealed outcome packet + the stored-message payload for a deliberation
+ * verdict. Pure — throws WorkRoomOutcomePacketError on an invalid packet (e.g. a
+ * raw-chat evidence ref), never here.
+ */
+export function buildDeliberationOutcomeSeal(input: DeliberationRoomSealInput): {
+  packet: WorkRoomOutcomePacket;
+  storedPayload: StoredDeliberationOutcome;
+} {
+  const outcomeState = mapConsensusToOutcomeState(input.consensusState);
+  const summary =
+    input.mergedRecommendation.trim() ||
+    `Deliberation ${input.deliberationRunId} reached ${input.consensusState}.`;
+
+  const packet = buildWorkRoomOutcomePacket({
+    sourceKey: DELIBERATION_ROOM_SOURCE_KEY,
+    outcomeState,
+    summary,
+    accountablePrincipalRef: input.accountablePrincipalRef,
+    completedAt: input.completedAt,
+    facts: [
+      {
+        category: "evidence",
+        provenance: "canonical",
+        sourceRef: { kind: "evidence", id: input.deliberationOutcomeId },
+      },
+    ],
+  });
+
+  return {
+    packet,
+    storedPayload: {
+      kind: WORK_ROOM_OUTCOME_MESSAGE_TYPE,
+      version: 1,
+      cycleKey: input.deliberationRunId,
+      carrierId: input.adjudicatorTaskNodeId,
+      packet,
+    },
+  };
+}

--- a/apps/web/lib/queue/functions/deliberation-run.ts
+++ b/apps/web/lib/queue/functions/deliberation-run.ts
@@ -18,6 +18,7 @@
 
 import { inngest } from "../inngest-client";
 import { gateAtEntry } from "../quiescence-gates";
+import { sealDeliberationOnRoom } from "@/lib/deliberation/deliberation-room-bridge.server";
 
 /* -------------------------------------------------------------------------- */
 /* Public input                                                               */
@@ -75,6 +76,7 @@ export async function runDeliberation(input: RunDeliberationInput): Promise<void
       branchNodes: {
         select: {
           id: true,
+          taskNodeId: true,
           workerRole: true,
           status: true,
           routeDecision: true,
@@ -320,6 +322,23 @@ export async function runDeliberation(input: RunDeliberationInput): Promise<void
       where: { id: adj.id },
       data: { status: "completed", completedAt: new Date() },
     });
+  }
+
+  // EP-DELIBERATION-ROOMS (BI-F8C5444A): seal the verdict onto a finite Work Room,
+  // NON-FATALLY — the deliberation stands even if room-sealing fails.
+  try {
+    const adjudicator = adjudicatorBranches[0];
+    if (adjudicator?.taskNodeId) {
+      await sealDeliberationOnRoom({
+        deliberationRunId: run.id,
+        adjudicatorTaskNodeId: adjudicator.taskNodeId,
+        consensusState: compactSummary.consensusState,
+      });
+    }
+  } catch (err) {
+    console.warn(
+      `[deliberation-run] room seal skipped for ${run.id}: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
   await pushThreadProgress(input.threadId, input.taskRunId, {

--- a/docs/superpowers/plans/2026-08-14-deliberation-on-rooms.md
+++ b/docs/superpowers/plans/2026-08-14-deliberation-on-rooms.md
@@ -1,0 +1,24 @@
+# Deliberation on Work Rooms — Implementation Plan (BI-F8C5444A)
+
+**Epic:** EP-DELIBERATION-ROOMS · **Date:** 2026-08-14 · **Scope:** platform (WWMD)
+**Design of record:** `docs/superpowers/specs/2026-08-12-work-model-convergence-addendum-common-work-formula-design.md` §3 · **Kernel:** DI-A92A7184020F (intra-first)
+
+Harmonize the deliberation/debate pattern onto the Work Room substrate: a completed deliberation becomes a finite room whose verdict is sealed as a durable outcome — the durable-use pilot that proves the room-comms concept on a live pattern.
+
+## Slice delivered (this PR)
+
+Reuses the room substrate rather than rewriting the deliberation orchestrator, and adds **no new MCP tool, source-registry entry, or migration** (zero grant/tool-surface/audit drift):
+
+1. **Materialize the room** — the deliberation's adjudicator `TaskNode` is bridged to a finite `task-node` Work Room (`bridgeTaskNodeToWorkItem`, idempotent). The existing `task-node` source-registry entry already projects finite/evidence-only.
+2. **Seal the verdict** — on runner completion (after `synthesizeDeliberation`), `sealDeliberationOnRoom` builds a `WorkRoomOutcomePacket` from the verdict and persists it as a `work-room-outcome-packet` message:
+   - `consensus → achieved`, `partial-consensus → partially-achieved`, else `not-achieved`.
+   - The evidence fact references the canonical `DeliberationOutcome` record (`kind:"evidence"`), satisfying `raw_chat_not_durable` and the task-node evidence requirement.
+   - Idempotent (skips a room already carrying an outcome packet); NON-FATAL (the deliberation stands if sealing fails).
+
+- Pure core: `apps/web/lib/deliberation/deliberation-room.ts` (`mapConsensusToOutcomeState`, `verdictNeedsEscalation`, `buildDeliberationOutcomeSeal`) + tests.
+- Server bridge: `deliberation-room-bridge.server.ts`; wired into `apps/web/lib/queue/functions/deliberation-run.ts`.
+
+## Follow-ups (deliberately scoped out)
+
+- **DecisionInteraction write + escalation attention:** `DecisionInteraction.deliberationRunId` FK exists but is never written today. Sealing the verdict to the decision ledger (and lighting the `attention/sources/ai-decision.ts` escalation path for no-consensus via `outcomeType:"escalate"`, `humanOutcome:null`) is the next slice — the `not-achieved` packet is the interim review signal.
+- **Live debate on the room feed:** admit each branch's principal (`appendRoomPolicyParticipant`) and post its position (`post_room_message`) so the debate is visible in the room as it happens, not only at seal.


### PR DESCRIPTION
**BI-F8C5444A** — harmonize the deliberation/debate pattern onto the Work Room substrate. The durable-use pilot for room-comms: a completed deliberation becomes a finite `task-node` room whose verdict is sealed as a durable outcome.

## What
- **`deliberation-room.ts`** (pure) — `mapConsensusToOutcomeState` (consensus→achieved, partial→partially-achieved, else not-achieved), `verdictNeedsEscalation`, and `buildDeliberationOutcomeSeal`: builds the packet with a **canonical evidence ref** to the `DeliberationOutcome` (satisfies `raw_chat_not_durable` + the task-node evidence requirement). Tested, incl. round-trip through the room-outcome message parser.
- **`deliberation-room-bridge.server.ts`** — materializes the adjudicator `TaskNode` as a finite room (`bridgeTaskNodeToWorkItem`, idempotent) and persists the verdict as a `work-room-outcome-packet` message. Idempotent + **non-fatal**.
- Wired into the deliberation runner after synthesis.

Reuses the existing `task-node` source projection + outcome-packet/message substrate — **no new MCP tool, source-registry entry, or migration** (zero grant/tool-surface/audit drift).

## Verification
Local-CI merge gate **passed** (merged against main; full typecheck + suite + build; evidence `cmstosbb8020301qnn5dmt0dt`). 463 tests across `lib/deliberation` + `lib/queue`; typecheck clean; module-size / docs-impact / data-impact / WorkUnit-conformance gates pass.

## Follow-ups (scoped out)
Write the `DecisionInteraction` (`deliberationRunId` FK exists, never populated) + light the escalation attention path for no-consensus; live debate on the room feed (admit branch principals + post positions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)