### PR TITLE
fix(build): fail the diff-capture step instead of completing with no record (BI-79176815)

### DIFF
--- a/apps/web/lib/build/build-pipeline.test.ts
+++ b/apps/web/lib/build/build-pipeline.test.ts
@@ -2,7 +2,7 @@
 // Tests for pure state machine functions in the build pipeline.
 
 import { describe, it, expect } from "vitest";
-import { getResumeStep, shouldRetry, nextStep, buildFailedState } from "./build-pipeline";
+import { getResumeStep, shouldRetry, nextStep, buildFailedState, executeStep } from "./build-pipeline";
 import type { BuildExecutionState } from "./build-exec-types";
 
 describe("getResumeStep", () => {
@@ -86,5 +86,47 @@ describe("buildFailedState", () => {
     // completedAt must be gone -- contradictory state was the FB-78E967D4 root
     expect(result.completedAt).toBeUndefined();
     expect(result.containerId).toBe("sb-1");
+  });
+});
+
+describe("diff capture cannot silently succeed (BI-79176815)", () => {
+  const noop = () => {};
+
+  // The capture step used to open with `if (!state.containerId) return state;`.
+  // A build whose container had been reaped therefore advanced to "complete"
+  // with diffPatch, diffSummary and gitCommitHashes all empty and NOTHING
+  // logged — indistinguishable from a build that legitimately changed nothing.
+  // Observed live: Build Studio committed a real change to its build branch and
+  // the FeatureBuild row recorded none of it.
+  const stateWithoutContainer = {
+    step: "tests_run",
+    retryCount: 0,
+  } as unknown as BuildExecutionState;
+
+  it("fails the capture step instead of completing with an empty result", async () => {
+    await expect(
+      executeStep("tests_run", "FB-TEST", stateWithoutContainer, noop),
+    ).rejects.toThrow(/no sandbox container/i);
+  });
+
+  it("names the build, so the failure is actionable from the log alone", async () => {
+    await expect(
+      executeStep("tests_run", "FB-TEST", stateWithoutContainer, noop),
+    ).rejects.toThrow(/FB-TEST/);
+  });
+
+  it("says the work may still exist rather than implying it was lost", async () => {
+    // The owner-facing distinction that matters: "we could not record this"
+    // is not the same claim as "nothing changed".
+    await expect(
+      executeStep("tests_run", "FB-TEST", stateWithoutContainer, noop),
+    ).rejects.toThrow(/cannot be recorded/i);
+  });
+
+  it("leaves other steps alone", async () => {
+    const state = { step: "done", retryCount: 0 } as unknown as BuildExecutionState;
+    await expect(
+      executeStep("default" as never, "FB-TEST", state, noop),
+    ).resolves.toBe(state);
   });
 });

--- a/apps/web/lib/build/build-pipeline.ts
+++ b/apps/web/lib/build/build-pipeline.ts
@@ -88,7 +88,7 @@ export async function runBuildPipeline(params: {
   // stay blocked at the PR #850 gate forever because the orchestration loop
   // immediately breaks when state.step === "complete".
   let effectiveExistingState = existingState;
-  if (existingState?.step === "complete" && existingState.containerId) {
+  if (existingState?.step === "complete") {
     const { prisma } = await import("@dpf/db");
     const fbRow = await prisma.featureBuild.findUnique({
       where: { buildId },
@@ -96,18 +96,31 @@ export async function runBuildPipeline(params: {
     });
     const hasNoCapture = !fbRow?.diffPatch || fbRow.diffPatch.length === 0;
     if (hasNoCapture) {
-      console.log(
-        `[build-pipeline] self-heal: ${JSON.stringify(buildId)} is "complete" but has empty diffPatch — rewinding to re-run stepComplete capture`,
-      );
-      // Rewind to "code_generated". getResumeStep then advances to "tests_run",
-      // and the orchestration loop dispatches stepComplete (which is the
-      // diff/commit capture step) without re-running stepRunTests or any
-      // earlier sandbox setup. The capture is idempotent.
-      effectiveExistingState = {
-        ...existingState,
-        step: "code_generated",
-        retryCount: 0,
-      };
+      if (!existingState.containerId) {
+        // BI-79176815: detection must not depend on the container, or the one
+        // case that needs healing is the one case that cannot be detected.
+        console.warn(
+          `[build-pipeline] ${JSON.stringify(buildId)} is "complete" with an empty diffPatch and has NO sandbox container — its changes cannot be recovered by rewinding. The work may still exist on its build branch.`,
+        );
+      } else {
+        console.log(
+          `[build-pipeline] self-heal: ${JSON.stringify(buildId)} is "complete" but has empty diffPatch — rewinding to re-run stepComplete capture`,
+        );
+      }
+      // Rewind to "code_generated" ONLY when a container still exists.
+      // getResumeStep then advances to "tests_run" and the loop dispatches
+      // stepComplete (the diff/commit capture step) without re-running
+      // stepRunTests or earlier sandbox setup. The capture is idempotent.
+      // Without a container the rewind cannot capture anything and would only
+      // drive stepComplete into its throw, so leave the state alone and let
+      // the warning above stand as the record.
+      if (existingState.containerId) {
+        effectiveExistingState = {
+          ...existingState,
+          step: "code_generated",
+          retryCount: 0,
+        };
+      }
     }
   }
 
@@ -701,7 +714,23 @@ async function stepComplete(
   // would mark itself "complete" with a 5-commit branch in the sandbox but
   // diffPatch=NULL and gitCommitHashes=[] in the DB — and PR #850's gate
   // would then reject the build for "no releasable source changes."
-  if (!state.containerId) return state;
+  // No container means the diff CANNOT be captured. Returning state unchanged
+  // here advanced the build to "complete" with diffPatch/diffSummary/
+  // gitCommitHashes all empty and NOTHING logged (BI-79176815) — so a build
+  // that really did change code was indistinguishable from one that changed
+  // nothing, and the owner-facing review surface had no evidence to show.
+  //
+  // Throw instead, matching stepCreateSandbox above ("Sandbox container is not
+  // running"): the orchestration loop's retry/recovery path then sees a failed
+  // step rather than a silent success. Every other best-effort branch in this
+  // function warns; this one used to be the only one that said nothing at all.
+  if (!state.containerId) {
+    throw new Error(
+      `Cannot capture the build diff: no sandbox container for ${buildId}. `
+      + "The work may exist on the build branch but cannot be recorded, so this "
+      + "step fails rather than completing the build with an empty result.",
+    );
+  }
 
   const { prisma } = await import("@dpf/db");
   const { extractDiff, execInSandbox, listSandboxCommitsAheadOfBase } = await import(


### PR DESCRIPTION
## The defect

A build could commit real work and record none of it, silently.

`stepComplete` opened with:

```ts
if (!state.containerId) return state;
```

When the sandbox container was gone — reaped under host load, or a resumed
pipeline that lost its reference — the entire capture block was skipped with
**no log, no error, and no owner-visible signal**. The build advanced to
`complete` with `diffPatch`, `diffSummary` and `gitCommitHashes` all empty,
which is indistinguishable from a build that legitimately changed nothing.

## Observed

Driving a real backlog item end to end through Build Studio (during
[#4570](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4570)), the coding agent generated and committed a copy fix plus its
test onto the build branch. **The commit exists.** The `FeatureBuild` row
recorded none of it, so the review surface had no evidence and the build could
not be shipped.

This reintroduced, through a different door, the exact symptom the function's
own header comment says it exists to prevent:

> the pipeline would mark itself "complete" with a 5-commit branch in the
> sandbox but `diffPatch=NULL`

## Two compounding halves

**1. The capture step failed silently.** It now throws, matching
`stepCreateSandbox` in the same file (*"Sandbox container is not running"*). The
orchestration loop's existing retry/recovery path sees a failed step instead of
a silent success. Every other best-effort branch in `stepComplete` already
warns — this was the only one that said nothing at all.

**2. The self-heal was blind to exactly this case.** The recovery for
"complete but empty `diffPatch`" was gated on `existingState.containerId` — the
very thing whose absence causes the miss. The one case needing recovery was the
one case it could not detect.

Detection no longer requires a container. The **rewind** still does, because
without one there is nothing to re-capture and rewinding would only drive
`stepComplete` into its throw; that case now logs plainly that the changes
cannot be recovered by rewinding and may still exist on the build branch.

## On not adding a schema field

`FeatureBuild` genuinely cannot distinguish "empty" from "uncaptured", and
`BuildChangeNarrative` was considered and rejected as a home for a failure flag
— it is owner-facing prose. But **the defect is the silence, and silence is
fixable without a migration.** The error text is deliberate about the
distinction that matters to an owner: *"the work may exist but cannot be
recorded"* is a different claim from *"nothing changed"*. Conflating them is
what made this expensive to find.

## Verification

- **`local-CI gate: PASS`** — evidence `cmt5d91j20uca01o8df5krfek`, no override
- 15 tests in `build-pipeline.test.ts`; 1,949 across `lib/build`
- typecheck clean

One test was written and then removed: it exercised the `pending` step, which
reaches the database, so it would have passed for reasons unrelated to its
claim. A test that cannot fail honestly is worse than no test.