### PR TITLE
chore(tests): degenerate-environment fixture kit + probe conformance (BI-927D64C0)

### DIFF
--- a/apps/web/lib/decision/evidence-reverification.test.ts
+++ b/apps/web/lib/decision/evidence-reverification.test.ts
@@ -19,6 +19,7 @@ import {
   type SourceAccess,
 } from "./evidence-reverification";
 import { citationsToSources, type AdmissibleCitation } from "./evidence-grounding";
+import { partialSourceTree } from "@/lib/testing/degenerate-env";
 import { createRepoLocatorResolver } from "./locator-resolver";
 import type { LocatorResolver } from "./evidence-reverifier";
 
@@ -215,9 +216,9 @@ describe("reverifyDecisionEvidence", () => {
   // and the pass reported "degraded" — i.e. accused honest evidence of being
   // fabricated. Absence in a tree of unknown revision proves nothing.
   it("does NOT degrade a citation missing from a tree of unknown revision", async () => {
-    const repoRoot = await mkdtemp(join(tmpdir(), "dpf-unanchored-"));
-    // Exactly the live shape: a plausible root, no .git, and the cited file absent.
-    await writeFile(join(repoRoot, "package.json"), "{}", "utf8");
+    // Exactly the live shape: a plausible root, no .git, and the cited file absent
+    // (the shared degenerate-environment fixture — BI-927D64C0 M4).
+    const { root: repoRoot } = partialSourceTree({ withGit: false, withFile: false });
 
     const lookup = await reverifyDecisionEvidence({
       db: dbWith([citation()]),

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1058,6 +1058,12 @@
       "docs/architecture/agent-standards-dpf-conformance.md",
       "docs/architecture/context-engineering-standards.md"
     ],
+    "apps/web/lib/testing/degenerate-env/index.ts": [
+      "docs/testing/pre-pr-gate.md"
+    ],
+    "apps/web/lib/testing/degenerate-env/probe-conformance.test.ts": [
+      "docs/testing/pre-pr-gate.md"
+    ],
     "apps/web/lib/tool-description-hygiene.test.ts": [
       "docs/architecture/agent-standards-dpf-conformance.md",
       "docs/architecture/context-engineering-standards.md",
@@ -2851,6 +2857,8 @@
       ".github/workflows/ci.yml",
       ".github/workflows/codeql.yml",
       ".github/workflows/policy-guards-recheck.yml",
+      "apps/web/lib/testing/degenerate-env/index.ts",
+      "apps/web/lib/testing/degenerate-env/probe-conformance.test.ts",
       "docker-compose.local-ci.yml",
       "packages/dpf-skill-pack/hooks/pregate-evidence-guard.mjs",
       "scripts/check-guards.mjs",

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -10359,6 +10359,7 @@
         "test-runner-pins-must-hold",
         "appsmobile-jest-must-stay-on-29x",
         "appsweb-and-packagesdb-vitest",
+        "degenerate-environment-fixtures",
         "common-drift-and-how-to-stay-on-script",
         "label-association-guard-ratchet",
         "what-this-gate-is-not"

--- a/apps/web/lib/testing/degenerate-env/degenerate-env.test.ts
+++ b/apps/web/lib/testing/degenerate-env/degenerate-env.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  emptyAndNullRows,
+  flakySucceedsOnAttempt,
+  oversizedPayload,
+  partialSourceTree,
+  twoInstallIdentities,
+} from "./index";
+
+describe("partialSourceTree", () => {
+  it("models the BI-EE2B243D shape by default: available-looking root, no .git, cited file absent", () => {
+    const { root, citedFilePath } = partialSourceTree();
+    expect(existsSync(join(root, "package.json"))).toBe(true);
+    expect(existsSync(join(root, ".git"))).toBe(false);
+    expect(existsSync(join(root, ...citedFilePath.split("/")))).toBe(false);
+  });
+
+  it("produces the healthy control shape on demand", () => {
+    const { root, citedFilePath } = partialSourceTree({ withGit: true, withFile: true });
+    expect(existsSync(join(root, ".git"))).toBe(true);
+    expect(existsSync(join(root, ...citedFilePath.split("/")))).toBe(true);
+  });
+});
+
+describe("twoInstallIdentities", () => {
+  it("mints pairwise-independent ids — no shared linkId fixture", () => {
+    const { a, b } = twoInstallIdentities();
+    expect(a.linkId).not.toBe(b.linkId);
+    expect(a.installId).not.toBe(b.installId);
+  });
+});
+
+describe("oversizedPayload", () => {
+  it("is exactly the requested size and deterministic", () => {
+    const p = oversizedPayload(1024 * 1024 + 7);
+    expect(p.length).toBe(1024 * 1024 + 7);
+    expect(p).toBe(oversizedPayload(1024 * 1024 + 7));
+  });
+
+  it("rejects nonsense sizes", () => {
+    expect(() => oversizedPayload(-1)).toThrow();
+    expect(() => oversizedPayload(1.5)).toThrow();
+  });
+});
+
+describe("flakySucceedsOnAttempt", () => {
+  it("rejects transiently then succeeds on attempt n", async () => {
+    const fn = flakySucceedsOnAttempt(3, { value: 42 });
+    await expect(fn()).rejects.toThrow(/transient/);
+    await expect(fn()).rejects.toThrow(/transient/);
+    await expect(fn()).resolves.toBe(42);
+    expect(fn.attempts).toBe(3);
+  });
+
+  it("n=1 succeeds immediately (the healthy control)", async () => {
+    await expect(flakySucceedsOnAttempt(1)()).resolves.toBe("ok");
+  });
+});
+
+describe("emptyAndNullRows", () => {
+  it("produces null, empty-string, and each-field-null variants of the shape", () => {
+    const shape = { name: "widget", body: "text", count: 3 };
+    const rows = emptyAndNullRows(shape);
+    expect(rows.allNull).toEqual({ name: null, body: null, count: null });
+    expect(rows.emptyStrings).toEqual({ name: "", body: "", count: null });
+    expect(rows.eachFieldNull).toHaveLength(3);
+    expect(rows.eachFieldNull[0]).toEqual({ name: null, body: "text", count: 3 });
+    // populated + allNull + emptyStrings + one per field
+    expect(rows.rows).toHaveLength(3 + 3);
+  });
+});

--- a/apps/web/lib/testing/degenerate-env/index.ts
+++ b/apps/web/lib/testing/degenerate-env/index.ts
@@ -1,0 +1,224 @@
+// Degenerate-environment fixture kit (BI-927D64C0, mechanism M4).
+//
+// Class B is the dominant late-defect escape class (~30%): a module probes its
+// environment, and every unit-test fixture models the HEALTHY world — complete
+// tree, one install, small payload, first attempt succeeds, rows fully
+// populated. Production is partial, stale, absent, empty, and plural. Each
+// builder here is named after a real incident so the shape it models cannot
+// quietly drift back to "healthy":
+//
+//   - partialSourceTree      — BI-EE2B243D: an image-synced install root passed
+//                              the availability probe (package.json present)
+//                              while carrying no .git and only part of the
+//                              tree; true citations were "refuted".
+//   - twoInstallIdentities   — federation 8dde5854e (BI-AF675A20): the
+//                              link-mismatch guard "only ever passed because
+//                              unit tests reused one linkId fixture"; two real
+//                              installs mint INDEPENDENT ids.
+//   - oversizedPayload       — BI-DC6BE37C: a >1MB diff crashed exec maxBuffer.
+//   - flakySucceedsOnAttempt — BI-2B9E16CC: a transient failure was collapsed
+//                              to a terminal state; retry paths were untested.
+//   - emptyAndNullRows       — SQL three-valued logic: NULL bodies/fields
+//                              behave differently from absent rows and from
+//                              empty strings (see e.g. Prisma NOT-contains
+//                              dropping NULL rows).
+//
+// Dependency-free by contract: node builtins only, importable from any vitest
+// suite as `@/lib/testing/degenerate-env`.
+
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// (a) partialSourceTree — the image-synced install root (BI-EE2B243D)
+// ---------------------------------------------------------------------------
+
+export interface PartialSourceTreeOptions {
+  /** Plant a `.git` directory (an ANCHORED tree). Default false — the degenerate shape. */
+  withGit?: boolean;
+  /** Plant the cited file. Default false — the citation resolves to nothing. */
+  withFile?: boolean;
+  /** Repo-relative path of the cited file. */
+  citedFilePath?: string;
+  /** Contents written when `withFile` is true. */
+  citedFileContent?: string;
+}
+
+export interface PartialSourceTree {
+  /** Absolute path of the temp root. `package.json` is always present, so a coarse availability probe says "available". */
+  root: string;
+  /** Repo-relative path the caller should cite (present iff `withFile`). */
+  citedFilePath: string;
+}
+
+/**
+ * A temp dir shaped like the live install root that defeated the
+ * source-availability probe: `package.json` at the root (so "available"),
+ * no `.git` (revision unknown), and the cited file absent (partial tree).
+ * Both defects are opt-out so the same builder also produces the healthy
+ * control shape (`{ withGit: true, withFile: true }`).
+ */
+export function partialSourceTree(options: PartialSourceTreeOptions = {}): PartialSourceTree {
+  const {
+    withGit = false,
+    withFile = false,
+    citedFilePath = "apps/web/lib/cited.ts",
+    citedFileContent = 'export function cited() {\n  return "grounded value";\n}\n',
+  } = options;
+  const root = mkdtempSync(join(tmpdir(), "dpf-degenerate-env-"));
+  writeFileSync(join(root, "package.json"), "{}\n", "utf8");
+  if (withGit) mkdirSync(join(root, ".git"), { recursive: true });
+  if (withFile) {
+    const abs = join(root, ...citedFilePath.split("/"));
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, citedFileContent, "utf8");
+  }
+  return { root, citedFilePath };
+}
+
+// ---------------------------------------------------------------------------
+// (b) twoInstallIdentities — federation mints INDEPENDENT ids per side
+// ---------------------------------------------------------------------------
+
+export interface InstallIdentity {
+  installId: string;
+  linkId: string;
+}
+
+export interface TwoInstallIdentities {
+  /** The local side (e.g. the receiver). */
+  a: InstallIdentity;
+  /** The remote side (e.g. the sender). Every id differs from `a`'s. */
+  b: InstallIdentity;
+}
+
+/**
+ * Two id sets that are guaranteed pairwise distinct, for federation-shaped
+ * tests. A test that would pass with `a` substituted for `b` is reusing one
+ * identity fixture — exactly the blind spot that shipped the link:mismatch
+ * 422 (8dde5854e): equality between the sides' linkIds can never hold across
+ * two real installs.
+ */
+export function twoInstallIdentities(): TwoInstallIdentities {
+  const a: InstallIdentity = { installId: randomUUID(), linkId: randomUUID() };
+  let b: InstallIdentity = { installId: randomUUID(), linkId: randomUUID() };
+  // randomUUID collisions are not a practical concern, but the contract is
+  // "independent", so make distinctness unconditional rather than probabilistic.
+  while (b.installId === a.installId || b.linkId === a.linkId) {
+    b = { installId: randomUUID(), linkId: randomUUID() };
+  }
+  return { a, b };
+}
+
+// ---------------------------------------------------------------------------
+// (c) oversizedPayload — bigger than the buffer the code silently assumes
+// ---------------------------------------------------------------------------
+
+/**
+ * A deterministic filler string of exactly `bytes` bytes (ASCII, so bytes ===
+ * chars). Line-structured (80-char lines) so diff/exec paths treat it like
+ * real text. `oversizedPayload(2 * 1024 * 1024)` reproduces the >1MB diff
+ * that crashed the default `execFile` maxBuffer (BI-DC6BE37C).
+ */
+export function oversizedPayload(bytes: number): string {
+  if (!Number.isInteger(bytes) || bytes < 0) {
+    throw new Error(`oversizedPayload: bytes must be a non-negative integer, got ${bytes}`);
+  }
+  const LINE_WIDTH = 80; // 79 payload chars + "\n"
+  const stamp = "degenerate-payload-";
+  let out = "";
+  let line = 0;
+  while (out.length + LINE_WIDTH <= bytes) {
+    const head = `${stamp}${line.toString(36)}-`;
+    out += head + "x".repeat(LINE_WIDTH - 1 - head.length) + "\n";
+    line += 1;
+  }
+  if (out.length < bytes) out += "y".repeat(bytes - out.length);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// (d) flakySucceedsOnAttempt — transient failure is not terminal failure
+// ---------------------------------------------------------------------------
+
+export interface FlakyFn<T> {
+  (): Promise<T>;
+  /** How many times the fn has been invoked so far. */
+  readonly attempts: number;
+}
+
+/**
+ * An async fn that rejects (transiently) on the first `n - 1` calls and
+ * resolves `value` on attempt `n`. For retry-path tests: a caller that
+ * collapses the first rejection to a terminal state (BI-2B9E16CC) fails
+ * against `flakySucceedsOnAttempt(2)`; a correct retry loop succeeds and
+ * `fn.attempts` proves how many tries it took.
+ */
+export function flakySucceedsOnAttempt<T = "ok">(
+  n: number,
+  options: { value?: T; error?: (attempt: number) => Error } = {},
+): FlakyFn<T> {
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`flakySucceedsOnAttempt: n must be a positive integer, got ${n}`);
+  }
+  const { value = "ok" as T, error } = options;
+  let attempts = 0;
+  const fn = async (): Promise<T> => {
+    attempts += 1;
+    if (attempts < n) {
+      throw error
+        ? error(attempts)
+        : new Error(`transient failure (attempt ${attempts} of ${n - 1} that fail)`);
+    }
+    return value;
+  };
+  Object.defineProperty(fn, "attempts", { get: () => attempts });
+  return fn as FlakyFn<T>;
+}
+
+// ---------------------------------------------------------------------------
+// (e) emptyAndNullRows — SQL three-valued logic shapes
+// ---------------------------------------------------------------------------
+
+export interface DegenerateRows<S extends Record<string, unknown>> {
+  /** The healthy control: the shape exactly as given. */
+  populated: S;
+  /** Every field null — the DB row that exists but says nothing. */
+  allNull: { [K in keyof S]: null };
+  /** String fields emptied, everything else null — "" is not NULL and matches `contains`. */
+  emptyStrings: { [K in keyof S]: S[K] extends string ? "" : null };
+  /** One row per field with ONLY that field null — isolates which null breaks the path. */
+  eachFieldNull: Array<{ [K in keyof S]: S[K] | null }>;
+  /** All shapes above, for table-driven tests. */
+  rows: Array<Record<keyof S, unknown>>;
+}
+
+/**
+ * Degenerate row variants of `shape` for SQL three-valued-logic paths.
+ * NULL, "", and absent are three different worlds (a negated `contains`
+ * silently drops NULL rows; an empty string happily matches it). Feed
+ * `rows` through the query path under test and assert each variant lands
+ * where the contract says — not where the happy fixture happened to.
+ */
+export function emptyAndNullRows<S extends Record<string, unknown>>(shape: S): DegenerateRows<S> {
+  const keys = Object.keys(shape) as Array<keyof S>;
+  const allNull = Object.fromEntries(keys.map((k) => [k, null])) as DegenerateRows<S>["allNull"];
+  const emptyStrings = Object.fromEntries(
+    keys.map((k) => [k, typeof shape[k] === "string" ? "" : null]),
+  ) as DegenerateRows<S>["emptyStrings"];
+  const eachFieldNull = keys.map(
+    (nullKey) =>
+      Object.fromEntries(keys.map((k) => [k, k === nullKey ? null : shape[k]])) as {
+        [K in keyof S]: S[K] | null;
+      },
+  );
+  return {
+    populated: shape,
+    allNull,
+    emptyStrings,
+    eachFieldNull,
+    rows: [shape, allNull, emptyStrings, ...eachFieldNull],
+  };
+}

--- a/apps/web/lib/testing/degenerate-env/probe-conformance.test.ts
+++ b/apps/web/lib/testing/degenerate-env/probe-conformance.test.ts
@@ -1,0 +1,174 @@
+// Probe-conformance registry (BI-927D64C0, mechanism M4).
+//
+// Environment-probing modules must be tested against the world production
+// actually is — partial, stale, absent, empty, plural — not only the healthy
+// fixture. This suite does two things:
+//
+//   1. REGISTRY — a literal list of known probe modules, each mapped to the
+//      test file that must carry its degenerate-shape coverage and the markers
+//      that prove the coverage is present (kit usage, or an equivalent
+//      injected-degraded resolver). Asserted by reading the test file, not by
+//      duplicating its tests.
+//
+//   2. COMPLETENESS — a source-tree walk (fs only, no git) for the
+//      availability-probe signature, asserting every match is either
+//      enumerated above or carries an explicit reasoned waiver. A NEW probe
+//      module fails this test until someone decides where its degenerate
+//      coverage lives. The signature is deliberately narrow (calibrated on
+//      the real tree, 2026-08-22: three matches) — an over-reporting measure
+//      is a defect.
+
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve, sep } from "node:path";
+
+/** apps/web — this file lives at apps/web/lib/testing/degenerate-env/. */
+const WEB_ROOT = resolve(__dirname, "..", "..", "..");
+const LIB_ROOT = join(WEB_ROOT, "lib");
+
+/** Repo-relative paths below are relative to apps/web (posix separators). */
+interface ProbeRegistryEntry {
+  /** The environment-probing module. */
+  module: string;
+  /** Which degenerate shapes this probe MUST have at least one test for. */
+  shapes: string[];
+  /** The test file that carries the coverage. */
+  testFile: string;
+  /**
+   * Literal markers whose presence in `testFile` proves the degenerate cases
+   * exist there — kit builder names, degenerate verdicts, or the injected
+   * degraded-resolver shape.
+   */
+  markers: string[];
+}
+
+const PROBE_REGISTRY: ProbeRegistryEntry[] = [
+  {
+    // The source-availability probe from the BI-EE2B243D fix: package.json
+    // present said "available" while the tree was unanchored and partial.
+    module: "lib/mcp/packs/decision-reverify-pack.ts",
+    shapes: ["partial tree (no .git, cited file absent)", "unanchored-but-available root"],
+    testFile: "lib/decision/evidence-reverification.test.ts",
+    markers: [
+      "partialSourceTree", // the shared kit builds the image-synced shape
+      "unanchored-source", // the degenerate verdict is asserted, not just reachable
+      "UNANCHORED", // the readable-but-revision-unknown SourceAccess fixture
+    ],
+  },
+  {
+    // The re-verifier primitive: degradation arrives via an injected
+    // LocatorResolver — that counts as the degenerate-environment fixture.
+    module: "lib/decision/evidence-reverifier.ts",
+    shapes: ["locator resolves to nothing", "resolver throws (fails closed)"],
+    testFile: "lib/decision/evidence-reverifier.test.ts",
+    markers: [
+      "resolved: false", // injected resolver returning a miss
+      '"unresolved"', // the miss verdict asserted
+      "fails closed", // the throwing-resolver case
+    ],
+  },
+];
+
+/**
+ * Modules that match the probe signature but are NOT enumerated, each with the
+ * reason the waiver is sound. Keep this list SHORT — a waiver is a decision,
+ * not a default.
+ */
+const PROBE_WAIVERS: Array<{ module: string; reason: string }> = [
+  {
+    module: "lib/build/codebase-tools.ts",
+    reason:
+      "getProjectRoot()'s package.json check is a root-locator helper; the environment " +
+      "VERDICT built on it (available/anchored) lives in decision-reverify-pack.ts, which is " +
+      "enumerated with degenerate coverage. A second registry row here would double-count " +
+      "the same probe.",
+  },
+  {
+    module: "lib/actions/platform-dev-config.ts",
+    reason:
+      "existsSync(.git/MERGE_HEAD) reads a merge-in-progress marker inside a tree already " +
+      "known to be a checkout — git-state detail, not a source-availability probe deciding " +
+      "whether the environment can be trusted.",
+  },
+];
+
+/**
+ * The availability-probe signature, calibrated against the real probe
+ * (decision-reverify-pack.ts): a filesystem existence/stat/read check aimed at
+ * the two files that make a directory look like a repo root — `.git` and
+ * `package.json`. `[^)\n]*` keeps the match within one call on one line, which
+ * is what keeps precision high.
+ */
+const PROBE_SIGNATURE =
+  /existsSync\([^)\n]*\.git|existsSync\([^)\n]*package\.json|statSync\([^)\n]*package\.json|readFileSync\([^)\n]*package\.json/;
+
+function walkTsSources(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const abs = join(dir, entry);
+    if (statSync(abs).isDirectory()) {
+      walkTsSources(abs, out);
+      continue;
+    }
+    if (!entry.endsWith(".ts")) continue;
+    if (entry.endsWith(".test.ts") || entry.endsWith(".d.ts")) continue;
+    out.push(abs);
+  }
+  return out;
+}
+
+function toWebRelative(abs: string): string {
+  return relative(WEB_ROOT, abs).split(sep).join("/");
+}
+
+describe("degenerate-environment probe conformance", () => {
+  it("every enumerated probe module exists and its test file carries the degenerate cases", () => {
+    for (const entry of PROBE_REGISTRY) {
+      const modulePath = join(WEB_ROOT, entry.module);
+      const testPath = join(WEB_ROOT, entry.testFile);
+      expect(existsSync(modulePath), `registry module missing: ${entry.module}`).toBe(true);
+      expect(existsSync(testPath), `registry test file missing: ${entry.testFile}`).toBe(true);
+
+      const testSource = readFileSync(testPath, "utf8");
+      for (const marker of entry.markers) {
+        expect(
+          testSource.includes(marker),
+          `${entry.testFile} no longer contains the degenerate-case marker ${JSON.stringify(marker)} ` +
+            `required for ${entry.module} (shapes: ${entry.shapes.join("; ")}). ` +
+            "If the test was reworded, update the marker; if the case was deleted, restore it — " +
+            "the healthy fixture alone shipped BI-EE2B243D.",
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("every module matching the availability-probe signature is enumerated or explicitly waived", () => {
+    const matches = walkTsSources(LIB_ROOT)
+      .filter((abs) => PROBE_SIGNATURE.test(readFileSync(abs, "utf8")))
+      .map(toWebRelative)
+      .sort();
+
+    const enumerated = new Set(PROBE_REGISTRY.map((e) => e.module));
+    const waived = new Set(PROBE_WAIVERS.map((w) => w.module));
+
+    const unaccounted = matches.filter((m) => !enumerated.has(m) && !waived.has(m));
+    expect(
+      unaccounted,
+      "New availability-probe module(s) detected with no degenerate-environment coverage " +
+        "decision. Add each to PROBE_REGISTRY (map it to a test file exercising the " +
+        "partial/stale/absent shapes via @/lib/testing/degenerate-env or an injected degraded " +
+        "resolver) or add a reasoned waiver. Do not widen the waiver list by default.",
+    ).toEqual([]);
+
+    // Waivers must stay honest: a waiver for a module that no longer matches
+    // (or no longer exists) is stale and must be removed.
+    const matchSet = new Set(matches);
+    const staleWaivers = PROBE_WAIVERS.filter((w) => !matchSet.has(w.module)).map((w) => w.module);
+    expect(staleWaivers, "Stale waiver(s): module no longer matches the probe signature").toEqual(
+      [],
+    );
+
+    // Calibration guard: the signature itself must keep matching the real
+    // probe it was derived from, or the completeness check is measuring nothing.
+    expect(matchSet.has("lib/mcp/packs/decision-reverify-pack.ts")).toBe(true);
+  });
+});

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -753,6 +753,34 @@ imports at runtime. If `toBeInTheDocument`-style assertions regress on a future
 bump, restore the pin or extend the workaround. Upstream:
 [testing-library/jest-dom#662](https://github.com/testing-library/jest-dom/issues/662).
 
+## Degenerate-environment fixtures
+
+Modules that probe their environment (does `.git` exist? is `package.json`
+readable? did the remote answer?) must be unit-tested against the world
+production actually is — **partial, stale, absent, empty, plural** — not only
+the healthy fixture. The dominant late-defect escape class (~30%, BI-927D64C0)
+is a probe whose every test fixture modelled the healthy world: an image-synced
+partial tree passed the availability probe and true citations were "refuted"
+(BI-EE2B243D); a federation guard "only ever passed because unit tests reused
+one linkId fixture" (BI-AF675A20); a >1MB diff crashed the default exec
+maxBuffer (BI-DC6BE37C); a transient failure was collapsed to a terminal state
+(BI-2B9E16CC).
+
+Use the shared, dependency-free fixture kit
+[`apps/web/lib/testing/degenerate-env/`](../../apps/web/lib/testing/degenerate-env/index.ts)
+(importable as `@/lib/testing/degenerate-env`): `partialSourceTree()`,
+`twoInstallIdentities()`, `oversizedPayload(bytes)`,
+`flakySucceedsOnAttempt(n)`, `emptyAndNullRows(shape)` — each named after the
+incident it models. An injected degraded resolver/stub that produces the same
+shapes counts as equivalent.
+
+The conformance registry
+[`probe-conformance.test.ts`](../../apps/web/lib/testing/degenerate-env/probe-conformance.test.ts)
+enumerates the known availability-probe modules and walks `apps/web/lib/**`
+for the probe signature: a new probe module fails the suite until it is either
+mapped to a test file carrying degenerate coverage or given an explicit
+reasoned waiver there.
+
 ## Common drift, and how to stay on-script
 
 These are the failure modes that recur across sessions, clients, and machines.


### PR DESCRIPTION
Mechanism **M4** (class B — healthy-environment-only fixtures, the dominant escape class at ~30%) of the merged detection-hardening plan (#4395, umbrella BI-3D73CBC6, EP-413F2602).

## What

- `apps/web/lib/testing/degenerate-env/`: dependency-free builders for the recurring degenerate shapes — `partialSourceTree` (the BI-EE2B243D image-synced root: package.json, no .git, cited file absent — extracted from the fix's inline fixture, which now consumes the kit), `twoInstallIdentities` (federation 8dde5854e), `oversizedPayload` (BI-DC6BE37C), `flakySucceedsOnAttempt` (BI-2B9E16CC), `emptyAndNullRows` (BI-8A7E3E56).
- `probe-conformance.test.ts`: an enumerated registry mapping each environment-probe module to the degenerate shapes its tests must cover (markers asserted in the named test files), plus a completeness walk — a NEW module matching the availability-probe signature fails until enumerated or waived (2 reasoned waivers; stale waivers fail; a calibration guard keeps the signature honest).
- `docs/testing/pre-pr-gate.md`: new Degenerate-environment fixtures section (no new doc page).
- Red cases proven live: a planted probe module failed the walk; a removed marker failed the registry.

## Verification

- vitest: 4 files, 28/28 pass · scoped typecheck green.
- Local-CI gate: **PASS** at 44c6986d8937 (slot-0, evidence cmt5inli01jlx01o8tbdfkszk, verdict via pregate:status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)