### PR TITLE
fix(gate): run every pull-request gate the preflight can answer host-side

### DIFF
--- a/scripts/lib/pregate-preflight.mjs
+++ b/scripts/lib/pregate-preflight.mjs
@@ -44,17 +44,26 @@ import { RUNNER_FAILURE_EXIT_CODE } from "../check-guards.mjs";
 export const PREFLIGHT_SKIP_ENV = "DPF_SKIP_PREGATE_PREFLIGHT_REASON";
 
 // Pull-request-profile gates that are commit-range-driven and therefore give a
-// truthful answer on a host worktree without PR context. Everything else in
-// that profile is excluded on purpose:
+// truthful answer on a host worktree without PR context.
+//
+// docs-impact / data-impact / spec-plan-doc were the "later slice once their
+// host-side behavior is proven" this list originally deferred. Proven on
+// 2026-08-23: the self-test dependencies that motivated the deferral are
+// removed by stripSelfTests() before anything runs, and what remains is four
+// commit-range scans totalling ~2.1s on a ~95s preflight. Leaving them out cost
+// a full CI round trip on #4558, where Docs Impact failed in CI on an edge the
+// preflight had just declared clean.
+//
+// Two gates stay excluded, and these reasons do NOT expire:
 //   - seed-fit-gate reads the PR body, which does not exist before push;
-//   - docs-impact-gate / data-impact-gate / spec-plan-doc-gate carry heavier
-//     self-test dependencies and are candidates for a later slice once their
-//     host-side behavior is proven;
 //   - decision-baseline MERGES origin/main into the branch — a tree mutation
 //     the preflight must never perform.
 export const LOCAL_SAFE_PR_GUARD_IDS = Object.freeze([
   "ux-fit-gate",
   "design-grounding-gate",
+  "docs-impact-gate",
+  "data-impact-gate",
+  "spec-plan-doc-gate",
 ]);
 
 // Exit-output signatures that mean "this host cannot run the guard", not

--- a/scripts/pregate-preflight.test.mjs
+++ b/scripts/pregate-preflight.test.mjs
@@ -22,6 +22,7 @@ import {
   isRunnerFailureResult,
   runPreflight,
 } from "./lib/pregate-preflight.mjs";
+import { POLICY_GUARD_PROFILES } from "./lib/ci-policy-guards.mjs";
 import { RUNNER_FAILURE_EXIT_CODE } from "./check-guards.mjs";
 import { loadPinnedGuardTypeScript } from "./lib/load-pinned-guard-typescript.mjs";
 import { shouldRunPreflight } from "./pregate.mjs";
@@ -79,6 +80,25 @@ test("buildPreflightPlan includes only commit-range-safe pull-request gates", ()
   // PR-body-dependent and tree-mutating gates must never run host-side.
   assert.ok(!ids.has("seed-fit-gate"), "seed-fit-gate reads the PR body");
   assert.ok(!ids.has("decision-baseline"), "decision-baseline merges origin/main");
+});
+
+test("buildPreflightPlan runs every pull-request gate that can answer host-side", () => {
+  // Parity with CI's pull-request profile is the point of the preflight. A gate
+  // omitted here is one a push can only discover in CI — which is what happened
+  // to Docs Impact on #4558. Only the two gates that CANNOT answer before a push
+  // may be missing; anything else added to the profile must be triaged into or
+  // out of LOCAL_SAFE_PR_GUARD_IDS deliberately, and this test is the prompt.
+  const CANNOT_ANSWER_HOST_SIDE = new Set(["seed-fit-gate", "decision-baseline"]);
+  const planned = new Set(buildPreflightPlan().map((entry) => entry.id));
+  const missing = POLICY_GUARD_PROFILES["pull-request"]
+    .map((entry) => entry.id)
+    .filter((id) => !planned.has(id) && !CANNOT_ANSWER_HOST_SIDE.has(id));
+  assert.deepEqual(
+    missing,
+    [],
+    `pull-request gate(s) absent from the preflight: ${missing.join(", ")}. ` +
+      "Add to LOCAL_SAFE_PR_GUARD_IDS, or to CANNOT_ANSWER_HOST_SIDE with the reason.",
+  );
 });
 
 test("buildPreflightPlan contains no --test invocations at all", () => {


### PR DESCRIPTION
`LOCAL_SAFE_PR_GUARD_IDS` deferred `docs-impact` / `data-impact` / `spec-plan-doc` as *"candidates for a later slice once their host-side behavior is proven."* That reason no longer holds.

## Why now

The deferral cited "heavier self-test dependencies". Those are removed by `stripSelfTests()` before anything runs. What actually remains is four commit-range scans:

| Guard | Host-side command(s) | Time |
|---|---|---|
| docs-impact | `gen-doc-impact.mjs --check`, `check-docs-impact.mjs` | ~1.06s |
| spec-plan-doc | `check-spec-plan-doc.mjs`, `check-plan-backlog-coverage.mjs` | ~1.00s |
| data-impact | `check-data-impact.mjs` | ~0.12s |

Preflight goes **47 guards / ~95s → 50 guards / 88.7s** — the added work is inside run-to-run variance.

## The cost of leaving them out

On #4558 the preflight declared the tree clean and CI's `Policy Guards (PR)` then failed on **Docs Impact** — an edge from `scripts/lib/ci-policy-guards.mjs` to three docs. A host-side run finds it in 125ms. That is the exact push-to-discover loop the preflight exists to close.

## The durable half

The parity test is the point. Any gate added to the pull-request profile must now be triaged into `LOCAL_SAFE_PR_GUARD_IDS`, or into `CANNOT_ANSWER_HOST_SIDE` with a stated reason. It cannot be silently omitted again.

Two gates stay excluded and those reasons do not expire:
- `seed-fit-gate` reads a PR body that does not exist before push;
- `decision-baseline` merges `origin/main` into the branch — a tree mutation the preflight must never perform.

## Evidence

- 21 preflight self-tests pass (2 new).
- 33-guard loop green; `Policy Guards (pull-request)` all 7 green host-side.
- Full preflight green at 50 guards.
- Scripts-only diff. Neither file is reachable from `apps/web`, so the web bundle graph is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
