### PR TITLE
fix(build-studio): sync sandbox root config (BI-86EAD856)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -305,14 +305,14 @@ COPY version.json ./version.json
 # Decoupling it from DPF_VERSION is the fix for BI-C8E90A79 — a stamped label
 # can no longer mask which source was built. Exclusions keep it reproducible
 # across builds of the same source (node_modules / .next / generated / tsbuildinfo).
-RUN (find /app/apps/web-src /app/packages-src /app/scripts /app/docs/professions /app/patches -type f \
+RUN (find /app/apps/web-src /app/packages-src /app/scripts /app/config /app/docs/professions /app/patches -type f \
       -not -path '*/node_modules/*' \
       -not -path '*/.pnpm-store/*' \
       -not -path '*/.next/*' \
       -not -path '*/generated/*' \
       -not -name '*.tsbuildinfo' \
       -exec sha256sum {} +; \
-     sha256sum /app/pnpm-workspace.yaml /app/pnpm-lock.yaml /app/package.json /app/tsconfig.base.json /app/.gitignore) \
+     sha256sum /app/pnpm-workspace.yaml /app/pnpm-lock.yaml /app/package.json /app/tsconfig.base.json /app/.gitignore /app/version.json) \
       | sort -k 2 | sha256sum | cut -d ' ' -f 1 > /app/.dpf-source-content-hash
 
 # Operator-facing image version baked in at build time. The explicit

--- a/apps/web/lib/verify/dockerfile-build-context.guard.test.ts
+++ b/apps/web/lib/verify/dockerfile-build-context.guard.test.ts
@@ -197,4 +197,15 @@ describe("Docker runtime source bundle is complete for Build Studio", () => {
     expect(entrypoint).toContain('docs/professions/*)');
     expect(entrypoint).toContain("${1#docs/professions/}");
   });
+
+  it("bootstraps root configuration and version metadata into the managed workspace", () => {
+    const entrypoint = readFileSync(DOCKER_ENTRYPOINT, "utf8");
+    expect(entrypoint).toContain('cp -r /app/config/. "$WORKSPACE/config/"');
+    expect(entrypoint).toContain('cp /app/version.json "$WORKSPACE/"');
+    expect(entrypoint).toContain('config/*)');
+    expect(entrypoint).toContain("${1#config/}");
+    expect(entrypoint).toContain('version.json)');
+    expect(dockerfile).toMatch(/find \/app\/apps\/web-src[^\n]*\/app\/config/);
+    expect(dockerfile).toMatch(/sha256sum[^\n]*\/app\/version\.json/);
+  });
 });

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -76,10 +76,11 @@ fi
 
 sync_image_source_to_workspace() {
   echo "  Syncing source volume from image version $IMAGE_VERSION..."
-  mkdir -p "$WORKSPACE/apps" "$WORKSPACE/docs" "$WORKSPACE/packages" "$WORKSPACE/scripts"
-  rm -rf "$WORKSPACE/apps/web" "$WORKSPACE/docs/professions" "$WORKSPACE/packages" "$WORKSPACE/scripts"
-  mkdir -p "$WORKSPACE/apps/web" "$WORKSPACE/docs/professions" "$WORKSPACE/packages" "$WORKSPACE/scripts"
+  mkdir -p "$WORKSPACE/apps" "$WORKSPACE/config" "$WORKSPACE/docs" "$WORKSPACE/packages" "$WORKSPACE/scripts"
+  rm -rf "$WORKSPACE/apps/web" "$WORKSPACE/config" "$WORKSPACE/docs/professions" "$WORKSPACE/packages" "$WORKSPACE/scripts"
+  mkdir -p "$WORKSPACE/apps/web" "$WORKSPACE/config" "$WORKSPACE/docs/professions" "$WORKSPACE/packages" "$WORKSPACE/scripts"
   cp -r /app/apps/web-src/. "$WORKSPACE/apps/web/"
+  cp -r /app/config/. "$WORKSPACE/config/"
   cp -r /app/docs/professions/. "$WORKSPACE/docs/professions/"
   cp -r /app/packages-src/. "$WORKSPACE/packages/"
   rm -rf "$WORKSPACE/apps/web/.next" \
@@ -97,6 +98,7 @@ sync_image_source_to_workspace() {
   cp /app/package.json "$WORKSPACE/" 2>/dev/null || true
   cp /app/tsconfig.base.json "$WORKSPACE/" 2>/dev/null || true
   cp /app/.gitignore "$WORKSPACE/" 2>/dev/null || true
+  cp /app/version.json "$WORKSPACE/"
 }
 
 install_workspace_dependencies() {
@@ -145,10 +147,13 @@ image_source_path_for_workspace_path() {
     scripts/*)
       printf '/app/scripts/%s\n' "${1#scripts/}"
       ;;
+    config/*)
+      printf '/app/config/%s\n' "${1#config/}"
+      ;;
     docs/professions/*)
       printf '/app/docs/professions/%s\n' "${1#docs/professions/}"
       ;;
-    pnpm-workspace.yaml | pnpm-lock.yaml | package.json | tsconfig.base.json | .gitignore)
+    pnpm-workspace.yaml | pnpm-lock.yaml | package.json | tsconfig.base.json | .gitignore | version.json)
       printf '/app/%s\n' "$1"
       ;;
     *)


### PR DESCRIPTION
## Summary

Make the Build Studio managed workspace self-contained on a fresh install by synchronizing the image-owned root configuration and version metadata that runtime imports expect.

## Changes

- copy `/app/config` and `/app/version.json` into `/workspace` during image-source bootstrap
- map those paths back to their immutable image sources for dependency-drift repair
- include root configuration and version metadata in the source-content hash
- guard the complete source-closure contract with focused regression assertions

## Test plan

- [x] **Source-only change** (types, isolated unit logic, doc, schema-only)
  - [x] `pnpm typecheck` (covered by exact-tree local CI)
  - [x] Targeted unit tests: `apps/web/lib/verify/dockerfile-build-context.guard.test.ts` (5/5)

- [x] **Runtime-bound change** (server route, MCP tool, build/runtime wiring, compose, installer, prisma migration, UX surface)
  - [x] Source checks above passed where they can run in the worktree
  - [x] Functional verification ran against the **canonical runtime**:
        - [x] governed shared nonprod env (lease id: `NPEL-8E95CFE92A`)
  - [x] Evidence captured below

- [ ] **Verification-harness limitation acknowledged**

### Verification evidence

- TDD: the new source-closure assertion failed before implementation and passed after it.
- `pnpm exec vitest run apps/web/lib/verify/dockerfile-build-context.guard.test.ts`: 5/5 passed.
- Alpine `/bin/sh -n docker-entrypoint.sh`: passed.
- `pnpm pregate:preflight`: 47/47 guards clean.
- Fresh-install evidence: sandbox `/api/health` was 500 with `config/seed-content-paths.json` absent; copying the exact proposed `config` and `version.json` inputs and restarting changed it to 200 and Docker `healthy`.
- The same fresh install completed onboarding 11/11, with 10 completed steps, AI Providers safely skipped, 30 decision-perspective profiles, and portal/sandbox health endpoints both 200.
- Exact-tree local CI: PASS for `fix/close-sandbox-workspace-root-dependency-gap@9ff5de22a803702ab67d8adeb365de83962f1cce`; 32,610 log lines in 14m15s; durable evidence `cmt4r2mws07yf01pjbx1jz8v5`.
- Fresh semantic review receipt `cmt4r3fkw07z001pjkq0fteqi`: pass, no issues, publication permitted.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and again against the final diff
- [x] `pnpm run pregate:preflight` passed before requesting a shared-sandbox lease
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` returned `PR readiness: READY` after the final push

Local-CI-Evidence: cmt4r2mws07yf01pjbx1jz8v5 (fix/close-sandbox-workspace-root-dependency-gap@9ff5de22a803702ab67d8adeb365de83962f1cce)

## Related issues / Epic

Backlog item: BI-86EAD856

## Epic / Backlog linkage (for multi-BI work)

Not applicable; this PR covers exactly BI-86EAD856.

## Overlap sweep

Reviewed all 10 open PRs before publication. None touches `Dockerfile`, `docker-entrypoint.sh`, or `apps/web/lib/verify/dockerfile-build-context.guard.test.ts`.

## Notes for the reviewer

No schema migration and no direct UI change. The final acceptance will rebuild and run an untouched fresh install from the merged commit; this PR's runtime evidence intentionally distinguishes the pre-fix failure from the evidence-only repair.

Docs-Impact-Decision: internal Build Studio workspace source-closure repair; no user-facing workflow or documented provider/model-routing behavior changed.
