### PR TITLE
docs(spec): record field evidence for the Stage 2/4 split

### DIFF
--- a/docs/superpowers/specs/2026-08-15-resilient-concurrent-development-process.md
+++ b/docs/superpowers/specs/2026-08-15-resilient-concurrent-development-process.md
@@ -47,6 +47,53 @@ Validation / user acceptance is the final stage and legitimately happens **post-
 
 **Key rule:** Stage 4 (cloud) is a *safety net*, not where failures are discovered. Failures must surface fast at Stage 2 (local, in-context) — otherwise threads pay the slow git round-trip (push → wait → CI-red → return → fix → re-push). Stage 2 is comprehensive *because* it is plain-Node, not Docker. Docs/reconciliation branches → lint only.
 
+## 4a. Observed in the field (2026-08-15/16) — evidence for the Stage 2/4 split
+
+One Claude Code session shipped five PRs (#4335, #4343, #4345, #4347, #4353) in a
+single evening while other sessions worked concurrently. It ran the heavy local
+Docker gate (`pnpm run pregate`) roughly **fourteen times to get five passes**.
+The failure distribution is the argument for §4's Stage 2/4 split, so it is
+recorded rather than left as folklore.
+
+**Cheap, correct failures — the preflight (~16–25 s each).** Module Size Guard,
+Derived Artifact Registry (a doc edit left `doc-impact.generated.json` stale), and
+Design Grounding Gate each failed fast, before any lease was claimed, and each was
+a real defect. This is precisely the Stage 2 behaviour the pipeline wants: plain
+Node, seconds, in-context, no Docker, no shared resource consumed.
+
+**Expensive, non-informative failures — the Docker stage.** Six of the fourteen
+runs died without producing build evidence:
+
+| Failure | Count | Cost each | Signal |
+| --- | --- | --- | --- |
+| `blocked_sandbox_drift` (exit 3) | 3 | ~5 s + a lease cycle | none — sandbox defect, self-heals on plain re-run |
+| `received SIGTERM` mid-run (exit 1) | 3 | 0:30, 1:10, 2:06 into ~3–5 min runs | none — the log showed `fail 0` throughout |
+
+The SIGTERMs were **slot contention**, not a product failure and not a defect in
+the invocation. Host state at the time: load average 5.4, ~22 live worktrees,
+several sessions gating against the same 2-slot resource. The decisive evidence
+is that the run passed first try once `list_nonprod_environment_leases` returned
+`{leases:[],queued:[]}`.
+
+**Diagnostic rule for any surface hitting this:** on `gate-worktree: received
+SIGTERM`, do **not** retry blindly and do **not** "fix" the invocation — check
+`list_nonprod_environment_leases` and retry only when it is empty. (A plausible
+but wrong hypothesis was pursued first in this session — that redirecting the
+command's output caused it — and was disproved when an unpiped, sole-command run
+died the same way. The queue message is also mildly misleading: "previous
+local-CI lease claim was released; creating fresh admission attempt N" can print
+while another session still holds the slot.)
+
+**Why this is evidence for the design, not an argument for a bigger gate.** Every
+defect that mattered was caught by the seconds-long preflight. The multi-minute
+Docker stage caught nothing in fourteen attempts that the cheap stage had not
+already caught, while consuming the scarce shared resource ~9 times without
+producing evidence. §1's second structural fault — one scarce heavyweight local
+resource that starves under demand — is not a projection; this is it happening at
+a fan-out of a handful of threads, well below the ~160 the pipeline targets.
+
+Tracked under `BI-8D56F777` (Stages 2 + 4).
+
 ## 5. Cross-surface enforcement matrix
 
 "Gate" = mandatory/platform; "Skill" = advisory paved road; every surface inherits both.


### PR DESCRIPTION
Advances BI-8D56F777 (Stages 2 + 4), EP-056D2A5E. Documentation only.

## Why

§1 of this spec predicts that funnelling every thread through **one scarce, heavyweight, local Docker gate** will starve under demand. This records an instance of exactly that, with numbers, so the claim stops being a projection and becomes evidence.

## The data

One Claude Code session shipped five PRs (#4335, #4343, #4345, #4347, #4353) in an evening, alongside other concurrent sessions. It ran `pnpm run pregate` roughly **fourteen times to get five passes**.

**Cheap and correct — the preflight (~16–25 s, no lease claimed):**
Module Size Guard, Derived Artifact Registry (a doc edit left `doc-impact.generated.json` stale), Design Grounding Gate. Every one a *real defect*, caught in seconds by plain Node. This is exactly the Stage 2 behaviour the pipeline wants.

**Expensive and non-informative — the Docker stage:**

| Failure | Count | Cost | Signal |
|---|---|---|---|
| `blocked_sandbox_drift` (exit 3) | 3 | ~5 s + a lease cycle | none — self-heals on plain re-run |
| `received SIGTERM` mid-run (exit 1) | 3 | 0:30, 1:10, 2:06 into 3–5 min runs | none — log showed `fail 0` throughout |

The SIGTERMs were **slot contention** — host load 5.4, ~22 live worktrees, several sessions gating at once — and the run passed first try once `list_nonprod_environment_leases` returned `{leases:[],queued:[]}`.

## The load-bearing point

Every defect that mattered was caught by the seconds-long preflight. The multi-minute Docker stage caught **nothing in fourteen attempts** that the cheap stage had not already caught, while consuming the scarce shared resource ~9 times without producing evidence — at a fan-out of *a handful* of threads, far below the ~160 the pipeline targets.

## Also recorded

A diagnostic rule for any surface hitting this: on `gate-worktree: received SIGTERM`, do **not** retry blindly and do **not** "fix" the invocation — check the leases and retry only when empty.

Including the wrong hypothesis pursued first in that session (that redirecting the command's output caused it), disproved when an unpiped sole-command run died identically. Recorded deliberately: the wrong theory is cheap to re-derive and costs a real debugging cycle each time. Also notes the queue message can print "previous local-CI lease claim was released" while another session still holds the slot.

## Verification

`pnpm run pregate` PASS — gated sha `227acd13c95a`, evidence `cmsvb1jx708e401prdrvmxvsp`. Passed first try with the lease confirmed clear beforehand, which is the fifteenth data point for the rule above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)