### PR TITLE
feat(routing): capture model reasoning as its own channel (BI-1E77BEE3)

### DIFF
--- a/apps/web/lib/routing/adapter-types.ts
+++ b/apps/web/lib/routing/adapter-types.ts
@@ -78,6 +78,25 @@ export interface AdapterResult {
    * returning the fragment (BI-1D144CC1). Absent/false means a clean stop.
    */
   truncated?: boolean;
+  /**
+   * The model's own reasoning/scratchpad for this turn, when the provider emits
+   * it as a channel SEPARATE from the answer — llama.cpp / Docker Model Runner
+   * send `reasoning_content`, some OpenAI-compatible providers send `reasoning`.
+   *
+   * Verified on the canonical runtime 2026-08-16 against Qwen3.8-27B: a single
+   * turn produced 249 chars of `reasoning_content` against 50 chars of
+   * `content`, so this is the bulk of what a thinking model spends its time on
+   * and the only honest source for a progress surface. (BI-1E77BEE3.)
+   *
+   * MUST NOT be substituted for `text`. It is scratchpad, not a considered
+   * position — real samples read like "likely say no... Need be concise" — so
+   * any surface rendering it has to frame it as working-out, subordinate to the
+   * answer, and never quote it as the coworker's conclusion.
+   *
+   * Absent when the provider emits no separate reasoning channel, which is the
+   * common case; consumers must treat undefined as "not offered", not "none".
+   */
+  reasoning?: string;
 }
 
 /** Contract every execution adapter implements */

--- a/apps/web/lib/routing/chat-adapter.test.ts
+++ b/apps/web/lib/routing/chat-adapter.test.ts
@@ -270,6 +270,83 @@ describe("chatAdapter", () => {
     expect(result.truncated).toBe(true);
   });
 
+  // ── Reasoning capture (BI-1E77BEE3) ───────────────────────────────────────
+  // Shapes mirror the live Docker Model Runner response for Qwen3.8-27B
+  // (canonical runtime, 2026-08-16): reasoning_content is separate from content
+  // and is the bulk of the turn — 253 chars vs 3 ("No.") on the sampled call.
+
+  it("captures reasoning_content as its own channel without touching the answer", async () => {
+    stubFetchOk({
+      choices: [{
+        message: {
+          content: "Don't ship; the three failing tests block release.",
+          reasoning_content: "We need answer user's request. Need likely say no, don't ship due failing tests.",
+        },
+        finish_reason: "stop",
+      }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+
+    const result = await chatAdapter.execute(makeRequest({ providerId: "local", modelId: "qwen3.8-27b" }));
+
+    expect(result.text).toBe("Don't ship; the three failing tests block release.");
+    expect(result.reasoning).toContain("don't ship due failing tests");
+  });
+
+  it("accepts the `reasoning` spelling other OpenAI-compatible providers use", async () => {
+    stubFetchOk({
+      choices: [{ message: { content: "Answer.", reasoning: "Thinking out loud." }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    });
+
+    const result = await chatAdapter.execute(makeRequest({ providerId: "ollama", modelId: "llama3.1" }));
+
+    expect(result.text).toBe("Answer.");
+    expect(result.reasoning).toBe("Thinking out loud.");
+  });
+
+  it("omits reasoning entirely when the provider offers none", async () => {
+    stubFetchOk({
+      choices: [{ message: { content: "Plain answer." }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    });
+
+    const result = await chatAdapter.execute(makeRequest({ providerId: "ollama", modelId: "llama3.1" }));
+
+    // undefined means "not offered" — a disclosure surface must not render an
+    // empty reasoning panel for models that never think aloud.
+    expect(result.reasoning).toBeUndefined();
+    expect("reasoning" in result).toBe(false);
+  });
+
+  it("reasoning never displaces the answer when both are present", async () => {
+    stubFetchOk({
+      choices: [{
+        message: { content: "The answer.", reasoning_content: "Scratchpad that must not be shown as the answer." },
+        finish_reason: "stop",
+      }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    });
+
+    const result = await chatAdapter.execute(makeRequest({ providerId: "local", modelId: "qwen3.8-27b" }));
+
+    expect(result.text).toBe("The answer.");
+    expect(result.text).not.toContain("Scratchpad");
+  });
+
+  it("falls back to reasoning as text ONLY when there is no content at all", async () => {
+    // Last-resort path: a thinking-only reply would otherwise render blank.
+    stubFetchOk({
+      choices: [{ message: { reasoning_content: "Only thinking, no answer emitted." }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    });
+
+    const result = await chatAdapter.execute(makeRequest({ providerId: "local", modelId: "qwen3.8-27b" }));
+
+    expect(result.text).toBe("Only thinking, no answer emitted.");
+    expect(result.reasoning).toBe("Only thinking, no answer emitted.");
+  });
+
   it("OpenAI-compat: finish_reason=stop is not truncated", async () => {
     stubFetchOk({
       choices: [{ message: { content: "Done." }, finish_reason: "stop" }],

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -467,6 +467,8 @@ export const chatAdapter: ExecutionAdapterHandler = {
     // this to avoid returning a max_tokens-truncated fragment as a final answer
     // (BI-1D144CC1). Each branch below maps its provider-specific value.
     let truncated = false;
+    /** Separate thinking channel, when the provider emits one (BI-1E77BEE3). */
+    let reasoning: string | undefined;
 
     if (isAnthropic(providerId)) {
       // Anthropic response
@@ -542,11 +544,22 @@ export const chatAdapter: ExecutionAdapterHandler = {
         message?: {
           content?: string;
           reasoning?: string;
+          /** llama.cpp / Docker Model Runner name for the separate thinking channel. */
+          reasoning_content?: string;
           tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: string } }>;
         };
       }>)?.[0];
       const msg = choice?.message;
-      text = msg?.content || msg?.reasoning || "";
+
+      // Capture reasoning as its OWN channel (BI-1E77BEE3). Providers disagree on
+      // the field name: llama.cpp / Docker Model Runner emit `reasoning_content`,
+      // other OpenAI-compatible providers emit `reasoning`.
+      reasoning = msg?.reasoning_content || msg?.reasoning || undefined;
+
+      // The answer is `content`. Falling back to reasoning is a LAST resort for a
+      // provider that returns only a thinking channel — without it such a turn
+      // renders blank. When content exists, reasoning must never displace it.
+      text = msg?.content || reasoning || "";
       truncated = choice?.finish_reason === "length";
 
       if (msg?.tool_calls && msg.tool_calls.length > 0) {
@@ -590,6 +603,9 @@ export const chatAdapter: ExecutionAdapterHandler = {
     return {
       text,
       toolCalls,
+      // Only present when the provider actually offered a separate channel;
+      // consumers read undefined as "not offered", not "the model had none".
+      ...(reasoning ? { reasoning } : {}),
       usage: { inputTokens, outputTokens, cacheCreationInputTokens, cacheReadInputTokens },
       inferenceMs,
       truncated,

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -47,7 +47,7 @@ apps/web/lib/mcp/packs/sandbox-pack.ts	920
 apps/web/lib/navigation/portal-navigation-model.ts	965
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1422
-apps/web/lib/routing/chat-adapter.test.ts	996
+apps/web/lib/routing/chat-adapter.test.ts	1073
 apps/web/lib/routing/fallback.test.ts	1140
 apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1621
@@ -60,7 +60,7 @@ apps/web/lib/tak/agentic-loop.ts	2812
 apps/web/lib/tak/route-context-map.ts	1273
 apps/web/lib/work-capsules/mcp-handlers.ts	919
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1085
-apps/web/lib/work-capsules/work-capsule-store.ts	1060
+apps/web/lib/work-capsules/work-capsule-store.ts	1034
 apps/web/lib/workbooks/platform-tables.ts	938
 apps/web/lib/workforce/calendar-data.ts	1134
 apps/web/lib/workspace/command-center.ts	1118


### PR DESCRIPTION
## Why

The coworker now thinks for 10+ seconds before answering (dense Qwen3.8-27B, BI-68EED40A) and the UI shows only an animation. Operator: *"we don't see what's actually going on, intermediate steps. Do the models provide any feedback that can be piped to the UX?"*

They do — and DPF was throwing it away.

## The evidence

Asked the live model a real question through Docker Model Runner, **non-streaming** (the path `chat-adapter` already uses):

```
message keys: ['content', 'reasoning_content', 'role']

content:            3 chars  ->  "No."
reasoning_content: 253 chars ->  "...Likely 'No.' Maybe with nuance: 'No, fix or
                                  explicitly defer them with a document...'"
```

Ten seconds of waiting produces **"No."** — while 253 characters of reasoning, containing a *more useful* answer than the one returned, are discarded.

## The defect

The OpenAI-compatible parse was:

```ts
text = msg?.content || msg?.reasoning || "";
```

Two problems:

1. It treats reasoning as a **fallback for the answer**, not a distinct channel.
2. It reads `reasoning`, but llama.cpp / Docker Model Runner emit **`reasoning_content`** — so it never matched a local thinking model at all.

## The change

`AdapterResult.reasoning` carries it separately. `text` is unchanged in every case where content exists.

- Both field spellings accepted (`reasoning_content`, `reasoning`).
- **Absent** when the provider offers none, so a disclosure surface distinguishes "not offered" from "none" and won't render an empty panel for non-thinking models.
- The content-less fallback is retained so a thinking-only reply cannot render blank.

## No transport change needed

I initially assumed this required streaming. It does not — `reasoning_content` is on the non-streaming response, so the "why was that slow" disclosure ships today. Only live token-by-token rendering needs the SSE work (Half B of BI-1E77BEE3), which requires a route handler because coworker chat is `"use server"` and cannot push increments.

Relevant: `/api/v1/agent/stream` already exists as a stub that says *"the real implementation will subscribe to the agent event bus"*, and `lib/sse/sse-stream.ts` provides `createSseResponse()` with heartbeat support. Half B extends those rather than inventing a transport.

## Trust constraint, carried in the type

Reasoning is scratchpad, not a considered position — real samples read *"likely say no... Need be concise."* The `AdapterResult.reasoning` docblock states that any surface must frame it as working-out, keep it subordinate to the answer, and never quote it as the coworker's conclusion. Rendering it as the coworker speaking would be its own trust defect.

## Verification

- 33 tests pass; five new: both spellings, not-offered, reasoning never displacing a present answer, and the content-less fallback
- typecheck clean
- local-CI pregate: **PASS** — gated sha `a7e824ed0`, evidence `cmsw88oui139701pntsuunpo2`

## Module Size Guard

`chat-adapter.test.ts` 996 -> 1073 for the five new cases. Header comment trimmed first; the rest is the coverage itself, which cannot be added without lines. Of the two baseline entries `--update` rewrote, one is this loosening and the other is a **tightening** inherited from already-merged work (`work-capsule-store.ts` 1060 -> 1034). Nothing else was relaxed.

Design-Grounding-Decision: grounded in docs/superpowers/plans/2026-08-15-qwen38-27b-local-tier-plan.md and apps/web/lib/routing/chat-adapter.ts
Docs-Impact-Decision: internal routing contract; the operator-facing disclosure UI lands with the streaming half

🤖 Generated with [Claude Code](https://claude.com/claude-code)
