### PR TITLE
feat(governance): make the consequential-tool gate reach what it governs (EP-1C37C089)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -95,6 +95,13 @@ export type ToolAnnotations = {
   irreversibleHint?: boolean;
 };
 
+/**
+ * Declared reach of a tool's effect. See `ToolDefinition.consequence`.
+ * Closed set: a new axis is a deliberate widening of what the gate governs,
+ * not a string literal someone invents at a call site.
+ */
+export type ToolConsequence = "outward" | "irreversible";
+
 export type ToolDefinition = {
   name: string;
   description: string;
@@ -109,6 +116,17 @@ export type ToolDefinition = {
   requiresExternalAccess?: boolean;
   executionMode?: "proposal" | "immediate";
   sideEffect?: boolean;
+  /**
+   * How far this tool's effect reaches. DECLARED, not inferred: "can this be
+   * undone" is not recoverable from the name, the schema, or `sideEffect`
+   * (true for `update_backlog_item` and `place_linkedin_ad` alike).
+   * `outward` = leaves the platform (third party, publish, spend) → the
+   * business stance governs it, so it is alignment-gated. `irreversible` =
+   * stays inside but no inverse call restores prior state → receipted, not
+   * alignment-gated. Absent = ordinary, which is a claim the coverage test
+   * pins rather than a default. Rationale: consequential-tool-policy.ts.
+   */
+  consequence?: ToolConsequence;
   /**
    * Tool captures the coworker's own recommendation or work product as a
    * structured artifact (e.g. save_marketing_review). Persistence-only; no

--- a/apps/web/lib/mcp/packs/admin-pack.ts
+++ b/apps/web/lib/mcp/packs/admin-pack.ts
@@ -113,6 +113,7 @@ const definitions: ToolDefinition[] = [
     requiredCapability: "view_admin",
     executionMode: "immediate",
     sideEffect: true, // Tier 3: potentially destructive
+    consequence: "irreversible",
   },
 ];
 

--- a/apps/web/lib/mcp/packs/backlog-pack-definitions.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack-definitions.ts
@@ -82,6 +82,7 @@ export const backlogPackDefinitions: ToolDefinition[] = [
     },
     requiredCapability: "manage_backlog",
     sideEffect: true,
+    consequence: "irreversible",
   },
   {
     name: "size_backlog_item",

--- a/apps/web/lib/mcp/packs/build-lifecycle-pack.ts
+++ b/apps/web/lib/mcp/packs/build-lifecycle-pack.ts
@@ -131,6 +131,7 @@ const definitions: ToolDefinition[] = [
     requiredCapability: "manage_capabilities",
     executionMode: "immediate",
     sideEffect: true,
+    consequence: "irreversible",
     buildPhases: ["ship"],
   },
   {
@@ -148,6 +149,7 @@ const definitions: ToolDefinition[] = [
     requiredCapability: "manage_capabilities",
     executionMode: "immediate",
     sideEffect: true,
+    consequence: "outward",
     buildPhases: ["ship"],
   },
   {

--- a/apps/web/lib/mcp/packs/contribution-hive-pack.ts
+++ b/apps/web/lib/mcp/packs/contribution-hive-pack.ts
@@ -48,6 +48,7 @@ const definitions: ToolDefinition[] = [
     requiredCapability: "view_platform",
     executionMode: "proposal",
     sideEffect: true,
+    consequence: "outward",
     buildPhases: ["ship"],
     // 2-state model (EP-1A78BAE1): there is no mode-based pre-authorization.
     // Sharing is a per-change human-in-the-loop decision (the FeatureBuild

--- a/apps/web/lib/mcp/packs/coworker-tool-grant-pack.ts
+++ b/apps/web/lib/mcp/packs/coworker-tool-grant-pack.ts
@@ -33,6 +33,7 @@ const definitions: ToolDefinition[] = [
     },
     requiredCapability: "manage_platform",
     sideEffect: true,
+    consequence: "irreversible",
   },
 ];
 

--- a/apps/web/lib/mcp/packs/feedback-pack.ts
+++ b/apps/web/lib/mcp/packs/feedback-pack.ts
@@ -45,6 +45,7 @@ const definitions: ToolDefinition[] = [
     },
     requiredCapability: null,
     sideEffect: true,
+    consequence: "outward",
   },
   {
     name: "register_tech_debt",

--- a/apps/web/lib/mcp/packs/marketing-ops-pack.ts
+++ b/apps/web/lib/mcp/packs/marketing-ops-pack.ts
@@ -124,6 +124,7 @@ const definitions: ToolDefinition[] = [
     },
     requiredCapability: "operate_marketing",
     sideEffect: true,
+    consequence: "outward",
   },
   {
     name: "send_marketing_email",
@@ -137,6 +138,7 @@ const definitions: ToolDefinition[] = [
     },
     requiredCapability: "operate_marketing",
     sideEffect: true,
+    consequence: "outward",
   },
   {
     name: "place_linkedin_ad",
@@ -150,6 +152,7 @@ const definitions: ToolDefinition[] = [
     },
     requiredCapability: "operate_marketing",
     sideEffect: true,
+    consequence: "outward",
   },
   {
     name: "refresh_channel_kpis",
@@ -175,6 +178,7 @@ const definitions: ToolDefinition[] = [
     },
     requiredCapability: "operate_marketing",
     sideEffect: true,
+    consequence: "outward",
   },
   {
     name: "plan_upcoming_marketing_drafts",

--- a/apps/web/lib/mcp/packs/mdm-stewardship-pack.ts
+++ b/apps/web/lib/mcp/packs/mdm-stewardship-pack.ts
@@ -32,6 +32,7 @@ const definitions: ToolDefinition[] = [
     },
     requiredCapability: "operate_customer",
     sideEffect: true,
+    consequence: "irreversible",
   },
   {
     name: "find_duplicate_customer_accounts",
@@ -72,6 +73,7 @@ const definitions: ToolDefinition[] = [
     },
     requiredCapability: "operate_customer",
     sideEffect: true,
+    consequence: "irreversible",
   },
   {
     name: "run_mdm_steward_sweep",

--- a/apps/web/lib/mcp/packs/platform-update-pack.ts
+++ b/apps/web/lib/mcp/packs/platform-update-pack.ts
@@ -20,6 +20,7 @@ const definitions: ToolDefinition[] = [
     requiredCapability: "manage_platform",
     executionMode: "immediate",
     sideEffect: true,
+    consequence: "irreversible",
   },
   {
     name: "summarize_upgrade_impact",

--- a/apps/web/lib/mcp/packs/release-pack.ts
+++ b/apps/web/lib/mcp/packs/release-pack.ts
@@ -64,6 +64,7 @@ const definitions: ToolDefinition[] = [
     requiredCapability: "view_operations" as const,
     executionMode: "immediate" as const,
     sideEffect: true,
+    consequence: "irreversible",
     buildPhases: ["ship"],
   },
   {

--- a/apps/web/lib/tak/consequential-tool-coverage.test.ts
+++ b/apps/web/lib/tak/consequential-tool-coverage.test.ts
@@ -1,0 +1,106 @@
+// Coverage conformance for the consequential-tool gate.
+//
+// The gate itself was never broken: it is fail-closed, it vetoes rather than
+// averages, and it refuses bypass arguments. What was broken was its REACH.
+// `ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES` carried nine names, seven of which
+// (`create_product`, `create_product_line`, `launch_campaign`,
+// `publish_storefront`, `send_quote`, `send_invoice`, `execute_change`)
+// matched no tool anywhere in the codebase. A name that resolves to nothing
+// gates nothing, so the list read as broad coverage while alignment actually
+// ran on two real tools out of ~198 side-effecting ones.
+//
+// That failure is silent by construction: nothing errors when a gate names a
+// tool that does not exist, and nothing errors when a tool that spends money
+// ships without a classification. These tests make both loud.
+
+import { describe, expect, it } from "vitest";
+import { PLATFORM_TOOLS, type ToolConsequence } from "@/lib/mcp-tools";
+import {
+  ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES,
+  classifyConsequentialTool,
+} from "./consequential-tool-policy";
+
+const byName = new Map(PLATFORM_TOOLS.map((t) => [t.name, t]));
+
+/**
+ * The declared set, pinned. This is the review surface: changing what an agent
+ * may do to the outside world without a human noticing requires editing this
+ * list, and the diff says so out loud.
+ */
+const EXPECTED: Record<string, ToolConsequence> = {
+  // Leaves the platform: reaches a third party, publishes externally, or spends money.
+  send_marketing_email: "outward",
+  publish_to_linkedin: "outward",
+  place_linkedin_ad: "outward",
+  tick_marketing_scheduler: "outward",
+  create_portal_pr: "outward",
+  contribute_to_hive: "outward",
+  escalate_feedback_upstream: "outward",
+  // Stays inside, but no inverse call restores the prior state.
+  admin_run_command: "irreversible",
+  apply_platform_update: "irreversible",
+  deploy_feature: "irreversible",
+  execute_promotion: "irreversible",
+  merge_customer_accounts: "irreversible",
+  merge_customer_contacts: "irreversible",
+  manage_coworker_tool_grant: "irreversible",
+  retire_backlog_item: "irreversible",
+};
+
+describe("consequential-tool coverage", () => {
+  // The regression that started this. A gate whose allowlist names a
+  // non-existent tool is not a narrow gate — it is an absent one.
+  it("every name the alignment list gates resolves to a real tool", () => {
+    const unresolved = ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES.filter((n) => !byName.has(n));
+    expect(unresolved).toEqual([]);
+  });
+
+  it("every tool declared consequential is registered and actually mutates", () => {
+    for (const [name, consequence] of Object.entries(EXPECTED)) {
+      const tool = byName.get(name);
+      expect(tool, `${name} is not a registered tool`).toBeDefined();
+      expect(tool!.consequence, `${name} lost its declaration`).toBe(consequence);
+      // A read cannot be irreversible. If this fails the declaration is wrong,
+      // not the test.
+      expect(tool!.sideEffect, `${name} declares consequence but no side effect`).toBe(true);
+    }
+  });
+
+  it("no tool declares a consequence without a side effect", () => {
+    const bogus = PLATFORM_TOOLS.filter((t) => t.consequence && !t.sideEffect).map((t) => t.name);
+    expect(bogus).toEqual([]);
+  });
+
+  it("routes what leaves the business through the alignment gate", () => {
+    for (const [name, consequence] of Object.entries(EXPECTED)) {
+      if (consequence !== "outward") continue;
+      const c = classifyConsequentialTool({ toolName: name, tool: byName.get(name)! });
+      expect(c.consequential, name).toBe(true);
+      expect(c.alignmentRequired, name).toBe(true);
+      expect(c.collaborationShape, name).toBe("outward-review");
+    }
+  });
+
+  // Deliberate asymmetry: an irreversible platform operation is recorded and
+  // receipted, but a BUSINESS stance has nothing to say about
+  // `admin_run_command`. Capability and authority govern those. Sending them
+  // through the WWWD corpus would manufacture escalations, not safety.
+  it("records irreversible platform operations without asking the business stance", () => {
+    for (const [name, consequence] of Object.entries(EXPECTED)) {
+      if (consequence !== "irreversible") continue;
+      const c = classifyConsequentialTool({ toolName: name, tool: byName.get(name)! });
+      expect(c.consequential, name).toBe(true);
+      expect(c.alignmentRequired, name).toBe(false);
+      expect(c.collaborationShape, name).toBe("change-consequential");
+    }
+  });
+
+  it("leaves ordinary bookkeeping mutations alone", () => {
+    const ordinary = byName.get("update_backlog_item");
+    expect(ordinary?.sideEffect).toBe(true);
+    expect(ordinary?.consequence).toBeUndefined();
+    const c = classifyConsequentialTool({ toolName: "update_backlog_item", tool: ordinary! });
+    expect(c.consequential).toBe(false);
+    expect(c.alignmentRequired).toBe(false);
+  });
+});

--- a/apps/web/lib/tak/consequential-tool-policy.test.ts
+++ b/apps/web/lib/tak/consequential-tool-policy.test.ts
@@ -24,12 +24,23 @@ describe("consequential tool policy", () => {
     }).collaborationShape).toBe("specialist-alignment");
   });
 
+  // These cases used to assert shapes for `send_quote` and `execute_change` —
+  // neither of which exists as a tool. The test passed because the classifier
+  // is keyed on a bare string, so it happily classifies a name nothing can
+  // call. The Work Room binding is now driven by the tool's DECLARED reach,
+  // and consequential-tool-coverage.test.ts checks these names resolve.
   it.each([
-    ["send_quote", "outward-review"],
-    ["execute_change", "change-consequential"],
-  ])("binds %s to the %s Work Room shape", (toolName, collaborationShape) => {
-    expect(classifyConsequentialTool({ toolName, tool: { sideEffect: true } }).collaborationShape)
+    ["send_marketing_email", "outward" as const, "outward-review"],
+    ["execute_promotion", "irreversible" as const, "change-consequential"],
+  ])("binds a %s tool to the %s Work Room shape", (toolName, consequence, collaborationShape) => {
+    expect(classifyConsequentialTool({ toolName, tool: { sideEffect: true, consequence } }).collaborationShape)
       .toBe(collaborationShape);
+  });
+
+  it("keeps the precondition-gated HR transition on its change shape", () => {
+    expect(classifyConsequentialTool({
+      toolName: "transition_employee_status", tool: { sideEffect: true },
+    })).toMatchObject({ consequential: true, preconditionRequired: true, collaborationShape: "change-consequential" });
   });
 
   it("does not charge ordinary bookkeeping mutations for an alignment check", () => {

--- a/apps/web/lib/tak/consequential-tool-policy.ts
+++ b/apps/web/lib/tak/consequential-tool-policy.ts
@@ -1,4 +1,4 @@
-import type { ToolDefinition } from "@/lib/mcp-tools";
+import type { ToolConsequence, ToolDefinition } from "@/lib/mcp-tools";
 import { getWorkCaseAction } from "@/lib/work-management/action-registry";
 import type { WorkCaseExecutionContext } from "@/lib/work-management/work-case-governance-hook";
 import type { WorkroomShapeKey } from "@/lib/work-management/room-shapes";
@@ -12,29 +12,49 @@ export type ConsequentialToolClassification = {
   alignmentRequired: boolean;
   preconditionRequired: boolean;
   collaborationShape: WorkroomShapeKey | null;
-  reason: "read-only" | "ordinary-side-effect" | "explicit-policy" | "work-case-consequential";
+  reason:
+    | "read-only"
+    | "ordinary-side-effect"
+    | "explicit-policy"
+    | "work-case-consequential"
+    | "declared-outward"
+    | "declared-irreversible";
 };
 
+/**
+ * Legacy name-keyed alignment list, kept only for tools that predate the
+ * declared `ToolDefinition.consequence` axis.
+ *
+ * It previously carried nine names, SEVEN of which matched nothing in the
+ * codebase (`create_product`, `create_product_line`, `launch_campaign`,
+ * `publish_storefront`, `send_quote`, `send_invoice`, `execute_change`). A
+ * name that resolves to no tool gates nothing, so the list read as broad
+ * coverage while alignment actually ran on two real tools. The dead names are
+ * removed and `every name resolves` is now a conformance test — the drift, not
+ * the list, was the defect.
+ */
 export const ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES = [
   "create_digital_product",
-  "create_product",
-  "create_product_line",
   "create_marketing_campaign",
-  "launch_campaign",
-  "publish_storefront",
-  "send_quote",
-  "send_invoice",
-  "execute_change",
 ] as const;
 const EXPLICIT = new Set<string>(ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES);
 const PRECONDITION = new Set(["transition_employee_status"]);
 
-export function collaborationShapeForTool(toolName: string): WorkroomShapeKey | null {
-  if (["create_digital_product", "create_product", "create_product_line", "create_marketing_campaign", "launch_campaign"]
-    .includes(toolName)) return "specialist-alignment";
-  if (["publish_storefront", "send_quote", "send_invoice"].includes(toolName)) return "outward-review";
-  if (toolName === "execute_change") return "change-consequential";
+/** Alignment applies to what leaves the business, not to internal platform ops. */
+function alignmentRequiredFor(toolName: string, consequence: ToolConsequence | undefined): boolean {
+  return consequence === "outward" || EXPLICIT.has(toolName);
+}
+
+export function collaborationShapeForTool(
+  toolName: string,
+  consequence?: ToolConsequence,
+): WorkroomShapeKey | null {
+  if (["create_digital_product", "create_marketing_campaign"].includes(toolName)) {
+    return "specialist-alignment";
+  }
   if (toolName === "transition_employee_status") return "change-consequential";
+  if (consequence === "outward") return "outward-review";
+  if (consequence === "irreversible") return "change-consequential";
   return null;
 }
 
@@ -44,26 +64,41 @@ export function collaborationShapeForTool(toolName: string): WorkroomShapeKey | 
  * Work Case metadata may elevate but never downgrade a call.
  */
 export function classifyConsequentialTool(input: {
-  tool: Pick<ToolDefinition, "sideEffect">;
+  tool: Pick<ToolDefinition, "sideEffect" | "consequence">;
   toolName: string;
   workCase?: WorkCaseExecutionContext;
 }): ConsequentialToolClassification {
+  const consequence = input.tool.consequence;
   const action = input.workCase ? getWorkCaseAction(input.workCase.action) : undefined;
   if (action?.consequential) {
     return {
       class: "consequential-mutation",
       consequential: true,
-      alignmentRequired: EXPLICIT.has(input.toolName),
+      alignmentRequired: alignmentRequiredFor(input.toolName, consequence),
       preconditionRequired: PRECONDITION.has(input.toolName),
-      collaborationShape: collaborationShapeForTool(input.toolName) ?? "change-consequential",
+      collaborationShape: collaborationShapeForTool(input.toolName, consequence) ?? "change-consequential",
       reason: "work-case-consequential",
+    };
+  }
+  // A declared reach is the tool's own claim about itself and outranks the
+  // legacy name list. `outward` additionally requires WWWD alignment;
+  // `irreversible` is receipted and reserved but not alignment-gated.
+  if (input.tool.sideEffect && consequence) {
+    return {
+      class: "consequential-mutation",
+      consequential: true,
+      alignmentRequired: alignmentRequiredFor(input.toolName, consequence),
+      preconditionRequired: PRECONDITION.has(input.toolName),
+      collaborationShape: collaborationShapeForTool(input.toolName, consequence),
+      reason: consequence === "outward" ? "declared-outward" : "declared-irreversible",
     };
   }
   if (input.tool.sideEffect && (EXPLICIT.has(input.toolName) || PRECONDITION.has(input.toolName))) {
     return {
-      class: "consequential-mutation", consequential: true, alignmentRequired: EXPLICIT.has(input.toolName),
+      class: "consequential-mutation", consequential: true,
+      alignmentRequired: alignmentRequiredFor(input.toolName, consequence),
       preconditionRequired: PRECONDITION.has(input.toolName),
-      collaborationShape: collaborationShapeForTool(input.toolName), reason: "explicit-policy",
+      collaborationShape: collaborationShapeForTool(input.toolName, consequence), reason: "explicit-policy",
     };
   }
   if (input.tool.sideEffect) {

--- a/docs/superpowers/plans/2026-08-16-consequential-tool-gate-coverage.md
+++ b/docs/superpowers/plans/2026-08-16-consequential-tool-gate-coverage.md
@@ -1,0 +1,83 @@
+# Make the consequential-tool gate's coverage match what it governs — plan
+
+**Status:** phase 1 shipped · 2026-08-16
+**Epic:** EP-1C37C089 (WWWD constitutional alignment gate)
+**Spec context:** [`2026-08-13-wwwd-constitutional-alignment-gate.md`](../specs/2026-08-13-wwwd-constitutional-alignment-gate.md)
+**Kernel decision:** `DI-D0F56A1E21D4` (composite 12.18 vs 11.97, margin 0.213)
+
+## 1. Problem
+
+The pre-execution governance gate shipped and works. It is fail-closed (no alignment receipt → `escalate` → the call is rejected), it **vetoes** rather than averaging (`composeAlignmentVerdicts`: any `decline` wins), and it refuses smuggled bypass arguments (`findAlignmentBypassArgument`).
+
+Its **coverage** was the defect.
+
+`ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES` listed nine tool names. **Seven matched nothing in the codebase:**
+
+```
+create_product   create_product_line   launch_campaign   publish_storefront
+send_quote       send_invoice          execute_change
+```
+
+A name that resolves to no tool gates nothing. So a list that reads like broad coverage of business-direction actions was, in effect, gating **two** real tools — `create_digital_product` and `create_marketing_campaign` — out of **~198 side-effecting** tools on the surface.
+
+The failure is silent by construction. Nothing errors when a gate names a tool that does not exist, and nothing errors when a tool that spends money ships with no classification. The existing policy test even asserted Work Room shapes for `send_quote` and `execute_change`; it passed, because the classifier is keyed on a bare string and will happily classify a name nothing can call.
+
+**Nothing declared irreversibility.** `ToolDefinition` carried `sideEffect`, which is equally true of `update_backlog_item` and `place_linkedin_ad`. Whether an effect can be undone was recoverable from neither the name, the schema, nor the flag — only from a hand-maintained list that had rotted.
+
+### What was ungated
+
+Found by hand (a name-pattern sweep missed the worst of them):
+
+| Tool | Why it matters |
+|---|---|
+| `place_linkedin_ad` | places a paid ad campaign — **money leaves the business** |
+| `send_marketing_email` | email to real recipients; unrecallable |
+| `publish_to_linkedin` | public post under the org's identity |
+| `tick_marketing_scheduler` | **fan-out**: dispatches every due `ScheduledOutboundAction` at once |
+| `create_portal_pr` | publishes a branch to the remote |
+| `contribute_to_hive` | publishes a FeaturePack to the community commons |
+| `admin_run_command` | shell execution |
+| `apply_platform_update`, `deploy_feature`, `execute_promotion` | change the running system |
+| `merge_customer_accounts` / `_contacts` | collapses identity records |
+| `manage_coworker_tool_grant` | **mutates the authorization model itself** |
+
+Several of these carry "only call after the user has explicitly approved" **in the tool description**. That is an instruction to a model, not an enforced gate — governance by politeness, which is exactly what a pre-execution interceptor exists to replace.
+
+## 2. Phase 1 — declared reach (this PR)
+
+**`ToolDefinition.consequence`** — a closed axis, `"outward" | "irreversible"`, declared by the tool's author because that is the only place the fact lives.
+
+- **`outward`** — the effect leaves the platform: reaches a third party, publishes externally, or spends money. The business's own WWWD stance governs whether it should happen → **alignment-gated**.
+- **`irreversible`** — the effect stays inside, but no inverse call restores the prior state → **consequential** (audit row, execution receipt, reservation) but **not** alignment-gated.
+
+**The asymmetry is deliberate.** A business stance has nothing to say about `admin_run_command`; capability and authority govern those. Routing internal platform operations through the WWWD corpus would manufacture escalations, not safety — and a gate that cries wolf gets bypassed. Alignment is spent where the business's own direction is genuinely the question: what leaves the business.
+
+`classifyConsequentialTool` reads the declaration first; the legacy name list survives only for the two tools that predate the axis, with its dead names removed.
+
+**Conformance (`consequential-tool-coverage.test.ts`)** — the drift, not the list, was the defect:
+1. every name in the alignment list resolves to a registered tool;
+2. every tool in the pinned declared set is registered, still declares its reach, and actually mutates;
+3. no tool declares a consequence without a side effect;
+4. `outward` classifies as alignment-required + `outward-review`; `irreversible` as consequential + not alignment-required.
+
+The pinned set is the review surface: widening what an agent may do to the outside world without a human noticing now requires editing a list whose diff says so.
+
+## 3. Operational consequence — read before upgrading
+
+This **changes runtime behaviour** for outward marketing actions. Once live, `send_marketing_email`, `publish_to_linkedin`, `place_linkedin_ad` and `tick_marketing_scheduler` must clear the WWWD alignment gate. If the organization's stance corpus is thin or unembedded, the gate is fail-closed and will **escalate rather than fire**.
+
+That is the intended behaviour — it is the platform promise ("keep humans in control of consequential automated decisions") applied to the actions that most obviously need it. But it is a real change to how autopilot behaves, and it reaches the live install only when the operator runs `/ops/self-upgrade`. An org running outbound marketing on autopilot should expect escalations until its stance corpus answers the question.
+
+## 4. Out of scope — named, not silently dropped
+
+**~180 side-effecting tools remain untriaged.** Absence of a declaration currently means "ordinary", which is a real claim nobody has actually checked for most of the surface. Phase 1 classifies the set that can be defended tool-by-tool; it does not sweep everything.
+
+Filed as **BI-B54D5B65**. The end state is a triage where every side-effecting tool has been consciously classified and the test asserts *completeness* rather than a pinned subset — at which point a new tool cannot ship without someone deciding what it can undo.
+
+Also out of scope: joining this to the evidence work (BI-8192557E). A consequential call clears an alignment gate today; it does not have to cite re-verifiable evidence for its own justification. That is a genuine next step, and `requireEvidence` still has no production callers (**BI-D045A069**).
+
+## 5. Verification
+
+- Unit: `pnpm --filter web exec vitest run lib/tak/ lib/mcp/ lib/mcp-governed-execute.test.ts` — 2,215 tests / 214 files.
+- Production build: `pnpm --filter web build`.
+- No migration. No UI surface, so no UX verification path.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -41,8 +41,8 @@ apps/web/lib/integrate/build-orchestrator.ts	1801
 apps/web/lib/integrate/sandbox/build-branch.ts	949
 apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp-tools-backlog.test.ts	874
-apps/web/lib/mcp-tools.ts	1953
-apps/web/lib/mcp/packs/contribution-hive-pack.ts	854
+apps/web/lib/mcp-tools.ts	1971
+apps/web/lib/mcp/packs/contribution-hive-pack.ts	855
 apps/web/lib/mcp/packs/sandbox-pack.ts	920
 apps/web/lib/navigation/portal-navigation-model.ts	965
 apps/web/lib/operate/coworker-regression-detector.ts	935


### PR DESCRIPTION
The pre-execution alignment gate was never broken. It is fail-closed (no alignment receipt → `escalate` → rejected), it **vetoes** rather than averaging, and it refuses smuggled bypass arguments. Its **coverage** was the defect.

## What was actually gated

`ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES` listed nine names. **Seven matched nothing in the codebase:** `create_product`, `create_product_line`, `launch_campaign`, `publish_storefront`, `send_quote`, `send_invoice`, `execute_change`.

A name that resolves to no tool gates nothing. A list that read as broad coverage of business-direction actions was gating **two** real tools out of **~198 side-effecting** ones.

The failure is silent by construction. The existing policy test asserted Work Room shapes for `send_quote` and `execute_change` — and passed, because the classifier keys on a bare string and will happily classify a name nothing can call. The test suite encoded the fiction.

## What was ungated

Nothing declared irreversibility. `sideEffect` is equally true of `update_backlog_item` and `place_linkedin_ad`, so "can this be undone" was recoverable from neither name, schema, nor flag.

| Tool | Why it matters |
|---|---|
| `place_linkedin_ad` | places a paid campaign — **money leaves the business** |
| `tick_marketing_scheduler` | **fan-out**: dispatches every due `ScheduledOutboundAction` at once |
| `send_marketing_email`, `publish_to_linkedin` | unrecallable, under the org's identity |
| `create_portal_pr`, `contribute_to_hive` | publish outward |
| `admin_run_command`, `deploy_feature`, `execute_promotion`, `apply_platform_update` | change the running system |
| `merge_customer_accounts` / `_contacts` | collapse identity records |
| `manage_coworker_tool_grant` | **mutates the authorization model itself** |

A name-pattern sweep missed `place_linkedin_ad`, `create_portal_pr` and `manage_coworker_tool_grant`; they were found by reading the full side-effect list by hand. Several carry *"only call after the user has explicitly approved"* **in the tool description** — an instruction to a model, not an enforced gate.

## The change

`ToolDefinition.consequence` — `"outward" | "irreversible"`, declared by the author because that is the only place the fact lives.

- **`outward`** — leaves the platform (third party, publish, spend). The business's own stance governs it → **alignment-gated**.
- **`irreversible`** — stays inside, no inverse call restores prior state → **receipted and reserved**, *not* alignment-gated.

**The asymmetry is deliberate.** A business stance has nothing to say about `admin_run_command`; capability and authority govern those. Routing internal platform ops through the WWWD corpus would manufacture escalations, not safety — and a gate that cries wolf gets bypassed.

Conformance test pins the declared set **and asserts every gated name resolves to a real tool**. The drift, not the list, was the defect.

## ⚠️ Changes runtime behaviour — read before upgrading

Outward marketing actions must now clear the WWWD alignment gate, which is fail-closed: **a thin or unembedded stance corpus will escalate rather than fire.** That is the intended promise applied where it matters most, but an org running outbound marketing on autopilot should expect escalations until its stance corpus answers the question. It reaches the live install only via operator-triggered `/ops/self-upgrade`.

## Scope — named, not silently dropped

**~180 side-effecting tools remain untriaged.** "No declaration" means "ordinary", and for most of the surface nobody has checked that. Filed as **BI-B54D5B65**, including the durable fix: flip the test from a pinned subset to a *completeness* assertion so a new tool cannot ship without someone deciding what it can undo.

Not joined to the evidence work (BI-8192557E) here: a consequential call clears an alignment gate, but does not yet have to cite re-verifiable evidence for its own justification. `requireEvidence` still has no production callers (**BI-D045A069**).

## Design grounding

See the commit's `## Design grounding` section. Plan: `docs/superpowers/plans/2026-08-16-consequential-tool-gate-coverage.md`. Scope routed through `principle_decide` (`DI-D0F56A1E21D4`, composite 12.18 vs 11.97 — a near tie; the decisive contribution was *Outbound and irreversible actions require explicit go* scoring **negative** for leaving them ungated).

## Verification

- `pnpm --filter web exec vitest run lib/tak/ lib/mcp/ lib/mcp-governed-execute.test.ts` — 2,215 tests / 214 files green.
- `pnpm --filter web build` — compiled successfully.
- `pnpm run pregate` — gate passed (evidence `cmswcyymx1e7s01pnw2214ato`, sha `43fc2ff5028a`). Two earlier attempts were killed by host-pressure SIGTERM mid-run, not by any guard; re-run on a quiet host passed.

No migration, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)