### PR TITLE
feat(twin): TERRITORY map substrate — geographic scene, asset ranges, map packs (BI-3A56AE0C)

### DIFF
--- a/apps/web/lib/twin/geographic-scene.test.ts
+++ b/apps/web/lib/twin/geographic-scene.test.ts
@@ -1,0 +1,137 @@
+import type { GeographicSceneLayout } from "@dpf/storefront-templates";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGeographicSceneModel,
+  geographicBounds,
+  validateGeographicSceneLayout,
+} from "./geographic-scene";
+
+const layout: GeographicSceneLayout = {
+  schemaVersion: 1,
+  spaceKind: "geographic",
+  viewport: { longitude: -87.6298, latitude: 41.8781, zoom: 10 },
+  zones: [{
+    id: "north-zone",
+    label: "North service zone",
+    geometry: {
+      kind: "polygon",
+      rings: [[
+        { longitude: -87.7, latitude: 41.95 },
+        { longitude: -87.6, latitude: 41.95 },
+        { longitude: -87.6, latitude: 41.88 },
+        { longitude: -87.7, latitude: 41.95 },
+      ]],
+    },
+  }],
+  placements: [
+    {
+      id: "depot-placement",
+      label: "North depot",
+      entityRef: { kind: "service-depot", id: "depot-north" },
+      geometry: { kind: "point", longitude: -87.65, latitude: 41.91 },
+    },
+    {
+      id: "route-placement",
+      entityRef: { kind: "service-route", id: "route-7" },
+      geometry: {
+        kind: "line-string",
+        coordinates: [
+          { longitude: -87.65, latitude: 41.91 },
+          { longitude: -87.61, latitude: 41.89 },
+        ],
+      },
+    },
+  ],
+};
+
+describe("geographic scene adapter", () => {
+  it("validates and projects stable domain-neutral GeoJSON features", () => {
+    expect(validateGeographicSceneLayout(layout)).toEqual({ ok: true, value: layout });
+
+    const model = buildGeographicSceneModel({
+      layout,
+      selectedEntityIds: ["depot-north"],
+      presentations: {
+        "depot-north": { label: "Depot A", statusLabel: "Ready", intent: "success" },
+      },
+    });
+
+    expect(model.zones.features[0]).toMatchObject({
+      id: "north-zone",
+      geometry: { type: "Polygon" },
+      properties: { featureKind: "zone", label: "North service zone" },
+    });
+    expect(model.placements.features).toEqual([
+      expect.objectContaining({
+        id: "depot-placement",
+        geometry: { type: "Point", coordinates: [-87.65, 41.91] },
+        properties: expect.objectContaining({
+          entityId: "depot-north",
+          label: "Depot A",
+          statusLabel: "Ready",
+          selected: true,
+        }),
+      }),
+      expect.objectContaining({
+        id: "route-placement",
+        // Assert the projected coordinates, not just the geometry type.
+        // `objectContaining` only relaxes the keys it is given — the VALUE of
+        // `geometry` is still compared with strict deep equality, so a partial
+        // `{ type: "LineString" }` can never match a real GeoJSON LineString.
+        // Spelling the pairs out also actually exercises the projection this
+        // test claims to cover: {longitude, latitude} -> [lng, lat].
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [-87.65, 41.91],
+            [-87.61, 41.89],
+          ],
+        },
+        properties: expect.objectContaining({ entityId: "route-7", selected: false }),
+      }),
+    ]);
+  });
+
+  it("rejects invalid coordinates and open polygon rings", () => {
+    expect(validateGeographicSceneLayout({
+      ...layout,
+      viewport: { longitude: 181, latitude: 41.8, zoom: 10 },
+    })).toMatchObject({ ok: false });
+    expect(validateGeographicSceneLayout({
+      ...layout,
+      zones: [{
+        ...layout.zones[0],
+        geometry: {
+          kind: "polygon",
+          rings: [[
+            { longitude: -87.7, latitude: 41.95 },
+            { longitude: -87.6, latitude: 41.95 },
+            { longitude: -87.6, latitude: 41.88 },
+            { longitude: -87.5, latitude: 41.8 },
+          ]],
+        },
+      }],
+    })).toMatchObject({ ok: false });
+  });
+
+  it("derives the smallest bounds across the antimeridian", () => {
+    expect(geographicBounds([
+      { longitude: 179, latitude: 10 },
+      { longitude: -179, latitude: 12 },
+    ])).toEqual({
+      west: 179,
+      south: 10,
+      east: -179,
+      north: 12,
+      crossesAntimeridian: true,
+    });
+  });
+
+  it("rejects feature id reuse across zones and placements", () => {
+    expect(validateGeographicSceneLayout({
+      ...layout,
+      placements: [{ ...layout.placements[0], id: "north-zone" }],
+    })).toEqual({ ok: false, error: "Geographic placement is invalid or reuses a feature id." });
+  });
+});

--- a/apps/web/lib/twin/geographic-scene.ts
+++ b/apps/web/lib/twin/geographic-scene.ts
@@ -1,0 +1,303 @@
+import type {
+  GeographicCoordinate,
+  GeographicPlacementGeometry,
+  GeographicPolygonGeometry,
+  GeographicSceneLayout,
+} from "@dpf/storefront-templates";
+
+import { isRecord } from "@/lib/shared/coerce";
+
+export const MAX_GEOGRAPHIC_SCENE_ZONES = 200;
+export const MAX_GEOGRAPHIC_SCENE_PLACEMENTS = 5_000;
+
+const MAX_COORDINATES = 20_000;
+const MAX_ID_LENGTH = 160;
+const MAX_LABEL_LENGTH = 240;
+const MIN_ZOOM = 0;
+const MAX_ZOOM = 24;
+
+type GeoJsonPosition = [longitude: number, latitude: number];
+
+type GeoJsonGeometry =
+  | { type: "Point"; coordinates: GeoJsonPosition }
+  | { type: "LineString"; coordinates: GeoJsonPosition[] }
+  | { type: "Polygon"; coordinates: GeoJsonPosition[][] };
+
+export interface GeographicFeatureProperties {
+  featureId: string;
+  featureKind: "zone" | "placement";
+  label: string;
+  entityKind: string | null;
+  entityId: string | null;
+  selected: boolean;
+  statusLabel: string | null;
+  sublabel: string | null;
+  intent: string | null;
+}
+
+export interface GeographicFeature {
+  type: "Feature";
+  id: string;
+  geometry: GeoJsonGeometry;
+  properties: GeographicFeatureProperties;
+}
+
+export interface GeographicFeatureCollection {
+  type: "FeatureCollection";
+  features: GeographicFeature[];
+}
+
+export interface GeographicScenePresentation {
+  label?: string;
+  statusLabel?: string;
+  sublabel?: string;
+  intent?: string;
+}
+
+export type GeographicScenePresentationMap = Readonly<
+  Record<string, GeographicScenePresentation>
+>;
+
+export interface GeographicBounds {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+  crossesAntimeridian: boolean;
+}
+
+export interface GeographicSceneModel {
+  viewport: GeographicSceneLayout["viewport"];
+  bounds: GeographicBounds;
+  zones: GeographicFeatureCollection;
+  placements: GeographicFeatureCollection;
+}
+
+export type GeographicSceneValidationResult =
+  | { ok: true; value: GeographicSceneLayout }
+  | { ok: false; error: string };
+
+function validString(value: unknown, maxLength: number): value is string {
+  return (
+    typeof value === "string" &&
+    value.trim().length > 0 &&
+    value.length <= maxLength
+  );
+}
+
+function validLongitude(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= -180 && value <= 180;
+}
+
+function validLatitude(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= -90 && value <= 90;
+}
+
+function validCoordinate(value: unknown): value is GeographicCoordinate {
+  return isRecord(value) && validLongitude(value.longitude) && validLatitude(value.latitude);
+}
+
+function sameCoordinate(left: GeographicCoordinate, right: GeographicCoordinate): boolean {
+  return left.longitude === right.longitude && left.latitude === right.latitude;
+}
+
+function validPolygon(value: unknown): value is GeographicPolygonGeometry {
+  if (!isRecord(value) || value.kind !== "polygon" || !Array.isArray(value.rings) || value.rings.length === 0) {
+    return false;
+  }
+  return value.rings.every((ring) =>
+    Array.isArray(ring) &&
+    ring.length >= 4 &&
+    ring.length <= MAX_COORDINATES &&
+    ring.every(validCoordinate) &&
+    sameCoordinate(ring[0], ring[ring.length - 1]),
+  );
+}
+
+function validPlacementGeometry(value: unknown): value is GeographicPlacementGeometry {
+  if (!isRecord(value) || typeof value.kind !== "string") return false;
+  if (value.kind === "point") return validCoordinate(value);
+  if (value.kind === "line-string") {
+    return Array.isArray(value.coordinates) && value.coordinates.length >= 2 && value.coordinates.every(validCoordinate);
+  }
+  return validPolygon(value);
+}
+
+function coordinateCount(value: GeographicPlacementGeometry): number {
+  if (value.kind === "point") return 1;
+  if (value.kind === "line-string") return value.coordinates.length;
+  return value.rings.reduce((total, ring) => total + ring.length, 0);
+}
+
+export function validateGeographicSceneLayout(value: unknown): GeographicSceneValidationResult {
+  if (!isRecord(value) || value.schemaVersion !== 1 || value.spaceKind !== "geographic") {
+    return { ok: false, error: "Geographic scene must use schema version 1 and geographic space kind." };
+  }
+  if (
+    !isRecord(value.viewport) ||
+    !validCoordinate(value.viewport) ||
+    typeof value.viewport.zoom !== "number" ||
+    !Number.isFinite(value.viewport.zoom) ||
+    value.viewport.zoom < MIN_ZOOM ||
+    value.viewport.zoom > MAX_ZOOM
+  ) {
+    return { ok: false, error: "Geographic viewport is outside supported coordinate or zoom bounds." };
+  }
+  if (!Array.isArray(value.zones) || value.zones.length > MAX_GEOGRAPHIC_SCENE_ZONES) {
+    return { ok: false, error: `Geographic scene supports at most ${MAX_GEOGRAPHIC_SCENE_ZONES} zones.` };
+  }
+  if (!Array.isArray(value.placements) || value.placements.length > MAX_GEOGRAPHIC_SCENE_PLACEMENTS) {
+    return { ok: false, error: `Geographic scene supports at most ${MAX_GEOGRAPHIC_SCENE_PLACEMENTS} placements.` };
+  }
+  if (value.underlayRef !== undefined && !validString(value.underlayRef, MAX_ID_LENGTH)) {
+    return { ok: false, error: "Geographic scene underlay reference is invalid." };
+  }
+
+  const ids = new Set<string>();
+  let coordinates = 0;
+  for (const zone of value.zones) {
+    if (
+      !isRecord(zone) ||
+      !validString(zone.id, MAX_ID_LENGTH) ||
+      !validString(zone.label, MAX_LABEL_LENGTH) ||
+      !validPolygon(zone.geometry) ||
+      ids.has(zone.id)
+    ) {
+      return { ok: false, error: "Geographic zone is invalid or reuses a feature id." };
+    }
+    ids.add(zone.id);
+    coordinates += zone.geometry.rings.reduce(
+      (total, ring) => total + ring.length,
+      0,
+    );
+  }
+  for (const placement of value.placements) {
+    if (
+      !isRecord(placement) ||
+      !validString(placement.id, MAX_ID_LENGTH) ||
+      (placement.label !== undefined && !validString(placement.label, MAX_LABEL_LENGTH)) ||
+      !isRecord(placement.entityRef) ||
+      !validString(placement.entityRef.kind, MAX_ID_LENGTH) ||
+      !validString(placement.entityRef.id, MAX_ID_LENGTH) ||
+      !validPlacementGeometry(placement.geometry) ||
+      ids.has(placement.id)
+    ) {
+      return { ok: false, error: "Geographic placement is invalid or reuses a feature id." };
+    }
+    ids.add(placement.id);
+    coordinates += coordinateCount(placement.geometry);
+  }
+  if (coordinates > MAX_COORDINATES) {
+    return { ok: false, error: `Geographic scene supports at most ${MAX_COORDINATES} coordinates.` };
+  }
+  return { ok: true, value: value as unknown as GeographicSceneLayout };
+}
+
+function position(coordinate: GeographicCoordinate): GeoJsonPosition {
+  return [coordinate.longitude, coordinate.latitude];
+}
+
+function geometry(value: GeographicPlacementGeometry): GeoJsonGeometry {
+  if (value.kind === "point") return { type: "Point", coordinates: position(value) };
+  if (value.kind === "line-string") {
+    return { type: "LineString", coordinates: value.coordinates.map(position) };
+  }
+  return { type: "Polygon", coordinates: value.rings.map((ring) => ring.map(position)) };
+}
+
+function allCoordinates(layout: GeographicSceneLayout): GeographicCoordinate[] {
+  const result: GeographicCoordinate[] = [];
+  for (const zone of layout.zones) result.push(...zone.geometry.rings.flat());
+  for (const placement of layout.placements) {
+    if (placement.geometry.kind === "point") result.push(placement.geometry);
+    else if (placement.geometry.kind === "line-string") result.push(...placement.geometry.coordinates);
+    else result.push(...placement.geometry.rings.flat());
+  }
+  return result.length > 0 ? result : [layout.viewport];
+}
+
+function signedLongitude(value: number): number {
+  const normalized = ((value % 360) + 360) % 360;
+  return normalized > 180 ? normalized - 360 : normalized;
+}
+
+export function geographicBounds(coordinates: readonly GeographicCoordinate[]): GeographicBounds {
+  if (coordinates.length === 0) throw new RangeError("At least one geographic coordinate is required.");
+  if (coordinates.length > MAX_COORDINATES || !coordinates.every(validCoordinate)) {
+    throw new RangeError("Geographic bounds coordinates are invalid or exceed the supported limit.");
+  }
+  const longitudes = coordinates.map((item) => ((item.longitude % 360) + 360) % 360).sort((a, b) => a - b);
+  let largestGap = -1;
+  let gapStart = 0;
+  for (let index = 0; index < longitudes.length; index += 1) {
+    const current = longitudes[index];
+    const next = index === longitudes.length - 1 ? longitudes[0] + 360 : longitudes[index + 1];
+    if (next - current > largestGap) {
+      largestGap = next - current;
+      gapStart = index;
+    }
+  }
+  const west = signedLongitude(longitudes[(gapStart + 1) % longitudes.length]);
+  const east = signedLongitude(longitudes[gapStart]);
+  return {
+    west,
+    south: Math.min(...coordinates.map((item) => item.latitude)),
+    east,
+    north: Math.max(...coordinates.map((item) => item.latitude)),
+    crossesAntimeridian: west > east,
+  };
+}
+
+export function buildGeographicSceneModel(input: {
+  layout: GeographicSceneLayout;
+  presentations?: GeographicScenePresentationMap;
+  selectedEntityIds?: readonly string[];
+}): GeographicSceneModel {
+  const presentations = input.presentations ?? {};
+  const selected = new Set(input.selectedEntityIds ?? []);
+  return {
+    viewport: input.layout.viewport,
+    bounds: geographicBounds(allCoordinates(input.layout)),
+    zones: {
+      type: "FeatureCollection",
+      features: input.layout.zones.map((zone) => ({
+        type: "Feature",
+        id: zone.id,
+        geometry: geometry(zone.geometry),
+        properties: {
+          featureId: zone.id,
+          featureKind: "zone",
+          label: zone.label,
+          entityKind: null,
+          entityId: null,
+          selected: false,
+          statusLabel: null,
+          sublabel: null,
+          intent: null,
+        },
+      })),
+    },
+    placements: {
+      type: "FeatureCollection",
+      features: input.layout.placements.map((placement) => {
+        const presentation = presentations[placement.entityRef.id];
+        return {
+          type: "Feature",
+          id: placement.id,
+          geometry: geometry(placement.geometry),
+          properties: {
+            featureId: placement.id,
+            featureKind: "placement",
+            label: presentation?.label ?? placement.label ?? placement.entityRef.id,
+            entityKind: placement.entityRef.kind,
+            entityId: placement.entityRef.id,
+            selected: selected.has(placement.entityRef.id),
+            statusLabel: presentation?.statusLabel ?? null,
+            sublabel: presentation?.sublabel ?? null,
+            intent: presentation?.intent ?? null,
+          },
+        } satisfies GeographicFeature;
+      }),
+    },
+  };
+}

--- a/apps/web/lib/twin/map-asset-range.test.ts
+++ b/apps/web/lib/twin/map-asset-range.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveMapAssetRange } from "./map-asset-range";
+
+describe("map asset byte ranges", () => {
+  it("returns the whole asset when Range is absent", () => {
+    expect(resolveMapAssetRange(null, 100)).toEqual({
+      status: "full",
+      start: 0,
+      end: 99,
+      length: 100,
+    });
+  });
+
+  it.each([
+    ["bytes=10-19", { status: "partial", start: 10, end: 19, length: 10 }],
+    ["bytes=90-", { status: "partial", start: 90, end: 99, length: 10 }],
+    ["bytes=-10", { status: "partial", start: 90, end: 99, length: 10 }],
+    ["bytes=90-200", { status: "partial", start: 90, end: 99, length: 10 }],
+    ["bytes=-200", { status: "partial", start: 0, end: 99, length: 100 }],
+  ])("resolves %s", (header, expected) => {
+    expect(resolveMapAssetRange(header, 100)).toEqual(expected);
+  });
+
+  it.each(["bytes=100-101", "bytes=20-10", "bytes=-0", "bytes=", "items=0-1", "bytes=0-1,4-5"])(
+    "rejects unsupported or unsatisfiable range %s",
+    (header) => {
+      expect(resolveMapAssetRange(header, 100)).toMatchObject({ status: "unsatisfiable" });
+    },
+  );
+
+  it("rejects invalid asset lengths before arithmetic", () => {
+    expect(() => resolveMapAssetRange(null, 0)).toThrow("Map asset length must be a positive safe integer.");
+  });
+});

--- a/apps/web/lib/twin/map-asset-range.ts
+++ b/apps/web/lib/twin/map-asset-range.ts
@@ -1,0 +1,48 @@
+export type MapAssetRangeResult =
+  | { status: "full"; start: 0; end: number; length: number }
+  | { status: "partial"; start: number; end: number; length: number }
+  | { status: "unsatisfiable"; reason: string };
+
+const BYTE_RANGE = /^bytes=(\d*)-(\d*)$/;
+
+export function resolveMapAssetRange(
+  rangeHeader: string | null,
+  byteLength: number,
+): MapAssetRangeResult {
+  if (!Number.isSafeInteger(byteLength) || byteLength <= 0) {
+    throw new RangeError("Map asset length must be a positive safe integer.");
+  }
+  if (rangeHeader === null) {
+    return { status: "full", start: 0, end: byteLength - 1, length: byteLength };
+  }
+  if (rangeHeader.includes(",")) {
+    return { status: "unsatisfiable", reason: "Multiple byte ranges are not supported." };
+  }
+  const match = BYTE_RANGE.exec(rangeHeader.trim());
+  if (!match || (!match[1] && !match[2])) {
+    return { status: "unsatisfiable", reason: "Byte range syntax is invalid." };
+  }
+
+  if (!match[1]) {
+    const suffixLength = Number(match[2]);
+    if (!Number.isSafeInteger(suffixLength) || suffixLength <= 0) {
+      return { status: "unsatisfiable", reason: "Byte range suffix is invalid." };
+    }
+    const length = Math.min(suffixLength, byteLength);
+    return { status: "partial", start: byteLength - length, end: byteLength - 1, length };
+  }
+
+  const start = Number(match[1]);
+  const requestedEnd = match[2] ? Number(match[2]) : byteLength - 1;
+  if (
+    !Number.isSafeInteger(start) ||
+    !Number.isSafeInteger(requestedEnd) ||
+    start < 0 ||
+    start >= byteLength ||
+    requestedEnd < start
+  ) {
+    return { status: "unsatisfiable", reason: "Byte range is outside the asset." };
+  }
+  const end = Math.min(requestedEnd, byteLength - 1);
+  return { status: "partial", start, end, length: end - start + 1 };
+}

--- a/apps/web/lib/twin/map-pack-manifest.test.ts
+++ b/apps/web/lib/twin/map-pack-manifest.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { mapPackFileName, validateMapPackManifest } from "./map-pack-manifest";
+
+const manifest = {
+  schemaVersion: 1,
+  packId: "us-il-chicago-2026.08",
+  locale: "en-US",
+  region: "Chicago metropolitan area",
+  bounds: { west: -88.3, south: 41.4, east: -87.2, north: 42.2 },
+  sourceName: "Open map region provider",
+  sourceUrl: "https://example.org/map-source",
+  attribution: "Map data © source contributors",
+  archiveVersion: "2026.08",
+  byteLength: 4_096,
+  sha256: "a".repeat(64),
+  pmtilesSpecVersion: 3,
+  minZoom: 0,
+  maxZoom: 14,
+  createdAt: "2026-08-01T14:00:00.000Z",
+};
+
+describe("map pack manifest", () => {
+  it("accepts a complete immutable region-pack identity", () => {
+    expect(validateMapPackManifest(manifest)).toEqual({ ok: true, value: manifest });
+    expect(mapPackFileName(manifest.packId)).toBe("us-il-chicago-2026.08.pmtiles");
+  });
+
+  it.each([
+    ["path traversal", { ...manifest, packId: "../../private" }],
+    ["untrusted source protocol", { ...manifest, sourceUrl: "file:///private/map" }],
+    ["invalid checksum", { ...manifest, sha256: "not-a-checksum" }],
+    ["invalid archive length", { ...manifest, byteLength: 0 }],
+    ["inverted latitude", { ...manifest, bounds: { ...manifest.bounds, south: 45, north: 40 } }],
+    ["unsupported PMTiles version", { ...manifest, pmtilesSpecVersion: 2 }],
+  ])("rejects %s", (_label, candidate) => {
+    expect(validateMapPackManifest(candidate)).toMatchObject({ ok: false });
+  });
+
+  it("never derives a filesystem path from an untrusted id", () => {
+    expect(() => mapPackFileName("../secrets")).toThrow("Map pack id is invalid.");
+  });
+});

--- a/apps/web/lib/twin/map-pack-manifest.ts
+++ b/apps/web/lib/twin/map-pack-manifest.ts
@@ -1,0 +1,113 @@
+import { isRecord } from "@/lib/shared/coerce";
+
+const PACK_ID = /^[a-z0-9](?:[a-z0-9.-]{0,78}[a-z0-9])?$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+const MAX_ARCHIVE_BYTES = 1_000_000_000_000;
+
+export interface MapPackBounds {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+}
+
+export interface MapPackManifest {
+  schemaVersion: 1;
+  packId: string;
+  locale: string;
+  region: string;
+  bounds: MapPackBounds;
+  sourceName: string;
+  sourceUrl: string;
+  attribution: string;
+  archiveVersion: string;
+  byteLength: number;
+  sha256: string;
+  pmtilesSpecVersion: 3;
+  minZoom: number;
+  maxZoom: number;
+  createdAt: string;
+}
+
+export type MapPackManifestResult =
+  | { ok: true; value: MapPackManifest }
+  | { ok: false; error: string };
+
+function boundedText(value: unknown, maxLength: number): value is string {
+  return typeof value === "string" && value.trim().length > 0 && value.length <= maxLength;
+}
+
+function boundedNumber(value: unknown, minimum: number, maximum: number): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= minimum && value <= maximum;
+}
+
+function validUrl(value: unknown): value is string {
+  if (!boundedText(value, 2_048)) return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" && !parsed.username && !parsed.password;
+  } catch {
+    return false;
+  }
+}
+
+function validBounds(value: unknown): value is MapPackBounds {
+  return (
+    isRecord(value) &&
+    boundedNumber(value.west, -180, 180) &&
+    boundedNumber(value.east, -180, 180) &&
+    boundedNumber(value.south, -90, 90) &&
+    boundedNumber(value.north, -90, 90) &&
+    value.south <= value.north
+  );
+}
+
+export function validateMapPackManifest(value: unknown): MapPackManifestResult {
+  if (!isRecord(value) || value.schemaVersion !== 1) {
+    return { ok: false, error: "Map pack manifest must use schema version 1." };
+  }
+  if (typeof value.packId !== "string" || !PACK_ID.test(value.packId)) {
+    return { ok: false, error: "Map pack id must be a bounded lowercase identifier." };
+  }
+  if (
+    !boundedText(value.locale, 35) ||
+    !boundedText(value.region, 120) ||
+    !boundedText(value.sourceName, 160) ||
+    !validUrl(value.sourceUrl) ||
+    !boundedText(value.attribution, 1_000) ||
+    !boundedText(value.archiveVersion, 80)
+  ) {
+    return { ok: false, error: "Map pack provenance is incomplete or invalid." };
+  }
+  if (!validBounds(value.bounds)) {
+    return { ok: false, error: "Map pack coverage bounds are invalid." };
+  }
+  if (
+    !Number.isSafeInteger(value.byteLength) ||
+    (value.byteLength as number) <= 0 ||
+    (value.byteLength as number) > MAX_ARCHIVE_BYTES ||
+    typeof value.sha256 !== "string" ||
+    !SHA256.test(value.sha256) ||
+    value.pmtilesSpecVersion !== 3
+  ) {
+    return { ok: false, error: "Map pack archive identity is invalid." };
+  }
+  if (
+    !Number.isInteger(value.minZoom) ||
+    !Number.isInteger(value.maxZoom) ||
+    !boundedNumber(value.minZoom, 0, 24) ||
+    !boundedNumber(value.maxZoom, 0, 24) ||
+    value.minZoom > value.maxZoom
+  ) {
+    return { ok: false, error: "Map pack zoom range is invalid." };
+  }
+  if (typeof value.createdAt !== "string" || !Number.isFinite(Date.parse(value.createdAt))) {
+    return { ok: false, error: "Map pack creation time is invalid." };
+  }
+  return { ok: true, value: value as unknown as MapPackManifest };
+}
+
+export function mapPackFileName(packId: string): string {
+  if (!PACK_ID.test(packId)) throw new TypeError("Map pack id is invalid.");
+  return `${packId}.pmtiles`;
+}

--- a/docs/superpowers/plans/2026-08-01-territory-map-substrate.md
+++ b/docs/superpowers/plans/2026-08-01-territory-map-substrate.md
@@ -1,0 +1,182 @@
+# TERRITORY map substrate implementation plan
+
+**Backlog:** `BI-3A56AE0C`  
+**Epic:** `EP-SPATIAL-OPERATIONAL-VIEWS`  
+**Downstream:** the vertical cockpits that consume this renderer — HOA/property, equipment yard, HVAC field service — tracked under the recovered-cohort item `BI-D3EFD80C`.  
+**Distribution decision:** `DI-63D94E36B0B0` (`managed-region-pack`, high confidence)  
+**Coverage receipt:** `cmsvc6gcv0aa001prb5kpy1pk` (`atomic`)
+
+> **Coverage rebinding (2026-08-16).** The original anchors — `BI-3B07C332` with downstream `BI-8D9A2DE5`, `BI-49036A4F`, `BI-76C1B949`, and receipt `cmsahfmd800lv01qkgxfx0cqr` — do not resolve in this install, so the plan could not pass `check_plan_backlog_coverage`. Rebound to `BI-3A56AE0C`. Recorded `atomic`: the three modules are one indivisible contract rather than phases, because a consumer cannot render anything with only a subset of scene layout, asset range and pack manifest.
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Outcome
+
+Deliver the reusable, domain-neutral geographic renderer that makes a TERRITORY operational twin possible without requiring a cloud map account. The renderer consumes the existing `GeographicSceneLayout`; MapLibre renders a locally served PMTiles basemap plus typed GeoJSON overlays; every install reports whether it is operating in `schematic`, `geocoded`, or `optimized` mode; and loss of WebGL, the region pack, or network connectivity never removes the accessible operational workflow.
+
+This BI does not implement HVAC dispatch, HOA priorities, route optimization, geocoding, or a new business-data model. Those remain downstream compositions over this substrate.
+
+## Evidence and standards
+
+- The approved spatial design already selects MapLibre GL JS and PMTiles: `docs/superpowers/specs/2026-07-21-spatial-operational-views-design.md`.
+- Current registry evidence on 2026-08-01 identifies `maplibre-gl@6.1.0` (BSD-3-Clause, ESM-only, about 18.9 MB unpacked) and `pmtiles@4.4.1` (BSD-3-Clause, one runtime dependency, about 371 KB unpacked). Adoption remains gated by Tool Evaluations `cmsahdvye00k001qkwhk1bcks` and `cmsahdvzy00k401qk7ly9uu3n`.
+- `map-gl-offline@0.8.8` is an optional cache candidate, not an assumed dependency. Its broader SQL.js/Turf/i18n dependency graph is under Tool Evaluation `cmsahfcbf00lj01qkuvtvar72`. If it is not approved or does not materially beat the local-region design, do not add it.
+- [MapLibre GL JS](https://maplibre.org/maplibre-gl-js/docs/) is a browser WebGL renderer; v6 uses an ESM worker URL and supports native GeoJSON point, line, polygon, fill, symbol, and heatmap layers.
+- [PMTiles](https://docs.protomaps.com/pmtiles/) is a single-file archive format whose browser reader fetches metadata and tiles with HTTP Range requests. The official MapLibre integration uses `addProtocol` and the `pmtiles` package.
+- HTTP delivery follows RFC 9110 range semantics: valid byte ranges return `206` plus `Content-Range`; unsatisfiable ranges return `416`; immutable packs carry an ETag and `Accept-Ranges: bytes`.
+- WCAG 2.2 AA applies to controls, focus, contrast, and non-color status. A map is an enhancement, never the only representation of a job, person, route, or exception.
+
+## Substrate verification
+
+- `packages/storefront-templates/src/scene-layout.ts` already owns geographic viewport, point, line-string, polygon, zone, placement, and entity-reference contracts.
+- `OperationalSceneLayout` already persists renderer-neutral geometry; no new scene table or map-specific persistence model is needed.
+- `Address.latitude` / `Address.longitude`, `CustomerSite`, address-validation confidence helpers, and `FieldDispatchProfile.routeMode` already own location and capability truth.
+- `apps/web/lib/workspace-home/types.ts` and profiles already register `geo-map` / `customer-map`; the missing element is an implementation, not another primitive key.
+- `apps/web/lib/api/nearby-geo.ts` already owns bounded coordinate validation and haversine distance math.
+- No MapLibre or PMTiles dependency, renderer, related open PR, or recent main-branch implementation exists as of pickup.
+
+**Verdict:** extend the existing geographic scene and dispatch capability contracts. Do not add a parallel geography model, route-mode enum, customer location table, or archetype-specific map renderer.
+
+## Architecture decision
+
+The 2026-07-21 design left PMTiles distribution open. Three options were evaluated through the platform kernel:
+
+| Option | Result |
+| --- | --- |
+| Bake a locale archive into every portal image | Rejected: local, but makes routine builds, transfers, rollbacks, and upgrades multi-gigabyte. |
+| Install-managed signed region pack | **Selected:** one versioned archive in a persistent map-data volume, fetched or imported once, checksum verified, served locally. |
+| Remote-first archive plus browser cache | Rejected as the default: fastest initially, but normal operations inherit WAN and tile-host availability. |
+
+`DI-63D94E36B0B0` recommends the managed region pack with high confidence (composite 4.514, margin 2.817); strongest contributors were **Ship Real Functionality** and **Optimize for the Whole**; no commandment conflict fired.
+
+The portal image carries renderer code, a small no-basemap schematic style, and the asset-manifest contract. Region packs remain outside Git and outside the image in a persistent, install-managed location. The normal renderer reads only the local portal endpoint. Remote URLs are import sources, never an undeclared runtime dependency.
+
+## Delivery sequence
+
+### 1. Close the dependency gate
+
+- Wait for the three Tool Evaluation results; adopt only approved or explicitly conditional versions.
+- The dependency-free pure geographic adapter in phase 2 and manifest/range contracts in phase 3 may proceed while evaluations run; no package, renderer import, archive-format integration, or external-tool integration may land before approval.
+- Pin exact versions in `apps/web/package.json`, `pnpm-lock.yaml`, and `packages/db/data/approved_tools_registry.json` with evidence IDs and re-evaluation dates.
+- Prefer only `maplibre-gl` and `pmtiles`. Add `map-gl-offline` only if the evaluation and a measured sandbox comparison prove its storage and dependency cost worthwhile.
+- Record package integrity, license, transitive dependency count, ESM/SSR behavior, CSP/worker requirements, bundle delta, removal smoke test, and CVE scan.
+
+Verification: approved-tool guard, lockfile integrity, production build, and a clean uninstall/reinstall smoke test in the governed sandbox.
+
+### 2. Extract the reusable geographic presentation contract (refactoring allocation)
+
+Create a pure adapter under `apps/web/lib/twin/geographic-scene.ts` that:
+
+- validates longitude/latitude bounds and rejects non-finite coordinates;
+- converts `GeographicSceneLayout` into stable GeoJSON feature collections grouped by point, line, polygon, and zone;
+- preserves `SceneEntityRef`, labels, selection state, and domain-neutral presentation tokens without importing HVAC or HOA vocabulary;
+- returns explicit capability and failure facts (`renderer-ready`, `webgl-unavailable`, `region-pack-missing`, `region-out-of-coverage`);
+- clamps and derives a bounded initial viewport without mutating authored scene geometry.
+
+This shared contract and its tests receive at least 20% of the implementation/refactoring effort. MapLibre components, accessible lists, later HVAC/HOA projections, and test fixtures all consume it instead of translating scene data independently.
+
+Likely files:
+
+- `apps/web/lib/twin/geographic-scene.ts`
+- `apps/web/lib/twin/geographic-scene.test.ts`
+- minimal additive types in `packages/storefront-templates/src/scene-layout.ts` only if a proven renderer-neutral gap remains
+
+Verification: property/boundary tests for invalid coordinates, antimeridian-safe bounds, empty scenes, stable feature IDs, selection, and geometry parity.
+
+### 3. Implement local region-pack governance and HTTP range delivery
+
+Define a small versioned manifest contract containing pack ID, locale/region, bounding box, source and attribution, archive version, byte length, SHA-256, PMTiles spec version, created time, and minimum/maximum zoom. The filesystem asset remains in an ignored persistent map-data volume; the manifest is the only source of delivery truth.
+
+Add a narrowly scoped route such as `apps/web/app/api/map-assets/[packId]/route.ts` backed by `apps/web/lib/twin/map-assets.server.ts`:
+
+- authorize the current organization/install before revealing configured assets;
+- resolve only allowlisted manifest IDs—never caller-supplied filesystem paths;
+- support one bounded byte range, `HEAD`, `If-Range`, ETag, immutable cache headers, `206`, and `416`;
+- cap open handles and concurrent reads; abort on client disconnect;
+- never proxy an arbitrary remote URL;
+- fail with typed `missing`, `invalid-checksum`, `outside-coverage`, or `unavailable` status.
+
+Extend installer/deployment contracts rather than adding a portal-image blob. Add the persistent map-data location and platform-specific behavior to the deployment doctrine and `docs/install/platform-support-watchlist.md`. Import/download is transactional: stage, verify length/checksum/manifest, then atomically promote; preserve the prior valid pack for rollback.
+
+Likely files:
+
+- `apps/web/lib/twin/map-pack-manifest.ts` and tests
+- `apps/web/lib/twin/map-assets.server.ts` and tests
+- `apps/web/app/api/map-assets/[packId]/route.ts` and tests
+- minimal compose/install asset-volume wiring plus cross-platform watchlist entry
+
+Verification: exact range bytes, suffix/open ranges, `HEAD`, ETag/If-Range, invalid ranges, traversal attempts, checksum rejection, interrupted import, rollback, Windows/macOS/Linux path resolution, and no outbound request during normal map use.
+
+### 4. Build the MapLibre renderer as a progressive enhancement
+
+Create a dynamically imported client component under `apps/web/components/twin/geographic/`:
+
+- instantiate MapLibre only in the browser and only when the geographic view is selected;
+- register and unregister the PMTiles protocol exactly once per module lifecycle;
+- use a first-party local style and the local `/api/map-assets/...` URL—no CDN CSS, glyphs, sprites, telemetry, geocoder, or tile calls;
+- render zones, routes, sites, and moving resources from the shared GeoJSON adapter;
+- expose selected entity IDs and activation callbacks compatible with the existing twin selection model;
+- use DPF design tokens, text/status plus shape (not color alone), >=44 px controls, keyboard navigation, reduced-motion behavior, and clear attribution;
+- preserve the accessible list/schedule supplied by the downstream composition when WebGL or the pack is unavailable.
+
+Likely files:
+
+- `apps/web/components/twin/geographic/GeographicSceneCanvas.tsx`
+- `apps/web/components/twin/geographic/GeographicSceneCanvas.test.tsx`
+- a small MapLibre style module and CSS import at the owning client boundary
+
+Verification: component lifecycle/cleanup, no SSR import crash, no request to a non-local origin, point/line/polygon parity, keyboard selection, WebGL failure, missing pack, light/dark themes, mobile layout, and axe.
+
+### 5. Prove offline, performance, and honest degradation
+
+- With the region pack installed, block WAN egress and prove the basemap and overlays still render from the local portal.
+- If the optional browser cache is approved, measure cold/warm storage, quota failure, eviction, version invalidation, and rollback; never label the renderer offline-capable based only on a service-worker registration.
+- Keep MapLibre and PMTiles out of non-geographic route chunks. Measure first geographic-view interaction, map-ready timing, heap growth, range-request count/bytes, and cleanup after unmount.
+- On missing/invalid pack, WebGL failure, or out-of-coverage coordinates, show the typed capability state and retain the list/schematic workflow—never an empty gray canvas or fake coordinates.
+
+Targets:
+
+- non-geographic Operations routes: zero map asset requests and no eager MapLibre initialization;
+- selection response after renderer ready: <=100 ms p95;
+- bounded initial region requests with documented byte total;
+- no normal-operation outbound network request;
+- exact entity count and selection parity between GeoJSON output and the accessible downstream representation.
+
+Verification: governed production build, exact shared local-CI, offline browser exercise, network request capture, bundle report, WebGL-disabled exercise, keyboard-only flow, responsive/theme screenshots, and migration apply if deployment metadata unexpectedly requires schema work.
+
+### 6. Documentation and downstream handoff
+
+- Add operator guidance for installing/updating/importing a region pack, attribution, coverage, storage cost, rollback, and typed degraded modes.
+- Document the domain integration contract for `BI-8D9A2DE5`: downstream code supplies `GeographicSceneLayout`, current presentation bindings, and an accessible list; it does not instantiate MapLibre directly.
+- Add the evaluated tools and use cases to the durable tool corpus so later archetypes reuse the same evidence instead of searching anew.
+- Record verification evidence to `BI-3B07C332`; route confirmed map/range/offline techniques to the WSID commons only after the PR merges.
+
+## Backlog coverage
+
+- **Decision:** `atomic`
+- **Receipt:** `cmsahfmd800lv01qkgxfx0cqr`
+- **Rationale:** evaluated dependency pins, the renderer adapter, local PMTiles range delivery, and offline/fallback behavior form one production capability. A dependency-only, asset-only, or map-only phase has no independently usable owner outcome.
+- **Downstream BIs:** generic TERRITORY remains `BI-8D9A2DE5`; HVAC and HOA compositions remain `BI-49036A4F` and `BI-76C1B949`.
+
+## Architecture review (advisory)
+
+- **Alignment:** well aligned after selecting managed region packs.
+- **Important:** the older spec's phrase “bundled region asset” could be read as image-baked. This plan makes it an install-managed, verified persistent asset and keeps routine images small.
+- **Important:** runtime map requests must stay local and declared. Remote-first tiles or arbitrary URL proxying would violate fully-local-by-choice and create an unbounded SSRF/data-egress surface.
+- **Important:** MapLibre is a renderer, not a domain source. `GeographicSceneLayout`, canonical addresses/sites, and domain Operations projections remain authoritative.
+- **Important:** map-only interaction is not accessible parity. Downstream compositions must provide the schedule/list workflow and exact shared entity references.
+- **Minor:** the old spec names `maplibre-offline-pmtiles`, which does not resolve in the npm registry. This plan removes that assumption and treats `map-gl-offline` as an evaluated optional candidate.
+
+## Risks and rollback
+
+| Risk | Mitigation | Rollback |
+| --- | --- | --- |
+| Portal images become multi-gigabyte | Persistent managed pack outside image and Git | Remove asset-volume wiring; renderer falls back honestly |
+| Range route exposes files or enables SSRF | Manifest ID allowlist, fixed root, no remote proxy, traversal tests | Disable map-asset capability without affecting Operations data |
+| Unapproved dependency enters lockfile | Tool Evaluation and approved-registry guard before install | Revert package/lock changes; no data migration |
+| Map slows every business route | Client-only dynamic import on geographic selection | Feature-disable geographic renderer; list/schematic remains |
+| Region pack is stale, corrupt, or wrong locale | Signed/checksummed manifest, coverage bounds, transactional promotion | Restore prior valid pack atomically |
+| WebGL or browser storage is unavailable | Typed capability state and accessible workflow | Continue in schematic/list mode |
+| Tiles carry incompatible attribution/license | Manifest records source/license/attribution; tool/content review | Reject pack before promotion |
+
+No partial map is production-ready: evaluated dependencies, local verified range delivery, renderer lifecycle, honest degradation, and offline evidence ship together under `BI-3B07C332`.


### PR DESCRIPTION
## What

The shared geographic substrate several vertical cockpits sit on — **substrate, not a vertical**. Adds `lib/twin/geographic-scene.ts`, `map-asset-range.ts` and `map-pack-manifest.ts` with tests: a `GeographicSceneLayout` contract, asset-range computation, and a pack manifest.

Built 2026-08-01, never proposed as a PR, recovered in the 2026-08-15 sweep (cohort `BI-D3EFD80C`).

## Why this one goes first

The HOA/property and equipment-yard plans both **consume** this renderer. The plan states the integration contract explicitly: downstream code supplies `GeographicSceneLayout`, presentation bindings and an accessible list — it does **not** instantiate MapLibre directly. Landing those verticals before the substrate would push each toward duplicating map handling, exactly what the contract exists to prevent.

Accessibility is part of that contract, not a follow-up: consumers must render an accessible ranked list alongside the visual scene.

## A real test failure, found by actually running it

The branch's own suite failed on first execution:

```
FAIL lib/twin/geographic-scene.test.ts
  > validates and projects stable domain-neutral GeoJSON features
```

The production code was correct; **the assertion was wrong**. Inside `expect.objectContaining({...})` only the listed *keys* are relaxed — the *value* of `geometry` is still compared with strict deep equality. So `geometry: { type: "LineString" }` could never match a real GeoJSON LineString, which also carries `coordinates`. The sibling Point case passed only because it happened to spell its geometry out in full.

Fixed by asserting the actual projected pairs — strictly stronger than loosening the matcher, because it exercises the `{longitude, latitude}` → `[lng, lat]` projection the test claims to cover rather than just the type tag.

Good evidence this suite had never run in CI, which is consistent with a branch pushed and never proposed.

## Coverage rebinding

The plan's original anchors — `BI-3B07C332`, downstream `BI-8D9A2DE5`/`BI-49036A4F`/`BI-76C1B949`, receipt `cmsahfmd800lv01qkgxfx0cqr` — **do not resolve in this install**, so it could not pass `check_plan_backlog_coverage`. Rebound to `BI-3A56AE0C` with fresh receipt `cmsvc6gcv0aa001prb5kpy1pk`, recorded **`atomic`**: the three modules are one indivisible contract, not phases — a consumer cannot render anything given only a subset of scene layout, asset range and pack manifest.

## Verification

- 482 commits behind `main` but merges **cleanly**; no conflicts.
- `lib/twin/` — **152 tests across 27 files pass**.
- `pnpm run pregate` — **gate passed** on the exact proposed tree.
- Coverage gate: `1 changed plan(s) carry complete coverage evidence. OK.`

Squashed to one signed commit because the drift-reconciling merge commit carried no DCO sign-off; the tree is byte-identical to the verified merge (`git write-tree` compared). Original tip pinned at `refs/salvage/2026-08-15/feat/territory-map-substrate`.

First of the five recovered verticals; the remaining four consume this substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)