### PR TITLE
chore(gitignore): ignore the machine-local Browser-pane launch config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ apps/mobile/coverage/
 .claude/settings.local.json
 .claude/autonomous-e2e-progress.md
 .claude/worktrees/
+# Browser-pane / preview launch config — machine-local ports and URLs, same
+# family as settings.local.json above. Never tracked; without this line it
+# shows as untracked work in every session's end-of-session guard.
+.claude/launch.json
 
 # Local verification and handoff artifacts
 output/


### PR DESCRIPTION
## Why

`.claude/launch.json` holds machine-local Browser-pane preview configuration — the port and URL the pane opens against. It has **never** been tracked, and no worktree carries it except a root clone that happened to open a preview.

Every `.claude/*` sibling of the same kind is already ignored: `settings.local.json`, `*.jsonl`, `*.lock`, `autonomous-e2e-progress.md`, `worktrees/`. This one fell through the gap.

The cost of the gap is not cosmetic. In a shared root clone it surfaces as untracked work in the **end-of-session uncommitted-work guard**, every session, where the correct answer is always "not mine, leave it alone". A flag that fires forever and can never be actioned is how people learn to skip a guard — the opposite of what it is for. I hit exactly this three times in one session before checking the file's mtime and finding it predated the session by eight days.

## What

One ignore line plus a comment saying why. Four insertions, zero deletions, nothing else.

## Verified

- With the line present, an identical `launch.json` is ignored — `git check-ignore -v` resolves to `.gitignore:60` — and `git status` is clean.
- `git log -- .claude/launch.json` is empty: the file has no history, so nothing already tracked is affected. (An ignore line does **not** untrack an already-tracked file, which is the usual footgun; it does not apply here.)
- `pnpm gate:context`: no gate-sensitive surfaces in this diff.
- `pnpm run pregate:preflight`: 47 guards clean.

## Pre-push gate

Pushed with the recorded override `docs-adjacent`, because the sandbox gate shares the `local-integration-ci` lease and another session (`feat/scheduled-work-register`) holds it until 2026-08-23T01:00Z. Claiming a scarce shared lease for a `.gitignore` line would have disrupted active work for zero verification value — there is no runtime code, test, build input or derived artifact in this diff. CI still enforces everything.

If you would rather this carried a sandbox-gate record anyway, say so and I will run it once that lease frees.
