### PR TITLE
fix(self-upgrade): a Run History row expanded mid-swap reports reconnecting, not a server error

### DIFF
--- a/apps/web/components/ops/RunImpactDetail.test.tsx
+++ b/apps/web/components/ops/RunImpactDetail.test.tsx
@@ -14,7 +14,7 @@ vi.mock("@/lib/actions/promotions", () => ({
   getSelfUpgradeRunImpact: (...a: unknown[]) => getSelfUpgradeRunImpactMock(...a),
 }));
 
-import { RunImpactDetail } from "./RunImpactDetail";
+import { RunImpactDetail, RUN_IMPACT_RETRY_MS } from "./RunImpactDetail";
 import type { ImpactItem, UpgradeImpactSummary } from "@/lib/self-upgrade/impact/types";
 
 afterEach(() => {
@@ -115,5 +115,37 @@ describe("RunImpactDetail", () => {
     fireEvent.click(screen.getByText("View changes"));
 
     await waitFor(() => expect(screen.getByText("Unauthorized")).toBeTruthy());
+  });
+
+  it("holds a calm reconnect line — not an error — when the portal swaps mid-fetch", async () => {
+    // BI: expanding a RUNNING row while the upgrade swaps the container printed
+    // Next's sanitized transport failure verbatim under "Hide changes".
+    vi.useFakeTimers();
+    const swapFailure = new Error(
+      "An unexpected response was received from the server.",
+    );
+    getSelfUpgradeRunImpactMock.mockRejectedValueOnce(swapFailure);
+    getSelfUpgradeRunImpactMock.mockResolvedValueOnce(
+      summary([item("s1", "Patched an advisory", "security")]),
+    );
+    render(<RunImpactDetail runId="SUR-AAAA0001" digest={DIGEST} />);
+
+    fireEvent.click(screen.getByText("View changes"));
+
+    await vi.waitFor(() =>
+      expect(screen.getByText(/Portal is restarting to finish this upgrade/)).toBeTruthy(),
+    );
+    expect(
+      screen.queryByText(/An unexpected response was received/),
+    ).toBeNull();
+    expect(screen.queryByText(/change list is no longer/)).toBeNull();
+
+    // The retry lands once the swapped-in portal answers.
+    await vi.advanceTimersByTimeAsync(RUN_IMPACT_RETRY_MS + 50);
+    await vi.waitFor(() =>
+      expect(screen.getByText("Patched an advisory")).toBeTruthy(),
+    );
+    expect(screen.queryByText(/Portal is restarting/)).toBeNull();
+    vi.useRealTimers();
   });
 });

--- a/apps/web/components/ops/RunImpactDetail.tsx
+++ b/apps/web/components/ops/RunImpactDetail.tsx
@@ -16,7 +16,7 @@
 // carries the record, it does not re-derive it, so a run keeps reporting the
 // changes IT applied even after upstream has moved on.
 
-import { useState, useTransition } from "react";
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import { getSelfUpgradeRunImpact } from "@/lib/actions/promotions";
 import type {
   RunImpactDigest,
@@ -26,6 +26,10 @@ import { UpgradeScopeRibbon } from "@/components/ops/UpgradeScopeRibbon";
 import { ImpactItemRow } from "@/components/ops/ImpactItemRow";
 import { InlineBusy } from "@/components/ui/InlineBusy";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { isExpectedDuringSwap } from "@/lib/self-upgrade/is-expected-during-swap";
+
+/** How long to wait before re-fetching after a swap-window transport failure. */
+export const RUN_IMPACT_RETRY_MS = 3_000;
 
 export function RunImpactDetail({
   runId,
@@ -37,7 +41,40 @@ export function RunImpactDetail({
   const [expanded, setExpanded] = useState(false);
   const [summary, setSummary] = useState<UpgradeImpactSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Distinct from `error`: the request never landed because the portal is
+  // being swapped out by the very upgrade this row describes. That is the
+  // expected shape of a running upgrade, not a defect (BI-D77BF495 handling,
+  // extended here — expanding a RUNNING row used to print Next's sanitized
+  // "An unexpected response was received from the server." as if the page
+  // had broken).
+  const [reconnecting, setReconnecting] = useState(false);
   const [isPending, startTransition] = useTransition();
+  const loadedRef = useRef(false);
+
+  const load = useCallback(() => {
+    startTransition(async () => {
+      try {
+        setSummary(await getSelfUpgradeRunImpact(runId));
+        loadedRef.current = true;
+        setReconnecting(false);
+        setError(null);
+      } catch (err) {
+        if (isExpectedDuringSwap(err)) {
+          setReconnecting(true);
+        } else {
+          setError(getErrorMessage(err));
+        }
+      }
+    });
+  }, [runId]);
+
+  // Keep retrying for as long as the row is open and the portal is mid-swap;
+  // the list appears on its own once the new container answers.
+  useEffect(() => {
+    if (!expanded || !reconnecting) return;
+    const timer = setTimeout(load, RUN_IMPACT_RETRY_MS);
+    return () => clearTimeout(timer);
+  }, [expanded, reconnecting, load]);
 
   function toggle() {
     if (expanded) {
@@ -46,15 +83,9 @@ export function RunImpactDetail({
     }
     setExpanded(true);
     // Fetch once per row — a second expand replays what is already held.
-    if (summary || isPending) return;
+    if (loadedRef.current || isPending) return;
     setError(null);
-    startTransition(async () => {
-      try {
-        setSummary(await getSelfUpgradeRunImpact(runId));
-      } catch (err) {
-        setError(getErrorMessage(err));
-      }
-    });
+    load();
   }
 
   const items = summary?.allItems ?? [];
@@ -76,12 +107,23 @@ export function RunImpactDetail({
       </button>
 
       {expanded && (
-        <div className="pt-1" aria-busy={isPending || undefined}>
+        <div className="pt-1" aria-busy={isPending || reconnecting || undefined}>
           {isPending && <InlineBusy label="Loading changes…" />}
+          {!isPending && reconnecting && (
+            <div
+              className="text-dpf-caption text-[var(--dpf-muted)]"
+              role="status"
+              aria-live="polite"
+              data-run-impact-reconnecting={runId}
+            >
+              Portal is restarting to finish this upgrade. The list loads
+              when it is back.
+            </div>
+          )}
           {error && (
             <div className="text-dpf-caption text-[var(--dpf-destructive)]">{error}</div>
           )}
-          {!isPending && !error && items.length === 0 && (
+          {!isPending && !error && !reconnecting && loadedRef.current && items.length === 0 && (
             // The digest exists but the item list does not — say so plainly
             // rather than rendering an empty box that reads as "no changes".
             <div className="text-dpf-caption text-[var(--dpf-muted)]">

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -741,7 +741,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 52
+    "textMass": 46
   },
   "apps/web/app/(shell)/coworker-decisions/review/page.tsx": {
     "vocabulary": 0,
@@ -6973,7 +6973,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 21
+    "textMass": 35
   },
   "apps/web/components/ops/SelfUpgradeClient.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## What broke

Expanding **View changes** on a Run History row while that run is still `RUNNING` printed Next's sanitized transport failure verbatim under the row:

> An unexpected response was received from the server.

Nothing was actually wrong. The row fires a server action (`getSelfUpgradeRunImpact`) against a portal that the very upgrade it describes is swapping out, so the response never lands intact — Next stamps it `E394` and sanitizes the message. To the operator watching their own upgrade, it reads as a defect in the run.

## Why this surface and not the others

The swap-window error shape is already classified centrally by `lib/self-upgrade/is-expected-during-swap.ts` (BI-D77BF495), and two surfaces already hold a calm "reconnecting" state on it:

- `SelfUpgradeTriggerControl` — trigger / force / abort
- `SelfUpgradeClient` — rollback

`RunImpactDetail` was the third caller that never got wired. It also catches its own rejection inside the transition, so neither the `(shell)` crash boundary nor `DeploymentSkewBanner` ever sees the error — exactly the swallowed case `lib/deployment-skew.ts` documents under BI-F381D902.

## The change

`RunImpactDetail` now separates a swap-window failure from a real one:

- swap-window → a calm status line ("Portal is restarting to finish this upgrade. The list loads when it is back.") plus a 3s re-fetch while the row stays open, so the change list fills in on its own once the swapped-in container answers;
- everything else (auth, a missing summary) → unchanged error rendering.

`loadedRef` replaces the previous `summary`-truthiness check for "already fetched", so a run whose summary genuinely resolves to `null` still reports "change list is no longer available" instead of re-fetching on every expand.

## Verification

- `apps/web/components/ops/RunImpactDetail.test.tsx` — new test is red without the component change, green with it (verified by stashing the component).
- `pnpm --filter web exec vitest run components/ops` — 24 files, 191 tests pass.
- `tsc --noEmit` for `apps/web` — clean.
- `pnpm pregate` — PASS, gated sha `02e9e54aae21`, evidence `cmt6awxjm03ce01pq29c29r9p`.

## Docs impact

None. No route, contract, operator procedure or install path changes — one client component's error branch. The swap-window rationale lives in code comments next to the two existing callers, which is where the prior BIs put it.

## Not done in this branch

`DPF_MCP_BEARER_TOKEN` is unset in the authoring session, so the backlog item for this defect could not be filed through MCP, and the semantic-review receipt could not be recorded (`semantic-review-gate` reports `missing-receipt` as a shadow observation; publication remains allowed). Both need a session with a token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
