### PR TITLE
chore(skills): make the invocation classification carry information (BI-8AD9D018)

### DIFF
--- a/apps/web/lib/skills/skill-relevance.test.ts
+++ b/apps/web/lib/skills/skill-relevance.test.ts
@@ -1,3 +1,5 @@
+import { globSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it, expect } from "vitest";
 import {
   rankSkillsByRelevance,
@@ -74,5 +76,48 @@ describe("rankSkillsByRelevance", () => {
     const skills = Array.from({ length: 20 }, (_, i) => skill(`p${i}`));
     const out = rankSkillsByRelevance(skills, "zzz no matches here", 3);
     expect(out.map((s) => s.skillId)).toEqual(["p0", "p1", "p2"]);
+  });
+});
+
+describe("no coworker's agent-invocable set exceeds the cap (BI-8AD9D018)", () => {
+  // rankSkillsByRelevance silently drops past DEFAULT_SKILL_SUMMARY_CAP. That
+  // is correct behaviour for a runaway set, but a coworker that sits over the
+  // cap in the SEEDED corpus is shedding skills on every turn with nothing
+  // saying so — portfolio-advisor was eligible for 17 before this guard.
+  //
+  // Reads the shipped .skill.md corpus rather than the database so the check
+  // runs in CI without a seeded install: the files are what the seed loads.
+  const skillsDir = join(__dirname, "..", "..", "..", "..", "skills");
+
+  function eligibleByCoworker() {
+    const files = globSync("**/*.skill.md", { cwd: skillsDir }).map((rel) => join(skillsDir, rel));
+    expect(files.length).toBeGreaterThan(0);
+
+    const parsed = files.map((filePath) => {
+      const frontmatter = readFileSync(filePath, "utf8").split("---")[1] ?? "";
+      const assignTo = /^assignTo: \[(.*)\]/m.exec(frontmatter)?.[1] ?? "";
+      return {
+        file: filePath,
+        roles: assignTo.replace(/"/g, "").split(",").map((role) => role.trim()).filter(Boolean),
+        // Absent means true: the loader's default is agent-invocable.
+        agentInvocable: !/^agentInvocable: false$/m.test(frontmatter),
+      };
+    });
+
+    const wildcard = parsed.filter((s) => s.roles.includes("*") && s.agentInvocable).length;
+    const roles = new Set(parsed.flatMap((s) => s.roles).filter((role) => role !== "*"));
+
+    return [...roles].map((role) => ({
+      role,
+      eligible: parsed.filter((s) => s.roles.includes(role) && s.agentInvocable).length + wildcard,
+    }));
+  }
+
+  it("keeps every coworker at or under DEFAULT_SKILL_SUMMARY_CAP", () => {
+    const over = eligibleByCoworker()
+      .filter((entry) => entry.eligible > DEFAULT_SKILL_SUMMARY_CAP)
+      .map((entry) => `${entry.role}: ${entry.eligible}`);
+
+    expect(over).toEqual([]);
   });
 });

--- a/apps/web/lib/skills/skill-relevance.test.ts
+++ b/apps/web/lib/skills/skill-relevance.test.ts
@@ -99,8 +99,12 @@ describe("no coworker's agent-invocable set exceeds the cap (BI-8AD9D018)", () =
       return {
         file: filePath,
         roles: assignTo.replace(/"/g, "").split(",").map((role) => role.trim()).filter(Boolean),
-        // Absent means true: the loader's default is agent-invocable.
-        agentInvocable: !/^agentInvocable: false$/m.test(frontmatter),
+        // Mirrors normalizeSkillFrontmatterForSeed: an explicit agentInvocable
+        // wins; absent, the loader derives it from disable-model-invocation, so
+        // a file carrying only the Surface A field still resolves correctly.
+        agentInvocable: /^agentInvocable:\s*(true|false)$/m.test(frontmatter)
+          ? /^agentInvocable:\s*true$/m.test(frontmatter)
+          : !/^disable-model-invocation:\s*true$/m.test(frontmatter),
       };
     });
 

--- a/packages/db/src/seed-skills.test.ts
+++ b/packages/db/src/seed-skills.test.ts
@@ -7,6 +7,7 @@ import {
   LEGACY_SKILL_SOURCE_TYPE,
   SKILL_WILDCARD_AGENT_IDS,
   discoverDpfPlatformSkillFiles,
+  discoverLegacySkillFiles,
   normalizeSkillFrontmatterForSeed,
   parseAllowedTools,
   parseFrontmatter,
@@ -403,5 +404,63 @@ describe("SKILL_WILDCARD_AGENT_IDS uniqueness", () => {
     await expect(
       reconcileSkillAssignments(prisma, "some-skill", ["agent-a", "agent-a"]),
     ).rejects.toThrow(/Unique constraint failed/);
+  });
+});
+
+describe("invocation classification is populated, not uniform (BI-8AD9D018)", () => {
+  // The frontmatter has always carried userInvocable / agentInvocable /
+  // disable-model-invocation, and for a long time every skill on both planes
+  // declared the identical triple. A field the whole corpus agrees on cannot
+  // steer anything: apps/web/lib/skills/skill-relevance.ts ranks the eligible
+  // set against a per-turn cap, and with nothing marked user-invocable-only a
+  // heavyweight setup flow competed for the same slot as the lookup the turn
+  // actually needed. Presence was seeded; population never was.
+  //
+  // These guards fail when a plane goes uniform again — the shape the original
+  // regression took — rather than pinning any particular skill's value.
+  const repoRoot = join(__dirname, "..", "..", "..");
+
+  function frontmattersIn(sources: { filePath: string }[]) {
+    return sources.map((source) => parseFrontmatter(readFileSync(source.filePath, "utf8")).frontmatter);
+  }
+
+  it("the coworker plane marks some skills user-invocable-only", () => {
+    const frontmatters = frontmattersIn(discoverLegacySkillFiles(join(repoRoot, "skills")));
+    expect(frontmatters.length).toBeGreaterThan(0);
+
+    const agentInvocable = frontmatters.filter((fm) => fm.agentInvocable === true);
+    const userOnly = frontmatters.filter((fm) => fm.agentInvocable === false);
+
+    // Both populations non-empty: an all-true corpus is the dead-field
+    // regression, an all-false one would leave coworkers unable to reach
+    // anything on their own.
+    expect(agentInvocable.length).toBeGreaterThan(0);
+    expect(userOnly.length).toBeGreaterThan(0);
+  });
+
+  it("the dpf-platform pack marks some skills user-invocable-only", () => {
+    const frontmatters = frontmattersIn(
+      discoverDpfPlatformSkillFiles(join(repoRoot, "packages", "dpf-skill-pack", "skills")),
+    );
+    expect(frontmatters.length).toBeGreaterThan(0);
+
+    expect(frontmatters.filter((fm) => fm.agentInvocable === true).length).toBeGreaterThan(0);
+    expect(frontmatters.filter((fm) => fm.agentInvocable === false).length).toBeGreaterThan(0);
+  });
+
+  it("keeps the pack's two invocation surfaces in agreement", () => {
+    // Surface A (disable-model-invocation, read by Claude Code / Codex / Grok)
+    // and Surface B (agentInvocable, read by the in-portal seed loader) express
+    // the same intent for the same skill. A skill the external clients may not
+    // auto-invoke but the portal may is a split brain across four clients.
+    const frontmatters = frontmattersIn(
+      discoverDpfPlatformSkillFiles(join(repoRoot, "packages", "dpf-skill-pack", "skills")),
+    );
+
+    const contradictions = frontmatters
+      .filter((fm) => fm["disable-model-invocation"] !== !fm.agentInvocable)
+      .map((fm) => fm.name);
+
+    expect(contradictions).toEqual([]);
   });
 });

--- a/packages/dpf-skill-pack/skills/dpf-add-archetype/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-add-archetype/SKILL.md
@@ -2,7 +2,7 @@
 name: dpf-add-archetype
 description: "Use when adding a NEW business archetype to the DPF platform — a new industry or vertical the storefront-templates taxonomy does not yet cover, or when an archetype idea is floated and needs the paved road. Covers all four provisioning dimensions (template substrate, WSID profession corpus, AI coworker decision, skills/tools) and the completeness gate that blocks a shallow archetype from shipping."
 # Agent Skills standard fields (Surface A — Claude Code)
-disable-model-invocation: false
+disable-model-invocation: true
 user-invocable: true
 allowed-tools: Read Grep Glob Edit Write Bash mcp__dpf__principle_decide mcp__dpf__query_backlog mcp__dpf__create_backlog_item mcp__dpf__establish_coworker
 
@@ -13,7 +13,7 @@ capability: manage_platform
 taskType: code_generation
 triggerPattern: "new archetype|add .* archetype|new industry|new vertical|add .* vertical|archetype for|cover .* industry"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: ["Read", "Grep", "Glob", "Edit", "Write", "Bash", "mcp__dpf__principle_decide", "mcp__dpf__query_backlog", "mcp__dpf__create_backlog_item", "mcp__dpf__establish_coworker"]
 composesFrom: ["dpf-verify-substrate-first", "dpf-decision-via-kernel", "dpf-file-backlog-item", "dpf-writing-plans", "dpf-establish-coworker", "dpf-pr-with-dco"]
 contextRequirements: []

--- a/packages/dpf-skill-pack/skills/dpf-clear-dependabot-alerts/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-clear-dependabot-alerts/SKILL.md
@@ -2,7 +2,7 @@
 name: dpf-clear-dependabot-alerts
 description: "Use when clearing Dependabot or security-advisory alerts on the DPF repo — a batch of npm vulnerability alerts, a 'bump the vulnerable dependency' ask, or a security-tab sweep. Covers the DPF pattern for transitive vulnerabilities, lockfile regeneration, verification, and shipping a DCO PR."
 # Agent Skills standard fields (Surface A — Claude Code)
-disable-model-invocation: false
+disable-model-invocation: true
 user-invocable: true
 allowed-tools: Bash Read Edit Grep
 
@@ -13,7 +13,7 @@ capability: null
 taskType: workflow
 triggerPattern: "dependabot|security alert|vulnerability alert|clear .* (alert|CVE|advisory)|bump .* (vulnerable|CVE)|dependency (vuln|CVE|advisory)|security tab"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: ["Bash", "Read", "Edit", "Grep"]
 composesFrom: ["dpf-verify-substrate-first"]
 contextRequirements: ["gh CLI authenticated", "pnpm available", "registry reachable"]

--- a/packages/dpf-skill-pack/skills/dpf-drive-portal-and-observe-build/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-drive-portal-and-observe-build/SKILL.md
@@ -2,7 +2,7 @@
 name: dpf-drive-portal-and-observe-build
 description: "Use when driving the live DPF portal through the browser (Claude-in-Chrome) — messaging a coworker, clicking through a build's gates, filling an admin form — OR observing what the build/inference engine is doing: which model ran a phase, why a tool call failed, where a build is stuck. Covers the DOM mechanics that fail by default on live pages, and where build truth actually lives across the database, activity events, container logs and runtime-health surfaces."
 # Agent Skills standard fields (Surface A — Claude Code)
-disable-model-invocation: false
+disable-model-invocation: true
 user-invocable: true
 allowed-tools: Bash(docker logs *) Bash(docker exec *) Bash(curl *) Bash(nvidia-smi *) mcp__claude-in-chrome__navigate mcp__claude-in-chrome__read_page mcp__claude-in-chrome__find mcp__claude-in-chrome__get_page_text mcp__claude-in-chrome__computer mcp__claude-in-chrome__form_input mcp__dpf__resolve_model_selection mcp__dpf__get_build_sandbox_state mcp__dpf__list_build_activity_since
 
@@ -13,7 +13,7 @@ capability: null
 taskType: verification
 triggerPattern: "drive the portal|drive the (live|running) (portal|install)|via the browser|claude-in-chrome|chrome mcp|send (a |the )?coworker( a)? message|click through|fill (in |out )?(the )?form|why is .* (stuck|stalled|hung)|which model (ran|is running)|why did .* tool call fail|observe the build|build (phase|engine|dispatch)|inference (truth|logs)|portal logs|runtime health|model selection"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: ["Bash", "mcp__claude-in-chrome__navigate", "mcp__claude-in-chrome__read_page", "mcp__claude-in-chrome__find", "mcp__claude-in-chrome__get_page_text", "mcp__claude-in-chrome__computer", "mcp__claude-in-chrome__form_input", "mcp__dpf__resolve_model_selection", "mcp__dpf__get_build_sandbox_state", "mcp__dpf__list_build_activity_since"]
 composesFrom: ["dpf-evidence-before-diagnosis", "dpf-verify-on-live-install"]
 contextRequirements: []

--- a/packages/dpf-skill-pack/skills/dpf-establish-coworker/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-establish-coworker/SKILL.md
@@ -3,7 +3,7 @@ name: dpf-establish-coworker
 description: "Use when creating a NEW AI coworker on the DPF platform, from any dev surface (Claude/Codex session, Build Studio, MCP client) — or when a coworker idea is floated and needs the paved road. Walks the enforced lifecycle: establish a draft through the establish_coworker factory door, complete the code-side definition checklist the CI conformance gate enforces, earn a behavioral certification from the nightly golden-journey sweep, then promote to production. A coworker created any other way ships incomplete and unsummonable; this skill is the single paved road that makes it robust by construction."
 
 # Agent Skills standard fields (Surface A — Claude Code)
-disable-model-invocation: false
+disable-model-invocation: true
 user-invocable: true
 allowed-tools: Read Grep Glob Edit Write Bash mcp__dpf__establish_coworker mcp__dpf__manage_coworker_tool_grant mcp__dpf__query_backlog mcp__dpf__create_backlog_item
 
@@ -14,7 +14,7 @@ capability: manage_platform
 taskType: code_generation
 triggerPattern: "new coworker|create .* coworker|add .* coworker|establish .* coworker|new agent role|hire .* (ai|digital) (coworker|worker)"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: ["Read", "Grep", "Glob", "Edit", "Write", "Bash", "mcp__dpf__establish_coworker", "mcp__dpf__manage_coworker_tool_grant", "mcp__dpf__query_backlog", "mcp__dpf__create_backlog_item"]
 composesFrom: ["dpf-verify-substrate-first", "dpf-file-backlog-item", "dpf-pr-with-dco"]
 contextRequirements: []

--- a/packages/dpf-skill-pack/skills/dpf-farm-ranch-seasonal-planning/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-farm-ranch-seasonal-planning/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dpf-farm-ranch-seasonal-planning
 description: "Use for agriculture-ranching operating plans and decision briefs spanning fields, pasture, crops, hay, livestock, working animals, equipment, inputs, vendors, weather, markets, and obligations. Keeps location, evidence date, authority, and human approval explicit."
-disable-model-invocation: false
+disable-model-invocation: true
 user-invocable: true
 allowed-tools: mcp__dpf__wiki_query mcp__dpf__search_knowledge mcp__dpf__search_knowledge_base mcp__dpf__query_backlog mcp__dpf__create_backlog_item
 
@@ -11,7 +11,7 @@ capability: null
 taskType: analysis
 triggerPattern: "farm plan|ranch plan|seasonal plan|fertiliz|hay cut|baling|grazing|pasture|calving|breeding|herd health|vaccination|farrier|tractor maintenance|implement|feed inventory|seed inventory|pesticide|applicator|market cattle|sell cattle|weather window"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: ["mcp__dpf__wiki_query", "mcp__dpf__search_knowledge", "mcp__dpf__search_knowledge_base", "mcp__dpf__query_backlog", "mcp__dpf__create_backlog_item"]
 composesFrom: ["dpf-retrieve-decision-context", "dpf-decision-via-kernel"]
 contextRequirements: ["storefront archetype", "operating location", "dated farm or ranch records", "applicable profession corpus"]

--- a/packages/dpf-skill-pack/skills/dpf-my-surface-backlog/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-my-surface-backlog/SKILL.md
@@ -3,7 +3,7 @@ name: dpf-my-surface-backlog
 description: "See, open, and file backlog items for your OWN area — the BIs against your surface (portfolio) and occupation — and track their status. Scope is resolved from your identity and cannot be widened, so it stays safe on a small local model and for sensitive portfolios."
 
 # Agent Skills standard fields (Surface A — Claude Code)
-disable-model-invocation: false
+disable-model-invocation: true
 user-invocable: true
 allowed-tools: mcp__dpf__list_my_backlog mcp__dpf__get_backlog_item mcp__dpf__create_backlog_item mcp__dpf__get_my_coworker_profile
 
@@ -14,7 +14,7 @@ capability: null
 taskType: workflow
 triggerPattern: "my backlog|(BIs?|backlog|items?|work) for my (surface|area|portfolio|occupation)|what('?s| is) (in|on) my (backlog|queue|plate)|file (a )?BI for my (area|surface)|my capability (gaps?|needs?) as backlog"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: ["mcp__dpf__list_my_backlog", "mcp__dpf__get_backlog_item", "mcp__dpf__create_backlog_item", "mcp__dpf__get_my_coworker_profile"]
 composesFrom: ["dpf-file-backlog-item"]
 contextRequirements: ["dpf MCP server reachable"]

--- a/packages/dpf-skill-pack/skills/dpf-worktree-per-session/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-worktree-per-session/SKILL.md
@@ -3,7 +3,7 @@ name: dpf-worktree-per-session
 description: "Use when starting, entering, auditing, or managing a concurrent DPF coding session that touches the working tree. Each thread gets its own git worktree (not a shared clone), seeded MCP config, isolated COMPOSE_PROJECT_NAME, and an explicit compile-ready vs source-only verification-readiness classification so agents do not claim unrun local gates. Composes with dpf-finishing-a-development-branch as the predecessor isolation step."
 
 # Agent Skills standard fields (Surface A — Claude Code)
-disable-model-invocation: false
+disable-model-invocation: true
 user-invocable: true
 allowed-tools: Bash(git fetch *) Bash(git worktree *) Bash(git branch *) Bash(git checkout *) Bash(git status *) Bash(git rev-parse *) Bash(git log *) Bash(grep *) Bash(test *) Bash(command -v *) Bash(pnpm *) Bash(corepack *) Bash(scripts/seed-worktree-mcp*) Bash(scripts/sync-mcp-worktrees*)
 
@@ -14,7 +14,7 @@ capability: null
 taskType: workflow
 triggerPattern: "new worktree|create worktree|spawn session|concurrent session|parallel work|isolated branch|worktree readiness|source-only worktree|compile-ready worktree"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: ["Bash"]
 composesFrom: []
 contextRequirements: ["git available; scripts/seed-worktree-mcp.{ps1,sh} present; .mcp.json populated in root clone; worktree verification readiness must be classified"]

--- a/skills/admin/manage-users.skill.md
+++ b/skills/admin/manage-users.skill.md
@@ -7,7 +7,7 @@ capability: "manage_users"
 taskType: "conversation"
 triggerPattern: "user|account|role management"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: []
 composesFrom: []
 contextRequirements: []

--- a/skills/admin/setup-branding.skill.md
+++ b/skills/admin/setup-branding.skill.md
@@ -7,7 +7,7 @@ capability: "manage_branding"
 taskType: "conversation"
 triggerPattern: "brand|theme|logo|color"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [analyze_brand_document, analyze_public_website_branding]
 composesFrom: []
 contextRequirements: []

--- a/skills/admin/setup-platform-development.skill.md
+++ b/skills/admin/setup-platform-development.skill.md
@@ -7,7 +7,7 @@ capability: "manage_platform_config"
 taskType: "conversation"
 triggerPattern: "platform development|contribution|governance|sharing|fork|contribute"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: []
 composesFrom: []
 contextRequirements: []

--- a/skills/build/build-page.skill.md
+++ b/skills/build/build-page.skill.md
@@ -7,7 +7,7 @@ capability: "view_platform"
 taskType: "code_generation"
 triggerPattern: "build page|scaffold page|new page|add route|create screen|page implementation"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [read_project_file, search_project_files, propose_file_change]
 composesFrom: []
 contextRequirements: []

--- a/skills/build/design-component.skill.md
+++ b/skills/build/design-component.skill.md
@@ -7,7 +7,7 @@ capability: "view_platform"
 taskType: "code_generation"
 triggerPattern: "design component|ui component|component states|refactor component|new control|interface element"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [read_project_file, search_project_files, propose_file_change]
 composesFrom: []
 contextRequirements: []

--- a/skills/build/manage-sandbox.skill.md
+++ b/skills/build/manage-sandbox.skill.md
@@ -7,7 +7,7 @@ capability: "view_platform"
 taskType: "action"
 triggerPattern: "sandbox|container|not running|start sandbox|sandbox down|sandbox status"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [check_sandbox, start_sandbox]
 composesFrom: []
 contextRequirements: []

--- a/skills/build/ship-feature.skill.md
+++ b/skills/build/ship-feature.skill.md
@@ -7,7 +7,7 @@ capability: "view_platform"
 taskType: "action"
 triggerPattern: "ship feature|deploy|release|launch|ready to ship|create release"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [deploy_feature, create_release_bundle]
 composesFrom: []
 contextRequirements: []

--- a/skills/compliance/add-regulation.skill.md
+++ b/skills/compliance/add-regulation.skill.md
@@ -7,7 +7,7 @@ capability: "manage_compliance"
 taskType: "conversation"
 triggerPattern: "add regulation|new regulation|register regulation"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [create_backlog_item]
 composesFrom: []
 contextRequirements: []

--- a/skills/compliance/onboard-regulation.skill.md
+++ b/skills/compliance/onboard-regulation.skill.md
@@ -7,7 +7,7 @@ capability: "manage_compliance"
 taskType: "analysis"
 triggerPattern: "onboard|import|framework|standard"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [prefill_onboarding_wizard, search_public_web]
 composesFrom: []
 contextRequirements: []

--- a/skills/customer/add-customer.skill.md
+++ b/skills/customer/add-customer.skill.md
@@ -7,7 +7,7 @@ capability: "view_customer"
 taskType: "conversation"
 triggerPattern: "add|register|new customer"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [create_customer_account]
 composesFrom: []
 contextRequirements: []

--- a/skills/design/ui-ux-design-intelligence.skill.md
+++ b/skills/design/ui-ux-design-intelligence.skill.md
@@ -7,7 +7,7 @@ capability: "view_platform"
 taskType: "code_generation"
 triggerPattern: "design|ui|ux|style|color palette|typography|font|layout|accessibility|landing page|dashboard|component"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [read_project_file, search_project_files, propose_file_change, check_sandbox]
 composesFrom: []
 contextRequirements: []

--- a/skills/docs/generate-diagram.skill.md
+++ b/skills/docs/generate-diagram.skill.md
@@ -7,7 +7,7 @@ capability: null
 taskType: "code_generation"
 triggerPattern: "diagram|mermaid|flowchart|sequence"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: []
 composesFrom: []
 contextRequirements: []

--- a/skills/ea/create-view.skill.md
+++ b/skills/ea/create-view.skill.md
@@ -7,7 +7,7 @@ capability: "manage_ea_model"
 taskType: "conversation"
 triggerPattern: "create view|new view|ea view"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: []
 composesFrom: []
 contextRequirements: []

--- a/skills/employee/assign-role.skill.md
+++ b/skills/employee/assign-role.skill.md
@@ -7,7 +7,7 @@ capability: "view_employee"
 taskType: "conversation"
 triggerPattern: "assign|role|update role"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [query_employees]
 composesFrom: []
 contextRequirements: []

--- a/skills/ops/create-item.skill.md
+++ b/skills/ops/create-item.skill.md
@@ -7,7 +7,7 @@ capability: "manage_backlog"
 taskType: "conversation"
 triggerPattern: "create|new|add item|task"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [create_backlog_item]
 composesFrom: []
 contextRequirements: []

--- a/skills/platform/add-provider.skill.md
+++ b/skills/platform/add-provider.skill.md
@@ -7,7 +7,7 @@ capability: "manage_provider_connections"
 taskType: "conversation"
 triggerPattern: "add provider|new provider|register"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [add_provider]
 composesFrom: []
 contextRequirements: []

--- a/skills/platform/draft-kernel-edit-pr.skill.md
+++ b/skills/platform/draft-kernel-edit-pr.skill.md
@@ -7,7 +7,7 @@ capability: null
 taskType: "conversation"
 triggerPattern: "edit kernel|update principle|edit principle|change kernel|kernel edit|propose kernel"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: []
 composesFrom: []
 contextRequirements: []

--- a/skills/platform/ingest-article-from-url.skill.md
+++ b/skills/platform/ingest-article-from-url.skill.md
@@ -7,7 +7,7 @@ capability: null
 taskType: "conversation"
 triggerPattern: "ingest.*article|ingest.*url|add.*article.*wiki|wiki.*from.*url|ingest.*linkedin|pull.*into.*wiki"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: ["fetch_public_website", "wiki_ingest"]
 composesFrom: []
 contextRequirements: []

--- a/skills/portfolio/register-product.skill.md
+++ b/skills/portfolio/register-product.skill.md
@@ -7,7 +7,7 @@ capability: "view_portfolio"
 taskType: "conversation"
 triggerPattern: "register|create|new product"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [create_digital_product]
 composesFrom: []
 contextRequirements: []

--- a/skills/product-management/commercial-opportunity-review.skill.md
+++ b/skills/product-management/commercial-opportunity-review.skill.md
@@ -7,7 +7,7 @@ capability: "view_portfolio"
 taskType: "analysis"
 triggerPattern: "commercial opportunity|what customers buy|offer review"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [search_portfolio_context, list_opportunities, list_quotes, evaluate_org_business_decision]
 composesFrom: []
 contextRequirements: []

--- a/skills/product-management/investment-preparation.skill.md
+++ b/skills/product-management/investment-preparation.skill.md
@@ -7,7 +7,7 @@ capability: "view_portfolio"
 taskType: "analysis"
 triggerPattern: "investment preparation|funding decision|compare bets"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [query_backlog, score_demand_item, approve_demand_for_funding, evaluate_org_business_decision]
 composesFrom: []
 contextRequirements: []

--- a/skills/product-management/product-line-performance-review.skill.md
+++ b/skills/product-management/product-line-performance-review.skill.md
@@ -7,7 +7,7 @@ capability: "view_portfolio"
 taskType: "analysis"
 triggerPattern: "product line performance|portfolio mix|line review"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [search_portfolio_context, query_backlog, evaluate_org_business_decision]
 composesFrom: []
 contextRequirements: []

--- a/skills/storefront/email-campaign-builder.skill.md
+++ b/skills/storefront/email-campaign-builder.skill.md
@@ -7,7 +7,7 @@ capability: "view_marketing"
 taskType: "conversation"
 triggerPattern: "email|newsletter|send|subject line|campaign email"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [get_marketing_summary]
 composesFrom: []
 contextRequirements: []

--- a/skills/storefront/extract-brand-design-system.skill.md
+++ b/skills/storefront/extract-brand-design-system.skill.md
@@ -7,7 +7,7 @@ capability: "manage_branding"
 taskType: "conversation"
 triggerPattern: "brand|design system|extract brand|theme|refresh brand|analyze site"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools:
   - extract_brand_design_system
   - analyze_public_website_branding

--- a/skills/universal/add-skill.skill.md
+++ b/skills/universal/add-skill.skill.md
@@ -7,7 +7,7 @@ capability: null
 taskType: code_generation
 triggerPattern: "add skill|new skill|create skill|custom action|add button|quick action"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: []
 composesFrom: []
 contextRequirements: []

--- a/skills/universal/evaluate-page.skill.md
+++ b/skills/universal/evaluate-page.skill.md
@@ -7,7 +7,7 @@ capability: null
 taskType: analysis
 triggerPattern: "evaluate page|audit page|accessibility audit|ux review|usability review|contrast|a11y"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: []
 composesFrom: []
 contextRequirements: []

--- a/skills/workspace/create-task.skill.md
+++ b/skills/workspace/create-task.skill.md
@@ -7,7 +7,7 @@ capability: "manage_backlog"
 taskType: "conversation"
 triggerPattern: "create|new task|add item"
 userInvocable: true
-agentInvocable: true
+agentInvocable: false
 allowedTools: [create_backlog_item]
 composesFrom: []
 contextRequirements: []


### PR DESCRIPTION
## What

Every skill on both instruction planes declared the same invocation triple — `disable-model-invocation: false`, `userInvocable: true`, `agentInvocable: true` — across 34 of 34 pack skills and 67 of 68 coworker skills. `packages/db/src/seed-skills.ts` parses the fields and `apps/web/lib/skills/runtime.ts` surfaces them, but a value the whole corpus agrees on cannot steer anything. Presence was seeded; population never was.

The cost is measurable. `apps/web/lib/skills/skill-relevance.ts` sets `DEFAULT_SKILL_SUMMARY_CAP = 12`: every eligible skill injects its summary into the coworker system prompt each turn, and past 12 the ranker drops the rest. `portfolio-advisor` was eligible for 17 and shedding silently.

## Two planes, two criteria

On the **coworker plane** a skill is user-invocable-only when invoking it is a deliberate act: it creates a record, generates code, runs a setup flow, or is a review asked for by name.

On the **pack**, size is irrelevant. The guardrails — `dpf-verify-substrate-first`, `dpf-evidence-before-diagnosis`, `dpf-systematic-debugging` — are worthless if they only fire when asked, so only the seven flows that take over a session are demoted. Both invocation surfaces move together, so the four external clients and the portal cannot disagree about the same skill.

Eligible sets against the cap of 12:

| coworker | before | after |
|---|---|---|
| portfolio-advisor | 17 | 10 |
| build-specialist | 12 | 4 |
| inventory-specialist | 12 | 9 |
| marketing-specialist | 12 | 8 |
| platform-engineer | 11 | 5 |

Nothing leaves any dropdown — the 34 demoted skills all keep `userInvocable: true`.

## Guards

`seed-skills.test.ts` asserts each plane holds both classifications, and that the pack's two surfaces never contradict. `skill-relevance.test.ts` asserts no coworker's agent-invocable set exceeds the cap, reading the shipped `.skill.md` corpus so it runs in CI without a seeded install.

The cap guard was negative-tested rather than trusted green: reverting the four `portfolio-advisor` demotions fails it with `expected [ 'portfolio-advisor: 14' ] to deeply equal []`.

## Evidence

- pregate `local-CI gate: PASS`, gated sha `d19ceb4b59a2` = HEAD, evidence `cmt3qjtif0y5y01mrpo3g1x4n`, slot-0
- `packages/db src/seed-skills.test.ts` 21 passed · `apps/web lib/skills` 88 passed across 11 files · process-spine health 7 passed
- `tsc --noEmit` clean for `@dpf/db` and `web`
- `check-instruction-plane-size.mjs` OK, skill-description bytes unchanged at 14157 — the ratchet counts `name` + `description`, and this touches neither

Semantic review receipt is fresh for this exact tree (`WC-6D847DA6`, digest `aee47458…`), but read it honestly: it returned `auto-pass` with the rationale *"code-change at risk=medium below activation threshold high → no independent review"*, in `mode: shadow`. **No reviewer looked at this diff.** Worth a human eye on the judgment calls below rather than treating the receipt as review.

## Worth pressing on

1. Three coworkers land at 2 eligible skills (`admin-assistant`, `onboarding-coo`, `external-coding-agent`) because every one of their role skills is a deliberate act, leaving only the two ambient universal ones. Defensible, but it is the call most worth disagreeing with — one line per file to revert.
2. `ship-feature` and `manage-sandbox` are demoted. If any autonomous flow depends on the *model* pulling those skill bodies in, rather than calling the underlying tools, that path changes. I found no such caller but did not exhaustively trace autonomous run paths.
3. The cap guard reimplements `assignTo` / `agentInvocable` parsing with regexes to avoid a cross-package import from `apps/web` into `packages/db`. Duplicated parsing that could drift from the loader.
4. No seed re-run is included. Existing installs keep the old flags in `SkillDefinition` rows until the skills seed runs again — whether that needs an explicit step is an open question I did not resolve.

## Not run

Full repo suite, portal build, runtime/UX verification. This is frontmatter plus two test files and touches no runtime code path, so no runtime-bound gate was exercised. Those are unrun, not green.

Unrelated pre-existing failure, already being fixed separately: `packages/db/src/skill-quality-audit.test.ts` computes its repo root from `process.cwd()` and fails as ENOENT when vitest is invoked with `--root` from the repo root. Present on `main`.

Closes BI-8AD9D018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Seed-Fit-Decision: global-default
