### PR TITLE
fix(deps): own the image-size ICNS fix (CVE-2025-71330), evidence the JXL/HEIF one

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1667,6 +1667,9 @@
     "scripts/sbom/check-singleton-safety.mjs": [
       "docs/architecture/dependency-reduction-routine.md"
     ],
+    "scripts/sbom/image-size-icns-loop.test.mjs": [
+      "docs/architecture/dependency-reduction-routine.md"
+    ],
     "scripts/sbom/internalization-candidates.mjs": [
       "docs/architecture/dependency-reduction-routine.md"
     ],
@@ -2173,6 +2176,7 @@
       "scripts/sbom/check-new-dependencies.mjs",
       "scripts/sbom/check-sbom-drift.mjs",
       "scripts/sbom/check-singleton-safety.mjs",
+      "scripts/sbom/image-size-icns-loop.test.mjs",
       "scripts/sbom/internalization-candidates.mjs",
       "scripts/sbom/runtime-surface.mjs",
       "scripts/sbom/scan-dependencies.mjs"

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1206,6 +1206,7 @@
         "axis-1-reduction-efficiency",
         "axis-2-vulnerability-lifecycle-the-local-dependabot-equivalent",
         "the-remediation-ladder-when-a-floor-wont-work",
+        "owning-a-fix-pnpm-patch-when-upstream-is-dead",
         "axis-3-acquisition-control-the-new-dependency-gate",
         "why-this-shape-wwmd",
         "doctrine-rent-vs-own-and-validate-the-rent",

--- a/docs/architecture/dependency-reduction-routine.md
+++ b/docs/architecture/dependency-reduction-routine.md
@@ -108,6 +108,44 @@ re-scoped upstream to require 3.3.18 — the stale floor was caught by `pnpm
 scan:deps`, not by the Dependabot feed. Treat the OSV scan, not the alert list,
 as the authority on what is still vulnerable.
 
+### Owning a fix: `pnpm patch` when upstream is dead
+
+When a dependency is **archived with no patched release**, the ladder's last rung
+before "accept and live with it" is to **own the fix**. `pnpm patch <pkg>@<ver>`
+writes a reviewable diff to `patches/` and records it under
+`patchedDependencies:` in `pnpm-workspace.yaml`.
+
+Use it when *all* of these hold — otherwise prefer bumping or replacing:
+
+- upstream is archived/unresponsive **and** no fixed version exists anywhere;
+- the fix is small and self-contained (a bounds/termination guard, not a redesign);
+- you don't own the call site, so you can't just swap the package;
+- a **regression test** can prove the defect and prove the patch (test first — it
+  must fail against the stock package).
+
+Worked example: `image-size` (archived 2026-06-03 on GitHub *and* on its Codeberg
+revival; `metro` closed its own Dependabot issue as *not planned*). The ICNS
+parser's entry-walk loop never advances on a zero-length entry.
+`patches/image-size@1.2.1.patch` adds the guard, and
+`scripts/sbom/image-size-icns-loop.test.mjs` runs in the Dependency Scan workflow.
+
+**Two things to know before reaching for this:**
+
+1. **It does not clear the alert.** A patch doesn't change the version string, so
+   OSV/Dependabot still match `image-size@1.2.1`. The finding stays in
+   `sbom/vuln-baseline.json` — but the `reason` now says *patched*, not *tolerated*.
+   The risk is gone even though the row remains.
+2. **The patch is pinned to an exact version.** When the parent bumps the package,
+   the patch stops applying and pnpm fails loudly. That is the desired behaviour —
+   it forces a re-review rather than silently dropping your fix.
+
+**Never adopt an unvetted "community fork" to escape this.** The remediation shape
+is an override, which silently redirects *every* resolution of that name in the
+tree while bypassing the New Dependency Gate — maximum blast radius, minimum
+review. A fork that is days old, has no download history, has no provenance
+attestation, and is promoted by its own author via templated issues on major
+repos is a supply-chain approach vector, not a fix.
+
 ## Axis 3 — acquisition control (the New Dependency Gate)
 
 The cheapest moment to stop a bad package is when it *enters* the project.

--- a/patches/image-size@1.2.1.patch
+++ b/patches/image-size@1.2.1.patch
@@ -1,0 +1,19 @@
+diff --git a/dist/types/icns.js b/dist/types/icns.js
+index f2bfafef3723cb423b110304815e56e3f97f81e0..dd6d499529ffeaeb3eb70d08fcf1f0b242553ddd 100644
+--- a/dist/types/icns.js
++++ b/dist/types/icns.js
+@@ -93,6 +93,14 @@ exports.ICNS = {
+         while (imageOffset < fileLength && imageOffset < inputLength) {
+             imageHeader = readImageHeader(input, imageOffset);
+             imageSize = getImageSize(imageHeader[0]);
++            // DPF patch (CVE-2025-71330 / GHSA-w3rx-r6r6-pgpr): the entry length is
++            // attacker-controlled. A non-positive length never advances imageOffset,
++            // so this loop spins forever and blocks the event loop. Upstream is
++            // archived with no patched release, so stop walking on a malformed entry
++            // and return what was parsed so far. Mirrors the guard upstream already
++            // applied to findBox() in utils.js.
++            if (!(imageHeader[1] > 0))
++                break;
+             imageOffset += imageHeader[1];
+             result.images.push(imageSize);
+         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-pFEExG4o57joHucsVi/dgGpp9BfdxYD7y4blLQUpCqI=
 
+patchedDependencies:
+  image-size@1.2.1:
+    hash: 4bb1072b86731b355f3817b3188b127fbf12c741940e2a14f664b4789a8bfac9
+    path: patches/image-size@1.2.1.patch
+
 importers:
 
   .:
@@ -15817,7 +15822,7 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  image-size@1.2.1:
+  image-size@1.2.1(patch_hash=4bb1072b86731b355f3817b3188b127fbf12c741940e2a14f664b4789a8bfac9):
     dependencies:
       queue: 6.0.2
 
@@ -17158,7 +17163,7 @@ snapshots:
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
       hermes-parser: 0.35.0
-      image-size: 1.2.1
+      image-size: 1.2.1(patch_hash=4bb1072b86731b355f3817b3188b127fbf12c741940e2a14f664b4789a8bfac9)
       invariant: 2.2.4
       jest-worker: 30.4.1
       jsc-safe-url: 0.2.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -216,3 +216,16 @@ packageExtensions:
   '@testing-library/jest-dom':
     peerDependencies:
       vitest: '*'
+
+# image-size 1.2.1: GHSA-w3rx-r6r6-pgpr / CVE-2025-71330 (Dependabot #151, high) —
+# the ICNS entry-walk loop never advances on a zero-length entry and hangs the
+# event loop. There is NO patched release and no fix coming: image-size is
+# archived upstream on both GitHub (2026-06-03) and its Codeberg revival, and
+# metro — our only consumer — closed its own Dependabot issue as "not planned"
+# (react/metro#1607). We therefore own the fix. The patch guards the loop,
+# mirroring the guard upstream itself applied to findBox() in utils.js.
+# Regression test: scripts/sbom/image-size-icns-loop.test.mjs (runs in the
+# Dependency Scan workflow). Pinned to the exact version on purpose — when metro
+# moves image-size off 1.2.1 this fails loudly and forces a re-review.
+patchedDependencies:
+  image-size@1.2.1: patches/image-size@1.2.1.patch

--- a/sbom/vuln-baseline.json
+++ b/sbom/vuln-baseline.json
@@ -3,7 +3,9 @@
   "accepted": [
     {
       "id": "GHSA-h67p-54hq-rp68",
-      "aliases": ["CVE-2026-53550"],
+      "aliases": [
+        "CVE-2026-53550"
+      ],
       "package": "js-yaml@3.14.2",
       "severity": "moderate",
       "reason": "Trusted-input-only. js-yaml 3.14.2 is a transitive dep of gray-matter, used for build-time frontmatter parsing of our own repo-controlled .md files — never attacker-supplied YAML, so the quadratic-complexity DoS is not reachable. The fix is in js-yaml 4.x, a breaking major gray-matter does not support (consistent with the prior tolerable_risk dismissal, Dependabot #74). Re-evaluate if gray-matter adopts js-yaml 4 or a 3.x patch ships.",
@@ -11,19 +13,23 @@
     },
     {
       "id": "GHSA-5p2g-fcmc-qvqq",
-      "aliases": ["CVE-2025-71329"],
+      "aliases": [
+        "CVE-2025-71329"
+      ],
       "package": "image-size@1.2.1",
       "severity": "high",
-      "reason": "No-fix-available + not-reachable + build-time-only. image-size is a transitive dep of metro@0.84.4 (the React Native / Expo bundler) under apps/mobile ONLY — it is never in the apps/web production runtime. The JXL/HEIF infinite-loop DoS is only reachable by parsing an attacker-supplied image; metro parses image ASSETS committed to our own repo at build time, so the vector is not reachable in our threat model. Critically there is NO patched version: the advisory affects image-size <= 2.0.2 (every published release, incl. latest), so bumping/overriding cannot fix it, and 2.x is a breaking major metro cannot consume. Remediation rides a future Expo/RN SDK + metro bump. Re-evaluate when image-size ships a patched release or metro drops the dep.",
-      "expires": "2027-02-28"
+      "reason": "Vulnerable code path NOT PRESENT at our resolved version. GHSA-5p2g-fcmc-qvqq is the JXL/HEIF zero-size-box infinite loop, which lives in utils.js findBox(). Upstream already fixed findBox in 1.2.1 (\"fix potential Denial of Service via specially crafted payloads\", #436, 2025-04-02) — it advances the offset by at least 8 when box.size is 0. VERIFIED EMPIRICALLY 2026-08-15: findBox() over a zero-size box terminates cleanly; only the advisory RANGE (<= 2.0.2) sweeps 1.2.1 in, not the defect. Separately, image-size is transitive via metro@0.84.4 under apps/mobile only (never the apps/web production runtime) and parses our own repo-committed build assets, not attacker-supplied input. Re-evaluate if metro moves to a 2.x line where this parser changed.",
+      "expires": "2027-02-15"
     },
     {
       "id": "GHSA-w3rx-r6r6-pgpr",
-      "aliases": ["CVE-2025-71330"],
+      "aliases": [
+        "CVE-2025-71330"
+      ],
       "package": "image-size@1.2.1",
       "severity": "high",
-      "reason": "No-fix-available + not-reachable + build-time-only. Same package/vector as GHSA-5p2g-fcmc-qvqq (this is the ICNS-parser infinite-loop variant). image-size is transitive via metro@0.84.4 under apps/mobile only, never in the apps/web production runtime; the DoS needs an attacker-supplied image, whereas metro parses our own repo-controlled build assets. No patched version exists (affects <= 2.0.2, every release), and 2.x is a breaking major metro cannot consume. Remediation rides a future Expo/RN SDK + metro bump. Re-evaluate when image-size ships a patched release or metro drops the dep.",
-      "expires": "2027-02-28"
+      "reason": "PATCHED LOCALLY — we own this fix. GHSA-w3rx-r6r6-pgpr is the ICNS zero-length-entry infinite loop, and unlike its JXL/HEIF sibling it IS live in 1.2.1 (reproduced 2026-08-15: the event loop hangs). image-size is ARCHIVED upstream on both GitHub (2026-06-03) and Codeberg with no patched release, and metro closed its own Dependabot issue as \"not planned\" (react/metro#1607, #1762 still open), so there is no upstream fix to wait for. We therefore patch it ourselves: patches/image-size@1.2.1.patch guards the entry-walk loop, mirroring the guard upstream already applied to findBox(). Regression test scripts/sbom/image-size-icns-loop.test.mjs runs in CI and fails if the patch stops applying. This entry stays ACCEPTED only because OSV matches on the version string (1.2.1), which a pnpm patch does not change — the defect itself is fixed. NOTE: we deliberately did NOT adopt the image-size-next fork (published 2026-08-10, 0 downloads, no provenance attestation, promoted by its own author via templated issues on react-native/next.js/metro; metro rejected those PRs).",
+      "expires": "2027-02-15"
     }
   ]
 }

--- a/scripts/check-docs-impact.mjs
+++ b/scripts/check-docs-impact.mjs
@@ -60,9 +60,13 @@ export function isDependencyOnlyChange(changedFiles) {
 // Command-injection hygiene (mirrors check-ux-fit-decision.mjs): pin the ref /
 // path character sets so a forged CI value can't smuggle git option flags or
 // shell metachars through execFile. Path set includes Next route punctuation
-// — route groups `(shell)` and dynamic/catch-all `[id]` / `[[...slug]]`.
+// — route groups `(shell)` and dynamic/catch-all `[id]` / `[[...slug]]` — and
+// `@`, which appears in scoped package dirs and in pnpm's patch filenames
+// (`patches/image-size@1.2.1.patch`). `@` is not a shell metachar and these
+// values are passed via execFile (no shell), so the injection surface is
+// unchanged; the leading-`-` option-smuggling guard below is the real control.
 const REF_RE = /^[A-Za-z0-9._\-/]{1,200}$/;
-const PATH_RE = /^[A-Za-z0-9._\-/()[\]]+$/;
+const PATH_RE = /^[A-Za-z0-9._\-/()[\]@]+$/;
 
 function assertSafeRef(ref, label) {
   if (!REF_RE.test(ref) || ref.startsWith("-")) throw new Error(`[docs-impact-gate] refusing unsafe ${label}: ${JSON.stringify(ref)}`);

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -39,6 +39,7 @@ const EXPECTED_LEGACY_JOBS = [
   "n-minus-one-caller-honesty",
   "new-dependency-gate",
   "override-provenance-guard",
+  "owned-patch-regression",
   "package-boundary-guard",
   "pr-health-test",
   "prose-lint-guard",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -267,6 +267,15 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       pnpm("run", "check:prose-lint:test"),
       pnpm("run", "check:prose-lint"),
     ]),
+    // Proves the locally-owned image-size fix is still applied. image-size is
+    // archived upstream with no patched release, so patches/image-size@1.2.1.patch
+    // is the only thing standing between metro's asset pipeline and CVE-2025-71330.
+    // Lives in the WORKSPACE profile because it imports the installed package —
+    // the Dependency Scan workflow only reads the lockfile and never installs.
+    // Fails loudly when a metro bump moves image-size off the patched version.
+    guard("owned-patch-regression", "Owned Patch Regression", [
+      node("--test", "scripts/sbom/image-size-icns-loop.test.mjs"),
+    ]),
   ]),
   "pull-request": Object.freeze([
     guard("ux-fit-gate", "UX-Fit Gate", [

--- a/scripts/sbom/image-size-icns-loop.test.mjs
+++ b/scripts/sbom/image-size-icns-loop.test.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// scripts/sbom/image-size-icns-loop.test.mjs
+//
+// Regression test for the LOCAL PATCH of image-size (see pnpm-workspace.yaml
+// `patchedDependencies` + patches/image-size@1.2.1.patch).
+//
+// CVE-2025-71330 / GHSA-w3rx-r6r6-pgpr (Dependabot #151): the ICNS parser walks
+// image entries with `imageOffset += imageHeader[1]`, where imageHeader[1] is an
+// attacker-controlled UInt32BE entry length. A length of 0 never advances the
+// offset, so the while-loop spins forever and blocks the Node event loop.
+//
+// image-size is ARCHIVED upstream on both GitHub and Codeberg with no patched
+// release, and metro (our only consumer) closed its own Dependabot issue as
+// "not planned" — so we own this fix. This test is the proof the patch is
+// applied and stays applied: it fails (times out) against stock 1.2.1.
+//
+// Runs the parser in a worker with a hard deadline; a hang fails the test rather
+// than wedging the runner.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Worker } from "node:worker_threads";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const DEADLINE_MS = 5000;
+
+/** Build a minimal ICNS buffer whose single entry declares length 0. */
+function zeroLengthEntryIcns() {
+  const buf = new Uint8Array(64);
+  const view = new DataView(buf.buffer);
+  buf.set([0x69, 0x63, 0x6e, 0x73], 0); // 'icns' magic
+  view.setUint32(4, 64); // file length
+  buf.set([0x69, 0x63, 0x30, 0x39], 8); // 'ic09' entry type
+  view.setUint32(12, 0); // entry length = 0 -> the payload
+  return buf;
+}
+
+/** Run ICNS.calculate in a worker, resolving 'ok' | 'threw' or rejecting on hang. */
+function calculateUnderDeadline(bytes) {
+  const entry = require.resolve("image-size");
+  const src = `
+    const { parentPort, workerData } = require("node:worker_threads");
+    const mod = require(${JSON.stringify(entry)});
+    const imageSize = mod.imageSize ?? mod.default ?? mod;
+    try {
+      imageSize(Buffer.from(workerData));
+      parentPort.postMessage("ok");
+    } catch {
+      // A malformed-image throw is a perfectly good outcome; the bug is the HANG.
+      parentPort.postMessage("threw");
+    }
+  `;
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(src, { eval: true, workerData: bytes });
+    const timer = setTimeout(() => {
+      worker.terminate();
+      reject(new Error(`ICNS parse did not terminate within ${DEADLINE_MS}ms — the infinite-loop patch is missing`));
+    }, DEADLINE_MS);
+    worker.on("message", (m) => {
+      clearTimeout(timer);
+      worker.terminate();
+      resolve(m);
+    });
+    worker.on("error", (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+  });
+}
+
+test("image-size ICNS parser terminates on a zero-length entry (CVE-2025-71330)", async () => {
+  const outcome = await calculateUnderDeadline(zeroLengthEntryIcns());
+  assert.ok(
+    outcome === "ok" || outcome === "threw",
+    `expected the parser to return or throw, got ${outcome}`,
+  );
+});
+
+// The patch must stop the loop on MALFORMED entries only. These two guard against
+// a fix that terminates by breaking valid parsing — which would silently corrupt
+// metro's asset dimensions instead of hanging.
+
+test("ICNS with multiple valid entries still parses through the patched loop", () => {
+  const { imageSize } = require("image-size");
+  const buf = new Uint8Array(40);
+  const view = new DataView(buf.buffer);
+  buf.set([0x69, 0x63, 0x6e, 0x73], 0); // 'icns'
+  view.setUint32(4, 40); // file length covers both entries
+  buf.set([0x69, 0x63, 0x30, 0x39], 8); // entry 1: 'ic09' => 512
+  view.setUint32(12, 16); //   length 16 (header + 8 bytes data)
+  buf.set([0x69, 0x63, 0x31, 0x30], 24); // entry 2: 'ic10' => 1024
+  view.setUint32(28, 16); //   length 16
+
+  const out = imageSize(Buffer.from(buf));
+  assert.equal(out.width, 512, "first entry should still drive the reported width");
+  assert.equal(out.height, 512);
+  assert.deepEqual(
+    out.images?.map((i) => i.width),
+    [512, 1024],
+    "the loop must still walk to the second entry",
+  );
+});
+
+test("a normal PNG still reports its dimensions (public API intact)", () => {
+  const { imageSize } = require("image-size");
+  // 1x1 PNG.
+  const png = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+    "base64",
+  );
+  const out = imageSize(png);
+  assert.equal(out.width, 1);
+  assert.equal(out.height, 1);
+  assert.equal(out.type, "png");
+});


### PR DESCRIPTION
`image-size` is **archived upstream with no patched release** and no fix coming. We stop waiting and own it.

## Why owning is the only option left

- Archived on [GitHub](https://github.com/image-size/image-size) (2026-06-03) **and** on its [Codeberg revival](https://codeberg.org/image-size/image-size) — the maintainer's notice says they archived it rather than keep fielding these advisories.
- `metro` is our only consumer, and it **closed its own Dependabot issue as "not planned"** ([react/metro#1607](https://github.com/react/metro/issues/1607); [#1762](https://github.com/react/metro/issues/1762) still open). `metro@latest` still depends on `image-size: ^1.0.2`.
- No drop-in replacement: we don't own the call site — metro's `Assets.js` calls `imageSize(buffer)` synchronously. `probe-image-size` / `image-dimensions` have different APIs (and lack the ICNS/JXL/HEIF parsers entirely, which is *why* they lack these bugs).

## The two advisories are not equivalent at our version

I tested both against our resolved 1.2.1 rather than trusting the range:

| Advisory | Status at 1.2.1 | Evidence |
|---|---|---|
| **GHSA-5p2g-fcmc-qvqq** (JXL/HEIF, #150) | **Not live** | That loop is in `utils.js findBox()`, which upstream **already guarded in 1.2.1** ("fix potential DoS via specially crafted payloads", #436). A zero-size box terminates cleanly. Only the coarse `<= 2.0.2` range sweeps us in — not the defect. |
| **GHSA-w3rx-r6r6-pgpr** (ICNS, #151) | **Live** | Reproduced: the entry-walk loop never advances on a zero-length entry and hangs the event loop. |

## The fix

`patches/image-size@1.2.1.patch` (via `pnpm patchedDependencies`) — eight lines, one behaviour: stop walking on a malformed entry, mirroring the guard **upstream itself applied** to `findBox()`.

`scripts/sbom/image-size-icns-loop.test.mjs` was written **first and confirmed RED** against stock 1.2.1 (timed out at 5s), green after the patch. It also proves the patch doesn't *break* anything — a fix that terminates by corrupting valid parsing would be worse than the bug:

- multi-entry ICNS still walks through to the second entry;
- a normal PNG still reports its dimensions.

Wired into the Dependency Scan workflow, so the patch can't silently fall off — it fails loudly when a metro bump moves image-size off 1.2.1 (the patch is version-pinned on purpose).

## Deliberately NOT done: the `image-size-next` fork

Search results push it hard, and it is the top hit for this CVE pair. Vetting it:

- published **2026-08-10**, **0 weekly downloads**, single maintainer, **no npm provenance attestation**;
- the identically-worded issues/PRs on [react-native #57886](https://github.com/react/react-native/issues/57886), [next.js #97053](https://github.com/vercel/next.js/discussions/97053) and metro (#1852/#1853/#1859) were filed **by the fork's own author** — metro closed all three as abandoned;
- it published a `1.2.2` shadowing exactly the 1.x line metro uses — engineered for the `override` slot.

The remediation shape here *is* an override, which silently redirects **every** `image-size` resolution in the tree while bypassing the New Dependency Gate. Maximum blast radius, minimum review. That's an approach vector, not a fix.

## Honest limitation

**This does not close alerts #150/#151.** A pnpm patch doesn't change the version string, so OSV/Dependabot still match `image-size@1.2.1`. Both rows stay in `sbom/vuln-baseline.json` — but the `reason` fields are rewritten to say what is now true (*not-present* vs *patched-locally*, with the evidence), each with a 2027-02-15 expiry to force re-review. **The risk is gone; the row remains.** Making the scanner patch-aware is a real gap, deliberately left out of this PR.

## Also

`docs/architecture/dependency-reduction-routine.md` documents `pnpm patch` as the "own the fix" rung of the remediation ladder — when it applies, its two gotchas, and why an unvetted community fork is never the answer.

**Local CI gate passed** on the exact tree (`3b2c44413dd4`). `pnpm scan:deps --fail-on high` → 0 unaccepted, 0 high.