### PR TITLE
feat(crm): wire CRM to value-stream/lifecycle substrate (BI-9078F4EE)

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
@@ -22,6 +22,7 @@ import {
   readActivationProfile,
 } from "@/lib/storefront/archetype-activation";
 import { getAccountStatusMeta } from "@/lib/crm/presentation";
+import { accountStatusToOvsmStage, ovsmStageLabel } from "@/lib/crm/account-value-stream";
 import { formatRevenueAmount } from "@/lib/crm/revenue-cockpit";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { getFinancialProfile } from "@dpf/finance-templates";
@@ -272,6 +273,14 @@ export default async function AccountDetailPage({
           <div className="flex items-center gap-2">
             <h1 className="text-xl font-bold text-[var(--dpf-text)]">{account.name}</h1>
             <CustomerStatusBadge label={statusMeta.label} tone={statusMeta.tone} />
+            {account.status !== "superseded" && account.status !== "archived" && (
+              <span
+                className="rounded-full border border-[var(--dpf-border)] px-2 py-0.5 text-xs text-[var(--dpf-muted)]"
+                title="Operational value stream stage"
+              >
+                Value stream · {ovsmStageLabel(accountStatusToOvsmStage(account.status))}
+              </span>
+            )}
           </div>
           {account.status !== "superseded" && (
             <div className="flex items-center gap-2">

--- a/apps/web/app/(shell)/customer/(crm)/funnel/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/funnel/page.tsx
@@ -8,6 +8,7 @@ import {
   type CrmTone,
 } from "@/lib/crm/presentation";
 import { formatRevenueAmount } from "@/lib/crm/revenue-cockpit";
+import { EXCLUDE_TOMBSTONED } from "@dpf/db/customer-lifecycle";
 import { OwnerFirstSummaryBand } from "@/components/owner-first/OwnerFirstSummary";
 import { loadOwnerFirstContext } from "@/lib/owner-first/context";
 import { buildWorkspaceStorefrontSummary } from "@/lib/owner-first/domain-summary";
@@ -43,12 +44,22 @@ export default async function FunnelPage() {
   ]);
 
   // CRM pipeline stages
-  const [engagements, opportunities] = await Promise.all([
+  const [engagements, opportunities, accountsByStatus] = await Promise.all([
     prisma.engagement.groupBy({ by: ["status"], _count: true }),
     prisma.opportunity.groupBy({ by: ["stage"], _count: true, _sum: { expectedValue: true } }),
+    prisma.customerAccount.groupBy({ by: ["status"], _count: true, where: EXCLUDE_TOMBSTONED }),
   ]);
 
   const totalInteractions = bookings + inquiries + orders + donations;
+  // Direct + reseller leads: accounts in the early relationship lifecycle (prospect/qualified).
+  // These feed the top of funnel when there is no published storefront, so a direct- or
+  // reseller-sourced pipeline is represented instead of a storefront we don't have (BI-9078F4EE).
+  const accountCount = (status: string) =>
+    accountsByStatus.find((a) => a.status === status)?._count ?? 0;
+  const directLeads = accountCount("prospect") + accountCount("qualified");
+  const hasStorefrontActivity = totalInteractions > 0;
+  // Top of funnel is storefront interactions when a storefront is active, else direct/reseller leads.
+  const topOfFunnel = hasStorefrontActivity ? totalInteractions : directLeads;
   const totalEngagements = engagements.reduce((s, e) => s + e._count, 0);
   const openOpps = opportunities.filter((o) =>
     OPEN_OPPORTUNITY_STAGES.includes(o.stage as (typeof OPEN_OPPORTUNITY_STAGES)[number]),
@@ -59,8 +70,8 @@ export default async function FunnelPage() {
   const wonValue = Number(opportunities.find((o) => o.stage === "closed_won")?._sum?.expectedValue ?? 0);
 
   // Conversion rates
-  const convToEngagement = totalInteractions > 0
-    ? ((totalEngagements / totalInteractions) * 100).toFixed(0)
+  const convToEngagement = topOfFunnel > 0
+    ? ((totalEngagements / topOfFunnel) * 100).toFixed(0)
     : null;
   const convToOpp = totalEngagements > 0
     ? (((totalOpenOpps + closedWon + closedLost) / totalEngagements) * 100).toFixed(0)
@@ -76,22 +87,32 @@ export default async function FunnelPage() {
   const primaryCount = ctaType === "booking" ? bookings : ctaType === "purchase" ? orders : ctaType === "donation" ? donations : inquiries;
 
   // Funnel stages data
+  const topWidthBase = Math.max(topOfFunnel, 1);
   const funnelStages = [
-    {
-      label: "Storefront Interactions",
-      count: totalInteractions,
-      detail: `${ctaLabel}: ${primaryCount}`,
-      convLabel: null as string | null,
-      tone: "accent" as CrmTone,
-      width: 100,
-    },
+    hasStorefrontActivity
+      ? {
+          label: "Storefront Interactions",
+          count: totalInteractions,
+          detail: `${ctaLabel}: ${primaryCount}`,
+          convLabel: null as string | null,
+          tone: "accent" as CrmTone,
+          width: 100,
+        }
+      : {
+          label: "Direct & Reseller Leads",
+          count: directLeads,
+          detail: `Prospects: ${accountCount("prospect")}, Qualified: ${accountCount("qualified")}`,
+          convLabel: null as string | null,
+          tone: "accent" as CrmTone,
+          width: 100,
+        },
     {
       label: "Engagements",
       count: totalEngagements,
       detail: engagements.map((e) => `${e.status}: ${e._count}`).join(", ") || "none",
       convLabel: convToEngagement ? `${convToEngagement}% conversion` : null,
       tone: "attention" as CrmTone,
-      width: totalInteractions > 0 ? Math.max(15, (totalEngagements / totalInteractions) * 100) : 15,
+      width: topOfFunnel > 0 ? Math.max(15, (totalEngagements / topOfFunnel) * 100) : 15,
     },
     {
       label: "Opportunities",
@@ -99,7 +120,7 @@ export default async function FunnelPage() {
       detail: openOpps.map((o) => `${o.stage}: ${o._count}`).join(", ") || "none",
       convLabel: convToOpp ? `${convToOpp}% conversion` : null,
       tone: "info" as CrmTone,
-      width: totalInteractions > 0 ? Math.max(10, ((totalOpenOpps + closedWon + closedLost) / Math.max(totalInteractions, 1)) * 100) : 10,
+      width: topOfFunnel > 0 ? Math.max(10, ((totalOpenOpps + closedWon + closedLost) / topWidthBase) * 100) : 10,
     },
     {
       label: "Closed Won",
@@ -107,7 +128,7 @@ export default async function FunnelPage() {
       detail: wonValue > 0 ? `Value: ${formatRevenueAmount(wonValue, baseCurrency)}` : "no revenue yet",
       convLabel: winRate ? `${winRate}% win rate` : null,
       tone: "success" as CrmTone,
-      width: totalInteractions > 0 ? Math.max(5, (closedWon / Math.max(totalInteractions, 1)) * 100) : 5,
+      width: topOfFunnel > 0 ? Math.max(5, (closedWon / topWidthBase) * 100) : 5,
     },
   ];
 
@@ -258,9 +279,14 @@ export default async function FunnelPage() {
         </>
       )}
 
-      {totalInteractions === 0 && (
+      {topOfFunnel === 0 && totalOpenOpps + closedWon + closedLost === 0 && (
         <p className="text-sm text-[var(--dpf-muted)] mt-4">
-          No storefront interactions in the last 30 days. Set up and publish your storefront to start receiving customer interactions.
+          No pipeline yet. Add an account or publish a storefront to begin.
+        </p>
+      )}
+      {topOfFunnel > 0 && !hasStorefrontActivity && (
+        <p className="text-xs text-[var(--dpf-muted)] mt-4">
+          Top of funnel: direct &amp; reseller leads (accounts in early lifecycle stages).
         </p>
       )}
     </div>

--- a/apps/web/lib/actions/crm-account-admin.ts
+++ b/apps/web/lib/actions/crm-account-admin.ts
@@ -11,6 +11,8 @@ import { prisma } from "@dpf/db";
 import { revalidatePath } from "next/cache";
 import { CUSTOMER_ACCOUNT_STATUSES } from "@dpf/db/customer-lifecycle";
 import { requireCapability } from "./shared/guards";
+import { recordLifecycleTransition } from "@/lib/lifecycle/lifecycle-transition";
+import { resolveCustomerAccountPoint } from "@/lib/lifecycle-grammars";
 import { logSystemActivity } from "@/lib/crm/crm-activity";
 import { customerAccountNormalizedColumns } from "@/lib/mdm/dedup-gate";
 
@@ -75,6 +77,19 @@ export async function updateCustomerAccount(input: {
   });
 
   const statusChanged = input.status !== undefined && input.status !== existing.status;
+  if (statusChanged) {
+    // Record the operator's lifecycle transition on the universal ledger with the in-stage
+    // state axis (two-axis reporting). Authoritative: the operator holds operate_customer and
+    // may set any settable status, so this is not gated by grammar readiness.
+    await recordLifecycleTransition({
+      governedThingKind: "CustomerAccount",
+      governedThingId: updated.id,
+      from: resolveCustomerAccountPoint(existing.status),
+      to: resolveCustomerAccountPoint(input.status as string),
+      reason: `Operator changed account status ${existing.status} → ${input.status}`,
+      authoritative: true,
+    });
+  }
   await logSystemActivity(
     statusChanged
       ? `Account "${updated.name}" status changed from ${existing.status} to ${input.status}`

--- a/apps/web/lib/actions/crm-commercial.test.ts
+++ b/apps/web/lib/actions/crm-commercial.test.ts
@@ -40,6 +40,9 @@ vi.mock("@dpf/db", () => ({
     activity: {
       create: vi.fn(),
     },
+    lifecycleEvent: {
+      create: vi.fn(),
+    },
   },
 }));
 
@@ -84,6 +87,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   // Dedup gate candidate fetch: default to "no similar rows".
   vi.mocked(prisma.$queryRaw).mockResolvedValue([]);
+  // Lifecycle ledger write (updateCustomerAccount records a status transition).
+  vi.mocked(prisma.lifecycleEvent.create).mockResolvedValue({ id: "evt-1" } as never);
 });
 
 describe("createQuote commercial lineage", () => {

--- a/apps/web/lib/actions/crm-opportunity-maintenance.ts
+++ b/apps/web/lib/actions/crm-opportunity-maintenance.ts
@@ -1,0 +1,43 @@
+"use server";
+
+// Opportunity maintenance actions. Extracted from crm.ts to keep that module focused
+// (module-size ratchet, BI-OPT-RATCHETS).
+
+import { prisma } from "@dpf/db";
+import { logSystemActivity } from "@/lib/crm/crm-activity";
+
+const DORMANT_THRESHOLD_DAYS = 45;
+
+/** Mark open opportunities with no stage change in DORMANT_THRESHOLD_DAYS as dormant. */
+export async function flagDormantOpportunities() {
+  const threshold = new Date();
+  threshold.setDate(threshold.getDate() - DORMANT_THRESHOLD_DAYS);
+
+  const stale = await prisma.opportunity.findMany({
+    where: {
+      isDormant: false,
+      stage: { notIn: ["closed_won", "closed_lost"] },
+      stageChangedAt: { lt: threshold },
+    },
+    select: { id: true, accountId: true, contactId: true, title: true },
+  });
+
+  for (const opp of stale) {
+    await prisma.opportunity.update({
+      where: { id: opp.id },
+      data: { isDormant: true },
+    });
+
+    await logSystemActivity(
+      `Opportunity "${opp.title}" marked dormant (no stage change in ${DORMANT_THRESHOLD_DAYS} days)`,
+      {
+        type: "system",
+        accountId: opp.accountId,
+        contactId: opp.contactId || undefined,
+        opportunityId: opp.id,
+      },
+    );
+  }
+
+  return { flagged: stale.length };
+}

--- a/apps/web/lib/actions/crm.ts
+++ b/apps/web/lib/actions/crm.ts
@@ -20,6 +20,7 @@ import {
   type DedupCheckResult,
   type DedupResolution,
 } from "@/lib/mdm/dedup-gate";
+import { qualifyAccountFromOpportunity, activateAccountFromWonDeal } from "@/lib/crm/account-lifecycle";
 
 import {
   searchCustomerSiteAddresses as searchCustomerSiteAddressesImpl,
@@ -618,6 +619,9 @@ export async function createOpportunity(input: {
     },
   );
 
+  // Assistive: opening an opportunity qualifies the account (gated; no-ops if already further).
+  await qualifyAccountFromOpportunity(opportunity.accountId, opportunity.title);
+
   return opportunity;
 }
 
@@ -664,6 +668,9 @@ export async function advanceOpportunityStage(
       opportunityId: updated.id,
     },
   );
+
+  // Assistive: a won deal activates the account (authoritative business event; no-ops if active).
+  if (newStage === "closed_won") await activateAccountFromWonDeal(updated.accountId, updated.title);
 
   revalidatePath("/customer/opportunities");
   revalidatePath(`/customer/opportunities/${updated.id}`);
@@ -722,45 +729,13 @@ export async function closeOpportunity(
     },
   );
 
+  // Assistive: closing a deal WON activates the account (authoritative business event).
+  if (won) await activateAccountFromWonDeal(opp.accountId, opp.title);
+
   return opp;
 }
 
-// ─── Dormant Deal Detection ─────────────────────────────────────────────────
-
-const DORMANT_THRESHOLD_DAYS = 45;
-
-export async function flagDormantOpportunities() {
-  const threshold = new Date();
-  threshold.setDate(threshold.getDate() - DORMANT_THRESHOLD_DAYS);
-
-  const stale = await prisma.opportunity.findMany({
-    where: {
-      isDormant: false,
-      stage: { notIn: ["closed_won", "closed_lost"] },
-      stageChangedAt: { lt: threshold },
-    },
-    select: { id: true, accountId: true, contactId: true, title: true },
-  });
-
-  for (const opp of stale) {
-    await prisma.opportunity.update({
-      where: { id: opp.id },
-      data: { isDormant: true },
-    });
-
-    await logSystemActivity(
-      `Opportunity "${opp.title}" marked dormant (no stage change in ${DORMANT_THRESHOLD_DAYS} days)`,
-      {
-        type: "system",
-        accountId: opp.accountId,
-        contactId: opp.contactId || undefined,
-        opportunityId: opp.id,
-      },
-    );
-  }
-
-  return { flagged: stale.length };
-}
+// Opportunity maintenance (flagDormantOpportunities) moved to crm-opportunity-maintenance.ts.
 
 // ─── Quote Actions ──────────────────────────────────────────────────────────
 

--- a/apps/web/lib/crm/account-lifecycle.ts
+++ b/apps/web/lib/crm/account-lifecycle.ts
@@ -1,0 +1,95 @@
+// Server helper — apply a customer-account status transition AND record it on the universal
+// LifecycleEvent ledger with the in-stage state axis, so the account lifecycle is both moved
+// and measured (two-axis reporting). BI-9078F4EE.
+//
+// CustomerAccount uses NATIVE decomposition: the stored `status` union carries both stage and
+// in-stage state, so the grammar resolver splits it and the event's toStatus is null by design
+// (status is not a backbone LifecycleStatus).
+
+import { prisma } from "@dpf/db";
+import { canAdvance } from "../lifecycle-grammar";
+import { CUSTOMER_ACCOUNT_GRAMMAR, resolveCustomerAccountPoint } from "../lifecycle-grammars";
+
+export type AccountStatusTransitionResult = { changed: boolean; reason?: string };
+
+/**
+ * Transition an account to `toStatus`, recording a LifecycleEvent atomically. Non-authoritative
+ * calls are GATED by the grammar (an illegal or backward move safely no-ops); authoritative calls
+ * (operator override, or a business-authoritative event such as a closed-won deal) may jump
+ * stages. Idempotent: a same-status call is a no-op with no event written. The status update and
+ * the ledger event are one transaction, so the ledger never records a transition that didn't land.
+ */
+export async function applyAccountStatusTransition(input: {
+  accountId: string;
+  toStatus: string;
+  reason: string;
+  authoritative?: boolean;
+  actorPrincipalId?: string | null;
+}): Promise<AccountStatusTransitionResult> {
+  const account = await prisma.customerAccount.findUnique({
+    where: { id: input.accountId },
+    select: { status: true },
+  });
+  if (!account) return { changed: false, reason: "account not found" };
+  if (account.status === input.toStatus) return { changed: false };
+
+  const from = resolveCustomerAccountPoint(account.status);
+  const to = resolveCustomerAccountPoint(input.toStatus);
+
+  // Gate a non-authoritative (assistive) signal: an illegal or backward move no-ops so, e.g., an
+  // opportunity opened on an already-active account does not pull it back to `qualified`.
+  if (!input.authoritative && from.stage !== to.stage) {
+    const check = canAdvance(CUSTOMER_ACCOUNT_GRAMMAR, from, to.stage);
+    if (!check.allowed) return { changed: false, reason: check.reason };
+  }
+
+  await prisma.$transaction([
+    prisma.customerAccount.update({
+      where: { id: input.accountId },
+      data: { status: input.toStatus },
+    }),
+    prisma.lifecycleEvent.create({
+      data: {
+        governedThingKind: "CustomerAccount",
+        governedThingId: input.accountId,
+        fromStage: from.stage,
+        toStage: to.stage,
+        fromState: from.state,
+        toState: to.state,
+        reason: input.reason,
+        actorPrincipalId: input.actorPrincipalId ?? null,
+      },
+    }),
+  ]);
+  return { changed: true };
+}
+
+/**
+ * Best-effort assistive signals wired into the opportunity lifecycle. These NEVER throw: a
+ * lifecycle-signal failure must not fail the operator's primary CRM action (the opportunity was
+ * already created/closed). A failure is swallowed; the transition is advisory.
+ */
+export async function qualifyAccountFromOpportunity(accountId: string, opportunityTitle: string): Promise<void> {
+  try {
+    await applyAccountStatusTransition({
+      accountId,
+      toStatus: "qualified",
+      reason: `Opportunity "${opportunityTitle}" opened`,
+    });
+  } catch {
+    /* assistive signal — never fail the caller's primary action */
+  }
+}
+
+export async function activateAccountFromWonDeal(accountId: string, opportunityTitle: string): Promise<void> {
+  try {
+    await applyAccountStatusTransition({
+      accountId,
+      toStatus: "active",
+      reason: `Opportunity "${opportunityTitle}" won`,
+      authoritative: true,
+    });
+  } catch {
+    /* assistive signal — never fail the caller's primary action */
+  }
+}

--- a/apps/web/lib/crm/account-value-stream.test.ts
+++ b/apps/web/lib/crm/account-value-stream.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  accountStatusToOvsmStage,
+  opportunityStageToOvsmStage,
+  ovsmStageLabel,
+  CUSTOMER_OVSM_STAGES,
+} from "./account-value-stream";
+import { CUSTOMER_ACCOUNT_STATUSES } from "@dpf/db/customer-lifecycle";
+
+describe("accountStatusToOvsmStage", () => {
+  const cases: Array<[string, string]> = [
+    ["prospect", "capture"],
+    ["qualified", "qualify"],
+    ["onboarding", "deliver"],
+    ["active", "retain"],
+    ["at_risk", "retain"], // active-stage state
+    ["suspended", "retain"],
+    ["closed", "retain"],
+  ];
+  it.each(cases)("maps account status %s → OVSM %s", (status, ovsm) => {
+    expect(accountStatusToOvsmStage(status)).toBe(ovsm);
+  });
+
+  it("maps every canonical account status to a primary OVSM stage", () => {
+    for (const status of CUSTOMER_ACCOUNT_STATUSES) {
+      expect(CUSTOMER_OVSM_STAGES).toContain(accountStatusToOvsmStage(status));
+    }
+  });
+});
+
+describe("opportunityStageToOvsmStage", () => {
+  it("maps open stages to qualify, won to deliver, lost to capture", () => {
+    expect(opportunityStageToOvsmStage("qualification")).toBe("qualify");
+    expect(opportunityStageToOvsmStage("negotiation")).toBe("qualify");
+    expect(opportunityStageToOvsmStage("closed_won")).toBe("deliver");
+    expect(opportunityStageToOvsmStage("closed_lost")).toBe("capture");
+  });
+});
+
+describe("ovsmStageLabel", () => {
+  it("labels the primary stages", () => {
+    expect(ovsmStageLabel("retain")).toBe("Retain & Grow");
+    expect(ovsmStageLabel("qualify")).toBe("Qualify & Schedule");
+  });
+});

--- a/apps/web/lib/crm/account-value-stream.ts
+++ b/apps/web/lib/crm/account-value-stream.ts
@@ -1,0 +1,71 @@
+// Pure utility — maps a customer account / sales opportunity onto its stage in the
+// Operational Value Stream (OVSM), so the CRM can show where a relationship sits in the value
+// stream (BI-9078F4EE / EP-VSL-SURFACE). No new stage vocabulary: it reuses the canonical
+// OVSM stage keys (packages/storefront-templates/src/operational-value-stream.ts) and the
+// account/opportunity lifecycle grammars (apps/web/lib/lifecycle-grammars.ts).
+
+import type { OperationalValueStreamStageKey } from "@dpf/storefront-templates";
+import { resolveCustomerAccountPoint, resolveOpportunityPoint } from "../lifecycle-grammars";
+
+/** The six PRIMARY OVSM stages a customer relationship can occupy, in order. */
+export const CUSTOMER_OVSM_STAGES: OperationalValueStreamStageKey[] = [
+  "attract",
+  "capture",
+  "qualify",
+  "deliver",
+  "settle",
+  "retain",
+];
+
+// Account lifecycle STAGE (from CUSTOMER_ACCOUNT_GRAMMAR) → its representative OVSM stage.
+// prospect = a captured lead (capture); qualified = qualify; onboarding = delivering first
+// value (deliver); active = the recurring back-half (retain); closed = terminal, still shown
+// against retain (the account's in-stage state carries the "ended" nuance).
+const ACCOUNT_STAGE_TO_OVSM: Record<string, OperationalValueStreamStageKey> = {
+  prospect: "capture",
+  qualified: "qualify",
+  onboarding: "deliver",
+  active: "retain",
+  closed: "retain",
+};
+
+// Opportunity STAGE → OVSM. An open sales opportunity IS the "qualify & schedule" work of the
+// value stream; a won deal moves to delivery; a lost deal falls back to capture (an un-converted
+// captured lead).
+const OPPORTUNITY_STAGE_TO_OVSM: Record<string, OperationalValueStreamStageKey> = {
+  qualification: "qualify",
+  discovery: "qualify",
+  proposal: "qualify",
+  negotiation: "qualify",
+  closed_won: "deliver",
+  closed_lost: "capture",
+};
+
+/** OVSM stage for a stored CustomerAccount.status. */
+export function accountStatusToOvsmStage(status: string): OperationalValueStreamStageKey {
+  const point = resolveCustomerAccountPoint(status);
+  return ACCOUNT_STAGE_TO_OVSM[point.stage] ?? "capture";
+}
+
+/** OVSM stage for a stored Opportunity.stage. */
+export function opportunityStageToOvsmStage(stage: string): OperationalValueStreamStageKey {
+  const point = resolveOpportunityPoint(stage);
+  return OPPORTUNITY_STAGE_TO_OVSM[point.stage] ?? "qualify";
+}
+
+const OVSM_STAGE_LABELS: Record<OperationalValueStreamStageKey, string> = {
+  attract: "Attract & Discover",
+  capture: "Capture Demand",
+  qualify: "Qualify & Schedule",
+  deliver: "Deliver the Value",
+  settle: "Settle & Account",
+  retain: "Retain & Grow",
+  "trust-compliance": "Trust & Compliance",
+  "operate-improve": "Operate & Improve",
+  "return-inspect": "Return & Inspect",
+  "receive-store": "Receive & Store",
+};
+
+export function ovsmStageLabel(stage: OperationalValueStreamStageKey): string {
+  return OVSM_STAGE_LABELS[stage] ?? stage;
+}

--- a/apps/web/lib/lifecycle/lifecycle-transition.ts
+++ b/apps/web/lib/lifecycle/lifecycle-transition.ts
@@ -46,6 +46,13 @@ export type RecordLifecycleTransitionInput = {
   evidenceRef?: string | null;
   actorPrincipalId?: string | null;
   toolExecutionId?: string | null;
+  /**
+   * Skip the canAdvance readiness gate for an AUTHORITATIVE transition — an operator override
+   * or a business-authoritative event (e.g. a closed-won deal activating an account) that is
+   * allowed to jump stages. Point VALIDITY is still enforced (both points must be real states),
+   * so authoritative never means unvalidated.
+   */
+  authoritative?: boolean;
 };
 
 export type RecordLifecycleTransitionResult =
@@ -80,7 +87,7 @@ export async function recordLifecycleTransition(
           };
         }
       }
-      if (input.from && input.to && input.from.stage !== input.to.stage) {
+      if (!input.authoritative && input.from && input.to && input.from.stage !== input.to.stage) {
         const check = canAdvance(grammar, input.from, input.to.stage);
         if (!check.allowed) {
           return { ok: false, reason: check.reason ?? "illegal lifecycle advancement" };

--- a/apps/web/lib/mcp/packs/crm-sales-pipeline-pack.ts
+++ b/apps/web/lib/mcp/packs/crm-sales-pipeline-pack.ts
@@ -10,8 +10,20 @@
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack } from "../tool-pack";
 import { prisma } from "@dpf/db";
-import { EXCLUDE_TOMBSTONED } from "@dpf/db/customer-lifecycle";
+import {
+  CUSTOMER_ACCOUNT_STATUSES,
+  CUSTOMER_TOMBSTONE_STATUSES,
+  EXCLUDE_TOMBSTONED,
+} from "@dpf/db/customer-lifecycle";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+// The full canonical account-lifecycle set an operator may set, minus the two system-managed
+// tombstones (`superseded` = merge tombstone; `archived` = its own action). Surfaced here so
+// create_customer_account exposes the whole lifecycle (BI-9078F4EE), not a hard-coded 4 —
+// derived from the canonical union, no new enum invented.
+const SETTABLE_ACCOUNT_STATUSES: string[] = CUSTOMER_ACCOUNT_STATUSES.filter(
+  (status) => !(CUSTOMER_TOMBSTONE_STATUSES as readonly string[]).includes(status),
+);
 
 const definitions: ToolDefinition[] = [
   {
@@ -81,7 +93,7 @@ const definitions: ToolDefinition[] = [
         name: { type: "string", description: "Company / account name. The ONLY required field." },
         website: { type: "string", description: "Optional website URL — include when known; it strengthens duplicate detection." },
         industry: { type: "string", description: "Optional industry." },
-        status: { type: "string", description: "Optional: prospect (default) | active | at_risk | closed." },
+        status: { type: "string", enum: SETTABLE_ACCOUNT_STATUSES, description: "Optional account-lifecycle status (default prospect). Full lifecycle: prospect → qualified → onboarding → active, plus at_risk / suspended / closed. Tombstones (superseded/archived) are system-managed and not settable here." },
         notes: { type: "string", description: "Optional free-text notes." },
         duplicateResolution: { type: "string", description: "Optional duplicate decision after a duplicates_found response: `use-existing:<accountId>` to reuse that account, or `confirm-new` to create anyway once the user confirms it is a different company." },
         duplicateReason: { type: "string", description: "Required with duplicateResolution `confirm-new`: one line on why this is not a duplicate (audited)." },
@@ -299,6 +311,14 @@ async function createCustomerAccountTool(
 ): Promise<ToolResult> {
   const name = typeof params["name"] === "string" ? params["name"].trim() : "";
   if (!name) return { success: false, error: "missing_name", message: "name is required to create a customer account." };
+  const requestedStatus = typeof params["status"] === "string" ? params["status"].trim() : "";
+  if (requestedStatus && !SETTABLE_ACCOUNT_STATUSES.includes(requestedStatus)) {
+    return {
+      success: false,
+      error: "invalid_status",
+      message: `"${requestedStatus}" is not a settable account status. Choose one of: ${SETTABLE_ACCOUNT_STATUSES.join(", ")}.`,
+    };
+  }
   const { createCustomerAccount } = await import("@/lib/actions/crm");
   const rawResolution = typeof params["duplicateResolution"] === "string" ? params["duplicateResolution"].trim() : "";
   const duplicateReason = typeof params["duplicateReason"] === "string" ? params["duplicateReason"].trim() : "";

--- a/docs/superpowers/plans/2026-08-15-crm-lifecycle-wiring.md
+++ b/docs/superpowers/plans/2026-08-15-crm-lifecycle-wiring.md
@@ -1,0 +1,31 @@
+# Plan — Wire the CRM to the value-stream/lifecycle substrate (BI-9078F4EE)
+
+**BI:** `BI-9078F4EE` (Workstream 1) · **Epic:** `EP-VSL-SURFACE`
+**Depends on:** `BI-E55991E9` (canonical lifecycle grammar — this branch stacks on `feat/vsl-lifecycle-grammar`)
+**Date:** 2026-08-15 · **Branch:** `feat/vsl-crm-lifecycle-wiring`
+
+## Design grounding
+
+Source of truth is the canonical lifecycle grammar shipped in BI-E55991E9 (`apps/web/lib/lifecycle-grammars.ts` — `CUSTOMER_ACCOUNT_GRAMMAR`, `OPPORTUNITY_GRAMMAR`, `resolveCustomerAccountPoint`) and the OVSM stage keys (`packages/storefront-templates/src/operational-value-stream.ts`). This BI **consumes** that grammar; it invents no new lifecycle enum. The account-status union (`packages/db/src/customer-lifecycle.ts`, 9 values) is unchanged.
+
+A surface sweep found the CRM already surfaces 7 of 9 account statuses in the UI (`ACCOUNT_STATUS_META`, `OPERATOR_SETTABLE_ACCOUNT_STATUSES`); the real gaps were: MCP `create_customer_account` capped at 4 in prose, no OVSM binding anywhere, a storefront-only funnel, and no signal-assisted transitions.
+
+## Deliverables (atomic — one coherent "wire CRM to lifecycle" slice)
+
+1. **OVSM binding** — `apps/web/lib/crm/account-value-stream.ts`: pure `accountStatusToOvsmStage` / `opportunityStageToOvsmStage` / `ovsmStageLabel` mapping onto the six primary OVSM stages; account detail page shows the value-stream position. (AC3)
+2. **MCP full status set** — `crm-sales-pipeline-pack.ts`: `create_customer_account.status` now an `enum` of the settable canonical statuses (9 minus the two system-managed tombstones), with handler validation returning `invalid_status`. (AC2)
+3. **Signal-assisted transitions** — `apps/web/lib/crm/account-lifecycle.ts` `applyAccountStatusTransition` (gated or authoritative, records a `LifecycleEvent` with the state axis) wired into `createOpportunity` (→ `qualified`, gated), `advanceOpportunityStage`/`closeOpportunity` on won (→ `active`, authoritative). Operator override via the existing admin control, whose status changes now also record a `LifecycleEvent`. (AC5, AC1)
+4. **Storefront-optional funnel** — `funnel/page.tsx`: top of funnel is fed by direct + reseller leads (early-lifecycle accounts) when no storefront activity exists; empty state only when there is truly no pipeline. (AC4)
+5. **Writer extension** — `recordLifecycleTransition` gains an `authoritative` flag (skips the readiness gate for operator overrides / business-authoritative events; point validity still enforced).
+
+No new enum invented; aligns to the canonical grammar (AC6).
+
+## Verification
+
+- Unit: `account-value-stream.test.ts` (10) + grammar/writer/pipeline regression — all green (46).
+- Typecheck: `apps/web` clean.
+- Local merged-CI gate before push; live UX verification of the funnel + account detail recommended on the running portal.
+
+## Backlog Coverage
+
+Atomic: the OVSM mapping, MCP status set, signal transitions, and storefront-optional funnel are one indivisible "wire the CRM to the lifecycle substrate" slice — each reads the same grammar and none is independently useful without the others (a funnel fed by lifecycle stages needs the accounts to move through those stages via the signals; the OVSM view needs the mapping). No phase is independently shippable.

--- a/docs/user-guide/customers/index.md
+++ b/docs/user-guide/customers/index.md
@@ -59,8 +59,12 @@ The section navigation is permission-aware:
 - **Quotes** (`/customer/quotes`) — quote status, validity, line items, acceptance,
   and the resulting order.
 - **Orders** (`/customer/sales-orders`) — accepted commercial commitments.
-- **Sales Funnel** (`/customer/funnel`) — the last 30 days of Storefront
-  interactions flowing into engagements, opportunities, and won work.
+- **Sales Funnel** (`/customer/funnel`) — the pipeline flowing into engagements,
+  opportunities, and won work. When a storefront is published, the top of the
+  funnel is the last 30 days of storefront interactions; when it is not, the top
+  of the funnel is fed by your **direct and reseller leads** (accounts in the
+  early prospect/qualified lifecycle stages), so a direct- or channel-sourced
+  pipeline is represented without a storefront.
 - **Marketing** (`/customer/marketing`) — acquisition strategy, campaigns,
   approval queues, publishing, and proposed automation. This tab requires the
   marketing capability and is covered in [Marketing](marketing.md).
@@ -167,6 +171,10 @@ Account detail is the relationship history, not just a contact card. It includes
 - customer sites, nested sublocations, and managed configuration items;
 - lifecycle attention, evidence source, renewal/end-of-support dates, and
   archetype-specific charge models;
+- the account's **value-stream position** — where the relationship sits in the
+  operational value stream (Capture → Qualify → Deliver → Retain), shown next to
+  its status. Opening an opportunity moves a prospect to *qualified*, and winning
+  a deal activates the account; you can always override the status from **Edit**;
 - approved billable-time economics where the selected business profile enables
   that workflow.
 

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -207,7 +207,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 8
+    "textMass": 6
   },
   "apps/web/app/(shell)/admin/page.tsx": {
     "vocabulary": 0,
@@ -522,7 +522,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 89
+    "textMass": 88
   },
   "apps/web/app/(shell)/coworker-decisions/page.tsx": {
     "vocabulary": 0,
@@ -592,7 +592,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 100
+    "textMass": 104
   },
   "apps/web/app/(shell)/customer/(crm)/engagements/page.tsx": {
     "vocabulary": 0,
@@ -606,7 +606,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 34
+    "textMass": 48
   },
   "apps/web/app/(shell)/customer/(crm)/opportunities/[id]/page.tsx": {
     "vocabulary": 0,
@@ -1495,7 +1495,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 29
+    "textMass": 24
   },
   "apps/web/app/(shell)/platform/federation-proposals/page.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Wire the CRM to the value-stream/lifecycle substrate (BI-9078F4EE)

Workstream 1 of **EP-VSL-SURFACE**, built on the canonical lifecycle grammar (BI-E55991E9, merged in #4289). Consumes that grammar — **no new lifecycle enum**.

### What changed
- **OVSM binding** — `apps/web/lib/crm/account-value-stream.ts` maps account status / opportunity stage onto the six primary OVSM stages; the account detail page shows its value-stream position.
- **MCP full status set** — `create_customer_account` now exposes the full settable canonical status set (enum + `invalid_status` validation), replacing the hard-coded 4-value prose cap. Derived from `CUSTOMER_ACCOUNT_STATUSES` minus the two system-managed tombstones.
- **Signal-assisted transitions** — opening an opportunity qualifies the account (gated, no-ops if already further); a won deal activates it (authoritative). Operator status changes and signals both record a two-axis `LifecycleEvent`. Signals are **best-effort** — a lifecycle-signal failure never fails the operator's primary CRM action.
- **Storefront-optional funnel** — top of funnel is fed by direct + reseller leads (early-lifecycle accounts) when there's no storefront activity; empty state only when there's truly no pipeline.
- **Writer** — `recordLifecycleTransition` gains an `authoritative` flag (skips the readiness gate for operator overrides / business-authoritative events; point validity still enforced). `applyAccountStatusTransition` writes the status change + ledger event in one `$transaction`.
- **Refactor** — extracted the orphaned `flagDormantOpportunities` from the `crm.ts` god-module into `crm-opportunity-maintenance.ts` (module-size ratchet).

### Reviews & verification
- Independent code review applied: signals made best-effort (never break the primary write) and the account transition made atomic.
- 46 unit tests green (OVSM mapping, grammar, writer, pipeline-inspector regression); `apps/web` typecheck clean.
- Data-Impact: no persistent surface changed. Docs-Impact: user guide updated for the funnel + value-stream changes. Module-size + prose-lint ratchets green.
- Local merged-CI gate passed.

Plan: `docs/superpowers/plans/2026-08-15-crm-lifecycle-wiring.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
