### PR TITLE
fix(setup): choosing a country no longer discards the state already typed

### DIFF
--- a/apps/web/components/admin/BusinessContextForm.tsx
+++ b/apps/web/components/admin/BusinessContextForm.tsx
@@ -18,6 +18,7 @@ import {
   US_STATES,
   countryName,
   usStateName,
+  usStateCode,
   type OrgAddress,
 } from "@/lib/shared/org-address";
 import { resolveTimezoneFromAddress } from "@/lib/timezone-from-location";
@@ -163,9 +164,18 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
   }
 
   function onCountryChange(value: string) {
+    const previous = countrySel;
     setCountrySel(value);
     const next: OrgAddress = { ...data.address };
-    // A country switch invalidates the previous state/province selection.
+
+    // Switching BETWEEN countries invalidates the previous state/province: a Texas
+    // code means nothing once the country is the UK. But the FIRST selection is not
+    // a switch, and clearing there silently discarded whatever the operator had
+    // already typed into the free-text region field -- they type "TX", pick United
+    // States, and the state vanishes with no message (IMP-066). The field also
+    // changes identity at that moment (free-text `region` -> `stateCode` picker),
+    // so the loss is invisible: the new control simply renders empty.
+    const carried = previous ? null : (data.address.region ?? "").trim();
     delete next.stateCode;
     delete next.region;
     if (!value) {
@@ -177,6 +187,18 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
     } else {
       next.countryCode = value;
       next.country = countryName(value) ?? value;
+      // Carry a first-selection region across. For the US the picker is code-based,
+      // so map "TX" or "Texas" onto the canonical code; anything unrecognised is
+      // kept as free text rather than dropped.
+      if (carried) {
+        const code = value === "US" ? usStateCode(carried) : null;
+        if (code) {
+          next.stateCode = code;
+          next.region = usStateName(code) ?? carried;
+        } else {
+          next.region = carried;
+        }
+      }
     }
     setAddress(next);
   }

--- a/apps/web/components/admin/BusinessContextForm.tsx
+++ b/apps/web/components/admin/BusinessContextForm.tsx
@@ -16,9 +16,8 @@ import { MarketContextFields } from "@/components/admin/MarketContextFields";
 import {
   COUNTRY_OPTIONS,
   US_STATES,
-  countryName,
-  usStateName,
-  usStateCode,
+  applyCountrySelection,
+  applyStateSelection,
   type OrgAddress,
 } from "@/lib/shared/org-address";
 import { resolveTimezoneFromAddress } from "@/lib/timezone-from-location";
@@ -164,55 +163,16 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
   }
 
   function onCountryChange(value: string) {
-    const previous = countrySel;
     setCountrySel(value);
-    const next: OrgAddress = { ...data.address };
-
-    // Switching BETWEEN countries invalidates the previous state/province: a Texas
-    // code means nothing once the country is the UK. But the FIRST selection is not
-    // a switch, and clearing there silently discarded whatever the operator had
-    // already typed into the free-text region field -- they type "TX", pick United
-    // States, and the state vanishes with no message (IMP-066). The field also
-    // changes identity at that moment (free-text `region` -> `stateCode` picker),
-    // so the loss is invisible: the new control simply renders empty.
-    const carried = previous ? null : (data.address.region ?? "").trim();
-    delete next.stateCode;
-    delete next.region;
-    if (!value) {
-      delete next.countryCode;
-      delete next.country;
-    } else if (value === OTHER_COUNTRY) {
-      delete next.countryCode; // free-text country input fills `country`
-      delete next.country;
-    } else {
-      next.countryCode = value;
-      next.country = countryName(value) ?? value;
-      // Carry a first-selection region across. For the US the picker is code-based,
-      // so map "TX" or "Texas" onto the canonical code; anything unrecognised is
-      // kept as free text rather than dropped.
-      if (carried) {
-        const code = value === "US" ? usStateCode(carried) : null;
-        if (code) {
-          next.stateCode = code;
-          next.region = usStateName(code) ?? carried;
-        } else {
-          next.region = carried;
-        }
-      }
-    }
-    setAddress(next);
+    // Logic lives in the canonical address module so it is testable without
+    // mounting the form, and so this component stays under the module-size
+    // ceiling. See applyCountrySelection for why a FIRST selection differs from a
+    // country switch (IMP-066).
+    setAddress(applyCountrySelection(data.address, value, countrySel, OTHER_COUNTRY));
   }
 
   function onStateChange(value: string) {
-    const next: OrgAddress = { ...data.address };
-    if (value) {
-      next.stateCode = value;
-      next.region = usStateName(value) ?? value;
-    } else {
-      delete next.stateCode;
-      delete next.region;
-    }
-    setAddress(next);
+    setAddress(applyStateSelection(data.address, value));
   }
 
   // Auto-derived from the captured address — shown read-only; the operator

--- a/apps/web/lib/shared/org-address.test.ts
+++ b/apps/web/lib/shared/org-address.test.ts
@@ -8,6 +8,8 @@ import {
   parseOrgAddress,
   sanitizeOrgAddressInput,
   serializeOrgAddress,
+  usStateCode,
+  usStateName,
 } from "./org-address";
 import { COUNTRY_TO_TIMEZONE, US_STATE_TO_TIMEZONE } from "@/lib/timezone-from-location";
 
@@ -197,6 +199,47 @@ describe("COUNTRY_OPTIONS resolve a timezone", () => {
   it("every offered country code is resolvable via COUNTRY_TO_TIMEZONE", () => {
     for (const { code } of COUNTRY_OPTIONS) {
       expect(COUNTRY_TO_TIMEZONE[code], `country ${code} is offered but has no timezone`).toBeDefined();
+    }
+  });
+});
+
+describe("usStateCode", () => {
+  // IMP-066: the business form discarded a typed state when the operator picked a
+  // country, because the field changes identity at that moment (free-text `region`
+  // -> `stateCode` picker). Carrying the value across needs a reverse lookup that
+  // accepts whatever a human actually types.
+  it("accepts a code in any case", () => {
+    expect(usStateCode("TX")).toBe("TX");
+    expect(usStateCode("tx")).toBe("TX");
+    expect(usStateCode("  Tx  ")).toBe("TX");
+  });
+
+  it("accepts a display name in any case", () => {
+    expect(usStateCode("Texas")).toBe("TX");
+    expect(usStateCode("texas")).toBe("TX");
+    expect(usStateCode("NEW YORK")).toBe("NY");
+  });
+
+  it("returns null for a non-US region rather than inventing a code", () => {
+    expect(usStateCode("Ontario")).toBeNull();
+    expect(usStateCode("Bavaria")).toBeNull();
+    expect(usStateCode("ZZ")).toBeNull();
+  });
+
+  it("returns null for empty input", () => {
+    expect(usStateCode("")).toBeNull();
+    expect(usStateCode("   ")).toBeNull();
+    expect(usStateCode(null)).toBeNull();
+    expect(usStateCode(undefined)).toBeNull();
+  });
+
+  it("round-trips every state in the picker list", () => {
+    // Guards the pair: a state added to US_STATES must be resolvable from both its
+    // code and its display name, or the carry-across silently drops it.
+    for (const { code, name } of US_STATES) {
+      expect(usStateCode(code)).toBe(code);
+      expect(usStateCode(name)).toBe(code);
+      expect(usStateName(code)).toBe(name);
     }
   });
 });

--- a/apps/web/lib/shared/org-address.test.ts
+++ b/apps/web/lib/shared/org-address.test.ts
@@ -10,6 +10,8 @@ import {
   serializeOrgAddress,
   usStateCode,
   usStateName,
+  applyCountrySelection,
+  applyStateSelection,
 } from "./org-address";
 import { COUNTRY_TO_TIMEZONE, US_STATE_TO_TIMEZONE } from "@/lib/timezone-from-location";
 
@@ -241,5 +243,70 @@ describe("usStateCode", () => {
       expect(usStateCode(name)).toBe(code);
       expect(usStateName(code)).toBe(name);
     }
+  });
+});
+
+describe("applyCountrySelection", () => {
+  const OTHER = "__other__";
+
+  // IMP-066: the state field changes identity when a country is picked — free-text
+  // `region` before, `stateCode` picker after — and the old handler cleared both
+  // unconditionally. A FIRST selection is not a switch.
+  it("carries a typed state across the first country selection", () => {
+    const out = applyCountrySelection({ city: "Fort Worth", region: "TX" }, "US", "", OTHER);
+    expect(out.stateCode).toBe("TX");
+    expect(out.region).toBe("Texas");
+    expect(out.countryCode).toBe("US");
+  });
+
+  it("accepts a typed full state name too", () => {
+    const out = applyCountrySelection({ region: "texas" }, "US", null, OTHER);
+    expect(out.stateCode).toBe("TX");
+    expect(out.region).toBe("Texas");
+  });
+
+  it("keeps an unrecognised region as free text rather than dropping it", () => {
+    const out = applyCountrySelection({ region: "Bavaria" }, "DE", "", OTHER);
+    expect(out.region).toBe("Bavaria");
+    expect(out.stateCode).toBeUndefined();
+  });
+
+  it("still clears when switching BETWEEN countries", () => {
+    // A Texas code is meaningless once the country is the UK.
+    const out = applyCountrySelection(
+      { region: "Texas", stateCode: "TX", countryCode: "US" },
+      "GB",
+      "US",
+      OTHER,
+    );
+    expect(out.stateCode).toBeUndefined();
+    expect(out.region).toBeUndefined();
+    expect(out.countryCode).toBe("GB");
+  });
+
+  it("clears country fields when the selection is emptied", () => {
+    const out = applyCountrySelection({ region: "Texas", stateCode: "TX", countryCode: "US" }, "", "US", OTHER);
+    expect(out.countryCode).toBeUndefined();
+    expect(out.country).toBeUndefined();
+  });
+
+  it("carries the region into the free-text country path", () => {
+    const out = applyCountrySelection({ region: "Jalisco" }, OTHER, "", OTHER);
+    expect(out.region).toBe("Jalisco");
+    expect(out.countryCode).toBeUndefined();
+  });
+});
+
+describe("applyStateSelection", () => {
+  it("keeps code and display name in step", () => {
+    const out = applyStateSelection({ city: "Austin" }, "TX");
+    expect(out.stateCode).toBe("TX");
+    expect(out.region).toBe("Texas");
+  });
+
+  it("clears both when the selection is emptied", () => {
+    const out = applyStateSelection({ stateCode: "TX", region: "Texas" }, "");
+    expect(out.stateCode).toBeUndefined();
+    expect(out.region).toBeUndefined();
   });
 });

--- a/apps/web/lib/shared/org-address.ts
+++ b/apps/web/lib/shared/org-address.ts
@@ -170,6 +170,66 @@ export function usStateCode(input: string | null | undefined): string | null {
   return null;
 }
 
+/**
+ * Apply a country selection to an address, preserving a state the operator already
+ * typed.
+ *
+ * The state field changes identity when a country is picked: free-text `region`
+ * before, a code-based `stateCode` picker after. Switching BETWEEN countries must
+ * clear it (a Texas code is meaningless once the country is the UK), but the FIRST
+ * selection is not a switch — clearing there silently discarded typed input, and
+ * invisibly, because the replacement control just renders empty (IMP-066).
+ *
+ * `previousCountry` is the selection before this change ("" / null when none).
+ * Pure so the behaviour is testable without mounting the form.
+ */
+export function applyCountrySelection(
+  address: OrgAddress,
+  value: string,
+  previousCountry: string | null | undefined,
+  otherCountrySentinel: string,
+): OrgAddress {
+  const next: OrgAddress = { ...address };
+  const carried = previousCountry ? null : (address.region ?? "").trim();
+
+  delete next.stateCode;
+  delete next.region;
+
+  if (!value || value === otherCountrySentinel) {
+    delete next.countryCode;
+    delete next.country;
+    // A free-text country still deserves the carried region.
+    if (value === otherCountrySentinel && carried) next.region = carried;
+    return next;
+  }
+
+  next.countryCode = value;
+  next.country = countryName(value) ?? value;
+  if (carried) {
+    const code = value === "US" ? usStateCode(carried) : null;
+    if (code) {
+      next.stateCode = code;
+      next.region = usStateName(code) ?? carried;
+    } else {
+      next.region = carried;
+    }
+  }
+  return next;
+}
+
+/** Apply a state-picker selection, keeping code and display name in step. */
+export function applyStateSelection(address: OrgAddress, value: string): OrgAddress {
+  const next: OrgAddress = { ...address };
+  if (value) {
+    next.stateCode = value;
+    next.region = usStateName(value) ?? value;
+  } else {
+    delete next.stateCode;
+    delete next.region;
+  }
+  return next;
+}
+
 /** Display name for an ISO alpha-2 country code, or null when unknown. */
 export function countryName(code: string | null | undefined): string | null {
   const c = code?.trim().toUpperCase();

--- a/apps/web/lib/shared/org-address.ts
+++ b/apps/web/lib/shared/org-address.ts
@@ -151,6 +151,25 @@ export function usStateName(code: string | null | undefined): string | null {
   return (c && US_STATE_NAME_BY_CODE.get(c)) || null;
 }
 
+/**
+ * Canonical US state CODE from either a code ("tx") or a display name ("Texas"),
+ * or null when it matches neither.
+ *
+ * Exists so a state the operator typed as free text before picking a country can
+ * be carried into the code-based picker instead of being discarded (IMP-066).
+ */
+export function usStateCode(input: string | null | undefined): string | null {
+  const raw = input?.trim();
+  if (!raw) return null;
+  const upper = raw.toUpperCase();
+  if (US_STATE_NAME_BY_CODE.has(upper)) return upper;
+  const lower = raw.toLowerCase();
+  for (const { code, name } of US_STATES) {
+    if (name.toLowerCase() === lower) return code;
+  }
+  return null;
+}
+
 /** Display name for an ISO alpha-2 country code, or null when unknown. */
 export function countryName(code: string | null | undefined): string | null {
   const c = code?.trim().toUpperCase();


### PR DESCRIPTION
## The defect

In the business setup form the state field **changes identity** when a country is
picked:

| Before country selected | After |
|---|---|
| free-text `region` input | code-based `stateCode` dropdown |

`onCountryChange` cleared both unconditionally:

```ts
// A country switch invalidates the previous state/province selection.
delete next.stateCode;
delete next.region;
```

That is right when switching **between** countries — a Texas code means nothing
once the country is the UK. It is wrong on the **first** selection, which is not a
switch.

An operator types `TX`, picks United States, and loses it. The loss is invisible:
the replacement control simply renders empty, so the state reads as *"never filled
in"* rather than *"discarded"*.

## The fix

A first selection now carries the typed value across. For the US the picker is
code-based, so `TX` or `Texas` maps onto the canonical code; anything unrecognised
is preserved as free text rather than dropped. Switching between two countries
still clears, exactly as before.

Adds `usStateCode()` to the canonical address module — the reverse of the existing
`usStateName()` — accepting a code or a display name in any case, and returning
`null` rather than inventing a code for a non-US region.

## Tests

Code / name / case / whitespace, non-US regions (`Ontario`, `Bavaria`), empty and
null input, plus a **round-trip over every entry in `US_STATES`** so a state added
to the picker cannot end up resolvable in one direction only.

## Relationship to #4419

Two halves of the same data loss:

- **#4419** dropped the state on the way **out** (storefront render)
- **this** drops it on the way **in** (setup capture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)