### PR TITLE
fix(hygiene): ignore .claude/launch.json so the work guard can be satisfied (BI-58F514AC)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ apps/mobile/coverage/
 .claude/settings.local.json
 .claude/autonomous-e2e-progress.md
 .claude/worktrees/
+# Written on demand by the Claude Code Browser pane (preview_start); it is
+# machine-local (ports, commands, localhost URLs). Untracked AND unignored,
+# it made uncommitted-work-guard fire on every session end — BI-58F514AC.
+.claude/launch.json
 
 # Local verification and handoff artifacts
 output/


### PR DESCRIPTION
## What

Adds `.claude/launch.json` to `.gitignore`, beside the two siblings that were already there.

## Why

The Claude Code Browser pane writes `.claude/launch.json` on demand (`preview_start` creates it when absent). It is machine-local — ports, commands, localhost URLs. It was **neither tracked nor ignored**, so it sat in `git status --porcelain` permanently and `uncommitted-work-guard` named it at every session end. In one session that was eight consecutive Stops, for a file dated 2026-08-14 that the session never touched.

`.claude/settings.local.json` and `.claude/worktrees/` were already ignored; launch.json was missed because the tooling that creates it postdates that block.

## Why this matters more than a stray file

`packages/dpf-skill-pack/hooks/uncommitted-work-scan.mjs` states the cost in its own `REGENERATED_PATTERNS` comment (BI-910C37B1):

> paths whose churn is noise, not work. A hook or a generator rewrites these, so warning about them **trains the reflex of waving the guard away — and that reflex is what loses the real work.**

That is precisely what happened: the agent correctly determined the file was not its work and then dismissed the guard eight times running. A guard that cannot be satisfied is a guard that gets tuned out, and the next firing that *does* name real losable work inherits that reflex.

## Why `.gitignore` and not another `REGENERATED_PATTERNS` entry

Ignoring removes the file from **every** git surface — status, other hooks, future tooling — instead of teaching one hook to skip it, and it avoids a second home for one rule. The pattern is the exact path, not a glob; nothing tracked under `.claude/` matches it.

## Verification — functional, with the file physically present in both trees

| tree | `uncommitted-work-guard` output |
|---|---|
| root clone on `main` | `.claude/launch.json (??)` |
| this worktree, pre-commit | `.gitignore (M)` only — the in-flight edit |
| this worktree, post-commit | *nothing*, while `test -f .claude/launch.json` is still true |

- `pnpm run pregate:preflight` — OK, 47 guards clean
- exact-tree local-CI gate — **PASS**, evidence `cmt54k9uw117c01pfrpjnwoq9`
- semantic-review receipt — `pass` (auto-pass at risk=low)

Backlog item: BI-58F514AC · Workroom: WC-541B924F

🤖 Generated with [Claude Code](https://claude.com/claude-code)
