### PR TITLE
fix(ui): make provider loading retry observable

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/loading.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/loading.test.tsx
@@ -1,12 +1,15 @@
 // @vitest-environment jsdom
-import { act, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import ProvidersLoading from "./loading";
 
-vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+const { refresh } = vi.hoisted(() => ({ refresh: vi.fn() }));
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh }) }));
 
 describe("ProvidersLoading", () => {
+  beforeEach(() => refresh.mockClear());
   afterEach(() => vi.useRealTimers());
 
   it("turns an indefinite skeleton into an actionable dependency failure", () => {
@@ -17,6 +20,15 @@ describe("ProvidersLoading", () => {
     act(() => vi.advanceTimersByTime(15_000));
 
     expect(screen.getByRole("alert").textContent).toMatch(/couldn.t load provider data/i);
-    expect(screen.getByRole("button", { name: /try again/i }).hasAttribute("disabled")).toBe(false);
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(screen.getByRole("status", { name: /loading provider data/i })).toBeTruthy();
+
+    act(() => vi.advanceTimersByTime(14_999));
+    expect(screen.getByRole("status", { name: /loading provider data/i })).toBeTruthy();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.getByRole("alert").textContent).toMatch(/couldn.t load provider data/i);
   });
 });

--- a/apps/web/app/(shell)/platform/ai/providers/loading.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/loading.tsx
@@ -4,37 +4,46 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/Button";
-import { Skeleton } from "@/components/ui/report-kit";
+import { Notice, Skeleton } from "@/components/ui/report-kit";
 
 const PROVIDER_LOAD_TIMEOUT_MS = 15_000;
 
 export default function ProvidersLoading() {
   const router = useRouter();
   const [timedOut, setTimedOut] = useState(false);
+  const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
     const timeout = window.setTimeout(() => setTimedOut(true), PROVIDER_LOAD_TIMEOUT_MS);
     return () => window.clearTimeout(timeout);
-  }, []);
+  }, [attempt]);
+
+  function retryProviderLoad() {
+    setTimedOut(false);
+    setAttempt((current) => current + 1);
+    router.refresh();
+  }
 
   if (timedOut) {
     return (
       <main className="mx-auto max-w-5xl p-4 sm:p-6">
-        <section
-          role="alert"
-          className="rounded-xl border border-[var(--dpf-warning)] bg-[var(--dpf-surface-1)] p-5 text-[var(--dpf-text)] shadow-sm"
-        >
-          <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-warning)]">
-            Provider service unavailable
-          </p>
-          <h1 className="mt-2 text-lg font-semibold">We couldn&apos;t load provider data</h1>
-          <p className="mt-2 max-w-2xl text-sm text-[var(--dpf-muted)]">
-            The local job service may still be starting. Your provider settings are safe; retry
-            after a moment or check Platform Health if this keeps happening.
-          </p>
-          <Button className="mt-4" onClick={() => router.refresh()}>
-            Try again
-          </Button>
+        <section role="alert" aria-labelledby="provider-load-failure-heading">
+          <Notice variant="warn" title="Provider service unavailable" className="p-5 shadow-sm">
+            <h1 id="provider-load-failure-heading" className="text-lg font-semibold">
+              We couldn&apos;t load provider data
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm text-[var(--dpf-muted)]">
+              The local job service may still be starting. Your provider settings are safe; retry
+              after a moment or check Platform Health if this keeps happening.
+            </p>
+            <Button
+              className="mt-4 min-h-11"
+              data-dpf-primary-action
+              onClick={retryProviderLoad}
+            >
+              Try again
+            </Button>
+          </Notice>
         </section>
       </main>
     );

--- a/docs/ux-fit/2026-08-22-provider-load-retry-state.ux-fit.json
+++ b/docs/ux-fit/2026-08-22-provider-load-retry-state.ux-fit.json
@@ -1,0 +1,17 @@
+{
+  "version": "1",
+  "decidedOption": "restart-bounded-cycle",
+  "decisionInteractionId": "DI-52066CC21D08",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/platform/ai/providers/loading.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "refresh-under-alert",
+      "restart-bounded-cycle"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- make **Try again** visibly re-enter the provider loading state and start a fresh 15-second recovery window
- preserve the bounded dependency-failure state when the refreshed provider data remains unavailable
- converge the failure presentation on the shared `Notice` primitive while retaining accessible status and alert semantics

## Verification
- TDD red/green coverage for refresh, visible loading recovery, and repeated timeout
- 4 related test files / 13 tests passed
- web typecheck, prose lint, style drift, UX primitive adoption, documentation integrity, and diff checks passed
- governed exhaustive exact-merge CI passed against current `origin/main`, including fresh migrations, full tests, production image build, and healthy runtime probes

## Tracking
- BI-DB71E580
- UX decision: DI-52066CC21D08