### PR TITLE
fix(tak): hand off on the dead ends that actually happen, and tune the prose gauge to real output

### DIFF
--- a/apps/web/lib/prose/generated-prose.test.ts
+++ b/apps/web/lib/prose/generated-prose.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   analyzeGeneratedProse,
   classifyGeneratedProse,
+  LONG_SENTENCE_RATIO_BASELINE,
 } from "./generated-prose";
 
 describe("analyzeGeneratedProse", () => {
@@ -47,13 +48,26 @@ describe("analyzeGeneratedProse", () => {
     expect(analyzeGeneratedProse("A ROBUST, Cutting-Edge result.").puffery).toBe(2);
   });
 
-  it("reports long sentences but keeps them out of the tell count", () => {
-    // A long sentence can be the right sentence — surfaced, never scored.
+  it("keeps long sentences out of the TELL count but lets them set the zone", () => {
+    // BI-41F15FD7, corrected against the corpus. Long sentences are not word-list
+    // tells, but sentence length is the readability problem this corpus actually
+    // has: 64% of real messages contain one, and 19.2% of all sentences are long.
     const long = `${"word ".repeat(40)}end.`;
     const reading = analyzeGeneratedProse(long);
 
     expect(reading.longSentences).toBe(1);
     expect(reading.tells).toBe(0);
+    expect(reading.longSentenceRatio).toBe(1);
+    expect(reading.zone).toBe("noticeable");
+  });
+
+  it("does not flag prose at or under the measured p90 long-sentence ratio", () => {
+    // Baseline is p90, not the median, on purpose: at the median half the corpus
+    // would flag every day, which is a number nobody reads.
+    const short = "Short one. Another short one. A third short one.";
+    const reading = analyzeGeneratedProse(short);
+
+    expect(reading.longSentenceRatio).toBeLessThanOrEqual(LONG_SENTENCE_RATIO_BASELINE);
     expect(reading.zone).toBe("clean");
   });
 
@@ -81,5 +95,13 @@ describe("classifyGeneratedProse", () => {
   it("never divides by zero on empty text", () => {
     expect(classifyGeneratedProse(0, 0)).toBe("clean");
     expect(classifyGeneratedProse(2, 0)).toBe("slop");
+  });
+
+  it("treats the two signals independently", () => {
+    // A word-list tell is rare and specific; a high long-sentence ratio is
+    // common and diffuse. Either can raise the zone on its own.
+    expect(classifyGeneratedProse(0, 10, 0.9)).toBe("noticeable");
+    expect(classifyGeneratedProse(1, 10, 0)).toBe("noticeable");
+    expect(classifyGeneratedProse(0, 10, 0.1)).toBe("clean");
   });
 });

--- a/apps/web/lib/prose/generated-prose.ts
+++ b/apps/web/lib/prose/generated-prose.ts
@@ -78,11 +78,47 @@ export type GeneratedProseAxes = {
 export type GeneratedProseZone = "clean" | "noticeable" | "slop";
 
 export type GeneratedProseReading = GeneratedProseAxes & {
-  /** Total tells across the three content axes. Long sentences are reported
-   *  but excluded — a long sentence can be the right sentence. */
+  /** Total tells across the three word-list axes. */
   tells: number;
+  /** Long sentences as a share of all sentences. The axis that actually
+   *  carries signal in this corpus — see LONG_SENTENCE_RATIO_BASELINE. */
+  longSentenceRatio: number;
   zone: GeneratedProseZone;
 };
+
+/**
+ * Measured on the live install, 2026-08-23, over 899 model-written coworker
+ * messages (BI-41F15FD7):
+ *
+ *   word-list tells   2 puffery + 1 superficial -ing + 0 chatbot filler
+ *                     -> 0.3% of messages scored anything at all
+ *   long sentences    686 of 3,582 sentences (19.2%)
+ *                     575 of 899 messages contained at least one (64%)
+ *                     per-message ratio: median 0.25, p90 0.33
+ *
+ * The word lists were ported from a critique of long-form AI marketing prose.
+ * DPF coworker output is short operational status text, which has no room for
+ * puffery and no reason for throat-clearing, so those axes fire on almost
+ * nothing. Sentence length is the readability problem this corpus actually has.
+ *
+ * CHOOSING THE THRESHOLD. The ratio is lumpy, because most messages are only
+ * three or four sentences long, so values pile up on 0, 0.25 and one third.
+ * p75, p90 and p95 are ALL 0.33. That makes the quantiles useless as a dial:
+ *
+ *   > 1/3   ->  31 messages   3.4%
+ *   >= 1/3  -> 226 messages  25.1%
+ *
+ * The rule is therefore "MORE than a third of the sentences run long", which
+ * excludes the very common one-long-sentence-in-three shape. That shape is not
+ * a defect, and flagging a quarter of all output every day produces a number
+ * nobody reads. Strictly-greater comparison against 1/3 does this exactly:
+ * a computed 1/3 is not greater than the literal 1/3.
+ *
+ * Derived from one corpus measurement, not a law. Re-derive it when the corpus
+ * changes rather than nudging it by feel — and note the metric is dominated by
+ * message length, so it is a weak signal on very short replies.
+ */
+export const LONG_SENTENCE_RATIO_BASELINE = 1 / 3;
 
 function countOccurrences(haystack: string, needle: string): number {
   if (!needle) return 0;
@@ -124,6 +160,9 @@ export function analyzeGeneratedProse(text: string): GeneratedProseReading {
   const longSentences = sentenceList.filter((s) => wordCount(s) > LONG_SENTENCE_WORDS).length;
 
   const tells = puffery + superficialIng + chatbotFiller;
+  const longSentenceRatio = sentenceList.length
+    ? longSentences / sentenceList.length
+    : 0;
 
   return {
     puffery,
@@ -132,24 +171,34 @@ export function analyzeGeneratedProse(text: string): GeneratedProseReading {
     longSentences,
     sentences: sentenceList.length,
     tells,
-    zone: classifyGeneratedProse(tells, sentenceList.length),
+    longSentenceRatio,
+    zone: classifyGeneratedProse(tells, sentenceList.length, longSentenceRatio),
   };
 }
 
 /**
- * Band the tell count by density rather than absolute count, so a long report
- * is not penalized for being long and a two-sentence alert is not excused for
- * being short.
+ * Band by density rather than absolute count, so a long report is not penalized
+ * for being long and a two-sentence alert is not excused for being short.
  *
- * Thresholds are heuristic and deliberately loose — this gauge exists to make
- * a regression visible, not to adjudicate style. Tighten them from a baseline,
- * not from taste.
+ * Two independent signals, because they mean different things. A word-list tell
+ * is rare and specific — worth surfacing on its own. A high long-sentence ratio
+ * is common and diffuse — worth surfacing only past the measured p90.
+ *
+ * These thresholds now come from a corpus measurement rather than taste; the
+ * word-list bands are unchanged and remain unvalidated at the `slop` end, which
+ * production has never reached.
  */
-export function classifyGeneratedProse(tells: number, sentences: number): GeneratedProseZone {
-  if (tells === 0) return "clean";
+export function classifyGeneratedProse(
+  tells: number,
+  sentences: number,
+  longSentenceRatio = 0,
+): GeneratedProseZone {
   const density = tells / Math.max(sentences, 1);
   if (density >= 0.5 || tells >= 6) return "slop";
-  return "noticeable";
+  if (tells > 0) return "noticeable";
+  // No word-list tells: the sentence-length axis decides.
+  if (longSentenceRatio > LONG_SENTENCE_RATIO_BASELINE) return "noticeable";
+  return "clean";
 }
 
 /**

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -778,7 +778,7 @@ describe("runAgenticLoop", () => {
       agentId: "admin-assistant",
     });
 
-    expect(result.content).toContain("try again in about 30 seconds");
+    expect(result.content).toMatch(/Nothing is misconfigured/); // BI-33F1EA72 hand-off
     expect(result.content).not.toContain("Model Assignment");
   });
 

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -49,6 +49,7 @@ import { clampToolResultForModel, resolveToolResultCharCap } from "./tool-result
 import { applyBacklogCreateClaimGuard } from "./backlog-create-claim-guard";
 import { applyEscalationLadderGuard, buildHumanHandoff } from "./escalation-ladder";
 import { logGeneratedProse } from "../prose/generated-prose"; // BI-41F15FD7
+import { noEligibleModelHandoff, providersBusyHandoff, providerUnreachableHandoff } from "./inference-dead-ends";
 import { assessToolSurface, computeToolSelectionAccuracy, contextEconomyTurnMetricFields } from "./context-economy-metrics";
 import { summarizeDroppedMessages } from "./compaction-digest";
 import { describeContextCapacityFailure } from "./context-capacity-failure";
@@ -196,24 +197,16 @@ export function describeToolRouteFailure(
   // branch above misses it and — before this fix — it fell through to the generic
   // "temporarily unavailable, try again in 30 seconds" below. That is a LIE for a
   if (/No eligible endpoints/i.test(msg)) {
-    return (
-      "No AI model can handle this request right now. No eligible model met this " +
-      "turn's routing requirements. The cause can be provider availability, data-policy " +
-      "or residency limits, capability requirements, or context size — not necessarily " +
-      "a disconnected provider. Open Platform > AI Operations > Providers & Routing " +
-      "to review the active route and provider status."
-    );
+    return noEligibleModelHandoff();
   }
 
   // Endpoints exist but all transiently failed (rate-limit / overload / network).
   if (/All endpoints failed/i.test(msg)) {
-    return (
-      "The AI providers are momentarily busy (usually rate-limited or overloaded). " +
-      "Please try again in about 30 seconds — no setup change is needed."
-    );
+    return providersBusyHandoff();
   }
 
-  return "The AI provider is temporarily unavailable. Please try again in about 30 seconds.";
+  // Most common dead end on a real install: 114 of 196 (BI-33F1EA72).
+  return providerUnreachableHandoff();
 }
 
 // Narration patterns: agent describes code or announces intent instead of calling tools.

--- a/apps/web/lib/tak/inference-dead-ends.test.ts
+++ b/apps/web/lib/tak/inference-dead-ends.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  noEligibleModelHandoff,
+  providersBusyHandoff,
+  providerUnreachableHandoff,
+} from "./inference-dead-ends";
+
+// BI-33F1EA72. Measured on the live install: 196 of 1,138 assistant messages
+// were dead ends, and 84% of those were provider availability — the paths the
+// hand-off rung originally did NOT cover.
+describe("dead-end replies hand off instead of asking the user to poll", () => {
+  const all = [
+    ["no eligible model", noEligibleModelHandoff()],
+    ["providers busy", providersBusyHandoff()],
+    ["provider unreachable", providerUnreachableHandoff()],
+  ] as const;
+
+  it.each(all)("%s ends on the resumption, not on the limitation", (_name, message) => {
+    const lastLine = message.trimEnd().split("\n").pop() ?? "";
+    expect(lastLine).toMatch(/pick this|straight back up/i);
+  });
+
+  it.each(all)("%s gives at least one numbered step", (_name, message) => {
+    expect(message).toMatch(/^1\. /m);
+  });
+
+  it("stops telling the user to poll on the most common dead end", () => {
+    // The prior copy was "Please try again in about 30 seconds." — a poll
+    // instruction with no step and no resumption. 114 of 196 dead ends.
+    const message = providerUnreachableHandoff();
+    expect(message).not.toMatch(/try again in about 30 seconds/i);
+    expect(message).toMatch(/Providers & Routing/);
+  });
+
+  it("keeps the genuinely transient case short rather than inventing config steps", () => {
+    // Nothing is misconfigured when every endpoint is rate-limited, so a
+    // three-step "go check your settings" would be a fabricated instruction.
+    const message = providersBusyHandoff();
+    expect(message).toMatch(/Nothing is misconfigured/);
+    expect(message).not.toMatch(/^2\. /m);
+  });
+
+  it("names the routing causes rather than blaming a disconnected provider", () => {
+    const message = noEligibleModelHandoff();
+    expect(message).toMatch(/residency|data-policy/);
+    expect(message).toMatch(/context size/);
+  });
+});

--- a/apps/web/lib/tak/inference-dead-ends.ts
+++ b/apps/web/lib/tak/inference-dead-ends.ts
@@ -1,0 +1,62 @@
+// apps/web/lib/tak/inference-dead-ends.ts
+//
+// The replies a coworker gives when no model answered (BI-33F1EA72).
+//
+// WHY THESE LIVE TOGETHER, AND HERE. Measured on the live install
+// (2026-08-23, served b8777fbb1952): 196 of 1,138 assistant messages — 17.2% —
+// were dead ends, and they were dominated by provider availability:
+//
+//     provider temporarily unavailable      114   58%
+//     providers momentarily busy             50   26%
+//     no eligible model / routing            19   10%
+//     local model not strong enough          12    6%
+//
+// Rung 4 of the escalation ladder was originally wired only to the last of
+// those — 6% of the problem — because that was the one string I had seen in a
+// session log. The other 84% still ended on "Please try again in about 30
+// seconds", which asks the user to poll and is the exact shape the rung exists
+// to replace: it names a limitation and stops.
+//
+// Kept out of agentic-loop.ts because that file is the largest module in the
+// repo and its size ratchet only permits shrinking; copy this length does not
+// belong in that budget.
+import { buildHumanHandoff } from "./escalation-ladder";
+
+/** Routing eliminated every candidate — a real configuration question. */
+export function noEligibleModelHandoff(): string {
+  return buildHumanHandoff({
+    blocker:
+      "No AI model can handle this request right now — no available model met this turn's requirements.",
+    steps: [
+      "Open Platform > AI Operations > Providers & Routing.",
+      "Check the active route for this coworker: provider status, data-policy or residency limits, capability requirements, and context size.",
+    ],
+    verify: "re-check which models this coworker can reach",
+  });
+}
+
+/**
+ * Endpoints exist but all transiently failed. Genuinely nothing to configure,
+ * so the hand-off is one step — but it stays a hand-off, so the reply ends on
+ * the user's next action rather than on the outage.
+ */
+export function providersBusyHandoff(): string {
+  return buildHumanHandoff({
+    blocker:
+      "Every AI provider is busy right now — usually rate-limited or briefly overloaded. Nothing is misconfigured.",
+    steps: ["Give it about 30 seconds, then send the message again."],
+    verify: "pick this up on the next try",
+  });
+}
+
+/** The single most common dead end on a real install. */
+export function providerUnreachableHandoff(): string {
+  return buildHumanHandoff({
+    blocker: "I can't reach an AI provider at the moment, so I couldn't answer this.",
+    steps: [
+      "Open Platform > AI Operations > Providers & Routing.",
+      "Reconnect or add a provider — an expired sign-in or exhausted quota is the usual cause.",
+    ],
+    verify: "confirm a provider is reachable",
+  });
+}


### PR DESCRIPTION
Two corrections to work I shipped earlier this week. Both come from measuring the live install rather than from judgement, and both replace a guess with a number.

## 1. The hand-off rung was aimed at 6% of the problem (BI-33F1EA72)

Counting every assistant message on the install (1,138 rows, served `b8777fbb1952`), **196 are dead-end replies — 17.2%, nearly one in five**:

| dead end | count | share |
|---|---|---|
| provider temporarily unavailable | **114** | 58% |
| providers momentarily busy | 50 | 26% |
| no eligible model / routing | 19 | 10% |
| **local model not strong enough** — the only path the rung covered | **12** | **6%** |

I picked that call site from the one dead-end string I'd personally seen in a session log. One query against `AgentMessage` would have ranked them before I wrote a line. The other 84% still ended on *"Please try again in about 30 seconds"* — asking the user to poll, which is precisely the shape rung 4 exists to replace.

All three provider paths now hand off. Copy lives in a new `inference-dead-ends.ts` rather than growing `agentic-loop.ts`, whose size ratchet only permits shrinking.

One deliberate asymmetry: the transient case keeps **one** step and says *"Nothing is misconfigured."* Inventing a three-step go-check-your-settings for a rate limit would be a fabricated instruction.

## 2. The prose gauge fired on 0.3% of real output (BI-41F15FD7)

Ran the gauge over **899 model-written coworker messages**. It flagged **0.3%** — 2 puffery hits, 1 superficial `-ing`, **0 chatbot filler** in the entire corpus. The word lists were ported from a critique of long-form AI marketing prose; DPF coworkers write short operational status text with no room for puffery.

The signal that exists is the one I deliberately discarded: **686 of 3,582 sentences run long (19.2%), across 64% of messages.** Excluding it also made the gauge inconsistent with its sibling `check-prose-lint.ts`, which already scores that axis at the same 25-word threshold.

Choosing the threshold needed the distribution, not a quantile — most replies are three or four sentences, so ratios pile up on 0, 0.25 and one third, and **p75, p90 and p95 are all 0.33**:

```
>  1/3    31 messages   3.4%
>= 1/3   226 messages  25.1%
```

The rule is "**more than** a third of sentences run long", which excludes the very common one-in-three shape. Strictly-greater against `1/3` does that exactly. Re-measured after: **3.8% flagged, up from 0.3%** — a number someone might act on rather than one nobody reads. Word lists stay, demoted to a regression tripwire.

## Evidence

- pregate **PASS** on `2044fca01dd4`
- 1,376 tests across `lib/tak` and `lib/prose`; `tsc` clean; module-size ratchet at zero growth; 47 preflight guards clean
- Design-grounding section in the commit

## Why the gauge still isn't observed firing live

At the current (old) tuning it fires on ~1 message in 300, so no realistic number of hand-driven turns separates "ran and found clean" from "didn't run". **That unobservability is itself the evidence of the mistuning.** Once this lands, ~3.8% is observable and the verification becomes trivial.

## Worth pressing on

1. The dead-end counts come from a corpus snapshot. The live panel showed better copy than some sampled rows, so a few of the 196 may predate improvements already made — the ranking is what matters, not the absolute.
2. `1/3` is derived from one corpus measurement. Re-derive when the corpus changes rather than nudging it by feel; the metric is weak on very short replies.
3. Unrelated but noticed while verifying: "Say hello in one short sentence" was classified evidence-required, nudged, then downgraded to could-not-verify. A greeting shouldn't need evidence, and that guard may be contributing to the dead-end rate measured above.

Addresses BI-33F1EA72 and BI-41F15FD7.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)