### PR TITLE
feat(skills): the remaining skills-program backlog — six items, one commit each

### DIFF
--- a/apps/web/app/api/v1/ops/epics/route.ts
+++ b/apps/web/app/api/v1/ops/epics/route.ts
@@ -126,7 +126,16 @@ export async function POST(request: Request) {
     try {
       const { searchPlatformKnowledge } = await import("@/lib/semantic-memory");
       const searchText = `${title} ${description ?? ""}`.trim();
-      const hits = await searchPlatformKnowledge({ query: searchText, entityType: "epic", limit: 5 });
+      const search = await searchPlatformKnowledge({ query: searchText, entityType: "epic", limit: 5 });
+      // BI-339C441F: an unavailable search is not "no similar epics". The
+      // overlap list stays empty either way, but the outage gets said out loud
+      // instead of passing for a clean check.
+      if (search.status === "unavailable") {
+        console.warn(
+          `[ops/epics] overlap check skipped — semantic search unavailable (${search.reason}).`,
+        );
+      }
+      const hits = search.results;
       if (hits.length > 0) {
         const epicRows = await prisma.epic.findMany({
           where: { epicId: { in: hits.map((h) => h.entityId) } },

--- a/apps/web/lib/actions/backlog.ts
+++ b/apps/web/lib/actions/backlog.ts
@@ -379,7 +379,16 @@ export async function createEpic(input: EpicInput): Promise<CreateEpicResult> {
   try {
     const { searchPlatformKnowledge } = await import("@/lib/semantic-memory");
     const searchText = `${input.title} ${input.description ?? ""}`.trim();
-    const hits = await searchPlatformKnowledge({ query: searchText, entityType: "epic", limit: 5 });
+    const search = await searchPlatformKnowledge({ query: searchText, entityType: "epic", limit: 5 });
+    // BI-339C441F: an unavailable search is not "no similar epics". Leave the
+    // overlap list empty either way, but do not let a retrieval outage read as
+    // a clean duplicate check.
+    if (search.status === "unavailable") {
+      console.warn(
+        `[backlog] epic overlap check skipped — semantic search unavailable (${search.reason}).`,
+      );
+    }
+    const hits = search.results;
     if (hits.length > 0) {
       const epicRows = await prisma.epic.findMany({
         where: { epicId: { in: hits.map((h) => h.entityId) } },

--- a/apps/web/lib/inference/semantic-memory-availability.test.ts
+++ b/apps/web/lib/inference/semantic-memory-availability.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// BI-339C441F. The behaviour under test is a DISTINCTION, not a value: an
+// embedding failure and an empty corpus must not produce the same answer.
+vi.mock("./embedding", () => ({ generateEmbedding: vi.fn() }));
+vi.mock("@dpf/db", () => ({
+  searchSimilar: vi.fn(async () => []),
+  upsertVectors: vi.fn(async () => undefined),
+  scrollPoints: vi.fn(async () => []),
+  QDRANT_COLLECTIONS: { PLATFORM_KNOWLEDGE: "platform-knowledge", AGENT_MEMORY: "agent-memory" },
+  prisma: {},
+  semanticMemoryOps: {},
+}));
+
+const { generateEmbedding } = await import("./embedding");
+const { searchPlatformKnowledge } = await import("./semantic-memory");
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("searchPlatformKnowledge reports that it could not look", () => {
+  it("returns unavailable with a reason when the query cannot be embedded", async () => {
+    vi.mocked(generateEmbedding).mockResolvedValue(null);
+
+    const search = await searchPlatformKnowledge({ query: "anything" });
+
+    expect(search.status).toBe("unavailable");
+    expect(search.results).toEqual([]);
+    if (search.status === "unavailable") expect(search.reason).toBeTruthy();
+  });
+
+  it("returns ok with an empty list when the corpus genuinely holds nothing", async () => {
+    vi.mocked(generateEmbedding).mockResolvedValue([0.1, 0.2, 0.3]);
+
+    const search = await searchPlatformKnowledge({ query: "anything" });
+
+    expect(search.status).toBe("ok");
+    expect(search.results).toEqual([]);
+  });
+
+  it("distinguishes the two — the regression is that both looked identical", async () => {
+    vi.mocked(generateEmbedding).mockResolvedValue(null);
+    const broken = await searchPlatformKnowledge({ query: "q" });
+
+    vi.mocked(generateEmbedding).mockResolvedValue([0.1]);
+    const empty = await searchPlatformKnowledge({ query: "q" });
+
+    // Both carry no results. Only the status tells a caller whether "no
+    // results" is evidence of anything.
+    expect(broken.results).toEqual(empty.results);
+    expect(broken.status).not.toBe(empty.status);
+  });
+});

--- a/apps/web/lib/inference/semantic-memory.ts
+++ b/apps/web/lib/inference/semantic-memory.ts
@@ -409,13 +409,52 @@ export async function storePlatformKnowledge(params: {
 
 // ─── Search Platform Knowledge ──────────────────────────────────────────────
 
+export type PlatformKnowledgeHit = {
+  entityId: string;
+  entityType: string;
+  title: string;
+  score: number;
+};
+
+/**
+ * Why this returns a status and not just an array (BI-339C441F).
+ *
+ * This function used to answer `[]` when generateEmbedding() returned null —
+ * making "the corpus holds nothing like your query" and "I could not embed
+ * your query, so I never looked" the same answer. Callers cannot tell those
+ * apart, and one of them is a lie by omission.
+ *
+ * It matters most where an empty result is treated as PERMISSION. create_backlog_item
+ * and dpf-file-backlog-item both say "search before you create"; with retrieval
+ * down, that check returns its cleanest possible result at the exact moment it
+ * is least trustworthy, and duplicates get filed with an audit trail claiming
+ * they were checked. Observed 2026-08-21: three consecutive queries returned
+ * empty, including a control that certainly matched a live epic.
+ *
+ * `unavailable` is not an error — the caller decides whether to proceed. It
+ * just has to know it is proceeding blind.
+ */
+export type PlatformKnowledgeSearch =
+  | { status: "ok"; results: PlatformKnowledgeHit[] }
+  | { status: "unavailable"; reason: string; results: [] };
+
 export async function searchPlatformKnowledge(params: {
   query: string;
   entityType?: string;
   limit?: number;
-}): Promise<Array<{ entityId: string; entityType: string; title: string; score: number }>> {
+}): Promise<PlatformKnowledgeSearch> {
   const embedding = await generateEmbedding(params.query);
-  if (!embedding) return [];
+  if (!embedding) {
+    console.warn(
+      "[semantic-memory] searchPlatformKnowledge could not embed the query — " +
+        "reporting unavailable rather than an empty result set.",
+    );
+    return {
+      status: "unavailable",
+      reason: "the embedding model did not return a vector for this query",
+      results: [],
+    };
+  }
 
   const filter = params.entityType
     ? { must: [{ key: "entityType", match: { value: params.entityType } }] }
@@ -429,12 +468,15 @@ export async function searchPlatformKnowledge(params: {
     0.6,
   );
 
-  return results.map((r) => ({
-    entityId: String(r.payload["entityId"] ?? ""),
-    entityType: String(r.payload["entityType"] ?? ""),
-    title: String(r.payload["title"] ?? ""),
-    score: r.score,
-  }));
+  return {
+    status: "ok",
+    results: results.map((r) => ({
+      entityId: String(r.payload["entityId"] ?? ""),
+      entityType: String(r.payload["entityType"] ?? ""),
+      title: String(r.payload["title"] ?? ""),
+      score: r.score,
+    })),
+  };
 }
 
 // ─── Store Capability Knowledge ────────────────────────────────────────────

--- a/apps/web/lib/mcp/packs/knowledge-pack.test.ts
+++ b/apps/web/lib/mcp/packs/knowledge-pack.test.ts
@@ -56,9 +56,10 @@ describe("knowledge pack — registration", () => {
 
 describe("knowledge pack — handler behavior (delegation preserved)", () => {
   it("search_knowledge summarizes semantic results from the service", async () => {
-    semanticMemory.searchPlatformKnowledge.mockResolvedValue([
-      { entityType: "backlog", entityId: "BI-1", title: "Widget", score: 0.9 },
-    ]);
+    semanticMemory.searchPlatformKnowledge.mockResolvedValue({
+      status: "ok",
+      results: [{ entityType: "backlog", entityId: "BI-1", title: "Widget", score: 0.9 }],
+    });
     const res = await knowledgePack.handlers.search_knowledge({ query: "widget" }, "u1");
     expect(res.success).toBe(true);
     expect(res.message).toContain("backlog:BI-1");
@@ -71,10 +72,27 @@ describe("knowledge pack — handler behavior (delegation preserved)", () => {
   });
 
   it("search_knowledge returns an empty result set when nothing matches", async () => {
-    semanticMemory.searchPlatformKnowledge.mockResolvedValue([]);
+    semanticMemory.searchPlatformKnowledge.mockResolvedValue({ status: "ok", results: [] });
     const res = await knowledgePack.handlers.search_knowledge({ query: "none" }, "u1");
     expect(res.success).toBe(true);
     expect(res.data).toEqual({ results: [] });
+  });
+
+  it("search_knowledge fails loudly when retrieval is unavailable (BI-339C441F)", async () => {
+    // The regression: this used to be indistinguishable from the case above,
+    // so a caller told to "search before you create" read an outage as a
+    // clean duplicate check.
+    semanticMemory.searchPlatformKnowledge.mockResolvedValue({
+      status: "unavailable",
+      reason: "the embedding model did not return a vector for this query",
+      results: [],
+    });
+    const res = await knowledgePack.handlers.search_knowledge({ query: "none" }, "u1");
+
+    expect(res.success).toBe(false);
+    expect(res.message).toContain("unavailable");
+    expect(res.message).toContain('NOT "no results"');
+    expect(res.data).toMatchObject({ searchStatus: "unavailable" });
   });
 
   it("search_knowledge_base forwards the article filters to the service", async () => {

--- a/apps/web/lib/mcp/packs/knowledge-pack.ts
+++ b/apps/web/lib/mcp/packs/knowledge-pack.ts
@@ -110,11 +110,25 @@ const definitions: ToolDefinition[] = [
 
 async function searchKnowledgeHandler(params: Record<string, unknown>): Promise<ToolResult> {
   const { searchPlatformKnowledge } = await import("@/lib/semantic-memory");
-  const results = await searchPlatformKnowledge({
+  const search = await searchPlatformKnowledge({
     query: String(params["query"] ?? ""),
     entityType: typeof params["type"] === "string" ? params["type"] : undefined,
     limit: typeof params["limit"] === "number" ? params["limit"] : 5,
   });
+  // BI-339C441F: never report "nothing matched" when we could not look. A
+  // caller told to search before creating will read an empty array as
+  // permission to proceed, so the difference has to reach them.
+  if (search.status === "unavailable") {
+    return {
+      success: false,
+      message:
+        `Semantic search is unavailable — ${search.reason}. This is NOT "no results": ` +
+        "the corpus was never queried. Do not treat this as evidence that nothing matches. " +
+        "Fall back to list_backlog_items or query_backlog and say the check was lexical only.",
+      data: { results: [], searchStatus: "unavailable" },
+    };
+  }
+  const results = search.results;
   if (results.length === 0) {
     return { success: true, message: "No matching knowledge found.", data: { results: [] } };
   }

--- a/apps/web/lib/prose/generated-prose.test.ts
+++ b/apps/web/lib/prose/generated-prose.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyzeGeneratedProse,
+  classifyGeneratedProse,
+} from "./generated-prose";
+
+describe("analyzeGeneratedProse", () => {
+  it("scores clean prose as clean", () => {
+    const reading = analyzeGeneratedProse(
+      "Every skill declared the same invocation triple, so the ranker had nothing to rank on. " +
+        "34 skills now declare their real classification.",
+    );
+
+    expect(reading.tells).toBe(0);
+    expect(reading.zone).toBe("clean");
+  });
+
+  it("counts puffery, superficial -ing clauses, and chatbot filler separately", () => {
+    const reading = analyzeGeneratedProse(
+      "This represents a pivotal, seamless upgrade, ensuring reliability. I hope this helps!",
+    );
+
+    expect(reading.puffery).toBe(2); // pivotal, seamless
+    expect(reading.superficialIng).toBe(1); // ", ensuring"
+    expect(reading.chatbotFiller).toBe(1); // "i hope this helps"
+    expect(reading.tells).toBe(4);
+  });
+
+  it("counts every occurrence, not every matching phrase", () => {
+    // Three "seamless" in one paragraph should read as three tells, not one.
+    const reading = analyzeGeneratedProse("Seamless here, seamless there, seamless everywhere.");
+    expect(reading.puffery).toBe(3);
+  });
+
+  it("does not flag participial clauses that carry a real fact", () => {
+    // The closed list is the whole point: this clause asserts something
+    // checkable, so it is not filler even though it matches ", <verb>ing".
+    const reading = analyzeGeneratedProse(
+      "The loader reads both planes, returning null when the row is absent.",
+    );
+
+    expect(reading.superficialIng).toBe(0);
+    expect(reading.tells).toBe(0);
+  });
+
+  it("is case-insensitive", () => {
+    expect(analyzeGeneratedProse("A ROBUST, Cutting-Edge result.").puffery).toBe(2);
+  });
+
+  it("reports long sentences but keeps them out of the tell count", () => {
+    // A long sentence can be the right sentence — surfaced, never scored.
+    const long = `${"word ".repeat(40)}end.`;
+    const reading = analyzeGeneratedProse(long);
+
+    expect(reading.longSentences).toBe(1);
+    expect(reading.tells).toBe(0);
+    expect(reading.zone).toBe("clean");
+  });
+
+  it("handles empty and whitespace input without throwing", () => {
+    for (const input of ["", "   ", "\n\n"]) {
+      const reading = analyzeGeneratedProse(input);
+      expect(reading.tells).toBe(0);
+      expect(reading.sentences).toBe(0);
+      expect(reading.zone).toBe("clean");
+    }
+  });
+});
+
+describe("classifyGeneratedProse", () => {
+  it("bands by density so a long report is not punished for being long", () => {
+    // Same three tells: dense in a short alert, diluted across a long report.
+    expect(classifyGeneratedProse(3, 4)).toBe("slop");
+    expect(classifyGeneratedProse(3, 40)).toBe("noticeable");
+  });
+
+  it("escalates on absolute count even when diluted", () => {
+    expect(classifyGeneratedProse(6, 100)).toBe("slop");
+  });
+
+  it("never divides by zero on empty text", () => {
+    expect(classifyGeneratedProse(0, 0)).toBe("clean");
+    expect(classifyGeneratedProse(2, 0)).toBe("slop");
+  });
+});

--- a/apps/web/lib/prose/generated-prose.ts
+++ b/apps/web/lib/prose/generated-prose.ts
@@ -151,3 +151,33 @@ export function classifyGeneratedProse(tells: number, sentences: number): Genera
   if (density >= 0.5 || tells >= 6) return "slop";
   return "noticeable";
 }
+
+/**
+ * Emit the gauge for one generated response.
+ *
+ * Lives here rather than inline in the agentic loop because that file is the
+ * largest module in the repo and its size ratchet only permits shrinking —
+ * observability should not spend that budget. Silent on a clean turn.
+ *
+ * `redact` is the caller's log sanitizer, injected so this module stays
+ * import-free and unit-testable.
+ */
+export function logGeneratedProse(
+  text: string,
+  context: { threadId?: string | null; modelId?: string | null },
+  redact: (line: string) => string = (line) => line,
+): GeneratedProseReading {
+  const reading = analyzeGeneratedProse(text);
+  if (reading.zone !== "clean") {
+    console.log(
+      redact(
+        `[generated-prose] thread=${JSON.stringify(context.threadId ?? null)} ` +
+          `zone=${reading.zone} tells=${reading.tells} puffery=${reading.puffery} ` +
+          `ing=${reading.superficialIng} filler=${reading.chatbotFiller} ` +
+          `longSentences=${reading.longSentences} sentences=${reading.sentences} ` +
+          `model=${JSON.stringify(context.modelId ?? null)}`,
+      ),
+    );
+  }
+  return reading;
+}

--- a/apps/web/lib/prose/generated-prose.ts
+++ b/apps/web/lib/prose/generated-prose.ts
@@ -1,0 +1,153 @@
+// apps/web/lib/prose/generated-prose.ts
+//
+// Observability-only slop gauge for prose the platform GENERATES.
+//
+// scripts/check-prose-lint.ts already ratchets prose quality — but only for UI
+// copy a human typed into a .tsx file. It has no counterpart for the text a
+// model produces at runtime: alert humanization, backlog item bodies, wiki
+// overlay drafts, PR descriptions, coworker replies. Those are the strings
+// customers read most often, and nothing measured them.
+//
+// WHY A CHECKER AND NOT A PROMPT RULE. The obvious alternative is to instruct
+// the model to write better. That is the wrong mechanism for the local tier:
+// packages/db/src/local-model-capabilities.ts puts Qwen at
+// instructionFollowingScore 78 and Gemma at 65, so a style block is followed
+// unreliably — and, worse, it is followed AT THE COST OF THE TASK, because
+// contextRetention (55 and 45) is the weakest dimension in both priors and a
+// long style section displaces task content on exactly the models that can
+// least afford it. Measuring after the fact costs the model nothing and is
+// deterministic.
+//
+// IMPORTANT: nothing here changes what is emitted. It scores and returns, in
+// the same spirit as ./tak/context-pressure.ts — measure first so a regression
+// is visible instead of silent, and only then decide what to enforce. The
+// ratchet promotion is deliberately deferred (BI-41F15FD7 step 4) until a
+// baseline exists.
+//
+// Pure module — no imports, no I/O — so it is unit-tested directly and is
+// cheap enough to run on a response path.
+
+/** Empty puffery. Says a thing was important without saying what happened. */
+const PUFFERY = [
+  "pivotal", "testament to", "evolving landscape", "setting the stage",
+  "in today's", "ever-changing", "game-changer", "game changer",
+  "seamless", "seamlessly", "robust", "cutting-edge", "state-of-the-art",
+  "best-in-class", "world-class", "unlock the power", "harness the power",
+  "delve into", "navigate the complexities", "it's worth noting",
+  "at the end of the day", "significant improvement", "greatly enhances",
+];
+
+/**
+ * The superficial `-ing` clause: a comma, then a participle that adds no fact.
+ * "…, ensuring reliability" and "…, highlighting the need for" assert nothing
+ * checkable — they are grammatical filler attached to a real sentence.
+ *
+ * Matched as a CLOSED list rather than any `-ing` word, because plenty of
+ * participial clauses carry real content ("…, returning null when the row is
+ * absent"). A closed list under-reports and never fabricates.
+ */
+const SUPERFICIAL_ING = [
+  "highlighting", "ensuring", "reflecting", "showcasing", "underscoring",
+  "emphasizing", "demonstrating", "illustrating", "signifying",
+  "showcasing the", "paving the way", "further solidifying",
+];
+
+/** Assistant throat-clearing. Never carries information. */
+const CHATBOT_FILLER = [
+  "i hope this helps", "let me know if", "feel free to", "great question",
+  "certainly!", "of course!", "i'd be happy to", "as an ai",
+  "in conclusion", "to summarize,", "here's a breakdown",
+  "let's dive in", "without further ado",
+];
+
+/**
+ * Matches the authored-copy threshold in scripts/check-prose-lint.ts. Kept as
+ * a local literal rather than an import: that file is a build-time script with
+ * a heavy dependency graph, and this module is deliberately import-free.
+ */
+const LONG_SENTENCE_WORDS = 25;
+
+export type GeneratedProseAxes = {
+  puffery: number;
+  superficialIng: number;
+  chatbotFiller: number;
+  longSentences: number;
+  sentences: number;
+};
+
+export type GeneratedProseZone = "clean" | "noticeable" | "slop";
+
+export type GeneratedProseReading = GeneratedProseAxes & {
+  /** Total tells across the three content axes. Long sentences are reported
+   *  but excluded — a long sentence can be the right sentence. */
+  tells: number;
+  zone: GeneratedProseZone;
+};
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index !== -1) {
+    count += 1;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+function splitSentences(text: string): string[] {
+  return text
+    .split(/[.!?]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function wordCount(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+/**
+ * Score generated prose. Case-insensitive; counts every occurrence, not every
+ * matching phrase, so three "seamless" in one paragraph read as three.
+ */
+export function analyzeGeneratedProse(text: string): GeneratedProseReading {
+  const lower = (text ?? "").toLowerCase();
+
+  const puffery = PUFFERY.reduce((n, p) => n + countOccurrences(lower, p), 0);
+  const chatbotFiller = CHATBOT_FILLER.reduce((n, p) => n + countOccurrences(lower, p), 0);
+  const superficialIng = SUPERFICIAL_ING.reduce(
+    (n, p) => n + countOccurrences(lower, `, ${p}`),
+    0,
+  );
+
+  const sentenceList = splitSentences(text ?? "");
+  const longSentences = sentenceList.filter((s) => wordCount(s) > LONG_SENTENCE_WORDS).length;
+
+  const tells = puffery + superficialIng + chatbotFiller;
+
+  return {
+    puffery,
+    superficialIng,
+    chatbotFiller,
+    longSentences,
+    sentences: sentenceList.length,
+    tells,
+    zone: classifyGeneratedProse(tells, sentenceList.length),
+  };
+}
+
+/**
+ * Band the tell count by density rather than absolute count, so a long report
+ * is not penalized for being long and a two-sentence alert is not excused for
+ * being short.
+ *
+ * Thresholds are heuristic and deliberately loose — this gauge exists to make
+ * a regression visible, not to adjudicate style. Tighten them from a baseline,
+ * not from taste.
+ */
+export function classifyGeneratedProse(tells: number, sentences: number): GeneratedProseZone {
+  if (tells === 0) return "clean";
+  const density = tells / Math.max(sentences, 1);
+  if (density >= 0.5 || tells >= 6) return "slop";
+  return "noticeable";
+}

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -48,7 +48,7 @@ import { estimateContextTokens, classifyContextPressure, deriveCompactionCaps } 
 import { clampToolResultForModel, resolveToolResultCharCap } from "./tool-result-budget";
 import { applyBacklogCreateClaimGuard } from "./backlog-create-claim-guard";
 import { applyEscalationLadderGuard, buildHumanHandoff } from "./escalation-ladder";
-import { analyzeGeneratedProse } from "../prose/generated-prose";
+import { logGeneratedProse } from "../prose/generated-prose"; // BI-41F15FD7
 import { assessToolSurface, computeToolSelectionAccuracy, contextEconomyTurnMetricFields } from "./context-economy-metrics";
 import { summarizeDroppedMessages } from "./compaction-digest";
 import { describeContextCapacityFailure } from "./context-capacity-failure";
@@ -595,30 +595,15 @@ function buildDowngradedFabricationMessage(): string {
 }
 
 function buildLocalToolCallFailureMessage(_result: RoutedInferenceResult): string {
-  // User-facing message: respects IDENTITY_BLOCK rule #5 — never expose
-  // infrastructure names ("Docker Model Runner"), model IDs, or routing
-  // architecture. The internal route + model details are already recorded
-  // for engineers via RoutedInferenceResult.
-  //
-  // Honest copy (G2, 2026-05-23): the prior version promised "I'll route
-  // through a different model" which the loop never delivered. On a single-
-  // provider install the promise was mathematically impossible; on a multi-
-  // provider install the re-route call simply isn't wired. Replaced with
-  // honest copy that points at the actual fix.
-  //
-  // Rung 4 of the escalation ladder (BI-33F1EA72): connecting a provider is
-  // work only the human can do, so this is a hand-off, not an apology. The
-  // prior copy was honest about the limitation but ended there, which leaves
-  // the user holding a dead end. buildHumanHandoff keeps the same facts and
-  // adds the two halves that make it actionable: the steps, and the promise
-  // that the work resumes.
+  // Respects IDENTITY_BLOCK rule #5 — no infrastructure names, model ids, or
+  // routing architecture; engineers get those from RoutedInferenceResult.
+  // Copy must stay honest (G2, 2026-05-23): an earlier version promised a
+  // re-route the loop never performs.
+  // Rung 4 (BI-33F1EA72): connecting a provider is work only the human can do,
+  // so this hands off rather than apologizing — steps, then the resumption.
   return buildHumanHandoff({
-    blocker:
-      "I'm on the local AI here, and it couldn't carry this one through.",
-    steps: [
-      "Open Platform > AI > Providers.",
-      "Connect a stronger provider — Claude, Gemini, or OpenAI.",
-    ],
+    blocker: "I'm on the local AI here, and it couldn't carry this one through.",
+    steps: ["Open Platform > AI > Providers.", "Connect a stronger provider — Claude, Gemini, or OpenAI."],
     verify: "confirm the stronger provider is live",
   });
 }
@@ -2437,24 +2422,8 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
       }
       const finalContent = applyEscalationLadderGuard(applyBacklogCreateClaimGuard(
         trimmed.length > 0 ? result.content : (bestPreNudgeContent || result.content), executedTools), executedTools);
-      // BI-41F15FD7 — generated-prose gauge. Observability ONLY: the content is
-      // returned unchanged; this makes the slop density of what we actually
-      // emit visible, the same way [context-pressure] made prompt fill visible.
-      // Authored UI copy has been ratcheted by scripts/check-prose-lint.ts for
-      // a while; the text a model produces at runtime was never measured, and
-      // it is the text customers read most. Logged only when it is not clean,
-      // so a healthy turn stays silent. See ../prose/generated-prose.
-      const prose = analyzeGeneratedProse(finalContent);
-      if (prose.zone !== "clean") {
-        console.log(
-          sanitizeForLog(
-            `[generated-prose] thread=${JSON.stringify(threadId)} zone=${prose.zone} ` +
-              `tells=${prose.tells} puffery=${prose.puffery} ing=${prose.superficialIng} ` +
-              `filler=${prose.chatbotFiller} longSentences=${prose.longSentences} ` +
-              `sentences=${prose.sentences} model=${JSON.stringify(result.modelId)}`,
-          ),
-        );
-      }
+      // BI-41F15FD7 — observability only; content is returned unchanged.
+      logGeneratedProse(finalContent, { threadId, modelId: result.modelId }, sanitizeForLog);
       logTurnSummary(result.providerId, result.modelId);
       return {
         content: finalContent,

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -48,6 +48,7 @@ import { estimateContextTokens, classifyContextPressure, deriveCompactionCaps } 
 import { clampToolResultForModel, resolveToolResultCharCap } from "./tool-result-budget";
 import { applyBacklogCreateClaimGuard } from "./backlog-create-claim-guard";
 import { applyEscalationLadderGuard, buildHumanHandoff } from "./escalation-ladder";
+import { analyzeGeneratedProse } from "../prose/generated-prose";
 import { assessToolSurface, computeToolSelectionAccuracy, contextEconomyTurnMetricFields } from "./context-economy-metrics";
 import { summarizeDroppedMessages } from "./compaction-digest";
 import { describeContextCapacityFailure } from "./context-capacity-failure";
@@ -2436,6 +2437,24 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
       }
       const finalContent = applyEscalationLadderGuard(applyBacklogCreateClaimGuard(
         trimmed.length > 0 ? result.content : (bestPreNudgeContent || result.content), executedTools), executedTools);
+      // BI-41F15FD7 — generated-prose gauge. Observability ONLY: the content is
+      // returned unchanged; this makes the slop density of what we actually
+      // emit visible, the same way [context-pressure] made prompt fill visible.
+      // Authored UI copy has been ratcheted by scripts/check-prose-lint.ts for
+      // a while; the text a model produces at runtime was never measured, and
+      // it is the text customers read most. Logged only when it is not clean,
+      // so a healthy turn stays silent. See ../prose/generated-prose.
+      const prose = analyzeGeneratedProse(finalContent);
+      if (prose.zone !== "clean") {
+        console.log(
+          sanitizeForLog(
+            `[generated-prose] thread=${JSON.stringify(threadId)} zone=${prose.zone} ` +
+              `tells=${prose.tells} puffery=${prose.puffery} ing=${prose.superficialIng} ` +
+              `filler=${prose.chatbotFiller} longSentences=${prose.longSentences} ` +
+              `sentences=${prose.sentences} model=${JSON.stringify(result.modelId)}`,
+          ),
+        );
+      }
       logTurnSummary(result.providerId, result.modelId);
       return {
         content: finalContent,

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -47,7 +47,7 @@ import { persistExecutionPlan, loadExecutionPlan } from "./execution-plan-store"
 import { estimateContextTokens, classifyContextPressure, deriveCompactionCaps } from "./context-pressure";
 import { clampToolResultForModel, resolveToolResultCharCap } from "./tool-result-budget";
 import { applyBacklogCreateClaimGuard } from "./backlog-create-claim-guard";
-import { applyEscalationLadderGuard } from "./escalation-ladder";
+import { applyEscalationLadderGuard, buildHumanHandoff } from "./escalation-ladder";
 import { assessToolSurface, computeToolSelectionAccuracy, contextEconomyTurnMetricFields } from "./context-economy-metrics";
 import { summarizeDroppedMessages } from "./compaction-digest";
 import { describeContextCapacityFailure } from "./context-capacity-failure";
@@ -604,13 +604,22 @@ function buildLocalToolCallFailureMessage(_result: RoutedInferenceResult): strin
   // provider install the promise was mathematically impossible; on a multi-
   // provider install the re-route call simply isn't wired. Replaced with
   // honest copy that points at the actual fix.
-  return (
-    "I'm on a local AI that wasn't strong enough to finish this. "
-    + "Connecting a stronger provider (Claude, Gemini, or OpenAI) at "
-    + "Platform > AI > Providers unlocks the work I'm built for. "
-    + "If a stronger provider is already connected, try rephrasing or breaking "
-    + "the request into a smaller step."
-  );
+  //
+  // Rung 4 of the escalation ladder (BI-33F1EA72): connecting a provider is
+  // work only the human can do, so this is a hand-off, not an apology. The
+  // prior copy was honest about the limitation but ended there, which leaves
+  // the user holding a dead end. buildHumanHandoff keeps the same facts and
+  // adds the two halves that make it actionable: the steps, and the promise
+  // that the work resumes.
+  return buildHumanHandoff({
+    blocker:
+      "I'm on the local AI here, and it couldn't carry this one through.",
+    steps: [
+      "Open Platform > AI > Providers.",
+      "Connect a stronger provider — Claude, Gemini, or OpenAI.",
+    ],
+    verify: "confirm the stronger provider is live",
+  });
 }
 
 type ExecutedTool = { name: string; args?: Record<string, unknown>; result: ToolResult };

--- a/apps/web/lib/tak/escalation-ladder.test.ts
+++ b/apps/web/lib/tak/escalation-ladder.test.ts
@@ -4,6 +4,8 @@ import {
   UNESCALATED_FILE_OFFER,
   classifyLadderActivity,
   applyEscalationLadderGuard,
+  ESCALATION_RUNGS,
+  buildHumanHandoff,
 } from "./escalation-ladder";
 
 const ok = (name: string) => ({ name, result: { success: true, entityId: "BI-FBDF739F" } });
@@ -115,5 +117,53 @@ describe("ESCALATION_LADDER_BLOCK", () => {
 
   it("keeps operating-principle 5 intact — peers are described to users by role, not id", () => {
     expect(ESCALATION_LADDER_BLOCK).toMatch(/never a tool name or an internal id/);
+  });
+});
+
+describe("rung 4 — hand off to the human (BI-33F1EA72)", () => {
+  it("tells coworkers not to route or file a blocker only a person can clear", () => {
+    expect(ESCALATION_LADDER_BLOCK).toMatch(/HAND OFF/);
+    expect(ESCALATION_LADDER_BLOCK).toMatch(/do not route it and do not file it/);
+  });
+
+  it("keeps FILE as the last rung after the hand-off is inserted", () => {
+    const handoffAt = ESCALATION_LADDER_BLOCK.indexOf("HAND OFF");
+    const fileAt = ESCALATION_LADDER_BLOCK.indexOf("FILE —");
+    expect(handoffAt).toBeGreaterThan(-1);
+    expect(fileAt).toBeGreaterThan(handoffAt);
+  });
+
+  it("does NOT count a hand-off as a peer attempt", () => {
+    // The guard exists to catch "filed without asking a colleague". A hand-off
+    // involves the human, so counting it here would let a coworker satisfy the
+    // guard by telling the user to fix it themselves and filing anyway.
+    expect(ESCALATION_RUNGS).not.toContain("handoff");
+  });
+
+  it("renders the blocker, numbered steps, and what gets re-checked", () => {
+    const message = buildHumanHandoff({
+      blocker: "I can't sign in to the billing portal from here.",
+      steps: ["Open the billing portal.", "Approve the pending access request."],
+      verify: "retry the sync",
+    });
+
+    expect(message).toContain("I can't sign in to the billing portal from here.");
+    expect(message).toContain("1. Open the billing portal.");
+    expect(message).toContain("2. Approve the pending access request.");
+    expect(message).toContain("I'll retry the sync");
+  });
+
+  it("never ends on the limitation — the last line hands the work back", () => {
+    // The failure this rung exists to fix: naming what could not be done and
+    // stopping there. The closing line must be the resumption, not the blocker.
+    const message = buildHumanHandoff({
+      blocker: "Blocked.",
+      steps: ["Do the thing."],
+      verify: "check it took",
+    });
+
+    const lastLine = message.trimEnd().split("\n").pop() ?? "";
+    expect(lastLine).toMatch(/pick this straight back up/);
+    expect(lastLine).not.toMatch(/^Blocked\.$/);
   });
 });

--- a/apps/web/lib/tak/escalation-ladder.ts
+++ b/apps/web/lib/tak/escalation-ladder.ts
@@ -21,7 +21,7 @@
 import type { ExecutedToolLike } from "./backlog-create-claim-guard";
 
 /** Ladder rungs, cheapest and least disruptive first. */
-export type LadderRung = "reroute" | "consult" | "convene" | "file";
+export type LadderRung = "reroute" | "consult" | "convene" | "handoff" | "file";
 
 /**
  * Rung 1 — re-route. Read-only roster discovery by intent (BI-5FB59BC6). Costs
@@ -51,7 +51,20 @@ const CONVENE_TOOLS = [
 ] as const;
 
 /**
- * Rung 4 — file. Genuinely no path forward in this conversation. Last resort,
+ * Rung 4 — hand off (BI-33F1EA72). The blocker is one only a human can clear:
+ * entering a credential, completing an interactive sign-in, granting host or
+ * physical access, running a privileged command. No peer coworker can unblock
+ * it, so rungs 1-3 cannot, and filing it buries a two-minute fix in a queue.
+ *
+ * Deliberately has NO tools. Every other rung is evidenced by a tool call;
+ * this rung's artifact is the reply itself — numbered steps the human can run
+ * plus a check the coworker can re-run afterwards. buildHumanHandoff() below is
+ * the canonical shape, so the rung is a formatter, not a tool grant.
+ */
+const HANDOFF_TOOLS = [] as const;
+
+/**
+ * Rung 5 — file. Genuinely no path forward in this conversation. Last resort,
  * not first.
  */
 const FILE_TOOLS = ["create_backlog_item", "report_quality_issue"] as const;
@@ -60,6 +73,7 @@ const RUNG_TOOLS: Record<LadderRung, readonly string[]> = {
   reroute: REROUTE_TOOLS,
   consult: CONSULT_TOOLS,
   convene: CONVENE_TOOLS,
+  handoff: HANDOFF_TOOLS,
   file: FILE_TOOLS,
 };
 
@@ -77,7 +91,8 @@ export const ESCALATION_LADDER_BLOCK = `WHEN YOU CANNOT ANSWER — WORK THE LADD
 2. RE-ROUTE — the question belongs to another specialist's area (a platform or deployment failure is not a delivery-process question; a billing dispute is not an engineering question). Call find_coworker with the intent, hand the work to the peer it names, and tell the user who is picking it up. This costs the user nothing — do it silently and do it first.
 3. CONSULT — you own the surface but need a peer's knowledge for one bounded question. Call request_coworker, then answer in your own voice with the peer's grounded result and say who you checked with.
 4. CONVENE — the work needs more than one party, more than one turn, or a human decision. Call summon_coworker to bring peers into this conversation, or open a work room and invite the participants who can actually resolve it.
-5. FILE — only when there is no path forward in this conversation at all. Say plainly which peers you tried and why the work could not proceed, then file it.
+5. HAND OFF — the blocker is one only a person can clear: typing a credential, finishing a sign-in, granting access on their machine, running something that needs their permission. No colleague can do it for them, so do not route it and do not file it. Give them the shortest numbered list of steps that clears it, say what you will check once they are done, and offer to pick the work straight back up. Never end on what you could not do; end on what they can do next.
+6. FILE — only when there is no path forward in this conversation at all. Say plainly which peers you tried and why the work could not proceed, then file it.
 NEVER file a backlog item as a substitute for asking a colleague. A filed item with no attempt to reach a peer is a dead end handed to the user. When you describe a peer, use their role in plain language ("our platform engineer", "the finance specialist") — never a tool name or an internal id.`;
 
 /**
@@ -97,7 +112,14 @@ export const COORDINATOR_BLOCK = `THE COO COORDINATES; SPECIALISTS DO THE WORK. 
 - If you are the COO: you route, consult, and convene — you do not re-do specialist work, and you do not answer for a specialist when bringing them in is one call away. Hold the thread: a question you route is still yours to track until someone owns it.
 - Either way, coordination is visible, and no one speaks as the decider: recommendations carry their own attribution, and approval always belongs to the human.`;
 
-/** Rungs 1-3: an actual attempt to involve another coworker. */
+/**
+ * Rungs 1-3: an actual attempt to involve another coworker.
+ *
+ * `handoff` is deliberately absent. This list answers "did the coworker try a
+ * PEER before filing", and a handoff involves the human, not a peer — counting
+ * it here would let "I told the user to fix it themselves, then filed anyway"
+ * satisfy a guard that exists to catch exactly that.
+ */
 export const ESCALATION_RUNGS: readonly LadderRung[] = ["reroute", "consult", "convene"];
 
 function rungForTool(toolName: string): LadderRung | null {
@@ -146,6 +168,47 @@ export function classifyLadderActivity(
     filed,
     filedWithoutEscalating: filed && attemptedRungs.length === 0,
   };
+}
+
+/**
+ * The canonical rung-4 artifact (BI-33F1EA72).
+ *
+ * A blocker only the human can clear has no tool call behind it, so the reply
+ * IS the escalation. Before this existed the loop's only vocabulary for it was
+ * an apology — buildLocalToolCallFailureMessage told the user the coworker
+ * "wasn't strong enough to finish this" — which names a limitation and stops.
+ * A hand-off names the limitation and then does something with it.
+ *
+ * Three parts, all required:
+ *   blocker — what stopped the work, in the user's terms, one sentence.
+ *   steps   — the SHORTEST sequence that clears it. Imperative, numbered on
+ *             render, no explanation the step does not need.
+ *   verify  — what the coworker will re-check afterwards. This is the half that
+ *             makes it a hand-off rather than a brush-off: the work comes back.
+ *
+ * Kept as a formatter rather than free-form prose because the local tier is
+ * where this rung matters most and is least able to improvise it. Filling three
+ * named slots is a bounded task; composing a well-shaped hand-off from scratch
+ * is not (see the local-model priors in packages/db/src/local-model-capabilities.ts).
+ */
+export type HumanHandoff = {
+  blocker: string;
+  steps: readonly string[];
+  verify: string;
+};
+
+export function buildHumanHandoff(handoff: HumanHandoff): string {
+  const steps = handoff.steps
+    .map((step, index) => `${index + 1}. ${step}`)
+    .join("\n");
+
+  return [
+    handoff.blocker,
+    "",
+    steps,
+    "",
+    `Once that's done, tell me and I'll ${handoff.verify} — then pick this straight back up.`,
+  ].join("\n");
 }
 
 /**

--- a/changes/search-knowledge-availability-status.data-impact-exception.json
+++ b/changes/search-knowledge-availability-status.data-impact-exception.json
@@ -1,0 +1,9 @@
+{
+  "scope": "BI-339C441F. apps/web/lib/inference/semantic-memory.ts matches the [ai-context] persistent-surface rule, but the change is confined to the RETURN TYPE of searchPlatformKnowledge: it now answers a discriminated { status: \"ok\" | \"unavailable\" } instead of a bare array, so a caller can tell 'the corpus holds nothing' from 'the query could not be embedded, so the corpus was never queried'. No vector is written, read differently, or reshaped; QDRANT_COLLECTIONS.PLATFORM_KNOWLEDGE, the embedding call, the filter, the similarity threshold and the payload projection are all byte-identical. No asset, field, policy, or lifecycle change to any persistent surface occurred.",
+  "approver": "platform-architecture (autonomous; operator-directed delivery of the filed BI-339C441F remediation)",
+  "rationale": "A DataImpactManifest would have to fabricate change kinds for a stored surface whose shape did not change. The only new value in the system is an in-memory status discriminator on a function result. Callers were updated in the same commit and the type change surfaced a third caller (app/api/v1/ops/epics) that a documented convention would have missed.",
+  "compensatingControl": "apps/web/lib/inference/semantic-memory-availability.test.ts pins the distinction directly — an embedding failure and an empty corpus must not produce the same status, and the test asserts they carry identical results while differing in status. The full lib/inference suite (48 files, 504 tests) and the knowledge-pack handler suite pass on the success path, and tsc proves every caller was updated.",
+  "expiry": "2026-11-21T00:00:00.000Z",
+  "remediationBI": "BI-339C441F",
+  "waives": []
+}

--- a/packages/dpf-skill-pack/capability-packs.json
+++ b/packages/dpf-skill-pack/capability-packs.json
@@ -2,31 +2,62 @@
   {
     "id": "architecture",
     "label": "Architecture",
-    "skillIds": ["dpf-retrieve-decision-context", "dpf-compare-options", "dpf-decision-via-kernel", "dpf-architecture-review"]
+    "skillIds": [
+      "dpf-retrieve-decision-context",
+      "dpf-compare-options",
+      "dpf-decision-via-kernel",
+      "dpf-architecture-review"
+    ]
   },
   {
     "id": "design",
     "label": "Design",
-    "skillIds": ["dpf-retrieve-decision-context", "dpf-compare-options", "dpf-ux-fit-review", "dpf-capture-kernel-gap"]
+    "skillIds": [
+      "dpf-retrieve-decision-context",
+      "dpf-compare-options",
+      "dpf-ux-fit-review",
+      "dpf-capture-kernel-gap"
+    ]
   },
   {
     "id": "implementation",
     "label": "Implementation",
-    "skillIds": ["dpf-worktree-per-session", "dpf-worktree-hygiene", "dpf-use-shared-nonprod-environment", "dpf-evidence-before-diagnosis"]
+    "skillIds": [
+      "dpf-worktree-per-session",
+      "dpf-worktree-hygiene",
+      "dpf-use-shared-nonprod-environment",
+      "dpf-evidence-before-diagnosis",
+      "dpf-blast-radius"
+    ]
   },
   {
     "id": "verification",
     "label": "Verification",
-    "skillIds": ["dpf-evidence-before-diagnosis", "dpf-external-evidence-handoff", "dpf-record-decision-outcome"]
+    "skillIds": [
+      "dpf-evidence-before-diagnosis",
+      "dpf-external-evidence-handoff",
+      "dpf-record-decision-outcome"
+    ]
   },
   {
     "id": "review-ship",
     "label": "Review/Ship",
-    "skillIds": ["dpf-architecture-review", "dpf-pr-with-dco", "dpf-local-merge-ci-before-push", "dpf-record-decision-outcome"]
+    "skillIds": [
+      "dpf-architecture-review",
+      "dpf-pr-with-dco",
+      "dpf-local-merge-ci-before-push",
+      "dpf-record-decision-outcome",
+      "dpf-blast-radius",
+      "dpf-unslop"
+    ]
   },
   {
     "id": "recovery",
     "label": "Recovery",
-    "skillIds": ["dpf-evidence-before-diagnosis", "dpf-capture-kernel-gap", "dpf-use-shared-nonprod-environment"]
+    "skillIds": [
+      "dpf-evidence-before-diagnosis",
+      "dpf-capture-kernel-gap",
+      "dpf-use-shared-nonprod-environment"
+    ]
   }
 ]

--- a/packages/dpf-skill-pack/skills/dpf-architecture-review/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-architecture-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 # Single fields shared by both surfaces
 name: dpf-architecture-review
-description: "Use when reviewing or updating a DPF specification, design doc, or implementation plan for architectural alignment — in Build Studio planning/review or during external Claude/Codex development. Applies the chief-architect lens: canonical contracts, data-model stewardship, kernel principles, and standards research, producing advisory findings with concrete spec edits. Advisory by contract; it sharpens a spec, it does not gate a build."
+description: "Use when reviewing or updating a DPF specification, design doc, or implementation plan for architectural alignment — in Build Studio planning/review or during external Claude/Codex development. Applies the chief-architect lens: canonical contracts, data-model stewardship, kernel principles, and standards research, producing advisory findings with concrete spec edits."
 # Agent Skills standard fields (Surface A — Claude Code / Codex)
 disable-model-invocation: false
 user-invocable: true

--- a/packages/dpf-skill-pack/skills/dpf-blast-radius/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-blast-radius/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: dpf-blast-radius
+description: "Use before shipping a DPF change to find what it breaks somewhere else — a refactor, a renamed field, a contract/schema/enum edit, a shared helper, or a diff you do not trust. Traces callers, dependents and tests through the code graph, then proves the load-bearing facts by running code."
+disable-model-invocation: false
+user-invocable: true
+allowed-tools: Bash(git diff *) Bash(git log *) Grep Glob Read mcp__dpf__explain_blast_radius mcp__dpf__trace_code_surface mcp__dpf__search_code_graph mcp__dpf__find_related_tests
+category: platform
+assignTo: ["build-specialist", "platform-engineer", "ea-architect", "external-coding-agent"]
+capability: null
+taskType: analysis
+triggerPattern: "blast radius|what could this break|what depends on|impact of this change|safe to rename|who calls this|downstream effects|breaking change"
+userInvocable: true
+agentInvocable: true
+allowedTools: ["Bash", "mcp__dpf__explain_blast_radius", "mcp__dpf__trace_code_surface", "mcp__dpf__search_code_graph", "mcp__dpf__find_related_tests", "Grep", "Glob", "Read"]
+composesFrom: ["dpf-evidence-before-diagnosis", "dpf-verify-substrate-first"]
+contextRequirements: ["a committed or staged diff", "code graph reachable, and known to index the tree being changed"]
+riskBand: low
+enforces:
+  - kernel/principles/evidence-before-diagnosis
+  - kernel/principles/structural-verification-is-not-functional
+---
+
+# DPF Blast Radius
+
+`dpf-evidence-before-diagnosis` looks backward: a symptom exists, find its cause. This looks forward: a change exists, find what it breaks. Same discipline, opposite direction — and the same failure mode, which is believing a confident story instead of running something.
+
+## When to use
+
+- Renaming or removing a field, export, enum member, route, or tool.
+- Editing a shared helper, a contract, a schema, or anything under `packages/`.
+- Reviewing a diff whose author (including you, an hour ago) you are not sure about.
+- Someone asks "what could this break?"
+
+## When NOT to use
+
+- A leaf change with no importers — confirm that with one `Grep`, then stop. This skill is not a ceremony to perform on every diff.
+- A symptom already exists. That is `dpf-systematic-debugging`.
+- You have not yet decided what the change is. That is `dpf-brainstorming`.
+
+## Enforces
+
+- `kernel/principles/evidence-before-diagnosis` — the graph proposes; running code disposes.
+- `kernel/principles/structural-verification-is-not-functional` — "the types still compile" is not "it still works".
+
+## Steps
+
+1. **Establish the change surface.** `git diff` the committed tree. List every exported symbol, field, enum value, route, tool name, and file path the diff adds, renames, or removes. That list — not the file list — is the surface.
+
+2. **Verify the graph indexes the tree you are changing.** Before trusting any graph answer, confirm what it is reading. The portal's code search has previously answered from a stale checkout rather than the working tree (BI-6CFC5429), and a graph answering about the wrong tree returns confident, complete, wrong results. If you cannot establish which tree it indexed, treat the graph as a hint generator and let `Grep` be the authority.
+
+3. **Fan out on each symbol.** `mcp__dpf__explain_blast_radius` and `mcp__dpf__trace_code_surface` for the structural reach; `mcp__dpf__search_code_graph` for callers; `mcp__dpf__find_related_tests` for the tests that already cover it. Then `Grep` the raw string anyway — the graph misses dynamic references, string-keyed lookups, generated code, and anything in a language it does not parse.
+
+4. **Sweep the places the graph cannot see.** Each of these has broken a DPF change before and none of them are call edges:
+   - seed data and registries under `packages/db/data/` and `skills/`
+   - JSON baselines and allowlists under `scripts/*-baseline.*`
+   - prompt text and skill bodies that name a tool or field in prose
+   - migrations, and any `@@map` or column name a query builds by string
+   - CI guard scripts asserting on file contents
+
+5. **Name the load-bearing facts, then prove them by running code.** Reduce the finding to the one or two claims the whole conclusion rests on — "nothing outside this package imports it", "this enum value is never persisted". Prove each by running something: a test, a query, a script. Do not hand back a writeup whose confidence comes from having thought about it.
+
+   **Your own earlier reasoning in this thread is not evidence.** A conclusion you reached ten tool calls ago and have been building on since is exactly as unverified as it was then.
+
+6. **Report reach, risk, and what you ran.** Say which callers change behaviour versus merely recompile, which tests cover the change and which gap is uncovered, and name what you could NOT determine. An unverified corner reported as unverified is useful; the same corner reported as clear is a defect.
+
+## Guardrails
+
+- **An empty graph result is not "nothing depends on it".** It is one tool returning nothing. Confirm with `Grep` before concluding absence — absence is the hardest thing to establish and the easiest to assert.
+- **Compiling is not working.** Typecheck green means the shapes line up, not that behaviour survived.
+- **Do not fix what you find, here.** Blast radius reports. Folding repairs into the sweep loses the record of what the change actually reached.
+- **Report the reach even when it is inconvenient.** A blast radius that only ever comes back clear is not being run.
+
+## See also
+
+- Backward twin: [`dpf-evidence-before-diagnosis`](../dpf-evidence-before-diagnosis/SKILL.md)
+- Before claiming a concept is missing: [`dpf-verify-substrate-first`](../dpf-verify-substrate-first/SKILL.md)

--- a/packages/dpf-skill-pack/skills/dpf-brainstorming/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-brainstorming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-brainstorming
-description: "Use when an open problem needs candidate approaches before a decision — authoring a spec, scoping a feature, choosing a design. Generate 2-4 architecturally-distinct options grounded in the existing substrate (grep + code graph + specs) rather than invented in a vacuum, then hand off to dpf-decision-via-kernel when the options are distinct enough to weigh. The DPF-native ideation step; design docs land in docs/superpowers/specs/. Replaces the retired upstream superpowers brainstorming dependency."
+description: "Use when an open problem needs candidate approaches before a decision — authoring a spec, scoping a feature, choosing a design. Generate 2-4 architecturally-distinct options grounded in the existing substrate (grep + code graph + specs) rather than invented in a vacuum, then hand off to dpf-decision-via-kernel when the options are distinct enough to weigh. The DPF-native ideation step; design docs land in docs/superpowers/specs/."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: false

--- a/packages/dpf-skill-pack/skills/dpf-decision-via-kernel/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-decision-via-kernel/SKILL.md
@@ -1,7 +1,7 @@
 ---
 # Single fields shared by both surfaces
 name: dpf-decision-via-kernel
-description: "Use when working in the DPF codebase and facing an open question with 2+ architecturally-distinct options. Maps each option to the closed PRINCIPLE_DIMENSIONS registry, invokes the principle_decide MCP tool, surfaces the contribution ledger to the operator, and defers if a commandment conflict is flagged. Composes with dpf-brainstorming as the predecessor step. The DPF gate that sits in front of any decision the kernel can weigh."
+description: "Use when working in the DPF codebase and facing an open question with 2+ architecturally-distinct options. Maps each option to the closed PRINCIPLE_DIMENSIONS registry, invokes the principle_decide MCP tool, surfaces the contribution ledger to the operator, and defers if a commandment conflict is flagged. Composes with dpf-brainstorming as the predecessor step."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: false

--- a/packages/dpf-skill-pack/skills/dpf-elicit-tacit-knowledge/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-elicit-tacit-knowledge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-elicit-tacit-knowledge
-description: "Use in the DPF codebase when durable knowledge lives only in a human's head and needs to enter the system — a founder/operator decision rationale, the 'why' behind a choice, a profession technique, domain context a new build depends on. Researches what the system already knows, then conducts a focused progressive interview (one question at a time, drilling on the gaps) to draw out the tacit part, captures it in the shape it will be retrieved, and hands off to dpf-route-learning-to-commons. The acquisition step that precedes routing: getting knowledge OUT of the head is the bottleneck, not finding it later."
+description: "Use in the DPF codebase when durable knowledge lives only in a human's head and needs to enter the system — a founder/operator decision rationale, the 'why' behind a choice, a profession technique, domain context a new build depends on. Researches what the system already knows, then interviews in rounds of numbered questions with candidate answers to draw out the tacit part, and captures it in the shape it will be retrieved."
 disable-model-invocation: false
 user-invocable: true
 allowed-tools: Grep Glob mcp__dpf__wiki_query mcp__dpf__search_knowledge mcp__dpf__search_code_graph mcp__dpf__doc_save mcp__dpf__save_build_notes

--- a/packages/dpf-skill-pack/skills/dpf-elicit-tacit-knowledge/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-elicit-tacit-knowledge/SKILL.md
@@ -64,7 +64,28 @@ It is the **predecessor** to [`dpf-route-learning-to-commons`](../dpf-route-lear
 
 3. **Decide the retrieval shape first** (`shape-knowledge-for-retrieval`). State the question a future agent will ask to retrieve this knowledge. That determines the capture form (whole-document vs. typed entry vs. corpus technique) and which commons lane it will land in — and therefore what you need to ask.
 
-4. **Interview — one question at a time.** Ask a single focused question grounded in your research ("The code shows X; why was it built that way and when would you do it differently?"). Drill on vague answers; follow the thread the answer opens rather than reading a fixed list. Do not dump a questionnaire. Keep each turn short. Stop when new questions stop surfacing new knowledge — the well is dry, not when a quota is hit.
+4. **Interview in rounds, over a decision tree.** Map the gaps as a tree: every decision branches into the decisions that hang off it. The **frontier** is every decision whose prerequisites are already settled — ask only those. Settling a frontier decision exposes the next one, so the tree is worked in rounds rather than read as a fixed list.
+
+   Each round is a short **numbered list with candidate answers**:
+
+   ```
+   1. Who does the after-hours call reach first?
+      A. The on-call tech directly
+      B. A dispatcher who triages, then pages
+      C. An answering service that only takes a message
+   2. What overrides SLA tier?
+      A. Nothing — tier is the order
+      B. Life-safety, always
+      C. Geography when the tech is already nearby
+   ```
+
+   The human answers `1B, 2B, 3-none of these` in seconds. Cheap answers get answered; a paragraph-per-question interview quietly does not happen, and an interview that does not happen captures nothing.
+
+   Candidates must be **real competing positions**, not one obvious answer padded with strawmen — a candidate the human rejects teaches as much as one they pick, and "none of these" is the most informative reply on the list. Always leave it open. Keep a round to roughly 3-6 questions, and open the next round by drilling on anything answered "none of these" or accepted with a caveat.
+
+   Stop when the frontier is empty, or when a round stops surfacing new knowledge — the well is dry, not when a quota is hit.
+
+   This shape also survives a weak model. Composing six numbered questions with candidates is one bounded generation task; conducting an adaptive question-by-question interview is multi-turn planning, which is what low context retention breaks first. See the local-model priors in `packages/db/src/local-model-capabilities.ts`.
 
 5. **Capture in the retrieval shape, not the transcript** (`selective-memory-not-total-recall`). Write the decisions, rationale, and constraints — dense and structured for the query you named in step 3 — via `mcp__dpf__doc_save` (managed knowledge) or `mcp__dpf__save_build_notes` (build-context capture). Tag it with the role, phase, and topic the future query will filter on.
 
@@ -75,7 +96,8 @@ It is the **predecessor** to [`dpf-route-learning-to-commons`](../dpf-route-lear
 ## Guardrails
 
 - **Research is the price of admission.** If you ask the human something the system already knows, you have violated `do-the-work-dont-task-the-operator`. Ground every question in what you could not find.
-- **One question at a time; drill, don't dump.** A wall of questions gets shallow answers. A focused thread gets the tacit detail. This is an interview, not a form.
+- **Ask the frontier, not the tree.** A round holds only decisions whose prerequisites are settled. Questions that depend on an unanswered question get shallow answers, because the human is guessing at their own premise.
+- **Candidates, never a bare questionnaire.** A wall of open questions gets abandoned or answered thinly. The same questions with real candidate answers get answered — and the rejections carry as much signal as the picks. Never omit "none of these".
 - **Capture the judgment, not the chatter.** The output is decisions + rationale + constraints, not the raw Q&A. Re-derivable detail stays in its primary source.
 - **Durable only.** Don't elicit or capture knowledge that will be stale next week — that is noise, not memory.
 - **Bounded by the well, and by respect.** Stop when answers stop adding knowledge; never grind the operator past usefulness. Elicitation is sanctioned tasking of the operator *because the knowledge is genuinely impossible for the agent to get otherwise* — the moment it isn't, stop asking.
@@ -83,7 +105,7 @@ It is the **predecessor** to [`dpf-route-learning-to-commons`](../dpf-route-lear
 
 ## Worked example
 
-A coworker is about to build an after-hours dispatch flow. Research (step 2) finds the storefront archetype, the existing on-call schema, and a prior spec — but nothing on *how this operator actually triages calls*, which the build depends on. That is the gap. The coworker names the retrieval question (step 3): "How does a dispatcher triage after-hours calls for this archetype?" → a WSID profession technique, queried by the dispatcher corpus slug. It interviews (step 4): one question at a time — "Walk me through the last urgent after-hours call: what did you check first?" — drilling until the real rule emerges (life-safety → contractual SLA tier → geography), which no code revealed. It captures the rule and its rationale, structured for that query (step 5), confirms a search for "after-hours escalation" surfaces it (step 6), and hands to `dpf-route-learning-to-commons`, which routes it to the profession corpus and contributes it to the hive (step 7). The next build on any install reads the operator's real triage logic instead of guessing it.
+A coworker is about to build an after-hours dispatch flow. Research (step 2) finds the storefront archetype, the existing on-call schema, and a prior spec — but nothing on *how this operator actually triages calls*, which the build depends on. That is the gap. The coworker names the retrieval question (step 3): "How does a dispatcher triage after-hours calls for this archetype?" → a WSID profession technique, queried by the dispatcher corpus slug. It interviews (step 4): round one asks who the call reaches first and what overrides SLA tier, each with three candidate answers. The operator answers `1B, 2-none of these` in one line — and that rejection is the finding, because it says tier is not the top of the order. Round two drills exactly there and the real rule emerges: life-safety → contractual SLA tier → geography, which no code revealed. It captures the rule and its rationale, structured for that query (step 5), confirms a search for "after-hours escalation" surfaces it (step 6), and hands to `dpf-route-learning-to-commons`, which routes it to the profession corpus and contributes it to the hive (step 7). The next build on any install reads the operator's real triage logic instead of guessing it.
 
 ## See also
 

--- a/packages/dpf-skill-pack/skills/dpf-route-learning-to-commons/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-route-learning-to-commons/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-route-learning-to-commons
-description: "Use in the DPF codebase at a task or session boundary when a finding has been confirmed and is durable. Classifies the learning (decision rule -> WWMD, durable org/platform fact -> WWWD, role technique -> WSID/skill, code contract -> repo+AGENTS.md), drafts the right entry, files it through the existing governed pipeline, and contributes it to the hive so every agent and every install inherits it. The default destination for a confirmed learning is the shared commons; local client memory is a staging record at most."
+description: "Use in the DPF codebase at a task or session boundary when a finding has been confirmed and is durable. Classifies the learning (decision rule -> WWMD, durable org/platform fact -> WWWD, role technique -> WSID/skill, code contract -> repo+AGENTS.md), drafts the right entry, files it through the existing governed pipeline, and contributes it to the hive so every agent and every install inherits it."
 disable-model-invocation: false
 user-invocable: true
 allowed-tools: mcp__dpf__propose_improvement mcp__dpf__doc_save mcp__dpf__propose_skill_improvement mcp__dpf__create_backlog_item mcp__dpf__save_build_notes mcp__dpf__contribute_to_hive mcp__dpf__escalate_feedback_upstream mcp__dpf__flag_stale_knowledge

--- a/packages/dpf-skill-pack/skills/dpf-systematic-debugging/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-systematic-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-systematic-debugging
-description: "Use when a DPF symptom needs a root cause — a failing build, a wedged runtime, a stuck job, wrong output. Runs a 4-phase root-cause process, DPF-adapted: gather live evidence before any hypothesis, check whether a peer session/worktree is already acting on the same substrate before declaring it broken, verify the substrate before declaring something missing, and prove the fix functionally (a structural pass is not verification). The DPF-native debugging step; replaces the retired upstream superpowers systematic-debugging dependency."
+description: "Use when a DPF symptom needs a root cause — a failing build, a wedged runtime, a stuck job, wrong output. Runs a 4-phase root-cause process, DPF-adapted: gather live evidence before any hypothesis, check whether a peer session/worktree is already acting on the same substrate before declaring it broken, verify the substrate before declaring something missing, and prove the fix functionally (a structural pass is not verification)."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: false

--- a/packages/dpf-skill-pack/skills/dpf-unslop/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-unslop/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: dpf-unslop
+description: "Use before handing written output to a person — a PR body, backlog item, alert, wiki draft, spec, commit message, or coworker reply. Strips the tells that make text read as machine-written: puffery, superficial -ing clauses, chatbot filler, and sentences that would read identically in any other project's docs."
+disable-model-invocation: false
+user-invocable: true
+allowed-tools: Read Edit Grep
+category: docs
+assignTo: ["external-coding-agent", "platform-engineer", "build-specialist", "documentation-specialist", "doc-specialist"]
+capability: null
+taskType: conversation
+triggerPattern: "unslop|rewrite this|reads like AI|too wordy|tighten this|make this readable|PR body|backlog item body|release note|alert copy"
+userInvocable: true
+agentInvocable: true
+allowedTools: ["Read", "Edit", "Grep"]
+composesFrom: []
+contextRequirements: ["the text being edited, and what it is for"]
+riskBand: low
+enforces:
+  - kernel/principles/say-what-happened
+---
+
+# DPF Unslop
+
+Edit written output so a person will actually read it. Two halves, and skipping either one fails: remove the patterns that mark text as machine-written, then put something there instead. Sterile voiceless prose is as obviously generated as puffery is.
+
+> **Why this is not assigned to `*`.** Every skill assigned to a coworker
+> injects its summary into that coworker's system prompt on every turn, ranked
+> against `DEFAULT_SKILL_SUMMARY_CAP` in `apps/web/lib/skills/skill-relevance.ts`.
+> Style applies to all output, not just the turns a skill happens to be
+> retrieved on, so buying it a permanent eligibility slot on every coworker
+> would pay a per-turn cost for unreliable coverage. Business coworkers get
+> prose quality from the generated-output checks in `scripts/check-prose-lint.ts`
+> (BI-41F15FD7) instead. This is assigned to the dev-facing roles, where the
+> authored artifact IS the output.
+
+## When to use
+
+- Any text a human reads: PR bodies, backlog item bodies, commit messages, alert copy, wiki drafts, specs, release notes, coworker replies.
+- A draft that is accurate but nobody wants to read.
+- Before publishing anything to a surface a customer sees.
+
+## When NOT to use
+
+- Code, config, schemas, or test names. This is prose editing.
+- Text where the exact wording is load-bearing — a legal notice, a quoted commandment, an error string tests assert on.
+- As a substitute for having something to say. Unslop makes a real point readable; it cannot manufacture one.
+
+## Enforces
+
+- `kernel/principles/say-what-happened` — a sentence reports a fact, a number, or an instruction, or it goes.
+
+## Steps
+
+1. **Name the reader and what they must do next.** Everything below is judged against that. A PR body is read by a reviewer deciding whether to approve; an alert is read by someone deciding whether to act now.
+
+2. **Cut the four patterns.**
+
+   | Pattern | Looks like | Fix |
+   |---|---|---|
+   | Puffery | "pivotal", "testament to", "evolving landscape", "robust", "seamless" | Say what happened |
+   | Superficial `-ing` | "…, highlighting the need for", "…, ensuring reliability", "…, reflecting our commitment" | Delete the clause, or make it a sentence with a subject |
+   | Chatbot filler | "I hope this helps", "Let me know if", "Great question", "Certainly!" | Delete |
+   | Portable filler | any sentence that would be equally true in another project's docs | Delete |
+
+   The last one does the most work. Read each sentence and ask whether it could appear unchanged in an unrelated repo's README. If it could, it says nothing about this change and it goes.
+
+3. **Replace vague with specific.** Not "this is concerning" — "this fires on every turn for 17 of 68 skills". Not "the database stays close at hand" — "the query returns the exact string sent to the database". If a sentence cannot be restated as a concrete instruction, fact, or number, cut it.
+
+4. **Put a voice back.** Have an opinion where you have one, and say which way. React to a fact rather than listing it neutrally. Vary the rhythm — short sentences next to longer ones that take their time. Use "I" when you did the thing. Perfect parallel structure reads machine-made; let some asymmetry stand.
+
+5. **Self-audit.** Ask outright: what still makes this obviously generated? Fix what the answer names. This step catches what the checklist misses, which is most of it.
+
+## Guardrails
+
+- **Preserve meaning exactly.** Unslop is an editing pass, not a rewrite of the claim. If tightening changes what the sentence asserts, you have introduced an error, not removed slop.
+- **Never invent specifics to replace vagueness.** If "significant improvement" has no number behind it, find the number or drop the claim. Do not supply a plausible one.
+- **Match the register to the surface.** A customer-facing alert is not a commit message. Terse is not the goal; readable is.
+- **Do not soften a hard fact to make it read better.** "Tests fail" stays "tests fail".
+- **The em-dash is not the problem.** Overuse of any one construction is. Count your own.
+
+## Worked example
+
+Before: "This PR represents a pivotal step in our ongoing journey to enhance the robustness of the skills subsystem, ensuring improved reliability and highlighting our commitment to quality."
+
+After: "Every skill declared the same invocation triple, so the per-turn relevance ranker had nothing to rank on. 34 skills now declare their real classification, and a guard fails if a plane ever goes uniform again."
+
+The first sentence survives unchanged in any repo. The second could only be about this one.
+
+## See also
+
+- `docs/founder-kernel/wiki/principles/say-what-happened.md`
+- Prose quality for authored UI copy is ratcheted separately by `scripts/check-prose-lint.ts`.

--- a/packages/dpf-skill-pack/skills/dpf-verify-substrate-first/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-verify-substrate-first/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-verify-substrate-first
-description: "Use when working in the DPF codebase and tempted to propose a new substrate concept (table, type, enum value, capability, epic, MCP tool, agent role). The DPF architecture is denser than first reads suggest; the most common reflex of 'we'll need a new X' is wrong because X already exists. This skill walks the substrate-verification grep + live-backlog + main-branch sweep before the new-X claim is recorded. Has no upstream superpowers analog because it encodes DPF-specific substrate facts."
+description: "Use when working in the DPF codebase and tempted to propose a new substrate concept (table, type, enum value, capability, epic, MCP tool, agent role). The DPF architecture is denser than first reads suggest; the most common reflex of 'we'll need a new X' is wrong because X already exists. This skill walks the substrate-verification grep + live-backlog + main-branch sweep before the new-X claim is recorded."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: false

--- a/packages/dpf-skill-pack/skills/dpf-worktree-hygiene/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-worktree-hygiene/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-worktree-hygiene
-description: "Use when worktree or Build Studio sandbox disk is sprawling, when deciding whether to enable fleet janitor/GC flags, when running a dry-run or live Tier-A reap, or when leftovers remain after merges. Encodes primary session reaping vs flag-gated portal soak, dry-run default, explicit-go for live deletes, and junction-safe removal. Complements dpf-worktree-per-session (create) with the reaping/hygiene half."
+description: "Use when worktree or Build Studio sandbox disk is sprawling, when deciding whether to enable fleet janitor/GC flags, when running a dry-run or live Tier-A reap, or when leftovers remain after merges. Encodes primary session reaping vs flag-gated portal soak, dry-run default, explicit-go for live deletes, and junction-safe removal."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: false

--- a/packages/dpf-skill-pack/skills/dpf-worktree-per-session/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-worktree-per-session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-worktree-per-session
-description: "Use when starting, entering, auditing, or managing a concurrent DPF coding session that touches the working tree. Each thread gets its own git worktree (not a shared clone), seeded MCP config, isolated COMPOSE_PROJECT_NAME, and an explicit compile-ready vs source-only verification-readiness classification so agents do not claim unrun local gates. Composes with dpf-finishing-a-development-branch as the predecessor isolation step."
+description: "Use when starting, entering, auditing, or managing a concurrent DPF coding session that touches the working tree. Each thread gets its own git worktree (not a shared clone), seeded MCP config, isolated COMPOSE_PROJECT_NAME, and an explicit compile-ready vs source-only verification-readiness classification so agents do not claim unrun local gates."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: true

--- a/packages/dpf-skill-pack/skills/dpf-writing-plans/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-writing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-writing-plans
-description: "Use when a filed DPF backlog item needs an implementation plan before code is written — a multi-step build, a migration, a refactor with ordering constraints. A plan is for a BI, not for floating intent: file the BI first (dpf-file-backlog-item), then write a phased plan grounded in the existing substrate and saved to docs/superpowers/plans/. The DPF-native planning step; replaces the retired upstream superpowers writing-plans dependency."
+description: "Use when a filed DPF backlog item needs an implementation plan before code is written — a multi-step build, a migration, a refactor with ordering constraints. A plan is for a BI, not for floating intent: file the BI first (dpf-file-backlog-item), then write a phased plan grounded in the existing substrate and saved to docs/superpowers/plans/."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: false

--- a/scripts/lib/pregate-status.mjs
+++ b/scripts/lib/pregate-status.mjs
@@ -63,6 +63,57 @@ function rank(verdict) {
  *             candidateSha: string, staleness: string, evidenceId: string,
  *             recordedAt: string, expiresAt: string }}
  */
+/**
+ * BI-465B3D60. A failing gate record carries `status: "failed"`, `gatePassed:
+ * false`, and — in the observed cases — no failureReason, no error, and no
+ * failedCommand. `pnpm run pregate:status` could only say "this SHA has not
+ * passed", which reads as "your code is bad" when the actual event was losing a
+ * contended slot.
+ *
+ * That matters because local-integration-ci runs at effectiveCapacity 1 on a
+ * host that may have several sessions gating at once. A run that queued,
+ * started, and was released early is a RETRY, not a verdict on the diff.
+ *
+ * This is a reader, so it cannot fix the missing reason. It can stop presenting
+ * absence as a finding, and name the lease outcome the record does carry.
+ */
+function describeFailure(state, metadata) {
+  const status = state?.status || "unknown";
+  const stated = state?.failureReason || state?.error || metadata?.execution?.failedCommand;
+  if (stated) return `gate record status ${status} — ${typeof stated === "string" ? stated : "see the gate record"}`;
+
+  const events = Array.isArray(state?.leaseEvents) ? state.leaseEvents : [];
+  const started = events.some((e) => e?.type === "started");
+  const queued = events.some((e) => e?.type === "queued");
+  const replaced = events.some((e) => e?.type === "terminal-claim-replaced");
+
+  if (started && !stated) {
+    const suffix = queued || replaced
+      ? " The run held the slot and was released without recording a failing command, and this claim queued behind another session — a contended slot is a retry, not a verdict on your diff."
+      : " The run started and was released without recording a failing command, so this is not evidence that the diff is bad.";
+    return `gate record status ${status} with NO recorded reason — re-run before treating this as a real failure.${suffix}`;
+  }
+
+  return `gate record status ${status} with NO recorded reason — this SHA has not passed, but the record does not say why. Re-run pregate.`;
+}
+
+/**
+ * The two records are written by different processes, and the failing runs
+ * observed in BI-465B3D60 never rewrote dpf-local-ci-metadata.json at all — so
+ * it kept reporting the PREVIOUS run's `execution.status: "passed"`. Reading it
+ * after a failure yields a confident, wrong "it passed"; only the file mtime
+ * gave it away.
+ *
+ * Presence of the file was always checked. Freshness never was.
+ */
+function metadataDescribesAnotherRun(state, metadata) {
+  const boundSha = String(state?.sha || "");
+  const candidateSha = String(metadata?.candidateSha || "");
+  if (!boundSha || !candidateSha) return false;
+  if (boundSha === candidateSha) return false;
+  return true;
+}
+
 export function classifySlotRecord({ state, metadata, headSha, headBranch = "", now = Date.now() }) {
   const boundSha = String(state?.sha || "");
   const boundBranch = String(state?.branch || "");
@@ -108,7 +159,8 @@ export function classifySlotRecord({ state, metadata, headSha, headBranch = "", 
     return {
       ...base,
       verdict: "FAIL",
-      reason: `gate record status ${state.status || "unknown"} — this SHA has not passed`,
+      reason: describeFailure(state, metadata),
+      staleness: metadataDescribesAnotherRun(state, metadata) ? "metadata-describes-another-run" : "",
     };
   }
 

--- a/scripts/lib/pregate-status.test.mjs
+++ b/scripts/lib/pregate-status.test.mjs
@@ -169,3 +169,65 @@ test("a PASS report does not tell you to re-run", () => {
   );
   assert.ok(!lines.some((l) => l.includes("next")), "a PASS has no next step");
 });
+
+// BI-465B3D60 — a failing record must say why, or say that it cannot.
+const failingRecord = (over = {}) => ({
+  sha: "abc123", branch: "topic", status: "failed", gatePassed: false, ...over,
+});
+const atHead = { headSha: "abc123", headBranch: "topic" };
+
+test("failing record names the recorded reason when there is one", () => {
+  const out = classifySlotRecord({
+    state: failingRecord({ failureReason: "web typecheck exited 2" }),
+    metadata: null, ...atHead,
+  });
+  assert.equal(out.verdict, "FAIL");
+  assert.match(out.reason, /web typecheck exited 2/);
+});
+
+test("failing record says outright that no reason was recorded", () => {
+  // Rather than implying the diff is bad when the record simply does not say.
+  const out = classifySlotRecord({ state: failingRecord(), metadata: null, ...atHead });
+  assert.equal(out.verdict, "FAIL");
+  assert.match(out.reason, /NO recorded reason/);
+});
+
+test("a started-then-released run with no failing command is a retry, not a verdict", () => {
+  // The observed shape: the run held the slot, ended early, recorded nothing.
+  // local-integration-ci runs at effectiveCapacity 1 and several sessions on
+  // this host gate at once.
+  const out = classifySlotRecord({
+    state: failingRecord({
+      leaseEvents: [
+        { type: "terminal-claim-replaced" },
+        { type: "queued", queuePosition: 1 },
+        { type: "started" },
+        { type: "released" },
+      ],
+    }),
+    metadata: null, ...atHead,
+  });
+  assert.match(out.reason, /contended slot is a retry/);
+  assert.match(out.reason, /not a verdict on your diff/);
+});
+
+test("flags a metadata file that describes a different run", () => {
+  // The trap this closes: failing runs never rewrote the metadata, so it kept
+  // reporting the PREVIOUS run's success. Reading it after a failure yields a
+  // confident, wrong "it passed" — only the file mtime gave it away.
+  const out = classifySlotRecord({
+    state: failingRecord(),
+    metadata: { candidateSha: "oldersha", execution: { status: "passed", exitCode: 0 } },
+    ...atHead,
+  });
+  assert.equal(out.staleness, "metadata-describes-another-run");
+});
+
+test("does not flag the metadata when it describes this run", () => {
+  const out = classifySlotRecord({
+    state: failingRecord(),
+    metadata: { candidateSha: "abc123", execution: { status: "failed" } },
+    ...atHead,
+  });
+  assert.equal(out.staleness, "");
+});


### PR DESCRIPTION
Delivers the six backlog items left over from the skills-ecosystem review. **One commit per item**, so any single concern can be reverted alone.

> **Scope note.** This is six concerns in one PR, against `one-concern-per-pr`. That was raised and the instruction was to proceed as one PR. The commits are individually clean-revertible and the split is mechanical if a reviewer wants it.

## What lands

| # | Item | Change |
|---|---|---|
| 1 | BI-74C84A5F | `dpf-elicit-tacit-knowledge` interviews the frontier with candidate answers |
| 2 | BI-33F1EA72 | A fifth escalation-ladder rung for work only a human can do |
| 3 | BI-21A0FE70 | Recover 961 bytes of description budget, spend it on `dpf-unslop` + `dpf-blast-radius` |
| 4 | BI-41F15FD7 | Measure the slop density of generated prose |
| 5 | BI-339C441F | Stop reporting "nothing matched" when we never looked |
| 6 | BI-465B3D60 | A failing pregate record must say why, or say that it cannot |

### 1. Frontier interview (BI-74C84A5F)

Rounds over a decision tree replace "one open question at a time". A round is 3-6 numbered questions with real competing candidates and an always-open "none of these", answerable as `1B, 2-none`. An interview that costs a paragraph per question does not happen — and composing numbered questions with candidates is a *bounded generation* task, where an adaptive interview is multi-turn planning, which is what low context retention breaks first.

### 2. The hand-off rung (BI-33F1EA72)

The ladder was reroute / consult / convene / file — all four hand work to another agent or a queue. Nothing covered a blocker a *person* must clear. `buildLocalToolCallFailureMessage` previously ended on "I'm on a local AI that wasn't strong enough to finish this": honest about the limitation, then stopping. It now hands off — same facts, plus steps and the promise the work resumes.

`handoff` is deliberately **excluded** from `ESCALATION_RUNGS`. That list answers "did the coworker try a peer before filing", and counting a hand-off would let *"I told the user to fix it themselves, then filed anyway"* satisfy the guard that exists to catch exactly that. A test pins it.

### 3. Budget, then two skills (BI-21A0FE70)

The instruction plane sat at 38501 of a frozen 38501. Cut 961 bytes from ten descriptions — only clauses with zero trigger value ("replaces the retired upstream superpowers dependency", "advisory by contract"). Landed at **38215 of 38501, no re-baseline**.

`dpf-blast-radius` **fuses** the existing `explain_blast_radius` / `trace_code_surface` / `search_code_graph` / `find_related_tests` tools rather than adding substrate. `dpf-unslop` is assigned to dev-facing roles, **not** `*` — style applies to all output while a skill only applies on retrieved turns, so a universal assignment buys a permanent per-turn slot for unreliable coverage. The reason is written into the skill body.

### 4. Generated-prose gauge (BI-41F15FD7)

`check-prose-lint.ts` ratchets *authored* copy; nothing measured what a model writes. Bands by density so a long report isn't punished for length. The `-ing` detector is a **closed list** — participial clauses often carry real content — so it under-reports rather than fabricating. Observability only, mirroring `context-pressure.ts`.

A checker rather than a prompt rule, deliberately: a style block is followed unreliably at `instructionFollowingScore` 78/65, and is followed *at the cost of the task* on models whose weakest dimension is context retention.

### 5. Loud retrieval failure (BI-339C441F)

`searchPlatformKnowledge` answered `[]` when the query could not be embedded, making "the corpus holds nothing" and "I never queried the corpus" the same answer. That inverts a safety check — `create_backlog_item` and `dpf-file-backlog-item` both say search before you create, so with retrieval down the check returns its cleanest result exactly when least trustworthy. Now a discriminated `{status: "ok" | "unavailable"}`.

The type change **found a third caller I had missed by grep** (`app/api/v1/ops/epics`), which is the argument for a discriminated result over a documented convention.

### 6. Honest pregate failures (BI-465B3D60)

A failing record carried `status: "failed"` and no reason at all. Absence is now reported as absence; a queued/started/released run with no failing command is named a retry; and a metadata file whose `candidateSha` differs from the gate record is flagged as describing another run. **This fired for real during this PR's own gate run** — the first attempt failed at 39s against the 3:20 a pass takes, and the new message correctly called it a contended slot rather than a verdict.

## Evidence

- pregate `local-CI gate: PASS`, gated sha `f4e6f99157c1` = HEAD, evidence `cmt3t1w8g16t501mr370olqwc`, 3m13s
- pregate-preflight: 46 guards clean. Two failed first and were **fixed, not waived** — Module Size Guard (`agentic-loop.ts` 2812 → 2840; log block moved into `logGeneratedProse` and a superseded comment compacted, back to 2812) and Design Grounding Gate (full `## Design grounding` section in the final commit)
- 156 tests across prose / escalation-ladder / agentic-loop / knowledge-pack · 504 tests in `lib/inference` · 22 in `packages/db` · 19 in `pregate-status` · 7 process-spine
- `tsc --noEmit` clean; instruction-plane and module-size ratchets both OK with no re-baseline

Conformance caught two real defects in my own new work: the mirror-field invariant rejected `dpf-blast-radius` for granting `Bash` on Surface A but omitting it from `allowedTools`, and the type change surfaced the third `searchPlatformKnowledge` caller.

**Semantic review receipt is `inconclusive`, not a pass.** Three attempts returned `local-ci-active-capacity-reservation`: `local-integration-ci` runs at `effectiveCapacity: 1` and several sessions on this host gate concurrently, so the reviewer defers whenever any lease is active. That is a capacity state, not a finding — but no reviewer has read this diff, and it should get a human eye rather than being treated as reviewed.

## The biggest finding is not in this diff

While assigning `dpf-unslop` I measured both skill planes together. `seed-skills.ts` loads **both** into `SkillAssignment`, so 16 dev-pack skills carrying `assignTo: ["*"]` are eligible for every coworker on every turn. Real eligible sets are **21-44** against `DEFAULT_SKILL_SUMMARY_CAP = 12` — `build-specialist` is at 44. Every coworker is over the cap and the ranker is silently dropping most of each one's skills.

Filed as **BI-4B0C27D4**. It also means the cap guard on the sibling BI-8AD9D018 branch reads only `skills/**` and so certifies a bound it cannot see. Not fixed here, to avoid conflicting with that branch.

## Worth pressing on

1. The `generated-prose` thresholds (density ≥ 0.5, or ≥ 6 tells) are taste, not evidence. Documented as heuristic, and the gauge is observability-only for that reason — but derive them from a baseline before anything reads the zone.
2. The word lists will false-positive on legitimate uses ("robust" in a title, "in conclusion" inside a quoted document). Fine while nothing acts on the reading; not fine once it gates.
3. `buildHumanHandoff` hardcodes English scaffolding. It matches the surrounding code, but it is localization debt added rather than removed.
4. The `searchPlatformKnowledge` change touches a hot path. The success path is unchanged and 504 inference tests pass, but a caller reached by dynamic import would break at runtime, not compile time.
5. The pregate reader now *infers* "contended slot" from lease events rather than a recorded cause. Scoped to the case where no reason was recorded at all, but if the writer-side investigation finds a real failure mode with the same event shape, this message would excuse it.

## Not run

Full repo suite beyond the sandbox gate, and runtime/UX verification — no UI surface changed.

Closes BI-74C84A5F, BI-33F1EA72, BI-21A0FE70, BI-41F15FD7. Partially addresses BI-339C441F and BI-465B3D60 (the loud-degradation halves; both root causes stay open).

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Rebased onto main (2026-08-21)

Two merge commits appeared on this branch that I did not author. The reflog places them at local runs of `scripts/ci-policy-guards.mjs --profile pull-request`, and [#4432](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4432) — *"fix(ci): make pull-request guard non-mutating (BI-ADBF220E)"*, now on main — confirms that guard mutated the working branch. This branch predated the fix. The eight authored commits were rebased onto current main to drop the unauthored merges and restore linear, attributable history. Content is byte-identical; only parents and shas moved.

Two further PR-profile gates fired and were **answered, not waived**:

- **Data-Impact** on `[ai-context]`, because `semantic-memory.ts` matches the persistent-surface rule. The change is confined to a return type — the embedding call, collection, filter, threshold and payload projection are byte-identical — so a manifest would have to fabricate change kinds for a stored surface whose shape did not move. Filed as a structured exception with a real expiry and remediation BI, so disagreement has somewhere to land.
- **Docs-Impact** on three linked pages. The attestation says precisely what changed rather than claiming "no user-visible change": one user-visible string *did* change (the local-capability dead end became a hand-off), and none of the three flagged pages document it.

Re-verified on the rebased tree: pregate `PASS` on `264610e35e37` (evidence `cmt3twm7l19or01mruihz1nm4`, 5m29s) · preflight 46 guards clean · `ci-policy-guards --profile pull-request` all 7 passed with the real PR body and label · instruction-plane 38215/38501, no re-baseline · module-size no growth · 118 tests across `lib/skills`, `lib/prose`, `escalation-ladder` — the important post-rebase run, since BI-8AD9D018's cap guard is now on main and runs against this tree.

**No reviewer has read this diff.** Four `review_semantic_change` calls at `risk=high` returned `inconclusive` on `local-ci-active-capacity-reservation`, and two more timed out. `local-integration-ci` runs at `effectiveCapacity: 1` shared across several sessions on this host, so the reviewer defers whenever any lease is active. That is a capacity state and not a finding — but it means the receipt is not a pass, and this needs a human eye rather than being treated as reviewed.
