### PR TITLE
fix(ux-budget): grade a UI surface by its words, not by how many full stops it has (BI-0ED0F6B3)

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1076,6 +1076,9 @@
       "docs/architecture/context-engineering-standards.md",
       "docs/architecture/mcp-tool-authorization-runbook.md"
     ],
+    "apps/web/lib/ux-budget/budgets.ts": [
+      "docs/platform-usability-standards.md"
+    ],
     "apps/web/lib/ux-budget/measure.ts": [
       "docs/platform-usability-standards.md"
     ],
@@ -2719,6 +2722,7 @@
       "apps/web/lib/shell/shell-action-contract.ts",
       "apps/web/lib/tak/escalation-ladder.ts",
       "apps/web/lib/tak/prompt-assembler.ts",
+      "apps/web/lib/ux-budget/budgets.ts",
       "apps/web/lib/ux-budget/measure.ts",
       "apps/web/lib/workforce/oversight-copy.ts",
       "packages/validators/src/readability.ts",

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -5698,6 +5698,7 @@
         "choice-load-is-disclosure-too-bi-d6135b88",
         "readability-plain-language",
         "audience-tiers",
+        "prose-is-not-a-user-interface-bi-0ed0f6b3",
         "enforcement-points",
         "coworker-rule",
         "name-the-role-not-the-species-bi-f2ec4699",

--- a/apps/web/lib/owner-first/ux-audit.test.ts
+++ b/apps/web/lib/owner-first/ux-audit.test.ts
@@ -6,6 +6,8 @@ import {
   countSmallControls,
   countTechnicalDetail,
   countWords,
+  visibleText,
+  visibleUtterances,
   hasOwnerFirstNextAction,
   measureOwnerFirst,
   OWNER_FIRST_NEXT_ACTION_ATTR,
@@ -87,5 +89,36 @@ describe("auditOwnerFirst", () => {
   it("exposes usable default thresholds for a summary band", () => {
     expect(OWNER_FIRST_SUMMARY_THRESHOLDS.maxGenericDecisionLabels).toBe(0);
     expect(OWNER_FIRST_SUMMARY_THRESHOLDS.requireOwnerFirstNextAction).toBe(true);
+  });
+});
+
+describe("visibleUtterances (BI-0ED0F6B3)", () => {
+  it("gives each block-level element its own utterance", () => {
+    const html = `<h1>Mileage</h1><table><tr><th>Date</th><th>Route</th><th>Miles</th></tr></table><button>See my drives</button>`;
+    expect(visibleUtterances(html)).toEqual([
+      "Mileage",
+      "Date",
+      "Route",
+      "Miles",
+      "See my drives",
+    ]);
+  });
+
+  it("keeps inline markup inside one utterance", () => {
+    const html = `<p>Read the <a href="/x"><strong>setup guide</strong></a> before you start.</p>`;
+    expect(visibleUtterances(html)).toEqual(["Read the setup guide before you start."]);
+  });
+
+  it("breaks on <br>", () => {
+    expect(visibleUtterances("<p>Business<br>Personal</p>")).toEqual(["Business", "Personal"]);
+  });
+
+  it("covers the same words as visibleText", () => {
+    const html = `<nav><a>Home</a></nav><main><h2>Owed</h2><p>Three drives &amp; two routes.</p></main>`;
+    expect(visibleUtterances(html).join(" ").split(/\s+/)).toEqual(visibleText(html).split(/\s+/));
+  });
+
+  it("drops comments and yields nothing for empty markup", () => {
+    expect(visibleUtterances("<div><!-- note --></div>")).toEqual([]);
   });
 });

--- a/apps/web/lib/owner-first/ux-audit.ts
+++ b/apps/web/lib/owner-first/ux-audit.ts
@@ -47,6 +47,47 @@ export function visibleText(html: string): string {
   return decodeEntities(withoutTags).replace(/\s+/g, " ").trim();
 }
 
+/**
+ * Elements that flow INSIDE a phrase rather than starting a new one. Everything
+ * not listed here — headings, cells, list items, buttons, paragraphs, divs,
+ * `<br>` — ends the current utterance.
+ *
+ * `<a>` is inline on purpose: "read the <a>setup guide</a> first" is one
+ * sentence, and treating every anchor as a boundary would shred real body copy.
+ * A nav link still lands in its own utterance because the markup wraps it in a
+ * list item or a div.
+ */
+const INLINE_ELEMENTS = new Set([
+  "a", "abbr", "b", "bdi", "bdo", "cite", "code", "data", "dfn", "em", "i",
+  "kbd", "mark", "q", "rp", "rt", "ruby", "s", "samp", "small", "span",
+  "strong", "sub", "sup", "time", "u", "var", "wbr",
+]);
+
+// A character HTML text can never contain, so splitting on it cannot cut a word.
+const UTTERANCE_BREAK = "\u0000";
+
+const NAMED_TAG_RE = /<\/?([a-zA-Z][a-zA-Z0-9-]*)\b[^>]*>/g;
+
+/**
+ * The surface's visible text split into UTTERANCES — one heading, one table
+ * cell, one button label, one nav item, one paragraph each.
+ *
+ * `visibleText` deliberately flattens all of that into a single space-joined
+ * string, which is right for counting words and wrong for anything that needs
+ * sentence boundaries: a UI carries its boundaries in its ELEMENTS, not in full
+ * stops (BI-0ED0F6B3). Pair this with `analyzeUtteranceReadability`.
+ */
+export function visibleUtterances(html: string): string[] {
+  const marked = String(html).replace(NAMED_TAG_RE, (_m, name: string) =>
+    INLINE_ELEMENTS.has(name.toLowerCase()) ? " " : UTTERANCE_BREAK,
+  );
+  // Comments, doctypes and anything else tag-shaped but unnamed: drop as before.
+  return decodeEntities(marked.replace(/<[^>]*>/g, " "))
+    .split(UTTERANCE_BREAK)
+    .map((part) => part.replace(/\s+/g, " ").trim())
+    .filter((part) => part.length > 0);
+}
+
 /** Visible word count. */
 export function countWords(html: string): number {
   const text = visibleText(html);

--- a/apps/web/lib/ux-budget/measure.ts
+++ b/apps/web/lib/ux-budget/measure.ts
@@ -16,14 +16,19 @@
 // CI checker must never need a database. The policy vocabulary (ReadingLevel, the
 // grade caps) is shared; only the DB-backed override resolution stays at runtime.
 
-import { analyzeReadability, withinReadingLevel, type ReadingLevel } from "@dpf/validators";
+import { analyzeUtteranceReadability, withinReadingLevel, type ReadingLevel } from "@dpf/validators";
 import {
   countSmallControls,
   countWords,
-  visibleText,
+  visibleUtterances,
   OWNER_FIRST_NEXT_ACTION_ATTR,
 } from "../owner-first/ux-audit";
-import { countDisclosureRegions, defaultVisibleHtml, leadBandHtml } from "./scope";
+import {
+  countDisclosureRegions,
+  defaultVisibleHtml,
+  leadBandHtml,
+  routeContentHtml,
+} from "./scope";
 
 /** Marks the one control a surface most wants the owner to press. */
 export const PRIMARY_ACTION_ATTR = "data-dpf-primary-action";
@@ -93,7 +98,11 @@ export type UxBudgetMetrics = {
    * catches a 0→1 transition on a pre-existing route.
    */
   buriedPrimaryAction: number;
-  /** Flesch–Kincaid grade of the default-visible prose. */
+/**
+   * Flesch–Kincaid grade of the route's own default-visible copy, measured one
+   * UI utterance at a time (BI-0ED0F6B3). Scored over `<main>` where the shell
+   * marks one, so the number describes this page rather than the shared chrome.
+   */
   readingGradeLevel: number;
 };
 
@@ -108,7 +117,7 @@ function hasMarkedPrimaryAction(html: string): boolean {
 export function measureUxBudget(html: string): UxBudgetMetrics {
   const visible = defaultVisibleHtml(html);
   const lead = leadBandHtml(html);
-  const prose = visibleText(visible);
+  const utterances = visibleUtterances(routeContentHtml(visible));
   // Compare the FULL DOM against the visible scope: a marker present in one but not
   // the other means the primary action exists yet the owner cannot see it on arrival.
   const buried = hasMarkedPrimaryAction(html) && !hasMarkedPrimaryAction(visible);
@@ -124,7 +133,8 @@ export function measureUxBudget(html: string): UxBudgetMetrics {
     hasNextActionMarker: visible.includes(OWNER_FIRST_NEXT_ACTION_ATTR),
     buriedPrimaryAction: buried ? 1 : 0,
     // An empty surface has no prose to grade; report 0 rather than a fabricated score.
-    readingGradeLevel: prose.length === 0 ? 0 : analyzeReadability(prose).gradeLevel,
+    readingGradeLevel:
+      utterances.length === 0 ? 0 : analyzeUtteranceReadability(utterances).gradeLevel,
   };
 }
 

--- a/apps/web/lib/ux-budget/scope.ts
+++ b/apps/web/lib/ux-budget/scope.ts
@@ -296,5 +296,17 @@ export function countDisclosureRegions(html: string): number {
  */
 export function routeContentHtml(html: string): string {
   const mains = extractSubtrees(html, (tag) => tag.name === "main");
-  return mains.length > 0 ? mains.join("\n") : html;
+  if (mains.length === 0) return html;
+  const scoped = mains.join("\n");
+  // A `<main>` that does not actually hold the page's words is not the route's
+  // content — it is a landmark wrapped around a client shell, a portal target, or
+  // (in a component test) a mocked-out subtree. Scoping to it would grade a
+  // scrap: /platform/ai/skills renders a one-word <main> under test and would
+  // have been graded on that single word. Below half the surface's words, keep
+  // the whole scope; a diluted grade beats a grade of the wrong thing.
+  return words(scoped) * 2 >= words(html) ? scoped : html;
+}
+
+function words(html: string): number {
+  return (html.replace(/<[^>]*>/g, " ").match(/[a-zA-Z0-9]+/g) ?? []).length;
 }

--- a/apps/web/lib/ux-budget/scope.ts
+++ b/apps/web/lib/ux-budget/scope.ts
@@ -283,3 +283,18 @@ export function countDisclosureRegions(html: string): number {
   const rendered = removeSubtrees(html, (tag) => NON_RENDERED.has(tag.name));
   return extractSubtrees(rendered, isDisclosureRegion).length;
 }
+
+/**
+ * The ROUTE-OWNED region of a surface: the `<main>` landmark when the shell
+ * marks one, otherwise the whole scope unchanged.
+ *
+ * Only the reading-level axis uses this (BI-0ED0F6B3). Every other budget is
+ * about what the owner MEETS on arrival, and the shell's header and rail are
+ * part of that; but a reading grade computed over shared chrome measures the
+ * chrome, identically, on all 202 routes, and drowns whatever the page itself
+ * says. Word and control counts keep their existing whole-surface scope.
+ */
+export function routeContentHtml(html: string): string {
+  const mains = extractSubtrees(html, (tag) => tag.name === "main");
+  return mains.length > 0 ? mains.join("\n") : html;
+}

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -197,11 +197,23 @@ describe("budget axes", () => {
   });
 
   it("scores the route's own copy, not the shell chrome around it", () => {
-    const dense = `<main><h1>Infrastructure Optimization</h1><p>Administrative documentation.</p></main>`;
+    const dense = `<main><h1>Infrastructure Optimization</h1>
+      <p>Administrative documentation of organizational infrastructure.</p>
+      <ul><li>Authorization</li><li>Diagnostics</li><li>Provisioning</li><li>Observability</li></ul>
+      <p>Reconciliation of heterogeneous configuration repositories.</p></main>`;
     const chrome = `<header><a>Home</a><a>Work</a><a>Money</a></header><nav><ul><li>Jobs</li><li>Bills</li></ul></nav>`;
     // Adding a rail of short, easy nav labels must not dilute the page's grade.
     expect(measureUxBudget(chrome + dense).readingGradeLevel).toBe(
       measureUxBudget(dense).readingGradeLevel,
+    );
+  });
+
+  it("keeps the whole surface when <main> does not hold the page's words", () => {
+    // A landmark wrapped around a client shell or a mocked subtree carries a
+    // word or two. Grading THAT would be worse than grading the chrome too.
+    const scrap = `<header><h1>Date</h1><p>Route</p><p>Miles</p><p>Sorted</p></header><main><div>Infrastructure</div></main>`;
+    expect(measureUxBudget(scrap).readingGradeLevel).toBe(
+      measureUxBudget(scrap.replace(/<\/?main>/g, "")).readingGradeLevel,
     );
   });
 

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -168,6 +168,47 @@ describe("budget axes", () => {
   it("does not fabricate a reading grade for an empty surface", () => {
     expect(measureUxBudget("<div></div>").readingGradeLevel).toBe(0);
   });
+
+  // ── BI-0ED0F6B3 — the reading grade measures difficulty, not punctuation ──
+
+  /** The /finance/mileage surface, in the markup shape that exposed the defect. */
+  const LABEL_SURFACE = `<main><h1>Mileage</h1><p>3 to sort</p><a>See my drives</a>
+    <table><tr><th>Date</th><th>Route</th><th>Miles</th><th>Sorted</th><th>Owed</th></tr></table>
+    <ul><li>Business</li><li>Personal</li><li>Commute</li></ul></main>`;
+
+  it("grades a surface of plain labels as plain", () => {
+    // Every word here is ordinary English. Before the fix the whole page
+    // collapsed into one "sentence" and graded in the teens.
+    const grade = measureUxBudget(LABEL_SURFACE).readingGradeLevel;
+    expect(grade).toBeLessThan(9);
+  });
+
+  it("cannot be gamed by punctuating the labels", () => {
+    const stopped = LABEL_SURFACE.replace(/<\/(h1|p|a|th|li)>/g, ".</$1>");
+    expect(measureUxBudget(stopped).readingGradeLevel).toBe(
+      measureUxBudget(LABEL_SURFACE).readingGradeLevel,
+    );
+  });
+
+  it("still fails a surface whose own words are dense", () => {
+    const dense = `<main><h1>Infrastructure</h1><p>Optimization</p>
+      <ul><li>Administrative</li><li>Documentation</li><li>Organizational</li></ul></main>`;
+    expect(measureUxBudget(dense).readingGradeLevel).toBeGreaterThan(9);
+  });
+
+  it("scores the route's own copy, not the shell chrome around it", () => {
+    const dense = `<main><h1>Infrastructure Optimization</h1><p>Administrative documentation.</p></main>`;
+    const chrome = `<header><a>Home</a><a>Work</a><a>Money</a></header><nav><ul><li>Jobs</li><li>Bills</li></ul></nav>`;
+    // Adding a rail of short, easy nav labels must not dilute the page's grade.
+    expect(measureUxBudget(chrome + dense).readingGradeLevel).toBe(
+      measureUxBudget(dense).readingGradeLevel,
+    );
+  });
+
+  it("falls back to the whole surface when the shell marks no <main>", () => {
+    const noMain = `<div><h1>Date</h1><p>Route</p></div>`;
+    expect(measureUxBudget(noMain).readingGradeLevel).not.toBe(0);
+  });
 });
 
 describe("reading tier resolves from audience, not shell alone (BI-1DE6F69E)", () => {

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -412,10 +412,57 @@ Two metrics, both Flesch–Kincaid:
 - **Grade Level** — approximate U.S. school grade; target ≤ 9 for business copy.
 - **Reading Ease** — 0–100, higher is easier; aim ≥ 55 for business copy ("plain English").
 
+### Prose is not a user interface (BI-0ED0F6B3)
+
+Flesch–Kincaid assumes **paragraphs**. It divides words by sentences, and it finds
+sentences by looking for full stops. That holds for a storefront page, a campaign, a
+business-type write-up — and it does not hold for a rendered product screen, which is
+headings, table cells, button labels and nav items, almost none of which are
+punctuated.
+
+Score a whole screen as one string and every label on it collapses into a single
+enormous "sentence". Words-per-sentence explodes and the grade climbs for copy that
+carries no difficulty at all. Measured: the same fifteen words at the same 1.4
+syllables per word score **grade 6.8** unpunctuated and **grade 1.5** with a stop
+after each label. Identical vocabulary; the only variable is punctuation the screen
+had no reason to carry. On real surfaces the same mechanism put 185 of 201 routes
+over their cap, `/platform/identity/agents` at grade 377 — an arithmetic impossibility
+for prose, and the clearest sign the number was measuring layout rather than language.
+
+So there are **two scorers**, and picking the wrong one is a defect:
+
+| Input | Function | Sentence boundary |
+|---|---|---|
+| Prose — storefront copy, campaigns, docs, a marketing snippet | `analyzeReadability` | a full stop |
+| A rendered UI surface | `analyzeUtteranceReadability` | **the element boundary** |
+
+In a user interface the sentence boundary *is* the element boundary. Each utterance —
+one heading, one cell, one label, one list item — is at least one sentence, and real
+body copy inside an utterance still splits on its own full stops. Two consequences
+worth naming:
+
+- **The grade cannot be moved by punctuating labels.** Adding full stops to a screen
+  changes the number by zero. Before, it was worth five grades.
+- **The grade still rises for genuinely dense words.** A screen of one-word labels
+  reading *Infrastructure / Optimization / Administrative / Documentation* still fails
+  the high-school cap, at exactly the words-per-sentence of a screen reading *Date /
+  Route / Miles*. The measure separates difficulty from punctuation; it does not
+  excuse jargon.
+
+The UI reading grade is also scored over the route's own `<main>` rather than the
+shared shell. Chrome is identical on every route and was diluting all of them equally.
+Word and control budgets keep their whole-surface scope — the shell's header and rail
+are part of what the owner meets on arrival.
+
 ### Enforcement points
 
 - **Documentation site (today):** the `/business-types/` generator scores every page's business-facing copy at build time, warns when a page exceeds the target, writes `_readability-report.md`, and prints the grade in each page footer. Architecture and standards sections are excluded by design.
 - **Generated copy (platform) — implemented (BI-8F8C5F28):** when an AI coworker on a customer-copy surface (marketing, storefront) writes external copy, it is held to the org's readability target. The target is an **operator-adjustable policy stored on the existing `PlatformConfig` key/value table (key `content_readability_policy`) and set from the existing `/admin/settings` page — no new table or admin surface**. It is resolved at runtime (`apps/web/lib/readability/policy.ts`, honouring a per-archetype `marketingSkillRules.readingLevel` override) and injected into the coworker's prompt at **Block 5** of the assembler (`apps/web/lib/tak/prompt-assembler.ts`). The shared Flesch–Kincaid scorer + tiered-policy types live in `@dpf/validators` (`packages/validators/src/readability.ts`).
+- **Product screens (route sweep):** the UX route budget grades every page route's own
+  copy with `analyzeUtteranceReadability` against the tier in
+  `apps/web/lib/ux-budget/budgets.ts`. Advisory on pre-existing routes, blocking on
+  net-new ones. It is an absolute check, not a ratcheted axis, so it carries no entry
+  in `route-budget-baseline.json`.
 - **Operator visibility (planned):** showing the live Flesch–Kincaid score to the operator while they edit marketing/storefront copy, the way a word processor does. The shared scorer (`@dpf/validators`) is ready; surfacing it in the copy editor is the remaining step.
 
 ### Coworker rule

--- a/packages/validators/src/readability.test.ts
+++ b/packages/validators/src/readability.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   analyzeReadability,
+  analyzeUtteranceReadability,
   countSyllables,
   parseReadabilityPolicy,
   resolveReadingLevel,
@@ -103,5 +104,87 @@ describe("readingLevelDirective", () => {
     expect(readingLevelDirective("high-school")).toContain("grade 9");
     expect(readingLevelDirective("college")).toContain("grade 13");
     expect(readingLevelDirective("uncapped")).toBeNull();
+  });
+});
+
+// ── BI-0ED0F6B3 — Flesch–Kincaid over a UI surface ──────────────────────────
+
+/** The /finance/mileage copy that exposed the defect: labels, not prose. */
+const UI_LABELS = [
+  "Mileage",
+  "3 to sort",
+  "See my drives",
+  "Date",
+  "Route",
+  "Miles",
+  "Sorted",
+  "Owed",
+  "Business",
+  "Personal",
+  "Commute",
+];
+
+const JARGON =
+  "Organizational participation in international infrastructure optimization initiatives necessitates comprehensive administrative documentation.";
+
+describe("analyzeReadability — the prose assumption it rests on", () => {
+  it("inflates the grade of unpunctuated UI labels, at unchanged word difficulty", () => {
+    const flat = analyzeReadability(UI_LABELS.join(" "));
+    const punctuated = analyzeReadability(UI_LABELS.join(". ") + ".");
+
+    // Same words, same syllables per word. The ONLY difference is full stops.
+    expect(flat.words).toBe(punctuated.words);
+    expect(flat.syllablesPerWord).toBe(punctuated.syllablesPerWord);
+
+    // And yet the grade moves by five, because sentence count went 1 -> 11.
+    expect(flat.sentences).toBe(1);
+    expect(punctuated.sentences).toBe(11);
+    expect(flat.gradeLevel).toBeGreaterThan(punctuated.gradeLevel + 4);
+  });
+});
+
+describe("analyzeUtteranceReadability", () => {
+  it("scores each UI utterance as its own sentence", () => {
+    const ui = analyzeUtteranceReadability(UI_LABELS);
+    expect(ui.sentences).toBe(UI_LABELS.length);
+    expect(ui.wordsPerSentence).toBeLessThan(2);
+  });
+
+  it("cannot be gamed by adding full stops", () => {
+    const bare = analyzeUtteranceReadability(UI_LABELS);
+    const stopped = analyzeUtteranceReadability(UI_LABELS.map((l) => `${l}.`));
+    expect(stopped.gradeLevel).toBe(bare.gradeLevel);
+    expect(stopped.sentences).toBe(bare.sentences);
+  });
+
+  it("agrees with the prose analyzer on a single prose utterance", () => {
+    const prose = "the cat sat on the mat and the dog ran to the log";
+    expect(analyzeUtteranceReadability([prose])).toEqual(analyzeReadability(prose));
+    expect(analyzeUtteranceReadability([JARGON])).toEqual(analyzeReadability(JARGON));
+  });
+
+  it("still splits genuine prose inside one utterance on its full stops", () => {
+    const paragraph = "We sorted your drives. Three still need a category. Pick one for each.";
+    expect(analyzeUtteranceReadability([paragraph]).sentences).toBe(3);
+  });
+
+  it("still catches jargon on a label-shaped surface", () => {
+    // The point of the correction is a measure that separates plain from dense
+    // WITHOUT counting periods. Both surfaces are pure one-word labels.
+    const plain = analyzeUtteranceReadability(["Date", "Route", "Miles", "Sorted", "Owed"]);
+    const dense = analyzeUtteranceReadability([
+      "Infrastructure",
+      "Optimization",
+      "Administrative",
+      "Documentation",
+      "Organizational",
+    ]);
+    expect(plain.wordsPerSentence).toBe(dense.wordsPerSentence);
+    expect(withinReadingLevel(plain.gradeLevel, "high-school")).toBe(true);
+    expect(withinReadingLevel(dense.gradeLevel, "high-school")).toBe(false);
+  });
+
+  it("ignores utterances with no scoreable text", () => {
+    expect(analyzeUtteranceReadability(["  ", "—", "Date"]).sentences).toBe(1);
   });
 });

--- a/packages/validators/src/readability.ts
+++ b/packages/validators/src/readability.ts
@@ -49,12 +49,15 @@ export interface ReadabilityScore {
   gradeLevel: number;
 }
 
-export function analyzeReadability(rawText: string): ReadabilityScore {
-  const text = toProse(rawText);
-  const sentences = Math.max(
-    text.split(/[.!?]+/).map((s) => s.trim()).filter(Boolean).length,
-    1,
-  );
+/** Sentences a run of PROSE contains, split on terminal punctuation. */
+function proseSentences(text: string): string[] {
+  return text.split(/[.!?]+/).map((s) => s.trim()).filter(Boolean);
+}
+
+/** The Flesch–Kincaid arithmetic, given text and a sentence count established
+ *  by the caller. Both public analyzers differ only in how they count sentences. */
+function score(text: string, sentenceCount: number): ReadabilityScore {
+  const sentences = Math.max(sentenceCount, 1);
   const words = text.split(/\s+/).filter((w) => /[a-z0-9]/i.test(w));
   const wordCount = Math.max(words.length, 1);
   const syllables = words.reduce((n, w) => n + countSyllables(w), 0);
@@ -69,6 +72,53 @@ export function analyzeReadability(rawText: string): ReadabilityScore {
     readingEase: round1(206.835 - 1.015 * wps - 84.6 * spw),
     gradeLevel: round1(0.39 * wps + 11.8 * spw - 15.59),
   };
+}
+
+/**
+ * Flesch–Kincaid over PROSE — text whose sentence boundaries are full stops.
+ * Correct for a paragraph, a marketing snippet, a doc body.
+ *
+ * DO NOT use this on a rendered UI surface. See `analyzeUtteranceReadability`.
+ */
+export function analyzeReadability(rawText: string): ReadabilityScore {
+  const text = toProse(rawText);
+  return score(text, proseSentences(text).length);
+}
+
+/**
+ * Flesch–Kincaid over a UI SURFACE — BI-0ED0F6B3.
+ *
+ * THE DEFECT THIS EXISTS TO FIX. Flesch–Kincaid divides words by sentences, and
+ * `analyzeReadability` finds sentences by looking for full stops. A user
+ * interface has almost none: it is headings, table cells, button labels, nav
+ * items and list items, and none of those are punctuated. Flatten such a page
+ * into one string and every label in it collapses into a single enormous
+ * "sentence", words-per-sentence explodes, and the grade climbs for text that
+ * carries no complexity at all.
+ *
+ * Measured proof (packages/validators/src/readability.test.ts): the same fifteen
+ * words, at the same 1.4 syllables per word, score grade 3.9 unpunctuated and
+ * grade 1.5 with a stop after each label. Identical vocabulary; the only variable
+ * is punctuation the UI had no reason to carry. On a real 200-word surface the
+ * same mechanism produced grades in the teens, and that inflation is what drove
+ * every /admin route over the high-school cap.
+ *
+ * THE CORRECTION. In a UI the SENTENCE BOUNDARY IS THE ELEMENT BOUNDARY. Each
+ * utterance — one heading, one cell, one label — is at least one sentence, and
+ * genuine prose inside an utterance still splits on its own full stops. Feed the
+ * utterances in separately and words-per-sentence becomes what it should be: a
+ * measure of how long the surface's actual phrases are.
+ *
+ * The result is dominated by syllables-per-word for a label-shaped surface, which
+ * is the punctuation-independent signal that separates plain copy from jargon,
+ * while still catching a genuinely long sentence in real body copy. It also
+ * cannot be gamed by adding full stops — a stop inside an utterance only ever
+ * splits a sentence that was already counted.
+ */
+export function analyzeUtteranceReadability(utterances: readonly string[]): ReadabilityScore {
+  const texts = utterances.map((u) => toProse(u)).filter((t) => /[a-z0-9]/i.test(t));
+  const sentences = texts.reduce((n, t) => n + Math.max(proseSentences(t).length, 1), 0);
+  return score(texts.join(" "), sentences);
 }
 
 // ── Reading levels & the tiered policy ──────────────────────────────────────


### PR DESCRIPTION
Fixes the reading-level check so it measures how hard a screen is to read, rather
than how many full stops it happens to contain. Works BI-0ED0F6B3.

## The defect

`reading-level` reported a Flesch–Kincaid grade over the whole rendered page,
flattened to one string. Flesch–Kincaid divides words by **sentences**, and it
finds sentences by looking for full stops. A product screen has almost none — it
is headings, table cells, button labels and nav items. So the page collapsed into
a single enormous "sentence", words-per-sentence exploded, and the grade climbed
for copy carrying no difficulty at all.

Measured, with the platform's own analyzer:

| input | grade | words | sentences | w/s | syl/w |
|---|---|---|---|---|---|
| UI labels, as rendered | **6.8** | 15 | 1 | 15.0 | 1.40 |
| the same 15 words, a stop after each | **1.5** | 15 | 11 | 1.4 | 1.40 |

Identical vocabulary, identical syllables-per-word. The only variable is
punctuation the screen had no reason to carry.

The consequence was not marginal. In the route-budget report, **185 of 201 routes
failed** the check, median grade 16.8, with `/platform/identity/agents` at
**377.1** — a grade arithmetically impossible for prose, and the clearest
available sign the number was describing layout rather than language.

## The fix

**In a UI the sentence boundary is the element boundary.** `visibleUtterances`
splits the served DOM at block-level elements — inline markup stays inside its
phrase, so real body copy is not shredded — and `analyzeUtteranceReadability`
scores each utterance as at least one sentence. Genuine prose inside an utterance
still splits on its own full stops.

**The grade is scored over the route's own `<main>`**, not the shared shell.
Chrome is identical on every route and was diluting all of them equally. Guarded:
when `<main>` holds under half the surface's words it is a landmark around a
client shell rather than the content, and the whole scope is kept instead.
`/platform/ai/skills` is exactly that shape and would otherwise have been graded
on a single word. Word and control budgets keep their whole-surface scope.

Two properties make the result trustworthy, both asserted in tests:

- **Punctuation cannot move it.** Adding full stops to a screen changes the grade
  by exactly zero. Before, it was worth five grades.
- **Density still moves it.** A screen of one-word labels reading *Infrastructure
  / Optimization / Administrative / Documentation* still fails the high-school
  cap, at exactly the words-per-sentence of a screen reading *Date / Route /
  Miles*. This separates difficulty from punctuation; it does not excuse jargon.

Deliberately **not** done: the cap was not raised, and no route was added to a
baseline or exception list. Both hide the defect instead of fixing it.

## Blast radius

`analyzeReadability` is unchanged and remains the prose analyzer. Proven rather
than asserted: compared against the pre-change implementation over **155,447 real
paragraphs from `docs/`, zero behavioural differences**. So the prose-lint guard,
`setup-ux`, the marketing/storefront validators and the coworker reading-level
policy are untouched — and each of those already scored one sentence at a time,
which is why they never saw this defect.

`reading-level` is an **absolute** check, not a ratcheted axis: it has no entry in
`route-budget-baseline.json`. **No baseline update is required**, and no
pre-existing route can newly block on it — the check is advisory there and
blocking only on net-new routes.

## The measured effect, all 201 routes

Sweep run 32661659842 on this branch, against run 32625564367 on `main`:

| | before | after |
|---|---|---|
| median grade | 16.8 | **8.7** |
| p90 | 26.8 | **11.5** |
| max | **377.1** (`/platform/identity/agents`) | **15.4** |
| routes at or under 9 | 5 | **119** |
| routes failing `reading-level` | **185 of 201** | **35 of 201** |

**199 routes moved down, 0 moved up, 2 unchanged.** The two unchanged are already-plain
pages at 3.7. No route newly fails — the one place that could have (`/platform/ai/skills`,
whose `<main>` is a client shell) was caught in unit test and is what the scoping guard
above exists for.

The 35 that still fail now read like findings someone can act on rather than noise:
`/platform/identity/authorization` 15.4, `/knowledge/new` 15.2,
`/platform/identity/principals` 15.2, `/admin/archetypes` 14.9, and a `/compliance/*`
cluster at 9.9–12.6 carrying genuine regulatory vocabulary.

## AUDIENCE_READING_LEVELS — the exception is withdrawn

`AUDIENCE_READING_LEVELS` re-tiered `admin` and `builder` to college (13). Its stated
justification was that `/admin/graph-explorer` blocked at 11.0 as the first net-new admin
route while the plainest admin surfaces could not clear 9 either. That reasoning was sound
about a number that was wrong. **Every route named in it now passes at grade 9:**

| route | before | after |
|---|---|---|
| `/admin/graph-explorer` (the net-new route that blocked) | 11.1 | **3.4** |
| `/admin/cockpit` | 12.6 | **6.4** |
| `/admin` | 13.2 | **8.2** |
| `/admin/data-stewardship` | 18.7 | **6.5** |
| `/admin/business-models` | 29.5 | **8.4** |

The premise is gone, so the exception goes with it, and the hide-complexity doctrine holds
for every audience — which is what the readability policy asked for in the first place.
53 of 99 formerly-college routes still read above 9 on operator vocabulary an admin console
cannot avoid (`Authorization`, `Federation`, `Principals`); all are pre-existing, so those
are now visible advisory findings rather than a bar quietly lowered to meet them.

The table is kept as an empty seam, so a future exception is a data change with a measured
justification rather than a rewrite of `readingLevelFor`.

Routed through `principle_decide` — recommends restoring the strict tier, high confidence,
margin 2.07, no commandment conflict (ledger `DI-710B4860812F`); operator-confirmed.

## Verification

- `packages/validators` — 107 tests pass
- `apps/web` ux-budget / owner-first / prose — pass
- prose-lint guard — 22 tests pass
- `pnpm --filter web exec tsc --noEmit` — clean
- local-CI gate — PASS (evidence `cmt67h4cb0ekp01mqozym533h`)
- UX route sweep on this branch — run 32661659842, success, 201 routes measured
- No baseline update required and none is included (see Blast radius)

Refs: BI-0ED0F6B3

Process-Spine-Decision: docs/platform-usability-standards.md updated in this PR with the prose/UI scorer split.
