### PR TITLE
fix(self-upgrade): preserve consumer release context

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -38,7 +38,7 @@ vi.mock("@/lib/actions/promotions", () => ({
 // `shared.triggerResult` and try to render it. Stub the impact panel so the
 // trigger-control tests stay focused on this component's behavior.
 vi.mock("@/components/ops/UpgradeImpactPanel", () => ({
-  default: () => null,
+  default: ({ enabled }: { enabled: boolean }) => <div data-impact-enabled={enabled} />,
 }));
 
 import SelfUpgradeClient, { conciseFailureReason } from "./SelfUpgradeClient";
@@ -1004,7 +1004,7 @@ describe("Update-available banner — at-a-glance scope", () => {
       <SelfUpgradeClient {...baseStatus} isFresh={true} initialImpactSummary={okSummary} />,
     );
     expect(html).not.toContain('data-update-glance="true"');
-    expect(html).not.toContain('data-impact-scope-headline="available"');
+    expect(html).toContain('data-impact-enabled="false"');
   });
 
   it("omits the glance ribbon when the summary did not resolve", () => {

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -809,7 +809,7 @@ export default function SelfUpgradeClient({
         </div>
       )}
 
-      <UpgradeImpactPanel enabled={enabled} initialSummary={initialImpactSummary} />
+      <UpgradeImpactPanel enabled={enabled && !isFresh && Boolean(targetSha)} initialSummary={initialImpactSummary} />
 
       {enabled && !latestRun && (
         <div className="p-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] text-xs text-[var(--dpf-muted)]">

--- a/apps/web/lib/self-upgrade/owner-summary.test.ts
+++ b/apps/web/lib/self-upgrade/owner-summary.test.ts
@@ -82,6 +82,33 @@ describe("buildOwnerReleaseSummary", () => {
     expect(s.recommendedAction.label).toBe("No action needed");
   });
 
+  it("does not surface a stale no-target skip after release discovery proves the install is current", () => {
+    const sha = "f".repeat(40);
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        support: {
+          supported: true,
+          targetKind: "release-artifact",
+          reason: "enabled",
+          message: null,
+        },
+        isFresh: true,
+        targetSha: sha,
+        deployedSha: sha,
+        latestRun: {
+          status: "skipped",
+          reason: "no-target",
+          targetSha: null,
+        },
+      }),
+      NO_LOCAL_CHANGES,
+    );
+
+    expect(s.state).toBe("up-to-date");
+    expect(s.recommendedAction.detail).toBe("You're running the latest version. Nothing to install.");
+    expect(allCopy(s)).not.toContain("No target build could be resolved");
+  });
+
   it("reports update-available with a consequence/reversibility risk notice", () => {
     const s = buildOwnerReleaseSummary(
       baseInput({ isFresh: false, targetSha: "f".repeat(40) }),

--- a/apps/web/lib/self-upgrade/owner-summary.ts
+++ b/apps/web/lib/self-upgrade/owner-summary.ts
@@ -191,7 +191,12 @@ export function buildOwnerReleaseSummary(
       : null;
 
   // "Why nothing happened" copy for the routine no-op path (run skipped).
-  const skip = runStatus === "skipped" ? describeSkipReason(input.latestRun?.reason) : null;
+  // A resolved, fresh target is newer evidence than an older skipped run. Do
+  // not let a historical Git-era "no-target" result overwrite the current
+  // release-artifact verdict after a consumer install has recovered discovery.
+  const skip = runStatus === "skipped" && !input.isFresh
+    ? describeSkipReason(input.latestRun?.reason)
+    : null;
 
   // What's kept from the owner's own install.
   const localCount = localChanges.available ? localChanges.changes.length : 0;

--- a/apps/web/lib/self-upgrade/release-target.test.ts
+++ b/apps/web/lib/self-upgrade/release-target.test.ts
@@ -58,6 +58,27 @@ describe("consumer release target", () => {
     expect(context?.composeFiles).toEqual(["docker-compose.yml", "docker-compose.release.yml"]);
   });
 
+  it("projects host-absolute compose paths onto the candidate release asset root", () => {
+    const context = parseReleaseInstallContext({
+      state: {
+        installMode: "consumer",
+        imageTag: "v2026.08.22",
+        installPath: "D:\\DPF",
+        composeFiles: [
+          "D:\\DPF\\docker-compose.yml",
+          "D:\\DPF\\docker-compose.release.yml",
+        ],
+      },
+      markerMode: null,
+      env: { GHCR_OWNER: "opendigitalproductfactory" },
+    });
+
+    expect(context?.composeFiles).toEqual([
+      "docker-compose.yml",
+      "docker-compose.release.yml",
+    ]);
+  });
+
   it("keeps contributor and explicit local installs on the source strategy", () => {
     expect(resolveUpgradeStrategy("upstream", null)).toBe("source");
     expect(resolveUpgradeStrategy("local", {

--- a/apps/web/lib/self-upgrade/release-target.ts
+++ b/apps/web/lib/self-upgrade/release-target.ts
@@ -28,12 +28,23 @@ function releaseMode(value: unknown): "consumer" | "customer" | null {
   return value === "consumer" || value === "customer" ? value : null;
 }
 
+function releaseComposeFile(value: string): string | null {
+  const file = value.trim().replaceAll("\\", "/").split("/").filter(Boolean).at(-1) ?? "";
+  return /^docker-compose(?:\.[A-Za-z0-9-]+)?\.ya?ml$/.test(file) ? file : null;
+}
+
 function composeFiles(value: unknown, fallback?: string): string[] {
   const recorded = Array.isArray(value)
-    ? value.filter((entry): entry is string => typeof entry === "string" && Boolean(entry.trim())).map((entry) => entry.trim())
+    ? value
+        .filter((entry): entry is string => typeof entry === "string")
+        .map(releaseComposeFile)
+        .filter((entry): entry is string => Boolean(entry))
     : [];
   if (recorded.length > 0) return recorded;
-  return fallback?.split(/\s+/).filter(Boolean) ?? [];
+  return fallback
+    ?.split(/\s+/)
+    .map(releaseComposeFile)
+    .filter((entry): entry is string => Boolean(entry)) ?? [];
 }
 
 /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,6 +196,10 @@ services:
       # into the portal so sourceless installs remain classifiable even when a
       # legacy installer did not write a host .install-mode marker.
       DPF_IMAGE_TAG: ${DPF_IMAGE_TAG:-}
+      # Keep the registry namespace visible to the runtime as well as Compose.
+      # Consumer self-upgrade needs this identity to resolve and launch the
+      # immutable promoter image instead of falling back to the Git path.
+      GHCR_OWNER: ${GHCR_OWNER:-opendigitalproductfactory}
       DPF_ENVIRONMENT: production
       DPF_HOST_INSTALL_PATH: ${DPF_HOST_INSTALL_PATH:-}
       DPF_HOST_PLATFORM: ${DPF_HOST_PLATFORM:-}

--- a/scripts/check-compose-env-contract.mjs
+++ b/scripts/check-compose-env-contract.mjs
@@ -106,6 +106,25 @@ export function findComposeEnvViolations(rel, composeText, declaredKeys) {
   return out;
 }
 
+/**
+ * Release-image interpolation happens in the host Compose process, but the
+ * self-upgrade resolver runs inside portal. Keep that release identity on both
+ * sides of the container boundary or a consumer install is misclassified as a
+ * source checkout and falls back to Git.
+ */
+export function findReleaseRuntimeContextViolations(composeText) {
+  const portal = (composeText ?? "").match(
+    /^  portal:\r?\n([\s\S]*?)(?=^  [a-zA-Z0-9_-]+:\r?$)/m,
+  )?.[1] ?? "";
+  return /^      GHCR_OWNER: \$\{GHCR_OWNER:-opendigitalproductfactory\}$/m.test(portal)
+    ? []
+    : [{
+        where: "docker-compose.yml:portal.environment",
+        message:
+          "portal does not receive GHCR_OWNER, so a consumer release install cannot resolve its immutable self-upgrade target and falls back to Git",
+      }];
+}
+
 function main() {
   const root = join(dirname(fileURLToPath(import.meta.url)), "..");
   const envExample = join(root, ".env.example");
@@ -118,6 +137,9 @@ function main() {
     const file = join(root, rel);
     if (!existsSync(file)) continue;
     violations.push(...findComposeEnvViolations(rel, readFileSync(file, "utf8"), declared));
+    if (rel === "docker-compose.yml") {
+      violations.push(...findReleaseRuntimeContextViolations(readFileSync(file, "utf8")));
+    }
   }
 
   if (violations.length > 0) {

--- a/scripts/check-compose-env-contract.test.mjs
+++ b/scripts/check-compose-env-contract.test.mjs
@@ -5,6 +5,7 @@ import {
   hostPartOf,
   varRefs,
   findComposeEnvViolations,
+  findReleaseRuntimeContextViolations,
 } from "./check-compose-env-contract.mjs";
 
 test("hostPartOf keeps ${A:-B} colons out of the split", () => {
@@ -53,4 +54,22 @@ test("ignores named volumes and non-interpolated mounts", () => {
   const compose = "      - pgdata:/var/lib/postgresql/data\n      - ./local:/app";
   const v = findComposeEnvViolations("docker-compose.yml", compose, new Set());
   assert.equal(v.length, 0);
+});
+
+test("catches a portal that cannot see the registry owner used by release Compose", () => {
+  const broken = [
+    "services:",
+    "  portal:",
+    "    environment:",
+    "      DPF_IMAGE_TAG: ${DPF_IMAGE_TAG:-}",
+    "  postgres:",
+    "    image: postgres:16",
+  ].join("\n");
+  const valid = broken.replace(
+    "      DPF_IMAGE_TAG: ${DPF_IMAGE_TAG:-}",
+    "      DPF_IMAGE_TAG: ${DPF_IMAGE_TAG:-}\n      GHCR_OWNER: ${GHCR_OWNER:-opendigitalproductfactory}",
+  );
+
+  assert.match(findReleaseRuntimeContextViolations(broken)[0]?.message ?? "", /falls back to Git/);
+  assert.deepEqual(findReleaseRuntimeContextViolations(valid), []);
 });


### PR DESCRIPTION
## Outcome

Restores source-free consumer self-upgrade discovery and promotion by carrying the release registry identity into the running portal and projecting host-recorded Compose paths onto the immutable release-asset root.

## Root cause

- Compose used `GHCR_OWNER` to select release images but did not pass it into `portal`.
- `loadReleaseInstallContext()` therefore rejected an otherwise valid consumer install and the runtime fell back to the Git/source path.
- Windows installer state records absolute Compose paths; the release promoter needs candidate-asset-relative filenames.
- A recovered current release could still surface a stale historical `no-target` message and an irrelevant impact-summary panel.

## Changes

- pass `GHCR_OWNER` into the portal environment and enforce it in the existing Compose env contract gate;
- normalize Windows/POSIX host Compose paths to validated release-asset filenames;
- let current verified release evidence supersede stale `no-target` copy;
- suppress the advisory update-summary panel when no update exists.

## Verification

- 101 focused Vitest tests passed
- 9 Compose env-contract tests passed
- Compose env-contract checker passed
- web typecheck passed
- module-size and design-grounding guards passed
- exact-tree local CI passed: `cmt4kvqba02ms01pj0vndyjw0`
- live source-free `.2` portal remained healthy and changed from `Target: unknown` to verified target `fc51ddd842e4ecb53a2c4dced27e03865b79c5e4`
- canonical data preserved: 65 BacklogItem rows and 5 Epic rows

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md`
- Current code substrate reviewed: `apps/web/lib/self-upgrade/release-target.ts`, `apps/web/lib/actions/promotions.ts`, `apps/web/components/ops/SelfUpgradeClient.tsx`, and `docker-compose.yml`
- Source of truth: verified release install-state plus the immutable published release stamp
- Decision: preserve release-artifact identity across the host/container boundary and avoid presenting source-only diagnostics to source-free installs

Docs-Impact-Decision: Corrects release-context discovery and stale state presentation on the existing self-upgrade workflow; no user steps, controls, or documented behavior change.

