### PR TITLE
fix(coworker-lifecycle): certification oracles count governed ToolExecution evidence (BI-68BBF206)

### DIFF
--- a/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
@@ -12,6 +12,9 @@ type FindingRow = { findingKey: string; status: string };
 function makeDeps(overrides?: {
   loopContent?: string;
   executedTools?: Array<{ name: string; result: { success: boolean } }>;
+  /** Governed ToolExecution audit evidence returned for each journey's thread
+   *  (BI-68BBF206) — the native-mcp/CLI-subprocess execution record. */
+  governedEvidence?: Array<{ name: string; success: boolean }>;
   tools?: Array<{ name: string; sideEffect?: boolean }>;
   existingFindings?: FindingRow[];
   superuser?: { id: string } | null;
@@ -46,6 +49,7 @@ function makeDeps(overrides?: {
         { name: "query_backlog", result: { success: true } },
       ],
     }),
+    fetchToolEvidence: vi.fn().mockResolvedValue(overrides?.governedEvidence ?? []),
     db: {
       user: {
         findFirst: vi
@@ -239,6 +243,89 @@ describe("coworker certification runner (EP-COWORKER-LIFECYCLE Phase 2)", () => 
   it("routes certification through the coworker's bound route, workspace otherwise", () => {
     expect(certificationRouteFor("marketing-specialist")).not.toBe("/workspace");
     expect(certificationRouteFor("dispatcher")).toBe("/workspace");
+  });
+});
+
+describe("governed ToolExecution evidence union (BI-68BBF206, native-mcp dispatch)", () => {
+  // Under cli-adapter native-mcp mode the model's MCP tool calls execute inside
+  // the CLI subprocess against the governed MCP server: ToolExecution audit rows
+  // are written, but the in-process loop's executedTools list stays empty.
+  // Pre-fix, ORACLE-TOOL failed every such journey with "attempted: none" even
+  // though ORACLE-SURFACE passed and the reply cited real tool results.
+  it("passes ORACLE-TOOL when the in-process list is empty but audit rows show a successful in-surface call", async () => {
+    const { deps, created } = makeDeps({
+      executedTools: [],
+      governedEvidence: [{ name: "query_backlog", success: true }],
+    });
+
+    const sweep = await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });
+
+    expect(sweep.failed).toBe(0);
+    expect(sweep.results[0].status).toBe("passed");
+    expect((created.runs[0] as Record<string, unknown>).status).toBe("passed");
+    const journey = sweep.results[0].journeys[0];
+    expect(journey.executedToolNames).toContain("query_backlog");
+    const toolVerdict = journey.verdicts.find((v) => v.oracleId === "ORACLE-TOOL");
+    expect(toolVerdict?.passed).toBe(true);
+  });
+
+  it("scopes the audit query to the journey's thread, agent, and execution window", async () => {
+    const { deps } = makeDeps();
+    await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });
+
+    expect(deps.fetchToolEvidence).toHaveBeenCalled();
+    const call = (deps.fetchToolEvidence as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    // Thread naming observed live: certification:<agentId>/<journeyId>.
+    expect(call.threadId).toBe("certification:coo/derived-read-probe");
+    expect(call.agentId).toBe("coo");
+    expect(call.since).toBeInstanceOf(Date);
+    expect(call.until).toBeInstanceOf(Date);
+    expect(call.until.getTime()).toBeGreaterThanOrEqual(call.since.getTime());
+  });
+
+  it("fails ORACLE-PURITY when audit rows show a tool outside the offered read-only surface", async () => {
+    const { deps, created } = makeDeps({
+      governedEvidence: [{ name: "create_backlog_item", success: true }],
+    });
+
+    const sweep = await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });
+
+    expect(sweep.failed).toBe(1);
+    expect((created.runs[0] as Record<string, unknown>).status).toBe("failed");
+    const purity = sweep.results[0].journeys[0].verdicts.find(
+      (v) => v.oracleId === "ORACLE-PURITY",
+    );
+    expect(purity?.passed).toBe(false);
+    const keys = (created.findings as Array<{ findingKey: string }>).map((f) => f.findingKey);
+    expect(
+      keys.some((k) => k.startsWith("coworker-cert:coo:") && k.endsWith("ORACLE-PURITY")),
+    ).toBe(true);
+  });
+
+  it("an audit-read failure falls back to in-loop evidence instead of failing the coworker", async () => {
+    const { deps } = makeDeps();
+    (deps.fetchToolEvidence as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("db unavailable"),
+    );
+
+    const sweep = await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });
+
+    // In-loop evidence (successful query_backlog) still certifies the journey.
+    expect(sweep.failed).toBe(0);
+    expect(sweep.results[0].status).toBe("passed");
+  });
+
+  it("does not consult audit evidence for a capacity-inconclusive journey", async () => {
+    const { deps } = makeDeps();
+    const capacityErr = Object.assign(new Error("inference admission timeout"), {
+      code: "INFERENCE_ADMISSION_TIMEOUT",
+    });
+    (deps.runLoop as ReturnType<typeof vi.fn>).mockRejectedValue(capacityErr);
+
+    const sweep = await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });
+
+    expect(sweep.results[0].status).toBe("inconclusive");
+    expect(deps.fetchToolEvidence).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/lib/coworker-lifecycle/certification-runner.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.ts
@@ -88,6 +88,17 @@ type LoopResult = {
   executedTools: Array<{ name: string; result: { success: boolean } }>;
 };
 
+/** One executed-tool evidence record, transport-agnostic. */
+export type ToolEvidence = { name: string; success: boolean };
+
+/** The thread name a journey executes under. Single source for both the loop
+ *  dispatch and the governed-audit evidence query — they must never drift
+ *  (journeyId is already `<agentId>/<journey>`, matching the live thread
+ *  naming `certification:<agentId>/<journeyId>`). */
+export function certificationThreadId(journeyId: string): string {
+  return `certification:${journeyId}`;
+}
+
 export type CertificationDeps = {
   resolveAgent: typeof resolveAutonomousWorkAgent;
   resolveTools: typeof resolveAutonomousWorkTools;
@@ -102,6 +113,18 @@ export type CertificationDeps = {
     requireTools: boolean;
     modelRequirements?: Record<string, unknown>;
   }) => Promise<LoopResult>;
+  /** Governed audit evidence (BI-68BBF206): the ToolExecution rows written for
+   *  this journey's thread within the journey's execution window. The in-loop
+   *  executed-tools list only sees calls the in-process loop dispatched itself;
+   *  native-mcp transports execute the model's MCP tool calls inside the CLI
+   *  subprocess against the governed MCP server, which writes ToolExecution
+   *  audit rows the loop counter never observes. Oracles judge the UNION. */
+  fetchToolEvidence: (params: {
+    threadId: string;
+    agentId: string;
+    since: Date;
+    until: Date;
+  }) => Promise<ToolEvidence[]>;
   db: typeof prisma;
   now: () => Date;
 };
@@ -118,7 +141,7 @@ async function defaultRunLoop(
     userId: params.userId,
     routeContext: params.routeContext,
     agentId: params.journey.agentId,
-    threadId: `certification:${params.journey.journeyId}`,
+    threadId: certificationThreadId(params.journey.journeyId),
     interactionMode: "chat",
     requireTools: params.requireTools,
     ...(params.modelRequirements && Object.keys(params.modelRequirements).length > 0
@@ -135,14 +158,54 @@ async function defaultRunLoop(
   };
 }
 
+async function defaultFetchToolEvidence(
+  params: Parameters<CertificationDeps["fetchToolEvidence"]>[0],
+): Promise<ToolEvidence[]> {
+  // Scoped to one journey's thread AND agent AND its execution window: the
+  // thread name is deterministic per journey, so the createdAt bounds are what
+  // exclude rows from earlier sweeps that reused the same threadId. Bounded
+  // take is belt-and-braces — a single journey executes a handful of calls.
+  const rows = await prisma.toolExecution.findMany({
+    where: {
+      threadId: params.threadId,
+      agentId: params.agentId,
+      createdAt: { gte: params.since, lte: params.until },
+    },
+    select: { toolName: true, success: true },
+    orderBy: { createdAt: "asc" },
+    take: 500,
+  });
+  return rows.map((r) => ({ name: r.toolName, success: r.success }));
+}
+
 function defaultDeps(): CertificationDeps {
   return {
     resolveAgent: resolveAutonomousWorkAgent,
     resolveTools: resolveAutonomousWorkTools,
     runLoop: defaultRunLoop,
+    fetchToolEvidence: defaultFetchToolEvidence,
     db: prisma,
     now: () => new Date(),
   };
+}
+
+/** Union in-loop and governed-audit tool evidence, deduped by (name, success).
+ *  The in-loop list stays authoritative-and-cheap for in-process providers;
+ *  the ToolExecution rows are the audited truth for transports (native-mcp
+ *  CLI subprocess) whose calls never pass through the in-process counter. */
+export function unionToolEvidence(
+  inLoop: ToolEvidence[],
+  governed: ToolEvidence[],
+): ToolEvidence[] {
+  const seen = new Set<string>();
+  const union: ToolEvidence[] = [];
+  for (const t of [...inLoop, ...governed]) {
+    const key = `${t.success ? "ok" : "fail"}:${t.name}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    union.push(t);
+  }
+  return union;
 }
 
 function inferenceInconclusiveJourney(
@@ -223,12 +286,34 @@ async function executeJourney(
       return inferenceInconclusiveJourney(journey, startedAt, deps);
     }
 
+    // BI-68BBF206: under native-mcp dispatch the model's tool calls execute
+    // inside the CLI subprocess against the governed MCP server — ToolExecution
+    // audit rows are written, but the in-process executedTools list stays
+    // empty, so ORACLE-TOOL read every journey as "attempted: none". The
+    // audited rows are the source of truth for governed tool use; union them
+    // with the in-loop list (which remains correct — and cheaper — for
+    // in-process providers) and judge the union.
+    const inLoopEvidence: ToolEvidence[] = loop.executedTools.map((t) => ({
+      name: t.name,
+      success: t.result.success,
+    }));
+    let governedEvidence: ToolEvidence[] = [];
+    try {
+      governedEvidence = await deps.fetchToolEvidence({
+        threadId: certificationThreadId(journey.journeyId),
+        agentId: journey.agentId,
+        since: new Date(startedAt),
+        until: deps.now(),
+      });
+    } catch {
+      // An audit-read failure must not fail the coworker: fall back to the
+      // in-loop evidence only (the pre-fix behavior), never to a verdict.
+    }
+    const executedTools = unionToolEvidence(inLoopEvidence, governedEvidence);
+
     const verdicts = evaluateJourneyOracles({
       content: loop.content,
-      executedTools: loop.executedTools.map((t) => ({
-        name: t.name,
-        success: t.result.success,
-      })),
+      executedTools,
       offeredToolNames: readOnlyTools.map((t) => t.name),
       downgraded: loop.downgraded,
     });
@@ -239,7 +324,7 @@ async function executeJourney(
       passed: journeyPassed(verdicts),
       capacityInconclusive: false,
       verdicts,
-      executedToolNames: [...new Set(loop.executedTools.map((t) => t.name))],
+      executedToolNames: [...new Set(executedTools.map((t) => t.name))],
       downgraded: loop.downgraded,
       durationMs: deps.now().getTime() - startedAt,
     };


### PR DESCRIPTION
## Summary

Every coworker certification failed ORACLE-TOOL with "attempted: none" fleet-wide while ORACLE-SURFACE passed and the models' answers cited real tool results. Root cause: certification journeys dispatch via the cli-adapter in native-mcp mode — MCP tool calls execute inside the CLI subprocess against the governed server (ToolExecution rows are written) but the loop's in-process counter never increments.

Fix: the runner now unions in-loop evidence with governed ToolExecution rows scoped by the shared `certificationThreadId()` + agentId + journey time window (the window is load-bearing: thread names are deterministic per journey, so prior sweeps share the threadId). The union feeds ORACLE-TOOL, ORACLE-PURITY, and the persisted executedToolNames. Audit-read failure falls back to pre-fix in-loop-only behavior; capacity-inconclusive journeys never consult evidence.

## Verification

- 63/63 lib/coworker-lifecycle tests (5 new: DB-evidence pass, scoping assertion, out-of-surface PURITY failure, audit-failure fallback, inconclusive skip); web typecheck clean; local-CI gate PASS.
- Live evidence for the defect: AssuranceRuns 2026-08-18 23:39–23:52 all failed ORACLE-TOOL while ToolExecution rows for the same threads/agents/windows show successful in-surface calls (e.g. security-engineer list_my_backlog, ux-design-critic wiki_query ×3).

## Design grounding

- Existing specs/plans reviewed: docs/superpowers/plans/2026-07-07-coworker-lifecycle-plan.md (Phase 2 oracle contract; no spec pinned the evidence source — resolved toward the audited record)
- Current code substrate reviewed: apps/web/lib/coworker-lifecycle/certification-runner.ts + certification-oracles.ts, packages/db/prisma/schema/ai-coworker.prisma (ToolExecution threadId + indexes)
- Source of truth: ToolExecution is the audited record of governed tool use; oracles read evidence, not a transport-specific counter.
- Decision: union rather than replace, so in-process providers keep the cheaper path.

Seed-Fit-Decision: global-default (certification runner behavior is platform substrate identical on every install)
Docs-Impact-Decision: internal certification-runner fix; no user-visible surface or documented contract changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)