### PR TITLE
fix(kernel): make the consumer-context attenuation actually fire (BI-5BB1A364 follow-up)

### DIFF
--- a/apps/web/lib/decision/consumer-context-attenuation.test.ts
+++ b/apps/web/lib/decision/consumer-context-attenuation.test.ts
@@ -71,7 +71,7 @@ describe("consumerContextWeightMultiplier", () => {
     schema_grounding: 0.5,
   };
 
-  it("is a no-op (1) for any archetype other than route-domain-specific", () => {
+  it("is a no-op (1) for a row that declares no contexts, whatever its archetype", () => {
     expect(
       consumerContextWeightMultiplier({
         consumerArchetype: "universal",
@@ -147,5 +147,68 @@ describe("consumerContextWeightMultiplier", () => {
       dimensionVector: { blast_radius: -0.5 },
     });
     expect(m).toBeCloseTo(ROUTE_DOMAIN_CONTEXTLESS_ATTENUATION, 6);
+  });
+});
+
+// BI-86EF5900 follow-up: the lever used to gate on
+// `consumerArchetype === "route-domain-specific"`, an archetype NO kernel
+// principle page carries (measured: universal 72, ai-coworker-universal 23,
+// specialist 1, route-domain-specific 0 across 96 pages). Every test above
+// passes that archetype explicitly, so the suite was green while the
+// production path returned 1 on its first line for every principle, always.
+// These cases pin the shape the corpus ACTUALLY has.
+describe("consumerContextWeightMultiplier — real corpus shapes", () => {
+  const UI_VECTOR = {
+    long_term_maintainability: 0.9,
+    reusability: 0.7,
+    schema_grounding: 0.5,
+    human_cognitive_load: -0.35,
+    governance_compliance: 0.4,
+  };
+
+  // The live frontmatter of docs/founder-kernel/wiki/principles/no-hardcoded-colors.md:
+  // archetype `universal` (it binds all three populations) AND context `ui`.
+  const NO_HARDCODED_COLORS = {
+    consumerArchetype: "universal",
+    principleConsumerContexts: ["ui"],
+    dimensionVector: UI_VECTOR,
+  };
+
+  it("attenuates a universal-archetype UI commandment for a contextless caller", () => {
+    const m = consumerContextWeightMultiplier({
+      ...NO_HARDCODED_COLORS,
+      callerConsumerContexts: undefined,
+    });
+    expect(m).toBeLessThan(1);
+    expect(m).toBeGreaterThan(0);
+  });
+
+  it("keeps full weight when the caller declares the matching context", () => {
+    expect(
+      consumerContextWeightMultiplier({
+        ...NO_HARDCODED_COLORS,
+        callerConsumerContexts: ["ui"],
+      }),
+    ).toBe(1);
+  });
+
+  it("zeroes a UI commandment for a caller in an unrelated context", () => {
+    expect(
+      consumerContextWeightMultiplier({
+        ...NO_HARDCODED_COLORS,
+        callerConsumerContexts: ["build-studio"],
+      }),
+    ).toBe(0);
+  });
+
+  it("leaves a domain-universal commandment (no declared contexts) at full weight", () => {
+    expect(
+      consumerContextWeightMultiplier({
+        consumerArchetype: "universal",
+        principleConsumerContexts: [],
+        callerConsumerContexts: undefined,
+        dimensionVector: { evidence_density: 0.8, governance_compliance: 0.7 },
+      }),
+    ).toBe(1);
   });
 });

--- a/apps/web/lib/decision/consumer-context-attenuation.ts
+++ b/apps/web/lib/decision/consumer-context-attenuation.ts
@@ -99,8 +99,14 @@ export function professionLocalAttenuationFactor(
 }
 
 export type ConsumerContextAttenuationInput = {
-  /** `principleConsumerArchetype` column value, or null/undefined. */
-  consumerArchetype: string | null | undefined;
+  /**
+   * `principleConsumerArchetype` column value. NO LONGER GATES this lever —
+   * it encodes populations, not route/domain (see the note on
+   * `consumerContextWeightMultiplier`). Retained on the input so callers keep
+   * passing it and the reason it is not consulted stays discoverable here
+   * rather than becoming folklore.
+   */
+  consumerArchetype?: string | null | undefined;
   /** The row's own `principleConsumerContexts`. Empty/undefined for non-route archetypes and un-backfilled rows. */
   principleConsumerContexts: readonly string[] | null | undefined;
   /** The caller's declared `consumerContexts`, or undefined when the caller declared none. */
@@ -112,10 +118,32 @@ export type ConsumerContextAttenuationInput = {
 /**
  * The combined weight multiplier for a single commandment row.
  *
- * - Not `route-domain-specific` → 1 (no-op; this lever only concerns the
- *   defect's own archetype).
- * - The row's own `principleConsumerContexts` is empty → 1 (backward compat;
- *   same as the retrieval filter's treatment of un-backfilled rows).
+ * KEYED ON DECLARED CONTEXTS, NOT ON ARCHETYPE (BI-86EF5900 follow-up).
+ * This lever originally gated on `principleConsumerArchetype ===
+ * "route-domain-specific"` and was therefore INERT: measured across all 96
+ * kernel principle pages the archetype distribution is universal 72,
+ * ai-coworker-universal 23, specialist 1 — route-domain-specific ZERO. The
+ * function returned 1 on its first line for every principle, always, so the
+ * defect BI-5BB1A364 set out to fix was never actually mitigated.
+ *
+ * The archetype could not carry this: per the seed's coherence matrix
+ * (seed-wiki-kernel.ts, spec §8A.1) `universal` REQUIRES two or more
+ * `principleAppliesTo` populations, so archetype encodes WHICH POPULATIONS a
+ * principle binds. `principleConsumerContexts` encodes WHICH ROUTE/DOMAIN.
+ * Those axes are orthogonal: `no-hardcoded-colors` is correctly `universal`
+ * (all three populations must bind theme tokens) AND correctly `ui`-scoped.
+ * Gating a domain lever on a population field made route-domain-specific
+ * structurally unreachable for any rule spanning populations — which is
+ * nearly all of them.
+ *
+ * Keying on the contexts field also makes this lever agree with the
+ * retrieval-side filter, which already keys on `principleConsumerContexts`
+ * alone with no archetype check (wiki-store.ts `listPrinciplesByTier`). The
+ * two halves of BI-5BB1A364 disagreeing is what left the gap.
+ *
+ * - The row declares no `principleConsumerContexts` → 1. No declared domain
+ *   scope means the rule is domain-universal; unchanged, and the majority
+ *   case (53 of 96 pages).
  * - Caller declared NO context → attenuate (contextless-caller bucket,
  *   BI-5BB1A364 scope item 2) rather than exclude.
  * - Caller declared a context that INTERSECTS this row's contexts → 1 (the
@@ -131,8 +159,6 @@ export type ConsumerContextAttenuationInput = {
 export function consumerContextWeightMultiplier(
   input: ConsumerContextAttenuationInput,
 ): number {
-  if (input.consumerArchetype !== "route-domain-specific") return 1;
-
   const rowContexts = input.principleConsumerContexts ?? [];
   if (rowContexts.length === 0) return 1;
 


### PR DESCRIPTION
The lever built to stop a route-scoped commandment co-ranking on an unrelated decision **has never fired once.** `consumerContextWeightMultiplier` opened with:

```js
if (input.consumerArchetype !== "route-domain-specific") return 1;
```

Measured across all 96 kernel principle pages, the archetype distribution is:

| archetype | pages |
|---|---|
| `universal` | 72 |
| `ai-coworker-universal` | 23 |
| `specialist` | 1 |
| **`route-domain-specific`** | **0** |

The function returned `1` on its first line for every principle, always. It was designed, unit-tested and shipped against a value nothing in the corpus carries — and **every existing test passes that archetype explicitly**, so the suite stayed green while production got no mitigation at all.

## Why the archetype could never carry this

Per the seed coherence matrix (`seed-wiki-kernel.ts`, spec §8A.1), `universal` **requires two or more** `principleAppliesTo` populations. So archetype encodes **which populations** a principle binds; `principleConsumerContexts` encodes **which route/domain**. The two axes are orthogonal.

`no-hardcoded-colors` is correctly `universal` — all three populations must bind theme tokens — **and** correctly scoped to `ui`. Gating a domain lever on a population field made `route-domain-specific` structurally unreachable for any rule spanning populations, which is nearly all of them.

It also left the two halves of BI-5BB1A364 disagreeing: the retrieval-side filter in `wiki-store.ts` `listPrinciplesByTier` already keys on `principleConsumerContexts` **alone**, with no archetype check. Scoring now keys on the same field, so both halves apply one rule.

## Measured cost of the inert lever

Seven commandments declare a context but are archetyped `universal`, so they voted at full weight `1.0` on every decision regardless of topic:

`no-hardcoded-colors` (ui) · `all-changes-land-via-pr` · `dco-sign-off-required` · `build-gate-mandatory` · `worktree-is-source-control-not-runtime` · `structural-verification-is-not-functional` · `test-in-the-portal-build`

On a live sequencing decision this session (`DI-D968EB6BD76A` — what order to repair four defects in), **five of the top eight contributors were context-scoped commandments firing outside their context.** The kernel reported *"Worktree is source-control isolation, not runtime isolation"* as the second-strongest reason to pick a defect-repair order, and *No Hardcoded Colors* outranked the one principle that actually discriminated the options (*Trust Is Prospective*, 0.9 vs 0.4).

## Behaviour after this change

- row declares **no** contexts → full weight (53 of 96 pages, unchanged)
- row declares contexts, caller's context **intersects** → full weight
- row declares contexts, caller's context **does not** intersect → 0
- row declares contexts, caller declares **none** → attenuated, not excluded

## Verification

- **19 unit tests pass**, including four new cases pinned to the **real** corpus shape (`universal` archetype + declared context) rather than the unreachable one.
- **667 tests pass** across 69 decision and principle-decide files.
- `pnpm --filter web build`: clean.
- `pregate:preflight`: 50 guards clean.
- exact-tree local CI gate: **PASS** (evidence `cmt5f6c5h14ni01o8riiqddet`).

## Not yet verified live — please read before merging

This changes scoring for **every future decision**. The live portal still runs the old code, so the before/after on `DI-D968EB6BD76A` and `DI-7A4DFF0A1809` can only be confirmed once deployed. Whether the fix changes any **conclusion** or only the **explanation** should be checked before it is relied on. I expect the same conclusions with a much cleaner ledger, but that is an expectation, not a measurement.

Follow-up to BI-5BB1A364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
