### PR TITLE
fix(code-graph): stop an empty graph reporting healthy, and let a degraded read say so (BI-86EF5900, BI-4501D3C8)

### DIFF
--- a/apps/web/lib/build/code-graph-access.test.ts
+++ b/apps/web/lib/build/code-graph-access.test.ts
@@ -106,9 +106,13 @@ describe("getCodeGraphFreshness", () => {
       indexedFileCount: 42,
       lastError: null,
     } as never);
+    // Merged query (BI-86EF5900): benchmark relationship counts AND population
+    // in one round trip, so rows are tagged { kind, label, count }.
     mockQueryRawUnsafe.mockResolvedValue([
-      { relationship: "DEFINES", count: 10 },
-      { relationship: "IMPORTS", count: 20 },
+      { kind: "rel", label: "DEFINES", count: 10 },
+      { kind: "rel", label: "IMPORTS", count: 20 },
+      { kind: "pop", label: "nodes", count: 42 },
+      { kind: "pop", label: "edges", count: 30 },
     ]);
 
     const result = await getCodeGraphFreshness("source-code", {
@@ -126,6 +130,40 @@ describe("getCodeGraphFreshness", () => {
     expect(result.warnings).toContain(
       "Code graph structural relationships are missing: IMPLEMENTS_ROUTE, EXPOSES_TOOL, TESTED_BY.",
     );
+    expect(result.nodeCount).toBe(42);
+    expect(result.edgeCount).toBe(30);
+  });
+
+  // BI-86EF5900: the live failure shape — file hashes present, graph empty,
+  // status "ready". The warning must say so rather than letting the caller read
+  // an empty graph as an authoritative empty answer.
+  it("warns that an empty projection is not evidence of absence", async () => {
+    vi.mocked(prisma.codeGraphIndexState.findUnique).mockResolvedValue({
+      graphKey: "source-code",
+      indexStatus: "ready",
+      graphVersion: 3,
+      workspaceRoot: "/workspace",
+      lastIndexedAt: new Date("2026-05-13T00:00:00.000Z"),
+      lastIndexedBranch: "main",
+      lastIndexedHeadSha: "abc123",
+      workspaceDirty: false,
+      workspaceDirtyObservedAt: null,
+      indexedFileCount: 4406,
+      lastError: null,
+    } as never);
+    mockQueryRawUnsafe.mockResolvedValue([
+      { kind: "pop", label: "nodes", count: 0 },
+      { kind: "pop", label: "edges", count: 0 },
+    ]);
+
+    const result = await getCodeGraphFreshness("source-code", {
+      inspectStructuralHealth: true,
+      now: new Date("2026-05-13T01:00:00.000Z"),
+    });
+
+    expect(result.nodeCount).toBe(0);
+    expect(result.warnings.join(" ")).toMatch(/NO EVIDENCE of absence/);
+    expect(result.trust?.tier).not.toBe("high");
   });
 });
 

--- a/apps/web/lib/build/code-graph-access.ts
+++ b/apps/web/lib/build/code-graph-access.ts
@@ -28,6 +28,9 @@ export type CodeGraphFreshness = {
   indexedFileCount: number;
   lastError: string | null;
   relationshipCounts?: Record<BenchmarkRelationship, number>;
+  /** Rows actually present in the graph for this key (BI-86EF5900). null = uninspected/unreadable. */
+  nodeCount?: number | null;
+  edgeCount?: number | null;
   warnings: string[];
   summary: string;
   trust?: TrustAssessment;
@@ -87,35 +90,58 @@ function toCount(value: unknown): number {
 
 async function inspectStructuralRelationshipHealth(graphKey: string): Promise<{
   counts: Record<BenchmarkRelationship, number>;
+  /**
+   * Rows actually present in the graph (BI-86EF5900). `indexedFileCount` reads
+   * CodeGraphFileHash — a DIFFERENT table — so it cannot fall when the graph
+   * empties. Measured live 2026-08-23: 4406 file hashes, 0 nodes, 0 edges,
+   * status "ready". These are the counts that can.
+   */
+  nodeCount: number | null;
+  edgeCount: number | null;
   warnings: string[];
 }> {
   const counts = Object.fromEntries(
     BENCHMARK_REQUIRED_RELATIONSHIPS.map((relationship) => [relationship, 0]),
   ) as Record<BenchmarkRelationship, number>;
 
+  let nodeCount: number | null = null;
+  let edgeCount: number | null = null;
+
   try {
+    // ONE raw call: benchmark relationship counts AND total population, so the
+    // file keeps a single raw-SQL site and one round trip.
     const rows = (await prisma.$queryRawUnsafe(
       [
-        "SELECT rel_type AS relationship, count(*)::int AS count",
+        "SELECT 'rel' AS kind, rel_type AS label, count(*)::int AS count",
         "  FROM graph_edge",
         " WHERE props->>'graphKey' = $1 AND rel_type = ANY($2::text[])",
         " GROUP BY rel_type",
+        " UNION ALL",
+        "SELECT 'pop', 'nodes', (SELECT count(*)::int FROM graph_node WHERE props->>'graphKey' = $1)",
+        " UNION ALL",
+        "SELECT 'pop', 'edges', (SELECT count(*)::int FROM graph_edge WHERE props->>'graphKey' = $1)",
       ].join("\n"),
       graphKey,
       [...BENCHMARK_REQUIRED_RELATIONSHIPS],
-    )) as Array<{ relationship?: unknown; count?: unknown }>;
+    )) as Array<{ kind?: unknown; label?: unknown; count?: unknown }>;
+
     for (const row of rows) {
-      const relationship = row.relationship;
-      if (
-        typeof relationship === "string" &&
-        BENCHMARK_REQUIRED_RELATIONSHIPS.includes(relationship as BenchmarkRelationship)
-      ) {
-        counts[relationship as BenchmarkRelationship] = toCount(row.count);
+      const label = row.label;
+      if (typeof label !== "string") continue;
+      if (row.kind === "pop") {
+        if (label === "nodes") nodeCount = toCount(row.count);
+        if (label === "edges") edgeCount = toCount(row.count);
+        continue;
+      }
+      if (BENCHMARK_REQUIRED_RELATIONSHIPS.includes(label as BenchmarkRelationship)) {
+        counts[label as BenchmarkRelationship] = toCount(row.count);
       }
     }
   } catch (error) {
     return {
       counts,
+      nodeCount: null,
+      edgeCount: null,
       warnings: [
         `Could not inspect code graph relationship health: ${
           error instanceof Error ? error.message : "unknown error"
@@ -125,13 +151,23 @@ async function inspectStructuralRelationshipHealth(graphKey: string): Promise<{
   }
 
   const missing = BENCHMARK_REQUIRED_RELATIONSHIPS.filter((relationship) => counts[relationship] === 0);
-  return {
-    counts,
-    warnings:
-      missing.length > 0
-        ? [`Code graph structural relationships are missing: ${missing.join(", ")}.`]
-        : [],
-  };
+  const warnings: string[] = [];
+  if (nodeCount === 0) {
+    warnings.push(
+      "Code graph holds ZERO nodes for this graphKey — the projection is empty, not merely " +
+        "stale. Every query returns nothing regardless of what exists in the tree; an empty " +
+        "result is NO EVIDENCE of absence.",
+    );
+  } else if (edgeCount === 0) {
+    warnings.push(
+      "Code graph holds nodes but ZERO edges — a file index, not a graph. It cannot answer " +
+        "what-uses-this questions.",
+    );
+  }
+  if (missing.length > 0) {
+    warnings.push(`Code graph structural relationships are missing: ${missing.join(", ")}.`);
+  }
+  return { counts, nodeCount, edgeCount, warnings };
 }
 
 export async function getCodeGraphFreshness(
@@ -202,6 +238,7 @@ export async function getCodeGraphFreshness(
     // BI-6CFC5429: let freshness see WHICH ref was indexed, not just when.
     lastIndexedBranch: state.lastIndexedBranch,
     ...(relationshipHealth ? { relationshipCounts: relationshipHealth.counts } : {}),
+    ...(relationshipHealth ? { nodeCount: relationshipHealth.nodeCount, edgeCount: relationshipHealth.edgeCount } : {}),
     asOf: options.now,
   });
 
@@ -216,6 +253,7 @@ export async function getCodeGraphFreshness(
     indexedFileCount: state.indexedFileCount,
     lastError: state.lastError,
     ...(relationshipHealth ? { relationshipCounts: relationshipHealth.counts } : {}),
+    ...(relationshipHealth ? { nodeCount: relationshipHealth.nodeCount, edgeCount: relationshipHealth.edgeCount } : {}),
     warnings,
     summary,
     trust,

--- a/apps/web/lib/ea/mirror-freshness-trust.ts
+++ b/apps/web/lib/ea/mirror-freshness-trust.ts
@@ -1,0 +1,93 @@
+// Staleness signal for the Prisma→EA data-model mirror (BI-4501D3C8).
+//
+// query_ontology_graph returned elements with NO staleness signal at all, so a
+// caller could not distinguish "this model does not exist" from "this model
+// was merged after the last mirror run". That window is real: the mirror is a
+// NIGHTLY reconcile (data-model-mirror-nightly, 03:00 UTC). PR #4481 merged at
+// 01:17 and the six models it added were invisible to the mirror until 03:05 —
+// nearly two hours in which a correct question got an empty, unqualified
+// answer. A BI was filed in that window asserting the models were absent and
+// that nothing refreshed the mirror; both claims were wrong, and an empty
+// result with no staleness marker is what made them look right.
+//
+// Reuses the existing trust-vector shape rather than inventing a second
+// staleness convention — a second one would be the single-source-of-truth
+// failure the rulebook exists to prevent.
+
+import { DATA_MODEL_MIRROR_TASK_ID } from "@dpf/db";
+import { scoreTrustVector } from "@/lib/trust-vector/score";
+import type { TrustAssessment, TrustDimensionInput } from "@/lib/trust-vector/types";
+
+/** Beyond this the nightly has plainly not run and the mirror is unreliable. */
+const STALE_AFTER_HOURS = 26;
+
+export type MirrorFreshnessInput = {
+  lastRunAt: Date | string | null;
+  lastStatus: string | null;
+  isActive: boolean;
+  elementCount: number;
+  asOf?: Date;
+};
+
+function hoursSince(when: Date, now: Date): number {
+  return (now.getTime() - when.getTime()) / 3_600_000;
+}
+
+export function buildMirrorFreshnessTrust(input: MirrorFreshnessInput): TrustAssessment {
+  const now = input.asOf ? new Date(input.asOf) : new Date();
+  const lastRun = input.lastRunAt ? new Date(input.lastRunAt) : null;
+  const age = lastRun ? hoursSince(lastRun, now) : null;
+
+  const dimensions: TrustDimensionInput[] = [
+    {
+      key: "freshness",
+      label: "Mirror freshness",
+      score: age === null ? 0 : age > STALE_AFTER_HOURS ? 0.2 : age > 24 ? 0.6 : 1,
+      weight: 2,
+      rationale:
+        age === null
+          ? "The data-model mirror has no recorded run — the ontology may predate the current schema entirely."
+          : `Mirror last reconciled ${age.toFixed(1)}h ago. It runs nightly, so a model merged since ` +
+            "that run is NOT yet mirrored and its absence here is not evidence it does not exist.",
+      ...(lastRun ? { measuredAt: lastRun.toISOString() } : {}),
+      evidenceRefs: [
+        {
+          kind: "prisma-row",
+          label: DATA_MODEL_MIRROR_TASK_ID,
+          ref: DATA_MODEL_MIRROR_TASK_ID,
+          sourceTable: "ScheduledAgentTask",
+        },
+      ],
+    },
+    {
+      key: "runtimeAvailability",
+      label: "Mirror cadence",
+      score: input.isActive ? (input.lastStatus === "ok" ? 1 : 0.4) : 0,
+      weight: 1,
+      rationale: input.isActive
+        ? `The nightly mirror task is active; last run status "${input.lastStatus ?? "unknown"}".`
+        : "The nightly mirror task is INACTIVE — nothing is refreshing this ontology.",
+      evidenceRefs: [],
+    },
+    {
+      key: "sourceAuthority",
+      label: "Source authority",
+      score: 0.9,
+      weight: 1,
+      rationale:
+        "EaElement rows are the deterministic projection of the Prisma schema, authoritative " +
+        "as of the last reconcile — not as of now.",
+      evidenceRefs: [
+        { kind: "prisma-row", label: "EaElement", ref: "EaElement", sourceTable: "EaElement" },
+      ],
+    },
+  ];
+
+  return scoreTrustVector({
+    subject: { type: "ea-ontology", id: "data-model-mirror", label: "EA ontology (data-model mirror)" },
+    asOf: now.toISOString(),
+    dimensions,
+    sourceSummary:
+      "Ontology trust is derived from when the nightly Prisma→EA mirror last reconciled and whether its task is active.",
+  });
+}

--- a/apps/web/lib/mcp/packs/code-intelligence-pack.ts
+++ b/apps/web/lib/mcp/packs/code-intelligence-pack.ts
@@ -21,25 +21,64 @@ function optionalString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
-/** Shape a code-graph query result into a ToolResult, surfacing unavailability. */
-function codeGraphReadToolResult(
-  result: Record<string, unknown> & { available?: unknown; summary?: unknown },
-): ToolResult {
-  const message = typeof result.summary === "string" && result.summary.trim()
+/**
+ * Shape a code-graph query result into a ToolResult, surfacing unavailability
+ * AND degraded trust.
+ *
+ * BI-86EF5900: these tools returned a bare `{ results: [] }` while the graph
+ * reported `ready`. The trust vector that says otherwise was already computed
+ * and simply never reached the caller, so absence read as evidence — an agent
+ * asking whether a model exists got silence from an EMPTY graph and could
+ * reasonably conclude it does not exist. Measured live: search_code_graph
+ * ("MileageRate") returned [] for a model merged to main.
+ *
+ * Every read now carries the trust vector when the graph is degraded, and an
+ * empty result on a degraded graph is stated as NO EVIDENCE rather than as a
+ * finding. Reuses the existing trust-vector shape rather than inventing a
+ * second staleness convention.
+ */
+async function codeGraphReadToolResult(
+  result: Record<string, unknown> & { available?: unknown; summary?: unknown; results?: unknown },
+): Promise<ToolResult> {
+  const baseMessage = typeof result.summary === "string" && result.summary.trim()
     ? result.summary
     : "Code graph query completed.";
+
   if (result.available === false) {
     return {
       success: false,
       error: "Code graph unavailable",
-      message,
+      message: baseMessage,
       data: result,
     };
   }
+
+  let trust: unknown = undefined;
+  let message = baseMessage;
+  try {
+    const { getCodeGraphFreshness } = await import("@/lib/build/code-graph-access");
+    const freshness = await getCodeGraphFreshness(
+      typeof result.graphKey === "string" ? result.graphKey : undefined,
+      { inspectStructuralHealth: true },
+    );
+    const assessment = freshness.trust;
+    if (assessment && (assessment.tier === "low" || assessment.action === "qualify")) {
+      trust = assessment;
+      const empty = Array.isArray(result.results) && result.results.length === 0;
+      message = empty
+        ? `${baseMessage} — but this graph is ${assessment.tier} trust (${assessment.action}): ` +
+          `${assessment.primaryRationale} AN EMPTY RESULT HERE IS NO EVIDENCE OF ABSENCE. ` +
+          "Verify with a direct grep against the merge target before concluding the substrate does not exist."
+        : `${baseMessage} — graph trust is ${assessment.tier} (${assessment.action}): ${assessment.primaryRationale}`;
+    }
+  } catch {
+    // Trust enrichment is advisory; never fail a read because scoring failed.
+  }
+
   return {
     success: true,
     message,
-    data: result,
+    data: trust ? { ...result, trust } : result,
   };
 }
 
@@ -193,7 +232,7 @@ async function searchCodeGraphHandler(params: Record<string, unknown>): Promise<
     graphKey: optionalString(params["graphKey"]) ?? undefined,
     limit: typeof params["limit"] === "number" ? params["limit"] : undefined,
   });
-  return codeGraphReadToolResult(result as unknown as Record<string, unknown> & {
+  return await codeGraphReadToolResult(result as unknown as Record<string, unknown> & {
     available?: unknown;
     summary?: unknown;
   });
@@ -207,7 +246,7 @@ async function traceCodeSurfaceHandler(params: Record<string, unknown>): Promise
     model: optionalString(params["model"]) ?? undefined,
     graphKey: optionalString(params["graphKey"]) ?? undefined,
   });
-  return codeGraphReadToolResult(result as unknown as Record<string, unknown> & {
+  return await codeGraphReadToolResult(result as unknown as Record<string, unknown> & {
     available?: unknown;
     summary?: unknown;
   });
@@ -220,7 +259,7 @@ async function findRelatedTestsHandler(params: Record<string, unknown>): Promise
     graphKey: optionalString(params["graphKey"]) ?? undefined,
     limit: typeof params["limit"] === "number" ? params["limit"] : undefined,
   });
-  return codeGraphReadToolResult(result as unknown as Record<string, unknown> & {
+  return await codeGraphReadToolResult(result as unknown as Record<string, unknown> & {
     available?: unknown;
     summary?: unknown;
   });

--- a/apps/web/lib/mcp/packs/ea-ontology-pack.ts
+++ b/apps/web/lib/mcp/packs/ea-ontology-pack.ts
@@ -245,10 +245,44 @@ async function queryOntologyGraphHandler(params: Record<string, unknown>): Promi
     },
   });
   const total = await prisma.eaElement.count({ where });
+
+  // BI-4501D3C8: never return ontology elements without a staleness signal.
+  // The mirror is a NIGHTLY reconcile, so an element merged since the last run
+  // is legitimately absent here — and a bare empty result made that
+  // indistinguishable from "does not exist".
+  let trust: unknown = undefined;
+  let staleness = "";
+  try {
+    const { buildMirrorFreshnessTrust } = await import("@/lib/ea/mirror-freshness-trust");
+    const { DATA_MODEL_MIRROR_TASK_ID } = await import("@dpf/db");
+    const task = await prisma.scheduledAgentTask.findUnique({
+      where: { taskId: DATA_MODEL_MIRROR_TASK_ID },
+      select: { lastRunAt: true, lastStatus: true, isActive: true },
+    });
+    const assessment = buildMirrorFreshnessTrust({
+      lastRunAt: task?.lastRunAt ?? null,
+      lastStatus: task?.lastStatus ?? null,
+      isActive: task?.isActive ?? false,
+      elementCount: total,
+    });
+    trust = assessment;
+    if (total === 0) {
+      staleness =
+        ` — NO MATCHES. This is a nightly mirror (${assessment.tier} trust, ${assessment.action}): ` +
+        `${assessment.primaryRationale} An empty result is NOT evidence the model does not exist; ` +
+        "check the committed schema with describe_committed_model before concluding absence.";
+    } else if (assessment.tier === "low" || assessment.action === "qualify") {
+      staleness = ` — mirror trust ${assessment.tier} (${assessment.action}): ${assessment.primaryRationale}`;
+    }
+  } catch {
+    // Advisory only; a scoring failure must not fail the read.
+  }
+
   return {
     success: true,
-    message: `Found ${elements.length} elements (${total} total)`,
+    message: `Found ${elements.length} elements (${total} total)${staleness}`,
     data: {
+      ...(trust ? { trust } : {}),
       elements: elements.map(el => ({
         elementId: el.id,
         name: el.name,

--- a/apps/web/lib/trust-vector/adapters/code-graph-population.test.ts
+++ b/apps/web/lib/trust-vector/adapters/code-graph-population.test.ts
@@ -1,0 +1,55 @@
+// BI-86EF5900: an EMPTY graph must not be able to present as healthy.
+//
+// Live measurement 2026-08-23: CodeGraphFileHash held 4406 rows while
+// graph_node/graph_edge for that graphKey held ZERO, and the tool reported
+// indexStatus "ready" for "4406 indexed files". indexedFileCount reads a
+// different table than the graph, so it cannot fall when the graph empties.
+import { describe, it, expect } from "vitest";
+
+import { buildCodeGraphFreshnessTrust } from "./code-graph";
+
+const READY = {
+  graphKey: "source-code",
+  available: true,
+  indexStatus: "ready",
+  lastIndexedAt: new Date().toISOString(),
+  workspaceDirty: false,
+  indexedFileCount: 4406,
+  lastError: null,
+  lastIndexedBranch: "main",
+};
+
+describe("code-graph trust — graph population", () => {
+  it("scores an empty graph at zero coverage even when 4406 files are 'indexed'", () => {
+    const trust = buildCodeGraphFreshnessTrust({ ...READY, nodeCount: 0, edgeCount: 0 });
+    const coverage = trust.dimensions.find((d) => d.label === "Graph population");
+    expect(coverage?.score).toBe(0);
+    expect(coverage?.rationale).toMatch(/EMPTY/);
+    expect(coverage?.rationale).toMatch(/no evidence of absence/i);
+  });
+
+  it("does not let an empty graph present as high trust", () => {
+    const trust = buildCodeGraphFreshnessTrust({ ...READY, nodeCount: 0, edgeCount: 0 });
+    expect(trust.tier).not.toBe("high");
+    expect(["qualify", "warn-stale", "refresh-required", "escalate", "defer"]).toContain(trust.action);
+  });
+
+  it("distinguishes a file index (nodes, no edges) from an empty graph", () => {
+    const trust = buildCodeGraphFreshnessTrust({ ...READY, nodeCount: 4406, edgeCount: 0 });
+    const coverage = trust.dimensions.find((d) => d.label === "Graph population");
+    expect(coverage?.score).toBe(0.35);
+    expect(coverage?.rationale).toMatch(/file index, not a graph/);
+  });
+
+  it("scores a populated graph at full coverage", () => {
+    const trust = buildCodeGraphFreshnessTrust({ ...READY, nodeCount: 4406, edgeCount: 10764 });
+    const coverage = trust.dimensions.find((d) => d.label === "Graph population");
+    expect(coverage?.score).toBe(1);
+  });
+
+  it("reports unknown rather than healthy when population cannot be inspected", () => {
+    const trust = buildCodeGraphFreshnessTrust({ ...READY, nodeCount: null, edgeCount: null });
+    const coverage = trust.dimensions.find((d) => d.label === "Graph population");
+    expect(coverage?.score).toBeNull();
+  });
+});

--- a/apps/web/lib/trust-vector/adapters/code-graph.ts
+++ b/apps/web/lib/trust-vector/adapters/code-graph.ts
@@ -11,6 +11,14 @@ type CodeGraphFreshnessTrustInput = {
   lastError: string | null;
   relationshipCounts?: Record<string, number>;
   /**
+   * Rows actually present in the graph (BI-86EF5900). `indexedFileCount` reads
+   * CodeGraphFileHash, a different table, so it stays high while the graph is
+   * empty — measured live: 4406 "indexed files", 0 nodes, 0 edges, status
+   * "ready". These are the counts that can actually fall to zero.
+   */
+  nodeCount?: number | null;
+  edgeCount?: number | null;
+  /**
    * Branch the index was built from (BI-6CFC5429). Freshness previously scored
    * only how recently the INDEXER RAN, not how old the CONTENT it indexed was —
    * so re-indexing a 10-week-old branch every hour scored a permanent 1.0/high.
@@ -72,6 +80,9 @@ export function buildCodeGraphFreshnessTrust(
 
   if (input.relationshipCounts) {
     dimensions.push(buildStructuralHealthDimension(input.relationshipCounts));
+  }
+  if (input.nodeCount !== undefined) {
+    dimensions.push(buildPopulationDimension(input.nodeCount, input.edgeCount ?? null));
   }
 
   return scoreTrustVector({
@@ -297,4 +308,62 @@ function toDate(value: Date | string | null | undefined): Date | null {
   if (!value) return null;
   const date = value instanceof Date ? value : new Date(value);
   return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Coverage scored from what the graph actually HOLDS, not from how many files a
+ * bookkeeping table remembers. An empty projection scores 0 here, which drags
+ * the composite down and flips the action to `qualify` — so a graph that is
+ * "ready" for 4406 files but holds nothing can no longer present as healthy.
+ */
+function buildPopulationDimension(
+  nodeCount: number | null,
+  edgeCount: number | null,
+): TrustDimensionInput {
+  if (nodeCount === null) {
+    return {
+      key: "coverageCompleteness",
+      label: "Graph population",
+      score: null,
+      weight: 2,
+      rationale: "Graph population could not be inspected, so coverage is unknown.",
+      evidenceRefs: [],
+    };
+  }
+  if (nodeCount === 0) {
+    return {
+      key: "coverageCompleteness",
+      label: "Graph population",
+      score: 0,
+      weight: 2,
+      rationale:
+        "Graph holds 0 nodes for this key — the projection is EMPTY, not stale. " +
+        "Any empty result is no evidence of absence.",
+      evidenceRefs: [
+        { kind: "prisma-row", label: "graph_node", ref: "graph_node", sourceTable: "graph_node" },
+      ],
+    };
+  }
+  if (edgeCount === 0) {
+    return {
+      key: "coverageCompleteness",
+      label: "Graph population",
+      score: 0.35,
+      weight: 2,
+      rationale:
+        `Graph holds ${nodeCount} node(s) but 0 edges — a file index, not a graph. ` +
+        "Relationship questions cannot be answered.",
+      evidenceRefs: [
+        { kind: "prisma-row", label: "graph_edge", ref: "graph_edge", sourceTable: "graph_edge" },
+      ],
+    };
+  }
+  return {
+    key: "coverageCompleteness",
+    label: "Graph population",
+    score: 1,
+    weight: 2,
+    rationale: `Graph holds ${nodeCount} node(s) and ${edgeCount} edge(s).`,
+    evidenceRefs: [],
+  };
 }


### PR DESCRIPTION
The cross-cutting half of the schema-inspection programme: **a stale or low-trust result must be visible as such.** Three tools failed that, each by returning nothing while looking fine.

## 1. The health number measured a different table than the graph

`get_code_graph_freshness` reports `indexedFileCount`, read from `CodeGraphFileHash`. **That is not the graph.** Measured on the live install 2026-08-23:

```
CodeGraphFileHash                4406 rows
graph_node  with this graphKey      0
graph_edge  with this graphKey      0
indexStatus                     ready
```

BI-86EF5900 filed this as "0/5 relationship types". It is worse: the projection is **entirely empty**, not edgeless. The 5102 `graph_edge` rows present are all foreign EA edges (`ASSOCIATED_WITH`, `BELONGS_TO`, `DEPENDS_ON`…), none carrying `graphKey`.

A health number sourced from a different substrate than the thing it describes is **structurally incapable of reporting that thing's failure** — it cannot fall when the graph empties. So a completely empty projection reported "ready for 4406 indexed files".

Freshness now counts `graph_node` and `graph_edge` for the key and scores an empty projection at zero coverage, dragging the composite down and flipping the action to `qualify`. *Ready but empty* can no longer present as fine.

## 2. The trust vector was computed and thrown away

`search_code_graph`, `trace_code_surface` and `find_related_tests` returned a bare `{ results: [] }` while the adapter had **already scored the graph low**. Callers got silence and no reason to distrust it — which is exactly how an agent asking whether a model exists concludes that it does not.

Every read now carries the trust vector when the graph is degraded, and an empty result on a degraded graph is stated as **NO EVIDENCE OF ABSENCE**, with an instruction to verify by grep against the merge target.

## 3. The ontology had no staleness signal at all

`query_ontology_graph` returned elements with nothing to say how old the mirror was. The mirror is a **nightly** reconcile, so an element merged since the last run is legitimately absent: PR #4481 merged at 01:17 and its six models were invisible until the 03:05 run.

A BI was filed inside that window asserting the models were absent and that nothing refreshed the mirror. **Both claims were wrong**, and the unqualified empty answer is what made them look right. Results now carry mirror freshness scored from the nightly task's own last-run and active state — reusing the same trust-vector shape rather than inventing a second staleness convention.

## Notes

Population is folded into the **existing** raw query rather than added as a second one — one round trip, and the file keeps a single raw-SQL site so the connector-lifecycle debt guard stays flat rather than being re-baselined.

## Verification

- **73 tests pass across 10 files**, including five new cases pinned to the exact live failure shape (4406 file hashes, 0 nodes, 0 edges, status `ready`) proving it can no longer score high trust, and that a file-index-without-edges is distinguished from an empty graph.
- `pnpm --filter web build`: clean.
- `pregate:preflight`: 50 guards clean.
- exact-tree local CI gate: **PASS** (evidence `cmt5hcyfr1epj01o8f5hanemy`).

## Scope

**This does not repopulate the graph.** That needs a re-index against the default branch — a runtime action on the live install, plus repointing `PROJECT_ROOT`, which is the shared root cause with BI-6CFC5429 and affects every consumer of that env var. What this PR does is make the empty state impossible to mistake for an answer while that remains outstanding.

Addresses BI-86EF5900 (visibility half) and BI-4501D3C8 (residual staleness-signal defect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
