### PR TITLE
refactor(workroom): converge the WorkRoom view vocabulary onto Workroom (BI-C2C16582)

### DIFF
--- a/apps/web/app/(shell)/workspace/cases/[caseKey]/page.tsx
+++ b/apps/web/app/(shell)/workspace/cases/[caseKey]/page.tsx
@@ -5,8 +5,8 @@ import { WorkCaseDetailView } from "@/components/workspace/WorkCaseDetailView";
 import { auth } from "@/lib/auth";
 import { getGrantedCapabilities } from "@/lib/permissions";
 import { loadEffectiveAuthContext } from "@/lib/identity/load-effective-auth-context";
-import { loadPrismaWorkRoomParticipants } from "@/lib/work-management/room-participation-prisma.server";
-import { resolveWorkRoomStructureForCase } from "@/lib/work-management/room-structure.server";
+import { loadPrismaWorkroomParticipants } from "@/lib/work-management/room-participation-prisma.server";
+import { resolveWorkroomStructureForCase } from "@/lib/work-management/room-structure.server";
 import { loadWorkspaceWorkCaseDetail } from "@/lib/work-management/workspace-case-loader";
 
 type Props = {
@@ -36,8 +36,8 @@ export default async function WorkspaceCaseDetailPage({ params }: Props) {
       sensitivityClearance: effectiveAuth.sensitivityClearance,
       isSuperuser: effectiveAuth.isSuperuser,
     },
-    participantLoader: loadPrismaWorkRoomParticipants,
-    structureLoader: resolveWorkRoomStructureForCase,
+    participantLoader: loadPrismaWorkroomParticipants,
+    structureLoader: resolveWorkroomStructureForCase,
   });
   if (!detail) notFound();
 

--- a/apps/web/components/ui/report-kit/statusColors.test.ts
+++ b/apps/web/components/ui/report-kit/statusColors.test.ts
@@ -99,9 +99,9 @@ describe("statusColors", () => {
 
   it("maps Work Room state, outcome health, and activity through shared domains", () => {
     expect(resolveIntent("workCaseState", "waiting-on-person")).toBe("warning");
-    expect(resolveIntent("workRoomOutcomeHealth", "at-risk")).toBe("warning");
-    expect(resolveIntent("workRoomActivity", "message")).toBe("neutral");
-    expect(resolveIntent("workRoomActivity", "decision-resolved")).toBe("success");
+    expect(resolveIntent("workroomOutcomeHealth", "at-risk")).toBe("warning");
+    expect(resolveIntent("workroomActivity", "message")).toBe("neutral");
+    expect(resolveIntent("workroomActivity", "decision-resolved")).toBe("success");
   });
 
   // BI-5B2F5447 (D0): the portfolioCoverage badge map is the render side of the

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -440,14 +440,14 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     closed: "neutral",
     cancelled: "neutral",
   },
-  workRoomOutcomeHealth: {
+  workroomOutcomeHealth: {
     "on-track": "success",
     "at-risk": "warning",
     blocked: "danger",
     idle: "neutral",
     unknown: "neutral",
   },
-  workRoomActivity: {
+  workroomActivity: {
     message: "neutral",
     ask: "warning",
     "coworker-joined": "accent",

--- a/apps/web/components/workspace/WorkCaseAttentionLens.tsx
+++ b/apps/web/components/workspace/WorkCaseAttentionLens.tsx
@@ -4,7 +4,7 @@ import { LocalTime } from "@/components/ui/LocalTime";
 import { StatCard, StatusBadge } from "@/components/ui/report-kit";
 import {
   roomLabel,
-} from "@/components/workspace/work-room/presentation";
+} from "@/components/workspace/workroom/presentation";
 import type {
   WorkspaceWorkCaseLensView,
   WorkspaceWorkCaseListItem,

--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -3,9 +3,9 @@ import { describe, expect, it } from "vitest";
 
 import { WorkCaseDetailView } from "./WorkCaseDetailView";
 import type { WorkspaceWorkCaseDetailView } from "@/lib/work-management/workspace-case-loader";
-import type { WorkRoomView } from "@/lib/work-management/room-types";
+import type { WorkroomView } from "@/lib/work-management/room-types";
 
-const room: WorkRoomView = {
+const room: WorkroomView = {
   roomKey: "booking%3ABK-1",
   caseRef: { caseId: "booking:BK-1", sourceType: "booking", sourceId: "BK-1" },
   title: "Confirm condenser appointment",
@@ -214,7 +214,7 @@ describe("WorkCaseDetailView", () => {
   });
 
   it("explains an incomplete room boundary without inventing missing facts", () => {
-    const incompleteRoom: WorkRoomView = {
+    const incompleteRoom: WorkroomView = {
       ...room,
       outcome: { ...room.outcome, statement: null },
       boundary: {

--- a/apps/web/components/workspace/WorkCaseDetailView.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.tsx
@@ -1,8 +1,8 @@
 import { ArrowLeft, DoorClosed } from "lucide-react";
 
 import { EmptyState } from "@/components/ui/report-kit";
-import { WorkRoomBody } from "@/components/workspace/work-room/WorkRoomBody";
-import { WorkRoomHeader } from "@/components/workspace/work-room/WorkRoomHeader";
+import { WorkroomBody } from "@/components/workspace/workroom/WorkroomBody";
+import { WorkroomHeader } from "@/components/workspace/workroom/WorkroomHeader";
 import type { WorkspaceWorkCaseDetailView } from "@/lib/work-management/workspace-case-loader";
 
 type Props = {
@@ -39,8 +39,8 @@ export function WorkCaseDetailView({ detail }: Props) {
 
   return (
     <main className="space-y-5 text-[var(--dpf-text)]">
-      <WorkRoomHeader room={detail.room} summary={detail.summary} />
-      <WorkRoomBody detail={detail} room={detail.room} />
+      <WorkroomHeader room={detail.room} summary={detail.summary} />
+      <WorkroomBody detail={detail} room={detail.room} />
     </main>
   );
 }

--- a/apps/web/components/workspace/workroom/WorkroomBody.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomBody.tsx
@@ -10,24 +10,24 @@ import { EmptyState, Notice, StatusBadge } from "@/components/ui/report-kit";
 import { WorkItemCommentBox } from "@/components/workspace/WorkItemCommentBox";
 import type { WorkspaceWorkCaseDetailView } from "@/lib/work-management/workspace-case-loader";
 import type {
-  WorkRoomActivityView,
-  WorkRoomBoundaryGap,
-  WorkRoomView,
+  WorkroomActivityView,
+  WorkroomBoundaryGap,
+  WorkroomView,
 } from "@/lib/work-management/room-types";
 
 import {
   ACTIVITY_KIND_LABEL,
   roomLabel,
 } from "./presentation";
-import { WorkRoomCycles } from "./WorkRoomCycles";
-import { WorkRoomParticipants } from "./WorkRoomParticipants";
+import { WorkroomCycles } from "./WorkroomCycles";
+import { WorkroomParticipants } from "./WorkroomParticipants";
 
 type Props = {
   detail: WorkspaceWorkCaseDetailView;
-  room: WorkRoomView;
+  room: WorkroomView;
 };
 
-const BOUNDARY_GAP_LABEL: Record<WorkRoomBoundaryGap, string> = {
+const BOUNDARY_GAP_LABEL: Record<WorkroomBoundaryGap, string> = {
   purpose: "Purpose not defined",
   outcome: "Outcome not defined",
   scope: "Scope not defined",
@@ -41,7 +41,7 @@ const BOUNDARY_GAP_LABEL: Record<WorkRoomBoundaryGap, string> = {
   "closure-rule": "Closure rule not defined",
 };
 
-function ActivityEvent({ event }: { event: WorkRoomActivityView }) {
+function ActivityEvent({ event }: { event: WorkroomActivityView }) {
   const label = ACTIVITY_KIND_LABEL[event.kind];
 
   return (
@@ -54,7 +54,7 @@ function ActivityEvent({ event }: { event: WorkRoomActivityView }) {
       </span>
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-2">
-          <StatusBadge domain="workRoomActivity" status={event.kind} label={label} variant="soft" />
+          <StatusBadge domain="workroomActivity" status={event.kind} label={label} variant="soft" />
           {event.occurredAt ? (
             <LocalTime value={event.occurredAt} mode="datetime" className="text-xs text-[var(--dpf-muted)]" />
           ) : null}
@@ -67,7 +67,7 @@ function ActivityEvent({ event }: { event: WorkRoomActivityView }) {
   );
 }
 
-function BoundaryNotice({ room }: { room: WorkRoomView }) {
+function BoundaryNotice({ room }: { room: WorkroomView }) {
   if (!room.projection.incompleteBoundary) return null;
 
   const gaps = room.boundary.gaps.map((gap) => BOUNDARY_GAP_LABEL[gap]);
@@ -85,14 +85,14 @@ function BoundaryNotice({ room }: { room: WorkRoomView }) {
   );
 }
 
-function ContextPanels({ room }: { room: WorkRoomView }) {
+function ContextPanels({ room }: { room: WorkroomView }) {
   const decisions = room.activity.filter((event) =>
     event.kind === "decision-proposed" || event.kind === "decision-resolved",
   );
 
   return (
     <div className="space-y-3">
-      <WorkRoomParticipants room={room} />
+      <WorkroomParticipants room={room} />
 
       <section aria-label="Work" className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
         <details>
@@ -191,12 +191,12 @@ function RoomDetails({ detail, room }: Props) {
   );
 }
 
-export function WorkRoomBody({ detail, room }: Props) {
+export function WorkroomBody({ detail, room }: Props) {
   return (
     <>
       <BoundaryNotice room={room} />
 
-      <WorkRoomCycles room={room} />
+      <WorkroomCycles room={room} />
 
       <div className="grid items-start gap-5 xl:grid-cols-[minmax(0,1.65fr)_minmax(18rem,0.75fr)]">
         <section

--- a/apps/web/components/workspace/workroom/WorkroomCycles.test.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomCycles.test.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import type { WorkRoomView } from "@/lib/work-management/room-types";
+import type { WorkroomView } from "@/lib/work-management/room-types";
 
-import { WorkRoomCycles } from "./WorkRoomCycles";
+import { WorkroomCycles } from "./WorkroomCycles";
 
-function room(): WorkRoomView {
+function room(): WorkroomView {
   const packet = {
     outcomeState: "partially-achieved" as const,
     summary: "Last week closed with one follow-up.",
@@ -61,9 +61,9 @@ function room(): WorkRoomView {
   };
 }
 
-describe("WorkRoomCycles", () => {
+describe("WorkroomCycles", () => {
   it("puts the current boundary before completed Outcome Packets", () => {
-    const html = renderToStaticMarkup(<WorkRoomCycles room={room()} />);
+    const html = renderToStaticMarkup(<WorkroomCycles room={room()} />);
 
     expect(html).toContain("Current cycle");
     expect(html).toContain("Review cash position and assign exceptions.");
@@ -76,7 +76,7 @@ describe("WorkRoomCycles", () => {
   it("shows healthy-idle guidance for a standing room without a current cycle", () => {
     const value = room();
     value.currentCycle = null;
-    const html = renderToStaticMarkup(<WorkRoomCycles room={value} />);
+    const html = renderToStaticMarkup(<WorkroomCycles room={value} />);
 
     expect(html).toContain("Ready for the next cycle");
     expect(html).toContain("healthy and idle");
@@ -85,6 +85,6 @@ describe("WorkRoomCycles", () => {
   it("does not add cycle chrome to finite rooms", () => {
     const value = room();
     value.mode = "finite";
-    expect(renderToStaticMarkup(<WorkRoomCycles room={value} />)).toBe("");
+    expect(renderToStaticMarkup(<WorkroomCycles room={value} />)).toBe("");
   });
 });

--- a/apps/web/components/workspace/workroom/WorkroomCycles.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomCycles.tsx
@@ -8,12 +8,12 @@ import {
 import { LocalTime } from "@/components/ui/LocalTime";
 import { EmptyState, StatusBadge } from "@/components/ui/report-kit";
 import type {
-  WorkRoomCycleView,
-  WorkRoomOutcomePacket,
-  WorkRoomView,
+  WorkroomCycleView,
+  WorkroomOutcomePacket,
+  WorkroomView,
 } from "@/lib/work-management/room-types";
 
-function OutcomePacketSummary({ packet }: { packet: WorkRoomOutcomePacket }) {
+function OutcomePacketSummary({ packet }: { packet: WorkroomOutcomePacket }) {
   const durableCount = packet.decisionRefs.length
     + packet.artifactRefs.length
     + packet.actionRefs.length
@@ -48,7 +48,7 @@ function OutcomePacketSummary({ packet }: { packet: WorkRoomOutcomePacket }) {
   );
 }
 
-function CurrentCycle({ cycle }: { cycle: WorkRoomCycleView }) {
+function CurrentCycle({ cycle }: { cycle: WorkroomCycleView }) {
   return (
     <section aria-labelledby="work-room-current-cycle-title" className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
       <div className="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--dpf-border)] px-4 py-3">
@@ -98,7 +98,7 @@ function CurrentCycle({ cycle }: { cycle: WorkRoomCycleView }) {
   );
 }
 
-function CompletedCycles({ cycles }: { cycles: readonly WorkRoomCycleView[] }) {
+function CompletedCycles({ cycles }: { cycles: readonly WorkroomCycleView[] }) {
   if (cycles.length === 0) return null;
 
   return (
@@ -136,7 +136,7 @@ function CompletedCycles({ cycles }: { cycles: readonly WorkRoomCycleView[] }) {
   );
 }
 
-export function WorkRoomCycles({ room }: { room: WorkRoomView }) {
+export function WorkroomCycles({ room }: { room: WorkroomView }) {
   if (room.mode !== "standing") return null;
 
   return (

--- a/apps/web/components/workspace/workroom/WorkroomHeader.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomHeader.tsx
@@ -2,26 +2,26 @@ import { AlertTriangle, ArrowLeft, Clock, Users } from "lucide-react";
 
 import { LocalTime } from "@/components/ui/LocalTime";
 import { Notice, StatusBadge } from "@/components/ui/report-kit";
-import { WorkRoomStructurePanel } from "@/components/workspace/work-room/WorkRoomStructurePanel";
+import { WorkroomStructurePanel } from "@/components/workspace/workroom/WorkroomStructurePanel";
 import type { WorkspaceWorkCaseListItem } from "@/lib/work-management/workspace-case-loader";
-import type { WorkRoomView } from "@/lib/work-management/room-types";
+import type { WorkroomView } from "@/lib/work-management/room-types";
 
 import {
   roomLabel,
 } from "./presentation";
 
 type Props = {
-  room: WorkRoomView;
+  room: WorkroomView;
   summary: WorkspaceWorkCaseListItem;
 };
 
-function accountableName(room: WorkRoomView): string {
+function accountableName(room: WorkroomView): string {
   return room.participants.find((participant) =>
     participant.roles.includes("accountable"),
   )?.displayName ?? "Accountable owner not assigned";
 }
 
-function participantSummary(room: WorkRoomView): string {
+function participantSummary(room: WorkroomView): string {
   const count = room.participants.length;
   if (count === 0) return "No participants listed";
   const names = room.participants.slice(0, 2).map((participant) => participant.displayName);
@@ -29,7 +29,7 @@ function participantSummary(room: WorkRoomView): string {
   return `${count} ${count === 1 ? "participant" : "participants"} · ${names.join(", ")}${remainder > 0 ? ` +${remainder}` : ""}`;
 }
 
-export function WorkRoomHeader({ room, summary }: Props) {
+export function WorkroomHeader({ room, summary }: Props) {
   const health = room.outcome.health;
   const purposeNeedsDisclosure = (room.purpose?.length ?? 0) > 280;
   const dueAt = room.boundary.timeBoundary.reviewAt
@@ -112,7 +112,7 @@ export function WorkRoomHeader({ room, summary }: Props) {
               Outcome
             </h2>
             {health ? (
-              <StatusBadge domain="workRoomOutcomeHealth" status={health} label={roomLabel(health)} variant="soft" />
+              <StatusBadge domain="workroomOutcomeHealth" status={health} label={roomLabel(health)} variant="soft" />
             ) : null}
           </div>
           <p className="mt-2 text-base font-semibold leading-6 text-[var(--dpf-text)]">
@@ -120,7 +120,7 @@ export function WorkRoomHeader({ room, summary }: Props) {
           </p>
         </section>
 
-        <WorkRoomStructurePanel structure={room.structure} />
+        <WorkroomStructurePanel structure={room.structure} />
 
         <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
           <section aria-label="Attention" className="rounded-lg border border-[var(--dpf-border)] p-3">

--- a/apps/web/components/workspace/workroom/WorkroomParticipants.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomParticipants.tsx
@@ -1,11 +1,11 @@
 import { ShieldCheck, Users } from "lucide-react";
 
 import { Notice, StatusBadge } from "@/components/ui/report-kit";
-import type { WorkRoomView } from "@/lib/work-management/room-types";
+import type { WorkroomView } from "@/lib/work-management/room-types";
 
 import { roomLabel } from "./presentation";
 
-export function WorkRoomParticipants({ room }: { room: WorkRoomView }) {
+export function WorkroomParticipants({ room }: { room: WorkroomView }) {
   const hasUnavailableCoworker = room.participants.some(
     (participant) => participant.kind === "agent" && participant.presence === "unknown",
   );

--- a/apps/web/components/workspace/workroom/WorkroomStructurePanel.test.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomStructurePanel.test.tsx
@@ -2,19 +2,19 @@ import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { resolveWorkRoomStructure } from "@/lib/work-management/room-structure";
+import { resolveWorkroomStructure } from "@/lib/work-management/room-structure";
 
-import { WorkRoomStructurePanel } from "./WorkRoomStructurePanel";
+import { WorkroomStructurePanel } from "./WorkroomStructurePanel";
 
-describe("WorkRoomStructurePanel", () => {
+describe("WorkroomStructurePanel", () => {
   it("renders nothing when the subject has no structure", () => {
-    const html = renderToStaticMarkup(<WorkRoomStructurePanel structure={null} />);
+    const html = renderToStaticMarkup(<WorkroomStructurePanel structure={null} />);
     expect(html).toBe("");
   });
 
   it("surfaces the value stream, lifecycle stage/state, and advancement gates", () => {
-    const structure = resolveWorkRoomStructure({ kind: "opportunity", stage: "qualification" });
-    const html = renderToStaticMarkup(<WorkRoomStructurePanel structure={structure} />);
+    const structure = resolveWorkroomStructure({ kind: "opportunity", stage: "qualification" });
+    const html = renderToStaticMarkup(<WorkroomStructurePanel structure={structure} />);
     expect(html).toContain("Value stream");
     expect(html).toContain("Lifecycle");
     // Labels may carry "&" which HTML-escapes; assert on a special-char-free token.

--- a/apps/web/components/workspace/workroom/WorkroomStructurePanel.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomStructurePanel.tsx
@@ -1,10 +1,10 @@
 import { GitBranch, Lock, Milestone, Unlock } from "lucide-react";
 
 import { StatusBadge } from "@/components/ui/report-kit";
-import type { WorkRoomStructure } from "@/lib/work-management/room-structure";
+import type { WorkroomStructure } from "@/lib/work-management/room-structure";
 
 type Props = {
-  structure: WorkRoomStructure | null;
+  structure: WorkroomStructure | null;
 };
 
 const BAND_INTENT: Record<string, "neutral" | "success" | "warning"> = {
@@ -18,7 +18,7 @@ const BAND_INTENT: Record<string, "neutral" | "success" | "warning"> = {
  * collaboration happens within (EP-WORKROOM-COMMS / EP-VSL-SURFACE fold). Renders
  * nothing when the subject has no value-stream/lifecycle binding.
  */
-export function WorkRoomStructurePanel({ structure }: Props) {
+export function WorkroomStructurePanel({ structure }: Props) {
   if (!structure || (!structure.valueStream && !structure.lifecycle)) return null;
   const { valueStream, lifecycle } = structure;
 

--- a/apps/web/components/workspace/workroom/presentation.ts
+++ b/apps/web/components/workspace/workroom/presentation.ts
@@ -1,8 +1,8 @@
 import type {
-  WorkRoomActivityKind,
+  WorkroomActivityKind,
 } from "@/lib/work-management/room-types";
 
-export const ACTIVITY_KIND_LABEL: Record<WorkRoomActivityKind, string> = {
+export const ACTIVITY_KIND_LABEL: Record<WorkroomActivityKind, string> = {
   message: "Message",
   ask: "Input needed",
   "coworker-joined": "Coworker joined",

--- a/apps/web/lib/deliberation/deliberation-room-bridge.server.ts
+++ b/apps/web/lib/deliberation/deliberation-room-bridge.server.ts
@@ -9,7 +9,7 @@
 import { prisma } from "@dpf/db";
 
 import { bridgeTaskNodeToWorkItem } from "@/lib/queue/bridges/task-node-bridge";
-import { WORK_ROOM_OUTCOME_MESSAGE_TYPE } from "@/lib/work-management/room-cycle-adapter";
+import { WORKROOM_OUTCOME_MESSAGE_TYPE } from "@/lib/work-management/room-cycle-adapter";
 import { buildDeliberationOutcomeSeal, verdictNeedsEscalation } from "./deliberation-room";
 
 /** Accountable ref for a machine-sealed deliberation verdict (a system record; a human reviews the room). */
@@ -44,7 +44,7 @@ export async function sealDeliberationOnRoom(input: {
 
   // Idempotent: don't re-seal a room that already carries an outcome packet.
   const existing = await prisma.workItemMessage.findFirst({
-    where: { workItemId: workItem.id, messageType: WORK_ROOM_OUTCOME_MESSAGE_TYPE },
+    where: { workItemId: workItem.id, messageType: WORKROOM_OUTCOME_MESSAGE_TYPE },
     select: { messageId: true },
   });
 
@@ -63,7 +63,7 @@ export async function sealDeliberationOnRoom(input: {
       data: {
         workItemId: workItem.id,
         senderType: "system",
-        messageType: WORK_ROOM_OUTCOME_MESSAGE_TYPE,
+        messageType: WORKROOM_OUTCOME_MESSAGE_TYPE,
         body: packet.summary,
         structuredPayload: storedPayload as never,
         channel: "in-app",

--- a/apps/web/lib/deliberation/deliberation-room.test.ts
+++ b/apps/web/lib/deliberation/deliberation-room.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseStoredWorkRoomOutcome } from "../work-management/room-cycle-adapter";
+import { parseStoredWorkroomOutcome } from "../work-management/room-cycle-adapter";
 import {
   buildDeliberationOutcomeSeal,
   mapConsensusToOutcomeState,
@@ -44,7 +44,7 @@ describe("buildDeliberationOutcomeSeal", () => {
     expect(packet.evidenceRefs).toEqual([{ kind: "evidence", id: "DOUT-1" }]);
     expect(packet.accountablePrincipalRef).toBe("system:deliberation");
     // The stored payload round-trips through the room-outcome message parser.
-    expect(parseStoredWorkRoomOutcome(storedPayload)?.packet.outcomeState).toBe("achieved");
+    expect(parseStoredWorkroomOutcome(storedPayload)?.packet.outcomeState).toBe("achieved");
     expect(storedPayload.carrierId).toBe(BASE.adjudicatorTaskNodeId);
     expect(storedPayload.cycleKey).toBe("DRUN-1");
   });

--- a/apps/web/lib/deliberation/deliberation-room.ts
+++ b/apps/web/lib/deliberation/deliberation-room.ts
@@ -3,7 +3,7 @@
  *
  * Harmonizes the deliberation/debate pattern onto the Work Room substrate: a
  * finished deliberation becomes a finite `task-node` room whose verdict is sealed
- * as a durable WorkRoomOutcomePacket, referencing the canonical DeliberationOutcome
+ * as a durable WorkroomOutcomePacket, referencing the canonical DeliberationOutcome
  * (satisfies raw_chat_not_durable). A real consensus seals `achieved`/
  * `partially-achieved`; no-consensus/insufficient-evidence seals `not-achieved` —
  * the signal an operator reviews (and the alternate close = escalation).
@@ -13,15 +13,15 @@
  * message. Design of record:
  * docs/superpowers/specs/2026-08-12-work-room-multi-agent-communication-substrate-design.md §3
  */
-import { WORK_ROOM_OUTCOME_MESSAGE_TYPE } from "../work-management/room-cycle-adapter";
-import { buildWorkRoomOutcomePacket } from "../work-management/outcome-packet";
-import type { WorkRoomOutcomePacket } from "../work-management/room-types";
+import { WORKROOM_OUTCOME_MESSAGE_TYPE } from "../work-management/room-cycle-adapter";
+import { buildWorkroomOutcomePacket } from "../work-management/outcome-packet";
+import type { WorkroomOutcomePacket } from "../work-management/room-types";
 
 /** The registry sourceKey a deliberation room projects through (finite, evidence-only). */
 export const DELIBERATION_ROOM_SOURCE_KEY = "task-node";
 
 /** Map a deliberation consensus state to a room outcome state. */
-export function mapConsensusToOutcomeState(consensusState: string): WorkRoomOutcomePacket["outcomeState"] {
+export function mapConsensusToOutcomeState(consensusState: string): WorkroomOutcomePacket["outcomeState"] {
   switch (consensusState) {
     case "consensus":
       return "achieved";
@@ -51,20 +51,20 @@ export interface DeliberationRoomSealInput {
 }
 
 export interface StoredDeliberationOutcome {
-  kind: typeof WORK_ROOM_OUTCOME_MESSAGE_TYPE;
+  kind: typeof WORKROOM_OUTCOME_MESSAGE_TYPE;
   version: 1;
   cycleKey: string;
   carrierId: string;
-  packet: WorkRoomOutcomePacket;
+  packet: WorkroomOutcomePacket;
 }
 
 /**
  * Build the sealed outcome packet + the stored-message payload for a deliberation
- * verdict. Pure — throws WorkRoomOutcomePacketError on an invalid packet (e.g. a
+ * verdict. Pure — throws WorkroomOutcomePacketError on an invalid packet (e.g. a
  * raw-chat evidence ref), never here.
  */
 export function buildDeliberationOutcomeSeal(input: DeliberationRoomSealInput): {
-  packet: WorkRoomOutcomePacket;
+  packet: WorkroomOutcomePacket;
   storedPayload: StoredDeliberationOutcome;
 } {
   const outcomeState = mapConsensusToOutcomeState(input.consensusState);
@@ -72,7 +72,7 @@ export function buildDeliberationOutcomeSeal(input: DeliberationRoomSealInput): 
     input.mergedRecommendation.trim() ||
     `Deliberation ${input.deliberationRunId} reached ${input.consensusState}.`;
 
-  const packet = buildWorkRoomOutcomePacket({
+  const packet = buildWorkroomOutcomePacket({
     sourceKey: DELIBERATION_ROOM_SOURCE_KEY,
     outcomeState,
     summary,
@@ -90,7 +90,7 @@ export function buildDeliberationOutcomeSeal(input: DeliberationRoomSealInput): 
   return {
     packet,
     storedPayload: {
-      kind: WORK_ROOM_OUTCOME_MESSAGE_TYPE,
+      kind: WORKROOM_OUTCOME_MESSAGE_TYPE,
       version: 1,
       cycleKey: input.deliberationRunId,
       carrierId: input.adjudicatorTaskNodeId,

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -464,10 +464,10 @@
     "apps/web/components/workspace/WorkCaseDetailView.tsx": [
       "docs/user-guide/workspace/work-rooms.md"
     ],
-    "apps/web/components/workspace/work-room/WorkRoomCycles.tsx": [
+    "apps/web/components/workspace/workroom/WorkroomCycles.tsx": [
       "docs/user-guide/workspace/work-rooms.md"
     ],
-    "apps/web/components/workspace/work-room/WorkRoomParticipants.tsx": [
+    "apps/web/components/workspace/workroom/WorkroomParticipants.tsx": [
       "docs/user-guide/workspace/work-rooms.md"
     ],
     "apps/web/design/tokens-utilities.test.ts": [
@@ -2777,8 +2777,8 @@
       "apps/web/app/(shell)/workspace/my-queue/page.tsx",
       "apps/web/components/workspace/WorkCaseAttentionLens.tsx",
       "apps/web/components/workspace/WorkCaseDetailView.tsx",
-      "apps/web/components/workspace/work-room/WorkRoomCycles.tsx",
-      "apps/web/components/workspace/work-room/WorkRoomParticipants.tsx",
+      "apps/web/components/workspace/workroom/WorkroomCycles.tsx",
+      "apps/web/components/workspace/workroom/WorkroomParticipants.tsx",
       "apps/web/lib/work-management/room-channel-continuity.ts",
       "apps/web/lib/work-management/room-channel-ingress.ts",
       "apps/web/lib/work-management/room-participation.ts",

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 636,
+  "pageCount": 637,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -2137,7 +2137,7 @@
       "publishedPublic": true,
       "publishedPortal": false,
       "anchors": [
-        "work-room-participation-and-channel-continuity",
+        "workroom-participation-and-channel-continuity",
         "design-grounding",
         "authorization-boundary",
         "participant-projection",
@@ -2158,6 +2158,20 @@
         "decision-rules",
         "links-to-live-work",
         "maintenance"
+      ]
+    },
+    "docs/architecture/workroom-vocabulary-boundary.md": {
+      "publicHref": "/architecture/workroom-vocabulary-boundary/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "workroom-vocabulary-boundary",
+        "the-three-layers",
+        "naming-rules",
+        "a-known-tension-accepted-deliberately",
+        "what-is-deliberately-not-renamed-yet",
+        "related"
       ]
     },
     "docs/business-types/_readability-report.md": {

--- a/apps/web/lib/mcp/packs/room-messaging-pack.ts
+++ b/apps/web/lib/mcp/packs/room-messaging-pack.ts
@@ -21,7 +21,7 @@ import { getCoworkerRoomEngagement } from "@/lib/work-management/coworker-room-e
 import { heartbeatAgentWorkItemPresence } from "@/lib/work-management/room-agent-presence.server";
 import { postWorkItemComment, type PostCommentDb } from "@/lib/work-management/post-work-item-comment";
 import { appendRoomPolicyParticipant } from "@/lib/work-management/room-policy";
-import type { WorkRoomParticipantRole } from "@/lib/work-management/room-types";
+import type { WorkroomParticipantRole } from "@/lib/work-management/room-types";
 import { resolveAgentRoomAccess } from "@/lib/work-management/room-agent-access.server";
 import { decodeWorkCaseKey } from "@/lib/work-management/workspace-case-loader";
 
@@ -237,7 +237,7 @@ async function inviteRoomParticipantHandler(
   }
 
   const canAct = params["canAct"] !== false; // default: invited to participate (post), not merely observe
-  const roles: WorkRoomParticipantRole[] = ["contributor"];
+  const roles: WorkroomParticipantRole[] = ["contributor"];
   const newEvidence = appendRoomPolicyParticipant(item.evidence, {
     principalRef: inviteePrincipalId,
     roles,

--- a/apps/web/lib/tak/consequential-tool-policy.ts
+++ b/apps/web/lib/tak/consequential-tool-policy.ts
@@ -1,7 +1,7 @@
 import type { ToolDefinition } from "@/lib/mcp-tools";
 import { getWorkCaseAction } from "@/lib/work-management/action-registry";
 import type { WorkCaseExecutionContext } from "@/lib/work-management/work-case-governance-hook";
-import type { WorkRoomShapeKey } from "@/lib/work-management/room-shapes";
+import type { WorkroomShapeKey } from "@/lib/work-management/room-shapes";
 
 export const CONSEQUENCE_CLASSES = ["routine-read", "ordinary-mutation", "consequential-mutation"] as const;
 export type ConsequenceClass = (typeof CONSEQUENCE_CLASSES)[number];
@@ -11,7 +11,7 @@ export type ConsequentialToolClassification = {
   consequential: boolean;
   alignmentRequired: boolean;
   preconditionRequired: boolean;
-  collaborationShape: WorkRoomShapeKey | null;
+  collaborationShape: WorkroomShapeKey | null;
   reason: "read-only" | "ordinary-side-effect" | "explicit-policy" | "work-case-consequential";
 };
 
@@ -29,7 +29,7 @@ export const ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES = [
 const EXPLICIT = new Set<string>(ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES);
 const PRECONDITION = new Set(["transition_employee_status"]);
 
-export function collaborationShapeForTool(toolName: string): WorkRoomShapeKey | null {
+export function collaborationShapeForTool(toolName: string): WorkroomShapeKey | null {
   if (["create_digital_product", "create_product", "create_product_line", "create_marketing_campaign", "launch_campaign"]
     .includes(toolName)) return "specialist-alignment";
   if (["publish_storefront", "send_quote", "send_invoice"].includes(toolName)) return "outward-review";

--- a/apps/web/lib/work-management/action-registry.test.ts
+++ b/apps/web/lib/work-management/action-registry.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   WORK_CASE_ACTION_REGISTRY,
-  WORK_ROOM_LIFECYCLE_ACTION_REGISTRY,
+  WORKROOM_LIFECYCLE_ACTION_REGISTRY,
   getWorkCaseAction,
-  getWorkRoomLifecycleAction,
+  getWorkroomLifecycleAction,
 } from "./action-registry";
 import { WORK_CASE_SOURCE_REGISTRY } from "./source-registry";
 
@@ -74,7 +74,7 @@ describe("Work Case action registry", () => {
 
 describe("Work Room lifecycle action registry", () => {
   it("maps every room lifecycle operation to an existing receipt-aware action", () => {
-    expect(WORK_ROOM_LIFECYCLE_ACTION_REGISTRY.map((entry) => entry.operation)).toEqual([
+    expect(WORKROOM_LIFECYCLE_ACTION_REGISTRY.map((entry) => entry.operation)).toEqual([
       "open-cycle",
       "pause-cycle",
       "verify-cycle",
@@ -84,9 +84,9 @@ describe("Work Room lifecycle action registry", () => {
       "split",
       "archive",
     ]);
-    for (const entry of WORK_ROOM_LIFECYCLE_ACTION_REGISTRY) {
+    for (const entry of WORKROOM_LIFECYCLE_ACTION_REGISTRY) {
       expect(getWorkCaseAction(entry.canonicalAction)?.requiresReceipt).toBe(true);
-      expect(getWorkRoomLifecycleAction(entry.operation)).toEqual(entry);
+      expect(getWorkroomLifecycleAction(entry.operation)).toEqual(entry);
     }
   });
 });

--- a/apps/web/lib/work-management/action-registry.ts
+++ b/apps/web/lib/work-management/action-registry.ts
@@ -21,7 +21,7 @@ export interface WorkCaseActionDescriptor {
   sanctionedMutators: readonly string[];
 }
 
-export type WorkRoomLifecycleOperation =
+export type WorkroomLifecycleOperation =
   | "open-cycle"
   | "pause-cycle"
   | "verify-cycle"
@@ -31,8 +31,8 @@ export type WorkRoomLifecycleOperation =
   | "split"
   | "archive";
 
-export interface WorkRoomLifecycleActionDescriptor {
-  operation: WorkRoomLifecycleOperation;
+export interface WorkroomLifecycleActionDescriptor {
+  operation: WorkroomLifecycleOperation;
   displayLabel: string;
   canonicalAction: WorkCaseActionVerb;
 }
@@ -275,7 +275,7 @@ const WORK_CASE_ACTIONS_BY_VERB = new Map<WorkCaseActionVerb, WorkCaseActionDesc
   WORK_CASE_ACTION_REGISTRY.map((entry) => [entry.action, entry]),
 );
 
-export const WORK_ROOM_LIFECYCLE_ACTION_REGISTRY = [
+export const WORKROOM_LIFECYCLE_ACTION_REGISTRY = [
   { operation: "open-cycle", displayLabel: "Open cycle", canonicalAction: "open-cycle" },
   { operation: "pause-cycle", displayLabel: "Pause cycle", canonicalAction: "pause-cycle" },
   { operation: "verify-cycle", displayLabel: "Verify cycle", canonicalAction: "verify-cycle" },
@@ -284,12 +284,12 @@ export const WORK_ROOM_LIFECYCLE_ACTION_REGISTRY = [
   { operation: "renew", displayLabel: "Renew", canonicalAction: "renew" },
   { operation: "split", displayLabel: "Split", canonicalAction: "split" },
   { operation: "archive", displayLabel: "Archive", canonicalAction: "archive" },
-] as const satisfies readonly WorkRoomLifecycleActionDescriptor[];
+] as const satisfies readonly WorkroomLifecycleActionDescriptor[];
 
-const WORK_ROOM_LIFECYCLE_ACTIONS_BY_OPERATION = new Map<
-  WorkRoomLifecycleOperation,
-  WorkRoomLifecycleActionDescriptor
->(WORK_ROOM_LIFECYCLE_ACTION_REGISTRY.map((entry) => [entry.operation, entry]));
+const WORKROOM_LIFECYCLE_ACTIONS_BY_OPERATION = new Map<
+  WorkroomLifecycleOperation,
+  WorkroomLifecycleActionDescriptor
+>(WORKROOM_LIFECYCLE_ACTION_REGISTRY.map((entry) => [entry.operation, entry]));
 
 export function getWorkCaseAction(
   action: string | null | undefined,
@@ -299,10 +299,10 @@ export function getWorkCaseAction(
   return WORK_CASE_ACTIONS_BY_VERB.get(normalized) ?? null;
 }
 
-export function getWorkRoomLifecycleAction(
+export function getWorkroomLifecycleAction(
   operation: string | null | undefined,
-): WorkRoomLifecycleActionDescriptor | null {
-  const normalized = operation?.trim() as WorkRoomLifecycleOperation | undefined;
+): WorkroomLifecycleActionDescriptor | null {
+  const normalized = operation?.trim() as WorkroomLifecycleOperation | undefined;
   if (!normalized) return null;
-  return WORK_ROOM_LIFECYCLE_ACTIONS_BY_OPERATION.get(normalized) ?? null;
+  return WORKROOM_LIFECYCLE_ACTIONS_BY_OPERATION.get(normalized) ?? null;
 }

--- a/apps/web/lib/work-management/coworker-room-engagement.server.ts
+++ b/apps/web/lib/work-management/coworker-room-engagement.server.ts
@@ -12,14 +12,14 @@
 import { prisma } from "@dpf/db";
 
 import { ensureAgentPrincipalIdentity } from "@/lib/identity/principal-linking";
-import type { WorkRoomParticipantRole } from "./room-types";
+import type { WorkroomParticipantRole } from "./room-types";
 import { PRESENCE_ACTIVE_WINDOW_MS } from "./work-item-presence";
 import { encodeWorkCaseKey } from "./workspace-case-loader";
 import { readWorkspaceRoomPolicy } from "./workspace-room-access";
 
 export interface CoworkerRoomEngagementRoom {
   caseKey: string;
-  roles: WorkRoomParticipantRole[];
+  roles: WorkroomParticipantRole[];
   coordinator: boolean;
   activeNow: boolean;
 }
@@ -64,7 +64,7 @@ export async function getCoworkerRoomEngagement(input: {
   const rooms: CoworkerRoomEngagementRoom[] = items.map((item) => {
     const policy = readWorkspaceRoomPolicy(item.evidence);
     const mine = (policy.participants ?? []).find((participant) => participant.principalRef === principalRef);
-    const roles = (mine?.roles ?? []) as WorkRoomParticipantRole[];
+    const roles = (mine?.roles ?? []) as WorkroomParticipantRole[];
     return {
       caseKey: encodeWorkCaseKey({ sourceType: item.sourceType, sourceId: item.sourceId ?? item.itemId }),
       roles,

--- a/apps/web/lib/work-management/outcome-packet.test.ts
+++ b/apps/web/lib/work-management/outcome-packet.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { buildWorkRoomOutcomePacket, WorkRoomOutcomePacketError } from "./outcome-packet";
+import { buildWorkroomOutcomePacket, WorkroomOutcomePacketError } from "./outcome-packet";
 
 const receipt = { kind: "receipt" as const, id: "R-1", sourceType: "tool-execution" };
 const evidence = { kind: "runtime-verification" as const, id: "RV-1", status: "passed" };
 
 describe("Work Room Outcome Packets", () => {
   it("uses source policy for required categories while allowing optional categories to stay empty", () => {
-    const packet = buildWorkRoomOutcomePacket({
+    const packet = buildWorkroomOutcomePacket({
       sourceKey: "scheduled",
       outcomeState: "achieved",
       summary: "Weekly cash position reviewed and exceptions assigned.",
@@ -28,20 +28,20 @@ describe("Work Room Outcome Packets", () => {
   });
 
   it("rejects a standing packet that omits a source-required category", () => {
-    expect(() => buildWorkRoomOutcomePacket({
+    expect(() => buildWorkroomOutcomePacket({
       sourceKey: "scheduled",
       outcomeState: "partially-achieved",
       summary: "Review completed without verification.",
       facts: [{ category: "receipts", sourceRef: receipt, provenance: "canonical" }],
       accountablePrincipalRef: "prn-finance-owner",
       completedAt: "2026-08-01T10:00:00.000Z",
-    })).toThrowError(expect.objectContaining<Partial<WorkRoomOutcomePacketError>>({ reason: "missing_required_category" }));
+    })).toThrowError(expect.objectContaining<Partial<WorkroomOutcomePacketError>>({ reason: "missing_required_category" }));
   });
 
   it.each(["decisions", "artifacts", "evidence"] as const)(
     "does not let raw chat satisfy the %s field",
     (category) => {
-      expect(() => buildWorkRoomOutcomePacket({
+      expect(() => buildWorkroomOutcomePacket({
         sourceKey: "scheduled",
         outcomeState: "achieved",
         summary: "A chat message claimed the cycle was done.",
@@ -52,12 +52,12 @@ describe("Work Room Outcome Packets", () => {
         ],
         accountablePrincipalRef: "prn-finance-owner",
         completedAt: "2026-08-01T10:00:00.000Z",
-      })).toThrowError(expect.objectContaining<Partial<WorkRoomOutcomePacketError>>({ reason: "raw_chat_not_durable" }));
+      })).toThrowError(expect.objectContaining<Partial<WorkroomOutcomePacketError>>({ reason: "raw_chat_not_durable" }));
     },
   );
 
   it("requires every unresolved item to carry an explicit disposition", () => {
-    expect(() => buildWorkRoomOutcomePacket({
+    expect(() => buildWorkroomOutcomePacket({
       sourceKey: "scheduled",
       outcomeState: "partially-achieved",
       summary: "One exception remains.",
@@ -68,6 +68,6 @@ describe("Work Room Outcome Packets", () => {
       unresolvedWork: [{ summary: "Investigate variance", ownerRef: null, disposition: "later" as never }],
       accountablePrincipalRef: "prn-finance-owner",
       completedAt: "2026-08-01T10:00:00.000Z",
-    })).toThrowError(expect.objectContaining<Partial<WorkRoomOutcomePacketError>>({ reason: "invalid_unresolved_disposition" }));
+    })).toThrowError(expect.objectContaining<Partial<WorkroomOutcomePacketError>>({ reason: "invalid_unresolved_disposition" }));
   });
 });

--- a/apps/web/lib/work-management/outcome-packet.ts
+++ b/apps/web/lib/work-management/outcome-packet.ts
@@ -1,25 +1,25 @@
 import { dedupeRoomSourceRefs, roomText } from "./room-projection-utils";
 import { getWorkCaseSourceEntry } from "./source-registry";
 import type {
-  WorkRoomOutcomePacket,
-  WorkRoomOutcomePacketCategory,
+  WorkroomOutcomePacket,
+  WorkroomOutcomePacketCategory,
 } from "./room-types";
 import type { WorkCaseSourceRef } from "./case-types";
 
-export type WorkRoomOutcomeFactProvenance = "canonical" | "raw-chat";
+export type WorkroomOutcomeFactProvenance = "canonical" | "raw-chat";
 
-export interface WorkRoomOutcomeFact {
-  category: WorkRoomOutcomePacketCategory;
+export interface WorkroomOutcomeFact {
+  category: WorkroomOutcomePacketCategory;
   sourceRef: WorkCaseSourceRef;
-  provenance: WorkRoomOutcomeFactProvenance;
+  provenance: WorkroomOutcomeFactProvenance;
 }
 
-export interface BuildWorkRoomOutcomePacketInput {
+export interface BuildWorkroomOutcomePacketInput {
   sourceKey: string;
-  outcomeState: WorkRoomOutcomePacket["outcomeState"];
+  outcomeState: WorkroomOutcomePacket["outcomeState"];
   summary: string;
-  facts: readonly WorkRoomOutcomeFact[];
-  unresolvedWork?: WorkRoomOutcomePacket["unresolvedWork"];
+  facts: readonly WorkroomOutcomeFact[];
+  unresolvedWork?: WorkroomOutcomePacket["unresolvedWork"];
   accountablePrincipalRef: string;
   verifiedByRef?: string | null;
   completedAt: Date | string;
@@ -27,7 +27,7 @@ export interface BuildWorkRoomOutcomePacketInput {
   sourceRefs?: readonly WorkCaseSourceRef[];
 }
 
-export type WorkRoomOutcomePacketErrorReason =
+export type WorkroomOutcomePacketErrorReason =
   | "unknown_source"
   | "missing_summary"
   | "missing_accountable"
@@ -36,20 +36,20 @@ export type WorkRoomOutcomePacketErrorReason =
   | "missing_required_category"
   | "invalid_unresolved_disposition";
 
-export class WorkRoomOutcomePacketError extends Error {
+export class WorkroomOutcomePacketError extends Error {
   constructor(
-    readonly reason: WorkRoomOutcomePacketErrorReason,
+    readonly reason: WorkroomOutcomePacketErrorReason,
     message: string,
   ) {
     super(message);
-    this.name = "WorkRoomOutcomePacketError";
+    this.name = "WorkroomOutcomePacketError";
   }
 }
 
 function iso(value: Date | string): string {
   const date = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(date.getTime())) {
-    throw new WorkRoomOutcomePacketError("invalid_completed_at", "Outcome Packet completion time must be valid.");
+    throw new WorkroomOutcomePacketError("invalid_completed_at", "Outcome Packet completion time must be valid.");
   }
   return date.toISOString();
 }
@@ -59,8 +59,8 @@ function optionalIso(value: Date | string | null | undefined): string | null {
 }
 
 function refsFor(
-  facts: readonly WorkRoomOutcomeFact[],
-  category: WorkRoomOutcomePacketCategory,
+  facts: readonly WorkroomOutcomeFact[],
+  category: WorkroomOutcomePacketCategory,
 ): WorkCaseSourceRef[] {
   return dedupeRoomSourceRefs(
     facts.filter((fact) => fact.category === category).map((fact) => fact.sourceRef),
@@ -68,13 +68,13 @@ function refsFor(
 }
 
 function validateUnresolvedWork(
-  unresolvedWork: BuildWorkRoomOutcomePacketInput["unresolvedWork"],
-): WorkRoomOutcomePacket["unresolvedWork"] {
+  unresolvedWork: BuildWorkroomOutcomePacketInput["unresolvedWork"],
+): WorkroomOutcomePacket["unresolvedWork"] {
   const allowed = new Set(["carry-over", "new-case", "deferred", "accepted"]);
   return (unresolvedWork ?? []).map((item) => {
     const summary = roomText(item.summary);
     if (!summary || !allowed.has(item.disposition)) {
-      throw new WorkRoomOutcomePacketError(
+      throw new WorkroomOutcomePacketError(
         "invalid_unresolved_disposition",
         "Unresolved work needs a summary and a carry-over, new-case, deferred, or accepted disposition.",
       );
@@ -83,27 +83,27 @@ function validateUnresolvedWork(
   });
 }
 
-export function buildWorkRoomOutcomePacket(
-  input: BuildWorkRoomOutcomePacketInput,
-): WorkRoomOutcomePacket {
+export function buildWorkroomOutcomePacket(
+  input: BuildWorkroomOutcomePacketInput,
+): WorkroomOutcomePacket {
   const source = getWorkCaseSourceEntry(input.sourceKey);
   if (!source) {
-    throw new WorkRoomOutcomePacketError("unknown_source", `Work Room source '${input.sourceKey}' is not registered.`);
+    throw new WorkroomOutcomePacketError("unknown_source", `Work Room source '${input.sourceKey}' is not registered.`);
   }
   const summary = roomText(input.summary);
   if (!summary) {
-    throw new WorkRoomOutcomePacketError("missing_summary", "Outcome Packet summary is required.");
+    throw new WorkroomOutcomePacketError("missing_summary", "Outcome Packet summary is required.");
   }
   const accountablePrincipalRef = roomText(input.accountablePrincipalRef);
   if (!accountablePrincipalRef) {
-    throw new WorkRoomOutcomePacketError("missing_accountable", "Outcome Packet accountable principal is required.");
+    throw new WorkroomOutcomePacketError("missing_accountable", "Outcome Packet accountable principal is required.");
   }
 
   const invalidChat = input.facts.find(
     (fact) => fact.provenance === "raw-chat" && ["decisions", "artifacts", "evidence"].includes(fact.category),
   );
   if (invalidChat) {
-    throw new WorkRoomOutcomePacketError(
+    throw new WorkroomOutcomePacketError(
       "raw_chat_not_durable",
       `Raw chat cannot satisfy the '${invalidChat.category}' Outcome Packet field.`,
     );
@@ -118,7 +118,7 @@ export function buildWorkRoomOutcomePacket(
   };
   for (const category of source.roomProjection.outcomePacket.requiredCategories) {
     if (refs[category].length === 0) {
-      throw new WorkRoomOutcomePacketError(
+      throw new WorkroomOutcomePacketError(
         "missing_required_category",
         `${source.displayLabel} Outcome Packets require '${category}'.`,
       );
@@ -129,7 +129,7 @@ export function buildWorkRoomOutcomePacket(
     ...(input.sourceRefs ?? []),
     ...Object.values(refs).flat(),
   ]);
-  const packet: WorkRoomOutcomePacket = {
+  const packet: WorkroomOutcomePacket = {
     outcomeState: input.outcomeState,
     summary,
     decisionRefs: refs.decisions,

--- a/apps/web/lib/work-management/post-work-item-comment.test.ts
+++ b/apps/web/lib/work-management/post-work-item-comment.test.ts
@@ -43,7 +43,7 @@ describe("postWorkItemComment (BI-B416B12A)", () => {
         body: "@mark can you and @ops-coworker take this?",
         structuredPayload: {
           mentionedAgentIds: ["AGT-9"],
-          workRoom: {
+          workroom: {
             caseKey: "manual-task%3AWI-1",
             caseId: "manual-task:WI-1",
             workItemId: "WI-1",

--- a/apps/web/lib/work-management/post-work-item-comment.ts
+++ b/apps/web/lib/work-management/post-work-item-comment.ts
@@ -11,8 +11,8 @@
 import { buildMentionNotifications } from "./mention-notify";
 import type { MentionRoster } from "./mentions";
 import {
-  buildCanonicalWorkRoomMetadata,
-  type CanonicalWorkRoomRef,
+  buildCanonicalWorkroomMetadata,
+  type CanonicalWorkroomRef,
 } from "./room-channel-continuity";
 
 export interface PostCommentDb {
@@ -34,7 +34,7 @@ export async function postWorkItemComment(args: {
   db: PostCommentDb;
   workItemId: string;
   workItemTitle: string;
-  roomRef?: CanonicalWorkRoomRef;
+  roomRef?: CanonicalWorkroomRef;
   body: string;
   sender: { type: "user" | "agent"; id: string; label: string };
   roster: MentionRoster;
@@ -64,7 +64,7 @@ export async function postWorkItemComment(args: {
               ...(fanout.mentionedAgentIds.length > 0
                 ? { mentionedAgentIds: fanout.mentionedAgentIds }
                 : {}),
-              ...(args.roomRef ? buildCanonicalWorkRoomMetadata(args.roomRef) : {}),
+              ...(args.roomRef ? buildCanonicalWorkroomMetadata(args.roomRef) : {}),
             },
           }
         : {}),

--- a/apps/web/lib/work-management/receipt-envelope.ts
+++ b/apps/web/lib/work-management/receipt-envelope.ts
@@ -7,7 +7,7 @@ import type {
   WorkCaseRef,
   WorkCaseSourceRef,
 } from "./case-types";
-import type { WorkRoomShapeKey } from "./room-shapes";
+import type { WorkroomShapeKey } from "./room-shapes";
 
 export type ReceiptEnvelopeStatus = "valid" | "invalid" | "observed" | "failed";
 
@@ -26,7 +26,7 @@ export interface ReceiptEnvelope {
   outputDigest?: unknown;
   policyRefs: readonly string[];
   governance?: {
-    collaborationShape: WorkRoomShapeKey;
+    collaborationShape: WorkroomShapeKey;
     authorityLadderLevel: "none" | "discover" | "content" | "action";
     requiredPrincipalRefs: readonly string[];
     decisionInteractionId?: string;

--- a/apps/web/lib/work-management/room-activity.ts
+++ b/apps/web/lib/work-management/room-activity.ts
@@ -1,23 +1,23 @@
 import type { WorkCaseActorRef, WorkCaseSourceRef } from "./case-types";
 import type {
-  WorkRoomActivityKind,
-  WorkRoomActivityView,
+  WorkroomActivityKind,
+  WorkroomActivityView,
 } from "./room-types";
 
-export interface WorkRoomActivityInput {
+export interface WorkroomActivityInput {
   sourceEventId: string;
-  kind: WorkRoomActivityKind;
+  kind: WorkroomActivityKind;
   occurredAt: Date | string | null;
   actorRef: WorkCaseActorRef | null;
   summary: string;
   sourceRef: WorkCaseSourceRef;
-  emphasis?: WorkRoomActivityView["emphasis"];
-  channel?: WorkRoomActivityView["channel"];
+  emphasis?: WorkroomActivityView["emphasis"];
+  channel?: WorkroomActivityView["channel"];
 }
 
 function defaultEmphasis(
-  kind: WorkRoomActivityKind,
-): WorkRoomActivityView["emphasis"] {
+  kind: WorkroomActivityKind,
+): WorkroomActivityView["emphasis"] {
   if (kind === "message") return "quiet";
   if (
     kind === "decision-proposed"
@@ -38,10 +38,10 @@ function iso(value: Date | string | null): string | null {
   return value instanceof Date ? value.toISOString() : value;
 }
 
-export function normalizeWorkRoomActivities(
-  activities: readonly WorkRoomActivityInput[],
-): WorkRoomActivityView[] {
-  const keyed = new Map<string, WorkRoomActivityView>();
+export function normalizeWorkroomActivities(
+  activities: readonly WorkroomActivityInput[],
+): WorkroomActivityView[] {
+  const keyed = new Map<string, WorkroomActivityView>();
   for (const activity of activities) {
     const sourceEventId = activity.sourceEventId.trim();
     if (!sourceEventId) continue;

--- a/apps/web/lib/work-management/room-agent-access.server.ts
+++ b/apps/web/lib/work-management/room-agent-access.server.ts
@@ -9,11 +9,11 @@ import { prisma } from "@dpf/db";
 
 import { ensureAgentPrincipalIdentity } from "@/lib/identity/principal-linking";
 import { authorizeAgentRoomAccess } from "./room-agent-access";
-import type { WorkRoomAccessDecision, WorkRoomAccessLevel } from "./room-participation";
+import type { WorkroomAccessDecision, WorkroomAccessLevel } from "./room-participation";
 import { readWorkspaceRoomPolicy } from "./workspace-room-access";
 
 export interface AgentRoomAccessResult {
-  decision: WorkRoomAccessDecision;
+  decision: WorkroomAccessDecision;
   agentPrincipalId: string | null;
 }
 
@@ -26,7 +26,7 @@ const DEFAULT_AGENT_CLEARANCE = ["public", "internal"] as const;
  */
 export async function resolveAgentRoomAccess(input: {
   agentId: string;
-  requested: Exclude<WorkRoomAccessLevel, "none">;
+  requested: Exclude<WorkroomAccessLevel, "none">;
   workItem: { id: string; evidence: unknown; assignedToAgentId: string | null };
 }): Promise<AgentRoomAccessResult> {
   const principal = await ensureAgentPrincipalIdentity(input.agentId);

--- a/apps/web/lib/work-management/room-agent-access.ts
+++ b/apps/web/lib/work-management/room-agent-access.ts
@@ -3,7 +3,7 @@
  *
  * EP-WORKROOM-COMMS (BI-AD057F18). A room's membership may be all-people,
  * all-agent, or mixed; an agent joins/posts/reads only for THAT room's outcome,
- * scoped by exposure + rights. This reuses the human `authorizeWorkRoomAccess`
+ * scoped by exposure + rights. This reuses the human `authorizeWorkroomAccess`
  * decision (none < discover < content < action) — the ref space is the canonical
  * `Principal.principalId`, and presence never grants authority.
  *
@@ -13,13 +13,13 @@
  * Design of record: docs/superpowers/specs/2026-08-12-work-room-multi-agent-communication-substrate-design.md §1
  */
 import {
-  authorizeWorkRoomAccess,
-  type WorkRoomAccessDecision,
-  type WorkRoomAccessLevel,
+  authorizeWorkroomAccess,
+  type WorkroomAccessDecision,
+  type WorkroomAccessLevel,
 } from "./room-participation";
 
 export interface AuthorizeAgentRoomAccessInput {
-  requested: Exclude<WorkRoomAccessLevel, "none">;
+  requested: Exclude<WorkroomAccessLevel, "none">;
   agentPrincipalRef: string | null;
   agentSensitivityClearance: readonly string[];
   /** Principals allowed to READ the room (content): policy-admitted + everyone who can act. */
@@ -37,10 +37,10 @@ export interface AuthorizeAgentRoomAccessInput {
  */
 export function authorizeAgentRoomAccess(
   input: AuthorizeAgentRoomAccessInput,
-): WorkRoomAccessDecision {
+): WorkroomAccessDecision {
   const assignedPrincipalRefs =
     input.requested === "action" ? input.actionPrincipalRefs : input.admittedPrincipalRefs;
-  return authorizeWorkRoomAccess({
+  return authorizeWorkroomAccess({
     requested: input.requested,
     principalRef: input.agentPrincipalRef,
     assignedPrincipalRefs,
@@ -53,8 +53,8 @@ export function authorizeAgentRoomAccess(
 
 /** True when the decision grants at least the requested level (not degraded to discover/none). */
 export function grantsRequested(
-  decision: WorkRoomAccessDecision,
-  requested: Exclude<WorkRoomAccessLevel, "none">,
+  decision: WorkroomAccessDecision,
+  requested: Exclude<WorkroomAccessLevel, "none">,
 ): boolean {
   return decision.level === requested;
 }

--- a/apps/web/lib/work-management/room-boundary.ts
+++ b/apps/web/lib/work-management/room-boundary.ts
@@ -5,13 +5,13 @@ import {
   roomText,
 } from "./room-projection-utils";
 import type {
-  WorkRoomBoundaryGap,
-  WorkRoomBoundaryView,
-  WorkRoomContextView,
-  WorkRoomParticipantView,
+  WorkroomBoundaryGap,
+  WorkroomBoundaryView,
+  WorkroomContextView,
+  WorkroomParticipantView,
 } from "./room-types";
 
-export type WorkRoomBoundaryInput = Omit<WorkRoomBoundaryView, "gaps">;
+export type WorkroomBoundaryInput = Omit<WorkroomBoundaryView, "gaps">;
 
 const BOUNDARY_GAP_ORDER = [
   "purpose",
@@ -25,12 +25,12 @@ const BOUNDARY_GAP_ORDER = [
   "measures",
   "time-boundary",
   "closure-rule",
-] as const satisfies readonly WorkRoomBoundaryGap[];
+] as const satisfies readonly WorkroomBoundaryGap[];
 
 function timeBoundary(input: {
   detail: WorkCaseDetail;
-  boundary?: Partial<WorkRoomBoundaryInput>;
-}): WorkRoomBoundaryView["timeBoundary"] {
+  boundary?: Partial<WorkroomBoundaryInput>;
+}): WorkroomBoundaryView["timeBoundary"] {
   return {
     dueAt: roomText(
       input.boundary?.timeBoundary?.dueAt ?? input.detail.summary.dueAt,
@@ -42,14 +42,14 @@ function timeBoundary(input: {
   };
 }
 
-export function buildWorkRoomBoundary(input: {
+export function buildWorkroomBoundary(input: {
   detail: WorkCaseDetail;
-  boundary?: Partial<WorkRoomBoundaryInput>;
-  participants: readonly WorkRoomParticipantView[];
-  context: WorkRoomContextView;
+  boundary?: Partial<WorkroomBoundaryInput>;
+  participants: readonly WorkroomParticipantView[];
+  context: WorkroomContextView;
   contextProvided: boolean;
-}): WorkRoomBoundaryView {
-  const boundary: Omit<WorkRoomBoundaryView, "gaps"> = {
+}): WorkroomBoundaryView {
+  const boundary: Omit<WorkroomBoundaryView, "gaps"> = {
     purpose: roomText(input.boundary?.purpose),
     outcome: roomText(input.boundary?.outcome),
     scopeIncluded: roomStrings(input.boundary?.scopeIncluded),
@@ -67,7 +67,7 @@ export function buildWorkRoomBoundary(input: {
       input.boundary?.sourceRefs ?? input.detail.summary.sourceRefs,
     ),
   };
-  const missing = new Set<WorkRoomBoundaryGap>();
+  const missing = new Set<WorkroomBoundaryGap>();
   if (!boundary.purpose) missing.add("purpose");
   if (!boundary.outcome) missing.add("outcome");
   if (

--- a/apps/web/lib/work-management/room-channel-continuity.test.ts
+++ b/apps/web/lib/work-management/room-channel-continuity.test.ts
@@ -20,7 +20,7 @@ describe("Work Room channel continuity", () => {
     })).toEqual({
       summary: "Approval is needed before Friday.",
       deepLink: "https://dpf.example/workspace/cases/booking%3ABK-1",
-      metadata: { workRoom: room },
+      metadata: { workroom: room },
     });
   });
 

--- a/apps/web/lib/work-management/room-channel-continuity.ts
+++ b/apps/web/lib/work-management/room-channel-continuity.ts
@@ -1,15 +1,15 @@
-export type CanonicalWorkRoomRef = {
+export type CanonicalWorkroomRef = {
   caseKey: string;
   caseId: string;
   workItemId: string;
 };
 
-export function buildCanonicalWorkRoomMetadata(room: CanonicalWorkRoomRef) {
-  return { workRoom: room };
+export function buildCanonicalWorkroomMetadata(room: CanonicalWorkroomRef) {
+  return { workroom: room };
 }
 
 export function buildRoomChannelEnvelope(input: {
-  room: CanonicalWorkRoomRef;
+  room: CanonicalWorkroomRef;
   portalOrigin: string;
   summary: string;
 }) {
@@ -17,7 +17,7 @@ export function buildRoomChannelEnvelope(input: {
   return {
     summary: input.summary,
     deepLink: `${origin}/workspace/cases/${input.room.caseKey}`,
-    metadata: buildCanonicalWorkRoomMetadata(input.room),
+    metadata: buildCanonicalWorkroomMetadata(input.room),
   };
 }
 
@@ -26,7 +26,7 @@ type InboundRoomEventInput = {
   providerEventId: string;
   externalSubject: string;
   resolvedPrincipalRef: string | null;
-  room: CanonicalWorkRoomRef | null;
+  room: CanonicalWorkroomRef | null;
   body: string;
   requestedAction: string | null;
   sensitivity: string;
@@ -48,7 +48,7 @@ export type NormalizedInboundRoomEvent =
       status: "accepted";
       eventId: string;
       principalRef: string;
-      room: CanonicalWorkRoomRef;
+      room: CanonicalWorkroomRef;
       activity: { kind: "external-event"; summary: string };
       requestedAction: string | null;
       deliveryAcknowledged: false;

--- a/apps/web/lib/work-management/room-channel-ingress-prisma.server.ts
+++ b/apps/web/lib/work-management/room-channel-ingress-prisma.server.ts
@@ -1,18 +1,18 @@
 import { prisma } from "@dpf/db";
 
 import {
-  ingestWorkRoomChannelEvent,
+  ingestWorkroomChannelEvent,
   type RoomChannelIngressDb,
 } from "./room-channel-ingress";
 
 type PrismaRoomChannelIngressInput = Omit<
-  Parameters<typeof ingestWorkRoomChannelEvent>[0],
+  Parameters<typeof ingestWorkroomChannelEvent>[0],
   "db"
 >;
 
 const ingressDb = prisma as unknown as RoomChannelIngressDb;
 
 /** Provider-neutral production entry point for an adapter's verified inbound event. */
-export function ingestPrismaWorkRoomChannelEvent(input: PrismaRoomChannelIngressInput) {
-  return ingestWorkRoomChannelEvent({ ...input, db: ingressDb });
+export function ingestPrismaWorkroomChannelEvent(input: PrismaRoomChannelIngressInput) {
+  return ingestWorkroomChannelEvent({ ...input, db: ingressDb });
 }

--- a/apps/web/lib/work-management/room-channel-ingress.test.ts
+++ b/apps/web/lib/work-management/room-channel-ingress.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { ingestWorkRoomChannelEvent, type RoomChannelIngressDb } from "./room-channel-ingress";
+import { ingestWorkroomChannelEvent, type RoomChannelIngressDb } from "./room-channel-ingress";
 
 function database(overrides: Partial<RoomChannelIngressDb> = {}): RoomChannelIngressDb {
   return {
@@ -29,7 +29,7 @@ function database(overrides: Partial<RoomChannelIngressDb> = {}): RoomChannelIng
 describe("Work Room channel ingress", () => {
   it("resolves identity and room context before writing one canonical activity", async () => {
     const upsert = vi.fn(async () => undefined);
-    const result = await ingestWorkRoomChannelEvent({
+    const result = await ingestWorkroomChannelEvent({
       db: database({
         workItemMessage: { findUnique: async () => null, upsert },
       }),
@@ -55,7 +55,7 @@ describe("Work Room channel ingress", () => {
         channel: "teams",
         structuredPayload: expect.objectContaining({
           externalEventId: "microsoft-graph:evt-1",
-          workRoom: expect.objectContaining({ caseId: "booking:BK-1" }),
+          workroom: expect.objectContaining({ caseId: "booking:BK-1" }),
         }),
       }),
     }));
@@ -63,7 +63,7 @@ describe("Work Room channel ingress", () => {
 
   it("quarantines an unresolved external identity without loading room content", async () => {
     const loadSession = vi.fn(async () => null);
-    const result = await ingestWorkRoomChannelEvent({
+    const result = await ingestWorkroomChannelEvent({
       db: database({
         communicationChannelBinding: { findFirst: async () => null },
         communicationChannelSession: { findFirst: loadSession },
@@ -86,7 +86,7 @@ describe("Work Room channel ingress", () => {
 
   it("does not write a duplicate provider event", async () => {
     const upsert = vi.fn(async () => undefined);
-    const result = await ingestWorkRoomChannelEvent({
+    const result = await ingestWorkroomChannelEvent({
       db: database({
         workItemMessage: {
           findUnique: async () => ({ messageId: "microsoft-graph:evt-1" }),

--- a/apps/web/lib/work-management/room-channel-ingress.ts
+++ b/apps/web/lib/work-management/room-channel-ingress.ts
@@ -1,6 +1,6 @@
 import { encodeWorkCaseKey } from "./workspace-case-loader";
 import {
-  buildCanonicalWorkRoomMetadata,
+  buildCanonicalWorkroomMetadata,
   normalizeInboundRoomEvent,
   type NormalizedInboundRoomEvent,
 } from "./room-channel-continuity";
@@ -35,7 +35,7 @@ export type RoomChannelIngressDb = {
   };
 };
 
-export async function ingestWorkRoomChannelEvent(input: {
+export async function ingestWorkroomChannelEvent(input: {
   db: RoomChannelIngressDb;
   channelType: string;
   providerKey: string;
@@ -123,7 +123,7 @@ export async function ingestWorkRoomChannelEvent(input: {
       structuredPayload: {
         externalEventId: eventId,
         principalRef: normalized.principalRef,
-        ...buildCanonicalWorkRoomMetadata(normalized.room),
+        ...buildCanonicalWorkroomMetadata(normalized.room),
         requestedAction: normalized.requestedAction,
       },
       channel: input.channelType,

--- a/apps/web/lib/work-management/room-coordinator.test.ts
+++ b/apps/web/lib/work-management/room-coordinator.test.ts
@@ -3,15 +3,15 @@ import { describe, expect, it } from "vitest";
 import {
   deriveRoomCoordinator,
   selectRoomCoordinator,
-  WorkRoomParticipantError,
+  WorkroomParticipantError,
 } from "./room-coordinator";
-import type { WorkRoomParticipantRole, WorkRoomParticipantView } from "./room-types";
+import type { WorkroomParticipantRole, WorkroomParticipantView } from "./room-types";
 
 function participant(
   principalRef: string,
-  roles: WorkRoomParticipantRole[],
-  kind: WorkRoomParticipantView["kind"] = "person",
-): WorkRoomParticipantView {
+  roles: WorkroomParticipantRole[],
+  kind: WorkroomParticipantView["kind"] = "person",
+): WorkroomParticipantView {
   return {
     principalRef,
     displayName: principalRef,
@@ -39,11 +39,11 @@ describe("selectRoomCoordinator", () => {
 
   it("throws on more than one active coordinator", () => {
     const two = [participant("user:1", ["coordinator"]), participant("agent:9", ["coordinator"], "agent")];
-    expect(() => selectRoomCoordinator(two)).toThrow(WorkRoomParticipantError);
+    expect(() => selectRoomCoordinator(two)).toThrow(WorkroomParticipantError);
     try {
       selectRoomCoordinator(two);
     } catch (error) {
-      expect((error as WorkRoomParticipantError).reason).toBe("multiple_active_coordinators");
+      expect((error as WorkroomParticipantError).reason).toBe("multiple_active_coordinators");
     }
   });
 });

--- a/apps/web/lib/work-management/room-coordinator.ts
+++ b/apps/web/lib/work-management/room-coordinator.ts
@@ -11,22 +11,22 @@
  *
  * Design of record: docs/superpowers/specs/2026-08-12-work-room-multi-agent-communication-substrate-design.md §2
  */
-import type { WorkRoomParticipantView } from "./room-types";
+import type { WorkroomParticipantView } from "./room-types";
 
-export type WorkRoomParticipantErrorReason = "multiple_active_coordinators";
+export type WorkroomParticipantErrorReason = "multiple_active_coordinators";
 
-export class WorkRoomParticipantError extends Error {
-  constructor(readonly reason: WorkRoomParticipantErrorReason, message: string) {
+export class WorkroomParticipantError extends Error {
+  constructor(readonly reason: WorkroomParticipantErrorReason, message: string) {
     super(message);
-    this.name = "WorkRoomParticipantError";
+    this.name = "WorkroomParticipantError";
   }
 }
 
-function isCoordinator(participant: WorkRoomParticipantView): boolean {
+function isCoordinator(participant: WorkroomParticipantView): boolean {
   return participant.roles.includes("coordinator");
 }
 
-function isAccountable(participant: WorkRoomParticipantView): boolean {
+function isAccountable(participant: WorkroomParticipantView): boolean {
   return participant.roles.includes("accountable");
 }
 
@@ -36,11 +36,11 @@ function isAccountable(participant: WorkRoomParticipantView): boolean {
  * Coordinator; more than one is a defect, not a merge.
  */
 export function selectRoomCoordinator(
-  participants: readonly WorkRoomParticipantView[],
-): WorkRoomParticipantView | null {
+  participants: readonly WorkroomParticipantView[],
+): WorkroomParticipantView | null {
   const coordinators = participants.filter(isCoordinator);
   if (coordinators.length > 1) {
-    throw new WorkRoomParticipantError(
+    throw new WorkroomParticipantError(
       "multiple_active_coordinators",
       "A Work Room can have only one active Coordinator.",
     );
@@ -58,8 +58,8 @@ export function selectRoomCoordinator(
  * Pure: returns a new array; participant objects are copied only when changed.
  */
 export function deriveRoomCoordinator(
-  participants: readonly WorkRoomParticipantView[],
-): WorkRoomParticipantView[] {
+  participants: readonly WorkroomParticipantView[],
+): WorkroomParticipantView[] {
   // Validates single-coordinator and short-circuits when one is already named.
   if (selectRoomCoordinator(participants)) {
     return [...participants];

--- a/apps/web/lib/work-management/room-cycle-adapter.test.ts
+++ b/apps/web/lib/work-management/room-cycle-adapter.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { buildWorkRoomOutcomePacket } from "./outcome-packet";
+import { buildWorkroomOutcomePacket } from "./outcome-packet";
 import {
   projectWorkItemCycleCarriers,
-  projectStoredWorkRoomOutcomePackets,
-  WORK_ROOM_CYCLE_EVIDENCE_KIND,
-  WORK_ROOM_OUTCOME_MESSAGE_TYPE,
+  projectStoredWorkroomOutcomePackets,
+  WORKROOM_CYCLE_EVIDENCE_KIND,
+  WORKROOM_OUTCOME_MESSAGE_TYPE,
 } from "./room-cycle-adapter";
 
-const packet = buildWorkRoomOutcomePacket({
+const packet = buildWorkroomOutcomePacket({
   sourceKey: "scheduled",
   outcomeState: "achieved",
   summary: "Weekly cash review completed.",
@@ -33,8 +33,8 @@ function item(status = "in-progress") {
     dueAt: "2026-08-01T16:00:00.000Z",
     createdAt: "2026-07-27T09:00:00.000Z",
     evidence: {
-      workRoomCycle: {
-        kind: WORK_ROOM_CYCLE_EVIDENCE_KIND,
+      workroomCycle: {
+        kind: WORKROOM_CYCLE_EVIDENCE_KIND,
         version: 1,
         cycleKey: "2026-W31",
         trigger: "Weekly schedule fired.",
@@ -67,9 +67,9 @@ describe("Work Room cycle source adapter", () => {
       items: [item("completed")],
       messages: [{
         messageId: "MSG-OUTCOME-31",
-        messageType: WORK_ROOM_OUTCOME_MESSAGE_TYPE,
+        messageType: WORKROOM_OUTCOME_MESSAGE_TYPE,
         structuredPayload: {
-          kind: WORK_ROOM_OUTCOME_MESSAGE_TYPE,
+          kind: WORKROOM_OUTCOME_MESSAGE_TYPE,
           version: 1,
           cycleKey: "2026-W31",
           carrierId: "WI-CYCLE-31",
@@ -93,9 +93,9 @@ describe("Work Room cycle source adapter", () => {
     const earlier = { ...packet, completedAt: "2026-07-25T16:00:00.000Z" };
     const messages = [earlier, packet].map((storedPacket, index) => ({
       messageId: `MSG-${index}`,
-      messageType: WORK_ROOM_OUTCOME_MESSAGE_TYPE,
+      messageType: WORKROOM_OUTCOME_MESSAGE_TYPE,
       structuredPayload: {
-        kind: WORK_ROOM_OUTCOME_MESSAGE_TYPE,
+        kind: WORKROOM_OUTCOME_MESSAGE_TYPE,
         version: 1,
         cycleKey: `cycle-${index}`,
         carrierId: `WI-${index}`,
@@ -103,6 +103,6 @@ describe("Work Room cycle source adapter", () => {
       },
     }));
 
-    expect(projectStoredWorkRoomOutcomePackets(messages)).toEqual([packet, earlier]);
+    expect(projectStoredWorkroomOutcomePackets(messages)).toEqual([packet, earlier]);
   });
 });

--- a/apps/web/lib/work-management/room-cycle-adapter.ts
+++ b/apps/web/lib/work-management/room-cycle-adapter.ts
@@ -1,11 +1,11 @@
 import type { WorkCaseSourceRef } from "./case-types";
-import type { WorkRoomCycleCarrierCandidate } from "./room-cycle";
-import type { WorkRoomOutcomePacket } from "./room-types";
+import type { WorkroomCycleCarrierCandidate } from "./room-cycle";
+import type { WorkroomOutcomePacket } from "./room-types";
 
-export const WORK_ROOM_CYCLE_EVIDENCE_KIND = "work-room-cycle";
-export const WORK_ROOM_OUTCOME_MESSAGE_TYPE = "work-room-outcome-packet";
+export const WORKROOM_CYCLE_EVIDENCE_KIND = "work-room-cycle";
+export const WORKROOM_OUTCOME_MESSAGE_TYPE = "work-room-outcome-packet";
 
-export interface WorkRoomCycleWorkItemRecord {
+export interface WorkroomCycleWorkItemRecord {
   id: string;
   itemId: string;
   sourceType: string;
@@ -21,14 +21,14 @@ export interface WorkRoomCycleWorkItemRecord {
   completedAt?: Date | string | null;
 }
 
-export interface WorkRoomCycleMessageRecord {
+export interface WorkroomCycleMessageRecord {
   messageId: string;
   messageType: string;
   structuredPayload?: unknown;
 }
 
 interface StoredCycleBoundary {
-  kind: typeof WORK_ROOM_CYCLE_EVIDENCE_KIND;
+  kind: typeof WORKROOM_CYCLE_EVIDENCE_KIND;
   version: 1;
   cycleKey: string;
   trigger: string;
@@ -42,11 +42,11 @@ interface StoredCycleBoundary {
 }
 
 interface StoredOutcomePacket {
-  kind: typeof WORK_ROOM_OUTCOME_MESSAGE_TYPE;
+  kind: typeof WORKROOM_OUTCOME_MESSAGE_TYPE;
   version: 1;
   cycleKey: string;
   carrierId: string;
-  packet: WorkRoomOutcomePacket;
+  packet: WorkroomOutcomePacket;
 }
 
 function record(value: unknown): Record<string, unknown> | null {
@@ -69,11 +69,11 @@ function sourceRefs(value: unknown): WorkCaseSourceRef[] | null {
   return refs.length === value.length ? refs : null;
 }
 
-export function parseStoredWorkRoomCycle(value: unknown): StoredCycleBoundary | null {
+export function parseStoredWorkroomCycle(value: unknown): StoredCycleBoundary | null {
   const container = record(value);
-  const candidate = record(container?.workRoomCycle ?? value);
+  const candidate = record(container?.workroomCycle ?? value);
   if (
-    candidate?.kind !== WORK_ROOM_CYCLE_EVIDENCE_KIND
+    candidate?.kind !== WORKROOM_CYCLE_EVIDENCE_KIND
     || candidate.version !== 1
     || typeof candidate.cycleKey !== "string"
     || typeof candidate.trigger !== "string"
@@ -86,7 +86,7 @@ export function parseStoredWorkRoomCycle(value: unknown): StoredCycleBoundary | 
   const context = sourceRefs(candidate.contextRefs);
   if (!stops || !context) return null;
   return {
-    kind: WORK_ROOM_CYCLE_EVIDENCE_KIND,
+    kind: WORKROOM_CYCLE_EVIDENCE_KIND,
     version: 1,
     cycleKey: candidate.cycleKey,
     trigger: candidate.trigger,
@@ -100,7 +100,7 @@ export function parseStoredWorkRoomCycle(value: unknown): StoredCycleBoundary | 
   };
 }
 
-function looksLikeOutcomePacket(value: unknown): value is WorkRoomOutcomePacket {
+function looksLikeOutcomePacket(value: unknown): value is WorkroomOutcomePacket {
   const candidate = record(value);
   return Boolean(
     candidate
@@ -112,10 +112,10 @@ function looksLikeOutcomePacket(value: unknown): value is WorkRoomOutcomePacket 
   );
 }
 
-export function parseStoredWorkRoomOutcome(value: unknown): StoredOutcomePacket | null {
+export function parseStoredWorkroomOutcome(value: unknown): StoredOutcomePacket | null {
   const candidate = record(value);
   if (
-    candidate?.kind !== WORK_ROOM_OUTCOME_MESSAGE_TYPE
+    candidate?.kind !== WORKROOM_OUTCOME_MESSAGE_TYPE
     || candidate.version !== 1
     || typeof candidate.cycleKey !== "string"
     || typeof candidate.carrierId !== "string"
@@ -124,40 +124,40 @@ export function parseStoredWorkRoomOutcome(value: unknown): StoredOutcomePacket 
   return candidate as unknown as StoredOutcomePacket;
 }
 
-export function projectStoredWorkRoomOutcomePackets(
-  messages: readonly WorkRoomCycleMessageRecord[],
-): WorkRoomOutcomePacket[] {
+export function projectStoredWorkroomOutcomePackets(
+  messages: readonly WorkroomCycleMessageRecord[],
+): WorkroomOutcomePacket[] {
   return messages
     .flatMap((message) => {
-      if (message.messageType !== WORK_ROOM_OUTCOME_MESSAGE_TYPE) return [];
-      const stored = parseStoredWorkRoomOutcome(message.structuredPayload);
+      if (message.messageType !== WORKROOM_OUTCOME_MESSAGE_TYPE) return [];
+      const stored = parseStoredWorkroomOutcome(message.structuredPayload);
       return stored ? [stored.packet] : [];
     })
     .sort((left, right) => right.completedAt.localeCompare(left.completedAt));
 }
 
 function projectedStatus(
-  item: WorkRoomCycleWorkItemRecord,
+  item: WorkroomCycleWorkItemRecord,
   boundary: StoredCycleBoundary,
-): WorkRoomCycleCarrierCandidate["status"] {
+): WorkroomCycleCarrierCandidate["status"] {
   if (item.status === "completed") return boundary.carriedOver ? "carried-over" : "closed";
   if (item.status === "verifying") return "verifying";
   return "open";
 }
 
 export function projectWorkItemCycleCarriers(input: {
-  items: readonly WorkRoomCycleWorkItemRecord[];
-  messages: readonly WorkRoomCycleMessageRecord[];
-}): WorkRoomCycleCarrierCandidate[] {
-  const packets = new Map<string, WorkRoomOutcomePacket>();
+  items: readonly WorkroomCycleWorkItemRecord[];
+  messages: readonly WorkroomCycleMessageRecord[];
+}): WorkroomCycleCarrierCandidate[] {
+  const packets = new Map<string, WorkroomOutcomePacket>();
   for (const message of input.messages) {
-    if (message.messageType !== WORK_ROOM_OUTCOME_MESSAGE_TYPE) continue;
-    const stored = parseStoredWorkRoomOutcome(message.structuredPayload);
+    if (message.messageType !== WORKROOM_OUTCOME_MESSAGE_TYPE) continue;
+    const stored = parseStoredWorkroomOutcome(message.structuredPayload);
     if (stored) packets.set(`${stored.cycleKey}:${stored.carrierId}`, stored.packet);
   }
 
   return input.items.flatMap((item) => {
-    const boundary = parseStoredWorkRoomCycle(item.evidence);
+    const boundary = parseStoredWorkroomCycle(item.evidence);
     if (!boundary) return [];
     const packet = packets.get(`${boundary.cycleKey}:${item.itemId}`) ?? null;
     return [{

--- a/apps/web/lib/work-management/room-cycle-prisma.server.ts
+++ b/apps/web/lib/work-management/room-cycle-prisma.server.ts
@@ -1,12 +1,12 @@
 import { Prisma, prisma } from "@dpf/db";
 
 import type {
-  WorkRoomCycleParentRecord,
-  WorkRoomCycleStoreDb,
-  WorkRoomCycleStoreTx,
+  WorkroomCycleParentRecord,
+  WorkroomCycleStoreDb,
+  WorkroomCycleStoreTx,
 } from "./room-cycle-store";
 
-function txAdapter(tx: Prisma.TransactionClient): WorkRoomCycleStoreTx {
+function txAdapter(tx: Prisma.TransactionClient): WorkroomCycleStoreTx {
   return {
     getRoom: async (workItemId) => tx.workItem.findUnique({
       where: { id: workItemId },
@@ -25,7 +25,7 @@ function txAdapter(tx: Prisma.TransactionClient): WorkRoomCycleStoreTx {
         assignedToUserId: true,
         assignedToAgentId: true,
       },
-    }) as Promise<WorkRoomCycleParentRecord | null>,
+    }) as Promise<WorkroomCycleParentRecord | null>,
     listCycles: (workItemId) => tx.workItem.findMany({
       where: { parentItemId: workItemId },
       select: {
@@ -82,7 +82,7 @@ function txAdapter(tx: Prisma.TransactionClient): WorkRoomCycleStoreTx {
   };
 }
 
-export const prismaWorkRoomCycleDb: WorkRoomCycleStoreDb = {
+export const prismaWorkroomCycleDb: WorkroomCycleStoreDb = {
   withinRoomLock: (workItemId, callback) => prisma.$transaction(async (tx) => {
     await tx.$queryRaw<Array<{ id: string }>>(
       Prisma.sql`SELECT "id" FROM "WorkItem" WHERE "id" = ${workItemId} FOR UPDATE`,

--- a/apps/web/lib/work-management/room-cycle-store.test.ts
+++ b/apps/web/lib/work-management/room-cycle-store.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import { buildWorkRoomOutcomePacket } from "./outcome-packet";
+import { buildWorkroomOutcomePacket } from "./outcome-packet";
 import {
-  completeWorkRoomCycle,
-  applyWorkRoomCarryOver,
-  openWorkRoomCycle,
-  type WorkRoomCycleParentRecord,
-  type WorkRoomCycleStoreDb,
-  type WorkRoomCycleStoreMessage,
+  completeWorkroomCycle,
+  applyWorkroomCarryOver,
+  openWorkroomCycle,
+  type WorkroomCycleParentRecord,
+  type WorkroomCycleStoreDb,
+  type WorkroomCycleStoreMessage,
 } from "./room-cycle-store";
-import type { WorkRoomCycleWorkItemRecord } from "./room-cycle-adapter";
+import type { WorkroomCycleWorkItemRecord } from "./room-cycle-adapter";
 
-const room: WorkRoomCycleParentRecord = {
+const room: WorkroomCycleParentRecord = {
   id: "room-row",
   itemId: "ROOM-WEEKLY-CASH",
   sourceType: "scheduled",
@@ -28,10 +28,10 @@ const room: WorkRoomCycleParentRecord = {
 };
 
 function harness() {
-  const cycles: WorkRoomCycleWorkItemRecord[] = [];
-  const messages: WorkRoomCycleStoreMessage[] = [];
+  const cycles: WorkroomCycleWorkItemRecord[] = [];
+  const messages: WorkroomCycleStoreMessage[] = [];
   let next = 1;
-  const db: WorkRoomCycleStoreDb = {
+  const db: WorkroomCycleStoreDb = {
     withinRoomLock: async (_roomWorkItemId, callback) => callback({
       getRoom: async () => room,
       listCycles: async () => cycles,
@@ -88,7 +88,7 @@ function policy() {
   };
 }
 
-function openInput(db: WorkRoomCycleStoreDb, cycleKey = "2026-W31") {
+function openInput(db: WorkroomCycleStoreDb, cycleKey = "2026-W31") {
   return {
     db,
     roomWorkItemId: room.id,
@@ -110,7 +110,7 @@ function openInput(db: WorkRoomCycleStoreDb, cycleKey = "2026-W31") {
 describe("Work Room cycle store", () => {
   it("opens one bounded child WorkItem and emits a governed lifecycle receipt", async () => {
     const state = harness();
-    const result = await openWorkRoomCycle(openInput(state.db));
+    const result = await openWorkroomCycle(openInput(state.db));
 
     expect(result.idempotent).toBe(false);
     expect(state.cycles).toHaveLength(1);
@@ -127,17 +127,17 @@ describe("Work Room cycle store", () => {
 
   it("makes retries idempotent and rejects a second active logical cycle", async () => {
     const state = harness();
-    await openWorkRoomCycle(openInput(state.db));
-    expect((await openWorkRoomCycle(openInput(state.db))).idempotent).toBe(true);
-    await expect(openWorkRoomCycle(openInput(state.db, "2026-W32")))
+    await openWorkroomCycle(openInput(state.db));
+    expect((await openWorkroomCycle(openInput(state.db))).idempotent).toBe(true);
+    await expect(openWorkroomCycle(openInput(state.db, "2026-W32")))
       .rejects.toMatchObject({ reason: "active_cycle_exists" });
     expect(state.cycles).toHaveLength(1);
   });
 
   it("seals completion in an append-only Outcome Packet and reuses it on retry", async () => {
     const state = harness();
-    const opened = await openWorkRoomCycle(openInput(state.db));
-    const packet = buildWorkRoomOutcomePacket({
+    const opened = await openWorkroomCycle(openInput(state.db));
+    const packet = buildWorkroomOutcomePacket({
       sourceKey: "scheduled",
       outcomeState: "achieved",
       summary: "Weekly cash review completed.",
@@ -159,19 +159,19 @@ describe("Work Room cycle store", () => {
       now: new Date("2026-08-01T16:00:00.000Z"),
     };
 
-    expect((await completeWorkRoomCycle(input)).idempotent).toBe(false);
+    expect((await completeWorkroomCycle(input)).idempotent).toBe(false);
     expect(state.cycles[0]?.status).toBe("completed");
     expect(state.messages.at(-1)).toMatchObject({
       messageType: "work-room-outcome-packet",
       structuredPayload: { packet },
     });
-    expect((await completeWorkRoomCycle(input)).idempotent).toBe(true);
+    expect((await completeWorkroomCycle(input)).idempotent).toBe(true);
     expect(state.messages).toHaveLength(2);
   });
 
   it("creates carry-over work once and attaches it to the target cycle", async () => {
     const state = harness();
-    await openWorkRoomCycle(openInput(state.db, "2026-W32"));
+    await openWorkroomCycle(openInput(state.db, "2026-W32"));
     const commands = [{
       kind: "attach-to-cycle" as const,
       summary: "Recheck late payment",
@@ -180,13 +180,13 @@ describe("Work Room cycle store", () => {
       idempotencyKey: "carry:late-payment",
     }];
 
-    const first = await applyWorkRoomCarryOver({
+    const first = await applyWorkroomCarryOver({
       db: state.db,
       roomWorkItemId: room.id,
       commands,
       actor: { type: "user", id: "user-finance" },
     });
-    const second = await applyWorkRoomCarryOver({
+    const second = await applyWorkroomCarryOver({
       db: state.db,
       roomWorkItemId: room.id,
       commands,

--- a/apps/web/lib/work-management/room-cycle-store.ts
+++ b/apps/web/lib/work-management/room-cycle-store.ts
@@ -1,19 +1,19 @@
 import type { WorkCasePolicyInput } from "./policy-envelope";
 import {
-  buildWorkRoomCycle,
-  evaluateWorkRoomCyclePolicy,
-  type WorkRoomCycleCarrierCandidate,
+  buildWorkroomCycle,
+  evaluateWorkroomCyclePolicy,
+  type WorkroomCycleCarrierCandidate,
 } from "./room-cycle";
 import {
-  parseStoredWorkRoomCycle,
-  parseStoredWorkRoomOutcome,
-  WORK_ROOM_CYCLE_EVIDENCE_KIND,
-  WORK_ROOM_OUTCOME_MESSAGE_TYPE,
-  type WorkRoomCycleWorkItemRecord,
+  parseStoredWorkroomCycle,
+  parseStoredWorkroomOutcome,
+  WORKROOM_CYCLE_EVIDENCE_KIND,
+  WORKROOM_OUTCOME_MESSAGE_TYPE,
+  type WorkroomCycleWorkItemRecord,
 } from "./room-cycle-adapter";
-import type { WorkRoomOutcomePacket } from "./room-types";
+import type { WorkroomOutcomePacket } from "./room-types";
 
-export interface WorkRoomCycleParentRecord {
+export interface WorkroomCycleParentRecord {
   id: string;
   itemId: string;
   sourceType: string;
@@ -29,28 +29,28 @@ export interface WorkRoomCycleParentRecord {
   assignedToAgentId: string | null;
 }
 
-export interface WorkRoomCycleStoreMessage {
+export interface WorkroomCycleStoreMessage {
   messageId: string;
   messageType: string;
   structuredPayload: unknown;
 }
 
-export interface WorkRoomCycleStoreTx {
-  getRoom(workItemId: string): Promise<WorkRoomCycleParentRecord | null>;
-  listCycles(workItemId: string): Promise<WorkRoomCycleWorkItemRecord[]>;
-  listMessages(workItemId: string): Promise<WorkRoomCycleStoreMessage[]>;
-  findWorkItemBySource(sourceType: string, sourceId: string): Promise<WorkRoomCycleWorkItemRecord | null>;
-  createWorkItem(data: Record<string, unknown>): Promise<WorkRoomCycleWorkItemRecord>;
+export interface WorkroomCycleStoreTx {
+  getRoom(workItemId: string): Promise<WorkroomCycleParentRecord | null>;
+  listCycles(workItemId: string): Promise<WorkroomCycleWorkItemRecord[]>;
+  listMessages(workItemId: string): Promise<WorkroomCycleStoreMessage[]>;
+  findWorkItemBySource(sourceType: string, sourceId: string): Promise<WorkroomCycleWorkItemRecord | null>;
+  createWorkItem(data: Record<string, unknown>): Promise<WorkroomCycleWorkItemRecord>;
   completeCycle(itemId: string, completedAt: Date): Promise<void>;
   appendMessage(data: Record<string, unknown>): Promise<{ messageId: string }>;
 }
 
-export interface WorkRoomCycleStoreDb {
-  withinRoomLock<T>(workItemId: string, callback: (tx: WorkRoomCycleStoreTx) => Promise<T>): Promise<T>;
+export interface WorkroomCycleStoreDb {
+  withinRoomLock<T>(workItemId: string, callback: (tx: WorkroomCycleStoreTx) => Promise<T>): Promise<T>;
 }
 
-export interface OpenWorkRoomCycleInput {
-  db: WorkRoomCycleStoreDb;
+export interface OpenWorkroomCycleInput {
+  db: WorkroomCycleStoreDb;
   roomWorkItemId: string;
   cycleKey: string;
   trigger: string;
@@ -59,32 +59,32 @@ export interface OpenWorkRoomCycleInput {
   expectedReviewAt: Date | string;
   stopConditions: readonly string[];
   measureSummary: string;
-  contextRefs: WorkRoomCycleCarrierCandidate["contextRefs"];
+  contextRefs: WorkroomCycleCarrierCandidate["contextRefs"];
   actor: { type: "user" | "agent"; id: string };
   idempotencyKey: string;
   policy: Omit<WorkCasePolicyInput, "action">;
   now?: Date;
 }
 
-export class WorkRoomCycleStoreError extends Error {
+export class WorkroomCycleStoreError extends Error {
   constructor(
     readonly reason: "room_not_found" | "finite_room" | "active_cycle_exists" | "policy_denied" | "cycle_not_found",
     message: string,
   ) {
     super(message);
-    this.name = "WorkRoomCycleStoreError";
+    this.name = "WorkroomCycleStoreError";
   }
 }
 
-function actorData(actor: OpenWorkRoomCycleInput["actor"]): Record<string, string> {
+function actorData(actor: OpenWorkroomCycleInput["actor"]): Record<string, string> {
   return actor.type === "user"
     ? { senderType: "user", senderUserId: actor.id }
     : { senderType: "agent", senderAgentId: actor.id };
 }
 
-function storedBoundary(input: OpenWorkRoomCycleInput) {
+function storedBoundary(input: OpenWorkroomCycleInput) {
   return {
-    kind: WORK_ROOM_CYCLE_EVIDENCE_KIND,
+    kind: WORKROOM_CYCLE_EVIDENCE_KIND,
     version: 1,
     cycleKey: input.cycleKey,
     trigger: input.trigger,
@@ -100,10 +100,10 @@ function storedBoundary(input: OpenWorkRoomCycleInput) {
 }
 
 function cycleCandidate(
-  item: WorkRoomCycleWorkItemRecord,
-  packet: WorkRoomOutcomePacket | null = null,
-): WorkRoomCycleCarrierCandidate | null {
-  const boundary = parseStoredWorkRoomCycle(item.evidence);
+  item: WorkroomCycleWorkItemRecord,
+  packet: WorkroomOutcomePacket | null = null,
+): WorkroomCycleCarrierCandidate | null {
+  const boundary = parseStoredWorkroomCycle(item.evidence);
   if (!boundary) return null;
   return {
     cycleKey: boundary.cycleKey,
@@ -140,27 +140,27 @@ function lifecycleReceipt(input: {
   };
 }
 
-export async function openWorkRoomCycle(input: OpenWorkRoomCycleInput): Promise<{
-  cycle: WorkRoomCycleWorkItemRecord;
+export async function openWorkroomCycle(input: OpenWorkroomCycleInput): Promise<{
+  cycle: WorkroomCycleWorkItemRecord;
   messageId: string | null;
   idempotent: boolean;
 }> {
   return input.db.withinRoomLock(input.roomWorkItemId, async (tx) => {
     const room = await tx.getRoom(input.roomWorkItemId);
-    if (!room) throw new WorkRoomCycleStoreError("room_not_found", "Work Room was not found.");
-    const policy = evaluateWorkRoomCyclePolicy({ operation: "open-cycle", cycle: null, policy: input.policy });
-    if (!policy.ok) throw new WorkRoomCycleStoreError("policy_denied", policy.message);
+    if (!room) throw new WorkroomCycleStoreError("room_not_found", "Work Room was not found.");
+    const policy = evaluateWorkroomCyclePolicy({ operation: "open-cycle", cycle: null, policy: input.policy });
+    if (!policy.ok) throw new WorkroomCycleStoreError("policy_denied", policy.message);
 
     const cycles = await tx.listCycles(room.id);
-    const existing = cycles.find((item) => parseStoredWorkRoomCycle(item.evidence)?.cycleKey === input.cycleKey);
+    const existing = cycles.find((item) => parseStoredWorkroomCycle(item.evidence)?.cycleKey === input.cycleKey);
     if (existing) return { cycle: existing, messageId: null, idempotent: true };
-    const active = cycles.find((item) => !["completed", "cancelled"].includes(item.status) && parseStoredWorkRoomCycle(item.evidence));
+    const active = cycles.find((item) => !["completed", "cancelled"].includes(item.status) && parseStoredWorkroomCycle(item.evidence));
     if (active) {
-      throw new WorkRoomCycleStoreError("active_cycle_exists", `Cycle '${parseStoredWorkRoomCycle(active.evidence)?.cycleKey}' is already active.`);
+      throw new WorkroomCycleStoreError("active_cycle_exists", `Cycle '${parseStoredWorkroomCycle(active.evidence)?.cycleKey}' is already active.`);
     }
 
     const boundary = storedBoundary(input);
-    buildWorkRoomCycle({
+    buildWorkroomCycle({
       cycleKey: boundary.cycleKey,
       carrierKind: "work-item",
       carrierId: "pending",
@@ -190,7 +190,7 @@ export async function openWorkRoomCycle(input: OpenWorkRoomCycleInput): Promise<
       assignedToUserId: room.assignedToUserId,
       assignedToAgentId: room.assignedToAgentId,
       dueAt: new Date(boundary.expectedReviewAt),
-      evidence: { workRoomCycle: boundary },
+      evidence: { workroomCycle: boundary },
       parentItemId: room.id,
     });
     const receipt = lifecycleReceipt({
@@ -213,15 +213,15 @@ export async function openWorkRoomCycle(input: OpenWorkRoomCycleInput): Promise<
   });
 }
 
-export async function applyWorkRoomCarryOver(input: {
-  db: WorkRoomCycleStoreDb;
+export async function applyWorkroomCarryOver(input: {
+  db: WorkroomCycleStoreDb;
   roomWorkItemId: string;
-  commands: readonly import("./room-cycle").WorkRoomCarryOverCommand[];
-  actor: OpenWorkRoomCycleInput["actor"];
+  commands: readonly import("./room-cycle").WorkroomCarryOverCommand[];
+  actor: OpenWorkroomCycleInput["actor"];
 }): Promise<{ createdItemIds: string[]; reusedItemIds: string[] }> {
   return input.db.withinRoomLock(input.roomWorkItemId, async (tx) => {
     const room = await tx.getRoom(input.roomWorkItemId);
-    if (!room) throw new WorkRoomCycleStoreError("room_not_found", "Work Room was not found.");
+    if (!room) throw new WorkroomCycleStoreError("room_not_found", "Work Room was not found.");
     const cycles = await tx.listCycles(room.id);
     const createdItemIds: string[] = [];
     const reusedItemIds: string[] = [];
@@ -233,10 +233,10 @@ export async function applyWorkRoomCarryOver(input: {
         continue;
       }
       const target = command.kind === "attach-to-cycle"
-        ? cycles.find((cycle) => parseStoredWorkRoomCycle(cycle.evidence)?.cycleKey === command.targetCycleKey)
+        ? cycles.find((cycle) => parseStoredWorkroomCycle(cycle.evidence)?.cycleKey === command.targetCycleKey)
         : null;
       if (command.kind === "attach-to-cycle" && !target) {
-        throw new WorkRoomCycleStoreError("cycle_not_found", `Target cycle '${command.targetCycleKey}' was not found.`);
+        throw new WorkroomCycleStoreError("cycle_not_found", `Target cycle '${command.targetCycleKey}' was not found.`);
       }
       const item = await tx.createWorkItem({
         sourceType: "work-room-carry-over",
@@ -252,7 +252,7 @@ export async function applyWorkRoomCarryOver(input: {
         assignedToUserId: null,
         assignedToAgentId: null,
         evidence: {
-          workRoomCarryOver: {
+          workroomCarryOver: {
             version: 1,
             roomItemId: room.itemId,
             ownerRef: command.ownerRef,
@@ -284,43 +284,43 @@ export async function applyWorkRoomCarryOver(input: {
   });
 }
 
-export async function completeWorkRoomCycle(input: {
-  db: WorkRoomCycleStoreDb;
+export async function completeWorkroomCycle(input: {
+  db: WorkroomCycleStoreDb;
   roomWorkItemId: string;
   carrierId: string;
-  packet: WorkRoomOutcomePacket;
-  actor: OpenWorkRoomCycleInput["actor"];
+  packet: WorkroomOutcomePacket;
+  actor: OpenWorkroomCycleInput["actor"];
   idempotencyKey: string;
   policy: Omit<WorkCasePolicyInput, "action">;
   now?: Date;
 }): Promise<{ messageId: string | null; idempotent: boolean }> {
   return input.db.withinRoomLock(input.roomWorkItemId, async (tx) => {
     const room = await tx.getRoom(input.roomWorkItemId);
-    if (!room) throw new WorkRoomCycleStoreError("room_not_found", "Work Room was not found.");
+    if (!room) throw new WorkroomCycleStoreError("room_not_found", "Work Room was not found.");
     const cycles = await tx.listCycles(room.id);
     const cycle = cycles.find((item) => item.itemId === input.carrierId);
-    if (!cycle) throw new WorkRoomCycleStoreError("cycle_not_found", "Work Room cycle was not found.");
-    const boundary = parseStoredWorkRoomCycle(cycle.evidence);
-    if (!boundary) throw new WorkRoomCycleStoreError("cycle_not_found", "Work Item is not a Work Room cycle carrier.");
+    if (!cycle) throw new WorkroomCycleStoreError("cycle_not_found", "Work Room cycle was not found.");
+    const boundary = parseStoredWorkroomCycle(cycle.evidence);
+    if (!boundary) throw new WorkroomCycleStoreError("cycle_not_found", "Work Item is not a Work Room cycle carrier.");
     const messages = await tx.listMessages(room.id);
     const existing = messages.find((message) => {
-      const stored = parseStoredWorkRoomOutcome(message.structuredPayload);
+      const stored = parseStoredWorkroomOutcome(message.structuredPayload);
       return stored?.cycleKey === boundary.cycleKey && stored.carrierId === cycle.itemId;
     });
     if (existing) return { messageId: existing.messageId, idempotent: true };
 
-    const view = buildWorkRoomCycle(cycleCandidate(cycle)!);
-    const policy = evaluateWorkRoomCyclePolicy({ operation: "complete-cycle", cycle: view, policy: input.policy });
-    if (!policy.ok) throw new WorkRoomCycleStoreError("policy_denied", policy.message);
+    const view = buildWorkroomCycle(cycleCandidate(cycle)!);
+    const policy = evaluateWorkroomCyclePolicy({ operation: "complete-cycle", cycle: view, policy: input.policy });
+    if (!policy.ok) throw new WorkroomCycleStoreError("policy_denied", policy.message);
     const completedAt = input.now ?? new Date(input.packet.completedAt);
     await tx.completeCycle(cycle.id, completedAt);
     const message = await tx.appendMessage({
       workItemId: room.id,
       ...actorData(input.actor),
-      messageType: WORK_ROOM_OUTCOME_MESSAGE_TYPE,
+      messageType: WORKROOM_OUTCOME_MESSAGE_TYPE,
       body: input.packet.summary,
       structuredPayload: {
-        kind: WORK_ROOM_OUTCOME_MESSAGE_TYPE,
+        kind: WORKROOM_OUTCOME_MESSAGE_TYPE,
         version: 1,
         cycleKey: boundary.cycleKey,
         carrierId: cycle.itemId,

--- a/apps/web/lib/work-management/room-cycle.test.ts
+++ b/apps/web/lib/work-management/room-cycle.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import type { WorkCaseSourceRef } from "./case-types";
-import { buildWorkRoomOutcomePacket } from "./outcome-packet";
+import { buildWorkroomOutcomePacket } from "./outcome-packet";
 import {
-  buildWorkRoomCycle,
-  evaluateWorkRoomCyclePolicy,
-  planWorkRoomCarryOver,
-  selectCompletedWorkRoomCycles,
-  selectCurrentWorkRoomCycle,
-  WorkRoomCycleError,
-  type WorkRoomCycleCarrierCandidate,
+  buildWorkroomCycle,
+  evaluateWorkroomCyclePolicy,
+  planWorkroomCarryOver,
+  selectCompletedWorkroomCycles,
+  selectCurrentWorkroomCycle,
+  WorkroomCycleError,
+  type WorkroomCycleCarrierCandidate,
 } from "./room-cycle";
 
 const roomRef: WorkCaseSourceRef = { kind: "source", id: "WEEKLY-CASH", sourceType: "scheduled" };
@@ -17,7 +17,7 @@ const contextRef: WorkCaseSourceRef = { kind: "evidence", id: "cash-position:202
 const receiptRef: WorkCaseSourceRef = { kind: "receipt", id: "R-1" };
 const verificationRef: WorkCaseSourceRef = { kind: "runtime-verification", id: "RV-1", status: "passed" };
 
-function candidate(overrides: Partial<WorkRoomCycleCarrierCandidate> = {}): WorkRoomCycleCarrierCandidate {
+function candidate(overrides: Partial<WorkroomCycleCarrierCandidate> = {}): WorkroomCycleCarrierCandidate {
   return {
     cycleKey: "2026-W31",
     carrierKind: "work-item",
@@ -54,11 +54,11 @@ function policy() {
 
 describe("standing Work Room cycles", () => {
   it("allows a finite room to complete without a recurring cycle", () => {
-    expect(selectCurrentWorkRoomCycle("booking", [])).toBeNull();
+    expect(selectCurrentWorkroomCycle("booking", [])).toBeNull();
   });
 
   it("uses source-owned precedence when multiple carriers describe one logical cycle", () => {
-    const cycle = selectCurrentWorkRoomCycle("scheduled", [
+    const cycle = selectCurrentWorkroomCycle("scheduled", [
       candidate({ carrierKind: "task-run", carrierId: "TR-31" }),
       candidate({ carrierKind: "work-capsule", carrierId: "WC-31" }),
       candidate({ carrierKind: "work-item", carrierId: "WI-31" }),
@@ -68,22 +68,22 @@ describe("standing Work Room cycles", () => {
   });
 
   it("rejects two distinct active cycles in one standing room", () => {
-    expect(() => selectCurrentWorkRoomCycle("scheduled", [
+    expect(() => selectCurrentWorkroomCycle("scheduled", [
       candidate(),
       candidate({ cycleKey: "2026-W32", carrierId: "WI-CYCLE-32" }),
-    ])).toThrowError(expect.objectContaining<Partial<WorkRoomCycleError>>({ reason: "multiple_active_cycles" }));
+    ])).toThrowError(expect.objectContaining<Partial<WorkroomCycleError>>({ reason: "multiple_active_cycles" }));
   });
 
   it("requires a bounded charter and scoped context", () => {
-    expect(() => selectCurrentWorkRoomCycle("scheduled", [candidate({ contextRefs: [], measureSummary: null })]))
-      .toThrowError(expect.objectContaining<Partial<WorkRoomCycleError>>({ reason: "missing_cycle_boundary" }));
+    expect(() => selectCurrentWorkroomCycle("scheduled", [candidate({ contextRefs: [], measureSummary: null })]))
+      .toThrowError(expect.objectContaining<Partial<WorkroomCycleError>>({ reason: "missing_cycle_boundary" }));
   });
 
   it("requires a sealed Outcome Packet on a closed cycle", () => {
-    expect(() => buildWorkRoomCycle(candidate({ status: "closed" })))
-      .toThrowError(expect.objectContaining<Partial<WorkRoomCycleError>>({ reason: "missing_cycle_boundary" }));
+    expect(() => buildWorkroomCycle(candidate({ status: "closed" })))
+      .toThrowError(expect.objectContaining<Partial<WorkroomCycleError>>({ reason: "missing_cycle_boundary" }));
 
-    const packet = buildWorkRoomOutcomePacket({
+    const packet = buildWorkroomOutcomePacket({
       sourceKey: "scheduled",
       outcomeState: "achieved",
       summary: "Review completed.",
@@ -94,14 +94,14 @@ describe("standing Work Room cycles", () => {
       accountablePrincipalRef: "prn-finance-owner",
       completedAt: "2026-08-01T16:00:00.000Z",
     });
-    expect(buildWorkRoomCycle(candidate({ status: "closed", outcomePacket: packet }))).toMatchObject({
+    expect(buildWorkroomCycle(candidate({ status: "closed", outcomePacket: packet }))).toMatchObject({
       status: "closed",
       outcomePacket: packet,
     });
   });
 
   it("projects one deterministic completed cycle per logical cycle", () => {
-    const packet = buildWorkRoomOutcomePacket({
+    const packet = buildWorkroomOutcomePacket({
       sourceKey: "scheduled",
       outcomeState: "achieved",
       summary: "Review completed.",
@@ -112,7 +112,7 @@ describe("standing Work Room cycles", () => {
       accountablePrincipalRef: "prn-finance-owner",
       completedAt: "2026-08-01T16:00:00.000Z",
     });
-    const completed = selectCompletedWorkRoomCycles("scheduled", [
+    const completed = selectCompletedWorkroomCycles("scheduled", [
       candidate({ status: "closed", outcomePacket: packet, carrierKind: "task-run", carrierId: "TR-31" }),
       candidate({ status: "closed", outcomePacket: packet, carrierKind: "work-item", carrierId: "WI-31" }),
     ]);
@@ -122,31 +122,31 @@ describe("standing Work Room cycles", () => {
   });
 
   it("denies consequential writes to a sealed cycle but permits renewal", () => {
-    const sealed = { ...selectCurrentWorkRoomCycle("scheduled", [candidate()])!, status: "closed" as const };
-    expect(evaluateWorkRoomCyclePolicy({ operation: "split", cycle: sealed, policy: policy() })).toMatchObject({
+    const sealed = { ...selectCurrentWorkroomCycle("scheduled", [candidate()])!, status: "closed" as const };
+    expect(evaluateWorkroomCyclePolicy({ operation: "split", cycle: sealed, policy: policy() })).toMatchObject({
       ok: false,
       reason: "closed_cycle_sealed",
     });
-    expect(evaluateWorkRoomCyclePolicy({ operation: "renew", cycle: sealed, policy: policy() })).toMatchObject({
+    expect(evaluateWorkroomCyclePolicy({ operation: "renew", cycle: sealed, policy: policy() })).toMatchObject({
       ok: true,
       requiredReceiptKind: "governed-action",
     });
   });
 
   it("maps renew, split, carry-over, and archive through receipt-emitting governed actions", () => {
-    const active = selectCurrentWorkRoomCycle("scheduled", [candidate()]);
+    const active = selectCurrentWorkroomCycle("scheduled", [candidate()]);
     for (const operation of ["split", "carry-over"] as const) {
-      expect(evaluateWorkRoomCyclePolicy({ operation, cycle: active, policy: policy() })).toMatchObject({
+      expect(evaluateWorkroomCyclePolicy({ operation, cycle: active, policy: policy() })).toMatchObject({
         ok: true,
         enforcementMode: "governed-action",
         requiredReceiptKind: "governed-action",
       });
     }
-    expect(evaluateWorkRoomCyclePolicy({ operation: "archive", cycle: null, policy: policy() })).toMatchObject({ ok: true });
+    expect(evaluateWorkroomCyclePolicy({ operation: "archive", cycle: null, policy: policy() })).toMatchObject({ ok: true });
   });
 
   it("plans carry-over attachment and new-case creation idempotently", () => {
-    const packet = buildWorkRoomOutcomePacket({
+    const packet = buildWorkroomOutcomePacket({
       sourceKey: "scheduled",
       outcomeState: "partially-achieved",
       summary: "Weekly review completed with follow-up work.",
@@ -169,8 +169,8 @@ describe("standing Work Room cycles", () => {
       unresolvedWork: packet.unresolvedWork,
     };
 
-    const first = planWorkRoomCarryOver(input);
-    const second = planWorkRoomCarryOver(input);
+    const first = planWorkroomCarryOver(input);
+    const second = planWorkroomCarryOver(input);
     expect(first).toHaveLength(2);
     expect(first.map((command) => command.kind)).toEqual(["attach-to-cycle", "create-case"]);
     expect(second).toEqual(first);

--- a/apps/web/lib/work-management/room-cycle.ts
+++ b/apps/web/lib/work-management/room-cycle.ts
@@ -1,7 +1,7 @@
 import type { WorkCaseSourceRef } from "./case-types";
 import {
-  getWorkRoomLifecycleAction,
-  type WorkRoomLifecycleOperation,
+  getWorkroomLifecycleAction,
+  type WorkroomLifecycleOperation,
 } from "./action-registry";
 import {
   evaluateWorkCasePolicy,
@@ -10,11 +10,11 @@ import {
 } from "./policy-envelope";
 import { dedupeRoomSourceRefs, roomText } from "./room-projection-utils";
 import { getWorkCaseSourceEntry } from "./source-registry";
-import type { WorkRoomCycleView, WorkRoomOutcomePacket } from "./room-types";
+import type { WorkroomCycleView, WorkroomOutcomePacket } from "./room-types";
 
-export interface WorkRoomCycleCarrierCandidate {
+export interface WorkroomCycleCarrierCandidate {
   cycleKey: string;
-  carrierKind: WorkRoomCycleView["carrierKind"];
+  carrierKind: WorkroomCycleView["carrierKind"];
   carrierId: string;
   trigger: string | null;
   objective: string | null;
@@ -24,22 +24,22 @@ export interface WorkRoomCycleCarrierCandidate {
   stopConditions: readonly string[];
   measureSummary: string | null;
   contextRefs: readonly WorkCaseSourceRef[];
-  status: WorkRoomCycleView["status"];
-  outcomePacket?: WorkRoomOutcomePacket | null;
+  status: WorkroomCycleView["status"];
+  outcomePacket?: WorkroomOutcomePacket | null;
   sourceRefs: readonly WorkCaseSourceRef[];
 }
 
-export type WorkRoomCycleErrorReason =
+export type WorkroomCycleErrorReason =
   | "unknown_source"
   | "finite_room_has_cycle"
   | "multiple_active_cycles"
   | "missing_cycle_boundary"
   | "unsupported_cycle_carrier";
 
-export class WorkRoomCycleError extends Error {
-  constructor(readonly reason: WorkRoomCycleErrorReason, message: string) {
+export class WorkroomCycleError extends Error {
+  constructor(readonly reason: WorkroomCycleErrorReason, message: string) {
     super(message);
-    this.name = "WorkRoomCycleError";
+    this.name = "WorkroomCycleError";
   }
 }
 
@@ -49,7 +49,7 @@ function iso(value: Date | string | null): string | null {
   return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
-export function buildWorkRoomCycle(candidate: WorkRoomCycleCarrierCandidate): WorkRoomCycleView {
+export function buildWorkroomCycle(candidate: WorkroomCycleCarrierCandidate): WorkroomCycleView {
   const trigger = roomText(candidate.trigger);
   const objective = roomText(candidate.objective);
   const accountablePrincipalRef = roomText(candidate.accountablePrincipalRef);
@@ -68,13 +68,13 @@ export function buildWorkRoomCycle(candidate: WorkRoomCycleCarrierCandidate): Wo
     || !measureSummary
     || contextRefs.length === 0
   ) {
-    throw new WorkRoomCycleError(
+    throw new WorkroomCycleError(
       "missing_cycle_boundary",
       `Cycle '${candidate.cycleKey}' requires trigger, objective, accountable principal, opened/review times, stop condition, measure, and scoped context.`,
     );
   }
   if ((candidate.status === "closed" || candidate.status === "carried-over") && !candidate.outcomePacket) {
-    throw new WorkRoomCycleError(
+    throw new WorkroomCycleError(
       "missing_cycle_boundary",
       `Closed cycle '${candidate.cycleKey}' requires a sealed Outcome Packet.`,
     );
@@ -96,24 +96,24 @@ export function buildWorkRoomCycle(candidate: WorkRoomCycleCarrierCandidate): Wo
   };
 }
 
-export function selectCurrentWorkRoomCycle(
+export function selectCurrentWorkroomCycle(
   sourceKey: string,
-  candidates: readonly WorkRoomCycleCarrierCandidate[],
-): WorkRoomCycleView | null {
+  candidates: readonly WorkroomCycleCarrierCandidate[],
+): WorkroomCycleView | null {
   const source = getWorkCaseSourceEntry(sourceKey);
   if (!source) {
-    throw new WorkRoomCycleError("unknown_source", `Work Room source '${sourceKey}' is not registered.`);
+    throw new WorkroomCycleError("unknown_source", `Work Room source '${sourceKey}' is not registered.`);
   }
   const active = candidates.filter((candidate) => candidate.status === "open" || candidate.status === "verifying");
   if (source.roomProjection.mode === "finite") {
     if (active.length > 0) {
-      throw new WorkRoomCycleError("finite_room_has_cycle", `${source.displayLabel} is finite and cannot project a recurring cycle.`);
+      throw new WorkroomCycleError("finite_room_has_cycle", `${source.displayLabel} is finite and cannot project a recurring cycle.`);
     }
     return null;
   }
   const logicalCycles = new Set(active.map((candidate) => candidate.cycleKey));
   if (logicalCycles.size > 1) {
-    throw new WorkRoomCycleError("multiple_active_cycles", "A standing Work Room can have only one active logical cycle.");
+    throw new WorkroomCycleError("multiple_active_cycles", "A standing Work Room can have only one active logical cycle.");
   }
   if (active.length === 0) return null;
 
@@ -123,25 +123,25 @@ export function selectCurrentWorkRoomCycle(
     return rank || left.carrierId.localeCompare(right.carrierId);
   })[0];
   if (!selected || !precedence.includes(selected.carrierKind)) {
-    throw new WorkRoomCycleError("unsupported_cycle_carrier", "No supported carrier can project the active cycle.");
+    throw new WorkroomCycleError("unsupported_cycle_carrier", "No supported carrier can project the active cycle.");
   }
-  return buildWorkRoomCycle(selected);
+  return buildWorkroomCycle(selected);
 }
 
-export function selectCompletedWorkRoomCycles(
+export function selectCompletedWorkroomCycles(
   sourceKey: string,
-  candidates: readonly WorkRoomCycleCarrierCandidate[],
-): WorkRoomCycleView[] {
+  candidates: readonly WorkroomCycleCarrierCandidate[],
+): WorkroomCycleView[] {
   const source = getWorkCaseSourceEntry(sourceKey);
   if (!source) {
-    throw new WorkRoomCycleError("unknown_source", `Work Room source '${sourceKey}' is not registered.`);
+    throw new WorkroomCycleError("unknown_source", `Work Room source '${sourceKey}' is not registered.`);
   }
 
   const precedence = source.roomProjection.cycleCarrierPrecedence;
   const completed = candidates.filter(
     (candidate) => candidate.status === "closed" || candidate.status === "carried-over",
   );
-  const byLogicalCycle = new Map<string, WorkRoomCycleCarrierCandidate>();
+  const byLogicalCycle = new Map<string, WorkroomCycleCarrierCandidate>();
   for (const candidate of completed) {
     if (!precedence.includes(candidate.carrierKind)) continue;
     const existing = byLogicalCycle.get(candidate.cycleKey);
@@ -151,7 +151,7 @@ export function selectCompletedWorkRoomCycles(
   }
 
   return [...byLogicalCycle.values()]
-    .map(buildWorkRoomCycle)
+    .map(buildWorkroomCycle)
     .sort((left, right) => {
       const completedOrder = (right.outcomePacket?.completedAt ?? "")
         .localeCompare(left.outcomePacket?.completedAt ?? "");
@@ -159,16 +159,16 @@ export function selectCompletedWorkRoomCycles(
     });
 }
 
-export type WorkRoomCyclePolicyDecision =
+export type WorkroomCyclePolicyDecision =
   | WorkCasePolicyDecision
   | { ok: false; reason: "unknown_lifecycle_operation" | "missing_current_cycle" | "closed_cycle_sealed"; message: string };
 
-export function evaluateWorkRoomCyclePolicy(input: {
-  operation: WorkRoomLifecycleOperation | string;
-  cycle: WorkRoomCycleView | null;
+export function evaluateWorkroomCyclePolicy(input: {
+  operation: WorkroomLifecycleOperation | string;
+  cycle: WorkroomCycleView | null;
   policy: Omit<WorkCasePolicyInput, "action">;
-}): WorkRoomCyclePolicyDecision {
-  const lifecycle = getWorkRoomLifecycleAction(input.operation);
+}): WorkroomCyclePolicyDecision {
+  const lifecycle = getWorkroomLifecycleAction(input.operation);
   if (!lifecycle) {
     return { ok: false, reason: "unknown_lifecycle_operation", message: `Unknown Work Room lifecycle operation '${input.operation}'.` };
   }
@@ -182,7 +182,7 @@ export function evaluateWorkRoomCyclePolicy(input: {
   return evaluateWorkCasePolicy({ ...input.policy, action: lifecycle.canonicalAction });
 }
 
-export interface WorkRoomCarryOverCommand {
+export interface WorkroomCarryOverCommand {
   kind: "attach-to-cycle" | "create-case";
   summary: string;
   ownerRef: string | null;
@@ -199,16 +199,16 @@ function stableHash(value: string): string {
   return (hash >>> 0).toString(16).padStart(8, "0");
 }
 
-export function planWorkRoomCarryOver(input: {
+export function planWorkroomCarryOver(input: {
   roomKey: string;
   fromCycleKey: string;
   toCycleKey?: string | null;
-  unresolvedWork: WorkRoomOutcomePacket["unresolvedWork"];
-}): WorkRoomCarryOverCommand[] {
+  unresolvedWork: WorkroomOutcomePacket["unresolvedWork"];
+}): WorkroomCarryOverCommand[] {
   const commands = input.unresolvedWork.flatMap((item) => {
     if (item.disposition !== "carry-over" && item.disposition !== "new-case") return [];
     if (item.disposition === "carry-over" && !roomText(input.toCycleKey)) {
-      throw new WorkRoomCycleError("missing_cycle_boundary", "Carry-over requires a target cycle.");
+      throw new WorkroomCycleError("missing_cycle_boundary", "Carry-over requires a target cycle.");
     }
     const fingerprint = [item.summary.trim(), item.ownerRef ?? "", item.disposition].join("|");
     return [{

--- a/apps/web/lib/work-management/room-participation-prisma.server.ts
+++ b/apps/web/lib/work-management/room-participation-prisma.server.ts
@@ -4,9 +4,9 @@ import { projectParticipants } from "@/lib/tak/conversation-participants";
 
 import { filterActivePresence, type PresenceRow } from "./work-item-presence";
 import {
-  projectWorkRoomParticipants,
-  type WorkRoomConversationParticipant,
-  type WorkRoomParticipantAssignment,
+  projectWorkroomParticipants,
+  type WorkroomConversationParticipant,
+  type WorkroomParticipantAssignment,
 } from "./room-participation";
 import type { WorkspaceRoomParticipantLoader } from "./workspace-case-loader";
 
@@ -35,7 +35,7 @@ function toWorkState(state: string): "working" | "waiting" | "idle" | "unknown" 
   return "unknown";
 }
 
-export const loadPrismaWorkRoomParticipants: WorkspaceRoomParticipantLoader = async (input) => {
+export const loadPrismaWorkroomParticipants: WorkspaceRoomParticipantLoader = async (input) => {
   const lineage = input.assignedThreadId
     ? await projectParticipants(input.assignedThreadId, { ownerAgentId: input.assignedToAgentId })
     : [];
@@ -107,7 +107,7 @@ export const loadPrismaWorkRoomParticipants: WorkspaceRoomParticipantLoader = as
     })),
     input.now.getTime(),
   );
-  const assignments: WorkRoomParticipantAssignment[] = [];
+  const assignments: WorkroomParticipantAssignment[] = [];
 
   const policyPrincipalByRef = new Map(
     policyPrincipals.map((principal) => [principal.principalId, principal]),
@@ -166,7 +166,7 @@ export const loadPrismaWorkRoomParticipants: WorkspaceRoomParticipantLoader = as
     });
   }
 
-  const conversationParticipants: WorkRoomConversationParticipant[] = lineage.flatMap((participant) => {
+  const conversationParticipants: WorkroomConversationParticipant[] = lineage.flatMap((participant) => {
     if (!participant.principalResolved) return [];
     const principal = principalByAlias.get(`agent:${participant.agentId}`);
     if (!principal) return [];
@@ -190,5 +190,5 @@ export const loadPrismaWorkRoomParticipants: WorkspaceRoomParticipantLoader = as
     }];
   });
 
-  return projectWorkRoomParticipants({ assignments, conversationParticipants, presence });
+  return projectWorkroomParticipants({ assignments, conversationParticipants, presence });
 };

--- a/apps/web/lib/work-management/room-participation.test.ts
+++ b/apps/web/lib/work-management/room-participation.test.ts
@@ -1,23 +1,23 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  authorizeWorkRoomAccess,
-  projectWorkRoomDiscovery,
-  projectWorkRoomParticipants,
+  authorizeWorkroomAccess,
+  projectWorkroomDiscovery,
+  projectWorkroomParticipants,
 } from "./room-participation";
 import {
-  bindWorkRoomShape,
-  getWorkRoomShape,
-  WORK_ROOM_SHAPE_KEYS,
+  bindWorkroomShape,
+  getWorkroomShape,
+  WORKROOM_SHAPE_KEYS,
 } from "./room-shapes";
 
 describe("Work Room participation", () => {
   it("registers the five consequential collaboration shapes", () => {
-    expect(WORK_ROOM_SHAPE_KEYS).toEqual([
+    expect(WORKROOM_SHAPE_KEYS).toEqual([
       "specialist-alignment", "approval-sign-off", "outward-review",
       "change-consequential", "escalation",
     ]);
-    expect(getWorkRoomShape("specialist-alignment")).toMatchObject({
+    expect(getWorkroomShape("specialist-alignment")).toMatchObject({
       authorityLadderLevel: "action",
       inclusionOrder: ["coordinator", "specialist", "approver"],
     });
@@ -26,7 +26,7 @@ describe("Work Room participation", () => {
   it.each(["person", "agent"] as const)(
     "requires the same specialist-alignment roles for a %s initiator",
     (kind) => {
-      const binding = bindWorkRoomShape({
+      const binding = bindWorkroomShape({
         shape: "specialist-alignment",
         initiator: { principalRef: "PRN-INIT", kind },
         participants: {
@@ -43,7 +43,7 @@ describe("Work Room participation", () => {
   );
 
   it("fails closed when a shape-required participant is absent", () => {
-    expect(bindWorkRoomShape({
+    expect(bindWorkroomShape({
       shape: "outward-review",
       initiator: { principalRef: "PRN-INIT", kind: "person" },
       participants: { coordinator: "PRN-INIT", specialist: "PRN-BRAND" },
@@ -52,7 +52,7 @@ describe("Work Room participation", () => {
   });
 
   it("keeps an unauthorized room non-discoverable", () => {
-    expect(authorizeWorkRoomAccess({
+    expect(authorizeWorkroomAccess({
       requested: "content",
       principalRef: "PRN-OUTSIDER",
       assignedPrincipalRefs: ["PRN-OWNER"],
@@ -64,7 +64,7 @@ describe("Work Room participation", () => {
   });
 
   it("limits discover-only participants to explicitly safe metadata", () => {
-    const decision = authorizeWorkRoomAccess({
+    const decision = authorizeWorkroomAccess({
       requested: "content",
       principalRef: "PRN-OBSERVER",
       assignedPrincipalRefs: ["PRN-OWNER"],
@@ -74,7 +74,7 @@ describe("Work Room participation", () => {
       isSuperuser: false,
     });
     expect(decision).toEqual({ level: "discover", reason: "discover-only" });
-    expect(projectWorkRoomDiscovery({
+    expect(projectWorkroomDiscovery({
       decision,
       allowedFields: ["title", "mode"],
       metadata: {
@@ -91,7 +91,7 @@ describe("Work Room participation", () => {
   });
 
   it("never lets presence expand authority", () => {
-    expect(authorizeWorkRoomAccess({
+    expect(authorizeWorkroomAccess({
       requested: "action",
       principalRef: "PRN-PRESENT",
       assignedPrincipalRefs: [],
@@ -104,7 +104,7 @@ describe("Work Room participation", () => {
   });
 
   it("projects assigned people and lineage-derived AI coworkers with accountability", () => {
-    expect(projectWorkRoomParticipants({
+    expect(projectWorkroomParticipants({
       assignments: [{
         principalRef: "PRN-HUMAN",
         displayName: "Mara Chen",

--- a/apps/web/lib/work-management/room-participation.ts
+++ b/apps/web/lib/work-management/room-participation.ts
@@ -1,12 +1,12 @@
 import type { ActiveViewer } from "./work-item-presence";
 import { deriveRoomCoordinator } from "./room-coordinator";
 import type {
-  WorkRoomParticipantRole,
-  WorkRoomParticipantView,
+  WorkroomParticipantRole,
+  WorkroomParticipantView,
 } from "./room-types";
 
-export const WORK_ROOM_ACCESS_LEVELS = ["none", "discover", "content", "action"] as const;
-export type WorkRoomAccessLevel = (typeof WORK_ROOM_ACCESS_LEVELS)[number];
+export const WORKROOM_ACCESS_LEVELS = ["none", "discover", "content", "action"] as const;
+export type WorkroomAccessLevel = (typeof WORKROOM_ACCESS_LEVELS)[number];
 
 const SENSITIVITY_RANK: Record<string, number> = {
   public: 0,
@@ -16,16 +16,16 @@ const SENSITIVITY_RANK: Record<string, number> = {
   critical: 3,
 };
 
-export type WorkRoomAccessDecision = {
-  level: WorkRoomAccessLevel;
+export type WorkroomAccessDecision = {
+  level: WorkroomAccessLevel;
   reason: "authorized" | "discover-only" | "not-admitted" | "insufficient-clearance";
 };
 
-export type WorkRoomDiscoveryField = "title" | "outcome" | "mode";
+export type WorkroomDiscoveryField = "title" | "outcome" | "mode";
 
-export function projectWorkRoomDiscovery(input: {
-  decision: WorkRoomAccessDecision;
-  allowedFields: readonly WorkRoomDiscoveryField[];
+export function projectWorkroomDiscovery(input: {
+  decision: WorkroomAccessDecision;
+  allowedFields: readonly WorkroomDiscoveryField[];
   metadata: { title: string; outcome: string | null; mode: "finite" | "standing" };
 }) {
   if (input.decision.level === "none") return null;
@@ -38,8 +38,8 @@ export function projectWorkRoomDiscovery(input: {
   };
 }
 
-export function authorizeWorkRoomAccess(input: {
-  requested: Exclude<WorkRoomAccessLevel, "none">;
+export function authorizeWorkroomAccess(input: {
+  requested: Exclude<WorkroomAccessLevel, "none">;
   principalRef: string | null;
   assignedPrincipalRefs: readonly string[];
   discoverablePrincipalRefs?: readonly string[];
@@ -47,7 +47,7 @@ export function authorizeWorkRoomAccess(input: {
   sensitivityCeiling: string | null;
   sensitivityClearance: readonly string[];
   isSuperuser: boolean;
-}): WorkRoomAccessDecision {
+}): WorkroomAccessDecision {
   if (input.isSuperuser) return { level: input.requested, reason: "authorized" };
   if (!input.principalRef) return { level: "none", reason: "not-admitted" };
 
@@ -75,11 +75,11 @@ export function authorizeWorkRoomAccess(input: {
   return { level: input.requested, reason: "authorized" };
 }
 
-export type WorkRoomParticipantAssignment = {
+export type WorkroomParticipantAssignment = {
   principalRef: string;
   displayName: string;
-  kind: WorkRoomParticipantView["kind"];
-  roles: WorkRoomParticipantRole[];
+  kind: WorkroomParticipantView["kind"];
+  roles: WorkroomParticipantRole[];
   currentWorkSummary: string | null;
   enteredReason: string | null;
   sponsorPrincipalRef: string | null;
@@ -87,20 +87,20 @@ export type WorkRoomParticipantAssignment = {
   authoritySummary: string;
 };
 
-export type WorkRoomConversationParticipant = Omit<
-  WorkRoomParticipantView,
+export type WorkroomConversationParticipant = Omit<
+  WorkroomParticipantView,
   "kind" | "presence" | "sourceRefs"
 > & {
-  sourceRef: WorkRoomParticipantView["sourceRefs"][number];
+  sourceRef: WorkroomParticipantView["sourceRefs"][number];
 };
 
-export function projectWorkRoomParticipants(input: {
-  assignments: readonly WorkRoomParticipantAssignment[];
-  conversationParticipants: readonly WorkRoomConversationParticipant[];
+export function projectWorkroomParticipants(input: {
+  assignments: readonly WorkroomParticipantAssignment[];
+  conversationParticipants: readonly WorkroomConversationParticipant[];
   presence: readonly ActiveViewer[];
-}): WorkRoomParticipantView[] {
+}): WorkroomParticipantView[] {
   const active = new Set(input.presence.map((viewer) => viewer.principalId));
-  const projected = new Map<string, WorkRoomParticipantView>();
+  const projected = new Map<string, WorkroomParticipantView>();
 
   for (const assignment of input.assignments) {
     const existing = projected.get(assignment.principalRef);

--- a/apps/web/lib/work-management/room-policy.test.ts
+++ b/apps/web/lib/work-management/room-policy.test.ts
@@ -32,11 +32,11 @@ describe("appendRoomPolicyParticipant", () => {
   });
 
   it("appends (latest-wins) without clobbering prior evidence", () => {
-    const prior = [{ workRoomCycle: { boundary: 1 } }, { workRoomPolicy: { admittedPrincipalRefs: ["PRN-a"], actionPrincipalRefs: ["PRN-a"], discoverablePrincipalRefs: [], sensitivityCeiling: "internal", participants: [] } }];
+    const prior = [{ workroomCycle: { boundary: 1 } }, { workroomPolicy: { admittedPrincipalRefs: ["PRN-a"], actionPrincipalRefs: ["PRN-a"], discoverablePrincipalRefs: [], sensitivityCeiling: "internal", participants: [] } }];
     const out = appendRoomPolicyParticipant(prior, { principalRef: "PRN-b", roles: ["contributor"], canAct: true });
     // prior entries preserved
     expect(out.length).toBe(prior.length + 1);
-    expect(out[0]).toEqual({ workRoomCycle: { boundary: 1 } });
+    expect(out[0]).toEqual({ workroomCycle: { boundary: 1 } });
     // latest policy now admits both a (carried) and b (new)
     const policy = latestPolicy(out);
     expect(policy.admittedPrincipalRefs).toEqual(expect.arrayContaining(["PRN-a", "PRN-b"]));

--- a/apps/web/lib/work-management/room-policy.ts
+++ b/apps/web/lib/work-management/room-policy.ts
@@ -1,7 +1,7 @@
 /**
  * Work Room policy writer (EP-WORKROOM-COMMS, BI-8CD6E35F).
  *
- * The substrate READS an outcome-scoped `{ workRoomPolicy: {...} }` object off
+ * The substrate READS an outcome-scoped `{ workroomPolicy: {...} }` object off
  * WorkItem.evidence (workspace-room-access.readWorkspaceRoomPolicy, latest-wins)
  * but nothing WRITES it. This is the pure writer: given the current evidence and
  * an invitee, it returns a new evidence array with an appended policy snapshot
@@ -11,13 +11,13 @@
  * Pure module: no DB. Refs are canonical Principal.principalId (PRN).
  * Design of record: docs/superpowers/specs/2026-08-12-work-room-multi-agent-communication-substrate-design.md §1-§2
  */
-import type { WorkRoomParticipantRole } from "./room-types";
+import type { WorkroomParticipantRole } from "./room-types";
 import { readWorkspaceRoomPolicy } from "./workspace-room-access";
 
 export interface RoomParticipantInvite {
   /** Canonical Principal.principalId (PRN) of the invitee. */
   principalRef: string;
-  roles: WorkRoomParticipantRole[];
+  roles: WorkroomParticipantRole[];
   /** Whether the invitee may act (post) in the room, not just read. */
   canAct: boolean;
   enteredReason?: string | null;
@@ -34,7 +34,7 @@ export function appendRoomPolicyParticipant(evidence: unknown, invite: RoomParti
   const action = new Set(current.actionPrincipalRefs ?? []);
   if (invite.canAct) action.add(invite.principalRef);
 
-  const roles = invite.roles.length > 0 ? invite.roles : (["observer"] as WorkRoomParticipantRole[]);
+  const roles = invite.roles.length > 0 ? invite.roles : (["observer"] as WorkroomParticipantRole[]);
   const participants = [
     ...(current.participants ?? []).filter((participant) => participant.principalRef !== invite.principalRef),
     {
@@ -54,5 +54,5 @@ export function appendRoomPolicyParticipant(evidence: unknown, invite: RoomParti
   };
 
   const prior = Array.isArray(evidence) ? evidence : evidence ? [evidence] : [];
-  return [...prior, { workRoomPolicy: mergedPolicy }];
+  return [...prior, { workroomPolicy: mergedPolicy }];
 }

--- a/apps/web/lib/work-management/room-read-model.test.ts
+++ b/apps/web/lib/work-management/room-read-model.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import type { WorkCaseDetail, WorkCaseSourceRef } from "./case-types";
 import {
-  buildWorkRoomView,
-  type BuildWorkRoomViewInput,
+  buildWorkroomView,
+  type BuildWorkroomViewInput,
 } from "./room-read-model";
 
 const sourceRef: WorkCaseSourceRef = {
@@ -39,7 +39,7 @@ function caseDetail(overrides: Partial<WorkCaseDetail["summary"]> = {}): WorkCas
   };
 }
 
-function completeBoundary(): BuildWorkRoomViewInput["boundary"] {
+function completeBoundary(): BuildWorkroomViewInput["boundary"] {
   return {
     purpose: "Coordinate the repair without losing customer context.",
     outcome: "Cooling is restored and verified.",
@@ -62,7 +62,7 @@ function completeBoundary(): BuildWorkRoomViewInput["boundary"] {
 
 describe("Work Room read model", () => {
   it("projects a finite Work Case without creating a second identity", () => {
-    const room = buildWorkRoomView({
+    const room = buildWorkroomView({
       caseKey: "booking%3ABK-100",
       detail: caseDetail(),
       boundary: completeBoundary(),
@@ -119,7 +119,7 @@ describe("Work Room read model", () => {
       id: "WEEKLY-CASH",
       sourceType: "scheduled",
     };
-    const room = buildWorkRoomView({
+    const room = buildWorkroomView({
       caseKey: "scheduled%3AWEEKLY-CASH",
       detail: caseDetail({
         caseId: "scheduled:WEEKLY-CASH",
@@ -144,7 +144,7 @@ describe("Work Room read model", () => {
       id: "EXT-1",
       sourceType: "external-ticket",
     };
-    const room = buildWorkRoomView({
+    const room = buildWorkroomView({
       caseKey: "external-ticket%3AEXT-1",
       detail: caseDetail({
         caseId: "external-ticket:EXT-1",
@@ -178,7 +178,7 @@ describe("Work Room read model", () => {
   });
 
   it("keeps participant roles, work state, and presence as separate axes", () => {
-    const room = buildWorkRoomView({
+    const room = buildWorkroomView({
       caseKey: "booking%3ABK-100",
       detail: caseDetail(),
       boundary: completeBoundary(),
@@ -228,14 +228,14 @@ describe("Work Room read model", () => {
         status: "comment",
       },
     };
-    const input: BuildWorkRoomViewInput = {
+    const input: BuildWorkroomViewInput = {
       caseKey: "booking%3ABK-100",
       detail: caseDetail(),
       activities: [activity, activity],
     };
 
-    const first = buildWorkRoomView(input);
-    const second = buildWorkRoomView(input);
+    const first = buildWorkroomView(input);
+    const second = buildWorkroomView(input);
 
     expect(first.activity).toHaveLength(1);
     expect(first.activity[0]).toMatchObject({
@@ -247,7 +247,7 @@ describe("Work Room read model", () => {
   });
 
   it("preserves terminal Work Case behavior without inferring completion facts", () => {
-    const room = buildWorkRoomView({
+    const room = buildWorkroomView({
       caseKey: "booking%3ABK-100",
       detail: caseDetail({
         state: "closed",

--- a/apps/web/lib/work-management/room-read-model.ts
+++ b/apps/web/lib/work-management/room-read-model.ts
@@ -5,12 +5,12 @@ import type {
 } from "./case-types";
 import type { ReceiptEnvelope } from "./receipt-envelope";
 import {
-  normalizeWorkRoomActivities,
-  type WorkRoomActivityInput,
+  normalizeWorkroomActivities,
+  type WorkroomActivityInput,
 } from "./room-activity";
 import {
-  buildWorkRoomBoundary,
-  type WorkRoomBoundaryInput,
+  buildWorkroomBoundary,
+  type WorkroomBoundaryInput,
 } from "./room-boundary";
 import {
   dedupeRoomSourceRefs,
@@ -21,36 +21,36 @@ import {
   type WorkCaseSourceRegistryEntry,
 } from "./source-registry";
 import type {
-  WorkRoomBoundaryGap,
-  WorkRoomContextView,
-  WorkRoomCycleView,
-  WorkRoomOutcomePacket,
-  WorkRoomOutcomeView,
-  WorkRoomParticipantView,
-  WorkRoomView,
+  WorkroomBoundaryGap,
+  WorkroomContextView,
+  WorkroomCycleView,
+  WorkroomOutcomePacket,
+  WorkroomOutcomeView,
+  WorkroomParticipantView,
+  WorkroomView,
 } from "./room-types";
 
-export type { WorkRoomActivityInput } from "./room-activity";
-export type { WorkRoomBoundaryInput } from "./room-boundary";
+export type { WorkroomActivityInput } from "./room-activity";
+export type { WorkroomBoundaryInput } from "./room-boundary";
 
-export interface BuildWorkRoomViewInput {
+export interface BuildWorkroomViewInput {
   caseKey: string;
   detail: WorkCaseDetail;
-  boundary?: Partial<WorkRoomBoundaryInput>;
-  currentCycle?: WorkRoomCycleView | null;
-  completedCycles?: readonly WorkRoomCycleView[];
-  participants?: readonly WorkRoomParticipantView[];
-  activities?: readonly WorkRoomActivityInput[];
-  context?: Partial<WorkRoomContextView>;
-  outcomePacket?: WorkRoomOutcomePacket | null;
-  outcomeHealth?: WorkRoomOutcomeView["health"];
+  boundary?: Partial<WorkroomBoundaryInput>;
+  currentCycle?: WorkroomCycleView | null;
+  completedCycles?: readonly WorkroomCycleView[];
+  participants?: readonly WorkroomParticipantView[];
+  activities?: readonly WorkroomActivityInput[];
+  context?: Partial<WorkroomContextView>;
+  outcomePacket?: WorkroomOutcomePacket | null;
+  outcomeHealth?: WorkroomOutcomeView["health"];
   receipts?: readonly ReceiptEnvelope[];
-  sourceHealth?: WorkRoomView["projection"]["sourceHealth"];
+  sourceHealth?: WorkroomView["projection"]["sourceHealth"];
   /**
    * The subject's value-stream + lifecycle structure, pre-resolved by the loader via
-   * `resolveWorkRoomStructure` (kept out of this pure build, like `sourceHealth`).
+   * `resolveWorkroomStructure` (kept out of this pure build, like `sourceHealth`).
    */
-  structure?: WorkRoomView["structure"];
+  structure?: WorkroomView["structure"];
 }
 
 function primarySourceRef(detail: WorkCaseDetail): WorkCaseSourceRef {
@@ -59,7 +59,7 @@ function primarySourceRef(detail: WorkCaseDetail): WorkCaseSourceRef {
     ?? { kind: "source", id: detail.summary.caseId };
 }
 
-function caseRefForDetail(detail: WorkCaseDetail): WorkRoomView["caseRef"] {
+function caseRefForDetail(detail: WorkCaseDetail): WorkroomView["caseRef"] {
   const source = primarySourceRef(detail);
   const separator = detail.summary.caseId.indexOf(":");
   return {
@@ -89,26 +89,26 @@ function blockingActorKindForState(
 }
 
 function sourceHealth(
-  input: BuildWorkRoomViewInput,
+  input: BuildWorkroomViewInput,
   source: WorkCaseSourceRegistryEntry | null,
-): WorkRoomView["projection"]["sourceHealth"] {
+): WorkroomView["projection"]["sourceHealth"] {
   if (input.sourceHealth) return input.sourceHealth;
   return source ? "ok" : "partial";
 }
 
 function projectionConfidence(
   source: WorkCaseSourceRegistryEntry | null,
-  health: WorkRoomView["projection"]["sourceHealth"],
-  gaps: readonly WorkRoomBoundaryGap[],
-): WorkRoomView["projection"]["confidence"] {
+  health: WorkroomView["projection"]["sourceHealth"],
+  gaps: readonly WorkroomBoundaryGap[],
+): WorkroomView["projection"]["confidence"] {
   if (!source || health === "unavailable") return "low";
   if (health === "partial" || gaps.length > 0) return "medium";
   return "high";
 }
 
-export function buildWorkRoomView(
-  input: BuildWorkRoomViewInput,
-): WorkRoomView {
+export function buildWorkroomView(
+  input: BuildWorkroomViewInput,
+): WorkroomView {
   const expectedCaseKey = encodeURIComponent(input.detail.summary.caseId);
   if (input.caseKey !== expectedCaseKey) {
     throw new Error(
@@ -118,12 +118,12 @@ export function buildWorkRoomView(
 
   const source = sourceEntryForDetail(input.detail);
   const participants = [...(input.participants ?? [])];
-  const context: WorkRoomContextView = {
+  const context: WorkroomContextView = {
     refs: dedupeRoomSourceRefs(input.context?.refs ?? []),
     digest: roomText(input.context?.digest),
     sensitivityCeiling: roomText(input.context?.sensitivityCeiling),
   };
-  const boundary = buildWorkRoomBoundary({
+  const boundary = buildWorkroomBoundary({
     detail: input.detail,
     boundary: input.boundary,
     participants,
@@ -157,7 +157,7 @@ export function buildWorkRoomView(
     currentCycle: input.currentCycle ?? null,
     completedCycles: [...(input.completedCycles ?? [])],
     participants,
-    activity: normalizeWorkRoomActivities(input.activities ?? []),
+    activity: normalizeWorkroomActivities(input.activities ?? []),
     work: {
       nextAction: standingIdle
         ? "Open next cycle"

--- a/apps/web/lib/work-management/room-shapes.ts
+++ b/apps/web/lib/work-management/room-shapes.ts
@@ -1,29 +1,29 @@
-import type { WorkRoomAccessLevel } from "./room-participation";
-import type { WorkRoomParticipantRole } from "./room-types";
+import type { WorkroomAccessLevel } from "./room-participation";
+import type { WorkroomParticipantRole } from "./room-types";
 
-export const WORK_ROOM_SHAPE_KEYS = [
+export const WORKROOM_SHAPE_KEYS = [
   "specialist-alignment",
   "approval-sign-off",
   "outward-review",
   "change-consequential",
   "escalation",
 ] as const;
-export type WorkRoomShapeKey = (typeof WORK_ROOM_SHAPE_KEYS)[number];
+export type WorkroomShapeKey = (typeof WORKROOM_SHAPE_KEYS)[number];
 
 type ShapeRole = Extract<
-  WorkRoomParticipantRole,
+  WorkroomParticipantRole,
   "coordinator" | "specialist" | "approver" | "reviewer"
 >;
 
-export type WorkRoomShapeDefinition = {
-  key: WorkRoomShapeKey;
+export type WorkroomShapeDefinition = {
+  key: WorkroomShapeKey;
   inclusionOrder: readonly ShapeRole[];
-  authorityLadderLevel: WorkRoomAccessLevel;
+  authorityLadderLevel: WorkroomAccessLevel;
   sensitivityStepUp: boolean;
   description: string;
 };
 
-const SHAPES: Record<WorkRoomShapeKey, WorkRoomShapeDefinition> = {
+const SHAPES: Record<WorkroomShapeKey, WorkroomShapeDefinition> = {
   "specialist-alignment": {
     key: "specialist-alignment",
     inclusionOrder: ["coordinator", "specialist", "approver"],
@@ -61,27 +61,27 @@ const SHAPES: Record<WorkRoomShapeKey, WorkRoomShapeDefinition> = {
   },
 };
 
-export function getWorkRoomShape(key: WorkRoomShapeKey): WorkRoomShapeDefinition {
+export function getWorkroomShape(key: WorkroomShapeKey): WorkroomShapeDefinition {
   return SHAPES[key];
 }
 
-export type WorkRoomShapeBinding = {
-  shape: WorkRoomShapeKey;
+export type WorkroomShapeBinding = {
+  shape: WorkroomShapeKey;
   initiator: { principalRef: string; kind: "person" | "agent" };
   requiredParticipants: Array<{ role: ShapeRole; principalRef: string }>;
-  authorityLadderLevel: WorkRoomAccessLevel;
+  authorityLadderLevel: WorkroomAccessLevel;
   stepUpRequired: boolean;
   gaps: ShapeRole[];
   allowed: boolean;
 };
 
-export function bindWorkRoomShape(input: {
-  shape: WorkRoomShapeKey;
-  initiator: WorkRoomShapeBinding["initiator"];
+export function bindWorkroomShape(input: {
+  shape: WorkroomShapeKey;
+  initiator: WorkroomShapeBinding["initiator"];
   participants: Partial<Record<ShapeRole, string>>;
   sensitivityCeiling: string | null;
-}): WorkRoomShapeBinding {
-  const definition = getWorkRoomShape(input.shape);
+}): WorkroomShapeBinding {
+  const definition = getWorkroomShape(input.shape);
   const gaps = definition.inclusionOrder.filter((role) => !input.participants[role]);
   const requiredParticipants = definition.inclusionOrder.flatMap((role) => {
     const principalRef = input.participants[role];

--- a/apps/web/lib/work-management/room-structure.server.ts
+++ b/apps/web/lib/work-management/room-structure.server.ts
@@ -2,39 +2,39 @@
  * Server binding for Work Room structure (EP-WORKROOM-COMMS / EP-VSL-SURFACE fold).
  *
  * Fetches the room subject's stored stage/status with full prisma and folds it onto
- * the pure `resolveWorkRoomStructure` resolver. Injected into the case loader as its
+ * the pure `resolveWorkroomStructure` resolver. Injected into the case loader as its
  * `structureLoader` so the loader keeps its narrow client and never touches the CRM
  * models directly.
  *
  * First slice resolves the OPPORTUNITY subject (a clean, direct source → subject
  * mapping). Account-backed sources (engagement/activity/booking → CustomerAccount) and
- * platform-development subjects are paved follow-ups: `workRoomStructureSubjectFor`
+ * platform-development subjects are paved follow-ups: `workroomStructureSubjectFor`
  * already accepts an `accountStatus`, so wiring them is an additive resolver branch —
  * no contract change.
  */
 import { prisma } from "@dpf/db";
 
 import {
-  resolveWorkRoomStructure,
-  workRoomStructureSubjectFor,
-  type WorkRoomStructure,
+  resolveWorkroomStructure,
+  workroomStructureSubjectFor,
+  type WorkroomStructure,
 } from "./room-structure";
 
 /**
  * Resolve the value-stream + lifecycle structure for a room's subject from its source
  * ref. Returns null when the subject has no binding (or cannot be found).
  */
-export async function resolveWorkRoomStructureForCase(ref: {
+export async function resolveWorkroomStructureForCase(ref: {
   sourceType: string;
   sourceId: string;
-}): Promise<WorkRoomStructure | null> {
+}): Promise<WorkroomStructure | null> {
   if (ref.sourceType === "opportunity") {
     const opportunity = await prisma.opportunity.findFirst({
       where: { OR: [{ id: ref.sourceId }, { opportunityId: ref.sourceId }] },
       select: { stage: true },
     });
-    return resolveWorkRoomStructure(
-      workRoomStructureSubjectFor({ sourceType: ref.sourceType, opportunityStage: opportunity?.stage }),
+    return resolveWorkroomStructure(
+      workroomStructureSubjectFor({ sourceType: ref.sourceType, opportunityStage: opportunity?.stage }),
     );
   }
 

--- a/apps/web/lib/work-management/room-structure.test.ts
+++ b/apps/web/lib/work-management/room-structure.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  resolveWorkRoomStructure,
-  workRoomStructureSubjectFor,
+  resolveWorkroomStructure,
+  workroomStructureSubjectFor,
 } from "./room-structure";
 
-describe("resolveWorkRoomStructure", () => {
+describe("resolveWorkroomStructure", () => {
   it("returns null for a null subject (no value-stream/lifecycle binding)", () => {
-    expect(resolveWorkRoomStructure(null)).toBeNull();
+    expect(resolveWorkroomStructure(null)).toBeNull();
   });
 
   it("folds an opportunity subject onto its OVSM stage + lifecycle grammar", () => {
-    const structure = resolveWorkRoomStructure({ kind: "opportunity", stage: "qualification" });
+    const structure = resolveWorkroomStructure({ kind: "opportunity", stage: "qualification" });
     expect(structure).not.toBeNull();
     expect(structure?.valueStream).not.toBeNull();
     expect(structure?.lifecycle?.grammarKey).toBe("opportunity");
@@ -21,13 +21,13 @@ describe("resolveWorkRoomStructure", () => {
   });
 
   it("folds a customer-account subject onto its OVSM stage + lifecycle grammar", () => {
-    const structure = resolveWorkRoomStructure({ kind: "customer-account", status: "active" });
+    const structure = resolveWorkroomStructure({ kind: "customer-account", status: "active" });
     expect(structure?.lifecycle?.grammarKey).toBe("customer-account");
     expect(structure?.valueStream?.label.length ?? 0).toBeGreaterThan(0);
   });
 
   it("derives advancement gates from the current stage with a typed allow/refuse per target", () => {
-    const structure = resolveWorkRoomStructure({ kind: "opportunity", stage: "qualification" });
+    const structure = resolveWorkroomStructure({ kind: "opportunity", stage: "qualification" });
     const gates = structure?.lifecycle?.nextGates ?? [];
     expect(gates.length).toBeGreaterThan(0);
     for (const gate of gates) {
@@ -40,9 +40,9 @@ describe("resolveWorkRoomStructure", () => {
   });
 });
 
-describe("workRoomStructureSubjectFor", () => {
+describe("workroomStructureSubjectFor", () => {
   it("maps an opportunity source with a stage to an opportunity subject", () => {
-    expect(workRoomStructureSubjectFor({ sourceType: "opportunity", opportunityStage: "proposal" })).toEqual({
+    expect(workroomStructureSubjectFor({ sourceType: "opportunity", opportunityStage: "proposal" })).toEqual({
       kind: "opportunity",
       stage: "proposal",
     });
@@ -50,7 +50,7 @@ describe("workRoomStructureSubjectFor", () => {
 
   it("maps account-backed sources with a status to a customer-account subject", () => {
     for (const sourceType of ["engagement", "activity", "booking", "storefront-booking"]) {
-      expect(workRoomStructureSubjectFor({ sourceType, accountStatus: "at_risk" })).toEqual({
+      expect(workroomStructureSubjectFor({ sourceType, accountStatus: "at_risk" })).toEqual({
         kind: "customer-account",
         status: "at_risk",
       });
@@ -58,8 +58,8 @@ describe("workRoomStructureSubjectFor", () => {
   });
 
   it("returns null when the subject stage/status is missing or the source has no binding", () => {
-    expect(workRoomStructureSubjectFor({ sourceType: "opportunity", opportunityStage: null })).toBeNull();
-    expect(workRoomStructureSubjectFor({ sourceType: "backlog-item" })).toBeNull();
-    expect(workRoomStructureSubjectFor({ sourceType: "work-capsule" })).toBeNull();
+    expect(workroomStructureSubjectFor({ sourceType: "opportunity", opportunityStage: null })).toBeNull();
+    expect(workroomStructureSubjectFor({ sourceType: "backlog-item" })).toBeNull();
+    expect(workroomStructureSubjectFor({ sourceType: "work-capsule" })).toBeNull();
   });
 });

--- a/apps/web/lib/work-management/room-structure.ts
+++ b/apps/web/lib/work-management/room-structure.ts
@@ -27,23 +27,23 @@ import {
 import type { OperationalValueStreamStageKey } from "@dpf/storefront-templates";
 
 /** The room subject descriptor the loader builds from the subject's stored row. */
-export type WorkRoomStructureSubject =
+export type WorkroomStructureSubject =
   | { kind: "opportunity"; stage: string }
   | { kind: "customer-account"; status: string };
 
-export interface WorkRoomValueStream {
+export interface WorkroomValueStream {
   stage: OperationalValueStreamStageKey;
   label: string;
 }
 
-export interface WorkRoomLifecycleGate {
+export interface WorkroomLifecycleGate {
   toStage: string;
   toStageLabel: string;
   allowed: boolean;
   reason?: string;
 }
 
-export interface WorkRoomLifecycle {
+export interface WorkroomLifecycle {
   grammarKey: string;
   stage: string;
   stageLabel: string;
@@ -51,18 +51,18 @@ export interface WorkRoomLifecycle {
   stateLabel: string;
   band: string;
   /** The advancement gates from the current stage — what it would take to move on. */
-  nextGates: WorkRoomLifecycleGate[];
+  nextGates: WorkroomLifecycleGate[];
 }
 
-export interface WorkRoomStructure {
-  valueStream: WorkRoomValueStream | null;
-  lifecycle: WorkRoomLifecycle | null;
+export interface WorkroomStructure {
+  valueStream: WorkroomValueStream | null;
+  lifecycle: WorkroomLifecycle | null;
 }
 
-function buildLifecycle(grammar: LifecycleGrammar, point: LifecyclePoint): WorkRoomLifecycle {
+function buildLifecycle(grammar: LifecycleGrammar, point: LifecyclePoint): WorkroomLifecycle {
   const stageDef = getStage(grammar, point.stage);
   const stateDef = stageDef?.states.find((candidate) => candidate.key === point.state) ?? null;
-  const nextGates: WorkRoomLifecycleGate[] = (stageDef?.advancesTo ?? []).map((toStage) => {
+  const nextGates: WorkroomLifecycleGate[] = (stageDef?.advancesTo ?? []).map((toStage) => {
     const check = canAdvance(grammar, point, toStage);
     return {
       toStage,
@@ -87,7 +87,7 @@ function buildLifecycle(grammar: LifecycleGrammar, point: LifecyclePoint): WorkR
  * when the subject has no value-stream/lifecycle binding (e.g. a platform-development
  * subject that is not on the customer OVSM — a paved follow-up).
  */
-export function resolveWorkRoomStructure(subject: WorkRoomStructureSubject | null): WorkRoomStructure | null {
+export function resolveWorkroomStructure(subject: WorkroomStructureSubject | null): WorkroomStructure | null {
   if (!subject) return null;
 
   switch (subject.kind) {
@@ -116,11 +116,11 @@ export function resolveWorkRoomStructure(subject: WorkRoomStructureSubject | nul
  * development, workflow) — those fold onto the platform's own delivery stream in a
  * follow-up. `opportunityStage` / `accountStatus` are supplied by the loader.
  */
-export function workRoomStructureSubjectFor(input: {
+export function workroomStructureSubjectFor(input: {
   sourceType: string;
   opportunityStage?: string | null;
   accountStatus?: string | null;
-}): WorkRoomStructureSubject | null {
+}): WorkroomStructureSubject | null {
   if (input.sourceType === "opportunity" && input.opportunityStage) {
     return { kind: "opportunity", stage: input.opportunityStage };
   }

--- a/apps/web/lib/work-management/room-types.ts
+++ b/apps/web/lib/work-management/room-types.ts
@@ -7,11 +7,11 @@ import type {
   WorkCaseState,
 } from "./case-types";
 import type { ReceiptEnvelope } from "./receipt-envelope";
-import type { WorkRoomStructure } from "./room-structure";
+import type { WorkroomStructure } from "./room-structure";
 
-export type WorkRoomMode = "finite" | "standing";
+export type WorkroomMode = "finite" | "standing";
 
-export type WorkRoomActivityKind =
+export type WorkroomActivityKind =
   | "message"
   | "ask"
   | "coworker-joined"
@@ -31,7 +31,7 @@ export type WorkRoomActivityKind =
   | "cycle-closed"
   | "cycle-carried-over";
 
-export type WorkRoomParticipantRole =
+export type WorkroomParticipantRole =
   | "accountable"
   | "coordinator"
   | "contributor"
@@ -40,20 +40,20 @@ export type WorkRoomParticipantRole =
   | "reviewer"
   | "observer";
 
-export type WorkRoomParticipantWorkState =
+export type WorkroomParticipantWorkState =
   | "working"
   | "waiting"
   | "idle"
   | "unknown";
 
-export type WorkRoomOutcomePacketCategory =
+export type WorkroomOutcomePacketCategory =
   | "decisions"
   | "artifacts"
   | "actions"
   | "receipts"
   | "evidence";
 
-export interface WorkRoomOutcomePacket {
+export interface WorkroomOutcomePacket {
   outcomeState:
     | "achieved"
     | "partially-achieved"
@@ -77,7 +77,7 @@ export interface WorkRoomOutcomePacket {
   sourceRefs: WorkCaseSourceRef[];
 }
 
-export type WorkRoomBoundaryGap =
+export type WorkroomBoundaryGap =
   | "purpose"
   | "outcome"
   | "scope"
@@ -90,7 +90,7 @@ export type WorkRoomBoundaryGap =
   | "time-boundary"
   | "closure-rule";
 
-export interface WorkRoomBoundaryView {
+export interface WorkroomBoundaryView {
   purpose: string | null;
   outcome: string | null;
   scopeIncluded: string[];
@@ -106,11 +106,11 @@ export interface WorkRoomBoundaryView {
     stopConditionSummary: string | null;
   };
   closureRuleSummary: string | null;
-  gaps: WorkRoomBoundaryGap[];
+  gaps: WorkroomBoundaryGap[];
   sourceRefs: WorkCaseSourceRef[];
 }
 
-export interface WorkRoomCycleView {
+export interface WorkroomCycleView {
   cycleKey: string;
   carrierKind: "work-item" | "work-capsule" | "task-run";
   carrierId: string;
@@ -122,16 +122,16 @@ export interface WorkRoomCycleView {
   stopConditions: string[];
   measureSummary: string | null;
   status: "open" | "verifying" | "closed" | "carried-over";
-  outcomePacket: WorkRoomOutcomePacket | null;
+  outcomePacket: WorkroomOutcomePacket | null;
   sourceRefs: WorkCaseSourceRef[];
 }
 
-export interface WorkRoomParticipantView {
+export interface WorkroomParticipantView {
   principalRef: string;
   displayName: string;
   kind: "person" | "agent" | "system" | "external";
-  roles: WorkRoomParticipantRole[];
-  workState: WorkRoomParticipantWorkState;
+  roles: WorkroomParticipantRole[];
+  workState: WorkroomParticipantWorkState;
   presence: "active" | "idle" | "away" | "unknown";
   currentWorkSummary: string | null;
   enteredReason: string | null;
@@ -141,9 +141,9 @@ export interface WorkRoomParticipantView {
   sourceRefs: WorkCaseSourceRef[];
 }
 
-export interface WorkRoomActivityView {
+export interface WorkroomActivityView {
   eventId: string;
-  kind: WorkRoomActivityKind;
+  kind: WorkroomActivityKind;
   occurredAt: string | null;
   actorRef: WorkCaseActorRef | null;
   summary: string;
@@ -155,7 +155,7 @@ export interface WorkRoomActivityView {
   };
 }
 
-export interface WorkRoomWorkView {
+export interface WorkroomWorkView {
   nextAction: string;
   attentionRequired: boolean;
   attentionReason: string | null;
@@ -166,43 +166,43 @@ export interface WorkRoomWorkView {
   sourceRefs: WorkCaseSourceRef[];
 }
 
-export interface WorkRoomContextView {
+export interface WorkroomContextView {
   refs: WorkCaseSourceRef[];
   digest: string | null;
   sensitivityCeiling: string | null;
 }
 
-export interface WorkRoomOutcomeView {
+export interface WorkroomOutcomeView {
   statement: string | null;
-  packet: WorkRoomOutcomePacket | null;
+  packet: WorkroomOutcomePacket | null;
   health: "on-track" | "at-risk" | "blocked" | "idle" | "unknown" | null;
   sourceRefs: WorkCaseSourceRef[];
 }
 
-export interface WorkRoomView {
+export interface WorkroomView {
   roomKey: string;
   caseRef: WorkCaseRef;
   title: string;
   purpose: string | null;
-  mode: WorkRoomMode;
+  mode: WorkroomMode;
   state: WorkCaseState;
-  outcome: WorkRoomOutcomeView;
-  boundary: WorkRoomBoundaryView;
-  currentCycle: WorkRoomCycleView | null;
-  completedCycles: WorkRoomCycleView[];
-  participants: WorkRoomParticipantView[];
-  activity: WorkRoomActivityView[];
-  work: WorkRoomWorkView;
-  context: WorkRoomContextView;
+  outcome: WorkroomOutcomeView;
+  boundary: WorkroomBoundaryView;
+  currentCycle: WorkroomCycleView | null;
+  completedCycles: WorkroomCycleView[];
+  participants: WorkroomParticipantView[];
+  activity: WorkroomActivityView[];
+  work: WorkroomWorkView;
+  context: WorkroomContextView;
   receipts: ReceiptEnvelope[];
   sourceRefs: WorkCaseSourceRef[];
   /**
    * The value stream + lifecycle the room's SUBJECT sits in — the structure the
    * collaboration happens within. Null when the subject has no value-stream/lifecycle
    * binding (e.g. a platform-development subject not on the customer OVSM). Resolved by
-   * the loader via `resolveWorkRoomStructure` and passed pre-resolved (DB-free build).
+   * the loader via `resolveWorkroomStructure` and passed pre-resolved (DB-free build).
    */
-  structure: WorkRoomStructure | null;
+  structure: WorkroomStructure | null;
   projection: {
     confidence: WorkCaseProjectionConfidence;
     incompleteBoundary: boolean;

--- a/apps/web/lib/work-management/source-registry.ts
+++ b/apps/web/lib/work-management/source-registry.ts
@@ -3,9 +3,9 @@ import {
   type WorkCaseActionVerb,
 } from "./case-types";
 import type {
-  WorkRoomCycleView,
-  WorkRoomMode,
-  WorkRoomOutcomePacketCategory,
+  WorkroomCycleView,
+  WorkroomMode,
+  WorkroomOutcomePacketCategory,
 } from "./room-types";
 
 export const WORK_CASE_WORK_ITEM_SOURCE_TYPES = [
@@ -43,10 +43,10 @@ export interface WorkCaseReceiptPolicy {
 }
 
 export interface WorkCaseRoomProjectionPolicy {
-  mode: WorkRoomMode;
-  cycleCarrierPrecedence: readonly WorkRoomCycleView["carrierKind"][];
+  mode: WorkroomMode;
+  cycleCarrierPrecedence: readonly WorkroomCycleView["carrierKind"][];
   outcomePacket: {
-    requiredCategories: readonly WorkRoomOutcomePacketCategory[];
+    requiredCategories: readonly WorkroomOutcomePacketCategory[];
   };
 }
 

--- a/apps/web/lib/work-management/workspace-case-loader.test.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.test.ts
@@ -143,7 +143,7 @@ describe("workspace Work Case loader", () => {
 
   it("loads the current cycle, completed packets, and governed receipts from canonical child records", async () => {
     const boundary = (cycleKey: string) => ({
-      workRoomCycle: {
+      workroomCycle: {
         kind: "work-room-cycle",
         version: 1,
         cycleKey,
@@ -293,7 +293,7 @@ describe("workspace Work Case loader", () => {
       ...baseItem,
       evidence: [{
         kind: "work-room-policy",
-        workRoomPolicy: {
+        workroomPolicy: {
           admittedPrincipalRefs: ["PRN-USER-1"],
           sensitivityCeiling: "confidential",
         },
@@ -325,7 +325,7 @@ describe("workspace Work Case loader", () => {
     const itemWithParticipantPolicy = {
       ...baseItem,
       evidence: [{
-        workRoomPolicy: {
+        workroomPolicy: {
           participants: [{
             principalRef: "PRN-REVIEWER",
             roles: ["reviewer"],

--- a/apps/web/lib/work-management/workspace-case-loader.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.ts
@@ -10,20 +10,20 @@ import {
   type WorkCaseReadModelEvidenceInput,
 } from "./case-read-model";
 import {
-  buildWorkRoomView,
-  type WorkRoomActivityInput,
+  buildWorkroomView,
+  type WorkroomActivityInput,
 } from "./room-read-model";
 import {
-  projectStoredWorkRoomOutcomePackets,
+  projectStoredWorkroomOutcomePackets,
   projectWorkItemCycleCarriers,
-  WORK_ROOM_OUTCOME_MESSAGE_TYPE,
+  WORKROOM_OUTCOME_MESSAGE_TYPE,
 } from "./room-cycle-adapter";
 import {
-  selectCompletedWorkRoomCycles,
-  selectCurrentWorkRoomCycle,
+  selectCompletedWorkroomCycles,
+  selectCurrentWorkroomCycle,
 } from "./room-cycle";
-import type { WorkRoomStructure } from "./room-structure";
-import type { WorkRoomParticipantView, WorkRoomView } from "./room-types";
+import type { WorkroomStructure } from "./room-structure";
+import type { WorkroomParticipantView, WorkroomView } from "./room-types";
 import { getWorkCaseSourceEntry } from "./source-registry";
 import { fromWorkItemMessage } from "./receipt-envelope";
 import {
@@ -119,12 +119,12 @@ export type WorkspaceRoomAuthContext = {
  * Resolves the value-stream + lifecycle STRUCTURE of the room's subject. Injected
  * (like `participantLoader`) so this loader keeps its narrow prisma client and stays
  * off the CRM models — the caller wires a full-prisma resolver
- * (`resolveWorkRoomStructureForCase`). Returns null for subjects with no binding.
+ * (`resolveWorkroomStructureForCase`). Returns null for subjects with no binding.
  */
-export type WorkRoomStructureLoader = (ref: {
+export type WorkroomStructureLoader = (ref: {
   sourceType: string;
   sourceId: string;
-}) => Promise<WorkRoomStructure | null>;
+}) => Promise<WorkroomStructure | null>;
 
 export type WorkspaceRoomParticipantLoader = (input: {
   workItemId: string;
@@ -135,7 +135,7 @@ export type WorkspaceRoomParticipantLoader = (input: {
   status: string;
   now: Date;
   policyParticipants: readonly WorkspaceRoomPolicyParticipant[];
-}) => Promise<WorkRoomParticipantView[]>;
+}) => Promise<WorkroomParticipantView[]>;
 
 export type WorkspaceWorkCaseListItem = {
   caseId: string;
@@ -181,7 +181,7 @@ export type WorkspaceWorkCaseDetailView = {
   // Transitional compatibility seam. The loader always returns the room
   // projection; the optional marker lets the existing detail component remain
   // unchanged until BI-32E26F62 replaces its composition on the same route.
-  room?: WorkRoomView;
+  room?: WorkroomView;
 };
 
 function iso(value: Date | string | null | undefined): string | null {
@@ -352,12 +352,12 @@ function evidenceFromMessages(messages: WorkspaceWorkItemMessageRecord[]): WorkC
 function roomActivitiesFromMessages(
   item: WorkspaceWorkItemRecord,
   messages: WorkspaceWorkItemMessageRecord[],
-): WorkRoomActivityInput[] {
+): WorkroomActivityInput[] {
   return messages.map((message) => ({
     sourceEventId: message.messageId,
     // Free text remains a message. Only the canonical structured lifecycle
     // journal can project a cycle boundary event.
-    kind: message.messageType === WORK_ROOM_OUTCOME_MESSAGE_TYPE
+    kind: message.messageType === WORKROOM_OUTCOME_MESSAGE_TYPE
       ? "cycle-closed"
       : message.messageType === "work-room-cycle-opened"
         ? "cycle-opened"
@@ -390,7 +390,7 @@ function roomReceiptsFromMessages(
 ) {
   return messages.flatMap((message) => {
     if (!message.id || !message.structuredPayload) return [];
-    if (!["work-room-cycle-opened", WORK_ROOM_OUTCOME_MESSAGE_TYPE].includes(message.messageType)) return [];
+    if (!["work-room-cycle-opened", WORKROOM_OUTCOME_MESSAGE_TYPE].includes(message.messageType)) return [];
     return [fromWorkItemMessage({
       id: message.id,
       messageId: message.messageId,
@@ -420,7 +420,7 @@ export async function loadWorkspaceWorkCaseDetail({
   userId: string;
   authContext?: WorkspaceRoomAuthContext;
   participantLoader?: WorkspaceRoomParticipantLoader;
-  structureLoader?: WorkRoomStructureLoader;
+  structureLoader?: WorkroomStructureLoader;
   now?: Date;
 }): Promise<WorkspaceWorkCaseDetailView | null> {
   const decoded = decodeWorkCaseKey(caseKey);
@@ -499,16 +499,16 @@ export async function loadWorkspaceWorkCaseDetail({
   });
   const sourceEntry = getWorkCaseSourceEntry(item.sourceType);
   const currentCycle = sourceEntry
-    ? selectCurrentWorkRoomCycle(item.sourceType, cycleCandidates)
+    ? selectCurrentWorkroomCycle(item.sourceType, cycleCandidates)
     : null;
   const completedCycles = sourceEntry
-    ? selectCompletedWorkRoomCycles(item.sourceType, cycleCandidates)
+    ? selectCompletedWorkroomCycles(item.sourceType, cycleCandidates)
     : [];
-  const storedPackets = projectStoredWorkRoomOutcomePackets(messages);
+  const storedPackets = projectStoredWorkroomOutcomePackets(messages);
   const structure = structureLoader
     ? await structureLoader({ sourceType: source.sourceType, sourceId: source.sourceId })
     : null;
-  const room = buildWorkRoomView({
+  const room = buildWorkroomView({
     caseKey,
     detail,
     structure,

--- a/apps/web/lib/work-management/workspace-room-access.test.ts
+++ b/apps/web/lib/work-management/workspace-room-access.test.ts
@@ -10,7 +10,7 @@ describe("Workspace Work Room access", () => {
     const item = {
       assignedToUserId: "user-2",
       evidence: [{
-        workRoomPolicy: {
+        workroomPolicy: {
           admittedPrincipalRefs: ["PRN-1"],
           actionPrincipalRefs: [],
           sensitivityCeiling: "internal",
@@ -56,8 +56,8 @@ describe("Workspace Work Room access", () => {
       item: {
         assignedToUserId: "user-2",
         evidence: [
-          { workRoomPolicy: { admittedPrincipalRefs: ["PRN-1"], sensitivityCeiling: "internal" } },
-          { workRoomPolicy: { admittedPrincipalRefs: [], sensitivityCeiling: "confidential" } },
+          { workroomPolicy: { admittedPrincipalRefs: ["PRN-1"], sensitivityCeiling: "internal" } },
+          { workroomPolicy: { admittedPrincipalRefs: [], sensitivityCeiling: "confidential" } },
         ],
       },
       userId: "user-1",
@@ -70,7 +70,7 @@ describe("Workspace Work Room access", () => {
   });
 
   it("parses explicitly named participants separately from access admission", () => {
-    expect(readWorkspaceRoomPolicy([{ workRoomPolicy: {
+    expect(readWorkspaceRoomPolicy([{ workroomPolicy: {
       admittedPrincipalRefs: ["PRN-REVIEWER"],
       participants: [{
         principalRef: "PRN-REVIEWER",

--- a/apps/web/lib/work-management/workspace-room-access.ts
+++ b/apps/web/lib/work-management/workspace-room-access.ts
@@ -1,4 +1,4 @@
-import { authorizeWorkRoomAccess, type WorkRoomAccessDecision } from "./room-participation";
+import { authorizeWorkroomAccess, type WorkroomAccessDecision } from "./room-participation";
 
 export type WorkspaceRoomPolicyMetadata = {
   admittedPrincipalRefs: string[];
@@ -21,7 +21,7 @@ export function readWorkspaceRoomPolicy(evidence: unknown): Partial<WorkspaceRoo
   // earlier snapshot; reading the first would preserve stale authority.
   for (const value of [...values].reverse()) {
     if (!value || typeof value !== "object") continue;
-    const policy = (value as Record<string, unknown>).workRoomPolicy;
+    const policy = (value as Record<string, unknown>).workroomPolicy;
     if (!policy || typeof policy !== "object") continue;
     const record = policy as Record<string, unknown>;
     const strings = (key: string) => Array.isArray(record[key])
@@ -76,7 +76,7 @@ export function authorizeWorkspaceRoomItem(input: {
     sensitivityClearance: readonly string[];
     isSuperuser: boolean;
   };
-}): WorkRoomAccessDecision {
+}): WorkroomAccessDecision {
   const policy = readWorkspaceRoomPolicy(input.item.evidence);
   const principalId = input.authContext?.principalId ?? `user:${input.userId}`;
   const assignedToCurrentUser = input.item.assignedToUserId === input.userId;
@@ -85,7 +85,7 @@ export function authorizeWorkspaceRoomItem(input: {
     ? policy.actionPrincipalRefs ?? []
     : policy.admittedPrincipalRefs ?? [];
 
-  return authorizeWorkRoomAccess({
+  return authorizeWorkroomAccess({
     requested: input.requested,
     principalRef: principalId,
     assignedPrincipalRefs: [

--- a/docs/architecture/work-room-participation-and-channel-continuity.md
+++ b/docs/architecture/work-room-participation-and-channel-continuity.md
@@ -1,6 +1,6 @@
-# Work Room Participation and Channel Continuity
+# Workroom Participation and Channel Continuity
 
-Work Room is an application projection over the canonical Work Case and its existing source records. This slice adds no identity, room, membership, or channel table.
+Workroom is an application projection over the canonical Work Case and its existing source records. This slice adds no identity, room, membership, or channel table.
 
 ## Design grounding
 
@@ -8,7 +8,7 @@ Work Room is an application projection over the canonical Work Case and its exis
   - `docs/superpowers/plans/2026-07-26-work-rooms-collaboration.md`
   - `docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md`
 - Current code substrate reviewed:
-  - Work Case and Work Room projection, Workspace case loader, Work Item presence, conversation-participant lineage, effective authorization context, Principal aliases, and communication bindings/sessions.
+  - Work Case and Workroom projection, Workspace case loader, Work Item presence, conversation-participant lineage, effective authorization context, Principal aliases, and communication bindings/sessions.
 - Source of truth:
   - Work Case and its source records own work state; `Principal`/`PrincipalAlias` own identity and authority; `CommunicationChannelBinding` and `CommunicationChannelSession` own external identity and room attachment.
 - Decision:
@@ -44,4 +44,4 @@ External providers remain adapters to DPF, not alternate room authorities. The g
 
 Unresolved identity or room context is quarantined before activity persistence. Capability flags produce an explicit degraded result. Confidential or higher consequential requests require step-up authentication. Delivery acknowledgement and action completion remain separate facts; this ingress records external activity and never marks a governed action complete.
 
-Teams, Slack, and other providers consume this shared contract. Provider-specific feature work does not belong in the Work Room projection.
+Teams, Slack, and other providers consume this shared contract. Provider-specific feature work does not belong in the Workroom projection.

--- a/docs/architecture/workroom-vocabulary-boundary.md
+++ b/docs/architecture/workroom-vocabulary-boundary.md
@@ -1,0 +1,82 @@
+# Workroom vocabulary boundary
+
+**Backlog item:** `BI-C2C16582`
+**Epic:** `EP-WORK-CONVERGENCE`
+**Status:** Current
+
+Founder-directed 2026-08-15: **Workroom** is the canonical name for what we claim
+and how we work. This page is the single place that says what the word means at
+each layer, so the two vocabularies that merged here do not re-diverge.
+
+## The three layers
+
+| Layer | Name | What it is | Where it lives |
+| --- | --- | --- | --- |
+| Durable record | **Workroom** | The claim. Names the backlog item, holds the lease, records branch / base SHA / worktree / PR, accumulates evidence. | `Workroom` + `WorkroomActivity` Prisma models |
+| Projection | **WorkCase** | The business-language projection of a unit of work, whatever produced it. | `WORK_CASE_SOURCE_REGISTRY` |
+| Surface | **Workroom view** | What a person sees and acts in: participants, cycles, outcome packet, structure. | `WorkroomView`, `WorkroomCycle`, `WorkroomOutcomePacket`, `apps/web/components/workspace/workroom/` |
+
+Read it as one sentence: **a Workroom is claimed as a record, projected as a
+WorkCase, and rendered as a Workroom view.**
+
+## Naming rules
+
+- One stem, one casing: **`Workroom`** — never `WorkRoom`, `work-room` or
+  `WORK_ROOM`. The compound is a single word, like `Workspace`.
+- The **record** is `Workroom`. Do not call it a capsule in new prose or new code.
+- A **view type** keeps its role in the name: `WorkroomView`, `WorkroomCycleView`,
+  `WorkroomParticipantView`. The suffix is what distinguishes a projection from
+  the record, now that both share a stem.
+- **WorkCase** keeps its own name. It is the business-language layer and is not a
+  Workroom synonym.
+
+## A known tension, accepted deliberately
+
+`WORK_CASE_SOURCE_REGISTRY` currently carries **13 sources**, each with its own
+`roomProjection` policy:
+
+```
+task-node · backlog-item · work-capsule · approval · data-control-operation
+manual-task · scheduled · engagement · opportunity · booking
+storefront-booking · activity · field-service-job
+```
+
+The room is therefore a *container* that renders for any of those sources, while
+the claim record is *one* of them (`work-capsule`). Converging both onto the name
+Workroom means one source shares the container's name, and a booking, an
+opportunity or a field-service job renders in something called a Workroom.
+
+This was raised before the convergence landed and the direction was reaffirmed
+(2026-08-15). It is recorded here rather than left implicit, because it is the
+thing most likely to confuse a reader later.
+
+**The practical rule that keeps it workable:** when the word is ambiguous in a
+sentence, say which layer you mean — "the Workroom record", "the WorkCase", or
+"the Workroom view". Do not disambiguate by inventing a new noun.
+
+If the ambiguity later proves costly, the reversible move is to rename the
+*container* (the view layer) rather than the record, because the record's name is
+founder-directed. That would be a follow-on BI under `EP-WORK-CONVERGENCE`, not a
+silent drift.
+
+## What is deliberately NOT renamed yet
+
+⟦runtime: these lag the vocabulary on purpose — check before assuming drift⟧
+
+- **MCP tool names** — `create_work_capsule`, `claim_capsule_scope`,
+  `heartbeat_capsule` and the rest keep their names behind an alias window,
+  because external Claude / Codex / Grok clients and peer installs hold them.
+  `BI-0702869B`.
+- **Prisma field vocabulary** — `workCapsuleId` foreign keys, the `capsule` /
+  `workCapsule` relation fields, and the `capsuleId` semantic key with its `WC-*`
+  values. The models carry `@@map` to their original physical tables, so the
+  columns are unchanged on disk.
+- **Dated specs and plans** under `docs/superpowers/` keep their original
+  filenames and wording. They are the record of what was decided when, not live
+  contracts.
+
+## Related
+
+- [Claim a workroom before you work](../founder-kernel/wiki/principles/claim-a-workroom-before-you-work.md)
+- [Workroom participation and channel continuity](work-room-participation-and-channel-continuity.md)
+- Plan: `docs/superpowers/plans/2026-08-15-workroom-canonical-rename.md`

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -139,7 +139,7 @@ outcome is "someone will pick this up later"; handing one to an operator who ask
 without first trying to reach a colleague who could move the work, is the conversational form of the
 dead-end button. Coworkers are a team that can reach each other directly, so filing is the last rung
 of an ordered ladder — re-route to the specialist who owns the area, consult a peer for one bounded
-question, convene the parties in a work room, and only then file, naming who was tried. The contract
+question, convene the parties in a workroom, and only then file, naming who was tried. The contract
 is assembled into every coworker's prompt from `platform-identity/escalation-ladder`
 (`apps/web/lib/tak/escalation-ladder.ts`), and a turn that files without attempting a rung above it
 offers the escalation instead of ending the thread. Full rationale in

--- a/docs/testing/archetype-job-validation.md
+++ b/docs/testing/archetype-job-validation.md
@@ -13,7 +13,7 @@ one: where people work and do specific jobs has a virtual counterpart. For
 born-virtual work the mapping is direct. For physical work, jobs are organized
 by **expected outcome** — cooking the food, seating the guest, taking orders
 and serving, paying the employees — and each outcome maps to a working surface
-(a standing Work Room per ongoing outcome, a finite room per bounded one) with
+(a standing Workroom per ongoing outcome, a finite room per bounded one) with
 the people and AI coworkers who own that outcome inside its boundary. The
 underlying substrate exists (Work Cases/Rooms, workspace homes, roles,
 coworkers); the current phase is TAILORING it per archetype, per job, per
@@ -23,7 +23,7 @@ virtual room serve its physical outcome better than working without it?
 First exercised live on the restaurant archetype, 2026-07-29 (goal thread:
 restaurant-owner overnight exercise). Companion substrate:
 
-- **Work Rooms** (`docs/superpowers/specs/2026-07-26-work-rooms-collaboration-design.md`,
+- **Workrooms** (`docs/superpowers/specs/2026-07-26-work-rooms-collaboration-design.md`,
   EP-2984B02B) — the collaboration surface a job uses for active work.
 - **Workspace home profiles** (`apps/web/lib/workspace-home/profiles.ts`) —
   archetype-category tailoring of the signed-in home.

--- a/docs/user-guide/workspace/index.md
+++ b/docs/user-guide/workspace/index.md
@@ -101,7 +101,7 @@ business action until the durable operations provider confirms it.
 - **Calendar** — Upcoming dates pulled from your backlog items, leave requests, deadlines, and any scheduled events in the areas you have access to.
 - **Managed Documents** — Maintained documents with lifecycle state, versions, references, and publication status.
 - **"Needs you" inbox** — The one place for business decisions that need you now. Routine technical recovery stays with your digital team, while money leaving the business and public actions always come to you.
-- **Work Rooms** — Active, access-controlled places where people and AI coworkers coordinate toward a named outcome. A Work Room is the friendly Workspace view over a governed Work Case.
+- **Workrooms** — Active, access-controlled places where people and AI coworkers coordinate toward a named outcome. A Workroom is the friendly Workspace view over a governed Work Case.
 
 ## What You Can Do
 
@@ -110,6 +110,6 @@ business action until the durable operations provider confirms it.
 - Review recent activity from colleagues and digital coworkers without leaving your workspace
 - Access your calendar for today's events and upcoming deadlines
 - Open [Managed Documents](documents.md) to review document state, versions, and references
-- Open [My Work and Work Rooms](work-rooms.md) to see the outcome, accountable participants, current attention, activity, and next action for active company work. Room access is checked before internal context loads; participant details explain each person or AI coworker's role, current work, authority, and sponsorship. Connected communication channels link back to the same canonical room and cannot treat message delivery as completed work.
+- Open [My Work and Workrooms](work-rooms.md) to see the outcome, accountable participants, current attention, activity, and next action for active company work. Room access is checked before internal context loads; participant details explain each person or AI coworker's role, current work, authority, and sponsorship. Connected communication channels link back to the same canonical room and cannot treat message delivery as completed work.
 - Use your digital coworker to get a personalized briefing on what needs your attention
 - Open the ["Needs you" inbox](attention-inbox.md) to review plain-language decision cards, weekly batches, and the full technical record when needed

--- a/docs/user-guide/workspace/work-rooms.md
+++ b/docs/user-guide/workspace/work-rooms.md
@@ -1,5 +1,5 @@
 ---
-title: "My Work and Work Rooms"
+title: "My Work and Workrooms"
 area: workspace
 order: 3
 relatedCode:
@@ -7,8 +7,8 @@ relatedCode:
   - apps/web/app/(shell)/workspace/cases/[caseKey]/page.tsx
   - apps/web/components/workspace/WorkCaseAttentionLens.tsx
   - apps/web/components/workspace/WorkCaseDetailView.tsx
-  - apps/web/components/workspace/work-room/WorkRoomCycles.tsx
-  - apps/web/components/workspace/work-room/WorkRoomParticipants.tsx
+  - apps/web/components/workspace/workroom/WorkroomCycles.tsx
+  - apps/web/components/workspace/workroom/WorkroomParticipants.tsx
   - apps/web/lib/work-management/room-channel-continuity.ts
   - apps/web/lib/work-management/room-channel-ingress.ts
   - apps/web/lib/work-management/room-participation.ts
@@ -18,13 +18,13 @@ relatedCode:
 
 ## Overview
 
-**My Work** is the Workspace view of active company work available to you. Each item opens a **Work Room**: a focused place where authorized people and AI coworkers coordinate toward a named outcome.
+**My Work** is the Workspace view of active company work available to you. Each item opens a **Workroom**: a focused place where authorized people and AI coworkers coordinate toward a named outcome.
 
-A Work Room is not an unbounded chat channel. It has a work boundary: purpose, outcome, scope, accountability, authority, sensitivity, measures, timing, and a closure rule. The platform keeps the underlying governed Work Case and its evidence; the room presents that structure in language suited to doing the work.
+A Workroom is not an unbounded chat channel. It has a work boundary: purpose, outcome, scope, accountability, authority, sensitivity, measures, timing, and a closure rule. The platform keeps the underlying governed Work Case and its evidence; the room presents that structure in language suited to doing the work.
 
 ## What You See First
 
-The top of a Work Room answers four questions:
+The top of a Workroom answers four questions:
 
 1. What outcome does this room own?
 2. What needs attention now?
@@ -61,7 +61,7 @@ Open **Participants** to see why each person or coworker is in the room, what th
 
 Room access has separate discovery, content, and action boundaries. Assignment or an explicit room policy admits a principal; a presence heartbeat never does. Sensitivity clearance is checked on the server before messages, participants, or context load. A person without content access receives the same not-found experience as an unknown room.
 
-When an existing communication adapter attaches a Teams, Slack, email, or other external conversation to a Work Room, DPF remains the canonical context:
+When an existing communication adapter attaches a Teams, Slack, email, or other external conversation to a Workroom, DPF remains the canonical context:
 
 - concise notifications carry a link back to the internal room and its canonical Work Case reference;
 - the channel binding resolves the external subject to one `Principal` before an inbound event can attach;
@@ -70,7 +70,7 @@ When an existing communication adapter attaches a Teams, Slack, email, or other 
 - sent or delivered status proves transport only, not that governed work completed;
 - if an adapter cannot receive or interact, the channel reports a degraded state while the DPF room remains usable.
 
-Unresolved external identities or room attachments are quarantined from room activity. Provider-specific setup and capabilities remain part of Employee Communication administration, not the Work Room itself.
+Unresolved external identities or room attachments are quarantined from room activity. Provider-specific setup and capabilities remain part of Employee Communication administration, not the Workroom itself.
 
 ## Finite and Standing Rooms
 
@@ -87,4 +87,4 @@ In a standing room, the **Current cycle** panel shows the objective, trigger, re
 
 If a room boundary is incomplete, the page identifies the missing elements instead of inventing them. If the source is unavailable, the last available projection is marked clearly and the page gives one recovery direction. If an AI coworker's current status is unavailable, the participant panel says so and directs you back to the room's next action instead of implying that the coworker is still working.
 
-If you do not have access, the internal room title, participants, source references, and sensitivity details are not shown. External customer case pages remain customer-safe case summaries; they do not expose internal Work Room controls or participants.
+If you do not have access, the internal room title, participants, source references, and sensitivity details are not shown. External customer case pages remain customer-safe case summaries; they do not expose internal Workroom controls or participants.

--- a/scripts/check-ux-fit-decision.mjs
+++ b/scripts/check-ux-fit-decision.mjs
@@ -405,6 +405,67 @@ function lines(out) {
   return out.split("\n").map((s) => s.trim()).filter(Boolean);
 }
 
+// User-visible copy in a line: quoted string literals and JSX text nodes. This is
+// what the UX budget actually measures, so it is what decides whether a moved file
+// introduced a new surface.
+function visibleCopy(line) {
+  const out = new Set();
+  // A module specifier is not user copy — `import … from "@/components/…"` changes
+  // with every file move and would otherwise read as new on-screen text.
+  if (/^\s*[+-]?\s*(import|export)\b.*\bfrom\b/.test(line)) return out;
+  for (const m of line.matchAll(/["'`]([^"'`]{2,})["'`]/g)) {
+    const text = m[1].trim();
+    if (text.includes("/") || text.startsWith("@")) continue; // path-like, not copy
+    out.add(text);
+  }
+  for (const m of line.matchAll(/>\s*([A-Za-z][^<>{}]{2,})\s*</g)) out.add(m[1].trim());
+  return out;
+}
+
+/**
+ * Paths that arrived at their location by a `git mv` that introduced NO new
+ * user-visible copy.
+ *
+ * Rename detection alone is not enough and a raw similarity threshold is the wrong
+ * instrument: renaming a frequently-repeated identifier can push a byte-identical
+ * move down to ~90% similarity, while a genuinely new control can sit above it.
+ * What the gate cares about is whether a new surface appeared, so compare the copy:
+ * if every string/JSX text on the added side already existed on the removed side,
+ * the move is the same control at a new path. Anything that adds copy still has to
+ * prove its fit. Returns the NEW paths.
+ */
+export function collectCopyPreservingRenames(base, runGit = git) {
+  const out = new Set();
+  const raw = runGit(
+    "diff",
+    "--name-status",
+    "--find-renames=50%",
+    `${base}...HEAD`,
+    "--",
+    "apps/web/**/*.tsx",
+  );
+  for (const line of raw.split("\n")) {
+    const parts = line.trim().split(/\t+/);
+    if (parts.length !== 3 || !/^R\d*$/.test(parts[0])) continue;
+    const [, oldPath, newPath] = parts;
+    const body = runGit("diff", "--find-renames=50%", `${base}...HEAD`, "--", oldPath, newPath);
+    const added = new Set();
+    const removed = new Set();
+    for (const l of body.split("\n")) {
+      if (l.startsWith("+++") || l.startsWith("---")) continue;
+      if (l.startsWith("+")) for (const c of visibleCopy(l)) added.add(c);
+      else if (l.startsWith("-")) for (const c of visibleCopy(l)) removed.add(c);
+    }
+    // Compare normalized: a rename re-cases and re-spaces the same words
+    // ("Work Room" -> "Workroom", workRoomX -> workroomX). Text that survives
+    // normalization as new IS new copy and still needs measured evidence.
+    const norm = (s) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+    const removedNorm = new Set([...removed].map(norm));
+    if ([...added].every((c) => removedNorm.has(norm(c)))) out.add(newPath);
+  }
+  return out;
+}
+
 function main() {
   const base = assertSafeRef(process.env.BASE_SHA || "origin/main", "BASE_SHA");
   // BI-1ADD56FC: never write .git/shallow into a full shared clone (breaks worktrees).
@@ -417,10 +478,18 @@ function main() {
     lines(git("diff", "--name-only", "--diff-filter=A", `${base}...HEAD`, "--", "apps/web/**/*.tsx")),
   );
 
+  // A moved file is the SAME control at a new path, not a new one. Without rename
+  // detection `git mv` reads as delete+add, so a pure rename would demand fresh
+  // measured UX evidence for a screen nobody changed. Forgiven only when the move
+  // introduced no new user-visible copy; a move that also added a surface still
+  // has to prove its fit.
+  const renamedFiles = collectCopyPreservingRenames(base);
+
   const impactingFiles = [];
   const reasons = new Map();
   for (const f of changed) {
     const safePath = assertSafePath(f);
+    if (renamedFiles.has(safePath)) continue;
     const isNewRoute = ROUTE_FILE_RE.test(safePath) && addedFiles.has(safePath);
     const added = git("diff", `${base}...HEAD`, "--", safePath)
       .split("\n")

--- a/scripts/check-ux-fit-decision.test.mjs
+++ b/scripts/check-ux-fit-decision.test.mjs
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 import {
+  collectCopyPreservingRenames,
   MEASURED_AXES,
   MEASURED_AXIS_POLARITY,
   UI_CONTROL_RE,
@@ -295,4 +296,50 @@ test("polarity does not drift from lib/ux-budget/ratchet.ts", () => {
   );
   assert.deepEqual(MEASURED_AXIS_POLARITY, source);
   assert.deepEqual(Object.keys(MEASURED_AXIS_POLARITY).sort(), [...MEASURED_AXES].sort());
+});
+
+// ── Renamed components (BI-C2C16582) ────────────────────────────────────────────
+//
+// A `git mv` reads as delete+add without rename detection, so a pure rename used to
+// demand fresh measured UX evidence for a screen nobody changed. The exemption is
+// narrow ON PURPOSE: it forgives a move that introduces no new user-visible copy,
+// and nothing else. These fixtures pin both halves — especially that a rename which
+// DOES add copy still has to prove its fit, which is what stops the exemption from
+// becoming a way to smuggle UI in behind a file move.
+
+function fakeGit(nameStatus, bodies) {
+  return (...args) => {
+    if (args.includes("--name-status")) return nameStatus;
+    const newPath = args[args.length - 1];
+    return bodies[newPath] ?? "";
+  };
+}
+
+test("a rename that only re-cases identifiers is exempt", () => {
+  const ns = "R093\tapps/web/a/WorkRoomHeader.tsx\tapps/web/a/WorkroomHeader.tsx";
+  const body = [
+    '-import { WorkRoomView } from "@/lib/work-management/room-types";',
+    '+import { WorkroomView } from "@/lib/work-management/room-types";',
+    '-  <div data-testid="workRoomOutcomeHealth">Outcome health</div>',
+    '+  <div data-testid="workroomOutcomeHealth">Outcome health</div>',
+  ].join("\n");
+  const out = collectCopyPreservingRenames("base", fakeGit(ns, { "apps/web/a/WorkroomHeader.tsx": body }));
+  assert.equal(out.has("apps/web/a/WorkroomHeader.tsx"), true);
+});
+
+test("a rename that ADDS user-visible copy is NOT exempt", () => {
+  const ns = "R090\tapps/web/a/WorkRoomHeader.tsx\tapps/web/a/WorkroomHeader.tsx";
+  const body = [
+    '-  <div data-testid="workRoomOutcomeHealth">Outcome health</div>',
+    '+  <div data-testid="workroomOutcomeHealth">Outcome health</div>',
+    '+  <button>Archive this workroom</button>',
+  ].join("\n");
+  const out = collectCopyPreservingRenames("base", fakeGit(ns, { "apps/web/a/WorkroomHeader.tsx": body }));
+  assert.equal(out.has("apps/web/a/WorkroomHeader.tsx"), false);
+});
+
+test("a plain added file is never treated as a rename", () => {
+  const ns = "A\tapps/web/a/BrandNewPanel.tsx";
+  const out = collectCopyPreservingRenames("base", fakeGit(ns, {}));
+  assert.equal(out.size, 0);
 });

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -8399,35 +8399,35 @@
     "longSentences": 0,
     "textMass": 39
   },
-  "apps/web/components/workspace/work-room/WorkRoomBody.tsx": {
+  "apps/web/components/workspace/workroom/WorkroomBody.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
     "textMass": 37
   },
-  "apps/web/components/workspace/work-room/WorkRoomCycles.tsx": {
+  "apps/web/components/workspace/workroom/WorkroomCycles.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
     "textMass": 39
   },
-  "apps/web/components/workspace/work-room/WorkRoomHeader.tsx": {
+  "apps/web/components/workspace/workroom/WorkroomHeader.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
     "textMass": 46
   },
-  "apps/web/components/workspace/work-room/WorkRoomParticipants.tsx": {
+  "apps/web/components/workspace/workroom/WorkroomParticipants.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
     "textMass": 31
   },
-  "apps/web/components/workspace/work-room/WorkRoomStructurePanel.tsx": {
+  "apps/web/components/workspace/workroom/WorkroomStructurePanel.tsx": {
     "vocabulary": 0,
     "genericLabels": 0,
     "readability": 0,


### PR DESCRIPTION
Phase 2 of the Workroom canonical rename (`EP-WORK-CONVERGENCE`, umbrella `BI-D2D190BF`). Phase 1 renamed the record; this merges the **other** vocabulary that already owned the name, so there is one stem instead of two spellings of the same word.

## What changed

One stem, one casing — `Workroom`, never `WorkRoom` / `workRoom` / `WORK_ROOM` / `work-room`.

61 code files: `WorkroomView`, `WorkroomCycle`, `WorkroomOutcomePacket`, `WorkroomParticipantView`, `WorkroomStructure`, `authorizeWorkroomAccess`. Component directory and files moved with `git mv` so history follows. Doc prose converged in 5 live pages; dated specs, plans and ux-fit records keep their original wording as the record of what was decided when.

## The actual deliverable: the boundary

`docs/architecture/workroom-vocabulary-boundary.md`. **A Workroom is claimed as a record, projected as a WorkCase, and rendered as a Workroom view.** View types keep a role suffix (`WorkroomView`, `WorkroomCycleView`) because that suffix is now the only thing distinguishing a projection from the record.

## A tension recorded, not hidden

`WORK_CASE_SOURCE_REGISTRY` carries **13 sources**, each with its own `roomProjection`: `task-node`, `backlog-item`, **`work-capsule`**, `approval`, `data-control-operation`, `manual-task`, `scheduled`, `engagement`, `opportunity`, `booking`, `storefront-booking`, `activity`, `field-service-job`.

So the room is a *container* and the claim record is *one of the 13*. Converging means one source shares the container's name, and a booking or field-service job renders in something called a Workroom. **This was raised before landing and the direction was reaffirmed by the operator.** The boundary doc names the disambiguation rule ("the Workroom record" / "the WorkCase" / "the Workroom view") and the reversible exit — rename the container, not the record — if it proves costly.

## ⚠️ Guard exemption — NEEDS REVIEW

The UX-Fit gate listed added `.tsx` with `--diff-filter=A` and **no rename detection**, so `git mv` read as delete+add and every moved component was reported as "adds a user-facing control", demanding measured UX evidence for screens nobody changed.

I did **not** supply a manifest for a non-change, and did not invent a `decisionInteractionId` or sweep numbers — that is the attestation theatre `BI-D967DEE0` rebuilt this gate to stop.

My first attempt was a 95% similarity threshold. **That was wrong**: git scored the moved files 90–97% because renaming a repeated identifier drags similarity down even when nothing changed, so the threshold would have been tuned to my own diff. Verified exactly instead — *for every moved component, the old blob with the rename substitution applied equals the new file byte-for-byte.*

The shipped rule compares what the gate cares about: user-visible copy (quoted strings and JSX text), ignoring module specifiers, compared normalized (a rename re-cases and re-spaces the same words). **Text that survives normalization as new IS new copy and still requires measured evidence.**

Three fixtures pin it — a re-casing rename is exempt, **a rename that ADDS a control is NOT exempt**, and a plain added file is never treated as a rename. That middle test is load-bearing: it stops the exemption becoming a way to smuggle UI in behind a file move.

Prose-lint baseline keys were renamed **in place with recorded values untouched** — still 1205 files, no ratchet loosened.

## Verification

`tsc --noEmit` clean · 404 tests across 69 files · 26 gate tests · derived artifacts regenerate cleanly (448 code edges, 87 route edges) · local-CI gate passed, evidence `cmsv0kfcs000i01mrpuawi971`, gated sha `4875a02dff57`.

The `doc-impact` generator caught the moved component paths in the user guide's `relatedCode` frontmatter; repointed rather than regenerated around, so doc→code edges stay real.

## Still deliberately unrenamed

MCP tool names behind their alias window (`BI-0702869B`) and the Prisma field vocabulary — `workCapsuleId`, the `capsule`/`workCapsule` relation fields, and the `capsuleId` semantic key with its `WC-*` values, whose columns are unchanged on disk under `@@map`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)