### PR TITLE
fix(release): merge the dpf-postgres manifest so the tag actually exists

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -217,6 +217,7 @@ jobs:
           - dpf-browser-use
           - dpf-adp
           - dpf-edge-node
+          - dpf-postgres
 
     steps:
       - uses: actions/checkout@v7

--- a/scripts/check-release-compose-pins.test.mjs
+++ b/scripts/check-release-compose-pins.test.mjs
@@ -103,13 +103,38 @@ test("postgres specifically is pinned — the exact consumer-install outage", ()
   assert.match(release, /dpf-postgres:\$\{DPF_IMAGE_TAG:-latest\}/);
 });
 
-test("every release-pinned dpf image is actually published by the workflow", () => {
-  const imageNames = [...release.matchAll(/\/(dpf-[a-z0-9-]+):\$\{DPF_IMAGE_TAG/g)].map((m) => m[1]);
-  const missing = [...new Set(imageNames)].filter((n) => !publishWorkflow.includes(`name: ${n}`));
+/** Image names in the build matrix (`- name: dpf-x`) and the merge matrix (`- dpf-x`). */
+function publishMatrices(source) {
+  const builds = new Set([...source.matchAll(/^\s*- name:\s*(dpf-[a-z0-9-]+)\s*$/gm)].map((m) => m[1]));
+  const mergeBlock = source.slice(source.indexOf("\n  merge:"));
+  const merges = new Set([...mergeBlock.matchAll(/^\s*-\s*(dpf-[a-z0-9-]+)\s*$/gm)].map((m) => m[1]));
+  return { builds, merges };
+}
+
+test("every release-pinned dpf image is actually BUILT by the workflow", () => {
+  const { builds } = publishMatrices(publishWorkflow);
+  const imageNames = [...new Set([...release.matchAll(/\/(dpf-[a-z0-9-]+):\$\{DPF_IMAGE_TAG/g)].map((m) => m[1]))];
+  const missing = imageNames.filter((n) => !builds.has(n));
   assert.deepEqual(
     missing,
     [],
     "the release overlay pins images that publish-image.yml never builds, so the pull " +
       "will 404: " + missing.join(", "),
+  );
+});
+
+test("every built image is also MERGED into a tag manifest", () => {
+  // Building without merging pushes per-arch images BY DIGEST ONLY -- no human tag
+  // is ever created, so `docker compose pull` fails with:
+  //     postgres Error manifest unknown
+  // That shipped once: dpf-postgres was added to the build matrix but not the merge
+  // matrix, so both arches built green and the tag still did not exist.
+  const { builds, merges } = publishMatrices(publishWorkflow);
+  const unmerged = [...builds].filter((n) => !merges.has(n));
+  assert.deepEqual(
+    unmerged,
+    [],
+    "these are built per-arch but never assembled into a tag manifest, so pulling the " +
+      "tag returns 'manifest unknown': " + unmerged.join(", "),
   );
 });


### PR DESCRIPTION
## Symptom

[#4370](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4370) added `dpf-postgres` to the **build** matrix but not the **merge** matrix. Both arches built green and the publish still produced no usable image:

```
postgres Pulling
postgres Error manifest unknown
Error response from daemon: manifest unknown
```

## Cause

The build step pushes **by digest only** (`push-by-digest=true`, `name-canonical=true`) — deliberately, so no human-readable tag is created there. The separate `merge` job assembles the per-arch digests into the manifest list under `dpf-postgres:latest`.

Without a merge-matrix entry the tag never comes into existence, so `docker compose pull` 404s **even though every build job is green**. That's a particularly nasty signal: 14 green build jobs and no usable artifact.

## The test gap that let it through

The guard I added in #4370 asserted the image appeared in the workflow at all — which the build matrix alone satisfied. Half the chain, the same shape as asserting a `cp` without its `COPY` in #4368.

It now checks the two matrices **separately**:

- every release-pinned image must be **BUILT**
- every built image must also be **MERGED** into a tag manifest

Verified the new case fails against exactly the state #4370 left behind, and passes with the merge entry restored.

## Credit where due

The publish workflow's **E2E install verification caught this one on its own**, failing at `postgres Error manifest unknown`.

That job only started doing useful work once the fresh-install glob bug ([#4367](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4367)) stopped aborting it before it reached anything meaningful. Repairing the safety net is now paying for itself.
