### PR TITLE
fix(db): activate verified local provider routing

### DIFF
--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -206,6 +206,9 @@ hosts the local LLM behind an OpenAI-compatible endpoint at
 `http://model-runner.docker.internal/engines/v1`. The installer
 auto-detects this and sets `DPF_LLM_PROVIDER=model-runner` per the
 [provider contract](../superpowers/specs/2026-05-09-deployment-contracts.md).
+After a model pull is verified, first boot discovers that model and enables
+both the local provider and its routing connection automatically; no provider
+toggle is required before using an AI coworker.
 
 To use an external endpoint (Anthropic, OpenAI, hosted Ollama, etc.)
 instead, set `LLM_BASE_URL` in `.env` before re-running the installer:

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -138,6 +138,9 @@ On Windows, Docker Desktop ships **Docker Model Runner**, which hosts the
 local LLM behind an OpenAI-compatible endpoint. The installer auto-detects
 it and sets `DPF_LLM_PROVIDER=model-runner` per the
 [provider contract](../superpowers/specs/2026-05-09-deployment-contracts.md).
+After a model pull is verified, first boot discovers that model and enables
+both the local provider and its routing connection automatically; no provider
+toggle is required before using an AI coworker.
 
 To use an external endpoint (Anthropic, OpenAI, hosted Ollama, etc.) set
 `LLM_BASE_URL` in `.env` before re-running the installer:

--- a/packages/db/src/provider-connection.test.ts
+++ b/packages/db/src/provider-connection.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "../generated/client/client";
+
+import { activateProviderWithDefaultConnection } from "./provider-connection";
+
+describe("activateProviderWithDefaultConnection", () => {
+  it("activates the provider and its canonical connection in one transaction", async () => {
+    const transaction = {
+      modelProvider: { update: vi.fn().mockResolvedValue({}) },
+      aiProviderConnection: { update: vi.fn().mockResolvedValue({}) },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (work: (tx: typeof transaction) => Promise<void>) => work(transaction)),
+    };
+
+    await activateProviderWithDefaultConnection(prisma as unknown as PrismaClient, {
+      providerId: "local",
+      sensitivityClearance: ["public", "internal", "confidential", "restricted"],
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalledOnce();
+    expect(transaction.modelProvider.update).toHaveBeenCalledWith({
+      where: { providerId: "local" },
+      data: {
+        status: "active",
+        sensitivityClearance: ["public", "internal", "confidential", "restricted"],
+      },
+    });
+    expect(transaction.aiProviderConnection.update).toHaveBeenCalledWith({
+      where: { connectionId: "provider-default-local" },
+      data: { status: "active" },
+    });
+  });
+
+  it("surfaces a missing canonical connection so the transaction can roll back", async () => {
+    const missingConnection = new Error("canonical connection missing");
+    const transaction = {
+      modelProvider: { update: vi.fn().mockResolvedValue({}) },
+      aiProviderConnection: { update: vi.fn().mockRejectedValue(missingConnection) },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (work: (tx: typeof transaction) => Promise<void>) => work(transaction)),
+    };
+
+    await expect(
+      activateProviderWithDefaultConnection(prisma as unknown as PrismaClient, {
+        providerId: "local",
+        sensitivityClearance: ["public"],
+      }),
+    ).rejects.toBe(missingConnection);
+
+    expect(transaction.modelProvider.update).toHaveBeenCalledOnce();
+    expect(transaction.aiProviderConnection.update).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/db/src/provider-connection.ts
+++ b/packages/db/src/provider-connection.ts
@@ -66,6 +66,33 @@ export async function ensureDefaultProviderConnection(
   await refreshDefaultProviderConnectionOwners(prisma, entry.providerId);
 }
 
+/**
+ * Activate a provider and the canonical connection routing evaluates for it.
+ *
+ * Keeping these writes in one transaction prevents the provider registry from
+ * advertising an active provider while its default connection still vetoes
+ * dispatch. `update` is intentional: a missing canonical connection is an
+ * invariant violation and must roll back the provider activation.
+ */
+export async function activateProviderWithDefaultConnection(
+  prisma: PrismaClient,
+  input: { providerId: string; sensitivityClearance: string[] },
+): Promise<void> {
+  await prisma.$transaction(async (tx) => {
+    await tx.modelProvider.update({
+      where: { providerId: input.providerId },
+      data: {
+        status: "active",
+        sensitivityClearance: input.sensitivityClearance,
+      },
+    });
+    await tx.aiProviderConnection.update({
+      where: { connectionId: `provider-default-${input.providerId}` },
+      data: { status: "active" },
+    });
+  });
+}
+
 export async function refreshDefaultProviderConnectionOwners(
   prisma: PrismaClient,
   providerId: string,

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -93,7 +93,10 @@ import {
   localInputModalities,
   localOutputModalities,
 } from "./local-model-capabilities.js";
-import { ensureDefaultProviderConnection } from "./provider-connection.js";
+import {
+  activateProviderWithDefaultConnection,
+  ensureDefaultProviderConnection,
+} from "./provider-connection.js";
 import { seedIntegrationCoverage } from "../scripts/seed-integration-coverage.js";
 import { seedAbsorptionPosture } from "./seed-absorption-posture.js";
 import * as crypto from "crypto";
@@ -1696,12 +1699,9 @@ async function seedLocalModels(): Promise<void> {
     provider.status === "disabled" ||
     (provider.sensitivityClearance as string[]).length === 0
   ) {
-    await prisma.modelProvider.update({
-      where: { providerId: "local" },
-      data: {
-        status: "active",
-        sensitivityClearance: ["public", "internal", "confidential", "restricted"],
-      },
+    await activateProviderWithDefaultConnection(prisma, {
+      providerId: "local",
+      sensitivityClearance: ["public", "internal", "confidential", "restricted"],
     });
   }
 


### PR DESCRIPTION
## Summary

- activate a verified bundled local provider and its canonical routing connection atomically during fresh-install model discovery
- centralize that provider/connection invariant in one transactional helper, including rollback behavior when the canonical connection is missing
- document the automatic first-boot behavior for Windows and macOS installers

## Verification

- `pnpm --filter @dpf/db exec vitest run src/provider-connection.test.ts src/provider-trust-registry.test.ts` — 27/27 passed
- `pnpm --filter @dpf/db test` against a freshly migrated database — 2,290/2,290 passed
- `pnpm --filter @dpf/db typecheck` — passed
- 538 migrations plus the complete canonical seed against Docker Model Runner — passed; local provider `active`, canonical connection `active`, one active discovered model
- documentation impact, index, and link-integrity checks — passed
- governed manual merged-code fallback — passed; the automatic Windows runner stopped before product execution on the separately owned `pnpm` launcher defect in #4436

Backlog: BI-06873BE6
