### PR TITLE
fix(installer): -Help on Windows printed nothing and ran a full install

### DIFF
--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -1,13 +1,72 @@
 #Requires -Version 5.1
+# DELIBERATELY a *simple* param block: no [CmdletBinding()]. Adding it would turn
+# this into an advanced script, which enables prefix matching against the common
+# parameters -- the exact class of breakage that made every guarded command fail in
+# scripts/safety/dpf-shell-guard.ps1. Keep it simple; -Help is a plain switch.
 param(
     [string]$InstallDir,
     [string]$Version = "latest",
     [switch]$LibraryOnly,
     [switch]$WithEdge,
     [switch]$NoEdge,
-    [ValidateNotNullOrEmpty()][string]$OrganizationJoinPackage
+    [ValidateNotNullOrEmpty()][string]$OrganizationJoinPackage,
+    [switch]$Help
 )
 $ErrorActionPreference = "Stop"
+
+function Show-DPFInstallerUsage {
+    @'
+Open Digital Product Factory - Installer
+
+Usage:
+  powershell -ExecutionPolicy Bypass -File install-dpf.ps1 [flags]
+
+Flags:
+  -InstallDir <path>
+                Install location. Defaults to D:\DPF (or the drive with the
+                most free space). The consumer install has no git checkout;
+                everything it needs ships inside the release images.
+  -Version <tag>
+                Image tag to install. Defaults to "latest".
+  -LibraryOnly  Dot-source the script's functions without running the install
+                flow. Used by tests and by other scripts that reuse helpers.
+  -WithEdge     Bundle a local Edge Node alongside the Authority Core (network
+                discovery from this host). OPT-IN: not installed by default.
+                A node added this way auto-approves at enrollment.
+  -NoEdge       Force-skip the local Edge Node even if a prior install enabled
+                it (Edge is already off by default).
+  -OrganizationJoinPackage <file.dpfjoin>
+                Join an existing organization trust domain during install. The
+                private package is validated, consumed, and deleted on success;
+                certificates and restart wiring are automatic.
+  -Help         Show this help and exit without installing.
+
+Uninstall:
+  powershell -ExecutionPolicy Bypass -File uninstall-dpf.ps1
+
+The POSIX installer (install-dpf.sh) carries additional flags -- --dry-run,
+--headless, --customer, --contributor -- that this script does not yet accept.
+'@ | Write-Host
+}
+
+# Must run before ANY install work. Before this existed the script had no -Help
+# parameter at all, so `install-dpf.ps1 -Help` bound nothing, fell through to
+# $args, and ran a FULL UNATTENDED INSTALL -- while docs/install/windows.md told
+# the operator that exact command "documents every flag" (IMP-026).
+if ($Help) {
+    Show-DPFInstallerUsage
+    exit 0
+}
+
+# Reject unknown arguments rather than silently ignoring them, mirroring
+# install-dpf.sh's `*) echo "Unknown flag" >&2; exit 2`. A simple param block
+# collects undeclared tokens in $args, so a typo like -Helpp would otherwise
+# install silently.
+if ($args.Count -gt 0) {
+    Write-Host "install-dpf.ps1: unrecognized argument(s): $($args -join ' ')" -ForegroundColor Red
+    Write-Host "Run 'powershell -File install-dpf.ps1 -Help' for usage." -ForegroundColor Red
+    exit 2
+}
 $OrganizationJoinPackagePath = if ($OrganizationJoinPackage) { [IO.Path]::GetFullPath($OrganizationJoinPackage) } else { $null }
 if ($OrganizationJoinPackagePath -and -not (Test-Path -LiteralPath $OrganizationJoinPackagePath -PathType Leaf)) {
     throw "organization_join_package_not_found:$OrganizationJoinPackagePath"

--- a/scripts/check-installer-help-contract.test.mjs
+++ b/scripts/check-installer-help-contract.test.mjs
@@ -1,0 +1,100 @@
+// docs/install/windows.md tells the operator:
+//
+//     `powershell -File install-dpf.ps1 -Help` documents every flag.
+//
+// install-dpf.ps1 had no -Help parameter. With a simple param() block an
+// undeclared switch does not error -- it lands in $args and is ignored -- so that
+// documented command ran a FULL UNATTENDED INSTALL of the platform. The operator
+// asked to read the flags and got the whole stack (IMP-026).
+//
+// install-dpf.sh never had this problem: it handles `-h|--help) usage; exit 0` and
+// rejects unknown flags with exit 2. The defect was Windows-only, which is exactly
+// how it survived -- the POSIX path looks correct and nobody diffs the two.
+//
+// This asserts the contract in both directions:
+//   1. every installer the docs describe actually accepts -Help / --help
+//   2. neither installer silently ignores an unrecognised argument
+//
+// It is a source-text contract rather than an execution test because running the
+// real installer is the thing being guarded against.
+
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const read = (p) => readFileSync(join(repoRoot, p), "utf8");
+
+const ps = read("install-dpf.ps1");
+const sh = read("install-dpf.sh");
+
+test("install-dpf.ps1 declares a -Help switch", () => {
+  assert.match(
+    ps,
+    /\[switch\]\$Help/,
+    "no -Help parameter: a simple param() block silently ignores it and installs",
+  );
+});
+
+test("install-dpf.ps1 acts on -Help before doing any install work", () => {
+  const helpGuard = ps.search(/if\s*\(\s*\$Help\s*\)/);
+  assert.notEqual(helpGuard, -1, "-Help is declared but never checked");
+
+  // The exit must come before anything that mutates the host. Docker calls are the
+  // earliest observable side effect in this script.
+  const firstDocker = ps.search(/\bdocker\b/);
+  if (firstDocker !== -1) {
+    assert.ok(
+      helpGuard < firstDocker,
+      "the -Help check must run before any docker invocation, or asking for help " +
+        "still starts installing",
+    );
+  }
+  const guardBlock = ps.slice(helpGuard, helpGuard + 200);
+  assert.match(guardBlock, /exit 0/, "-Help must exit 0, not fall through to the install flow");
+});
+
+test("install-dpf.ps1 rejects unrecognised arguments instead of ignoring them", () => {
+  // A simple param block collects undeclared tokens in $args. Without an explicit
+  // check, `-Helpp` (or any typo) installs silently.
+  assert.match(
+    ps,
+    /\$args\.Count\s*-gt\s*0/,
+    "no unknown-argument check: a mistyped flag falls into $args and installs silently",
+  );
+  const idx = ps.search(/\$args\.Count\s*-gt\s*0/);
+  assert.match(
+    ps.slice(idx, idx + 400),
+    /exit 2/,
+    "an unrecognised argument should exit non-zero, mirroring install-dpf.sh",
+  );
+});
+
+test("install-dpf.sh still handles --help and unknown flags", () => {
+  // Guards the half that was already correct, so a future refactor cannot quietly
+  // bring it down to the Windows behaviour.
+  assert.match(sh, /-h\|--help\)\s*usage;\s*exit 0/, "install-dpf.sh must keep its --help handler");
+  assert.match(sh, /Unknown flag|Run 'bash install-dpf\.sh --help'/, "install-dpf.sh must reject unknown flags");
+});
+
+test("every installer command the install guides name is accepted by that installer", () => {
+  // The doc is the promise; the script is the implementation. This catches the
+  // general case rather than the single -Help instance.
+  const cases = [
+    { doc: "docs/install/windows.md", pattern: /install-dpf\.ps1\s+-Help/, script: ps, flag: "-Help", decl: /\[switch\]\$Help/ },
+    { doc: "docs/install/linux.md", pattern: /install-dpf\.sh\s+--help/, script: sh, flag: "--help", decl: /--help/ },
+  ];
+  for (const c of cases) {
+    const path = join(repoRoot, c.doc);
+    if (!existsSync(path)) continue;
+    if (!c.pattern.test(readFileSync(path, "utf8"))) continue;
+    assert.match(
+      c.script,
+      c.decl,
+      `${c.doc} documents ${c.flag}, but the installer does not declare it — ` +
+        `following the guide runs the installer instead of printing help`,
+    );
+  }
+});

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -34,6 +34,7 @@ const EXPECTED_LEGACY_JOBS = [
   "fk-index-coverage-guard",
   "fpaw-standard-guard",
   "host-port-range-guard",
+  "installer-help-contract",
   "installer-skip-visibility",
   "installer-state-contract",
   "instruction-plane-guard",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -67,6 +67,12 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       // commandment frontmatter and the offline fallback.
       node("--test", "scripts/check-db-commandment-coverage.test.mjs"),
     ]),
+    guard("installer-help-contract", "Installer Help Contract", [
+      // docs/install/windows.md documented `install-dpf.ps1 -Help`, which had no
+      // -Help parameter -- a simple param() block ignored it and ran a full
+      // unattended install. Asserts documented installer flags actually exist.
+      node("--test", "scripts/check-installer-help-contract.test.mjs"),
+    ]),
     guard("installer-skip-visibility", "Installer Skip Visibility", [
       // A guarded install step that skips in silence reads as success, and is
       // then recorded as done by Save-Progress. Optional-script guards must say so.


### PR DESCRIPTION
## The defect

`docs/install/windows.md:114` tells the operator:

> ``powershell -File install-dpf.ps1 -Help`` documents every flag.

`install-dpf.ps1` had **no `-Help` parameter**. With a simple `param()` block an
undeclared switch does not error — it lands in `$args` and is ignored — so that
documented command ran a **full unattended install** of the platform.

Someone asking to read the flags got the whole stack: Docker pulls, containers,
volumes, an install directory, a scheduled task.

## Why it survived

`install-dpf.sh` never had this problem:

```sh
-h|--help)  usage; exit 0 ;;
*)          echo "Run 'bash install-dpf.sh --help' for usage." >&2; exit 2 ;;
```

The defect was **Windows-only**. The POSIX path looks correct, and nobody diffs
the two installers against the docs.

## The fix

- a `-Help` switch that prints usage and exits 0 **before any install work**
- unknown-argument rejection (`exit 2`), mirroring `install-dpf.sh`, so a typo
  like `-Helpp` cannot install silently either

Verified against the real script:

```
$ install-dpf.ps1 -Help    → usage printed, EXIT=0, nothing touched
$ install-dpf.ps1 -Helpp   → "unrecognized argument(s): -Helpp", EXIT=2
```

The param block stays **simple** on purpose. Adding `[CmdletBinding()]` would
enable prefix matching against the common parameters — the exact breakage that
made every guarded command fail in `dpf-shell-guard.ps1` (`-d` matching `-Debug`).

## The guard

`installer-help-contract` asserts the **general case**, not the instance:

> if an install guide names an installer flag, the installer must declare it

It also pins `install-dpf.sh`'s existing `--help` handling so a future refactor
cannot quietly level it down to the Windows behaviour.

Fails **4/5** against the pre-fix script. The one test that passes both is the
POSIX half — which is precisely the point.

## How it was found

A from-zero reset rehearsal, reading the Windows guide as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)