### PR TITLE
fix(installer): warn when Windows skips agent-toolchain wiring instead of skipping silently

### DIFF
--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -1852,6 +1852,14 @@ if (-not (Test-StepDone "started")) {
 if (-not (Test-StepDone "mcp_seed")) {
     # Seed per-worktree MCP config first (idempotent; needs the token already
     # generated at Admin > Platform Development > MCP).
+    # Neither of the two scripts below ships in the release bundle, so on a
+    # `consumer` install both Test-Path checks are false. That is expected --
+    # install-dpf.sh gates the same convergence on contributor mode ("customer
+    # installs don't need agent CLIs wired up") -- but it must not be SILENT.
+    # Without an else branch, "the script isn't here" is indistinguishable from
+    # "it ran and succeeded", and we then Save-Progress the step as done. A user
+    # expecting MCP-connected agents after install gets no signal about why they
+    # are absent. install-dpf.sh already warns in this case; match it.
     $seedScript = Join-Path $DPF_DIR "scripts\seed-worktree-mcp.ps1"
     if (Test-Path $seedScript) {
         Write-Action "Seeding MCP token to worktrees..."
@@ -1860,6 +1868,8 @@ if (-not (Test-StepDone "mcp_seed")) {
         } catch {
             Write-Warn "MCP seed step encountered an issue (non-fatal): $_"
         }
+    } else {
+        Write-Warn "scripts\seed-worktree-mcp.ps1 not found; skipping MCP token seeding."
     }
 
     # Converge the agent toolchain (Claude + Codex + kernel memory + state).
@@ -1871,6 +1881,11 @@ if (-not (Test-StepDone "mcp_seed")) {
         } catch {
             Write-Warn "Agent toolchain bootstrap encountered an issue (non-fatal): $_"
         }
+    } else {
+        Write-Warn "scripts\dpf-bootstrap-agent-toolchain.ps1 not found; skipping agent toolchain convergence."
+        Write-Warn "Agent CLIs (Claude Code / Codex) will NOT be wired to this install's MCP endpoint."
+        Write-Warn "To connect one later: Admin > Platform Development > MCP, issue a token, then add the"
+        Write-Warn "'dpf' server to your agent client's config using that token."
     }
     Save-Progress "mcp_seed"
 }

--- a/scripts/check-installer-skip-visibility.test.mjs
+++ b/scripts/check-installer-skip-visibility.test.mjs
@@ -1,0 +1,103 @@
+// A guarded step that skips in silence is indistinguishable from one that ran and
+// succeeded -- and this installer then records the step as done via Save-Progress.
+//
+// The agent-toolchain block is the case that motivated this. Neither
+// scripts/seed-worktree-mcp.ps1 nor scripts/dpf-bootstrap-agent-toolchain.ps1 ships
+// in the release bundle, so on a `consumer` install both Test-Path guards are false.
+// That much is intentional -- install-dpf.sh gates the same convergence on
+// contributor mode, commenting "customer installs don't need agent CLIs wired up".
+//
+// The defect was that install-dpf.ps1 had no `else`, so a Ready-to-go install
+// completed with agent wiring silently absent and no explanation, while the POSIX
+// installer warned in exactly the same situation. A user who expected
+// MCP-connected agents had nothing to go on.
+//
+// This asserts the *visibility* contract, not the bundling decision: if a step is
+// skipped because its script is absent, the operator must be told.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const psInstaller = readFileSync(join(repoRoot, "install-dpf.ps1"), "utf8");
+const shInstaller = readFileSync(join(repoRoot, "install-dpf.sh"), "utf8");
+
+/** Optional-script guards in install-dpf.ps1 that must explain themselves when skipped. */
+const GUARDED_STEPS = Object.freeze([
+  { varName: "seedScript", script: "seed-worktree-mcp.ps1" },
+  { varName: "bootstrapScript", script: "dpf-bootstrap-agent-toolchain.ps1" },
+]);
+
+/**
+ * Return the source of the `if (Test-Path $<varName>) { ... } else { ... }` construct,
+ * brace-matched from the guard so we read the real else branch rather than a regex guess.
+ */
+function guardBlock(source, varName) {
+  const guard = new RegExp(`if\\s*\\(Test-Path\\s+\\$${varName}\\)\\s*\\{`);
+  const m = source.match(guard);
+  assert.ok(m, `install-dpf.ps1 should still guard $${varName} with Test-Path`);
+
+  let i = source.indexOf("{", m.index);
+  let depth = 0;
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  // Include whatever follows the closing brace, so an `else { ... }` is visible.
+  const tail = source.slice(i, i + 700);
+  return { body: source.slice(m.index, i + 1), tail };
+}
+
+for (const { varName, script } of GUARDED_STEPS) {
+  test(`skipping ${script} is reported to the operator, not silent`, () => {
+    const { tail } = guardBlock(psInstaller, varName);
+    assert.match(
+      tail,
+      /^\}\s*else\s*\{/,
+      `install-dpf.ps1: the Test-Path guard for ${script} has no else branch, so its absence ` +
+        `is silent and then recorded as done by Save-Progress "mcp_seed"`,
+    );
+    const elseBody = tail.slice(0, tail.indexOf("}", tail.indexOf("else")) + 1);
+    assert.match(
+      elseBody,
+      /Write-Warn/,
+      `install-dpf.ps1: the else branch for ${script} must Write-Warn so the skip is visible`,
+    );
+    assert.ok(
+      elseBody.includes(script),
+      `install-dpf.ps1: the warning for ${script} should name the script the operator is missing`,
+    );
+  });
+}
+
+test("the Windows warning matches the POSIX installer, which already warns", () => {
+  // install-dpf.sh:
+  //   warn "scripts/dpf-bootstrap-agent-toolchain.sh not found; skipping agent toolchain convergence."
+  assert.match(
+    shInstaller,
+    /warn "scripts\/dpf-bootstrap-agent-toolchain\.sh not found; skipping agent toolchain convergence\."/,
+    "install-dpf.sh should still warn here; if this moved, keep the two installers in step",
+  );
+  assert.match(
+    psInstaller,
+    /skipping agent toolchain convergence\./,
+    "install-dpf.ps1 should warn with the same wording as install-dpf.sh",
+  );
+});
+
+test("a skipped agent-toolchain step tells the operator how to connect MCP later", () => {
+  // The consumer path has no supported route to a working connector, so the warning
+  // is the only place the operator learns what to do instead.
+  const { tail } = guardBlock(psInstaller, "bootstrapScript");
+  assert.match(
+    tail,
+    /Platform Development > MCP/,
+    "the skip warning should point at Admin > Platform Development > MCP for issuing a token",
+  );
+});

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -30,6 +30,7 @@ const EXPECTED_LEGACY_JOBS = [
   "finding-substrate-guard",
   "fpaw-standard-guard",
   "host-port-range-guard",
+  "installer-skip-visibility",
   "installer-state-contract",
   "instruction-plane-guard",
   "instruction-plane-rule-coverage",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -55,6 +55,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       // out of the install dir must ship in the image's /dpf-release-assets.
       node("--test", "scripts/check-release-asset-contract.test.mjs"),
     ]),
+    guard("installer-skip-visibility", "Installer Skip Visibility", [
+      // A guarded install step that skips in silence reads as success, and is
+      // then recorded as done by Save-Progress. Optional-script guards must say so.
+      node("--test", "scripts/check-installer-skip-visibility.test.mjs"),
+    ]),
     guard("installer-state-contract", "Installer State Contract", [
       // Drives real bash: install-dpf.sh runs under `set -euo pipefail`, and the
       // failure mode here is shell exit-status semantics, not source text.


### PR DESCRIPTION
## What

`install-dpf.ps1` guarded two optional steps — `seed-worktree-mcp.ps1` and
`dpf-bootstrap-agent-toolchain.ps1` — with a bare `if (Test-Path ...)` and **no
`else`**, then recorded the step complete via `Save-Progress "mcp_seed"`.

Neither script ships in the release bundle, so on a `consumer` ("Ready to go")
install both guards are false and both blocks are skipped.

## Why this is a bug (and what it isn't)

The skipping is at least partly **intentional**. `install-dpf.sh:465` gates the
same convergence on install mode:

```sh
# Contributor mode only — customer installs don't need agent CLIs wired up.
if [ "$DPF_INSTALL_MODE" = "contributor" ]; then
```

…and, crucially, **warns** when the script is absent. Windows did neither: no mode
gate, and no warning. A Ready-to-go install therefore finishes reporting complete
success with agent CLIs unwired, no indication why, and no signposting of the
manual route.

This PR fixes the **silence**, not the bundling. Whether consumer installs should
converge the agent toolchain at all is a product decision the two installers
currently disagree on — filed separately rather than settled here.

## How it was found

Restoring MCP connectivity by hand after a from-zero reset + reinstall rehearsal.
The manual steps this warning now describes are exactly the ones that were needed.

## Changes

- `install-dpf.ps1` — `else { Write-Warn ... }` on both guards, matching
  `install-dpf.sh`'s existing wording, and pointing at
  **Admin > Platform Development > MCP** for the manual route.
- `scripts/check-installer-skip-visibility.test.mjs` — new policy guard: an
  optional-script guard that skips must name the missing script and explain the
  consequence. Brace-matches the real `else` branch rather than regex-guessing.
- Registered as `installer-skip-visibility` in the guard registry and inventory.

## Verification

The guard fails against the pre-fix installer and passes after:

```
✖ a skipped agent-toolchain step tells the operator how to connect MCP later
  AssertionError: the skip warning should point at Admin > Platform Development > MCP
```

After the fix: `pass 4 / fail 0`. `ci-policy-guards`, `release-asset-contract`
and the sibling contract guards all still pass.

## Note on the pattern

Third instance of one failure mode in this install path: a missing link in a chain
reporting success for the whole (cf. a `cp` without its `COPY`, and images built
but never merged into a manifest). Here the guard *is* the bug — `if (Test-Path)`
treats "the file is missing" as "nothing to do".

🤖 Generated with [Claude Code](https://claude.com/claude-code)