### PR TITLE
fix(agents): load AGENTS.md by import, not by an inert pointer (BI-C6308D90)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
 # DPF — Pointer to AGENTS.md
 
-Read [/AGENTS.md](AGENTS.md) at the repo root before any work in this project. It is the canonical rulebook; tool-specific files in this repo are pointers to it.
+@AGENTS.md
+
+That import loads the canonical rulebook. Other tool files here are pointers to it.

--- a/docs/superpowers/specs/2026-07-24-agent-instruction-plane-split-and-ratchet-design.md
+++ b/docs/superpowers/specs/2026-07-24-agent-instruction-plane-split-and-ratchet-design.md
@@ -1,3 +1,9 @@
+---
+title: Agent instruction-plane split, discriminator reconciliation, and a re-accretion ratchet
+authoredAt: 2026-07-24
+status: active
+---
+
 # Agent instruction-plane split, discriminator reconciliation, and a re-accretion ratchet
 
 - **Backlog item:** BI-0020D511 — "Agent instruction-plane audit: 32k always-on preamble, and prose/code discriminator drift on load-bearing rules"
@@ -30,6 +36,8 @@ BI-0020D511 was scouted on a branch (`claude/feature-flags-modularity-d5725e`) t
 ### 1a. The always-on plane is *pointer-forced*, not harness-injected
 
 There is **no `SessionStart` hook that injects `AGENTS.md`** (`.claude/settings.json` `SessionStart` runs only `worktree-freshness`). `CLAUDE.md` is a **pointer**: *"Read /AGENTS.md at the repo root before any work."* In this very audit session, only `CLAUDE.md` (438 chars) was auto-loaded; `AGENTS.md` entered context because the agent *obeyed the pointer and read the whole file*.
+
+> **Correction, 2026-08-21 (BI-C6308D90).** The mechanism described in this section was compliance-dependent and it failed in practice: a markdown link in `CLAUDE.md` is inert prose, so whether `AGENTS.md` entered context depended on the model choosing to follow the pointer, and it silently stopped doing so. Claude Code auto-loads `CLAUDE.md` only, and 2.1.197 does not read `AGENTS.md` natively. `CLAUDE.md` now uses the harness's own import directive — a bare `@AGENTS.md` line — which inlines the rulebook deterministically at session start with no hook and no duplication. The rest of this section still holds: the pointer file remains the control point, and the manifest still measures whatever it forces.
 
 This is not a caveat — it is **the control point for the split.** The ~28k-token cost is incurred by a read the pointer *instructs*. If the pointer instructs the agent to read a small doctrine file always, and names the procedure/history files as *on-demand* reads, the split is enforced at the pointer with zero harness changes. The BI's "ALWAYS-ON, every thread" is true in effect but the mechanism is softer than "injected", and the softer mechanism is what makes the fix cheap.
 

--- a/scripts/process-spine-conformance.test.mjs
+++ b/scripts/process-spine-conformance.test.mjs
@@ -17,6 +17,19 @@ test("surface pointers reference AGENTS.md", () => {
   assert.match(claudeMd, /AGENTS\.md/);
 });
 
+// BI-C6308D90: a markdown link to AGENTS.md is inert prose — the harness auto-loads
+// CLAUDE.md only, and whether the rulebook entered context depended on the model
+// choosing to follow the pointer. It silently stopped. `@AGENTS.md` is the harness's
+// own import directive and inlines the rulebook deterministically; assert it stays.
+test("CLAUDE.md imports AGENTS.md rather than only linking to it", () => {
+  const claudeMd = readFileSync(join(repoRoot, "CLAUDE.md"), "utf8");
+  assert.match(
+    claudeMd,
+    /^@AGENTS\.md\s*$/m,
+    "CLAUDE.md must contain a bare `@AGENTS.md` import line — a markdown link does not load the rulebook",
+  );
+});
+
 test("plugin hooks.json wires uncommitted-work guard on SessionEnd and Stop", () => {
   const hooks = JSON.parse(
     readFileSync(join(repoRoot, "packages/dpf-skill-pack/hooks/hooks.json"), "utf8"),


### PR DESCRIPTION
## What

`CLAUDE.md` now loads the rulebook with the harness's own import directive — a bare `@AGENTS.md` line — instead of a markdown link that nothing acts on.

## Why

A markdown link in `CLAUDE.md` is inert prose. Claude Code auto-loads `CLAUDE.md` and nothing else, so whether `AGENTS.md` reached an agent's context depended on the model choosing to obey a sentence. It silently stopped doing so, and sessions have been running without the file that carries the branch/worktree rules (§3), the build gate (§4), and the consult-the-kernel-before-surfacing-a-menu rule (§11).

Evidence:

- This session's auto-loaded context contained `CLAUDE.md` and not `AGENTS.md`.
- `strings` over the installed Claude Code 2.1.197 binary names `AGENTS.md` only inside the `/init` prompt — the harness does not read it as a memory file — while the same binary documents `@path/to/import` as the directive that inlines a file into `CLAUDE.md`.
- The four `SessionStart` hooks (`worktree-freshness`, `mcp-health`, `janitor-throttle`, `reconcile-claude-plugin`) inject no doctrine.
- The design doc that established this mechanism said so itself: §1a of the instruction-plane spec records that `AGENTS.md` entered context "because the agent *obeyed the pointer and read the whole file*". That is a compliance mechanism, not a loading mechanism. It now carries a dated correction.

## Why this option

Routed through `principle_decide` (`DI-532F59D9108F`) against the BI's own candidate fix and the naive one:

| Option | Composite | |
|---|---|---|
| **`@AGENTS.md` import directive** | **15.59** | recommended, margin 5.69, confidence high |
| SessionStart hook emitting AGENTS.md as additionalContext | 9.90 | the BI's candidate — a script to maintain, and `additionalContext` is unproven on some hosts |
| Copy the rules into CLAUDE.md | 1.88 | a second copy of doctrine that drifts; violates single-source-of-truth |

No commandment conflict; autonomy-eligible. The import keeps `AGENTS.md` the single source — no duplication, no new script, no hook.

## Ratchet

`CLAUDE.md` shrinks 194 → 128 bytes, so the instruction-plane ratchet sees only a shrink (38,149 vs baseline 38,501). The rulebook was always meant to be in the always-on plane; this makes the manifest's measurement honest rather than aspirational.

## Verification

- `pnpm run pregate:preflight` — OK, 47 guards clean
- `node scripts/check-instruction-plane-size.mjs` — OK
- `node scripts/check-instruction-plane-rule-coverage.mjs` — OK, 42 anchors reachable
- `node --test scripts/process-spine-conformance.test.mjs` — 9/9, including the new test pinning the bare `@AGENTS.md` line so this cannot regress to a link
- `node scripts/gen-doc-index.mjs` — no diff

**Not verified, deliberately:** the import takes effect only in a *new* session, so it cannot be functionally proven from inside the session that made the change, and the headless CLI in this environment has no credentials to probe with. The mechanism is evidenced from the harness binary and its documented directive, not from a live reload.

## Scope left open

BI-C6308D90 also covers Codex, Grok and Antigravity. Codex reads `AGENTS.md` natively; the other two are unconfirmed. This PR fixes Claude Code only and the BI stays open for the cross-surface sweep.

## Overlap

#4473 also touches `scripts/process-spine-conformance.test.mjs`, at line ~113 and appending at the end; this change inserts at line ~17. Different regions, no conflict expected.

Backlog item: BI-C6308D90 · Workroom: WC-9B5241E7 · Decision: DI-532F59D9108F

🤖 Generated with [Claude Code](https://claude.com/claude-code)
