### PR TITLE
fix(release): promote :latest only after E2E install verification passes (BI-FA7ECEF0)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -21,8 +21,8 @@ name: Publish Docker Images
 #   buildx-with-QEMU. With native matrix jobs, each runner pushes a
 #   single-arch image referenced by its content digest; the merge job
 #   uses `docker buildx imagetools create` to assemble the multi-arch
-#   manifest list under the human-readable tag (e.g. dpf-portal:v4.0.0
-#   and dpf-portal:latest both point at the merged manifest list).
+#   manifest list under the immutable tag (e.g. dpf-portal:v2026.08.21).
+#   `latest` is a separate, verification-gated promotion - see promote-latest.
 
 on:
   push:
@@ -30,9 +30,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Image tag (e.g. v0.1.0). Defaults to latest."
+        description: "Immutable image tag to publish (e.g. v2026.08.21). Empty = this run's ref name."
         required: false
-        default: "latest"
+        default: ""
 
 env:
   REGISTRY: ghcr.io
@@ -47,7 +47,38 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      # Resolved once here so merge, verify and promote-latest cannot disagree
+      # about which tag this run is publishing. Previously each job recomputed
+      # it, which is how `latest` ended up meaning two different things inside
+      # one run.
+      tag: ${{ steps.tag.outputs.version }}
     steps:
+      - name: Resolve the immutable tag for this run
+        id: tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          TAG="${INPUT_TAG:-$REF_NAME}"
+
+          # `latest` is a PROMOTION result now, not something a run may publish
+          # directly — promoting it is what the verify gate below guards. A run
+          # that wrote it straight from the build would walk around that gate,
+          # which is exactly the failure this workflow had on 2026-08-16.
+          if [ "${TAG}" = "latest" ]; then
+            echo "::error::Refusing to publish the mutable 'latest' tag directly. Pass an immutable tag (e.g. v2026.08.21); 'latest' is promoted automatically once E2E install verification passes."
+            exit 1
+          fi
+          if [ -z "${TAG}" ]; then
+            echo "::error::Could not resolve a tag for this run."
+            exit 1
+          fi
+
+          echo "version=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Publishing under immutable tag: ${TAG}"
+
       - uses: actions/checkout@v7
 
       - name: Set up Node.js
@@ -198,12 +229,12 @@ jobs:
 
   # ─── Stage 2: Assemble multi-arch manifest lists ─────────────────
   # One merge job per image. Each downloads the per-arch digests and
-  # uses `docker buildx imagetools create` to point the named tag
-  # (vX.Y.Z + latest) at a manifest list referencing both arch digests.
+  # uses `docker buildx imagetools create` to point the immutable tag
+  # (vX.Y.Z) at a manifest list referencing both arch digests.
   merge:
     name: Merge ${{ matrix.image }} manifest
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, gate]
     permissions:
       contents: read
       packages: write
@@ -233,18 +264,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Determine tag
-        id: tag
-        env:
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-        run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-          else
-            TAG="${INPUT_TAG}"
-          fi
-          echo "version=$TAG" >> "$GITHUB_OUTPUT"
-
       - name: Normalize image owner
         id: owner
         run: echo "value=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
@@ -260,7 +279,7 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE="${{ env.REGISTRY }}/${{ steps.owner.outputs.value }}/${{ matrix.image }}"
-          TAG="${{ steps.tag.outputs.version }}"
+          TAG="${{ needs.gate.outputs.tag }}"
 
           # Collect every digest file produced by the build matrix for
           # this image and turn them into fully-qualified
@@ -279,9 +298,12 @@ jobs:
             exit 1
           fi
 
+          # Immutable tag ONLY. `latest` is repointed by promote-latest once
+          # E2E install verification passes. Publishing it here put unverified
+          # images straight in front of customers, because installs
+          # self-upgrade against `latest`.
           docker buildx imagetools create \
             --tag "${IMAGE}:${TAG}" \
-            --tag "${IMAGE}:latest" \
             "${REFS[@]}"
 
       - name: Verify multi-arch manifest
@@ -291,7 +313,7 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE="${{ env.REGISTRY }}/${{ steps.owner.outputs.value }}/${{ matrix.image }}"
-          TAG="${{ steps.tag.outputs.version }}"
+          TAG="${{ needs.gate.outputs.tag }}"
 
           docker buildx imagetools inspect "${IMAGE}:${TAG}"
 
@@ -310,13 +332,20 @@ jobs:
   # identical to the manual-dispatch install-verification.yml.
   verify:
     name: E2E install verification (release mode)
-    needs: merge
+    needs: [merge, gate]
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:
       contents: read
       packages: read
     env:
+      # Pin the install to the tag this run just published. Without this,
+      # docker-compose.release.yml resolves ${DPF_IMAGE_TAG:-latest} and the
+      # gate would install the PREVIOUS `latest` — verifying the wrong images
+      # and then promoting untested ones. The installer only ever reads
+      # DPF_IMAGE_TAG out of .env, never writes it, so the shell environment
+      # is what compose interpolates here.
+      DPF_IMAGE_TAG: ${{ needs.gate.outputs.tag }}
       DPF_MODEL_PULL_MODE: skip
       DPF_HEALTH_TIMEOUT: 900
       DPF_HEALTH_URL: http://localhost:3000/api/health
@@ -402,3 +431,65 @@ jobs:
       - name: Tear down (uninstall --purge)
         if: always()
         run: bash uninstall-dpf.sh --purge --headless --yes || true
+
+  # ─── Stage 4: Promote `latest` ───────────────────────────────────
+  # `latest` is what customer installs self-upgrade against, so it moves ONLY
+  # after stage 3 proves the freshly published images actually install. Until
+  # 2026-08-16 the merge job wrote it alongside the immutable tag, which meant
+  # a run whose E2E verification failed had already shipped to every install
+  # (run 31954043204: 12/12 builds green, 6/6 merges green, verify FAILED,
+  # `latest` already repointed). BI-FA7ECEF0.
+  #
+  # Retagging from the immutable tag — rather than re-assembling from digests —
+  # guarantees `latest` and the verified tag are the same bytes.
+  promote-latest:
+    name: Promote ${{ matrix.image }} to latest
+    needs: [verify, gate]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - dpf-portal
+          - dpf-sandbox
+          - dpf-promoter
+          - dpf-browser-use
+          - dpf-adp
+          - dpf-edge-node
+          - dpf-postgres
+
+    steps:
+      # CodeQL actions/unpinned-tag: SHA-pinned, matching the merge job.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Normalize image owner
+        id: owner
+        run: echo "value=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Repoint latest at the verified manifest
+        env:
+          TAG: ${{ needs.gate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          IMAGE="${{ env.REGISTRY }}/${{ steps.owner.outputs.value }}/${{ matrix.image }}"
+
+          docker buildx imagetools create --tag "${IMAGE}:latest" "${IMAGE}:${TAG}"
+
+          # The retag must preserve both architectures; a single-arch `latest`
+          # silently breaks arm64 installs.
+          raw="$(docker buildx imagetools inspect "${IMAGE}:latest" --raw)"
+          echo "$raw" | grep -q '"architecture": "amd64"'             || { echo "::error::Missing linux/amd64 in ${IMAGE}:latest"; exit 1; }
+          echo "$raw" | grep -q '"architecture": "arm64"'             || { echo "::error::Missing linux/arm64 in ${IMAGE}:latest"; exit 1; }
+
+          echo "Promoted ${IMAGE}:${TAG} -> :latest"


### PR DESCRIPTION
## Summary

Closes **BI-FA7ECEF0**. `dpf-*:latest` is what customer installs self-upgrade against, and the `merge` job published it alongside the immutable tag — **before** stage 3 ever ran. Run [31954043204](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/actions/runs/31954043204) is the proof: 12/12 build legs green, 6/6 merges green, **E2E install verification FAILED**, and `latest` had already been repointed on every image. The gate meant to vet a release ran after the release had shipped.

The chain has published unattended every day since 2026-08-17 (v2026.08.17, .19, .20 all fully green), so this ordering is now exercised **daily** rather than at occasional manual releases.

## Changes

- `merge` publishes the **immutable tag only**.
- New **`promote-latest`** job (`needs: [verify, gate]`) repoints `latest` by retagging **from the verified immutable tag** — so `latest` and the tag the gate actually installed are the same bytes. It re-asserts both architectures, since a single-arch `latest` silently breaks arm64 installs.
- `verify` now sets `DPF_IMAGE_TAG` to this run's tag.
- `gate` resolves the tag once and exports it; `merge` / `verify` / `promote-latest` all consume that one value instead of recomputing it.
- `workflow_dispatch` input no longer defaults to `latest`.

Job graph is now `gate → build → merge → verify → promote-latest`, with `promote-latest` the **only** job that writes `:latest`.

## Two things that make this more than moving a line

**1. The `DPF_IMAGE_TAG` wiring is load-bearing.** `docker-compose.release.yml` resolves `${DPF_IMAGE_TAG:-latest}`. Gating the `latest` write *without* pinning the tag would have made stage 3 install the **previous** `latest`, pass, and then promote images it never touched — a gate that looks stronger and verifies nothing. Confirmed safe to set via job env: `install-dpf.sh`'s `_dpf_env_value` only **reads** `DPF_IMAGE_TAG` from `.env` and never writes it, so the shell environment is what compose interpolates. The one hardcoded `:latest` remaining in `install-dpf.sh` (~line 916) is a registry-reachability probe that only warns; it does not choose which images run.

**2. The dispatch default was a hole in the gate.** With `default: "latest"`, a dispatch taken with defaults resolved `TAG=latest` and `merge` wrote the mutable pointer directly — walking straight around the new gate. That is exactly how run 31954043204 was launched. The default is now empty (falls back to ref name) and an explicit `-f tag=latest` is refused with a message pointing at the promotion path.

## Test plan

- [x] **Source-only change** (CI workflow)
  - [x] Workflow YAML parses; job graph asserted programmatically
  - [x] All 21 `run` blocks pass `bash -n`
  - [x] Tag resolver exercised across every case
  - [x] Repo gates

### Verification evidence

**Job graph and sole `latest` writer**, asserted from the parsed YAML rather than by reading:

```
gate             needs=None
build            needs=gate
merge            needs=['build', 'gate']
verify           needs=['merge', 'gate']
promote-latest   needs=['verify', 'gate']

writes/uses ':latest' -> job 'promote-latest' (needs=['verify', 'gate'])
```

**Tag resolver, all five cases** (the 4th is the exact 08-16 mistake):

```
INPUT_TAG='v2026.08.21'  REF_NAME='v2026.08.21'  rc=0  version=v2026.08.21
INPUT_TAG=''             REF_NAME='v2026.08.21'  rc=0  version=v2026.08.21
INPUT_TAG=''             REF_NAME='main'         rc=0  version=main
INPUT_TAG='latest'       REF_NAME='main'         rc=1  ::error::Refusing to publish the mutable 'latest' tag directly...
INPUT_TAG=''             REF_NAME=''             rc=1  ::error::Could not resolve a tag for this run.
```

**Gates:** Actions Injection Audit `0 occurrences / PASSED`; Docs Impact `OK`; Design Grounding `OK`; `ci-policy-guards.test.mjs` **8/8**; all 21 run blocks `bash -n` clean.

**Not verified locally:** the promotion job needs a real GHCR push, so its first live exercise is the next daily run. If it fails, the blast radius is that `latest` stays on the last verified image — strictly safer than today's behaviour.

## Pre-PR readiness

Local-CI-Override: external-contribution-no-install: single CI-workflow change in a clean clone outside the managed worktree tree; no runtime surface to lease. The workflow-specific gates above ran against this exact tree. CI gates this PR in full.

## Overlap sweep

`gh pr list --state open --limit 40` → only #4415 (`feat/governed-autonomy-tak-conformance`). It does not touch `publish-image.yml`. #4366, which previously edited this file, merged 2026-08-16T15:21Z and this branch is based on top of it.

## Notes for the reviewer

- **Complements #4366, doesn't overlap it.** That PR added daily *detection* of a published image that has fallen behind. This adds *prevention* at publish time. Detection tells you `latest` is bad after the fact; this stops it becoming bad.
- **Failure mode is fail-safe.** If `promote-latest` fails, `latest` simply stays on the previously verified image. Today a verify failure leaves `latest` pointing at unverified images.
- **Branch dispatches now publish `:<branch>`** (e.g. `:main`) instead of clobbering `:latest`. That is the intended consequence of closing the default-input hole, but it is a visible behaviour change for anyone used to dispatching on `main`.
- Still open and **not** addressed here: **BI-5D22046E** — `install-dpf.sh` exits 1 with zero diagnostic output, which is why the 08-16 verify failure was undiagnosable. This PR makes such a failure non-shipping; it does not make it debuggable.
