### PR TITLE
fix(self-upgrade): a moved capability catalog is a migration, not a wedge

### DIFF
--- a/.github/workflows/self-upgrade-acceptance.yml
+++ b/.github/workflows/self-upgrade-acceptance.yml
@@ -150,6 +150,51 @@ jobs:
             -e PROMOTE_BACKUP_PATH=/backups/recovery \
             "$DPF_ACCEPTANCE_IMAGE" --readiness --json | tee "$DPF_N1_EVIDENCE/readiness-success.json"
           jq -e '.result == "ready" and .quiescenceBegan == false and (.failures | length == 0)' "$DPF_N1_EVIDENCE/readiness-success.json"
+      # BI-AA6FBAD0: the step above seeds a schemaVersion-1 state, which is
+      # UNVERSIONED for capability purposes and so skips every capability check.
+      # Every live install is v2 and carries the catalog hash of the release it
+      # was installed from, so that is the shape that actually breaks: the first
+      # release to move the catalog wedged every existing install with
+      # `capability_state_stale`, and this gate was structurally unable to see it.
+      # The fixture below is the candidate's own projection restamped with a
+      # previous catalog hash - exactly what an install looks like one release
+      # behind.
+      - name: Readiness migrates a v2 install carrying the previous catalog hash
+        env:
+          STATE_OUT: ${{ runner.temp }}/dpf-state/install-state.json
+        run: |
+          node --input-type=module -e '
+            import { readFile, writeFile } from "node:fs/promises";
+            const { projectInstallState } = await import("./scripts/installer/migrate-install-state.mjs");
+            const { computeCapabilityStateVersion } = await import("./scripts/lib/capability-state-hash.mjs");
+            const catalog = JSON.parse(await readFile("scripts/capability-service-catalog.generated.json", "utf8"));
+            const baseline = { schemaVersion: 1, installerVersion: "acceptance", platform: "linux", arch: "amd64", installPath: "/opt/dpf", stateDir: "/dpf-state", composeProjectName: "dpf" };
+            const hostIdentity = { platform: "linux", arch: "amd64", capabilityHostPlatform: "linux", provenance: "installer" };
+            const { projectedState } = await projectInstallState({ bytes: Buffer.from(JSON.stringify(baseline)), hostIdentity, catalog });
+            const previousCatalogHash = "1".repeat(64);
+            const stale = {
+              ...projectedState,
+              capabilityCatalogHash: previousCatalogHash,
+              capabilityStateVersion: computeCapabilityStateVersion(previousCatalogHash, projectedState.enabledRuntimeCapabilities, catalog.capabilities.map(({ capabilityId }) => capabilityId)),
+            };
+            await writeFile(process.env.STATE_OUT, `${JSON.stringify(stale, null, 2)}\n`);
+          '
+          docker run --rm --read-only \
+            -v "$PWD:/host-source:ro" \
+            -v "$RUNNER_TEMP/dpf-state:/dpf-state:ro" \
+            -v "$RUNNER_TEMP/dpf-backups:/backups:ro" \
+            -e DPF_PROMOTER_STATE_DIR=/dpf-state \
+            -e DPF_PROMOTER_DOCKER_PREFLIGHT=ready \
+            -e PROMOTE_SOURCE=/host-source \
+            -e PROMOTE_TARGET_SHA="$GITHUB_SHA" \
+            -e PROMOTE_HEALTH_URL=http://host.docker.internal:3000/api/health \
+            -e PROMOTE_COMPOSE_PROJECT="$DPF_N1_PROJECT" \
+            -e PROMOTE_BACKUP_PATH=/backups/recovery \
+            "$DPF_ACCEPTANCE_IMAGE" --readiness --json | tee "$DPF_N1_EVIDENCE/readiness-stale-catalog.json"
+          jq -e '.result == "ready" and .quiescenceBegan == false and (.failures | length == 0)' "$DPF_N1_EVIDENCE/readiness-stale-catalog.json"
+          jq -e '.migrationRequired == true' "$DPF_N1_EVIDENCE/readiness-stale-catalog.json"
+      # A readiness failure must name its cause: a bare code cost hours of live
+      # diagnosis on SUR-C45B5F4B.
       - name: Invalid state refuses before quiescence
         run: |
           printf '%s\n' '{}' > "$RUNNER_TEMP/dpf-state/install-state.json"
@@ -173,6 +218,7 @@ jobs:
           set -e
           test "$status" -eq 78
           jq -e '.result == "failed" and .quiescenceBegan == false and (.failures | length > 0)' "$DPF_N1_EVIDENCE/readiness-refusal.json"
+          jq -e '[.failures[] | select(.message | test("failed: [a-z_]+: .+"))] | length > 0' "$DPF_N1_EVIDENCE/readiness-refusal.json"
       - name: Record bounded PR compatibility evidence
         if: github.event_name == 'pull_request'
         run: |

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8557,6 +8557,7 @@
         "step-4-verify-postgres-only-done-criteria",
         "if-it-fails-anyway-recovery",
         "failure-class-host-out-of-memory-candidate-build-enomem",
+        "failure-class-capability-state-stale-a-release-moved-the-capability-catalog",
         "failure-class-migration-unique-violation-p3018-23505",
         "references"
       ]

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -16,6 +16,8 @@ import { join, resolve } from "node:path";
 
 const SCRIPT = resolve(__dirname, "../../../../scripts/promote.sh");
 const REPO_ROOT = resolve(__dirname, "../../../..");
+const MIGRATOR = join(REPO_ROOT, "scripts", "installer", "migrate-install-state.mjs");
+const CATALOG = join(REPO_ROOT, "scripts", "capability-service-catalog.generated.json");
 const gitBash = join(process.env.ProgramFiles ?? "C:\\Program Files", "Git", "bin", "bash.exe");
 const BASH_COMMAND = process.platform === "win32" && existsSync(gitBash) ? gitBash : "bash";
 const BASH_OK = spawnSync(BASH_COMMAND, ["--version"], { encoding: "utf8" }).status === 0;
@@ -160,11 +162,19 @@ function runPromote(opts: {
   const secretPath = join(stateDir, "runtime-transition.secret");
   writeFileSync(secretPath, secret);
   const stateBytes = readFileSync(join(stateDir, "install-state.json"));
+  // Ask the canonical migrator for the real projection. The previous fixture
+  // asserted `projectionHash === sourceHash`, which is never true of an actual
+  // projection; it went unnoticed only because promote.sh skipped the migrator
+  // whenever the schema version did not change, so the carrier's CAS binding
+  // was never checked (BI-AA6FBAD0).
+  const projection = JSON.parse(execFileSync(process.execPath, [MIGRATOR,
+    "--state", join(stateDir, "install-state.json"), "--catalog", CATALOG,
+    "--host-platform", "linux", "--host-arch", "amd64"], { encoding: "utf8" })) as { sourceHash: string; projectionHash: string };
   const envelope = {
     kind: "install-state-migration", version: 1, runId: "SUR-FUNCTIONAL",
     promoterDigest: `sha256:${"d".repeat(64)}`,
-    sourceHash: createHash("sha256").update(stateBytes).digest("hex"),
-    projectionHash: createHash("sha256").update(stateBytes).digest("hex"),
+    sourceHash: projection.sourceHash,
+    projectionHash: projection.projectionHash,
     fromSchemaVersion: 2, toSchemaVersion: 2,
     hostIdentity: { platform: "linux", arch: "amd64", provenance: "explicit" },
     issuedAt: new Date(Date.now() - 1_000).toISOString(),
@@ -231,13 +241,17 @@ function makeScratch(): { root: string; source: string; backup: string; fakeBin:
   const backup = join(root, "backup");
   const stateDir = join(backup, "state");
   mkdirSync(stateDir, { recursive: true });
-  const catalog = JSON.parse(readFileSync(join(REPO_ROOT, "scripts", "capability-service-catalog.generated.json"), "utf8")) as { catalogHash: string; capabilities: Array<{ capabilityId: string }> };
-  // The historical functional fixture exercises sandbox refresh, which is
-  // owned by the build capability in the governed catalog.
-  const enabledRuntimeCapabilities = ["runtime:build", "runtime:core"];
-  const stateLines = catalog.capabilities.map(({ capabilityId }) => `${capabilityId}=${enabledRuntimeCapabilities.includes(capabilityId) ? "active" : "disabled"}`).sort().join("\n");
-  const capabilityStateVersion = createHash("sha256").update(`${catalog.catalogHash}\n${stateLines}`).digest("hex");
-  writeFileSync(join(stateDir, "install-state.json"), JSON.stringify({ platform: "linux", enabledRuntimeCapabilities, capabilityCatalogHash: catalog.catalogHash, capabilityStateVersion }));
+  // Produce the install-state the way an install actually gets one: hand a
+  // legacy state to the canonical migrator. Hand-assembling the capability
+  // snapshot here re-derived the closure by hand and drifted from the resolver;
+  // the legacy default already enables `runtime:build`, which is what the
+  // sandbox-refresh path in this fixture exercises.
+  writeFileSync(join(stateDir, "install-state.json"), JSON.stringify({
+    schemaVersion: 1, installerVersion: "functional", platform: "linux", arch: "amd64",
+    installPath: "/opt/dpf", stateDir: "/dpf-state", composeProjectName: "dpf",
+  }));
+  execFileSync(process.execPath, [MIGRATOR, "--state", join(stateDir, "install-state.json"),
+    "--catalog", CATALOG, "--host-platform", "linux", "--host-arch", "amd64", "--write"], { encoding: "utf8" });
   return { root, source, backup, fakeBin, head };
 }
 

--- a/docs/runbooks/bet5-windows-self-upgrade.md
+++ b/docs/runbooks/bet5-windows-self-upgrade.md
@@ -205,6 +205,55 @@ let the next cron tick retry. The `build-failure-classifier` now labels this cla
 (environment), so the failure surfaces as retryable rather than the old generic
 `promoter-readiness-failed (unclassified)`.
 
+## Failure class: capability-state-stale (a release moved the capability catalog)
+
+Promoter **readiness** refuses before quiescence with:
+
+```
+promoter-readiness-failed: Promoter readiness check failed: capability_projection_failed
+failures: [capability_projection_failed, install_state_projection_failed]
+```
+
+Canonical case **SUR-C45B5F4B (2026-08-22)**: the install was healthy and already at install-state
+`schemaVersion: 2`. The candidate simply carried a capability service catalog in which `inngest` and
+`redis` had moved from `runtime:durable-automation` into `runtime:core`. That legitimately moves
+`catalogHash`, so the install's recorded `capabilityCatalogHash` was one release behind and every
+projection refused with `capability_state_stale`.
+
+Like the OOM class above, this dies **before any portal swap** — a safe refusal, not a bad deploy.
+
+**This was a platform defect, now fixed.** The install-state migrator treated migration as purely a
+*schema-version* edge, so a schema-2 state could never have its capability snapshot re-projected. The
+first release to move the catalog therefore wedged every existing install, and the upgrade that would
+have restamped the state *was* the blocked upgrade. A catalog that moves within schema 2 is now a
+first-class migration: readiness re-projects it, and the promoter persists the restamp under the same
+lock and compare-and-swap binding as a schema migration. See
+[the design amendment](../superpowers/specs/2026-07-18-install-state-readiness-migration-design.md) §7.
+
+**Recovery for a run that already failed this way:** none needed — nothing was deployed. Upgrade to a
+build carrying the fix and re-trigger; the run restamps the install-state itself.
+
+**A refusal still means something.** These two codes fail closed for causes that are *not* the
+platform's doing, and they still do:
+
+- the enabled capability set was edited without restamping (`capabilityStateVersion` disagrees with an
+  **unchanged** catalog);
+- the state names a capability the candidate catalog no longer defines
+  (`unknown_runtime_capability:<id>`).
+
+To tell them apart, read the failure `message`, not just the code — every readiness probe now carries
+its underlying error, e.g. `capability_projection_failed: capability_state_stale`. Reproduce a refusal
+by hand against the mounted state with:
+
+```bash
+docker run --rm --read-only -v "$PWD:/host-source:ro" -v "$HOME/.dpf:/dpf-state:ro" \
+  -e DPF_PROMOTER_STATE_DIR=/dpf-state -e DPF_PROMOTER_DOCKER_PREFLIGHT=ready \
+  -e PROMOTE_SOURCE=/host-source -e PROMOTE_TARGET_SHA="<target>" \
+  -e PROMOTE_HEALTH_URL=http://host.docker.internal:3000/api/health \
+  -e PROMOTE_COMPOSE_PROJECT=dpf -e PROMOTE_BACKUP_PATH=/backups/recovery \
+  dpf-promoter:<target> --readiness
+```
+
 ## Failure class: migration-unique-violation (P3018 + 23505)
 
 A data migration's bulk UPDATE/INSERT hits `duplicate key value violates unique constraint` and the

--- a/docs/superpowers/specs/2026-07-18-install-state-readiness-migration-design.md
+++ b/docs/superpowers/specs/2026-07-18-install-state-readiness-migration-design.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Install-State Readiness Migration Design
 
 **Date:** 2026-07-18
@@ -173,3 +177,31 @@ PR acceptance is tiered rather than monolithic. The required Production Build ow
 9. The existing `dpf_state_migrate()` (`state.sh`) and `Test-DpfStateSchema` older-version path (`state.ps1`) delegate to the one canonical migrator; no shell/PowerShell path stamps `schemaVersion` independently, and `validate-install-state.mjs` dispatches by version.
 10. Rollback reuses the governed `$PROMOTE_BACKUP_PATH/install-state.json` recovery copy and its existing `EXIT`-trap restore; no second `pre-migration` artifact is introduced.
 11. Install-state signing/locking follows governed substrate decision `DI-6D6D452E46D5`: reuse transition-protocol signing and promote.sh recovery; use one cross-runtime filesystem lock/CAS protocol for offline writers.
+
+## 7. Amendment 2026-08-22 — migration is not only a schema-version edge (BI-AA6FBAD0)
+
+**Incident.** `SUR-C45B5F4B` failed at pre-quiescence readiness with `promoter-readiness-failed: capability_projection_failed`. The install was healthy and already at schema 2; the candidate simply carried a capability catalog in which `inngest` and `redis` had moved from `runtime:durable-automation` to `runtime:core`. That legitimately moves `catalogHash`, so the install's recorded `capabilityCatalogHash` was one release behind and every projection refused with `capability_state_stale`.
+
+**Blind spot.** §3 modelled migration entirely as a **schema-version edge**, and the implementation followed:
+
+- `projectInstallState` resolved capabilities with `migrate: source.schemaVersion === 1`, so a schema-2 state always took the strict equality path;
+- it returned the source unchanged for schema 2, so the capability fields could never be re-projected;
+- `migrationRequired` was defined as `schemaVersion !== 2`;
+- `promote.sh` only invoked the migrator when `fromSchemaVersion != toSchemaVersion`.
+
+Together these made the capability snapshot **immutable after the v1→v2 migration**. The first release to move the catalog therefore wedged every existing install, and the upgrade that would have restamped the state *was* the blocked upgrade — the same self-wedging shape §3 already recognised for host identity.
+
+**Correction.** A capability catalog that moves **within** schema 2 is a real migration:
+
+- `projectInstallState` always resolves in migrate mode — it *is* the migrator — and always projects `enabledRuntimeCapabilities`, `capabilityCatalogHash`, and `capabilityStateVersion`;
+- `migrationRequired` is true when the schema version **or** any projected capability field differs from source;
+- `promote.sh` always calls the migrator and lets `migrationRequired` decide the write, rather than duplicating that decision in shell.
+
+Acceptance criterion 4 stands unchanged — capability fields still come only from the canonical resolver — and the fail-closed causes are unchanged: a snapshot that disagrees with an **unchanged** catalog, and a capability the candidate catalog no longer defines, both still refuse.
+
+**Why the gate could not see it.** Two independent coverage holes, both now closed:
+
+1. `scripts/self-upgrade-sensitive-paths.mjs` owned only part of the promoter's baked closure — the generated capability catalog, the profile resolver, and the transition/teardown scripts were unowned, so changing them never triggered the acceptance workflow. Ownership is now derived mechanically from `Dockerfile.promoter`'s `COPY` inputs by a colocated test, so a newly baked file cannot escape the gate.
+2. The acceptance workflow only ever exercised readiness against a **schema-1** fixture, which is unversioned for capability purposes and skips every capability check. It now also asserts readiness against the shape every live install actually has: schema 2 carrying the **previous** release's catalog hash.
+
+**Diagnosability.** Readiness reported the bare code `capability_projection_failed` while discarding the one line that named the cause. Every readiness probe now carries its own error text into the failure `message`, and the acceptance workflow asserts a refusal message names its cause.

--- a/scripts/installer/migrate-install-state.mjs
+++ b/scripts/installer/migrate-install-state.mjs
@@ -21,27 +21,44 @@ export async function projectInstallState({ bytes, hostIdentity, catalog }) {
   const canonicalSourceArch = new Map([["x64", "amd64"], ["amd64", "amd64"], ["x86_64", "x86_64"], ["arm64", "arm64"]]).get(source.arch);
   if ((source.schemaVersion === 2 || canonicalSourceArch) && canonicalSourceArch !== hostIdentity.arch) throw new Error("host_identity_contradictory");
 
+  // This function IS the migrator, so it always resolves in migrate mode. The
+  // catalog moves whenever a release adds or moves a service, which leaves the
+  // previous hash on every already-installed state — restamping that is the
+  // whole job. Migrate mode still fails closed on the causes migration must
+  // never paper over: a snapshot that disagrees with an UNCHANGED catalog, and
+  // a capability the candidate catalog no longer defines.
+  //
+  // Gating this on `schemaVersion === 1` wedged every live install instead: a
+  // v2 state took the strict path, so the first release to move the catalog
+  // failed promoter readiness with `capability_state_stale`, and the upgrade
+  // that would have restamped the state WAS the blocked upgrade (BI-AA6FBAD0,
+  // live run SUR-C45B5F4B).
   const capability = resolveCapabilityComposeProfiles({
     catalog,
     state: source,
     hostPlatform: hostIdentity.capabilityHostPlatform,
-    migrate: source.schemaVersion === 1,
+    migrate: true,
   });
-  const projectedState = source.schemaVersion === 2 ? source : {
-    ...source,
-    schemaVersion: 2,
-    platform: hostIdentity.platform,
-    arch: hostIdentity.arch,
+  const projectedCapability = {
     enabledRuntimeCapabilities: capability.enabledRuntimeCapabilities,
     capabilityCatalogHash: capability.capabilityCatalogHash,
     capabilityStateVersion: capability.capabilityStateVersion,
   };
+  const projectedState = source.schemaVersion === 2
+    ? { ...source, ...projectedCapability }
+    : { ...source, schemaVersion: 2, platform: hostIdentity.platform, arch: hostIdentity.arch, ...projectedCapability };
   const validated = await validateInstallState(projectedState);
   if (!validated.valid) throw new Error(validated.errors.join(", "));
+  // A catalog move is a real migration even though the schema version does not
+  // change, so `migrationRequired` tracks the projected capability snapshot as
+  // well. Without this the restamp is recomputed on every single upgrade and
+  // never persisted, because the promoter only writes when this flag is set.
+  const capabilityMoved = Object.entries(projectedCapability)
+    .some(([key, value]) => JSON.stringify(source[key]) !== JSON.stringify(value));
   return {
     sourceHash: sha256(sourceBytes),
     projectionHash: sha256(projectedBytes(projectedState)),
-    migrationRequired: source.schemaVersion !== 2,
+    migrationRequired: source.schemaVersion !== 2 || capabilityMoved,
     projectedState,
   };
 }

--- a/scripts/installer/migrate-install-state.test.mjs
+++ b/scripts/installer/migrate-install-state.test.mjs
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
+import { computeCapabilityStateVersion } from "../lib/capability-state-hash.mjs";
 import { projectInstallState } from "./migrate-install-state.mjs";
 import { resolveHostIdentity } from "./resolve-host-identity.mjs";
 
@@ -43,9 +44,48 @@ test("returns a valid v2 state idempotently", async () => {
   assert.deepEqual(result.projectedState, migrated.projectedState);
 });
 
-test("refuses contradictory capability snapshots", async () => {
-  const state = { ...legacy, enabledRuntimeCapabilities: ["runtime:core"], capabilityCatalogHash: "0".repeat(64), capabilityStateVersion: "0".repeat(64) };
-  await assert.rejects(projectInstallState({ bytes: Buffer.from(JSON.stringify(state)), hostIdentity: identity, catalog }), /capability_state_stale/);
+const catalogCapabilityIds = catalog.capabilities.map(({ capabilityId }) => capabilityId);
+const migratedState = async () =>
+  (await projectInstallState({ bytes: Buffer.from(JSON.stringify(legacy)), hostIdentity: identity, catalog })).projectedState;
+
+test("migrates a v2 install-state across a shipped capability-catalog change", async () => {
+  // Every live install carries the catalog hash of the release it was installed
+  // from, so a release that adds or moves a service leaves that hash behind.
+  // That is the ORDINARY case on every upgrade, not corruption: refusing it
+  // wedges every existing install, because the upgrade that would restamp the
+  // state IS the blocked upgrade (BI-AA6FBAD0, live run SUR-C45B5F4B).
+  const current = await migratedState();
+  const previousCatalogHash = "1".repeat(64);
+  const stale = {
+    ...current,
+    capabilityCatalogHash: previousCatalogHash,
+    capabilityStateVersion: computeCapabilityStateVersion(previousCatalogHash, current.enabledRuntimeCapabilities, catalogCapabilityIds),
+  };
+
+  const result = await projectInstallState({ bytes: Buffer.from(JSON.stringify(stale)), hostIdentity: identity, catalog });
+
+  assert.equal(result.migrationRequired, true, "a moved catalog must be persisted, not silently re-derived every upgrade");
+  assert.equal(result.projectedState.capabilityCatalogHash, catalog.catalogHash);
+  assert.equal(result.projectedState.capabilityStateVersion, computeCapabilityStateVersion(catalog.catalogHash, current.enabledRuntimeCapabilities, catalogCapabilityIds));
+  assert.deepEqual(result.projectedState.enabledRuntimeCapabilities, current.enabledRuntimeCapabilities, "the operator's enabled set survives the catalog move");
+});
+
+test("refuses a capability snapshot the catalog cannot explain", async () => {
+  // Catalog UNCHANGED but the snapshot disagrees with it: the enabled set was
+  // edited without restamping. That is not the platform's doing, so migration
+  // must not paper over it.
+  const current = await migratedState();
+  const tampered = { ...current, capabilityStateVersion: "0".repeat(64) };
+  await assert.rejects(projectInstallState({ bytes: Buffer.from(JSON.stringify(tampered)), hostIdentity: identity, catalog }), /capability_state_stale/);
+});
+
+test("refuses a capability the candidate catalog no longer defines", async () => {
+  const current = await migratedState();
+  const retired = { ...current, enabledRuntimeCapabilities: [...current.enabledRuntimeCapabilities, "runtime:retired-by-this-release"] };
+  await assert.rejects(
+    projectInstallState({ bytes: Buffer.from(JSON.stringify(retired)), hostIdentity: identity, catalog }),
+    /unknown_runtime_capability:runtime:retired-by-this-release/,
+  );
 });
 
 test("refuses unverifiable and future-version state", async () => {

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -43,30 +43,42 @@ done
 
 if [[ $_readiness -eq 1 ]]; then
   _readiness_failures=()
+  # A bare failure code cost hours of live diagnosis on SUR-C45B5F4B: readiness
+  # reported `capability_projection_failed` while discarding the one line that
+  # named the cause (`capability_state_stale`). Every probe below now carries its
+  # own error text out with it. No temp files - the acceptance gate runs this
+  # container `--read-only`, so the node probes report failure as data on stdout
+  # rather than as a stream the shell would have to spool.
+  _readiness_details=()
+  _readiness_fail() { _readiness_failures+=("$1"); _readiness_details+=("$(printf '%s' "${2-}" | tr -d '\000\r' | tr '\n' ' ' | cut -c1-400)"); }
   _contract="${DPF_PROMOTER_CONTRACT:-/app/promoter-contract.json}"
-  [[ -r "$_contract" ]] || _readiness_failures+=(contract_unreadable)
+  [[ -r "$_contract" ]] || _readiness_fail contract_unreadable "no readable promoter contract at $_contract"
   if [[ -r "$_contract" ]]; then
     while IFS= read -r _required_file; do
-      [[ -r "$_required_file" ]] || _readiness_failures+=(required_file_unreadable)
+      [[ -r "$_required_file" ]] || _readiness_fail required_file_unreadable "contract requires unreadable file: $_required_file"
     done < <(jq -r '.requiredFiles[]? // empty' "$_contract" 2>/dev/null)
   fi
-  [[ -x "$_promoter_dir/promote.sh" ]] || _readiness_failures+=(entrypoint_unavailable)
+  [[ -x "$_promoter_dir/promote.sh" ]] || _readiness_fail entrypoint_unavailable "$_promoter_dir/promote.sh is not executable"
   if [[ "${DPF_PROMOTER_DOCKER_PREFLIGHT:-}" != "ready" ]] || ! command -v docker >/dev/null 2>&1 || ! docker --version >/dev/null 2>&1; then
-    _readiness_failures+=(docker_unavailable)
+    _readiness_fail docker_unavailable "docker preflight=${DPF_PROMOTER_DOCKER_PREFLIGHT:-<unset>} and no usable docker CLI"
   fi
-  [[ -d "${PROMOTE_SOURCE:-}" && -r "${PROMOTE_SOURCE:-}" ]] || _readiness_failures+=(source_mount_unreadable)
-  [[ -n "${PROMOTE_TARGET_SHA:-}" ]] || _readiness_failures+=(target_sha_missing)
-  [[ -n "${PROMOTE_HEALTH_URL:-}" ]] || _readiness_failures+=(health_url_missing)
+  [[ -d "${PROMOTE_SOURCE:-}" && -r "${PROMOTE_SOURCE:-}" ]] || _readiness_fail source_mount_unreadable "candidate source mount ${PROMOTE_SOURCE:-<unset>} is not a readable directory"
+  [[ -n "${PROMOTE_TARGET_SHA:-}" ]] || _readiness_fail target_sha_missing "PROMOTE_TARGET_SHA is unset"
+  [[ -n "${PROMOTE_HEALTH_URL:-}" ]] || _readiness_fail health_url_missing "PROMOTE_HEALTH_URL is unset"
   _state_dir="${DPF_PROMOTER_STATE_DIR:-/dpf-state}"
   _state_file="$_state_dir/install-state.json"
-  [[ -d "$_state_dir" && -r "$_state_dir" ]] || _readiness_failures+=(state_mount_unreadable)
+  [[ -d "$_state_dir" && -r "$_state_dir" ]] || _readiness_fail state_mount_unreadable "state mount $_state_dir is not a readable directory"
   _state_validator="$_promoter_dir/installer/validate-install-state.mjs"
-  if [[ ! -r "$_state_file" ]] || [[ ! -f "$_state_validator" ]] || ! node "$_state_validator" "$_state_file" >/dev/null 2>&1; then
-    _readiness_failures+=(install_state_invalid)
+  if [[ ! -r "$_state_file" ]] || [[ ! -f "$_state_validator" ]]; then
+    _readiness_fail install_state_invalid "no readable install-state at $_state_file"
+  elif ! _state_error="$(node "$_state_validator" "$_state_file" 2>&1 >/dev/null)"; then
+    _readiness_fail install_state_invalid "$_state_error"
   fi
   _profile_adapter="${PROMOTE_SOURCE:-}/scripts/lib/resolve-capability-compose-profiles.mjs"
-  if [[ ! -f "$_profile_adapter" ]] || ! node "$_profile_adapter" --state "$_state_file" --overlay promote --migrate >/dev/null 2>&1; then
-    _readiness_failures+=(capability_projection_failed)
+  if [[ ! -f "$_profile_adapter" ]]; then
+    _readiness_fail capability_projection_failed "candidate source has no profile adapter at $_profile_adapter"
+  elif ! _profile_error="$(node "$_profile_adapter" --state "$_state_file" --overlay promote --migrate 2>&1 >/dev/null)"; then
+    _readiness_fail capability_projection_failed "$_profile_error"
   fi
   # Host identity is resolved by the shipped resolver, not read raw from the caller's env.
   # The promoter is candidate-owned but launched by the DEPLOYED portal, so an N-1 caller
@@ -74,35 +86,47 @@ if [[ $_readiness -eq 1 ]]; then
   # since the upgrade that teaches the caller to send it IS the blocked upgrade. The
   # resolver still prefers explicit env, falls back to the installer-owned identity in the
   # mounted install-state, and fails closed on contradictory or unverifiable evidence.
+  # Both probes report refusal as `{"error":...}` on stdout instead of dying on
+  # stderr, so the reason survives into the readiness report.
   _migration_projection=""
+  _readiness_error() { printf '%s' "$1" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{let v;try{v=JSON.parse(s)}catch{return process.stdout.write(s?`unparseable probe output: ${s}`:"probe produced no output")}process.stdout.write(typeof v?.error==="string"?v.error:"")})' 2>/dev/null; }
   _host_identity="$(STATE_FILE="$_state_file" PROMOTER_DIR="$_promoter_dir" node --input-type=module -e '
     import { readFile } from "node:fs/promises"; import { pathToFileURL } from "node:url";
-    const { resolveHostIdentity } = await import(pathToFileURL(process.env.PROMOTER_DIR + "/installer/resolve-host-identity.mjs").href);
-    const state=JSON.parse((await readFile(process.env.STATE_FILE)).toString("utf8").replace(/^\uFEFF/,""));
-    process.stdout.write(JSON.stringify(resolveHostIdentity({state,env:process.env})));
-  ' 2>/dev/null)" || _host_identity=""
-  if [[ -n "$_host_identity" ]]; then
+    try {
+      const { resolveHostIdentity } = await import(pathToFileURL(process.env.PROMOTER_DIR + "/installer/resolve-host-identity.mjs").href);
+      const state=JSON.parse((await readFile(process.env.STATE_FILE)).toString("utf8").replace(/^\uFEFF/,""));
+      process.stdout.write(JSON.stringify(resolveHostIdentity({state,env:process.env})));
+    } catch (error) { process.stdout.write(JSON.stringify({error:String(error?.message ?? error)})); }
+  ' 2>&1)" || _host_identity=""
+  _host_identity_error="$(_readiness_error "$_host_identity")"
+  if [[ -n "$_host_identity" && -z "$_host_identity_error" ]]; then
     _migration_projection="$(STATE_FILE="$_state_file" PROMOTER_DIR="$_promoter_dir" DPF_HOST_IDENTITY="$_host_identity" node --input-type=module -e '
       import { readFile } from "node:fs/promises"; import { pathToFileURL } from "node:url";
-      const { projectInstallState } = await import(pathToFileURL(process.env.PROMOTER_DIR + "/installer/migrate-install-state.mjs").href);
-      const bytes=await readFile(process.env.STATE_FILE); const source=JSON.parse(bytes.toString("utf8").replace(/^\uFEFF/,"")); const catalog=JSON.parse(await readFile(process.env.PROMOTER_DIR+"/capability-service-catalog.generated.json","utf8"));
-      const hostIdentity=JSON.parse(process.env.DPF_HOST_IDENTITY);
-      const r=await projectInstallState({bytes,hostIdentity,catalog}); process.stdout.write(JSON.stringify({sourceHash:r.sourceHash,projectionHash:r.projectionHash,migrationRequired:r.migrationRequired,fromSchemaVersion:source.schemaVersion??1,toSchemaVersion:r.projectedState.schemaVersion}));
-    ' 2>/dev/null)" || _readiness_failures+=(install_state_projection_failed)
+      try {
+        const { projectInstallState } = await import(pathToFileURL(process.env.PROMOTER_DIR + "/installer/migrate-install-state.mjs").href);
+        const bytes=await readFile(process.env.STATE_FILE); const source=JSON.parse(bytes.toString("utf8").replace(/^\uFEFF/,"")); const catalog=JSON.parse(await readFile(process.env.PROMOTER_DIR+"/capability-service-catalog.generated.json","utf8"));
+        const hostIdentity=JSON.parse(process.env.DPF_HOST_IDENTITY);
+        const r=await projectInstallState({bytes,hostIdentity,catalog}); process.stdout.write(JSON.stringify({sourceHash:r.sourceHash,projectionHash:r.projectionHash,migrationRequired:r.migrationRequired,fromSchemaVersion:source.schemaVersion??1,toSchemaVersion:r.projectedState.schemaVersion}));
+      } catch (error) { process.stdout.write(JSON.stringify({error:String(error?.message ?? error)})); }
+    ' 2>&1)" || _migration_projection=""
+    _projection_error="$(_readiness_error "$_migration_projection")"
+    if [[ -n "$_projection_error" ]]; then
+      _migration_projection=""
+      _readiness_fail install_state_projection_failed "$_projection_error"
+    fi
   else
-    _readiness_failures+=(host_identity_missing)
+    _readiness_fail host_identity_missing "${_host_identity_error:-the shipped resolver produced no host identity}"
   fi
-  [[ -n "${PROMOTE_COMPOSE_PROJECT:-}" ]] || _readiness_failures+=(compose_identity_missing)
-  [[ -n "${PROMOTE_BACKUP_PATH:-}" && -d "$(dirname "${PROMOTE_BACKUP_PATH:-/missing}")" ]] || _readiness_failures+=(recovery_parent_unavailable)
-  [[ -d "$_state_dir" ]] || _readiness_failures+=(transition_secret_parent_unavailable)
+  [[ -n "${PROMOTE_COMPOSE_PROJECT:-}" ]] || _readiness_fail compose_identity_missing "PROMOTE_COMPOSE_PROJECT is unset"
+  [[ -n "${PROMOTE_BACKUP_PATH:-}" && -d "$(dirname "${PROMOTE_BACKUP_PATH:-/missing}")" ]] || _readiness_fail recovery_parent_unavailable "no writable parent for PROMOTE_BACKUP_PATH=${PROMOTE_BACKUP_PATH:-<unset>}"
+  [[ -d "$_state_dir" ]] || _readiness_fail transition_secret_parent_unavailable "state dir $_state_dir is not a directory"
   if [[ ${#_readiness_failures[@]} -gt 0 ]]; then
-    printf '{"stage":"preflight","result":"failed","quiescenceBegan":false,"failures":['
-    _sep=""
-    for _failure in "${_readiness_failures[@]}"; do
-      printf '%s{"code":"%s","message":"Promoter readiness check failed: %s"}' "$_sep" "$_failure" "$_failure"
-      _sep=,
-    done
-    printf ']}\n'
+    _failures_json="$(
+      for _index in "${!_readiness_failures[@]}"; do
+        printf '%s\n%s\n' "${_readiness_failures[$_index]}" "${_readiness_details[$_index]-}"
+      done | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const l=s.split("\n"),o=[];for(let i=0;i+1<l.length;i+=2){const code=l[i],detail=(l[i+1]||"").trim();o.push({code,message:`Promoter readiness check failed: ${code}${detail?`: ${detail}`:""}`})}process.stdout.write(JSON.stringify(o))})'
+    )"
+    printf '{"stage":"preflight","result":"failed","quiescenceBegan":false,"failures":%s}\n' "$_failures_json"
     exit 78
   fi
   printf '%s\n' "$_migration_projection" | jq -c '. + {stage:"preflight",result:"ready",quiescenceBegan:false,failures:[]}'
@@ -302,19 +326,22 @@ if [[ $_dry_run -eq 0 ]]; then
   _migration_field() {
     printf '%s' "$_migration_envelope" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const v=JSON.parse(s);const p=process.argv[1].split(".");let x=v;for(const k of p)x=x?.[k];if(typeof x!=="string"&&typeof x!=="number")process.exit(2);process.stdout.write(String(x))})' "$1"
   }
-  _migration_from="$(_migration_field fromSchemaVersion)"
-  _migration_to="$(_migration_field toSchemaVersion)"
-  if [[ "$_migration_from" != "$_migration_to" ]]; then
-    node "$_promoter_dir/installer/migrate-install-state.mjs" \
-      --state "$_install_state" \
-      --catalog "$_promoter_dir/capability-service-catalog.generated.json" \
-      --host-platform "$(_migration_field hostIdentity.platform)" \
-      --host-arch "$(_migration_field hostIdentity.arch)" \
-      --expected-source-hash "$(_migration_field sourceHash)" \
-      --expected-projection-hash "$(_migration_field projectionHash)" \
-      --recovery-path "$_capability_recovery" \
-      --write >/dev/null
-  fi
+  # The migrator itself decides whether there is anything to write - it no-ops
+  # unless its own projection reports migrationRequired, under the same lock and
+  # CAS the expected-hash flags below bind. Gating the call on a schema-version
+  # bump duplicated that decision in the shell and got it wrong: a capability
+  # catalog that moves WITHIN schema v2 is a real migration, and skipping the
+  # write left every install re-deriving the same restamp on every upgrade,
+  # never persisting it (BI-AA6FBAD0).
+  node "$_promoter_dir/installer/migrate-install-state.mjs" \
+    --state "$_install_state" \
+    --catalog "$_promoter_dir/capability-service-catalog.generated.json" \
+    --host-platform "$(_migration_field hostIdentity.platform)" \
+    --host-arch "$(_migration_field hostIdentity.arch)" \
+    --expected-source-hash "$(_migration_field sourceHash)" \
+    --expected-projection-hash "$(_migration_field projectionHash)" \
+    --recovery-path "$_capability_recovery" \
+    --write >/dev/null
 fi
 
 # Real platform version from the source's git release tags, baked into the new

--- a/scripts/self-upgrade-sensitive-paths.mjs
+++ b/scripts/self-upgrade-sensitive-paths.mjs
@@ -12,6 +12,14 @@ export const SELF_UPGRADE_SENSITIVE_PATH_RULES = Object.freeze([
   rule("promoter-contract", "contract", /^(?:(?:promoter-contract|scripts\/promoter-contract)(?:\.schema)?\.json|apps\/web\/lib\/self-upgrade\/promoter-contract|scripts\/promoter-contract(?:\.|\/)|Dockerfile\.promoter)/),
   rule("acceptance-workflow", "workflow", /^\.github\/workflows\/self-upgrade-acceptance\.yml$/),
   rule("n-minus-one-harness", "harness", /^scripts\/(?:self-upgrade-sensitive-paths|test-n-minus-one-upgrade)(?:\.test)?\.mjs$/),
+  // Everything Dockerfile.promoter bakes into the promoter image decides whether
+  // an install can upgrade, so changing any of it must run the acceptance gate.
+  // The rules above missed most of this closure - including the generated
+  // capability catalog and the profile resolver - which is how a change to the
+  // capability projection reached main without the gate ever running
+  // (BI-AA6FBAD0). The colocated test derives the closure from Dockerfile.promoter
+  // and fails if a newly baked file is not owned here.
+  rule("promoter-image-closure", "promoterClosure", /^(?:Dockerfile|scripts\/(?:capability-service-catalog\.generated\.json|promoter-migration-envelope\.mjs|runtime-transition-authority\.mjs|rotate-runtime-transition-secret\.mjs|governed-teardown\.mjs|salvage-sweep\.mjs)|scripts\/lib\/(?:transition-signing|resolve-capability-compose-profiles|govern-capability-compose-args|capability-state-hash)\.mjs)$/),
 ]);
 
 export function normalizeRepositoryPath(path) {

--- a/scripts/self-upgrade-sensitive-paths.test.mjs
+++ b/scripts/self-upgrade-sensitive-paths.test.mjs
@@ -17,6 +17,7 @@ const examples = {
   contract: "scripts/promoter-contract.schema.json",
   workflow: ".github/workflows/self-upgrade-acceptance.yml",
   harness: "scripts/test-n-minus-one-upgrade.mjs",
+  promoterClosure: "scripts/capability-service-catalog.generated.json",
 };
 
 test("classifies every contract-owned path family", () => {
@@ -47,6 +48,16 @@ test("lifecycle policy inventory fails closed when a path has no sensitive owner
   ]);
 });
 
+test("every file baked into the promoter image is self-upgrade sensitive", async () => {
+  // The promoter image IS the upgrade mechanism, so its inputs are the exact set
+  // whose change can wedge an install. Deriving them from the Dockerfile means a
+  // newly baked file cannot silently escape the acceptance gate.
+  const dockerfile = await readFile(new URL("../Dockerfile.promoter", import.meta.url), "utf8");
+  const baked = [...dockerfile.matchAll(/^COPY\s+(\S+)\s+\S+\s*$/gm)].map(([, source]) => source);
+  assert.ok(baked.length >= 15, `expected the promoter closure, parsed ${baked.length} COPY inputs`);
+  assert.deepEqual(findUnownedLifecyclePaths(baked), [], "a file baked into the promoter image must trigger the self-upgrade acceptance gate");
+});
+
 test("acceptance workflow is path-sensitive, nightly, least-privilege, bounded, and retains evidence", async () => {
   const workflow = await readFile(new URL("../.github/workflows/self-upgrade-acceptance.yml", import.meta.url), "utf8");
   assert.match(workflow, /pull_request:/);
@@ -62,4 +73,10 @@ test("acceptance workflow is path-sensitive, nightly, least-privilege, bounded, 
   assert.match(workflow, /promote-install-state-rollback\.test\.mjs/);
   assert.match(workflow, /Invalid state refuses before quiescence/);
   assert.match(workflow, /\.quiescenceBegan == false/);
+  // BI-AA6FBAD0: readiness must be proven against the shape every live install
+  // actually has - schemaVersion 2 carrying the PREVIOUS release's catalog hash.
+  // A v1 fixture is unversioned for capability purposes and skips every
+  // capability check, which is why the gate could not see the wedge.
+  assert.match(workflow, /Readiness migrates a v2 install carrying the previous catalog hash/);
+  assert.match(workflow, /capabilityCatalogHash/);
 });


### PR DESCRIPTION
## The failure

`SUR-C45B5F4B` failed pre-quiescence with `promoter-readiness-failed: capability_projection_failed`. The install was healthy and already schema 2; the candidate had simply moved `inngest` and `redis` into `runtime:core`, which legitimately moves `catalogHash`.

#4446 fixed half of this — it taught the resolver that a moved catalog is allowed under `--migrate`. The other half still refused, so the run still failed on current `main`.

## Root cause

`projectInstallState` treated migration as purely a **schema-version edge**:

- it asked for migrate mode only when `schemaVersion === 1`, so a v2 state always took the strict equality path;
- it returned a v2 source unchanged, so the capability fields could never be re-projected;
- `migrationRequired` was `schemaVersion !== 2`;
- `promote.sh` then wrote only when `fromSchemaVersion != toSchemaVersion`.

The capability snapshot was therefore **immutable after the v1→v2 migration**. The first release to move the catalog wedged every existing install, and the upgrade that would have restamped the state *was* the blocked upgrade — the same self-wedging shape `promote.sh` already calls out for host identity.

## The fix

`projectInstallState` *is* the migrator, so it always resolves in migrate mode, always projects the capability fields, and reports `migrationRequired` when the schema version **or** any projected capability field moved. `promote.sh` stops duplicating that decision and lets the migrator's own flag drive the write, under the same lock, CAS and expected-hash binding as before.

Fail-closed behaviour is unchanged: a snapshot that disagrees with an **unchanged** catalog, a capability the candidate no longer defines, a contradictory host identity, and a future schema version all still refuse.

## Why the gate did not catch it

Two independent holes, both closed here:

- **Most of the promoter's baked closure was not self-upgrade-sensitive.** The generated capability catalog, the profile resolver and the transition/teardown scripts were unowned, so changing them never ran the acceptance workflow — which is how the resolver change in #4446 merged without it. Ownership is now derived from `Dockerfile.promoter`'s `COPY` inputs by a colocated test, so a newly baked file cannot escape. That test immediately found two more unowned files.
- **Acceptance only ever ran readiness against a schema-1 fixture**, which is unversioned for capability purposes and skips every capability check. It now also asserts the shape every live install actually has: schema 2 carrying the **previous** release's catalog hash.

## Diagnosability

Readiness reported a bare code while discarding the line that named the cause, which is what made this expensive to diagnose. Each probe now carries its error text into the failure `message` — without temp files, since the acceptance gate runs that container `--read-only`. The acceptance workflow asserts a refusal names its cause.

## Verification

Functional, on the canonical container — not structural:

- A promoter built from this tree runs the exact readiness command that failed `SUR-C45B5F4B` against the real `~/.dpf/install-state.json` and returns `ready`, `migrationRequired: true`, schema 2 → 2, preserving all seven enabled capabilities. On `main` the same command returns exit 78.
- Both new acceptance fixtures executed locally against that container; the existing schema-1 N-1 fixture still passes; a tampered snapshot still refuses, now reporting `capability_projection_failed: capability_state_stale`.
- `pregate:status` → **PASS** (exact-tree merged-with-main run; evidence `cmt4i3k8g1kzu01qwjm25omtv`). 47 preflight guards clean. `lib/self-upgrade/` → 48 files, 641 tests passing.

`promote-script-functional.test.ts` initially broke: its fixture asserted `projectionHash === sourceHash`, which is never true of a real projection and was only ever unchecked because the migrator was skipped. The fixture now builds its state and its envelope hashes from the canonical migrator.

Pre-existing on macOS before and after, green in the Linux gate: install-state CLI/rollback tests fail `state_path_escape` (the `/var` symlink, BI-745658D7) and the PowerShell lifecycle tests need `pwsh`. This branch removes one `main` failure — the stale assertion #4446 left red — and adds none.

BI-AA6FBAD0 · Workroom WC-8DC5A87A

🤖 Generated with [Claude Code](https://claude.com/claude-code)