### PR TITLE
feat(guard): private-identity tripwire at commit time, not just the merge gate (BI-C9E5E7D9)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -133,6 +133,28 @@ if [ -n "$STAGED_FILES" ]; then
   fi
 fi
 
+# ─── Guard 3b: staged private-identity tripwire (BI-C9E5E7D9) ────────────────
+# The REQUIRED merge gate (check-no-private-identity in Policy Guards (source))
+# already blocks a real operator/customer/person name from spreading into the OSS
+# repo — but only at CI time, after a full green run, forcing a late scrub commit
+# and a queue re-run. This runs the SAME guard against the STAGED snapshot only,
+# so a leak is caught here, at commit time, naming the file + token. Staged-only
+# keeps it fast (sub-second). Skip: DPF_SKIP_PRIVATE_IDENTITY_SCAN=1.
+
+if [ -n "$STAGED_FILES" ]; then
+  if [ "$DPF_SKIP_PRIVATE_IDENTITY_SCAN" = "1" ]; then
+    echo "[pre-commit] DPF_SKIP_PRIVATE_IDENTITY_SCAN=1 - skipping staged private-identity scan."
+  else
+    if ! node scripts/check-no-private-identity.mjs --staged; then
+      echo ""
+      echo "Commit rejected. A protected private-identity token is in your staged changes."
+      echo "Genericize it (see the placeholder convention above), then re-stage the file."
+      echo ""
+      exit 1
+    fi
+  fi
+fi
+
 # ─── Guard 5: schema regression ─────────────────────────────────────────────
 # When schema.prisma is staged, run the same reorder-tolerant set-based
 # check the CI workflow uses (.github/workflows/schema-regression-guard.yml

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -5110,6 +5110,8 @@
       "anchors": [
         "oss-repo-identity-hygiene",
         "what-is-and-isnt-allowed",
+        "approved-placeholders-write-these-from-the-first-draft",
+        "caught-at-commit-time-not-just-at-ci",
         "how-it-is-enforced",
         "the-ratchet",
         "when-the-guard-fails-on-your-pr",

--- a/docs/operations/oss-repo-identity-hygiene.md
+++ b/docs/operations/oss-repo-identity-hygiene.md
@@ -28,6 +28,31 @@ private config. See
 [Customer 0 Pre-Install Readiness](customer-zero-preinstall-readiness.md) for a
 worked example of a doc written this way.
 
+### Approved placeholders (write these from the first draft)
+
+Reach for one of these from the first draft — never the real name — so a dogfood
+or operator spec is genericized *before* it is ever staged:
+
+| Instead of the real… | Write |
+| --- | --- |
+| operator / customer-0 organization name | **`operator`**, **`customer 0`**, or **`the operator's organization`** |
+| owner / founder person name | **`operator/owner`** or **`the owner`** |
+| this specific install | **`this operator install`** or **`your install`** |
+| the publishing legal entity | **`the publishing entity`** |
+
+These placeholders read the same on every install and never trip the guard, so a
+spec written with them is portable OSS documentation by construction.
+
+### Caught at commit time, not just at CI
+
+The same `check-no-private-identity` guard also runs as a **pre-commit tripwire**
+against your **staged** files (`.githooks/pre-commit`, `--staged` mode). A new
+protected token is rejected at `git commit` — naming the file *and* the token —
+so you fix it immediately instead of discovering it after a full green CI run and
+a late scrub commit. The staged tripwire respects the same baseline (legitimate
+audited occurrences never block), and the required CI gate remains the
+authoritative backstop. Emergency bypass: `DPF_SKIP_PRIVATE_IDENTITY_SCAN=1`.
+
 ## How it is enforced
 
 Two scanners run on every PR; they cover different risks and have different
@@ -36,7 +61,7 @@ teeth:
 | Scanner | Catches | Runs at | Blocks merge? |
 | --- | --- | --- | --- |
 | gitleaks (`secrets-scan.yml`) | secret-**shaped** content — keys, tokens, credentials | pre-commit + CI | No — advisory only |
-| **check-no-private-identity** (Repo Guard Loop) | protected-identity **names/tokens** | CI (required) | **Yes** |
+| **check-no-private-identity** (Repo Guard Loop) | protected-identity **names/tokens** | **pre-commit (staged tripwire) + CI (required)** | **Yes** (at CI) |
 
 An organization *name* is not secret-shaped, so gitleaks does not catch it — that
 is the gap that let a real customer identity into a docs PR once. Because the

--- a/docs/superpowers/plans/2026-08-15-private-identity-precommit-tripwire.md
+++ b/docs/superpowers/plans/2026-08-15-private-identity-precommit-tripwire.md
@@ -1,0 +1,40 @@
+# Plan — Catch private-identity leaks at commit time, not just the merge gate (BI-C9E5E7D9)
+
+**BI:** BI-C9E5E7D9 · **Type:** tool · **Priority:** P3 · **Triage:** build · **Size:** small
+
+**For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Problem
+
+`check-no-private-identity` (required merge check inside Policy Guards (source)) blocks real operator/customer/person identity from the OSS repo — but only at **CI/merge time**. A dogfood/operator spec naturally names the real operator, goes fully green on functional checks, then sits BLOCKED solely on the identity leak, forcing a late scrub commit + full CI re-run. Observed this session: the WWWD-embedding plan doc tripped it at pregate after a green local run. The guard catches the leak *last*; it should catch it *first*.
+
+## Approach (BI recommendation #1 + #2)
+
+1. **Pre-commit staged tripwire** — add a `--staged` mode to `scripts/check-no-private-identity.mjs` that scans ONLY the staged snapshot of this commit's files and diffs against the SAME baseline, then wire it into `.githooks/pre-commit` as a new guard (staged-only → sub-second). Same ratchet semantics: legitimate baselined occurrences never block.
+2. **Placeholder convention** — document the approved generic placeholder set (`operator`, `operator/owner`, `customer 0`, `this operator install`, `the publishing entity`) in `docs/operations/oss-repo-identity-hygiene.md` so authors write the placeholder from the first draft.
+
+The required CI gate is unchanged — this is an earlier tripwire, not a replacement backstop.
+
+## Phases (atomic)
+
+- **Guard `--staged` mode** — `scanStaged(regex, {files, readBlob})` reuses the existing `buildTokenRegex` / baseline / `diff`; reads staged blobs via `git show :<file>`; applies the same SCAN_EXT / SCAN_DIRS / SELF_EXCLUDE inclusion rules; `--staged` branch in `main` blocks with file + token named. Verify: unit tests (synthetic token, injected reader) for counting, inclusion filters, new-file block, baselined-allow, grown-count block.
+- **Hook wiring** — Guard 3b in `.githooks/pre-commit` runs `--staged` on staged files, with `DPF_SKIP_PRIVATE_IDENTITY_SCAN=1` escape hatch. Verify: committing a clean change passes the hook (this PR's own commit is the functional proof).
+- **Docs** — placeholder convention + pre-commit tripwire section in the hygiene doc; enforcement table updated to "pre-commit (staged) + CI".
+
+## Acceptance criteria
+
+- [ ] A NEW private-identity token in a staged file is caught locally before push, naming file + token.
+- [ ] Staged-only scan (no full-repo walk on every commit; sub-second).
+- [ ] Placeholder convention documented in `oss-repo-identity-hygiene.md`.
+- [ ] Legitimate baseline occurrences do NOT block commits (respects the ratchet).
+- [ ] The required merge-gate guard is unchanged — earlier tripwire, not a replacement.
+
+## Backlog coverage
+
+- **Decision:** `atomic` — the `--staged` guard mode, the hook wiring, and the placeholder doc are one small tripwire; no phase is independently useful (the mode without the hook never runs; the hook without the mode has nothing to call; the doc without the mechanism is aspiration).
+- **Receipt:** `cmstsh4wc05by01qx1xh6xnd7` (atomic; recorded 2026-08-15).
+
+## Risks & rollback
+
+- **False block** at commit time on a legitimate baselined name → mitigated: staged diff respects the baseline, and `DPF_SKIP_PRIVATE_IDENTITY_SCAN=1` is the escape hatch; CI remains authoritative.
+- **Rollback:** remove the Guard 3b block from `.githooks/pre-commit` (the `--staged` mode is inert unless invoked). No baseline or CI change.

--- a/scripts/check-no-private-identity.mjs
+++ b/scripts/check-no-private-identity.mjs
@@ -33,6 +33,7 @@
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { execFileSync } from "node:child_process";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const TOKENS_PATH = join(REPO_ROOT, "scripts", "private-identity-tokens.txt");
@@ -145,6 +146,74 @@ function serialize(counts) {
   return `${keys.map((k) => `${k}\t${counts[k]}`).join("\n")}\n`;
 }
 
+// ─── Staged (pre-commit) mode ────────────────────────────────────────────────
+// The full scan above is the REQUIRED merge-gate backstop. This staged mode is
+// the earlier, faster tripwire (BI-C9E5E7D9): it scans ONLY the staged snapshot
+// of the files in this commit and compares against the same baseline, so a NEW
+// private-identity token is caught at `git commit` time — naming the file AND the
+// token — instead of at the late CI/merge gate after a full green run. Same
+// ratchet semantics: legitimate baselined occurrences never block.
+
+/** Staged file paths (repo-relative, forward slashes); added/copied/modified/renamed. */
+export function stagedFiles({ repoRoot = REPO_ROOT } = {}) {
+  let out;
+  try {
+    out = execFileSync(
+      "git",
+      ["diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z"],
+      { cwd: repoRoot, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+    );
+  } catch {
+    return [];
+  }
+  return out
+    .split("\0")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((p) => p.replace(/\\/g, "/"));
+}
+
+/** Read a file's STAGED (index) content, not the working-tree copy. */
+function readStagedBlob(relPath, repoRoot) {
+  try {
+    return execFileSync("git", ["show", `:${relPath}`], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Per-file token counts + the distinct matched tokens, over the STAGED content of
+ * the given files (defaults to the current commit's staged files). Only files
+ * under the scanned trees with a scannable extension, minus the self-exclude set —
+ * exactly the CI scan's inclusion rules, so the two agree on what counts.
+ */
+export function scanStaged(regex, { repoRoot = REPO_ROOT, files, readBlob } = {}) {
+  const counts = {};
+  const tokensByFile = {};
+  if (!regex) return { counts, tokensByFile };
+  const read = readBlob ?? ((rel) => readStagedBlob(rel, repoRoot));
+  const list = files ?? stagedFiles({ repoRoot });
+  for (const rel of list) {
+    if (SELF_EXCLUDE.has(rel)) continue;
+    if (!SCAN_EXT.has(ext(rel))) continue;
+    if (!SCAN_DIRS.some((d) => rel === d || rel.startsWith(`${d}/`))) continue;
+    const body = read(rel);
+    if (body == null) continue;
+    regex.lastIndex = 0;
+    const matches = body.match(regex) ?? [];
+    if (matches.length > 0) {
+      counts[rel] = matches.length;
+      tokensByFile[rel] = [...new Set(matches.map((m) => m.toLowerCase()))];
+    }
+  }
+  return { counts, tokensByFile };
+}
+
 /** Parse `<path>\t<count>` lines; union-merge duplicates resolve to MAX. */
 export function parseBaseline(text) {
   const counts = {};
@@ -182,6 +251,43 @@ function main() {
     process.exit(1);
   }
   const regex = buildTokenRegex(tokenText);
+
+  // ── Staged tripwire (pre-commit): scan only this commit's staged files ──
+  if (process.argv.includes("--staged")) {
+    let baseline;
+    try {
+      baseline = parseBaseline(readFileSync(BASELINE_PATH, "utf8"));
+    } catch {
+      // No baseline yet (fresh clone / bootstrap): treat every occurrence as new.
+      baseline = {};
+    }
+    const { counts, tokensByFile } = scanStaged(regex);
+    const { grew, fresh } = diff(counts, baseline);
+    if (grew.length === 0 && fresh.length === 0) {
+      console.log("✓ No new private-identity tokens in the staged files.");
+      return;
+    }
+    console.error("");
+    console.error("ERROR: a protected private-identity token is in your staged changes.");
+    console.error("");
+    console.error("Caught at commit time (before push) so you can fix it now instead of");
+    console.error("after a full CI run. Genericize it — use an approved placeholder");
+    console.error("(operator, operator/owner, customer 0, this operator install). See");
+    console.error("docs/operations/oss-repo-identity-hygiene.md.");
+    console.error("");
+    for (const entry of [...fresh, ...grew]) {
+      const file = entry.split(" ")[0];
+      const toks = tokensByFile[file] ? ` — token(s): ${tokensByFile[file].join(", ")}` : "";
+      console.error(`  - ${entry}${toks}`);
+    }
+    console.error("");
+    console.error("If this reference is genuinely legitimate and operator-approved, run");
+    console.error("`node scripts/check-no-private-identity.mjs --update` to retighten the");
+    console.error("baseline and call it out in the PR description. To bypass in an");
+    console.error("emergency: DPF_SKIP_PRIVATE_IDENTITY_SCAN=1 git commit ...");
+    process.exit(1);
+  }
+
   const current = scan(regex);
 
   if (process.argv.includes("--update")) {

--- a/scripts/check-no-private-identity.test.mjs
+++ b/scripts/check-no-private-identity.test.mjs
@@ -5,7 +5,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { buildTokenRegex, scan, parseBaseline, diff } from "./check-no-private-identity.mjs";
+import { buildTokenRegex, scan, parseBaseline, diff, scanStaged } from "./check-no-private-identity.mjs";
 
 // A fixture token that is NOT a real protected name, so the test never depends
 // on the live denylist.
@@ -62,5 +62,55 @@ test("diff flags a new file and a grown file, ignores a shrunk file", () => {
 test("diff is clean when everything is at or below baseline", () => {
   const { grew, fresh } = diff({ "a.md": 1 }, { "a.md": 2 });
   assert.equal(grew.length, 0);
+  assert.equal(fresh.length, 0);
+});
+
+// ─── Staged (pre-commit) tripwire — BI-C9E5E7D9 ──────────────────────────────
+
+test("scanStaged counts tokens per staged file and records the matched tokens", () => {
+  const re = buildTokenRegex(TOKENS);
+  const { counts, tokensByFile } = scanStaged(re, {
+    files: ["docs/spec.md", "apps/web/lib/x.ts"],
+    readBlob: (rel) =>
+      rel === "docs/spec.md" ? "AcmeCorp ships. acmecorp again." : "no token here",
+  });
+  assert.deepEqual(counts, { "docs/spec.md": 2 });
+  assert.deepEqual(tokensByFile["docs/spec.md"], ["acmecorp"]);
+});
+
+test("scanStaged honors SCAN_EXT / SCAN_DIRS / SELF_EXCLUDE like the CI scan", () => {
+  const re = buildTokenRegex(TOKENS);
+  const { counts } = scanStaged(re, {
+    files: [
+      "README.md",                                   // outside SCAN_DIRS → ignored
+      "docs/logo.png",                               // non-scannable ext → ignored
+      "scripts/private-identity-tokens.txt",         // self-exclude → ignored
+      "packages/db/notes.md",                        // scanned
+    ],
+    readBlob: () => "AcmeCorp",
+  });
+  assert.deepEqual(counts, { "packages/db/notes.md": 1 });
+});
+
+test("staged diff blocks a NEW file but allows a legitimately-baselined occurrence", () => {
+  const re = buildTokenRegex(TOKENS);
+  const { counts } = scanStaged(re, {
+    files: ["docs/new-leak.md", "docs/baselined.md"],
+    readBlob: () => "AcmeCorp",
+  });
+  const baseline = { "docs/baselined.md": 1 };
+  const { grew, fresh } = diff(counts, baseline);
+  assert.deepEqual(fresh, ["docs/new-leak.md (1)"]); // new file → blocked
+  assert.equal(grew.length, 0);                      // baselined occurrence → allowed
+});
+
+test("staged diff flags a grown count in an already-baselined file", () => {
+  const re = buildTokenRegex(TOKENS);
+  const { counts } = scanStaged(re, {
+    files: ["docs/baselined.md"],
+    readBlob: () => "AcmeCorp and AcmeCorp",
+  });
+  const { grew, fresh } = diff(counts, { "docs/baselined.md": 1 });
+  assert.deepEqual(grew, ["docs/baselined.md (1 -> 2)"]);
   assert.equal(fresh.length, 0);
 });


### PR DESCRIPTION
## What & why (BI-C9E5E7D9, P3)

`check-no-private-identity` (a required merge check) blocks a real operator/customer/person name from spreading into the OSS repo — but only at **CI/merge time**. A dogfood/operator spec naturally names the real operator, goes fully green on functional checks, then sits BLOCKED solely on the identity leak, forcing a late scrub commit + full CI re-run. The guard catches the leak *last*; it should catch it *first*. (Observed this session: an operator-authored plan doc tripped it at pregate after an otherwise-green local run.)

## Change

1. **Pre-commit staged tripwire** — new `--staged` mode on `scripts/check-no-private-identity.mjs` scans ONLY this commit's staged snapshot (via `git show :<file>`) against the SAME baseline, reusing `buildTokenRegex` / `diff`. Wired as Guard 3b in `.githooks/pre-commit` (staged-only → sub-second), with a `DPF_SKIP_PRIVATE_IDENTITY_SCAN=1` escape hatch. Blocks at `git commit` naming the file **and** the token.
2. **Placeholder convention** — `docs/operations/oss-repo-identity-hygiene.md` now documents the approved generic placeholder set (`operator`, `operator/owner`, `customer 0`, `this operator install`, `the publishing entity`) so authors genericize from the first draft; the enforcement table records the new pre-commit tripwire.

Same ratchet semantics — legitimate baselined occurrences never block. The **required CI gate is unchanged**: this is an earlier tripwire, not a replacement backstop.

## Design grounding

Extends the existing identity ratchet (`scripts/check-no-private-identity.mjs`) and the existing pre-commit guard chain (`.githooks/pre-commit`); no new contract. Plan: `docs/superpowers/plans/2026-08-15-private-identity-precommit-tripwire.md`.

## Backlog coverage

Receipt `cmstsh4wc05by01qx1xh6xnd7` — **atomic** (the `--staged` mode, the hook wiring, and the placeholder doc are one small tripwire; no phase is independently useful).

## Verification

- Local-CI merged-gate: **PASS** (evidence `cmstsq7f105sf01qx0437ivfw`).
- 11 guard tests green: `scanStaged` counting, SCAN_EXT/SCAN_DIRS/SELF_EXCLUDE inclusion, new-file block, baselined-allow, grown-count block (synthetic token, injected reader — no real name).
- **Dogfood proof:** this PR's own commit ran the new Guard 3b live → `✓ No new private-identity tokens in the staged files`.

Signed-off-by: dpf-ci <dpf-ci@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)