### PR TITLE
chore(db): bundle EP-24741BBF, uncovered since the last capture

### DIFF
--- a/packages/db/recovery/backlog/animal-welfare-operations-vertical.json
+++ b/packages/db/recovery/backlog/animal-welfare-operations-vertical.json
@@ -3,7 +3,7 @@
   "bundleId": "animal-welfare-operations-vertical",
   "description": "Operator-invoked recovery input for the animal-welfare operations vertical epic (pet-rescue archetype operating model).",
   "source": {
-    "capturedAt": "2026-08-23T01:31:32.616Z",
+    "capturedAt": "2026-08-23T02:00:56.767Z",
     "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
     "planPath": "docs/architecture/archetype-operating-model-audit.md"
   },

--- a/packages/db/recovery/backlog/dpf-directory-service-identity-absorption.json
+++ b/packages/db/recovery/backlog/dpf-directory-service-identity-absorption.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": 1,
+  "bundleId": "dpf-directory-service-identity-absorption",
+  "description": "Operator-invoked recovery input for the DPF Directory Service epic — absorbing identity (employees, agent identities, service accounts, LDAP) rather than federating to an external directory.",
+  "source": {
+    "capturedAt": "2026-08-23T02:00:56.767Z",
+    "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
+    "planPath": "docs/superpowers/plans/2026-08-22-instance-identity-and-purpose.md"
+  },
+  "epic": {
+    "epicId": "EP-24741BBF",
+    "title": "DPF Directory Service: absorb identity instead of federating to someone else's",
+    "description": "DPF must BE the directory for an installation, not merely consume one. Most installations have no Active Directory, so an identity stack that only federates outward leaves them with nothing. This is the absorption principle applied to identity.\n\nWHY THIS EPIC EXISTS (root cause, verified 2026-08-23):\nThe requirement was specified in docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md and its plan, which explicitly scoped \"an identity edge for LDAP/OIDC/SAML/SCIM\" plus a bundled identity service. The plan carries 111 unchecked tasks, ZERO checked, and NO backlog coverage - no Backlog item marker, no BI references. Phases 1-2 (auth seams, principal spine) were absorbed into other work; phase 3 (directory protocols) was last and never picked up. Because the plan tracked deliverables in Markdown checkboxes rather than live backlog items, phase 3 was never open in any system anyone queries. scripts/check-plan-backlog-coverage.mjs now guards exactly this failure class (\"Do not use Markdown checkboxes as deferred-work storage\") but postdates the plan.\n\nWHAT ALREADY EXISTS (reuse, do not rebuild):\n- Principal and PrincipalAlias spine (packages/db/prisma/schema/core-identity.prisma)\n- EmployeeProfile as the canonical worker (workforce.prisma)\n- Agent identity: apps/web/lib/identity/agent-identity-snapshot.ts, aidoc-resolver.ts, authorization-classes.ts, effective-auth-context.ts, principal-linking.ts\n- /platform/identity workspace routes and components\n- Organization PKI (Step CA) for machine trust\n\nWHAT IS ABSENT (verified by repository-wide search):\n- No LDAP/OIDC/SAML/SCIM surface anywhere. The single ldap string in the codebase is a keyword list in integration-benchmarking.ts.\n- No identity edge service. authentik appears zero times in docker-compose.yml.\n- No service-account model of any kind.\n\nSCOPE:\nOne directory covering three identity classes on the same spine - human employees, non-human agent identities, and service accounts - exposed over standard directory protocols so existing tools can bind to it, with outward federation remaining optional rather than required.",
+    "status": "open",
+    "scopeKind": "platform",
+    "scopeRationale": "Identity is universal platform substrate: every archetype needs employees, agents, and service accounts authenticated against one directory.",
+    "createdAt": "2026-08-23T01:38:26.410Z"
+  },
+  "items": [
+    {
+      "itemId": "BI-1E0AB1E5",
+      "epicId": "EP-24741BBF",
+      "title": "Retire the uncovered 2026-04-22 enterprise auth plan into governed backlog items",
+      "body": "docs/superpowers/plans/2026-04-22-enterprise-auth-directory-federation.md holds 111 unchecked tasks, zero checked, and no backlog coverage. Parts of it silently landed (principal spine, /platform/identity); the directory protocol phase never did, and nothing surfaced it as outstanding.\n\nAudit the plan against what actually shipped, move every still-relevant deliverable into this epic as live backlog items, and mark the plan superseded so it stops reading as an active plan. Cite scripts/check-plan-backlog-coverage.mjs as the guard that now prevents this class of loss.",
+      "status": "triaging",
+      "type": "portfolio",
+      "workType": "chore",
+      "source": "user-request",
+      "scopeKind": "unknown",
+      "dependsOn": [],
+      "externalDependencies": [],
+      "activities": [],
+      "createdAt": "2026-08-23T01:38:56.912Z"
+    },
+    {
+      "itemId": "BI-59C8828F",
+      "epicId": "EP-24741BBF",
+      "title": "Model service accounts as a first-class identity class on the Principal spine",
+      "body": "DPF has no service-account model of any kind (verified: no ServiceAccount in any Prisma schema or lib/identity module). Employees and agent identities exist; the third class an install needs - a non-human, non-agent credential owned by a system or integration - does not.\n\nAdd service accounts as a Principal subtype reusing PrincipalAlias, not a parallel identity table (AGENTS.md principal-convergence rule). Must carry: owning employee or team, purpose, credential rotation state, and an explicit expiry. A service account with no accountable owner must be refusable.\n\nDepends on nothing; unblocks the directory projection.",
+      "status": "triaging",
+      "type": "portfolio",
+      "workType": "feature",
+      "source": "user-request",
+      "scopeKind": "unknown",
+      "dependsOn": [],
+      "externalDependencies": [],
+      "activities": [],
+      "createdAt": "2026-08-23T01:38:56.825Z"
+    },
+    {
+      "itemId": "BI-5B1772E5",
+      "epicId": "EP-24741BBF",
+      "title": "Project employees, agent identities, and service accounts into one directory tree",
+      "body": "The three identity classes live in separate models today. A directory needs one coherent tree with stable distinguished names.\n\nDefine the projection from Principal/PrincipalAlias/EmployeeProfile/agent identity/service account into directory entries: DN scheme, object classes, group membership derived from employee hierarchy and role, and what is deliberately NOT published (secrets, business context, internal ids).\n\nThe projection is derived and fingerprinted, never a second writable identity truth.",
+      "status": "triaging",
+      "type": "portfolio",
+      "workType": "feature",
+      "source": "user-request",
+      "scopeKind": "unknown",
+      "dependsOn": [],
+      "externalDependencies": [],
+      "activities": [],
+      "createdAt": "2026-08-23T01:38:56.864Z"
+    },
+    {
+      "itemId": "BI-8B61BCAA",
+      "epicId": "EP-24741BBF",
+      "title": "Bind DPF login to its own directory before offering outward federation",
+      "body": "Auth today is tokens and mTLS (apps/web/lib/auth: mcp-api-token, employee-scoped-token, edge-node-mtls, federation-link-token). There is no OIDC/SAML/SCIM anywhere.\n\nMake the installation's own directory the authentication authority for people, so one login works across the instances in an organization. Outward federation to Entra/Okta/etc stays OPTIONAL - the platform must be complete without it.\n\nThis is the auth-scope requirement: a development companion and its production peer on the same network should share one identity scope without copying credentials between them.",
+      "status": "triaging",
+      "type": "portfolio",
+      "workType": "feature",
+      "source": "user-request",
+      "scopeKind": "unknown",
+      "dependsOn": [],
+      "externalDependencies": [],
+      "activities": [],
+      "createdAt": "2026-08-23T01:38:56.897Z"
+    },
+    {
+      "itemId": "BI-F584A125",
+      "epicId": "EP-24741BBF",
+      "title": "Serve LDAP so existing tools can bind to a DPF installation",
+      "body": "No LDAP surface exists. This is the item that makes DPF usable as the directory for an install that has no Active Directory - the 99% case.\n\nServe the projected tree over LDAP (bind, search, group membership) with TLS from the existing organization PKI. Read paths first; writes only where the directory is genuinely canonical.\n\nThe 2026-04-22 plan proposed authentik as a bundled identity edge. Re-evaluate: bundling a second identity service versus serving the projection directly. Whichever is chosen must not create a parallel identity truth.",
+      "status": "triaging",
+      "type": "portfolio",
+      "workType": "feature",
+      "source": "user-request",
+      "scopeKind": "unknown",
+      "dependsOn": [],
+      "externalDependencies": [],
+      "activities": [],
+      "createdAt": "2026-08-23T01:38:56.881Z"
+    }
+  ]
+}

--- a/packages/db/recovery/backlog/external-website-channels-cms-interoperability.json
+++ b/packages/db/recovery/backlog/external-website-channels-cms-interoperability.json
@@ -3,7 +3,7 @@
   "bundleId": "external-website-channels-cms-interoperability",
   "description": "Operator-invoked recovery input for the external website channels and CMS interoperability epic (WordPress projection).",
   "source": {
-    "capturedAt": "2026-08-23T01:31:32.616Z",
+    "capturedAt": "2026-08-23T02:00:56.767Z",
     "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
     "planPath": "docs/superpowers/plans/2026-08-21-wordpress-channel-projection.md"
   },

--- a/packages/db/recovery/backlog/initiative-readiness-governed-completion.json
+++ b/packages/db/recovery/backlog/initiative-readiness-governed-completion.json
@@ -3,7 +3,7 @@
   "bundleId": "initiative-readiness-governed-completion",
   "description": "Operator-invoked recovery input for the initiative-readiness and governed-completion enforcement epic.",
   "source": {
-    "capturedAt": "2026-08-23T01:31:32.616Z",
+    "capturedAt": "2026-08-23T02:00:56.767Z",
     "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
     "planPath": "docs/superpowers/plans/2026-08-08-initiative-readiness-and-goal-completion-reconciliation-implementation.md"
   },

--- a/packages/db/recovery/backlog/manifest.json
+++ b/packages/db/recovery/backlog/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "capturedAt": "2026-08-23T01:31:32.616Z",
+  "capturedAt": "2026-08-23T02:00:56.767Z",
   "scope": "not-done",
   "bundles": [
     {
@@ -12,6 +12,11 @@
       "epicId": "EP-1FABA22D",
       "file": "purpose-aware-installation-ecosystem-productivity.json",
       "itemCount": 13
+    },
+    {
+      "epicId": "EP-24741BBF",
+      "file": "dpf-directory-service-identity-absorption.json",
+      "itemCount": 5
     },
     {
       "epicId": "EP-31C5A6C8",
@@ -34,9 +39,9 @@
       "itemCount": 7
     }
   ],
-  "capturedItemCount": 44,
+  "capturedItemCount": 49,
   "unassignedItemCount": 9,
-  "unfinishedItemCount": 53,
+  "unfinishedItemCount": 58,
   "skipped": [
     {
       "itemId": "BI-0E8B29C3",

--- a/packages/db/recovery/backlog/purpose-aware-installation-ecosystem-productivity.json
+++ b/packages/db/recovery/backlog/purpose-aware-installation-ecosystem-productivity.json
@@ -3,7 +3,7 @@
   "bundleId": "purpose-aware-installation-ecosystem-productivity",
   "description": "Operator-invoked recovery input for the approved purpose-aware installation epic, umbrella for install identity and ecosystem productivity work.",
   "source": {
-    "capturedAt": "2026-08-23T01:31:32.616Z",
+    "capturedAt": "2026-08-23T02:00:56.767Z",
     "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
     "planPath": "docs/superpowers/plans/2026-08-08-purpose-aware-installation-ecosystem-productivity.md"
   },

--- a/packages/db/recovery/backlog/reset-cycle-3-platform-findings.json
+++ b/packages/db/recovery/backlog/reset-cycle-3-platform-findings.json
@@ -3,7 +3,7 @@
   "bundleId": "reset-cycle-3-platform-findings",
   "description": "Operator-invoked recovery input for the platform findings from from-scratch reset/dogfood cycle 3 (install, lifecycle, agent-host and CI-gate).",
   "source": {
-    "capturedAt": "2026-08-23T01:31:32.616Z",
+    "capturedAt": "2026-08-23T02:00:56.767Z",
     "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
     "planPath": "docs/architecture/archetype-operating-model-audit.md"
   },

--- a/packages/db/recovery/backlog/unassigned-items.json
+++ b/packages/db/recovery/backlog/unassigned-items.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "capturedAt": "2026-08-23T01:31:32.616Z",
+  "capturedAt": "2026-08-23T02:00:56.767Z",
   "items": [
     {
       "itemId": "BI-0E8B29C3",

--- a/packages/db/recovery/backlog/veterinary-clinic-operating-system.json
+++ b/packages/db/recovery/backlog/veterinary-clinic-operating-system.json
@@ -3,7 +3,7 @@
   "bundleId": "veterinary-clinic-operating-system",
   "description": "Operator-invoked recovery input for the veterinary clinic operating system epic (archetype acceptance-scenario contract and fixtures).",
   "source": {
-    "capturedAt": "2026-08-23T01:31:32.616Z",
+    "capturedAt": "2026-08-23T02:00:56.767Z",
     "repository": "OpenDigitalProductFactory/opendigitalproductfactory",
     "planPath": "docs/architecture/archetype-operating-model-audit.md"
   },


### PR DESCRIPTION
Third and final PR in the teardown drain, after #4553 (bundles) and #4556 (repaired `backlog:capture`).

## What the pre-teardown re-verify found

Re-verifying against the live database, as `packages/db/recovery/backlog/README.md` requires, found a **seventh epic with not-done work and no bundle**.

**EP-24741BBF — "DPF Directory Service: absorb identity instead of federating to someone else's"** — five `triaging` items, created *after* #4556's capture at `01:31:32Z` and while #4556 sat in the merge queue:

- BI-8B61BCAA — Bind DPF login to its own directory before offering outward auth
- BI-F584A125 — Serve LDAP so existing tools can bind to a DPF installation
- BI-5B1772E5 — Project employees, agent identities, and service accounts into one directory
- BI-59C8828F — Model service accounts as a first-class identity class
- BI-1E0AB1E5 — Retire the uncovered 2026-04-22 enterprise auth plan into governed work

Main claimed 53 not-done items while the installation held 58. Those five had no path off the instance.

Nothing else moved: the six previously bundled epics are unchanged at 13, 10, 7, 6, 5, 3, and the nine unbundled orphans are the same nine.

## Counts

| Epic | Items |
| --- | ---: |
| EP-1FABA22D Purpose-Aware Installation | 13 |
| EP-5102F494 Animal-welfare operations | 10 |
| EP-56AE0F69 Reset/dogfood cycle 3 | 7 |
| EP-55AF36AC Veterinary Clinic OS | 6 |
| EP-129D11FD Initiative Readiness | 5 |
| **EP-24741BBF DPF Directory Service** | **5** (new) |
| EP-31C5A6C8 External Website Channels | 3 |
| — no epic — (`unassigned-items.json`, not reconcilable) | 9 |

**49 bundled + 9 unassigned = 58 = live not-done count.** `manifest.json` closes.

## The repaired capture did the work

The whole set was produced by one `backlog:capture` run with no manual step — the command that could not run at all before #4556. The new bundle is renamed from the generated `ep-24741bbf.json` to a semantic filename matching its siblings; re-running capture confirms it now reuses that filename and `bundleId` rather than writing the generated name back alongside it.

## Verification

Real Prisma-backed `backlog:reconcile` against the live installation database — all seven bundles parse, every item resolves to `skip`, zero creates:

```
animal-welfare-operations-vertical.json                create=0 skip=10
dpf-directory-service-identity-absorption.json         create=0 skip= 5
external-website-channels-cms-interoperability.json    create=0 skip= 3
initiative-readiness-governed-completion.json          create=0 skip= 5
purpose-aware-installation-ecosystem-productivity.json create=0 skip=13
reset-cycle-3-platform-findings.json                   create=0 skip= 7
veterinary-clinic-operating-system.json                create=0 skip= 6
```

Read-only; `--apply` was never used. Gate answers are in commit trailers.

## Standing instruction

This is the fifth time the backlog moved during this work. **The merged bundles are a floor, not a guarantee.** Immediately before the reset:

```bash
pnpm --filter @dpf/db backlog:capture -- --out packages/db/recovery/backlog
```

Confirm `manifest.json` closes, commit any diff, and merge it to main before tearing down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
