### PR TITLE
feat: enforce initiative entry readiness

### DIFF
--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -92,6 +92,10 @@ const { mockGetQuiescenceLevel } = vi.hoisted(() => ({
   mockGetQuiescenceLevel: vi.fn(),
 }));
 
+const { mockEnforceBuildInitiativeReadiness } = vi.hoisted(() => ({
+  mockEnforceBuildInitiativeReadiness: vi.fn(),
+}));
+
 vi.mock("@/lib/auth", () => ({
   auth: mockAuth,
 }));
@@ -127,17 +131,15 @@ vi.mock("@/lib/build/decision-service", () => ({
   evaluateBuildStudioDecision: mockEvaluateBuildStudioDecision,
 }));
 
+vi.mock("@/lib/build/build-entry-gate", () => ({
+  enforceBuildInitiativeReadiness: mockEnforceBuildInitiativeReadiness,
+  assertBuildPhaseInitiativeReadiness: mockEnforceBuildInitiativeReadiness,
+}));
+
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
-// `resumeBuildImplementation` / `advanceBuildPhase` fire `autoExecuteBuild`
-// fire-and-forget (build.ts). That background chain dynamically imports the
-// real build pipeline and event bus, whose console.log calls land AFTER the
-// test resolves — leaving an onUserConsoleLog RPC pending at worker teardown
-// (EnvironmentTeardownError, 0 failed tests, exit 1). Mocking both modules
-// makes the dispatch a silent no-op so the run is deterministic. These tests
-// assert governed-action behavior, not pipeline execution.
 vi.mock("@/lib/build-pipeline", () => ({
   runBuildPipeline: mockRunBuildPipeline,
 }));
@@ -157,10 +159,6 @@ vi.mock("@/lib/agent-event-bus", () => ({
   },
 }));
 
-// createFeatureBuild fires `void startBuildPhaseRun(...)` (cost tracking) which
-// throws QuiescingError whenever the portal is draining for a self-upgrade.
-// Mock the level reader so the test can drive that drain, and mirror the real
-// QuiescingError shape so `instanceof`/`.level` behave like production.
 vi.mock("@/lib/self-upgrade/quiescence", () => ({
   getQuiescenceLevel: mockGetQuiescenceLevel,
   QuiescingError: class QuiescingError extends Error {
@@ -224,6 +222,7 @@ describe("governed build start approvals", () => {
         confidenceScore: 0.9,
       },
     });
+    mockEnforceBuildInitiativeReadiness.mockResolvedValue({ allowed: true, message: "allowed" });
     mockEvaluateBuildStudioDecision.mockResolvedValue({
       status: "recommended",
       recommendation: { optionId: "start-implementation", confidence: "high", margin: 0.8 },

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -54,6 +54,7 @@ import {
   formatResumeImplementationOutcomeMessage,
 } from "@/lib/build/build-actions-core";
 import { admitRuntimeGuardedWork } from "@/lib/platform-runtime/work-admission";
+import { assertBuildPhaseInitiativeReadiness } from "@/lib/build/build-entry-gate";
 
 // ─── Auth Guard ──────────────────────────────────────────────────────────────
 
@@ -427,6 +428,8 @@ export async function advanceBuildPhase(
   if (!canTransitionPhase(currentPhase, targetPhase)) {
     throw new Error(`Cannot transition from ${currentPhase} to ${targetPhase}`);
   }
+
+  await assertBuildPhaseInitiativeReadiness({ buildId, currentPhase, targetPhase });
 
   if (currentPhase === "ideate" && targetPhase === "plan") {
     const businessBrief = await prisma.businessBuildBrief.findUnique({
@@ -924,7 +927,6 @@ export async function retryBuildExecution(buildId: string): Promise<void> {
     throw new Error("Build is not in a failed state. Cannot retry.");
   }
 
-  // Reset phase back to build if it was set to failed
   if (build.phase === "failed") {
     await prisma.featureBuild.update({
       where: { buildId },
@@ -1201,6 +1203,7 @@ export async function updateSandboxInfo(
   const build = await prisma.featureBuild.findUnique({ where: { buildId } });
   if (!build) throw new Error("Build not found");
   if (build.createdById !== userId) throw new Error("Forbidden");
+  await assertBuildPhaseInitiativeReadiness({ buildId, currentPhase: build.phase, targetPhase: "complete" });
 
   await prisma.featureBuild.update({
     where: { buildId },
@@ -1513,8 +1516,6 @@ export async function shipBuild(input: {
   };
 }
 
-// ─── Complete Build — mark phase as complete after all ship steps ────────────
-
 export async function completeBuild(buildId: string): Promise<void> {
   const userId = await requireBuildAccess();
 
@@ -1530,7 +1531,6 @@ export async function completeBuild(buildId: string): Promise<void> {
   await recordReadyDependentsAfterCompletion({ db: prisma, buildId }).catch((err) => {
     console.error("[completeBuild] dependency readiness check failed:", err);
   });
-  // BI-8BD61C30: drop sandbox .builds/<id> when the build completes (best-effort).
   void import("@/lib/build/sandbox/sandbox-build-gc")
     .then((m) => m.releaseSandboxForTerminalBuild(buildId, { deleteBranch: false }))
     .catch(() => {});

--- a/apps/web/lib/backlog/initiative-readiness/entry-adapter.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/entry-adapter.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+
+import { projectBacklogItemReadiness } from "./entry-adapter";
+
+const item = {
+  id: "row-1",
+  itemId: "BI-ENTRY",
+  type: "portfolio",
+  source: "user-request",
+  workType: "feature",
+  scopeKind: "platform",
+  archetypeCategories: [],
+  archetypeIds: [],
+  activeBuildKind: null,
+};
+
+const transitionObject = {
+  kind: "work-capsule" as const,
+  id: "WC-PENDING",
+  expectedVersion: "new",
+  targetState: "working",
+};
+
+describe("projectBacklogItemReadiness", () => {
+  it("allows governed design work before a canonical design exists", () => {
+    const projection = projectBacklogItemReadiness({
+      item,
+      activities: [],
+      target: "design",
+      transitionObject,
+      authorization: "pass",
+      capsuleIdentity: "pass",
+      evaluatedAt: "2026-08-22T00:00:00.000Z",
+    });
+
+    expect(projection.governed).toBe(true);
+    expect(projection.decision).toMatchObject({ verdict: "allowed", profile: "cross-domain" });
+  });
+
+  it("fails closed for an implementation claim with only textual spec and plan hints", () => {
+    const projection = projectBacklogItemReadiness({
+      item,
+      activities: [],
+      target: "implementation",
+      transitionObject,
+      authorization: "pass",
+      capsuleIdentity: "pass",
+      artifactHints: { hasSpec: true, hasPlan: true },
+      evaluatedAt: "2026-08-22T00:00:00.000Z",
+    });
+
+    expect(projection.decision.verdict).toBe("input-required");
+    expect(projection.decision.unmet.map((entry) => entry.code)).toEqual(expect.arrayContaining([
+      "CANONICAL_DESIGN_REQUIRED",
+      "SPEC_APPROVAL_REQUIRED",
+      "PLAN_REVIEW_REQUIRED",
+      "PLAN_COVERAGE_REQUIRED",
+    ]));
+  });
+
+  it("projects current typed evidence and one valid baseline into an allowed plan transition", () => {
+    const baseline = {
+      schemaVersion: 1,
+      baselineId: "baseline-1",
+      subject: { kind: "backlog-item", id: "BI-ENTRY" },
+      profile: "cross-domain",
+      artifactDigest: "sha256:design",
+      supersedesBaselineId: null,
+      objectiveStatements: [{ objectiveId: "OBJ-1" }],
+      acceptanceStatements: [{ acceptanceId: "AC-1" }],
+      approvalReceiptId: "r-approval",
+      authoritySnapshot: { decision: "allow" },
+    };
+    const receipt = (id: string, gateKey: string, decision: "pass" | "not-applicable" = "pass") => ({
+      id,
+      kind: "initiative_gate_receipt",
+      gateKey,
+      recordedAt: new Date("2026-08-22T00:00:00.000Z"),
+      payload: {
+        schemaVersion: 1,
+        receiptId: id,
+        policyVersion: "initiative-readiness.v1",
+        gate: gateKey,
+        decision,
+        subject: { kind: "backlog-item", id: "BI-ENTRY" },
+        artifactRef: { kind: "document-version", versionId: "version-1" },
+        artifactDigest: "sha256:design",
+        artifactAuthorRef: "PRN-AUTHOR",
+        reviewerPrincipalId: "PRN-REVIEWER",
+        reviewerAgentId: "AGT-REVIEWER",
+        authorityDecisionId: "DI-1",
+        authoritySnapshot: {
+          decision: "allow",
+          effectiveHumanCapability: "manage_backlog",
+          effectiveAgentGrant: "initiative_review",
+          tokenScope: "organization",
+          organizationId: "ORG-1",
+          actionKey: "review_initiative",
+          policyVersion: "coworker-authority.v1",
+        },
+        reason: "Reviewed against the current canonical design.",
+        findingRefs: [],
+        resolvedFindingRefs: [],
+      },
+    });
+    const activities = [
+      { id: "baseline-row", kind: "initiative_scope_baseline", gateKey: null, recordedAt: new Date(), payload: baseline },
+      receipt("r-research", "research"),
+      receipt("r-approval", "spec-approval"),
+      receipt("r-architecture", "architecture-review"),
+      receipt("r-data", "data-review", "not-applicable"),
+      receipt("r-ux", "ux-fit-review", "not-applicable"),
+      receipt("r-security", "security-review", "not-applicable"),
+      receipt("r-compliance", "compliance-review", "not-applicable"),
+      receipt("r-domain", "domain-review", "not-applicable"),
+    ];
+
+    const projection = projectBacklogItemReadiness({
+      item,
+      activities,
+      target: "plan",
+      transitionObject,
+      authorization: "pass",
+      capsuleIdentity: "pass",
+      evaluatedAt: "2026-08-22T00:00:00.000Z",
+    });
+
+    expect(projection.decision.verdict).toBe("allowed");
+    expect(projection.baselineId).toBe("baseline-1");
+  });
+
+  it("denies instead of falling back when the newest governance evidence is malformed", () => {
+    const projection = projectBacklogItemReadiness({
+      item,
+      activities: [{
+        id: "bad",
+        kind: "initiative_gate_receipt",
+        gateKey: "research",
+        recordedAt: new Date(),
+        payload: { schemaVersion: 99, decision: "pass" },
+      }],
+      target: "design",
+      transitionObject,
+      authorization: "pass",
+      capsuleIdentity: "pass",
+      evaluatedAt: "2026-08-22T00:00:00.000Z",
+    });
+
+    expect(projection.decision.verdict).toBe("denied");
+    expect(projection.decision.blockers.map((entry) => entry.code)).toContain("READINESS_PROJECTION_FAILED");
+  });
+
+  it("denies evidence whose typed subject belongs to another initiative", () => {
+    const projection = projectBacklogItemReadiness({
+      item,
+      activities: [{
+        id: "foreign",
+        kind: "initiative_gate_receipt",
+        gateKey: "research",
+        recordedAt: new Date(),
+        payload: {
+          schemaVersion: 1,
+          receiptId: "foreign",
+          policyVersion: "initiative-readiness.v1",
+          gate: "research",
+          decision: "pass",
+          subject: { kind: "backlog-item", id: "BI-FOREIGN" },
+          artifactRef: { kind: "document-version", versionId: "version-1" },
+          artifactDigest: "sha256:foreign",
+          artifactAuthorRef: "PRN-AUTHOR",
+          reviewerPrincipalId: "PRN-REVIEWER",
+          reviewerAgentId: "AGT-REVIEWER",
+          authorityDecisionId: "DI-1",
+          authoritySnapshot: { decision: "allow" },
+          reason: "Foreign review.",
+          findingRefs: [],
+          resolvedFindingRefs: [],
+        },
+      }],
+      target: "design",
+      transitionObject,
+      authorization: "pass",
+      capsuleIdentity: "pass",
+      evaluatedAt: "2026-08-22T00:00:00.000Z",
+    });
+
+    expect(projection.decision.verdict).toBe("denied");
+    expect(projection.decision.blockers.map((entry) => entry.code)).toContain("READINESS_PROJECTION_FAILED");
+  });
+});

--- a/apps/web/lib/backlog/initiative-readiness/entry-adapter.ts
+++ b/apps/web/lib/backlog/initiative-readiness/entry-adapter.ts
@@ -1,0 +1,328 @@
+import { evaluateInitiativeReadiness } from "./evaluate";
+import { deriveAuthoritativeReadinessProfile } from "./profiles";
+import type {
+  InitiativeReadinessDecision,
+  InitiativeReadinessFacts,
+  InitiativeTransitionObject,
+  ReadinessEvidenceState,
+  ReadinessTarget,
+} from "./types";
+
+export type InitiativeReadinessActivity = {
+  id: string;
+  kind: string;
+  gateKey: string | null;
+  recordedAt: Date;
+  payload: unknown;
+};
+
+export type InitiativeReadinessItem = {
+  id: string;
+  itemId: string;
+  type?: string | null;
+  source?: string | null;
+  workType?: string | null;
+  scopeKind?: string | null;
+  archetypeCategories?: readonly string[];
+  archetypeIds?: readonly string[];
+  activeBuildKind?: string | null;
+};
+
+type Baseline = {
+  baselineId: string;
+  supersedesBaselineId: string | null;
+  artifactDigest: string;
+  profile: InitiativeReadinessFacts["profile"];
+};
+
+const GATE_NAMES = new Set([
+  "classification", "research", "design-spec", "spec-approval", "architecture-review",
+  "data-review", "ux-fit-review", "security-review", "compliance-review", "domain-review",
+  "plan-review", "dependency-disposition", "archetype-provisioning", "archetype-completeness",
+]);
+
+function normalizeGate(value: string | null): string | null {
+  return value?.replaceAll("_", "-") ?? null;
+}
+
+function object(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function parseBaselines(activities: readonly InitiativeReadinessActivity[], itemId: string): {
+  current: Baseline | null;
+  malformed: boolean;
+  ambiguous: boolean;
+} {
+  const rows = activities.filter((activity) => activity.kind === "initiative_scope_baseline");
+  const parsed: Baseline[] = [];
+  for (const row of rows) {
+    const payload = object(row.payload);
+    const subject = object(payload?.subject);
+    const profile = payload?.profile;
+    if (!payload
+      || payload.schemaVersion !== 1
+      || typeof payload.baselineId !== "string"
+      || (payload.supersedesBaselineId !== null && typeof payload.supersedesBaselineId !== "string")
+      || typeof payload.artifactDigest !== "string"
+      || subject?.kind !== "backlog-item"
+      || subject.id !== itemId
+      || !(typeof profile === "string" && ["doc-only", "fix", "feature", "cross-domain", "archetype"].includes(profile))) {
+      return { current: null, malformed: true, ambiguous: true };
+    }
+    parsed.push({
+      baselineId: payload.baselineId,
+      supersedesBaselineId: payload.supersedesBaselineId as string | null,
+      artifactDigest: payload.artifactDigest,
+      profile: profile as Baseline["profile"],
+    });
+  }
+  const ids = new Set(parsed.map((entry) => entry.baselineId));
+  if (ids.size !== parsed.length || parsed.some((entry) => entry.supersedesBaselineId && !ids.has(entry.supersedesBaselineId))) {
+    return { current: null, malformed: false, ambiguous: true };
+  }
+  const superseded = new Set(parsed.flatMap((entry) => entry.supersedesBaselineId ? [entry.supersedesBaselineId] : []));
+  const heads = parsed.filter((entry) => !superseded.has(entry.baselineId));
+  return {
+    current: heads.length === 1 ? heads[0]! : null,
+    malformed: false,
+    ambiguous: heads.length > 1,
+  };
+}
+
+function validString(value: unknown): value is string {
+  return typeof value === "string" && Boolean(value.trim());
+}
+
+function validStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(validString);
+}
+
+function validArtifactRef(value: Record<string, unknown> | null): boolean {
+  if (!value) return false;
+  if (value.kind === "feature-build-revision") return validString(value.revisionId);
+  if (value.kind === "document-version") return validString(value.versionId);
+  return value.kind === "repo-blob-at-commit"
+    && validString(value.repositoryFullName)
+    && validString(value.commitSha)
+    && validString(value.path)
+    && validString(value.providerBlobId);
+}
+
+function validAuthoritySnapshot(value: Record<string, unknown> | null): boolean {
+  return value?.decision === "allow"
+    && validString(value.effectiveHumanCapability)
+    && validString(value.effectiveAgentGrant)
+    && validString(value.tokenScope)
+    && validString(value.organizationId)
+    && validString(value.actionKey)
+    && validString(value.policyVersion);
+}
+
+function projectGateReceipt(
+  activity: InitiativeReadinessActivity,
+  canonicalDigest: string | null,
+  itemId: string,
+): { state: ReadinessEvidenceState; malformed: boolean; gate: string | null } {
+  const payload = object(activity.payload);
+  const gate = normalizeGate(activity.gateKey);
+  if (!payload || !gate || !GATE_NAMES.has(gate)) return { state: "malformed", malformed: true, gate };
+  const payloadGate = normalizeGate(typeof payload.gate === "string" ? payload.gate : null);
+  const decision = payload.decision;
+  const artifactRef = object(payload.artifactRef);
+  const authority = object(payload.authoritySnapshot);
+  const subject = object(payload.subject);
+  const valid = payload.schemaVersion === 1
+    && payload.receiptId === activity.id
+    && payloadGate === gate
+    && ["pass", "fail", "not-applicable"].includes(String(decision))
+    && validString(payload.policyVersion)
+    && validString(payload.artifactDigest)
+    && validString(payload.artifactAuthorRef)
+    && validString(payload.reviewerPrincipalId)
+    && validString(payload.reviewerAgentId)
+    && validString(payload.authorityDecisionId)
+    && validString(payload.reason)
+    && subject?.kind === "backlog-item"
+    && subject.id === itemId
+    && validArtifactRef(artifactRef)
+    && validAuthoritySnapshot(authority)
+    && validStringArray(payload.findingRefs)
+    && validStringArray(payload.resolvedFindingRefs)
+    && (gate !== "classification" || decision !== "pass"
+      || ["doc-only", "fix", "feature", "cross-domain", "archetype"].includes(String(payload.selectedProfile)))
+    && (gate === "classification" || payload.selectedProfile === undefined)
+    && (decision === "fail" || payload.findingRefs.length === 0);
+  if (!valid) return { state: "malformed", malformed: true, gate };
+  if (canonicalDigest && payload.artifactDigest !== canonicalDigest) {
+    return { state: "stale", malformed: false, gate };
+  }
+  return { state: decision as ReadinessEvidenceState, malformed: false, gate };
+}
+
+function latestGateStates(
+  activities: readonly InitiativeReadinessActivity[],
+  canonicalDigest: string | null,
+  itemId: string,
+): { states: Map<string, ReadinessEvidenceState>; malformed: boolean } {
+  const latest = [...activities]
+    .filter((activity) => activity.kind === "initiative_gate_receipt")
+    .sort((left, right) => right.recordedAt.getTime() - left.recordedAt.getTime() || right.id.localeCompare(left.id));
+  const states = new Map<string, ReadinessEvidenceState>();
+  let malformed = false;
+  for (const activity of latest) {
+    const gate = normalizeGate(activity.gateKey);
+    if (gate && states.has(gate)) continue;
+    const projected = projectGateReceipt(activity, canonicalDigest, itemId);
+    malformed ||= projected.malformed;
+    if (projected.gate) states.set(projected.gate, projected.state);
+  }
+  return { states, malformed };
+}
+
+function state(states: ReadonlyMap<string, ReadinessEvidenceState>, gate: string): ReadinessEvidenceState {
+  return states.get(gate) ?? "missing";
+}
+
+function projectPlanCoverage(
+  activities: readonly InitiativeReadinessActivity[],
+  baseline: Baseline | null,
+): ReadinessEvidenceState {
+  const latest = [...activities]
+    .filter((activity) => activity.kind === "plan_backlog_coverage")
+    .sort((left, right) => right.recordedAt.getTime() - left.recordedAt.getTime() || right.id.localeCompare(left.id))[0];
+  if (!latest) return "missing";
+  const payload = object(latest.payload);
+  const artifact = object(payload?.planArtifactRef);
+  if (!payload
+    || payload.schemaVersion !== 2
+    || !["atomic", "decomposed"].includes(String(payload.decision))
+    || !validString(payload.planPath)
+    || !Array.isArray(payload.deliverables)
+    || artifact?.kind !== "repo-blob-at-commit"
+    || artifact.path !== payload.planPath
+    || !validString(payload.planArtifactDigest)
+    || !baseline
+    || payload.scopeBaselineId !== baseline.baselineId
+    || payload.scopeBaselineArtifactDigest !== baseline.artifactDigest) {
+    return "malformed";
+  }
+  return "pass";
+}
+
+export function projectBacklogItemReadiness(args: {
+  item: InitiativeReadinessItem;
+  activities: readonly InitiativeReadinessActivity[];
+  target: ReadinessTarget;
+  transitionObject: InitiativeTransitionObject;
+  authorization: ReadinessEvidenceState;
+  capsuleIdentity: ReadinessEvidenceState;
+  planCoverage?: ReadinessEvidenceState;
+  artifactHints?: { hasSpec: boolean; hasPlan: boolean };
+  evaluatedAt: string;
+}): {
+  governed: boolean;
+  baselineId: string | null;
+  artifactHints: { hasSpec: boolean; hasPlan: boolean };
+  decision: InitiativeReadinessDecision;
+} {
+  const baseline = parseBaselines(args.activities, args.item.itemId);
+  const receipts = latestGateStates(args.activities, baseline.current?.artifactDigest ?? null, args.item.itemId);
+  const profile = deriveAuthoritativeReadinessProfile({
+    ...args.item,
+    recordedProfiles: baseline.current ? [baseline.current.profile] : [],
+  });
+  const governed = profile !== null;
+  const evidence = receipts.states;
+  const baselineState: ReadinessEvidenceState = baseline.current ? "pass" : "missing";
+  const coverage = args.planCoverage ?? projectPlanCoverage(args.activities, baseline.current);
+  const dependency = state(evidence, "dependency-disposition");
+  const archetypeProvisioning = state(evidence, "archetype-provisioning");
+  const facts: InitiativeReadinessFacts = {
+    subject: { kind: "backlog-item", id: args.item.itemId },
+    transitionObject: args.transitionObject,
+    profile: profile ?? "doc-only",
+    evaluatedAt: args.evaluatedAt,
+    classification: profile ? "pass" : "missing",
+    canonicalDesign: baselineState,
+    canonicalDesignAmbiguous: baseline.ambiguous,
+    research: state(evidence, "research"),
+    specApproval: state(evidence, "spec-approval"),
+    specialistReviews: {
+      architecture: state(evidence, "architecture-review"),
+      data: state(evidence, "data-review"),
+      ux: state(evidence, "ux-fit-review"),
+      security: state(evidence, "security-review"),
+      compliance: state(evidence, "compliance-review"),
+      domain: state(evidence, "domain-review"),
+    },
+    plan: coverage,
+    planReview: state(evidence, "plan-review"),
+    planCoverage: coverage,
+    traceability: coverage,
+    dependencies: dependency === "missing" ? "not-applicable" : dependency,
+    authorization: args.authorization,
+    artifactAuthor: baselineState,
+    capsuleIdentity: args.capsuleIdentity,
+    deliveryEvidence: "missing",
+    acceptanceEvidence: "missing",
+    objectiveBaseline: baselineState,
+    objectiveReconciliation: "missing",
+    archetypeProvisioning: {
+      templateSubstrate: archetypeProvisioning,
+      professionCorpus: archetypeProvisioning,
+      coworkerDefinition: archetypeProvisioning,
+      skillsAndTools: archetypeProvisioning,
+    },
+    archetypeCompleteness: state(evidence, "archetype-completeness"),
+    projectionError: baseline.malformed || receipts.malformed,
+  };
+  return {
+    governed,
+    baselineId: baseline.current?.baselineId ?? null,
+    artifactHints: args.artifactHints ?? { hasSpec: false, hasPlan: false },
+    decision: evaluateInitiativeReadiness(facts, args.target),
+  };
+}
+
+export function projectBacklogItemReadinessSummary(args: {
+  item: InitiativeReadinessItem;
+  activities: readonly InitiativeReadinessActivity[];
+  hasSpec: boolean;
+  hasPlan: boolean;
+  evaluatedAt: string;
+}) {
+  const decisions = Object.fromEntries((["design", "plan", "implementation", "completion"] as const).map((target) => {
+    const projected = projectBacklogItemReadiness({
+      item: args.item,
+      activities: args.activities,
+      target,
+      transitionObject: {
+        kind: "backlog-item",
+        id: args.item.itemId,
+        expectedVersion: "read-projection",
+        targetState: target,
+      },
+      authorization: "pass",
+      capsuleIdentity: "pass",
+      artifactHints: { hasSpec: args.hasSpec, hasPlan: args.hasPlan },
+      evaluatedAt: args.evaluatedAt,
+    });
+    return [target, projected.decision];
+  })) as Record<ReadinessTarget, InitiativeReadinessDecision>;
+  return {
+    governed: projectBacklogItemReadiness({
+      item: args.item,
+      activities: args.activities,
+      target: "design",
+      transitionObject: { kind: "backlog-item", id: args.item.itemId, expectedVersion: "read-projection", targetState: "design" },
+      authorization: "pass",
+      capsuleIdentity: "pass",
+      evaluatedAt: args.evaluatedAt,
+    }).governed,
+    artifactHints: { hasSpec: args.hasSpec, hasPlan: args.hasPlan },
+    decisions,
+  };
+}

--- a/apps/web/lib/backlog/initiative-readiness/index.ts
+++ b/apps/web/lib/backlog/initiative-readiness/index.ts
@@ -3,6 +3,7 @@ export * from "./baseline-manifest";
 export * from "./baseline-repository";
 export * from "./objective-mapping-repository";
 export * from "./evaluate";
+export * from "./entry-adapter";
 export * from "./profiles";
 export * from "./projection";
 export * from "./receipt-reader";

--- a/apps/web/lib/backlog/recommend.test.ts
+++ b/apps/web/lib/backlog/recommend.test.ts
@@ -19,10 +19,35 @@ function candidate(overrides: Partial<RecommendCandidate>): RecommendCandidate {
     epicStatus: null,
     hasSpec: false,
     hasPlan: false,
+    implementationReadinessVerdict: "input-required",
     updatedAt: baseDate,
     ...overrides,
   };
 }
+
+describe("rankCandidates — readiness intent", () => {
+  it("does not recommend an underspecified initiative for implementation", () => {
+    const ranked = rankCandidates([
+      candidate({ itemId: "BI-DESIGN", hasSpec: true, hasPlan: true }),
+      candidate({ itemId: "BI-READY", implementationReadinessVerdict: "allowed" }),
+    ], { mode: "implementation-ready" });
+
+    expect(ranked.map((entry) => entry.itemId)).toEqual(["BI-READY"]);
+    expect(ranked[0]?.signals.implementationReadinessVerdict).toBe("allowed");
+  });
+
+  it("keeps underspecified initiatives visible as design candidates with an honest next action", () => {
+    const ranked = rankCandidates([
+      candidate({ itemId: "BI-DESIGN", hasSpec: true, hasPlan: false }),
+    ], { mode: "design-candidate" });
+
+    expect(ranked[0]).toMatchObject({
+      itemId: "BI-DESIGN",
+      nextAction: "continue-design",
+      signals: { implementationReadinessVerdict: "input-required" },
+    });
+  });
+});
 
 describe("rankCandidates — demand value", () => {
   it("ranks a higher demandScore ahead of a lower one (all else equal)", () => {

--- a/apps/web/lib/backlog/recommend.ts
+++ b/apps/web/lib/backlog/recommend.ts
@@ -13,6 +13,7 @@ export type RecommendCandidate = {
   epicStatus: string | null;
   hasSpec: boolean;
   hasPlan: boolean;
+  implementationReadinessVerdict: "allowed" | "input-required" | "denied";
   updatedAt: Date;
 };
 
@@ -22,6 +23,7 @@ export type RankedCandidate = {
   rationale: string;
   rank: number;
   score: number;
+  nextAction: "start-implementation" | "continue-design";
   signals: {
     hasSpec: boolean;
     hasPlan: boolean;
@@ -31,6 +33,7 @@ export type RankedCandidate = {
     priority: number | null;
     epicStatus: string | null;
     demandScore: number | null;
+    implementationReadinessVerdict: "allowed" | "input-required" | "denied";
   };
 };
 
@@ -38,6 +41,7 @@ export type RankOptions = {
   excludeItemIds?: readonly string[];
   forAgentId?: string | null;
   count?: number;
+  mode?: "design-candidate" | "implementation-ready";
 };
 
 const DEFAULT_COUNT = 3;
@@ -97,7 +101,9 @@ export function rankCandidates(
   const forAgentId = opts.forAgentId ?? null;
 
   const eligible = items.filter(
-    (item) => !exclude.has(item.itemId) && isPickable(item, forAgentId),
+    (item) => !exclude.has(item.itemId)
+      && isPickable(item, forAgentId)
+      && (opts.mode !== "implementation-ready" || item.implementationReadinessVerdict === "allowed"),
   );
 
   // Batch-relative demand-value term: normalize each item's demandScore against
@@ -139,6 +145,9 @@ export function rankCandidates(
     rationale: buildRationale(entry.firedSignals),
     rank: idx + 1,
     score: Math.round(entry.score * 100) / 100,
+    nextAction: entry.item.implementationReadinessVerdict === "allowed"
+      ? "start-implementation"
+      : "continue-design",
     signals: {
       hasSpec: entry.item.hasSpec,
       hasPlan: entry.item.hasPlan,
@@ -150,6 +159,7 @@ export function rankCandidates(
       priority: entry.item.priority,
       epicStatus: entry.item.epicStatus,
       demandScore: entry.item.demandScore,
+      implementationReadinessVerdict: entry.item.implementationReadinessVerdict,
     },
   }));
 }

--- a/apps/web/lib/build-flow-state.test.ts
+++ b/apps/web/lib/build-flow-state.test.ts
@@ -19,6 +19,9 @@ vi.mock("@/lib/agent-event-bus", () => ({
 vi.mock("@/lib/self-upgrade/completion", () => ({
   isFeatureBuildDeployed: vi.fn(),
 }));
+vi.mock("@/lib/build/build-entry-gate", () => ({
+  enforceBuildInitiativeReadiness: vi.fn(async () => ({ allowed: true, message: "allowed" })),
+}));
 
 import { prisma } from "@dpf/db";
 import { isFeatureBuildDeployed } from "@/lib/self-upgrade/completion";

--- a/apps/web/lib/build-flow-state.ts
+++ b/apps/web/lib/build-flow-state.ts
@@ -16,6 +16,7 @@ import { PHASE_LABELS } from "@/lib/feature-build-types";
 import { isFeatureBuildDeployed } from "@/lib/self-upgrade/completion";
 import { recordReadyDependentsAfterCompletion } from "@/lib/build/feature-build-dependencies";
 import { readBuildPrDeliveryState } from "@/lib/build/build-pr-delivery-state";
+import { enforceBuildInitiativeReadiness } from "@/lib/build/build-entry-gate";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -472,6 +473,10 @@ export async function reconcileBuildCompletion(buildId: string): Promise<boolean
   if (state.upstream.state !== "skipped" && !(await isFeatureBuildDeployed(buildId))) {
     return false;
   }
+  const readiness = await enforceBuildInitiativeReadiness({
+    buildId, target: "completion", targetPhase: "complete", expectedPhase: "ship",
+  });
+  if (!readiness.allowed) return false;
 
   await prisma.featureBuild.update({
     where: { buildId },

--- a/apps/web/lib/build/build-entry-gate.test.ts
+++ b/apps/web/lib/build/build-entry-gate.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { enforceBuildInitiativeReadiness } from "./build-entry-gate";
+
+function database(activities: unknown[] = []) {
+  return {
+    featureBuild: {
+      findUnique: vi.fn().mockResolvedValue({
+        id: "build-row",
+        buildId: "FB-ENTRY",
+        kind: "feature",
+        originatingBacklogItemId: "bi-row",
+        designReview: { decision: "pass" },
+        planReview: { decision: "pass" },
+        originator: {
+          id: "bi-row",
+          itemId: "BI-ENTRY",
+          type: "portfolio",
+          source: "user-request",
+          workType: "feature",
+          scopeKind: "platform",
+          archetypeCategories: [],
+          archetypeIds: [],
+          activities,
+        },
+      }),
+    },
+    backlogItemActivity: {
+      create: vi.fn().mockResolvedValue({ id: "decision-row" }),
+    },
+    buildActivity: {
+      create: vi.fn().mockResolvedValue({ id: "build-activity" }),
+    },
+  };
+}
+
+describe("enforceBuildInitiativeReadiness", () => {
+  it("does not treat legacy designReview or planReview JSON as governed evidence", async () => {
+    const db = database();
+
+    const result = await enforceBuildInitiativeReadiness({
+      db,
+      buildId: "FB-ENTRY",
+      target: "implementation",
+      targetPhase: "build",
+      evaluatedAt: "2026-08-22T00:00:00.000Z",
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.decision.unmet.map((entry) => entry.code)).toContain("SPEC_APPROVAL_REQUIRED");
+    expect(db.backlogItemActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ kind: "initiative_readiness_decision" }),
+    }));
+  });
+
+  it("fails closed when a governed build has no canonical backlog subject", async () => {
+    const db = database();
+    db.featureBuild.findUnique.mockResolvedValueOnce({
+      id: "build-row",
+      buildId: "FB-ORPHAN",
+      kind: "feature",
+      originatingBacklogItemId: null,
+      originator: null,
+    });
+
+    const result = await enforceBuildInitiativeReadiness({
+      db,
+      buildId: "FB-ORPHAN",
+      target: "plan",
+      targetPhase: "plan",
+      evaluatedAt: "2026-08-22T00:00:00.000Z",
+    });
+
+    expect(result).toMatchObject({ allowed: false, error: "classification_required" });
+    expect(db.buildActivity.create).toHaveBeenCalled();
+  });
+
+  it("returns an allowed decision from the shared projector without consulting advisory JSON", async () => {
+    const db = database();
+    const projectReadiness = vi.fn().mockReturnValue({
+      governed: true,
+      decision: {
+        decisionId: "IRD-ALLOWED",
+        policyVersion: "initiative-readiness.v1",
+        subject: { kind: "backlog-item", id: "BI-ENTRY" },
+        transitionObject: { kind: "feature-build", id: "FB-ENTRY", expectedVersion: "ideate", targetState: "plan" },
+        profile: "feature",
+        target: "plan",
+        verdict: "allowed",
+        satisfied: [],
+        unmet: [],
+        blockers: [],
+        evaluatedAt: "2026-08-22T00:00:00.000Z",
+      },
+    });
+
+    const result = await enforceBuildInitiativeReadiness({
+      db,
+      buildId: "FB-ENTRY",
+      target: "plan",
+      targetPhase: "plan",
+      evaluatedAt: "2026-08-22T00:00:00.000Z",
+      dependencies: { projectReadiness },
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(projectReadiness).toHaveBeenCalledWith(expect.objectContaining({
+      activities: [],
+      target: "plan",
+    }));
+  });
+});

--- a/apps/web/lib/build/build-entry-gate.ts
+++ b/apps/web/lib/build/build-entry-gate.ts
@@ -1,0 +1,165 @@
+import { randomUUID } from "node:crypto";
+
+import { prisma } from "@dpf/db";
+
+import {
+  projectBacklogItemReadiness,
+  type InitiativeReadinessActivity,
+  type InitiativeReadinessDecision,
+  type ReadinessTarget,
+} from "@/lib/backlog/initiative-readiness";
+
+type BuildEntryGateDb = {
+  featureBuild: { findUnique(args: unknown): Promise<any> };
+  backlogItemActivity: { create(args: unknown): Promise<any> };
+  buildActivity: { create(args: unknown): Promise<any> };
+};
+
+type ProjectReadiness = typeof projectBacklogItemReadiness;
+
+export type BuildInitiativeReadinessResult = {
+  allowed: boolean;
+  error?: "classification_required" | "initiative_not_ready";
+  message: string;
+  decision: InitiativeReadinessDecision;
+};
+
+function withDecisionId(decision: InitiativeReadinessDecision): InitiativeReadinessDecision {
+  return decision.decisionId === "unpersisted"
+    ? { ...decision, decisionId: `IRD-${randomUUID().replaceAll("-", "").slice(0, 12).toUpperCase()}` }
+    : decision;
+}
+
+function orphanDecision(args: {
+  buildId: string;
+  target: ReadinessTarget;
+  targetPhase: string;
+  evaluatedAt: string;
+}): InitiativeReadinessDecision {
+  return {
+    decisionId: `IRD-${randomUUID().replaceAll("-", "").slice(0, 12).toUpperCase()}`,
+    policyVersion: "initiative-readiness.v1",
+    subject: { kind: "feature-build", id: args.buildId },
+    transitionObject: {
+      kind: "feature-build",
+      id: args.buildId,
+      expectedVersion: "current",
+      targetState: args.targetPhase,
+    },
+    profile: "feature",
+    target: args.target,
+    verdict: "denied",
+    satisfied: [],
+    unmet: [],
+    blockers: [{ code: "CLASSIFICATION_REQUIRED", state: "blocked", accountableRole: "product-owner", evidenceRefs: [] }],
+    evaluatedAt: args.evaluatedAt,
+  };
+}
+
+function codes(decision: InitiativeReadinessDecision) {
+  return [...decision.blockers, ...decision.unmet].map((entry) => entry.code);
+}
+
+export async function enforceBuildInitiativeReadiness(args: {
+  buildId: string;
+  target: ReadinessTarget;
+  targetPhase: string;
+  expectedPhase?: string;
+  evaluatedAt?: string;
+  db?: BuildEntryGateDb;
+  dependencies?: { projectReadiness?: ProjectReadiness };
+}): Promise<BuildInitiativeReadinessResult> {
+  const db = args.db ?? (prisma as unknown as BuildEntryGateDb);
+  const evaluatedAt = args.evaluatedAt ?? new Date().toISOString();
+  const build = await db.featureBuild.findUnique({
+    where: { buildId: args.buildId },
+    select: {
+      id: true,
+      buildId: true,
+      kind: true,
+      originatingBacklogItemId: true,
+      originator: {
+        select: {
+          id: true, itemId: true, type: true, source: true, workType: true, scopeKind: true,
+          archetypeCategories: true, archetypeIds: true,
+          activities: {
+            where: { kind: { in: ["initiative_gate_receipt", "initiative_scope_baseline", "plan_backlog_coverage"] } },
+            orderBy: [{ recordedAt: "desc" }, { id: "desc" }],
+            take: 100,
+            select: { id: true, kind: true, gateKey: true, recordedAt: true, payload: true },
+          },
+        },
+      },
+    },
+  });
+  if (!build) throw new Error(`FeatureBuild ${args.buildId} not found.`);
+  if (!build.originator) {
+    const decision = orphanDecision({ ...args, evaluatedAt });
+    await db.buildActivity.create({ data: {
+      buildId: args.buildId,
+      tool: "initiative-readiness",
+      summary: `${args.target} denied: CLASSIFICATION_REQUIRED`,
+    } });
+    return { allowed: false, error: "classification_required", message: "Build has no canonical originating backlog subject.", decision };
+  }
+
+  const projected = (args.dependencies?.projectReadiness ?? projectBacklogItemReadiness)({
+    item: { ...build.originator, activeBuildKind: build.kind },
+    activities: build.originator.activities as InitiativeReadinessActivity[],
+    target: args.target,
+    transitionObject: {
+      kind: "feature-build",
+      id: build.buildId,
+      expectedVersion: args.expectedPhase ?? "current",
+      targetState: args.targetPhase,
+    },
+    authorization: "pass",
+    capsuleIdentity: "pass",
+    evaluatedAt,
+  });
+  const decision = withDecisionId(projected.decision);
+  await db.backlogItemActivity.create({ data: {
+    backlogItemId: build.originator.id,
+    kind: "initiative_readiness_decision",
+    summary: `${args.target} readiness: ${decision.verdict}`,
+    payload: {
+      schemaVersion: 1,
+      ...decision,
+      stableCodes: codes(decision),
+      authority: { actionKey: "advance_build_phase", enforcementState: "enforced" },
+    },
+  } });
+  const blocked = projected.governed && decision.verdict !== "allowed";
+  return {
+    allowed: !blocked,
+    ...(blocked ? { error: "initiative_not_ready" as const } : {}),
+    message: blocked
+      ? `Cannot enter ${args.targetPhase}: ${codes(decision).join(", ")}.`
+      : `${args.target} readiness allowed.`,
+    decision,
+  };
+}
+
+export async function assertBuildPhaseInitiativeReadiness(args: {
+  buildId: string;
+  currentPhase: string;
+  targetPhase: string;
+}): Promise<void> {
+  const target = args.currentPhase === "ideate" && args.targetPhase === "plan"
+    ? "plan"
+    : args.currentPhase === "plan" && args.targetPhase === "build"
+      ? "implementation"
+      : args.currentPhase === "review" && args.targetPhase === "ship"
+        ? "implementation"
+        : args.targetPhase === "complete"
+          ? "completion"
+          : null;
+  if (!target) return;
+  const readiness = await enforceBuildInitiativeReadiness({
+    buildId: args.buildId,
+    target,
+    targetPhase: args.targetPhase,
+    expectedPhase: args.currentPhase,
+  });
+  if (!readiness.allowed) throw new Error(readiness.message);
+}

--- a/apps/web/lib/build/build-on-plan-approval.ts
+++ b/apps/web/lib/build/build-on-plan-approval.ts
@@ -18,6 +18,7 @@
 // Called from: reviewBuildPlan success path in mcp-tools.ts (fire-and-forget).
 
 import { prisma } from "@dpf/db";
+import { enforceBuildInitiativeReadiness } from "@/lib/build/build-entry-gate";
 
 function logBuildActivity(buildId: string, tool: string, summary: string): Promise<void> {
   return prisma.buildActivity.create({ data: { buildId, tool, summary } }).then(() => void 0).catch(() => void 0);
@@ -73,6 +74,15 @@ export async function dispatchBuildForApprovedPlan(params: {
     if (!build.buildPlan) {
       await log("Skipped — no buildPlan");
       return { kind: "skipped-no-plan", reason: "buildPlan is null" };
+    }
+    if (build.phase === "plan") {
+      const readiness = await enforceBuildInitiativeReadiness({
+        buildId, target: "implementation", targetPhase: "build", expectedPhase: "plan",
+      });
+      if (!readiness.allowed) {
+        await log(`Skipped — ${readiness.message}`);
+        return { kind: "dispatched-failure", error: readiness.message, durationMs: Date.now() - t0 };
+      }
     }
 
     const plan = build.buildPlan as { fileStructure?: unknown[]; tasks?: unknown[] };

--- a/apps/web/lib/build/plan-to-build-transition.test.ts
+++ b/apps/web/lib/build/plan-to-build-transition.test.ts
@@ -15,6 +15,7 @@ const startBuildBranchMock = vi.fn();
 const startBuildPhaseRunMock = vi.fn();
 const completeBuildPhaseRunMock = vi.fn();
 const dispatchBuildMock = vi.fn();
+const enforceInitiativeReadinessMock = vi.fn();
 
 vi.mock("@dpf/db", () => {
   const prisma = {
@@ -54,6 +55,9 @@ vi.mock("@/lib/build/build-phase-run", () => ({
 }));
 vi.mock("@/lib/build/build-on-plan-approval", () => ({
   dispatchBuildForApprovedPlan: (...a: unknown[]) => dispatchBuildMock(...a),
+}));
+vi.mock("@/lib/build/build-entry-gate", () => ({
+  enforceBuildInitiativeReadiness: (...a: unknown[]) => enforceInitiativeReadinessMock(...a),
 }));
 
 import {
@@ -132,6 +136,17 @@ describe("performPlanToBuildTransition (BI-05208DE5)", () => {
     startBuildPhaseRunMock.mockReset().mockResolvedValue(undefined);
     completeBuildPhaseRunMock.mockReset().mockResolvedValue(undefined);
     dispatchBuildMock.mockReset().mockResolvedValue({ kind: "dispatched" });
+    enforceInitiativeReadinessMock.mockReset().mockResolvedValue({ allowed: true, message: "allowed" });
+  });
+
+  it("blocks before branch mutation when canonical implementation readiness is not allowed", async () => {
+    enforceInitiativeReadinessMock.mockResolvedValueOnce({ allowed: false, message: "PLAN_COVERAGE_REQUIRED" });
+
+    const out = await performPlanToBuildTransition({ buildId: "FB-X", userId: "u1" });
+
+    expect(out).toEqual({ kind: "gate-blocked", reason: "PLAN_COVERAGE_REQUIRED" });
+    expect(startBuildBranchMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalledWith(expect.objectContaining({ data: { phase: "build" } }));
   });
 
   it("advances a complete, reviewed, WWMD-recommended plan to build (initializes branch, flips phase, dispatches)", async () => {

--- a/apps/web/lib/build/plan-to-build-transition.ts
+++ b/apps/web/lib/build/plan-to-build-transition.ts
@@ -41,6 +41,7 @@ import { logBuildActivity } from "@/lib/mcp/build-tool-helpers";
 import { resolvePlannedFilePaths } from "@/lib/decision-perspective/planned-file-paths";
 import type { DecisionOutcomeType } from "@/lib/decision-perspective/types";
 import type { AutonomousBuildExecutionProfileRefV1 } from "@/lib/build/autonomous-build-eligibility-reader";
+import { enforceBuildInitiativeReadiness } from "@/lib/build/build-entry-gate";
 
 /**
  * How many consecutive failed plan→build transition attempts before a build
@@ -268,6 +269,16 @@ export async function performPlanToBuildTransition(params: {
   if (!build) return { kind: "not-ready", reason: "build not found" };
   if (build.phase !== "plan" || !canTransitionPhase("plan", "build")) {
     return { kind: "not-ready", reason: `build is in phase ${build.phase}, not plan` };
+  }
+  const initiativeReadiness = await enforceBuildInitiativeReadiness({
+    buildId,
+    target: "implementation",
+    targetPhase: "build",
+    expectedPhase: "plan",
+  });
+  if (!initiativeReadiness.allowed) {
+    logBuildActivity(buildId, "phase:gate-blocked", initiativeReadiness.message);
+    return { kind: "gate-blocked", reason: initiativeReadiness.message };
   }
 
   // Already escalated → do not re-attempt the failing transition; keep the

--- a/apps/web/lib/build/ship-on-review-approval.test.ts
+++ b/apps/web/lib/build/ship-on-review-approval.test.ts
@@ -120,6 +120,9 @@ vi.mock("@/lib/agent-event-bus", () => ({
 vi.mock("@/lib/build/auto-accept", () => ({
   autoAcceptBuildOnEvidence: vi.fn(async () => ({ accepted: false as const, reason: "flag-off" })),
 }));
+vi.mock("@/lib/build/build-entry-gate", () => ({
+  enforceBuildInitiativeReadiness: vi.fn(async () => ({ allowed: true, message: "allowed" })),
+}));
 
 import {
   dispatchShipForVerifiedBuild,

--- a/apps/web/lib/build/ship-on-review-approval.ts
+++ b/apps/web/lib/build/ship-on-review-approval.ts
@@ -25,6 +25,7 @@
 // Once operators have reviewed a few cycles, this gate can be made opt-out.
 
 import { prisma } from "@dpf/db";
+import { enforceBuildInitiativeReadiness } from "@/lib/build/build-entry-gate";
 
 import { resolveShippedFilePaths } from "@/lib/decision-perspective/planned-file-paths";
 
@@ -285,6 +286,13 @@ export async function advanceReviewedBuildToShip(
   );
   if (!canTransitionPhase("review", "ship")) {
     return { kind: "skipped", reason: "transition not allowed" };
+  }
+  const readiness = await enforceBuildInitiativeReadiness({
+    buildId, target: "implementation", targetPhase: "ship", expectedPhase: "review",
+  });
+  if (!readiness.allowed) {
+    await log(`Not advanced — ${readiness.message}`);
+    return { kind: "skipped", reason: readiness.message };
   }
 
   const brief = build.brief as { fixContext?: unknown } | null;

--- a/apps/web/lib/mcp/build-design-review-handler.ts
+++ b/apps/web/lib/mcp/build-design-review-handler.ts
@@ -23,6 +23,7 @@ import {
 } from "@/lib/mcp/build-tool-helpers";
 import type { ReviewBranchInput } from "@/lib/build/build-reviewers";
 import { triggerDesignReviewAutoRepair } from "@/lib/build/pre-build-review-auto-repair";
+import { enforceBuildInitiativeReadiness } from "@/lib/build/build-entry-gate";
 import { toFailureResult } from "./build-review-handlers";
 
 type HandlerContext = Parameters<ToolPackHandler>[2];
@@ -67,7 +68,10 @@ export async function reviewDesignDoc(params: Record<string, unknown>, userId: s
         try {
           const fixPlan = (build.plan as Record<string, unknown> | null);
           const gate = checkPhaseGate("ideate", "plan", { kind: "fix", processSize: fixProcessSize, deliverableSensitivity: fixPlan?.deliverableSensitivity, qualityFirst: fixPlan?.qualityFirst === true, fixContext: fc, designReview: review });
-          if (gate.allowed) {
+          const readiness = gate.allowed
+            ? await enforceBuildInitiativeReadiness({ buildId, target: "plan", targetPhase: "plan", expectedPhase: "ideate" })
+            : null;
+          if (gate.allowed && readiness?.allowed) {
             const { completeBuildPhaseRun, startBuildPhaseRun } = await import("@/lib/build/build-phase-run");
             void completeBuildPhaseRun(buildId, "ideate");
             void startBuildPhaseRun(buildId, "plan").catch(() => {}); // swallow QuiescingError thrown during a self-upgrade drain (BI-QUIESCE-005)
@@ -79,8 +83,9 @@ export async function reviewDesignDoc(params: Record<string, unknown>, userId: s
             if (context?.threadId) agentEventBus.emit(context.threadId, { type: "phase:change", buildId, phase: "plan" });
             logBuildActivity(buildId, "phase:advance", "Phase advanced: ideate → plan (fix)");
           } else {
-            logBuildActivity(buildId, "phase:gate-blocked", gate.reason ?? "unknown");
-            fixPhaseGateBlocker = gate.reason ?? null;
+            const reason = gate.reason ?? readiness?.message ?? "Initiative readiness is incomplete.";
+            logBuildActivity(buildId, "phase:gate-blocked", reason);
+            fixPhaseGateBlocker = reason;
           }
         } catch (err) {
           console.error("[reviewDesignDoc:fix] auto-advance failed:", err);
@@ -557,7 +562,10 @@ export async function reviewDesignDoc(params: Record<string, unknown>, userId: s
             designReview: updatedBuild.designReview,
             happyPathState,
           });
-          if (gate.allowed) {
+          const readiness = gate.allowed
+            ? await enforceBuildInitiativeReadiness({ buildId, target: "plan", targetPhase: "plan", expectedPhase: "ideate" })
+            : null;
+          if (gate.allowed && readiness?.allowed) {
             // EP-COST Phase 3: record ideate-phase cost rollup, start plan tracking, and compact thread
             const { completeBuildPhaseRun, startBuildPhaseRun } = await import("@/lib/build/build-phase-run");
             void completeBuildPhaseRun(buildId, "ideate");
@@ -577,14 +585,15 @@ export async function reviewDesignDoc(params: Record<string, unknown>, userId: s
                 .catch(err => console.error("[plan-on-approval] auto-dispatch failed:", err))
             );
           } else {
-            logBuildActivity(buildId, "phase:gate-blocked", gate.reason ?? "unknown");
+            const reason = gate.reason ?? readiness?.message ?? "Initiative readiness is incomplete.";
+            logBuildActivity(buildId, "phase:gate-blocked", reason);
             // Surface the blocker to the agent so it can self-correct on the next
             // turn. Without this, the agent sees "review passed" and assumes
             // ideate is done — but the phase silently stays in ideate forever
             // because intake anchors (taxonomy, constrainedGoal) weren't set.
             // The agent has the tools (confirm_taxonomy_placement,
             // update_feature_brief) — it just didn't know they were required.
-            phaseGateBlocker = gate.reason ?? null;
+            phaseGateBlocker = reason;
           }
         }
       } catch (err) {

--- a/apps/web/lib/mcp/build-lifecycle-handlers.ts
+++ b/apps/web/lib/mcp/build-lifecycle-handlers.ts
@@ -17,6 +17,7 @@ import {
   updateBuildHappyPathState,
 } from "@/lib/mcp/build-tool-helpers";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { enforceBuildInitiativeReadiness } from "@/lib/build/build-entry-gate";
 import { resolveIdeateBuildForToolPure } from "@/lib/build/ideate-build-resolution";
 import { formatUpdateFeatureBriefError } from "./update-feature-brief-error";
 
@@ -211,6 +212,12 @@ export async function verificationPreflight(params: Record<string, unknown>, use
 export async function startBuild(params: Record<string, unknown>, userId: string, context?: HandlerContext): Promise<ToolResult> {
   const buildId = await resolveActiveBuildId(userId, extractBuildIdHint(params));
   if (!buildId) return { success: false, error: "No active build.", message: "No active build." };
+  const readiness = await enforceBuildInitiativeReadiness({
+    buildId, target: "implementation", targetPhase: "build", expectedPhase: "plan",
+  });
+  if (!readiness.allowed) {
+    return { success: false, error: "initiative_not_ready", message: readiness.message, data: { readiness: readiness.decision } };
+  }
 
   try {
     const { assertFeatureBuildDependenciesSatisfied } = await import("@/lib/build/feature-build-dependencies");
@@ -483,4 +490,3 @@ export async function startScoutResearch(params: Record<string, unknown>, userId
     data: { urlCount: externalUrls.length },
   };
 }
-

--- a/apps/web/lib/mcp/packs/backlog-pack-definitions.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack-definitions.ts
@@ -296,7 +296,7 @@ export const backlogPackDefinitions: ToolDefinition[] = [
   {
     name: "get_next_recommended_work",
     description:
-      "Return a short ranked list of backlog items the caller could pick up next. Ranks by spec/plan presence, triage outcome, effort size, priority, and active-build state. Read-only. " +
+      "Return a short ranked list of backlog items the caller could pick up next. Design-candidate mode keeps provisional work visible with Continue design; implementation-ready mode returns only initiatives allowed by the canonical readiness policy. Textual spec/plan references are hints, never proof of implementation readiness. Read-only. " +
       "Call once at session start (or after finishing a BI); pass excludeItemIds for rejected candidates instead of re-polling without filters.",
     inputSchema: {
       type: "object",
@@ -305,6 +305,7 @@ export const backlogPackDefinitions: ToolDefinition[] = [
         epicId: { type: "string", description: "Restrict to one epic" },
         forAgentId: { type: "string", description: "Only items grant-claimable by this agent" },
         excludeItemIds: { type: "array", items: { type: "string" }, description: "Items to skip (already considered or rejected)" },
+        mode: { type: "string", enum: ["design-candidate", "implementation-ready"], description: "Recommendation intent. Defaults to design-candidate; implementation-ready fails closed to policy-allowed initiatives only." },
       },
       required: [],
     },

--- a/apps/web/lib/mcp/packs/backlog-pack-read-tools.test.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack-read-tools.test.ts
@@ -4,13 +4,20 @@ const mocks = vi.hoisted(() => ({
   count: vi.fn(),
   findMany: vi.fn(),
   findEpic: vi.fn(),
+  countEpics: vi.fn(),
+  findEpics: vi.fn(),
+  buildReferenceIndex: vi.fn(),
 }));
 
 vi.mock("@dpf/db", () => ({
   prisma: {
     backlogItem: { count: mocks.count, findMany: mocks.findMany },
-    epic: { findFirst: mocks.findEpic },
+    epic: { findFirst: mocks.findEpic, count: mocks.countEpics, findMany: mocks.findEpics },
   },
+}));
+
+vi.mock("@/lib/backlog/spec-plan-search", () => ({
+  buildSpecPlanReferenceIndex: mocks.buildReferenceIndex,
 }));
 
 import { listBacklogItems } from "./backlog-pack-read-tools";
@@ -44,6 +51,39 @@ describe("backlog deferral read projection", () => {
     vi.clearAllMocks();
     mocks.count.mockResolvedValue(1);
     mocks.findMany.mockResolvedValue([]);
+    mocks.buildReferenceIndex.mockResolvedValue({ specs: new Set(), plans: new Set() });
+    mocks.countEpics.mockResolvedValue(0);
+    mocks.findEpics.mockResolvedValue([]);
+  });
+
+  it("does not report a plan-only epic as having a spec", async () => {
+    mocks.countEpics.mockResolvedValue(1);
+    mocks.findEpics.mockResolvedValue([{
+      id: "epic-row",
+      epicId: "EP-PLAN-ONLY",
+      title: "Plan only",
+      status: "open",
+      priority: 1,
+      updatedAt: new Date("2026-08-22T00:00:00.000Z"),
+      scopeKind: "platform",
+      archetypeCategories: [],
+      archetypeIds: [],
+      scopeRationale: null,
+      lifecycleTags: [],
+      items: [],
+    }]);
+    mocks.buildReferenceIndex.mockResolvedValue({
+      specs: new Set(),
+      plans: new Set(["EP-PLAN-ONLY"]),
+    });
+
+    const { listEpics } = await import("./backlog-pack-read-tools");
+    const result = await listEpics({});
+
+    expect((result.data as { epics: unknown[] }).epics[0]).toMatchObject({
+      hasSpec: false,
+      hasPlan: true,
+    });
   });
 
   it("builds the nonconformant filter from the canonical projection fields", async () => {

--- a/apps/web/lib/mcp/packs/backlog-pack-read-tools.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack-read-tools.ts
@@ -192,7 +192,8 @@ export async function listEpics(params: Record<string, unknown>): Promise<ToolRe
         priority: e.priority,
         ...scopeData(e),
         itemCount: { total, triaging, open, inProgress, deferred, done, retired },
-        hasSpec: refIndex.specs.has(e.epicId) || refIndex.plans.has(e.epicId),
+        hasSpec: refIndex.specs.has(e.epicId),
+        hasPlan: refIndex.plans.has(e.epicId),
         updatedAt: e.updatedAt.toISOString(),
         _hasOpen: triaging + open + inProgress + deferred > 0,
       };
@@ -239,6 +240,7 @@ export async function listBacklogItems(params: Record<string, unknown>): Promise
     take: limit,
     orderBy: [{ priority: "asc" }, { updatedAt: "desc" }],
     select: {
+      id: true,
       itemId: true,
       title: true,
       status: true,
@@ -256,11 +258,42 @@ export async function listBacklogItems(params: Record<string, unknown>): Promise
       triageOutcome: true,
       ...deferralSelect,
       epic: { select: { epicId: true } },
-      activeBuild: { select: { phase: true, draftApprovedAt: true } },
+      activeBuild: { select: { phase: true, draftApprovedAt: true, kind: true } },
+      activities: {
+        where: { kind: { in: ["initiative_gate_receipt", "initiative_scope_baseline", "plan_backlog_coverage"] } },
+        orderBy: [{ recordedAt: "desc" }, { id: "desc" }],
+        take: 100,
+        select: { id: true, kind: true, gateKey: true, recordedAt: true, payload: true },
+      },
     },
   });
   const { deriveLifecycleLabel } = await import("@/lib/governed-backlog-workflow");
-  const data = items.map((i) => ({
+  const { buildSpecPlanReferenceIndex } = await import("@/lib/backlog/spec-plan-search");
+  const { projectBacklogItemReadinessSummary } = await import("@/lib/backlog/initiative-readiness/entry-adapter");
+  const refIndex = await buildSpecPlanReferenceIndex();
+  const evaluatedAt = new Date().toISOString();
+  const data = items.map((i) => {
+    const semanticEpic = i.epic?.epicId ?? null;
+    const hasSpec = refIndex.specs.has(i.itemId) || Boolean(semanticEpic && refIndex.specs.has(semanticEpic));
+    const hasPlan = refIndex.plans.has(i.itemId) || Boolean(semanticEpic && refIndex.plans.has(semanticEpic));
+    const readiness = projectBacklogItemReadinessSummary({
+      item: {
+        id: i.id,
+        itemId: i.itemId,
+        type: i.type,
+        source: i.source,
+        workType: i.workType,
+        scopeKind: i.scopeKind,
+        archetypeCategories: i.archetypeCategories,
+        archetypeIds: i.archetypeIds,
+        activeBuildKind: i.activeBuild?.kind ?? null,
+      },
+      activities: (i.activities ?? []).map((activity) => ({ ...activity, gateKey: activity.gateKey ?? null })),
+      hasSpec,
+      hasPlan,
+      evaluatedAt,
+    });
+    return ({
     itemId: i.itemId,
     title: i.title,
     status: i.status,
@@ -277,6 +310,9 @@ export async function listBacklogItems(params: Record<string, unknown>): Promise
     deferral: deferralData(i),
     epicId: i.epic?.epicId ?? null,
     hasActiveBuild: i.activeBuildId != null,
+    hasSpec,
+    hasPlan,
+    readiness,
     lifecycleLabel: deriveLifecycleLabel({
       backlogItem: { status: i.status, triageOutcome: i.triageOutcome, activeBuildId: i.activeBuildId },
       featureBuild: i.activeBuild
@@ -285,7 +321,8 @@ export async function listBacklogItems(params: Record<string, unknown>): Promise
       governedBacklogEnabled: true,
     }),
     updatedAt: i.updatedAt.toISOString(),
-  }));
+  });
+  });
   return {
     success: true,
     message: `Listed ${data.length} of ${matching} backlog item(s).`,
@@ -314,6 +351,7 @@ export async function getBacklogItem(params: Record<string, unknown>): Promise<T
       activeBuild: {
         select: {
           buildId: true,
+          kind: true,
           phase: true,
           draftApprovedAt: true,
           sandboxId: true,
@@ -322,7 +360,7 @@ export async function getBacklogItem(params: Record<string, unknown>): Promise<T
       },
       activities: {
         orderBy: { recordedAt: "desc" },
-        take: 10,
+        take: 100,
       },
     },
   });
@@ -337,6 +375,28 @@ export async function getBacklogItem(params: Record<string, unknown>): Promise<T
   });
   const { mapDemandRows } = await import("@/lib/demand/demand-data");
   const demandView = mapDemandRows([item])[0]!;
+  const { projectBacklogItemReadinessSummary } = await import("@/lib/backlog/initiative-readiness/entry-adapter");
+  const hasSpec = specPlanRefs.some((entry) => entry.kind === "spec");
+  const hasPlan = specPlanRefs.some((entry) => entry.kind === "plan");
+  const readiness = projectBacklogItemReadinessSummary({
+    item: {
+      id: item.id,
+      itemId: item.itemId,
+      type: item.type,
+      source: item.source,
+      workType: item.workType,
+      scopeKind: item.scopeKind,
+      archetypeCategories: item.archetypeCategories,
+      archetypeIds: item.archetypeIds,
+      activeBuildKind: item.activeBuild?.kind ?? null,
+    },
+    activities: item.activities
+      .filter((activity) => ["initiative_gate_receipt", "initiative_scope_baseline", "plan_backlog_coverage"].includes(activity.kind))
+      .map((activity) => ({ ...activity, gateKey: activity.gateKey ?? null })),
+    hasSpec,
+    hasPlan,
+    evaluatedAt: new Date().toISOString(),
+  });
   return {
     success: true,
     message: `Loaded ${item.itemId}`,
@@ -391,13 +451,14 @@ export async function getBacklogItem(params: Record<string, unknown>): Promise<T
             sandboxId: item.activeBuild.sandboxId,
           }
         : null,
+      readiness,
       specPlanFiles: specPlanRefs.map((r) => ({
         path: r.path,
         kind: r.kind,
         title: r.title,
         date: r.date,
       })),
-      recentActivity: item.activities.map((a) => ({
+      recentActivity: item.activities.slice(0, 10).map((a) => ({
         id: a.id,
         kind: a.kind,
         summary: a.summary,

--- a/apps/web/lib/mcp/packs/backlog-pack.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack.ts
@@ -634,6 +634,7 @@ async function getNextRecommendedWork(params: Record<string, unknown>): Promise<
   const { prisma } = await import("@dpf/db");
   const { rankCandidates } = await import("@/lib/backlog/recommend");
   const { buildSpecPlanReferenceIndex } = await import("@/lib/backlog/spec-plan-search");
+  const { projectBacklogItemReadinessSummary } = await import("@/lib/backlog/initiative-readiness/entry-adapter");
 
   const count = typeof params["count"] === "number" ? params["count"] : undefined;
   const epicIdRaw = typeof params["epicId"] === "string" ? params["epicId"].trim() : "";
@@ -641,6 +642,9 @@ async function getNextRecommendedWork(params: Record<string, unknown>): Promise<
   const excludeItemIds = Array.isArray(params["excludeItemIds"])
     ? (params["excludeItemIds"] as unknown[]).filter((x): x is string => typeof x === "string")
     : [];
+  const mode = params["mode"] === "implementation-ready"
+    ? "implementation-ready"
+    : "design-candidate";
 
   const where: Record<string, unknown> = {
     status: { in: ["open", "triaging"] },
@@ -671,11 +675,24 @@ async function getNextRecommendedWork(params: Record<string, unknown>): Promise<
       demandScore: true,
       effortSize: true,
       triageOutcome: true,
+      type: true,
+      source: true,
+      workType: true,
+      scopeKind: true,
+      archetypeCategories: true,
+      archetypeIds: true,
       activeBuildId: true,
       claimedById: true,
       claimedByAgentId: true,
       updatedAt: true,
       epic: { select: { epicId: true, status: true } },
+      activeBuild: { select: { kind: true } },
+      activities: {
+        where: { kind: { in: ["initiative_gate_receipt", "initiative_scope_baseline", "plan_backlog_coverage"] } },
+        orderBy: [{ recordedAt: "desc" }, { id: "desc" }],
+        take: 100,
+        select: { id: true, kind: true, gateKey: true, recordedAt: true, payload: true },
+      },
     },
   });
 
@@ -686,6 +703,23 @@ async function getNextRecommendedWork(params: Record<string, unknown>): Promise<
       refIndex.specs.has(i.itemId) || (semanticEpic ? refIndex.specs.has(semanticEpic) : false);
     const hasPlan =
       refIndex.plans.has(i.itemId) || (semanticEpic ? refIndex.plans.has(semanticEpic) : false);
+    const readiness = projectBacklogItemReadinessSummary({
+      item: {
+        id: i.itemId,
+        itemId: i.itemId,
+        type: i.type,
+        source: i.source,
+        workType: i.workType,
+        scopeKind: i.scopeKind,
+        archetypeCategories: i.archetypeCategories,
+        archetypeIds: i.archetypeIds,
+        activeBuildKind: i.activeBuild?.kind ?? null,
+      },
+      activities: (i.activities ?? []).map((activity) => ({ ...activity, gateKey: activity.gateKey ?? null })),
+      hasSpec,
+      hasPlan,
+      evaluatedAt: new Date().toISOString(),
+    });
     return {
       itemId: i.itemId,
       title: i.title,
@@ -701,6 +735,7 @@ async function getNextRecommendedWork(params: Record<string, unknown>): Promise<
       epicStatus: i.epic?.status ?? null,
       hasSpec,
       hasPlan,
+      implementationReadinessVerdict: readiness.decisions.implementation.verdict,
       updatedAt: i.updatedAt,
     };
   });
@@ -709,12 +744,15 @@ async function getNextRecommendedWork(params: Record<string, unknown>): Promise<
     excludeItemIds,
     forAgentId,
     count,
+    mode,
   });
 
   return {
     success: true,
-    message: `Recommending ${ranked.length} item(s).`,
-    data: { recommendations: ranked },
+    message: mode === "implementation-ready"
+      ? `Recommending ${ranked.length} implementation-ready item(s).`
+      : `Recommending ${ranked.length} design candidate(s).`,
+    data: { mode, recommendations: ranked },
   };
 }
 

--- a/apps/web/lib/mcp/packs/work-capsules-pack.ts
+++ b/apps/web/lib/mcp/packs/work-capsules-pack.ts
@@ -135,7 +135,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "claim_backlog_item_for_work",
     description:
-      "Claim a BacklogItem for work by binding it to the worktree + branch + session you are starting in (soft claim-at-start). Creates, reuses+late-binds, or resumes the durable abandoned Workroom for the same BI and branch, then stamps the BI claim so a directly-working agent's BI no longer looks unclaimed to a parallel session. A branch bound to a different BI returns branch_occupied and preserves its history. Advisory, NOT a lock: if the BI already has active work elsewhere the call still binds this location but returns a non-blocking conflict — it does not steal the existing claim. Multiple branches per BI are expected and are not a conflict.",
+      "Claim a BacklogItem for work by binding it to the worktree + branch + session you are starting in. Governed work must declare design, review, plan, or implementation intent; legacy omission is evaluated as implementation and fails closed unless canonical readiness is allowed. Claim, intent event, readiness decision, and exact identity readback share one transaction. A branch bound to a different BI returns branch_occupied and preserves its history. The BI claim remains a soft coordination signal, not a lock.",
     inputSchema: {
       type: "object",
       properties: {
@@ -146,6 +146,7 @@ const definitions: ToolDefinition[] = [
         baseBranch: { type: "string", description: "Optional base branch (defaults to main)." },
         provider: { type: "string", description: "Provider string (claude, codex, grok) — mapped to the closest executor kind." },
         sessionRef: { type: "string", description: "Owner/session id, stored as the workroom executorRef." },
+        workIntent: { type: "string", enum: ["design", "review", "plan", "implementation"], description: "Lifecycle intent. Required for governed callers; omission is the legacy implementation-safe default." },
       },
       required: ["itemId", "worktreePath", "branchName", "provider", "sessionRef"],
     },

--- a/apps/web/lib/work-capsules/claim-backlog-item-handler.ts
+++ b/apps/web/lib/work-capsules/claim-backlog-item-handler.ts
@@ -1,0 +1,98 @@
+import type { ToolResult } from "@/lib/mcp-tools";
+import { WORK_INTENTS, type WorkIntent } from "@/lib/work-capsules";
+import { ensureCapsuleWorkItemAnchorWithPrisma } from "@/lib/work-capsules/capsule-workitem-anchor.server";
+
+import { providerToExecutorKind } from "./external-session-capture";
+import { claimGovernedBacklogWorkspace } from "./governed-work-claim";
+import { branchOccupiedResult } from "./mcp-result-errors";
+import type { CapsuleDb, WorkCapsuleActor } from "./work-capsule-store-types";
+
+type ToolContext = { agentId?: string; threadId?: string; taskRunId?: string; routeContext?: string } | undefined;
+
+function stringParam(params: Record<string, unknown>, key: string): string | null {
+  const value = params[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export async function claimBacklogItemForWork(args: {
+  params: Record<string, unknown>;
+  userId: string;
+  context: ToolContext;
+  db: CapsuleDb;
+  resolveActor: (userId: string, context: ToolContext) => Promise<WorkCapsuleActor>;
+}): Promise<ToolResult> {
+  const { params } = args;
+  const itemId = stringParam(params, "itemId");
+  const worktreePath = stringParam(params, "worktreePath");
+  const branchName = stringParam(params, "branchName");
+  const provider = stringParam(params, "provider");
+  const sessionRef = stringParam(params, "sessionRef");
+  const requestedIntent = stringParam(params, "workIntent");
+  if (!itemId || !worktreePath || !branchName || !provider || !sessionRef) {
+    return { success: false, error: "invalid_input", message: "itemId, worktreePath, branchName, provider, and sessionRef are required." };
+  }
+  if (requestedIntent && !WORK_INTENTS.includes(requestedIntent as WorkIntent)) {
+    return { success: false, error: "invalid_work_intent", message: `workIntent must be one of: ${WORK_INTENTS.join(", ")}.` };
+  }
+  const repositoryFullName = stringParam(params, "repositoryFullName")
+    ?? process.env.DPF_REPO_FULL_NAME?.trim()
+    ?? "OpenDigitalProductFactory/opendigitalproductfactory";
+  try {
+    const governed = await claimGovernedBacklogWorkspace({
+      db: args.db,
+      input: {
+        backlogItemId: itemId,
+        repositoryFullName,
+        headBranch: branchName,
+        worktreePath,
+        baseBranch: stringParam(params, "baseBranch") ?? "main",
+        executorKind: providerToExecutorKind(provider),
+        executorRef: sessionRef,
+      },
+      actor: await args.resolveActor(args.userId, args.context),
+      workIntent: requestedIntent as WorkIntent | null,
+    });
+    if (!governed.ok) {
+      return {
+        success: false,
+        error: governed.data.code,
+        message: governed.error,
+        data: { workIntent: governed.data.workIntent, readiness: governed.data.readiness },
+      };
+    }
+    const result = governed.data.claim;
+    await ensureCapsuleWorkItemAnchorWithPrisma({
+      capsuleId: result.capsuleId,
+      backlogItemId: result.backlogItemId,
+      title: `Work on ${result.backlogItemId}`,
+    }).catch((error) => {
+      console.warn(`[work-convergence] WorkItem anchor skipped for ${result.capsuleId}: ${error instanceof Error ? error.message : "unknown"}`);
+    });
+    const base = `Bound ${result.backlogItemId} to ${result.headBranch} (${result.capsuleId}).`;
+    const conflicts = result.conflict
+      ? [
+          ...(result.conflict.backlogClaim ? [`${result.backlogItemId} already has an ACTIVE claim by another session; this call did NOT steal it`] : []),
+          ...result.conflict.otherLocations.map((location) => `also in flight on ${location.headBranch ?? "?"} (${location.capsuleId})`),
+        ]
+      : [];
+    return {
+      success: true,
+      entityId: result.capsuleId,
+      message: conflicts.length
+        ? `${base} ADVISORY: ${conflicts.join("; ")}. Coordinate before pushing.`
+        : `${base} Claim-at-start recorded for this session.`,
+      data: {
+        ...result,
+        workIntent: governed.data.workIntent,
+        readiness: governed.data.readiness,
+        readback: governed.data.readback,
+      },
+    };
+  } catch (error) {
+    const occupied = branchOccupiedResult(error);
+    if (occupied) return occupied;
+    const detail = error instanceof Error ? error.message : "Unknown failure";
+    if (/not found/i.test(detail)) return { success: false, error: "not_found", message: detail };
+    throw error;
+  }
+}

--- a/apps/web/lib/work-capsules/governed-work-claim.test.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { claimGovernedBacklogWorkspace } from "./governed-work-claim";
+import type { CapsuleDb } from "./work-capsule-store-types";
+
+const actor = { userId: "user-1", agentId: "AGT-1", principalId: "PRN-1" };
+const input = {
+  backlogItemId: "BI-ENTRY",
+  repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+  headBranch: "feat/entry",
+  worktreePath: "D:\\DPF-worktrees\\entry",
+  baseBranch: "main",
+  executorKind: "codex-desktop" as const,
+  executorRef: "session-1",
+};
+
+function database(activities: unknown[] = []) {
+  const db = {
+    backlogItem: {
+      findFirst: vi.fn().mockResolvedValue({
+        id: "row-bi",
+        itemId: "BI-ENTRY",
+        type: "portfolio",
+        source: "user-request",
+        workType: "feature",
+        scopeKind: "platform",
+        archetypeCategories: [],
+        archetypeIds: [],
+        activeBuild: null,
+      }),
+      update: vi.fn(),
+    },
+    backlogItemActivity: {
+      findMany: vi.fn().mockResolvedValue(activities),
+      create: vi.fn().mockResolvedValue({ id: "decision-row" }),
+    },
+    workroom: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      findUnique: vi.fn().mockResolvedValue({
+        id: "row-wc",
+        capsuleId: "WC-ENTRY",
+        backlogItemId: "BI-ENTRY",
+        status: "ready",
+        archivedAt: null,
+        repositoryFullName: input.repositoryFullName,
+        headBranch: input.headBranch,
+        worktreePath: input.worktreePath,
+        executorKind: input.executorKind,
+        executorRef: input.executorRef,
+        leaseHolderPrincipalId: actor.principalId,
+        leaseExpiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      }),
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+    workroomActivity: {
+      create: vi.fn(),
+      findFirst: vi.fn().mockResolvedValue({
+        payload: {
+          schemaVersion: 1,
+          intent: "design",
+          policyVersion: "initiative-readiness.v1",
+          subject: { kind: "backlog-item", id: "BI-ENTRY" },
+        },
+      }),
+    },
+    $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(db)),
+  };
+  return db as unknown as CapsuleDb;
+}
+
+describe("claimGovernedBacklogWorkspace", () => {
+  it("records a denial without mutating workspace state for a legacy implementation claim", async () => {
+    const db = database();
+    const claimWorkspace = vi.fn();
+
+    const result = await claimGovernedBacklogWorkspace({
+      db,
+      input,
+      actor,
+      workIntent: null,
+      now: new Date("2026-08-22T00:00:00.000Z"),
+      dependencies: { claimWorkspace },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      data: { code: "initiative_not_ready", workIntent: "implementation" },
+    });
+    expect(claimWorkspace).not.toHaveBeenCalled();
+    expect(db.backlogItemActivity?.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ kind: "initiative_readiness_decision" }),
+    }));
+  });
+
+  it("atomically declares design intent and returns exact readback for governed design work", async () => {
+    const db = database();
+    const claimWorkspace = vi.fn().mockResolvedValue({
+      capsuleId: "WC-ENTRY",
+      backlogItemId: "BI-ENTRY",
+      headBranch: input.headBranch,
+      worktreePath: input.worktreePath,
+      claimed: true,
+      conflict: null,
+    });
+    const declareIntent = vi.fn().mockResolvedValue({ id: "intent-row" });
+
+    const result = await claimGovernedBacklogWorkspace({
+      db,
+      input,
+      actor,
+      workIntent: "design",
+      now: new Date("2026-08-22T00:00:00.000Z"),
+      dependencies: { claimWorkspace, declareIntent },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: { workIntent: "design", readiness: { verdict: "allowed" } },
+    });
+    expect(declareIntent).toHaveBeenCalledWith(expect.objectContaining({
+      capsuleId: "WC-ENTRY",
+      intent: "design",
+      subject: { kind: "backlog-item", id: "BI-ENTRY" },
+    }));
+    expect(result.ok && result.data.readback).toMatchObject({
+      capsuleId: "WC-ENTRY",
+      backlogItemId: "BI-ENTRY",
+      executorRef: "session-1",
+      workIntent: "design",
+    });
+  });
+
+  it("rolls back an allowed claim when exact readback does not match the requested session", async () => {
+    const db = database();
+    const claimWorkspace = vi.fn().mockResolvedValue({
+      capsuleId: "WC-ENTRY",
+      backlogItemId: "BI-ENTRY",
+      headBranch: input.headBranch,
+      worktreePath: input.worktreePath,
+      claimed: true,
+      conflict: null,
+    });
+    const declareIntent = vi.fn().mockResolvedValue({ id: "intent-row" });
+    (db.workroom.findUnique as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      capsuleId: "WC-ENTRY",
+      backlogItemId: "BI-ENTRY",
+      status: "ready",
+      archivedAt: null,
+      repositoryFullName: input.repositoryFullName,
+      headBranch: input.headBranch,
+      worktreePath: input.worktreePath,
+      executorKind: input.executorKind,
+      executorRef: "foreign-session",
+      leaseHolderPrincipalId: actor.principalId,
+      leaseExpiresAt: new Date("2099-01-01T00:00:00.000Z"),
+    });
+
+    const result = await claimGovernedBacklogWorkspace({
+      db,
+      input,
+      actor,
+      workIntent: "design",
+      now: new Date("2026-08-22T00:00:00.000Z"),
+      dependencies: { claimWorkspace, declareIntent },
+    });
+
+    expect(result).toMatchObject({ ok: false, data: { code: "capsule_identity_mismatch" } });
+    expect(db.$transaction).toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/work-capsules/governed-work-claim.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.ts
@@ -1,0 +1,285 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import {
+  INITIATIVE_READINESS_POLICY_VERSION,
+  projectBacklogItemReadiness,
+  type InitiativeReadinessDecision,
+  type InitiativeReadinessActivity,
+} from "@/lib/backlog/initiative-readiness";
+import {
+  parseWorkIntentDeclared,
+  type WorkCapsuleExecutorKind,
+  type WorkIntent,
+} from "@/lib/work-capsules";
+import { err, ok, type ActionResult } from "@/lib/shared/action-result";
+
+import { claimBacklogItemWorkspace } from "./work-capsule-store";
+import { declareWorkCapsuleIntent } from "./work-capsule-intent-store";
+import type { CapsuleDb, WorkCapsuleActor } from "./work-capsule-store-types";
+
+type ClaimInput = {
+  backlogItemId: string;
+  repositoryFullName: string;
+  headBranch: string;
+  worktreePath: string;
+  baseBranch?: string | null;
+  executorKind?: WorkCapsuleExecutorKind | null;
+  executorRef?: string | null;
+  title?: string;
+  objective?: string;
+};
+
+type ClaimResult = Awaited<ReturnType<typeof claimBacklogItemWorkspace>>;
+
+type Dependencies = {
+  claimWorkspace?: typeof claimBacklogItemWorkspace;
+  declareIntent?: typeof declareWorkCapsuleIntent;
+};
+
+type ExactReadback = {
+  capsuleId: string;
+  backlogItemId: string;
+  status: string;
+  repositoryFullName: string;
+  headBranch: string;
+  worktreePath: string;
+  executorKind: string | null;
+  executorRef: string | null;
+  leaseHolderPrincipalId: string;
+  leaseExpiresAt: string;
+  workIntent: WorkIntent;
+};
+
+type GovernedClaimSuccess = {
+  workIntent: WorkIntent;
+  readiness: InitiativeReadinessDecision;
+  claim: ClaimResult;
+  readback: ExactReadback;
+};
+
+type GovernedClaimFailure = {
+  code: "initiative_not_ready" | "capsule_identity_mismatch" | "readiness_projection_failed";
+  workIntent: WorkIntent;
+  readiness: InitiativeReadinessDecision;
+};
+
+type GovernedClaimSuccessResult = Exclude<ActionResult<GovernedClaimSuccess>, { error: string }>;
+
+export type GovernedClaimResult =
+  | GovernedClaimSuccessResult
+  | (Extract<ActionResult<GovernedClaimSuccess>, { error: string }> & { data: GovernedClaimFailure });
+
+function claimSuccess(data: GovernedClaimSuccess): GovernedClaimSuccessResult {
+  return ok(data) as GovernedClaimSuccessResult;
+}
+
+class CapsuleIdentityMismatch extends Error {
+  constructor(readonly decision: InitiativeReadinessDecision) {
+    super("Claimed Workroom identity did not match the requested subject, branch, worktree, executor, lease, and intent.");
+  }
+}
+
+function targetForIntent(intent: WorkIntent): "design" | "plan" | "implementation" {
+  if (intent === "implementation") return "implementation";
+  if (intent === "plan") return "plan";
+  return "design";
+}
+
+function decisionWithId(decision: InitiativeReadinessDecision): InitiativeReadinessDecision {
+  return { ...decision, decisionId: `IRD-${randomUUID().replaceAll("-", "").slice(0, 12).toUpperCase()}` };
+}
+
+function decisionCodes(decision: InitiativeReadinessDecision) {
+  return {
+    satisfied: decision.satisfied.map((entry) => entry.code),
+    unmet: decision.unmet.map((entry) => entry.code),
+    blockers: decision.blockers.map((entry) => entry.code),
+  };
+}
+
+async function recordDecision(args: {
+  db: CapsuleDb;
+  backlogItemRowId: string;
+  decision: InitiativeReadinessDecision;
+  workIntent: WorkIntent;
+  actor: WorkCapsuleActor;
+}) {
+  if (!args.db.backlogItemActivity) throw new Error("Initiative readiness decision persistence is unavailable.");
+  const codes = decisionCodes(args.decision);
+  const factsDigest = createHash("sha256").update(JSON.stringify({
+    policyVersion: args.decision.policyVersion,
+    subject: args.decision.subject,
+    transitionObject: args.decision.transitionObject,
+    target: args.decision.target,
+    profile: args.decision.profile,
+    codes,
+  })).digest("hex");
+  await args.db.backlogItemActivity.create({ data: {
+    backlogItemId: args.backlogItemRowId,
+    kind: "initiative_readiness_decision",
+    summary: `${args.decision.target} readiness: ${args.decision.verdict}`,
+    payload: {
+      schemaVersion: 1,
+      ...args.decision,
+      workIntent: args.workIntent,
+      factsDigest,
+      stableCodes: codes,
+      authority: { actionKey: "claim_backlog_item_for_work", enforcementState: "enforced" },
+    },
+    recordedById: args.actor.userId,
+    recordedByAgentId: args.actor.agentId,
+  } });
+}
+
+function exactReadback(args: {
+  row: Record<string, unknown> | null;
+  intentPayload: unknown;
+  input: ClaimInput;
+  actor: WorkCapsuleActor;
+  capsuleId: string;
+  workIntent: WorkIntent;
+  now: Date;
+}): ExactReadback | null {
+  const parsedIntent = parseWorkIntentDeclared(args.intentPayload);
+  const row = args.row;
+  const lease = row?.leaseExpiresAt instanceof Date
+    ? row.leaseExpiresAt
+    : typeof row?.leaseExpiresAt === "string" ? new Date(row.leaseExpiresAt) : null;
+  if (!row
+    || row.capsuleId !== args.capsuleId
+    || row.backlogItemId !== args.input.backlogItemId
+    || row.repositoryFullName !== args.input.repositoryFullName
+    || row.headBranch !== args.input.headBranch
+    || row.worktreePath !== args.input.worktreePath
+    || row.executorKind !== (args.input.executorKind ?? null)
+    || row.executorRef !== (args.input.executorRef ?? null)
+    || row.archivedAt != null
+    || ["abandoned", "archived", "complete", "superseded"].includes(String(row.status))
+    || row.leaseHolderPrincipalId !== args.actor.principalId
+    || !lease || lease.getTime() <= args.now.getTime()
+    || !parsedIntent.ok
+    || parsedIntent.intent !== args.workIntent
+    || parsedIntent.subject.kind !== "backlog-item"
+    || parsedIntent.subject.id !== args.input.backlogItemId) return null;
+  return {
+    capsuleId: String(row.capsuleId),
+    backlogItemId: String(row.backlogItemId),
+    status: String(row.status),
+    repositoryFullName: String(row.repositoryFullName),
+    headBranch: String(row.headBranch),
+    worktreePath: String(row.worktreePath),
+    executorKind: row.executorKind == null ? null : String(row.executorKind),
+    executorRef: row.executorRef == null ? null : String(row.executorRef),
+    leaseHolderPrincipalId: String(row.leaseHolderPrincipalId),
+    leaseExpiresAt: lease.toISOString(),
+    workIntent: parsedIntent.intent,
+  };
+}
+
+export async function claimGovernedBacklogWorkspace(args: {
+  db: CapsuleDb;
+  input: ClaimInput;
+  actor: WorkCapsuleActor;
+  workIntent: WorkIntent | null;
+  now?: Date;
+  dependencies?: Dependencies;
+}): Promise<GovernedClaimResult> {
+  if (!args.db.backlogItem || !args.db.backlogItemActivity) {
+    throw new Error("Governed Workroom claim requires backlog item and activity access.");
+  }
+  const now = args.now ?? new Date();
+  const workIntent = args.workIntent ?? "implementation";
+  const target = targetForIntent(workIntent);
+  const claimWorkspace = args.dependencies?.claimWorkspace ?? claimBacklogItemWorkspace;
+  const declareIntent = args.dependencies?.declareIntent ?? declareWorkCapsuleIntent;
+  const transact = args.db.$transaction
+    ? <T>(fn: (tx: CapsuleDb) => Promise<T>) => args.db.$transaction!(fn)
+    : <T>(fn: (tx: CapsuleDb) => Promise<T>) => fn(args.db);
+  let backlogItemRowId = "";
+  let evaluated: InitiativeReadinessDecision | null = null;
+
+  try {
+    return await transact(async (tx) => {
+      if (!tx.backlogItem || !tx.backlogItemActivity) throw new Error("Readiness transaction lost backlog access.");
+      const item = await tx.backlogItem.findFirst({
+        where: { OR: [{ itemId: args.input.backlogItemId }, { id: args.input.backlogItemId }] },
+        select: {
+          id: true, itemId: true, type: true, source: true, workType: true, scopeKind: true,
+          archetypeCategories: true, archetypeIds: true, activeBuild: { select: { kind: true } },
+        },
+      });
+      if (!item) throw new Error(`BacklogItem ${args.input.backlogItemId} not found`);
+      backlogItemRowId = item.id;
+      const activities = await tx.backlogItemActivity.findMany({
+        where: { backlogItemId: item.id, kind: { in: ["initiative_gate_receipt", "initiative_scope_baseline", "plan_backlog_coverage"] } },
+        orderBy: [{ recordedAt: "desc" }, { id: "desc" }],
+        select: { id: true, kind: true, gateKey: true, recordedAt: true, payload: true },
+      }) as InitiativeReadinessActivity[];
+      const projection = projectBacklogItemReadiness({
+        item: { ...item, activeBuildKind: item.activeBuild?.kind ?? null },
+        activities,
+        target,
+        transitionObject: {
+          kind: "work-capsule",
+          id: `${args.input.repositoryFullName}#${args.input.headBranch}`,
+          expectedVersion: "claim.v1",
+          targetState: workIntent,
+        },
+        authorization: "pass",
+        capsuleIdentity: "pass",
+        evaluatedAt: now.toISOString(),
+      });
+      evaluated = decisionWithId(projection.decision);
+      if (projection.governed && evaluated.verdict !== "allowed") {
+        await recordDecision({ db: tx, backlogItemRowId: item.id, decision: evaluated, workIntent, actor: args.actor });
+        return {
+          ...err(`Cannot start ${workIntent}: ${[...evaluated.blockers, ...evaluated.unmet].map((entry) => entry.code).join(", ")}.`),
+          data: { code: "initiative_not_ready" as const, workIntent, readiness: evaluated },
+        };
+      }
+
+      const claim = await claimWorkspace({ db: tx, input: args.input, actor: args.actor, now });
+      await declareIntent({
+        db: tx,
+        capsuleId: claim.capsuleId,
+        intent: workIntent,
+        policyVersion: INITIATIVE_READINESS_POLICY_VERSION,
+        subject: { kind: "backlog-item", id: item.itemId },
+        actor: args.actor,
+      });
+      const row = await tx.workroom.findUnique({ where: { capsuleId: claim.capsuleId } }) as Record<string, unknown> | null;
+      const latestIntent = tx.workroomActivity.findFirst
+        ? await tx.workroomActivity.findFirst({
+          where: { workCapsuleId: row?.id, kind: "work-intent-declared" },
+          orderBy: [{ recordedAt: "desc" }, { id: "desc" }],
+          select: { payload: true },
+        })
+        : null;
+      const readback = exactReadback({
+        row,
+        intentPayload: latestIntent?.payload,
+        input: args.input,
+        actor: args.actor,
+        capsuleId: claim.capsuleId,
+        workIntent,
+        now,
+      });
+      if (!readback) throw new CapsuleIdentityMismatch(evaluated);
+      await recordDecision({ db: tx, backlogItemRowId: item.id, decision: evaluated, workIntent, actor: args.actor });
+      return claimSuccess({ workIntent, readiness: evaluated, claim, readback });
+    });
+  } catch (error) {
+    if (!(error instanceof CapsuleIdentityMismatch) || !evaluated || !backlogItemRowId) throw error;
+    const priorDecision = evaluated as InitiativeReadinessDecision;
+    const denied: InitiativeReadinessDecision = {
+      ...priorDecision,
+      verdict: "denied",
+      blockers: [{ code: "CAPSULE_IDENTITY_MISMATCH", state: "fail", accountableRole: "delivery-coordinator", evidenceRefs: [] }],
+    };
+    await recordDecision({ db: args.db, backlogItemRowId, decision: denied, workIntent, actor: args.actor });
+    return {
+      ...err(error.message),
+      data: { code: "capsule_identity_mismatch", workIntent, readiness: denied },
+    };
+  }
+}

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@dpf/db";
-import { ensureCapsuleWorkItemAnchorNonFatal, ensureCapsuleWorkItemAnchorWithPrisma } from "@/lib/work-capsules/capsule-workitem-anchor.server";
+import { ensureCapsuleWorkItemAnchorNonFatal } from "@/lib/work-capsules/capsule-workitem-anchor.server";
 import { computeChangeImpactContract } from "@/lib/build/gate-context-bridge";
 import type { ToolResult } from "@/lib/mcp-tools";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
@@ -31,7 +31,6 @@ import {
 } from "@/lib/work-capsules";
 import {
   adoptWorktreeCapsule,
-  claimBacklogItemWorkspace,
   claimWorkCapsuleScope,
   createWorkCapsule,
   heartbeatWorkCapsule,
@@ -46,8 +45,9 @@ import {
   type WorkCapsuleActor,
 } from "./work-capsule-store";
 import { listLocalBranches } from "./git-scanner";
-import { providerToExecutorKind, ensureExternalSessionCapsule } from "./external-session-capture";
+import { ensureExternalSessionCapsule } from "./external-session-capture";
 import { branchOccupiedResult, invalidScopeResult } from "./mcp-result-errors";
+import { claimBacklogItemForWork } from "./claim-backlog-item-handler";
 type ToolContext = {
   routeContext?: string;
   agentId?: string;
@@ -329,96 +329,7 @@ export async function claimBacklogItemForWorkTool(
   userId: string,
   context: ToolContext,
 ): Promise<ToolResult> {
-  const itemId = stringParam(params, "itemId");
-  const worktreePath = stringParam(params, "worktreePath");
-  const branchName = stringParam(params, "branchName");
-  const provider = stringParam(params, "provider");
-  const sessionRef = stringParam(params, "sessionRef");
-
-  if (!itemId || !worktreePath || !branchName || !provider || !sessionRef) {
-    return {
-      success: false,
-      error: "invalid_input",
-      message: "itemId, worktreePath, branchName, provider, and sessionRef are required.",
-    };
-  }
-
-  const repositoryFullName =
-    stringParam(params, "repositoryFullName") ??
-    process.env.DPF_REPO_FULL_NAME?.trim() ??
-    "OpenDigitalProductFactory/opendigitalproductfactory";
-  const baseBranch = stringParam(params, "baseBranch") ?? "main";
-  const executorKind = providerToExecutorKind(provider);
-
-  try {
-    const result = await claimBacklogItemWorkspace({
-      db: workCapsuleDb(),
-      input: {
-        backlogItemId: itemId,
-        repositoryFullName,
-        headBranch: branchName,
-        worktreePath,
-        baseBranch,
-        executorKind,
-        executorRef: sessionRef,
-      },
-      actor: await actor(userId, context),
-    });
-
-    // EP-WORK-CONVERGENCE (BI-650994D7): anchor the capsule to the single canonical
-    // WorkItem for its backlog item, NON-FATALLY — the claim stands even if this fails,
-    // so capsule and case never split into two rows for one job.
-    try {
-      await ensureCapsuleWorkItemAnchorWithPrisma({
-        capsuleId: result.capsuleId,
-        backlogItemId: result.backlogItemId,
-        title: `Work on ${result.backlogItemId}`,
-      });
-    } catch (anchorError) {
-      console.warn(
-        `[work-convergence] WorkItem anchor skipped for ${result.capsuleId}: ${
-          anchorError instanceof Error ? anchorError.message : "unknown"
-        }`,
-      );
-    }
-
-    const base = `Bound ${result.backlogItemId} to ${result.headBranch} (${result.capsuleId}).`;
-    let message: string;
-    if (result.conflict) {
-      const parts: string[] = [];
-      if (result.conflict.backlogClaim) {
-        const age = result.conflict.backlogClaim.claimAgeMinutes;
-        parts.push(
-          `${result.backlogItemId} already has an ACTIVE claim by another session` +
-            (age != null ? ` (${age}m ago)` : "") +
-            " — this call did NOT steal it",
-        );
-      }
-      for (const loc of result.conflict.otherLocations) {
-        parts.push(`also in flight on ${loc.headBranch ?? "?"} (${loc.capsuleId})`);
-      }
-      message =
-        `${base} ADVISORY: ${result.backlogItemId} already has active work elsewhere — ${parts.join("; ")}. ` +
-        "Claim-at-start is a soft signal, not a lock: coordinate with the other session before pushing.";
-    } else {
-      message = `${base} Claim-at-start recorded for this session.`;
-    }
-
-    return {
-      success: true,
-      entityId: result.capsuleId,
-      message,
-      data: result,
-    };
-  } catch (error) {
-    const occupied = branchOccupiedResult(error);
-    if (occupied) return occupied;
-    const detail = error instanceof Error ? error.message : "Unknown failure";
-    if (/not found/i.test(detail)) {
-      return { success: false, error: "not_found", message: detail };
-    }
-    throw error;
-  }
+  return claimBacklogItemForWork({ params, userId, context, db: workCapsuleDb(), resolveActor: actor });
 }
 
 export async function claimCapsuleScopeTool(

--- a/apps/web/lib/work-capsules/work-capsule-store-types.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store-types.ts
@@ -12,10 +12,19 @@ export type CapsuleDb = {
     findMany(args: unknown): Promise<any[]>;
     update(args: unknown): Promise<any>;
   };
-  workroomActivity: { create(args: unknown): Promise<any> };
+  workroomActivity: {
+    create(args: unknown): Promise<any>;
+    findFirst?(args: unknown): Promise<any>;
+  };
   backlogItem?: {
     findFirst(args: unknown): Promise<any>;
+    findUnique?(args: unknown): Promise<any>;
     update(args: unknown): Promise<any>;
+  };
+  backlogItemActivity?: {
+    count(args: unknown): Promise<number>;
+    findMany(args: unknown): Promise<any[]>;
+    create(args: unknown): Promise<any>;
   };
   $transaction?<T>(fn: (tx: CapsuleDb) => Promise<T>): Promise<T>;
   $queryRaw?(strings: TemplateStringsArray, ...values: unknown[]): Promise<unknown>;

--- a/scripts/process-spine-conformance.test.mjs
+++ b/scripts/process-spine-conformance.test.mjs
@@ -1,6 +1,6 @@
 // BI-EF42607A — versioned process spine + conformance test (spec §6.1).
 import assert from "node:assert/strict";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
@@ -97,5 +97,36 @@ test("typecheck gates include the bootstrap planning library", () => {
       bootstrapPackage.scripts?.typecheck,
       "@dpf/bootstrap must define a typecheck script for the recursive sweep to pick it up",
     );
+  }
+});
+
+test("every direct protected FeatureBuild phase writer references the canonical initiative gate", () => {
+  const root = join(repoRoot, "apps/web/lib");
+  const files = [];
+  const visit = (dir) => {
+    for (const name of readdirSync(dir)) {
+      const path = join(dir, name);
+      if (statSync(path).isDirectory()) visit(path);
+      else if (name.endsWith(".ts") && !name.endsWith(".test.ts")) files.push(path);
+    }
+  };
+  visit(root);
+  const directWriter = /featureBuild\.(?:update|updateMany)\s*\([\s\S]{0,300}?data:\s*\{[\s\S]{0,160}?phase:\s*(?:"plan"|"build"|"ship"|"complete"|targetPhase)/;
+  const writers = files
+    .filter((path) => directWriter.test(readFileSync(path, "utf8")))
+    .map((path) => path.slice(repoRoot.length + 1).replaceAll("\\", "/"))
+    .sort();
+  assert.deepEqual(writers, [
+    "apps/web/lib/actions/build.ts",
+    "apps/web/lib/build-flow-state.ts",
+    "apps/web/lib/build/build-on-plan-approval.ts",
+    "apps/web/lib/build/plan-to-build-transition.ts",
+    "apps/web/lib/build/ship-on-review-approval.ts",
+    "apps/web/lib/mcp/build-design-review-handler.ts",
+  ]);
+  for (const path of writers) {
+    const source = readFileSync(join(repoRoot, path), "utf8");
+    assert.match(source, /from "@\/lib\/build\/build-entry-gate"/);
+    assert.match(source, /(?:enforceBuildInitiativeReadiness|assertBuildPhaseInitiativeReadiness)/);
   }
 });


### PR DESCRIPTION
## Summary

Prevents governed feature and archetype work from entering implementation through Workroom claims or Build Studio phase transitions until the canonical initiative-readiness evidence allows it.

## What changed

- Projects typed scope baselines, gate receipts, and plan-coverage evidence through the existing readiness evaluator. Textual spec or plan references remain hints and cannot satisfy a gate.
- Separates design candidates from implementation-ready backlog recommendations and exposes the readiness verdict on backlog reads.
- Adds `workIntent` to governed Workroom claims, evaluates readiness before mutation, records denials, and verifies the exact claim/intent identity in the same transaction.
- Enforces the shared gate at protected Build Studio transitions into plan, build, ship, and complete.
- Adds a source invariant that inventories every direct protected phase writer so a new bypass fails CI.
- Extracts claim orchestration and phase-target mapping into focused modules, keeping existing oversized modules within their shrink-only ratchets.

## Verification

- Focused Vitest: 121/121 passed.
- Web TypeScript `--noEmit`: passed.
- Next.js production build: passed.
- Pregate preflight: 46/46 guards passed.
- Module-size, style-drift, and process-spine conformance guards: passed.
- UX: not applicable; this slice changes MCP/server workflow behavior and no route, component, or visual contract.
- Migration: not applicable; no schema or data migration.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-08-08-initiative-readiness-and-goal-completion-reconciliation-design.md` and `docs/superpowers/plans/2026-08-08-initiative-readiness-and-goal-completion-reconciliation-implementation.md`.
- Current code substrate reviewed: `apps/web/lib/backlog/initiative-readiness`, Workroom claim handlers, backlog MCP packs, and every direct protected FeatureBuild phase writer.
- Source of truth: typed governance activities projected through the canonical initiative-readiness evaluator.
- Decision: gate declared implementation intent and protected phase transitions at their mutation doors; keep filesystem references informational only.

Process-Spine-Decision: protected FeatureBuild phase transitions use the canonical initiative-readiness gate, with direct writers inventoried by a conformance test.

Docs-Impact-Decision: readiness enforcement changes internal MCP and Build Studio mutation guards; no documented route, screen, or user-guide behavior changes.

## Related work

- `BI-4D756545`
- Parent: `BI-CF5A1078`
- Epic: `EP-129D11FD`

## Overlap sweep

Open PR #4438 also concerns backlog durability but has no file overlap. The other open PRs do not implement initiative entry readiness.
