### PR TITLE
fix(onboarding): project storefront completion from publish (BI-0E659356)

### DIFF
--- a/apps/web/app/api/storefront/admin/publish/route.test.ts
+++ b/apps/web/app/api/storefront/admin/publish/route.test.ts
@@ -1,0 +1,48 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  updateStorefront: vi.fn(),
+  completeSetupStepFromEvidence: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
+vi.mock("@dpf/db", () => ({
+  prisma: { storefrontConfig: { update: mocks.updateStorefront } },
+}));
+vi.mock("@/lib/onboarding/setup-progress-service.server", () => ({
+  completeSetupStepFromEvidence: mocks.completeSetupStepFromEvidence,
+}));
+
+import { POST } from "./route";
+
+function request(body: unknown): NextRequest {
+  return { json: vi.fn().mockResolvedValue(body) } as unknown as NextRequest;
+}
+
+describe("storefront publish route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auth.mockResolvedValue({ user: { type: "admin" } });
+    mocks.updateStorefront.mockResolvedValue({ organizationId: "org-1" });
+  });
+
+  it("projects a successful publish into onboarding progress", async () => {
+    const response = await POST(request({ id: "sf-1", isPublished: true }));
+
+    expect(response.status).toBe(200);
+    expect(mocks.updateStorefront).toHaveBeenCalledWith({
+      where: { id: "sf-1" },
+      data: { isPublished: true },
+      select: { organizationId: true },
+    });
+    expect(mocks.completeSetupStepFromEvidence).toHaveBeenCalledWith("org-1", "storefront");
+  });
+
+  it("never reopens onboarding when a storefront is unpublished", async () => {
+    await POST(request({ id: "sf-1", isPublished: false }));
+
+    expect(mocks.completeSetupStepFromEvidence).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/storefront/admin/publish/route.ts
+++ b/apps/web/app/api/storefront/admin/publish/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
+import { completeSetupStepFromEvidence } from "@/lib/onboarding/setup-progress-service.server";
 
 export async function POST(req: NextRequest) {
   const session = await auth();
@@ -8,6 +9,13 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const { id, isPublished } = (await req.json()) as { id: string; isPublished: boolean };
-  await prisma.storefrontConfig.update({ where: { id }, data: { isPublished } });
+  const storefront = await prisma.storefrontConfig.update({
+    where: { id },
+    data: { isPublished },
+    select: { organizationId: true },
+  });
+  if (isPublished) {
+    await completeSetupStepFromEvidence(storefront.organizationId, "storefront");
+  }
   return NextResponse.json({ success: true });
 }

--- a/apps/web/components/storefront-admin/StorefrontDashboard.test.tsx
+++ b/apps/web/components/storefront-admin/StorefrontDashboard.test.tsx
@@ -1,10 +1,17 @@
 // @vitest-environment jsdom
 
-import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { StorefrontDashboard } from "./StorefrontDashboard";
 
+const refresh = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh }) }));
+
 afterEach(() => cleanup());
+beforeEach(() => {
+  refresh.mockClear();
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+});
 
 const baseConfig = {
   id: "sf-1",
@@ -46,5 +53,13 @@ describe("StorefrontDashboard publish CTA", () => {
     expect(screen.getByText(/your supporter hub is ready/i)).toBeTruthy();
     expect(screen.getByText(/publish it so supporters can find you/i)).toBeTruthy();
     expect(screen.queryByText(/customers can find you/i)).toBeNull();
+  });
+
+  it("refreshes the server shell after publishing so onboarding advances immediately", async () => {
+    render(<StorefrontDashboard config={{ ...baseConfig, isPublished: false }} counts={counts} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /publish now/i }));
+
+    await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
   });
 });

--- a/apps/web/components/storefront-admin/StorefrontDashboard.tsx
+++ b/apps/web/components/storefront-admin/StorefrontDashboard.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 
 type DashboardConfig = {
   id: string;
@@ -20,6 +21,7 @@ type Counts = { inquiries: number; bookings: number; orders: number; donations: 
 export function StorefrontDashboard({ config, counts }: { config: DashboardConfig; counts: Counts }) {
   const [published, setPublished] = useState(config.isPublished);
   const [toggling, setToggling] = useState(false);
+  const router = useRouter();
   const portalLabel = config.portalLabel ?? "storefront";
   const stakeholderLabel = (config.stakeholderLabel ?? "customers").toLowerCase();
 
@@ -31,7 +33,11 @@ export function StorefrontDashboard({ config, counts }: { config: DashboardConfi
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id: config.id, isPublished: !published }),
       });
-      if (res.ok) setPublished((p) => !p);
+      if (res.ok) {
+        const nextPublished = !published;
+        setPublished(nextPublished);
+        if (nextPublished) router.refresh();
+      }
     } finally {
       setToggling(false);
     }
@@ -76,7 +82,7 @@ export function StorefrontDashboard({ config, counts }: { config: DashboardConfi
           <button
             onClick={togglePublish}
             disabled={toggling}
-            className="bg-[var(--dpf-accent)] text-white"
+            className="bg-[var(--dpf-accent)] text-[var(--dpf-on-accent)]"
             style={{
               padding: "8px 18px",
               borderRadius: 6,
@@ -103,7 +109,9 @@ export function StorefrontDashboard({ config, counts }: { config: DashboardConfi
           View Live ↗
         </a>
         <button onClick={togglePublish} disabled={toggling}
-          className={published ? "bg-[var(--dpf-error)] text-white" : "bg-[var(--dpf-accent)] text-white"}
+          className={published
+            ? "bg-[var(--dpf-error)] text-[var(--dpf-on-accent)]"
+            : "bg-[var(--dpf-accent)] text-[var(--dpf-on-accent)]"}
           style={{ padding: "6px 14px", borderRadius: 6, border: "none", cursor: "pointer", fontSize: 13, fontWeight: 600 }}>
           {toggling ? "..." : published ? "Unpublish" : "Publish"}
         </button>

--- a/apps/web/lib/actions/setup-progress.test.ts
+++ b/apps/web/lib/actions/setup-progress.test.ts
@@ -114,8 +114,16 @@ describe("setup-progress", () => {
     it("blocks advancing past the storefront step until a StorefrontConfig exists", async () => {
       const mockProgress = {
         id: "test-id",
+        organizationId: "org-1",
         currentStep: "storefront",
-        steps: Object.fromEntries(SETUP_STEPS.map((s) => [s, "pending"])),
+        steps: Object.fromEntries(
+          SETUP_STEPS.map((step) => [
+            step,
+            SETUP_STEPS.indexOf(step) < SETUP_STEPS.indexOf("storefront")
+              ? "completed"
+              : "pending",
+          ]),
+        ),
         context: {},
       };
       (prisma.platformSetupProgress.findUniqueOrThrow as any).mockResolvedValue(mockProgress);
@@ -130,8 +138,16 @@ describe("setup-progress", () => {
     it("advances past the storefront step once a StorefrontConfig exists", async () => {
       const mockProgress = {
         id: "test-id",
+        organizationId: "org-1",
         currentStep: "storefront",
-        steps: Object.fromEntries(SETUP_STEPS.map((s) => [s, "pending"])),
+        steps: Object.fromEntries(
+          SETUP_STEPS.map((step) => [
+            step,
+            SETUP_STEPS.indexOf(step) < SETUP_STEPS.indexOf("storefront")
+              ? "completed"
+              : "pending",
+          ]),
+        ),
         context: {},
       };
       (prisma.platformSetupProgress.findUniqueOrThrow as any).mockResolvedValue(mockProgress);
@@ -143,6 +159,10 @@ describe("setup-progress", () => {
 
       await advanceStep("test-id");
 
+      expect(prisma.storefrontConfig.findFirst).toHaveBeenCalledWith({
+        where: { organizationId: "org-1" },
+        select: { id: true },
+      });
       expect(prisma.platformSetupProgress.update).toHaveBeenCalledWith({
         where: { id: "test-id" },
         data: expect.objectContaining({ currentStep: "platform-development" }),

--- a/apps/web/lib/actions/setup-progress.ts
+++ b/apps/web/lib/actions/setup-progress.ts
@@ -1,31 +1,12 @@
 "use server";
 
 import { prisma } from "@dpf/db";
-import { SETUP_STEPS, type SetupStep, type StepStatus, type SetupContext } from "./setup-constants";
-import { runSetupCompletionSeeds } from "@/lib/onboarding/setup-completion-seeds";
-
-/**
- * Runs once when initial setup completes: the shared seed chain in
- * setup-completion-seeds.ts (mission prompt, WWWD corpus, portfolio
- * decomposition BI-2D452667, market offer BI-4503E6B9, archetype supply,
- * risk posture + envelope). Fail-open and idempotent — onboarding completion
- * must never block on embedding/seeding errors, and the seeds are safe to
- * re-run. The boot backfill (backfill-org-wwwd-on-boot.ts) runs the same
- * chain for installs that completed setup before these seeders existed.
- */
-async function finalizeSetupCompletion(organizationId: string | null): Promise<void> {
-  try {
-    const orgId =
-      organizationId ??
-      (await prisma.organization.findFirst({ select: { id: true } }))?.id ??
-      null;
-    if (!orgId) return;
-
-    await runSetupCompletionSeeds(orgId);
-  } catch (err) {
-    console.warn("[setup] mission/WWWD seeding on completion failed (fail-open):", err);
-  }
-}
+import { SETUP_STEPS, type StepStatus, type SetupContext } from "./setup-constants";
+import {
+  projectSetupStepCompletion,
+  projectSetupStepResolution,
+} from "@/lib/onboarding/setup-progress-projection";
+import { finalizeSetupCompletion } from "@/lib/onboarding/setup-progress-service.server";
 
 const BOOTSTRAP_PLATFORM_ORG = {
   orgId: "ORG-PLATFORM",
@@ -90,9 +71,7 @@ export async function advanceStep(
     where: { id: progressId },
   });
 
-  const steps = progress.steps as Record<string, StepStatus>;
   const context = { ...(progress.context as SetupContext), ...contextUpdate };
-  const currentIdx = SETUP_STEPS.indexOf(progress.currentStep as SetupStep);
 
   // The storefront step is only "complete" once the storefront actually exists.
   // The setup overlay's Continue must not advance past it (to operating-hours /
@@ -101,28 +80,31 @@ export async function advanceStep(
   // embedded SetupWizard creates the config; until then, Continue is a no-op that
   // keeps the user on the storefront setup.
   if (progress.currentStep === "storefront") {
-    const storefront = await prisma.storefrontConfig.findFirst({ select: { id: true } });
+    const storefront = await prisma.storefrontConfig.findFirst({
+      where: progress.organizationId ? { organizationId: progress.organizationId } : undefined,
+      select: { id: true },
+    });
     if (!storefront) {
       return { ...progress, blocked: "storefront-required" as const };
     }
   }
 
-  steps[progress.currentStep] = "completed";
-
-  const nextIdx = currentIdx + 1;
-  const nextStep = nextIdx < SETUP_STEPS.length ? SETUP_STEPS[nextIdx] : null;
+  const projection = projectSetupStepCompletion({
+    completedStep: progress.currentStep as (typeof SETUP_STEPS)[number],
+    steps: progress.steps as Record<string, StepStatus>,
+  });
 
   const updated = await prisma.platformSetupProgress.update({
     where: { id: progressId },
     data: {
-      currentStep: nextStep ?? progress.currentStep,
-      steps,
+      currentStep: projection.currentStep,
+      steps: projection.steps,
       context,
-      ...(nextStep === null ? { completedAt: new Date() } : {}),
+      ...(projection.isComplete ? { completedAt: new Date() } : {}),
     },
   });
 
-  if (nextStep === null) await finalizeSetupCompletion(progress.organizationId);
+  if (projection.isComplete) await finalizeSetupCompletion(progress.organizationId);
   return updated;
 }
 
@@ -132,30 +114,31 @@ export async function skipStep(progressId: string) {
     where: { id: progressId },
   });
 
-  const steps = progress.steps as Record<string, StepStatus>;
   const context = progress.context as SetupContext;
-  const currentIdx = SETUP_STEPS.indexOf(progress.currentStep as SetupStep);
-
-  steps[progress.currentStep] = "skipped";
-  context.skippedSteps = [
-    ...(context.skippedSteps ?? []),
-    progress.currentStep,
-  ];
-
-  const nextIdx = currentIdx + 1;
-  const nextStep = nextIdx < SETUP_STEPS.length ? SETUP_STEPS[nextIdx] : null;
+  const projection = projectSetupStepResolution({
+    resolvedStep: progress.currentStep as (typeof SETUP_STEPS)[number],
+    resolution: "skipped",
+    steps: progress.steps as Record<string, StepStatus>,
+  });
+  const updatedContext = {
+    ...context,
+    skippedSteps: [
+      ...(context.skippedSteps ?? []),
+      progress.currentStep,
+    ],
+  };
 
   const updated = await prisma.platformSetupProgress.update({
     where: { id: progressId },
     data: {
-      currentStep: nextStep ?? progress.currentStep,
-      steps,
-      context,
-      ...(nextStep === null ? { completedAt: new Date() } : {}),
+      currentStep: projection.currentStep,
+      steps: projection.steps,
+      context: updatedContext,
+      ...(projection.isComplete ? { completedAt: new Date() } : {}),
     },
   });
 
-  if (nextStep === null) await finalizeSetupCompletion(progress.organizationId);
+  if (projection.isComplete) await finalizeSetupCompletion(progress.organizationId);
   return updated;
 }
 

--- a/apps/web/lib/onboarding/setup-progress-projection.test.ts
+++ b/apps/web/lib/onboarding/setup-progress-projection.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { SETUP_STEPS, type StepStatus } from "@/lib/actions/setup-constants";
+import { projectSetupStepCompletion } from "./setup-progress-projection";
+
+function pendingSteps(): Record<string, StepStatus> {
+  return Object.fromEntries(SETUP_STEPS.map((step) => [step, "pending"]));
+}
+
+describe("projectSetupStepCompletion", () => {
+  it("advances to the first remaining pending step", () => {
+    const result = projectSetupStepCompletion({
+      completedStep: "storefront",
+      steps: {
+        ...pendingSteps(),
+        "account-bootstrap": "completed",
+        "business-context": "completed",
+        "ai-providers": "completed",
+        branding: "completed",
+        "how-you-decide": "completed",
+        "operating-hours": "completed",
+      },
+    });
+
+    expect(result.steps.storefront).toBe("completed");
+    expect(result.currentStep).toBe("platform-development");
+    expect(result.isComplete).toBe(false);
+  });
+
+  it("records out-of-order evidence without skipping an earlier pending step", () => {
+    const result = projectSetupStepCompletion({
+      completedStep: "storefront",
+      steps: {
+        ...pendingSteps(),
+        "account-bootstrap": "completed",
+        "business-context": "completed",
+        "ai-providers": "completed",
+        branding: "completed",
+        "how-you-decide": "completed",
+      },
+    });
+
+    expect(result.steps.storefront).toBe("completed");
+    expect(result.currentStep).toBe("operating-hours");
+  });
+
+  it("is idempotent and reports completion only after every step is resolved", () => {
+    const resolved = Object.fromEntries(
+      SETUP_STEPS.map((step) => [step, step === "storefront" ? "pending" : "completed"]),
+    ) as Record<string, StepStatus>;
+
+    const first = projectSetupStepCompletion({ completedStep: "storefront", steps: resolved });
+    const second = projectSetupStepCompletion({ completedStep: "storefront", steps: first.steps });
+
+    expect(second).toEqual(first);
+    expect(second.currentStep).toBe("storefront");
+    expect(second.isComplete).toBe(true);
+  });
+});

--- a/apps/web/lib/onboarding/setup-progress-projection.ts
+++ b/apps/web/lib/onboarding/setup-progress-projection.ts
@@ -1,0 +1,53 @@
+import {
+  SETUP_STEPS,
+  type SetupStep,
+  type StepStatus,
+} from "@/lib/actions/setup-constants";
+
+type ProjectStepResolutionInput = {
+  resolvedStep: SetupStep;
+  resolution: Exclude<StepStatus, "pending">;
+  steps: Record<string, StepStatus>;
+};
+
+export type SetupProgressProjection = {
+  currentStep: SetupStep;
+  isComplete: boolean;
+  steps: Record<string, StepStatus>;
+};
+
+/**
+ * The legacy setup progress row is a projection of completed setup evidence.
+ * Always choose the first unresolved step so evidence arriving out of order can
+ * be retained without moving the operator past work they have not completed.
+ */
+export function projectSetupStepResolution({
+  resolvedStep,
+  resolution,
+  steps,
+}: ProjectStepResolutionInput): SetupProgressProjection {
+  const projectedSteps = { ...steps, [resolvedStep]: resolution };
+  const firstPending = SETUP_STEPS.find(
+    (step) => (projectedSteps[step] ?? "pending") === "pending",
+  );
+
+  return {
+    currentStep: firstPending ?? resolvedStep,
+    isComplete: firstPending === undefined,
+    steps: projectedSteps,
+  };
+}
+
+export function projectSetupStepCompletion({
+  completedStep,
+  steps,
+}: {
+  completedStep: SetupStep;
+  steps: Record<string, StepStatus>;
+}): SetupProgressProjection {
+  return projectSetupStepResolution({
+    resolvedStep: completedStep,
+    resolution: "completed",
+    steps,
+  });
+}

--- a/apps/web/lib/onboarding/setup-progress-service.server.test.ts
+++ b/apps/web/lib/onboarding/setup-progress-service.server.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SETUP_STEPS, type StepStatus } from "@/lib/actions/setup-constants";
+
+const mocks = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  update: vi.fn(),
+  runSetupCompletionSeeds: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    platformSetupProgress: {
+      findFirst: mocks.findFirst,
+      update: mocks.update,
+    },
+    organization: { findFirst: vi.fn() },
+  },
+}));
+vi.mock("./setup-completion-seeds", () => ({
+  runSetupCompletionSeeds: mocks.runSetupCompletionSeeds,
+}));
+
+import { completeSetupStepFromEvidence } from "./setup-progress-service.server";
+
+function pendingSteps(): Record<string, StepStatus> {
+  return Object.fromEntries(SETUP_STEPS.map((step) => [step, "pending"]));
+}
+
+describe("completeSetupStepFromEvidence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.update.mockImplementation(async ({ data }: { data: unknown }) => data);
+  });
+
+  it("records storefront evidence without skipping an earlier pending step", async () => {
+    mocks.findFirst.mockResolvedValue({
+      id: "progress-1",
+      organizationId: "org-1",
+      currentStep: "operating-hours",
+      completedAt: null,
+      steps: {
+        ...pendingSteps(),
+        "account-bootstrap": "completed",
+        "business-context": "completed",
+        "ai-providers": "completed",
+        branding: "completed",
+        "how-you-decide": "completed",
+      },
+    });
+
+    await completeSetupStepFromEvidence("org-1", "storefront");
+
+    expect(mocks.update).toHaveBeenCalledWith({
+      where: { id: "progress-1" },
+      data: expect.objectContaining({
+        currentStep: "operating-hours",
+        steps: expect.objectContaining({ storefront: "completed" }),
+      }),
+    });
+    expect(mocks.runSetupCompletionSeeds).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the evidence is already reflected", async () => {
+    mocks.findFirst.mockResolvedValue({
+      id: "progress-1",
+      organizationId: "org-1",
+      currentStep: "platform-development",
+      completedAt: null,
+      steps: {
+        ...pendingSteps(),
+        "account-bootstrap": "completed",
+        "business-context": "completed",
+        "ai-providers": "completed",
+        branding: "completed",
+        "how-you-decide": "completed",
+        "operating-hours": "completed",
+        storefront: "completed",
+      },
+    });
+
+    await completeSetupStepFromEvidence("org-1", "storefront");
+
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it("runs completion seeds only when the final pending step is resolved", async () => {
+    mocks.findFirst.mockResolvedValue({
+      id: "progress-1",
+      organizationId: "org-1",
+      currentStep: "workspace",
+      completedAt: null,
+      steps: Object.fromEntries(
+        SETUP_STEPS.map((step) => [step, step === "workspace" ? "pending" : "completed"]),
+      ),
+    });
+
+    await completeSetupStepFromEvidence("org-1", "workspace");
+
+    expect(mocks.update).toHaveBeenCalledWith({
+      where: { id: "progress-1" },
+      data: expect.objectContaining({ completedAt: expect.any(Date) }),
+    });
+    expect(mocks.runSetupCompletionSeeds).toHaveBeenCalledWith("org-1");
+  });
+});

--- a/apps/web/lib/onboarding/setup-progress-service.server.ts
+++ b/apps/web/lib/onboarding/setup-progress-service.server.ts
@@ -1,0 +1,67 @@
+import "server-only";
+
+import { prisma } from "@dpf/db";
+import type { SetupStep, StepStatus } from "@/lib/actions/setup-constants";
+import { projectSetupStepCompletion } from "./setup-progress-projection";
+import { runSetupCompletionSeeds } from "./setup-completion-seeds";
+
+/**
+ * Runs once when initial setup completes: the shared seed chain in
+ * setup-completion-seeds.ts (mission prompt, WWWD corpus, portfolio
+ * decomposition BI-2D452667, market offer BI-4503E6B9, archetype supply,
+ * risk posture + envelope). Fail-open and idempotent — onboarding completion
+ * must never block on embedding/seeding errors, and the seeds are safe to
+ * re-run. The boot backfill runs the same chain for older completed installs.
+ */
+export async function finalizeSetupCompletion(
+  organizationId: string | null,
+): Promise<void> {
+  try {
+    const orgId =
+      organizationId ??
+      (await prisma.organization.findFirst({ select: { id: true } }))?.id ??
+      null;
+    if (!orgId) return;
+
+    await runSetupCompletionSeeds(orgId);
+  } catch (error) {
+    console.warn("[setup] mission/WWWD seeding on completion failed (fail-open):", error);
+  }
+}
+
+/**
+ * Reconcile canonical domain evidence into the resumable setup projection.
+ * The transition is scoped, monotonic, idempotent, and safe when work arrives
+ * out of order; it never reopens a completed setup record.
+ */
+export async function completeSetupStepFromEvidence(
+  organizationId: string,
+  completedStep: SetupStep,
+) {
+  const progress = await prisma.platformSetupProgress.findFirst({
+    where: { organizationId, completedAt: null },
+    orderBy: { createdAt: "desc" },
+  });
+  if (!progress) return null;
+
+  const projection = projectSetupStepCompletion({
+    completedStep,
+    steps: progress.steps as Record<string, StepStatus>,
+  });
+  const alreadyProjected =
+    progress.currentStep === projection.currentStep &&
+    (progress.steps as Record<string, StepStatus>)[completedStep] === "completed";
+  if (alreadyProjected) return progress;
+
+  const updated = await prisma.platformSetupProgress.update({
+    where: { id: progress.id },
+    data: {
+      currentStep: projection.currentStep,
+      steps: projection.steps,
+      ...(projection.isComplete ? { completedAt: new Date() } : {}),
+    },
+  });
+
+  if (projection.isComplete) await finalizeSetupCompletion(organizationId);
+  return updated;
+}


### PR DESCRIPTION
## Summary

- project canonical storefront publication into resumable onboarding progress
- share one monotonic first-pending transition across overlay advance, skip, and external evidence
- refresh the server shell after publish so the overlay advances immediately

## Verification

- 32 focused tests passed
- web typecheck passed
- 47-guard pregate preflight passed
- exact-tree merged-code local CI passed (`cmt4jlbj201an01pj22taqsi1`)