### PR TITLE
fix(onboarding): make nonprofit WWWD starters mission-aware

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/stance/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/stance/page.tsx
@@ -14,6 +14,7 @@ import { HowYouDecideCards, type StanceCard } from "@/components/onboarding/HowY
 import { BUSINESS_STANCE_SLUG_PREFIX } from "@/lib/wiki/business-stance";
 import {
   resolveStanceVectors,
+  resolveStanceAuthoringExamples,
   STANCE_VECTOR_KEYS,
 } from "@/lib/onboarding/archetype-business-context";
 import { stanceVectorSlug } from "@/lib/onboarding/seed-org-wwwd-corpus";
@@ -56,6 +57,7 @@ export default async function BusinessStancePage() {
   // shown until the owner confirms them. Confirmed = the vector's primary
   // material sits at the owner-confirmed tier (A / >=0.9).
   let cards: StanceCard[] = [];
+  let authoringExamples = resolveStanceAuthoringExamples({ industry: null });
   if (organizationId) {
     const [storefront, profileId] = await Promise.all([
       prisma.storefrontConfig.findFirst({
@@ -65,6 +67,9 @@ export default async function BusinessStancePage() {
     ]);
     const defaults = resolveStanceVectors({
       archetypeId: storefront?.archetypeId ?? null,
+      industry: storefront?.archetype?.category ?? null,
+    });
+    authoringExamples = resolveStanceAuthoringExamples({
       industry: storefront?.archetype?.category ?? null,
     });
     const vectorSlugs = STANCE_VECTOR_KEYS.map((key) => stanceVectorSlug(key));
@@ -179,7 +184,7 @@ export default async function BusinessStancePage() {
         )}
       </section>
 
-      <BusinessStanceForm />
+      <BusinessStanceForm examples={authoringExamples} />
 
       <p className="text-xs text-[var(--dpf-muted)] mt-6">
         Reviewing what your AI has already decided?{" "}

--- a/apps/web/components/wiki/BusinessStanceForm.test.tsx
+++ b/apps/web/components/wiki/BusinessStanceForm.test.tsx
@@ -1,0 +1,33 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("@/lib/actions/business-stance", () => ({
+  publishBusinessStance: vi.fn(),
+  saveBusinessStance: vi.fn(),
+}));
+
+import { BusinessStanceForm } from "./BusinessStanceForm";
+
+describe("BusinessStanceForm", () => {
+  it("renders archetype-aware authoring examples supplied by the server page (BI-5220C674)", () => {
+    const html = renderToStaticMarkup(
+      createElement(BusinessStanceForm, {
+        examples: {
+          title: "How we prioritize limited support",
+          body: "Urgent mission need comes first; contributions never buy priority.",
+          summary: "Mission and need set priority",
+        },
+      }),
+    );
+
+    expect(html).toContain('placeholder="How we prioritize limited support"');
+    expect(html).toContain("Urgent mission need comes first; contributions never buy priority.");
+    expect(html).toContain('placeholder="Mission and need set priority"');
+    expect(html).not.toMatch(/placeholder="[^"]*refund/i);
+  });
+});

--- a/apps/web/components/wiki/BusinessStanceForm.tsx
+++ b/apps/web/components/wiki/BusinessStanceForm.tsx
@@ -14,7 +14,11 @@ import { useRouter } from "next/navigation";
 import { publishBusinessStance, saveBusinessStance } from "@/lib/actions/business-stance";
 import { DECISION_AREAS } from "@/lib/wiki/business-stance";
 
-export function BusinessStanceForm() {
+type BusinessStanceFormProps = {
+  examples: { title: string; body: string; summary: string };
+};
+
+export function BusinessStanceForm({ examples }: BusinessStanceFormProps) {
   const router = useRouter();
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
@@ -64,7 +68,7 @@ export function BusinessStanceForm() {
         type="text"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
-        placeholder="How we decide refunds"
+        placeholder={examples.title}
         className="w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)] mb-3"
       />
 
@@ -76,7 +80,7 @@ export function BusinessStanceForm() {
         value={body}
         onChange={(e) => setBody(e.target.value)}
         rows={4}
-        placeholder="We refund within 30 days, no questions asked. Beyond 30 days a manager decides based on the account relationship."
+        placeholder={examples.body}
         className="w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)] mb-3"
       />
 
@@ -88,7 +92,7 @@ export function BusinessStanceForm() {
         type="text"
         value={summary}
         onChange={(e) => setSummary(e.target.value)}
-        placeholder="30-day no-questions refunds; manager discretion after"
+        placeholder={examples.summary}
         className="w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)] mb-3"
       />
 

--- a/apps/web/lib/onboarding/archetype-business-context.test.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.test.ts
@@ -4,6 +4,7 @@ import {
   resolveBusinessProfile,
   GENERIC_BUSINESS_PROFILE,
   resolveStanceVectors,
+  resolveStanceAuthoringExamples,
   GENERIC_STANCE_VECTORS,
 } from "./archetype-business-context";
 
@@ -174,5 +175,31 @@ describe("resolveStanceVectors (BI-70ADC71F)", () => {
     const v = resolveStanceVectors({ industry: "public-sector" });
     expect(v["customer-goodwill"].ceilingUsd).toBeUndefined();
     expect(v["customer-goodwill"].stance).toMatch(/resident|process|equal/i);
+  });
+
+  it("projects all five nonprofit-community vectors without commercial assumptions (BI-5220C674)", () => {
+    const vectors = resolveStanceVectors({
+      archetypeId: "pet-rescue",
+      industry: "nonprofit-community",
+    });
+    const rendered = Object.values(vectors)
+      .flatMap((vector) => [vector.title, vector.stance])
+      .join(" ");
+
+    expect(rendered).toMatch(/mission|people we serve|supporter|donor|steward/i);
+    expect(rendered).not.toMatch(/prices|quotes|discounts|customer|refund|sell/i);
+    expect(vectors["customer-goodwill"].ceilingUsd).toBeUndefined();
+    expect(vectors["pricing-integrity"].ceilingUsd).toBeUndefined();
+  });
+
+  it("keeps commercial defaults unchanged while giving nonprofits a relevant authoring example", () => {
+    expect(resolveStanceVectors({ industry: "no-such-industry" })).toEqual(GENERIC_STANCE_VECTORS);
+
+    const nonprofit = resolveStanceAuthoringExamples({ industry: "nonprofit-community" });
+    expect(`${nonprofit.title} ${nonprofit.body} ${nonprofit.summary}`).toMatch(/mission|support|need/i);
+    expect(`${nonprofit.title} ${nonprofit.body} ${nonprofit.summary}`).not.toMatch(/refund|customer|price/i);
+
+    const commercial = resolveStanceAuthoringExamples({ industry: "food-hospitality" });
+    expect(commercial.title).toBe("How we decide refunds");
   });
 });

--- a/apps/web/lib/onboarding/archetype-business-context.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.ts
@@ -17,6 +17,11 @@
 // deepen a specific business model. Keep entries to broad, true, editable
 // starters — do not encode brittle specifics that read as fabricated.
 
+import { NONPROFIT_STANCE_VECTORS } from "./archetype-stance-presentation";
+
+export { resolveStanceAuthoringExamples } from "./archetype-stance-presentation";
+export type { StanceAuthoringExamples } from "./archetype-stance-presentation";
+
 export type ArchetypeBusinessProfile = {
   /** Completes the clause "we exist to …". */
   missionTheme: string;
@@ -698,14 +703,7 @@ const INDUSTRY_STANCE_VECTORS: Record<string, Partial<ArchetypeStanceVectors>> =
         "Fees are set in public session and applied uniformly. There are no discounts or improvised exceptions — changing a fee is a public decision, not a service gesture.",
     },
   },
-  "nonprofit-community": {
-    "spend-authority": {
-      title: "Spending donors' money without asking",
-      stance:
-        "Program supplies within the approved budget proceed up to the ceiling per purchase. Anything outside budget or above it goes to the director — every dollar carries a donor's trust.",
-      ceilingUsd: 150,
-    },
-  },
+  "nonprofit-community": NONPROFIT_STANCE_VECTORS,
 };
 
 /**

--- a/apps/web/lib/onboarding/archetype-stance-presentation.ts
+++ b/apps/web/lib/onboarding/archetype-stance-presentation.ts
@@ -1,0 +1,67 @@
+export type StanceAuthoringExamples = {
+  title: string;
+  body: string;
+  summary: string;
+};
+
+type NonprofitStanceKey =
+  | "customer-goodwill"
+  | "pricing-integrity"
+  | "growth-vs-stability"
+  | "quality-bar"
+  | "spend-authority";
+
+type StancePresentation = {
+  title: string;
+  stance: string;
+  ceilingUsd?: number;
+};
+
+export const NONPROFIT_STANCE_VECTORS: Record<NonprofitStanceKey, StancePresentation> = {
+  "customer-goodwill": {
+    title: "When we let someone we serve down",
+    stance:
+      "When our organization lets down people we serve, supporters, volunteers, or partners, we acknowledge it quickly and make a practical repair without making them fight for it. Safety, safeguarding, or material trust concerns go to the director immediately.",
+  },
+  "pricing-integrity": {
+    title: "Access, eligibility, and contributions",
+    stance:
+      "We state eligibility, suggested contributions, and what our programs provide clearly. Ability to contribute never buys priority, bends mission criteria, or quietly changes a commitment.",
+  },
+  "growth-vs-stability": {
+    title: "New opportunities vs existing commitments",
+    stance:
+      "Commitments to people we already serve and the cause at the heart of our mission get first call on capacity. We accept new opportunities only at the pace our people, funding, and duty of care can sustain.",
+  },
+  "quality-bar": {
+    title: "Our service and stewardship standard",
+    stance:
+      "Our work protects the wellbeing, dignity, and trust of the people and cause we serve. If delivery or stewardship falls below that standard, we correct it openly and learn before repeating it.",
+  },
+  "spend-authority": {
+    title: "Spending donors' money without asking",
+    stance:
+      "Program supplies within the approved budget proceed up to the ceiling per purchase. Anything outside budget or above it goes to the director — every dollar carries a donor's trust.",
+    ceilingUsd: 150,
+  },
+};
+
+const GENERIC_STANCE_AUTHORING_EXAMPLES: StanceAuthoringExamples = {
+  title: "How we decide refunds",
+  body: "We refund within 30 days, no questions asked. Beyond 30 days a manager decides based on the account relationship.",
+  summary: "30-day no-questions refunds; manager discretion after",
+};
+
+const NONPROFIT_STANCE_AUTHORING_EXAMPLES: StanceAuthoringExamples = {
+  title: "How we prioritize limited support",
+  body: "We use our published mission and eligibility criteria consistently. Urgent need comes first; a larger contribution never buys priority. When capacity is full, the director decides and we explain the constraint plainly.",
+  summary: "Mission and need set priority; contributions do not",
+};
+
+export function resolveStanceAuthoringExamples(input: {
+  industry?: string | null;
+}): StanceAuthoringExamples {
+  return input.industry === "nonprofit-community"
+    ? NONPROFIT_STANCE_AUTHORING_EXAMPLES
+    : GENERIC_STANCE_AUTHORING_EXAMPLES;
+}


### PR DESCRIPTION
Makes all five nonprofit-community WWWD starter stances mission-aware and threads archetype-specific authoring examples into the existing stance form while preserving commercial defaults. Tests: 18 focused Vitest tests and the full exact-tree pregate passed. Local-CI-Evidence: cmt4bo1880ebw01pk5w8rbljb.