### PR TITLE
fix(build-studio): make the operator canvas readable (BI-101C107C follow-on)

### DIFF
--- a/apps/web/components/build/BuildSolutionSummaryBand.tsx
+++ b/apps/web/components/build/BuildSolutionSummaryBand.tsx
@@ -15,6 +15,7 @@
 
 import { StatusBadge } from "@/components/ui/report-kit";
 import type { Intent } from "@/components/ui/report-kit/statusColors";
+import { clampStatement, toProseStatement } from "@/lib/build/owner-change-view";
 import type { AutonomousBuildCustodyView } from "@/lib/build/autonomous-build-custody";
 
 type Props = {
@@ -36,12 +37,15 @@ function normalizeCopy(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
+/**
+ * This band is handed the originating backlog item's description, which for a
+ * promoted BI is the whole markdown body. It previously only collapsed
+ * whitespace, so "## Problem" and "> **...**" rendered literally on the canvas
+ * — the same wall the Outcome slot showed, one card lower. Both now share the
+ * one stripper.
+ */
 function compactCopy(value: string, maxLength: number): string {
-  const normalized = normalizeCopy(value);
-  if (normalized.length <= maxLength) return normalized;
-  const sentenceBreak = normalized.lastIndexOf(".", maxLength);
-  const cutAt = sentenceBreak >= 80 ? sentenceBreak + 1 : maxLength;
-  return `${normalized.slice(0, cutAt).trim()}...`;
+  return clampStatement(normalizeCopy(toProseStatement(value)), maxLength);
 }
 
 function isTechnicalPlanCopy(value: string): boolean {

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -79,6 +79,7 @@ import {
   BUILD_STUDIO_TEST_IDS,
   getBuildStudioGraphPanelClassName,
   getBuildStudioShellClassName,
+  getBuildStudioContentPaneClassName,
   getBuildStudioSidebarClassName,
   shouldOpenBuildStudioSidebarByDefault,
 } from "./build-studio-layout";
@@ -851,14 +852,14 @@ export function BuildStudio({
             }}
             onOpenQueueDrawer={() => {
               setEngineerView(true);
-              setDrawerInitialSectionId("bs-queue");
+              setDrawerInitialSectionId("progress");
               setDrawerOpen(true);
             }}
           />
         </div>
 
         {/* Right: Preview or Brief */}
-        <div className="flex min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto bg-[var(--dpf-surface-1)]">
+        <div className={getBuildStudioContentPaneClassName(drawerOpen)}>
           {engineerView ? (
             <PortalContextStrip
               envelope={portalContext ?? null}
@@ -1203,12 +1204,6 @@ function buildDetailsDrawerSections(
       defaultOpen: defaultId === "review",
       content: <ReviewPanel build={activeBuild} />,
     },
-    {
-      id: "bs-queue",
-      title: "BS Queue",
-      defaultOpen: defaultId === "bs-queue",
-      content: <BsQueueSection builds={allBuilds} customerStatuses={customerStatuses} />,
-    },
   ];
 }
 
@@ -1314,82 +1309,12 @@ function AssuranceRow({ expanded, onToggle, freshness, buildId, bomSummary, find
   );
 }
 
-function BsQueueSection({
-  builds,
-  customerStatuses,
-}: {
-  builds: readonly FeatureBuildRow[];
-  customerStatuses: Record<string, BuildStudioCustomerStatus>;
-}) {
-  const entries = builds.map((b) => ({
-    build: b,
-    queueState: deriveQueueState(b),
-    attention: deriveBuildAttention(b, customerStatuses[b.id]),
-  }));
-  const kindRank = { running: 0, blocked: 1, queued: 2, idle: 3 } as const;
-  const sorted = [...entries].sort((a, b) => {
-    const aNeeds = a.attention.needsOwner;
-    const bNeeds = b.attention.needsOwner;
-    if (aNeeds !== bNeeds) return aNeeds ? -1 : 1;
-    const ra = kindRank[a.queueState.kind];
-    const rb = kindRank[b.queueState.kind];
-    if (ra !== rb) return ra - rb;
-    if (a.queueState.kind === "queued" && b.queueState.kind === "queued") {
-      return a.queueState.position - b.queueState.position;
-    }
-    return a.build.buildId.localeCompare(b.build.buildId);
-  });
-  const counts = entries.reduce(
-    (acc, entry) => {
-      if (entry.queueState.kind === "running") acc.runningCount += 1;
-      if (entry.queueState.kind === "blocked") acc.blockedCount += 1;
-      if (entry.queueState.kind === "queued") acc.queuedCount += 1;
-      return acc;
-    },
-    { runningCount: 0, blockedCount: 0, queuedCount: 0 },
-  );
-  const labelForQueueState = (entry: (typeof entries)[number]) => {
-    // Canonical vocabulary — same producer as the rail, so the two panels
-    // showing the same builds can no longer disagree.
-    if (entry.attention.needsOwner) return ownerStateBadgeLabel(entry.attention.state);
-    if (entry.queueState.kind === "running") return "Working";
-    if (entry.queueState.kind === "blocked") return "Blocked";
-    if (entry.queueState.kind === "queued") return `Waiting ${entry.queueState.position}`;
-    return formatOperatorPhaseLabel(entry.build.phase);
-  };
-
-  return (
-    <div className="flex flex-col gap-2">
-      <p className="text-[var(--dpf-muted)]">
-        AI Coworker workload, read-only here. Use the build's main action when
-        one of these needs you.
-      </p>
-      <div className="flex flex-wrap gap-3 text-[11px] text-[var(--dpf-text)]">
-        <span>Working: <span className="font-semibold">{counts.runningCount}</span></span>
-        <span>Blocked: <span className="font-semibold text-[var(--dpf-warning)]">{counts.blockedCount}</span></span>
-        <span>Waiting: <span className="font-semibold">{counts.queuedCount}</span></span>
-      </div>
-      <ul className="flex flex-col gap-1">
-        {sorted.map((entry) => (
-          <li
-            key={entry.build.buildId}
-            className="flex items-center gap-2 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-[11px]"
-            data-build-id={entry.build.buildId}
-            data-queue-kind={entry.queueState.kind}
-          >
-            <span className="min-w-0 flex-1 truncate text-[var(--dpf-text)]">{entry.build.title}</span>
-            <span className="ml-auto shrink-0 text-[10px] font-semibold text-[var(--dpf-muted)]">
-              {labelForQueueState(entry)}
-            </span>
-          </li>
-        ))}
-        {sorted.length === 0 && (
-          <li className="text-[var(--dpf-muted)]">No builds.</li>
-        )}
-      </ul>
-    </div>
-  );
-}
+// BsQueueSection was deleted here. It re-listed the SAME builds the fleet rail
+// already shows, in a different vocabulary, and its counters tallied only
+// running/blocked/queued while its list rendered every entry — so it could
+// display "Working: 1  Blocked: 0  Waiting: 0" above a list of four rows. Its
+// own copy told the operator it was read-only and to go act somewhere else: a
+// panel that cost attention and returned no action. The rail is the one list.
 
 /* ────────────────────────────────────────────────────────────────────────── */
 /* NodeInspector helpers — derive title + body + coworker-prefill from click. */
@@ -1755,7 +1680,7 @@ function FleetRailZone({
         onClick={onOpenQueueDrawer}
         role="status"
         aria-live="polite"
-        aria-label="Open technical build queue details"
+        aria-label="Open build progress details"
         data-testid="build-studio-fleet-header"
         className="flex w-full shrink-0 cursor-pointer items-center justify-between border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-1.5 text-left text-[11px] font-semibold text-[var(--dpf-text)] transition-colors hover:bg-[var(--dpf-surface-3)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
       >

--- a/apps/web/components/build/BuildStudioDetailsDrawer.test.tsx
+++ b/apps/web/components/build/BuildStudioDetailsDrawer.test.tsx
@@ -211,7 +211,7 @@ describe("BuildStudio DetailsDrawer integration", () => {
     fireEvent.click(screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawerPill));
     const sectionHeaders = document.querySelectorAll("[data-section-id]");
     const ids = Array.from(sectionHeaders).map((s) => s.getAttribute("data-section-id"));
-    expect(ids).toEqual(["canonical-doc", "progress", "brief", "review", "bs-queue"]);
+    expect(ids).toEqual(["canonical-doc", "progress", "brief", "review"]);
   });
 
   it("phase=ideate → Brief is default-open", () => {
@@ -281,19 +281,18 @@ describe("BuildStudio DetailsDrawer integration", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawer)).toHaveAttribute("data-open", "true");
-      const queueSection = document.querySelector(`[data-testid="${BUILD_STUDIO_TEST_IDS.detailsDrawerQueue}"]`);
-      expect(queueSection).toHaveAttribute("data-open", "true");
+      // The fleet header used to open a duplicate BS-Queue panel; it now opens
+      // real progress detail (BI readable-canvas).
+      const progressSection = document.querySelector('[data-testid="details-drawer-section-progress"]');
+      expect(progressSection).toHaveAttribute("data-open", "true");
     });
   });
 
-  it("BS-Queue section lists builds with kind + buildId", () => {
+  it("does not re-list the fleet inside the drawer — the rail is the one list", () => {
     render(
       <BuildStudio
         builds={[
           makeBuild({ buildId: "FB-RUNRUNRUN", phase: "build" }),
-          // BI-5939B62F: ideate/plan now derive to "running", so use a still-idle
-          // phase (ship with acceptance recorded → idle, not needs-you) to keep
-          // the running → idle sort covered.
           makeBuild({
             buildId: "FB-IDLEEEEEE",
             phase: "ship",
@@ -307,17 +306,14 @@ describe("BuildStudio DetailsDrawer integration", () => {
       />,
     );
     fireEvent.click(screen.getByTestId("build-studio-fleet-header"));
-    const queueSection = document.querySelector(`[data-testid="${BUILD_STUDIO_TEST_IDS.detailsDrawerQueue}"]`);
-    expect(queueSection).toBeInTheDocument();
-    // Both rows rendered, sorted running → idle.
-    const rows = queueSection!.querySelectorAll("[data-build-id]");
-    expect(rows).toHaveLength(2);
-    expect(rows[0]).toHaveAttribute("data-build-id", "FB-RUNRUNRUN");
-    expect(rows[0]).toHaveAttribute("data-queue-kind", "running");
-    expect(rows[1]).toHaveAttribute("data-build-id", "FB-IDLEEEEEE");
-    expect(rows[1]).toHaveAttribute("data-queue-kind", "idle");
+    // The duplicate queue panel is gone: no drawer section re-renders the
+    // build list, and its counters (which tallied only running/blocked/queued
+    // while listing every row) can no longer disagree with what it shows.
+    expect(
+      document.querySelector('[data-testid="details-drawer-section-bs-queue"]'),
+    ).toBeNull();
+    expect(document.body.textContent).not.toContain("AI Coworker workload");
   });
-
   it("close button unmounts the drawer from the owner-facing DOM", async () => {
     render(
       <BuildStudio

--- a/apps/web/components/build/DetailsDrawer.test.tsx
+++ b/apps/web/components/build/DetailsDrawer.test.tsx
@@ -120,11 +120,15 @@ describe("DetailsDrawer", () => {
     expect(screen.queryByText("brief body")).not.toBeInTheDocument();
   });
 
-  it("the BS-queue section uses the canonical detailsDrawerQueue test ID for integration", () => {
+  it("gives every section the same id shape — no per-section special cases", () => {
     render(
       <DetailsDrawer isOpen onClose={vi.fn()} sections={sampleSections()} />,
     );
-    expect(screen.getByTestId(BUILD_STUDIO_TEST_IDS.detailsDrawerQueue)).toBeInTheDocument();
+    for (const section of sampleSections()) {
+      expect(
+        screen.getByTestId(`details-drawer-section-${section.id}`),
+      ).toBeInTheDocument();
+    }
   });
 
   it("Esc closes the drawer when open", () => {

--- a/apps/web/components/build/DetailsDrawer.tsx
+++ b/apps/web/components/build/DetailsDrawer.tsx
@@ -146,8 +146,9 @@ export function DetailsDrawer({ isOpen, onClose, sections, fallbackFocusRef }: D
           const open = openIds.has(section.id);
           const headerId = `details-drawer-${section.id}-header`;
           const panelId = `details-drawer-${section.id}-panel`;
-          const sectionTestId =
-            section.id === "bs-queue" ? BUILD_STUDIO_TEST_IDS.detailsDrawerQueue : `details-drawer-section-${section.id}`;
+          // One id rule for every section. The former `bs-queue` special case
+          // named a section that no longer exists.
+          const sectionTestId = `details-drawer-section-${section.id}`;
           return (
             <section
               key={section.id}

--- a/apps/web/components/build/build-studio-layout.test.ts
+++ b/apps/web/components/build/build-studio-layout.test.ts
@@ -45,7 +45,6 @@ describe("BUILD_STUDIO_TEST_IDS", () => {
       nodeInspector: expect.any(String),
       detailsDrawer: expect.any(String),
       detailsDrawerPill: expect.any(String),
-      detailsDrawerQueue: expect.any(String),
       buildListItem: expect.any(String),
       phaseMiniRail: expect.any(String),
       queueStateBadge: expect.any(String),

--- a/apps/web/components/build/build-studio-layout.ts
+++ b/apps/web/components/build/build-studio-layout.ts
@@ -28,7 +28,6 @@ export const BUILD_STUDIO_TEST_IDS = {
   nodeInspectorExpand: "build-studio-node-inspector-expand",
   detailsDrawer: "build-studio-details-drawer",
   detailsDrawerPill: "build-studio-details-drawer-pill",
-  detailsDrawerQueue: "build-studio-details-drawer-queue",
   buildListItem: "build-studio-build-list-item",
   phaseMiniRail: "build-studio-phase-mini-rail",
   queueStateBadge: "build-studio-queue-state-badge",
@@ -209,6 +208,24 @@ export function getWorkflowCanvasClassName(): string {
  * DetailsDrawer container — slides in from the right edge of the workflow
  * region. NEVER covers the coworker zone (the parent shell already separates them).
  */
+/**
+ * The centre content pane. When the DetailsDrawer is open it reserves the
+ * drawer's width as right padding.
+ *
+ * The drawer is `absolute right-0 z-20`, so it OVERLAYS rather than displaces:
+ * the canvas kept its full width and its text was occluded mid-sentence with no
+ * reflow and no scroll affordance. Reserving the width here restores reflow
+ * while keeping the drawer's translate-x slide (a flex sibling would have to
+ * animate width instead, which is visibly janky).
+ *
+ * Padding is dropped below the `lg` breakpoint, where the drawer covers most of
+ * the viewport and displacing the canvas would leave nothing readable.
+ */
+export function getBuildStudioContentPaneClassName(drawerOpen: boolean): string {
+  const base = "flex min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto bg-[var(--dpf-surface-1)] transition-[padding] duration-200 motion-reduce:transition-none";
+  return drawerOpen ? `${base} lg:pr-[min(480px,40vw)]` : base;
+}
+
 export function getDetailsDrawerClassName(isOpen: boolean): string {
   const base = [
     "absolute",

--- a/apps/web/lib/build/outcome-statement.test.ts
+++ b/apps/web/lib/build/outcome-statement.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { OUTCOME_STATEMENT_MAX, toOutcomeStatement } from "./owner-change-view";
+
+// The literal shape the operator hit: the Outcome slot rendered the WHOLE
+// markdown BI body as one plain <p>, so `##`, `>` and `**` appeared on screen.
+const REAL_BI_BODY = `## Problem
+On the owner cockpit (\`/workspace\`), the attention card reads:
+> **Choose how to fix this for customers?**
+
+The question mark makes it ungrammatical.
+
+## Scope
+**In scope:** rewrite the four \`copy.ts\` entries.
+**Out of scope:** the other 16 headlines.`;
+
+describe("toOutcomeStatement", () => {
+  it("reduces a full markdown BI body to one readable sentence", () => {
+    const out = toOutcomeStatement(REAL_BI_BODY);
+    expect(out).toBe(
+      "On the owner cockpit (/workspace), the attention card reads: Choose how to fix this for customers?",
+    );
+  });
+
+  it("never leaks markdown structure to the operator", () => {
+    const out = toOutcomeStatement(REAL_BI_BODY);
+    for (const marker of ["##", "**", "> ", "`"]) {
+      expect(out, `must not contain ${marker}`).not.toContain(marker);
+    }
+  });
+
+  it("passes a short, well-formed outcome through untouched", () => {
+    const clean = "Let owners rotate API keys without losing access for live tenants.";
+    expect(toOutcomeStatement(clean)).toBe(clean);
+  });
+
+  it("skips a leading heading and takes the prose beneath it", () => {
+    expect(toOutcomeStatement("## Problem\n\nThe invoice total is wrong for multi-currency customers."))
+      .toBe("The invoice total is wrong for multi-currency customers.");
+  });
+
+  it("stops at the first paragraph rather than concatenating the whole doc", () => {
+    const out = toOutcomeStatement("First paragraph here.\n\nSecond paragraph should not appear.");
+    expect(out).toBe("First paragraph here.");
+  });
+
+  it("strips structure even when a body is headings and bullets only", () => {
+    const out = toOutcomeStatement("## Scope\n- one\n- two");
+    expect(out).not.toContain("##");
+    expect(out).not.toContain("- ");
+  });
+
+  it("drops fenced code blocks", () => {
+    const out = toOutcomeStatement("Fix the parser.\n\n```ts\nconst x = 1;\n```");
+    expect(out).toBe("Fix the parser.");
+    expect(out).not.toContain("const x");
+  });
+
+  it("reduces a link to its label", () => {
+    expect(toOutcomeStatement("See [the runbook](https://example.com/r) for detail."))
+      .toBe("See the runbook for detail.");
+  });
+
+  it("clamps an over-long statement at a sentence boundary when there is one", () => {
+    const first = `${"word ".repeat(30).trim()}.`;
+    const out = toOutcomeStatement(`${first} ${"tail ".repeat(60).trim()}.`);
+    expect(out.length).toBeLessThanOrEqual(OUTCOME_STATEMENT_MAX);
+    expect(out).toBe(first);
+  });
+
+  it("clamps on a word boundary with an ellipsis when there is no sentence break", () => {
+    const out = toOutcomeStatement("x".repeat(40) + " " + "y".repeat(400));
+    expect(out.length).toBeLessThanOrEqual(OUTCOME_STATEMENT_MAX + 1);
+    expect(out.endsWith("…")).toBe(true);
+    // Never mid-word before the ellipsis.
+    expect(out).not.toMatch(/y…$/);
+  });
+
+  it("returns empty for empty input rather than inventing copy", () => {
+    expect(toOutcomeStatement("")).toBe("");
+    expect(toOutcomeStatement("   \n  ")).toBe("");
+  });
+});

--- a/apps/web/lib/build/owner-change-view.ts
+++ b/apps/web/lib/build/owner-change-view.ts
@@ -246,6 +246,19 @@ export const OUTCOME_STATEMENT_MAX = 240;
  * in one line; anything longer belongs behind disclosure.
  */
 export function toOutcomeStatement(raw: string): string {
+  return clampStatement(toProseStatement(raw), OUTCOME_STATEMENT_MAX);
+}
+
+/**
+ * Strip markdown structure and return the first prose paragraph, unclamped.
+ *
+ * Shared by every operator-facing surface that may be handed a raw BI body —
+ * the Outcome slot and the "What we're building" band both were, and both
+ * leaked literal "##", ">" and "**" onto the canvas because each had its own
+ * idea of "tidy this up" (one collapsed whitespace, the other did nothing).
+ * One stripper, so a new surface cannot reintroduce the wall.
+ */
+export function toProseStatement(raw: string): string {
   let text = raw.trim();
   if (!text) return text;
 
@@ -293,20 +306,23 @@ export function toOutcomeStatement(raw: string): string {
     .replace(/\s+/g, " ")
     .trim();
 
-  if (statement.length <= OUTCOME_STATEMENT_MAX) return statement;
+  return statement;
+}
 
-  // Prefer a sentence boundary inside the budget; otherwise clamp on a word.
-  const window = statement.slice(0, OUTCOME_STATEMENT_MAX);
+/** Clamp at a sentence boundary inside the budget; else a word boundary. */
+export function clampStatement(statement: string, maxLength: number): string {
+  if (statement.length <= maxLength) return statement;
+  const window = statement.slice(0, maxLength);
   const sentenceEnd = Math.max(
     window.lastIndexOf(". "),
     window.lastIndexOf("? "),
     window.lastIndexOf("! "),
   );
-  if (sentenceEnd > OUTCOME_STATEMENT_MAX * 0.4) {
+  if (sentenceEnd > maxLength * 0.4) {
     return statement.slice(0, sentenceEnd + 1);
   }
   const wordEnd = window.lastIndexOf(" ");
-  return `${statement.slice(0, wordEnd > 0 ? wordEnd : OUTCOME_STATEMENT_MAX).trimEnd()}\u2026`;
+  return `${statement.slice(0, wordEnd > 0 ? wordEnd : maxLength).trimEnd()}\u2026`;
 }
 
 function firstText(...values: Array<string | null | undefined>): string {

--- a/apps/web/lib/build/owner-change-view.ts
+++ b/apps/web/lib/build/owner-change-view.ts
@@ -53,13 +53,13 @@ export function projectOwnerChangeView(input: {
   previewDrivingBuildId?: string | null;
 }): OwnerChangeView {
   const { build, status } = input;
-  const outcome = firstText(
+  const outcome = toOutcomeStatement(firstText(
     build.businessBuildBrief?.businessOutcome,
     build.designDoc?.problemStatement,
     build.description,
     build.originator?.resolution,
     build.title,
-  );
+  ));
   const previewAvailable =
     build.sandboxPort !== null && ["build", "review", "ship"].includes(build.phase);
   const pendingDecision = build.decisionInteraction;
@@ -225,6 +225,88 @@ export function fallbackNext(phase: BuildPhase): string {
   if (phase === "abandoned") return "Resume only if this outcome is still valuable.";
   if (phase === "ship") return "Review the proof before release.";
   return "No action is needed unless Build Studio asks for a decision.";
+}
+
+
+/** Longest an outcome statement may be before it is clamped. */
+export const OUTCOME_STATEMENT_MAX = 240;
+
+/**
+ * Reduce whatever the fallback chain found to ONE readable sentence.
+ *
+ * The chain's third entry is `build.description`, which for any build promoted
+ * from the backlog is the WHOLE markdown BI body — "## Problem ... ## Scope ...
+ * ## Acceptance criteria". BuildOperatorOverview rendered that into a single
+ * plain <p>, so the operator's first viewport was a wall of unrendered markdown
+ * (literal "##" and "> **" on screen), unclamped and occluded by the details
+ * drawer. The full text is not lost: the drawer's Canonical doc section already
+ * renders the same string as proper formatted markdown.
+ *
+ * So this is deliberately lossy. The Outcome slot answers "what did I ask for?"
+ * in one line; anything longer belongs behind disclosure.
+ */
+export function toOutcomeStatement(raw: string): string {
+  let text = raw.trim();
+  if (!text) return text;
+
+  // Drop fenced code blocks entirely — never a useful outcome statement.
+  text = text.replace(/```[\s\S]*?```/g, " ");
+
+  const lines = text.split(/\r?\n/);
+  const prose: string[] = [];
+  for (const line of lines) {
+    let s = line.trim();
+    if (!s) {
+      // A blank line ends the first paragraph once we have prose.
+      if (prose.length > 0) break;
+      continue;
+    }
+    // Skip structural markdown: headings, list bullets, table rows, rules.
+    if (/^#{1,6}\s/.test(s)) continue;
+    if (/^[-*+]\s/.test(s) || /^\d+\.\s/.test(s)) continue;
+    if (/^\|/.test(s) || /^[-=]{3,}$/.test(s)) continue;
+    // Blockquote markers are noise, but the quoted text may be the statement.
+    s = s.replace(/^>\s?/, "");
+    if (!s) continue;
+    prose.push(s);
+  }
+
+  // When a body carries no prose at all (headings + bullets only), fall back to
+  // the raw text — but still strip the structural markers, or the operator sees
+  // literal "##" and "-" in the Outcome slot.
+  let statement = (
+    prose.length > 0
+      ? prose.join(" ")
+      : text
+        .replace(/^#{1,6}\s+/gm, "")
+        .replace(/^[-*+]\s+/gm, "")
+        .replace(/^\d+\.\s+/gm, "")
+        .replace(/^>\s?/gm, "")
+  ).trim();
+
+  // Strip inline markdown emphasis/code, and reduce links to their label.
+  statement = statement
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/(?<!\w)[*_]([^*_]+)[*_](?!\w)/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (statement.length <= OUTCOME_STATEMENT_MAX) return statement;
+
+  // Prefer a sentence boundary inside the budget; otherwise clamp on a word.
+  const window = statement.slice(0, OUTCOME_STATEMENT_MAX);
+  const sentenceEnd = Math.max(
+    window.lastIndexOf(". "),
+    window.lastIndexOf("? "),
+    window.lastIndexOf("! "),
+  );
+  if (sentenceEnd > OUTCOME_STATEMENT_MAX * 0.4) {
+    return statement.slice(0, sentenceEnd + 1);
+  }
+  const wordEnd = window.lastIndexOf(" ");
+  return `${statement.slice(0, wordEnd > 0 ? wordEnd : OUTCOME_STATEMENT_MAX).trimEnd()}\u2026`;
 }
 
 function firstText(...values: Array<string | null | undefined>): string {

--- a/docs/superpowers/plans/2026-08-21-build-studio-readable-canvas.md
+++ b/docs/superpowers/plans/2026-08-21-build-studio-readable-canvas.md
@@ -1,0 +1,66 @@
+---
+title: Build Studio — a readable operator canvas
+date: 2026-08-21
+status: active
+owner: platform
+backlogItem: BI-101C107C
+---
+
+# Build Studio — a readable operator canvas
+
+**Backlog:** `BI-101C107C` (follow-on) · **Decision:** `DI-BCC92F9AFC08` (Phase 3) · **Follows:** PR #4423 (ratchet), PR #4424 (one attention truth)
+
+## Outcome
+
+The operator's first viewport on `/build` is readable without delivery-process knowledge: one outcome sentence, nothing occluded, and no surface showing the same list twice.
+
+## The durable rule this establishes
+
+**There is exactly one markdown stripper for operator-facing copy, and every surface handed a raw backlog body must use it.**
+
+That rule is the point of this change, not the individual fixes. Both surfaces that render `build.description` had invented their own idea of "tidy this up" — one collapsed whitespace and clamped, the other did nothing at all — so the same markdown wall appeared twice on one screen with only one of them ever getting fixed.
+
+```
+lib/build/owner-change-view.ts
+  toProseStatement(raw)              strip structure, first prose paragraph
+  clampStatement(text, maxLength)    sentence boundary, else word + ellipsis
+  toOutcomeStatement(raw)            = clampStatement(toProseStatement(raw), 240)
+```
+
+A new operator surface that receives a backlog description **composes these**. It does not write a normalizer. `BuildSolutionSummaryBand` now applies the same stripper with its own 260/170 budgets, which is the intended shape: shared stripping, local clamping.
+
+## Defects closed
+
+| # | Defect | Fix |
+| --- | --- | --- |
+| 1 | Outcome slot rendered the whole markdown BI body as one plain `<p>` — literal `##`, `>`, `` ` `` on screen, unclamped | `toOutcomeStatement()` reduces to one sentence |
+| 2 | "What we're building" rendered the **same** raw body one card lower | same stripper, local budget |
+| 3 | DetailsDrawer is `absolute right-0 z-20` — it overlaid the canvas, clipping text mid-sentence with no reflow | centre pane reserves the drawer width while open |
+| 4 | `BsQueueSection` re-listed the fleet in a second vocabulary, with counters that could read `Working: 1 Blocked: 0 Waiting: 0` above four rows | deleted; the rail is the one list |
+
+### On #1 being deliberately lossy
+
+The Outcome slot answers *"what did I ask for?"* in one line. The full body is not lost — the drawer's Canonical doc section already renders that same string as properly formatted markdown, which is why the canvas rendering it raw was strictly worse than the disclosure one panel away.
+
+### On #2 — the case for looking
+
+#1 was green in tests and the canvas read cleanly. #2 was found by opening the running portal against the exact build from the report (`FB-755EFA29`) and scrolling down. No DOM-level test would have caught it, because the assertions were written against the surface that had been fixed.
+
+### On #3 — why padding rather than a flex sibling
+
+Reserving width as padding keeps the drawer's `translate-x` slide. A flex sibling would have to animate width instead, which is visibly janky. Padding is dropped below `lg`, where the drawer covers most of the viewport and displacing the canvas would leave nothing readable.
+
+**Known limitation:** with the drawer *and* the coworker panel open, the canvas becomes narrow enough that the outcome heading wraps to roughly seven lines. Strictly better than occlusion, not yet good. Worth a follow-up that considers mutual exclusion or a narrower drawer at that breakpoint.
+
+## Verification
+
+- `tsc --noEmit` clean; **235 test files / 2,523 tests pass**; new `outcome-statement.test.ts` (11 tests) asserts no `##`, `**`, `>` or backtick can reach the operator.
+- Policy guards: source 52/52, pull-request 7/7.
+- **Live**, on the contributor preview against `FB-755EFA29`: both surfaces read the clean single line; opening the drawer reflows the canvas rather than clipping it; drawer sections are Canonical doc / Progress / Outcome and brief / Review with no BS Queue; the fleet header announces "Open build progress details".
+- Surface ratchet: `components/build` non-test LOC **16,370 → 16,317** — third consecutive shrink since the ratchet landed.
+
+## Not in scope
+
+- The drawer's **Feature Brief DESCRIPTION** field still renders the raw body unformatted. Behind progressive disclosure, and the adjacent Canonical doc section already renders the same string as markdown — lower severity than the canvas, and its own item.
+- `lib/portal-context/work-resolver.ts` carries a third private copy of the stall logic (noted during Phase 2).
+- Dissolving the four-layer status projection stack.

--- a/scripts/build-studio-surface-baseline.json
+++ b/scripts/build-studio-surface-baseline.json
@@ -4,5 +4,5 @@
   "expiry": "2026-11-21",
   "note": "Build Studio surface ratchet baseline (BI-101C107C). Shrink-only: the Build Studio UI surface leaves this budget by DELETING or CONVERGING components, never by expanding the baseline. A 'simplification' that adds net lines is not a simplification. Regenerate with: node scripts/check-build-studio-surface-budget.mjs --update",
   "componentCount": 70,
-  "nonTestLoc": 16370
+  "nonTestLoc": 16313
 }

--- a/scripts/build-studio-surface-baseline.json
+++ b/scripts/build-studio-surface-baseline.json
@@ -4,5 +4,5 @@
   "expiry": "2026-11-21",
   "note": "Build Studio surface ratchet baseline (BI-101C107C). Shrink-only: the Build Studio UI surface leaves this budget by DELETING or CONVERGING components, never by expanding the baseline. A 'simplification' that adds net lines is not a simplification. Regenerate with: node scripts/check-build-studio-surface-budget.mjs --update",
   "componentCount": 70,
-  "nonTestLoc": 16313
+  "nonTestLoc": 16317
 }


### PR DESCRIPTION
## What this fixes

Four defects in the operator's first viewport, all reported from a real screenshot of `/build`. **Every one is a removal.** Verified on the running portal against the exact build from the report (`FB-755EFA29`).

### 1. The wall of text

`owner-change-view`'s outcome fallback chain lands on `build.description`, which for any build promoted from the backlog is the **whole markdown BI body** — `## Problem … ## Scope … ## Acceptance criteria`. `BuildOperatorOverview` rendered that into a single plain `<p>`, so the first viewport showed literal `##`, `> **` and backticks, unclamped, and then occluded by the drawer. The same string already renders as **proper formatted markdown** in the drawer's Canonical doc section — the canvas was showing a worse copy of something one panel away.

`toOutcomeStatement()` reduces it to one readable sentence: drops fenced code, skips headings/bullets/tables, takes the first prose paragraph, strips inline emphasis, reduces links to their label, then clamps at a sentence boundary inside 240 chars. Deliberately lossy — the Outcome slot answers *"what did I ask for?"* in one line. A short, well-formed `businessOutcome` passes through untouched.

**Before:** nine lines of raw markdown.
**After:** `On the owner cockpit (/workspace), the attention card headline for a business-journey item reads:`

### 2. The same wall, one card lower — found by looking, not by a test

With #1 fixed I opened the running portal, and **"What we're building" was still rendering the raw body**. `BuildSolutionSummaryBand.compactCopy()` collapsed whitespace and clamped length but never stripped markdown — its own private idea of "tidy this up", different from the Outcome slot's. Same duplicate-derivation shape as the attention defect, applied to copy.

The reducer is now split — `toProseStatement()` strips, `clampStatement()` clamps — so both surfaces share one stripper and a third can't reintroduce the wall by writing its own normalizer.

**This is the case for verifying in a browser.** Tests were green and the fix was half-done.

### 3. The drawer occluded the canvas

`getDetailsDrawerClassName` is `absolute right-0 z-20`, so the drawer **overlaid**: the canvas kept full width and its text was cut mid-sentence with no reflow. The centre pane now reserves the drawer's width while open. Kept the `translate-x` slide (a flex sibling would animate width, which is janky); dropped below `lg` where displacing the canvas would leave nothing readable.

Verified live: opening the drawer reflows the canvas into a narrower column. **Caveat:** with the coworker panel also open the canvas gets quite narrow and the heading wraps to seven lines. Better than occlusion, not yet good — worth revisiting.

### 4. The duplicate queue panel

`BsQueueSection` re-listed the **same builds** the fleet rail already shows, in a different vocabulary, and its counters tallied only running/blocked/queued while its list rendered every entry — so it could display `Working: 1  Blocked: 0  Waiting: 0` above a list of four rows. Its own copy told the operator it was read-only and to act elsewhere: a panel that cost attention and returned no action.

Deleted. The fleet header now opens real progress detail and announces *"Open build progress details"*. Its `bs-queue` test-id special case and constant go too, rather than lingering as residue for a section that no longer exists.

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit` | clean |
| Vitest (`components/build` + `lib/build`) | **235 files / 2,523 tests pass** |
| New `outcome-statement.test.ts` | 11 tests |
| Policy Guards (source) | 52/52 |
| Policy Guards (pull-request) | 7/7 |
| local-CI pregate | **PASS** — evidence `cmt3pxogr0wgx01mrduiyust4` |
| Surface ratchet | 16,370 → **16,317**, baseline retightened |

**Third consecutive shrink** under the BI-101C107C ratchet.

**Live verification** (contributor preview, `FB-755EFA29`): both the Outcome slot and "What we're building" read the clean single line with no markdown markers; drawer opened and the canvas reflowed rather than clipped; drawer sections are Canonical doc / Progress / Outcome and brief / Review with no BS Queue.

Tests assert no `##`, `**`, `>` or backtick can reach the operator.

## Known remaining instance — deliberately not fixed here

The drawer's **Feature Brief DESCRIPTION** field still renders the raw body unformatted. It is behind progressive disclosure and the adjacent Canonical doc section already renders that same string as proper markdown, so it is lower severity than the canvas and belongs in its own item rather than a third expansion of this PR.

Phase 3 of `DI-BCC92F9AFC08`, following #4423 (ratchet) and #4424 (one attention truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)