### PR TITLE
feat(install): establish typed installation operating-intent contract (BI-A9F60372)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -5016,6 +5016,7 @@
         "idempotence-guarantee",
         "agent-toolchain-only-update",
         "where-state-lives",
+        "installation-operating-intent-and-environment-class",
         "diagnostics",
         "show-substrate-flag",
         "dpf-doctor",

--- a/apps/web/lib/installation-journey/operating-intent.test.ts
+++ b/apps/web/lib/installation-journey/operating-intent.test.ts
@@ -1,63 +1,251 @@
 import { describe, expect, it, vi } from "vitest";
-
 import {
+  absorbBootstrapIntent,
+  deriveExistingInstallIntent,
   INSTALLATION_OPERATING_INTENT_KEY,
   loadInstallationOperatingIntent,
   resolveInvestmentFundingAuthority,
+  saveInstallationOperatingIntent,
+  type BootstrapIntentEnvelope,
+  type InstallationIntentDb,
+  type LoadedInstallationOperatingIntent,
 } from "./operating-intent";
+import type { InstallationOperatingIntentV1 } from "@dpf/db/installation-operating-intent";
 
-function dbWith(value: unknown) {
-  return {
-    platformConfig: {
-      findUnique: vi.fn().mockResolvedValue(value === undefined ? null : { value }),
+describe("Installation Operating Intent Repository & Derivation (EP-1FABA22D / BI-A9F60372)", () => {
+  const validIntent: InstallationOperatingIntentV1 = {
+    schemaVersion: 1,
+    primaryPurpose: "operate-organization",
+    secondaryPurposes: ["participate-community"],
+    relationshipIntents: ["same-organization"],
+    evidence: [
+      {
+        source: "organization",
+        claim: "Existing enterprise business",
+        observedAt: "2026-08-08T12:00:00.000Z",
+      },
+    ],
+    confidence: "high",
+    confirmation: {
+      status: "confirmed",
+      confirmedAt: "2026-08-08T12:00:00.000Z",
+      confirmedByPrincipalId: "usr-admin",
     },
   };
-}
 
-const intent = (primaryPurpose: string, status = "confirmed") => ({
-  schemaVersion: 1,
-  primaryPurpose,
-  secondaryPurposes: [],
-  relationshipIntents: [],
-  evidence: [{ source: "human", claim: "Confirmed by the operator.", observedAt: "2026-08-08T12:00:00.000Z" }],
-  confidence: "high",
-  confirmation: status === "confirmed"
-    ? { status, confirmedAt: "2026-08-08T12:00:00.000Z", confirmedByPrincipalId: "principal-1" }
-    : { status },
-});
+  describe("loadInstallationOperatingIntent", () => {
+    it("returns missing when config key does not exist", async () => {
+      const db: InstallationIntentDb = {
+        platformConfig: {
+          findUnique: vi.fn().mockResolvedValue(null),
+          upsert: vi.fn(),
+        },
+      };
 
-describe("installation operating intent repository", () => {
-  it("reads the canonical PlatformConfig key", async () => {
-    const db = dbWith(intent("operate-organization"));
-
-    const result = await loadInstallationOperatingIntent(db);
-
-    expect(db.platformConfig.findUnique).toHaveBeenCalledWith({
-      where: { key: INSTALLATION_OPERATING_INTENT_KEY },
-      select: { value: true },
+      const result = await loadInstallationOperatingIntent(db);
+      expect(result).toEqual({ status: "missing" });
+      expect(db.platformConfig.findUnique).toHaveBeenCalledWith({
+        where: { key: INSTALLATION_OPERATING_INTENT_KEY },
+        select: { value: true },
+      });
     });
-    expect(result.status).toBe("valid");
+
+    it("returns valid when valid intent is stored", async () => {
+      const db: InstallationIntentDb = {
+        platformConfig: {
+          findUnique: vi.fn().mockResolvedValue({ value: validIntent }),
+          upsert: vi.fn(),
+        },
+      };
+
+      const result = await loadInstallationOperatingIntent(db);
+      expect(result).toEqual({ status: "valid", intent: validIntent });
+    });
+
+    it("returns invalid when config value is malformed", async () => {
+      const db: InstallationIntentDb = {
+        platformConfig: {
+          findUnique: vi.fn().mockResolvedValue({ value: { schemaVersion: 99 } }),
+          upsert: vi.fn(),
+        },
+      };
+
+      const result = await loadInstallationOperatingIntent(db);
+      expect(result.status).toBe("invalid");
+    });
   });
 
-  it.each([
-    ["missing", dbWith(undefined)],
-    ["invalid", dbWith({ schemaVersion: 99 })],
-  ])("fails closed for %s configuration", async (status, db) => {
-    const loaded = await loadInstallationOperatingIntent(db);
-    expect(loaded.status).toBe(status);
-    expect(resolveInvestmentFundingAuthority(loaded)).toMatchObject({ allowed: false });
+  describe("saveInstallationOperatingIntent", () => {
+    it("validates and upserts intent", async () => {
+      const upsertMock = vi.fn().mockResolvedValue({});
+      const db: InstallationIntentDb = {
+        platformConfig: {
+          findUnique: vi.fn(),
+          upsert: upsertMock,
+        },
+      };
+
+      const result = await saveInstallationOperatingIntent(db, validIntent);
+      expect(result.ok).toBe(true);
+      expect(upsertMock).toHaveBeenCalledWith({
+        where: { key: INSTALLATION_OPERATING_INTENT_KEY },
+        update: { value: validIntent },
+        create: {
+          key: INSTALLATION_OPERATING_INTENT_KEY,
+          value: validIntent,
+        },
+      });
+    });
+
+    it("refuses invalid intent without saving", async () => {
+      const upsertMock = vi.fn();
+      const db: InstallationIntentDb = {
+        platformConfig: {
+          findUnique: vi.fn(),
+          upsert: upsertMock,
+        },
+      };
+
+      const invalid = { ...validIntent, primaryPurpose: "invalid" as any };
+      const result = await saveInstallationOperatingIntent(db, invalid);
+      expect(result.ok).toBe(false);
+      expect(upsertMock).not.toHaveBeenCalled();
+    });
   });
 
-  it("allows only a confirmed organization-operating installation", async () => {
-    const production = await loadInstallationOperatingIntent(dbWith(intent("operate-organization")));
-    const companion = await loadInstallationOperatingIntent(dbWith(intent("evolve-dpf")));
-    const suggested = await loadInstallationOperatingIntent(dbWith(intent("operate-organization", "suggested")));
+  describe("deriveExistingInstallIntent", () => {
+    it("derives evolve-dpf when running in development environment", async () => {
+      const db: InstallationIntentDb = {
+        platformConfig: { findUnique: vi.fn(), upsert: vi.fn() },
+      };
 
-    expect(resolveInvestmentFundingAuthority(production)).toEqual({ allowed: true });
-    expect(resolveInvestmentFundingAuthority(companion)).toMatchObject({
-      allowed: false,
-      error: "installation_authority_required",
+      const derived = await deriveExistingInstallIntent(db, {
+        environmentClass: "development",
+        isDevWorkspace: true,
+      });
+
+      expect(derived.primaryPurpose).toBe("evolve-dpf");
+      expect(derived.confidence).toBe("high");
+      expect(derived.confirmation.status).toBe("suggested");
+      expect(derived.evidence.length).toBeGreaterThan(0);
     });
-    expect(resolveInvestmentFundingAuthority(suggested)).toMatchObject({ allowed: false });
+
+    it("derives operate-organization when organization is present in production", async () => {
+      const db: InstallationIntentDb = {
+        platformConfig: { findUnique: vi.fn(), upsert: vi.fn() },
+        organization: {
+          findFirst: vi.fn().mockResolvedValue({ id: "org-1", name: "Acme Corp" }),
+        },
+        businessContext: {
+          findFirst: vi.fn().mockResolvedValue({ id: "bc-1", mission: "Serve clients" }),
+        },
+      };
+
+      const derived = await deriveExistingInstallIntent(db, {
+        environmentClass: "production",
+        isDevWorkspace: false,
+      });
+
+      expect(derived.primaryPurpose).toBe("operate-organization");
+      expect(derived.confidence).toBe("high");
+      expect(derived.confirmation.status).toBe("suggested");
+      expect(derived.evidence.some((e) => e.source === "organization")).toBe(true);
+      expect(derived.evidence.some((e) => e.source === "business-context")).toBe(true);
+    });
+
+    it("derives deliver-managed-services when service-provider link exists", async () => {
+      const db: InstallationIntentDb = {
+        platformConfig: { findUnique: vi.fn(), upsert: vi.fn() },
+        federationLink: {
+          findMany: vi.fn().mockResolvedValue([{ id: "link-1", preset: "service-provider" }]),
+        },
+      };
+
+      const derived = await deriveExistingInstallIntent(db, {
+        environmentClass: "production",
+        isDevWorkspace: false,
+      });
+
+      expect(derived.primaryPurpose).toBe("deliver-managed-services");
+      expect(derived.relationshipIntents).toContain("service-provider");
+      expect(derived.confirmation.status).toBe("suggested");
+    });
+  });
+
+  describe("absorbBootstrapIntent", () => {
+    it("absorbs unabsorbed bootstrap intent into PlatformConfig", async () => {
+      const upsertMock = vi.fn().mockResolvedValue({});
+      const db: InstallationIntentDb = {
+        platformConfig: {
+          findUnique: vi.fn().mockResolvedValue(null),
+          upsert: upsertMock,
+        },
+      };
+
+      const bootstrap: BootstrapIntentEnvelope = {
+        schemaVersion: 1,
+        primaryPurpose: "operate-organization",
+        secondaryPurposes: ["grow-channel"],
+        relationshipIntents: ["channel"],
+        confidence: "high",
+        recordedAt: "2026-08-08T10:00:00.000Z",
+        absorbedAt: null,
+      };
+
+      const result = await absorbBootstrapIntent(db, bootstrap);
+      expect(result.absorbed).toBe(true);
+      expect(result.intent?.primaryPurpose).toBe("operate-organization");
+      expect(result.intent?.secondaryPurposes).toEqual(["grow-channel"]);
+      expect(result.intent?.confirmation.status).toBe("suggested");
+      expect(upsertMock).toHaveBeenCalled();
+    });
+
+    it("does not overwrite already-confirmed intent", async () => {
+      const upsertMock = vi.fn();
+      const db: InstallationIntentDb = {
+        platformConfig: {
+          findUnique: vi.fn().mockResolvedValue({ value: validIntent }),
+          upsert: upsertMock,
+        },
+      };
+
+      const bootstrap: BootstrapIntentEnvelope = {
+        schemaVersion: 1,
+        primaryPurpose: "deliver-managed-services",
+        confidence: "high",
+        recordedAt: "2026-08-08T10:00:00.000Z",
+      };
+
+      const result = await absorbBootstrapIntent(db, bootstrap);
+      expect(result.absorbed).toBe(false);
+      expect(result.intent?.primaryPurpose).toBe("operate-organization");
+      expect(upsertMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("resolveInvestmentFundingAuthority", () => {
+    it("allows confirmed operate-organization install", () => {
+      const loaded: LoadedInstallationOperatingIntent = {
+        status: "valid",
+        intent: validIntent,
+      };
+      expect(resolveInvestmentFundingAuthority(loaded)).toEqual({ allowed: true });
+    });
+
+    it("refuses unconfirmed install", () => {
+      const loaded: LoadedInstallationOperatingIntent = {
+        status: "valid",
+        intent: {
+          ...validIntent,
+          confirmation: { status: "suggested" },
+        },
+      };
+      const result = resolveInvestmentFundingAuthority(loaded);
+      expect(result.allowed).toBe(false);
+    });
+
+    it("refuses missing install intent", () => {
+      expect(resolveInvestmentFundingAuthority({ status: "missing" }).allowed).toBe(false);
+    });
   });
 });

--- a/apps/web/lib/installation-journey/operating-intent.ts
+++ b/apps/web/lib/installation-journey/operating-intent.ts
@@ -1,16 +1,39 @@
+// EP-1FABA22D · Purpose-Aware Installation and Ecosystem Productivity (BI-A9F60372)
+// Guarded repository boundary over Prisma PlatformConfig key `installation.operating-intent.v1`.
+
 import {
   parseInstallationOperatingIntent,
+  validateOperatingIntent,
   type InstallationOperatingIntentV1,
+  type InstallationOperatingPurpose,
+  type InstallationEnvironmentClass,
+  type InstallationOperatingIntentEvidence,
+  type InstallationIntentConfidence,
 } from "@dpf/db/installation-operating-intent";
+import type { Prisma } from "@dpf/db";
 
 export const INSTALLATION_OPERATING_INTENT_KEY = "installation.operating-intent.v1";
 
-type InstallationIntentDb = {
+export type InstallationIntentDb = {
   platformConfig: {
     findUnique(args: {
       where: { key: string };
-      select: { value: true };
+      select?: { value: true } | Record<string, boolean>;
     }): Promise<{ value: unknown } | null>;
+    upsert(args: {
+      where: { key: string };
+      update: { value: Prisma.InputJsonValue };
+      create: { key: string; value: Prisma.InputJsonValue };
+    }): Promise<unknown>;
+  };
+  organization?: {
+    findFirst?(args?: unknown): Promise<{ id: string; name: string } | null>;
+  };
+  businessContext?: {
+    findFirst?(args?: unknown): Promise<{ id: string; mission?: string | null } | null>;
+  };
+  federationLink?: {
+    findMany?(args?: unknown): Promise<Array<{ id: string; preset?: string | null }>>;
   };
 };
 
@@ -36,6 +59,186 @@ export async function loadInstallationOperatingIntent(
   return parsed.ok
     ? { status: "valid", intent: parsed.value }
     : { status: "invalid", error: parsed.error };
+}
+
+export async function saveInstallationOperatingIntent(
+  db: InstallationIntentDb,
+  intent: InstallationOperatingIntentV1,
+): Promise<{ ok: true; intent: InstallationOperatingIntentV1 } | { ok: false; error: string }> {
+  const validated = validateOperatingIntent(intent);
+  if (!validated.valid || !validated.data) {
+    return { ok: false, error: validated.errors.join("; ") };
+  }
+
+  await db.platformConfig.upsert({
+    where: { key: INSTALLATION_OPERATING_INTENT_KEY },
+    update: { value: validated.data as unknown as Prisma.InputJsonValue },
+    create: {
+      key: INSTALLATION_OPERATING_INTENT_KEY,
+      value: validated.data as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  return { ok: true, intent: validated.data };
+}
+
+/**
+ * Derives suggested installation intent for existing installations.
+ * Invariant: derivation produces `status: "suggested"` and never auto-confirms.
+ */
+export async function deriveExistingInstallIntent(
+  db: InstallationIntentDb,
+  options?: {
+    environmentClass?: InstallationEnvironmentClass;
+    isDevWorkspace?: boolean;
+  },
+): Promise<InstallationOperatingIntentV1> {
+  const now = new Date().toISOString();
+  const evidence: InstallationOperatingIntentEvidence[] = [];
+  let primaryPurpose: InstallationOperatingPurpose = "operate-organization";
+  let confidence: InstallationIntentConfidence = "medium";
+  const relationshipIntents: ("same-organization" | "service-provider" | "channel" | "community-peer")[] = [];
+
+  const envClass = options?.environmentClass ?? (process.env.NODE_ENV === "production" ? "production" : "development");
+  const isDevWorkspace = options?.isDevWorkspace ?? Boolean(process.env.DPF_DEV_WORKSPACE_PATH);
+
+  if (isDevWorkspace || envClass === "development") {
+    primaryPurpose = "evolve-dpf";
+    confidence = "high";
+    evidence.push({
+      source: "installer",
+      claim: "Development workspace or development environment detected on host",
+      observedAt: now,
+    });
+  }
+
+  if (db.organization?.findFirst) {
+    const org = await db.organization.findFirst();
+    if (org) {
+      evidence.push({
+        source: "organization",
+        claim: "Existing organization record present",
+        sourceRef: org.id,
+        observedAt: now,
+      });
+      if (envClass === "production" && !isDevWorkspace) {
+        primaryPurpose = "operate-organization";
+        confidence = "high";
+      }
+    }
+  }
+
+  if (db.businessContext?.findFirst) {
+    const context = await db.businessContext.findFirst();
+    if (context) {
+      evidence.push({
+        source: "business-context",
+        claim: "Existing business context configured",
+        sourceRef: context.id,
+        observedAt: now,
+      });
+    }
+  }
+
+  if (db.federationLink?.findMany) {
+    const links = await db.federationLink.findMany();
+    if (links && links.length > 0) {
+      for (const link of links) {
+        if (link.preset === "service-provider" && !relationshipIntents.includes("service-provider")) {
+          relationshipIntents.push("service-provider");
+        } else if (link.preset === "channel" && !relationshipIntents.includes("channel")) {
+          relationshipIntents.push("channel");
+        } else if (link.preset === "same-organization" && !relationshipIntents.includes("same-organization")) {
+          relationshipIntents.push("same-organization");
+        } else if (link.preset === "community-peer" && !relationshipIntents.includes("community-peer")) {
+          relationshipIntents.push("community-peer");
+        }
+      }
+      evidence.push({
+        source: "federation",
+        claim: `Found ${links.length} existing federation link(s)`,
+        observedAt: now,
+      });
+      if (relationshipIntents.includes("service-provider") && primaryPurpose !== "evolve-dpf") {
+        primaryPurpose = "deliver-managed-services";
+      }
+    }
+  }
+
+  if (evidence.length === 0) {
+    evidence.push({
+      source: "installer",
+      claim: "Default installation intent derived from host environment",
+      observedAt: now,
+    });
+    confidence = "low";
+  }
+
+  return {
+    schemaVersion: 1,
+    primaryPurpose,
+    secondaryPurposes: [],
+    relationshipIntents,
+    evidence,
+    confidence,
+    confirmation: {
+      status: "suggested",
+    },
+  };
+}
+
+export interface BootstrapIntentEnvelope {
+  schemaVersion: 1;
+  primaryPurpose: InstallationOperatingPurpose;
+  secondaryPurposes?: InstallationOperatingPurpose[];
+  relationshipIntents?: ("same-organization" | "service-provider" | "channel" | "community-peer")[];
+  pairedProductionInstallationRef?: string;
+  confidence: InstallationIntentConfidence;
+  recordedAt: string;
+  absorbedAt?: string | null;
+}
+
+/**
+ * Idempotently absorbs pre-DB bootstrap intent from install-state into PlatformConfig.
+ */
+export async function absorbBootstrapIntent(
+  db: InstallationIntentDb,
+  bootstrapIntent: BootstrapIntentEnvelope | null | undefined,
+): Promise<{ absorbed: boolean; intent?: InstallationOperatingIntentV1 }> {
+  if (!bootstrapIntent || bootstrapIntent.absorbedAt) {
+    return { absorbed: false };
+  }
+
+  const existing = await loadInstallationOperatingIntent(db);
+  if (existing.status === "valid" && existing.intent.confirmation.status === "confirmed") {
+    return { absorbed: false, intent: existing.intent };
+  }
+
+  const now = new Date().toISOString();
+  const intent: InstallationOperatingIntentV1 = {
+    schemaVersion: 1,
+    primaryPurpose: bootstrapIntent.primaryPurpose,
+    secondaryPurposes: bootstrapIntent.secondaryPurposes ?? [],
+    relationshipIntents: bootstrapIntent.relationshipIntents ?? [],
+    pairedProductionInstallationRef: bootstrapIntent.pairedProductionInstallationRef,
+    evidence: [
+      {
+        source: "installer",
+        claim: "Bootstrap intent captured by installer prior to database initialization",
+        observedAt: bootstrapIntent.recordedAt || now,
+      },
+    ],
+    confidence: bootstrapIntent.confidence || "medium",
+    confirmation: {
+      status: "suggested",
+    },
+  };
+
+  const saveRes = await saveInstallationOperatingIntent(db, intent);
+  if (saveRes.ok) {
+    return { absorbed: true, intent: saveRes.intent };
+  }
+  return { absorbed: false };
 }
 
 /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -906,7 +906,7 @@ services:
   dpf-stt:
     profiles: ["runtime-local-speech", "tts"]
     # Pinned to the multi-arch index digest for hwdsl2/whisper-server:latest
-    # resolved on 2026-08-06 (the prior 120e4b78… digest was deleted from the
+    # resolved on 2026-08-15 (the prior 0b03ecb5… digest was deleted from the
     # registry — Release Image Manifest Guard caught it again). The registry
     # owner re-pushes :latest periodically and prunes the previous index, so
     # this digest must be re-resolved every time the guard fails. Bump
@@ -916,7 +916,7 @@ services:
     # the sidecar won't start, set DPF_STT_IMAGE in .env to a reachable ref
     # (e.g. hwdsl2/whisper-server:latest) then `docker compose up -d dpf-stt`,
     # and open a PR re-resolving the digest here (this is that PR's pattern).
-    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:0b03ecb54c8247cd4fe42e808746f36f44eff7998dc45018554c50252975e29f}
+    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:166a8c04e2687608a116372e92f11bfda3e963f3c1dbf390a7c820db0f45887b}
     restart: unless-stopped
     logging: *default-logging
     environment:

--- a/docs/operations/install.md
+++ b/docs/operations/install.md
@@ -184,6 +184,14 @@ session start.
 
 Bearer tokens never appear in this file. The `transcript` field is routed through `redactTranscriptForPersistence` before write; the `mcpReadiness` and `smokeTest` shapes are bearer-free by contract. If you find a bearer-shaped substring in this file on any install, it is a security regression — see `BI-4B17051B` for the contract.
 
+## Installation operating intent and environment class
+
+Per EP-1FABA22D (BI-A9F60372), `install-state.json` (v2 schema) captures the canonical local host environment class and pre-DB bootstrap intent envelope:
+
+- **`environmentClass`** — `"production"`, `"development"`, `"test"`, or `null`. Installer state is the canonical source of truth for the local host's environment fact; `FederationLink.environmentClass` is canonical for peer link facts.
+- **`bootstrapIntent`** — Pre-DB envelope recorded by the installer before runtime database availability. On portal runtime boot, `absorbBootstrapIntent` idempotently ingests this envelope into `PlatformConfig` under key `installation.operating-intent.v1` with `status: "suggested"` and marks `absorbedAt`.
+- **Purpose Confirmation Invariant** — Expressing operating purpose (`operate-organization`, `evolve-dpf`, `deliver-managed-services`, `grow-channel`, `participate-community`) configures platform productivity and compiles work; it **never grants identity, trust, authority, qualification, or permission**.
+
 ## Diagnostics
 
 ### `--show-substrate` flag
@@ -209,9 +217,11 @@ For the avoidance of doubt, the installer:
 
 ## See also
 
+- Spec: [`docs/superpowers/specs/2026-08-08-purpose-aware-installation-ecosystem-productivity-design.md`](../superpowers/specs/2026-08-08-purpose-aware-installation-ecosystem-productivity-design.md)
+- Plan: [`docs/superpowers/plans/2026-08-08-purpose-aware-installation-ecosystem-productivity.md`](../superpowers/plans/2026-08-08-purpose-aware-installation-ecosystem-productivity.md)
 - Spec: [`docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md`](../superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md)
 - Plan: [`docs/superpowers/plans/2026-05-26-agent-toolchain-bootstrap.md`](../superpowers/plans/2026-05-26-agent-toolchain-bootstrap.md)
 - Skill pack: [`packages/dpf-skill-pack/README.md`](../../packages/dpf-skill-pack/README.md)
 - Planning library: [`packages/dpf-bootstrap/README.md`](../../packages/dpf-bootstrap/README.md)
 - State schema: [`scripts/installer/install-state.schema.json`](../../scripts/installer/install-state.schema.json)
-- Backlog: BI-4B17051B (EP-INSTALL-HARDENING-2026-05-23)
+- Backlog: BI-A9F60372 (EP-1FABA22D), BI-4B17051B (EP-INSTALL-HARDENING-2026-05-23)

--- a/packages/db/src/installation-operating-intent.ts
+++ b/packages/db/src/installation-operating-intent.ts
@@ -1,8 +1,15 @@
+// EP-1FABA22D · Purpose-Aware Installation and Ecosystem Productivity (BI-A9F60372)
+// Pure TypeScript types, validator, and projection helpers for the installation operating intent.
+// Single source of truth for operating purpose, environment class, and profile snapshot contracts.
+
+import { createHash } from "crypto";
 import {
   FEDERATION_RELATIONSHIP_PRESETS,
+  isFederationRelationshipPreset,
   type FederationRelationshipPreset,
 } from "./federation-link-types";
 
+/** Canonical installation operating purposes */
 export const INSTALLATION_OPERATING_PURPOSES = [
   "operate-organization",
   "evolve-dpf",
@@ -10,10 +17,26 @@ export const INSTALLATION_OPERATING_PURPOSES = [
   "grow-channel",
   "participate-community",
 ] as const;
-
 export type InstallationOperatingPurpose = (typeof INSTALLATION_OPERATING_PURPOSES)[number];
 
-export const INSTALLATION_INTENT_EVIDENCE_SOURCES = [
+/** Canonical environment classes (converged with federation vocabulary) */
+export const INSTALLATION_ENVIRONMENT_CLASSES = [
+  "production",
+  "development",
+  "test",
+] as const;
+export type InstallationEnvironmentClass = (typeof INSTALLATION_ENVIRONMENT_CLASSES)[number];
+
+/** Confirmation status for the intent */
+export const INSTALLATION_INTENT_CONFIRMATION_STATUSES = [
+  "suggested",
+  "confirmed",
+  "needs-review",
+] as const;
+export type InstallationIntentConfirmationStatus = (typeof INSTALLATION_INTENT_CONFIRMATION_STATUSES)[number];
+
+/** Admissible sources for intent derivation evidence */
+export const INSTALLATION_EVIDENCE_SOURCES = [
   "installer",
   "organization",
   "business-context",
@@ -21,100 +44,278 @@ export const INSTALLATION_INTENT_EVIDENCE_SOURCES = [
   "federation",
   "human",
 ] as const;
+export type InstallationEvidenceSource = (typeof INSTALLATION_EVIDENCE_SOURCES)[number];
 
-export type InstallationIntentEvidenceSource = (typeof INSTALLATION_INTENT_EVIDENCE_SOURCES)[number];
-export type InstallationIntentConfidence = "high" | "medium" | "low";
-export type InstallationIntentConfirmationStatus = "suggested" | "confirmed" | "needs-review";
+/** Intent confidence levels */
+export const INSTALLATION_INTENT_CONFIDENCE_LEVELS = [
+  "high",
+  "medium",
+  "low",
+] as const;
+export type InstallationIntentConfidence = (typeof INSTALLATION_INTENT_CONFIDENCE_LEVELS)[number];
 
-export type InstallationOperatingIntentV1 = {
+/** Privacy-safe evidence descriptor for intent derivation */
+export interface InstallationOperatingIntentEvidence {
+  source: InstallationEvidenceSource;
+  claim: string;
+  sourceRef?: string;
+  valueFingerprint?: string;
+  observedAt: string;
+}
+
+/** Stored semantic operating intent in PlatformConfig key `installation.operating-intent.v1` */
+export interface InstallationOperatingIntentV1 {
   schemaVersion: 1;
   primaryPurpose: InstallationOperatingPurpose;
   secondaryPurposes: InstallationOperatingPurpose[];
   relationshipIntents: FederationRelationshipPreset[];
   pairedProductionInstallationRef?: string;
-  evidence: Array<{
-    source: InstallationIntentEvidenceSource;
-    claim: string;
-    sourceRef?: string;
-    valueFingerprint?: string;
-    observedAt: string;
-  }>;
+  evidence: InstallationOperatingIntentEvidence[];
   confidence: InstallationIntentConfidence;
   confirmation: {
     status: InstallationIntentConfirmationStatus;
     confirmedAt?: string;
     confirmedByPrincipalId?: string;
   };
-};
+}
 
-export type InstallationOperatingIntentParseResult =
+/** Read-time derived snapshot of the installation operating profile */
+export interface InstallationOperatingProfileSnapshot {
+  schemaVersion: 1;
+  profileFingerprint: string;
+  environmentClass: InstallationEnvironmentClass;
+  primaryPurpose: InstallationOperatingPurpose;
+  secondaryPurposes: InstallationOperatingPurpose[];
+  relationshipIntents: FederationRelationshipPreset[];
+  pairedProductionInstallationRef?: string;
+  confidence: InstallationIntentConfidence;
+  confirmationStatus: InstallationIntentConfirmationStatus;
+  confirmedAt?: string;
+  confirmedByPrincipalId?: string;
+  evidence: InstallationOperatingIntentEvidence[];
+}
+
+export function isInstallationOperatingPurpose(value: unknown): value is InstallationOperatingPurpose {
+  return typeof value === "string" && (INSTALLATION_OPERATING_PURPOSES as readonly string[]).includes(value);
+}
+
+export function isInstallationEnvironmentClass(value: unknown): value is InstallationEnvironmentClass {
+  return typeof value === "string" && (INSTALLATION_ENVIRONMENT_CLASSES as readonly string[]).includes(value);
+}
+
+export function isInstallationIntentConfirmationStatus(value: unknown): value is InstallationIntentConfirmationStatus {
+  return typeof value === "string" && (INSTALLATION_INTENT_CONFIRMATION_STATUSES as readonly string[]).includes(value);
+}
+
+export function isInstallationEvidenceSource(value: unknown): value is InstallationEvidenceSource {
+  return typeof value === "string" && (INSTALLATION_EVIDENCE_SOURCES as readonly string[]).includes(value);
+}
+
+export function isInstallationIntentConfidence(value: unknown): value is InstallationIntentConfidence {
+  return typeof value === "string" && (INSTALLATION_INTENT_CONFIDENCE_LEVELS as readonly string[]).includes(value);
+}
+
+export interface IntentValidationResult {
+  valid: boolean;
+  errors: string[];
+  data?: InstallationOperatingIntentV1;
+}
+
+/**
+ * Validates raw data against the InstallationOperatingIntentV1 schema.
+ * Rejects unknown schema versions, invalid enums, and duplicate purposes.
+ */
+export function validateOperatingIntent(raw: unknown): IntentValidationResult {
+  const errors: string[] = [];
+
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { valid: false, errors: ["Operating intent must be a non-null object"] };
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  if (obj.schemaVersion !== 1) {
+    errors.push(`Unsupported or missing schemaVersion: ${String(obj.schemaVersion)} (expected 1)`);
+  }
+
+  if (!isInstallationOperatingPurpose(obj.primaryPurpose)) {
+    errors.push(`Invalid primaryPurpose: ${String(obj.primaryPurpose)}`);
+  }
+
+  const secondaryPurposes: InstallationOperatingPurpose[] = [];
+  if (!Array.isArray(obj.secondaryPurposes)) {
+    errors.push("secondaryPurposes must be an array");
+  } else {
+    const seen = new Set<string>();
+    for (const item of obj.secondaryPurposes) {
+      if (!isInstallationOperatingPurpose(item)) {
+        errors.push(`Invalid secondaryPurpose: ${String(item)}`);
+      } else if (seen.has(item)) {
+        errors.push(`Duplicate secondaryPurpose: ${item}`);
+      } else if (item === obj.primaryPurpose) {
+        errors.push(`secondaryPurpose cannot duplicate primaryPurpose: ${item}`);
+      } else {
+        seen.add(item);
+        secondaryPurposes.push(item);
+      }
+    }
+  }
+
+  const relationshipIntents: FederationRelationshipPreset[] = [];
+  if (!Array.isArray(obj.relationshipIntents)) {
+    errors.push("relationshipIntents must be an array");
+  } else {
+    const seenPresets = new Set<string>();
+    for (const item of obj.relationshipIntents) {
+      if (typeof item !== "string" || !isFederationRelationshipPreset(item)) {
+        errors.push(`Invalid relationshipIntent: ${String(item)}`);
+      } else if (seenPresets.has(item)) {
+        errors.push(`Duplicate relationshipIntent: ${item}`);
+      } else {
+        seenPresets.add(item);
+        relationshipIntents.push(item);
+      }
+    }
+  }
+
+  if (
+    obj.pairedProductionInstallationRef !== undefined &&
+    typeof obj.pairedProductionInstallationRef !== "string"
+  ) {
+    errors.push("pairedProductionInstallationRef must be a string if provided");
+  }
+
+  const evidence: InstallationOperatingIntentEvidence[] = [];
+  if (!Array.isArray(obj.evidence)) {
+    errors.push("evidence must be an array");
+  } else {
+    for (let i = 0; i < obj.evidence.length; i++) {
+      const ev = obj.evidence[i];
+      if (!ev || typeof ev !== "object" || Array.isArray(ev)) {
+        errors.push(`evidence[${i}] must be an object`);
+        continue;
+      }
+      const evObj = ev as Record<string, unknown>;
+      if (!isInstallationEvidenceSource(evObj.source)) {
+        errors.push(`evidence[${i}].source is invalid: ${String(evObj.source)}`);
+      }
+      if (typeof evObj.claim !== "string" || evObj.claim.trim().length === 0) {
+        errors.push(`evidence[${i}].claim must be a non-empty string`);
+      }
+      if (evObj.sourceRef !== undefined && typeof evObj.sourceRef !== "string") {
+        errors.push(`evidence[${i}].sourceRef must be a string`);
+      }
+      if (evObj.valueFingerprint !== undefined && typeof evObj.valueFingerprint !== "string") {
+        errors.push(`evidence[${i}].valueFingerprint must be a string`);
+      }
+      if (typeof evObj.observedAt !== "string" || Number.isNaN(Date.parse(evObj.observedAt))) {
+        errors.push(`evidence[${i}].observedAt must be a valid ISO date string`);
+      }
+      if (errors.length === 0) {
+        evidence.push({
+          source: evObj.source as InstallationEvidenceSource,
+          claim: String(evObj.claim),
+          sourceRef: evObj.sourceRef as string | undefined,
+          valueFingerprint: evObj.valueFingerprint as string | undefined,
+          observedAt: String(evObj.observedAt),
+        });
+      }
+    }
+  }
+
+  if (!isInstallationIntentConfidence(obj.confidence)) {
+    errors.push(`Invalid confidence level: ${String(obj.confidence)}`);
+  }
+
+  if (!obj.confirmation || typeof obj.confirmation !== "object" || Array.isArray(obj.confirmation)) {
+    errors.push("confirmation must be an object");
+  } else {
+    const conf = obj.confirmation as Record<string, unknown>;
+    if (!isInstallationIntentConfirmationStatus(conf.status)) {
+      errors.push(`Invalid confirmation.status: ${String(conf.status)}`);
+    }
+    if (conf.confirmedAt !== undefined) {
+      if (typeof conf.confirmedAt !== "string" || Number.isNaN(Date.parse(conf.confirmedAt))) {
+        errors.push("confirmation.confirmedAt must be a valid ISO date string");
+      }
+    }
+    if (conf.confirmedByPrincipalId !== undefined && typeof conf.confirmedByPrincipalId !== "string") {
+      errors.push("confirmation.confirmedByPrincipalId must be a string");
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  const conf = obj.confirmation as Record<string, unknown>;
+  const validatedData: InstallationOperatingIntentV1 = {
+    schemaVersion: 1,
+    primaryPurpose: obj.primaryPurpose as InstallationOperatingPurpose,
+    secondaryPurposes,
+    relationshipIntents,
+    pairedProductionInstallationRef: obj.pairedProductionInstallationRef as string | undefined,
+    evidence,
+    confidence: obj.confidence as InstallationIntentConfidence,
+    confirmation: {
+      status: conf.status as InstallationIntentConfirmationStatus,
+      confirmedAt: conf.confirmedAt as string | undefined,
+      confirmedByPrincipalId: conf.confirmedByPrincipalId as string | undefined,
+    },
+  };
+
+  return { valid: true, errors: [], data: validatedData };
+}
+
+export type ParseInstallationOperatingIntentResult =
   | { ok: true; value: InstallationOperatingIntentV1 }
   | { ok: false; error: string };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
+/**
+ * Parses and validates an operating intent. Returns structured result with ok: true/false.
+ */
+export function parseInstallationOperatingIntent(raw: unknown): ParseInstallationOperatingIntentResult {
+  const result = validateOperatingIntent(raw);
+  if (result.valid && result.data) {
+    return { ok: true, value: result.data };
+  }
+  return { ok: false, error: result.errors.join("; ") || "Invalid operating intent" };
 }
 
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
+/**
+ * Safely parses and validates an operating intent. Returns null if corrupt or invalid.
+ */
+export function parseOperatingIntent(raw: unknown): InstallationOperatingIntentV1 | null {
+  const result = validateOperatingIntent(raw);
+  return result.valid && result.data ? result.data : null;
 }
 
-function isIsoDate(value: unknown): value is string {
-  return isNonEmptyString(value) && Number.isFinite(Date.parse(value));
-}
+/**
+ * Computes a deterministic sha256 profile fingerprint over stable semantic facts.
+ * Volatile timestamps and mutable display copy are excluded.
+ */
+export function computeProfileFingerprint(
+  input: Omit<InstallationOperatingProfileSnapshot, "profileFingerprint">
+): string {
+  const payload = {
+    v: input.schemaVersion,
+    env: input.environmentClass,
+    primary: input.primaryPurpose,
+    secondary: [...input.secondaryPurposes].sort(),
+    relationships: [...input.relationshipIntents].sort(),
+    pairedRef: input.pairedProductionInstallationRef ?? null,
+    confidence: input.confidence,
+    status: input.confirmationStatus,
+    confirmedBy: input.confirmedByPrincipalId ?? null,
+    evidence: input.evidence
+      .map((e) => ({
+        s: e.source,
+        c: e.claim,
+        ref: e.sourceRef ?? null,
+        fp: e.valueFingerprint ?? null,
+      }))
+      .sort((a, b) => a.c.localeCompare(b.c)),
+  };
 
-function isPurpose(value: unknown): value is InstallationOperatingPurpose {
-  return (INSTALLATION_OPERATING_PURPOSES as readonly unknown[]).includes(value);
-}
-
-function isRelationship(value: unknown): value is FederationRelationshipPreset {
-  return (FEDERATION_RELATIONSHIP_PRESETS as readonly unknown[]).includes(value);
-}
-
-export function parseInstallationOperatingIntent(value: unknown): InstallationOperatingIntentParseResult {
-  if (!isRecord(value) || value.schemaVersion !== 1) {
-    return { ok: false, error: "Unsupported or missing installation operating-intent schema version." };
-  }
-  if (!isPurpose(value.primaryPurpose)) {
-    return { ok: false, error: "Installation primary purpose is not recognized." };
-  }
-  if (!Array.isArray(value.secondaryPurposes) || !value.secondaryPurposes.every(isPurpose)) {
-    return { ok: false, error: "Installation secondary purposes are invalid." };
-  }
-  const purposeSet = new Set([value.primaryPurpose, ...value.secondaryPurposes]);
-  if (purposeSet.size !== value.secondaryPurposes.length + 1) {
-    return { ok: false, error: "Installation purposes must be unique." };
-  }
-  if (!Array.isArray(value.relationshipIntents) || !value.relationshipIntents.every(isRelationship)) {
-    return { ok: false, error: "Installation relationship intent is not recognized." };
-  }
-  if (new Set(value.relationshipIntents).size !== value.relationshipIntents.length) {
-    return { ok: false, error: "Installation relationship intents must be unique." };
-  }
-  if (value.pairedProductionInstallationRef !== undefined && !isNonEmptyString(value.pairedProductionInstallationRef)) {
-    return { ok: false, error: "Paired production installation reference must be a non-empty string." };
-  }
-  if (!Array.isArray(value.evidence) || !value.evidence.every((entry) => {
-    if (!isRecord(entry)) return false;
-    return (INSTALLATION_INTENT_EVIDENCE_SOURCES as readonly unknown[]).includes(entry.source)
-      && isNonEmptyString(entry.claim)
-      && isIsoDate(entry.observedAt)
-      && (entry.sourceRef === undefined || isNonEmptyString(entry.sourceRef))
-      && (entry.valueFingerprint === undefined || isNonEmptyString(entry.valueFingerprint));
-  })) {
-    return { ok: false, error: "Installation intent evidence is invalid." };
-  }
-  if (value.confidence !== "high" && value.confidence !== "medium" && value.confidence !== "low") {
-    return { ok: false, error: "Installation intent confidence is invalid." };
-  }
-  if (!isRecord(value.confirmation)
-    || !["suggested", "confirmed", "needs-review"].includes(String(value.confirmation.status))) {
-    return { ok: false, error: "Installation intent confirmation is invalid." };
-  }
-  if (value.confirmation.status === "confirmed"
-    && (!isIsoDate(value.confirmation.confirmedAt) || !isNonEmptyString(value.confirmation.confirmedByPrincipalId))) {
-    return { ok: false, error: "Confirmed installation intent requires confirmation provenance." };
-  }
-
-  return { ok: true, value: value as InstallationOperatingIntentV1 };
+  return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
 }

--- a/packages/db/src/installation-operating-intent.ts
+++ b/packages/db/src/installation-operating-intent.ts
@@ -234,13 +234,20 @@ export function validateOperatingIntent(raw: unknown): IntentValidationResult {
     if (!isInstallationIntentConfirmationStatus(conf.status)) {
       errors.push(`Invalid confirmation.status: ${String(conf.status)}`);
     }
-    if (conf.confirmedAt !== undefined) {
+    if (conf.status === "confirmed") {
       if (typeof conf.confirmedAt !== "string" || Number.isNaN(Date.parse(conf.confirmedAt))) {
+        errors.push("confirmation.confirmedAt is required when status is 'confirmed'");
+      }
+      if (typeof conf.confirmedByPrincipalId !== "string" || conf.confirmedByPrincipalId.trim().length === 0) {
+        errors.push("confirmation.confirmedByPrincipalId is required when status is 'confirmed'");
+      }
+    } else {
+      if (conf.confirmedAt !== undefined && (typeof conf.confirmedAt !== "string" || Number.isNaN(Date.parse(conf.confirmedAt)))) {
         errors.push("confirmation.confirmedAt must be a valid ISO date string");
       }
-    }
-    if (conf.confirmedByPrincipalId !== undefined && typeof conf.confirmedByPrincipalId !== "string") {
-      errors.push("confirmation.confirmedByPrincipalId must be a string");
+      if (conf.confirmedByPrincipalId !== undefined && typeof conf.confirmedByPrincipalId !== "string") {
+        errors.push("confirmation.confirmedByPrincipalId must be a string");
+      }
     }
   }
 

--- a/packages/db/test/installation-operating-intent.test.ts
+++ b/packages/db/test/installation-operating-intent.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeProfileFingerprint,
+  INSTALLATION_ENVIRONMENT_CLASSES,
+  INSTALLATION_EVIDENCE_SOURCES,
+  INSTALLATION_INTENT_CONFIDENCE_LEVELS,
+  INSTALLATION_INTENT_CONFIRMATION_STATUSES,
+  INSTALLATION_OPERATING_PURPOSES,
+  isInstallationEnvironmentClass,
+  isInstallationEvidenceSource,
+  isInstallationIntentConfidence,
+  isInstallationIntentConfirmationStatus,
+  isInstallationOperatingPurpose,
+  parseOperatingIntent,
+  validateOperatingIntent,
+  type InstallationOperatingIntentV1,
+  type InstallationOperatingProfileSnapshot,
+} from "../src/installation-operating-intent";
+
+describe("Installation Operating Intent Contract (EP-1FABA22D / BI-A9F60372)", () => {
+  it("maintains closed purpose and environment sets", () => {
+    expect(INSTALLATION_OPERATING_PURPOSES).toEqual([
+      "operate-organization",
+      "evolve-dpf",
+      "deliver-managed-services",
+      "grow-channel",
+      "participate-community",
+    ]);
+
+    expect(INSTALLATION_ENVIRONMENT_CLASSES).toEqual([
+      "production",
+      "development",
+      "test",
+    ]);
+
+    expect(INSTALLATION_INTENT_CONFIRMATION_STATUSES).toEqual([
+      "suggested",
+      "confirmed",
+      "needs-review",
+    ]);
+
+    expect(INSTALLATION_EVIDENCE_SOURCES).toEqual([
+      "installer",
+      "organization",
+      "business-context",
+      "capability",
+      "federation",
+      "human",
+    ]);
+
+    expect(INSTALLATION_INTENT_CONFIDENCE_LEVELS).toEqual(["high", "medium", "low"]);
+  });
+
+  it("evaluates type guards correctly", () => {
+    expect(isInstallationOperatingPurpose("operate-organization")).toBe(true);
+    expect(isInstallationOperatingPurpose("invalid-purpose")).toBe(false);
+    expect(isInstallationOperatingPurpose(null)).toBe(false);
+
+    expect(isInstallationEnvironmentClass("production")).toBe(true);
+    expect(isInstallationEnvironmentClass("staging")).toBe(false);
+
+    expect(isInstallationIntentConfirmationStatus("confirmed")).toBe(true);
+    expect(isInstallationIntentConfirmationStatus("pending")).toBe(false);
+
+    expect(isInstallationEvidenceSource("installer")).toBe(true);
+    expect(isInstallationEvidenceSource("unknown")).toBe(false);
+
+    expect(isInstallationIntentConfidence("high")).toBe(true);
+    expect(isInstallationIntentConfidence("critical")).toBe(false);
+  });
+
+  const validIntent: InstallationOperatingIntentV1 = {
+    schemaVersion: 1,
+    primaryPurpose: "operate-organization",
+    secondaryPurposes: ["participate-community"],
+    relationshipIntents: ["same-organization", "service-provider"],
+    pairedProductionInstallationRef: "inst-prod-001",
+    evidence: [
+      {
+        source: "installer",
+        claim: "Installer created dedicated production container topology",
+        sourceRef: "install-state.v2",
+        valueFingerprint: "sha256:abcd",
+        observedAt: "2026-08-08T12:00:00.000Z",
+      },
+      {
+        source: "organization",
+        claim: "Organization industry is healthcare-wellness",
+        sourceRef: "org-1",
+        observedAt: "2026-08-08T12:05:00.000Z",
+      },
+    ],
+    confidence: "high",
+    confirmation: {
+      status: "confirmed",
+      confirmedAt: "2026-08-08T12:10:00.000Z",
+      confirmedByPrincipalId: "princ-admin-1",
+    },
+  };
+
+  it("validates a well-formed operating intent", () => {
+    const result = validateOperatingIntent(validIntent);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.data).toEqual(validIntent);
+
+    const parsed = parseOperatingIntent(validIntent);
+    expect(parsed).toEqual(validIntent);
+  });
+
+  it("rejects non-object or null input", () => {
+    expect(validateOperatingIntent(null).valid).toBe(false);
+    expect(validateOperatingIntent("string").valid).toBe(false);
+    expect(validateOperatingIntent([]).valid).toBe(false);
+    expect(parseOperatingIntent(null)).toBeNull();
+  });
+
+  it("rejects unsupported schema versions", () => {
+    const invalid = { ...validIntent, schemaVersion: 2 };
+    const result = validateOperatingIntent(invalid);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("schemaVersion"))).toBe(true);
+  });
+
+  it("rejects invalid primary purpose", () => {
+    const invalid = { ...validIntent, primaryPurpose: "run-everything" };
+    const result = validateOperatingIntent(invalid);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("primaryPurpose"))).toBe(true);
+  });
+
+  it("rejects secondary purpose when it duplicates primary purpose or itself", () => {
+    const dupPrimary = {
+      ...validIntent,
+      secondaryPurposes: ["operate-organization"],
+    };
+    expect(validateOperatingIntent(dupPrimary).valid).toBe(false);
+
+    const dupSelf = {
+      ...validIntent,
+      secondaryPurposes: ["evolve-dpf", "evolve-dpf"],
+    };
+    expect(validateOperatingIntent(dupSelf).valid).toBe(false);
+  });
+
+  it("rejects invalid or duplicate relationship intents", () => {
+    const invalidPreset = {
+      ...validIntent,
+      relationshipIntents: ["untrusted-peer"],
+    };
+    expect(validateOperatingIntent(invalidPreset).valid).toBe(false);
+
+    const duplicatePreset = {
+      ...validIntent,
+      relationshipIntents: ["same-organization", "same-organization"],
+    };
+    expect(validateOperatingIntent(duplicatePreset).valid).toBe(false);
+  });
+
+  it("rejects malformed evidence items", () => {
+    const emptyClaim = {
+      ...validIntent,
+      evidence: [
+        {
+          source: "installer",
+          claim: "   ",
+          observedAt: "2026-08-08T12:00:00.000Z",
+        },
+      ],
+    };
+    expect(validateOperatingIntent(emptyClaim).valid).toBe(false);
+
+    const invalidDate = {
+      ...validIntent,
+      evidence: [
+        {
+          source: "installer",
+          claim: "valid claim",
+          observedAt: "not-a-date",
+        },
+      ],
+    };
+    expect(validateOperatingIntent(invalidDate).valid).toBe(false);
+  });
+
+  it("rejects invalid confirmation dates or statuses", () => {
+    const invalidStatus = {
+      ...validIntent,
+      confirmation: {
+        status: "auto-approved",
+      },
+    };
+    expect(validateOperatingIntent(invalidStatus).valid).toBe(false);
+
+    const invalidDate = {
+      ...validIntent,
+      confirmation: {
+        status: "confirmed",
+        confirmedAt: "invalid-time",
+      },
+    };
+    expect(validateOperatingIntent(invalidDate).valid).toBe(false);
+  });
+
+  describe("computeProfileFingerprint", () => {
+    const baseSnapshot: Omit<InstallationOperatingProfileSnapshot, "profileFingerprint"> = {
+      schemaVersion: 1,
+      environmentClass: "production",
+      primaryPurpose: "operate-organization",
+      secondaryPurposes: ["participate-community", "deliver-managed-services"],
+      relationshipIntents: ["service-provider", "same-organization"],
+      pairedProductionInstallationRef: "prod-ref",
+      confidence: "high",
+      confirmationStatus: "confirmed",
+      confirmedAt: "2026-08-08T12:00:00.000Z",
+      confirmedByPrincipalId: "princ-1",
+      evidence: [
+        {
+          source: "installer",
+          claim: "Host has 64GB RAM",
+          sourceRef: "install-state",
+          observedAt: "2026-08-08T12:00:00.000Z",
+        },
+        {
+          source: "organization",
+          claim: "Verified commercial domain",
+          observedAt: "2026-08-08T12:01:00.000Z",
+        },
+      ],
+    };
+
+    it("is deterministic and order-invariant for array facts", () => {
+      const fp1 = computeProfileFingerprint(baseSnapshot);
+      expect(typeof fp1).toBe("string");
+      expect(fp1).toHaveLength(64);
+
+      // Reordered arrays & different timestamp (timestamp is excluded from fingerprint)
+      const reordered: Omit<InstallationOperatingProfileSnapshot, "profileFingerprint"> = {
+        ...baseSnapshot,
+        confirmedAt: "2026-08-15T00:00:00.000Z",
+        secondaryPurposes: ["deliver-managed-services", "participate-community"],
+        relationshipIntents: ["same-organization", "service-provider"],
+        evidence: [baseSnapshot.evidence[1], baseSnapshot.evidence[0]],
+      };
+
+      const fp2 = computeProfileFingerprint(reordered);
+      expect(fp2).toBe(fp1);
+    });
+
+    it("changes when substantive facts differ", () => {
+      const fpBase = computeProfileFingerprint(baseSnapshot);
+
+      const differentEnv = computeProfileFingerprint({
+        ...baseSnapshot,
+        environmentClass: "development",
+      });
+      expect(differentEnv).not.toBe(fpBase);
+
+      const differentPurpose = computeProfileFingerprint({
+        ...baseSnapshot,
+        primaryPurpose: "evolve-dpf",
+      });
+      expect(differentPurpose).not.toBe(fpBase);
+
+      const differentConfirmation = computeProfileFingerprint({
+        ...baseSnapshot,
+        confirmationStatus: "suggested",
+      });
+      expect(differentConfirmation).not.toBe(fpBase);
+    });
+  });
+});

--- a/scripts/installer/install-state.schema.json
+++ b/scripts/installer/install-state.schema.json
@@ -249,6 +249,64 @@
         }
       },
       "additionalProperties": false
+    },
+    "environmentClass": {
+      "type": ["string", "null"],
+      "enum": ["production", "development", "test", null],
+      "description": "Canonical host environment class (EP-1FABA22D / Contract 12). Installer state is canonical for the local host fact; FederationLink.environmentClass is canonical for peer link facts."
+    },
+    "bootstrapIntent": {
+      "type": ["object", "null"],
+      "description": "Pre-DB installation operating intent envelope recorded by the installer before runtime database availability. Absorbed idempotently into PlatformConfig installation.operating-intent.v1 at runtime boot.",
+      "required": ["schemaVersion", "primaryPurpose", "confidence", "recordedAt"],
+      "properties": {
+        "schemaVersion": { "const": 1 },
+        "primaryPurpose": {
+          "type": "string",
+          "enum": [
+            "operate-organization",
+            "evolve-dpf",
+            "deliver-managed-services",
+            "grow-channel",
+            "participate-community"
+          ]
+        },
+        "secondaryPurposes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "operate-organization",
+              "evolve-dpf",
+              "deliver-managed-services",
+              "grow-channel",
+              "participate-community"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "relationshipIntents": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "same-organization",
+              "service-provider",
+              "channel",
+              "community-peer"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "pairedProductionInstallationRef": { "type": ["string", "null"] },
+        "confidence": {
+          "type": "string",
+          "enum": ["high", "medium", "low"]
+        },
+        "recordedAt": { "type": "string", "format": "date-time" },
+        "absorbedAt": { "type": ["string", "null"], "format": "date-time" }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/scripts/installer/install-state.v2.schema.json
+++ b/scripts/installer/install-state.v2.schema.json
@@ -249,6 +249,64 @@
         }
       },
       "additionalProperties": false
+    },
+    "environmentClass": {
+      "type": ["string", "null"],
+      "enum": ["production", "development", "test", null],
+      "description": "Canonical host environment class (EP-1FABA22D / Contract 12). Installer state is canonical for the local host fact; FederationLink.environmentClass is canonical for peer link facts."
+    },
+    "bootstrapIntent": {
+      "type": ["object", "null"],
+      "description": "Pre-DB installation operating intent envelope recorded by the installer before runtime database availability. Absorbed idempotently into PlatformConfig installation.operating-intent.v1 at runtime boot.",
+      "required": ["schemaVersion", "primaryPurpose", "confidence", "recordedAt"],
+      "properties": {
+        "schemaVersion": { "const": 1 },
+        "primaryPurpose": {
+          "type": "string",
+          "enum": [
+            "operate-organization",
+            "evolve-dpf",
+            "deliver-managed-services",
+            "grow-channel",
+            "participate-community"
+          ]
+        },
+        "secondaryPurposes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "operate-organization",
+              "evolve-dpf",
+              "deliver-managed-services",
+              "grow-channel",
+              "participate-community"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "relationshipIntents": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "same-organization",
+              "service-provider",
+              "channel",
+              "community-peer"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "pairedProductionInstallationRef": { "type": ["string", "null"] },
+        "confidence": {
+          "type": "string",
+          "enum": ["high", "medium", "low"]
+        },
+        "recordedAt": { "type": "string", "format": "date-time" },
+        "absorbedAt": { "type": ["string", "null"], "format": "date-time" }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/scripts/installer/validate-install-state.test.mjs
+++ b/scripts/installer/validate-install-state.test.mjs
@@ -225,6 +225,44 @@ test("uses the repository schema rather than a duplicated field list", async () 
   assert.match(result.errors.join("\n"), new RegExp(schema.required[0]));
 });
 
+test("validates environmentClass and bootstrapIntent in v2 state", async () => {
+  for (const envClass of ["production", "development", "test", null]) {
+    const withEnv = { ...valid, environmentClass: envClass };
+    assert.deepEqual(await validateInstallState(withEnv), { valid: true, errors: [] }, `envClass: ${envClass}`);
+  }
+
+  const invalidEnv = { ...valid, environmentClass: "staging" };
+  const resInvalidEnv = await validateInstallState(invalidEnv);
+  assert.equal(resInvalidEnv.valid, false);
+
+  const withBootstrap = {
+    ...valid,
+    environmentClass: "production",
+    bootstrapIntent: {
+      schemaVersion: 1,
+      primaryPurpose: "operate-organization",
+      secondaryPurposes: ["deliver-managed-services"],
+      relationshipIntents: ["service-provider"],
+      confidence: "high",
+      recordedAt: "2026-08-08T12:00:00Z",
+      absorbedAt: null,
+    },
+  };
+  assert.deepEqual(await validateInstallState(withBootstrap), { valid: true, errors: [] });
+
+  const invalidBootstrapPurpose = {
+    ...valid,
+    bootstrapIntent: {
+      schemaVersion: 1,
+      primaryPurpose: "unsupported-purpose",
+      confidence: "high",
+      recordedAt: "2026-08-08T12:00:00Z",
+    },
+  };
+  const resInvalidBootstrap = await validateInstallState(invalidBootstrapPurpose);
+  assert.equal(resInvalidBootstrap.valid, false);
+});
+
 test("command-line contract validates the installer-resolved state path", async () => {
   const dir = await mkdtemp(join(tmpdir(), "dpf-state-validator-"));
   const path = join(dir, "install-state.json");
@@ -233,3 +271,4 @@ test("command-line contract validates the installer-resolved state path", async 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /install-state valid/);
 });
+

--- a/tests/release/installer-release-contract.test.mjs
+++ b/tests/release/installer-release-contract.test.mjs
@@ -3,9 +3,9 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const RETIRED_STT_DIGEST =
-  "hwdsl2/whisper-server@sha256:120e4b7835898715d97b16e54e991e5226535fdfad506863a3b9cd4dd6d6377f";
-const CURRENT_STT_DIGEST =
   "hwdsl2/whisper-server@sha256:0b03ecb54c8247cd4fe42e808746f36f44eff7998dc45018554c50252975e29f";
+const CURRENT_STT_DIGEST =
+  "hwdsl2/whisper-server@sha256:166a8c04e2687608a116372e92f11bfda3e963f3c1dbf390a7c820db0f45887b";
 const MANIFEST_GUARD =
   "node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned";
 


### PR DESCRIPTION
### Summary

Implements **BI-A9F60372** (P0 under Epic **EP-1FABA22D** / Umbrella **BI-34667080**): *Establish the typed installation operating-intent contract and compatibility path*.

### Key Changes
1. **Contract Definition (\@dpf/db\)**:
   - Defined typed closed-set vocabulary: \INSTALLATION_OPERATING_PURPOSES\ (\operate-organization\, \volve-dpf\, \deliver-managed-services\, \grow-channel\, \participate-community\) and \INSTALLATION_ENVIRONMENT_CLASSES\ (\production\, \development\, \	est\).
   - Implemented \alidateOperatingIntent\, \parseInstallationOperatingIntent\, \parseOperatingIntent\, and order-invariant \computeProfileFingerprint\.
   - Strictly enforced \confirmedAt\ and \confirmedByPrincipalId\ when confirmation status is \confirmed\.
2. **Repository & Derivation (\pps/web\)**:
   - Guarded repository over Prisma \PlatformConfig\ key \installation.operating-intent.v1\.
   - Idempotent \bsorbBootstrapIntent\ ingesting pre-DB bootstrap intent from installer state.
   - Deterministic \deriveExistingInstallIntent\ analyzing existing DB state (org, context, federation links) producing unconfirmed suggestions (\status: 'suggested'\).
3. **Installer State Schema & Docs (\scripts/installer\, \docs/operations/install.md\)**:
   - Extended \install-state.v2.schema.json\ and mirror with \nvironmentClass\ and \ootstrapIntent\.
   - Documented operating intent contract and host environment class in \docs/operations/install.md\.
   - Added validation test coverage in \alidate-install-state.test.mjs\.
4. **Release STT Digest**:
   - Re-pinned multi-arch \hwdsl2/whisper-server\ index digest in \docker-compose.yml\ per registry rotation.

### Verification Gate
- \pnpm --filter @dpf/db exec vitest run\ (19/19 passed across src and test)
- \pnpm --filter web exec vitest run\ (15/15 passed)
- \
ode --test scripts/installer/validate-install-state.test.mjs\ (16/16 passed)
- \pnpm --filter web build\ (zero errors, production build verified)
- DCO signed-off commits.

Docs-Impact-Decision: Updated docs/operations/install.md with installation operating-intent and host environment-class contract; docker-compose.yml STT image digest re-pin has no user-guide impact.
Process-Spine-Decision: Typed installation operating-intent contract and compatibility path under EP-1FABA22D.