### PR TITLE
feat(work-posture): derive proactivity and priority from work shape, stream and the clock

### DIFF
--- a/apps/web/lib/work-posture/derive.test.ts
+++ b/apps/web/lib/work-posture/derive.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  activityKindBiasFor,
+  deriveStreamBiases,
+  deriveTemporalBias,
+  modeBiasFor,
+  shapeBiasFor,
+} from "./derive";
+import { TEMPORAL_BANDS } from "./temporal-band";
+
+// The trap this file guards: `proactivityLevel` can only ever RAISE cadence
+// (tighten.ts), so any bias that intends "be quieter" must express it as
+// `damp`. A table entry that sets `proactivityLevel: "quiet"` compiles, reads
+// naturally, and does nothing — the exact shape of dead control this epic
+// exists to remove from the platform.
+
+const ALL_SHAPE_KEYS = [
+  "change-consequential",
+  "approval-sign-off",
+  "outward-review",
+  "escalation",
+  "specialist-alignment",
+  "craft-stewardship",
+];
+
+const ALL_ACTIVITY_KINDS = [
+  "remediation",
+  "governance",
+  "launch-readiness",
+  "craft-judgment",
+];
+
+describe("derivation tables have no inert entries", () => {
+  it("no shape bias expresses quiet as a proactivity level", () => {
+    for (const key of ALL_SHAPE_KEYS) {
+      const bias = shapeBiasFor(key);
+      expect(bias, `${key} should resolve a bias`).not.toBeNull();
+      expect(
+        bias!.proactivityLevel,
+        `${key} sets proactivityLevel "quiet", which the tighten-only clamps ignore — use damp instead`,
+      ).not.toBe("quiet");
+    }
+  });
+
+  it("no activity-kind bias expresses quiet as a proactivity level", () => {
+    for (const kind of ALL_ACTIVITY_KINDS) {
+      const bias = activityKindBiasFor(kind);
+      expect(bias).not.toBeNull();
+      expect(bias!.proactivityLevel).not.toBe("quiet");
+    }
+  });
+
+  it("no temporal bias expresses quiet as a proactivity level", () => {
+    for (const band of TEMPORAL_BANDS) {
+      const bias = deriveTemporalBias(band);
+      if (bias) expect(bias.proactivityLevel).not.toBe("quiet");
+    }
+  });
+
+  it("every declared bias carries a stable reason code and a reason", () => {
+    const biases = [
+      ...ALL_SHAPE_KEYS.map((k) => shapeBiasFor(k)!),
+      ...ALL_ACTIVITY_KINDS.map((k) => activityKindBiasFor(k)!),
+      ...TEMPORAL_BANDS.map((b) => deriveTemporalBias(b)).filter((b) => b !== null),
+      ...deriveStreamBiases({
+        demandSignature: "emergency-reactive",
+        capacityUnit: "slot-hours",
+        loadBearingStageKeys: ["deliver"],
+        stageKey: "deliver",
+        trustGates: ["identity-verified"],
+      }),
+      modeBiasFor("standing", false)!,
+    ];
+    for (const bias of biases) {
+      expect(bias.reasonCode).toMatch(/^[a-z0-9_]+$/);
+      expect(bias.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every declared bias actually changes something", () => {
+    for (const key of ALL_SHAPE_KEYS) {
+      const bias = shapeBiasFor(key)!;
+      const hasEffect =
+        bias.proactivityLevel !== undefined ||
+        bias.actionBoundary !== undefined ||
+        bias.minimumTier !== undefined ||
+        bias.verificationDepth !== undefined ||
+        bias.priorityAxis !== undefined ||
+        bias.damp === true;
+      expect(hasEffect, `${key} declares a bias with no effect`).toBe(true);
+    }
+  });
+});
+
+describe("stream derivation", () => {
+  it("returns nothing for an absent or steady stream", () => {
+    expect(deriveStreamBiases(null)).toEqual([]);
+    expect(deriveStreamBiases({ demandSignature: "steady" })).toEqual([]);
+  });
+
+  it("does not fire the load-bearing bias when the stage is not load-bearing", () => {
+    expect(
+      deriveStreamBiases({ loadBearingStageKeys: ["deliver"], stageKey: "attract" }),
+    ).toEqual([]);
+  });
+
+  it("treats an empty trustGates list as no trust gate", () => {
+    expect(deriveStreamBiases({ trustGates: [] })).toEqual([]);
+  });
+});

--- a/apps/web/lib/work-posture/derive.ts
+++ b/apps/web/lib/work-posture/derive.ts
@@ -1,0 +1,261 @@
+/**
+ * EP-WORK-POSTURE Slice B (BI-0C5A83A8) — derivation tables.
+ *
+ * Design: docs/superpowers/specs/2026-08-22-workroom-work-posture-design.md §4, §5, §6.
+ *
+ * Layer 3 of the precedence ladder. Each derivation contributes a BIAS, never a
+ * final value: biases are applied through the tighten-only clamps in
+ * `tighten.ts`, so no table here can widen authority however it is edited.
+ *
+ * A bias that wants a coworker to be QUIETER must set `damp`, not
+ * `proactivityLevel` — the tighten-only clamps raise proactivity and never lower
+ * it, so a `proactivityLevel: "quiet"` bias is silently inert. `damp` is the
+ * only reducing lever, and by construction it cannot reach authority.
+ *
+ * The tables are declared ONCE in code and are deliberately NOT per-archetype.
+ * The archetype contribution is derived from the OVSM projection's four
+ * properties — demandSignature, capacityUnit, loadBearingStageKeys, trustGates
+ * — which the projection already produces for every leaf archetype. Authoring a
+ * per-archetype posture table is the defect BI-BEDAFF57 exists to prevent.
+ */
+import type { QualityTier } from "@/lib/routing/quality-tiers";
+import type {
+  ProactivityActionBoundary,
+  ProactivityLevel,
+} from "@/lib/proactivity/proactivity-types";
+import type { VerificationDepth } from "@/lib/golden-triangle";
+import type { TemporalBand } from "./temporal-band";
+
+/** What a single derivation input wants to tighten. All fields optional. */
+export interface PostureBias {
+  proactivityLevel?: ProactivityLevel;
+  actionBoundary?: ProactivityActionBoundary;
+  minimumTier?: QualityTier;
+  verificationDepth?: VerificationDepth;
+  /** Which Golden Triangle axis this input pulls toward, for the priority bias. */
+  priorityAxis?: "quality" | "cost" | "time";
+  /**
+   * Lower cadence by one step. The ONLY reducing lever — `proactivityLevel`
+   * can raise but never lower, so a bias that wants quiet sets this instead.
+   * Never reaches the action boundary, tier floor or verification depth.
+   */
+  damp?: boolean;
+  reasonCode: string;
+  reason: string;
+}
+
+// ── Shape: collaboration shape (WorkroomShapeKey) ────────────────────────────
+
+const SHAPE_BIAS: Record<string, PostureBias> = {
+  "change-consequential": {
+    actionBoundary: "propose",
+    priorityAxis: "quality",
+    reasonCode: "shape_change_consequential",
+    reason: "A consequential change is reviewed and confirmed before execution.",
+  },
+  "approval-sign-off": {
+    actionBoundary: "propose",
+    priorityAxis: "quality",
+    verificationDepth: "shallow",
+    reasonCode: "shape_approval_sign_off",
+    reason: "An accountable approver signs off, so evidence quality outranks speed.",
+  },
+  "outward-review": {
+    actionBoundary: "propose",
+    priorityAxis: "quality",
+    verificationDepth: "deep",
+    reasonCode: "shape_outward_review",
+    reason: "The action faces outward, so it is reviewed and verified before it leaves.",
+  },
+  escalation: {
+    proactivityLevel: "assertive",
+    actionBoundary: "propose",
+    priorityAxis: "time",
+    reasonCode: "shape_escalation",
+    reason: "An escalation is waiting on a human, so timing outranks cost.",
+  },
+  "specialist-alignment": {
+    priorityAxis: "quality",
+    reasonCode: "shape_specialist_alignment",
+    reason: "A corpus check routes to a qualified specialist before the approver sees it.",
+  },
+  "craft-stewardship": {
+    // Damp rather than declaring `proactivityLevel: "quiet"`: the tighten-only
+    // clamps can only RAISE proactivity, so a "quiet" bias would be silently
+    // inert. Lowering cadence is expressible only through `damp`, which by
+    // construction cannot reach authority.
+    damp: true,
+    priorityAxis: "cost",
+    reasonCode: "shape_craft_stewardship",
+    reason: "Standing corpus curation is background work; it should not interrupt.",
+  },
+};
+
+// ── Shape: activity kind (WORK_CAPSULE_SCOPE_ACTIVITY_KINDS) ─────────────────
+
+const ACTIVITY_KIND_BIAS: Record<string, PostureBias> = {
+  remediation: {
+    proactivityLevel: "assertive",
+    priorityAxis: "time",
+    reasonCode: "activity_remediation",
+    reason: "Remediation work is fixing something already wrong, so it should not wait.",
+  },
+  governance: {
+    actionBoundary: "propose",
+    priorityAxis: "quality",
+    reasonCode: "activity_governance",
+    reason: "Governance work sets precedent, so it is proposed rather than taken.",
+  },
+  "launch-readiness": {
+    priorityAxis: "quality",
+    verificationDepth: "shallow",
+    reasonCode: "activity_launch_readiness",
+    reason: "Launch readiness is a gate; an unverified pass is worth nothing.",
+  },
+  "craft-judgment": {
+    priorityAxis: "quality",
+    reasonCode: "activity_craft_judgment",
+    reason: "Craft judgment is the deliverable, so quality outranks speed and cost.",
+  },
+};
+
+// ── Stream: the archetype's operational value stream (OVSM) ──────────────────
+
+/**
+ * Demand signatures that mean waiting is expensive. `steady` contributes
+ * nothing — the absence of a bias is a real answer, not a gap.
+ */
+const URGENT_DEMAND_SIGNATURES = new Set([
+  "emergency-reactive",
+  "synchronized-contention",
+]);
+
+/**
+ * Capacity units that are DESTROYED rather than deferred when unused: an empty
+ * appointment slot, a spoiled item, an unsold seat. Idle capacity in these
+ * units is a loss the business never recovers, so surfacing beats batching.
+ */
+const PERISHABLE_CAPACITY_UNITS = new Set([
+  "slot-hours",
+  "perishable-stock",
+  "physical-hard-cap",
+]);
+
+export interface ArchetypeStreamInput {
+  demandSignature?: string | null;
+  capacityUnit?: string | null;
+  loadBearingStageKeys?: readonly string[] | null;
+  trustGates?: readonly string[] | null;
+  /** The stage this work sits in, when known. */
+  stageKey?: string | null;
+}
+
+export function deriveStreamBiases(stream: ArchetypeStreamInput | null | undefined): PostureBias[] {
+  if (!stream) return [];
+  const biases: PostureBias[] = [];
+
+  if (stream.demandSignature && URGENT_DEMAND_SIGNATURES.has(stream.demandSignature)) {
+    biases.push({
+      proactivityLevel: "assertive",
+      priorityAxis: "time",
+      reasonCode: "stream_urgent_demand",
+      reason: `Demand for this business is ${stream.demandSignature}, so delay compounds.`,
+    });
+  }
+
+  if (stream.demandSignature === "fiscal-calendar") {
+    biases.push({
+      priorityAxis: "quality",
+      reasonCode: "stream_fiscal_calendar",
+      reason: "Work on a fiscal calendar is judged against a filed date, not a preference.",
+    });
+  }
+
+  if (stream.capacityUnit && PERISHABLE_CAPACITY_UNITS.has(stream.capacityUnit)) {
+    biases.push({
+      proactivityLevel: "assertive",
+      priorityAxis: "time",
+      reasonCode: "stream_perishable_capacity",
+      reason: `Capacity is measured in ${stream.capacityUnit}, which is lost rather than deferred when unused.`,
+    });
+  }
+
+  if (stream.stageKey && (stream.loadBearingStageKeys ?? []).includes(stream.stageKey)) {
+    biases.push({
+      proactivityLevel: "assertive",
+      reasonCode: "stream_load_bearing_stage",
+      reason: "This stage carries the value stream; a stall here stalls the business.",
+    });
+  }
+
+  if ((stream.trustGates ?? []).length > 0) {
+    biases.push({
+      verificationDepth: "deep",
+      actionBoundary: "propose",
+      priorityAxis: "quality",
+      reasonCode: "stream_trust_gate",
+      reason: "This stage carries a trust gate, so the work is verified before it advances.",
+    });
+  }
+
+  return biases;
+}
+
+// ── Clock: the temporal band ─────────────────────────────────────────────────
+
+export function deriveTemporalBias(band: TemporalBand): PostureBias | null {
+  switch (band) {
+    case "breach-imminent":
+      return {
+        proactivityLevel: "assertive",
+        priorityAxis: "time",
+        reasonCode: "clock_breach_imminent",
+        reason: "The obligation is at or past its due time.",
+      };
+    case "pre-deadline":
+      return {
+        proactivityLevel: "assertive",
+        priorityAxis: "time",
+        reasonCode: "clock_pre_deadline",
+        reason: "The obligation falls due soon.",
+      };
+    case "low-traffic":
+      return {
+        priorityAxis: "cost",
+        reasonCode: "clock_low_traffic",
+        reason: "Inside a declared low-traffic window, so the work can be run cheaply.",
+      };
+    case "out-of-hours":
+      return {
+        damp: true,
+        reasonCode: "clock_out_of_hours",
+        reason: "The business is closed, so follow-up waits — authority is unchanged.",
+      };
+    case "in-hours":
+      return null;
+  }
+}
+
+export function shapeBiasFor(shapeKey: string | null | undefined): PostureBias | null {
+  return shapeKey ? (SHAPE_BIAS[shapeKey] ?? null) : null;
+}
+
+export function activityKindBiasFor(kind: string | null | undefined): PostureBias | null {
+  return kind ? (ACTIVITY_KIND_BIAS[kind] ?? null) : null;
+}
+
+/**
+ * A standing room between cycles is ongoing background activity, not a live
+ * push. Damping applies to cadence only, exactly as out-of-hours does.
+ */
+export function modeBiasFor(
+  mode: string | null | undefined,
+  cycleActive: boolean,
+): PostureBias | null {
+  if (mode !== "standing" || cycleActive) return null;
+  return {
+    damp: true,
+    reasonCode: "mode_standing_between_cycles",
+    reason: "This standing room is between cycles, so follow-up is quieter.",
+  };
+}

--- a/apps/web/lib/work-posture/index.ts
+++ b/apps/web/lib/work-posture/index.ts
@@ -1,0 +1,8 @@
+/**
+ * EP-WORK-POSTURE — public surface of the work-posture resolver.
+ * See docs/superpowers/specs/2026-08-22-workroom-work-posture-design.md.
+ */
+export * from "./temporal-band";
+export * from "./tighten";
+export * from "./derive";
+export * from "./resolve";

--- a/apps/web/lib/work-posture/resolve.test.ts
+++ b/apps/web/lib/work-posture/resolve.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveWorkPosture, type WorkPostureInput } from "./resolve";
+import { TIGHTEN_RANKS } from "./tighten";
+import type {
+  ProactivityActionBoundary,
+  ProactivityLevel,
+  ProactivityPlan,
+} from "@/lib/proactivity/proactivity-types";
+import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
+import type { WeeklySchedule } from "@/lib/operating-hours-types";
+
+const LEVELS: ProactivityLevel[] = ["quiet", "balanced", "assertive"];
+const BOUNDARIES: ProactivityActionBoundary[] = ["preauthorized", "propose", "advise"];
+
+const BALANCED_PRIORITY: GoldenTrianglePreference = {
+  costWeight: 1 / 3,
+  qualityWeight: 1 / 3,
+  timeWeight: 1 / 3,
+  preset: "balanced",
+};
+
+function plan(
+  resolvedLevel: ProactivityLevel,
+  actionBoundary: ProactivityActionBoundary,
+): ProactivityPlan {
+  return {
+    resolvedLevel,
+    policyId: `proactivity:test:${resolvedLevel}`,
+    attentionWindowMinutes: 60,
+    followUpCadenceMinutes: [120],
+    maxAttempts: 2,
+    spendClass: "standard",
+    channelPolicy: "preferred-channel",
+    escalationTarget: "attention-surface",
+    actionBoundary,
+    explanation: "test",
+    evidenceRefs: [],
+  };
+}
+
+function baseInput(overrides: Partial<WorkPostureInput> = {}): WorkPostureInput {
+  return {
+    inherited: {
+      proactivityPlan: plan("balanced", "propose"),
+      priority: BALANCED_PRIORITY,
+      source: "agent",
+    },
+    ...overrides,
+  };
+}
+
+const NINE_TO_FIVE: WeeklySchedule = {
+  monday: { enabled: true, open: "09:00", close: "17:00" },
+  tuesday: { enabled: true, open: "09:00", close: "17:00" },
+  wednesday: { enabled: true, open: "09:00", close: "17:00" },
+  thursday: { enabled: true, open: "09:00", close: "17:00" },
+  friday: { enabled: true, open: "09:00", close: "17:00" },
+  saturday: { enabled: false, open: "09:00", close: "17:00" },
+  sunday: { enabled: false, open: "09:00", close: "17:00" },
+};
+
+const WED_1000 = new Date("2026-08-19T10:00:00Z");
+const WED_2200 = new Date("2026-08-19T22:00:00Z");
+
+describe("resolveWorkPosture — Balanced-inert", () => {
+  it("returns the inherited posture unchanged when nothing is declared or derivable", () => {
+    const input = baseInput();
+    const result = resolveWorkPosture(input);
+
+    expect(result.proactivityLevel).toBe("balanced");
+    expect(result.actionBoundary).toBe("propose");
+    expect(result.priority).toBe(BALANCED_PRIORITY);
+    expect(result.adjustments).toEqual([]);
+    expect(result.inert).toBe(true);
+    expect(result.proactivitySource).toBe("agent");
+  });
+
+  it("stays inert in-hours with an empty shape and no stream", () => {
+    const result = resolveWorkPosture(
+      baseInput({
+        shape: { shapeKey: null, activityKind: null, mode: "finite" },
+        stream: null,
+        temporal: { now: WED_1000, schedule: NINE_TO_FIVE, timezone: "UTC" },
+      }),
+    );
+    expect(result.inert).toBe(true);
+    expect(result.temporalBand).toBe("in-hours");
+  });
+
+  it("stays inert for an unrecognised shape key", () => {
+    expect(
+      resolveWorkPosture(baseInput({ shape: { shapeKey: "not-a-shape" } })).inert,
+    ).toBe(true);
+  });
+});
+
+describe("resolveWorkPosture — the tighten-only invariant", () => {
+  // The load-bearing property: across the FULL cross-product of inherited
+  // postures and every derivable context, a derivation must never widen
+  // authority, lower a tier floor, or drop a verification requirement.
+  const CONTEXTS: Array<Partial<WorkPostureInput>> = [
+    { shape: { shapeKey: "craft-stewardship" } },
+    { shape: { shapeKey: "escalation" } },
+    { shape: { shapeKey: "outward-review" } },
+    { shape: { shapeKey: "change-consequential" } },
+    { shape: { shapeKey: "approval-sign-off" } },
+    { shape: { shapeKey: "specialist-alignment" } },
+    { shape: { activityKind: "remediation" } },
+    { shape: { activityKind: "governance" } },
+    { shape: { activityKind: "launch-readiness" } },
+    { shape: { mode: "standing", cycleActive: false } },
+    { stream: { demandSignature: "emergency-reactive" } },
+    { stream: { demandSignature: "steady" } },
+    { stream: { capacityUnit: "slot-hours" } },
+    { stream: { trustGates: ["identity-verified"] } },
+    { stream: { loadBearingStageKeys: ["deliver"], stageKey: "deliver" } },
+    { temporal: { now: WED_2200, schedule: NINE_TO_FIVE, timezone: "UTC" } },
+    { temporal: { now: WED_1000, schedule: NINE_TO_FIVE, timezone: "UTC", dueAt: WED_1000 } },
+  ];
+
+  it("never widens the action boundary, for any inherited posture in any context", () => {
+    for (const level of LEVELS) {
+      for (const boundary of BOUNDARIES) {
+        for (const context of CONTEXTS) {
+          const result = resolveWorkPosture(
+            baseInput({
+              inherited: {
+                proactivityPlan: plan(level, boundary),
+                priority: BALANCED_PRIORITY,
+                source: "agent",
+              },
+              ...context,
+            }),
+          );
+          expect(
+            TIGHTEN_RANKS.boundary[result.actionBoundary],
+            `boundary widened from ${boundary} in ${JSON.stringify(context)}`,
+          ).toBeGreaterThanOrEqual(TIGHTEN_RANKS.boundary[boundary]);
+        }
+      }
+    }
+  });
+
+  it("never lowers a tier floor or drops a verification requirement", () => {
+    for (const context of CONTEXTS) {
+      const result = resolveWorkPosture(
+        baseInput({
+          hardPolicy: { minimumTierFloor: "strong", verificationDepthFloor: "shallow" },
+          ...context,
+        }),
+      );
+      expect(TIGHTEN_RANKS.tier[result.minimumTier!]).toBeGreaterThanOrEqual(
+        TIGHTEN_RANKS.tier.strong,
+      );
+      expect(TIGHTEN_RANKS.verification[result.verificationDepth!]).toBeGreaterThanOrEqual(
+        TIGHTEN_RANKS.verification.shallow,
+      );
+    }
+  });
+
+  it("out-of-hours damping reaches cadence only, never authority", () => {
+    for (const boundary of BOUNDARIES) {
+      const closed = resolveWorkPosture(
+        baseInput({
+          inherited: {
+            proactivityPlan: plan("assertive", boundary),
+            priority: BALANCED_PRIORITY,
+            source: "agent",
+          },
+          temporal: { now: WED_2200, schedule: NINE_TO_FIVE, timezone: "UTC" },
+        }),
+      );
+      // Cadence damped...
+      expect(closed.proactivityLevel).toBe("balanced");
+      // ...authority untouched.
+      expect(closed.actionBoundary).toBe(boundary);
+    }
+  });
+
+  it("does not damp an exempt family when the business is closed", () => {
+    const result = resolveWorkPosture(
+      baseInput({
+        inherited: {
+          proactivityPlan: plan("assertive", "propose"),
+          priority: BALANCED_PRIORITY,
+          source: "agent",
+        },
+        temporal: {
+          now: WED_2200,
+          schedule: NINE_TO_FIVE,
+          timezone: "UTC",
+          activityFamily: "security-incident",
+        },
+      }),
+    );
+    expect(result.temporalBand).toBe("in-hours");
+    expect(result.proactivityLevel).toBe("assertive");
+  });
+});
+
+describe("resolveWorkPosture — derivation", () => {
+  it("an escalation shape raises persistence and pulls toward time", () => {
+    const result = resolveWorkPosture(
+      baseInput({
+        inherited: {
+          proactivityPlan: plan("quiet", "propose"),
+          priority: BALANCED_PRIORITY,
+          source: "agent",
+        },
+        shape: { shapeKey: "escalation" },
+      }),
+    );
+    expect(result.proactivityLevel).toBe("assertive");
+    expect(result.proactivitySource).toBe("derived");
+    expect(result.priority!.timeWeight).toBeGreaterThan(result.priority!.costWeight);
+  });
+
+  it("an outward-review shape requires deep verification and a propose boundary", () => {
+    const result = resolveWorkPosture(
+      baseInput({
+        inherited: {
+          proactivityPlan: plan("balanced", "preauthorized"),
+          priority: BALANCED_PRIORITY,
+          source: "agent",
+        },
+        shape: { shapeKey: "outward-review" },
+      }),
+    );
+    expect(result.verificationDepth).toBe("deep");
+    expect(result.actionBoundary).toBe("propose");
+  });
+
+  it("a trust gate on the stage deepens verification for any archetype", () => {
+    const result = resolveWorkPosture(
+      baseInput({ stream: { trustGates: ["licence-checked"] } }),
+    );
+    expect(result.verificationDepth).toBe("deep");
+  });
+
+  it("a perishable capacity unit raises persistence", () => {
+    expect(
+      resolveWorkPosture(baseInput({ stream: { capacityUnit: "perishable-stock" } }))
+        .proactivityLevel,
+    ).toBe("assertive");
+  });
+
+  it("a steady demand signature contributes nothing", () => {
+    expect(resolveWorkPosture(baseInput({ stream: { demandSignature: "steady" } })).inert).toBe(
+      true,
+    );
+  });
+
+  it("a craft-stewardship room is quieter — the quiet intent is expressed as damping", () => {
+    // Regression guard: expressing this as `proactivityLevel: "quiet"` would be
+    // silently inert, because the tighten-only clamps never lower proactivity.
+    // Only `damp` can reduce cadence.
+    const result = resolveWorkPosture(
+      baseInput({
+        inherited: {
+          proactivityPlan: plan("assertive", "propose"),
+          priority: BALANCED_PRIORITY,
+          source: "agent",
+        },
+        shape: { shapeKey: "craft-stewardship" },
+      }),
+    );
+    expect(result.proactivityLevel).toBe("balanced");
+    expect(result.actionBoundary).toBe("propose");
+  });
+
+  it("a standing room between cycles is quieter, but not between-cycles when active", () => {
+    expect(
+      resolveWorkPosture(baseInput({ shape: { mode: "standing", cycleActive: false } }))
+        .proactivityLevel,
+    ).toBe("quiet");
+    expect(
+      resolveWorkPosture(baseInput({ shape: { mode: "standing", cycleActive: true } })).inert,
+    ).toBe(true);
+  });
+
+  it("a deadline beats the closed-business clock", () => {
+    const result = resolveWorkPosture(
+      baseInput({
+        temporal: {
+          now: WED_2200,
+          schedule: NINE_TO_FIVE,
+          timezone: "UTC",
+          dueAt: new Date("2026-08-20T00:00:00Z"),
+        },
+      }),
+    );
+    expect(result.temporalBand).toBe("pre-deadline");
+    expect(result.proactivityLevel).toBe("assertive");
+  });
+});
+
+describe("resolveWorkPosture — precedence", () => {
+  it("a room declaration outranks derivation for the proactivity level", () => {
+    const result = resolveWorkPosture(
+      baseInput({
+        shape: { shapeKey: "escalation" }, // derives assertive
+        declaration: { proactivityLevel: "quiet" },
+      }),
+    );
+    expect(result.proactivityLevel).toBe("quiet");
+    expect(result.proactivitySource).toBe("room-declaration");
+  });
+
+  it("a room declaration may still only tighten the action boundary", () => {
+    const result = resolveWorkPosture(
+      baseInput({
+        inherited: {
+          proactivityPlan: plan("balanced", "advise"),
+          priority: BALANCED_PRIORITY,
+          source: "agent",
+        },
+        declaration: { actionBoundary: "preauthorized" }, // attempts to widen
+      }),
+    );
+    expect(result.actionBoundary).toBe("advise");
+  });
+
+  it("hard policy outranks the room declaration", () => {
+    const result = resolveWorkPosture(
+      baseInput({
+        declaration: { actionBoundary: "preauthorized" },
+        hardPolicy: { actionBoundaryFloor: "propose" },
+      }),
+    );
+    expect(result.actionBoundary).toBe("propose");
+  });
+
+  it("regulated work is advised, never acted, whatever anything else says", () => {
+    const result = resolveWorkPosture(
+      baseInput({
+        inherited: {
+          proactivityPlan: plan("assertive", "preauthorized"),
+          priority: BALANCED_PRIORITY,
+          source: "agent",
+        },
+        declaration: { actionBoundary: "preauthorized" },
+        shape: { shapeKey: "escalation" },
+        hardPolicy: { regulated: true },
+      }),
+    );
+    expect(result.actionBoundary).toBe("advise");
+  });
+});
+
+describe("resolveWorkPosture — provenance", () => {
+  it("records every clamp with a stable reason code", () => {
+    const result = resolveWorkPosture(
+      baseInput({
+        inherited: {
+          proactivityPlan: plan("quiet", "preauthorized"),
+          priority: BALANCED_PRIORITY,
+          source: "agent",
+        },
+        shape: { shapeKey: "outward-review" },
+        hardPolicy: { minimumTierFloor: "frontier" },
+      }),
+    );
+    const codes = result.adjustments.map((a) => a.reasonCode);
+    expect(codes).toContain("shape_outward_review");
+    expect(codes).toContain("hard_policy_floor");
+    for (const adjustment of result.adjustments) {
+      expect(adjustment.reasonCode).toMatch(/^[a-z0-9_]+$/);
+      expect(adjustment.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("is deterministic", () => {
+    const input = baseInput({
+      shape: { shapeKey: "approval-sign-off" },
+      stream: { demandSignature: "emergency-reactive" },
+      temporal: { now: WED_1000, schedule: NINE_TO_FIVE, timezone: "UTC" },
+    });
+    expect(resolveWorkPosture(input)).toEqual(resolveWorkPosture(input));
+  });
+});

--- a/apps/web/lib/work-posture/resolve.ts
+++ b/apps/web/lib/work-posture/resolve.ts
@@ -1,0 +1,357 @@
+/**
+ * EP-WORK-POSTURE Slice B (BI-0C5A83A8) — the work-posture resolver.
+ *
+ * Design: docs/superpowers/specs/2026-08-22-workroom-work-posture-design.md §3.
+ *
+ * ONE precedence ladder for BOTH postures. This does not replace
+ * `resolveProactivityPlan` or `compileGoldenTrianglePolicy` — it composes over
+ * them:
+ *
+ *   1. Hard policy      residency · sensitivity · regulated ceiling (never relaxed)
+ *   2. Room declaration an explicit choice made when the room was convened
+ *   3. Derived          work shape × archetype stream × clock × stakes
+ *   4. Agent            the coworker's own saved posture
+ *   5. Org / activity-family
+ *   6. Platform default Balanced/balanced
+ *
+ * Layers 1, 4, 5 and 6 already exist and keep their current meaning; the
+ * resolver receives their result as `inherited` and layers 2 and 3 on top.
+ *
+ * Two properties make this safe to put on the hot path:
+ *
+ *   TIGHTEN-ONLY  Every derived delta is applied through `tighten.ts`, which
+ *                 can only move a value in the tightening direction. A widening
+ *                 derivation is unrepresentable, not merely untested.
+ *
+ *   BALANCED-INERT  A fully default context derives no deltas, so the result is
+ *                 the inherited posture unchanged — byte-identical to today.
+ *
+ * Pure and deterministic: no I/O, no ambient Date, no random. `now` and the
+ * schedule arrive as inputs.
+ */
+import type { QualityTier } from "@/lib/routing/quality-tiers";
+import type {
+  ProactivityActionBoundary,
+  ProactivityLevel,
+  ProactivityPlan,
+} from "@/lib/proactivity/proactivity-types";
+import type {
+  GoldenTrianglePreference,
+  PolicyAdjustment,
+  VerificationDepth,
+} from "@/lib/golden-triangle";
+
+import {
+  activityKindBiasFor,
+  deriveStreamBiases,
+  deriveTemporalBias,
+  modeBiasFor,
+  shapeBiasFor,
+  type ArchetypeStreamInput,
+  type PostureBias,
+} from "./derive";
+import {
+  dampProactivityLevel,
+  tightenActionBoundary,
+  tightenMinimumTier,
+  tightenProactivityLevel,
+  tightenVerificationDepth,
+} from "./tighten";
+import { resolveTemporalBand, type TemporalBandInput, type TemporalBand } from "./temporal-band";
+
+/** Which precedence layer supplied a value — surfaced so the operator sees why. */
+export type PostureLayer =
+  | "hard-policy"
+  | "room-declaration"
+  | "derived"
+  | "agent"
+  | "organization"
+  | "platform";
+
+/** Hard bounds the posture may never cross. Layer 1. */
+export interface PostureHardPolicy {
+  /** An absolute floor on the action boundary — the posture may only tighten past it. */
+  actionBoundaryFloor?: ProactivityActionBoundary;
+  minimumTierFloor?: QualityTier;
+  verificationDepthFloor?: VerificationDepth;
+  /** True when the work is regulated; recorded for provenance and applied as a floor. */
+  regulated?: boolean;
+  reason?: string;
+}
+
+/** An explicit posture chosen when the room was convened. Layer 2. */
+export interface RoomPostureDeclaration {
+  proactivityLevel?: ProactivityLevel;
+  actionBoundary?: ProactivityActionBoundary;
+  priority?: GoldenTrianglePreference;
+  declaredBy?: string | null;
+  declaredAt?: string | null;
+}
+
+/** The shape axes of the room the work is happening in. Layer 3 input. */
+export interface RoomShapeInput {
+  /** WorkroomShapeKey — the declared collaboration shape. */
+  shapeKey?: string | null;
+  /** Workroom.activityKind. */
+  activityKind?: string | null;
+  /** WorkroomMode — "finite" | "standing". */
+  mode?: string | null;
+  /** Whether a standing room currently has an open cycle. */
+  cycleActive?: boolean;
+}
+
+export interface WorkPostureInput {
+  /**
+   * The posture resolved by the EXISTING ladders (agent → org/activity-family →
+   * platform). This resolver never re-derives it.
+   */
+  inherited: {
+    proactivityPlan: ProactivityPlan;
+    priority?: GoldenTrianglePreference | null;
+    /** Which of the existing layers supplied it, for provenance. */
+    source?: PostureLayer;
+  };
+  hardPolicy?: PostureHardPolicy | null;
+  declaration?: RoomPostureDeclaration | null;
+  shape?: RoomShapeInput | null;
+  stream?: ArchetypeStreamInput | null;
+  /** Everything the clock needs. Passed in — the resolver reads no ambient time. */
+  temporal?: TemporalBandInput | null;
+}
+
+export interface ResolvedWorkPosture {
+  proactivityLevel: ProactivityLevel;
+  actionBoundary: ProactivityActionBoundary;
+  minimumTier?: QualityTier;
+  verificationDepth?: VerificationDepth;
+  priority: GoldenTrianglePreference | null;
+  /** The band that applied, or null when no temporal input was supplied. */
+  temporalBand: TemporalBand | null;
+  /** Which layer supplied the headline proactivity value. */
+  proactivitySource: PostureLayer;
+  /** Which layer supplied the priority. */
+  prioritySource: PostureLayer;
+  /**
+   * Every clamp, in application order, with a stable reasonCode. This is the
+   * decision log the provenance surface (BI-4EB2F1D0) renders.
+   */
+  adjustments: PolicyAdjustment[];
+  /** True when nothing was derived or declared — the inherited posture stands. */
+  inert: boolean;
+}
+
+function record(
+  adjustments: PolicyAdjustment[],
+  field: string,
+  from: unknown,
+  to: unknown,
+  bias: { reasonCode: string; reason: string },
+): void {
+  if (from === to) return;
+  adjustments.push({ field, from, to, reasonCode: bias.reasonCode, reason: bias.reason });
+}
+
+/** Collect every derivation bias that applies, in a stable order. */
+function collectBiases(input: WorkPostureInput, band: TemporalBand | null): PostureBias[] {
+  const biases: PostureBias[] = [];
+
+  const shapeBias = shapeBiasFor(input.shape?.shapeKey);
+  if (shapeBias) biases.push(shapeBias);
+
+  const kindBias = activityKindBiasFor(input.shape?.activityKind);
+  if (kindBias) biases.push(kindBias);
+
+  biases.push(...deriveStreamBiases(input.stream));
+
+  if (band) {
+    const temporalBias = deriveTemporalBias(band);
+    if (temporalBias) biases.push(temporalBias);
+  }
+
+  const mode = modeBiasFor(input.shape?.mode, input.shape?.cycleActive ?? false);
+  if (mode) biases.push(mode);
+
+  return biases;
+}
+
+/**
+ * Fold the priority axis bias into a Golden Triangle preference.
+ *
+ * Deliberately conservative: a derived axis nudges the inherited weights toward
+ * that axis rather than replacing the operator's posture. An explicit
+ * declaration or an agent's own saved posture still reads as itself; the
+ * derivation shifts emphasis, it does not overrule intent.
+ */
+function applyPriorityAxis(
+  base: GoldenTrianglePreference | null,
+  axes: ReadonlyArray<"quality" | "cost" | "time">,
+): GoldenTrianglePreference | null {
+  if (!base || axes.length === 0) return base;
+
+  const NUDGE = 0.1;
+  let { costWeight, qualityWeight, timeWeight } = base;
+  for (const axis of axes) {
+    if (axis === "quality") qualityWeight += NUDGE;
+    else if (axis === "cost") costWeight += NUDGE;
+    else timeWeight += NUDGE;
+  }
+  const sum = costWeight + qualityWeight + timeWeight;
+  if (sum <= 0) return base;
+  return {
+    costWeight: costWeight / sum,
+    qualityWeight: qualityWeight / sum,
+    timeWeight: timeWeight / sum,
+    // The posture is no longer the named preset once a derivation shifted it.
+    preset: "custom",
+  };
+}
+
+export function resolveWorkPosture(input: WorkPostureInput): ResolvedWorkPosture {
+  const adjustments: PolicyAdjustment[] = [];
+  const inheritedPlan = input.inherited.proactivityPlan;
+
+  // ── Layer 6/5/4: the inherited starting point ──
+  let proactivityLevel = inheritedPlan.resolvedLevel;
+  let actionBoundary = inheritedPlan.actionBoundary;
+  let priority = input.inherited.priority ?? null;
+  let proactivitySource: PostureLayer = input.inherited.source ?? "platform";
+  let prioritySource: PostureLayer = input.inherited.source ?? "platform";
+  let minimumTier: QualityTier | undefined;
+  let verificationDepth: VerificationDepth | undefined;
+
+  const band = input.temporal ? resolveTemporalBand(input.temporal).band : null;
+  const biases = collectBiases(input, band);
+
+  // ── Layer 3: derived. Applied ONLY through the tighten-only clamps. ──
+  const priorityAxes: Array<"quality" | "cost" | "time"> = [];
+  for (const bias of biases) {
+    if (bias.proactivityLevel) {
+      const next = tightenProactivityLevel(proactivityLevel, bias.proactivityLevel);
+      record(adjustments, "proactivityLevel", proactivityLevel, next, bias);
+      if (next !== proactivityLevel) proactivitySource = "derived";
+      proactivityLevel = next;
+    }
+    if (bias.actionBoundary) {
+      const next = tightenActionBoundary(actionBoundary, bias.actionBoundary);
+      record(adjustments, "actionBoundary", actionBoundary, next, bias);
+      actionBoundary = next;
+    }
+    if (bias.minimumTier) {
+      const next = tightenMinimumTier(minimumTier, bias.minimumTier);
+      record(adjustments, "minimumTier", minimumTier, next, bias);
+      minimumTier = next;
+    }
+    if (bias.verificationDepth) {
+      const next = tightenVerificationDepth(verificationDepth, bias.verificationDepth);
+      record(adjustments, "verificationDepth", verificationDepth, next, bias);
+      verificationDepth = next;
+    }
+    if (bias.priorityAxis) priorityAxes.push(bias.priorityAxis);
+  }
+
+  // Damping is applied AFTER every tightening bias, and reaches the cadence
+  // level only — never the action boundary, tier floor or verification depth.
+  // This is what makes "the business is closed" safe (design §3.2, §6).
+  for (const bias of biases) {
+    if (!bias.damp) continue;
+    const next = dampProactivityLevel(proactivityLevel);
+    record(adjustments, "proactivityLevel", proactivityLevel, next, bias);
+    if (next !== proactivityLevel) proactivitySource = "derived";
+    proactivityLevel = next;
+  }
+
+  if (priorityAxes.length > 0) {
+    const next = applyPriorityAxis(priority, priorityAxes);
+    if (next && next !== priority) {
+      adjustments.push({
+        field: "priority",
+        from: priority?.preset ?? null,
+        to: next.preset,
+        reasonCode: "derived_priority_axis",
+        reason: `Priority shifted toward ${[...new Set(priorityAxes)].join(" and ")} by the shape of this work.`,
+      });
+      prioritySource = "derived";
+      priority = next;
+    }
+  }
+
+  // ── Layer 2: the room's explicit declaration outranks derivation ──
+  const declaration = input.declaration;
+  if (declaration?.proactivityLevel && declaration.proactivityLevel !== proactivityLevel) {
+    adjustments.push({
+      field: "proactivityLevel",
+      from: proactivityLevel,
+      to: declaration.proactivityLevel,
+      reasonCode: "room_declaration",
+      reason: "The room declared this proactivity level when it was convened.",
+    });
+    proactivityLevel = declaration.proactivityLevel;
+    proactivitySource = "room-declaration";
+  }
+  if (declaration?.actionBoundary) {
+    // Even a declaration may only TIGHTEN authority: convening a room cannot
+    // buy a coworker more freedom than its own policy already granted.
+    const next = tightenActionBoundary(actionBoundary, declaration.actionBoundary);
+    record(adjustments, "actionBoundary", actionBoundary, next, {
+      reasonCode: "room_declaration",
+      reason: "The room declared this action boundary when it was convened.",
+    });
+    actionBoundary = next;
+  }
+  if (declaration?.priority) {
+    adjustments.push({
+      field: "priority",
+      from: priority?.preset ?? null,
+      to: declaration.priority.preset,
+      reasonCode: "room_declaration",
+      reason: "The room declared this cost/quality/time posture when it was convened.",
+    });
+    priority = declaration.priority;
+    prioritySource = "room-declaration";
+  }
+
+  // ── Layer 1: hard policy. Floors only; never relaxed by anything above. ──
+  const hard = input.hardPolicy;
+  if (hard) {
+    const hardReason = {
+      reasonCode: "hard_policy_floor",
+      reason: hard.reason ?? "A policy floor applies that the posture cannot trade away.",
+    };
+    if (hard.actionBoundaryFloor) {
+      const next = tightenActionBoundary(actionBoundary, hard.actionBoundaryFloor);
+      record(adjustments, "actionBoundary", actionBoundary, next, hardReason);
+      actionBoundary = next;
+    }
+    if (hard.regulated) {
+      const next = tightenActionBoundary(actionBoundary, "advise");
+      record(adjustments, "actionBoundary", actionBoundary, next, {
+        reasonCode: "regulated_ceiling",
+        reason: "This work is regulated, so the coworker advises rather than acts.",
+      });
+      actionBoundary = next;
+    }
+    if (hard.minimumTierFloor) {
+      const next = tightenMinimumTier(minimumTier, hard.minimumTierFloor);
+      record(adjustments, "minimumTier", minimumTier, next, hardReason);
+      minimumTier = next;
+    }
+    if (hard.verificationDepthFloor) {
+      const next = tightenVerificationDepth(verificationDepth, hard.verificationDepthFloor);
+      record(adjustments, "verificationDepth", verificationDepth, next, hardReason);
+      verificationDepth = next;
+    }
+  }
+
+  return {
+    proactivityLevel,
+    actionBoundary,
+    minimumTier,
+    verificationDepth,
+    priority,
+    temporalBand: band,
+    proactivitySource,
+    prioritySource,
+    adjustments,
+    inert: adjustments.length === 0,
+  };
+}

--- a/apps/web/lib/work-posture/temporal-band.test.ts
+++ b/apps/web/lib/work-posture/temporal-band.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DAMPING_EXEMPT_ACTIVITY_FAMILIES,
+  DEFAULT_DEADLINE_WARNING_MINUTES,
+  isDampingExempt,
+  resolveTemporalBand,
+  TEMPORAL_BANDS,
+} from "./temporal-band";
+import type { WeeklySchedule } from "@/lib/operating-hours-types";
+
+const NINE_TO_FIVE: WeeklySchedule = {
+  monday: { enabled: true, open: "09:00", close: "17:00" },
+  tuesday: { enabled: true, open: "09:00", close: "17:00" },
+  wednesday: { enabled: true, open: "09:00", close: "17:00" },
+  thursday: { enabled: true, open: "09:00", close: "17:00" },
+  friday: { enabled: true, open: "09:00", close: "17:00" },
+  saturday: { enabled: false, open: "09:00", close: "17:00" },
+  sunday: { enabled: false, open: "09:00", close: "17:00" },
+};
+
+const CLOSED_ALL_WEEK: WeeklySchedule = {
+  monday: { enabled: false, open: "09:00", close: "17:00" },
+  tuesday: { enabled: false, open: "09:00", close: "17:00" },
+  wednesday: { enabled: false, open: "09:00", close: "17:00" },
+  thursday: { enabled: false, open: "09:00", close: "17:00" },
+  friday: { enabled: false, open: "09:00", close: "17:00" },
+  saturday: { enabled: false, open: "09:00", close: "17:00" },
+  sunday: { enabled: false, open: "09:00", close: "17:00" },
+};
+
+// 2026-08-19 is a Wednesday. Times below are UTC and the schedule is read in UTC
+// unless a test pins another zone.
+const WED_1000 = new Date("2026-08-19T10:00:00Z");
+const WED_2200 = new Date("2026-08-19T22:00:00Z");
+const SAT_1000 = new Date("2026-08-22T10:00:00Z");
+
+describe("resolveTemporalBand", () => {
+  it("resolves in-hours inside the operating window", () => {
+    const result = resolveTemporalBand({
+      now: WED_1000,
+      schedule: NINE_TO_FIVE,
+      timezone: "UTC",
+    });
+    expect(result.band).toBe("in-hours");
+    expect(result.reasonCode).toBe("within_operating_hours");
+  });
+
+  it("resolves out-of-hours outside the operating window", () => {
+    const result = resolveTemporalBand({
+      now: WED_2200,
+      schedule: NINE_TO_FIVE,
+      timezone: "UTC",
+    });
+    expect(result.band).toBe("out-of-hours");
+  });
+
+  it("resolves out-of-hours on a disabled day", () => {
+    expect(
+      resolveTemporalBand({ now: SAT_1000, schedule: NINE_TO_FIVE, timezone: "UTC" }).band,
+    ).toBe("out-of-hours");
+  });
+
+  it("resolves out-of-hours for a closed-all-week schedule", () => {
+    expect(
+      resolveTemporalBand({ now: WED_1000, schedule: CLOSED_ALL_WEEK, timezone: "UTC" }).band,
+    ).toBe("out-of-hours");
+  });
+
+  it("resolves low-traffic inside a declared trough", () => {
+    const result = resolveTemporalBand({
+      now: WED_2200,
+      schedule: NINE_TO_FIVE,
+      timezone: "UTC",
+      lowTrafficWindows: [{ dayOfWeek: 3, start: "21:00", end: "23:00" }],
+    });
+    expect(result.band).toBe("low-traffic");
+  });
+
+  it("resolves pre-deadline inside the warning window, beating the operating clock", () => {
+    // Closed (22:00) but due in 2h — the obligation does not stop being due
+    // because the office is shut.
+    const result = resolveTemporalBand({
+      now: WED_2200,
+      schedule: NINE_TO_FIVE,
+      timezone: "UTC",
+      dueAt: new Date("2026-08-20T00:00:00Z"),
+    });
+    expect(result.band).toBe("pre-deadline");
+  });
+
+  it("resolves breach-imminent at or past the due time", () => {
+    expect(
+      resolveTemporalBand({
+        now: WED_1000,
+        schedule: NINE_TO_FIVE,
+        timezone: "UTC",
+        dueAt: WED_1000,
+      }).band,
+    ).toBe("breach-imminent");
+  });
+
+  it("does not open the pre-deadline band outside the warning window", () => {
+    const wellBeyond = new Date(
+      WED_1000.getTime() + (DEFAULT_DEADLINE_WARNING_MINUTES + 60) * 60_000,
+    );
+    expect(
+      resolveTemporalBand({
+        now: WED_1000,
+        schedule: NINE_TO_FIVE,
+        timezone: "UTC",
+        dueAt: wellBeyond,
+      }).band,
+    ).toBe("in-hours");
+  });
+
+  it("reaches every declared band", () => {
+    const reached = new Set([
+      resolveTemporalBand({ now: WED_1000, schedule: NINE_TO_FIVE, timezone: "UTC" }).band,
+      resolveTemporalBand({ now: WED_2200, schedule: NINE_TO_FIVE, timezone: "UTC" }).band,
+      resolveTemporalBand({
+        now: WED_2200,
+        schedule: NINE_TO_FIVE,
+        timezone: "UTC",
+        lowTrafficWindows: [{ dayOfWeek: 3, start: "21:00", end: "23:00" }],
+      }).band,
+      resolveTemporalBand({
+        now: WED_1000,
+        schedule: NINE_TO_FIVE,
+        timezone: "UTC",
+        dueAt: new Date("2026-08-19T12:00:00Z"),
+      }).band,
+      resolveTemporalBand({
+        now: WED_1000,
+        schedule: NINE_TO_FIVE,
+        timezone: "UTC",
+        dueAt: WED_1000,
+      }).band,
+    ]);
+    expect([...reached].sort()).toEqual([...TEMPORAL_BANDS].sort());
+  });
+
+  describe("damping exemptions", () => {
+    it.each(DAMPING_EXEMPT_ACTIVITY_FAMILIES)(
+      "never damps %s even when the business is closed",
+      (family) => {
+        const result = resolveTemporalBand({
+          now: WED_2200,
+          schedule: NINE_TO_FIVE,
+          timezone: "UTC",
+          activityFamily: family,
+        });
+        expect(result.band).not.toBe("out-of-hours");
+        expect(result.dampingExempt).toBe(true);
+        expect(result.reasonCode).toBe("damping_exempt");
+      },
+    );
+
+    it("still damps a non-exempt family at the same instant", () => {
+      const result = resolveTemporalBand({
+        now: WED_2200,
+        schedule: NINE_TO_FIVE,
+        timezone: "UTC",
+        activityFamily: "todo-follow-up",
+      });
+      expect(result.band).toBe("out-of-hours");
+      expect(result.dampingExempt).toBe(false);
+    });
+
+    it("classifies exemption membership", () => {
+      expect(isDampingExempt("security-incident")).toBe(true);
+      expect(isDampingExempt("interactive-chat")).toBe(false);
+      expect(isDampingExempt(null)).toBe(false);
+    });
+  });
+
+  describe("timezone handling", () => {
+    it("reads the schedule in the org's zone, not the host zone", () => {
+      // 2026-08-19T22:00Z is 18:00 in New York (EDT) — inside 09:00–17:00? No,
+      // 18:00 is past close, so closed. At 2026-08-19T20:00Z it is 16:00 EDT: open.
+      expect(
+        resolveTemporalBand({
+          now: new Date("2026-08-19T20:00:00Z"),
+          schedule: NINE_TO_FIVE,
+          timezone: "America/New_York",
+        }).band,
+      ).toBe("in-hours");
+      expect(
+        resolveTemporalBand({
+          now: new Date("2026-08-19T20:00:00Z"),
+          schedule: NINE_TO_FIVE,
+          timezone: "UTC",
+        }).band,
+      ).toBe("out-of-hours");
+    });
+
+    it("honours the same wall-clock rule either side of a DST transition", () => {
+      // US DST ends 2026-11-01. 14:00 local on either side must read as in-hours
+      // even though the UTC offset differs.
+      const beforeDst = new Date("2026-10-30T18:00:00Z"); // 14:00 EDT (UTC-4)
+      const afterDst = new Date("2026-11-02T19:00:00Z"); // 14:00 EST (UTC-5)
+      expect(
+        resolveTemporalBand({
+          now: beforeDst,
+          schedule: NINE_TO_FIVE,
+          timezone: "America/New_York",
+        }).band,
+      ).toBe("in-hours");
+      expect(
+        resolveTemporalBand({
+          now: afterDst,
+          schedule: NINE_TO_FIVE,
+          timezone: "America/New_York",
+        }).band,
+      ).toBe("in-hours");
+    });
+
+    it("falls back rather than throwing on an unknown zone", () => {
+      expect(() =>
+        resolveTemporalBand({
+          now: WED_1000,
+          schedule: NINE_TO_FIVE,
+          timezone: "Not/AZone",
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe("fail-open", () => {
+    it("resolves in-hours when no schedule is configured", () => {
+      const result = resolveTemporalBand({ now: WED_2200, schedule: null });
+      expect(result.band).toBe("in-hours");
+      expect(result.reasonCode).toBe("no_schedule");
+    });
+
+    it("ignores a malformed day rather than throwing", () => {
+      const broken = {
+        ...NINE_TO_FIVE,
+        wednesday: { enabled: true, open: "not-a-time", close: "17:00" },
+      } as WeeklySchedule;
+      expect(resolveTemporalBand({ now: WED_1000, schedule: broken, timezone: "UTC" }).band).toBe(
+        "out-of-hours",
+      );
+    });
+
+    it("ignores an invalid dueAt", () => {
+      expect(
+        resolveTemporalBand({
+          now: WED_1000,
+          schedule: NINE_TO_FIVE,
+          timezone: "UTC",
+          dueAt: new Date("nonsense"),
+        }).band,
+      ).toBe("in-hours");
+    });
+  });
+
+  it("is deterministic for a fixed instant", () => {
+    const args = { now: WED_1000, schedule: NINE_TO_FIVE, timezone: "UTC" };
+    expect(resolveTemporalBand(args)).toEqual(resolveTemporalBand(args));
+  });
+});

--- a/apps/web/lib/work-posture/temporal-band.ts
+++ b/apps/web/lib/work-posture/temporal-band.ts
@@ -1,0 +1,291 @@
+/**
+ * EP-WORK-POSTURE Slice A (BI-462F3AF7) — the business clock as a posture input.
+ *
+ * Design: docs/superpowers/specs/2026-08-22-workroom-work-posture-design.md §6.
+ *
+ * A pure, deterministic function: given `now`, the org's weekly schedule and
+ * timezone, its declared low-traffic windows, and an optional obligation
+ * deadline, resolve exactly ONE temporal band. No I/O, no ambient `Date`, no
+ * random — inputs in, band out, snapshot-testable. Same discipline as the
+ * Golden Triangle compiler.
+ *
+ * FUSE, DO NOT BUILD. The weekly schedule, timezone and low-traffic windows all
+ * come from the EXISTING operating-hours substrate (`lib/operating-hours-*`,
+ * backed by BusinessProfile), which already drives the self-upgrade window and
+ * deployment windows. This module introduces no second calendar and no second
+ * timezone-resolution path.
+ *
+ * The band is an INPUT to posture, never a decision by itself: what a band does
+ * to proactivity and priority is decided by the resolver in `resolve.ts`, under
+ * the tighten-only invariant. In particular `out-of-hours` damps CADENCE AND
+ * CHANNEL ONLY and never authority.
+ */
+import type { DaySchedule, WeeklySchedule } from "@/lib/operating-hours-types";
+import type { LowTrafficWindow } from "@/lib/self-upgrade/auto-window";
+
+export const TEMPORAL_BANDS = [
+  "in-hours",
+  "out-of-hours",
+  "low-traffic",
+  "pre-deadline",
+  "breach-imminent",
+] as const;
+export type TemporalBand = (typeof TEMPORAL_BANDS)[number];
+
+/**
+ * Activity families whose harm ACCRUES while the business is closed. They are
+ * exempt from out-of-hours damping entirely: a silently damped security
+ * incident is the failure mode this design most needs to avoid (design §6).
+ *
+ * Deliberately a small, explicit list rather than a predicate — adding to it
+ * should be a reviewed decision, not an emergent property of some heuristic.
+ */
+export const DAMPING_EXEMPT_ACTIVITY_FAMILIES = [
+  "security-incident",
+  "platform-health",
+  "queue-health",
+] as const;
+
+const DAY_KEYS: ReadonlyArray<keyof WeeklySchedule> = [
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+];
+
+/** Default warning window before an obligation's due time (24h), in minutes. */
+export const DEFAULT_DEADLINE_WARNING_MINUTES = 24 * 60;
+
+export interface TemporalBandInput {
+  /** The instant being judged. Passed in — never read from the ambient clock. */
+  now: Date;
+  /** The org's weekly operating schedule, from the operating-hours substrate. */
+  schedule?: WeeklySchedule | null;
+  /** IANA zone the schedule is expressed in (resolveOperatingHoursTimezone output). */
+  timezone?: string | null;
+  /** Declared low-traffic troughs, from BusinessProfile.lowTrafficWindows. */
+  lowTrafficWindows?: readonly LowTrafficWindow[] | null;
+  /** When the obligation this work discharges is due, if any. */
+  dueAt?: Date | null;
+  /** How far ahead of `dueAt` the pre-deadline band opens. */
+  deadlineWarningMinutes?: number;
+  /**
+   * The activity family, when known. Only consulted to apply the damping
+   * exemption — an exempt family never resolves `out-of-hours`.
+   */
+  activityFamily?: string | null;
+}
+
+export interface TemporalBandResult {
+  band: TemporalBand;
+  /** True when the family's exemption suppressed an out-of-hours result. */
+  dampingExempt: boolean;
+  /** Stable machine-readable code, for posture adjustment provenance. */
+  reasonCode: string;
+  /** Operator-readable reason, for the provenance surface. */
+  reason: string;
+}
+
+/** Minutes since local midnight for an "HH:mm" string, or null if malformed. */
+function parseClock(value: string): number | null {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value);
+  if (!match) return null;
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return null;
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
+  return hours * 60 + minutes;
+}
+
+/**
+ * Wall-clock day-of-week and minute-of-day for `now` in `timezone`.
+ *
+ * Uses Intl rather than arithmetic on the epoch so DST transitions are handled
+ * by the platform's tz database rather than by us. Falls back to the host zone
+ * when the timezone is absent or not recognised — fail-open, never throw.
+ */
+function localWallClock(now: Date, timezone: string | null | undefined): {
+  dayOfWeek: number;
+  minuteOfDay: number;
+} {
+  const options: Intl.DateTimeFormatOptions = {
+    weekday: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    ...(timezone ? { timeZone: timezone } : {}),
+  };
+  let parts: Intl.DateTimeFormatPart[];
+  try {
+    parts = new Intl.DateTimeFormat("en-US", options).formatToParts(now);
+  } catch {
+    // Unknown IANA zone — fall back to the host zone rather than failing.
+    parts = new Intl.DateTimeFormat("en-US", {
+      weekday: "short",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }).formatToParts(now);
+  }
+  const lookup = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find((part) => part.type === type)?.value ?? "";
+
+  const weekdayIndex: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  };
+  const dayOfWeek = weekdayIndex[lookup("weekday")] ?? now.getUTCDay();
+  // Intl renders midnight as "24" in some ICU versions under hour12:false.
+  const hour = Number(lookup("hour")) % 24;
+  const minute = Number(lookup("minute"));
+  const minuteOfDay =
+    Number.isFinite(hour) && Number.isFinite(minute) ? hour * 60 + minute : 0;
+  return { dayOfWeek, minuteOfDay };
+}
+
+/**
+ * Is `minuteOfDay` inside [open, close)? A window whose close is at or before
+ * its open is treated as crossing midnight (e.g. 22:00–02:00).
+ */
+function withinWindow(minuteOfDay: number, open: number, close: number): boolean {
+  return close > open
+    ? minuteOfDay >= open && minuteOfDay < close
+    : minuteOfDay >= open || minuteOfDay < close;
+}
+
+function isOpenNow(day: DaySchedule | undefined, minuteOfDay: number): boolean {
+  if (!day || !day.enabled) return false;
+  const open = parseClock(day.open);
+  const close = parseClock(day.close);
+  if (open === null || close === null) return false;
+  return withinWindow(minuteOfDay, open, close);
+}
+
+function inLowTrafficWindow(
+  windows: readonly LowTrafficWindow[],
+  dayOfWeek: number,
+  minuteOfDay: number,
+): boolean {
+  for (const window of windows) {
+    if (!window || window.dayOfWeek !== dayOfWeek) continue;
+    const start = parseClock(window.start);
+    const end = parseClock(window.end);
+    if (start === null || end === null) continue;
+    if (withinWindow(minuteOfDay, start, end)) return true;
+  }
+  return false;
+}
+
+export function isDampingExempt(activityFamily: string | null | undefined): boolean {
+  if (!activityFamily) return false;
+  return (DAMPING_EXEMPT_ACTIVITY_FAMILIES as readonly string[]).includes(activityFamily);
+}
+
+/**
+ * Resolve the temporal band for an instant.
+ *
+ * Precedence, highest first — deadline pressure outranks the operating clock,
+ * because an obligation does not stop being due because the office is shut:
+ *
+ *   breach-imminent  at or past the due boundary
+ *   pre-deadline     inside the obligation's warning window
+ *   low-traffic      inside a declared trough
+ *   out-of-hours     business closed (suppressed for exempt families)
+ *   in-hours         everything else, including "we don't know"
+ *
+ * Fail-open: a missing, malformed or unparseable schedule resolves `in-hours`,
+ * which is today's behaviour. This never throws.
+ */
+export function resolveTemporalBand(input: TemporalBandInput): TemporalBandResult {
+  const exempt = isDampingExempt(input.activityFamily);
+
+  try {
+    const { dueAt, now } = input;
+    if (dueAt instanceof Date && !Number.isNaN(dueAt.getTime())) {
+      const minutesUntilDue = (dueAt.getTime() - now.getTime()) / 60_000;
+      if (minutesUntilDue <= 0) {
+        return {
+          band: "breach-imminent",
+          dampingExempt: exempt,
+          reasonCode: "deadline_breached",
+          reason: "The obligation is at or past its due time.",
+        };
+      }
+      const warning = input.deadlineWarningMinutes ?? DEFAULT_DEADLINE_WARNING_MINUTES;
+      if (minutesUntilDue <= warning) {
+        return {
+          band: "pre-deadline",
+          dampingExempt: exempt,
+          reasonCode: "deadline_near",
+          reason: "The obligation falls due inside the warning window.",
+        };
+      }
+    }
+
+    const { dayOfWeek, minuteOfDay } = localWallClock(now, input.timezone);
+
+    const lowTraffic = input.lowTrafficWindows ?? [];
+    if (lowTraffic.length > 0 && inLowTrafficWindow(lowTraffic, dayOfWeek, minuteOfDay)) {
+      return {
+        band: "low-traffic",
+        dampingExempt: exempt,
+        reasonCode: "low_traffic_window",
+        reason: "Inside a declared low-traffic window.",
+      };
+    }
+
+    const schedule = input.schedule;
+    if (!schedule) {
+      return {
+        band: "in-hours",
+        dampingExempt: exempt,
+        reasonCode: "no_schedule",
+        reason: "No operating schedule is configured, so no timing adjustment applies.",
+      };
+    }
+
+    const dayKey = DAY_KEYS[dayOfWeek];
+    if (isOpenNow(dayKey ? schedule[dayKey] : undefined, minuteOfDay)) {
+      return {
+        band: "in-hours",
+        dampingExempt: exempt,
+        reasonCode: "within_operating_hours",
+        reason: "The business is open.",
+      };
+    }
+
+    if (exempt) {
+      // The business is closed, but harm accrues regardless — do not damp.
+      return {
+        band: "in-hours",
+        dampingExempt: true,
+        reasonCode: "damping_exempt",
+        reason:
+          "The business is closed, but this kind of work worsens while unattended, so its timing is not damped.",
+      };
+    }
+
+    return {
+      band: "out-of-hours",
+      dampingExempt: false,
+      reasonCode: "outside_operating_hours",
+      reason: "The business is closed.",
+    };
+  } catch {
+    // Fail-open: a clock helper must never throw into a posture resolution.
+    return {
+      band: "in-hours",
+      dampingExempt: exempt,
+      reasonCode: "temporal_resolution_failed",
+      reason: "The business clock could not be read, so no timing adjustment applies.",
+    };
+  }
+}

--- a/apps/web/lib/work-posture/tighten.test.ts
+++ b/apps/web/lib/work-posture/tighten.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dampProactivityLevel,
+  tightenActionBoundary,
+  tightenMinimumTier,
+  tightenProactivityLevel,
+  tightenVerificationDepth,
+  TIGHTEN_RANKS,
+} from "./tighten";
+import type {
+  ProactivityActionBoundary,
+  ProactivityLevel,
+} from "@/lib/proactivity/proactivity-types";
+import type { QualityTier } from "@/lib/routing/quality-tiers";
+import type { VerificationDepth } from "@/lib/golden-triangle";
+
+const LEVELS: ProactivityLevel[] = ["quiet", "balanced", "assertive"];
+const BOUNDARIES: ProactivityActionBoundary[] = ["preauthorized", "propose", "advise"];
+const TIERS: QualityTier[] = ["basic", "adequate", "strong", "frontier"];
+const DEPTHS: VerificationDepth[] = ["none", "shallow", "deep"];
+
+// These are exhaustive cross-product assertions rather than examples: the point
+// of the tighten mechanism is that NO input pair can produce a widening result.
+
+describe("tighten-only clamps", () => {
+  it("proactivity never decreases", () => {
+    for (const current of LEVELS) {
+      for (const candidate of LEVELS) {
+        const result = tightenProactivityLevel(current, candidate);
+        expect(TIGHTEN_RANKS.proactivity[result]).toBeGreaterThanOrEqual(
+          TIGHTEN_RANKS.proactivity[current],
+        );
+      }
+    }
+  });
+
+  it("action boundary never becomes more permissive", () => {
+    for (const current of BOUNDARIES) {
+      for (const candidate of BOUNDARIES) {
+        const result = tightenActionBoundary(current, candidate);
+        expect(TIGHTEN_RANKS.boundary[result]).toBeGreaterThanOrEqual(
+          TIGHTEN_RANKS.boundary[current],
+        );
+      }
+    }
+  });
+
+  it("tier floor never drops", () => {
+    for (const current of TIERS) {
+      for (const candidate of TIERS) {
+        const result = tightenMinimumTier(current, candidate)!;
+        expect(TIGHTEN_RANKS.tier[result]).toBeGreaterThanOrEqual(TIGHTEN_RANKS.tier[current]);
+      }
+    }
+  });
+
+  it("verification depth never shallows", () => {
+    for (const current of DEPTHS) {
+      for (const candidate of DEPTHS) {
+        const result = tightenVerificationDepth(current, candidate)!;
+        expect(TIGHTEN_RANKS.verification[result]).toBeGreaterThanOrEqual(
+          TIGHTEN_RANKS.verification[current],
+        );
+      }
+    }
+  });
+
+  it("a null candidate is a no-op on every axis", () => {
+    expect(tightenProactivityLevel("balanced", null)).toBe("balanced");
+    expect(tightenActionBoundary("propose", null)).toBe("propose");
+    expect(tightenMinimumTier("strong", null)).toBe("strong");
+    expect(tightenVerificationDepth("shallow", null)).toBe("shallow");
+    expect(tightenMinimumTier(undefined, null)).toBeUndefined();
+    expect(tightenVerificationDepth(undefined, null)).toBeUndefined();
+  });
+
+  it("an undefined current takes the candidate on the optional axes", () => {
+    expect(tightenMinimumTier(undefined, "adequate")).toBe("adequate");
+    expect(tightenVerificationDepth(undefined, "shallow")).toBe("shallow");
+  });
+});
+
+describe("damping", () => {
+  it("lowers cadence by at most one step and bottoms out at quiet", () => {
+    expect(dampProactivityLevel("assertive")).toBe("balanced");
+    expect(dampProactivityLevel("balanced")).toBe("quiet");
+    expect(dampProactivityLevel("quiet")).toBe("quiet");
+  });
+
+  it("is the only reducing operation — it takes and returns a level only", () => {
+    // Guards the design invariant structurally: damping cannot reach the action
+    // boundary, tier floor or verification depth because it has no access to them.
+    expect(dampProactivityLevel.length).toBe(1);
+  });
+});

--- a/apps/web/lib/work-posture/tighten.ts
+++ b/apps/web/lib/work-posture/tighten.ts
@@ -1,0 +1,120 @@
+/**
+ * EP-WORK-POSTURE Slice B (BI-0C5A83A8) — the tighten-only mechanism.
+ *
+ * Design: docs/superpowers/specs/2026-08-22-workroom-work-posture-design.md §3.2.
+ *
+ *   A derivation may TIGHTEN. It may NEVER WIDEN.
+ *
+ * This is the property that makes it safe to put a derived posture on the hot
+ * path, and it is deliberately implemented as a MECHANISM rather than a
+ * convention: derived deltas are applied only through the clamps below, each of
+ * which can move a value in one direction. A widening derivation is therefore
+ * unrepresentable, not merely untested — there is no code path that expresses
+ * one.
+ *
+ * The direction of "tighter" per axis:
+ *   proactivity level   quiet < balanced < assertive   — tighter = MORE persistent
+ *   action boundary     preauthorized < propose < advise — tighter = LESS authority
+ *   quality tier        basic < adequate < strong < frontier — tighter = HIGHER floor
+ *   verification depth  none < shallow < deep          — tighter = MORE checking
+ *
+ * Note the asymmetry that makes this safe: raising proactivity increases how
+ * hard a coworker pushes for attention, while tightening the action boundary
+ * decreases what it may do unattended. Neither direction ever hands a coworker
+ * authority it did not already have.
+ */
+import type { QualityTier } from "@/lib/routing/quality-tiers";
+import type {
+  ProactivityActionBoundary,
+  ProactivityLevel,
+} from "@/lib/proactivity/proactivity-types";
+import type { VerificationDepth } from "@/lib/golden-triangle";
+
+const PROACTIVITY_RANK: Record<ProactivityLevel, number> = {
+  quiet: 0,
+  balanced: 1,
+  assertive: 2,
+};
+
+/** Ascending in RESTRICTIVENESS: preauthorized is the most permissive. */
+const BOUNDARY_RANK: Record<ProactivityActionBoundary, number> = {
+  preauthorized: 0,
+  propose: 1,
+  advise: 2,
+};
+
+const TIER_RANK: Record<QualityTier, number> = {
+  basic: 0,
+  adequate: 1,
+  strong: 2,
+  frontier: 3,
+};
+
+const VERIFICATION_RANK: Record<VerificationDepth, number> = {
+  none: 0,
+  shallow: 1,
+  deep: 2,
+};
+
+function pickHigher<T extends string>(
+  current: T,
+  candidate: T | null | undefined,
+  rank: Record<T, number>,
+): T {
+  if (candidate == null) return current;
+  return rank[candidate] > rank[current] ? candidate : current;
+}
+
+/** Raise persistence only. A derivation can never make a coworker quieter. */
+export function tightenProactivityLevel(
+  current: ProactivityLevel,
+  candidate: ProactivityLevel | null | undefined,
+): ProactivityLevel {
+  return pickHigher(current, candidate, PROACTIVITY_RANK);
+}
+
+/** Restrict authority only. A derivation can never widen the action boundary. */
+export function tightenActionBoundary(
+  current: ProactivityActionBoundary,
+  candidate: ProactivityActionBoundary | null | undefined,
+): ProactivityActionBoundary {
+  return pickHigher(current, candidate, BOUNDARY_RANK);
+}
+
+/** Raise the quality floor only. A derivation can never lower a tier floor. */
+export function tightenMinimumTier(
+  current: QualityTier | undefined,
+  candidate: QualityTier | null | undefined,
+): QualityTier | undefined {
+  if (candidate == null) return current;
+  if (current === undefined) return candidate;
+  return pickHigher(current, candidate, TIER_RANK);
+}
+
+/** Deepen verification only. A derivation can never drop a verification requirement. */
+export function tightenVerificationDepth(
+  current: VerificationDepth | undefined,
+  candidate: VerificationDepth | null | undefined,
+): VerificationDepth | undefined {
+  if (candidate == null) return current;
+  if (current === undefined) return candidate;
+  return pickHigher(current, candidate, VERIFICATION_RANK);
+}
+
+/**
+ * Damping is the ONE derived effect that reduces something, so it is expressed
+ * separately and constrained by construction: it lowers the proactivity LEVEL
+ * (cadence and channel) by at most one step and touches nothing else. It cannot
+ * reach the action boundary, the tier floor or the verification depth, so
+ * out-of-hours damping can never hand a coworker authority (design §3.2, §6).
+ */
+export function dampProactivityLevel(current: ProactivityLevel): ProactivityLevel {
+  return current === "assertive" ? "balanced" : current === "balanced" ? "quiet" : "quiet";
+}
+
+export const TIGHTEN_RANKS = {
+  proactivity: PROACTIVITY_RANK,
+  boundary: BOUNDARY_RANK,
+  tier: TIER_RANK,
+  verification: VERIFICATION_RANK,
+} as const;

--- a/docs/superpowers/plans/2026-08-22-work-posture-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-22-work-posture-implementation-plan.md
@@ -1,0 +1,108 @@
+---
+status: active
+---
+
+# Work Posture — implementation plan
+
+**Epic:** `EP-WORK-POSTURE`
+**Design:** [Work Posture design](../specs/2026-08-22-workroom-work-posture-design.md)
+**Kernel consult:** `DI-D2A1964BD351` — `derive-and-layer`, composite 10.603, margin 6.373, high confidence
+
+## Backlog coverage
+
+| Slice | Item | Size | Content |
+| --- | --- | --- | --- |
+| A | `BI-462F3AF7` | small | Temporal band resolver over the existing operating-hours substrate |
+| B | `BI-0C5A83A8` | medium | Work-posture resolver — the precedence ladder, tighten-only invariant, provenance |
+| C | `BI-B32E8C32` | small | `taskClass` is dead in the Golden Triangle compiler — make it live as the shape carrier |
+| D | `BI-4F468192` | medium | Room-scoped posture — declaration on `scopeClaims` + derivation from shape/stream/clock |
+| E | `BI-13ED1BE1` | large | `verificationDepth` becomes load-bearing; the two HITL ladders join |
+| F | `BI-5087F34F` | medium | Scheduled work records its trigger, room and obligation |
+| G | `BI-BEDAFF57` | small | Archetype posture conformance test over the whole catalogue |
+| H | `BI-4EB2F1D0` | medium | Room surface renders the posture and its provenance |
+
+## Ordering and why
+
+The ordering is chosen so that **nothing changes behaviour until D**, and D is a single,
+reviewable switch-on rather than a diffuse one.
+
+```
+A ──► B ──► D ──► H
+      ▲     │
+C ────┘     ├──► E
+            └──► F
+G (independent — depends only on D's derivation table)
+```
+
+- **A and B are pure and inert.** They compute; nothing calls them. They can land and sit
+  in the tree with zero runtime risk, which is what makes the invariant testing worth
+  doing thoroughly before anything depends on it.
+- **C is independently valuable.** Making `taskClass` live is a defect fix in its own
+  right and is Balanced-inert on its own.
+- **D is the switch-on.** One slice, one review, one place to look if posture behaviour
+  changes unexpectedly.
+- **E, F, H, G follow D** and are independently shippable against it.
+
+## Phase 1 — the derivation core (this branch: A + B)
+
+Pure, deterministic, no I/O, no caller. Delivered together because B consumes A and
+neither is meaningful alone.
+
+1. **Temporal band resolver.** Pure function over `(now, weeklySchedule, timezone,
+   lowTrafficWindows, dueAt, warningWindow)` returning one band. Reads the existing
+   operating-hours contract types; introduces no second calendar and no second timezone
+   resolution path.
+2. **Exemption list.** `security-incident`, `platform-health`, `queue-health`, and a late
+   `field-dispatch-appointment` never receive a damping effect. Explicit and tested — the
+   silently damped security incident is the failure this design most needs to prevent.
+3. **Work-posture resolver.** The §3.1 ladder as a pure composition over both existing
+   engines, emitting `PolicyAdjustment` provenance for every clamp.
+4. **Tighten-only enforcement.** Not a convention — a mechanism. The composition applies
+   derived deltas through a clamp function that can only move a value in the tightening
+   direction, so a widening derivation is unrepresentable rather than merely untested.
+5. **Balanced-inert no-regression test**, in the shape of the existing
+   `golden-triangle/hot-path-no-regression.test.ts`.
+
+**Exit criteria.** Unit tests green for the affected packages; production build clean;
+every band reachable in test including DST and a closed-all-week schedule; the tighten-only
+property asserted over the full cross-product of derived vs. inherited postures.
+
+No UX verification applies — Phase 1 has no surface. No migration applies — Phase 1 adds
+no schema.
+
+## Phase 2 — make the compiler read its own input (C)
+
+Task-class table in `compileGoldenTrianglePolicy`, bumping the compiler version. Guarded
+by the existing compile snapshots so that an unknown or default task class compiles
+exactly as it does today.
+
+## Phase 3 — switch on at the room (D), then G
+
+The room declaration reader/writer on `scopeClaims`, the shape and archetype derivation,
+wired at the room-scoped seams only. The non-room inference path is untouched. G follows
+immediately, because the archetype conformance test is what proves the derivation reaches
+all 111 leaf archetypes rather than the one that field dispatch supplies today.
+
+## Phase 4 — enforcement and triggers (E, F)
+
+E is the largest slice and the one that changes what the platform will *refuse* to do, so
+it lands alone. F follows.
+
+## Phase 5 — surface (H)
+
+Carries the UX-fit manifest and live UX verification.
+
+## Risks and how each is bounded
+
+| Risk | Bound |
+| --- | --- |
+| A derivation quietly widens authority | Tighten-only is a mechanism, not a convention (Phase 1 step 4); asserted at both B and D |
+| Out-of-hours damping silences an incident | Explicit exemption list, tested, named in the spec |
+| Posture behaviour changes before anyone intends it | A and B ship inert; D is the single switch-on |
+| Per-archetype authoring creeps in | G's conformance test; the spec names an authored posture table as the defect to prevent |
+| The compiler version bump breaks receipt reading | Receipts carry `compilerVersion`; the bump is additive and old receipts stay interpretable |
+
+## Out of scope
+
+Everything in the design's §11 non-goals: no replacement of either engine, no new decision
+engine, no per-archetype authoring, no second calendar, no new table.

--- a/docs/superpowers/specs/2026-08-22-workroom-work-posture-design.md
+++ b/docs/superpowers/specs/2026-08-22-workroom-work-posture-design.md
@@ -1,0 +1,277 @@
+---
+status: active
+---
+
+# Work Posture — making proactivity and the Golden Triangle workroom-, shape- and time-aware
+
+**Epic:** `EP-WORK-CONVERGENCE` (posture ladder) · `EP-1C37C089` (gate binding)
+**Status:** Design — approved direction, decomposition in §9
+**Kernel consult:** `DI-D2A1964BD351` — `derive-and-layer` recommended, composite 10.603, margin 6.373, high confidence, no commandment conflict
+
+Proactivity and the Golden Triangle were designed before the Workroom existed. Both
+resolve against *who* is acting (agent, org, platform) and, for proactivity, a flat
+`activityFamily`. Neither knows *what shape of work is happening*, *what the archetype's
+value stream demands*, or *what time it is for the business*. This design closes that
+without replacing either engine: one pure composition layer derives posture from
+substrate that already exists, and lets a room declare an override.
+
+> **The room's shape bounds what is permitted; the posture decides how hard and how fast
+> the coworker pushes inside those bounds. A derivation may tighten authority. It may
+> never widen it.**
+
+---
+
+## 1. What is actually true today
+
+Every claim here is code-verified, not inferred.
+
+| # | Finding | Evidence |
+| --- | --- | --- |
+| 1 | **Neither posture knows the room.** Proactivity scopes are `agent:` → `route-context:` → `activity-family:`. Golden Triangle scopes are agent → organization → platform. `Workroom` appears in neither ladder. | `proactivity-resolver.server.ts` `scopeKeysForInput`; `golden-triangle/persistence.ts` `getEffectivePostureForAgent` |
+| 2 | **`taskClass` is a dead input.** It is declared on `CompileInput`, threaded through every caller, and **never read** by `compileGoldenTrianglePolicy`. Every live caller passes the literal `"conversation"`. The "what kind of work is this" slot already exists and does nothing. | `golden-triangle/types.ts` `CompileInput.taskClass`; `compile.ts` (no reference); `dispatch.ts`, `coworker-review.ts`, `telemetry-receipts.ts` |
+| 3 | **There is no temporal input.** `ProactivityResolverInput` carries `deadlineWindowDays`, consulted for exactly one family (`tax-compliance`, ≤ 7 days). Nothing damps immediacy when the business is closed; nothing raises it when it is open and the work is load-bearing. | `proactivity-types.ts`; `proactivity-resolver.ts` `resolveLevel` |
+| 4 | **Operating-hours substrate exists and is unused by posture.** `BusinessProfile.businessHours` + `timezone` + `lowTrafficWindows` are read by the self-upgrade window and deployment windows. No proactivity or routing path consults them. | `operating-hours-read.ts`, `operating-hours-types.ts`, `actions/deployment-windows.ts` |
+| 5 | **`verificationDepth` is inert.** The compiler emits it, the chips render it, the right-sizing dial reads it as a label — **no verification step is gated by it**. "Marketing and payroll require verification" is currently unenforceable. | `compile.ts` header comment; only consumers are `posture-display.ts`, `GoldenTriangleOutcomes.tsx`, `explore/build-rightsizing-dial.ts`, `receipt.ts` |
+| 6 | **Archetype awareness is one archetype deep.** `ProactivityResolverInput.archetype` accepts `demandSignature` / `capacityUnit` / `loadBearingStageKeys` / `trustGates`. The **only** supplier is field dispatch. The OVSM projection already derives all four for every leaf archetype. | `field-dispatch-proactivity.ts` is the sole populator; `packages/storefront-templates/src/operational-value-stream.ts` derives them universally |
+| 7 | **Scheduled work carries no posture and no trigger.** `ScheduledAgentTask` holds cron + timezone + `taskKind` + `taskConfig`. The proactivity plan is consulted only *after a failure*, to size retry cadence. Nothing records **why** the job exists, so nothing can judge immediacy at fire time. | `ai-coworker.prisma` `ScheduledAgentTask` (`attempts` comment); `attention/sources/scheduled-task.ts` |
+| 8 | **The posture never reaches the autonomy envelope.** `resolveWorkCaseAutonomyEnvelope` decides HITL from trust level, risk class and regulatory ceiling. The proactivity plan's `actionBoundary` (`advise`/`propose`/`preauthorized`) is a **parallel, unjoined** ladder. Two mechanisms decide "may a human be skipped" and they never meet. | `work-management/autonomy-envelope.ts` vs `proactivity-types.ts` `ProactivityActionBoundary` |
+
+**The one place the two postures are already treated as one thing** is
+`proactivity/delegated-posture.ts`, which composes a caller's proactivity *and* Golden
+Triangle preference for a delegated subtask, with `regulated` / `qualityCritical`
+receiver overrides that the receiver may not have traded away. That module is the seed
+this design generalizes — it is not new thinking, it is thinking that was applied to one
+narrow path and never promoted.
+
+## 2. Why this is a design problem and not five bug fixes
+
+Findings 1–8 look like eight independent gaps. They are one gap seen from eight angles:
+**posture is resolved from identity, and work is not identity.** A `finance-controller`
+coworker has one proactivity level and one Cost/Quality/Time posture, whether it is
+drafting a marketing note at 9pm on a Saturday or releasing a payroll run on the
+statutory due date. Identity is a poor proxy for what the work needs.
+
+The four things that actually determine what a turn needs are all already modelled
+somewhere in the platform, and none of them reach the posture:
+
+- **shape** — what kind of collaboration this is (`WorkroomShapeKey`, `activityKind`, `mode`)
+- **stream** — what the archetype's operational value stream demands (OVSM)
+- **clock** — where "now" sits against operating hours and the obligation's deadline
+- **stakes** — whether this action is outward-facing, moves money, or is regulated
+
+## 3. Approach: derive and layer
+
+Rejected alternatives, with the kernel's scoring in `DI-D2A1964BD351`:
+
+- **Unify into one new primitive** (composite 4.230). Replacing both engines and migrating
+  every caller — CRM packs, field dispatch, stall surface, build custodian, attention
+  sources, the dispatch hot path, coworker panels — buys a cleaner diagram at the cost of
+  a large blast radius and a long period where posture behaviour is unproven. Rejected.
+- **Author posture per archetype** (composite 2.431). 111 leaf archetypes each hand-tuned
+  is unmaintainable, drifts on the first archetype addition, and contradicts the OVSM
+  contract's own rule — *derive, never author*. Rejected.
+
+**Adopted:** one pure composition layer over the two existing engines. No new tables. No
+replacement. The room-level declaration rides `Workroom.scopeClaims` exactly as the
+declared collaboration shape already does (`workroom-shape-claim.ts`), so this lands
+migration-free and folds into a first-class column when W2 referential integrity ships.
+
+### 3.1 The single ladder
+
+Both postures resolve through one precedence order:
+
+```
+1. Hard policy          residency · sensitivity ceiling · regulated ceiling   (never relaxed)
+2. Room declaration     an explicit choice made when the room was convened
+3. Derived              work shape × archetype stream × temporal band × stakes
+4. Agent                the coworker's own saved posture
+5. Org / activity-family
+6. Platform default     Balanced / balanced — byte-identical to today
+```
+
+Layer 3 is the new one. Layers 1, 4, 5 and 6 already exist and keep their current
+meaning; layer 2 is new but is a straight reuse of the shape-claim mechanism.
+
+### 3.2 The safety invariant
+
+> **A derivation may tighten. It may never widen.**
+
+This mirrors the Golden Triangle's existing "residency is never relaxed" rule and is the
+property that makes it safe to ship a derivation on the hot path:
+
+- A derived posture may raise a proactivity level, tighten an `actionBoundary`
+  (`preauthorized` → `propose` → `advise`), raise a tier floor, or add a verification
+  requirement.
+- A derived posture may **never** loosen an `actionBoundary`, lower a tier floor, remove
+  a verification requirement, or relax residency. Out-of-hours damping changes **cadence
+  and channel only** — never authority.
+- Every clamp is recorded as a `PolicyAdjustment` with a stable `reasonCode`, so the
+  operator sees *why* their setting did not apply, exactly as the compiler does today.
+- **Damping is the single reducing lever, and it is separate by construction.** A bias that
+  wants a coworker to be quieter sets `damp`; it cannot express that as a proactivity
+  level, because the clamps only raise. This is what keeps "be less noisy" from ever being
+  a route to "act unattended" — the two live in different parameters, and `damp` has no
+  access to the authority axes. A derivation table entry that tries to say "quiet" the
+  other way is inert, and a conformance test rejects it rather than letting it read as
+  working.
+
+Combined with **Balanced-inert** (a fully default context derives no deltas, so the
+composed result is byte-identical to today) this makes the layer shippable on the shared
+inference path without a flag-day.
+
+## 4. Deriving from shape
+
+The four shape axes are already live code. Each contributes a *bias*, declared once in a
+code table — not authored per room and not per archetype.
+
+| Shape / kind | Proactivity bias | Priority bias | Boundary floor |
+| --- | --- | --- | --- |
+| `change-consequential` | balanced | quality | `propose` |
+| `approval-sign-off` | balanced | quality + verification | `propose` |
+| `outward-review` | balanced | quality + verification | `propose` |
+| `escalation` | **assertive** | time | `propose` |
+| `specialist-alignment` | balanced | balanced | — |
+| `craft-stewardship` | damped one step | cost-tolerant | — |
+| `activityKind: remediation` | assertive | time | — |
+| `activityKind: governance` | balanced | quality | `propose` |
+| `mode: standing` | damped one step between cycles | — | — |
+
+`taskClass` (finding 2) is the carrier: the resolver passes the room's shape as the
+task class, and `compileGoldenTrianglePolicy` gains a task-class table. This turns a dead
+contract field into the load-bearing one, rather than adding a parallel input.
+
+## 5. Deriving from the archetype's stream
+
+No per-archetype authoring. The OVSM projection already derives four properties for every
+leaf archetype; the resolver consumes those four:
+
+- `demandSignature` — `emergency-reactive` and `synchronized-contention` raise immediacy;
+  `fiscal-calendar` binds the work to deadline bands; `steady` contributes nothing.
+- `capacityUnit` — perishable and contended units (`slot-hours`, `perishable-stock`,
+  `physical-hard-cap`) raise immediacy, because unused capacity is destroyed rather than
+  deferred.
+- `loadBearingStageKeys` — work on a load-bearing stage raises immediacy.
+- `trustGates` — a stage carrying a trust gate raises the **verification** floor.
+
+"All archetypes require adjustment" is therefore satisfied *mechanically*: a conformance
+test asserts every leaf archetype resolves a posture from its own OVSM, and adding a new
+archetype inherits the behaviour with no posture authoring. This is the same discipline
+the OVSM itself declares — derive, never author.
+
+## 6. Deriving from the clock
+
+A pure function of `(now, weeklySchedule, timezone, lowTrafficWindows, dueAt)` yields one
+temporal band. It reads the operating-hours substrate that already exists (finding 4);
+it does not introduce a second calendar.
+
+| Band | Meaning | Effect |
+| --- | --- | --- |
+| `in-hours` | inside the business's operating window | no change |
+| `out-of-hours` | business closed | immediacy damped one step; channel drops to in-app; **cadence only, authority unchanged** |
+| `low-traffic` | inside a declared low-traffic window | cost-tolerant priority; batch-friendly |
+| `pre-deadline` | inside the obligation's warning window | immediacy raised one step |
+| `breach-imminent` | at or past the due boundary | assertive floor |
+
+**Out-of-hours exemptions.** Damping is wrong for work whose harm accrues while the
+business is closed. These families are exempt and stay at their derived level:
+`security-incident`, `platform-health`, `queue-health`, and any
+`field-dispatch-appointment` already running late. The exemption list is explicit and
+tested — a silent damp on a security incident is the failure mode this design most needs
+to avoid.
+
+## 7. Stakes: making verification load-bearing
+
+Finding 5 is the sharpest gap. Three stake classes carry a **quality floor plus mandatory
+verification** expressed as `PolicyConstraints` the posture cannot trade away:
+
+- **outward-facing** — anything that leaves the business under its own name (marketing
+  sends, customer communication, published content)
+- **money-movement** — payroll runs, disbursements, refunds
+- **regulated** — statutory filing, licensed advice
+
+For these, `verificationDepth: "deep"` stops being decorative: the autonomy envelope
+requires the verification receipt on the case before the action may close. The denial
+reason joins the existing named set alongside `missing_decision_interaction` and
+`stop_condition_tripped` — it is a policy denial, not a generic refusal.
+
+This is also where finding 8 closes: the proactivity `actionBoundary` and the autonomy
+envelope's `decisionMode` become **one projection**, with the stricter of the two winning.
+A `preauthorized` proactivity setting can no longer imply autonomy that the envelope
+would deny, and an `autonomous-action` envelope can no longer act on work whose shape
+declared `propose`.
+
+## 8. Triggers on scheduled work
+
+Finding 7: a scheduled job knows *when* it fires and nothing about *why*. The four
+trigger sources are already named in the governed value-stream design (§5.1) — time,
+user request, incoming message, detected need. Scheduled work records:
+
+- the **trigger kind** it represents,
+- the **room / shape** it serves, so posture resolves through §3.1 at fire time rather
+  than from cron alone,
+- the **obligation** it discharges, where one exists, so §6's deadline bands apply.
+
+The immediate consequence: a job that fires at 03:00 to discharge an obligation due at
+09:00 resolves `pre-deadline`, not `out-of-hours`. Today it would resolve neither,
+because the resolver is never asked.
+
+## 9. Decomposition
+
+Each slice is independently shippable and independently inert until the next lands.
+
+| Slice | Content | Inert until |
+| --- | --- | --- |
+| **A** | Temporal band resolver — pure function over the existing operating-hours substrate, with the exemption list. No caller. | B |
+| **B** | Work-posture resolver — the §3.1 ladder as a pure composition over both engines, with `PolicyAdjustment` provenance and the tighten-only invariant. Not wired. | D |
+| **C** | Task-class table in the Golden Triangle compiler — makes the dead `taskClass` field live; shape → priority bias. Balanced-inert. | — |
+| **D** | Room declaration + room-derived posture — `scopeClaims` reader/writer, shape and archetype derivation, wired at the room-scoped seams. | — |
+| **E** | Verification becomes load-bearing — stake classes, the envelope join, the new named denial reason. | — |
+| **F** | Scheduled-work trigger record — trigger kind, room/shape link, obligation link, posture at fire time. | — |
+| **G** | Archetype conformance — a test asserting every leaf archetype resolves a posture from its own OVSM. | — |
+| **H** | Surface — the posture and its provenance rendered on the room, answering "why is it behaving like this". | D |
+
+## 10. Research & Benchmarking
+
+Three comparable open-source approaches to context-sensitive autonomy and scheduling
+posture were examined before settling on derive-and-layer.
+
+- **Temporal (temporal.io) — workflow policy inheritance.** Retry policies, timeouts and
+  task-queue priority are declared per workflow *type* and overridable per execution,
+  with the child inheriting the parent's policy unless it declares its own. DPF **adopts**
+  the inheritance-with-explicit-override precedence and the principle that a policy is
+  attached to the *work definition*, not the worker. DPF **rejects** Temporal's
+  worker-side policy resolution: our equivalent must resolve where governance can see it,
+  because the posture feeds an authority decision, not just a retry count.
+- **Kubernetes — PriorityClass, PodDisruptionBudget and maintenance windows.** Scheduling
+  urgency is a named class attached to the workload, and disruption is bounded by an
+  independently-declared budget that the scheduler may not trade away. DPF **adopts**
+  exactly this split: derived urgency (our temporal band and shape bias) is separate from,
+  and subordinate to, an inviolable budget (our `PolicyConstraints`). This is the direct
+  precedent for §3.2's tighten-only invariant.
+- **OPA / Open Policy Agent — external decision point with a decision log.** Policy is
+  evaluated outside the calling code and every decision is logged with its inputs. DPF
+  **adopts** the decision-log discipline — every derived posture carries its
+  `PolicyAdjustment` provenance so an operator can see which layer won and why. DPF
+  **rejects** the external-PDP topology for this layer: the posture resolver must stay a
+  pure function on the hot path, fail-open, with `principle_decide` remaining the only PDP.
+
+**Standards basis.** The tighten-only invariant and the mandatory-verification classes
+are the NIST AI RMF *Manage* function applied concretely: risk controls that automation
+may tighten but not relax, with a recorded basis for each decision. The HITL join in §7
+implements the `human-in-the-loop-at-phase-boundaries` commandment at a boundary that is
+currently unguarded — a posture setting must not be able to purchase autonomy.
+
+## 11. Non-goals
+
+- Not replacing the proactivity resolver or the Golden Triangle compiler — this composes them.
+- Not a new decision engine; `principle_decide` remains the PDP.
+- Not per-archetype posture authoring (§5), and not a new calendar (§6).
+- Not a new table — the room declaration rides `scopeClaims` until W2 lands.
+
+## 12. Related
+
+- [Work shapes and the decision gate](../../architecture/work-shapes-and-the-decision-gate.md) — the shape axes and the gate this posture sits beside
+- [Golden Triangle Decision Primitive](../../design/golden-triangle-design.md) — the preference-to-policy compiler
+- [AI Coworker Proactivity Policy](2026-06-29-ai-coworker-proactivity-policy-design.md) — the proactivity engine
+- [Governed Value-Stream Lifecycles](2026-08-15-governed-value-stream-lifecycles-design.md) — §5.1 names the four triggers this design binds
+- [A Governance Gate on Consequential Tool Use](2026-08-13-wwwd-constitutional-alignment-gate.md) — the envelope this posture must not be able to widen


### PR DESCRIPTION
## Why

Proactivity and the Golden Triangle were designed before the Workroom existed. Both resolve against **who is acting** — agent, org, platform, plus a flat `activityFamily` — and never against what shape of work is happening, what the archetype's value stream demands, or what time it is for the business. A `finance-controller` has one proactivity level and one cost/quality/time posture whether it is drafting a note at 9pm on a Saturday or releasing payroll on the statutory due date.

The investigation behind this branch found eight gaps. They are not eight bugs; they are one gap seen from eight angles — **posture is resolved from identity, and work is not identity.** Two of them are sharper than expected:

- **`taskClass` is a dead input.** It is a required field on the Golden Triangle's `CompileInput`, threaded through every caller, and never read by `compileGoldenTrianglePolicy`. Every live caller passes the literal `"conversation"`. The "what kind of work is this" slot already exists and does nothing. (`BI-B32E8C32`)
- **`verificationDepth` is decorative.** It is compiled, rendered as a "Deep verification" chip, and written to receipts — but gates no verification step. `compile.ts` says so in its own header. An operator can set Assured on a payroll run, see the chip, and the action completes unverified. (`BI-13ED1BE1`)

Also: the operating-hours substrate (`businessHours` / `timezone` / `lowTrafficWindows`) already exists and already drives self-upgrade and deployment windows — no coworker path reads it. And `ProactivityResolverInput.archetype` accepts four OVSM properties that the projection derives for all 111 leaf archetypes, but field dispatch is the only supplier.

Full evidence table in the spec §1, each row citing the file it was verified against.

## What this PR contains

Phase 1 of `EP-WORK-POSTURE`: the governing design and plan, plus the **pure derivation core** they specify.

- `BI-462F3AF7` — temporal band resolver: `in-hours` · `out-of-hours` · `low-traffic` · `pre-deadline` · `breach-imminent`, over the **existing** operating-hours substrate. No second calendar, no second timezone-resolution path.
- `BI-0C5A83A8` — work-posture resolver: one precedence ladder (hard policy > room declaration > derived > agent > org > platform) composed over **both** existing engines. Neither engine is replaced.

**Nothing calls this code.** There is no import of `@/lib/work-posture` outside the new directory, no schema change, no migration, no route, no UI. That is deliberate — the switch-on is a single later reviewable slice (`BI-4F468192`), so if posture behaviour ever changes unexpectedly there is one place to look.

## The two properties that make this safe to wire up later

**Tighten-only — a mechanism, not a convention.** Derived deltas are applied only through clamps that move a value in one direction, so a widening derivation is *unrepresentable* rather than merely untested. Damping — the single reducing lever — takes and returns a proactivity level and nothing else, so out-of-hours quieting structurally cannot reach the action boundary, tier floor, or verification depth. "The business is closed" can never become "act unattended."

**Balanced-inert.** A fully default context derives no deltas, so the composed result is the inherited posture unchanged.

Damping is also wrong for work whose harm accrues while the business is shut, so `security-incident`, `platform-health`, `queue-health` and a late field dispatch are exempt outright — explicitly and by test. A silently damped security incident is the failure mode this design most needs to avoid.

## On archetypes

No per-archetype posture tables. The OVSM projection already derives `demandSignature`, `capacityUnit`, `loadBearingStageKeys` and `trustGates` for every leaf archetype; the resolver consumes those four. "All archetypes adjusted" is satisfied **mechanically** — `BI-BEDAFF57` adds a conformance test so a new archetype inherits the behaviour with no posture authoring. An authored per-archetype table is the defect that BI exists to prevent.

## A defect found and fixed in self-review

The first revision declared `craft-stewardship: { proactivityLevel: "quiet" }`. Because the clamps only *raise*, that bias was silently inert — the exact class of dead control this epic exists to remove, reproduced inside the change meant to fix it. Fixed to `damp: true`, documented at the type and the module header, and locked by a new conformance test (`derive.test.ts`) asserting no derivation table entry can express quiet in a way the clamps ignore, and that every declared bias actually changes something.

## Verification

- **Unit tests** — 58 passed / 4 files / 0 failed for `lib/work-posture`. Regression sweep across `lib/work-posture lib/proactivity lib/golden-triangle`: 24 files, 200 passed, 0 failed.
- **Production build** — `pnpm --filter web build` exits 0. (27 "Ecmascript file had an error" lines in the log are pre-existing Node-builtin-in-edge-graph warnings in unrelated modules; none reference the new directory.)
- **Preflight guards** — 47 clean.
- **Doc gates** — `docs:index` regenerated (no diff), `check:doc-links` 22/22, diagrams fresh.
- **Not run, and why** — no UX verification (this change has no surface; the provenance surface is `BI-4EB2F1D0`, filed not built). No migration check (no schema change).

The tighten-only invariant is asserted as a property, not by example: a 17-context list crossed with every inherited level and boundary, plus exhaustive cross-product monotonicity over all four rank tables. Timezone handling is asserted across a real DST transition and an unknown IANA zone.

## Honest note on the semantic-review receipt

The receipt for this tree is `disposition: auto-pass`, and **no Change Reviewer actually ran** — the rationale reads "code-change at risk=low below activation threshold high". I recognised the under-classification and re-called with `risk: high`, but the tool returned the cached receipt (`reusedFreshReceipt: true`) still stamped `risk: low`. Receipts cache on tree identity, so an author's initial risk call is final for that tree.

That is a real gap in the gate — the author of a change unilaterally decides whether it is independently reviewed, and the first answer sticks — so I filed it as **`BI-888825F6`** rather than quietly accepting the pass. The gate is in `shadow` mode today, so nothing is being bypassed; it becomes load-bearing when the mode is ratcheted, which is the right time to have fixed it.

## Filed, not built

`BI-B32E8C32` (taskClass) · `BI-4F468192` (room switch-on) · `BI-13ED1BE1` (verification becomes load-bearing; the two HITL ladders join) · `BI-5087F34F` (scheduled-work triggers) · `BI-BEDAFF57` (archetype conformance) · `BI-4EB2F1D0` (provenance surface).

`BI-13ED1BE1` is the one I would sequence next — it is the slice that changes what the platform will *refuse* to do.

## Decision record

Approach chosen by kernel consult `DI-D2A1964BD351`: **derive-and-layer** (composite 10.603) over unifying both engines into one new primitive (4.230) and over per-archetype authoring (2.431). High confidence, margin 6.373, no commandment conflict.

---

Epic: `EP-WORK-POSTURE` · Workroom: `WC-FDCA77BE`
Spec: `docs/superpowers/specs/2026-08-22-workroom-work-posture-design.md`
Plan: `docs/superpowers/plans/2026-08-22-work-posture-implementation-plan.md`

Local-CI-Evidence: cmt4n7mab03yw01ohtem7yxnj (feat/workroom-work-posture@ac7d4e01c96b)
