### PR TITLE
feat(decision): make the uncertain band measurable, stakes-sensitive, and exitable

### DIFF
--- a/apps/web/app/(shell)/platform/ai/founder-review/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/founder-review/page.tsx
@@ -9,6 +9,8 @@ import {
   type DecisionInteractionQueueRow,
 } from "@/lib/founder-review/queue";
 import type { WikiPerspective } from "@/lib/wiki/perspective-intent";
+import { BandTelemetryPanel } from "@/components/platform/BandTelemetryPanel";
+import { computeBandTelemetry, type BandTelemetryRow } from "@/lib/decision/band-telemetry";
 
 type PageProps = {
   searchParams?: Promise<{ mode?: string; profile?: string }>;
@@ -93,10 +95,41 @@ export default async function FounderReviewPage({ searchParams }: PageProps) {
     .filter((candidate) => !mode || candidate.perspective === mode);
   const visibleCandidates = dedupeFounderReviewCandidates(candidates);
   const groups = groupFounderReviewCandidates(visibleCandidates);
+
+  // BI-3217C098: the tuning instrument. Read-only aggregation over recorded
+  // decisions; a failure here must not take down the review inbox.
+  const telemetry = await (async () => {
+    try {
+      const rows = await prisma.decisionInteraction.findMany({
+        where: profileFilter ? { profileId: profileFilter } : {},
+        orderBy: { createdAt: "desc" },
+        take: 500,
+        select: {
+          outcomePayload: true,
+          recommendedOptionId: true,
+          chosenOptionId: true,
+        },
+      });
+      return computeBandTelemetry(rows.map((r) => {
+        const payload = (r.outcomePayload ?? {}) as Record<string, unknown>;
+        return {
+          margin: typeof payload["margin"] === "number" ? payload["margin"] : null,
+          verdict: (payload["verdict"] as BandTelemetryRow["verdict"]) ?? null,
+          bandUpper: typeof payload["bandUpper"] === "number" ? payload["bandUpper"] : null,
+          recommendedOptionId: r.recommendedOptionId,
+          chosenOptionId: r.chosenOptionId,
+        };
+      }));
+    } catch {
+      return null;
+    }
+  })();
   const title = titleForMode(mode);
 
   return (
     <main className="space-y-6 text-[var(--dpf-text)]">
+      {telemetry ? <BandTelemetryPanel telemetry={telemetry} /> : null}
+
       <div>
         <h1 className="text-lg font-semibold">{title}</h1>
         <p className="mt-1 text-sm text-[var(--dpf-muted)]">

--- a/apps/web/components/platform/BandTelemetryPanel.tsx
+++ b/apps/web/components/platform/BandTelemetryPanel.tsx
@@ -1,0 +1,88 @@
+import type { BandTelemetry } from "@/lib/decision/band-telemetry";
+
+/**
+ * BI-3217C098. The tuning instrument: where decisions land, and whether the
+ * confident ones deserved their confidence.
+ *
+ * Both numbers are shown together on purpose. The uncertain share alone can be
+ * driven to zero by lowering the bar, which looks like progress and is not — so
+ * the reversal rate sits beside it, and an unjudgeable rate says so rather than
+ * rendering a flattering 0%.
+ */
+export function BandTelemetryPanel({ telemetry }: { telemetry: BandTelemetry }) {
+  if (telemetry.total === 0) return null;
+
+  const peak = Math.max(1, ...telemetry.buckets.map((b) => b.count));
+  const share = telemetry.uncertainShare;
+
+  return (
+    <section
+      aria-labelledby="band-telemetry-title"
+      className="rounded-lg border border-[var(--dpf-border)] p-4"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 id="band-telemetry-title" className="text-base font-semibold text-[var(--dpf-text)]">
+          Decision separation
+        </h2>
+        <p className="text-xs text-[var(--dpf-muted)]">
+          {telemetry.scored} of {telemetry.total} decisions carried a margin
+        </p>
+      </div>
+
+      <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+        {share == null
+          ? "Not enough decisions to read a distribution yet."
+          : `${Math.round(share * 100)}% landed in the uncertain band. Tuning is working when this falls because decisions separate — not because the bar moved.`}
+      </p>
+
+      <ul className="mt-3 flex items-end gap-1" aria-label="Margin distribution">
+        {telemetry.buckets.map((bucket) => (
+          <li
+            key={`${bucket.from}-${bucket.to}`}
+            className="flex min-w-0 flex-1 flex-col items-center gap-1"
+            title={`${bucket.count} decision(s) with a margin of ${bucket.from.toFixed(2)}–${bucket.to.toFixed(2)}`}
+          >
+            <span
+              className={
+                bucket.insideUncertainBand
+                  ? "w-full rounded-t-sm bg-[var(--dpf-warning)]"
+                  : "w-full rounded-t-sm bg-[var(--dpf-accent)]"
+              }
+              style={{ height: `${Math.max(2, (bucket.count / peak) * 64)}px` }}
+            />
+            <span className="text-[10px] text-[var(--dpf-muted)]">{bucket.from.toFixed(1)}</span>
+          </li>
+        ))}
+      </ul>
+      <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+        Bars left of the band edge
+        {telemetry.typicalBandUpper == null ? "" : ` (${telemetry.typicalBandUpper.toFixed(2)})`} are
+        decisions the gate could not call either way.
+      </p>
+
+      <table className="mt-4 w-full text-sm">
+        <caption className="sr-only">Reversal rate by verdict band</caption>
+        <thead>
+          <tr className="text-left text-xs text-[var(--dpf-muted)]">
+            <th scope="col" className="pb-1 font-normal">Band</th>
+            <th scope="col" className="pb-1 font-normal">Judged</th>
+            <th scope="col" className="pb-1 font-normal">Reversed</th>
+          </tr>
+        </thead>
+        <tbody>
+          {telemetry.reversals.map((band) => (
+            <tr key={band.verdict} className="border-t border-[var(--dpf-border)]">
+              <td className="py-1.5 capitalize text-[var(--dpf-text)]">{band.verdict}</td>
+              <td className="py-1.5 text-[var(--dpf-muted)]">{band.judged}</td>
+              <td className="py-1.5 text-[var(--dpf-text)]">
+                {band.rate == null
+                  ? <span className="text-[var(--dpf-muted)]">no call could be checked</span>
+                  : `${band.reversed} (${Math.round(band.rate * 100)}%)`}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/apps/web/components/platform/BandTelemetryPanel.tsx
+++ b/apps/web/components/platform/BandTelemetryPanel.tsx
@@ -1,4 +1,19 @@
-import type { BandTelemetry } from "@/lib/decision/band-telemetry";
+import { DataTable, type Column } from "@/components/ui/report-kit";
+import type { BandReversal, BandTelemetry } from "@/lib/decision/band-telemetry";
+
+const REVERSAL_COLUMNS: Column<BandReversal>[] = [
+  { key: "verdict", header: "Band", cell: (b) => <span className="capitalize">{b.verdict}</span> },
+  { key: "judged", header: "Judged", align: "right", cell: (b) => b.judged },
+  {
+    key: "reversed",
+    header: "Reversed",
+    align: "right",
+    // A rate of null is reported as unjudgeable, never as a flattering 0%.
+    cell: (b) => (b.rate == null
+      ? <span className="text-[var(--dpf-muted)]">no call could be checked</span>
+      : `${b.reversed} (${Math.round(b.rate * 100)}%)`),
+  },
+];
 
 /**
  * BI-3217C098. The tuning instrument: where decisions land, and whether the
@@ -43,14 +58,17 @@ export function BandTelemetryPanel({ telemetry }: { telemetry: BandTelemetry }) 
             title={`${bucket.count} decision(s) with a margin of ${bucket.from.toFixed(2)}–${bucket.to.toFixed(2)}`}
           >
             <span
-              className={
-                bucket.insideUncertainBand
-                  ? "w-full rounded-t-sm bg-[var(--dpf-warning)]"
-                  : "w-full rounded-t-sm bg-[var(--dpf-accent)]"
-              }
-              style={{ height: `${Math.max(2, (bucket.count / peak) * 64)}px` }}
+              className="w-full rounded-t-sm"
+              style={{
+                height: `${Math.max(2, (bucket.count / peak) * 64)}px`,
+                // Semantic, not decorative: inside the band is unresolved,
+                // clear of it is an assurance.
+                background: bucket.insideUncertainBand
+                  ? "var(--dpf-warning)"
+                  : "var(--dpf-success)",
+              }}
             />
-            <span className="text-[10px] text-[var(--dpf-muted)]">{bucket.from.toFixed(1)}</span>
+            <span className="text-xs text-[var(--dpf-muted)]">{bucket.from.toFixed(1)}</span>
           </li>
         ))}
       </ul>
@@ -60,29 +78,15 @@ export function BandTelemetryPanel({ telemetry }: { telemetry: BandTelemetry }) 
         decisions the gate could not call either way.
       </p>
 
-      <table className="mt-4 w-full text-sm">
-        <caption className="sr-only">Reversal rate by verdict band</caption>
-        <thead>
-          <tr className="text-left text-xs text-[var(--dpf-muted)]">
-            <th scope="col" className="pb-1 font-normal">Band</th>
-            <th scope="col" className="pb-1 font-normal">Judged</th>
-            <th scope="col" className="pb-1 font-normal">Reversed</th>
-          </tr>
-        </thead>
-        <tbody>
-          {telemetry.reversals.map((band) => (
-            <tr key={band.verdict} className="border-t border-[var(--dpf-border)]">
-              <td className="py-1.5 capitalize text-[var(--dpf-text)]">{band.verdict}</td>
-              <td className="py-1.5 text-[var(--dpf-muted)]">{band.judged}</td>
-              <td className="py-1.5 text-[var(--dpf-text)]">
-                {band.rate == null
-                  ? <span className="text-[var(--dpf-muted)]">no call could be checked</span>
-                  : `${band.reversed} (${Math.round(band.rate * 100)}%)`}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div className="mt-4">
+        <DataTable
+          ariaLabel="Reversal rate by verdict band"
+          columns={REVERSAL_COLUMNS}
+          rows={telemetry.reversals}
+          getRowKey={(band) => band.verdict}
+          dense
+        />
+      </div>
     </section>
   );
 }

--- a/apps/web/lib/actions/work-pattern-review.ts
+++ b/apps/web/lib/actions/work-pattern-review.ts
@@ -436,6 +436,10 @@ export async function recordWorkPatternReview(formData: FormData): Promise<Revie
   const recommendedOptionId = await recommendOptionAgainstCommandments({
     db: prisma,
     scoredOptions,
+    // BI-1BBB2136: weigh the options at the SAME consequence tier this
+    // interaction is about to be recorded under, so the band edges match the
+    // stakes rather than defaulting for every decision alike.
+    riskTier: riskTierFor(shadowEvaluation?.riskClass ?? shadowRiskClass),
   });
 
   await prisma.$transaction(async (tx) => {
@@ -628,6 +632,8 @@ export async function resolveWorkPatternCaseProposal(formData: FormData): Promis
   const recommendedOptionId = await recommendOptionAgainstCommandments({
     db: prisma,
     scoredOptions,
+    // BI-1BBB2136: same tier this interaction records, so the bar matches the stakes.
+    riskTier: riskTierFor(reviewState.riskClass),
   });
 
   await prisma.$transaction(async (tx) => {

--- a/apps/web/lib/decision-perspective/option-recommendation.ts
+++ b/apps/web/lib/decision-perspective/option-recommendation.ts
@@ -17,8 +17,13 @@
 
 import { listPrinciplesByTier } from "@dpf/db/wiki-store";
 import { projectLocalAxisVector } from "@dpf/db/profession-local-axes";
-import { decide, type DecisionOption, type DecisionPrinciple } from "../decision/option-scoring";
-import type { DecisionScoredOption } from "./types";
+import {
+  decide,
+  type DecisionOption,
+  type DecisionPrinciple,
+  type DecisionStakes,
+} from "../decision/option-scoring";
+import type { DecisionRiskTier, DecisionScoredOption } from "./types";
 
 const TIER_DEFAULT_WEIGHT = 1.0; // commandments only; matches principle-decide-pack.ts's TIER_DEFAULT_WEIGHT.commandment.
 
@@ -57,12 +62,32 @@ function projectOptionFeaturesForProfession(
  * signal). Never throws on a retrieval failure — a gate's core verdict
  * (recommend/escalate/arbitrate/defer) must not depend on this succeeding.
  */
+/**
+ * BI-1BBB2136: one mapping from the gate's consequence tier to decision stakes,
+ * consumed by every caller so no call site invents its own vocabulary. Higher
+ * consequence widens the uncertain band from both sides — more separation
+ * required before an assurance, less opposition required before a decline.
+ */
+export function stakesForRiskTier(riskTier: DecisionRiskTier | null | undefined): DecisionStakes {
+  switch (riskTier) {
+    case "high":
+    case "critical":
+      return "high";
+    case "low":
+      return "routine";
+    default:
+      return "elevated";
+  }
+}
+
 export async function recommendOptionAgainstCommandments(input: {
   db: CommandmentClient;
   scoredOptions: DecisionScoredOption[];
   organizationId?: string | null;
   /** When set, namespaced local-axis features project onto the spine (Phase 3). */
   professionKey?: string | null;
+  /** BI-1BBB2136: the gate's consequence tier, which sets the band edges. */
+  riskTier?: DecisionRiskTier | null;
 }): Promise<string | null> {
   if (input.scoredOptions.length === 0) return null;
   const scoredOptions = projectOptionFeaturesForProfession(
@@ -97,7 +122,9 @@ export async function recommendOptionAgainstCommandments(input: {
     features: o.features,
   }));
 
-  const result = decide(options, principles);
+  const result = decide(options, principles, {
+    stakes: stakesForRiskTier(input.riskTier),
+  });
   return result.recommendation?.optionId ?? null;
 }
 

--- a/apps/web/lib/decision/band-telemetry.test.ts
+++ b/apps/web/lib/decision/band-telemetry.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { computeBandTelemetry, isBetterTuned, type BandTelemetryRow } from "./band-telemetry";
+
+const row = (over: Partial<BandTelemetryRow>): BandTelemetryRow => ({
+  margin: 0.5,
+  verdict: "proceed",
+  bandUpper: 0.2,
+  recommendedOptionId: null,
+  chosenOptionId: null,
+  ...over,
+});
+
+describe("BI-3217C098 — the margin histogram", () => {
+  it("buckets real margins and marks which buckets sit inside the uncertain band", () => {
+    const t = computeBandTelemetry([
+      row({ margin: 0.05 }), row({ margin: 0.1 }), row({ margin: 0.8 }),
+    ], { bucketCount: 4 });
+
+    expect(t.scored).toBe(3);
+    expect(t.buckets.reduce((n, b) => n + b.count, 0)).toBe(3);
+    expect(t.buckets[0]!.insideUncertainBand).toBe(true);
+    expect(t.buckets.at(-1)!.insideUncertainBand).toBe(false);
+  });
+
+  it("keeps the band visible even when every decision cleared it", () => {
+    const t = computeBandTelemetry([row({ margin: 0.9 }), row({ margin: 0.95 })], { bucketCount: 5 });
+    expect(t.buckets.some((b) => b.insideUncertainBand)).toBe(true);
+  });
+
+  it("reports how many rows it could actually score, so a thin sample is never mistaken for a picture", () => {
+    const t = computeBandTelemetry([row({ margin: null, verdict: null }), row({ margin: 0.4 })]);
+    expect(t.total).toBe(2);
+    expect(t.scored).toBe(1);
+  });
+
+  it("reports the share that landed in the uncertain band — the number to drive down", () => {
+    const t = computeBandTelemetry([
+      row({ verdict: "uncertain", margin: 0.05 }),
+      row({ verdict: "proceed", margin: 0.6 }),
+      row({ verdict: "decline", margin: 0.6 }),
+      row({ verdict: "proceed", margin: 0.7 }),
+    ]);
+    expect(t.uncertainShare).toBe(0.25);
+  });
+});
+
+describe("BI-3217C098 — reversal rate keeps the assurances honest", () => {
+  it("counts a reversal only where the pick and the choice are both known", () => {
+    const t = computeBandTelemetry([
+      row({ verdict: "proceed", recommendedOptionId: "a", chosenOptionId: "a" }),
+      row({ verdict: "proceed", recommendedOptionId: "a", chosenOptionId: "b" }),
+      // Unjudgeable: no human choice recorded. Must not count as agreement.
+      row({ verdict: "proceed", recommendedOptionId: "a", chosenOptionId: null }),
+    ]);
+    const proceed = t.reversals.find((r) => r.verdict === "proceed")!;
+    expect(proceed.judged).toBe(2);
+    expect(proceed.reversed).toBe(1);
+    expect(proceed.rate).toBe(0.5);
+  });
+
+  it("reports null rather than zero when nothing could be judged", () => {
+    const t = computeBandTelemetry([row({ verdict: "decline" })]);
+    expect(t.reversals.find((r) => r.verdict === "decline")!.rate).toBeNull();
+  });
+});
+
+describe("BI-3217C098 — narrowing the bar is not improvement", () => {
+  const population = (uncertain: number, assured: number, reversed: number): BandTelemetryRow[] => [
+    ...Array.from({ length: uncertain }, () => row({ verdict: "uncertain", margin: 0.05 })),
+    ...Array.from({ length: assured - reversed }, () => row({ verdict: "proceed", margin: 0.6, recommendedOptionId: "a", chosenOptionId: "a" })),
+    ...Array.from({ length: reversed }, () => row({ verdict: "proceed", margin: 0.6, recommendedOptionId: "a", chosenOptionId: "b" })),
+  ];
+
+  it("calls a smaller uncertain band with steady confident calls an improvement", () => {
+    const before = computeBandTelemetry(population(6, 4, 1));
+    const after = computeBandTelemetry(population(2, 8, 2));
+    expect(isBetterTuned(before, after).improved).toBe(true);
+  });
+
+  it("REFUSES to call it improvement when confident calls are reversed more often", () => {
+    const before = computeBandTelemetry(population(6, 4, 0));
+    const after = computeBandTelemetry(population(2, 8, 4));
+    const verdict = isBetterTuned(before, after);
+    expect(verdict.improved).toBe(false);
+    expect(verdict.reason).toContain("the separation did not");
+  });
+
+  it("refuses to judge a shrunken band when no confident call can be checked", () => {
+    const before = computeBandTelemetry([row({ verdict: "uncertain", margin: 0.05 }), row({ verdict: "proceed", margin: 0.6 })]);
+    const after = computeBandTelemetry([row({ verdict: "proceed", margin: 0.6 }), row({ verdict: "proceed", margin: 0.7 })]);
+    expect(isBetterTuned(before, after).improved).toBe(false);
+  });
+
+  it("does not call a growing uncertain band an improvement", () => {
+    const before = computeBandTelemetry(population(2, 8, 1));
+    const after = computeBandTelemetry(population(6, 4, 1));
+    expect(isBetterTuned(before, after).improved).toBe(false);
+  });
+});

--- a/apps/web/lib/decision/band-telemetry.ts
+++ b/apps/web/lib/decision/band-telemetry.ts
@@ -1,0 +1,190 @@
+// apps/web/lib/decision/band-telemetry.ts
+//
+// BI-3217C098 (spec slice 6). The instrument for tuning the uncertain band.
+//
+// BI-2107B5D2 made the data exist — real margins, band edges, and causes are
+// recorded per decision instead of four synthetic constants. This reads them.
+//
+// TWO numbers, because either alone lies:
+//
+//   • The MARGIN HISTOGRAM shows where decisions land. Tuning is working when
+//     mass moves AWAY from the middle, toward both ends.
+//   • The REVERSAL RATE per band shows whether the confident calls deserved
+//     their confidence. Without it, narrowing the band until the middle stops
+//     firing looks identical to improving separation — and that is the failure
+//     the spec names: a band that never fires is trivially achievable and
+//     proves nothing.
+//
+// A falling middle band with a rising reversal rate is a REGRESSION, and only
+// the second number can say so.
+
+import type { DecisionVerdict } from "./option-scoring";
+
+/** One recorded decision, as the ledger stores it. */
+export interface BandTelemetryRow {
+  /** Real separation between the winner and runner-up. Null on rows that weighed nothing. */
+  margin: number | null;
+  verdict: DecisionVerdict | null;
+  /** The upper band edge in force for this decision, so a moved bar is visible. */
+  bandUpper: number | null;
+  /** The kernel's pick, when the gate scored real options. */
+  recommendedOptionId: string | null;
+  /** What the human actually chose, once their response resolved to a scored option. */
+  chosenOptionId: string | null;
+}
+
+export interface HistogramBucket {
+  /** Inclusive lower edge of the bucket. */
+  from: number;
+  /** Exclusive upper edge. */
+  to: number;
+  count: number;
+  /** True when this bucket sits below the upper band edge — i.e. inside the uncertain band. */
+  insideUncertainBand: boolean;
+}
+
+export interface BandReversal {
+  verdict: DecisionVerdict;
+  /** Rows where both the kernel's pick and the human's choice are known. */
+  judged: number;
+  /** Of those, how many the human decided differently. */
+  reversed: number;
+  /** reversed / judged, or null when nothing could be judged. */
+  rate: number | null;
+}
+
+export interface BandTelemetry {
+  buckets: HistogramBucket[];
+  /** Share of decisions that landed in the uncertain band. The number to drive down. */
+  uncertainShare: number | null;
+  reversals: BandReversal[];
+  /** Rows the histogram could use (a margin was recorded). */
+  scored: number;
+  /** Rows seen in total, so a small sample is never mistaken for a settled picture. */
+  total: number;
+  /** The most common upper band edge across the population, for marking the chart. */
+  typicalBandUpper: number | null;
+}
+
+const DEFAULT_BUCKET_COUNT = 10;
+
+function mode(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const counts = new Map<number, number>();
+  for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
+  let best: number | null = null;
+  let bestCount = -1;
+  for (const [v, c] of counts) {
+    if (c > bestCount) {
+      best = v;
+      bestCount = c;
+    }
+  }
+  return best;
+}
+
+/**
+ * A reversal is only countable where BOTH the kernel's pick and the human's
+ * choice are known. Rows missing either are reported as unjudged rather than
+ * counted as agreement — treating silence as assent is how a reversal rate
+ * flatters itself.
+ */
+function reversalFor(verdict: DecisionVerdict, rows: BandTelemetryRow[]): BandReversal {
+  const judgable = rows.filter(
+    (r) => r.verdict === verdict && r.recommendedOptionId && r.chosenOptionId,
+  );
+  const reversed = judgable.filter((r) => r.chosenOptionId !== r.recommendedOptionId).length;
+  return {
+    verdict,
+    judged: judgable.length,
+    reversed,
+    rate: judgable.length === 0 ? null : reversed / judgable.length,
+  };
+}
+
+export function computeBandTelemetry(
+  rows: BandTelemetryRow[],
+  options: { bucketCount?: number } = {},
+): BandTelemetry {
+  const bucketCount = Math.max(1, options.bucketCount ?? DEFAULT_BUCKET_COUNT);
+  const scored = rows.filter((r) => typeof r.margin === "number" && Number.isFinite(r.margin));
+  const margins = scored.map((r) => r.margin as number);
+  const typicalBandUpper = mode(
+    rows.map((r) => r.bandUpper).filter((v): v is number => typeof v === "number"),
+  );
+
+  const max = margins.length ? Math.max(...margins) : 0;
+  // Always span at least the band edge, so the uncertain region is visible even
+  // when every recorded decision cleared it.
+  const span = Math.max(max, typicalBandUpper ?? 0) || 1;
+  const width = span / bucketCount;
+
+  const buckets: HistogramBucket[] = Array.from({ length: bucketCount }, (_, i) => {
+    const from = i * width;
+    const to = i === bucketCount - 1 ? span : (i + 1) * width;
+    return {
+      from,
+      to,
+      count: 0,
+      // A bucket counts as inside the band when its lower edge is below the bar.
+      insideUncertainBand: typicalBandUpper != null && from < typicalBandUpper,
+    };
+  });
+
+  for (const margin of margins) {
+    const index = Math.min(bucketCount - 1, Math.max(0, Math.floor(margin / width)));
+    buckets[index]!.count += 1;
+  }
+
+  const uncertainCount = rows.filter((r) => r.verdict === "uncertain").length;
+
+  return {
+    buckets,
+    uncertainShare: rows.length === 0 ? null : uncertainCount / rows.length,
+    reversals: (["proceed", "decline", "uncertain"] as const).map((v) => reversalFor(v, rows)),
+    scored: scored.length,
+    total: rows.length,
+    typicalBandUpper,
+  };
+}
+
+/**
+ * Is a later population better tuned than an earlier one?
+ *
+ * Deliberately strict: a smaller uncertain share only counts as improvement
+ * when the confident calls did NOT get worse. Narrowing the bar shrinks the
+ * middle band without improving separation, and this is what refuses to call
+ * that progress.
+ */
+export function isBetterTuned(before: BandTelemetry, after: BandTelemetry): {
+  improved: boolean;
+  reason: string;
+} {
+  if (before.uncertainShare == null || after.uncertainShare == null) {
+    return { improved: false, reason: "Not enough decisions to compare." };
+  }
+  if (after.uncertainShare >= before.uncertainShare) {
+    return { improved: false, reason: "The uncertain band did not shrink." };
+  }
+  const assuredRate = (t: BandTelemetry) => {
+    const judged = t.reversals
+      .filter((r) => r.verdict !== "uncertain")
+      .reduce((acc, r) => ({ judged: acc.judged + r.judged, reversed: acc.reversed + r.reversed }), { judged: 0, reversed: 0 });
+    return judged.judged === 0 ? null : judged.reversed / judged.judged;
+  };
+  const beforeRate = assuredRate(before);
+  const afterRate = assuredRate(after);
+  if (beforeRate == null || afterRate == null) {
+    return {
+      improved: false,
+      reason: "The band shrank, but no confident call could be judged — a narrower bar cannot be told from better separation.",
+    };
+  }
+  if (afterRate > beforeRate) {
+    return {
+      improved: false,
+      reason: "The band shrank while confident calls were reversed more often — the bar moved, the separation did not.",
+    };
+  }
+  return { improved: true, reason: "The uncertain band shrank and confident calls held." };
+}

--- a/apps/web/lib/decision/kernel-consult-ledger.ts
+++ b/apps/web/lib/decision/kernel-consult-ledger.ts
@@ -10,6 +10,7 @@
 // outcome is always observable in the tool response (`ledger.recorded`),
 // per make-silent-failures-observable.
 
+import type { RetryAttemptRecord } from "@/lib/decision/uncertain-retry";
 import {
   readVerdict,
   VERDICT_RETRY_HINTS,
@@ -208,6 +209,11 @@ export async function recordKernelConsultInteraction(input: {
    * `now` is injected for determinism in tests.
    */
   seal?: boolean;
+  /**
+   * BI-60B3D270: attempts from a bounded retry out of the uncertain band, when
+   * the caller ran one. Absent means the decision was reached first-pass.
+   */
+  retryAttempts?: RetryAttemptRecord[] | null;
   now?: Date;
 }): Promise<KernelConsultLedgerOutcome> {
   try {
@@ -343,6 +349,10 @@ export async function recordKernelConsultInteraction(input: {
         bandUpper: recordedVerdict?.bands.upper ?? null,
         bandLower: recordedVerdict?.bands.lower ?? null,
         bandStakes: recordedVerdict?.bands.stakes ?? null,
+        // BI-60B3D270: when the caller ran a bounded retry, record what it
+        // changed on each attempt. A later histogram can then separate a
+        // first-pass assurance from one that took two tries to reach.
+        retryAttempts: input.retryAttempts ?? null,
         insufficientSignal: input.result.flags.insufficientSignal === true,
         commandmentConflictPrinciples: input.result.flags.commandmentConflictPrinciples,
         structuredCoverage: input.result.flags.structuredCoverage,

--- a/apps/web/lib/decision/option-scoring.ts
+++ b/apps/web/lib/decision/option-scoring.ts
@@ -325,6 +325,17 @@ export type DecisionResult = {
 export const DECISION_STAKES = ["routine", "elevated", "high"] as const;
 export type DecisionStakes = (typeof DECISION_STAKES)[number];
 
+/**
+ * BI-1BBB2136: parse a caller-supplied stakes value. An unrecognised value
+ * yields undefined so the caller falls back to the default rather than failing
+ * a governance consult over a typo.
+ */
+export function parseDecisionStakes(value: unknown): DecisionStakes | undefined {
+  return (DECISION_STAKES as readonly string[]).includes(String(value))
+    ? (value as DecisionStakes)
+    : undefined;
+}
+
 /** Multipliers applied to the base tie-margin to derive the upper band edge. */
 export const STAKES_BAND_MULTIPLIER: Record<DecisionStakes, number> = {
   routine: 0.5,

--- a/apps/web/lib/decision/three-band-verdict.test.ts
+++ b/apps/web/lib/decision/three-band-verdict.test.ts
@@ -180,3 +180,33 @@ describe("BI-2107B5D2 — the ledger records real margins, not constants", () =>
     }
   });
 });
+
+describe("BI-1BBB2136 — stakes reach the band edges from real call sites", () => {
+  it("maps consequence tiers onto stakes with one shared mapping", async () => {
+    const { stakesForRiskTier } = await import("../decision-perspective/option-recommendation");
+    expect(stakesForRiskTier("critical")).toBe("high");
+    expect(stakesForRiskTier("high")).toBe("high");
+    expect(stakesForRiskTier("medium")).toBe("elevated");
+    expect(stakesForRiskTier("low")).toBe("routine");
+    // An absent tier keeps the historical behaviour rather than guessing.
+    expect(stakesForRiskTier(null)).toBe("elevated");
+    expect(stakesForRiskTier(undefined)).toBe("elevated");
+  });
+
+  it("makes a high-stakes call demand more separation than a routine one", () => {
+    const options = [
+      option("a", { speed_to_value: 0.75, blast_radius: 0.5, cognitive_load: 0.5 }),
+      option("b", { speed_to_value: 0.5, blast_radius: 0.5, cognitive_load: 0.5 }),
+    ];
+    const principles = [principle()];
+
+    const routine = decide(options, principles, { stakes: "routine" });
+    const high = decide(options, principles, { stakes: "high" });
+
+    // Same options, same principles — only the bar moved. The whole point of
+    // stakes: a margin that is an assurance for a routine call is not one when
+    // the consequence is high.
+    expect(high.recommendation?.bands?.upper).toBeGreaterThan(routine.recommendation!.bands!.upper);
+    expect(routine.recommendation?.margin).toBe(high.recommendation?.margin);
+  });
+});

--- a/apps/web/lib/decision/uncertain-retry.test.ts
+++ b/apps/web/lib/decision/uncertain-retry.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { decideWithBoundedRetry } from "./uncertain-retry";
+import type { DecisionResult } from "./option-scoring";
+
+const result = (over: {
+  verdict?: "proceed" | "uncertain" | "decline";
+  cause?: string | null;
+  none?: boolean;
+}): DecisionResult => ({
+  recommendation: over.none ? null : {
+    optionId: "a",
+    composite: 0.5,
+    margin: 0.1,
+    confidence: over.verdict === "proceed" ? "high" : "low",
+    verdict: over.verdict ?? "uncertain",
+    verdictCause: (over.cause ?? "low-margin") as never,
+    bands: { upper: 0.2, lower: -0.2, stakes: "elevated" },
+  },
+  scores: [],
+  flags: {
+    tieMargin: 0.2,
+    semanticFallbackRatio: 0,
+    structuredCoverage: "strong",
+    commandmentConflict: false,
+    commandmentConflictPrinciples: [],
+  },
+  reasoning: "",
+});
+
+describe("BI-60B3D270 — the uncertain band has an exit that is not a human", () => {
+  it("returns an assurance untouched, without spending an attempt", () => {
+    const nextAttempt = vi.fn();
+    const out = decideWithBoundedRetry(result({ verdict: "proceed", cause: null }), { nextAttempt });
+    expect(out.assured).toBe(true);
+    expect(out.attempts).toEqual([]);
+    expect(nextAttempt).not.toHaveBeenCalled();
+  });
+
+  it("retries an uncertain verdict and stops as soon as it becomes an assurance", () => {
+    const out = decideWithBoundedRetry(result({ verdict: "uncertain" }), {
+      nextAttempt: () => ({ changed: "added discriminating features", result: result({ verdict: "proceed", cause: null }) }),
+    });
+    expect(out.assured).toBe(true);
+    expect(out.attempts).toEqual([
+      { attempt: 1, cause: "low-margin", changed: "added discriminating features", verdict: "proceed" },
+    ]);
+  });
+
+  it("never retries a commandment conflict — no change resolves it", () => {
+    const nextAttempt = vi.fn();
+    const out = decideWithBoundedRetry(
+      result({ verdict: "uncertain", cause: "commandment-conflict" }),
+      { nextAttempt },
+    );
+    expect(out.stopReason).toBe("not-retryable");
+    expect(nextAttempt).not.toHaveBeenCalled();
+  });
+
+  it("refuses a retry that changes nothing, rather than proving the same answer twice", () => {
+    const out = decideWithBoundedRetry(result({ verdict: "uncertain" }), {
+      nextAttempt: () => ({ changed: "   ", result: result({ verdict: "proceed", cause: null }) }),
+    });
+    expect(out.stopReason).toBe("unchanged-input");
+    expect(out.attempts).toEqual([]);
+  });
+
+  it("treats a repeated change as no change", () => {
+    const out = decideWithBoundedRetry(result({ verdict: "uncertain" }), {
+      maxAttempts: 3,
+      nextAttempt: () => ({ changed: "same tweak", result: result({ verdict: "uncertain" }) }),
+    });
+    expect(out.stopReason).toBe("unchanged-input");
+    expect(out.attempts).toHaveLength(1);
+  });
+
+  it("is bounded — an unbounded loop is a hang wearing the costume of diligence", () => {
+    let n = 0;
+    const out = decideWithBoundedRetry(result({ verdict: "uncertain" }), {
+      maxAttempts: 2,
+      nextAttempt: () => ({ changed: `change ${(n += 1)}`, result: result({ verdict: "uncertain" }) }),
+    });
+    expect(out.stopReason).toBe("attempts-exhausted");
+    expect(out.attempts).toHaveLength(2);
+    expect(out.assured).toBe(false);
+  });
+
+  it("stops when the caller has nothing left to change", () => {
+    const out = decideWithBoundedRetry(result({ verdict: "uncertain" }), { nextAttempt: () => null });
+    expect(out.stopReason).toBe("no-change-offered");
+  });
+
+  it("does not retry a result that weighed nothing — that is a corpus gap, not a close call", () => {
+    const nextAttempt = vi.fn();
+    const out = decideWithBoundedRetry(result({ none: true }), { nextAttempt });
+    expect(out.stopReason).toBe("not-retryable");
+    expect(nextAttempt).not.toHaveBeenCalled();
+  });
+
+  it("records every attempt with its cause and what changed", () => {
+    let n = 0;
+    const out = decideWithBoundedRetry(result({ verdict: "uncertain", cause: "coverage-weak" }), {
+      maxAttempts: 3,
+      nextAttempt: () => ({ changed: `richer features ${(n += 1)}`, result: n >= 2 ? result({ verdict: "decline", cause: "all-options-opposed" }) : result({ verdict: "uncertain", cause: "coverage-weak" }) }),
+    });
+    expect(out.assured).toBe(true);
+    expect(out.attempts.map((a) => a.changed)).toEqual(["richer features 1", "richer features 2"]);
+    expect(out.attempts[0]!.cause).toBe("coverage-weak");
+  });
+});

--- a/apps/web/lib/decision/uncertain-retry.ts
+++ b/apps/web/lib/decision/uncertain-retry.ts
@@ -1,0 +1,138 @@
+// apps/web/lib/decision/uncertain-retry.ts
+//
+// BI-60B3D270 (spec slice 5). An exit from the UNCERTAIN band that is not a
+// human turn.
+//
+// BI-2107B5D2 shipped VERDICT_RETRY_HINTS — a string per cause naming the input
+// to change. A string is advice, not an exit: every uncertain verdict still cost
+// an interruption, and a high-stakes hold could have no release path at all.
+//
+// Two rules make this a retry rather than a loop:
+//
+//   1. RETRYING IDENTICALLY IS REFUSED. A corpus gap re-run against the same
+//      empty corpus returns the same nothing forever. The caller must name what
+//      it changed, and repeating the same change is treated as no change.
+//   2. THE ATTEMPT COUNT IS BOUNDED AND VISIBLE. An unbounded retry loop is a
+//      hang wearing the costume of diligence.
+//
+// A commandment conflict never enters the loop: it is a decline with a named
+// cause, and no amount of retrying resolves a conflict with a commandment.
+
+import {
+  readVerdict,
+  VERDICT_RETRY_HINTS,
+  type DecisionResult,
+  type DecisionVerdict,
+  type DecisionVerdictCause,
+} from "./option-scoring";
+
+export const DEFAULT_MAX_RETRY_ATTEMPTS = 2;
+
+export interface RetryAttemptRecord {
+  /** 1-based; attempt 0 is the original decision and is not recorded here. */
+  attempt: number;
+  /** The cause that justified this attempt. */
+  cause: DecisionVerdictCause;
+  /** What the caller changed before re-deciding. Recorded, not inferred. */
+  changed: string;
+  /** The verdict this attempt produced. */
+  verdict: DecisionVerdict;
+}
+
+export type RetryStopReason =
+  | "not-retryable"
+  | "attempts-exhausted"
+  | "no-change-offered"
+  | "unchanged-input";
+
+export interface BoundedRetryOutcome {
+  /** The last decision produced — the original when nothing was retried. */
+  final: DecisionResult;
+  attempts: RetryAttemptRecord[];
+  /** True when the final verdict is an assurance (proceed or decline). */
+  assured: boolean;
+  /** Why the loop stopped; null when it stopped because the verdict became an assurance. */
+  stopReason: RetryStopReason | null;
+}
+
+export interface NextAttempt {
+  /** What the caller changed. An empty or repeated value is refused. */
+  changed: string;
+  result: DecisionResult;
+}
+
+export interface BoundedRetryOptions {
+  maxAttempts?: number;
+  /**
+   * Produce the next attempt for a retryable cause, or null when the caller has
+   * nothing left to change. The hint names what SHOULD change; honouring it is
+   * the caller's job, because only the caller holds the corpus and the options.
+   */
+  nextAttempt: (context: {
+    cause: DecisionVerdictCause;
+    hint: string;
+    attempt: number;
+    previous: DecisionResult;
+  }) => NextAttempt | null;
+}
+
+function isAssurance(verdict: DecisionVerdict): boolean {
+  return verdict === "proceed" || verdict === "decline";
+}
+
+/**
+ * Run a bounded retry around an uncertain decision.
+ *
+ * Returns immediately for an assurance, for a result with no recommendation
+ * (nothing was weighed — that is a corpus gap the caller must fill, not a
+ * decision to re-run), and for a cause with no retry hint.
+ */
+export function decideWithBoundedRetry(
+  first: DecisionResult,
+  options: BoundedRetryOptions,
+): BoundedRetryOutcome {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_RETRY_ATTEMPTS;
+  const attempts: RetryAttemptRecord[] = [];
+  const changesSeen = new Set<string>();
+
+  let current = first;
+
+  for (let attempt = 1; ; attempt += 1) {
+    if (!current.recommendation) {
+      return { final: current, attempts, assured: false, stopReason: "not-retryable" };
+    }
+    const { verdict, verdictCause } = readVerdict(current.recommendation, current.flags);
+    if (isAssurance(verdict)) {
+      return { final: current, attempts, assured: true, stopReason: null };
+    }
+    if (!verdictCause) {
+      return { final: current, attempts, assured: false, stopReason: "not-retryable" };
+    }
+    const hint = VERDICT_RETRY_HINTS[verdictCause];
+    if (!hint) {
+      // commandment-conflict, and anything else declared unretryable.
+      return { final: current, attempts, assured: false, stopReason: "not-retryable" };
+    }
+    if (attempt > maxAttempts) {
+      return { final: current, attempts, assured: false, stopReason: "attempts-exhausted" };
+    }
+
+    const next = options.nextAttempt({ cause: verdictCause, hint, attempt, previous: current });
+    if (!next) {
+      return { final: current, attempts, assured: false, stopReason: "no-change-offered" };
+    }
+    const changed = next.changed.trim();
+    if (!changed || changesSeen.has(changed)) {
+      // Rule 1. Re-running an unchanged input is not a retry; refuse rather
+      // than spend an attempt proving the same answer twice.
+      return { final: current, attempts, assured: false, stopReason: "unchanged-input" };
+    }
+    changesSeen.add(changed);
+
+    current = next.result;
+    const produced = current.recommendation
+      ? readVerdict(current.recommendation, current.flags).verdict
+      : "uncertain";
+    attempts.push({ attempt, cause: verdictCause, changed, verdict: produced });
+  }
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -10613,6 +10613,7 @@
         "agent-authority-overview",
         "tool-execution-log",
         "effective-permissions",
+        "reading-decision-separation",
         "living-playbook-experiments",
         "tool-evaluation-pipeline",
         "development-surfaces"

--- a/apps/web/lib/mcp/packs/principle-decide-pack.ts
+++ b/apps/web/lib/mcp/packs/principle-decide-pack.ts
@@ -11,7 +11,7 @@
 // The definition moved verbatim out of the inline PLATFORM_TOOLS array; grants
 // mirror agent-grants.ts TOOL_TO_GRANTS, which stays the gating source.
 
-import { DECISION_STAKES, type DecisionStakes } from "@/lib/decision/option-scoring";
+import { parseDecisionStakes } from "@/lib/decision/option-scoring";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
 import {
@@ -85,8 +85,7 @@ const definitions: ToolDefinition[] = [
         stakes: {
           type: "string",
           enum: ["routine", "elevated", "high"],
-          description:
-            "BI-1BBB2136. How consequential this decision is. Stakes widen or narrow the UNCERTAIN band from both sides: a high-stakes call demands more separation before it will call anything an assurance, and less opposition before it declines. Defaults to 'elevated' (the historical behaviour). Pass the caller's real risk tier rather than leaving it to the default — an unset tier means every decision, however consequential, is weighed at the same bar.",
+          description: "How consequential this decision is (BI-1BBB2136). Stakes widen or narrow the UNCERTAIN band from both sides: a high-stakes call demands more separation before it calls anything an assurance, and less opposition before it declines. Defaults to 'elevated'. Pass your real risk tier — leaving it unset weighs every decision, however consequential, at the same bar.",
         },
         ringScope: {
           type: "array",
@@ -281,11 +280,7 @@ async function principleDecide(
     typeof params["tieMargin"] === "number"
       ? params["tieMargin"]
       : PRINCIPLE_DECIDE_DEFAULTS.tieMargin;
-  // BI-1BBB2136: an unrecognised value falls back to the default rather than
-  // failing the call — a mistyped tier must not block a governance consult.
-  const stakes = (DECISION_STAKES as readonly string[]).includes(String(params["stakes"]))
-    ? (params["stakes"] as DecisionStakes)
-    : undefined;
+  const stakes = parseDecisionStakes(params["stakes"]);
   const contextualThreshold =
     PRINCIPLE_DECIDE_DEFAULTS.contextualSimilarityThreshold;
   const semanticWarnRatio =

--- a/apps/web/lib/mcp/packs/principle-decide-pack.ts
+++ b/apps/web/lib/mcp/packs/principle-decide-pack.ts
@@ -11,6 +11,7 @@
 // The definition moved verbatim out of the inline PLATFORM_TOOLS array; grants
 // mirror agent-grants.ts TOOL_TO_GRANTS, which stays the gating source.
 
+import { DECISION_STAKES, type DecisionStakes } from "@/lib/decision/option-scoring";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
 import {
@@ -80,6 +81,12 @@ const definitions: ToolDefinition[] = [
           type: "number",
           description:
             "Margin threshold below which confidence flips to 'low' and the reasoning recommends human review. Default 0.2.",
+        },
+        stakes: {
+          type: "string",
+          enum: ["routine", "elevated", "high"],
+          description:
+            "BI-1BBB2136. How consequential this decision is. Stakes widen or narrow the UNCERTAIN band from both sides: a high-stakes call demands more separation before it will call anything an assurance, and less opposition before it declines. Defaults to 'elevated' (the historical behaviour). Pass the caller's real risk tier rather than leaving it to the default — an unset tier means every decision, however consequential, is weighed at the same bar.",
         },
         ringScope: {
           type: "array",
@@ -274,6 +281,11 @@ async function principleDecide(
     typeof params["tieMargin"] === "number"
       ? params["tieMargin"]
       : PRINCIPLE_DECIDE_DEFAULTS.tieMargin;
+  // BI-1BBB2136: an unrecognised value falls back to the default rather than
+  // failing the call — a mistyped tier must not block a governance consult.
+  const stakes = (DECISION_STAKES as readonly string[]).includes(String(params["stakes"]))
+    ? (params["stakes"] as DecisionStakes)
+    : undefined;
   const contextualThreshold =
     PRINCIPLE_DECIDE_DEFAULTS.contextualSimilarityThreshold;
   const semanticWarnRatio =
@@ -642,6 +654,7 @@ async function principleDecide(
 
   const result = decide(decisionOptions, cappedPrinciples, {
     tieMargin,
+    ...(stakes ? { stakes } : {}),
     semanticFallbackWarnRatio: semanticWarnRatio,
     minFeatureKeys,
     sensitivityEpsilon,

--- a/docs/user-guide/ai-workforce/index.md
+++ b/docs/user-guide/ai-workforce/index.md
@@ -216,6 +216,30 @@ Agent tool availability is the **intersection** of two authority systems:
 
 An action is only possible if BOTH allow it. This prevents agents from exceeding their design scope, even when triggered by a user with broad permissions.
 
+## Reading Decision Separation
+
+The decision review inbox (`/platform/ai/founder-review`) opens with **Decision separation** — how
+your coworkers' decisions are landing, and whether the confident ones held up.
+
+Every decision the kernel weighs produces a *margin*: how far the winning option beat the
+runner-up. Decisions fall in three bands. **Proceed** and **decline** are both settled answers.
+The **uncertain** band in the middle is where the platform could not call it either way, and it
+is the only band that costs someone's attention.
+
+The chart shows where decisions landed. Bars left of the band edge are the uncertain ones. The
+headline percentage is the share that landed there — the number to drive down by improving the
+corpora and principles your coworkers decide against, so that decisions separate cleanly.
+
+Beneath it, **reversed** shows how often a settled answer was later overturned by a person. This
+is the honesty check on the first number. Lowering the bar would shrink the uncertain band
+without making anything clearer, and the reversal rate is what shows the difference: a shrinking
+middle band alongside a rising reversal rate is a step backwards, not progress. Where a decision
+has no recorded human choice to compare against, the table says **no call could be checked**
+rather than counting it as agreement.
+
+A thin sample is labelled as one: the panel states how many decisions carried a margin, so a
+tidy-looking chart over a handful of rows is not mistaken for a settled picture.
+
 ## Living Playbook experiments
 
 An approved Living Playbook candidate can carry an evidence-cleared replay definition. For those

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1376,7 +1376,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 95
+    "textMass": 92
   },
   "apps/web/app/(shell)/platform/ai/assignments/bindings/[bindingId]/page.tsx": {
     "vocabulary": 0,
@@ -1439,7 +1439,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 198
+    "textMass": 179
   },
   "apps/web/app/(shell)/platform/ai/memory/MyMemoryAuditClient.tsx": {
     "vocabulary": 0,
@@ -6291,6 +6291,13 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 51
+  },
+  "apps/web/components/platform/BandTelemetryPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 20
   },
   "apps/web/components/platform/BuildStudioConfigForm.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
Closes the gaps left open when #4430 merged: the three-band verdict shipped with its vocabulary and its data, but nothing measured the band, nothing varied the bar, and the middle band still had no exit but a human.

| BI | What |
|---|---|
| `BI-3217C098` | Band telemetry — margin histogram and per-band reversal rate |
| `BI-1BBB2136` | Stakes reach the band edges from real call sites |
| `BI-60B3D270` | A bounded exit from the uncertain band |

## BI-3217C098 — the instrument

`BI-2107B5D2` made margins real; nothing read them, so the band the operator wants to tune was invisible.

**Two numbers, because either alone lies.** The histogram shows where decisions land, with the band edge marked — tuning is working when mass moves *away from the middle*. The reversal rate shows whether the confident calls deserved their confidence.

`isBetterTuned` **refuses** to call a smaller uncertain band an improvement when confident calls were reversed more often, or when no confident call could be checked. Narrowing the bar until the middle stops firing is trivially achievable and proves nothing; that refusal is the point, and it has its own tests.

Reversals count only where **both** the kernel's pick and the human's choice are known. Rows missing either report as unjudged, never as agreement — treating silence as assent is how a reversal rate flatters itself.

Surfaced read-only on the existing founder-review inbox. No new route, and a query failure leaves the inbox intact.

## BI-1BBB2136 — a knob nobody turned

`grep` for the stakes parameter found two hits: its own declaration and its own signature. **No caller passed it**, so every decision ran at the `elevated` default however consequential — substrate present, callers absent, the same shape as a gate covering two tools out of 169.

`principle_decide` now accepts a tier; `stakesForRiskTier` is the single mapping from consequence to band edges; and both `work-pattern-review` call sites weigh options at the same tier the `DecisionInteraction` records. A margin that is an assurance for a routine call is not one when the consequence is high — now true in the code, not only in the type.

## BI-60B3D270 — an exit that is not a human

Retry hints were advice. `decideWithBoundedRetry` makes them an exit, under two rules:

- **Retrying identically is refused.** The caller must name what it changed; an empty or repeated change is no change. A corpus gap re-run against the same empty corpus returns the same nothing forever.
- **The attempt count is bounded and visible.** An unbounded retry loop is a hang wearing the costume of diligence.

A commandment conflict never enters the loop, and a result that weighed nothing is not retried. Attempts are recorded on the ledger, so a later histogram can separate a first-pass assurance from one that took two tries.

## Ratchets

Four guards caught the new panel and all four were right: an accent-button-shaped class on the histogram bars (now semantic tokens by state, which is truer), an off-scale text size, a raw `<table>` (now a report-kit `DataTable`), and `principle-decide-pack` crossing its 800-LOC ceiling (the stakes parser moved to `option-scoring`, where the enum already lives). Prose and surface baselines retightened rather than expanded.

## Still open, tracked not hidden

- `BI-CFA638E8` — `DecisionInteraction` has no acting-agent link, so a coworker's own gate verdicts stay unrenderable. Matching on `profileId` would fabricate attribution on a governance surface.
- `BI-B9403248` — the plan-coverage lockout; this PR only made its message actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
