### PR TITLE
fix(compose): point the portal's PROJECT_ROOT at the tree builds actually edit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,7 +214,32 @@ services:
       DPF_BACKUPS_HOST_PATH: ${DPF_BACKUPS_HOST_PATH:-}
       DPF_SELF_UPGRADE_HOST_SOURCE_MOUNT: /host-dpf
       INSTANCE_TYPE: dev
-      PROJECT_ROOT: /workspace
+      # Agent codebase tools (search_project_files, list_project_directory,
+      # read_project_file, writeProjectFile) resolve through this root.
+      #
+      # It used to be `/workspace` — the `dpf-source-code` named volume. NOTHING
+      # POPULATES THAT VOLUME: no compose service, no script. Docker creates it
+      # empty and whatever seeded it once drifts forever. On 2026-08-19 it held a
+      # 2026-06-08 commit on a stray branch `my-changes` with 4,444 of the repo's
+      # ~10,000 files, so agent code search returned success=true with EMPTY
+      # results for files that plainly exist. The Build Studio ideate agent
+      # searched correctly, found nothing, looped, and the operator was told "the
+      # local AI wasn't strong enough — connect a stronger provider" (BI-6CFC5429).
+      #
+      # `/sandbox-workspace` is the `sandbox_workspace` volume the build sandboxes
+      # mount as their own `/workspace` — the tree a build actually edits, and
+      # already the intended target for writeProjectFile. Kernel decision
+      # DI-9EC6B0895748 selected it over the read-write host bind `/host-dpf`,
+      # which scored roughly half: `/host-dpf` reads current but would let agent
+      # tooling write into the operator's real git clone (negative contributions
+      # on "Least privilege, deny by default" and "Outbound and irreversible
+      # actions require explicit go").
+      #
+      # NOT changed in the sibling compose files, whose /workspace is populated:
+      # docker-compose.local-ci.yml binds a per-slot source volume from the slot
+      # manifest; docker-compose.dev-against-live-db.yml bind-mounts the dev
+      # worktree. Only this base file pointed at the orphaned volume.
+      PROJECT_ROOT: /sandbox-workspace
       SANDBOX_PREVIEW_URL: http://sandbox:3000
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       HIVE_CONTRIBUTION_TOKEN: ${HIVE_CONTRIBUTION_TOKEN:-}


### PR DESCRIPTION
## Why

Agent codebase tools — `search_project_files`, `list_project_directory`, `read_project_file`, `writeProjectFile` — all resolve through `PROJECT_ROOT`. The portal pointed it at `/workspace`, the `dpf-source-code` named volume.

**Nothing populates that volume.** No compose service, no script. Docker creates it empty, and whatever seeded it once drifts forever.

On 2026-08-19 it held commit `c5504514` (**2026-06-08**) on a stray branch `my-changes` with **4,444 of the repo's ~10,000 files**. So:

```
search_project_files{"owner-decision"}   -> success=true, results: []
list_project_directory{"apps/web/lib/attention"} -> "Directory not found"
search_code_graph{...}                   -> 0 results, indexStatus "ready", warnings []
```

…for a file that plainly exists. The Build Studio ideate agent searched correctly, found nothing, looped, and the runtime told the operator:

> *"I'm on a local AI that wasn't strong enough to finish this. Connecting a stronger provider unlocks the work I'm built for."*

An unpopulated docker volume was surfaced to the operator as a reason to buy inference.

## The change

One line: the portal's `PROJECT_ROOT` becomes `/sandbox-workspace` — the `sandbox_workspace` volume the build sandboxes mount as their own `/workspace`. That is the tree a build actually edits, and already the intended target for `writeProjectFile`.

### Verified on the running portal

```
/sandbox-workspace/apps/web/lib/attention/owner-decision-copy.ts   present
/sandbox-workspace  workspace sentinels                            both resolve
/workspace/apps/web/lib/attention                                  No such file or directory
```

That is the exact file the ideate agent could not find.

## Why not `/host-dpf`

`/host-dpf` is the unconditional read-write bind of the install's live source, already used by `DPF_REPO_ROOT`, and it reads *more* current than the sandbox. It was rejected.

`PROJECT_ROOT` is not only the agent **read** root — `codebase-tools.ts` exports `writeProjectFile`, which resolves through the same `getProjectRoot()` and calls `fs.writeFileSync`. Pointing it at `/host-dpf` would let agent tooling write into the operator's real git clone. Today those writes land in an isolated volume.

Routed through the kernel rather than decided by preference — **`principle_decide` → DI-9EC6B0895748**:

| Option | Composite | Note |
|---|---|---|
| **`/sandbox-workspace`** | **12.59** | selected |
| split read/write roots | 12.51 | near-tie; larger change, kept as a future refinement |
| `/host-dpf` | 6.66 | negative contributions on *Least privilege, deny by default* and *Outbound and irreversible actions require explicit go* |
| populate `/workspace` | 4.93 | keeps a third repo copy in play; no existing writer to model on |

Top contributor for the winner: *"Worktree is source-control isolation, not runtime isolation."* Margin (0.076) is below the tie threshold, so the kernel marks it advisory and recommends owner review — flagging that rather than presenting it as settled.

## Sibling compose files deliberately unchanged

Their `/workspace` **is** populated, so they are not broken:

- `docker-compose.local-ci.yml` binds a per-slot source volume from the slot manifest.
- `docker-compose.dev-against-live-db.yml` bind-mounts the dev worktree.

Only the base file pointed at the orphaned volume.

## Reviewer attention

- This is a **deployment-contract change**: it takes effect on portal recreate, and it changes which tree agent reads and writes resolve against for every install.
- `/sandbox-workspace` has its own staleness — the sandbox baseline was `4ed2c672` (2026-07-22). Sandbox-baseline refresh is a separate concern, not addressed here. This PR fixes *which tree*, not *how current that tree is*.
- Pairs with **#4433**, which adds the fail-loud sentinel guard so a wrong root is legible instead of silent. Either can land first; together they close BI-6CFC5429's root-resolution criteria.

## Verification

Compose-only; no application code. `pregate` preflight could not run to completion because four route derived artifacts (`route-manifest`, `route-audience`, `route-shells`, `page-purpose`) are **already stale on `origin/main`** — reproduced by checking out `HEAD~1` (i.e. exactly `origin/main`, zero changes) in the same worktree and seeing all four report STALE. Filed as **BI-C29A4334**; it currently blocks every branch before it can claim a lease. The push therefore carries a recorded `docs-adjacent` override naming that.

Local-CI-Override: docs-adjacent: compose-only PROJECT_ROOT repoint, no application code; pregate preflight blocked by four route derived artifacts already stale on origin/main (BI-C29A4334, proven by HEAD~1 checkout)
Docs-Impact-Decision: internal runtime path for portal agent tooling; no user-visible behaviour or doc changes. The three linked pages do not describe this setting — platform-overview.md's "/workspace" line describes the SANDBOX's workspace, which is unchanged (the sandbox still mounts sandbox_workspace:/workspace), and disaster-recovery.md never mentions PROJECT_ROOT or these volumes.
