### PR TITLE
feat(work-room): GAID-federated room participants — admit + mirror primitives (EP-WORKROOM-COMMS Phase 2)

### DIFF
--- a/apps/web/lib/identity/principal-linking.ts
+++ b/apps/web/lib/identity/principal-linking.ts
@@ -440,6 +440,31 @@ export function principalKindForContact(input: {
   return "customer";
 }
 
+/**
+ * Resolve-or-mint a LOCAL mirrored Principal for a FOREIGN (cross-install) GAID
+ * (EP-WORKROOM-COMMS Phase 2, BI-4CA4FCE5). The mirrored principal carries a `gaid`
+ * alias whose issuer is the FOREIGN namespace (never the empty INTERNAL_ISSUER), so
+ * it can never collide with a local agent's GAID. This is how an external agent is
+ * admitted to a room by its canonical PRN without any direct remote write — the
+ * sovereignty boundary lives in the A2A ingress/mirror layer, not here.
+ */
+export async function ensureFederatedRoomPrincipal(input: {
+  foreignGaid: string;
+  /** The foreign install's issuer namespace (must be non-empty; not INTERNAL_ISSUER). */
+  issuer: string;
+  displayName?: string | null;
+  db?: PrincipalDb;
+}): Promise<SyncedPrincipal> {
+  if (!input.issuer || input.issuer === INTERNAL_ISSUER) {
+    throw new Error("A federated (foreign) GAID must carry a non-empty foreign issuer namespace.");
+  }
+  return upsertPrincipalForAliases(input.db ?? prisma, {
+    kind: "external-agent",
+    displayName: input.displayName?.trim() || input.foreignGaid,
+    aliases: [{ aliasType: "gaid", aliasValue: input.foreignGaid, issuer: input.issuer }],
+  });
+}
+
 export async function ensureAgentPrincipalIdentity(
   agentId: string,
   db: PrincipalDb = prisma,

--- a/apps/web/lib/work-management/federated-room.server.ts
+++ b/apps/web/lib/work-management/federated-room.server.ts
@@ -1,0 +1,129 @@
+/**
+ * Server binding for GAID-federated Work Room participation
+ * (EP-WORKROOM-COMMS Phase 2, BI-4CA4FCE5).
+ *
+ * The sovereignty-preserving "apply" primitives an inbound A2A room event calls: an
+ * external GAID participant is admitted to a room by its LOCAL mirrored principal
+ * (outcome-scoped), and inbound posts are mirrored as external WorkItemMessages —
+ * never a direct remote write. Gated (flag + trusted link + same-org) via the pure
+ * core. First slice: same-org trusted links only, behind DPF_FEDERATION_A2A_ENABLED.
+ * The HTTP CloudEvent ingress that drives these is a documented follow-up.
+ */
+import { prisma } from "@dpf/db";
+
+import { ensureFederatedRoomPrincipal } from "@/lib/identity/principal-linking";
+import {
+  buildFederatedRoomMessageMirror,
+  evaluateFederatedRoomAdmission,
+  type FederatedRoomGateDecision,
+} from "./federated-room";
+import { appendRoomPolicyParticipant } from "./room-policy";
+import { decodeWorkCaseKey } from "./workspace-case-loader";
+
+function a2aFederationEnabled(): boolean {
+  return process.env.DPF_FEDERATION_A2A_ENABLED === "true";
+}
+
+async function resolveRoomWorkItem(caseKey: string) {
+  const decoded = decodeWorkCaseKey(caseKey);
+  if (!decoded) return null;
+  return prisma.workItem.findFirst({
+    where: {
+      OR: [
+        { sourceType: decoded.sourceType, sourceId: decoded.sourceId },
+        { sourceType: decoded.sourceType, itemId: decoded.sourceId },
+      ],
+    },
+    select: { id: true, itemId: true, title: true, evidence: true },
+  });
+}
+
+export interface FederatedRoomAdmissionResult {
+  gate: FederatedRoomGateDecision;
+  mirroredPrincipalId?: string;
+  workItemId?: string;
+  error?: "invalid-case-key" | "room-not-found";
+}
+
+/**
+ * Admit an external GAID participant to a room, outcome-scoped, if the sovereignty
+ * gate passes. Mints/resolves the LOCAL mirrored principal and appends it to the
+ * room policy. `linkTrusted` and `sameOrg` are resolved by the caller (the A2A
+ * ingress) from the federation link auth.
+ */
+export async function admitFederatedRoomParticipant(input: {
+  federationLinkId: string;
+  linkTrusted: boolean;
+  sameOrg: boolean;
+  foreignGaid: string;
+  issuer: string;
+  caseKey: string;
+  canAct: boolean;
+  displayName?: string | null;
+}): Promise<FederatedRoomAdmissionResult> {
+  const gate = evaluateFederatedRoomAdmission({
+    a2aEnabled: a2aFederationEnabled(),
+    linkTrusted: input.linkTrusted,
+    sameOrg: input.sameOrg,
+  });
+  if (!gate.allowed) return { gate };
+
+  const principal = await ensureFederatedRoomPrincipal({
+    foreignGaid: input.foreignGaid,
+    issuer: input.issuer,
+    displayName: input.displayName,
+  });
+
+  const item = await resolveRoomWorkItem(input.caseKey);
+  if (!item) return { gate, error: "room-not-found" };
+
+  const newEvidence = appendRoomPolicyParticipant(item.evidence, {
+    principalRef: principal.principalId,
+    roles: ["contributor"],
+    canAct: input.canAct,
+    enteredReason: `Federated participant via link ${input.federationLinkId}`,
+  });
+  await prisma.workItem.update({ where: { id: item.id }, data: { evidence: newEvidence as never } });
+
+  return { gate, mirroredPrincipalId: principal.principalId, workItemId: item.id };
+}
+
+/**
+ * Mirror an inbound federated room post as an external WorkItemMessage. Idempotent
+ * on the peer message id. Requires the participant to have been admitted first
+ * (same gate applies upstream at the ingress).
+ */
+export async function mirrorFederatedRoomMessage(input: {
+  federationLinkId: string;
+  foreignGaid: string;
+  caseKey: string;
+  body: string;
+  /** Stable peer event id for idempotency. */
+  peerMessageId: string;
+}): Promise<{ mirrored: boolean; workItemId?: string }> {
+  const item = await resolveRoomWorkItem(input.caseKey);
+  if (!item) return { mirrored: false };
+
+  const mirror = buildFederatedRoomMessageMirror({
+    foreignGaid: input.foreignGaid,
+    federationLinkId: input.federationLinkId,
+    messageId: `a2a:${input.federationLinkId}:${input.peerMessageId}`,
+    body: input.body,
+  });
+
+  await prisma.workItemMessage.upsert({
+    where: { messageId: mirror.messageId },
+    create: {
+      messageId: mirror.messageId,
+      workItemId: item.id,
+      senderType: mirror.senderType,
+      messageType: mirror.messageType,
+      channel: mirror.channel,
+      body: mirror.body,
+      structuredPayload: mirror.structuredPayload as never,
+    },
+    update: {},
+  });
+
+  return { mirrored: true, workItemId: item.id };
+}

--- a/apps/web/lib/work-management/federated-room.test.ts
+++ b/apps/web/lib/work-management/federated-room.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFederatedRoomMessageMirror,
+  evaluateFederatedRoomAdmission,
+} from "./federated-room";
+
+describe("evaluateFederatedRoomAdmission (sovereignty gate, deny-by-default)", () => {
+  it("allows only when flag + trusted link + same-org all hold", () => {
+    expect(evaluateFederatedRoomAdmission({ a2aEnabled: true, linkTrusted: true, sameOrg: true })).toEqual({
+      allowed: true,
+      reason: "allowed",
+    });
+  });
+
+  it("denies when the A2A federation flag is off", () => {
+    const d = evaluateFederatedRoomAdmission({ a2aEnabled: false, linkTrusted: true, sameOrg: true });
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toBe("a2a-federation-disabled");
+  });
+
+  it("denies an untrusted link", () => {
+    const d = evaluateFederatedRoomAdmission({ a2aEnabled: true, linkTrusted: false, sameOrg: true });
+    expect(d).toEqual({ allowed: false, reason: "link-not-trusted" });
+  });
+
+  it("denies cross-org in the first slice", () => {
+    const d = evaluateFederatedRoomAdmission({ a2aEnabled: true, linkTrusted: true, sameOrg: false });
+    expect(d).toEqual({ allowed: false, reason: "cross-org-denied" });
+  });
+});
+
+describe("buildFederatedRoomMessageMirror", () => {
+  it("mirrors an inbound post as an external message carrying the GAID (never a local sender)", () => {
+    const m = buildFederatedRoomMessageMirror({
+      foreignGaid: "gaid:priv:peer.example:agent-9",
+      federationLinkId: "LINK-1",
+      messageId: "a2a:LINK-1:evt-7",
+      body: "Peer coworker weighs in.",
+    });
+    expect(m.senderType).toBe("external");
+    expect(m.channel).toBe("a2a");
+    expect(m.structuredPayload).toEqual({
+      federated: true,
+      gaid: "gaid:priv:peer.example:agent-9",
+      federationLinkId: "LINK-1",
+    });
+    // No senderUserId / senderAgentId — external identity rides in structuredPayload.
+    expect("senderUserId" in m).toBe(false);
+    expect("senderAgentId" in m).toBe(false);
+  });
+});

--- a/apps/web/lib/work-management/federated-room.ts
+++ b/apps/web/lib/work-management/federated-room.ts
@@ -1,0 +1,81 @@
+/**
+ * Cross-install (GAID-federated) Work Room participation — pure core
+ * (EP-WORKROOM-COMMS Phase 2, BI-4CA4FCE5).
+ *
+ * An external agent/person from another install may join a room — GAID-identified,
+ * outcome-scoped, NEVER carte-blanche — and their posts are MIRRORED in (never a
+ * direct remote write). This module holds the sovereignty gate and the mirrored-
+ * message shape; the server binding (federated-room.server.ts) does the DB work.
+ *
+ * First slice is deliberately conservative: same-org trusted links only, behind a
+ * flag. Design of record:
+ * docs/superpowers/specs/2026-08-12-work-room-multi-agent-communication-substrate-design.md §5
+ */
+
+export interface FederatedRoomGateInput {
+  /** DPF_FEDERATION_A2A_ENABLED — the A2A room-federation feature flag. */
+  a2aEnabled: boolean;
+  /** The federation link is mutually approved and not revoked/quarantined. */
+  linkTrusted: boolean;
+  /** The peer is the SAME organization (first slice denies cross-org). */
+  sameOrg: boolean;
+}
+
+export interface FederatedRoomGateDecision {
+  allowed: boolean;
+  reason:
+    | "allowed"
+    | "a2a-federation-disabled"
+    | "link-not-trusted"
+    | "cross-org-denied";
+}
+
+/**
+ * The sovereignty gate every federated room admission/mirror must pass. All three
+ * conditions are required; the first failure is reported. Deny-by-default.
+ */
+export function evaluateFederatedRoomAdmission(input: FederatedRoomGateInput): FederatedRoomGateDecision {
+  if (!input.a2aEnabled) return { allowed: false, reason: "a2a-federation-disabled" };
+  if (!input.linkTrusted) return { allowed: false, reason: "link-not-trusted" };
+  if (!input.sameOrg) return { allowed: false, reason: "cross-org-denied" };
+  return { allowed: true, reason: "allowed" };
+}
+
+export interface FederatedRoomMessageMirrorInput {
+  foreignGaid: string;
+  federationLinkId: string;
+  /** Stable idempotency key from the peer event (providerKey:providerEventId shape). */
+  messageId: string;
+  body: string;
+}
+
+export interface FederatedRoomMessageMirror {
+  messageId: string;
+  senderType: "external";
+  messageType: "external-event";
+  channel: "a2a";
+  body: string;
+  structuredPayload: { federated: true; gaid: string; federationLinkId: string };
+}
+
+/**
+ * Build the mirrored WorkItemMessage for an inbound federated room post. Sender is
+ * "external" (no local user/agent); the GAID and link ride in structuredPayload —
+ * mirroring the human external-channel ingress pattern. No schema change.
+ */
+export function buildFederatedRoomMessageMirror(
+  input: FederatedRoomMessageMirrorInput,
+): FederatedRoomMessageMirror {
+  return {
+    messageId: input.messageId,
+    senderType: "external",
+    messageType: "external-event",
+    channel: "a2a",
+    body: input.body,
+    structuredPayload: {
+      federated: true,
+      gaid: input.foreignGaid,
+      federationLinkId: input.federationLinkId,
+    },
+  };
+}

--- a/docs/superpowers/plans/2026-08-14-gaid-federated-rooms.md
+++ b/docs/superpowers/plans/2026-08-14-gaid-federated-rooms.md
@@ -1,0 +1,23 @@
+# GAID-Federated Work Room Participants — Implementation Plan (BI-4CA4FCE5)
+
+**Epic:** EP-WORKROOM-COMMS (Phase 2) · **Date:** 2026-08-14 · **Scope:** platform (WWMD)
+**Design of record:** `docs/superpowers/specs/2026-08-12-work-room-multi-agent-communication-substrate-design.md` §5 · **Kernel:** DI-A92A7184020F (intra-first; Phase 2 follows Phase 1)
+**Builds on:** the federated GAID/A2A coordination substrate (`2026-08-08-federated-a2a-gaid-coordination-design.md`, `2026-08-11-a2a-coordination-layer-design.md`).
+
+Let an external agent/person from another install join a room — GAID-identified, outcome-scoped, never carte-blanche — with sovereignty preserved: their join/posts are MIRRORED in via the federation envelope, never a direct remote write. Room membership stays PRN-based; the sovereignty boundary lives in the ingress/mirror layer.
+
+## Slice delivered (this PR) — the sovereignty-preserving "apply" primitives
+
+Conservative first slice: **same-org, trusted links only, behind `DPF_FEDERATION_A2A_ENABLED` (off by default)**. No migration (all new values ride existing free-string columns).
+
+- **Foreign GAID → local mirrored principal** — `ensureFederatedRoomPrincipal({foreignGaid, issuer, displayName})` (principal-linking.ts): a `Principal(kind:"external-agent")` carrying a `gaid` alias with the **foreign** issuer namespace (never the empty INTERNAL_ISSUER, so it can't collide with a local agent's GAID). This is the local identity a room admits by PRN.
+- **Sovereignty gate (pure)** — `evaluateFederatedRoomAdmission({a2aEnabled, linkTrusted, sameOrg})`: deny-by-default; all three required. Tested.
+- **Admit primitive** — `admitFederatedRoomParticipant(...)`: gate → mint mirrored principal → `appendRoomPolicyParticipant` (admit the mirrored PRN, outcome-scoped to that one room) → persist `WorkItem.evidence`. `linkTrusted`/`sameOrg` resolved by the caller from the federation link auth.
+- **Mirror inbound posts** — `mirrorFederatedRoomMessage(...)`: an inbound federated post becomes an external `WorkItemMessage` (`senderType:"external"`, `channel:"a2a"`, GAID in `structuredPayload`), idempotent on the peer event id — the human external-channel-ingress pattern applied to A2A. Never a direct remote write.
+
+## Follow-ups (deliberately deferred — noted in the design)
+
+- **HTTP CloudEvent ingress dispatch** — add `dpf.room.participant-joined` / `dpf.room.message-posted` to the federation inbox dispatch (`api/v1/federation/…`), landing a `FederatedRecordMirror(recordType:"room-*")` then calling these apply primitives. Depends on peer-side event emission.
+- **RFC 9421 device signature + `peerSigningPublicKey` pinning + an A2A-readiness bit on `FederationLink`** (spec §4.3, §9) — a migration + enrollment-handshake change. This slice runs on **token-trust only**; label it the **"A2A-shaped DPF federation profile,"** not "A2A compliant."
+- **Cross-org** projection-contract egress minimization + signed commitments (spec §8.2, §11) — first slice is same-org, deny cross-org.
+- Typed `senderGaid`/`senderPrincipalId` columns and a `WorkRoomParticipantView.kind` policy marker — kept in `structuredPayload` / derived from the mirrored `Principal.kind` to avoid migrations.


### PR DESCRIPTION
**BI-4CA4FCE5** — the sovereignty-preserving Phase 2 core. An external agent/person from another install can join a room, **GAID-identified and outcome-scoped**, with their posts **mirrored in via the federation envelope — never a direct remote write**. Conservative first slice: **same-org, trusted links only, behind `DPF_FEDERATION_A2A_ENABLED` (off by default)**. **No migration.**

## What
- **`ensureFederatedRoomPrincipal`** (principal-linking.ts) — resolve/mint a **local mirrored** `Principal(kind:"external-agent")` for a **foreign** GAID, carrying a `gaid` alias with the foreign issuer namespace (never `INTERNAL_ISSUER` — can't collide with a local agent's GAID). The identity a room admits by canonical PRN.
- **`federated-room.ts`** (pure) — `evaluateFederatedRoomAdmission` (deny-by-default gate: flag + trusted link + same-org, all required) + `buildFederatedRoomMessageMirror` (external sender, GAID in `structuredPayload`). Tested.
- **`federated-room.server.ts`** — `admitFederatedRoomParticipant` (gate → mint mirrored principal → `appendRoomPolicyParticipant` → persist evidence) + `mirrorFederatedRoomMessage` (inbound post → external `WorkItemMessage`, idempotent). `linkTrusted`/`sameOrg` resolved by the caller from the federation link auth.

## Verification
Local-CI merge gate **passed** (merged against main; evidence `cmstpbufo03r001qnao0e2vkd`). 237 tests across `lib/work-management` + `lib/identity`; typecheck clean; module-size / docs-impact / data-impact / WorkUnit-conformance pass.

## Follow-ups (deferred, noted in the plan)
HTTP CloudEvent ingress dispatch (`dpf.room.*` → `FederatedRecordMirror` → these apply primitives); **RFC 9421 device-signature + `peerSigningPublicKey` pin + A2A-readiness bit** (migration) — this slice is **token-trust only**, an *"A2A-shaped DPF federation profile,"* **same-org**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)