### PR TITLE
feat(hive-scout): widen scout aperture to product/market sources with design-challenge output

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler-summary.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler-summary.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { extractDiscoveryTriageSummary } from "./agent-task-scheduler-summary";
+import {
+  extractDiscoveryTriageSummary,
+  extractHiveScoutSummary,
+} from "./agent-task-scheduler-summary";
 
 describe("extractDiscoveryTriageSummary wrapped tool results", () => {
   it("reads triage metrics from MCP tool-result payloads wrapped under data", () => {
@@ -39,5 +42,51 @@ describe("extractDiscoveryTriageSummary wrapped tool results", () => {
     expect(summary?.compactStatus).toContain("processed=3");
     expect(summary?.compactStatus).toContain("escalations=2");
     expect(summary?.payload?.metrics).toMatchObject({ decisionsCreated: 3 });
+  });
+});
+
+describe("extractHiveScoutSummary market-aperture metrics (BI-B8E4317D)", () => {
+  const baseData = {
+    catalogEntries: 112,
+    gaps: 32,
+    created: 0,
+    duplicates: 32,
+    needsReview: 0,
+  };
+
+  it("surfaces market-source counts in the payload and compact status", () => {
+    const summary = extractHiveScoutSummary([
+      {
+        name: "run_hive_scout_ingest",
+        args: {},
+        result: {
+          success: true,
+          message: "ok",
+          data: {
+            ...baseData,
+            marketSources: { enabled: true, attempted: 10, fetched: 9, changed: 4, failed: 1, material: [], failures: [] },
+          },
+        },
+      },
+    ] as never);
+
+    expect(summary?.payload?.metrics).toMatchObject({
+      marketSourcesAttempted: 10,
+      marketSourcesFetched: 9,
+      marketSourcesChanged: 4,
+      marketSourcesFailed: 1,
+    });
+    expect(summary?.compactStatus).toContain("market-fetched=9/10");
+    expect(summary?.compactStatus).toContain("market-changed=4");
+    expect(summary?.compactStatus).toContain("market-failed=1");
+  });
+
+  it("stays backward compatible with runs that predate the market pass", () => {
+    const summary = extractHiveScoutSummary([
+      { name: "run_hive_scout_ingest", args: {}, result: { success: true, message: "ok", data: baseData } },
+    ] as never);
+
+    expect(summary?.payload?.metrics).not.toHaveProperty("marketSourcesAttempted");
+    expect(summary?.compactStatus).not.toContain("market-fetched");
   });
 });

--- a/apps/web/lib/actions/agent-task-scheduler-summary.ts
+++ b/apps/web/lib/actions/agent-task-scheduler-summary.ts
@@ -61,6 +61,10 @@ type HiveScoutSummaryPayload = {
     reviewClassificationHistogram?: Record<string, number>;
     reviewClassificationByFramework?: Record<string, Record<string, number>>;
     reviewClassificationByIndustry?: Record<string, Record<string, number>>;
+    marketSourcesAttempted?: number;
+    marketSourcesFetched?: number;
+    marketSourcesChanged?: number;
+    marketSourcesFailed?: number;
   };
   createdItemIds?: string[];
 };
@@ -221,6 +225,19 @@ export function extractHiveScoutSummary(
     scoutTool.result.data.reviewClassificationByIndustry,
   );
 
+  // Market-aperture pass metrics (BI-B8E4317D) — absent on runs predating it.
+  const marketRaw = isRecord(scoutTool.result.data.marketSources)
+    ? scoutTool.result.data.marketSources
+    : null;
+  const marketMetrics = marketRaw
+    ? {
+        marketSourcesAttempted: asNumber(marketRaw.attempted) ?? 0,
+        marketSourcesFetched: asNumber(marketRaw.fetched) ?? 0,
+        marketSourcesChanged: asNumber(marketRaw.changed) ?? 0,
+        marketSourcesFailed: asNumber(marketRaw.failed) ?? 0,
+      }
+    : null;
+
   const payload: HiveScoutSummaryPayload = {
     processedAt: new Date().toISOString(),
     metrics: {
@@ -250,6 +267,7 @@ export function extractHiveScoutSummary(
       ...(reviewClassificationHistogram ? { reviewClassificationHistogram } : {}),
       ...(reviewClassificationByFramework ? { reviewClassificationByFramework } : {}),
       ...(reviewClassificationByIndustry ? { reviewClassificationByIndustry } : {}),
+      ...(marketMetrics ?? {}),
     },
     ...(createdItemIds.length > 0 ? { createdItemIds } : {}),
   };
@@ -265,6 +283,13 @@ export function extractHiveScoutSummary(
     `review-schema-drops=${payload.metrics.reviewSchemaDropCount}`,
     `review-cache-hits=${payload.metrics.reviewCacheHits}`,
     `needs-review=${payload.metrics.needsReview}`,
+    ...(marketMetrics
+      ? [
+          `market-fetched=${marketMetrics.marketSourcesFetched}/${marketMetrics.marketSourcesAttempted}`,
+          `market-changed=${marketMetrics.marketSourcesChanged}`,
+          `market-failed=${marketMetrics.marketSourcesFailed}`,
+        ]
+      : []),
   ].join(" ");
 
   const threadMessage = [

--- a/apps/web/lib/actions/hive-scout/ingest-500-agents-run.test.ts
+++ b/apps/web/lib/actions/hive-scout/ingest-500-agents-run.test.ts
@@ -22,7 +22,11 @@ const mocks = vi.hoisted(() => ({
       findMany: vi.fn(),
     },
     rawSource: {
+      findUnique: vi.fn(),
       upsert: vi.fn(),
+    },
+    platformConfig: {
+      findUnique: vi.fn(),
     },
     digitalProduct: {
       findUnique: vi.fn(),
@@ -107,7 +111,12 @@ describe("runHiveScoutIngest — RawSource upsert", () => {
     mocks.prisma.backlogItem.create.mockResolvedValue({ id: "backlog-row-1", itemId: "HS-1" });
     mocks.prisma.backlogItemActivity.create.mockResolvedValue({ id: "activity-1" });
     mocks.prisma.user.findMany.mockResolvedValue([]);
+    mocks.prisma.rawSource.findUnique.mockResolvedValue(null);
     mocks.prisma.rawSource.upsert.mockResolvedValue({ id: "raw-fixed-id" });
+    mocks.prisma.platformConfig.findUnique.mockImplementation(async (args?: unknown) => {
+      const key = (args as { where?: { key?: string } } | undefined)?.where?.key;
+      return key === "hive-scout.market.enabled" ? { key, value: false } : null;
+    });
     mocks.prisma.digitalProduct.findUnique.mockResolvedValue({ id: "dp-ai-workforce" });
     mocks.prisma.taxonomyNode.findUnique.mockResolvedValue({ id: "tn-workforce-services" });
     mocks.loadPrompt.mockResolvedValue("{{NAME}} {{SOURCE_URL}}");
@@ -163,5 +172,84 @@ describe("runHiveScoutIngest — RawSource upsert", () => {
       "hive-scout:500-ai-agents:github-com-example-threat-hunter",
       "hive-scout:500-ai-agents:github-com-example-threat-hunter",
     ]);
+  });
+});
+
+describe("runHiveScoutIngest — market-aperture pass (BI-B8E4317D)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.prisma.eaReferenceModelElement.findMany.mockResolvedValue([{ name: "Operate" }]);
+    mocks.prisma.skillDefinition.findMany.mockResolvedValue([]);
+    mocks.prisma.agent.findMany.mockResolvedValue([]);
+    mocks.prisma.backlogItem.findUnique.mockResolvedValue(null);
+    mocks.prisma.backlogItem.create.mockResolvedValue({ id: "backlog-row-1", itemId: "HS-1" });
+    mocks.prisma.backlogItemActivity.create.mockResolvedValue({ id: "activity-1" });
+    mocks.prisma.user.findMany.mockResolvedValue([]);
+    mocks.prisma.rawSource.findUnique.mockResolvedValue(null);
+    mocks.prisma.rawSource.upsert.mockResolvedValue({ id: "raw-fixed-id" });
+    // Market pass ENABLED: no config rows -> defaults (enabled, seeded list).
+    mocks.prisma.platformConfig.findUnique.mockResolvedValue(null);
+    mocks.prisma.digitalProduct.findUnique.mockResolvedValue({ id: "dp-ai-workforce" });
+    mocks.prisma.taxonomyNode.findUnique.mockResolvedValue({ id: "tn-workforce-services" });
+    mocks.loadPrompt.mockResolvedValue("{{NAME}} {{SOURCE_URL}}");
+  });
+
+  it("fetches every default market source, cites a RawSource per source, and returns changed material", async () => {
+    const fetchedUrls: string[] = [];
+    const result = await runHiveScoutIngest({
+      fetcher: async (url: string) => {
+        fetchedUrls.push(url);
+        if (url.includes("github")) return SAMPLE_README;
+        return `<html><body><h1>Release notes</h1><p>New effortless flow for ${url}</p></body></html>`;
+      },
+    } as never);
+
+    const market = result.marketSources;
+    expect(market).toBeDefined();
+    expect(market?.enabled).toBe(true);
+    expect(market?.attempted).toBeGreaterThan(0);
+    expect(market?.fetched).toBe(market?.attempted);
+    expect(market?.failed).toBe(0);
+    // First run: no prior locator hash, so every source counts as changed.
+    expect(market?.changed).toBe(market?.attempted);
+    expect(market?.material.length).toBe(market?.fetched);
+    for (const item of market?.material ?? []) {
+      expect(item.url).toMatch(/^https?:\/\//);
+      expect(item.excerpt).toContain("Release notes");
+      expect(item.excerpt).not.toContain("<");
+    }
+    // The catalog README fetch plus one fetch per market source.
+    expect(fetchedUrls.length).toBe(1 + (market?.attempted ?? 0));
+
+    const marketKeys = mocks.prisma.rawSource.upsert.mock.calls
+      .map((call: unknown[]) => (call[0] as { where: { sourceKey: string } }).where.sourceKey)
+      .filter((key: string) => key.startsWith("hive-scout:market:"));
+    expect(marketKeys.length).toBe(market?.fetched);
+  });
+
+  it("marks a source unchanged when the stored locator hash matches, and captures per-source failures without failing the run", async () => {
+    const { marketContentHash, extractMarketText, DEFAULT_MARKET_SOURCES } = await import("./market-sources");
+    const stableBody = "<html><body>Stable content</body></html>";
+    const stableHash = marketContentHash(extractMarketText(stableBody));
+    mocks.prisma.rawSource.findUnique.mockResolvedValue({
+      locator: { kind: "hive-scout-market", url: "x", contentHash: stableHash, fetchedAt: "2026-08-15T00:00:00.000Z" },
+    });
+
+    const failingUrl = DEFAULT_MARKET_SOURCES[0]!.url;
+    const result = await runHiveScoutIngest({
+      fetcher: async (url: string) => {
+        if (url.includes("github")) return SAMPLE_README;
+        if (url === failingUrl) throw new Error("HTTP 403");
+        return stableBody;
+      },
+    } as never);
+
+    const market = result.marketSources;
+    expect(market?.failed).toBe(1);
+    expect(market?.failures[0]).toMatchObject({ key: DEFAULT_MARKET_SOURCES[0]!.key, error: "HTTP 403" });
+    expect(market?.changed).toBe(0);
+    expect(market?.fetched).toBe((market?.attempted ?? 0) - 1);
+    // Catalog result is untouched by market-source failures.
+    expect(result.catalogEntries).toBe(1);
   });
 });

--- a/apps/web/lib/actions/hive-scout/ingest-500-agents.test.ts
+++ b/apps/web/lib/actions/hive-scout/ingest-500-agents.test.ts
@@ -161,7 +161,13 @@ describe("runHiveScoutIngest ambiguity review", () => {
   function makePrisma() {
     return {
       platformConfig: {
-        findUnique: async (_args?: unknown) => null,
+        // Market-aperture pass is covered by market-sources.test.ts and the
+        // run-shaped integration test; keep this suite focused on catalog +
+        // review behaviour by disabling it through the real config mechanism.
+        findUnique: async (args?: unknown) => {
+          const key = (args as { where?: { key?: string } } | undefined)?.where?.key;
+          return key === "hive-scout.market.enabled" ? { key, value: false } : null;
+        },
       },
       eaReferenceModelElement: {
         findMany: async () => [{ name: "Operate" }],
@@ -350,7 +356,9 @@ describe("runHiveScoutIngest ambiguity review", () => {
     const prisma = makePrisma();
     (prisma.platformConfig as { findUnique: (args?: unknown) => Promise<unknown> }).findUnique = async (args?: unknown) => {
       const where = (args as { where: { key: string } }).where;
-      return where.key === "hive-scout.review.enabled" ? { key: where.key, value: false } : null;
+      return where.key === "hive-scout.review.enabled" || where.key === "hive-scout.market.enabled"
+        ? { key: where.key, value: false }
+        : null;
     };
 
     const result = await runHiveScoutIngest({

--- a/apps/web/lib/actions/hive-scout/ingest-500-agents.ts
+++ b/apps/web/lib/actions/hive-scout/ingest-500-agents.ts
@@ -72,6 +72,7 @@ import {
   resolveHiveScoutWorkforceLinks,
   type HiveScoutPrisma,
 } from "./ingest-db";
+import { runMarketSourcePass, type MarketSourcePassResult } from "./market-sources";
 
 // Re-exported so existing importers (tests, scripts, MCP tools) keep a single
 // entry point for the Hive Scout ingest API.
@@ -121,6 +122,8 @@ export interface IngestResult {
   duplicates: number;
   needsReview: number;
   createdItemIds?: string[];
+  /** Market-aperture pass (BI-B8E4317D) — product/market sources beyond the agent catalog. */
+  marketSources?: MarketSourcePassResult;
 }
 
 // ─── Main entry point ───────────────────────────────────────────────────────
@@ -414,6 +417,11 @@ export async function runHiveScoutIngest(
 
   await adminNotifier(created, db);
 
+  // Market-aperture pass runs after the catalog pass so a market-source
+  // failure can never mask a catalog regression; per-source errors are
+  // captured inside the pass, never thrown.
+  const marketSources = await runMarketSourcePass({ db, fetcher });
+
   return {
     catalogEntries: entries.length,
     gaps,
@@ -437,6 +445,7 @@ export async function runHiveScoutIngest(
     duplicates,
     needsReview,
     createdItemIds,
+    marketSources,
   };
 }
 

--- a/apps/web/lib/actions/hive-scout/market-sources.test.ts
+++ b/apps/web/lib/actions/hive-scout/market-sources.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_MARKET_SOURCES,
+  MARKET_MATERIAL_EXCERPT_CHARS,
+  MARKET_SOURCE_LIMIT,
+  MARKET_SOURCES_CONFIG_KEY,
+  MARKET_STORED_EXCERPT_CHARS,
+  extractMarketText,
+  loadMarketSourceSettings,
+  marketContentHash,
+  marketSourceKey,
+  runMarketSourcePass,
+  type MarketSource,
+} from "./market-sources";
+
+function makeConfigDb(rows: Record<string, unknown>) {
+  return {
+    platformConfig: {
+      findUnique: async (args?: unknown) => {
+        const key = (args as { where?: { key?: string } } | undefined)?.where?.key;
+        return key && key in rows ? { key, value: rows[key] } : null;
+      },
+    },
+  };
+}
+
+function makePassDb(rows: Record<string, unknown>, priorLocators: Record<string, unknown> = {}) {
+  const upserts: Array<Record<string, unknown>> = [];
+  return {
+    upserts,
+    db: {
+      ...makeConfigDb(rows),
+      rawSource: {
+        findUnique: async (args?: unknown) => {
+          const key = (args as { where?: { sourceKey?: string } } | undefined)?.where?.sourceKey;
+          return key && key in priorLocators ? { locator: priorLocators[key] } : null;
+        },
+        upsert: async (args: Record<string, unknown>) => {
+          upserts.push(args);
+          return { id: `raw-${upserts.length}` };
+        },
+      },
+    },
+  };
+}
+
+describe("loadMarketSourceSettings", () => {
+  it("defaults to enabled with the seeded source list", async () => {
+    const settings = await loadMarketSourceSettings(makeConfigDb({}) as never);
+    expect(settings.enabled).toBe(true);
+    expect(settings.configFallback).toBe(false);
+    expect(settings.sources).toEqual(DEFAULT_MARKET_SOURCES.slice(0, MARKET_SOURCE_LIMIT));
+  });
+
+  it("honours the enabled kill switch in boolean, string, and object shapes", async () => {
+    for (const value of [false, "false", { enabled: false }]) {
+      const settings = await loadMarketSourceSettings(
+        makeConfigDb({ "hive-scout.market.enabled": value }) as never,
+      );
+      expect(settings.enabled).toBe(false);
+    }
+  });
+
+  it("accepts a valid operator override and caps it at the source limit", async () => {
+    const override: MarketSource[] = Array.from({ length: MARKET_SOURCE_LIMIT + 3 }, (_, i) => ({
+      key: `src-${i}`,
+      title: `Source ${i}`,
+      url: `https://example.com/${i}`,
+    }));
+    const settings = await loadMarketSourceSettings(
+      makeConfigDb({ [MARKET_SOURCES_CONFIG_KEY]: override }) as never,
+    );
+    expect(settings.configFallback).toBe(false);
+    expect(settings.sources).toHaveLength(MARKET_SOURCE_LIMIT);
+    expect(settings.sources[0]).toEqual({ key: "src-0", title: "Source 0", url: "https://example.com/0" });
+  });
+
+  it("falls back to defaults on malformed overrides and flags the fallback", async () => {
+    const malformed: unknown[] = [
+      "not json at all",
+      [{ key: "a", title: "A" }], // missing url
+      [{ key: "a", title: "A", url: "ftp://nope" }], // non-http url
+      [{ key: "a", title: "A", url: "https://x.test" }, { key: "a", title: "B", url: "https://y.test" }], // dup key
+      [],
+    ];
+    for (const value of malformed) {
+      const settings = await loadMarketSourceSettings(
+        makeConfigDb({ [MARKET_SOURCES_CONFIG_KEY]: value }) as never,
+      );
+      expect(settings.configFallback).toBe(true);
+      expect(settings.sources).toEqual(DEFAULT_MARKET_SOURCES.slice(0, MARKET_SOURCE_LIMIT));
+    }
+  });
+
+  it("parses a JSON-string override (PlatformConfig rows edited as text)", async () => {
+    const settings = await loadMarketSourceSettings(
+      makeConfigDb({
+        [MARKET_SOURCES_CONFIG_KEY]: JSON.stringify([
+          { key: "only", title: "Only source", url: "https://example.com/feed" },
+        ]),
+      }) as never,
+    );
+    expect(settings.configFallback).toBe(false);
+    expect(settings.sources).toEqual([{ key: "only", title: "Only source", url: "https://example.com/feed" }]);
+  });
+});
+
+describe("extractMarketText", () => {
+  it("strips HTML including script/style bodies and entities", () => {
+    const text = extractMarketText(
+      `<html><head><style>.a{color:red}</style><script>alert("x")</script></head>` +
+        `<body><h1>Big &amp; bold</h1><p>release notes</p></body></html>`,
+    );
+    expect(text).toBe("Big bold release notes");
+  });
+
+  it("strips RSS/Atom markup and CDATA wrappers", () => {
+    const text = extractMarketText(
+      `<?xml version="1.0"?><rss><channel><item><title><![CDATA[New agent launch]]></title>` +
+        `<description>Ships an inbox</description></item></channel></rss>`,
+    );
+    expect(text).toContain("New agent launch");
+    expect(text).toContain("Ships an inbox");
+    expect(text).not.toContain("<");
+  });
+});
+
+describe("marketContentHash / marketSourceKey", () => {
+  it("is stable for identical text and differs when content changes", () => {
+    expect(marketContentHash("same text")).toBe(marketContentHash("same text"));
+    expect(marketContentHash("same text")).not.toBe(marketContentHash("different text"));
+  });
+
+  it("derives a stable namespaced sourceKey from the url", () => {
+    const key = marketSourceKey("https://example.com/changelog");
+    expect(key).toMatch(/^hive-scout:market:/);
+    expect(marketSourceKey("https://example.com/changelog")).toBe(key);
+  });
+});
+
+describe("runMarketSourcePass", () => {
+  const twoSources: MarketSource[] = [
+    { key: "alpha", title: "Alpha changelog", url: "https://alpha.test/changelog" },
+    { key: "beta", title: "Beta blog", url: "https://beta.test/blog" },
+  ];
+
+  it("returns early when disabled without touching sources", async () => {
+    const { db } = makePassDb({ "hive-scout.market.enabled": false });
+    let fetches = 0;
+    const result = await runMarketSourcePass({
+      db: db as never,
+      fetcher: async () => {
+        fetches++;
+        return "x";
+      },
+    });
+    expect(result.enabled).toBe(false);
+    expect(result.attempted).toBe(0);
+    expect(fetches).toBe(0);
+  });
+
+  it("upserts a citable RawSource with a structured locator and bounded excerpts", async () => {
+    const { db, upserts } = makePassDb({ [MARKET_SOURCES_CONFIG_KEY]: twoSources });
+    const longBody = `<html><body>${"release detail ".repeat(2000)}</body></html>`;
+    const result = await runMarketSourcePass({
+      db: db as never,
+      fetcher: async () => longBody,
+      now: new Date("2026-08-16T12:00:00.000Z"),
+    });
+
+    expect(result.fetched).toBe(2);
+    expect(result.changed).toBe(2);
+    expect(upserts).toHaveLength(2);
+    const create = (upserts[0] as { create: Record<string, unknown> }).create;
+    expect(create.sourceType).toBe("external-url");
+    expect(create.url).toBe("https://alpha.test/changelog");
+    expect((create.excerpt as string).length).toBeLessThanOrEqual(MARKET_STORED_EXCERPT_CHARS);
+    expect(create.locator).toMatchObject({
+      kind: "hive-scout-market",
+      url: "https://alpha.test/changelog",
+      fetchedAt: "2026-08-16T12:00:00.000Z",
+    });
+    expect((create.locator as { contentHash: string }).contentHash).toMatch(/^[0-9a-f]{64}$/);
+    for (const item of result.material) {
+      expect(item.excerpt.length).toBeLessThanOrEqual(MARKET_MATERIAL_EXCERPT_CHARS);
+    }
+  });
+
+  it("reports changed=false when the prior locator hash matches the fresh content", async () => {
+    const body = "<html><body>unchanged</body></html>";
+    const hash = marketContentHash(extractMarketText(body));
+    const priorLocators = {
+      [marketSourceKey(twoSources[0]!.url)]: {
+        kind: "hive-scout-market",
+        url: twoSources[0]!.url,
+        contentHash: hash,
+        fetchedAt: "2026-08-15T12:00:00.000Z",
+      },
+    };
+    const { db } = makePassDb({ [MARKET_SOURCES_CONFIG_KEY]: twoSources }, priorLocators);
+    const result = await runMarketSourcePass({ db: db as never, fetcher: async () => body });
+
+    expect(result.fetched).toBe(2);
+    // alpha has a matching prior hash; beta has no prior row.
+    expect(result.changed).toBe(1);
+    expect(result.material.find((m) => m.key === "alpha")?.changed).toBe(false);
+    expect(result.material.find((m) => m.key === "beta")?.changed).toBe(true);
+  });
+
+  it("captures per-source failures and keeps going", async () => {
+    const { db, upserts } = makePassDb({ [MARKET_SOURCES_CONFIG_KEY]: twoSources });
+    const result = await runMarketSourcePass({
+      db: db as never,
+      fetcher: async (url: string) => {
+        if (url.includes("alpha")) throw new Error("HTTP 500");
+        return "<html><body>ok</body></html>";
+      },
+    });
+    expect(result.attempted).toBe(2);
+    expect(result.fetched).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(result.failures[0]).toMatchObject({ key: "alpha", error: "HTTP 500" });
+    expect(upserts).toHaveLength(1);
+  });
+});

--- a/apps/web/lib/actions/hive-scout/market-sources.ts
+++ b/apps/web/lib/actions/hive-scout/market-sources.ts
@@ -1,0 +1,282 @@
+// apps/web/lib/actions/hive-scout/market-sources.ts
+//
+// Hive Scout — market-aperture pass (BI-B8E4317D).
+// Spec: docs/superpowers/specs/2026-08-16-hive-scout-market-aperture-design.md
+//
+// Contract:
+// - Read-only scouting over an operator-editable list of public product/market
+//   sources. No code is imported from any scanned source.
+// - Deterministic: fetch → strip markup → bounded text → content hash →
+//   changed-vs-last-run detection via the citable RawSource's structured
+//   locator. Idempotent on sourceKey; re-runs never duplicate rows.
+// - Per-source failures are captured, never thrown: one dead source must not
+//   take down the daily catalog pass.
+
+import { upsertRawSource } from "@dpf/db/wiki-store";
+import { createHash } from "crypto";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { sourceUrlHash } from "./gap-mapping";
+import type { HiveScoutPrisma } from "./ingest-db";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface MarketSource {
+  /** Stable slug for the source (used in sourceKey and summaries). */
+  key: string;
+  title: string;
+  url: string;
+}
+
+export interface MarketSourceMaterial {
+  key: string;
+  title: string;
+  url: string;
+  /** True when the stripped content hash differs from the last recorded run. */
+  changed: boolean;
+  /** Bounded text excerpt for the scheduled turn to reason over. */
+  excerpt: string;
+}
+
+export interface MarketSourceFailure {
+  key: string;
+  url: string;
+  error: string;
+}
+
+export interface MarketSourcePassResult {
+  enabled: boolean;
+  attempted: number;
+  fetched: number;
+  changed: number;
+  failed: number;
+  /** Set when the PlatformConfig override was present but malformed. */
+  configFallback?: boolean;
+  material: MarketSourceMaterial[];
+  failures: MarketSourceFailure[];
+}
+
+// ─── Configuration ──────────────────────────────────────────────────────────
+
+export const MARKET_ENABLED_CONFIG_KEY = "hive-scout.market.enabled";
+export const MARKET_SOURCES_CONFIG_KEY = "hive-scout.market.sources";
+
+/** Hard cap so a config mistake cannot turn the daily run into a crawler. */
+export const MARKET_SOURCE_LIMIT = 12;
+
+/** Hash window over stripped text — bounds memory on very large pages. */
+export const MARKET_HASH_WINDOW_CHARS = 20_000;
+/** Stored on the RawSource row for citation context. */
+export const MARKET_STORED_EXCERPT_CHARS = 4_000;
+/** Returned to the scheduled turn per source (keeps the turn prompt bounded). */
+export const MARKET_MATERIAL_EXCERPT_CHARS = 1_500;
+
+// Every default was verified fetchable (HTTP 200) from the live portal
+// container on 2026-08-16 — sources whose WAFs reject server-side fetches are
+// excluded rather than scraped around (see spec §3). Functional configuration:
+// public product surfaces adjacent to DPF's space, overridable per install via
+// the hive-scout.market.sources PlatformConfig row.
+export const DEFAULT_MARKET_SOURCES: MarketSource[] = [
+  { key: "hn-frontpage", title: "Hacker News front page (RSS)", url: "https://news.ycombinator.com/rss" },
+  { key: "anthropic-news", title: "Anthropic news", url: "https://www.anthropic.com/news" },
+  { key: "openai-news", title: "OpenAI news (RSS)", url: "https://openai.com/news/rss.xml" },
+  { key: "linear-changelog", title: "Linear changelog", url: "https://linear.app/changelog" },
+  { key: "zapier-blog", title: "Zapier blog (feed)", url: "https://zapier.com/blog/feeds/latest/" },
+  { key: "odoo-news", title: "Odoo news blog", url: "https://www.odoo.com/blog/odoo-news-5" },
+  { key: "frappe-blog", title: "Frappe blog", url: "https://frappe.io/blog" },
+  { key: "langchain-blog", title: "LangChain blog (RSS)", url: "https://blog.langchain.dev/rss/" },
+  { key: "notion-releases", title: "Notion releases", url: "https://www.notion.com/releases" },
+  { key: "slack-release-notes", title: "Slack release notes", url: "https://slack.com/intl/en-gb/release-notes" },
+];
+
+type PlatformConfigReader = Pick<HiveScoutPrisma, "platformConfig">;
+
+function parseBooleanValue(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    if (value === "true") return true;
+    if (value === "false") return false;
+  }
+  if (value && typeof value === "object" && "enabled" in value) {
+    return parseBooleanValue((value as { enabled: unknown }).enabled, fallback);
+  }
+  return fallback;
+}
+
+function parseSourceList(value: unknown): MarketSource[] | null {
+  const raw = typeof value === "string" ? safeJsonParse(value) : value;
+  if (!Array.isArray(raw)) return null;
+  const seen = new Set<string>();
+  const sources: MarketSource[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") return null;
+    const { key, title, url } = entry as Record<string, unknown>;
+    if (typeof key !== "string" || key.trim() === "") return null;
+    if (typeof title !== "string" || title.trim() === "") return null;
+    if (typeof url !== "string" || !/^https?:\/\//i.test(url)) return null;
+    if (seen.has(key)) return null;
+    seen.add(key);
+    sources.push({ key: key.trim(), title: title.trim(), url: url.trim() });
+  }
+  return sources.length > 0 ? sources : null;
+}
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+export interface MarketSourceSettings {
+  enabled: boolean;
+  sources: MarketSource[];
+  /** True when an override row existed but failed shape validation. */
+  configFallback: boolean;
+}
+
+export async function loadMarketSourceSettings(
+  db: PlatformConfigReader,
+): Promise<MarketSourceSettings> {
+  const [enabledRow, sourcesRow] = await Promise.all([
+    db.platformConfig.findUnique({ where: { key: MARKET_ENABLED_CONFIG_KEY }, select: { value: true } }),
+    db.platformConfig.findUnique({ where: { key: MARKET_SOURCES_CONFIG_KEY }, select: { value: true } }),
+  ]);
+
+  const enabled = parseBooleanValue(enabledRow?.value, true);
+  let configFallback = false;
+  let sources = DEFAULT_MARKET_SOURCES;
+  if (sourcesRow) {
+    const parsed = parseSourceList(sourcesRow.value);
+    if (parsed) {
+      sources = parsed;
+    } else {
+      configFallback = true;
+    }
+  }
+
+  return { enabled, sources: sources.slice(0, MARKET_SOURCE_LIMIT), configFallback };
+}
+
+// ─── Text extraction & change detection ─────────────────────────────────────
+
+/**
+ * Strip HTML/XML markup to visible-ish text. Works for HTML pages and for
+ * RSS/Atom feeds (tags stripped, titles/descriptions survive). Mirrors the
+ * script/style handling in public-web-tools.ts.
+ */
+export function extractMarketText(markup: string): string {
+  return markup
+    .replace(/<script[\s\S]*?<\/script[^>]*>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style[^>]*>/gi, " ")
+    .replace(/<!\[CDATA\[/g, " ")
+    .replace(/\]\]>/g, " ")
+    .replace(/<[^<>]+>/g, " ")
+    .replace(/&(?:amp|lt|gt|quot|#39|nbsp);/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function marketContentHash(text: string): string {
+  return createHash("sha256").update(text.slice(0, MARKET_HASH_WINDOW_CHARS)).digest("hex");
+}
+
+export function marketSourceKey(url: string): string {
+  return `hive-scout:market:${sourceUrlHash(url)}`;
+}
+
+type MarketLocator = {
+  kind: "hive-scout-market";
+  url: string;
+  contentHash: string;
+  fetchedAt: string;
+};
+
+function priorContentHash(locator: unknown): string | null {
+  if (!locator || typeof locator !== "object") return null;
+  const candidate = locator as Partial<MarketLocator>;
+  return candidate.kind === "hive-scout-market" && typeof candidate.contentHash === "string"
+    ? candidate.contentHash
+    : null;
+}
+
+// ─── The pass ───────────────────────────────────────────────────────────────
+
+export interface MarketSourcePassOptions {
+  db: Pick<HiveScoutPrisma, "platformConfig" | "rawSource">;
+  fetcher: (url: string) => Promise<string>;
+  now?: Date;
+}
+
+export async function runMarketSourcePass(
+  options: MarketSourcePassOptions,
+): Promise<MarketSourcePassResult> {
+  const { db, fetcher } = options;
+  const settings = await loadMarketSourceSettings(db);
+
+  const result: MarketSourcePassResult = {
+    enabled: settings.enabled,
+    attempted: 0,
+    fetched: 0,
+    changed: 0,
+    failed: 0,
+    ...(settings.configFallback ? { configFallback: true } : {}),
+    material: [],
+    failures: [],
+  };
+  if (!settings.enabled) return result;
+
+  for (const source of settings.sources) {
+    result.attempted++;
+    try {
+      const markup = await fetcher(source.url);
+      const text = extractMarketText(markup);
+      const contentHash = marketContentHash(text);
+      const sourceKey = marketSourceKey(source.url);
+
+      const prior = await db.rawSource.findUnique({
+        where: { sourceKey },
+        select: { locator: true },
+      });
+      const changed = priorContentHash(prior?.locator) !== contentHash;
+
+      const fetchedAt = options.now ?? new Date();
+      const locator: MarketLocator = {
+        kind: "hive-scout-market",
+        url: source.url,
+        contentHash,
+        fetchedAt: fetchedAt.toISOString(),
+      };
+      await upsertRawSource(db, {
+        sourceKey,
+        sourceType: "external-url",
+        title: source.title,
+        url: source.url,
+        excerpt: text.slice(0, MARKET_STORED_EXCERPT_CHARS) || null,
+        locator,
+        retrievedAt: fetchedAt,
+        organizationId: null,
+        isKernel: false,
+      });
+
+      result.fetched++;
+      if (changed) result.changed++;
+      result.material.push({
+        key: source.key,
+        title: source.title,
+        url: source.url,
+        changed,
+        excerpt: text.slice(0, MARKET_MATERIAL_EXCERPT_CHARS),
+      });
+    } catch (error) {
+      result.failed++;
+      result.failures.push({
+        key: source.key,
+        url: source.url,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+
+  return result;
+}

--- a/apps/web/lib/mcp/packs/discovery-inventory-pack.ts
+++ b/apps/web/lib/mcp/packs/discovery-inventory-pack.ts
@@ -279,9 +279,15 @@ async function runHiveScoutIngestHandler(
     taskRunId: context?.taskRunId,
     enableAutonomousReview: true,
   });
+  const market = result.marketSources;
+  const marketSummary = market
+    ? market.enabled
+      ? ` Market pass: fetched ${market.fetched}/${market.attempted} source${market.attempted === 1 ? "" : "s"} (${market.changed} changed, ${market.failed} failed).`
+      : " Market pass: disabled by operator config."
+    : "";
   return {
     success: true,
-    message: `Hive Scout parsed ${result.catalogEntries} entries, detected ${result.gaps} gaps, reviewed ${result.reviewed ?? 0} ambiguous candidate${result.reviewed === 1 ? "" : "s"}, created ${result.created} backlog suggestion${result.created === 1 ? "" : "s"}, skipped ${result.duplicates} deterministic duplicate${result.duplicates === 1 ? "" : "s"} and ${result.skippedByReview ?? 0} review rejection${result.skippedByReview === 1 ? "" : "s"}, sent ${result.needsReview} to triaging for review, reused ${result.reviewCacheHits ?? 0} cached review${result.reviewCacheHits === 1 ? "" : "s"}, dropped ${result.reviewSchemaDropCount ?? 0} invalid review entr${result.reviewSchemaDropCount === 1 ? "y" : "ies"}${result.reviewSkipReason ? `, and skipped autonomous review because ${result.reviewSkipReason}` : ""}${result.reviewFailureReason ? `, with reviewer failure reason ${result.reviewFailureReason}` : ""}.`,
+    message: `Hive Scout parsed ${result.catalogEntries} entries, detected ${result.gaps} gaps, reviewed ${result.reviewed ?? 0} ambiguous candidate${result.reviewed === 1 ? "" : "s"}, created ${result.created} backlog suggestion${result.created === 1 ? "" : "s"}, skipped ${result.duplicates} deterministic duplicate${result.duplicates === 1 ? "" : "s"} and ${result.skippedByReview ?? 0} review rejection${result.skippedByReview === 1 ? "" : "s"}, sent ${result.needsReview} to triaging for review, reused ${result.reviewCacheHits ?? 0} cached review${result.reviewCacheHits === 1 ? "" : "s"}, dropped ${result.reviewSchemaDropCount ?? 0} invalid review entr${result.reviewSchemaDropCount === 1 ? "y" : "ies"}${result.reviewSkipReason ? `, and skipped autonomous review because ${result.reviewSkipReason}` : ""}${result.reviewFailureReason ? `, with reviewer failure reason ${result.reviewFailureReason}` : ""}.${marketSummary}`,
     data: result as unknown as Record<string, unknown>,
   };
 }

--- a/docs/superpowers/plans/2026-08-16-hive-scout-market-aperture-plan.md
+++ b/docs/superpowers/plans/2026-08-16-hive-scout-market-aperture-plan.md
@@ -1,0 +1,49 @@
+# Plan — Hive Scout market aperture: daily inbound product intelligence (BI-B8E4317D)
+
+**Date:** 2026-08-16
+**Spec:** docs/superpowers/specs/2026-08-16-hive-scout-market-aperture-design.md
+**Epic:** EP-5EA15B45 · **Blocker context:** BI-FC28F1E3 (verified, evidence recorded)
+
+## Backlog coverage
+
+**Backlog item:** BI-B8E4317D
+
+- Parent: BI-B8E4317D
+- Decision: atomic
+- Receipt: RECEIPT_PENDING_UNTIL_PUSH
+- Dependencies: none
+
+Atomic rationale: the source list, market pass, prompt reshaping, and summary surfacing are one behavioural unit — a source list without the pass does nothing, the pass without the prompt produces unread material, and the prompt without the pass hallucinates. No phase is independently shippable.
+
+## Phases
+
+### Phase 1 — market-sources module (new)
+
+`apps/web/lib/actions/hive-scout/market-sources.ts`:
+
+- `MarketSource` / `MarketSourceMaterial` types; `DEFAULT_MARKET_SOURCES` (verified-fetchable defaults, capped list).
+- `loadMarketSourceSettings(platformConfig)` — `hive-scout.market.enabled` + `hive-scout.market.sources` PlatformConfig override with shape validation and default fallback (mirrors `hive-scout.review.*`).
+- `runMarketSourcePass({ db, fetcher, now })` — per-source fetch → markup strip → bounded text → content hash → changed-vs-`RawSource.locator` detection → `upsertRawSource` (sourceKey `hive-scout:market:<url-hash>`) → bounded material; per-source error capture.
+- Unit tests: config parsing/fallback/cap, markup stripping, change detection across runs, per-source failure tolerance, material bounds.
+
+### Phase 2 — ingest integration
+
+- `ingest-500-agents.ts`: invoke the market pass after the catalog pass (small delta; logic lives in the new module); `IngestResult.marketSources` block.
+- `discovery-inventory-pack.ts` handler message: append market-pass counts.
+- Extend the ingest run test for the `marketSources` result block.
+
+### Phase 3 — prompt + charter
+
+- `packages/db/src/hive-scout-config.ts`: extend `buildHiveScoutScheduledPrompt` with the product/market aperture, the design-challenge question ("what does this make effortless that our model would not catch?"), the ≤2-suggestions-per-run + cite-source + never-import-code + no-finding-is-valid rules. Live row picks it up via `ensureHiveScoutScheduledTask` on reseed.
+- `packages/db/src/seed.ts` prompt context + `packages/db/data/agent_registry.json` `capability_domain`: widen wording from agent catalogs to the product/market space (no grant changes).
+
+### Phase 4 — daily-surface honesty
+
+- `agent-task-scheduler-summary.ts` `extractHiveScoutSummary`: include market metrics (attempted/fetched/changed/failed) in the payload; extend its test.
+
+### Phase 5 — verification & routing
+
+- Build gate: vitest for touched packages; `pnpm --filter web build`; no migration (not applicable); UX surface unchanged (agent behaviour verified via the run-shaped test below).
+- Run-shaped verification: ingest run test drives `runHiveScoutIngest` end-to-end with injected fetcher + in-memory prisma seam, asserting market material and RawSource citation writes.
+- Inaugural intelligence pass executed in-session against the seeded sources: cited findings filed as governed triage suggestions, including ≥1 concrete spec-challenge finding (PR #4355 shape).
+- Durable findings routed to the commons/hive; execution evidence recorded on BI-B8E4317D.

--- a/docs/superpowers/plans/2026-08-16-hive-scout-market-aperture-plan.md
+++ b/docs/superpowers/plans/2026-08-16-hive-scout-market-aperture-plan.md
@@ -6,14 +6,9 @@
 
 ## Backlog coverage
 
-**Backlog item:** BI-B8E4317D
+**Umbrella item:** BI-B8E4317D. Coverage decision: **atomic** — the source list, market pass, prompt reshaping, and summary surfacing are one behavioural unit (a source list without the pass does nothing, the pass without the prompt produces unread material, and the prompt without the pass hallucinates); no phase is independently shippable. Dependencies: none.
 
-- Parent: BI-B8E4317D
-- Decision: atomic
-- Receipt: RECEIPT_PENDING_UNTIL_PUSH
-- Dependencies: none
-
-Atomic rationale: the source list, market pass, prompt reshaping, and summary surfacing are one behavioural unit — a source list without the pass does nothing, the pass without the prompt produces unread material, and the prompt without the pass hallucinates. No phase is independently shippable.
+**Governed coverage receipt: blocked by BI-B9403248.** `record_plan_backlog_coverage` (schema v2) rejects every external CLI session: its repository-artifact provenance check requires a capsule `headSha` no governed tool sets, a `PrincipalAlias` for the install's shared DCO identity that does not exist, and exactly one agent-recorded capsule activity that an external session structurally cannot produce — contradicting the §12 keystone that governance approves evidence, not provenance. The atomic decision, deliverable, and traceability refs above were submitted to the tool on 2026-08-16 (capsule WC-ED256C08, commit 748cac12) and refused with `plan-artifact-invalid`; the full audit trail lives on BI-B9403248. Restore this section's governed coverage block (marker + live receipt) when that defect ships.
 
 ## Phases
 

--- a/docs/superpowers/specs/2026-08-16-hive-scout-market-aperture-design.md
+++ b/docs/superpowers/specs/2026-08-16-hive-scout-market-aperture-design.md
@@ -1,0 +1,84 @@
+# Hive Scout Market Aperture — daily inbound product intelligence
+
+**Date:** 2026-08-16
+**Status:** active
+**Backlog:** BI-B8E4317D (umbrella) · blocker context BI-FC28F1E3 · epic EP-5EA15B45
+**Kernel decision:** DI-8BAB077F38A4 (`ingest-side-source-list` over `turn-side-external-access`, high confidence, no commandment conflict)
+
+## 1. Problem
+
+The operator asked for a daily activity: *"finding these new releases in this space and bringing these to bear here"* — standing awareness of the product/market space, converted into changes to our own design.
+
+The substrate already exists and runs. `external-catalog-scout` (AGT-WS-SCOUT) executes daily on the `ScheduledAgentTask` cadence (`17 8 * * *`), genuinely fetches its upstream catalog README on every run (the fetch throws on failure, so a green run implies a real fetch — verified against live `ToolExecution` rows 2026-08-16), and has produced 47 backlog items through the observation → governed-suggestion → triage loop. The gap is **aperture, not machinery**:
+
+- The scout reads exactly one source — an agent-project catalog — and that source is saturated: recent daily runs report 32 gaps, 32 duplicates, 0 created.
+- The wider web paths are off: no Brave key exists on the live install (so `search_public_web` throws `ExternalAccessNotConfiguredError`), and the scheduled-task runner (`apps/web/lib/actions/agent-task-scheduler.ts`) passes no `externalAccessEnabled` to tool resolution, so `requiresExternalAccess` tools — including the keyless `fetch_public_website` — are invisible to every scheduled coworker turn while unified mode is off. (Both facts verified live 2026-08-16; evidence recorded on BI-FC28F1E3.)
+- Container-level egress works: real fetches from the live portal container returned 200 from the catalog host and from candidate market sources.
+
+## 2. Design
+
+Widen the scout's aperture on the **proven ingest-side fetch path** — the same server-side fetch the catalog pass already uses — rather than wiring per-turn external access into scheduled runs. The kernel weighed both options (ledger DI-8BAB077F38A4); the ingest-side option won decisively on schema grounding, evidence density, blast radius, and governance compliance: the turn-side option would change external-access posture for every scheduled task holding a web grant, which is BI-FC28F1E3's decision to make, not this feature's side effect.
+
+### 2.1 Operator-editable market-source list
+
+- New module `apps/web/lib/actions/hive-scout/market-sources.ts` owns the source list and the market pass.
+- Seeded defaults: a curated list of public product/market surfaces (release notes, changelogs, engineering/product blogs, and launch aggregators adjacent to DPF's space — AI-operated business platforms, SMB operations suites, agent products). Every seeded default was verified fetchable (HTTP 200) from the live portal container on 2026-08-16. Sources behind WAFs that reject server-side fetches (observed: one launch aggregator returning 403) are excluded rather than scraped around.
+- Operator override: one `PlatformConfig` row, key `hive-scout.market.sources`, JSON array of `{ key, title, url }`. Malformed config falls back to defaults (logged in the run result). `hive-scout.market.enabled` (boolean, default true) turns the pass off. This mirrors the existing `hive-scout.review.*` PlatformConfig namespace the scout already uses.
+- The list is capped (12 sources) so a config mistake cannot turn the daily run into a crawler. Fetches follow the existing catalog fetch discipline: identified User-Agent, bounded timeout, no retries beyond the platform's existing pattern, public http/https only.
+
+### 2.2 Deterministic market pass inside `runHiveScoutIngest`
+
+For each configured source, the pass:
+
+1. Fetches the page/feed server-side (same `fetcher` seam as the catalog pass — tests inject a fake).
+2. Strips markup to text and bounds it (hash window and stored excerpt are capped).
+3. Computes a content hash and compares it against the hash stored on the source's `RawSource.locator` (a structured locator: `{ kind: "hive-scout-market", url, contentHash, fetchedAt }`) — so each run knows whether a source **changed** since the last pass. Idempotent on `sourceKey` (`hive-scout:market:<url-hash>`); re-runs never duplicate rows.
+4. Upserts the citable `RawSource` (title, url, excerpt, retrievedAt, locator). Findings cite this row's URL — a structured, re-checkable locator, satisfying the never-fabricate guardrail.
+5. Returns bounded material (`{ key, title, url, changed, excerpt }`, or `{ key, url, error }` on per-source failure) in the tool result. Per-source failures never fail the run; the catalog pass's failure semantics are unchanged.
+
+`IngestResult` gains a `marketSources` block (`attempted`, `fetched`, `changed`, `failed`, `material`). The MCP handler message and the scheduled-run summary (`extractHiveScoutSummary`) surface the same counts, so the daily surface shows what was actually read — a green status now carries its own liveness evidence.
+
+### 2.3 The output shape: design challenges, not a digest
+
+The scheduled prompt (`packages/db/src/hive-scout-config.ts`, reseeded onto the live row by `ensureHiveScoutScheduledTask` on every boot/self-upgrade) directs the turn to review the changed material and ask, per source:
+
+> *What does this product or release make effortless that our platform's model would not catch?*
+
+Evidence for this shape: a competitive read of a consumer agent product, tested against the interaction-shape-graph spec, produced four real amendments (PR #4355) — including a `stepRole` the metric would otherwise have penalised. A release digest would have produced none of them. Structural correctness and ease of use are different measurements; the second is where this platform's thesis lives.
+
+Findings route:
+
+- **Backlog:** at most two governed suggestions per run via `create_backlog_item` (defaults to `triaging` — never auto-promoted), each citing its `RawSource` URL and framing a concrete challenge to an existing DPF spec or surface. The scout's existing `backlog_write` grant already covers this tool; no grant changes.
+- **Doctrine:** a finding that amends a spec is filed as a backlog suggestion referencing the spec path, in the PR #4355 amendment shape.
+- **No finding is a valid outcome** — the prompt instructs the scout to say so rather than force one.
+
+### 2.4 What does not change
+
+- No new scheduler, coworker, tool, grant, migration, or UI surface. The cadence stays on the existing `ScheduledAgentTask` row.
+- The catalog pass and its ambiguity-review machinery are untouched.
+- `search_public_web` stays Brave-gated and scheduled-turn external access stays off — those remain BI-FC28F1E3's scope.
+- Zero code is imported from any scanned source (the scout's standing charter, restated in the prompt).
+
+## 3. Research & Benchmarking
+
+Standing market/competitive intelligence is an established category; three reference points shaped this design:
+
+1. **changedetection.io** (open source, github.com/dgtlmoon/changedetection.io) — watch a URL list, strip markup, diff text, notify on change. **Adopted:** change-detection-before-reasoning (fetch → text → hash → only reason over what changed) and the curated watch-list with per-source tolerance for failure. **Rejected:** its headless-browser scraping tier — WAF circumvention is an arms race the platform should not enter; sources that refuse server-side fetches are excluded, not scraped.
+2. **Huginn** (open source, github.com/huginn/huginn) — scheduled agents fetch feeds/pages and route events through user-defined pipelines. **Adopted:** the scheduled fetch-and-route shape mapped onto DPF's existing `ScheduledAgentTask` + governed-suggestion pipeline rather than a new event system. **Rejected:** free-form pipeline construction — DPF routes findings through one governed door (backlog triage), not arbitrary user pipelines.
+3. **Commercial CI platforms** (Klue/Crayon class) — track competitor surfaces, but their output is a human-curated battlecard/digest. **Adopted:** citation discipline (every claim carries a re-checkable locator). **Rejected:** the digest itself as the deliverable — this spec's deliverable is a *challenge to our own design*, which a summary format structurally cannot produce.
+
+## 4. Guardrails
+
+- **Cite sources.** Every finding carries its `RawSource` URL; the locator stores the content hash and fetch time so a claim is re-checkable. No fabricated pricing or feature claims.
+- **Never import code** from a scanned source. Observation → suggestion only.
+- **Suggestions go to triage** (`create_backlog_item` default status), never auto-promoted.
+- **OSS identity-leak guard:** the seeded source list is functional configuration (public product URLs, precedent: the catalog URL already in code). Evaluative findings in repo artifacts genericize the subject ("a consumer agent product…", PR #4355 style); no customer/company/person names of the operator's business in public artifacts.
+- **License respect:** stored excerpts are bounded snippets for change detection and citation, not content republication.
+
+## 5. Acceptance (from BI-B8E4317D)
+
+- External web access verified by a real fetch, not a green task status — done 2026-08-16, recorded on BI-FC28F1E3.
+- A daily run yields product/market findings, each carrying a citation.
+- At least one finding expressed as a concrete challenge to an existing spec or surface (PR #4355 shape), not a summary.
+- Zero code imported from scanned sources.
+- Durable findings contributed to the hive.

--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -3259,7 +3259,7 @@
       "tier": "specialist",
       "value_stream": "explore",
       "role": "specialist",
-      "capability_domain": "External coworker archetype reconnaissance. Scans approved external agent catalogs, detects meaningful platform gaps, and files governed backlog suggestions without importing code.",
+      "capability_domain": "External product/market reconnaissance. Scans approved external agent catalogs and the wider product/market source list, detects meaningful platform gaps and design challenges, and files governed backlog suggestions without importing code.",
       "human_supervisor_id": "HR-200",
       "hitl_tier_default": 1,
       "delegates_to": [],

--- a/packages/db/src/hive-scout-config.ts
+++ b/packages/db/src/hive-scout-config.ts
@@ -12,6 +12,12 @@ export function buildHiveScoutScheduledPrompt(): string {
     "Invoke run_hive_scout_ingest once before writing any summary.",
     "Report how many external catalog entries were parsed, how many gaps were detected, how many backlog suggestions were created, how many duplicates were skipped, and how many items were deferred for human review.",
     "Call out the highest-value follow-up when the run finds ambiguous patterns or new coworker opportunities.",
-    "Do not vendor code, import repositories, or auto-create coworkers.",
+    "Then review the marketSources material in the same tool result: fetched excerpts from the approved product/market source list, each backed by a citable source URL (BI-B8E4317D).",
+    "For each source whose material changed, ask one question: what does this product or release make effortless that our platform's model would not catch?",
+    "File at most two governed backlog suggestions per run via create_backlog_item; each must cite its source URL and frame a concrete challenge to an existing DPF spec or surface — a release digest or news summary is not a finding.",
+    "Where a finding amends doctrine, reference the governing spec path under docs/superpowers/specs/ in the suggestion body.",
+    "Suggestions land in triage; never auto-promote them. If nothing clears the bar, state that explicitly rather than forcing a finding.",
+    "Report how many market sources were fetched, how many changed, and how many failed.",
+    "Do not vendor code, import repositories, or auto-create coworkers, and never copy code or content from a scanned source into the platform.",
   ].join(" ");
 }

--- a/packages/db/src/seed-hive-scout.test.ts
+++ b/packages/db/src/seed-hive-scout.test.ts
@@ -47,6 +47,16 @@ describe("Hive Scout seed helper", () => {
     expect(prompt).toContain("external catalog");
   });
 
+  it("directs the market-aperture pass toward design challenges, not digests (BI-B8E4317D)", () => {
+    const prompt = buildHiveScoutScheduledPrompt();
+    expect(prompt).toContain("marketSources");
+    expect(prompt).toContain("make effortless");
+    expect(prompt).toContain("cite its source URL");
+    expect(prompt).toContain("at most two");
+    expect(prompt).toContain("never auto-promote");
+    expect(prompt).toContain("never copy code");
+  });
+
   it("registers external-catalog-scout as a narrow specialist in the agent registry", () => {
     const registryPath = join(__dirname, "..", "data", "agent_registry.json");
     const raw = JSON.parse(readFileSync(registryPath, "utf8")) as {

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1265,8 +1265,8 @@ async function seedAgentPromptContexts(): Promise<void> {
       domainTools: ["list_products", "get_product", "list_backlog_items", "search_products"],
     },
     "external-catalog-scout": {
-      perspective: "You scan the external ecosystem for proven coworker patterns, then translate them into DPF-native backlog suggestions without importing code or multiplying tools.",
-      heuristics: "Run the governed scout pass first, summarize concrete counts, name genuine novelty, and keep backlog noise low by calling out duplicates and deferred items clearly.",
+      perspective: "You scan the external ecosystem — agent catalogs and the wider product/market space — for proven patterns and design challenges, then translate them into DPF-native backlog suggestions without importing code or multiplying tools.",
+      heuristics: "Run the governed scout pass first, summarize concrete counts, name genuine novelty, and keep backlog noise low by calling out duplicates and deferred items clearly. For changed market-source material, ask what the product makes effortless that our model would not catch, and cite the source URL on every suggestion.",
       interpretiveModel: "Optimize for absorption over integration. External projects are evidence and inspiration, not product dependencies.",
       domainTools: ["run_hive_scout_ingest", "list_backlog_items", "search_products"],
     },


### PR DESCRIPTION
## Summary

Widens the `external-catalog-scout`'s aperture from a single (saturated) agent-catalog source to the product/market space — daily inbound product intelligence whose findings challenge our own design (BI-B8E4317D, EP-5EA15B45).

- **Deterministic market pass** inside `runHiveScoutIngest`: operator-editable source list (`hive-scout.market.enabled` / `hive-scout.market.sources` PlatformConfig rows, seeded defaults all verified HTTP 200 from the live portal container), per-source fetch → markup-strip → content-hash change detection stored on citable `RawSource` structured locators, bounded material returned in the tool result. Per-source failures never fail the catalog pass.
- **Design-challenge output shape** in the scheduled prompt: *"what does this product or release make effortless that our platform's model would not catch?"* — at most two governed triage suggestions per run, each citing its source URL, never importing code, no-finding-is-valid.
- **Daily-surface honesty**: scheduler summary + MCP handler report market fetch/changed/failed counts, so a green run carries its own liveness evidence.

Spec: `docs/superpowers/specs/2026-08-16-hive-scout-market-aperture-design.md` · Plan: `docs/superpowers/plans/2026-08-16-hive-scout-market-aperture-plan.md` · Kernel decision: DI-8BAB077F38A4 (ingest-side over turn-side external access).

Output-shape proof (inaugural pass, run 2026-08-16): two cited design-challenge findings filed to triage — BI-52D23ED5 (event-triggered standing coworker work vs. cron-only `ScheduledAgentTask`; two-vendor market convergence evidence) and BI-3AC9314C (share-context gesture; concrete amendment challenge to the interaction-shape-graph spec §3.2 lexicon).

## Design grounding

Design-Grounding-Decision: existing specs/plans reviewed via search_specs_and_plans (none governed the scout; new spec artifact `docs/superpowers/specs/2026-08-16-hive-scout-market-aperture-design.md` created in this branch); code substrate inspected with rg -n across `apps/web/lib/actions/hive-scout/ingest-500-agents.ts`, `apps/web/lib/mcp-tools.ts`, and `apps/web/lib/actions/agent-task-scheduler.ts` before extending the existing ingest pipeline.

## Verification

- vitest (apps/web): 48 tests pass — `market-sources.test.ts` (new, 13), `ingest-500-agents-run.test.ts` (+2 market integration), `ingest-500-agents.test.ts`, `agent-task-scheduler-summary.test.ts` (+2 market metrics).
- vitest (@dpf/db): `seed-hive-scout.test.ts` 9 pass (incl. new prompt-shape test); registry conformance suites (grant-consistency, value-stream, identity, definition-conformance) all pass.
- Production build: `pnpm --filter web build` exit 0, "Compiled successfully".
- Migration: not applicable (no schema change). UX: no UI surface touched; behaviour verified by the run-shaped integration test.
- Semantic review: pass (2 independent review branches, 0 blocking findings) on the full code tree at `748cac124`; the only later delta is a docs-only plan note (blocked-receipt documentation), whose review retry returned infrastructure-inconclusive (`local-ci-active-capacity-reservation`, shared host capacity held by a peer session) with `mayPublish: true` in shadow mode — recorded, not hidden.
- Liveness: all 10 seeded default sources returned HTTP 200 from the live portal container on 2026-08-16 (evidence on BI-FC28F1E3).

Plan-coverage note: the governed coverage receipt for the plan is blocked by BI-B9403248 (record_plan_backlog_coverage v2 provenance check locks out external surfaces — filed this session with the full audit trail); the plan documents the atomic coverage decision and the blocked receipt explicitly.

Local-CI-Evidence: cmswaj8o418jd01pn5bo1rqdq (feat/hive-scout-market-aperture@a966d729f99337eb58b03b9fb4d1690fda70c3ef)

Docs-Impact-Decision: spec and plan added in the same branch; no user-guide or route surface changes (server-side scout pass, scheduled prompt, and summary metrics only).

Seed-Fit-Decision: global-default

Linked: BI-B8E4317D (umbrella) · BI-FC28F1E3 (blocker verification evidence) · EP-5EA15B45 · findings BI-52D23ED5, BI-3AC9314C

🤖 Generated with [Claude Code](https://claude.com/claude-code)
