### PR TITLE
fix(security): Dependabot alert reads are broken in both security workflows

### DIFF
--- a/.github/workflows/security-findings-watch.yml
+++ b/.github/workflows/security-findings-watch.yml
@@ -53,9 +53,15 @@ jobs:
         with:
           node-version: 24
 
+      # The default GITHUB_TOKEN can read Code Scanning but NOT Dependabot or
+      # Secret Scanning alerts — both 403 even with `security-events: read`.
+      # DEPENDABOT_ALERTS_TOKEN (a token with the security_events scope) is the
+      # existing convention from audit-stale-overrides.yml. Until that secret is
+      # set, the sweep reports those two surfaces as UNREADABLE rather than zero,
+      # which is the intended degradation: incomplete, and visibly so.
       - name: Sweep all three security surfaces
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DEPENDABOT_ALERTS_TOKEN || secrets.GITHUB_TOKEN }}
         run: node scripts/sbom/sweep-security-surfaces.mjs --json sbom/security-sweep.json --md sbom/security-sweep.md
 
       - name: Publish sweep to the run summary

--- a/scripts/audit-stale-overrides.mjs
+++ b/scripts/audit-stale-overrides.mjs
@@ -122,10 +122,16 @@ export function classifyFloors(entries, lookup) {
 
 // ---- I/O layer (network; not exercised by unit tests) --------------------
 
+// The Dependabot alerts endpoint is CURSOR-paginated (before/after) and rejects
+// `page=` outright: HTTP 400 "Pagination using the `page` parameter is not
+// supported." This loop used to pass `page`, so EVERY cross-check threw on the
+// first request and the audit silently degraded to tag-coverage-only — reporting
+// "cross-check SKIPPED" as if it were merely offline. Follow the `Link: rel=next`
+// header instead, which is the correct form for this endpoint.
 async function fetchAllDependabotAlerts({ repo, token }) {
   const alerts = [];
-  for (let page = 1; page <= 20; page++) {
-    const url = `${API}/repos/${repo}/dependabot/alerts?per_page=100&state=all&page=${page}`;
+  let url = `${API}/repos/${repo}/dependabot/alerts?per_page=100&state=all`;
+  for (let hop = 0; hop < 20 && url; hop++) {
     const res = await fetch(url, {
       headers: {
         accept: "application/vnd.github+json",
@@ -133,11 +139,20 @@ async function fetchAllDependabotAlerts({ repo, token }) {
         "x-github-api-version": "2022-11-28",
       },
     });
+    // 403 here is the default GITHUB_TOKEN, which cannot read Dependabot alerts —
+    // name it explicitly so the remedy (set DEPENDABOT_ALERTS_TOKEN) is obvious
+    // rather than looking like a generic outage.
+    if (res.status === 403) {
+      throw new Error(
+        "GitHub API 403 reading Dependabot alerts — the default GITHUB_TOKEN cannot read this surface. " +
+          "Set the DEPENDABOT_ALERTS_TOKEN repository secret to a token with the security_events scope.",
+      );
+    }
     if (!res.ok) throw new Error(`GitHub API ${res.status} ${res.statusText}`);
     const batch = await res.json();
-    if (!Array.isArray(batch) || batch.length === 0) break;
+    if (!Array.isArray(batch)) throw new Error("GitHub API returned a non-array alert payload");
     alerts.push(...batch);
-    if (batch.length < 100) break;
+    url = /<([^>]+)>;\s*rel="next"/.exec(res.headers.get("link") ?? "")?.[1] ?? null;
   }
   return alerts;
 }

--- a/scripts/sbom/sweep-security-surfaces.mjs
+++ b/scripts/sbom/sweep-security-surfaces.mjs
@@ -62,7 +62,16 @@ async function fetchAlerts(surface) {
     // 404 here means the feature is disabled for the repo, not that it is clean —
     // report it as unknown rather than folding it into a zero.
     if (res.status === 404) return { ok: false, alerts: [], reason: "surface not enabled or not visible to this token (404)" };
-    if (res.status === 403) return { ok: false, alerts: [], reason: "token lacks security-events: read (403)" };
+    // The default GITHUB_TOKEN reads Code Scanning but 403s on Dependabot and
+    // Secret Scanning even with `security-events: read`. Name the remedy here —
+    // a bare "403" reads like a transient outage and gets ignored.
+    if (res.status === 403) {
+      return {
+        ok: false,
+        alerts: [],
+        reason: "403 — the default GITHUB_TOKEN cannot read this surface; set the DEPENDABOT_ALERTS_TOKEN secret (security_events scope)",
+      };
+    }
     if (!res.ok) return { ok: false, alerts: [], reason: `HTTP ${res.status}` };
     const batch = await res.json();
     if (!Array.isArray(batch)) return { ok: false, alerts: [], reason: "unexpected non-array response" };


### PR DESCRIPTION
## What

Two independent defects that each made a security check **silently under-report rather than fail**. Both were surfaced by the first live run of the Security Findings Watch (#4387) — the "an unreadable surface is NOT a clean surface" design working as intended on day one.

### 1. Wrong pagination — `scripts/audit-stale-overrides.mjs`

The Dependabot alerts endpoint is **cursor**-paginated and rejects `page=` outright: `HTTP 400 — Pagination using the 'page' parameter is not supported.` The fetch loop passed `page`, so every cross-check threw on the **first** request. The caller treats a throw as "offline", so the monthly Stale Override Audit has been reporting `cross-check SKIPPED (offline / no token)` — indistinguishable from a genuine outage — instead of ever checking a single floor against a live advisory. It has never actually done its job.

Now follows the `Link: rel="next"` header, which is correct for this endpoint. With a scoped token the audit cross-checks 76 overrides (16 indeterminate) where it previously produced nothing at all.

### 2. Wrong token — `.github/workflows/security-findings-watch.yml`

The default `GITHUB_TOKEN` can read Code Scanning but **403s on Dependabot and Secret Scanning even with `security-events: read`**. The watch used the default token, so 2 of 3 surfaces came back unreadable on its first scheduled run. Now uses `secrets.DEPENDABOT_ALERTS_TOKEN || secrets.GITHUB_TOKEN`, the convention already established by `audit-stale-overrides.yml`.

Both 403 paths now **name the remedy** instead of reporting a bare 403, which reads like a transient outage and gets ignored.

## Operator action still required

The `DEPENDABOT_ALERTS_TOKEN` repository secret is **not set** on this repo. Until it is, both workflows degrade — the daily watch keeps reporting Dependabot + Secret Scanning as unreadable, and the stale-override audit skips its cross-check. It needs a token with the `security_events` scope. Creating a credential is an operator action; this change makes the degradation loud and self-describing rather than silent, but it cannot substitute for the credential.

## Provenance

This fix was committed on 2026-08-16 at `5e89e42a` and **never pushed** — the prior pass was blocked by three consecutive SIGTERM kills of the local gate (host slot contention, not a test failure). It sat invisible for six days while issue #4389 reported "2 of 3 surfaces unreadable" every single day. Cherry-picked clean onto current `main`.

## Verified

- `node --test scripts/audit-stale-overrides.test.mjs` — 10/10 pass.
- `pnpm run pregate:preflight` — 47 guards clean.
- Substance verified live in the originating session: the sweep returns Dependabot 2 / code scanning 0 / secret scanning 0 against a scoped token, matching direct `gh api` queries.

## Docs impact

Defect fixes in two CI security jobs and their scripts. No route, contract, or user-visible product surface change.

Reviewed under Workroom `WC-42C558DD` (security findings watch), pass 2.
