### PR TITLE
fix(edge-node): allow the unused image-size patch during the pruned prod deploy

### DIFF
--- a/services/edge-node/Dockerfile
+++ b/services/edge-node/Dockerfile
@@ -52,7 +52,16 @@ RUN pnpm --filter dpf-edge-node build
 # directory with REAL files in node_modules — no symlinks back into
 # /app/packages, no workspace context required at runtime. The
 # runner stage just copies /app/deploy/edge-node and runs it.
-RUN pnpm deploy --filter dpf-edge-node --prod --legacy --ignore-scripts /app/deploy/edge-node
+# allowUnusedPatches is scoped to THIS command on purpose. --prod prunes to
+# edge-node's runtime subgraph, which legitimately contains no image-size —
+# that patch belongs to a metro/Expo transitive of the mobile app — and pnpm
+# treats a declared-but-unapplied patch as a hard ERR_PNPM_UNUSED_PATCH.
+# Setting it workspace-wide would disarm the guard for the real install too,
+# and pnpm-workspace.yaml pins image-size to an exact version precisely so it
+# "fails loudly and forces a re-review" when metro moves off 1.2.1. So relax
+# it only here, where the patch cannot apply by construction.
+RUN pnpm --config.allowUnusedPatches=true deploy \
+    --filter dpf-edge-node --prod --legacy --ignore-scripts /app/deploy/edge-node
 # pnpm deploy --prod strips devDependencies but ALSO doesn't include
 # our just-built dist/. Copy it in explicitly.
 RUN cp -r /app/services/edge-node/dist /app/deploy/edge-node/dist


### PR DESCRIPTION
## Summary

Third and final fault blocking the `dpf-edge-node` image. With the `ENOENT` cleared by #4351 and the `tsc` failure by #4359, the build now reaches `Dockerfile:55` and dies there:

```
ERR_PNPM_UNUSED_PATCH  The following patches were not used: image-size@1.2.1
```

**This was found by building the image locally, not by CI** — and it would have failed tomorrow's scheduled release run. No PR check builds Docker images, and the previous CI failure stopped at line 48, so nothing had ever executed line 55 since #4321 landed the repo's first patched dependency.

With this merged, **`docker build -f services/edge-node/Dockerfile .` completes for the first time.**

## Changes

- `services/edge-node/Dockerfile`: pass `--config.allowUnusedPatches=true` to the `pnpm deploy` step only.

### Why it fails, and why the fix is scoped

`pnpm deploy --prod` prunes to edge-node's runtime subgraph, which legitimately contains **no** `image-size` — that patch belongs to a metro/Expo transitive of the mobile app. pnpm treats a declared-but-unapplied patch as a hard error, so the prune itself is what trips it.

The relaxation is deliberately **not** set workspace-wide. `pnpm-workspace.yaml` pins `image-size` to an exact version precisely so it *"fails loudly and forces a re-review"* when metro moves off 1.2.1; an `allowUnusedPatches` setting in the workspace file would disarm that for the real install too. Here the patch cannot apply by construction, so this is the one place the relaxation is correct.

`services/edge-node/Dockerfile` is the only Dockerfile in the repo using `pnpm deploy`, so the blast radius is a single image.

## Test plan

- [x] **Runtime-bound change** (image build wiring)
  - [x] Functional verification against a real Docker build + container run on the canonical local engine
  - [x] Evidence below

### Verification evidence

**1. Reproduced the hard error on the host, and confirmed the flag clears it:**

```
$ pnpm deploy --filter dpf-edge-node --prod --legacy --ignore-scripts /tmp/deploytest
 ERR_PNPM_UNUSED_PATCH  The following patches were not used: image-size@1.2.1

$ pnpm --config.allowUnusedPatches=true deploy --filter dpf-edge-node --prod --legacy --ignore-scripts /tmp/deploytest
 WARN  The following patches were not used: image-size@1.2.1
 Progress: resolved 406, reused 5, downloaded 1, added 6, done
```

Error becomes a warning; the deploy completes.

**2. Full image build from current `main` + this fix — succeeds:**

```
#22 exporting to image
#22 naming to docker.io/library/dpf-edge-node:verify2 done
#22 DONE 1.1s
```

**3. Smoke-tested the resulting image** (a build that succeeds is structural; this is the functional half):

- **Entrypoint runs.** Loads `dist/index.js`, executes `main()`, stops at `authorityUrl: Invalid input: expected string, received undefined` — the expected result with no config supplied, and proof that module resolution works end to end.
- **Collector dependencies present:** `/usr/bin/nmap`, `/usr/bin/snmpwalk`.
- **Bundled OUI dataset present:** `data/oui.tsv`.
- **Deploy tree is self-contained:** `node_modules/@dpf/validators` resolves into the bundle's own `.pnpm` store, not back to `/app/packages` — so the runner stage has no dangling reference.
- **`dist/api-client.js` loads clean.** Its only `@dpf/validators` mention is a comment, so the package is type-only and erased at emit.

## Pre-PR readiness

Gates run locally against this exact tree: Docs Impact **OK**, Design Grounding **OK**, Actions Injection **PASSED**, Spec/Plan/Doc **8/8**.

Local-CI-Override: external-contribution-no-install: clean clone outside the managed worktree tree, and the host's worktree/portal stack is mid-teardown by a concurrent session, so no sandbox lease is obtainable. The runtime-bound half was verified directly against the local Docker engine instead, as evidenced above. CI gates this PR in full.

## Overlap sweep

`gh pr list --state open --limit 50` → #4350 (`feat/qwen38-27b-local-tier`) and #4331 (`feat/build-studio-owner-brief-proof`). Neither touches `services/edge-node` or image build wiring. No coordination needed.

## Notes for the reviewer

- **This closes the release chain.** #4351 restored the automation, #4359 fixed the type error and the CI blind spot, and this makes the image actually build. `v2026.08.16`'s Release already published successfully with its counted binaries; images were the missing half.
- **`v2026.08.16` will not get images retroactively** — that tag predates all three fixes. Tomorrow's 06:40 UTC checkpoint is the first tag that can complete the full chain. (Today's scheduled run is a deliberate no-op: `v2026.08.16` already exists.)
- **Nothing has repointed `:latest` throughout.** The `merge` job is `needs: build`, so every failed run skipped it. The seven-week-old `latest` is still serving customer installs and will be replaced by the first fully green run.
- Still open: gating the `:latest` tag behind the E2E verify job instead of repointing it beforehand. Needs a BI once the portal is back up to file one through the governed path.
