### PR TITLE
fix(ci): unify local-CI scratch identity

### DIFF
--- a/docs/operations/local-ci-sandbox-slots.md
+++ b/docs/operations/local-ci-sandbox-slots.md
@@ -64,8 +64,12 @@ Slot 0 preserves the established external endpoints:
 
 - portal: `http://localhost:3010`
 - PostgreSQL host port: `15432`
-- scratch checkout: `D:/DPF-worktrees/.local-ci-runner` on the canonical
-  Windows host layout
+- scratch checkout: `<root-parent>/<root-name>-worktrees/.local-ci-runner`;
+  for example `D:/DPF-worktrees/.local-ci-runner` for a conventional
+  `D:/DPF` clone, or
+  `D:/DPF-worktrees/.opendigitalproductfactory.git-worktrees/.local-ci-runner`
+  when the Git common directory is the central bare
+  `D:/DPF-worktrees/.opendigitalproductfactory.git`
 
 The versioned public slot resources (slot keys, ordinals, portal ports, and
 PostgreSQL ports) live once in
@@ -186,6 +190,13 @@ filesystem target remains inside the slot scratch boundary. The command must
 come from the lease record or diagnosed slot state; never guess a peer slot.
 Use `--dry-run` when investigating so the exact targets are visible without
 mutation.
+
+The gate, runner, status reader, and cleanup planner all resolve the same root
+from `git rev-parse --git-common-dir`. Only a conventional common directory
+named `.git` is reduced to its parent clone; a central bare common directory is
+already the root. If a caller supplies a different root, manifest construction
+fails before cleanup or other host mutation. This prevents a linked topic
+worktree from inventing a second `*-worktrees` boundary.
 
 If freshness convergence cannot prove the dependency graph, the result is
 `blocked_sandbox_drift`, not a product failure. Each slot has its own

--- a/docs/operations/runtime-glossary.md
+++ b/docs/operations/runtime-glossary.md
@@ -34,6 +34,11 @@ leased convergence environment for exact merged-tree tests and production
 builds, not a per-worktree runtime and not a customer-facing portal. A typed
 slot manifest isolates its scratch checkout, process fence, Compose project,
 portal/PostgreSQL ports, database/volume, dependency state, and evidence.
+All local-CI entry points derive those resources from one canonical Git
+common-dir identity: the clone parent of a conventional `.git` directory, or
+the bare repository directory itself for the centrally managed worktree fleet.
+The manifest then owns the sibling scratch path and its exact cleanup boundary;
+a topic worktree path is never treated as a second runtime root.
 Automatic capacity is one; the second declared identity remains unavailable to
 automatic admission until its governed pilot.
 

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -193,6 +193,15 @@ runtime is declared in `docker-compose.local-ci.yml` behind the `local-ci`
 profile. A versioned slot manifest owns every mutable identity: scratch
 checkout, process fence, Compose project, portal and PostgreSQL ports,
 container/database/volume, dependency convergence state, output, and evidence.
+Every entry point derives that manifest from the same canonical Git common-dir
+identity. In a conventional clone, `<clone>/.git` resolves to `<clone>`; in the
+centrally managed worktree fleet, the bare `.opendigitalproductfactory.git`
+directory is already the root identity. The scratch checkout is then created
+as a sibling under `<root>-worktrees` (slot 0 uses `.local-ci-runner`), and
+cleanup is fenced to that exact manifest-owned scratch boundary. Gate, runner,
+status, and cleanup code must not independently derive the root from the topic
+worktree path: doing so can point cleanup at a different sibling and is rejected
+before host state is mutated.
 Slot 0 preserves the singleton portal on `http://localhost:3010` and uses its
 dedicated PostgreSQL endpoint on port `15432`; it may still consume shared,
 read-only or concurrency-safe development services such as Qdrant and Neo4j.
@@ -789,7 +798,8 @@ Fix a surface's labels, then `--update` to retighten — the guard prints a
 `shrank in N file(s)` line to prompt you. For the rare label that names a
 composite widget rather than one control (a radio-group heading), add a
 `label-association-allow` comment on the same line stating why. Tracked debt
-paydown: `BI-6CDC9ADB`.
+is the checked-in baseline itself; file a live BI before proposing a separate
+paydown campaign.
 
 ## What this gate is NOT
 

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -37,6 +37,7 @@ import {
   LOCAL_CI_SLOT_KEYS,
   createLocalCiSlotManifest,
   localCiSlotEnvironment,
+  resolveLocalCiRootClone,
 } from "./lib/local-ci-slot-manifest.mjs";
 import { classifyBaseResilience } from "./lib/local-ci-base-freshness.mjs";
 import {
@@ -846,7 +847,7 @@ async function main() {
     worktreePath,
     gitOrEmpty(gitBin, ["rev-parse", "--git-common-dir"], worktreePath),
   );
-  const rootClone = dirname(gitCommonDir);
+  const rootClone = resolveLocalCiRootClone(gitCommonDir);
   const queueObserverDirectory = process.env.DPF_LOCAL_QUEUE_OBSERVER_DIR
     || resolvePath(gitCommonDir, "dpf-local-ci-queue-observers");
   let slotManifest = createLocalCiSlotManifest({

--- a/scripts/lib/local-ci-slot-manifest.mjs
+++ b/scripts/lib/local-ci-slot-manifest.mjs
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module";
-import { dirname, basename, isAbsolute, join, relative, resolve } from "node:path";
+import { dirname, basename, isAbsolute, join, posix, relative, resolve, win32 } from "node:path";
 
 const require = createRequire(import.meta.url);
 const SLOT_RESOURCE_MANIFEST = require(
@@ -26,6 +26,30 @@ function requireAbsolutePath(name, value) {
     throw new Error(`${name} must be an absolute path`);
   }
   return resolve(value);
+}
+
+/**
+ * Resolve the repository root identity used by every local-CI caller.
+ *
+ * A normal clone reports `<clone>/.git` as its common directory, so the root
+ * is the clone directory. A centrally-managed worktree fleet reports the bare
+ * repository itself (for example `.opendigitalproductfactory.git`), which is
+ * already the root identity. Keeping this here prevents the gate and runner
+ * from independently guessing different scratch-worktree parents.
+ *
+ * @param {string} gitCommonDir
+ */
+export function resolveLocalCiRootClone(gitCommonDir) {
+  const pathApi = win32.isAbsolute(gitCommonDir)
+    ? win32
+    : posix.isAbsolute(gitCommonDir)
+      ? posix
+      : null;
+  if (!pathApi) throw new Error("gitCommonDir must be an absolute path");
+  const commonDir = pathApi.resolve(gitCommonDir);
+  return pathApi.basename(commonDir).toLowerCase() === ".git"
+    ? pathApi.dirname(commonDir)
+    : commonDir;
 }
 
 /**
@@ -76,6 +100,12 @@ export function createLocalCiSlotManifest(input) {
     "candidateGitDir",
     input.candidateGitDir ?? gitCommonDir,
   );
+  const canonicalRootClone = resolveLocalCiRootClone(gitCommonDir);
+  if (resolve(rootClone) !== resolve(canonicalRootClone)) {
+    throw new Error(
+      `rootClone must match the canonical Git common-dir root: ${canonicalRootClone}`,
+    );
+  }
   const worktreeBase = join(dirname(rootClone), `${basename(rootClone)}-worktrees`);
   const workspace = resources.ordinal === 0
     ? join(worktreeBase, ".local-ci-runner")

--- a/scripts/lib/local-ci-slot-manifest.mjs
+++ b/scripts/lib/local-ci-slot-manifest.mjs
@@ -40,10 +40,12 @@ function requireAbsolutePath(name, value) {
  * @param {string} gitCommonDir
  */
 export function resolveLocalCiRootClone(gitCommonDir) {
-  const pathApi = win32.isAbsolute(gitCommonDir)
-    ? win32
-    : posix.isAbsolute(gitCommonDir)
-      ? posix
+  // win32.isAbsolute('/tmp/repo') is also true, so POSIX must win for a
+  // slash-rooted path. Drive-letter and UNC paths then fall through to win32.
+  const pathApi = posix.isAbsolute(gitCommonDir)
+    ? posix
+    : win32.isAbsolute(gitCommonDir)
+      ? win32
       : null;
   if (!pathApi) throw new Error("gitCommonDir must be an absolute path");
   const commonDir = pathApi.resolve(gitCommonDir);

--- a/scripts/lib/local-ci-slot-manifest.test.mjs
+++ b/scripts/lib/local-ci-slot-manifest.test.mjs
@@ -70,6 +70,14 @@ test("Windows bare-common-dir layout does not grow a duplicate worktrees suffix"
   );
 });
 
+test("POSIX common-dir paths retain POSIX separators", () => {
+  assert.equal(
+    resolveLocalCiRootClone("/tmp/dpf-worktrees/.opendigitalproductfactory.git"),
+    "/tmp/dpf-worktrees/.opendigitalproductfactory.git",
+  );
+  assert.equal(resolveLocalCiRootClone("/tmp/dpf/.git"), "/tmp/dpf");
+});
+
 test("slot manifests are versioned and every mutable identity is isolated", () => {
   const paths = fixture();
   const slots = LOCAL_CI_SLOT_KEYS.map((slotKey) =>

--- a/scripts/lib/local-ci-slot-manifest.test.mjs
+++ b/scripts/lib/local-ci-slot-manifest.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, win32 } from "node:path";
 import test from "node:test";
 
 import {
@@ -10,6 +10,7 @@ import {
   assertLocalCiCleanupTarget,
   createLocalCiSlotManifest,
   localCiSlotEnvironment,
+  resolveLocalCiRootClone,
 } from "./local-ci-slot-manifest.mjs";
 
 function fixture() {
@@ -23,6 +24,50 @@ function fixture() {
 test("derives declared capacity from the closed physical slot manifest", () => {
   assert.deepEqual(LOCAL_CI_SLOT_KEYS, ["slot-0", "slot-1"]);
   assert.equal(LOCAL_CI_DECLARED_CAPACITY, 2);
+});
+
+test("normal and bare-common-dir repositories share one canonical root resolver", () => {
+  const normal = fixture();
+  assert.equal(resolveLocalCiRootClone(normal.gitCommonDir), normal.rootClone);
+
+  const bareCommonDir = join(dirname(normal.rootClone), ".opendigitalproductfactory.git");
+  assert.equal(resolveLocalCiRootClone(bareCommonDir), bareCommonDir);
+
+  const gateManifest = createLocalCiSlotManifest({
+    ...normal,
+    rootClone: resolveLocalCiRootClone(bareCommonDir),
+    gitCommonDir: bareCommonDir,
+    slotKey: "slot-0",
+  });
+  const runnerManifest = createLocalCiSlotManifest({
+    ...normal,
+    rootClone: resolveLocalCiRootClone(bareCommonDir),
+    gitCommonDir: bareCommonDir,
+    slotKey: "slot-0",
+  });
+  assert.equal(gateManifest.scratch.workspace, runnerManifest.scratch.workspace);
+  assert.equal(
+    gateManifest.scratch.workspace,
+    join(dirname(bareCommonDir), `${bareCommonDir.split(/[\\/]/).at(-1)}-worktrees`, ".local-ci-runner"),
+  );
+  assert.throws(
+    () => createLocalCiSlotManifest({
+      ...normal,
+      rootClone: dirname(bareCommonDir),
+      gitCommonDir: bareCommonDir,
+      slotKey: "slot-0",
+    }),
+    /rootClone must match the canonical Git common-dir root/,
+  );
+});
+
+test("Windows bare-common-dir layout does not grow a duplicate worktrees suffix", () => {
+  const commonDir = String.raw`D:\DPF-worktrees\.opendigitalproductfactory.git`;
+  assert.equal(resolveLocalCiRootClone(commonDir), win32.normalize(commonDir));
+  assert.notEqual(
+    resolveLocalCiRootClone(commonDir),
+    String.raw`D:\DPF-worktrees`,
+  );
 });
 
 test("slot manifests are versioned and every mutable identity is isolated", () => {

--- a/scripts/lib/pregate-status.test.mjs
+++ b/scripts/lib/pregate-status.test.mjs
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
+
+import { worktreeContextFromGit } from "../pregate-status.mjs";
 
 import {
   classifySlotRecord,
@@ -11,6 +16,41 @@ import {
 const HEAD = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const OLD = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 const NOW = Date.parse("2026-08-04T12:00:00.000Z");
+
+test("status reader preserves the central bare common-dir as the canonical root", () => {
+  const hostRoot = mkdtempSync(join(tmpdir(), "dpf-pregate-status-"));
+  const worktreePath = join(hostRoot, "candidate");
+  const gitCommonDir = join(hostRoot, ".opendigitalproductfactory.git");
+  const statePath = join(gitCommonDir, "worktrees", "candidate", "dpf-local-ci-gate.json");
+
+  const context = worktreeContextFromGit({
+    worktreePath,
+    gitCommonDirRaw: gitCommonDir,
+    statePathRaw: statePath,
+    headBranch: "fix/example",
+    headSha: "abc123",
+  });
+
+  assert.equal(context.gitCommonDir, gitCommonDir);
+  assert.equal(context.rootClone, gitCommonDir);
+  assert.equal(context.candidateGitDir, join(gitCommonDir, "worktrees", "candidate"));
+});
+
+test("status reader still resolves a normal clone root from its .git common-dir", () => {
+  const hostRoot = mkdtempSync(join(tmpdir(), "dpf-pregate-status-normal-"));
+  const worktreePath = join(hostRoot, "clone");
+  const gitCommonDir = join(worktreePath, ".git");
+
+  const context = worktreeContextFromGit({
+    worktreePath,
+    gitCommonDirRaw: gitCommonDir,
+    statePathRaw: join(gitCommonDir, "dpf-local-ci-gate.json"),
+    headBranch: "fix/example",
+    headSha: "abc123",
+  });
+
+  assert.equal(context.rootClone, worktreePath);
+});
 
 function passingState(overrides = {}) {
   return {

--- a/scripts/local-ci-runner.mjs
+++ b/scripts/local-ci-runner.mjs
@@ -20,6 +20,7 @@ import {
   assertLocalCiCleanupTarget,
   createLocalCiSlotManifest,
   localCiSlotEnvironment,
+  resolveLocalCiRootClone,
 } from "./lib/local-ci-slot-manifest.mjs";
 import {
   LOCAL_CI_BASE_FRESHNESS,
@@ -319,15 +320,6 @@ async function resolveDatabaseUrl(env, manifest) {
   return "";
 }
 
-function resolveRootClone(repoTop) {
-  const result = git(["worktree", "list", "--porcelain"], repoTop);
-  if (result.status !== 0) die(`could not list worktrees: ${result.stderr}`);
-  for (const line of result.stdout.split("\n")) {
-    if (line.startsWith("worktree ")) return line.slice("worktree ".length).trim();
-  }
-  return "";
-}
-
 export const LOCAL_CI_MISSING_DATABASE_URL = "postgresql://dpf:dpf_dev@127.0.0.1:1/dpf_local_ci_missing_database";
 
 export function createLocalIntegrationChildInvocation({
@@ -425,10 +417,8 @@ async function main() {
   if (!baseRef) die("--base-ref cannot be empty");
 
   const repoTop = gitOrEmpty(["rev-parse", "--show-toplevel"]);
-  const root = resolveRootClone(repoTop);
-  if (!root) die("could not resolve the root clone");
-
   const gitCommonDir = gitOrEmpty(["rev-parse", "--path-format=absolute", "--git-common-dir"], repoTop);
+  const root = resolveLocalCiRootClone(gitCommonDir);
   const candidateGitDir = gitOrEmpty(["rev-parse", "--absolute-git-dir"], repoTop);
   const manifest = createLocalCiSlotManifest({
     slotKey,

--- a/scripts/pregate-status.mjs
+++ b/scripts/pregate-status.mjs
@@ -21,6 +21,7 @@ import { dirname, resolve as resolvePath } from "node:path";
 import {
   createLocalCiSlotManifest,
   LOCAL_CI_SLOT_KEYS,
+  resolveLocalCiRootClone,
 } from "./lib/local-ci-slot-manifest.mjs";
 import {
   classifySlotRecord,
@@ -45,21 +46,37 @@ function readJson(path) {
   }
 }
 
+export function worktreeContextFromGit({
+  worktreePath,
+  gitCommonDirRaw,
+  statePathRaw,
+  headBranch,
+  headSha,
+}) {
+  const gitCommonDir = resolvePath(worktreePath, gitCommonDirRaw);
+  return {
+    worktreePath,
+    gitCommonDir,
+    rootClone: resolveLocalCiRootClone(gitCommonDir),
+    candidateGitDir: dirname(resolvePath(worktreePath, statePathRaw)),
+    headBranch,
+    headSha,
+  };
+}
+
 export function resolveWorktreeContext(cwd = process.cwd()) {
   const worktreePath = gitText(["rev-parse", "--show-toplevel"], cwd);
   if (!worktreePath) return null;
   const gitCommonDirRaw = gitText(["rev-parse", "--git-common-dir"], worktreePath);
   const statePathRaw = gitText(["rev-parse", "--git-path", "dpf-local-ci-gate.json"], worktreePath);
   if (!gitCommonDirRaw || !statePathRaw) return null;
-  const gitCommonDir = resolvePath(worktreePath, gitCommonDirRaw);
-  return {
+  return worktreeContextFromGit({
     worktreePath,
-    gitCommonDir,
-    rootClone: dirname(gitCommonDir),
-    candidateGitDir: dirname(resolvePath(worktreePath, statePathRaw)),
+    gitCommonDirRaw,
+    statePathRaw,
     headBranch: gitText(["rev-parse", "--abbrev-ref", "HEAD"], worktreePath),
     headSha: gitText(["rev-parse", "HEAD"], worktreePath),
-  };
+  });
 }
 
 /** Read and classify every slot's records for this worktree. */

--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -22,6 +22,7 @@ import { checkHostDiskSpace } from "./lib/disk-space-preflight.mjs";
 import {
   createLocalCiSlotManifest,
   LOCAL_CI_SLOT_KEYS,
+  resolveLocalCiRootClone,
 } from "./lib/local-ci-slot-manifest.mjs";
 import {
   isRecoverableInterruptedGateState,
@@ -148,7 +149,7 @@ export function resolvePregateGateContext({
     sha,
     worktreePath,
     gitCommonDir,
-    rootClone: dirname(gitCommonDir),
+    rootClone: resolveLocalCiRootClone(gitCommonDir),
     candidateGitDir,
   };
 }

--- a/scripts/pregate.test.mjs
+++ b/scripts/pregate.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { join, resolve } from "node:path";
 import test from "node:test";
 
 import {
@@ -8,9 +9,35 @@ import {
   runGateWithQueuedRevival,
   detectWorkingShell,
   recoverInterruptedGateState,
+  resolvePregateGateContext,
   reviveInterruptedQueuedGateState,
   shouldUseShell,
 } from "./pregate.mjs";
+
+test("pregate recovery uses the bare common directory as the canonical root", () => {
+  const fixtureRoot = resolve(".pregate-bare-layout");
+  const worktreePath = join(fixtureRoot, "worktrees", "candidate");
+  const gitCommonDir = join(fixtureRoot, ".opendigitalproductfactory.git");
+  const candidateGitDir = join(gitCommonDir, "worktrees", "candidate");
+  const responses = new Map([
+    ["rev-parse --show-toplevel", worktreePath],
+    ["rev-parse --abbrev-ref HEAD", "fix/local-ci-scratch-identity"],
+    ["rev-parse HEAD", "a".repeat(40)],
+    ["rev-parse --git-common-dir", gitCommonDir],
+    ["rev-parse --git-path dpf-local-ci-gate.json", join(candidateGitDir, "dpf-local-ci-gate.json")],
+  ]);
+  const spawnSyncImpl = (_command, args) => ({
+    status: 0,
+    error: null,
+    stdout: `${responses.get(args.join(" ")) ?? ""}\n`,
+  });
+
+  const context = resolvePregateGateContext({ cwd: worktreePath, spawnSyncImpl });
+
+  assert.equal(context.gitCommonDir, gitCommonDir);
+  assert.equal(context.rootClone, gitCommonDir);
+  assert.equal(context.candidateGitDir, candidateGitDir);
+});
 
 test("queued gate revivals share the original bounded admission deadline", () => {
   const startedAtMs = Date.parse("2026-08-12T03:00:00.000Z");


### PR DESCRIPTION
## Summary
- derive the local-CI root clone consistently for normal clones and the central bare `.opendigitalproductfactory.git` layout
- keep scratch, cleanup, gate, runner, pregate, and status paths on the same canonical identity
- add cross-layout regression coverage, including the exact linked-worktree cleanup boundary that blocked queued claims

## Backlog
- BI-D9A4037F

## Verification
- 31 focused slot/status tests pass
- 47 host preflight guards pass
- exact-tree local CI on `efe41ae113df` passed scratch setup, migrations, docs/guards, web typecheck, exhaustive Vitest, Next production compile, and OCI layer export
- evidence `cmt4ck3eq0fcu01pkgmn4mgye` then exited 5 only on `mcp:request-failed`; the gate classified this as control-plane starvation, not a product-diff failure
- independent high-assurance semantic review `cmt4dbs1j0ftw01pkg01i82oi`: no findings, publication allowed

## Risk
No schema migration or user-facing UX change. The repair is limited to CI host-path identity and diagnostics.

Local-CI-Evidence: cmt4ck3eq0fcu01pkgmn4mgye