### PR TITLE
feat(decision): repo-backed locator resolver for the evidence re-verifier

### DIFF
--- a/apps/web/lib/decision/locator-resolver.test.ts
+++ b/apps/web/lib/decision/locator-resolver.test.ts
@@ -1,0 +1,165 @@
+// Anti-fabrication regression suite for the repo-backed LocatorResolver
+// (BI-8192557E). The threat this guards: a citation that is STRUCTURALLY
+// well-formed — it normalizes to a StructuredLocator and passes admissibility —
+// but is FABRICATED. A plausible filePath+line that does not exist, or a real
+// file that never contained the claimed excerpt, must degrade the affected
+// dimension rather than certify it.
+//
+// Written before the resolver existed (dpf-tdd): admissibility is not truth.
+
+import { describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createRepoLocatorResolver } from "./locator-resolver";
+import { reverifyCitations, type RecordedCitation } from "./evidence-reverifier";
+
+async function fixtureRepo(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "dpf-locator-"));
+  await mkdir(join(root, "apps", "web", "lib"), { recursive: true });
+  await writeFile(
+    join(root, "apps", "web", "lib", "real.ts"),
+    ["export function real() {", "  return \"grounded value\";", "}", ""].join("\n"),
+    "utf8",
+  );
+  await mkdir(join(root, "docs"), { recursive: true });
+  await writeFile(join(root, "docs", "spec.md"), "# Spec\n\nThe gate is fail-closed.\n", "utf8");
+  return root;
+}
+
+function citation(over: Partial<RecordedCitation> & Pick<RecordedCitation, "locator">): RecordedCitation {
+  return {
+    optionId: over.optionId ?? "opt-a",
+    dimensionKey: over.dimensionKey ?? "evidence_density",
+    recordedExcerpt: over.recordedExcerpt ?? null,
+    locator: over.locator,
+  };
+}
+
+describe("createRepoLocatorResolver — fabrication resistance", () => {
+  it("DEGRADES a well-formed citation whose file does not exist", async () => {
+    const root = await fixtureRepo();
+    const resolve = createRepoLocatorResolver({ repoRoot: root });
+
+    // Plausible shape, plausible path, entirely invented.
+    const report = await reverifyCitations(
+      [citation({ locator: { sourceType: "code", filePath: "apps/web/lib/totally-invented.ts", line: 42 } })],
+      resolve,
+    );
+
+    expect(report.allConfirmed).toBe(false);
+    expect(report.unresolved).toBe(1);
+    expect(report.degrade).toEqual([{ optionId: "opt-a", dimensionKey: "evidence_density" }]);
+  });
+
+  it("DEGRADES a real file that does not contain the claimed excerpt", async () => {
+    const root = await fixtureRepo();
+    const resolve = createRepoLocatorResolver({ repoRoot: root });
+
+    const report = await reverifyCitations(
+      [
+        citation({
+          locator: { sourceType: "code", filePath: "apps/web/lib/real.ts" },
+          recordedExcerpt: "return \"a value that was never there\";",
+        }),
+      ],
+      resolve,
+    );
+
+    expect(report.degraded).toBe(1);
+    expect(report.allConfirmed).toBe(false);
+    expect(report.results[0]?.verdict).toBe("degraded");
+    // The live excerpt is reported so a reviewer can see what IS there.
+    expect(report.results[0]?.liveExcerpt).toContain("grounded value");
+  });
+
+  it("CONFIRMS a citation whose excerpt is genuinely present", async () => {
+    const root = await fixtureRepo();
+    const resolve = createRepoLocatorResolver({ repoRoot: root });
+
+    const report = await reverifyCitations(
+      [
+        citation({
+          locator: { sourceType: "code", filePath: "apps/web/lib/real.ts" },
+          recordedExcerpt: "grounded value",
+        }),
+        citation({
+          optionId: "opt-b",
+          locator: { sourceType: "spec", path: "docs/spec.md" },
+          recordedExcerpt: "The gate is fail-closed.",
+        }),
+      ],
+      resolve,
+    );
+
+    expect(report.confirmed).toBe(2);
+    expect(report.allConfirmed).toBe(true);
+    expect(report.degrade).toEqual([]);
+  });
+
+  it("is whitespace-insensitive so reformatting does not false-degrade", async () => {
+    const root = await fixtureRepo();
+    const resolve = createRepoLocatorResolver({ repoRoot: root });
+
+    const report = await reverifyCitations(
+      [citation({ locator: { sourceType: "code", filePath: "apps/web/lib/real.ts" }, recordedExcerpt: "return    \"grounded    value\";" })],
+      resolve,
+    );
+
+    expect(report.results[0]?.verdict).toBe("confirmed");
+  });
+
+  it("refuses to escape the repo root (path traversal is unresolved, never read)", async () => {
+    const root = await fixtureRepo();
+    const resolve = createRepoLocatorResolver({ repoRoot: root });
+
+    const report = await reverifyCitations(
+      [
+        citation({ locator: { sourceType: "code", filePath: "../../../../etc/passwd" } }),
+        citation({ optionId: "opt-b", locator: { sourceType: "doc", path: "/etc/hosts" } }),
+      ],
+      resolve,
+    );
+
+    expect(report.unresolved).toBe(2);
+    expect(report.results.every((r) => r.liveExcerpt === null)).toBe(true);
+  });
+
+  it("treats source types it cannot reach as unresolved, never confirmed", async () => {
+    const root = await fixtureRepo();
+    const resolve = createRepoLocatorResolver({ repoRoot: root });
+
+    // A repo resolver cannot verify a live DB query or runtime state. Fail-closed:
+    // out-of-reach is NOT evidence of truth.
+    const report = await reverifyCitations(
+      [
+        citation({ locator: { sourceType: "db-query", query: "SELECT 1" } as never }),
+        citation({ optionId: "opt-b", locator: { sourceType: "runtime-state", ref: "portal" } as never }),
+      ],
+      resolve,
+    );
+
+    expect(report.unresolved).toBe(2);
+    expect(report.allConfirmed).toBe(false);
+  });
+
+  it("scopes a line-anchored code citation to a window around that line", async () => {
+    const root = await fixtureRepo();
+    const resolve = createRepoLocatorResolver({ repoRoot: root, lineWindow: 1 });
+
+    // Line 1 is `export function real() {`. With a ±1 window the body is in
+    // range, but a claim about something far away is not.
+    const near = await reverifyCitations(
+      [citation({ locator: { sourceType: "code", filePath: "apps/web/lib/real.ts", line: 1 }, recordedExcerpt: "grounded value" })],
+      resolve,
+    );
+    expect(near.results[0]?.verdict).toBe("confirmed");
+
+    const far = await reverifyCitations(
+      [citation({ locator: { sourceType: "code", filePath: "apps/web/lib/real.ts", line: 99 }, recordedExcerpt: "grounded value" })],
+      resolve,
+    );
+    expect(far.results[0]?.verdict).not.toBe("confirmed");
+  });
+});

--- a/apps/web/lib/decision/locator-resolver.ts
+++ b/apps/web/lib/decision/locator-resolver.ts
@@ -1,0 +1,112 @@
+// Repo-backed LocatorResolver for the trust-envelope external verifier
+// (BI-8192557E; consumes lib/decision/evidence-reverifier.ts, BI-70FF9114).
+//
+// WHY THIS EXISTS: admissibility is not truth. `lib/deliberation/evidence.ts`
+// already rejects citation theater — a citation must normalize to a
+// StructuredLocator and pass `checkAdmissibility`. But a locator can be
+// perfectly well-formed and still FABRICATED: a plausible filePath+line that
+// never existed, or a real file that never contained the claimed excerpt. Until
+// something re-resolves the locator against the live source, a confident
+// fabrication is indistinguishable from grounded evidence — and multi-model
+// deliberation makes that worse, because co-trained branches co-hallucinate and
+// their agreement reads as corroboration.
+//
+// FAIL-CLOSED IS THE WHOLE CONTRACT. Every path that cannot positively read the
+// cited artifact returns `resolved: false`, which `reverifyCitations` maps to
+// `unresolved` → degrade. Out-of-reach is never treated as evidence of truth.
+// That covers: missing files, unreadable files, path traversal, absolute paths,
+// and source types a repo resolver simply cannot verify (db-query,
+// runtime-state, tool-output, web, paper).
+//
+// Verifier identity is an audit field, never a gate input
+// (governance-approves-evidence-not-provenance).
+
+import { readFile } from "node:fs/promises";
+import { isAbsolute, normalize, resolve as resolvePath, sep } from "node:path";
+
+import type { StructuredLocator } from "@/lib/deliberation/evidence";
+import type { LocatorResolution, LocatorResolver } from "@/lib/decision/evidence-reverifier";
+
+/** Source types a repo-backed resolver can actually read. Everything else is out of reach. */
+const REPO_READABLE = new Set(["code", "spec", "doc"]);
+
+const UNRESOLVED: LocatorResolution = { resolved: false, liveExcerpt: null };
+
+export type RepoLocatorResolverOptions = {
+  /** Absolute path the resolver is confined to. Nothing outside is ever read. */
+  repoRoot: string;
+  /**
+   * For a line-anchored `code` locator, how many lines either side of the cited
+   * line to treat as the supporting window. A citation pointing at line N should
+   * be supported by what is AT line N — not by a coincidental match 4,000 lines
+   * away in the same file. Defaults to 40 (generous enough to survive ordinary
+   * drift, tight enough that the anchor still means something).
+   */
+  lineWindow?: number;
+};
+
+/** The repo-relative path a locator points at, or null when the shape carries none. */
+function pathOf(locator: StructuredLocator): string | null {
+  if (locator.sourceType === "code") return locator.filePath ?? null;
+  if (locator.sourceType === "spec" || locator.sourceType === "doc") return locator.path ?? null;
+  return null;
+}
+
+/**
+ * Confine a repo-relative path to the root. Returns null for absolute paths and
+ * for anything that normalizes outside the root — those are never opened.
+ */
+function confine(repoRoot: string, relPath: string): string | null {
+  if (!relPath || isAbsolute(relPath)) return null;
+  const root = resolvePath(repoRoot);
+  const target = resolvePath(root, normalize(relPath));
+  // Suffix guard, not a bare startsWith: `/repo-evil` must not pass for `/repo`.
+  if (target !== root && !target.startsWith(root + sep)) return null;
+  return target;
+}
+
+/** Narrow a file to the window around a cited line (1-indexed). */
+function windowAround(content: string, line: number, lineWindow: number): string {
+  const lines = content.split(/\r?\n/);
+  if (line < 1 || line > lines.length) return "";
+  const from = Math.max(0, line - 1 - lineWindow);
+  const to = Math.min(lines.length, line + lineWindow);
+  return lines.slice(from, to).join("\n");
+}
+
+/**
+ * Build a resolver that re-reads cited artifacts from a repo checkout.
+ *
+ * The returned resolver never throws: `reverifyCitations` already treats a
+ * throwing resolver as unresolved, but returning the fail-closed value directly
+ * keeps the degrade reason readable in the report.
+ */
+export function createRepoLocatorResolver(options: RepoLocatorResolverOptions): LocatorResolver {
+  const { repoRoot, lineWindow = 40 } = options;
+
+  return async function resolveLocator(locator: StructuredLocator): Promise<LocatorResolution> {
+    if (!REPO_READABLE.has(locator.sourceType)) return UNRESOLVED;
+
+    const relPath = pathOf(locator);
+    if (!relPath) return UNRESOLVED;
+
+    const absolute = confine(repoRoot, relPath);
+    if (!absolute) return UNRESOLVED;
+
+    let content: string;
+    try {
+      content = await readFile(absolute, "utf8");
+    } catch {
+      // Missing, unreadable, or a directory — all fail-closed.
+      return UNRESOLVED;
+    }
+
+    const line = locator.sourceType === "code" ? locator.line : undefined;
+    const liveExcerpt =
+      typeof line === "number" ? windowAround(content, line, lineWindow) : content;
+
+    // A cited line outside the file yields an empty window: resolved, but it
+    // supports nothing, so any recorded excerpt degrades.
+    return { resolved: true, liveExcerpt };
+  };
+}

--- a/docs/superpowers/plans/2026-08-15-wire-evidence-reverifier-plan.md
+++ b/docs/superpowers/plans/2026-08-15-wire-evidence-reverifier-plan.md
@@ -1,0 +1,89 @@
+# Wire the trust-envelope evidence re-verifier — plan
+
+**Status:** in progress · 2026-08-15
+**Backlog item:** BI-8192557E
+**Epic:** EP-DECISION-TIER-REBALANCE
+**Spec context:** [`trust-is-prospective-not-retrospective`](../../founder-kernel/wiki/principles/trust-is-prospective-not-retrospective.md) (PR #4322)
+
+## Backlog coverage
+
+- Decision: decomposed
+- Parent: BI-8192557E
+- Receipt: cmsulvbc01hht01ppkpul5748
+- Dependencies: deliberation→evidence-grade, criteria-accrual and real-diversity all depend on reverifier-wire landing first
+- Rationale: the safety wire ships independently of the grade-raising wires and must precede them.
+- Mappings:
+  - reverifier-wire (this plan, phase 1) -> BI-8192557E
+  - cold-start-weights -> BI-8AC099F4
+
+## 1. Problem
+
+`apps/web/lib/decision/evidence-reverifier.ts` (BI-70FF9114, marked done) implements an independent re-verification pass: it re-resolves each recorded `StructuredLocator` against the live source, compares the live excerpt to the recorded one, and degrades the affected dimension to unevidenced when the citation no longer holds. **It has zero consumers**, because it requires an injected `LocatorResolver` and no resolver implementation exists anywhere in the codebase.
+
+The consequence is a fabricated-evidence hole. `lib/deliberation/evidence.ts` already rejects citation theater — a citation must normalize to a `StructuredLocator` and pass `checkAdmissibility`, and an outcome with no cited sourceType gets a `needs-more-evidence` badge rather than "fabricated consensus". But **admissibility is not truth**: a plausible `filePath` + `line` that never existed, or a real file that never contained the claimed excerpt, passes admissibility today and nothing re-checks it.
+
+This matters more, not less, as plurality is wired into calibration. Measured on the live install: 1,244 deliberation runs, of which **988 use `multi-model-same-provider`** — co-trained branches share priors and therefore co-hallucinate, so their agreement reads as corroboration. Convergence over unverified citations would industrialize confident fabrication rather than catch it.
+
+**Ordering constraint:** this must land before any wire that lets convergence raise `evidenceGrade` (BI-8192557E phases 2–4).
+
+## 2. Where it attaches
+
+Traced chain (all existing):
+
+```
+principle_decide (lib/mcp/packs/principle-decide-pack.ts)
+  → groundOptionsFromParams (lib/decision/evidence-grounding.ts)   // Axis 1, BI-EA97E5CD
+  → recordKernelConsultInteraction (lib/decision/kernel-consult-ledger.ts)
+  → DecisionInteraction.sources (jsonb)   // admissible citations, sealed into the hash chain
+```
+
+So citations are already persisted per (optionId, dimensionKey) with their locator and excerpt. The re-verifier reads that record — it does not need new storage.
+
+**Independence is the contract.** The verifier must not run inside the scoring call: `evidence-reverifier.ts` specifies a pass with no access to the original scorer's reasoning, mirroring `lib/build/verified-finding-review.ts` (which is exposed via `lib/mcp-tools.ts`). Wiring it into `principle_decide` itself would destroy the separation-of-duties property that makes it meaningful.
+
+## 3. Phases
+
+### Phase 1 — repo-backed resolver (this PR)
+`lib/decision/locator-resolver.ts` — `createRepoLocatorResolver({ repoRoot, lineWindow })`.
+
+- Reads `code` / `spec` / `doc` locators from a repo checkout. These are the fabricable, verifiable ones.
+- **Fail-closed everywhere.** Missing file, unreadable file, path traversal, absolute path, or a source type the resolver cannot reach (`db-query`, `runtime-state`, `tool-output`, `web`, `paper`) all return `resolved: false` → `unresolved` → degrade. Out-of-reach is never evidence of truth.
+- Path confinement uses a `root + sep` suffix guard so `/repo-evil` cannot pass for `/repo`.
+- A line-anchored `code` citation is scoped to a window around the cited line, so a coincidental match elsewhere in a large file does not confirm an anchor that is wrong.
+- Excerpt comparison is whitespace-insensitive (via `excerptSupported`) so reformatting does not false-degrade.
+
+Regression suite `locator-resolver.test.ts` plants fabricated-but-well-formed citations and asserts degradation — written before the module existed.
+
+### Phase 2 — PREREQUISITE: persist the locator (discovered while building phase 1)
+
+**Re-verification cannot run on any decision recorded today, because the locator is discarded at write time.** `kernel-consult-ledger.ts` maps each admissible citation to:
+
+```ts
+{ materialId: `${optionId}:${dimensionKey}`,
+  sourceType: c.locator.sourceType,   // ← only the STRING survives
+  summary:    c.excerpt ?? …,
+  effectiveWeight: GRADE_WEIGHT[c.grade] }
+```
+
+The `locator` object itself — `filePath`, `line`, `commit`, `path`, `heading` — is dropped. `evidenceDigests` seals a hash into the append-only chain, which proves the recorded evidence was not *tampered with*, but a digest cannot be re-resolved against source, so it cannot prove the citation was ever *true*. Tamper-evidence and truth-verification are different properties; only the former exists today.
+
+Measured on the live install: of 603 `DecisionInteraction` rows, **537 have no sources at all**, and all **66** that do carry `sourceType: "principle"` (internal doctrine references such as `mark-dpf-platform:never-fabricate`) rather than the external `code`/`spec`/`doc` citations Axis 4 exists to re-check.
+
+Phase 2 therefore splits:
+- **2a — persist the structured locator** alongside the existing summary (additive; migration-safe), so a recorded decision carries what re-resolution needs. Without this, phases 2b/3 have nothing to verify.
+- **2b — independent verification surface.** Load the decision's citations, run `reverifyCitations` with the repo resolver, return the report, and record degraded (option, dimension) pairs. Follows the `verified-finding-review` exposure pattern; an MCP tool carries the known grant/gate cascade (`TOOL_TO_GRANTS` entry required, or the tool is denied).
+
+### Phase 3 — degrade feeds Axis 1
+A degraded pair drops the affected dimension to unevidenced on re-scoring, and the decision is flagged. This is what closes the loop with `evidence-grounding.ts`.
+
+## 4. Out of scope
+
+- Raising `evidenceGrade` from deliberation convergence (BI-8192557E phase 2) — blocked on this.
+- Criteria accrual and `DeliberationRoleProfile` population (phases 3–4).
+- Resolvers for `db-query` / `runtime-state` / `web`; those need surface-specific resolvers and stay fail-closed until then.
+
+## 5. Verification
+
+- Unit: `pnpm --filter web exec vitest run lib/decision/locator-resolver.test.ts`.
+- Production build: `pnpm --filter web build`.
+- No UI surface in phase 1, so no UX verification path; no migration.


### PR DESCRIPTION
## Why

`apps/web/lib/decision/evidence-reverifier.ts` (BI-70FF9114) has had **zero consumers** since it landed. It re-resolves each recorded `StructuredLocator` against live source, compares excerpts, and degrades the dimension when a citation no longer holds — but it needs an injected `LocatorResolver`, and **no resolver existed anywhere in the codebase**. This adds the first one.

**The hole it closes: admissibility is not truth.** `lib/deliberation/evidence.ts` already rejects citation theater — a citation must normalize to a `StructuredLocator` and pass `checkAdmissibility`, and an uncited outcome gets a `needs-more-evidence` badge rather than "fabricated consensus". But a locator can be perfectly well-formed and still **invented**: a plausible `filePath` + `line` that never existed, or a real file that never contained the claimed excerpt. Nothing re-checked that.

This matters more as plurality feeds calibration. Of **1,244** deliberation runs on the live install, **988 use `multi-model-same-provider`** — co-trained branches share priors and therefore co-hallucinate, so their agreement reads as corroboration. Convergence over unverified citations would industrialize confident fabrication rather than catch it.

## What this adds

`lib/decision/locator-resolver.ts` — `createRepoLocatorResolver({ repoRoot, lineWindow })`, reading `code` / `spec` / `doc` locators from a repo checkout.

**Fail-closed is the whole contract.** Missing file, unreadable file, path traversal, absolute path, and any source type a repo resolver cannot reach (`db-query`, `runtime-state`, `tool-output`, `web`, `paper`) all return `resolved: false` → `unresolved` → degrade. **Out-of-reach is never treated as evidence of truth.**

Three details worth review:
- Path confinement uses a `root + sep` suffix guard, so `/repo-evil` cannot pass for `/repo`.
- A line-anchored `code` citation is scoped to a window around the cited line, so a coincidental match 4,000 lines away cannot confirm an anchor that is wrong.
- Excerpt comparison stays whitespace-insensitive, so reformatting does not false-degrade.

## Prerequisite discovered while building (recorded in the plan)

**Re-verification cannot run on any decision recorded today.** `kernel-consult-ledger.ts` maps each admissible citation to `{ materialId, sourceType, summary, effectiveWeight }` — **the `locator` object is dropped**; only the sourceType string survives.

`evidenceDigests` seals a hash into the append-only chain, proving the record was not *tampered with* — but a digest cannot be re-resolved against source, so it cannot prove the citation was ever *true*. Tamper-evidence and truth-verification are different properties; only the former exists today.

Measured: of **603** `DecisionInteraction` rows, **537 have no sources at all**, and all **66** that do carry `sourceType: "principle"` (internal doctrine refs like `mark-dpf-platform:never-fabricate`) rather than the external citations Axis 4 exists to check.

So phase 2 splits: **2a persist the structured locator** (additive, migration-safe) before **2b the verification surface**. Recorded in the plan so it is not rediscovered.

## Verification

- **Unit:** `vitest run lib/decision/locator-resolver.test.ts` → **7 passed**. Tests were written **before** the module (TDD) and plant fabricated-but-well-formed citations to prove they degrade.
- **Production build:** `pnpm --filter web build` → `✓ Compiled successfully`, exit 0. (26 Edge-runtime warnings are pre-existing and unrelated.)
- **local-CI gate:** passed, 3:21, gated sha `05a5386c935f`, evidence `cmsum4vyf1i3z01ppyzktozu8`.
- **Typecheck:** pre-commit `typecheck ok`.
- No UI surface, no migration.
- Plan-backlog coverage receipt: `cmsulvbc01hht01ppkpul5748` (BI-8192557E, BI-8AC099F4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)