### PR TITLE
fix(decision): an unrecorded verdict is unmeasured, never zero (BI-3217C098)

### DIFF
--- a/apps/web/components/platform/BandTelemetryPanel.tsx
+++ b/apps/web/components/platform/BandTelemetryPanel.tsx
@@ -41,12 +41,15 @@ export function BandTelemetryPanel({ telemetry }: { telemetry: BandTelemetry }) 
         </h2>
         <p className="text-xs text-[var(--dpf-muted)]">
           {telemetry.scored} of {telemetry.total} decisions carried a margin
+          {telemetry.classified < telemetry.total
+            ? `, ${telemetry.classified} a verdict`
+            : ""}
         </p>
       </div>
 
       <p className="mt-1 text-sm text-[var(--dpf-muted)]">
         {share == null
-          ? "Not enough decisions to read a distribution yet."
+          ? "No decision here carries a verdict yet, so the band cannot be measured. Decisions recorded before the three bands existed cannot be classified after the fact — this reads as unmeasured, never as zero."
           : `${Math.round(share * 100)}% landed in the uncertain band. Tuning is working when this falls because decisions separate — not because the bar moved.`}
       </p>
 

--- a/apps/web/lib/decision/band-telemetry.test.ts
+++ b/apps/web/lib/decision/band-telemetry.test.ts
@@ -98,3 +98,38 @@ describe("BI-3217C098 — narrowing the bar is not improvement", () => {
     expect(isBetterTuned(before, after).improved).toBe(false);
   });
 });
+
+describe("BI-3217C098 — an unrecorded verdict is unmeasured, never zero", () => {
+  it("reports null rather than 0% when no decision carries a verdict", () => {
+    // Every row written before the three bands existed looks like this.
+    // Dividing by all rows rendered that absence as a flattering 0% — the
+    // instrument committing the exact failure it exists to catch.
+    const t = computeBandTelemetry([
+      row({ verdict: null, margin: 0.5 }),
+      row({ verdict: null, margin: 0.1 }),
+    ]);
+    expect(t.classified).toBe(0);
+    expect(t.uncertainShare).toBeNull();
+  });
+
+  it("measures the share over classified rows only, ignoring unclassifiable history", () => {
+    const t = computeBandTelemetry([
+      row({ verdict: null, margin: 0.5 }),
+      row({ verdict: null, margin: 0.5 }),
+      row({ verdict: "uncertain", margin: 0.05 }),
+      row({ verdict: "proceed", margin: 0.6 }),
+    ]);
+    expect(t.classified).toBe(2);
+    // 1 of the 2 classified, not 1 of 4.
+    expect(t.uncertainShare).toBe(0.5);
+  });
+
+  it("still counts every row in the histogram — a margin is readable even when a verdict is not", () => {
+    const t = computeBandTelemetry([
+      row({ verdict: null, margin: 0.5 }),
+      row({ verdict: "proceed", margin: 0.6 }),
+    ]);
+    expect(t.scored).toBe(2);
+    expect(t.total).toBe(2);
+  });
+});

--- a/apps/web/lib/decision/band-telemetry.ts
+++ b/apps/web/lib/decision/band-telemetry.ts
@@ -55,8 +55,18 @@ export interface BandReversal {
 
 export interface BandTelemetry {
   buckets: HistogramBucket[];
-  /** Share of decisions that landed in the uncertain band. The number to drive down. */
+  /**
+   * Share of CLASSIFIED decisions that landed in the uncertain band — the
+   * number to drive down. Null when nothing carried a verdict.
+   */
   uncertainShare: number | null;
+  /**
+   * Rows that carried a verdict at all. Decisions recorded before the three
+   * bands existed carry none, and dividing by every row would render that
+   * absence as a flattering 0% — the exact failure this instrument exists to
+   * catch, committed by the instrument itself.
+   */
+  classified: number;
   reversals: BandReversal[];
   /** Rows the histogram could use (a margin was recorded). */
   scored: number;
@@ -136,11 +146,13 @@ export function computeBandTelemetry(
     buckets[index]!.count += 1;
   }
 
-  const uncertainCount = rows.filter((r) => r.verdict === "uncertain").length;
+  const classified = rows.filter((r) => r.verdict != null);
+  const uncertainCount = classified.filter((r) => r.verdict === "uncertain").length;
 
   return {
     buckets,
-    uncertainShare: rows.length === 0 ? null : uncertainCount / rows.length,
+    classified: classified.length,
+    uncertainShare: classified.length === 0 ? null : uncertainCount / classified.length,
     reversals: (["proceed", "decline", "uncertain"] as const).map((v) => reversalFor(v, rows)),
     scored: scored.length,
     total: rows.length,

--- a/docs/user-guide/ai-workforce/index.md
+++ b/docs/user-guide/ai-workforce/index.md
@@ -238,7 +238,9 @@ has no recorded human choice to compare against, the table says **no call could 
 rather than counting it as agreement.
 
 A thin sample is labelled as one: the panel states how many decisions carried a margin, so a
-tidy-looking chart over a handful of rows is not mistaken for a settled picture.
+tidy-looking chart over a handful of rows is not mistaken for a settled picture. Decisions taken
+before the three bands existed cannot be classified after the fact, and the panel says so rather
+than counting them as settled — an unmeasured band reads as unmeasured, never as zero.
 
 ## Living Playbook experiments
 


### PR DESCRIPTION
Found auditing my own delivery from #4447, before anyone read a number off it.

## The defect

Every decision recorded before the three bands existed carries `verdict: null` — the field did not exist. `uncertainShare` divided by **all** rows, so on the live corpus the panel would have rendered:

> **0% landed in the uncertain band.** Tuning is working when this falls…

A perfect score that actually meant *"we never recorded it."*

That is absence rendering as a value: the exact failure this instrument was built to catch, committed by the instrument itself. It is also the worst possible timing — it would have looked like success on day one and quietly poisoned the baseline every later reading was compared against, which is precisely the "narrowing the bar looks like separation" trap the spec spends a section refusing.

## The fix

- `uncertainShare` is computed over **classified** rows only, and is `null` when none carry a verdict.
- `classified` is reported alongside `scored` and `total`, so the panel can say how much of the corpus it could actually read.
- With nothing classified the panel says the band **cannot be measured** — and says why: decisions taken before the bands existed cannot be classified after the fact.
- Histogram behaviour is unchanged. A margin is readable even where a verdict is not, so the distribution still uses every scored row.

Three tests pin *unmeasured ≠ zero*, including one asserting the share is taken over the classified subset (1 of 2) rather than the whole population (1 of 4).

The user-guide section gains the same distinction, so the operator reading the panel is told what an empty band means rather than inferring it.

Also in this branch: the worktree's Prisma client was stale after rebasing onto newer `main` (`externalChannelProjection` unresolvable), regenerated so the typecheck reflects the real schema rather than a cached one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
