### PR TITLE
fix(topology): render compact physical hierarchy (BI-6649C95A)

### DIFF
--- a/apps/web/components/inventory/TopologyGraph.tsx
+++ b/apps/web/components/inventory/TopologyGraph.tsx
@@ -9,7 +9,7 @@ import { getDeviceVisual } from "@/lib/graph/device-icons";
 import { isDockerOriginNode } from "@/lib/graph/docker-filter";
 import { describeGraphScope } from "@/lib/graph/subnet-scope";
 import { projectPhysicalTopology } from "@/lib/graph/physical-topology";
-import { createScopeToken, isResetScopeKey, isSubnetSelectorKey, resolveDisplayedGraphData, resolveSubnetScopeState } from "@/lib/graph/topology-graph-state";
+import { createScopeToken, isResetScopeKey, isSubnetSelectorKey, resolveDisplayedGraphData, resolveSubnetScopeState, shouldShowViewportReset } from "@/lib/graph/topology-graph-state";
 import { usePhysicalTopologyViewport } from "@/lib/graph/use-physical-topology-viewport";
 import { TopologyIntegritySummary } from "@/components/inventory/TopologyIntegritySummary";
 import { TopologyLegend } from "@/components/inventory/TopologyLegend";
@@ -124,6 +124,7 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
   // Pan and zoom state
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [hasViewportInteraction, setHasViewportInteraction] = useState(false);
   const isPanningRef = useRef(false);
   const panStartRef = useRef({ x: 0, y: 0, panX: 0, panY: 0 });
 
@@ -189,6 +190,10 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
   );
 
   const fitPhysicalTopology = usePhysicalTopologyViewport(layoutResult, dimensions, selectedView, setZoom, setPan);
+
+  useEffect(() => {
+    setHasViewportInteraction(false);
+  }, [scopeToken, selectedView]);
 
   // Force simulation state (only for exploration view)
   const nodesRef = useRef<SimNode[]>([]);
@@ -569,6 +574,7 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
 
     // Handle panning via middle-click or left-click drag
     if (isPanningRef.current) {
+      setHasViewportInteraction(true);
       setPan({
         x: panStartRef.current.panX + (e.clientX - panStartRef.current.x),
         y: panStartRef.current.panY + (e.clientY - panStartRef.current.y),
@@ -604,6 +610,7 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
       const mouseX = e.clientX - rect.left;
       const mouseY = e.clientY - rect.top;
       const zoomFactor = e.deltaY < 0 ? 1.1 : 0.9;
+      setHasViewportInteraction(true);
       setZoom((prev) => {
         const next = Math.max(0.2, Math.min(5, prev * zoomFactor));
         setPan((p) => ({
@@ -823,12 +830,17 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
             {isSubnetScoped ? " / scoped" : ""}
           </span>
           <span>{Math.round(zoom * 100)}%</span>
-          {(zoom !== 1 || pan.x !== 0 || pan.y !== 0) && (
+          {shouldShowViewportReset(selectedView, hasViewportInteraction, zoom, pan) && (
             <button
               type="button"
-              onClick={selectedView === "network-topology"
-                ? fitPhysicalTopology
-                : () => { setZoom(1); setPan({ x: 0, y: 0 }); }}
+              onClick={() => {
+                if (selectedView === "network-topology") fitPhysicalTopology();
+                else {
+                  setZoom(1);
+                  setPan({ x: 0, y: 0 });
+                }
+                setHasViewportInteraction(false);
+              }}
               className="text-[9px] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] underline"
             >
               reset

--- a/apps/web/components/inventory/TopologyGraph.tsx
+++ b/apps/web/components/inventory/TopologyGraph.tsx
@@ -2,15 +2,17 @@
 
 import { useRef, useEffect, useState, useCallback, useMemo, useTransition } from "react";
 import { getImpactData, getDependencyAuditData, type GraphData } from "@/lib/actions/graph";
-import { hasSubnetScopeNode } from "@/lib/graph/scope-helpers";
 import type { GraphViewName, PositionedNode, LayoutResult } from "@/lib/graph/types";
 import { VIEW_CONFIGS, resolveViewForTaxonomy } from "@/lib/graph/view-config";
 import { useGraphLayout } from "@/lib/graph/use-graph-layout";
-import { getDeviceVisual, LEGEND_ENTRIES } from "@/lib/graph/device-icons";
+import { getDeviceVisual } from "@/lib/graph/device-icons";
 import { isDockerOriginNode } from "@/lib/graph/docker-filter";
-import { describeGraphScope, filterBySubnet, filterGraphData } from "@/lib/graph/subnet-scope";
+import { describeGraphScope } from "@/lib/graph/subnet-scope";
 import { projectPhysicalTopology } from "@/lib/graph/physical-topology";
+import { createScopeToken, isResetScopeKey, isSubnetSelectorKey, resolveDisplayedGraphData, resolveSubnetScopeState } from "@/lib/graph/topology-graph-state";
+import { usePhysicalTopologyViewport } from "@/lib/graph/use-physical-topology-viewport";
 import { TopologyIntegritySummary } from "@/components/inventory/TopologyIntegritySummary";
+import { TopologyLegend } from "@/components/inventory/TopologyLegend";
 import { OSI_LAYER_NAMES, SHOW_DOCKER_STORAGE_KEY, TOPOLOGY_GRAPH_LIVE_REGION_PROPS } from "@/lib/graph/topology-constants";
 
 // ─── Constants ──────────────────────────────────────────────────────────────
@@ -41,78 +43,6 @@ type Props = {
 };
 
 type SimNode = PositionedNode & { vx?: number; vy?: number };
-
-export function createScopeToken(
-  sequence: number,
-  selectedView: GraphViewName,
-  activeSubnetId: string | null,
-) {
-  return `${selectedView}:${activeSubnetId ?? "all"}:${sequence}`;
-}
-
-export function resolveSubnetScopeState(
-  graph: GraphData,
-  selectedView: GraphViewName,
-  activeSubnetId: string | null,
-): {
-  graphData: GraphData;
-  activeSubnetId: string | null;
-  invalidScope: boolean;
-} {
-  if (selectedView !== "subnet-topology" || !activeSubnetId) {
-    return {
-      graphData: graph,
-      activeSubnetId: null,
-      invalidScope: false,
-    };
-  }
-
-  if (!hasSubnetScopeNode(graph, activeSubnetId)) {
-    return {
-      graphData: graph,
-      activeSubnetId: null,
-      invalidScope: true,
-    };
-  }
-
-  return {
-    graphData: filterBySubnet(graph, activeSubnetId),
-    activeSubnetId,
-    invalidScope: false,
-  };
-}
-
-export function resolveDisplayedGraphData(
-  graph: GraphData,
-  selectedView: GraphViewName,
-  activeSubnetId: string | null,
-  focusNodeId: string | null,
-  maxHops: number,
-  hideDocker = false,
-) {
-  const viewConfig = VIEW_CONFIGS[selectedView];
-  const projectedGraph = selectedView === "network-topology"
-    ? projectPhysicalTopology(graph).data
-    : graph;
-  const scopeState = resolveSubnetScopeState(projectedGraph, selectedView, activeSubnetId);
-
-  return filterGraphData(scopeState.graphData, {
-    focusNodeId,
-    maxHops,
-    selectedView,
-    subnetFilter: "all",
-    viewConfig,
-    hideDocker,
-  });
-}
-
-export function isResetScopeKey(key: string) {
-  return key === "Enter" || key === " ";
-}
-
-export function isSubnetSelectorKey(key: string) {
-  return key === "Enter" || key === " ";
-}
 
 // ─── Theme palette ──────────────────────────────────────────────────────────
 // Canvas pixels don't inherit CSS variables, so we resolve theme tokens at
@@ -205,11 +135,7 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
   const [isPending, startTransition] = useTransition();
   const [dynamicData, setDynamicData] = useState<GraphData | null>(null);
   const effectiveData = useMemo(() => dynamicData ?? data, [dynamicData, data]);
-  const physicalProjection = useMemo(() => projectPhysicalTopology(effectiveData), [effectiveData]);
 
-  // Show Docker-origin nodes? Default off — Docker subnets/containers are
-  // noise for the external-of-platform viewpoint operators usually want.
-  // Persisted to localStorage so opt-ins survive across sessions.
   const [showDocker, setShowDocker] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
     return window.localStorage.getItem(SHOW_DOCKER_STORAGE_KEY) === "1";
@@ -251,6 +177,7 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
     () => resolveDisplayedGraphData(effectiveData, selectedView, activeSubnetId, focusNodeId, maxHops, hideDocker),
     [effectiveData, selectedView, activeSubnetId, focusNodeId, maxHops, hideDocker],
   );
+  const physicalProjection = useMemo(() => projectPhysicalTopology(filteredData), [filteredData]);
 
   // Layout computation
   const layoutResult = useGraphLayout(filteredData, viewConfig, focusNodeId, dimensions, scopeToken);
@@ -260,6 +187,8 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
     () => availableSubnets.find((subnet) => subnet.id === activeSubnetId) ?? null,
     [availableSubnets, activeSubnetId],
   );
+
+  const fitPhysicalTopology = usePhysicalTopologyViewport(layoutResult, dimensions, selectedView, setZoom, setPan);
 
   // Force simulation state (only for exploration view)
   const nodesRef = useRef<SimNode[]>([]);
@@ -515,12 +444,14 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
       const dv = ciType ? getDeviceVisual(ciType) : null;
       const nodeColor = dv?.color ?? node.color;
       const radius = (dv?.size ?? node.size ?? 4) * (isHovered || isFocus ? 1.5 : 1);
+      const topologyVisualScale = selectedView === "network-topology" ? Math.max(zoom, 0.65) : 1;
+      const renderRadius = radius / topologyVisualScale;
 
       ctx.globalAlpha = hoveredNode && !isHovered && !isFocus ? 0.3 : 1;
 
       if (dv && node.label === "InfraCI") {
         // Draw device-type symbol instead of circle
-        const fontSize = Math.max(12, radius * 2.5);
+        const fontSize = Math.max(12, radius * 2.5) / topologyVisualScale;
         ctx.font = `${fontSize}px -apple-system, sans-serif`;
         ctx.fillStyle = nodeColor;
         ctx.textAlign = "center";
@@ -530,7 +461,7 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
       } else {
         // Default circle for non-InfraCI nodes
         ctx.beginPath();
-        ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
+        ctx.arc(node.x, node.y, renderRadius, 0, Math.PI * 2);
         ctx.fillStyle = nodeColor;
         ctx.fill();
       }
@@ -539,21 +470,26 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
         ctx.strokeStyle = palette.focusRing;
         ctx.lineWidth = 2;
         ctx.beginPath();
-        ctx.arc(node.x, node.y, radius + 3, 0, Math.PI * 2);
+        ctx.arc(node.x, node.y, renderRadius + 3 / topologyVisualScale, 0, Math.PI * 2);
         ctx.stroke();
       }
 
       ctx.globalAlpha = 1;
 
-      if (isHovered || isFocus || (dv?.size ?? node.size) >= 6 || !isPositioned) {
-        ctx.font = `${isHovered || isFocus ? 11 : 9}px -apple-system, sans-serif`;
+      const showPhysicalLabel = selectedView === "network-topology" && zoom >= 0.55;
+      if (isHovered || isFocus || showPhysicalLabel || (dv?.size ?? node.size) >= 6 || !isPositioned) {
+        const labelSize = (isHovered || isFocus ? 11 : 9) / topologyVisualScale;
+        const label = showPhysicalLabel && node.name.length > 18
+          ? `${node.name.slice(0, 17)}\u2026`
+          : node.name;
+        ctx.font = `${labelSize}px -apple-system, sans-serif`;
         ctx.fillStyle = isHovered || isFocus ? palette.labelHover : palette.label;
         ctx.textAlign = "center";
-        ctx.fillText(node.name, node.x, node.y - radius - 6);
+        ctx.fillText(label, node.x, node.y - renderRadius - 6 / topologyVisualScale);
       }
     }
     ctx.restore();
-  }, [dimensions, hoveredNode, focusNodeId, layoutResult, filteredData.links, isForceLayout, zoom, pan, palette]);
+  }, [dimensions, hoveredNode, focusNodeId, layoutResult, filteredData.links, isForceLayout, zoom, pan, palette, selectedView, viewConfig.layout]);
 
   // ─── Initialize force simulation nodes ────────────────────────────────
   useEffect(() => {
@@ -880,14 +816,7 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
             <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--dpf-accent)] border-t-transparent" />
           </div>
         )}
-        <div className="absolute bottom-2 left-2 flex flex-wrap gap-x-3 gap-y-1 text-[9px] text-[var(--dpf-muted)]">
-          {LEGEND_ENTRIES.map((entry) => (
-            <span key={entry.ciType} className="flex items-center gap-1">
-              <span style={{ color: entry.visual.color, fontSize: 11 }}>{entry.visual.symbol}</span>
-              {entry.visual.label}
-            </span>
-          ))}
-        </div>
+        <TopologyLegend physical={selectedView === "network-topology"} />
         <div className="absolute bottom-2 right-2 text-[9px] text-[var(--dpf-muted)] flex items-center gap-2">
           <span>
             {displayNodes.length} nodes / {displayLinks.length} edges
@@ -897,7 +826,9 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
           {(zoom !== 1 || pan.x !== 0 || pan.y !== 0) && (
             <button
               type="button"
-              onClick={() => { setZoom(1); setPan({ x: 0, y: 0 }); }}
+              onClick={selectedView === "network-topology"
+                ? fitPhysicalTopology
+                : () => { setZoom(1); setPan({ x: 0, y: 0 }); }}
               className="text-[9px] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] underline"
             >
               reset
@@ -905,7 +836,7 @@ export function TopologyGraph({ data, defaultView, taxonomyNodeId, initialFocusN
           )}
         </div>
         {!focusNodeId && (
-          <div className="absolute bottom-2 left-2 text-[9px] text-[var(--dpf-muted)]">
+          <div className="absolute top-2 right-2 text-[9px] text-[var(--dpf-muted)]">
             Scroll to zoom / Shift-drag to pan / Click to focus
           </div>
         )}

--- a/apps/web/components/inventory/TopologyLegend.tsx
+++ b/apps/web/components/inventory/TopologyLegend.tsx
@@ -1,0 +1,15 @@
+import { LEGEND_ENTRIES, PHYSICAL_LEGEND_ENTRIES } from "@/lib/graph/device-icons";
+
+export function TopologyLegend({ physical }: { physical: boolean }) {
+  const entries = physical ? PHYSICAL_LEGEND_ENTRIES : LEGEND_ENTRIES;
+  return (
+    <div className="absolute bottom-2 left-2 flex flex-wrap gap-x-3 gap-y-1 text-dpf-caption text-[var(--dpf-muted)]">
+      {entries.map((entry) => (
+        <span key={entry.ciType} className="flex items-center gap-1">
+          <span style={{ color: entry.visual.color, fontSize: 11 }}>{entry.visual.symbol}</span>
+          {entry.visual.label}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/inventory/__tests__/TopologyGraph.subnet.test.tsx
+++ b/apps/web/components/inventory/__tests__/TopologyGraph.subnet.test.tsx
@@ -143,16 +143,16 @@ vi.mock("@/lib/graph/use-graph-layout", () => ({
 
 vi.mock("@/lib/graph/device-icons", () => ({
   LEGEND_ENTRIES: [],
+  PHYSICAL_LEGEND_ENTRIES: [],
   getDeviceVisual: () => null,
 }));
 
-const topologyGraphModule = await import("@/components/inventory/TopologyGraph");
+const { TopologyGraph } = await import("@/components/inventory/TopologyGraph");
 const {
-  TopologyGraph,
   createScopeToken,
   resolveDisplayedGraphData,
   resolveSubnetScopeState,
-} = topologyGraphModule;
+} = await import("@/lib/graph/topology-graph-state");
 
 const graphData: GraphData = {
   nodes: [

--- a/apps/web/components/inventory/__tests__/TopologyGraph.subnet.test.tsx
+++ b/apps/web/components/inventory/__tests__/TopologyGraph.subnet.test.tsx
@@ -152,6 +152,7 @@ const {
   createScopeToken,
   resolveDisplayedGraphData,
   resolveSubnetScopeState,
+  shouldShowViewportReset,
 } = await import("@/lib/graph/topology-graph-state");
 
 const graphData: GraphData = {
@@ -299,6 +300,12 @@ describe("TopologyGraph subnet scope", () => {
     expect(createScopeToken(1, "subnet-topology", "subnet-a")).not.toBe(
       createScopeToken(2, "subnet-topology", "subnet-b"),
     );
+  });
+
+  it("hides reset for automatic physical fitting until the operator moves the viewport", () => {
+    expect(shouldShowViewportReset("network-topology", false, 0.72, { x: 18, y: 12 })).toBe(false);
+    expect(shouldShowViewportReset("network-topology", true, 0.72, { x: 18, y: 12 })).toBe(true);
+    expect(shouldShowViewportReset("exploration", false, 0.72, { x: 18, y: 12 })).toBe(true);
   });
 
   it("rapidly switching subnets passes only the latest scoped graph and token to layout", () => {

--- a/apps/web/lib/graph/__tests__/device-icons.test.ts
+++ b/apps/web/lib/graph/__tests__/device-icons.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { getDeviceVisual, PHYSICAL_LEGEND_ENTRIES } from "@/lib/graph/device-icons";
+
+describe("physical topology device visuals", () => {
+  it("identifies the WAN uplink instead of rendering it as an unknown device", () => {
+    expect(getDeviceVisual("wan_uplink").label).toBe("WAN / Internet");
+  });
+
+  it("keeps the physical legend limited to the hierarchy shown in that view", () => {
+    expect(PHYSICAL_LEGEND_ENTRIES.map((entry) => entry.ciType)).toEqual([
+      "wan_uplink",
+      "router",
+      "switch",
+      "access_point",
+      "network_client",
+    ]);
+  });
+});

--- a/apps/web/lib/graph/__tests__/layout-physical.test.ts
+++ b/apps/web/lib/graph/__tests__/layout-physical.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import type { GraphData } from "@/lib/actions/graph";
+import { computePhysicalTopologyLayout } from "@/lib/graph/layout-physical";
+
+function node(id: string, ciType: string): GraphData["nodes"][number] {
+  return { id, name: id, label: "InfraCI", color: "", size: 1, ciType };
+}
+
+describe("computePhysicalTopologyLayout", () => {
+  it("places the physical spine from WAN down to clients", () => {
+    const data: GraphData = {
+      nodes: [
+        node("wan", "wan_uplink"),
+        node("gateway", "router"),
+        node("switch", "switch"),
+        node("ap", "access_point"),
+        node("client", "network_client"),
+      ],
+      links: [
+        { source: "wan", target: "gateway", type: "UPLINKS_TO" },
+        { source: "gateway", target: "switch", type: "CONNECTS_TO" },
+        { source: "switch", target: "ap", type: "CONNECTS_TO" },
+        { source: "ap", target: "client", type: "CONNECTS_TO" },
+      ],
+    };
+
+    const positions = new Map(computePhysicalTopologyLayout(data).nodes.map((item) => [item.id, item]));
+    expect(positions.get("wan")!.y).toBeLessThan(positions.get("gateway")!.y);
+    expect(positions.get("gateway")!.y).toBeLessThan(positions.get("switch")!.y);
+    expect(positions.get("switch")!.y).toBeLessThan(positions.get("ap")!.y);
+    expect(positions.get("ap")!.y).toBeLessThan(positions.get("client")!.y);
+  });
+
+  it("wraps large client groups beneath their actual access points", () => {
+    const clients = Array.from({ length: 72 }, (_, index) => node(`client-${index}`, "network_client"));
+    const aps = Array.from({ length: 4 }, (_, index) => node(`ap-${index}`, "access_point"));
+    const data: GraphData = {
+      nodes: [node("wan", "wan_uplink"), node("gateway", "router"), node("switch", "switch"), ...aps, ...clients],
+      links: [
+        { source: "wan", target: "gateway", type: "UPLINKS_TO" },
+        { source: "gateway", target: "switch", type: "CONNECTS_TO" },
+        ...aps.map((ap) => ({ source: "switch", target: ap.id, type: "CONNECTS_TO" })),
+        ...clients.map((client, index) => ({ source: `ap-${index % 4}`, target: client.id, type: "CONNECTS_TO" })),
+      ],
+    };
+
+    const result = computePhysicalTopologyLayout(data);
+    const positioned = new Map(result.nodes.map((item) => [item.id, item]));
+    const xs = result.nodes.map((item) => item.x);
+
+    expect(Math.max(...xs) - Math.min(...xs)).toBeLessThanOrEqual(2_600);
+    for (let index = 0; index < clients.length; index += 1) {
+      const parent = positioned.get(`ap-${index % 4}`)!;
+      const client = positioned.get(`client-${index}`)!;
+      expect(client.y).toBeGreaterThan(parent.y);
+      expect(Math.abs(client.x - parent.x)).toBeLessThanOrEqual(250);
+    }
+  });
+
+  it("is deterministic for the same graph", () => {
+    const data: GraphData = {
+      nodes: [node("gateway", "router"), node("switch", "switch")],
+      links: [{ source: "gateway", target: "switch", type: "CONNECTS_TO" }],
+    };
+    expect(computePhysicalTopologyLayout(data)).toEqual(computePhysicalTopologyLayout(data));
+  });
+});

--- a/apps/web/lib/graph/__tests__/physical-topology.test.ts
+++ b/apps/web/lib/graph/__tests__/physical-topology.test.ts
@@ -24,8 +24,8 @@ describe("projectPhysicalTopology", () => {
 
     expect(result.data.nodes.map((node) => node.id)).toEqual(["gateway", "switch", "ap"]);
     expect(result.data.links).toEqual([
-      { source: "switch", target: "gateway", type: "CONNECTS_TO" },
-      { source: "ap", target: "switch", type: "CONNECTS_TO" },
+      { source: "gateway", target: "switch", type: "CONNECTS_TO" },
+      { source: "switch", target: "ap", type: "CONNECTS_TO" },
     ]);
     expect(result.integrity).toMatchObject({ state: "current", deviceCount: 3, physicalLinkCount: 2, sources: ["unifi"] });
   });
@@ -44,5 +44,47 @@ describe("projectPhysicalTopology", () => {
   it("marks old physical evidence stale", () => {
     const result = projectPhysicalTopology(data, new Date("2026-08-10T21:00:01.000Z"));
     expect(result.integrity.state).toBe("stale");
+  });
+
+  it("orients observed child-to-parent facts as WAN to gateway to switch to AP to client", () => {
+    const graph: GraphData = {
+      nodes: [
+        { id: "wan", name: "Starlink", label: "InfraCI", color: "", size: 1, ciType: "wan_uplink" },
+        { id: "gateway", name: "Gateway", label: "InfraCI", color: "", size: 1, ciType: "router" },
+        { id: "switch", name: "Switch", label: "InfraCI", color: "", size: 1, ciType: "switch" },
+        { id: "ap", name: "AP", label: "InfraCI", color: "", size: 1, ciType: "access_point" },
+        { id: "client", name: "Client", label: "InfraCI", color: "", size: 1, ciType: "network_client" },
+      ],
+      links: [
+        { source: "gateway", target: "wan", type: "UPLINKS_TO" },
+        { source: "switch", target: "gateway", type: "CONNECTS_TO" },
+        { source: "ap", target: "switch", type: "CONNECTS_TO" },
+        { source: "client", target: "ap", type: "CONNECTS_TO" },
+      ],
+    };
+
+    expect(projectPhysicalTopology(graph).data.links).toEqual([
+      { source: "wan", target: "gateway", type: "UPLINKS_TO" },
+      { source: "gateway", target: "switch", type: "CONNECTS_TO" },
+      { source: "switch", target: "ap", type: "CONNECTS_TO" },
+      { source: "ap", target: "client", type: "CONNECTS_TO" },
+    ]);
+  });
+
+  it("deduplicates corroborated physical facts after display orientation", () => {
+    const result = projectPhysicalTopology({
+      nodes: data.nodes,
+      links: [
+        { source: "switch", target: "gateway", type: "CONNECTS_TO" },
+        { source: "gateway", target: "switch", type: "CONNECTS_TO" },
+        { source: "ap", target: "switch", type: "CONNECTS_TO" },
+      ],
+    });
+
+    expect(result.data.links).toEqual([
+      { source: "gateway", target: "switch", type: "CONNECTS_TO" },
+      { source: "switch", target: "ap", type: "CONNECTS_TO" },
+    ]);
+    expect(result.integrity.physicalLinkCount).toBe(2);
   });
 });

--- a/apps/web/lib/graph/__tests__/viewport-fit.test.ts
+++ b/apps/web/lib/graph/__tests__/viewport-fit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { fitNodesToViewport } from "@/lib/graph/viewport-fit";
+
+describe("fitNodesToViewport", () => {
+  it("fits a wide physical hierarchy inside the initial canvas", () => {
+    const transform = fitNodesToViewport(
+      [
+        { x: 30, y: 30 },
+        { x: 6_930, y: 430 },
+      ],
+      { width: 2_000, height: 800 },
+      { padding: 60 },
+    );
+
+    expect(transform.zoom).toBeLessThan(1);
+    for (const node of [{ x: 30, y: 30 }, { x: 6_930, y: 430 }]) {
+      const x = node.x * transform.zoom + transform.pan.x;
+      const y = node.y * transform.zoom + transform.pan.y;
+      expect(x).toBeGreaterThanOrEqual(60);
+      expect(x).toBeLessThanOrEqual(1_940);
+      expect(y).toBeGreaterThanOrEqual(60);
+      expect(y).toBeLessThanOrEqual(740);
+    }
+  });
+
+  it("does not enlarge a compact hierarchy beyond 100 percent", () => {
+    const transform = fitNodesToViewport(
+      [{ x: 100, y: 100 }, { x: 300, y: 300 }],
+      { width: 800, height: 500 },
+    );
+
+    expect(transform.zoom).toBe(1);
+    expect(transform.pan).toEqual({ x: 200, y: 50 });
+  });
+
+  it("returns the neutral transform when no positioned nodes exist", () => {
+    expect(fitNodesToViewport([], { width: 800, height: 500 })).toEqual({
+      zoom: 1,
+      pan: { x: 0, y: 0 },
+    });
+  });
+});

--- a/apps/web/lib/graph/device-icons.ts
+++ b/apps/web/lib/graph/device-icons.ts
@@ -8,11 +8,14 @@ export type DeviceVisual = {
   label: string;
 };
 
+const NETWORK_BLUE = "#38bdf8";
+
 export const DEVICE_VISUALS: Record<string, DeviceVisual> = {
+  wan_uplink:      { symbol: "\u2726", color: NETWORK_BLUE, size: 8, label: "WAN / Internet" },
   router:          { symbol: "\u25B3", color: "#f472b6", size: 8, label: "Router" },
   gateway:         { symbol: "\u25B3", color: "#f472b6", size: 8, label: "Gateway" },
   switch:          { symbol: "\u25C7", color: "#a78bfa", size: 7, label: "Switch" },
-  access_point:    { symbol: "\u25CE", color: "#38bdf8", size: 7, label: "Access Point" },
+  access_point:    { symbol: "\u25CE", color: NETWORK_BLUE, size: 7, label: "Access Point" },
   network_client:  { symbol: "\u25CF", color: "#22d3ee", size: 4, label: "Client" },
   subnet:          { symbol: "\u25A2", color: "#fbbf24", size: 6, label: "Subnet" },
   vlan:            { symbol: "\u25AC", color: "#fb923c", size: 5, label: "VLAN" },
@@ -25,10 +28,10 @@ export const DEVICE_VISUALS: Record<string, DeviceVisual> = {
   application:     { symbol: "\u25C6", color: "#4ade80", size: 5, label: "Application" },
   database:        { symbol: "\u25A3", color: "#c084fc", size: 6, label: "Database" },
   ai_service:      { symbol: "\u2606", color: "#e879f9", size: 6, label: "AI Service" },
-  network_device:  { symbol: "\u25CF", color: "#38bdf8", size: 5, label: "Network Device" },
+  network_device:  { symbol: "\u25CF", color: NETWORK_BLUE, size: 5, label: "Network Device" },
 };
 
-const DEFAULT_VISUAL: DeviceVisual = { symbol: "\u25CF", color: "#38bdf8", size: 5, label: "Unknown" };
+const DEFAULT_VISUAL: DeviceVisual = { symbol: "\u25CF", color: NETWORK_BLUE, size: 5, label: "Unknown" };
 
 export function getDeviceVisual(ciType: string | undefined | null): DeviceVisual {
   if (!ciType) return DEFAULT_VISUAL;
@@ -43,4 +46,12 @@ export const LEGEND_ENTRIES: Array<{ ciType: string; visual: DeviceVisual }> = [
   { ciType: "network_client", visual: DEVICE_VISUALS.network_client! },
   { ciType: "subnet", visual: DEVICE_VISUALS.subnet! },
   { ciType: "container", visual: DEVICE_VISUALS.container! },
+];
+
+export const PHYSICAL_LEGEND_ENTRIES: Array<{ ciType: string; visual: DeviceVisual }> = [
+  { ciType: "wan_uplink", visual: DEVICE_VISUALS.wan_uplink! },
+  { ciType: "router", visual: DEVICE_VISUALS.router! },
+  { ciType: "switch", visual: DEVICE_VISUALS.switch! },
+  { ciType: "access_point", visual: DEVICE_VISUALS.access_point! },
+  { ciType: "network_client", visual: DEVICE_VISUALS.network_client! },
 ];

--- a/apps/web/lib/graph/layout-physical.ts
+++ b/apps/web/lib/graph/layout-physical.ts
@@ -1,0 +1,90 @@
+import type { GraphData } from "@/lib/actions/graph";
+import type { LayoutResult, PositionedNode } from "./types";
+import { getPhysicalDisplayRank } from "./physical-topology";
+
+const CLIENT_COLUMNS = 5;
+const CLIENT_COLUMN_GAP = 100;
+const CLIENT_ROW_GAP = 65;
+const GROUP_GAP = 80;
+const RANK_GAP = 110;
+const TOP = 60;
+
+function displayRank(ciType: string | null | undefined) {
+  return getPhysicalDisplayRank(ciType) ?? 2;
+}
+
+/**
+ * Compact top-down layout for the physical network projection.
+ *
+ * Dagre puts every client on one rank-wide row, which makes a normal site
+ * thousands of pixels wide. This layout keeps the infrastructure spine in
+ * hierarchy order and wraps leaf clients beneath the AP/switch that observed
+ * them. It changes display coordinates only; canonical relationship direction
+ * remains owned by the inventory read model.
+ */
+export function computePhysicalTopologyLayout(data: GraphData): LayoutResult {
+  if (data.nodes.length === 0) return { nodes: [], links: [] };
+
+  const nodeIds = new Set(data.nodes.map((node) => node.id));
+  const children = new Map<string, string[]>();
+  const parentByChild = new Map<string, string>();
+  for (const link of data.links) {
+    if (!nodeIds.has(link.source) || !nodeIds.has(link.target)) continue;
+    const next = children.get(link.source) ?? [];
+    next.push(link.target);
+    children.set(link.source, next);
+    if (!parentByChild.has(link.target)) parentByChild.set(link.target, link.source);
+  }
+
+  const positions = new Map<string, { x: number; y: number }>();
+  const clientGroups = new Map<string, GraphData["nodes"]>();
+  for (const node of data.nodes) {
+    if (displayRank(node.ciType) !== 4) continue;
+    const parentId = parentByChild.get(node.id) ?? `unattached:${node.id}`;
+    const group = clientGroups.get(parentId) ?? [];
+    group.push(node);
+    clientGroups.set(parentId, group);
+  }
+
+  let cursorX = 0;
+  for (const [parentId, clients] of clientGroups) {
+    const columns = Math.min(CLIENT_COLUMNS, clients.length);
+    const groupWidth = Math.max(CLIENT_COLUMN_GAP, columns * CLIENT_COLUMN_GAP);
+    for (const [index, client] of clients.entries()) {
+      positions.set(client.id, {
+        x: cursorX + (index % CLIENT_COLUMNS + 0.5) * CLIENT_COLUMN_GAP,
+        y: TOP + 4 * RANK_GAP + Math.floor(index / CLIENT_COLUMNS) * CLIENT_ROW_GAP,
+      });
+    }
+    if (parentId.startsWith("unattached:")) {
+      cursorX += groupWidth + GROUP_GAP;
+    } else {
+      positions.set(parentId, {
+        x: cursorX + groupWidth / 2,
+        y: TOP + 3 * RANK_GAP,
+      });
+      cursorX += groupWidth + GROUP_GAP;
+    }
+  }
+
+  let fallbackX = Math.max(CLIENT_COLUMN_GAP / 2, cursorX);
+  for (const rank of [3, 2, 1, 0]) {
+    for (const node of data.nodes.filter((candidate) => displayRank(candidate.ciType) === rank)) {
+      const childPositions = (children.get(node.id) ?? [])
+        .map((id) => positions.get(id))
+        .filter((position): position is { x: number; y: number } => Boolean(position));
+      const existing = positions.get(node.id);
+      const x = childPositions.length > 0
+        ? childPositions.reduce((total, position) => total + position.x, 0) / childPositions.length
+        : existing?.x ?? fallbackX;
+      positions.set(node.id, { x, y: TOP + rank * RANK_GAP });
+      if (childPositions.length === 0 && !existing) fallbackX += 150;
+    }
+  }
+
+  const nodes: PositionedNode[] = data.nodes.map((node) => ({
+    ...node,
+    ...(positions.get(node.id) ?? { x: fallbackX, y: TOP + displayRank(node.ciType) * RANK_GAP }),
+  }));
+  return { nodes, links: data.links };
+}

--- a/apps/web/lib/graph/physical-topology.ts
+++ b/apps/web/lib/graph/physical-topology.ts
@@ -16,6 +16,21 @@ const MANAGED_DEVICE_TYPES = new Set([
   "wan_uplink",
 ]);
 
+const DISPLAY_RANK_BY_CI_TYPE: Record<string, number> = {
+  wan_uplink: 0,
+  gateway: 1,
+  router: 1,
+  switch: 2,
+  network_device: 2,
+  access_point: 3,
+  network_client: 4,
+  host: 4,
+};
+
+export function getPhysicalDisplayRank(ciType: string | null | undefined): number | null {
+  return DISPLAY_RANK_BY_CI_TYPE[ciType ?? ""] ?? null;
+}
+
 export type PhysicalTopologyIntegrity = {
   state: "current" | "partial" | "stale" | "empty";
   deviceCount: number;
@@ -33,7 +48,27 @@ export function projectPhysicalTopology(
   const connectedIds = new Set(physicalLinks.flatMap((link) => [link.source, link.target]));
   const nodes = graph.nodes.filter((node) => connectedIds.has(node.id));
   const nodeIds = new Set(nodes.map((node) => node.id));
-  const links = physicalLinks.filter((link) => nodeIds.has(link.source) && nodeIds.has(link.target));
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  const seenLinks = new Set<string>();
+  const links = physicalLinks
+    .filter((link) => nodeIds.has(link.source) && nodeIds.has(link.target))
+    .map((link) => {
+      const sourceRank = getPhysicalDisplayRank(nodesById.get(link.source)?.ciType);
+      const targetRank = getPhysicalDisplayRank(nodesById.get(link.target)?.ciType);
+      if (sourceRank != null && targetRank != null && sourceRank > targetRank) {
+        return { ...link, source: link.target, target: link.source };
+      }
+      return link;
+    })
+    .filter((link) => {
+      const endpoints = link.type === "CONNECTS_TO" || link.type === "PEER_OF"
+        ? [link.source, link.target].sort().join("-")
+        : `${link.source}-${link.target}`;
+      const key = `${link.type}-${endpoints}`;
+      if (seenLinks.has(key)) return false;
+      seenLinks.add(key);
+      return true;
+    });
   const deviceCount = nodes.filter((node) => MANAGED_DEVICE_TYPES.has(node.ciType ?? "")).length;
   const sources = [...new Set(nodes.map((node) => node.sourceKind).filter((value): value is string => Boolean(value)))].sort();
   const observedTimes = nodes

--- a/apps/web/lib/graph/topology-graph-state.ts
+++ b/apps/web/lib/graph/topology-graph-state.ts
@@ -1,0 +1,61 @@
+import type { GraphData } from "@/lib/actions/graph";
+import { hasSubnetScopeNode } from "./scope-helpers";
+import { projectPhysicalTopology } from "./physical-topology";
+import { filterBySubnet, filterGraphData } from "./subnet-scope";
+import { VIEW_CONFIGS } from "./view-config";
+import type { GraphViewName } from "./types";
+
+export function createScopeToken(
+  sequence: number,
+  selectedView: GraphViewName,
+  activeSubnetId: string | null,
+) {
+  return `${selectedView}:${activeSubnetId ?? "all"}:${sequence}`;
+}
+
+export function resolveSubnetScopeState(
+  graph: GraphData,
+  selectedView: GraphViewName,
+  activeSubnetId: string | null,
+): { graphData: GraphData; activeSubnetId: string | null; invalidScope: boolean } {
+  if (selectedView !== "subnet-topology" || !activeSubnetId) {
+    return { graphData: graph, activeSubnetId: null, invalidScope: false };
+  }
+  if (!hasSubnetScopeNode(graph, activeSubnetId)) {
+    return { graphData: graph, activeSubnetId: null, invalidScope: true };
+  }
+  return {
+    graphData: filterBySubnet(graph, activeSubnetId),
+    activeSubnetId,
+    invalidScope: false,
+  };
+}
+
+export function resolveDisplayedGraphData(
+  graph: GraphData,
+  selectedView: GraphViewName,
+  activeSubnetId: string | null,
+  focusNodeId: string | null,
+  maxHops: number,
+  hideDocker = false,
+) {
+  const viewConfig = VIEW_CONFIGS[selectedView];
+  const projectedGraph = selectedView === "network-topology"
+    ? projectPhysicalTopology(graph).data
+    : graph;
+  const scopeState = resolveSubnetScopeState(projectedGraph, selectedView, activeSubnetId);
+  return filterGraphData(scopeState.graphData, {
+    focusNodeId,
+    maxHops,
+    selectedView,
+    subnetFilter: "all",
+    viewConfig,
+    hideDocker,
+  });
+}
+
+export function isResetScopeKey(key: string) {
+  return key === "Enter" || key === " ";
+}
+
+export const isSubnetSelectorKey = isResetScopeKey;

--- a/apps/web/lib/graph/topology-graph-state.ts
+++ b/apps/web/lib/graph/topology-graph-state.ts
@@ -59,3 +59,13 @@ export function isResetScopeKey(key: string) {
 }
 
 export const isSubnetSelectorKey = isResetScopeKey;
+
+export function shouldShowViewportReset(
+  selectedView: GraphViewName,
+  hasViewportInteraction: boolean,
+  zoom: number,
+  pan: { x: number; y: number },
+) {
+  if (selectedView === "network-topology") return hasViewportInteraction;
+  return zoom !== 1 || pan.x !== 0 || pan.y !== 0;
+}

--- a/apps/web/lib/graph/use-graph-layout.ts
+++ b/apps/web/lib/graph/use-graph-layout.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import type { GraphData } from "@/lib/actions/graph";
 import type { LayoutResult, ViewConfig } from "./types";
 import { computeHierarchicalLayout } from "./layout-hierarchical";
+import { computePhysicalTopologyLayout } from "./layout-physical";
 import { computeRadialLayout } from "./layout-radial";
 import { computeSwimLaneLayout } from "./layout-swimlane";
 
@@ -41,14 +42,18 @@ export function useGraphLayout(
 
     switch (view.layout) {
       case "hierarchical": {
-        const roots = detectRoots(filtered, view);
         if (!isCancelled) {
-          setResult(
-            computeHierarchicalLayout(filtered, {
-              direction: view.direction,
-              rootIds: roots,
-            }),
-          );
+          if (view.name === "network-topology") {
+            setResult(computePhysicalTopologyLayout(filtered));
+          } else {
+            const roots = detectRoots(filtered, view);
+            setResult(
+              computeHierarchicalLayout(filtered, {
+                direction: view.direction,
+                rootIds: roots,
+              }),
+            );
+          }
         }
         break;
       }

--- a/apps/web/lib/graph/use-physical-topology-viewport.ts
+++ b/apps/web/lib/graph/use-physical-topology-viewport.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, type Dispatch, type SetStateAction } from "react";
+
+import type { GraphViewName, LayoutResult } from "./types";
+import { fitNodesToViewport } from "./viewport-fit";
+
+type Pan = { x: number; y: number };
+
+export function usePhysicalTopologyViewport(
+  layout: LayoutResult | null,
+  dimensions: { width: number; height: number },
+  selectedView: GraphViewName,
+  setZoom: Dispatch<SetStateAction<number>>,
+  setPan: Dispatch<SetStateAction<Pan>>,
+) {
+  const fit = useCallback(() => {
+    if (!layout) return;
+    const transform = fitNodesToViewport(layout.nodes, dimensions, { padding: 60 });
+    setZoom(transform.zoom);
+    setPan(transform.pan);
+  }, [dimensions, layout, setPan, setZoom]);
+
+  useEffect(() => {
+    if (selectedView === "network-topology" && layout) fit();
+  }, [fit, layout, selectedView]);
+
+  return fit;
+}

--- a/apps/web/lib/graph/viewport-fit.ts
+++ b/apps/web/lib/graph/viewport-fit.ts
@@ -1,0 +1,53 @@
+type Point = { x?: number; y?: number };
+
+type Viewport = { width: number; height: number };
+
+type FitOptions = {
+  padding?: number;
+  minZoom?: number;
+  maxZoom?: number;
+};
+
+export type ViewportTransform = {
+  zoom: number;
+  pan: { x: number; y: number };
+};
+
+export function fitNodesToViewport(
+  nodes: Point[],
+  viewport: Viewport,
+  options: FitOptions = {},
+): ViewportTransform {
+  const positioned = nodes.filter(
+    (node): node is Required<Point> => Number.isFinite(node.x) && Number.isFinite(node.y),
+  );
+  if (positioned.length === 0) {
+    return { zoom: 1, pan: { x: 0, y: 0 } };
+  }
+
+  const padding = options.padding ?? 50;
+  const minZoom = options.minZoom ?? 0.1;
+  const maxZoom = options.maxZoom ?? 1;
+  const xs = positioned.map((node) => node.x);
+  const ys = positioned.map((node) => node.y);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  const graphWidth = Math.max(1, maxX - minX);
+  const graphHeight = Math.max(1, maxY - minY);
+  const availableWidth = Math.max(1, viewport.width - padding * 2);
+  const availableHeight = Math.max(1, viewport.height - padding * 2);
+  const zoom = Math.max(
+    minZoom,
+    Math.min(maxZoom, availableWidth / graphWidth, availableHeight / graphHeight),
+  );
+
+  return {
+    zoom,
+    pan: {
+      x: viewport.width / 2 - ((minX + maxX) / 2) * zoom,
+      y: viewport.height / 2 - ((minY + maxY) / 2) * zoom,
+    },
+  };
+}

--- a/docs/superpowers/plans/2026-08-08-truthful-physical-network-topology-implementation.md
+++ b/docs/superpowers/plans/2026-08-08-truthful-physical-network-topology-implementation.md
@@ -196,12 +196,20 @@ No schema migration is planned: existing `DiscoveryConnection`, `DiscoveryRun`, 
 
 Documentation is required because the current UniFi guide claims the edge already renders the real network, which the installed runtime disproves.
 
+## Design grounding
+
+- Existing specs/plans reviewed: this implementation plan and its accepted truthful physical topology design.
+- Current code substrate reviewed: physical projection, hierarchical layout, viewport transforms, canvas rendering, and the live UniFi graph output.
+- Source of truth: canonical inventory entities and relationships; the layout changes display direction and coordinates only.
+- Decision: complete the accepted physical hierarchy contract with a compact, automatically fitted topology projection.
+
 ## Implementation record
 
 Implemented on `fix/truthful-network-topology` as one atomic repair. The final shape preserves the design decisions while making these execution-level adjustments:
 
 - HTTP test servers replaced checked-in vendor fixtures, keeping real network identifiers and payloads out of the repository while covering official pagination, device detail, clients, and bounded legacy fallback.
 - The physical read model filters and orients canonical graph data before layout, so no change to the generic layout engine or subnet-scoping helper was required.
+- Canonical-runtime review after the official UniFi evidence repair exposed that the initial projection had not actually implemented its specified display orientation: child-to-parent facts rendered clients above the gateway, and Dagre placed every client on one clipped row. The physical read model now orients and deduplicates display edges, while a topology-specific layout wraps clients beneath their observed AP/switch and automatically fits the first viewport. Canonical facts remain unchanged.
 - Source kind and observation freshness are projected through `discovery-sync.ts` and `graph-sync.ts`; the UI does not query UniFi-specific persistence.
 - Shared topology constants and the UniFi TLS-aware fetch helper were extracted to keep changed modules within repository size limits.
 - No migration was required; the existing discovery, inventory, attribution, and graph contracts were sufficient.

--- a/docs/ux-fit/2026-08-08-truthful-network-topology.ux-fit.json
+++ b/docs/ux-fit/2026-08-08-truthful-network-topology.ux-fit.json
@@ -4,7 +4,7 @@
   "decisionInteractionId": "DI-1709E09FD759",
   "scope": {
     "files": [
-      "apps/web/components/inventory/TopologyIntegritySummary.tsx"
+      "apps/web/components/inventory/TopologyGraph.tsx"
     ]
   },
   "evidence": {


### PR DESCRIPTION
## Summary

- render the Infrastructure physical topology as a compact gateway-to-switch-to-device hierarchy instead of a dense force-directed projection
- derive display-only placement from canonical physical relationships while preserving the inventory graph as source truth
- use stable device icons, fit the initial viewport to the hierarchy, and clarify the topology legend
- complete the accepted truthful-network-topology plan and measured UX-fit evidence for BI-6649C95A

## Verification

- Governed merged-code pregate passed against current `origin/main`, including the repository's exhaustive unit, typecheck, production-build, and policy gates.
- Targeted graph tests cover physical projection, hierarchical layout, viewport fitting, device icons, and subnet behavior.
- UX-fit evidence is committed at `docs/ux-fit/2026-08-08-truthful-network-topology.ux-fit.json`.
- Migration: not applicable; this final slice changes topology projection and presentation only.
- Post-merge acceptance: deploy through `/ops/self-upgrade`, compare the live topology with the UniFi controller, and record visual acceptance before closing BI-6649C95A / WC-F3143CF3.

## Documentation impact

The implementation plan is updated with the final hierarchy and viewport behavior. No additional operator documentation is needed because the data-source and discovery contract documentation landed with the earlier atomic slices of this BI.
