### PR TITLE
feat(lifecycle): stance ↔ lifecycle consistency guard — block a stance-negating structural change (BI-EAD441E0 S1+S2)

### DIFF
--- a/apps/web/lib/lifecycle/grammar-consistency-check.test.ts
+++ b/apps/web/lib/lifecycle/grammar-consistency-check.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGrammarSnapshot, serializeSnapshot, resolveDependency } from "./grammar-negation";
+import { checkGrammarConsistency } from "./grammar-consistency-check";
+import { KERNEL_STANCE_DEPENDENCIES } from "./stance-lifecycle-dependencies";
+
+// BI-EAD441E0 slice S2 — behavioral proof of the consistency check + kernel couplings,
+// independent of the frozen baseline file (which the sibling guard test pins).
+
+describe("checkGrammarConsistency", () => {
+  const liveBaseline = serializeSnapshot(buildGrammarSnapshot());
+
+  it("is in sync and finds nothing when baseline matches the live grammars", () => {
+    const r = checkGrammarConsistency(liveBaseline);
+    expect(r.inSync).toBe(true);
+    expect(r.negating).toEqual([]);
+    expect(r.weakening).toEqual([]);
+  });
+
+  it("BLOCKS: a current snapshot that removed ovsm::retain negates the recurring-use kernel stance", () => {
+    // Build a mutated "current" with the retain stage gone, keeping the real
+    // baseline as "previous".
+    const mutated = buildGrammarSnapshot();
+    for (const key of Object.keys(mutated.stages)) {
+      if (key.startsWith("ovsm::retain")) delete mutated.stages[key];
+    }
+    for (const key of Object.keys(mutated.states)) {
+      if (key.startsWith("ovsm::retain::")) delete mutated.states[key];
+    }
+    const r = checkGrammarConsistency(liveBaseline, KERNEL_STANCE_DEPENDENCIES, mutated);
+    expect(r.inSync).toBe(false);
+    expect(r.negating).toHaveLength(1);
+    expect(r.negating[0]).toMatchObject({
+      slug: "stances/how-do-we-manage-the-business-and-what-is-the-goal-of-a-customer-relationship",
+      delta: "removed",
+      severity: "negating",
+    });
+  });
+
+  it("throws (fails loud) on an unparseable baseline rather than reporting a clean pass", () => {
+    expect(() => checkGrammarConsistency("{ not valid")).toThrow();
+  });
+});
+
+describe("KERNEL_STANCE_DEPENDENCIES", () => {
+  it("every declared kernel coupling resolves against the live grammars", () => {
+    // A coupling that points at a non-existent grammar element is dead weight —
+    // catch it here so the kernel couplings stay real.
+    for (const stance of KERNEL_STANCE_DEPENDENCIES) {
+      for (const dep of stance.dependencies) {
+        expect(
+          resolveDependency(dep),
+          `kernel coupling ${stance.slug} -> ${dep.grammar}::${dep.stage}${dep.state ? "::" + dep.state : ""} does not resolve`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/apps/web/lib/lifecycle/grammar-consistency-check.ts
+++ b/apps/web/lib/lifecycle/grammar-consistency-check.ts
@@ -1,0 +1,56 @@
+// BI-EAD441E0 slice S2 — the shared consistency check, run by BOTH the CI guard
+// test and the baseline `--update` script so the two can never diverge.
+//
+// The committed snapshot baseline (lifecycle-grammar-snapshot.json) is the LAST
+// ACCEPTED grammar structure. This check builds the CURRENT snapshot from the live
+// grammars and, when they differ, runs the negation analysis over the declared
+// kernel stance couplings:
+//   - a change that negates a stance (removes/renames a depended element) → BLOCK;
+//   - a benign structural change (additions, or edits nothing depends on) → the
+//     baseline is stale and must be re-frozen via the `--update` script, a
+//     deliberate reviewed step (structural evolution is a first-class propagated
+//     concern, not an ad-hoc drift).
+
+import {
+  analyzeGrammarNegation,
+  buildGrammarSnapshot,
+  serializeSnapshot,
+  type GrammarSnapshot,
+  type NegationFinding,
+  type StanceDependencies,
+} from "./grammar-negation";
+import { KERNEL_STANCE_DEPENDENCIES } from "./stance-lifecycle-dependencies";
+
+export type ConsistencyResult = {
+  /** True when the committed baseline already matches the live grammars. */
+  inSync: boolean;
+  /** Negating findings — a structural change invalidated a stance's stated intent. MUST block. */
+  negating: NegationFinding[];
+  /** Weakening findings — a depended element changed meaning but still exists. Surface. */
+  weakening: NegationFinding[];
+  /** The freshly-built current snapshot, serialized — what `--update` would write. */
+  currentSerialized: string;
+};
+
+/**
+ * Run the consistency check. Pure except for reading the live grammar registry
+ * via `buildGrammarSnapshot()`; callers pass the committed baseline text and,
+ * optionally, an override stance set (tests use a fixture).
+ */
+export function checkGrammarConsistency(
+  baselineSerialized: string,
+  stances: readonly StanceDependencies[] = KERNEL_STANCE_DEPENDENCIES,
+  currentSnapshot: GrammarSnapshot = buildGrammarSnapshot(),
+): ConsistencyResult {
+  const currentSerialized = serializeSnapshot(currentSnapshot);
+  const inSync = currentSerialized === baselineSerialized;
+
+  const previous = JSON.parse(baselineSerialized) as GrammarSnapshot;
+  const findings = analyzeGrammarNegation(previous, currentSnapshot, stances);
+  return {
+    inSync,
+    negating: findings.filter((f) => f.severity === "negating"),
+    weakening: findings.filter((f) => f.severity === "weakening"),
+    currentSerialized,
+  };
+}

--- a/apps/web/lib/lifecycle/grammar-negation.test.ts
+++ b/apps/web/lib/lifecycle/grammar-negation.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+
+import type { LifecycleHealthBand } from "@/lib/lifecycle-grammar";
+import {
+  analyzeGrammarNegation,
+  buildGrammarSnapshot,
+  parseLifecycleDependencies,
+  resolveDependency,
+  serializeSnapshot,
+  type GrammarSnapshot,
+} from "./grammar-negation";
+
+// Deep-MUTABLE mirror of the grammar shape so the fixture can be edited freely in
+// tests (the real LifecycleGrammar arrays are readonly). A mutable structure is
+// still assignable to buildGrammarSnapshot's readonly-typed parameter.
+type MutState = { key: string; label: string; band: LifecycleHealthBand; isEntry?: boolean; isExitReady?: boolean };
+type MutStage = {
+  key: string;
+  label: string;
+  advancesTo: string[];
+  isTerminal?: boolean;
+  exitCriteria?: string[];
+  staleAfterDays?: number;
+  states: MutState[];
+};
+type MutGrammar = { key: string; label: string; stages: MutStage[] };
+
+// A tiny two-grammar fixture registry, including a `retain` stage so the BI's
+// named regression (gutting OVSM retain while a stance depends on it) is exercised
+// without coupling the test to the live grammar corpus.
+function fixtureRegistry(): Record<string, MutGrammar> {
+  return {
+    ovsm: {
+      key: "ovsm",
+      label: "Operational value stream",
+      stages: [
+        {
+          key: "acquire",
+          label: "Acquire",
+          advancesTo: ["retain"],
+          exitCriteria: ["first value delivered"],
+          states: [{ key: "open", label: "Open", band: "on-track", isEntry: true, isExitReady: true }],
+        },
+        {
+          key: "retain",
+          label: "Retain",
+          advancesTo: [],
+          isTerminal: true,
+          exitCriteria: ["renewal secured"],
+          states: [
+            { key: "active", label: "Active", band: "on-track", isEntry: true },
+            { key: "at_risk", label: "At risk", band: "blocked" },
+          ],
+        },
+      ],
+    },
+    account: {
+      key: "account",
+      label: "Account",
+      stages: [
+        {
+          key: "closed",
+          label: "Closed",
+          advancesTo: [],
+          isTerminal: true,
+          states: [{ key: "closed", label: "Closed", band: "on-track", isEntry: true }],
+        },
+      ],
+    },
+  };
+}
+
+describe("parseLifecycleDependencies", () => {
+  it("reads valid dependencies, carrying state only when present", () => {
+    const deps = parseLifecycleDependencies({
+      lifecycleDependencies: [
+        { grammar: "ovsm", stage: "retain" },
+        { grammar: "ovsm", stage: "retain", state: "active" },
+      ],
+    });
+    expect(deps).toEqual([
+      { grammar: "ovsm", stage: "retain" },
+      { grammar: "ovsm", stage: "retain", state: "active" },
+    ]);
+  });
+
+  it("returns [] for absent / non-array / malformed metadata without throwing", () => {
+    expect(parseLifecycleDependencies(null)).toEqual([]);
+    expect(parseLifecycleDependencies("nope")).toEqual([]);
+    expect(parseLifecycleDependencies({})).toEqual([]);
+    expect(parseLifecycleDependencies({ lifecycleDependencies: "x" })).toEqual([]);
+    // entries missing grammar or stage, or of wrong type, are dropped individually
+    expect(
+      parseLifecycleDependencies({
+        lifecycleDependencies: [
+          { stage: "retain" },
+          { grammar: "ovsm" },
+          { grammar: 3, stage: "retain" },
+          "junk",
+          { grammar: "ovsm", stage: "retain", state: 9 },
+        ],
+      }),
+    ).toEqual([{ grammar: "ovsm", stage: "retain" }]); // last entry keeps stage, drops bad state
+  });
+});
+
+describe("buildGrammarSnapshot + resolveDependency", () => {
+  it("captures every stage and state with its semantic descriptor", () => {
+    const snap = buildGrammarSnapshot(fixtureRegistry());
+    expect(snap.stages["ovsm::retain"]).toEqual({
+      label: "Retain",
+      exitCriteria: ["renewal secured"],
+    });
+    expect(snap.states["ovsm::retain::at_risk"]).toEqual({ label: "At risk", band: "blocked" });
+  });
+
+  it("serializes deterministically (sorted keys, stable bytes)", () => {
+    const a = serializeSnapshot(buildGrammarSnapshot(fixtureRegistry()));
+    const b = serializeSnapshot(buildGrammarSnapshot(fixtureRegistry()));
+    expect(a).toBe(b);
+    expect(a.endsWith("\n")).toBe(true);
+  });
+
+  it("resolves stage-level and state-level deps; rejects unknowns", () => {
+    const reg = fixtureRegistry();
+    expect(resolveDependency({ grammar: "ovsm", stage: "retain" }, reg)).toBe(true);
+    expect(resolveDependency({ grammar: "ovsm", stage: "retain", state: "at_risk" }, reg)).toBe(true);
+    expect(resolveDependency({ grammar: "ovsm", stage: "gone" }, reg)).toBe(false);
+    expect(resolveDependency({ grammar: "ovsm", stage: "retain", state: "gone" }, reg)).toBe(false);
+    expect(resolveDependency({ grammar: "nope", stage: "retain" }, reg)).toBe(false);
+  });
+});
+
+describe("analyzeGrammarNegation", () => {
+  const previous = buildGrammarSnapshot(fixtureRegistry());
+
+  function withMutation(mut: (reg: Record<string, MutGrammar>) => void): GrammarSnapshot {
+    const reg = fixtureRegistry();
+    mut(reg);
+    return buildGrammarSnapshot(reg);
+  }
+
+  it("REGRESSION: gutting the retain stage while a stance depends on it is caught as negating", () => {
+    const current = withMutation((reg) => {
+      reg.ovsm.stages = reg.ovsm.stages.filter((s) => s.key !== "retain");
+    });
+    const findings = analyzeGrammarNegation(previous, current, [
+      { slug: "stances/recurring-use-is-the-goal", dependencies: [{ grammar: "ovsm", stage: "retain" }] },
+    ]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      slug: "stances/recurring-use-is-the-goal",
+      delta: "removed",
+      severity: "negating",
+    });
+  });
+
+  it("catches a removed in-stage STATE a stance depends on", () => {
+    const current = withMutation((reg) => {
+      reg.ovsm.stages[1].states = reg.ovsm.stages[1].states.filter((s) => s.key !== "at_risk");
+    });
+    const findings = analyzeGrammarNegation(previous, current, [
+      { slug: "stances/watch-at-risk", dependencies: [{ grammar: "ovsm", stage: "retain", state: "at_risk" }] },
+    ]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ delta: "removed", severity: "negating" });
+  });
+
+  it("treats a rename as a removal of the old key (negating)", () => {
+    const current = withMutation((reg) => {
+      reg.ovsm.stages[1] = { ...reg.ovsm.stages[1], key: "renew" };
+    });
+    const findings = analyzeGrammarNegation(previous, current, [
+      { slug: "stances/x", dependencies: [{ grammar: "ovsm", stage: "retain" }] },
+    ]);
+    expect(findings[0]).toMatchObject({ delta: "removed", severity: "negating" });
+  });
+
+  it("flags a re-semanticized (label/band/exit-criteria changed) element as weakening", () => {
+    const current = withMutation((reg) => {
+      reg.ovsm.stages[1] = { ...reg.ovsm.stages[1], exitCriteria: ["something entirely different"] };
+    });
+    const findings = analyzeGrammarNegation(previous, current, [
+      { slug: "stances/x", dependencies: [{ grammar: "ovsm", stage: "retain" }] },
+    ]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ delta: "resemanticized", severity: "weakening" });
+  });
+
+  it("flags a state band change as weakening", () => {
+    const current = withMutation((reg) => {
+      reg.ovsm.stages[1].states = reg.ovsm.stages[1].states.map((s) =>
+        s.key === "at_risk" ? { ...s, band: "ready" } : s,
+      );
+    });
+    const findings = analyzeGrammarNegation(previous, current, [
+      { slug: "stances/x", dependencies: [{ grammar: "ovsm", stage: "retain", state: "at_risk" }] },
+    ]);
+    expect(findings[0]).toMatchObject({ delta: "resemanticized", severity: "weakening" });
+  });
+
+  it("reports NOTHING when an unrelated element changes or an element is added", () => {
+    const current = withMutation((reg) => {
+      // change a stage nobody depends on + add a brand-new stage
+      reg.account.stages[0] = { ...reg.account.stages[0], label: "Closed/Lost" };
+      reg.ovsm.stages.push({ key: "expand", label: "Expand", advancesTo: [], states: [] });
+    });
+    const findings = analyzeGrammarNegation(previous, current, [
+      { slug: "stances/x", dependencies: [{ grammar: "ovsm", stage: "retain" }] },
+    ]);
+    expect(findings).toEqual([]);
+  });
+
+  it("skips a dependency that was never valid in the previous snapshot (not this change's doing)", () => {
+    const current = buildGrammarSnapshot(fixtureRegistry());
+    const findings = analyzeGrammarNegation(previous, current, [
+      { slug: "stances/bad", dependencies: [{ grammar: "ovsm", stage: "never-existed" }] },
+    ]);
+    expect(findings).toEqual([]);
+  });
+
+  it("emits at most one finding per dependency, preferring removal over re-semanticization", () => {
+    const current = withMutation((reg) => {
+      // remove the whole stage AND (moot) it would also count as a label change — removal wins
+      reg.ovsm.stages = reg.ovsm.stages.filter((s) => s.key !== "retain");
+    });
+    const findings = analyzeGrammarNegation(previous, current, [
+      { slug: "stances/x", dependencies: [{ grammar: "ovsm", stage: "retain", state: "active" }] },
+    ]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].delta).toBe("removed");
+  });
+});

--- a/apps/web/lib/lifecycle/grammar-negation.ts
+++ b/apps/web/lib/lifecycle/grammar-negation.ts
@@ -1,0 +1,244 @@
+// BI-EAD441E0 slice S1 — the pure detection core of the stance ↔ lifecycle
+// consistency guard.
+//
+// Lifecycle structure (the stage/state grammar, BI-E55991E9) and the governance
+// stances (WWWD corpus) are COUPLED. A structural change that removes, renames,
+// or re-semanticizes a grammar element a stance DEPENDS ON must be detected so it
+// can be routed through governance rather than silently invalidating stated
+// intent (e.g. gutting the OVSM `retain` stage while a stance says continued use
+// is the goal).
+//
+// This module is PURE — no I/O, no DB, no throw. It is consumed by:
+//   - the CI structural guard (S2, scripts/check-lifecycle-stance-consistency.mjs)
+//     which diffs a committed snapshot baseline against the current grammars, and
+//   - the per-install runtime routing (S3, BI-696B91AB) which runs the SAME
+//     analysis against the install's live stance corpus.
+// One analyzer, both surfaces — the detection can never diverge between them.
+
+import type { LifecycleGrammar } from "@/lib/lifecycle-grammar";
+import { LIFECYCLE_GRAMMARS } from "@/lib/lifecycle-grammars";
+
+// ─── Coupling model ───────────────────────────────────────────────────────────
+
+/**
+ * A stance's declared dependency on a grammar element. Stored in the existing
+ * free-form `WikiPage.metadata` JSON column (key `lifecycleDependencies`), so a
+ * negation is DETECTABLE rather than guessed. `state` is optional — a stance may
+ * depend on a whole stage (e.g. "retain exists") or a specific in-stage state.
+ */
+export type LifecycleDependency = {
+  grammar: string;
+  stage: string;
+  state?: string;
+};
+
+// ─── Snapshot ─────────────────────────────────────────────────────────────────
+
+/** Semantic descriptor of one stage — the fields whose change is re-semanticization. */
+export type StageDescriptor = { label: string; exitCriteria: string[] };
+/** Semantic descriptor of one in-stage state. */
+export type StateDescriptor = { label: string; band: string };
+
+/**
+ * A deterministic, serializable projection of the declared grammars. Keyed so a
+ * removed/renamed element is a missing key and a re-semanticized element is a
+ * changed value. This is what the S2 baseline freezes and diffs against.
+ */
+export type GrammarSnapshot = {
+  stages: Record<string, StageDescriptor>; // key: `${grammar}::${stage}`
+  states: Record<string, StateDescriptor>; // key: `${grammar}::${stage}::${state}`
+};
+
+export function stageKey(grammar: string, stage: string): string {
+  return `${grammar}::${stage}`;
+}
+export function stateKey(grammar: string, stage: string, state: string): string {
+  return `${grammar}::${stage}::${state}`;
+}
+
+/**
+ * Build a snapshot from a grammar registry (defaults to the live
+ * `LIFECYCLE_GRAMMARS`). Pure and deterministic: keys are sorted on serialize by
+ * the caller (see `serializeSnapshot`), so the same registry always yields the
+ * same bytes.
+ */
+export function buildGrammarSnapshot(
+  registry: Record<string, LifecycleGrammar> = LIFECYCLE_GRAMMARS,
+): GrammarSnapshot {
+  const stages: Record<string, StageDescriptor> = {};
+  const states: Record<string, StateDescriptor> = {};
+  for (const grammar of Object.values(registry)) {
+    for (const stage of grammar.stages) {
+      stages[stageKey(grammar.key, stage.key)] = {
+        label: stage.label,
+        exitCriteria: [...(stage.exitCriteria ?? [])],
+      };
+      for (const state of stage.states) {
+        states[stateKey(grammar.key, stage.key, state.key)] = {
+          label: state.label,
+          band: state.band,
+        };
+      }
+    }
+  }
+  return { stages, states };
+}
+
+/** Deterministic JSON with sorted keys — safe to freeze as a baseline and diff. */
+export function serializeSnapshot(snapshot: GrammarSnapshot): string {
+  const sortObj = <T>(o: Record<string, T>): Record<string, T> =>
+    Object.fromEntries(Object.keys(o).sort().map((k) => [k, o[k]]));
+  return `${JSON.stringify({ stages: sortObj(snapshot.stages), states: sortObj(snapshot.states) }, null, 2)}\n`;
+}
+
+// ─── Dependency parsing + resolution ───────────────────────────────────────────
+
+/**
+ * Read declared lifecycle dependencies off a stance page's `metadata` JSON.
+ * Tolerant of every malformed shape — a non-object metadata, a missing or
+ * non-array `lifecycleDependencies`, or entries missing `grammar`/`stage` — and
+ * returns `[]` rather than throwing (this runs on the publish/CI path). `state`
+ * is carried only when it is a non-empty string.
+ */
+export function parseLifecycleDependencies(metadata: unknown): LifecycleDependency[] {
+  if (!metadata || typeof metadata !== "object") return [];
+  const raw = (metadata as Record<string, unknown>)["lifecycleDependencies"];
+  if (!Array.isArray(raw)) return [];
+  const out: LifecycleDependency[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    const grammar = e["grammar"];
+    const stage = e["stage"];
+    if (typeof grammar !== "string" || !grammar) continue;
+    if (typeof stage !== "string" || !stage) continue;
+    const state = e["state"];
+    out.push({
+      grammar,
+      stage,
+      ...(typeof state === "string" && state ? { state } : {}),
+    });
+  }
+  return out;
+}
+
+/** Whether a declared dependency resolves against a registry today (the queryable half of AC-1). */
+export function resolveDependency(
+  dep: LifecycleDependency,
+  registry: Record<string, LifecycleGrammar> = LIFECYCLE_GRAMMARS,
+): boolean {
+  const grammar = registry[dep.grammar];
+  if (!grammar) return false;
+  const stage = grammar.stages.find((s) => s.key === dep.stage);
+  if (!stage) return false;
+  if (dep.state === undefined) return true;
+  return stage.states.some((s) => s.key === dep.state);
+}
+
+// ─── Negation analysis ─────────────────────────────────────────────────────────
+
+export type NegationDelta = "removed" | "resemanticized";
+export type NegationSeverity = "negating" | "weakening";
+
+export type NegationFinding = {
+  /** The stance whose stated intent the structural change affects. */
+  slug: string;
+  dependency: LifecycleDependency;
+  delta: NegationDelta;
+  severity: NegationSeverity;
+  detail: string;
+};
+
+/** A stance and the dependencies it declared (as parsed from its metadata). */
+export type StanceDependencies = {
+  slug: string;
+  dependencies: readonly LifecycleDependency[];
+};
+
+function exitCriteriaChanged(a: string[], b: string[]): boolean {
+  return a.length !== b.length || a.some((v, i) => v !== b[i]);
+}
+
+/**
+ * Compute which stances a structural change negates or weakens, by diffing a
+ * `previous` snapshot against the `current` one for every declared stance
+ * dependency. At most ONE finding per dependency, most-severe first:
+ *
+ *   - a depended stage/state key present in `previous` but gone from `current`
+ *     → `removed` / **negating** (a rename is the old key going missing);
+ *   - a still-present depended element whose label / band / exit-criteria changed
+ *     → `resemanticized` / **weakening**.
+ *
+ * A dependency that did not resolve in `previous` either is NOT this change's
+ * doing and is skipped (it is pre-existing unresolved intent, out of scope).
+ */
+export function analyzeGrammarNegation(
+  previous: GrammarSnapshot,
+  current: GrammarSnapshot,
+  stances: readonly StanceDependencies[],
+): NegationFinding[] {
+  const findings: NegationFinding[] = [];
+  for (const stance of stances) {
+    for (const dep of stance.dependencies) {
+      const sKey = stageKey(dep.grammar, dep.stage);
+      const prevStage = previous.stages[sKey];
+      // Skip deps that were never valid in the previous snapshot — not this change's doing.
+      if (!prevStage) continue;
+
+      const curStage = current.stages[sKey];
+      const stKey = dep.state !== undefined ? stateKey(dep.grammar, dep.stage, dep.state) : null;
+      const prevState = stKey ? previous.states[stKey] : null;
+      // A state-level dep that was never valid in previous is likewise skipped.
+      if (stKey && !prevState) continue;
+
+      // ── Removal (negating) takes precedence ──
+      if (!curStage) {
+        findings.push({
+          slug: stance.slug,
+          dependency: dep,
+          delta: "removed",
+          severity: "negating",
+          detail: `stage '${dep.grammar}::${dep.stage}' was removed or renamed; the stance depends on it`,
+        });
+        continue;
+      }
+      if (stKey) {
+        const curState = current.states[stKey];
+        if (!curState) {
+          findings.push({
+            slug: stance.slug,
+            dependency: dep,
+            delta: "removed",
+            severity: "negating",
+            detail: `state '${dep.grammar}::${dep.stage}::${dep.state}' was removed or renamed; the stance depends on it`,
+          });
+          continue;
+        }
+      }
+
+      // ── Re-semanticization (weakening) on a still-present element ──
+      const stageResemanticized =
+        curStage.label !== prevStage.label ||
+        exitCriteriaChanged(prevStage.exitCriteria, curStage.exitCriteria);
+      let stateResemanticized = false;
+      if (stKey && prevState) {
+        const curState = current.states[stKey]!;
+        stateResemanticized =
+          curState.label !== prevState.label || curState.band !== prevState.band;
+      }
+      if (stageResemanticized || stateResemanticized) {
+        const target = stateResemanticized
+          ? `state '${dep.grammar}::${dep.stage}::${dep.state}'`
+          : `stage '${dep.grammar}::${dep.stage}'`;
+        findings.push({
+          slug: stance.slug,
+          dependency: dep,
+          delta: "resemanticized",
+          severity: "weakening",
+          detail: `${target} kept its key but changed meaning (label/band/exit-criteria); the stance may no longer hold`,
+        });
+      }
+    }
+  }
+  return findings;
+}

--- a/apps/web/lib/lifecycle/lifecycle-grammar-consistency.guard.test.ts
+++ b/apps/web/lib/lifecycle/lifecycle-grammar-consistency.guard.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { buildGrammarSnapshot, serializeSnapshot } from "./grammar-negation";
+import { checkGrammarConsistency } from "./grammar-consistency-check";
+
+// BI-EAD441E0 slice S2 — THE CI STRUCTURAL GUARD.
+//
+// This test runs in the required Unit Tests job on every PR and every install's
+// CI, so it ships to the fleet through the normal self-upgrade path and blocks a
+// stance-negating grammar change pre-merge. Two failure modes, two remedies:
+//   1. A grammar change NEGATES a kernel stance -> FAIL, fix the stance (or the change).
+//   2. A benign grammar change left the baseline stale -> FAIL, re-freeze the
+//      baseline with `pnpm --filter web exec tsx scripts/update-lifecycle-grammar-snapshot.ts`
+//      (a deliberate, reviewed step — structural evolution is a first-class concern).
+
+const BASELINE_PATH = join(__dirname, "lifecycle-grammar-snapshot.json");
+
+function readBaseline(): string {
+  try {
+    return readFileSync(BASELINE_PATH, "utf8");
+  } catch {
+    throw new Error(
+      `lifecycle-grammar-snapshot.json is missing at ${BASELINE_PATH}. ` +
+        "Freeze it: pnpm --filter web exec tsx scripts/update-lifecycle-grammar-snapshot.ts",
+    );
+  }
+}
+
+describe("lifecycle grammar ↔ stance consistency guard (BI-EAD441E0)", () => {
+  it("no grammar change negates a kernel stance (BLOCKS a stance-negating change)", () => {
+    const result = checkGrammarConsistency(readBaseline());
+    // A negating finding means a stage/state a standing stance depends on was
+    // removed or renamed. This is the guard's hard stop.
+    expect(
+      result.negating,
+      result.negating.length
+        ? `Grammar change NEGATES a governing stance — route through governance, do not silently apply:\n` +
+            result.negating.map((f) => `  - ${f.slug}: ${f.detail}`).join("\n")
+        : "",
+    ).toEqual([]);
+  });
+
+  it("the committed baseline is in sync with the live grammars (re-freeze on any structural change)", () => {
+    const result = checkGrammarConsistency(readBaseline());
+    expect(
+      result.inSync,
+      result.inSync
+        ? ""
+        : "The lifecycle grammars changed but the committed snapshot baseline was not re-frozen. " +
+          "After confirming the first test passed (no stance negated), regenerate it:\n" +
+          "  pnpm --filter web exec tsx scripts/update-lifecycle-grammar-snapshot.ts",
+    ).toBe(true);
+  });
+
+  it("fails loud when it cannot evaluate — a corrupt/empty baseline is not a silent pass", () => {
+    // Self-verifying discipline: a baseline that does not parse must throw, never
+    // resolve to "no findings" (which would look like a clean pass).
+    expect(() => checkGrammarConsistency("not json")).toThrow();
+  });
+
+  it("the frozen baseline round-trips the live grammars exactly", () => {
+    // Guards against a hand-edited or stale baseline that happens to parse.
+    expect(readBaseline()).toBe(serializeSnapshot(buildGrammarSnapshot()));
+  });
+});

--- a/apps/web/lib/lifecycle/lifecycle-grammar-snapshot.json
+++ b/apps/web/lib/lifecycle/lifecycle-grammar-snapshot.json
@@ -1,0 +1,301 @@
+{
+  "stages": {
+    "backbone::build": {
+      "label": "Build",
+      "exitCriteria": []
+    },
+    "backbone::design": {
+      "label": "Design",
+      "exitCriteria": []
+    },
+    "backbone::plan": {
+      "label": "Plan",
+      "exitCriteria": []
+    },
+    "backbone::production": {
+      "label": "Production",
+      "exitCriteria": []
+    },
+    "backbone::retirement": {
+      "label": "Retirement",
+      "exitCriteria": []
+    },
+    "customer-account::active": {
+      "label": "Active",
+      "exitCriteria": []
+    },
+    "customer-account::closed": {
+      "label": "Closed",
+      "exitCriteria": []
+    },
+    "customer-account::onboarding": {
+      "label": "Onboarding",
+      "exitCriteria": [
+        "Onboarding milestones complete",
+        "First value delivered"
+      ]
+    },
+    "customer-account::prospect": {
+      "label": "Prospect",
+      "exitCriteria": [
+        "Contact and account identified",
+        "Fit hypothesis recorded"
+      ]
+    },
+    "customer-account::qualified": {
+      "label": "Qualified",
+      "exitCriteria": [
+        "Qualification confirmed",
+        "Commercial path agreed"
+      ]
+    },
+    "opportunity::closed_lost": {
+      "label": "Lost",
+      "exitCriteria": [
+        "Lost reason recorded",
+        "Reusable learning captured"
+      ]
+    },
+    "opportunity::closed_won": {
+      "label": "Won",
+      "exitCriteria": [
+        "Order or onboarding path confirmed",
+        "Handoff owner recorded"
+      ]
+    },
+    "opportunity::discovery": {
+      "label": "Discovery",
+      "exitCriteria": [
+        "Needs and success criteria captured",
+        "Stakeholders and blockers identified",
+        "Commercial fit is plausible"
+      ]
+    },
+    "opportunity::negotiation": {
+      "label": "Negotiation",
+      "exitCriteria": [
+        "Decision process confirmed",
+        "Commercial objections resolved",
+        "Signature or close step scheduled"
+      ]
+    },
+    "opportunity::proposal": {
+      "label": "Proposal",
+      "exitCriteria": [
+        "Quote or proposal sent",
+        "Commercial owner identified",
+        "Budget and timeline confirmed"
+      ]
+    },
+    "opportunity::qualification": {
+      "label": "Qualification",
+      "exitCriteria": [
+        "Buyer problem is clear",
+        "Account and primary contact are known",
+        "Value hypothesis is recorded"
+      ]
+    },
+    "ovsm::attract": {
+      "label": "Attract",
+      "exitCriteria": []
+    },
+    "ovsm::capture": {
+      "label": "Capture",
+      "exitCriteria": []
+    },
+    "ovsm::deliver": {
+      "label": "Deliver",
+      "exitCriteria": []
+    },
+    "ovsm::qualify": {
+      "label": "Qualify",
+      "exitCriteria": []
+    },
+    "ovsm::retain": {
+      "label": "Retain",
+      "exitCriteria": []
+    },
+    "ovsm::settle": {
+      "label": "Settle",
+      "exitCriteria": []
+    },
+    "tech-currency::approaching-eol": {
+      "label": "Approaching EOL",
+      "exitCriteria": []
+    },
+    "tech-currency::current": {
+      "label": "Current",
+      "exitCriteria": []
+    },
+    "tech-currency::end-of-life": {
+      "label": "End of life",
+      "exitCriteria": []
+    },
+    "tech-currency::unsupported": {
+      "label": "Unsupported",
+      "exitCriteria": []
+    }
+  },
+  "states": {
+    "backbone::build::active": {
+      "label": "Active",
+      "band": "ready"
+    },
+    "backbone::build::draft": {
+      "label": "Draft",
+      "band": "on-track"
+    },
+    "backbone::build::inactive": {
+      "label": "Inactive",
+      "band": "on-track"
+    },
+    "backbone::design::active": {
+      "label": "Active",
+      "band": "ready"
+    },
+    "backbone::design::draft": {
+      "label": "Draft",
+      "band": "on-track"
+    },
+    "backbone::design::inactive": {
+      "label": "Inactive",
+      "band": "on-track"
+    },
+    "backbone::plan::active": {
+      "label": "Active",
+      "band": "ready"
+    },
+    "backbone::plan::draft": {
+      "label": "Draft",
+      "band": "on-track"
+    },
+    "backbone::plan::inactive": {
+      "label": "Inactive",
+      "band": "on-track"
+    },
+    "backbone::production::active": {
+      "label": "Active",
+      "band": "ready"
+    },
+    "backbone::production::draft": {
+      "label": "Draft",
+      "band": "on-track"
+    },
+    "backbone::production::inactive": {
+      "label": "Inactive",
+      "band": "on-track"
+    },
+    "backbone::retirement::active": {
+      "label": "Active",
+      "band": "ready"
+    },
+    "backbone::retirement::draft": {
+      "label": "Draft",
+      "band": "on-track"
+    },
+    "backbone::retirement::inactive": {
+      "label": "Inactive",
+      "band": "on-track"
+    },
+    "customer-account::active::active": {
+      "label": "Active",
+      "band": "on-track"
+    },
+    "customer-account::active::at_risk": {
+      "label": "At risk",
+      "band": "blocked"
+    },
+    "customer-account::active::suspended": {
+      "label": "Suspended",
+      "band": "blocked"
+    },
+    "customer-account::closed::archived": {
+      "label": "Archived",
+      "band": "on-track"
+    },
+    "customer-account::closed::closed": {
+      "label": "Closed",
+      "band": "on-track"
+    },
+    "customer-account::closed::superseded": {
+      "label": "Superseded (merged)",
+      "band": "on-track"
+    },
+    "customer-account::onboarding::onboarding": {
+      "label": "Onboarding",
+      "band": "on-track"
+    },
+    "customer-account::prospect::prospect": {
+      "label": "Prospect",
+      "band": "on-track"
+    },
+    "customer-account::qualified::qualified": {
+      "label": "Qualified",
+      "band": "ready"
+    },
+    "opportunity::closed_lost::lost": {
+      "label": "Lost",
+      "band": "on-track"
+    },
+    "opportunity::closed_won::won": {
+      "label": "Won",
+      "band": "ready"
+    },
+    "opportunity::discovery::open": {
+      "label": "Open",
+      "band": "on-track"
+    },
+    "opportunity::negotiation::open": {
+      "label": "Open",
+      "band": "on-track"
+    },
+    "opportunity::proposal::open": {
+      "label": "Open",
+      "band": "on-track"
+    },
+    "opportunity::qualification::open": {
+      "label": "Open",
+      "band": "on-track"
+    },
+    "ovsm::attract::in-stage": {
+      "label": "In stage",
+      "band": "on-track"
+    },
+    "ovsm::capture::in-stage": {
+      "label": "In stage",
+      "band": "on-track"
+    },
+    "ovsm::deliver::in-stage": {
+      "label": "In stage",
+      "band": "on-track"
+    },
+    "ovsm::qualify::in-stage": {
+      "label": "In stage",
+      "band": "on-track"
+    },
+    "ovsm::retain::in-stage": {
+      "label": "In stage",
+      "band": "on-track"
+    },
+    "ovsm::settle::in-stage": {
+      "label": "In stage",
+      "band": "on-track"
+    },
+    "tech-currency::approaching-eol::approaching-eol": {
+      "label": "Approaching EOL",
+      "band": "blocked"
+    },
+    "tech-currency::current::current": {
+      "label": "Current",
+      "band": "on-track"
+    },
+    "tech-currency::end-of-life::end-of-life": {
+      "label": "End of life",
+      "band": "blocked"
+    },
+    "tech-currency::unsupported::unsupported": {
+      "label": "Unsupported",
+      "band": "blocked"
+    }
+  }
+}

--- a/apps/web/lib/lifecycle/stance-lifecycle-dependencies.ts
+++ b/apps/web/lib/lifecycle/stance-lifecycle-dependencies.ts
@@ -1,0 +1,31 @@
+// BI-EAD441E0 slice S2 — the repo-declared kernel stance ↔ lifecycle couplings.
+//
+// These are the platform's OWN standing stances whose stated intent depends on a
+// specific grammar element existing. Declaring them in SOURCE (not just per-install
+// metadata) is what ships the structural premise fleet-wide: the CI guard
+// (lifecycle-grammar-consistency.guard.test.ts) checks these against every grammar
+// change, so a structural change that would negate a kernel stance is blocked on
+// every install through the normal PR → upstream main → self-upgrade path.
+//
+// Per-install operator stances declare their OWN dependencies in WikiPage.metadata
+// (`lifecycleDependencies`) and are checked at runtime by slice S3 (BI-696B91AB)
+// using the SAME analyzer. This file is the kernel-level, source-of-truth half.
+
+import type { StanceDependencies } from "./grammar-negation";
+
+/**
+ * Kernel stance couplings. Each entry ties a standing platform stance (by its
+ * canonical WWWD slug) to the grammar element its intent rests on. Adding a
+ * coupling here protects that structural element fleet-wide.
+ */
+export const KERNEL_STANCE_DEPENDENCIES: readonly StanceDependencies[] = [
+  {
+    // "continued / recurring use is the goal" — the recurring-revenue doctrine
+    // (business archetype: subscription/usage recurring revenue; the business
+    // compounds on retention). Its intent is inert if the value stream has no
+    // `retain` stage to instrument, so the OVSM `retain` stage is load-bearing
+    // for this stance and must not be silently removed or renamed.
+    slug: "stances/how-do-we-manage-the-business-and-what-is-the-goal-of-a-customer-relationship",
+    dependencies: [{ grammar: "ovsm", stage: "retain" }],
+  },
+];

--- a/apps/web/scripts/update-lifecycle-grammar-snapshot.ts
+++ b/apps/web/scripts/update-lifecycle-grammar-snapshot.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env tsx
+// BI-EAD441E0 slice S2 — re-freeze the committed lifecycle-grammar snapshot baseline.
+//
+// Run this after a DELIBERATE, reviewed grammar change, once the consistency guard
+// has confirmed the change negates no governing stance. It writes the current
+// grammar projection to apps/web/lib/lifecycle/lifecycle-grammar-snapshot.json so
+// the ratchet tracks HEAD and the next PR only sees ITS delta.
+//
+//   pnpm --filter web exec tsx scripts/update-lifecycle-grammar-snapshot.ts
+//   pnpm --filter web exec tsx scripts/update-lifecycle-grammar-snapshot.ts --check  # verify only
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { buildGrammarSnapshot, serializeSnapshot } from "@/lib/lifecycle/grammar-negation";
+import { checkGrammarConsistency } from "@/lib/lifecycle/grammar-consistency-check";
+
+const BASELINE_PATH = join(process.cwd(), "lib/lifecycle/lifecycle-grammar-snapshot.json");
+
+function main(): void {
+  const check = process.argv.includes("--check");
+  const current = serializeSnapshot(buildGrammarSnapshot());
+
+  let baseline = "";
+  try {
+    baseline = readFileSync(BASELINE_PATH, "utf8");
+  } catch {
+    if (check) {
+      console.error(`[lifecycle-snapshot] MISSING baseline at ${BASELINE_PATH}. Run without --check to create it.`);
+      process.exit(1);
+    }
+  }
+
+  if (baseline === current) {
+    console.info("[lifecycle-snapshot] baseline already in sync — no change.");
+    return;
+  }
+
+  // Refuse to re-freeze OVER a stance-negating change: the operator must resolve
+  // the negation (or reconcile the stance) first. Never silently accept it.
+  const result = checkGrammarConsistency(baseline || current);
+  if (result.negating.length > 0) {
+    console.error(
+      "[lifecycle-snapshot] REFUSING to re-freeze — this grammar change negates a governing stance:\n" +
+        result.negating.map((f) => `  - ${f.slug}: ${f.detail}`).join("\n") +
+        "\nRoute it through governance (update the stance, or revert the structural change) before re-freezing.",
+    );
+    process.exit(1);
+  }
+
+  if (check) {
+    console.error(
+      "[lifecycle-snapshot] OUT OF SYNC — the grammars changed but the baseline was not re-frozen. " +
+        "Run without --check to update it.",
+    );
+    process.exit(1);
+  }
+
+  writeFileSync(BASELINE_PATH, current);
+  console.info(
+    `[lifecycle-snapshot] re-froze baseline` +
+      (result.weakening.length ? ` (${result.weakening.length} weakening change(s) surfaced — review the stances)` : "") +
+      ".",
+  );
+}
+
+main();

--- a/docs/superpowers/plans/2026-08-15-stance-lifecycle-consistency-guard.md
+++ b/docs/superpowers/plans/2026-08-15-stance-lifecycle-consistency-guard.md
@@ -36,7 +36,12 @@ This plan implements **S1 (coupling model + pure negation analyzer)** and **S2 (
 - `s2-ci-structural-guard` → **BI-EAD441E0** (depends on `s1-coupling-analyzer`)
 - `s3-runtime-governance-routing` → **BI-696B91AB** (depends on `s1-coupling-analyzer`; sequenced after the EP-1C37C089 gate is built)
 
-**Implementation status (2026-08-15): NOT STARTED.** This plan and its spec are captured design only — no code has been written for S1 or S2. The next session picks up at Phase 1.
+**Implementation status (2026-08-15): S1 + S2 IMPLEMENTED.** Shipped in this PR:
+
+- **S1** — `apps/web/lib/lifecycle/grammar-negation.ts` (pure: `parseLifecycleDependencies`, `buildGrammarSnapshot`, `serializeSnapshot`, `resolveDependency`, `analyzeGrammarNegation`) + `grammar-negation.test.ts` (13 tests incl. the retain-gutting regression).
+- **S2** — the CI guard is implemented as a **vitest guard-test** (`lifecycle-grammar-consistency.guard.test.ts`) rather than a `scripts/*.mjs` entry: it runs in the already-required **Unit Tests** job, imports the live TS grammars natively (a `.mjs` cannot), and blocks merge on a negating change — a cleaner wiring than a bespoke guard-loop `.mjs` that would have to shell out to `tsx`. Supporting files: the frozen baseline `apps/web/lib/lifecycle/lifecycle-grammar-snapshot.json`, the shared core `grammar-consistency-check.ts`, the repo-declared kernel couplings `stance-lifecycle-dependencies.ts` (seeded with the recurring-use → `ovsm::retain` coupling), and the `--update` re-freeze script `apps/web/scripts/update-lifecycle-grammar-snapshot.ts`.
+
+Functional proof: gutting `ovsm::retain` from the live grammar source turns the guard test RED with the governance message ("Grammar change NEGATES a governing stance — route through governance, do not silently apply"); reverting returns it green. **S3** (per-install runtime routing) remains on BI-696B91AB, sequenced after the EP-1C37C089 gate is built.
 
 ## Risks & rollback
 


### PR DESCRIPTION
## What & why (BI-EAD441E0, P1 · slices S1+S2)

Lifecycle structure (the grammar, BI-E55991E9) and governance stances (the WWWD corpus) are **coupled**: a structural change that removes, renames, or re-semanticizes a grammar element a stance depends on must be **detected and routed through governance — never silently applied** (e.g. gutting the OVSM `retain` stage while the stance "continued/recurring use is the goal" depends on it). This PR ships the detection core (S1) and the fleet-propagated block (S2). Runtime governance routing (S3) is filed separately as BI-696B91AB, sequenced after the EP-1C37C089 gate is built.

## S1 — pure negation analyzer

`apps/web/lib/lifecycle/grammar-negation.ts` (pure, no I/O, no throw):
- **Coupling model with no new schema:** stances declare `lifecycleDependencies` in the *existing* free-form `WikiPage.metadata` JSON — already plumbed through `saveWikiOverlayEdit`. No Prisma model, no migration.
- `buildGrammarSnapshot` / `serializeSnapshot` — a deterministic, freezable projection of the declared `LIFECYCLE_GRAMMARS` registry.
- `analyzeGrammarNegation` — a removed/renamed depended element → **negating** (block); a label/band/exit-criteria change on a still-present element → **weakening** (surface); a rename is the old key going missing.

## S2 — CI structural guard (fleet-propagated block)

Implemented as a **vitest guard-test** (`lifecycle-grammar-consistency.guard.test.ts`) that runs in the already-**required Unit Tests job** — so it ships to every install via the normal PR → upstream `main` → self-upgrade path and blocks merge on a negating change. (A `scripts/*.mjs` guard was rejected: it cannot import the live TS grammars; the guard must build the *current* snapshot from them.) Supporting files:
- `lifecycle-grammar-snapshot.json` — the frozen baseline (last accepted structure).
- `stance-lifecycle-dependencies.ts` — repo-declared **kernel** couplings, seeded with the recurring-use doctrine → `ovsm::retain` (the platform's own stated intent, protected fleet-wide).
- `grammar-consistency-check.ts` — the shared core used by both the guard test and the `--update` script, so they can't diverge.
- `scripts/update-lifecycle-grammar-snapshot.ts` — the deliberate, reviewed re-freeze after a benign structural change; **refuses** to re-freeze over a negating change.

The guard is **self-verifying / fails loud**: an unparseable baseline throws rather than passing silently.

## Functional proof (not just structural)

Gutting `ovsm::retain` from the live grammar source turns the guard RED with the exact governance message — *"Grammar change NEGATES a governing stance — route through governance, do not silently apply: stances/how-do-we-manage-… stage 'ovsm::retain' was removed or renamed; the stance depends on it"* — and reverting returns it green. That is the BI's named regression, verified functionally.

## Verification

- Local-CI merged gate: **PASS** (evidence `cmswapeie18z101pnu4uzplmk`).
- **66 lifecycle tests green** (13 analyzer + behavioral + guard tests, plus existing lifecycle suites intact); full `apps/web` typecheck clean.

## Acceptance mapping

- Stances declare/resolve a grammar dependency; queryable → S1 (`parseLifecycleDependencies`, `resolveDependency`).
- Removing/renaming/re-semanticizing runs a negation-impact pass BEFORE apply → S1 + S2.
- A negating change is blocked (with a named message/remedy), never silently applied → S2.
- Ships to every instance post-upgrade in source → S2 (required-job test).
- Fails loud when it cannot evaluate → S2.
- Regression: gutting `retain` while the recurring-use stance depends on it is caught → proven above.

Plan/coverage receipt `cmsuopg0k1o6f01ppu8oix04h` (decomposed; S3 → BI-696B91AB).

Signed-off-by: dpf-ci <dpf-ci@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)