### PR TITLE
docs(spec): record fresh-install convene behaviour and the silent-refusal diagnostic

### DIFF
--- a/docs/superpowers/specs/2026-08-15-coworker-escalation-ladder-design.md
+++ b/docs/superpowers/specs/2026-08-15-coworker-escalation-ladder-design.md
@@ -178,6 +178,72 @@ requested level for a superuser *before* any clearance check, so no
 route-fronted coworker may hold superuser; and the conversational channel
 remains unpoliced for peers that are legitimately admitted.
 
+## 4b. Fresh-install behaviour and how to diagnose a silent refusal
+
+Written down because the clamp's correct-for-disclosure silence is
+actively hostile during setup, and because the knowledge otherwise lives only in
+the session that built it. A new install is where this bites first.
+
+### Who can convene whom on a brand-new instance
+
+| Principal | Clearance resolved | Can convene a seeded `internal` coworker | …a seeded `confidential` coworker |
+| --- | --- | --- | --- |
+| Installation owner (superuser) | `INSTALLATION_OWNER_SENSITIVITY_FLOOR` = `public`, `internal`, `confidential` | yes | yes |
+| Employee with nothing explicit | `normalizePrincipalSensitivities(undefined)` → `["public"]` | **no** | **no** |
+| Principal with corrupt stored clearance | `[]` (fails closed) | no | no |
+
+`workforce-seed.ts` creates tier-2 coworkers at `sensitivity: "confidential"`,
+and only superusers receive the owner floor. So on a new box a regular employee
+cannot convene *any* seeded coworker — not merely the confidential ones — until
+clearance is granted explicitly.
+
+**Verify the escalation ladder as the installation owner first.** Verifying as an
+ordinary employee reproduces a total convene failure that looks like a broken
+feature and is in fact unseeded clearance.
+
+### Diagnosing a refused convene
+
+`CONVENE_DENIED_MESSAGE` is deliberately uninformative — it names no peer, role,
+sensitivity level, or subject, because a refusal that explains itself discloses
+the thing being protected (§4a). The unavoidable consequence is that a *setup
+gap* and a *policy decision* are indistinguishable from the UI.
+
+The reason exists in exactly one place: the `DelegationChain` audit row written
+before the refusal is thrown.
+
+```sql
+SELECT "toAgentId", reason, "originUserId", "createdAt"
+FROM "DelegationChain"
+WHERE status = 'blocked'
+ORDER BY "createdAt" DESC
+LIMIT 20;
+```
+
+`reason` carries the target agent and the required sensitivity
+(`conveneDenialAuditReason`). A blocked row naming a sensitivity the asking human
+plainly should hold is a seeding problem, not a policy problem.
+
+Note the same table also carries `delegatesTo`/`escalatesTo` refusals from
+`enforceHandoffAuthority`, whose reason text names the *caller* agent. The two are
+distinguishable by reason wording.
+
+### A defaulting trap worth generalising
+
+The first version of this clamp defaulted an unlinked user to
+`["public", "internal"]`, copied from `workspace-room-access.ts`. That produced an
+inversion: a properly **linked** employee with nothing explicit resolves to
+`["public"]`, so being *linked* made a user more restricted than being *unknown* —
+and the looser branch was the default.
+
+The room-access default covers a **missing auth context**. The convene path reads
+a **real principal row**. Same-shaped default, different meaning. Corrected by
+delegating to `packages/db/src/principal-sensitivity.ts`, which owns clearance
+normalization, rather than restating a default beside it.
+
+The general rule: when a default already exists elsewhere, confirm it answers the
+*same question* before copying it. Two defaults that look alike can encode
+opposite assumptions about what an absent value means.
+
 ## 5. The triggering incident is not a ladder bug
 
 For the record, so the BI is not miscategorised: the upgrade failure itself was


### PR DESCRIPTION
Advances BI-154DAA7E. Documentation only — no decision changes and no behaviour moves.

## Why this exists

The convene clamp ([#4345](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4345), [#4347](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4347)) is **deliberately silent** when it refuses. It names no peer, role, sensitivity level, or subject, because a refusal that explains itself discloses the thing being protected (§4a).

The unavoidable consequence: a **setup gap** and a **policy decision** look identical from the UI. That is acceptable on a seeded, understood install. It is expensive on a new instance — which is exactly where the clamp bites first, and a Windows instance is being stood up from scratch now.

This records the operational half beneath §4a, which owns the contract.

## What it records

**1. Who can convene whom on a brand-new instance.**

| Principal | Clearance | `internal` coworker | `confidential` coworker |
|---|---|---|---|
| Installation owner (superuser) | `public`, `internal`, `confidential` | yes | yes |
| Employee, nothing explicit | `["public"]` | **no** | **no** |
| Corrupt stored clearance | `[]` | no | no |

`workforce-seed.ts` creates tier-2 coworkers at `confidential`, and only superusers receive `INSTALLATION_OWNER_SENSITIVITY_FLOOR`. So a regular employee on a new box cannot convene **any** seeded coworker — not merely the confidential ones.

**Verify the escalation ladder as the installation owner first.** Verifying as an ordinary employee reproduces a total convene failure that looks like a broken feature and is unseeded clearance.

**2. How to diagnose a refused convene.** The reason exists in exactly one place — the `DelegationChain` row written before the refusal is thrown. Includes the query, notes that `reason` carries the target agent and required sensitivity, and warns that the same table also holds `delegatesTo`/`escalatesTo` refusals whose reason names the **caller** agent instead, so the two are distinguishable only by wording.

**3. A defaulting trap, generalised.** The first version defaulted an unlinked user to `["public","internal"]`, copied from `workspace-room-access.ts`. That made a **linked** employee more restricted than an **unknown** one, with the looser branch as the default. The room-access default covers a *missing auth context*; the convene path reads a *real principal row*. Same-shaped default, opposite assumption about what an absent value means.

The general rule now written down: when a default already exists elsewhere, confirm it answers the same question before copying it.

## Scope

Spec-corpus addition recording already-shipped behaviour and its diagnostic path. `check-docs-impact`, `check-seed-fit-decision`, and `check-design-grounding-decision` all pass clean on this diff.

## Verification

`pnpm run pregate` PASS — gated sha `df15496e27b1`, evidence `cmsvagxs007i801przuboaped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)