### PR TITLE
fix(deps): floor deepmerge-ts to 8.0.0 — recursive-graph stack exhaustion (GHSA-ggr8-5vv4-36mx)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   '@hono/node-server': ^2.0.5
   '@expo/cli@0.24.24>picomatch': 3.0.2
   brace-expansion@<=5.0.8: 5.0.9
+  deepmerge-ts: ^8.0.0
   lodash: 4.18.0
   lodash-es: 4.18.0
   node-forge: 1.4.0
@@ -5203,9 +5204,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
-    engines: {node: '>=16.0.0'}
+  deepmerge-ts@8.0.2:
+    resolution: {integrity: sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==}
+    engines: {node: '>=16.9.0'}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -12195,7 +12196,7 @@ snapshots:
   '@prisma/config@7.9.1(magicast@0.5.3)':
     dependencies:
       c12: 3.3.4(magicast@0.5.3)
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.2
       effect: 3.20.0
       empathic: 2.0.0
     transitivePeerDependencies:
@@ -12717,7 +12718,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.85.3': {}
 
@@ -14845,7 +14848,7 @@ snapshots:
 
   dedent@1.7.2: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.2: {}
 
   deepmerge@4.3.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,14 @@ overrides:
   # bypassing the 5.0.8 mitigation — found on PR #3893's OSV scan). Floor
   # every transitive line to the current patched release, 5.0.9.
   'brace-expansion@<=5.0.8': '5.0.9'
+  # deepmerge-ts < 8.0.0: GHSA-ggr8-5vv4-36mx / CVE-2026-40345 (Dependabot #155,
+  # high) — deepmerge()/deepmergeInto() recurse per property with no visited-pair
+  # tracking, so two records that self-reference at the same key path recurse until
+  # RangeError. Transitive of @prisma/config, which merges our own repo-committed
+  # prisma config at CLI time rather than an attacker-supplied object graph — but
+  # 8.0.0 is a clean upstream fix with zero runtime dependencies and the same
+  # `node >=16` engine, so floor it instead of accepting the finding.
+  deepmerge-ts: '^8.0.0'
   lodash: '4.18.0'
   lodash-es: '4.18.0'
   node-forge: '1.4.0'


### PR DESCRIPTION
## What

Floor `deepmerge-ts` to `^8.0.0` (resolves 8.0.2) in `pnpm-workspace.yaml` overrides.

**GHSA-ggr8-5vv4-36mx / CVE-2026-40345** (Dependabot #155, high) — `deepmerge()` / `deepmergeInto()` recurse per enumerable key with no visited-object or pair tracking, so two records that self-reference at the same key path recurse until `RangeError: Maximum call stack size exceeded`.

## Why this is urgent beyond the advisory

This was the **one unaccepted high** in `pnpm scan:deps --fail-on high`, and the OSV vulnerability scan is a **required check**. Because that gate is whole-tree, an unaccepted high on `main` fails the check on *every* PR — Dependabot's own bump PR #4459 (mammoth 1.12.0 → 1.12.1) currently shows a red required check for a defect that has nothing to do with mammoth. Landing this unblocks the queue, not just the alert.

## Why a floor and not a baseline acceptance

Reachability here is genuinely low: `deepmerge-ts` is transitive of `@prisma/config` → `prisma` → `@dpf/db`, which merges `packages/db/prisma.config.ts` — our own repo-committed config, never an attacker-supplied object graph.

But unlike `image-size` (archived upstream, no patched release, owned via `pnpm patch`) there **is** a clean upstream fix. Per the "own the fix" ladder in `docs/architecture/dependency-reduction-routine.md`, take the fix rather than write a justification. 8.0.2 has zero runtime dependencies and moves the engine floor only from `node >=16.0.0` to `>=16.9.0`, which this workspace (node 24) already clears.

## Verified, not assumed

- `pnpm why deepmerge-ts -r` — exactly one version, 8.0.2, via `@prisma/config@7.9.1`.
- **The actual consumer path runs.** `pnpm exec prisma validate` in `packages/db` prints `Loaded Prisma config from prisma.config.ts` and validates the schema, so the c12 + deepmerge-ts config merge works across the 8.x major.
- `node scripts/sbom/scan-dependencies.mjs --fail-on high` → 1980 components, 2 advisories, **both accepted, 0 unaccepted high**. Was 1981 / 3 / 1 unaccepted high.
- `pnpm run pregate:preflight` — 47 guards clean.
- `pnpm check:sbom-drift` and `pnpm check:new-deps` clean.

The lockfile also picks up two transitive peer entries (`bufferutil`, `utf-8-validate`) under the metro snapshot from re-resolution; no version moves.

**Noted, not fixed here:** `sbom/baseline.json` totals are already stale on `main` by one component (drift check reports `-1` on an unmodified main tree too). Informational fields only, and the guard is green; out of scope for a dependency floor.

## Docs impact

The rationale lives inline in `pnpm-workspace.yaml`, which is where the Override Provenance Guard requires it. No route, contract, or user-visible surface change.

Reviewed under Workroom `WC-42C558DD` (security findings watch), pass 2.
