### PR TITLE
fix(coworker): align the convene clearance default with the principal path

### DIFF
--- a/apps/web/lib/tak/convene-clearance.test.ts
+++ b/apps/web/lib/tak/convene-clearance.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   decideConveneClearance,
+  clearanceForPrincipal,
   conveneDenialAuditReason,
   CONVENE_DENIED_MESSAGE,
 } from "./convene-clearance";
@@ -66,6 +67,61 @@ describe("decideConveneClearance", () => {
   it("fails closed on an empty clearance list", () => {
     expect(
       decideConveneClearance({ askingHumanClearance: [], targetAgentSensitivity: "public" }),
+    ).toEqual({ permitted: false, reason: "insufficient-clearance" });
+  });
+});
+
+describe("clearanceForPrincipal", () => {
+  it("matches the principal path for an employee with nothing explicit", () => {
+    // normalizePrincipalSensitivities returns ["public"] for empty/absent. The
+    // first version of this clamp hardcoded ["public","internal"], which made an
+    // UNLINKED user more cleared than a LINKED one — an inversion on every
+    // fresh install, in the wrong direction for a disclosure clamp.
+    expect(clearanceForPrincipal(undefined)).toEqual(["public"]);
+    expect(clearanceForPrincipal(null)).toEqual(["public"]);
+    expect(clearanceForPrincipal([])).toEqual(["public"]);
+  });
+
+  it("an unlinked user is never MORE cleared than a linked one — the inversion regression", () => {
+    const linkedWithNothingExplicit = clearanceForPrincipal([]);
+    const unlinked = clearanceForPrincipal(undefined);
+    expect(unlinked).toEqual(linkedWithNothingExplicit);
+    // and neither can convene a merely-internal coworker
+    expect(
+      decideConveneClearance({ askingHumanClearance: unlinked, targetAgentSensitivity: "internal" }),
+    ).toEqual({ permitted: false, reason: "insufficient-clearance" });
+  });
+
+  it("passes through a granted clearance in canonical order", () => {
+    expect(clearanceForPrincipal(["confidential", "public", "internal"])).toEqual([
+      "public",
+      "internal",
+      "confidential",
+    ]);
+  });
+
+  it("FAILS CLOSED on corrupt stored clearance — empty, denying even public", () => {
+    // normalizePrincipalSensitivities throws on an unknown member. On the
+    // convene path that must not become a 500 and must not widen access.
+    expect(clearanceForPrincipal(["public", "not-a-level"])).toEqual([]);
+    expect(
+      decideConveneClearance({
+        askingHumanClearance: clearanceForPrincipal(["public", "not-a-level"]),
+        targetAgentSensitivity: "public",
+      }),
+    ).toEqual({ permitted: false, reason: "insufficient-clearance" });
+  });
+
+  it("the installation-owner floor still convenes a confidential coworker", () => {
+    // Fresh-install path: superusers receive INSTALLATION_OWNER_SENSITIVITY_FLOOR,
+    // and workforce-seed creates tier-2 coworkers at "confidential". If this
+    // fails, every seeded confidential coworker is unconvenable on a new box.
+    const owner = clearanceForPrincipal(["public", "internal", "confidential"]);
+    expect(
+      decideConveneClearance({ askingHumanClearance: owner, targetAgentSensitivity: "confidential" }),
+    ).toEqual({ permitted: true });
+    expect(
+      decideConveneClearance({ askingHumanClearance: owner, targetAgentSensitivity: "restricted" }),
     ).toEqual({ permitted: false, reason: "insufficient-clearance" });
   });
 });

--- a/apps/web/lib/tak/convene-clearance.ts
+++ b/apps/web/lib/tak/convene-clearance.ts
@@ -27,7 +27,40 @@
 // Refusing at the convene is the cheaper and more honest fix: an over-cleared
 // peer is never in the room, so there is no prose channel to police. The tool
 // gate stays as defence in depth behind it.
-import { coerceDataSensitivity, type PrincipalSensitivity } from "@dpf/db/principal-sensitivity";
+import {
+  coerceDataSensitivity,
+  normalizePrincipalSensitivities,
+  type PrincipalSensitivity,
+} from "@dpf/db/principal-sensitivity";
+
+/**
+ * Resolve the asking human's clearance from whatever their Principal row holds.
+ *
+ * Delegates to `normalizePrincipalSensitivities` — the SAME function the
+ * principal-linking and seed paths use — so the convene clamp cannot drift from
+ * the clearance a principal is actually granted. The first version of this
+ * clamp hardcoded `["public", "internal"]`, copied from the room-access
+ * precedent, which produced an inversion on a fresh install: a properly LINKED
+ * employee with no explicit clearance resolves to `["public"]`, while an
+ * unlinked user got the looser `["public", "internal"]`. Being linked made you
+ * more restricted than being unknown, and the looser branch was the default —
+ * the wrong direction for a disclosure clamp.
+ *
+ * A stored value containing an unrecognised level makes
+ * `normalizePrincipalSensitivities` throw. Here that must not become a 500 on
+ * the convene path, and it must not widen access, so it resolves to an EMPTY
+ * clearance — which denies every sensitivity including "public". Corrupt
+ * clearance data refuses everyone rather than guessing.
+ */
+export function clearanceForPrincipal(
+  stored: readonly string[] | null | undefined,
+): PrincipalSensitivity[] {
+  try {
+    return normalizePrincipalSensitivities(stored);
+  } catch {
+    return [];
+  }
+}
 
 export type ConveneClearanceDecision =
   | { permitted: true }

--- a/apps/web/lib/tak/coworker-collaboration.ts
+++ b/apps/web/lib/tak/coworker-collaboration.ts
@@ -25,6 +25,7 @@ import { isHandoffPermitted } from "@/lib/tak/collaboration-authority";
 import { coerceDataSensitivity } from "@dpf/db/principal-sensitivity";
 import {
   decideConveneClearance,
+  clearanceForPrincipal,
   conveneDenialAuditReason,
   CONVENE_DENIED_MESSAGE,
 } from "./convene-clearance";
@@ -166,10 +167,11 @@ export type SummonCoworkerInput = {
  * clearance. Placed in the shared target resolver rather than at each call site
  * so a future third convene path inherits it instead of forgetting it.
  *
- * The default for a user with no linked principal mirrors the established
- * precedent in `workspace-room-access.ts` (`["public", "internal"]`) rather
- * than inventing a stricter or looser one — so an unlinked user can still reach
- * ordinary specialists but never a confidential or restricted peer.
+ * Clearance resolves through `clearanceForPrincipal`, which delegates to the
+ * same `normalizePrincipalSensitivities` the principal-linking and seed paths
+ * use, so this clamp cannot drift from the clearance a principal is actually
+ * granted — and an unlinked user is never treated as MORE cleared than a linked
+ * one with nothing explicit.
  */
 async function enforceConveneClearance(
   target: { agentId: string; slugId: string | null },
@@ -187,7 +189,7 @@ async function enforceConveneClearance(
   ]);
 
   const decision = decideConveneClearance({
-    askingHumanClearance: alias?.principal.sensitivityClearance ?? ["public", "internal"],
+    askingHumanClearance: clearanceForPrincipal(alias?.principal.sensitivityClearance),
     targetAgentSensitivity: agentRow?.sensitivity,
   });
   if (decision.permitted) return;


### PR DESCRIPTION
Advances BI-154DAA7E. Follow-up to [#4345](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4345), found while predicting what a from-scratch install will do — a new Windows instance is being stood up now.

## The inversion

The clamp hardcoded `["public", "internal"]` as the clearance for a user with no linked principal, copied from the `workspace-room-access.ts` precedent. But the principal path defaults differently — `normalizePrincipalSensitivities` returns `["public"]` for an absent or empty clearance.

So a properly **linked** employee with nothing explicit resolved to `["public"]`, while an **unlinked** user got the looser `["public", "internal"]`.

Being linked made you *more* restricted than being unknown, and the looser branch was the default. Wrong direction for a disclosure clamp, and it would have surfaced on every fresh install.

Copying the room-access precedent was the mistake: that default covers a **missing auth context**, whereas this path reads a **real principal row**. Same-looking situation, different meaning.

## The fix

`clearanceForPrincipal` delegates to the same `normalizePrincipalSensitivities` that principal-linking and the seed use, so the clamp can't drift from the clearance a principal is actually granted.

That function **throws** on an unrecognised member. On the convene path that must neither become a 500 nor widen access, so corrupt stored clearance resolves to an **empty** list — denying every sensitivity including `public`. Corrupt data refuses everyone rather than guessing.

## Why this matters for a fresh install

`workforce-seed.ts` creates tier-2 coworkers at `confidential`, and only superusers receive `INSTALLATION_OWNER_SENSITIVITY_FLOOR` (`public`/`internal`/`confidential`). So on a new instance:

- **installation owner** → can convene the seeded confidential coworkers
- **regular employee with nothing explicit** → `["public"]`, and every convene is refused

That refusal is deliberately silent (it must not disclose), which makes a *setup gap* and a *policy decision* indistinguishable in the UI. The diagnostic is the `DelegationChain` audit row, which carries the target agent and required sensitivity.

Added a regression asserting the owner floor still convenes a `confidential` coworker — if that ever breaks, every seeded confidential coworker is unconvenable on a new box.

## Verification

18 tests (5 new), including the inversion regression asserting an unlinked user is never more cleared than a linked one, fail-closed on corrupt clearance, and the fresh-install owner-floor case.

`pnpm run pregate` PASS — gated sha `e4dbb0429d7d`, evidence `cmsv556qx052401rr78kpggg7`.

Note: three earlier gate attempts died on SIGTERM from slot-0 contention with concurrent sessions, not from this change. It passed once `list_nonprod_environment_leases` showed the slot clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)