### PR TITLE
fix(release): ship uninstall-dpf.* so the documented uninstall command exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,11 @@ RUN NODE_OPTIONS="--max-old-space-size=8192" NEXT_TELEMETRY_DISABLED=1 pnpm --fi
 FROM deps AS init
 COPY pnpm-workspace.yaml tsconfig.base.json .gitignore ./
 COPY docker-compose.yml docker-compose.release.yml docker-compose.pki.yml docker-compose.organization-trust.yml docker-compose.tls.yml docker-compose.edge-actions.yml ./
+# The install docs tell operators to run these (docs/install/linux.md,
+# docs/install/cloud-single-vm.md), and a consumer install has no git checkout, so they
+# must ship in the bundle or the documented uninstall fails 'file not found' on every
+# Ready-to-go install. Both halves are required: this COPY and the cp below (IMP-043).
+COPY uninstall-dpf.sh uninstall-dpf.ps1 uninstall-dpf.bat ./
 COPY scripts/pki/edge-client.tpl ./scripts/pki/
 COPY scripts/set-hooks-path.mjs ./scripts/
 COPY scripts/lib/resolve-capability-compose-profiles.mjs ./scripts/lib/
@@ -176,6 +181,7 @@ RUN mkdir -p /dpf-release-assets/scripts/lib /dpf-release-assets/scripts/install
       /dpf-release-assets/monitoring && \
     cp docker-compose.yml docker-compose.release.yml docker-compose.pki.yml docker-compose.organization-trust.yml docker-compose.tls.yml docker-compose.edge-actions.yml /dpf-release-assets/ && \
     mkdir -p /dpf-release-assets/scripts/pki && cp scripts/pki/edge-client.tpl /dpf-release-assets/scripts/pki/ && \
+    cp uninstall-dpf.sh uninstall-dpf.ps1 uninstall-dpf.bat /dpf-release-assets/ && \
     cp scripts/bootstrap-organization-pki.ps1 /dpf-release-assets/scripts/ && \
     cp scripts/lib/resolve-capability-compose-profiles.mjs scripts/lib/govern-capability-compose-args.mjs scripts/lib/capability-state-hash.mjs /dpf-release-assets/scripts/lib/ && \
     cp scripts/capability-service-catalog.generated.json /dpf-release-assets/scripts/ && \

--- a/scripts/check-release-asset-contract.test.mjs
+++ b/scripts/check-release-asset-contract.test.mjs
@@ -42,6 +42,22 @@ const REQUIRED_IN_BUNDLE = Object.freeze([
   "scripts/safety/dpf-shell-guard-fallback-patterns.json",
   "scripts/installer/lib/state.ps1",
   "scripts/bootstrap-organization-pki.ps1",
+  // The install guides tell operators to run these by name, so a consumer install
+  // that lacks them fails the documented uninstall with "file not found" — the
+  // only offered route to zero footprint (IMP-073).
+  "uninstall-dpf.sh",
+  "uninstall-dpf.ps1",
+  "uninstall-dpf.bat",
+]);
+
+/**
+ * Commands the published install guides instruct an operator to run by name.
+ * A documented command whose file never ships is worse than an undocumented gap:
+ * the operator follows the guide and gets "file not found".
+ */
+const DOCUMENTED_COMMANDS = Object.freeze([
+  { doc: "docs/install/linux.md", file: "uninstall-dpf.sh" },
+  { doc: "docs/install/cloud-single-vm.md", file: "uninstall-dpf.sh" },
 ]);
 
 /** The single RUN block that assembles /dpf-release-assets. */
@@ -85,8 +101,29 @@ test("every bundled asset is also COPYed into the build stage that assembles it"
   );
 });
 
+test("every documented command's file actually ships in the bundle", () => {
+  // IMP-073: docs/install/linux.md and cloud-single-vm.md both list
+  // `bash uninstall-dpf.sh` in their command tables, while the file shipped only
+  // in source. Following the guide on a Ready-to-go install produced "file not found".
+  const block = releaseAssetBlock(dockerfile);
+  for (const { doc, file } of DOCUMENTED_COMMANDS) {
+    const docPath = join(repoRoot, doc);
+    if (!existsSync(docPath)) continue;
+    const body = readFileSync(docPath, "utf8");
+    if (!body.includes(file)) continue;
+    assert.ok(
+      block.includes(file),
+      `${doc} tells the operator to run ${file}, but it is not in /dpf-release-assets — ` +
+        `the consumer install has no git checkout, so the documented command cannot work`,
+    );
+  }
+});
+
 test("every required path is actually referenced by an installer (no stale entries)", () => {
   for (const p of REQUIRED_IN_BUNDLE) {
+    // The uninstallers are referenced by the install GUIDES rather than by
+    // install-dpf.*, so the installer-reference check does not apply to them.
+    if (p.startsWith("uninstall-dpf.")) continue;
     const win = p.replace(/\//g, "\\\\");
     const referenced =
       psInstaller.includes(p) || psInstaller.includes(p.replace(/\//g, "\\")) ||


### PR DESCRIPTION
## The defect

The install guides tell operators to run the uninstaller **by name**:

```
docs/install/linux.md:166        | Soft uninstall (keep data) | `bash uninstall-dpf.sh` |
docs/install/linux.md:167        | Full uninstall (wipe data) | `bash uninstall-dpf.sh --purge` |
docs/install/cloud-single-vm.md  | same, twice
```

The file never shipped. A Ready-to-go install contains exactly:

```
dpf-start.ps1   dpf-stop.ps1
```

`uninstall-dpf.sh` / `.ps1` / `.bat` existed only in source. The consumer install
has **no git checkout**, so following the published guide produces
`file not found` — and the only offered route to zero footprint doesn't exist on
the machine that needs it.

## Why it kept happening

Third instance of one omission: **IMP-041** (safety scripts), **IMP-052** (agent
toolchain bootstrap), now the uninstaller. It's also the mechanism behind
**IMP-002** ("no documented path to zero footprint") — the path isn't merely
undocumented, the tool is absent.

Both halves are added, because **IMP-043** established either alone is broken: a
`cp` without its `COPY` fails the image build with a bare `exit code: 1`; a `COPY`
without its `cp` ships nothing.

## The new guard

A pattern list only catches what it's asserted against, so this adds a check for
the class rather than the instance:

> **every documented command's file actually ships in the bundle** — if an install
> guide names a file the operator is told to run, that file must be in
> `/dpf-release-assets`.

A documented command whose file never ships is worse than an undocumented gap: the
operator follows the guide, hits a missing file, and has no reason to suspect the
guide is wrong.

Fails **3/7** against the pre-fix Dockerfile; 7/7 after. Sibling guards
(`installer-skip-visibility`, `db-commandment-coverage`) still green.

## How it was found

A from-zero reset rehearsal. The teardown reached for the platform's own
uninstaller — the thing a non-technical operator would use — and there wasn't one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)