### PR TITLE
feat(work-room): fold value-stream + lifecycle structure onto Work Rooms

### DIFF
--- a/apps/web/app/(shell)/workspace/cases/[caseKey]/page.tsx
+++ b/apps/web/app/(shell)/workspace/cases/[caseKey]/page.tsx
@@ -6,6 +6,7 @@ import { auth } from "@/lib/auth";
 import { getGrantedCapabilities } from "@/lib/permissions";
 import { loadEffectiveAuthContext } from "@/lib/identity/load-effective-auth-context";
 import { loadPrismaWorkRoomParticipants } from "@/lib/work-management/room-participation-prisma.server";
+import { resolveWorkRoomStructureForCase } from "@/lib/work-management/room-structure.server";
 import { loadWorkspaceWorkCaseDetail } from "@/lib/work-management/workspace-case-loader";
 
 type Props = {
@@ -36,6 +37,7 @@ export default async function WorkspaceCaseDetailPage({ params }: Props) {
       isSuperuser: effectiveAuth.isSuperuser,
     },
     participantLoader: loadPrismaWorkRoomParticipants,
+    structureLoader: resolveWorkRoomStructureForCase,
   });
   if (!detail) notFound();
 

--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -108,6 +108,7 @@ const room: WorkRoomView = {
     { kind: "source", id: "BK-1", sourceType: "booking" },
     { kind: "work-item", id: "WI-1", status: "awaiting-input" },
   ],
+  structure: null,
   projection: {
     confidence: "high",
     incompleteBoundary: false,

--- a/apps/web/components/workspace/work-room/WorkRoomCycles.test.tsx
+++ b/apps/web/components/workspace/work-room/WorkRoomCycles.test.tsx
@@ -56,6 +56,7 @@ function room(): WorkRoomView {
     participants: [], activity: [],
     work: { nextAction: "Continue work", attentionRequired: false, attentionReason: null, blockingActorKind: null, activeCapsuleRefs: [], activeTaskRunSummary: null, terminal: false, sourceRefs: [] },
     context: { refs: [], digest: null, sensitivityCeiling: "high" }, receipts: [], sourceRefs: [],
+    structure: null,
     projection: { confidence: "high", incompleteBoundary: false, sourceHealth: "ok" },
   };
 }

--- a/apps/web/components/workspace/work-room/WorkRoomHeader.tsx
+++ b/apps/web/components/workspace/work-room/WorkRoomHeader.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, ArrowLeft, Clock, Users } from "lucide-react";
 
 import { LocalTime } from "@/components/ui/LocalTime";
 import { Notice, StatusBadge } from "@/components/ui/report-kit";
+import { WorkRoomStructurePanel } from "@/components/workspace/work-room/WorkRoomStructurePanel";
 import type { WorkspaceWorkCaseListItem } from "@/lib/work-management/workspace-case-loader";
 import type { WorkRoomView } from "@/lib/work-management/room-types";
 
@@ -118,6 +119,8 @@ export function WorkRoomHeader({ room, summary }: Props) {
             {room.outcome.statement ?? "Outcome not defined"}
           </p>
         </section>
+
+        <WorkRoomStructurePanel structure={room.structure} />
 
         <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
           <section aria-label="Attention" className="rounded-lg border border-[var(--dpf-border)] p-3">

--- a/apps/web/components/workspace/work-room/WorkRoomStructurePanel.test.tsx
+++ b/apps/web/components/workspace/work-room/WorkRoomStructurePanel.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { resolveWorkRoomStructure } from "@/lib/work-management/room-structure";
+
+import { WorkRoomStructurePanel } from "./WorkRoomStructurePanel";
+
+describe("WorkRoomStructurePanel", () => {
+  it("renders nothing when the subject has no structure", () => {
+    const html = renderToStaticMarkup(<WorkRoomStructurePanel structure={null} />);
+    expect(html).toBe("");
+  });
+
+  it("surfaces the value stream, lifecycle stage/state, and advancement gates", () => {
+    const structure = resolveWorkRoomStructure({ kind: "opportunity", stage: "qualification" });
+    const html = renderToStaticMarkup(<WorkRoomStructurePanel structure={structure} />);
+    expect(html).toContain("Value stream");
+    expect(html).toContain("Lifecycle");
+    // Labels may carry "&" which HTML-escapes; assert on a special-char-free token.
+    const safe = (label: string) => label.split(/\s*&\s*/)[0];
+    expect(html).toContain(safe(structure!.valueStream!.label));
+    expect(html).toContain(safe(structure!.lifecycle!.stageLabel));
+    expect(html).toContain("Advancement gates");
+    // Every derived gate target is named in the panel.
+    for (const gate of structure!.lifecycle!.nextGates) {
+      expect(html).toContain(safe(gate.toStageLabel));
+    }
+  });
+});

--- a/apps/web/components/workspace/work-room/WorkRoomStructurePanel.tsx
+++ b/apps/web/components/workspace/work-room/WorkRoomStructurePanel.tsx
@@ -1,0 +1,98 @@
+import { GitBranch, Lock, Milestone, Unlock } from "lucide-react";
+
+import { StatusBadge } from "@/components/ui/report-kit";
+import type { WorkRoomStructure } from "@/lib/work-management/room-structure";
+
+type Props = {
+  structure: WorkRoomStructure | null;
+};
+
+const BAND_INTENT: Record<string, "neutral" | "success" | "warning"> = {
+  "on-track": "neutral",
+  ready: "success",
+  blocked: "warning",
+};
+
+/**
+ * The value stream + lifecycle the room's subject sits in — the structure the
+ * collaboration happens within (EP-WORKROOM-COMMS / EP-VSL-SURFACE fold). Renders
+ * nothing when the subject has no value-stream/lifecycle binding.
+ */
+export function WorkRoomStructurePanel({ structure }: Props) {
+  if (!structure || (!structure.valueStream && !structure.lifecycle)) return null;
+  const { valueStream, lifecycle } = structure;
+
+  return (
+    <section
+      aria-labelledby="work-room-structure-title"
+      className="mt-4 rounded-lg border border-[var(--dpf-border)] p-4"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <Milestone className="size-4 text-[var(--dpf-muted)]" aria-hidden="true" />
+        <h2
+          id="work-room-structure-title"
+          className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]"
+        >
+          Structure
+        </h2>
+      </div>
+
+      <div className="mt-3 grid gap-3 md:grid-cols-2">
+        {valueStream ? (
+          <div>
+            <p className="text-xs font-medium uppercase tracking-[0.12em] text-[var(--dpf-muted)]">
+              Value stream
+            </p>
+            <div className="mt-1.5">
+              <StatusBadge intent="neutral" label={valueStream.label} variant="soft" />
+            </div>
+          </div>
+        ) : null}
+
+        {lifecycle ? (
+          <div>
+            <p className="text-xs font-medium uppercase tracking-[0.12em] text-[var(--dpf-muted)]">
+              Lifecycle
+            </p>
+            <div className="mt-1.5 flex flex-wrap items-center gap-2 text-sm text-[var(--dpf-text)]">
+              <span className="font-semibold">{lifecycle.stageLabel}</span>
+              <StatusBadge
+                intent={BAND_INTENT[lifecycle.band] ?? "neutral"}
+                label={lifecycle.stateLabel}
+                variant="soft"
+              />
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      {lifecycle && lifecycle.nextGates.length > 0 ? (
+        <div className="mt-3 border-t border-[var(--dpf-border)] pt-3">
+          <p className="inline-flex items-center gap-2 text-xs font-medium uppercase tracking-[0.12em] text-[var(--dpf-muted)]">
+            <GitBranch className="size-3.5" aria-hidden="true" />
+            Advancement gates
+          </p>
+          <ul className="mt-2 flex flex-col gap-1.5">
+            {lifecycle.nextGates.map((gate) => (
+              <li key={gate.toStage} className="flex items-start gap-2 text-sm">
+                {gate.allowed ? (
+                  <Unlock className="mt-0.5 size-3.5 shrink-0 text-[var(--dpf-success)]" aria-hidden="true" />
+                ) : (
+                  <Lock className="mt-0.5 size-3.5 shrink-0 text-[var(--dpf-muted)]" aria-hidden="true" />
+                )}
+                <span className="text-[var(--dpf-text)]">
+                  <span className={gate.allowed ? "font-medium" : "text-[var(--dpf-muted)]"}>
+                    {gate.toStageLabel}
+                  </span>
+                  {!gate.allowed && gate.reason ? (
+                    <span className="text-[var(--dpf-muted)]"> — {gate.reason}</span>
+                  ) : null}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/lib/work-management/room-read-model.ts
+++ b/apps/web/lib/work-management/room-read-model.ts
@@ -46,6 +46,11 @@ export interface BuildWorkRoomViewInput {
   outcomeHealth?: WorkRoomOutcomeView["health"];
   receipts?: readonly ReceiptEnvelope[];
   sourceHealth?: WorkRoomView["projection"]["sourceHealth"];
+  /**
+   * The subject's value-stream + lifecycle structure, pre-resolved by the loader via
+   * `resolveWorkRoomStructure` (kept out of this pure build, like `sourceHealth`).
+   */
+  structure?: WorkRoomView["structure"];
 }
 
 function primarySourceRef(detail: WorkCaseDetail): WorkCaseSourceRef {
@@ -168,6 +173,7 @@ export function buildWorkRoomView(
     context,
     receipts: [...(input.receipts ?? [])],
     sourceRefs,
+    structure: input.structure ?? null,
     projection: {
       confidence: projectionConfidence(source, health, boundary.gaps),
       incompleteBoundary: boundary.gaps.length > 0,

--- a/apps/web/lib/work-management/room-structure.server.ts
+++ b/apps/web/lib/work-management/room-structure.server.ts
@@ -1,0 +1,42 @@
+/**
+ * Server binding for Work Room structure (EP-WORKROOM-COMMS / EP-VSL-SURFACE fold).
+ *
+ * Fetches the room subject's stored stage/status with full prisma and folds it onto
+ * the pure `resolveWorkRoomStructure` resolver. Injected into the case loader as its
+ * `structureLoader` so the loader keeps its narrow client and never touches the CRM
+ * models directly.
+ *
+ * First slice resolves the OPPORTUNITY subject (a clean, direct source → subject
+ * mapping). Account-backed sources (engagement/activity/booking → CustomerAccount) and
+ * platform-development subjects are paved follow-ups: `workRoomStructureSubjectFor`
+ * already accepts an `accountStatus`, so wiring them is an additive resolver branch —
+ * no contract change.
+ */
+import { prisma } from "@dpf/db";
+
+import {
+  resolveWorkRoomStructure,
+  workRoomStructureSubjectFor,
+  type WorkRoomStructure,
+} from "./room-structure";
+
+/**
+ * Resolve the value-stream + lifecycle structure for a room's subject from its source
+ * ref. Returns null when the subject has no binding (or cannot be found).
+ */
+export async function resolveWorkRoomStructureForCase(ref: {
+  sourceType: string;
+  sourceId: string;
+}): Promise<WorkRoomStructure | null> {
+  if (ref.sourceType === "opportunity") {
+    const opportunity = await prisma.opportunity.findFirst({
+      where: { OR: [{ id: ref.sourceId }, { opportunityId: ref.sourceId }] },
+      select: { stage: true },
+    });
+    return resolveWorkRoomStructure(
+      workRoomStructureSubjectFor({ sourceType: ref.sourceType, opportunityStage: opportunity?.stage }),
+    );
+  }
+
+  return null;
+}

--- a/apps/web/lib/work-management/room-structure.test.ts
+++ b/apps/web/lib/work-management/room-structure.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveWorkRoomStructure,
+  workRoomStructureSubjectFor,
+} from "./room-structure";
+
+describe("resolveWorkRoomStructure", () => {
+  it("returns null for a null subject (no value-stream/lifecycle binding)", () => {
+    expect(resolveWorkRoomStructure(null)).toBeNull();
+  });
+
+  it("folds an opportunity subject onto its OVSM stage + lifecycle grammar", () => {
+    const structure = resolveWorkRoomStructure({ kind: "opportunity", stage: "qualification" });
+    expect(structure).not.toBeNull();
+    expect(structure?.valueStream).not.toBeNull();
+    expect(structure?.lifecycle?.grammarKey).toBe("opportunity");
+    // The lifecycle carries a resolved stage/state and a health band.
+    expect(typeof structure?.lifecycle?.stageLabel).toBe("string");
+    expect(structure?.lifecycle?.band).toBeDefined();
+  });
+
+  it("folds a customer-account subject onto its OVSM stage + lifecycle grammar", () => {
+    const structure = resolveWorkRoomStructure({ kind: "customer-account", status: "active" });
+    expect(structure?.lifecycle?.grammarKey).toBe("customer-account");
+    expect(structure?.valueStream?.label.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("derives advancement gates from the current stage with a typed allow/refuse per target", () => {
+    const structure = resolveWorkRoomStructure({ kind: "opportunity", stage: "qualification" });
+    const gates = structure?.lifecycle?.nextGates ?? [];
+    expect(gates.length).toBeGreaterThan(0);
+    for (const gate of gates) {
+      expect(typeof gate.toStage).toBe("string");
+      expect(typeof gate.toStageLabel).toBe("string");
+      expect(typeof gate.allowed).toBe("boolean");
+      // A refused gate must explain why; an allowed gate needs no reason.
+      if (!gate.allowed) expect(gate.reason).toBeTruthy();
+    }
+  });
+});
+
+describe("workRoomStructureSubjectFor", () => {
+  it("maps an opportunity source with a stage to an opportunity subject", () => {
+    expect(workRoomStructureSubjectFor({ sourceType: "opportunity", opportunityStage: "proposal" })).toEqual({
+      kind: "opportunity",
+      stage: "proposal",
+    });
+  });
+
+  it("maps account-backed sources with a status to a customer-account subject", () => {
+    for (const sourceType of ["engagement", "activity", "booking", "storefront-booking"]) {
+      expect(workRoomStructureSubjectFor({ sourceType, accountStatus: "at_risk" })).toEqual({
+        kind: "customer-account",
+        status: "at_risk",
+      });
+    }
+  });
+
+  it("returns null when the subject stage/status is missing or the source has no binding", () => {
+    expect(workRoomStructureSubjectFor({ sourceType: "opportunity", opportunityStage: null })).toBeNull();
+    expect(workRoomStructureSubjectFor({ sourceType: "backlog-item" })).toBeNull();
+    expect(workRoomStructureSubjectFor({ sourceType: "work-capsule" })).toBeNull();
+  });
+});

--- a/apps/web/lib/work-management/room-structure.ts
+++ b/apps/web/lib/work-management/room-structure.ts
@@ -1,0 +1,137 @@
+/**
+ * Work Room structure — the value stream + lifecycle of the room's SUBJECT
+ * (EP-WORKROOM-COMMS / EP-VSL-SURFACE fold).
+ *
+ * A Work Room is collaborative, but the collaboration happens WITHIN a structure:
+ * the subject the room is formed around sits in an OVSM value-stream stage and
+ * follows a lifecycle grammar (Stage → in-stage State → next advancement gates).
+ * This pure resolver folds the existing OVSM + lifecycle-grammar substrate onto a
+ * room's subject — reused, not rebuilt. The loader resolves the subject's stored
+ * status/stage and passes a descriptor here; this stays DB-free.
+ *
+ * Design of record: docs/superpowers/specs/2026-08-12-work-model-convergence-addendum-common-work-formula-design.md §2;
+ * VSL substrate: apps/web/lib/lifecycle-grammars.ts + apps/web/lib/crm/account-value-stream.ts.
+ */
+import {
+  accountStatusToOvsmStage,
+  opportunityStageToOvsmStage,
+  ovsmStageLabel,
+} from "@/lib/crm/account-value-stream";
+import { canAdvance, getStage, type LifecycleGrammar, type LifecyclePoint } from "@/lib/lifecycle-grammar";
+import {
+  CUSTOMER_ACCOUNT_GRAMMAR,
+  OPPORTUNITY_GRAMMAR,
+  resolveCustomerAccountPoint,
+  resolveOpportunityPoint,
+} from "@/lib/lifecycle-grammars";
+import type { OperationalValueStreamStageKey } from "@dpf/storefront-templates";
+
+/** The room subject descriptor the loader builds from the subject's stored row. */
+export type WorkRoomStructureSubject =
+  | { kind: "opportunity"; stage: string }
+  | { kind: "customer-account"; status: string };
+
+export interface WorkRoomValueStream {
+  stage: OperationalValueStreamStageKey;
+  label: string;
+}
+
+export interface WorkRoomLifecycleGate {
+  toStage: string;
+  toStageLabel: string;
+  allowed: boolean;
+  reason?: string;
+}
+
+export interface WorkRoomLifecycle {
+  grammarKey: string;
+  stage: string;
+  stageLabel: string;
+  state: string;
+  stateLabel: string;
+  band: string;
+  /** The advancement gates from the current stage — what it would take to move on. */
+  nextGates: WorkRoomLifecycleGate[];
+}
+
+export interface WorkRoomStructure {
+  valueStream: WorkRoomValueStream | null;
+  lifecycle: WorkRoomLifecycle | null;
+}
+
+function buildLifecycle(grammar: LifecycleGrammar, point: LifecyclePoint): WorkRoomLifecycle {
+  const stageDef = getStage(grammar, point.stage);
+  const stateDef = stageDef?.states.find((candidate) => candidate.key === point.state) ?? null;
+  const nextGates: WorkRoomLifecycleGate[] = (stageDef?.advancesTo ?? []).map((toStage) => {
+    const check = canAdvance(grammar, point, toStage);
+    return {
+      toStage,
+      toStageLabel: getStage(grammar, toStage)?.label ?? toStage,
+      allowed: check.allowed,
+      ...(check.reason ? { reason: check.reason } : {}),
+    };
+  });
+  return {
+    grammarKey: grammar.key,
+    stage: point.stage,
+    stageLabel: stageDef?.label ?? point.stage,
+    state: point.state,
+    stateLabel: stateDef?.label ?? point.state,
+    band: stateDef?.band ?? "on-track",
+    nextGates,
+  };
+}
+
+/**
+ * Resolve the value-stream + lifecycle structure for a room's subject. Returns null
+ * when the subject has no value-stream/lifecycle binding (e.g. a platform-development
+ * subject that is not on the customer OVSM — a paved follow-up).
+ */
+export function resolveWorkRoomStructure(subject: WorkRoomStructureSubject | null): WorkRoomStructure | null {
+  if (!subject) return null;
+
+  switch (subject.kind) {
+    case "opportunity": {
+      const ovsm = opportunityStageToOvsmStage(subject.stage);
+      return {
+        valueStream: { stage: ovsm, label: ovsmStageLabel(ovsm) },
+        lifecycle: buildLifecycle(OPPORTUNITY_GRAMMAR, resolveOpportunityPoint(subject.stage)),
+      };
+    }
+    case "customer-account": {
+      const ovsm = accountStatusToOvsmStage(subject.status);
+      return {
+        valueStream: { stage: ovsm, label: ovsmStageLabel(ovsm) },
+        lifecycle: buildLifecycle(CUSTOMER_ACCOUNT_GRAMMAR, resolveCustomerAccountPoint(subject.status)),
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Map a room source to its subject descriptor from the source's stored fields.
+ * Returns null for sources without a value-stream/lifecycle subject (platform
+ * development, workflow) — those fold onto the platform's own delivery stream in a
+ * follow-up. `opportunityStage` / `accountStatus` are supplied by the loader.
+ */
+export function workRoomStructureSubjectFor(input: {
+  sourceType: string;
+  opportunityStage?: string | null;
+  accountStatus?: string | null;
+}): WorkRoomStructureSubject | null {
+  if (input.sourceType === "opportunity" && input.opportunityStage) {
+    return { kind: "opportunity", stage: input.opportunityStage };
+  }
+  if (
+    (input.sourceType === "engagement" ||
+      input.sourceType === "activity" ||
+      input.sourceType === "booking" ||
+      input.sourceType === "storefront-booking") &&
+    input.accountStatus
+  ) {
+    return { kind: "customer-account", status: input.accountStatus };
+  }
+  return null;
+}

--- a/apps/web/lib/work-management/room-types.ts
+++ b/apps/web/lib/work-management/room-types.ts
@@ -7,6 +7,7 @@ import type {
   WorkCaseState,
 } from "./case-types";
 import type { ReceiptEnvelope } from "./receipt-envelope";
+import type { WorkRoomStructure } from "./room-structure";
 
 export type WorkRoomMode = "finite" | "standing";
 
@@ -195,6 +196,13 @@ export interface WorkRoomView {
   context: WorkRoomContextView;
   receipts: ReceiptEnvelope[];
   sourceRefs: WorkCaseSourceRef[];
+  /**
+   * The value stream + lifecycle the room's SUBJECT sits in — the structure the
+   * collaboration happens within. Null when the subject has no value-stream/lifecycle
+   * binding (e.g. a platform-development subject not on the customer OVSM). Resolved by
+   * the loader via `resolveWorkRoomStructure` and passed pre-resolved (DB-free build).
+   */
+  structure: WorkRoomStructure | null;
   projection: {
     confidence: WorkCaseProjectionConfidence;
     incompleteBoundary: boolean;

--- a/apps/web/lib/work-management/workspace-case-loader.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.ts
@@ -22,6 +22,7 @@ import {
   selectCompletedWorkRoomCycles,
   selectCurrentWorkRoomCycle,
 } from "./room-cycle";
+import type { WorkRoomStructure } from "./room-structure";
 import type { WorkRoomParticipantView, WorkRoomView } from "./room-types";
 import { getWorkCaseSourceEntry } from "./source-registry";
 import { fromWorkItemMessage } from "./receipt-envelope";
@@ -113,6 +114,17 @@ export type WorkspaceRoomAuthContext = {
   sensitivityClearance: readonly string[];
   isSuperuser: boolean;
 };
+
+/**
+ * Resolves the value-stream + lifecycle STRUCTURE of the room's subject. Injected
+ * (like `participantLoader`) so this loader keeps its narrow prisma client and stays
+ * off the CRM models — the caller wires a full-prisma resolver
+ * (`resolveWorkRoomStructureForCase`). Returns null for subjects with no binding.
+ */
+export type WorkRoomStructureLoader = (ref: {
+  sourceType: string;
+  sourceId: string;
+}) => Promise<WorkRoomStructure | null>;
 
 export type WorkspaceRoomParticipantLoader = (input: {
   workItemId: string;
@@ -400,6 +412,7 @@ export async function loadWorkspaceWorkCaseDetail({
   userId,
   authContext,
   participantLoader,
+  structureLoader,
   now = new Date(),
 }: {
   prismaClient: WorkspaceCasePrismaClient;
@@ -407,6 +420,7 @@ export async function loadWorkspaceWorkCaseDetail({
   userId: string;
   authContext?: WorkspaceRoomAuthContext;
   participantLoader?: WorkspaceRoomParticipantLoader;
+  structureLoader?: WorkRoomStructureLoader;
   now?: Date;
 }): Promise<WorkspaceWorkCaseDetailView | null> {
   const decoded = decodeWorkCaseKey(caseKey);
@@ -491,9 +505,13 @@ export async function loadWorkspaceWorkCaseDetail({
     ? selectCompletedWorkRoomCycles(item.sourceType, cycleCandidates)
     : [];
   const storedPackets = projectStoredWorkRoomOutcomePackets(messages);
+  const structure = structureLoader
+    ? await structureLoader({ sourceType: source.sourceType, sourceId: source.sourceId })
+    : null;
   const room = buildWorkRoomView({
     caseKey,
     detail,
+    structure,
     boundary: {
       purpose: item.description,
       outcome: null,

--- a/docs/superpowers/plans/2026-08-14-work-room-vsl-structure-fold.md
+++ b/docs/superpowers/plans/2026-08-14-work-room-vsl-structure-fold.md
@@ -1,0 +1,68 @@
+# Fold value-stream + lifecycle STRUCTURE onto Work Rooms — Implementation Plan
+
+**Epic:** EP-WORKROOM-COMMS (structure fold) · **Date:** 2026-08-14 · **Scope:** platform (WWMD)
+**Design of record:** `docs/superpowers/specs/2026-08-12-work-model-convergence-addendum-common-work-formula-design.md` §2 (a Work Room is collaborative *within a structure*)
+**Reuses:** the VSL substrate (EP-VSL-SURFACE) — OVSM value stream + lifecycle grammars. Folded on, **not rebuilt**.
+
+## Why
+
+A Work Room is collaborative, but collaboration needs a frame: the *subject* the room is
+formed around sits somewhere in a value stream and follows a lifecycle. The founder's
+vision — "they need structures: a value stream, lifecycles for the subject they are
+formed around" — plus the parallel EP-VSL-SURFACE loose ends (OVSM stage resolvers,
+lifecycle-grammar backbone) folded onto the room projection so a room shows *where its
+subject is* and *what it takes to advance*, keeping the collaboration on-task.
+
+## What the substrate already gives us (reused verbatim)
+
+- **OVSM value stream** — `accountStatusToOvsmStage` / `opportunityStageToOvsmStage` /
+  `ovsmStageLabel` (`apps/web/lib/crm/account-value-stream.ts`) map a subject's stored
+  status/stage to one of the 6 OVSM stages.
+- **Lifecycle grammars** — `CUSTOMER_ACCOUNT_GRAMMAR`, `OPPORTUNITY_GRAMMAR` +
+  `resolveCustomerAccountPoint` / `resolveOpportunityPoint`
+  (`apps/web/lib/lifecycle-grammars.ts`) resolve a subject to a `(stage, state)` point.
+- **The advancement gate** — `canAdvance(grammar, from, toStage)` + `getStage`
+  (`apps/web/lib/lifecycle-grammar.ts`) yield, for the current stage, a typed allow/refuse
+  per legal onward target.
+
+## The fold (this slice)
+
+No schema change, no boundary-gap touch, `buildWorkRoomView` stays pure/DB-free.
+
+1. **`apps/web/lib/work-management/room-structure.ts` (pure)** — `resolveWorkRoomStructure(subject)`
+   folds a subject descriptor (`{kind:"opportunity",stage}` | `{kind:"customer-account",status}`)
+   onto `{ valueStream:{stage,label}, lifecycle:{grammarKey,stage,state,band,nextGates[]} }`.
+   `nextGates` = for each `getStage(...).advancesTo`, `canAdvance(...)`. Plus
+   `workRoomStructureSubjectFor({sourceType, opportunityStage?, accountStatus?})` — the
+   per-source → subject mapping (a plain side-function, **not** the source-registry, to
+   avoid the `satisfies` exhaustiveness drift).
+2. **`WorkRoomView.structure`** (`room-types.ts`) — new field, `WorkRoomStructure | null`.
+3. **`buildWorkRoomView`** (`room-read-model.ts`) — takes `structure` pre-resolved as
+   input (like `sourceHealth`) and sets it; the build stays pure.
+4. **`room-structure.server.ts`** — `resolveWorkRoomStructureForCase({sourceType,sourceId})`
+   fetches the subject's stored stage/status with full prisma and calls the pure resolver.
+   First slice resolves the **opportunity** subject (a clean, direct source→subject map).
+5. **Loader injection** — `loadWorkspaceWorkCaseDetail` gains an optional `structureLoader`
+   (mirrors the existing `participantLoader` injection); the page wires
+   `resolveWorkRoomStructureForCase`. Keeps the loader's narrow prisma client off the CRM models.
+6. **UI** — `WorkRoomStructurePanel` renders the value stream, lifecycle stage/state
+   (health-banded), and advancement gates (locked/unlocked with the refusal reason) in the
+   room header; renders nothing when structure is null.
+
+## Deliberately deferred (paved, additive — no contract change)
+
+- **Account-backed sources** (engagement / activity / booking → `CustomerAccount.status`):
+  `workRoomStructureSubjectFor` already accepts `accountStatus`; wiring is an additive
+  branch in `resolveWorkRoomStructureForCase` once the source→account resolution lands.
+- **Platform-development subjects** (backlog-item / work-capsule / task-node): fold onto
+  the platform's *own* delivery value stream + a work lifecycle — a separate grammar.
+- Structure on the room LIST projection and as a filter/rollup dimension.
+
+## Verification
+
+- Pure resolver unit tests (`room-structure.test.ts`): opportunity + customer-account fold,
+  null subject, gate derivation with typed allow/refuse.
+- Panel render test (`WorkRoomStructurePanel.test.tsx`): value stream + lifecycle + gates
+  surfaced; null renders nothing.
+- Existing room read-model / detail-view / loader tests updated for the new field and green.
+- `tsc --noEmit` clean; full local-CI gate before PR.

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1264,7 +1264,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 20
+    "textMass": 18
   },
   "apps/web/app/(shell)/performance/loading.tsx": {
     "vocabulary": 0,
@@ -8412,5 +8412,12 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 31
+  },
+  "apps/web/components/workspace/work-room/WorkRoomStructurePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
   }
 }


### PR DESCRIPTION
## What

Folds **value-stream + lifecycle structure onto Work Rooms**. A Work Room is collaborative, but collaboration needs a frame: the *subject* the room is formed around sits in an OVSM value stream and follows a lifecycle (Stage → in-stage State → advancement gates). This surfaces *where the subject is* and *what it takes to advance* — keeping the collaboration on-task.

Reuses the EP-VSL-SURFACE substrate (OVSM stage resolvers + lifecycle grammars + `canAdvance`) — **folded on, not rebuilt**. No schema change, no boundary-gap touch, `buildWorkRoomView` stays pure/DB-free.

## How

- **`room-structure.ts` (pure)** — `resolveWorkRoomStructure(subject)` → `{ valueStream:{stage,label}, lifecycle:{grammarKey,stage,state,band,nextGates[]} }`. `nextGates` derived per legal onward target via `canAdvance`. `workRoomStructureSubjectFor(...)` maps a source to its subject descriptor (a side-function, **not** the source-registry — avoids the `satisfies` exhaustiveness drift).
- **`WorkRoomView.structure`** — new optional field; `buildWorkRoomView` takes it pre-resolved (like `sourceHealth`).
- **`room-structure.server.ts`** — `resolveWorkRoomStructureForCase` fetches the subject's stored stage/status with full prisma. First slice: the **opportunity** subject.
- **Loader injection** — `loadWorkspaceWorkCaseDetail` gains an optional `structureLoader` (mirrors `participantLoader`); the case page wires it. Keeps the loader's narrow prisma client off the CRM models.
- **`WorkRoomStructurePanel`** — renders value stream, lifecycle stage/state (health-banded), and advancement gates (locked/unlocked + refusal reason) in the room header; renders nothing when structure is null.

## Deferred (paved, additive — no contract change)

- Account-backed sources (engagement/activity/booking → `CustomerAccount.status`) — `workRoomStructureSubjectFor` already accepts `accountStatus`; wiring is one additive branch.
- Platform-development subjects (backlog-item/work-capsule/task-node) → the platform's own delivery stream + a work lifecycle.
- Structure on the room LIST projection and as a filter/rollup dimension.

## Test

- Pure resolver units (`room-structure.test.ts`): opportunity + customer-account fold, null subject, typed gate derivation.
- Panel render test (`WorkRoomStructurePanel.test.tsx`): value stream + lifecycle + gates surfaced; null renders nothing.
- Existing read-model / detail-view / loader tests updated for the new field; 211 work-management + work-room tests green. `tsc --noEmit` clean; full local-CI gate run before push.

## Design grounding

**Design-Grounding-Decision:** extend — folds EP-VSL-SURFACE substrate onto the Work Room projection (code substrate: `apps/web/lib/work-management/room-structure.ts`, `apps/web/lib/work-management/room-read-model.ts`, `apps/web/components/workspace/work-room/WorkRoomStructurePanel.tsx`).

Design of record: `docs/superpowers/specs/2026-08-12-work-model-convergence-addendum-common-work-formula-design.md` · Plan: `docs/superpowers/plans/2026-08-14-work-room-vsl-structure-fold.md`

**Seed-Fit-Decision:** not-applicable — no seed/schema change.
**Process-Spine-Decision:** doc-updated — plan added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
