### PR TITLE
fix(promoter): a platform catalog change is a migration, not a wedge

### DIFF
--- a/scripts/lib/resolve-capability-compose-profiles.mjs
+++ b/scripts/lib/resolve-capability-compose-profiles.mjs
@@ -53,7 +53,29 @@ export function resolveCapabilityComposeProfiles({ catalog, state, hostPlatform,
   for (const entry of catalog.capabilities) if (entry.activationPolicy === "always") visit(entry.capabilityId);
   const enabledRuntimeCapabilities = sortedUnique(enabled);
   const capabilityStateVersion = computeCapabilityStateVersion(catalog.catalogHash, enabledRuntimeCapabilities, catalog.capabilities.map(({ capabilityId }) => capabilityId));
-  if (!unversioned && (state.capabilityCatalogHash !== catalog.catalogHash || state.capabilityStateVersion !== capabilityStateVersion)) throw new Error("capability_state_stale");
+  // Reconciliation, split by CAUSE — because the two look identical in a hash
+  // comparison and are opposite in meaning.
+  //
+  // A CATALOG change is the platform's own doing: shipping a release that adds
+  // or moves a service moves `catalogHash`, and every already-installed state
+  // then carries the previous one. That is precisely what `--migrate` is for,
+  // and refusing it wedges every pre-existing install — the upgrade that would
+  // restamp the state IS the blocked upgrade. (Observed: a release moving
+  // `inngest` into `runtime:core` failed promoter readiness with
+  // `capability_projection_failed` on an otherwise healthy install. The same
+  // self-wedging shape is called out for host identity in promote.sh.)
+  //
+  // A STATE-VERSION change with an UNCHANGED catalog is not the platform's
+  // doing: the enabled set was edited without restamping. Migration must never
+  // paper over that, so it still fails closed even under `--migrate`.
+  if (!unversioned) {
+    const catalogMoved = state.capabilityCatalogHash !== catalog.catalogHash;
+    if (catalogMoved) {
+      if (!migrate) throw new Error("capability_state_stale");
+    } else if (state.capabilityStateVersion !== capabilityStateVersion) {
+      throw new Error("capability_state_stale");
+    }
+  }
   for (const overlay of overlays) if (!OVERLAYS.has(overlay)) throw new Error(`unknown_lifecycle_profile:${overlay}`);
 
   const entries = enabledRuntimeCapabilities.map((id) => byId.get(id));

--- a/scripts/lib/resolve-capability-compose-profiles.test.mjs
+++ b/scripts/lib/resolve-capability-compose-profiles.test.mjs
@@ -57,6 +57,38 @@ test("stale catalog or state hash fails closed", async () => {
   assert.match(staleState.stderr, /^capability_state_stale\s*$/);
 });
 
+test("a platform catalog change migrates instead of wedging the install", async () => {
+  // The regression this guards: shipping a release that adds or moves a service
+  // moves `catalogHash`, so every already-installed state carries the previous
+  // one. Refusing that under --migrate wedges every pre-existing install,
+  // because the upgrade that would restamp the state IS the blocked upgrade.
+  // Observed live as promoter readiness `capability_projection_failed`.
+  const previousRelease = { ...snapshot(["runtime:core"]), capabilityCatalogHash: "0".repeat(64) };
+
+  const withoutMigrate = await run(previousRelease);
+  assert.equal(withoutMigrate.status, 2, "still fails closed without --migrate");
+  assert.match(withoutMigrate.stderr, /^capability_state_stale\s*$/);
+
+  const migrated = await run(previousRelease, "--migrate");
+  assert.equal(migrated.status, 0, migrated.stderr);
+  const projection = JSON.parse(migrated.stdout);
+  // The operator's chosen capabilities survive the migration untouched; only
+  // the platform's own version stamp moves.
+  assert.ok(projection.enabledRuntimeCapabilities.includes("runtime:core"));
+  assert.notEqual(projection.capabilityCatalogHash, "0".repeat(64));
+});
+
+test("an edited enabled-set is NOT papered over by --migrate", async () => {
+  // Opposite cause, identical-looking symptom. The catalog is unchanged, so a
+  // mismatched state version means the enabled set was edited without
+  // restamping. Migration must never accept that.
+  const base = snapshot(["runtime:core"]);
+  const tampered = { ...base, capabilityStateVersion: "0".repeat(64) };
+  const result = await run(tampered, "--migrate");
+  assert.equal(result.status, 2, "an unstamped edit must still fail closed under --migrate");
+  assert.match(result.stderr, /^capability_state_stale\s*$/);
+});
+
 test("a partial legacy capability snapshot fails closed instead of receiving defaults", async () => {
   const result = await run({ schemaVersion: 1, enabledRuntimeCapabilities: ["runtime:core"] }, "--migrate");
   assert.equal(result.status, 2);


### PR DESCRIPTION
**Every pre-existing install is currently unable to upgrade.** This restores the upgrade path.

Docs-Impact-Decision: no-docs-change (internal promoter readiness contract; no operator-facing surface changes)

## What happened

`SelfUpgradeRun SUR-BC816B0C` failed on a healthy install with
`promoter-readiness-failed: Promoter readiness check failed: capability_projection_failed`.

#4436 moved `inngest` into `runtime:core`. That is a correct change, and it legitimately moves
`catalogHash`. Every already-installed state carries the *previous* hash, and
`resolveCapabilityComposeProfiles` refused it:

```js
if (!unversioned && (state.capabilityCatalogHash !== catalog.catalogHash || ...)) throw new Error("capability_state_stale");
```

`--migrate` did not help. It only relaxed the **unversioned** (legacy) branch — never a *versioned*
state whose catalog had moved. And the write path that would restamp the state sits *after* that
throw, so `--write` could not recover either.

**The upgrade that would teach the state the new hash is the blocked upgrade.** That is the same
self-wedging shape already called out for host identity ten lines further down in `promote.sh`:

> demanding it wedges every pre-existing install, since the upgrade that teaches the caller to send it IS the blocked upgrade

## The fix

The two causes look identical in a hash comparison and are **opposite in meaning**, so they are split:

| Condition | Cause | Behaviour |
|---|---|---|
| catalog moved, state carries the old hash | the platform's own doing, on every release that touches the catalog | **this is what `--migrate` is for** — allowed under `--migrate`, still fails closed without it |
| catalog unchanged, state version differs | the enabled set was edited without restamping — not the platform's doing | **still fails closed, even under `--migrate`** |

Migration must never paper over the second case, so it does not.

## Verification — against the real install, not fixtures

The exact command promoter readiness runs, against the real `/Users/markbodman/.dpf/install-state.json`
and the real failing candidate tree (`b77e7508a`):

```
$ node scripts/lib/resolve-capability-compose-profiles.mjs \
    --state <install-state.json> --overlay promote --migrate
{"enabledRuntimeCapabilities":["runtime:browser-automation","runtime:build","runtime:core",
 "runtime:deep-observability","runtime:durable-automation","runtime:external-ai","runtime:local-speech"],
 "capabilityCatalogHash":"c83c56c0…","capabilityStateVersion":"f3099952…", …}
exit=0
```

Before: `capability_state_stale`, exit 2. All seven of the operator's enabled capabilities survive
untouched; only the platform's own version stamp moves.

Two new colocated tests cover both directions — the migration, and the refusal to paper over an
unstamped edit.

## Note for the reviewer

Two pre-existing tests in this file fail on macOS with `state_path_escape` (the `/var` symlink,
BI-745658D7). They fail identically with and without this change (11 pass / 2 fail either way) and
pass in the Linux gate.

Local gate: `pregate:status` = **PASS** for `20de273791c8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
