### PR TITLE
docs(spec): amend the interaction shape graph for ease-of-use blind spots

### DIFF
--- a/docs/superpowers/specs/2026-08-14-portfolio-shaped-information-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-14-portfolio-shaped-information-architecture-design.md
@@ -93,7 +93,11 @@ How comparable business platforms bind a domain model to primary navigation:
 | 3 | Reconcile remaining sections to the portfolio spine; make it the default after live-install validation | L |
 | 4 | *(referenced, separate epic)* coworker navigate-and-act capability | L |
 
-## 8. Acceptance
+### 7.1 Open question on the phase-2 label pass *(raised 2026-08-15, unresolved)*
+
+Phase 2 lists `"AI Coworkers"` → `"Agent Identities"` as a quick win. Under the lexicon rule proposed in the companion spec (§3.4, *Interaction Shape Graph*), that rename runs the wrong way: *AI Coworkers* is the operator's word for the thing, *Agent Identities* is the machinery's. Rail labels are among the most expensive strings in the product to change twice, because operators learn them.
+
+If the rename exists to disambiguate the identity **record** from the coworker — a real distinction — then the record is what should be renamed or kept off the rail, not the surface the owner reads. **This needs an answer before phase 2 lands.** Flagged rather than edited, because the disambiguation it is solving may be load-bearing in a way not visible from this document.
 
 - Every `shellNav` entry resolves — via a checked-in test — to exactly one FPAW portfolio key or an explicitly declared cross-cut; none is silently unclassified.
 - People, AI Workforce, and Coworker Decisions are reachable under one Workforce section without violating section-scoped nav or the breadcrumb guarantee.

--- a/docs/superpowers/specs/2026-08-15-interaction-shape-graph-and-design-shaping-design.md
+++ b/docs/superpowers/specs/2026-08-15-interaction-shape-graph-and-design-shaping-design.md
@@ -4,6 +4,7 @@
 **Proposed epic home:** EP-8DC217EB (Vertical Integration Inward) · composes with EP-VSL-SURFACE / EP-VSL-GOVERN
 **Companion:** [Portfolio-shaped information architecture](2026-08-14-portfolio-shaped-information-architecture-design.md)
 **Origin:** UX surface & navigation analysis, 2026-08-14 — four owner flows break the same way; six rail sections don't map to the four-portfolio model.
+**Amended:** 2026-08-15 — §3.2 `delegate` + `lexicon`, §3.3 `entry-gated-by-setup` + `spine-stage-inert`, §4 `prerequisitesToEntry`, §10 ordering note. Source: competitive read of a consumer agent product (Grokbot) whose entire differentiator is ease of use, tested against this model for what it fails to catch. Rationale inline at each amendment.
 
 ---
 
@@ -64,10 +65,13 @@ Every human-reachable surface carries a shape binding:
 |---|---|---|
 | `spineStage` | `OperationalValueStreamStageKey` | Which stage of earning/supporting this serves. |
 | `jobLane` | derived from `route-audience` + `page-purpose.primaryUser` | Whose job path this sits on. |
-| `stepRole` | `entry · progress · decide · complete · reference` | What the surface does *within* a flow — the field that makes "arrives but cannot continue" detectable. |
+| `stepRole` | `entry · progress · decide · delegate · complete · reference` | What the surface does *within* a flow — the field that makes "arrives but cannot continue" detectable. |
 | `continuesTo` | nav graph edges + `page-purpose.findability` | The next surface(s) in the job path. |
+| `lexicon` | approved operator vocabulary, extending `page-purpose` | Which words this surface is permitted to say. See §3.4. |
 
 `stepRole` is the load-bearing addition. A `progress` or `decide` node with no `continuesTo` is a **dead end** — the exact defect found in sales-orders (read-only, no detail), recruiting (no candidate→employee convert), and the bill detail (no approve control).
+
+**`delegate` is a distinct role, not a flavour of `progress`.** A `delegate` node is where the human hands the remainder of the job to a coworker. It **terminates the human's traversal** for flow-load purposes (§4), and its `continuesTo` names the receiving job lane rather than another surface. Typing delegation as `progress` or `decide` would make handing work to a coworker *increase* `stepsToOutcome` — the metric would penalise the platform's primary answer to cognitive load, and the phase-2 baseline would bake that inversion in. This is why the role belongs in the phase-0 contract rather than in a later phase.
 
 ### 3.3 Violation types
 
@@ -79,8 +83,26 @@ Emitted as conformance findings on the existing EA canvas and into blast-radius 
 | `job-path-broken` | A `progress`/`decide` node has no `continuesTo`, or its only continuation leaves the app (e.g. an emailed token page as sole actuation). |
 | `flow-load-regressed` | A job path's flow-load metrics (§4) worsen against baseline. |
 | `spine-stage-orphaned` | An OVS stage has no surface bound to it — the business has a stage the UI cannot serve. |
+| `entry-gated-by-setup` | A job path's `entry` requires configuration, connection, or permission that could have been requested in-flow at the step that needs it. |
+| `spine-stage-inert` | A stage is bound to surfaces and traversable, but no job path reached a `complete` node on it within the observation window. |
+| `lexicon-leak` | A user-visible string on the surface names an internal primitive (§3.4). |
 
-The last one is the inverse check, and valuable: it detects *missing* shape, not just malformed shape.
+`spine-stage-orphaned` is the inverse check, and valuable: it detects *missing* shape, not just malformed shape. Two of the additions extend that inverse logic to the two blind spots the structural findings cannot see:
+
+- **`entry-gated-by-setup`** covers the cost paid *before* the path. Every metric in §4 begins at `entry`, so a job whose entry is fronted by connector configuration scores identically to one that starts on first intent. The alternative posture — authorisation surfacing mid-flow, at the step that needs it, granted once and inherited — is the single largest ease-of-use gap between this platform and consumer agent products, and it is currently unmeasured rather than decided against.
+- **`spine-stage-inert`** covers the difference between traversable and used. A stage can bind cleanly, pass every page budget, hold no dead ends, and still produce nothing a human accepted. Without this finding the conformance suite certifies *process* and is silent on *value* — the criticism this platform is most exposed to, given how much governance machinery sits behind each surface.
+
+### 3.4 Lexicon — the shape has a vocabulary, not only a structure
+
+§1.1 requires that implementation complexity stay hidden and that design semantics never be promoted into human semantics. Today that requirement is asserted for *structure* and enforced for structure only. Nothing checks the **words**, and words are how machinery leaks first: `capsule`, `decomposition`, `projection`, `extractor`, `gear`, `pregate`, `backlog item`, `epic` are all builder primitives that have appeared, or can appear, in copy an owner reads.
+
+The cost of leaving this unenforced is already measurable. Retiring one leaked primitive — `WorkCapsule` → `Workroom` — took four coordinated PRs (#4338 model rename, #4339 doctrine, #4340 view vocabulary, #4342 MCP tool aliases) and a database model rename. That is the correct instinct executed by hand, and by hand it does not survive the next surface.
+
+**Rule.** A surface's user-visible strings draw from the approved operator lexicon. A string naming an internal primitive emits `lexicon-leak`, graded and ratcheted exactly as §5 grades every other finding: pre-existing leaks are baselined and may only improve, net-new leaks block.
+
+**Mechanism (no new machinery).** `ux-route-sweep` already drives every route in a real portal and already captures an ARIA snapshot for drift detection, so the visible strings are in hand at the moment the sweep runs. The lexicon itself extends `page-purpose`, which already carries `job` and `successOutcome` in operator language. The net-new cost is a word list and a check, not a subsystem.
+
+**Boundary.** This governs what a surface *says*, never what the model *is*. Internal names stay internal and stay precise; the rule only stops them reaching a reader who did not build the system.
 
 ## 4. Flow-level cognitive load *(operator-selected: flow-level, complementing the page budget)*
 
@@ -94,6 +116,9 @@ Metrics, measured per job path:
 | `sectionCrossings` | Rail-section changes mid-path. | The product-lifecycle flow crosses three; each is a reorientation cost. |
 | `groupExits` | Route-group / app exits mid-path. | Catches approvals that leave the shell for email-token pages. |
 | `deadEnds` | `progress`/`decide` nodes with no continuation. | The single most common defect found in the analysis. |
+| `prerequisitesToEntry` | Configuration, connection, or permission steps standing between stated intent and the first `entry` node. | Setup is load the other four metrics cannot see, because they all start at `entry`. It is where a non-technical operator abandons before reaching a surface this spec would score as healthy. |
+
+A `delegate` node closes the human's traversal: `stepsToOutcome` counts the steps to the delegation, not the coworker's subsequent path. Delegated work is still subject to `spine-stage-inert` (§3.3), so handing a job to a coworker cannot be used to make a stage look cheap while producing nothing.
 
 These are budgeted per job path the same way page budgets are per shell — founder-tunable, explicitly calibration rather than science, consistent with the existing `UX_BUDGETS` posture.
 
@@ -147,18 +172,24 @@ Practical consequences:
 - **No new job model.** Reuses `route-audience` + `page-purpose` generators.
 - **No new CI machinery.** Reuses the sweep + ratchet + baseline pattern already running for UX budgets.
 - **No new autonomy model.** References the Reduction Gear's `CalibrationKey`→`AutonomyTier` ladder; does not extend the deliberately cadence-only proactivity module.
+- **No new copy pipeline.** The §3.4 lexicon check reads the strings `ux-route-sweep` already captures and extends the `page-purpose` record already generated; it adds a word list and a check, not a subsystem.
+- **No new delegation model.** `delegate` types a surface that already exists; the coworker side is owned by the coworker epic referenced in the companion spec §4.4.
 
 ## 10. Phasing
 
 | Phase | Deliverable | Size |
 |---|---|---|
-| 0 | Shape node contract (`spineStage`, `jobLane`, `stepRole`, `continuesTo`) + extractor enrichment emitting `shape-off-spine` / `spine-stage-orphaned` as **advisory** | M |
+| 0 | Shape node contract (`spineStage`, `jobLane`, `stepRole` **incl. `delegate`**, `continuesTo`, **`lexicon`**) + extractor enrichment emitting `shape-off-spine` / `spine-stage-orphaned` as **advisory** | M |
 | 1 | `job-path-broken` detection (dead-end + group-exit) across the four analyzed flows; validate it reproduces the known defects | M |
-| 2 | Flow-load metrics + baseline + ratchet CI policy (advisory legacy / blocking net-new) | M |
+| 2 | Flow-load metrics incl. `prerequisitesToEntry` + baseline + ratchet CI policy (advisory legacy / blocking net-new) | M |
+| 2b | `lexicon-leak` word list + check on the existing sweep, baselined against the current estate | S |
 | 3 | Proactivity ↔ Reduction Gear coupling; per-stage "who runs this" rendering | L |
+| 3b | `spine-stage-inert` — completion observation per stage over a rolling window | M |
 | 4 | Shape lens on the EA canvas as an operator-facing view | M |
 
 **Phase 1 is the proof gate:** if the detector does not independently reproduce the four flow breaks already found by hand, the model is wrong and phases 2–4 do not proceed.
+
+**Ordering constraint (from the 2026-08-15 amendment).** `delegate` and `lexicon` are phase-0 contract changes, not later additions. Both are cheap to add before the baseline is written and expensive afterwards: `delegate` because phase 2 would otherwise baseline a `stepsToOutcome` that penalises delegation, and `lexicon` because a baseline written without it has no record of which leaks were pre-existing. `prerequisitesToEntry` and `spine-stage-inert` are genuinely later work and are phased accordingly.
 
 ## 11. Acceptance
 
@@ -166,4 +197,6 @@ Practical consequences:
 - The detector independently reproduces the four known flow breaks (bill approval dead-end, recruiting→hire gap, sales-order dead end, product→build discontinuity).
 - A net-new surface introducing a dead end or lacking a shape binding fails CI; pre-existing violations ratchet.
 - The EA canvas renders the shape lens with per-stage human/AI attribution sourced from gear autonomy tiers.
-- No design semantics leak into end-user surfaces — the shape informs navigation and impact analysis, it is not shown as a model to the user.
+- No design semantics leak into end-user surfaces — the shape informs navigation and impact analysis, it is not shown as a model to the user. This is asserted for **words as well as structure**: no user-visible string names an internal primitive without a baselined exception (§3.4).
+- Handing a job to a coworker registers as a `delegate` node and does not increase `stepsToOutcome`; a stage cannot pass by delegating work that never completes (`spine-stage-inert`).
+- Every job path reports `prerequisitesToEntry`, so setup cost is visible rather than invisible-by-construction.


### PR DESCRIPTION
Amends the two UX-refactor design docs (#4311, #4312) with four gaps found by testing the shape-graph model against a competitive read of **Grokbot** — a consumer agent product whose only real differentiator is ease of use. The exercise was: what does that product make effortless that this model would not catch?

Most of what the read surfaced was **already in the spec** and better developed there — §1.1's hide/couple boundary, principle 5, §4 flow-level load, §5 ratchet, §7 the kernel principle, §11's no-leak acceptance. This PR only carries what was genuinely missing.

## The four amendments

| # | Amendment | Where | Why it matters |
|---|---|---|---|
| 1 | `delegate` added to `stepRole` | §3.2, §4, §11 | **Modelling bug, not an omission.** Delegation currently types as `progress`/`decide`, so handing a job to a coworker *increases* `stepsToOutcome`. The metric would penalise the platform's primary answer to cognitive load. |
| 2 | `prerequisitesToEntry` + `entry-gated-by-setup` | §3.3, §4 | Every existing metric begins at `entry`. Setup cost is invisible by construction — a job fronted by connector config scores the same as one that starts on intent. |
| 3 | `spine-stage-inert` | §3.3 | Separates *traversable* from *used*. A stage can pass every check and still produce nothing a human accepted. |
| 4 | `lexicon` field + §3.4 + `lexicon-leak` | §3.2, §3.4, §3.3, §9 | §1.1 requires machinery stay hidden; that is enforced for structure and not for **words**. |

### On the lexicon amendment specifically

The evidence is in this repo, from tonight. Retiring **one** leaked primitive — `WorkCapsule` → `Workroom` — took four coordinated PRs (#4338 model, #4339 doctrine, #4340 views, #4342 MCP tools) plus a database model rename. That is the right instinct executed by hand, and by hand it will not survive the next surface. The check rides strings `ux-route-sweep` already captures; net-new cost is a word list, not a subsystem.

## Phasing impact

`delegate` and `lexicon` are marked **phase-0 contract work**. Both are cheap before the baseline is written and expensive after — `delegate` because phase 2 would otherwise baseline a metric that inverts on delegation, `lexicon` because a baseline written without it has no record of which leaks were pre-existing. `prerequisitesToEntry` (phase 2) and `spine-stage-inert` (phase 3b) are genuinely later work.

## Open question for the operator — needs an answer before IA phase 2

The IA spec's phase-2 label pass lists `"AI Coworkers"` → `"Agent Identities"`. Under the lexicon rule that runs the wrong way: *AI Coworkers* is the operator's word, *Agent Identities* is the machinery's, and rail labels are expensive to change twice because operators learn them.

Raised as §7.1 in the IA spec rather than edited, because the disambiguation it solves (identity **record** vs coworker) may be load-bearing in a way the document does not show. If it is, the record is what should be renamed or kept off the rail.

## Verification

Doc-only, two files, both already under `docs/superpowers/specs/`. Neither spec has left draft status, so nothing downstream depends on the amended text yet.

**Not verified locally.** The root clone at `D:\DPF` has lost its `.git` directory and every worktree under `D:\DPF-worktrees` is orphaned (`fatal: not a git repository: D:/DPF/.git/worktrees/…`); at least one has been reduced to a bare `node_modules`. No local gate could run. Authored against `main@7a6c66b` through the GitHub API — CI is the first gate this change meets. Flagging separately because that clone state will block other local work until it is restored.

Epic home: **EP-8DC217EB** (Vertical Integration Inward), matching both amended specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
