### PR TITLE
fix(planning): plan-coverage refusals name the condition and the offending value, never a backlog id (BI-38A353B2)

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1528,6 +1528,9 @@
     "scripts/check-label-association.mjs": [
       "docs/testing/pre-pr-gate.md"
     ],
+    "scripts/check-live-blocker-references.mjs": [
+      "docs/testing/pre-pr-gate.md"
+    ],
     "scripts/check-mcp-tool-pack.mjs": [
       "docs/architecture/mcp-tool-packs.md"
     ],
@@ -2886,6 +2889,7 @@
       "packages/dpf-skill-pack/hooks/pregate-evidence-guard.mjs",
       "scripts/check-guards.mjs",
       "scripts/check-label-association.mjs",
+      "scripts/check-live-blocker-references.mjs",
       "scripts/check-mobile-jest-pin.mjs",
       "scripts/ci-policy-guards.test.mjs",
       "scripts/gate-worktree.mjs",

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -10382,6 +10382,7 @@
         "appsweb-and-packagesdb-vitest",
         "degenerate-environment-fixtures",
         "common-drift-and-how-to-stay-on-script",
+        "live-blocker-references-guard",
         "label-association-guard-ratchet",
         "what-this-gate-is-not"
       ]

--- a/apps/web/lib/planning/plan-backlog-coverage.test.ts
+++ b/apps/web/lib/planning/plan-backlog-coverage.test.ts
@@ -247,6 +247,49 @@ describe("validatePlanBacklogCoverageReceipt v2", () => {
     })).toMatchObject({ ok: false, code });
   });
 
+  // BI-38A353B2: two prior sessions bisected these refusals by trial because
+  // the text restated the rule instead of naming the offending value.
+  describe("a refusal names the offending value, not just the rule", () => {
+    it("names the deliverable whose traceability is incomplete", () => {
+      const result = validatePlanBacklogCoverageReceipt({
+        receipt: { ...v2, deliverables: [{ ...v2.deliverables[0]!, verificationRefs: [] }] },
+        mappedBacklogItems: [{ itemId: "BI-EXISTING-1", status: "open" }],
+        requireGovernedImplementation: true,
+        currentPlanDigest: "sha256:plan",
+        traceabilityContext,
+      });
+      expect(result).toMatchObject({ ok: false, code: "traceability-incomplete" });
+      expect((result as { error: string }).error).toContain(v2.deliverables[0]!.key);
+    });
+
+    it("names which acceptance ids no deliverable verifies", () => {
+      const result = validatePlanBacklogCoverageReceipt({
+        receipt: v2,
+        mappedBacklogItems: [
+          { itemId: "BI-EXISTING-1", status: "open" },
+          { itemId: "BI-EXISTING-2", status: "open" },
+        ],
+        requireGovernedImplementation: true,
+        currentPlanDigest: "sha256:plan",
+        traceabilityContext: { ...traceabilityContext, acceptanceIds: [...traceabilityContext.acceptanceIds, "AC-ORPHAN"] },
+      });
+      expect(result).toMatchObject({ ok: false, code: "traceability-incomplete" });
+      expect((result as { error: string }).error).toContain("AC-ORPHAN");
+    });
+
+    it("names which traceability input is absent rather than 'could not be resolved'", () => {
+      const result = validatePlanBacklogCoverageReceipt({
+        receipt: v2,
+        mappedBacklogItems: [{ itemId: "BI-EXISTING-1", status: "open" }],
+        requireGovernedImplementation: true,
+        currentPlanDigest: "sha256:plan",
+        traceabilityContext: { ...traceabilityContext, acceptanceIds: [] },
+      });
+      expect(result).toMatchObject({ ok: false, code: "traceability-incomplete" });
+      expect((result as { error: string }).error).toContain("acceptance ids");
+    });
+  });
+
   it("rejects arbitrary non-empty refs and requires every current acceptance criterion to be covered", () => {
     expect(validatePlanBacklogCoverageReceipt({
       receipt: {
@@ -512,7 +555,12 @@ describe("recordPlanBacklogCoverage", () => {
 
   // BI-B9403248: an external session that hits this has no route forward and no
   // way to learn there is one — the baseline is minted by the initiative
-  // spec-approval gate, which no MCP tool exposes. The message must say so.
+  // spec-approval gate. The message must say so.
+  //
+  // BI-38A353B2: and it must say so WITHOUT citing a backlog id. The previous
+  // text told callers to cite BI-B9403248, which closed on 2026-08-21 while
+  // the block stayed live, so the gate instructed contributors to blame a
+  // fixed defect. A condition does not go stale; an id does.
   it("names the missing scope baseline and how it is minted, instead of failing opaquely", async () => {
     const { db, activityCreate } = fakeDb();
     db.backlogItemActivity.findMany = vi.fn(async () => []);
@@ -540,9 +588,14 @@ describe("recordPlanBacklogCoverage", () => {
 
     expect(result).toMatchObject({ ok: false, code: "traceability-incomplete" });
     const error = (result as { error: string }).error;
-    expect(error).toContain("initiative_scope_baseline");
+    expect(error).toContain("BI-PARENT");
+    expect(error).toContain("initiative scope baseline");
+    expect(error).toContain("record_initiative_design_review");
     expect(error).toContain("spec-approval");
-    expect(error).toContain("BI-B9403248");
+    expect(error).toContain("independent");
+    // The remediation must not hand the caller a backlog id to cite: the id
+    // goes stale the moment it closes, the condition never does.
+    expect(error).not.toMatch(/\b(?:BI|EP)-[0-9A-F]{8}\b/);
     expect(activityCreate).not.toHaveBeenCalled();
   });
 

--- a/apps/web/lib/planning/plan-backlog-coverage.ts
+++ b/apps/web/lib/planning/plan-backlog-coverage.ts
@@ -304,7 +304,19 @@ export function validatePlanBacklogCoverageReceipt(args: {
     const traceability = args.traceabilityContext;
     if (!traceability || !traceability.planText.trim()
       || traceability.objectiveIds.length === 0 || traceability.acceptanceIds.length === 0) {
-      return { ok: false, code: "traceability-incomplete", error: "Current plan and scope-baseline traceability could not be resolved." };
+      // Name which of the three inputs is absent; "could not be resolved" sent
+      // two prior sessions bisecting by trial (BI-38A353B2).
+      const absent = [
+        !traceability || !traceability.planText.trim() ? "the plan text (the resolved plan artifact is empty)" : null,
+        traceability && traceability.objectiveIds.length === 0 ? "objective ids on the scope baseline" : null,
+        traceability && traceability.acceptanceIds.length === 0 ? "acceptance ids on the scope baseline" : null,
+      ].filter(Boolean);
+      return {
+        ok: false,
+        code: "traceability-incomplete",
+        error: `Plan coverage needs plan text plus objective and acceptance ids from the scope baseline; missing: ${absent.join(", ") || "the scope-baseline traceability context"}. `
+          + "Objective and acceptance ids come from the scope manifest in the canonical design the spec-approval gate baselined; re-approve the design if it does not declare them.",
+      };
     }
     if (!args.receipt.scopeBaselineId || !args.receipt.scopeBaselineArtifactDigest
       || args.receipt.scopeBaselineId !== traceability.baselineId
@@ -314,22 +326,34 @@ export function validatePlanBacklogCoverageReceipt(args: {
     const objectiveIds = new Set(traceability.objectiveIds);
     const acceptanceIds = new Set(traceability.acceptanceIds);
     const coveredAcceptance = new Set<string>();
+    let firstIncompleteKey: string | null = null;
     const incomplete = args.receipt.deliverables.some((deliverable) => {
+      const failed = (): true => { firstIncompleteKey ??= deliverable.key; return true; };
       if (!deliverable.independentlyShippable && args.receipt.decision !== "atomic") return false;
       const v2 = deliverable as Partial<PlanBacklogDeliverableV2>;
       if (!nonEmptyRefs(v2.requirementRefs)
         || !nonEmptyRefs(v2.contractRefs)
         || !nonEmptyRefs(v2.flowRefs)
-        || !nonEmptyRefs(v2.verificationRefs)) return true;
+        || !nonEmptyRefs(v2.verificationRefs)) return failed();
       const allRefs = [...v2.requirementRefs, ...v2.contractRefs, ...v2.flowRefs, ...v2.verificationRefs];
       if (allRefs.some((ref) => !traceability.planText.includes(ref))
         || v2.requirementRefs.some((ref) => !objectiveIds.has(ref))
-        || v2.verificationRefs.some((ref) => !acceptanceIds.has(ref))) return true;
+        || v2.verificationRefs.some((ref) => !acceptanceIds.has(ref))) return failed();
       for (const ref of v2.verificationRefs) coveredAcceptance.add(ref);
-      return Boolean(v2.disposition && v2.verificationRefs.some((ref) => acceptanceIds.has(ref)));
+      return v2.disposition && v2.verificationRefs.some((ref) => acceptanceIds.has(ref)) ? failed() : false;
     });
     if (incomplete || [...acceptanceIds].some((id) => !coveredAcceptance.has(id))) {
-      return { ok: false, code: "traceability-incomplete", error: "Every implementation deliverable needs requirement, contract, flow, and verification references." };
+      // Name the offending deliverable and which leg failed, rather than
+      // restating the rule the caller already read (BI-38A353B2).
+      const uncovered = [...acceptanceIds].filter((id) => !coveredAcceptance.has(id));
+      return {
+        ok: false,
+        code: "traceability-incomplete",
+        error: uncovered.length > 0 && !incomplete
+          ? `Every acceptance id on the scope baseline must be covered by some deliverable's verificationRefs; uncovered: ${uncovered.join(", ")}.`
+          : `Deliverable ${firstIncompleteKey ?? "(unknown)"} is not fully traced: each implementation deliverable needs non-empty requirementRefs, contractRefs, flowRefs, and verificationRefs, every ref must appear verbatim in the plan text, requirementRefs must be baseline objective ids, and verificationRefs must be baseline acceptance ids.`
+          + (uncovered.length > 0 ? ` Uncovered acceptance ids: ${uncovered.join(", ")}.` : ""),
+      };
     }
   }
 
@@ -685,15 +709,20 @@ export async function recordPlanBacklogCoverage(args: {
       select: { payload: true },
     }));
     if (!baseline) {
-      // BI-B9403248: this used to say only "could not be resolved", which named
-      // neither the missing artifact nor a way to produce one. The baseline is
-      // minted by the initiative spec-approval gate — no MCP tool exposes it —
-      // so a caller who does not know that has no route forward and no way to
-      // learn there is one. Say what is missing and who can mint it.
+      // The remediation text names the CONDITION, never a blocker id. It used
+      // to instruct callers to "cite BI-B9403248 for the blocked receipt";
+      // that BI closed on 2026-08-21 (PR #4422) while the block stayed live,
+      // so every contributor who followed the message literally blamed a
+      // fixed defect for a live gate, and every auditor who checked the id
+      // found it closed and concluded the block was stale (BI-38A353B2). An
+      // id written as a literal goes stale silently; a condition does not.
       return {
         ok: false as const,
         code: "traceability-incomplete" as const,
-        error: `BacklogItem ${currentParent.itemId} has no initiative scope baseline, so plan coverage cannot be bound to a governed scope. The baseline is recorded as an \`initiative_scope_baseline\` activity when the initiative's spec-approval gate passes; it is not currently reachable from an MCP session. Take the item through initiative spec approval first, or record the plan's coverage table in the plan and cite BI-B9403248 for the blocked receipt.`,
+        error: `BacklogItem ${currentParent.itemId} has no initiative scope baseline, so plan coverage cannot be bound to a governed scope. `
+          + "A baseline is written only when the initiative's spec-approval gate passes: call `record_initiative_design_review` with gate=`spec-approval`, decision=`pass`, and a canonical design under `docs/superpowers/specs/`. "
+          + "That gate requires a reviewer independent of the artifact's author, so the author cannot record it — an independent reviewer must, which on this platform means an in-platform reviewer coworker holding the `initiative_design_review` grant. "
+          + "Until this item carries a baseline, record the plan's coverage table in the plan itself and state the blocking CONDITION — \"no initiative scope baseline exists for <item>\" — rather than citing a backlog id, which goes stale when that id closes.",
       };
     }
     const receipt: PlanBacklogCoverageReceipt = {

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -803,6 +803,42 @@ Name them so you catch yourself.
 | Trusting a green test run without naming the tree | Sibling worktrees hold identical paths; shell cwd persists between calls | Check the runner's root banner; reconcile the test count against your file |
 | Adding a `<label>` next to its input and checking it in the browser | It renders, screenshots and inspects correctly while a screen reader announces an *unlabelled* field — every human check passes, so the Label Association Guard is the only thing that sees it | Bind it: `htmlFor={id}` with a matching `id`, or wrap the control inside the label |
 
+### Live Blocker References Guard
+
+`scripts/check-live-blocker-references.mjs` fails a PR whose **changed source**
+cites a **closed** `BI-`/`EP-` id from user-facing text — a message that tells
+the reader a fixed defect is their live blocker.
+
+It is the missing half of Doc Anchor Existence. That guard proves a cited id
+EXISTS; nothing proved it was still OPEN. `record_plan_backlog_coverage` spent
+two days instructing every caller to "cite BI-B9403248 for the blocked
+receipt" after BI-B9403248 shipped, so contributors recorded the wrong cause in
+their plans and auditors reading those plans found a closed id and concluded the
+block was stale. Remediation text is written inline as a literal and then never
+revisited when the referenced work closes.
+
+The scope is deliberately narrow, because a guard that invents a defect is worse
+than one that hides a defect:
+
+- only string literals that also carry citation language (`cite`, `blocked by`,
+  `tracked in`, `see`, `filed as`) — a bare mention is not an instruction;
+- **never a comment.** A closed id recorded as provenance above the code it
+  explains is exactly what you want; flagging it would be noise;
+- never a test file; only changed files under `apps/` and `packages/`;
+- existing pairs are grandfathered in `scripts/live-blocker-baseline.txt`;
+- no token, unreachable endpoint, or ambiguous response ⇒ WARN and pass, naming
+  what was skipped. A runner with no live install can neither fail nor invent.
+
+```bash
+node scripts/check-live-blocker-references.mjs            # check (what CI runs)
+pnpm check:live-blockers                                  # same
+node scripts/check-live-blocker-references.mjs --update   # regenerate the grandfather baseline
+```
+
+Prefer naming the **condition** the reader is hitting over any id: a condition
+does not go stale when the work behind it ships. If an id genuinely belongs in
+the text, repoint it at the live item.
+
 ### Label Association Guard (ratchet)
 
 `scripts/check-label-association.mjs` fails a PR that adds a **net-new** form

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "check:retention-enrollment": "node scripts/check-retention-enrollment.mjs",
     "check:closed-set-strings": "node scripts/check-no-new-closed-set-strings.mjs",
     "check:doc-anchors": "node scripts/check-doc-anchor-existence.mjs",
+    "check:live-blockers": "node scripts/check-live-blocker-references.mjs",
     "check:baseline-budgets": "node scripts/check-no-expired-baseline-budgets.mjs",
     "check:spec-status": "node scripts/check-spec-status-frontmatter.mjs",
     "check:data-impact": "node scripts/check-data-impact.mjs",

--- a/scripts/check-doc-anchor-existence.mjs
+++ b/scripts/check-doc-anchor-existence.mjs
@@ -42,7 +42,7 @@ import { formatTxtBudgetHeader, parseTxtBudgetHeader } from "./lib/baseline-budg
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const BASELINE_PATH = path.join(REPO_ROOT, "scripts", "doc-anchor-baseline.txt");
-const DEFAULT_ENDPOINT = "http://127.0.0.1:3000/api/mcp/v1";
+export const DEFAULT_ENDPOINT = "http://127.0.0.1:3000/api/mcp/v1";
 const FETCH_TIMEOUT_MS = 5000;
 
 const DEFAULT_BUDGET = Object.freeze({ owner: "platform-architecture", expiry: "2026-11-16" });
@@ -122,7 +122,7 @@ export function interpretToolResponse(kind, id, body) {
 }
 
 /** POST one MCP tools/call. Returns the raw response text, or null on failure. */
-async function callTool(endpoint, token, name, args) {
+export async function callTool(endpoint, token, name, args) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {

--- a/scripts/check-live-blocker-references.mjs
+++ b/scripts/check-live-blocker-references.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// scripts/check-live-blocker-references.mjs
+//
+// BI-38A353B2 — a CLOSED backlog id must not be cited as a live blocker from
+// user-facing runtime text.
+//
+// THE PROBLEM IT FIXES: `record_plan_backlog_coverage` told every caller to
+// "cite BI-B9403248 for the blocked receipt". BI-B9403248 closed on
+// 2026-08-21 while the block it named stayed live, so the gate instructed
+// contributors to blame a fixed defect, and anyone auditing a plan that
+// followed the instruction found a closed id and concluded the block was
+// stale. Remediation text is written inline as a literal and then never
+// revisited when the referenced work closes. This is "absence is invisible to
+// every gate" applied to references: check-doc-anchor-existence.mjs proves a
+// cited id EXISTS; nothing proved it was still OPEN.
+//
+// THE CONTRACT (deliberately narrow — a mention is not a citation):
+//   - Only CHANGED source files (vs BASE_SHA, default origin/main) under
+//     apps/ and packages/, extensions .ts/.tsx/.mjs/.js, excluding tests.
+//   - Only ids inside a STRING LITERAL that also carries remediation language
+//     ("cite", "blocked by", "tracked in", "see BI-", "blocker"). A BI- id in
+//     a CODE COMMENT is provenance, not instruction, and is never flagged —
+//     comments are exactly where a closed id SHOULD stay recorded.
+//   - Existing pairs are grandfathered in scripts/live-blocker-baseline.txt.
+//   - Verified over MCP: a BI whose status is terminal (done / retired /
+//     cancelled) FAILS. Anything else — open, triaging, unknown — passes.
+//   - DEGRADES GRACEFULLY: no bearer token, unreachable endpoint, or an
+//     ambiguous response ⇒ WARN and pass, printing exactly what was skipped.
+//     A gate that cannot reach the install must never invent a defect.
+//
+//   node scripts/check-live-blocker-references.mjs            # check (CI)
+//   node scripts/check-live-blocker-references.mjs --update   # regenerate the baseline
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { callTool, DEFAULT_ENDPOINT } from "./check-doc-anchor-existence.mjs";
+import { formatTxtBudgetHeader, parseTxtBudgetHeader } from "./lib/baseline-budget.mjs";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const BASELINE_PATH = path.join(REPO_ROOT, "scripts", "live-blocker-baseline.txt");
+const DEFAULT_BUDGET = Object.freeze({ owner: "platform-architecture", expiry: "2026-11-16" });
+const BUDGET_NOTE_LINES = Object.freeze([
+  "Grandfathered source-string -> backlog-id citations (BI-38A353B2). One",
+  "<source-path>\\t<id> pair per line. Regenerate with --update.",
+]);
+
+const ID_RE = /\b(?:EP|BI)-[0-9A-F]{8}\b/g;
+/** Language that turns a mention into an instruction to the reader. */
+const CITATION_CUE = /\b(?:cite|citing|blocked by|blocker|tracked (?:in|on|by)|see|refer to|filed as|follow)\b/i;
+/** Terminal backlog statuses — a citation to one of these is the defect. */
+export const TERMINAL_STATUSES = Object.freeze(["done", "retired", "cancelled", "canceled", "superseded"]);
+
+const SOURCE_EXT = /\.(?:ts|tsx|mjs|js)$/;
+const TEST_FILE = /\.(?:test|spec)\.[^.]+$/;
+
+/**
+ * Extract (id) citations that live inside a string literal carrying citation
+ * language. Comments are skipped: a closed id recorded as provenance in a
+ * comment is desirable, not a defect.
+ */
+export function extractLiveBlockerCitations(source) {
+  const found = new Set();
+  for (const raw of source.split("\n")) {
+    const line = raw.trim();
+    if (line.startsWith("//") || line.startsWith("*") || line.startsWith("/*")) continue;
+    // Strip a trailing line comment so `foo(); // see BI-XXXXXXXX` is not read
+    // as instruction text.
+    const code = line.replace(/\/\/.*$/, "");
+    for (const literal of code.match(/(?:"[^"]*"|'[^']*'|`[^`]*`)/g) ?? []) {
+      if (!CITATION_CUE.test(literal)) continue;
+      for (const id of literal.match(ID_RE) ?? []) found.add(id);
+    }
+  }
+  return [...found];
+}
+
+export function parseBlockerBaseline(text) {
+  const pairs = new Set();
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    pairs.add(trimmed);
+  }
+  return pairs;
+}
+
+export function serializeBlockerBaseline(pairs, budget = DEFAULT_BUDGET) {
+  const unique = [...new Set(pairs.map((p) => `${p.file}\t${p.id}`))].sort();
+  return `${formatTxtBudgetHeader({ ...budget, noteLines: BUDGET_NOTE_LINES })}${unique.join("\n")}\n`;
+}
+
+/** "terminal" | "live" | "unknown" from a get_backlog_item response body. */
+export function interpretStatus(id, body) {
+  let parsed;
+  try {
+    parsed = typeof body === "string" ? JSON.parse(body) : body;
+  } catch {
+    return "unknown";
+  }
+  if (!parsed || typeof parsed !== "object" || parsed.error) return "unknown";
+  const result = parsed.result ?? parsed;
+  const text = typeof result === "string" ? result : JSON.stringify(result);
+  if (!text.includes(id)) return "unknown";
+  const match = /"status"\s*:\s*"([^"]+)"/.exec(text);
+  if (!match) return "unknown";
+  return TERMINAL_STATUSES.includes(match[1].toLowerCase()) ? "terminal" : "live";
+}
+
+const REF_RE = /^[A-Za-z0-9._\-/]{1,200}$/;
+function git(...args) {
+  try {
+    return execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+  } catch (e) {
+    return (e.stdout && e.stdout.toString()) || "";
+  }
+}
+
+function isScannedSource(file) {
+  return (file.startsWith("apps/") || file.startsWith("packages/"))
+    && SOURCE_EXT.test(file) && !TEST_FILE.test(file);
+}
+
+function scanAllSources() {
+  const pairs = [];
+  for (const file of git("ls-files").split("\n").map((s) => s.trim()).filter(isScannedSource)) {
+    const abs = path.join(REPO_ROOT, file);
+    if (!fs.existsSync(abs)) continue;
+    for (const id of extractLiveBlockerCitations(fs.readFileSync(abs, "utf8"))) pairs.push({ file, id });
+  }
+  return pairs;
+}
+
+async function main() {
+  if (process.argv.includes("--update")) {
+    let budget = DEFAULT_BUDGET;
+    try {
+      const existing = parseTxtBudgetHeader(fs.readFileSync(BASELINE_PATH, "utf8"));
+      if (existing.owner && existing.expiry) budget = existing;
+    } catch { /* first run — defaults */ }
+    const pairs = scanAllSources();
+    fs.writeFileSync(BASELINE_PATH, serializeBlockerBaseline(pairs, budget));
+    console.log(`Wrote live-blocker baseline: ${new Set(pairs.map((p) => `${p.file}\t${p.id}`)).size} grandfathered citation(s).`);
+    return;
+  }
+
+  let baseline;
+  try {
+    baseline = parseBlockerBaseline(fs.readFileSync(BASELINE_PATH, "utf8"));
+  } catch {
+    console.error(`[live-blocker] Missing ${path.relative(REPO_ROOT, BASELINE_PATH)} — run: node scripts/check-live-blocker-references.mjs --update`);
+    process.exit(1);
+  }
+
+  const base = process.env.BASE_SHA || "origin/main";
+  if (!REF_RE.test(base) || base.startsWith("-")) {
+    console.error(`[live-blocker] refusing unsafe BASE_SHA: ${JSON.stringify(base)}`);
+    process.exit(1);
+  }
+  const diffOutput = git("diff", "--name-only", `${base}...HEAD`);
+  if (!diffOutput.trim()) {
+    console.log(`[live-blocker] No diff against ${base} (or ref unavailable) — nothing to check. OK.`);
+    return;
+  }
+  const changed = diffOutput.split("\n").map((s) => s.trim()).filter(isScannedSource);
+
+  const newPairs = [];
+  for (const file of changed) {
+    const abs = path.join(REPO_ROOT, file);
+    if (!fs.existsSync(abs)) continue;
+    for (const id of extractLiveBlockerCitations(fs.readFileSync(abs, "utf8"))) {
+      if (!baseline.has(`${file}\t${id}`)) newPairs.push({ file, id });
+    }
+  }
+
+  if (newPairs.length === 0) {
+    console.log(`[live-blocker] ${changed.length} changed source file(s), no new backlog-id citations in user-facing strings. OK.`);
+    return;
+  }
+
+  const token = process.env.DPF_MCP_BEARER_TOKEN;
+  const endpoint = process.env.DPF_MCP_ENDPOINT || DEFAULT_ENDPOINT;
+  if (!token) {
+    console.warn(`[live-blocker] WARN: ${newPairs.length} new citation(s) NOT verified — DPF_MCP_BEARER_TOKEN unset (no live install on this runner). Skipped:`);
+    for (const p of newPairs) console.warn(`  ~ ${p.file}: ${p.id}`);
+    console.warn("[live-blocker] Passing (degraded). Verify on an install with the portal up before merge.");
+    return;
+  }
+
+  const terminal = [];
+  const skipped = [];
+  for (const pair of newPairs) {
+    if (pair.id.startsWith("EP-")) { skipped.push(pair); continue; }
+    const body = await callTool(endpoint, token, "get_backlog_item", { itemId: pair.id });
+    const verdict = body === null ? "unknown" : interpretStatus(pair.id, body);
+    if (verdict === "terminal") terminal.push(pair);
+    else if (verdict === "unknown") skipped.push(pair);
+  }
+
+  if (skipped.length > 0) {
+    console.warn(`[live-blocker] WARN: ${skipped.length} citation(s) not verified — no governed status lookup, endpoint unreachable, or ambiguous response (never treated as closed):`);
+    for (const p of skipped) console.warn(`  ~ ${p.file}: ${p.id}`);
+  }
+
+  if (terminal.length > 0) {
+    console.error("");
+    console.error("[live-blocker] FAILED — user-facing text cites a backlog id that is CLOSED, so it names a fixed defect as a live blocker:");
+    for (const p of terminal) console.error(`  ✗ ${p.file}: ${p.id}`);
+    console.error("");
+    console.error("Name the CONDITION the reader is actually hitting rather than an id — a condition does not go stale");
+    console.error("when the work behind it ships. If the id genuinely belongs in the text, repoint it at the live item.");
+    console.error("A closed id recorded in a CODE COMMENT as provenance is fine and is never flagged.");
+    process.exit(1);
+  }
+  console.log(`[live-blocker] ${newPairs.length} new citation(s) checked, none closed. OK.`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main();
+}

--- a/scripts/check-live-blocker-references.test.mjs
+++ b/scripts/check-live-blocker-references.test.mjs
@@ -1,0 +1,67 @@
+// scripts/check-live-blocker-references.test.mjs
+//
+// BI-38A353B2. The guard's whole value is that it bites on an instruction and
+// stays silent on provenance — a closed id recorded in a comment is the
+// desirable case, so a guard that flags it would be an over-reporting measure,
+// which is itself a defect.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  extractLiveBlockerCitations,
+  interpretStatus,
+  parseBlockerBaseline,
+  serializeBlockerBaseline,
+  TERMINAL_STATUSES,
+} from "./check-live-blocker-references.mjs";
+
+test("flags a backlog id cited as a blocker inside user-facing text", () => {
+  const source = 'return { error: "Blocked — cite BI-B9403248 for the blocked receipt." };';
+  assert.deepEqual(extractLiveBlockerCitations(source), ["BI-B9403248"]);
+});
+
+test("ignores a backlog id recorded as provenance in a comment", () => {
+  const source = [
+    "// BI-B9403248: this used to fail opaquely; see EP-1C37C089 for the program.",
+    " * Fixed in BI-B9403248 — cite it nowhere.",
+    "/* blocked by BI-B9403248 historically */",
+    'const message = "Plan coverage needs a scope baseline.";',
+  ].join("\n");
+  assert.deepEqual(extractLiveBlockerCitations(source), []);
+});
+
+test("ignores a trailing line comment on a line of code", () => {
+  const source = 'const x = "no ids here"; // see BI-B9403248 for why';
+  assert.deepEqual(extractLiveBlockerCitations(source), []);
+});
+
+test("ignores a string that merely mentions an id without instructing the reader", () => {
+  const source = 'log(`coverage receipt for BI-C7E2E924 recorded`);';
+  assert.deepEqual(extractLiveBlockerCitations(source), []);
+});
+
+test("reads a terminal status as terminal and anything else as live", () => {
+  for (const status of TERMINAL_STATUSES) {
+    const body = JSON.stringify({ result: { itemId: "BI-AAAAAAAA", status } });
+    assert.equal(interpretStatus("BI-AAAAAAAA", body), "terminal");
+  }
+  const open = JSON.stringify({ result: { itemId: "BI-AAAAAAAA", status: "triaging" } });
+  assert.equal(interpretStatus("BI-AAAAAAAA", open), "live");
+});
+
+test("never reports terminal from an unusable response", () => {
+  assert.equal(interpretStatus("BI-AAAAAAAA", "not json"), "unknown");
+  assert.equal(interpretStatus("BI-AAAAAAAA", JSON.stringify({ error: { code: -32000 } })), "unknown");
+  // A response about a DIFFERENT item is not evidence about this one.
+  assert.equal(interpretStatus("BI-AAAAAAAA", JSON.stringify({ result: { itemId: "BI-BBBBBBBB", status: "done" } })), "unknown");
+  assert.equal(interpretStatus("BI-AAAAAAAA", JSON.stringify({ result: { itemId: "BI-AAAAAAAA" } })), "unknown");
+});
+
+test("baseline round-trips", () => {
+  const pairs = [{ file: "apps/web/b.ts", id: "BI-00000002" }, { file: "apps/web/a.ts", id: "BI-00000001" }];
+  const parsed = parseBlockerBaseline(serializeBlockerBaseline(pairs));
+  assert.ok(parsed.has("apps/web/a.ts\tBI-00000001"));
+  assert.ok(parsed.has("apps/web/b.ts\tBI-00000002"));
+  assert.equal(parsed.size, 2);
+});

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -44,6 +44,7 @@ const EXPECTED_LEGACY_JOBS = [
   "instruction-plane-rule-coverage",
   "janitor-tests",
   "label-association-guard",
+  "live-blocker-references",
   "mcp-tool-pack-guard",
   "mobile-jest-pin-guard",
   "module-size-guard",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -235,6 +235,14 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("--test", "scripts/check-doc-anchor-existence.test.mjs"),
       node("scripts/check-doc-anchor-existence.mjs"),
     ]),
+    // BI-38A353B2: doc-anchor-existence proves a cited id EXISTS; nothing
+    // proved it was still OPEN. A closed id cited from user-facing runtime
+    // text names a fixed defect as a live blocker. Same diff scope, same
+    // grandfather baseline, same warn-pass degradation.
+    guard("live-blocker-references", "Live Blocker References", [
+      node("--test", "scripts/check-live-blocker-references.test.mjs"),
+      node("scripts/check-live-blocker-references.mjs"),
+    ]),
     // BI-79BCE3F2: ONE status/supersession frontmatter convention across
     // docs/superpowers/{specs,plans} — new/changed files must carry
     // status: draft|active|binding|superseded; supersededBy only on superseded.

--- a/scripts/live-blocker-baseline.txt
+++ b/scripts/live-blocker-baseline.txt
@@ -1,0 +1,7 @@
+# owner: platform-architecture
+# expiry: 2026-11-16
+# Grandfathered source-string -> backlog-id citations (BI-38A353B2). One
+# <source-path>\t<id> pair per line. Regenerate with --update.
+apps/web/lib/operate/a2a-collaboration-health/analysis.ts	BI-9DB7C332
+apps/web/lib/operate/db-continuity.ts	BI-B61779DB
+packages/dpf-skill-pack/hooks/portal-image-guard.mjs	BI-5A3DFF40


### PR DESCRIPTION
`record_plan_backlog_coverage` told every caller to "record the plan's
coverage table in the plan and cite BI-B9403248 for the blocked receipt".
BI-B9403248 closed 2026-08-21 (PR #4422) while the block it named stayed
live, so the gate instructed contributors to blame a fixed defect, and any
reader auditing such a plan found a closed id and reasonably concluded the
block was stale. A hardcoded id goes stale silently; a condition does not.

- The missing-baseline refusal now names the item, the missing artifact,
  the exact call that mints one (`record_initiative_design_review`,
  gate=spec-approval, decision=pass, design under docs/superpowers/specs/),
  the independence requirement that decides who may record it, and the
  honest fallback stated as a CONDITION with no backlog id in it.
- Its two sibling refusals on the same path stop restating the rule: one
  names which traceability input is absent, the other names the offending
  deliverable key and the uncovered acceptance ids. Two prior sessions
  bisected these by trial; that is the cost being removed.
- New guard `check-live-blocker-references.mjs` (registered as "Live
  Blocker References") fails when CHANGED source cites a CLOSED BI-/EP- id
  from a user-facing string. It is the missing half of Doc Anchor
  Existence, which proves a cited id EXISTS but never that it is still
  OPEN — "absence is invisible to every gate" applied to references.

The guard is deliberately narrow, because an over-reporting measure is
itself a defect: only string literals carrying citation language, never a
comment (a closed id recorded as provenance is the desirable case), never a
test file, diff-scoped, grandfather-baselined, and warn-passing whenever the
install is unreachable or the response is ambiguous. Verified against the
live install: it fails on the exact original text and passes on the
replacement.

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/plans/2026-08-16-late-defect-detection-hardening-plan.md
    (a gate whose accepted-caller set is narrower than its governed population)
- Current code substrate reviewed:
  - apps/web/lib/planning/plan-backlog-coverage.ts (all three refusals)
  - scripts/check-doc-anchor-existence.mjs (existence half; its MCP lookup,
    grandfather baseline and warn-pass degradation are reused verbatim)
  - scripts/lib/ci-policy-guards.mjs (guard registry)
- Source of truth:
  - The live backlog: BI-B9403248 status=done, BI-72F368BC status=open.
- Decision:
  - Name conditions, not ids, and enforce that with a guard rather than
    trusting the next author to revisit the literal. No new lookup substrate;
    the existing anchor guard's transport is exported and shared.

Docs-Impact-Decision: docs/testing/pre-pr-gate.md gains the guard's own section
(scope, why comments are never flagged, the commands, the baseline). The other
two pages the gate links for ci-policy-guards.mjs do not go stale:
docs/architecture/context-engineering-standards.md states P1-P14 context rules
and marks which have an automatic guard, and this change adds no rule and
changes no rule's enforcement status; docs/maintenance/staleness-report.md is a
generated maintenance artifact.

---

**Local CI:** `pregate` PASS — `1e82112df3a9`, evidence `cmt67skum0fs701mq2yersr3n`, 3:46 / 32918 log lines, production build compiled successfully.

**Guard verified against the live install:** reinstating the original `cite BI-B9403248` text makes the new guard exit 1 naming the file and id; the replacement passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Local-CI-Override: operator-emergency: the local-CI runner dies at the tail of its run before writing its record (same defect as merged PR #4571). On this branch it passed migrations, 37 guards, typecheck classification=passed and vitest 2905 files classification=passed; an earlier run on this branch passed end to end including next build (Compiled successfully in 38.1s, evidence cmt67skum0fs701mq2yersr3n). Operator approved.
