### PR TITLE
fix(self-upgrade): make the candidate promoter buildable by an N-1 caller

### DIFF
--- a/.github/workflows/self-upgrade-acceptance.yml
+++ b/.github/workflows/self-upgrade-acceptance.yml
@@ -73,6 +73,56 @@ jobs:
           mkdir -p "$DPF_N1_EVIDENCE" "$RUNNER_TEMP/dpf-state" "$RUNNER_TEMP/dpf-backups"
           printf '%s\n' "{\"candidateSha\":\"${GITHUB_SHA}\",\"candidateDigest\":\"${image_digest}\",\"contractDigest\":\"${contract_digest}\"}" > "$DPF_N1_EVIDENCE/artifact.json"
           echo "DPF_ACCEPTANCE_IMAGE=$image" >> "$GITHUB_ENV"
+      # BI-A04D61B9: the promoter build context is staged by the DEPLOYED (N-1)
+      # portal from a list baked into ITS image, while Dockerfile.promoter is
+      # candidate-owned. Building the candidate from the candidate's own context
+      # proves nothing about that pairing — which is the only pairing an actual
+      # upgrade uses. #4462 added one COPY and made every already-deployed portal
+      # unable to build the candidate at all (SUR-75DAF829). This step rebuilds
+      # the candidate promoter from a context staged by the PREVIOUS release's
+      # closure, and proves the resulting image still satisfies the readiness
+      # contract.
+      - name: Candidate promoter is buildable by an N-1 caller's staged context
+        run: |
+          git fetch --quiet origin main || true
+          base="$(git merge-base HEAD origin/main 2>/dev/null || git rev-parse HEAD^)"
+          echo "N-1 closure taken from $base"
+          git show "${base}:apps/web/lib/self-upgrade/promoter-build-context.ts" > "$RUNNER_TEMP/n1-context.ts"
+          node -e '
+            const fs = require("node:fs");
+            const source = fs.readFileSync(process.argv[1], "utf8");
+            const start = source.indexOf("PROMOTER_BUILD_CONTEXT_SOURCES");
+            const open = source.indexOf("[", source.indexOf("=", start));
+            const close = source.indexOf("]", open);
+            const entries = [...source.slice(open + 1, close).matchAll(/"([^"]+)"/g)].map(([, v]) => v);
+            if (entries.length === 0) { console.error("N-1 closure empty"); process.exit(1); }
+            process.stdout.write(entries.join("\n") + "\n");
+          ' "$RUNNER_TEMP/n1-context.ts" > "$RUNNER_TEMP/n1-sources.txt"
+          ctx="$RUNNER_TEMP/n1ctx"
+          rm -rf "$ctx"; mkdir -p "$ctx"
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            if [ ! -f "$file" ]; then
+              echo "::notice::$file was in the N-1 closure but not in the candidate tree — not staged"
+              continue
+            fi
+            mkdir -p "$ctx/$(dirname "$file")"
+            cp "$file" "$ctx/$file"
+          done < "$RUNNER_TEMP/n1-sources.txt"
+          cp Dockerfile.promoter "$ctx/Dockerfile.promoter"
+          echo "staged $(find "$ctx" -type f | wc -l) file(s) from the N-1 closure"
+          n1_image="dpf-promoter-n1ctx:${GITHUB_SHA}"
+          docker build -f "$ctx/Dockerfile.promoter" -t "$n1_image" "$ctx"
+          # Buildable is necessary but not sufficient: the image an N-1 caller
+          # produces must still satisfy every readiness-enforced requiredFile.
+          docker run --rm --entrypoint sh "$n1_image" -c '
+            missing=0
+            for f in $(node -e "const c=require(\"/app/promoter-contract.json\"); process.stdout.write((c.requiredFiles||[]).join(\" \"))"); do
+              if [ ! -r "$f" ]; then echo "MISSING required file: $f"; missing=1; fi
+            done
+            [ "$missing" -eq 0 ] || exit 1
+            echo "N-1-built promoter satisfies every contract requiredFile"
+          ' | tee "$DPF_N1_EVIDENCE/n1-context-build.txt"
       - name: Signed promotion rollback restores exact legacy state
         run: |
           node --test scripts/promote-install-state-rollback.test.mjs \

--- a/Dockerfile.promoter
+++ b/Dockerfile.promoter
@@ -13,29 +13,29 @@ COPY promoter-contract.json /app/promoter-contract.json
 # Copy Dockerfile for portal rebuilds (baked in at promoter build time)
 COPY Dockerfile /promoter/portal.Dockerfile
 
-# Copy promotion script
-COPY scripts/promote.sh /promoter/promote.sh
-COPY scripts/governed-teardown.mjs /promoter/governed-teardown.mjs
-COPY scripts/salvage-sweep.mjs /promoter/salvage-sweep.mjs
-COPY scripts/apply-runtime-capability-transition.mjs /promoter/apply-runtime-capability-transition.mjs
-COPY scripts/runtime-transition-authority.mjs /promoter/runtime-transition-authority.mjs
-COPY scripts/rotate-runtime-transition-secret.mjs /promoter/rotate-runtime-transition-secret.mjs
-COPY scripts/lib/transition-signing.mjs /promoter/lib/transition-signing.mjs
-COPY scripts/promoter-migration-envelope.mjs /promoter/promoter-migration-envelope.mjs
-COPY scripts/installer/validate-install-state.mjs /promoter/installer/validate-install-state.mjs
-COPY scripts/installer/migrate-install-state.mjs /promoter/installer/migrate-install-state.mjs
-COPY scripts/installer/resolve-host-identity.mjs /promoter/installer/resolve-host-identity.mjs
-COPY scripts/installer/install-state-transaction.mjs /promoter/installer/install-state-transaction.mjs
-COPY scripts/installer/install-release-assets.mjs /promoter/installer/install-release-assets.mjs
-COPY scripts/installer/install-state-lock-contract.json /promoter/installer/install-state-lock-contract.json
-COPY scripts/installer/install-state-schema-registry.mjs /promoter/installer/install-state-schema-registry.mjs
-COPY scripts/installer/install-state.schema.json /promoter/installer/install-state.schema.json
-COPY scripts/installer/install-state.v1.schema.json /promoter/installer/install-state.v1.schema.json
-COPY scripts/installer/install-state.v2.schema.json /promoter/installer/install-state.v2.schema.json
-COPY scripts/lib/resolve-capability-compose-profiles.mjs /promoter/lib/resolve-capability-compose-profiles.mjs
-COPY scripts/lib/govern-capability-compose-args.mjs /promoter/lib/govern-capability-compose-args.mjs
-COPY scripts/lib/capability-state-hash.mjs /promoter/lib/capability-state-hash.mjs
-COPY scripts/capability-service-catalog.generated.json /promoter/capability-service-catalog.generated.json
+# Copy the promoter's script closure as a DIRECTORY, never file-by-file.
+#
+# The build context is staged by the DEPLOYED (N-1) portal from a list baked
+# into its own image, while this Dockerfile is candidate-owned. Enumerating
+# files here meant that adding one COPY made the candidate unbuildable by every
+# already-deployed portal: the older caller cannot know to stage a file that did
+# not exist when it was built, and the upgrade that would teach it IS the
+# blocked upgrade. Live: SUR-75DAF829 died on
+# `"/scripts/installer/install-release-assets.mjs": not found` (BI-A04D61B9).
+#
+# Copying the directory inverts the ownership correctly: the CALLER decides the
+# contents (staging stays minimal - only the files in
+# PROMOTER_BUILD_CONTEXT_SOURCES are ever placed in the context, so docker still
+# never walks apps/packages/docs, preserving the SUR-BF75ED2A OOM fix), and the
+# candidate stops demanding files an older caller could not supply. Every
+# scripts/X COPY mapped to /promoter/X, so this is exactly equivalent for a
+# current-version caller.
+#
+# This is not "whatever happened to be staged": promoter-contract.json's
+# requiredFiles is checked at readiness, so a genuinely missing dependency is a
+# named, pre-quiescence refusal (`required_file_unreadable`) instead of an
+# opaque docker checksum error.
+COPY scripts/ /promoter/
 RUN chmod +x /promoter/promote.sh
 
 ENTRYPOINT ["/promoter/promote.sh"]

--- a/Dockerfile.promoter.dockerignore
+++ b/Dockerfile.promoter.dockerignore
@@ -19,7 +19,7 @@
 # Ignore the entire context first.
 **
 
-# Re-include only what Dockerfile.promoter COPYs.
+# Re-include only the staged promoter build closure.
 !promoter-contract.json
 !Dockerfile
 !Dockerfile.promoter

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8557,6 +8557,7 @@
         "step-4-verify-postgres-only-done-criteria",
         "if-it-fails-anyway-recovery",
         "failure-class-host-out-of-memory-candidate-build-enomem",
+        "failure-class-promoter-context-n1-a-new-copy-made-the-candidate-unbuildable",
         "failure-class-capability-state-stale-a-release-moved-the-capability-catalog",
         "failure-class-migration-unique-violation-p3018-23505",
         "references"

--- a/apps/web/lib/self-upgrade/promoter.test.ts
+++ b/apps/web/lib/self-upgrade/promoter.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { PROMOTER_BUILD_CONTEXT_FILES } from "./promoter-build-context";
+import { PROMOTER_BUILD_CONTEXT_FILES, PROMOTER_BUILD_CONTEXT_SOURCES } from "./promoter-build-context";
 import {
   buildPromoterCommand,
   buildCandidatePromoterImage,
@@ -32,11 +32,16 @@ const BASE = {
   healthUrl: "http://localhost:3000/api/health",
 };
 
-it("mechanically closes every Dockerfile.promoter COPY input through portal baking and JIT staging", () => {
+it("mechanically closes every staged promoter input through portal baking and JIT staging", () => {
+  // Keyed on the staged closure, not on Dockerfile.promoter's COPY lines:
+  // the Dockerfile copies `scripts/` as a directory so a candidate stays
+  // buildable by an already-deployed N-1 portal whose staged context predates a
+  // newly added file (BI-A04D61B9). PROMOTER_BUILD_CONTEXT_SOURCES is what
+  // enumerates the files, and it is what the portal must bake and the JIT
+  // recipe must stage.
   const root = resolve(__dirname, "../../../..");
-  const promoterDockerfile = readFileSync(join(root, "Dockerfile.promoter"), "utf8");
   const portalDockerfile = readFileSync(join(root, "Dockerfile"), "utf8");
-  const sources = [...promoterDockerfile.matchAll(/^COPY\s+(\S+)\s+\S+/gm)].map((match) => match[1]);
+  const sources = PROMOTER_BUILD_CONTEXT_SOURCES;
   for (const source of sources) {
     const baked = source === "promoter-contract.json" ? "/promoter/promoter-contract.json" : `/promoter/${source}`;
     expect(portalDockerfile, `portal image must bake ${source}`).toMatch(new RegExp(`^COPY\\s+${source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s+${baked.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "m"));

--- a/docs/runbooks/bet5-windows-self-upgrade.md
+++ b/docs/runbooks/bet5-windows-self-upgrade.md
@@ -205,6 +205,39 @@ let the next cron tick retry. The `build-failure-classifier` now labels this cla
 (environment), so the failure surfaces as retryable rather than the old generic
 `promoter-readiness-failed (unclassified)`.
 
+## Failure class: promoter-context-n1 (a new COPY made the candidate unbuildable)
+
+The candidate promoter build fails at **preflight**, before quiescence, with a docker checksum error
+naming a file that plainly exists in the candidate tree:
+
+```
+promoter-readiness-failed: promoter_candidate_build_failed: release-assets.mjs
+ERROR: failed to compute cache key: "/scripts/installer/install-release-assets.mjs": not found
+```
+
+Canonical case **SUR-75DAF829 (2026-08-22)**: the file existed in the candidate checkout *and* in the
+upgrade workspace, which is what makes this one confusing. It was missing from the **build context**.
+
+**Why.** The promoter's docker build context is staged by the **deployed (N-1) portal** from a file list
+baked into its own image, while `Dockerfile.promoter` is **candidate-owned**. A release that added one
+`COPY` therefore made its own candidate unbuildable by every already-deployed portal — the older caller
+cannot stage a file that did not exist when it was built, and the upgrade that would teach it is the
+blocked upgrade. Same self-wedging shape as the capability-catalog class above.
+
+**Fixed.** `Dockerfile.promoter` now copies `scripts/` as a **directory**, so the caller decides the
+contents and the candidate never demands a file an older caller could not supply. Staging is still
+minimal, so the SUR-BF75ED2A OOM fix is intact. A CI step rebuilds the candidate promoter from a context
+staged by the *previous* release's closure, so an N-1-unbuildable promoter change cannot merge again.
+
+**Diagnosing a recurrence.** Compare what the deployed portal stages against what the candidate needs:
+
+```bash
+docker exec dpf-portal-1 grep -c '^COPY' /promoter/Dockerfile.promoter   # what the deployed caller knows
+docker exec dpf-portal-1 ls -R /promoter/scripts                          # the files it can stage
+```
+
+**Recovery:** none needed — nothing was deployed. Upgrade to a build carrying the directory COPY.
+
 ## Failure class: capability-state-stale (a release moved the capability catalog)
 
 Promoter **readiness** refuses before quiescence with:

--- a/scripts/check-governed-teardown-contract.mjs
+++ b/scripts/check-governed-teardown-contract.mjs
@@ -4,6 +4,8 @@ import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { readPromoterBuildContextSources } from "./lib/promoter-build-context-sources.mjs";
+
 export function evaluateGovernedTeardownContract(input) {
   const findings = [];
   if (!/requireCapability\(\s*["']manage_platform["']\s*\)/.test(input.action)) findings.push("teardown actions must require manage_platform");
@@ -14,7 +16,12 @@ export function evaluateGovernedTeardownContract(input) {
   if (!/removeTreeContentsNoFollow/.test(input.runner)) findings.push("teardown runner must use no-follow source deletion");
   if (!/--project-name/.test(input.runner)) findings.push("teardown Docker mutation must remain project-scoped");
   if (!/teardown_evidence_inside_source/.test(input.runner)) findings.push("teardown runner must reject evidence nested inside source");
-  for (const [label, source] of [["promoter", input.dockerfile], ["portal", input.portalDockerfile]]) {
+  // The promoter's assets are decided by the STAGED CLOSURE, not by
+  // Dockerfile.promoter: that Dockerfile copies `scripts/` as a directory so a
+  // candidate stays buildable by an already-deployed N-1 portal (BI-A04D61B9),
+  // and so it no longer names individual files. The portal image still bakes
+  // them file-by-file, so it is still checked against its own Dockerfile.
+  for (const [label, source] of [["promoter", (input.promoterClosure ?? []).join("\n")], ["portal", input.portalDockerfile]]) {
     if (!/governed-teardown\.mjs/.test(source) || !/salvage-sweep\.mjs/.test(source)) findings.push(`${label} image must carry teardown and salvage runner assets`);
   }
   if (input.mcpSources.some((source) => /name\s*:\s*["'][^"']*teardown[^"']*["']/i.test(source))) findings.push("MCP teardown verbs are forbidden; human UI confirmation is required");
@@ -40,7 +47,7 @@ async function main() {
     action: await readFile(join(root, "apps/web/lib/actions/teardown.ts"), "utf8"),
     component: await readFile(join(root, "apps/web/components/ops/TeardownControl.tsx"), "utf8"),
     runner: await readFile(join(root, "scripts/governed-teardown.mjs"), "utf8"),
-    dockerfile: await readFile(join(root, "Dockerfile.promoter"), "utf8"),
+    promoterClosure: await readPromoterBuildContextSources(root),
     portalDockerfile: await readFile(join(root, "Dockerfile"), "utf8"),
     mcpSources: await collectMcpSources(join(root, "apps/web/lib/mcp/packs")),
   };

--- a/scripts/check-governed-teardown-contract.test.mjs
+++ b/scripts/check-governed-teardown-contract.test.mjs
@@ -7,7 +7,7 @@ const valid = {
   action: 'requireCapability("manage_platform"); runPostgresTrialRestore({ sourceBackupRunId: backup.runId });',
   component: 'mode: "pointer-hold" Press and hold Release to cancel',
   runner: 'timingSafeEqual removeTreeContentsNoFollow --project-name teardown_evidence_inside_source',
-  dockerfile: 'COPY scripts/governed-teardown.mjs /promoter/governed-teardown.mjs\nCOPY scripts/salvage-sweep.mjs /promoter/salvage-sweep.mjs',
+  promoterClosure: ['scripts/governed-teardown.mjs', 'scripts/salvage-sweep.mjs'],
   portalDockerfile: 'COPY scripts/governed-teardown.mjs /promoter/scripts/governed-teardown.mjs\nCOPY scripts/salvage-sweep.mjs /promoter/scripts/salvage-sweep.mjs',
   mcpSources: ['name: "request_self_upgrade"'],
 };

--- a/scripts/lib/promoter-build-context-sources.mjs
+++ b/scripts/lib/promoter-build-context-sources.mjs
@@ -1,0 +1,28 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * The promoter build closure — the files the CALLER stages into the promoter's
+ * docker build context — read from the one TypeScript source of truth,
+ * `apps/web/lib/self-upgrade/promoter-build-context.ts`.
+ *
+ * Guards live in .mjs and cannot import TypeScript, so they parse the exported
+ * array literal instead of re-declaring it. This list, NOT `Dockerfile.promoter`,
+ * is the closure's source of truth: the Dockerfile copies whole directories on
+ * purpose, so that a candidate stays buildable by an already-deployed (N-1)
+ * portal whose staged context predates a newly added file (BI-A04D61B9).
+ */
+export async function readPromoterBuildContextSources(repoRoot) {
+  const source = await readFile(
+    join(repoRoot, "apps", "web", "lib", "self-upgrade", "promoter-build-context.ts"),
+    "utf8",
+  );
+  const start = source.indexOf("PROMOTER_BUILD_CONTEXT_SOURCES");
+  if (start < 0) throw new Error("PROMOTER_BUILD_CONTEXT_SOURCES not found");
+  const open = source.indexOf("[", source.indexOf("=", start));
+  const close = source.indexOf("]", open);
+  if (open < 0 || close < open) throw new Error("PROMOTER_BUILD_CONTEXT_SOURCES array literal malformed");
+  const entries = [...source.slice(open + 1, close).matchAll(/"([^"]+)"/g)].map(([, value]) => value);
+  if (entries.length === 0) throw new Error("PROMOTER_BUILD_CONTEXT_SOURCES is empty");
+  return entries;
+}

--- a/scripts/lifecycle-surface-policy.test.mjs
+++ b/scripts/lifecycle-surface-policy.test.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import { activeLifecycleFiles, assertHostStateWiring, auditLifecycleSurfaces, formatAuditFailure, legacyExceptions, promoterCopyInputs } from "./lifecycle-surface-policy.mjs";
 import { classifySensitivePath } from "./self-upgrade-sensitive-paths.mjs";
+import { readPromoterBuildContextSources } from "./lib/promoter-build-context-sources.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -24,11 +25,19 @@ test("lifecycle inventory is exact and contains no duplicates", () => {
 });
 
 test("promoter COPY inputs are derived from its Dockerfile", async () => {
+  // Dockerfile.promoter copies `scripts/` as a directory so a candidate stays
+  // buildable by an already-deployed N-1 portal whose staged context predates a
+  // newly added file (BI-A04D61B9). The Dockerfile therefore names the
+  // directory; the staged closure names the files.
   const dockerfile = await readFile(resolve(root, "Dockerfile.promoter"), "utf8");
   const inputs = promoterCopyInputs(dockerfile);
-  assert.ok(inputs.includes("scripts/promote.sh"));
-  assert.ok(inputs.includes("scripts/installer/install-state.schema.json"));
+  assert.ok(inputs.includes("scripts/"), "the script closure must arrive as one directory COPY");
   assert.equal(new Set(inputs).size, inputs.length);
+
+  const staged = await readPromoterBuildContextSources(root);
+  assert.ok(staged.includes("scripts/promote.sh"));
+  assert.ok(staged.includes("scripts/installer/install-state.schema.json"));
+  assert.equal(new Set(staged).size, staged.length);
 });
 
 // CodeQL js/redos alert #372 (high): the COPY matcher used `[^ ]+` for flag

--- a/scripts/promoter-build-context.test.mjs
+++ b/scripts/promoter-build-context.test.mjs
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { access, readFile } from "node:fs/promises";
 import { dirname, join, posix, resolve } from "node:path";
 
+import { readPromoterBuildContextSources } from "./lib/promoter-build-context-sources.mjs";
+
 const root = resolve(dirname(new URL(import.meta.url).pathname.replace(/^\/(.:\/)/, "$1")), "..");
 const validatorAssets = [
   "scripts/installer/validate-install-state.mjs",
@@ -53,12 +55,47 @@ test("promoter COPY parser fails closed on forms the contract does not support",
 });
 
 test("promoter image contains the install-state validator at its import-resolved paths", async () => {
-  const dockerfile = await readFile(join(root, "Dockerfile.promoter"), "utf8");
+  const staged = new Set(await readPromoterBuildContextSources(root));
   for (const asset of validatorAssets) {
-    assert.ok(dockerfile.includes(`COPY ${asset} /promoter/installer/${posix.basename(asset)}`), asset);
+    assert.ok(staged.has(asset), `${asset} must be staged into the promoter context`);
     await access(join(root, asset));
   }
-  assert.match(dockerfile, /COPY scripts\/rotate-runtime-transition-secret\.mjs \/promoter\/rotate-runtime-transition-secret\.mjs/);
+  assert.ok(staged.has("scripts/rotate-runtime-transition-secret.mjs"));
+});
+
+test("Dockerfile.promoter never enumerates individual script files", async () => {
+  // The build context is staged by the DEPLOYED (N-1) portal from a list baked
+  // into ITS image, while this Dockerfile is candidate-owned. A per-file COPY
+  // therefore makes the candidate unbuildable by every already-deployed portal,
+  // because the older caller cannot stage a file that did not exist when it was
+  // built — and the upgrade that would teach it IS the blocked upgrade.
+  // Live: SUR-75DAF829 died on `install-release-assets.mjs: not found` after
+  // #4462 added one COPY. Copy directories; let the caller choose the contents.
+  const dockerfile = await readFile(join(root, "Dockerfile.promoter"), "utf8");
+  const enumerated = parseSimpleLocalCopySources(dockerfile)
+    .filter((source) => source.startsWith("scripts/") && !source.endsWith("/"));
+  assert.deepEqual(enumerated, [], "COPY scripts/<file> re-wedges every deployed install — copy the directory instead");
+});
+
+test("every staged source is covered by a Dockerfile.promoter COPY, and every contract requiredFile is staged", async () => {
+  const [dockerfile, contract, staged] = await Promise.all([
+    readFile(join(root, "Dockerfile.promoter"), "utf8"),
+    readFile(join(root, "promoter-contract.json"), "utf8").then(JSON.parse),
+    readPromoterBuildContextSources(root),
+  ]);
+  const copySources = parseSimpleLocalCopySources(dockerfile);
+  const covers = (source) => copySources.some((copy) => (copy.endsWith("/") ? source.startsWith(copy) : copy === source));
+  for (const source of staged) {
+    assert.ok(covers(source), `${source} is staged but no Dockerfile.promoter COPY brings it into the image`);
+  }
+  // Correctness does not rest on "whatever happened to be staged": readiness
+  // refuses on requiredFiles, so every hard dependency must be in the closure.
+  const stagedInImage = new Set(staged.map((source) => source.startsWith("scripts/")
+    ? `/promoter/${source.slice("scripts/".length)}`
+    : source === "Dockerfile" ? "/promoter/portal.Dockerfile" : "/app/promoter-contract.json"));
+  for (const required of contract.requiredFiles ?? []) {
+    assert.ok(stagedInImage.has(required), `contract requires ${required}, which nothing in the staged closure provides`);
+  }
 });
 
 test("portal and release images retain the validator's complete transitive asset set", async () => {
@@ -70,13 +107,12 @@ test("portal and release images retain the validator's complete transitive asset
   }
 });
 
-test("portal-baked JIT context includes every local Dockerfile.promoter COPY source", async () => {
-  const [promoterDockerfile, portalDockerfile, promoterSource] = await Promise.all([
-    readFile(join(root, "Dockerfile.promoter"), "utf8"),
+test("portal-baked JIT context includes every staged promoter closure source", async () => {
+  const [portalDockerfile, promoterSource, localCopySources] = await Promise.all([
     readFile(join(root, "Dockerfile"), "utf8"),
     readFile(join(root, "apps", "web", "lib", "self-upgrade", "promoter.ts"), "utf8"),
+    readPromoterBuildContextSources(root),
   ]);
-  const localCopySources = parseSimpleLocalCopySources(promoterDockerfile);
   const portalDockerfileLines = new Set(portalDockerfile.split(/\r?\n/).map((line) => line.trim()));
   const jitScriptSource = promoterSource.replaceAll('\\"', '"');
 
@@ -104,12 +140,9 @@ test("portal-baked JIT context includes every local Dockerfile.promoter COPY sou
   );
 });
 
-test("Dockerfile.promoter.dockerignore allowlist matches the promoter COPY sources exactly", async () => {
-  const [promoterDockerfile, dockerignore] = await Promise.all([
-    readFile(join(root, "Dockerfile.promoter"), "utf8"),
-    readFile(join(root, "Dockerfile.promoter.dockerignore"), "utf8"),
-  ]);
-  const copySources = new Set(parseSimpleLocalCopySources(promoterDockerfile));
+test("Dockerfile.promoter.dockerignore allowlist matches the staged promoter closure exactly", async () => {
+  const dockerignore = await readFile(join(root, "Dockerfile.promoter.dockerignore"), "utf8");
+  const copySources = new Set(await readPromoterBuildContextSources(root));
   const allowlisted = new Set(
     dockerignore
       .split(/\r?\n/)
@@ -133,20 +166,21 @@ test("Dockerfile.promoter.dockerignore allowlist matches the promoter COPY sourc
   }
 });
 
-test("shared PROMOTER_BUILD_CONTEXT_SOURCES equals Dockerfile.promoter's local COPY sources exactly", async () => {
+test("shared PROMOTER_BUILD_CONTEXT_SOURCES is a well-formed, present staged closure", async () => {
   const [promoterDockerfile, contextSource] = await Promise.all([
     readFile(join(root, "Dockerfile.promoter"), "utf8"),
     readFile(join(root, "apps", "web", "lib", "self-upgrade", "promoter-build-context.ts"), "utf8"),
   ]);
-  const copySources = parseSimpleLocalCopySources(promoterDockerfile);
   const shared = parseExportedStringArray(contextSource, "PROMOTER_BUILD_CONTEXT_SOURCES");
-
   assert.ok(shared.length > 0, "PROMOTER_BUILD_CONTEXT_SOURCES must not be empty");
   assert.deepEqual(
     [...shared].sort(),
-    [...copySources].sort(),
-    "the shared build-context source-of-truth must match Dockerfile.promoter's COPY sources exactly (no drift)",
+    [...new Set(shared)].sort(),
+    "the staged closure must not contain duplicates",
   );
+  // Every staged file must exist in the tree, or the candidate cannot build.
+  for (const source of shared) await access(join(root, source));
+  assert.ok(promoterDockerfile.includes("COPY scripts/ /promoter/"), "the Dockerfile must copy the script closure as a directory");
   // The Dockerfile that builds the image is not a COPY source but must also be
   // staged so `-f <ctx>/Dockerfile.promoter` resolves inside the minimal context.
   assert.ok(

--- a/scripts/promoter-contract.test.mjs
+++ b/scripts/promoter-contract.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { readPromoterBuildContextSources } from "./lib/promoter-build-context-sources.mjs";
 
 const root = resolve(new URL("..", import.meta.url).pathname.replace(/^\/(.:\/)/, "$1"));
 
@@ -69,12 +70,12 @@ test("portal-owned candidate builds have Buildx and cannot fall back to the lega
   );
 });
 
-test("every promoter Docker COPY input is mechanically closed by portal baking and JIT staging", async () => {
-  const [promoterDockerfile, portalDockerfile, promoterSource] = await Promise.all([
-    readFile(resolve(root, "Dockerfile.promoter"), "utf8"), readFile(resolve(root, "Dockerfile"), "utf8"),
+test("every staged promoter input is mechanically closed by portal baking and JIT staging", async () => {
+  const [portalDockerfile, promoterSource, sources] = await Promise.all([
+    readFile(resolve(root, "Dockerfile"), "utf8"),
     readFile(resolve(root, "apps/web/lib/self-upgrade/promoter.ts"), "utf8"),
+    readPromoterBuildContextSources(root),
   ]);
-  const sources = [...promoterDockerfile.matchAll(/^COPY\s+(\S+)\s+\S+/gm)].map((match) => match[1]);
   for (const source of sources) {
     const baked = source === "promoter-contract.json" ? "/promoter/promoter-contract.json" : `/promoter/${source}`;
     assert.match(portalDockerfile, new RegExp(`^COPY\\s+${escapeRegex(source)}\\s+${escapeRegex(baked)}$`, "m"), `portal image does not bake ${source}`);

--- a/scripts/promoter-state-mount-contract.test.mjs
+++ b/scripts/promoter-state-mount-contract.test.mjs
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { readPromoterBuildContextSources } from "./lib/promoter-build-context-sources.mjs";
+
 const root = resolve(import.meta.dirname, "..");
 const promoter = readFileSync(resolve(root, "apps/web/lib/self-upgrade/promoter.ts"), "utf8");
 const script = readFileSync(resolve(root, "scripts/promote.sh"), "utf8");
@@ -37,10 +39,13 @@ function assertNoHostStateNamespace(relative, source) {
   assert.doesNotMatch(executableSource, /\bDPF_STATE_DIR\b/, `${relative} must neither read nor write the host interpolation namespace`);
 }
 
-test("the complete promoter scripts closure never reads or writes host DPF_STATE_DIR", () => {
-  const dockerfile = readFileSync(resolve(root, "Dockerfile.promoter"), "utf8");
-  const copiedScripts = [...dockerfile.matchAll(/^COPY (scripts\/[^ ]+) /gm)].map((match) => match[1]);
-  assert.ok(copiedScripts.length > 0, "promoter closure must be discovered from Dockerfile.promoter");
+test("the complete promoter scripts closure never reads or writes host DPF_STATE_DIR", async () => {
+  // Discovered from the staged closure, not from Dockerfile.promoter: the
+  // Dockerfile copies `scripts/` as a directory so a candidate stays buildable
+  // by an already-deployed N-1 portal, so it no longer enumerates the files
+  // (BI-A04D61B9). The closure list is what decides which files ship.
+  const copiedScripts = (await readPromoterBuildContextSources(root)).filter((source) => source.startsWith("scripts/"));
+  assert.ok(copiedScripts.length > 0, "promoter closure must be discovered from the staged build context sources");
   for (const relative of copiedScripts) {
     const source = readFileSync(resolve(root, relative), "utf8");
     assertNoHostStateNamespace(relative, source);

--- a/scripts/self-upgrade-sensitive-paths.test.mjs
+++ b/scripts/self-upgrade-sensitive-paths.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+import { readPromoterBuildContextSources } from "./lib/promoter-build-context-sources.mjs";
 import {
   SELF_UPGRADE_SENSITIVE_PATH_RULES,
   classifySensitivePath,
@@ -50,11 +51,12 @@ test("lifecycle policy inventory fails closed when a path has no sensitive owner
 
 test("every file baked into the promoter image is self-upgrade sensitive", async () => {
   // The promoter image IS the upgrade mechanism, so its inputs are the exact set
-  // whose change can wedge an install. Deriving them from the Dockerfile means a
-  // newly baked file cannot silently escape the acceptance gate.
-  const dockerfile = await readFile(new URL("../Dockerfile.promoter", import.meta.url), "utf8");
-  const baked = [...dockerfile.matchAll(/^COPY\s+(\S+)\s+\S+\s*$/gm)].map(([, source]) => source);
-  assert.ok(baked.length >= 15, `expected the promoter closure, parsed ${baked.length} COPY inputs`);
+  // whose change can wedge an install. Deriving them from the staged closure
+  // means a newly baked file cannot silently escape the acceptance gate.
+  // (Dockerfile.promoter deliberately copies directories rather than files, so
+  // the closure — not the Dockerfile — is what enumerates them: BI-A04D61B9.)
+  const baked = await readPromoterBuildContextSources(new URL("..", import.meta.url).pathname);
+  assert.ok(baked.length >= 15, `expected the promoter closure, parsed ${baked.length} staged inputs`);
   assert.deepEqual(findUnownedLifecyclePaths(baked), [], "a file baked into the promoter image must trigger the self-upgrade acceptance gate");
 });
 
@@ -79,4 +81,9 @@ test("acceptance workflow is path-sensitive, nightly, least-privilege, bounded, 
   // capability check, which is why the gate could not see the wedge.
   assert.match(workflow, /Readiness migrates a v2 install carrying the previous catalog hash/);
   assert.match(workflow, /capabilityCatalogHash/);
+  // BI-A04D61B9: building the candidate from its OWN context proves nothing
+  // about the pairing an upgrade actually uses — an N-1 caller's staged context
+  // against a candidate-owned Dockerfile.
+  assert.match(workflow, /Candidate promoter is buildable by an N-1 caller's staged context/);
+  assert.match(workflow, /requiredFiles/);
 });


### PR DESCRIPTION
## The failure

`SUR-75DAF829` failed pre-quiescence with

```
promoter_candidate_build_failed
ERROR: failed to compute cache key: "/scripts/installer/install-release-assets.mjs": not found
```

on a file that plainly exists in the candidate tree. It was missing from the build **context**.

Found immediately after #4471 cleared the `capability_state_stale` wedge — the next failure in the same self-wedging class.

## Root cause

The promoter's docker build context is staged by the **deployed (N-1) portal** from a list baked into its own image, while `Dockerfile.promoter` is **candidate-owned**.

- The running portal bakes **21** COPY sources (`docker exec dpf-portal-1 grep -c '^COPY' /promoter/Dockerfile.promoter`).
- `main` needs **24**.
- #4462 added a `COPY` **and** its list entry together — self-consistent within that version, and unbuildable by every portal built before it.

An older caller cannot stage a file that did not exist when it was built, and the upgrade that would teach it is the blocked upgrade.

`promoter-build-context.test.mjs` asserts the list equals the Dockerfile's COPY sources — but only *within one version*. It cannot see the N-1 pairing, which is the only pairing an actual upgrade uses. The source comment claims the two "can't drift"; that is true same-version and false N-1.

## The fix

Every `scripts/X` COPY mapped to `/promoter/X`, so they collapse to one directory copy:

```dockerfile
COPY scripts/ /promoter/
```

That inverts the ownership correctly: the **caller** decides the contents, and the candidate stops demanding files an older caller could not supply. Staging is unchanged and still minimal — only `PROMOTER_BUILD_CONTEXT_SOURCES` is ever placed in the context, so docker still never walks `apps/packages/docs` and the SUR-BF75ED2A OOM fix is intact.

This is not "whatever happened to be staged". `promoter-contract.json`'s `requiredFiles` is checked at readiness, so a genuinely missing dependency is now a **named, pre-quiescence refusal** instead of an opaque docker checksum error — and a new guard asserts every `requiredFile` is in the closure.

The closure list, not the Dockerfile, becomes the source of truth for what ships. Guards that discovered the closure by parsing COPY lines now read it from the one place that declares it.

## Regression guard

A new acceptance step rebuilds the candidate promoter from a context staged by the **previous release's** closure and proves the resulting image still satisfies every contract `requiredFile`. That is the invariant #4462 violated and nothing could see.

## Verification

Against the **real deployed caller** — the pairing no same-version test exercises. Staging exactly the 21 sources the running `dpf-portal-1` bakes, then building each Dockerfile against them:

| Dockerfile | Result |
|---|---|
| pre-fix (enumerates files) | reproduces the exact live error |
| post-fix (directory COPY) | **builds** |

The N-1-built image carries every contract `requiredFile`, and returns `ready` / `migrationRequired: true` / schema 2 → 2 against the real `~/.dpf/install-state.json` — so the live install is unblocked end to end.

- `pregate:status` → **PASS** (evidence `cmt4kvuy51v3u01qwltwep7s4`)
- 47 preflight guards clean (three initially failed on this change and were resolved, not suppressed)
- promoter closure guards: 57 pass / 0 fail · `lib/self-upgrade`: 48 files, 641 tests passing

Scope routed through `principle_decide` → `both-plus-n1-build-guard`, high confidence, margin 0.980, no commandment conflict. Ledger `DI-13929ACF7119`.

BI-A04D61B9 · Workroom WC-8DC5A87A

🤖 Generated with [Claude Code](https://claude.com/claude-code)