### PR TITLE
fix(build-studio): package sandbox source closure (BI-F697A831)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,13 @@ COPY scripts/set-hooks-path.mjs ./scripts/
 COPY scripts/lib/resolve-capability-compose-profiles.mjs ./scripts/lib/
 COPY scripts/lib/govern-capability-compose-args.mjs ./scripts/lib/
 COPY scripts/lib/capability-state-hash.mjs ./scripts/lib/
+# apps/web-src is copied from this stage into the runner for Build Studio's
+# first-install sandbox. Keep every repo-relative import used by that source in
+# the same source bundle; otherwise the production portal can be healthy while
+# the sandbox's `next dev` exits with "Module not found".
+COPY scripts/lib/capability-service-projection.mjs ./scripts/lib/
+COPY scripts/lib/transition-signing.mjs ./scripts/lib/
+COPY scripts/installer/resolve-host-identity.mjs ./scripts/installer/
 COPY scripts/capability-service-catalog.generated.json ./scripts/
 COPY scripts/installer/validate-install-state.mjs ./scripts/installer/
 COPY scripts/installer/install-state-transaction.mjs ./scripts/installer/

--- a/apps/web/lib/verify/dockerfile-build-context.guard.test.ts
+++ b/apps/web/lib/verify/dockerfile-build-context.guard.test.ts
@@ -28,6 +28,7 @@ import { extractStaticImports } from "./bundle-boundary";
 const REPO_ROOT = resolve(__dirname, "..", "..", "..", "..");
 const APPS_WEB = join(REPO_ROOT, "apps", "web");
 const DOCKERFILE = join(REPO_ROOT, "Dockerfile");
+const DOCKER_ENTRYPOINT = join(REPO_ROOT, "docker-entrypoint.sh");
 
 type Stage = { name: string; parent: string | null; body: string[] };
 
@@ -53,19 +54,19 @@ function parseStages(dockerfile: string): Stage[] {
  * FROMs (filesystem is inherited down the chain). `--from=<stage>` COPYs pull
  * from other image stages, not the build context, so they're excluded.
  */
-function copyAllowlistForBuildStage(stages: Stage[]): {
+function copyAllowlistForStage(stages: Stage[], stageName: string): {
   dirPrefixes: string[];
   exactFiles: string[];
 } {
   const byName = new Map(stages.map((s) => [s.name, s]));
-  const buildStage = stages.find((s) => s.body.some((l) => /\bnext build\b/.test(l)));
-  if (!buildStage) {
-    throw new Error("Dockerfile: could not find the stage that runs `next build`");
+  const targetStage = byName.get(stageName);
+  if (!targetStage) {
+    throw new Error(`Dockerfile: could not find stage \`${stageName}\``);
   }
 
   // Walk the FROM chain from the build stage up to the base image.
   const chain: Stage[] = [];
-  let cursor: Stage | undefined = buildStage;
+  let cursor: Stage | undefined = targetStage;
   const seen = new Set<string>();
   while (cursor && !seen.has(cursor.name)) {
     seen.add(cursor.name);
@@ -97,6 +98,17 @@ function copyAllowlistForBuildStage(stages: Stage[]): {
   return { dirPrefixes, exactFiles };
 }
 
+function copyAllowlistForBuildStage(stages: Stage[]): {
+  dirPrefixes: string[];
+  exactFiles: string[];
+} {
+  const buildStage = stages.find((s) => s.body.some((l) => /\bnext build\b/.test(l)));
+  if (!buildStage) {
+    throw new Error("Dockerfile: could not find the stage that runs `next build`");
+  }
+  return copyAllowlistForStage(stages, buildStage.name);
+}
+
 function isCovered(
   repoRelPath: string,
   allow: { dirPrefixes: string[]; exactFiles: string[] },
@@ -125,6 +137,27 @@ function collectSourceFiles(dir: string, acc: string[] = []): string[] {
   return acc;
 }
 
+function escapingImportViolations(
+  files: string[],
+  allow: { dirPrefixes: string[]; exactFiles: string[] },
+): string[] {
+  const violations: string[] = [];
+  for (const file of files) {
+    const specs = extractStaticImports(readFileSync(file, "utf8"));
+    for (const spec of specs) {
+      if (!spec.startsWith(".")) continue;
+      const resolved = resolve(join(file, ".."), spec);
+      const repoRel = relative(REPO_ROOT, resolved);
+      if (repoRel.startsWith("..")) continue;
+      if (isCovered(repoRel, allow)) continue;
+      violations.push(
+        `${relative(REPO_ROOT, file)} imports "${spec}" → ${repoRel} (not COPYed into the stage)`,
+      );
+    }
+  }
+  return violations;
+}
+
 describe("Dockerfile build context covers every escaping build-time import", () => {
   const allow = copyAllowlistForBuildStage(parseStages(readFileSync(DOCKERFILE, "utf8")));
   const files = collectSourceFiles(APPS_WEB);
@@ -136,25 +169,32 @@ describe("Dockerfile build context covers every escaping build-time import", () 
   });
 
   it("every static import that escapes apps/web resolves inside a COPYed path", () => {
-    const violations: string[] = [];
-    for (const file of files) {
-      const specs = extractStaticImports(readFileSync(file, "utf8"));
-      for (const spec of specs) {
-        if (!spec.startsWith(".")) continue; // bare/package specifiers, not context files
-        const resolved = resolve(join(file, ".."), spec);
-        const repoRel = relative(REPO_ROOT, resolved);
-        // In-tree (under apps/web) is covered by the `apps/web/` prefix; escaping
-        // imports must land inside another COPYed prefix.
-        if (repoRel.startsWith("..")) continue; // outside the repo entirely — ignore
-        if (isCovered(repoRel, allow)) continue;
-        violations.push(
-          `${relative(REPO_ROOT, file)} imports "${spec}" → ${repoRel} (not COPYed into the build stage)`,
-        );
-      }
-    }
+    const violations = escapingImportViolations(files, allow);
     expect(
       violations,
       `These build-time imports point at repo paths the production Dockerfile never COPYs into the \`next build\` stage, so the Docker image build fails "Module not found" at self-upgrade/deploy even though plain \`next build\` (CI) passes. Fix by adding a COPY for the containing directory to the build stage of the Dockerfile:\n  ${violations.join("\n  ")}`,
     ).toEqual([]);
+  });
+});
+
+describe("Docker runtime source bundle is complete for Build Studio", () => {
+  const dockerfile = readFileSync(DOCKERFILE, "utf8");
+  const stages = parseStages(dockerfile);
+  const initAllow = copyAllowlistForStage(stages, "init");
+  const files = collectSourceFiles(APPS_WEB);
+
+  it("packages every repo-relative dependency imported by the web source", () => {
+    const violations = escapingImportViolations(files, initAllow);
+    expect(
+      violations,
+      `These imports are present in apps/web-src but absent from the init stage copied into the runner, so a fresh Build Studio sandbox exits with \"Module not found\":\n  ${violations.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("bootstraps profession data and maps it back to its image source", () => {
+    const entrypoint = readFileSync(DOCKER_ENTRYPOINT, "utf8");
+    expect(entrypoint).toContain('cp -r /app/docs/professions/. "$WORKSPACE/docs/professions/"');
+    expect(entrypoint).toContain('docs/professions/*)');
+    expect(entrypoint).toContain("${1#docs/professions/}");
   });
 });

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -76,10 +76,11 @@ fi
 
 sync_image_source_to_workspace() {
   echo "  Syncing source volume from image version $IMAGE_VERSION..."
-  mkdir -p "$WORKSPACE/apps" "$WORKSPACE/packages" "$WORKSPACE/scripts"
-  rm -rf "$WORKSPACE/apps/web" "$WORKSPACE/packages" "$WORKSPACE/scripts"
-  mkdir -p "$WORKSPACE/apps/web" "$WORKSPACE/packages" "$WORKSPACE/scripts"
+  mkdir -p "$WORKSPACE/apps" "$WORKSPACE/docs" "$WORKSPACE/packages" "$WORKSPACE/scripts"
+  rm -rf "$WORKSPACE/apps/web" "$WORKSPACE/docs/professions" "$WORKSPACE/packages" "$WORKSPACE/scripts"
+  mkdir -p "$WORKSPACE/apps/web" "$WORKSPACE/docs/professions" "$WORKSPACE/packages" "$WORKSPACE/scripts"
   cp -r /app/apps/web-src/. "$WORKSPACE/apps/web/"
+  cp -r /app/docs/professions/. "$WORKSPACE/docs/professions/"
   cp -r /app/packages-src/. "$WORKSPACE/packages/"
   rm -rf "$WORKSPACE/apps/web/.next" \
          "$WORKSPACE/apps/web/tsconfig.tsbuildinfo" \
@@ -143,6 +144,9 @@ image_source_path_for_workspace_path() {
       ;;
     scripts/*)
       printf '/app/scripts/%s\n' "${1#scripts/}"
+      ;;
+    docs/professions/*)
+      printf '/app/docs/professions/%s\n' "${1#docs/professions/}"
       ;;
     pnpm-workspace.yaml | pnpm-lock.yaml | package.json | tsconfig.base.json | .gitignore)
       printf '/app/%s\n' "$1"


### PR DESCRIPTION
## Summary

- package all repo-relative script dependencies imported by `apps/web-src` into the runtime source bundle
- copy `docs/professions` into the first-install workspace and map it to the canonical image source
- generalize the Dockerfile guard so both build-time and Build Studio runtime source closures fail closed

## Evidence

- focused guard: 4/4 passed
- scoped `apps/web` typecheck: passed in the commit hook
- `docker-entrypoint.sh`: passed Alpine `/bin/sh -n`
- `pregate:preflight`: 47/47 guards passed on the rebased tree
- exact-tree `pnpm run pregate`: PASS for `d13c643ba06a` (evidence `cmt4ngvvx05dz01pjf5smfq10`)
- semantic-review receipt: fresh for base tree `bbc01fdc` / head tree `450b2773`; infrastructure-inconclusive with `mayPublish: true`, no issues

## Impact

- UX: not applicable; packaging/runtime repair with no rendered UI change
- Migration: not applicable; no schema or data migration

Backlog: BI-F697A831
Workroom: WC-680D80AE

Docs-Impact-Decision: Runtime image packaging and regression-guard repair only; no rendered route, workflow, or user-guide behavior changes.
