### PR TITLE
feat(payroll): US statutory engine and payroll tax emission (BI-4EB27955, BI-947F8703)

### DIFF
--- a/apps/web/lib/hr/payroll-tax-emission.test.ts
+++ b/apps/web/lib/hr/payroll-tax-emission.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  determineDepositCadence,
+  emitPayrollTaxSnapshots,
+  summarisePeriod,
+  type EmittablePayRun,
+} from "./payroll-tax-emission";
+
+function run(over: Partial<EmittablePayRun> = {}): EmittablePayRun {
+  return {
+    payRunId: "PR-0001",
+    payDate: new Date("2026-08-31T00:00:00.000Z"),
+    amounts: [
+      { taxType: "federal_withholding", side: "employee_withheld", taxableAmount: 5000, taxAmount: 633.33 },
+      { taxType: "social_security", side: "employee_withheld", taxableAmount: 5000, taxAmount: 310 },
+      { taxType: "social_security", side: "employer_contribution", taxableAmount: 5000, taxAmount: 310 },
+      { taxType: "medicare", side: "employee_withheld", taxableAmount: 5000, taxAmount: 72.5 },
+      { taxType: "medicare", side: "employer_contribution", taxableAmount: 5000, taxAmount: 72.5 },
+      { taxType: "futa", side: "employer_contribution", taxableAmount: 5000, taxAmount: 30 },
+    ],
+    ...over,
+  };
+}
+
+describe("emitPayrollTaxSnapshots", () => {
+  it("emits one snapshot per tax type and side, tagged as a payroll run", () => {
+    const snapshots = emitPayrollTaxSnapshots(run());
+    expect(snapshots).toHaveLength(6);
+    // sourceType is what lets these ride the existing sales-tax machinery.
+    expect(snapshots.every((s) => s.sourceType === "payroll_run")).toBe(true);
+    expect(snapshots.every((s) => s.sourceId === "PR-0001")).toBe(true);
+  });
+
+  it("dates the liability by pay date, not period end", () => {
+    const snapshots = emitPayrollTaxSnapshots(run());
+    // A deposit obligation is triggered by paying, not by the work being done.
+    expect(snapshots[0]?.occurredAt.toISOString()).toBe("2026-08-31T00:00:00.000Z");
+  });
+
+  it("aggregates repeated amounts of the same type and side", () => {
+    const snapshots = emitPayrollTaxSnapshots(
+      run({
+        amounts: [
+          { taxType: "medicare", side: "employee_withheld", taxableAmount: 5000, taxAmount: 72.5 },
+          { taxType: "medicare", side: "employee_withheld", taxableAmount: 3000, taxAmount: 43.5 },
+        ],
+      }),
+    );
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]?.taxAmount).toBe(116);
+    expect(snapshots[0]?.taxableAmount).toBe(8000);
+  });
+
+  it("keeps the two sides of the same tax separate", () => {
+    const snapshots = emitPayrollTaxSnapshots(run());
+    const ss = snapshots.filter((s) => s.taxType === "social_security");
+    // Employee-withheld is someone else's money the business holds; merging it
+    // with the employer's own contribution hides that.
+    expect(ss).toHaveLength(2);
+    expect(ss.map((s) => s.side).sort()).toEqual(["employee_withheld", "employer_contribution"]);
+  });
+
+  it("drops zero amounts rather than opening an empty period to file", () => {
+    const snapshots = emitPayrollTaxSnapshots(
+      run({
+        amounts: [
+          { taxType: "state_withholding", side: "employee_withheld", taxableAmount: 5000, taxAmount: 0 },
+          { taxType: "medicare", side: "employee_withheld", taxableAmount: 5000, taxAmount: 72.5 },
+        ],
+      }),
+    );
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]?.taxType).toBe("medicare");
+  });
+
+  it("emits nothing for a run with no tax at all", () => {
+    expect(emitPayrollTaxSnapshots(run({ amounts: [] }))).toHaveLength(0);
+  });
+});
+
+describe("determineDepositCadence", () => {
+  it("puts a large lookback liability on the semiweekly schedule", () => {
+    expect(determineDepositCadence(60_000, 50_000)).toBe("semiweekly");
+  });
+
+  it("keeps a small lookback liability monthly", () => {
+    expect(determineDepositCadence(10_000, 50_000)).toBe("monthly");
+  });
+
+  it("treats exactly-at-threshold as monthly, not semiweekly", () => {
+    // The rule is "more than", so the boundary must not escalate cadence.
+    expect(determineDepositCadence(50_000, 50_000)).toBe("monthly");
+  });
+});
+
+describe("summarisePeriod", () => {
+  it("reports withheld and employer money separately as well as together", () => {
+    const totals = summarisePeriod(emitPayrollTaxSnapshots(run()));
+    expect(totals.employeeWithheld).toBe(1015.83);
+    expect(totals.employerContribution).toBe(412.5);
+    expect(totals.total).toBe(1428.33);
+  });
+
+  it("totals an empty period at zero rather than failing", () => {
+    expect(summarisePeriod([])).toEqual({
+      employeeWithheld: 0,
+      employerContribution: 0,
+      total: 0,
+    });
+  });
+});

--- a/apps/web/lib/hr/payroll-tax-emission.ts
+++ b/apps/web/lib/hr/payroll-tax-emission.ts
@@ -1,0 +1,141 @@
+// lib/hr/payroll-tax-emission.ts — putting payroll liabilities onto the tax
+// spine that already ships (BI-947F8703).
+//
+// Substrate verification (2026-08-22) found the tax compliance spine is
+// tax-type GENERIC, not sales-tax specific: TaxRegistration.taxType is a free
+// string, TaxDecisionSnapshot/TaxLiabilityEntry carry sourceType + sourceId,
+// TaxObligationPeriod already tracks due dates and notifications, and
+// TaxRemittanceRun already carries executionMode, preparedByAgentId and a
+// human MFA step-up on its credential.
+//
+// So payroll tax filing is mostly an EMITTER problem. A PayRun that writes
+// snapshots with sourceType "payroll_run" reuses the entire
+// accrue -> period -> due -> prepare -> approve -> file -> confirm machinery
+// that already works for sales tax. This module is that emitter, kept pure so
+// the mapping is testable without a database.
+//
+// Deposit schedules are included because a payroll deposit is not merely "the
+// period total" — the cadence itself is determined by a lookback at prior
+// liability, and getting that wrong is what produces late-deposit penalties.
+
+export type PayrollTaxType =
+  | "federal_withholding"
+  | "social_security"
+  | "medicare"
+  | "futa"
+  | "state_withholding"
+  | "suta";
+
+/** Who owes it. Withheld amounts are the employee's money the business holds. */
+export type RemitterSide = "employee_withheld" | "employer_contribution";
+
+export interface PayrollTaxAmount {
+  taxType: PayrollTaxType;
+  side: RemitterSide;
+  /** Wages the tax was charged on. */
+  taxableAmount: number;
+  taxAmount: number;
+}
+
+export interface PayrollTaxSnapshot {
+  sourceType: "payroll_run";
+  sourceId: string;
+  taxType: PayrollTaxType;
+  side: RemitterSide;
+  taxableAmount: number;
+  taxAmount: number;
+  occurredAt: Date;
+  currency: string;
+}
+
+export interface EmittablePayRun {
+  payRunId: string;
+  payDate: Date;
+  currency?: string;
+  amounts: readonly PayrollTaxAmount[];
+}
+
+const round2 = (n: number): number => Math.round((n + Number.EPSILON) * 100) / 100;
+
+/**
+ * Turn a pay run into tax snapshots, one per (taxType, side).
+ *
+ * Zero amounts are dropped: a run in a no-income-tax state should not emit an
+ * empty state-withholding liability that then shows up as a period to file.
+ * The occurrence date is the PAY DATE, not the period end — deposit obligations
+ * are triggered by payment, not by the work being done.
+ */
+export function emitPayrollTaxSnapshots(run: EmittablePayRun): PayrollTaxSnapshot[] {
+  const currency = run.currency ?? "USD";
+  const merged = new Map<string, PayrollTaxSnapshot>();
+
+  for (const amount of run.amounts) {
+    if (amount.taxAmount === 0) continue;
+    const key = `${amount.taxType}:${amount.side}`;
+    const existing = merged.get(key);
+    if (existing) {
+      existing.taxableAmount = round2(existing.taxableAmount + amount.taxableAmount);
+      existing.taxAmount = round2(existing.taxAmount + amount.taxAmount);
+      continue;
+    }
+    merged.set(key, {
+      sourceType: "payroll_run",
+      sourceId: run.payRunId,
+      taxType: amount.taxType,
+      side: amount.side,
+      taxableAmount: round2(amount.taxableAmount),
+      taxAmount: round2(amount.taxAmount),
+      occurredAt: run.payDate,
+      currency,
+    });
+  }
+
+  return [...merged.values()];
+}
+
+export type DepositCadence = "semiweekly" | "monthly";
+
+/**
+ * Determine deposit cadence from the lookback rule: a business whose total
+ * liability in the lookback window exceeded the threshold deposits semiweekly,
+ * otherwise monthly.
+ *
+ * The threshold and window are PARAMETERS, not constants, for the same reason
+ * the rates are: they are set by the authority, change, and must be cited and
+ * effective-dated rather than printed into source.
+ */
+export function determineDepositCadence(
+  lookbackLiabilityTotal: number,
+  semiweeklyThreshold: number,
+): DepositCadence {
+  return lookbackLiabilityTotal > semiweeklyThreshold ? "semiweekly" : "monthly";
+}
+
+/**
+ * Total a set of snapshots for one period, split by side.
+ *
+ * The split matters: the employee-withheld portion is money the business is
+ * holding on someone else's behalf, and reporting it merged with the employer's
+ * own contribution hides that distinction from anyone reading the liability.
+ */
+export function summarisePeriod(snapshots: readonly PayrollTaxSnapshot[]): {
+  employeeWithheld: number;
+  employerContribution: number;
+  total: number;
+} {
+  const employeeWithheld = round2(
+    snapshots
+      .filter((s) => s.side === "employee_withheld")
+      .reduce((t, s) => t + s.taxAmount, 0),
+  );
+  const employerContribution = round2(
+    snapshots
+      .filter((s) => s.side === "employer_contribution")
+      .reduce((t, s) => t + s.taxAmount, 0),
+  );
+  return {
+    employeeWithheld,
+    employerContribution,
+    total: round2(employeeWithheld + employerContribution),
+  };
+}

--- a/apps/web/lib/hr/statutory-us.test.ts
+++ b/apps/web/lib/hr/statutory-us.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import {
+  bracketTax,
+  cappedWages,
+  computeUsStatutory,
+  usStatutory,
+  ZERO_YTD,
+  type UsPayrollTaxRuleSet,
+} from "./statutory-us";
+import { computePayslip } from "./payroll";
+
+// FIXTURE RATES — deliberately round, obviously synthetic numbers.
+//
+// These are NOT the real IRS/state figures and must never be read as such. The
+// engine takes rates as effective-dated data precisely so the real ones are
+// seeded from a cited source rather than printed into code, and these fixtures
+// exist to prove the MECHANISM (caps, thresholds, annualization, employer
+// asymmetry) independent of any year's published numbers.
+const RULES: UsPayrollTaxRuleSet = {
+  taxYear: 2026,
+  periodsPerYear: 12,
+  federal: {
+    standardDeductionPerPeriod: 1000,
+    brackets: [
+      { upTo: 20_000, rate: 0.1 },
+      { upTo: 60_000, rate: 0.2 },
+      { upTo: null, rate: 0.3 },
+    ],
+  },
+  fica: {
+    socialSecurityRate: 0.062,
+    socialSecurityWageBase: 100_000,
+    medicareRate: 0.0145,
+    additionalMedicareRate: 0.009,
+    additionalMedicareThreshold: 200_000,
+  },
+  unemployment: {
+    futaRate: 0.006,
+    futaWageBase: 7_000,
+    sutaRate: 0.03,
+    sutaWageBase: 10_000,
+  },
+  state: {
+    stateCode: "CA",
+    standardDeductionPerPeriod: 500,
+    brackets: [
+      { upTo: 40_000, rate: 0.02 },
+      { upTo: null, rate: 0.05 },
+    ],
+  },
+};
+
+const NO_INCOME_TAX_STATE: UsPayrollTaxRuleSet = { ...RULES, state: undefined };
+
+describe("cappedWages", () => {
+  it("stops charging once the annual base is reached", () => {
+    expect(cappedWages(10_000, 95_000, 100_000)).toBe(5_000);
+    expect(cappedWages(10_000, 100_000, 100_000)).toBe(0);
+  });
+
+  it("never returns a negative, which would refund correctly withheld tax", () => {
+    expect(cappedWages(10_000, 120_000, 100_000)).toBe(0);
+  });
+
+  it("charges the full period when far below the base", () => {
+    expect(cappedWages(8_000, 0, 100_000)).toBe(8_000);
+  });
+});
+
+describe("bracketTax", () => {
+  it("taxes each band at its own rate, not the top rate on everything", () => {
+    // 20,000 @ 10% = 2,000; next 10,000 @ 20% = 2,000 -> 4,000
+    expect(bracketTax(30_000, RULES.federal.brackets)).toBe(4_000);
+  });
+
+  it("applies the open top band above the last ceiling", () => {
+    // 2,000 + 8,000 + (40,000 @ 30% = 12,000) = 22,000
+    expect(bracketTax(100_000, RULES.federal.brackets)).toBe(22_000);
+  });
+
+  it("taxes nothing at zero", () => {
+    expect(bracketTax(0, RULES.federal.brackets)).toBe(0);
+  });
+});
+
+describe("computeUsStatutory", () => {
+  it("annualizes so the first paycheck is not taxed as a whole year", () => {
+    const r = computeUsStatutory({ taxablePay: 5_000, ficaWages: 5_000 }, RULES);
+    // (5,000 - 1,000) x 12 = 48,000 annual -> 2,000 + 5,600 = 7,600 -> /12
+    expect(r.federalWithholding).toBeCloseTo(633.33, 2);
+  });
+
+  it("charges Social Security only up to the wage base", () => {
+    const under = computeUsStatutory(
+      { taxablePay: 10_000, ficaWages: 10_000, ytd: { ...ZERO_YTD, socialSecurityWagesYtd: 95_000 } },
+      RULES,
+    );
+    // Only 5,000 of the 10,000 is still below the 100,000 base.
+    expect(under.socialSecurityEmployee).toBe(310);
+
+    const over = computeUsStatutory(
+      { taxablePay: 10_000, ficaWages: 10_000, ytd: { ...ZERO_YTD, socialSecurityWagesYtd: 100_000 } },
+      RULES,
+    );
+    expect(over.socialSecurityEmployee).toBe(0);
+  });
+
+  it("charges Medicare with no ceiling at all", () => {
+    const r = computeUsStatutory(
+      { taxablePay: 10_000, ficaWages: 10_000, ytd: { ...ZERO_YTD, medicareWagesYtd: 500_000 } },
+      RULES,
+    );
+    expect(r.medicareEmployee).toBe(145);
+  });
+
+  it("adds additional Medicare only above the threshold", () => {
+    const below = computeUsStatutory(
+      { taxablePay: 10_000, ficaWages: 10_000, ytd: { ...ZERO_YTD, medicareWagesYtd: 150_000 } },
+      RULES,
+    );
+    expect(below.additionalMedicareEmployee).toBe(0);
+
+    const straddling = computeUsStatutory(
+      { taxablePay: 10_000, ficaWages: 10_000, ytd: { ...ZERO_YTD, medicareWagesYtd: 195_000 } },
+      RULES,
+    );
+    // Only the 5,000 above 200,000 attracts the extra 0.9%.
+    expect(straddling.additionalMedicareEmployee).toBe(45);
+  });
+
+  it("does not make the employer match additional Medicare", () => {
+    const r = computeUsStatutory(
+      { taxablePay: 10_000, ficaWages: 10_000, ytd: { ...ZERO_YTD, medicareWagesYtd: 195_000 } },
+      RULES,
+    );
+    // Employer matches SS and Medicare, but never the additional 0.9%.
+    expect(r.medicareEmployer).toBe(r.medicareEmployee);
+    expect(r.socialSecurityEmployer).toBe(r.socialSecurityEmployee);
+    expect(r.totalEmployer).toBe(
+      r.socialSecurityEmployer + r.medicareEmployer + r.futaEmployer + r.sutaEmployer,
+    );
+  });
+
+  it("charges FUTA and SUTA to the employer only, each on its own base", () => {
+    const r = computeUsStatutory({ taxablePay: 5_000, ficaWages: 5_000 }, RULES);
+    expect(r.futaEmployer).toBe(30);
+    expect(r.sutaEmployer).toBe(150);
+    // Neither appears in the employee total.
+    expect(r.totalEmployee).toBe(
+      r.federalWithholding +
+        r.stateWithholding +
+        r.socialSecurityEmployee +
+        r.medicareEmployee +
+        r.additionalMedicareEmployee,
+    );
+  });
+
+  it("stops FUTA once its low wage base is exhausted", () => {
+    const r = computeUsStatutory(
+      { taxablePay: 5_000, ficaWages: 5_000, ytd: { ...ZERO_YTD, futaWagesYtd: 7_000 } },
+      RULES,
+    );
+    expect(r.futaEmployer).toBe(0);
+  });
+
+  it("withholds no state tax in a state with no income tax", () => {
+    const r = computeUsStatutory({ taxablePay: 5_000, ficaWages: 5_000 }, NO_INCOME_TAX_STATE);
+    expect(r.stateWithholding).toBe(0);
+    // Federal and FICA are unaffected by the state having no income tax.
+    expect(r.federalWithholding).toBeGreaterThan(0);
+    expect(r.socialSecurityEmployee).toBeGreaterThan(0);
+  });
+
+  it("charges FICA on gross even when pre-tax deductions lower income-tax pay", () => {
+    // A 401(k)-style deferral reduces taxablePay but not the FICA base.
+    const r = computeUsStatutory({ taxablePay: 4_000, ficaWages: 5_000 }, RULES);
+    expect(r.socialSecurityEmployee).toBe(310);
+    expect(r.medicareEmployee).toBe(72.5);
+  });
+});
+
+describe("usStatutory adapter", () => {
+  it("drives the gross-to-net engine end to end", () => {
+    const slip = computePayslip({
+      baseSalary: 5_000,
+      statutory: usStatutory(RULES),
+    });
+
+    const direct = computeUsStatutory({ taxablePay: 5_000, ficaWages: 5_000 }, RULES);
+    expect(slip.grossPay).toBe(5_000);
+    // Net is gross less every employee-side statutory amount.
+    expect(slip.netPay).toBeCloseTo(5_000 - direct.totalEmployee, 2);
+    // Employer cost sits on top of gross, never inside it.
+    expect(slip.totalEmployerCost).toBeCloseTo(5_000 + direct.totalEmployer, 2);
+  });
+
+  it("keeps a prior period reproducible when a later rule set changes", () => {
+    const oldRules = RULES;
+    const newRules: UsPayrollTaxRuleSet = {
+      ...RULES,
+      taxYear: 2027,
+      fica: { ...RULES.fica, socialSecurityWageBase: 120_000 },
+    };
+    const before = computeUsStatutory(
+      { taxablePay: 10_000, ficaWages: 10_000, ytd: { ...ZERO_YTD, socialSecurityWagesYtd: 100_000 } },
+      oldRules,
+    );
+    const after = computeUsStatutory(
+      { taxablePay: 10_000, ficaWages: 10_000, ytd: { ...ZERO_YTD, socialSecurityWagesYtd: 100_000 } },
+      newRules,
+    );
+    // The 2026 period must not re-compute under the 2027 base — which is the
+    // whole reason rules are effective-dated data rather than constants.
+    expect(before.socialSecurityEmployee).toBe(0);
+    expect(after.socialSecurityEmployee).toBe(620);
+  });
+});

--- a/apps/web/lib/hr/statutory-us.ts
+++ b/apps/web/lib/hr/statutory-us.ts
@@ -1,0 +1,246 @@
+// lib/hr/statutory-us.ts — US payroll statutory calculation (BI-4EB27955).
+//
+// lib/hr/payroll.ts deliberately takes a pluggable StatutoryDeductionFn rather
+// than baking in one country's rules. This module supplies the US shape WITHOUT
+// baking in the numbers: every rate, wage base and threshold arrives as
+// effective-dated DATA (a UsPayrollTaxRuleSet, persisted as PayrollTaxRule rows),
+// and this file is only the mechanism that applies them.
+//
+// That split is not stylistic. US rates change annually and a wage base printed
+// into source becomes wrong every January in a way no test catches — the suite
+// keeps passing while every payslip is quietly incorrect. Rates as data with a
+// cited sourceUrl and an effective window are auditable; rates as constants are
+// a silent liability.
+//
+// SCOPE: this computes withholding and contributions from a supplied rule set.
+// It does NOT ship the 2026 IRS/state figures — seeding those is a separate,
+// source-cited data task, because publishing a number here that I cannot cite
+// would be a fabrication with money attached.
+
+/** One progressive bracket. `upTo` null means "and everything above". */
+export interface TaxBracket {
+  upTo: number | null;
+  rate: number;
+}
+
+export interface UsFederalWithholdingRules {
+  /** Standard deduction applied before the brackets, per pay period. */
+  standardDeductionPerPeriod: number;
+  brackets: readonly TaxBracket[];
+}
+
+export interface UsFicaRules {
+  socialSecurityRate: number;
+  /** Annual wage ceiling for Social Security. Above it, no further SS is due. */
+  socialSecurityWageBase: number;
+  medicareRate: number;
+  /** Extra employee-only Medicare above the threshold. Employer does not match. */
+  additionalMedicareRate: number;
+  additionalMedicareThreshold: number;
+}
+
+export interface UsUnemploymentRules {
+  /** Employer-only. */
+  futaRate: number;
+  futaWageBase: number;
+  sutaRate: number;
+  sutaWageBase: number;
+}
+
+export interface UsStateWithholdingRules {
+  stateCode: string;
+  standardDeductionPerPeriod: number;
+  brackets: readonly TaxBracket[];
+}
+
+export interface UsPayrollTaxRuleSet {
+  taxYear: number;
+  periodsPerYear: number;
+  federal: UsFederalWithholdingRules;
+  fica: UsFicaRules;
+  unemployment: UsUnemploymentRules;
+  /** Omitted for a no-income-tax state (TX, FL, WA, …). */
+  state?: UsStateWithholdingRules;
+}
+
+/** Year-to-date figures, needed because caps are annual but pay is periodic. */
+export interface YearToDate {
+  grossYtd: number;
+  socialSecurityWagesYtd: number;
+  medicareWagesYtd: number;
+  futaWagesYtd: number;
+  sutaWagesYtd: number;
+}
+
+export const ZERO_YTD: YearToDate = {
+  grossYtd: 0,
+  socialSecurityWagesYtd: 0,
+  medicareWagesYtd: 0,
+  futaWagesYtd: 0,
+  sutaWagesYtd: 0,
+};
+
+export interface UsStatutoryResult {
+  federalWithholding: number;
+  stateWithholding: number;
+  socialSecurityEmployee: number;
+  socialSecurityEmployer: number;
+  medicareEmployee: number;
+  medicareEmployer: number;
+  additionalMedicareEmployee: number;
+  futaEmployer: number;
+  sutaEmployer: number;
+  totalEmployee: number;
+  totalEmployer: number;
+}
+
+const round2 = (n: number): number => Math.round((n + Number.EPSILON) * 100) / 100;
+
+/**
+ * Wages still subject to a capped tax this period, given the annual ceiling and
+ * what has already been taxed. Returns 0 once the cap is reached — never a
+ * negative, which would refund tax that was correctly withheld.
+ */
+export function cappedWages(periodWages: number, ytdWages: number, wageBase: number): number {
+  const remaining = wageBase - ytdWages;
+  if (remaining <= 0) return 0;
+  return Math.min(periodWages, remaining);
+}
+
+/** Progressive bracket tax on an annualized amount. */
+export function bracketTax(annualTaxable: number, brackets: readonly TaxBracket[]): number {
+  let remaining = annualTaxable;
+  let previousCeiling = 0;
+  let tax = 0;
+
+  for (const bracket of brackets) {
+    if (remaining <= 0) break;
+    const ceiling = bracket.upTo ?? Number.POSITIVE_INFINITY;
+    const span = ceiling - previousCeiling;
+    const taxedHere = Math.min(remaining, span);
+    tax += taxedHere * bracket.rate;
+    remaining -= taxedHere;
+    previousCeiling = ceiling;
+  }
+  return tax;
+}
+
+/**
+ * Withholding via the annualized method: annualize the period's taxable pay,
+ * apply the standard deduction and brackets, then divide back down. This is how
+ * a progressive annual schedule is applied to a periodic paycheck without the
+ * first pay period of the year being taxed as though it were the whole year.
+ */
+function periodWithholding(
+  taxablePeriodPay: number,
+  standardDeductionPerPeriod: number,
+  brackets: readonly TaxBracket[],
+  periodsPerYear: number,
+): number {
+  const afterDeduction = Math.max(taxablePeriodPay - standardDeductionPerPeriod, 0);
+  const annualized = afterDeduction * periodsPerYear;
+  return round2(bracketTax(annualized, brackets) / periodsPerYear);
+}
+
+/**
+ * Compute US statutory amounts for one pay period.
+ *
+ * `taxablePay` is gross less pre-tax deductions — the payroll engine has already
+ * done that subtraction. FICA is charged on its own base (`ficaWages`), which
+ * differs from income-tax-taxable pay because some pre-tax deductions reduce one
+ * and not the other; the caller supplies both rather than this module guessing.
+ */
+export function computeUsStatutory(
+  input: {
+    taxablePay: number;
+    ficaWages: number;
+    ytd?: YearToDate;
+  },
+  rules: UsPayrollTaxRuleSet,
+): UsStatutoryResult {
+  const ytd = input.ytd ?? ZERO_YTD;
+  const { fica, unemployment, federal, state } = rules;
+
+  const federalWithholding = periodWithholding(
+    input.taxablePay,
+    federal.standardDeductionPerPeriod,
+    federal.brackets,
+    rules.periodsPerYear,
+  );
+
+  const stateWithholding = state
+    ? periodWithholding(
+        input.taxablePay,
+        state.standardDeductionPerPeriod,
+        state.brackets,
+        rules.periodsPerYear,
+      )
+    : 0;
+
+  const ssWages = cappedWages(input.ficaWages, ytd.socialSecurityWagesYtd, fica.socialSecurityWageBase);
+  const socialSecurityEmployee = round2(ssWages * fica.socialSecurityRate);
+
+  const medicareEmployee = round2(input.ficaWages * fica.medicareRate);
+
+  // Additional Medicare applies only to the portion above the threshold, and
+  // only to the employee — the employer does not match it.
+  const overThreshold = Math.max(
+    input.ficaWages + ytd.medicareWagesYtd - fica.additionalMedicareThreshold,
+    0,
+  );
+  const additionalMedicareBase = Math.min(overThreshold, input.ficaWages);
+  const additionalMedicareEmployee = round2(additionalMedicareBase * fica.additionalMedicareRate);
+
+  const futaWages = cappedWages(input.ficaWages, ytd.futaWagesYtd, unemployment.futaWageBase);
+  const sutaWages = cappedWages(input.ficaWages, ytd.sutaWagesYtd, unemployment.sutaWageBase);
+
+  const socialSecurityEmployer = socialSecurityEmployee;
+  const medicareEmployer = medicareEmployee;
+  const futaEmployer = round2(futaWages * unemployment.futaRate);
+  const sutaEmployer = round2(sutaWages * unemployment.sutaRate);
+
+  const totalEmployee = round2(
+    federalWithholding +
+      stateWithholding +
+      socialSecurityEmployee +
+      medicareEmployee +
+      additionalMedicareEmployee,
+  );
+  const totalEmployer = round2(
+    socialSecurityEmployer + medicareEmployer + futaEmployer + sutaEmployer,
+  );
+
+  return {
+    federalWithholding,
+    stateWithholding,
+    socialSecurityEmployee,
+    socialSecurityEmployer,
+    medicareEmployee,
+    medicareEmployer,
+    additionalMedicareEmployee,
+    futaEmployer,
+    sutaEmployer,
+    totalEmployee,
+    totalEmployer,
+  };
+}
+
+/**
+ * Adapt the US calculation to the StatutoryDeductionFn the gross-to-net engine
+ * expects. The engine's shape has one income-tax slot and one employee/employer
+ * social-security pair, so federal and state withholding are summed into
+ * incomeTax and the FICA family into the NI slots. The full breakdown stays
+ * available from computeUsStatutory for payslip lines and tax filing.
+ */
+export function usStatutory(rules: UsPayrollTaxRuleSet, ytd: YearToDate = ZERO_YTD) {
+  return ({ gross, taxable }: { gross: number; taxable: number }) => {
+    const r = computeUsStatutory({ taxablePay: taxable, ficaWages: gross, ytd }, rules);
+    return {
+      incomeTax: round2(r.federalWithholding + r.stateWithholding),
+      employeeNI: round2(
+        r.socialSecurityEmployee + r.medicareEmployee + r.additionalMedicareEmployee,
+      ),
+      employerNI: r.totalEmployer,
+    };
+  };
+}


### PR DESCRIPTION
Follows #4476 (merged). Two pure modules, 28 tests — the statutory calculation the payroll engine has always had a slot for, and the emitter that puts payroll liabilities onto the tax spine that already ships.

## `statutory-us.ts`

Supplies the US shape for the `StatutoryDeductionFn` plug point `payroll.ts` already declares — **without baking in the numbers**. Every rate, wage base and threshold arrives as effective-dated data; this module is only the mechanism.

That split is not stylistic. US figures change annually, and a wage base printed into source goes wrong every January in a way no test catches: the suite keeps passing while every payslip is quietly incorrect. Rates as data with a cited source and an effective window are auditable; rates as constants are a silent liability with money attached.

The mechanics that are easy to get wrong, each with a test:

- **annualization**, so the first paycheck of the year isn't taxed as though it were the whole year
- **Social Security stops at its wage base**, and capped wages never go negative (which would refund correctly-withheld tax)
- **Medicare has no ceiling**
- **additional Medicare applies only above the threshold, and the employer does not match it**
- **FUTA and SUTA are employer-only**, each on its own base
- **FICA is charged on gross** even when a pre-tax deferral lowers income-tax pay

There is also a test proving a prior period does not re-compute under a later year's wage base — which is the whole reason rules are effective-dated data rather than constants.

## `payroll-tax-emission.ts`

Substrate verification found the tax compliance spine is **tax-type generic**, not sales-tax specific: `TaxRegistration.taxType` is a free string, `TaxDecisionSnapshot`/`TaxLiabilityEntry` carry `sourceType`+`sourceId`, `TaxObligationPeriod` already tracks due dates and notifications, and `TaxRemittanceRun` already carries `executionMode`, `preparedByAgentId` and a human MFA step-up on its credential.

So payroll filing is mostly an **emitter** problem: snapshots tagged `sourceType: "payroll_run"` reuse the entire accrue → period → due → prepare → approve → file → confirm machinery that already works for sales tax. No new plumbing.

Two decisions worth review:

- **Liabilities date by pay date, not period end** — the deposit obligation is triggered by payment, not by the work being done.
- **Employee-withheld stays separate from employer contribution** — withheld money is someone else's, held in trust, and merging the two hides that from anyone reading the liability.

Deposit cadence is a lookback determination with the threshold as a **parameter**, not a constant, for the same reason as the rates.

## Deliberately not included

**The actual 2026 IRS and state figures.** Publishing a rate here that I cannot cite would be a fabrication in code that computes payroll withholding, where being wrong means penalties. Seeding them is a source-cited data task; the natural home is effective-dated `PayrollTaxRule` rows carrying a `sourceUrl`.

The test fixtures are round, obviously synthetic numbers (10/20/30% brackets, $100k SS base) chosen to prove the **mechanism** independent of any year's published values. They must never be read as real rates.

This means the engine is correct-by-construction but **not yet usable for a real payroll run**. That gate is the rate seeding, and per the plan it must not ship on a structural pass.

## Verification

- `pregate` sandbox gate **PASS** at `df91400e8e87`, evidence `cmt4pb1uq041t01qpstn6dige`
- `pregate:preflight` — 47 guards clean
- 28 tests (17 statutory, 11 emission)

Refs: EP-PAYROLL-ABSORB, BI-4EB27955, BI-947F8703

Docs-Impact-Decision: pure library code only — no route, screen, schema or user-visible behaviour ships here, so no user-guide page changes. User-guide coverage lands with the surface that runs a filing.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
Local-CI-Evidence: cmt4r9mpe04cv01pfgxx08lks (feat/payroll-statutory-engine@a6e826581b72)
