### PR TITLE
fix(workrooms): key every capsule on (repository, branch) so a claim late-binds instead of forking (BI-F83CF689)

### DIFF
--- a/apps/web/lib/mcp/packs/work-capsules-pack.ts
+++ b/apps/web/lib/mcp/packs/work-capsules-pack.ts
@@ -94,6 +94,7 @@ const definitions: ToolDefinition[] = [
         source: { type: "string", enum: ENUMS.sources, description: "Origin of the capsule." },
         idempotencyKey: { type: "string", description: "Stable caller-provided key used to make create retries idempotent." },
         executorKind: { type: "string", enum: ENUMS.executors, description: "Optional executor expected to work the capsule." },
+        repositoryFullName: { type: "string", description: "Optional GitHub repository full name; defaults to the platform repo. The workroom's durable branch identity is keyed on (repository, branch)." },
         ...scopeProperties,
       },
       required: ["title", "objective", "source", "idempotencyKey"],

--- a/apps/web/lib/work-capsules/claim-backlog-item-handler.ts
+++ b/apps/web/lib/work-capsules/claim-backlog-item-handler.ts
@@ -5,6 +5,7 @@ import { ensureCapsuleWorkItemAnchorWithPrisma } from "@/lib/work-capsules/capsu
 import { providerToExecutorKind } from "./external-session-capture";
 import { claimGovernedBacklogWorkspace } from "./governed-work-claim";
 import { branchOccupiedResult } from "./mcp-result-errors";
+import { defaultPlatformRepositoryFullName } from "./work-capsule-branch-identity";
 import type { CapsuleDb, WorkCapsuleActor } from "./work-capsule-store-types";
 
 type ToolContext = { agentId?: string; threadId?: string; taskRunId?: string; routeContext?: string } | undefined;
@@ -35,8 +36,7 @@ export async function claimBacklogItemForWork(args: {
     return { success: false, error: "invalid_work_intent", message: `workIntent must be one of: ${WORK_INTENTS.join(", ")}.` };
   }
   const repositoryFullName = stringParam(params, "repositoryFullName")
-    ?? process.env.DPF_REPO_FULL_NAME?.trim()
-    ?? "OpenDigitalProductFactory/opendigitalproductfactory";
+    ?? defaultPlatformRepositoryFullName();
   try {
     const governed = await claimGovernedBacklogWorkspace({
       db: args.db,

--- a/apps/web/lib/work-capsules/external-session-capture.ts
+++ b/apps/web/lib/work-capsules/external-session-capture.ts
@@ -17,6 +17,7 @@ import {
   type WorkCapsuleActor,
 } from "./work-capsule-store";
 import type { WorkCapsuleExecutorKind } from "@/lib/work-capsules";
+import { defaultPlatformRepositoryFullName } from "./work-capsule-branch-identity";
 
 /** Map a self-declared provider string to the closest desktop executor kind. */
 export function providerToExecutorKind(provider: string): WorkCapsuleExecutorKind {
@@ -112,10 +113,7 @@ export async function ensureExternalSessionCapsule(args: {
       input: {
         title,
         objective,
-        repositoryFullName:
-          args.repositoryFullName?.trim() ||
-          process.env.DPF_REPO_FULL_NAME?.trim() ||
-          "OpenDigitalProductFactory/opendigitalproductfactory",
+        repositoryFullName: args.repositoryFullName?.trim() || defaultPlatformRepositoryFullName(),
         headBranch: branchName,
         worktreePath,
         baseBranch: args.baseBranch?.trim() || "main",

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -559,7 +559,7 @@ export async function createWorkCapsuleTool(
       objective,
       source,
       idempotencyKey,
-      executorKind: validatedExecutorKind,
+      executorKind: validatedExecutorKind, repositoryFullName: stringParam(params, "repositoryFullName"),
       scope: parseScopeInput(params),
     },
     actor: await actor(userId, context),

--- a/apps/web/lib/work-capsules/work-capsule-branch-identity-binding.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-branch-identity-binding.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/portal-context/invalidation", () => ({
+  revalidatePortalContext: vi.fn(),
+}));
+
+import {
+  adoptWorktreeCapsule,
+  createWorkCapsule,
+  planCapsuleWorkspace,
+  type CapsuleDb,
+} from "./work-capsule-store";
+
+const db = {
+  workroom: {
+    create: vi.fn(),
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+    update: vi.fn(),
+  },
+  workroomActivity: { create: vi.fn() },
+  backlogItem: { findFirst: vi.fn(), update: vi.fn() },
+  $transaction: vi.fn(async (fn: (tx: typeof db) => Promise<unknown>) => fn(db)),
+};
+
+function capsuleDb(): CapsuleDb {
+  return db as unknown as CapsuleDb;
+}
+
+beforeEach(() => {
+  for (const model of [db.workroom, db.workroomActivity, db.backlogItem]) {
+    for (const fn of Object.values(model)) (fn as ReturnType<typeof vi.fn>).mockReset();
+  }
+  db.$transaction.mockReset();
+  db.$transaction.mockImplementation(async (fn: (tx: typeof db) => Promise<unknown>) => fn(db));
+});
+
+// BI-F83CF689: create_workroom / plan_workroom_worktree left
+// repositoryFullName null, so the (repo, branch) identity key could not match
+// and claim_backlog_item_for_work forked a SECOND live capsule on a branch
+// that already had one. Both calls reported success.
+describe("branch identity is keyed on (repository, branch) — BI-F83CF689", () => {
+  it("stamps the platform repository when create_workroom does not name one", async () => {
+    db.workroom.findUnique.mockResolvedValueOnce(null);
+    db.workroom.create.mockResolvedValueOnce({ id: "row-1", capsuleId: "WC-REPO001" });
+
+    await createWorkCapsule({
+      db: capsuleDb(),
+      input: {
+        title: "Plan coverage",
+        objective: "Make the receipt reachable.",
+        source: "manual",
+        idempotencyKey: "manual:repo-default",
+      },
+      actor: { userId: "user-1", agentId: null, principalId: "principal-1" },
+    });
+
+    expect(db.workroom.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      }),
+    }));
+  });
+
+  it("backfills the repository when planning a worktree for a repo-less capsule", async () => {
+    db.workroom.findUnique.mockResolvedValueOnce({
+      id: "row-1",
+      capsuleId: "WC-REPO002",
+      title: "Plan coverage",
+      status: "draft",
+      headBranch: null,
+      worktreePath: null,
+      baseBranch: null,
+      repositoryFullName: null,
+    });
+    db.workroom.findFirst.mockResolvedValue(null);
+    db.workroom.update.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      id: "row-1",
+      capsuleId: "WC-REPO002",
+      ...data,
+    }));
+
+    const planned = await planCapsuleWorkspace({
+      db: capsuleDb(),
+      capsuleId: "WC-REPO002",
+      taxonomy: "fix",
+      os: "linux",
+      home: "/home/dev",
+      actor: { userId: "user-1", agentId: null, principalId: "principal-1" },
+    });
+
+    expect(planned.repositoryFullName).toBe("OpenDigitalProductFactory/opendigitalproductfactory");
+  });
+
+  it("late-binds a repo-less capsule on the same branch instead of forking a second one", async () => {
+    // Row written before the default existed: same branch, no repository.
+    db.workroom.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-ORPHAN1",
+        status: "ready",
+        backlogItemId: null,
+        executorRef: null,
+        headBranch: "feat/identity",
+        worktreePath: "/wt/identity",
+        repositoryFullName: null,
+      });
+    db.workroom.update.mockResolvedValue({
+      id: "row-1",
+      capsuleId: "WC-ORPHAN1",
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+    });
+
+    const result = await adoptWorktreeCapsule({
+      db: capsuleDb(),
+      input: {
+        title: "Adopt",
+        objective: "Bind the branch.",
+        repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+        headBranch: "feat/identity",
+        worktreePath: "/wt/identity",
+        backlogItemId: "BI-F83CF689",
+      },
+      actor: { userId: "user-1", agentId: null, principalId: "principal-1" },
+    });
+
+    expect(result.capsuleId).toBe("WC-ORPHAN1");
+    expect(db.workroom.create).not.toHaveBeenCalled();
+    expect(db.workroom.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+        backlogItemId: "BI-F83CF689",
+      }),
+    }));
+  });
+
+  it("refuses loudly when the repo-less capsule on the branch belongs to another item", async () => {
+    db.workroom.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "row-1",
+        capsuleId: "WC-ORPHAN2",
+        status: "working",
+        backlogItemId: "BI-OTHER",
+        executorRef: "session-other",
+        headBranch: "feat/identity",
+        worktreePath: "/wt/identity",
+        repositoryFullName: null,
+      });
+
+    await expect(adoptWorktreeCapsule({
+      db: capsuleDb(),
+      input: {
+        title: "Adopt",
+        objective: "Bind the branch.",
+        repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+        headBranch: "feat/identity",
+        worktreePath: "/wt/identity",
+        backlogItemId: "BI-F83CF689",
+      },
+      actor: { userId: "user-1", agentId: null, principalId: "principal-1" },
+    })).rejects.toThrow(/already bound to Work Capsule WC-ORPHAN2/);
+    expect(db.workroom.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/work-capsules/work-capsule-branch-identity.ts
+++ b/apps/web/lib/work-capsules/work-capsule-branch-identity.ts
@@ -34,6 +34,9 @@ type BranchCapsuleRecord = {
   baseSha?: string | null;
   headSha?: string | null;
   headBranch?: string | null;
+  epicId?: string | null;
+  worktreePath?: string | null;
+  repositoryFullName?: string | null;
 };
 
 export const TERMINAL_CAPSULE_STATUSES: WorkCapsuleStatus[] = ["complete", "abandoned", "archived"];
@@ -138,4 +141,59 @@ export function planAbandonedCapsuleResume(args: {
       },
     },
   };
+}
+
+/**
+ * The repository a Workroom is bound to when the caller did not name one.
+ *
+ * BI-F83CF689: three call sites each inlined this fallback, and the two that
+ * did NOT — `create_workroom` and `plan_workroom_worktree` — left
+ * `repositoryFullName` null. Because a branch's durable identity is keyed on
+ * (repositoryFullName, headBranch), a null repo cannot match, so the documented
+ * paved road produced a SECOND live capsule on a branch that already had one.
+ * One resolver, used everywhere a capsule is created or planned.
+ */
+export function defaultPlatformRepositoryFullName(): string {
+  return process.env.DPF_REPO_FULL_NAME?.trim() || "OpenDigitalProductFactory/opendigitalproductfactory";
+}
+
+type BranchIdentityReader = {
+  workroom: { findFirst: (args: unknown) => Promise<BranchCapsuleRecord | null> };
+};
+
+/**
+ * Read the one capsule that owns this branch's durable identity.
+ *
+ * The schema deliberately owns one capsule identity per (repository, branch).
+ * That row is read regardless of lifecycle: an abandoned same-BI capsule is
+ * the durable identity to resume, while a foreign/terminal identity must
+ * refuse instead of falling through to an impossible duplicate create
+ * (BI-E363A524).
+ *
+ * BI-F83CF689: rows created before the repository was persisted on create and
+ * plan carry a null repositoryFullName, so the keyed read cannot see them and
+ * the caller forks a SECOND live capsule on a branch that already has one. A
+ * live repo-less row on the same branch IS that branch's identity — return it
+ * and let the caller bind the repository. A TERMINAL repo-less row is history,
+ * not identity: adopting it would newly refuse branch names that were
+ * previously free, which is a regression rather than enforcement.
+ */
+export async function readBranchIdentityCapsule(
+  db: BranchIdentityReader,
+  input: Pick<CapsuleAdoptionInput, "repositoryFullName" | "headBranch">,
+): Promise<{ existing: Awaited<ReturnType<BranchIdentityReader["workroom"]["findFirst"]>>; repositoryUnbound: boolean }> {
+  const keyed = await db.workroom.findFirst({
+    where: { repositoryFullName: input.repositoryFullName, headBranch: input.headBranch },
+    orderBy: { updatedAt: "desc" },
+  });
+  if (keyed) return { existing: keyed, repositoryUnbound: false };
+  const unkeyed = await db.workroom.findFirst({
+    where: {
+      repositoryFullName: null,
+      headBranch: input.headBranch,
+      status: { notIn: TERMINAL_CAPSULE_STATUSES },
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+  return { existing: unkeyed, repositoryUnbound: unkeyed !== null };
 }

--- a/apps/web/lib/work-capsules/work-capsule-store.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.ts
@@ -32,7 +32,9 @@ import {
   isTerminalCapsuleStatus,
   leaseUntil,
   planAbandonedCapsuleResume,
+  readBranchIdentityCapsule,
   TERMINAL_CAPSULE_STATUSES,
+  defaultPlatformRepositoryFullName,
   type CapsuleAdoptionInput,
 } from "./work-capsule-branch-identity";
 import type { CapsuleDb, WorkCapsuleActor } from "./work-capsule-store-types";
@@ -52,6 +54,8 @@ type CapsuleCreateInput = {
   executorKind?: WorkCapsuleExecutorKind | null;
   executorRef?: string | null;
   status?: WorkCapsuleStatus;
+  /** Keyed branch identity is (repositoryFullName, headBranch) — never null (BI-F83CF689). */
+  repositoryFullName?: string | null;
   backlogItemId?: string | null;
   epicId?: string | null;
   featureBuildId?: string | null;
@@ -139,6 +143,7 @@ export async function createWorkCapsule(args: {
           source: args.input.source,
           executorKind: args.input.executorKind ?? null,
           executorRef: args.input.executorRef ?? null,
+          repositoryFullName: args.input.repositoryFullName?.trim() || defaultPlatformRepositoryFullName(),
           backlogItemId: args.input.backlogItemId ?? null,
           epicId: args.input.epicId ?? null,
           featureBuildId: args.input.featureBuildId ?? null,
@@ -194,17 +199,7 @@ export async function adoptWorktreeCapsule(args: {
   }
   const scope = normalizeWorkCapsuleScopeInput(args.input.scope);
 
-  // The schema deliberately owns one capsule identity per (repository, branch).
-  // Read that row regardless of lifecycle: an abandoned same-BI capsule is the
-  // durable identity to resume, while a foreign/terminal identity must refuse
-  // instead of falling through to an impossible duplicate create (BI-E363A524).
-  const existing = await args.db.workroom.findFirst({
-    where: {
-      repositoryFullName: args.input.repositoryFullName,
-      headBranch: args.input.headBranch,
-    },
-    orderBy: { updatedAt: "desc" },
-  });
+  const { existing, repositoryUnbound } = await readBranchIdentityCapsule(args.db, args.input);
 
   const now = new Date();
   const resumePlan = planAbandonedCapsuleResume({ existing, input: args.input, actor: args.actor, now });
@@ -223,6 +218,10 @@ export async function adoptWorktreeCapsule(args: {
     // capsule instead of leaving the work orphaned — this is what lets a worktree
     // cut before the BI was chosen still join the BI↔location record.
     const lateBind = Boolean(args.input.backlogItemId) && existing.backlogItemId == null;
+    // BI-F83CF689: bind the repository onto a capsule that predates the
+    // create/plan default, so its branch identity becomes keyed and the next
+    // caller matches it directly.
+    const repoBound = repositoryUnbound;
     // Head sync (BI-B9403248): headSha used to be written only on CREATE, so a
     // capsule adopted or claimed before the artifact commit existed could never
     // satisfy the plan-coverage ownership check, and any amend/rebase/squash
@@ -230,7 +229,7 @@ export async function adoptWorktreeCapsule(args: {
     // state, not privileged data, so re-adopting the same branch advances it.
     const headSynced = Boolean(args.input.headSha) && args.input.headSha !== existing.headSha;
     const baseSynced = Boolean(args.input.baseSha) && args.input.baseSha !== existing.baseSha;
-    if (lateBind || headSynced || baseSynced) {
+    if (lateBind || headSynced || baseSynced || repoBound) {
       const bound = await inTransaction(args.db, async (tx) => {
         const updated = await tx.workroom.update({
           where: { capsuleId: existing.capsuleId },
@@ -239,14 +238,11 @@ export async function adoptWorktreeCapsule(args: {
               ? {
                 backlogItemId: args.input.backlogItemId,
                 ...(args.input.epicId && existing.epicId == null ? { epicId: args.input.epicId } : {}),
-                ...(args.input.executorRef && existing.executorRef == null
-                  ? { executorRef: args.input.executorRef }
-                  : {}),
-                ...(args.input.worktreePath && existing.worktreePath !== args.input.worktreePath
-                  ? { worktreePath: args.input.worktreePath }
-                  : {}),
+                ...(args.input.executorRef && existing.executorRef == null ? { executorRef: args.input.executorRef } : {}),
+                ...(args.input.worktreePath && existing.worktreePath !== args.input.worktreePath ? { worktreePath: args.input.worktreePath } : {}),
               }
               : {}),
+            ...(repoBound ? { repositoryFullName: args.input.repositoryFullName } : {}),
             ...(headSynced ? { headSha: args.input.headSha } : {}),
             ...(baseSynced ? { baseSha: args.input.baseSha } : {}),
             ...(headSynced || baseSynced ? { lastSyncedAt: now } : {}),
@@ -255,11 +251,12 @@ export async function adoptWorktreeCapsule(args: {
         await recordActivity(tx, {
           workCapsuleId: existing.id,
           kind: "adopted",
-          summary: lateBind
-            ? `Late-bound ${existing.capsuleId} to ${args.input.backlogItemId}`
+          summary: lateBind ? `Late-bound ${existing.capsuleId} to ${args.input.backlogItemId}`
+            : repoBound ? `Bound ${existing.capsuleId} to ${args.input.repositoryFullName} for ${args.input.headBranch}`
             : `Synced ${existing.capsuleId} branch state for ${args.input.headBranch}`,
           payload: {
             ...(lateBind ? { backlogItemId: args.input.backlogItemId, lateBind: true } : {}),
+            ...(repoBound ? { repositoryFullName: args.input.repositoryFullName, repositoryLateBind: true } : {}),
             ...(headSynced ? { headSha: args.input.headSha, previousHeadSha: existing.headSha ?? null } : {}),
             ...(baseSynced ? { baseSha: args.input.baseSha, previousBaseSha: existing.baseSha ?? null } : {}),
           },
@@ -598,6 +595,8 @@ export async function planCapsuleWorkspace(args: {
         worktreePath,
         branchTaxonomy: input.taxonomy,
         baseBranch: capsule.baseBranch ?? "main",
+        // Planning IS the moment a capsule acquires branch identity (BI-F83CF689).
+        repositoryFullName: capsule.repositoryFullName ?? defaultPlatformRepositoryFullName(),
         status: capsule.status === "draft" ? "ready" : capsule.status,
       },
     });
@@ -605,7 +604,7 @@ export async function planCapsuleWorkspace(args: {
       workCapsuleId: capsule.id,
       kind: "workspace-planned",
       summary: `Planned ${headBranch} at ${worktreePath}`,
-      payload: { headBranch, worktreePath, branchTaxonomy: input.taxonomy },
+      payload: { headBranch, worktreePath, branchTaxonomy: input.taxonomy, repositoryFullName: updated.repositoryFullName },
       actor: args.actor,
     });
     return updated;

--- a/docs/founder-kernel/wiki/principles/claim-a-workroom-before-you-work.md
+++ b/docs/founder-kernel/wiki/principles/claim-a-workroom-before-you-work.md
@@ -44,6 +44,18 @@ relabel — a `WorkRoom` view layer over `WorkCase` already existed, and the rec
 and the room are one concept rather than two. Governed by `EP-WORK-CONVERGENCE`
 (umbrella `BI-D2D190BF`).
 
+A branch has exactly ONE durable workroom identity, and it is keyed on
+`(repositoryFullName, headBranch)`. That is why `create_workroom` and
+`plan_workroom_worktree` always stamp a repository — a workroom born without one
+cannot be matched by that key, so the next `claim_backlog_item_for_work` on the
+same branch forks a SECOND live capsule instead of late-binding, leaving the
+objective and scope claims on one row and the backlog item on the other, with
+both calls reporting success (BI-F83CF689). Adopting a branch that already
+carries a live repo-less workroom binds the repository to it; a live workroom
+bound to a different backlog item refuses with `branch_occupied` rather than
+forking. If you ever see two non-archived workrooms on one branch, that is the
+defect, not a supported shape.
+
 ⟦runtime: the MCP tools are now named `create_workroom`, `claim_workroom_scope`,
 `heartbeat_workroom` and so on; the legacy `*_capsule_*` names remain callable but
 unadvertised for the alias window. The Prisma field vocabulary (`workCapsuleId`,


### PR DESCRIPTION
create_workroom and plan_workroom_worktree left repositoryFullName null.
A workroom's durable branch identity is keyed on (repositoryFullName,
headBranch), so a null repo cannot match: the documented paved road
create_workroom -> plan_workroom_worktree -> claim_backlog_item_for_work
produced TWO live capsules on one branch, one holding the objective and
scope claims and the other holding the BI and repo binding, with both
calls reporting success and no signal to the caller.

- One resolver, defaultPlatformRepositoryFullName(), replaces the three
  inlined DPF_REPO_FULL_NAME fallbacks and now also backs create and plan,
  so a capsule is never born without a repository.
- readBranchIdentityCapsule() owns the identity read: keyed on (repo,
  branch), falling back to the LIVE repo-less row on the same branch, which
  adopt then binds the repository to and records on the activity log. A
  terminal legacy row is deliberately excluded — adopting it would newly
  refuse branch names that were previously free.
- A repo-less row bound to a different item now raises branch_occupied
  instead of silently forking a second capsule.

No backfill migration: a migration cannot know an install's repository, and
the adopt-side late-bind resolves legacy rows with the repo the caller
actually names. 83 repo-null rows exist on this install; exactly one branch
carried the duplicate pair the defect reports.

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-06-05-unified-delivery-surfaces-execution-alignment-design.md
    (MCP is the coordination plane; the Workroom is the unit of WIP)
- Current code substrate reviewed:
  - apps/web/lib/work-capsules/work-capsule-store.ts (adopt/create/plan)
  - apps/web/lib/work-capsules/work-capsule-branch-identity.ts (identity rules)
  - apps/web/lib/work-capsules/claim-backlog-item-handler.ts and
    external-session-capture.ts (the two sites that already defaulted the repo)
- Source of truth:
  - adopt_worktree's stated contract, "A branch has one durable workroom
    identity", and the (repositoryFullName, headBranch) schema key.
- Decision:
  - Fix the matching key at its source rather than teach callers to pass a
    repository. No new substrate; the identity read moves to the module that
    already owns branch identity.

---

**Local CI:** `pregate:status` PASS — `fix/workroom-repo-late-binding @ b48d22f22ea2`, evidence `cmt5918vc062501o885vqi0f7`, 7:13 / 32677 log lines, production build compiled successfully.

**Unit tests:** `lib/work-capsules/` — 17 files, 124 tests pass, including 4 new regressions in `work-capsule-branch-identity-binding.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Seed-Fit-Decision: global-default
