### PR TITLE
fix(hooks): close the shell bypass on the root-clone write guard (BI-D471606A)

### DIFF
--- a/packages/dpf-skill-pack/hooks/root-clone-guard.mjs
+++ b/packages/dpf-skill-pack/hooks/root-clone-guard.mjs
@@ -271,6 +271,93 @@ export function isRootCloneGitStateMutation(seg, cwd, isDir = () => false) {
   return cloneRoot !== null && target === cloneRoot;
 }
 
+// ── shell writes (BI-D471606A) ───────────────────────────────────────────────
+//
+// The file-tool block above is only half the surface. A session told to "make
+// file changes with sed, heredocs, or short scripts rather than the dedicated
+// Write/Edit tools" — which is what bypass-permissions mode instructs — routes
+// every edit around `Write|Edit|MultiEdit` and never touches that guard. On
+// 2026-08-21 exactly that happened: hours of edits landed in the shared root
+// clone with no guard consulted, and were destroyed when a second session
+// cleaned the tree.
+//
+// So the same rule is enforced on the shell surface. Deliberately conservative:
+// a write must be IDENTIFIABLE (a redirect target, a tee/sed -i/cp/mv
+// destination) or an interpreter that plainly writes. A read-only command in
+// the clone root stays allowed — a guard that blocks `cat` gets disabled, and a
+// disabled guard protects nothing.
+
+/** Redirect targets: `> f`, `>> f`, `2> f`, `&> f`. Heredocs land here too (`cat > f <<EOF`). */
+function redirectTargets(seg) {
+  const out = [];
+  const re = /(?:\d*|&)>{1,2}\s*("[^"]+"|'[^']+'|[^\s;|&<>]+)/g;
+  let m;
+  while ((m = re.exec(seg)) !== null) {
+    const raw = m[1].replace(/^['"]|['"]$/g, "");
+    if (raw && raw !== "/dev/null") out.push(raw);
+  }
+  return out;
+}
+
+/** Destinations of the common write verbs. */
+function writeVerbTargets(seg) {
+  const tokens = tokenize(seg);
+  if (tokens.length === 0) return [];
+  const verb = baseName(tokens[0] ?? "").toLowerCase();
+  const rest = tokens.slice(1);
+  // POSIX flags only. The shared isFlag() also treats a leading "/" as a
+  // Windows switch, which would swallow every absolute path operand here.
+  const operands = rest.filter((t) => !t.startsWith("-"));
+
+  if (verb === "tee") return operands;
+  if (verb === "sed") {
+    // Only `-i` mutates in place; a plain sed writes to stdout.
+    const inPlace = rest.some((t) => t === "-i" || /^-i\S*$/.test(t) || t === "--in-place");
+    // The script operand is not a path; the remaining operands are.
+    return inPlace ? operands.slice(1) : [];
+  }
+  if (verb === "cp" || verb === "mv" || verb === "install" || verb === "rsync") {
+    return operands.length >= 2 ? [operands[operands.length - 1]] : [];
+  }
+  if (verb === "truncate" || verb === "touch") return operands;
+  return [];
+}
+
+const INTERPRETERS = new Set(["python", "python3", "node", "ruby", "perl", "php", "bash", "sh", "zsh"]);
+/** Write verbs that appear in a one-liner or heredoc body we cannot resolve to a path. */
+// A WRITE, not merely a file touch. `open(path)` for reading is the most common
+// one-liner in this repo, so an open only counts when a write mode appears as
+// its OWN argument — matching a bare [wax] after the quote flagged
+// `open('a.json')` on the filename's first letter. Erring toward allowing reads. A guard that blocks reading gets switched off,
+// and a switched-off guard protects nothing.
+const WRITE_INTENT = /(\bopen\s*\([^)]*,\s*(mode\s*=\s*)?["'][wax]|\bwriteFileSync\b|\bwriteFile\b|\.write\s*\(|\bos\.remove\b|\bshutil\.(copy|move|rmtree)|\bfs\.rm\b|\bunlink\b|\bmkdirs?\b|\brename\s*\()/;
+
+/**
+ * An interpreter invoked with inline code or a heredoc, whose body plainly
+ * writes. The path is unknowable from the command, so this only fires when the
+ * session is standing IN the clone root — the same precondition decideFileWrite
+ * uses. A read-only one-liner is left alone.
+ */
+export function isRootCloneInterpreterWrite(command, cwd, isDir = () => false) {
+  // Evaluated over the WHOLE command, not a segment: segments() splits on
+  // newlines, and a heredoc body lives on the lines after its interpreter.
+  const firstLine = String(command).split("\n")[0] ?? "";
+  const tokens = tokenize(firstLine);
+  const verb = baseName(tokens[0] ?? "").toLowerCase();
+  if (!INTERPRETERS.has(verb)) return false;
+  const inlineCode = tokens.some((t) => t === "-c" || t === "-e");
+  const heredoc = /<<-?\s*['"]?\w+/.test(firstLine);
+  if (!inlineCode && !heredoc) return false;
+  if (!WRITE_INTENT.test(String(command))) return false;
+  const cloneRoot = deriveCloneRoot(cwd, isDir);
+  return cloneRoot !== null && norm(cwd) === cloneRoot;
+}
+
+/** Every identifiable write destination in one segment. */
+export function shellWriteTargets(seg) {
+  return [...redirectTargets(seg), ...writeVerbTargets(seg)];
+}
+
 const FILE_WRITE_TOOL_NAMES = new Set(["Write", "Edit", "MultiEdit"]);
 
 function fileWriteTargets(toolInput) {
@@ -341,6 +428,14 @@ export function decide({ command, cwd = "", env = {}, isSymlink = () => false, i
       return { block: true, reason: ROOT_GIT_STATE_GUIDANCE };
     }
 
+    // BI-D471606A: a shell write into the shared root clone is the same defect
+    // the file-tool guard already refuses; only the surface differs.
+    for (const target of shellWriteTargets(seg)) {
+      if (isUnderRootSharedArea(resolveAgainst(cwd, target), cloneRoot())) {
+        return { block: true, reason: ROOT_FILE_WRITE_GUIDANCE };
+      }
+    }
+
     // `git clean -fdx` follows junctioned/ignored dirs into the shared root.
     if (isDestructiveGitClean(seg)) {
       return { block: true, reason: GUIDANCE };
@@ -356,6 +451,10 @@ export function decide({ command, cwd = "", env = {}, isSymlink = () => false, i
       //     or names the clone's own packages/node_modules/etc).
       if (isUnderRootSharedArea(resolved, cloneRoot())) return { block: true, reason: GUIDANCE };
     }
+  }
+
+  if (isRootCloneInterpreterWrite(command, cwd, isDir)) {
+    return { block: true, reason: ROOT_FILE_WRITE_GUIDANCE };
   }
 
   return { block: false };

--- a/packages/dpf-skill-pack/hooks/root-clone-guard.test.mjs
+++ b/packages/dpf-skill-pack/hooks/root-clone-guard.test.mjs
@@ -275,3 +275,82 @@ test("the junction install block honors the existing root-mutation escape hatch"
     false,
   );
 });
+
+// ── BI-D471606A: the shell surface, which bypassed every file-tool guard ──────
+//
+// On 2026-08-21 a session edited the shared root clone for hours through
+// heredocs and `sed -i`, because bypass-permissions mode instructs exactly that.
+// decideFileWrite never saw a single edit. These assert the shell surface now
+// reaches the same verdict as the file surface.
+
+const shellIn = (command, cwd) =>
+  decide({ command, cwd, env: {}, isSymlink: noSym, isDir: mainGit });
+
+test("blocks a heredoc write into the shared root clone", () => {
+  const v = shellIn("cat > apps/web/lib/thing.ts <<'EOF'", MAIN);
+  assert.equal(v.block, true);
+  assert.match(v.reason, /root clone/i);
+});
+
+test("blocks a redirect and an append into the shared root clone", () => {
+  assert.equal(shellIn("echo x > packages/db/src/seed.ts", MAIN).block, true);
+  assert.equal(shellIn("echo x >> packages/db/src/seed.ts", MAIN).block, true);
+});
+
+test("blocks sed -i in the shared root clone, but not a read-only sed", () => {
+  assert.equal(shellIn("sed -i '' 's/a/b/' apps/web/app/page.tsx", MAIN).block, true);
+  assert.equal(shellIn("sed -n '1,20p' apps/web/app/page.tsx", MAIN).block, false);
+});
+
+test("blocks tee, cp and mv destinations in the shared root clone", () => {
+  assert.equal(shellIn("echo x | tee apps/web/lib/a.ts", MAIN).block, true);
+  assert.equal(shellIn("cp /tmp/a.ts apps/web/lib/a.ts", MAIN).block, true);
+  assert.equal(shellIn("mv /tmp/a.ts apps/web/lib/a.ts", MAIN).block, true);
+});
+
+test("blocks an interpreter one-liner that plainly writes from the clone root", () => {
+  assert.equal(shellIn(`python3 - <<'PY'\nopen("x.ts","w").write("y")\nPY`, MAIN).block, true);
+  assert.equal(shellIn('node -e \'require("fs").writeFileSync("x","y")\'', MAIN).block, true);
+});
+
+test("leaves a read-only interpreter one-liner alone — a guard that blocks reads gets disabled", () => {
+  assert.equal(shellIn('python3 -c "import json;print(json.load(open(\'a.json\')))"', MAIN).block, false);
+  assert.equal(shellIn("node -e 'console.log(1)'", MAIN).block, false);
+});
+
+test("does not touch writes inside a session's own worktree", () => {
+  const inWorktree = (command) =>
+    decide({ command, cwd: SIBLING, env: {}, isSymlink: noSym, isDir: noGit });
+  assert.equal(inWorktree("cat > apps/web/lib/thing.ts <<'EOF'").block, false);
+  assert.equal(inWorktree("sed -i '' 's/a/b/' apps/web/app/page.tsx").block, false);
+  assert.equal(inWorktree(`python3 - <<'PY'\nopen("x","w").write("y")\nPY`).block, false);
+});
+
+test("never blocks a write to /dev/null", () => {
+  assert.equal(shellIn("pnpm run build > /dev/null", MAIN).block, false);
+});
+
+test("honours the documented emergency bypass", () => {
+  const v = decide({
+    command: "cat > apps/web/lib/a.ts <<'EOF'",
+    cwd: MAIN,
+    env: { DPF_ALLOW_ROOT_CLONE_MUTATION: "1" },
+    isSymlink: noSym,
+    isDir: mainGit,
+  });
+  assert.equal(v.block, false);
+});
+
+test("the shell surface and the file surface agree — the bypass is what this closes", () => {
+  const target = "apps/web/lib/same-file.ts";
+  const fileVerdict = decideFileWrite({
+    toolName: "Write",
+    toolInput: { file_path: target },
+    cwd: MAIN,
+    env: {},
+    isDir: mainGit,
+  });
+  const shellVerdict = shellIn(`cat > ${target} <<'EOF'`, MAIN);
+  assert.equal(fileVerdict.block, shellVerdict.block);
+  assert.equal(fileVerdict.block, true);
+});


### PR DESCRIPTION
Closes `BI-D471606A`. The guard that should have prevented this thread's work-loss incident already existed — it just never saw the edits.

## What was wrong

`root-clone-guard.mjs:55` carries a written refusal for a direct file write into the shared root clone (`BI-FFF58567`), wired in `.claude/settings.json` against `Write|Edit|MultiEdit`. Its Bash branch covers only recursive deletes — the 2026-06-19 incident that wiped 730 files.

So a session that edits through Bash never touches it. Bypass-permissions mode instructs precisely that: *"make file changes with sed, heredocs, or short scripts, rather than the dedicated Read, Edit, or Write tools."* On 2026-08-21 hours of edits landed in the shared clone with no guard consulted, and were destroyed when a second session cleaned the tree.

**This is not one hook's gap** — every `Write|Edit|MultiEdit` guard is disabled the same way for the same sessions. This PR closes it for the one that protects the working tree; the audit of the other five stays open on the BI.

## What this does

The shell surface now reaches the same verdict as the file surface for **identifiable** writes: redirects and heredocs (`>`, `>>`, `2>`, `cat > f <<EOF`), `tee`, `sed -i`, and `cp`/`mv`/`install`/`rsync` destinations. Interpreter one-liners that plainly write (`python3 -c`, `node -e`, heredoc bodies) cannot be resolved to a path, so they fire only when the session is standing in the clone root — the same precondition `decideFileWrite` already uses.

Deliberately conservative: a read-only command in the clone root stays allowed. A guard that blocks `cat` gets switched off, and a switched-off guard protects nothing.

## Three bugs the tests caught

Worth naming, because each would have made the guard quietly useless:

1. `isFlag()` treats a leading `/` as a Windows switch, so every absolute-path operand was silently dropped — `cp /tmp/a.ts apps/web/lib/a.ts` parsed as having no destination.
2. `segments()` splits on newlines, severing a heredoc body from the interpreter that opened it. Interpreter writes are now read over the whole command.
3. The write-intent pattern matched `open('a.json')` — reading the **filename's** first letter as append mode. A mode must now appear as its own argument.

The last one is the important one: it was over-blocking reads, which is how a guard earns a bypass. The test that caught it is kept as the specification.

Fail-open discipline, guidance text, and the `DPF_ALLOW_ROOT_CLONE_MUTATION=1` bypass are unchanged. A parity test asserts the file surface and the shell surface agree on the same path — the bypass is what this closes, so it is what the test pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
