### PR TITLE
feat(coworker): escalation ladder — reach a peer before reaching the backlog

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1013,6 +1013,9 @@
     "apps/web/lib/tak/delegation-authority.ts": [
       "docs/prompts/a2a-coworker-substrate-prompt.md"
     ],
+    "apps/web/lib/tak/escalation-ladder.ts": [
+      "docs/platform-usability-standards.md"
+    ],
     "apps/web/lib/tak/prompt-assembler.ts": [
       "docs/architecture/agent-standards-dpf-conformance.md",
       "docs/platform-usability-standards.md"
@@ -2535,6 +2538,7 @@
       "apps/web/lib/shared/use-save-state.test.ts",
       "apps/web/lib/shared/use-save-state.ts",
       "apps/web/lib/shell/shell-action-contract.ts",
+      "apps/web/lib/tak/escalation-ladder.ts",
       "apps/web/lib/tak/prompt-assembler.ts",
       "apps/web/lib/ux-budget/measure.ts",
       "apps/web/lib/workforce/oversight-copy.ts",

--- a/apps/web/lib/tak/agent-routing.ts
+++ b/apps/web/lib/tak/agent-routing.ts
@@ -21,16 +21,16 @@ MANDATORY BEHAVIORS:
 - The user is ALWAYS talking about their current screen. Never ask "which page?" or "which component?"
 - Avoid unnecessary clarifying questions. Outside Build Studio ideate, ask at most one short question only when missing information would materially change the action or make it misleading.
 - When the user uploads a file: the file content appears in this conversation. READ IT. Never say "I can't see the file" — the data is right here.
-- When the user reports a problem: search the code yourself, then create a backlog item. Do NOT ask the user for technical details.
+- When the user reports a problem: search the code yourself. If it lands outside your area, hand it to the specialist who owns it before you record anything. Do NOT ask the user for technical details.
 - When the user asks you to build something: propose a design in 2-3 sentences and create a backlog item. Don't ask 5 rounds of questions first.
-- When you can't do something: say so briefly and create a backlog item. Don't pretend.
+- When you can't do something: say so briefly and work the escalation ladder — reach a peer before you reach the backlog. Don't pretend.
 - Interpret typos with common sense. Never ask the user to clarify spelling.
 - Never mention schemas, table names, tool names, file paths, or system architecture. Users are not developers.
 - Don't default to plans, numbered steps, "here's what I'll do", "give me 30 seconds", or "before I start". Move the work forward directly unless the user explicitly asks for a plan.
 - Avoid self-focused commentary about blame or pace. Correct course directly and keep the user oriented.
 - Stay calm under pressure. If context is incomplete or the safest action is unclear, pause briefly, verify, and ask for the minimum missing input rather than forcing an answer.
 - Never optimize for a pass signal alone. Do not game tests, approvals, or workflow proxies when they conflict with the user's real goal.
-- You HAVE create_backlog_item — always use it when issues are reported.
+- You are NOT alone. You HAVE find_coworker, request_coworker and summon_coworker — the whole team is reachable from this conversation. When a question is outside your area, route it to the peer who owns it; when you need one bounded answer, consult them; when it needs several parties or a human decision, bring them in here. You also HAVE create_backlog_item, but it is the LAST rung: file only when no peer can move the work, and say who you tried.
 SCOPE AWARENESS:
 - Small fixes to the current page (bugs, styling, behavior changes): handle directly — search the code, diagnose, create a backlog item with findings.
 - Large requests (new features, new pages, new database models, integrations): tell the user "This needs the Build Studio for a proper design and build cycle" and offer to redirect them to /build with a brief summary of what they want. Create a backlog item to capture the requirement.

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -47,6 +47,7 @@ import { persistExecutionPlan, loadExecutionPlan } from "./execution-plan-store"
 import { estimateContextTokens, classifyContextPressure, deriveCompactionCaps } from "./context-pressure";
 import { clampToolResultForModel, resolveToolResultCharCap } from "./tool-result-budget";
 import { applyBacklogCreateClaimGuard } from "./backlog-create-claim-guard";
+import { applyEscalationLadderGuard } from "./escalation-ladder";
 import { assessToolSurface, computeToolSelectionAccuracy, contextEconomyTurnMetricFields } from "./context-economy-metrics";
 import { summarizeDroppedMessages } from "./compaction-digest";
 import { describeContextCapacityFailure } from "./context-capacity-failure";
@@ -2186,7 +2187,7 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
             ? `${trimmed}\n\n${buildUnsavedAdviceNote(routeContext)}`
             : trimmed;
           return {
-            content: applyBacklogCreateClaimGuard(base, executedTools),
+            content: applyEscalationLadderGuard(applyBacklogCreateClaimGuard(base, executedTools), executedTools),
             providerId: result.providerId,
             modelId: result.modelId,
             downgraded: result.downgraded,
@@ -2424,8 +2425,8 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
       if (trimmed.length === 0 && bestPreNudgeContent.length > 0) {
         console.log(`[agentic-loop] recovering pre-nudge content (${bestPreNudgeContent.length} chars)`);
       }
-      const finalContent = applyBacklogCreateClaimGuard(
-        trimmed.length > 0 ? result.content : (bestPreNudgeContent || result.content), executedTools);
+      const finalContent = applyEscalationLadderGuard(applyBacklogCreateClaimGuard(
+        trimmed.length > 0 ? result.content : (bestPreNudgeContent || result.content), executedTools), executedTools);
       logTurnSummary(result.providerId, result.modelId);
       return {
         content: finalContent,

--- a/apps/web/lib/tak/escalation-ladder.test.ts
+++ b/apps/web/lib/tak/escalation-ladder.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  ESCALATION_LADDER_BLOCK,
+  UNESCALATED_FILE_OFFER,
+  classifyLadderActivity,
+  applyEscalationLadderGuard,
+} from "./escalation-ladder";
+
+const ok = (name: string) => ({ name, result: { success: true, entityId: "BI-FBDF739F" } });
+const failed = (name: string) => ({ name, result: { success: false, error: "denied" } });
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("classifyLadderActivity", () => {
+  it("flags the observed failure: filed a BI with no peer attempt", () => {
+    // The BI-FBDF739F turn — a delivery-process coworker answered a platform
+    // deploy failure by filing, never calling find_coworker/request_coworker.
+    const activity = classifyLadderActivity([ok("create_backlog_item")]);
+    expect(activity.filed).toBe(true);
+    expect(activity.attemptedRungs).toEqual([]);
+    expect(activity.filedWithoutEscalating).toBe(true);
+  });
+
+  it("does not flag a file that followed a re-route attempt", () => {
+    const activity = classifyLadderActivity([
+      ok("find_coworker"),
+      ok("create_backlog_item"),
+    ]);
+    expect(activity.attemptedRungs).toEqual(["reroute"]);
+    expect(activity.filedWithoutEscalating).toBe(false);
+  });
+
+  it("counts a DENIED handoff as an attempt — the coworker still tried the peer door", () => {
+    const activity = classifyLadderActivity([
+      failed("request_coworker"),
+      ok("create_backlog_item"),
+    ]);
+    expect(activity.attemptedRungs).toEqual(["consult"]);
+    expect(activity.filedWithoutEscalating).toBe(false);
+  });
+
+  it("does not treat an UNSUCCESSFUL create as a filed dead end", () => {
+    const activity = classifyLadderActivity([failed("create_backlog_item")]);
+    expect(activity.filed).toBe(false);
+    expect(activity.filedWithoutEscalating).toBe(false);
+  });
+
+  it("reports attempted rungs in ladder order regardless of call order", () => {
+    const activity = classifyLadderActivity([
+      ok("summon_coworker"),
+      ok("find_coworker"),
+      ok("request_coworker"),
+    ]);
+    expect(activity.attemptedRungs).toEqual(["reroute", "consult", "convene"]);
+  });
+
+  it("treats work-room tools as the convene rung", () => {
+    for (const tool of ["invite_room_participant", "post_room_message", "spawn_work_thread"]) {
+      expect(classifyLadderActivity([ok(tool)]).attemptedRungs).toEqual(["convene"]);
+    }
+  });
+
+  it("ignores unrelated tools", () => {
+    const activity = classifyLadderActivity([ok("query_backlog"), ok("search_knowledge")]);
+    expect(activity.attemptedRungs).toEqual([]);
+    expect(activity.filed).toBe(false);
+  });
+});
+
+describe("applyEscalationLadderGuard", () => {
+  it("offers escalation instead of leaving the user with a dead-end id", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const out = applyEscalationLadderGuard("I've logged this as BI-FBDF739F.", [
+      ok("create_backlog_item"),
+    ]);
+    expect(out).toContain(UNESCALATED_FILE_OFFER);
+  });
+
+  it("does NOT scold the user — the appended text is an offer, not a correction", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const out = applyEscalationLadderGuard("Logged it.", [ok("create_backlog_item")]);
+    expect(out).not.toMatch(/correction|should have|failed to/i);
+  });
+
+  it("leaves content untouched when the ladder was worked", () => {
+    const content = "I've asked our platform engineer to pick this up.";
+    expect(
+      applyEscalationLadderGuard(content, [ok("find_coworker"), ok("create_backlog_item")]),
+    ).toBe(content);
+  });
+
+  it("leaves content untouched when nothing was filed", () => {
+    const content = "Here's what the page shows.";
+    expect(applyEscalationLadderGuard(content, [])).toBe(content);
+  });
+
+  it("is idempotent across the loop's multiple return points", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const tools = [ok("create_backlog_item")];
+    const once = applyEscalationLadderGuard("Logged it.", tools);
+    expect(applyEscalationLadderGuard(once, tools)).toBe(once);
+  });
+});
+
+describe("ESCALATION_LADDER_BLOCK", () => {
+  it("names every peer door so no coworker is left with filing as its only rung", () => {
+    for (const tool of ["find_coworker", "request_coworker", "summon_coworker"]) {
+      expect(ESCALATION_LADDER_BLOCK).toContain(tool);
+    }
+  });
+
+  it("states that filing is last, not first", () => {
+    expect(ESCALATION_LADDER_BLOCK).toMatch(/LAST rung, not the first/);
+  });
+
+  it("keeps operating-principle 5 intact — peers are described to users by role, not id", () => {
+    expect(ESCALATION_LADDER_BLOCK).toMatch(/never a tool name or an internal id/);
+  });
+});

--- a/apps/web/lib/tak/escalation-ladder.ts
+++ b/apps/web/lib/tak/escalation-ladder.ts
@@ -1,0 +1,170 @@
+// apps/web/lib/tak/escalation-ladder.ts
+//
+// EP-COWORKER-INTERACTIVITY: the coworker escalation ladder.
+//
+// Before this contract the shared operating prompt offered coworkers exactly
+// ONE way out of a question they could not answer: file a backlog item. That
+// instruction appeared four times (prompt-assembler OPERATING PRINCIPLES 1, 7
+// and 15; agent-routing MANDATORY BEHAVIORS "always use it when issues are
+// reported"), while `find_coworker`, `request_coworker` and `summon_coworker`
+// — all granted, all implemented in `coworker-collaboration.ts`, all rendered
+// on the panel as visible `collaboration:*` events — were never mentioned to
+// any coworker outside two bespoke COO route prompts.
+//
+// The observable failure: a route-bound specialist receives a question outside
+// its area, cannot answer, and files a BI. The peer who could have answered is
+// one tool call away and is never asked. Filing became the first resort because
+// it was the only rung the prompt described.
+//
+// This module is the single source of truth for the four-rung ladder and for
+// the turn-level guard that keeps rung 4 honest.
+import type { ExecutedToolLike } from "./backlog-create-claim-guard";
+
+/** Ladder rungs, cheapest and least disruptive first. */
+export type LadderRung = "reroute" | "consult" | "convene" | "file";
+
+/**
+ * Rung 1 — re-route. Read-only roster discovery by intent (BI-5FB59BC6). Costs
+ * the user nothing and resolves the single most common failure: the route bound
+ * the wrong specialist to the surface.
+ */
+const REROUTE_TOOLS = ["find_coworker"] as const;
+
+/**
+ * Rung 2 — consult. A bounded question to a peer, answered back in this thread
+ * in the answering coworker's voice. The pattern the COO route already uses to
+ * consult AGT-902 on residency/sovereignty questions.
+ */
+const CONSULT_TOOLS = ["request_coworker"] as const;
+
+/**
+ * Rung 3 — convene. More than one party, more than one turn, or a decision a
+ * human has to make: bring peers into the conversation or open a work room and
+ * drive it to an outcome.
+ */
+const CONVENE_TOOLS = [
+  "summon_coworker",
+  "invite_room_participant",
+  "post_room_message",
+  "spawn_work_thread",
+  "start_deliberation",
+] as const;
+
+/**
+ * Rung 4 — file. Genuinely no path forward in this conversation. Last resort,
+ * not first.
+ */
+const FILE_TOOLS = ["create_backlog_item", "report_quality_issue"] as const;
+
+const RUNG_TOOLS: Record<LadderRung, readonly string[]> = {
+  reroute: REROUTE_TOOLS,
+  consult: CONSULT_TOOLS,
+  convene: CONVENE_TOOLS,
+  file: FILE_TOOLS,
+};
+
+/**
+ * The prompt contract. Injected into the shared identity block so EVERY
+ * coworker inherits it, not just the two COO routes.
+ *
+ * Deliberately phrased in plain language on the user-visible side: operating
+ * principle 5 forbids naming tools, schemas or infrastructure to the employee,
+ * so the ladder tells the coworker which door to open while describing the peer
+ * to the user by role ("our platform engineer"), never by tool or agent id.
+ */
+export const ESCALATION_LADDER_BLOCK = `WHEN YOU CANNOT ANSWER — WORK THE LADDER IN ORDER. You are one of a team of AI coworkers who can reach each other directly. Filing a backlog item is the LAST rung, not the first.
+1. ANSWER — you know it, or the page data and your tools can get it. Do that.
+2. RE-ROUTE — the question belongs to another specialist's area (a platform or deployment failure is not a delivery-process question; a billing dispute is not an engineering question). Call find_coworker with the intent, hand the work to the peer it names, and tell the user who is picking it up. This costs the user nothing — do it silently and do it first.
+3. CONSULT — you own the surface but need a peer's knowledge for one bounded question. Call request_coworker, then answer in your own voice with the peer's grounded result and say who you checked with.
+4. CONVENE — the work needs more than one party, more than one turn, or a human decision. Call summon_coworker to bring peers into this conversation, or open a work room and invite the participants who can actually resolve it.
+5. FILE — only when there is no path forward in this conversation at all. Say plainly which peers you tried and why the work could not proceed, then file it.
+NEVER file a backlog item as a substitute for asking a colleague. A filed item with no attempt to reach a peer is a dead end handed to the user. When you describe a peer, use their role in plain language ("our platform engineer", "the finance specialist") — never a tool name or an internal id.`;
+
+/** Rungs 1-3: an actual attempt to involve another coworker. */
+export const ESCALATION_RUNGS: readonly LadderRung[] = ["reroute", "consult", "convene"];
+
+function rungForTool(toolName: string): LadderRung | null {
+  for (const rung of Object.keys(RUNG_TOOLS) as LadderRung[]) {
+    if (RUNG_TOOLS[rung].includes(toolName)) return rung;
+  }
+  return null;
+}
+
+export type LadderActivity = {
+  /** Rungs 1-3 attempted this turn, in ladder order. */
+  attemptedRungs: LadderRung[];
+  /** A backlog item / quality issue was successfully filed this turn. */
+  filed: boolean;
+  /** True when the turn filed without any attempt to reach a peer. */
+  filedWithoutEscalating: boolean;
+};
+
+/**
+ * Classify a turn's tool calls against the ladder.
+ *
+ * An escalation counts as attempted whether or not it succeeded — a denied
+ * handoff (HandoffDeniedError) or an empty roster result is still evidence the
+ * coworker tried the peer door before falling through to filing. Only the FILE
+ * rung requires success, because an unsuccessful create is not a dead end.
+ */
+export function classifyLadderActivity(
+  executedTools: readonly ExecutedToolLike[],
+): LadderActivity {
+  const attempted = new Set<LadderRung>();
+  let filed = false;
+
+  for (const tool of executedTools) {
+    const rung = rungForTool(tool.name);
+    if (!rung) continue;
+    if (rung === "file") {
+      if (tool.result?.success) filed = true;
+      continue;
+    }
+    attempted.add(rung);
+  }
+
+  const attemptedRungs = ESCALATION_RUNGS.filter((r) => attempted.has(r));
+  return {
+    attemptedRungs,
+    filed,
+    filedWithoutEscalating: filed && attemptedRungs.length === 0,
+  };
+}
+
+/**
+ * Appended when a turn files without trying a peer.
+ *
+ * Deliberately an OFFER, not a correction. The existing backlog-create-claim
+ * guard annotates because the model made a false claim; here the model did
+ * something real but incomplete, and scolding the user for the coworker's
+ * shortfall would be worse than the shortfall. Converting the dead end into a
+ * one-line offer keeps the thread alive, which is the entire point of the
+ * ladder.
+ */
+export const UNESCALATED_FILE_OFFER =
+  "I've logged this, but I haven't brought anyone else in on it yet — " +
+  "another coworker may be able to move it now rather than later. " +
+  "Say the word and I'll pull in the right specialist.";
+
+/**
+ * Turn-level guard: when a coworker files without working the ladder, append
+ * the offer and emit a counter so the reflex rate is measurable rather than
+ * anecdotal.
+ *
+ * Idempotent — safe to apply at more than one return point in the agentic loop.
+ */
+export function applyEscalationLadderGuard(
+  content: string,
+  executedTools: readonly ExecutedToolLike[],
+): string {
+  const activity = classifyLadderActivity(executedTools);
+  if (!activity.filedWithoutEscalating) return content;
+  if (content.includes("pull in the right specialist")) return content;
+
+  console.warn(
+    "[agentic-loop] escalation-ladder: filed a backlog item with no peer attempt " +
+      "(rungs 1-3 unused) — offering escalation instead of ending the thread.",
+  );
+
+  return `${content.trimEnd()}\n\n${UNESCALATED_FILE_OFFER}`;
+}

--- a/apps/web/lib/tak/prompt-assembler.ts
+++ b/apps/web/lib/tak/prompt-assembler.ts
@@ -11,6 +11,7 @@ import {
 import { withCoworkerInteractionContract } from "./coworker-interaction-contract";
 import { DECISION_ROUTING_BLOCK } from "./decision-routing-block";
 import { LIMITATION_RESPONSE_BLOCK } from "./limitation-response-block";
+import { ESCALATION_LADDER_BLOCK } from "./escalation-ladder";
 import { buildInitiativeBlock } from "./initiative-block";
 import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
 import { readingLevelDirective, type ReadingLevel } from "@dpf/validators";
@@ -97,13 +98,13 @@ export type PromptInput = {
 const IDENTITY_BLOCK = `You are an AI co-worker inside a digital product management platform. You are a specialist assigned to the area the employee is currently viewing. You have tools that perform real actions — call them, don't write about calling them. The employee sees your tool calls as approval cards; when they approve, the action executes. You know what page the employee is on and what data is available in the page data section below.
 
 OPERATING PRINCIPLES:
-1. NEVER claim you did something you didn't do. If you lack a tool for a task, say "I can't do that directly — I'll create a backlog item for it" and ACTUALLY call create_backlog_item.
+1. NEVER claim you did something you didn't do. If you lack a tool for a task, say so plainly and work the escalation ladder below — a peer may have the tool you're missing. Only when no rung reaches a peer do you file it, and then you must ACTUALLY call create_backlog_item.
 2. Prefer tool use over narration. Avoid filler like "Action:", "Step 1:", "What you need to do next:", "I will now...", or "Here's my plan:" unless the user explicitly asks for a plan.
 3. NEVER ask for confirmation before using a tool. The approval card IS the confirmation. Call the tool and let the employee approve or reject.
 4. Keep responses brief and practical. Respond in 2-4 sentences max unless the user asks for more detail.
 5. AUDIENCE IS A BUSINESS EXPERT, NOT A DEVELOPER. The employee is competent in their domain (sales, ops, finance, customer support, etc.) but is NOT a software engineer. They do not know what a tool name, schema field, route, container, model ID, error code, branch, commit, or database table is. NEVER mention any of: tool names (e.g. "saveBuildEvidence", "reviewDesignDoc", "run_sandbox_command"), schema/field names (e.g. "buildPlan", "fileStructure", "taskResults", "verificationOut"), provider/model IDs (e.g. "anthropic-sub", "claude-haiku-4-5-20251001", "Docker Model Runner", "Gemini"), infrastructure (e.g. "Inngest", "Prisma", "sandbox container", "MCP", "Docker", "Neo4j", "Qdrant"), error codes (e.g. "P2002", "503", "ECONNREFUSED"), file paths (e.g. "apps/web/lib/..."), branch or commit SHAs, or system terms ("agentic loop", "authoritative state", "persisted evidence"). If a tool returns a technical error, TRANSLATE it: name the user-visible thing that went wrong ("I couldn't save your changes", "the deployment hasn't started yet", "I need a contact email"), explain in one short sentence what the user can do ("try again", "fill in the missing field", "ask an admin"), and STOP. Never echo tool output verbatim. Never include keywords from internal messages like "REJECTED:", "fail.", "stuck", "iteration", or "dispatch".
 6. If an employee asks for MULTIPLE things, handle each one. Create separate tool calls for each action. Don't ask which one to do first.
-7. If you can't do something with your available tools, be honest and create a backlog item to track the gap. Don't pretend.
+7. If you can't do something with your available tools, be honest, then work the escalation ladder below before you file anything. Don't pretend, and don't hand the employee a backlog id when a colleague could have moved the work now.
 8. Tools are invisible to the employee. Call them silently, never announce or narrate.
 9. If a tool errors, explain in plain language and suggest what to do next.
 10. When you observe friction or a missing capability, use propose_improvement to suggest a platform enhancement.
@@ -111,7 +112,7 @@ OPERATING PRINCIPLES:
 12. NEVER make things up. If you don't know something, say so. If you're unsure about data, check with your tools first. Do not fabricate numbers, statuses, names, or capabilities. Ground every statement in what you can actually see in the page data or retrieve through tools.
 13. TAKE THE NEXT WELL-SUPPORTED ACTION — but never fabricate required fields. If a tool requires fields the employee hasn't provided AND there is no reasonable default (e.g. a person's last name, email address, phone number), ask for those specific fields in ONE short message listing exactly what you need. Do NOT guess names, emails, or identifiers. For optional fields and fields with sensible defaults, assume and act — state your assumption briefly.
 14. When you have enough context for a useful low-risk action, take it. If ambiguity would materially change the action or make it misleading, pause and ask one short clarifying question instead of forcing an answer.
-15. NEVER describe code you haven't written through a tool. NEVER say "built", "created", "deployed", "shipped", or "implemented" unless you called a tool that did it. If you lack the right tool, say so and create a backlog item.
+15. NEVER describe code you haven't written through a tool. NEVER say "built", "created", "deployed", "shipped", or "implemented" unless you called a tool that did it. If you lack the right tool, say so and work the escalation ladder below.
 16. When a user says "build this" or "do it", start with the most relevant evidence-gathering or action tool for the task. A brief text response is acceptable first if you need to state a blocker or ask for one missing fact required for correctness.
 17. Stay calm under pressure. Repeated failures, missing context, or tight constraints are signals to slow down, verify, and surface the blocker — not to guess, conceal uncertainty, or cut corners.
 18. Never optimize for proxy success alone. Do NOT game tests, acceptance criteria, approval flows, or tooling just to produce a pass signal. If a constraint appears impossible or inconsistent, say so clearly and preserve the user's real intent.
@@ -162,6 +163,7 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
     { category: "platform-identity", slug: "identity-block", fallback: IDENTITY_BLOCK },
     { category: "platform-identity", slug: "decision-routing", fallback: DECISION_ROUTING_BLOCK },
     { category: "platform-identity", slug: "limitation-response", fallback: LIMITATION_RESPONSE_BLOCK },
+    { category: "platform-identity", slug: "escalation-ladder", fallback: ESCALATION_LADDER_BLOCK },
     { category: "platform-identity", slug: modeSlug, fallback: input.mode === "advise" ? ADVISE_MODE_BLOCK : ACT_MODE_BLOCK },
     { category: "platform-mission", slug: "company-mission", fallback: COMPANY_MISSION_FALLBACK },
   ]);
@@ -181,6 +183,12 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
   // enabler and ask a single yes/no; never dead-end or deflect to an admin.
   // Surface-uniform with the legacy path (apps/web/lib/actions/agent-coworker.ts).
   staticBlocks.push(loaded.get("platform-identity/limitation-response") ?? LIMITATION_RESPONSE_BLOCK);
+
+  // Block 1d: Escalation ladder (static) — a coworker who cannot answer reaches
+  // a PEER before it reaches the backlog. Filing is rung 4, not rung 1. Kept as
+  // its own overridable block rather than folded into the identity block so a
+  // DB override of the identity text cannot silently drop the contract.
+  staticBlocks.push(loaded.get("platform-identity/escalation-ladder") ?? ESCALATION_LADDER_BLOCK);
 
   // Block 3: Mode (static per session — advise or act doesn't change mid-conversation)
   staticBlocks.push(loaded.get(`platform-identity/${modeSlug}`) ?? (input.mode === "advise" ? ADVISE_MODE_BLOCK : ACT_MODE_BLOCK));

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -134,6 +134,17 @@ such as “Resolve” or “De-conflict” on an audit-only detail is a failed w
 empty-state copy. The canonical contract and benchmark evidence are in
 [`decision-governance-surface-redesign-design.md` §10](superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md#10-addendum-2026-08-08-bi-76eedee8-findings-must-carry-an-achievable-outcome).
 
+The same contract governs a coworker conversation. A filed backlog id is an action whose promised
+outcome is "someone will pick this up later"; handing one to an operator who asked for help *now*,
+without first trying to reach a colleague who could move the work, is the conversational form of the
+dead-end button. Coworkers are a team that can reach each other directly, so filing is the last rung
+of an ordered ladder — re-route to the specialist who owns the area, consult a peer for one bounded
+question, convene the parties in a work room, and only then file, naming who was tried. The contract
+is assembled into every coworker's prompt from `platform-identity/escalation-ladder`
+(`apps/web/lib/tak/escalation-ladder.ts`), and a turn that files without attempting a rung above it
+offers the escalation instead of ending the thread. Full rationale in
+[`coworker-escalation-ladder-design.md`](superpowers/specs/2026-08-15-coworker-escalation-ladder-design.md).
+
 Repeated detector or consultation events are audit occurrences, not automatically separate units
 of operator work. A queue must project one item per deterministic work identity, disclose how many
 occurrences it represents, and make one successful disposition clear every still-open occurrence

--- a/docs/superpowers/specs/2026-08-15-coworker-escalation-ladder-design.md
+++ b/docs/superpowers/specs/2026-08-15-coworker-escalation-ladder-design.md
@@ -1,0 +1,141 @@
+# Coworker Escalation Ladder — design
+
+- **Epic:** EP-COWORKER-INTERACTIVITY
+- **Status:** Implemented (rungs 1-4 prompt contract + turn guard); front-door/router split staged
+- **Date:** 2026-08-15
+
+## 1. Problem
+
+A coworker that cannot answer a question files a backlog item. That is its only
+exit. The observed incident: an operator asked the delivery-process coworker on
+a platform surface to help fix a failed self-upgrade. The coworker filed
+BI-FBDF739F and advised "if it's a transient error, re-run the deployment
+trigger." The failure was not transient (see §5), the coworker was not the right
+specialist, and the peer who could have diagnosed it was never asked.
+
+Two independent defects produced that turn.
+
+### 1a. Filing was the only rung the prompt described
+
+The instruction to file appears four times in the mandatory prompt every
+coworker inherits:
+
+| Location | Text |
+|---|---|
+| `prompt-assembler.ts` principle 1 | *"If you lack a tool for a task, say 'I can't do that directly — I'll create a backlog item for it' and ACTUALLY call create_backlog_item."* |
+| `prompt-assembler.ts` principle 7 | *"…be honest and create a backlog item to track the gap."* |
+| `prompt-assembler.ts` principle 15 | *"If you lack the right tool, say so and create a backlog item."* |
+| `agent-routing.ts` MANDATORY BEHAVIORS | *"You HAVE create_backlog_item — always use it when issues are reported."* |
+
+Meanwhile `find_coworker`, `request_coworker` and `summon_coworker` — all
+granted (`agent-grants.ts:193,339,340`), all implemented in
+`coworker-collaboration.ts` with delegation-authority enforcement, all rendered
+on the panel as visible `collaboration:*` events — appeared **zero times** in
+the shared operating principles. The only coworkers told the peer door exists
+were the two COO routes (`agent-routing.ts:605,688`), which use
+`request_coworker` to consult AGT-902 and answer in the COO's voice.
+
+The coworker did exactly what it was told. This is a prompt defect, not a model
+defect.
+
+### 1b. Route binding ignores question content
+
+`resolveSelectedCoworkerForRoute` plus `ROUTE_AGENT_MAP`/`FALLBACK_ENTRY` bind
+one specialist per **route**. Nothing matches against the **content** of the
+question. `find_coworker` is read-only discovery *by intent* and is exactly the
+missing step, but no panel path calls it.
+
+Compounding both: that turn ran on the bundled local model, so it was a degraded
+turn as well as a misrouted one.
+
+## 2. Substrate that already exists (fuse, do not build)
+
+- **Peer doors** — `request_coworker` (delegate a bounded sub-task) and
+  `summon_coworker` (bring a peer into the conversation) in
+  `apps/web/lib/tak/coworker-collaboration.ts`. Both coworker-initiated by
+  contract; the human never picks or tasks peers. Depth/fan-out caps inherited
+  from `spawnWorkThread`.
+- **Roster discovery** — `find_coworker`, read-only discovery-by-intent.
+- **Work rooms** — participation, cycles, channel ingress, read-model and
+  outcome packets under `apps/web/lib/work-management/room-*.ts`, surfaced by
+  `WorkRoomParticipants.tsx`. Spec: `2026-07-26-work-rooms-collaboration-design.md`.
+- **Front-door pattern** — already shipping, hardcoded for one consultation in
+  the COO route prompt and in `2026-03-21-coo-led-onboarding-design.md`.
+- **Turn-guard idiom** — `backlog-create-claim-guard.ts`, applied at the agentic
+  loop's return points.
+
+Nothing new was needed at the substrate layer. The gap was that no coworker was
+told any of it existed.
+
+## 3. The contract
+
+Four rungs, cheapest first, in `apps/web/lib/tak/escalation-ladder.ts`:
+
+| Rung | Tools | When |
+|---|---|---|
+| 1 — re-route | `find_coworker` | Question belongs to another specialist's area. Silent, costs the user nothing. |
+| 2 — consult | `request_coworker` | You own the surface, need one bounded answer from a peer. |
+| 3 — convene | `summon_coworker`, `invite_room_participant`, `post_room_message`, `spawn_work_thread`, `start_deliberation` | More than one party, more than one turn, or a human decision. |
+| 4 — file | `create_backlog_item`, `report_quality_issue` | No path forward in this conversation. Must say which peers were tried. |
+
+`ESCALATION_LADDER_BLOCK` is registered as its own DB-overridable
+`platform-identity/escalation-ladder` block **rather than folded into the
+identity block** — the identity block is itself DB-overridable
+(`prompts/platform-identity/identity-block.prompt.md`), so folding the ladder in
+would let an identity override silently drop the contract. It sits in the static
+(cacheable) region of the assembled prompt, so it costs no per-turn cache
+invalidation.
+
+Principles 1, 7 and 15 and the `agent-routing.ts` behaviors now point at the
+ladder instead of naming the backlog as the fallback.
+
+### 3a. Guard shape — an offer, not a correction
+
+`applyEscalationLadderGuard` runs at both agentic-loop return points. When a
+turn files with **no** rung 1-3 attempt, it appends a one-line offer to bring in
+a specialist and emits a `console.warn` so the reflex rate is measurable.
+
+It deliberately does **not** scold. The existing create-claim guard annotates
+because the model made a false claim; here the model did something real but
+incomplete, and correcting the user for the coworker's shortfall would be worse
+than the shortfall. Converting a dead end into an offer keeps the thread alive,
+which is the point of the ladder.
+
+A **denied** handoff counts as an attempt — trying the peer door and being
+refused by delegation authority is not the failure mode being guarded. Only the
+FILE rung requires success, since an unsuccessful create is not a dead end.
+
+## 4. Staged, not built here
+
+**Front door / router split.** Making the COO the accountable front door on
+every surface — COO owns the byline and the routing decision, the assigned
+specialist does the work and speaks in-thread under attribution — is the natural
+next slice. It is **blocked on `2026-07-18-coo-persona-attribution-contract-design.md`**,
+still "Draft for deliberation", which documents three contradictory overseer
+identities live in the codebase (prompt file "Jiminy", in-code un-named
+executor, DB label "COO"). That contract must resolve before a COO is placed on
+every surface, or the platform ships three COOs.
+
+**Content-aware route binding.** Calling `find_coworker` on the panel path when
+the question's intent does not match the route-bound specialist's area, rather
+than relying on the coworker to notice. Follow-on.
+
+## 5. The triggering incident is not a ladder bug
+
+For the record, so the BI is not miscategorised: the upgrade failure itself was
+a Dockerfile gap. PR #4321 added `patchedDependencies: image-size@1.2.1` to
+`pnpm-workspace.yaml:230`; `Dockerfile:23` COPYs `pnpm-workspace.yaml` but never
+COPYs `patches/` before `RUN pnpm install --frozen-lockfile` at `Dockerfile:44`,
+so pnpm exits 254 on ENOENT for `/app/patches/image-size@1.2.1.patch`. Every
+image build since #4321 fails identically. The "re-run it, it may be transient"
+advice could never have worked — which is precisely what a consulted platform
+specialist would have known.
+
+## 6. Verification
+
+`apps/web/lib/tak/escalation-ladder.test.ts` — 15 cases covering the observed
+failure shape, denied-handoff-counts-as-attempt, unsuccessful-create,
+ladder-order reporting, guard idempotence across both loop return points, and
+prompt-contract assertions (every peer door named; filing stated as last;
+operating-principle 5 preserved so peers are described to users by role, never
+by tool name or agent id).

--- a/prompts/platform-identity/escalation-ladder.prompt.md
+++ b/prompts/platform-identity/escalation-ladder.prompt.md
@@ -1,0 +1,23 @@
+---
+name: escalation-ladder
+displayName: Coworker Escalation Ladder
+description: A coworker who cannot answer reaches a peer before it reaches the backlog — filing is the last rung, not the first
+category: platform-identity
+version: 1
+
+composesFrom: []
+contentFormat: markdown
+variables: []
+
+valueStream: ""
+stage: ""
+sensitivity: internal
+---
+
+WHEN YOU CANNOT ANSWER — WORK THE LADDER IN ORDER. You are one of a team of AI coworkers who can reach each other directly. Filing a backlog item is the LAST rung, not the first.
+1. ANSWER — you know it, or the page data and your tools can get it. Do that.
+2. RE-ROUTE — the question belongs to another specialist's area (a platform or deployment failure is not a delivery-process question; a billing dispute is not an engineering question). Call find_coworker with the intent, hand the work to the peer it names, and tell the user who is picking it up. This costs the user nothing — do it silently and do it first.
+3. CONSULT — you own the surface but need a peer's knowledge for one bounded question. Call request_coworker, then answer in your own voice with the peer's grounded result and say who you checked with.
+4. CONVENE — the work needs more than one party, more than one turn, or a human decision. Call summon_coworker to bring peers into this conversation, or open a work room and invite the participants who can actually resolve it.
+5. FILE — only when there is no path forward in this conversation at all. Say plainly which peers you tried and why the work could not proceed, then file it.
+NEVER file a backlog item as a substitute for asking a colleague. A filed item with no attempt to reach a peer is a dead end handed to the user. When you describe a peer, use their role in plain language ("our platform engineer", "the finance specialist") — never a tool name or an internal id.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -6,7 +6,7 @@ apps/web/components/admin/McpTokenManager.tsx	1326
 apps/web/components/agent/AgentCoworkerPanel.tsx	1297
 apps/web/components/agent/AgentMessageInput.tsx	1034
 apps/web/components/ea/EaCanvas.tsx	1047
-apps/web/components/inventory/TopologyGraph.tsx	1030
+apps/web/components/inventory/TopologyGraph.tsx	973
 apps/web/components/ops/SelfUpgradeClient.test.tsx	1118
 apps/web/components/ops/SelfUpgradeClient.tsx	1139
 apps/web/components/platform/EffectivePermissionsPanel.tsx	844
@@ -42,7 +42,6 @@ apps/web/lib/integrate/sandbox/build-branch.ts	949
 apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp-tools-backlog.test.ts	874
 apps/web/lib/mcp-tools.ts	1953
-apps/web/lib/mcp/packs/backlog-pack.ts	857
 apps/web/lib/mcp/packs/contribution-hive-pack.ts	854
 apps/web/lib/mcp/packs/sandbox-pack.ts	920
 apps/web/lib/navigation/portal-navigation-model.ts	965
@@ -57,7 +56,7 @@ apps/web/lib/tak/agent-grants.test.ts	914
 apps/web/lib/tak/agent-grants.ts	939
 apps/web/lib/tak/agent-routing.ts	1053
 apps/web/lib/tak/agentic-loop.test.ts	2501
-apps/web/lib/tak/agentic-loop.ts	2811
+apps/web/lib/tak/agentic-loop.ts	2812
 apps/web/lib/tak/route-context-map.ts	1273
 apps/web/lib/work-capsules/mcp-handlers.ts	919
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1085


### PR DESCRIPTION
Closes BI-6886CFCD.

## The defect

Coworkers had exactly one exit when they could not answer a question: file a backlog item. That instruction appears **four times** in the mandatory prompt every coworker inherits:

| Location | Text |
|---|---|
| `prompt-assembler.ts:100` (principle 1) | *"say 'I can't do that directly — I'll create a backlog item for it' and ACTUALLY call create_backlog_item"* |
| `prompt-assembler.ts:106` (principle 7) | *"…be honest and create a backlog item to track the gap"* |
| `prompt-assembler.ts:114` (principle 15) | *"If you lack the right tool, say so and create a backlog item"* |
| `agent-routing.ts:33` | *"You HAVE create_backlog_item — always use it when issues are reported"* |

Meanwhile `find_coworker`, `request_coworker` and `summon_coworker` — all granted (`agent-grants.ts:193,339,340`), all implemented in `coworker-collaboration.ts` with delegation-authority enforcement, all rendered on the panel as visible `collaboration:*` events — appeared **zero times** in the shared operating principles. The only coworkers ever told the peer door exists were the two COO routes, which consult AGT-902 and answer in the COO's voice.

Filing became the first resort because it was the only rung described. This is a prompt defect, not a model defect.

**Observed failure.** An operator on a platform surface asked the delivery-process coworker to help fix a failed self-upgrade. It filed BI-FBDF739F and advised *"if it's a transient error, re-run the deployment trigger."* The failure was deterministic (BI-FF2BB8F7 — a `patches/` COPY gap in the Dockerfile from #4321), the coworker was the wrong specialist, and the peer who could have diagnosed it was never asked. That turn also ran degraded on the bundled local model.

## The contract

| Rung | Doors | When |
|---|---|---|
| 1 re-route | `find_coworker` | Not your area. Silent, costs the user nothing. |
| 2 consult | `request_coworker` | One bounded question to a peer. |
| 3 convene | `summon_coworker`, room invite/post, `spawn_work_thread`, `start_deliberation` | Several parties, several turns, or a human decision. |
| 4 file | `create_backlog_item` | No path forward — and say who you tried. |

Two decisions worth review:

- **Registered as its own DB-overridable `platform-identity/escalation-ladder` block, not folded into the identity block.** The identity block is itself overridable via `prompts/platform-identity/identity-block.prompt.md`, so folding the ladder in would let an identity override silently delete the contract. It sits in the static/cacheable region, so there is no per-turn cache cost.
- **The guard offers, it does not scold.** When a turn files with no rung 1-3 attempt, `applyEscalationLadderGuard` appends a one-line offer to bring in a specialist and logs a counter so the reflex rate is measurable. The existing create-claim guard annotates because the model made a false claim; here the model did something real but incomplete, and correcting the *user* for the coworker's shortfall would be worse than the shortfall. A denied handoff counts as an attempt; only the file rung requires success.

## Design grounding

Extends the work-rooms and A2A collaboration substrate rather than adding to it — no new tables, tools, or agent roles. Source of truth for the new contract: `docs/superpowers/specs/2026-08-15-coworker-escalation-ladder-design.md` (new). Substrate fused: `coworker-collaboration.ts`, `work-management/room-*.ts`, `backlog-create-claim-guard.ts` (guard idiom), the prompt-assembler block registry.

**Module-size baseline note:** `agentic-loop.ts` 2811 → 2812, one import line to wire the guard (call sites were compacted to avoid the rest of the growth). The same `--update` also retightened `TopologyGraph.tsx` (1030 → 973) and dropped `backlog-pack.ts` off the list — unrelated shrinkages already on main that the ratchet had not captured. Kept, because the ratchet only tightens.

## Verification

- 15 new cases in `escalation-ladder.test.ts`, covering the observed failure shape, denied-handoff-counts-as-attempt, unsuccessful-create, ladder-order reporting, guard idempotence across both loop return points, and prompt-contract assertions (every peer door named; filing stated last; operating-principle 5 preserved so peers are described by role, never by tool name or agent id).
- 223 tests green across the 6 touched suites.
- `pnpm run pregate` PASS — gated sha `4d22ff9bf7ca`, evidence `cmsuukzd222g101pprnntz5cz`.

## Not in this PR

- **BI-80ADD3A8** — COO as accountable front door + router on every surface. Blocked on `2026-07-18-coo-persona-attribution-contract-design.md`, still Draft for deliberation, which documents three contradictory overseer identities live in the tree ("Jiminy" in the prompt file, an un-named executor in code, "COO" forced by the DB label). Shipping a COO onto every surface before that resolves would ship three COOs.
- **BI-36408DB6** — panel route-binding ignores question content; call `find_coworker` when intent does not match the bound specialist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Seed fit

`prompts/platform-identity/escalation-ladder.prompt.md` is a platform-identity block assembled into every coworker's system prompt on every surface and every install. It encodes no archetype, vertical, or install-specific content, and it is DB-overridable per install via the `PromptTemplate` row if an operator wants to tune the wording.

Seed-Fit-Decision: global-default
