### PR TITLE
feat(decisions): persist the structured locator so a recorded citation can be re-checked (BI-8192557E)

### DIFF
--- a/apps/web/lib/decision-perspective/persistence.ts
+++ b/apps/web/lib/decision-perspective/persistence.ts
@@ -8,8 +8,10 @@ import {
   type DecisionOutcomeType,
   type DecisionPerspectiveEvaluationResult,
   type DecisionRiskTier,
+  type DecisionEvaluationSource,
   type PerspectiveMaterialFreshness,
 } from "./types";
+import { normalizeLocator } from "@/lib/deliberation/evidence";
 
 type DecisionInteractionClient = {
   decisionInteraction: {
@@ -90,16 +92,28 @@ function normalizeFreshnessDistribution(value: unknown): Record<PerspectiveMater
 function normalizeSources(value: unknown): DecisionPerspectiveEvaluationResult["sources"] {
   if (!Array.isArray(value)) return [];
   return value
-    .map((entry) => {
+    .map((entry): DecisionEvaluationSource | null => {
       const source = asRecord(entry);
-      return typeof source.materialId === "string" && typeof source.sourceType === "string"
-        ? {
-          materialId: source.materialId,
-          sourceType: source.sourceType,
-          summary: typeof source.summary === "string" ? source.summary : "",
-          effectiveWeight: typeof source.effectiveWeight === "number" ? source.effectiveWeight : 0,
-        }
-        : null;
+      if (typeof source.materialId !== "string" || typeof source.sourceType !== "string") return null;
+      const normalized: DecisionEvaluationSource = {
+        materialId: source.materialId,
+        sourceType: source.sourceType,
+        summary: typeof source.summary === "string" ? source.summary : "",
+        effectiveWeight: typeof source.effectiveWeight === "number" ? source.effectiveWeight : 0,
+      };
+      // Trust-envelope re-verification fields (BI-8192557E phase 2a). Absent on
+      // every row written before they existed — carried through only when the
+      // locator still normalizes, so a malformed one reads as "no locator"
+      // (unverifiable) rather than as a citation the re-verifier can confirm.
+      const locator = normalizeLocator(source.locator);
+      if (locator) normalized.locator = locator;
+      if (typeof source.grade === "string") normalized.grade = source.grade;
+      if (typeof source.optionId === "string") normalized.optionId = source.optionId;
+      if (typeof source.dimensionKey === "string") normalized.dimensionKey = source.dimensionKey;
+      if (typeof source.excerpt === "string" || source.excerpt === null) {
+        normalized.excerpt = source.excerpt as string | null;
+      }
+      return normalized;
     })
     .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
 }

--- a/apps/web/lib/decision-perspective/types.ts
+++ b/apps/web/lib/decision-perspective/types.ts
@@ -231,13 +231,39 @@ export type DecisionPerspectiveEvaluationResult = {
   constitutionalAlignment?: import("./alignment-criteria").ConstitutionalAlignmentResult;
   rationale: string;
   materialScores: PerspectiveMaterialScore[];
-  sources: Array<{
-    materialId: string;
-    sourceType: string;
-    summary: string;
-    effectiveWeight: number;
-  }>;
+  sources: Array<DecisionEvaluationSource>;
   gapReason?: "no-applicable-material" | "material-below-confidence";
+};
+
+/**
+ * One cited source on a recorded decision.
+ *
+ * The first four fields are the original contract (every gate populates them).
+ * The rest are the trust-envelope re-verification fields (BI-8192557E phase 2a):
+ * before them only `sourceType` — a bare string — survived the write, so a
+ * recorded citation could be proven un-tampered-with (via the sealed
+ * `evidenceDigests` hash chain) but never re-resolved against live source. A
+ * digest cannot answer "was this citation ever TRUE"; the structured locator can.
+ *
+ * All five are optional and additive: rows written before this carry none of
+ * them, and their absence must read as UNVERIFIABLE — never as confirmed
+ * (see `recordedCitationsFromSources`).
+ */
+export type DecisionEvaluationSource = {
+  materialId: string;
+  sourceType: string;
+  summary: string;
+  effectiveWeight: number;
+  /** Structured locator, re-resolvable against live source by the re-verifier. */
+  locator?: import("@/lib/deliberation/evidence").StructuredLocator;
+  /** Evidence grade the citation was admitted at (A/B/C; D is inadmissible). */
+  grade?: string;
+  /** The scored option this citation backs. */
+  optionId?: string;
+  /** The scored dimension this citation backs. */
+  dimensionKey?: string;
+  /** The excerpt the score relied on, as recorded at decision time. */
+  excerpt?: string | null;
 };
 
 export type DecisionInteractionGateView = {

--- a/apps/web/lib/decision/evidence-grounding.ts
+++ b/apps/web/lib/decision/evidence-grounding.ts
@@ -275,12 +275,40 @@ export async function buildScoredDecisionOptions(input: {
   );
 }
 
-/** Shape the admissible citations for the DecisionInteraction.sources column. */
+/** Grade → effective weight for the persisted source row. A most conclusive. */
+const GRADE_WEIGHT: Record<string, number> = { A: 1, B: 0.75, C: 0.5, D: 0.25 };
+
+/**
+ * Shape the admissible citations for the DecisionInteraction.sources column.
+ *
+ * BI-8192557E phase 2a: the row now carries the STRUCTURED LOCATOR, not just
+ * `locator.sourceType`. Re-verification (`reverifyCitations`) re-resolves a
+ * locator against live source; a bare sourceType string cannot be re-resolved,
+ * so before this every recorded citation was permanently unverifiable. The
+ * sealed `evidenceDigests` chain proves the record was not tampered with —
+ * a different property from whether the citation was ever true.
+ *
+ * This is the single home for the ledger source shape; the kernel-consult
+ * ledger delegates here rather than re-deriving it.
+ */
 export function citationsToSources(
   citations: AdmissibleCitation[],
-): Array<{ sourceType: string; locator: StructuredLocator; grade: ClaimEvidenceGrade; optionId: string; dimensionKey: string; excerpt: string | null }> {
+): Array<{
+  materialId: string;
+  sourceType: string;
+  summary: string;
+  effectiveWeight: number;
+  locator: StructuredLocator;
+  grade: ClaimEvidenceGrade;
+  optionId: string;
+  dimensionKey: string;
+  excerpt: string | null;
+}> {
   return citations.map((c) => ({
+    materialId: `${c.optionId}:${c.dimensionKey}`,
     sourceType: c.locator.sourceType,
+    summary: c.excerpt ?? `${c.dimensionKey} cited from ${c.locator.sourceType}`,
+    effectiveWeight: GRADE_WEIGHT[c.grade] ?? 0.5,
     locator: c.locator,
     grade: c.grade,
     optionId: c.optionId,

--- a/apps/web/lib/decision/kernel-consult-ledger.ts
+++ b/apps/web/lib/decision/kernel-consult-ledger.ts
@@ -21,10 +21,7 @@ import type {
   DecisionRiskTier,
 } from "@/lib/decision-perspective/types";
 import { sealDecision, type SealablePayload } from "@/lib/decision/decision-chain";
-import type { AdmissibleCitation } from "@/lib/decision/evidence-grounding";
-
-/** Grade → effective weight for the persisted source row. A most conclusive. */
-const GRADE_WEIGHT: Record<string, number> = { A: 1, B: 0.75, C: 0.5, D: 0.25 };
+import { citationsToSources, type AdmissibleCitation } from "@/lib/decision/evidence-grounding";
 
 type ProfileResolverDb = {
   decisionPerspectiveProfile: {
@@ -212,14 +209,12 @@ export async function recordKernelConsultInteraction(input: {
       : [];
 
     // Trust-envelope evidence grounding: bind each cited source onto the ledger
-    // row's `sources` column (was always empty on the kernel path).
-    const sources: DecisionPerspectiveEvaluationResult["sources"] = (input.citations ?? []).map(
-      (c) => ({
-        materialId: `${c.optionId}:${c.dimensionKey}`,
-        sourceType: c.locator.sourceType,
-        summary: c.excerpt ?? `${c.dimensionKey} cited from ${c.locator.sourceType}`,
-        effectiveWeight: GRADE_WEIGHT[c.grade] ?? 0.5,
-      }),
+    // row's `sources` column (was always empty on the kernel path). The row
+    // carries the structured locator (BI-8192557E phase 2a) so the independent
+    // re-verifier can re-resolve it against live source later; without it a
+    // recorded citation is permanently unverifiable.
+    const sources: DecisionPerspectiveEvaluationResult["sources"] = citationsToSources(
+      input.citations ?? [],
     );
 
     const evaluation: DecisionPerspectiveEvaluationResult = {

--- a/apps/web/lib/decision/recorded-citations.test.ts
+++ b/apps/web/lib/decision/recorded-citations.test.ts
@@ -1,0 +1,310 @@
+// End-to-end round-trip for the trust-envelope citation record (BI-8192557E
+// phase 2a). The property under test is NOT "the decoder parses JSON" — it is
+// that a citation recorded by `principle_decide` survives the write, survives
+// the jsonb round-trip, and arrives at `reverifyCitations` in a shape the
+// repo-backed resolver can actually re-resolve against live source.
+//
+// Two failure modes are guarded explicitly:
+//   1. a fabricated-but-well-formed locator (admissible, but never true) must
+//      DEGRADE after the round-trip — persistence must not launder it; and
+//   2. a legacy row with no locator must report as UNVERIFIABLE, never as
+//      confirmed. Absence of evidence is not evidence.
+
+import { describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { citationsToSources, type AdmissibleCitation } from "./evidence-grounding";
+import { recordKernelConsultInteraction } from "./kernel-consult-ledger";
+import { recordedCitationsFromSources } from "./recorded-citations";
+import { reverifyCitations } from "./evidence-reverifier";
+import { createRepoLocatorResolver } from "./locator-resolver";
+import { decisionInteractionRowToEvaluation } from "@/lib/decision-perspective/persistence";
+import type { DecisionResult } from "./option-scoring";
+import type { DecisionCallerContext } from "./caller-context";
+
+const REAL_EXCERPT = 'return "grounded value";';
+
+async function fixtureRepo(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "dpf-recorded-citations-"));
+  await mkdir(join(root, "apps", "web", "lib"), { recursive: true });
+  await writeFile(
+    join(root, "apps", "web", "lib", "real.ts"),
+    ["export function real() {", `  ${REAL_EXCERPT}`, "}", ""].join("\n"),
+    "utf8",
+  );
+  return root;
+}
+
+/**
+ * The jsonb boundary. Prisma stores `sources` as JSON, so anything that does
+ * not survive serialization is not actually persisted — asserting on the
+ * in-memory object would hide exactly the loss this phase exists to fix.
+ */
+function throughJsonb<T>(value: T): unknown {
+  return JSON.parse(JSON.stringify(value));
+}
+
+/** Read the persisted row back the way the audit surface does. */
+function readBackSources(sources: unknown) {
+  return decisionInteractionRowToEvaluation({
+    interactionId: "DI-TEST",
+    profileId: "mark-dpf-platform",
+    profileVersionId: "mark-dpf-platform-v1",
+    sources,
+  }).sources;
+}
+
+const wwmdContext: DecisionCallerContext = {
+  principalId: null,
+  governingProfileId: "mark-dpf-platform",
+  governingProfileKind: "platform",
+  callingPopulation: "external_coding_agent",
+  resolvedVia: "calling-population",
+};
+
+function makeResult(): DecisionResult {
+  return {
+    recommendation: { optionId: "option-a", composite: 4.2, margin: 1.5, confidence: "high" },
+    scores: [{ optionId: "option-a", composite: 4.2, contributions: [] }],
+    flags: {
+      tieMargin: 0.2,
+      semanticFallbackRatio: 0,
+      structuredCoverage: "strong",
+      commandmentConflict: false,
+      commandmentConflictPrinciples: [],
+    },
+    reasoning: "Recommends option-a.",
+  };
+}
+
+function makeDb() {
+  const created: Array<Record<string, unknown>> = [];
+  return {
+    created,
+    decisionPerspectiveProfile: {
+      findUnique: async () => ({ profileId: "mark-dpf-platform", kind: "platform" }),
+    },
+    decisionPerspectiveProfileVersion: {
+      findFirst: async () => ({ versionId: "mark-dpf-platform-v1" }),
+    },
+    decisionInteraction: {
+      create: async (args: { data: Record<string, unknown> }) => {
+        created.push(args.data);
+        return args.data;
+      },
+    },
+  };
+}
+
+function citation(over: Partial<AdmissibleCitation> = {}): AdmissibleCitation {
+  return {
+    optionId: "option-a",
+    dimensionKey: "evidence_density",
+    grade: "B",
+    excerpt: REAL_EXCERPT,
+    locator: { sourceType: "code", filePath: "apps/web/lib/real.ts", line: 2 },
+    ...over,
+  };
+}
+
+describe("recordKernelConsultInteraction — locator persistence", () => {
+  it("writes the structured locator onto the row, not just its sourceType", async () => {
+    const db = makeDb();
+    const outcome = await recordKernelConsultInteraction({
+      db: db as never,
+      result: makeResult(),
+      callerContext: wwmdContext,
+      question: "Which storage approach should we take?",
+      optionIds: ["option-a"],
+      optionDescriptions: { "option-a": "Reuse table" },
+      appliedPrincipleCount: 3,
+      citations: [citation()],
+    });
+
+    expect(outcome.recorded).toBe(true);
+    const [source] = readBackSources(throughJsonb(db.created[0]!.sources));
+    expect(source).toMatchObject({
+      materialId: "option-a:evidence_density",
+      sourceType: "code",
+      locator: { sourceType: "code", filePath: "apps/web/lib/real.ts", line: 2 },
+      grade: "B",
+      optionId: "option-a",
+      dimensionKey: "evidence_density",
+      excerpt: REAL_EXCERPT,
+    });
+  });
+
+  it("keeps the pre-existing source fields intact (additive, not a replacement)", async () => {
+    const db = makeDb();
+    await recordKernelConsultInteraction({
+      db: db as never,
+      result: makeResult(),
+      callerContext: wwmdContext,
+      question: "q",
+      optionIds: ["option-a"],
+      optionDescriptions: {},
+      appliedPrincipleCount: 1,
+      citations: [citation({ grade: "A" })],
+    });
+    const [source] = readBackSources(throughJsonb(db.created[0]!.sources));
+    expect(source!.summary).toBe(REAL_EXCERPT);
+    expect(source!.effectiveWeight).toBe(1);
+  });
+
+  it("does not change what the hash chain seals", async () => {
+    const db = makeDb();
+    await recordKernelConsultInteraction({
+      db: db as never,
+      result: makeResult(),
+      callerContext: wwmdContext,
+      question: "q",
+      optionIds: ["option-a"],
+      optionDescriptions: {},
+      appliedPrincipleCount: 1,
+      citations: [citation()],
+      evidenceDigests: { "option-a": { evidence_density: "digest-1" } },
+      now: new Date("2026-08-15T00:00:00.000Z"),
+    });
+    // The seal covers criteria + evidence digests; `sources` is deliberately
+    // outside it, so widening the source row must not disturb the chain.
+    const row = db.created[0]!;
+    expect(row.chainEntryHash).toEqual(expect.any(String));
+    expect(JSON.stringify(row.sources)).not.toContain(row.chainEntryHash as string);
+  });
+});
+
+describe("recordedCitationsFromSources", () => {
+  it("round-trips a persisted locator into a confirmed re-verification", async () => {
+    const repoRoot = await fixtureRepo();
+    const persisted = throughJsonb(citationsToSources([citation()]));
+
+    const { citations, unverifiable, whollyUnverifiable } = recordedCitationsFromSources(
+      readBackSources(persisted),
+    );
+    expect(unverifiable).toEqual([]);
+    expect(whollyUnverifiable).toBe(false);
+    expect(citations).toHaveLength(1);
+
+    const report = await reverifyCitations(citations, createRepoLocatorResolver({ repoRoot }));
+    expect(report.allConfirmed).toBe(true);
+    expect(report.confirmed).toBe(1);
+    expect(report.degrade).toEqual([]);
+  });
+
+  it("degrades a fabricated-but-well-formed locator that survived the write", async () => {
+    const repoRoot = await fixtureRepo();
+    const fabricated = citation({
+      // Normalizes cleanly and passes admissibility — and does not exist.
+      locator: { sourceType: "code", filePath: "apps/web/lib/invented.ts", line: 2 },
+    });
+    const persisted = throughJsonb(citationsToSources([fabricated]));
+
+    const { citations } = recordedCitationsFromSources(readBackSources(persisted));
+    const report = await reverifyCitations(citations, createRepoLocatorResolver({ repoRoot }));
+
+    expect(report.allConfirmed).toBe(false);
+    expect(report.results[0]!.verdict).toBe("unresolved");
+    expect(report.degrade).toEqual([{ optionId: "option-a", dimensionKey: "evidence_density" }]);
+  });
+
+  it("degrades a real file that never contained the recorded excerpt", async () => {
+    const repoRoot = await fixtureRepo();
+    const persisted = throughJsonb(
+      citationsToSources([citation({ excerpt: "return \"a value never written\";" })]),
+    );
+
+    const { citations } = recordedCitationsFromSources(readBackSources(persisted));
+    const report = await reverifyCitations(citations, createRepoLocatorResolver({ repoRoot }));
+
+    expect(report.results[0]!.verdict).toBe("degraded");
+    expect(report.allConfirmed).toBe(false);
+  });
+
+  it("reports a legacy row (no locator) as unverifiable, never as verified", async () => {
+    // Exactly the shape every row on the live install carries today: the four
+    // original fields and nothing else.
+    const legacy = readBackSources([
+      {
+        materialId: "mark-dpf-platform:never-fabricate",
+        sourceType: "principle",
+        summary: "Never fabricate.",
+        effectiveWeight: 1,
+      },
+    ]);
+
+    const { citations, unverifiable, whollyUnverifiable } = recordedCitationsFromSources(legacy);
+    expect(citations).toEqual([]);
+    expect(unverifiable).toEqual([
+      {
+        materialId: "mark-dpf-platform:never-fabricate",
+        sourceType: "principle",
+        reason: "no-locator",
+      },
+    ]);
+    expect(whollyUnverifiable).toBe(true);
+
+    // And the re-verifier must not read "nothing to check" as "all confirmed".
+    const report = await reverifyCitations(citations, async () => ({
+      resolved: true,
+      liveExcerpt: "anything",
+    }));
+    expect(report.allConfirmed).toBe(false);
+  });
+
+  it("rejects a locator that no longer normalizes rather than passing it through", () => {
+    const { citations, unverifiable } = recordedCitationsFromSources([
+      {
+        materialId: "option-a:evidence_density",
+        sourceType: "code",
+        summary: "x",
+        effectiveWeight: 0.5,
+        // A `code` locator with no filePath cannot be re-resolved. Handing it to
+        // a resolver would let a permissive one decide; fail closed here instead.
+        locator: { sourceType: "code" } as never,
+      },
+    ]);
+    expect(citations).toEqual([]);
+    expect(unverifiable[0]!.reason).toBe("malformed-locator");
+  });
+
+  it("recovers the (option, dimension) binding from materialId when the explicit fields are absent", () => {
+    const { citations } = recordedCitationsFromSources([
+      {
+        materialId: "option-b:blast_radius",
+        sourceType: "spec",
+        summary: "x",
+        effectiveWeight: 0.5,
+        locator: { sourceType: "spec", path: "docs/spec.md" },
+      },
+    ]);
+    expect(citations[0]).toMatchObject({ optionId: "option-b", dimensionKey: "blast_radius" });
+  });
+
+  it("refuses a citation with no attributable (option, dimension) pair", () => {
+    const { citations, unverifiable } = recordedCitationsFromSources([
+      {
+        materialId: "unbound",
+        sourceType: "doc",
+        summary: "x",
+        effectiveWeight: 0.5,
+        locator: { sourceType: "doc", path: "docs/thing.md" },
+      },
+    ]);
+    // Re-verification reports degrades per (option, dimension); a verdict that
+    // cannot name its pair could never be acted on, so it is not a citation.
+    expect(citations).toEqual([]);
+    expect(unverifiable[0]!.reason).toBe("no-dimension-binding");
+  });
+
+  it("yields nothing for a row with no sources, and that still cannot read as confirmed", async () => {
+    // `whollyUnverifiable` is about recorded-but-opaque evidence; a row with no
+    // sources at all has none to be opaque. The fail-closed guarantee for that
+    // case lives downstream: an empty report is never `allConfirmed`.
+    expect(recordedCitationsFromSources([]).whollyUnverifiable).toBe(false);
+    expect(recordedCitationsFromSources(null).citations).toEqual([]);
+    const report = await reverifyCitations([], async () => ({ resolved: true, liveExcerpt: "x" }));
+    expect(report.allConfirmed).toBe(false);
+  });
+});

--- a/apps/web/lib/decision/recorded-citations.ts
+++ b/apps/web/lib/decision/recorded-citations.ts
@@ -1,0 +1,123 @@
+// Read side of the trust-envelope citation record (BI-8192557E phase 2a).
+//
+// `citationsToSources` writes the structured locator onto
+// DecisionInteraction.sources; this module reads it back into the
+// `RecordedCitation[]` shape `reverifyCitations` consumes. It is a pure
+// decoder — it resolves nothing and verifies nothing, so it carries no
+// separation-of-duties concern: the independent verification pass (phase 2b)
+// supplies its own resolver.
+//
+// FAIL-CLOSED IS THE WHOLE POINT. Of the decision rows on a live install
+// today, none carry a locator — they predate the write. A row with no
+// locator must be reported as UNVERIFIABLE, never folded into the verified
+// set and never counted as a confirmation. So a source without a
+// re-resolvable locator is split out into `unverifiable` rather than being
+// dropped silently (which would let "0 citations, 0 failures" read as clean)
+// or emitted as a citation with an empty locator (which would let the
+// re-verifier's own resolver decide, and a permissive resolver would confirm it).
+
+import type { RecordedCitation } from "@/lib/decision/evidence-reverifier";
+import { normalizeLocator } from "@/lib/deliberation/evidence";
+import type { DecisionEvaluationSource } from "@/lib/decision-perspective/types";
+
+/** Why a recorded source cannot be handed to the re-verifier. */
+export type UnverifiableReason =
+  /** Row predates locator persistence, or the gate never recorded one. */
+  | "no-locator"
+  /** A locator is present but no longer normalizes to a StructuredLocator. */
+  | "malformed-locator"
+  /** No (option, dimension) binding, so a degrade could not be attributed. */
+  | "no-dimension-binding";
+
+export type UnverifiableSource = {
+  materialId: string;
+  sourceType: string;
+  reason: UnverifiableReason;
+};
+
+export type RecordedCitationSet = {
+  /** Sources that carry everything re-resolution needs. */
+  citations: RecordedCitation[];
+  /** Sources that do NOT — explicitly unverifiable, never treated as verified. */
+  unverifiable: UnverifiableSource[];
+  /**
+   * True when at least one source was recorded and NONE of them can be
+   * re-verified — i.e. the decision's evidence is opaque to Axis 4. Callers
+   * must not present such a decision as re-verified.
+   */
+  whollyUnverifiable: boolean;
+};
+
+/**
+ * Decode a decision's recorded `sources` into re-verifiable citations plus an
+ * explicit unverifiable remainder.
+ *
+ * A source qualifies only when it carries a normalizable `StructuredLocator`
+ * AND the (optionId, dimensionKey) binding a degrade verdict attaches to —
+ * `reverifyCitations` reports degrades per (option, dimension), so a citation
+ * that cannot name its pair could be checked but never acted on.
+ */
+export function recordedCitationsFromSources(
+  sources: DecisionEvaluationSource[] | null | undefined,
+): RecordedCitationSet {
+  const citations: RecordedCitation[] = [];
+  const unverifiable: UnverifiableSource[] = [];
+
+  for (const source of sources ?? []) {
+    const identity = { materialId: source.materialId, sourceType: source.sourceType };
+
+    if (source.locator === undefined || source.locator === null) {
+      unverifiable.push({ ...identity, reason: "no-locator" });
+      continue;
+    }
+    // Re-normalize rather than trusting the stored shape: `sources` is jsonb, so
+    // the persisted value is whatever was written, including by an older or
+    // hand-edited writer.
+    const locator = normalizeLocator(source.locator);
+    if (!locator) {
+      unverifiable.push({ ...identity, reason: "malformed-locator" });
+      continue;
+    }
+
+    const { optionId, dimensionKey } = resolveBinding(source);
+    if (!optionId || !dimensionKey) {
+      unverifiable.push({ ...identity, reason: "no-dimension-binding" });
+      continue;
+    }
+
+    citations.push({
+      optionId,
+      dimensionKey,
+      locator,
+      recordedExcerpt: source.excerpt ?? null,
+    });
+  }
+
+  return {
+    citations,
+    unverifiable,
+    whollyUnverifiable: citations.length === 0 && unverifiable.length > 0,
+  };
+}
+
+/**
+ * Recover the (option, dimension) pair. Explicit fields win; otherwise fall back
+ * to the `materialId` convention the ledger writes (`${optionId}:${dimensionKey}`),
+ * which is the only binding rows written before the explicit fields carry.
+ */
+function resolveBinding(source: DecisionEvaluationSource): {
+  optionId: string | null;
+  dimensionKey: string | null;
+} {
+  if (source.optionId && source.dimensionKey) {
+    return { optionId: source.optionId, dimensionKey: source.dimensionKey };
+  }
+  const separator = source.materialId.indexOf(":");
+  if (separator <= 0 || separator === source.materialId.length - 1) {
+    return { optionId: null, dimensionKey: null };
+  }
+  return {
+    optionId: source.materialId.slice(0, separator),
+    dimensionKey: source.materialId.slice(separator + 1),
+  };
+}

--- a/docs/superpowers/plans/2026-08-15-wire-evidence-reverifier-plan.md
+++ b/docs/superpowers/plans/2026-08-15-wire-evidence-reverifier-plan.md
@@ -37,7 +37,7 @@ principle_decide (lib/mcp/packs/principle-decide-pack.ts)
   → DecisionInteraction.sources (jsonb)   // admissible citations, sealed into the hash chain
 ```
 
-So citations are already persisted per (optionId, dimensionKey) with their locator and excerpt. The re-verifier reads that record — it does not need new storage.
+So citations are persisted per (optionId, dimensionKey), and the re-verifier reads that record rather than needing new storage. ⟦corrected in phase 2a: the *locator* was NOT among the persisted fields — see §3 Phase 2. Only the widening below made this true.⟧
 
 **Independence is the contract.** The verifier must not run inside the scoring call: `evidence-reverifier.ts` specifies a pass with no access to the original scorer's reasoning, mirroring `lib/build/verified-finding-review.ts` (which is exposed via `lib/mcp-tools.ts`). Wiring it into `principle_decide` itself would destroy the separation-of-duties property that makes it meaningful.
 
@@ -73,6 +73,22 @@ Phase 2 therefore splits:
 - **2a — persist the structured locator** alongside the existing summary (additive; migration-safe), so a recorded decision carries what re-resolution needs. Without this, phases 2b/3 have nothing to verify.
 - **2b — independent verification surface.** Load the decision's citations, run `reverifyCitations` with the repo resolver, return the report, and record degraded (option, dimension) pairs. Follows the `verified-finding-review` exposure pattern; an MCP tool carries the known grant/gate cascade (`TOOL_TO_GRANTS` entry required, or the tool is denied).
 
+#### Phase 2a — SHIPPED (this PR)
+
+**No migration.** `DecisionInteraction.sources` is already `Json @default("[]")`, so the locator is carried as additional keys on each source entry. Nothing is tightened, nothing is backfilled, and the change applies against any existing data state because existing rows simply lack the new keys.
+
+**Write.** `citationsToSources` (`lib/decision/evidence-grounding.ts`) becomes the single home for the ledger source shape and now emits `locator`, `grade`, `optionId`, `dimensionKey` and `excerpt` alongside the original `materialId` / `sourceType` / `summary` / `effectiveWeight`. It had been an unused export duplicating a shape the ledger re-derived inline; `kernel-consult-ledger.ts` now delegates to it (and `GRADE_WEIGHT` moved with it) rather than mapping citations itself.
+
+**What is sealed is unchanged.** `SealablePayload` covers `{question, optionIds, criteria, evidenceDigests, recommendedOptionId, composite}`. `sources` was never inside it, so widening the source row does not touch the append-only chain — asserted directly in `recorded-citations.test.ts`.
+
+**Read.** `normalizeSources` (`lib/decision-perspective/persistence.ts`) carries the new keys through, re-running `normalizeLocator` rather than trusting the stored shape: `sources` is jsonb, so the persisted value is whatever some writer put there. A locator that no longer normalizes is dropped to "no locator", never passed through as a checkable citation.
+
+**Decode.** `lib/decision/recorded-citations.ts` — `recordedCitationsFromSources(sources)` returns `{ citations, unverifiable, whollyUnverifiable }`. A pure decoder: it resolves nothing, so it carries no separation-of-duties concern and is **not** wired into `principle_decide`; phase 2b supplies its own resolver.
+
+**Fail-closed, concretely.** A source without a re-resolvable locator is split into `unverifiable` with a reason (`no-locator` for every row on the install today, `malformed-locator`, `no-dimension-binding`) rather than dropped silently — dropping would let "0 citations, 0 failures" read as clean. `reverifyCitations` already refuses to report `allConfirmed` on an empty result set, so an all-legacy decision cannot present as re-verified.
+
+**Not yet closed:** nothing *calls* `recordedCitationsFromSources` in production — that is phase 2b, by design. And a locator only reaches the record when a caller supplies `evidence` to `principle_decide`; phase 2a makes an evidenced call re-verifiable, it does not make callers cite.
+
 ### Phase 3 — degrade feeds Axis 1
 A degraded pair drops the affected dimension to unevidenced on re-scoring, and the decision is flagged. This is what closes the loop with `evidence-grounding.ts`.
 
@@ -84,6 +100,8 @@ A degraded pair drops the affected dimension to unevidenced on re-scoring, and t
 
 ## 5. Verification
 
-- Unit: `pnpm --filter web exec vitest run lib/decision/locator-resolver.test.ts`.
+- Unit: `pnpm --filter web exec vitest run lib/decision/locator-resolver.test.ts` (phase 1) and `lib/decision/recorded-citations.test.ts` (phase 2a).
 - Production build: `pnpm --filter web build`.
-- No UI surface in phase 1, so no UX verification path; no migration.
+- No UI surface in phase 1 or 2a, so no UX verification path; no migration in either.
+
+Phase 2a's round-trip test is deliberately end-to-end rather than a decoder unit test: it drives a real `recordKernelConsultInteraction` write, pushes the row through `JSON.parse(JSON.stringify(...))` (the jsonb boundary — anything that does not survive serialization is not actually persisted), reads it back through `decisionInteractionRowToEvaluation`, and re-verifies with the real repo resolver against a temp checkout. It asserts a genuine citation confirms, a fabricated-but-well-formed one degrades, a real file lacking the recorded excerpt degrades, and a legacy four-field row reports `unverifiable` rather than confirmed.


### PR DESCRIPTION
## The gap

`apps/web/lib/decision/evidence-reverifier.ts` re-resolves a recorded `StructuredLocator` against live source and degrades the affected dimension when a citation no longer holds. Its repo-backed resolver shipped in #4324. **Neither could run on any decision this platform has ever recorded**, because the locator was discarded at write time.

`kernel-consult-ledger.ts` mapped each admissible citation down to `{ materialId, sourceType, summary, effectiveWeight }` — only the sourceType *string* survived. `filePath`, `line`, `commit`, `path`, `heading` were dropped.

`evidenceDigests` seals a hash into the append-only chain, which proves the record was not **tampered with**. A digest cannot be re-resolved against source, so it cannot prove the citation was ever **true**. Different properties; only the first existed.

## What changed

**No migration.** `DecisionInteraction.sources` is already `Json @default("[]")`, so the locator rides as additional keys. Nothing is tightened or backfilled; existing rows simply lack the new keys.

- **Write** — `citationsToSources` (`evidence-grounding.ts`) was an unused export duplicating a shape the ledger re-derived inline. It becomes the single home for the source row and now emits `locator` / `grade` / `optionId` / `dimensionKey` / `excerpt` alongside the original four fields; the ledger delegates to it (`GRADE_WEIGHT` moved with it).
- **Seal untouched** — `SealablePayload` covers `{question, optionIds, criteria, evidenceDigests, recommendedOptionId, composite}`; `sources` was never inside it. Asserted directly in the test.
- **Read** — `normalizeSources` re-runs `normalizeLocator` rather than trusting the stored shape (`sources` is jsonb — the value is whatever some writer put there).
- **Decode** — new `lib/decision/recorded-citations.ts`: `recordedCitationsFromSources(sources)` → `{ citations, unverifiable, whollyUnverifiable }`.

## Fail-closed, concretely

A source without a re-resolvable locator is split into `unverifiable` with a reason (`no-locator` / `malformed-locator` / `no-dimension-binding`) rather than dropped — dropping would let "0 citations, 0 failures" read as clean. Every row on the install today lands there as `no-locator`. `reverifyCitations` already refuses `allConfirmed` on an empty result set, so an all-legacy decision cannot present as re-verified.

## Separation of duties

The decoder is pure and **nothing calls it in production yet** — the independent verification surface is phase 2b, by design. Wiring verification into `principle_decide` would destroy the property that makes it mean anything. Verifier identity stays an audit field, never a gate input.

Phase 2a makes an evidenced call re-verifiable; it does not make callers cite.

## Verification

- `pnpm --filter web exec vitest run lib/decision lib/decision-perspective` — green (304 tests).
- `pnpm --filter web build` — green.
- `pnpm run pregate` — gate passed (evidence `cmsv2xxpg017i01rrci9uki7i`, sha `ec3dbc220650`).

The round-trip test is deliberately end-to-end rather than a decoder unit test: it drives a real `recordKernelConsultInteraction` write, pushes the row through `JSON.parse(JSON.stringify(...))` (the jsonb boundary — anything that does not survive serialization is not actually persisted), reads it back through `decisionInteractionRowToEvaluation`, and re-verifies with the real repo resolver against a temp checkout. A true citation confirms; a fabricated-but-well-formed one degrades; a real file lacking the recorded excerpt degrades; a legacy four-field row reports unverifiable.

Plan updated in the same PR: `docs/superpowers/plans/2026-08-15-wire-evidence-reverifier-plan.md` (§3 Phase 2a, §5, plus a correction to §2 which claimed the locator was already persisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)