### PR TITLE
fix(release): stage self-upgrade installer asset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,7 @@ COPY scripts/lib/capability-state-hash.mjs ./scripts/lib/
 COPY scripts/capability-service-catalog.generated.json ./scripts/
 COPY scripts/installer/validate-install-state.mjs ./scripts/installer/
 COPY scripts/installer/install-state-transaction.mjs ./scripts/installer/
+COPY scripts/installer/install-release-assets.mjs ./scripts/installer/
 COPY scripts/installer/install-state-lock-contract.json ./scripts/installer/
 COPY scripts/installer/install-state-schema-registry.mjs ./scripts/installer/
 COPY scripts/installer/install-state.schema.json ./scripts/installer/

--- a/scripts/check-release-asset-contract.test.mjs
+++ b/scripts/check-release-asset-contract.test.mjs
@@ -30,6 +30,7 @@ const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const dockerfile = readFileSync(join(repoRoot, "Dockerfile"), "utf8");
 const psInstaller = readFileSync(join(repoRoot, "install-dpf.ps1"), "utf8");
 const shInstaller = readFileSync(join(repoRoot, "install-dpf.sh"), "utf8");
+const promoteScript = readFileSync(join(repoRoot, "scripts/promote.sh"), "utf8");
 const agentPointerPath = "config/consumer-install/agent-pointer.md";
 
 /**
@@ -43,6 +44,7 @@ const REQUIRED_IN_BUNDLE = Object.freeze([
   "scripts/safety/dpf-shell-guard-fallback-patterns.json",
   "scripts/installer/lib/state.ps1",
   "scripts/installer/lib/compose-chain.ps1",
+  "scripts/installer/install-release-assets.mjs",
   "scripts/bootstrap-organization-pki.ps1",
   // The install guides tell operators to run these by name, so a consumer install
   // that lacks them fails the documented uninstall with "file not found" — the
@@ -90,7 +92,12 @@ test("every bundled asset is also COPYed into the build stage that assembles it"
   // through: the init stage COPYs each asset explicitly, so a file that is cp'd
   // but never COPYed fails the build with a bare `exit code: 1`. That exact gap
   // shipped once -- the cp was added without the COPY.
+  const initStageStart = dockerfile.indexOf("FROM deps AS init");
+  const releaseAssetStart = dockerfile.indexOf("RUN ", dockerfile.indexOf("/dpf-release-assets"));
+  assert.ok(initStageStart >= 0, "Dockerfile must still declare the init stage");
+  assert.ok(releaseAssetStart > initStageStart, "release assets must still be assembled in the init stage");
   const copiedIntoStage = dockerfile
+    .slice(initStageStart, releaseAssetStart)
     .split(/\r?\n/)
     .filter((l) => /^COPY\s/.test(l) || /^\s{5,}scripts\//.test(l))
     .join("\n");
@@ -129,7 +136,8 @@ test("every required path is actually referenced by an installer (no stale entri
     const win = p.replace(/\//g, "\\\\");
     const referenced =
       psInstaller.includes(p) || psInstaller.includes(p.replace(/\//g, "\\")) ||
-      psInstaller.includes(win) || shInstaller.includes(p);
+      psInstaller.includes(win) || shInstaller.includes(p) || promoteScript.includes(p) ||
+      promoteScript.includes(p.replace(/^scripts\//, ""));
     assert.ok(referenced, `${p} is shipped/required but no installer references it — stale entry?`);
   }
 });


### PR DESCRIPTION
## Summary

Repair the consumer self-upgrade release image build that failed for `v2026.08.22-self-upgrade.1`. The init stage now receives the installer module before assembling `/dpf-release-assets`, and the contract test can no longer be fooled by a COPY in a later Docker stage.

## Changes

- COPY `scripts/installer/install-release-assets.mjs` into the Docker `init` stage before release-asset assembly.
- Require that module in the shipped consumer bundle and validate COPY coverage specifically inside the assembling stage.
- Recognize `scripts/promote.sh` as the runtime consumer of the installer module.

## Test plan

- [ ] **Source-only change** (not applicable: release-image runtime wiring)
- [x] **Runtime-bound change**
  - [x] Source checks passed: 8/8 release-asset contract tests and 19/19 combined release contract/workflow tests.
  - [x] Functional verification: exact Docker `--target init` build completed all 59 init steps; the built image contains `/dpf-release-assets/scripts/installer/install-release-assets.mjs`, and `SHA256SUMS` includes it.
  - [x] Exact merged-tree local CI passed for the published branch and commit.
- [ ] **Verification-harness limitation acknowledged** (none)

### Verification evidence

- Red test reproduced the missing init-stage COPY before the Dockerfile repair.
- `node --test scripts/check-release-asset-contract.test.mjs`: 8/8 passed.
- `node --test scripts/check-release-asset-contract.test.mjs scripts/check-release-compose-pins.test.mjs scripts/ci-build-artifact-workflow.test.mjs`: 19/19 passed.
- Real `docker build --target init` completed `init 59/59`; container inspection verified the module and checksum entry.
- Governed exact-tree local CI: `cmt4fymbj0hu801pkofexnlfm` (`fix/release-assets-init-stage@41ff4d0af588`).
- Semantic review receipt: `cmt4f37520h7401pk8hv2f0kv`; no issues, infrastructure-inconclusive due an active capacity reservation, publication allowed by policy.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed against the final diff.
- [x] `pnpm run pregate:preflight` passed.
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`.
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` run against the final pushed commit.

Local-CI-Evidence: cmt4fymbj0hu801pkofexnlfm (fix/release-assets-init-stage@41ff4d0af588)

## Related issues / Epic

- Repairs the release packaging path for BI-89887875 / Workroom WC-EF274155 after the merged consumer self-upgrade PR #4462.

## Overlap sweep

- Open PRs were reviewed before publication. None touch the Docker release-asset assembly or its contract test.

## Notes for the reviewer

- The failed `.1` release/tag is immutable and will not be moved or installed. After this repair merges, a fresh `.2` release will run the full image publish and verification workflow before any canonical-install bootstrap.

Design-Grounding-Decision: no-contract-change (restores the already-reviewed consumer release-asset contract from PR #4462 and strengthens its stage-local conformance test).

Docs-Impact-Decision: no documentation change; the self-upgrade operator contract is already documented by PR #4462, and this PR repairs only the release-image packaging implementation.
