### PR TITLE
fix(decisions): a citation can only be refuted against source of known revision (BI-EE2B243D)

### DIFF
--- a/apps/web/lib/decision/evidence-reverification.test.ts
+++ b/apps/web/lib/decision/evidence-reverification.test.ts
@@ -66,7 +66,20 @@ function dbWith(citations: AdmissibleCitation[] | null, overrides: Record<string
   };
 }
 
-const AVAILABLE = (repoRoot: string): SourceAccess => ({ available: true, repoRoot });
+/** A real checkout: revision is knowable, so a miss is evidence about the citation. */
+const AVAILABLE = (repoRoot: string): SourceAccess => ({
+  available: true,
+  repoRoot,
+  anchored: true,
+  anchorDetail: "a git checkout",
+});
+/** Readable source of unknown revision — the live install's image-synced volume. */
+const UNANCHORED = (repoRoot: string): SourceAccess => ({
+  available: true,
+  repoRoot,
+  anchored: false,
+  anchorDetail: "NOT a git checkout, so its revision is unknown",
+});
 const UNAVAILABLE: SourceAccess = { available: false, detail: "no source checkout on this install" };
 const NEVER_CALLED: LocatorResolver = async () => {
   throw new Error("resolver must not be called");
@@ -194,6 +207,71 @@ describe("reverifyDecisionEvidence", () => {
       unverifiable: 1,
       complete: false,
     });
+  });
+
+  // BI-EE2B243D — the live regression. PROJECT_ROOT on the install is an
+  // image-synced source volume: package.json is present, `.git` is not, and the
+  // tree carries only PART of the repo. Every true citation resolved to nothing
+  // and the pass reported "degraded" — i.e. accused honest evidence of being
+  // fabricated. Absence in a tree of unknown revision proves nothing.
+  it("does NOT degrade a citation missing from a tree of unknown revision", async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "dpf-unanchored-"));
+    // Exactly the live shape: a plausible root, no .git, and the cited file absent.
+    await writeFile(join(repoRoot, "package.json"), "{}", "utf8");
+
+    const lookup = await reverifyDecisionEvidence({
+      db: dbWith([citation()]),
+      interactionId: "DI-TEST",
+      sourceAccess: UNANCHORED(repoRoot),
+      resolve: createRepoLocatorResolver({ repoRoot }),
+    });
+
+    if (!lookup.found) throw new Error("expected found");
+    expect(lookup.report.outcome).not.toBe("degraded");
+    expect(lookup.report.outcome).toBe("unverifiable");
+    expect(lookup.report.unverifiableCause).toBe("unanchored-source");
+    expect(lookup.report.degrade).toEqual([]);
+    expect(lookup.report.degraded).toBe(0);
+    expect(lookup.report.inconclusive).toEqual([
+      {
+        optionId: "option-a",
+        dimensionKey: "evidence_density",
+        rawVerdict: "unresolved",
+        reason: "unanchored-source",
+      },
+    ]);
+    expect(lookup.report.sourceAccess.anchored).toBe(false);
+  });
+
+  // Confirmation survives the anchoring rule: if the cited text IS there, it
+  // existed, whatever revision the tree is at. Only refutation needs an anchor.
+  it("still confirms a citation whose text is present on an unanchored tree", async () => {
+    const repoRoot = await fixtureRepo();
+    const lookup = await reverifyDecisionEvidence({
+      db: dbWith([citation()]),
+      interactionId: "DI-TEST",
+      sourceAccess: UNANCHORED(repoRoot),
+      resolve: createRepoLocatorResolver({ repoRoot }),
+    });
+
+    if (!lookup.found) throw new Error("expected found");
+    expect(lookup.report.outcome).toBe("verified");
+    expect(lookup.report.confirmed).toBe(1);
+    expect(lookup.report.inconclusive).toEqual([]);
+  });
+
+  it("keeps a real refutation when the tree IS a checkout", async () => {
+    const repoRoot = await fixtureRepo();
+    const lookup = await reverifyDecisionEvidence({
+      db: dbWith([citation({ locator: { sourceType: "code", filePath: "apps/web/lib/invented.ts" } })]),
+      interactionId: "DI-TEST",
+      sourceAccess: AVAILABLE(repoRoot),
+      resolve: createRepoLocatorResolver({ repoRoot }),
+    });
+
+    if (!lookup.found) throw new Error("expected found");
+    expect(lookup.report.outcome).toBe("degraded");
+    expect(lookup.report.inconclusive).toEqual([]);
   });
 
   it("reports a missing decision as not found rather than as an empty pass", async () => {

--- a/apps/web/lib/decision/evidence-reverification.ts
+++ b/apps/web/lib/decision/evidence-reverification.ts
@@ -27,6 +27,7 @@ import {
   reverifyCitations,
   type CitationReVerification,
   type LocatorResolver,
+  type ReVerificationVerdict,
 } from "@/lib/decision/evidence-reverifier";
 import {
   recordedCitationsFromSources,
@@ -34,9 +35,23 @@ import {
 } from "@/lib/decision/recorded-citations";
 import { decisionInteractionRowToEvaluation } from "@/lib/decision-perspective/persistence";
 
-/** Whether this install can read the source a `code`/`spec`/`doc` locator names. */
+/**
+ * Whether this install can read the source a `code`/`spec`/`doc` locator names,
+ * and — critically — whether that source can be tied to a known commit.
+ *
+ * `anchored` is what licenses a REFUTATION. Absence of a file only proves a
+ * citation false if we know which revision we are looking at; on a tree of
+ * unknown provenance, "the file is not here" is equally explained by the tree
+ * being partial or stale. The live install proved this the hard way: PROJECT_ROOT
+ * is an image-synced source volume with no `.git` and only part of the tree, so
+ * every true citation resolved to nothing and was reported as fabricated
+ * evidence (BI-EE2B243D).
+ *
+ * Confirmation is safe either way — if the cited text IS present, it existed —
+ * so an unanchored tree still confirms; it just may never degrade.
+ */
 export type SourceAccess =
-  | { available: true; repoRoot: string }
+  | { available: true; repoRoot: string; anchored: boolean; anchorDetail: string }
   | { available: false; detail: string };
 
 /**
@@ -49,7 +64,20 @@ export type SourceAccess =
  */
 export type DecisionEvidenceOutcome = "verified" | "degraded" | "unverifiable";
 
-export type UnverifiableCause = "no-source-access" | "no-recorded-locators";
+export type UnverifiableCause =
+  | "no-source-access"
+  | "no-recorded-locators"
+  /** Source is readable but of unknown revision, so nothing can be refuted. */
+  | "unanchored-source";
+
+/** A citation that was checked but cannot be adjudicated on this tree. */
+export type InconclusiveCitation = {
+  optionId: string;
+  dimensionKey: string;
+  /** What the raw pass said before the anchoring rule softened it. */
+  rawVerdict: ReVerificationVerdict;
+  reason: "unanchored-source";
+};
 
 export type DecisionEvidenceReport = {
   interactionId: string;
@@ -71,11 +99,17 @@ export type DecisionEvidenceReport = {
   confirmed: number;
   degraded: number;
   unresolved: number;
-  /** (option, dimension) pairs whose evidence no longer holds. */
+  /** (option, dimension) pairs whose evidence no longer holds. Empty on an unanchored tree. */
   degrade: Array<{ optionId: string; dimensionKey: string }>;
+  /**
+   * Checked, but not adjudicable here. On an unanchored tree a non-confirming
+   * citation lands here instead of in `degrade` — it is an open question, not a
+   * finding against the decision.
+   */
+  inconclusive: InconclusiveCitation[];
   results: CitationReVerification[];
   unverifiableSources: UnverifiableSource[];
-  sourceAccess: { available: boolean; detail: string };
+  sourceAccess: { available: boolean; anchored: boolean; detail: string };
 };
 
 export type DecisionEvidenceLookup =
@@ -131,7 +165,7 @@ function emptyReport(
   recordedSources: number,
   unverifiableSources: UnverifiableSource[],
   cause: UnverifiableCause,
-  sourceAccess: { available: boolean; detail: string },
+  sourceAccess: { available: boolean; anchored: boolean; detail: string },
 ): DecisionEvidenceReport {
   return {
     interactionId,
@@ -149,6 +183,7 @@ function emptyReport(
     degraded: 0,
     unresolved: 0,
     degrade: [],
+    inconclusive: [],
     results: [],
     unverifiableSources,
     sourceAccess,
@@ -183,10 +218,11 @@ export async function reverifyDecisionEvidence(input: {
 
   const question = typeof row.question === "string" ? row.question : null;
   const recordedAt = row.createdAt instanceof Date ? row.createdAt : null;
+  const anchored = input.sourceAccess.available && input.sourceAccess.anchored;
   const accessDetail = input.sourceAccess.available
-    ? `source readable at ${input.sourceAccess.repoRoot}`
+    ? `source readable at ${input.sourceAccess.repoRoot} — ${input.sourceAccess.anchorDetail}`
     : input.sourceAccess.detail;
-  const access = { available: input.sourceAccess.available, detail: accessDetail };
+  const access = { available: input.sourceAccess.available, anchored, detail: accessDetail };
 
   // Re-use the audit read path rather than parsing the jsonb here, so the
   // verifier sees exactly what the Decision Canvas sees.
@@ -235,24 +271,48 @@ export async function reverifyDecisionEvidence(input: {
 
   const report = await reverifyCitations(citations, input.resolve);
 
+  // The anchoring rule. On a tree whose revision we cannot establish, a
+  // non-confirming result is an OPEN QUESTION, not a finding: the file may be
+  // absent because the citation was false, or because this tree is partial or
+  // stale, and nothing here distinguishes those. Confirmation survives — if the
+  // cited text is present, it existed — so the pass stays useful without ever
+  // manufacturing a fabrication verdict out of a deployment artifact.
+  const inconclusive: InconclusiveCitation[] = anchored
+    ? []
+    : report.results
+      .filter((r) => r.verdict !== "confirmed")
+      .map((r) => ({
+        optionId: r.optionId,
+        dimensionKey: r.dimensionKey,
+        rawVerdict: r.verdict,
+        reason: "unanchored-source" as const,
+      }));
+  const degrade = anchored ? report.degrade : [];
+  const outcome: DecisionEvidenceOutcome = degrade.length > 0
+    ? "degraded"
+    : report.confirmed > 0
+      ? "verified"
+      : "unverifiable";
+
   return {
     found: true,
     report: {
       interactionId: String(row.interactionId ?? input.interactionId),
       question,
       recordedAt,
-      outcome: report.degrade.length > 0 ? "degraded" : "verified",
-      unverifiableCause: null,
+      outcome,
+      unverifiableCause: outcome === "unverifiable" && !anchored ? "unanchored-source" : null,
       coverage: {
         recordedSources,
         checked: citations.length,
         unverifiable: unverifiable.length,
-        complete: unverifiable.length === 0,
+        complete: unverifiable.length === 0 && inconclusive.length === 0,
       },
       confirmed: report.confirmed,
-      degraded: report.degraded,
-      unresolved: report.unresolved,
-      degrade: report.degrade,
+      degraded: anchored ? report.degraded : 0,
+      unresolved: anchored ? report.unresolved : 0,
+      degrade,
+      inconclusive,
       results: report.results,
       unverifiableSources: unverifiable,
       sourceAccess: access,

--- a/apps/web/lib/mcp/packs/decision-reverify-pack.ts
+++ b/apps/web/lib/mcp/packs/decision-reverify-pack.ts
@@ -27,7 +27,8 @@ const definitions: ToolDefinition[] = [
     name: "reverify_decision_evidence",
     description:
       "Independently re-check the evidence cited by a recorded decision. Loads the decision's persisted citations and re-resolves each structured locator (code/spec/doc) against live source, reporting which citations still hold and which no longer do. Use it to audit a past decision before relying on it, or to spot a citation that was well-formed but never true. " +
-      "Read THREE fields together, they mean different things: `outcome` ('verified' = every citation that could be checked still holds; 'degraded' = at least one no longer holds; 'unverifiable' = nothing could be checked), `unverifiableCause` (why nothing could be checked), and `coverage` (how many of the decision's recorded sources were actually checkable). A 'verified' outcome at low coverage is NOT a clean bill of health for the decision. " +
+      "Read FOUR fields together, they mean different things: `outcome` ('verified' = every citation that could be adjudicated still holds; 'degraded' = at least one no longer holds; 'unverifiable' = nothing could be adjudicated), `unverifiableCause` (why), `coverage` (how many recorded sources were actually checkable), and `inconclusive` (citations looked up but not adjudicable in this environment). A 'verified' outcome at low coverage is NOT a clean bill of health for the decision. " +
+      "A citation can only be REFUTED against source of known revision. Where the source is not a checkout, a citation that fails to resolve is reported as inconclusive, never as degraded — absence in a tree of unknown provenance is not evidence the citation was false. " +
       "Advisory and read-only: it does not change the decision or its score. Call once per decision; do not poll.",
     inputSchema: {
       type: "object",
@@ -54,18 +55,29 @@ function summarize(report: {
   confirmed: number;
   degraded: number;
   unresolved: number;
-  sourceAccess: { detail: string };
+  inconclusive: unknown[];
+  sourceAccess: { anchored: boolean; detail: string };
 }): string {
   const { coverage } = report;
+  const open = report.inconclusive.length;
+  // Never phrase an unanchored miss as a finding against the decision.
+  const openNote = open > 0
+    ? ` ${open} citation(s) could NOT be adjudicated here: ${report.sourceAccess.detail}. That is an open question about this environment, not evidence against the decision — re-run where the source is a checkout.`
+    : "";
+
   if (report.outcome === "unverifiable") {
-    return report.unverifiableCause === "no-source-access"
-      ? `Cannot verify: ${report.sourceAccess.detail}. This is an environment limitation, NOT a finding about the decision's evidence — none of its ${coverage.recordedSources} recorded source(s) were checked.`
-      : `Cannot verify: none of the ${coverage.recordedSources} recorded source(s) carry a re-resolvable locator, so this decision's evidence is opaque to re-verification. Treat it as unverified, not as verified.`;
+    if (report.unverifiableCause === "no-source-access") {
+      return `Cannot verify: ${report.sourceAccess.detail}. This is an environment limitation, NOT a finding about the decision's evidence — none of its ${coverage.recordedSources} recorded source(s) were checked.`;
+    }
+    if (report.unverifiableCause === "unanchored-source") {
+      return `Cannot verify: ${report.sourceAccess.detail}. ${coverage.checked} citation(s) were looked up and none could be confirmed, but on a tree of unknown revision that does NOT mean they are false — treat this as unverified, not as fabricated.`;
+    }
+    return `Cannot verify: none of the ${coverage.recordedSources} recorded source(s) carry a re-resolvable locator, so this decision's evidence is opaque to re-verification. Treat it as unverified, not as verified.`;
   }
   const scope = `Checked ${coverage.checked} of ${coverage.recordedSources} recorded source(s)${coverage.unverifiable > 0 ? `; ${coverage.unverifiable} carried no re-resolvable locator and were NOT checked` : ""}.`;
   return report.outcome === "degraded"
     ? `Evidence DEGRADED: ${report.degraded} citation(s) no longer match their source and ${report.unresolved} no longer resolve at all. ${scope} The affected (option, dimension) pairs should be treated as unevidenced.`
-    : `Evidence holds: all ${report.confirmed} checked citation(s) still resolve and still match. ${scope}${coverage.unverifiable > 0 ? " Coverage is partial — this is not a clean bill of health for the whole decision." : ""}`;
+    : `Evidence holds: ${report.confirmed} checked citation(s) still resolve and still match. ${scope}${openNote}${coverage.unverifiable > 0 ? " Coverage is partial — this is not a clean bill of health for the whole decision." : ""}`;
 }
 
 async function reverifyDecisionEvidenceHandler(
@@ -98,12 +110,26 @@ async function reverifyDecisionEvidenceHandler(
     const repoRoot = getProjectRoot();
     const { existsSync } = await import("node:fs");
     const { join } = await import("node:path");
-    sourceAccess = existsSync(join(repoRoot, "package.json"))
-      ? { available: true, repoRoot }
-      : {
+    if (!existsSync(join(repoRoot, "package.json"))) {
+      sourceAccess = {
         available: false,
         detail: `no source found at ${repoRoot} (mount the project via PROJECT_ROOT to enable re-verification)`,
       };
+    } else {
+      // A checkout carries `.git` (a directory, or a file when it is a
+      // worktree). Without it the tree has no revision we can name, and an
+      // image-synced source volume is exactly that — readable, partial, and
+      // silent about which commit it represents.
+      const anchored = existsSync(join(repoRoot, ".git"));
+      sourceAccess = {
+        available: true,
+        repoRoot,
+        anchored,
+        anchorDetail: anchored
+          ? "a git checkout, so a missing file is evidence about the citation"
+          : "NOT a git checkout, so its revision is unknown; citations can be confirmed here but never refuted",
+      };
+    }
   }
 
   const resolve = sourceAccess.available

--- a/docs/superpowers/plans/2026-08-15-wire-evidence-reverifier-plan.md
+++ b/docs/superpowers/plans/2026-08-15-wire-evidence-reverifier-plan.md
@@ -107,6 +107,29 @@ Phase 2 therefore splits:
 
 **Path guard (security).** A cited `filePath` is attacker-influenced data — it comes from whatever agent made the decision and is echoed back as `liveExcerpt`. Phase 1's resolver confines reads to the repo root, but the repo root legitimately *contains* `.env`, keys and credential files, so an unguarded citation naming one would round-trip its contents to any caller holding `registry_read`. `guardResolverPaths` wraps the resolver with `isPathAllowedSync` — the same blocklist `read_project_file` enforces — and a blocked path fails closed to `unresolved`. Regression-tested against a fixture repo containing a planted secret.
 
+#### Phase 2b.1 — the anchoring rule (correction, BI-EE2B243D)
+
+**2b shipped with a defect that only functional verification on the live install could find.** Run against a real decision minutes after the install self-upgraded, every one of four *true* citations came back `degraded` — the fabrication verdict — with `sourceAccess: {available: true, detail: "source readable at /workspace"}`.
+
+The citations were correct; the resolver could not see the files. `PROJECT_ROOT=/workspace` is the Build Studio image-synced source volume: it has `package.json` at the root (so the availability probe said "available"), it has **no `.git`**, and it carries only *part* of the tree — `apps/web/lib/decision/` held 7 files and was missing `recorded-citations.ts`, `evidence-grounding.ts`, `evidence-reverifier.ts` and `locator-resolver.ts`, all merged and deployed.
+
+This is precisely the failure the three-way outcome existed to prevent, defeated by a probe too coarse to notice. And it is the worst available failure for this feature: **a false accusation of fabricated evidence** is more damaging than declining to check.
+
+**The rule: a citation can only be REFUTED against source of known revision.**
+
+Absence is evidence only when you know which revision you are looking at. On a tree of unknown provenance, "the file is not here" is equally explained by the citation being false, the tree being partial, or the tree being stale — and nothing distinguishes them. Confirmation is not symmetric: if the cited text *is* present, it existed, whatever revision the tree is at. So:
+
+| tree | resolves + matches | anything else |
+|---|---|---|
+| anchored (a `.git` checkout) | `confirmed` | `degraded` — a real finding |
+| unanchored | `confirmed` | `inconclusive` — an open question about the environment |
+
+`SourceAccess` gains `anchored` + `anchorDetail`; the report gains `inconclusive[]` and the cause `unanchored-source`; `degrade` is empty on an unanchored tree by construction. The tool description now states the asymmetry, because the description is what an agent reads before trusting a verdict.
+
+**Consequence for this install:** re-verification is confirm-only until the verifier is pointed at a checkout. That is the honest state — better inert than wrong — and the report says exactly why rather than going quiet.
+
+**Regression test** plants the live shape precisely: a root with `package.json`, no `.git`, and the cited file absent. It must yield `unverifiable` / `unanchored-source`, never `degraded`. The original suite missed this because every fixture either contained the cited file or fabricated a path in a tree that was otherwise complete.
+
 **Deliberately NOT in 2b: recording the verdict.** The plan bullet above says "record degraded pairs"; that is held back to phase 3, for a reason found while building. The decision row is sealed into the append-only hash chain and a write guard forbids mutating sealed fields, so a verdict cannot be written back onto it — it needs its own record, whose shape is determined by how phase 3 consumes a degrade during re-scoring. Inventing that record now would fix the shape before the consumer exists. 2b is read-only and advisory, which is also the cleaner separation-of-duties story.
 
 ### Phase 3 — degrade feeds Axis 1


### PR DESCRIPTION
Found by running `reverify_decision_evidence` against a real decision on the **live install**, minutes after it self-upgraded to `48cbb33e6`. Four citations, all pointing at files that exist at the deployed commit, came back **`degraded`** — the fabrication verdict — with `sourceAccess: {available: true, detail: "source readable at /workspace"}`.

The citations were true. The resolver could not see the files.

## Root cause

`PROJECT_ROOT` on this install is the Build Studio image-synced source volume:

- `package.json` at the root — so the availability probe said "available"
- **no `.git`** — so the tree's revision is unknowable
- **only part of the tree** — `apps/web/lib/decision/` held 7 files, missing `recorded-citations.ts`, `evidence-grounding.ts`, `evidence-reverifier.ts` and `locator-resolver.ts`, all merged and deployed

This is precisely the failure the three-way outcome shipped in phase 2b existed to prevent, defeated by a probe too coarse to notice. And it is the worst failure available to this feature: **falsely accusing honest evidence of being fabricated is more damaging than declining to check.**

## The rule

**Absence is evidence only when you know which revision you are looking at.** On a tree of unknown provenance, "the file is not here" is equally explained by a false citation, a partial tree, or a stale tree — and nothing distinguishes them.

Confirmation is *not* symmetric: if the cited text **is** present, it existed, whatever revision the tree is at. So an unanchored tree may confirm, and may never refute.

| tree | resolves + matches | anything else |
|---|---|---|
| anchored (`.git` checkout) | `confirmed` | `degraded` — a real finding |
| unanchored | `confirmed` | `inconclusive` — an open question about the environment |

`SourceAccess` gains `anchored` + `anchorDetail`; the report gains `inconclusive[]` and the cause `unanchored-source`; `degrade` is empty on an unanchored tree by construction. The tool description states the asymmetry, since that is what an agent reads before trusting a verdict.

## Consequence for this install

Re-verification becomes **confirm-only** until it is pointed at a checkout. That is the honest state — better inert than wrong — and the report says exactly why rather than going quiet. Pointing `PROJECT_ROOT` at a real checkout (or resolving against the deployed commit's git tree) restores refutation; that is the natural follow-on, not this PR.

## Regression test

Plants the live shape precisely: a root with `package.json`, **no** `.git`, and the cited file absent → must yield `unverifiable` / `unanchored-source`, never `degraded`. Plus: an unanchored tree still confirms a present citation, and an anchored tree still degrades a fabricated one.

The original suite missed this because every fixture either contained the cited file or fabricated a path in an otherwise **complete** tree — the partial-tree case was never modelled.

## Verification

- `pnpm --filter web exec vitest run lib/decision lib/mcp/packs/decision-reverify-pack.test.ts` — 526 tests / 59 files green.
- `pnpm --filter web build` — compiled successfully.
- `pnpm run pregate` — gate passed (evidence `cmswf978702it01o3snx0qsv2`, sha `31761b59fb37`).

No migration, no UI surface. Plan updated in the same PR (`Phase 2b.1 — the anchoring rule`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)