### PR TITLE
docs: portfolio-shaped IA design + pay-a-bill flow fix plan

### DIFF
--- a/docs/superpowers/plans/2026-08-14-pay-a-bill-flow-fix-plan.md
+++ b/docs/superpowers/plans/2026-08-14-pay-a-bill-flow-fix-plan.md
@@ -1,0 +1,90 @@
+# Pay-a-bill flow — fix plan
+
+**Status:** draft for operator review · 2026-08-14
+**Backlog item:** BI-8C7E6910
+**Scope:** the accounts-payable "receive a bill → approve → pay" flow, as the worked example of the cross-cutting "flows arrive but can't continue" pattern from the UX surface analysis ("The UX Has No Spine").
+
+## Backlog coverage
+
+- Decision: decomposed
+- Parent: BI-8C7E6910
+- Receipt: cmsuhjdqi171501ppmvwhxcvl
+- Dependencies: pay-surface-consolidation depends on in-shell-approve; generalize-approvals depends on in-shell-approve
+- Rationale: each phase ships independently against a live BacklogItem; the keystone establishes the authority-gated approve pattern the later two reuse.
+- Mappings:
+  - approve-link-404 -> BI-451F6E1C
+  - in-shell-approve (keystone) -> BI-18684670
+  - pay-surface-consolidation -> BI-10832E25
+  - generalize-approvals -> BI-E591399F
+
+---
+
+## 1. What the flow is, and where it actually breaks
+
+Traced through source (`app/(shell)/finance/**`, `lib/actions/ap.ts`, `lib/attention/sources/business-approvals.ts`):
+
+```
+/finance/bills/new → submit → /finance/bills/[id] (draft)
+   → SubmitBillButton → status = awaiting_approval
+      → [approval] ─────────────────────────────► ??? 
+   → (once approved) RecordBillPaymentButton  OR  /finance/payment-runs
+      → /finance/payments
+```
+
+The breaks are **not** where I first assumed. Substrate verification changed the picture:
+
+| Assumed gap | Actual finding |
+|---|---|
+| "No in-shell approval inbox — need to build one." | **Already exists.** `loadBillItems()` (`business-approvals.ts:97`) surfaces every `awaiting_approval` bill in the "Needs you" attention inbox as *"Approve bill {ref}"*, deadline-tiered by `dueDate`, deep-linked to the bill. Expenses (`loadExpenseItems`) and regulatory filings ride the same producer. |
+| "Approvals happen off-surface via email." | True, but the attention inbox **already routes the owner in-shell** — its action is "Review bill" → `/finance/bills/[id]`. |
+| — | **The real break:** the bill detail page renders **no approve control for `awaiting_approval`** (only `SubmitBillButton` for draft, `RecordBillPaymentButton` for approved). So the owner clicks "Review bill" from Needs-you, lands on the bill… and there is nothing to click. The *only* place approval can be actuated is the emailed public token page `/s/approve/[token]` — and that link is a 404 (BI-451F6E1C). |
+
+**One-line diagnosis:** the approval *queue* is built and correct; the approval *action* is missing from the in-shell surface it points at, so the whole approval step is stranded on a broken email link.
+
+Secondary frictions (real, lower severity):
+- **Payment paths split across three Finance tab-families** — Bills/Suppliers under *Spend*, Payment Runs under *Close*, Payments under *Revenue* (`finance-nav.ts`). Paying in batch means Spend→Close; reviewing means Spend→Revenue.
+- **Purchase Orders are absent from the Spend sub-nav** despite being the upstream of a bill (`/finance/purchase-orders` reachable only by deep link).
+- **Two "pay" surfaces** (`RecordBillPaymentButton` vs `PaymentRunBuilder`) with no cross-link or guidance on which to use.
+
+---
+
+## 2. Fix — smallest change that makes the flow continue
+
+Grounded in existing substrate (`lib/approval-authority.ts`, the attention producer, the AP actions). No new inbox, no new model.
+
+### Phase 1 — make the approval actionable in-shell *(the keystone)*
+1. Add `approveBill(billId)` server action in `lib/actions/ap.ts`, gated by `lib/approval-authority.ts` (reuse the same authority check the token page uses). Transitions `awaiting_approval → approved`, writes the audit row.
+2. Add `ApproveBillButton` to `/finance/bills/[id]`, rendered **only** for `awaiting_approval` and **only** when the viewer passes the authority check. This is the control the attention inbox's "Review bill" link already points at.
+3. Fix the emailed link (BI-451F6E1C) to resolve — either correct the URL to `/s/approve/[token]` or add the missing route as a redirect. The token page stays as the *out-of-office / delegate* channel; the in-shell button becomes the primary path.
+
+*Result: the already-working "Needs you → Approve bill" queue becomes a real, one-click approval path. This is the pattern fix — the same three steps apply to expense claims and quote acceptance.*
+
+### Phase 2 — de-fragment the pay surfaces
+4. Move Payment Runs and Payments into the **Spend** family alongside Bills/Suppliers (or introduce a single "Pay" sub-tab), so the bill→pay→confirm arc lives in one Finance family.
+5. Surface Purchase Orders in the Spend sub-nav and cross-link PO → derived Bill.
+6. On the bill detail, when `approved`, show one clear "Pay" affordance that offers both single-payment and add-to-payment-run, instead of two disconnected surfaces.
+
+### Phase 3 — generalize the keystone (separate flows, same shape)
+7. Apply the Phase-1 pattern to **expense claims** (`/finance/expense-claims/[id]`, attention source `loadExpenseItems` already live) and **quote acceptance** (`/customer/quotes/[id]`), so no owner approval depends on an emailed public token page.
+
+---
+
+## 3. Child backlog items (filed)
+
+| BI | Deliverable | workType | size | Depends on |
+|---|---|---|---|---|
+| `BI-18684670` | **P1 keystone:** in-shell `approveBill` action + `ApproveBillButton` on bill detail, authority-gated | feature | small | — |
+| `BI-451F6E1C` | Fix emailed approval link to resolve to an existing route | bug | small | — |
+| `BI-10832E25` | **P2:** consolidate Payment Runs + Payments + POs into the Finance *Spend* family; unify the "Pay" affordance | refactor | medium | P1 |
+| `BI-E591399F` | **P3:** extend in-shell approve action to expense claims + quote acceptance (retire email-token dependence) | feature | medium | P1 |
+
+Umbrella: `BI-8C7E6910`. Epic home: **EP-SAP-PARITY** (finance functional-parity gap closure) for the umbrella, keystone and P2, with the attention-surface producer as the integration point. P3 is cross-domain (finance + CRM) and also relates to EP-VSL-SURFACE.
+
+---
+
+## 4. Acceptance (flow-level)
+
+- From "Needs you", clicking an *"Approve bill"* item lands on the bill with a working **Approve** control (authority-gated); approving flips status and clears the item from the queue.
+- No owner-facing approval step depends on an emailed public-token page for its only actuation.
+- The bill → approve → pay → confirm arc is reachable without leaving the Finance *Spend* family.
+- A regression test asserts (a) the emitted approval attention item's deep-link target renders an approve control for `awaiting_approval`, and (b) the approval email URL resolves to an existing route.

--- a/docs/superpowers/specs/2026-08-14-portfolio-shaped-information-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-14-portfolio-shaped-information-architecture-design.md
@@ -1,0 +1,101 @@
+# Portfolio-shaped information architecture — design
+
+**Status:** draft for operator review · 2026-08-14
+**Proposed epic home:** EP-8DC217EB (Vertical Integration Inward — recombine DPF's own functionality)
+**Supersedes nothing; extends:** the EP-NAV-COHERENCE nav model (its *mechanics* are DONE and are constraints here, not open design space).
+**Source analysis:** "The UX Has No Spine" (UX surface & navigation analysis, 2026-08-14).
+
+---
+
+## 1. Problem
+
+DPF's own published operating standard (`DPF-FPAW`, `docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md`) places every governed aspect of a business into **four portfolios** — `products_and_services_sold`, `for_employees` (Workforce), `manufacturing_and_delivery`, `foundational`. This is the platform's canonical, model-backed organizing spine (runtime keys: `productsAndServicesSold | forEmployees | manufactureAndDeliver | foundational`, persisted on `PortfolioDecomposition`).
+
+The primary rail organizes into **six sections** that do not correspond to those portfolios (`apps/web/lib/navigation/portal-shell-sections.ts`): Workspace, Business, Products, Delivery, Platform, Knowledge. The six mix three different organizing principles at once — *whose work* (Workspace), *what domain* (Business/Products/Delivery), and *plumbing* (Platform/Knowledge) — so the model's clean spine is invisible in navigation.
+
+Consequences (evidenced in the source analysis):
+- **Workforce is one portfolio but three UI homes** — `/employee` (Business), `/platform/ai` (Platform), `/coworker-decisions` (Knowledge). Managing "who does the work" crosses three rail sections.
+- Common owner jobs cross 2–3 rail sections and route groups mid-flow (product lifecycle spans Products→Delivery→Platform; customer lifecycle spans shell→storefront→portal).
+- The prior nav program fixed **mechanics** (no cross-rail teleport, one `SectionNav` renderer, global breadcrumb, worker/operator mode) but never the **taxonomy**. Coherent rail, still-lost owner.
+
+## 2. Goal & non-goals
+
+**Goal:** make the primary navigation legible against the four-portfolio spine the platform already models, without regressing the coherence guarantees already shipped.
+
+**Non-goals:**
+- Not a rewrite of the nav model. `portal-navigation-model.ts` stays the single source; this changes the *section taxonomy* it maps into (`shellNav.sectionKey`), not the per-route records.
+- Not a change to the FPAW standard or `PortfolioDecomposition`.
+- Not a removal of worker/operator mode — this composes with it.
+
+## 3. Constraints inherited from EP-NAV-COHERENCE (must not regress)
+
+- Section-scoped secondary nav never teleports across rail sections.
+- Every destination carries a global breadcrumb home.
+- Worker ("Simple") mode is always one toggle from operator ("Full"); no mode strands a role away from a surface it can reach.
+- One `SectionNav` renderer; no per-surface tab-nav clones (ratchet-guarded).
+
+## 4. Proposal
+
+### 4.1 Reconcile the six sections toward the four portfolios
+
+Target rail spine (operator mode), each section keyed to an FPAW portfolio, plus two orthogonal cross-cuts that are honestly *not* portfolios:
+
+| Rail section | FPAW portfolio | Absorbs today's |
+|---|---|---|
+| **Workspace** *(cross-cut: "my work")* | — | Workspace, Needs-you, performance |
+| **Customers & Revenue** | `products_and_services_sold` | Customer/CRM, Marketing, Storefront, Rental, Portfolio (goods sold) |
+| **Workforce** | `for_employees` | People, AI Workforce, Coworker Decisions |
+| **Make & Deliver** | `manufacturing_and_delivery` | Build, Delivery, Ops/backlog, EA/architecture |
+| **Foundation** | `foundational` | Platform hub, Identity, Tools, Admin, Audit |
+| **Knowledge** *(cross-cut: reference)* | — | Docs, knowledge base |
+
+The two cross-cuts (Workspace, Knowledge) stay first-class but are *labeled as cross-cuts*, not pretend-domains — this is the honest fix for "Workspace maps to no portfolio."
+
+### 4.2 First slice — unify Workforce (highest signal, lowest blast radius)
+
+Bring `/employee`, `/platform/ai`, and `/coworker-decisions` under one **Workforce** rail section (people + AI coworkers = one portfolio in the model). Internally they remain distinct surfaces with section-scoped nav (per the coherence constraint); the change is the `shellNav.sectionKey` grouping and the section label, not the routes. This proves the reconciliation on the exact case that most violates the model, before touching the larger sections.
+
+### 4.3 Mechanism
+
+- Change is localized to `shellNav.sectionKey` assignments in `portal-navigation-model.ts` and the `PORTAL_SHELL_SECTIONS` definitions — the existing single source.
+- Add an explicit, lossless map from each section to its FPAW exchange key (or `cross-cut`) so the rail taxonomy is *traceable* to the standard (the standard already requires this adapter mapping for camelCase→snake_case).
+- Ship behind the existing `nav-mode` cookie as an operator-previewable spine so it can be validated on a live install before it becomes default (mirrors how worker/operator already gates rail shape).
+
+### 4.4 Compose with the coworker-as-navigator gap
+
+The analysis found the UX coworker is a page-attached copilot with **no navigation capability**. A portfolio-shaped rail and a navigating coworker are complementary: the rail makes the structure legible for humans; the coworker makes it *traversable by intent* ("pay this supplier" → routes + acts). This spec covers the rail; the coworker capability is EP-UX-SYSTEM / coworker-epic work and is referenced, not built here.
+
+## 5. Research & benchmarking
+
+How comparable business platforms bind a domain model to primary navigation:
+
+- **SAP Fiori launchpad (spaces & pages).** Navigation is organized into *spaces* that map to business roles/areas, not to the underlying module tree; a role sees a curated space. Adopt: role/portfolio-shaped top level over a raw module tree. Reject: SAP's per-role hand-curation doesn't scale to DPF's archetype variety — DPF should *derive* the spine from the FPAW placement + capability activation it already computes.
+- **ServiceNow workspaces.** Task-oriented workspaces (Agent, Dispatcher) group cross-table work by *what the person is doing*, distinct from the admin app-nav. Adopt: the Workspace cross-cut ("my work") as a first-class peer to the domain sections — validates keeping Workspace, but labeled as a cross-cut. 
+- **Odoo apps.** One rail item per installed "app"; clean but flat, and it leaks the build-time module boundary to users (DPF's current six-section problem in a different form). Reject flat-module-as-nav; it's precisely what produces "26 top-level domains".
+- **Microsoft Dynamics 365 areas/groups.** Two-level area→group→subarea sitemap tied to the security model. Adopt: portfolio→section→surface as a model-tied two-level spine; DPF already has the capability/permission gating to drive it.
+
+**Adopted stance:** derive a portfolio-shaped, capability-gated two-level spine from substrate DPF already computes (FPAW placement + `getActiveOrgCapabilities` + nav-mode), rather than hand-curating per role (SAP) or exposing the module tree (Odoo).
+
+## 6. §1 substrate check (no parallel utilities)
+
+- **No new nav model.** Extends `portal-navigation-model.ts` / `portal-shell-sections.ts`; no second registry.
+- **No new taxonomy.** Reuses the FPAW four-portfolio keys already persisted on `PortfolioDecomposition`; adds only a section→portfolio adapter map (the standard already mandates the key adapter).
+- **No new mode system.** Reuses the `nav-mode` cookie for operator preview.
+- **No coherence regression.** Section-scoped nav, breadcrumb, and the one-renderer ratchet are unchanged; only `sectionKey` groupings move.
+
+## 7. Phased plan
+
+| Phase | Deliverable | Size |
+|---|---|---|
+| 0 | Section→FPAW-portfolio adapter map + trace test asserting every `shellNav` entry resolves to a portfolio or an explicit cross-cut | S |
+| 1 | **Workforce unification slice** — regroup People + AI Workforce + Coworker Decisions under one Workforce section (behind nav-mode preview) | M |
+| 2 | Label & de-dupe pass (folds in the quick wins: "Portal"→"Storefront Setup", drop `/platform/ai` vs `/overview` duplicate, "AI Coworkers"→"Agent Identities", rail-label↔H1 alignment) | S |
+| 3 | Reconcile remaining sections to the portfolio spine; make it the default after live-install validation | L |
+| 4 | *(referenced, separate epic)* coworker navigate-and-act capability | L |
+
+## 8. Acceptance
+
+- Every `shellNav` entry resolves — via a checked-in test — to exactly one FPAW portfolio key or an explicitly declared cross-cut; none is silently unclassified.
+- People, AI Workforce, and Coworker Decisions are reachable under one Workforce section without violating section-scoped nav or the breadcrumb guarantee.
+- The reconciled spine is previewable via nav-mode on a live install before it becomes default.
+- No regression in the EP-NAV-COHERENCE guarantees (§3), asserted by the existing nav tests plus the new trace test.


### PR DESCRIPTION
## Why

A UX surface & navigation analysis of the whole `(shell)` route group found the primary rail organizes into **six ad-hoc sections** that do not map to the **four-portfolio operating model** DPF publishes as its own standard (`DPF-FPAW`). The clearest symptom: **Workforce is one portfolio in the model but three UI homes** — `/employee` (Business), `/platform/ai` (Platform), `/coworker-decisions` (Knowledge).

The prior nav-coherence program fixed navigation **mechanics** (no cross-rail teleport, one `SectionNav` renderer, global breadcrumb, worker/operator mode) but never the **taxonomy** — which is why the rail is coherent and owners still get lost.

## What this adds

Two documents. **No code changes.**

**`docs/superpowers/specs/2026-08-14-portfolio-shaped-information-architecture-design.md`**
- Reconciles the six rail sections to the four FPAW portfolios, keeping Workspace and Knowledge as explicitly-labeled *cross-cuts* rather than pretend-domains.
- Leads with a **Workforce unification slice** — the case that most violates the model — as the lowest-blast-radius proof.
- Treats the shipped EP-NAV-COHERENCE guarantees as **constraints, not open design space**.
- Extends `portal-navigation-model.ts` / `portal-shell-sections.ts` (changes `shellNav.sectionKey` groupings only); adds a section→FPAW-portfolio adapter map so the rail taxonomy is traceable to the standard. No second registry, no new taxonomy, no new mode system.
- Includes §5 Research & Benchmarking (SAP Fiori spaces, ServiceNow workspaces, Odoo apps, Dynamics areas) and the §1 substrate check.

**`docs/superpowers/plans/2026-08-14-pay-a-bill-flow-fix-plan.md`**
- Works the AP flow as the concrete example of the cross-cutting *"flow arrives but cannot continue"* pattern.
- **Substrate verification changed the conclusion:** the in-shell approval inbox largely **already exists** — `loadBillItems()` already surfaces every `awaiting_approval` bill in the "Needs you" attention inbox, deep-linked to the bill. The real gap is narrow: the bill detail page renders **no approve control** for `awaiting_approval`, so the queue dead-ends, and the only actuation is an emailed public-token page whose emitted link is a **404**.
- Fix is one authority-gated button + one server action reusing `lib/approval-authority.ts` — not a new inbox.

## Backlog coverage

Recorded via `record_plan_backlog_coverage` — umbrella `BI-8C7E6910`, receipt `cmsuhjdqi171501ppmvwhxcvl`, decision `decomposed`:

| BI | Deliverable |
|---|---|
| `BI-18684670` | keystone — in-shell authority-gated Approve on the bill detail |
| `BI-451F6E1C` | fix emailed approval link (404) |
| `BI-10832E25` | consolidate Payment Runs + Payments + POs into Finance *Spend* |
| `BI-E591399F` | extend in-shell approval to expense claims + quote acceptance |

Also filed from the same analysis: `BI-5301D393` (`/complaints` is an unreachable surface — wire or retire).

## Verification

- `check-plan-backlog-coverage` gate: **PASS** locally against the changed plan.
- Docs-only change; no unit/build surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)