### PR TITLE
fix(release): ship the shell guard in the release assets so consumer installs work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,6 +177,11 @@ RUN mkdir -p /dpf-release-assets/scripts/lib /dpf-release-assets/scripts/install
     cp scripts/installer/install-state.v2.schema.json /dpf-release-assets/scripts/installer/ && \
     cp scripts/installer/native-edge-host.ps1 /dpf-release-assets/scripts/installer/ && \
     cp scripts/installer/lib/state.ps1 /dpf-release-assets/scripts/installer/lib/ && \
+    mkdir -p /dpf-release-assets/scripts/safety && \
+    cp scripts/safety/dpf-shell-guard.ps1 scripts/safety/dpf-shell-guard.sh \
+       scripts/safety/dpf-shell-guard-fallback-patterns.json \
+       scripts/safety/pre-destructive-snapshot.ps1 scripts/safety/pre-destructive-snapshot.sh \
+       /dpf-release-assets/scripts/safety/ && \
     cp -R monitoring/. /dpf-release-assets/monitoring/ && \
     cd /dpf-release-assets && \
     find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS

--- a/scripts/check-release-asset-contract.test.mjs
+++ b/scripts/check-release-asset-contract.test.mjs
@@ -1,0 +1,108 @@
+// The consumer ("Ready to go") install has NO git checkout. Everything the
+// installer touches under the install directory must therefore be present in the
+// image's /dpf-release-assets bundle, because that bundle IS the install directory.
+//
+// This broke twice in one week, the same way both times:
+//
+//   1. The bundle existed in source but the published image predated it, so
+//      `docker cp <c>:/dpf-release-assets/.` failed -> consumer_release_asset_export_failed.
+//   2. Once that was fixed, the very next step failed:
+//        Copy-Item : Cannot find path 'D:\DPF\scripts\safety\dpf-shell-guard.ps1'
+//      The installer unconditionally copies the kernel-commandment shell guard out
+//      of the install dir, and the bundle never shipped scripts/safety/ at all.
+//
+// Defect 2 hid behind defect 1, and CI could not see either: the publish workflow's
+// E2E install verification runs `install-dpf.sh --release` from an actions/checkout,
+// so $REPO_ROOT is a FULL SOURCE TREE. It exercises release *mode* but never the
+// no-checkout consumer *scenario* that the Windows README actually instructs
+// (download install-dpf.ps1 alone, no clone).
+//
+// So this asserts the contract statically instead: every path the installers copy
+// unconditionally out of the install directory must be in the Dockerfile's bundle.
+
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const dockerfile = readFileSync(join(repoRoot, "Dockerfile"), "utf8");
+const psInstaller = readFileSync(join(repoRoot, "install-dpf.ps1"), "utf8");
+const shInstaller = readFileSync(join(repoRoot, "install-dpf.sh"), "utf8");
+
+/**
+ * Repo-relative paths the installers copy out of the install directory with no
+ * mode guard, so the consumer path always needs them. Keep in sync deliberately:
+ * test "every required path is actually referenced" fails on a stale entry.
+ */
+const REQUIRED_IN_BUNDLE = Object.freeze([
+  "scripts/safety/dpf-shell-guard.ps1",
+  "scripts/safety/dpf-shell-guard.sh",
+  "scripts/safety/dpf-shell-guard-fallback-patterns.json",
+  "scripts/installer/lib/state.ps1",
+  "scripts/bootstrap-organization-pki.ps1",
+]);
+
+/** The single RUN block that assembles /dpf-release-assets. */
+function releaseAssetBlock(source) {
+  const start = source.indexOf("/dpf-release-assets");
+  assert.notEqual(start, -1, "Dockerfile must still build /dpf-release-assets");
+  const lineStart = source.lastIndexOf("RUN ", start);
+  // The block ends at the SHA256SUMS generation that closes it.
+  const end = source.indexOf("SHA256SUMS", source.indexOf("find .", lineStart));
+  assert.ok(end > lineStart, "release-asset block must end by generating SHA256SUMS");
+  return source.slice(lineStart, end);
+}
+
+const block = releaseAssetBlock(dockerfile);
+
+test("every file the installers unconditionally copy is shipped in the bundle", () => {
+  const missing = REQUIRED_IN_BUNDLE.filter((p) => !block.includes(p));
+  assert.deepEqual(
+    missing,
+    [],
+    "the consumer install has no git checkout, so these must ship in /dpf-release-assets. " +
+      "Missing: " + missing.join(", "),
+  );
+});
+
+test("every required path is actually referenced by an installer (no stale entries)", () => {
+  for (const p of REQUIRED_IN_BUNDLE) {
+    const win = p.replace(/\//g, "\\\\");
+    const referenced =
+      psInstaller.includes(p) || psInstaller.includes(p.replace(/\//g, "\\")) ||
+      psInstaller.includes(win) || shInstaller.includes(p);
+    assert.ok(referenced, `${p} is shipped/required but no installer references it — stale entry?`);
+  }
+});
+
+test("every required path exists in the repo", () => {
+  for (const p of REQUIRED_IN_BUNDLE) {
+    assert.ok(existsSync(join(repoRoot, p)), `${p} is required by the installer but absent from the repo`);
+  }
+});
+
+test("the shell guard the installer copies is in the bundle — the exact defect", () => {
+  // install-dpf.ps1: Copy-Item -Path (Join-Path $DPF_DIR "scripts\safety\dpf-shell-guard.ps1")
+  assert.match(
+    psInstaller,
+    /Join-Path \$DPF_DIR "scripts\\safety\\dpf-shell-guard\.ps1"/,
+    "installer should still copy the guard; if this moved, update the contract list",
+  );
+  assert.ok(
+    block.includes("scripts/safety/dpf-shell-guard.ps1"),
+    "Dockerfile must ship scripts/safety/dpf-shell-guard.ps1 or the consumer install dies at safety-bin setup",
+  );
+});
+
+test("SHA256SUMS is generated last, so newly added assets are covered", () => {
+  const shaIdx = dockerfile.indexOf("sha256sum > SHA256SUMS");
+  const safetyIdx = dockerfile.indexOf("/dpf-release-assets/scripts/safety");
+  assert.ok(shaIdx > 0, "the bundle must still be checksummed");
+  assert.ok(
+    safetyIdx > 0 && safetyIdx < shaIdx,
+    "assets must be copied BEFORE the manifest is generated, or the installer's " +
+      "Test-DPFReleaseAssetManifest -RejectUnlisted will reject them",
+  );
+});

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -45,6 +45,7 @@ const EXPECTED_LEGACY_JOBS = [
   "pr-health-test",
   "prose-lint-guard",
   "published-image-freshness",
+  "release-asset-contract",
   "repo-guard-loop",
   "reporting-composition-guard",
   "retired-substrate-guard",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -47,6 +47,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("shell-guard-shim-contract", "Shell Guard Shim Contract", [
       node("--test", "scripts/check-shell-guard-shim-contract.test.mjs"),
     ]),
+    guard("release-asset-contract", "Release Asset Contract", [
+      // The consumer install has no git checkout: whatever the installer copies
+      // out of the install dir must ship in the image's /dpf-release-assets.
+      node("--test", "scripts/check-release-asset-contract.test.mjs"),
+    ]),
     guard("installer-state-contract", "Installer State Contract", [
       // Drives real bash: install-dpf.sh runs under `set -euo pipefail`, and the
       // failure mode here is shell exit-status semantics, not source text.


### PR DESCRIPTION
## Symptom

The **"Ready to go"** install on Windows dies immediately after the release assets are extracted:

```
Copy-Item : Cannot find path 'D:\DPF\scripts\safety\dpf-shell-guard.ps1'
  at install-dpf.ps1:1593
```

## Cause

`install-dpf.ps1` (and `install-dpf.sh`) **unconditionally** copy the kernel-commandment shell guard out of the install directory into `safety-bin`. On the consumer path there is no git checkout — the install directory **is** the `/dpf-release-assets` bundle from the image — and that bundle never shipped `scripts/safety/` at all.

This was hiding behind the previous defect. Until the images were republished, the consumer path died earlier at `docker cp <c>:/dpf-release-assets/.`, so nothing ever reached the safety-bin step. Fixing one blocker surfaced the next.

## Why CI could not see it

`publish-image.yml`'s **"E2E install verification (release mode)"** runs `install-dpf.sh --release` *after* `actions/checkout`, so `$REPO_ROOT` is a **full source tree**. It exercises release **mode** but never the no-checkout consumer **scenario**.

That asymmetry also explains why only Windows breaks:

| Platform | README says | Has a checkout? | Result |
|---|---|---|---|
| Windows | `iwr` the script alone, no clone | **No** | breaks — needs repo files it doesn't have |
| macOS / Linux | `git clone` then `bash install-dpf.sh` | Yes | works, by accident of having the source |

## Fix

Ship `scripts/safety/{dpf-shell-guard.ps1, dpf-shell-guard.sh, dpf-shell-guard-fallback-patterns.json, pre-destructive-snapshot.{ps1,sh}}` in the bundle.

They land **before** the `SHA256SUMS` step, so they're covered by the manifest the installer verifies with `-RejectUnlisted`. Both platforms' guards ship, since either installer may run against the bundle.

## Regression coverage

`scripts/check-release-asset-contract.test.mjs` asserts:

- every path the installers copy unconditionally out of the install dir is in the Dockerfile bundle
- no entry is stale — each is still referenced by an installer **and** still exists in the repo
- assets are copied **before** `SHA256SUMS`, so `-RejectUnlisted` cannot reject them

**Confirmed it fails (3 of 5) against the pre-fix Dockerfile and passes against the fixed one.**

Registered as policy guard `release-asset-contract`.

## Found by

A real zero-footprint reinstall on Windows following the README verbatim — the third distinct blocker on that path in this sequence, after the stale published image and the `safety-bin` shim arg-binding bug.

**Note:** this fix only reaches users once the images are republished — the bundle is baked at image build time.

## Follow-up worth doing separately

The E2E verification should exercise the consumer scenario as documented (script only, no checkout), not just release mode from a checkout. As written it structurally cannot catch this class of defect.
