### PR TITLE
refactor(scripts): sweep entrypoint guards to shared symlink-robust isEntryModule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,7 @@ COPY scripts/lib/module-size-scope.mjs ./scripts/lib/
 COPY scripts/lib/ci-policy-guards.mjs ./scripts/lib/
 COPY scripts/lib/host-command-invocation.mjs ./scripts/lib/
 COPY scripts/lib/git-fetch-shared-safe.mjs ./scripts/lib/
+COPY scripts/lib/entry-module.mjs ./scripts/lib/
 COPY scripts/module-size-baseline.txt ./scripts/
 COPY scripts/prose-lint-baseline.json ./scripts/
 COPY scripts/style-drift-baseline.json ./scripts/

--- a/scripts/check-build-script-policy.mjs
+++ b/scripts/check-build-script-policy.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import { readFile } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
+
+import { isEntryModule } from "./lib/entry-module.mjs";
 
 function unquote(value) {
   if (
@@ -86,6 +87,6 @@ async function main() {
   console.log(`Build-script policy guard passed (${result.scanned} explicit decisions).`);
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if (isEntryModule(import.meta.url)) {
   await main();
 }

--- a/scripts/ci-policy-guards.mjs
+++ b/scripts/ci-policy-guards.mjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 
 import { appendFileSync, writeFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 
 import {
   POLICY_GUARD_PROFILES,
   formatRunSummary,
   runPolicyProfile,
 } from "./lib/ci-policy-guards.mjs";
+import { isEntryModule } from "./lib/entry-module.mjs";
 
 function argument(name) {
   const index = process.argv.indexOf(name);
@@ -79,6 +79,6 @@ export async function main() {
   if (!result.ok) process.exitCode = 1;
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if (isEntryModule(import.meta.url)) {
   await main();
 }

--- a/scripts/gate-context.mjs
+++ b/scripts/gate-context.mjs
@@ -18,9 +18,9 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { buildGateContext, formatGateContextMarkdown } from "./lib/gate-context.mjs";
+import { isEntryModule } from "./lib/entry-module.mjs";
 
 // Same conservative ref/path pinning as the gate checkers
 // (js/indirect-command-line-injection): execFile arg arrays, no shell, and a
@@ -131,6 +131,6 @@ export async function main() {
   process.stdout.write(`${formatGateContextMarkdown(context)}\n`);
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if (isEntryModule(import.meta.url)) {
   await main();
 }

--- a/scripts/lib/bootstrap-worktree-deps.mjs
+++ b/scripts/lib/bootstrap-worktree-deps.mjs
@@ -20,6 +20,7 @@
 import { existsSync, readFileSync, readdirSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { resolveHostCommandInvocation } from "./host-command-invocation.mjs";
+import { isEntryModule } from "./entry-module.mjs";
 import { parseRepositoryPnpmVersion, resolvePinnedPnpmInvocation } from "./pinned-pnpm.mjs";
 
 export { resolvePinnedPnpmInvocation } from "./pinned-pnpm.mjs";
@@ -419,9 +420,7 @@ export function bootstrapWorktreeDeps(worktreePath, opts = {}) {
 // break the seed script (the worktree just stays source-only). Skipped on import
 // so unit tests of the pure helpers never trigger an install (mirrors
 // worktree-create.mjs).
-const invokedDirectly =
-  process.argv[1] && process.argv[1].replace(/\\/g, "/").endsWith("bootstrap-worktree-deps.mjs");
-if (invokedDirectly) {
+if (isEntryModule(import.meta.url)) {
   const args = process.argv.slice(2);
   const classifyOnly = args.includes("--classify-only");
   const target = args.find((a) => !a.startsWith("--")) ?? process.cwd();

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -319,6 +319,9 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         // nothing about it.
         "scripts/lib/pregate-console.test.mjs",
         "scripts/lib/pregate-status.test.mjs",
+        // Symlink-robust entry guard shared by the pregate script family: a
+        // guard that misses makes the gate exit 0 silently (false pass).
+        "scripts/lib/entry-module.test.mjs",
       ),
       node("scripts/runtime-artifact-janitor.mjs", "--help"),
     ]),

--- a/scripts/lib/dev-portal-workspace-preflight.mjs
+++ b/scripts/lib/dev-portal-workspace-preflight.mjs
@@ -16,8 +16,9 @@
  *     file is not available when the mount is gone.
  */
 
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /**
  * @typedef {{ ok: true } | { ok: false; reason: string; detail: string }} PreflightResult
@@ -185,11 +186,22 @@ function main() {
   process.exit(preflightExitCode(result));
 }
 
-const entry = typeof process.argv[1] === "string" ? process.argv[1].replace(/\\/g, "/") : "";
-const isMain =
-  entry.endsWith("/dev-portal-workspace-preflight.mjs")
-  || entry.endsWith("dev-portal-workspace-preflight.mjs");
+// Self-contained mirror of scripts/lib/entry-module.mjs `isEntryModule` — this
+// file is baked ALONE into the image at /usr/local/bin (Dockerfile), where a
+// relative import cannot resolve. Realpath both spellings so a symlinked
+// invocation path (macOS /var tmpdir) cannot make the guard silently skip main().
+function isEntryScript() {
+  const argvPath = process.argv[1];
+  if (!argvPath) return false;
+  const thisFile = fileURLToPath(import.meta.url);
+  if (argvPath === thisFile) return true;
+  try {
+    return realpathSync(argvPath) === realpathSync(thisFile);
+  } catch {
+    return false;
+  }
+}
 
-if (isMain) {
+if (isEntryScript()) {
   main();
 }

--- a/scripts/lib/dev-portal-workspace-preflight.test.mjs
+++ b/scripts/lib/dev-portal-workspace-preflight.test.mjs
@@ -4,7 +4,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, chmodSync, readFileSync, rmSync, symlinkSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -191,6 +191,35 @@ exit 99
       false,
       "pnpm/dev chain must not run when preflight fails",
     );
+  });
+
+  // BI-FFFEFBCC: this file is baked ALONE into the image (no lib/entry-module.mjs
+  // beside it), so its entry guard is a self-contained realpath mirror. Pin that
+  // the guard still fires — main() runs and reports the empty workspace — when
+  // the script is invoked through a symlinked directory (macOS /var tmpdir shape).
+  it("still runs main() when invoked through a symlinked path", (t) => {
+    const temp = mkdtempSync(join(tmpdir(), "dpf-preflight-symlink-"));
+    const link = join(temp, "lib-link");
+    try {
+      // "junction" keeps this runnable on Windows hosts without symlink privilege.
+      symlinkSync(here, link, "junction");
+    } catch (error) {
+      rmSync(temp, { recursive: true, force: true });
+      t.skip(`cannot create a directory symlink on this host: ${error.code}`);
+      return;
+    }
+    try {
+      const empty = mkdtempSync(join(tmpdir(), "dpf-empty-ws-"));
+      const run = spawnSync(process.execPath, [join(link, "dev-portal-workspace-preflight.mjs")], {
+        env: { ...process.env, DPF_DEV_PORTAL_WORKSPACE_ROOT: empty },
+        encoding: "utf8",
+      });
+      assert.notEqual(run.status, 0, "main() must run under a symlinked argv[1], not silently exit 0");
+      assert.match(run.stderr || "", /BI-0DF1F354|package-json-missing|STOPPING/i);
+      rmSync(empty, { recursive: true, force: true });
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
   });
 
   it("Dockerfile bakes preflight into the image path (structural)", () => {

--- a/scripts/lib/entry-module.mjs
+++ b/scripts/lib/entry-module.mjs
@@ -1,0 +1,26 @@
+// entry-module.mjs — symlink-robust "am I the executed entry script?" check.
+//
+// The naive guard `process.argv[1] === fileURLToPath(import.meta.url)` breaks
+// whenever the caller's spelling of the path and the ESM loader's disagree
+// about symlinks: without --preserve-symlinks-main Node realpath-resolves the
+// entry module, so a script invoked through a symlinked path (macOS
+// `/var/folders` tmpdir resolving to `/private/var`, symlinked checkouts) sees
+// import.meta.url name the real path while argv[1] keeps the caller's
+// spelling. The guard is then false, main() never runs, and the process exits
+// 0 with no output — a silent false "pass" from any gate script invoked that
+// way. Compare realpaths so both spellings agree before deciding.
+
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export function isEntryModule(importMetaUrl, argvPath = process.argv[1]) {
+  if (!argvPath) return false;
+  const thisFile = fileURLToPath(importMetaUrl);
+  if (argvPath === thisFile) return true;
+  try {
+    return realpathSync(argvPath) === realpathSync(thisFile);
+  } catch {
+    // argv[1] (or this file) no longer resolves — not a matching entry path.
+    return false;
+  }
+}

--- a/scripts/lib/entry-module.test.mjs
+++ b/scripts/lib/entry-module.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { test } from "node:test";
+import { isEntryModule } from "./entry-module.mjs";
+
+test("isEntryModule matches when argv[1] is the exact entry path", () => {
+  const temp = mkdtempSync(join(tmpdir(), "dpf-entry-module-"));
+  try {
+    const script = join(temp, "script.mjs");
+    writeFileSync(script, "export {};\n");
+    assert.equal(isEntryModule(pathToFileURL(script).href, script), true);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("isEntryModule matches when argv[1] reaches the entry through a symlink", () => {
+  const temp = mkdtempSync(join(tmpdir(), "dpf-entry-module-"));
+  try {
+    const script = join(temp, "script.mjs");
+    writeFileSync(script, "export {};\n");
+    const link = join(temp, "link.mjs");
+    symlinkSync(script, link);
+    // The loader hands import.meta.url the real path while the caller typed
+    // the symlink — the exact macOS /var vs /private/var tmpdir shape.
+    assert.equal(isEntryModule(pathToFileURL(script).href, link), true);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("isEntryModule rejects a different file and a missing argv path", () => {
+  const temp = mkdtempSync(join(tmpdir(), "dpf-entry-module-"));
+  try {
+    const script = join(temp, "script.mjs");
+    const other = join(temp, "other.mjs");
+    writeFileSync(script, "export {};\n");
+    writeFileSync(other, "export {};\n");
+    assert.equal(isEntryModule(pathToFileURL(script).href, other), false);
+    assert.equal(isEntryModule(pathToFileURL(script).href, undefined), false);
+    assert.equal(isEntryModule(pathToFileURL(script).href, join(temp, "gone.mjs")), false);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+});

--- a/scripts/lib/git-fetch-shared-safe.mjs
+++ b/scripts/lib/git-fetch-shared-safe.mjs
@@ -17,6 +17,8 @@
 
 import { execFileSync } from "node:child_process";
 
+import { isEntryModule } from "./entry-module.mjs";
+
 /**
  * @param {(args: string[]) => string} git  — exec wrapper returning stdout
  * @returns {boolean}
@@ -101,10 +103,7 @@ export function defaultGit(args) {
 }
 
 // CLI: node scripts/lib/git-fetch-shared-safe.mjs assert|fetch
-const entry = typeof process.argv[1] === "string" ? process.argv[1].replace(/\\/g, "/") : "";
-const isMain =
-  entry.endsWith("/git-fetch-shared-safe.mjs") || entry.endsWith("git-fetch-shared-safe.mjs");
-if (isMain) {
+if (isEntryModule(import.meta.url)) {
   const cmd = process.argv[2] || "assert";
   try {
     if (cmd === "assert") {

--- a/scripts/lib/git-shallow-preflight.mjs
+++ b/scripts/lib/git-shallow-preflight.mjs
@@ -8,6 +8,8 @@ import { existsSync, statSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
+import { isEntryModule } from "./entry-module.mjs";
+
 /**
  * @param {string} cwd
  * @param {string[]} args
@@ -173,10 +175,7 @@ export function ensureFullHistory(opts) {
 }
 
 // CLI: node scripts/lib/git-shallow-preflight.mjs [cwd]
-const invoked =
-  process.argv[1] &&
-  process.argv[1].replace(/\\/g, "/").endsWith("git-shallow-preflight.mjs");
-if (invoked) {
+if (isEntryModule(import.meta.url)) {
   const cwd = process.argv[2] || process.cwd();
   const result = ensureFullHistory({ cwd, fetch: true });
   if (!result.ok) {

--- a/scripts/lib/junction-safe-worktree-remove.mjs
+++ b/scripts/lib/junction-safe-worktree-remove.mjs
@@ -22,6 +22,8 @@
 import { lstatSync, readdirSync, rmdirSync, unlinkSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 
+import { isEntryModule } from "./entry-module.mjs";
+
 // node_modules is THE reparse-point vector in DPF worktrees: <wt>/node_modules
 // and the workspace packages' <wt>/{apps,packages,services}/*/node_modules.
 const NODE_MODULES = "node_modules";
@@ -164,7 +166,6 @@ function main(argv) {
 }
 
 // Run only when invoked directly (not when imported by a test).
-const invokedPath = process.argv[1] ? process.argv[1].replace(/\\/g, "/") : "";
-if (invokedPath.endsWith("junction-safe-worktree-remove.mjs")) {
+if (isEntryModule(import.meta.url)) {
   main(process.argv.slice(2));
 }

--- a/scripts/lib/local-sandbox-fence.mjs
+++ b/scripts/lib/local-sandbox-fence.mjs
@@ -8,9 +8,9 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { fileURLToPath } from "node:url";
 
-const THIS_FILE = fileURLToPath(import.meta.url);
+import { isEntryModule } from "./entry-module.mjs";
+
 const DEFAULT_MAX_HEARTBEAT_AGE_MS = 8 * 60 * 1000;
 
 function readFence(path) {
@@ -255,7 +255,7 @@ function cli() {
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }
 
-if (process.argv[1] === THIS_FILE) {
+if (isEntryModule(import.meta.url)) {
   try {
     cli();
   } catch (error) {

--- a/scripts/local-ci-slot-cleanup.mjs
+++ b/scripts/local-ci-slot-cleanup.mjs
@@ -3,15 +3,13 @@
 import { spawnSync } from "node:child_process";
 import { rmSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
 import {
   assertLocalCiCleanupTarget,
   createLocalCiSlotManifest,
   localCiSlotEnvironment,
 } from "./lib/local-ci-slot-manifest.mjs";
-
-const THIS_FILE = fileURLToPath(import.meta.url);
+import { isEntryModule } from "./lib/entry-module.mjs";
 
 export function createLocalCiCleanupPlan(manifest, composeFile) {
   assertLocalCiCleanupTarget(manifest, manifest.output.build);
@@ -126,7 +124,7 @@ function main() {
   process.stdout.write(`local-ci-slot-cleanup: released ${manifest.slotKey} resources\n`);
 }
 
-if (process.argv[1] === THIS_FILE) {
+if (isEntryModule(import.meta.url)) {
   try {
     main();
   } catch (error) {

--- a/scripts/merge-readiness-policy.mjs
+++ b/scripts/merge-readiness-policy.mjs
@@ -5,6 +5,8 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { isEntryModule } from "./lib/entry-module.mjs";
+
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 export const DEFAULT_MANIFEST = resolve(ROOT, "config/merge-readiness-policy.json");
 const TERMINAL_SUCCESS = new Set(["success", "skipped"]);
@@ -199,4 +201,4 @@ function main() {
   throw new Error(`unknown command: ${command}`);
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) main();
+if (isEntryModule(import.meta.url)) main();

--- a/scripts/pr-health.mjs
+++ b/scripts/pr-health.mjs
@@ -31,13 +31,13 @@
 
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 
 // Single SoT for override codes (BI-563F6AB6) — shared with PreToolUse guards.
 import {
   LOCAL_CI_OVERRIDE_REASON_CODES,
   classifyLocalCiOverride,
 } from "../packages/dpf-skill-pack/hooks/lib/local-ci-override.mjs";
+import { isEntryModule } from "./lib/entry-module.mjs";
 
 export { LOCAL_CI_OVERRIDE_REASON_CODES, classifyLocalCiOverride };
 
@@ -321,4 +321,4 @@ function main() {
   process.exit(1);
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) main();
+if (isEntryModule(import.meta.url)) main();

--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -7,7 +7,6 @@
 
 import { execFileSync, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 
 import { buildGatePlan, evaluateReadiness, formatReadinessReport } from "./pr-readiness/core.mjs";
 import { collectWorktreeDiff } from "./gate-context.mjs";
@@ -15,6 +14,7 @@ import { resolvePolicyGuardInvocation } from "./lib/ci-policy-guards.mjs";
 import { buildGateContext } from "./lib/gate-context.mjs";
 import { fetchOriginMainSharedSafe, isShallowRepository } from "./lib/git-fetch-shared-safe.mjs";
 import { isEnvironmentFailureOutput } from "./lib/pregate-preflight.mjs";
+import { isEntryModule } from "./lib/entry-module.mjs";
 
 function git(args, { allowFail = false } = {}) {
   try {
@@ -187,4 +187,4 @@ function main() {
   process.exit(verdict.ready ? 0 : 1);
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) main();
+if (isEntryModule(import.meta.url)) main();

--- a/scripts/pregate-preflight.mjs
+++ b/scripts/pregate-preflight.mjs
@@ -9,14 +9,13 @@
 // Exit codes: 0 = clean (environment-skipped guards are warnings), 1 = at
 // least one guard reported a genuine violation.
 
-import { fileURLToPath } from "node:url";
-
 import {
   PREFLIGHT_SKIP_ENV,
   buildPreflightPlan,
   runPreflight,
 } from "./lib/pregate-preflight.mjs";
 import { checkStaleRootClone } from "./lib/stale-root-clone.mjs";
+import { isEntryModule } from "./lib/entry-module.mjs";
 
 export async function main() {
   if (process.argv.includes("--plan")) {
@@ -115,6 +114,6 @@ export async function main() {
   );
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if (isEntryModule(import.meta.url)) {
   await main();
 }

--- a/scripts/pregate-preflight.test.mjs
+++ b/scripts/pregate-preflight.test.mjs
@@ -8,6 +8,8 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 
@@ -334,6 +336,36 @@ test("pregate-preflight.mjs --plan emits the JSON plan without running guards", 
   assert.ok(plan.length > 0);
   assert.ok(plan.some((entry) => entry.id === "module-size-guard"));
   assert.ok(plan.every((entry) => entry.commands.every((c) => !c.startsWith("node --test"))));
+});
+
+// BI-FFFEFBCC (follow-on to BI-745658D7): Node realpath-resolves the ESM entry
+// module, so under a symlinked invocation path (macOS /var tmpdir → /private/var)
+// the naive `process.argv[1] === fileURLToPath(import.meta.url)` guard is false,
+// main() silently never runs, and the process exits 0 with no output. This pins
+// the isEntryModule adoption: main() must run whichever spelling the caller used.
+test("pregate-preflight.mjs still runs main() when invoked through a symlinked path", (t) => {
+  const temp = mkdtempSync(join(tmpdir(), "dpf-preflight-symlink-"));
+  const link = join(temp, "repo-link");
+  try {
+    // "junction" keeps this runnable on Windows hosts without symlink privilege.
+    symlinkSync(repoRoot, link, "junction");
+  } catch (error) {
+    rmSync(temp, { recursive: true, force: true });
+    t.skip(`cannot create a directory symlink on this host: ${error.code}`);
+    return;
+  }
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [join(link, "scripts", "pregate-preflight.mjs"), "--plan"],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const plan = JSON.parse(result.stdout);
+    assert.ok(plan.length > 0, "main() must run under a symlinked argv[1], not silently exit 0");
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
 });
 
 test("pregate.mjs --dry-run skips the preflight and still reaches gate routing", () => {

--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -245,6 +245,7 @@ test("gate-worktree.mjs refuses to run when neither an explicit command, the stu
   cpSync(join(repoRoot, "scripts", "lib", "agent-identity.mjs"), join(temp, "scripts", "lib", "agent-identity.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-base-freshness.mjs"), join(temp, "scripts", "lib", "local-ci-base-freshness.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "git-fetch-shared-safe.mjs"), join(temp, "scripts", "lib", "git-fetch-shared-safe.mjs"));
+  cpSync(join(repoRoot, "scripts", "lib", "entry-module.mjs"), join(temp, "scripts", "lib", "entry-module.mjs"));
   cpSync(
     join(repoRoot, "apps", "web", "lib", "nonprod", "local-ci-slot-resources.json"),
     join(temp, "apps", "web", "lib", "nonprod", "local-ci-slot-resources.json"),


### PR DESCRIPTION
# Sweep entrypoint guards to shared symlink-robust `isEntryModule` (BI-FFFEFBCC)

Follow-on to **BI-745658D7**, which found that the naive entrypoint guard
`process.argv[1] === fileURLToPath(import.meta.url)` compares unequal when a script is invoked
via a symlinked path (macOS tmpdir `/var` → `/private/var`: Node's ESM loader realpaths the
main-entry module URL while `argv[1]` keeps the caller's spelling), so `main()` silently never
runs and the process exits 0 — a false pass from any gate/policy script invoked that way.
That BI's branch (`fix/pregate-entry-guard-symlink`) hardens gate-worktree.mjs + the core
pregate family and explicitly scopes the remaining sweep out as follow-on work. This PR is
that follow-on.

## What changed

- Adopt `isEntryModule(import.meta.url)` from `scripts/lib/entry-module.mjs` in 10 scripts that
  carried the fragile equality guard: `pregate-preflight`, `merge-readiness-policy`,
  `ci-policy-guards`, `pr-health`, `gate-context`, `check-build-script-policy`, `pr-readiness`,
  `local-ci-slot-cleanup`, `lib/local-sandbox-fence`, `lib/git-fetch-shared-safe`.
- Also converted the hand-rolled `argv[1].endsWith(...)` suffix-match variants found in the sweep:
  `lib/bootstrap-worktree-deps`, `lib/git-shallow-preflight`, `lib/junction-safe-worktree-remove`
  (looser than a path identity check; same class).
- `lib/dev-portal-workspace-preflight.mjs` keeps a **self-contained** realpath mirror of the
  helper because the Dockerfile bakes it alone into `/usr/local/bin`, where a relative import
  cannot resolve (that constraint is why it had a suffix-match guard in the first place).
- `scripts/lib/entry-module.mjs` + `scripts/lib/entry-module.test.mjs` are recreated
  **byte-identical** to branch `fix/pregate-entry-guard-symlink` (BI-745658D7), and the policy-profile
  registration + contract-test `cpSync` hunks match that branch, so the two PRs land cleanly in
  either merge order.
- Out of scope (stays with BI-745658D7's branch): `gate-worktree.mjs`, `pregate.mjs`,
  `pregate-status.mjs`, `local-ci-runner.mjs`, and the gate-worktree symlink contract test.

- Second commit (`181d78bb2`): CI's Policy Guards (source) caught that the gate-context runtime
  closure test pins every transitive import into the Dockerfile init stage — added
  `COPY scripts/lib/entry-module.mjs ./scripts/lib/` (contract test now passes; pregate re-run PASS
  for the new head).

## Tests

- New symlink-spawn regression tests: `pregate-preflight.test.mjs` spawns
  `pregate-preflight.mjs --plan` through a symlinked directory and asserts the plan prints
  (**fails against the old guard** — verified by stashing the script change);
  `dev-portal-workspace-preflight.test.mjs` spawns the baked-standalone preflight through a
  symlinked directory and asserts the failure diagnosis fires.
- `entry-module.test.mjs` (exact/symlink/negative cases) registered in the CI policy-guard profile.
- Batch over the 13 test files covering every swept script: **140 tests, 139 pass** — the one
  failure (`pr-readiness.test.mjs:236`, `formatReadinessReport`) reproduces on a clean tree at
  main `1622c0b5f` with all changes stashed (pre-existing, flagged separately).
- `tests/release/pregate-node-gate-contract.test.mjs`: 26/27 — the one failure is the documented
  pre-existing macOS symlinked-tmpdir refusal case that BI-745658D7's branch fixes.
- Functional: spawning `bootstrap-worktree-deps.mjs --classify-only` through a symlinked path
  prints the readiness JSON (main runs).

## Governance

- Backlog: BI-FFFEFBCC (epic EP-413F2602), Workroom WC-8D03C63F.
- Semantic review receipt recorded for the exact committed tree (`8aaff739c`): shadow-mode,
  infrastructure-inconclusive after retry (local review capacity), `mayPublish: true` — not a
  semantic finding; noted here rather than hidden.

Local-CI-Evidence: cmsz7zlr85vak01pko6cduyvs (claude/adoring-bhaskara-6ec739@181d78bb2)
Docs-Impact-Decision: internal entrypoint-guard refactor (shared isEntryModule helper, identical CLI behavior); no user-visible behavior or documented workflow changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
