### PR TITLE
feat(self-upgrade): trace a change to the upgrade that applied it (BI-F7A591AF)

### DIFF
--- a/apps/web/components/ops/ImpactItemRow.tsx
+++ b/apps/web/components/ops/ImpactItemRow.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+// apps/web/components/ops/ImpactItemRow.tsx
+//
+// One change in an upgrade impact summary, rendered as a categorised row.
+//
+// Two surfaces show the same thing and must not drift: the "What's in this
+// update?" panel (the upgrade you are deciding on) and a Run History row
+// expanded to show what a PAST upgrade carried. The badge vocabulary is the
+// operator's read of "what kind of change is this?", so it lives in one place.
+
+import type { ImpactItem } from "@/lib/self-upgrade/impact/types";
+
+const CATEGORY_LABEL: Record<ImpactItem["category"], string> = {
+  breaking: "Breaking",
+  security: "Security",
+  feature: "New",
+  performance: "Faster",
+  fix: "Fix",
+  dependency: "Dependency",
+  documentation: "Docs",
+  maintenance: "Internal",
+  other: "Other",
+};
+
+const NEUTRAL_BADGE =
+  "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] border-[var(--dpf-border)]";
+
+const CATEGORY_BADGE: Record<ImpactItem["category"], string> = {
+  breaking:
+    "bg-[var(--dpf-destructive)]/15 text-[var(--dpf-destructive)] border-[var(--dpf-destructive)]/30",
+  security:
+    "bg-[var(--dpf-destructive)]/10 text-[var(--dpf-destructive)] border-[var(--dpf-destructive)]/25",
+  feature:
+    "bg-[var(--dpf-success)]/15 text-[var(--dpf-success)] border-[var(--dpf-success)]/30",
+  performance:
+    "bg-[var(--dpf-info)]/15 text-[var(--dpf-info)] border-[var(--dpf-info)]/30",
+  fix:
+    "bg-[var(--dpf-warning)]/15 text-[var(--dpf-warning)] border-[var(--dpf-warning)]/30",
+  dependency:
+    "bg-[var(--dpf-info)]/10 text-[var(--dpf-info)] border-[var(--dpf-info)]/25",
+  documentation: NEUTRAL_BADGE,
+  maintenance: NEUTRAL_BADGE,
+  other: NEUTRAL_BADGE,
+};
+
+// Summaries persisted before a category existed replay from JSON, so a row can
+// carry a category this build has no entry for. Fall back to the neutral badge
+// and a readable label instead of rendering `undefined`.
+export function categoryLabel(category: ImpactItem["category"]): string {
+  return CATEGORY_LABEL[category] ?? "Other";
+}
+
+export function categoryBadge(category: ImpactItem["category"]): string {
+  return CATEGORY_BADGE[category] ?? NEUTRAL_BADGE;
+}
+
+export function ImpactItemRow({
+  item,
+  phrasing,
+}: {
+  item: ImpactItem;
+  phrasing?: { description: string; whyRelevant: string };
+}) {
+  // Default view: phrased text; never SHAs or paths. Fall back to the raw
+  // commit description if LLM phrasing is unavailable.
+  const description = phrasing?.description ?? item.description;
+  const whyRelevant = phrasing?.whyRelevant ?? "";
+  return (
+    <li
+      className="py-2 px-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] space-y-1"
+      data-impact-category={item.category}
+      data-touches-customizations={item.touchesCustomizations ? "true" : "false"}
+    >
+      <div className="flex items-start gap-2">
+        <span
+          className={`shrink-0 px-2 py-0.5 rounded-full border text-dpf-caption uppercase tracking-wide ${categoryBadge(item.category)}`}
+        >
+          {categoryLabel(item.category)}
+        </span>
+        <span className="text-sm text-[var(--dpf-text)]">{description}</span>
+      </div>
+      {whyRelevant && (
+        <div className="text-xs text-[var(--dpf-muted)] pl-1">
+          <span className="font-medium text-[var(--dpf-text)]">Why relevant: </span>
+          {whyRelevant}
+        </div>
+      )}
+      {item.touchesCustomizations && (
+        <div className="text-xs text-[var(--dpf-warning)] pl-1">
+          Touches your customizations — may need merge review.
+        </div>
+      )}
+    </li>
+  );
+}

--- a/apps/web/components/ops/RunImpactDetail.test.tsx
+++ b/apps/web/components/ops/RunImpactDetail.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+//
+// BI-F7A591AF: a Run History row showed status + runId + a SHA pair, so the
+// question asked after an upgrade goes wrong — which upgrade introduced this,
+// and when? — could only be answered by reading the database. These guard the
+// two properties that make the row answer it: the digest is visible without a
+// click, and the item list loads lazily for the ONE run the operator expands.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+
+const getSelfUpgradeRunImpactMock = vi.fn();
+vi.mock("@/lib/actions/promotions", () => ({
+  getSelfUpgradeRunImpact: (...a: unknown[]) => getSelfUpgradeRunImpactMock(...a),
+}));
+
+import { RunImpactDetail } from "./RunImpactDetail";
+import type { ImpactItem, UpgradeImpactSummary } from "@/lib/self-upgrade/impact/types";
+
+afterEach(() => {
+  cleanup();
+  getSelfUpgradeRunImpactMock.mockReset();
+});
+
+const DIGEST = {
+  counts: {
+    breaking: 0,
+    security: 1,
+    feature: 0,
+    fix: 0,
+    performance: 0,
+    dependency: 2,
+    documentation: 1,
+    maintenance: 0,
+    other: 0,
+    total: 4,
+  },
+  headline: "One security patch, two dependency updates and a doc addition.",
+};
+
+function item(sha: string, description: string, category: ImpactItem["category"]): ImpactItem {
+  return {
+    sha,
+    description,
+    type: "feat",
+    scope: null,
+    category,
+    breaking: false,
+    prNumber: null,
+    prTitle: null,
+    prLabels: [],
+    score: 0,
+    reasons: [],
+    touchesCustomizations: false,
+  };
+}
+
+function summary(items: ImpactItem[]): UpgradeImpactSummary {
+  return {
+    currentLineageSha: "a".repeat(40),
+    targetSha: "b".repeat(40),
+    counts: DIGEST.counts,
+    topItems: items,
+    allItems: items,
+    phrased: null,
+    enrichment: { githubReachable: true, prsEnriched: 1 },
+    generatedAt: "2026-08-01T00:00:00.000Z",
+    fromCache: true,
+  };
+}
+
+describe("RunImpactDetail", () => {
+  it("shows what the run carried without a click, and fetches nothing up front", () => {
+    render(<RunImpactDetail runId="SUR-AAAA0001" digest={DIGEST} />);
+
+    expect(screen.getByText(DIGEST.headline)).toBeTruthy();
+    expect(screen.getByText(/1 security · 2 dependency · 1 docs/)).toBeTruthy();
+    expect(getSelfUpgradeRunImpactMock).not.toHaveBeenCalled();
+  });
+
+  it("loads the item list only when expanded, and only once", async () => {
+    getSelfUpgradeRunImpactMock.mockResolvedValue(
+      summary([item("s1", "Patched an advisory", "security")]),
+    );
+    render(<RunImpactDetail runId="SUR-AAAA0001" digest={DIGEST} />);
+
+    fireEvent.click(screen.getByText("View changes"));
+
+    await waitFor(() => expect(screen.getByText("Patched an advisory")).toBeTruthy());
+    expect(getSelfUpgradeRunImpactMock).toHaveBeenCalledWith("SUR-AAAA0001");
+    expect(screen.getByText("Security")).toBeTruthy();
+
+    // Collapse and re-expand: the held summary is replayed, not re-fetched.
+    fireEvent.click(screen.getByText("Hide changes"));
+    fireEvent.click(screen.getByText("View changes"));
+    await waitFor(() => expect(screen.getByText("Patched an advisory")).toBeTruthy());
+    expect(getSelfUpgradeRunImpactMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("says so plainly when the recorded change list is gone", async () => {
+    getSelfUpgradeRunImpactMock.mockResolvedValue(null);
+    render(<RunImpactDetail runId="SUR-AAAA0001" digest={DIGEST} />);
+
+    fireEvent.click(screen.getByText("View changes"));
+
+    await waitFor(() =>
+      expect(screen.getByText(/change list is no longer/)).toBeTruthy(),
+    );
+  });
+
+  it("surfaces a load failure instead of rendering an empty list", async () => {
+    getSelfUpgradeRunImpactMock.mockRejectedValue(new Error("Unauthorized"));
+    render(<RunImpactDetail runId="SUR-AAAA0001" digest={DIGEST} />);
+
+    fireEvent.click(screen.getByText("View changes"));
+
+    await waitFor(() => expect(screen.getByText("Unauthorized")).toBeTruthy());
+  });
+});

--- a/apps/web/components/ops/RunImpactDetail.tsx
+++ b/apps/web/components/ops/RunImpactDetail.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+// apps/web/components/ops/RunImpactDetail.tsx
+//
+// "What did this upgrade carry?" for one row of the self-upgrade Run History.
+//
+// A completed run was identified by a SHA pair and a status badge, so the
+// question an operator actually asks after something goes wrong — *which*
+// upgrade introduced this, and when? — could only be answered by reading the
+// database. The summary is already persisted against the run
+// (SelfUpgradeRun.impactSummaryId → UpgradeImpactSummary), so this surfaces it:
+// the headline + counts inline, and the full item list on demand.
+//
+// Loading is lazy and per-row: a page of history ships only digests, and the
+// item list is fetched for the one run the operator expands. Read-only — it
+// carries the record, it does not re-derive it, so a run keeps reporting the
+// changes IT applied even after upstream has moved on.
+
+import { useState, useTransition } from "react";
+import { getSelfUpgradeRunImpact } from "@/lib/actions/promotions";
+import type {
+  RunImpactDigest,
+  UpgradeImpactSummary,
+} from "@/lib/self-upgrade/impact/types";
+import { UpgradeScopeRibbon } from "@/components/ops/UpgradeScopeRibbon";
+import { ImpactItemRow } from "@/components/ops/ImpactItemRow";
+import { InlineBusy } from "@/components/ui/InlineBusy";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+export function RunImpactDetail({
+  runId,
+  digest,
+}: {
+  runId: string;
+  digest: RunImpactDigest;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [summary, setSummary] = useState<UpgradeImpactSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function toggle() {
+    if (expanded) {
+      setExpanded(false);
+      return;
+    }
+    setExpanded(true);
+    // Fetch once per row — a second expand replays what is already held.
+    if (summary || isPending) return;
+    setError(null);
+    startTransition(async () => {
+      try {
+        setSummary(await getSelfUpgradeRunImpact(runId));
+      } catch (err) {
+        setError(getErrorMessage(err));
+      }
+    });
+  }
+
+  const items = summary?.allItems ?? [];
+
+  return (
+    <div className="space-y-1" data-run-impact={runId}>
+      <UpgradeScopeRibbon
+        surface="history"
+        counts={digest.counts}
+        headline={digest.headline}
+      />
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={expanded}
+        className="text-dpf-caption text-[var(--dpf-accent)] hover:underline"
+      >
+        {expanded ? "Hide changes" : "View changes"}
+      </button>
+
+      {expanded && (
+        <div className="pt-1" aria-busy={isPending || undefined}>
+          {isPending && <InlineBusy label="Loading changes…" />}
+          {error && (
+            <div className="text-dpf-caption text-[var(--dpf-destructive)]">{error}</div>
+          )}
+          {!isPending && !error && items.length === 0 && (
+            // The digest exists but the item list does not — say so plainly
+            // rather than rendering an empty box that reads as "no changes".
+            <div className="text-dpf-caption text-[var(--dpf-muted)]">
+              This run recorded a summary, but its change list is no longer
+              available.
+            </div>
+          )}
+          {items.length > 0 && (
+            <ul className="space-y-1.5" data-run-impact-items={runId}>
+              {items.map((item, idx) => (
+                <ImpactItemRow
+                  key={item.sha}
+                  item={item}
+                  phrasing={
+                    // Phrasings are positional against topItems only; anything
+                    // past that renders its raw commit description.
+                    idx < (summary?.topItems.length ?? 0)
+                      ? summary?.phrased?.itemPhrasings[idx]
+                      : undefined
+                  }
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -7,6 +7,7 @@ import { CoworkerActivityInspectionLink } from "./CoworkerActivityInspectionLink
 import UpgradeImpactPanel from "@/components/ops/UpgradeImpactPanel";
 import type { SummaryResult, RunImpactDigest } from "@/lib/self-upgrade/impact/types";
 import { UpgradeScopeRibbon } from "@/components/ops/UpgradeScopeRibbon";
+import { RunImpactDetail } from "@/components/ops/RunImpactDetail";
 import { StatusBadge } from "@/components/ui/report-kit";
 import { describeSkipReason } from "@/lib/self-upgrade/skip-reason";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
@@ -1097,6 +1098,21 @@ export default function SelfUpgradeClient({
                           >
                             {reasonText}
                           </span>
+                        </td>
+                      </tr>
+                    )}
+                    {/* What this run actually carried. A SHA pair cannot answer
+                        "which upgrade introduced this?" — the summary the run
+                        recorded can, and it is already persisted against the
+                        run. The item-level detail loads only when expanded. */}
+                    {run.impact && (
+                      <tr data-run-impact-for={run.runId}>
+                        <td />
+                        <td colSpan={3} className="px-3 pb-2 pt-0 align-top">
+                          <RunImpactDetail
+                            runId={run.runId}
+                            digest={run.impact}
+                          />
                         </td>
                       </tr>
                     )}

--- a/apps/web/components/ops/UpgradeImpactPanel.tsx
+++ b/apps/web/components/ops/UpgradeImpactPanel.tsx
@@ -20,90 +20,9 @@ import { CollapsibleList } from "@/components/ui/report-kit";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { InlineBusy } from "@/components/ui/InlineBusy";
 import { Skeleton } from "@/components/ui/Skeleton";
-
-const CATEGORY_LABEL: Record<ImpactItem["category"], string> = {
-  breaking: "Breaking",
-  security: "Security",
-  feature: "New",
-  performance: "Faster",
-  fix: "Fix",
-  dependency: "Dependency",
-  documentation: "Docs",
-  maintenance: "Internal",
-  other: "Other",
-};
-
-const NEUTRAL_BADGE =
-  "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] border-[var(--dpf-border)]";
-
-const CATEGORY_BADGE: Record<ImpactItem["category"], string> = {
-  breaking:
-    "bg-[var(--dpf-destructive)]/15 text-[var(--dpf-destructive)] border-[var(--dpf-destructive)]/30",
-  security:
-    "bg-[var(--dpf-destructive)]/10 text-[var(--dpf-destructive)] border-[var(--dpf-destructive)]/25",
-  feature:
-    "bg-[var(--dpf-success)]/15 text-[var(--dpf-success)] border-[var(--dpf-success)]/30",
-  performance:
-    "bg-[var(--dpf-info)]/15 text-[var(--dpf-info)] border-[var(--dpf-info)]/30",
-  fix:
-    "bg-[var(--dpf-warning)]/15 text-[var(--dpf-warning)] border-[var(--dpf-warning)]/30",
-  dependency:
-    "bg-[var(--dpf-info)]/10 text-[var(--dpf-info)] border-[var(--dpf-info)]/25",
-  documentation: NEUTRAL_BADGE,
-  maintenance: NEUTRAL_BADGE,
-  other: NEUTRAL_BADGE,
-};
-
-// Summaries persisted before a category existed replay from JSON, so a row can
-// carry a category this build has no entry for. Fall back to the neutral badge
-// and a readable label instead of rendering `undefined`.
-function categoryLabel(category: ImpactItem["category"]): string {
-  return CATEGORY_LABEL[category] ?? "Other";
-}
-
-function categoryBadge(category: ImpactItem["category"]): string {
-  return CATEGORY_BADGE[category] ?? NEUTRAL_BADGE;
-}
-
-function ItemRow({
-  item,
-  phrasing,
-}: {
-  item: ImpactItem;
-  phrasing?: { description: string; whyRelevant: string };
-}) {
-  // Default view: phrased text; never SHAs or paths. Fall back to the raw
-  // commit description if LLM phrasing is unavailable.
-  const description = phrasing?.description ?? item.description;
-  const whyRelevant = phrasing?.whyRelevant ?? "";
-  return (
-    <li
-      className="py-2 px-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] space-y-1"
-      data-impact-category={item.category}
-      data-touches-customizations={item.touchesCustomizations ? "true" : "false"}
-    >
-      <div className="flex items-start gap-2">
-        <span
-          className={`shrink-0 px-2 py-0.5 rounded-full border text-[10px] uppercase tracking-wide ${categoryBadge(item.category)}`}
-        >
-          {categoryLabel(item.category)}
-        </span>
-        <span className="text-sm text-[var(--dpf-text)]">{description}</span>
-      </div>
-      {whyRelevant && (
-        <div className="text-xs text-[var(--dpf-muted)] pl-1">
-          <span className="font-medium text-[var(--dpf-text)]">Why relevant: </span>
-          {whyRelevant}
-        </div>
-      )}
-      {item.touchesCustomizations && (
-        <div className="text-xs text-[var(--dpf-warning)] pl-1">
-          Touches your customizations — may need merge review.
-        </div>
-      )}
-    </li>
-  );
-}
+// The categorised row (badge vocabulary included) is shared with the Run
+// History detail view — one definition, two surfaces.
+import { ImpactItemRow } from "./ImpactItemRow";
 
 // Shape-of-content placeholder shown while the summary generates (on the
 // auto-fetch on first view, or a manual (re)summarize). Mirrors the OK-result
@@ -338,14 +257,14 @@ export default function UpgradeImpactPanel({
             >
               {[
                 ...result.summary.topItems.map((item, idx) => (
-                  <ItemRow
+                  <ImpactItemRow
                     key={item.sha}
                     item={item}
                     phrasing={result.summary.phrased?.itemPhrasings[idx]}
                   />
                 )),
                 ...remainingItems.map((item) => (
-                  <ItemRow key={item.sha} item={item} />
+                  <ImpactItemRow key={item.sha} item={item} />
                 )),
               ]}
             </CollapsibleList>

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -21,6 +21,7 @@ vi.mock("@dpf/db", () => ({
     selfUpgradeRun: {
       create: vi.fn(),
       findMany: vi.fn(),
+      findUnique: vi.fn(),
     },
   },
 }));
@@ -54,6 +55,8 @@ vi.mock("@/lib/self-upgrade/run-store", () => ({
 vi.mock("@/lib/self-upgrade/impact", () => ({
   getCurrentImpactSummaryId: vi.fn().mockResolvedValue(null),
   loadRunImpactDigest: vi.fn().mockResolvedValue(null),
+  loadRunImpactDigests: vi.fn().mockResolvedValue(new Map()),
+  loadRunImpactSummary: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/lib/self-upgrade/window", () => ({
@@ -162,7 +165,11 @@ import { getSelfUpgradeConfig } from "@/lib/self-upgrade/config";
 import { resolveTargetSha, isShaFresh } from "@/lib/self-upgrade/version";
 import { getDeployedSha } from "@/lib/self-upgrade/completion";
 import { createRun, getLatestRun, getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
-import { getCurrentImpactSummaryId } from "@/lib/self-upgrade/impact";
+import {
+  getCurrentImpactSummaryId,
+  loadRunImpactDigests,
+  loadRunImpactSummary,
+} from "@/lib/self-upgrade/impact";
 import { isUpgradeWindowOpen, nextUpgradeWindowOpen } from "@/lib/self-upgrade/window";
 import { resolveAutoUpgradeWindow, nextAutoWindowOpen } from "@/lib/self-upgrade/auto-window";
 import { getActiveSelfUpgradeBlackout } from "@/lib/self-upgrade/blackout";
@@ -171,6 +178,7 @@ import { inngest } from "@/lib/queue/inngest-client";
 import { revalidatePath } from "next/cache";
 import { runSelfUpgradeRollback, SelfUpgradeRollbackError } from "@/lib/self-upgrade/rollback";
 import {
+  getSelfUpgradeRunImpact,
   getSelfUpgradeStatus,
   listSelfUpgradeRuns,
   rollbackSelfUpgrade,
@@ -688,6 +696,74 @@ describe("listSelfUpgradeRuns – pagination", () => {
     expect(prisma.selfUpgradeRun.findMany).toHaveBeenCalledWith(
       expect.objectContaining({ orderBy: { createdAt: "desc" } }),
     );
+  });
+});
+
+// BI-F7A591AF: a history row identified only by a SHA pair could not answer
+// "which upgrade introduced this?". Each row now carries the digest of the
+// summary the run recorded — batched, never a query per row.
+describe("listSelfUpgradeRuns – per-run impact digest", () => {
+  it("attaches each run's own digest, keyed by its recorded summary id", async () => {
+    vi.mocked(prisma.selfUpgradeRun.findMany).mockResolvedValue(
+      [
+        { ...mockRunRow1, impactSummaryId: "UIS-1" },
+        { ...mockRunRow2, impactSummaryId: null },
+      ] as never,
+    );
+    vi.mocked(loadRunImpactDigests).mockResolvedValue(
+      new Map([["UIS-1", { counts: { total: 4 }, headline: "Four changes." }]]) as never,
+    );
+
+    const result = await listSelfUpgradeRuns({ limit: 20 });
+
+    expect(loadRunImpactDigests).toHaveBeenCalledTimes(1);
+    expect(loadRunImpactDigests).toHaveBeenCalledWith(["UIS-1", null]);
+    expect(result.runs[0]!.impact).toMatchObject({ headline: "Four changes." });
+    // A run that recorded no summary reports null rather than borrowing another's.
+    expect(result.runs[1]!.impact).toBeNull();
+  });
+
+  it("asks for digests only for the page it returns, not the lookahead row", async () => {
+    vi.mocked(prisma.selfUpgradeRun.findMany).mockResolvedValue(
+      [
+        { ...mockRunRow1, impactSummaryId: "UIS-1" },
+        { ...mockRunRow2, impactSummaryId: "UIS-2" },
+      ] as never,
+    );
+    vi.mocked(loadRunImpactDigests).mockResolvedValue(new Map() as never);
+
+    await listSelfUpgradeRuns({ limit: 1 });
+
+    expect(loadRunImpactDigests).toHaveBeenCalledWith(["UIS-1"]);
+  });
+});
+
+describe("getSelfUpgradeRunImpact", () => {
+  it("loads the full summary by the run's OWN recorded id", async () => {
+    vi.mocked(prisma.selfUpgradeRun.findUnique).mockResolvedValue(
+      { impactSummaryId: "UIS-9" } as never,
+    );
+    vi.mocked(loadRunImpactSummary).mockResolvedValue({ targetSha: "b" } as never);
+
+    const out = await getSelfUpgradeRunImpact("SUR-AAAA0001");
+
+    expect(loadRunImpactSummary).toHaveBeenCalledWith("UIS-9");
+    expect(out).toMatchObject({ targetSha: "b" });
+  });
+
+  it("returns null for a run that recorded no summary", async () => {
+    vi.mocked(prisma.selfUpgradeRun.findUnique).mockResolvedValue(
+      { impactSummaryId: null } as never,
+    );
+    vi.mocked(loadRunImpactSummary).mockResolvedValue(null as never);
+
+    expect(await getSelfUpgradeRunImpact("SUR-BBBB0002")).toBeNull();
+    expect(loadRunImpactSummary).toHaveBeenCalledWith(null);
+  });
+
+  it("rejects users without view_operations permission", async () => {
+    vi.mocked(can).mockReturnValue(false);
+    await expect(getSelfUpgradeRunImpact("SUR-AAAA0001")).rejects.toThrow("Unauthorized");
   });
 });
 

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -14,7 +14,16 @@ import { resolveTargetSha, isShaFresh } from "@/lib/self-upgrade/version";
 import { getDeployedSha } from "@/lib/self-upgrade/completion";
 import { getJobEngineHealth } from "@/lib/queue/job-engine-health";
 import { createRun, failRun, getLatestRun, getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
-import { getCurrentImpactSummaryId, loadRunImpactDigest } from "@/lib/self-upgrade/impact";
+import {
+  getCurrentImpactSummaryId,
+  loadRunImpactDigest,
+  loadRunImpactDigests,
+  loadRunImpactSummary,
+} from "@/lib/self-upgrade/impact";
+import type {
+  RunImpactDigest,
+  UpgradeImpactSummary,
+} from "@/lib/self-upgrade/impact/types";
 import {
   isStoreOpen,
   isUpgradeWindowOpen,
@@ -532,6 +541,14 @@ export type SelfUpgradeRunDto = {
   completedAt: Date | null;
   failureLog: string | null;    // schema: failureLog (was: error)
   createdAt: Date;
+  /** The summary this run carried, when one was recorded at launch. */
+  impactSummaryId?: string | null;
+  /**
+   * "What did this run carry?" — headline + counts for the history row, so an
+   * adverse change can be traced back to the upgrade that introduced it without
+   * a DB read. Null when the run recorded no summary.
+   */
+  impact?: RunImpactDigest | null;
 };
 
 export async function listSelfUpgradeRuns(opts?: {
@@ -560,13 +577,42 @@ export async function listSelfUpgradeRuns(opts?: {
       completedAt: true,
       failureLog: true,
       createdAt: true,
+      impactSummaryId: true,
     },
   });
 
   const hasNext = rows.length > limit;
-  const runs = hasNext ? rows.slice(0, limit) : rows;
-  const nextCursor = hasNext ? runs[runs.length - 1].runId : null;
+  const page = hasNext ? rows.slice(0, limit) : rows;
+  const nextCursor = hasNext ? page[page.length - 1].runId : null;
+
+  // One batched, Postgres-projected read for the whole page — never a query per
+  // row, and never the full item list of every summary (see
+  // getPersistedSummaryDigests). Best-effort: a digest read failure leaves the
+  // rows as they were rather than failing the history table.
+  const digests = await loadRunImpactDigests(page.map((r) => r.impactSummaryId));
+  const runs = page.map((run) => ({
+    ...run,
+    impact: run.impactSummaryId ? (digests.get(run.impactSummaryId) ?? null) : null,
+  }));
+
   return { runs, nextCursor };
+}
+
+/**
+ * The item-level detail behind one Run History row, fetched only when the
+ * operator expands it. Read-only, ops-gated, and loaded by the run's OWN
+ * recorded summary id — so a completed run keeps reporting the changes it
+ * applied even after upstream has moved on.
+ */
+export async function getSelfUpgradeRunImpact(
+  runId: string,
+): Promise<UpgradeImpactSummary | null> {
+  await requireOpsAccess();
+  const run = await prisma.selfUpgradeRun.findUnique({
+    where: { runId },
+    select: { impactSummaryId: true },
+  });
+  return loadRunImpactSummary(run?.impactSummaryId ?? null);
 }
 
 export async function getSelfUpgradeStatus() {

--- a/apps/web/lib/self-upgrade/impact/index.ts
+++ b/apps/web/lib/self-upgrade/impact/index.ts
@@ -18,6 +18,7 @@ import { cacheKey, getCached, setCached } from "./cache";
 import {
   getPersistedSummary,
   getPersistedSummaryById,
+  getPersistedSummaryDigests,
   getPersistedSummaryRow,
   persistSummary,
 } from "./store";
@@ -277,6 +278,37 @@ export async function loadRunImpactDigest(
   if (!summary) return null;
   const headline = summary.phrased?.headline?.trim();
   return { counts: summary.counts, headline: headline ? headline : null };
+}
+
+/**
+ * Digests for a page of runs — "what did each past upgrade carry?".
+ *
+ * Keyed by the run's OWN `impactSummaryId` for the same reason
+ * `loadRunImpactDigest` is: a completed run must keep showing the changes IT
+ * applied, and a (lineage, target) re-derivation drifts as soon as the upstream
+ * target advances past that run's endpoints. One batched read for the whole
+ * page, projected in Postgres, so the history table does not fan out into a
+ * query per row or ship every item of every summary.
+ */
+export async function loadRunImpactDigests(
+  impactSummaryIds: Array<string | null | undefined>,
+): Promise<Map<string, RunImpactDigest>> {
+  const ids = impactSummaryIds.filter((id): id is string => !!id);
+  if (ids.length === 0) return new Map();
+  return getPersistedSummaryDigests(ids).catch(() => new Map());
+}
+
+/**
+ * The full persisted summary a given run carried — the item-level detail behind
+ * a Run History row, loaded on demand when the operator expands it. Returns
+ * null when the run recorded no summary (a scheduled run that never generated
+ * one) or the row has since been removed.
+ */
+export async function loadRunImpactSummary(
+  impactSummaryId: string | null | undefined,
+): Promise<UpgradeImpactSummary | null> {
+  if (!impactSummaryId) return null;
+  return getPersistedSummaryById(impactSummaryId).catch(() => null);
 }
 
 /**

--- a/apps/web/lib/self-upgrade/impact/store.test.ts
+++ b/apps/web/lib/self-upgrade/impact/store.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const findUniqueMock = vi.fn();
 const upsertMock = vi.fn();
+const queryRawMock = vi.fn();
 
 vi.mock("@dpf/db", () => ({
   prisma: {
@@ -9,11 +10,17 @@ vi.mock("@dpf/db", () => ({
       findUnique: (...a: unknown[]) => findUniqueMock(...a),
       upsert: (...a: unknown[]) => upsertMock(...a),
     },
+    $queryRaw: (...a: unknown[]) => queryRawMock(...a),
   },
   Prisma: {},
 }));
 
-import { getPersistedSummary, getPersistedSummaryRow, persistSummary } from "./store";
+import {
+  getPersistedSummary,
+  getPersistedSummaryDigests,
+  getPersistedSummaryRow,
+  persistSummary,
+} from "./store";
 import type { UpgradeImpactSummary } from "./types";
 
 const LINEAGE = "a".repeat(40);
@@ -37,6 +44,7 @@ function summary(overrides: Partial<UpgradeImpactSummary> = {}): UpgradeImpactSu
 beforeEach(() => {
   findUniqueMock.mockReset();
   upsertMock.mockReset();
+  queryRawMock.mockReset();
 });
 
 describe("impact store", () => {
@@ -82,5 +90,36 @@ describe("impact store", () => {
     expect(arg.create.generatedAt).toBeInstanceOf(Date);
     // update overwrites the blob in place (idempotent recompute).
     expect(arg.update.summary).toMatchObject({ targetSha: TARGET });
+  });
+
+  // The Run History table needs two fields per row. Reading the whole `summary`
+  // JSON to get them would haul every item of every summary on the page, so the
+  // projection happens in Postgres.
+  it("getPersistedSummaryDigests projects counts + headline and keys by id", async () => {
+    queryRawMock.mockResolvedValue([
+      { id: "UIS-1", counts: { breaking: 1, total: 4 }, headline: " Four changes. " },
+      { id: "UIS-2", counts: { breaking: 0, total: 2 }, headline: null },
+    ]);
+    const out = await getPersistedSummaryDigests(["UIS-1", "UIS-2"]);
+    expect(out.get("UIS-1")).toEqual({
+      counts: { breaking: 1, total: 4 },
+      headline: "Four changes.",
+    });
+    expect(out.get("UIS-2")?.headline).toBeNull();
+  });
+
+  it("getPersistedSummaryDigests de-duplicates ids and skips the query when empty", async () => {
+    expect((await getPersistedSummaryDigests([])).size).toBe(0);
+    expect(queryRawMock).not.toHaveBeenCalled();
+
+    queryRawMock.mockResolvedValue([]);
+    await getPersistedSummaryDigests(["UIS-1", "UIS-1", ""]);
+    // Tagged-template call: values are passed as trailing args, never inlined.
+    expect(queryRawMock.mock.calls[0]!.slice(1)).toEqual([["UIS-1"]]);
+  });
+
+  it("getPersistedSummaryDigests drops a row whose counts are unreadable", async () => {
+    queryRawMock.mockResolvedValue([{ id: "UIS-3", counts: null, headline: "x" }]);
+    expect((await getPersistedSummaryDigests(["UIS-3"])).size).toBe(0);
   });
 });

--- a/apps/web/lib/self-upgrade/impact/store.ts
+++ b/apps/web/lib/self-upgrade/impact/store.ts
@@ -11,7 +11,7 @@
 // cheap to recompute, so they stay in the L1 cache only.
 
 import { prisma, Prisma } from "@dpf/db";
-import type { UpgradeImpactSummary } from "./types";
+import type { ImpactCategoryCounts, UpgradeImpactSummary } from "./types";
 
 function compoundKey(currentLineageSha: string, targetSha: string) {
   return { currentLineageSha_targetSha: { currentLineageSha, targetSha } };
@@ -59,6 +59,44 @@ export async function getPersistedSummaryRow(
   });
   if (!row) return null;
   return { id: row.id, summary: row.summary as UpgradeImpactSummary };
+}
+
+/**
+ * Batch-read the DIGEST (headline + counts) for a set of summary ids.
+ *
+ * The Run History table needs "what did this run carry?" for every visible row.
+ * Reading each row's full `summary` JSON to get two fields would haul the entire
+ * `allItems` array for a page of runs — potentially megabytes for a large
+ * upgrade — so the projection happens in Postgres via jsonb paths and only the
+ * two fields cross the wire. Bounded by the caller's page size; ids are
+ * parameterised, never interpolated.
+ */
+export async function getPersistedSummaryDigests(
+  ids: string[],
+): Promise<Map<string, { counts: ImpactCategoryCounts; headline: string | null }>> {
+  const unique = Array.from(new Set(ids.filter((id) => typeof id === "string" && id.length > 0)));
+  const out = new Map<string, { counts: ImpactCategoryCounts; headline: string | null }>();
+  if (unique.length === 0) return out;
+
+  const rows = await prisma.$queryRaw<
+    Array<{ id: string; counts: unknown; headline: string | null }>
+  >`
+    SELECT id,
+           summary -> 'counts' AS counts,
+           summary -> 'phrased' ->> 'headline' AS headline
+      FROM "UpgradeImpactSummary"
+     WHERE id = ANY(${unique})
+  `;
+
+  for (const row of rows) {
+    if (!row.counts || typeof row.counts !== "object") continue;
+    const headline = row.headline?.trim();
+    out.set(row.id, {
+      counts: row.counts as ImpactCategoryCounts,
+      headline: headline ? headline : null,
+    });
+  }
+  return out;
 }
 
 /**

--- a/apps/web/lib/self-upgrade/run-types.ts
+++ b/apps/web/lib/self-upgrade/run-types.ts
@@ -17,6 +17,8 @@ export type SelfUpgradeRunStatus =
   | "completing"
   | "rolled_back";
 
+import type { RunImpactDigest } from "@/lib/self-upgrade/impact/types";
+
 export type LatestRun = {
   runId: string;
   status: string;
@@ -30,6 +32,15 @@ export type LatestRun = {
   completionEvidence?: unknown;
   failureLog: string | null;
   createdAt: Date | string;
+  /** The impact summary this run carried, when one was recorded at launch. */
+  impactSummaryId?: string | null;
+  /**
+   * "What did this run carry?" — the headline + counts persisted with the run,
+   * so Run History answers which upgrade introduced a change instead of leaving
+   * an operator to correlate a SHA pair by hand. Null when no summary was
+   * recorded (a scheduled run that never generated one).
+   */
+  impact?: RunImpactDigest | null;
 };
 
 export type QuiescenceBlockerLine = {

--- a/docs/superpowers/decisions/2026-08-15-run-history-impact-digest.md
+++ b/docs/superpowers/decisions/2026-08-15-run-history-impact-digest.md
@@ -1,0 +1,75 @@
+# Run History — carry each upgrade's summary with the run that applied it
+
+**Date:** 2026-08-15
+**Surface:** `/ops/self-upgrade` → Run History (`apps/web/components/ops/SelfUpgradeClient.tsx`)
+**Backlog:** BI-F7A591AF
+**Kernel decision:** DI-E3CC179DC0C2, profile `mark-dpf-platform`
+**UX-fit manifest:** `docs/ux-fit/2026-08-15-run-history-impact-digest.ux-fit.json`
+
+## Problem
+
+When something breaks after an upgrade, the operator's question is *which*
+upgrade introduced it, and when. Run History could not answer it: each row was a
+status badge, a run id, a 12-char SHA pair and a timestamp. Correlating a
+symptom to a change meant reading `UpgradeImpactSummary` out of Postgres by
+hand.
+
+The record itself was never missing. It was unreachable:
+
+- `UpgradeImpactSummary` persists the full computed summary (`schema.prisma`).
+- `SelfUpgradeRun.impactSummaryId` pins the exact summary a run carried.
+- `loadRunImpactDigest` already surfaces that digest — but only for the *latest*
+  run's card.
+- `change-record.ts` mirrors headline + counts into the ChangeRequest register.
+
+So this is a surfacing change, not new substrate.
+
+## Decision
+
+Each history row carries its own digest (headline + counts ribbon) inline, and
+expands on demand to the item list that run applied.
+
+Three properties are load-bearing:
+
+1. **Loaded by the run's OWN `impactSummaryId`** — never a (lineage, target)
+   re-derivation, which drifts the moment upstream advances past that run's
+   endpoints. A completed run must keep reporting the changes *it* applied. This
+   is the same rule the Latest Run card follows.
+2. **One batched read per page, projected in Postgres.** `getPersistedSummaryDigests`
+   selects `summary->'counts'` and `summary->'phrased'->>'headline'` for the
+   page's ids via a parameterised `ANY($1)` — not a query per row, and not the
+   full `allItems` array of every summary on the page. Digests are fetched for
+   the returned page only, never the pagination lookahead row.
+3. **The item list is lazy and per-row.** Expanding one run fetches that run's
+   summary through the ops-gated `getSelfUpgradeRunImpact` action, once, and
+   holds it across collapse/expand.
+
+The categorised row itself (`ImpactItemRow`) is now shared with the "What's in
+this update?" panel rather than duplicated — the badge vocabulary is the
+operator's read of "what kind of change is this?" and must not drift between the
+upgrade you are deciding on and the upgrade you are diagnosing.
+
+## Kernel consultation
+
+`principle_decide` (DI-E3CC179DC0C2) scored digest-only vs digest + lazy
+disclosure vs a full inline list for every row. Result: **digest +
+lazy disclosure** — composite 10.560 vs 7.268 (digest-only) and 5.685 (full
+inline), margin 3.292, high confidence, no commandment conflict. The full inline
+list scored worst: it is the only option that scores badly on
+`human_cognitive_load` while adding no answer the disclosure does not already
+give.
+
+## Failure modes handled
+
+- A run that recorded no summary shows no digest — it does not borrow a
+  neighbour's.
+- A digest read failure leaves the rows as they were; the history table still
+  renders.
+- An expanded row whose summary row has since gone says so in words rather than
+  rendering an empty list that reads as "no changes".
+
+## Related
+
+- [Upgrade impact change categories](2026-08-15-upgrade-impact-change-categories.md) — the badge taxonomy these rows render (BI-6EC1350E).
+- [Latest Run card — human-readable upgrade scope](2026-07-15-self-upgrade-run-card-human-readable-scope.md) — the same digest, one surface earlier.
+- [Self-upgrade change register design](../specs/2026-06-16-self-upgrade-change-register-design.md) — the ITIL shadow record that carries the same headline + counts.

--- a/docs/ux-fit/2026-08-15-run-history-impact-digest.ux-fit.json
+++ b/docs/ux-fit/2026-08-15-run-history-impact-digest.ux-fit.json
@@ -1,0 +1,18 @@
+{
+  "version": "1",
+  "decidedOption": "digest-plus-lazy-disclosure",
+  "decisionInteractionId": "DI-E3CC179DC0C2",
+  "scope": {
+    "files": [
+      "apps/web/components/ops/RunImpactDetail.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "digest-only",
+      "digest-plus-lazy-disclosure",
+      "full-inline-list"
+    ]
+  }
+}

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -8,7 +8,7 @@ apps/web/components/agent/AgentMessageInput.tsx	1034
 apps/web/components/ea/EaCanvas.tsx	1047
 apps/web/components/inventory/TopologyGraph.tsx	1030
 apps/web/components/ops/SelfUpgradeClient.test.tsx	1118
-apps/web/components/ops/SelfUpgradeClient.tsx	1123
+apps/web/components/ops/SelfUpgradeClient.tsx	1139
 apps/web/components/platform/EffectivePermissionsPanel.tsx	844
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	923
 apps/web/components/storefront/SlotBookingFlow.tsx	1015
@@ -22,12 +22,12 @@ apps/web/lib/actions/ai-providers.ts	914
 apps/web/lib/actions/build-governed.test.ts	1149
 apps/web/lib/actions/build.ts	1744
 apps/web/lib/actions/compliance.ts	867
-apps/web/lib/actions/crm.ts	1068
+apps/web/lib/actions/crm.ts	1043
 apps/web/lib/actions/ea.ts	918
 apps/web/lib/actions/mcp-tokens.test.ts	1254
 apps/web/lib/actions/platform-dev-config.ts	1254
-apps/web/lib/actions/promotions.self-upgrade.test.ts	1022
-apps/web/lib/actions/promotions.ts	948
+apps/web/lib/actions/promotions.self-upgrade.test.ts	1098
+apps/web/lib/actions/promotions.ts	994
 apps/web/lib/actions/tax-remittance.test.ts	1080
 apps/web/lib/actions/tax-remittance.ts	978
 apps/web/lib/ai-operations-map/load-map-data.test.ts	928

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -5956,6 +5956,13 @@
     "longSentences": 0,
     "textMass": 41
   },
+  "apps/web/components/ops/ImpactItemRow.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
   "apps/web/components/ops/ImprovementsClient.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
@@ -6026,6 +6033,13 @@
     "longSentences": 0,
     "textMass": 47
   },
+  "apps/web/components/ops/RunImpactDetail.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 21
+  },
   "apps/web/components/ops/SelfUpgradeClient.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
@@ -6066,7 +6080,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 1,
-    "textMass": 88
+    "textMass": 78
   },
   "apps/web/components/ops/backlog-form-assist.ts": {
     "vocabulary": 0,


### PR DESCRIPTION
## What

When something breaks after an upgrade, the operator's question is **which** upgrade introduced it, and when. Run History could not answer it — a row was a status badge, a run id, a 12-char SHA pair and a timestamp, so correlating a symptom to a change meant reading `UpgradeImpactSummary` out of Postgres by hand.

The record was never missing, only unreachable: `SelfUpgradeRun.impactSummaryId` already pins the exact summary each run carried, and the Latest Run card already renders that digest. This surfaces it per history row.

## Change

- Each history row shows what that run carried — headline + counts ribbon — inline.
- A per-row **View changes** disclosure lazily loads that run's persisted item list, once, held across collapse/expand.
- The categorised item row moves to a shared `ImpactItemRow`, so the badge vocabulary cannot drift between the upgrade you are *deciding on* (the "What's in this update?" panel) and the one you are *diagnosing*.

Three properties are load-bearing:

1. **Loaded by the run's OWN `impactSummaryId`** — never a (lineage, target) re-derivation, which drifts the moment upstream advances past that run's endpoints. Same rule the Latest Run card follows.
2. **One batched read per page, projected in Postgres** — `getPersistedSummaryDigests` selects `summary->'counts'` and `summary->'phrased'->>'headline'` for the page's ids via a parameterised `ANY($1)`. Not a query per row; not the full `allItems` array of every summary on the page; not the pagination lookahead row.
3. **Ops-gated and read-only** — `getSelfUpgradeRunImpact` goes through `requireOpsAccess()` and carries the record rather than re-deriving it.

Failure modes handled: a run with no recorded summary shows no digest (it never borrows a neighbour's); a digest read failure leaves the table rendering as before; an expanded row whose summary row is gone says so in words rather than showing an empty list that reads as "no changes".

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/decisions/2026-07-15-self-upgrade-run-card-human-readable-scope.md`, `docs/superpowers/decisions/2026-08-15-upgrade-impact-change-categories.md`, `docs/superpowers/specs/2026-06-16-self-upgrade-change-register-design.md`, `docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md`
- Current code substrate reviewed: `apps/web/lib/self-upgrade/impact/*`, `promotions.ts` (`listSelfUpgradeRuns`, `getSelfUpgradeStatus`), `SelfUpgradeClient.tsx`, `UpgradeScopeRibbon.tsx`, `UpgradeImpactPanel.tsx`, `schema.prisma` (`UpgradeImpactSummary`, `SelfUpgradeRun`)
- Source of truth: `SelfUpgradeRun.impactSummaryId` → `UpgradeImpactSummary`; the 2026-07-15 run-card decision governs how a run's scope is surfaced.
- Decision: surface the existing record, add no new persistence. Recorded at `docs/superpowers/decisions/2026-08-15-run-history-impact-digest.md`.
- Kernel: `DI-E3CC179DC0C2` — digest + lazy disclosure over digest-only and a full inline list (composite 10.560 vs 7.268 vs 5.685, high confidence, no commandment conflict). UX-fit manifest: `docs/ux-fit/2026-08-15-run-history-impact-digest.ux-fit.json`.

## Verification

- `pnpm --filter web exec vitest run lib/self-upgrade lib/actions/promotions components/ops` — 71 files, 865 tests, green. New coverage: `RunImpactDetail.test.tsx` (digest without a click, lazy single fetch, missing-list wording, load-failure surfacing), `store.test.ts` (jsonb projection, id de-duplication, unreadable-counts row dropped), and action tests asserting the digest is batched, page-scoped, per-run, and ops-gated.
- `pnpm --filter web build` — exit 0.
- `pnpm typecheck` — clean.
- `pnpm run pregate` — local-CI gate passed (`6d1cb23a0d56`, evidence `cmsulj2y91gq501ppht1kvdqe`).
- Ratchets re-baselined after rebasing onto current main: module-size (three files grew), prose-lint (two new files).
- Not done: live-portal UX verification — the history table renders from the deployed image, so it is observable on the install only after this ships through `/ops/self-upgrade`. Component-level rendering is covered by the jsdom tests above.

## Related

Follows #4320 (BI-6EC1350E), which replaced the catch-all `other` category these rows render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)