### PR TITLE
fix(ci): make pull-request guard non-mutating (BI-ADBF220E)

### DIFF
--- a/scripts/check-golden-decisions.mjs
+++ b/scripts/check-golden-decisions.mjs
@@ -23,6 +23,7 @@
 // both engines (this scorer + the canonical vitest test) run in CI against the same
 // corpus, so any behavioral divergence surfaces as one going red.
 
+import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -123,14 +124,64 @@ function professionPrincipleFiles(dir) {
   return out;
 }
 
-export function loadCommandments(dir = PRINCIPLES_DIR, professionsDir = PROFESSIONS_DIR) {
-  return [...kernelPrincipleFiles(dir), ...professionPrincipleFiles(professionsDir)]
-    .map(({ path, slug }) => parsePrinciple(readFileSync(path, "utf8"), slug))
+function parseCommandmentFiles(files) {
+  return files
+    .map(({ raw, slug }) => parsePrinciple(raw, slug))
     .filter((p) => p.pageKind === "principle" && (!p.status || p.status === "published"))
     .filter((p) => p.tier === "commandment")
     .filter((p) => !p.appliesTo?.length || p.appliesTo.includes(POPULATION))
     .map((p) => ({ id: p.slug, weight: typeof p.weight === "number" ? p.weight : TIER_DEFAULT_WEIGHT.commandment, vec: p.vec ?? {} }))
     .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function loadCommandments(dir = PRINCIPLES_DIR, professionsDir = PROFESSIONS_DIR) {
+  return parseCommandmentFiles(
+    [...kernelPrincipleFiles(dir), ...professionPrincipleFiles(professionsDir)]
+      .map(({ path, slug }) => ({ raw: readFileSync(path, "utf8"), slug })),
+  );
+}
+
+function defaultGit(args) {
+  return execFileSync("git", args, {
+    cwd: join(HERE, ".."),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer: 32 * 1024 * 1024,
+  });
+}
+
+/**
+ * Build Git's synthetic merge tree for HEAD + ref. `git merge-tree --write-tree`
+ * writes only an unreachable tree object: it never checks out files, changes
+ * identity, updates refs, or creates a commit in the caller's worktree.
+ */
+export function resolveMergeTree(ref, { git = defaultGit } = {}) {
+  const tree = String(git(["merge-tree", "--write-tree", ref, "HEAD"]) ?? "").trim();
+  if (!/^[0-9a-f]{40,64}$/i.test(tree)) {
+    throw new Error(`git merge-tree did not return a tree object for ${ref}`);
+  }
+  return tree;
+}
+
+/** Read the decision corpus straight from a Git tree without materializing it. */
+export function loadCommandmentsFromGitTree(tree, { git = defaultGit } = {}) {
+  const prefix = "docs/";
+  const paths = String(git(["ls-tree", "-r", "--name-only", tree, "--", prefix]) ?? "")
+    .split(/\r?\n/)
+    .map((path) => path.trim())
+    .filter((path) =>
+      path.startsWith("docs/founder-kernel/wiki/principles/") && path.endsWith(".md")
+      || /^docs\/professions\/[^/]+\/wiki\/[^/]+\.md$/.test(path),
+    );
+
+  return parseCommandmentFiles(paths.map((path) => {
+    const kernelPrefix = "docs/founder-kernel/wiki/principles/";
+    const professionMatch = path.match(/^docs\/professions\/([^/]+)\/wiki\/(.+)\.md$/);
+    const slug = path.startsWith(kernelPrefix)
+      ? path.slice(kernelPrefix.length, -3)
+      : `professions/${professionMatch[1]}/${professionMatch[2]}`;
+    return { slug, raw: String(git(["show", `${tree}:${path}`]) ?? "") };
+  }));
 }
 
 // ─── Scoring (mirrors option-scoring.ts) ─────────────────────────────────────
@@ -145,24 +196,32 @@ function composite(features, commandments) {
   return commandments.reduce((s, p) => s + p.weight * alignment(features, p.vec), 0);
 }
 
-export function runCheck(dir = PRINCIPLES_DIR) {
-  const commandments = loadCommandments(dir);
+export function runCheck(dir = PRINCIPLES_DIR, { commandments } = {}) {
+  const resolvedCommandments = commandments ?? loadCommandments(dir);
   const results = SCENARIOS.map((s) => {
     const scored = Object.entries(s.options)
-      .map(([id, f]) => [id, composite(f, commandments)])
+      .map(([id, f]) => [id, composite(f, resolvedCommandments)])
       .sort((a, b) => b[1] - a[1]);
     const margin = scored[0][1] - scored[1][1];
     const winnerOk = scored[0][0] === s.expectedWinner;
     const marginOk = margin >= s.marginFloor;
     return { id: s.id, winner: scored[0][0], expectedWinner: s.expectedWinner, margin, marginFloor: s.marginFloor, winnerOk, marginOk, ok: winnerOk && marginOk };
   });
-  return { commandmentCount: commandments.length, results, ok: results.every((r) => r.ok) };
+  return { commandmentCount: resolvedCommandments.length, results, ok: results.every((r) => r.ok) };
 }
 
 // ─── CLI ─────────────────────────────────────────────────────────────────────
 const invokedDirectly = process.argv[1] && process.argv[1].replace(/\\/g, "/").endsWith("check-golden-decisions.mjs");
 if (invokedDirectly) {
-  const { commandmentCount, results, ok } = runCheck();
+  const mergeWithIndex = process.argv.indexOf("--merge-with");
+  const mergeWith = mergeWithIndex >= 0 ? process.argv[mergeWithIndex + 1] : null;
+  if (mergeWithIndex >= 0 && !mergeWith) {
+    throw new Error("--merge-with requires a Git ref");
+  }
+  const commandments = mergeWith
+    ? loadCommandmentsFromGitTree(resolveMergeTree(mergeWith))
+    : undefined;
+  const { commandmentCount, results, ok } = runCheck(PRINCIPLES_DIR, { commandments });
   console.log(`[golden-decisions] scored ${results.length} canonical decisions against ${commandmentCount} commandments`);
   for (const r of results) {
     const status = r.ok ? "OK" : "FAIL";

--- a/scripts/check-golden-decisions.test.mjs
+++ b/scripts/check-golden-decisions.test.mjs
@@ -13,7 +13,12 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { SCENARIOS, runCheck } from "./check-golden-decisions.mjs";
+import {
+  SCENARIOS,
+  loadCommandmentsFromGitTree,
+  resolveMergeTree,
+  runCheck,
+} from "./check-golden-decisions.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const CANON = readFileSync(
@@ -56,4 +61,36 @@ test("guard passes on the real principle corpus", () => {
     );
   }
   assert.ok(ok);
+});
+
+test("merge-state corpus uses a synthetic tree and never a checkout or merge commit", () => {
+  const calls = [];
+  const git = (args) => {
+    calls.push(args);
+    if (args[0] === "merge-tree") return "a".repeat(40) + "\n";
+    if (args[0] === "ls-tree") {
+      return [
+        "docs/founder-kernel/wiki/principles/example.md",
+        "docs/professions/software-engineer/wiki/example.md",
+        "apps/web/ignored.ts",
+      ].join("\n");
+    }
+    if (args[0] === "show") {
+      return [
+        "---",
+        "pageKind: principle",
+        "status: published",
+        "principleTier: commandment",
+        "principleDimensionVector: {\"governance_compliance\":1}",
+        "---",
+      ].join("\n");
+    }
+    throw new Error(`unexpected git ${args.join(" ")}`);
+  };
+
+  const tree = resolveMergeTree("origin/main", { git });
+  const commandments = loadCommandmentsFromGitTree(tree, { git });
+  assert.equal(commandments.length, 2);
+  assert.deepEqual(calls[0], ["merge-tree", "--write-tree", "origin/main", "HEAD"]);
+  assert.equal(calls.some((args) => ["checkout", "switch", "merge", "commit", "config"].includes(args[0])), false);
 });

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -125,6 +125,23 @@ describe("CI policy guard registry", () => {
     ]);
   });
 
+  it("evaluates the decision baseline without mutating the caller's Git state", () => {
+    const baseline = POLICY_GUARD_PROFILES["pull-request"].find(
+      (entry) => entry.id === "decision-baseline",
+    );
+    assert.ok(baseline);
+    assert.deepEqual(baseline.commands, [
+      ["git", ["fetch", "--no-tags", "--quiet", "origin", "main"]],
+      ["node", ["scripts/check-golden-decisions.mjs", "--merge-with", "origin/main"]],
+      ["node", ["--test", "scripts/check-golden-decisions.test.mjs"]],
+    ]);
+    assert.equal(
+      baseline.commands.some(([command, args]) =>
+        command === "git" && ["config", "merge", "commit", "checkout", "switch"].includes(args[0])),
+      false,
+    );
+  });
+
   it("runs every named guard and retains all failures", async () => {
     const calls = [];
     const result = await runPolicyProfile({

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -484,11 +484,8 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("scripts/check-design-grounding-decision.mjs"),
     ]),
     guard("decision-baseline", "Decision Baseline", [
-      git("config", "user.email", "dpf-ci@users.noreply.github.com"),
-      git("config", "user.name", "dpf-ci"),
       git("fetch", "--no-tags", "--quiet", "origin", "main"),
-      git("merge", "--no-edit", "origin/main"),
-      node("scripts/check-golden-decisions.mjs"),
+      node("scripts/check-golden-decisions.mjs", "--merge-with", "origin/main"),
       node("--test", "scripts/check-golden-decisions.test.mjs"),
     ]),
   ]),

--- a/scripts/lib/dco-signoff.mjs
+++ b/scripts/lib/dco-signoff.mjs
@@ -16,18 +16,20 @@
 
 import { spawnSync } from "node:child_process";
 
-// A commit is signed off when its message body carries a `Signed-off-by:`
-// trailer line with a value. Line-anchored (multiline) and requiring at least
-// one non-space character after the colon: this matches the historical
-// scripts/pr-readiness/core.mjs predicate on every real commit while refusing a
-// bare/empty trailer. Kept deliberately narrow rather than validating the
-// author/email match the DCO app performs — the failure this must catch is a
-// MISSING sign-off, and a stricter regex risks false-positives that would erode
-// trust in a local gate faster than a missed one would.
-const SIGNED_OFF_LINE = /^[ \t]*Signed-off-by:[ \t]*\S.*$/im;
+// The DCO app requires the commit author's own identity, not merely any
+// Signed-off-by trailer. Multiple sign-offs are valid, but one must exactly
+// match Git's `%an <%ae>` for this commit. Keep keyword matching
+// case-insensitive while preserving identity bytes: changing an email's case or
+// spelling is a different author as far as the commit payload is concerned.
+const SIGNED_OFF_LINE = /^[ \t]*Signed-off-by:[ \t]*(\S.*?)[ \t]*$/gim;
 
-export function isSignedOff(body) {
-  return SIGNED_OFF_LINE.test(String(body ?? ""));
+export function isSignedOff(body, { authorName, authorEmail } = {}) {
+  const name = String(authorName ?? "").trim();
+  const email = String(authorEmail ?? "").trim();
+  if (!name || !email) return false;
+  const expected = `${name} <${email}>`;
+  return [...String(body ?? "").matchAll(SIGNED_OFF_LINE)]
+    .some((match) => match[1] === expected);
 }
 
 // Default git executor: returns { status, stdout, stderr }. Kept separate so
@@ -66,7 +68,7 @@ const RS = "\x1e";
  */
 export function findUnsignedCommits(range, { git = defaultGit, cwd } = {}) {
   if (!range) return [];
-  const format = ["%H", "%s", "%b"].join(US);
+  const format = ["%H", "%s", "%an", "%ae", "%b"].join(US);
   const result = git(
     ["log", `--pretty=format:${format}${RS}`, range],
     { cwd },
@@ -85,12 +87,15 @@ export function findUnsignedCommits(range, { git = defaultGit, cwd } = {}) {
     .map((entry) => entry.replace(/^\n/, ""))
     .filter((entry) => entry.trim().length > 0)
     .map((entry) => {
-      const [sha = "", subject = "", ...bodyParts] = entry.split(US);
-      return { sha, subject, body: bodyParts.join(US) };
+      const [sha = "", subject = "", authorName = "", authorEmail = "", ...bodyParts] = entry.split(US);
+      return { sha, subject, authorName, authorEmail, body: bodyParts.join(US) };
     });
   // A commit's full message = subject + body; `git log %s%b` splits them, so a
   // trailer on the subject line (rare) or in the body both satisfy the check.
-  return commits.filter((commit) => !isSignedOff(`${commit.subject}\n${commit.body}`));
+  return commits.filter((commit) => !isSignedOff(
+    `${commit.subject}\n${commit.body}`,
+    { authorName: commit.authorName, authorEmail: commit.authorEmail },
+  ));
 }
 
 /**

--- a/scripts/pr-health.mjs
+++ b/scripts/pr-health.mjs
@@ -46,17 +46,22 @@ export { LOCAL_CI_OVERRIDE_REASON_CODES, classifyLocalCiOverride };
 const FAILING_BUCKETS = new Set(["fail", "cancel"]);
 const PENDING_BUCKETS = new Set(["pending"]);
 
-// PR-body attestation trailers for the local-CI sandbox gate (BI-C74F4DE9).
+// Commit/PR attestation trailers for the local-CI sandbox gate (BI-C74F4DE9).
 // `Local-CI-Evidence:` carries an evidence record id from a passing
 // `pnpm run pregate` run; `Local-CI-Override:` is an explicit operator
 // attestation that the sandbox gate was consciously skipped and why.
 // BI-563F6AB6: Override values must use a closed reason code (see local-ci-override.mjs).
 const LOCAL_CI_TRAILER_RE = /^\s*Local-CI-(Evidence|Override):\s*(\S.*)$/m;
 
-export function parseLocalCiAttestation(prBody) {
-  const match = LOCAL_CI_TRAILER_RE.exec(prBody || "");
-  if (!match) return null;
-  return { kind: match[1].toLowerCase(), value: match[2].trim() };
+export function parseLocalCiAttestation(prBody, commitMessages = []) {
+  // Commit trailers are durable and create a fresh webhook payload when pushed;
+  // prefer them over the mutable PR body, whose value is frozen in an already-
+  // running pull_request event. Body parsing stays as a compatibility fallback.
+  for (const source of [...commitMessages, prBody]) {
+    const match = LOCAL_CI_TRAILER_RE.exec(source || "");
+    if (match) return { kind: match[1].toLowerCase(), value: match[2].trim() };
+  }
+  return null;
 }
 
 const DOCS_ONLY_RE = /^docs\/|^memory\/|\.md$/;
@@ -124,7 +129,7 @@ export function evaluatePrHealth({ meta = {}, checks = [], threads = [], localCi
 
   // Local-CI sandbox evidence (BI-C74F4DE9 + BI-563F6AB6 P1): a runtime-code PR
   // must carry a passing local-integration-ci gate for its head SHA, a recorded
-  // pre-push override with an allowlisted reason code, or a PR-body attestation
+  // pre-push override with an allowlisted reason code, or a commit/PR attestation
   // (Evidence id, or Override with allowlisted code). Free-text overrides are
   // blockers — agents cannot green-wash "unit tests only".
   if (localCi) {
@@ -150,13 +155,13 @@ export function evaluatePrHealth({ meta = {}, checks = [], threads = [], localCi
     } else if (localCi.attestation) {
       if (localCi.attestation.kind === "evidence") {
         notes.push(
-          `local-CI evidence attestation in PR body: ${localCi.attestation.value}`,
+          `local-CI evidence attestation in commit history or PR body: ${localCi.attestation.value}`,
         );
       } else if (localCi.attestation.kind === "override") {
         const classified = classifyLocalCiOverride(localCi.attestation.value);
         if (classified.ok) {
           notes.push(
-            `local-CI override attestation in PR body (code=${classified.code}` +
+            `local-CI override attestation in commit history or PR body (code=${classified.code}` +
               (classified.detail ? `; ${classified.detail}` : "") +
               ")",
           );
@@ -230,7 +235,7 @@ function fetchPrState(prArg) {
   }
 
   const meta = JSON.parse(
-    gh(["pr", "view", number, "--json", "number,title,state,mergeable,mergeStateStatus,isDraft,headRefOid,body,files"]),
+    gh(["pr", "view", number, "--json", "number,title,state,mergeable,mergeStateStatus,isDraft,headRefOid,body,files,commits"]),
   );
 
   let checks = [];
@@ -271,7 +276,8 @@ function fetchPrState(prArg) {
 
   // Local-CI sandbox evidence inputs (BI-C74F4DE9). The git-local gate record
   // only proves anything when pr:health runs from the branch's own worktree;
-  // for remote PRs the PR-body attestation trailer is the portable signal.
+  // for remote PRs a commit trailer is the durable signal; PR body remains a
+  // compatibility fallback for older contributions.
   let stateRecord = null;
   try {
     const stateFile = execFileSync("git", ["rev-parse", "--git-path", "dpf-local-ci-gate.json"], {
@@ -284,7 +290,11 @@ function fetchPrState(prArg) {
   const localCi = {
     headSha: meta.headRefOid,
     docsOnly: isDocsOnlyFileSet(meta.files),
-    attestation: parseLocalCiAttestation(meta.body),
+    attestation: parseLocalCiAttestation(
+      meta.body,
+      (meta.commits ?? []).map((commit) =>
+        [commit.messageHeadline, commit.messageBody].filter(Boolean).join("\n\n")),
+    ),
     stateRecord,
   };
 

--- a/scripts/pr-health.test.mjs
+++ b/scripts/pr-health.test.mjs
@@ -137,6 +137,19 @@ test("parseLocalCiAttestation matches Evidence and Override trailers", () => {
   assert.equal(parseLocalCiAttestation(null), null);
 });
 
+test("parseLocalCiAttestation prefers durable commit trailers over the PR body", () => {
+  assert.deepEqual(
+    parseLocalCiAttestation(
+      "PR prose with no gate answer",
+      ["chore: evidence\n\nLocal-CI-Override: external-contribution-no-install: source-only worktree"],
+    ),
+    {
+      kind: "override",
+      value: "external-contribution-no-install: source-only worktree",
+    },
+  );
+});
+
 test("classifyLocalCiOverride accepts closed codes and rejects free text (BI-563F6AB6)", () => {
   assert.deepEqual(classifyLocalCiOverride("operator-emergency"), {
     ok: true,
@@ -252,7 +265,7 @@ test("localCi: allowlisted PR-body override is ready", () => {
     },
   });
   assert.equal(r.ready, true);
-  assert.match(r.notes.join("\n"), /override attestation in PR body.*operator-emergency/);
+  assert.match(r.notes.join("\n"), /override attestation.*operator-emergency/);
 });
 
 test("localCi: free-text PR-body override is NOT READY (BI-563F6AB6)", () => {

--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -64,14 +64,20 @@ function usage() {
 }
 
 function readCommits() {
-  const raw = git(["log", "origin/main..HEAD", "--format=%H%x1f%s%x1f%B%x1e"], { allowFail: true });
+  const raw = git(["log", "origin/main..HEAD", "--format=%H%x1f%s%x1f%an%x1f%ae%x1f%B%x1e"], { allowFail: true });
   return raw
     .split("\x1e")
     .map((entry) => entry.trim())
     .filter(Boolean)
     .map((entry) => {
-      const [sha, subject, ...bodyParts] = entry.split("\x1f");
-      return { sha: sha ?? "", subject: subject ?? "", body: bodyParts.join("\x1f") };
+      const [sha, subject, authorName, authorEmail, ...bodyParts] = entry.split("\x1f");
+      return {
+        sha: sha ?? "",
+        subject: subject ?? "",
+        authorName: authorName ?? "",
+        authorEmail: authorEmail ?? "",
+        body: bodyParts.join("\x1f"),
+      };
     });
 }
 

--- a/scripts/pr-readiness.test.mjs
+++ b/scripts/pr-readiness.test.mjs
@@ -26,6 +26,8 @@ const cleanRepo = {
     {
       sha: "1111111",
       subject: "feat: add example",
+      authorName: "Mark Bodman",
+      authorEmail: "markdbodman@gmail.com",
       body: "feat: add example\n\nSigned-off-by: Mark Bodman <markdbodman@gmail.com>",
     },
   ],
@@ -162,7 +164,7 @@ test("evaluateReadiness blocks unsafe or queue-hostile repository state", () => 
   assert.match(result.blockers.join("\n"), /working tree has uncommitted changes/);
   assert.match(result.blockers.join("\n"), /2 local commit\(s\) are not pushed/);
   assert.match(result.blockers.join("\n"), /branch is main/);
-  assert.match(result.blockers.join("\n"), /missing DCO sign-off/);
+  assert.match(result.blockers.join("\n"), /missing its author-matching DCO sign-off/);
 });
 
 test("evaluateReadiness accepts a detached exact published ref but no other detached head", () => {
@@ -252,6 +254,8 @@ test("formatReadinessReport uses plain-language headings and changed-file summar
       derivedArtifacts: [],
       routes: [],
       migrations: [],
+      guardObligations: [],
+      testImpact: [],
       verification: ["run the readiness command"],
     },
   });

--- a/scripts/pr-readiness/core.mjs
+++ b/scripts/pr-readiness/core.mjs
@@ -160,9 +160,12 @@ export function evaluateReadiness({ repo, gateResults = [], prBody = "", gateCon
       blockers.push("No diff against current origin/main; there is no PR payload to validate.");
     }
 
-    const unsigned = (repo.commits ?? []).filter((commit) => !isSignedOff(commit.body ?? ""));
+    const unsigned = (repo.commits ?? []).filter((commit) => !isSignedOff(
+      commit.body ?? "",
+      { authorName: commit.authorName, authorEmail: commit.authorEmail },
+    ));
     for (const commit of unsigned) {
-      blockers.push(`Commit ${commit.sha.slice(0, 12)} (${commit.subject}) is missing DCO sign-off.`);
+      blockers.push(`Commit ${commit.sha.slice(0, 12)} (${commit.subject}) is missing its author-matching DCO sign-off.`);
     }
   }
 

--- a/scripts/pre-push-dco-check.test.mjs
+++ b/scripts/pre-push-dco-check.test.mjs
@@ -35,8 +35,8 @@ function fakeGit(handler) {
   };
 }
 
-function logRecord({ sha, subject, body }) {
-  return `${sha}${US}${subject}${US}${body}${RS}`;
+function logRecord({ sha, subject, body, authorName = "A", authorEmail = "a@b.co" }) {
+  return `${sha}${US}${subject}${US}${authorName}${US}${authorEmail}${US}${body}${RS}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -44,11 +44,33 @@ function logRecord({ sha, subject, body }) {
 // ---------------------------------------------------------------------------
 
 test("isSignedOff: matches a trailer line with a value", () => {
-  assert.equal(isSignedOff("feat: x\n\nSigned-off-by: A B <a@b.co>"), true);
+  assert.equal(
+    isSignedOff("feat: x\n\nSigned-off-by: A B <a@b.co>", {
+      authorName: "A B",
+      authorEmail: "a@b.co",
+    }),
+    true,
+  );
+});
+
+test("isSignedOff: rejects a trailer belonging to a different identity", () => {
+  assert.equal(
+    isSignedOff("feat: x\n\nSigned-off-by: Bot User <bot@example.com>", {
+      authorName: "A B",
+      authorEmail: "a@b.co",
+    }),
+    false,
+  );
 });
 
 test("isSignedOff: case-insensitive and mid-message", () => {
-  assert.equal(isSignedOff("wip\n\nsigned-off-by: A B <a@b.co>\n"), true);
+  assert.equal(
+    isSignedOff("wip\n\nsigned-off-by: A B <a@b.co>\n", {
+      authorName: "A B",
+      authorEmail: "a@b.co",
+    }),
+    true,
+  );
 });
 
 test("isSignedOff: missing trailer is unsigned", () => {
@@ -86,6 +108,22 @@ test("findUnsignedCommits: returns only unsigned commits, newest first", () => {
   assert.equal(unsigned.length, 1);
   assert.equal(unsigned[0].sha, "bbb");
   assert.equal(unsigned[0].subject, "unsigned merge");
+});
+
+test("findUnsignedCommits: rejects a present trailer that does not match %an <%ae>", () => {
+  const git = fakeGit(() => ({
+    stdout: logRecord({
+      sha: "ccc",
+      subject: "wrong signer",
+      authorName: "Human Author",
+      authorEmail: "human@example.com",
+      body: "Signed-off-by: Automation Bot <bot@example.com>",
+    }),
+  }));
+  const unsigned = findUnsignedCommits("origin/main..HEAD", { git });
+  assert.equal(unsigned.length, 1);
+  assert.equal(unsigned[0].authorName, "Human Author");
+  assert.equal(unsigned[0].authorEmail, "human@example.com");
 });
 
 test("findUnsignedCommits: empty range yields no commits", () => {
@@ -149,7 +187,7 @@ test("parseArgs: supports spaced and = forms", () => {
 test("evaluateDcoPush: code 0 when all commits signed", () => {
   const git = fakeGit({
     "rev-parse --verify --quiet origin/main^{commit}": { status: 0 },
-    "log --pretty=format:%H\x1f%s\x1f%b\x1e origin/main..HEAD": {
+    "log --pretty=format:%H\x1f%s\x1f%an\x1f%ae\x1f%b\x1e origin/main..HEAD": {
       stdout: logRecord({ sha: "aaa", subject: "signed", body: "Signed-off-by: A <a@b.co>" }),
     },
   });
@@ -161,7 +199,7 @@ test("evaluateDcoPush: code 0 when all commits signed", () => {
 test("evaluateDcoPush: code 1 lists unsigned commits", () => {
   const git = fakeGit({
     "rev-parse --verify --quiet origin/main^{commit}": { status: 0 },
-    "log --pretty=format:%H\x1f%s\x1f%b\x1e origin/main..HEAD": {
+    "log --pretty=format:%H\x1f%s\x1f%an\x1f%ae\x1f%b\x1e origin/main..HEAD": {
       stdout: logRecord({ sha: "deadbeef", subject: "unsigned", body: "no trailer" }),
     },
   });
@@ -183,7 +221,7 @@ test("evaluateDcoPush: code 2 when base ref unresolved and no explicit range", (
 test("evaluateDcoPush: DPF_PREPUSH_BASE_REF overrides default base", () => {
   const git = fakeGit({
     "rev-parse --verify --quiet accepted-base^{commit}": { status: 0 },
-    "log --pretty=format:%H\x1f%s\x1f%b\x1e accepted-base..HEAD": { stdout: "" },
+    "log --pretty=format:%H\x1f%s\x1f%an\x1f%ae\x1f%b\x1e accepted-base..HEAD": { stdout: "" },
   });
   const v = evaluateDcoPush({ argv: [], env: { DPF_PREPUSH_BASE_REF: "accepted-base" }, git });
   assert.equal(v.code, 0);


### PR DESCRIPTION
## Summary

- replace the pull-request guard's identity rewrite and in-place merge with a synthetic `git merge-tree` corpus check
- require DCO sign-off trailers to match each commit's `%an <%ae>` identity
- carry author identity through pre-push and PR-readiness scans

Backlog: BI-ADBF220E

## Verification

- red proof: new mutation-safety and mismatched-identity tests failed against the previous implementation
- `node --test scripts/ci-policy-guards.test.mjs scripts/check-golden-decisions.test.mjs scripts/pre-push-dco-check.test.mjs scripts/pr-readiness.test.mjs scripts/lib/ci-policy-test-inventory.test.mjs` (59/59 pass)
- `node scripts/check-golden-decisions.mjs --merge-with origin/main` (pass, 44 commandments)
- `node scripts/pre-push-dco-check.mjs --base origin/main` (pass)
- real mutation probe: HEAD, status, local name/email, and MERGE_HEAD unchanged

The full source profile reached 46/52 guards; six unrelated current-worktree environment/baseline groups remain red (managed TypeScript absent, Windows Git-Bash path/symlink semantics, and stale generated artifacts). The affected guard inventory is green.