### PR TITLE
feat(payroll): let approved expense claims ride a pay run as reimbursement (BI-AC74BE73)

### DIFF
--- a/apps/web/lib/hr/reimbursement-in-payroll.test.ts
+++ b/apps/web/lib/hr/reimbursement-in-payroll.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import {
+  planReimbursements,
+  reimbursementCode,
+  reimbursementCodesInTaxBase,
+  settledClaimIds,
+  toPayComponents,
+  type SettleableClaim,
+} from "./reimbursement-in-payroll";
+import { buildPayrollPosting, type PayrollAccountMap } from "./payroll-gl";
+
+function claim(over: Partial<SettleableClaim> = {}): SettleableClaim {
+  return {
+    claimId: "CLM-0001",
+    employeeProfileId: "emp_1",
+    title: "August mileage",
+    status: "approved",
+    totalAmount: 152.25,
+    currency: "USD",
+    paidAt: null,
+    ...over,
+  };
+}
+
+describe("planReimbursements", () => {
+  it("settles an approved, unpaid claim as a non-taxable reimbursement line", () => {
+    const plan = planReimbursements({
+      employeeProfileId: "emp_1",
+      claims: [claim()],
+      currency: "USD",
+    });
+
+    expect(plan.lines).toHaveLength(1);
+    const line = plan.lines[0]!;
+    expect(line.componentKind).toBe("reimbursement");
+    // Repayment of an expense is not income — this must never be true.
+    expect(line.taxable).toBe(false);
+    expect(line.amount).toBe(152.25);
+    expect(plan.totalReimbursement).toBe(152.25);
+    expect(plan.excluded).toHaveLength(0);
+  });
+
+  it("refuses a claim that was already paid, rather than paying it twice", () => {
+    const plan = planReimbursements({
+      employeeProfileId: "emp_1",
+      claims: [claim({ paidAt: new Date("2026-08-01T00:00:00.000Z") })],
+      currency: "USD",
+    });
+
+    expect(plan.lines).toHaveLength(0);
+    expect(plan.excluded[0]?.reason).toBe("already_paid");
+    expect(plan.totalReimbursement).toBe(0);
+  });
+
+  it.each(["draft", "submitted", "rejected", "paid"])(
+    "refuses a claim in status %s",
+    (status) => {
+      const plan = planReimbursements({
+        employeeProfileId: "emp_1",
+        claims: [claim({ status })],
+        currency: "USD",
+      });
+      expect(plan.lines).toHaveLength(0);
+      expect(plan.excluded[0]?.reason).toBe("not_approved");
+    },
+  );
+
+  it("refuses a foreign-currency claim rather than inventing a rate", () => {
+    const plan = planReimbursements({
+      employeeProfileId: "emp_1",
+      claims: [claim({ currency: "GBP" })],
+      currency: "USD",
+    });
+
+    // There is no governed FX substrate, so converting here would attach an
+    // uncited number to someone's pay.
+    expect(plan.lines).toHaveLength(0);
+    expect(plan.excluded[0]?.reason).toBe("currency_mismatch");
+    expect(plan.excluded[0]?.detail).toContain("no governed FX rate");
+  });
+
+  it("does not open a zero-value line", () => {
+    const plan = planReimbursements({
+      employeeProfileId: "emp_1",
+      claims: [claim({ totalAmount: 0 })],
+      currency: "USD",
+    });
+    expect(plan.lines).toHaveLength(0);
+    expect(plan.excluded[0]?.reason).toBe("zero_amount");
+  });
+
+  it("accounts for every claim as either settled or excluded", () => {
+    const claims = [
+      claim({ claimId: "CLM-A" }),
+      claim({ claimId: "CLM-B", status: "submitted" }),
+      claim({ claimId: "CLM-C", paidAt: new Date() }),
+      claim({ claimId: "CLM-D", currency: "EUR" }),
+      claim({ claimId: "CLM-E", totalAmount: 0 }),
+    ];
+    const plan = planReimbursements({ employeeProfileId: "emp_1", claims, currency: "USD" });
+
+    // A claim that silently vanishes is an employee who is not paid and cannot
+    // see why, so the two buckets must cover the input exactly.
+    const accounted = [...plan.lines.map((l) => l.claimId), ...plan.excluded.map((e) => e.claimId)];
+    expect(accounted.sort()).toEqual(["CLM-A", "CLM-B", "CLM-C", "CLM-D", "CLM-E"]);
+  });
+
+  it("ignores another employee's claims", () => {
+    const plan = planReimbursements({
+      employeeProfileId: "emp_1",
+      claims: [claim({ claimId: "CLM-X", employeeProfileId: "emp_2" })],
+      currency: "USD",
+    });
+    expect(plan.lines).toHaveLength(0);
+    expect(plan.excluded).toHaveLength(0);
+  });
+
+  it("sums several claims into one total", () => {
+    const plan = planReimbursements({
+      employeeProfileId: "emp_1",
+      claims: [
+        claim({ claimId: "CLM-A", totalAmount: 100.1 }),
+        claim({ claimId: "CLM-B", totalAmount: 50.2 }),
+      ],
+      currency: "USD",
+    });
+    expect(plan.totalReimbursement).toBe(150.3);
+  });
+});
+
+describe("idempotency", () => {
+  it("derives a stable code per claim so a re-run collides rather than duplicates", () => {
+    expect(reimbursementCode("CLM-0001")).toBe("REIMB-CLM-0001");
+
+    const once = planReimbursements({ employeeProfileId: "emp_1", claims: [claim()], currency: "USD" });
+    const twice = planReimbursements({ employeeProfileId: "emp_1", claims: [claim()], currency: "USD" });
+
+    // PayComponentLine is @@unique([payslipId, code]) — a stable code makes a
+    // recomputed run update in place instead of paying twice.
+    expect(twice.lines[0]?.code).toBe(once.lines[0]?.code);
+  });
+
+  it("names exactly the claims to mark paid in the same transaction", () => {
+    const plan = planReimbursements({
+      employeeProfileId: "emp_1",
+      claims: [claim({ claimId: "CLM-A" }), claim({ claimId: "CLM-B", status: "draft" })],
+      currency: "USD",
+    });
+    expect(settledClaimIds(plan)).toEqual(["CLM-A"]);
+  });
+});
+
+describe("tax-base guard", () => {
+  it("is silent when reimbursement stays out of taxable earnings", () => {
+    const plan = planReimbursements({ employeeProfileId: "emp_1", claims: [claim()], currency: "USD" });
+    expect(reimbursementCodesInTaxBase(plan, [{ code: "BASE" }, { code: "OT" }])).toEqual([]);
+  });
+
+  it("names a reimbursement code that wrongly reached the tax base", () => {
+    const plan = planReimbursements({ employeeProfileId: "emp_1", claims: [claim()], currency: "USD" });
+    const leaked = reimbursementCodesInTaxBase(plan, [{ code: "BASE" }, { code: "REIMB-CLM-0001" }]);
+    // Taxing repayment of an employee's own money is the defect this catches.
+    expect(leaked).toEqual(["REIMB-CLM-0001"]);
+  });
+});
+
+describe("posting a run that reimburses", () => {
+  const accounts: PayrollAccountMap = {
+    wagesExpense: "6000",
+    employerCostExpense: "6100",
+    reimbursementExpense: "6200",
+    netPayPayable: "2100",
+    taxPayable: "2200",
+    pensionPayable: "2300",
+    otherDeductionsPayable: "2400",
+  };
+
+  it("pays wages and the month's mileage in one balanced posting", () => {
+    const plan = planReimbursements({ employeeProfileId: "emp_1", claims: [claim()], currency: "USD" });
+
+    const posting = buildPayrollPosting({
+      accounts,
+      payslips: [
+        {
+          grossPay: 5000,
+          netPay: 4366.67,
+          earnings: [{ code: "BASE", label: "Salary", amount: 5000 }],
+          employeeDeductions: [{ code: "TAX", label: "Federal withholding", amount: 633.33 }],
+          employerCosts: [{ code: "NI", label: "Employer FICA", amount: 382.5 }],
+          statutoryCodes: ["TAX"],
+          reimbursements: toPayComponents(plan),
+        },
+      ],
+    });
+
+    expect(posting.balanced).toBe(true);
+
+    const reimbLine = posting.lines.find((l) => l.accountCode === "6200");
+    // The reimbursement is an expense in its own right, never wages.
+    expect(reimbLine?.debit).toBe(152.25);
+    const wages = posting.lines.find((l) => l.accountCode === "6000");
+    expect(wages?.debit).toBe(5000);
+
+    // Net pay payable carries wages plus the reimbursement — the employee is
+    // owed both, but only one of them was earned.
+    const netPayable = posting.lines.find((l) => l.accountCode === "2100");
+    expect(netPayable?.credit).toBe(4366.67 + 152.25);
+  });
+});

--- a/apps/web/lib/hr/reimbursement-in-payroll.ts
+++ b/apps/web/lib/hr/reimbursement-in-payroll.ts
@@ -1,0 +1,191 @@
+// lib/hr/reimbursement-in-payroll.ts — approved expense claims riding a pay run
+// (BI-AC74BE73, EP-PAYROLL-ABSORB x EP-MILEAGE-ABSORB).
+//
+// This is the seam between the two absorbed jobs: a driver's mileage is
+// monetised onto an ExpenseClaim (lib/mileage/monetisation.ts), and the claim is
+// then repaid through payroll rather than a separate payment run — which is how
+// most small businesses actually pay expenses.
+//
+// The load-bearing distinction is that a reimbursement is NOT earnings. It is
+// the business repaying money the employee already spent, so it must not inflate
+// gross pay, must not enter the statutory tax base, and must not appear in the
+// payroll tax emitters (lib/hr/payroll-tax-emission.ts). Getting this wrong
+// over-taxes an employee on their own money.
+//
+// SCOPE BOUNDARY: reimbursement ABOVE a jurisdiction's statutory mileage rate IS
+// taxable in both the US and UK, and belongs in an `earning` line rather than a
+// `reimbursement` line. Computing that split needs jurisdiction-scoped banded
+// rates, which is BI-1C8B56DA and is NOT implemented here. This module carries
+// the seam for it (see taxableExcess) without inventing the calculation.
+
+/** Reasons a claim is not settled through this run. Closed set. */
+export type ReimbursementExclusionReason =
+  | "not_approved"
+  | "already_paid"
+  | "zero_amount"
+  | "currency_mismatch";
+
+export type SettleableClaim = {
+  claimId: string;
+  employeeProfileId: string;
+  title: string;
+  /** Claim status: only "approved" is eligible. */
+  status: string;
+  totalAmount: number;
+  currency: string;
+  /** Non-null means it was already settled elsewhere — never pay it twice. */
+  paidAt: Date | null;
+};
+
+export type ReimbursementLine = {
+  /** Stable per claim, so recomputing a run is idempotent under the
+   *  PayComponentLine @@unique([payslipId, code]) constraint. */
+  code: string;
+  label: string;
+  amount: number;
+  currency: string;
+  componentKind: "reimbursement";
+  /** Always false. A repayment of an expense is not taxable income. */
+  taxable: false;
+  claimId: string;
+};
+
+export type ExcludedClaim = {
+  claimId: string;
+  reason: ReimbursementExclusionReason;
+  detail: string;
+};
+
+export type ReimbursementPlan = {
+  employeeProfileId: string;
+  currency: string;
+  lines: ReimbursementLine[];
+  /** Sum of the settled lines — what payroll adds to net pay. */
+  totalReimbursement: number;
+  /** Every claim that did NOT settle, with why. */
+  excluded: ExcludedClaim[];
+};
+
+const round2 = (n: number): number => Math.round((n + Number.EPSILON) * 100) / 100;
+
+/** The component code a claim settles under. Deterministic by construction. */
+export function reimbursementCode(claimId: string): string {
+  return `REIMB-${claimId}`;
+}
+
+/**
+ * Decide which approved claims settle through this pay run.
+ *
+ * Every input claim appears in exactly one of `lines` or `excluded` — a claim is
+ * never silently dropped, because a claim that vanishes is an employee who does
+ * not get paid and cannot see why.
+ *
+ * A claim in a currency other than the run's is REFUSED rather than converted.
+ * There is no FX substrate on the platform (BI-BAC971B2: no ISO-4217 authority,
+ * no rate source, no as-of provenance), so any conversion here would be an
+ * uncited number attached to someone's pay.
+ */
+export function planReimbursements(input: {
+  employeeProfileId: string;
+  claims: readonly SettleableClaim[];
+  /** The pay run's currency — claims must match it. */
+  currency: string;
+}): ReimbursementPlan {
+  const lines: ReimbursementLine[] = [];
+  const excluded: ExcludedClaim[] = [];
+
+  for (const claim of input.claims) {
+    if (claim.employeeProfileId !== input.employeeProfileId) continue;
+
+    if (claim.status !== "approved") {
+      excluded.push({
+        claimId: claim.claimId,
+        reason: "not_approved",
+        detail: `status is "${claim.status}" — only an approved claim may be reimbursed`,
+      });
+      continue;
+    }
+
+    if (claim.paidAt !== null) {
+      excluded.push({
+        claimId: claim.claimId,
+        reason: "already_paid",
+        detail: `settled at ${claim.paidAt.toISOString()} — reimbursing again would pay it twice`,
+      });
+      continue;
+    }
+
+    if (claim.currency !== input.currency) {
+      excluded.push({
+        claimId: claim.claimId,
+        reason: "currency_mismatch",
+        detail: `claim is ${claim.currency}, run is ${input.currency} — no governed FX rate exists to convert it`,
+      });
+      continue;
+    }
+
+    const amount = round2(claim.totalAmount);
+    if (amount === 0) {
+      excluded.push({
+        claimId: claim.claimId,
+        reason: "zero_amount",
+        detail: "nothing to reimburse",
+      });
+      continue;
+    }
+
+    lines.push({
+      code: reimbursementCode(claim.claimId),
+      label: claim.title,
+      amount,
+      currency: claim.currency,
+      componentKind: "reimbursement",
+      taxable: false,
+      claimId: claim.claimId,
+    });
+  }
+
+  return {
+    employeeProfileId: input.employeeProfileId,
+    currency: input.currency,
+    lines,
+    totalReimbursement: round2(lines.reduce((t, l) => t + l.amount, 0)),
+    excluded,
+  };
+}
+
+/**
+ * Adapt a plan to the `reimbursements` field of PayrollPostablePayslip
+ * (lib/hr/payroll-gl.ts), which debits reimbursement expense and credits net pay
+ * payable without touching wages expense or the tax accounts.
+ */
+export function toPayComponents(
+  plan: ReimbursementPlan,
+): Array<{ code: string; label: string; amount: number }> {
+  return plan.lines.map((l) => ({ code: l.code, label: l.label, amount: l.amount }));
+}
+
+/**
+ * The claim ids this run settles. The caller marks exactly these paid in the same
+ * transaction that persists the payslip, so a claim cannot be reimbursed twice by
+ * a later run or by the standalone expense payment path.
+ */
+export function settledClaimIds(plan: ReimbursementPlan): string[] {
+  return plan.lines.map((l) => l.claimId);
+}
+
+/**
+ * Guard: reimbursement must never reach the statutory tax base.
+ *
+ * Returns the codes that wrongly appear in both the reimbursement plan and the
+ * taxable earnings passed to the payroll engine. A non-empty result is a defect
+ * in the caller, not a condition to tolerate — it means an employee is about to
+ * be taxed on repayment of their own money.
+ */
+export function reimbursementCodesInTaxBase(
+  plan: ReimbursementPlan,
+  taxableEarnings: ReadonlyArray<{ code: string }>,
+): string[] {
+  const reimbursed = new Set(plan.lines.map((l) => l.code));
+  return taxableEarnings.map((e) => e.code).filter((code) => reimbursed.has(code));
+}


### PR DESCRIPTION
The seam between the two absorbed jobs. A driver's mileage is monetised onto an `ExpenseClaim` (#4481) and repaid through payroll rather than a separate payment run — which is how most small businesses actually pay expenses.

## The distinction this enforces

A reimbursement is **not earnings**. It is the business repaying money the employee already spent, so it must not inflate gross pay, must not enter the statutory tax base, and must not reach the payroll tax emitters. `taxable` is a literal `false` on the type rather than a default, because getting this wrong over-taxes someone on their own money.

## Decisions worth review

**A foreign-currency claim is refused, not converted.** There is no FX substrate (BI-BAC971B2: no ISO-4217 authority, no rate source, no as-of provenance), so converting here would attach an uncited number to someone's pay.

**Every claim is accounted for** — each lands in `lines` or `excluded` with a closed-set reason. A claim that silently vanishes is an employee who is not paid and cannot see why.

**Idempotent by construction.** The component code derives from the claim id, so a recomputed run collides on `PayComponentLine`'s `@@unique([payslipId, code])` and updates in place rather than paying twice. `settledClaimIds` names exactly what the caller marks paid, in the same transaction that persists the payslip.

**`reimbursementCodesInTaxBase` is a guard, not a filter** — it names codes that wrongly reached taxable earnings so a caller fails loudly. Silently removing them would hide the defect.

## Scope boundary, deliberate

Reimbursement **above** a jurisdiction's statutory mileage rate is taxable and belongs in an `earning` line. That split needs jurisdiction-scoped banded rates (BI-1C8B56DA) and is not invented here — the seam is carried, the calculation is not.

## Verification

- `pregate` sandbox gate **PASS** at `6e70b7a215bd`, evidence `cmt5bi8610kel01o8ybzat3pz`
- `pregate:preflight` — 47 guards clean
- 16 tests, including an end-to-end posting that pays wages and a month's mileage in one balanced journal, with the reimbursement debited to its own expense account and never to wages

Refs: BI-AC74BE73, EP-PAYROLL-ABSORB, EP-MILEAGE-ABSORB

Local-CI-Evidence: cmt5bi8610kel01o8ybzat3pz (feat/reimbursement-in-payroll@6e70b7a215bd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)