### PR TITLE
fix(wiki): reserve a share of the result limit for the profession pass (BI-F3FB4F41)

### DIFF
--- a/apps/web/lib/wiki/embeddings.ts
+++ b/apps/web/lib/wiki/embeddings.ts
@@ -451,38 +451,18 @@ export async function searchWikiPages(input: SearchWikiPagesInput): Promise<Wiki
     return orgResults.slice(0, limit);
   }
 
-  // ── Pass B — kernel fallback, masking any kernel pages the org has overridden ──
-  // The set of kernelPageIds claimed by pass A (org rows that override kernel pages).
-  const maskedKernelPageIds = orgResults
-    .map((r) => r.kernelPageId)
-    .filter((id): id is string => id !== null);
-
-  const kernelFilter: Record<string, unknown> = {
-    must: [...baseFilter, { key: "isKernel", match: { value: true } }],
-  };
-  if (maskedKernelPageIds.length > 0) {
-    kernelFilter.must_not = [
-      { key: "entityId", match: { any: maskedKernelPageIds } },
-    ];
-  }
-  if (ringScopeShould.length > 0) kernelFilter.should = ringScopeShould;
-
-  const remaining = limit - orgResults.length;
-  const kernelRaw = await searchSimilar(
-    QDRANT_COLLECTIONS.WIKI_PAGES,
-    vector,
-    kernelFilter,
-    remaining,
-    scoreThreshold,
-  );
-  const kernelResults = kernelRaw.map((r) => projectResult(r, "kernel"));
-
   // ── Pass C — WSID profession corpus, opt-in (BI-CC44E74F) ──
   // Profession pages are the isKernel:false / organizationId:null cohort — the
   // exact rows passes A and B exclude by construction. Fetched at full `limit`
   // (not `remaining`) because the slug post-filter below may discard rows when
   // the caller scoped to specific professionKeys; Qdrant cannot express a slug
   // prefix over the existing payload without a schema backfill.
+  //
+  // Runs BEFORE pass B (BI-F3FB4F41): pass B sizes itself to `limit` minus what
+  // passes A and C have already claimed. Ordered the other way round, passes A
+  // and B together fill `limit` exactly on any non-sparse corpus and the
+  // profession pass is sliced away every time — which made the opt-in inert in
+  // production even though the corpus was ingested and embedded.
   let professionResults: WikiSearchResult[] = [];
   if (input.includeProfessionCorpus) {
     const professionFilter: Record<string, unknown> = {
@@ -507,7 +487,64 @@ export async function searchWikiPages(input: SearchWikiPagesInput): Promise<Wiki
       .filter((r) => keyPrefixes.length === 0 || keyPrefixes.some((p) => r.slug.startsWith(p)));
   }
 
-  const semanticResults = [...orgResults, ...kernelResults, ...professionResults].slice(0, limit);
+  // The share of `limit` the profession pass may claim before pass B is sized.
+  // A caller that named professionKeys asked for that craft specifically, so
+  // craft doctrine leads and takes the larger share; the default broad include
+  // takes a minority share so org and kernel doctrine still dominate. Unused
+  // quota falls through to pass B — a thin profession corpus costs nothing.
+  const professionScoped = (input.professionKeys?.length ?? 0) > 0;
+  const professionQuota = input.includeProfessionCorpus
+    ? Math.max(1, Math.ceil((limit * (professionScoped ? 2 : 1)) / 3))
+    : 0;
+  const professionSlice = professionResults.slice(
+    0,
+    Math.min(professionResults.length, professionQuota),
+  );
+
+  // ── Pass B — kernel fallback, masking any kernel pages the org has overridden ──
+  // The set of kernelPageIds claimed by pass A (org rows that override kernel pages).
+  const maskedKernelPageIds = orgResults
+    .map((r) => r.kernelPageId)
+    .filter((id): id is string => id !== null);
+
+  const kernelFilter: Record<string, unknown> = {
+    must: [...baseFilter, { key: "isKernel", match: { value: true } }],
+  };
+  if (maskedKernelPageIds.length > 0) {
+    kernelFilter.must_not = [
+      { key: "entityId", match: { any: maskedKernelPageIds } },
+    ];
+  }
+  if (ringScopeShould.length > 0) kernelFilter.should = ringScopeShould;
+
+  // The profession share comes off the TOP of `limit`, not off pass B's
+  // leftovers: pass A alone can fill `limit` on a rich org overlay, which would
+  // truncate the profession slice just as surely as pass B did.
+  const nonProfessionBudget = Math.max(0, limit - professionSlice.length);
+  const orgSlice = orgResults.slice(0, nonProfessionBudget);
+  const remaining = Math.max(0, nonProfessionBudget - orgSlice.length);
+  const kernelRaw =
+    remaining > 0
+      ? await searchSimilar(
+          QDRANT_COLLECTIONS.WIKI_PAGES,
+          vector,
+          kernelFilter,
+          remaining,
+          scoreThreshold,
+        )
+      : [];
+  const kernelResults = kernelRaw.map((r) => projectResult(r, "kernel"));
+
+  // Org-over-kernel overlay precedence is deliberate and unchanged: an org page
+  // leads its kernel counterpart even at a lower cosine score. A global score
+  // sort would silently reorder org vs kernel for every existing caller, so the
+  // profession slice is placed rather than merged — leading when the caller
+  // scoped to a craft, trailing on the default broad include.
+  const semanticResults = (
+    professionScoped
+      ? [...professionSlice, ...orgSlice, ...kernelResults]
+      : [...orgSlice, ...kernelResults, ...professionSlice]
+  ).slice(0, limit);
   if (semanticResults.length === 0) {
     // A healthy embedding provider does not prove the vector index contains
     // every published Postgres row. Preserve Postgres as doctrine truth when

--- a/apps/web/lib/wiki/profession-corpus-retrieval.test.ts
+++ b/apps/web/lib/wiki/profession-corpus-retrieval.test.ts
@@ -101,9 +101,12 @@ describe("semantic retrieval — profession pass (BI-CC44E74F)", () => {
     });
     // Pass B (kernel) + pass C (profession); no org pass without an org.
     expect(qdrant.searchSimilar).toHaveBeenCalledTimes(2);
-    const professionFilter = qdrant.searchSimilar.mock.calls[1][2] as {
-      must: Array<{ key: string; match: Record<string, unknown> }>;
-    };
+    // Located by its cohort filter rather than by call index: pass C runs
+    // before pass B (BI-F3FB4F41), so the ordinal is not part of the contract.
+    type Clause = { key: string; match: Record<string, unknown> };
+    const professionFilter = qdrant.searchSimilar.mock.calls
+      .map((c: unknown[]) => c[2] as { must: Clause[] })
+      .find((f) => f.must.some((m) => m.key === "isKernel" && m.match.value === false))!;
     expect(professionFilter.must).toEqual(
       expect.arrayContaining([
         { key: "isKernel", match: { value: false } },
@@ -119,5 +122,97 @@ describe("semantic retrieval — profession pass (BI-CC44E74F)", () => {
     ]);
     await searchWikiPages({ query: "anything", organizationId: null });
     expect(qdrant.searchSimilar).toHaveBeenCalledTimes(1);
+  });
+});
+
+// BI-F3FB4F41 — the profession pass must survive a DENSE corpus.
+//
+// The fixtures above are sparse: passes A and B return fewer rows than `limit`,
+// so a profession pass appended last still fits. Production is not sparse —
+// pass B sizes itself to `limit - orgResults.length`, so A and B together fill
+// `limit` exactly and anything concatenated after them is sliced away. These
+// tests pin the reserved-share behaviour against a corpus dense enough to
+// reproduce that, which is the only shape that catches the regression.
+describe("semantic retrieval — profession share on a dense corpus (BI-F3FB4F41)", () => {
+  const vec = Array.from({ length: 8 }, () => 0.1);
+
+  /** Qdrant-shaped hit whose payload carries the fields projectResult reads. */
+  const hit = (slug: string, isKernel: boolean, organizationId: string | null, score: number) => ({
+    id: slug,
+    score,
+    payload: {
+      entityId: slug,
+      entityType: "wiki-page",
+      slug,
+      title: slug,
+      status: "published",
+      pageKind: "principle",
+      isKernel,
+      organizationId,
+      kernelPageId: null,
+      contentPreview: slug,
+    },
+  });
+
+  /** Routes each pass by the filter it was called with, then honours its limit. */
+  const denseCorpus = () => {
+    qdrant.searchSimilar.mockImplementation(
+      async (_c: string, _v: number[], filter: Record<string, unknown>, lim: number) => {
+        const must = (filter.must ?? []) as Array<{ key: string; match: { value: unknown } }>;
+        const clause = (key: string) => must.find((m) => m.key === key)?.match?.value;
+        const isKernel = clause("isKernel");
+        const org = clause("organizationId");
+        if (isKernel === true) {
+          return Array.from({ length: 50 }, (_, i) => hit(`principles/kernel-${i}`, true, null, 0.9 - i / 100)).slice(0, lim);
+        }
+        if (isKernel === false && org === null) {
+          return Array.from({ length: 50 }, (_, i) =>
+            hit(`professions/data-architect/craft-${i}`, false, null, 0.95 - i / 100),
+          ).slice(0, lim);
+        }
+        if (typeof org === "string") {
+          return Array.from({ length: 50 }, (_, i) => hit(`stances/org-${i}`, false, org, 0.8 - i / 100)).slice(0, lim);
+        }
+        return [];
+      },
+    );
+    embedding.generateEmbedding.mockResolvedValue(vec);
+  };
+
+  beforeEach(denseCorpus);
+
+  it("returns profession pages even though org+kernel could fill the limit alone", async () => {
+    const results = await searchWikiPages({
+      query: "referential integrity",
+      organizationId: "org-1",
+      limit: 25,
+      includeProfessionCorpus: true,
+    });
+    expect(results).toHaveLength(25);
+    expect(results.filter((r) => r.source === "profession").length).toBeGreaterThan(0);
+  });
+
+  it("leads with craft doctrine when the caller scoped to a professionKey", async () => {
+    const results = await searchWikiPages({
+      query: "referential integrity",
+      organizationId: "org-1",
+      limit: 9,
+      includeProfessionCorpus: true,
+      professionKeys: ["data-architect"],
+    });
+    expect(results[0]?.source).toBe("profession");
+    // Scoped share is two thirds of the limit; kernel doctrine still present.
+    expect(results.filter((r) => r.source === "profession")).toHaveLength(6);
+    expect(results.some((r) => r.source !== "profession")).toBe(true);
+  });
+
+  it("keeps org+kernel whole when the profession pass is not opted in", async () => {
+    const results = await searchWikiPages({
+      query: "referential integrity",
+      organizationId: "org-1",
+      limit: 25,
+    });
+    expect(results).toHaveLength(25);
+    expect(results.every((r) => r.source !== "profession")).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes **BI-F3FB4F41**.

## Symptom

`wiki_query` returned **zero** WSID profession-corpus pages, at any limit, even for query text taken near-verbatim from a corpus page. `evaluate_profession_decision` therefore answered "No applicable craft guidance" with `professionProfileSelected: false` and confidence 0 (DI-59E5DE84A65F) — it reads through the same retrieval path.

## This is not an ingestion or embedding gap

Checked on the live install (served sha `e80c3f2bc`) before touching any code:

| Check | Result |
| --- | --- |
| `WikiPage` rows under `professions/%` | 225 (of 361) |
| `vector_embedding` collection `wiki-pages` | 361 points, 229 with `isKernel=false` |
| Payload of a profession page | `isKernel:false`, `organizationId:null`, `status:"published"` — matches the pass-C filter exactly |
| Deployed bundle | `includeProfessionCorpus` present in 59 files under `/app/apps/web/.next` |
| `buildFilterSql` null handling | correct: `(NOT (payload ? key) OR payload->key = 'null'::jsonb)` |

The substrate was healthy the whole time. The rows were being sliced off the end of the result set.

## Root cause

Pass B sizes itself to `limit - orgResults.length`, so passes A and B together fill `limit` **exactly** on any non-sparse corpus. Pass C was concatenated after them, and the merge ended in `.slice(0, limit)` — so every profession row was discarded.

Live reproduction: `professionKey: "mcp-integration"`, `limit: 25`, query text near-verbatim from `tool-name-contract-stability.md` returned 10 org + 15 kernel + **0 profession**.

BI-CC44E74F removed the pass-A short-circuit but left the merge unchanged, so the opt-in shipped inert. `includeProfessionCorpus` defaults to `true` from the MCP handler, so this affected every caller.

## Fix

Pass C now runs **before** pass B and claims a reserved share off the top of `limit`:

- **two thirds** when the caller named `professionKeys` — craft doctrine is the point of that call, so it leads;
- **one third** on the default broad include, so org and kernel doctrine still dominate;
- unused quota falls through to pass B, so a thin profession corpus costs nothing.

The budget is taken from pass A as well as pass B. My first attempt reserved it only against pass B, and the new tests caught that a rich org overlay fills `limit` on its own and truncates the slice just the same.

**Org-over-kernel overlay precedence is deliberately untouched** — an org page still leads its kernel counterpart even at a lower cosine score. A global score sort would have been simpler but would silently reorder org vs kernel for every existing caller, so the profession slice is *placed* rather than merged.

## Tests

The existing fixtures could not catch this class: they are sparse enough that A+B never fill `limit`, which is the only regime where a trailing concatenation survives. Adds three tests over a corpus dense enough that **every** pass could fill the limit alone.

One existing assertion located the pass-C filter by call index; it now locates it by its cohort filter, since pass ordering is not part of the contract.

- `profession-corpus-retrieval.test.ts`: 8/8
- `lib/wiki` + MCP pack suites: 498/498 across 39 files

## Impact

Unblocks EP-413F2602 Objective 2 finish-line items 1 (corpus live and retrievable) and 2 (vector set exercised by a recorded consult under the acumen's profile) for all six acumens. The WSID decision layer was built, seeded, embedded — and unreachable.

## Design grounding

- **Spec evidence:** `docs/superpowers/plans/2026-08-16-simplify-strengthen-delivery-plan.md` Objective 2 (EP-413F2602) requires the WSID corpus to be retrievable via `wiki_query`; BI-CC44E74F established the pass, this restores its effect.
- **Code evidence:** `apps/web/lib/wiki/embeddings.ts` pass A/B/C sizing and merge; `apps/web/lib/mcp/packs/wiki-pack.ts` defaults `includeProfessionCorpus` true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
