### PR TITLE
fix(db): stop the schema regression guard failing main against itself (BI-8742C12A)

### DIFF
--- a/packages/db/scripts/schema-regression-guard.mjs
+++ b/packages/db/scripts/schema-regression-guard.mjs
@@ -225,7 +225,15 @@ export const INTENTIONAL_MODEL_RENAMES = new Map([
 
 // Apply the sanctioned model renames to a schema line so that a relation field
 // differing only by its referenced model name compares equal.
+//
+// `@@map("...")` is deliberately exempt. Its argument is the PHYSICAL TABLE
+// name, not a model name, and the whole point of an honoured rename is that the
+// new model keeps `@@map("<old model name>")`. Substituting inside it rewrote
+// the base's `@@map("WorkCapsule")` into `@@map("Workroom")`, which never
+// matches the head, so every renamed model reported its own `@@map` as removed
+// — main regressed against itself and blocked any PR touching the schema.
 function applyModelRenames(line, renames) {
+  if (/^@@map\(/.test(line.trim())) return line;
   let out = line;
   for (const [from, to] of renames) {
     out = out.replace(new RegExp(`\\b${from}\\b`, "g"), to);

--- a/packages/db/scripts/schema-regression-guard.test.ts
+++ b/packages/db/scripts/schema-regression-guard.test.ts
@@ -310,6 +310,30 @@ model Holder {
     expect(regressions).toContain("model OldThing removed entirely");
   });
 
+  // Regression: once the rename has SHIPPED, base already contains the new model
+  // carrying @@map("<old name>"). The rename substitution used to rewrite inside
+  // that directive — turning base's @@map("OldThing") into @@map("NewThing"),
+  // which never matches head — so every renamed model reported its own @@map as
+  // removed and main regressed against itself. The @@map argument is a physical
+  // table name and must never be substituted.
+  it("reports nothing when base ALREADY carries the shipped rename", () => {
+    const shipped = parseSchema(`
+model NewThing {
+  id    String @id
+  name  String
+  kids  OldKid[]
+  @@map("OldThing")
+}
+
+model Holder {
+  id      String   @id
+  thingId String?
+  thing   NewThing? @relation(fields: [thingId], references: [id])
+}
+`);
+    expect(diffSchemas(shipped, shipped, new Set(), RENAMES)).toEqual([]);
+  });
+
   it("still reports a genuine field drop inside a renamed model", () => {
     const head = parseSchema(`
 model NewThing {


### PR DESCRIPTION
## This is currently blocking every PR that touches the schema

`node packages/db/scripts/schema-regression-guard.mjs origin/main` **fails on an unmodified checkout of `origin/main`**. Reproduced on a clean detached worktree at `origin/main`:

```
❌ Schema regression detected.
  - model Workroom: removed `@@map("Workroom")`
  - model WorkroomActivity: removed `@@map("WorkroomActivity")`
```

`main` regresses against itself, so the failure is unconditional for any PR whose diff touches `packages/db/prisma/schema.prisma`.

## Root cause

`applyModelRenames()` substitutes sanctioned model renames into each **base** schema line before comparing against head, without exempting `@@map("...")`.

The `@@map` argument is the **physical table name**, not a model name — and the entire safety property of the rename allowlist is that the new model keeps `@@map("<old model name>")`. With `WorkCapsule -> Workroom` in `INTENTIONAL_MODEL_RENAMES`, base's

```prisma
@@map("WorkCapsule")
```

becomes `@@map("Workroom")`, which never appears in head. So each renamed model reports its own `@@map` as removed. The guard corrupts the very directive its correctness depends on.

Latent until the rename shipped: once `main` itself carries `model Workroom { … @@map("WorkCapsule") }`, base is the corrupted side.

## Why the tests missed it

Rename coverage in `schema-regression-guard.test.ts` is otherwise good, but **every rename case builds a base that predates the rename** (`model OldThing` → head `model NewThing { @@map("OldThing") }`). Nothing exercised base-already-renamed — the shipped steady state, which is exactly where the bug lives.

## The fix

1. Exempt `@@map(` lines from rename substitution.
2. Add the missing case: base == head == already-renamed schema must yield no regressions.

## Verification

- The new test is **red against the unfixed guard** and green with the fix (verified by reverting the one-line guard change and re-running: `1 failed | 24 passed`).
- **25/25** tests pass in `packages/db/scripts/schema-regression-guard.test.ts`.
- The guard now reports `✅ No schema regressions detected.` on a clean `origin/main` worktree.
- `pnpm run pregate` — **gate passed**, gated sha `a27017aaa571`, evidence `cmsv7n2bf017d01pr0mtqcgkv`.

## Discovery

Found while opening #4348 during the 2026-08-15 sweep of never-proposed branches. That PR's schema change was correct; the gate was wrong. #4348 stays blocked on this one.

Tracked as `BI-8742C12A`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)