### PR TITLE
fix(governance): embed published overlay pages on the write-path + self-heal on upgrade (BI-D4C1E05E)

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/page.tsx
@@ -12,6 +12,7 @@ import { Prisma, prisma } from "@dpf/db";
 import { WikiPageList, type WikiPageListItem } from "@/components/wiki/WikiPageList";
 import { DecisionDisciplineHub } from "@/components/wiki/DecisionDisciplineHub";
 import { buildDisciplineCards } from "@/lib/wiki/decision-governance-hub";
+import { getOverlayEmbeddingCoverage } from "@/lib/wiki/overlay-embedding-coverage";
 import {
   WWMD_PLATFORM_PROFILE_ID,
   WWWD_ORGANIZATION_PROFILE_ID,
@@ -200,6 +201,13 @@ export default async function WikiBrowsePage({
     }),
   ]);
 
+  // BI-D4C1E05E: embedding coverage for this org's overlay pages. A published
+  // page counts in a decision only once it is EMBEDDED; surfacing published-vs-
+  // embedded stops "ACTIVE" from overstating readiness. Fail-open helper.
+  const embeddingCoverage = organizationId
+    ? await getOverlayEmbeddingCoverage(organizationId)
+    : null;
+
   const wwmdOpenReviews = countUniqueOpenReviews(wwmdOpenReviewRows as DecisionInteractionQueueRow[]);
   const wwwdOpenReviews = countUniqueOpenReviews(wwwdOpenReviewRows as DecisionInteractionQueueRow[]);
   const wsidOpenReviews = countUniqueOpenReviews(wsidOpenReviewRows as DecisionInteractionQueueRow[]);
@@ -301,6 +309,26 @@ export default async function WikiBrowsePage({
           are built from. Kernel pages ship with the platform; overlay pages live
           alongside.
         </p>
+        {embeddingCoverage && !embeddingCoverage.degraded && embeddingCoverage.published > 0 && (
+          <p
+            className={`text-xs mb-4 ${
+              embeddingCoverage.pending > 0
+                ? "text-[var(--dpf-warning)]"
+                : "text-[var(--dpf-muted)]"
+            }`}
+            title={
+              embeddingCoverage.pending > 0
+                ? `Published but not yet retrievable: ${embeddingCoverage.pendingSlugs.join(", ")}`
+                : undefined
+            }
+          >
+            Retrieval coverage: {embeddingCoverage.embedded}/{embeddingCoverage.published}{" "}
+            overlay pages embedded
+            {embeddingCoverage.pending > 0
+              ? ` · ${embeddingCoverage.pending} not yet counting (next upgrade embeds them).`
+              : " · all counting."}
+          </p>
+        )}
         <WikiPageList pages={pages} />
       </section>
     </div>

--- a/apps/web/lib/actions/business-stance.ts
+++ b/apps/web/lib/actions/business-stance.ts
@@ -17,7 +17,6 @@ import {
   projectDeclaredStanceAlignment,
   type StanceAlignmentDimension,
 } from "@/lib/decision-perspective/stance-dimension-map";
-import { storeWikiPage } from "@/lib/wiki/embeddings";
 import {
   decisionAreaToDomainClass,
   validateBusinessStance,
@@ -114,26 +113,13 @@ export async function publishBusinessStance(
     return { ok: false, error: "No organization is configured for this install." };
   }
 
-  // Deliberation layer (best-effort): the gate-live material below is the
-  // enforcement; a failed embed only weakens retrieval context.
-  try {
-    await storeWikiPage({
-      pageId: result.pageId,
-      slug: validated.slug,
-      title: validated.title,
-      body: validated.body,
-      abstract: validated.summary,
-      pageKind: "stance",
-      status: "published",
-      isKernel: false,
-      kernelVersion: null,
-      organizationId: org.id,
-      kernelPageId: null,
-      ...projection,
-    });
-  } catch {
-    // best-effort; enforcement continues below
-  }
+  // BI-D4C1E05E: embedding now happens inside saveWikiOverlayEdit (the shared
+  // publish-path embed seam) on the status→published transition above, so no
+  // separate storeWikiPage call is needed here. It would only double-embed:
+  // storeWikiPage writes principle-payload fields exclusively for
+  // pageKind === "principle", so the stance-alignment `projection` is dropped by
+  // the embed regardless of caller — it flows to the Postgres dimension column
+  // via the saveWikiOverlayEdit upsert, not the vector payload.
 
   const promoted = await promoteStanceMaterial({
     db: prisma,

--- a/apps/web/lib/actions/stance-confirm.ts
+++ b/apps/web/lib/actions/stance-confirm.ts
@@ -101,9 +101,12 @@ export async function confirmStanceVectors(input: {
           changeSummary: "Stance confirmed by the owner (How you decide)",
           createdById: userId,
         });
-        // Deliberation layer (best-effort); the material below is the enforcement.
+        // Deliberation layer; the material below is the enforcement, so a failed
+        // embed never rolls back the confirm. BI-D4C1E05E: it must NOT be a
+        // SILENT skip — log loudly so the reembed reconcile's self-heal is a
+        // known follow-up rather than an undiagnosed governance gap.
         try {
-          await storeWikiPage({
+          const embedded = await storeWikiPage({
             pageId: saved.id,
             slug,
             title,
@@ -117,8 +120,20 @@ export async function confirmStanceVectors(input: {
             kernelPageId: null,
             ...projectStanceDimensionVector(vector.key),
           });
-        } catch {
-          // best-effort
+          if (!embedded) {
+            console.error(
+              `[embed-published-overlay] EMBED-SKIPPED slug=${slug} origin=stance-confirm — ` +
+                "confirmed stance was NOT embedded (embedding provider unavailable); invisible to " +
+                "wiki_query / principle_decide until the reembed reconcile runs. " +
+                "Fix: docker model pull ai/nomic-embed-text-v1.5",
+            );
+          }
+        } catch (err) {
+          console.error(
+            `[embed-published-overlay] EMBED-FAILED slug=${slug} origin=stance-confirm: ` +
+              `${(err as Error).message}. Stance confirmed but not embedded; the reembed ` +
+              "reconcile will self-heal it on the next upgrade boot.",
+          );
         }
       }
 

--- a/apps/web/lib/actions/wiki-edit.test.ts
+++ b/apps/web/lib/actions/wiki-edit.test.ts
@@ -17,6 +17,12 @@ vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
 // BI-8AC24F3D: mocked so the callsite wiring is what is under test here; the
 // helper's own contract is covered in lib/wiki/craft-override-promotion.test.ts.
+// BI-D4C1E05E: mock the shared embed seam so these action tests don't reach the
+// real storeWikiPage → generateEmbedding network path. The seam's own contract is
+// covered in lib/wiki/embed-published-overlay.test.ts.
+vi.mock("@/lib/wiki/embed-published-overlay", () => ({
+  embedPublishedOverlayPage: vi.fn().mockResolvedValue({ embedded: true, slug: "x" }),
+}));
 vi.mock("@/lib/wiki/craft-override-promotion", () => ({
   promoteCraftOverrideOnPublish: vi.fn().mockResolvedValue(null),
 }));
@@ -437,16 +443,27 @@ describe("saveWikiOverlayEdit — craft-override promotion", () => {
         page: expect.objectContaining({ id: "wp_craft", slug: craftSlug, pageKind: "heuristic" }),
       }),
     );
+    // BI-D4C1E05E: publishing also embeds the page via the shared seam.
+    const { embedPublishedOverlayPage } = await import("@/lib/wiki/embed-published-overlay");
+    expect(embedPublishedOverlayPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: "wiki-edit",
+        organizationId: "org_test",
+        page: expect.objectContaining({ id: "wp_craft", slug: craftSlug }),
+      }),
+    );
   });
 
-  it("does NOT promote when the save leaves the page in draft", async () => {
+  it("does NOT promote or embed when the save leaves the page in draft", async () => {
     const { promoteCraftOverrideOnPublish } = await import("@/lib/wiki/craft-override-promotion");
+    const { embedPublishedOverlayPage } = await import("@/lib/wiki/embed-published-overlay");
     stubExistingCraftPage("draft");
     stubUpdateResult("draft");
 
     await save("draft");
 
     expect(promoteCraftOverrideOnPublish).not.toHaveBeenCalled();
+    expect(embedPublishedOverlayPage).not.toHaveBeenCalled();
   });
 
   it("does NOT re-promote when editing a page that was ALREADY published", async () => {

--- a/apps/web/lib/actions/wiki-edit.ts
+++ b/apps/web/lib/actions/wiki-edit.ts
@@ -30,6 +30,7 @@ import { extractWikilinks } from "@dpf/db/wiki-frontmatter";
 import { revalidatePath } from "next/cache";
 import { requireUser } from "@/lib/actions/shared/guards";
 import { promoteCraftOverrideOnPublish } from "@/lib/wiki/craft-override-promotion";
+import { embedPublishedOverlayPage } from "@/lib/wiki/embed-published-overlay";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -180,6 +181,11 @@ export async function saveWikiOverlayEdit(
     // transition can be detected below (BI-8AC24F3D). Null when creating a new
     // row, which counts as "was not published".
     let previousStatus: WikiPageStatus | null = null;
+    // Body this page held before this save. BI-D4C1E05E: an already-published
+    // page only needs re-embedding when its body actually changed — so a no-op
+    // or metadata-only re-save of a published page skips the embed. Null when
+    // creating a new row (which always embeds if it lands published).
+    let previousBody: string | null = null;
 
     // If pageId supplied: load + verify scope.
     if (input.pageId) {
@@ -192,6 +198,7 @@ export async function saveWikiOverlayEdit(
           organizationId: true,
           pageKind: true,
           status: true,
+          body: true,
         },
       })) as
         | {
@@ -201,6 +208,7 @@ export async function saveWikiOverlayEdit(
             organizationId: string | null;
             pageKind: string;
             status: WikiPageStatus;
+            body: string;
           }
         | null;
       if (!existing) {
@@ -229,6 +237,7 @@ export async function saveWikiOverlayEdit(
         };
       }
       previousStatus = existing.status;
+      previousBody = existing.body;
     } else if (input.overridesKernelPageId) {
       // Creating a new overlay that overrides a kernel page.
       const kernel = (await prisma.wikiPage.findFirst({
@@ -306,6 +315,35 @@ export async function saveWikiOverlayEdit(
           pageKind: input.pageKind,
           abstract: input.abstract ?? null,
         },
+        origin: "wiki-edit",
+      });
+    }
+
+    // BI-D4C1E05E: embed the page into the `wiki-pages` vector store so a
+    // published stance/overlay is actually retrievable by the decision engine.
+    // Embed when the page lands published AND either it just became published
+    // (draft→published, or a fresh/override row with no prior status) OR its body
+    // changed — a no-op / metadata-only re-save of an already-published page skips
+    // the embed (storeWikiPage upserts by pageId, so a refresh would be idempotent
+    // but wasteful). Draft saves are never embedded (retrieval filters
+    // status=published). Never rolls back the save on a failed embed; the reembed
+    // reconcile self-heals on the next upgrade boot.
+    const bodyChangedWhilePublished =
+      previousStatus === "published" && previousBody !== input.body;
+    if (
+      saved.status === "published" &&
+      (previousStatus !== "published" || bodyChangedWhilePublished)
+    ) {
+      await embedPublishedOverlayPage({
+        page: {
+          id: saved.id,
+          slug: saved.slug,
+          title: input.title.trim(),
+          body: input.body,
+          abstract: input.abstract ?? null,
+          pageKind: input.pageKind,
+        },
+        organizationId: org.id,
         origin: "wiki-edit",
       });
     }

--- a/apps/web/lib/actions/wiki-publish.test.ts
+++ b/apps/web/lib/actions/wiki-publish.test.ts
@@ -16,6 +16,11 @@ vi.mock("@dpf/db", () => ({
 }));
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+// BI-D4C1E05E: mock the shared embed seam so batch-publish tests don't reach the
+// real storeWikiPage → generateEmbedding network path (covered in its own test).
+vi.mock("@/lib/wiki/embed-published-overlay", () => ({
+  embedPublishedOverlayPage: vi.fn().mockResolvedValue({ embedded: true, slug: "x" }),
+}));
 
 import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";

--- a/apps/web/lib/actions/wiki-publish.ts
+++ b/apps/web/lib/actions/wiki-publish.ts
@@ -24,6 +24,7 @@ import {
 import { revalidatePath } from "next/cache";
 import { requireUser } from "@/lib/actions/shared/guards";
 import { promoteCraftOverrideOnPublish } from "@/lib/wiki/craft-override-promotion";
+import { embedPublishedOverlayPage } from "@/lib/wiki/embed-published-overlay";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -205,6 +206,21 @@ export async function publishWikiOverlayPages(
           origin: "wiki-publish",
         });
         if (promotion) craftPromotions.push(promotion);
+
+        // BI-D4C1E05E: embed the newly-published page so it is retrievable by
+        // the decision engine — the same embed seam every publish path shares.
+        await embedPublishedOverlayPage({
+          page: {
+            id: row.id,
+            slug: row.slug,
+            title: row.title,
+            body: row.body,
+            abstract: row.abstract,
+            pageKind: row.pageKind,
+          },
+          organizationId: org.id,
+          origin: "wiki-publish",
+        });
       }
       revalidatePath(`/coworker-decisions/${row.slug}`);
     }

--- a/apps/web/lib/inference/jit-retrieval-discipline.test.ts
+++ b/apps/web/lib/inference/jit-retrieval-discipline.test.ts
@@ -27,6 +27,7 @@ const ALLOWED_EMBEDDING_CALLERS: ReadonlySet<string> = new Set([
   "apps/web/lib/inference/semantic-memory.ts", // conversation / platform / capability memory
   "apps/web/lib/documents/embeddings.ts", // uploaded documents
   "apps/web/lib/wiki/embeddings.ts", // WWMD/WWWD corpus pages
+  "apps/web/lib/wiki/embed-published-overlay.ts", // BI-D4C1E05E: the shared publish-path embed seam — embeds published wiki-overlay KNOWLEDGE pages (stances/overlays) via storeWikiPage, never an operational record
   "apps/web/lib/wiki/lint.ts", // corpus dedup similarity
   "apps/web/lib/wiki/principle-similarity.ts", // principle-vector similarity
   "apps/web/lib/mcp/packs/principle-decide-pack.ts", // principle-direction + semantic-decision knowledge

--- a/apps/web/lib/self-upgrade/portal-migrate-boot.test.ts
+++ b/apps/web/lib/self-upgrade/portal-migrate-boot.test.ts
@@ -170,7 +170,10 @@ describe.skipIf(!BASH_OK)("portal-migrate-boot.sh (BI-5322D025)", () => {
       const log = r.stdout;
       expect(log.indexOf("prisma migrate deploy")).toBeLessThan(log.indexOf("scripts/sync-provider-registry.ts"));
       expect(log.indexOf("scripts/sync-provider-registry.ts")).toBeLessThan(log.indexOf("scripts/reconcile-catalog-capabilities.ts"));
-      expect(log.indexOf("scripts/reconcile-catalog-capabilities.ts")).toBeLessThan(log.indexOf("BOOT_MARKER"));
+      // BI-D4C1E05E: the wiki embedding self-heal runs after the catalog reconcile
+      // and before the server starts.
+      expect(log.indexOf("scripts/reconcile-catalog-capabilities.ts")).toBeLessThan(log.indexOf("scripts/reembed-wiki-store.ts"));
+      expect(log.indexOf("scripts/reembed-wiki-store.ts")).toBeLessThan(log.indexOf("BOOT_MARKER"));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -211,6 +214,31 @@ describe.skipIf(!BASH_OK)("portal-migrate-boot.sh (BI-5322D025)", () => {
       });
       expect(r.status, bootDiagnostics(r)).toBe(0); // boot still succeeds
       expect(r.stderr).toContain("catalog capability reconciliation failed");
+      expect(r.stdout).toContain("BOOT_MARKER"); // server WAS started despite the failure
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, TIMEOUT_MS);
+
+  it("DEGRADES OPEN — still starts the server when wiki embedding self-heal fails", () => {
+    // BI-D4C1E05E: a drifted wiki vector index is a degraded retrieval state, not a
+    // correctness hazard for serving the portal, and the embedding provider may be
+    // legitimately unreachable at boot (the reembed script exits 1 in that case). So
+    // reembed-wiki-store.ts failing must NOT block boot — same degrade-open contract
+    // as the model-catalog reconcile, and the write-path embed keeps new publishes
+    // covered in the meantime.
+    const root = mkdtempSync(join(tmpdir(), "dpf-pmb-"));
+    try {
+      const appDir = join(root, "app");
+      mkdirSync(appDir, { recursive: true });
+      const r = run({
+        appDir,
+        fakeBin: makeFakeBin(root),
+        pnpmExit: 0,
+        pnpmFailMatch: "scripts/reembed-wiki-store.ts",
+      });
+      expect(r.status, bootDiagnostics(r)).toBe(0); // boot still succeeds
+      expect(r.stderr).toContain("wiki embedding self-heal did not reach full coverage");
       expect(r.stdout).toContain("BOOT_MARKER"); // server WAS started despite the failure
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -410,7 +410,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - button\n  - combobox\n    - option [selected]\n    - option\n  - button\n  - paragraph\n    - text"
     },
     "/coworker-decisions": {
-      "defaultVisibleWords": 306,
+      "defaultVisibleWords": 323,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,

--- a/apps/web/lib/wiki/embed-published-overlay.test.ts
+++ b/apps/web/lib/wiki/embed-published-overlay.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// BI-D4C1E05E — proof the shared embed seam embeds published overlay pages and,
+// crucially, that a failed embed is a LOUD, non-silent, non-throwing result (the
+// silent try/catch swallow is the bug this closes).
+
+const storeWikiPage = vi.fn();
+const isEmbeddingAvailable = vi.fn();
+
+vi.mock("@/lib/wiki/embeddings", () => ({
+  storeWikiPage: (...args: unknown[]) => storeWikiPage(...args),
+}));
+vi.mock("@/lib/inference/embedding", () => ({
+  isEmbeddingAvailable: (...args: unknown[]) => isEmbeddingAvailable(...args),
+}));
+
+import { embedPublishedOverlayPage } from "./embed-published-overlay";
+
+const PAGE = {
+  id: "p1",
+  slug: "stances/how-do-we-manage-the-business",
+  title: "How we manage the business",
+  body: "Continued, recurring use is the goal.",
+  abstract: "recurring use",
+  pageKind: "stance",
+};
+
+afterEach(() => vi.clearAllMocks());
+
+describe("embedPublishedOverlayPage (BI-D4C1E05E)", () => {
+  it("embeds a published page with the right payload when the provider is warm", async () => {
+    storeWikiPage.mockResolvedValue(true);
+    const out = await embedPublishedOverlayPage({
+      page: PAGE,
+      organizationId: "org1",
+      origin: "wiki-edit",
+    });
+    expect(out).toEqual({ embedded: true, slug: PAGE.slug });
+    expect(storeWikiPage).toHaveBeenCalledTimes(1);
+    expect(storeWikiPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageId: "p1",
+        slug: PAGE.slug,
+        status: "published",
+        isKernel: false,
+        organizationId: "org1",
+        kernelPageId: null,
+      }),
+    );
+    expect(isEmbeddingAvailable).not.toHaveBeenCalled(); // no warm probe needed on success
+  });
+
+  it("warms then retries once when the first embed returns false and the provider comes up", async () => {
+    storeWikiPage.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    isEmbeddingAvailable.mockResolvedValue(true);
+    const out = await embedPublishedOverlayPage({
+      page: PAGE,
+      organizationId: "org1",
+      origin: "wiki-edit",
+    });
+    expect(out).toEqual({ embedded: true, slug: PAGE.slug });
+    expect(storeWikiPage).toHaveBeenCalledTimes(2); // idle-evict warm-then-retry
+    expect(isEmbeddingAvailable).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a LOUD, non-silent skip (never throws) when the provider stays down", async () => {
+    storeWikiPage.mockResolvedValue(false);
+    isEmbeddingAvailable.mockResolvedValue(false);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const out = await embedPublishedOverlayPage({
+      page: PAGE,
+      organizationId: "org1",
+      origin: "wiki-edit",
+    });
+    expect(out).toEqual({ embedded: false, slug: PAGE.slug, reason: "provider-unavailable" });
+    expect(storeWikiPage).toHaveBeenCalledTimes(1); // no retry when the probe says still down
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("EMBED-SKIPPED"));
+    errSpy.mockRestore();
+  });
+
+  it("turns a storeWikiPage throw into a loud error result, never rethrows", async () => {
+    storeWikiPage.mockRejectedValue(new Error("vector store down"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const out = await embedPublishedOverlayPage({
+      page: PAGE,
+      organizationId: "org1",
+      origin: "wiki-publish",
+    });
+    expect(out).toEqual({ embedded: false, slug: PAGE.slug, reason: "error" });
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("EMBED-FAILED"));
+    errSpy.mockRestore();
+  });
+});

--- a/apps/web/lib/wiki/embed-published-overlay.ts
+++ b/apps/web/lib/wiki/embed-published-overlay.ts
@@ -1,0 +1,97 @@
+// BI-D4C1E05E: the ONE place a published org-overlay page becomes retrievable
+// WWWD/decision context (its `wiki-pages` vector-store row).
+//
+// THE DEFECT THIS CLOSES
+// Every path that flips an org-overlay page to `published` promoted decision
+// material but did NOT embed the page, so the stance existed in Postgres and in
+// the governance list yet was invisible to vector retrieval (`wiki_query`,
+// `principle_decide`, `evaluate_org_business_decision`). An operator publishes a
+// stance, the UI says "your AI now weighs this", and no decision path can see it.
+// This is the embedding sibling of BI-8AC24F3D's `promoteCraftOverrideOnPublish`:
+// a publish that structurally succeeds and functionally does nothing.
+//
+// The fix is one implementation with every publish caller, not a per-action
+// best-effort try/catch that swallows the skip. Keeping this in a plain module
+// (not a "use server" file) is deliberate — every export of a "use server"
+// module becomes a callable server action, and this helper must not be reachable
+// as its own endpoint. Same shape as `craft-override-promotion.ts`.
+
+import { storeWikiPage } from "@/lib/wiki/embeddings";
+import { isEmbeddingAvailable } from "@/lib/inference/embedding";
+
+/** The page fields embedding needs. Satisfied by rows every publish caller already has. */
+export type EmbeddableOverlayPage = {
+  id: string;
+  slug: string;
+  title: string;
+  body: string;
+  abstract: string | null;
+  pageKind: string;
+};
+
+export type OverlayEmbedOutcome =
+  | { embedded: true; slug: string }
+  | { embedded: false; slug: string; reason: "provider-unavailable" | "error" };
+
+/**
+ * Embed a just-published org-overlay page into the `wiki-pages` vector store so
+ * it is retrievable as WWWD/decision context. Publishing a stance/overlay page
+ * IS the operator's approval — this is the retrieval sibling of
+ * `promoteCraftOverrideOnPublish`'s enforcement.
+ *
+ * NEVER THROWS, and callers must never roll back the publish on a failed embed:
+ * the status flip has already happened and the reembed reconcile
+ * (`scripts/reembed-wiki-store.ts`, wired into portal boot) self-heals any
+ * missed page on the next upgrade. A failed embed is a LOUD warning, never a
+ * silent skip — that silence was the bug.
+ */
+export async function embedPublishedOverlayPage(input: {
+  page: EmbeddableOverlayPage;
+  organizationId: string;
+  /** Where the call came from, for the log line only. */
+  origin: string;
+}): Promise<OverlayEmbedOutcome> {
+  const { page, organizationId, origin } = input;
+
+  const doStore = (): Promise<boolean> =>
+    storeWikiPage({
+      pageId: page.id,
+      slug: page.slug,
+      title: page.title,
+      body: page.body,
+      abstract: page.abstract,
+      pageKind: page.pageKind,
+      status: "published",
+      isKernel: false,
+      kernelVersion: null,
+      organizationId,
+      kernelPageId: null,
+    });
+
+  try {
+    let ok = await doStore();
+    if (!ok) {
+      // Idle-evict-safe warm-then-retry: the Docker Model Runner can evict the
+      // embed model after idle, so the first `generateEmbedding` returns null.
+      // Probing `/models` warms the runner; retry once before declaring a skip.
+      const up = await isEmbeddingAvailable();
+      if (up) ok = await doStore();
+    }
+    if (ok) return { embedded: true, slug: page.slug };
+
+    console.error(
+      `[embed-published-overlay] EMBED-SKIPPED slug=${page.slug} origin=${origin} — ` +
+        "published page was NOT embedded (embedding provider unavailable after warm+retry), " +
+        "so it is invisible to wiki_query / principle_decide until the reembed reconcile runs. " +
+        "Fix: docker model pull ai/nomic-embed-text-v1.5",
+    );
+    return { embedded: false, slug: page.slug, reason: "provider-unavailable" };
+  } catch (err) {
+    console.error(
+      `[embed-published-overlay] EMBED-FAILED slug=${page.slug} origin=${origin}: ` +
+        `${(err as Error).message}. Page is published but not embedded; the reembed ` +
+        "reconcile will self-heal it on the next upgrade boot.",
+    );
+    return { embedded: false, slug: page.slug, reason: "error" };
+  }
+}

--- a/apps/web/lib/wiki/embedding-reconciliation.ts
+++ b/apps/web/lib/wiki/embedding-reconciliation.ts
@@ -17,7 +17,18 @@ export async function reconcilePublishedWikiEmbeddings(input: {
   limit?: number;
   dryRun?: boolean;
 } = {}): Promise<WikiEmbeddingReconciliationResult> {
-  const limit = Math.max(1, Math.min(input.limit ?? DEFAULT_PAGE_LIMIT, DEFAULT_PAGE_LIMIT));
+  // BI-D4C1E05E: this reconcile is now the fleet self-heal wired into portal boot,
+  // so its page limit must be RAISABLE (the maintainer/boot path passes a full-corpus
+  // limit). The default stays DEFAULT_PAGE_LIMIT for the fire-and-forget recall
+  // callers that want it bounded — but the old unraisable `Math.min(..., 500)` cap
+  // would have left any install with >500 published pages self-healing only an
+  // arbitrary subset, permanently skipping the unembedded stance that motivated
+  // this BI. Order by `updatedAt desc` so a just-authored (most-recently-touched)
+  // unembedded page is covered first when a limit does bite. The point scan is
+  // scaled to the page limit so a large corpus doesn't falsely re-embed already-
+  // embedded pages (an incomplete point set only wastes work — it never misses a
+  // genuinely-missing page).
+  const limit = Math.max(1, input.limit ?? DEFAULT_PAGE_LIMIT);
   const [pages, points] = await Promise.all([
     prisma.wikiPage.findMany({
       where: { status: "published", ...(input.kind ? { pageKind: input.kind } : {}) },
@@ -28,11 +39,11 @@ export async function reconcilePublishedWikiEmbeddings(input: {
         principleRingScope: true, principleDimensionVector: true, principlePublic: true,
       },
       take: limit,
-      orderBy: { id: "asc" },
+      orderBy: { updatedAt: "desc" },
     }),
     scrollPoints(QDRANT_COLLECTIONS.WIKI_PAGES, {
       must: [{ key: "entityType", match: { value: "wiki-page" } }],
-    }, VECTOR_SCAN_LIMIT),
+    }, Math.max(VECTOR_SCAN_LIMIT, limit)),
   ]);
   const present = new Set(points
     .map((point) => point.payload.entityId)

--- a/apps/web/lib/wiki/overlay-embedding-coverage.test.ts
+++ b/apps/web/lib/wiki/overlay-embedding-coverage.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const wikiPageFindMany = vi.fn();
+const scrollPoints = vi.fn();
+
+vi.mock("@dpf/db", () => ({
+  QDRANT_COLLECTIONS: { WIKI_PAGES: "wiki-pages" },
+  scrollPoints: (...args: unknown[]) => scrollPoints(...args),
+  prisma: { wikiPage: { findMany: (...args: unknown[]) => wikiPageFindMany(...args) } },
+}));
+
+import { getOverlayEmbeddingCoverage } from "./overlay-embedding-coverage";
+
+afterEach(() => vi.clearAllMocks());
+
+describe("getOverlayEmbeddingCoverage (BI-D4C1E05E)", () => {
+  it("reports the published-vs-embedded gap by matching pages to vector points", async () => {
+    wikiPageFindMany.mockResolvedValue([
+      { id: "a", slug: "stances/one" },
+      { id: "b", slug: "stances/two" },
+      { id: "c", slug: "stances/three" },
+    ]);
+    // Only a and c have vector rows; b is published but not embedded.
+    scrollPoints.mockResolvedValue([
+      { payload: { entityId: "a" } },
+      { payload: { entityId: "c" } },
+    ]);
+    const cov = await getOverlayEmbeddingCoverage("org1");
+    expect(cov.published).toBe(3);
+    expect(cov.embedded).toBe(2);
+    expect(cov.pending).toBe(1);
+    expect(cov.pendingSlugs).toEqual(["stances/two"]);
+    expect(cov.degraded).toBe(false);
+  });
+
+  it("fails open (degraded, never throws) when the vector store is unreachable", async () => {
+    wikiPageFindMany.mockResolvedValue([{ id: "a", slug: "stances/one" }]);
+    scrollPoints.mockRejectedValue(new Error("store down"));
+    const cov = await getOverlayEmbeddingCoverage("org1");
+    expect(cov.degraded).toBe(true);
+    expect(cov.published).toBe(0);
+  });
+});

--- a/apps/web/lib/wiki/overlay-embedding-coverage.ts
+++ b/apps/web/lib/wiki/overlay-embedding-coverage.ts
@@ -1,0 +1,65 @@
+// BI-D4C1E05E — read model for the governance UI's embedding-coverage indicator.
+//
+// "ACTIVE" in the governance list means the WikiPage row is published. It does
+// NOT mean the page is embedded, and only an embedded page is retrievable by the
+// decision engine (wiki_query / principle_decide). Surfacing published-vs-embedded
+// stops "ACTIVE" from overstating readiness: an operator can see at a glance that
+// a stance is published but not yet counting, and that the reembed reconcile will
+// close the gap on the next upgrade boot.
+//
+// This mirrors reconcilePublishedWikiEmbeddings' scan (published rows ∩ vector
+// points) but is ORG-SCOPED and read-only — it never embeds. Fail-open: on any
+// store error it reports what it can rather than throwing into the page render.
+
+import { prisma, QDRANT_COLLECTIONS, scrollPoints } from "@dpf/db";
+
+const PAGE_SCAN_LIMIT = 2_000;
+const VECTOR_SCAN_LIMIT = 20_000;
+
+export type OverlayEmbeddingCoverage = {
+  /** Published org-overlay pages (the ones the governance list shows as ACTIVE). */
+  published: number;
+  /** Of those, how many have a `wiki-pages` vector row (retrievable). */
+  embedded: number;
+  /** published − embedded: published but NOT retrievable yet. */
+  pending: number;
+  /** Slugs of pending pages (capped) so the UI can name what is not counting. */
+  pendingSlugs: string[];
+  /** True when the coverage scan itself failed (store unreachable) — fail-open. */
+  degraded: boolean;
+};
+
+export async function getOverlayEmbeddingCoverage(
+  organizationId: string,
+): Promise<OverlayEmbeddingCoverage> {
+  try {
+    const [pages, points] = await Promise.all([
+      prisma.wikiPage.findMany({
+        where: { organizationId, status: "published", isKernel: false },
+        select: { id: true, slug: true },
+        take: PAGE_SCAN_LIMIT,
+        orderBy: { slug: "asc" },
+      }),
+      scrollPoints(
+        QDRANT_COLLECTIONS.WIKI_PAGES,
+        { must: [{ key: "entityType", match: { value: "wiki-page" } }] },
+        VECTOR_SCAN_LIMIT,
+      ),
+    ]);
+    const present = new Set(
+      points
+        .map((point) => point.payload.entityId)
+        .filter((id): id is string => typeof id === "string"),
+    );
+    const pendingSlugs = pages.filter((p) => !present.has(p.id)).map((p) => p.slug);
+    return {
+      published: pages.length,
+      embedded: pages.length - pendingSlugs.length,
+      pending: pendingSlugs.length,
+      pendingSlugs: pendingSlugs.slice(0, 50),
+      degraded: false,
+    };
+  } catch {
+    return { published: 0, embedded: 0, pending: 0, pendingSlugs: [], degraded: true };
+  }
+}

--- a/apps/web/scripts/reembed-wiki-store.ts
+++ b/apps/web/scripts/reembed-wiki-store.ts
@@ -65,7 +65,15 @@ async function main(): Promise<void> {
     }
   }
 
-  const result = await reconcilePublishedWikiEmbeddings({ kind: flags.kind, dryRun: flags.dryRun });
+  // Full-corpus reembed: this maintainer/boot self-heal must cover EVERY published
+  // page, not the default fire-and-forget page window (BI-D4C1E05E). Pass an
+  // effectively-unbounded limit so no unembedded page is skipped.
+  const FULL_CORPUS_LIMIT = 1_000_000;
+  const result = await reconcilePublishedWikiEmbeddings({
+    kind: flags.kind,
+    dryRun: flags.dryRun,
+    limit: FULL_CORPUS_LIMIT,
+  });
 
   console.info(
     `[reembed-wiki-store] scanned=${result.scanned} missing=${result.missing} ` +

--- a/docs/superpowers/plans/2026-08-15-wwwd-stance-embedding-writepath.md
+++ b/docs/superpowers/plans/2026-08-15-wwwd-stance-embedding-writepath.md
@@ -1,0 +1,70 @@
+# Plan — WWWD stance publish embeds on the write-path + self-heals on upgrade (BI-D4C1E05E)
+
+**BI:** BI-D4C1E05E — *Publishing a WWWD stance does NOT embed it — the stance is silently invisible to the decision engine until a separate reembed.*
+**Type:** bug · **Priority:** P1 · **Triage:** build · **Size:** small
+**Related:** EP-1C37C089 (governance gate), BI-512FBD20 (reembed reconciler — becomes the self-heal engine), BI-8AC24F3D (`craft-override-promotion.ts` — the direct precedent), BI-7E1F128A (WWWD alignment).
+
+**For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+---
+
+## Problem (confirmed against source, 2026-08-15)
+
+Two generic overlay write-paths flip an org-overlay page to `published` and promote craft/stance material, but **neither embeds the page**:
+
+- `saveWikiOverlayEdit` (`apps/web/lib/actions/wiki-edit.ts`) — the action the portal Edit / craft / free-form stance editor calls. On the `draft→published` transition it calls `promoteCraftOverrideOnPublish` but never `storeWikiPage`.
+- `publishWikiOverlayPages` (`apps/web/lib/actions/wiki-publish.ts`) — batch publish. Same: promotes material, does not embed.
+
+The two *specialized* stance actions (`publishBusinessStance`, `confirmStanceVectors`) do call `storeWikiPage`, but wrapped in `try { … } catch { /* best-effort */ }` — a **silent** skip. The leaked live slug (`stances/how-do-we-manage-…`) is a free-form page authored via the **generic** editor → `saveWikiOverlayEdit`, which is why `vector_embedding` count stayed 301 and `wiki_query` never returned it.
+
+This is the same defect class BI-8AC24F3D closed for material promotion: *a publish that structurally succeeds and functionally does nothing.* The fix follows that exact precedent — **one embed implementation, wired at every publish path** — and adds the fleet self-heal + coverage surfacing the BI requires.
+
+## Approach
+
+Mirror `promoteCraftOverrideOnPublish`: a single plain-module helper `embedPublishedOverlayPage`, called at every `→published` transition. Embedding failure is **observable, never silent** (loud greppable log + numeric outcome), matching the `searchWikiPages` degradation marker. Self-heal pre-existing gaps on upgrade via the already-self-verifying reembed reconciler, run as a non-fatal boot step. Surface embedded-vs-published coverage in the governance UI so "ACTIVE" cannot overstate readiness.
+
+---
+
+## Phases
+
+### Phase 1 — Single embed seam on the write-path
+**Deliverable:** `apps/web/lib/wiki/embed-published-overlay.ts` — `embedPublishedOverlayPage(page)` that maps a saved overlay row to `storeWikiPage` input and embeds it. Returns a typed `{ embedded: true } | { embedded: false; reason }`; on failure emits a loud, greppable `console.error("[embed-published-overlay] …")` naming the slug and the fix (`docker model pull ai/nomic-embed-text-v1.5`). Never throws to the caller (a publish must not roll back on embed failure) but never swallows silently either.
+**Wire:**
+- `wiki-edit.ts` — after `promoteCraftOverrideOnPublish`, inside the same `saved.status === "published" && previousStatus !== "published"` guard, call `embedPublishedOverlayPage`. Also embed on re-publish of an already-published page whose body changed (edit-then-save keeps the index fresh) — guard on `published` target, not only the transition, but skip when body unchanged.
+- `wiki-publish.ts` — inside the `targetStatus === "published"` branch of the batch loop, call `embedPublishedOverlayPage` per row.
+- `business-stance.ts` — `publishBusinessStance` delegates to `saveWikiOverlayEdit(status:"published")`, which now embeds via the shared seam, so its own direct `storeWikiPage` call is REMOVED (it would double-embed). The stance-alignment `projection` is not lost by this: `storeWikiPage` writes principle-payload fields only for `pageKind === "principle"`, so the projection is dropped by the embed regardless of caller — its durable home is the Postgres dimension column via the `saveWikiOverlayEdit` upsert, untouched.
+- `stance-confirm.ts` — this path uses `upsertWikiPage` directly (NOT `saveWikiOverlayEdit`), so it is a genuinely separate write path and keeps its own `storeWikiPage` call; its silent `catch {}` is converted to the same LOUD, greppable `EMBED-SKIPPED` / `EMBED-FAILED` marker.
+**Verify:** unit test `embed-published-overlay.test.ts` — warm embedder → `storeWikiPage` called with the right payload, returns embedded; embedder cold (`generateEmbedding` → null) → returns `{embedded:false}` and logs the marker, does not throw. Action-level: `wiki-edit.test.ts` asserts publishing a `stance` page invokes the embed seam.
+
+### Phase 2 — Coverage-gap mode on the reconciler + wire into upgrade boot
+**Deliverable:**
+- `scripts/portal-migrate-boot.sh` — after catalog-capability reconciliation and before `exec "$@"`, add a **non-fatal** step running `reembed-wiki-store.ts`. On failure: `WARN` and continue (matches the model-catalog precedent — embedding-provider unavailability must not crash-loop the portal). *No new flag needed:* `reconcilePublishedWikiEmbeddings` is ALREADY coverage-gap-based (it computes `missing = published − present-in-vector-store` and embeds only the gap), so the existing script is a cheap no-op once coverage is complete and keeps its fail-loud provider precondition. **Full-corpus coverage (review S1):** the reconciler's page limit was an unraisable `Math.min(…, 500)` cap — as the fleet self-heal that would embed only an arbitrary 500-page subset on large installs and could permanently skip the unembedded stance. The cap is made raisable (default 500 for the fire-and-forget recall path), the maintainer/boot script passes a full-corpus limit, ordering is `updatedAt desc` so recent publishes win, and the point scan is scaled to the page limit.
+**Verify:** `--dry-run --missing-only` on a seeded corpus reports the gap count without embedding. Boot-script unit test (`portal-migrate-boot` harness, `DPF_APP_DIR` + fake `pnpm`) asserts the reembed step runs and a non-zero exit only WARNs (boot still `exec`s). Functional: on the live install, publish a stance via the generic editor → confirm a new `vector_embedding` row + `wiki_query` returns it (the BI's dogfood AC).
+
+### Phase 3 — Governance UI coverage indicator
+**Deliverable:** `/coworker-decisions` surfaces embedded-vs-published for org-overlay stance/overlay pages (e.g. "23 published · 22 embedded · 1 pending"), driven by a read helper (`overlay-embedding-coverage.ts`) that counts published overlay pages vs their `vector_embedding` rows. A page that is published-but-unembedded is visibly flagged so ACTIVE cannot overstate readiness.
+**Verify:** read-helper unit test (published vs embedded counts). Route render check via the contributor preview: the indicator shows the real gap before self-heal and closes to full after a reembed.
+
+---
+
+## Backlog coverage
+
+- **Decision:** `atomic` — the write-path embed seam, the upgrade-time self-heal, and the coverage surfacing are one indivisible fix for a single defect. The write-path fix alone stops NEW gaps but leaves every existing install's unembedded pages dark; the reconcile alone heals history but lets new publishes re-open the gap; the UI indicator is meaningless without both. No phase is independently shippable as a fix to BI-D4C1E05E.
+- **Parent BI:** BI-D4C1E05E
+- **Receipt:** `cmstr1scj020n01qxgkrwzas7` (atomic; recorded 2026-08-15 via `record_plan_backlog_coverage`).
+
+## Risks & rollback
+
+- **Blast radius:** all publish paths for org-overlay pages, plus every portal boot. Mitigated: embed is best-effort-but-loud (never rolls back a publish, never crash-loops boot); the boot step is non-fatal; `--missing-only` is a cheap no-op when covered.
+- **Embedder-down at publish:** page publishes, embed logs the loud marker, and the next boot's `--missing-only` reconcile (or a manual full reembed) closes the gap — the self-heal is the backstop, exactly as designed.
+- **Re-embed cost on boot:** bounded by `--missing-only` (only the gap); full corpus re-embed stays an explicit maintainer command.
+- **Rollback:** revert the boot-script line (self-heal off; write-path fix still stands) and/or the write-path wiring (reverts to prior behaviour) independently. No schema migration, so no data rollback needed.
+
+## Definition of done (BI acceptance criteria)
+
+- [ ] Publishing/saving any overlay page embeds it — new `vector_embedding` row + surfaces in `wiki_query`.
+- [ ] Reembed coverage reconcile runs in the upgrade sequence, idempotently, self-healing pre-existing gaps.
+- [ ] Reconcile stays self-verifying: numeric coverage, fails loud when the embedder is unavailable, never silent.
+- [ ] Governance UI shows embedding coverage (embedded vs published).
+- [ ] Regression test: write-path with embedder warm → embedded; cold → loud, never silently dropped.
+- [ ] The operator's own (customer 0) `how-do-we-manage-…` stance becomes retrievable via this pipeline on next upgrade (dogfood), not a manual one-off.

--- a/docs/user-guide/wiki/index.md
+++ b/docs/user-guide/wiki/index.md
@@ -23,6 +23,8 @@ order: 1
 
 The wiki is authoritative for governed platform knowledge that has been imported, authored, linted, and published. It is not a substitute for runtime state, backlog state, or source code when those are the current evidence source.
 
+A page only counts in a coworker's decision once it is **embedded** for retrieval, which normally happens the moment you publish it. The Governing material section of `/coworker-decisions` shows a **retrieval coverage** line — how many of your published overlay pages are embedded — so "published" can never overstate "counting". If a page is published but not yet embedded (for example, if the embedding service was briefly unavailable when you published), it is flagged there, and the platform re-embeds it automatically on the next upgrade.
+
 ## AI Coworker Support
 
 Coworkers can retrieve wiki context, propose edits, and use principles as governance context. They must keep source-backed knowledge separate from guesses and should surface missing citations as stewardship issues.

--- a/scripts/portal-migrate-boot.sh
+++ b/scripts/portal-migrate-boot.sh
@@ -57,6 +57,26 @@ if ! pnpm --filter @dpf/db exec tsx scripts/reconcile-catalog-capabilities.ts; t
   echo "[portal-boot] WARN: catalog capability reconciliation failed — starting with the existing model catalog (see error above)" >&2
 fi
 
+# BI-D4C1E05E — self-heal the wiki vector store on every upgrade boot.
+# A self-upgrade merges upstream main and rebuilds, but published stances/overlay
+# pages that were authored while an earlier build never embedded them stay
+# invisible to the decision engine (wiki_query / principle_decide) until a manual
+# reembed. This step embeds only the MISSING pages (reconcilePublishedWikiEmbeddings
+# is coverage-gap-based and idempotent), so it is a cheap no-op once coverage is
+# complete and a loud, self-verifying self-heal when it is not.
+#
+# NON-FATAL, exactly like the catalog reconcile above: the embedding provider
+# (Docker Model Runner) may legitimately be unreachable at boot, and the script
+# EXITS 1 in that case (fail-loud precondition) — but a drifted vector index is a
+# DEGRADED retrieval state, not a correctness hazard for serving the portal, and
+# the next boot (or a manual reembed) closes the gap. Blocking boot on the embed
+# provider would crash-loop the portal the same way blocking on the model catalog
+# did (#318). Failures are logged; the write-path embed (this same BI) keeps new
+# publishes covered in the meantime.
+if ! pnpm --filter web exec tsx scripts/reembed-wiki-store.ts; then
+  echo "[portal-boot] WARN: wiki embedding self-heal did not reach full coverage — embedding provider may be unavailable; new publishes still embed on the write-path, and the next boot retries (see error above)" >&2
+fi
+
 # BET-5 (BI-A1E864A5 / BI-922EBB99 / BI-2A3BE4D7): the one-time Neo4j+Qdrant → Postgres boot
 # backfill was retired here once the fleet completed migration (zero un-migrated installs).
 # The platform runs Postgres-only; new installs never provision the legacy stores. The


### PR DESCRIPTION
## What & why (BI-D4C1E05E, P1)

Publishing a WWWD stance (or any org-overlay page) via the generic editor persisted the `WikiPage` and promoted decision material but **never embedded it**, so the stance was invisible to vector retrieval (`wiki_query` / `principle_decide` / `evaluate_org_business_decision`) until a manual reembed. The governance list showed it ACTIVE while the decision engine could not see it — the same silent-partial-corpus class as BI-512FBD20 / BI-7E1F128A, and it undermines the governance gate (EP-1C37C089).

Root cause (confirmed in source): the generic publish paths `saveWikiOverlayEdit` and `publishWikiOverlayPages` flipped pages to `published` and called `promoteCraftOverrideOnPublish` but never `storeWikiPage`. The specialized stance actions embedded but swallowed failures in a silent `catch {}`.

## Fix (all three BI parts)

1. **Write-path embeds** — new shared `embedPublishedOverlayPage` seam (plain module, mirrors `craft-override-promotion.ts`) wired at every publish transition. Never throws, **never silent**: a failed embed logs a loud, greppable `EMBED-SKIPPED` / `EMBED-FAILED` marker and the publish still succeeds; idle-evict-safe warm-then-retry.
2. **Self-heal on upgrade** — `portal-migrate-boot.sh` runs `reembed-wiki-store.ts` as a **non-fatal** boot step (degrade-open, matching the model-catalog precedent — an embed provider down at boot must not crash-loop the portal). `reconcilePublishedWikiEmbeddings` is already coverage-gap based (embeds only the missing pages), now with a raisable full-corpus limit + `updatedAt desc` ordering so a just-authored unembedded page is covered first.
3. **Coverage surfaced** — `/coworker-decisions` shows embedded-vs-published for overlay pages so ACTIVE cannot overstate readiness.

## Design grounding

Extends the wiki write-path (source of truth `apps/web/lib/wiki/embeddings.ts` + the `craft-override-promotion.ts` precedent, BI-8AC24F3D). No new contract — composes the existing `storeWikiPage` primitive and the `reembed-wiki-store.ts` reconciler (BI-512FBD20). Plan: `docs/superpowers/plans/2026-08-15-wwwd-stance-embedding-writepath.md`.

## Backlog coverage

Receipt `cmstr1scj020n01qxgkrwzas7` — **atomic** (the write-path embed, the upgrade self-heal, and the coverage indicator are one indivisible fix; no phase is independently shippable).

## Independent semantic review

An independent adversarial review returned **no blockers**; its Should-fix findings were incorporated before this PR:
- **S1** — the reconciler's unraisable 500-page cap would have made the fleet self-heal cover only an arbitrary subset on large installs → cap made raisable, boot passes a full-corpus limit, ordered `updatedAt desc`.
- **S2** — `publishBusinessStance` double-embedded (delegates to `saveWikiOverlayEdit`, which now embeds) → redundant direct `storeWikiPage` removed; the stance-alignment projection is dropped by the embed regardless of caller (principle-only payload), so nothing is lost.
- **S3** — the seam was unmocked in the `wiki-edit`/`wiki-publish` suites (live fetch) → mocked, plus the promised "publish invokes the seam" assertion added.
- **N1** — embed now guards on transition-or-body-changed (no re-embed on a no-op re-save).

## Verification

- Local-CI merged-gate: **PASS** (evidence `cmsts3lwy04fc01qxi17d7oky`).
- 67 unit tests green: embed-seam (warm/retry/loud-skip/throw), org-scoped coverage read model, boot ordering + degrade-open, plus existing `embeddings` / `wiki-edit` / `wiki-publish` / `jit-retrieval-discipline` suites. Full `apps/web` typecheck clean. Private-identity + style-drift + prose-lint guards clean.
- Dogfood AC: on next upgrade the operator's own (customer 0) `how-do-we-manage-…` stance embeds via the boot self-heal — not a manual one-off.

Signed-off-by: dpf-ci <dpf-ci@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)