### PR TITLE
docs(professions): seed the security-services WSID corpus from a guard-patrol dogfood

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 661,
+  "pageCount": 665,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -7749,6 +7749,50 @@
         "why",
         "how-to-apply",
         "see-also"
+      ]
+    },
+    "docs/professions/security-guarding-operations/wiki/alarm-response-and-keyholding-duty.md": {
+      "publicHref": "/professions/security-guarding-operations/wiki/alarm-response-and-keyholding-duty/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "heuristic",
+        "interoperability-posture",
+        "source"
+      ]
+    },
+    "docs/professions/security-guarding-operations/wiki/assignment-instructions-and-post-orders.md": {
+      "publicHref": "/professions/security-guarding-operations/wiki/assignment-instructions-and-post-orders/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "heuristic",
+        "interoperability-posture",
+        "source"
+      ]
+    },
+    "docs/professions/security-guarding-operations/wiki/officer-licensing-and-vetting-currency.md": {
+      "publicHref": "/professions/security-guarding-operations/wiki/officer-licensing-and-vetting-currency/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "heuristic",
+        "interoperability-posture",
+        "source"
+      ]
+    },
+    "docs/professions/security-guarding-operations/wiki/patrol-verification-and-proof-of-presence.md": {
+      "publicHref": "/professions/security-guarding-operations/wiki/patrol-verification-and-proof-of-presence/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "heuristic",
+        "interoperability-posture",
+        "source"
       ]
     },
     "docs/professions/security/wiki/cis-controls-implementation-groups.md": {

--- a/docs/professions/security-guarding-operations/wiki/alarm-response-and-keyholding-duty.md
+++ b/docs/professions/security-guarding-operations/wiki/alarm-response-and-keyholding-duty.md
@@ -1,0 +1,37 @@
+---
+title: Response obligations run on a clock the customer is buying, and keys are a custodial duty
+pageKind: heuristic
+status: published
+abstract: Alarm response is sold as a time-bounded promise and keyholding as custody of a customer's means of entry; both fail quietly unless the clock and the chain of custody are recorded per event.
+professionCompetencyLevel: practitioner
+professionArchetype:
+  - security-services
+sources:
+  - bsi/bs-7984-keyholding
+---
+
+## Heuristic
+
+An activation starts a clock. Record the moments, not a duration, because durations cannot be audited and moments can:
+
+- activation received, and from whom or what;
+- response accepted and by which officer;
+- arrival on site;
+- site made secure, or escalation to police or the customer;
+- stand-down, with the outcome and cause where known.
+
+Attendance is not the deliverable. The deliverable is a determination — false activation, genuine intrusion, environmental cause, or fault — and the customer's next action depends on which. A response record that ends at "attended, all secure" discards the fact worth keeping.
+
+Keys and access credentials are custody, not inventory. Track which officer holds what, from when, under what authority, and what was returned. A key held by someone who has left is an incident, and its discovery should not depend on anyone thinking to look.
+
+Repeated false activations are a commercial and regulatory problem, not just an operational nuisance. Count them per site and per cause, because policing response is withdrawn on those counts and the customer usually learns this later than the provider could have told them.
+
+Never let response commitments outrun coverage. A response time promised across more sites than the on-duty pattern can reach is a promise that fails on the worst night, which is the night it is tested.
+
+## Interoperability posture
+
+Keep activations, responses, custody events, and outcomes as separate linked records with stable identifiers, so alarm receiving centres, monitoring platforms, and customer portals can integrate or be replaced without losing the evidentiary timeline.
+
+## Source
+
+- BSI BS 7984 — keyholding and response services

--- a/docs/professions/security-guarding-operations/wiki/assignment-instructions-and-post-orders.md
+++ b/docs/professions/security-guarding-operations/wiki/assignment-instructions-and-post-orders.md
@@ -1,0 +1,36 @@
+---
+title: The site, not the contract, is the unit of operational truth
+pageKind: heuristic
+status: published
+abstract: A guarding contract is sold per customer but delivered per site, and every access code, escalation path, and post order belongs to the site rather than to the account that pays for it.
+professionCompetencyLevel: practitioner
+professionArchetype:
+  - security-services
+sources:
+  - bsi/bs-7499-static-and-mobile
+---
+
+## Heuristic
+
+Hold sites as first-class records beneath the customer, because one customer routinely has many, and almost nothing an officer needs is true across all of them. Coverage, billing, and instructions are each scoped differently, so an account-level model forces guesswork at the gate.
+
+Per site, keep what an officer arriving at 03:00 must have without phoning anyone:
+
+- access route, gate and door specifics, parking, and safe approach;
+- alarm codes and key or fob custody, held under stated authority;
+- post orders — what to patrol, what to check, what to leave alone;
+- hazards, dogs, occupancy, and lone-working constraints;
+- escalation path with names and hours, and what the customer wants done before they are called;
+- what counts as an incident *here*, which is rarely the generic definition.
+
+Post orders decay. They are written once at mobilisation and then diverge from the site as codes rotate, contacts leave, and layouts change. Give them a review date and an owner, and treat an officer's report of a stale instruction as a defect to fix rather than a note to file.
+
+Separate what the customer is buying from what the site needs. Contracted hours, rates, and recurring agreements sit with the account; the operational truth sits with the site. Conflating them makes it impossible to answer either "what are we owed?" or "what happens tonight?" without reconstructing the other.
+
+## Interoperability posture
+
+Model customer, site, post order, assignment, and recurring agreement as separate linked records with stable identifiers, so billing systems, workforce scheduling, and field applications can each read the slice they need without duplicating the site record.
+
+## Source
+
+- BSI BS 7499 — static site guarding and mobile patrol services

--- a/docs/professions/security-guarding-operations/wiki/officer-licensing-and-vetting-currency.md
+++ b/docs/professions/security-guarding-operations/wiki/officer-licensing-and-vetting-currency.md
@@ -1,0 +1,45 @@
+---
+title: Treat licence and vetting currency as a deployment gate, not a personnel record
+pageKind: heuristic
+status: published
+abstract: An unlicensed or unvetted officer on a post is a contractual and regulatory breach the moment the shift starts; currency must be checked before assignment, not audited afterwards.
+professionCompetencyLevel: practitioner
+professionArchetype:
+  - security-services
+sources:
+  - bsi/bs-7858-screening
+  - bsi/bs-7499-static-and-mobile
+---
+
+## Heuristic
+
+Hold licence and screening state per officer as dated facts with an explicit expiry, and evaluate them at the moment of assignment. A roster that fills a post from a list of names, rather than from a list of officers currently cleared for that post, will eventually place someone unlicensed on site.
+
+Record separately, because they expire on different clocks:
+
+- the individual licence or permit, with issuing authority, number, class, and expiry;
+- screening and background checks, with the date completed and the period they cover;
+- site-specific clearances, inductions, and any customer-imposed vetting;
+- training and competency records the deployment depends on, such as first aid, conflict management, or a physical-intervention qualification;
+- restrictions attached to any of the above.
+
+Deployment is a chain, and the weakest dated fact governs it:
+
+- officer licensed for the *class* of work the post requires;
+- screening current and unbroken across the period claimed;
+- site clearance granted and not withdrawn by the customer;
+- required competencies in date;
+- working-time and rest position permitting the shift.
+
+Expiries are scheduled work, not alerts. A licence lapsing in six weeks is a rostering constraint now, because the replacement must be cleared before the gap opens. Warn on the lead time the *remedy* needs, not on the expiry date.
+
+Never infer currency from a previous shift. Presence on last week's roster is evidence of past deployment, not of present eligibility.
+
+## Interoperability posture
+
+Keep officers, licences, screening records, competencies, site clearances, and assignments as separate linked records with stable identifiers, so licence-authority checks, screening providers, and customer vetting portals can be reconciled without rewriting the deployment history.
+
+## Source
+
+- BSI BS 7858 — screening of individuals working in a secure environment
+- BSI BS 7499 — static site guarding and mobile patrol services

--- a/docs/professions/security-guarding-operations/wiki/patrol-verification-and-proof-of-presence.md
+++ b/docs/professions/security-guarding-operations/wiki/patrol-verification-and-proof-of-presence.md
@@ -1,0 +1,37 @@
+---
+title: A patrol you cannot evidence is a patrol you did not sell
+pageKind: heuristic
+status: published
+abstract: Mobile patrol and tour services are bought as recurring assurance; without per-visit proof of presence the service is unbillable, undefendable in dispute, and indistinguishable from absence.
+professionCompetencyLevel: practitioner
+professionArchetype:
+  - security-services
+sources:
+  - bsi/bs-7499-static-and-mobile
+---
+
+## Heuristic
+
+Model the visit, not the route. A route is a plan; a visit is the thing that happened, and it is the visit a customer disputes, an insurer asks about, and an invoice rests on.
+
+Capture per visit:
+
+- site and the specific checkpoints or areas covered;
+- officer identity, arrival and departure times from the site itself;
+- how presence was evidenced — scanned point, geotagged record, or signed log;
+- exceptions found, with enough detail to act on rather than merely to file;
+- anything deliberately not done, and why.
+
+Randomised timing is a service feature, so do not let the schedule become the evidence. If patrols are contracted as unpredictable, the record must show what actually occurred, and the plan must not be reconstructible from it by the people it is meant to deter.
+
+Treat a missed checkpoint as an event, not a gap in a report. Something prevented it — access denied, an obstruction, a vehicle fault, an officer diverted to an alarm — and that cause is usually more valuable to the customer than the scan would have been.
+
+Keep proof of presence separate from narrative. The narrative explains; the proof stands alone when a claim is contested months later and the officer no longer works for the company.
+
+## Interoperability posture
+
+Give sites, checkpoints, visits, officers, and exceptions stable identifiers and independent records, so scanning hardware, telematics, and customer reporting portals can be substituted without invalidating historical evidence.
+
+## Source
+
+- BSI BS 7499 — static site guarding and mobile patrol services


### PR DESCRIPTION
## What this fixes

`security-services` was the **weakest of all 25 archetype categories**. Before:

```
CATEGORY                     corpus decision | fin setup vocab play bizctx
security-services               0      .     |  .   .    .     Y    Y
```

Zero WSID corpus pages — every other category had at least one — no coworker
decision, and three of five substrate dimensions missing.

The completeness gate's own header names exactly this failure mode: an archetype
must not ship "the template substrate alone and forget its corpus + coworker (as
warehousing-fulfilment did before it was backfilled)".

## How it was found

By running the archetype as a fictitious company — a licensed guarding and mobile
patrol firm — through a from-zero install and walking its real operating loop.

The gap did not present as a gap. Because *security*, *guard*, *control room*,
*alarm* and *incident* are all core software-operations vocabulary, coworker
search returned confident wrong answers rather than no match:

| Query | Returned | Actually does |
|---|---|---|
| `security officer` | Security Auditor | CVE scanning, npm supply-chain audit |
| `guard` | Architecture Guardrail | architecture conformance |
| `control room` | **Finance Controller** | budget governance |
| `alarm response` | SOC Incident Commander | cyber containment |
| `patrol`, `rostering` | *no match* | — |

The workspace showed the same substitution: the territory map for this field
business listed "12 technicians" who were Build Frontend Engineer, Architecture
Guardrail and Platform Admin.

## What's added

Four practitioner-level heuristics, each covering something the walk showed had
nowhere to live:

- **`officer-licensing-and-vetting-currency`** — licence and screening state as
  dated facts evaluated *at assignment*, with expiry treated as scheduled work on
  the remedy's lead time rather than an alert on the date.
- **`patrol-verification-and-proof-of-presence`** — the visit, not the route, as
  the record; proof kept separable from narrative so it stands when contested
  months later.
- **`alarm-response-and-keyholding-duty`** — response as recorded moments rather
  than a duration; keys as custody; false-activation counts as a commercial fact.
- **`assignment-instructions-and-post-orders`** — the site, not the contract, as
  the unit of operational truth; post-order decay as a defect to fix.

`corpus 0 → 4`, matching `warehousing-fulfilment`. Gate passes. Doc index
regenerated 661 → 665.

## What this deliberately does not do

**No coworker decision line.** My own evidence says neither disposition would be
truthful: `extends:dispatcher` overstates it (Dispatcher covers routing and field
exceptions, not licence currency or key custody), `seeded:` is false, and
`new-planned:` needs a backlog id in *this* repo's backlog, which a dogfooding
instance cannot create.

So `security-services` stays grandfathered in the baseline. This shrinks the gap
on its hardest dimension; it does not claim to close it. A maintainer recording
that decision would complete it.

I could not run `check:prose-lint` locally (no `node_modules` in the working
clone) — CI is the check on style here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)