### PR TITLE
feat(coworker): the COO as standing coordinator on every surface

### DIFF
--- a/apps/web/lib/tak/collaboration-authority.test.ts
+++ b/apps/web/lib/tak/collaboration-authority.test.ts
@@ -32,3 +32,45 @@ describe("isHandoffPermitted", () => {
     ).toBe(false);
   });
 });
+
+describe("standing coordinator (BI-80ADD3A8)", () => {
+  const COORD = ["AGT-ORCH-000", "coo"];
+
+  it("permits escalating to the COO from an agent whose chain points elsewhere — the 64-of-71 case", () => {
+    // Registry reality: a management tree where most agents escalate to a
+    // mid-chain lead (HR-300, AGT-ORCH-300, ...), not the COO. Coordination
+    // must be reachable exactly when the caller's own chain has no answer.
+    expect(isHandoffPermitted({
+      delegatesTo: [],
+      escalatesTo: "HR-300",
+      targetIds: ["AGT-ORCH-000", "coo"],
+      standingCoordinatorIds: COORD,
+    })).toBe(true);
+  });
+
+  it("permits the coordinator even for an agent with NO declared authority", () => {
+    expect(isHandoffPermitted({
+      delegatesTo: [],
+      escalatesTo: null,
+      targetIds: ["coo"],
+      standingCoordinatorIds: COORD,
+    })).toBe(true);
+  });
+
+  it("widens TARGETS only — a non-coordinator target is still denied", () => {
+    expect(isHandoffPermitted({
+      delegatesTo: [],
+      escalatesTo: null,
+      targetIds: ["AGT-902"],
+      standingCoordinatorIds: COORD,
+    })).toBe(false);
+  });
+
+  it("changes nothing when the coordinator set is not supplied — legacy callers keep fail-closed semantics", () => {
+    expect(isHandoffPermitted({
+      delegatesTo: [],
+      escalatesTo: "HR-300",
+      targetIds: ["AGT-ORCH-000"],
+    })).toBe(false);
+  });
+});

--- a/apps/web/lib/tak/collaboration-authority.ts
+++ b/apps/web/lib/tak/collaboration-authority.ts
@@ -13,16 +13,30 @@
  * @param delegatesTo  Agent.delegatesTo (canonical agentIds or slugs).
  * @param escalatesTo  Agent.escalatesTo (a single agentId/slug/HR role, or null).
  * @param targetIds    The target agent's identifiers to test (agentId + slugId).
+ * @param standingCoordinatorIds  BI-80ADD3A8: identifiers of the platform's ONE
+ *   standing coordinator role (the COO). A target in this set is always a
+ *   permitted ESCALATION TARGET — the registry is a management tree and only 7
+ *   of 71 agents escalate directly to the COO, so without this rule the
+ *   founder-directed "COO handles coordination" is structurally unreachable
+ *   from most surfaces. Target-only by design: this widens who may be handed
+ *   TO, never what the caller may otherwise do, and the hop is still recorded
+ *   on the DelegationChain and still subject to the convene clearance clamp.
  *
  * An empty delegatesTo with no escalatesTo means the agent has declared no
  * delegation authority, so any handoff is denied (fail-closed) — the caller
- * must be explicitly permitted.
+ * must be explicitly permitted, with the single standing-coordinator exception
+ * above: coordination must be reachable precisely when an agent's own chain
+ * has no answer.
  */
 export function isHandoffPermitted(opts: {
   delegatesTo: readonly string[];
   escalatesTo: string | null;
   targetIds: readonly string[];
+  standingCoordinatorIds?: readonly string[];
 }): boolean {
+  if (opts.standingCoordinatorIds?.some((id) => opts.targetIds.includes(id))) {
+    return true;
+  }
   const allowed = new Set<string>([
     ...opts.delegatesTo,
     ...(opts.escalatesTo ? [opts.escalatesTo] : []),

--- a/apps/web/lib/tak/coordinator-authority.ts
+++ b/apps/web/lib/tak/coordinator-authority.ts
@@ -1,0 +1,38 @@
+// apps/web/lib/tak/coordinator-authority.ts
+//
+// BI-80ADD3A8: the COO as standing coordinator on every coworker surface.
+//
+// Founder-directed (2026-08-15, reaffirmed 2026-08-16): the COO handles
+// coordination; specialists do the work. The ratified persona contract
+// (2026-07-18, BI-7D29937E) bounds the shape: the COO is a ROLE and a
+// coordinator — presentation label and router — never the accountable byline,
+// which stays with the authenticated (human × client × session) triple.
+//
+// The structural blocker this module removes: isHandoffPermitted honours only
+// an agent's DIRECT delegatesTo/escalatesTo, and the registry is a management
+// TREE — 71 agents, only 7 of which escalate directly to the COO. A finance
+// specialist escalating a cross-cutting question to the coordinator would be
+// DENIED by its own org chart. Editing 71 seed rows would flatten the
+// management chain and not survive re-seed (registry values are seed
+// snapshots); a standing-target rule is one governed, auditable decision.
+//
+// Deliberate asymmetry: the coordinator is always a permitted TARGET — any
+// coworker may hand a thread UP to coordination — but never an implicit
+// SOURCE. The COO delegating outward still uses its declared delegatesTo, and
+// every hop still records a DelegationChain row. The convene clearance clamp
+// (escalation-ladder spec §4a/§4b) is NOT bypassed: reaching the coordinator
+// still requires the asking human's clearance to cover the COO's
+// classification.
+
+/**
+ * The standing coordinator's identifiers (canonical agentId + slug alias).
+ * One role by design — the ratified contract's role-only identity. If a
+ * per-install coordinator override ever ships, it must remain ONE role, not a
+ * list of privileged targets, or "coordinator" degrades into a bypass set.
+ */
+export const STANDING_COORDINATOR_IDS: readonly string[] = ["AGT-ORCH-000", "coo"];
+
+/** True when any of the target's identifiers name the standing coordinator. */
+export function isCoordinatorTarget(targetIds: readonly string[]): boolean {
+  return targetIds.some((id) => STANDING_COORDINATOR_IDS.includes(id));
+}

--- a/apps/web/lib/tak/coworker-collaboration.ts
+++ b/apps/web/lib/tak/coworker-collaboration.ts
@@ -22,6 +22,7 @@ import { agentEventBus } from "@/lib/agent-event-bus";
 import { resolveAgent } from "@/lib/tak/agent-resolution";
 import { spawnWorkThread } from "@/lib/actions/agent-coworker";
 import { isHandoffPermitted } from "@/lib/tak/collaboration-authority";
+import { STANDING_COORDINATOR_IDS } from "@/lib/tak/coordinator-authority";
 import { coerceDataSensitivity } from "@dpf/db/principal-sensitivity";
 import {
   decideConveneClearance,
@@ -99,6 +100,8 @@ async function enforceHandoffAuthority(
     delegatesTo: caller.delegatesTo ?? [],
     escalatesTo: caller.escalatesTo ?? null,
     targetIds,
+    // BI-80ADD3A8: the COO is a standing escalation target from every surface.
+    standingCoordinatorIds: STANDING_COORDINATOR_IDS,
   });
   if (!permitted) {
     await recordDelegationHop({

--- a/apps/web/lib/tak/escalation-ladder.ts
+++ b/apps/web/lib/tak/escalation-ladder.ts
@@ -80,6 +80,23 @@ export const ESCALATION_LADDER_BLOCK = `WHEN YOU CANNOT ANSWER — WORK THE LADD
 5. FILE — only when there is no path forward in this conversation at all. Say plainly which peers you tried and why the work could not proceed, then file it.
 NEVER file a backlog item as a substitute for asking a colleague. A filed item with no attempt to reach a peer is a dead end handed to the user. When you describe a peer, use their role in plain language ("our platform engineer", "the finance specialist") — never a tool name or an internal id.`;
 
+/**
+ * BI-80ADD3A8: the coordinator contract, injected beside the ladder so every
+ * coworker knows the same two facts: the COO coordinates, specialists work.
+ *
+ * Bounded by the ratified persona contract (2026-07-18, BI-7D29937E): the COO
+ * is a role and a router — its coordination is VISIBLE, but the byline on any
+ * recommendation stays with the authenticated identity, never "the COO
+ * decided". The handoff itself is authorized by the standing-coordinator rule
+ * in collaboration-authority.ts; this block only tells coworkers the door
+ * exists and when to use it — rung 2/3 of the ladder, aimed at the COO when no
+ * single specialist owns the question.
+ */
+export const COORDINATOR_BLOCK = `THE COO COORDINATES; SPECIALISTS DO THE WORK. You are one team with one standing coordinator: the COO.
+- If you are a SPECIALIST: you own the work on your surface. When a question is outside your area and no single peer obviously owns it — it spans areas, it is contested, or find_coworker returns nothing decisive — hand it to the COO (request_coworker or summon_coworker toward the COO role) instead of guessing or filing. The COO routes it, convenes the right people, and the thread comes back to whoever owns the work. Tell the user plainly: "I've brought this to our COO to route."
+- If you are the COO: you route, consult, and convene — you do not re-do specialist work, and you do not answer for a specialist when bringing them in is one call away. Hold the thread: a question you route is still yours to track until someone owns it.
+- Either way, coordination is visible, and no one speaks as the decider: recommendations carry their own attribution, and approval always belongs to the human.`;
+
 /** Rungs 1-3: an actual attempt to involve another coworker. */
 export const ESCALATION_RUNGS: readonly LadderRung[] = ["reroute", "consult", "convene"];
 

--- a/apps/web/lib/tak/prompt-assembler.ts
+++ b/apps/web/lib/tak/prompt-assembler.ts
@@ -11,7 +11,7 @@ import {
 import { withCoworkerInteractionContract } from "./coworker-interaction-contract";
 import { DECISION_ROUTING_BLOCK } from "./decision-routing-block";
 import { LIMITATION_RESPONSE_BLOCK } from "./limitation-response-block";
-import { ESCALATION_LADDER_BLOCK } from "./escalation-ladder";
+import { ESCALATION_LADDER_BLOCK, COORDINATOR_BLOCK } from "./escalation-ladder";
 import { buildInitiativeBlock } from "./initiative-block";
 import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
 import { readingLevelDirective, type ReadingLevel } from "@dpf/validators";
@@ -164,6 +164,7 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
     { category: "platform-identity", slug: "decision-routing", fallback: DECISION_ROUTING_BLOCK },
     { category: "platform-identity", slug: "limitation-response", fallback: LIMITATION_RESPONSE_BLOCK },
     { category: "platform-identity", slug: "escalation-ladder", fallback: ESCALATION_LADDER_BLOCK },
+    { category: "platform-identity", slug: "coordinator-contract", fallback: COORDINATOR_BLOCK },
     { category: "platform-identity", slug: modeSlug, fallback: input.mode === "advise" ? ADVISE_MODE_BLOCK : ACT_MODE_BLOCK },
     { category: "platform-mission", slug: "company-mission", fallback: COMPANY_MISSION_FALLBACK },
   ]);
@@ -189,6 +190,12 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
   // its own overridable block rather than folded into the identity block so a
   // DB override of the identity text cannot silently drop the contract.
   staticBlocks.push(loaded.get("platform-identity/escalation-ladder") ?? ESCALATION_LADDER_BLOCK);
+
+  // Block 1e: Coordinator contract (static) — the COO coordinates, specialists
+  // do the work (BI-80ADD3A8). Own overridable block for the same reason as the
+  // ladder: folding it into an overridable identity block would let an override
+  // silently drop the contract.
+  staticBlocks.push(loaded.get("platform-identity/coordinator-contract") ?? COORDINATOR_BLOCK);
 
   // Block 3: Mode (static per session — advise or act doesn't change mid-conversation)
   staticBlocks.push(loaded.get(`platform-identity/${modeSlug}`) ?? (input.mode === "advise" ? ADVISE_MODE_BLOCK : ACT_MODE_BLOCK));

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -142,7 +142,12 @@ of an ordered ladder — re-route to the specialist who owns the area, consult a
 question, convene the parties in a workroom, and only then file, naming who was tried. The contract
 is assembled into every coworker's prompt from `platform-identity/escalation-ladder`
 (`apps/web/lib/tak/escalation-ladder.ts`), and a turn that files without attempting a rung above it
-offers the escalation instead of ending the thread. Full rationale in
+offers the escalation instead of ending the thread. When no single specialist obviously owns a
+question — it spans areas, or is contested — the ladder points at the standing coordinator: the
+specialist hands the thread to the COO, says so plainly ("I've brought this to our COO to route"),
+and the COO routes, convenes, and holds the thread until someone owns it. Coordination is visible;
+the byline never becomes "the COO decided" — recommendations keep their own attribution and approval
+stays with the human (`platform-identity/coordinator-contract`). Full rationale in
 [`coworker-escalation-ladder-design.md`](superpowers/specs/2026-08-15-coworker-escalation-ladder-design.md).
 
 Repeated detector or consultation events are audit occurrences, not automatically separate units

--- a/docs/superpowers/specs/2026-08-15-coworker-escalation-ladder-design.md
+++ b/docs/superpowers/specs/2026-08-15-coworker-escalation-ladder-design.md
@@ -244,6 +244,52 @@ The general rule: when a default already exists elsewhere, confirm it answers th
 *same question* before copying it. Two defaults that look alike can encode
 opposite assumptions about what an absent value means.
 
+## 4c. The standing coordinator (BI-80ADD3A8)
+
+Founder-directed (2026-08-15, reaffirmed 2026-08-16): **the COO coordinates;
+specialists do the work.** This section records the shape and the two
+mechanisms that make it real, bounded by the ratified persona contract
+(2026-07-18, BI-7D29937E): the COO is a *role and a router* — its coordination
+is visible, but the byline on any recommendation stays with the authenticated
+`(human × client × session)` triple. Never "the COO decided."
+
+**The structural blocker.** `isHandoffPermitted` honours only an agent's direct
+`delegatesTo`/`escalatesTo`, and the registry is a management *tree*: 71
+agents, only 7 of which escalate directly to the COO. A finance specialist
+handing a cross-cutting question to the coordinator would be denied by its own
+org chart. Editing 71 seed rows would flatten the management chain and not
+survive re-seed (registry values are seed snapshots).
+
+**Mechanism 1 — standing-coordinator authority.**
+`STANDING_COORDINATOR_IDS` (`coordinator-authority.ts`) names the ONE
+coordinator role; `isHandoffPermitted` accepts it and always permits a target
+in that set. Deliberate asymmetry: the coordinator is always a permitted
+**target** — any coworker may hand a thread *up* to coordination — never an
+implicit source. The COO delegating outward still uses its declared
+`delegatesTo`; every hop still records a `DelegationChain` row; and the convene
+clearance clamp (§4a) is **not** bypassed.
+
+**Mechanism 2 — the coordinator contract block.** `COORDINATOR_BLOCK`, a
+DB-overridable `platform-identity/coordinator-contract` prompt block beside the
+ladder, telling every coworker the same two facts: specialists own the work on
+their surface and hand cross-cutting/contested/unowned questions to the COO;
+the COO routes, consults, and convenes, does not re-do specialist work, and
+holds a routed thread until someone owns it.
+
+**Interaction with the ladder.** The coordinator is *where rung 2/3 points when
+rung 1 has no decisive answer* — `find_coworker` finding nothing, several
+plausible owners, or a question spanning areas. It does not replace direct
+peer-to-peer consultation when the owner is obvious.
+
+**Open, deliberately.** The COO's own classification is `confidential`
+(`coo.prompt.md`), so on a fresh install an employee holding only `["public"]`
+cannot have the coordinator convened into their thread — the §4b clearance
+matrix applies to the COO like any peer. Whether the coordinator role should be
+classified lower, or default employee clearance seeded higher, is an operator
+policy decision, not one this contract makes. Content-aware route binding
+(BI-36408DB6) also lands here: if the COO is the router, intent-mismatch
+detection belongs to the coordinator path rather than to each bound specialist.
+
 ## 5. The triggering incident is not a ladder bug
 
 For the record, so the BI is not miscategorised: the upgrade failure itself was

--- a/prompts/platform-identity/coordinator-contract.prompt.md
+++ b/prompts/platform-identity/coordinator-contract.prompt.md
@@ -1,0 +1,20 @@
+---
+name: coordinator-contract
+displayName: Coordinator Contract
+description: The COO coordinates and routes; specialists do the work; coordination is visible and never the byline
+category: platform-identity
+version: 1
+
+composesFrom: []
+contentFormat: markdown
+variables: []
+
+valueStream: ""
+stage: ""
+sensitivity: internal
+---
+
+THE COO COORDINATES; SPECIALISTS DO THE WORK. You are one team with one standing coordinator: the COO.
+- If you are a SPECIALIST: you own the work on your surface. When a question is outside your area and no single peer obviously owns it — it spans areas, it is contested, or find_coworker returns nothing decisive — hand it to the COO (request_coworker or summon_coworker toward the COO role) instead of guessing or filing. The COO routes it, convenes the right people, and the thread comes back to whoever owns the work. Tell the user plainly: "I've brought this to our COO to route."
+- If you are the COO: you route, consult, and convene — you do not re-do specialist work, and you do not answer for a specialist when bringing them in is one call away. Hold the thread: a question you route is still yours to track until someone owns it.
+- Either way, coordination is visible, and no one speaks as the decider: recommendations carry their own attribution, and approval always belongs to the human.


### PR DESCRIPTION
Advances BI-80ADD3A8 — the coordinator half. Folds in the behavioural half of BI-36408DB6.

## Founder direction

The COO handles coordination; specialists do the work. Bounded by the **ratified** persona contract (BI-7D29937E): the COO is a role and a router whose coordination is visible, while the byline on any recommendation stays with the authenticated `(human × client × session)` triple. Never "the COO decided."

## The structural blocker this removes

`isHandoffPermitted` honours only an agent's direct `delegatesTo`/`escalatesTo`, and the registry is a management **tree** — 71 agents, only **7** escalating directly to the COO. A specialist handing a cross-cutting question to the coordinator was denied by its own org chart. Editing 71 seed rows would flatten the chain and not survive re-seed (registry values are seed snapshots), so the rule lives in the authority decision:

1. **Standing-coordinator authority** ([coordinator-authority.ts](apps/web/lib/tak/coordinator-authority.ts)): the ONE coordinator role (`AGT-ORCH-000`/`coo`) is always a permitted **target**. Target-only by design — any coworker may hand a thread *up* to coordination; the COO delegating outward still uses its declared `delegatesTo`; every hop still writes a `DelegationChain` row; the convene clearance clamp (§4a) is **not** bypassed. Callers that do not pass the set keep exact legacy fail-closed semantics.
2. **Coordinator contract block** — a DB-overridable `platform-identity/coordinator-contract` prompt block beside the ladder: specialists own the work on their surface and hand cross-cutting/contested/unowned questions to the COO; the COO routes, consults, convenes, never re-does specialist work, and holds a routed thread until someone owns it. Own block for the same reason as the ladder: an identity-block override must not silently drop the contract.

The coordinator is where ladder rung 2/3 points **when rung 1 has no decisive answer** — it does not replace direct peer consultation when the owner is obvious.

## Recorded open, deliberately (spec §4c)

The COO's own classification is `confidential`, so a fresh-install employee holding `["public"]` cannot have the coordinator convened into their thread — the §4b clearance matrix applies to the COO like any peer. Classifying the coordinator role lower vs seeding employee clearance higher is an **operator policy decision** this contract does not make. The mechanical intent-mismatch detection of BI-36408DB6 stays open on that BI.

## Verification

66 tests green across the touched suites (4 new: the 64-of-71 escalation case, no-declared-authority reaching the coordinator, target-only widening, legacy-caller semantics unchanged).

`pnpm run pregate` PASS — gated sha `e3d24ed56`.

Seed-Fit-Decision: global-default

`prompts/platform-identity/coordinator-contract.prompt.md` is a platform-identity block assembled into every coworker's prompt on every surface and install; no archetype or install-specific content; DB-overridable per install via its PromptTemplate row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)