### PR TITLE
fix(guard): catch Node built-ins reached by a client component, not just imported

### DIFF
--- a/scripts/check-bundle-boundaries.mjs
+++ b/scripts/check-bundle-boundaries.mjs
@@ -17,6 +17,13 @@
  *   2. NODE BUILT-INS IN A "use client" COMPONENT: fs / child_process / path /
  *      crypto / etc. don't exist in the browser bundle and break the client
  *      build. Server-only code must live in a server module / route / action.
+ *   2b. THE SAME BUILT-INS REACHED *TRANSITIVELY* from a "use client" component.
+ *      Check 2 only reads the client file itself, so a client component that
+ *      imports one label out of a module that imports a module that reads the
+ *      filesystem passes it — and then fails the production build with
+ *      "the chunking context does not support external modules". That is a full
+ *      CI round trip for something a graph walk finds in under a second
+ *      (BI-98AF1066 follow-up, 2026-08-23 / PR #4483).
  *   3. HOST-ONLY STATIC IMPORTS IN SERVER ENTRYPOINTS: route/page/action/Inngest
  *      modules must not statically import Docker-only promoter code. Use a
  *      dynamic import() boundary so Next/Turbopack does not trace that graph at
@@ -26,7 +33,7 @@
  * Exit 0 = clean; exit 1 = violations (with a clear, actionable report).
  */
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { join, relative } from "node:path";
+import { dirname, join, relative } from "node:path";
 
 const ROOT = process.cwd();
 const SCAN_DIRS = [join(ROOT, "apps", "web")];
@@ -83,7 +90,7 @@ function* walk(dir) {
 // A file is a client component if a "use client" directive sits at the top
 // (optionally after comments). We only look at the head to avoid matching a
 // "use client" string literal deeper in the file.
-function isUseClient(body) {
+export function isUseClient(body) {
   const head = body.slice(0, 600);
   return /(^|\n)\s*['"]use client['"]\s*;?/.test(head);
 }
@@ -99,7 +106,7 @@ function clientNodeBuiltinImports(body) {
   return hits;
 }
 
-function extractStaticImports(body) {
+export function extractStaticImports(body) {
   const noType = body.replace(
     /\b(?:import|export)\s+type\b[\s\S]*?from\s*["'][^"']+["']/g,
     "",
@@ -177,114 +184,258 @@ function scriptsModulesReachedByWeb() {
   return reached;
 }
 
-const dynViolations = [];
-const clientViolations = [];
-const hostOnlyStaticViolations = [];
-const bundledScriptViolations = [];
+// ── Check 2b: Node built-ins reached TRANSITIVELY from a "use client" file ──
+//
+// Check 2 reads the client file and stops. The failure this adds is one hop
+// further out: a client component imports a label map, that module imports the
+// composer, and the composer reads installer state. Turbopack then refuses the
+// whole page — the error names `node:fs/promises` and no file at all.
+//
+// Deliberately NARROWER than check 2 in two ways, so it can be a hard fail with
+// no baseline:
+//
+//   * Only built-ins Turbopack cannot shim. `crypto`, `path`, `stream` and
+//     friends have browser polyfills and are reached transitively all over the
+//     portal today; failing those would be a migration, not a guard.
+//   * The walk STOPS at a "use server" module. Next replaces those imports with
+//     RPC references, so their graph is never bundled for the browser — a client
+//     component importing a server action that imports Prisma is correct, and
+//     flagging it would be a false positive.
+export const TRANSITIVE_FATAL_BUILTINS = new Set([
+  "fs", "fs/promises", "child_process", "net", "dns", "tls", "cluster",
+  "worker_threads", "module", "v8", "vm", "readline", "http2", "dgram",
+]);
 
-for (const rel of scriptsModulesReachedByWeb()) {
-  let body;
+const WEB_ROOT = join(ROOT, "apps", "web");
+const sourceCache = new Map();
+
+function readSource(file) {
+  if (sourceCache.has(file)) return sourceCache.get(file);
+  let body = null;
   try {
-    body = readFileSync(join(ROOT, rel), "utf8");
+    body = readFileSync(file, "utf8");
   } catch {
-    continue;
+    body = null;
   }
-  for (const specifier of moduleReferences(body)) {
-    if (!isBundleSafeSpecifier(specifier)) bundledScriptViolations.push(`${rel} -> ${specifier}`);
-  }
+  sourceCache.set(file, body);
+  return body;
 }
 
-for (const baseDir of SCAN_DIRS) {
-  for (const file of walk(baseDir)) {
+// Resolve only what lives inside apps/web: relative paths and the "@/" alias.
+// Bare and workspace specifiers are left alone — following them would drag in
+// `@dpf/db`'s polyfillable `crypto` and drown the signal.
+export function resolveWebModule(specifier, fromFile) {
+  let base;
+  if (specifier.startsWith("@/")) base = join(WEB_ROOT, specifier.slice(2));
+  else if (specifier.startsWith(".")) base = join(dirname(fromFile), specifier);
+  else return null;
+
+  for (const candidate of [base, `${base}.ts`, `${base}.tsx`, join(base, "index.ts"), join(base, "index.tsx")]) {
+    try {
+      if (statSync(candidate).isFile()) return candidate;
+    } catch {
+      // try the next extension
+    }
+  }
+  return null;
+}
+
+// Mirrors isUseClient: only the head, so a "use server" string deeper in the
+// file cannot mask a module that really is part of the client graph.
+export function isUseServer(body) {
+  return /(^|\n)\s*['"]use server['"]\s*;?/.test(body.slice(0, 600));
+}
+
+// Memoised depth-first search. Returns the chain of specifiers that reaches a
+// fatal built-in, or null. `visiting` breaks import cycles: an edge already on
+// the stack contributes nothing, and any real path is found via another branch.
+const reachCache = new Map();
+
+function relPath(file) {
+  return relative(ROOT, file).replace(/\\/g, "/");
+}
+
+/**
+ * The chain of modules from `file` to a fatal built-in, or null if none.
+ *
+ * `isSeed` marks the client component itself: a "use server" directive stops the
+ * walk at an imported module, but the seed is by definition client code.
+ * `visiting` breaks import cycles — an edge already on the stack contributes
+ * nothing, and any genuine path is still found down another branch.
+ */
+export function fatalBuiltinChain(file, isSeed = true, visiting = new Set()) {
+  if (reachCache.has(file)) return reachCache.get(file);
+  if (visiting.has(file)) return null;
+
+  const body = readSource(file);
+  if (!body) return null;
+  // A server action is an RPC boundary, not a bundled import. Stop here.
+  if (!isSeed && isUseServer(body)) return null;
+
+  visiting.add(file);
+  let result = null;
+  for (const specifier of extractStaticImports(stripComments(body))) {
+    if (TRANSITIVE_FATAL_BUILTINS.has(specifier.replace(/^node:/, ""))) {
+      result = [specifier];
+      break;
+    }
+    const next = resolveWebModule(specifier, file);
+    if (!next) continue;
+    const deeper = fatalBuiltinChain(next, false, visiting);
+    if (deeper) {
+      result = [relPath(next), ...deeper];
+      break;
+    }
+  }
+  visiting.delete(file);
+
+  // Only cache a settled answer: a null produced while a cycle was open on the
+  // stack may be wrong for a later, cycle-free visit.
+  if (visiting.size === 0) reachCache.set(file, result);
+  return result;
+}
+
+function main() {
+  const dynViolations = [];
+  const clientViolations = [];
+  const transitiveClientViolations = [];
+  const hostOnlyStaticViolations = [];
+  const bundledScriptViolations = [];
+
+  for (const rel of scriptsModulesReachedByWeb()) {
     let body;
     try {
-      body = readFileSync(file, "utf8");
+      body = readFileSync(join(ROOT, rel), "utf8");
     } catch {
       continue;
     }
-    const rel = relative(ROOT, file).replace(/\\/g, "/");
+    for (const specifier of moduleReferences(body)) {
+      if (!isBundleSafeSpecifier(specifier)) bundledScriptViolations.push(`${rel} -> ${specifier}`);
+    }
+  }
 
-    if (DYN_REQUIRE.test(body) && !DYNAMIC_REQUIRE_ALLOW.has(rel)) {
-      dynViolations.push(rel);
-    }
-    if (isUseClient(body)) {
-      const hits = clientNodeBuiltinImports(body);
-      if (hits.length) clientViolations.push(`${rel}  (imports: ${hits.join(", ")})`);
-    }
-    if (isServerBundleEntrypoint(rel)) {
-      for (const specifier of extractStaticImports(body)) {
-        if (HOST_ONLY_IMPORTS.some((re) => re.test(specifier))) {
-          hostOnlyStaticViolations.push(`${rel} -> ${specifier}`);
+  for (const baseDir of SCAN_DIRS) {
+    for (const file of walk(baseDir)) {
+      let body;
+      try {
+        body = readFileSync(file, "utf8");
+      } catch {
+        continue;
+      }
+      const rel = relative(ROOT, file).replace(/\\/g, "/");
+
+      if (DYN_REQUIRE.test(body) && !DYNAMIC_REQUIRE_ALLOW.has(rel)) {
+        dynViolations.push(rel);
+      }
+      if (isUseClient(body)) {
+        const hits = clientNodeBuiltinImports(body);
+        if (hits.length) clientViolations.push(`${rel}  (imports: ${hits.join(", ")})`);
+        // Only when check 2 is silent: a direct import is already reported above,
+        // and naming it twice buries the transitive cases that need the chain.
+        if (!hits.length) {
+          const chain = fatalBuiltinChain(file);
+          if (chain) transitiveClientViolations.push([rel, ...chain].join("\n      -> "));
+        }
+      }
+      if (isServerBundleEntrypoint(rel)) {
+        for (const specifier of extractStaticImports(body)) {
+          if (HOST_ONLY_IMPORTS.some((re) => re.test(specifier))) {
+            hostOnlyStaticViolations.push(`${rel} -> ${specifier}`);
+          }
         }
       }
     }
   }
+
+  let failed = false;
+
+  if (dynViolations.length > 0) {
+    failed = true;
+    console.error("");
+    console.error('ERROR: BI-98AF1066 — bundle-hostile dynamic require found.');
+    console.error("");
+    console.error('`new Function(... require ...)` is invisible to the bundler and can resolve to');
+    console.error('undefined in a Next server chunk — the lazy-node "d is not a function" crash that');
+    console.error('crash-looped /build. Use a direct import instead:');
+    console.error('    import * as childProcess from "node:child_process";');
+    console.error("");
+    for (const v of dynViolations) console.error("  " + v);
+    console.error("");
+  }
+
+  if (clientViolations.length > 0) {
+    failed = true;
+    console.error("");
+    console.error('ERROR: BI-98AF1066 — Node built-in imported by a "use client" component.');
+    console.error("");
+    console.error("These modules don't exist in the browser bundle and break the client build.");
+    console.error("Move the server-only code to a server module, route handler, or server action,");
+    console.error("and call it from the client via that boundary.");
+    console.error("");
+    for (const v of clientViolations) console.error("  " + v);
+    console.error("");
+  }
+
+  if (transitiveClientViolations.length > 0) {
+    failed = true;
+    console.error("");
+    console.error('ERROR: BI-98AF1066 — a "use client" component REACHES a Node built-in.');
+    console.error("");
+    console.error("Not imported directly — reached through the modules below. Every module a client");
+    console.error("component imports FOR A VALUE is bundled for the browser, so one label pulled out");
+    console.error("of a server module drags its whole graph in. Turbopack then fails the page with");
+    console.error('"the chunking context does not support external modules", naming no file at all.');
+    console.error("");
+    for (const v of transitiveClientViolations) console.error("  " + v);
+    console.error("");
+    console.error("Fix by splitting the contract, not by patching the import: move the types, labels");
+    console.error("and other pure values the client needs into their own module that imports nothing");
+    console.error("server-side, and leave the filesystem and database work where it is. An `import");
+    console.error("type` is erased at build time and is always safe.");
+    console.error("");
+  }
+
+  if (hostOnlyStaticViolations.length > 0) {
+    failed = true;
+    console.error("");
+    console.error("ERROR: BI-98AF1066 — host-only module statically imported into a server bundle entrypoint.");
+    console.error("");
+    console.error("Routes, pages, server actions, and Inngest functions must not statically import");
+    console.error("Docker-only promoter code. Use a dynamic import() boundary at the call site so");
+    console.error("Next/Turbopack does not trace the host-only graph during page-load or route builds.");
+    console.error("");
+    for (const v of hostOnlyStaticViolations) console.error("  " + v);
+    console.error("");
+  }
+
+  if (bundledScriptViolations.length > 0) {
+    failed = true;
+    console.error("");
+    console.error("ERROR: BI-76651B7B — a scripts/ module the web bundle reaches imports promoter-only code.");
+    console.error("");
+    console.error("apps/web statically imports these scripts/ helpers, so Next bundles them AND");
+    console.error("everything they reach. Pulling installer modules or a generated catalog into one");
+    console.error("breaks the production build with module-not-found - from outside apps/web, where");
+    console.error("the other checks never look.");
+    console.error("");
+    for (const v of bundledScriptViolations) console.error("  " + v);
+    console.error("");
+    console.error("Keep the shared module pure (node: builtins only) and move the filesystem and");
+    console.error("projection work into a promoter-only entrypoint the portal never imports.");
+    console.error("");
+  }
+
+  if (failed) {
+    console.error("These are caught statically here so they don't surface as a slow Docker build");
+    console.error("failure or a corrupt runtime in production. Fix at the source above.");
+    console.error("");
+    process.exit(1);
+  }
+
+  console.log("✓ Bundle boundaries clean: no bundle-hostile dynamic requires, no Node built-ins imported or reached by client components, no static host-only imports in server entrypoints.");
 }
 
-let failed = false;
-
-if (dynViolations.length > 0) {
-  failed = true;
-  console.error("");
-  console.error('ERROR: BI-98AF1066 — bundle-hostile dynamic require found.');
-  console.error("");
-  console.error('`new Function(... require ...)` is invisible to the bundler and can resolve to');
-  console.error('undefined in a Next server chunk — the lazy-node "d is not a function" crash that');
-  console.error('crash-looped /build. Use a direct import instead:');
-  console.error('    import * as childProcess from "node:child_process";');
-  console.error("");
-  for (const v of dynViolations) console.error("  " + v);
-  console.error("");
+// Run the scan only when invoked directly, not when imported by the self-test.
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  main();
 }
-
-if (clientViolations.length > 0) {
-  failed = true;
-  console.error("");
-  console.error('ERROR: BI-98AF1066 — Node built-in imported by a "use client" component.');
-  console.error("");
-  console.error("These modules don't exist in the browser bundle and break the client build.");
-  console.error("Move the server-only code to a server module, route handler, or server action,");
-  console.error("and call it from the client via that boundary.");
-  console.error("");
-  for (const v of clientViolations) console.error("  " + v);
-  console.error("");
-}
-
-if (hostOnlyStaticViolations.length > 0) {
-  failed = true;
-  console.error("");
-  console.error("ERROR: BI-98AF1066 — host-only module statically imported into a server bundle entrypoint.");
-  console.error("");
-  console.error("Routes, pages, server actions, and Inngest functions must not statically import");
-  console.error("Docker-only promoter code. Use a dynamic import() boundary at the call site so");
-  console.error("Next/Turbopack does not trace the host-only graph during page-load or route builds.");
-  console.error("");
-  for (const v of hostOnlyStaticViolations) console.error("  " + v);
-  console.error("");
-}
-
-if (bundledScriptViolations.length > 0) {
-  failed = true;
-  console.error("");
-  console.error("ERROR: BI-76651B7B — a scripts/ module the web bundle reaches imports promoter-only code.");
-  console.error("");
-  console.error("apps/web statically imports these scripts/ helpers, so Next bundles them AND");
-  console.error("everything they reach. Pulling installer modules or a generated catalog into one");
-  console.error("breaks the production build with module-not-found - from outside apps/web, where");
-  console.error("the other checks never look.");
-  console.error("");
-  for (const v of bundledScriptViolations) console.error("  " + v);
-  console.error("");
-  console.error("Keep the shared module pure (node: builtins only) and move the filesystem and");
-  console.error("projection work into a promoter-only entrypoint the portal never imports.");
-  console.error("");
-}
-
-if (failed) {
-  console.error("These are caught statically here so they don't surface as a slow Docker build");
-  console.error("failure or a corrupt runtime in production. Fix at the source above.");
-  console.error("");
-  process.exit(1);
-}
-
-console.log("✓ Bundle boundaries clean: no bundle-hostile dynamic requires, no Node built-ins in client components, no static host-only imports in server entrypoints.");

--- a/scripts/check-bundle-boundaries.test.mjs
+++ b/scripts/check-bundle-boundaries.test.mjs
@@ -1,0 +1,153 @@
+// Self-test for the bundle-boundary guard (BI-98AF1066).
+//
+// Check 2b is the one with real teeth and real false-positive risk, so it is
+// what this file exercises: a client component that REACHES a Node built-in
+// through other modules. The motivating regression is PR #4483 — a workspace
+// panel imported one label out of a module that read installer state, which
+// failed the production build with "the chunking context does not support
+// external modules (request: node:fs/promises)" while typecheck and 24k unit
+// tests stayed green.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  TRANSITIVE_FATAL_BUILTINS,
+  extractStaticImports,
+  fatalBuiltinChain,
+  isUseClient,
+  isUseServer,
+} from "./check-bundle-boundaries.mjs";
+
+/** Write a throwaway module tree and return a resolver for its files. */
+function fixture(files) {
+  const root = mkdtempSync(join(tmpdir(), "dpf-bundle-guard-"));
+  for (const [name, body] of Object.entries(files)) {
+    const full = join(root, name);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, body, "utf8");
+  }
+  return { root, path: (name) => join(root, name), cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+test("isUseServer detects the directive after leading comments", () => {
+  assert.ok(isUseServer('// header\n\n"use server";\nexport async function a() {}'));
+  assert.ok(isUseServer("'use server'"));
+  assert.equal(isUseServer('export const a = "use server";'), false);
+});
+
+test("isUseClient and isUseServer do not confuse each other", () => {
+  assert.ok(isUseClient('"use client";'));
+  assert.equal(isUseServer('"use client";'), false);
+  assert.equal(isUseClient('"use server";'), false);
+});
+
+test("extractStaticImports ignores type-only imports", () => {
+  const specs = extractStaticImports(
+    'import type { A } from "./a";\nimport { b } from "./b";\n',
+  );
+  assert.deepEqual(specs, ["./b"]);
+});
+
+test("extractStaticImports keeps a mixed import, because its value half is bundled", () => {
+  const specs = extractStaticImports('import { b, type A } from "./b";');
+  assert.deepEqual(specs, ["./b"]);
+});
+
+test("TRANSITIVE_FATAL_BUILTINS covers fs but not the polyfillable ones", () => {
+  // Narrower than check 2 on purpose: crypto/path/stream are reached all over
+  // the portal today and Turbopack shims them, so failing those would be a
+  // migration rather than a guard.
+  assert.ok(TRANSITIVE_FATAL_BUILTINS.has("fs/promises"));
+  assert.ok(TRANSITIVE_FATAL_BUILTINS.has("child_process"));
+  assert.equal(TRANSITIVE_FATAL_BUILTINS.has("crypto"), false);
+  assert.equal(TRANSITIVE_FATAL_BUILTINS.has("path"), false);
+});
+
+test("fatalBuiltinChain reports the full path from client component to built-in", () => {
+  const f = fixture({
+    "panel.tsx": '"use client";\nimport { LABEL } from "./view";\nexport const P = LABEL;\n',
+    "view.ts": 'import { read } from "./io";\nexport const LABEL = read;\n',
+    "io.ts": 'import { readFile } from "node:fs/promises";\nexport const read = readFile;\n',
+  });
+  try {
+    const chain = fatalBuiltinChain(f.path("panel.tsx"));
+    assert.ok(chain, "expected the guard to reach node:fs/promises");
+    assert.equal(chain.at(-1), "node:fs/promises");
+    assert.equal(chain.length, 3, `expected view -> io -> builtin, got ${JSON.stringify(chain)}`);
+    assert.match(chain[0], /view\.ts$/);
+    assert.match(chain[1], /io\.ts$/);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("fatalBuiltinChain stops at a 'use server' module, which is an RPC boundary", () => {
+  // A client component importing a server action that imports Prisma is
+  // CORRECT: Next replaces the import with an RPC reference and never bundles
+  // that graph. Flagging it would make the guard unusable.
+  const f = fixture({
+    "panel.tsx": '"use client";\nimport { save } from "./actions";\nexport const P = save;\n',
+    "actions.ts": '"use server";\nimport { readFile } from "node:fs/promises";\nexport async function save() { return readFile; }\n',
+  });
+  try {
+    assert.equal(fatalBuiltinChain(f.path("panel.tsx")), null);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("fatalBuiltinChain does not follow a type-only import", () => {
+  const f = fixture({
+    "panel.tsx": '"use client";\nimport type { T } from "./io";\nexport const P: T | null = null;\n',
+    "io.ts": 'import { readFile } from "node:fs/promises";\nexport type T = typeof readFile;\n',
+  });
+  try {
+    assert.equal(fatalBuiltinChain(f.path("panel.tsx")), null);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("fatalBuiltinChain terminates on an import cycle", () => {
+  const f = fixture({
+    "panel.tsx": '"use client";\nimport { a } from "./a";\nexport const P = a;\n',
+    "a.ts": 'import { b } from "./b";\nexport const a = b;\n',
+    "b.ts": 'import { a } from "./a";\nexport const b = a;\n',
+  });
+  try {
+    assert.equal(fatalBuiltinChain(f.path("panel.tsx")), null);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("fatalBuiltinChain finds a built-in past a cycle", () => {
+  const f = fixture({
+    "panel.tsx": '"use client";\nimport { a } from "./a";\nexport const P = a;\n',
+    "a.ts": 'import { b } from "./b";\nimport { c } from "./c";\nexport const a = [b, c];\n',
+    "b.ts": 'import { a } from "./a";\nexport const b = a;\n',
+    "c.ts": 'import { readFile } from "node:fs/promises";\nexport const c = readFile;\n',
+  });
+  try {
+    const chain = fatalBuiltinChain(f.path("panel.tsx"));
+    assert.ok(chain, "a cycle on one branch must not hide a built-in on another");
+    assert.equal(chain.at(-1), "node:fs/promises");
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("fatalBuiltinChain is quiet for a genuinely pure client graph", () => {
+  const f = fixture({
+    "panel.tsx": '"use client";\nimport { LABEL } from "./presentation";\nexport const P = LABEL;\n',
+    "presentation.ts": 'export const LABEL = "Production";\n',
+  });
+  try {
+    assert.equal(fatalBuiltinChain(f.path("panel.tsx")), null);
+  } finally {
+    f.cleanup();
+  }
+});

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -172,6 +172,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("--test", "scripts/check-docker-patch-context.test.mjs"),
     ]),
     guard("bundle-boundary-guard", "Bundle Boundary Guard", [
+      node("--test", "scripts/check-bundle-boundaries.test.mjs"),
       node("scripts/check-bundle-boundaries.mjs"),
     ]),
     guard("application-boundary-guard", "Application Boundary Guard", [


### PR DESCRIPTION
Follow-up to #4483, which walked straight through the guard built for its exact failure class.

## What happened

A `"use client"` workspace panel imported one label out of a module that imported the module that reads installer state. The production build failed with:

```
the chunking context does not support external modules (request: node:fs/promises)
```

naming no file at all. Typecheck passed. 24,321 unit tests passed. `check-bundle-boundaries` passed. It took a full CI round trip to find, and the error pointed at nothing.

Check 2 reads the `"use client"` file and stops, so it only ever sees a *direct* import.

## Check 2b

Walks the local import graph from every client component and reports the chain:

```
apps/web/components/workspace/InstallationIdentityPanel.tsx
    -> apps/web/lib/installation-journey/installation-identity-view.ts
    -> apps/web/lib/install/environment-class.ts
    -> node:fs/promises
```

That is the output from re-introducing the real regression against this branch — the files the bundler never named.

## Deliberately narrower than check 2

So it lands as a hard fail with **no baseline, no allowlist, nothing to migrate**:

- **Only built-ins Turbopack cannot shim.** `crypto`, `path`, `stream` are reached transitively all over the portal today and work fine in the browser. Failing those would be a migration wearing a guard's clothes.
- **The walk stops at a `"use server"` module.** Next replaces those imports with RPC references and never bundles that graph, so a client component importing a server action that imports Prisma is *correct*. Following it would false-positive on nearly every form in the portal.
- **Only `apps/web`-internal modules are followed** (relative and `@/`). Following workspace packages would drag in `@dpf/db`'s polyfillable `crypto` and drown the signal.

Type-only imports are not followed — they are erased at build time and are always safe.

## Cost

| | before | after |
|---|---|---|
| `check-bundle-boundaries.mjs` | 3.8s | 4.5s |
| Full `pregate-preflight` (47 guards) | ~95s | ~80–102s (inside run-to-run variance) |

**+0.7s**, against a ~20 minute CI round trip per occurrence. Clean across the repo today.

## Evidence

- Re-introducing #4483's exact import makes the guard fail with the chain above; reverting it makes the guard pass.
- 11 self-tests in `scripts/check-bundle-boundaries.test.mjs` (83ms), covering the chain report, the `"use server"` stop, type-only imports, import cycles, a built-in found *past* a cycle, and a genuinely pure client graph.
- 33-guard loop green, 47-guard `pregate-preflight` green.

## Two structural notes

- The scan moves into `main()` so the self-test can import the helpers without triggering a repo-wide walk. This matches `check-no-type-reexport-in-use-server.mjs`. Pure restructure — the guard's behaviour when run directly is unchanged.
- The new self-test is enumerated in `ci-policy-guards.mjs`. An unlisted `*.test.mjs` silently never runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
