### PR TITLE
fix(compliance): only report obligations that bind on this install

### DIFF
--- a/apps/web/lib/compliance/deadline-horizon-runner.test.ts
+++ b/apps/web/lib/compliance/deadline-horizon-runner.test.ts
@@ -9,6 +9,34 @@ import {
 import { DEADLINE_HORIZON_ADAPTER_KEY } from "./deadline-horizon-sweep";
 
 const NOW = new Date("2026-08-21T00:00:00.000Z");
+
+/** Minimal install context: a US software platform. */
+const CONTEXT = {
+  archetype: { archetypeId: "software-platform", name: "Software Platform", category: "software-platform" },
+  businessContext: { industry: "software", stateCode: "TX", handlesCardPayments: false },
+  regional: {
+    operatesIn: ["us"],
+    sellsTo: ["us"],
+    employsIn: ["us"],
+    dataResidency: ["us"],
+    archetype: "software-platform",
+    archetypeId: "software-platform",
+  },
+} as never;
+
+/** A regulation that binds on any US operating business. */
+const APPLIES = {
+  regulationId: "REG-X", name: "Applies", shortName: "X", jurisdiction: "US-federal",
+  industry: null, sourceType: "external", sourceUrl: null,
+  applicability: { basis: ["operating"], jurisdictions: ["us"] },
+};
+
+/** A regulation gated to an archetype this install is not. */
+const DOES_NOT_APPLY = {
+  regulationId: "REG-Y", name: "Elsewhere", shortName: "Y", jurisdiction: "US-state",
+  industry: "financial", sourceType: "external", sourceUrl: null,
+  applicability: { basis: ["operating"], jurisdictions: ["us"], archetypes: ["banking-financial-services"] },
+};
 const days = (n: number) => new Date(NOW.getTime() + n * 86_400_000);
 
 type Row = Record<string, unknown>;
@@ -72,10 +100,11 @@ describe("runDeadlineHorizonSweep", () => {
         frequency: "annual",
         reviewDate: days(12),
         status: "active",
+        regulation: APPLIES,
       }],
     });
 
-    const result = await runDeadlineHorizonSweep(db, { now: NOW, runKey: "20260821000000" });
+    const result = await runDeadlineHorizonSweep(db, { now: NOW, runKey: "20260821000000", context: CONTEXT });
 
     expect(result.stoppedBy).toBeNull();
     expect(result.findings).toHaveLength(1);
@@ -109,11 +138,12 @@ describe("runDeadlineHorizonSweep", () => {
         frequency: null,
         reviewDate: days(400), // pushed well beyond the horizon
         status: "active",
+        regulation: APPLIES,
       }],
       existingFindings: [{ findingKey: "stale-key", status: "open", reopenCount: 0 }],
     });
 
-    const result = await runDeadlineHorizonSweep(db, { now: NOW });
+    const result = await runDeadlineHorizonSweep(db, { now: NOW, context: CONTEXT });
 
     expect(result.findings).toEqual([]);
     expect(result.reconciled).toBe(1);
@@ -127,11 +157,55 @@ describe("runDeadlineHorizonSweep", () => {
       existingFindings: [{ findingKey: "stale-key", status: "open", reopenCount: 0 }],
     });
 
-    const result = await runDeadlineHorizonSweep(db, { now: NOW });
+    const result = await runDeadlineHorizonSweep(db, { now: NOW, context: CONTEXT });
 
     expect(result.stoppedBy?.kind).toBe("failure");
     // Resolving on an unread sweep would report compliance nobody observed.
     expect(result.reconciled).toBe(0);
     expect(updated).toEqual([]);
+  });
+});
+
+describe("applicability scoping, end to end", () => {
+  it("raises nothing for a regulation gated to another archetype", async () => {
+    // The live defect: this software-platform install was told its bank
+    // supervision filings were overdue, because the sweep read every seeded
+    // pack rather than the ones that bind on it.
+    const { db, created } = fakeDb({
+      obligations: [{
+        obligationId: "OBL-BANK",
+        title: "Bank supervision filing",
+        frequency: "annual",
+        reviewDate: days(-30),
+        status: "active",
+        regulation: DOES_NOT_APPLY,
+      }],
+    });
+
+    const result = await runDeadlineHorizonSweep(db, { now: NOW, context: CONTEXT });
+
+    expect(result.findings).toEqual([]);
+    expect(created).toEqual([]);
+    expect(result.scanned.obligationsOutOfScope).toBe(1);
+    // Read fine, nothing in scope — a clean sweep, not a failure.
+    expect(result.stoppedBy).toBeNull();
+  });
+
+  it("does not treat an unreadable regulation as applying by default", async () => {
+    const { db, created } = fakeDb({
+      obligations: [{
+        obligationId: "OBL-ORPHAN",
+        title: "Orphaned obligation",
+        frequency: "annual",
+        reviewDate: days(-30),
+        status: "active",
+        regulation: null,
+      }],
+    });
+
+    const result = await runDeadlineHorizonSweep(db, { now: NOW, context: CONTEXT });
+
+    expect(created).toEqual([]);
+    expect(result.scanned.obligationsOutOfScope).toBe(1);
   });
 });

--- a/apps/web/lib/compliance/deadline-horizon-runner.ts
+++ b/apps/web/lib/compliance/deadline-horizon-runner.ts
@@ -7,6 +7,12 @@
 // compliance sweep rather than a scanner.
 
 import { persistAssuranceFindings } from "@/lib/assurance/finding-persistence";
+import {
+  classifyRegulationForInstall,
+  resolveComplianceLibraryContext,
+  type ComplianceLibraryClient,
+  type ComplianceLibraryContext,
+} from "@/lib/compliance-library";
 import { OBLIGATION_ASSURANCE_WATCH_SHAPE_KEY } from "@/lib/work-management/work-shapes";
 import {
   DEADLINE_HORIZON_ADAPTER_KEY,
@@ -24,7 +30,12 @@ export const DEADLINE_HORIZON_SCOPE_ID = "organization";
 
 type FindManyDelegate = { findMany(args: unknown): Promise<unknown[]> };
 
-export type DeadlineHorizonDb = {
+/**
+ * The client this runner needs. It includes ComplianceLibraryClient because the
+ * sweep must know which regimes bind on THIS install — unless the caller passes
+ * a resolved `context`, which is how the tests avoid a database.
+ */
+export type DeadlineHorizonDb = Partial<ComplianceLibraryClient> & {
   obligation: FindManyDelegate;
   control: FindManyDelegate;
   licenseRequirementReference: FindManyDelegate;
@@ -50,14 +61,32 @@ export type DeadlineHorizonRunResult = DeadlineHorizonResult & {
  */
 export async function runDeadlineHorizonSweep(
   db: DeadlineHorizonDb,
-  options: { now: Date; horizonDays?: number; runKey?: string },
+  options: {
+    now: Date;
+    horizonDays?: number;
+    runKey?: string;
+    /** Test seam — production resolves this from the install. */
+    context?: ComplianceLibraryContext;
+  },
 ): Promise<DeadlineHorizonRunResult> {
   const horizonDays = options.horizonDays ?? DEFAULT_HORIZON_DAYS;
 
   const [obligations, controls, licenseReferences] = await Promise.all([
     db.obligation.findMany({
       where: { status: "active" },
-      select: { obligationId: true, title: true, frequency: true, reviewDate: true, status: true },
+      select: {
+        obligationId: true, title: true, frequency: true, reviewDate: true, status: true,
+        // Compliance packs seed unconditionally and are filtered at READ time.
+        // The sweep is a reader, so it must carry the regulation through and
+        // filter too — otherwise a software business is told its bank
+        // supervision filings are overdue.
+        regulation: {
+          select: {
+            regulationId: true, name: true, shortName: true, jurisdiction: true,
+            industry: true, sourceType: true, sourceUrl: true, applicability: true,
+          },
+        },
+      },
       orderBy: { reviewDate: "asc" },
       take: MAX_ROWS_PER_TABLE,
     }),
@@ -80,10 +109,24 @@ export async function runDeadlineHorizonSweep(
     }),
   ]);
 
+  // Resolve once for the whole run: the archetype, business context, and
+  // confirmed processing activities that decide which regimes bind here.
+  const context =
+    options.context ?? (await resolveComplianceLibraryContext(db as ComplianceLibraryClient));
+
+  const scopedObligations = (obligations as Array<Record<string, unknown>>).map((row) => {
+    const regulation = row.regulation as Parameters<typeof classifyRegulationForInstall>[0] | null;
+    // No regulation row is not "applies by default" — an obligation whose
+    // regulation cannot be read cannot be shown to bind, and defaulting it in
+    // would reintroduce exactly the noise this filter removes.
+    const scope = regulation ? classifyRegulationForInstall(regulation, context).scope : "reference";
+    return { ...row, appliesToInstall: scope === "applies" };
+  });
+
   const swept = sweepDeadlineHorizon({
     now: options.now,
     horizonDays,
-    obligations: obligations as never,
+    obligations: scopedObligations as never,
     controls: controls as never,
     licenseReferences: licenseReferences as never,
   });
@@ -104,6 +147,7 @@ export async function runDeadlineHorizonSweep(
       summary: {
         horizonDays: swept.horizonDays,
         scanned: swept.scanned,
+        installArchetype: context.archetype?.category ?? context.businessContext.industry ?? null,
         findings: swept.findings.length,
         stoppedBy: swept.stoppedBy,
         shape: `${OBLIGATION_ASSURANCE_WATCH_SHAPE_KEY}@1.0.0`,

--- a/apps/web/lib/compliance/deadline-horizon-sweep.test.ts
+++ b/apps/web/lib/compliance/deadline-horizon-sweep.test.ts
@@ -23,6 +23,7 @@ const obligation = (over: Partial<DeadlineHorizonInput["obligations"][number]> =
   frequency: "annual" as string | null,
   reviewDate: null as Date | null,
   status: "active",
+  appliesToInstall: true,
   ...over,
 });
 
@@ -284,5 +285,54 @@ describe("a frequency nothing can compute", () => {
       controls: [control({ reviewFrequency: null })],
     });
     expect(result.findings).toEqual([]);
+  });
+});
+
+// ── the live-install defect: obligations that do not bind on this business ───
+
+describe("obligations whose regulation does not apply to this install", () => {
+  it("are never findings, however overdue they look", () => {
+    // What this prevents, observed live: a software-platform install was told
+    // its bank supervision filings, its municipal water testing, and its UK
+    // premium-listing declaration were overdue. Compliance packs seed
+    // unconditionally and are filtered at READ time; the sweep is a reader and
+    // must filter too.
+    const result = sweepDeadlineHorizon({
+      ...empty,
+      obligations: [
+        obligation({ obligationId: "IN", reviewDate: days(-5) }),
+        obligation({ obligationId: "OUT", reviewDate: days(-5), appliesToInstall: false }),
+      ],
+    });
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].evidence.obligationId).toBe("IN");
+  });
+
+  it("counts what it skipped, so the number is visible rather than assumed", () => {
+    const result = sweepDeadlineHorizon({
+      ...empty,
+      obligations: [
+        obligation({ obligationId: "IN", reviewDate: days(1) }),
+        obligation({ obligationId: "OUT-1", frequency: "annual", appliesToInstall: false }),
+        obligation({ obligationId: "OUT-2", frequency: "annual", appliesToInstall: false }),
+      ],
+    });
+    expect(result.scanned.obligations).toBe(1);
+    expect(result.scanned.obligationsOutOfScope).toBe(2);
+  });
+
+  it("treats 'read fine, nothing in scope' as a clean sweep, not a failure", () => {
+    // The distinction matters: reporting this as a failure would train the
+    // operator to ignore the one signal that means the sweep is really broken.
+    const result = sweepDeadlineHorizon({
+      ...empty,
+      obligations: [obligation({ frequency: "annual", appliesToInstall: false })],
+    });
+    expect(result.findings).toEqual([]);
+    expect(result.stoppedBy).toBeNull();
+  });
+
+  it("still fails closed when it read nothing at all", () => {
+    expect(sweepDeadlineHorizon(empty).stoppedBy?.kind).toBe("failure");
   });
 });

--- a/apps/web/lib/compliance/deadline-horizon-sweep.ts
+++ b/apps/web/lib/compliance/deadline-horizon-sweep.ts
@@ -43,6 +43,21 @@ export type SweepObligation = {
   frequency: string | null;
   reviewDate: Date | null;
   status: string;
+  /**
+   * Whether the obligation's REGULATION actually applies to this install, as
+   * decided by classifyRegulationForInstall. Compliance packs are seeded
+   * unconditionally and filtered at read time, so an install carries every
+   * pack's obligations in its database whether or not they bind on it.
+   *
+   * Only "applies" is swept. This is not a refinement — without it the watch
+   * tells a software business its municipal water testing and its bank
+   * supervision filings are overdue, which is what it did on the live install
+   * before this field existed. "review" means the regulation MIGHT bind but a
+   * required detail was never captured; the honest work there is confirming
+   * scope, not chasing a due date, and raising a deadline finding pre-empts a
+   * decision the operator has not made.
+   */
+  appliesToInstall: boolean;
 };
 
 export type SweepControl = {
@@ -75,7 +90,13 @@ export type DeadlineHorizonResult = {
   findings: NormalizedAssuranceFinding[];
   /** Non-null when a declared stop condition ended the run early. */
   stoppedBy: { kind: "failure" | "budget"; reason: string } | null;
-  scanned: { obligations: number; controls: number; licenseReferences: number };
+  scanned: {
+    obligations: number;
+    /** Read, then skipped because the regulation does not bind on this install. */
+    obligationsOutOfScope: number;
+    controls: number;
+    licenseReferences: number;
+  };
   horizonDays: number;
 };
 
@@ -148,13 +169,18 @@ export function sweepDeadlineHorizon(input: DeadlineHorizonInput): DeadlineHoriz
   const horizonDays = input.horizonDays ?? DEFAULT_HORIZON_DAYS;
   const now = input.now;
   const horizonEnd = new Date(now.getTime() + horizonDays * DAY_MS);
+  const inScope = input.obligations.filter((o) => o.appliesToInstall);
   const scanned = {
-    obligations: input.obligations.length,
+    obligations: inScope.length,
+    obligationsOutOfScope: input.obligations.length - inScope.length,
     controls: input.controls.length,
     licenseReferences: input.licenseReferences.length,
   };
 
-  if (scanned.obligations + scanned.controls + scanned.licenseReferences === 0) {
+  // Read NOTHING at all — the substrate is empty or unreadable. A failure stop:
+  // an unread estate and a clear one look identical and are not the same.
+  const rowsRead = input.obligations.length + input.controls.length + input.licenseReferences.length;
+  if (rowsRead === 0) {
     return {
       findings: [],
       stoppedBy: {
@@ -168,11 +194,21 @@ export function sweepDeadlineHorizon(input: DeadlineHorizonInput): DeadlineHoriz
     };
   }
 
+  // Read fine, but nothing in scope. NOT a failure — this is the correct and
+  // common answer for an install whose archetype no seeded pack binds on, and
+  // the distinction matters: reporting it as a failure would train the operator
+  // to ignore the one signal that means the sweep is actually broken.
+  if (scanned.obligations + scanned.controls + scanned.licenseReferences === 0) {
+    return { findings: [], stoppedBy: null, scanned, horizonDays };
+  }
+
   const findings: NormalizedAssuranceFinding[] = [];
 
   // ── Obligation.frequency + reviewDate ──────────────────────────────────────
   for (const obligation of input.obligations) {
     if (obligation.status !== "active") continue;
+    // Out of scope for this install — never a finding. See `appliesToInstall`.
+    if (!obligation.appliesToInstall) continue;
     const cadence = classifyObligationFrequency(obligation.frequency);
     const cadenceDays = cadence.periodDays;
 

--- a/docs/user-guide/compliance/regulations-and-obligations.md
+++ b/docs/user-guide/compliance/regulations-and-obligations.md
@@ -82,9 +82,16 @@ controls when reviewing inactive history. The scope is retained in the URL.
 
 ### What it does
 
-The **obligation assurance watch** reads every active obligation's recorded
-review date and frequency and raises a finding on the assurance ledger for each
-one falling due. The coworker reviews what the sweep raised and reports it to you in plain
+The **obligation assurance watch** reads the recorded review date and frequency
+of every obligation **that applies to your business**, and raises a finding on
+the assurance ledger for each one falling due.
+
+That scoping matters more than it sounds. Compliance packs are loaded for every
+business type and then filtered to yours, so your database holds obligations
+from regimes that do not bind on you — bank supervision, municipal water
+testing, police training. The watch only ever reports the ones that apply. An
+obligation the platform cannot confirm applies to you is left alone: deciding
+whether a regime binds is your call, and a due-date reminder would pre-empt it. The coworker reviews what the sweep raised and reports it to you in plain
 language: what is overdue, oldest first, with the recorded owner; what
 falls due in the next 30 days; and — most important — any obligation that
 declares a recurrence with **no next date**.
@@ -142,7 +149,10 @@ thing.
   Accepting a lapse, deferring a review, or remediating it is your decision, and
   the platform requires an explicit governed decision to record it.
 - It does not read your regulator. It only reads what is recorded here, so an
-  obligation nobody entered is an obligation nobody is watching. **This is the
+  obligation nobody entered is an obligation nobody is watching.
+- It does not decide that a regime applies to you. Where applicability cannot be
+  confirmed from what you have recorded, the obligation shows as needing review
+  and the watch stays silent on its dates rather than assuming. **This is the
   biggest limit on the page.** Obligations arrive from a compliance pack matched
   to your business type, and today packs exist for 3 of the 25 business
   categories the platform supports. If yours is not one of them, this screen

--- a/packages/db/src/vertical-pack-applicability.test.ts
+++ b/packages/db/src/vertical-pack-applicability.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+
+import { parseApplicability, regulationApplies, type RegionProfile } from "./regulation-applicability";
+import { VERTICAL_RECURRING_REGULATIONS } from "./seed-vertical-recurring-compliance";
+import { PEOPLE_PREMISES_REGULATIONS } from "./seed-people-premises-compliance";
+import { INDUSTRIAL_VERTICAL_REGULATIONS } from "./seed-industrial-vertical-compliance";
+
+// Packs are seeded to EVERY install and filtered per-install. So the property
+// that matters is not "does my pack seed" — it always does — but "does it stay
+// out of the way of an install it does not bind on".
+//
+// The live defect this pins: a software-platform install carried 69 obligations
+// from regimes that do not apply to it, and the deadline watch reported them as
+// overdue because it never asked.
+
+const ALL = [
+  ...VERTICAL_RECURRING_REGULATIONS,
+  ...PEOPLE_PREMISES_REGULATIONS,
+  ...INDUSTRIAL_VERTICAL_REGULATIONS,
+];
+
+const profileFor = (archetype: string): RegionProfile => ({
+  operatesIn: ["us"],
+  sellsTo: ["us"],
+  employsIn: ["us"],
+  dataResidency: ["us"],
+  archetype,
+  archetypeId: archetype,
+});
+
+const appliesTo = (reg: (typeof ALL)[number], archetype: string) =>
+  regulationApplies(
+    parseApplicability(JSON.parse(JSON.stringify(reg.applicability)))!,
+    profileFor(archetype),
+  ).applies;
+
+describe("archetype packs stay out of the way of installs they do not bind on", () => {
+  it("reaches the archetypes it declares", () => {
+    for (const reg of ALL) {
+      const declared = parseApplicability(JSON.parse(JSON.stringify(reg.applicability)))!.archetypes ?? [];
+      for (const archetype of declared) {
+        expect(appliesTo(reg, archetype), `${reg.regulationId} must apply to ${archetype}`).toBe(true);
+      }
+    }
+  });
+
+  it("reaches NOTHING it does not declare", () => {
+    const everyDeclared = new Set(
+      ALL.flatMap((r) => parseApplicability(JSON.parse(JSON.stringify(r.applicability)))!.archetypes ?? []),
+    );
+    const leaks: string[] = [];
+    for (const reg of ALL) {
+      const declared = new Set(
+        parseApplicability(JSON.parse(JSON.stringify(reg.applicability)))!.archetypes ?? [],
+      );
+      for (const archetype of everyDeclared) {
+        if (declared.has(archetype)) continue;
+        if (appliesTo(reg, archetype)) leaks.push(`${reg.regulationId} -> ${archetype}`);
+      }
+    }
+    expect(leaks).toEqual([]);
+  });
+
+  it("keeps a software platform clear of every trade pack", () => {
+    // The concrete shape of the live defect, stated as its own case.
+    const reaching = ALL
+      .filter((reg) => appliesTo(reg, "software-platform"))
+      .map((reg) => reg.regulationId);
+    expect(reaching).toEqual(["REG-US-SOFTWARE-ASSURANCE-CYCLE"]);
+  });
+
+  it("keeps a restaurant clear of clinical, carrier and security packs", () => {
+    const reaching = ALL
+      .filter((reg) => appliesTo(reg, "food-hospitality"))
+      .map((reg) => reg.regulationId);
+    expect(reaching).toEqual(["REG-US-FOOD-SERVICE-OPS"]);
+  });
+});

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -74,6 +74,35 @@ if [[ $_readiness -eq 1 ]]; then
   elif ! _state_error="$(node "$_state_validator" "$_state_file" 2>&1 >/dev/null)"; then
     _readiness_fail install_state_invalid "$_state_error"
   fi
+  # Build-context completeness. The candidate promoter image is built FROM the
+  # host source tree, so every COPY source in Dockerfile.promoter must exist
+  # there. When one does not, BuildKit reports it as an opaque cache-key
+  # checksum failure naming a single path, hours after the useful moment:
+  #
+  #   promoter_candidate_build_failed: ... failed to compute cache key:
+  #   "/scripts/installer/install-release-assets.mjs": not found
+  #
+  # Observed on SUR-75DAF829 and SUR-0C221FD3 (2026-08-22). The file was present
+  # in git and absent from the host WORKING TREE, because the host install path
+  # was checked out to a feature branch 44 commits behind main that predated it.
+  # Nothing in that error says "your host tree is stale", which is the only
+  # thing the operator needed to know.
+  #
+  # This probe reads the COPY sources out of the candidate's own
+  # Dockerfile.promoter, so it stays correct as that file changes, and names
+  # EVERY missing path at once rather than the first one BuildKit trips over.
+  _promoter_dockerfile="${PROMOTE_SOURCE:-}/Dockerfile.promoter"
+  if [[ -n "${PROMOTE_SOURCE:-}" && -r "$_promoter_dockerfile" ]]; then
+    _missing_context=()
+    while IFS= read -r _copy_src; do
+      [[ -n "$_copy_src" ]] || continue
+      [[ -e "${PROMOTE_SOURCE}/${_copy_src}" ]] || _missing_context+=("$_copy_src")
+    done < <(awk '/^COPY /{ for (i = 2; i < NF; i++) if ($i !~ /^--/) print $i }' "$_promoter_dockerfile")
+    if [[ ${#_missing_context[@]} -gt 0 ]]; then
+      _readiness_fail promoter_build_context_incomplete \
+        "host source tree ${PROMOTE_SOURCE} is missing ${#_missing_context[@]} file(s) the promoter image COPYs: ${_missing_context[*]} - if these exist in git, the host install path is checked out to a stale branch or has an incomplete working tree"
+    fi
+  fi
   _profile_adapter="${PROMOTE_SOURCE:-}/scripts/lib/resolve-capability-compose-profiles.mjs"
   if [[ ! -f "$_profile_adapter" ]]; then
     _readiness_fail capability_projection_failed "candidate source has no profile adapter at $_profile_adapter"

--- a/scripts/promoter-readiness.test.mjs
+++ b/scripts/promoter-readiness.test.mjs
@@ -14,6 +14,7 @@ test("readiness contract is non-mutating and reports every required dependency",
     "state_mount_unreadable", "install_state_invalid",
     "capability_projection_failed", "compose_identity_missing",
     "recovery_parent_unavailable", "transition_secret_parent_unavailable",
+    "promoter_build_context_incomplete",
   ]) assert.match(block, new RegExp(code));
   assert.match(block, /"quiescenceBegan":false/);
   assert.match(block, /validate-install-state\.mjs.*\$_state_file/s);
@@ -22,4 +23,34 @@ test("readiness contract is non-mutating and reports every required dependency",
   assert.match(block, /docker --version/);
   assert.doesNotMatch(block, /-w "\$_state_dir"/);
   assert.doesNotMatch(block, /docker compose (?:down|up)|docker stop|docker rm|cp .*install-state/);
+});
+
+test("the build-context probe reads COPY sources from the candidate's own Dockerfile", async () => {
+  // Hard-coding the list would go stale the first time someone adds a COPY, and
+  // the failure mode of a stale list is silence — the probe would pass while the
+  // build fails on the file it did not know to check.
+  const script = await readFile(resolve(root, "scripts/promote.sh"), "utf8");
+  assert.match(script, /PROMOTE_SOURCE.*Dockerfile\.promoter/s);
+  assert.match(script, /awk .*\/\^COPY \//);
+  // It must name EVERY missing path, not stop at the first: BuildKit reports one
+  // per attempt, so a first-only probe just moves the guessing game.
+  assert.match(script, /_missing_context\[\*\]/);
+});
+
+test("the probe's COPY parser sees every COPY source in Dockerfile.promoter", async () => {
+  const dockerfile = await readFile(resolve(root, "Dockerfile.promoter"), "utf8");
+  // Mirror of the awk in promote.sh: every whitespace-separated argument of a
+  // COPY except the flags and the final destination.
+  const parsed = dockerfile
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("COPY "))
+    .flatMap((line) => line.split(/\s+/).slice(1, -1).filter((a) => !a.startsWith("--")));
+
+  assert.ok(parsed.length > 10, `expected the promoter to COPY many files, parsed ${parsed.length}`);
+  // The file whose absence produced the opaque BuildKit failure this probe exists for.
+  assert.ok(parsed.includes("scripts/installer/install-release-assets.mjs"));
+  for (const source of parsed) {
+    assert.doesNotMatch(source, /^--/, `flag leaked into COPY sources: ${source}`);
+    assert.doesNotMatch(source, /^\//, `destination leaked into COPY sources: ${source}`);
+  }
 });


### PR DESCRIPTION
Two fixes found by running the merged work against the live install rather than fixtures.

Docs-Impact-Decision: docs-updated — `docs/user-guide/compliance/regulations-and-obligations.md` now states that the watch only reports obligations that apply to your business, and what it does when applicability cannot be confirmed.

## 1 · The watch was reporting obligations that do not bind on this install

Compliance packs are seeded **unconditionally** and filtered at **read** time by
`classifyRegulationForInstall`. Every reader has to filter. The deadline sweep is a reader and did
not — it queried `status: "active"` and swept every pack the install had ever been seeded.

Measured on the live install, which is `software-platform`:

```
obligations by scope   applies 53 · reference 69
findings before        53      ← what is live today
findings after         27
out-of-scope skipped   69
regimes dropped        BSA/AML · Bank Supervision · Co-op Governance · FedRAMP · GLBA
                       HIPAA · Municipal Finance · NCUA · NPDES · POST · SDWA
                       Subchapter T · UK Corp Gov Code
```

A software business was being told its bank supervision filings, HIPAA obligations, municipal water
testing and police officer training were overdue. With the frequency-semantics fix in #4445 that is
**141 → 27**: 114 of the original findings were noise.

This is the same defect I flagged in a seed pack in #4445, in my own reader — and worse there. A
pack reaching the wrong install shows on a screen an operator can dismiss; the sweep writes it to
the assurance ledger as an open finding addressed to someone.

Three deliberate choices:

- **Only `applies` is swept.** `review` — the regime might bind but a required detail was never
  captured — is *not* swept. The honest work there is confirming scope, and a due-date finding would
  pre-empt a decision the operator has not made.
- **An unreadable regulation is out of scope, never applying by default.** Defaulting in would
  reintroduce exactly the noise this removes.
- **"Read fine, nothing in scope" is a clean sweep, not a failure stop.** Reporting it as a failure
  would train the operator to ignore the one signal that means the sweep is genuinely broken.

Per-archetype isolation of the new packs is now pinned exhaustively: every declared archetype is
reached, no undeclared one is, and the two concrete shapes are stated on their own — a software
platform sees only the software assurance pack, a restaurant only food service.

## 2 · The promoter names the stale host tree instead of a BuildKit checksum error

Two upgrades failed today with:

```
promoter_candidate_build_failed: ... failed to compute cache key:
"/scripts/installer/install-release-assets.mjs": not found
```

The file is present in git and absent from the host **working tree**: the host install path is
checked out to a feature branch 44 commits behind main that predates it. The promoter image builds
*from* that tree, so every COPY source has to exist there — and nothing in that error says "your
host tree is stale", which is the only thing the operator needed to know.

Readiness now checks the build context before the build, reading COPY sources from the candidate's
own `Dockerfile.promoter` rather than a hard-coded list — a stale list fails silently, passing while
the build dies on the file it did not know to check.

It names **every** missing path at once. BuildKit reports one per attempt; on the real host tree
there are **three** (`governed-teardown.mjs`, `salvage-sweep.mjs`, `install-release-assets.mjs`), so
the operator would have fixed one and hit the next two. Verified against that tree and against a
complete one, which reports zero.

Same lesson as the `capability_projection_failed` detail plumbing directly above it in
`promote.sh`: a bare failure code costs hours of live diagnosis.

## Note

This does not fix the stale host tree itself — that is an operator action on a working clone other
sessions may be using. It makes the next occurrence self-diagnosing.

Local gate: `pregate:status` = **PASS** for `ca529c6cd10b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
