### PR TITLE
docs(kernel): trust is prospective, not retrospective

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 634,
+  "pageCount": 635,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -4255,6 +4255,21 @@
         "examples",
         "when-this-does-not-apply",
         "see-also"
+      ]
+    },
+    "docs/founder-kernel/wiki/principles/trust-is-prospective-not-retrospective.md": {
+      "publicHref": "/founder-kernel/wiki/principles/trust-is-prospective-not-retrospective/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "applies-to",
+        "how-to-apply",
+        "decision-dimensions",
+        "examples",
+        "sources"
       ]
     },
     "docs/founder-kernel/wiki/principles/universal-work-formula.md": {

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1202,7 +1202,7 @@
       "ariaSnapshot": "- heading [level=1]\n- paragraph\n  - text\n- text\n- textbox\n- button\n- paragraph\n  - text"
     },
     "/inventory": {
-      "defaultVisibleWords": 946,
+      "defaultVisibleWords": 949,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 2,
@@ -1796,7 +1796,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - link\n  - paragraph\n    - text\n  - link\n  - heading [level=1]\n  - paragraph\n    - text\n  - heading [level=2]\n  - paragraph\n    - text\n  - button\n  - heading [level=2]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n  - heading [level=2]\n  - paragraph\n    - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n        - cell\n          - combobox\n            - option\n            - option [selected]\n            - option\n        - cell\n          - text\n        - cell\n          - button\n  - heading [level=2]\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup"
     },
     "/platform/tools/discovery": {
-      "defaultVisibleWords": 968,
+      "defaultVisibleWords": 971,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 2,

--- a/docs/founder-kernel/wiki/principles/trust-is-prospective-not-retrospective.md
+++ b/docs/founder-kernel/wiki/principles/trust-is-prospective-not-retrospective.md
@@ -1,0 +1,67 @@
+---
+title: Trust Is Prospective, Not Retrospective
+pageKind: principle
+status: published
+abstract: The platform exists to anticipate and prevent the wrong action, not merely to record the actions already taken.
+principleTier: commandment
+principleDirection: Weigh a consequential action against broader context and its potential consequences before it executes; treat the record of past outcomes as the learning mechanism, not the goal.
+principleDimensionVector: {"legibility_of_consequence": 1.0}
+principleWeight: 0.3
+principleWeightRationale: >-
+  Focused vector + low weight, per AUTHORING.md's procedural-meta guidance. This principle
+  governs WHEN a consequence must be surfaced, not which substantive option is better, so it
+  has no business tilting trade-offs like shortcut-vs-proper-fix. A first cut carrying
+  blast_radius / reversibility / governance_compliance dragged `quick-vs-proper-normal` to
+  margin 0.213 (floor 0.3) — the same failure PR #2157 hit — because a small quick fix scores
+  well on a negative blast_radius axis. Reversibility and blast radius remain central to the
+  rule's PROSE (they set how hard the gate presses) without being vector axes that pull
+  unrelated decisions.
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleRingScope:
+  - universal-ring
+principleConsumerArchetype: universal
+principlePublic: true
+principlePublicRationale: This is the platform's central trust thesis and the clearest statement of what distinguishes governed agency from unsupervised autonomy — adopters need to see it plainly.
+---
+
+## Rule
+
+Trust is earned by preventing the wrong action, not by documenting it afterwards. Before a consequential action executes, it is weighed and gated against broader context and its potential consequences. The accumulating record of past decisions and outcomes is the **learning mechanism** that makes that anticipation sharper — it is not the objective.
+
+## Why
+
+An LLM is trained to a point and thereafter lives inside its environment, memory, tools, and harness. Whatever wisdom it exhibits after that boundary comes from the harness, not from more training. Humans acquire the same capability by accumulating consequences until they can anticipate them — what we call becoming wise. This platform's purpose is to do that deliberately, and at a scale no individual can reach.
+
+The failure this guards against is specific and irrecoverable: trusted autonomy proceeding unsupervised into harm — the class of incident where an agent wipes a production database *and its backups*. Evidence collected after that event is worthless to the party who lost the data. Trust does not survive it, and no audit trail restores it. An audit log is a retrospective artifact; it explains a loss it did not prevent.
+
+This is why the platform invests in graphs, corpora, and decision gates. Their value is not that they remember — retrieval is solved. Their value is that they can **surface the consequence before the act**. A corpus that only records what happened is an archive. A corpus that carries the detail which highlights a potential consequence *shapes the action*, and that is the job.
+
+## Applies To
+
+Every actor taking consequential action — in-platform coworkers, external coding agents, and humans. Symmetric by design: the gate is on the consequence, not on who is acting. It does not apply to read-shaped, reversible, non-committing work, which must stay fast and ungated; over-gating trivial action trains people to bypass gates and destroys the control that matters.
+
+## How To Apply
+
+Before a consequential action, establish what could go wrong and whether the actor can see it — do not rely on the actor's confidence. Retrieve the context that bears on the *consequence*, not just the context that bears on the task. When a corpus, graph, or prior outcome indicates a risk, surface it in the decision path where it can change the action, not in a log read afterwards.
+
+Design capture accordingly: when recording an outcome, write down what a future actor would need in order to anticipate this situation — the condition that made it go wrong, not merely that it went wrong. An entry that cannot shape a future action is an archive entry, and archives do not build trust.
+
+Autonomy is granted against demonstrated ability to anticipate, and it is bounded by the reversibility and blast radius of the action — never by fluency or by accumulated volume of successful past runs alone.
+
+## Decision Dimensions
+
+- `legibility_of_consequence: 1.0` — the principle exists to make consequence visible at the moment of decision. This is its defining axis and deliberately its only one.
+
+The vector is single-axis and the weight is low (0.3) by design. This rule governs *when a consequence must be surfaced*, not *which substantive option is better*, so it must not tilt trade-offs it has no bearing on. Blast radius and reversibility still determine how hard the gate presses — that is stated in **How To Apply** — but they are not vector axes here, because a small shortcut scores well on a negative `blast_radius` axis and would be wrongly endorsed by this principle.
+
+## Examples
+
+- **Positive:** An agent about to run a destructive migration retrieves prior incidents and the affected data state, surfaces "this pattern wedged an install with existing rows" *in the approval path*, and the action is amended before it runs. The corpus changed the act.
+- **Counterexample:** The same agent runs the migration, wedges the install, and a complete, tamper-evident record of the decision is written to the audit ledger. Governance is satisfied on paper; the install is broken and trust is spent. Perfect retrospective evidence, zero prospective value.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations` — do not duplicate citation prose here.)


### PR DESCRIPTION
## What this is

A **founder ruling**, captured during the UX surface analysis thread and written to the kernel. **Merging this PR is the ratification** — the wording and the tier are the founder's to confirm or change.

## The ruling, as given

> The entire vision of this platform is to ensure trust — less about accumulating evidence of past decisions, but in anticipating and guarding against doing the wrong thing in the future. Past decisions and outcomes is how humans learn. The core of this platform is to do this at unprecedented scale.

The supporting reasoning: an LLM is trained to a point and thereafter lives inside its environment, memory, tools, and harness — so whatever wisdom it shows past that boundary comes from the harness. Humans acquire the same capability by accumulating consequences until they can anticipate them ("becoming wise"). The failure guarded against is trusted autonomy proceeding unsupervised into irrecoverable harm — the class of incident where an agent destroys a production database *and its backups*. Evidence gathered after that event restores neither the data nor the trust.

The operative consequence for design: **a corpus that only records what happened is an archive; one that carries the detail which highlights a potential consequence shapes the action.** That is a different acceptance test than "the decision was recorded correctly."

## Why it matters now

Live install counts: **331 wiki pages** (206 profession pages across 24 professions, 52 kernel principles), 122 corpus-usage stats — but **0 craft pages** and **0 weight proposals**. Platform-seeded material is `derived` tier (0.6 × 0.75 = **0.45**), permanently below the **0.55** recommendation threshold, so `evaluate_profession_decision` returns `escalate` for every profession, structurally. Seeding corpus increases what the system *knows* without increasing what it can *decide*; only human rulings promote material.

This is the first such ruling. The missing mechanism to capture more of them is filed as **`BI-8192557E`** (founder-attributed ruling capture), under EP-DECISION-TIER-REBALANCE alongside `BI-8AC099F4` (AHP pairwise cold-start).

## Note on the dimension vector

The first cut carried `blast_radius`, `reversibility` and `governance_compliance` and was **rejected by the golden-decisions guard** — it dragged the canonical `quick-vs-proper-normal` decision to margin **0.213** against a **0.3** floor. Cause: a small quick fix scores well on a negative `blast_radius` axis, so those axes made this principle quietly endorse the shortcuts it has no bearing on (the same failure recorded for PR #2157).

Recalibrated per `AUTHORING.md` to a **focused single-axis vector** (`legibility_of_consequence: 1.0`) with **`principleWeight: 0.3`** and a rationale. Note that shrinking vector numbers is a no-op — alignment is scale-invariant — so weight is the correct knob. Guard now passes:

```
[OK] quick-vs-proper-normal: winner=proper-seed-fix margin=0.3876 floor=0.3
[OK] cheap-sound-vs-rebuild-guard: winner=cheap-sound-additive margin=3.7583 floor=0.1
```

Reversibility and blast radius remain central to the rule's **prose** — they set how hard the gate presses — without being vector axes that pull unrelated decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Seed fit

This principle is canonical seeded content that ships to every install, so the Seed Contribution Fit Gate requires an explicit decision.

**`global-default`** — it is universal agent-governance doctrine, not vertical or archetype-specific. Every install that runs AI coworkers is subject to the same failure mode (trusted autonomy proceeding unsupervised into irrecoverable harm), and the guard it implies costs nothing where consequences are low because it applies only to consequential, hard-to-reverse actions. This matches the page frontmatter, which already declares `principleRingScope: universal-ring`, `principleConsumerArchetype: universal`, `principlePublic: true`, and `principleAppliesTo` covering in-platform coworkers, external coding agents, and humans.

Rejected alternatives: `archetype-scoped` / `vertical-scoped` would imply some industries do not need consequence-weighing before irreversible action, which is not true; `install-local-only` would keep founder doctrine out of the fleet it is meant to govern; `parameterize-first` has nothing to parameterize, since the rule states a posture rather than a threshold.

Seed-Fit-Decision: global-default
