### PR TITLE
fix: make UniFi rerun identities unique

### DIFF
--- a/apps/web/lib/actions/__tests__/discovery-rerun.test.ts
+++ b/apps/web/lib/actions/__tests__/discovery-rerun.test.ts
@@ -161,4 +161,46 @@ describe("rerunDiscoveryConnection", () => {
       expect.objectContaining({ trigger: "manual_connection" }),
     );
   });
+
+  it("uses a unique run key for every rerun while preserving the connection source", async () => {
+    mockAuth.mockResolvedValue(authorizedSession);
+    mockCan.mockReturnValue(true);
+    mockPrisma.discoveryConnection.findUnique.mockResolvedValue(baseConnection);
+    mockDecryptSecret.mockReturnValue("plain-api-key");
+    mockBuildDeps.mockReturnValue({ fetchFn: vi.fn() });
+    mockCollectUnifi.mockResolvedValue({
+      items: [{ observedKey: "unifi:aa:bb:cc:dd:ee:ff", itemType: "router" }],
+      relationships: [],
+      warnings: [],
+    });
+    mockNormalize.mockReturnValue({ entities: [], relationships: [] });
+    mockPersistRun.mockResolvedValue({
+      runId: "run-abc",
+      createdEntities: 0,
+      updatedEntities: 0,
+      staleEntities: 0,
+      createdRelationships: 0,
+      updatedRelationships: 0,
+      staleRelationships: 0,
+      createdIssues: 0,
+    });
+    mockPrisma.discoveryConnection.update.mockResolvedValue({ ...baseConnection });
+
+    await rerunDiscoveryConnection("conn-1");
+    await rerunDiscoveryConnection("conn-1");
+
+    const firstRunMeta = mockPersistRun.mock.calls[0]?.[2];
+    const secondRunMeta = mockPersistRun.mock.calls[1]?.[2];
+
+    expect(firstRunMeta).toMatchObject({
+      sourceSlug: baseConnection.connectionKey,
+      trigger: "manual_connection",
+    });
+    expect(secondRunMeta).toMatchObject({
+      sourceSlug: baseConnection.connectionKey,
+      trigger: "manual_connection",
+    });
+    expect(firstRunMeta.runKey).not.toBe(baseConnection.connectionKey);
+    expect(secondRunMeta.runKey).not.toBe(firstRunMeta.runKey);
+  });
 });

--- a/apps/web/lib/actions/discovery.ts
+++ b/apps/web/lib/actions/discovery.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { randomUUID } from "node:crypto";
+
 import {
   executeBootstrapDiscovery,
   loadDiscoveryAttributionInputs,
@@ -463,7 +465,7 @@ export async function rerunDiscoveryConnection(connectionId: string): Promise<Re
     prisma as never,
     normalized,
     {
-      runKey: conn.connectionKey,
+      runKey: `${conn.connectionKey}:${randomUUID()}`,
       sourceSlug: conn.connectionKey,
       trigger: "manual_connection",
     },


### PR DESCRIPTION
## Summary

UniFi discovery reruns reused the connection key as `DiscoveryRun.runKey`, so a second run violated the unique constraint and prevented the live topology from refreshing. This change gives every rerun an immutable UUID-suffixed identity while preserving the stable connection key as the source slug.

## Changes

- Generate a unique `runKey` for each UniFi rerun with `randomUUID()`.
- Keep `sourceSlug` stable so observations continue to reconcile to the same UniFi connection.
- Cover repeated reruns and the separation between run identity and source identity.

## Test plan

- [x] **Source-only checks completed before canonical-runtime verification**
  - [x] `pnpm with 10.33.2 --filter web typecheck` (passed after regenerating the pinned Prisma client)
  - [x] `pnpm with 10.33.2 --filter web exec vitest run lib/actions/__tests__/discovery-rerun.test.ts lib/actions/discovery.test.ts` (22 passed)
- [x] **Runtime-bound change**
  - [x] Source checks passed in the worktree
  - [ ] Canonical-runtime functional verification will run after merge and governed install advance; this defect prevents truthful pre-merge live-path proof on the currently installed bytes.
- [ ] **Verification-harness limitation acknowledged** — not applicable

### Verification evidence

- Pregate preflight: 38 guards passed.
- Exact-tree merged-code local CI: `cmstu3utu0ac301qxwe8vlo2e` (`fix/unifi-rerun-runkey@1bc11f3083cb8e2806c407f7c8506e831ecd2070`) — passed, including typecheck, full tests, and production build.
- Semantic-review receipt: `cmsttpjhg094x01qxzovrc16r`; infrastructure-inconclusive under the shadow policy while local CI held host capacity, publication allowed. The equivalent pre-rebase tree received an independent pass with no issues (`cmsttgie6089v01qx7uuvcv2h`).

## Pre-PR readiness

- [x] `pnpm gate:context` impact requirements resolved (`find_related_tests` returned no registered links; style-drift guard passed)
- [x] `pnpm run pregate:preflight` passed
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`
- [x] `pnpm with 10.33.2 pr:ready --pr-body-file /tmp/unifi-rerun-pr.md` returned `PR readiness: READY` after the final push

Local-CI-Evidence: cmstu3utu0ac301qxwe8vlo2e (fix/unifi-rerun-runkey@1bc11f3083cb8e2806c407f7c8506e831ecd2070)

## Related issues / Epic

- BI-6649C95A — UniFi discovery rerun crashes on duplicate `DiscoveryRun.runKey`
- Follow-up acceptance for the truthful physical network topology effort delivered in #4159.

## Epic / Backlog linkage

This PR completes the live-verification repair required before BI-6649C95A and BI-PIR-dcf1651a can be closed.

## Overlap sweep

No open PR changes `apps/web/lib/actions/discovery.ts` or `apps/web/lib/actions/__tests__/discovery-rerun.test.ts`.

## Notes for the reviewer

- No migration, configuration, API-contract, or UI styling change.
- Documentation impact: no user-facing documentation change is needed; this restores the already-specified rerun behavior rather than changing it.

Process-Spine-Decision: reuse docs/superpowers/specs/2026-08-08-truthful-physical-network-topology-design.md and docs/superpowers/plans/2026-08-08-truthful-physical-network-topology-implementation.md; this is the live-verification repair for that shipped contract.
