### PR TITLE
feat(self-upgrade): specific change categories in the update summary (BI-6EC1350E)

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -892,7 +892,7 @@ describe("SelfUpgradeClient – upgrade activity", () => {
 
 describe("Latest Run card — human-readable upgrade scope", () => {
   const digest = {
-    counts: { breaking: 1, feature: 5, fix: 3, performance: 0, other: 0, total: 9 },
+    counts: { breaking: 1, security: 0, feature: 5, fix: 3, performance: 0, dependency: 0, documentation: 0, maintenance: 0, other: 0, total: 9 },
     headline: "Nine changes since your last upgrade, one breaking.",
   };
 
@@ -952,7 +952,7 @@ describe("Latest Run card — human-readable upgrade scope", () => {
         {...baseStatus}
         latestRun={makeRun("succeeded")}
         latestRunImpact={{
-          counts: { breaking: 0, feature: 2, fix: 1, performance: 0, other: 0, total: 3 },
+          counts: { breaking: 0, security: 0, feature: 2, fix: 1, performance: 0, dependency: 0, documentation: 0, maintenance: 0, other: 0, total: 3 },
           headline: null,
         }}
       />,
@@ -969,7 +969,7 @@ describe("Update-available banner — at-a-glance scope", () => {
     summary: {
       currentLineageSha: "a".repeat(40),
       targetSha: "b".repeat(40),
-      counts: { breaking: 2, feature: 4, fix: 1, performance: 0, other: 0, total: 7 },
+      counts: { breaking: 2, security: 0, feature: 4, fix: 1, performance: 0, dependency: 0, documentation: 0, maintenance: 0, other: 0, total: 7 },
       topItems: [],
       allItems: [],
       phrased: {

--- a/apps/web/components/ops/UpgradeImpactPanel.test.tsx
+++ b/apps/web/components/ops/UpgradeImpactPanel.test.tsx
@@ -49,9 +49,13 @@ function summaryWith(
     targetSha: "b".repeat(40),
     counts: {
       breaking: 0,
+      security: 0,
       feature: allItems.length,
       fix: 0,
       performance: 0,
+      dependency: 0,
+      documentation: 0,
+      maintenance: 0,
       other: 0,
       total: allItems.length,
     },
@@ -207,5 +211,45 @@ describe("UpgradeImpactPanel — activity indication", () => {
     expect(signal?.aborted).toBe(false);
     unmount();
     expect(signal?.aborted).toBe(true);
+  });
+});
+
+describe("UpgradeImpactPanel — category badges", () => {
+  it("labels each category distinctly instead of rendering a wall of OTHER", () => {
+    const items = [
+      item("sha-sec", "Patched an advisory", "security"),
+      item("sha-dep", "Bumped the framework", "dependency"),
+      item("sha-doc", "Documented the governance model", "documentation"),
+      item("sha-int", "Tidied internals", "maintenance"),
+    ];
+    render(
+      <UpgradeImpactPanel enabled initialSummary={summaryWith(items, items)} />,
+    );
+
+    expect(screen.getByText("Security")).toBeTruthy();
+    expect(screen.getByText("Dependency")).toBeTruthy();
+    expect(screen.getByText("Docs")).toBeTruthy();
+    expect(screen.getByText("Internal")).toBeTruthy();
+    expect(screen.queryByText("Other")).toBeNull();
+  });
+
+  // A summary persisted before a category existed replays from JSON; the badge
+  // map must degrade to the neutral label rather than render `undefined`.
+  it("falls back to a readable badge for a category this build does not know", () => {
+    const legacy = item("sha-x", "Recorded under an older taxonomy", "other");
+    const unknown = {
+      ...legacy,
+      sha: "sha-y",
+      category: "not-a-category" as ImpactItem["category"],
+    };
+    render(
+      <UpgradeImpactPanel
+        enabled
+        initialSummary={summaryWith([unknown], [unknown])}
+      />,
+    );
+
+    expect(screen.getByText("Other")).toBeTruthy();
+    expect(screen.getByText("Recorded under an older taxonomy")).toBeTruthy();
   });
 });

--- a/apps/web/components/ops/UpgradeImpactPanel.tsx
+++ b/apps/web/components/ops/UpgradeImpactPanel.tsx
@@ -23,24 +23,47 @@ import { Skeleton } from "@/components/ui/Skeleton";
 
 const CATEGORY_LABEL: Record<ImpactItem["category"], string> = {
   breaking: "Breaking",
+  security: "Security",
   feature: "New",
   performance: "Faster",
   fix: "Fix",
+  dependency: "Dependency",
+  documentation: "Docs",
+  maintenance: "Internal",
   other: "Other",
 };
+
+const NEUTRAL_BADGE =
+  "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] border-[var(--dpf-border)]";
 
 const CATEGORY_BADGE: Record<ImpactItem["category"], string> = {
   breaking:
     "bg-[var(--dpf-destructive)]/15 text-[var(--dpf-destructive)] border-[var(--dpf-destructive)]/30",
+  security:
+    "bg-[var(--dpf-destructive)]/10 text-[var(--dpf-destructive)] border-[var(--dpf-destructive)]/25",
   feature:
     "bg-[var(--dpf-success)]/15 text-[var(--dpf-success)] border-[var(--dpf-success)]/30",
   performance:
     "bg-[var(--dpf-info)]/15 text-[var(--dpf-info)] border-[var(--dpf-info)]/30",
   fix:
     "bg-[var(--dpf-warning)]/15 text-[var(--dpf-warning)] border-[var(--dpf-warning)]/30",
-  other:
-    "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] border-[var(--dpf-border)]",
+  dependency:
+    "bg-[var(--dpf-info)]/10 text-[var(--dpf-info)] border-[var(--dpf-info)]/25",
+  documentation: NEUTRAL_BADGE,
+  maintenance: NEUTRAL_BADGE,
+  other: NEUTRAL_BADGE,
 };
+
+// Summaries persisted before a category existed replay from JSON, so a row can
+// carry a category this build has no entry for. Fall back to the neutral badge
+// and a readable label instead of rendering `undefined`.
+function categoryLabel(category: ImpactItem["category"]): string {
+  return CATEGORY_LABEL[category] ?? "Other";
+}
+
+function categoryBadge(category: ImpactItem["category"]): string {
+  return CATEGORY_BADGE[category] ?? NEUTRAL_BADGE;
+}
 
 function ItemRow({
   item,
@@ -61,9 +84,9 @@ function ItemRow({
     >
       <div className="flex items-start gap-2">
         <span
-          className={`shrink-0 px-2 py-0.5 rounded-full border text-[10px] uppercase tracking-wide ${CATEGORY_BADGE[item.category]}`}
+          className={`shrink-0 px-2 py-0.5 rounded-full border text-[10px] uppercase tracking-wide ${categoryBadge(item.category)}`}
         >
-          {CATEGORY_LABEL[item.category]}
+          {categoryLabel(item.category)}
         </span>
         <span className="text-sm text-[var(--dpf-text)]">{description}</span>
       </div>

--- a/apps/web/lib/self-upgrade/impact/cache.test.ts
+++ b/apps/web/lib/self-upgrade/impact/cache.test.ts
@@ -23,7 +23,7 @@ describe("getCached / setCached", () => {
     summary: {
       currentLineageSha: "a",
       targetSha: "b",
-      counts: { breaking: 0, feature: 0, fix: 0, performance: 0, other: 0, total: 0 },
+      counts: { breaking: 0, security: 0, feature: 0, fix: 0, performance: 0, dependency: 0, documentation: 0, maintenance: 0, other: 0, total: 0 },
       topItems: [],
       allItems: [],
       phrased: null,

--- a/apps/web/lib/self-upgrade/impact/classify.test.ts
+++ b/apps/web/lib/self-upgrade/impact/classify.test.ts
@@ -23,26 +23,57 @@ describe("countCategories", () => {
       parseCommit(raw("perf: d")),
       parseCommit(raw("docs: e")),
       parseCommit(raw("feat!: f")),
+      parseCommit(raw("build(deps): bump next from 16.2.12 to 16.3.0")),
+      parseCommit(raw("chore: h")),
+      parseCommit(raw("Unparseable subject line")),
     ];
     expect(countCategories(commits)).toEqual({
       breaking: 1,
+      security: 0,
       feature: 2,
       fix: 1,
       performance: 1,
+      dependency: 1,
+      documentation: 1,
+      maintenance: 1,
       other: 1,
-      total: 6,
+      total: 9,
     });
   });
 
   it("yields zeros and total=0 for empty input", () => {
     expect(countCategories([])).toEqual({
-      breaking: 0, feature: 0, fix: 0, performance: 0, other: 0, total: 0,
+      breaking: 0,
+      security: 0,
+      feature: 0,
+      fix: 0,
+      performance: 0,
+      dependency: 0,
+      documentation: 0,
+      maintenance: 0,
+      other: 0,
+      total: 0,
     });
   });
 });
 
 describe("orderForFullList", () => {
-  it("orders breaking → feature → perf → fix → other, newest first within bucket", () => {
+  it("ranks the upkeep buckets below the changes an operator asked for", () => {
+    const commits = [
+      parseCommit(raw("chore: tidy", "2026-05-01T00:00:00Z")),
+      parseCommit(raw("docs: explain", "2026-05-02T00:00:00Z")),
+      parseCommit(raw("build(deps-dev): bump vitest", "2026-05-03T00:00:00Z")),
+      parseCommit(raw("fix: a real fix", "2026-05-04T00:00:00Z")),
+    ];
+    expect(orderForFullList(commits).map((c) => c.category)).toEqual([
+      "fix",
+      "dependency",
+      "documentation",
+      "maintenance",
+    ]);
+  });
+
+  it("orders breaking → feature → perf → fix → docs, newest first within bucket", () => {
     const commits = [
       parseCommit(raw("fix: older", "2026-04-01T00:00:00Z")),
       parseCommit(raw("feat!: breaking new", "2026-04-15T00:00:00Z")),
@@ -58,7 +89,7 @@ describe("orderForFullList", () => {
       "performance",
       "fix",
       "fix",
-      "other",
+      "documentation",
     ]);
     // Within the two fixes, newer first.
     expect(ordered[3]!.authorDate).toBe("2026-05-15T00:00:00Z");

--- a/apps/web/lib/self-upgrade/impact/classify.ts
+++ b/apps/web/lib/self-upgrade/impact/classify.ts
@@ -3,14 +3,18 @@
 // Pure aggregation over ParsedCommit[] — counts that feed the headline and
 // the deterministic ordering rule for the foldable "all items" view.
 
-import type { ImpactCategoryCounts, ParsedCommit } from "./types";
+import type { ChangeCategory, ImpactCategoryCounts, ParsedCommit } from "./types";
 
 export function countCategories(commits: ParsedCommit[]): ImpactCategoryCounts {
   const counts: ImpactCategoryCounts = {
     breaking: 0,
+    security: 0,
     feature: 0,
     fix: 0,
     performance: 0,
+    dependency: 0,
+    documentation: 0,
+    maintenance: 0,
     other: 0,
     total: commits.length,
   };
@@ -20,17 +24,27 @@ export function countCategories(commits: ParsedCommit[]): ImpactCategoryCounts {
   return counts;
 }
 
-const CATEGORY_RANK: Record<ParsedCommit["category"], number> = {
+/**
+ * Canonical severity ordering for every category — the single source of truth
+ * for "which bucket outranks which", shared by the foldable list here and the
+ * scored ordering in ./score. Risk first (breaking, then security), then the
+ * changes an operator asked for, then the upkeep they did not.
+ */
+export const CATEGORY_RANK: Record<ChangeCategory, number> = {
   breaking: 0,
-  feature: 1,
-  performance: 2,
-  fix: 3,
-  other: 4,
+  security: 1,
+  feature: 2,
+  performance: 3,
+  fix: 4,
+  dependency: 5,
+  documentation: 6,
+  maintenance: 7,
+  other: 8,
 };
 
 /**
- * Ordering for the full foldable list: breaking → feature → perf → fix → other,
- * stable within bucket by author date descending (newest first).
+ * Ordering for the full foldable list: by CATEGORY_RANK, stable within bucket
+ * by author date descending (newest first).
  */
 export function orderForFullList(commits: ParsedCommit[]): ParsedCommit[] {
   return [...commits].sort((a, b) => {

--- a/apps/web/lib/self-upgrade/impact/conventional.test.ts
+++ b/apps/web/lib/self-upgrade/impact/conventional.test.ts
@@ -19,13 +19,26 @@ describe("categoryFor", () => {
     expect(categoryFor("feat", true)).toBe("breaking");
     expect(categoryFor("fix", true)).toBe("breaking");
   });
-  it("maps feat/fix/perf to their buckets and the rest to other", () => {
+  it("maps each type to its own operator-facing bucket", () => {
     expect(categoryFor("feat", false)).toBe("feature");
     expect(categoryFor("fix", false)).toBe("fix");
     expect(categoryFor("perf", false)).toBe("performance");
-    expect(categoryFor("refactor", false)).toBe("other");
-    expect(categoryFor("docs", false)).toBe("other");
-    expect(categoryFor("chore", false)).toBe("other");
+    expect(categoryFor("docs", false)).toBe("documentation");
+    expect(categoryFor("refactor", false)).toBe("maintenance");
+    expect(categoryFor("chore", false)).toBe("maintenance");
+    expect(categoryFor("test", false)).toBe("maintenance");
+    expect(categoryFor("ci", false)).toBe("maintenance");
+    expect(categoryFor("revert", false)).toBe("maintenance");
+  });
+
+  it("separates dependency bumps from other build work by scope", () => {
+    expect(categoryFor("build", false, "deps")).toBe("dependency");
+    expect(categoryFor("build", false, "deps-dev")).toBe("dependency");
+    expect(categoryFor("build", false, "docker")).toBe("maintenance");
+    expect(categoryFor("build", false, null)).toBe("maintenance");
+  });
+
+  it("keeps `other` only for subjects it could not parse", () => {
     expect(categoryFor("unknown", false)).toBe("other");
   });
 });
@@ -74,10 +87,29 @@ describe("parseCommit", () => {
     expect(parsed.prNumber).toBe(999);
   });
 
+  // `doc(skill): …` appears 16 times in the last 400 upstream commits; without
+  // the alias it parsed as `unknown` and was filed as unparseable.
+  it("normalises the `doc:` spelling upstream actually emits", () => {
+    const parsed = parseCommit(raw("doc(skill): record the CI-gate cascade (#4243)"));
+    expect(parsed.type).toBe("docs");
+    expect(parsed.category).toBe("documentation");
+  });
+
+  it("classifies a dependabot-shaped bump as a dependency change", () => {
+    const parsed = parseCommit(raw("build(deps): bump next from 16.2.12 to 16.3.0 (#4305)"));
+    expect(parsed.type).toBe("build");
+    expect(parsed.scope).toBe("deps");
+    expect(parsed.category).toBe("dependency");
+  });
+
   it("recognises unknown types as `unknown` rather than crashing", () => {
     const parsed = parseCommit(raw("blorp(thing): mystery change"));
     expect(parsed.type).toBe("unknown");
     expect(parsed.category).toBe("other");
+  });
+
+  it("is case-insensitive about the type token", () => {
+    expect(parseCommit(raw("Fix: capitalised type")).type).toBe("fix");
   });
 
   it("parseCommits is the bulk wrapper", () => {

--- a/apps/web/lib/self-upgrade/impact/conventional.ts
+++ b/apps/web/lib/self-upgrade/impact/conventional.ts
@@ -12,7 +12,9 @@ import type { ChangeCategory, ConventionalType, ParsedCommit, RawCommit } from "
 // `type(scope)!: description (#1234)` — scope and `!` and `(#nn)` optional.
 // We intentionally accept a permissive scope ([^)]+) so multi-word scopes
 // like `(self-upgrade)` and `(web,infra)` both parse.
-const CONVENTIONAL_RE = /^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?(?<bang>!)?:\s+(?<body>.+?)$/;
+// Case-insensitive on the type token: a `Fix: …` subject is the same change as
+// `fix: …`, and the type is lower-cased before lookup.
+const CONVENTIONAL_RE = /^(?<type>[A-Za-z]+)(?:\((?<scope>[^)]+)\))?(?<bang>!)?:\s+(?<body>.+?)$/;
 const TRAILING_PR_RE = /\s*\(#(\d+)\)\s*$/;
 
 const KNOWN_TYPES: ReadonlySet<ConventionalType> = new Set<ConventionalType>([
@@ -20,16 +22,54 @@ const KNOWN_TYPES: ReadonlySet<ConventionalType> = new Set<ConventionalType>([
   "test", "build", "ci", "style", "revert",
 ]);
 
-/** Map a Conventional type + breaking marker to an ImpactCategory bucket. */
-export function categoryFor(type: ConventionalType, breaking: boolean): ChangeCategory {
+// Spelling variants DPF actually emits upstream (`doc(skill): …` appears 16
+// times in the last 400 commits on main). Normalised to the canonical type so
+// they never fall through to `unknown` and get filed as unparseable.
+const TYPE_ALIASES: Readonly<Record<string, ConventionalType>> = {
+  doc: "docs",
+  feature: "feat",
+  bugfix: "fix",
+};
+
+// Dependency bumps arrive as `build(deps)` / `build(deps-dev)` — the scope, not
+// the type, is what separates "we upgraded React" from "we changed the build".
+// Dependabot's group PRs use the same scope shape.
+const DEPENDENCY_SCOPE_RE = /^deps(-dev)?$/;
+
+/**
+ * Map a Conventional type + breaking marker (+ scope, where the scope is what
+ * distinguishes the bucket) to an operator-facing category.
+ *
+ * The `security` bucket is NOT derivable from the subject grammar alone — it
+ * comes from PR labels / advisory references and is applied later by
+ * `refineCategories` (./refine), after PR enrichment.
+ */
+export function categoryFor(
+  type: ConventionalType,
+  breaking: boolean,
+  scope: string | null = null,
+): ChangeCategory {
   if (breaking) return "breaking";
+  const scopeText = (scope ?? "").trim().toLowerCase();
   switch (type) {
     case "feat": return "feature";
     case "fix": return "fix";
     case "perf": return "performance";
-    // refactor / docs / chore / test / build / ci / style / revert / unknown
-    // all aggregate as "other" — the headline groups them together, but the
-    // per-item scoring keeps refactors visible if they touch a customized path.
+    case "docs": return "documentation";
+    case "build":
+      return DEPENDENCY_SCOPE_RE.test(scopeText) ? "dependency" : "maintenance";
+    // refactor / chore / test / ci / style / revert are internal upkeep: real
+    // work, but nothing an operator acts on. They stay visible (and can still
+    // outrank on score when they touch a customized path) under one honest
+    // label instead of sharing a bucket with docs and dependency bumps.
+    case "refactor":
+    case "chore":
+    case "test":
+    case "ci":
+    case "style":
+    case "revert":
+      return "maintenance";
+    // Unparseable subject — we genuinely do not know. Say so.
     default: return "other";
   }
 }
@@ -64,10 +104,13 @@ export function parseCommit(raw: RawCommit): ParsedCommit {
     };
   }
 
-  const rawType = m.groups["type"]!;
-  const type: ConventionalType = (KNOWN_TYPES as ReadonlySet<string>).has(rawType)
-    ? (rawType as ConventionalType)
-    : "unknown";
+  const rawType = m.groups["type"]!.toLowerCase();
+  const aliased = TYPE_ALIASES[rawType];
+  const type: ConventionalType =
+    aliased ??
+    ((KNOWN_TYPES as ReadonlySet<string>).has(rawType)
+      ? (rawType as ConventionalType)
+      : "unknown");
   const scope = m.groups["scope"] ?? null;
   const breaking = m.groups["bang"] === "!";
   const description = m.groups["body"]!.trim();
@@ -79,7 +122,7 @@ export function parseCommit(raw: RawCommit): ParsedCommit {
     breaking,
     description,
     prNumber,
-    category: categoryFor(type, breaking),
+    category: categoryFor(type, breaking, scope),
   };
 }
 

--- a/apps/web/lib/self-upgrade/impact/format.test.ts
+++ b/apps/web/lib/self-upgrade/impact/format.test.ts
@@ -3,16 +3,56 @@ import { formatImpactCounts, formatChangeTotal } from "./format";
 import type { ImpactCategoryCounts } from "./types";
 
 function counts(overrides: Partial<ImpactCategoryCounts> = {}): ImpactCategoryCounts {
-  return { breaking: 0, feature: 0, fix: 0, performance: 0, other: 0, total: 0, ...overrides };
+  return {
+    breaking: 0,
+    security: 0,
+    feature: 0,
+    fix: 0,
+    performance: 0,
+    dependency: 0,
+    documentation: 0,
+    maintenance: 0,
+    other: 0,
+    total: 0,
+    ...overrides,
+  };
 }
 
 describe("formatImpactCounts", () => {
   it("joins non-zero categories in severity order", () => {
     expect(
       formatImpactCounts(
-        counts({ breaking: 1, feature: 5, performance: 2, fix: 3, other: 1, total: 12 }),
+        counts({
+          breaking: 1,
+          security: 2,
+          feature: 5,
+          performance: 2,
+          fix: 3,
+          dependency: 4,
+          documentation: 1,
+          maintenance: 2,
+          other: 1,
+          total: 21,
+        }),
       ),
-    ).toBe("1 breaking · 5 new · 2 perf · 3 fixes · 1 other");
+    ).toBe(
+      "1 breaking · 2 security · 5 new · 2 perf · 3 fixes · 4 dependency · 1 docs · 2 internal · 1 other",
+    );
+  });
+
+  it("names dependency and documentation changes instead of lumping them as other", () => {
+    expect(
+      formatImpactCounts(counts({ dependency: 4, documentation: 1, total: 5 })),
+    ).toBe("4 dependency · 1 docs");
+  });
+
+  // Summaries persisted under the earlier five-key taxonomy replay from JSON
+  // with the new keys absent — they must still render, not print NaN.
+  it("treats keys missing from a legacy persisted summary as zero", () => {
+    const legacy = { breaking: 0, feature: 1, fix: 2, performance: 0, other: 3, total: 6 };
+    expect(formatImpactCounts(legacy as unknown as ImpactCategoryCounts)).toBe(
+      "1 new · 2 fixes · 3 other",
+    );
   });
 
   it("singularizes a lone fix", () => {

--- a/apps/web/lib/self-upgrade/impact/format.ts
+++ b/apps/web/lib/self-upgrade/impact/format.ts
@@ -14,12 +14,22 @@ import type { ImpactCategoryCounts } from "./types";
  * answer to "how big is this upgrade?" that a raw SHA pair never gave.
  */
 export function formatImpactCounts(counts: ImpactCategoryCounts): string {
+  // Summaries persisted under the earlier taxonomy carry only the original five
+  // keys, so every read is `?? 0` — a missing key is "none of those", never NaN.
+  const n = (value: number | undefined): number => value ?? 0;
   const parts: string[] = [];
-  if (counts.breaking > 0) parts.push(`${counts.breaking} breaking`);
-  if (counts.feature > 0) parts.push(`${counts.feature} new`);
-  if (counts.performance > 0) parts.push(`${counts.performance} perf`);
-  if (counts.fix > 0) parts.push(`${counts.fix} fix${counts.fix === 1 ? "" : "es"}`);
-  if (counts.other > 0) parts.push(`${counts.other} other`);
+  const push = (count: number, label: string) => {
+    if (count > 0) parts.push(`${count} ${label}`);
+  };
+  push(n(counts.breaking), "breaking");
+  push(n(counts.security), "security");
+  push(n(counts.feature), "new");
+  push(n(counts.performance), "perf");
+  push(n(counts.fix), `fix${n(counts.fix) === 1 ? "" : "es"}`);
+  push(n(counts.dependency), "dependency");
+  push(n(counts.documentation), "docs");
+  push(n(counts.maintenance), "internal");
+  push(n(counts.other), "other");
   if (parts.length === 0) {
     return `${counts.total} change${counts.total === 1 ? "" : "s"}`;
   }

--- a/apps/web/lib/self-upgrade/impact/index.test.ts
+++ b/apps/web/lib/self-upgrade/impact/index.test.ts
@@ -57,7 +57,7 @@ function storedSummary(
   return {
     currentLineageSha: "a".repeat(40),
     targetSha: "b".repeat(40),
-    counts: { breaking: 0, feature: 1, fix: 0, performance: 0, other: 0, total: 1 },
+    counts: { breaking: 0, security: 0, feature: 1, fix: 0, performance: 0, dependency: 0, documentation: 0, maintenance: 0, other: 0, total: 1 },
     topItems: [],
     allItems: [],
     phrased: null,
@@ -294,6 +294,42 @@ describe("summarizeUpgradeImpact — orchestrator", () => {
     });
     expect(out.ok).toBe(true);
   });
+
+  // The categories a commit subject can prove are settled before enrichment;
+  // "this bump closes an advisory" is only knowable from the PR. Counts are
+  // therefore taken AFTER the refinement pass — if they were taken before, the
+  // headline would say "dependency update" while the badge said "security".
+  it("counts categories after PR enrichment refines them", async () => {
+    const out = await summarizeUpgradeImpact({ skipPhrasing: true }, {
+      loadCurrentLineageSha: async () => "a".repeat(40),
+      loadTargetSha: async () => "b".repeat(40),
+      loadInstallSignals: async () => SIGNALS,
+      loadChangeSet: async () => [
+        rawCommit("build(deps): bump nanoid (#77)", [], "1".repeat(40)),
+        rawCommit("build(deps): bump next (#78)", [], "2".repeat(40)),
+        rawCommit("docs: explain the gate (#79)", [], "3".repeat(40)),
+      ],
+      enrichPrs: async () => ({
+        reachable: true,
+        enriched: 1,
+        byPr: new Map([
+          [77, { prNumber: 77, title: "Bump nanoid", labels: ["security"], body: null }],
+        ]),
+      }),
+      phraseSummary: async () => null,
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.summary.counts).toMatchObject({
+      security: 1,
+      dependency: 1,
+      documentation: 1,
+      other: 0,
+      total: 3,
+    });
+    // …and the promoted item outranks the routine bump in the ordered list.
+    expect(out.summary.topItems[0]!.category).toBe("security");
+  });
 });
 
 describe("loadPersistedImpactSummary", () => {
@@ -331,7 +367,7 @@ describe("loadRunImpactDigest", () => {
   it("returns counts + headline from the run's own summary id", async () => {
     getPersistedSummaryByIdMock.mockResolvedValue(
       storedSummary({
-        counts: { breaking: 1, feature: 5, fix: 3, performance: 0, other: 0, total: 9 },
+        counts: { breaking: 1, security: 0, feature: 5, fix: 3, performance: 0, dependency: 0, documentation: 0, maintenance: 0, other: 0, total: 9 },
         phrased: {
           headline: "Nine changes, one breaking.",
           itemPhrasings: [],
@@ -342,7 +378,7 @@ describe("loadRunImpactDigest", () => {
     const out = await loadRunImpactDigest("UIS-42");
     expect(getPersistedSummaryByIdMock).toHaveBeenCalledWith("UIS-42");
     expect(out).toEqual({
-      counts: { breaking: 1, feature: 5, fix: 3, performance: 0, other: 0, total: 9 },
+      counts: { breaking: 1, security: 0, feature: 5, fix: 3, performance: 0, dependency: 0, documentation: 0, maintenance: 0, other: 0, total: 9 },
       headline: "Nine changes, one breaking.",
     });
   });

--- a/apps/web/lib/self-upgrade/impact/index.ts
+++ b/apps/web/lib/self-upgrade/impact/index.ts
@@ -25,6 +25,7 @@ import { collectChangeSet } from "./change-set";
 import { collectInstallSignals } from "./install-signals";
 import { parseCommits } from "./conventional";
 import { countCategories } from "./classify";
+import { refineCategories } from "./refine";
 import { enrichPrs } from "./pr-enrich";
 import { orderByImpact, scoreCommits } from "./score";
 import { phraseSummary } from "./phrase";
@@ -184,14 +185,19 @@ export async function summarizeUpgradeImpact(
 
   // No commits but range was valid (e.g. fast-forward with no merge commits)
   // — still surface a usable summary with empty items.
-  const commits = parseCommits(raw);
-  const counts = countCategories(commits);
+  const parsed = parseCommits(raw);
   const signals = await loadInstallSignals();
 
-  const prNumbers = commits
+  const prNumbers = parsed
     .map((c) => c.prNumber)
     .filter((n): n is number => typeof n === "number");
   const enrichment = await enrich(prNumbers);
+
+  // Categories are settled only after PR enrichment — a `build(deps)` bump that
+  // closes an advisory is a security change, and only the PR says so. Counts
+  // MUST be taken after this pass or the headline and the badges disagree.
+  const commits = refineCategories(parsed, enrichment.byPr);
+  const counts = countCategories(commits);
 
   const scored = scoreCommits({
     commits,

--- a/apps/web/lib/self-upgrade/impact/phrase.test.ts
+++ b/apps/web/lib/self-upgrade/impact/phrase.test.ts
@@ -4,7 +4,7 @@ import { phraseSummary } from "./phrase";
 import type { ImpactCategoryCounts, ImpactItem, InstallSignals } from "./types";
 
 const emptyCounts: ImpactCategoryCounts = {
-  breaking: 0, feature: 0, fix: 0, performance: 0, other: 0, total: 0,
+  breaking: 0, security: 0, feature: 0, fix: 0, performance: 0, dependency: 0, documentation: 0, maintenance: 0, other: 0, total: 0,
 };
 
 const emptySignals: InstallSignals = {

--- a/apps/web/lib/self-upgrade/impact/phrase.ts
+++ b/apps/web/lib/self-upgrade/impact/phrase.ts
@@ -34,9 +34,10 @@ Your job is ONLY phrasing. Follow these rules:
 4. Do NOT include SHAs, file paths, commit hashes, or PR numbers in any field.
 5. Each item's "description" is ONE plain-English sentence (<=20 words) that says what changed.
 6. Each item's "whyRelevant" is ONE plain-English sentence (<=20 words) tied to install state — empty string when no install-specific reason exists.
-7. "headline" is ONE sentence summarising counts in plain English (e.g. "1 breaking change, 2 new features, and 5 fixes since your last upgrade.").
+7. "headline" is ONE sentence summarising counts in plain English (e.g. "1 breaking change, 2 new features, and 5 fixes since your last upgrade."). Name each category the counts actually contain — say "dependency updates", "documentation", "internal maintenance" and "security fixes" rather than collapsing them into "other changes".
 8. "touchesCustomizationsCallout" is ONE sentence ONLY if any item has touchesCustomizations=true; otherwise empty string. Mention this may need merge review.
 9. If an item description is empty or just a type prefix, paraphrase it neutrally as "internal change" — do not invent details.
+10. Each item's phrasing must be true to its category: "dependency" says which dependency moved, "documentation" says what was documented, "maintenance" says what internal upkeep happened, "security" says what was patched or hardened. Never describe a dependency bump as a new feature.
 
 Schema:
 {

--- a/apps/web/lib/self-upgrade/impact/refine.test.ts
+++ b/apps/web/lib/self-upgrade/impact/refine.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCommit } from "./conventional";
+import { refineCategories } from "./refine";
+import type { ParsedCommit, PrEnrichment, RawCommit } from "./types";
+
+function raw(subject: string): RawCommit {
+  return {
+    sha: "0000000000000000000000000000000000000000",
+    subject,
+    author: "Test",
+    authorDate: "2026-05-01T00:00:00Z",
+    files: [],
+  };
+}
+
+function pr(overrides: Partial<PrEnrichment> & { prNumber: number }): PrEnrichment {
+  return { title: null, labels: [], body: null, ...overrides };
+}
+
+function refineOne(subject: string, enrichment?: PrEnrichment): ParsedCommit {
+  const commit = parseCommit(raw(subject));
+  const byPr = new Map<number, PrEnrichment>();
+  if (enrichment) byPr.set(enrichment.prNumber, enrichment);
+  return refineCategories([commit], byPr)[0]!;
+}
+
+describe("refineCategories", () => {
+  it("promotes a dependency bump carrying a security label", () => {
+    const out = refineOne(
+      "build(deps): bump nanoid from 5.0.9 to 5.1.6 (#4313)",
+      pr({ prNumber: 4313, labels: ["dependencies", "security"] }),
+    );
+    expect(out.category).toBe("security");
+  });
+
+  it("promotes on an advisory id in the PR title", () => {
+    const out = refineOne(
+      "fix(deps): raise the floor (#4313)",
+      pr({ prNumber: 4313, title: "Clear GHSA-4943-9vgg-gr5r in the lockfile" }),
+    );
+    expect(out.category).toBe("security");
+  });
+
+  it("promotes on advisory wording in the commit subject with no PR reachable", () => {
+    const out = refineOne("fix(web): patch the session-fixation vulnerability");
+    expect(out.category).toBe("security");
+  });
+
+  it("leaves a routine bump as a dependency change", () => {
+    const out = refineOne(
+      "build(deps): bump next from 16.2.12 to 16.3.0 (#4305)",
+      pr({ prNumber: 4305, labels: ["dependencies"], title: "Bump next" }),
+    );
+    expect(out.category).toBe("dependency");
+  });
+
+  it("never demotes a breaking change", () => {
+    const out = refineOne(
+      "feat(api)!: drop the legacy endpoint (#4200)",
+      pr({ prNumber: 4200, labels: ["security"] }),
+    );
+    expect(out.category).toBe("breaking");
+  });
+
+  it("leaves an unparseable subject honest as `other`", () => {
+    const out = refineOne("Some security-flavoured wording without a CVE");
+    expect(out.category).toBe("other");
+  });
+
+  it("does not mutate its input", () => {
+    const commits = [parseCommit(raw("build(deps): bump x (#1)"))];
+    const byPr = new Map([[1, pr({ prNumber: 1, labels: ["security"] })]]);
+    const out = refineCategories(commits, byPr);
+    expect(commits[0]!.category).toBe("dependency");
+    expect(out[0]!.category).toBe("security");
+  });
+});

--- a/apps/web/lib/self-upgrade/impact/refine.ts
+++ b/apps/web/lib/self-upgrade/impact/refine.ts
@@ -1,0 +1,71 @@
+// apps/web/lib/self-upgrade/impact/refine.ts
+//
+// Second classification pass — the part the commit subject alone cannot decide.
+//
+// `conventional.ts` derives a category from the subject grammar (type + scope).
+// That is enough to separate a feature from a fix from a docs commit from a
+// dependency bump, but NOT enough to tell a routine version bump from one that
+// closes a published advisory: upstream emits both as `build(deps): bump X`.
+// The distinguishing evidence — advisory ids, `security` / `dependabot` labels,
+// "vulnerability" wording — lives on the PR, so this pass runs AFTER pr-enrich
+// and re-buckets the affected commits before counts are taken.
+//
+// Deliberately conservative: it only ever PROMOTES a commit to `security`, and
+// only on explicit evidence. A commit with no PR enrichment keeps the category
+// the subject earned it — we never guess a security fix into existence.
+
+import type { ParsedCommit, PrEnrichment } from "./types";
+
+/** Labels that state, unambiguously, that a PR is security work. */
+const SECURITY_LABELS: ReadonlySet<string> = new Set([
+  "security",
+  "vulnerability",
+  "cve",
+  "advisory",
+  "dependabot-security",
+  "security-fix",
+]);
+
+// Advisory identifiers + the words a security PR title/body actually uses.
+// `GHSA-…` / `CVE-…` are the load-bearing signals; the prose terms are the
+// fallback for hand-written subjects that reference no id.
+const SECURITY_TEXT_RE =
+  /\b(cve-\d{4}-\d{4,}|ghsa-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}|vulnerabilit(?:y|ies)|security advisor(?:y|ies)|osv (?:finding|alert)s?)\b/i;
+
+// A category `security` may override. A breaking change stays breaking (it is
+// the higher-risk signal and the one the operator must not lose), and a commit
+// we could not parse stays honest as `other`.
+const PROMOTABLE: ReadonlySet<ParsedCommit["category"]> = new Set([
+  "fix",
+  "dependency",
+  "maintenance",
+  "feature",
+]);
+
+function isSecurity(commit: ParsedCommit, pr: PrEnrichment | undefined): boolean {
+  if (pr) {
+    for (const label of pr.labels) {
+      if (SECURITY_LABELS.has(label)) return true;
+    }
+    if (pr.title && SECURITY_TEXT_RE.test(pr.title)) return true;
+    if (pr.body && SECURITY_TEXT_RE.test(pr.body)) return true;
+  }
+  return SECURITY_TEXT_RE.test(commit.description);
+}
+
+/**
+ * Apply PR-derived evidence to the subject-derived categories. Returns a new
+ * array; input is not mutated. Counts MUST be taken from the output of this
+ * pass, not from `parseCommits`, or the headline and the badges disagree.
+ */
+export function refineCategories(
+  commits: ParsedCommit[],
+  enrichmentByPr: Map<number, PrEnrichment>,
+): ParsedCommit[] {
+  return commits.map((commit) => {
+    if (!PROMOTABLE.has(commit.category)) return commit;
+    const pr = commit.prNumber != null ? enrichmentByPr.get(commit.prNumber) : undefined;
+    if (!isSecurity(commit, pr)) return commit;
+    return { ...commit, category: "security" };
+  });
+}

--- a/apps/web/lib/self-upgrade/impact/score.test.ts
+++ b/apps/web/lib/self-upgrade/impact/score.test.ts
@@ -28,24 +28,48 @@ function commits(...subjects: ParsedCommit[]): ParsedCommit[] {
 }
 
 describe("scoreCommits — base weights", () => {
-  it("ranks breaking > feature > perf > fix > other when nothing matches install state", () => {
+  it("ranks breaking > feature > perf > fix > dependency > docs > maintenance when nothing matches install state", () => {
     const c = commits(
       parseCommit(raw("feat!: bk")),
       parseCommit(raw("feat: f")),
       parseCommit(raw("perf: p")),
       parseCommit(raw("fix: x")),
+      parseCommit(raw("build(deps): bump thing")),
+      parseCommit(raw("docs: d")),
       parseCommit(raw("chore: o")),
     );
     const scored = scoreCommits({ commits: c, signals: emptySignals, enrichmentByPr: new Map() });
-    // base weights: 100, 50, 30, 25, 8
-    expect(scored.map((s) => s.score)).toEqual([100, 50, 30, 25, 8]);
+    // base weights: 100, 50, 30, 25, 12, 6, 5
+    expect(scored.map((s) => s.score)).toEqual([100, 50, 30, 25, 12, 6, 5]);
     expect(scored.map((s) => s.reasons[0]!.kind)).toEqual([
       "breaking-change",
       "base-weight",
       "base-weight",
       "base-weight",
       "base-weight",
+      "base-weight",
+      "base-weight",
     ]);
+  });
+
+  // A security fix must outrank anything an operator merely asked for — it is
+  // the one bucket besides `breaking` they should never scroll past.
+  it("weights a security change above a feature", () => {
+    const c = commits(parseCommit(raw("fix: patch the disclosed vulnerability")));
+    const [scored] = scoreCommits({
+      commits: c,
+      signals: emptySignals,
+      enrichmentByPr: new Map(),
+    });
+    // The subject alone does not promote — refineCategories owns that pass —
+    // so score the already-refined category directly.
+    expect(scored!.score).toBe(25);
+    const promoted = scoreCommits({
+      commits: [{ ...c[0]!, category: "security" }],
+      signals: emptySignals,
+      enrichmentByPr: new Map(),
+    });
+    expect(promoted[0]!.score).toBe(80);
   });
 });
 

--- a/apps/web/lib/self-upgrade/impact/score.ts
+++ b/apps/web/lib/self-upgrade/impact/score.ts
@@ -15,6 +15,7 @@
 // Reasons are accumulated verbatim so the operator UI can show *why* an item
 // landed where it did, with no LLM rewriting.
 
+import { CATEGORY_RANK } from "./classify";
 import type {
   ImpactItem,
   ImpactItemReason,
@@ -25,9 +26,18 @@ import type {
 
 const BASE_WEIGHT: Record<ParsedCommit["category"], number> = {
   breaking: 100,
+  // A security fix is the one thing besides a breaking change an operator
+  // should never scroll past, so it outweighs a feature.
+  security: 80,
   feature: 50,
   performance: 30,
   fix: 25,
+  // Dependency bumps outweigh docs and internal upkeep: they change what the
+  // product actually runs on, and are the usual suspect when an upgrade
+  // regresses something. Still far below anything an operator asked for.
+  dependency: 12,
+  documentation: 6,
+  maintenance: 5,
   other: 8,
 };
 
@@ -164,13 +174,12 @@ export function scoreCommits(input: ScoreInput): ImpactItem[] {
  * `git log --reverse`, so we use array index for stability).
  */
 export function orderByImpact(items: ImpactItem[]): ImpactItem[] {
-  const RANK: Record<ImpactItem["category"], number> = {
-    breaking: 0, feature: 1, performance: 2, fix: 3, other: 4,
-  };
   const indexed = items.map((item, index) => ({ item, index }));
   indexed.sort((a, b) => {
     if (a.item.score !== b.item.score) return b.item.score - a.item.score;
-    if (a.item.category !== b.item.category) return RANK[a.item.category] - RANK[b.item.category];
+    if (a.item.category !== b.item.category) {
+      return CATEGORY_RANK[a.item.category] - CATEGORY_RANK[b.item.category];
+    }
     return b.index - a.index; // newer first (later in `git log --reverse` => higher index)
   });
   return indexed.map((entry) => entry.item);

--- a/apps/web/lib/self-upgrade/impact/store.test.ts
+++ b/apps/web/lib/self-upgrade/impact/store.test.ts
@@ -23,7 +23,7 @@ function summary(overrides: Partial<UpgradeImpactSummary> = {}): UpgradeImpactSu
   return {
     currentLineageSha: LINEAGE,
     targetSha: TARGET,
-    counts: { breaking: 0, feature: 1, fix: 0, performance: 0, other: 0, total: 1 },
+    counts: { breaking: 0, security: 0, feature: 1, fix: 0, performance: 0, dependency: 0, documentation: 0, maintenance: 0, other: 0, total: 1 },
     topItems: [],
     allItems: [],
     phrased: null,

--- a/apps/web/lib/self-upgrade/impact/types.ts
+++ b/apps/web/lib/self-upgrade/impact/types.ts
@@ -17,11 +17,26 @@
 // is grounded against. The LLM only PHRASES — never invents items, never
 // reorders, never changes categories.
 
+/**
+ * Operator-facing change buckets.
+ *
+ * `other` is the honest fallback for a subject we could not parse — NOT a
+ * catch-all. Docs, dependency bumps and internal maintenance each get their own
+ * bucket because they are different operator concerns: a dependency bump is a
+ * supply-chain event worth a second look, a docs commit is not, and lumping
+ * them together made the panel render a wall of identical "OTHER" badges while
+ * the headline could plainly say "1 documentation addition and 4 dependency
+ * updates".
+ */
 export type ChangeCategory =
   | "breaking"
+  | "security"
   | "feature"
   | "fix"
   | "performance"
+  | "dependency"
+  | "documentation"
+  | "maintenance"
   | "other";
 
 export type ConventionalType =
@@ -67,11 +82,21 @@ export type ParsedCommit = RawCommit & {
   category: ChangeCategory;
 };
 
+/**
+ * Per-category tallies. Every key is present on a freshly computed summary, but
+ * summaries persisted under the earlier (breaking/feature/fix/performance/other)
+ * taxonomy are replayed from JSON and carry only those keys — every reader must
+ * therefore treat a missing key as 0 rather than assume presence.
+ */
 export type ImpactCategoryCounts = {
   breaking: number;
+  security: number;
   feature: number;
   fix: number;
   performance: number;
+  dependency: number;
+  documentation: number;
+  maintenance: number;
   other: number;
   total: number;
 };

--- a/apps/web/lib/self-upgrade/owner-summary.ts
+++ b/apps/web/lib/self-upgrade/owner-summary.ts
@@ -84,14 +84,10 @@ export interface OwnerReleaseInput {
     targetSha: string | null;
   } | null;
   latestRunImpact: {
-    counts: {
-      breaking: number;
-      feature: number;
-      fix: number;
-      performance: number;
-      other: number;
-      total: number;
-    };
+    // Only `breaking` and `total` are read here, so the shape stays permissive:
+    // a summary persisted under an older category taxonomy assigns cleanly and
+    // this builder never has to know the current bucket list.
+    counts: { total: number; breaking?: number } & Record<string, number | undefined>;
     headline: string | null;
   } | null;
   /**

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/superpowers/decisions/2026-08-15-upgrade-impact-change-categories.md
+++ b/docs/superpowers/decisions/2026-08-15-upgrade-impact-change-categories.md
@@ -1,0 +1,123 @@
+# Upgrade impact summary — specific change categories instead of a catch-all "other"
+
+**Date:** 2026-08-15
+**Surface:** `/ops/self-upgrade` → "What's in this update?" panel (`apps/web/components/ops/UpgradeImpactPanel.tsx`) and the Latest Run scope ribbon (`UpgradeScopeRibbon`)
+**Module:** `apps/web/lib/self-upgrade/impact/`
+**Backlog:** BI-6EC1350E
+**Kernel decision:** DI-626B8EA95F90, profile `mark-dpf-platform`
+
+## Problem
+
+An operator opened the panel on a real install and saw five changes, every one
+of them badged **OTHER** — while the LLM headline directly above them read
+"5 updates included: 1 documentation addition and 4 dependency updates". The
+phrasing layer knew what the changes were; the taxonomy underneath it did not.
+
+Root cause: `ChangeCategory` carried only `breaking | feature | fix |
+performance | other`, and `categoryFor()` mapped `docs`, `chore`, `build`, `ci`,
+`test`, `refactor`, `style`, `revert` and every unparseable subject into the
+single `other` bucket.
+
+That bucket is not marginal. Over the last 400 commits on `main`:
+
+| type | count |
+| --- | --- |
+| `fix` | 185 |
+| `feat` | 123 |
+| `docs` | 50 |
+| `doc` (parsed as `unknown` → `other`) | 16 |
+| `build` (almost entirely `build(deps*)`) | 13 |
+| `chore` / `test` / `refactor` | 11 |
+
+So roughly a fifth of every upgrade rendered as an undifferentiated wall of
+identical badges, and the two things an operator most wants separated — "we
+documented something" and "we changed what the product runs on" — were the same
+badge.
+
+## Decision
+
+Replace the catch-all with categories that map to distinct operator concerns:
+
+| category | derived from | badge |
+| --- | --- | --- |
+| `breaking` | `!` marker / `BREAKING CHANGE:` | Breaking |
+| `security` | PR labels + advisory ids, applied after PR enrichment | Security |
+| `feature` | `feat` | New |
+| `performance` | `perf` | Faster |
+| `fix` | `fix` | Fix |
+| `dependency` | `build(deps)` / `build(deps-dev)` | Dependency |
+| `documentation` | `docs` (and the `doc` spelling upstream also emits) | Docs |
+| `maintenance` | `chore`, `refactor`, `test`, `ci`, `style`, `revert`, other `build` scopes | Internal |
+| `other` | **only** a subject the parser could not read | Other |
+
+Three consequences worth stating explicitly:
+
+1. **`other` now means "we don't know", not "we didn't bother".** It is the
+   honest fallback for an unparseable subject, and nothing else. Any commit that
+   lands there is a parser gap, which makes the bucket a usable signal.
+2. **`security` cannot come from the subject alone.** Upstream emits a routine
+   version bump and an advisory-clearing bump with the same
+   `build(deps): bump X from A to B` subject; only the PR (labels, `CVE-…` /
+   `GHSA-…` ids, title, body) distinguishes them. A second pass —
+   `refine.ts` — runs **after** `pr-enrich` and promotes on explicit evidence
+   only. It never demotes, never promotes a breaking change, and never guesses a
+   security fix into existence when GitHub is unreachable (Never Fabricate).
+3. **Counts are taken after that pass.** Taking them before would put the
+   headline and the badges in disagreement — the exact failure this change
+   exists to remove.
+
+Ordering follows one shared `CATEGORY_RANK` (in `classify.ts`, consumed by
+`score.ts` — single source of truth, not two rank tables): risk first
+(breaking → security), then what the operator asked for
+(feature → performance → fix), then upkeep (dependency → documentation →
+maintenance), then unknown. Base weights follow the same shape, with
+`dependency` (12) deliberately above `documentation` (6) and `maintenance` (5):
+a dependency bump changes what the product actually runs on and is the usual
+suspect when an upgrade regresses something.
+
+## Backward compatibility
+
+`UpgradeImpactSummary` rows persist the computed summary as JSON, so summaries
+written under the old five-key taxonomy replay into the new code. Both readers
+degrade rather than break:
+
+- `formatImpactCounts` reads every key as `?? 0`, so a missing key is "none of
+  those", never `NaN`.
+- The panel resolves badges through `categoryLabel()` / `categoryBadge()`, which
+  fall back to the neutral badge for any category this build has no entry for.
+
+No migration, no backfill: a stale summary keeps saying what it said when it was
+generated, which is the correct behaviour for an audit record.
+
+## Kernel consultation
+
+`principle_decide` (DI-626B8EA95F90) scored a minimal option (split out
+`dependency` + `documentation` from the subject grammar only) against the full
+option (also `security` + `maintenance`, with security refined from PR
+evidence). Result: **full** — composite 9.902 vs 6.130, margin 3.771, confidence
+high, strong structured coverage, no commandment conflict. Top contributors:
+*Research and Use Standards* and *Classify ambiguous requests before acting* —
+both pulling toward classifying a change by what it actually is rather than
+filing the ambiguous remainder in one bucket.
+
+## Scope of change (no contract change)
+
+- `impact/types.ts` — widened `ChangeCategory` and `ImpactCategoryCounts`.
+- `impact/conventional.ts` — scope-aware `categoryFor`, `doc`/`feature`/`bugfix`
+  type aliases, case-insensitive type token.
+- `impact/refine.ts` *(new)* — the post-enrichment security promotion pass.
+- `impact/classify.ts` — exported `CATEGORY_RANK`; counts cover every bucket.
+- `impact/score.ts` — base weights per category; consumes the shared rank.
+- `impact/format.ts` — counts ribbon names each bucket; legacy-safe reads.
+- `impact/index.ts` — enrich → refine → count ordering.
+- `impact/phrase.ts` — the LLM is told to name the categories, not collapse them.
+- `components/ops/UpgradeImpactPanel.tsx` — badge labels/colors + fallback.
+- `lib/self-upgrade/owner-summary.ts` — reads counts structurally, so it no
+  longer restates the bucket list.
+
+## Related
+
+- [Latest Run card — human-readable upgrade scope](2026-07-15-self-upgrade-run-card-human-readable-scope.md)
+- [Self-upgrade change register design](../specs/2026-06-16-self-upgrade-change-register-design.md)
+- BI-F7A591AF — surfacing each past run's persisted summary in Run History, so an
+  adverse change can be traced to the upgrade that introduced it (follow-on).


### PR DESCRIPTION
## What

The "What's in this update?" panel on `/ops/self-upgrade` badged **every** change `OTHER`, while its own headline directly above them read *"1 documentation addition and 4 dependency updates"*. The phrasing layer knew what the changes were; the taxonomy underneath it did not.

`categoryFor()` mapped `docs`, `chore`, `build`, `ci`, `test`, `refactor`, `style`, `revert` **and** every unparseable subject into one `other` bucket. Over the last 400 commits on `main` that bucket is ~20% of a typical upgrade (50 `docs` + 16 `doc:` + 13 `build(deps*)` + 11 chore/test/refactor).

## Change

| category | derived from | badge |
| --- | --- | --- |
| `breaking` | `!` / `BREAKING CHANGE:` | Breaking |
| `security` | PR labels + `CVE-…`/`GHSA-…`, applied after PR enrichment | Security |
| `feature` | `feat` | New |
| `performance` | `perf` | Faster |
| `fix` | `fix` | Fix |
| `dependency` | `build(deps)` / `build(deps-dev)` | Dependency |
| `documentation` | `docs` (+ the `doc` spelling upstream also emits) | Docs |
| `maintenance` | `chore`, `refactor`, `test`, `ci`, `style`, `revert`, other `build` scopes | Internal |
| `other` | **only** a subject the parser could not read | Other |

- `other` now means "we don't know", not "we didn't bother" — anything landing there is a parser gap, which makes the bucket a usable signal.
- **`security` cannot come from the subject.** Upstream emits a routine bump and an advisory-clearing bump identically, so a new pass (`impact/refine.ts`) runs **after** `pr-enrich` and promotes only on explicit evidence: security labels, `CVE-…`/`GHSA-…` ids, or advisory wording. It never demotes, never touches a breaking change, and never invents a security fix when GitHub is unreachable.
- **Counts are taken after that pass** — taking them before is what let the headline and the badges disagree in the first place.
- Ordering runs off one shared `CATEGORY_RANK` (`classify.ts`, consumed by `score.ts`) instead of two rank tables.
- The LLM phrasing prompt is told to name the categories rather than collapse them into "other changes".

## Backward compatibility

Summaries persisted under the old five-key taxonomy replay from JSON and still render: `formatImpactCounts` reads every key as `?? 0`, and the panel resolves badges through a fallback that degrades to the neutral badge for any unknown category. No migration, no backfill — a stale summary keeps saying what it said when it was written, which is correct for an audit record.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/decisions/2026-07-15-self-upgrade-run-card-human-readable-scope.md`, `docs/superpowers/specs/2026-06-16-self-upgrade-change-register-design.md`, `docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md`, `docs/superpowers/specs/2026-07-22-self-upgrade-owner-release-card-design.md`
- Current code substrate reviewed: `apps/web/lib/self-upgrade/impact/*`, `UpgradeImpactPanel.tsx`, `UpgradeScopeRibbon.tsx`, `SelfUpgradeClient.tsx`, `owner-summary.ts`, `change-record.ts`
- Source of truth: the impact module's `ChangeCategory` taxonomy; the 2026-07-15 run-card decision governs how counts are surfaced.
- Decision: extend the existing taxonomy in place — no parallel classifier, no new module boundary. Recorded at `docs/superpowers/decisions/2026-08-15-upgrade-impact-change-categories.md`.
- Kernel: `DI-626B8EA95F90` — full taxonomy over a minimal dependency/docs-only split (composite 9.902 vs 6.130, margin 3.771, high confidence, no commandment conflict).

## Verification

- `pnpm --filter web exec vitest run lib/self-upgrade components/ops` — 67 files, 799 tests, green. New coverage: `refine.test.ts` (security promotion, no-demotion, no-fabrication, input immutability), scope-derived dependency classification, the `doc:` alias, legacy-counts rendering, unknown-category badge fallback, and an orchestrator test asserting counts are taken **after** enrichment.
- `pnpm --filter web build` — clean.
- `pnpm typecheck` — clean.
- `pnpm run pregate` — local-CI gate passed (`1aed40a71dd4`, evidence `cmsuk43141d5x01ppzojd1zd8`, lease NPEL-C23410B2A4).
- Not done: live-portal UX verification. The panel renders from the deployed image, so this is observable on the install only after the change ships through `/ops/self-upgrade`; component-level rendering is covered by the jsdom tests above.

## Follow-on

BI-F7A591AF — surface each past run's persisted summary in Run History, so an adverse change can be traced to the upgrade that introduced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)