### PR TITLE
feat(decisions): re-verify a recorded decision's cited evidence against live source (BI-8192557E phase 2b)

### DIFF
--- a/apps/web/lib/decision/evidence-reverification.test.ts
+++ b/apps/web/lib/decision/evidence-reverification.test.ts
@@ -1,0 +1,246 @@
+// Phase 2b — the independent re-verification pass over a recorded decision.
+//
+// The tests that matter here are the ones separating the three ways a decision
+// can fail to be "verified", because collapsing them is how a re-verifier turns
+// into a fabrication-accusation generator:
+//   - a citation that no longer holds        → degraded   (a real finding)
+//   - no source checkout on this install     → unverifiable/no-source-access
+//   - no locators on the record at all       → unverifiable/no-recorded-locators
+// Only the first is a statement about the decision's evidence.
+
+import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  guardResolverPaths,
+  reverifyDecisionEvidence,
+  type SourceAccess,
+} from "./evidence-reverification";
+import { citationsToSources, type AdmissibleCitation } from "./evidence-grounding";
+import { createRepoLocatorResolver } from "./locator-resolver";
+import type { LocatorResolver } from "./evidence-reverifier";
+
+const REAL_EXCERPT = 'return "grounded value";';
+const SECRET = "DATABASE_URL=postgres://user:hunter2@db/prod";
+
+async function fixtureRepo(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "dpf-reverify-"));
+  await mkdir(join(root, "apps", "web", "lib"), { recursive: true });
+  await writeFile(
+    join(root, "apps", "web", "lib", "real.ts"),
+    ["export function real() {", `  ${REAL_EXCERPT}`, "}", ""].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(root, ".env"), `${SECRET}\n`, "utf8");
+  return root;
+}
+
+function citation(over: Partial<AdmissibleCitation> = {}): AdmissibleCitation {
+  return {
+    optionId: "option-a",
+    dimensionKey: "evidence_density",
+    grade: "B",
+    excerpt: REAL_EXCERPT,
+    locator: { sourceType: "code", filePath: "apps/web/lib/real.ts", line: 2 },
+    ...over,
+  };
+}
+
+/** A db whose row carries exactly what the ledger would have written. */
+function dbWith(citations: AdmissibleCitation[] | null, overrides: Record<string, unknown> = {}) {
+  const sources = citations === null ? [] : JSON.parse(JSON.stringify(citationsToSources(citations)));
+  return {
+    decisionInteraction: {
+      findUnique: vi.fn(async () => ({
+        interactionId: "DI-TEST",
+        profileId: "mark-dpf-platform",
+        profileVersionId: "v1",
+        question: "Which storage approach?",
+        createdAt: new Date("2026-08-16T00:00:00.000Z"),
+        sources,
+        ...overrides,
+      })),
+    },
+  };
+}
+
+const AVAILABLE = (repoRoot: string): SourceAccess => ({ available: true, repoRoot });
+const UNAVAILABLE: SourceAccess = { available: false, detail: "no source checkout on this install" };
+const NEVER_CALLED: LocatorResolver = async () => {
+  throw new Error("resolver must not be called");
+};
+
+describe("reverifyDecisionEvidence", () => {
+  it("confirms a decision whose citations still resolve and still match", async () => {
+    const repoRoot = await fixtureRepo();
+    const lookup = await reverifyDecisionEvidence({
+      db: dbWith([citation()]),
+      interactionId: "DI-TEST",
+      sourceAccess: AVAILABLE(repoRoot),
+      resolve: createRepoLocatorResolver({ repoRoot }),
+    });
+
+    expect(lookup.found).toBe(true);
+    if (!lookup.found) return;
+    expect(lookup.report.outcome).toBe("verified");
+    expect(lookup.report.confirmed).toBe(1);
+    expect(lookup.report.degrade).toEqual([]);
+    expect(lookup.report.coverage).toMatchObject({ recordedSources: 1, checked: 1, complete: true });
+  });
+
+  it("degrades a fabricated-but-well-formed citation", async () => {
+    const repoRoot = await fixtureRepo();
+    const lookup = await reverifyDecisionEvidence({
+      db: dbWith([citation({ locator: { sourceType: "code", filePath: "apps/web/lib/invented.ts" } })]),
+      interactionId: "DI-TEST",
+      sourceAccess: AVAILABLE(repoRoot),
+      resolve: createRepoLocatorResolver({ repoRoot }),
+    });
+
+    if (!lookup.found) throw new Error("expected found");
+    expect(lookup.report.outcome).toBe("degraded");
+    expect(lookup.report.degrade).toEqual([{ optionId: "option-a", dimensionKey: "evidence_density" }]);
+    expect(lookup.report.unverifiableCause).toBeNull();
+  });
+
+  // The load-bearing distinction. Without this the pass reports every decision
+  // on every production install as fabricated.
+  it("reports no-source-access as unverifiable, NOT as degraded, and never resolves", async () => {
+    const lookup = await reverifyDecisionEvidence({
+      db: dbWith([citation()]),
+      interactionId: "DI-TEST",
+      sourceAccess: UNAVAILABLE,
+      resolve: NEVER_CALLED,
+    });
+
+    if (!lookup.found) throw new Error("expected found");
+    expect(lookup.report.outcome).toBe("unverifiable");
+    expect(lookup.report.unverifiableCause).toBe("no-source-access");
+    expect(lookup.report.degrade).toEqual([]);
+    expect(lookup.report.degraded).toBe(0);
+    expect(lookup.report.sourceAccess.available).toBe(false);
+    // Recorded sources are still reported, so the caller can see what went unchecked.
+    expect(lookup.report.coverage).toMatchObject({ recordedSources: 1, checked: 0 });
+  });
+
+  it("reports a legacy row with no locators as unverifiable, not verified", async () => {
+    const db = {
+      decisionInteraction: {
+        findUnique: vi.fn(async () => ({
+          interactionId: "DI-LEGACY",
+          profileId: "mark-dpf-platform",
+          profileVersionId: "v1",
+          question: "q",
+          createdAt: new Date("2026-08-01T00:00:00.000Z"),
+          // Exactly the shape live rows carry today.
+          sources: [
+            {
+              materialId: "mark-dpf-platform:never-fabricate",
+              sourceType: "principle",
+              summary: "Never fabricate.",
+              effectiveWeight: 1,
+            },
+          ],
+        })),
+      },
+    };
+    const lookup = await reverifyDecisionEvidence({
+      db,
+      interactionId: "DI-LEGACY",
+      sourceAccess: AVAILABLE("/nonexistent"),
+      resolve: NEVER_CALLED,
+    });
+
+    if (!lookup.found) throw new Error("expected found");
+    expect(lookup.report.outcome).toBe("unverifiable");
+    expect(lookup.report.unverifiableCause).toBe("no-recorded-locators");
+    expect(lookup.report.unverifiableSources[0]!.reason).toBe("no-locator");
+  });
+
+  it("reports partial coverage rather than a clean bill of health", async () => {
+    const repoRoot = await fixtureRepo();
+    const sources = [
+      ...JSON.parse(JSON.stringify(citationsToSources([citation()]))),
+      // A second source the ledger's perspective-gate path writes: no locator.
+      { materialId: "opt:dim", sourceType: "principle", summary: "doctrine", effectiveWeight: 1 },
+    ];
+    const db = {
+      decisionInteraction: {
+        findUnique: vi.fn(async () => ({
+          interactionId: "DI-MIXED",
+          profileId: "p",
+          profileVersionId: "v1",
+          question: "q",
+          createdAt: new Date(),
+          sources,
+        })),
+      },
+    };
+
+    const lookup = await reverifyDecisionEvidence({
+      db,
+      interactionId: "DI-MIXED",
+      sourceAccess: AVAILABLE(repoRoot),
+      resolve: createRepoLocatorResolver({ repoRoot }),
+    });
+
+    if (!lookup.found) throw new Error("expected found");
+    expect(lookup.report.outcome).toBe("verified");
+    expect(lookup.report.coverage).toMatchObject({
+      recordedSources: 2,
+      checked: 1,
+      unverifiable: 1,
+      complete: false,
+    });
+  });
+
+  it("reports a missing decision as not found rather than as an empty pass", async () => {
+    const lookup = await reverifyDecisionEvidence({
+      db: { decisionInteraction: { findUnique: vi.fn(async () => null) } },
+      interactionId: "DI-NOPE",
+      sourceAccess: UNAVAILABLE,
+      resolve: NEVER_CALLED,
+    });
+    expect(lookup).toEqual({ found: false, interactionId: "DI-NOPE" });
+  });
+});
+
+describe("guardResolverPaths", () => {
+  it("refuses a citation naming a blocked file instead of echoing its contents", async () => {
+    const repoRoot = await fixtureRepo();
+    const { isPathAllowedSync } = await import("@/lib/integrate/codebase-tools");
+    const guarded = guardResolverPaths(createRepoLocatorResolver({ repoRoot }), isPathAllowedSync);
+
+    // The cited path is INSIDE the repo root, so phase 1's confinement check
+    // passes it. Without the blocklist the secret would round-trip as liveExcerpt.
+    const resolution = await guarded({ sourceType: "code", filePath: ".env" });
+
+    expect(resolution).toEqual({ resolved: false, liveExcerpt: null });
+    expect(JSON.stringify(resolution)).not.toContain("hunter2");
+  });
+
+  it("still resolves an ordinary source path", async () => {
+    const repoRoot = await fixtureRepo();
+    const { isPathAllowedSync } = await import("@/lib/integrate/codebase-tools");
+    const guarded = guardResolverPaths(createRepoLocatorResolver({ repoRoot }), isPathAllowedSync);
+
+    const resolution = await guarded({ sourceType: "code", filePath: "apps/web/lib/real.ts", line: 2 });
+    expect(resolution.resolved).toBe(true);
+    expect(resolution.liveExcerpt).toContain(REAL_EXCERPT);
+  });
+
+  it("passes through a locator whose sourceType names no path", async () => {
+    const seen: string[] = [];
+    const guarded = guardResolverPaths(
+      async (locator) => {
+        seen.push(locator.sourceType);
+        return { resolved: false, liveExcerpt: null };
+      },
+      () => false, // even a deny-all guard must not swallow pathless locators
+    );
+    await guarded({ sourceType: "runtime-state", snapshotKey: "k", capturedAt: "2026-08-16" });
+    expect(seen).toEqual(["runtime-state"]);
+  });
+});

--- a/apps/web/lib/decision/evidence-reverification.ts
+++ b/apps/web/lib/decision/evidence-reverification.ts
@@ -1,0 +1,261 @@
+// Independent evidence re-verification for a recorded decision (BI-8192557E
+// phase 2b, EP-VERIFICATION-INTEGRITY; spec §2 Axis 4).
+//
+// Phase 2a made a recorded citation carry its StructuredLocator. This is the
+// pass that USES it: load a decision's persisted citations, re-resolve each one
+// against live source, and report which no longer hold.
+//
+// SEPARATION OF DUTIES. This never runs inside `principle_decide`. It is a
+// distinct call, made later, with no access to the original scorer's reasoning
+// — the property that makes the result mean anything. Verifier identity is an
+// audit field, never a gate input (governance-approves-evidence-not-provenance).
+//
+// FAIL-CLOSED IN BOTH DIRECTIONS — the load-bearing design point. Naively piping
+// every source into `reverifyCitations` is wrong, because that function folds
+// `unresolved` into `degrade`: correct when the resolver COULD read the cited
+// artifact and it was not there (that is fabrication), but catastrophic when the
+// resolver cannot reach source at all. A production install has no repo checkout
+// (`isDevInstance()` is false), so an unguarded pass would report every decision
+// ever made as fabricated evidence. "We could not look" and "we looked and it
+// failed" are different findings and are reported as different outcomes here.
+//
+// Read-only by contract. The decision row is sealed into the append-only hash
+// chain, so a verdict cannot be written back onto it; consuming a degrade — and
+// re-scoring the affected dimension — is phase 3.
+
+import {
+  reverifyCitations,
+  type CitationReVerification,
+  type LocatorResolver,
+} from "@/lib/decision/evidence-reverifier";
+import {
+  recordedCitationsFromSources,
+  type UnverifiableSource,
+} from "@/lib/decision/recorded-citations";
+import { decisionInteractionRowToEvaluation } from "@/lib/decision-perspective/persistence";
+
+/** Whether this install can read the source a `code`/`spec`/`doc` locator names. */
+export type SourceAccess =
+  | { available: true; repoRoot: string }
+  | { available: false; detail: string };
+
+/**
+ * Overall verdict for the citations that COULD be checked.
+ *
+ * `verified` is deliberately not a claim about the whole decision — read it
+ * together with `coverage`. A decision whose only citation confirmed, but which
+ * recorded four more with no locator, is `verified` at coverage 1/5, and the
+ * caller must be told both numbers.
+ */
+export type DecisionEvidenceOutcome = "verified" | "degraded" | "unverifiable";
+
+export type UnverifiableCause = "no-source-access" | "no-recorded-locators";
+
+export type DecisionEvidenceReport = {
+  interactionId: string;
+  question: string | null;
+  recordedAt: Date | null;
+  outcome: DecisionEvidenceOutcome;
+  /** Set only when `outcome` is "unverifiable" — WHY nothing could be checked. */
+  unverifiableCause: UnverifiableCause | null;
+  coverage: {
+    /** Sources on the decision record. */
+    recordedSources: number;
+    /** Of those, how many carried a re-resolvable locator and were checked. */
+    checked: number;
+    /** Of those, how many could not be checked at all. */
+    unverifiable: number;
+    /** True when every recorded source was checkable. */
+    complete: boolean;
+  };
+  confirmed: number;
+  degraded: number;
+  unresolved: number;
+  /** (option, dimension) pairs whose evidence no longer holds. */
+  degrade: Array<{ optionId: string; dimensionKey: string }>;
+  results: CitationReVerification[];
+  unverifiableSources: UnverifiableSource[];
+  sourceAccess: { available: boolean; detail: string };
+};
+
+export type DecisionEvidenceLookup =
+  | { found: false; interactionId: string }
+  | { found: true; report: DecisionEvidenceReport };
+
+/** The one row shape this pass needs. Structural so tests need no Prisma. */
+export type DecisionInteractionReader = {
+  decisionInteraction: {
+    findUnique(args: {
+      where: { interactionId: string };
+      select: Record<string, true>;
+    }): Promise<Record<string, unknown> | null>;
+  };
+};
+
+/**
+ * Wrap a repo-backed resolver with the project-file path guard.
+ *
+ * A cited `filePath` is attacker-influenced data: it arrives from whatever
+ * agent made the decision and is echoed back as `liveExcerpt`. The phase-1
+ * resolver confines reads to the repo root, but the repo root legitimately
+ * CONTAINS `.env`, keys and credential files — so a citation naming one would
+ * otherwise round-trip its contents to any caller holding `registry_read`.
+ * `isPathAllowedSync` is the same blocklist `read_project_file` enforces;
+ * reusing it keeps one home for "what source may be read out of this install".
+ *
+ * A blocked path fails closed to `unresolved`, exactly like a missing file:
+ * unreadable is never evidence of truth.
+ */
+export function guardResolverPaths(
+  resolve: LocatorResolver,
+  isPathAllowed: (path: string) => boolean,
+): LocatorResolver {
+  return async (locator) => {
+    const cited =
+      locator.sourceType === "code"
+        ? locator.filePath
+        : locator.sourceType === "spec" || locator.sourceType === "doc"
+          ? locator.path
+          : null;
+    if (cited !== null && !isPathAllowed(cited)) {
+      return { resolved: false, liveExcerpt: null };
+    }
+    return resolve(locator);
+  };
+}
+
+function emptyReport(
+  interactionId: string,
+  question: string | null,
+  recordedAt: Date | null,
+  recordedSources: number,
+  unverifiableSources: UnverifiableSource[],
+  cause: UnverifiableCause,
+  sourceAccess: { available: boolean; detail: string },
+): DecisionEvidenceReport {
+  return {
+    interactionId,
+    question,
+    recordedAt,
+    outcome: "unverifiable",
+    unverifiableCause: cause,
+    coverage: {
+      recordedSources,
+      checked: 0,
+      unverifiable: unverifiableSources.length,
+      complete: recordedSources === 0,
+    },
+    confirmed: 0,
+    degraded: 0,
+    unresolved: 0,
+    degrade: [],
+    results: [],
+    unverifiableSources,
+    sourceAccess,
+  };
+}
+
+/**
+ * Re-verify one recorded decision's cited evidence.
+ *
+ * `resolve` is injected rather than constructed here so the pass stays pure and
+ * testable and never hard-codes a filesystem dependency — the same contract
+ * `evidence-reverifier.ts` set.
+ */
+export async function reverifyDecisionEvidence(input: {
+  db: DecisionInteractionReader;
+  interactionId: string;
+  sourceAccess: SourceAccess;
+  resolve: LocatorResolver;
+}): Promise<DecisionEvidenceLookup> {
+  const row = await input.db.decisionInteraction.findUnique({
+    where: { interactionId: input.interactionId },
+    select: {
+      interactionId: true,
+      profileId: true,
+      profileVersionId: true,
+      question: true,
+      sources: true,
+      createdAt: true,
+    },
+  });
+  if (!row) return { found: false, interactionId: input.interactionId };
+
+  const question = typeof row.question === "string" ? row.question : null;
+  const recordedAt = row.createdAt instanceof Date ? row.createdAt : null;
+  const accessDetail = input.sourceAccess.available
+    ? `source readable at ${input.sourceAccess.repoRoot}`
+    : input.sourceAccess.detail;
+  const access = { available: input.sourceAccess.available, detail: accessDetail };
+
+  // Re-use the audit read path rather than parsing the jsonb here, so the
+  // verifier sees exactly what the Decision Canvas sees.
+  const evaluation = decisionInteractionRowToEvaluation({
+    interactionId: String(row.interactionId ?? input.interactionId),
+    profileId: String(row.profileId ?? ""),
+    profileVersionId: String(row.profileVersionId ?? ""),
+    sources: row.sources,
+  });
+  const recordedSources = evaluation.sources.length;
+  const { citations, unverifiable } = recordedCitationsFromSources(evaluation.sources);
+
+  // Order matters: report the environment limitation BEFORE the evidence
+  // verdict. Without source access nothing below is a statement about the
+  // citations, and presenting it as one would manufacture a fabrication finding
+  // out of a deployment fact.
+  if (!input.sourceAccess.available) {
+    return {
+      found: true,
+      report: emptyReport(
+        String(row.interactionId ?? input.interactionId),
+        question,
+        recordedAt,
+        recordedSources,
+        unverifiable,
+        "no-source-access",
+        access,
+      ),
+    };
+  }
+
+  if (citations.length === 0) {
+    return {
+      found: true,
+      report: emptyReport(
+        String(row.interactionId ?? input.interactionId),
+        question,
+        recordedAt,
+        recordedSources,
+        unverifiable,
+        "no-recorded-locators",
+        access,
+      ),
+    };
+  }
+
+  const report = await reverifyCitations(citations, input.resolve);
+
+  return {
+    found: true,
+    report: {
+      interactionId: String(row.interactionId ?? input.interactionId),
+      question,
+      recordedAt,
+      outcome: report.degrade.length > 0 ? "degraded" : "verified",
+      unverifiableCause: null,
+      coverage: {
+        recordedSources,
+        checked: citations.length,
+        unverifiable: unverifiable.length,
+        complete: unverifiable.length === 0,
+      },
+      confirmed: report.confirmed,
+      degraded: report.degraded,
+      unresolved: report.unresolved,
+      degrade: report.degrade,
+      results: report.results,
+      unverifiableSources: unverifiable,
+      sourceAccess: access,
+    },
+  };
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -10010,6 +10010,7 @@
         "example-3-wsid-what-a-competent-data-architect-would-do",
         "human-in-the-loop-where-a-person-enters-each-path",
         "the-immutable-decision-ledger",
+        "un-tampered-with-is-not-the-same-as-true",
         "how-the-three-examples-relate",
         "related-reading"
       ]

--- a/apps/web/lib/integrate/codebase-tools.ts
+++ b/apps/web/lib/integrate/codebase-tools.ts
@@ -26,7 +26,13 @@ import {
   getCwd,
 } from "@/lib/shared/lazy-node";
 
-function getProjectRoot(): string {
+/**
+ * Where this install's source checkout lives, if it has one. Exported so any
+ * surface that needs to READ cited source (e.g. decision evidence
+ * re-verification) resolves it here rather than re-deriving the path — one home
+ * for "where is the source", alongside `isDevInstance` and `isPathAllowedSync`.
+ */
+export function getProjectRoot(): string {
   const path = getPath();
   if (process.env.PROJECT_ROOT) return path.resolve(process.env.PROJECT_ROOT);
   return path.resolve(getCwd(), "..", "..");

--- a/apps/web/lib/mcp/pack-registry.ts
+++ b/apps/web/lib/mcp/pack-registry.ts
@@ -94,6 +94,7 @@ import { buildVisibilityPack } from "./packs/build-visibility-pack";
 import { buildEvidenceExtraPack } from "./packs/build-evidence-extra-pack";
 import { changeReviewPack } from "./packs/change-review-pack";
 import { principleDecidePack } from "./packs/principle-decide-pack";
+import { decisionReverifyPack } from "./packs/decision-reverify-pack";
 import { productOutcomesPack } from "./packs/product-outcomes-pack";
 import { initiativeReadinessPack } from "./packs/initiative-readiness-pack";
 
@@ -186,6 +187,7 @@ export const TOOL_PACK_REGISTRY = composeToolPacks([
   buildEvidenceExtraPack,
   changeReviewPack,
   principleDecidePack,
+  decisionReverifyPack,
   productOutcomesPack,
   initiativeReadinessPack,
   surfaceReadinessPack,

--- a/apps/web/lib/mcp/packs/decision-reverify-pack.test.ts
+++ b/apps/web/lib/mcp/packs/decision-reverify-pack.test.ts
@@ -1,0 +1,47 @@
+// Pack conformance for reverify_decision_evidence (BI-8192557E phase 2b).
+//
+// Mirrors principle-decide-pack.test.ts: definitions and handlers agree, the
+// tool is read-only, and the pack's advertised grant matches agent-grants.ts —
+// TOOL_TO_GRANTS denies unlisted tools by default, so a pack that ships without
+// the gating entry is invisible rather than merely ungranted (BI-88B77204).
+
+import { describe, expect, it } from "vitest";
+
+import { decisionReverifyPack } from "./decision-reverify-pack";
+import { TOOL_TO_GRANTS } from "@/lib/tak/agent-grants";
+
+const EXPECTED_TOOLS = ["reverify_decision_evidence"] as const;
+
+describe("decisionReverifyPack", () => {
+  it("exposes exactly the expected tools, with a handler for each", () => {
+    expect(decisionReverifyPack.definitions.map((d) => d.name).sort()).toEqual([...EXPECTED_TOOLS].sort());
+    expect(Object.keys(decisionReverifyPack.handlers).sort()).toEqual([...EXPECTED_TOOLS].sort());
+  });
+
+  it("is read-only — re-verification must never mutate the decision it audits", () => {
+    for (const definition of decisionReverifyPack.definitions) {
+      expect(definition.sideEffect).toBe(false);
+    }
+  });
+
+  it("has a gating grant entry that matches the pack's advertised grant", () => {
+    expect(decisionReverifyPack.grants.reverify_decision_evidence).toEqual(["registry_read"]);
+    expect(TOOL_TO_GRANTS.reverify_decision_evidence).toEqual(["registry_read"]);
+  });
+
+  it("requires an interactionId", async () => {
+    const res = await decisionReverifyPack.handlers.reverify_decision_evidence!({}, "user-1", undefined as never);
+    expect(res.success).toBe(false);
+    expect(res.message).toContain("interactionId");
+  });
+
+  // The description is the only thing an agent reads before calling. If it does
+  // not separate the verdict from its coverage, a partial pass gets reported
+  // upward as "the decision is verified".
+  it("tells the caller that outcome and coverage are different claims", () => {
+    const [definition] = decisionReverifyPack.definitions;
+    expect(definition!.description).toContain("coverage");
+    expect(definition!.description).toContain("unverifiable");
+    expect(definition!.description).toContain("NOT a clean bill of health");
+  });
+});

--- a/apps/web/lib/mcp/packs/decision-reverify-pack.ts
+++ b/apps/web/lib/mcp/packs/decision-reverify-pack.ts
@@ -1,0 +1,143 @@
+// Decision evidence re-verification tool pack (BI-8192557E phase 2b).
+//
+// Exposes the independent Axis-4 pass: load a recorded decision's persisted
+// citations and re-resolve each StructuredLocator against live source, so a
+// citation that was admissible-but-false is caught after the fact.
+//
+// Deliberately a SEPARATE tool rather than a step inside `principle_decide`.
+// Re-verification only means something when it runs without access to the
+// original scorer's reasoning (separation of duties, mirroring
+// lib/build/verified-finding-review.ts). Folding it into the scoring call would
+// make the decision certify itself.
+//
+// Read-only and advisory: it reports, it never mutates the decision. The row is
+// sealed into the append-only hash chain, and acting on a degrade (re-scoring
+// the affected dimension) is phase 3. Grant is `registry_read`, matching the
+// sibling decision-governance reads (`principle_decide`,
+// `list_open_decision_reviews`); grants mirror agent-grants.ts TOOL_TO_GRANTS,
+// which stays the gating source.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+// Type-only: erased at build time, so the handler keeps its lazy-import shape.
+import type { SourceAccess } from "@/lib/decision/evidence-reverification";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "reverify_decision_evidence",
+    description:
+      "Independently re-check the evidence cited by a recorded decision. Loads the decision's persisted citations and re-resolves each structured locator (code/spec/doc) against live source, reporting which citations still hold and which no longer do. Use it to audit a past decision before relying on it, or to spot a citation that was well-formed but never true. " +
+      "Read THREE fields together, they mean different things: `outcome` ('verified' = every citation that could be checked still holds; 'degraded' = at least one no longer holds; 'unverifiable' = nothing could be checked), `unverifiableCause` (why nothing could be checked), and `coverage` (how many of the decision's recorded sources were actually checkable). A 'verified' outcome at low coverage is NOT a clean bill of health for the decision. " +
+      "Advisory and read-only: it does not change the decision or its score. Call once per decision; do not poll.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        interactionId: {
+          type: "string",
+          description:
+            "The decision's interactionId (e.g. 'DI-18A9DB68B82F'), as returned by principle_decide's ledger or listed by list_open_decision_reviews.",
+        },
+      },
+      required: ["interactionId"],
+    },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+];
+
+/** Human-readable headline. States coverage in the same breath as the verdict. */
+function summarize(report: {
+  outcome: string;
+  unverifiableCause: string | null;
+  coverage: { recordedSources: number; checked: number; unverifiable: number };
+  confirmed: number;
+  degraded: number;
+  unresolved: number;
+  sourceAccess: { detail: string };
+}): string {
+  const { coverage } = report;
+  if (report.outcome === "unverifiable") {
+    return report.unverifiableCause === "no-source-access"
+      ? `Cannot verify: ${report.sourceAccess.detail}. This is an environment limitation, NOT a finding about the decision's evidence — none of its ${coverage.recordedSources} recorded source(s) were checked.`
+      : `Cannot verify: none of the ${coverage.recordedSources} recorded source(s) carry a re-resolvable locator, so this decision's evidence is opaque to re-verification. Treat it as unverified, not as verified.`;
+  }
+  const scope = `Checked ${coverage.checked} of ${coverage.recordedSources} recorded source(s)${coverage.unverifiable > 0 ? `; ${coverage.unverifiable} carried no re-resolvable locator and were NOT checked` : ""}.`;
+  return report.outcome === "degraded"
+    ? `Evidence DEGRADED: ${report.degraded} citation(s) no longer match their source and ${report.unresolved} no longer resolve at all. ${scope} The affected (option, dimension) pairs should be treated as unevidenced.`
+    : `Evidence holds: all ${report.confirmed} checked citation(s) still resolve and still match. ${scope}${coverage.unverifiable > 0 ? " Coverage is partial — this is not a clean bill of health for the whole decision." : ""}`;
+}
+
+async function reverifyDecisionEvidenceHandler(
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  const interactionId = String(params["interactionId"] ?? "").trim();
+  if (!interactionId) {
+    return { success: false, message: "interactionId is required." };
+  }
+
+  const { prisma } = await import("@dpf/db");
+  const { reverifyDecisionEvidence, guardResolverPaths } = await import(
+    "@/lib/decision/evidence-reverification"
+  );
+  const { createRepoLocatorResolver } = await import("@/lib/decision/locator-resolver");
+  const { isDevInstance, getProjectRoot, isPathAllowedSync } = await import(
+    "@/lib/integrate/codebase-tools"
+  );
+
+  // Source reachability is decided BEFORE resolving anything, so an install
+  // without a checkout reports "cannot verify" rather than a wall of degrades.
+  let sourceAccess: SourceAccess;
+  if (!isDevInstance()) {
+    sourceAccess = {
+      available: false,
+      detail:
+        "this install has no source checkout (production instances ship no code), so code/spec/doc locators cannot be re-resolved here",
+    };
+  } else {
+    const repoRoot = getProjectRoot();
+    const { existsSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    sourceAccess = existsSync(join(repoRoot, "package.json"))
+      ? { available: true, repoRoot }
+      : {
+        available: false,
+        detail: `no source found at ${repoRoot} (mount the project via PROJECT_ROOT to enable re-verification)`,
+      };
+  }
+
+  const resolve = sourceAccess.available
+    ? guardResolverPaths(createRepoLocatorResolver({ repoRoot: sourceAccess.repoRoot }), isPathAllowedSync)
+    : async () => ({ resolved: false, liveExcerpt: null });
+
+  const lookup = await reverifyDecisionEvidence({
+    db: prisma as never,
+    interactionId,
+    sourceAccess,
+    resolve,
+  });
+
+  if (!lookup.found) {
+    return {
+      success: false,
+      message: `No decision found with interactionId "${interactionId}".`,
+    };
+  }
+
+  return {
+    success: true,
+    message: summarize(lookup.report),
+    data: lookup.report,
+  };
+}
+
+export const decisionReverifyPack: ToolPack = {
+  packId: "decision-reverify",
+  definitions,
+  handlers: {
+    reverify_decision_evidence: (params) => reverifyDecisionEvidenceHandler(params),
+  },
+  grants: {
+    reverify_decision_evidence: ["registry_read"],
+  },
+};

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -276,6 +276,12 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   // reads decision-perspective material, never a work capsule.
   evaluate_profession_decision: ["registry_read"],
 
+  // Independent re-verification of a recorded decision's cited evidence
+  // (BI-8192557E phase 2b). Same `registry_read` tier as its siblings: auditing
+  // the evidence behind a decision must not need a higher grant than making the
+  // decision did, or the check is less reachable than the thing it checks.
+  reverify_decision_evidence: ["registry_read"],
+
   // Two more doors sealed the same way as evaluate_profession_decision, found
   // by the registry-wide sweep the BI-88B77204 fix added. Both packs already
   // declared the grant they intended; only the gating entry was missing, so

--- a/docs/superpowers/plans/2026-08-15-wire-evidence-reverifier-plan.md
+++ b/docs/superpowers/plans/2026-08-15-wire-evidence-reverifier-plan.md
@@ -87,7 +87,27 @@ Phase 2 therefore splits:
 
 **Fail-closed, concretely.** A source without a re-resolvable locator is split into `unverifiable` with a reason (`no-locator` for every row on the install today, `malformed-locator`, `no-dimension-binding`) rather than dropped silently — dropping would let "0 citations, 0 failures" read as clean. `reverifyCitations` already refuses to report `allConfirmed` on an empty result set, so an all-legacy decision cannot present as re-verified.
 
-**Not yet closed:** nothing *calls* `recordedCitationsFromSources` in production — that is phase 2b, by design. And a locator only reaches the record when a caller supplies `evidence` to `principle_decide`; phase 2a makes an evidenced call re-verifiable, it does not make callers cite.
+**Not yet closed:** nothing *calls* `recordedCitationsFromSources` in production — that is phase 2b, by design. And a locator only reaches the record when a caller supplies `evidence` to `principle_decide`; phase 2a makes an evidenced call re-verifiable, it does not make callers cite. That second gap is now tracked as **BI-D045A069**.
+
+#### Phase 2b — SHIPPED
+
+`reverify_decision_evidence` (MCP, grant `registry_read`) — `lib/mcp/packs/decision-reverify-pack.ts` over `lib/decision/evidence-reverification.ts`. Loads a recorded decision by `interactionId`, decodes its citations with `recordedCitationsFromSources`, re-resolves each against live source with the phase-1 repo resolver, and reports what still holds.
+
+**A separate tool, not a step in `principle_decide`.** Re-verification only means something without access to the original scorer's reasoning. Grant matches the decision-governance siblings: auditing the evidence behind a decision must not require a higher grant than making the decision did, or the check is less reachable than the thing it checks.
+
+**Three outcomes, deliberately not two — the load-bearing design point.** `reverifyCitations` folds `unresolved` into `degrade`. That is right when the resolver could read the cited artifact and it was not there (fabrication), and catastrophic when the resolver cannot reach source at all: a production install has no checkout (`isDevInstance()` is false), so an unguarded pass would report **every decision ever made** as fabricated evidence. Source reachability is therefore decided *before* anything resolves, and the surface returns:
+
+| outcome | meaning |
+|---|---|
+| `verified` | every citation that could be checked still resolves and still matches |
+| `degraded` | at least one no longer holds — a real finding about the evidence |
+| `unverifiable` | nothing could be checked; `unverifiableCause` is `no-source-access` (a deployment fact, **not** a finding) or `no-recorded-locators` (a pre-2a record) |
+
+`coverage` rides alongside, so `verified` is never read as a clean bill of health for the whole decision: a decision with one confirmed citation and four unverifiable ones is `verified` at coverage 1/5, and the tool's own message says so.
+
+**Path guard (security).** A cited `filePath` is attacker-influenced data — it comes from whatever agent made the decision and is echoed back as `liveExcerpt`. Phase 1's resolver confines reads to the repo root, but the repo root legitimately *contains* `.env`, keys and credential files, so an unguarded citation naming one would round-trip its contents to any caller holding `registry_read`. `guardResolverPaths` wraps the resolver with `isPathAllowedSync` — the same blocklist `read_project_file` enforces — and a blocked path fails closed to `unresolved`. Regression-tested against a fixture repo containing a planted secret.
+
+**Deliberately NOT in 2b: recording the verdict.** The plan bullet above says "record degraded pairs"; that is held back to phase 3, for a reason found while building. The decision row is sealed into the append-only hash chain and a write guard forbids mutating sealed fields, so a verdict cannot be written back onto it — it needs its own record, whose shape is determined by how phase 3 consumes a degrade during re-scoring. Inventing that record now would fix the shape before the consumer exists. 2b is read-only and advisory, which is also the cleaner separation-of-duties story.
 
 ### Phase 3 — degrade feeds Axis 1
 A degraded pair drops the affected dimension to unevidenced on re-scoring, and the decision is flagged. This is what closes the loop with `evidence-grounding.ts`.
@@ -100,7 +120,7 @@ A degraded pair drops the affected dimension to unevidenced on re-scoring, and t
 
 ## 5. Verification
 
-- Unit: `pnpm --filter web exec vitest run lib/decision/locator-resolver.test.ts` (phase 1) and `lib/decision/recorded-citations.test.ts` (phase 2a).
+- Unit: `pnpm --filter web exec vitest run lib/decision/locator-resolver.test.ts` (phase 1), `lib/decision/recorded-citations.test.ts` (phase 2a), and `lib/decision/evidence-reverification.test.ts` + `lib/mcp/packs/decision-reverify-pack.test.ts` (phase 2b).
 - Production build: `pnpm --filter web build`.
 - No UI surface in phase 1 or 2a, so no UX verification path; no migration in either.
 

--- a/docs/user-guide/ai-workforce/decision-perspective-in-practice.md
+++ b/docs/user-guide/ai-workforce/decision-perspective-in-practice.md
@@ -248,6 +248,32 @@ gate decision are:
 - **Operations Map** — decision-pressure overlays, so a rising escalation rate on one profile is visible
   next to cost pressure.
 
+### Un-tampered-with is not the same as true
+
+The ledger is sealed into an append-only hash chain, so a recorded decision can be proven **unaltered
+since it was written**. That is a different — and weaker — claim than the evidence behind it being
+**correct**. A citation can be perfectly well-formed, name a real-looking file and line, pass every
+admissibility check, and still describe something that was never there. Sealing it only guarantees
+nobody edited the claim afterwards.
+
+Closing that gap needs a second, later pass that goes back to the source. A decision's citations record
+*where* each one came from, and re-verification re-reads those places and reports what it finds:
+
+| It says | It means |
+|---|---|
+| **Verified** | every citation it could check still resolves, and still says what the decision claimed |
+| **Degraded** | at least one no longer holds — treat those points as unevidenced and revisit the decision |
+| **Unverifiable** | nothing could be checked — either this install carries no source to check against, or the decision predates citation recording |
+
+Read the verdict together with its **coverage**. "Verified" describes only the citations that could be
+checked, so a decision with one confirmed citation and four unverifiable ones is not a decision with
+five confirmed citations. Unverifiable is deliberately never reported as either a pass or a failure:
+not having looked is not the same as having looked and found a problem, and neither one is evidence
+that the decision was sound.
+
+This runs as its own pass, on purpose. A check performed by the same reasoning that made the decision
+would tell you very little; the point is that something independent went back and looked.
+
 ## How the three examples relate
 
 Read together, the trio shows the same engine producing the *right kind* of answer for the *kind of

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -53,14 +53,14 @@ apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1621
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	940
-apps/web/lib/tak/agent-grants.ts	976
+apps/web/lib/tak/agent-grants.ts	982
 apps/web/lib/tak/agent-routing.ts	1053
 apps/web/lib/tak/agentic-loop.test.ts	2501
 apps/web/lib/tak/agentic-loop.ts	2812
 apps/web/lib/tak/route-context-map.ts	1273
 apps/web/lib/work-capsules/mcp-handlers.ts	919
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1085
-apps/web/lib/work-capsules/work-capsule-store.ts	1060
+apps/web/lib/work-capsules/work-capsule-store.ts	1034
 apps/web/lib/workbooks/platform-tables.ts	938
 apps/web/lib/workforce/calendar-data.ts	1134
 apps/web/lib/workspace/command-center.ts	1118

--- a/scripts/tool-surface-baseline.json
+++ b/scripts/tool-surface-baseline.json
@@ -3,14 +3,14 @@
   "selectionCliff": 15,
   "entries": {
     "registry.toolDefinitions": {
-      "value": 387,
-      "reason": "Adds nine independently granted initiative-evidence writers for classification/research/dependency evidence and the design, architecture, data, UX, security, compliance, domain, and archetype review lanes (BI-64AF127B). Separate tool identities preserve least privilege and reviewer independence; a generic caller-selected lane would allow one grant to impersonate specialist authority.",
-      "recordedAt": "2026-08-15"
+      "value": 388,
+      "reason": "Adds reverify_decision_evidence (BI-8192557E phase 2b): the independent re-check of a recorded decision's cited evidence against live source. It earns a permanent identity because separation of duties is the property that makes it worth anything — folding re-verification into principle_decide would let a decision certify its own citations, and no existing tool can re-resolve a StructuredLocator. Read-only, registry_read, mutates nothing.",
+      "recordedAt": "2026-08-16"
     },
     "registry.packFiles": {
-      "value": 92,
-      "reason": "Adds the initiative-readiness pack (BI-64AF127B) as the single adapter owning all nine lane-specific evidence definitions, handlers, and grants. Keeping them together prevents readiness policy from being duplicated across backlog, Build Studio, and specialist packs.",
-      "recordedAt": "2026-08-15"
+      "value": 93,
+      "reason": "Adds the decision-reverify pack (BI-8192557E phase 2b) as the adapter owning that tool's definition, handler and grant. Kept out of principle-decide-pack deliberately: co-locating the verifier with the scorer is the coupling the separation-of-duties contract forbids.",
+      "recordedAt": "2026-08-16"
     },
     "tier.coreToolNames": {
       "value": 30,


### PR DESCRIPTION
Phase 2a made a recorded citation carry its `StructuredLocator`. This is the pass that uses it.

`reverify_decision_evidence` (MCP, grant `registry_read`) loads a decision by `interactionId`, decodes its citations with `recordedCitationsFromSources`, re-resolves each against live source with the phase-1 repo resolver, and reports which still hold — so a citation that was *admissible but never true* gets caught after the fact.

## Design grounding

Extends the merged plan [`docs/superpowers/plans/2026-08-15-wire-evidence-reverifier-plan.md`](docs/superpowers/plans/2026-08-15-wire-evidence-reverifier-plan.md) §3 Phase 2b, updated in this PR. No new contract invented: the resolver (#4324), the re-verifier (BI-70FF9114) and the decoder (#4344) all already existed — this is the adapter that connects them to a real decision. Scope choice was routed through `principle_decide` (ledger `DI-18A9DB68B82F`, composite 13.34 vs 7.67, high confidence, no commandment conflict).

## Separation of duties

A **separate tool**, not a step inside `principle_decide`. Re-verification only means something when it runs without access to the original scorer's reasoning; folding it into the scoring call would let a decision certify its own citations. Grant matches its decision-governance siblings — auditing the evidence behind a decision must not need a higher grant than making the decision did, or the check is less reachable than the thing it checks.

## Three outcomes, not two — the load-bearing bit

`reverifyCitations` folds `unresolved` into `degrade`. That is correct when the resolver *could* read the cited artifact and it was not there (fabrication), and catastrophic when the resolver cannot reach source at all: a production install has no checkout (`isDevInstance()` is false), so an unguarded pass would report **every decision ever made** as fabricated evidence. Source reachability is therefore decided *before* anything resolves.

| outcome | meaning |
|---|---|
| `verified` | every citation that could be checked still resolves and still matches |
| `degraded` | at least one no longer holds — a real finding |
| `unverifiable` | nothing could be checked; cause is `no-source-access` (a deployment fact, **not** a finding) or `no-recorded-locators` (a pre-2a record) |

`coverage` rides alongside so `verified` is never read as a clean bill of health: one confirmed citation plus four unverifiable ones is `verified` at coverage 1/5, and the tool says so in its own message. A pack test asserts the tool description itself carries that distinction, since the description is all an agent reads before calling.

## Path guard (security)

A cited `filePath` is attacker-influenced data — it comes from whatever agent made the decision and is echoed back as `liveExcerpt`. Phase 1 confines reads to the repo root, but the repo root legitimately **contains** `.env`, keys and credential files, so a citation naming one would round-trip its contents to any caller holding `registry_read`. `guardResolverPaths` wraps the resolver with `isPathAllowedSync` — the same blocklist `read_project_file` enforces — failing closed to `unresolved`. Regression-tested against a fixture repo with a planted secret.

## Deliberately not here

**Recording the verdict.** The plan's 2b bullet says "record degraded pairs"; that is held to phase 3. The decision row is sealed into the append-only hash chain and a write guard forbids mutating sealed fields, so a verdict needs its own record — whose shape depends on how phase 3 consumes a degrade during re-scoring. Fixing that shape before the consumer exists would be guessing. 2b is read-only and advisory.

## Ratchets

Both re-baselined **with recorded reasons**, per each guard's own contract:
- `registry.toolDefinitions` 387→388 and `registry.packFiles` 92→93 — reasons written into `scripts/tool-surface-baseline.json`.
- `agent-grants.ts` 976→982 (the grant entry plus a 4-line rationale). The same update retightens `work-capsule-store.ts` 1060→1034, a shrink from already-merged work.

## Verification

- `pnpm --filter web exec vitest run lib/decision lib/mcp/packs/decision-reverify-pack.test.ts lib/mcp/pack-registry.test.ts lib/mcp/tool-naming-lint.test.ts lib/mcp/tool-registry.test.ts lib/coworker/authorized-surface-registry.test.ts` — 577 tests across 63 files, green.
- `pnpm --filter web build` — exit 0. The 28 Turbopack warnings are pre-existing Edge-Runtime notices in `packages/db/src/*`, untouched here.
- `pnpm run pregate` — gate passed (evidence `cmsw98jdl158t01pnqqvjlgzn`, sha `b1ab267f882b`).

No UI surface and no migration, so no UX verification path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)