### PR TITLE
fix(workroom): an AI principal can never ride the superuser short-circuit

### DIFF
--- a/apps/web/lib/work-management/room-agent-access.test.ts
+++ b/apps/web/lib/work-management/room-agent-access.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { authorizeWorkroomAccess } from "./room-participation";
 import { authorizeAgentRoomAccess, grantsRequested } from "./room-agent-access";
 
 const BASE = {
@@ -64,5 +65,56 @@ describe("authorizeAgentRoomAccess", () => {
     });
     expect(d.level).toBe("discover");
     expect(d.reason).toBe("discover-only");
+  });
+});
+
+describe("superuser guard (BI-154DAA7E)", () => {
+  // The superuser short-circuit in authorizeWorkroomAccess is a HUMAN
+  // affordance. An AI principal must never ride it: one flag would void
+  // admission AND the sensitivity ceiling at once.
+  it("the agent input cannot express superuser at all — the field does not exist", () => {
+    // Type-level guarantee, asserted at runtime for the compiled contract:
+    // passing isSuperuser must not change the decision for an unadmitted agent.
+    const decision = authorizeAgentRoomAccess({
+      requested: "action",
+      agentPrincipalRef: "agent:AGT-ORCH-000",
+      agentSensitivityClearance: ["public", "internal", "confidential", "restricted"],
+      admittedPrincipalRefs: [],
+      actionPrincipalRefs: [],
+      sensitivityCeiling: "public",
+      // @ts-expect-error BI-154DAA7E — isSuperuser was removed from the agent path
+      isSuperuser: true,
+    });
+    expect(decision.level).toBe("none");
+    expect(decision.reason).toBe("not-admitted");
+  });
+
+  it("an under-cleared agent is capped even if a future caller smuggles the flag through the core", () => {
+    // Belt and braces: the core decision refuses the short-circuit for
+    // principalKind "agent" even with isSuperuser true.
+    const decision = authorizeWorkroomAccess({
+      requested: "content",
+      principalRef: "agent:AGT-ORCH-000",
+      assignedPrincipalRefs: ["agent:AGT-ORCH-000"],
+      sensitivityCeiling: "restricted",
+      sensitivityClearance: ["public", "internal"],
+      isSuperuser: true,
+      principalKind: "agent",
+    });
+    expect(decision.level).toBe("discover");
+    expect(decision.reason).toBe("insufficient-clearance");
+  });
+
+  it("a human superuser is unchanged — the owner affordance survives", () => {
+    const decision = authorizeWorkroomAccess({
+      requested: "action",
+      principalRef: "user:owner",
+      assignedPrincipalRefs: [],
+      sensitivityCeiling: "restricted",
+      sensitivityClearance: [],
+      isSuperuser: true,
+    });
+    expect(decision.level).toBe("action");
+    expect(decision.reason).toBe("authorized");
   });
 });

--- a/apps/web/lib/work-management/room-agent-access.ts
+++ b/apps/web/lib/work-management/room-agent-access.ts
@@ -28,7 +28,6 @@ export interface AuthorizeAgentRoomAccessInput {
   actionPrincipalRefs: readonly string[];
   discoverablePrincipalRefs?: readonly string[];
   sensitivityCeiling: string | null;
-  isSuperuser?: boolean;
 }
 
 /**
@@ -47,7 +46,12 @@ export function authorizeAgentRoomAccess(
     discoverablePrincipalRefs: input.discoverablePrincipalRefs ?? [],
     sensitivityCeiling: input.sensitivityCeiling,
     sensitivityClearance: input.agentSensitivityClearance,
-    isSuperuser: input.isSuperuser ?? false,
+    // BI-154DAA7E: an AI principal can NEVER be superuser. The field is not
+    // accepted on this input at all — expressing it is a type error — and the
+    // core decision refuses the short-circuit for principalKind "agent" even if
+    // a future caller finds another way to set the flag.
+    isSuperuser: false,
+    principalKind: "agent",
   });
 }
 

--- a/apps/web/lib/work-management/room-participation.ts
+++ b/apps/web/lib/work-management/room-participation.ts
@@ -47,8 +47,19 @@ export function authorizeWorkroomAccess(input: {
   sensitivityCeiling: string | null;
   sensitivityClearance: readonly string[];
   isSuperuser: boolean;
+  /**
+   * BI-154DAA7E: the superuser short-circuit is a HUMAN affordance — the
+   * installation owner bypassing ceiling checks on their own install. An AI
+   * principal must never ride it: a coworker provisioned as "superuser" would
+   * void every room-side clearance guarantee in one flag. Callers on the agent
+   * path pass "agent" and the short-circuit is refused regardless of
+   * isSuperuser; omitting the field preserves the human behaviour unchanged.
+   */
+  principalKind?: "human" | "agent";
 }): WorkroomAccessDecision {
-  if (input.isSuperuser) return { level: input.requested, reason: "authorized" };
+  if (input.isSuperuser && input.principalKind !== "agent") {
+    return { level: input.requested, reason: "authorized" };
+  }
   if (!input.principalRef) return { level: "none", reason: "not-admitted" };
 
   const admitted = input.assignedPrincipalRefs.includes(input.principalRef);

--- a/docs/superpowers/specs/2026-08-15-coworker-escalation-ladder-design.md
+++ b/docs/superpowers/specs/2026-08-15-coworker-escalation-ladder-design.md
@@ -173,10 +173,18 @@ coworker still reports as unsummonable rather than as a clearance refusal —
 otherwise the generic refusal would imply a restricted matter that does not
 exist.
 
-Still open, tracked on BI-154DAA7E: `authorizeWorkRoomAccess` returns the
-requested level for a superuser *before* any clearance check, so no
-route-fronted coworker may hold superuser; and the conversational channel
-remains unpoliced for peers that are legitimately admitted.
+The superuser short-circuit is now guarded (BI-154DAA7E): the agent access
+input cannot express `isSuperuser` at all — the field was removed from
+`authorizeAgentRoomAccess`, so an AI principal claiming it is a type error —
+and `authorizeWorkroomAccess` refuses the short-circuit for
+`principalKind: "agent"` even if a future caller sets the flag another way. The
+short-circuit remains a human affordance: the installation owner on their own
+install.
+
+Still open, tracked on BI-154DAA7E: the conversational channel remains
+unpoliced for peers that are legitimately admitted — clearance is a *level*,
+while some confidentiality is *relational* (whose reports, whose deal), which a
+level-based clamp cannot express.
 
 ## 4b. Fresh-install behaviour and how to diagnose a silent refusal
 


### PR DESCRIPTION
Advances BI-154DAA7E — with this, the superuser item closes; the remaining open scope on that BI is relational confidentiality only.

## The exposure

`authorizeWorkroomAccess` returns the requested access level for a superuser **before** any admission or clearance check. That short-circuit is a human affordance — the installation owner on their own install — but the agent path (`authorizeAgentRoomAccess`, BI-AD057F18) accepted an optional `isSuperuser` and passed it straight through. No production caller set it; the field was an unused loaded gun. A coworker provisioned as "superuser" — and a COO fronting every surface is exactly the agent someone would be tempted to so provision — would void admission **and** the sensitivity ceiling with one flag.

## Two layers

1. **Type level:** `isSuperuser` is removed from the agent input entirely. An agent caller expressing it is a compile error (asserted with `@ts-expect-error` in the test).
2. **Decision level:** `authorizeWorkroomAccess` takes `principalKind` (`"human" | "agent"`, optional) and refuses the short-circuit for `"agent"` even with `isSuperuser: true` — covering any future caller that finds another way to set the flag. Omitting the field preserves human behaviour unchanged.

The agent resolver pins `{ isSuperuser: false, principalKind: "agent" }`.

Also updates the escalation-ladder spec's still-open list: the superuser item moves to guarded; what remains open on BI-154DAA7E is the relational-confidentiality question (clearance is a *level*; some confidentiality is *relational* — whose reports, whose deal — which a level-based clamp cannot express).

## Verification

20 tests green across the room-access suites (3 new): the unadmitted-superuser-agent case, the smuggled-flag case at the core decision, and the human-owner-unchanged case.

`pnpm run pregate` PASS — gated sha `df1e5b989`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Docs-Impact-Decision: Internal authority hardening in room-participation.ts with no user-visible behaviour change — the human superuser affordance is unchanged, and no production caller ever set the removed agent-side flag, so the work-rooms user guide describes exactly the same behaviour before and after. The design record lives in the escalation-ladder spec section 4a/4c, updated in this PR.
