### PR TITLE
fix(install): normalize HuggingFace model refs in the Windows installer too (BI-68EED40A)

### DIFF
--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -1973,8 +1973,27 @@ if (-not (Test-StepDone "model")) {
     # files to the runtime name so that portal /v1/models discovery and inference
     # references match exactly what the model-runner serves (prevents "model not found"
     # in inference.model-manager even when pull was executed).
+    #
+    # HuggingFace sources normalize differently from the ai/ catalog. Verified on-box
+    # 2026-08-16: pulling hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M lists as
+    # huggingface.co/ggml-org/qwen3.8-27b-gguf:Q4_K_M -- host rewritten to its long
+    # form, repo path lowercased, quant tag case PRESERVED. Stripping ai/ alone is a
+    # no-op on those refs, so the post-pull presence check below could never match and
+    # the installer would warn "pull reported success but not listed" on every run.
     $pullName = $selectedModel
-    $runtimeModel = $pullName -replace '^ai/',''
+    if ($pullName -match '^(hf\.co|huggingface\.co)/') {
+        if ($pullName -match '^(.*):([^:/]+)$') {
+            $hfPath = $Matches[1]
+            $hfTag  = $Matches[2]
+        } else {
+            $hfPath = $pullName
+            $hfTag  = ''
+        }
+        $hfPath = ($hfPath -replace '^hf\.co/','huggingface.co/').ToLowerInvariant()
+        if ($hfTag) { $runtimeModel = "${hfPath}:${hfTag}" } else { $runtimeModel = $hfPath }
+    } else {
+        $runtimeModel = $pullName -replace '^ai/',''
+    }
     # Expected size upfront (manifest only) so user with known bandwidth can estimate duration.
     $sizeMB = 0
     try {


### PR DESCRIPTION
## The defect

`install-dpf.ps1` derived the on-disk model name as:

```powershell
$runtimeModel = $pullName -replace '^ai/',''
```

That is a **no-op** on a `hf.co/...` reference. #4350 pointed the 23 GB+ tier at `hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M`, so on Windows the post-pull presence check could never match its own pull:

```powershell
$listed = docker model list | ... | Where-Object { $_ -eq $runtimeModel }
```

Result on a 24 GB Windows host: download ~18 GB, then `Model pull reported success but hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M not listed`, **every run**, with `$selectedModel` never normalized to the name the model-runner actually serves.

This is the same defect fixed in `install-dpf.sh` in #4350 — its PowerShell twin was missed. `main` is currently in the half-state where Windows *selects* the new model and then cannot register it, which is worse than before that merge for Windows specifically. This closes that window.

## The fix

Applies the transform verified on-box against a real pull:

| | value |
|---|---|
| pulled | `hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M` |
| listed by `docker model list` | `huggingface.co/ggml-org/qwen3.8-27b-gguf:Q4_K_M` |

Host rewritten to its long form, repo path lowercased, **quant tag case preserved**. The `ai/` strip stays as the fallback branch for catalog refs.

Both installers were swept for other `ai/`-prefix assumptions; the only remaining occurrences are these fallback branches.

## Why no gate caught it

Nothing in CI exercises a HuggingFace pull end-to-end — the guards check shape, not round-trip behaviour. It surfaced only because the operator mentioned re-installing on a 24 GB Windows box, i.e. from someone about to run the broken path, not from verification. Worth noting as a coverage gap rather than a one-off.

## Verification

- local-CI pregate: **PASS** — gated sha `07ab1f317`, evidence `cmsva2qo106iv01prxb5etnpg`
  (first attempt returned `blocked_sandbox_drift`, a sandbox-side condition explicitly not product evidence; self-healed on retry)
- `install-dpf.ps1` is ASCII-only and brace-balanced per the repo's PowerShell rules
- `pwsh` is not available on the authoring host, so CI's installer-surface job is the real parser check

## Not verified here

The end-to-end Windows pull itself. This host is macOS; the transform is verified from a real `docker model pull` on the same Docker Model Runner, but the PowerShell path has not been executed on Windows. The operator is re-installing on a 24 GB Windows box and that run is the functional confirmation.

Design-Grounding-Decision: grounded in docs/superpowers/plans/2026-08-15-qwen38-27b-local-tier-plan.md and apps/web/lib/inference/local-model-policy.ts
Docs-Impact-Decision: installer internals only; no user-facing docs surface changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)