### PR TITLE
fix(onboarding): ensure WWWD profile before stance promotion (BI-68743C43)

### DIFF
--- a/apps/web/lib/actions/stance-confirm.test.ts
+++ b/apps/web/lib/actions/stance-confirm.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEnsureProfile, mockPrisma, mockPromote, mockRequireCapability } = vi.hoisted(() => ({
+  mockEnsureProfile: vi.fn(),
+  mockPromote: vi.fn(),
+  mockRequireCapability: vi.fn(),
+  mockPrisma: {
+    organization: { findFirst: vi.fn() },
+    storefrontConfig: { findFirst: vi.fn() },
+    wikiPage: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
+vi.mock("@dpf/db/wiki-store", () => ({
+  upsertWikiPage: vi.fn(async () => ({ id: "wiki-stance" })),
+  appendRevision: vi.fn(async () => ({})),
+}));
+vi.mock("@/lib/actions/shared/guards", () => ({ requireCapability: mockRequireCapability }));
+vi.mock("@/lib/decision-perspective/stance-promotion", () => ({
+  promoteStanceMaterial: mockPromote,
+}));
+vi.mock("@/lib/onboarding/ensure-org-decision-perspective-profile", () => ({
+  ensureOrgDecisionPerspectiveProfile: mockEnsureProfile,
+}));
+vi.mock("@/lib/wiki/embeddings", () => ({ storeWikiPage: vi.fn(async () => true) }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { confirmStanceVectors } from "./stance-confirm";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireCapability.mockResolvedValue({ userId: "owner-1" });
+  mockPrisma.organization.findFirst.mockResolvedValue({
+    id: "org-rescue",
+    name: "Second Chance Animal Rescue",
+  });
+  mockPrisma.storefrontConfig.findFirst.mockResolvedValue({
+    archetypeId: "pet-rescue",
+    archetype: { category: "nonprofit-community" },
+  });
+  mockPrisma.wikiPage.findFirst.mockResolvedValue(null);
+  mockEnsureProfile.mockResolvedValue({
+    profileId: "org-perspective-org-rescue",
+    versionId: "org-perspective-org-rescue-v1",
+  });
+  mockPromote.mockResolvedValue({
+    ok: true,
+    profileId: "org-perspective-org-rescue",
+    materialIds: [],
+    keptHigherTier: [],
+  });
+});
+
+describe("confirmStanceVectors", () => {
+  it("ensures the decision profile before promoting stances during active setup", async () => {
+    const result = await confirmStanceVectors({
+      vectors: [
+        {
+          key: "customer-goodwill",
+          stance: "Make the adopter whole quickly and protect the animal's wellbeing.",
+          ceilingUsd: 100,
+        },
+      ],
+    });
+
+    expect(result).toEqual({ ok: true, confirmedVectors: 1, upgradedIdentityPages: 0 });
+    expect(mockEnsureProfile).toHaveBeenCalledWith({
+      organizationId: "org-rescue",
+      organizationName: "Second Chance Animal Rescue",
+      db: mockPrisma,
+    });
+    expect(mockEnsureProfile.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPromote.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/apps/web/lib/actions/stance-confirm.ts
+++ b/apps/web/lib/actions/stance-confirm.ts
@@ -22,6 +22,9 @@ import {
   resolveStanceVectors,
   type StanceVectorKey,
 } from "@/lib/onboarding/archetype-business-context";
+import {
+  ensureOrgDecisionPerspectiveProfile,
+} from "@/lib/onboarding/ensure-org-decision-perspective-profile";
 import { STANCE_VECTOR_BUNDLES, stanceVectorSlug } from "@/lib/onboarding/seed-org-wwwd-corpus";
 import {
   classesCoveredByVectors,
@@ -65,6 +68,15 @@ export async function confirmStanceVectors(input: {
   });
 
   try {
+    // `how-you-decide` is valid before the full setup-completion seed chain.
+    // Materialize only the profile/version container this write path needs;
+    // the final corpus seeder remains responsible for starter pages/materials.
+    await ensureOrgDecisionPerspectiveProfile({
+      organizationId: org.id,
+      organizationName: org.name,
+      db: prisma,
+    });
+
     for (const vector of v.vectors) {
       const slug = stanceVectorSlug(vector.key);
       const title = defaults[vector.key].title;
@@ -149,7 +161,7 @@ export async function confirmStanceVectors(input: {
       if (!promoted.ok) {
         return {
           ok: false,
-          error: "Your stances were saved, but the decision profile is missing — finish business setup first.",
+          error: "Your stances were saved, but their decision profile could not be prepared. Please try again.",
         };
       }
     }

--- a/apps/web/lib/onboarding/ensure-org-decision-perspective-profile.test.ts
+++ b/apps/web/lib/onboarding/ensure-org-decision-perspective-profile.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ensureOrgDecisionPerspectiveProfile,
+  ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+  type EnsureOrgDecisionPerspectiveProfileClient,
+} from "./ensure-org-decision-perspective-profile";
+
+type Row = Record<string, unknown>;
+
+function makeFakeDb() {
+  const profiles: Row[] = [];
+  const versions: Row[] = [];
+
+  function upsertBy(
+    rows: Row[],
+    key: string,
+    value: string,
+    create: Row,
+    update: Row,
+  ): Row {
+    const found = rows.find((row) => row[key] === value);
+    if (found) {
+      Object.assign(found, update);
+      return found;
+    }
+    const row = { ...create };
+    rows.push(row);
+    return row;
+  }
+
+  const db: EnsureOrgDecisionPerspectiveProfileClient = {
+    decisionPerspectiveProfile: {
+      upsert: vi.fn(async (args: any) =>
+        upsertBy(profiles, "profileId", args.where.profileId, args.create, args.update),
+      ),
+      update: vi.fn(async (args: any) => {
+        const found = profiles.find((row) => row.profileId === args.where.profileId);
+        if (found) Object.assign(found, args.data);
+        return found;
+      }),
+    },
+    decisionPerspectiveProfileVersion: {
+      upsert: vi.fn(async (args: any) =>
+        upsertBy(versions, "versionId", args.where.versionId, args.create, args.update),
+      ),
+    },
+  };
+
+  return { db, profiles, versions };
+}
+
+describe("ensureOrgDecisionPerspectiveProfile", () => {
+  it("creates the canonical active profile and version before WWWD material writes", async () => {
+    const fake = makeFakeDb();
+
+    const result = await ensureOrgDecisionPerspectiveProfile({
+      organizationId: "org_rescue",
+      organizationName: "Second Chance Animal Rescue",
+      db: fake.db,
+    });
+
+    expect(result).toEqual({
+      profileId: "org-perspective-org_rescue",
+      versionId: "org-perspective-org_rescue-v1",
+    });
+    expect(fake.profiles).toEqual([
+      expect.objectContaining({
+        profileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+        fallbackProfileId: null,
+        status: "active",
+      }),
+      expect.objectContaining({
+        profileId: result.profileId,
+        name: "Second Chance Animal Rescue perspective",
+        ownerOrganizationId: "org_rescue",
+        fallbackProfileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+        currentVersionId: result.versionId,
+        status: "active",
+      }),
+    ]);
+    expect(fake.versions).toEqual([
+      expect.objectContaining({
+        versionId: result.versionId,
+        profileId: result.profileId,
+        versionNumber: 1,
+      }),
+    ]);
+  });
+
+  it("replays idempotently with the same profile and version", async () => {
+    const fake = makeFakeDb();
+    const input = {
+      organizationId: "org_rescue",
+      organizationName: "Second Chance Animal Rescue",
+      db: fake.db,
+    };
+
+    const first = await ensureOrgDecisionPerspectiveProfile(input);
+    const second = await ensureOrgDecisionPerspectiveProfile(input);
+
+    expect(second).toEqual(first);
+    expect(fake.profiles).toHaveLength(2);
+    expect(fake.versions).toHaveLength(1);
+  });
+});

--- a/apps/web/lib/onboarding/ensure-org-decision-perspective-profile.ts
+++ b/apps/web/lib/onboarding/ensure-org-decision-perspective-profile.ts
@@ -1,0 +1,113 @@
+import { prisma } from "@dpf/db";
+
+import { DECISION_DOMAIN_CLASSES } from "@/lib/decision-perspective/types";
+
+/** Platform fallback our organization profiles chain to (material.ts:14). */
+export const ORG_PERSPECTIVE_FALLBACK_PROFILE_ID = "dpf-organizational-principles";
+
+const PLAN_READINESS_DOMAIN_CLASS = "plan-readiness";
+const DEFAULT_AUTONOMY_POLICY = {
+  allowRecommendation: true,
+  allowArbitration: false,
+  maxRiskForArbitration: "low",
+  minimumConfidenceForRecommendation: 0.55,
+  minimumConfidenceForArbitration: 0.9,
+};
+
+/** Structural client — satisfied by the real PrismaClient and by test fakes. */
+export type EnsureOrgDecisionPerspectiveProfileClient = {
+  decisionPerspectiveProfile: {
+    upsert(args: unknown): Promise<unknown>;
+    update(args: unknown): Promise<unknown>;
+  };
+  decisionPerspectiveProfileVersion: {
+    upsert(args: unknown): Promise<unknown>;
+  };
+};
+
+export type EnsureOrgDecisionPerspectiveProfileInput = {
+  organizationId: string;
+  organizationName: string | null;
+  db?: EnsureOrgDecisionPerspectiveProfileClient;
+};
+
+export type EnsureOrgDecisionPerspectiveProfileResult = {
+  profileId: string;
+  versionId: string;
+};
+
+/**
+ * Materialize the canonical organization decision-profile container.
+ *
+ * This is deliberately narrower than `seedOrgWwwdCorpus`: any valid WWWD
+ * write path may ensure its container without triggering unrelated page,
+ * embedding, or setup-completion work. Stable-id upserts make replay safe.
+ */
+export async function ensureOrgDecisionPerspectiveProfile(
+  input: EnsureOrgDecisionPerspectiveProfileInput,
+): Promise<EnsureOrgDecisionPerspectiveProfileResult> {
+  const db = input.db ?? (prisma as unknown as EnsureOrgDecisionPerspectiveProfileClient);
+  const profileId = `org-perspective-${input.organizationId}`;
+  const versionId = `${profileId}-v1`;
+
+  // The fallback FK target historically shipped only as an in-code constant.
+  // Ensure it first so a fresh install cannot fail the organization upsert.
+  await db.decisionPerspectiveProfile.upsert({
+    where: { profileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID },
+    update: {},
+    create: {
+      profileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+      name: "DPF Organizational Principles",
+      kind: "organization",
+      scope: { domains: ["platform-governance", PLAN_READINESS_DOMAIN_CLASS] },
+      fallbackProfileId: null,
+      defaultResolver: { type: "build-studio-owner" },
+      autonomyPolicy: DEFAULT_AUTONOMY_POLICY,
+      status: "active",
+    },
+  });
+
+  await db.decisionPerspectiveProfile.upsert({
+    where: { profileId },
+    update: {
+      name: `${input.organizationName ?? "Organization"} perspective`,
+      kind: "organization",
+      scope: { domains: [...DECISION_DOMAIN_CLASSES] },
+      ownerOrganizationId: input.organizationId,
+      fallbackProfileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+      defaultResolver: { type: "build-studio-owner" },
+      autonomyPolicy: DEFAULT_AUTONOMY_POLICY,
+      status: "active",
+    },
+    create: {
+      profileId,
+      name: `${input.organizationName ?? "Organization"} perspective`,
+      kind: "organization",
+      scope: { domains: [...DECISION_DOMAIN_CLASSES] },
+      ownerOrganizationId: input.organizationId,
+      fallbackProfileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
+      defaultResolver: { type: "build-studio-owner" },
+      autonomyPolicy: DEFAULT_AUTONOMY_POLICY,
+      status: "active",
+    },
+  });
+
+  await db.decisionPerspectiveProfileVersion.upsert({
+    where: { versionId },
+    update: { changeSummary: "Organization perspective seeded at onboarding." },
+    create: {
+      versionId,
+      profileId,
+      versionNumber: 1,
+      materialFingerprint: `seed:${profileId}:v1`,
+      changeSummary: "Organization perspective seeded at onboarding.",
+    },
+  });
+
+  await db.decisionPerspectiveProfile.update({
+    where: { profileId },
+    data: { currentVersionId: versionId },
+  });
+
+  return { profileId, versionId };
+}

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
@@ -35,7 +35,7 @@
 import { prisma } from "@dpf/db";
 import { upsertWikiPage, appendRevision } from "@dpf/db/wiki-store";
 import { storeWikiPage, type StoreWikiPageInput } from "@/lib/wiki/embeddings";
-import { DECISION_DOMAIN_CLASSES, type DecisionDomainClass } from "@/lib/decision-perspective/types";
+import { type DecisionDomainClass } from "@/lib/decision-perspective/types";
 import {
   projectDeclaredStanceAlignment,
   projectStanceDimensionVector,
@@ -49,10 +49,12 @@ import {
   STANCE_VECTOR_KEYS,
   type StanceVectorKey,
 } from "./archetype-business-context";
+import {
+  ensureOrgDecisionPerspectiveProfile,
+  type EnsureOrgDecisionPerspectiveProfileClient,
+} from "./ensure-org-decision-perspective-profile";
 
-/** Platform fallback our org profile chains to (material.ts:14). */
-export const ORG_PERSPECTIVE_FALLBACK_PROFILE_ID = "dpf-organizational-principles";
-const PLAN_READINESS_DOMAIN_CLASS = "plan-readiness";
+export { ORG_PERSPECTIVE_FALLBACK_PROFILE_ID } from "./ensure-org-decision-perspective-profile";
 
 /**
  * Which decision classes each stance vector's material lands in (the "gate
@@ -73,24 +75,11 @@ export function stanceVectorSlug(key: StanceVectorKey): string {
   return `stances/${key}`;
 }
 
-const DEFAULT_AUTONOMY_POLICY = {
-  allowRecommendation: true,
-  allowArbitration: false,
-  maxRiskForArbitration: "low",
-  minimumConfidenceForRecommendation: 0.55,
-  minimumConfidenceForArbitration: 0.9,
-};
-
 /** Structural client — satisfied by the real PrismaClient and by test fakes. */
-export type SeedOrgWwwdClient = {
+export type SeedOrgWwwdClient = EnsureOrgDecisionPerspectiveProfileClient & {
   businessContext: { findUnique: (args: unknown) => Promise<unknown> };
   storefrontConfig: { findFirst: (args: unknown) => Promise<unknown> };
   organization: { findUnique: (args: unknown) => Promise<unknown> };
-  decisionPerspectiveProfile: {
-    upsert: (args: unknown) => Promise<unknown>;
-    update: (args: unknown) => Promise<unknown>;
-  };
-  decisionPerspectiveProfileVersion: { upsert: (args: unknown) => Promise<unknown> };
   perspectiveMaterial: { upsert: (args: unknown) => Promise<unknown> };
   wikiPage: {
     findFirst: (args: unknown) => Promise<unknown>;
@@ -305,9 +294,6 @@ export async function seedOrgWwwdCorpus(
   const embed = input.embed ?? storeWikiPage;
   const organizationId = input.organizationId;
 
-  const profileId = `org-perspective-${organizationId}`;
-  const versionId = `${profileId}-v1`;
-
   const [bc, sf, org] = await Promise.all([
     db.businessContext.findUnique({
       where: { organizationId },
@@ -329,68 +315,15 @@ export async function seedOrgWwwdCorpus(
   const industry = sf?.archetype?.category ?? bc?.industry ?? null;
   const orgName = org?.name ?? null;
 
-  // 0. Ensure the platform fallback profile ROW exists. The org profile's
-  // fallbackProfileId carries an FK to it, but the fallback shipped only as an
-  // in-code constant (default-profile.ts) — no seed ever materialized it, so
-  // this upsert threw P2003 on every install and the fail-open completion
-  // chain swallowed it: THE reason the WWWD substrate stayed dormant
-  // (observed live 2026-07-06, BI-44526F3E). Minimal row, no version — the
-  // resolution chain only needs the profile to exist.
-  await db.decisionPerspectiveProfile.upsert({
-    where: { profileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID },
-    update: {},
-    create: {
-      profileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
-      name: "DPF Organizational Principles",
-      kind: "organization",
-      scope: { domains: ["platform-governance", PLAN_READINESS_DOMAIN_CLASS] },
-      fallbackProfileId: null,
-      defaultResolver: { type: "build-studio-owner" },
-      autonomyPolicy: DEFAULT_AUTONOMY_POLICY,
-      status: "active",
-    },
+  // Ensure the shared profile/version container before seeding its corpus.
+  // The same narrow factory is used by other valid WWWD write paths.
+  const { profileId, versionId } = await ensureOrgDecisionPerspectiveProfile({
+    organizationId,
+    organizationName: orgName,
+    db,
   });
 
-  // 1. Profile (container).
-  await db.decisionPerspectiveProfile.upsert({
-    where: { profileId },
-    update: {
-      name: `${orgName ?? "Organization"} perspective`,
-      kind: "organization",
-      scope: { domains: [...DECISION_DOMAIN_CLASSES] },
-      ownerOrganizationId: organizationId,
-      fallbackProfileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
-      defaultResolver: { type: "build-studio-owner" },
-      autonomyPolicy: DEFAULT_AUTONOMY_POLICY,
-      status: "active",
-    },
-    create: {
-      profileId,
-      name: `${orgName ?? "Organization"} perspective`,
-      kind: "organization",
-      scope: { domains: [...DECISION_DOMAIN_CLASSES] },
-      ownerOrganizationId: organizationId,
-      fallbackProfileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
-      defaultResolver: { type: "build-studio-owner" },
-      autonomyPolicy: DEFAULT_AUTONOMY_POLICY,
-      status: "active",
-    },
-  });
-
-  // 2. Version v1.
-  await db.decisionPerspectiveProfileVersion.upsert({
-    where: { versionId },
-    update: { changeSummary: "Organization perspective seeded at onboarding." },
-    create: {
-      versionId,
-      profileId,
-      versionNumber: 1,
-      materialFingerprint: `seed:${profileId}:v1`,
-      changeSummary: "Organization perspective seeded at onboarding.",
-    },
-  });
-
-  // 3. Org-overlay wiki pages (the working WWWD lever) + materials.
+  // Org-overlay wiki pages (the working WWWD lever) + materials.
   const pages = buildPages(bc, archetypeId, industry, orgName);
   const wikiPageIds: string[] = [];
   let embedded = true;
@@ -501,12 +434,6 @@ export async function seedOrgWwwdCorpus(
       });
     }
   }
-
-  // 4. Point the profile at v1.
-  await db.decisionPerspectiveProfile.update({
-    where: { profileId },
-    data: { currentVersionId: versionId },
-  });
 
   return {
     profileId,


### PR DESCRIPTION
## Summary

Make the organization WWWD decision profile available when the existing **How you decide** step first needs it, instead of waiting for the unrelated full setup-completion seed chain. This removes the contradictory fresh-install state where business setup is complete but stance confirmation says its profile is missing.

## Changes

- Extract the canonical fallback/profile/v1 bootstrap into one stable-ID, idempotent factory shared by the full WWWD corpus seeder and stance confirmation.
- Ensure that narrow prerequisite before publishing and promoting owner-confirmed stance material; leave starter-page/material seeding in the final completion path.
- Replace the misleading “finish business setup first” recovery copy and add lifecycle, replay, and action-ordering regression coverage.

## Test plan

- [x] **Source-only change**
  - [x] `pnpm --filter web typecheck`
  - [x] 18 focused tests across stance confirmation, profile bootstrap, full corpus seeding, and stance promotion
- [x] **Runtime-bound verification**
  - [x] Exact-tree merged-code pregate passed in governed shared nonprod sandbox `NPEL-76C3AB8D56`

### Verification evidence

- `pnpm run pregate:preflight`: 47/47 deterministic guards passed.
- `pnpm run pregate`: PASS for `fix/ensure-wwwd-profile-before-stances@0d5f0f9b300a1ebe96ce10894a8ca241d00afe1f`.
- Independent semantic review: `cmt4d6d140fsf01pk14yaful0`, no issues.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed against the final diff
- [x] `pnpm run pregate:preflight` passed
- [x] Exact-tree local-CI evidence captured
- [ ] `pnpm pr:ready` after PR metadata is available

Local-CI-Evidence: cmt4eik1f0gx001pk6276ve30 (fix/ensure-wwwd-profile-before-stances@0d5f0f9b300a1ebe96ce10894a8ca241d00afe1f)

## Related issues / Epic

- BI-68743C43
- EP-1FABA22D

## Overlap sweep

No overlapping open or in-progress decision-profile/setup-progress item was found before implementation.

## Notes for the reviewer

No schema, migration, dependency, route, or visual UI change. Kernel comparison `DI-E4097C193131` selected the shared narrow bootstrap over moving all completion seeds earlier or invoking the full corpus seeder from the action.
