### PR TITLE
fix(docker): carry pnpm patches into the image build context (BI-FF2BB8F7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,13 @@ COPY packages/integration-shared/package.json ./packages/integration-shared/
 COPY packages/storefront-templates/package.json ./packages/storefront-templates/
 COPY packages/types/package.json ./packages/types/
 COPY packages/validators/package.json ./packages/validators/
+# pnpm-workspace.yaml `patchedDependencies` names patch files by repo-relative
+# path. pnpm resolves them against the workspace root, so every stage that runs
+# `pnpm install` needs them in the build context — without this COPY the install
+# exits 254 with ENOENT on the patch file (SUR-8AB3353C, regression from #4321).
+# The `build` and `init` stages are FROM deps and share WORKDIR /app, so they
+# inherit /app/patches from this layer; only the runner stage needs its own copy.
+COPY patches/ ./patches/
 RUN pnpm install --frozen-lockfile
 
 # ─── Stage 3: build ───────────────────────────────────────────────────────────
@@ -202,6 +209,11 @@ COPY --from=build /app/apps/web/public ./apps/web/public
 COPY --from=init /app/packages ./packages
 COPY --from=init /app/node_modules ./node_modules
 COPY --from=init /app/pnpm-workspace.yaml /app/pnpm-lock.yaml /app/package.json /app/tsconfig.base.json /app/.gitignore ./
+# The workspace bootstrap in docker-entrypoint.sh copies these root manifests to
+# /workspace and runs `pnpm install` there. pnpm-workspace.yaml carries the
+# `patchedDependencies` directive, so the patch files must travel with it or that
+# runtime install fails the same way the image build did (SUR-8AB3353C).
+COPY --from=init /app/patches ./patches
 COPY --from=init /app/scripts ./scripts
 # Checked-in registries read by the packaged gate-context generator. Preserve
 # their repository-relative paths because the generator is also the CLI source
@@ -261,7 +273,7 @@ COPY version.json ./version.json
 # Decoupling it from DPF_VERSION is the fix for BI-C8E90A79 — a stamped label
 # can no longer mask which source was built. Exclusions keep it reproducible
 # across builds of the same source (node_modules / .next / generated / tsbuildinfo).
-RUN (find /app/apps/web-src /app/packages-src /app/scripts /app/docs/professions -type f \
+RUN (find /app/apps/web-src /app/packages-src /app/scripts /app/docs/professions /app/patches -type f \
       -not -path '*/node_modules/*' \
       -not -path '*/.pnpm-store/*' \
       -not -path '*/.next/*' \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -85,6 +85,12 @@ sync_image_source_to_workspace() {
          "$WORKSPACE/apps/web/tsconfig.tsbuildinfo" \
          "$WORKSPACE/packages/db/generated"
   cp -r /app/scripts/. "$WORKSPACE/scripts/"
+  # pnpm-workspace.yaml `patchedDependencies` resolves patch paths against the
+  # workspace root, so the patches must land alongside it — otherwise
+  # install_workspace_dependencies below exits non-zero on a missing patch file
+  # (SUR-8AB3353C). Replace rather than merge so a removed patch does not linger.
+  rm -rf "$WORKSPACE/patches"
+  cp -r /app/patches "$WORKSPACE/" 2>/dev/null || true
   cp /app/pnpm-workspace.yaml "$WORKSPACE/" 2>/dev/null || true
   cp /app/pnpm-lock.yaml "$WORKSPACE/" 2>/dev/null || true
   cp /app/package.json "$WORKSPACE/" 2>/dev/null || true

--- a/scripts/check-docker-patch-context.mjs
+++ b/scripts/check-docker-patch-context.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+// Docker Patch Context Guard.
+//
+// pnpm-workspace.yaml `patchedDependencies` names patch files by repo-relative
+// path, and pnpm resolves them against the workspace root at install time. A
+// missing patch file is not a warning — `pnpm install` exits 254 with ENOENT and
+// takes the whole image build (or the runtime workspace bootstrap) down with it.
+//
+// PR #4321 added the first such directive without adding the matching COPY, so
+// every self-upgrade after it failed deterministically (SUR-8AB3353C). This
+// guard closes the class: for each declared patch it proves the file exists, is
+// not excluded from the Docker build context, reaches every image stage that
+// runs `pnpm install`, and travels with the root manifests that the runtime
+// workspace bootstrap copies before installing.
+//
+// Fails closed: an unparseable Dockerfile stage graph is a failure, not a skip.
+
+import { readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = process.cwd();
+
+// Dockerfiles whose stages may run `pnpm install`. Every Dockerfile in the repo
+// is inspected; this list only records which ones are EXPECTED to be checked, so
+// a newly added Dockerfile cannot quietly opt out.
+const DOCKERFILES = ["Dockerfile", "Dockerfile.sandbox", "Dockerfile.promoter"];
+
+// Shell entrypoints baked into an image that run `pnpm install` against a
+// directory they populate themselves, rather than against the build context.
+const RUNTIME_BOOTSTRAP_SCRIPTS = ["docker-entrypoint.sh"];
+
+/**
+ * Parse the `patchedDependencies:` block of pnpm-workspace.yaml.
+ * Line-oriented on purpose — the other workspace guards in this directory read
+ * the same file the same way, and it avoids a YAML dependency in the guard path.
+ *
+ * @returns {{ spec: string, patchPath: string }[]}
+ */
+export function parsePatchedDependencies(yamlText) {
+  const lines = yamlText.split(/\r?\n/);
+  const start = lines.findIndex((l) => /^patchedDependencies:\s*$/.test(l));
+  if (start === -1) return [];
+
+  const entries = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === "" || line.trimStart().startsWith("#")) continue;
+    // Any non-indented, non-comment line ends the block.
+    if (!/^\s/.test(line)) break;
+
+    const match = line.match(/^\s+(?:"([^"]+)"|'([^']+)'|(\S+?)):\s*(\S.*?)\s*$/);
+    if (!match) {
+      throw new Error(
+        `check-docker-patch-context: unparseable patchedDependencies entry: ${line}`,
+      );
+    }
+    const spec = match[1] ?? match[2] ?? match[3];
+    const patchPath = match[4].replace(/^["']|["']$/g, "");
+    entries.push({ spec, patchPath });
+  }
+  return entries;
+}
+
+/**
+ * Would `.dockerignore` exclude this path from the build context?
+ * Deliberately conservative: it only understands the plain prefix and
+ * single-segment-glob forms this repo actually uses, and reports a pattern it
+ * cannot classify as exclusion so the guard errs toward failing.
+ */
+export function isDockerignored(patchPath, dockerignoreText) {
+  let excluded = false;
+  for (const raw of dockerignoreText.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const negated = line.startsWith("!");
+    const pattern = (negated ? line.slice(1) : line).replace(/\/+$/, "");
+    if (pattern === "") continue;
+
+    const regex = new RegExp(
+      `^${pattern
+        .split("/")
+        .map((seg) =>
+          seg === "**"
+            ? ".*"
+            : seg.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]*"),
+        )
+        .join("/")}(/.*)?$`,
+    );
+    if (regex.test(patchPath)) excluded = !negated;
+  }
+  return excluded;
+}
+
+/**
+ * Build the stage graph of a Dockerfile.
+ *
+ * Each stage records its parent (for `FROM <stage>`), its WORKDIR, the COPY
+ * instructions it issues, and whether it runs `pnpm install`.
+ */
+export function parseStages(dockerfileText) {
+  const stages = [];
+  let current = null;
+  // Join line continuations so a wrapped COPY/RUN is seen whole.
+  const text = dockerfileText.replace(/\\\r?\n\s*/g, " ");
+
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line === "" || line.startsWith("#")) continue;
+
+    const from = line.match(/^FROM\s+(\S+)(?:\s+AS\s+(\S+))?/i);
+    if (from) {
+      current = {
+        name: from[2] ?? `#${stages.length}`,
+        parent: from[1],
+        workdir: null,
+        copies: [],
+        runsPnpmInstall: false,
+      };
+      stages.push(current);
+      continue;
+    }
+    if (!current) continue;
+
+    const workdir = line.match(/^WORKDIR\s+(\S+)/i);
+    if (workdir) {
+      current.workdir = workdir[1];
+      continue;
+    }
+
+    const copy = line.match(/^COPY\s+(.*)$/i);
+    if (copy) {
+      const parts = copy[1].split(/\s+/).filter(Boolean);
+      const flags = parts.filter((p) => p.startsWith("--"));
+      const operands = parts.filter((p) => !p.startsWith("--"));
+      if (operands.length >= 2) {
+        current.copies.push({
+          sources: operands.slice(0, -1),
+          dest: operands[operands.length - 1],
+          fromStage:
+            flags
+              .find((f) => f.toLowerCase().startsWith("--from="))
+              ?.slice("--from=".length) ?? null,
+        });
+      }
+      continue;
+    }
+
+    if (/^RUN\b/i.test(line) && /\bpnpm\s+install\b/.test(line)) {
+      current.runsPnpmInstall = true;
+    }
+  }
+  return stages;
+}
+
+function resolveWorkdir(stage, byName) {
+  let node = stage;
+  const seen = new Set();
+  while (node && !seen.has(node.name)) {
+    if (node.workdir) return node.workdir;
+    seen.add(node.name);
+    node = byName.get(node.parent) ?? null;
+  }
+  return "/";
+}
+
+/**
+ * Does `stage` (or any stage it inherits from) place `patchPath` at the location
+ * pnpm will look for it — i.e. under the stage's workdir, preserving the
+ * repo-relative path?
+ */
+function stageProvidesPatch(stage, patchPath, byName, seen = new Set()) {
+  if (!stage || seen.has(stage.name)) return false;
+  seen.add(stage.name);
+
+  const workdir = resolveWorkdir(stage, byName);
+  const patchDir = dirname(patchPath); // e.g. "patches"
+
+  for (const copy of stage.copies) {
+    const dest = copy.dest.replace(/^\.\//, "").replace(/\/+$/, "");
+    const destAbs = dest.startsWith("/") ? dest : `${workdir.replace(/\/+$/, "")}/${dest}`;
+    const wantAbs = `${workdir.replace(/\/+$/, "")}/${patchDir}`;
+    if (destAbs !== wantAbs) continue;
+
+    for (const src of copy.sources) {
+      const normalized = src.replace(/^\.\//, "").replace(/\/+$/, "");
+      // Either the patch directory itself, or the exact patch file.
+      if (
+        normalized === patchDir ||
+        normalized === patchPath ||
+        normalized.endsWith(`/${patchDir}`)
+      ) {
+        return true;
+      }
+    }
+  }
+
+  // Inherited from the parent stage (same workdir chain), but NOT across a
+  // `--from=` copy boundary, which starts a fresh filesystem.
+  return stageProvidesPatch(byName.get(stage.parent), patchPath, byName, seen);
+}
+
+export function checkPatchContext(root = REPO_ROOT) {
+  const problems = [];
+
+  const workspacePath = join(root, "pnpm-workspace.yaml");
+  const entries = parsePatchedDependencies(readFileSync(workspacePath, "utf8"));
+  if (entries.length === 0) {
+    return { ok: true, entries, problems, checkedStages: [] };
+  }
+
+  const dockerignore = existsSync(join(root, ".dockerignore"))
+    ? readFileSync(join(root, ".dockerignore"), "utf8")
+    : "";
+
+  const checkedStages = [];
+
+  for (const { spec, patchPath } of entries) {
+    if (!existsSync(join(root, patchPath))) {
+      problems.push(
+        `pnpm-workspace.yaml patches ${spec} with ${patchPath}, but that file does not exist.`,
+      );
+      continue;
+    }
+
+    if (isDockerignored(patchPath, dockerignore)) {
+      problems.push(
+        `${patchPath} is excluded by .dockerignore, so it never reaches any Docker build context. ` +
+          `Add a negation (\`!${dirname(patchPath)}/\`) or drop the excluding pattern.`,
+      );
+    }
+
+    for (const dockerfile of DOCKERFILES) {
+      const dockerfilePath = join(root, dockerfile);
+      if (!existsSync(dockerfilePath)) continue;
+
+      const stages = parseStages(readFileSync(dockerfilePath, "utf8"));
+      const byName = new Map(stages.map((s) => [s.name, s]));
+
+      for (const stage of stages) {
+        if (!stage.runsPnpmInstall) continue;
+        checkedStages.push(`${dockerfile}:${stage.name}`);
+        if (!stageProvidesPatch(stage, patchPath, byName)) {
+          problems.push(
+            `${dockerfile} stage \`${stage.name}\` runs \`pnpm install\` but never COPYs ${patchPath} ` +
+              `into ${resolveWorkdir(stage, byName)}. pnpm resolves patchedDependencies against the ` +
+              `workspace root and exits 254 (ENOENT) when the patch is absent. ` +
+              `Add \`COPY ${dirname(patchPath)}/ ./${dirname(patchPath)}/\` before the install.`,
+          );
+        }
+      }
+    }
+
+    // Runtime bootstrap: an entrypoint that populates a workspace directory and
+    // installs into it must carry the patches there too. The build context is
+    // irrelevant at that point — only what the entrypoint copies exists.
+    for (const script of RUNTIME_BOOTSTRAP_SCRIPTS) {
+      const scriptPath = join(root, script);
+      if (!existsSync(scriptPath)) continue;
+      const text = readFileSync(scriptPath, "utf8");
+      if (!/\bpnpm\s+install\b/.test(text)) continue;
+      checkedStages.push(`${script}:runtime-bootstrap`);
+      if (!text.includes(`/${dirname(patchPath)}`)) {
+        problems.push(
+          `${script} runs \`pnpm install\` against a workspace it populates itself, but never copies ` +
+            `${dirname(patchPath)}/ into it. The runtime install fails with the same ENOENT the ` +
+            `image build does.`,
+        );
+      }
+    }
+  }
+
+  return { ok: problems.length === 0, entries, problems, checkedStages };
+}
+
+const isMain =
+  process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
+  const result = checkPatchContext();
+  if (!result.ok) {
+    console.error("Docker Patch Context Guard: FAIL\n");
+    console.error(result.problems.map((p) => `  - ${p}`).join("\n"));
+    process.exit(1);
+  }
+  console.log(
+    `Docker Patch Context Guard: ${result.entries.length} patched ` +
+      `${result.entries.length === 1 ? "dependency" : "dependencies"} reachable from ` +
+      `${new Set(result.checkedStages).size} installing stage(s) — ok.`,
+  );
+}

--- a/scripts/check-docker-patch-context.test.mjs
+++ b/scripts/check-docker-patch-context.test.mjs
@@ -1,0 +1,207 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  parsePatchedDependencies,
+  isDockerignored,
+  parseStages,
+  checkPatchContext,
+} from "./check-docker-patch-context.mjs";
+
+const WORKSPACE_WITH_PATCH = `packages:
+  - apps/*
+patchedDependencies:
+  image-size@1.2.1: patches/image-size@1.2.1.patch
+overrides:
+  lodash: 4.17.21
+`;
+
+function scaffold(files) {
+  const root = mkdtempSync(join(tmpdir(), "patch-context-"));
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(root, rel);
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  return root;
+}
+
+test("parses patchedDependencies and stops at the next top-level key", () => {
+  const entries = parsePatchedDependencies(WORKSPACE_WITH_PATCH);
+  assert.deepEqual(entries, [
+    { spec: "image-size@1.2.1", patchPath: "patches/image-size@1.2.1.patch" },
+  ]);
+});
+
+test("returns empty when no patchedDependencies block exists", () => {
+  assert.deepEqual(parsePatchedDependencies("packages:\n  - apps/*\n"), []);
+});
+
+test("dockerignore matching understands prefixes, globs and negations", () => {
+  assert.equal(isDockerignored("patches/a.patch", "node_modules\n"), false);
+  assert.equal(isDockerignored("patches/a.patch", "patches\n"), true);
+  assert.equal(isDockerignored("patches/a.patch", "patches/\n"), true);
+  assert.equal(isDockerignored("patches/a.patch", "**/*.patch\n"), true);
+  assert.equal(
+    isDockerignored("patches/a.patch", "patches\n!patches/\n"),
+    false,
+  );
+});
+
+test("stage parsing records inheritance, workdir, copies and installs", () => {
+  const stages = parseStages(`FROM node:24-alpine AS base
+WORKDIR /app
+FROM base AS deps
+COPY pnpm-workspace.yaml ./
+COPY patches/ ./patches/
+RUN pnpm install --frozen-lockfile
+FROM deps AS build
+RUN pnpm install --frozen-lockfile
+`);
+  assert.deepEqual(
+    stages.map((s) => s.name),
+    ["base", "deps", "build"],
+  );
+  assert.equal(stages[1].parent, "base");
+  assert.equal(stages[1].runsPnpmInstall, true);
+  assert.equal(stages[2].copies.length, 0);
+  assert.equal(stages[2].runsPnpmInstall, true);
+});
+
+test("line continuations do not hide a pnpm install", () => {
+  const stages = parseStages(`FROM node AS a
+WORKDIR /app
+RUN pnpm \\
+  install --frozen-lockfile
+`);
+  assert.equal(stages[0].runsPnpmInstall, true);
+});
+
+// --- End-to-end: the exact regression from PR #4321 -------------------------
+
+const DOCKERFILE_MISSING_COPY = `FROM node:24-alpine AS base
+WORKDIR /app
+FROM base AS deps
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+RUN pnpm install --frozen-lockfile
+`;
+
+const DOCKERFILE_FIXED = `FROM node:24-alpine AS base
+WORKDIR /app
+FROM base AS deps
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY patches/ ./patches/
+RUN pnpm install --frozen-lockfile
+FROM deps AS build
+COPY apps/ ./apps/
+RUN pnpm install --frozen-lockfile
+`;
+
+test("fails when an installing stage never COPYs the patch directory", () => {
+  const root = scaffold({
+    "pnpm-workspace.yaml": WORKSPACE_WITH_PATCH,
+    "patches/image-size@1.2.1.patch": "diff --git a b\n",
+    ".dockerignore": "node_modules\n",
+    Dockerfile: DOCKERFILE_MISSING_COPY,
+  });
+  try {
+    const result = checkPatchContext(root);
+    assert.equal(result.ok, false);
+    assert.match(result.problems.join("\n"), /stage `deps` runs `pnpm install`/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("passes once deps COPYs patches, and credits inheriting stages", () => {
+  const root = scaffold({
+    "pnpm-workspace.yaml": WORKSPACE_WITH_PATCH,
+    "patches/image-size@1.2.1.patch": "diff --git a b\n",
+    ".dockerignore": "node_modules\n",
+    Dockerfile: DOCKERFILE_FIXED,
+  });
+  try {
+    const result = checkPatchContext(root);
+    assert.equal(result.ok, true, result.problems.join("\n"));
+    // `build` is FROM deps and inherits /app/patches — it must not be flagged.
+    assert.ok(result.checkedStages.includes("Dockerfile:build"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails when the patch file is declared but absent", () => {
+  const root = scaffold({
+    "pnpm-workspace.yaml": WORKSPACE_WITH_PATCH,
+    ".dockerignore": "",
+    Dockerfile: DOCKERFILE_FIXED,
+  });
+  try {
+    const result = checkPatchContext(root);
+    assert.equal(result.ok, false);
+    assert.match(result.problems.join("\n"), /does not exist/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails when .dockerignore excludes the patch directory", () => {
+  const root = scaffold({
+    "pnpm-workspace.yaml": WORKSPACE_WITH_PATCH,
+    "patches/image-size@1.2.1.patch": "diff\n",
+    ".dockerignore": "node_modules\npatches\n",
+    Dockerfile: DOCKERFILE_FIXED,
+  });
+  try {
+    const result = checkPatchContext(root);
+    assert.equal(result.ok, false);
+    assert.match(result.problems.join("\n"), /excluded by \.dockerignore/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails when the runtime bootstrap installs without carrying patches", () => {
+  const root = scaffold({
+    "pnpm-workspace.yaml": WORKSPACE_WITH_PATCH,
+    "patches/image-size@1.2.1.patch": "diff\n",
+    ".dockerignore": "",
+    Dockerfile: DOCKERFILE_FIXED,
+    "docker-entrypoint.sh":
+      'cp /app/pnpm-workspace.yaml "$WORKSPACE/"\ncd "$WORKSPACE" && pnpm install --frozen-lockfile\n',
+  });
+  try {
+    const result = checkPatchContext(root);
+    assert.equal(result.ok, false);
+    assert.match(result.problems.join("\n"), /never copies patches\//);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("passes when the runtime bootstrap copies patches alongside the manifests", () => {
+  const root = scaffold({
+    "pnpm-workspace.yaml": WORKSPACE_WITH_PATCH,
+    "patches/image-size@1.2.1.patch": "diff\n",
+    ".dockerignore": "",
+    Dockerfile: DOCKERFILE_FIXED,
+    "docker-entrypoint.sh":
+      'cp -r /app/patches "$WORKSPACE/"\ncp /app/pnpm-workspace.yaml "$WORKSPACE/"\ncd "$WORKSPACE" && pnpm install --frozen-lockfile\n',
+  });
+  try {
+    const result = checkPatchContext(root);
+    assert.equal(result.ok, true, result.problems.join("\n"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// --- The live repo must satisfy its own guard ------------------------------
+
+test("the repository as committed passes the guard", () => {
+  const result = checkPatchContext(process.cwd());
+  assert.equal(result.ok, true, result.problems.join("\n"));
+});

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -105,6 +105,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("scripts/check-build-script-policy.mjs"),
       node("--test", "scripts/check-build-script-policy.test.mjs"),
       node("--test", "scripts/check-root-script-runtime.test.mjs"),
+      // A `patchedDependencies` entry whose patch file never reaches the Docker
+      // build context fails `pnpm install` with ENOENT and breaks every image
+      // build (SUR-8AB3353C, regression from #4321).
+      node("scripts/check-docker-patch-context.mjs"),
+      node("--test", "scripts/check-docker-patch-context.test.mjs"),
     ]),
     guard("bundle-boundary-guard", "Bundle Boundary Guard", [
       node("scripts/check-bundle-boundaries.mjs"),


### PR DESCRIPTION
## The break

PR #4321 added the repo's first pnpm patch:

```yaml
# pnpm-workspace.yaml:230-231
patchedDependencies:
  image-size@1.2.1: patches/image-size@1.2.1.patch
```

pnpm resolves that path against the workspace root and **reads the file to hash it** during install. `Dockerfile`'s `deps` stage COPYs `pnpm-workspace.yaml` but never COPYs `patches/`, so `RUN pnpm install --frozen-lockfile` cannot open `/app/patches/image-size@1.2.1.patch` and exits **254** with ENOENT.

Every image build since #4321 merged has failed this way, including run `SUR-8AB3353C`. It is deterministic — re-running a deploy trigger cannot clear it. `.dockerignore` does **not** exclude `patches/`; the missing COPY is the whole cause.

Worth noting: `image-size` reaches the tree via `metro` (`apps/mobile`), which the image context excludes — so the patched package is never even installed in the image. pnpm reads and hashes the patch file regardless, which is why an unused patch still took the build down.

## The fix

| Site | Change |
|---|---|
| `deps` stage | `COPY patches/ ./patches/` before the install |
| `build`, `init` | none needed — both are `FROM deps` at the same `WORKDIR /app` and inherit `/app/patches` (verified per stage, not assumed) |
| `runner` stage | `COPY --from=init /app/patches ./patches` |
| `docker-entrypoint.sh` | sync `patches/` into `/workspace` alongside the root manifests |
| `Dockerfile.sandbox`, `Dockerfile.promoter` | none needed — neither runs a build-time `pnpm install` |

The runner is a genuine **second failure site**: it copies the root manifests to `/app`, and `sync_image_source_to_workspace` copies them into `/workspace` before `install_workspace_dependencies` runs `pnpm install` there. Without `patches/` travelling alongside `pnpm-workspace.yaml`, that runtime bootstrap fails identically. The Build Studio sandbox installs against that same `/workspace`, so it is covered by the same fix.

`patches/` also joins the source-content hash, so editing a patch changes image identity — it changes the installed bytes, and that hash claims to be the honest fingerprint of what went into the image.

## Recurrence guard

`scripts/check-docker-patch-context.mjs` proves, for every declared patch, that it:

1. exists on disk,
2. is not excluded by `.dockerignore`,
3. reaches **every** Dockerfile stage that runs `pnpm install` — following `FROM` inheritance and `WORKDIR`, and deliberately *not* crediting a `COPY --from=` across a filesystem boundary,
4. is carried by any runtime bootstrap script that installs into a directory it populates itself.

Registered under the existing **Workspace Supply-Chain Policy** guard, so it adds no new CI job.

## Verification — functional, not structural

- `docker build --target deps` **reproduces** the failure with the COPY removed: `exit code: 254`, ENOENT in `createHexHashFromFile`.
- With the fix, the deps stage completes and the **full portal image builds green** through `deps`, `build`, `init` and `runner`.
- The guard was run against the **real** Dockerfile with the COPY reverted — it flags all three installing stages with the exact remedy — and passes on the committed tree.
- `pnpm run pregate`: **gate passed** (evidence `cmsuuf8mr227o01pps0nae1ma`).

## Backlog

Filed BI-FF2BB8F7 for the diagnosed defect. Retired BI-FBDF739F as a duplicate of it — that item described the same failing run but attributed it to PR #4332 and speculated it might be transient.

Signed-off-by: Mark Bodman <markdbodman@gmail.com>

Docs-Impact-Decision: Build-context plumbing only — a COPY of patches/ into the Docker stages that run pnpm install, the matching sync in docker-entrypoint.sh's workspace bootstrap, and a new entry under an existing policy-guard profile. No route, workflow, CLI surface, or operator-visible behaviour changes: the image simply builds again where it previously failed. docs/testing/pre-pr-gate.md documents the guard *profiles* and names scripts/lib/ci-policy-guards.mjs as the authoritative registry rather than enumerating individual guards, so adding a guard to an existing profile leaves it accurate as written.
