### PR TITLE
chore(tests): name-set referential integrity — remaining tool/infra name-sets resolve (BI-47629B5B)

### DIFF
--- a/apps/web/lib/mcp/name-set-referential-integrity.test.ts
+++ b/apps/web/lib/mcp/name-set-referential-integrity.test.ts
@@ -1,0 +1,145 @@
+// Name-set referential integrity — mechanism M1 of the late-defect-detection
+// hardening plan (BI-47629B5B, docs/superpowers/plans/
+// 2026-08-16-late-defect-detection-hardening-plan.md).
+//
+// A hardcoded name that resolves to no registered tool gates nothing while
+// reading as coverage (the ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES incident: seven
+// of nine names matched nothing). Every name-set that gates behavior must
+// therefore resolve against the registry it indexes into.
+//
+// Covered-set completeness note — the tool name-sets that gate behavior and
+// where each is resolution-tested:
+//   - ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES ......... here
+//   - PRECONDITION_TOOL_NAMES .................... here (also the only names
+//     hardcoded inside collaborationShapeForTool, which now reads these same
+//     exported sets — no third copy exists)
+//   - TOOL_TO_GRANTS keys ........................ here
+//   - CONSEQUENTIAL_DECISION_TOOLS ............... lib/tak/consequential-tool-coverage.test.ts
+//   - CORE_MCP_TOOL_NAMES ........................ lib/mcp/tool-tier.test.ts
+//     ("CORE_MCP_TOOL_NAMES drift guard")
+//   - prometheus scrape targets vs compose services
+//     ............................................ scripts/check-no-unresolved-prometheus-targets.mjs
+// New name-keyed gate lists must be added here or carry their own
+// resolution test.
+
+import { describe, expect, it } from "vitest";
+
+import { PLATFORM_TOOLS } from "@/lib/mcp-tools";
+import { BROWSER_USE_SERVER_SLUG } from "@/lib/browser-drive/sidecar";
+import { TOOL_TO_GRANTS, WORKROOM_TOOL_ALIASES } from "@/lib/tak/agent-grants";
+import {
+  ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES,
+  PRECONDITION_TOOL_NAMES,
+} from "@/lib/tak/consequential-tool-policy";
+
+/**
+ * Names from `names` that resolve to nothing. A name resolves when it is in
+ * `resolvable`, or when it is a namespaced external-server tool
+ * (`<serverSlug>__<toolName>`) whose slug is in `allowedNamespaces` — external
+ * sidecars own their own tool suffixes, so the repo can only vouch for the
+ * namespace prefix (see the browser-use entries in TOOL_TO_GRANTS).
+ */
+export function unresolvedNames(
+  names: Iterable<string>,
+  resolvable: ReadonlySet<string>,
+  allowedNamespaces: readonly string[] = [],
+): string[] {
+  const out: string[] = [];
+  for (const name of names) {
+    if (resolvable.has(name)) continue;
+    const sep = name.indexOf("__");
+    if (sep > 0 && allowedNamespaces.includes(name.slice(0, sep))) continue;
+    out.push(name);
+  }
+  return out;
+}
+
+const CATALOG_NAMES: ReadonlySet<string> = new Set(PLATFORM_TOOLS.map((t) => t.name));
+
+describe("unresolvedNames (the helper itself — red cases on fabricated sets)", () => {
+  const registry = new Set(["real_tool", "other_tool"]);
+
+  it("flags a phantom name added to a copy of a clean set", () => {
+    expect(unresolvedNames(["real_tool"], registry)).toEqual([]);
+    // The red case: one fabricated phantom, and the helper names it.
+    expect(unresolvedNames(["real_tool", "launch_campaign"], registry)).toEqual([
+      "launch_campaign",
+    ]);
+  });
+
+  it("resolves a namespaced name only through an allowed namespace", () => {
+    expect(unresolvedNames(["srv__anything"], registry, ["srv"])).toEqual([]);
+    expect(unresolvedNames(["rogue-srv__anything"], registry, ["srv"])).toEqual([
+      "rogue-srv__anything",
+    ]);
+    // A bare "__suffix" name has no slug; it must not slip through.
+    expect(unresolvedNames(["__anything"], registry, [""])).toEqual(["__anything"]);
+  });
+});
+
+describe("live name-sets resolve against the live catalog", () => {
+  it("every ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES entry is a registered tool", () => {
+    expect(unresolvedNames(ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES, CATALOG_NAMES)).toEqual([]);
+  });
+
+  it("every PRECONDITION_TOOL_NAMES entry is a registered tool", () => {
+    expect(unresolvedNames(PRECONDITION_TOOL_NAMES, CATALOG_NAMES)).toEqual([]);
+  });
+
+  // Retired tool names that deliberately KEEP a TOOL_TO_GRANTS row: a stale
+  // model call to them must reach the pack's removed-guard handler (which says
+  // "Tool removed — use X instead") rather than dying in default-deny with a
+  // misleading authorization error. See sandbox-pack.ts (iterateSandbox).
+  // Shrink-only: if one of these names comes back as a live catalog tool,
+  // remove it here; never add a name without a removed-guard rationale.
+  const RETIRED_GUARD_ROWS = ["launch_sandbox", "generate_code", "iterate_sandbox"] as const;
+
+  it("every TOOL_TO_GRANTS key resolves — catalog tool, pinned workroom alias, namespaced sidecar tool, or listed retirement guard", () => {
+    // Alias keys are legitimate non-catalog names ONLY because the sibling
+    // agent-grants test pins each one to a defined canonical row; anything
+    // else must be a live catalog tool, a namespaced/bare sidecar tool
+    // (checked separately below), or a listed retirement-guard row.
+    const resolvable = new Set([
+      ...CATALOG_NAMES,
+      ...Object.keys(WORKROOM_TOOL_ALIASES),
+      ...RETIRED_GUARD_ROWS,
+      // Bare sidecar names are admitted only via their namespaced twin — the
+      // mirror test below is what makes this admission referential.
+      ...Object.keys(TOOL_TO_GRANTS)
+        .filter((k) => k.startsWith(`${BROWSER_USE_SERVER_SLUG}__`))
+        .map((k) => k.slice(BROWSER_USE_SERVER_SLUG.length + 2)),
+    ]);
+    const unresolved = unresolvedNames(Object.keys(TOOL_TO_GRANTS), resolvable, [
+      BROWSER_USE_SERVER_SLUG,
+    ]);
+    expect(
+      unresolved,
+      `TOOL_TO_GRANTS keys that resolve to no registered tool (a key that matches nothing grants nothing — or worse, waits to silently authorize a future tool of the same name): ${unresolved.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("keeps the retirement-guard list honest — none of its names is a live catalog tool", () => {
+    for (const name of RETIRED_GUARD_ROWS) {
+      expect(
+        CATALOG_NAMES.has(name),
+        `${name} is live again — remove it from RETIRED_GUARD_ROWS`,
+      ).toBe(false);
+    }
+  });
+
+  it("gives every bare sidecar row the SAME grants as its namespaced twin (pre-namespace rows cannot drift in authority)", () => {
+    const bareRows = Object.keys(TOOL_TO_GRANTS).filter(
+      (k) => !k.includes("__") && TOOL_TO_GRANTS[`${BROWSER_USE_SERVER_SLUG}__${k}`] !== undefined,
+    );
+    expect(bareRows.length).toBeGreaterThan(0); // browse_open et al.
+    for (const bare of bareRows) {
+      expect(TOOL_TO_GRANTS[bare], `${bare} must match its namespaced twin`).toEqual(
+        TOOL_TO_GRANTS[`${BROWSER_USE_SERVER_SLUG}__${bare}`],
+      );
+    }
+  });
+
+  it("every workroom alias VALUE (canonical name) is a registered tool", () => {
+    expect(unresolvedNames(Object.values(WORKROOM_TOOL_ALIASES), CATALOG_NAMES)).toEqual([]);
+  });
+});

--- a/apps/web/lib/tak/consequential-tool-policy.ts
+++ b/apps/web/lib/tak/consequential-tool-policy.ts
@@ -38,7 +38,15 @@ export const ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES = [
   "create_marketing_campaign",
 ] as const;
 const EXPLICIT = new Set<string>(ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES);
-const PRECONDITION = new Set(["transition_employee_status"]);
+/**
+ * Name-keyed precondition list (like ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES, it
+ * predates the declared consequence axis). Exported so the name-set
+ * referential-integrity test (lib/mcp/name-set-referential-integrity.test.ts)
+ * can prove every name resolves to a live catalog tool — a name that resolves
+ * to nothing gates nothing (BI-47629B5B).
+ */
+export const PRECONDITION_TOOL_NAMES = ["transition_employee_status"] as const;
+const PRECONDITION = new Set<string>(PRECONDITION_TOOL_NAMES);
 
 /** Alignment applies to what leaves the business, not to internal platform ops. */
 function alignmentRequiredFor(toolName: string, consequence: ToolConsequence | undefined): boolean {
@@ -49,10 +57,11 @@ export function collaborationShapeForTool(
   toolName: string,
   consequence?: ToolConsequence,
 ): WorkroomShapeKey | null {
-  if (["create_digital_product", "create_marketing_campaign"].includes(toolName)) {
-    return "specialist-alignment";
-  }
-  if (toolName === "transition_employee_status") return "change-consequential";
+  // Single-source: these are the same name-keyed legacy lists declared above
+  // (EXPLICIT / PRECONDITION), not a third hand-maintained copy — so the
+  // referential-integrity test over those exports covers this function too.
+  if (EXPLICIT.has(toolName)) return "specialist-alignment";
+  if (PRECONDITION.has(toolName)) return "change-consequential";
   if (consequence === "outward") return "outward-review";
   if (consequence === "irreversible") return "change-consequential";
   return null;

--- a/scripts/check-no-unresolved-prometheus-targets.mjs
+++ b/scripts/check-no-unresolved-prometheus-targets.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * M1 name-set referential integrity — infra tier (BI-47629B5B,
+ * docs/superpowers/plans/2026-08-16-late-defect-detection-hardening-plan.md).
+ *
+ * A Prometheus scrape target is a hardcoded name-set entry that gates behavior:
+ * `up == 0` for a target that no longer exists fires ContainerDown/health
+ * banners forever. Two shipped incidents in this class:
+ *   - BI-31FDC859: a scrape job kept targeting a retired service, producing a
+ *     permanent false "Memory offline" banner;
+ *   - BI-7988DAD8: the portal probed a sidecar on a path it never served
+ *     (name-shaped config drifting from the thing it names).
+ *
+ * This guard asserts every ACTIVE (non-commented) scrape target host in
+ * monitoring/prometheus/*.yml resolves to a service name or container_name
+ * defined in the docker-compose*.yml files shipped at the repo root, or to one
+ * of the deliberate non-compose hosts (localhost self-scrape,
+ * host.docker.internal for native host exporters).
+ *
+ * The union of ALL root compose files is the resolution universe on purpose:
+ * which overlay mounts which prometheus file is substrate-specific, but a
+ * target matching NO compose file on any substrate is exactly the retired-
+ * service drift this guard exists to refuse.
+ *
+ *   node scripts/check-no-unresolved-prometheus-targets.mjs   # check (CI)
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const PROMETHEUS_DIR = join(REPO_ROOT, "monitoring", "prometheus");
+
+/**
+ * Hosts that legitimately resolve outside compose: Prometheus's own
+ * self-scrape, and the Docker Desktop / native-host bridge used by the
+ * windows_exporter job. Additions here need the same "why is this not a
+ * compose service" rationale.
+ */
+export const NON_COMPOSE_HOSTS = Object.freeze(["localhost", "host.docker.internal"]);
+
+/**
+ * Active (non-commented) scrape targets from a Prometheus config source.
+ * Handles both inline arrays (`- targets: ["a:1", "b:2"]`) and block lists
+ * (`- targets:` followed by `- "a:1"` items). Returns {job, host, target}.
+ */
+export function parseScrapeTargets(source) {
+  const out = [];
+  let job = null;
+  let inTargetsBlock = false;
+  let targetsIndent = 0;
+  for (const raw of source.split(/\r?\n/)) {
+    const line = raw.replace(/\t/g, "  ");
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#") || trimmed === "") continue;
+    const indent = line.length - line.trimStart().length;
+
+    const jobMatch = /^-?\s*job_name:\s*["']?([^"']+?)["']?\s*$/.exec(trimmed);
+    if (jobMatch) {
+      job = jobMatch[1];
+      inTargetsBlock = false;
+      continue;
+    }
+
+    const inline = /^-?\s*targets:\s*\[(.*)\]\s*$/.exec(trimmed);
+    if (inline) {
+      for (const m of inline[1].matchAll(/["']([^"']+)["']/g)) {
+        out.push(toTarget(job, m[1]));
+      }
+      inTargetsBlock = false;
+      continue;
+    }
+
+    if (/^-?\s*targets:\s*$/.test(trimmed)) {
+      inTargetsBlock = true;
+      targetsIndent = indent;
+      continue;
+    }
+
+    if (inTargetsBlock) {
+      const item = /^-\s*["']?([^"'\s]+?)["']?\s*$/.exec(trimmed);
+      if (item && indent > targetsIndent) {
+        out.push(toTarget(job, item[1]));
+        continue;
+      }
+      inTargetsBlock = false;
+    }
+  }
+  return out;
+}
+
+function toTarget(job, target) {
+  const host = target.replace(/:\d+$/, "");
+  return { job: job ?? "(no job_name)", host, target };
+}
+
+/**
+ * Service names and container_name values a compose file defines. Top-level
+ * `services:` children only — nested keys (environment, labels…) sit deeper
+ * than the two-space service indent.
+ */
+export function parseComposeServiceNames(source) {
+  const names = new Set();
+  let inServices = false;
+  for (const raw of source.split(/\r?\n/)) {
+    const line = raw.replace(/\t/g, "  ");
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#") || trimmed === "") continue;
+    if (/^[A-Za-z_-]+:/.test(line)) {
+      // A new top-level key: entering or leaving the services block.
+      inServices = line.startsWith("services:");
+      continue;
+    }
+    if (!inServices) continue;
+    const svc = /^  ([A-Za-z0-9._-]+):\s*(#.*)?$/.exec(line);
+    if (svc) names.add(svc[1]);
+    const containerName = /^\s+container_name:\s*["']?([A-Za-z0-9._-]+)["']?\s*$/.exec(line);
+    if (containerName) names.add(containerName[1]);
+  }
+  return names;
+}
+
+/**
+ * Pure evaluation: every scrape target host in every prometheus config must be
+ * a compose-defined service/container name or a listed non-compose host.
+ * Returns a list of error strings.
+ */
+export function evaluatePrometheusTargets({ prometheusConfigs, composeSources }) {
+  const errors = [];
+  const resolvable = new Set(NON_COMPOSE_HOSTS);
+  for (const src of composeSources) {
+    for (const name of parseComposeServiceNames(src)) resolvable.add(name);
+  }
+  if (resolvable.size === NON_COMPOSE_HOSTS.length) {
+    errors.push("no compose service names found — compose parsing is broken or the compose files moved");
+    return errors;
+  }
+  for (const { path, source } of prometheusConfigs) {
+    const targets = parseScrapeTargets(source);
+    if (targets.length === 0) {
+      errors.push(`${path}: no active scrape targets parsed — the config moved or the parser regressed`);
+      continue;
+    }
+    for (const { job, host, target } of targets) {
+      if (!resolvable.has(host)) {
+        errors.push(
+          `${path}: job "${job}" scrapes "${target}" but "${host}" is not a service/container in any docker-compose*.yml — a retired or renamed service here fires a permanent false down-alert (BI-31FDC859)`,
+        );
+      }
+    }
+  }
+  return errors;
+}
+
+function loadInputs() {
+  const prometheusConfigs = readdirSync(PROMETHEUS_DIR)
+    .filter((f) => /^prometheus.*\.ya?ml$/.test(f))
+    .map((f) => {
+      const path = join("monitoring", "prometheus", f);
+      const source = readFileSync(join(PROMETHEUS_DIR, f), "utf8");
+      return { path, source };
+    })
+    .filter(({ source }) => /^scrape_configs:/m.test(source));
+  const composeSources = readdirSync(REPO_ROOT)
+    .filter((f) => /^docker-compose.*\.ya?ml$/.test(f))
+    .map((f) => readFileSync(join(REPO_ROOT, f), "utf8"));
+  return { prometheusConfigs, composeSources };
+}
+
+function main() {
+  const { prometheusConfigs, composeSources } = loadInputs();
+  if (prometheusConfigs.length === 0) {
+    console.error("no Prometheus scrape configs found under monitoring/prometheus/ — the guard's discovery regressed");
+    process.exit(1);
+  }
+  const errors = evaluatePrometheusTargets({ prometheusConfigs, composeSources });
+  if (errors.length > 0) {
+    console.error("Prometheus scrape-target referential integrity failed (M1, BI-47629B5B):\n");
+    for (const e of errors) console.error(`  - ${e}`);
+    console.error(
+      "\nEvery scrape target must name a service defined in a root docker-compose*.yml",
+    );
+    console.error(
+      "(or a listed NON_COMPOSE_HOSTS entry). Retiring a service means retiring its",
+    );
+    console.error("scrape job in the same change — comment it out with the rationale.");
+    process.exit(1);
+  }
+  console.log(
+    `Prometheus scrape-target referential integrity OK — ${prometheusConfigs.length} config(s), every active target resolves to a compose service or a listed non-compose host.`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-no-unresolved-prometheus-targets.test.mjs
+++ b/scripts/check-no-unresolved-prometheus-targets.test.mjs
@@ -1,0 +1,162 @@
+// scripts/check-no-unresolved-prometheus-targets.test.mjs
+//
+// Unit coverage for the M1 (BI-47629B5B) Prometheus scrape-target referential
+// integrity guard: every active scrape target must name a compose-defined
+// service (or a listed non-compose host); a retired service left in a scrape
+// job (the BI-31FDC859 "Memory offline" incident) is refused.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  NON_COMPOSE_HOSTS,
+  parseScrapeTargets,
+  parseComposeServiceNames,
+  evaluatePrometheusTargets,
+} from "./check-no-unresolved-prometheus-targets.mjs";
+
+const GOOD_PROM = `
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "postgres"
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+
+  # A commented-out job must not count:
+  # - job_name: "neo4j"
+  #   static_configs:
+  #     - targets: ["neo4j:2004"]
+
+  - job_name: "sandbox"
+    static_configs:
+      - targets:
+          - "sandbox:3000"
+    metrics_path: /api/metrics
+
+  - job_name: "windows-host"
+    static_configs:
+      - targets: ["host.docker.internal:9182"]
+        labels:
+          instance: "windows-host"
+
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+`;
+
+const GOOD_COMPOSE = `
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: dpf
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter
+  sandbox:
+    container_name: dpf-sandbox
+    ports:
+      - "3000:3000"
+volumes:
+  pgdata: {}
+`;
+
+test("parseScrapeTargets reads inline arrays, block lists, and skips comments", () => {
+  const targets = parseScrapeTargets(GOOD_PROM);
+  assert.deepEqual(
+    targets.map((t) => `${t.job}=${t.target}`),
+    [
+      "postgres=postgres-exporter:9187",
+      "sandbox=sandbox:3000",
+      "windows-host=host.docker.internal:9182",
+      "prometheus=localhost:9090",
+    ],
+  );
+});
+
+test("parseComposeServiceNames reads service keys and container_name, not nested keys", () => {
+  const names = parseComposeServiceNames(GOOD_COMPOSE);
+  assert.deepEqual(
+    [...names].sort(),
+    ["dpf-sandbox", "postgres", "postgres-exporter", "sandbox"],
+  );
+  // Nested keys (environment, ports) and non-service top-level keys must not leak in.
+  assert.ok(!names.has("environment"));
+  assert.ok(!names.has("pgdata"));
+});
+
+test("the clean shape passes", () => {
+  const errors = evaluatePrometheusTargets({
+    prometheusConfigs: [{ path: "monitoring/prometheus/prometheus.yml", source: GOOD_PROM }],
+    composeSources: [GOOD_COMPOSE],
+  });
+  assert.deepEqual(errors, []);
+});
+
+test("RED: a scrape job for a retired service is refused (BI-31FDC859 shape)", () => {
+  const withRetired =
+    GOOD_PROM +
+    `
+  - job_name: "memory"
+    static_configs:
+      - targets: ["memory-service:9500"]
+`;
+  const errors = evaluatePrometheusTargets({
+    prometheusConfigs: [{ path: "prometheus.yml", source: withRetired }],
+    composeSources: [GOOD_COMPOSE],
+  });
+  assert.equal(errors.length, 1);
+  assert.ok(errors[0].includes('job "memory"'));
+  assert.ok(errors[0].includes("memory-service:9500"));
+  assert.ok(errors[0].includes("BI-31FDC859"));
+});
+
+test("RED: a block-list target for an unknown service is refused too", () => {
+  const errors = evaluatePrometheusTargets({
+    prometheusConfigs: [
+      {
+        path: "prometheus.yml",
+        source: GOOD_PROM.replace('- "sandbox:3000"', '- "ghost-sidecar:8080"'),
+      },
+    ],
+    composeSources: [GOOD_COMPOSE],
+  });
+  assert.equal(errors.length, 1);
+  assert.ok(errors[0].includes("ghost-sidecar"));
+});
+
+test("a container_name target resolves like a service name", () => {
+  const errors = evaluatePrometheusTargets({
+    prometheusConfigs: [
+      {
+        path: "prometheus.yml",
+        source: GOOD_PROM.replace('- "sandbox:3000"', '- "dpf-sandbox:3000"'),
+      },
+    ],
+    composeSources: [GOOD_COMPOSE],
+  });
+  assert.deepEqual(errors, []);
+});
+
+test("RED: a config whose targets all vanished is a parser/move failure, not a silent pass", () => {
+  const errors = evaluatePrometheusTargets({
+    prometheusConfigs: [{ path: "prometheus.yml", source: "global:\n  scrape_interval: 15s\n" }],
+    composeSources: [GOOD_COMPOSE],
+  });
+  assert.equal(errors.length, 1);
+  assert.ok(errors[0].includes("no active scrape targets"));
+});
+
+test("RED: empty compose parsing fails loudly instead of failing every target", () => {
+  const errors = evaluatePrometheusTargets({
+    prometheusConfigs: [{ path: "prometheus.yml", source: GOOD_PROM }],
+    composeSources: ["volumes:\n  pgdata: {}\n"],
+  });
+  assert.equal(errors.length, 1);
+  assert.ok(errors[0].includes("no compose service names found"));
+});
+
+test("the non-compose allowlist is exactly the two deliberate hosts", () => {
+  assert.deepEqual([...NON_COMPOSE_HOSTS], ["localhost", "host.docker.internal"]);
+});

--- a/scripts/ci-policy-test-inventory-allowlist.txt
+++ b/scripts/ci-policy-test-inventory-allowlist.txt
@@ -47,6 +47,7 @@ scripts/check-no-substrate-regression.test.mjs
 scripts/check-no-suitability-object-shorthand.test.mjs
 scripts/check-no-system-user-sentinel.test.mjs
 scripts/check-no-type-reexport-in-use-server.test.mjs
+scripts/check-no-unresolved-prometheus-targets.test.mjs
 scripts/check-reporting-composition.test.mjs
 scripts/check-style-drift.test.mjs
 scripts/ci-evidence-receipt-discovery.test.mjs


### PR DESCRIPTION
Mechanism **M1** (class A — assertions against a name rather than a resolved thing) of the merged detection-hardening plan (#4395, umbrella BI-3D73CBC6, EP-413F2602).

## What

- `apps/web/lib/mcp/name-set-referential-integrity.test.ts`: every remaining gating name-set resolves against its registry — ALIGNMENT_CONSEQUENTIAL_TOOL_NAMES (no resolution test actually existed), the PRECONDITION set and `collaborationShapeForTool` names (now single-sourced from the exported sets instead of a third hand-copied list — behavior-preserving), and all 392 TOOL_TO_GRANTS keys.
- The TOOL_TO_GRANTS check **immediately caught 9 phantom keys**: 6 bare `browse_*` pre-namespace twins (now mirror-tested to keep grants identical to their namespaced rows) and 3 retired sandbox tool names (documented shrink-only RETIRED_GUARD_ROWS list + a test that fails if any comes back live).
- `scripts/check-no-unresolved-prometheus-targets.mjs` (auto-discovered): every active prometheus scrape-target host resolves to a compose service (the BI-31FDC859 retired-scrape-target shape); red cases included.
- CORE_MCP_TOOL_NAMES and CONSEQUENTIAL_DECISION_TOOLS were already covered (tool-tier drift guard, consequential-tool-coverage) — noted, not duplicated.

## Verification

- vitest: 5 files, 193/193 pass · guard self-test 9/9 · guard exit 0 on tree.
- Local-CI gate: **PASS** at 29e6fa655655 (slot-0, evidence cmt5gqkf11bre01o8f95aj3lm, verdict via pregate:status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)