### PR TITLE
feat(crm): identity-resolution gate + provenance tuples for enrichment (BI-E2449835)

### DIFF
--- a/apps/web/lib/crm/enrichment/enrichment-proposal.test.ts
+++ b/apps/web/lib/crm/enrichment/enrichment-proposal.test.ts
@@ -100,4 +100,53 @@ describe("enrichment proposal builder (AC3/AC5/AC6)", () => {
     );
     expect(proposal.unresolvedGaps.some((g) => g.field === "website")).toBe(false);
   });
+
+  it("BLOCKS on a domain conflict — harvests nothing (identity gate, BI-E2449835)", () => {
+    const proposal = buildEnrichmentProposal({
+      recordKind: "customer-account",
+      recordId: "ACCT-1",
+      current: { name: "Acme IT", website: "https://acme-it.com" },
+      findings: [
+        { field: "website", value: "https://acme-industrial.com", source: "web-search", sourceRef: "serp:1" },
+        { field: "industry", value: "Manufacturing", source: "website", sourceRef: "https://acme-industrial.com" },
+      ],
+      scope: { sources: ["website", "web-search"], fields: ["website", "industry"] },
+    });
+    expect(proposal.identity.verdict).toBe("conflict");
+    expect(proposal.blocked).toBeDefined();
+    expect(proposal.changes).toHaveLength(0);
+  });
+
+  it("proceeds and marks identity 'agree' when the domain matches", () => {
+    const proposal = buildEnrichmentProposal({
+      recordKind: "customer-account",
+      recordId: "ACCT-1",
+      current: { name: "Acme IT", website: "https://acme-it.com" },
+      findings: [{ field: "industry", value: "IT Services", source: "website", sourceRef: "https://acme-it.com/about" }],
+      scope: { sources: ["website"], fields: ["industry"] },
+      anchor: { domain: "acme-it.com" },
+    });
+    expect(proposal.blocked).toBeUndefined();
+    expect(proposal.identity.verdict).toBe("agree");
+    expect(proposal.changes.find((c) => c.field === "industry")).toBeDefined();
+  });
+
+  it("carries the provenance tuple (confidence/retrievedAt/passage) into the change", () => {
+    const proposal = buildEnrichmentProposal(
+      base([
+        {
+          field: "industry",
+          value: "Managed IT Services",
+          source: "website",
+          sourceRef: "https://teamlogicit.com",
+          confidence: 0.9,
+          retrievedAt: "2026-08-15",
+          supportingPassage: "TeamLogic IT provides managed IT services",
+        },
+      ]),
+    );
+    const change = proposal.changes.find((c) => c.field === "industry");
+    expect(change).toMatchObject({ confidence: 0.9, retrievedAt: "2026-08-15" });
+    expect(change?.supportingPassage).toMatch(/managed IT services/i);
+  });
 });

--- a/apps/web/lib/crm/enrichment/enrichment-proposal.ts
+++ b/apps/web/lib/crm/enrichment/enrichment-proposal.ts
@@ -13,8 +13,10 @@
  * files it to the steward queue and (on approval) applies it with provenance.
  */
 import { evaluateMaterializability } from "./no-fabrication";
+import { assessIdentity } from "./identity-resolution";
 import {
   type EnrichableField,
+  type EnrichmentAnchor,
   type EnrichmentFieldChange,
   type EnrichmentFinding,
   type EnrichmentGap,
@@ -31,6 +33,12 @@ export type BuildProposalInput = {
   current: Record<string, unknown>;
   findings: EnrichmentFinding[];
   scope: EnrichmentScope;
+  /**
+   * The identity the coworker resolved during research (domain it settled on,
+   * etc.). Optional — when omitted the anchor is inferred from a `website`
+   * finding. Used by the identity-resolution gate (BI-E2449835).
+   */
+  anchor?: EnrichmentAnchor | null;
 };
 
 function currentString(current: Record<string, unknown>, field: EnrichableField): string | null {
@@ -53,6 +61,31 @@ function sameValue(a: string | null, b: string): boolean {
  */
 export function buildEnrichmentProposal(input: BuildProposalInput): EnrichmentProposal {
   const { recordKind, recordId, current, scope } = input;
+
+  // Identity-resolution gate (BI-E2449835): confirm the researched entity is the
+  // SAME company as the record BEFORE harvesting anything. A domain conflict is
+  // decisive — refuse and file nothing (a same-named different company).
+  const { recordAnchor, researchedAnchor, match } = assessIdentity(current, input.findings, input.anchor);
+  if (match.verdict === "conflict") {
+    return {
+      recordKind,
+      recordId,
+      changes: [],
+      unresolvedGaps: [],
+      rejected: [],
+      scope,
+      identity: match,
+      blocked: {
+        reason:
+          `Identity conflict: the record's domain (${recordAnchor.domain ?? "?"}) does not match the ` +
+          `researched domain (${researchedAnchor.domain ?? "?"}). This looks like a different company ` +
+          `with a similar name — confirm the right company before enriching.`,
+        recordAnchor,
+        researchedAnchor,
+      },
+    };
+  }
+
   const allowedFields = new Set<EnrichableField>(
     scope.fields.filter((f) => (enrichableFieldsFor(recordKind) as readonly string[]).includes(f)),
   );
@@ -94,6 +127,9 @@ export function buildEnrichmentProposal(input: BuildProposalInput): EnrichmentPr
       proposed: finding.value.trim(),
       source: finding.source,
       sourceRef: finding.sourceRef,
+      ...(finding.confidence !== undefined ? { confidence: finding.confidence } : {}),
+      ...(finding.retrievedAt ? { retrievedAt: finding.retrievedAt } : {}),
+      ...(finding.supportingPassage ? { supportingPassage: finding.supportingPassage } : {}),
     });
   }
   changes.sort((a, b) => a.field.localeCompare(b.field));
@@ -115,5 +151,5 @@ export function buildEnrichmentProposal(input: BuildProposalInput): EnrichmentPr
   }
   unresolvedGaps.sort((a, b) => a.field.localeCompare(b.field));
 
-  return { recordKind, recordId, changes, unresolvedGaps, rejected, scope };
+  return { recordKind, recordId, changes, unresolvedGaps, rejected, scope, identity: match };
 }

--- a/apps/web/lib/crm/enrichment/enrichment-service.test.ts
+++ b/apps/web/lib/crm/enrichment/enrichment-service.test.ts
@@ -51,6 +51,7 @@ const PROPOSAL: EnrichmentProposal = {
   unresolvedGaps: [{ field: "notes", reason: "left blank; please confirm" }],
   rejected: [],
   scope: { sources: ["website", "web-search"], fields: ["industry", "employeeCount", "location", "notes"] },
+  identity: { score: 1, agreements: ["domain"], conflicts: [], verdict: "agree" },
 };
 
 describe("fileEnrichmentProposal (AC7 — propose-to-queue, no direct write)", () => {

--- a/apps/web/lib/crm/enrichment/identity-resolution.test.ts
+++ b/apps/web/lib/crm/enrichment/identity-resolution.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  IDENTITY_MATCH_THRESHOLD,
+  assessIdentity,
+  normalizeDomain,
+  resolveRecordAnchor,
+  resolveResearchedAnchor,
+  scoreIdentityMatch,
+} from "./identity-resolution";
+import type { EnrichmentFinding } from "./types";
+
+describe("identity-resolution gate (BI-E2449835)", () => {
+  it("normalizes domains (scheme/www/path/port stripped)", () => {
+    expect(normalizeDomain("https://www.Acme.com/about?x=1")).toBe("acme.com");
+    expect(normalizeDomain("acme.com:8080")).toBe("acme.com");
+    expect(normalizeDomain("not a url")).toBeNull();
+    expect(normalizeDomain("")).toBeNull();
+    expect(normalizeDomain(null)).toBeNull();
+  });
+
+  it("REGRESSION: a DOMAIN CONFLICT hard-blocks (same-named different company)", () => {
+    const record = { name: "Acme IT", website: "https://acme-it.com" };
+    const findings: EnrichmentFinding[] = [
+      { field: "website", value: "https://acme-industrial.com", source: "web-search", sourceRef: "serp:1" },
+      { field: "industry", value: "Manufacturing", source: "website", sourceRef: "https://acme-industrial.com" },
+    ];
+    const { match } = assessIdentity(record, findings);
+    expect(match.verdict).toBe("conflict");
+    expect(match.conflicts).toContain("domain");
+    expect(match.score).toBe(0);
+  });
+
+  it("a matching domain is a strong agreement", () => {
+    const record = { name: "Acme IT", website: "https://acme-it.com" };
+    const findings: EnrichmentFinding[] = [
+      { field: "website", value: "http://www.acme-it.com/contact", source: "website", sourceRef: "x" },
+      { field: "industry", value: "IT Services", source: "website", sourceRef: "x" },
+    ];
+    const { match } = assessIdentity(record, findings);
+    expect(match.verdict).toBe("agree");
+    expect(match.agreements).toContain("domain");
+    expect(match.score).toBeGreaterThanOrEqual(IDENTITY_MATCH_THRESHOLD);
+  });
+
+  it("name + location corroboration reaches 'agree' without a domain", () => {
+    const record = { name: "TeamLogic IT of Round Rock", location: "Round Rock, TX" };
+    const match = scoreIdentityMatch(resolveRecordAnchor(record), {
+      domain: null,
+      name: "TeamLogic IT of Round Rock",
+      location: "Round Rock, Texas",
+    });
+    expect(match.agreements).toContain("name");
+    expect(match.agreements).toContain("location");
+    expect(match.verdict).toBe("agree");
+  });
+
+  it("a thin name-only record with only a name echo stays 'weak' (needs confirmation)", () => {
+    const record = { name: "Northgate Systems" };
+    const findings: EnrichmentFinding[] = [
+      { field: "industry", value: "Consulting", source: "web-search", sourceRef: "serp:1" },
+    ];
+    const { match } = assessIdentity(record, findings);
+    expect(match.verdict).toBe("weak");
+    expect(match.score).toBeLessThan(IDENTITY_MATCH_THRESHOLD);
+  });
+
+  it("normalizes company suffixes when comparing names", () => {
+    const match = scoreIdentityMatch({ domain: null, name: "Acme, Inc.", location: null }, { domain: null, name: "Acme Corporation", location: null });
+    expect(match.agreements).toContain("name");
+  });
+
+  it("an explicit anchor overrides finding-derived domain", () => {
+    const findings: EnrichmentFinding[] = [
+      { field: "industry", value: "IT", source: "web-search", sourceRef: "x" },
+    ];
+    const anchor = resolveResearchedAnchor(findings, { domain: "acme.com", name: null, location: null });
+    expect(anchor.domain).toBe("acme.com");
+  });
+});

--- a/apps/web/lib/crm/enrichment/identity-resolution.ts
+++ b/apps/web/lib/crm/enrichment/identity-resolution.ts
@@ -1,0 +1,167 @@
+/**
+ * Identity-resolution gate (BI-E2449835, design decision ①).
+ *
+ * The top trust risk in CRM enrichment is enriching a same-named but DIFFERENT
+ * company. Before findings are harvested, resolve the identity "anchor" of both
+ * the record and the researched entity and compare them:
+ *   - a DOMAIN CONFLICT (the record's own domain differs from the researched
+ *     domain) is a hard signal the research is about the wrong company → the
+ *     proposal is blocked and nothing is filed;
+ *   - weaker mismatches yield a low match score ("weak") — the proposal still
+ *     goes through the propose→apply gate, but the human is told the identity is
+ *     not strongly confirmed before they approve.
+ *
+ * Anchor priority is domain-first (the strongest key), then name similarity,
+ * then location corroboration — the market's accuracy-first ordering. Pure,
+ * DB-free.
+ */
+import type { EnrichmentAnchor, EnrichmentFinding, IdentityMatch } from "./types";
+
+/** At or above this score the identity is confirmed; below it is "weak". */
+export const IDENTITY_MATCH_THRESHOLD = 0.5;
+
+const COMPANY_SUFFIX =
+  /\b(inc|llc|l\.l\.c|ltd|limited|corp|corporation|co|company|gmbh|plc|group|holdings|pllc|pc|lp|llp|sarl|bv|ag)\b/gi;
+
+/** Reduce a URL or host to a bare registrable-ish domain (lowercase, no www). */
+export function normalizeDomain(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  let s = String(raw).trim().toLowerCase();
+  if (s.length === 0) return null;
+  s = s.replace(/^[a-z][a-z0-9+.-]*:\/\//, ""); // strip scheme
+  s = s.replace(/^www\./, "");
+  s = s.split(/[/?#]/)[0] ?? s; // strip path/query/hash
+  s = s.replace(/:\d+$/, ""); // strip port
+  return s.includes(".") && /[a-z0-9]/.test(s) ? s : null;
+}
+
+function normalizeName(raw: string | null | undefined): string {
+  if (!raw) return "";
+  return String(raw)
+    .toLowerCase()
+    .replace(COMPANY_SUFFIX, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function nameTokens(name: string | null | undefined): Set<string> {
+  return new Set(
+    normalizeName(name)
+      .split(/\s+/)
+      .filter((t) => t.length > 1),
+  );
+}
+
+/** Fraction of the smaller token set that is shared (0..1). */
+function tokenOverlap(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let shared = 0;
+  for (const t of a) if (b.has(t)) shared += 1;
+  return shared / Math.min(a.size, b.size);
+}
+
+function locationTokens(raw: string | null | undefined): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    String(raw)
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, " ")
+      .split(/\s+/)
+      .filter((t) => t.length > 1),
+  );
+}
+
+/** The record's own identity anchor, from its stored fields. */
+export function resolveRecordAnchor(current: Record<string, unknown>): EnrichmentAnchor {
+  const str = (k: string) => {
+    const v = current[k];
+    return typeof v === "string" && v.trim().length > 0 ? v.trim() : null;
+  };
+  return {
+    domain: normalizeDomain(str("website")),
+    name: str("name"),
+    location: str("location") ?? str("city") ?? str("region"),
+  };
+}
+
+/**
+ * The researched entity's anchor. An explicit caller-supplied anchor (the
+ * identity the coworker resolved during research) takes precedence; otherwise a
+ * `website` finding supplies the domain and name/location findings fill the rest.
+ */
+export function resolveResearchedAnchor(
+  findings: EnrichmentFinding[],
+  explicit?: EnrichmentAnchor | null,
+): EnrichmentAnchor {
+  const findingValue = (field: string) => findings.find((f) => f.field === field)?.value ?? null;
+  return {
+    domain: normalizeDomain(explicit?.domain ?? findingValue("website")),
+    name: (explicit?.name ?? findingValue("name")) || null,
+    location: (explicit?.location ?? findingValue("location")) || null,
+  };
+}
+
+/** Compare the record's anchor against the researched anchor. */
+export function scoreIdentityMatch(
+  recordAnchor: EnrichmentAnchor,
+  researchedAnchor: EnrichmentAnchor,
+): IdentityMatch {
+  const agreements: string[] = [];
+  const conflicts: string[] = [];
+
+  // Domain is the strongest key. Both present + equal = strong agreement;
+  // both present + different = hard conflict (a same-named different company).
+  const rd = normalizeDomain(recordAnchor.domain);
+  const xd = normalizeDomain(researchedAnchor.domain);
+  let domainVerdict: "agree" | "conflict" | "absent" = "absent";
+  if (rd && xd) {
+    if (rd === xd) {
+      agreements.push("domain");
+      domainVerdict = "agree";
+    } else {
+      conflicts.push("domain");
+      domainVerdict = "conflict";
+    }
+  }
+
+  const nameSim = tokenOverlap(nameTokens(recordAnchor.name), nameTokens(researchedAnchor.name));
+  if (recordAnchor.name && researchedAnchor.name && nameSim >= 0.6) {
+    agreements.push("name");
+  }
+
+  // Location is a weak corroborator: agree when the two share their significant
+  // tokens (so "Round Rock, TX" ≈ "Round Rock, Texas" — same city).
+  const locSim = tokenOverlap(locationTokens(recordAnchor.location), locationTokens(researchedAnchor.location));
+  if (locSim >= 0.5) {
+    agreements.push("location");
+  }
+
+  // A domain conflict is decisive: refuse regardless of other signals.
+  if (domainVerdict === "conflict") {
+    return { score: 0, agreements, conflicts, verdict: "conflict" };
+  }
+
+  let score = 0;
+  if (domainVerdict === "agree") score += 0.7;
+  score += Math.min(0.4, nameSim * 0.4);
+  if (agreements.includes("location")) score += 0.2;
+  score = Math.min(1, Math.round(score * 100) / 100);
+
+  return {
+    score,
+    agreements,
+    conflicts,
+    verdict: score >= IDENTITY_MATCH_THRESHOLD ? "agree" : "weak",
+  };
+}
+
+/** Convenience: resolve both anchors from a record + findings and compare. */
+export function assessIdentity(
+  current: Record<string, unknown>,
+  findings: EnrichmentFinding[],
+  explicitAnchor?: EnrichmentAnchor | null,
+): { recordAnchor: EnrichmentAnchor; researchedAnchor: EnrichmentAnchor; match: IdentityMatch } {
+  const recordAnchor = resolveRecordAnchor(current);
+  const researchedAnchor = resolveResearchedAnchor(findings, explicitAnchor);
+  return { recordAnchor, researchedAnchor, match: scoreIdentityMatch(recordAnchor, researchedAnchor) };
+}

--- a/apps/web/lib/crm/enrichment/types.ts
+++ b/apps/web/lib/crm/enrichment/types.ts
@@ -62,6 +62,37 @@ export type EnrichmentFinding = {
   sourceRef: string;
   /** 0..1 self-reported confidence; informational, not a gate. */
   confidence?: number;
+  /** ISO timestamp the value was observed — drives per-field freshness. */
+  retrievedAt?: string;
+  /** The passage the value was read from — provenance beyond the bare URL. */
+  supportingPassage?: string;
+};
+
+/**
+ * The identity "anchor" of a company record or a researched entity
+ * (BI-E2449835). Used to confirm the researched company is the SAME entity as
+ * the thin record before any field is harvested — a same-named different
+ * company is the classic way enrichment poisons a record.
+ */
+export type EnrichmentAnchor = {
+  domain?: string | null;
+  name?: string | null;
+  location?: string | null;
+};
+
+/**
+ * The result of comparing a record's anchor against a researched anchor.
+ * `conflict` (a domain mismatch) hard-blocks the proposal; `weak` proceeds but
+ * is surfaced for human confirmation at the review step.
+ */
+export type IdentityMatch = {
+  /** 0..1 confidence the two anchors are the same entity. */
+  score: number;
+  /** Signals that agreed, e.g. ["domain","name"]. */
+  agreements: string[];
+  /** Signals that conflicted, e.g. ["domain"]. */
+  conflicts: string[];
+  verdict: "agree" | "weak" | "conflict";
 };
 
 /**
@@ -108,6 +139,10 @@ export type EnrichmentFieldChange = {
   proposed: string;
   source: EnrichmentSourceKind;
   sourceRef: string;
+  /** Provenance tuple (BI-E2449835): carried from the finding for audit. */
+  confidence?: number;
+  retrievedAt?: string;
+  supportingPassage?: string;
 };
 
 /** A field the human asked to fill that could not be verified from any source. */
@@ -129,6 +164,18 @@ export type EnrichmentProposal = {
   /** Findings dropped by the no-fabrication guard (field + why). */
   rejected: Array<{ field: EnrichableField; value: string; reason: string }>;
   scope: EnrichmentScope;
+  /** Identity-resolution verdict (BI-E2449835). */
+  identity: IdentityMatch;
+  /**
+   * Set when the proposal was BLOCKED before harvesting because the researched
+   * entity does not match the record (a domain conflict — likely a same-named
+   * different company). When present, `changes` is empty and nothing is filed.
+   */
+  blocked?: {
+    reason: string;
+    recordAnchor: EnrichmentAnchor;
+    researchedAnchor: EnrichmentAnchor;
+  };
 };
 
 /** Structured `reasons` payload persisted on the enrichment MdmStewardTask. */

--- a/apps/web/lib/mcp/packs/crm-enrichment-pack.ts
+++ b/apps/web/lib/mcp/packs/crm-enrichment-pack.ts
@@ -19,6 +19,7 @@ import {
   ENRICHMENT_SOURCE_KINDS,
   enrichableFieldsFor,
   type EnrichableField,
+  type EnrichmentAnchor,
   type EnrichmentFinding,
   type EnrichmentRecordKind,
   type EnrichmentScope,
@@ -29,7 +30,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "propose_crm_enrichment",
     description:
-      "File a proactive enrichment proposal for a thin customer account or contact. Call this AFTER the human has agreed to enrichment and confirmed scope (which sources, which fields). Pass the facts you researched from public sources (each with its source + citation) as `findings`; the tool drops anything masked/partial/placeholder (never fabricates), computes the before→after diff, cites every field, and files the proposal to the data-steward queue. Nothing is written to the record here — apply it with apply_crm_enrichment after the human reviews the diff. Unverifiable fields are returned as gaps to confirm.",
+      "File a proactive enrichment proposal for a thin customer account or contact. Call this AFTER the human has agreed to enrichment and confirmed scope (which sources, which fields). Pass the identity you resolved as `anchor` (the company's domain — the strongest key — plus name/location) and the facts you researched as `findings` (each with its source + citation). The tool first CONFIRMS the researched company is the same entity as the record: if the record's own domain conflicts with your researched domain it REFUSES (a same-named different company); a weak match is filed but flagged for you to double-check. It then drops anything masked/partial/placeholder (never fabricates), computes the before→after diff, cites every field, and files the proposal to the data-steward queue. Nothing is written to the record here — apply it with apply_crm_enrichment after the human reviews the diff. Unverifiable fields are returned as gaps to confirm.",
     inputSchema: {
       type: "object",
       properties: {
@@ -39,6 +40,15 @@ const definitions: ToolDefinition[] = [
           description: "Which record is being enriched. Defaults to customer-account.",
         },
         recordId: { type: "string", description: "CustomerAccount.id or CustomerContact.id." },
+        anchor: {
+          type: "object",
+          description: "The identity you resolved for the researched company — used to confirm it matches the record before harvesting. Domain is the strongest key.",
+          properties: {
+            domain: { type: "string", description: "The company's own domain, e.g. acme.com (no scheme/path)." },
+            name: { type: "string" },
+            location: { type: "string" },
+          },
+        },
         scope: {
           type: "object",
           description: "The human-confirmed scope: which public sources and which fields you may touch.",
@@ -53,7 +63,7 @@ const definitions: ToolDefinition[] = [
         },
         findings: {
           type: "array",
-          description: "Researched facts to propose. Each: field, value, source (website|linkedin|web-search), sourceRef (URL/citation), optional confidence 0..1.",
+          description: "Researched facts to propose. Each: field, value, source (website|linkedin|web-search), sourceRef (URL/citation), optional confidence 0..1, optional retrievedAt (ISO date), optional supportingPassage (the text the value was read from).",
           items: {
             type: "object",
             properties: {
@@ -62,6 +72,8 @@ const definitions: ToolDefinition[] = [
               source: { type: "string", enum: ["website", "linkedin", "web-search"] },
               sourceRef: { type: "string" },
               confidence: { type: "number" },
+              retrievedAt: { type: "string" },
+              supportingPassage: { type: "string" },
             },
             required: ["field", "value", "source", "sourceRef"],
           },
@@ -121,9 +133,19 @@ function parseFindings(raw: unknown): EnrichmentFinding[] {
       source: source as EnrichmentSourceKind,
       sourceRef,
       ...(typeof o["confidence"] === "number" ? { confidence: o["confidence"] } : {}),
+      ...(typeof o["retrievedAt"] === "string" ? { retrievedAt: o["retrievedAt"] } : {}),
+      ...(typeof o["supportingPassage"] === "string" ? { supportingPassage: o["supportingPassage"] } : {}),
     });
   }
   return out;
+}
+
+function parseAnchor(raw: unknown): EnrichmentAnchor | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  const str = (k: string) => (typeof o[k] === "string" && o[k].trim().length > 0 ? o[k].trim() : null);
+  const anchor: EnrichmentAnchor = { domain: str("domain"), name: str("name"), location: str("location") };
+  return anchor.domain || anchor.name || anchor.location ? anchor : null;
 }
 
 const proposeCrmEnrichmentTool: ToolPackHandler = async (params, _userId, context) => {
@@ -142,6 +164,7 @@ const proposeCrmEnrichmentTool: ToolPackHandler = async (params, _userId, contex
     };
   }
   const findings = parseFindings(params["findings"]);
+  const anchor = parseAnchor(params["anchor"]);
 
   const { loadRecordForEnrichment, fileEnrichmentProposal } = await import("@/lib/crm/enrichment/enrichment-service");
   const { buildEnrichmentProposal } = await import("@/lib/crm/enrichment/enrichment-proposal");
@@ -158,7 +181,19 @@ const proposeCrmEnrichmentTool: ToolPackHandler = async (params, _userId, contex
     current: record.current,
     findings,
     scope,
+    anchor,
   });
+
+  // Identity-resolution gate (BI-E2449835): a domain conflict means the research
+  // is about a different, similarly-named company — refuse and file nothing.
+  if (proposal.blocked) {
+    return {
+      success: false,
+      error: "identity_conflict",
+      message: `Not filed for "${record.label}" — ${proposal.blocked.reason}`,
+      data: { blocked: proposal.blocked, identity: proposal.identity },
+    };
+  }
 
   const plan = resolveProactivityPlan({
     activityFamily: "crm-record-enrichment",
@@ -172,6 +207,10 @@ const proposeCrmEnrichmentTool: ToolPackHandler = async (params, _userId, contex
     });
     const diff = proposal.changes.map((c) => `${c.field}: ${c.current ?? "∅"} → "${c.proposed}" (${c.source})`).join("; ");
     const gaps = proposal.unresolvedGaps.map((g) => g.field).join(", ");
+    const identityWarning =
+      proposal.identity.verdict === "weak"
+        ? ` ⚠ Identity only weakly confirmed (match ${Math.round(proposal.identity.score * 100)}%, agreed on: ${proposal.identity.agreements.join("+") || "none"}) — double-check this is the right company before applying.`
+        : "";
     if (!taskId) {
       return {
         success: true,
@@ -186,7 +225,8 @@ const proposeCrmEnrichmentTool: ToolPackHandler = async (params, _userId, contex
         `${diff ? ` [${diff}]` : ""}` +
         `${proposal.rejected.length ? `; dropped ${proposal.rejected.length} unverifiable/masked value(s)` : ""}` +
         `${gaps ? `; confirm-what's-needed: ${gaps}` : ""}. ` +
-        `Review the diff, then apply with apply_crm_enrichment taskId "${taskId}" — nothing written yet.`,
+        `Review the diff, then apply with apply_crm_enrichment taskId "${taskId}" — nothing written yet.` +
+        identityWarning,
       data: { proposal, taskId },
     };
   } catch (err) {

--- a/docs/superpowers/specs/2026-08-14-crm-enrichment-ci-coworker-design.md
+++ b/docs/superpowers/specs/2026-08-14-crm-enrichment-ci-coworker-design.md
@@ -136,21 +136,25 @@ source waterfall** → **grounded-or-blank + per-field provenance** → **compli
 human approves → `apply_crm_enrichment` → freshness note. This is the genuinely net-new artifact
 and the home of "what others do."
 
-## Tool hardening (optional, incremental — separate BI)
+## Tool hardening (BI-E2449835 — partially delivered)
 
-Fold the 4 market decisions the shipped tools don't yet *enforce* into
+Folding the 4 market decisions the shipped tools don't yet *enforce* into
 `apps/web/lib/crm/enrichment/`:
-- **Identity-resolution gate** (decision ①) in `enrichment-proposal.ts`: require an `anchor`
-  (domain or name+geo+corroborator) + per-finding `anchorAgreement`; drop findings that don't
-  agree; return a `matchScore` and refuse to file below threshold. *Today the tool trusts
-  coworker-supplied findings blindly — this is the biggest correctness gap.*
-- **Confidence + passage fields** (decision ②) on `EnrichmentFinding`
-  (`confidence`, `retrievedAt`, `supportingPassage`) and a check that categorical values are in a
-  taxonomy enum.
-- **Compliance risk-tier + suppression-list hook** (decision ③): tag each field
+- **Identity-resolution gate** (decision ①) — **DELIVERED.** `identity-resolution.ts` resolves the
+  record anchor and the researched anchor (explicit `anchor` param, else inferred from a `website`
+  finding), scores the match domain-first, and `enrichment-proposal.ts` **hard-blocks on a domain
+  conflict** (a same-named different company → nothing filed) and flags a `weak` match for human
+  confirmation at the review step. `propose_crm_enrichment` gained an `anchor` input and returns
+  `identity_conflict` on a block.
+- **Confidence + passage fields** (decision ②) — **DELIVERED (data).** `EnrichmentFinding` /
+  `EnrichmentFieldChange` carry `confidence`, `retrievedAt`, `supportingPassage`, threaded into the
+  proposal + task reasons for audit. *Remaining:* entailment check (value present in the passage)
+  and categorical taxonomy-enum validation.
+- **Compliance risk-tier + suppression-list hook** (decision ③) — *remaining.* Tag each field
   `firmographic | personal-contact`; personal-contact requires a lawful-basis flag and a
-  suppression-list miss before it may be proposed.
-- **Per-field freshness** (`retrievedAt` → staleness SLA) driving re-enrichment triggers.
+  suppression-list miss before it may be proposed (needs a suppression-list model).
+- **Per-field freshness** (decision, `retrievedAt` → staleness SLA) — *remaining;* the `retrievedAt`
+  field now exists to drive it.
 
 ## Config turn-on checklist (separate BI)
 


### PR DESCRIPTION
## What & why (BI-E2449835)

The shipped CRM enrichment tools (BI-B2497DFB) trusted coworker-supplied findings blindly. The market's #1 hardening decision is an **identity-resolution gate**: the top way an AI enrichment coworker destroys trust is confidently enriching a *same-named but different* company. This adds that gate before any field is harvested.

## Changes (all in `apps/web/lib/crm/enrichment/` + the pack)

- **`identity-resolution.ts` (new)** — resolves the identity **anchor** of both the record and the researched entity: **domain-first** (scheme/www/path-normalized), then **name** token-overlap (company-suffix stripped), then **location** city-token corroboration. `scoreIdentityMatch` → `agree | weak | conflict`.
- **`enrichment-proposal.ts`** — **hard-blocks on a domain conflict** (record domain ≠ researched domain → files nothing, returns `blocked` + both anchors); a `weak` match still goes through the propose→apply gate but is flagged for human confirmation. Attaches the `identity` verdict to every proposal.
- **Provenance tuples (decision ②)** — `EnrichmentFinding` / `EnrichmentFieldChange` now carry `confidence`, `retrievedAt`, `supportingPassage`, threaded into the proposal + steward-task reasons for audit.
- **`crm-enrichment-pack.ts`** — `propose_crm_enrichment` gains an `anchor` input + the `retrievedAt`/`supportingPassage` finding fields; returns `identity_conflict` on a block and a ⚠ warning on a weak match.

## Verification

49 enrichment unit tests (incl. the **domain-conflict block regression**, name+location corroboration, and provenance carry-through); typecheck clean; merged-CI gate green against `origin/main`.

## Remaining in BI-E2449835 (need new substrate)

Compliance risk-tier + suppression list (decision ③), passage-entailment + taxonomy-enum checks, and per-field freshness SLAs (`retrievedAt` now exists to drive them). Recorded in `docs/superpowers/specs/2026-08-14-crm-enrichment-ci-coworker-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
