### PR TITLE
fix(build): make trivial-tail builds robust — modelTier is a preference, not a local-only residency boundary (BI-8B4359DE)

### DIFF
--- a/apps/web/lib/build/build-engine-selection-runtime.ts
+++ b/apps/web/lib/build/build-engine-selection-runtime.ts
@@ -192,7 +192,13 @@ export async function resolveBuildEngineSelection(
     }];
   });
 
-  const localOnly = localOnlySetting || opts.modelTier === "local";
+  // Only the explicit platform local-only switch is a hard residency boundary.
+  // A `modelTier === "local"` build is sized to PREFER the on-box model (cost),
+  // not to FORBID cloud — so cloud engines stay qualified as fallbacks. Without
+  // this, every trivial-tail build was local-only and starved whenever local-CI
+  // fenced the local model on a single host (BI-8B4359DE). Local is still
+  // preferred by cost ranking when available; sensitivity clearance still gates.
+  const localOnly = localOnlySetting;
   const qualification = qualifyBuildEngineCandidates({
     policy: opts.policy,
     candidates,

--- a/apps/web/lib/inference/route-contract-builder.test.ts
+++ b/apps/web/lib/inference/route-contract-builder.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { buildInitialRouteContext } from "./route-contract-builder";
+
+// BI-8B4359DE / robust-build gap: `modelTier` expresses a cost/quality TIER
+// preference (trivial-tail build work is sized to the on-box "local" tier), NOT
+// a data-residency boundary. Conflating "prefer the local tier" with a hard
+// `local_only` residency pinned every trivial build to the bundled local model —
+// which is fenced by local-CI capacity reservation on a single host — so those
+// builds could never route to (or fall back to) a connected cloud engine and
+// failed at ideate under sustained load. The ONLY hard local-only boundary is
+// the explicit platform switch (`localOnlyInference`); sensitivity clearance
+// still independently protects sensitive data on every request.
+describe("buildInitialRouteContext — modelTier is a preference, not a residency boundary", () => {
+  const base = { sensitivity: "public" as const, posture: null };
+
+  it("does NOT force local_only residency just because modelTier is 'local'", () => {
+    const ctx = buildInitialRouteContext({
+      ...base,
+      options: { modelTier: "local" },
+      localOnlyInference: false,
+    });
+    expect(ctx.residencyPolicy).not.toBe("local_only");
+  });
+
+  it("honors an explicit residencyPolicy override even when modelTier is 'local'", () => {
+    const ctx = buildInitialRouteContext({
+      ...base,
+      options: { modelTier: "local", residencyPolicy: "any_enabled" },
+      localOnlyInference: false,
+    });
+    expect(ctx.residencyPolicy).toBe("any_enabled");
+  });
+
+  it("STILL forces local_only when the platform local-only switch is on (hard boundary)", () => {
+    const ctx = buildInitialRouteContext({
+      ...base,
+      options: { modelTier: "local" },
+      localOnlyInference: true,
+    });
+    expect(ctx.residencyPolicy).toBe("local_only");
+  });
+
+  it("forces local_only under the platform switch regardless of a robust tier", () => {
+    const ctx = buildInitialRouteContext({
+      ...base,
+      options: { modelTier: "robust" },
+      localOnlyInference: true,
+    });
+    expect(ctx.residencyPolicy).toBe("local_only");
+  });
+});

--- a/apps/web/lib/inference/route-contract-builder.ts
+++ b/apps/web/lib/inference/route-contract-builder.ts
@@ -25,10 +25,15 @@ export function buildInitialRouteContext(input: {
     budgetClass: posture?.routeContext.budgetClass ?? options?.budgetClass,
     allowedProviders: options?.allowedProviders,
     deniedProviders: options?.deniedProviders,
+    // `modelTier` is a cost/quality TIER preference (trivial work is sized to the
+    // on-box "local" tier), NOT a data-residency boundary — conflating the two
+    // pinned every trivial-tail build to the local model, which is fenced by
+    // local-CI capacity reservation on a single host, so those builds could never
+    // fall back to a connected cloud engine and failed at ideate under load
+    // (BI-8B4359DE). Only the explicit platform switch enforces hard local-only;
+    // sensitivity clearance still independently protects sensitive data.
     residencyPolicy:
-      options?.modelTier === "local" || input.localOnlyInference
-        ? "local_only"
-        : options?.residencyPolicy,
+      input.localOnlyInference ? "local_only" : options?.residencyPolicy,
     requiredModelClass: options?.requiredModelClass,
   };
 }


### PR DESCRIPTION
## What & why

Trivial-tail Build Studio work (small doc/chore) is sized to the on-box **`local`** model tier for cost (`getModelTier`). But `modelTier === "local"` was *also* treated as a hard **`local_only` data-residency boundary** in two places — `route-contract-builder.ts` (the shared routing contract) and `build-engine-selection-runtime.ts` (build engine qualification) — even when the platform local-only switch (`inference-local-only`) is **OFF**.

On a single host the local model is fenced by **local-CI capacity reservation** (`local-provider-capacity.ts`) whenever a `local-integration-ci` lease is active *or queued* — under sustained multi-agent load, essentially always. With no cloud engine in the build's allowlist/fallback chain, every trivial-tail build **died at ideate** (`Local provider dispatch deferred`), masked to the operator as "provider temporarily unavailable". Directly observed: build **FB-30F520E3** failed this way after the earlier BI-0DBDCB77 fix deployed. Substantive (robust-tier) builds already route to cloud and complete — only the trivial tail was trapped.

## Change

`modelTier` expresses a cost/quality **tier preference**, not residency:
- `route-contract-builder.ts`: only `input.localOnlyInference` forces `local_only`.
- `build-engine-selection-runtime.ts`: `localOnly = localOnlySetting` (cloud engines stay qualified as fallbacks for trivial builds).

Local is still **preferred by cost ranking** when available (local = $0), and **sensitivity clearance still independently protects sensitive data** on every request. So trivial builds fall back to a connected cloud dev engine when local is fenced, and complete under load.

## Verification

- 4 new `route-contract-builder` tests (modelTier no longer forces local_only; platform switch still does).
- **1972 routing/inference + 1976 build tests pass, zero regressions**; the only test asserting the old behavior was the new one.
- Local-CI pregate ran the full merged-code suite: 24,551/24,553 pass; the 2 failures are host-pressure flakes unrelated to this diff (`portal-migrate-boot` watchdog timing + a restaurant-floor UI test) and pass in isolation — GitHub CI re-gates authoritatively.

Fixes BI-8B4359DE (build ideate starved by local-inference fencing). Follows BI-0DBDCB77 (which was necessary but insufficient — it addressed a preview surface, not the actual dispatch residency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
