### PR TITLE
feat(mileage): rate resolution, classification, monetisation, and mobile drive detection (BI-6D98AD8A, BI-E17E0034)

### DIFF
--- a/apps/mobile/src/features/mileage/consent.test.ts
+++ b/apps/mobile/src/features/mileage/consent.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  geometryRetentionCutoff,
+  mayCapture,
+  revocationEffect,
+  type CaptureContext,
+  type DriverConsent,
+} from "./consent";
+
+const POLICY = "2026-08-01";
+
+function consent(over: Partial<DriverConsent> = {}): DriverConsent {
+  return {
+    consentStatus: "granted",
+    policyVersion: POLICY,
+    grantedAt: new Date("2026-08-01T00:00:00.000Z"),
+    revokedAt: null,
+    retentionDays: 365,
+    ...over,
+  };
+}
+
+function context(over: Partial<CaptureContext> = {}): CaptureContext {
+  return {
+    consent: consent(),
+    currentPolicyVersion: POLICY,
+    osBackgroundPermission: "granted",
+    ...over,
+  };
+}
+
+describe("mayCapture", () => {
+  it("allows capture when consent and OS permission both hold", () => {
+    expect(mayCapture(context())).toEqual({ allowed: true });
+  });
+
+  it("refuses capture with no consent record at all", () => {
+    expect(mayCapture(context({ consent: null }))).toEqual({
+      allowed: false,
+      reason: "no-consent",
+    });
+  });
+
+  it("refuses capture while consent is merely pending", () => {
+    expect(mayCapture(context({ consent: consent({ consentStatus: "pending" }) }))).toEqual({
+      allowed: false,
+      reason: "no-consent",
+    });
+  });
+
+  it("stops capture the moment consent is revoked", () => {
+    expect(
+      mayCapture(context({ consent: consent({ consentStatus: "revoked", revokedAt: new Date() }) })),
+    ).toEqual({ allowed: false, reason: "revoked" });
+  });
+
+  it("refuses capture when the disclosure has changed under the driver", () => {
+    // Consent is pinned to what was actually disclosed; a new policy needs a
+    // fresh grant rather than silently inheriting the old one.
+    expect(mayCapture(context({ currentPolicyVersion: "2026-09-01" }))).toEqual({
+      allowed: false,
+      reason: "policy-superseded",
+    });
+  });
+
+  it("does not treat a consent record as capture authority when the OS says no", () => {
+    expect(mayCapture(context({ osBackgroundPermission: "denied" }))).toEqual({
+      allowed: false,
+      reason: "os-permission-denied",
+    });
+  });
+
+  it("refuses on an unknown OS permission rather than assuming granted", () => {
+    expect(mayCapture(context({ osBackgroundPermission: "unknown" }))).toEqual({
+      allowed: false,
+      reason: "os-permission-denied",
+    });
+  });
+});
+
+describe("geometryRetentionCutoff", () => {
+  it("derives the cutoff from the driver's own retention window", () => {
+    const now = new Date("2026-08-22T00:00:00.000Z");
+    const cutoff = geometryRetentionCutoff(consent({ retentionDays: 30 }), now);
+    expect(cutoff?.toISOString()).toBe("2026-07-23T00:00:00.000Z");
+  });
+
+  it("has no cutoff without a granted consent to measure from", () => {
+    expect(geometryRetentionCutoff(null, new Date())).toBeNull();
+    expect(geometryRetentionCutoff(consent({ grantedAt: null }), new Date())).toBeNull();
+  });
+});
+
+describe("revocationEffect", () => {
+  it("stops future capture without deleting captured trips or the consent record", () => {
+    const effect = revocationEffect(consent({ consentStatus: "revoked" }));
+    expect(effect.stopsFutureCapture).toBe(true);
+    // Trips already claimed are accounting evidence; the consent record is the
+    // lawful basis for having captured them.
+    expect(effect.deletesExistingTrips).toBe(false);
+    expect(effect.retainsConsentRecord).toBe(true);
+  });
+});

--- a/apps/mobile/src/features/mileage/consent.ts
+++ b/apps/mobile/src/features/mileage/consent.ts
@@ -1,0 +1,98 @@
+/**
+ * Consent gate for background location capture (BI-6D98AD8A).
+ *
+ * Continuously tracking where an employee drives is the most consequential thing
+ * this feature does, so the gate is a hard precondition rather than a setting:
+ * capture may not start, and a fix may not be retained, unless this module says
+ * yes. It is pure so the rule is testable and so the same decision can be made
+ * on the server before a Trip row is written.
+ *
+ * Two properties are deliberate:
+ *   • consent is pinned to a POLICY VERSION. Changing what we disclose
+ *     invalidates the old grant instead of silently inheriting it.
+ *   • revocation stops capture immediately but does NOT erase history. The
+ *     consent record is the lawful-basis evidence for trips already captured.
+ */
+
+export type ConsentStatus = "pending" | "granted" | "revoked" | "expired";
+
+export interface DriverConsent {
+  consentStatus: ConsentStatus;
+  /** The disclosure version the driver actually agreed to. */
+  policyVersion: string;
+  grantedAt: Date | null;
+  revokedAt: Date | null;
+  /** How long captured geometry may be kept. */
+  retentionDays: number;
+}
+
+export type CaptureDecision =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: "no-consent" | "revoked" | "expired" | "policy-superseded" | "os-permission-denied";
+    };
+
+export interface CaptureContext {
+  consent: DriverConsent | null;
+  /** The disclosure version the app is currently running. */
+  currentPolicyVersion: string;
+  /** Whether the OS has actually granted background location. */
+  osBackgroundPermission: "granted" | "denied" | "unknown";
+}
+
+/**
+ * May the app capture a location fix right now?
+ *
+ * Both gates must pass: the driver's recorded consent AND the operating
+ * system's own permission. A granted consent record with a denied OS permission
+ * is not capture authority — it is a prompt to fix the setting.
+ */
+export function mayCapture(context: CaptureContext): CaptureDecision {
+  const { consent, currentPolicyVersion, osBackgroundPermission } = context;
+
+  if (!consent || consent.consentStatus === "pending") {
+    return { allowed: false, reason: "no-consent" };
+  }
+  if (consent.consentStatus === "revoked") {
+    return { allowed: false, reason: "revoked" };
+  }
+  if (consent.consentStatus === "expired") {
+    return { allowed: false, reason: "expired" };
+  }
+  if (consent.policyVersion !== currentPolicyVersion) {
+    // The driver agreed to a different disclosure than the one now in force.
+    return { allowed: false, reason: "policy-superseded" };
+  }
+  if (osBackgroundPermission !== "granted") {
+    return { allowed: false, reason: "os-permission-denied" };
+  }
+  return { allowed: true };
+}
+
+/**
+ * The date before which captured geometry must have been minimised, given the
+ * driver's retention window. Returns null when there is no granted consent to
+ * measure from.
+ */
+export function geometryRetentionCutoff(consent: DriverConsent | null, now: Date): Date | null {
+  if (!consent || consent.grantedAt === null) return null;
+  return new Date(now.getTime() - consent.retentionDays * 24 * 60 * 60_000);
+}
+
+/**
+ * What a revoked driver keeps. Revocation stops future capture; already-captured
+ * trips stay as the evidence behind reimbursements already claimed, and the
+ * consent record itself is retained so the lawful basis remains auditable.
+ */
+export function revocationEffect(consent: DriverConsent): {
+  stopsFutureCapture: boolean;
+  deletesExistingTrips: boolean;
+  retainsConsentRecord: boolean;
+} {
+  return {
+    stopsFutureCapture: consent.consentStatus === "revoked",
+    deletesExistingTrips: false,
+    retainsConsentRecord: true,
+  };
+}

--- a/apps/mobile/src/features/mileage/trip-detection.test.ts
+++ b/apps/mobile/src/features/mileage/trip-detection.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  DEFAULT_DETECTION,
+  detectTrips,
+  haversineMetres,
+  type LocationFix,
+} from "./trip-detection";
+
+const START = { latitude: 37.7749, longitude: -122.4194 };
+const T0 = Date.parse("2026-08-19T16:00:00.000Z");
+
+/** Fixes marching north, ~111m per 0.001 degree of latitude. */
+function drive(fromMs: number, steps: number, stepMinutes = 1, startLat = START.latitude) {
+  const fixes: LocationFix[] = [];
+  for (let i = 0; i < steps; i += 1) {
+    fixes.push({
+      latitude: startLat + i * 0.002,
+      longitude: START.longitude,
+      timestamp: fromMs + i * stepMinutes * 60_000,
+      accuracy: 10,
+    });
+  }
+  return fixes;
+}
+
+/** Fixes at one spot, as a parked phone reports. */
+function parked(fromMs: number, minutes: number, lat: number) {
+  const fixes: LocationFix[] = [];
+  for (let i = 0; i <= minutes; i += 1) {
+    fixes.push({
+      latitude: lat,
+      longitude: START.longitude,
+      timestamp: fromMs + i * 60_000,
+      accuracy: 10,
+    });
+  }
+  return fixes;
+}
+
+describe("detectTrips", () => {
+  it("detects a single continuous drive", () => {
+    const trips = detectTrips(drive(T0, 10));
+    expect(trips).toHaveLength(1);
+    expect(trips[0]!.fixCount).toBe(10);
+    expect(trips[0]!.distanceMetres).toBeGreaterThan(1_500);
+  });
+
+  it("splits two drives separated by a long stop", () => {
+    const first = drive(T0, 8);
+    const stopLat = first[first.length - 1]!.latitude;
+    const stop = parked(first[first.length - 1]!.timestamp + 60_000, 10, stopLat);
+    const second = drive(stop[stop.length - 1]!.timestamp + 60_000, 8, 1, stopLat);
+
+    const trips = detectTrips([...first, ...stop, ...second]);
+    expect(trips).toHaveLength(2);
+    // The visit itself is not a trip — only the drives either side of it.
+    expect(trips[0]!.endedAt.getTime()).toBeLessThan(trips[1]!.startedAt.getTime());
+  });
+
+  it("does not split a drive at a traffic light", () => {
+    const first = drive(T0, 6);
+    const lat = first[first.length - 1]!.latitude;
+    // Two minutes stationary — well under the five-minute stop gap.
+    const light = parked(first[first.length - 1]!.timestamp + 30_000, 2, lat);
+    const rest = drive(light[light.length - 1]!.timestamp + 30_000, 6, 1, lat);
+
+    expect(detectTrips([...first, ...light, ...rest])).toHaveLength(1);
+  });
+
+  it("drops parking-lot jitter below the minimum trip distance", () => {
+    const jitter: LocationFix[] = [
+      { ...START, timestamp: T0, accuracy: 5 },
+      { latitude: START.latitude + 0.0002, longitude: START.longitude, timestamp: T0 + 30_000, accuracy: 5 },
+      { latitude: START.latitude + 0.0001, longitude: START.longitude, timestamp: T0 + 60_000, accuracy: 5 },
+    ];
+    // A driver asked to classify GPS drift stops classifying anything.
+    expect(detectTrips(jitter)).toHaveLength(0);
+  });
+
+  it("discards fixes too inaccurate to trust", () => {
+    const good = drive(T0, 6);
+    const wild: LocationFix = {
+      latitude: START.latitude + 5,
+      longitude: START.longitude + 5,
+      timestamp: T0 + 3 * 60_000 + 1,
+      accuracy: 5_000,
+    };
+    const withWild = detectTrips([...good, wild]);
+    const withoutWild = detectTrips(good);
+    // A 5km-accuracy fix would otherwise add hundreds of phantom kilometres.
+    expect(withWild[0]!.distanceMetres).toBe(withoutWild[0]!.distanceMetres);
+  });
+
+  it("orders unsorted fixes before segmenting", () => {
+    const fixes = drive(T0, 8);
+    const shuffled = [fixes[3]!, fixes[0]!, fixes[6]!, fixes[1]!, fixes[7]!, fixes[2]!, fixes[4]!, fixes[5]!];
+    expect(detectTrips(shuffled)).toHaveLength(1);
+  });
+
+  it("returns nothing for an empty stream", () => {
+    expect(detectTrips([])).toHaveLength(0);
+  });
+
+  it("keeps a trip whose fixes never stop arriving", () => {
+    const trips = detectTrips(drive(T0, 30));
+    expect(trips).toHaveLength(1);
+    expect(trips[0]!.endedAt.getTime()).toBe(T0 + 29 * 60_000);
+  });
+});
+
+describe("haversineMetres", () => {
+  it("agrees with the server-side implementation on a known separation", () => {
+    const oakland = { latitude: 37.8044, longitude: -122.2712 };
+    const metres = haversineMetres(START, oakland);
+    expect(metres).toBeGreaterThan(13_000);
+    expect(metres).toBeLessThan(14_000);
+  });
+});
+
+describe("DEFAULT_DETECTION", () => {
+  it("uses a stop gap long enough to survive traffic", () => {
+    expect(DEFAULT_DETECTION.stopGapMs).toBeGreaterThanOrEqual(3 * 60_000);
+  });
+});

--- a/apps/mobile/src/features/mileage/trip-detection.ts
+++ b/apps/mobile/src/features/mileage/trip-detection.ts
@@ -1,0 +1,157 @@
+/**
+ * Drive detection — turning a stream of raw location fixes into discrete trips
+ * (BI-6D98AD8A).
+ *
+ * This is the part that makes automatic capture feel automatic: the driver
+ * never starts or stops a timer, so the app has to decide, from motion alone,
+ * where one drive ends and the next begins.
+ *
+ * Deliberately pure and free of any Expo/native import so the whole heuristic is
+ * unit-testable on CI without a device. The native background-location task that
+ * FEEDS this is a separate concern (it needs expo-task-manager, which must clear
+ * the dependency gate first); this module is what that task will call.
+ *
+ * Nothing here records anything. Consent is enforced by the caller before a fix
+ * is ever collected — see consent.ts.
+ */
+
+export interface LocationFix {
+  latitude: number;
+  longitude: number;
+  /** Milliseconds since epoch. */
+  timestamp: number;
+  /** Metres per second, when the platform supplied it. */
+  speed?: number | null;
+  /** Horizontal accuracy in metres; a poor fix is treated as suspect. */
+  accuracy?: number | null;
+}
+
+export interface DetectedTrip {
+  startedAt: Date;
+  endedAt: Date;
+  start: { latitude: number; longitude: number };
+  end: { latitude: number; longitude: number };
+  /** Summed great-circle distance along the retained fixes, in metres. */
+  distanceMetres: number;
+  fixCount: number;
+}
+
+export interface DetectionOptions {
+  /** A gap this long with no movement ends the trip. */
+  stopGapMs: number;
+  /** Movement below this between consecutive fixes counts as stationary. */
+  stationaryRadiusMetres: number;
+  /** Trips shorter than this are noise (car park shuffling, GPS drift). */
+  minimumTripMetres: number;
+  /** Fixes less accurate than this are discarded before segmentation. */
+  maximumAccuracyMetres: number;
+}
+
+export const DEFAULT_DETECTION: DetectionOptions = {
+  // Five minutes stationary ends a drive. Shorter and a traffic light splits a
+  // commute into three trips; longer and a site visit merges into the drive.
+  stopGapMs: 5 * 60_000,
+  stationaryRadiusMetres: 60,
+  // Under ~100m is parking-lot noise, not a business drive worth reimbursing.
+  minimumTripMetres: 100,
+  // A fix worse than this would corrupt the distance more than it informs it.
+  maximumAccuracyMetres: 100,
+};
+
+const EARTH_RADIUS_METRES = 6_371_008.8;
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+/** Great-circle distance in metres. Mirrors the server-side implementation. */
+export function haversineMetres(
+  a: { latitude: number; longitude: number },
+  b: { latitude: number; longitude: number },
+): number {
+  const dLat = toRadians(b.latitude - a.latitude);
+  const dLon = toRadians(b.longitude - a.longitude);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.sin(dLon / 2) ** 2 * Math.cos(toRadians(a.latitude)) * Math.cos(toRadians(b.latitude));
+  return 2 * EARTH_RADIUS_METRES * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+function usable(fix: LocationFix, options: DetectionOptions): boolean {
+  if (fix.accuracy === null || fix.accuracy === undefined) return true;
+  return fix.accuracy <= options.maximumAccuracyMetres;
+}
+
+function buildTrip(fixes: LocationFix[], options: DetectionOptions): DetectedTrip | null {
+  if (fixes.length < 2) return null;
+
+  let distanceMetres = 0;
+  for (let i = 1; i < fixes.length; i += 1) {
+    distanceMetres += haversineMetres(fixes[i - 1]!, fixes[i]!);
+  }
+  if (distanceMetres < options.minimumTripMetres) return null;
+
+  const first = fixes[0]!;
+  const last = fixes[fixes.length - 1]!;
+  return {
+    startedAt: new Date(first.timestamp),
+    endedAt: new Date(last.timestamp),
+    start: { latitude: first.latitude, longitude: first.longitude },
+    end: { latitude: last.latitude, longitude: last.longitude },
+    distanceMetres: Math.round(distanceMetres),
+    fixCount: fixes.length,
+  };
+}
+
+/**
+ * Segment an ordered stream of fixes into trips.
+ *
+ * A trip ends when the device has not moved beyond `stationaryRadiusMetres` for
+ * `stopGapMs` — which covers both "parked and switched off" and "the OS stopped
+ * delivering fixes". Sub-minimum segments are dropped rather than surfaced,
+ * because a driver asked to classify GPS jitter stops classifying anything.
+ */
+export function detectTrips(
+  rawFixes: readonly LocationFix[],
+  options: DetectionOptions = DEFAULT_DETECTION,
+): DetectedTrip[] {
+  const fixes = rawFixes
+    .filter((f) => usable(f, options))
+    .slice()
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  const trips: DetectedTrip[] = [];
+  let current: LocationFix[] = [];
+  // The last fix at which the device was meaningfully somewhere else.
+  let lastMovedAt: number | null = null;
+
+  for (const fix of fixes) {
+    if (current.length === 0) {
+      current = [fix];
+      lastMovedAt = fix.timestamp;
+      continue;
+    }
+
+    const previous = current[current.length - 1]!;
+    const moved = haversineMetres(previous, fix);
+
+    if (moved > options.stationaryRadiusMetres) {
+      current.push(fix);
+      lastMovedAt = fix.timestamp;
+      continue;
+    }
+
+    // Stationary. Close the trip once we have been still long enough.
+    if (lastMovedAt !== null && fix.timestamp - lastMovedAt >= options.stopGapMs) {
+      const trip = buildTrip(current, options);
+      if (trip) trips.push(trip);
+      current = [fix];
+      lastMovedAt = fix.timestamp;
+    }
+  }
+
+  const trailing = buildTrip(current, options);
+  if (trailing) trips.push(trailing);
+
+  return trips;
+}

--- a/apps/web/lib/mileage/classification.test.ts
+++ b/apps/web/lib/mileage/classification.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyTrip,
+  haversineMetres,
+  qualifiesForRepeatedRoute,
+  REPEATED_ROUTE_THRESHOLD,
+  type ClassifiableTrip,
+  type ClassificationRule,
+} from "./classification";
+
+const HOME = { latitude: 37.7749, longitude: -122.4194 };
+const OFFICE = { latitude: 37.8044, longitude: -122.2712 };
+const SITE = { latitude: 37.6879, longitude: -122.4702 };
+
+function trip(over: Partial<ClassifiableTrip> = {}): ClassifiableTrip {
+  return {
+    startedAt: new Date("2026-08-19T16:00:00.000Z"), // Wed 09:00 PT
+    endedAt: new Date("2026-08-19T16:30:00.000Z"),
+    start: HOME,
+    end: OFFICE,
+    classification: "unclassified",
+    classifiedByKind: null,
+    ...over,
+  };
+}
+
+const commuteRule: ClassificationRule = {
+  id: "rule_commute",
+  priority: 10,
+  resultClassification: "commute",
+  predicate: { kind: "commute_exclusion", home: HOME, homeRadiusMetres: 250 },
+};
+
+const workHoursRule: ClassificationRule = {
+  id: "rule_hours",
+  priority: 100,
+  resultClassification: "business",
+  predicate: {
+    kind: "work_hours",
+    daysOfWeek: [1, 2, 3, 4, 5],
+    startMinuteOfDay: 8 * 60,
+    endMinuteOfDay: 18 * 60,
+    utcOffsetMinutes: -7 * 60,
+  },
+};
+
+describe("haversineMetres", () => {
+  it("measures a known separation", () => {
+    // Home to office is roughly 13.4 km across the bay.
+    expect(haversineMetres(HOME, OFFICE)).toBeGreaterThan(13_000);
+    expect(haversineMetres(HOME, OFFICE)).toBeLessThan(14_000);
+  });
+
+  it("is zero for the same point", () => {
+    expect(haversineMetres(HOME, HOME)).toBe(0);
+  });
+});
+
+describe("classifyTrip", () => {
+  it("classifies the drive out of home as commute, not business", () => {
+    const outcome = classifyTrip(trip(), [commuteRule, workHoursRule]);
+    // Commute is more specific than work-hours and must win despite the drive
+    // falling squarely inside working hours — this is the whole point of the
+    // commute-exclusion feature.
+    expect(outcome.classification).toBe("commute");
+    expect(outcome.ruleId).toBe("rule_commute");
+  });
+
+  it("classifies a site-to-site drive in working hours as business", () => {
+    const outcome = classifyTrip(trip({ start: OFFICE, end: SITE }), [
+      commuteRule,
+      workHoursRule,
+    ]);
+    expect(outcome.classification).toBe("business");
+    expect(outcome.ruleId).toBe("rule_hours");
+  });
+
+  it("treats a loop starting and ending at home as not a commute", () => {
+    const nearHome = { latitude: HOME.latitude + 0.0005, longitude: HOME.longitude };
+    const outcome = classifyTrip(
+      trip({
+        start: HOME,
+        end: nearHome,
+        startedAt: new Date("2026-08-22T04:00:00.000Z"), // Fri 21:00 PT, outside hours
+        endedAt: new Date("2026-08-22T04:20:00.000Z"),
+      }),
+      [commuteRule, workHoursRule],
+    );
+    // Both ends at home is an errand, not a commute leg.
+    expect(outcome.classification).toBe("unclassified");
+  });
+
+  it("leaves a drive outside working hours unclassified rather than guessing", () => {
+    const outcome = classifyTrip(
+      trip({
+        start: OFFICE,
+        end: SITE,
+        startedAt: new Date("2026-08-23T20:00:00.000Z"), // Sunday
+        endedAt: new Date("2026-08-23T20:30:00.000Z"),
+      }),
+      [commuteRule, workHoursRule],
+    );
+    expect(outcome.classification).toBe("unclassified");
+    expect(outcome.ruleId).toBeNull();
+  });
+
+  it("never overrules a driver's own classification", () => {
+    const outcome = classifyTrip(
+      trip({ classification: "business", classifiedByKind: "driver" }),
+      [commuteRule, workHoursRule],
+    );
+    // The commute rule matches this trip, but a human already decided.
+    expect(outcome.classification).toBe("business");
+    expect(outcome.ruleId).toBeNull();
+  });
+
+  it("never overrules an admin's classification either", () => {
+    const outcome = classifyTrip(
+      trip({ classification: "personal", classifiedByKind: "admin" }),
+      [commuteRule],
+    );
+    expect(outcome.classification).toBe("personal");
+  });
+
+  it("may re-decide a trip a previous rule classified", () => {
+    const outcome = classifyTrip(
+      trip({ classification: "business", classifiedByKind: "rule" }),
+      [commuteRule],
+    );
+    // Rule output is not human intent, so a corrected rule set may revise it.
+    expect(outcome.classification).toBe("commute");
+  });
+});
+
+describe("qualifiesForRepeatedRoute", () => {
+  const candidate = {
+    kind: "repeated_route" as const,
+    start: OFFICE,
+    end: SITE,
+    matchRadiusMetres: 200,
+  };
+
+  function driverTrip(classification: "business" | "personal"): ClassifiableTrip {
+    return trip({ start: OFFICE, end: SITE, classification, classifiedByKind: "driver" });
+  }
+
+  it("qualifies once the driver has classified the route the same way enough times", () => {
+    const history = Array.from({ length: REPEATED_ROUTE_THRESHOLD }, () =>
+      driverTrip("business"),
+    );
+    expect(qualifiesForRepeatedRoute(history, candidate)).toBe("business");
+  });
+
+  it("does not qualify below the threshold", () => {
+    const history = Array.from({ length: REPEATED_ROUTE_THRESHOLD - 1 }, () =>
+      driverTrip("business"),
+    );
+    expect(qualifiesForRepeatedRoute(history, candidate)).toBeNull();
+  });
+
+  it("does not qualify when the driver has classified the route inconsistently", () => {
+    const history = [driverTrip("business"), driverTrip("business"), driverTrip("personal")];
+    // An ambiguous route is exactly the one a person should keep deciding.
+    expect(qualifiesForRepeatedRoute(history, candidate)).toBeNull();
+  });
+
+  it("ignores rule-classified history when deciding to automate", () => {
+    const history = Array.from({ length: REPEATED_ROUTE_THRESHOLD }, () =>
+      trip({ start: OFFICE, end: SITE, classification: "business", classifiedByKind: "rule" }),
+    );
+    // Automating off your own automation would let one bad rule entrench itself.
+    expect(qualifiesForRepeatedRoute(history, candidate)).toBeNull();
+  });
+});

--- a/apps/web/lib/mileage/classification.ts
+++ b/apps/web/lib/mileage/classification.ts
@@ -1,0 +1,192 @@
+// lib/mileage/classification.ts — auto-classification of captured drives (BI-6D98AD8A).
+//
+// The three MileIQ-Pro behaviours worth absorbing differ only in their predicate,
+// so they share one evaluator:
+//
+//   commute_exclusion — the first drive of the day out of the driver's home area
+//                       (and the last one back) is commuting, not business.
+//   work_hours        — a drive inside the driver's declared working window is
+//                       business unless something more specific says otherwise.
+//   repeated_route    — a route the driver has already classified the same way
+//                       N times classifies itself from then on.
+//
+// Pure and DB-free. Rules arrive already scoped and ordered by the caller; this
+// module only decides. A rule NEVER overrides a human: a trip a driver or admin
+// has already classified is returned untouched, because the whole value of the
+// feature collapses the first time automation silently overwrites a person.
+
+export type TripClassification = "unclassified" | "business" | "personal" | "commute";
+
+export type GeoPoint = { latitude: number; longitude: number };
+
+export type ClassifiableTrip = {
+  startedAt: Date;
+  endedAt: Date;
+  start: GeoPoint;
+  end: GeoPoint;
+  classification: TripClassification;
+  /** Set when a human already decided; rules must not overwrite it. */
+  classifiedByKind: "driver" | "rule" | "admin" | null;
+};
+
+export type CommuteExclusionPredicate = {
+  kind: "commute_exclusion";
+  home: GeoPoint;
+  /** How close to home counts as "at home". */
+  homeRadiusMetres: number;
+};
+
+export type WorkHoursPredicate = {
+  kind: "work_hours";
+  /** 0=Sunday … 6=Saturday, in the driver's own timezone offset. */
+  daysOfWeek: readonly number[];
+  startMinuteOfDay: number;
+  endMinuteOfDay: number;
+  /** Minutes to add to UTC to reach the driver's local time. */
+  utcOffsetMinutes: number;
+};
+
+export type RepeatedRoutePredicate = {
+  kind: "repeated_route";
+  start: GeoPoint;
+  end: GeoPoint;
+  /** How close the endpoints must be to count as the same route. */
+  matchRadiusMetres: number;
+};
+
+export type MileagePredicate =
+  | CommuteExclusionPredicate
+  | WorkHoursPredicate
+  | RepeatedRoutePredicate;
+
+export type ClassificationRule = {
+  id: string;
+  /** Lower runs first. */
+  priority: number;
+  resultClassification: TripClassification;
+  predicate: MileagePredicate;
+};
+
+export type ClassificationOutcome = {
+  classification: TripClassification;
+  ruleId: string | null;
+};
+
+const EARTH_RADIUS_METRES = 6_371_008.8;
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+/** Great-circle distance between two points, in metres. */
+export function haversineMetres(a: GeoPoint, b: GeoPoint): number {
+  const dLat = toRadians(b.latitude - a.latitude);
+  const dLon = toRadians(b.longitude - a.longitude);
+  const lat1 = toRadians(a.latitude);
+  const lat2 = toRadians(b.latitude);
+
+  const h =
+    Math.sin(dLat / 2) ** 2 + Math.sin(dLon / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2);
+  return 2 * EARTH_RADIUS_METRES * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+function withinRadius(a: GeoPoint, b: GeoPoint, radiusMetres: number): boolean {
+  return haversineMetres(a, b) <= radiusMetres;
+}
+
+function localMinuteOfDay(at: Date, utcOffsetMinutes: number): number {
+  const shifted = new Date(at.getTime() + utcOffsetMinutes * 60_000);
+  return shifted.getUTCHours() * 60 + shifted.getUTCMinutes();
+}
+
+function localDayOfWeek(at: Date, utcOffsetMinutes: number): number {
+  return new Date(at.getTime() + utcOffsetMinutes * 60_000).getUTCDay();
+}
+
+function matchesCommuteExclusion(trip: ClassifiableTrip, p: CommuteExclusionPredicate): boolean {
+  const startsAtHome = withinRadius(trip.start, p.home, p.homeRadiusMetres);
+  const endsAtHome = withinRadius(trip.end, p.home, p.homeRadiusMetres);
+  // Exactly one end at home = the commute leg. Both ends at home is an errand
+  // loop, not a commute; neither end at home is a working drive.
+  return startsAtHome !== endsAtHome;
+}
+
+function matchesWorkHours(trip: ClassifiableTrip, p: WorkHoursPredicate): boolean {
+  const day = localDayOfWeek(trip.startedAt, p.utcOffsetMinutes);
+  if (!p.daysOfWeek.includes(day)) return false;
+  const minute = localMinuteOfDay(trip.startedAt, p.utcOffsetMinutes);
+  return minute >= p.startMinuteOfDay && minute <= p.endMinuteOfDay;
+}
+
+function matchesRepeatedRoute(trip: ClassifiableTrip, p: RepeatedRoutePredicate): boolean {
+  return (
+    withinRadius(trip.start, p.start, p.matchRadiusMetres) &&
+    withinRadius(trip.end, p.end, p.matchRadiusMetres)
+  );
+}
+
+function matches(trip: ClassifiableTrip, rule: ClassificationRule): boolean {
+  switch (rule.predicate.kind) {
+    case "commute_exclusion":
+      return matchesCommuteExclusion(trip, rule.predicate);
+    case "work_hours":
+      return matchesWorkHours(trip, rule.predicate);
+    case "repeated_route":
+      return matchesRepeatedRoute(trip, rule.predicate);
+  }
+}
+
+/**
+ * Decide a trip's classification.
+ *
+ * A trip a human already classified is returned unchanged — automation assists,
+ * it does not overrule. Otherwise the lowest-priority-number matching rule wins,
+ * which is what lets commute exclusion (specific) beat work hours (broad).
+ */
+export function classifyTrip(
+  trip: ClassifiableTrip,
+  rules: readonly ClassificationRule[],
+): ClassificationOutcome {
+  if (trip.classifiedByKind === "driver" || trip.classifiedByKind === "admin") {
+    return { classification: trip.classification, ruleId: null };
+  }
+
+  const winner = [...rules]
+    .sort((a, b) => a.priority - b.priority)
+    .find((rule) => matches(trip, rule));
+
+  if (!winner) return { classification: "unclassified", ruleId: null };
+  return { classification: winner.resultClassification, ruleId: winner.id };
+}
+
+/**
+ * How many identical classifications of the same route it takes before offering
+ * to auto-classify it. MileIQ asks on the third; matching that is deliberate —
+ * two could be coincidence, and asking too early trains people to dismiss.
+ */
+export const REPEATED_ROUTE_THRESHOLD = 3;
+
+/**
+ * Whether a route now qualifies for a repeated-route rule: at least the
+ * threshold of PRIOR trips over the same endpoints, all classified the same way
+ * by a human. Mixed history never qualifies — an ambiguous route is exactly the
+ * one a person should keep deciding.
+ */
+export function qualifiesForRepeatedRoute(
+  priorTrips: readonly ClassifiableTrip[],
+  candidate: RepeatedRoutePredicate,
+): TripClassification | null {
+  const onRoute = priorTrips.filter(
+    (t) =>
+      t.classifiedByKind === "driver" &&
+      matchesRepeatedRoute(t, candidate) &&
+      t.classification !== "unclassified",
+  );
+  if (onRoute.length < REPEATED_ROUTE_THRESHOLD) return null;
+
+  const [first, ...rest] = onRoute;
+  if (!first) return null;
+  return rest.every((t) => t.classification === first.classification)
+    ? first.classification
+    : null;
+}

--- a/apps/web/lib/mileage/monetisation.test.ts
+++ b/apps/web/lib/mileage/monetisation.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { mileageLogTotals, priceTrips, type PriceableTrip } from "./monetisation";
+import type { ResolvableRate } from "./rates";
+
+const RATE_2026: ResolvableRate = {
+  id: "rate_2026",
+  purposeKind: "business",
+  amountPerMile: 0.725,
+  currency: "USD",
+  effectiveFrom: new Date("2026-01-01T00:00:00.000Z"),
+  effectiveTo: null,
+  isOrgOverride: false,
+};
+
+function trip(over: Partial<PriceableTrip> = {}): PriceableTrip {
+  return {
+    id: "cuid_trip",
+    tripId: "TRIP-1",
+    startedAt: new Date("2026-08-19T16:00:00.000Z"),
+    distanceMetres: 16093.44, // 10 miles
+    classification: "business",
+    startPlaceLabel: null,
+    endPlaceLabel: null,
+    customerAccountId: null,
+    ...over,
+  };
+}
+
+describe("priceTrips", () => {
+  it("prices a business drive onto an expense line", () => {
+    const result = priceTrips([trip()], [RATE_2026]);
+    expect(result.lines).toHaveLength(1);
+    expect(result.lines[0]?.amount).toBe(7.25);
+    expect(result.lines[0]?.category).toBe("mileage");
+    // The rate is recorded on the line so the money stays reproducible.
+    expect(result.lines[0]?.mileageRateId).toBe("rate_2026");
+    expect(result.totalAmount).toBe(7.25);
+  });
+
+  it("does not reimburse commute or personal drives", () => {
+    const result = priceTrips(
+      [
+        trip({ tripId: "TRIP-C", classification: "commute" }),
+        trip({ tripId: "TRIP-P", classification: "personal" }),
+      ],
+      [RATE_2026],
+    );
+    expect(result.lines).toHaveLength(0);
+    expect(result.skipped.map((s) => s.reason)).toEqual(["not-business", "not-business"]);
+  });
+
+  it("accounts for every trip — a skipped drive is reported, never dropped", () => {
+    const trips = [
+      trip({ tripId: "TRIP-1" }),
+      trip({ tripId: "TRIP-2", classification: "personal" }),
+      trip({ tripId: "TRIP-3", distanceMetres: 0 }),
+    ];
+    const result = priceTrips(trips, [RATE_2026]);
+    const accountedFor = [
+      ...result.lines.map((l) => l.tripId),
+      ...result.skipped.map((s) => s.tripId),
+    ];
+    expect(accountedFor.sort()).toEqual(["TRIP-1", "TRIP-2", "TRIP-3"]);
+  });
+
+  it("refuses to price at zero when no rate covers the trip date", () => {
+    const result = priceTrips([trip({ startedAt: new Date("2025-06-01T00:00:00.000Z") })], [
+      RATE_2026,
+    ]);
+    expect(result.lines).toHaveLength(0);
+    expect(result.skipped[0]?.reason).toBe("no-rate-in-force");
+  });
+
+  it("prices a historical trip at its own year's rate", () => {
+    const rate2025: ResolvableRate = {
+      ...RATE_2026,
+      id: "rate_2025",
+      amountPerMile: 0.7,
+      effectiveFrom: new Date("2025-01-01T00:00:00.000Z"),
+      effectiveTo: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    const result = priceTrips(
+      [trip({ startedAt: new Date("2025-09-01T00:00:00.000Z") })],
+      [rate2025, RATE_2026],
+    );
+    expect(result.lines[0]?.amount).toBe(7);
+    expect(result.lines[0]?.mileageRateId).toBe("rate_2025");
+  });
+
+  it("carries customer attribution through to the line for job costing", () => {
+    const result = priceTrips([trip({ customerAccountId: "cuid_account" })], [RATE_2026]);
+    expect(result.lines[0]?.customerAccountId).toBe("cuid_account");
+  });
+
+  it("describes a line with place labels when they resolved", () => {
+    const result = priceTrips(
+      [trip({ startPlaceLabel: "Depot", endPlaceLabel: "Site 4" })],
+      [RATE_2026],
+    );
+    expect(result.lines[0]?.description).toBe("10.0 mi — Depot to Site 4");
+  });
+});
+
+describe("mileageLogTotals", () => {
+  it("reports commute separately from personal", () => {
+    const totals = mileageLogTotals([
+      trip({ classification: "business" }),
+      trip({ classification: "commute" }),
+      trip({ classification: "personal" }),
+      trip({ classification: "unclassified" }),
+    ]);
+    // A taxpayer must be able to show commute was excluded, not merely absent.
+    expect(totals.businessMiles).toBe(10);
+    expect(totals.commuteMiles).toBe(10);
+    expect(totals.personalMiles).toBe(10);
+    expect(totals.unclassifiedMiles).toBe(10);
+    expect(totals.totalMiles).toBe(40);
+  });
+});

--- a/apps/web/lib/mileage/monetisation.test.ts
+++ b/apps/web/lib/mileage/monetisation.test.ts
@@ -77,7 +77,7 @@ describe("priceTrips", () => {
       id: "rate_2025",
       amountPerMile: 0.7,
       effectiveFrom: new Date("2025-01-01T00:00:00.000Z"),
-      effectiveTo: new Date("2026-01-01T00:00:00.000Z"),
+      effectiveTo: new Date("2026-01-01T00:00:00.000Z"), // clock-bomb-guard: allow effective-dating fixture — resolveRateForDate is given an explicit trip date and never reads the wall clock
     };
     const result = priceTrips(
       [trip({ startedAt: new Date("2025-09-01T00:00:00.000Z") })],

--- a/apps/web/lib/mileage/monetisation.ts
+++ b/apps/web/lib/mileage/monetisation.ts
@@ -1,0 +1,135 @@
+// lib/mileage/monetisation.ts — turning classified drives into reimbursable
+// expense lines (BI-E17E0034).
+//
+// Mileage does NOT get its own reimbursement path. It monetises onto the
+// ExpenseClaim / ExpenseItem spine the platform already has, so approval,
+// GL posting and payment stay in exactly one place. This module is the pure
+// mapping; lib/mileage/mileage-service.ts does the Prisma writes.
+//
+// Only BUSINESS trips are reimbursable. Commute and personal drives are logged
+// (an IRS-compliant log needs total, business and personal miles) but never
+// produce money.
+
+import { resolveRateForDate, reimbursableAmount, metresToMiles, type ResolvableRate } from "./rates";
+import type { TripClassification } from "./classification";
+
+export type PriceableTrip = {
+  id: string;
+  tripId: string;
+  startedAt: Date;
+  distanceMetres: number;
+  classification: TripClassification;
+  startPlaceLabel: string | null;
+  endPlaceLabel: string | null;
+  customerAccountId: string | null;
+};
+
+export type MileageExpenseLine = {
+  tripId: string;
+  date: Date;
+  category: "mileage";
+  description: string;
+  amount: number;
+  currency: string;
+  /** The rate row that priced this line — kept so the money is reproducible. */
+  mileageRateId: string;
+  customerAccountId: string | null;
+};
+
+export type PricingSkip = {
+  tripId: string;
+  reason: "not-business" | "no-rate-in-force" | "zero-distance";
+};
+
+export type PricingResult = {
+  lines: readonly MileageExpenseLine[];
+  skipped: readonly PricingSkip[];
+  totalAmount: number;
+  currency: string;
+};
+
+function describe(trip: PriceableTrip): string {
+  const miles = metresToMiles(trip.distanceMetres).toFixed(1);
+  const from = trip.startPlaceLabel?.trim();
+  const to = trip.endPlaceLabel?.trim();
+  // Place labels are optional — a drive with no resolved places still needs a
+  // human-readable line on the claim.
+  return from && to ? `${miles} mi — ${from} to ${to}` : `${miles} mi business drive`;
+}
+
+/**
+ * Price a set of trips into expense lines.
+ *
+ * Every trip is accounted for: it either produces a line or appears in `skipped`
+ * with a reason. A trip is never silently dropped, because a driver noticing
+ * missing mileage after the fact is how trust in automatic capture dies.
+ */
+export function priceTrips(
+  trips: readonly PriceableTrip[],
+  rates: readonly ResolvableRate[],
+  currencyFallback = "USD",
+): PricingResult {
+  const lines: MileageExpenseLine[] = [];
+  const skipped: PricingSkip[] = [];
+
+  for (const trip of trips) {
+    if (trip.classification !== "business") {
+      skipped.push({ tripId: trip.tripId, reason: "not-business" });
+      continue;
+    }
+    if (trip.distanceMetres <= 0) {
+      skipped.push({ tripId: trip.tripId, reason: "zero-distance" });
+      continue;
+    }
+
+    const rate = resolveRateForDate(rates, trip.startedAt, "business");
+    if (!rate) {
+      // Cannot price yet — surfaced, never zero-filled.
+      skipped.push({ tripId: trip.tripId, reason: "no-rate-in-force" });
+      continue;
+    }
+
+    lines.push({
+      tripId: trip.tripId,
+      date: trip.startedAt,
+      category: "mileage",
+      description: describe(trip),
+      amount: reimbursableAmount(trip.distanceMetres, rate.amountPerMile),
+      currency: rate.currency,
+      mileageRateId: rate.id,
+      customerAccountId: trip.customerAccountId,
+    });
+  }
+
+  const currency = lines[0]?.currency ?? currencyFallback;
+  const totalAmount = Math.round(lines.reduce((t, l) => t + l.amount, 0) * 100) / 100;
+
+  return { lines, skipped, totalAmount, currency };
+}
+
+export type MileageLogTotals = {
+  totalMiles: number;
+  businessMiles: number;
+  personalMiles: number;
+  commuteMiles: number;
+  unclassifiedMiles: number;
+};
+
+/**
+ * Totals for an IRS-compliant mileage log. Commute is reported separately from
+ * personal because a taxpayer has to be able to show it was excluded, not merely
+ * absent.
+ */
+export function mileageLogTotals(trips: readonly PriceableTrip[]): MileageLogTotals {
+  const round = (n: number) => Math.round(n * 10) / 10;
+  const sum = (predicate: (t: PriceableTrip) => boolean) =>
+    trips.filter(predicate).reduce((t, x) => t + metresToMiles(x.distanceMetres), 0);
+
+  return {
+    totalMiles: round(sum(() => true)),
+    businessMiles: round(sum((t) => t.classification === "business")),
+    personalMiles: round(sum((t) => t.classification === "personal")),
+    commuteMiles: round(sum((t) => t.classification === "commute")),
+    unclassifiedMiles: round(sum((t) => t.classification === "unclassified")),
+  };
+}

--- a/apps/web/lib/mileage/rates.test.ts
+++ b/apps/web/lib/mileage/rates.test.ts
@@ -25,7 +25,7 @@ describe("resolveRateForDate", () => {
       id: "rate_2025",
       amountPerMile: 0.7,
       effectiveFrom: new Date("2025-01-01T00:00:00.000Z"),
-      effectiveTo: new Date("2026-01-01T00:00:00.000Z"),
+      effectiveTo: new Date("2026-01-01T00:00:00.000Z"), // clock-bomb-guard: allow effective-dating fixture — resolveRateForDate is given an explicit trip date and never reads the wall clock
     });
     const y2026 = rate({ id: "rate_2026", amountPerMile: 0.725 });
 
@@ -42,7 +42,7 @@ describe("resolveRateForDate", () => {
     const closing = rate({
       id: "closing",
       effectiveFrom: new Date("2025-01-01T00:00:00.000Z"),
-      effectiveTo: new Date("2026-01-01T00:00:00.000Z"),
+      effectiveTo: new Date("2026-01-01T00:00:00.000Z"), // clock-bomb-guard: allow effective-dating fixture — resolveRateForDate is given an explicit trip date and never reads the wall clock
     });
     const opening = rate({ id: "opening", effectiveFrom: new Date("2026-01-01T00:00:00.000Z") });
 

--- a/apps/web/lib/mileage/rates.test.ts
+++ b/apps/web/lib/mileage/rates.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  metresToMiles,
+  reimbursableAmount,
+  resolveRateForDate,
+  type ResolvableRate,
+} from "./rates";
+
+function rate(over: Partial<ResolvableRate> = {}): ResolvableRate {
+  return {
+    id: "rate_statutory_2026",
+    purposeKind: "business",
+    amountPerMile: 0.725,
+    currency: "USD",
+    effectiveFrom: new Date("2026-01-01T00:00:00.000Z"),
+    effectiveTo: null,
+    isOrgOverride: false,
+    ...over,
+  };
+}
+
+describe("resolveRateForDate", () => {
+  it("prices a trip at the rate in force on the day it was driven", () => {
+    const y2025 = rate({
+      id: "rate_2025",
+      amountPerMile: 0.7,
+      effectiveFrom: new Date("2025-01-01T00:00:00.000Z"),
+      effectiveTo: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    const y2026 = rate({ id: "rate_2026", amountPerMile: 0.725 });
+
+    // The load-bearing behaviour: a 2025 trip keeps its 2025 rate forever.
+    expect(resolveRateForDate([y2025, y2026], new Date("2025-06-15T12:00:00.000Z"))?.id).toBe(
+      "rate_2025",
+    );
+    expect(resolveRateForDate([y2025, y2026], new Date("2026-06-15T12:00:00.000Z"))?.id).toBe(
+      "rate_2026",
+    );
+  });
+
+  it("treats effectiveTo as exclusive so adjacent rates never both match", () => {
+    const closing = rate({
+      id: "closing",
+      effectiveFrom: new Date("2025-01-01T00:00:00.000Z"),
+      effectiveTo: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    const opening = rate({ id: "opening", effectiveFrom: new Date("2026-01-01T00:00:00.000Z") });
+
+    const onBoundary = resolveRateForDate([closing, opening], new Date("2026-01-01T00:00:00.000Z"));
+    expect(onBoundary?.id).toBe("opening");
+  });
+
+  it("lets an organization override beat the statutory rate for the same day", () => {
+    const statutory = rate({ id: "statutory", amountPerMile: 0.725 });
+    const override = rate({ id: "org", amountPerMile: 0.6, isOrgOverride: true });
+
+    expect(resolveRateForDate([statutory, override], new Date("2026-03-01T00:00:00.000Z"))?.id).toBe(
+      "org",
+    );
+  });
+
+  it("does not cross purposes", () => {
+    const business = rate({ id: "business" });
+    const charitable = rate({ id: "charitable", purposeKind: "charitable", amountPerMile: 0.14 });
+
+    expect(
+      resolveRateForDate([business, charitable], new Date("2026-03-01T00:00:00.000Z"), "charitable")
+        ?.id,
+    ).toBe("charitable");
+  });
+
+  it("returns null rather than a zero rate when nothing covers the date", () => {
+    const future = rate({ effectiveFrom: new Date("2027-01-01T00:00:00.000Z") });
+    // A caller must treat this as "cannot price yet" — pricing at zero would
+    // silently under-reimburse a real drive.
+    expect(resolveRateForDate([future], new Date("2026-06-01T00:00:00.000Z"))).toBeNull();
+  });
+});
+
+describe("reimbursableAmount", () => {
+  it("converts metres to miles and prices to whole cents", () => {
+    // 10 miles exactly at 0.725 = 7.25
+    expect(reimbursableAmount(16093.44, 0.725)).toBe(7.25);
+  });
+
+  it("rounds only at the money boundary, not per mile", () => {
+    const metres = 100_000; // ~62.137 miles
+    const expected = Math.round((metresToMiles(metres) * 0.725 + Number.EPSILON) * 100) / 100;
+    expect(reimbursableAmount(metres, 0.725)).toBe(expected);
+    expect(reimbursableAmount(metres, 0.725)).toBeCloseTo(45.05, 2);
+  });
+
+  it("prices a zero-distance trip at zero", () => {
+    expect(reimbursableAmount(0, 0.725)).toBe(0);
+  });
+});

--- a/apps/web/lib/mileage/rates.ts
+++ b/apps/web/lib/mileage/rates.ts
@@ -1,0 +1,75 @@
+// lib/mileage/rates.ts — effective-dated mileage rate resolution (BI-E17E0034).
+//
+// The whole point of this module is that a trip prices at the rate in force on
+// the day it was DRIVEN, never at today's rate. A reimbursement claimed in
+// January must still reconcile in December after the statutory rate changed, so
+// resolution is always a function of the trip date — there is deliberately no
+// "current rate" accessor to reach for by mistake.
+//
+// Pure and DB-free so every rule is unit-testable; the caller loads candidate
+// rates and hands them in.
+
+/** Metres in one statute mile. Mileage rates are per mile, capture is in metres. */
+export const METRES_PER_MILE = 1609.344;
+
+export type MileagePurpose = "business" | "medical" | "moving" | "charitable";
+
+export type ResolvableRate = {
+  id: string;
+  purposeKind: MileagePurpose;
+  /** Money per mile, e.g. 0.725. */
+  amountPerMile: number;
+  currency: string;
+  effectiveFrom: Date;
+  /** NULL means still open. */
+  effectiveTo: Date | null;
+  /** True when this rate belongs to an org's own override plan. */
+  isOrgOverride: boolean;
+};
+
+function coversDate(rate: ResolvableRate, on: Date): boolean {
+  if (rate.effectiveFrom.getTime() > on.getTime()) return false;
+  if (rate.effectiveTo === null) return true;
+  // effectiveTo is exclusive: a rate ending on the 1st does not price the 1st.
+  return rate.effectiveTo.getTime() > on.getTime();
+}
+
+/**
+ * Resolve the rate that prices a trip driven on `on`.
+ *
+ * An organization's own override wins over the statutory rate for the same day —
+ * that is the "custom company-wide rate" job. Among rates of equal precedence the
+ * latest effectiveFrom wins, so a mid-year correction supersedes cleanly without
+ * anyone editing history.
+ *
+ * Returns null when nothing covers the date; callers must treat that as "cannot
+ * price yet", never as zero.
+ */
+export function resolveRateForDate(
+  rates: readonly ResolvableRate[],
+  on: Date,
+  purpose: MileagePurpose = "business",
+): ResolvableRate | null {
+  const candidates = rates
+    .filter((r) => r.purposeKind === purpose && coversDate(r, on))
+    .sort((a, b) => {
+      if (a.isOrgOverride !== b.isOrgOverride) return a.isOrgOverride ? -1 : 1;
+      return b.effectiveFrom.getTime() - a.effectiveFrom.getTime();
+    });
+
+  return candidates[0] ?? null;
+}
+
+/** Metres to miles, unrounded — rounding belongs at the money boundary only. */
+export function metresToMiles(metres: number): number {
+  return metres / METRES_PER_MILE;
+}
+
+/**
+ * Money for a distance at a rate. Rounded half-up to cents at the last step so
+ * a long trip does not accumulate per-mile rounding drift.
+ */
+export function reimbursableAmount(distanceMetres: number, amountPerMile: number): number {
+  const raw = metresToMiles(distanceMetres) * amountPerMile;
+  return Math.round((raw + Number.EPSILON) * 100) / 100;
+}


### PR DESCRIPTION
Stacked on #4469 (base is `feat/absorption-data-substrate`, retarget to `main` once that merges).

## What

The behaviour half of mileage absorption — 49 tests, all pure and DB-free.

**Server (`apps/web/lib/mileage/`)**
- `rates.ts` — effective-dated rate resolution
- `classification.ts` — the three MileIQ-Pro auto-classification behaviours
- `monetisation.ts` — trips → `ExpenseItem` lines + IRS mileage-log totals

**Mobile (`apps/mobile/src/features/mileage/`)**
- `trip-detection.ts` — segments a raw fix stream into discrete drives
- `consent.ts` — the capture gate

## The decisions worth reviewing

**A rule never overrules a human.** A trip a driver or admin classified is returned untouched. The feature's value collapses the first time automation silently overwrites a person.

**Repeated-route automation counts only driver-classified history.** Automating off your own automation lets one bad rule entrench itself.

**No rate covering a trip date returns `null`, never zero.** Pricing an unpriceable drive at zero silently under-reimburses someone. Every trip is accounted for — it yields a line or appears in `skipped` with a reason, because a driver noticing missing mileage later is how trust in automatic capture dies.

**A granted consent record is not capture authority.** The OS permission must also hold, and an *unknown* permission refuses rather than assuming yes. Consent is pinned to a policy version, so changing the disclosure invalidates the old grant instead of inheriting it. Revocation stops capture and deletes nothing — claimed trips are accounting evidence and the consent record is the lawful basis for having captured them.

**Detection heuristics carry their reasoning.** Five-minute stop gap (shorter splits a commute at every traffic light; longer merges a site visit into the drive), sub-100m segments dropped as parking-lot jitter, >100m-accuracy fixes discarded before segmentation because one wild fix adds phantom kilometres.

Commute exclusion fires when *exactly one* end of the drive is at home — both ends at home is an errand loop, not a commute leg.

## Verification

- `pregate` sandbox gate **PASS** at `7157aa95a523`, evidence `cmt4i94kw1lb401qwp0zaxhdm`
- `pregate:preflight` — 47 guards clean
- 29 web tests, 20 mobile tests

## Deliberately not here

The native background-location task that will feed `trip-detection` needs `expo-task-manager`, a new dependency. That must clear the dependency gate on its own merits rather than riding in on a feature PR, so this lands the whole heuristic as testable logic and leaves the native registration to follow.

The clock-bomb guard flagged the effective-dating fixtures; they are annotated with a reason rather than wrapped in fake timers, because the resolver is always given an explicit trip date and never reads the wall clock — the 2026 boundary is the thing under test.

Refs: EP-MILEAGE-ABSORB, BI-6D98AD8A, BI-E17E0034

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Docs-Impact-Decision: pure domain logic only — this PR adds rate resolution, classification, monetisation and mobile drive detection as DB-free modules with no route, screen or user-visible surface yet. The flagged architecture runbooks describe the gate process, which is unchanged. User-guide coverage lands with the admin approval surface and the mobile drive card that expose this logic.
Local-CI-Evidence: cmt4iril81n1q01qw6qajv41p (feat/mileage-vertical@ef84af6eca36)
