### PR TITLE
fix(security): remove ReDoS ambiguity from the promoter COPY matcher (CodeQL #372)

### DIFF
--- a/scripts/lifecycle-surface-policy.mjs
+++ b/scripts/lifecycle-surface-policy.mjs
@@ -45,8 +45,20 @@ export async function auditLifecycleSurfaces(root) {
   return { violations, stale, remediationCount: [...remediationHits.values()].reduce((a, b) => a + b, 0) };
 }
 
+// CodeQL js/redos #372: `[^ ]+` excludes only a literal SPACE, so it also
+// matched tabs — exactly like the adjacent `\s+`. One `(?:--[^ ]+\s+)` iteration
+// could therefore cover what two iterations cover, the ambiguity that drives
+// exponential backtracking. Keeping the classes disjoint (`\S+` for tokens,
+// `[^\S\r\n]+` for horizontal gaps) removes every ambiguous split.
+// Using horizontal-only whitespace also fixes a latent correctness bug: the old
+// `\s+` matched newlines, so a COPY match could run past the end of its line.
+const COPY_INPUT_RE = /^COPY[^\S\r\n]+(?!.*--from=)(?:--\S+[^\S\r\n]+)*(\S+)[^\S\r\n]+[^\r\n]+$/gm;
+
 export function promoterCopyInputs(dockerfile) {
-  return [...dockerfile.matchAll(/^COPY\s+(?!.*--from=)(?:--[^ ]+\s+)*([^ ]+)\s+[^\r\n]+$/gm)].map((match) => match[1]);
+  // The literal carries /g, so reset lastIndex rather than sharing cursor state
+  // between calls.
+  COPY_INPUT_RE.lastIndex = 0;
+  return [...dockerfile.matchAll(COPY_INPUT_RE)].map((match) => match[1]);
 }
 
 export function assertHostStateWiring(compose) {

--- a/scripts/lifecycle-surface-policy.test.mjs
+++ b/scripts/lifecycle-surface-policy.test.mjs
@@ -31,6 +31,45 @@ test("promoter COPY inputs are derived from its Dockerfile", async () => {
   assert.equal(new Set(inputs).size, inputs.length);
 });
 
+// CodeQL js/redos alert #372 (high): the COPY matcher used `[^ ]+` for flag
+// bodies, which excludes only a literal SPACE — so it could also consume tabs,
+// exactly like the adjacent `\s+`. A single `(?:--[^ ]+\s+)` iteration could
+// therefore match what two iterations match, the classic ambiguity behind
+// exponential backtracking. The fix makes the two classes disjoint (`\S+` vs
+// horizontal whitespace) so no input can be split between them.
+//
+// Honesty note: no input was found that actually detonates the old pattern in
+// V8 (crafted "--\t"/"!\t--" runs up to n=60 all returned in <1ms), so this is
+// the removal of a LATENT ambiguity, not a patch for a demonstrated hang. The
+// timing assertion below is therefore a cheap canary against a future edit
+// reintroducing catastrophic backtracking — it is NOT proof the old code was
+// exploitable, and it passed before the fix too. The tests that carry real
+// weight here are the behavioural ones: the risk in this change is breaking
+// promoter COPY parsing, not the regex being slow.
+test("promoterCopyInputs stays linear on a crafted COPY line (canary)", () => {
+  const crafted = `COPY ${"--\t".repeat(60)}`;
+  const started = process.hrtime.bigint();
+  promoterCopyInputs(crafted);
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+  assert.ok(elapsedMs < 1000, `regex took ${elapsedMs.toFixed(0)}ms — catastrophic backtracking (js/redos #372)`);
+});
+
+test("promoterCopyInputs still parses flagged and tab-separated COPY forms", () => {
+  assert.deepEqual(promoterCopyInputs("COPY scripts/a.sh /app/a.sh"), ["scripts/a.sh"]);
+  assert.deepEqual(
+    promoterCopyInputs("COPY --chown=node:node --chmod=755 scripts/b.sh /app/b.sh"),
+    ["scripts/b.sh"],
+    "flag prefixes must still be skipped rather than captured",
+  );
+  assert.deepEqual(promoterCopyInputs("COPY\tscripts/c.sh\t/app/c.sh"), ["scripts/c.sh"], "tab separators stay supported");
+  assert.deepEqual(promoterCopyInputs("COPY --from=build /out /app"), [], "--from stages are still excluded");
+  assert.deepEqual(
+    promoterCopyInputs("COPY a.sh /app/a.sh\nRUN echo hi\nCOPY b.sh /app/b.sh"),
+    ["a.sh", "b.sh"],
+    "matching must stay line-anchored",
+  );
+});
+
 test("compose wires the resolved host state into portal and promoter", async () => {
   const compose = await readFile(resolve(root, "docker-compose.yml"), "utf8");
   assert.deepEqual(assertHostStateWiring(compose), []);


### PR DESCRIPTION
Closes the last open **Code Scanning** alert: **#372 `js/redos`** (high) at `scripts/lifecycle-surface-policy.mjs:49`.

## The defect

```js
/^COPY\s+(?!.*--from=)(?:--[^ ]+\s+)*([^ ]+)\s+[^\r\n]+$/gm
```

`[^ ]+` excludes only a literal **space**, so it also matched tabs — exactly like the adjacent `\s+`. A single `(?:--[^ ]+\s+)` iteration could therefore cover what two iterations cover, which is the classic ambiguity behind exponential backtracking.

## The fix

Keep the character classes **disjoint** — `\S+` for tokens, `[^\S\r\n]+` for horizontal gaps — so no input can be split between them:

```js
/^COPY[^\S\r\n]+(?!.*--from=)(?:--\S+[^\S\r\n]+)*(\S+)[^\S\r\n]+[^\r\n]+$/gm
```

Horizontal-only whitespace also fixes a **latent correctness bug**: the old `\s+` matched newlines, so a COPY match could run past the end of its line. The regex is hoisted to a module constant with an explicit `lastIndex` reset, since a `/g` literal carries cursor state between calls.

## Honesty note — this is not a demonstrated hang

I could not construct an input that detonates the old pattern in V8. Crafted `--\t`, `!\t--` and `--a\t` runs up to n=60, across several failure tails, **all returned in under 1ms**.

So this removes a **latent, statically-flagged ambiguity** — not an exploitable DoS. The timing assertion in the test is labelled a *canary* against a future edit reintroducing catastrophic backtracking; **it passed before this fix too** and proves nothing on its own. I've deliberately not dressed it up as a red-to-green security regression test.

## What is actually proven

The real risk in this change is breaking promoter COPY parsing, so that's what I verified:

- **Behavioural equivalence across all 12 Dockerfiles tracked in the repo** — 146 COPY inputs, byte-identical output before and after the change.
- New unit tests cover the plain, multi-flag (`--chown`/`--chmod`), tab-separated, `--from`-excluded, and multi-line-anchored forms.
- `pnpm run check:lifecycle-surfaces` still green.
- **Local CI gate passed** on the exact tree (`cf74746112f0`).

## Context

This was the third item on the Security tab. The other two are the `image-size` Dependabot alerts, whose underlying risk was fixed in #4321 (locally-owned patch) but whose alerts can't auto-close, because a `pnpm patch` doesn't change the version string OSV matches on.