### PR TITLE
feat(decisions): a decision record that says where it came from and what each option costs (BI-6700AF66)

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.tsx
@@ -12,6 +12,17 @@ import { LocalTime } from "@/components/ui/LocalTime";
 import { TIER_LABELS, tierForRow } from "@/lib/wiki/decision-audit";
 import { buildDecisionHelp } from "@/lib/wiki/decision-help";
 import { isWithdrawnHumanOutcome } from "@/lib/quality/decision-residue-staleness";
+import {
+  buildDecisionOriginCopy,
+  resolveDecisionOrigin,
+  type DecisionOriginDb,
+} from "@/lib/decision/decision-origin";
+import {
+  buildOptionConsequences,
+  consequencesByOption,
+  parseScoredOptions,
+  CONSEQUENCE_LABELS,
+} from "@/lib/decision/option-consequences";
 
 export const dynamic = "force-dynamic";
 
@@ -63,6 +74,15 @@ export default async function DecisionRecordPage({ params }: { params: Params })
     },
   });
   if (!row) notFound();
+
+  // Where the decision came from, and what each option would cost. Both
+  // degrade to nothing rather than guessing: an unresolvable origin says so,
+  // and an unscored row keeps the bare option list it has always had.
+  const origin = await resolveDecisionOrigin(prisma as unknown as DecisionOriginDb, row);
+  const originCopy = buildDecisionOriginCopy(origin);
+  const consequences = consequencesByOption(
+    buildOptionConsequences(parseScoredOptions(row.scoredOptions)),
+  );
 
   const tier = tierForRow(row);
   const tierLabel = TIER_LABELS[tier];
@@ -134,6 +154,39 @@ export default async function DecisionRecordPage({ params }: { params: Params })
         ) : null}
       </header>
 
+      {/* Where this came from — the work behind the question (BI-6700AF66). */}
+      <section className="mb-6">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--dpf-muted)] mb-2">
+          {originCopy.heading}
+        </h2>
+        {originCopy.unresolved ? (
+          <p className="text-sm text-[var(--dpf-muted)]">{originCopy.unresolved}</p>
+        ) : (
+          <dl className="rounded-lg border border-[var(--dpf-border)] p-3 text-sm">
+            {originCopy.lines.map((line) => (
+              <div key={line.label} className="flex gap-2 py-0.5">
+                <dt className="w-40 shrink-0 text-xs text-[var(--dpf-muted)]">{line.label}</dt>
+                <dd className="min-w-0 text-[var(--dpf-text)]">
+                  {line.href ? (
+                    <Link href={line.href} className="text-[var(--dpf-accent)] hover:underline">
+                      {line.value}
+                    </Link>
+                  ) : (
+                    line.value
+                  )}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+        {originCopy.basis ? (
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">{originCopy.basis}</p>
+        ) : null}
+        {originCopy.recurrence ? (
+          <p className="mt-1 text-xs text-[var(--dpf-warning)]">{originCopy.recurrence}</p>
+        ) : null}
+      </section>
+
       {/* Options weighed */}
       <section className="mb-6">
         <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--dpf-muted)] mb-2">
@@ -164,6 +217,33 @@ export default async function DecisionRecordPage({ params }: { params: Params })
                   {typeof description === "string" && description ? (
                     <p className="mt-1 text-xs text-[var(--dpf-muted)]">{description}</p>
                   ) : null}
+                  {(() => {
+                    // Only present when the gate scored real feature vectors
+                    // AND the option separates from the field. Otherwise the
+                    // option renders exactly as it did before.
+                    const c = consequences.get(optionId);
+                    if (!c) return null;
+                    return (
+                      <div className="mt-2 flex flex-col gap-1 text-xs">
+                        {c.strengths.length > 0 ? (
+                          <p className="text-[var(--dpf-muted)]">
+                            <span className="text-[var(--dpf-success)]">
+                              {CONSEQUENCE_LABELS.strengths}
+                            </span>
+                            {`: ${c.strengths.join("; ")}.`}
+                          </p>
+                        ) : null}
+                        {c.costs.length > 0 ? (
+                          <p className="text-[var(--dpf-muted)]">
+                            <span className="text-[var(--dpf-warning)]">
+                              {CONSEQUENCE_LABELS.costs}
+                            </span>
+                            {`: ${c.costs.join("; ")}.`}
+                          </p>
+                        ) : null}
+                      </div>
+                    );
+                  })()}
                 </li>
               );
             })}
@@ -255,6 +335,7 @@ export default async function DecisionRecordPage({ params }: { params: Params })
               resolved: row.humanOutcome !== null,
               contextMissing,
               withdrawn: isWithdrawnHumanOutcome(row.humanOutcome),
+              origin: { interactionId: row.interactionId, domainClass: row.domainClass },
             });
             const needsAction = help.steps.length > 0;
             return (

--- a/apps/web/app/(shell)/coworker-decisions/review/gap-answer-form.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/review/gap-answer-form.tsx
@@ -13,11 +13,18 @@ import { answerGovernanceGap } from "./actions";
 export function GapAnswerForm({
   domainClass,
   question,
+  autoOpen = false,
 }: {
   domainClass: string;
   question: string;
+  /**
+   * True when the reader arrived from a decision record's "answer it once"
+   * step. The box opens already showing the question they were just reading,
+   * so following the advice never lands on an empty form (BI-6700AF66).
+   */
+  autoOpen?: boolean;
 }) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(autoOpen);
   const [answer, setAnswer] = useState("");
   const [result, setResult] = useState<{ ok: boolean; message: string } | null>(
     null,
@@ -61,6 +68,7 @@ export function GapAnswerForm({
         Answer in your own words — it&#39;s saved as a draft for you to review, not
         published automatically.
       </p>
+      <p className="text-xs text-[var(--dpf-text)]">{question}</p>
       <textarea
         value={answer}
         onChange={(e) => setAnswer(e.target.value)}

--- a/apps/web/app/(shell)/coworker-decisions/review/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/review/page.tsx
@@ -98,7 +98,15 @@ function toGapClusters(
   }));
 }
 
-export default async function DecisionReviewPage() {
+/** Arrives from a decision record's "answer it once" step (BI-6700AF66). */
+type ReviewSearchParams = Promise<{ focus?: string; from?: string }>;
+
+export default async function DecisionReviewPage({
+  searchParams,
+}: {
+  searchParams?: ReviewSearchParams;
+}) {
+  const { focus: focusDomainClass = null } = (await searchParams) ?? {};
   const [
     conflictRows,
     unresolvedRows,
@@ -286,6 +294,7 @@ export default async function DecisionReviewPage() {
           {findings.map((f) => (
             <li
               key={f.id}
+              id={f.answer ? `finding-${f.answer.domainClass}` : undefined}
               className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
               style={{ borderLeftWidth: "3px", borderLeftColor: CLASS_ACCENT[f.findingClass] }}
             >
@@ -321,6 +330,7 @@ export default async function DecisionReviewPage() {
                 <GapAnswerForm
                   domainClass={f.answer.domainClass}
                   question={f.answer.question}
+                  autoOpen={f.answer.domainClass === focusDomainClass}
                 />
               )}
               {f.weightProposal && (

--- a/apps/web/lib/decision/decision-origin.test.ts
+++ b/apps/web/lib/decision/decision-origin.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDecisionOriginCopy,
+  parseDecisionCaller,
+  resolveDecisionOrigin,
+  type DecisionOriginDb,
+} from "./decision-origin";
+
+const ROOM = {
+  capsuleId: "WC-1234",
+  title: "Market aperture scouting",
+  objective: "Find external catalogs worth ingesting",
+  activityKind: "governance",
+  status: "working",
+};
+
+/** A db double whose tables are empty unless a test fills them. */
+function fakeDb(overrides: Partial<Record<string, unknown>> = {}): DecisionOriginDb {
+  const calls: Record<string, unknown[]> = {};
+  const db = {
+    workroom: { findFirst: async (args: never) => (calls.workroom ??= []).push(args) && null },
+    taskRun: { findUnique: async () => null },
+    featureBuild: { findUnique: async () => null },
+    agent: { findUnique: async () => null },
+    decisionInteraction: { findMany: async () => [] },
+  } as unknown as DecisionOriginDb;
+  return { ...db, ...(overrides as object) } as DecisionOriginDb;
+}
+
+const BASE_ROW = {
+  interactionId: "DI-1",
+  question: "run hive scout ingest",
+  buildId: null,
+  taskRunId: null,
+  outcomePayload: {},
+};
+
+describe("parseDecisionCaller", () => {
+  it("pulls the session ref out of an MCP session token", () => {
+    const caller = parseDecisionCaller({
+      caller: { apiTokenId: "session:abc123:external-catalog-scout", agentId: "scout" },
+    });
+    expect(caller.sessionRef).toBe("abc123");
+    expect(caller.agentId).toBe("scout");
+  });
+
+  it("leaves the session ref null for a token that is not a session token", () => {
+    expect(parseDecisionCaller({ caller: { apiTokenId: "dpfmcp_live" } }).sessionRef).toBeNull();
+    expect(parseDecisionCaller(null).sessionRef).toBeNull();
+    expect(parseDecisionCaller("nonsense").apiTokenId).toBeNull();
+  });
+});
+
+describe("resolveDecisionOrigin", () => {
+  it("reports nothing resolved rather than guessing", async () => {
+    const origin = await resolveDecisionOrigin(fakeDb(), BASE_ROW);
+    expect(origin.matchedVia).toBe("none");
+    expect(origin.workroom).toBeNull();
+    expect(origin.coworker).toBeNull();
+    expect(buildDecisionOriginCopy(origin).unresolved).not.toBeNull();
+  });
+
+  it("matches through the build the decision names", async () => {
+    const origin = await resolveDecisionOrigin(
+      fakeDb({
+        featureBuild: { findUnique: async () => ({ id: "row-1", title: "Catalog ingest" }) },
+        workroom: { findFirst: async () => ROOM },
+      }),
+      { ...BASE_ROW, buildId: "BUILD-9" },
+    );
+    expect(origin.matchedVia).toBe("build");
+    expect(origin.workroom?.capsuleId).toBe("WC-1234");
+    expect(origin.activity?.href).toBe("/build/BUILD-9");
+  });
+
+  it("resolves the task run before the room, because the key spaces differ", async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const origin = await resolveDecisionOrigin(
+      fakeDb({
+        taskRun: {
+          findUnique: async () => ({
+            id: "row-77",
+            title: "Daily catalog sweep",
+            objective: "Scan the external catalog for new entries",
+            status: "working",
+          }),
+        },
+        workroom: {
+          findFirst: async (args: { where: Record<string, unknown> }) => {
+            seen.push(args.where);
+            return ROOM;
+          },
+        },
+      }),
+      { ...BASE_ROW, taskRunId: "TR-5" },
+    );
+    expect(origin.matchedVia).toBe("task-run");
+    // The room is looked up by the run's ROW id, never by the semantic id.
+    expect(seen[0]).toEqual({ taskRunId: "row-77" });
+    expect(origin.activity?.detail).toContain("Scan the external catalog");
+  });
+
+  it("falls back to the session token when no build or run is named", async () => {
+    const origin = await resolveDecisionOrigin(
+      fakeDb({ workroom: { findFirst: async () => ROOM } }),
+      {
+        ...BASE_ROW,
+        outcomePayload: {
+          caller: { apiTokenId: "session:abc123:scout", client: "claude-code/2.1.241" },
+        },
+      },
+    );
+    expect(origin.matchedVia).toBe("session-token");
+    expect(origin.workroom?.title).toBe("Market aperture scouting");
+  });
+
+  it("reports the coworker alone when no room claimed the work", async () => {
+    const origin = await resolveDecisionOrigin(
+      fakeDb({
+        agent: {
+          findUnique: async () => ({
+            agentId: "external-catalog-scout",
+            name: "external-catalog-scout",
+            displayName: "Catalog Scout",
+            role: "research",
+            kind: "specialist",
+            portfolio: { slug: "foundational" },
+          }),
+        },
+      }),
+      { ...BASE_ROW, outcomePayload: { caller: { agentId: "external-catalog-scout" } } },
+    );
+    expect(origin.matchedVia).toBe("agent");
+    expect(origin.workroom).toBeNull();
+    expect(origin.coworker?.displayName).toBe("Catalog Scout");
+    expect(buildDecisionOriginCopy(origin).basis).toContain("no room claimed");
+  });
+
+  it("counts prior occurrences and how many are still open", async () => {
+    const origin = await resolveDecisionOrigin(
+      fakeDb({
+        decisionInteraction: {
+          findMany: async () => [
+            { interactionId: "DI-0", createdAt: new Date("2026-08-01"), humanOutcome: null },
+            { interactionId: "DI-2", createdAt: new Date("2026-08-10"), humanOutcome: { ok: true } },
+          ],
+        },
+      }),
+      BASE_ROW,
+    );
+    expect(origin.recurrence.priorOccurrences).toBe(2);
+    expect(origin.recurrence.stillOpen).toBe(1);
+    expect(buildDecisionOriginCopy(origin).recurrence).toContain("still waiting on you");
+  });
+});
+
+describe("buildDecisionOriginCopy", () => {
+  it("keeps a partial match honest about what matched it", async () => {
+    const origin = await resolveDecisionOrigin(
+      fakeDb({ workroom: { findFirst: async () => ROOM } }),
+      { ...BASE_ROW, outcomePayload: { caller: { apiTokenId: "session:abc123:scout" } } },
+    );
+    const copy = buildDecisionOriginCopy(origin);
+    expect(copy.basis).toBe("Matched through the session token that raised it.");
+    expect(copy.unresolved).toBeNull();
+    expect(copy.lines[0]?.href).toBe("/build/work/WC-1234");
+  });
+});

--- a/apps/web/lib/decision/decision-origin.ts
+++ b/apps/web/lib/decision/decision-origin.ts
@@ -1,0 +1,437 @@
+// Where a decision came from (BI-6700AF66, EP-0AF96937).
+//
+// A DecisionInteraction records what was asked and how the kernel scored it,
+// but the audit record shows the caller as an agent slug, a thread id and a
+// token id. That is not enough for an owner to rule: they need the piece of
+// work the coworker was inside, what that work is for, and whether this same
+// question has come back before.
+//
+// Nothing here invents context. Each step resolves against a real row, and the
+// result records WHICH step matched (`matchedVia`) so the surface can say how
+// it knew instead of implying certainty. When no step resolves, the origin is
+// `null` and the page says so — an honest gap beats a plausible guess.
+//
+// Spec: docs/superpowers/specs/2026-08-23-decision-concierge-design.md §4.1
+
+/* -------------------------------------------------------------------------- */
+/* Shapes                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/** How the origin was established. Ordered strongest-evidence first. */
+export type OriginMatch =
+  | "build" // the decision names a build, and a workroom owns that build
+  | "task-run" // the decision names a task run, and a workroom owns that run
+  | "session-token" // the caller's session ref matches a workroom's executor ref
+  | "agent" // only the coworker is known, not the room it worked in
+  | "thread" // only the conversation is known
+  | "none";
+
+export type DecisionOriginWorkroom = {
+  capsuleId: string;
+  title: string;
+  objective: string;
+  activityKind: string | null;
+  status: string;
+};
+
+export type DecisionOriginCoworker = {
+  agentId: string;
+  displayName: string;
+  role: string | null;
+  portfolioSlug: string | null;
+};
+
+/** What the coworker was doing when the decision was raised. */
+export type DecisionOriginActivity = {
+  kind: "build" | "task-run" | "thread" | "mcp-session";
+  label: string;
+  detail: string | null;
+  href: string | null;
+};
+
+/** How often this same question has already been asked. */
+export type DecisionOriginRecurrence = {
+  /** Rows with the same question text, excluding this one. */
+  priorOccurrences: number;
+  /** Of those, how many are still unresolved. */
+  stillOpen: number;
+  firstSeenAt: Date | null;
+};
+
+export type DecisionOrigin = {
+  matchedVia: OriginMatch;
+  workroom: DecisionOriginWorkroom | null;
+  coworker: DecisionOriginCoworker | null;
+  activity: DecisionOriginActivity | null;
+  recurrence: DecisionOriginRecurrence;
+};
+
+/** The interaction fields the resolver reads. */
+export type DecisionOriginRow = {
+  interactionId: string;
+  question: string;
+  buildId: string | null;
+  taskRunId: string | null;
+  outcomePayload: unknown;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Caller parsing (pure)                                                      */
+/* -------------------------------------------------------------------------- */
+
+export type DecisionCaller = {
+  client: string | null;
+  agentId: string | null;
+  threadId: string | null;
+  /** Raw token id, e.g. "session:<sessionId>:<agent>". */
+  apiTokenId: string | null;
+  /** The session segment of an MCP session token, when the token carries one. */
+  sessionRef: string | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+/**
+ * Read the caller block off an interaction's outcomePayload. MCP session tokens
+ * are recorded as `session:<sessionId>:<agentSlug>`; the middle segment is what
+ * a Workroom stores as its executorRef, which is the only link between an
+ * external CLI session and the room it claimed.
+ */
+export function parseDecisionCaller(outcomePayload: unknown): DecisionCaller {
+  const caller = asRecord(asRecord(outcomePayload).caller);
+  const apiTokenId = asString(caller.apiTokenId);
+  let sessionRef: string | null = null;
+  if (apiTokenId?.startsWith("session:")) {
+    const segments = apiTokenId.split(":");
+    sessionRef = segments.length >= 2 ? (asString(segments[1]) ?? null) : null;
+  }
+  return {
+    client: asString(caller.client),
+    agentId: asString(caller.agentId),
+    threadId: asString(caller.threadId),
+    apiTokenId,
+    sessionRef,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Database surface (structural, so tests inject a fake)                      */
+/* -------------------------------------------------------------------------- */
+
+type WorkroomRow = {
+  capsuleId: string;
+  title: string;
+  objective: string;
+  activityKind: string | null;
+  status: string;
+};
+
+type TaskRunRow = { id: string; title: string; objective: string; status: string };
+
+type BuildRow = { id: string; title: string | null };
+
+type AgentRow = {
+  agentId: string;
+  name: string;
+  displayName: string | null;
+  role: string | null;
+  kind: string | null;
+  portfolio: { slug: string } | null;
+};
+
+export type DecisionOriginDb = {
+  workroom: {
+    findFirst(args: {
+      where: Record<string, unknown>;
+      select: Record<string, boolean>;
+      orderBy?: Record<string, unknown>;
+    }): Promise<WorkroomRow | null>;
+  };
+  taskRun: {
+    findUnique(args: {
+      where: { taskRunId: string };
+      select: Record<string, boolean>;
+    }): Promise<TaskRunRow | null>;
+  };
+  featureBuild: {
+    findUnique(args: {
+      where: { buildId: string };
+      select: Record<string, boolean>;
+    }): Promise<BuildRow | null>;
+  };
+  agent: {
+    findUnique(args: {
+      where: { agentId: string };
+      select: Record<string, unknown>;
+    }): Promise<AgentRow | null>;
+  };
+  decisionInteraction: {
+    findMany(args: {
+      where: Record<string, unknown>;
+      select: Record<string, boolean>;
+      orderBy?: Record<string, unknown>;
+      take?: number;
+    }): Promise<Array<{ interactionId: string; createdAt: Date; humanOutcome: unknown }>>;
+  };
+};
+
+const WORKROOM_SELECT = {
+  capsuleId: true,
+  title: true,
+  objective: true,
+  activityKind: true,
+  status: true,
+};
+
+/* -------------------------------------------------------------------------- */
+/* Resolution                                                                 */
+/* -------------------------------------------------------------------------- */
+
+function toCoworker(agent: AgentRow | null): DecisionOriginCoworker | null {
+  if (!agent) return null;
+  return {
+    agentId: agent.agentId,
+    displayName: agent.displayName || agent.name,
+    role: agent.role ?? agent.kind ?? null,
+    portfolioSlug: agent.portfolio?.slug ?? null,
+  };
+}
+
+/**
+ * How many times this same question has already been recorded, and how many of
+ * those are still waiting on a human. Exact-question matching only: the
+ * semantic clusterer on the review page owns paraphrase grouping, and running
+ * embeddings from a record page would make the page fail when the embedding
+ * runtime is down.
+ */
+async function resolveRecurrence(
+  db: DecisionOriginDb,
+  row: DecisionOriginRow,
+): Promise<DecisionOriginRecurrence> {
+  const question = row.question.trim();
+  if (!question) return { priorOccurrences: 0, stillOpen: 0, firstSeenAt: null };
+  const siblings = await db.decisionInteraction.findMany({
+    where: { question, interactionId: { not: row.interactionId } },
+    select: { interactionId: true, createdAt: true, humanOutcome: true },
+    orderBy: { createdAt: "asc" },
+    take: 100,
+  });
+  return {
+    priorOccurrences: siblings.length,
+    stillOpen: siblings.filter((s) => s.humanOutcome === null).length,
+    firstSeenAt: siblings[0]?.createdAt ?? null,
+  };
+}
+
+/**
+ * Resolve the origin of one decision. Steps run strongest-evidence first and
+ * stop at the first workroom match; the coworker and the recurrence count are
+ * always attempted, because they are useful even when no room resolves.
+ */
+export async function resolveDecisionOrigin(
+  db: DecisionOriginDb,
+  row: DecisionOriginRow,
+): Promise<DecisionOrigin> {
+  const caller = parseDecisionCaller(row.outcomePayload);
+  const [recurrence, agent] = await Promise.all([
+    resolveRecurrence(db, row),
+    caller.agentId
+      ? db.agent.findUnique({
+        where: { agentId: caller.agentId },
+        select: {
+          agentId: true,
+          name: true,
+          displayName: true,
+          role: true,
+          kind: true,
+          portfolio: { select: { slug: true } },
+        },
+      })
+      : Promise.resolve(null),
+  ]);
+  const coworker = toCoworker(agent);
+
+  // 1. A build the decision names, and the workroom that owns that build.
+  if (row.buildId) {
+    const build = await db.featureBuild.findUnique({
+      where: { buildId: row.buildId },
+      select: { id: true, title: true },
+    });
+    if (build) {
+      const workroom = await db.workroom.findFirst({
+        where: { featureBuildId: build.id },
+        select: WORKROOM_SELECT,
+        orderBy: { updatedAt: "desc" },
+      });
+      return {
+        matchedVia: "build",
+        workroom,
+        coworker,
+        activity: {
+          kind: "build",
+          label: build.title ?? row.buildId,
+          detail: null,
+          href: `/build/${encodeURIComponent(row.buildId)}`,
+        },
+        recurrence,
+      };
+    }
+  }
+
+  // 2. A coworker task run, and the workroom that owns it. Note the key spaces
+  //    differ: the interaction stores the semantic taskRunId, the workroom
+  //    stores the row id, so the run must be resolved before the room.
+  if (row.taskRunId) {
+    const taskRun = await db.taskRun.findUnique({
+      where: { taskRunId: row.taskRunId },
+      select: { id: true, title: true, objective: true, status: true },
+    });
+    if (taskRun) {
+      const workroom = await db.workroom.findFirst({
+        where: { taskRunId: taskRun.id },
+        select: WORKROOM_SELECT,
+        orderBy: { updatedAt: "desc" },
+      });
+      return {
+        matchedVia: "task-run",
+        workroom,
+        coworker,
+        activity: {
+          kind: "task-run",
+          label: taskRun.title,
+          detail: taskRun.objective,
+          href: null,
+        },
+        recurrence,
+      };
+    }
+  }
+
+  // 3. An external CLI session: its session ref is what the room recorded as
+  //    its executor ref when the session claimed it.
+  if (caller.sessionRef) {
+    const workroom = await db.workroom.findFirst({
+      where: { executorRef: { contains: caller.sessionRef } },
+      select: WORKROOM_SELECT,
+      orderBy: { updatedAt: "desc" },
+    });
+    if (workroom) {
+      return {
+        matchedVia: "session-token",
+        workroom,
+        coworker,
+        activity: {
+          kind: "mcp-session",
+          label: caller.client ?? "external session",
+          detail: null,
+          href: null,
+        },
+        recurrence,
+      };
+    }
+  }
+
+  // 4. No room resolved. Report what is actually known — the coworker, or the
+  //    conversation — rather than nothing.
+  if (coworker) {
+    return {
+      matchedVia: "agent",
+      workroom: null,
+      coworker,
+      activity: caller.client
+        ? { kind: "mcp-session", label: caller.client, detail: null, href: null }
+        : null,
+      recurrence,
+    };
+  }
+  if (caller.threadId) {
+    return {
+      matchedVia: "thread",
+      workroom: null,
+      coworker: null,
+      activity: { kind: "thread", label: "a coworker conversation", detail: null, href: null },
+      recurrence,
+    };
+  }
+  return { matchedVia: "none", workroom: null, coworker: null, activity: null, recurrence };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Copy (pure)                                                                */
+/* -------------------------------------------------------------------------- */
+
+export type DecisionOriginCopy = {
+  heading: string;
+  /** One line per fact that actually resolved. */
+  lines: Array<{ label: string; value: string; href: string | null }>;
+  /** How the link was established, stated plainly. Null when nothing resolved. */
+  basis: string | null;
+  /** Recurrence sentence, or null when this is the first time. */
+  recurrence: string | null;
+  /** Shown when nothing resolved at all. */
+  unresolved: string | null;
+};
+
+const BASIS_TEXT: Record<OriginMatch, string | null> = {
+  build: "Matched through the build this decision belongs to.",
+  "task-run": "Matched through the coworker task that raised it.",
+  "session-token": "Matched through the session token that raised it.",
+  agent: "Only the coworker is known; no room claimed this work.",
+  thread: "Only the conversation is known.",
+  none: null,
+};
+
+/** Turn a resolved origin into the lines a surface renders. Pure. */
+export function buildDecisionOriginCopy(origin: DecisionOrigin): DecisionOriginCopy {
+  const lines: DecisionOriginCopy["lines"] = [];
+  if (origin.workroom) {
+    lines.push({
+      label: "Work room",
+      value: origin.workroom.title,
+      href: `/build/work/${encodeURIComponent(origin.workroom.capsuleId)}`,
+    });
+    lines.push({ label: "What that room is for", value: origin.workroom.objective, href: null });
+  }
+  if (origin.coworker) {
+    const role = origin.coworker.role ? ` (${origin.coworker.role})` : "";
+    lines.push({ label: "Coworker", value: `${origin.coworker.displayName}${role}`, href: null });
+  }
+  if (origin.activity) {
+    lines.push({
+      label: "Doing",
+      value: origin.activity.detail
+        ? `${origin.activity.label} — ${origin.activity.detail}`
+        : origin.activity.label,
+      href: origin.activity.href,
+    });
+  }
+
+  const { priorOccurrences, stillOpen } = origin.recurrence;
+  let recurrence: string | null = null;
+  if (priorOccurrences > 0) {
+    const times = priorOccurrences === 1 ? "once before" : `${priorOccurrences} times before`;
+    recurrence =
+      stillOpen > 0
+        ? `Asked ${times}; ${stillOpen} of those still waiting on you.`
+        : `Asked ${times}, and answered each time.`;
+  }
+
+  return {
+    heading: "Where this came from",
+    lines,
+    basis: lines.length > 0 ? BASIS_TEXT[origin.matchedVia] : null,
+    recurrence,
+    unresolved:
+      lines.length === 0
+        ? "The work behind this decision could not be traced. What it names is below."
+        : null,
+  };
+}

--- a/apps/web/lib/decision/option-consequences.test.ts
+++ b/apps/web/lib/decision/option-consequences.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOptionConsequences,
+  consequencesByOption,
+  parseScoredOptions,
+} from "./option-consequences";
+
+describe("parseScoredOptions", () => {
+  it("returns nothing for a row that was never scored", () => {
+    expect(parseScoredOptions(null)).toEqual([]);
+    expect(parseScoredOptions({})).toEqual([]);
+    expect(parseScoredOptions([])).toEqual([]);
+  });
+
+  it("drops malformed entries instead of guessing at them", () => {
+    const parsed = parseScoredOptions([
+      { id: "keep", features: { speed_to_value: 0.9 } },
+      { description: "no id" },
+      "not an object",
+      { id: "", features: { speed_to_value: 1 } },
+      { id: "no-numeric-features", features: { speed_to_value: "fast" } },
+    ]);
+    expect(parsed.map((p) => p.id)).toEqual(["keep", "no-numeric-features"]);
+    expect(parsed[1]!.features).toBeNull();
+  });
+});
+
+describe("buildOptionConsequences", () => {
+  it("says nothing when fewer than two options carry features", () => {
+    expect(
+      buildOptionConsequences([{ id: "proceed", features: { speed_to_value: 0.9 } }]),
+    ).toEqual([]);
+    expect(
+      buildOptionConsequences([
+        { id: "proceed", features: null },
+        { id: "decline", features: null },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("says nothing when the options do not separate", () => {
+    const consequences = buildOptionConsequences([
+      { id: "proceed", features: { speed_to_value: 0.5, blast_radius: 0.4 } },
+      { id: "decline", features: { speed_to_value: 0.5, blast_radius: 0.45 } },
+    ]);
+    expect(consequences).toEqual([]);
+  });
+
+  it("reads a high cost axis as a cost, not a strength", () => {
+    const consequences = buildOptionConsequences([
+      { id: "proceed", features: { blast_radius: 0.9, speed_to_value: 0.8 } },
+      { id: "decline", features: { blast_radius: 0.1, speed_to_value: 0.2 } },
+    ]);
+    const byOption = consequencesByOption(consequences);
+    const proceed = byOption.get("proceed");
+    expect(proceed).toBeDefined();
+    expect(proceed!.costs.join(" ")).toContain("breaks more if it is wrong");
+    expect(proceed!.strengths.join(" ")).toContain("sooner");
+    expect(proceed!.costs.join(" ")).not.toContain("sooner");
+  });
+
+  it("ignores feature keys that are not real dimensions", () => {
+    const consequences = buildOptionConsequences([
+      { id: "proceed", features: { made_up_axis: 0.95 } },
+      { id: "decline", features: { made_up_axis: 0.05 } },
+    ]);
+    expect(consequences).toEqual([]);
+  });
+
+  it("keeps at most two lines a side, strongest separation first", () => {
+    const consequences = buildOptionConsequences([
+      {
+        id: "proceed",
+        features: {
+          speed_to_value: 0.9,
+          reusability: 0.8,
+          evidence_density: 0.75,
+          cost_efficiency: 0.7,
+        },
+      },
+      {
+        id: "decline",
+        features: {
+          speed_to_value: 0.1,
+          reusability: 0.4,
+          evidence_density: 0.5,
+          cost_efficiency: 0.6,
+        },
+      },
+    ]);
+    const proceed = consequencesByOption(consequences).get("proceed");
+    expect(proceed!.strengths).toHaveLength(2);
+    expect(proceed!.strengths[0]).toContain("sooner");
+  });
+});

--- a/apps/web/lib/decision/option-consequences.ts
+++ b/apps/web/lib/decision/option-consequences.ts
@@ -1,0 +1,151 @@
+// What each option would actually cost (BI-6700AF66, EP-0AF96937).
+//
+// The decision record renders options as bare ids — "Proceed", "Decline" — so
+// the owner is asked to rule with the consequences withheld. When the gate
+// scored real per-option feature vectors, those vectors already say how the
+// options differ. This module turns that into one plain line per option.
+//
+// The rule that governs every branch here: NO FABRICATION. An option whose row
+// was never scored, or whose features do not separate it from the alternatives,
+// gets nothing back. Silence is correct; an invented consequence is not.
+//
+// Sign convention matters and is easy to get backwards: on a cost axis a HIGH
+// score means the option exhibits MORE of that cost. The catalogue owns those
+// phrasings (dimension-catalog.ts), so this module never re-words an axis.
+//
+// Spec: docs/superpowers/specs/2026-08-23-decision-concierge-design.md §4.2
+
+import { DIMENSION_CATALOG, type DimensionGuidance } from "./dimension-catalog";
+
+/** One scored option, as `DecisionInteraction.scoredOptions` records it. */
+export type ScoredOptionInput = {
+  id: string;
+  description?: string | null;
+  features?: Record<string, number> | null;
+};
+
+export type OptionConsequence = {
+  optionId: string;
+  /** Where this option is strongest, relative to the alternatives. */
+  strengths: string[];
+  /** What this option costs more than the alternatives. */
+  costs: string[];
+};
+
+/** An axis only counts as distinguishing at this much separation from the field. */
+const SEPARATION_FLOOR = 0.15;
+
+/** At most this many lines per side, so the card stays readable. */
+const MAX_PER_SIDE = 2;
+
+const GUIDANCE_BY_KEY = new Map<string, DimensionGuidance>(
+  DIMENSION_CATALOG.map((entry) => [entry.key as string, entry]),
+);
+
+/** Read the scoredOptions JSON defensively. Anything malformed is dropped. */
+export function parseScoredOptions(value: unknown): ScoredOptionInput[] {
+  if (!Array.isArray(value)) return [];
+  const parsed: ScoredOptionInput[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const record = entry as Record<string, unknown>;
+    if (typeof record.id !== "string" || record.id.length === 0) continue;
+    const rawFeatures = record.features;
+    let features: Record<string, number> | null = null;
+    if (rawFeatures && typeof rawFeatures === "object" && !Array.isArray(rawFeatures)) {
+      features = {};
+      for (const [key, val] of Object.entries(rawFeatures as Record<string, unknown>)) {
+        if (typeof val === "number" && Number.isFinite(val)) features[key] = val;
+      }
+      if (Object.keys(features).length === 0) features = null;
+    }
+    parsed.push({
+      id: record.id,
+      description: typeof record.description === "string" ? record.description : null,
+      features,
+    });
+  }
+  return parsed;
+}
+
+/** Mean of an axis across every option that scored it. */
+function fieldMean(options: ScoredOptionInput[], axis: string): number | null {
+  const values = options
+    .map((o) => o.features?.[axis])
+    .filter((v): v is number => typeof v === "number");
+  if (values.length === 0) return null;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/**
+ * Per-option consequence lines, derived only from axes where the option
+ * genuinely separates from the rest of the field. Returns an empty array when
+ * fewer than two options were scored — with nothing to compare against, no
+ * statement about relative cost is defensible.
+ */
+export function buildOptionConsequences(
+  scoredOptions: ScoredOptionInput[],
+): OptionConsequence[] {
+  const scored = scoredOptions.filter((o) => o.features && Object.keys(o.features).length > 0);
+  if (scored.length < 2) return [];
+
+  const axes = new Set<string>();
+  for (const option of scored) {
+    for (const key of Object.keys(option.features ?? {})) {
+      if (GUIDANCE_BY_KEY.has(key)) axes.add(key);
+    }
+  }
+
+  const consequences: OptionConsequence[] = [];
+  for (const option of scored) {
+    const strengths: Array<{ text: string; separation: number }> = [];
+    const costs: Array<{ text: string; separation: number }> = [];
+
+    for (const axis of axes) {
+      const value = option.features?.[axis];
+      if (typeof value !== "number") continue;
+      const others = scored.filter((o) => o.id !== option.id);
+      const mean = fieldMean(others, axis);
+      if (mean === null) continue;
+      // Only the above-mean side is stated. The catalogue phrases what a HIGH
+      // score asserts; there is no sanctioned wording for the low side, and
+      // inventing an inverse ("less blast radius") is exactly the fabrication
+      // this module refuses.
+      const separation = value - mean;
+      if (separation < SEPARATION_FLOOR) continue;
+
+      const guidance = GUIDANCE_BY_KEY.get(axis);
+      if (!guidance) continue;
+      // High on a cost axis is a cost; high on a benefit axis is a strength.
+      const target = guidance.kind === "cost" ? costs : strengths;
+      target.push({ text: guidance.highMeans, separation });
+    }
+
+    strengths.sort((a, b) => b.separation - a.separation);
+    costs.sort((a, b) => b.separation - a.separation);
+    consequences.push({
+      optionId: option.id,
+      strengths: strengths.slice(0, MAX_PER_SIDE).map((s) => s.text),
+      costs: costs.slice(0, MAX_PER_SIDE).map((c) => c.text),
+    });
+  }
+
+  return consequences.filter((c) => c.strengths.length > 0 || c.costs.length > 0);
+}
+
+/** Index consequences by option id for rendering. */
+export function consequencesByOption(
+  consequences: OptionConsequence[],
+): Map<string, OptionConsequence> {
+  return new Map(consequences.map((c) => [c.optionId, c]));
+}
+
+/**
+ * Section labels for the consequence lists. They live here rather than in the
+ * page so the copy that describes a scoring axis and the copy that frames it
+ * stay in one module.
+ */
+export const CONSEQUENCE_LABELS = {
+  strengths: "Best at",
+  costs: "Costs",
+} as const;

--- a/apps/web/lib/wiki/decision-help.ts
+++ b/apps/web/lib/wiki/decision-help.ts
@@ -44,7 +44,29 @@ export type DecisionHelpInput = {
    * asked, so telling the reader "a human already answered this" would be false.
    */
   withdrawn?: boolean;
+  /**
+   * Identity of the row this help is for. When present, every link back to
+   * Review & adjust carries it, so following the advice lands ON the finding
+   * with the question already in hand instead of on an empty form
+   * (BI-6700AF66).
+   */
+  origin?: { interactionId?: string; domainClass?: string };
 };
+
+/** Review & adjust, focused on this row's finding when the row is identified. */
+export function reviewHref(origin?: DecisionHelpInput["origin"]): string {
+  const params = new URLSearchParams();
+  if (origin?.domainClass) params.set("focus", origin.domainClass);
+  if (origin?.interactionId) params.set("from", origin.interactionId);
+  const query = params.toString();
+  if (!query) return "/coworker-decisions/review";
+  // The fragment lands the reader ON the finding; the query is what pre-opens
+  // its answer box with the question already stated.
+  const fragment = origin?.domainClass
+    ? `#finding-${encodeURIComponent(origin.domainClass)}`
+    : "";
+  return `/coworker-decisions/review?${query}${fragment}`;
+}
 
 /** The tier's playbook, named the way the rest of the surface names it. */
 function tierPlaybook(tier: DecisionAuditTierOrOther): string {
@@ -94,14 +116,14 @@ function unresolvedSteps(input: DecisionHelpInput): DecisionHelpStep[] {
     steps.push({
       label:
         "Answer it once on Review & adjust — your answer is captured as draft business doctrine your AI reuses, and the whole cluster of similar questions clears.",
-      href: "/coworker-decisions/review",
+      href: reviewHref(input.origin),
     });
     return steps;
   }
   steps.push({
     label:
       "Check Review & adjust — it rolls rows like this into a short list of themes instead of making you work the log line by line.",
-    href: "/coworker-decisions/review",
+    href: reviewHref(input.origin),
   });
   steps.push(
     input.tier === "wsid"

--- a/docs/superpowers/plans/2026-08-23-decision-concierge-plan.md
+++ b/docs/superpowers/plans/2026-08-23-decision-concierge-plan.md
@@ -1,0 +1,119 @@
+---
+status: draft
+---
+
+# Decision Concierge — implementation plan
+
+Spec: `docs/superpowers/specs/2026-08-23-decision-concierge-design.md`
+Epic: EP-0AF96937 · Workroom: WC-69329196
+Backlog: BI-6700AF66 (P1), BI-3D0FB84B (P2), BI-19B350FD (P3), BI-C62127B9 (P4)
+
+Each phase ships on its own and leaves the surface better than it found it. Do
+not start a later phase before the earlier one is merged: a recommendation shown
+without origin context is worse than no recommendation.
+
+---
+
+## Phase 1 — Context (BI-6700AF66)
+
+**Goal:** an owner opening a decision record can tell what it is about and what
+each option costs, and following any link out of it keeps what they just read.
+
+1. **`apps/web/lib/decision/decision-origin.ts`** (pure, dependency-injected db
+   reader; no Prisma import in the pure half).
+   - `resolveDecisionOrigin(row, db)` walking build → task run → session token →
+     agent → thread, returning `DecisionOrigin` plus `matchedVia` so the UI can
+     state how it knew.
+   - Recurrence counts exact-question repeats. Paraphrase clustering stays on
+     the review page: running embeddings from a record page would make the page
+     fail whenever the embedding runtime is down, and this count is context,
+     not a resolution boundary.
+   - Tests: each resolution step in isolation, the "nothing resolves" case, and
+     that a partial match never presents itself as certain.
+2. **Schema (deferred to Phase 2):** `DecisionInteraction.workroomId String?` +
+   `@@index`, written by the gate when the caller context carries a room. The
+   resolver covers every row without it, so this rides the migration Phase 2
+   already needs rather than spending a migration on a convenience column.
+4. **Record page** (`app/(shell)/coworker-decisions/decisions/[interactionId]`):
+   a "Where this came from" section above Options — workroom (linked, with its
+   objective), coworker (display name + role, not the agent slug), what it was
+   doing, requester, and the recurrence line. Theme tokens only.
+5. **Consequences:** `apps/web/lib/decision/option-consequences.ts` — pure
+   projection from `scoredOptions` features + origin blast radius to one line per
+   option. Returns nothing for unscored rows; the page renders exactly what it
+   does today in that case. Tests cover the empty case first.
+6. **Seeded forms:** the record's "answer it once" step carries `focus` (the
+   finding's domain) and `from` (the interaction id) plus a fragment, so the
+   review page opens that finding's answer box with the question restated.
+
+**Status:** implemented on `feat/decision-concierge` — steps 1, 4, 5 and 6 done,
+step 2 deferred as above, step 3 rides step 2.
+
+**Gate:** affected vitest files pass (30), `pnpm --filter web typecheck` clean,
+50 preflight guards clean, prose-lint and style-drift show no growth. Still
+outstanding: UX verification of the record page against a live unresolved
+decision on the contributor preview.
+
+---
+
+## Phase 2 — Proposal substrate (BI-3D0FB84B)
+
+1. `DecisionResolutionProposal` model + migration (spec §4.4). Run the new-model
+   cascade: classification, docs, any coverage tests the schema guards require.
+2. `apps/web/lib/decision/resolution-proposal-store.ts` — create, list-open,
+   rule (accept / amend / reject), supersede, expire. Ruling is idempotent and
+   loses to a concurrent ruling rather than double-writing (mirror
+   `ruleWeightAdjustmentProposal`'s already-ruled path).
+3. Write-through adapters, one per `actionKind`, each delegating to the existing
+   path — no new resolution mechanics.
+4. Inline accept / amend / reject control on the record; amendment posts the
+   edited text and stores the draft-vs-accepted delta.
+5. Review queue reshaped: proposal-ready rows first, headline = the proposal
+   summary, action = "Review the recommendation" into the record.
+6. Tests: lifecycle transitions, each adapter's write-through, the
+   nothing-auto-applies invariant, and supersession when the interaction
+   resolves elsewhere.
+
+---
+
+## Phase 3 — The panel (BI-19B350FD)
+
+1. `deliberation/governance-triage.deliberation.md` seed (roles, adjudication
+   mode, evidence requirements, output contract).
+2. `apps/web/lib/decision/triage-staffing.ts` — pure `domainClass` + portfolio →
+   profession families → live agents, with the honest empty case.
+3. Runner wiring: on escalate/defer with risk ≥ medium, start a governance-triage
+   run through the existing orchestrator, set `deliberationRunId`, seal onto the
+   room via the existing bridge, and write a proposal from the adjudicator's
+   output.
+4. Output-contract validation: a run missing `recommendedAction`, `draft`,
+   `consequences` or `dissent` records `insufficient-evidence` and writes no
+   proposal.
+5. Panel card on the record: roster, recommendation, dissent, confidence,
+   uncovered domains.
+6. Tests: staffing map, contract validation (the no-proposal path first), and
+   that a failed panel leaves the record exactly as Phase 1 left it.
+
+---
+
+## Phase 4 — The standing process (BI-C62127B9)
+
+1. Convene the standing governance workroom (idempotent; one row).
+2. `decision-concierge-sweep` scheduled task: shared queue predicates, cluster,
+   panel under caps, write proposals, post the room digest, age items, and log
+   what it skipped.
+3. Attention: `ai-decision` items gain one-tap approve/reject when a proposal is
+   ready; digest and nav counts.
+4. Tests: cap enforcement and the skip log, the ageing rule, and that the sweep
+   and the review page cannot drift apart on which decisions are open.
+
+---
+
+## Cross-cutting
+
+- One source for "which decisions are open": the review page, the sweep and the
+  attention source share the predicate module. If they can disagree, they will.
+- Every surface degrades to the current behaviour when a panel has not run, the
+  inference runtime is down, or the origin cannot be resolved.
+- Documentation impact per phase: the decision-governance surface docs and the
+  operator-facing help copy change with Phase 1 and Phase 4.

--- a/docs/superpowers/specs/2026-08-23-decision-concierge-design.md
+++ b/docs/superpowers/specs/2026-08-23-decision-concierge-design.md
@@ -1,0 +1,378 @@
+---
+status: draft
+---
+
+# Decision Concierge — the review queue proposes, the owner rules
+
+Phase 1 (BI-6700AF66) is implemented on this branch; phases 2-4 are proposed.
+Owner: platform (WWMD)
+Epic: EP-0AF96937 (Decision Governance Surface — close the review-and-adjust loop)
+Workroom: WC-69329196
+Date: 2026-08-23
+
+---
+
+## 1. Problem
+
+The decision ledger, the review workspace and the capture loops all work. What
+does not work is the shape of the human's job. Observed on the live install on
+2026-08-23, on `DI-453F73458838` ("run hive scout ingest", WWWD, escalate,
+medium risk) and on `/coworker-decisions/review`:
+
+1. **The queue is somewhere you have to know about.** The operator reached
+   `/coworker-decisions/review` from memory. Unresolved decisions accumulate
+   with no force pushing them at anyone, so business calls sit.
+2. **The record does not say what it is about.** The page shows
+   `agent external-catalog-scout`, a thread id and a token id. It does not say
+   which workroom that coworker was working in, what it was trying to
+   accomplish, or that the run is part of market-aperture scouting. Without
+   that, "Proceed / Decline" is not answerable.
+3. **The implications are not stated.** Two bare option ids, no statement of
+   what follows from either, no blast radius, no cost, no reversibility. The
+   operator is asked to rule with the consequences withheld.
+4. **Metadata does not travel.** Following the record's own guidance
+   ("Answer it once on Review & adjust") lands on a different page, where the
+   operator must re-find the finding, then type an answer into an empty
+   textarea. The question, the coworker, the workroom and the options — all
+   present one screen earlier — are gone.
+5. **The AI does not propose.** Every mechanism to resolve exists
+   (`captureOrgBusinessAnswer`, `WeightAdjustmentProposal`, the stance editor,
+   escalation capture), and every one of them starts from a blank field. The
+   platform staffs finance, legal, HR, security and marketing coworkers, and
+   asks none of them what the owner should do.
+
+The through-line: **the platform has built the whole apparatus for the human to
+answer, and none of it for the AI to propose.** The owner carries the retrieval
+cost, the context cost and the drafting cost of every governance decision.
+
+### 1.1 What "good" looks like
+
+One screen per open decision. It states what happened, who was doing what and
+inside which piece of work, what each option costs, what the coworkers who know
+that domain recommend, and what the recommendation would change if accepted —
+already drafted. The owner reads, then rules: accept, amend, reject. The queue
+comes to them on a cadence instead of waiting to be found.
+
+---
+
+## 2. What already exists (fuse, do not build)
+
+Verified against `origin/main` at `8ae58d373b`.
+
+| Need | Existing substrate |
+| --- | --- |
+| Decision ledger + audit record | `DecisionInteraction`, `EscalationCapture`, `DeferralCapture` (`packages/db/prisma/schema/decision-governance.prisma`) |
+| Decision record page | `apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.tsx` |
+| Findings workspace | `apps/web/app/(shell)/coworker-decisions/review/page.tsx` + `apps/web/lib/wiki/decision-review-findings.ts` |
+| Multi-agent panels | Deliberation Pattern Framework — `apps/web/lib/deliberation/*`, `DeliberationRun`, `DeliberationOutcome` (`mergedRecommendation`, `rationaleSummary`, `confidence`, `unresolvedRisks`, `branchRoster`), seeds in `deliberation/*.deliberation.md` |
+| Decision → panel link | `DecisionInteraction.deliberationRunId` — **the column exists and is never written by the escalation path** |
+| Panel → room sealing | `apps/web/lib/deliberation/deliberation-room-bridge.server.ts` |
+| Rooms with a convening shape | `Workroom` + `apps/web/lib/work-management/room-shapes.ts` (`specialist-alignment`, `craft-stewardship`, …) |
+| Specialist rosters | `Agent`, profession families in `docs/professions/registry.json`, `PROFESSION_REGISTRY` |
+| Proactive surfacing | Attention surface — `apps/web/lib/attention/*`, source `ai-decision`, rendered by `/workspace/inbox` and `OperatorCockpit` |
+| Cadence | `ScheduledAgentTask` (`taskKind`), steward sweeps (`run_mdm_steward_sweep`, `run_data_steward`) |
+| Write-through resolutions | `captureOrgBusinessAnswer`, `ruleWeightAdjustmentProposal`, held-material release, stance editor |
+
+Nothing in the list needs replacing. The gaps are four joins nobody has made:
+origin context is not resolved, no panel is ever convened for an escalation, a
+panel verdict has nowhere to live as a rulable proposal, and the resolution
+forms do not accept a pre-filled draft.
+
+---
+
+## 3. Research & Benchmarking
+
+| System | What it does | DPF stance |
+| --- | --- | --- |
+| ServiceNow Change Advisory Board / approval policies | The change record carries risk, impact and the CI blast radius; approval policy routes to the right group; the approver never leaves the record | **Adopt** the record-carries-its-own-context rule and the routing-by-policy idea. Reject the CAB meeting ritual — our panel is asynchronous. |
+| Camunda 8 / Flowable user tasks | Human task = form + variables + candidate groups; DMN tables hold the versioned rules | **Adopt** "the task carries its input variables" (our origin contract) and candidate-group routing (domainClass → profession family). Reject adding a BPMN engine; `Workroom` + `WorkItem` already model the human task. |
+| Dependabot / Renovate | The bot does not file a ticket asking a human to upgrade — it opens the diff and the human merges | **Adopt wholesale.** This is the central move: the panel produces the artifact, not a request for one. |
+| GitHub suggested changes / CODEOWNERS | Review lands as an accept-in-one-click patch, routed to the people who own that path | **Adopt** one-click accept of a concrete draft, and ownership-derived routing. |
+| AutoGen GroupChat, CrewAI hierarchical crews | Multi-agent panels with a manager that assigns specialists and synthesizes | **Reject as a dependency** — our Deliberation Pattern Framework already does branch topology, evidence, claims, consensus and synthesis, with provider diversity and budget caps. Adopt only the role-staffing idea. |
+| Constitutional-AI critique-and-revise, LLM-as-judge panels | Independent critics before a verdict; diversity beats a single reviewer | **Adopt** — mapped onto existing roles: specialists assert, a skeptic attacks the recommendation, an adjudicator synthesizes and records dissent. |
+| PagerDuty / Opsgenie | Work is pushed on a policy and escalates on age, rather than waiting in a queue | **Adopt** the push + ageing model for governance items; reuse the attention surface and the weekly digest rather than adding notification machinery. |
+
+Standard we conform to: the panel's output is advisory evidence for a human
+ruling, consistent with the Trustworthy AI Agent Standards Family framing
+already used by EP-1C37C089 — an agent may prepare and recommend a
+consequential change; only an accountable human commits it.
+
+---
+
+## 4. Design
+
+Five parts. Each is a join between things that already exist.
+
+### 4.1 The origin contract — a decision knows where it came from
+
+New pure module `apps/web/lib/decision/decision-origin.ts` resolving a
+`DecisionOrigin` for any `DecisionInteraction`:
+
+```ts
+type DecisionOrigin = {
+  workroom: { capsuleId: string; title: string; objective: string; activityKind: string | null } | null;
+  coworker: { agentId: string; displayName: string; role: string | null; portfolioSlug: string | null } | null;
+  activity: { kind: "build" | "task-run" | "thread" | "mcp-session" | "unknown"; label: string; href: string | null };
+  requestedBy: { principalRef: string; label: string } | null;
+  recurrence: { priorOccurrences: number; firstSeenAt: Date | null; sameQuestionOpen: number };
+};
+```
+
+Resolution order, each step evidence-backed and skipped when it yields nothing:
+
+1. `buildId` → `FeatureBuild` → `Workroom.featureBuildId`.
+2. `taskRunId` → `Workroom.taskRunId`, and the task run's goal.
+3. `outcomePayload.caller.apiTokenId` session ref → `Workroom.executorRef`.
+4. `outcomePayload.caller.agentId` → `Agent` (display name, role, portfolio).
+5. `outcomePayload.caller.threadId` → `AgentThread` → the turn that triggered it.
+6. Recurrence: how many times this same question has already been recorded and
+   how many are still open. Exact-question matching only — paraphrase clustering
+   belongs to the review page, and a record page that needs embeddings to render
+   fails whenever the embedding runtime is down.
+
+**Forward fix (Phase 2):** the gate writes `workroomId` onto
+`DecisionInteraction` when the caller context carries one, so future rows do not
+depend on the resolver's inference. It rides the Phase 2 migration rather than
+spending one of its own. The resolver stays for historic rows either way, and
+reports which step it used so the page says "matched through the session token"
+rather than implying certainty.
+
+Rendered on the record as a **Where this came from** block above the options:
+the workroom (linked), what that room is for, the coworker, what it was doing,
+and "this is the 3rd time this has come up; 2 still open".
+
+### 4.2 Consequence framing — what each option actually costs
+
+Options today render as bare ids (`Proceed`, `Decline`). The gate already has
+per-option feature vectors on scored rows (`scoredOptions`) and the platform
+already has the five cost axes (`blast_radius`, `human_cognitive_load`,
+`vendor_lock_in`, `business_disruption`, `operator_effort`).
+
+Each option gets a plain-language consequence line, in this order of authority:
+
+1. The panel's own per-option consequence text (§4.3), when a panel has run.
+2. Deterministic projection from `scoredOptions` features + the origin's blast
+   radius, when the row was scored.
+3. Nothing. **No fabricated consequence.** An unscored, un-paneled option shows
+   its description or its id, exactly as today. The
+   `insufficientSignal` treatment on this page is the precedent, and it stays.
+
+### 4.3 The triage panel — coworkers who know the domain propose first
+
+New deliberation pattern seed `deliberation/governance-triage.deliberation.md`:
+
+```yaml
+slug: governance-triage
+name: Governance Triage
+purpose: Specialists who own the affected domains recommend what the owner should do, and draft it.
+defaultRoles:
+  - roleId: domain-specialist   # count 2-3, staffed per domain (see below)
+  - roleId: skeptic             # attacks the leading recommendation and names what it costs
+  - roleId: adjudicator         # synthesizes, drafts the artifact, records dissent
+adjudicationMode: synthesis
+strategyProfile: balanced       # high-assurance when riskTier is high/critical
+```
+
+**Staffing** (`apps/web/lib/decision/triage-staffing.ts`, pure): map the
+decision's `domainClass` + origin portfolio to profession families in
+`docs/professions/registry.json`, then to the org's live `Agent` roster. A
+money question seats finance; a public-facing one seats marketing and legal; a
+people one seats HR; an infrastructure discovery one seats security and the
+platform craft. Each specialist branch is grounded in that profession's craft
+corpus (WSID) and the org's own stance corpus (WWWD) via the existing retrieval
+path — the panel argues from the business's recorded doctrine, not from generic
+priors. Where no profession maps, the panel runs with the kernel perspective
+alone and **says so** on the card.
+
+**Output contract** — the adjudicator must return, or the run is recorded as
+`insufficient-evidence` and no proposal is written:
+
+- `recommendedAction` — one of the resolution kinds in §4.4.
+- `draft` — the artifact itself: the stance text, the weight change, the option
+  id, or the explicit "no change needed, here is why".
+- `consequences` — per option, one line each.
+- `dissent` — every specialist who disagreed, and on what.
+- `confidence` + `unresolvedRisks` (already in `DeliberationOutcome`).
+
+The run links back through the existing `DecisionInteraction.deliberationRunId`
+column, and seals onto the room through the existing bridge.
+
+### 4.4 `DecisionResolutionProposal` — the rulable artifact
+
+A panel verdict has nowhere to live today. `DeliberationOutcome` is a synthesis
+record with no lifecycle; `WeightAdjustmentProposal` covers exactly one action
+kind; `AgentActionProposal` governs tool execution, not doctrine. One new model:
+
+```prisma
+model DecisionResolutionProposal {
+  proposalId        String   @id            // DRP-*
+  scopeKind         String                  // "interaction" | "gap-cluster"
+  interactionId     String?                 // when scopeKind=interaction
+  domainClass       String?                 // when scopeKind=gap-cluster
+  profileId         String
+  actionKind        String                  // see below
+  draftPayload      Json                    // shape per actionKind
+  summary           String   @db.Text       // what the owner is being asked to accept
+  consequences      Json     @default("[]") // [{optionId, text}]
+  dissent           Json     @default("[]")
+  confidence        Float?
+  deliberationRunId String?
+  status            String   @default("proposed") // proposed|accepted|amended|rejected|superseded|expired
+  ruledByUserId     String?
+  ruledAt           DateTime?
+  rulingNote        String?  @db.Text
+  supersededById    String?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+}
+```
+
+`actionKind` and where accepting it writes through — every one an existing path:
+
+| actionKind | Accept writes through to |
+| --- | --- |
+| `answer-gap` | `captureOrgBusinessAnswer` (draft WWWD pages, as today) |
+| `adopt-option` | `EscalationCapture` + `chosenOptionId` on the interaction |
+| `adjust-weight` | `WeightAdjustmentProposal` at `ruled` |
+| `amend-stance` | wiki overlay draft against the named page |
+| `release-material` | the held-material release path |
+| `no-change` | resolves the interaction with a recorded reason |
+
+Rules that do not bend:
+
+- **Nothing auto-applies.** `accepted` is a human act, and for corpus changes it
+  still lands as draft, exactly like the current answer-once loop.
+- **Amend is first-class.** The owner edits the draft in place and accepts the
+  edited text; the amendment is what gets recorded, and the delta between draft
+  and accepted text is the training signal for whether the panel is any good.
+- **A proposal expires.** If the underlying decision resolves elsewhere, or the
+  corpus moves under it, the proposal is `superseded`/`expired`, never silently
+  applied later.
+- **A rejected proposal does not resurface** for the same cluster without new
+  evidence, and the rejection reason is kept — it is doctrine too.
+
+### 4.5 One screen, no context loss
+
+- **The decision record becomes the resolution surface.** Origin block (§4.1),
+  options with consequences (§4.2), the panel's recommendation with dissent and
+  who was on the panel, and the accept / amend / reject control inline. No
+  navigation to rule.
+- **`Review & adjust` becomes the queue, not the workbench** — each row states
+  the proposal's headline and links into the record. Rows with a ready proposal
+  are marked as such and sorted first.
+- **Every existing form accepts a seed.** `GapAnswerForm` and the stance editor
+  take `defaultValue` from the draft and carry `interactionId`/`domainClass`
+  through, so following a link never lands on an empty field. Where no panel has
+  run yet, the forms behave exactly as they do now.
+- The panel's card names its limits plainly: which coworkers weighed in, which
+  domain had no specialist, and how confident the synthesis is.
+
+### 4.6 The standing room and the cadence
+
+A standing `Workroom` — `activityKind: governance`, `decisionScope: wwmd`,
+shape `specialist-alignment` — is the home of this process, convened once and
+never closed (the pattern BI-A2234157 established for ongoing activity).
+
+A scheduled steward (`ScheduledAgentTask`, `taskKind: decision-concierge-sweep`)
+runs on a cadence and:
+
+1. reads the open queue (the same predicates the review page uses — one source),
+2. clusters it (existing semantic clustering),
+3. convenes a panel per cluster, newest and highest-risk first, under a budget
+   cap and a per-sweep panel cap,
+4. writes proposals, posts the digest into the room,
+5. ages items: an unresolved decision with a ready proposal escalates its
+   attention placement rather than sitting flat.
+
+Proactive surfacing reuses what exists: the `ai-decision` attention source gains
+`decideEffort: "one-tap"` and an `approve`/`reject` action when a proposal is
+ready, so the cockpit and `/workspace/inbox` show the recommendation instead of
+"Review evidence"; the weekly digest carries the count and the top proposals; the
+Coworker Decision Engine nav entry carries the open count.
+
+### 4.7 Guardrails
+
+- Advisory only; the accountable human rules. Panel authorship is always shown.
+- No panel, no proposal — the page degrades to today's behaviour rather than
+  inventing a recommendation. Insufficient evidence is a stated outcome.
+- Budget: panels are capped per sweep and per decision, and the sweep records
+  what it skipped rather than silently truncating.
+- The panel reads the corpus; it never writes to it. Only an accepted proposal
+  writes, and only through the existing draft-first paths.
+- Risk tiering: high/critical decisions get the `high-assurance` profile and
+  provider diversity; low-risk ones stay economical.
+
+---
+
+## 5. Data model changes
+
+1. `DecisionResolutionProposal` (new, above).
+2. `DecisionInteraction.workroomId String?` + index — forward-recorded origin.
+3. No change to `DeliberationRun` / `DeliberationOutcome`; the governance-triage
+   pattern is a seed row, not a schema change.
+
+Both changes are additive and nullable. Migration backfills nothing: historic
+rows resolve their origin through the read-time resolver.
+
+---
+
+## 6. Phasing
+
+| Phase | Outcome | Ships without the next phase? |
+| --- | --- | --- |
+| **P1 — Context** | Origin contract, `workroomId` column + gate write, origin block on the record, consequence lines from scored options, seeded forms and carried-through metadata | Yes. Fixes complaints 2, 3 and 4 with no AI involved. |
+| **P2 — Proposal substrate** | `DecisionResolutionProposal`, the accept/amend/reject control, write-through adapters, review queue reshaped around proposals | Yes. A human (or a coworker in chat) can file a proposal even before the panel exists. |
+| **P3 — The panel** | `governance-triage` pattern, staffing map, output contract, run-on-escalate, panel card on the record | Yes. |
+| **P4 — The standing process** | Standing room, sweep steward, attention/digest/nav upgrades, ageing | Yes. |
+
+Phases 1 and 2 are the cognitive-load fix; 3 and 4 are the proactivity fix. The
+order matters: a recommendation shown without origin context is worse than none.
+
+---
+
+## 7. Success criteria
+
+- An owner can rule on an open decision without leaving the record, and without
+  re-reading anything from a previous screen.
+- Every open decision on the live install shows either its origin workroom and
+  coworker, or an honest "origin could not be resolved" line — never a bare
+  token id.
+- For decisions with a ready proposal, time-to-rule is a read plus one click.
+- The share of unresolved decisions older than 7 days trends down after P4.
+- Amendment rate is recorded from the first accepted proposal — it is the
+  measure of whether the panel is worth its cost, and it is reported, not hidden.
+
+---
+
+## 8. Non-goals
+
+- No new notification channel, no new top-level navigation, no second decision
+  detail page (the `/platform/ai/decisions/*` redirect stays the only alias).
+- No autonomous application of any doctrine change.
+- Not a replacement for the WWWD stance-onboarding flow; this closes the loop
+  for decisions that have already been asked, not first-time corpus authoring.
+- No change to the kernel scoring maths; three-band verdict work
+  (2026-08-21-three-band-decision-verdict.md) owns that.
+
+---
+
+## 9. Open questions for the operator
+
+1. Sweep cadence and panel budget: hourly with a small cap, or daily with a
+   larger one? Default proposed: every 4 hours, at most 5 panels per sweep.
+2. Should a panel run automatically on every escalation, or only for clusters
+   that recur? Default proposed: automatic for risk ≥ medium, clustered
+   otherwise.
+3. Does accepting an `answer-gap` proposal publish the WWWD page directly for
+   low-risk domains, or always land as draft? Default proposed: always draft,
+   matching the current loop.
+
+---
+
+## 10. Related
+
+- `docs/superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md` — the surface this extends
+- `docs/superpowers/specs/2026-06-23-human-attention-surface-design.md` — the proactive surface reused
+- `docs/superpowers/specs/2026-07-17-needs-you-cognitive-load-redesign-design.md` — decision-card contract
+- `docs/superpowers/specs/2026-08-21-three-band-decision-verdict.md` — confidence bands
+- EP-DECISION-TIER-REBALANCE — weight-proposal lifecycle this reuses

--- a/docs/user-guide/wiki/index.md
+++ b/docs/user-guide/wiki/index.md
@@ -47,6 +47,12 @@ Rows marked **escalate** or **defer** carry an "awaiting review" chip until a hu
 
 Neither outcome silently blocks work. The coworker that asked handled its own moment and moved on; the one exception is a Build Studio build paused at a decision gate, and that row says so. The log header totals what is waiting per tier, and each decision's drill-in now explains, in plain language, what its outcome means, whether anything is waiting on you, and the next steps with links.
 
+Each decision opens with **Where this came from**: the work room the coworker was inside and what that room is for, the coworker by name and role, what it was doing at the time, and how that link was established. When the same question has come back before, the record says how many times and how many are still waiting on you. If the work behind a decision cannot be traced, the record says that plainly rather than showing you an agent id and a token.
+
+Where the AI scored the options against real criteria, each option also carries what it is best at and what it costs, relative to the alternatives. An option that was never scored shows no such claim — a made-up consequence would be worse than none.
+
+Following **Answer it once** from a decision now opens that finding on Review & adjust with your answer box already open and the question restated, so you never restart from a blank field.
+
 Do not work the log line by line. Review & adjust groups the waiting rows into themes; answering a theme once — or adding a stance or craft guidance that covers it — teaches your AI so that question stops needing a human. Exact repeated asks appear once with a matching-ask count. Marking that item reviewed or dismissed applies the same disposition to every exact match, so the completed cluster leaves the queue while each original interaction remains in the audit ledger.
 
 ## Review & Adjust Findings

--- a/docs/ux-fit/2026-08-23-decision-record-origin-context.ux-fit.json
+++ b/docs/ux-fit/2026-08-23-decision-record-origin-context.ux-fit.json
@@ -1,0 +1,23 @@
+{
+  "version": "1",
+  "decidedOption": "inline-origin-block",
+  "decisionInteractionId": "DI-FC18F139E8BD",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "decisionInteractionId": "DI-FC18F139E8BD",
+    "consideredOptions": [
+      "inline-origin-block",
+      "technical-detail-drawer"
+    ]
+  },
+  "rationale": {
+    "inline-origin-block": "CHOSEN. Kernel composite 9.726, margin 1.445, high confidence, autonomy eligible. A 'Where this came from' block above the options carries the work room and what that room is for, the coworker by display name and role, what it was doing, how the link was matched, and whether the same question has come back before; each option carries at most two strength lines and two cost lines derived from the feature vector the gate actually scored. Highest legibility_of_consequence (0.85) and lowest operator_effort (0.15): the owner reads the reason for the question and the cost of each answer in the same viewport where they rule, instead of holding one screen in their head while working another. Scores positively on 'Do the work; don't task the operator with what an agent can do' (+0.172) where the drawer scores NEGATIVE (-0.080), which is exactly the complaint being fixed.",
+    "technical-detail-drawer": "REJECTED. Kernel composite 8.281. Keeping the record as it is and hiding the origin behind a collapsed drawer preserves today's first viewport, but it preserves today's defect with it: the context needed to rule stays one interaction away, so the owner is still asked to decide first and understand second. It scores worst on the two axes this change exists to move \u2014 legibility_of_consequence 0.35 and human_cognitive_load 0.55 \u2014 and it is the option 'Show the consequence before the confirm' rates lowest (0.058 vs 0.144)."
+  },
+  "notes": "BI-6700AF66, EP-0AF96937, spec docs/superpowers/specs/2026-08-23-decision-concierge-design.md \u00a74.1-\u00a74.2. Arrival cost is bounded: the block renders at most four short rows, and it renders NOTHING when the origin cannot be resolved \u2014 in that case it states plainly that the work behind the decision could not be traced rather than showing an empty frame. Consequence lines appear only when the gate scored real per-option feature vectors AND an option separates from the field by at least 0.15; an unscored decision keeps exactly the option list it had before, because an invented consequence is worse than none. Prose lint and style drift both pass with no growth on any axis (all new copy is built in lib/decision/decision-origin.ts and lib/decision/option-consequences.ts, and colour is --dpf-* tokens only). The 'answer it once' step now carries the finding's domain and the originating interaction id, so following it lands on the finding with its answer box already open and the question restated \u2014 no empty textarea. Scope is the decision record only: the review page and its answer form changed to RECEIVE the focus this record now sends (a query param and an already-open box), which adds no control of their own."
+}


### PR DESCRIPTION
Phase 1 of the Decision Concierge design. Closes the context half of the operator's report on the decision review loop; the proactivity half (phases 2-4) is specified and filed, not built here.

## What the operator hit

Opening `DI-453F73458838` showed an agent slug, a thread id, a token id and two bare option ids — nothing about which work room the coworker was inside, what that work is for, or what follows from Proceed versus Decline. Following the record's own "answer it once" advice landed on a different page with an empty textarea, with everything just read gone.

## What this changes

- **`lib/decision/decision-origin.ts`** resolves the work behind a decision — build → task run → session token → agent → thread — and reports **which** step matched. When nothing resolves it says the work could not be traced instead of dressing up a guess.
- **`lib/decision/option-consequences.ts`** turns the gate's own per-option feature vectors into at most two strength and two cost lines per option, honouring the cost-axis sign convention. A row that was never scored, or whose options do not separate by at least 0.15, gets nothing — a fabricated consequence is worse than none.
- The record renders both above the options, plus a recurrence line when the same question has come back before.
- **"Answer it once"** now carries the finding's domain and the interaction id, so Review & adjust opens that finding's answer box with the question restated.

## Verification

- 30 unit tests pass across the two new modules, `decision-help`, and the record page's existing suite.
- `pnpm run pregate` — **PASS** (evidence `cmt66ifsg0b2301mq1wdwm55w`), covering typecheck, the full vitest run and the production build. An earlier run failed with no recorded reason and passed clean on re-run.
- 50 preflight guards clean; prose-lint and style-drift show no growth on any axis (all new copy is built in `lib/`, colours are `--dpf-*` tokens only).
- **Functional check against the live database** via the contributor preview, on the operator's own record and the four next-most-recent open decisions: `DI-453F73458838` now resolves to "External Catalog Scout (specialist)" and honestly reports that no room claimed that work; the Build Studio gate rows render real per-option consequence lines and "Asked 2 times before; 2 of those still waiting on you".
- Not done: browser-rendered UX verification of the page. The preview route requires signing in, and I do not enter credentials. The code paths the page renders were exercised directly against live data as above.

## Design grounding

Extends `docs/superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md` through the new `docs/superpowers/specs/2026-08-23-decision-concierge-design.md` (source of truth, EP-0AF96937). Substrate reviewed before writing anything: `lib/deliberation/*` (the panel framework phases 2-4 reuse — `DecisionInteraction.deliberationRunId` already exists and is never written), `lib/attention/*`, `work-management/room-shapes.ts`, and the decision ledger. Nothing new was built where something existed.

Follow-on work filed: BI-3D0FB84B (rulable proposals), BI-19B350FD (the governance-triage panel), BI-C62127B9 (the standing sweep).

Workroom: WC-69329196

🤖 Generated with [Claude Code](https://claude.com/claude-code)