### PR TITLE
fix(test): resolve the repo root from the test file, not the cwd (BI-96033E25)

### DIFF
--- a/apps/web/components/platform/ActivityRoutingWorkbench.test.tsx
+++ b/apps/web/components/platform/ActivityRoutingWorkbench.test.tsx
@@ -76,7 +76,7 @@ const ACTIVITY_ROUTING_FIXTURE: OperationsMapActivityRouting = {
 
 function readWorkbenchSource(): string {
   return readFileSync(
-    join(process.cwd(), "components", "platform", "ActivityRoutingWorkbench.tsx"),
+    join(__dirname, "ActivityRoutingWorkbench.tsx"),
     "utf8",
   );
 }

--- a/apps/web/lib/architecture/background-operation-observation-contract.test.ts
+++ b/apps/web/lib/architecture/background-operation-observation-contract.test.ts
@@ -2,7 +2,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const SOURCE_ROOT = join(process.cwd());
+const SOURCE_ROOT = join(__dirname, "..", "..");
 const CONTRACT_EXCEPTION = "background-observation-contract-exception BI-B8F44BF7";
 const RATCHETED_BASELINE = ["components/ops/PromotionsClient.tsx"];
 

--- a/apps/web/lib/integrations/connectors/email-postmark-migration.test.ts
+++ b/apps/web/lib/integrations/connectors/email-postmark-migration.test.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("Postmark callback hardening migration", () => {
-  const sql = readFileSync(resolve(process.cwd(), "../../packages/db/prisma/migrations/20260717211500_harden_connector_callback_dispatch/migration.sql"), "utf8");
+  const sql = readFileSync(resolve(__dirname, "../../../../../packages/db/prisma/migrations/20260717211500_harden_connector_callback_dispatch/migration.sql"), "utf8");
   it("fails safely when historical inbound drafts are duplicated", () => {
     expect(sql).toContain("HAVING COUNT(*) > 1");
     expect(sql).toContain("RAISE EXCEPTION 'Duplicate inbound responder drafts must be reconciled before migration'");

--- a/apps/web/lib/self-upgrade/promoter.test.ts
+++ b/apps/web/lib/self-upgrade/promoter.test.ts
@@ -397,7 +397,7 @@ describe("promoter launch idempotency (SUR-E2BF265E)", () => {
 
 describe("runtime transition promoter entrypoint", () => {
   it("recognizes the mode and fails closed without protocol secret material", async () => {
-    const script = resolve(process.cwd(), "../../scripts/promote.sh");
+    const script = resolve(__dirname, "../../../../scripts/promote.sh");
     const stateDir = await mkdtemp(join(tmpdir(), "dpf-promoter-test-"));
     try {
       vi.stubEnv("DPF_PROMOTER_STATE_DIR", stateDir);

--- a/packages/db/src/healthcare-care-intake-evidence-immutability.test.ts
+++ b/packages/db/src/healthcare-care-intake-evidence-immutability.test.ts
@@ -4,8 +4,8 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const sql = readFileSync(resolve(
-  process.cwd(),
-  "prisma/migrations/20260717035500_enforce_care_intake_evidence_immutability/migration.sql",
+  __dirname,
+  "../prisma/migrations/20260717035500_enforce_care_intake_evidence_immutability/migration.sql",
 ), "utf8");
 
 describe("care intake reviewed evidence immutability migration", () => {

--- a/packages/db/src/healthcare-care-intake-staff-rls.test.ts
+++ b/packages/db/src/healthcare-care-intake-staff-rls.test.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const migration = readFileSync(
-  resolve(process.cwd(), "prisma/migrations/20260717032000_allow_staff_intake_review/migration.sql"),
+  resolve(__dirname, "../prisma/migrations/20260717032000_allow_staff_intake_review/migration.sql"),
   "utf8",
 );
 

--- a/packages/db/src/seed-wiki-kernel.test.ts
+++ b/packages/db/src/seed-wiki-kernel.test.ts
@@ -581,8 +581,8 @@ Prefer 3NF until a measured read-path needs denormalization.`;
 describe("founder-kernel principle frontmatter", () => {
   it("assigns a consumer archetype to every authored principle page", () => {
     const principleDir = resolve(
-      process.cwd(),
-      "../../docs/founder-kernel/wiki/principles",
+      __dirname,
+      "../../../docs/founder-kernel/wiki/principles",
     );
     const missing: string[] = [];
 
@@ -608,7 +608,7 @@ describe("founder-kernel principle frontmatter", () => {
     // DB). This sweep is the cheap CI-time equivalent, so an author learns at
     // PR time instead of at deploy time. Covers both corpora: the founder
     // kernel and every profession corpus under docs/professions/*/wiki/.
-    const repoRoot = resolve(process.cwd(), "../..");
+    const repoRoot = resolve(__dirname, "../../..");
 
     const walk = (dir: string): string[] => {
       if (!existsSync(dir)) return [];
@@ -661,8 +661,8 @@ describe("founder-kernel principle: remove-avoidable-failure-opportunities", () 
   // pins structural intent (valid keys + the two researched signs), NOT exact
   // magnitudes — recalibrating a weight must not break the build.
   const principlePath = resolve(
-    process.cwd(),
-    "../../docs/founder-kernel/wiki/principles/remove-avoidable-failure-opportunities.md",
+    __dirname,
+    "../../../docs/founder-kernel/wiki/principles/remove-avoidable-failure-opportunities.md",
   );
 
   it("seeds as a core principle with a valid, registry-backed dimensionVector", () => {
@@ -716,8 +716,8 @@ describe("founder-kernel principle dimension-vector sign convention", () => {
   // Audit: docs/superpowers/audits/2026-06-14-principle-dimension-sign-audit.md
   it("never assigns a positive weight to a cost dimension", () => {
     const principleDir = resolve(
-      process.cwd(),
-      "../../docs/founder-kernel/wiki/principles",
+      __dirname,
+      "../../../docs/founder-kernel/wiki/principles",
     );
     const offenders: string[] = [];
 

--- a/packages/db/src/skill-quality-audit.test.ts
+++ b/packages/db/src/skill-quality-audit.test.ts
@@ -136,7 +136,7 @@ Output: Blockers first.
       "skills/universal/add-skill.skill.md",
     ];
 
-    const rootDir = join(process.cwd(), "..", "..");
+    const rootDir = join(__dirname, "..", "..", "..");
     const results = skillPaths.map((path) => auditSkillMarkdown({
       path,
       content: readFileSync(join(rootDir, path), "utf-8"),


### PR DESCRIPTION
## The defect

Nine call sites computed a repo or package root as `process.cwd()` joined with a literal relative path, e.g. `packages/db/src/skill-quality-audit.test.ts:139`:

```js
const rootDir = join(process.cwd(), "..", "..");
```

That is only correct when vitest is invoked with cwd = the package directory. Run a single package's tests from the repo root — `vitest run --root <repo>/packages/db`, which is what a worktree-based session does — and the root resolved to the **parent of the repo**, failing with:

```
ENOENT: no such file or directory, open '/Users/<user>/skills/build/start-feature.skill.md'
```

That failure is indistinguishable from a genuinely missing skill file, so it reads as a defect in the skills corpus. The misdiagnosis cost real time during BI-8AD9D018. The bug class is silent: it passes in CI, which happens to use the package dir, and fails only for the contributor.

## The fix

Resolve from `__dirname` — the pattern `packages/db/src/seed-skills.test.ts` already used for the same root. Nine sites in eight files.

One site was worse than a bad path: `background-operation-observation-contract.test.ts` set `SOURCE_ROOT` to bare `process.cwd()`, so a repo-root run would have walked the entire monorepo instead of `apps/web`.

## Verification

Both full suites, run twice — from the package dir and from the repo root with `--root` — with the failure sets diffed:

| suite | scale | result |
|---|---|---|
| `packages/db` | 273 files | FAIL sets **identical** both ways |
| `apps/web` | 2791 files / 23909 tests | green both ways, diff **identical** |
| `apps/web` `tsc --noEmit` | — | exit 0, no diagnostics |
| guard-parity preflight | 46 guards | clean in 38.9s |

The 5 `packages/db` failures are pre-existing live-Postgres tests against an empty local DB (`PrismaClientKnownRequestError`), unrelated to path resolution and identical before and after.

## Gate disclosure

**Local pregate was NOT run.** The maintainer directed the bypass while a fix lands for the dev-portal lease loop that is starving `local-integration-ci` (BI-D45898C0); the box was at load-average 19.4. Pushed with a recorded `operator-emergency` override, not `--no-verify`. No lint or full-gate evidence is claimed. The guard-parity preflight above did run and is clean.

A pre-commit typecheck rejection during this work was **not** overridden — it was a SIGTERM under host load, confirmed by running `tsc --noEmit` directly (exit 0) and by the hook passing on retry.

## Known gaps

- ~45 `process.cwd()` uses in `scripts/**/*.test.mjs` and the skill-pack hook tests were left alone. Reasoning, not evidence: they run via package.json scripts where pnpm pins cwd to the repo root, and their cwd uses are subject-under-test or temp fixtures. Not proven by running them from a foreign cwd.
- **No regression guard.** A lint rule rejecting `process.cwd()` joined with a literal relative path in test files is the durable fix and is not in this PR.
- Duplicate check at filing time was lexical only — semantic search returned `unavailable` (local-CI capacity reservation), which is explicitly not "no results".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Docs-Impact-Decision: test-internal path-resolution fix only. `background-operation-observation-contract.test.ts` changed one line (`SOURCE_ROOT` from `process.cwd()` to `__dirname`-relative). The observation contract itself, the set of files it scans under the normal package-dir invocation, and all user-facing behaviour are unchanged — the fix only stops a repo-root `--root` run from scanning the whole monorepo. `docs/architecture/background-operation-observation-contract.md` documents the contract, not the harness's path resolution, and needs no edit.
