### PR TITLE
fix(edge-node): narrow the unsupported device-detail result, and typecheck every package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "pnpm -r --if-present --workspace-concurrency=1 --no-bail test",
     "test:e2e": "playwright test",
     "test:e2e:demo": "playwright test -c playwright-demo.config.ts",
-    "typecheck": "pnpm --filter web typecheck && pnpm --filter @dpf/db typecheck && pnpm --filter @dpf/types typecheck && pnpm --filter @dpf/validators typecheck && pnpm --filter @dpf/api-client typecheck && pnpm --filter @dpf/bootstrap typecheck && pnpm --filter mobile typecheck",
+    "typecheck": "pnpm -r --if-present typecheck",
     "db:generate": "pnpm --filter @dpf/db generate",
     "db:migrate": "pnpm --filter @dpf/db migrate",
     "db:seed": "pnpm --filter @dpf/db seed",

--- a/scripts/process-spine-conformance.test.mjs
+++ b/scripts/process-spine-conformance.test.mjs
@@ -74,5 +74,28 @@ test("typecheck gates include the bootstrap planning library", () => {
   assert.match(hook, /RUN_BOOTSTRAP=0/);
   assert.match(hook, /packages\/dpf-bootstrap\/\*\)\s+RUN_BOOTSTRAP=1/);
   assert.match(hook, /run_typecheck "@dpf\/bootstrap"\s+"packages\/dpf-bootstrap"/);
-  assert.match(rootPackage.scripts.typecheck, /--filter @dpf\/bootstrap typecheck/);
+
+  // The property is "root typecheck covers @dpf/bootstrap", not "root
+  // typecheck names @dpf/bootstrap". A recursive sweep satisfies it for every
+  // package at once, so pinning the explicit filter string would forbid the
+  // stronger form — and an enumerated list is what let dpf-edge-node go
+  // untypechecked until its release build failed.
+  const rootTypecheck = rootPackage.scripts.typecheck;
+  const sweepsWorkspace = /pnpm -r\b[^&|]*\btypecheck\b/.test(rootTypecheck);
+  assert.ok(
+    sweepsWorkspace || /--filter @dpf\/bootstrap typecheck/.test(rootTypecheck),
+    `root typecheck must cover @dpf/bootstrap, got: ${rootTypecheck}`,
+  );
+
+  // A sweep only covers the package if the package actually defines the
+  // script the sweep looks for, so assert that rather than assuming it.
+  if (sweepsWorkspace) {
+    const bootstrapPackage = JSON.parse(
+      readFileSync(join(repoRoot, "packages/dpf-bootstrap/package.json"), "utf8"),
+    );
+    assert.ok(
+      bootstrapPackage.scripts?.typecheck,
+      "@dpf/bootstrap must define a typecheck script for the recursive sweep to pick it up",
+    );
+  }
 });

--- a/services/edge-node/src/collectors/unifi.ts
+++ b/services/edge-node/src/collectors/unifi.ts
@@ -553,7 +553,11 @@ async function collectOfficialUnifi(
     })),
   );
   for (const { device, detail } of details) {
-    if (detail.kind === "error") {
+    // "unsupported" (404/405/501 from fetchOfficialObject) has to be handled
+    // alongside "error" here, not just for type-narrowing: an older controller
+    // generation with no per-device detail endpoint would otherwise read as a
+    // successful fetch. Matches how the clients call below folds the two.
+    if (detail.kind === "error" || detail.kind === "unsupported") {
       warnings.push(`unifi_partial:device_detail:${device.id}`);
       continue;
     }


### PR DESCRIPTION
## Summary

Follow-on to #4351. That PR restored the release chain and it fired for the first time in seven weeks: `v2026.08.16` was cut automatically and **the GitHub Release published successfully with all three counted Edge binary assets**. The image matrix did not — `dpf-edge-node` failed on both arches, this time on a *different* fault that the previous `ENOENT` had been masking. This PR fixes that fault and closes the CI gap that let it reach the release pipeline at all.

## Changes

- `services/edge-node/src/collectors/unifi.ts`: fold `"unsupported"` in with `"error"` when handling the per-device detail fetch.
- `package.json`: replace the hand-enumerated `typecheck` filter list with `pnpm -r --if-present typecheck`.

### The bug

```
src/collectors/unifi.ts(560,29): error TS2339: Property 'data' does not exist on type
  '{ kind: "unsupported"; } | { kind: "success"; data: OfficialDeviceDetail; }'
```

`fetchOfficialObject` returns a three-way union — success / unsupported / error — and the guard only narrowed out `"error"`. Beyond the type failure this is a live correctness bug: `"unsupported"` is what a 404/405/501 becomes, so a controller generation without a per-device detail endpoint would have been treated as a **successful fetch**. Three of the four callsites in this file already handle `"unsupported"`; the clients call 40 lines below uses exactly the `error || unsupported` form adopted here.

### Why CI never caught it

The root `typecheck` was a hand-maintained list of seven filters. **Fourteen** workspace packages define a `typecheck` script — seven were missing, including `dpf-edge-node`. Their type errors could therefore only surface at Docker build time, inside the release pipeline, after a tag had already been cut and a Release published.

That is the same drift shape as the hand-enumerated CI test inventory. Adding seven more entries just resets the clock, so the list is now `pnpm -r --if-present typecheck` — self-maintaining, and already the idiom used by the `test` script directly above it.

**All seven previously-unchecked packages are green today**, so this closes the hole without importing a backlog: `dpf-edge-node`, `dpf-adp-mcp`, `dpf-integration-test-harness`, `@dpf/coworker-sim-harness`, `@dpf/finance-templates`, `@dpf/integration-shared`, `@dpf/storefront-templates`.

## Test plan

- [x] **Source-only change** (isolated unit logic + build script)
  - [x] `pnpm typecheck` — the new recursive form, exit 0 across all 14 packages
  - [x] Targeted unit tests: `pnpm --filter dpf-edge-node test`

### Verification evidence

**Red/green against the compiler, not by inspection** — the unfixed tree reproduces CI's error at the identical position:

```
$ git stash && pnpm --filter dpf-edge-node typecheck
src/collectors/unifi.ts(560,29): error TS2339: Property 'data' does not exist on type
  '{ kind: "unsupported"; } | { kind: "success"; data: OfficialDeviceDetail; }'

$ git stash pop && pnpm --filter dpf-edge-node typecheck
> tsc --noEmit
EXIT=0
```

**Root typecheck, the exact command CI runs:**

```
$ pnpm typecheck
apps/web typecheck: Done
apps/mobile typecheck: Done
... 14 packages
EXIT=0
```

Also confirmed `pnpm -r` does **not** recurse into the root package — that would loop, since root defines `typecheck` itself.

**Each newly-covered package, individually:**

```
GREEN dpf-edge-node          GREEN @dpf/coworker-sim-harness
GREEN dpf-adp-mcp            GREEN @dpf/finance-templates
GREEN dpf-integration-test-harness   GREEN @dpf/integration-shared
GREEN @dpf/storefront-templates
```

**Edge-node suite:** `Test Files 15 passed (15) | Tests 199 passed | 5 skipped (204)`.

## Pre-PR readiness

Full workspace install and typecheck ran in a clean clone, so the source gates above are real. `pnpm run pregate` still cannot run: this machine's D: worktree tree and Docker engine are being torn down by a concurrent session, so there is no runtime to lease.

Local-CI-Override: external-contribution-no-install: clean clone outside the managed worktree tree; host Docker engine down (concurrent teardown), so no runtime-bound gate can execute locally. CI gates this PR in full.

## Overlap sweep

`gh pr list --state open --limit 50` at branch time → #4350 (`feat/qwen38-27b-local-tier`) and #4331 (`feat/build-studio-owner-brief-proof`). Neither touches `services/edge-node` or the root `typecheck` script. No coordination needed.

## Notes for the reviewer

- **`package.json` is the higher-risk half of this PR**, not the one-line type fix. It widens what `pnpm typecheck` covers for every developer and every CI job that calls it. It is green across the whole workspace right now, but it will start failing builds on packages that were previously invisible — which is the point.
- **`:latest` was never repointed by the failed run.** The `merge` job is `needs: build`, so it was skipped along with the E2E verification. No bad image shipped; the seven-week-old `latest` is still in place.
- **`v2026.08.16` will not retroactively get images.** That tag points at a commit without this fix. The next daily checkpoint is the first one that can complete the full chain.
- Still open from #4351: gating the `:latest` tag behind the E2E verify job, rather than repointing it before verification runs. Worth a BI once the portal is back up to file one through the governed path.
