### PR TITLE
fix(storefront): public address dropped the state; use the canonical formatter

### DIFF
--- a/apps/web/components/storefront/StorefrontTrustFooter.test.tsx
+++ b/apps/web/components/storefront/StorefrontTrustFooter.test.tsx
@@ -42,6 +42,33 @@ describe("StorefrontTrustFooter", () => {
     expect(html).toContain("/s/copper-kettle/policies#terms");
   });
 
+  // IMP-034: both storefront surfaces hand-joined a subset of address keys and
+  // dropped the state. It survived because every fixture here was a UK address
+  // (Bristol, BS1 1AA) which HAS no state — the test could not fail on a bug the
+  // data never exercised. A US address is the case that matters: "Fort Worth,
+  // 76106" without TX is not a usable business address.
+  it("includes the state for a US address", () => {
+    const html = renderToStaticMarkup(
+      <StorefrontTrustFooter
+        storefront={{
+          ...base,
+          orgAddress: {
+            line1: "4820 Ridgeline Parkway",
+            city: "Fort Worth",
+            region: "Texas",
+            stateCode: "TX",
+            postalCode: "76106",
+            country: "United States",
+          },
+        }}
+        hours={hours}
+      />,
+    );
+    expect(html).toContain("Texas");
+    expect(html).toContain("Fort Worth");
+    expect(html).toContain("76106");
+  });
+
   it("degrades gracefully when hours/contact/address are missing", () => {
     const html = renderToStaticMarkup(
       <StorefrontTrustFooter

--- a/apps/web/components/storefront/StorefrontTrustFooter.tsx
+++ b/apps/web/components/storefront/StorefrontTrustFooter.tsx
@@ -1,3 +1,4 @@
+import { formatOrgAddressLines } from "@/lib/shared/org-address";
 import Link from "next/link";
 import type { PublicStorefrontConfig } from "@/lib/storefront-types";
 import type { WeeklySchedule } from "@/lib/operating-hours-types";
@@ -32,11 +33,14 @@ export function StorefrontTrustFooter({
   hours: WeeklySchedule | null;
 }) {
   const { orgSlug, orgAddress } = storefront;
-  const addressLine = orgAddress
-    ? [orgAddress.street, orgAddress.city, orgAddress.postcode, orgAddress.country]
-        .filter(Boolean)
-        .join(", ")
-    : null;
+  // Use the canonical formatter rather than an ad-hoc join. Both storefront
+  // surfaces previously hand-joined a subset of keys and DROPPED the state/region:
+  // a Fort Worth address with stateCode "TX" rendered "Fort Worth, 76106" here and
+  // "Fort Worth, 76106, United States" in ContactSection — two different wrong
+  // answers from two copies of the same logic (IMP-034). formatOrgAddressLines
+  // covers both the legacy street/postcode keys and line1/postalCode, and includes
+  // region/state.
+  const addressLine = orgAddress ? formatOrgAddressLines(orgAddress).join(", ") || null : null;
   const socials = Object.entries(storefront.socialLinks ?? {}).filter(
     ([, url]) => typeof url === "string" && url.length > 0,
   ) as [string, string][];

--- a/apps/web/components/storefront/sections/ContactSection.tsx
+++ b/apps/web/components/storefront/sections/ContactSection.tsx
@@ -1,3 +1,4 @@
+import { formatOrgAddressLines } from "@/lib/shared/org-address";
 import type { PublicStorefrontConfig } from "@/lib/storefront-types";
 
 export function ContactSection({
@@ -24,7 +25,7 @@ export function ContactSection({
           <div>
             <span style={{ color: "var(--dpf-muted)", fontSize: 12 }}>Address</span><br />
             <span style={{ color: "var(--dpf-text)" }}>
-              {[storefront.orgAddress.street, storefront.orgAddress.city, storefront.orgAddress.postcode].filter(Boolean).join(", ")}
+              {formatOrgAddressLines(storefront.orgAddress).join(", ")}
             </span>
           </div>
         )}

--- a/apps/web/lib/storefront/storefront-types.ts
+++ b/apps/web/lib/storefront/storefront-types.ts
@@ -1,8 +1,32 @@
+/**
+ * Public-facing view of Organization.address.
+ *
+ * Declares BOTH key styles because the stored JSON carries either: the legacy
+ * street/postcode shape and the canonical OrgAddress line1/postalCode shape.
+ * storefront-data casts `org.address` straight onto this type, and a cast strips
+ * nothing at runtime — so when the interface listed only four legacy fields, the
+ * state was present in the object and invisible to every reader that trusted the
+ * type. That is what made a US address render as "Fort Worth, 76106" with
+ * stateCode "TX" stored correctly (IMP-034).
+ *
+ * Keep this a superset of what OrgAddress can hold, or the same class of silent
+ * drop returns.
+ */
 export interface StorefrontAddress {
+  /** Legacy keys — still written by older installs. */
   street?: string;
-  city?: string;
   postcode?: string;
+  /** Canonical OrgAddress keys. */
+  line1?: string;
+  line2?: string;
+  postalCode?: string;
+  city?: string;
+  /** State / province DISPLAY name, e.g. "Texas". This is what renders. */
+  region?: string;
+  /** Normalized 2-letter subdivision code, e.g. "TX". Not rendered directly. */
+  stateCode?: string;
   country?: string;
+  countryCode?: string;
 }
 
 export interface SocialLinks {


### PR DESCRIPTION
## The defect

A US business address rendered on the public storefront as

```
4820 Ridgeline Parkway, Fort Worth, 76106, United States
```

with `stateCode: "TX"` stored correctly. `Fort Worth, 76106` without TX is not a
usable business address — and this string is what customers see and what feeds
local-presence context.

## The normaliser was never at fault

`normalizeOrgAddress` already backfills the display `region` from `stateCode`:

```ts
region: str(input.region) ?? usStateName(stateCode) ?? undefined
```

and `formatOrgAddressLines` — documented as the *"single source of truth for
address display"* — includes `region` and `state` in `DISPLAY_KEYS`.

**Two storefront surfaces bypassed it** with their own hand-joins, and disagreed
with each other:

| Surface | Joined |
|---|---|
| `StorefrontTrustFooter` | street, city, postcode, country |
| `ContactSection` | street, city, postcode |

Neither included region/state.

## It's worse than the live symptom

Both read the **legacy** `street`/`postcode` keys. On a modern `line1`/`postalCode`
record they also drop the street and postal code. Same fixture, two paths:

```
old ad-hoc  ->  Fort Worth, United States
canonical   ->  4820 Ridgeline Parkway, Fort Worth, Texas, 76106, United States
```

The hand-join only *appeared* to work because the stored record happened to be
legacy-shaped.

Both call sites now use `formatOrgAddressLines`, which covers both key styles.

## Why it survived

Every fixture in `StorefrontTrustFooter.test.tsx` was a **UK address**
(`1 High St, Bristol, BS1 1AA`) — which has no state. The test could not fail on a
bug the data never exercised.

Adds a US-address case that does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design grounding

Design-Grounding-Decision: grounded

- Existing specs/plans reviewed:
  - `apps/web/lib/shared/org-address.ts` — its own docblock declares
    `formatOrgAddressLines` the *"single source of truth for address display
    (org-identity delegates here)"*. That contract already existed; the storefront
    was the surface violating it, so this change deletes duplicated logic rather
    than adding a new mechanism.
  - `docs/superpowers/specs/` searched for a storefront address-rendering contract;
    none supersedes the org-address module, so the module remains authoritative.

- Current code substrate reviewed:
  - `apps/web/lib/shared/org-address.ts` — `DISPLAY_KEYS` already lists
    `region`/`state`; `normalizeOrgAddress` already backfills `region` from
    `stateCode` via `usStateName()`. No new derivation was needed.
  - `apps/web/components/storefront/StorefrontTrustFooter.tsx` and
    `sections/ContactSection.tsx` — the two hand-joins, which disagreed with each
    other and both read only legacy keys.
  - `apps/web/lib/storefront/storefront-types.ts` — `StorefrontAddress` declared
    four legacy fields while `storefront-data.ts:279` casts `org.address` onto it.
    A cast strips nothing at runtime, so `region` was present in the object and
    invisible to every reader that trusted the type. Widened to a superset of what
    `OrgAddress` can carry.
  - `grep` for other `orgAddress` consumers to confirm these were the only two
    ad-hoc formatters.

Operational-Precedent: no-precedent (no prior storefront address-format change exists in this repo to follow; the org-address module is the only established contract and this aligns the storefront to it)

## Contract change

`StorefrontAddress` gains `line1`, `line2`, `postalCode`, `region`, `stateCode`,
`countryCode`. All optional, additive, and already present in the runtime payload —
the interface was under-declaring the object it is cast from. No caller loses a
field.
