### PR TITLE
fix(release): publish and pin dpf-postgres so consumer installs have a database

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -108,6 +108,14 @@ jobs:
             context: .
             file: services/edge-node/Dockerfile
             target: ""
+          # postgres is BUILT in the base compose (baked pgvector + inngest init,
+          # deliberately no host bind mount). Without publishing it, a consumer
+          # install has no database image and `up` tries to build from a ./docker
+          # context that a no-checkout install does not have.
+          - name: dpf-postgres
+            context: .
+            file: docker/postgres/Dockerfile
+            target: ""
         platform:
           - arch: amd64
             runner: ubuntu-latest

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -19,6 +19,14 @@
 # service classification (Phase 1) and is not published to GHCR.
 
 services:
+  postgres:
+    # Built in the base compose (baked pgvector + inngest init script, no host
+    # bind mount). It must be pinned here too, or a consumer install -- which has
+    # no source checkout -- tries to build from ./docker and dies with
+    #   resolve : GetFileAttributesEx <install>\docker: The system cannot find the file specified.
+    image: ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/dpf-postgres:${DPF_IMAGE_TAG:-latest}
+    build: !reset null
+
   portal-init:
     # portal-init shares the portal image (Dockerfile target: runner).
     image: ghcr.io/${GHCR_OWNER:-opendigitalproductfactory}/dpf-portal:${DPF_IMAGE_TAG:-latest}

--- a/scripts/check-release-compose-pins.test.mjs
+++ b/scripts/check-release-compose-pins.test.mjs
@@ -1,0 +1,115 @@
+// docker-compose.release.yml states its own contract at the top of the file:
+//
+//   "every installed-runtime service resolves to a versioned multi-arch GHCR image.
+//    The base docker-compose.yml's `build:` entries are reset to null so the runtime
+//    never silently builds when a release tag is meant to be pulled."
+//
+// `postgres` violated that for the entire life of the consumer install path: it is
+// BUILT in the base compose (baked pgvector + inngest init, deliberately no host
+// bind mount) and had no override in the release overlay, and dpf-postgres was not
+// in the publish matrix at all. A "Ready to go" install therefore reached
+//
+//   Image dpf-postgres  Building
+//   resolve : GetFileAttributesEx D:\DPF\docker: The system cannot find the file specified.
+//
+// because a no-checkout install has no ./docker context to build from. The install
+// had no database and could never become healthy.
+//
+// This asserts the contract mechanically, so the next service added with a `build:`
+// cannot quietly reintroduce it.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const base = readFileSync(join(repoRoot, "docker-compose.yml"), "utf8");
+const release = readFileSync(join(repoRoot, "docker-compose.release.yml"), "utf8");
+const publishWorkflow = readFileSync(join(repoRoot, ".github/workflows/publish-image.yml"), "utf8");
+
+/**
+ * Services excluded from the release overlay by documented classification —
+ * developer/test-only, never published to GHCR. Keep this list tiny and justified;
+ * it is the only sanctioned way to skip a pin.
+ */
+const DEV_ONLY_SERVICES = Object.freeze(["integration-test-harness", "dev-init", "dev-portal"]);
+
+/** Service names that declare a `build:` in a compose file. */
+function servicesWithBuild(source) {
+  const lines = source.split(/\r?\n/);
+  let inServices = false;
+  let current = null;
+  const found = new Set();
+  for (const line of lines) {
+    if (/^services:/.test(line)) { inServices = true; continue; }
+    if (!inServices) continue;
+    if (/^[a-zA-Z]/.test(line)) { inServices = false; continue; } // left the services block
+    const svc = line.match(/^ {2}([a-zA-Z0-9._-]+):\s*$/);
+    if (svc) { current = svc[1]; continue; }
+    if (current && /^ {4}build:/.test(line)) found.add(current);
+  }
+  return [...found];
+}
+
+/** Service names given an `image:` in the release overlay. */
+function servicesWithReleaseImage(source) {
+  const lines = source.split(/\r?\n/);
+  let current = null;
+  const found = new Set();
+  for (const line of lines) {
+    const svc = line.match(/^ {2}([a-zA-Z0-9._-]+):\s*$/);
+    if (svc) { current = svc[1]; continue; }
+    if (current && /^ {4}image:\s*\S/.test(line)) found.add(current);
+  }
+  return [...found];
+}
+
+const built = servicesWithBuild(base);
+const pinned = servicesWithReleaseImage(release);
+
+test("every built service is pinned to a published image in the release overlay", () => {
+  const needPin = built.filter((s) => !DEV_ONLY_SERVICES.includes(s));
+  const unpinned = needPin.filter((s) => !pinned.includes(s));
+  assert.deepEqual(
+    unpinned,
+    [],
+    "these build from source in the base compose but have no release image, so a " +
+      "consumer install (no checkout) cannot start them: " + unpinned.join(", "),
+  );
+});
+
+test("every pinned service also resets its build so the runtime cannot silently build", () => {
+  for (const svc of pinned) {
+    const block = release.slice(release.indexOf(`\n  ${svc}:`));
+    const nextSvc = block.slice(1).search(/\n {2}[a-zA-Z0-9._-]+:\s*$/m);
+    const scoped = nextSvc > 0 ? block.slice(0, nextSvc + 1) : block;
+    if (!servicesWithBuild(base).includes(svc)) continue; // nothing to reset
+    assert.match(
+      scoped,
+      /build:\s*!reset null/,
+      `${svc} is pinned to an image but does not reset its build: — the runtime could still build it`,
+    );
+  }
+});
+
+test("postgres specifically is pinned — the exact consumer-install outage", () => {
+  assert.ok(built.includes("postgres"), "postgres should still be built in the base compose");
+  assert.ok(
+    pinned.includes("postgres"),
+    "postgres must be pinned in the release overlay or the consumer install has no database",
+  );
+  assert.match(release, /dpf-postgres:\$\{DPF_IMAGE_TAG:-latest\}/);
+});
+
+test("every release-pinned dpf image is actually published by the workflow", () => {
+  const imageNames = [...release.matchAll(/\/(dpf-[a-z0-9-]+):\$\{DPF_IMAGE_TAG/g)].map((m) => m[1]);
+  const missing = [...new Set(imageNames)].filter((n) => !publishWorkflow.includes(`name: ${n}`));
+  assert.deepEqual(
+    missing,
+    [],
+    "the release overlay pins images that publish-image.yml never builds, so the pull " +
+      "will 404: " + missing.join(", "),
+  );
+});

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -46,6 +46,7 @@ const EXPECTED_LEGACY_JOBS = [
   "prose-lint-guard",
   "published-image-freshness",
   "release-asset-contract",
+  "release-compose-pins",
   "repo-guard-loop",
   "reporting-composition-guard",
   "retired-substrate-guard",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -47,6 +47,9 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("shell-guard-shim-contract", "Shell Guard Shim Contract", [
       node("--test", "scripts/check-shell-guard-shim-contract.test.mjs"),
     ]),
+    guard("release-compose-pins", "Release Compose Pins", [
+      node("--test", "scripts/check-release-compose-pins.test.mjs"),
+    ]),
     guard("release-asset-contract", "Release Asset Contract", [
       // The consumer install has no git checkout: whatever the installer copies
       // out of the install dir must ship in the image's /dpf-release-assets.


### PR DESCRIPTION
## Symptom

A **"Ready to go"** install reaches Step 7 and dies:

```
Image dpf-postgres  Building
resolve : GetFileAttributesEx D:\DPF\docker: The system cannot find the file specified.
[!] Portal didn't become healthy after 5 minutes.
```

## Cause — the release path had no database image

`postgres` is **built** in the base compose, deliberately, from `docker/postgres/Dockerfile` so pgvector and the inngest init script are baked in with no host bind mount (BI-4796D52B, BI-A35347E4). But:

- `docker-compose.release.yml` had **no postgres override**
- `publish-image.yml` **never built `dpf-postgres`** at all

So a consumer install — which has no source checkout — tried to build from a `./docker` context it doesn't have, and could never become healthy.

## This contradicts the overlay's own stated contract

From the top of `docker-compose.release.yml`:

> "every installed-runtime service resolves to a versioned multi-arch GHCR image. The base `docker-compose.yml`'s `build:` entries are reset to null so the runtime never silently builds when a release tag is meant to be pulled."

`postgres` was the one service that never honoured it. This isn't a design decision being overturned — it's a documented invariant that was never enforced.

## Fix

- add `dpf-postgres` to the publish matrix (`context: .`, `file: docker/postgres/Dockerfile`)
- pin it in the release overlay with `build: !reset null`, matching every other service

## Regression coverage

`scripts/check-release-compose-pins.test.mjs` enforces the stated contract mechanically:

- every service with a `build:` in the base compose is pinned in the overlay (bar the documented dev/test-only classifications)
- every pinned service also resets its `build:`, so the runtime cannot silently build
- **every `dpf-*` image the overlay pins is actually produced by `publish-image.yml`** — so a pin can never 404

**Confirmed it fails 2 of 4 against the pre-fix state.**

Registered as policy guard `release-compose-pins`.

## Found by

A real zero-footprint reinstall following the Windows README verbatim — the **fourth** distinct blocker on that path, each hidden behind the previous:

1. published image 1851 commits stale, no `/dpf-release-assets`
2. `safety-bin` shim arg-binding bricking `git`/`docker`/`prisma` (#4362)
3. release bundle missing `scripts/safety/` (#4368, #4369)
4. **no database image in the release path** (this)

Each was invisible until the one in front of it was cleared, which is the strongest argument for the install-verification job actually exercising the documented consumer scenario rather than release mode from a checkout.
