### PR TITLE
fix(ci): register the route-derived registry chain as pre-commit derived artifacts (BI-34D69270)

### DIFF
--- a/scripts/lib/derived-artifacts-registry.mjs
+++ b/scripts/lib/derived-artifacts-registry.mjs
@@ -95,6 +95,97 @@ export const DERIVED_ARTIFACTS = [
     // absent; CI (a compile-ready runner) is the backstop via --check.
     requiresBinary: "mmdc",
   },
+  // ─── Route-derived registry chain (BI-34D69270) ────────────────────────────
+  //
+  // route-manifest -> route-audience -> route-shells -> page-purpose: four
+  // artifacts generated from the App Router route tree, in strict dependency
+  // order (each reads the one before it from disk). Registered here so a route
+  // add/remove/rename regenerates + stages ALL of them at commit time, the way
+  // the "Route Manifest Freshness" CI guard checks them.
+  //
+  // Filed after #4302 inherited latent main-red from #4295: that PR added
+  // /ops/stack-currency's page without regenerating route-manifest.json, so the
+  // downstream registries never saw the route, all four stayed mutually
+  // consistent at the old count, and the staleness sat invisible until an
+  // unrelated route-touching PR tripped the required Merge Readiness
+  // aggregation and had to absorb the repair. Pre-commit auto-regen closes that
+  // class at the source: the committing dev can no longer ship a stale chain.
+  //
+  // Each entry lists the app route globs (a route change must regenerate the
+  // whole chain) plus its own upstream artifact + generator/logic files. Order
+  // in this array IS the regeneration order, so downstream entries read the
+  // freshly-written upstream artifact.
+  {
+    id: "route-manifest",
+    description: "App Router route manifest (SysML route projection source)",
+    sourceGlobs: [
+      "apps/web/app/**/page.ts",
+      "apps/web/app/**/page.tsx",
+      "apps/web/app/**/route.ts",
+      "apps/web/app/**/route.tsx",
+      "apps/web/scripts/build-route-manifest.ts",
+      "apps/web/lib/ea/route-extract.ts",
+    ],
+    artifactPaths: ["apps/web/lib/ea/route-manifest.json"],
+    generate: ["pnpm", "--filter", "web", "run", "build:route-manifest"],
+    check: ["pnpm", "--filter", "web", "run", "check:route-manifest"],
+  },
+  {
+    id: "route-audience",
+    description: "Per-route audience + destination-kind classification (derives from the manifest)",
+    sourceGlobs: [
+      "apps/web/app/**/page.ts",
+      "apps/web/app/**/page.tsx",
+      "apps/web/app/**/route.ts",
+      "apps/web/app/**/route.tsx",
+      "apps/web/lib/ea/route-manifest.json",
+      "apps/web/lib/navigation/route-audience.ts",
+      "apps/web/scripts/build-route-audience.ts",
+    ],
+    artifactPaths: ["apps/web/lib/navigation/route-audience.generated.json"],
+    generate: ["pnpm", "--filter", "web", "run", "build:route-audience"],
+    check: ["pnpm", "--filter", "web", "run", "check:route-audience"],
+  },
+  {
+    id: "route-shells",
+    description: "Intended page-shell + sweep-eligibility registry (derives from manifest + audience)",
+    sourceGlobs: [
+      "apps/web/app/**/page.ts",
+      "apps/web/app/**/page.tsx",
+      "apps/web/app/**/route.ts",
+      "apps/web/app/**/route.tsx",
+      "apps/web/lib/ea/route-manifest.json",
+      "apps/web/lib/navigation/route-audience.generated.json",
+      "apps/web/lib/ux-budget/route-shells.ts",
+      "apps/web/lib/ux-budget/budgets.ts",
+      "apps/web/scripts/build-route-shells.ts",
+    ],
+    artifactPaths: ["apps/web/lib/ux-budget/route-shells.generated.json"],
+    generate: ["pnpm", "--filter", "web", "run", "build:route-shells"],
+    check: ["pnpm", "--filter", "web", "run", "check:route-shells"],
+  },
+  {
+    id: "page-purpose",
+    description: "Per-route purpose-contract registry (derives from the shared route policy)",
+    sourceGlobs: [
+      "apps/web/app/**/page.ts",
+      "apps/web/app/**/page.tsx",
+      "apps/web/app/**/route.ts",
+      "apps/web/app/**/route.tsx",
+      "apps/web/lib/ea/route-manifest.json",
+      "apps/web/lib/ux-budget/page-purpose.ts",
+      "apps/web/lib/ux-budget/route-policy.ts",
+      "apps/web/lib/ux-budget/route-purpose-baseline.json",
+      "apps/web/lib/ux-budget/purpose-contracts/**",
+      "apps/web/scripts/build-page-purpose.ts",
+      "apps/web/scripts/registry-generator-support.ts",
+    ],
+    artifactPaths: ["apps/web/lib/ux-budget/route-purpose.generated.json"],
+    generate: ["pnpm", "--filter", "web", "run", "build:page-purpose"],
+    // Freshness only (committed == regenerated + non-diff identity ratchet). The
+    // base-ref transition ratchet is the CI workflow's job (audit-route-manifest.yml).
+    check: ["pnpm", "--filter", "web", "run", "check:page-purpose"],
+  },
   {
     id: "capability-service-catalog",
     description: "Compiled capability/service catalog",

--- a/scripts/lib/derived-artifacts-registry.test.mjs
+++ b/scripts/lib/derived-artifacts-registry.test.mjs
@@ -69,6 +69,18 @@ test("enrolls the five generators required by BI-48768E05", () => {
   }
 });
 
+test("enrolls the route-derived registry chain (BI-34D69270)", () => {
+  const ids = new Set(DERIVED_ARTIFACTS.map((e) => e.id));
+  // All four must be present, in dependency order, so a route change regenerates
+  // the whole chain at commit time (the #4295 latent-main-red class).
+  const chain = ["route-manifest", "route-audience", "route-shells", "page-purpose"];
+  for (const expected of chain) {
+    assert.ok(ids.has(expected), `missing registry entry: ${expected}`);
+  }
+  const order = DERIVED_ARTIFACTS.map((e) => e.id).filter((id) => chain.includes(id));
+  assert.deepEqual(order, chain, "route chain must be in dependency order (downstream reads upstream)");
+});
+
 test("sbom-baseline is registered with autoStage disabled (judgment call, not a pure function of sources)", () => {
   const entry = DERIVED_ARTIFACTS.find((e) => e.id === "sbom-baseline");
   assert.equal(entry.autoStage, false);


### PR DESCRIPTION
## What

Closes **BI-34D69270** — the latent-main-red class that #4302 inherited from #4295.

#4295 added `/ops/stack-currency`'s page **without regenerating `route-manifest.json`**, so the downstream chain (`route-audience` → `route-shells` → `page-purpose`) never saw the route. All four registries stayed mutually consistent at the old count, the staleness sat invisible, and an unrelated route-touching PR (#4302) later tripped the required `Merge Readiness` aggregation and had to absorb the repair.

## How

The existing derived-artifacts registry (`scripts/lib/derived-artifacts-registry.mjs`, BI-48768E05) is designed so adding a generator "makes a new derived artifact covered by construction — no hook or CI file needs to change." This registers the **full route chain** there, in strict dependency order:

`route-manifest → route-audience → route-shells → page-purpose`

Each entry lists the app route globs (a route change regenerates the whole chain) plus its own upstream artifact + generator/logic files. Because array order **is** regeneration order, each downstream generator reads the freshly-written upstream artifact from disk.

Effect: a route add/remove/rename now **auto-regenerates and stages** all four registries at commit time, and a new route with **no purpose contract is blocked at commit** (page-purpose's generate throws) — the incomplete state can't be committed, let alone reach main.

## Why this is the right leg

The freshness workflow (`audit-route-manifest.yml`) already triggers on `push:[main]` + `merge_group`, so the CI backstop exists. The gap that let #4295 through was the **missing pre-commit prevention** — this adds it, mirroring the exact pattern the registry was built for (it was itself filed after PR #3284 turned main red the same way with `doc-index`).

## Test

Verified in a bootstrapped worktree:
- Registry + gate unit tests green (14 + 12); a new test asserts the chain is present **and in dependency order**.
- **End-to-end:** staging a throwaway new route regenerated manifest/audience/shells and blocked on page-purpose (`Commit rejected`) — the #4295 scenario caught at commit; cleaned up after.
- All four `check:*` commands pass against the consistent tree (the CI `check-all` path).
- Full local-CI gate passed.

## Scope

This is the priority item of a 3-BI CI-gate-reliability cluster. Follow-ons (separate PRs): **BI-1D3EA15A** (run the GitHub-only guards in the local gate so branch-green predicts queue-green) and **BI-A4CE5EDC** (local-CI runner self-heals lockfile drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
