### PR TITLE
fix(pregate): exit 0 must mean gated-and-passed — abandoned or unrecorded runs exit 7 (BI-A9CF0D69)

### DIFF
--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -364,7 +364,7 @@ the reader exists (BI-B1065D41):
 
 | Signal | How it lies |
 | --- | --- |
-| The **exit code** | `pregate …; echo $?; tail …` reports *tail's* status. And a run that gave up while queued exits 0 having gated nothing (BI-2C7F51BA). |
+| The **exit code** | `pregate …; echo $?; tail …` reports *tail's* status. A run that gives up while queued, or reports 0 with no PASS record at HEAD, now exits **7** instead of 0 (BI-A9CF0D69; the historical exit-0 lie was BI-2C7F51BA) — but a chained/piped reading still surfaces someone else's status, so the record remains the verdict. |
 | The **log tail** | A *tolerated* `GuardRuntimeEnvironmentError` prints `Error:` and a red ✖ ~28,000 lines before a **passing** verdict. A watcher grepping `Error:` fabricates a failure. |
 | **`gate passed`** | True about the run you watched; silent about whether HEAD has moved since. `pregate:status` compares. |
 
@@ -766,7 +766,7 @@ Name them so you catch yourself.
 | Reaching for `DPF_SKIP_*` to get past a hook | Bypasses are for verified false positives only | Fix the underlying error; CI gates it anyway |
 | Verifying UX against worktree `next dev` | Not the production-bundled runtime | Use the canonical install or sandbox lease (AGENTS.md §13) |
 | Treating a local green as the merge gate | The binding gate is the CI **Unit Tests** check | Local pass = evidence; CI pass = the gate |
-| Reading a `pregate` exit code as the verdict | A run killed while queued exits 0 without running | `pnpm run pregate:status` — it reads the SHA-bound record and exits 0 only for a PASS at HEAD |
+| Reading a `pregate` exit code as the verdict | A pipeline surfaces the last command's status, not pregate's (an abandoned/uncorroborated run itself now exits 7, not 0 — BI-A9CF0D69) | `pnpm run pregate:status` — it reads the SHA-bound record and exits 0 only for a PASS at HEAD |
 | Piping `pregate` to `head`/`grep` | The verdict is the LAST line, so a truncating reader removes exactly what you wanted (and it used to SIGPIPE-kill the run mid-install) | Let it print its ~30 lines; open the log path it prints for detail |
 | Backgrounding `pregate` (`&` / `run_in_background`) | The harness caps and kills a backgrounded run mid-install | Run it in the FOREGROUND — on timeout the harness migrates it and it continues |
 | Wrapping `pregate` in `timeout` | Cuts it off mid-queue and manufactures a false green | Run it unbounded in the foreground |

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -250,7 +250,7 @@ function parseArgs(argv) {
       case "--help":
       case "-h":
         process.stdout.write(usage());
-        process.exit(0);
+        process.exit(0); // exit-0: --help prints usage; nothing gated and nothing claimed
         break;
       case "--":
         break;
@@ -832,7 +832,7 @@ async function main() {
       process.stdout.write("localCiCommand=missing; gate would fail before push/lease\n");
     }
     process.stdout.write("would call claim_nonprod_environment_lease and record_local_integration_result only when a real command or explicit stub is configured\n");
-    process.exit(0);
+    process.exit(0); // exit-0: --dry-run routing probe; changes nothing and records nothing
   }
 
   if (!options.finalizeEvidence && !commandSpec && !allowStub) {
@@ -950,7 +950,7 @@ async function main() {
         evidencePending: false,
       });
       process.stdout.write(`finalized existing local-CI evidence: ${state.evidenceRecordId}\n`);
-      process.exit(0);
+      process.exit(0); // exit-0: --finalize-evidence revalidated an already-recorded PASS for this sha
     }
     const pending = JSON.parse(readFileSync(pendingEvidenceFile, "utf8"));
     if (pending.branch !== branch) die(`pending evidence branch mismatch: ${pending.branch} != ${branch}`);
@@ -985,7 +985,7 @@ async function main() {
     });
     rmSync(pendingEvidenceFile, { force: true });
     process.stdout.write(`recorded pending local-CI evidence: ${evidenceId}\n`);
-    process.exit(0);
+    process.exit(0); // exit-0: --finalize-evidence recorded the pending PASS evidence for this sha
   }
 
   warnAboutMainFreshness({ gitBin, worktreePath });
@@ -1795,7 +1795,7 @@ async function main() {
 
   if (outcome.gatePassed) {
     process.stdout.write(`${formatGateSummary({ ...summaryInput, verdictLine: "gate passed" }).join("\n")}\n`);
-    process.exit(0);
+    process.exit(0); // exit-0: gate passed; the PASS record for this sha was written above
   }
   process.stderr.write(
     `${formatGateSummary({ ...summaryInput, verdictLine: "", failureSummary }).join("\n")}\n`,

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -147,6 +147,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/lib/ci-policy-test-inventory.test.mjs",
         "scripts/lib/git-shallow-preflight.test.mjs",
         "scripts/pregate-preflight.test.mjs",
+        "scripts/pregate-exit-honesty.test.mjs",
         "scripts/gate-context.test.mjs",
         "scripts/lib/gate-context-runtime-contract.test.mjs",
         "scripts/pre-push-dco-check.test.mjs",

--- a/scripts/pregate-exit-honesty.test.mjs
+++ b/scripts/pregate-exit-honesty.test.mjs
@@ -1,0 +1,120 @@
+// pregate-exit-honesty.test.mjs — BI-A9CF0D69 (plan §3 M5, class D).
+//
+// Two honesty rules for the dev-loop gate wrapper:
+//   1. Exit 0 MEANS "gated and passed": an elapsed admission window, or a zero
+//      status the SHA-bound slot records cannot corroborate as PASS-at-HEAD,
+//      exits ABANDONED_OR_UNRECORDED_EXIT_CODE instead of 0.
+//   2. Every `process.exit(0)` in the wrapper/gate pair carries an inline
+//      `// exit-0: <reason>` annotation. The set of silent-success sites is
+//      thereby declared and enumerable — a new unannotated exit(0) fails here
+//      rather than shipping a fresh way to read success into a did-not-run.
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ABANDONED_OR_UNRECORDED_EXIT_CODE,
+  isRecordExemptInvocation,
+  readReconciledVerdictAtHead,
+  resolveWrapperExitCode,
+} from "./pregate.mjs";
+
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
+
+describe("resolveWrapperExitCode", () => {
+  it("maps an elapsed admission window to the distinct abandoned code, never 0", () => {
+    assert.equal(
+      resolveWrapperExitCode({ status: 0, timedOut: true, recordExempt: false, verdictAtHead: "PASS" }),
+      ABANDONED_OR_UNRECORDED_EXIT_CODE,
+    );
+  });
+
+  it("refuses a zero status with no corroborating PASS record (red case)", () => {
+    assert.equal(
+      resolveWrapperExitCode({ status: 0, timedOut: false, recordExempt: false, verdictAtHead: "" }),
+      ABANDONED_OR_UNRECORDED_EXIT_CODE,
+    );
+    assert.equal(
+      resolveWrapperExitCode({ status: 0, timedOut: false, recordExempt: false, verdictAtHead: "NO-RECORD" }),
+      ABANDONED_OR_UNRECORDED_EXIT_CODE,
+    );
+  });
+
+  it("passes zero through only for PASS-at-HEAD or a record-exempt invocation", () => {
+    assert.equal(
+      resolveWrapperExitCode({ status: 0, timedOut: false, recordExempt: false, verdictAtHead: "PASS" }),
+      0,
+    );
+    assert.equal(
+      resolveWrapperExitCode({ status: 0, timedOut: false, recordExempt: true, verdictAtHead: "" }),
+      0,
+    );
+  });
+
+  it("keeps a genuine failure status, and coerces a killed spawn's null to 1", () => {
+    assert.equal(resolveWrapperExitCode({ status: 86, timedOut: false, recordExempt: false, verdictAtHead: "" }), 86);
+    assert.equal(resolveWrapperExitCode({ status: null, timedOut: false, recordExempt: false, verdictAtHead: "" }), 1);
+  });
+});
+
+describe("isRecordExemptInvocation", () => {
+  it("exempts exactly the closed no-record modes", () => {
+    assert.equal(isRecordExemptInvocation(["--dry-run"]), true);
+    assert.equal(isRecordExemptInvocation(["--finalize-evidence"]), true);
+    assert.equal(isRecordExemptInvocation(["--help"]), true);
+    assert.equal(isRecordExemptInvocation(["-h"]), true);
+    assert.equal(isRecordExemptInvocation([]), false);
+    assert.equal(isRecordExemptInvocation(["--push"]), false);
+  });
+});
+
+describe("readReconciledVerdictAtHead", () => {
+  it("fails closed to empty when context or records are unavailable", () => {
+    assert.equal(readReconciledVerdictAtHead({ resolveContextImpl: () => null }), "");
+    assert.equal(
+      readReconciledVerdictAtHead({
+        resolveContextImpl: () => ({}),
+        collectVerdictsImpl: () => [],
+      }),
+      "",
+    );
+    assert.equal(
+      readReconciledVerdictAtHead({
+        resolveContextImpl: () => { throw new Error("git unavailable"); },
+      }),
+      "",
+    );
+  });
+
+  it("reduces slot records through the reconciler", () => {
+    assert.equal(
+      readReconciledVerdictAtHead({
+        resolveContextImpl: () => ({}),
+        collectVerdictsImpl: () => [{ verdict: "PASS" }],
+        reconcileImpl: (slots) => slots[0],
+      }),
+      "PASS",
+    );
+  });
+});
+
+describe("exit(0) sites are declared", () => {
+  it("every process.exit(0) in the wrapper/gate pair carries an exit-0 annotation", () => {
+    const offenders = [];
+    for (const file of ["pregate.mjs", "gate-worktree.mjs", "pregate-status.mjs"]) {
+      const lines = readFileSync(join(SCRIPTS_DIR, file), "utf8").split("\n");
+      lines.forEach((line, index) => {
+        if (/process\.exit\(0\)/.test(line) && !/\/\/ exit-0: \S/.test(line)) {
+          offenders.push(`${file}:${index + 1}: ${line.trim()}`);
+        }
+      });
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `unannotated process.exit(0) — declare why this success is honest with a trailing "// exit-0: <reason>":\n${offenders.join("\n")}`,
+    );
+  });
+});

--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -37,11 +37,44 @@ import {
   installBrokenPipeTolerance,
   isVerboseGateConsole,
 } from "./lib/pregate-console.mjs";
+import { collectSlotVerdicts, resolveWorktreeContext } from "./pregate-status.mjs";
+import { reconcileSlots } from "./lib/pregate-status.mjs";
 import { isEntryModule } from "./lib/entry-module.mjs";
 
 const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
 export const WINDOWS_WRAPPER_TERMINATED_STATUS = 4294967295;
+
+// BI-A9CF0D69 (plan §3 M5): the wrapper's exit 0 must MEAN "gated and passed".
+// Historically a run that gave up while queued could surface exit 0 having
+// gated nothing (BI-2C7F51BA), and pregate:status existed to compensate. The
+// compensation stays (a SHA-bound record beats any exit code), but the wrapper
+// no longer tells the lie: an abandoned admission window, or a zero exit the
+// slot records cannot corroborate as PASS-at-HEAD, exits this distinct code.
+export const ABANDONED_OR_UNRECORDED_EXIT_CODE = 7;
+
+// Invocations that legitimately exit 0 without writing a PASS record: routing
+// probes and evidence replays change nothing about the tree and are exempt
+// from record corroboration — the same closed set shouldRunPreflight() exempts.
+export function isRecordExemptInvocation(args) {
+  return (
+    args.includes("--dry-run")
+    || args.includes("--finalize-evidence")
+    || args.includes("--help")
+    || args.includes("-h")
+  );
+}
+
+// Pure exit-code policy so the honesty rules are unit-testable without a gate:
+// timedOut (admission window elapsed, nothing gated) and status-0-without-a-
+// corroborating-PASS both map to ABANDONED_OR_UNRECORDED_EXIT_CODE; a genuine
+// failure keeps its own status; exempt invocations pass a zero through.
+export function resolveWrapperExitCode({ status, timedOut, recordExempt, verdictAtHead }) {
+  if (timedOut) return ABANDONED_OR_UNRECORDED_EXIT_CODE;
+  if (status !== 0) return status ?? 1;
+  if (recordExempt) return 0;
+  return verdictAtHead === "PASS" ? 0 : ABANDONED_OR_UNRECORDED_EXIT_CODE;
+}
 const DEFAULT_LEASE_WAIT_SECONDS = 7200;
 
 // Host-side guard parity preflight (BI-D35433FB): run the deterministic CI
@@ -622,12 +655,47 @@ async function main() {
   }
 
   const useShell = shouldUseShell();
-  const { result } = await runGateWithQueuedRevival({ args, useShell });
+  const { result, timedOut } = await runGateWithQueuedRevival({ args, useShell });
   if (result?.error) {
     process.stderr.write(`pregate: failed to launch gate: ${result.error.message}\n`);
     process.exit(1);
   }
-  process.exit(result?.status ?? 1);
+  const recordExempt = isRecordExemptInvocation(args);
+  const exitCode = resolveWrapperExitCode({
+    status: result?.status ?? 1,
+    timedOut: Boolean(timedOut),
+    recordExempt,
+    verdictAtHead: (result?.status ?? 1) === 0 && !recordExempt && !timedOut
+      ? readReconciledVerdictAtHead()
+      : "",
+  });
+  if (exitCode === ABANDONED_OR_UNRECORDED_EXIT_CODE) {
+    process.stderr.write(
+      timedOut
+        ? `pregate: admission window elapsed without gating — exiting ${ABANDONED_OR_UNRECORDED_EXIT_CODE}, not 0; nothing was verified (BI-A9CF0D69).\n`
+        : `pregate: gate reported 0 but no PASS record exists for current HEAD — treating as did-not-run and exiting ${ABANDONED_OR_UNRECORDED_EXIT_CODE} (BI-A9CF0D69). Read the verdict with: pnpm run pregate:status\n`,
+    );
+  }
+  process.exit(exitCode);
+}
+
+// Read the same SHA-bound slot records pregate:status reads, reduced to the
+// reconciled verdict for current HEAD. Failure to read is "", never "PASS" —
+// corroboration must fail closed or the honesty rule re-opens the exit-0 hole.
+export function readReconciledVerdictAtHead({
+  resolveContextImpl = resolveWorktreeContext,
+  collectVerdictsImpl = collectSlotVerdicts,
+  reconcileImpl = reconcileSlots,
+} = {}) {
+  try {
+    const context = resolveContextImpl();
+    if (!context) return "";
+    const slots = collectVerdictsImpl(context);
+    if (slots.length === 0) return "";
+    return reconcileImpl(slots)?.verdict ?? "";
+  } catch {
+    return "";
+  }
 }
 
 // Guard against side effects on import (e.g. from tests importing routing


### PR DESCRIPTION
Mechanism **M5** (class D — success signals without proof of execution) of the merged detection-hardening plan (#4395, umbrella BI-3D73CBC6, EP-413F2602).

## What

- An elapsed admission window exits a distinct `ABANDONED_OR_UNRECORDED_EXIT_CODE` (7) — never 0.
- A zero gate status is corroborated against the same SHA-bound slot records `pregate:status` reads (fail-closed); uncorroborated zeros exit 7.
- Routing probes (`--dry-run`/`--finalize-evidence`/`--help`) stay record-exempt.
- Every `process.exit(0)` in the wrapper/gate pair now carries an inline `// exit-0: <reason>` annotation; `pregate-exit-honesty.test.mjs` fails on any unannotated site (the silent-success set is declared and enumerable). Test registered in the policy-guard inventory.
- `docs/testing/pre-pr-gate.md` exit-code rows updated.

Field note: this PR's own gating was starved by the BI-D45898C0 lease-loop incident — a live class-D case where dead queue entries read as congestion; corroboration recorded on that BI.

## Verification

- `node --test scripts/pregate-exit-honesty.test.mjs` — 8/8 pass (red cases: status-0-without-PASS → 7; timedOut → 7; unannotated exit-0 fails).
- `node --test scripts/pregate.test.mjs` — 11/11 pass; ci-policy-test-inventory 8/8.
- Local-CI gate: **PASS** at cfb19d77001a (slot-0, evidence cmt5d4dsc0tmg01o83bjkd2hi, verdict via pregate:status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)