### PR TITLE
fix(db): make backlog:capture actually run, and refresh the bundles from it

### DIFF
--- a/packages/db/recovery/backlog/README.md
+++ b/packages/db/recovery/backlog/README.md
@@ -35,7 +35,8 @@ non-reconcilable record described below.
 
 `manifest.json` must satisfy `capturedItemCount + unassignedItemCount ==
 unfinishedItemCount`. When that arithmetic does not close, an item is
-unaccounted for and teardown is not safe.
+unaccounted for and teardown is not safe. Check it, do not assume it: the
+backlog moves in minutes, and every count in these files is a snapshot.
 
 ## Capture
 
@@ -43,8 +44,17 @@ unaccounted for and teardown is not safe.
 pnpm --filter @dpf/db backlog:capture -- --out packages/db/recovery/backlog
 ```
 
-Captures `triaging`, `open`, and `in-progress` items. Pass `--all` to include
-`done`, `deferred`, and `retired`.
+Captures every item that is not `done` — `triaging`, `open`, `in-progress`,
+`deferred`, and `retired`. Deferred and retired work is included because a reset
+destroys the row either way, and "we decided to stop" is a judgement someone may
+revisit. Pass `--all` to include `done` items too (you almost never want this).
+
+Re-capture **overwrites an epic's existing bundle in place**, keeping its
+filename, `bundleId`, `description`, and `planPath`. It does not write a second
+file under a generated name, which would leave the curated one stale on disk
+while still looking authoritative. A genuinely new epic gets a generated
+`ep-<id>.json` name; rename it to something meaningful and the next capture will
+keep that name.
 
 Do not hand-write a bundle. `buildBacklogRecoveryBundle` round-trips its output
 through `parseBacklogRecoveryBundle`, so a bundle that builds is guaranteed to
@@ -89,5 +99,10 @@ Two classes currently sit there by decision, not by oversight:
   `SOURCES` vocabulary, so these cannot be represented without rewriting the
   field. Where a trace has been analysed into a human-authored finding, that
   finding is bundled and carries the durable knowledge.
+
+- **Automated capability-need items (`BI-CAP-*`).** Filed by the capability-need
+  engine from a coworker's tool-surface pressure signal (`CWN-*` origin), the
+  same shape of derived observation as the `BI-MCP-EFF-*` items above and
+  regenerated the same way once the signal recurs.
 
 Anything else with no epic should be linked to one and captured, not left here.

--- a/packages/db/recovery/backlog/animal-welfare-operations-vertical.json
+++ b/packages/db/recovery/backlog/animal-welfare-operations-vertical.json
@@ -3,7 +3,7 @@
   "bundleId": "animal-welfare-operations-vertical",
   "description": "Operator-invoked recovery input for the animal-welfare operations vertical epic (pet-rescue archetype operating model).",
   "source": {
-    "capturedAt": "2026-08-23T00:54:15.000Z",
+    "capturedAt": "2026-08-23T01:31:32.616Z",
     "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
     "planPath": "docs/architecture/archetype-operating-model-audit.md"
   },
@@ -608,7 +608,239 @@
       "scopeKind": "platform",
       "dependsOn": [],
       "externalDependencies": [],
-      "activities": [],
+      "activities": [
+        {
+          "recoveryKey": "bi-d2a51b36-cmt548lx0011b01rm7d3em5tz",
+          "kind": "initiative_readiness_decision",
+          "summary": "design readiness: allowed",
+          "recordedAt": "2026-08-23T01:15:48.852Z",
+          "payload": {
+            "unmet": [],
+            "target": "design",
+            "profile": "cross-domain",
+            "subject": {
+              "id": "BI-D2A51B36",
+              "kind": "backlog-item"
+            },
+            "verdict": "allowed",
+            "blockers": [],
+            "authority": {
+              "actionKey": "claim_backlog_item_for_work",
+              "enforcementState": "enforced"
+            },
+            "satisfied": [
+              {
+                "code": "CLASSIFICATION_REQUIRED",
+                "state": "pass",
+                "evidenceRefs": [],
+                "accountableRole": "product-owner"
+              },
+              {
+                "code": "AUTHORIZATION_DENIED",
+                "state": "pass",
+                "evidenceRefs": [],
+                "accountableRole": "platform-governance"
+              }
+            ],
+            "decisionId": "IRD-5AC890C6B2C2",
+            "workIntent": "design",
+            "evaluatedAt": "2026-08-23T01:15:48.837Z",
+            "factsDigest": "f20646c25f81d88dc713083cb7dc1b9e5b7aca08e606a8a5b63ea73460433743",
+            "stableCodes": {
+              "unmet": [],
+              "blockers": [],
+              "satisfied": [
+                "CLASSIFICATION_REQUIRED",
+                "AUTHORIZATION_DENIED"
+              ]
+            },
+            "policyVersion": "initiative-readiness.v1",
+            "schemaVersion": 1,
+            "transitionObject": {
+              "id": "OpenDigitalProductFactory/opendigitalproductfactory#feat/bi-d2a51b36-resource-occupancy",
+              "kind": "work-capsule",
+              "targetState": "design",
+              "expectedVersion": "claim.v1"
+            }
+          }
+        },
+        {
+          "recoveryKey": "bi-d2a51b36-cmt54lmrl01d301rm4zjb90s9",
+          "kind": "initiative_readiness_decision",
+          "summary": "implementation readiness: input-required",
+          "recordedAt": "2026-08-23T01:25:56.481Z",
+          "payload": {
+            "unmet": [
+              {
+                "code": "CANONICAL_DESIGN_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "design-checklist-reviewer"
+              },
+              {
+                "code": "RESEARCH_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "design-author"
+              },
+              {
+                "code": "SPEC_APPROVAL_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "design-checklist-reviewer"
+              },
+              {
+                "code": "REVIEW_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "architecture-reviewer"
+              },
+              {
+                "code": "REVIEW_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "data-reviewer"
+              },
+              {
+                "code": "REVIEW_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "ux-reviewer"
+              },
+              {
+                "code": "REVIEW_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "security-reviewer"
+              },
+              {
+                "code": "REVIEW_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "compliance-reviewer"
+              },
+              {
+                "code": "REVIEW_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "domain-reviewer"
+              },
+              {
+                "code": "OBJECTIVE_BASELINE_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "design-checklist-reviewer"
+              },
+              {
+                "code": "ARTIFACT_AUTHOR_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "artifact-resolver"
+              },
+              {
+                "code": "PLAN_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "implementation-planner"
+              },
+              {
+                "code": "PLAN_REVIEW_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "plan-reviewer"
+              },
+              {
+                "code": "PLAN_COVERAGE_REQUIRED",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "portfolio-management"
+              },
+              {
+                "code": "TRACEABILITY_INCOMPLETE",
+                "state": "missing",
+                "evidenceRefs": [],
+                "accountableRole": "portfolio-management"
+              }
+            ],
+            "target": "implementation",
+            "profile": "cross-domain",
+            "subject": {
+              "id": "BI-D2A51B36",
+              "kind": "backlog-item"
+            },
+            "verdict": "input-required",
+            "blockers": [],
+            "authority": {
+              "actionKey": "claim_backlog_item_for_work",
+              "enforcementState": "enforced"
+            },
+            "satisfied": [
+              {
+                "code": "CLASSIFICATION_REQUIRED",
+                "state": "pass",
+                "evidenceRefs": [],
+                "accountableRole": "product-owner"
+              },
+              {
+                "code": "AUTHORIZATION_DENIED",
+                "state": "pass",
+                "evidenceRefs": [],
+                "accountableRole": "platform-governance"
+              },
+              {
+                "code": "DEPENDENCY_UNRESOLVED",
+                "state": "not-applicable",
+                "evidenceRefs": [],
+                "accountableRole": "portfolio-management"
+              },
+              {
+                "code": "CAPSULE_IDENTITY_MISMATCH",
+                "state": "pass",
+                "evidenceRefs": [],
+                "accountableRole": "delivery-coordinator"
+              }
+            ],
+            "decisionId": "IRD-63E785B55D6B",
+            "workIntent": "implementation",
+            "evaluatedAt": "2026-08-23T01:25:56.473Z",
+            "factsDigest": "5cd67f6af00037907d75fc85281667477bb8cf066df92631e0915a73b9d79e62",
+            "stableCodes": {
+              "unmet": [
+                "CANONICAL_DESIGN_REQUIRED",
+                "RESEARCH_REQUIRED",
+                "SPEC_APPROVAL_REQUIRED",
+                "REVIEW_REQUIRED",
+                "REVIEW_REQUIRED",
+                "REVIEW_REQUIRED",
+                "REVIEW_REQUIRED",
+                "REVIEW_REQUIRED",
+                "REVIEW_REQUIRED",
+                "OBJECTIVE_BASELINE_REQUIRED",
+                "ARTIFACT_AUTHOR_REQUIRED",
+                "PLAN_REQUIRED",
+                "PLAN_REVIEW_REQUIRED",
+                "PLAN_COVERAGE_REQUIRED",
+                "TRACEABILITY_INCOMPLETE"
+              ],
+              "blockers": [],
+              "satisfied": [
+                "CLASSIFICATION_REQUIRED",
+                "AUTHORIZATION_DENIED",
+                "DEPENDENCY_UNRESOLVED",
+                "CAPSULE_IDENTITY_MISMATCH"
+              ]
+            },
+            "policyVersion": "initiative-readiness.v1",
+            "schemaVersion": 1,
+            "transitionObject": {
+              "id": "OpenDigitalProductFactory/opendigitalproductfactory#feat/bi-d2a51b36-resource-occupancy",
+              "kind": "work-capsule",
+              "targetState": "implementation",
+              "expectedVersion": "claim.v1"
+            }
+          }
+        }
+      ],
       "effortSize": "large",
       "triageOutcome": "build",
       "createdAt": "2026-08-22T04:39:13.864Z"

--- a/packages/db/recovery/backlog/external-website-channels-cms-interoperability.json
+++ b/packages/db/recovery/backlog/external-website-channels-cms-interoperability.json
@@ -3,7 +3,7 @@
   "bundleId": "external-website-channels-cms-interoperability",
   "description": "Operator-invoked recovery input for the external website channels and CMS interoperability epic (WordPress projection).",
   "source": {
-    "capturedAt": "2026-08-23T00:54:15.000Z",
+    "capturedAt": "2026-08-23T01:31:32.616Z",
     "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
     "planPath": "docs/superpowers/plans/2026-08-21-wordpress-channel-projection.md"
   },

--- a/packages/db/recovery/backlog/initiative-readiness-governed-completion.json
+++ b/packages/db/recovery/backlog/initiative-readiness-governed-completion.json
@@ -3,7 +3,7 @@
   "bundleId": "initiative-readiness-governed-completion",
   "description": "Operator-invoked recovery input for the initiative-readiness and governed-completion enforcement epic.",
   "source": {
-    "capturedAt": "2026-08-23T00:54:15.000Z",
+    "capturedAt": "2026-08-23T01:31:32.616Z",
     "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
     "planPath": "docs/superpowers/plans/2026-08-08-initiative-readiness-and-goal-completion-reconciliation-implementation.md"
   },

--- a/packages/db/recovery/backlog/manifest.json
+++ b/packages/db/recovery/backlog/manifest.json
@@ -1,18 +1,8 @@
 {
   "schemaVersion": 1,
-  "capturedAt": "2026-08-23T00:54:15.000Z",
+  "capturedAt": "2026-08-23T01:31:32.616Z",
   "scope": "not-done",
   "bundles": [
-    {
-      "epicId": "EP-5102F494",
-      "file": "animal-welfare-operations-vertical.json",
-      "itemCount": 10
-    },
-    {
-      "epicId": "EP-31C5A6C8",
-      "file": "external-website-channels-cms-interoperability.json",
-      "itemCount": 3
-    },
     {
       "epicId": "EP-129D11FD",
       "file": "initiative-readiness-governed-completion.json",
@@ -24,19 +14,29 @@
       "itemCount": 13
     },
     {
-      "epicId": "EP-56AE0F69",
-      "file": "reset-cycle-3-platform-findings.json",
-      "itemCount": 6
+      "epicId": "EP-31C5A6C8",
+      "file": "external-website-channels-cms-interoperability.json",
+      "itemCount": 3
+    },
+    {
+      "epicId": "EP-5102F494",
+      "file": "animal-welfare-operations-vertical.json",
+      "itemCount": 10
     },
     {
       "epicId": "EP-55AF36AC",
       "file": "veterinary-clinic-operating-system.json",
       "itemCount": 6
+    },
+    {
+      "epicId": "EP-56AE0F69",
+      "file": "reset-cycle-3-platform-findings.json",
+      "itemCount": 7
     }
   ],
-  "capturedItemCount": 43,
-  "unassignedItemCount": 8,
-  "unfinishedItemCount": 51,
+  "capturedItemCount": 44,
+  "unassignedItemCount": 9,
+  "unfinishedItemCount": 53,
   "skipped": [
     {
       "itemId": "BI-0E8B29C3",
@@ -44,6 +44,10 @@
     },
     {
       "itemId": "BI-68A72876",
+      "reason": "item-has-no-epic"
+    },
+    {
+      "itemId": "BI-CAP-FC4033F6",
       "reason": "item-has-no-epic"
     },
     {

--- a/packages/db/recovery/backlog/purpose-aware-installation-ecosystem-productivity.json
+++ b/packages/db/recovery/backlog/purpose-aware-installation-ecosystem-productivity.json
@@ -3,7 +3,7 @@
   "bundleId": "purpose-aware-installation-ecosystem-productivity",
   "description": "Operator-invoked recovery input for the approved purpose-aware installation epic, umbrella for install identity and ecosystem productivity work.",
   "source": {
-    "capturedAt": "2026-08-23T00:54:15.000Z",
+    "capturedAt": "2026-08-23T01:31:32.616Z",
     "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
     "planPath": "docs/superpowers/plans/2026-08-08-purpose-aware-installation-ecosystem-productivity.md"
   },

--- a/packages/db/recovery/backlog/reset-cycle-3-platform-findings.json
+++ b/packages/db/recovery/backlog/reset-cycle-3-platform-findings.json
@@ -3,7 +3,7 @@
   "bundleId": "reset-cycle-3-platform-findings",
   "description": "Operator-invoked recovery input for the platform findings from from-scratch reset/dogfood cycle 3 (install, lifecycle, agent-host and CI-gate).",
   "source": {
-    "capturedAt": "2026-08-23T00:54:15.000Z",
+    "capturedAt": "2026-08-23T01:31:32.616Z",
     "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
     "planPath": "docs/architecture/archetype-operating-model-audit.md"
   },
@@ -289,6 +289,30 @@
             "toEpicId": "EP-56AE0F69",
             "fromEpicId": null
           }
+        },
+        {
+          "recoveryKey": "bi-11d611b3-cmt549dyi011w01rmiu93xjq6",
+          "kind": "evidence",
+          "summary": "Canonical P0 design source is published at immutable commit af2f4085198a",
+          "recordedAt": "2026-08-23T01:16:25.194Z",
+          "payload": {
+            "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/af2f4085198a59d3c078c316928fdd9f7bdcec50/docs/superpowers/specs/2026-08-23-external-agent-operating-profile-design.md",
+            "body": "Author-owned source provenance only; this is not an independent approval receipt. The specification defines OBJ-01..OBJ-05 and AC-01..AC-09 for the compiler, core MCP discovery, A2A compatibility advertisement, generated pointer, failure semantics, scale bounds, and tests.",
+            "evidenceKind": "source_verified",
+            "toolExecutionId": null
+          }
+        },
+        {
+          "recoveryKey": "bi-11d611b3-cmt54r3vu01fa01rmeepltiwg",
+          "kind": "evidence",
+          "summary": "Independent P0 review rejected af2f4085198a; digest, A2A, policy, and deferred-entry findings require revision",
+          "recordedAt": "2026-08-23T01:30:11.946Z",
+          "payload": {
+            "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/af2f4085198a59d3c078c316928fdd9f7bdcec50/docs/superpowers/specs/2026-08-23-external-agent-operating-profile-design.md",
+            "body": "Reviewer task /root/p0_spec_review inspected immutable commit af2f4085198a and returned REVISE / DO NOT APPROVE. Critical: profile digest self-reference and conflated schema/profile/authority/release identities (AC-P0-04/06/07). Important: no A2A 0.3 AgentCapabilities.extensions placement (AC-P0-04/05/09); policy fields lacked canonical owners and closed types (AC-P0-02/03); mandatory workCatalogRef/attentionRef were dead references to P1 capabilities (AC-P0-01/08); parent vocabulary changes lacked a refinement mapping. No initiative approval or baseline was recorded.",
+            "evidenceKind": "spec_review",
+            "toolExecutionId": null
+          }
         }
       ],
       "effortSize": "medium",
@@ -321,6 +345,24 @@
         }
       ],
       "createdAt": "2026-08-23T00:30:54.324Z"
+    },
+    {
+      "itemId": "BI-6804F720",
+      "epicId": "EP-56AE0F69",
+      "title": "External MCP coworker handoff drops caller thread context and cannot engage an independent reviewer",
+      "body": "## Problem\n\nAn authenticated external Codex desktop task can discover `request_coworker` and `summon_coworker`, but both calls fail before dispatch with `missing_threadId`. The MCP adapter does not propagate the caller task/thread identity required by the coworker-interaction owner. This makes independent initiative review unreachable even when the operator explicitly authorizes delegation.\n\n## Scope\n\nIn scope: carry a verified external task identity through the MCP request context into named-coworker handoff/summon, preserve the visible interaction/audit contract, and fail with actionable typed diagnostics only when no verifiable task identity exists. Cover Codex desktop plus the peer external MCP hosts through the shared adapter.\n\nOut of scope: weakening independent-review requirements, self-approving initiative artifacts, inventing synthetic human principals, or creating a second coworker-routing mechanism.\n\n## Acceptance criteria\n\n- `request_coworker` and `summon_coworker` invoked from an authenticated external MCP task receive a server-verified caller thread/task identity and dispatch exactly one visible peer interaction.\n- The caller cannot spoof another task identity through ordinary tool arguments.\n- Missing or invalid identity returns a typed, actionable failure that identifies the host-adapter/configuration repair path.\n- Claude, Codex, Grok, embedded, and generic MCP compatibility behavior is covered without duplicating the coordination contract per host.\n- Tests reproduce the current `missing_threadId` failure and prove the fixed end-to-end context propagation.\n\n## Dependencies and impact\n\nBlocks: `BI-11D611B3` independent spec approval and any external-agent initiative that requires a distinct reviewer principal.\n\nObserved from Codex task `01a027e8-73a3-74f1-aa45-0a347fb5d414` on 2026-08-23. Both named routes failed identically; no coworker offer exists for an alternate engagement route.",
+      "status": "open",
+      "type": "product",
+      "workType": "bug",
+      "source": "automated-detection",
+      "scopeKind": "platform",
+      "dependsOn": [],
+      "externalDependencies": [],
+      "activities": [],
+      "effortSize": "medium",
+      "triageOutcome": "build",
+      "scopeRationale": "The defect is in the universal MCP coordination adapter and blocks governed coworker delegation for external Codex/Claude/Grok sessions across every installation and archetype.",
+      "createdAt": "2026-08-23T01:22:50.225Z"
     },
     {
       "itemId": "BI-89887875",

--- a/packages/db/recovery/backlog/unassigned-items.json
+++ b/packages/db/recovery/backlog/unassigned-items.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "capturedAt": "2026-08-23T00:54:15.000Z",
+  "capturedAt": "2026-08-23T01:31:32.616Z",
   "items": [
     {
       "itemId": "BI-0E8B29C3",
@@ -21,7 +21,7 @@
     },
     {
       "itemId": "BI-68A72876",
-      "title": "[self-upgrade] capability-state-preflight-unavailable: promote.sh's capability preflight aborted with `error: capability_state_stale` \u00e2\u20ac\u201d a MISLABEL: it means the governed install snapshot (/dpf-state/i",
+      "title": "[self-upgrade] capability-state-preflight-unavailable: promote.sh's capability preflight aborted with `error: capability_state_stale` — a MISLABEL: it means the governed install snapshot (/dpf-state/i",
       "body": "failureFingerprint: 1e15e0d2957bb248\nclass: capability-state-preflight-unavailable\ndisposition: environment\nplaybook: docs/superpowers/specs/2026-06-06-procedural-functional-verification-design.md\nrunId: SUR-34CD50FD\n\n--- stderr (tail) ---\nerror: capability_state_stale\n",
       "status": "triaging",
       "type": "product",
@@ -33,6 +33,23 @@
       "scopeKind": null,
       "scopeRationale": null,
       "createdAt": "2026-08-23T00:22:13.426Z",
+      "completedAt": null,
+      "resolution": null
+    },
+    {
+      "itemId": "BI-CAP-FC4033F6",
+      "title": "[tool] Trim or phase the caution-zone tool surface before it reaches overload.",
+      "body": "Trim or phase the caution-zone tool surface before it reaches overload.\nBlocks: The tool surface is approaching the local selection cliff.\nKind: tool | Severity: minor\nCoworker: AGT-190\nFrom capability need CWN-C283E559\n\n[origin:capability-need:AGT-190:tool:trim or phase the caution-zone tool surface before it reaches overload.]",
+      "status": "triaging",
+      "type": "product",
+      "workType": "tool",
+      "source": "automated-detection",
+      "priority": null,
+      "effortSize": null,
+      "triageOutcome": null,
+      "scopeKind": null,
+      "scopeRationale": null,
+      "createdAt": "2026-08-23T01:04:04.783Z",
       "completedAt": null,
       "resolution": null
     },
@@ -56,7 +73,7 @@
     {
       "itemId": "BI-MCP-EFF-3E441834",
       "title": "[MCP efficiency] High failure: record_plan_backlog_coverage (100%)",
-      "body": "15/15 calls failed. Agents may be retrying blindly \u00e2\u20ac\u201d fix tool contract, grants, or skill guidance.\nRecommended action: fix_instructions\nSeverity: critical; kind: high_failure; tool: record_plan_backlog_coverage\nWaste call estimate: 15\nEvidence count: 15; fails: 15\nSource: MCP call efficiency scan (BI-A08EBAEC); sourceId=high_failure:record_plan_backlog_coverage\n\n[origin:mcp-call-efficiency:high_failure:record_plan_backlog_coverage]",
+      "body": "15/15 calls failed. Agents may be retrying blindly — fix tool contract, grants, or skill guidance.\nRecommended action: fix_instructions\nSeverity: critical; kind: high_failure; tool: record_plan_backlog_coverage\nWaste call estimate: 15\nEvidence count: 15; fails: 15\nSource: MCP call efficiency scan (BI-A08EBAEC); sourceId=high_failure:record_plan_backlog_coverage\n\n[origin:mcp-call-efficiency:high_failure:record_plan_backlog_coverage]",
       "status": "triaging",
       "type": "portfolio",
       "workType": "doc",

--- a/packages/db/recovery/backlog/veterinary-clinic-operating-system.json
+++ b/packages/db/recovery/backlog/veterinary-clinic-operating-system.json
@@ -3,7 +3,7 @@
   "bundleId": "veterinary-clinic-operating-system",
   "description": "Operator-invoked recovery input for the veterinary clinic operating system epic (archetype acceptance-scenario contract and fixtures).",
   "source": {
-    "capturedAt": "2026-08-23T00:54:15.000Z",
+    "capturedAt": "2026-08-23T01:31:32.616Z",
     "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
     "planPath": "docs/architecture/archetype-operating-model-audit.md"
   },

--- a/packages/db/scripts/capture-backlog-bundle.ts
+++ b/packages/db/scripts/capture-backlog-bundle.ts
@@ -8,7 +8,7 @@
 // Writes one bundle per epic (the bundle schema is single-epic), plus a manifest.
 // Everything it cannot represent is listed, never silently dropped.
 
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
 import {
@@ -19,15 +19,19 @@ import {
 import { prisma } from "../src/client";
 
 const CAPTURE_CONFIG_KEY = "installation.backlog-capture.v1";
-const UNFINISHED_STATUSES = ["triaging", "open", "in-progress"] as const;
+// Everything that is not `done`. Recovery must preserve deferred and retired
+// work too: a reset destroys the row either way, and "we decided to stop" is a
+// judgement someone may revisit, unlike completed work which git already
+// records as a merged PR. Pass --all to include `done` as well.
+const NOT_DONE_STATUSES = ["triaging", "open", "in-progress", "deferred", "retired"] as const;
 
 function usage(): string {
   return [
     "Usage: pnpm --filter @dpf/db backlog:capture -- --out <dir> [--all] [--no-receipt]",
     "",
-    "Captures unfinished backlog work as reconcilable recovery bundles.",
+    "Captures every not-done backlog item as reconcilable recovery bundles.",
     "  --out <dir>    Directory to write bundles into (required).",
-    "  --all          Include done/deferred/retired items, not just unfinished work.",
+    "  --all          Include done items too, not just work that is not done.",
     "  --no-receipt   Do not record the capture receipt in PlatformConfig.",
     "",
     "Restore a bundle with: pnpm --filter @dpf/db backlog:reconcile -- <bundle.json> --apply",
@@ -60,10 +64,60 @@ function bundleFileName(epicId: string): string {
   return `${epicId.toLowerCase().replace(/[^a-z0-9]+/g, "-")}.json`;
 }
 
+/** Files in the output directory that are records, not single-epic bundles. */
+const NON_BUNDLE_FILES = new Set(["manifest.json", "unassigned-items.json"]);
+
+/**
+ * Map each epic to the bundle file already committed for it.
+ *
+ * Re-capture must overwrite an epic's existing bundle, never write a second file
+ * beside it under a different name. A committed bundle carries a curated
+ * `bundleId`, `description`, and `planPath`; writing `ep-1faba22d.json` next to
+ * `purpose-aware-installation-ecosystem-productivity.json` would leave the
+ * curated one stale on disk while still looking authoritative — the exact
+ * failure this format exists to prevent.
+ */
+async function existingBundlesByEpic(
+  dir: string,
+): Promise<Map<string, { file: string; bundleId: string; description: string; planPath: string }>> {
+  const found = new Map<string, { file: string; bundleId: string; description: string; planPath: string }>();
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return found;
+  }
+  for (const file of entries) {
+    if (!file.endsWith(".json") || NON_BUNDLE_FILES.has(file)) continue;
+    try {
+      const parsed = JSON.parse(await readFile(resolve(dir, file), "utf8")) as {
+        bundleId?: unknown;
+        description?: unknown;
+        source?: { planPath?: unknown };
+        epic?: { epicId?: unknown };
+      };
+      const epicId = parsed.epic?.epicId;
+      // Only the first file claiming an epic wins, so a stray duplicate cannot
+      // silently retarget the capture.
+      if (typeof epicId === "string" && !found.has(epicId)) {
+        found.set(epicId, {
+          file,
+          bundleId: typeof parsed.bundleId === "string" ? parsed.bundleId : "",
+          description: typeof parsed.description === "string" ? parsed.description : "",
+          planPath: typeof parsed.source?.planPath === "string" ? parsed.source.planPath : "",
+        });
+      }
+    } catch {
+      // An unreadable or non-bundle JSON file is not a capture target.
+    }
+  }
+  return found;
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const capturedAt = new Date().toISOString();
-  const statusFilter = args.all ? undefined : { in: [...UNFINISHED_STATUSES] };
+  const statusFilter = args.all ? undefined : { in: [...NOT_DONE_STATUSES] };
 
   const epics = await prisma.epic.findMany({
     orderBy: { epicId: "asc" },
@@ -77,7 +131,7 @@ async function main(): Promise<void> {
       scopeRationale: true,
       createdAt: true,
       completedAt: true,
-      backlogItems: {
+      items: {
         where: statusFilter ? { status: statusFilter } : undefined,
         orderBy: { itemId: "asc" },
         select: {
@@ -112,29 +166,35 @@ async function main(): Promise<void> {
   });
 
   await mkdir(args.out, { recursive: true });
+  const existing = await existingBundlesByEpic(args.out);
 
   const written: Array<{ epicId: string; file: string; itemCount: number }> = [];
   const skipped: BacklogCaptureSkip[] = [];
   let capturedItems = 0;
 
   for (const epic of epics) {
-    if (epic.backlogItems.length === 0) continue;
-    const items = epic.backlogItems.map(
+    if (epic.items.length === 0) continue;
+    const items = epic.items.map(
       (item) => ({ ...item, epicId: epic.epicId }) as unknown as BacklogCaptureItemRow,
     );
+    // Refreshing an epic keeps the identity and curation of its committed
+    // bundle; only a genuinely new epic gets generated defaults.
+    const prior = existing.get(epic.epicId);
     const result = buildBacklogRecoveryBundle({
-      bundleId: `capture-${epic.epicId.toLowerCase()}`,
-      description: `Backlog captured from this installation on ${capturedAt}.`,
+      bundleId: prior?.bundleId || `capture-${epic.epicId.toLowerCase()}`,
+      description:
+        prior?.description || `Backlog captured from this installation on ${capturedAt}.`,
       capturedAt,
       repository: "OpenDigitalProductFactory/opendigitalproductfactory",
-      planPath: "docs/superpowers/plans/2026-08-22-instance-identity-and-purpose.md",
+      planPath:
+        prior?.planPath || "docs/superpowers/plans/2026-08-22-instance-identity-and-purpose.md",
       epic: { ...epic, epicId: epic.epicId } as never,
       items,
     });
     skipped.push(...result.skipped);
     if (!result.bundle) continue;
 
-    const file = bundleFileName(epic.epicId);
+    const file = prior?.file ?? bundleFileName(epic.epicId);
     await writeFile(
       resolve(args.out, file),
       `${JSON.stringify(result.bundle, null, 2)}\n`,
@@ -183,13 +243,13 @@ async function main(): Promise<void> {
   }
 
   const unfinishedItemCount = await prisma.backlogItem.count({
-    where: { status: { in: [...UNFINISHED_STATUSES] } },
+    where: { status: { in: [...NOT_DONE_STATUSES] } },
   });
 
   const manifest = {
     schemaVersion: 1,
     capturedAt,
-    scope: args.all ? "all" : "unfinished",
+    scope: args.all ? "all" : "not-done",
     bundles: written,
     capturedItemCount: capturedItems,
     unassignedItemCount: orphans.length,
@@ -221,7 +281,7 @@ async function main(): Promise<void> {
   process.stdout.write(
     [
       `Captured ${capturedItems} item(s) across ${written.length} bundle(s) into ${args.out}`,
-      `Unfinished items on this installation: ${unfinishedItemCount}`,
+      `Not-done items on this installation: ${unfinishedItemCount}`,
       orphans.length
         ? `Wrote ${orphans.length} item(s) with no epic to unassigned-items.json (not reconcilable — re-file them under an epic).`
         : "No items without an epic.",


### PR DESCRIPTION
Follow-up to #4553 (merged). That PR landed the bundles; this one repairs the command the README tells you to run before teardown, and regenerates the bundles from it.

## `backlog:capture` had never run

```
$ pnpm --filter @dpf/db backlog:capture -- --out packages/db/recovery/backlog
Unknown field `backlogItems` for select statement on model `Epic`
```

The `Epic` → `BacklogItem` relation is `items`, not `backlogItems` (`packages/db/prisma/schema/work-coordination.prisma`). The capture half of the recovery contract shipped in #4438 has been dead on arrival ever since — which is very likely why #4467's bundles were hand-written, and why #4553's were produced by an ad-hoc pipeline rather than the shipped script.

It failed at exactly the moment it matters: an operator running the documented pre-teardown re-capture would have got a stack trace and no bundles.

## Three fixes, all in `capture-backlog-bundle.ts`

**1. Correct the relation name** so the query runs at all.

**2. Re-capture overwrites an epic's bundle in place.** Filenames were derived from the epic id, so capturing into this directory would have written `ep-1faba22d.json` *beside* the curated `purpose-aware-installation-ecosystem-productivity.json` — a second copy under a new name, leaving the curated one stale on disk and still looking authoritative. That is the precise failure `README.md` warns about, reached by following `README.md`. Capture now reuses an existing bundle's `file`, `bundleId`, `description`, and `planPath`, matched by `epic.epicId`. A genuinely new epic still gets a generated name.

**3. Default scope is now every not-done status.** `deferred` and `retired` were excluded. A reset destroys those rows too, and "we decided to stop" is a judgement someone may revisit — unlike `done` work, which git already records as a merged PR. `--all` still adds `done`.

This one was load-bearing: without it the bundles merged in #4553 were **not reproducible by the documented command**. Capture produced 42 items where the committed set has 43, silently dropping EP-1FABA22D's one `retired` item. A capture command that quietly returns less than the committed backup is worse than one that crashes.

## Bundles regenerated by the script

The committed bundles are now the script's own output, so what is in git is exactly what the documented command reproduces. That is what makes the invariant checkable rather than aspirational — you can re-run capture and diff.

| Epic | Items |
| --- | ---: |
| EP-1FABA22D Purpose-Aware Installation | 13 |
| EP-5102F494 Animal-welfare operations | 10 |
| EP-56AE0F69 Reset/dogfood cycle 3 | **7** |
| EP-55AF36AC Veterinary Clinic OS | 6 |
| EP-129D11FD Initiative Readiness | 5 |
| EP-31C5A6C8 External Website Channels | 3 |
| — no epic — (`unassigned-items.json`, not reconcilable) | 9 |

**44 bundled + 9 unassigned = 53 = live not-done count.** `manifest.json` closes.

## The backlog moved again, and the fix caught it

While #4553 sat in the merge queue, **BI-6804F720** ("External MCP coworker handoff drops caller thread context") was filed into EP-56AE0F69, taking it from 6 to 7. The repaired script picked it up with no manual step — which is the whole point of having a working capture command.

That is the fourth time the backlog moved during this work (EP-55AF36AC appearing mid-session, orphans 9→12, BI-CAP-FC4033F6, now BI-6804F720). Every count in these files is a snapshot, and the README now says so.

## Verification

Real Prisma-backed `backlog:reconcile` against the live installation database — all six bundles parse, every item resolves to `skip`, zero creates:

```
animal-welfare-operations-vertical.json                create=0 skip=10
external-website-channels-cms-interoperability.json    create=0 skip= 3
initiative-readiness-governed-completion.json          create=0 skip= 5
purpose-aware-installation-ecosystem-productivity.json create=0 skip=13
reset-cycle-3-platform-findings.json                   create=0 skip= 7
veterinary-clinic-operating-system.json                create=0 skip= 6
```

Read-only throughout; `--apply` was never used. `dpf-postgres-1` publishes no host port, so a temporary `socat` container on `dpf_default` forwarded `127.0.0.1:15433` for the dry-run and was removed afterwards; no running service was reconfigured.

`packages/db` recovery tests: 17 passed (`backlog-recovery-bundle.test.ts`, `backlog-recovery-capture.test.ts`). The capture tests exercise `buildBacklogRecoveryBundle` directly and are unaffected by the script's query and file-naming changes.

Gate answers are in commit trailers, not this body.

## Before teardown

```bash
pnpm --filter @dpf/db backlog:capture -- --out packages/db/recovery/backlog
```

Confirm `manifest.json` closes (`capturedItemCount + unassignedItemCount == unfinishedItemCount`), commit any diff, and get it **merged to main** — a bundle on an unmerged branch in a worktree teardown deletes is not a backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
