### PR TITLE
feat(crm): instrument the recurring retain stage — MRR/ARR, churn-risk, renewals (BI-A72D29BE)

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/[id]/page.tsx
@@ -23,6 +23,8 @@ import {
 } from "@/lib/storefront/archetype-activation";
 import { getAccountStatusMeta } from "@/lib/crm/presentation";
 import { accountStatusToOvsmStage, ovsmStageLabel } from "@/lib/crm/account-value-stream";
+import { getAccountRetainSnapshot } from "@/lib/crm/retain-data";
+import { AccountRetainPanel } from "@/components/customer/AccountRetainPanel";
 import { formatRevenueAmount } from "@/lib/crm/revenue-cockpit";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { getFinancialProfile } from "@dpf/finance-templates";
@@ -224,6 +226,10 @@ export default async function AccountDetailPage({
   const laborEconomics = billableTimeEnabled ? await getAccountLaborEconomics(id) : null;
 
   const statusMeta = getAccountStatusMeta(account.status);
+  // Retain-stage instrumentation: MRR / churn-risk / renewal for accounts in the recurring back-half.
+  const retainSnapshot = ["onboarding", "active", "at_risk", "suspended"].includes(account.status)
+    ? await getAccountRetainSnapshot(account.id)
+    : null;
   const managedItemDefaults = deriveCustomerConfigurationItemDefaults(
     readActivationProfile(storefrontConfig?.archetype?.activationProfile),
   );
@@ -304,6 +310,8 @@ export default async function AccountDetailPage({
       </div>
 
       <AccountLifecycleActions {...lifecycleContext} />
+
+      {retainSnapshot && <AccountRetainPanel snapshot={retainSnapshot} />}
 
       {laborEconomics && laborEconomics.billableHours > 0 && (
         <BillableTimeSection

--- a/apps/web/app/(shell)/customer/(crm)/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/page.tsx
@@ -13,6 +13,7 @@ import { DuplicateAccountsPanel } from "@/components/customer/DuplicateAccountsP
 import { RevenueCockpit } from "@/components/customer/RevenueCockpit";
 import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
 import { buildRevenueCockpitSummary } from "@/lib/crm/revenue-cockpit";
+import { getWorkspaceRetainMetrics } from "@/lib/crm/retain-data";
 import {
   CRM_TONE_CLASSES,
   getAccountStatusMeta,
@@ -36,6 +37,8 @@ export default async function CustomerPage({
   const sp = await searchParams;
   const view = parseSurfaceView(sp?.view);
   const dataScope = parseSurfaceDataScope(sp?.dataScope);
+  // Kick off the retain rollup in parallel with the main batch (avoids a serial round-trip).
+  const retainPromise = getWorkspaceRetainMetrics();
   const [
     accounts,
     engagementCounts,
@@ -131,7 +134,11 @@ export default async function CustomerPage({
     }),
   ]);
 
+  const retain = await retainPromise;
   const revenueSummary = buildRevenueCockpitSummary({
+    mrr: retain.mrr,
+    arr: retain.arr,
+    atRiskAccountCount: retain.churnRiskOutreachCount,
     engagementCounts: engagementCounts.map((item) => ({
       status: item.status,
       count: item._count,

--- a/apps/web/components/customer/AccountRetainPanel.tsx
+++ b/apps/web/components/customer/AccountRetainPanel.tsx
@@ -1,0 +1,69 @@
+import { formatRevenueAmount } from "@/lib/crm/revenue-cockpit";
+import type { AccountRetainSnapshot } from "@/lib/crm/retain-data";
+import type { HealthBand } from "@/lib/crm/retain-metrics";
+import { LocalTime } from "@/components/ui/LocalTime";
+
+const HEALTH_META: Record<HealthBand, { label: string; cls: string }> = {
+  healthy: { label: "Healthy", cls: "text-[var(--dpf-success)]" },
+  watch: { label: "Watch", cls: "text-[var(--dpf-warning)]" },
+  "at-risk": { label: "At risk", cls: "text-[var(--dpf-danger)]" },
+};
+
+/**
+ * Retain-stage panel (BI-A72D29BE): recurring revenue, churn-risk health, and the next renewal
+ * for an account in the recurring back-half. Rendered only for retain-stage accounts.
+ */
+export function AccountRetainPanel({ snapshot }: { snapshot: AccountRetainSnapshot }) {
+  const { currency } = snapshot;
+  const health = HEALTH_META[snapshot.health.band];
+  const renewal = snapshot.nextRenewal;
+  return (
+    <section className="mb-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Retain</h2>
+        <span className={`text-xs font-medium ${health.cls}`}>{health.label}</span>
+      </div>
+      <dl className="grid grid-cols-3 gap-3 text-xs">
+        <div>
+          <dt className="text-[var(--dpf-muted)]">Recurring revenue</dt>
+          <dd className="text-[var(--dpf-text)]">
+            {snapshot.hasActiveRecurring ? `${formatRevenueAmount(snapshot.mrr, currency)}/mo` : "—"}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-[var(--dpf-muted)]">Annual (ARR)</dt>
+          <dd className="text-[var(--dpf-text)]">
+            {snapshot.hasActiveRecurring ? formatRevenueAmount(snapshot.arr, currency) : "—"}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-[var(--dpf-muted)]">Next renewal</dt>
+          <dd className="text-[var(--dpf-text)]">
+            {renewal ? (
+              <>
+                <LocalTime value={renewal} mode="date" />
+                {snapshot.renewalInDays != null && (
+                  <span className={snapshot.renewalInDays < 0 ? "text-[var(--dpf-danger)]" : undefined}>
+                    {snapshot.renewalInDays < 0
+                      ? ` · ${-snapshot.renewalInDays}d overdue`
+                      : ` · ${snapshot.renewalInDays}d`}
+                  </span>
+                )}
+              </>
+            ) : (
+              "—"
+            )}
+          </dd>
+        </div>
+      </dl>
+      {snapshot.health.reasons.length > 0 && (
+        <p className="mt-3 text-xs text-[var(--dpf-muted)]">{snapshot.health.reasons.join(" · ")}</p>
+      )}
+      {snapshot.health.suggestAtRisk && (
+        <p className="mt-2 text-xs text-[var(--dpf-danger)]">
+          Churn-risk signal — consider marking this account at risk and reaching out.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/lib/crm/retain-data.ts
+++ b/apps/web/lib/crm/retain-data.ts
@@ -1,0 +1,157 @@
+// Server data layer for retain-stage instrumentation (BI-A72D29BE). Reads live recurring
+// commitments + engagement recency and rolls them up through the pure retain-metrics helpers.
+// Bounded queries only (a handful of aggregates over active accounts — no per-account N+1).
+
+import { prisma } from "@dpf/db";
+import { EXCLUDE_TOMBSTONED } from "@dpf/db/customer-lifecycle";
+import {
+  assessAccountHealth,
+  computeArr,
+  computeMrr,
+  type HealthBand,
+} from "./retain-metrics";
+
+const DAY_MS = 86_400_000;
+/** Account statuses that occupy the recurring back-half (OVSM retain), where MRR/health apply. */
+const RETAIN_STATUSES = ["onboarding", "active", "at_risk", "suspended"];
+
+function daysUntil(date: Date | null, now: number): number | null {
+  if (!date) return null;
+  return Math.round((date.getTime() - now) / DAY_MS);
+}
+function daysSince(date: Date | null, now: number): number | null {
+  if (!date) return null;
+  return Math.round((now - date.getTime()) / DAY_MS);
+}
+
+export type WorkspaceRetainMetrics = {
+  mrr: number;
+  arr: number;
+  activeRecurringAccounts: number;
+  healthCounts: Record<HealthBand, number>;
+  /** Active accounts the signal flags for churn-risk OUTREACH (excludes already at_risk/suspended). */
+  churnRiskOutreachCount: number;
+};
+
+/** The next renewal date + whether THAT subscription auto-renews (not "any sub auto-renews"). */
+function nextRenewalOf(subs: readonly { renewalDate: Date | null; autoRenew: boolean }[]): {
+  date: Date | null;
+  autoRenew: boolean;
+} {
+  const soonest = subs
+    .filter((s): s is { renewalDate: Date; autoRenew: boolean } => s.renewalDate != null)
+    .sort((a, b) => a.renewalDate.getTime() - b.renewalDate.getTime())[0];
+  return { date: soonest?.renewalDate ?? null, autoRenew: soonest?.autoRenew ?? true };
+}
+
+/**
+ * Workspace retain rollup: MRR/ARR from active recurring commitments and a health-band tally
+ * over retain-stage accounts. Four bounded queries, joined in memory.
+ */
+export async function getWorkspaceRetainMetrics(): Promise<WorkspaceRetainMetrics> {
+  const now = Date.now();
+  const [accounts, subscriptions, schedules, lastActivity] = await Promise.all([
+    prisma.customerAccount.findMany({
+      where: { ...EXCLUDE_TOMBSTONED, status: { in: RETAIN_STATUSES } },
+      select: { id: true, status: true },
+    }),
+    prisma.subscription.findMany({
+      where: { status: "active" },
+      select: { id: true, accountId: true, status: true, billingCadence: true, totalValue: true, renewalDate: true, autoRenew: true },
+    }),
+    prisma.recurringSchedule.findMany({
+      where: { status: "active" },
+      select: { accountId: true, status: true, frequency: true, amount: true, subscriptionId: true },
+    }),
+    prisma.activity.groupBy({ by: ["accountId"], _max: { createdAt: true } }),
+  ]);
+
+  const subsByAccount = new Map<string, typeof subscriptions>();
+  for (const s of subscriptions) {
+    if (!s.accountId) continue;
+    (subsByAccount.get(s.accountId) ?? subsByAccount.set(s.accountId, []).get(s.accountId)!).push(s);
+  }
+  const schedByAccount = new Map<string, typeof schedules>();
+  for (const s of schedules) {
+    if (!s.accountId) continue;
+    (schedByAccount.get(s.accountId) ?? schedByAccount.set(s.accountId, []).get(s.accountId)!).push(s);
+  }
+  const lastActivityByAccount = new Map<string, Date | null>();
+  for (const row of lastActivity) {
+    if (row.accountId) lastActivityByAccount.set(row.accountId, row._max.createdAt ?? null);
+  }
+
+  let mrr = 0;
+  let activeRecurringAccounts = 0;
+  let churnRiskOutreachCount = 0;
+  const healthCounts: Record<HealthBand, number> = { healthy: 0, watch: 0, "at-risk": 0 };
+
+  for (const account of accounts) {
+    const subs = subsByAccount.get(account.id) ?? [];
+    const scheds = schedByAccount.get(account.id) ?? [];
+    mrr += computeMrr({
+      subscriptions: subs.map((s) => ({ id: s.id, status: s.status, billingCadence: s.billingCadence, totalValue: Number(s.totalValue) })),
+      schedules: scheds.map((s) => ({ status: s.status, frequency: s.frequency, amount: Number(s.amount), subscriptionId: s.subscriptionId })),
+    });
+    const hasActiveRecurring = subs.length > 0 || scheds.length > 0;
+    if (hasActiveRecurring) activeRecurringAccounts += 1;
+
+    const renewal = nextRenewalOf(subs);
+    const health = assessAccountHealth({
+      status: account.status,
+      renewalInDays: daysUntil(renewal.date, now),
+      autoRenew: renewal.autoRenew,
+      lastActivityInDays: daysSince(lastActivityByAccount.get(account.id) ?? null, now),
+      hasActiveRecurring,
+    });
+    healthCounts[health.band] += 1;
+    if (health.suggestAtRisk) churnRiskOutreachCount += 1;
+  }
+
+  return { mrr, arr: computeArr(mrr), activeRecurringAccounts, healthCounts, churnRiskOutreachCount };
+}
+
+export type AccountRetainSnapshot = {
+  mrr: number;
+  arr: number;
+  currency: string;
+  hasActiveRecurring: boolean;
+  nextRenewal: Date | null;
+  renewalInDays: number | null;
+  health: ReturnType<typeof assessAccountHealth>;
+};
+
+/** Per-account retain snapshot for the account detail page. Targeted single-account queries. */
+export async function getAccountRetainSnapshot(accountId: string): Promise<AccountRetainSnapshot> {
+  const now = Date.now();
+  const [account, subs, scheds, lastActivity] = await Promise.all([
+    prisma.customerAccount.findUnique({ where: { id: accountId }, select: { status: true, currency: true } }),
+    prisma.subscription.findMany({
+      where: { accountId, status: "active" },
+      select: { id: true, status: true, billingCadence: true, totalValue: true, renewalDate: true, autoRenew: true },
+    }),
+    prisma.recurringSchedule.findMany({
+      where: { accountId, status: "active" },
+      select: { status: true, frequency: true, amount: true, subscriptionId: true },
+    }),
+    prisma.activity.aggregate({ where: { accountId }, _max: { createdAt: true } }),
+  ]);
+
+  const mrr = computeMrr({
+    subscriptions: subs.map((s) => ({ id: s.id, status: s.status, billingCadence: s.billingCadence, totalValue: Number(s.totalValue) })),
+    schedules: scheds.map((s) => ({ status: s.status, frequency: s.frequency, amount: Number(s.amount), subscriptionId: s.subscriptionId })),
+  });
+  const hasActiveRecurring = subs.length > 0 || scheds.length > 0;
+  const renewal = nextRenewalOf(subs);
+  const renewalInDays = daysUntil(renewal.date, now);
+
+  const health = assessAccountHealth({
+    status: account?.status ?? "active",
+    renewalInDays,
+    autoRenew: renewal.autoRenew,
+    lastActivityInDays: daysSince(lastActivity._max.createdAt ?? null, now),
+    hasActiveRecurring,
+  });
+
+  return { mrr, arr: computeArr(mrr), currency: account?.currency ?? "USD", hasActiveRecurring, nextRenewal: renewal.date, renewalInDays, health };
+}

--- a/apps/web/lib/crm/retain-metrics.test.ts
+++ b/apps/web/lib/crm/retain-metrics.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  assessAccountHealth,
+  computeArr,
+  computeMrr,
+  monthlyRecurringValue,
+} from "./retain-metrics";
+
+describe("monthlyRecurringValue", () => {
+  it("normalises each period to a monthly figure", () => {
+    expect(monthlyRecurringValue(1200, "annual")).toBe(100);
+    expect(monthlyRecurringValue(1200, "annually")).toBe(100);
+    expect(monthlyRecurringValue(300, "quarterly")).toBe(100);
+    expect(monthlyRecurringValue(100, "monthly")).toBe(100);
+    expect(monthlyRecurringValue(100, "unknown-term")).toBe(100); // defaults to monthly
+  });
+  it("returns 0 for non-positive or invalid amounts", () => {
+    expect(monthlyRecurringValue(0, "monthly")).toBe(0);
+    expect(monthlyRecurringValue(-50, "monthly")).toBe(0);
+    expect(monthlyRecurringValue(Number.NaN, "monthly")).toBe(0);
+  });
+});
+
+describe("computeMrr / computeArr", () => {
+  it("a schedule supersedes only the subscription it renews (via subscriptionId)", () => {
+    const mrr = computeMrr({
+      subscriptions: [{ id: "sub-a", status: "active", billingCadence: "annual", totalValue: 12000 }],
+      schedules: [{ status: "active", frequency: "monthly", amount: 500, subscriptionId: "sub-a" }],
+    });
+    expect(mrr).toBe(500); // sub-a is covered by its schedule; only the schedule counts
+    expect(computeArr(mrr)).toBe(6000);
+  });
+  it("keeps a standalone add-on subscription that no active schedule covers", () => {
+    const mrr = computeMrr({
+      subscriptions: [
+        { id: "sub-a", status: "active", billingCadence: "annual", totalValue: 12000 }, // scheduled
+        { id: "sub-b", status: "active", billingCadence: "monthly", totalValue: 200 }, // standalone add-on
+      ],
+      schedules: [{ status: "active", frequency: "monthly", amount: 500, subscriptionId: "sub-a" }],
+    });
+    expect(mrr).toBe(700); // schedule 500 + uncovered sub-b 200
+  });
+  it("falls back to subscription contract value when no active schedule exists", () => {
+    const mrr = computeMrr({
+      subscriptions: [{ id: "sub-a", status: "active", billingCadence: "annual", totalValue: 12000 }],
+      schedules: [{ status: "cancelled", frequency: "monthly", amount: 500, subscriptionId: "sub-a" }],
+    });
+    expect(mrr).toBe(1000); // 12000 / 12 (cancelled schedule doesn't cover)
+  });
+  it("ignores non-active rows", () => {
+    expect(
+      computeMrr({
+        subscriptions: [{ id: "s", status: "expired", billingCadence: "monthly", totalValue: 999 }],
+        schedules: [],
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("assessAccountHealth", () => {
+  const base = {
+    status: "active",
+    renewalInDays: 200,
+    autoRenew: true,
+    lastActivityInDays: 5,
+    hasActiveRecurring: true,
+  };
+
+  it("is healthy when everything is nominal", () => {
+    const r = assessAccountHealth(base);
+    expect(r.band).toBe("healthy");
+    expect(r.suggestAtRisk).toBe(false);
+  });
+
+  it("flags at-risk on an overdue renewal and suggests the transition", () => {
+    const r = assessAccountHealth({ ...base, renewalInDays: -3 });
+    expect(r.band).toBe("at-risk");
+    expect(r.suggestAtRisk).toBe(true);
+    expect(r.reasons.join()).toMatch(/overdue/i);
+  });
+
+  it("flags at-risk on a near manual renewal (auto-renew off)", () => {
+    expect(assessAccountHealth({ ...base, renewalInDays: 20, autoRenew: false }).band).toBe("at-risk");
+    // auto-renew ON at the same proximity is only a watch
+    expect(assessAccountHealth({ ...base, renewalInDays: 20, autoRenew: true }).band).toBe("watch");
+  });
+
+  it("flags at-risk on long disengagement", () => {
+    expect(assessAccountHealth({ ...base, lastActivityInDays: 120 }).band).toBe("at-risk");
+    expect(assessAccountHealth({ ...base, lastActivityInDays: 50 }).band).toBe("watch");
+  });
+
+  it("treats an already at_risk/suspended status as authoritative and does not re-suggest", () => {
+    expect(assessAccountHealth({ ...base, status: "at_risk" }).suggestAtRisk).toBe(false);
+    expect(assessAccountHealth({ ...base, status: "suspended" }).band).toBe("at-risk");
+  });
+
+  it("watches an account with no active recurring commitment", () => {
+    expect(assessAccountHealth({ ...base, hasActiveRecurring: false }).band).toBe("watch");
+  });
+});

--- a/apps/web/lib/crm/retain-metrics.ts
+++ b/apps/web/lib/crm/retain-metrics.ts
@@ -1,0 +1,154 @@
+// Pure utility — instruments the recurring "retain" stage (BI-A72D29BE / EP-VSL-SURFACE):
+// MRR/ARR rollup from active recurring commitments, and a per-account health / churn-risk
+// signal that feeds the account grammar's `active`-stage `at_risk` state. No server imports.
+//
+// Two recurring sources exist and use slightly different period spellings:
+//   - Subscription.billingCadence: monthly | quarterly | annual  (totalValue is per period)
+//   - RecurringSchedule.frequency: weekly | biweekly | monthly | quarterly | annually
+// Both normalise to a monthly-recurring figure here.
+
+/** Months represented by one period of a given cadence/frequency term. */
+const MONTHS_PER_PERIOD: Record<string, number> = {
+  weekly: 12 / 52,
+  biweekly: 12 / 26,
+  monthly: 1,
+  quarterly: 3,
+  annual: 12,
+  annually: 12,
+  yearly: 12,
+};
+
+/** Normalise a per-period amount to its monthly-recurring contribution. Unknown terms → monthly. */
+export function monthlyRecurringValue(amountPerPeriod: number, term: string): number {
+  const months = MONTHS_PER_PERIOD[term] ?? 1;
+  if (!Number.isFinite(amountPerPeriod) || amountPerPeriod <= 0 || months <= 0) return 0;
+  return amountPerPeriod / months;
+}
+
+export type RecurringSubscriptionInput = {
+  id?: string;
+  status: string;
+  billingCadence: string;
+  totalValue: number;
+};
+export type RecurringScheduleInput = {
+  status: string;
+  frequency: string;
+  amount: number;
+  /** The Subscription this schedule renews, when linked. */
+  subscriptionId?: string | null;
+};
+
+/**
+ * Monthly Recurring Revenue from ACTIVE recurring commitments. A RecurringSchedule is the
+ * invoicing engine's finer-grained truth, so it SUPERSEDES only the specific Subscription it
+ * renews (via subscriptionId) — not every subscription on the account. MRR = all active schedules
+ * + every active subscription that has no active schedule covering it. This avoids both
+ * double-counting a scheduled contract and dropping a standalone add-on subscription.
+ */
+export function computeMrr(input: {
+  subscriptions: readonly RecurringSubscriptionInput[];
+  schedules: readonly RecurringScheduleInput[];
+}): number {
+  const activeSchedules = input.schedules.filter((s) => s.status === "active");
+  const coveredSubscriptionIds = new Set(
+    activeSchedules.map((s) => s.subscriptionId).filter((id): id is string => Boolean(id)),
+  );
+  const scheduleMrr = activeSchedules.reduce(
+    (sum, s) => sum + monthlyRecurringValue(Number(s.amount), s.frequency),
+    0,
+  );
+  const uncoveredSubscriptionMrr = input.subscriptions
+    .filter((s) => s.status === "active" && !(s.id && coveredSubscriptionIds.has(s.id)))
+    .reduce((sum, s) => sum + monthlyRecurringValue(Number(s.totalValue), s.billingCadence), 0);
+  return scheduleMrr + uncoveredSubscriptionMrr;
+}
+
+/** Annual Recurring Revenue = MRR × 12. */
+export function computeArr(mrr: number): number {
+  return mrr * 12;
+}
+
+// ─── Customer health / churn-risk ─────────────────────────────────────────────────────
+
+export const HEALTH_BANDS = ["healthy", "watch", "at-risk"] as const;
+export type HealthBand = (typeof HEALTH_BANDS)[number];
+
+export type AccountHealthInput = {
+  /** Current stored account status (active / at_risk / suspended / …). */
+  status: string;
+  /** Days until the next renewal (negative = overdue); null when no renewal is known. */
+  renewalInDays: number | null;
+  /** Whether the contract auto-renews. */
+  autoRenew: boolean;
+  /** Days since the last recorded engagement/activity; null when never engaged. */
+  lastActivityInDays: number | null;
+  /** Whether the account has any active recurring commitment. */
+  hasActiveRecurring: boolean;
+};
+
+export type AccountHealthResult = {
+  band: HealthBand;
+  reasons: string[];
+  /** True when the signal recommends the account be moved to the `at_risk` state. */
+  suggestAtRisk: boolean;
+};
+
+const RENEWAL_AT_RISK_DAYS = 30;
+const RENEWAL_WATCH_DAYS = 60;
+const ACTIVITY_AT_RISK_DAYS = 90;
+const ACTIVITY_WATCH_DAYS = 45;
+
+/**
+ * Assess an active account's churn risk from renewal proximity, auto-renew, engagement recency,
+ * and recurring-commitment presence. Deterministic and side-effect free — the caller decides
+ * whether to prompt an at_risk transition (kept human-in-the-loop, never auto-applied).
+ */
+export function assessAccountHealth(input: AccountHealthInput): AccountHealthResult {
+  const reasons: string[] = [];
+
+  // An already-flagged status is authoritative.
+  if (input.status === "at_risk") return { band: "at-risk", reasons: ["Account is flagged at risk"], suggestAtRisk: false };
+  if (input.status === "suspended") return { band: "at-risk", reasons: ["Account is suspended"], suggestAtRisk: false };
+
+  // Track severity numerically (0 healthy · 1 watch · 2 at-risk) so escalation composes without
+  // control-flow narrowing pitfalls; map to a band at the end.
+  const BANDS: HealthBand[] = ["healthy", "watch", "at-risk"];
+  let severity = 0;
+  const escalate = (to: number) => {
+    severity = Math.max(severity, to);
+  };
+
+  if (input.renewalInDays !== null) {
+    if (input.renewalInDays < 0) {
+      escalate(2);
+      reasons.push("Renewal is overdue");
+    } else if (input.renewalInDays <= RENEWAL_AT_RISK_DAYS && !input.autoRenew) {
+      escalate(2);
+      reasons.push(`Manual renewal due in ${input.renewalInDays} days`);
+    } else if (input.renewalInDays <= RENEWAL_WATCH_DAYS) {
+      escalate(1);
+      reasons.push(`Renewal within ${RENEWAL_WATCH_DAYS} days`);
+    }
+  }
+
+  if (input.lastActivityInDays !== null) {
+    if (input.lastActivityInDays >= ACTIVITY_AT_RISK_DAYS) {
+      escalate(2);
+      reasons.push(`No engagement for ${input.lastActivityInDays} days`);
+    } else if (input.lastActivityInDays >= ACTIVITY_WATCH_DAYS) {
+      escalate(1);
+      reasons.push(`Low engagement (${input.lastActivityInDays} days)`);
+    }
+  }
+
+  if (!input.hasActiveRecurring) {
+    escalate(1);
+    reasons.push("No active recurring commitment");
+  }
+
+  const band = BANDS[severity];
+  if (band === "healthy") reasons.push("On track");
+  // Only prompt a transition when the account is genuinely active (not already flagged).
+  return { band, reasons, suggestAtRisk: band === "at-risk" && input.status === "active" };
+}

--- a/apps/web/lib/crm/revenue-cockpit.ts
+++ b/apps/web/lib/crm/revenue-cockpit.ts
@@ -43,6 +43,12 @@ export type RevenueCockpitInput = {
   staleOpportunityCount: number;
   /** Active support contracts whose renewalDate falls within the next 30 days. */
   renewalsDueSoonCount?: number;
+  /** Monthly Recurring Revenue from active recurring commitments (retain-stage instrumentation). */
+  mrr?: number;
+  /** Annual Recurring Revenue (MRR × 12). */
+  arr?: number;
+  /** Retain-stage accounts the health signal flags as at churn risk. */
+  atRiskAccountCount?: number;
   /** Customer invoices past their due date and not yet paid/void. */
   overdueInvoiceCount?: number;
   marketingWork: {
@@ -90,6 +96,17 @@ export function buildRevenueCockpitSummary(input: RevenueCockpitInput): RevenueC
       id: "overdue-invoices",
       label: `${overdueInvoices} invoice${overdueInvoices === 1 ? " is" : "s are"} past due — chase payment`,
       href: "/finance/invoices",
+      tone: "danger",
+    });
+  }
+
+  // Retention-first: protecting existing recurring revenue outranks new-lead triage.
+  const atRiskAccounts = input.atRiskAccountCount ?? 0;
+  if (atRiskAccounts > 0) {
+    attentionItems.push({
+      id: "accounts-at-risk",
+      label: `${atRiskAccounts} customer${atRiskAccounts === 1 ? " is" : "s are"} at churn risk — reach out before renewal`,
+      href: "/customer",
       tone: "danger",
     });
   }
@@ -144,8 +161,22 @@ export function buildRevenueCockpitSummary(input: RevenueCockpitInput): RevenueC
     });
   }
 
+  const mrr = input.mrr ?? 0;
   return {
     metrics: [
+      // Recurring revenue is the retain-stage center of gravity — lead with it when present.
+      ...(mrr > 0
+        ? [
+            {
+              id: "recurring-revenue",
+              label: "Recurring revenue",
+              value: formatRevenueAmount(mrr, currency),
+              detail: `${formatRevenueAmount(input.arr ?? mrr * 12, currency)} ARR`,
+              href: "/customer",
+              tone: "success" as CrmTone,
+            },
+          ]
+        : []),
       {
         id: "engagements",
         label: "Engagements",

--- a/docs/superpowers/plans/2026-08-15-retain-instrumentation.md
+++ b/docs/superpowers/plans/2026-08-15-retain-instrumentation.md
@@ -1,0 +1,28 @@
+# Plan — Instrument the recurring "retain" stage (BI-A72D29BE)
+
+**BI:** `BI-A72D29BE` (Workstream 2) · **Epic:** `EP-VSL-SURFACE`
+**Depends on:** `BI-E55991E9` (grammar, merged) · stacked on `BI-9078F4EE`
+**Date:** 2026-08-15 · **Branch:** `feat/vsl-retain-instrumentation`
+
+## Design grounding
+
+A surface sweep corrected the BI's premise: there is **no `Contract` table** — the domain is `model Subscription` (renewalDate/autoRenew/billingCadence/totalValue), and it is **already migrated** (`20260704120000_add_subscription_support_contract`), alongside `RecurringSchedule`. So **no schema migration is required.** The gaps were purely instrumentation: no MRR/ARR computation, no customer-health/churn signal, and no retain surface existed anywhere. This BI builds those from live data and reads them through the account grammar (`active`-stage `at_risk` state) shipped in BI-E55991E9.
+
+**Scope note (onboarding milestones):** a *persisted* onboarding-milestone model would add a new Prisma model + the ~6-gate cascade. This BI represents retain health/engagement from existing signals and defers a dedicated milestone model to a clean follow-up BI if it proves needed — keeping this workstream migration-free.
+
+## Deliverables (atomic — one retain-instrumentation slice)
+
+1. **Pure metrics** — `apps/web/lib/crm/retain-metrics.ts`: `monthlyRecurringValue` (cadence/frequency normalisation), `computeMrr`/`computeArr` (schedules supersede contract estimate), `assessAccountHealth` (renewal proximity + auto-renew + engagement recency + recurring presence → `healthy`/`watch`/`at-risk`, with a human-in-the-loop `suggestAtRisk`). No server imports; fully unit-tested.
+2. **Server data** — `apps/web/lib/crm/retain-data.ts`: `getWorkspaceRetainMetrics` (MRR/ARR + health tally, bounded aggregate queries — no N+1) and `getAccountRetainSnapshot` (per-account).
+3. **Cockpit** — `revenue-cockpit.ts` gains a Recurring-revenue metric (MRR/ARR) and an "accounts at churn risk" attention item; the CRM hub feeds them from the rollup.
+4. **Account detail** — `AccountRetainPanel` shows MRR/ARR, health band + reasons, next renewal, and a churn-risk prompt, for retain-stage accounts.
+
+## Verification
+
+- Unit: `retain-metrics.test.ts` (11) + CRM regression — green.
+- Typecheck: `apps/web` clean. Ratchets (module-size, prose, style/token) green.
+- Local merged-CI gate before push; live UX verification of the cockpit + account panel recommended.
+
+## Backlog Coverage
+
+Atomic: the MRR/ARR rollup, the health/churn signal, and their two surfaces (cockpit + account panel) are one indivisible retain-instrumentation slice reading the same recurring substrate — none is independently useful without the metrics engine. No phase is independently shippable.

--- a/docs/user-guide/customers/index.md
+++ b/docs/user-guide/customers/index.md
@@ -175,6 +175,10 @@ Account detail is the relationship history, not just a contact card. It includes
   operational value stream (Capture → Qualify → Deliver → Retain), shown next to
   its status. Opening an opportunity moves a prospect to *qualified*, and winning
   a deal activates the account; you can always override the status from **Edit**;
+- for active, recurring customers, a **Retain** panel — recurring revenue
+  (MRR/ARR), a churn-risk health signal, and the next renewal date, with a prompt
+  to reach out before an at-risk account churns. The revenue cockpit rolls the
+  same recurring revenue and at-risk count up across the workspace;
 - approved billable-time economics where the selected business profile enables
   that workflow.
 

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -4528,6 +4528,13 @@
     "longSentences": 0,
     "textMass": 16
   },
+  "apps/web/components/customer/AccountRetainPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
   "apps/web/components/customer/AcquisitionSignalRouter.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,


### PR DESCRIPTION
## Instrument the recurring retain stage — MRR/ARR, churn-risk health, renewals (BI-A72D29BE)

Workstream 2 of **EP-VSL-SURFACE**, on the merged BI-E55991E9 grammar. **No schema migration** — a surface sweep found the recurring substrate (`Subscription`/`RecurringSchedule`) already exists; this adds the missing instrumentation, read through the account grammar's `active`-stage `at_risk` state.

### What changed
- **`retain-metrics.ts`** (pure): MRR/ARR normalisation across `Subscription.billingCadence` and `RecurringSchedule.frequency`; a schedule supersedes **only the subscription it renews** (via `subscriptionId`) so add-on subs aren't dropped. `assessAccountHealth` scores churn risk from renewal proximity, auto-renew, engagement recency, and recurring presence → `healthy`/`watch`/`at-risk`, with a human-in-the-loop `suggestAtRisk`.
- **`retain-data.ts`**: `getWorkspaceRetainMetrics` (MRR/ARR + health tally + churn-risk-outreach count) and `getAccountRetainSnapshot`. Bounded aggregate queries, no N+1; the hub rollup runs in parallel with the existing batch.
- **Revenue cockpit**: a Recurring-revenue (MRR/ARR) metric and an "accounts at churn risk" attention item — ranked above deal triage, reflecting the retention-first stance.
- **`AccountRetainPanel`** on account detail: MRR/ARR, health band + reasons, next renewal (viewer-local, with an overdue affordance), and a churn-risk prompt, for retain-stage accounts.

### Reviews & verification
- Independent code review applied — two real correctness fixes: (1) `autoRenew` now reads the *soonest-renewing* subscription (was `.some()`, which masked at-risk manual renewals); (2) MRR sums schedules + subscriptions **not covered** by a schedule (was all-or-nothing, dropping add-on subs). Plus parallelised the hub query, viewer-local renewal date, and retention-first attention ordering.
- 12 unit tests green; `apps/web` typecheck clean; ratchets (module-size, prose, style/token) green; local merged-CI passed.

Onboarding-milestone *persistence* deliberately deferred (would add a new model + migration cascade); represented here via existing engagement/renewal signals.

Plan: `docs/superpowers/plans/2026-08-15-retain-instrumentation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
