### PR TITLE
fix(install): unbreak every fresh Linux/macOS install (unmatched glob under set -e)

### DIFF
--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -30,6 +30,7 @@ const EXPECTED_LEGACY_JOBS = [
   "finding-substrate-guard",
   "fpaw-standard-guard",
   "host-port-range-guard",
+  "installer-state-contract",
   "instruction-plane-guard",
   "instruction-plane-rule-coverage",
   "janitor-tests",

--- a/scripts/installer/lib/state-cleanup-temps.test.mjs
+++ b/scripts/installer/lib/state-cleanup-temps.test.mjs
@@ -1,0 +1,113 @@
+// Regression test: dpf_state_cleanup_temps must never abort a `set -e` installer.
+//
+// install-dpf.sh runs under `set -euo pipefail` (line 34) and calls
+// dpf_state_cleanup_temps bare, inside dpf_state_init. The loop
+//
+//   for temp in "$directory/.${base}.tmp-"*; do [ -f "$temp" ] && rm -f "$temp"; done
+//
+// has no nullglob, so on a FRESH install -- no leftover temp files, i.e. the normal
+// case -- the glob stays literal, `[ -f ]` is false, and that false test is the
+// loop's last command, so the function returned 1. Every fresh Linux/macOS install
+// therefore died immediately after
+//
+//   -> Install state
+//      -  No prior install state; initializing ~/.dpf/install-state.json
+//   ##[error]Process completed with exit code 1
+//
+// with no error message at all. It also silently disabled the publish workflow's
+// "E2E install verification (release mode)" job -- the check meant to catch exactly
+// this class of breakage.
+//
+// These tests drive real bash, because the bug is a shell-semantics bug: asserting
+// on the source text would not have caught it.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const libDir = dirname(fileURLToPath(import.meta.url));
+const statePath = join(libDir, "state.sh").replace(/\\/g, "/");
+
+/** Run a bash snippet with state.sh sourced. Returns {status, stdout, stderr}. */
+function bash(snippet, { strict = true } = {}) {
+  const script = `${strict ? "set -euo pipefail" : ""}\n. '${statePath}'\n${snippet}\n`;
+  try {
+    const stdout = execFileSync("bash", ["-c", script], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err) {
+    return { status: err.status ?? 1, stdout: err.stdout ?? "", stderr: err.stderr ?? "" };
+  }
+}
+
+function withTempDir(fn) {
+  const dir = mkdtempSync(join(tmpdir(), "dpf-state-cleanup-"));
+  try { return fn(dir.replace(/\\/g, "/")); } finally { rmSync(dir, { recursive: true, force: true }); }
+}
+
+test("returns 0 when there are NO temp files — the fresh-install case that broke", () => {
+  withTempDir((dir) => {
+    const r = bash(`dpf_state_cleanup_temps '${dir}/install-state.json'\necho SURVIVED`);
+    assert.equal(r.status, 0, `aborted under set -e: ${r.stderr}`);
+    assert.match(r.stdout, /SURVIVED/, "the caller must continue past cleanup on a fresh install");
+  });
+});
+
+test("does not abort the caller when invoked bare under set -e", () => {
+  // Exactly how dpf_state_init calls it: no `|| rc=$?`, which would mask set -e.
+  withTempDir((dir) => {
+    const r = bash(`dpf_state_cleanup_temps '${dir}/install-state.json'\necho AFTER=$?`);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /AFTER=0/);
+  });
+});
+
+test("still removes leftover temp files when they exist", () => {
+  withTempDir((dir) => {
+    const a = join(dir, ".install-state.json.tmp-1-111-222");
+    const b = join(dir, ".install-state.json.tmp-9-999-999");
+    writeFileSync(a, "stale");
+    writeFileSync(b, "stale");
+    const r = bash(`dpf_state_cleanup_temps '${dir}/install-state.json'\necho CLEANED`);
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /CLEANED/);
+    assert.equal(existsSync(a), false, "leftover temp must be removed");
+    assert.equal(existsSync(b), false, "leftover temp must be removed");
+  });
+});
+
+test("leaves unrelated files in the state directory alone", () => {
+  withTempDir((dir) => {
+    const keep = join(dir, "install-state.json");
+    const alsoKeep = join(dir, ".install-state.json.lock");
+    writeFileSync(keep, "{}");
+    writeFileSync(alsoKeep, "lock");
+    const r = bash(`dpf_state_cleanup_temps '${dir}/install-state.json'`);
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(existsSync(keep), true, "the state file itself must survive");
+    assert.equal(existsSync(alsoKeep), true, "the lock file must survive");
+  });
+});
+
+test("dpf_state_init completes under set -e on a pristine state dir", () => {
+  // The end-to-end shape of the outage: dpf_state_init calls cleanup_temps bare.
+  withTempDir((dir) => {
+    const r = bash(
+      `export DPF_STATE_DIR='${dir}'\n` +
+      `dpf_state_init 'test-installer' '${dir}'\n` +
+      `echo INIT_OK`,
+    );
+    // DPF_STATE_DIR is honoured by dpf_state_dir(), so this stays hermetic and
+    // never touches the operator's real ~/.dpf.
+    assert.doesNotMatch(
+      r.stderr,
+      /line \d+: .*cleanup_temps/,
+      `cleanup must not be the abort site: ${r.stderr}`,
+    );
+    assert.equal(r.status, 0, `dpf_state_init aborted under set -e: ${r.stderr}`);
+    assert.match(r.stdout, /INIT_OK/);
+  });
+});

--- a/scripts/installer/lib/state.sh
+++ b/scripts/installer/lib/state.sh
@@ -133,7 +133,18 @@ dpf_state_lock_release() {
 dpf_state_cleanup_temps() {
   local path="$1" directory base temp
   directory="$(dirname "$path")"; base="$(basename "$path")"
-  for temp in "$directory/.${base}.tmp-"*; do [ -f "$temp" ] && rm -f "$temp"; done
+  # No nullglob: an unmatched glob stays LITERAL, so on the common case -- a fresh
+  # install with no leftover temps -- $temp is the pattern itself and `[ -f ]` is
+  # false. As the loop's last command that made the whole function return 1, and
+  # install-dpf.sh runs under `set -euo pipefail`, so a fresh install died right
+  # after "No prior install state; initializing ..." with exit 1 and no message.
+  # Guard with -e + continue, and return 0 explicitly so the exit status can never
+  # be inherited from the final test again.
+  for temp in "$directory/.${base}.tmp-"*; do
+    [ -e "$temp" ] || continue
+    rm -f "$temp"
+  done
+  return 0
 }
 
 dpf_state_temp_path() { echo "$(dirname "$1")/.$(basename "$1").tmp-${DPF_STATE_LOCK_OWNER_ID}"; }

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -47,6 +47,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("shell-guard-shim-contract", "Shell Guard Shim Contract", [
       node("--test", "scripts/check-shell-guard-shim-contract.test.mjs"),
     ]),
+    guard("installer-state-contract", "Installer State Contract", [
+      // Drives real bash: install-dpf.sh runs under `set -euo pipefail`, and the
+      // failure mode here is shell exit-status semantics, not source text.
+      node("--test", "scripts/installer/lib/state-cleanup-temps.test.mjs"),
+    ]),
     guard("published-image-freshness", "Published Image Freshness", [
       // Decision logic only — the live registry check needs Docker and runs on a
       // schedule (.github/workflows/published-image-freshness.yml).


### PR DESCRIPTION
## Symptom

`bash install-dpf.sh` dies on a **fresh** machine immediately after:

```
-> Install state
   -  No prior install state; initializing ~/.dpf/install-state.json
```

Exit code 1. **No error message at all.**

## Cause

```bash
dpf_state_cleanup_temps() {
  ...
  for temp in "$directory/.${base}.tmp-"*; do [ -f "$temp" ] && rm -f "$temp"; done
}
```

There is no `shopt -s nullglob`, so when the glob matches nothing — **the normal case on a fresh install** — bash leaves the pattern literal. `[ -f '<pattern>' ]` is false, that false test is the loop's last command, so it becomes the function's exit status. `install-dpf.sh` runs under `set -euo pipefail` (line 34) and calls it bare inside `dpf_state_init`, so the whole installer aborts.

The failure is invisible by construction: the `&&` short-circuit prints nothing, and `set -e` kills the script before the next step can print anything.

The fix guards the loop body with `[ -e "$temp" ] || continue` and returns 0 explicitly, so the function's status can never again be inherited from a probe.

## Verified end to end

Clean `linux/amd64` container, real installer, `--headless --release`:

**Before** — byte-identical to the CI failure:
```
-> Install state
   -  No prior install state; initializing /root/.dpf/install-state.json
exit=1
```

**After**:
```
-> Install mode
   OK Install mode: customer (compose mode: release)
-> Compose chain
   Files: -f docker-compose.yml -f docker-compose.release.yml -f docker-compose.linux.yml
-> Docker Engine          ← only stops here for lack of docker in the container
```

## Blast radius

This is the **"Ready to go" path on Linux and macOS** — the one a non-technical user takes.

It also silently disabled `publish-image.yml`'s **"E2E install verification (release mode)"** job, which runs exactly this command. The check meant to catch consumer-install breakage was itself broken by it — and a red E2E there reads as a release problem rather than an installer bug, which is part of why this survived.

## Regression coverage

`scripts/installer/lib/state-cleanup-temps.test.mjs` drives **real bash**, because this is a shell exit-status bug — asserting on source text would not have caught it. It covers:

- the fresh-install case (no temp files) returning 0
- bare invocation under `set -e` not aborting the caller
- genuine leftovers still being removed
- the state file and lock file being left alone
- `dpf_state_init` completing under `set -e`

Hermetic via `DPF_STATE_DIR`, so it never touches an operator's real `~/.dpf`.

**Confirmed the suite fails (4 of 5) against the pre-fix function and passes against the fixed one.**

Registered as policy guard `installer-state-contract`.

## Found by

The zero-footprint reset + fresh-install rehearsal. `dpf-portal:latest` has since been republished (it was 1851 commits behind, missing `/dpf-release-assets`), which cleared the Windows consumer blocker; with builds succeeding again the E2E job ran for the first time in months and surfaced this.
