### PR TITLE
feat(security): standing three-surface security findings watch with observable cadence

### DIFF
--- a/.github/workflows/security-findings-watch.yml
+++ b/.github/workflows/security-findings-watch.yml
@@ -1,0 +1,122 @@
+name: Security Findings Watch
+
+# The standing sweep behind Workroom WC-42C558DD.
+#
+# WHY: the GitHub Security tab aggregates THREE independent surfaces — Dependabot
+# alerts, Code Scanning (CodeQL), and Secret Scanning. Nothing previously swept
+# all three together: dependency-scan.yml covers OSV/dependencies only, and
+# audit-stale-overrides.yml reads Dependabot only. A high-severity `js/redos`
+# code-scanning alert consequently sat unnoticed while a Dependabot-only check
+# reported an all-clear. This job is the reconciled view.
+#
+# OBSERVABILITY IS THE POINT: each run upserts ONE tracking issue that always
+# states the cadence, the last sweep time, and the next scheduled run — so "when
+# does this run and when did it last run" is answerable at a glance instead of
+# inferred from workflow history.
+#
+# REPORT-ONLY by design. The blocking gate stays `pnpm scan:deps --fail-on high`
+# in dependency-scan.yml; a visibility job that can fail the build would get
+# muted, which is the failure mode this exists to prevent.
+
+on:
+  schedule:
+    - cron: "51 6 * * *" # daily 06:51 UTC — 10 min after dependency-scan so OSV results are fresh
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - "scripts/sbom/sweep-security-surfaces.mjs"
+      - ".github/workflows/security-findings-watch.yml"
+
+permissions:
+  contents: read
+  security-events: read # read all three alert surfaces
+  issues: write # upsert the single watch tracking issue
+
+concurrency:
+  group: security-findings-watch-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CADENCE_HUMAN: "daily at 06:51 UTC"
+  WATCH_ROOM: WC-42C558DD
+
+jobs:
+  sweep:
+    name: Security findings sweep
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Sweep all three security surfaces
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/sbom/sweep-security-surfaces.mjs --json sbom/security-sweep.json --md sbom/security-sweep.md
+
+      - name: Publish sweep to the run summary
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo "_Cadence: **${CADENCE_HUMAN}** · watch room \`${WATCH_ROOM}\` · run \`${{ github.run_id }}\`._"
+            echo ""
+            cat sbom/security-sweep.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ONE long-lived issue, updated in place. Kept open even at zero findings so
+      # the cadence and last-swept time stay observable — an issue that vanishes
+      # when clean cannot tell you whether the watch is still running at all,
+      # which is the specific thing being asked for here.
+      - name: Upsert the watch tracking issue
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE="Security findings watch — standing report"
+          # Derived in Node, not `date -d`: -d is GNU-only and silently unavailable
+          # on BSD/macOS, which would make this step impossible to exercise outside CI.
+          NOW="$(node -e "console.log(new Date().toISOString().replace('T',' ').slice(0,16)+' UTC')")"
+          NEXT="$(node -e "const n=new Date();const t=new Date(Date.UTC(n.getUTCFullYear(),n.getUTCMonth(),n.getUTCDate(),6,51));if(t<=n)t.setUTCDate(t.getUTCDate()+1);console.log(t.toISOString().replace('T',' ').slice(0,16)+' UTC')")"
+          OPEN_TOTAL="$(node -e "const r=require('./sbom/security-sweep.json');console.log(r.totals.open)")"
+          UNREADABLE="$(node -e "const r=require('./sbom/security-sweep.json');console.log(r.totals.unreadable)")"
+
+          BODY_FILE="$(mktemp)"
+          {
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| **Cadence** | ${CADENCE_HUMAN} |"
+            echo "| **Last swept** | ${NOW} |"
+            echo "| **Next run** | ${NEXT} |"
+            echo "| **Open findings** | ${OPEN_TOTAL} |"
+            echo "| **Unreadable surfaces** | ${UNREADABLE} |"
+            echo "| **Watch room** | \`${WATCH_ROOM}\` |"
+            echo ""
+            cat sbom/security-sweep.md
+            echo ""
+            echo "<sub>Auto-updated by .github/workflows/security-findings-watch.yml — run ${{ github.run_id }}. Edits to this body are overwritten each sweep; put durable decisions in the watch room, not here.</sub>"
+          } > "$BODY_FILE"
+
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --body-file "$BODY_FILE"
+            echo "Updated watch issue #$EXISTING."
+          else
+            gh issue create --title "$TITLE" --body-file "$BODY_FILE"
+          fi
+
+      - name: Upload sweep artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: security-sweep-${{ github.run_id }}
+          path: |
+            sbom/security-sweep.json
+            sbom/security-sweep.md
+          if-no-files-found: warn
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,8 @@ services/adp/pnpm-lock.yaml
 /sbom/internalization-candidates.md
 /sbom/stale-override-audit.json
 /sbom/stale-override-audit.md
+/sbom/security-sweep.json
+/sbom/security-sweep.md
 
 # Python bytecode caches
 __pycache__/

--- a/scripts/sbom/sweep-security-surfaces.mjs
+++ b/scripts/sbom/sweep-security-surfaces.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// scripts/sbom/sweep-security-surfaces.mjs
+//
+// The standing security-findings sweep for Workroom WC-42C558DD.
+//
+// WHY THIS EXISTS: the GitHub Security tab aggregates THREE independent
+// surfaces — Dependabot alerts, Code Scanning (CodeQL), and Secret Scanning.
+// Querying only Dependabot under-reports, which is exactly how a high-severity
+// `js/redos` code-scanning alert sat unnoticed while we reported "2 open" to an
+// operator who could see 3. This sweeps all three in one pass and prints ONE
+// reconciled posture, so no surface can be silently missed again.
+//
+// It is REPORT-ONLY and never fails the build. The blocking gate is the OSV
+// scan (scripts/sbom/scan-dependencies.mjs --fail-on high); this is the
+// visibility layer on top of it.
+//
+//   node scripts/sbom/sweep-security-surfaces.mjs                 # human-readable
+//   node scripts/sbom/sweep-security-surfaces.mjs --json out.json # machine-readable
+//   node scripts/sbom/sweep-security-surfaces.mjs --md out.md     # markdown report
+//
+// Needs a token with `security-events: read` in GITHUB_TOKEN (or GH_TOKEN).
+// Offline / no token → prints a clear SKIPPED notice and exits 0, so a local
+// run or an air-gapped install degrades loudly rather than reporting a false
+// all-clear.
+
+import { writeFileSync } from "node:fs";
+
+const REPO = process.env.GITHUB_REPOSITORY ?? "OpenDigitalProductFactory/opendigitalproductfactory";
+const TOKEN = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? "";
+const API = process.env.GITHUB_API_URL ?? "https://api.github.com";
+
+const argOf = (flag) => {
+  const i = process.argv.indexOf(flag);
+  return i === -1 ? null : process.argv[i + 1];
+};
+
+/**
+ * Fetch every page of an alerts endpoint. Returns {ok, alerts, reason}.
+ *
+ * Pagination follows the `Link: rel="next"` header rather than incrementing a
+ * `page` param: the Dependabot alerts endpoint is CURSOR-paginated (before/after)
+ * and returns HTTP 400 for `page=`, while code/secret scanning are page-based.
+ * Link-following is the one form that is correct for all three.
+ */
+async function fetchAlerts(surface) {
+  if (!TOKEN) return { ok: false, alerts: [], reason: "no GITHUB_TOKEN/GH_TOKEN in the environment" };
+  const alerts = [];
+  let url = `${API}/repos/${REPO}/${surface}/alerts?state=open&per_page=100`;
+  for (let hop = 0; hop < 20 && url; hop++) {
+    let res;
+    try {
+      res = await fetch(url, {
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          accept: "application/vnd.github+json",
+          "x-github-api-version": "2022-11-28",
+        },
+      });
+    } catch (err) {
+      return { ok: false, alerts: [], reason: `network error: ${err.message}` };
+    }
+    // 404 here means the feature is disabled for the repo, not that it is clean —
+    // report it as unknown rather than folding it into a zero.
+    if (res.status === 404) return { ok: false, alerts: [], reason: "surface not enabled or not visible to this token (404)" };
+    if (res.status === 403) return { ok: false, alerts: [], reason: "token lacks security-events: read (403)" };
+    if (!res.ok) return { ok: false, alerts: [], reason: `HTTP ${res.status}` };
+    const batch = await res.json();
+    if (!Array.isArray(batch)) return { ok: false, alerts: [], reason: "unexpected non-array response" };
+    alerts.push(...batch);
+    url = /<([^>]+)>;\s*rel="next"/.exec(res.headers.get("link") ?? "")?.[1] ?? null;
+  }
+  return { ok: true, alerts, reason: null };
+}
+
+const sevOf = (a) =>
+  a.security_advisory?.severity ?? a.rule?.security_severity_level ?? a.rule?.severity ?? "unknown";
+
+function normalize(surface, a) {
+  if (surface === "dependabot") {
+    return {
+      number: a.number,
+      severity: sevOf(a),
+      label: a.dependency?.package?.name ?? "unknown",
+      detail: a.security_advisory?.ghsa_id ?? "",
+      hasFix: Boolean(a.security_vulnerability?.first_patched_version?.identifier),
+      url: a.html_url,
+    };
+  }
+  if (surface === "code-scanning") {
+    return {
+      number: a.number,
+      severity: sevOf(a),
+      label: a.rule?.id ?? "unknown",
+      detail: a.most_recent_instance?.location?.path ?? "",
+      url: a.html_url,
+    };
+  }
+  return { number: a.number, severity: "unknown", label: a.secret_type ?? "secret", detail: "", url: a.html_url };
+}
+
+const SURFACES = [
+  ["dependabot", "Dependabot"],
+  ["code-scanning", "Code scanning"],
+  ["secret-scanning", "Secret scanning"],
+];
+
+const report = { repo: REPO, surfaces: {}, totals: { open: 0, unreadable: 0 } };
+
+for (const [surface, title] of SURFACES) {
+  const { ok, alerts, reason } = await fetchAlerts(surface);
+  report.surfaces[surface] = ok
+    ? { title, readable: true, open: alerts.length, alerts: alerts.map((a) => normalize(surface, a)) }
+    : { title, readable: false, open: null, reason, alerts: [] };
+  if (ok) report.totals.open += alerts.length;
+  else report.totals.unreadable += 1;
+}
+
+// ---- output ----------------------------------------------------------------
+
+const lines = [];
+lines.push(`# Security findings sweep — ${REPO}`);
+lines.push("");
+if (report.totals.unreadable > 0) {
+  lines.push(
+    `> **${report.totals.unreadable} of 3 surfaces could not be read.** A surface that cannot be read is NOT a clean surface — treat this sweep as incomplete.`,
+  );
+  lines.push("");
+}
+lines.push("| Surface | Open |");
+lines.push("| --- | --- |");
+for (const [surface, title] of SURFACES) {
+  const s = report.surfaces[surface];
+  lines.push(`| ${title} | ${s.readable ? s.open : `⚠️ unreadable — ${s.reason}`} |`);
+}
+lines.push("");
+
+for (const [surface, title] of SURFACES) {
+  const s = report.surfaces[surface];
+  if (!s.readable || s.open === 0) continue;
+  lines.push(`## ${title} (${s.open})`);
+  lines.push("");
+  lines.push("| # | Severity | What | Where |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const a of s.alerts) {
+    const where = surface === "dependabot" && a.hasFix === false ? `${a.detail} · **no patched release**` : a.detail;
+    lines.push(`| [${a.number}](${a.url}) | ${a.severity} | \`${a.label}\` | ${where || "—"} |`);
+  }
+  lines.push("");
+}
+
+lines.push("---");
+lines.push("");
+lines.push("**A row here is not automatically an unfixed risk.** A finding can stay open because a");
+lines.push("`pnpm patch` fixed the defect without changing the version string OSV matches on. Reconcile");
+lines.push("against `sbom/vuln-baseline.json` and the decision history in Workroom **WC-42C558DD**");
+lines.push("before concluding anything. The authority on what is actually vulnerable is");
+lines.push("`pnpm scan:deps --fail-on high`, not this list.");
+
+const md = lines.join("\n");
+const mdOut = argOf("--md");
+const jsonOut = argOf("--json");
+if (mdOut) writeFileSync(mdOut, `${md}\n`);
+if (jsonOut) writeFileSync(jsonOut, `${JSON.stringify(report, null, 2)}\n`);
+
+console.log(md);
+
+if (report.totals.unreadable === 3) {
+  console.log("\nSKIPPED — no surface was readable (offline or no token). Not reporting an all-clear.");
+}


### PR DESCRIPTION
Gives Workroom **WC-42C558DD** a real trigger, and makes the cadence and next-run time observable at a glance.

## Why

The GitHub Security tab aggregates **three independent surfaces** — Dependabot, Code Scanning (CodeQL), Secret Scanning — and **nothing swept all three together**. `dependency-scan.yml` covers OSV/dependencies only; `audit-stale-overrides.yml` reads Dependabot only.

That gap is not theoretical: a high-severity `js/redos` code-scanning alert sat unnoticed while a Dependabot-only check reported an all-clear.

## What

**`scripts/sbom/sweep-security-surfaces.mjs`** — sweeps all three surfaces, prints one reconciled posture.

The important design choice: **an unreadable surface reports as UNREADABLE, never as zero.** A disabled feature, a 403, or an offline run must not read as a clean bill of health. With no token it prints a SKIPPED notice and exits 0 rather than claiming all-clear, so local and air-gapped installs degrade loudly.

**`.github/workflows/security-findings-watch.yml`** — daily **06:51 UTC**, 10 minutes after `dependency-scan` so OSV results are fresh.

Report-only by design. The blocking gate stays `pnpm scan:deps --fail-on high`; a visibility job that can fail the build gets muted, which is the exact failure mode this exists to prevent.

## Observability is the point

Each run **upserts one long-lived tracking issue** whose header answers "when does this run and when did it last run" without digging through workflow history:

| | |
| --- | --- |
| **Cadence** | daily at 06:51 UTC |
| **Last swept** | 2026-08-16 22:18 UTC |
| **Next run** | 2026-08-17 06:51 UTC |
| **Open findings** | 2 |
| **Unreadable surfaces** | 0 |
| **Watch room** | `WC-42C558DD` |

The issue stays open **even at zero findings** — an issue that disappears when clean cannot tell you whether the watch is still running at all.

## Verified live, not just structurally

- **The first run caught a real bug**: the Dependabot endpoint is *cursor*-paginated and returns HTTP 400 for `page=`. It surfaced as an *unreadable surface* rather than a false zero — the design working as intended. Pagination now follows the `Link: rel="next"` header, correct for all three surfaces.
- Re-run returns Dependabot 2 / code scanning 0 / secret scanning 0, matching direct `gh api` queries.
- The sweep **independently confirmed code-scanning #372 (`js/redos`) flipped to `fixed`** at 2026-08-16T22:07Z following #4377 — so that alert has now genuinely closed.
- The issue-body derivation was dry-run end to end (table above is real output).
- **Local CI gate passed** on the exact tree (`6a5535c23ec4`).

## Notes

- Next-run is derived in Node, not `date -u -d` — `-d` is GNU-only and silently unavailable on BSD/macOS, which would have made the step impossible to exercise outside CI.
- Sweep outputs are gitignored alongside the other generated `sbom/` reports.
- Durable decision history stays in the watch room; the issue body is overwritten each sweep and says so explicitly.

## What this does not do

A DPF scheduled *agent* task would surface cadence in the portal (`nextRunAt`), but those run as coworker MCP turns with no shell and no `gh` — so they cannot sweep GitHub. Portal-side cadence visibility for this watch remains open; the room notes it.