### PR TITLE
fix(release): unstrand the daily checkpoint tags and unbreak the edge-node image

### DIFF
--- a/.github/workflows/daily-checkpoint-tag.yml
+++ b/.github/workflows/daily-checkpoint-tag.yml
@@ -1,9 +1,10 @@
 name: Daily Checkpoint Tag
 
 # Cuts a dated checkpoint tag (v<YYYY.MM.DD>) once per day WHEN main has new
-# commits since the previous checkpoint. Replaces manual version stamping.
+# commits since the previous checkpoint, then publishes that checkpoint as a
+# GitHub Release and a set of multi-arch GHCR images.
 #
-# WHY THESE TAGS EXIST — they are "how far behind" markers, NOT releases:
+# WHAT THESE TAGS ARE — dated release anchors AND "how far behind" markers:
 #   Every DPF instance self-upgrades continuously. The real drift signal is the
 #   number of merged commits an install is behind main, already computed by
 #   apps/web/lib/self-upgrade/release-batch.ts, which also decides when the next
@@ -12,12 +13,30 @@ name: Daily Checkpoint Tag
 #   reset `git describe` so any build reads like `v2026.08.01-12-g<sha>`
 #   ("12 commits past the Aug 1 checkpoint") — the counter, baked into the label.
 #
-# INTENTIONALLY TAG-ONLY. Tags are pushed with the built-in GITHUB_TOKEN, which
-# by GitHub's design does NOT trigger tag-push workflows — so a daily checkpoint
-# does NOT kick the heavier publish-release.yml (Edge-binary build). That path
-# stays for deliberate releases. Cutting a full downloadable Release per
-# checkpoint would be a separate, explicit change (it needs a PAT to chain the
-# release build, and would run that build 365x/year).
+# WHY THIS WORKFLOW DISPATCHES THE PUBLISH CHAIN EXPLICITLY.
+#   publish-release.yml and publish-image.yml both trigger on `push: tags: v*`.
+#   That trigger never fires for our checkpoints: the tag is pushed with the
+#   built-in GITHUB_TOKEN, and GitHub's recursion guard suppresses the resulting
+#   push event. Between 2026-06-26 and 2026-08-16 that left every daily
+#   checkpoint tag stranded — v2026.08.05 through v2026.08.15 all exist, and not
+#   one produced a Release or a refreshed image.
+#
+#   The fix does NOT need a PAT. workflow_dispatch is a documented exception to
+#   the recursion guard: "workflow_dispatch and repository_dispatch events
+#   always create workflow runs"
+#   (https://docs.github.com/en/actions/concepts/security/github_token).
+#   So we cut the tag, then POST to each workflow's dispatches endpoint with the
+#   same GITHUB_TOKEN and `actions: write`. No secret to rotate, no PAT whose
+#   scope outlives its owner.
+#
+#   Dispatching against a TAG ref requires the target workflow file — including
+#   its `workflow_dispatch:` block — to exist AT that tag. Both do, and the tag
+#   is cut from main HEAD, so the tag always carries the current workflow files.
+#
+#   No recursion risk: workflow_dispatch has no loop protection, but neither
+#   dispatched workflow dispatches anything back, and the Release each one
+#   creates is made with GITHUB_TOKEN (so its `release` event is suppressed by
+#   the ordinary guard).
 
 on:
   schedule:
@@ -26,6 +45,7 @@ on:
 
 permissions:
   contents: write # push the checkpoint tag
+  actions: write # POST .../actions/workflows/{file}/dispatches
 
 concurrency:
   group: daily-checkpoint-tag
@@ -41,6 +61,7 @@ jobs:
           fetch-depth: 0 # full history + tags for describe / rev-list
 
       - name: Cut checkpoint tag if main advanced
+        id: checkpoint
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -48,6 +69,15 @@ jobs:
           git fetch --tags --force origin
 
           today="v$(date -u +%Y.%m.%d)"
+
+          # The publish step keys off this output, so it must be written EXACTLY
+          # once on every path — a duplicate `tag=` line would leave which value
+          # wins up to undocumented runner behaviour, and losing that coin flip
+          # silently restores the stranded-tag bug this workflow exists to fix.
+          # An EXIT trap gives one write per run, including on failure (empty =
+          # publish nothing), no matter which branch below returns.
+          publish_tag=""
+          trap 'echo "tag=${publish_tag}" >> "$GITHUB_OUTPUT"' EXIT
 
           # Idempotent: never cut the same day twice (re-runs / dispatch).
           if git rev-parse -q --verify "refs/tags/${today}" >/dev/null; then
@@ -76,3 +106,42 @@ jobs:
           git tag -a "${today}" -m "${msg}"
           git push origin "refs/tags/${today}"
           echo "${msg}"
+
+          # Only now is the tag real and pushed, so only now is it publishable.
+          publish_tag="${today}"
+
+      - name: Publish the checkpoint (GitHub Release + GHCR images)
+        if: steps.checkpoint.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.checkpoint.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # REST endpoint rather than `gh workflow run --ref`: the CLI's ref
+          # resolution 404'd on legitimate refs (cli/cli#9781), and this call
+          # shape is the one the API reference documents for tag dispatch.
+          payload="$(printf '{"ref":"%s","inputs":{"tag":"%s"}}' "${TAG}" "${TAG}")"
+
+          dispatch() {
+            workflow="$1"
+            echo "Dispatching ${workflow} at ${TAG}..."
+            printf '%s' "${payload}" | gh api --method POST \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/dispatches" \
+              --input -
+          }
+
+          # Independent of each other: the Release carries source archives plus
+          # the counted native Edge binaries, the image run refreshes GHCR. A
+          # failure in one must not suppress the other, so both are attempted
+          # and the step fails afterwards if either did.
+          rc=0
+          dispatch publish-release.yml || rc=1
+          dispatch publish-image.yml || rc=1
+
+          if [ "${rc}" -ne 0 ]; then
+            echo "::error::At least one publish workflow failed to dispatch for ${TAG}."
+            exit 1
+          fi
+
+          echo "Dispatched Release + image publish for ${TAG}."

--- a/services/edge-node/Dockerfile
+++ b/services/edge-node/Dockerfile
@@ -20,6 +20,15 @@ WORKDIR /app
 # package.json.
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 
+# patchedDependencies in pnpm-workspace.yaml makes patches/ an INPUT to the
+# install, not an optional extra: pnpm hashes every referenced patch file
+# while resolving, so a missing one is a hard ENOENT rather than a skipped
+# patch. PR #4321 (image-size ICNS fix, CVE-2025-71330) added this repo's
+# first patched dependency and broke the edge-node image on exactly that.
+# Copy the whole directory — it is a handful of KB, and scoping it to
+# today's single patch would re-break the next time one is added.
+COPY patches ./patches
+
 # Every workspace package edge-node depends on (transitively). Today
 # that's @dpf/validators only; add more here if the dep tree grows.
 COPY packages/validators ./packages/validators


### PR DESCRIPTION
## Summary

The release pipeline has been silently dead since 2026-06-26. `main` is now **1834 commits** past the last published Release (v6.5.1) and the GHCR images are ~7 weeks stale. Two independent faults caused it, and this PR fixes both: the daily checkpoint tags were never able to trigger the publish workflows (a `GITHUB_TOKEN` recursion-guard interaction, not a broken job — the scheduled job has succeeded every single day), and the `dpf-edge-node` image has been unbuildable since #4321 landed the repo's first patched dependency.

## Changes

- `daily-checkpoint-tag.yml`: after cutting the tag, explicitly dispatch `publish-release.yml` and `publish-image.yml` at that tag via the REST dispatches endpoint. Adds `actions: write`. **No PAT and no new secret** — `workflow_dispatch` is a documented exception to the recursion guard.
- `daily-checkpoint-tag.yml`: the tag output is written **exactly once** through an `EXIT` trap, so no duplicate-key ambiguity can silently re-strand the tag.
- `daily-checkpoint-tag.yml`: header rewritten. The old "INTENTIONALLY TAG-ONLY … needs a PAT" rationale was the reason this was never wired up, and its PAT premise was factually wrong.
- `services/edge-node/Dockerfile`: `COPY patches ./patches`. `patchedDependencies` makes `patches/` an **input** to `pnpm install` — pnpm hashes each referenced patch while resolving, so a missing file is a hard `ENOENT`, not a skipped patch.

### Root cause detail

**Why nothing published.** Both publish workflows trigger only on `push: tags: v*`. The checkpoint job pushes its tag with the built-in `GITHUB_TOKEN`, and GitHub suppresses the resulting push event. `v2026.08.05` … `v2026.08.15` all exist; not one produced a Release or an image.

The fix rests on this documented exception (https://docs.github.com/en/actions/concepts/security/github_token):

> "workflow_dispatch and repository_dispatch events always create workflow runs."

Dispatching against a *tag* ref requires the target workflow — including its `workflow_dispatch:` block — to exist **at that tag**. Both do, and the tag is cut from `main` HEAD, so it always carries current workflow files. No recursion risk: neither dispatched workflow dispatches anything back.

**Why edge-node broke.** #4321 (image-size ICNS fix, CVE-2025-71330) added the first `patchedDependencies` entry. The Dockerfile copied the workspace skeleton but not `patches/`. The other ten image jobs in run 31922232804 were green; only this one failed, on both arches.

## Test plan

- [x] **Runtime-bound change** (build/runtime wiring, CI workflow)
  - [x] Functional verification — **CI workflow run on this PR** (the canonical runtime for a CI/image change)
  - [x] Evidence captured below

- [x] **Verification-harness limitation acknowledged** — the full `dpf-edge-node` image build could not be completed locally; see evidence. Not a product defect.

### Verification evidence

**1. Reproduced the failure locally on an unmodified clone** — identical step and exit code to CI run 31922232804:

```
#11 ERROR: process "/bin/sh -c corepack enable && pnpm install --filter dpf-edge-node...
    --no-frozen-lockfile --ignore-scripts" did not complete successfully: exit code: 254
ENOENT: no such file or directory, open '/app/patches/image-size@1.2.1.patch'
```

**2. With the fix applied, that step clears** — `Progress: resolved 531, reused 0, downloaded 526, added 529`, versus `ENOENT` at 1.8s before. **The full image build did not finish locally**: the host Docker engine was taken down mid-build by an unrelated teardown on this machine. The remaining stages are left to CI — flagging that honestly rather than claiming a green build I did not observe.

**3. Actions injection audit** (the gate this workflow edit is most likely to trip):

```
Workflows scanned: 36
Currently found:   0 occurrence(s)
✓ Actions injection audit PASSED
```

**4. Workflow correctness, checked directly rather than by inspection:**
- YAML parses; `permissions` resolves to `{contents: write, actions: write}`.
- Both `run` blocks pass `bash -n`.
- Dispatch step dry-run with `gh` stubbed emits exactly `{"ref":"v2026.08.16","inputs":{"tag":"v2026.08.16"}}` to both workflows; the failure path (one dispatch fails) correctly still attempts the other and then exits 1.
- All three checkpoint paths — already-exists, no-new-commits, cut — each write **exactly one** `tag=` line, with the correct value (empty, empty, `v2026.08.16`).

## Pre-PR readiness

Built from a clean shallow clone with no workspace install — `pnpm run pregate` cannot run here, and the machine's D: drive worktrees and Docker engine are mid-teardown by another session.

Local-CI-Override: external-contribution-no-install: clean shallow clone, no node_modules; host Docker engine and worktree tree torn down by a concurrent session. CI gates this PR in full.

## Overlap sweep

`gh pr list --state open --limit 50` → #4350 (`feat/qwen38-27b-local-tier`, inference tiering) and #4331 (`feat/build-studio-owner-brief-proof`). Neither touches release workflows, the edge-node image, or `patches/`. No coordination needed.

## Notes for the reviewer

Three things worth a decision, none of which this PR silently resolves:

1. **Cadence is now daily, by explicit owner request.** Every checkpoint becomes a published Release plus a full 12-job multi-arch image build — roughly 365 Releases/year and 365 image runs. The original author deliberately avoided exactly this; the owner has since asked for it, so it is a decision reversal, not an oversight.

2. **`:latest` moves before the E2E install verification runs.** In `publish-image.yml`, the `merge` job repoints `dpf-*:latest` and *then* stage 3 verifies the install. Customer installs self-upgrade against `latest`. That ordering is pre-existing, but daily cadence makes a bad `latest` ~365x more likely to be published. Worth a follow-up BI to gate the `latest` tag behind the verify job.

3. **Checkpoints are cut from `main` HEAD regardless of CI state on that SHA.** Nothing here checks that main is green before publishing. Deliberately not added — a silent "skipped today because main was red" would be its own failure mode — but it should be a conscious choice.

Going forward, Releases will be calver (`v2026.08.16`) alongside the existing semver line; the two coexist without conflict.
