### PR TITLE
docs(architecture): record the payroll absorption stance reversal (BI-4B2CD5FD)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1474,6 +1474,7 @@
         "purpose",
         "maturity-labels-closed-set",
         "finance-matrix-snapshot",
+        "payroll-absorption-stance-reversal-2026-08-22",
         "finance-doc-reconciliation-rules",
         "workforce-matrix-snapshot",
         "workforce-doc-reconciliation-rules",

--- a/docs/architecture/finance-workforce-maturity-matrix.md
+++ b/docs/architecture/finance-workforce-maturity-matrix.md
@@ -34,8 +34,28 @@ Labels are intentional and conservative. Promote a row only when UX verification
 | Fixed assets / currency | asset & currency models | **experimental** | Not a full fixed-asset suite claim |
 | QuickBooks import / sync | QB bridge plans/specs, import staging | **bridge-only** | External SoR during bridge; see convergence doctrine |
 | Full multi-entity statutory accounting | — | **out-of-scope** (current) | Aligns with owner-positioning: do not claim full accounting suite replacement |
-| Payroll tax filing engine | — | **out-of-scope** / **bridge-only** via payroll vendors | Prefer Gusto/ADP-class bridges when needed |
+| Payroll tax filing engine | `lib/hr/payroll-tax-emission.ts`, `lib/hr/statutory-us.ts`, the `Tax*` spine | **experimental** (was out-of-scope) | Native absorb decided — DI-87A27C692B16, EP-PAYROLL-ABSORB. The calculation and emission mechanism exist; the real IRS/state rates are NOT seeded, so do not claim a business can file from DPF today |
 | Payments (cards) | Stripe-class adapters | **bridge-only** | Rails stay external |
+
+### Payroll absorption — stance reversal (2026-08-22)
+
+This matrix previously recorded payroll processing as **bridge-only** and payroll tax
+filing as **out-of-scope**, preferring Gusto/ADP-class bridges. That stance is reversed
+by kernel decision **DI-87A27C692B16** under **EP-PAYROLL-ABSORB**.
+
+Read the ledger rather than the headline: the kernel's own recommendation was to bridge
+payroll and absorb only mileage, on speed-to-value and reversibility grounds. Full
+absorption scored HIGHER on Architecture Over Shortcuts, Ground New Work In Existing
+Platform, Proper Fix Over Quick Fix and Optimize for the Whole. The objection was about
+sequencing, not scope, and the founder retained authority and answered it by shipping
+mileage first. `principle_decide` is advisory by contract.
+
+**What the new labels do and do not claim.** Both rows move to *experimental*, not
+*usable-now*. The mechanism exists and is tested; what is missing is the seeded
+jurisdiction data. A rate that cannot be cited must not be printed into source, so the
+statutory engine consumes effective-dated rules with a `sourceUrl` instead. Until those
+are seeded, **no install can run a real payroll or file a real return**, and no public
+claim may imply otherwise.
 
 ### Finance doc reconciliation rules
 
@@ -53,7 +73,7 @@ Labels are intentional and conservative. Promote a row only when UX verification
 | Timesheets | timesheet models | **experimental** | Present; owner UX varies by install |
 | Staffing / scheduling | workforce ops plans, scheduling specs | **experimental** / **planned** (depth) | Direction real; depth varies — do not claim Workday HCM |
 | Recruiting coworker | talent BIs | **planned** | Not a default claim |
-| Payroll processing | external adapters | **bridge-only** | Prefer integrate mode until native absorb criteria met |
+| Payroll processing | `PayRun`, `Payslip`, `PayComponentLine`, `lib/hr/payroll.ts`, `lib/hr/payroll-gl.ts` | **experimental** (was bridge-only) | Native absorb decided — DI-87A27C692B16. Gross-to-net, payslip component lines and GL posting ship; the manual NACHA disbursement rail also ships. The automated provider rail stays gated on a tool-evaluation |
 | Full Workday HCM admin | — | **out-of-scope** (current) | Complexity shield: ship jobs, not suite clones |
 
 ### Workforce doc reconciliation rules


### PR DESCRIPTION
The maturity matrix is the honesty layer for what is shipped, and its own update rule says a row moves in the PR that ships the happy path. #4476 merged GL posting and #4490 carries the statutory engine, so these rows are now stale **in the conservative direction** — they still tell marketing and coworkers that payroll is bridge-only and tax filing out-of-scope.

| Row | Was | Now |
|---|---|---|
| Payroll processing | bridge-only | **experimental** |
| Payroll tax filing engine | out-of-scope | **experimental** |

## Why experimental and not usable-now

The mechanism ships and is tested — gross-to-net, payslip component lines, GL posting, the manual NACHA disbursement rail, the statutory calculation and the tax emitter. What is missing is the seeded jurisdiction data.

A rate that cannot be cited must not be printed into source, so the statutory engine consumes effective-dated rules carrying a `sourceUrl` instead of constants. **Until those are seeded, no install can run a real payroll or file a real return**, and no public claim may imply otherwise. Promoting either row further requires the rates plus functional verification on a live install.

## The reversal itself, recorded accurately

This is the part that would be easy to misreport later, so it is written down: kernel decision **DI-87A27C692B16** actually **recommended bridging payroll**, not absorbing it.

Reading the contribution ledger rather than the headline, full absorption scored *higher* on Architecture Over Shortcuts (0.42 vs 0.23), Ground New Work In Existing Platform (0.48 vs 0.27), Proper Fix Over Quick Fix (0.27 vs 0.18) and Optimize for the Whole. It lost only on speed-to-value, operator effort and reversibility — a **sequencing** objection, not a scope one. `principle_decide` is advisory by contract; the founder retained authority and answered the objection by shipping mileage first.

Recording a reversal this way matters more than the row labels: a future reader who sees only "absorbed" would reasonably assume the kernel agreed.

## Verification

- `pregate` sandbox gate **PASS** at `72eb51128c20`, evidence `cmt4qch3p014801pfv1k0olo9`
- `pregate:preflight` — 47 guards clean
- Docs-impact gate clean

Refs: EP-PAYROLL-ABSORB, BI-4B2CD5FD, DI-87A27C692B16

Docs-Impact-Decision: this PR IS the documentation change — it updates the maturity matrix that governs public claims about payroll. No code, route or schema changes.

Local-CI-Evidence: cmt4qch3p014801pfv1k0olo9 (docs/payroll-absorption-stance@72eb51128c20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)