### PR TITLE
fix(release): COPY the safety assets into the init stage (repairs image publish)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,14 @@ COPY scripts/installer/install-state.v2.schema.json ./scripts/installer/
 COPY scripts/installer/native-edge-host.ps1 ./scripts/installer/
 COPY scripts/bootstrap-organization-pki.ps1 ./scripts/
 COPY scripts/installer/lib/state.ps1 ./scripts/installer/lib/
+# The consumer installer copies the kernel-commandment shell guard out of the
+# install dir, which on that path IS the release-asset bundle. The init stage
+# COPYs each asset explicitly, so the guard must be pulled in here before the
+# bundle-assembly RUN can cp it.
+COPY scripts/safety/dpf-shell-guard.ps1 scripts/safety/dpf-shell-guard.sh \
+     scripts/safety/dpf-shell-guard-fallback-patterns.json \
+     scripts/safety/pre-destructive-snapshot.ps1 scripts/safety/pre-destructive-snapshot.sh \
+     ./scripts/safety/
 COPY monitoring/ ./monitoring/
 COPY scripts/backup-postgres.sh ./scripts/
 COPY scripts/restore-postgres.sh ./scripts/

--- a/scripts/check-release-asset-contract.test.mjs
+++ b/scripts/check-release-asset-contract.test.mjs
@@ -67,6 +67,24 @@ test("every file the installers unconditionally copy is shipped in the bundle", 
   );
 });
 
+test("every bundled asset is also COPYed into the build stage that assembles it", () => {
+  // Asserting only on the `cp` is half the chain and lets a broken image build
+  // through: the init stage COPYs each asset explicitly, so a file that is cp'd
+  // but never COPYed fails the build with a bare `exit code: 1`. That exact gap
+  // shipped once -- the cp was added without the COPY.
+  const copiedIntoStage = dockerfile
+    .split(/\r?\n/)
+    .filter((l) => /^COPY\s/.test(l) || /^\s{5,}scripts\//.test(l))
+    .join("\n");
+  const notStaged = REQUIRED_IN_BUNDLE.filter((p) => !copiedIntoStage.includes(p));
+  assert.deepEqual(
+    notStaged,
+    [],
+    "these are cp'd into /dpf-release-assets but never COPYed into the stage, so the " +
+      "build will fail: " + notStaged.join(", "),
+  );
+});
+
 test("every required path is actually referenced by an installer (no stale entries)", () => {
   for (const p of REQUIRED_IN_BUNDLE) {
     const win = p.replace(/\//g, "\\\\");


### PR DESCRIPTION
## Repairs a break I introduced

[#4368](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4368) added the safety guard to the `/dpf-release-assets` bundle but **not** to the build stage that assembles it, so `docker build` fails:

```
ERROR: failed to solve: process "/bin/sh -c mkdir -p ... cp scripts/safety/dpf-shell-guard.ps1 ..."
did not complete successfully: exit code: 1
```

The `init` stage `COPY`s every asset it needs **explicitly** — it is not a full source tree — so a file that is `cp`'d into the bundle but never `COPY`'d into the stage cannot exist at `cp` time. **Image publishing has been broken since #4368 merged.**

## The test gap that let it through

My contract test in #4368 asserted the `cp` into the bundle but not the `COPY` into the stage — half the chain. That is exactly why a green test sat next to a red build.

The new case asserts every required asset is **both** staged and bundled. Verified it fails against precisely the state #4368 left behind, and passes with the `COPY` restored.

## Verified by really building it

Static assertion already let one break through, so this was proven with an actual build:

```
docker build --target init            -> exit 0
/dpf-release-assets/scripts/safety/   -> 5 files present
SHA256SUMS                            -> 5 matching entries
```

The manifest entries matter: the installer verifies the bundle with `Test-DPFReleaseAssetManifest -RejectUnlisted`, so an unlisted asset would be rejected even if present.

## Context

This is the follow-up in a chain of blockers on the Windows "Ready to go" path found by a real zero-footprint reinstall: stale published image → `safety-bin` shim arg-binding → bundle missing `scripts/safety/` → (this) build-stage staging.
