### PR TITLE
fix: restore official UniFi topology evidence

### DIFF
--- a/packages/db/src/discovery-collectors/unifi.test.ts
+++ b/packages/db/src/discovery-collectors/unifi.test.ts
@@ -176,7 +176,7 @@ describe("collectUnifiDiscovery", () => {
         }
         if (path.endsWith("/integration/v1/sites/site-1/devices")) {
           return Response.json({ data: [
-            { id: "gw-1", macAddress: "aa:bb:cc:dd:ee:01", ipAddress: "192.168.0.1", name: "Cloud Gateway Ultra", model: "UCG-Ultra", firmwareVersion: "4.1.13", features: ["gateway"] },
+            { id: "gw-1", macAddress: "aa:bb:cc:dd:ee:01", ipAddress: "192.168.0.1", name: "Cloud Gateway Ultra", model: "UCG-Ultra", firmwareVersion: "4.1.13", features: ["switching"] },
             { id: "sw-1", macAddress: "aa:bb:cc:dd:ee:02", ipAddress: "192.168.0.2", name: "US 8 PoE 150W", model: "US-8-150W", firmwareVersion: "7.1.26", features: ["switching"] },
             { id: "ap-1", macAddress: "aa:bb:cc:dd:ee:03", ipAddress: "192.168.0.3", name: "U7 Pro", model: "U7-Pro", firmwareVersion: "8.0.24", features: ["accessPoint"] },
           ] });
@@ -202,7 +202,91 @@ describe("collectUnifiDiscovery", () => {
       expect.objectContaining({ relationshipType: "CONNECTS_TO", fromExternalRef: "unifi-device:aa:bb:cc:dd:ee:03", toExternalRef: "unifi-device:aa:bb:cc:dd:ee:02" }),
     ]));
     expect(result.warnings).toEqual([]);
-    expect(seen.some((path) => path.includes("/proxy/network/api/s/"))).toBe(false);
+    expect(seen.filter((path) => path.includes("/proxy/network/api/s/"))).toEqual([
+      "/proxy/network/api/s/default/stat/health",
+    ]);
+  });
+
+  it("links official API clients to the UniFi device named by access evidence", async () => {
+    const deps = makeDeps({
+      discoverClients: true,
+      fetchFn: async (url: string | URL) => {
+        const path = new URL(String(url)).pathname;
+        if (path.endsWith("/integration/v1/sites")) {
+          return Response.json({ data: [{ id: "site-1", name: "Default" }] });
+        }
+        if (path.endsWith("/integration/v1/sites/site-1/devices")) {
+          return Response.json({ data: [
+            { id: "gw-1", macAddress: "aa:bb:cc:dd:ee:01", name: "Cloud Gateway Ultra", model: "UCG-Ultra", features: ["switching"] },
+            { id: "ap-1", macAddress: "aa:bb:cc:dd:ee:03", name: "U7 Pro", model: "U7-Pro", features: ["accessPoint"] },
+          ] });
+        }
+        if (path.endsWith("/integration/v1/sites/site-1/devices/gw-1")) {
+          return Response.json({ id: "gw-1" });
+        }
+        if (path.endsWith("/integration/v1/sites/site-1/devices/ap-1")) {
+          return Response.json({ id: "ap-1", uplink: { deviceId: "gw-1" } });
+        }
+        if (path.endsWith("/integration/v1/sites/site-1/clients")) {
+          return Response.json({ data: [{
+            id: "client-1",
+            macAddress: "11:22:33:44:55:02",
+            name: "Laptop",
+            type: "WIRELESS",
+            access: { deviceId: "ap-1", type: "DEFAULT" },
+          }] });
+        }
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    const result = await collectUnifiDiscovery({ sourceKind: "unifi" }, deps);
+
+    expect(result.relationships).toContainEqual(expect.objectContaining({
+      relationshipType: "CONNECTS_TO",
+      fromExternalRef: "unifi-client:11:22:33:44:55:02",
+      toExternalRef: "unifi-device:aa:bb:cc:dd:ee:03",
+    }));
+  });
+
+  it("enriches an official API topology with the controller WAN subsystem", async () => {
+    const deps = makeDeps({
+      fetchFn: async (url: string | URL) => {
+        const path = new URL(String(url)).pathname;
+        if (path.endsWith("/integration/v1/sites")) {
+          return Response.json({ data: [{ id: "site-1", name: "Default" }] });
+        }
+        if (path.endsWith("/integration/v1/sites/site-1/devices")) {
+          return Response.json({ data: [{
+            id: "gw-1",
+            macAddress: "aa:bb:cc:dd:ee:01",
+            name: "Cloud Gateway Ultra",
+            model: "UCG-Ultra",
+            features: ["switching"],
+          }] });
+        }
+        if (path.endsWith("/integration/v1/sites/site-1/devices/gw-1")) {
+          return Response.json({ id: "gw-1" });
+        }
+        if (path.endsWith("/proxy/network/api/s/default/stat/health")) {
+          return Response.json(makeHealth());
+        }
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    const result = await collectUnifiDiscovery({ sourceKind: "unifi" }, deps);
+
+    expect(result.items).toContainEqual(expect.objectContaining({
+      itemType: "wan_uplink",
+      name: "Starlink (WAN)",
+      externalRef: "unifi-wan:default:wan",
+    }));
+    expect(result.relationships).toContainEqual(expect.objectContaining({
+      relationshipType: "UPLINKS_TO",
+      fromExternalRef: "unifi-device:aa:bb:cc:dd:ee:01",
+      toExternalRef: "unifi-wan:default:wan",
+    }));
   });
 
   it("does not hide an official API authentication failure behind legacy fallback", async () => {

--- a/packages/db/src/discovery-collectors/unifi.ts
+++ b/packages/db/src/discovery-collectors/unifi.ts
@@ -118,6 +118,8 @@ type OfficialClient = {
   ipAddress?: string;
   name?: string;
   hostname?: string;
+  access?: { deviceId?: string; type?: string; port?: number } | null;
+  uplinkDeviceId?: string;
   connectedDeviceId?: string;
   connectedDevice?: { id?: string };
   type?: string;
@@ -264,13 +266,62 @@ async function officialGetAll<T>(
 }
 
 function officialDeviceMapping(device: OfficialDevice) {
+  const model = device.model?.toLowerCase() ?? "";
+  if (/(ucg|udm|uxg|gateway)/.test(model)) return DEVICE_TYPE_MAP.udm;
+  if (/^(uap|u6|u7)/.test(model)) return DEVICE_TYPE_MAP.uap;
+  if (/^(us-|usw)/.test(model)) return DEVICE_TYPE_MAP.usw;
   const features = (device.features ?? []).map((feature) => feature.toLowerCase());
-  if (features.some((feature) => feature.includes("gateway"))) return DEVICE_TYPE_MAP.udm;
+  if (features.some((feature) => feature.includes("gateway") || feature.includes("routing"))) {
+    return DEVICE_TYPE_MAP.udm;
+  }
   if (features.some((feature) => feature.includes("switch"))) return DEVICE_TYPE_MAP.usw;
   if (features.some((feature) => feature.includes("accesspoint") || feature.includes("access_point"))) {
     return DEVICE_TYPE_MAP.uap;
   }
   return DEFAULT_DEVICE_MAPPING;
+}
+function appendWanHealthEvidence(input: {
+  source: NonNullable<DiscoveredItemInput["sourceKind"]>;
+  site: string;
+  wanHealth: UnifiHealthSubsystem;
+  gatewayRef?: string;
+  items: DiscoveredItemInput[];
+  relationships: DiscoveredRelationshipInput[];
+}) {
+  const { source, site, wanHealth, gatewayRef, items, relationships } = input;
+  const ispName = wanHealth.isp_name ?? wanHealth.isp_organization ?? null;
+  const wanRef = `unifi-wan:${site}:wan`;
+  items.push({
+    sourceKind: source,
+    itemType: "wan_uplink",
+    name: ispName ? `${ispName} (WAN)` : "Internet Uplink (WAN)",
+    externalRef: wanRef,
+    naturalKey: wanRef,
+    confidence: 0.95,
+    attributes: {
+      ispName,
+      ispOrganization: wanHealth.isp_organization ?? null,
+      wanIp: wanHealth.wan_ip ?? null,
+      linkStatus: wanHealth.status ?? null,
+      latencyMs: wanHealth.latency ?? null,
+      uptimeSeconds: wanHealth.uptime ?? null,
+      throughputDownBps: wanHealth.xput_down ?? null,
+      throughputUpBps: wanHealth.xput_up ?? null,
+      osiLayer: 3,
+      osiLayerName: "network",
+      protocolFamily: "ipv4",
+    },
+  });
+  if (gatewayRef) {
+    relationships.push({
+      sourceKind: source,
+      relationshipType: "UPLINKS_TO",
+      fromExternalRef: gatewayRef,
+      toExternalRef: wanRef,
+      confidence: 0.95,
+      attributes: { ispName, linkStatus: wanHealth.status ?? null },
+    });
+  }
 }
 
 async function collectOfficialUnifiDiscovery(
@@ -306,6 +357,7 @@ async function collectOfficialUnifiDiscovery(
   const software: DiscoveredSoftwareInput[] = [];
   const warnings: string[] = [];
   const idToRef = new Map<string, string>();
+  const macToRef = new Map<string, string>();
 
   for (const device of devices) {
     const mac = device.macAddress?.toLowerCase();
@@ -316,6 +368,7 @@ async function collectOfficialUnifiDiscovery(
     const ref = `unifi-device:${mac}`;
     const mapping = officialDeviceMapping(device);
     idToRef.set(device.id, ref);
+    macToRef.set(mac, ref);
     items.push({
       sourceKind: source,
       itemType: mapping.itemType,
@@ -400,7 +453,10 @@ async function collectOfficialUnifiDiscovery(
             osiLayerName: "network",
           },
         });
-        const parentId = client.connectedDeviceId ?? client.connectedDevice?.id;
+        const parentId = client.access?.deviceId
+          ?? client.uplinkDeviceId
+          ?? client.connectedDeviceId
+          ?? client.connectedDevice?.id;
         const parentRef = parentId ? idToRef.get(parentId) : undefined;
         if (parentRef) {
           relationships.push({
@@ -409,11 +465,29 @@ async function collectOfficialUnifiDiscovery(
             fromExternalRef: ref,
             toExternalRef: parentRef,
             confidence: 0.85,
-            attributes: { connectionType: client.type ?? "unknown" },
+            attributes: {
+              connectionType: client.type ?? client.access?.type ?? "unknown",
+              remotePort: client.access?.port,
+            },
           });
         }
       }
     }
+  }
+
+  const healthResult = await unifiGet<UnifiHealthSubsystem>("stat/health", deps);
+  const wanHealth = (healthResult.data ?? []).find((subsystem) => subsystem.subsystem === "wan");
+  if (wanHealth) {
+    const gatewayRef = (wanHealth.gw_mac && macToRef.get(wanHealth.gw_mac.toLowerCase()))
+      ?? idToRef.get(devices.find((device) => officialDeviceMapping(device).itemType === "router")?.id ?? "");
+    appendWanHealthEvidence({
+      source,
+      site: deps.site,
+      wanHealth,
+      gatewayRef,
+      items,
+      relationships,
+    });
   }
 
   return { supported: true, output: { items, relationships, software, warnings } };
@@ -550,15 +624,6 @@ export async function collectUnifiDiscovery(
   }
 
   // ── Internet Uplink (the WAN hop) ─────────────────────────────
-  // Everything above stops at the LAN edge: AP -> switch -> gateway. The hop the
-  // business actually depends on — gateway -> ISP (Starlink here) — was never
-  // modelled, so "are we online, and which hop broke?" was unanswerable. The
-  // `wan` health subsystem is the only place the controller reports it.
-  //
-  // Identity is anchored on the site + WAN designation, never on `wan_ip`: a
-  // Starlink CGNAT address changes routinely, and keying on it would mint a new
-  // uplink entity per address change (the churn pattern that produced thousands
-  // of orphaned rows elsewhere in discovery).
   const healthResult = await unifiGet<UnifiHealthSubsystem>("stat/health", resolvedDeps);
   if (healthResult.error) {
     warnings.push("unifi_partial:health");
@@ -569,32 +634,6 @@ export async function collectUnifiDiscovery(
   );
 
   if (wanHealth) {
-    const ispName = wanHealth.isp_name ?? wanHealth.isp_organization ?? null;
-    const wanRef = `unifi-wan:${resolvedDeps.site}:wan`;
-    items.push({
-      sourceKind: source,
-      itemType: "wan_uplink",
-      // Name the uplink after the ISP so the operator sees the dependency they
-      // actually have ("Starlink (WAN)") rather than an opaque port label.
-      name: ispName ? `${ispName} (WAN)` : "Internet Uplink (WAN)",
-      externalRef: wanRef,
-      naturalKey: wanRef,
-      confidence: 0.95,
-      attributes: {
-        ispName,
-        ispOrganization: wanHealth.isp_organization ?? null,
-        wanIp: wanHealth.wan_ip ?? null,
-        linkStatus: wanHealth.status ?? null,
-        latencyMs: wanHealth.latency ?? null,
-        uptimeSeconds: wanHealth.uptime ?? null,
-        throughputDownBps: wanHealth.xput_down ?? null,
-        throughputUpBps: wanHealth.xput_up ?? null,
-        osiLayer: 3,
-        osiLayerName: "network",
-        protocolFamily: "ipv4",
-      },
-    });
-
     // Complete the chain: gateway -> internet uplink. Prefer the gateway the
     // controller itself attributes the uplink to (`gw_mac`); fall back to the
     // routing device when the controller omits it.
@@ -602,20 +641,14 @@ export async function collectUnifiDiscovery(
       ?? macToRef.get(
         devices.find((device) => mapDeviceType(device.type).itemType === "router")?.mac ?? "",
       );
-
-    if (gatewayRef) {
-      relationships.push({
-        sourceKind: source,
-        relationshipType: "UPLINKS_TO",
-        fromExternalRef: gatewayRef,
-        toExternalRef: wanRef,
-        confidence: 0.95,
-        attributes: {
-          ispName,
-          linkStatus: wanHealth.status ?? null,
-        },
-      });
-    }
+    appendWanHealthEvidence({
+      source,
+      site: resolvedDeps.site,
+      wanHealth,
+      gatewayRef,
+      items,
+      relationships,
+    });
   }
 
   // ── Fetch VLANs ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Restore the physical topology evidence lost by the portal's official UniFi API branch. A live rerun found all 75 items but emitted only five infrastructure relationships, classified the Cloud Gateway Ultra as a switch, omitted all client attachments, and omitted the Starlink WAN hop. This change aligns the one-shot collector with the already-documented UniFi contract.

## Changes

- Classify gateway, switch, and AP roles from stable UniFi model families before ambiguous feature flags.
- Read official client attachment evidence from `access.deviceId` and emit client-to-AP/switch `CONNECTS_TO` relationships.
- Enrich official API results with the read-only WAN health subsystem and reuse one WAN evidence builder across official and legacy paths.
- Add live-shaped regression coverage for the UCG Ultra, client attachment, and Starlink WAN cases.

## Test plan

- [ ] **Source-only change** (types, isolated unit logic, doc, schema-only)
- [x] **Runtime-bound change** (server route, MCP tool, build/runtime wiring, compose, installer, prisma migration, UX surface)
  - [x] Source checks above passed where they can run in the worktree
  - [x] Functional verification ran against the **canonical runtime** — pick one:
        - [ ] root local install (`http://localhost:3000`)
        - [x] governed shared nonprod env (lease id: NPEL-8B7A3413D1)
        - [ ] CI workflow run (link: ____)
  - [x] Evidence captured below
- [x] **Verification-harness limitation acknowledged** — the exhaustive source-worktree DB suite cannot reach its migrated database; the exact-tree sandbox supplied the authoritative database/runtime gate.

### Verification evidence

- Red: three live-shaped assertions failed on the prior code for gateway classification, client attachment, and WAN evidence.
- Focused collector suite: 27/27 passed.
- `pnpm --filter @dpf/db exec tsc --noEmit`: passed.
- `pnpm --filter web build`: passed.
- `pnpm run pregate:preflight`: 38/38 guards passed.
- Exact-tree merged-code local CI: passed, evidence `cmstx5bsw05wu01s7t1vlm782` for `fix/unifi-official-topology@5b8fe962a5ae`.
- Independent semantic review: pass, evidence `cmstx7ls005xa01s7o8wuneby`, zero issues.
- Exhaustive source-worktree DB suite: 2,182 passed; 19 unrelated Prisma database-harness failures. The governed exact-tree gate passed with its provisioned database.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and again against the final diff
- [x] `pnpm run pregate:preflight` passed before requesting a shared-sandbox lease
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`
- [x] `pnpm pr:ready --pr-body-file <this-body-file>` returned `PR readiness: READY` after the final push

Local-CI-Evidence: cmstx5bsw05wu01s7t1vlm782 (fix/unifi-official-topology@5b8fe962a5ae)

## Related issues / Epic

Completes the remaining live acceptance gap for BI-6649C95A.

## Epic / Backlog linkage (for multi-BI work)

This PR covers: BI-6649C95A (remaining official UniFi topology evidence).

## Overlap sweep

No open PR title or branch matched UniFi, topology, or discovery.

## Notes for the reviewer

No migration or new dependency. Existing operator documentation already promises the gateway → switch → AP → client hierarchy and optional WAN evidence, so this repairs implementation drift rather than changing the documented contract. Final LAN comparison against the UniFi console will run after merge on the canonical install before the BI is closed.

