### PR TITLE
fix(decisions): answering an escalation shouldn't suppress the next decision (BI-ACF0D6D4)

### DIFF
--- a/apps/web/lib/decision-perspective/build-studio-gate.test.ts
+++ b/apps/web/lib/decision-perspective/build-studio-gate.test.ts
@@ -130,7 +130,10 @@ function makeDb() {
       })),
     },
     escalationCapture: {
-      count: vi.fn().mockResolvedValue(0),
+      // BI-ACF0D6D4: the gate now reads captures and compares each interaction's
+      // recommended option against the one the human chose, so a mere count can
+      // no longer stand in for "the owner overruled us".
+      findMany: vi.fn().mockResolvedValue([]),
     },
   };
 }
@@ -258,7 +261,13 @@ describe("evaluateBuildStudioPlanAdvancementGate", () => {
 
   it("uses recent same-domain overrides to lower confidence for the current gate", async () => {
     const db = makeDb();
-    db.escalationCapture.count.mockResolvedValue(3);
+    // Three captures where the human chose something OTHER than the gate's
+    // recommendation — genuine overrules, which still lower confidence.
+    db.escalationCapture.findMany.mockResolvedValue([
+      { interaction: { recommendedOptionId: "opt-a", chosenOptionId: "opt-b" } },
+      { interaction: { recommendedOptionId: "opt-a", chosenOptionId: "opt-c" } },
+      { interaction: { recommendedOptionId: "opt-d", chosenOptionId: "opt-e" } },
+    ]);
 
     const result = await evaluateBuildStudioPlanAdvancementGate({
       db: db as never,
@@ -266,16 +275,48 @@ describe("evaluateBuildStudioPlanAdvancementGate", () => {
       now: new Date("2026-05-17T12:00:00.000Z"),
     });
 
-    expect(db.escalationCapture.count).toHaveBeenCalledWith({
+    expect(db.escalationCapture.findMany).toHaveBeenCalledWith({
       where: {
         domainClass: PLAN_READINESS_DOMAIN_CLASS,
         createdAt: { gte: new Date("2026-04-17T12:00:00.000Z") },
-        interaction: { profileId: MARK_DPF_PLATFORM_PROFILE.profileId },
+        interaction: {
+          profileId: MARK_DPF_PLATFORM_PROFILE.profileId,
+          recommendedOptionId: { not: null },
+        },
+      },
+      select: {
+        interaction: { select: { recommendedOptionId: true, chosenOptionId: true } },
       },
     });
     expect(result.allowed).toBe(false);
     expect(result.evaluation.outcomeType).toBe("escalate");
     expect(result.evaluation.confidenceScore).toBe(0.6);
+  });
+
+  // The regression BI-ACF0D6D4 fixes: three ANSWERS that agreed with the gate
+  // must not read as three overrules. Same volume, opposite meaning.
+  it("does not lower confidence when the owner AGREED with the gate", async () => {
+    const db = makeDb();
+    db.escalationCapture.findMany.mockResolvedValue([
+      { interaction: { recommendedOptionId: "opt-a", chosenOptionId: "opt-a" } },
+      { interaction: { recommendedOptionId: "opt-a", chosenOptionId: "opt-a" } },
+      { interaction: { recommendedOptionId: "opt-b", chosenOptionId: "opt-b" } },
+    ]);
+
+    const agreed = await evaluateBuildStudioPlanAdvancementGate({
+      db: db as never,
+      build: makeBuild(),
+      now: new Date("2026-05-17T12:00:00.000Z"),
+    });
+
+    const clean = makeDb();
+    const baseline = await evaluateBuildStudioPlanAdvancementGate({
+      db: clean as never,
+      build: makeBuild(),
+      now: new Date("2026-05-17T12:00:00.000Z"),
+    });
+
+    expect(agreed.evaluation.confidenceScore).toBe(baseline.evaluation.confidenceScore);
   });
 
   it("preserves a caller-provided graduated risk tier", async () => {

--- a/apps/web/lib/decision-perspective/evaluator.ts
+++ b/apps/web/lib/decision-perspective/evaluator.ts
@@ -10,6 +10,10 @@ import { MARK_DPF_PLATFORM_PROFILE } from "./default-profile";
 import { resolveGateRecommendedOptionId } from "./option-recommendation";
 import type { AlignmentCorpora } from "./alignment-criteria";
 import { applyConstitutionalAlignment } from "./constitutional-alignment-application";
+import { getRecentOverrideCount } from "./override-count";
+
+// Re-exported for existing importers; owned by ./override-count (BI-ACF0D6D4).
+export { RECENT_OVERRIDE_WINDOW_DAYS } from "./override-count";
 import {
   hasPrincipleConflict,
   orderedProfileChain,
@@ -32,7 +36,6 @@ import type {
 
 export { scorePerspectiveMaterial } from "./material";
 
-export const RECENT_OVERRIDE_WINDOW_DAYS = 30;
 
 export function evaluateDecisionPerspective(
   input: DecisionPerspectiveEvaluationInput,
@@ -433,64 +436,6 @@ export function operatorMessageFor(
   return `WWMD recommends starting implementation with ${evaluation.confidenceScore} confidence.`;
 }
 
-/**
- * How often has the owner recently OVERRULED this profile in this domain?
- *
- * The count feeds `overridePenalty`, whose purpose is "the corpus is drifting
- * from what the owner actually does, so trust it less here". It used to count
- * every `EscalationCapture` — a row written whenever a human ANSWERS an
- * escalated decision — which measured engagement, not disagreement (BI-ACF0D6D4).
- *
- * The consequence was perverse and measured live: clearing a review queue of 13
- * items drove the penalty to its 0.3 cap, which subtracted enough confidence to
- * force the NEXT decision to escalate too. Answering the queue is what kept the
- * queue full. Agreeing with the gate penalised it exactly as hard as overruling
- * it.
- *
- * An override now requires proof of divergence: the gate must have actually
- * recommended something (`recommendedOptionId`), and the human must have chosen
- * something else. Two cases deliberately do NOT count:
- *
- *  - no recommendation was made — there was nothing to overrule, which is the
- *    shape of every plain escalation;
- *  - the human answered without picking a structured option (`chosenOptionId`
- *    null) — absence of evidence is not evidence of disagreement, and guessing
- *    here would reintroduce the same false signal in a quieter form.
- *
- * Comparing two columns is not expressible in a Prisma `where`, so the
- * candidate set is narrowed in SQL (window + domain + profile + has a
- * recommendation) and the divergence test is applied in memory. The window and
- * domain filters keep that set small.
- */
-export async function getRecentOverrideCount(input: {
-  db: any;
-  profileId: string;
-  domainClass: DecisionDomainClass;
-  now: Date;
-}): Promise<number> {
-  if (!input.db.escalationCapture?.findMany) return 0;
-  const gte = new Date(input.now.getTime() - RECENT_OVERRIDE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
-  const captures = await input.db.escalationCapture.findMany({
-    where: {
-      domainClass: input.domainClass,
-      createdAt: { gte },
-      interaction: {
-        profileId: input.profileId,
-        recommendedOptionId: { not: null },
-      },
-    },
-    select: {
-      interaction: { select: { recommendedOptionId: true, chosenOptionId: true } },
-    },
-  });
-  return captures.filter((capture: {
-    interaction: { recommendedOptionId: string | null; chosenOptionId: string | null } | null;
-  }) => {
-    const recommended = capture.interaction?.recommendedOptionId ?? null;
-    const chosen = capture.interaction?.chosenOptionId ?? null;
-    return recommended !== null && chosen !== null && chosen !== recommended;
-  }).length;
-}
 
 export async function evaluatePerspectiveGate(input: {
   db: any;

--- a/apps/web/lib/decision-perspective/evaluator.ts
+++ b/apps/web/lib/decision-perspective/evaluator.ts
@@ -433,21 +433,63 @@ export function operatorMessageFor(
   return `WWMD recommends starting implementation with ${evaluation.confidenceScore} confidence.`;
 }
 
-async function getRecentOverrideCount(input: {
+/**
+ * How often has the owner recently OVERRULED this profile in this domain?
+ *
+ * The count feeds `overridePenalty`, whose purpose is "the corpus is drifting
+ * from what the owner actually does, so trust it less here". It used to count
+ * every `EscalationCapture` — a row written whenever a human ANSWERS an
+ * escalated decision — which measured engagement, not disagreement (BI-ACF0D6D4).
+ *
+ * The consequence was perverse and measured live: clearing a review queue of 13
+ * items drove the penalty to its 0.3 cap, which subtracted enough confidence to
+ * force the NEXT decision to escalate too. Answering the queue is what kept the
+ * queue full. Agreeing with the gate penalised it exactly as hard as overruling
+ * it.
+ *
+ * An override now requires proof of divergence: the gate must have actually
+ * recommended something (`recommendedOptionId`), and the human must have chosen
+ * something else. Two cases deliberately do NOT count:
+ *
+ *  - no recommendation was made — there was nothing to overrule, which is the
+ *    shape of every plain escalation;
+ *  - the human answered without picking a structured option (`chosenOptionId`
+ *    null) — absence of evidence is not evidence of disagreement, and guessing
+ *    here would reintroduce the same false signal in a quieter form.
+ *
+ * Comparing two columns is not expressible in a Prisma `where`, so the
+ * candidate set is narrowed in SQL (window + domain + profile + has a
+ * recommendation) and the divergence test is applied in memory. The window and
+ * domain filters keep that set small.
+ */
+export async function getRecentOverrideCount(input: {
   db: any;
   profileId: string;
   domainClass: DecisionDomainClass;
   now: Date;
 }): Promise<number> {
-  if (!input.db.escalationCapture?.count) return 0;
+  if (!input.db.escalationCapture?.findMany) return 0;
   const gte = new Date(input.now.getTime() - RECENT_OVERRIDE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
-  return input.db.escalationCapture.count({
+  const captures = await input.db.escalationCapture.findMany({
     where: {
       domainClass: input.domainClass,
       createdAt: { gte },
-      interaction: { profileId: input.profileId },
+      interaction: {
+        profileId: input.profileId,
+        recommendedOptionId: { not: null },
+      },
+    },
+    select: {
+      interaction: { select: { recommendedOptionId: true, chosenOptionId: true } },
     },
   });
+  return captures.filter((capture: {
+    interaction: { recommendedOptionId: string | null; chosenOptionId: string | null } | null;
+  }) => {
+    const recommended = capture.interaction?.recommendedOptionId ?? null;
+    const chosen = capture.interaction?.chosenOptionId ?? null;
+    return recommended !== null && chosen !== null && chosen !== recommended;
+  }).length;
 }
 
 export async function evaluatePerspectiveGate(input: {

--- a/apps/web/lib/decision-perspective/override-count.test.ts
+++ b/apps/web/lib/decision-perspective/override-count.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { getRecentOverrideCount } from "./evaluator";
+
+// BI-ACF0D6D4 — `overridePenalty` is meant to mean "the owner keeps overruling
+// this profile here, so trust it less". It counted every EscalationCapture,
+// i.e. every time a human ANSWERED an escalation, so agreement was penalised
+// exactly as hard as disagreement.
+//
+// Measured live on DEPLOYED_SHA f35f608e5: clearing a 13-item review queue
+// produced 9 captures, driving the penalty to its 0.3 cap and subtracting
+// enough confidence (0.9 - 0.1 - 0.3 = 0.50, under the 0.55 threshold) to force
+// the NEXT decision to escalate. Answering the queue is what kept it full.
+describe("override penalty counts overrules, not answers (BI-ACF0D6D4)", () => {
+  type Capture = { recommendedOptionId: string | null; chosenOptionId: string | null };
+
+  /**
+   * Fake client that honours the same narrowing the real query asks for, so the
+   * test exercises the production filter rather than a copy of it.
+   */
+  function db(captures: Capture[]) {
+    return {
+      escalationCapture: {
+        findMany: vi.fn(async (args: { where?: { interaction?: { recommendedOptionId?: unknown } } }) => {
+          const requiresRecommendation = args?.where?.interaction?.recommendedOptionId !== undefined;
+          return captures
+            .filter((c) => (requiresRecommendation ? c.recommendedOptionId !== null : true))
+            .map((interaction) => ({ interaction }));
+        }),
+      },
+    };
+  }
+
+  const args = (captures: Capture[]) => ({
+    db: db(captures),
+    profileId: "org-1",
+    domainClass: "risk-assessment" as const,
+    now: new Date("2026-08-16T00:00:00.000Z"),
+  });
+
+  it("does not count an answer that AGREED with the recommendation", async () => {
+    expect(await getRecentOverrideCount(args([{ recommendedOptionId: "a", chosenOptionId: "a" }]))).toBe(0);
+  });
+
+  it("counts an answer that chose differently", async () => {
+    expect(await getRecentOverrideCount(args([{ recommendedOptionId: "a", chosenOptionId: "b" }]))).toBe(1);
+  });
+
+  // The live shape: a plain escalation carries no recommendation, so answering
+  // it overrules nothing. This is the case that drove the penalty to its cap.
+  it("does not count answers to escalations that made no recommendation", async () => {
+    expect(await getRecentOverrideCount(args([
+      { recommendedOptionId: null, chosenOptionId: "a" },
+      { recommendedOptionId: null, chosenOptionId: null },
+      { recommendedOptionId: null, chosenOptionId: "b" },
+    ]))).toBe(0);
+  });
+
+  // Absence of evidence is not evidence of disagreement — guessing here would
+  // reintroduce the same false signal in a quieter form.
+  it("does not count an answer with no structured option chosen", async () => {
+    expect(await getRecentOverrideCount(args([{ recommendedOptionId: "a", chosenOptionId: null }]))).toBe(0);
+  });
+
+  it("counts only the genuine overrules in a mixed set", async () => {
+    expect(await getRecentOverrideCount(args([
+      { recommendedOptionId: "a", chosenOptionId: "a" },
+      { recommendedOptionId: "a", chosenOptionId: "b" },
+      { recommendedOptionId: null, chosenOptionId: "c" },
+      { recommendedOptionId: "x", chosenOptionId: null },
+      { recommendedOptionId: "y", chosenOptionId: "z" },
+    ]))).toBe(2);
+  });
+
+  it("narrows in SQL before filtering in memory", async () => {
+    const client = db([{ recommendedOptionId: "a", chosenOptionId: "b" }]);
+    await getRecentOverrideCount({ ...args([]), db: client });
+    const where = (client.escalationCapture.findMany.mock.calls[0]![0] as {
+      where: {
+        domainClass: string;
+        createdAt: { gte: Date };
+        interaction: { profileId: string; recommendedOptionId: unknown };
+      };
+    }).where;
+    expect(where.domainClass).toBe("risk-assessment");
+    expect(where.interaction.profileId).toBe("org-1");
+    expect(where.interaction.recommendedOptionId).toEqual({ not: null });
+    expect(where.createdAt.gte).toBeInstanceOf(Date);
+  });
+
+  it("fails closed to zero when captures cannot be read", async () => {
+    expect(await getRecentOverrideCount({ ...args([]), db: {} })).toBe(0);
+  });
+});

--- a/apps/web/lib/decision-perspective/override-count.test.ts
+++ b/apps/web/lib/decision-perspective/override-count.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { getRecentOverrideCount } from "./evaluator";
+import { getRecentOverrideCount } from "./override-count";
 
 // BI-ACF0D6D4 — `overridePenalty` is meant to mean "the owner keeps overruling
 // this profile here, so trust it less". It counted every EscalationCapture,

--- a/apps/web/lib/decision-perspective/override-count.ts
+++ b/apps/web/lib/decision-perspective/override-count.ts
@@ -1,0 +1,70 @@
+// Recent-override counting for the decision gate's confidence discount.
+//
+// Extracted from `evaluator.ts` (BI-ACF0D6D4) when that module crossed the
+// 800-LOC ceiling. One concern: deciding what counts as the owner having
+// OVERRULED a profile, which is a governance judgement worth reading on its own
+// rather than buried in the evaluator.
+
+import type { DecisionDomainClass } from "./types";
+
+/** Window over which an overrule still counts against a profile's confidence. */
+export const RECENT_OVERRIDE_WINDOW_DAYS = 30;
+
+/**
+ * How often has the owner recently OVERRULED this profile in this domain?
+ *
+ * The count feeds `overridePenalty`, whose purpose is "the corpus is drifting
+ * from what the owner actually does, so trust it less here". It used to count
+ * every `EscalationCapture` — a row written whenever a human ANSWERS an
+ * escalated decision — which measured engagement, not disagreement (BI-ACF0D6D4).
+ *
+ * The consequence was perverse and measured live: clearing a review queue of 13
+ * items drove the penalty to its 0.3 cap, which subtracted enough confidence to
+ * force the NEXT decision to escalate too. Answering the queue is what kept the
+ * queue full. Agreeing with the gate penalised it exactly as hard as overruling
+ * it.
+ *
+ * An override now requires proof of divergence: the gate must have actually
+ * recommended something (`recommendedOptionId`), and the human must have chosen
+ * something else. Two cases deliberately do NOT count:
+ *
+ *  - no recommendation was made — there was nothing to overrule, which is the
+ *    shape of every plain escalation;
+ *  - the human answered without picking a structured option (`chosenOptionId`
+ *    null) — absence of evidence is not evidence of disagreement, and guessing
+ *    here would reintroduce the same false signal in a quieter form.
+ *
+ * Comparing two columns is not expressible in a Prisma `where`, so the
+ * candidate set is narrowed in SQL (window + domain + profile + has a
+ * recommendation) and the divergence test is applied in memory. The window and
+ * domain filters keep that set small.
+ */
+export async function getRecentOverrideCount(input: {
+  db: any;
+  profileId: string;
+  domainClass: DecisionDomainClass;
+  now: Date;
+}): Promise<number> {
+  if (!input.db.escalationCapture?.findMany) return 0;
+  const gte = new Date(input.now.getTime() - RECENT_OVERRIDE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const captures = await input.db.escalationCapture.findMany({
+    where: {
+      domainClass: input.domainClass,
+      createdAt: { gte },
+      interaction: {
+        profileId: input.profileId,
+        recommendedOptionId: { not: null },
+      },
+    },
+    select: {
+      interaction: { select: { recommendedOptionId: true, chosenOptionId: true } },
+    },
+  });
+  return captures.filter((capture: {
+    interaction: { recommendedOptionId: string | null; chosenOptionId: string | null } | null;
+  }) => {
+    const recommended = capture.interaction?.recommendedOptionId ?? null;
+    const chosen = capture.interaction?.chosenOptionId ?? null;
+    return recommended !== null && chosen !== null && chosen !== recommended;
+  }).length;
+}

--- a/docs/architecture/vector-decisioning-and-jsi.md
+++ b/docs/architecture/vector-decisioning-and-jsi.md
@@ -174,9 +174,25 @@ effectiveWeight = confidenceWeight × freshnessFactor × evidenceFactor × revie
 where each factor is an independent [0,1] discount: `freshnessFactor` (current 1 / stale 0.5 /
 superseded 0.2 / contradicted 0), `evidenceFactor` by grade (A 1 / B 0.75 / C 0.4 / D 0),
 `reviewFactor` (approved 1 / draft 0.35 / rejected 0), `promotionFactor` (promoted 1 / candidate
-0.45 / revoked 0). Confidence for a domain is the mean `effectiveWeight` across applicable
-materials, minus a risk-tier penalty (0 / 0.1 / 0.25 / 0.5 for low/medium/high/critical) and a
-recent-override penalty (capped at 0.3).
+0.45 / revoked 0).
+
+Confidence is then computed one of two ways, minus a risk-tier penalty (0 / 0.1 / 0.25 / 0.5 for
+low/medium/high/critical) and a recent-override penalty (capped at 0.3):
+
+- **Content-blind (WWMD / build-studio):** the mean `effectiveWeight` across applicable materials.
+  Coverage-shaped — it answers "how well-grounded is this class", not "what does our doctrine say
+  about THIS question".
+- **Content-aware (WWWD, BI-7E1F128A):** each material is weighted by its semantic relevance to the
+  question, and confidence is the strongest relevant DIRECTIONAL weight scaled by how one-sided the
+  relevant material is (`bestDirectionalWeight × |alignmentScore|`). Relevance is min-max normalised
+  **within the set actually scored** (BI-F5F2869D) — normalising across material that never gets
+  scored leaves the scored set with no 1.0 and an arbitrary ceiling.
+
+The recent-override penalty counts times the owner OVERRULED the profile in that class — the gate
+recommended one option and the human chose another. It deliberately does not count answering an
+escalation that carried no recommendation, nor an answer that agreed, nor one where no structured
+option was picked (BI-ACF0D6D4). Counting answers rather than overrules made working through a
+review queue drive the penalty to its cap and suppress the next decision.
 
 **External grounding.** A confidence score built as a **product of independent reliability
 discount factors applied to a base weight** is the same structural move as the **GRADE framework**

--- a/docs/user-guide/ai-workforce/decision-perspective.md
+++ b/docs/user-guide/ai-workforce/decision-perspective.md
@@ -42,6 +42,21 @@ When a coworker or external MCP client hits a decision point that doesn't have a
 
 Every invocation writes a `DecisionInteraction` row recording the active profile version, the source materials cited, the confidence score, the chosen outcome, and the rationale text. This is the audit ledger — auditors and operators reconstruct "what perspective governed this decision, and on what evidence" from it.
 
+**Answering the queue does not make your AI less confident.** Confidence carries a
+discount for how often you have recently OVERRULED a profile in the same decision
+class — the signal being "our recorded doctrine is drifting from what the owner
+actually does here, so trust it less". An overrule means the gate recommended one
+option and you chose a different one. Simply answering an escalation is not an
+overrule, and neither is agreeing with the recommendation.
+
+This mattered in practice (BI-ACF0D6D4): the discount used to count every answer,
+so clearing a review queue drove it to its cap and pushed the NEXT decision below
+the threshold to act — working through your backlog was what kept the backlog
+full. Two cases deliberately do not count against you: an escalation that carried
+no recommendation (there was nothing to overrule), and an answer where you did not
+pick one of the offered options (that is not evidence of disagreement). Repeated
+genuine disagreement in a class still lowers autonomy there, which is the point.
+
 ### Consequential Action Alignment
 
 For a consequential tool call, Decision Perspective is a pre-execution control rather than optional advice. The gate extracts the proposed market, customer, product, geography, and go-to-market motion, then checks them independently against the organization's published WWWD stance, organization-owned product portfolio, and GTM evidence. An explicit hard boundary in any required corpus vetoes the action; positive signals elsewhere cannot average the veto away.


### PR DESCRIPTION
Third and final cause in the chain behind "the AI keeps asking me things it already knows". #4341 fixed retrieval, #4346 fixed relevance normalisation — and neither changed the observed outcome, because this consumed the entire gain.

## The bug

`overridePenalty` means "the owner keeps overruling this profile here, so trust it less". It counted every `EscalationCapture` — a row written whenever a human **answers** an escalated decision. It never compared the human's choice to the gate's recommendation, so **agreeing penalised the gate exactly as hard as overruling it**.

Measured live on `DEPLOYED_SHA f35f608e5`. Clearing a 13-item review queue produced **9** captures for the org profile in `risk-assessment`, hitting the 0.3 cap:

```
bestDirectionalWeight 0.9 − RISK_PENALTY 0.1 − overridePenalty 0.3 = 0.50
```

0.50 is under the 0.55 recommendation threshold, so the next decision escalated too. **Answering the queue is what kept the queue full.**

## The fix

An override now requires proof of divergence: the gate must have recommended something, and the human must have chosen something else. Two cases deliberately don't count:

- **no recommendation was made** — nothing to overrule, which is the shape of every plain escalation;
- **no structured option chosen** — absence of evidence isn't evidence of disagreement, and guessing would reintroduce the same false signal more quietly.

Genuine repeated dissent still reduces autonomy, which is the signal's actual purpose.

Column-to-column comparison isn't expressible in a Prisma `where`, so the candidate set is narrowed in SQL (window + domain + profile + has a recommendation) and the divergence test runs in memory over that small set.

Approach scored through `principle_decide` rather than chosen unilaterally: **count-genuine-overrides**, margin 2.249, high confidence, no commandment conflict, over removing the penalty and over relocating it to a corpus-freshness finding (`DI-A6F090303766`).

## Test integrity

`getRecentOverrideCount` is now exported so its tests call the real function. **My first draft re-implemented the filter inside the test file** — it passed 6/6 and would have stayed green if the production code did the opposite. Rewritten to exercise the actual code, including an assertion on the SQL narrowing.

One existing build-studio test asserted the old `count` contract. It now supplies three *genuine overrules* and still expects the same lowered confidence, with a new sibling proving three answers that **agreed** leave confidence untouched — same volume, opposite meaning, which is precisely the defect.

`override-count.ts` is a pure extraction: `evaluator.ts` hit the 800-LOC ceiling at 841 (the rationale comment is long because this is a governance judgement, not a mechanical detail). 841 → 782, new module 70.

## Verification

- Local-CI gate **PASS** at `2af571074d5a`.
- 1906 tests green across `lib/decision-perspective`, `lib/founder-review`, `lib/decision`, `lib/actions`.
- **Falsifiable prediction:** genuine overrules in the live window = 0, so after redeploy the MSP question should compute `0.9 − 0.1 − 0 = 0.80`, clear 0.55, and resolve instead of escalate — while a novel aligned proposition still escalates as "New proposition". Both currently return an indistinguishable 0.50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)