### PR TITLE
feat(install): verify the pulled model digest against a pinned known-good value (BI-73E9A282)

### DIFF
--- a/apps/web/lib/inference/local-model-policy.test.ts
+++ b/apps/web/lib/inference/local-model-policy.test.ts
@@ -14,7 +14,47 @@ import {
   MAX_LOCAL_CONTEXT_TOKENS,
   clampServedContextTokens,
   recommendServedContextTokens,
+  expectedDigestForModel,
+  tierRequiresDigestPin,
+  LOCAL_MODEL_TIERS,
 } from "./local-model-policy";
+
+describe("model integrity pinning (BI-73E9A282)", () => {
+  // A HuggingFace ref names a FILE, not an immutable revision, and
+  // `docker model pull` accepts no flags — so a mutable upstream can change
+  // under a stable id. The digest is the only detection the platform can do.
+  it("every tier sourced outside the curated ai/ namespace pins a digest", () => {
+    const unpinned = LOCAL_MODEL_TIERS.filter(
+      (t) => tierRequiresDigestPin(t) && !t.expectedDigest,
+    ).map((t) => t.model);
+    expect(unpinned).toEqual([]);
+  });
+
+  it("digests are full sha256 values, not truncated or bare hex", () => {
+    for (const tier of LOCAL_MODEL_TIERS) {
+      if (!tier.expectedDigest) continue;
+      expect(tier.expectedDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    }
+  });
+
+  it("looks up the pinned digest by pull-form model id", () => {
+    expect(expectedDigestForModel("hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M")).toBe(
+      "sha256:66c4f325bc71350f07fb2da4f92455553c7bbc8af5d7ee2095fbeac79b9e66c9",
+    );
+  });
+
+  it("returns null for curated ai/ tiers and for unknown ids", () => {
+    // ai/ tiers resolve through Docker Hub's content-addressed registry, which
+    // already pins bytes to a tag — no separate digest needed.
+    expect(expectedDigestForModel("ai/qwen3-coder")).toBeNull();
+    expect(expectedDigestForModel("ai/nonexistent-model")).toBeNull();
+  });
+
+  it("classifies which tiers require a pin", () => {
+    expect(tierRequiresDigestPin({ model: "ai/qwen3-coder", weightsGb: 16, label: "x" })).toBe(false);
+    expect(tierRequiresDigestPin({ model: "hf.co/org/repo:Q4", weightsGb: 1, label: "x" })).toBe(true);
+  });
+});
 
 describe("classifyLocalModelRole / isEmbeddingModelId", () => {
   it("classifies embedders", () => {

--- a/apps/web/lib/inference/local-model-policy.ts
+++ b/apps/web/lib/inference/local-model-policy.ts
@@ -177,6 +177,24 @@ export interface LocalModelTier {
   /** Approximate resident weight footprint, GB (Q4). */
   weightsGb: number;
   label: string;
+  /**
+   * Known-good content digest, as `docker model inspect` reports it in `id`.
+   *
+   * Set this for any tier sourced from OUTSIDE Docker's curated `ai/` namespace.
+   * A HuggingFace reference like `...:Q4_K_M` names a FILE, not an immutable
+   * revision — the publisher can replace it in place — and `docker model pull`
+   * accepts no flags, so no revision or digest can be pinned at pull time. The
+   * installers compare against this value after pulling and warn on mismatch.
+   *
+   * Model weights are a CONTROL-PLANE input: they determine tool-calling and
+   * agentic behaviour, so substituted weights are a behavioural compromise, not
+   * merely a data one. This is detection, not prevention — the honest ceiling of
+   * what the platform can do given the pull API. (BI-73E9A282.)
+   *
+   * Omitted for `ai/` tiers: those resolve through Docker Hub's content-addressed
+   * registry, which already pins bytes to a tag.
+   */
+  expectedDigest?: string;
 }
 
 export const LOCAL_MODEL_TIERS: readonly LocalModelTier[] = [
@@ -198,7 +216,15 @@ export const LOCAL_MODEL_TIERS: readonly LocalModelTier[] = [
   // default coworkers) and capability family `qwen` (toolFidelity 80) in BOTH the
   // pull form and the runtime form DMR registers. It does NOT yet resolve as
   // vision-capable despite being a native VLM — see BI-C2EFF855.
-  { model: "hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M", weightsGb: 18, label: "Qwen3.8 27B (dense)" },
+  {
+    model: "hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M",
+    weightsGb: 18,
+    label: "Qwen3.8 27B (dense)",
+    // Captured on the canonical runtime 2026-08-16 from `docker model inspect`,
+    // alongside GGUF metadata: qwen35, 26.90B, MOSTLY_Q4_K_M, 17.66 GiB, 262144 ctx,
+    // general.license apache-2.0.
+    expectedDigest: "sha256:66c4f325bc71350f07fb2da4f92455553c7bbc8af5d7ee2095fbeac79b9e66c9",
+  },
   { model: "ai/qwen3-coder", weightsGb: 16, label: "Qwen3-Coder 30B (MoE, 3B active)" }, // the 24 GB-card sweet spot (measured ~20.7 GB @ 24k ctx)
   { model: "ai/qwen3:14B-Q6_K", weightsGb: 12, label: "Qwen3 14B" },
   { model: "ai/qwen3:8B-Q4_K_M", weightsGb: 6, label: "Qwen3 8B" },
@@ -207,6 +233,27 @@ export const LOCAL_MODEL_TIERS: readonly LocalModelTier[] = [
 
 /** Smallest tier — the CPU-OK fallback when nothing larger fits the budget. */
 const SMALLEST_TIER = LOCAL_MODEL_TIERS[LOCAL_MODEL_TIERS.length - 1]!;
+
+/**
+ * The known-good digest for a tier's model id, or null when the tier does not
+ * pin one. Matches on the PULL form (what the tier declares) — installers
+ * resolve the runtime form separately, and the digest is the same artifact
+ * either way.
+ */
+export function expectedDigestForModel(modelId: string): string | null {
+  const tier = LOCAL_MODEL_TIERS.find((t) => t.model === modelId);
+  return tier?.expectedDigest ?? null;
+}
+
+/**
+ * True when a tier is sourced from outside Docker's curated `ai/` namespace and
+ * therefore REQUIRES a pinned digest — a mutable upstream with no pull-time
+ * revision pin is exactly the case the digest check exists for. Used by the
+ * conformance test below so a future non-`ai/` tier cannot be added without one.
+ */
+export function tierRequiresDigestPin(tier: LocalModelTier): boolean {
+  return !tier.model.startsWith("ai/");
+}
 
 /**
  * The memory budget (GB) actually available to a local model on this host:

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -1396,6 +1396,9 @@ if (-not (Test-StepDone "hardware")) {
         $modelReason = "Qwen3-Coder-Next 80B (MoE) -- top agentic coder, fits your $gpuVRAM_GB GB VRAM with headroom"
     } elseif ($gpuVRAM_GB -ge 23) {
         $selectedModel = "hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M"
+        # Known-good content digest for this tier. Mirrors LocalModelTier.expectedDigest
+        # and SELECTION_TIERS in scripts/detect-hardware-host.ts -- keep in sync.
+        $expectedDigest = "sha256:66c4f325bc71350f07fb2da4f92455553c7bbc8af5d7ee2095fbeac79b9e66c9"
         $modelReason = "Qwen3.8 27B (dense, vision) -- most thorough local model, fits your $gpuVRAM_GB GB VRAM with headroom"
     } elseif ($gpuVRAM_GB -ge 21) {
         $selectedModel = "ai/qwen3-coder"
@@ -1596,7 +1599,7 @@ Copy-Item -Path (Join-Path $DPF_DIR "scripts\safety\dpf-shell-guard-fallback-pat
 # basename-based detection isn't fragile.
 # NOTE: no `--` separator before %*. With `pwsh -File`, PowerShell parses `--` as a
 # parameter prefix with an EMPTY name and aborts every guarded command with
-# "Parameter cannot be processed because the parameter name '' is ambiguous" —
+# "Parameter cannot be processed because the parameter name '' is ambiguous" --
 # which breaks git/docker/prisma for the whole user account, because safety-bin is
 # prepended to the user PATH below. The guard collects %* from the automatic $args.
 foreach ($tool in @("docker", "git", "prisma")) {
@@ -2025,6 +2028,31 @@ if (-not (Test-StepDone "model")) {
     } catch {}
     if ($isPresent) {
         $selectedModel = $runtimeModel
+        # Integrity check: a HuggingFace ref names a FILE, not an immutable
+        # revision, and `docker model pull` takes no flags, so nothing pins bytes
+        # at pull time. Model weights are a control-plane input, so a silent
+        # substitution is a behavioural compromise. DETECTION only -- warn
+        # loudly, never fail the install. (BI-73E9A282.)
+        if ($expectedDigest) {
+            $actualDigest = $null
+            try {
+                $inspected = docker model inspect $runtimeModel 2>$null | ConvertFrom-Json -ErrorAction SilentlyContinue
+                if ($inspected) { $actualDigest = $inspected.id }
+            } catch {}
+            if (-not $actualDigest) {
+                Write-Warn "Could not read the model digest to verify it; continuing."
+            } elseif ($actualDigest -eq $expectedDigest) {
+                Write-OK "Model integrity verified (digest matches the pinned value)"
+            } else {
+                Write-Warn "MODEL DIGEST MISMATCH for $runtimeModel"
+                Write-Warn "  expected: $expectedDigest"
+                Write-Warn "  actual:   $actualDigest"
+                Write-Warn "  The upstream model was republished, or the download differs from"
+                Write-Warn "  what this release pinned. The model still works, but its behaviour"
+                Write-Warn "  is no longer the version this install was tested against. Treat as"
+                Write-Warn "  a security event and re-run the tool evaluation before relying on it."
+            }
+        }
         # Persist the accurate runtime name for compose env + portal-init host_profile
         $selectedModel | Set-Content "$DPF_DIR\.selected-model" -ErrorAction SilentlyContinue
         $hpPath = "$DPF_DIR\.host-profile.json"

--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -505,6 +505,9 @@ fi
 if DPF_HOST_PROFILE_JSON="$(pnpm --filter @dpf/db exec -- tsx "$REPO_ROOT/scripts/detect-hardware-host.ts" 2>/dev/null)"; then
   export DPF_HOST_PROFILE="$DPF_HOST_PROFILE_JSON"
   DPF_SELECTED_MODEL="$(printf '%s' "$DPF_HOST_PROFILE_JSON" | sed -nE 's/.*"selectedModel"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')"
+  # Known-good content digest for the selected model, when the tier pins one.
+  # Empty for curated ai/ tiers (Docker Hub already pins bytes to a tag).
+  DPF_EXPECTED_DIGEST="$(printf '%s' "$DPF_HOST_PROFILE_JSON" | sed -nE 's/.*"expectedDigest"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')"
   if [ -n "$DPF_SELECTED_MODEL" ]; then
     ok "Hardware profile detected — selected AI model (pull form): $DPF_SELECTED_MODEL"
     info "  (Will register under short form for runtime references; normalized after pull.)"
@@ -514,6 +517,38 @@ if DPF_HOST_PROFILE_JSON="$(pnpm --filter @dpf/db exec -- tsx "$REPO_ROOT/script
 else
   warn "Host hardware detection failed (non-fatal); portal-init will skip the profile step."
 fi
+
+# Compare the pulled model's content digest against the tier's pinned value.
+# WHY: a HuggingFace reference names a FILE, not an immutable revision, and
+# `docker model pull` takes no flags, so nothing pins bytes at pull time. Model
+# weights are a control-plane input -- they decide tool-calling behaviour -- so a
+# silent substitution is a behavioural compromise, not just a data one.
+# This is DETECTION, not prevention: warn loudly, never fail the install. A
+# legitimate republish should prompt re-evaluation, not brick a new machine.
+# (BI-73E9A282.)
+verify_model_digest() {
+  _vmd_runtime="$1"
+  _vmd_expected="$2"
+  [ -n "$_vmd_expected" ] || return 0
+  _vmd_actual="$(docker model inspect "$_vmd_runtime" 2>/dev/null \
+    | sed -nE 's/.*"id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -1)"
+  if [ -z "$_vmd_actual" ]; then
+    warn "Could not read the model digest to verify it; continuing."
+    return 0
+  fi
+  if [ "$_vmd_actual" = "$_vmd_expected" ]; then
+    ok "Model integrity verified (digest matches the pinned value)"
+    return 0
+  fi
+  warn "MODEL DIGEST MISMATCH for $_vmd_runtime"
+  warn "  expected: $_vmd_expected"
+  warn "  actual:   $_vmd_actual"
+  warn "  The upstream model was republished, or the download differs from what"
+  warn "  this release pinned. The model still works, but its behaviour is no"
+  warn "  longer the version this install was tested against. Treat this as a"
+  warn "  security event and re-run the tool evaluation before relying on it."
+  return 0
+}
 
 # 8b. Set up Docker Model Runner and pull the selected chat model.
 #     Mirrors install-dpf.ps1 §Step 7 (lines 1895-1985). Docker Model
@@ -594,6 +629,7 @@ if [ "$DPF_PLATFORM" = "darwin" ] && command -v docker >/dev/null 2>&1; then
       if docker model list 2>/dev/null | awk 'NR>1{print $1}' | grep -Fxq "$_runtime_model"; then
         ok "Model $_runtime_model already on disk"
         DPF_SELECTED_MODEL="$_runtime_model"
+        verify_model_digest "$_runtime_model" "${DPF_EXPECTED_DIGEST:-}"
       else
         # Print expected size upfront (user request for time estimation given
         # internet speed). Uses cheap manifest inspect (no blob download).
@@ -625,6 +661,7 @@ except Exception:
         if docker model list 2>/dev/null | awk 'NR>1{print $1}' | grep -Fxq "$_runtime_model"; then
           ok "AI Coworker model ready: $_runtime_model"
           DPF_SELECTED_MODEL="$_runtime_model"
+          verify_model_digest "$_runtime_model" "${DPF_EXPECTED_DIGEST:-}"
         else
           warn "Model pull may have failed. You can retry later: docker model pull $_pull_name"
         fi

--- a/scripts/detect-hardware-host.ts
+++ b/scripts/detect-hardware-host.ts
@@ -35,6 +35,8 @@ type HostProfile = {
   ram: { totalGB: number };
   gpu: { name: string; vramGB: number | null } | null;
   selectedModel: string;
+  /** Known-good digest for selectedModel, when it is pinned. Null otherwise. */
+  expectedDigest: string | null;
   detectedAt: string;
   notes?: string[];
 };
@@ -88,7 +90,7 @@ function detectDarwin(): HostProfile {
     cpu: { name: cpuName, cores },
     ram: { totalGB },
     gpu,
-    selectedModel: selectModel({ architecture, totalGB, gpu }),
+    ...selectedFields({ architecture, totalGB, gpu }),
     detectedAt: new Date().toISOString(),
   };
 }
@@ -161,7 +163,7 @@ function detectLinux(): HostProfile {
     cpu: { name: cpuName, cores },
     ram: { totalGB },
     gpu,
-    selectedModel: selectModel({ architecture, totalGB, gpu }),
+    ...selectedFields({ architecture, totalGB, gpu }),
     detectedAt: new Date().toISOString(),
   };
 }
@@ -194,20 +196,37 @@ function detectLinux(): HostProfile {
 const MODEL_HEADROOM_GB = 5;            // context KV + embedder + overhead (measured on RTX 4090)
 const UNIFIED_USABLE_FRACTION = 0.75;   // Apple Silicon GPU share of unified RAM
 const CPU_USABLE_FRACTION = 0.5;
-const SELECTION_TIERS: { model: string; weightsGb: number }[] = [
+// `expectedDigest` mirrors LocalModelTier.expectedDigest: set for any tier
+// sourced outside the curated `ai/` namespace, where the upstream reference is
+// mutable and `docker model pull` offers no revision pin (BI-73E9A282).
+const SELECTION_TIERS: { model: string; weightsGb: number; expectedDigest?: string }[] = [
   { model: "ai/qwen3-coder-next", weightsGb: 48 },          // big unified (Apple 128 GB) / 64 GB+ discrete
-  { model: "hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M", weightsGb: 18 }, // dense 27B; replaces the 35B-A3B tier
+  {
+    model: "hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M",
+    weightsGb: 18,                                          // dense 27B; replaces the 35B-A3B tier
+    expectedDigest: "sha256:66c4f325bc71350f07fb2da4f92455553c7bbc8af5d7ee2095fbeac79b9e66c9",
+  },
   { model: "ai/qwen3-coder", weightsGb: 16 },               // 24 GB-card sweet spot (measured ~20.7 GB @ 24k ctx)
   { model: "ai/qwen3:14B-Q6_K", weightsGb: 12 },
   { model: "ai/qwen3:8B-Q4_K_M", weightsGb: 6 },
   { model: "ai/qwen3:4B-UD-Q4_K_XL", weightsGb: 3 },
 ];
 
+/** Spread-able { selectedModel, expectedDigest } so a profile picks once. */
+function selectedFields(p: {
+  architecture: Architecture;
+  totalGB: number;
+  gpu: HostProfile["gpu"];
+}): { selectedModel: string; expectedDigest: string | null } {
+  const picked = selectModel(p);
+  return { selectedModel: picked.model, expectedDigest: picked.expectedDigest };
+}
+
 function selectModel(p: {
   architecture: Architecture;
   totalGB: number;
   gpu: HostProfile["gpu"];
-}): string {
+}): { model: string; expectedDigest: string | null } {
   let budgetGb: number;
   if (p.architecture === "discrete" && p.gpu && typeof p.gpu.vramGB === "number") {
     budgetGb = p.gpu.vramGB;
@@ -217,9 +236,11 @@ function selectModel(p: {
     budgetGb = p.totalGB * CPU_USABLE_FRACTION;
   }
   for (const tier of SELECTION_TIERS) {
-    if (tier.weightsGb + MODEL_HEADROOM_GB <= budgetGb) return tier.model;
+    if (tier.weightsGb + MODEL_HEADROOM_GB <= budgetGb) {
+      return { model: tier.model, expectedDigest: tier.expectedDigest ?? null };
+    }
   }
-  return "ai/qwen3:4B-UD-Q4_K_XL";
+  return { model: "ai/qwen3:4B-UD-Q4_K_XL", expectedDigest: null };
 }
 
 function main(): void {


### PR DESCRIPTION
## Why

Closes the one material finding from the `tool-evaluation` of `hf.co/ggml-org/Qwen3.8-27B-GGUF`, which returned **CONDITIONAL**. #4350 made that repo the default local model for every install with a 23 GB+ budget — the first DPF default sourced outside Docker's curated `ai/` namespace.

A HuggingFace reference names a **file**, not an immutable revision; the publisher can replace it in place. And `docker model pull` accepts no flags at all:

```
Usage:  docker model pull MODEL
```

So nothing pins bytes at pull time, and neither installer checked what it received. A later install could fetch different weights under the same reference with no signal.

Model weights are a **control-plane** input — they determine tool-calling and agentic behaviour — so a silent substitution is a behavioural compromise, not merely a data one.

## What

- `LocalModelTier.expectedDigest`, set for the Qwen3.8 tier.
- Threaded through the host profile `scripts/detect-hardware-host.ts` already emits, because the installers cannot import TypeScript.
- Compared against `docker model inspect` after pull in **both** `install-dpf.sh` and `install-dpf.ps1`.

**Detection, not prevention** — the honest ceiling given the pull API. Warns loudly, never fails the install: a legitimate republish should prompt re-evaluation, not brick a new machine.

## The part that keeps this from rotting

```ts
it("every tier sourced outside the curated ai/ namespace pins a digest", ...)
```

A future external-sourced tier cannot be added without a digest. `ai/` tiers are exempt by design — Docker Hub's content-addressed registry already pins bytes to a tag.

## Verification

Against the live artifact, not only in tests — the shell extraction reads the digest out of a real `docker model inspect` and matches the pin:

```
extracted: sha256:66c4f325bc71350f07fb2da4f92455553c7bbc8af5d7ee2095fbeac79b9e66c9
pinned   : sha256:66c4f325bc71350f07fb2da4f92455553c7bbc8af5d7ee2095fbeac79b9e66c9
MATCH
```

- 34 policy tests pass; typecheck clean; `bash -n` clean; `install-dpf.ps1` ASCII-only and brace-balanced
- `detect-hardware-host.ts` runs and emits `expectedDigest` (null on this host, which selects an `ai/` tier — correct)
- local-CI pregate: **PASS** — gated sha `3199c02ae`, evidence `cmsvghxuq003l01pnl59bt7v2`

## Not verified here

The PowerShell branch has not been executed — this is a macOS host with no `pwsh`. CI's installer-surface job is the parser check; a real Windows install is the functional one.

## Pre-existing issue fixed in passing

`install-dpf.ps1` carried a non-ASCII em dash in a comment (arrived with #4362); that file is plain-ASCII by contract. Noted rather than deferred silently.

Design-Grounding-Decision: grounded in docs/superpowers/plans/2026-08-15-qwen38-27b-local-tier-plan.md and apps/web/lib/inference/local-model-policy.ts
Docs-Impact-Decision: installer integrity check; no user-facing docs surface changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)