### PR TITLE
fix(release): detect a published image that has fallen behind the install contract

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -157,6 +157,15 @@ jobs:
           build-args: |
             DPF_VERSION=${{ github.sha }}
             DPF_PLATFORM_VERSION=${{ github.ref_name }}
+          # Same identity, in the OCI-standard place. /app/.dpf-image-version is inside
+          # the filesystem, so reading it costs a `docker create` + `docker cp`; a label
+          # is readable straight from the manifest. `latest` sat 1851 commits behind main
+          # for ~7 weeks and nothing caught it, partly because the only identity was one
+          # no tool would think to look for. Keep both: the file is what the running
+          # portal self-reports, the label is what tooling inspects.
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}
           # Push by digest only — the merge job assembles the named
           # tag manifest list. `type=image,name=...,push-by-digest=true`
           # uploads the layers under the digest with no human tag.

--- a/.github/workflows/published-image-freshness.yml
+++ b/.github/workflows/published-image-freshness.yml
@@ -1,0 +1,68 @@
+# Is the image a new user would actually pull still able to install?
+#
+# `dpf-portal:latest` sat 1851 commits behind `main` for roughly seven weeks. The
+# "Ready to go" installer runs `docker cp <container>:/dpf-release-assets/.`, and that
+# directory only exists in images built after 1c157563a. Every non-technical user's
+# install failed with `consumer_release_asset_export_failed` for that entire period.
+#
+# It went unseen because CI only ever built images from source — nothing pulled the
+# PUBLISHED artifact and asked whether it still matched the installer's expectations.
+# One matrix cell (dpf-edge-node) failing its typecheck takes the whole publish down,
+# so `latest` silently stops advancing while every PR stays green.
+#
+# This runs daily against the real registry and fails loudly when the published image
+# falls behind the release contract.
+name: Published Image Freshness
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Image ref to check"
+        required: false
+        default: "ghcr.io/opendigitalproductfactory/dpf-portal:latest"
+      max_behind:
+        description: "Advisory commit-drift ceiling"
+        required: false
+        default: "250"
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  freshness:
+    name: Published image freshness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history: the check walks from the published image's commit to HEAD.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check published image against the release contract
+        # Inputs go through env, never interpolated straight into the shell: a
+        # `${{ github.event.inputs.* }}` inside `run:` is the standard Actions
+        # script-injection sink.
+        env:
+          IMAGE: ${{ github.event.inputs.image || 'ghcr.io/opendigitalproductfactory/dpf-portal:latest' }}
+          MAX_BEHIND: ${{ github.event.inputs.max_behind || '250' }}
+        run: |
+          set -euo pipefail
+          node scripts/check-published-image-freshness.mjs \
+            --image "$IMAGE" \
+            --ref HEAD \
+            --max-behind "$MAX_BEHIND"

--- a/scripts/check-published-image-freshness.mjs
+++ b/scripts/check-published-image-freshness.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// Compare the PUBLISHED image's source stamp to this branch, and fail when the
+// release pipeline has fallen behind the contract the installer depends on.
+//
+// Why: `dpf-portal:latest` sat 1851 commits behind main for ~7 weeks. The consumer
+// ("Ready to go") installer does `docker cp <c>:/dpf-release-assets/.`, and that
+// directory only exists in images built after 1c157563a. Every non-technical user's
+// install failed with consumer_release_asset_export_failed, and nothing detected it,
+// because nothing compared the published image to the branch.
+//
+// Requires Docker + registry read. The decision logic is separated into
+// scripts/lib/published-image-freshness.mjs so it is unit-tested without either.
+//
+// Usage:
+//   node scripts/check-published-image-freshness.mjs [--image <ref>] [--ref <git-ref>]
+//                                                    [--max-behind N] [--json]
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  RELEASE_CONTRACT_PATHS,
+  evaluatePublishedImageFreshness,
+} from "./lib/published-image-freshness.mjs";
+
+const DEFAULT_IMAGE = "ghcr.io/opendigitalproductfactory/dpf-portal:latest";
+const STAMP_PATH = "/app/.dpf-image-version";
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+const wantJson = process.argv.includes("--json");
+const image = arg("--image", DEFAULT_IMAGE);
+const gitRef = arg("--ref", "origin/main");
+const maxCommitsBehind = Number(arg("--max-behind", "250"));
+
+function run(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], ...opts }).trim();
+}
+
+/** Pull the image and read the commit it was built from. */
+function readPublishedSha(ref) {
+  run("docker", ["pull", "--quiet", ref]);
+  const cid = run("docker", ["create", ref]);
+  const dir = mkdtempSync(join(tmpdir(), "dpf-imgver-"));
+  try {
+    run("docker", ["cp", `${cid}:${STAMP_PATH}`, dir]);
+    return readFileSync(join(dir, ".dpf-image-version"), "utf8").trim() || null;
+  } catch {
+    return null; // unstamped -> UNKNOWN, handled as blocking by the evaluator
+  } finally {
+    try { run("docker", ["rm", "-f", cid]); } catch { /* best effort */ }
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function main() {
+  const headSha = run("git", ["rev-parse", gitRef]);
+
+  let publishedSha = null;
+  try {
+    publishedSha = readPublishedSha(image);
+  } catch (err) {
+    console.error(`[published-image-freshness] could not inspect ${image}: ${err.message}`);
+    process.exit(2); // infrastructure problem, not a verdict
+  }
+
+  let isAncestor = false;
+  let commitsBehind = 0;
+  let contractChanged = [];
+  if (publishedSha) {
+    try {
+      execFileSync("git", ["merge-base", "--is-ancestor", publishedSha, headSha], { stdio: "ignore" });
+      isAncestor = true;
+    } catch {
+      isAncestor = false;
+    }
+    if (isAncestor) {
+      commitsBehind = Number(run("git", ["rev-list", "--count", `${publishedSha}..${headSha}`]));
+      const changed = run("git", [
+        "diff", "--name-only", `${publishedSha}..${headSha}`, "--", ...RELEASE_CONTRACT_PATHS,
+      ]);
+      contractChanged = changed ? changed.split(/\r?\n/).filter(Boolean) : [];
+    }
+  }
+
+  const result = evaluatePublishedImageFreshness({
+    publishedSha, headSha, publishedShaIsAncestor: isAncestor,
+    contractPathsChangedSince: contractChanged, commitsBehind, maxCommitsBehind,
+  });
+
+  if (wantJson) {
+    console.log(JSON.stringify({ image, publishedSha, headSha, commitsBehind, contractChanged, ...result }, null, 2));
+  } else {
+    console.log(`[published-image-freshness] image        : ${image}`);
+    console.log(`[published-image-freshness] built from   : ${publishedSha ?? "(unstamped)"}`);
+    console.log(`[published-image-freshness] ${gitRef} head: ${headSha}`);
+    console.log(`[published-image-freshness] behind       : ${commitsBehind}`);
+    console.log(`[published-image-freshness] verdict      : ${result.verdict.toUpperCase()}`);
+    console.log(`[published-image-freshness] ${result.reason}`);
+    if (result.blocking) {
+      console.log("");
+      console.log("  Republish with:  gh workflow run publish-image.yml --ref main -f tag=latest");
+      console.log("  Then re-run the consumer install path end to end before calling it fixed.");
+    }
+  }
+  process.exit(result.blocking ? 1 : 0);
+}
+
+main();

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -43,6 +43,7 @@ const EXPECTED_LEGACY_JOBS = [
   "package-boundary-guard",
   "pr-health-test",
   "prose-lint-guard",
+  "published-image-freshness",
   "repo-guard-loop",
   "reporting-composition-guard",
   "retired-substrate-guard",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -47,6 +47,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("shell-guard-shim-contract", "Shell Guard Shim Contract", [
       node("--test", "scripts/check-shell-guard-shim-contract.test.mjs"),
     ]),
+    guard("published-image-freshness", "Published Image Freshness", [
+      // Decision logic only — the live registry check needs Docker and runs on a
+      // schedule (.github/workflows/published-image-freshness.yml).
+      node("--test", "scripts/lib/published-image-freshness.test.mjs"),
+    ]),
     guard("docs-link-integrity", "Docs Link Integrity", [
       node("scripts/gen-doc-index.mjs", "--check"),
       node(

--- a/scripts/lib/published-image-freshness.mjs
+++ b/scripts/lib/published-image-freshness.mjs
@@ -1,0 +1,111 @@
+// Decide whether a PUBLISHED image is too stale to serve the consumer install path.
+//
+// Background: `dpf-portal:latest` sat 1851 commits behind `main` for roughly seven
+// weeks. The "Ready to go" installer does
+//   docker cp <container>:/dpf-release-assets/. <staging>
+// and that directory is only present in images built after 1c157563a (2026-07-18).
+// Every non-technical user's install failed with
+// `consumer_release_asset_export_failed` for that whole period, and nothing noticed.
+//
+// Nothing noticed because nothing *looked*. The image already records the commit it
+// was built from at /app/.dpf-image-version (the DPF_VERSION build-arg), and
+// AGENTS.md section 12 already requires that identity — but no check compared the
+// published stamp to the branch.
+//
+// This module is the pure decision half so it can be unit-tested without Docker, a
+// network, or a registry credential. The IO half lives in
+// scripts/check-published-image-freshness.mjs.
+
+/**
+ * Paths whose change makes an old published image *incompatible*, not merely old.
+ * A change here alters the contract between the installer and the image it pulls.
+ */
+export const RELEASE_CONTRACT_PATHS = Object.freeze([
+  "Dockerfile",
+  "install-dpf.ps1",
+  "install-dpf.sh",
+  "docker-compose.yml",
+  "docker-compose.release.yml",
+]);
+
+export const FRESHNESS_VERDICTS = Object.freeze({
+  OK: "ok",
+  UNKNOWN: "unknown",
+  STALE: "stale",
+  INCOMPATIBLE: "incompatible",
+});
+
+/**
+ * @param {object} input
+ * @param {string|null} input.publishedSha        commit the published image was built from
+ * @param {string|null} input.headSha             current tip of the release branch
+ * @param {boolean} input.publishedShaIsAncestor  is publishedSha reachable from headSha?
+ * @param {string[]} input.contractPathsChangedSince
+ *        release-contract paths modified between publishedSha and headSha
+ * @param {number} input.commitsBehind
+ * @param {number} [input.maxCommitsBehind=250]   advisory drift ceiling
+ * @returns {{verdict: string, blocking: boolean, reason: string}}
+ */
+export function evaluatePublishedImageFreshness({
+  publishedSha,
+  headSha,
+  publishedShaIsAncestor,
+  contractPathsChangedSince,
+  commitsBehind,
+  maxCommitsBehind = 250,
+}) {
+  if (!publishedSha) {
+    return {
+      verdict: FRESHNESS_VERDICTS.UNKNOWN,
+      blocking: true,
+      reason:
+        "the published image carries no source stamp at /app/.dpf-image-version, so its " +
+        "identity cannot be established (AGENTS.md section 12: an image carries the identity " +
+        "of its bytes)",
+    };
+  }
+
+  if (!publishedShaIsAncestor) {
+    return {
+      verdict: FRESHNESS_VERDICTS.UNKNOWN,
+      blocking: true,
+      reason:
+        `the published image was built from ${short(publishedSha)}, which is not an ancestor ` +
+        `of ${short(headSha)} — it was built from a branch that is not in the release line`,
+    };
+  }
+
+  const changed = [...new Set(contractPathsChangedSince ?? [])].sort();
+  if (changed.length > 0) {
+    return {
+      verdict: FRESHNESS_VERDICTS.INCOMPATIBLE,
+      blocking: true,
+      reason:
+        `release-contract path(s) changed since the published image was built ` +
+        `(${short(publishedSha)}): ${changed.join(", ")}. The installer may now depend on an ` +
+        `artifact the published image does not contain — this is exactly the shape of the ` +
+        `consumer_release_asset_export_failed outage. Republish before shipping.`,
+    };
+  }
+
+  if (commitsBehind > maxCommitsBehind) {
+    return {
+      verdict: FRESHNESS_VERDICTS.STALE,
+      blocking: true,
+      reason:
+        `the published image is ${commitsBehind} commits behind (ceiling ${maxCommitsBehind}). ` +
+        `No release-contract path changed, so it should still install, but this much drift ` +
+        `means the release pipeline has not run successfully in a long time.`,
+    };
+  }
+
+  return {
+    verdict: FRESHNESS_VERDICTS.OK,
+    blocking: false,
+    reason: `published image is ${commitsBehind} commit(s) behind and no release-contract path changed`,
+  };
+}
+
+function short(sha) {
+  return typeof sha === "string" && sha.length >= 9 ? sha.slice(0, 9) : String(sha);
+}

--- a/scripts/lib/published-image-freshness.test.mjs
+++ b/scripts/lib/published-image-freshness.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  FRESHNESS_VERDICTS,
+  RELEASE_CONTRACT_PATHS,
+  evaluatePublishedImageFreshness,
+} from "./published-image-freshness.mjs";
+
+const base = {
+  publishedSha: "ab65c948b19292cb44e5b09ef07d7bd7303114fe",
+  headSha: "a99058c4a0000000000000000000000000000000",
+  publishedShaIsAncestor: true,
+  contractPathsChangedSince: [],
+  commitsBehind: 3,
+};
+
+test("a recent image with no contract drift is fresh", () => {
+  const r = evaluatePublishedImageFreshness(base);
+  assert.equal(r.verdict, FRESHNESS_VERDICTS.OK);
+  assert.equal(r.blocking, false);
+});
+
+test("reproduces the real outage: Dockerfile changed since the published image", () => {
+  // The actual 2026 incident — install-dpf.ps1 began requiring /dpf-release-assets in
+  // the same commit that added it to the Dockerfile, and the image was never rebuilt.
+  const r = evaluatePublishedImageFreshness({
+    ...base,
+    contractPathsChangedSince: ["Dockerfile", "install-dpf.ps1"],
+    commitsBehind: 1851,
+  });
+  assert.equal(r.verdict, FRESHNESS_VERDICTS.INCOMPATIBLE);
+  assert.equal(r.blocking, true);
+  assert.match(r.reason, /Dockerfile/);
+  assert.match(r.reason, /install-dpf\.ps1/);
+});
+
+test("contract drift outranks mere staleness", () => {
+  const drifted = evaluatePublishedImageFreshness({
+    ...base,
+    contractPathsChangedSince: ["Dockerfile"],
+    commitsBehind: 5000,
+  });
+  assert.equal(drifted.verdict, FRESHNESS_VERDICTS.INCOMPATIBLE);
+});
+
+test("large drift with no contract change is stale, not incompatible", () => {
+  const r = evaluatePublishedImageFreshness({ ...base, commitsBehind: 1851 });
+  assert.equal(r.verdict, FRESHNESS_VERDICTS.STALE);
+  assert.equal(r.blocking, true);
+  assert.match(r.reason, /1851 commits behind/);
+});
+
+test("drift exactly at the ceiling is still OK; one past it is stale", () => {
+  assert.equal(
+    evaluatePublishedImageFreshness({ ...base, commitsBehind: 250 }).verdict,
+    FRESHNESS_VERDICTS.OK,
+  );
+  assert.equal(
+    evaluatePublishedImageFreshness({ ...base, commitsBehind: 251 }).verdict,
+    FRESHNESS_VERDICTS.STALE,
+  );
+});
+
+test("an unstamped image is UNKNOWN and blocking, never silently OK", () => {
+  const r = evaluatePublishedImageFreshness({ ...base, publishedSha: null });
+  assert.equal(r.verdict, FRESHNESS_VERDICTS.UNKNOWN);
+  assert.equal(r.blocking, true);
+  assert.match(r.reason, /identity/);
+});
+
+test("an image built off the release line is UNKNOWN and blocking", () => {
+  const r = evaluatePublishedImageFreshness({ ...base, publishedShaIsAncestor: false });
+  assert.equal(r.verdict, FRESHNESS_VERDICTS.UNKNOWN);
+  assert.equal(r.blocking, true);
+  assert.match(r.reason, /not an ancestor/);
+});
+
+test("duplicate contract paths are de-duplicated and sorted in the reason", () => {
+  const r = evaluatePublishedImageFreshness({
+    ...base,
+    contractPathsChangedSince: ["install-dpf.ps1", "Dockerfile", "Dockerfile"],
+  });
+  assert.match(r.reason, /Dockerfile, install-dpf\.ps1/);
+});
+
+test("the release-contract path list covers the installer and the image recipe", () => {
+  // These two are the pair whose divergence caused the outage; if either is dropped
+  // from the list the guard stops detecting the exact failure it exists for.
+  assert.ok(RELEASE_CONTRACT_PATHS.includes("Dockerfile"));
+  assert.ok(RELEASE_CONTRACT_PATHS.includes("install-dpf.ps1"));
+  assert.ok(RELEASE_CONTRACT_PATHS.includes("install-dpf.sh"));
+});


### PR DESCRIPTION
## The outage this exists to catch

`ghcr.io/opendigitalproductfactory/dpf-portal:latest` was built from `ab65c948b` (2026-06-26) and sat **1851 commits behind `main`**.

The consumer ("Ready to go") installer runs `docker cp <container>:/dpf-release-assets/. <staging>`. That directory only exists in images built after `1c157563a` (2026-07-18) — the commit that added it to the Dockerfile's `runner` stage **and** added the installer's dependency on it, together. So for roughly **seven weeks**, every non-technical user's install died with `consumer_release_asset_export_failed`. Reproduced on both `latest` and `v6.5.1`.

The source was never wrong. `publish-image.yml` already builds `dpf-portal` from `runner`. The images just stopped being published.

## Why it ran unseen for seven weeks

**Correcting an earlier version of this description:** `publish-image.yml` *does* have an **"E2E install verification (release mode)"** job that runs the real consumer path against the published images. The gap is not that nothing checks. It is *when* it checks, and what its silence means:

1. **It runs after publication.** The job is `needs: merge`, so the manifest is already pushed when it starts. A failure cannot un-publish — `latest` is live and broken by the time anything notices.
2. **It had been skipped, not passing, for months.** Every recent publish failed earlier in the chain (`dpf-edge-node`'s `tsc`), so the verification never executed. The last run that actually ran it was `28265930591`. Skipped reads exactly like healthy on a dashboard.
3. **Nothing compares the published image to the branch between publishes.** Drift is invisible until someone next attempts a release.

Point 2 is the sharp one: the safety net existed, and the thing that broke the release also disabled the net that would have reported it.

## What this adds

| File | Role |
|---|---|
| `scripts/lib/published-image-freshness.mjs` | The decision: `OK` / `STALE` / `INCOMPATIBLE` / `UNKNOWN`. Pure — unit-tests with no Docker, network, or registry credential. |
| `scripts/check-published-image-freshness.mjs` | The IO: pull, read the stamp at `/app/.dpf-image-version`, diff the release-contract paths, exit non-zero when blocking. |
| `.github/workflows/published-image-freshness.yml` | Runs it **daily against the real registry**, independent of whether a publish was attempted. This is the part that shortens a seven-week outage to a day. |
| `publish-image.yml` | Also stamps `org.opencontainers.image.revision`. |

Design choices worth flagging:

- **Contract drift outranks drift-by-count.** 1851 commits behind with no contract change is `STALE`; *one* commit behind that touches `Dockerfile` or `install-dpf.ps1` is `INCOMPATIBLE`. The second is what breaks installs.
- **An unstamped or off-release-line image is `UNKNOWN` *and blocking*** — never silently OK. A guard that cannot establish identity must not pass. That principle is the direct lesson from a skipped job reading as green.
- **The revision label is additive.** `/app/.dpf-image-version` is what the running portal self-reports; reading it costs a `docker create` + `docker cp`. A label is readable from the manifest — where tooling actually looks.

## Verification

Against the **live registry**, before the republish:

```
built from   : ab65c948b19292cb44e5b09ef07d7bd7303114fe
behind       : 1851
verdict      : INCOMPATIBLE
release-contract path(s) changed since the published image was built (ab65c948b):
  Dockerfile, docker-compose.yml, install-dpf.ps1, install-dpf.sh
```

exit code `1`. The unit test reproduces the real incident as a fixture, so the regression is pinned rather than described.

Registered as policy guard `published-image-freshness` — decision logic in the `source` profile, registry check on the schedule since it needs Docker.

## Status of the underlying breakage

A republish from current `main` has since run: **all 12 image builds and all 6 manifest merges succeeded**, and `latest` now reports `built from a99058c4a` and **does contain `/dpf-release-assets`**. The immediate user-facing blocker is cleared independently of this PR.

That same run's E2E verification then **failed** on Linux release mode — exit 1 with no diagnostic, immediately after `No prior install state; initializing ~/.dpf/install-state.json`.

## Out of scope — each deserves its own change

1. The `dpf-edge-node` typecheck fragility that keeps breaking the publish. Its typecheck belongs in normal PR CI so it can never reach the release workflow broken, and one image's failure should not block publishing the others.
2. The E2E verification running *after* merge rather than gating it.
3. That job's current silent exit-1 on Linux release mode.
