### PR TITLE
feat(mileage): make mileage reachable — driver route, API, and the iOS app (BI-6D98AD8A, BI-E17E0034)

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -106,6 +106,16 @@ export default function TabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="mileage"
+        options={{
+          title: "Mileage",
+          href: hiddenHref("mileage"),
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="car" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="customers"
         options={{
           title: "Customers",

--- a/apps/mobile/app/(tabs)/mileage/_layout.tsx
+++ b/apps/mobile/app/(tabs)/mileage/_layout.tsx
@@ -1,0 +1,16 @@
+import { Stack } from "expo-router";
+import { useTheme } from "@/src/lib/theme";
+
+export default function MileageLayout() {
+  const { colors } = useTheme();
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: colors.surface1 },
+        headerTintColor: colors.text,
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: "Mileage" }} />
+    </Stack>
+  );
+}

--- a/apps/mobile/app/(tabs)/mileage/index.tsx
+++ b/apps/mobile/app/(tabs)/mileage/index.tsx
@@ -1,0 +1,222 @@
+import React, { useCallback, useEffect, useMemo } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useTheme } from "@/src/lib/theme";
+import {
+  MILEAGE_POLICY_VERSION,
+  useMileageStore,
+} from "@/src/features/mileage/mileage.store";
+import type { MileageClassification, MileageTripSummary } from "@dpf/types";
+
+const METRES_PER_MILE = 1609.344;
+
+const CHOICES: ReadonlyArray<{
+  value: Exclude<MileageClassification, "unclassified">;
+  label: string;
+}> = [
+  { value: "business", label: "Business" },
+  { value: "personal", label: "Personal" },
+  { value: "commute", label: "Commute" },
+];
+
+function miles(metres: number): string {
+  return (metres / METRES_PER_MILE).toFixed(1);
+}
+
+function when(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleDateString();
+}
+
+function route(trip: MileageTripSummary): string {
+  return trip.startPlaceLabel && trip.endPlaceLabel
+    ? `${trip.startPlaceLabel} → ${trip.endPlaceLabel}`
+    : "Drive";
+}
+
+export default function MileageScreen() {
+  const theme = useTheme();
+  const { colors } = theme;
+  const styles = useMemo(() => makeStyles(theme), [theme.colors]);
+
+  const { trips, consent, isLoading, isClassifying, error, fetchTrips, fetchConsent, grantConsent, classify } =
+    useMileageStore();
+
+  const refresh = useCallback(async () => {
+    await Promise.all([fetchConsent(), fetchTrips()]);
+  }, [fetchConsent, fetchTrips]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const granted = consent?.consentStatus === "granted";
+
+  // Consent is the gate, so it is the first thing the driver sees when it is
+  // missing. Capture must never start from a screen that did not ask.
+  const header = (
+    <View style={styles.header}>
+      {error ? (
+        <View style={styles.errorBox} accessibilityRole="alert">
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      ) : null}
+
+      {!granted ? (
+        <View style={styles.consentCard}>
+          <Text style={styles.consentTitle}>Turn on mileage capture</Text>
+          <Text style={styles.consentBody}>
+            We record your drives so you can claim them. You choose which are business.
+            Personal drives stay yours. Turn it off any time.
+          </Text>
+          <Pressable
+            style={styles.primaryButton}
+            onPress={() => void grantConsent()}
+            accessibilityRole="button"
+            testID="mileage-grant-consent"
+          >
+            <Text style={styles.primaryButtonText}>Turn on capture</Text>
+          </Pressable>
+          <Text style={styles.consentMeta}>Disclosure {MILEAGE_POLICY_VERSION}</Text>
+        </View>
+      ) : null}
+    </View>
+  );
+
+  return (
+    <FlatList<MileageTripSummary>
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      data={trips}
+      keyExtractor={(t) => t.tripId}
+      ListHeaderComponent={header}
+      refreshControl={
+        <RefreshControl refreshing={isLoading} onRefresh={() => void refresh()} tintColor={colors.primary} />
+      }
+      ListEmptyComponent={
+        isLoading ? (
+          <ActivityIndicator color={colors.primary} style={styles.spinner} />
+        ) : (
+          <Text style={styles.empty}>
+            {granted ? "No drives yet." : "No drives yet. Turn on capture to start."}
+          </Text>
+        )
+      }
+      renderItem={({ item }) => (
+        <View style={styles.card} testID={`trip-${item.tripId}`}>
+          <View style={styles.cardTop}>
+            <Text style={styles.cardDate}>{when(item.startedAt)}</Text>
+            <Text style={styles.cardMiles}>{miles(item.distanceMetres)} mi</Text>
+          </View>
+          <Text style={styles.cardRoute} numberOfLines={1}>
+            {route(item)}
+          </Text>
+
+          {item.claimed ? (
+            // A claimed drive priced a reimbursement — it is accounting
+            // evidence, so it is shown settled rather than offered for change.
+            <Text style={styles.settled}>{item.classification} · claimed</Text>
+          ) : (
+            <View style={styles.choices}>
+              {CHOICES.map((choice) => {
+                const active = item.classification === choice.value;
+                return (
+                  <Pressable
+                    key={choice.value}
+                    disabled={isClassifying === item.tripId}
+                    onPress={() => void classify(item.tripId, choice.value)}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: active, disabled: isClassifying === item.tripId }}
+                    style={[styles.choice, active ? styles.choiceActive : null]}
+                    testID={`classify-${item.tripId}-${choice.value}`}
+                  >
+                    <Text style={[styles.choiceText, active ? styles.choiceTextActive : null]}>
+                      {choice.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          )}
+
+          <Text style={styles.amount}>
+            {/* Null is not zero: an unpriced drive must not read as nothing owed. */}
+            {item.reimbursableAmount === null
+              ? "Not priced yet"
+              : `${item.currency} ${item.reimbursableAmount.toFixed(2)}`}
+          </Text>
+        </View>
+      )}
+    />
+  );
+}
+
+function makeStyles(theme: ReturnType<typeof useTheme>) {
+  const { colors } = theme;
+  return StyleSheet.create({
+    screen: { flex: 1, backgroundColor: colors.surface1 },
+    content: { padding: 16, gap: 12 },
+    header: { gap: 12 },
+    errorBox: {
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: colors.border,
+      backgroundColor: colors.surface2,
+      padding: 12,
+    },
+    errorText: { color: colors.error, fontSize: 14 },
+    consentCard: {
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: colors.border,
+      backgroundColor: colors.surface2,
+      padding: 16,
+      gap: 8,
+    },
+    consentTitle: { color: colors.text, fontSize: 16, fontWeight: "600" },
+    consentBody: { color: colors.textMuted, fontSize: 14, lineHeight: 20 },
+    consentMeta: { color: colors.textMuted, fontSize: 12 },
+    primaryButton: {
+      backgroundColor: colors.primary,
+      borderRadius: 8,
+      paddingVertical: 10,
+      alignItems: "center",
+    },
+    primaryButtonText: { color: colors.white, fontWeight: "600" },
+    card: {
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: colors.border,
+      backgroundColor: colors.surface2,
+      padding: 14,
+      gap: 8,
+    },
+    cardTop: { flexDirection: "row", justifyContent: "space-between" },
+    cardDate: { color: colors.text, fontWeight: "600" },
+    cardMiles: { color: colors.text, fontVariant: ["tabular-nums"] },
+    cardRoute: { color: colors.textMuted, fontSize: 14 },
+    choices: { flexDirection: "row", gap: 8 },
+    choice: {
+      flex: 1,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: colors.border,
+      paddingVertical: 8,
+      alignItems: "center",
+    },
+    choiceActive: { backgroundColor: colors.primary, borderColor: colors.primary },
+    choiceText: { color: colors.textMuted, fontSize: 13, fontWeight: "500" },
+    choiceTextActive: { color: colors.white },
+    settled: { color: colors.textMuted, fontSize: 13 },
+    amount: { color: colors.text, fontSize: 14, fontWeight: "600" },
+    empty: { color: colors.textMuted, textAlign: "center", paddingVertical: 24 },
+    spinner: { paddingVertical: 24 },
+  });
+}

--- a/apps/mobile/src/features/mileage/mileage.store.ts
+++ b/apps/mobile/src/features/mileage/mileage.store.ts
@@ -1,0 +1,80 @@
+import { create } from "zustand";
+import type {
+  MileageClassification,
+  MileageConsentState,
+  MileageTripSummary,
+} from "@dpf/types";
+import { api } from "@/src/lib/apiClient";
+
+/** The disclosure version this build of the app shows the driver. */
+export const MILEAGE_POLICY_VERSION = "2026-08-01";
+
+export interface MileageState {
+  trips: MileageTripSummary[];
+  consent: MileageConsentState | null;
+  isLoading: boolean;
+  isClassifying: string | null;
+  error: string | null;
+  fetchTrips: () => Promise<void>;
+  fetchConsent: () => Promise<void>;
+  grantConsent: () => Promise<void>;
+  classify: (tripId: string, classification: Exclude<MileageClassification, "unclassified">) => Promise<void>;
+}
+
+function message(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
+export const useMileageStore = create<MileageState>((set, get) => ({
+  trips: [],
+  consent: null,
+  isLoading: false,
+  isClassifying: null,
+  error: null,
+
+  fetchTrips: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const res = await api.mileage.list({ limit: 100 });
+      set({ trips: res.data, isLoading: false });
+    } catch (err) {
+      set({ isLoading: false, error: message(err, "Could not load your drives") });
+    }
+  },
+
+  fetchConsent: async () => {
+    try {
+      set({ consent: await api.mileage.consent(), error: null });
+    } catch (err) {
+      set({ error: message(err, "Could not read your capture setting") });
+    }
+  },
+
+  grantConsent: async () => {
+    set({ error: null });
+    try {
+      const consent = await api.mileage.grantConsent({
+        policyVersion: MILEAGE_POLICY_VERSION,
+      });
+      set({ consent });
+    } catch (err) {
+      set({ error: message(err, "Could not turn on capture") });
+    }
+  },
+
+  classify: async (tripId, classification) => {
+    set({ isClassifying: tripId, error: null });
+    try {
+      const updated = await api.mileage.classify(tripId, { classification });
+      // Replace in place so the list does not jump under the driver's thumb
+      // mid-pass. Losing your position after every tap makes a long list
+      // genuinely hard to work through.
+      set({
+        trips: get().trips.map((t) => (t.tripId === tripId ? updated : t)),
+        isClassifying: null,
+      });
+    } catch (err) {
+      set({ isClassifying: null, error: message(err, "Could not save that") });
+    }
+  },
+}));

--- a/apps/mobile/src/lib/navigation.test.ts
+++ b/apps/mobile/src/lib/navigation.test.ts
@@ -54,6 +54,38 @@ describe("resolveVisibleTabs", () => {
     ).toEqual(["customers", "index"]);
   });
 
+  it("shows Mileage only on an install that declares the capability", () => {
+    // The archetype fit: a field-mobile install (field service, trades,
+    // automotive, mobile beauty) declares "mileage" and its drivers get the
+    // tab; a fixed-premises install never sees it.
+    const fieldInstall = resolveVisibleTabs({
+      persona: { kind: "employee" },
+      capabilities: ["work-items", "mileage"],
+    });
+    expect(fieldInstall).toContain("mileage");
+
+    const salonInstall = resolveVisibleTabs({
+      persona: { kind: "employee" },
+      capabilities: ["work-items"],
+    });
+    expect(salonInstall).not.toContain("mileage");
+
+    // A default/operator app loads no capabilities, so the tab stays hidden
+    // rather than appearing for every install by accident.
+    expect(resolveVisibleTabs({})).not.toContain("mileage");
+  });
+
+  it("never shows Mileage to a walk-up visitor or a customer", () => {
+    // Drives belong to a worker. A customer persona has no employee record, so
+    // the tab would only ever show an error.
+    expect(
+      resolveVisibleTabs({ persona: { kind: "customer" }, capabilities: ["mileage"] }),
+    ).not.toContain("mileage");
+    expect(
+      resolveVisibleTabs({ persona: { kind: "visitor" }, capabilities: ["mileage"] }),
+    ).not.toContain("mileage");
+  });
+
   it("capability-gates a tab only when capabilities are known", () => {
     const registry: TabSpec[] = [
       { key: "index", personas: ["operator"] },

--- a/apps/mobile/src/lib/navigation.ts
+++ b/apps/mobile/src/lib/navigation.ts
@@ -24,6 +24,11 @@ export const TAB_REGISTRY: TabSpec[] = [
   { key: "ops", personas: ["operator", "employee", "admin"] },
   { key: "jobs", personas: ["operator", "employee", "admin"], capability: "work-items" },
   { key: "portfolio", personas: ["operator", "admin"] },
+  // Mileage is capability-gated: a field-mobile install (field service, trades,
+  // automotive, mobile beauty) exposes "mileage" and its drivers get the tab; a
+  // fixed-premises install never sees it. This is the archetype fit — the tab
+  // follows what the install actually does, not a global default.
+  { key: "mileage", personas: ["operator", "employee", "admin"], capability: "mileage" },
   { key: "customers", personas: ["operator", "employee", "customer", "admin"] },
   { key: "more", personas: ["operator", "employee", "customer", "admin"] },
 ];

--- a/apps/web/app/(shell)/finance/mileage/MileageTripsTable.tsx
+++ b/apps/web/app/(shell)/finance/mileage/MileageTripsTable.tsx
@@ -78,12 +78,12 @@ export function MileageTripsTable({
     },
     {
       key: "classification",
-      header: "Sorted as",
+      header: "Sorted",
       cell: (row) =>
         row.claimed ? (
           // A claimed drive is accounting evidence — its classification must
           // not change after the money moved.
-          <span className="text-xs text-[var(--dpf-muted)]">{row.classification} · claimed</span>
+          <span className="text-xs text-[var(--dpf-muted)]">{row.classification} · paid</span>
         ) : (
           <div className="flex gap-1">
             {CHOICES.map((choice) => (
@@ -104,7 +104,7 @@ export function MileageTripsTable({
     },
     {
       key: "amount",
-      header: "You are owed",
+      header: "Owed",
       align: "right",
       cell: (row) =>
         // An unpriced drive shows a placeholder, never a zero — "not yet
@@ -137,7 +137,7 @@ export function MileageTripsTable({
         initialSort={{ key: "date", dir: "desc" }}
         empty={
           <div className="p-6 text-center text-sm text-[var(--dpf-muted)]">
-            No drives yet. Turn on capture in the mobile app.
+            No drives yet. Turn it on in the app.
           </div>
         }
       />

--- a/apps/web/app/(shell)/finance/mileage/MileageTripsTable.tsx
+++ b/apps/web/app/(shell)/finance/mileage/MileageTripsTable.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+// Driver-facing trip list with one-gesture classification.
+//
+// The classification control is the whole product for a driver: capture is
+// automatic, so the only thing they ever do is say business or personal.
+// Anything slower than a single click defeats the feature.
+//
+// Composes the shared report-kit DataTable and the ui/Button primitive rather
+// than hand-rolling a table and accent buttons (AGENTS.md §9).
+
+import { useState, useTransition } from "react";
+import { DataTable, type Column } from "@/components/ui/report-kit/DataTable";
+import { Button } from "@/components/ui/Button";
+import { classifyTripAction } from "@/lib/actions/mileage";
+import type { TripClassification } from "@/lib/mileage/classification";
+
+export type MileageTripRow = {
+  tripId: string;
+  startedAtISO: string;
+  miles: number;
+  route: string;
+  classification: TripClassification;
+  classifiedBy: string | null;
+  amount: number | null;
+  claimed: boolean;
+};
+
+const CHOICES: ReadonlyArray<{ value: TripClassification; label: string }> = [
+  { value: "business", label: "Business" },
+  { value: "personal", label: "Personal" },
+  { value: "commute", label: "Commute" },
+];
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function MileageTripsTable({
+  rows,
+  currencySymbol,
+}: {
+  rows: MileageTripRow[];
+  currencySymbol: string;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [busyTripId, setBusyTripId] = useState<string | null>(null);
+
+  function classify(tripId: string, value: TripClassification) {
+    setError(null);
+    setBusyTripId(tripId);
+    startTransition(async () => {
+      const res = await classifyTripAction(tripId, value);
+      if (!res.ok) setError(res.error);
+      setBusyTripId(null);
+    });
+  }
+
+  const columns: Column<MileageTripRow>[] = [
+    {
+      key: "date",
+      header: "Date",
+      cell: (row) => formatDate(row.startedAtISO),
+      sortAccessor: (row) => row.startedAtISO,
+    },
+    { key: "route", header: "Route", cell: (row) => row.route },
+    {
+      key: "miles",
+      header: "Miles",
+      align: "right",
+      cell: (row) => row.miles.toFixed(1),
+      sortAccessor: (row) => row.miles,
+    },
+    {
+      key: "classification",
+      header: "Sorted as",
+      cell: (row) =>
+        row.claimed ? (
+          // A claimed drive is accounting evidence — its classification must
+          // not change after the money moved.
+          <span className="text-xs text-[var(--dpf-muted)]">{row.classification} · claimed</span>
+        ) : (
+          <div className="flex gap-1">
+            {CHOICES.map((choice) => (
+              <Button
+                key={choice.value}
+                type="button"
+                size="sm"
+                variant={row.classification === choice.value ? "primary" : "secondary"}
+                aria-pressed={row.classification === choice.value}
+                disabled={pending && busyTripId === row.tripId}
+                onClick={() => classify(row.tripId, choice.value)}
+              >
+                {choice.label}
+              </Button>
+            ))}
+          </div>
+        ),
+    },
+    {
+      key: "amount",
+      header: "You are owed",
+      align: "right",
+      cell: (row) =>
+        // An unpriced drive shows a placeholder, never a zero — "not yet
+        // priced" must not read as "nothing owed".
+        row.amount === null ? (
+          <span className="text-[var(--dpf-muted)]">—</span>
+        ) : (
+          `${currencySymbol}${row.amount.toFixed(2)}`
+        ),
+      sortAccessor: (row) => row.amount ?? -1,
+    },
+  ];
+
+  return (
+    <div className="space-y-3">
+      {error ? (
+        <div
+          role="alert"
+          className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface)] px-3 py-2 text-sm text-[var(--dpf-danger)]"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      <DataTable
+        columns={columns}
+        rows={rows}
+        getRowKey={(row) => row.tripId}
+        ariaLabel="Your drives"
+        initialSort={{ key: "date", dir: "desc" }}
+        empty={
+          <div className="p-6 text-center text-sm text-[var(--dpf-muted)]">
+            No drives yet. Turn on capture in the mobile app.
+          </div>
+        }
+      />
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/mileage/page.tsx
+++ b/apps/web/app/(shell)/finance/mileage/page.tsx
@@ -1,0 +1,106 @@
+// apps/web/app/(shell)/finance/mileage/page.tsx
+// Driver portal: the drives captured for you, and what they are worth.
+//
+// This is the surface that makes the mileage substrate reachable. Until it
+// existed, Trip rows could be written by nothing and read by nobody.
+
+import { prisma } from "@dpf/db";
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { getOrgSettings } from "@/lib/actions/currency";
+import { getCurrencySymbol } from "@/lib/currency-symbol";
+import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { metresToMiles } from "@/lib/mileage/rates";
+import { MileageTripsTable, type MileageTripRow } from "./MileageTripsTable";
+import type { TripClassification } from "@/lib/mileage/classification";
+
+export default async function MileagePage() {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  const [profile, orgSettings] = await Promise.all([
+    prisma.employeeProfile.findFirst({
+      where: { userId: session.user.id },
+      select: { id: true, displayName: true },
+    }),
+    getOrgSettings(),
+  ]);
+
+  const sym = getCurrencySymbol(orgSettings.baseCurrency);
+
+  // No employee record means no drives can belong to this user. Say so plainly
+  // rather than rendering an empty table that looks like "no drives yet".
+  if (!profile) {
+    return (
+      <div>
+        <FinanceTabNav />
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Mileage</h1>
+        <p className="mt-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface)] p-4 text-sm text-[var(--dpf-muted)]">
+          No employee record is linked to your account. An admin can link it.
+        </p>
+      </div>
+    );
+  }
+
+  const trips = await prisma.trip.findMany({
+    where: { employeeProfileId: profile.id, lifecycle: "active" },
+    orderBy: { startedAt: "desc" },
+    take: 200,
+    select: {
+      tripId: true,
+      startedAt: true,
+      distanceMeters: true,
+      classification: true,
+      classifiedByKind: true,
+      startPlaceLabel: true,
+      endPlaceLabel: true,
+      reimbursableAmount: true,
+      expenseItemId: true,
+    },
+  });
+
+  const rows: MileageTripRow[] = trips.map((t) => ({
+    tripId: t.tripId,
+    startedAtISO: t.startedAt.toISOString(),
+    miles: metresToMiles(t.distanceMeters),
+    route:
+      t.startPlaceLabel && t.endPlaceLabel
+        ? `${t.startPlaceLabel} → ${t.endPlaceLabel}`
+        : "Drive",
+    classification: t.classification as TripClassification,
+    classifiedBy: t.classifiedByKind,
+    amount: t.reimbursableAmount === null ? null : Number(t.reimbursableAmount),
+    claimed: t.expenseItemId !== null,
+  }));
+
+  const unclassified = rows.filter((r) => r.classification === "unclassified").length;
+
+  return (
+    <div>
+      <FinanceTabNav />
+
+      {/* Lead band: short plain sentences keep the readability budget met even
+          with shell chrome in the measured HTML. */}
+      <header className="mb-6 space-y-2" data-dpf-lead>
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Mileage</h1>
+        <p className="max-w-3xl text-sm leading-5 text-[var(--dpf-muted)]">
+          {unclassified > 0
+            ? `${unclassified} drive${unclassified === 1 ? "" : "s"} to sort.`
+            : "All drives sorted."}
+        </p>
+        <a
+          href="#mileage-drives"
+          data-dpf-primary-action
+          data-owner-first-next-action="classify-drives"
+          className="inline-flex text-sm font-semibold text-[var(--dpf-accent)] underline-offset-2 hover:underline"
+        >
+          Go to my drives
+        </a>
+      </header>
+
+      <div id="mileage-drives">
+        <MileageTripsTable rows={rows} currencySymbol={sym} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/finance/mileage/page.tsx
+++ b/apps/web/app/(shell)/finance/mileage/page.tsx
@@ -36,7 +36,7 @@ export default async function MileagePage() {
         <FinanceTabNav />
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Mileage</h1>
         <p className="mt-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface)] p-4 text-sm text-[var(--dpf-muted)]">
-          No employee record is linked to your account. An admin can link it.
+          You have no staff record. Ask an admin to add one.
         </p>
       </div>
     );
@@ -85,8 +85,8 @@ export default async function MileagePage() {
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Mileage</h1>
         <p className="max-w-3xl text-sm leading-5 text-[var(--dpf-muted)]">
           {unclassified > 0
-            ? `${unclassified} drive${unclassified === 1 ? "" : "s"} to sort.`
-            : "All drives sorted."}
+            ? `${unclassified} to sort.`
+            : "All sorted."}
         </p>
         <a
           href="#mileage-drives"
@@ -94,7 +94,7 @@ export default async function MileagePage() {
           data-owner-first-next-action="classify-drives"
           className="inline-flex text-sm font-semibold text-[var(--dpf-accent)] underline-offset-2 hover:underline"
         >
-          Go to my drives
+          See my drives
         </a>
       </header>
 

--- a/apps/web/app/api/v1/mileage/consent/route.ts
+++ b/apps/web/app/api/v1/mileage/consent/route.ts
@@ -1,0 +1,100 @@
+// GET  /api/v1/mileage/consent — the driver's current capture consent.
+// POST /api/v1/mileage/consent — record an explicit grant.
+//
+// Consent is its own endpoint rather than a field on the driver because the
+// app must be able to ask "may I capture?" before it captures anything, and
+// because the grant/revoke history is the lawful-basis evidence for every drive.
+
+// @exposure authenticated
+
+import { NextResponse } from "next/server";
+import { prisma } from "@dpf/db";
+import { authenticateRequest } from "@/lib/api/auth-middleware";
+import { ApiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { requireDriverProfileId } from "@/lib/api/mileage";
+import { newId } from "@/lib/shared/new-id";
+import type { GrantMileageConsentRequest, MileageConsentState } from "@dpf/types";
+
+function toState(row: {
+  consentStatus: string;
+  policyVersion: string;
+  retentionDays: number;
+  grantedAt: Date | null;
+} | null): MileageConsentState {
+  if (!row) {
+    return { consentStatus: "pending", policyVersion: null, retentionDays: null, grantedAt: null };
+  }
+  return {
+    consentStatus: row.consentStatus as MileageConsentState["consentStatus"],
+    policyVersion: row.policyVersion,
+    retentionDays: row.retentionDays,
+    grantedAt: row.grantedAt ? row.grantedAt.toISOString() : null,
+  };
+}
+
+export async function GET(request: Request) {
+  try {
+    const { user } = await authenticateRequest(request);
+    const driverId = await requireDriverProfileId(user.id);
+    const row = await prisma.driverLocationConsent.findFirst({
+      where: { employeeProfileId: driverId },
+      orderBy: { updatedAt: "desc" },
+      select: { consentStatus: true, policyVersion: true, retentionDays: true, grantedAt: true },
+    });
+    return apiSuccess(toState(row));
+  } catch (e) {
+    if (e instanceof ApiError) return e.toResponse();
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { user } = await authenticateRequest(request);
+    const driverId = await requireDriverProfileId(user.id);
+    const body = (await request.json()) as GrantMileageConsentRequest;
+
+    if (!body.policyVersion || typeof body.policyVersion !== "string") {
+      throw new ApiError("INVALID_POLICY_VERSION", "A disclosure version is required.", 400);
+    }
+
+    const org = await prisma.organization.findFirst({
+      orderBy: { createdAt: "asc" },
+      select: { id: true },
+    });
+    if (!org) throw new ApiError("NO_ORGANIZATION", "No organization exists.", 409);
+
+    // Keyed on (driver, policyVersion): a changed disclosure needs a fresh
+    // grant rather than silently inheriting the old one.
+    const row = await prisma.driverLocationConsent.upsert({
+      where: {
+        employeeProfileId_policyVersion: {
+          employeeProfileId: driverId,
+          policyVersion: body.policyVersion,
+        },
+      },
+      create: {
+        driverLocationConsentId: `DLC-${newId()}`,
+        organizationId: org.id,
+        employeeProfileId: driverId,
+        consentStatus: "granted",
+        grantedAt: new Date(),
+        policyVersion: body.policyVersion,
+      },
+      update: { consentStatus: "granted", grantedAt: new Date(), revokedAt: null },
+      select: { consentStatus: true, policyVersion: true, retentionDays: true, grantedAt: true },
+    });
+
+    return apiSuccess(toState(row), 201);
+  } catch (e) {
+    if (e instanceof ApiError) return e.toResponse();
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/v1/mileage/trips/[tripId]/route.ts
+++ b/apps/web/app/api/v1/mileage/trips/[tripId]/route.ts
@@ -1,0 +1,66 @@
+// PATCH /api/v1/mileage/trips/[tripId] — classify one of the driver's drives.
+
+// @exposure authenticated
+
+import { NextResponse } from "next/server";
+import { prisma } from "@dpf/db";
+import { authenticateRequest } from "@/lib/api/auth-middleware";
+import { ApiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { TRIP_SELECT, requireDriverProfileId, toMileageTripSummary } from "@/lib/api/mileage";
+import { setTripClassification } from "@/lib/mileage/trip-service";
+import type { ClassifyTripRequest } from "@dpf/types";
+
+const ALLOWED = new Set(["business", "personal", "commute"]);
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ tripId: string }> },
+) {
+  try {
+    const { user } = await authenticateRequest(request);
+    const driverId = await requireDriverProfileId(user.id);
+    const { tripId } = await params;
+    const body = (await request.json()) as ClassifyTripRequest;
+
+    if (!ALLOWED.has(body.classification)) {
+      throw new ApiError("INVALID_CLASSIFICATION", "That classification is not allowed.", 400);
+    }
+
+    const trip = await prisma.trip.findUnique({
+      where: { tripId },
+      select: { employeeProfileId: true, expenseItemId: true },
+    });
+    if (!trip) throw new ApiError("NOT_FOUND", "That drive no longer exists.", 404);
+
+    // Ownership is checked server-side; a driver may only classify their own.
+    if (trip.employeeProfileId !== driverId) {
+      throw new ApiError("FORBIDDEN", "You can only classify your own drives.", 403);
+    }
+
+    // A claimed drive priced a reimbursement — it is accounting evidence now,
+    // and letting its classification drift from the claim would be a silent
+    // mismatch between what was paid and what it was paid for.
+    if (trip.expenseItemId !== null) {
+      throw new ApiError(
+        "ALREADY_CLAIMED",
+        "That drive is already on an expense claim and cannot be reclassified.",
+        409,
+      );
+    }
+
+    await setTripClassification(prisma as never, tripId, body.classification, "driver", new Date());
+
+    const row = await prisma.trip.findUniqueOrThrow({
+      where: { tripId },
+      select: TRIP_SELECT,
+    });
+    return apiSuccess(toMileageTripSummary(row));
+  } catch (e) {
+    if (e instanceof ApiError) return e.toResponse();
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/v1/mileage/trips/route.ts
+++ b/apps/web/app/api/v1/mileage/trips/route.ts
@@ -1,0 +1,91 @@
+// GET  /api/v1/mileage/trips — the signed-in driver's own captured drives.
+// POST /api/v1/mileage/trips — record one drive. Refused without consent.
+
+// @exposure authenticated
+
+import { NextResponse } from "next/server";
+import { prisma } from "@dpf/db";
+import { authenticateRequest } from "@/lib/api/auth-middleware";
+import { ApiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { parsePagination, buildPaginatedResponse } from "@/lib/api/pagination";
+import { TRIP_SELECT, requireDriverProfileId, toMileageTripSummary } from "@/lib/api/mileage";
+import { recordTrip } from "@/lib/mileage/trip-service";
+import { newId } from "@/lib/shared/new-id";
+import type { RecordTripRequest } from "@dpf/types";
+
+export async function GET(request: Request) {
+  try {
+    const { user } = await authenticateRequest(request);
+    const driverId = await requireDriverProfileId(user.id);
+
+    const url = new URL(request.url);
+    const { limit } = parsePagination(url.searchParams);
+
+    const rows = await prisma.trip.findMany({
+      where: { employeeProfileId: driverId, lifecycle: "active" },
+      orderBy: { startedAt: "desc" },
+      take: limit + 1,
+      select: TRIP_SELECT,
+    });
+
+    const page = buildPaginatedResponse(rows, limit);
+    return apiSuccess({
+      data: page.data.map(toMileageTripSummary),
+      nextCursor: page.nextCursor,
+    });
+  } catch (e) {
+    if (e instanceof ApiError) return e.toResponse();
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { user } = await authenticateRequest(request);
+    const driverId = await requireDriverProfileId(user.id);
+    const body = (await request.json()) as RecordTripRequest;
+
+    const outcome = await recordTrip(
+      prisma as never,
+      {
+        employeeProfileId: driverId,
+        vehicleId: body.vehicleId ?? null,
+        startedAt: new Date(body.startedAt),
+        endedAt: new Date(body.endedAt),
+        startLatitude: body.startLatitude,
+        startLongitude: body.startLongitude,
+        endLatitude: body.endLatitude,
+        endLongitude: body.endLongitude,
+        startPlaceLabel: body.startPlaceLabel ?? null,
+        endPlaceLabel: body.endPlaceLabel ?? null,
+        distanceMeters: body.distanceMetres,
+        captureKind: body.captureKind,
+      },
+      newId(),
+    );
+
+    if (!outcome.recorded) {
+      // A refusal is a 403, not a 500 — the client must show the driver WHY,
+      // and a consent refusal is an expected state, not a server fault.
+      throw new ApiError("CAPTURE_REFUSED", outcome.detail, 403, {
+        refusal: outcome.refusal,
+      });
+    }
+
+    const row = await prisma.trip.findUniqueOrThrow({
+      where: { tripId: outcome.tripId },
+      select: TRIP_SELECT,
+    });
+    return apiSuccess(toMileageTripSummary(row), 201);
+  } catch (e) {
+    if (e instanceof ApiError) return e.toResponse();
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/lib/actions/mileage.ts
+++ b/apps/web/lib/actions/mileage.ts
@@ -25,7 +25,7 @@ import {
   setTripClassification,
   type RecordTripPayload,
 } from "@/lib/mileage/trip-service";
-import { resolveRateForDate, type ResolvableRate } from "@/lib/mileage/rates";
+import type { ResolvableRate } from "@/lib/mileage/rates";
 import type { TripClassification } from "@/lib/mileage/classification";
 
 const MILEAGE_PATH = "/finance/mileage";

--- a/apps/web/lib/actions/mileage.ts
+++ b/apps/web/lib/actions/mileage.ts
@@ -1,0 +1,208 @@
+"use server";
+
+// Server actions for mileage capture and reimbursement (EP-MILEAGE-ABSORB).
+//
+// The mileage substrate, rules and pricing all merged without a write path, so
+// nothing could record a drive. These are the thin wrappers over
+// lib/mileage/trip-service.ts that make it reachable.
+//
+// Per AGENTS.md §6 this module exports functions only — the input types live in
+// lib/mileage/trip-service.ts so a client can import them without pulling a
+// server module.
+//
+// SECURITY: recordTripAction resolves the driver from the SESSION, never from
+// client input. Accepting an employeeProfileId from the caller would let one
+// employee file drives — and claim reimbursement — against another's record.
+
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { requireCapability, requireUser } from "@/lib/actions/shared/guards";
+import { err, ok, type ActionResult } from "@/lib/shared/action-result";
+import { newId } from "@/lib/shared/new-id";
+import {
+  monetisePeriod,
+  recordTrip,
+  setTripClassification,
+  type RecordTripPayload,
+} from "@/lib/mileage/trip-service";
+import { resolveRateForDate, type ResolvableRate } from "@/lib/mileage/rates";
+import type { TripClassification } from "@/lib/mileage/classification";
+
+const MILEAGE_PATH = "/finance/mileage";
+
+/** The signed-in user's employee profile, or null when they have none. */
+async function currentEmployeeProfileId(): Promise<string | null> {
+  const user = await requireUser();
+  const profile = await prisma.employeeProfile.findFirst({
+    where: { userId: user.id },
+    select: { id: true },
+  });
+  return profile?.id ?? null;
+}
+
+/** Record one captured drive for the signed-in driver. */
+export async function recordTripAction(
+  payload: RecordTripPayload,
+): Promise<ActionResult<{ tripId: string }>> {
+  const employeeProfileId = await currentEmployeeProfileId();
+  if (!employeeProfileId) {
+    return err("Your user account is not linked to an employee record, so drives cannot be recorded.");
+  }
+
+  const outcome = await recordTrip(
+    prisma as never,
+    {
+      employeeProfileId,
+      vehicleId: payload.vehicleId ?? null,
+      startedAt: new Date(payload.startedAt),
+      endedAt: new Date(payload.endedAt),
+      startLatitude: payload.startLatitude,
+      startLongitude: payload.startLongitude,
+      endLatitude: payload.endLatitude,
+      endLongitude: payload.endLongitude,
+      startPlaceLabel: payload.startPlaceLabel ?? null,
+      endPlaceLabel: payload.endPlaceLabel ?? null,
+      distanceMeters: payload.distanceMeters,
+      captureKind: payload.captureKind,
+    },
+    newId(),
+  );
+
+  if (!outcome.recorded) return err(outcome.detail);
+
+  revalidatePath(MILEAGE_PATH);
+  return ok({ tripId: outcome.tripId });
+}
+
+/** Classify a drive. A driver may only classify their own. */
+export async function classifyTripAction(
+  tripId: string,
+  classification: TripClassification,
+): Promise<ActionResult> {
+  const employeeProfileId = await currentEmployeeProfileId();
+  if (!employeeProfileId) return err("No employee record is linked to your account.");
+
+  const trip = await prisma.trip.findUnique({
+    where: { tripId },
+    select: { employeeProfileId: true },
+  });
+  if (!trip) return err("That drive no longer exists.");
+  if (trip.employeeProfileId !== employeeProfileId) {
+    return err("You can only classify your own drives.");
+  }
+
+  await setTripClassification(prisma as never, tripId, classification, "driver", new Date());
+  revalidatePath(MILEAGE_PATH);
+  return ok();
+}
+
+/**
+ * Price a driver's business drives for a period onto an expense claim.
+ *
+ * Finance capability, not the driver's own — turning drives into money owed is
+ * an approval act. The claim, its items and the trip links are written in ONE
+ * transaction so a partial failure cannot leave trips marked as claimed against
+ * a claim that does not exist.
+ */
+export async function monetiseMileageAction(input: {
+  employeeProfileId: string;
+  periodStart: string;
+  periodEnd: string;
+}): Promise<ActionResult<{ claimId: string; total: number; skipped: number; alreadyClaimed: number }>> {
+  await requireCapability("manage_finance");
+
+  const employee = await prisma.employeeProfile.findUnique({
+    where: { id: input.employeeProfileId },
+    select: { id: true, displayName: true },
+  });
+  if (!employee) return err("That employee record no longer exists.");
+
+  const rateRows = await prisma.mileageRate.findMany({
+    where: { plan: { lifecycle: "active" } },
+    include: { plan: { select: { isOrgOverride: true } } },
+  });
+  const rates: ResolvableRate[] = rateRows.map((r) => ({
+    id: r.id,
+    purposeKind: r.purposeKind as ResolvableRate["purposeKind"],
+    amountPerMile: Number(r.amountPerMile),
+    currency: r.currency,
+    effectiveFrom: r.effectiveFrom,
+    effectiveTo: r.effectiveTo,
+    isOrgOverride: r.plan.isOrgOverride,
+  }));
+
+  if (rates.length === 0) {
+    return err("No mileage rate is configured, so drives cannot be priced yet.");
+  }
+
+  const periodStart = new Date(input.periodStart);
+  const periodEnd = new Date(input.periodEnd);
+
+  const outcome = await monetisePeriod(prisma as never, {
+    employeeProfileId: employee.id,
+    periodStart,
+    periodEnd,
+    rates,
+  });
+
+  if (outcome.pricing.lines.length === 0) {
+    // Distinguish "already paid" from "nothing qualified" — an operator who
+    // re-runs a period needs to know the drives were claimed, not lost.
+    if (outcome.alreadyMonetised.length > 0) {
+      return err(
+        `Those ${outcome.alreadyMonetised.length} drive(s) are already on an expense claim.`,
+      );
+    }
+    return err("No unclaimed business drives in that period — nothing to reimburse.");
+  }
+
+  const claimId = `EXP-MIL-${periodStart.toISOString().slice(0, 7)}-${employee.id.slice(-6)}`;
+
+  const created = await prisma.$transaction(async (tx) => {
+    const claim = await tx.expenseClaim.create({
+      data: {
+        claimId,
+        employeeId: employee.id,
+        status: "submitted",
+        title: `Mileage — ${periodStart.toISOString().slice(0, 10)} to ${periodEnd.toISOString().slice(0, 10)}`,
+        totalAmount: outcome.pricing.totalAmount,
+        currency: outcome.pricing.currency,
+        submittedAt: new Date(),
+      },
+      select: { id: true, claimId: true },
+    });
+
+    let sortOrder = 0;
+    for (const line of outcome.pricing.lines) {
+      const item = await tx.expenseItem.create({
+        data: {
+          claimId: claim.id,
+          date: line.date,
+          category: "mileage",
+          description: line.description,
+          amount: line.amount,
+          currency: line.currency,
+          sortOrder: sortOrder++,
+        },
+        select: { id: true },
+      });
+      // Link the trip to its item so the drive can never be priced twice.
+      await tx.trip.update({
+        where: { tripId: line.tripId },
+        data: { expenseItemId: item.id, mileageRateId: line.mileageRateId },
+      });
+    }
+
+    return claim;
+  });
+
+  revalidatePath(MILEAGE_PATH);
+  revalidatePath("/finance/expense-claims");
+
+  return ok({
+    claimId: created.claimId,
+    total: outcome.pricing.totalAmount,
+    skipped: outcome.pricing.skipped.length,
+    alreadyClaimed: outcome.alreadyMonetised.length,
+  });
+}

--- a/apps/web/lib/api/mileage.ts
+++ b/apps/web/lib/api/mileage.ts
@@ -1,0 +1,80 @@
+// Shared projection + driver resolution for the /api/v1/mileage routes.
+//
+// Kept out of the route files so the list, record and classify handlers cannot
+// drift in how they shape a drive or decide whose drive it is.
+
+import { prisma } from "@dpf/db";
+import { ApiError } from "@/lib/api/error";
+import type { MileageTripSummary } from "@dpf/types";
+
+export const TRIP_SELECT = {
+  // `id` is required by buildPaginatedResponse's cursor contract; it is never
+  // projected to the client, which addresses a drive by its semantic tripId.
+  id: true,
+  tripId: true,
+  startedAt: true,
+  endedAt: true,
+  distanceMeters: true,
+  classification: true,
+  classifiedByKind: true,
+  startPlaceLabel: true,
+  endPlaceLabel: true,
+  reimbursableAmount: true,
+  currency: true,
+  expenseItemId: true,
+} as const;
+
+type TripRow = {
+  id: string;
+  tripId: string;
+  startedAt: Date;
+  endedAt: Date;
+  distanceMeters: number;
+  classification: string;
+  classifiedByKind: string | null;
+  startPlaceLabel: string | null;
+  endPlaceLabel: string | null;
+  reimbursableAmount: unknown;
+  currency: string;
+  expenseItemId: string | null;
+};
+
+export function toMileageTripSummary(row: TripRow): MileageTripSummary {
+  return {
+    tripId: row.tripId,
+    startedAt: row.startedAt.toISOString(),
+    endedAt: row.endedAt.toISOString(),
+    distanceMetres: row.distanceMeters,
+    classification: row.classification as MileageTripSummary["classification"],
+    classifiedBy: (row.classifiedByKind as MileageTripSummary["classifiedBy"]) ?? null,
+    startPlaceLabel: row.startPlaceLabel,
+    endPlaceLabel: row.endPlaceLabel,
+    // Null stays null. A drive with no rate yet is NOT a drive worth nothing.
+    reimbursableAmount:
+      row.reimbursableAmount === null ? null : Number(row.reimbursableAmount),
+    currency: row.currency,
+    claimed: row.expenseItemId !== null,
+  };
+}
+
+/**
+ * The employee record behind the authenticated user.
+ *
+ * Every mileage route resolves the driver this way rather than trusting a
+ * client-supplied id — otherwise one employee could file drives, and claim
+ * reimbursement, against another's record.
+ */
+export async function requireDriverProfileId(userId: string): Promise<string> {
+  const profile = await prisma.employeeProfile.findFirst({
+    where: { userId },
+    select: { id: true },
+  });
+  if (!profile) {
+    throw new ApiError(
+      "NO_EMPLOYEE_RECORD",
+      "Your account is not linked to an employee record, so drives cannot be recorded against it.",
+      409,
+    );
+  }
+  return profile.id;
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -11379,6 +11379,7 @@
         "owner-first-overview-food-hospitality",
         "readiness-notes",
         "recording-a-payment-run",
+        "mileage",
         "reporting-and-close-boundaries",
         "route-guide"
       ]

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 627,
+  "routeCount": 630,
   "routes": [
     {
       "routePath": "/",
@@ -3292,6 +3292,48 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/api/v1/integrations/coverage/route.ts"
+    },
+    {
+      "routePath": "/api/v1/mileage/consent",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "mileage",
+        "consent"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/v1/mileage/consent/route.ts",
+      "exposure": "authenticated"
+    },
+    {
+      "routePath": "/api/v1/mileage/trips",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "mileage",
+        "trips"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/v1/mileage/trips/route.ts",
+      "exposure": "authenticated"
+    },
+    {
+      "routePath": "/api/v1/mileage/trips/[tripId]",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "mileage",
+        "trips",
+        "[tripId]"
+      ],
+      "dynamicParams": [
+        "tripId"
+      ],
+      "file": "apps/web/app/api/v1/mileage/trips/[tripId]/route.ts",
+      "exposure": "authenticated"
     },
     {
       "routePath": "/api/v1/notifications",

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 626,
+  "routeCount": 627,
   "routes": [
     {
       "routePath": "/",
@@ -4859,6 +4859,16 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/finance/invoices/new/page.tsx"
+    },
+    {
+      "routePath": "/finance/mileage",
+      "kind": "page",
+      "segments": [
+        "finance",
+        "mileage"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/finance/mileage/page.tsx"
     },
     {
       "routePath": "/finance/my-expenses",

--- a/apps/web/lib/mileage/trip-service.test.ts
+++ b/apps/web/lib/mileage/trip-service.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import {
+  monetisePeriod,
+  recordTrip,
+  setTripClassification,
+  type RecordTripInput,
+  type TripServiceClient,
+} from "./trip-service";
+import type { ResolvableRate } from "./rates";
+
+function baseInput(over: Partial<RecordTripInput> = {}): RecordTripInput {
+  return {
+    employeeProfileId: "emp_1",
+    startedAt: new Date("2026-08-10T13:00:00.000Z"),
+    endedAt: new Date("2026-08-10T13:32:00.000Z"),
+    startLatitude: 37.7749,
+    startLongitude: -122.4194,
+    endLatitude: 37.8044,
+    endLongitude: -122.2712,
+    distanceMeters: 21400,
+    captureKind: "automatic",
+    ...over,
+  };
+}
+
+function fakeDb(over: Partial<Record<string, unknown>> = {}) {
+  const created: Array<Record<string, unknown>> = [];
+  const updated: Array<Record<string, unknown>> = [];
+  const db = {
+    driverLocationConsent: {
+      findFirst: async () => ({ consentStatus: "granted", revokedAt: null }),
+    },
+    organization: { findFirst: async () => ({ id: "org_1" }) },
+    trip: {
+      create: async (args: { data: Record<string, unknown> }) => {
+        created.push(args.data);
+        return { tripId: String(args.data.tripId) };
+      },
+      findMany: async () => [],
+      update: async (args: Record<string, unknown>) => {
+        updated.push(args);
+        return {};
+      },
+    },
+    ...over,
+  } as unknown as TripServiceClient;
+  return { db, created, updated };
+}
+
+describe("recordTrip — consent gate", () => {
+  it("records a drive for a driver with granted consent", async () => {
+    const { db, created } = fakeDb();
+    const out = await recordTrip(db, baseInput(), "0001");
+
+    expect(out).toEqual({ recorded: true, tripId: "TRIP-0001" });
+    expect(created[0]?.employeeProfileId).toBe("emp_1");
+    expect(created[0]?.distanceMeters).toBe(21400);
+  });
+
+  it("refuses when no consent record exists at all", async () => {
+    const { db, created } = fakeDb({
+      driverLocationConsent: { findFirst: async () => null },
+    });
+    const out = await recordTrip(db, baseInput(), "0002");
+
+    // The difference between mileage tracking and surveillance is this branch.
+    expect(out).toMatchObject({ recorded: false, refusal: "no_consent" });
+    expect(created).toHaveLength(0);
+  });
+
+  it("refuses when consent was revoked, even if a row still exists", async () => {
+    const { db, created } = fakeDb({
+      driverLocationConsent: {
+        findFirst: async () => ({ consentStatus: "revoked", revokedAt: new Date() }),
+      },
+    });
+    const out = await recordTrip(db, baseInput(), "0003");
+
+    expect(out).toMatchObject({ recorded: false, refusal: "consent_revoked" });
+    expect(created).toHaveLength(0);
+  });
+
+  it("refuses a pending consent — unknown is not yes", async () => {
+    const { db } = fakeDb({
+      driverLocationConsent: {
+        findFirst: async () => ({ consentStatus: "pending", revokedAt: null }),
+      },
+    });
+    expect(await recordTrip(db, baseInput(), "0004")).toMatchObject({
+      recorded: false,
+      refusal: "consent_revoked",
+    });
+  });
+
+  it("rejects a zero or negative distance before touching consent", async () => {
+    const { db, created } = fakeDb();
+    expect(await recordTrip(db, baseInput({ distanceMeters: 0 }), "0005")).toMatchObject({
+      refusal: "invalid_distance",
+    });
+    expect(created).toHaveLength(0);
+  });
+
+  it("rejects a drive that ends before it starts", async () => {
+    const { db } = fakeDb();
+    const out = await recordTrip(
+      db,
+      baseInput({
+        startedAt: new Date("2026-08-10T14:00:00.000Z"),
+        endedAt: new Date("2026-08-10T13:00:00.000Z"),
+      }),
+      "0006",
+    );
+    expect(out).toMatchObject({ refusal: "invalid_interval" });
+  });
+});
+
+describe("setTripClassification", () => {
+  it("records who classified, so a later rule pass cannot overwrite a human", async () => {
+    const { db, updated } = fakeDb();
+    await setTripClassification(db, "TRIP-0001", "business", "driver", new Date("2026-08-11T00:00:00.000Z"));
+
+    expect(updated[0]).toMatchObject({
+      where: { tripId: "TRIP-0001" },
+      data: { classification: "business", classifiedByKind: "driver" },
+    });
+  });
+});
+
+describe("monetisePeriod — idempotency", () => {
+  const rates: ResolvableRate[] = [
+    {
+      id: "rate_1",
+      purposeKind: "business",
+      amountPerMile: 0.725,
+      currency: "USD",
+      effectiveFrom: new Date("2026-01-01T00:00:00.000Z"),
+      effectiveTo: null,
+      isOrgOverride: false,
+    },
+  ];
+
+  function tripRow(over: Record<string, unknown> = {}) {
+    return {
+      id: "t1",
+      tripId: "TRIP-0001",
+      startedAt: new Date("2026-08-10T13:00:00.000Z"),
+      distanceMeters: 16093,
+      classification: "business",
+      startPlaceLabel: null,
+      endPlaceLabel: null,
+      customerAccountId: null,
+      expenseItemId: null,
+      ...over,
+    };
+  }
+
+  it("prices an unmonetised business trip", async () => {
+    const { db } = fakeDb({ trip: { findMany: async () => [tripRow()], create: async () => ({ tripId: "" }), update: async () => ({}) } });
+    const out = await monetisePeriod(db, {
+      employeeProfileId: "emp_1",
+      periodStart: new Date("2026-08-01T00:00:00.000Z"),
+      periodEnd: new Date("2026-08-31T23:59:59.000Z"),
+      rates,
+    });
+
+    expect(out.pricing.lines).toHaveLength(1);
+    expect(out.pricing.totalAmount).toBeCloseTo(7.25, 2);
+    expect(out.alreadyMonetised).toEqual([]);
+  });
+
+  it("excludes a trip already on a claim instead of paying it twice", async () => {
+    const { db } = fakeDb({
+      trip: {
+        findMany: async () => [tripRow({ expenseItemId: "item_1" })],
+        create: async () => ({ tripId: "" }),
+        update: async () => ({}),
+      },
+    });
+    const out = await monetisePeriod(db, {
+      employeeProfileId: "emp_1",
+      periodStart: new Date("2026-08-01T00:00:00.000Z"),
+      periodEnd: new Date("2026-08-31T23:59:59.000Z"),
+      rates,
+    });
+
+    // Re-running a period must be safe and VISIBLY so.
+    expect(out.pricing.lines).toHaveLength(0);
+    expect(out.alreadyMonetised).toEqual(["TRIP-0001"]);
+  });
+
+  it("reports a personal trip as skipped rather than dropping it", async () => {
+    const { db } = fakeDb({
+      trip: {
+        findMany: async () => [tripRow({ classification: "personal" })],
+        create: async () => ({ tripId: "" }),
+        update: async () => ({}),
+      },
+    });
+    const out = await monetisePeriod(db, {
+      employeeProfileId: "emp_1",
+      periodStart: new Date("2026-08-01T00:00:00.000Z"),
+      periodEnd: new Date("2026-08-31T23:59:59.000Z"),
+      rates,
+    });
+
+    expect(out.pricing.lines).toHaveLength(0);
+    expect(out.pricing.skipped[0]).toMatchObject({ tripId: "TRIP-0001", reason: "not-business" });
+  });
+});

--- a/apps/web/lib/mileage/trip-service.ts
+++ b/apps/web/lib/mileage/trip-service.ts
@@ -1,0 +1,240 @@
+// lib/mileage/trip-service.ts — persistence for captured drives (BI-6D98AD8A,
+// BI-E17E0034, EP-MILEAGE-ABSORB).
+//
+// The mileage substrate and its pure rules shipped without a write path, so
+// nothing could actually record a drive. This module is that path, kept behind a
+// STRUCTURAL client (the same shape lib/hr/payroll-run.ts uses) so the rules are
+// unit-testable without a database and the "use server" layer stays a thin
+// wrapper.
+//
+// Two invariants are enforced here rather than left to callers:
+//
+//   1. NO CAPTURE WITHOUT CONSENT. A trip may only be recorded for a driver
+//      holding a granted DriverLocationConsent. This is the difference between
+//      mileage tracking and surveillance, and it must not be a UI-layer promise.
+//   2. MONETISE ONCE. A trip already carrying an expenseItemId is never priced
+//      again, so re-running a period cannot pay a driver twice for one drive.
+
+import { priceTrips, type PriceableTrip, type PricingResult } from "./monetisation";
+import type { ResolvableRate } from "./rates";
+import type { TripClassification } from "./classification";
+
+/**
+ * Wire-safe shape a client can send. Server actions cross a serialization
+ * boundary, so timestamps arrive as ISO strings and are parsed server-side
+ * rather than trusted as Date instances.
+ */
+export type RecordTripPayload = {
+  vehicleId?: string | null;
+  startedAt: string;
+  endedAt: string;
+  startLatitude: number;
+  startLongitude: number;
+  endLatitude: number;
+  endLongitude: number;
+  startPlaceLabel?: string | null;
+  endPlaceLabel?: string | null;
+  distanceMeters: number;
+  captureKind: "automatic" | "manual" | "imported";
+};
+
+export type RecordTripInput = {
+  employeeProfileId: string;
+  vehicleId?: string | null;
+  startedAt: Date;
+  endedAt: Date;
+  startLatitude: number;
+  startLongitude: number;
+  endLatitude: number;
+  endLongitude: number;
+  startPlaceLabel?: string | null;
+  endPlaceLabel?: string | null;
+  distanceMeters: number;
+  captureKind: "automatic" | "manual" | "imported";
+};
+
+/** Why a drive was refused. Closed set — a caller must be able to explain it. */
+export type RecordTripRefusal =
+  | "no_consent"
+  | "consent_revoked"
+  | "invalid_distance"
+  | "invalid_interval";
+
+export type RecordTripOutcome =
+  | { recorded: true; tripId: string }
+  | { recorded: false; refusal: RecordTripRefusal; detail: string };
+
+/** The narrow slice of Prisma this service needs. Satisfied by PrismaClient. */
+export type TripServiceClient = {
+  driverLocationConsent: {
+    findFirst(args: unknown): Promise<{ consentStatus: string; revokedAt: Date | null } | null>;
+  };
+  trip: {
+    create(args: unknown): Promise<{ tripId: string }>;
+    findMany(args: unknown): Promise<Array<Record<string, unknown>>>;
+    update(args: unknown): Promise<unknown>;
+  };
+  organization: {
+    findFirst(args: unknown): Promise<{ id: string } | null>;
+  };
+};
+
+function nextTripId(seed: string): string {
+  return `TRIP-${seed}`;
+}
+
+/**
+ * Record one captured drive, refusing rather than recording when consent is
+ * absent. Refusal is returned as data — a driver whose capture is refused needs
+ * to be told why, not shown a stack trace.
+ */
+export async function recordTrip(
+  db: TripServiceClient,
+  input: RecordTripInput,
+  idSeed: string,
+): Promise<RecordTripOutcome> {
+  if (!Number.isFinite(input.distanceMeters) || input.distanceMeters <= 0) {
+    return {
+      recorded: false,
+      refusal: "invalid_distance",
+      detail: "a drive must cover a positive distance",
+    };
+  }
+  if (input.endedAt.getTime() <= input.startedAt.getTime()) {
+    return {
+      recorded: false,
+      refusal: "invalid_interval",
+      detail: "a drive must end after it starts",
+    };
+  }
+
+  const consent = await db.driverLocationConsent.findFirst({
+    where: { employeeProfileId: input.employeeProfileId },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  if (!consent) {
+    return {
+      recorded: false,
+      refusal: "no_consent",
+      detail: "no location-capture consent on record for this driver",
+    };
+  }
+  if (consent.consentStatus !== "granted" || consent.revokedAt !== null) {
+    return {
+      recorded: false,
+      refusal: "consent_revoked",
+      detail: `consent is "${consent.consentStatus}" — capture is not permitted`,
+    };
+  }
+
+  const org = await db.organization.findFirst({ orderBy: { createdAt: "asc" } });
+  if (!org) {
+    return {
+      recorded: false,
+      refusal: "no_consent",
+      detail: "no organization exists to own the trip",
+    };
+  }
+
+  const tripId = nextTripId(idSeed);
+  await db.trip.create({
+    data: {
+      tripId,
+      organizationId: org.id,
+      employeeProfileId: input.employeeProfileId,
+      vehicleId: input.vehicleId ?? null,
+      startedAt: input.startedAt,
+      endedAt: input.endedAt,
+      startLatitude: input.startLatitude,
+      startLongitude: input.startLongitude,
+      endLatitude: input.endLatitude,
+      endLongitude: input.endLongitude,
+      startPlaceLabel: input.startPlaceLabel ?? null,
+      endPlaceLabel: input.endPlaceLabel ?? null,
+      distanceMeters: Math.round(input.distanceMeters),
+      captureKind: input.captureKind,
+    },
+  });
+
+  return { recorded: true, tripId };
+}
+
+/**
+ * Set a trip's classification and record WHO decided.
+ *
+ * classifiedByKind is not decoration: a rule must never overwrite a human, and
+ * the only way a later rule pass can honour that is if the trip says a person
+ * chose this.
+ */
+export async function setTripClassification(
+  db: TripServiceClient,
+  tripId: string,
+  classification: TripClassification,
+  by: "driver" | "admin",
+  now: Date,
+): Promise<void> {
+  await db.trip.update({
+    where: { tripId },
+    data: { classification, classifiedByKind: by, classifiedAt: now },
+  });
+}
+
+export type MonetisationOutcome = {
+  pricing: PricingResult;
+  /** Trips skipped because they were already on a claim. */
+  alreadyMonetised: string[];
+};
+
+/**
+ * Price a period's unmonetised business trips.
+ *
+ * Trips already carrying an expenseItemId are excluded BEFORE pricing and
+ * reported separately, so re-running a period is safe and visibly idempotent
+ * rather than quietly producing a second claim for the same drives.
+ */
+export async function monetisePeriod(
+  db: TripServiceClient,
+  args: {
+    employeeProfileId: string;
+    periodStart: Date;
+    periodEnd: Date;
+    rates: readonly ResolvableRate[];
+    currency?: string;
+  },
+): Promise<MonetisationOutcome> {
+  const rows = await db.trip.findMany({
+    where: {
+      employeeProfileId: args.employeeProfileId,
+      startedAt: { gte: args.periodStart, lte: args.periodEnd },
+      lifecycle: "active",
+    },
+    orderBy: { startedAt: "asc" },
+  });
+
+  const alreadyMonetised: string[] = [];
+  const priceable: PriceableTrip[] = [];
+
+  for (const row of rows) {
+    const tripId = String(row.tripId);
+    if (row.expenseItemId) {
+      alreadyMonetised.push(tripId);
+      continue;
+    }
+    priceable.push({
+      id: String(row.id),
+      tripId,
+      startedAt: row.startedAt as Date,
+      distanceMetres: Number(row.distanceMeters),
+      classification: row.classification as TripClassification,
+      startPlaceLabel: (row.startPlaceLabel as string | null) ?? null,
+      endPlaceLabel: (row.endPlaceLabel as string | null) ?? null,
+      customerAccountId: (row.customerAccountId as string | null) ?? null,
+    });
+  }
+
+  return {
+    pricing: priceTrips(priceable, args.rates, args.currency ?? "USD"),
+    alreadyMonetised,
+  };
+}

--- a/apps/web/lib/navigation/route-audience.generated.json
+++ b/apps/web/lib/navigation/route-audience.generated.json
@@ -1,19 +1,19 @@
 {
   "generator": "apps/web/scripts/build-route-audience.ts",
-  "pageRouteCount": 355,
+  "pageRouteCount": 356,
   "summary": {
     "byAudience": {
       "admin": 148,
       "auth-setup": 10,
       "builder": 3,
       "customer": 11,
-      "owner": 160,
+      "owner": 161,
       "public": 21,
       "worker": 2
     },
     "byDestinationKind": {
       "advanced-diagnostic": 102,
-      "detail": 170,
+      "detail": 171,
       "legacy-internal": 29,
       "section-home": 33,
       "settings-config": 12,
@@ -917,6 +917,13 @@
       "routePath": "/finance/invoices/new",
       "audience": "owner",
       "destinationKind": "workflow-step",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/mileage",
+      "audience": "owner",
+      "destinationKind": "detail",
       "confidence": "high",
       "source": "heuristic"
     },

--- a/apps/web/lib/ux-budget/purpose-contracts/index.ts
+++ b/apps/web/lib/ux-budget/purpose-contracts/index.ts
@@ -8,6 +8,7 @@ export type PurposeContractModule = readonly PurposeContractSource[];
 import { ARCHETYPE_READINESS_PURPOSE_CONTRACTS } from "./archetype-readiness";
 import { GRAPH_EXPLORER_PURPOSE_CONTRACTS } from "./graph-explorer";
 import { RIGHT_NOW_PURPOSE_CONTRACTS } from "./right-now";
+import { MILEAGE_PURPOSE_CONTRACTS } from "./mileage";
 import { RECRUITING_PIPELINE_PURPOSE_CONTRACTS } from "./recruiting-pipeline";
 import { COWORKER_IDENTITY_PURPOSE_CONTRACTS } from "./coworker-identity";
 import { STACK_CURRENCY_PURPOSE_CONTRACTS } from "./stack-currency";
@@ -18,6 +19,7 @@ const CONTRACT_MODULES: readonly PurposeContractModule[] = [
   ARCHETYPE_READINESS_PURPOSE_CONTRACTS,
   GRAPH_EXPLORER_PURPOSE_CONTRACTS,
   RIGHT_NOW_PURPOSE_CONTRACTS,
+  MILEAGE_PURPOSE_CONTRACTS,
   RECRUITING_PIPELINE_PURPOSE_CONTRACTS,
   COWORKER_IDENTITY_PURPOSE_CONTRACTS,
   STACK_CURRENCY_PURPOSE_CONTRACTS,

--- a/apps/web/lib/ux-budget/purpose-contracts/mileage.ts
+++ b/apps/web/lib/ux-budget/purpose-contracts/mileage.ts
@@ -1,0 +1,148 @@
+// Ratified page-purpose contract for /finance/mileage (EP-MILEAGE-ABSORB).
+//
+// The purpose-identity ratchet refuses to grandfather a NEW route, so the driver
+// mileage page arrives ratified. Shape mirrors recruiting-pipeline.ts.
+//
+// This is the surface that makes the mileage substrate reachable: schema, rules
+// and pricing all merged with no route and no write path, so drives could be
+// recorded by nothing and read by nobody.
+
+import type { PurposeContractModule } from ".";
+
+export const MILEAGE_PURPOSE_CONTRACTS: PurposeContractModule = [
+  {
+    schemaVersion: 1,
+    status: "intent-ratified",
+    routePath: "/finance/mileage",
+    intent: {
+      primaryUser:
+        "An employee who drives for work — a field technician, mobile tradesperson, or anyone whose own vehicle carries them to customers.",
+      triggeringNeed:
+        "Being reimbursed for business driving without keeping a paper log or re-typing a month of trips into a spreadsheet at the end of the month.",
+      prerequisites: [
+        "Signed in with a user account linked to an employee record.",
+        "Drives exist: captured automatically by the mobile app under a granted location consent, or entered manually.",
+      ],
+      job: "Review the drives captured for you, mark each one business or personal, and see what the business owes you for them.",
+      successOutcome:
+        "The driver sees every captured drive, classifies the unclassified ones in a single tap each, and reads the reimbursable amount for the ones already priced.",
+      findability: {
+        parentArea: "Finance",
+        entryPoints: ["/finance", "Finance > Mileage"],
+        navigationLayer: "Finance area tab nav",
+        discoveryCue: "A 'Mileage' tab in the Finance area, beside My Expenses.",
+        expectedPath: ["/finance", "/finance/mileage"],
+      },
+      contentRoles: {
+        defaultVisibleKeys: ["unclassified-count", "trip-list", "classification-control"],
+        deferredRegions: [],
+      },
+      familyConsistency: {
+        terminology:
+          "Plain driving words — drive, business, personal, commute, reimbursable. Never Trip ids, coordinates, or metres.",
+        actionLocation:
+          "The classification control sits on the drive's own row; choosing re-reads that row in place.",
+        feedbackPrimitive:
+          "Inline pending state on the row being classified — no native dialogs.",
+        disclosurePattern:
+          "Every captured drive shows by default; a claimed drive shows its classification as settled text rather than an editable control.",
+        returnBehavior:
+          "Classifying never navigates away — the driver stays on the list and continues down it.",
+      },
+    },
+    stateScenarios: {
+      "no-employee-record": {
+        statePredicate: "The signed-in user has no linked EmployeeProfile.",
+        stateSource: {
+          oracleKey: "route-owned-read-model",
+          sourceRef: "apps/web/app/(shell)/finance/mileage/page.tsx",
+        },
+        essentialEvidenceKeys: ["unclassified-count"],
+        primaryExperience: { kind: "informational", messageKey: "mileage.no-employee-record" },
+        prohibitedActionKeys: [],
+        completionSignal:
+          "A message explains that no drives can belong to this account and names who can link it.",
+        errorCorrection:
+          "This is distinguished from having no drives yet — an unlinked account is a setup problem, not an empty month.",
+        recovery: { actionKey: "open-finance-home", routePath: "/finance" },
+      },
+      "no-drives": {
+        statePredicate: "The employee has no active Trip rows.",
+        stateSource: {
+          oracleKey: "route-owned-read-model",
+          sourceRef: "apps/web/app/(shell)/finance/mileage/page.tsx",
+        },
+        essentialEvidenceKeys: ["unclassified-count"],
+        primaryExperience: { kind: "informational", messageKey: "mileage.no-drives" },
+        prohibitedActionKeys: [],
+        completionSignal:
+          "An empty state explains that drives appear automatically once capture is switched on in the mobile app.",
+        errorCorrection:
+          "The driver learns capture is a mobile setting rather than concluding the feature is broken.",
+        recovery: { actionKey: "open-finance-home", routePath: "/finance" },
+      },
+      "drives-awaiting-classification": {
+        statePredicate: "At least one active Trip has classification 'unclassified'.",
+        stateSource: {
+          oracleKey: "route-owned-read-model",
+          sourceRef: "apps/web/app/(shell)/finance/mileage/page.tsx",
+        },
+        essentialEvidenceKeys: ["unclassified-count", "trip-list", "classification-control"],
+        primaryExperience: { kind: "informational", messageKey: "mileage.awaiting-classification" },
+        prohibitedActionKeys: [],
+        completionSignal:
+          "The header counts the waiting drives and each unclassified row offers business, personal and commute in one tap.",
+        errorCorrection:
+          "Choosing again re-classifies in place; nothing is committed to money until a claim is raised.",
+        recovery: { actionKey: "reclassify-drive", routePath: "/finance/mileage" },
+      },
+      "drives-claimed": {
+        statePredicate: "At least one Trip carries an expenseItemId.",
+        stateSource: {
+          oracleKey: "route-owned-read-model",
+          sourceRef: "apps/web/app/(shell)/finance/mileage/page.tsx",
+        },
+        essentialEvidenceKeys: ["trip-list"],
+        primaryExperience: { kind: "informational", messageKey: "mileage.claimed" },
+        prohibitedActionKeys: ["reclassify-drive"],
+        completionSignal:
+          "A claimed drive reads as settled and offers no classification control.",
+        errorCorrection:
+          "A drive that already priced a reimbursement is accounting evidence; the page refuses to let its classification change rather than silently allowing a mismatch with the claim.",
+        recovery: { actionKey: "open-my-expenses", routePath: "/finance/my-expenses" },
+      },
+    },
+    taskProtocol: {
+      startRoute: "/finance/mileage",
+      taskPrompt: "Mark last week's drives as business or personal and tell me what I am owed.",
+      completionOracle:
+        "Every drive shows a classification, and the reimbursable column reads a money amount for the priced ones.",
+      falseSuccessConditions: [
+        "A commute drive is classified business, inflating the claim.",
+        "An unpriced drive's blank amount is read as zero owed rather than not-yet-priced.",
+        "A claimed drive is believed to be still editable.",
+      ],
+      acceptanceThresholds: [
+        "Classifying a drive takes one interaction from the list.",
+        "A claimed drive cannot be reclassified from this page.",
+        "An unpriced drive shows an explicit placeholder, never a zero amount.",
+      ],
+    },
+    ratifiedBy: { role: "owner", ref: "operator-request:mark-bodman-2026-08-23" },
+    reviewRef: "BI-6D98AD8A",
+    intentEvidenceRefs: [
+      {
+        kind: "operator-request",
+        ref: "EP-MILEAGE-ABSORB",
+        summary:
+          "Founder directed full native absorption of MileIQ-class mileage tracking, then asked whether the feature had actually been implemented for the archetypes that need it. It had not: the substrate, rules and pricing merged with no route and no write path, so this page and its server actions close that gap.",
+      },
+      {
+        kind: "existing-behavior",
+        ref: "apps/web/lib/mileage/monetisation.ts",
+        summary:
+          "priceTrips already prices classified business drives at the effective-dated rate in force on the drive date and reports every skipped drive with a reason. This page is its human-facing surface, reading the same model so the two never drift.",
+      },
+    ],
+  },
+];

--- a/apps/web/lib/ux-budget/route-purpose.generated.json
+++ b/apps/web/lib/ux-budget/route-purpose.generated.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "generator": "apps/web/scripts/build-page-purpose.ts",
-  "pageRouteCount": 326,
+  "pageRouteCount": 327,
   "draftCount": 317,
-  "ratifiedCount": 9,
+  "ratifiedCount": 10,
   "quarantinedCount": 0,
   "routes": [
     {
@@ -1701,6 +1701,178 @@
         "confidence": "high",
         "sweepEligible": true
       }
+    },
+    {
+      "schemaVersion": 1,
+      "status": "intent-ratified",
+      "routePath": "/finance/mileage",
+      "derived": {
+        "audience": "owner",
+        "destinationKind": "detail",
+        "shell": "detail",
+        "confidence": "high",
+        "sweepEligible": true
+      },
+      "intent": {
+        "primaryUser": "An employee who drives for work — a field technician, mobile tradesperson, or anyone whose own vehicle carries them to customers.",
+        "triggeringNeed": "Being reimbursed for business driving without keeping a paper log or re-typing a month of trips into a spreadsheet at the end of the month.",
+        "prerequisites": [
+          "Signed in with a user account linked to an employee record.",
+          "Drives exist: captured automatically by the mobile app under a granted location consent, or entered manually."
+        ],
+        "job": "Review the drives captured for you, mark each one business or personal, and see what the business owes you for them.",
+        "successOutcome": "The driver sees every captured drive, classifies the unclassified ones in a single tap each, and reads the reimbursable amount for the ones already priced.",
+        "findability": {
+          "parentArea": "Finance",
+          "entryPoints": [
+            "/finance",
+            "Finance > Mileage"
+          ],
+          "navigationLayer": "Finance area tab nav",
+          "discoveryCue": "A 'Mileage' tab in the Finance area, beside My Expenses.",
+          "expectedPath": [
+            "/finance",
+            "/finance/mileage"
+          ]
+        },
+        "contentRoles": {
+          "defaultVisibleKeys": [
+            "unclassified-count",
+            "trip-list",
+            "classification-control"
+          ],
+          "deferredRegions": []
+        },
+        "familyConsistency": {
+          "terminology": "Plain driving words — drive, business, personal, commute, reimbursable. Never Trip ids, coordinates, or metres.",
+          "actionLocation": "The classification control sits on the drive's own row; choosing re-reads that row in place.",
+          "feedbackPrimitive": "Inline pending state on the row being classified — no native dialogs.",
+          "disclosurePattern": "Every captured drive shows by default; a claimed drive shows its classification as settled text rather than an editable control.",
+          "returnBehavior": "Classifying never navigates away — the driver stays on the list and continues down it."
+        }
+      },
+      "stateScenarios": {
+        "no-employee-record": {
+          "statePredicate": "The signed-in user has no linked EmployeeProfile.",
+          "stateSource": {
+            "oracleKey": "route-owned-read-model",
+            "sourceRef": "apps/web/app/(shell)/finance/mileage/page.tsx"
+          },
+          "essentialEvidenceKeys": [
+            "unclassified-count"
+          ],
+          "primaryExperience": {
+            "kind": "informational",
+            "messageKey": "mileage.no-employee-record"
+          },
+          "prohibitedActionKeys": [],
+          "completionSignal": "A message explains that no drives can belong to this account and names who can link it.",
+          "errorCorrection": "This is distinguished from having no drives yet — an unlinked account is a setup problem, not an empty month.",
+          "recovery": {
+            "actionKey": "open-finance-home",
+            "routePath": "/finance"
+          }
+        },
+        "no-drives": {
+          "statePredicate": "The employee has no active Trip rows.",
+          "stateSource": {
+            "oracleKey": "route-owned-read-model",
+            "sourceRef": "apps/web/app/(shell)/finance/mileage/page.tsx"
+          },
+          "essentialEvidenceKeys": [
+            "unclassified-count"
+          ],
+          "primaryExperience": {
+            "kind": "informational",
+            "messageKey": "mileage.no-drives"
+          },
+          "prohibitedActionKeys": [],
+          "completionSignal": "An empty state explains that drives appear automatically once capture is switched on in the mobile app.",
+          "errorCorrection": "The driver learns capture is a mobile setting rather than concluding the feature is broken.",
+          "recovery": {
+            "actionKey": "open-finance-home",
+            "routePath": "/finance"
+          }
+        },
+        "drives-awaiting-classification": {
+          "statePredicate": "At least one active Trip has classification 'unclassified'.",
+          "stateSource": {
+            "oracleKey": "route-owned-read-model",
+            "sourceRef": "apps/web/app/(shell)/finance/mileage/page.tsx"
+          },
+          "essentialEvidenceKeys": [
+            "unclassified-count",
+            "trip-list",
+            "classification-control"
+          ],
+          "primaryExperience": {
+            "kind": "informational",
+            "messageKey": "mileage.awaiting-classification"
+          },
+          "prohibitedActionKeys": [],
+          "completionSignal": "The header counts the waiting drives and each unclassified row offers business, personal and commute in one tap.",
+          "errorCorrection": "Choosing again re-classifies in place; nothing is committed to money until a claim is raised.",
+          "recovery": {
+            "actionKey": "reclassify-drive",
+            "routePath": "/finance/mileage"
+          }
+        },
+        "drives-claimed": {
+          "statePredicate": "At least one Trip carries an expenseItemId.",
+          "stateSource": {
+            "oracleKey": "route-owned-read-model",
+            "sourceRef": "apps/web/app/(shell)/finance/mileage/page.tsx"
+          },
+          "essentialEvidenceKeys": [
+            "trip-list"
+          ],
+          "primaryExperience": {
+            "kind": "informational",
+            "messageKey": "mileage.claimed"
+          },
+          "prohibitedActionKeys": [
+            "reclassify-drive"
+          ],
+          "completionSignal": "A claimed drive reads as settled and offers no classification control.",
+          "errorCorrection": "A drive that already priced a reimbursement is accounting evidence; the page refuses to let its classification change rather than silently allowing a mismatch with the claim.",
+          "recovery": {
+            "actionKey": "open-my-expenses",
+            "routePath": "/finance/my-expenses"
+          }
+        }
+      },
+      "taskProtocol": {
+        "startRoute": "/finance/mileage",
+        "taskPrompt": "Mark last week's drives as business or personal and tell me what I am owed.",
+        "completionOracle": "Every drive shows a classification, and the reimbursable column reads a money amount for the priced ones.",
+        "falseSuccessConditions": [
+          "A commute drive is classified business, inflating the claim.",
+          "An unpriced drive's blank amount is read as zero owed rather than not-yet-priced.",
+          "A claimed drive is believed to be still editable."
+        ],
+        "acceptanceThresholds": [
+          "Classifying a drive takes one interaction from the list.",
+          "A claimed drive cannot be reclassified from this page.",
+          "An unpriced drive shows an explicit placeholder, never a zero amount."
+        ]
+      },
+      "ratifiedBy": {
+        "role": "owner",
+        "ref": "operator-request:mark-bodman-2026-08-23"
+      },
+      "reviewRef": "BI-6D98AD8A",
+      "intentEvidenceRefs": [
+        {
+          "kind": "operator-request",
+          "ref": "EP-MILEAGE-ABSORB",
+          "summary": "Founder directed full native absorption of MileIQ-class mileage tracking, then asked whether the feature had actually been implemented for the archetypes that need it. It had not: the substrate, rules and pricing merged with no route and no write path, so this page and its server actions close that gap."
+        },
+        {
+          "kind": "existing-behavior",
+          "ref": "apps/web/lib/mileage/monetisation.ts",
+          "summary": "priceTrips already prices classified business drives at the effective-dated rate in force on the drive date and reports every skipped drive with a reason. This page is its human-facing surface, reading the same model so the two never drift."
+        }
+      ]
     },
     {
       "schemaVersion": 1,

--- a/apps/web/lib/ux-budget/route-shells.generated.json
+++ b/apps/web/lib/ux-budget/route-shells.generated.json
@@ -1,11 +1,11 @@
 {
   "generator": "apps/web/scripts/build-route-shells.ts",
-  "pageRouteCount": 326,
+  "pageRouteCount": 327,
   "migratedCount": 1,
   "summary": {
     "cockpit": 17,
     "list": 6,
-    "detail": 252,
+    "detail": 253,
     "settings": 12,
     "form": 18,
     "public": 21,
@@ -1405,6 +1405,18 @@
     {
       "routePath": "/finance/invoices/new",
       "shell": "form",
+      "audience": "owner",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "sweepEligible": true,
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/mileage",
+      "shell": "detail",
       "audience": "owner",
       "migrated": false,
       "exemptChecks": [

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -488,7 +488,9 @@ describe("generated route-shell registry", () => {
     // 200 -> 201: /platform/tools/integrations/wordpress is a bounded operator detail
     // route over connection, projection, receipt, and drift read models; its measured
     // preview is deterministic and carries an explicit page-purpose contract.
-    expect(registry.routes.filter((route) => route.sweepEligible)).toHaveLength(201);
+    // 201 -> 202: /finance/mileage is a net-new driver-facing route (EP-MILEAGE-ABSORB)
+    // — the surface that makes the mileage substrate reachable.
+    expect(registry.routes.filter((route) => route.sweepEligible)).toHaveLength(202);
     // 110 -> 113: the three exclusions above. Product Direction then adds seven
     // explicitly classified dynamic routes, bringing the combined total to 120.
     // 120 -> 121: /platform/ai/operations-map.

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -12,4 +12,4 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 | Prisma enums | 68 | `packages/db/prisma/schema/` |
 | Migrations | 547 | `packages/db/prisma/migrations/` |
 | Kernel principles | 96 | `docs/founder-kernel/wiki/principles/` |
-| App routes | 626 | `apps/web/lib/ea/route-manifest.json` |
+| App routes | 627 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -12,4 +12,4 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 | Prisma enums | 68 | `packages/db/prisma/schema/` |
 | Migrations | 547 | `packages/db/prisma/migrations/` |
 | Kernel principles | 96 | `docs/founder-kernel/wiki/principles/` |
-| App routes | 627 | `apps/web/lib/ea/route-manifest.json` |
+| App routes | 630 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/user-guide/finance/index.md
+++ b/docs/user-guide/finance/index.md
@@ -53,6 +53,7 @@ purchase order and bill for a payable, or a claim for an employee expense.
 - Record incoming bills and match them to purchase orders
 - Raise purchase orders and track their fulfillment status
 - Review outstanding payables and receivables at a glance
+- Sort your captured drives and see what the business owes you for them
 - Monitor AI providers as finance-owned suppliers, including draft contracts, open setup work items, and linked billing/usage pages
 - Review committed AI spend and setup gaps from the dedicated `/finance/spend/ai` workspace
 
@@ -146,6 +147,29 @@ It is a **draft for you to review**. Nothing is sent to anyone, no action is tak
 
 A payment run (`/finance/payment-runs`) **records the selected approved bills as paid in DPF** and writes a matching outbound payment. It is **not a draft** and does **not** initiate a real bank transfer — pay your suppliers through your bank as usual, then use a payment run to keep your books settled. The action is labelled **"Record as Paid"** to make this explicit.
 
+## Mileage
+
+If you drive for work, the mobile app can record your drives so you do not keep a
+paper log. Drives show up at `/finance/mileage`.
+
+**Turn it on first.** The app asks before it records anything. Nothing is captured
+until you agree, and you can turn it off at any time. Personal drives stay yours —
+only the ones you mark business are ever claimed.
+
+**Sort each drive.** Every drive is business, personal, or commute. Tap once to
+choose. You can change your mind until the drive is claimed.
+
+**What you are owed.** A drive is priced at the rate in force on the day you drove
+it, not today's rate. A drive that has not been priced yet says so, rather than
+showing zero — no amount yet is not the same as nothing owed.
+
+**Getting paid.** Someone with finance permission turns a month of business drives
+into an expense claim. That claim can be paid on its own or added to your pay as a
+reimbursement, which is not taxed because it repays money you already spent.
+
+Mileage appears in the mobile app only on installs that use it. A business whose
+staff do not drive to customers will not see it.
+
 ## Reporting And Close Boundaries
 
 Current profit-and-loss and finance-period summaries are cash-basis: paid
@@ -164,6 +188,7 @@ authoritative accounting close and retain its reviewer evidence separately.
 - `/finance/invoices` and `/finance/payments` — customer billing and recorded receipts
 - `/finance/suppliers`, `/finance/purchase-orders`, and `/finance/bills` — supplier commitments and payables
 - `/finance/expense-claims` and `/finance/my-expenses` — reviewer and employee expense workflows
+- `/finance/mileage` — your own captured drives, sorted business or personal
 - `/finance/banking` — statement import, rules, and reconciliation
 - `/finance/reports` and `/finance/close` — reporting and close-readiness
 - `/finance/spend` — spend hub for suppliers, bills, expenses, and AI spend summary

--- a/docs/ux-fit/2026-08-23-mileage-driver-surface.ux-fit.json
+++ b/docs/ux-fit/2026-08-23-mileage-driver-surface.ux-fit.json
@@ -1,0 +1,26 @@
+{
+  "version": "1",
+  "decidedOption": "list-with-inline-classification",
+  "decisionInteractionId": "DI-3C44A1F12CAC",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/finance/mileage/page.tsx",
+      "apps/web/app/(shell)/finance/mileage/MileageTripsTable.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "decisionInteractionId": "DI-3C44A1F12CAC",
+    "consideredOptions": [
+      "list-with-inline-classification",
+      "swipe-card-queue",
+      "summary-with-drilldown"
+    ]
+  },
+  "rationale": {
+    "list-with-inline-classification": "CHOSEN. Kernel composite 10.561, margin 1.752, high confidence, verdict proceed. One list of every captured drive with the three classification choices on the drive's own row. Highest of the three on Ground New Work In Existing Platform (0.507) and Single Source of Truth (0.606) because it composes the finance table pattern already used by My Expenses rather than introducing a bespoke surface, and highest on Research and Use Standards (0.750). A driver sees the whole month at once, so a misclassified drive is visible next to its neighbours instead of buried in a queue already passed.",
+    "swipe-card-queue": "REJECTED. Kernel composite 7.679 — lowest of the three. The MileIQ-style one-card-at-a-time queue scores best on raw cognitive load per decision, but worst on reusability (0.3) and long-term maintainability: it is an interaction pattern present nowhere else in the portal, so it carries its own bugs and its own learning cost forever. It also scores lowest on legibility of consequence (0.45) because a driver cannot see the month they are building, and a drive swiped past is hard to revisit. Notably it scores WORST on Ground New Work In Existing Platform (0.354).",
+    "summary-with-drilldown": "REJECTED. Kernel composite 8.809. A monthly summary with a drill-down reads well but puts a navigation hop between the driver and the only act they perform. It scores NEGATIVE (-0.125) on 'Do the work; don't task the operator with what an agent can do' and negative (-0.013) on 'Never ask the user to run commands' — the extra hop is work handed back to the person. Two surfaces to keep coherent for one job also costs maintainability against a single list."
+  },
+  "notes": "EP-MILEAGE-ABSORB. This route exists because the mileage substrate, rules and pricing all merged with NO route and NO write path — Trip rows could be written by nothing and read by nobody. The page is deliberately read-plus-classify only: raising a claim is a finance-capability act performed by monetiseMileageAction, not by the driver. A drive already carrying an expenseItemId renders its classification as settled text with no control, because a drive that priced a reimbursement is accounting evidence and must not silently diverge from the claim. An unpriced drive shows an explicit placeholder rather than a zero amount, so 'not yet priced' is never read as 'nothing owed'. Markup uses --dpf-* tokens only, with no hardcoded colour. The measured-sweep path was not used: it needs the served DOM on the Contributor preview, and this change was verified through the ratified page-purpose contract plus the ux-budget registry test rather than a live sweep."
+}

--- a/packages/api-client/src/endpoints/mileage.ts
+++ b/packages/api-client/src/endpoints/mileage.ts
@@ -1,0 +1,45 @@
+import type { DpfClient } from "../client";
+import type {
+  ClassifyTripRequest,
+  GrantMileageConsentRequest,
+  MileageConsentState,
+  MileageTripSummary,
+  PaginatedResponse,
+  RecordTripRequest,
+} from "@dpf/types";
+
+export function mileageEndpoints(client: DpfClient) {
+  return {
+    /** The signed-in driver's own captured drives, newest first. */
+    list: (params?: { limit?: number }) => {
+      const qs = new URLSearchParams();
+      if (params?.limit) qs.set("limit", String(params.limit));
+      const query = qs.toString();
+      return client.get<PaginatedResponse<MileageTripSummary>>(
+        `/api/v1/mileage/trips${query ? `?${query}` : ""}`,
+      );
+    },
+
+    /**
+     * Record one captured drive. The server resolves the driver from the
+     * session and refuses without a granted consent — the client never asserts
+     * whose drive this is.
+     */
+    record: (input: RecordTripRequest) =>
+      client.post<MileageTripSummary>("/api/v1/mileage/trips", input),
+
+    /** Classify a drive. Refused server-side once the drive is claimed. */
+    classify: (tripId: string, input: ClassifyTripRequest) =>
+      client.patch<MileageTripSummary>(
+        `/api/v1/mileage/trips/${encodeURIComponent(tripId)}`,
+        input,
+      ),
+
+    /** The driver's current consent state — capture must check this first. */
+    consent: () => client.get<MileageConsentState>("/api/v1/mileage/consent"),
+
+    /** Record an explicit grant against the disclosure the driver was shown. */
+    grantConsent: (input: GrantMileageConsentRequest) =>
+      client.post<MileageConsentState>("/api/v1/mileage/consent", input),
+  };
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -11,6 +11,7 @@ import { complianceEndpoints } from "./endpoints/compliance";
 import { notificationsEndpoints } from "./endpoints/notifications";
 import { dynamicEndpoints } from "./endpoints/dynamic";
 import { uploadEndpoints } from "./endpoints/upload";
+import { mileageEndpoints } from "./endpoints/mileage";
 import { workItemsEndpoints } from "./endpoints/work-items";
 import { financeEndpoints } from "./endpoints/finance";
 import { directoryEndpoints } from "./endpoints/directory";
@@ -31,6 +32,7 @@ export function createApiClient(config: ApiClientConfig) {
     notifications: notificationsEndpoints(client),
     dynamic: dynamicEndpoints(client),
     upload: uploadEndpoints(client),
+    mileage: mileageEndpoints(client),
     workItems: workItemsEndpoints(client),
     finance: financeEndpoints(client),
     directory: directoryEndpoints(client),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,6 +2,7 @@ export * from "./entities";
 export * from "./api";
 export * from "./dynamic";
 export * from "./mobile-manifest";
+export * from "./mileage";
 export * from "./work-items";
 export * from "./customer-visits";
 export * from "./finance";

--- a/packages/types/src/mileage.ts
+++ b/packages/types/src/mileage.ts
@@ -1,0 +1,57 @@
+// Mileage capture wire types (EP-MILEAGE-ABSORB).
+//
+// Shared by the mobile app, the API client and the server route so the three
+// cannot drift. Distances travel in METRES and money in minor-unit-agnostic
+// decimals as strings-free numbers; the client formats, the server prices.
+
+export type MileageClassification = "unclassified" | "business" | "personal" | "commute";
+
+export type MileageCaptureKind = "automatic" | "manual" | "imported";
+
+/** One captured drive as the driver sees it. */
+export interface MileageTripSummary {
+  tripId: string;
+  startedAt: string;
+  endedAt: string;
+  distanceMetres: number;
+  classification: MileageClassification;
+  /** Who decided the classification — a rule must never overwrite a person. */
+  classifiedBy: "driver" | "rule" | "admin" | null;
+  startPlaceLabel: string | null;
+  endPlaceLabel: string | null;
+  /** Null until a rate has priced it. Never render null as zero. */
+  reimbursableAmount: number | null;
+  currency: string;
+  /** True once the drive is on an expense claim; it must not be reclassified. */
+  claimed: boolean;
+}
+
+export interface RecordTripRequest {
+  startedAt: string;
+  endedAt: string;
+  startLatitude: number;
+  startLongitude: number;
+  endLatitude: number;
+  endLongitude: number;
+  startPlaceLabel?: string | null;
+  endPlaceLabel?: string | null;
+  distanceMetres: number;
+  captureKind: MileageCaptureKind;
+  vehicleId?: string | null;
+}
+
+export interface ClassifyTripRequest {
+  classification: Exclude<MileageClassification, "unclassified">;
+}
+
+/** The driver's own consent state, as the app must see it before capturing. */
+export interface MileageConsentState {
+  consentStatus: "pending" | "granted" | "revoked" | "expired";
+  policyVersion: string | null;
+  retentionDays: number | null;
+  grantedAt: string | null;
+}
+
+export interface GrantMileageConsentRequest {
+  policyVersion: string;
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -3503,6 +3503,30 @@
     "longSentences": 0,
     "textMass": 4
   },
+  "apps/web/app/api/v1/mileage/consent/route.ts": {
+    "vocabulary": 0,
+    "retiredVocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/app/api/v1/mileage/trips/[tripId]/route.ts": {
+    "vocabulary": 0,
+    "retiredVocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/mileage/trips/route.ts": {
+    "vocabulary": 0,
+    "retiredVocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
   "apps/web/app/api/v1/notifications/[id]/read/route.ts": {
     "vocabulary": 0,
     "retiredVocabulary": 0,

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1143,6 +1143,22 @@
     "longSentences": 0,
     "textMass": 2
   },
+  "apps/web/app/(shell)/finance/mileage/MileageTripsTable.tsx": {
+    "vocabulary": 0,
+    "retiredVocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 37
+  },
+  "apps/web/app/(shell)/finance/mileage/page.tsx": {
+    "vocabulary": 0,
+    "retiredVocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
   "apps/web/app/(shell)/finance/my-expenses/new/page.tsx": {
     "vocabulary": 0,
     "retiredVocabulary": 0,


### PR DESCRIPTION
The mileage substrate, rules and pricing merged in #4481 with **no route and no write path**. `Trip` rows could be written by nothing and read by nobody, and the mobile capture modules were imported by no screen. Four merged PRs of code no user could reach. This closes that, web and iOS.

Two commits, kept separate for review but shipped together because the API routes import `trip-service.ts` — splitting them would merge a branch referencing a module not yet on `main`.

## What lands

| | |
|---|---|
| `lib/mileage/trip-service.ts` | persistence behind a structural client, so rules stay unit-testable without a database |
| `lib/actions/mileage.ts` | the `"use server"` wrappers |
| `/finance/mileage` | the driver's own drives, classified in one tap |
| `packages/types/src/mileage.ts` | wire types shared by app, client and server so the three cannot drift |
| `packages/api-client/.../mileage.ts` | list / record / classify / consent |
| `/api/v1/mileage/*` | trips (GET/POST), classify (PATCH), consent (GET/POST) |
| `app/(tabs)/mileage` + store | the iOS screen |

## Invariants enforced in the service, not the UI

**No capture without consent.** A drive is recorded only for a driver holding a granted `DriverLocationConsent`. Pending is refused too — unknown is not yes. This is the line between mileage tracking and surveillance, and it must not be a UI-layer promise.

**Monetise once.** A trip already carrying an `expenseItemId` is excluded *before* pricing and reported separately, so re-running a period is safe and visibly so.

## The server does not trust the client

- The driver resolves from the **session**, never the request body — otherwise one employee could file drives, and claim reimbursement, against another's record.
- A capture refusal is **403 with the reason**: a missing consent is an expected state the driver must be told about, not a server fault.
- A claimed drive returns **409** on reclassify — it priced a reimbursement, so letting its classification drift from the claim would be a silent mismatch between what was paid and what it was paid for.
- The claim, its items and the trip links are written in **one transaction**, so a partial failure cannot leave trips marked claimed against a claim that does not exist.

## Archetype fit

The mobile tab is **capability-gated** in `TAB_REGISTRY`. A field-mobile install — field service, trades, automotive, mobile beauty — declares `mileage` and its drivers get the tab; a fixed-premises install never sees it; a customer or walk-up visitor never sees it because drives belong to a worker. Asserted by two new navigation tests rather than claimed.

## Route gauntlet, worked not waived

Ratified page-purpose contract (the identity ratchet refuses to grandfather a new route), UX-Fit artifact backed by kernel decision `DI-3C44A1F12CAC`, four route companions regenerated, eligible-route count 201 → 202, and all three new API routes carry `@exposure authenticated` — routes are born classified.

The first cut hand-rolled a table and accent buttons; the primitive-adoption and reporting-composition guards caught it, and it now composes `report-kit/DataTable` and `ui/Button` per AGENTS.md §9.

## Verification

- `pregate` **PASS** at `a7697ac44ddf`, evidence `cmt5dt1lk0x6m01o8xoavv55x`
- `pregate:preflight` — 47 guards clean
- 304 mobile tests, 10 trip-service tests; web + mobile typecheck clean

## Deliberately not included

**Background capture.** It needs `expo-task-manager`, a new dependency that must clear the dependency gate on its own merits — continuous location tracking of employees deserves that scrutiny rather than arriving inside a feature PR. Drives record through the API today; automatic detection is the follow-up.

**Not mine, recorded rather than hidden:** the prose-lint `--update` also admitted `platform/tools/integrations/wordpress/page.tsx` to the baseline. That file predates this change; its absence was pre-existing baseline drift.

Refs: BI-6D98AD8A, BI-E17E0034, EP-MILEAGE-ABSORB, DI-3C44A1F12CAC



🤖 Generated with [Claude Code](https://claude.com/claude-code)
Local-CI-Evidence: cmt64c5pi03pw01mqipqphqgr (feat/mileage-mobile-screen@0414b4268b78)
