### PR TITLE
fix(pr-health): block a PR whose base is not main

### DIFF
--- a/scripts/pr-health.mjs
+++ b/scripts/pr-health.mjs
@@ -100,6 +100,22 @@ export function evaluatePrHealth({ meta = {}, checks = [], threads = [], localCi
   if (meta.isDraft) {
     blockers.push("PR is a draft — mark it ready for review");
   }
+  // AGENTS.md §3: "All changes land via PR against `main`." That is not just
+  // convention here — .github/workflows/ci.yml triggers on
+  // `pull_request: branches: [main]`, so a PR based on anything else runs only
+  // DCO / classify / acceptance. No Typecheck, no Unit Tests, no Policy Guards,
+  // no Production Build — and `mergeStateStatus` still reports CLEAN, because
+  // every required check it knows about did pass. This function is the
+  // mechanical merge-readiness answer doctrine points at, so it is where the
+  // off-contract base has to stop being invisible (#4483, 2026-08-23).
+  if (meta.baseRefName && meta.baseRefName !== "main") {
+    blockers.push(
+      `base is ${meta.baseRefName}, not main — AGENTS.md §3 requires PRs against main, and ` +
+        "ci.yml only runs the heavy suite (Typecheck, Unit Tests, Policy Guards, Production " +
+        "Build) for main-based PRs. Green here does NOT mean verified. Rebase onto origin/main " +
+        "and retarget the PR.",
+    );
+  }
   if (meta.mergeable === "CONFLICTING") {
     blockers.push("mergeable=CONFLICTING — rebase onto origin/main and resolve conflicts");
   } else if (meta.mergeable === "UNKNOWN") {
@@ -235,7 +251,7 @@ function fetchPrState(prArg) {
   }
 
   const meta = JSON.parse(
-    gh(["pr", "view", number, "--json", "number,title,state,mergeable,mergeStateStatus,isDraft,headRefOid,body,files,commits"]),
+    gh(["pr", "view", number, "--json", "number,title,state,mergeable,mergeStateStatus,isDraft,baseRefName,headRefOid,body,files,commits"]),
   );
 
   let checks = [];

--- a/scripts/pr-health.test.mjs
+++ b/scripts/pr-health.test.mjs
@@ -315,3 +315,34 @@ test("localCi omitted (null) leaves legacy behavior untouched", () => {
   const r = evalPr({ meta: okMeta, checks: [pass("Typecheck")], threads: [], localCi: null });
   assert.equal(r.ready, true);
 });
+
+// AGENTS.md §3 — PRs land against main. ci.yml is `pull_request: branches: [main]`,
+// so a feature-branch base silently skips the whole heavy suite while still
+// reporting CLEAN. #4483 sat like that with 4 checks instead of ~34.
+test("blocks a PR whose base is not main, even when every check it ran passed", () => {
+  const r = evaluatePrHealth({
+    meta: { ...okMeta, baseRefName: "feat/some-other-branch" },
+    checks: [pass("DCO"), pass("classify"), pass("acceptance")],
+    threads: [],
+  });
+  assert.equal(r.ready, false);
+  const text = r.blockers.join(" | ");
+  assert.match(text, /base is feat\/some-other-branch, not main/);
+  assert.match(text, /Green here does NOT mean verified/);
+});
+
+test("a main-based PR is not blocked by the base check", () => {
+  const r = evaluatePrHealth({
+    meta: { ...okMeta, baseRefName: "main" },
+    checks: [pass("Typecheck"), pass("Production Build")],
+    threads: [],
+  });
+  assert.equal(r.ready, true);
+  assert.deepEqual(r.blockers, []);
+});
+
+test("absent baseRefName does not invent a blocker", () => {
+  // Older callers and fixtures omit the field; missing evidence is not a failure.
+  const r = evaluatePrHealth({ meta: okMeta, checks: [pass("Typecheck")], threads: [] });
+  assert.equal(r.ready, true);
+});


### PR DESCRIPTION
AGENTS.md §3: *"All changes land via PR against `main`."*

That is not only convention. `.github/workflows/ci.yml` triggers on `pull_request: branches: [main]`, so a PR based on anything else runs **only** DCO / classify / acceptance — no Typecheck, no Unit Tests, no Policy Guards, no Production Build.

And it still reads green, because every required check GitHub knows about did pass. #4483 sat exactly like that: **4 checks instead of ~34**, `mergeStateStatus: CLEAN`, while a client-bundle break (`node:fs/promises` in the browser chunk) went undetected until the base was retargeted to `main` and Production Build finally ran.

## The fix

`pnpm pr:health` is the mechanical merge-readiness answer §3 already points at — *"Verify merge-readiness mechanically — `pnpm pr:health [<n>]`, never a visual scan of some checks."* So that is where an off-contract base has to stop being invisible.

`baseRefName` is now fetched, and a non-`main` base is a blocker that says plainly the green does not mean verified:

```
base is feat/some-branch, not main — AGENTS.md §3 requires PRs against main, and
ci.yml only runs the heavy suite (Typecheck, Unit Tests, Policy Guards, Production
Build) for main-based PRs. Green here does NOT mean verified. Rebase onto
origin/main and retarget the PR.
```

No new policy — this mechanizes a rule that already exists, in the tool doctrine already names for the job.

## Evidence

- 29 tests pass (3 new): blocks a non-main base even when every check it ran passed; a `main` base is not blocked; an **absent** `baseRefName` invents no blocker, because missing evidence is not a failure and older callers omit the field.
- 33-guard loop green; `Policy Guards (pull-request)` all 7 green host-side; full preflight green.
- Scripts-only diff, not reachable from `apps/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
