### PR TITLE
fix(coworker): clamp convening a peer to the asking human's clearance

### DIFF
--- a/apps/web/lib/tak/convene-clearance.test.ts
+++ b/apps/web/lib/tak/convene-clearance.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import {
+  decideConveneClearance,
+  conveneDenialAuditReason,
+  CONVENE_DENIED_MESSAGE,
+} from "./convene-clearance";
+
+const ALL = ["public", "internal", "confidential", "restricted"];
+
+describe("decideConveneClearance", () => {
+  it("permits an ordinary specialist for an ordinary employee", () => {
+    expect(
+      decideConveneClearance({
+        askingHumanClearance: ["public", "internal"],
+        targetAgentSensitivity: "internal",
+      }),
+    ).toEqual({ permitted: true });
+  });
+
+  it("refuses a confidential peer to an internal-only human — the layoff case", () => {
+    expect(
+      decideConveneClearance({
+        askingHumanClearance: ["public", "internal"],
+        targetAgentSensitivity: "confidential",
+      }),
+    ).toEqual({ permitted: false, reason: "insufficient-clearance" });
+  });
+
+  it("refuses a restricted peer — the M&A case", () => {
+    expect(
+      decideConveneClearance({
+        askingHumanClearance: ["public", "internal", "confidential"],
+        targetAgentSensitivity: "restricted",
+      }),
+    ).toEqual({ permitted: false, reason: "insufficient-clearance" });
+  });
+
+  it("permits when the human holds every level", () => {
+    for (const level of ALL) {
+      expect(
+        decideConveneClearance({ askingHumanClearance: ALL, targetAgentSensitivity: level }),
+      ).toEqual({ permitted: true });
+    }
+  });
+
+  it("is SET MEMBERSHIP, not rank — a gap in the middle still denies", () => {
+    // Mirrors the tool gate's `.includes()` exactly. A rank comparison would
+    // wrongly permit this and let a convene succeed where every subsequent tool
+    // call is denied.
+    expect(
+      decideConveneClearance({
+        askingHumanClearance: ["public", "internal", "restricted"],
+        targetAgentSensitivity: "confidential",
+      }),
+    ).toEqual({ permitted: false, reason: "insufficient-clearance" });
+  });
+
+  it("FAILS CLOSED on an unlabelled coworker", () => {
+    for (const value of [null, undefined, "", "not-a-level"]) {
+      expect(
+        decideConveneClearance({ askingHumanClearance: ALL.slice(0, 3), targetAgentSensitivity: value }),
+      ).toEqual({ permitted: false, reason: "insufficient-clearance" });
+    }
+  });
+
+  it("fails closed on an empty clearance list", () => {
+    expect(
+      decideConveneClearance({ askingHumanClearance: [], targetAgentSensitivity: "public" }),
+    ).toEqual({ permitted: false, reason: "insufficient-clearance" });
+  });
+});
+
+describe("CONVENE_DENIED_MESSAGE", () => {
+  // The refusal is load-bearing for disclosure. A refusal that names the peer,
+  // the level, or the subject — or that proposes "ask an admin for confidential
+  // clearance" per the limitation-response contract — discloses the very thing
+  // the clamp exists to protect.
+  it("names no sensitivity level", () => {
+    for (const level of ALL) {
+      expect(CONVENE_DENIED_MESSAGE.toLowerCase()).not.toContain(level);
+    }
+  });
+
+  it("names no peer, role, or subject and proposes no clearance enabler", () => {
+    for (const leak of ["hr", "layoff", "merger", "acquisition", "clearance", "permission", "authority", "admin"]) {
+      expect(CONVENE_DENIED_MESSAGE.toLowerCase()).not.toContain(leak);
+    }
+  });
+
+  it("does not reveal that a restricted matter exists", () => {
+    for (const leak of ["confidential", "restricted", "not allowed", "denied", "cleared"]) {
+      expect(CONVENE_DENIED_MESSAGE.toLowerCase()).not.toContain(leak);
+    }
+  });
+
+  it("still offers a way forward, so it is a refusal and not a dead end", () => {
+    expect(CONVENE_DENIED_MESSAGE).toMatch(/help with what I can see myself/);
+  });
+});
+
+describe("conveneDenialAuditReason", () => {
+  it("keeps the specifics for the audit row, which the user never sees", () => {
+    const reason = conveneDenialAuditReason({
+      targetAgentId: "AGT-HR-001",
+      requiredSensitivity: "confidential",
+    });
+    expect(reason).toContain("AGT-HR-001");
+    expect(reason).toContain("confidential");
+  });
+
+  it("is not the string shown to the user", () => {
+    expect(
+      conveneDenialAuditReason({ targetAgentId: "AGT-HR-001", requiredSensitivity: "confidential" }),
+    ).not.toEqual(CONVENE_DENIED_MESSAGE);
+  });
+});

--- a/apps/web/lib/tak/convene-clearance.ts
+++ b/apps/web/lib/tak/convene-clearance.ts
@@ -1,0 +1,84 @@
+// apps/web/lib/tak/convene-clearance.ts
+//
+// BI-154DAA7E: clamp a CONVENE to the asking human's clearance.
+//
+// What was already enforced, so this is not mistaken for a second copy of it:
+// every governed coworker TOOL CALL is already an intersection of the asking
+// human's clearance with the acting agent's data sensitivity —
+// `coworker-authority-decision.ts` denies `sensitivity-clearance-denied` when
+// `authContext.sensitivityClearance` does not include `dataPolicy.sensitivity`,
+// with authContext resolved from the requesting user and `actingAgentId` set.
+//
+// Two gaps that gate leaves open, both on the CONVENING side rather than the
+// tool side:
+//
+//  1. The conversational channel is not a tool call. A peer brought into a
+//     thread composes prose from its own model context — system prompt,
+//     working notes, profession corpus, its own earlier turns. The tool gate
+//     inspects tool arguments and results; it cannot inspect generated text.
+//     Disclosure does not need a tool: "you may want to hold off on that hire"
+//     leaks without one.
+//  2. Nothing stops the convene itself. `enforceHandoffAuthority` gates only on
+//     the caller agent's delegatesTo/escalatesTo. A peer classified above the
+//     asking human's clearance can therefore be admitted, generate prose, and
+//     have only its tool calls denied — a half-participating coworker that is
+//     both confusing and leaky.
+//
+// Refusing at the convene is the cheaper and more honest fix: an over-cleared
+// peer is never in the room, so there is no prose channel to police. The tool
+// gate stays as defence in depth behind it.
+import { coerceDataSensitivity, type PrincipalSensitivity } from "@dpf/db/principal-sensitivity";
+
+export type ConveneClearanceDecision =
+  | { permitted: true }
+  | { permitted: false; reason: "insufficient-clearance" };
+
+/**
+ * May this human have this coworker convened into their conversation?
+ *
+ * Mirrors the tool gate's test exactly — set membership of the agent's
+ * sensitivity in the human's clearance list, NOT a rank comparison. Clearance
+ * is a set of granted levels, so a principal holding {public, internal,
+ * restricted} but not "confidential" is denied a confidential peer. Diverging
+ * to a rank comparison here would silently widen access relative to the tool
+ * gate and let a convene succeed where every subsequent tool call is denied.
+ *
+ * Unknown/absent agent sensitivity coerces to "restricted" (fail closed) via
+ * `coerceDataSensitivity`, so a misconfigured or unlabelled coworker is never
+ * convened by default rather than being treated as public.
+ */
+export function decideConveneClearance(input: {
+  askingHumanClearance: readonly string[];
+  targetAgentSensitivity: string | null | undefined;
+}): ConveneClearanceDecision {
+  const required: PrincipalSensitivity = coerceDataSensitivity(input.targetAgentSensitivity);
+  return input.askingHumanClearance.includes(required)
+    ? { permitted: true }
+    : { permitted: false, reason: "insufficient-clearance" };
+}
+
+/**
+ * The operator-facing refusal.
+ *
+ * This string is load-bearing for disclosure, not just tone. The platform's
+ * limitation-response contract tells a blocked coworker to name the ONE thing
+ * that would unblock it and ask for a yes/no — which is exactly the wrong
+ * instinct here: "ask an admin to grant you confidential clearance" reveals
+ * that a restricted matter exists and hints at its class. A refusal that
+ * discloses is not a refusal.
+ *
+ * So this message names no peer, no role, no sensitivity level, and no subject,
+ * and it proposes no enabler. It is deliberately indistinguishable from "no
+ * such specialist is available", which is the only shape that leaks nothing.
+ */
+export const CONVENE_DENIED_MESSAGE =
+  "I can't bring anyone else in on this one. Let me help with what I can see myself, " +
+  "or you can raise it with your manager if you think someone else should be involved.";
+
+/** Audit-side reason. Never rendered to the asking human — see the message above. */
+export function conveneDenialAuditReason(p: {
+  targetAgentId: string;
+  requiredSensitivity: string;
+}): string {
+  return `convene of ${p.targetAgentId} denied: asking human's clearance does not include ${p.requiredSensitivity}`;
+}

--- a/apps/web/lib/tak/coworker-collaboration.ts
+++ b/apps/web/lib/tak/coworker-collaboration.ts
@@ -22,7 +22,21 @@ import { agentEventBus } from "@/lib/agent-event-bus";
 import { resolveAgent } from "@/lib/tak/agent-resolution";
 import { spawnWorkThread } from "@/lib/actions/agent-coworker";
 import { isHandoffPermitted } from "@/lib/tak/collaboration-authority";
+import { coerceDataSensitivity } from "@dpf/db/principal-sensitivity";
+import {
+  decideConveneClearance,
+  conveneDenialAuditReason,
+  CONVENE_DENIED_MESSAGE,
+} from "./convene-clearance";
 import type { CollaborationProvenance } from "@/lib/tak/conversation-participants-core";
+
+/** Raised when a convene is refused because the peer outranks the asking human's clearance. */
+export class ConveneDeniedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConveneDeniedError";
+  }
+}
 
 /** Raised when a coworker-initiated handoff is denied by delegation authority. */
 export class HandoffDeniedError extends Error {
@@ -147,7 +161,51 @@ export type SummonCoworkerInput = {
   routeContext?: string;
 };
 
-async function resolveTargetOrThrow(targetAgent: string) {
+/**
+ * BI-154DAA7E: refuse to convene a peer classified above the asking human's
+ * clearance. Placed in the shared target resolver rather than at each call site
+ * so a future third convene path inherits it instead of forgetting it.
+ *
+ * The default for a user with no linked principal mirrors the established
+ * precedent in `workspace-room-access.ts` (`["public", "internal"]`) rather
+ * than inventing a stricter or looser one — so an unlinked user can still reach
+ * ordinary specialists but never a confidential or restricted peer.
+ */
+async function enforceConveneClearance(
+  target: { agentId: string; slugId: string | null },
+  userId: string,
+): Promise<void> {
+  const [agentRow, alias] = await Promise.all([
+    prisma.agent.findFirst({
+      where: { OR: [{ agentId: target.agentId }, { slugId: target.agentId }] },
+      select: { sensitivity: true },
+    }),
+    prisma.principalAlias.findFirst({
+      where: { aliasType: "user", aliasValue: userId, issuer: "" },
+      include: { principal: { select: { sensitivityClearance: true } } },
+    }),
+  ]);
+
+  const decision = decideConveneClearance({
+    askingHumanClearance: alias?.principal.sensitivityClearance ?? ["public", "internal"],
+    targetAgentSensitivity: agentRow?.sensitivity,
+  });
+  if (decision.permitted) return;
+
+  await recordDelegationHop({
+    fromAgentId: target.agentId,
+    toAgentId: target.agentId,
+    status: "blocked",
+    reason: conveneDenialAuditReason({
+      targetAgentId: target.agentId,
+      requiredSensitivity: coerceDataSensitivity(agentRow?.sensitivity),
+    }),
+    originUserId: userId,
+  });
+  throw new ConveneDeniedError(CONVENE_DENIED_MESSAGE);
+}
+
+async function resolveTargetOrThrow(targetAgent: string, userId: string) {
   const target = await resolveAgent(targetAgent);
   if (!target) throw new Error(`UNKNOWN_AGENT: ${targetAgent}`);
   // Lifecycle gate (EP-COWORKER-LIFECYCLE Phase 3): a draft/retired coworker —
@@ -158,6 +216,12 @@ async function resolveTargetOrThrow(targetAgent: string) {
   if (!verdict.allowed) {
     throw new Error(`COWORKER_NOT_SUMMONABLE: ${verdict.reason}`);
   }
+
+  // BI-154DAA7E: disclosure clamp. Runs AFTER the lifecycle gate so an
+  // unsummonable coworker still reports as unsummonable rather than as a
+  // clearance refusal, which would let the generic refusal hint at a
+  // restricted matter that does not exist.
+  await enforceConveneClearance(target, userId);
   return target;
 }
 
@@ -171,7 +235,7 @@ export async function requestCoworker(
 ): Promise<CollaborationResult> {
   const objective = input.objective?.trim();
   if (!objective) throw new Error("OBJECTIVE_REQUIRED");
-  const target = await resolveTargetOrThrow(input.targetAgent);
+  const target = await resolveTargetOrThrow(input.targetAgent, userId);
 
   // Slice 2: enforce the caller's declared delegatesTo / escalatesTo before any
   // child thread is spawned. Throws HandoffDeniedError (and records a blocked
@@ -237,7 +301,7 @@ export async function summonCoworker(
 ): Promise<CollaborationResult> {
   const objective = input.objective?.trim();
   if (!objective) throw new Error("OBJECTIVE_REQUIRED");
-  const target = await resolveTargetOrThrow(input.targetAgent);
+  const target = await resolveTargetOrThrow(input.targetAgent, userId);
 
   const { child, taskRunId } = await spawnWorkThread(
     {

--- a/docs/superpowers/specs/2026-08-15-coworker-escalation-ladder-design.md
+++ b/docs/superpowers/specs/2026-08-15-coworker-escalation-ladder-design.md
@@ -120,6 +120,64 @@ every surface, or the platform ships three COOs.
 the question's intent does not match the route-bound specialist's area, rather
 than relying on the coworker to notice. Follow-on.
 
+## 4a. Rung 3 is clamped to the asking human's clearance (BI-154DAA7E)
+
+Making convening the default path raises a disclosure question the ladder did
+not create but did make routine: when a coworker brings a peer into a
+conversation, what may that peer say to the human sitting in it?
+
+**What was already enforced.** Every governed coworker *tool call* is already an
+intersection of the asking human's clearance with the acting agent's data
+sensitivity. `coworker-authority-decision.ts` denies `sensitivity-clearance-denied`
+when `authContext.sensitivityClearance` does not include
+`dataPolicy.sensitivity`, with `authContext` resolved from the requesting user
+and `actingAgentId` set. That check is unconditional and in the main decision
+path. An early reading of this gap as "nothing clamps a convened peer" was
+wrong: the clamp lives one layer below `coworker-collaboration.ts`, at the gate
+every governed call passes through.
+
+**What that gate structurally cannot cover.** It inspects tool arguments and
+results. It does not inspect *prose*. A peer convened into a thread composes its
+reply from its own model context — system prompt, working notes, profession
+corpus, its own earlier turns — and disclosure does not require a tool call:
+*"you may want to hold off on that hire"* leaks without one.
+
+**The fix is to refuse earlier, not to police the text.** An over-cleared peer
+that is never admitted has no prose channel to inspect.
+`decideConveneClearance` (`apps/web/lib/tak/convene-clearance.ts`) is called
+from `resolveTargetOrThrow`, the shared chokepoint behind both
+`request_coworker` and `summon_coworker`, so a future third convene path
+inherits the clamp instead of forgetting it. The tool gate remains behind it as
+defence in depth.
+
+Three details are load-bearing:
+
+- **Set membership, not rank.** The test mirrors the tool gate's `.includes()`
+  exactly. A rank comparison would permit a human holding
+  `{public, internal, restricted}` to convene a `confidential` peer, producing a
+  convene that succeeds while every subsequent tool call is denied.
+- **Fails closed.** An unlabelled or unrecognised agent sensitivity coerces to
+  `restricted` via `coerceDataSensitivity`, so a misconfigured coworker is not
+  convened by default.
+- **The refusal must not disclose.** This is where the clamp collides with the
+  limitation-response contract, which tells a blocked coworker to name the one
+  enabler and ask for a yes/no. Here that instinct is the leak: *"ask an admin
+  to grant you confidential clearance"* reveals that a restricted matter exists
+  and hints at its class. `CONVENE_DENIED_MESSAGE` therefore names no peer,
+  role, level, or subject and proposes no enabler — it is deliberately
+  indistinguishable from "no such specialist is available". The specifics go to
+  the `DelegationChain` audit row, which the asking human never sees.
+
+Ordering matters: the clamp runs *after* the lifecycle gate, so an unsummonable
+coworker still reports as unsummonable rather than as a clearance refusal —
+otherwise the generic refusal would imply a restricted matter that does not
+exist.
+
+Still open, tracked on BI-154DAA7E: `authorizeWorkRoomAccess` returns the
+requested level for a superuser *before* any clearance check, so no
+route-fronted coworker may hold superuser; and the conversational channel
+remains unpoliced for peers that are legitimately admitted.
+
 ## 5. The triggering incident is not a ladder bug
 
 For the record, so the BI is not miscategorised: the upgrade failure itself was


### PR DESCRIPTION
Advances BI-154DAA7E — does NOT close it. Two items on that BI are deliberately out of scope here and are listed under *Still open* below.

## Why now

The escalation ladder ([#4335](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4335)) made convening a peer the *default* path rather than a rarely-used tool. That raised a disclosure question it did not create but did make routine: when a coworker brings a peer into a conversation, what may that peer say to the human sitting in it?

## What was already enforced

Stated plainly because I initially filed this as a broad disclosure hole and was wrong. Every governed coworker **tool call** is already an intersection of the asking human's clearance with the acting agent's data sensitivity — [`coworker-authority-decision.ts:336`](apps/web/lib/govern/authority/coworker-authority-decision.ts:336):

```ts
if (!input.authContext.sensitivityClearance.includes(input.dataPolicy.sensitivity)) {
  return deny("sensitivity-clearance-denied", "request-authority");
}
```

`authContext` is resolved from the requesting user with `actingAgentId` set. Unconditional, in the main decision path. The clamp lives one layer *below* `coworker-collaboration.ts`, which is why grepping that file alone suggested it was missing.

## What that gate structurally cannot cover

It inspects tool arguments and results. It does not inspect **prose**. A convened peer composes its reply from its own model context — system prompt, working notes, profession corpus, its own earlier turns — and disclosure needs no tool call: *"you may want to hold off on that hire"* leaks without one.

## The fix: refuse earlier, don't police the text

A peer that is never admitted has no prose channel to inspect. `decideConveneClearance` is called from `resolveTargetOrThrow` — the shared chokepoint behind **both** `request_coworker` and `summon_coworker` — so a future third convene path inherits the clamp instead of forgetting it. The tool gate stays behind it as defence in depth.

Three details are load-bearing:

- **Set membership, not rank**, mirroring the tool gate's `.includes()` exactly. A rank comparison would let a human holding `{public, internal, restricted}` convene a `confidential` peer — a convene that succeeds while every subsequent tool call is denied.
- **Fails closed.** Unlabelled or unrecognised sensitivity coerces to `restricted`, so a misconfigured coworker is not convened by default.
- **The refusal must not disclose.** This collides with the limitation-response contract, which tells a blocked coworker to name the one enabler and ask for a yes/no. Here that instinct *is* the leak: "ask an admin to grant you confidential clearance" reveals a restricted matter exists and hints at its class. `CONVENE_DENIED_MESSAGE` names no peer, role, level, or subject and proposes no enabler — deliberately indistinguishable from "no such specialist is available". Specifics go to the `DelegationChain` audit row the human never sees.

**Ordering:** the clamp runs *after* the lifecycle gate, so an unsummonable coworker still reports as unsummonable rather than as a clearance refusal — otherwise the generic refusal would imply a restricted matter that does not exist.

The unlinked-principal default (`["public", "internal"]`) mirrors the existing precedent in `workspace-room-access.ts` rather than inventing a stricter or looser one.

## Still open on BI-154DAA7E

- `authorizeWorkRoomAccess` returns the requested level for a superuser **before** any clearance check, so no route-fronted coworker may hold superuser.
- Prose from peers that are legitimately admitted remains unpoliced.

## Design grounding

Extends the escalation-ladder contract (new §4a in its spec) rather than adding a new one. No new tables, tools, or agent roles. Reuses `coerceDataSensitivity` and the existing principal clearance ladder.

## Verification

13 new cases covering the layoff case (confidential peer, internal human), the M&A case (restricted), the set-membership-not-rank gap, fail-closed on unlabelled/empty, and four assertions that the refusal string leaks no level, peer, subject, or enabler.

`pnpm run pregate` PASS — gated sha `29e3105f0e74`, evidence `cmsv332sh018o01rrre84o6xq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
