### PR TITLE
fix(hooks): warn about losable work and an occupied clone, not just spec paths (BI-910C37B1, BI-D234C277)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -88,6 +88,15 @@
     ],
     "SessionStart": [
       {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/packages/dpf-skill-pack/hooks/shared-clone-occupancy.mjs\""
+          }
+        ]
+      },
+      {
         "hooks": [
           {
             "type": "command",

--- a/packages/dpf-skill-pack/hooks/shared-clone-occupancy.mjs
+++ b/packages/dpf-skill-pack/hooks/shared-clone-occupancy.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// packages/dpf-skill-pack/hooks/shared-clone-occupancy.mjs
+//
+// SessionStart advisory (BI-D234C277): say, before any work begins, that this
+// session is standing in the SHARED root clone — and who else is in it.
+//
+// The existing readiness banner reports "Worktree verification-readiness:
+// SOURCE-ONLY". That is a dependency status. It reads as "your tooling is
+// limited", not as "other sessions are working in this checkout". On 2026-08-21
+// a session read it the first way, edited the root clone for hours, and lost the
+// work when a second session cleaned the tree — a `git checkout -- .` leaves no
+// reflog entry, so nothing else would have told it either.
+//
+// Reads git state only: no MCP, no portal, no network. It still reports when
+// everything else is down, which is exactly when a session is most likely to be
+// improvising in the wrong directory. Advisory, always exit 0.
+// Silence with DPF_SKIP_CLONE_OCCUPANCY=1.
+
+import { spawnSync } from "node:child_process";
+import { statSync } from "node:fs";
+
+const REMEDY = "git worktree add -b <branch> ../dpf-worktrees/<topic> origin/main";
+
+function gitOut(args) {
+  try {
+    const r = spawnSync("git", args, { encoding: "utf8", timeout: 10_000 });
+    return r.status === 0 && r.stdout ? r.stdout : "";
+  } catch {
+    return "";
+  }
+}
+
+function isDirReal(p) {
+  try { return statSync(p).isDirectory(); } catch { return false; }
+}
+
+/**
+ * @param {string} cwd
+ * @param {(args: string[]) => string} runGit stdout, "" on failure
+ * @param {(p: string) => boolean} isDir
+ */
+export function describeCloneOccupancy(cwd, runGit, isDir = () => false) {
+  const norm = String(cwd).replace(/\\/g, "/").replace(/\/+$/, "");
+  // A linked worktree's .git is a FILE; only the primary clone has a directory.
+  if (!isDir(`${norm}/.git`)) return { isRootClone: false, lines: [] };
+
+  const branch = runGit(["-C", norm, "rev-parse", "--abbrev-ref", "HEAD"]).trim();
+  // Porcelain XY is column-significant: " M f" is unstaged, "M  f" is staged.
+  // Trimming first would read every unstaged edit as another session's staged work.
+  const dirty = runGit(["-C", norm, "status", "--porcelain"])
+    .split("\n")
+    .filter((l) => l.trim() !== "");
+  const staged = dirty.filter((l) => /^[MARCD]/.test(l));
+  const others = runGit(["-C", norm, "worktree", "list"])
+    .split("\n")
+    .filter((l) => l.trim() && !l.startsWith(`${norm} `));
+
+  const lines = [
+    "SHARED ROOT CLONE — this is not your worktree.",
+    `  ${norm}${branch && branch !== "HEAD" ? ` (on ${branch})` : ""}`,
+  ];
+  if (staged.length > 0) {
+    lines.push(
+      `  ${staged.length} staged change(s) are already here — another session is mid-work. Do not commit, stash, or reset them.`,
+    );
+  } else if (dirty.length > 0) {
+    lines.push(`  ${dirty.length} uncommitted change(s) are already here; they may not be yours.`);
+  }
+  if (others.length > 0) {
+    lines.push(`  ${others.length} other worktree(s) exist — sessions are expected to take one.`);
+  }
+  lines.push(
+    "  Take your own before editing anything:",
+    `    ${REMEDY}`,
+    "  Editing here races every other session in this clone, and a tree-clean from any of them destroys your uncommitted work with no reflog entry.",
+  );
+  return { isRootClone: true, lines };
+}
+
+function main() {
+  if (process.env.DPF_SKIP_CLONE_OCCUPANCY === "1") process.exit(0);
+  const cwd = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const { isRootClone, lines } = describeCloneOccupancy(cwd, gitOut, isDirReal);
+  if (!isRootClone) process.exit(0);
+  process.stdout.write(`${lines.join("\n")}\n`);
+  process.exit(0);
+}
+
+const invokedPath = process.argv[1] ? process.argv[1].replace(/\\/g, "/") : "";
+if (invokedPath.endsWith("shared-clone-occupancy.mjs")) {
+  main();
+}

--- a/packages/dpf-skill-pack/hooks/shared-clone-occupancy.test.mjs
+++ b/packages/dpf-skill-pack/hooks/shared-clone-occupancy.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { describeCloneOccupancy } from "./shared-clone-occupancy.mjs";
+
+const gitFor = (map) => (args) => {
+  if (args.includes("rev-parse")) return map.branch ?? "";
+  if (args.includes("status")) return map.status ?? "";
+  if (args.includes("worktree")) return map.worktrees ?? "";
+  return "";
+};
+
+describe("BI-D234C277 — shared clone occupancy", () => {
+  it("stays silent in a session's own worktree", () => {
+    const r = describeCloneOccupancy("/wt/topic", gitFor({}), () => false);
+    assert.equal(r.isRootClone, false);
+    assert.deepEqual(r.lines, []);
+  });
+
+  it("leads with the shared clone, not with dependency status", () => {
+    const r = describeCloneOccupancy(
+      "/root",
+      gitFor({ branch: "fix/another-session\n", worktrees: "/root  aaa [main]\n/other  bbb [x]\n" }),
+      (p) => p === "/root/.git",
+    );
+    assert.match(r.lines[0], /^SHARED ROOT CLONE/);
+    assert.match(r.lines.join("\n"), /on fix\/another-session/);
+    assert.match(r.lines.join("\n"), /git worktree add/);
+  });
+
+  it("warns off another session's staged work instead of advising a cleanup", () => {
+    const text = describeCloneOccupancy(
+      "/root",
+      gitFor({ branch: "main\n", status: "M  staged.ts\n" }),
+      (p) => p === "/root/.git",
+    ).lines.join("\n");
+    assert.match(text, /another session is mid-work/);
+    assert.match(text, /Do not commit, stash, or reset them/);
+  });
+
+  it("reads the porcelain columns — an unstaged edit is not another session's staged work", () => {
+    const text = describeCloneOccupancy(
+      "/root",
+      gitFor({ branch: "main\n", status: " M unstaged.ts\n" }),
+      (p) => p === "/root/.git",
+    ).lines.join("\n");
+    assert.doesNotMatch(text, /staged change/);
+    assert.match(text, /may not be yours/);
+  });
+
+  it("names the reflog blind spot, since nothing else reports it", () => {
+    const text = describeCloneOccupancy("/root", gitFor({ branch: "main\n" }), (p) => p === "/root/.git")
+      .lines.join("\n");
+    assert.match(text, /no reflog entry/);
+  });
+});

--- a/packages/dpf-skill-pack/hooks/uncommitted-work-guard.mjs
+++ b/packages/dpf-skill-pack/hooks/uncommitted-work-guard.mjs
@@ -8,7 +8,12 @@
 
 import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { findDurableArtifactDrift, buildWarning } from "./uncommitted-work-scan.mjs";
+import {
+  attributeWork,
+  buildAttributedWarning,
+  buildUnattributedWarning,
+  findLosableWork,
+} from "./uncommitted-work-scan.mjs";
 
 function skipGuard(env = process.env) {
   return env.DPF_SKIP_UNCOMMITTED_WORK_GUARD === "1";
@@ -55,10 +60,26 @@ function main() {
   const rootArgIdx = argv.indexOf("--repo-root");
   const baseDir = repoRoot(rootArgIdx >= 0 ? argv[rootArgIdx + 1] : null);
 
-  const drift = findDurableArtifactDrift(gitPorcelain(baseDir));
-  if (drift.length === 0) process.exit(0);
+  // BI-910C37B1: every losable modification, not only spec/plan paths. The
+  // 2026-08-21 loss was source edits this guard never mentioned.
+  const context = isGitHook ? "post-checkout" : "session-end";
+  const losable = findLosableWork(gitPorcelain(baseDir));
+  if (losable.length === 0) process.exit(0);
 
-  const warning = buildWarning(drift, { context: isGitHook ? "post-checkout" : "session-end" });
+  // Attribution: a hook cannot see which files THIS session wrote, so it must
+  // not claim ownership either way. When a caller supplies the touched set
+  // (newline- or colon-separated paths), the message splits by author; without
+  // it, the message says plainly that some of this may be another session's —
+  // because advising "stash it" over someone else's in-flight work is how the
+  // guard turns into the thing it exists to prevent.
+  const touched = String(process.env.DPF_SESSION_TOUCHED_PATHS ?? "")
+    .split(/[\n:]/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+
+  const warning = touched.length > 0
+    ? buildAttributedWarning(attributeWork(losable, touched), { context })
+    : buildUnattributedWarning(losable, { context });
 
   if (isGitHook) {
     process.stderr.write(`\n${warning}\n\n`);

--- a/packages/dpf-skill-pack/hooks/uncommitted-work-guard.test.mjs
+++ b/packages/dpf-skill-pack/hooks/uncommitted-work-guard.test.mjs
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  attributeWork,
+  buildAttributedWarning,
   buildWarning,
   findDurableArtifactDrift,
+  buildUnattributedWarning,
+  findLosableWork,
   parsePorcelainLine,
 } from "./uncommitted-work-scan.mjs";
 
@@ -60,5 +64,79 @@ describe("buildWarning", () => {
       context: "post-checkout",
     });
     assert.match(msg, /switching branches/);
+  });
+});
+// ── BI-910C37B1: scope and attribution ───────────────────────────────────────
+//
+// 2026-08-21: this guard fired for a plan file and stayed silent about the
+// uncommitted SOURCE edits that were actually destroyed. Later the same day it
+// reported another session's staged spec as if it belonged to the reader, with
+// advice — "commit, stash, or copy" — that would have swept their work away.
+
+describe("BI-910C37B1 — scope and attribution", () => {
+  it("findLosableWork sees source edits, not only spec and plan paths", () => {
+    const hits = findLosableWork([
+      " M apps/web/lib/decision/option-scoring.ts",
+      "?? apps/web/lib/decision/new-module.ts",
+      " M docs/superpowers/plans/a-plan.md",
+    ]);
+    assert.equal(hits.length, 3);
+    assert.equal(hits.filter((h) => h.durable).length, 1);
+  });
+
+  it("findLosableWork ignores regenerated artifacts — nagging about noise trains the reflex that loses work", () => {
+    const hits = findLosableWork([
+      " M apps/web/lib/docs/doc-index.generated.json",
+      " M scripts/prose-lint-baseline.json",
+      "?? .DS_Store",
+      "?? docs/user-guide/assets/diagrams/architecture/x/0.svg",
+      " M apps/web/lib/real-work.ts",
+    ]);
+    assert.deepEqual(hits.map((h) => h.path), ["apps/web/lib/real-work.ts"]);
+  });
+
+  it("attributeWork separates this session's work from another session's", () => {
+    const hits = findLosableWork([
+      " M apps/web/lib/mine.ts",
+      " M docs/superpowers/specs/theirs.md",
+    ]);
+    const { mine, theirs } = attributeWork(hits, ["apps/web/lib/mine.ts"]);
+    assert.deepEqual(mine.map((h) => h.path), ["apps/web/lib/mine.ts"]);
+    assert.deepEqual(theirs.map((h) => h.path), ["docs/superpowers/specs/theirs.md"]);
+  });
+
+  it("never recommends a mutating recovery for work this session did not author", () => {
+    const hits = findLosableWork([" M docs/superpowers/specs/theirs.md"]);
+    const warning = buildAttributedWarning(attributeWork(hits, []));
+    assert.match(warning, /NOT made by this session/);
+    assert.match(warning, /Do not commit or stash it/);
+    assert.doesNotMatch(warning, /Commit, stash, or copy it before/);
+  });
+
+  it("still tells a session to save its OWN work", () => {
+    const hits = findLosableWork([" M apps/web/lib/mine.ts"]);
+    const warning = buildAttributedWarning(attributeWork(hits, ["apps/web/lib/mine.ts"]));
+    assert.match(warning, /THIS session made/);
+    assert.match(warning, /Commit, stash, or copy it/);
+  });
+
+  it("says nothing when there is nothing losable", () => {
+    assert.equal(buildAttributedWarning({ mine: [], theirs: [] }), "");
+  });
+
+});
+
+describe("BI-910C37B1 — the unattributed message", () => {
+  it("lists losable work without claiming who made it, and names the shared clone as the fix", () => {
+    const warning = buildUnattributedWarning(
+      findLosableWork([" M apps/web/lib/a.ts", "?? docs/superpowers/plans/p.md"]),
+    );
+    assert.match(warning, /apps\/web\/lib\/a\.ts/);
+    assert.match(warning, /may belong to another session/);
+    assert.match(warning, /take a worktree/);
+  });
+
+  it("says nothing when nothing is losable", () => {
+    assert.equal(buildUnattributedWarning([]), "");
   });
 });

--- a/packages/dpf-skill-pack/hooks/uncommitted-work-scan.mjs
+++ b/packages/dpf-skill-pack/hooks/uncommitted-work-scan.mjs
@@ -22,6 +22,23 @@ export function parsePorcelainLine(line) {
 }
 
 /**
+ * BI-910C37B1: paths whose churn is noise, not work. A hook or a generator
+ * rewrites these, so warning about them trains the reflex of waving the guard
+ * away — and that reflex is what loses the real work.
+ */
+const REGENERATED_PATTERNS = [
+  /(^|\/)[^/]*\.generated\.(json|ts|mjs)$/,
+  /(^|\/)[^/]*-baseline\.(json|txt)$/,
+  /(^|\/)\.DS_Store$/,
+  /^docs\/user-guide\/assets\/diagrams\//,
+];
+
+function isRegenerated(relPath) {
+  const norm = String(relPath ?? "").replace(/\\/g, "/");
+  return REGENERATED_PATTERNS.some((re) => re.test(norm));
+}
+
+/**
  * @param {string[]} porcelainLines
  * @returns {Array<{ path: string, xy: string }>}
  */
@@ -33,6 +50,56 @@ export function findDurableArtifactDrift(porcelainLines) {
     hits.push({ path: parsed.path, xy: parsed.xy });
   }
   return hits;
+}
+
+/**
+ * BI-910C37B1: every losable modification, not just spec/plan paths.
+ *
+ * The guard's own message called uncommitted spec/plan edits "the #1 silent-loss
+ * vector". The 2026-08-21 incident falsified that: it fired for a plan file and
+ * stayed silent about the uncommitted SOURCE edits that were actually destroyed.
+ * Any tracked modification is losable.
+ *
+ * @param {string[]} porcelainLines
+ * @returns {Array<{ path: string, xy: string, durable: boolean }>}
+ */
+export function findLosableWork(porcelainLines) {
+  const hits = [];
+  for (const line of porcelainLines) {
+    const parsed = parsePorcelainLine(line);
+    if (!parsed) continue;
+    if (isRegenerated(parsed.path)) continue;
+    hits.push({
+      path: parsed.path,
+      xy: parsed.xy,
+      durable: isDurableArtifactPath(parsed.path),
+    });
+  }
+  return hits;
+}
+
+/**
+ * BI-910C37B1: split what this session touched from what it did not.
+ *
+ * The guard reports on whatever tree it is pointed at, with no notion of whose
+ * work it found. In a shared clone that produced the worst possible advice:
+ * "commit, stash, or copy these files" — aimed at another session's in-flight
+ * spec. Acting on it would have swept their work into a stash they do not know
+ * exists. Never recommend a mutating recovery for work this session did not author.
+ *
+ * @param {Array<{ path: string, xy: string, durable?: boolean }>} hits
+ * @param {Iterable<string>} sessionTouchedPaths
+ */
+export function attributeWork(hits, sessionTouchedPaths) {
+  const touched = new Set(
+    Array.from(sessionTouchedPaths ?? [], (p) => String(p).replace(/\\/g, "/")),
+  );
+  const mine = [];
+  const theirs = [];
+  for (const hit of hits) {
+    (touched.has(hit.path) ? mine : theirs).push(hit);
+  }
+  return { mine, theirs };
 }
 
 /**
@@ -49,6 +116,69 @@ export function buildWarning(drift, opts = {}) {
     `[uncommitted-work-guard] ${when} under docs/superpowers/specs/ or docs/superpowers/plans/:\n` +
     `${paths}\n` +
     `Commit, stash, or copy these files before switching branches or closing the session — uncommitted spec/plan edits are the #1 silent-loss vector (process-spine §2). ` +
+    `Bypass only when intentional: DPF_SKIP_UNCOMMITTED_WORK_GUARD=1.`
+  );
+}
+
+/**
+ * BI-910C37B1: two audiences, two messages.
+ *
+ * Work this session authored gets the recovery advice. Work it did not gets a
+ * hands-off notice instead — surfacing it to the operator is the only safe move,
+ * because the session cannot know what the other one is mid-way through.
+ *
+ * @param {{ mine: Array<{path:string,xy:string,durable?:boolean}>, theirs: Array<{path:string,xy:string,durable?:boolean}> }} attributed
+ * @param {{ context?: "session-end" | "post-checkout" }} [opts]
+ */
+export function buildAttributedWarning(attributed, opts = {}) {
+  const list = (rows) =>
+    rows.map((d) => `  - ${d.path} (${d.xy.trim() || "dirty"})`).join("\n");
+  const when =
+    opts.context === "post-checkout"
+      ? "You are switching branches with uncommitted work"
+      : "This session is ending with uncommitted work";
+  const parts = [];
+
+  if (attributed.mine.length > 0) {
+    parts.push(
+      `[uncommitted-work-guard] ${when} that THIS session made:\n` +
+        `${list(attributed.mine)}\n` +
+        `Commit, stash, or copy it before switching branches or closing the session.`,
+    );
+  }
+  if (attributed.theirs.length > 0) {
+    parts.push(
+      `[uncommitted-work-guard] Uncommitted work here was NOT made by this session:\n` +
+        `${list(attributed.theirs)}\n` +
+        `Do not commit or stash it — another session may be mid-way through it. Surface it to the operator instead. ` +
+        `If you are working in a shared clone, that is the defect to fix first: take a worktree.`,
+    );
+  }
+  if (parts.length === 0) return "";
+  return `${parts.join("\n\n")}\nBypass only when intentional: DPF_SKIP_UNCOMMITTED_WORK_GUARD=1.`;
+}
+
+/**
+ * BI-910C37B1: the honest message when the session's own touched-set is unknown.
+ *
+ * Lists what could be lost without asserting who made it, and names the shared
+ * clone as the thing to fix — because in a private worktree everything here is
+ * yours, and in a shared clone some of it is not.
+ *
+ * @param {Array<{path:string,xy:string,durable?:boolean}>} losable
+ * @param {{ context?: "session-end" | "post-checkout" }} [opts]
+ */
+export function buildUnattributedWarning(losable, opts = {}) {
+  if (losable.length === 0) return "";
+  const paths = losable.map((d) => `  - ${d.path} (${d.xy.trim() || "dirty"})`).join("\n");
+  const when =
+    opts.context === "post-checkout"
+      ? "You are switching branches with uncommitted work"
+      : "This session is ending with uncommitted work";
+  return (
+    `[uncommitted-work-guard] ${when}:\n${paths}\n` +
+    `If this is your work, commit, stash, or copy it now. If you are in a shared clone, some of it may belong to another session — ` +
+    `check before you commit or stash anything, and take a worktree so this cannot happen again. ` +
     `Bypass only when intentional: DPF_SKIP_UNCOMMITTED_WORK_GUARD=1.`
   );
 }

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -472,6 +472,10 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       ),
       node(
         "--test",
+        "packages/dpf-skill-pack/hooks/shared-clone-occupancy.test.mjs",
+      ),
+      node(
+        "--test",
         "scripts/process-spine-conformance.test.mjs",
         "scripts/lib/ensure-post-checkout-hook.test.mjs",
       ),


### PR DESCRIPTION
Closes `BI-910C37B1` and `BI-D234C277` — the detection half of the 2026-08-21 work-loss incident. (`BI-D471606A`, the prevention half, is #4448.)

## The guard watched the wrong files

It scanned `docs/superpowers/specs|plans/` only. During the incident it fired for a plan file and stayed **silent about the uncommitted source edits that were actually destroyed** — falsifying its own message, which calls spec edits "the #1 silent-loss vector".

It now scans every tracked modification, minus regenerated artifacts (`*.generated.*`, `*-baseline.*`, `.DS_Store`, rendered diagrams). That exclusion is not cosmetic: a guard that nags about generated JSON trains the reflex of waving it away, and that reflex is what loses real work.

## The guard could not tell whose work it found

Later the same session it reported **another session's** staged spec as if it belonged to the reader, with the advice *"commit, stash, or copy these files"*. Acting on that would have swept a stranger's in-flight work into a stash they do not know exists — the guard becoming the thing it exists to prevent.

Now: work this session made gets the recovery advice; work it did not gets a hands-off notice that says to surface it to the operator instead. Where no touched-set is available, the message says plainly that some of this may be another session's rather than asserting ownership either way. A hook cannot know what it did not observe, and pretending otherwise is what produced the dangerous advice.

## Nothing said the clone was occupied

A new SessionStart advisory (`shared-clone-occupancy.mjs`) states, before any work begins: this is the shared root clone, the branch it is sitting on, whether another session has staged work here, how many worktrees exist, and the `git worktree add` command to take instead.

The existing banner said `Worktree verification-readiness: SOURCE-ONLY`, which reads as a tooling limit, not a shared checkout — and that is how it was read. Git state only: no MCP, no portal, no network, so it still reports when everything else is down, which is exactly when a session is most likely to be improvising in the wrong directory.

It also names the blind spot that made the loss invisible: a `git checkout -- .` leaves **no reflog entry**, so nothing else would have reported it either.

## Notes

- Both hooks stay advisory, non-blocking, fail-open, with their existing bypasses (`DPF_SKIP_UNCOMMITTED_WORK_GUARD=1`, new `DPF_SKIP_CLONE_OCCUPANCY=1`).
- Occupancy lives in the plugin hook plane rather than `scripts/hooks`, because `run-hook.mjs` pairs `.sh`/`.ps1` and this needed one cross-platform home rather than two copies to keep in sync.
- A porcelain-column bug caught in review: trimming the status line first reads every unstaged edit as another session's staged work. Pinned by test.
- The new test file is registered in `ci-policy-guards.mjs`, so CI actually runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
