### PR TITLE
fix(lease): key the contributor-preview claim on the resource, not the process (BI-D45898C0)

### DIFF
--- a/scripts/dev-portal-lease.sh
+++ b/scripts/dev-portal-lease.sh
@@ -240,7 +240,22 @@ claim_lease() {
     [ -n "$BRANCH" ] || die "resolved an empty branch for contributor-preview worktree $WORKTREE_PATH"
   fi
   expires_at="$(node -e 'process.stdout.write(new Date(Date.now() + Number(process.argv[1]) * 60000).toISOString())' "$EXPIRES_MINUTES")"
-  base_claim_key="dev-portal:${OWNER_SESSION_ID}:${BRANCH}"
+  # BI-D45898C0: the claim key identifies the RESOURCE, not the claimant.
+  #
+  # It used to be "dev-portal:${OWNER_SESSION_ID}:${BRANCH}", and
+  # OWNER_SESSION_ID defaults to dev-portal-$$ — the shell PID. Every
+  # invocation therefore minted a DIFFERENT key for the same worktree and
+  # branch, so the queue could never recognise a re-claim as the same claim. A
+  # supervisor restarting this script enqueued an unbounded set of distinct
+  # claims for one preview: 2026-08-23 saw ~35 waiting, arriving every ~31s,
+  # starving three unrelated pre-PR gates behind them (165 arrivals against 11
+  # admissions, 19m median wait).
+  #
+  # Keyed on (worktree, branch) a re-claim is idempotent: the caller re-enters
+  # its own claim instead of joining the back of the queue. Ownership still
+  # travels separately as ownerSessionId, which is where claimant identity
+  # belongs.
+  base_claim_key="dev-portal:${WORKTREE_PATH}:${BRANCH}"
   claim_key="$base_claim_key"
   terminal_claim_attempt_sequence=0
   while :; do

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -490,6 +490,10 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       ),
       node(
         "--test",
+        "scripts/lib/dev-portal-lease-claim-key.test.mjs",
+      ),
+      node(
+        "--test",
         "scripts/process-spine-conformance.test.mjs",
         "scripts/lib/ensure-post-checkout-hook.test.mjs",
       ),

--- a/scripts/lib/dev-portal-lease-claim-key.test.mjs
+++ b/scripts/lib/dev-portal-lease-claim-key.test.mjs
@@ -1,0 +1,42 @@
+// scripts/lib/dev-portal-lease-claim-key.test.mjs
+// Node built-in test runner: node --test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const script = readFileSync(
+  fileURLToPath(new URL("../dev-portal-lease.sh", import.meta.url)),
+  "utf8",
+);
+
+const baseClaimKeyLine = script
+  .split("\n")
+  .find((l) => l.trim().startsWith("base_claim_key="));
+
+// BI-D45898C0. The claim key is the server's idempotency key: environment-lease.ts
+// does findUnique({ where: { claimKey } }). Keying it on the PID meant every
+// invocation minted a new claim for the same preview, so a restart loop enqueued
+// an unbounded set — ~35 waiting, one every ~31s, starving three unrelated
+// pre-PR gates behind them.
+
+test("the contributor-preview claim key identifies the resource, not the process", () => {
+  assert.ok(baseClaimKeyLine, "base_claim_key assignment must exist");
+  assert.match(baseClaimKeyLine, /\$\{WORKTREE_PATH\}/);
+  assert.match(baseClaimKeyLine, /\$\{BRANCH\}/);
+});
+
+test("the claim key never carries the owner session id — that is what made re-claims unrecognisable", () => {
+  assert.doesNotMatch(baseClaimKeyLine, /OWNER_SESSION_ID/);
+});
+
+test("the owner session id still travels as ownership, just not as identity of the claim", () => {
+  // Attribution is still recorded; it simply must not key the claim.
+  assert.match(script, /ownerSessionId/);
+  assert.match(script, /OWNER_SESSION_ID="dev-portal-\$\$"/);
+});
+
+test("the terminal-retry suffix stays bounded, so the one remaining key-minting path cannot run away", () => {
+  assert.match(script, /MAX_TERMINAL_CLAIM_ATTEMPTS/);
+  assert.match(script, /terminal claim retry budget exhausted/);
+});


### PR DESCRIPTION
Closes `BI-D45898C0`. One line, with a measured cost.

## Root cause

`scripts/dev-portal-lease.sh:243` built the claim key as:

```sh
base_claim_key="dev-portal:${OWNER_SESSION_ID}:${BRANCH}"
```

and `OWNER_SESSION_ID` defaults to `dev-portal-$$` — the **shell PID**.

Meanwhile `apps/web/lib/nonprod/environment-lease.ts:369` resolves a lease with `findUnique({ where: { claimKey } })`. The claim key *is* the server's idempotency key.

So every invocation minted a new identity for the same preview. A supervisor restarting the script could never re-enter its own claim — only join the back of the queue, forever. **The key identified the claimant where it had to identify the claim.**

## Measured cost

From the live queue on 2026-08-23, not inferred:

- ~35 claims waiting on a single slot, arriving every ~31 seconds, all with identical `worktreePath` and `branchName` and distinct `dev-portal-<pid>` owners
- `compute:nonprod-local-integration-ci`: **165 arrivals against 11 admissions**, 19m median wait, 8% abandonment
- three unrelated pre-PR gates starved behind it: `fix/build-studio-hide-the-guts`, `fix/build-studio-ui-undriveable`, `fix/workroom-repo-late-binding`

## Fix

Key on `(worktree, branch)` — the resource being claimed. A re-claim now re-enters its own lease instead of queueing a new one. Ownership still travels separately as `ownerSessionId`, which is where claimant identity belongs.

The other key-minting path, the `:rerun-N` suffix on a terminal claim, was already bounded by `MAX_TERMINAL_CLAIM_ATTEMPTS` and is left alone — a test pins that it stays bounded.

## Tests

Four, registered in `ci-policy-guards.mjs` so CI actually runs them. The load-bearing one asserts the key **never** carries `OWNER_SESSION_ID` again — this defect is invisible in any single run and only appears as queue depth over time, so a regression needs a guard rather than a reviewer noticing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Local-CI-Override: operator-emergency: this PR fixes the queue starvation that is preventing its own gate from running. Live at time of override: 1 active slot, 46 queued claims, 38 of them duplicate PID-keyed claims from a single worktree (scheduled-work-register) arriving ~2/min — the exact defect this diff removes. A correctly-behaved claim advanced 45->42 positions in 50 minutes; extrapolated wait ~11h. Authorized by the operator as an emergency to break the deadlock. Cloud CI remains authoritative and is unaffected by this override.


Docs-Impact-Decision: internal lease-claim keying in scripts/dev-portal-lease.sh plus its CI guard and unit test — no route, no user-visible behaviour, and no user-guide page describes the claim key. Contributor-facing effect (a restarted preview re-enters its own claim instead of re-queueing) is captured in BI-D45898C0 and this PR body.
