### PR TITLE
fix(tak): stop telling an owner to reconnect a provider that was never eligible (BI-A89E4827)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -49,10 +49,8 @@ import { clampToolResultForModel, resolveToolResultCharCap } from "./tool-result
 import { applyBacklogCreateClaimGuard } from "./backlog-create-claim-guard";
 import { applyEscalationLadderGuard, buildHumanHandoff } from "./escalation-ladder";
 import { logGeneratedProse } from "../prose/generated-prose"; // BI-41F15FD7
-import { noEligibleModelHandoff, providersBusyHandoff, providerUnreachableHandoff } from "./inference-dead-ends";
 import { assessToolSurface, computeToolSelectionAccuracy, contextEconomyTurnMetricFields } from "./context-economy-metrics";
 import { summarizeDroppedMessages } from "./compaction-digest";
-import { describeContextCapacityFailure } from "./context-capacity-failure";
 import {
   detectToolRefusedDespiteAvailability,
   appendToolRefusedRecoveryMessages,
@@ -103,111 +101,9 @@ const COMPLETION_CLAIM_PATTERN =
 export const HARD_COMPLETION_CLAIM_PATTERN =
   /\bI(?:'ve| have| just)?\s*(?:have\s+)?(?:saved|created|published|posted|sent|scheduled|recorded|queued|logged|added|drafted and saved|placed)\b|\b(?:saved|published|posted|sent|scheduled|queued|added|recorded)\s+(?:it|that|your|the)\b|\b(?:is|are|has been|have been)\s+(?:now\s+)?(?:live|saved|published|sent|scheduled|posted|queued|recorded)\b|in\s+(?:your\s+)?approval\s+queue|\b(?:prospect\s+)?account\s+created\b|\bACCT-[A-Z0-9]{4,}\b/i;
 
-/**
- * Build a plain-language, non-technical explanation when an agent turn fails
- * because routing could not complete a tool-using call (BI-23E0714C).
- *
- * The old behavior lumped every tool-route failure into one message that told
- * the operator to "Configure an active model that supports tools in
- * Platform > AI > Model Assignment" — which is wrong and a dead end whenever a
- * tool-capable provider IS already configured (the common case). This classifier
- * distinguishes the real situations so we never send a non-technical operator to
- * fix config that is already correct:
- *
- *  - REQUEST_TOO_LARGE  → context overflow; start a new thread.
- *  - No credential for ANY non-local provider → permanent config gap; point to setup.
- *    MUST be checked before the threshold branch: a threshold skip layered on top of
- *    a credential gap matches the threshold pattern but the real fix is "connect a
- *    provider", not "wait for a rate-limit to clear" (BI-AUDIT-003).
- *  - local bypassed for tool count + paid providers transiently down → rate-limit;
- *    nothing is misconfigured.
- *  - genuinely no tool-capable endpoint active → point to the REAL surface.
- *  - other endpoint failures → transient; retry shortly.
- */
-export function describeToolRouteFailure(
-  errorMessage: string,
-  toolCount: number,
-): string {
-  const msg = errorMessage ?? "";
-
-  if (msg.startsWith("REQUEST_TOO_LARGE:")) {
-    return "Your conversation is too long for this AI provider. Please start a new thread to continue.";
-  }
-
-  // Local runner rejected the request because prompt + tool schemas exceed the
-  // model's served context window (e.g. Docker Model Runner HTTP 400
-  // exceed_context_size_error). This is DETERMINISTIC, not a transient rate-limit,
-  // so the "try again shortly" branches below would mislead — and a fresh thread
-  // alone won't help if the tool surface itself is too big. Point at the real
-  // levers (shorter input / fewer active tools / larger-context model).
-  if (/exceed_context_size|exceeds the available context size/i.test(msg)) {
-    return (
-      "That request was too large for the active AI model's context window — usually too many " +
-      "tools active at once, or a long conversation. Try a shorter message or start a new thread. " +
-      "If it keeps happening, this coworker has more tools active than the local model can hold and needs right-sizing."
-    );
-  }
-
-  // Permanent configuration gap: a non-local provider is in the chain but has no
-  // credential row. This is NOT transient — the operator must connect a provider.
-  // Check this BEFORE the threshold branch: when codex has no credential AND local
-  // is threshold-blocked, the threshold pattern matches but the user needs to
-  // configure a provider, not wait for a rate-limit.
-  if (/No credential for/i.test(msg)) {
-    return (
-      "No AI provider credentials are configured for this feature. " +
-      "Open Platform › AI Operations › Providers & Routing, connect a cloud provider " +
-      "(Claude, OpenAI, Google, or similar), then try again."
-    );
-  }
-
-  // Most common real cause: the bundled local model was bypassed because this
-  // coworker exposes more tools than a small local model can reliably handle,
-  // and no paid provider was available to take the work. This is NOT a
-  // misconfiguration, so do not point the operator at a settings page.
-  if (/exceeds threshold|skipped local fallback/i.test(msg)) {
-    // Prefer the exact count the router reported ("58 tools exceeds threshold");
-    // fall back to the tool count we were handed.
-    const reported = msg.match(/(\d+)\s+tools?\s+exceeds threshold/i);
-    const count = reported ? Number(reported[1]) : toolCount;
-    const tools = count > 0 ? `${count} of them` : "many";
-    return (
-      "Your paid AI providers (such as Claude or GPT) are briefly unavailable right now — " +
-      "usually a short rate-limit that clears within a minute — and this coworker uses too many " +
-      `tools (${tools}) for the bundled local model to run on its own. Nothing is misconfigured. ` +
-      "Please wait a moment and try again."
-    );
-  }
-
-  // Genuine config gap: routing found no active model that supports tools at all.
-  if (/No eligible endpoints/i.test(msg) && /toolUse/i.test(msg)) {
-    return (
-      "No AI model that supports tools is active right now. Open Platform > AI > " +
-      "Providers & Routing to activate a tool-capable provider, then try again."
-    );
-  }
-
-  const contextCapacityFailure = describeContextCapacityFailure(msg);
-  if (contextCapacityFailure) return contextCapacityFailure;
-
-  // Config/capacity gap: routing eliminated EVERY candidate (e.g. the cloud
-  // provider's sign-in expired AND the bundled local model's context window is
-  // too small for this coworker's larger requests). This reaches here as a plain
-  // "No eligible endpoints for task type '…'" with no `toolUse` token, so the
-  // branch above misses it and — before this fix — it fell through to the generic
-  // "temporarily unavailable, try again in 30 seconds" below. That is a LIE for a
-  if (/No eligible endpoints/i.test(msg)) {
-    return noEligibleModelHandoff();
-  }
-
-  // Endpoints exist but all transiently failed (rate-limit / overload / network).
-  if (/All endpoints failed/i.test(msg)) {
-    return providersBusyHandoff();
-  }
-
-  // Most common dead end on a real install: 114 of 196 (BI-33F1EA72).
-  return providerUnreachableHandoff();
-}
+// The dead-end classifier and its copy live in ./inference-dead-ends (BI-A89E4827).
+import { describeToolRouteFailure } from "./inference-dead-ends";
+export { describeToolRouteFailure };
 
 // Narration patterns: agent describes code or announces intent instead of calling tools.
 // Includes preamble narration ("Let me check", "I need to fix") and intent announcements
@@ -1790,7 +1686,7 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
       console.warn(`[agentic-loop] routeAndCall threw: ${msg}`);
       logTurnSummary("unknown", "unknown");
       return {
-        content: describeToolRouteFailure(msg, routeOptions.tools?.length ?? 0),
+        content: describeToolRouteFailure(msg, routeOptions.tools?.length ?? 0, routeErr),
         providerId: "unknown",
         modelId: "unknown",
         downgraded: false,

--- a/apps/web/lib/tak/inference-dead-ends.test.ts
+++ b/apps/web/lib/tak/inference-dead-ends.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
+  describeToolRouteFailure,
+  localCapacityHeldHandoff,
   noEligibleModelHandoff,
   providersBusyHandoff,
-  providerUnreachableHandoff,
+  unexplainedDeadEndHandoff,
 } from "./inference-dead-ends";
 
 // BI-33F1EA72. Measured on the live install: 196 of 1,138 assistant messages
@@ -12,7 +14,8 @@ describe("dead-end replies hand off instead of asking the user to poll", () => {
   const all = [
     ["no eligible model", noEligibleModelHandoff()],
     ["providers busy", providersBusyHandoff()],
-    ["provider unreachable", providerUnreachableHandoff()],
+    ["local capacity held", localCapacityHeldHandoff()],
+    ["unexplained dead end", unexplainedDeadEndHandoff()],
   ] as const;
 
   it.each(all)("%s ends on the resumption, not on the limitation", (_name, message) => {
@@ -24,12 +27,38 @@ describe("dead-end replies hand off instead of asking the user to poll", () => {
     expect(message).toMatch(/^1\. /m);
   });
 
-  it("stops telling the user to poll on the most common dead end", () => {
+  it("stops telling the user to poll on an unexplained dead end", () => {
     // The prior copy was "Please try again in about 30 seconds." — a poll
     // instruction with no step and no resumption. 114 of 196 dead ends.
-    const message = providerUnreachableHandoff();
+    const message = unexplainedDeadEndHandoff();
     expect(message).not.toMatch(/try again in about 30 seconds/i);
     expect(message).toMatch(/Providers & Routing/);
+  });
+
+  // BI-A89E4827. The catch-all is by construction the branch that matched
+  // nothing, so it must not name a cause. The old copy asserted "an expired
+  // sign-in or exhausted quota is the usual cause" and sent an owner whose
+  // providers were all healthy to a settings page that could not help.
+  it("does not assert a cause it has not established", () => {
+    const message = unexplainedDeadEndHandoff();
+    expect(message).toMatch(/can't tell from here/i);
+    expect(message).not.toMatch(/is the usual cause/i);
+    expect(message).not.toMatch(/exhausted quota/i);
+  });
+
+  // BI-A89E4827. A host-capacity deferral is not a configuration problem, so
+  // the reply must not send the owner to a settings surface that cannot clear
+  // it — reconnecting a provider provably does nothing here.
+  it("treats a local capacity deferral as a wait, naming no settings surface", () => {
+    const message = localCapacityHeldHandoff();
+    expect(message).toMatch(/Nothing is misconfigured/);
+    expect(message).toMatch(/background job/i);
+    expect(message).not.toMatch(/Providers & Routing/);
+    expect(message).not.toMatch(/reconnect/i);
+  });
+
+  it("says so when host capacity could not be confirmed either way", () => {
+    expect(localCapacityHeldHandoff(true)).toMatch(/couldn't confirm/i);
   });
 
   it("keeps the genuinely transient case short rather than inventing config steps", () => {
@@ -44,5 +73,56 @@ describe("dead-end replies hand off instead of asking the user to poll", () => {
     const message = noEligibleModelHandoff();
     expect(message).toMatch(/residency|data-policy/);
     expect(message).toMatch(/context size/);
+  });
+});
+describe("describeToolRouteFailure classifies the deferral that stranded the owner", () => {
+  // The exact error text and class name observed on the live install:
+  //   [agentic-loop] routeAndCall threw:
+  //   Local provider dispatch deferred: local-ci-active-capacity-reservation
+  const deferralMessage = "Local provider dispatch deferred: local-ci-active-capacity-reservation";
+
+  it("recognises the typed error even when the message is opaque", () => {
+    const typed = Object.assign(new Error("something else entirely"), {
+      name: "LocalProviderCapacityDeferredError",
+    });
+    expect(describeToolRouteFailure("something else entirely", 0, typed))
+      .toBe(localCapacityHeldHandoff());
+  });
+
+  it("recognises the deferral when only its message survived a queue boundary", () => {
+    expect(describeToolRouteFailure(deferralMessage, 0)).toBe(localCapacityHeldHandoff());
+  });
+
+  it("distinguishes unproven capacity from held capacity", () => {
+    expect(
+      describeToolRouteFailure(
+        "Local provider dispatch deferred: local-ci-capacity-reservation-unavailable",
+        0,
+      ),
+    ).toBe(localCapacityHeldHandoff(true));
+  });
+
+  it("no longer sends a deferred turn to Providers & Routing", () => {
+    expect(describeToolRouteFailure(deferralMessage, 0)).not.toMatch(/Providers & Routing/);
+  });
+
+  it("leaves the established branches alone", () => {
+    expect(describeToolRouteFailure("REQUEST_TOO_LARGE: 200000", 0))
+      .toMatch(/too long for this AI provider/);
+    expect(describeToolRouteFailure("No credential for codex", 0))
+      .toMatch(/No AI provider credentials are configured/);
+    expect(describeToolRouteFailure("58 tools exceeds threshold for small local models", 58))
+      .toMatch(/58 of them/);
+    expect(describeToolRouteFailure("No eligible endpoints: toolUse required", 0))
+      .toMatch(/supports tools is active right now/);
+    expect(describeToolRouteFailure("No eligible endpoints for task type 'conversation'", 0))
+      .toBe(noEligibleModelHandoff());
+    expect(describeToolRouteFailure("All endpoints failed for conversation", 0))
+      .toBe(providersBusyHandoff());
+  });
+
+  it("falls through to the unexplained hand-off, not to a fabricated cause", () => {
+    expect(describeToolRouteFailure("ECONNRESET talking to the model host", 0))
+      .toBe(unexplainedDeadEndHandoff());
   });
 });

--- a/apps/web/lib/tak/inference-dead-ends.ts
+++ b/apps/web/lib/tak/inference-dead-ends.ts
@@ -20,6 +20,7 @@
 // Kept out of agentic-loop.ts because that file is the largest module in the
 // repo and its size ratchet only permits shrinking; copy this length does not
 // belong in that budget.
+import { describeContextCapacityFailure } from "./context-capacity-failure";
 import { buildHumanHandoff } from "./escalation-ladder";
 
 /** Routing eliminated every candidate — a real configuration question. */
@@ -49,14 +50,187 @@ export function providersBusyHandoff(): string {
   });
 }
 
-/** The single most common dead end on a real install. */
-export function providerUnreachableHandoff(): string {
+
+/**
+ * The local model is present and healthy, but a background job on this host
+ * holds the capacity reservation (BI-A89E4827).
+ *
+ * This is the dead end that stranded the owner: on a turn routed at
+ * `restricted` sensitivity the local model is the ONLY endpoint policy allows,
+ * so a capacity deferral is not one failed candidate among several — it is the
+ * whole chain. `callWithFallbackChain` rethrows the deferral verbatim in that
+ * case, and before this branch existed it matched none of the classifier's
+ * patterns and fell through to `providerUnreachableHandoff`, which told the
+ * owner to reconnect a provider. Every cloud provider was connected and
+ * healthy; none of them was eligible. Reconnecting one could not have helped,
+ * so the hand-off ended on a step that provably does nothing.
+ *
+ * The correct next action is to wait, and the correct thing to say is that
+ * nothing is misconfigured — so this deliberately names NO settings surface.
+ * Respects IDENTITY_BLOCK rule #5: no lease names, reason codes, or job ids.
+ */
+export function localCapacityHeldHandoff(unprovenCapacity = false): string {
   return buildHumanHandoff({
-    blocker: "I can't reach an AI provider at the moment, so I couldn't answer this.",
+    blocker: unprovenCapacity
+      ? "I couldn't confirm the local AI model was free to use, so I held off rather than risk disrupting something else running on this machine. Nothing is misconfigured."
+      : "The only AI model allowed to handle this request is tied up with a background job on this machine, so I couldn't answer. Nothing is misconfigured.",
+    steps: ["Give it a couple of minutes, then send the message again."],
+    verify: "check the moment it frees up",
+  });
+}
+
+/**
+ * Nothing above matched, so we do not know why (BI-A89E4827).
+ *
+ * The earlier copy asserted a cause — "an expired sign-in or exhausted quota is
+ * the usual cause" — on the strength of a population measurement (114 of 196
+ * dead ends were provider-unavailable, BI-33F1EA72). That is a fact about the
+ * population, not about the turn in front of us, and this branch is by
+ * construction the one that matched nothing. Stating it as the cause is the
+ * failure mode `Never Fabricate` names: a confident diagnosis with no evidence
+ * behind it, which sent the owner to a settings page that could not help.
+ *
+ * The population prior is still the best first thing to CHECK. It is offered as
+ * a check, and the reply says plainly that the cause is not known from here.
+ */
+export function unexplainedDeadEndHandoff(): string {
+  return buildHumanHandoff({
+    blocker: "I couldn't get an answer from any AI model just now, and I can't tell from here what stopped it.",
     steps: [
       "Open Platform > AI Operations > Providers & Routing.",
-      "Reconnect or add a provider — an expired sign-in or exhausted quota is the usual cause.",
+      "Check whether a provider needs reconnecting — the most common cause, though not the only one.",
     ],
-    verify: "confirm a provider is reachable",
+    verify: "re-check what this coworker can reach and tell you what I find",
   });
+}
+
+/** True when `error` is a local host-capacity deferral, however it reached us.
+ *
+ * Matched by NAME rather than by importing `LocalProviderCapacityDeferredError`,
+ * for the reason `dispatch-failure-class.ts` documents: a shared module that
+ * reaches into routing internals is how promoter-only code got dragged into the
+ * web bundle (BI-76651B7B). The name check also survives the error crossing a
+ * queue boundary, and the message fallback covers a deferral that arrives as a
+ * plain string with no type left on it.
+ */
+export function isLocalCapacityDeferral(error: unknown, message: string): boolean {
+  const name = typeof error === "object" && error !== null && "name" in error
+    ? (error as { name?: unknown }).name
+    : undefined;
+  return name === "LocalProviderCapacityDeferredError"
+    || /Local provider dispatch deferred/i.test(message);
+}
+
+/**
+ * Plain-language, non-technical explanation for a turn that failed because
+ * routing could not complete a tool-using call (BI-23E0714C).
+ *
+ * Lives here rather than in agentic-loop.ts for the reason at the top of this
+ * file: that module is the largest in the repo and its size ratchet only
+ * permits shrinking. It is re-exported from there so existing callers and tests
+ * are unaffected.
+ *
+ * The classifier exists so a non-technical operator is never sent to fix config
+ * that is already correct:
+ *
+ *  - REQUEST_TOO_LARGE  → context overflow; start a new thread.
+ *  - local host capacity held → wait; touching provider settings cannot help.
+ *  - No credential for ANY non-local provider → permanent config gap; point to setup.
+ *    MUST be checked before the threshold branch: a threshold skip layered on top of
+ *    a credential gap matches the threshold pattern but the real fix is "connect a
+ *    provider", not "wait for a rate-limit to clear" (BI-AUDIT-003).
+ *  - local bypassed for tool count + paid providers transiently down → rate-limit;
+ *    nothing is misconfigured.
+ *  - genuinely no tool-capable endpoint active → point to the REAL surface.
+ *  - anything else → say we do not know, and offer the check.
+ */
+export function describeToolRouteFailure(
+  errorMessage: string,
+  toolCount: number,
+  error?: unknown,
+): string {
+  const msg = errorMessage ?? "";
+
+  if (msg.startsWith("REQUEST_TOO_LARGE:")) {
+    return "Your conversation is too long for this AI provider. Please start a new thread to continue.";
+  }
+
+  // Checked early, and before the credential and threshold branches: a deferral
+  // is a host-capacity state, not a configuration one, and every branch below
+  // that names a settings surface would be wrong advice for it.
+  if (isLocalCapacityDeferral(error, msg)) {
+    return localCapacityHeldHandoff(/capacity-reservation-unavailable/i.test(msg));
+  }
+
+  // Local runner rejected the request because prompt + tool schemas exceed the
+  // model's served context window (e.g. Docker Model Runner HTTP 400
+  // exceed_context_size_error). This is DETERMINISTIC, not a transient rate-limit,
+  // so the "try again shortly" branches below would mislead — and a fresh thread
+  // alone won't help if the tool surface itself is too big. Point at the real
+  // levers (shorter input / fewer active tools / larger-context model).
+  if (/exceed_context_size|exceeds the available context size/i.test(msg)) {
+    return (
+      "That request was too large for the active AI model's context window — usually too many " +
+      "tools active at once, or a long conversation. Try a shorter message or start a new thread. " +
+      "If it keeps happening, this coworker has more tools active than the local model can hold and needs right-sizing."
+    );
+  }
+
+  // Permanent configuration gap: a non-local provider is in the chain but has no
+  // credential row. This is NOT transient — the operator must connect a provider.
+  // Check this BEFORE the threshold branch: when codex has no credential AND local
+  // is threshold-blocked, the threshold pattern matches but the user needs to
+  // configure a provider, not wait for a rate-limit.
+  if (/No credential for/i.test(msg)) {
+    return (
+      "No AI provider credentials are configured for this feature. " +
+      "Open Platform › AI Operations › Providers & Routing, connect a cloud provider " +
+      "(Claude, OpenAI, Google, or similar), then try again."
+    );
+  }
+
+  // Most common real cause: the bundled local model was bypassed because this
+  // coworker exposes more tools than a small local model can reliably handle,
+  // and no paid provider was available to take the work. This is NOT a
+  // misconfiguration, so do not point the operator at a settings page.
+  if (/exceeds threshold|skipped local fallback/i.test(msg)) {
+    // Prefer the exact count the router reported ("58 tools exceeds threshold");
+    // fall back to the tool count we were handed.
+    const reported = msg.match(/(\d+)\s+tools?\s+exceeds threshold/i);
+    const count = reported ? Number(reported[1]) : toolCount;
+    const tools = count > 0 ? `${count} of them` : "many";
+    return (
+      "Your paid AI providers (such as Claude or GPT) are briefly unavailable right now — " +
+      "usually a short rate-limit that clears within a minute — and this coworker uses too many " +
+      `tools (${tools}) for the bundled local model to run on its own. Nothing is misconfigured. ` +
+      "Please wait a moment and try again."
+    );
+  }
+
+  // Genuine config gap: routing found no active model that supports tools at all.
+  if (/No eligible endpoints/i.test(msg) && /toolUse/i.test(msg)) {
+    return (
+      "No AI model that supports tools is active right now. Open Platform > AI > " +
+      "Providers & Routing to activate a tool-capable provider, then try again."
+    );
+  }
+
+  const contextCapacityFailure = describeContextCapacityFailure(msg);
+  if (contextCapacityFailure) return contextCapacityFailure;
+
+  // Config/capacity gap: routing eliminated EVERY candidate (e.g. the cloud
+  // provider's sign-in expired AND the bundled local model's context window is
+  // too small for this coworker's larger requests). This reaches here as a plain
+  // "No eligible endpoints for task type '…'" with no `toolUse` token, so the
+  // branch above misses it.
+  if (/No eligible endpoints/i.test(msg)) {
+    return noEligibleModelHandoff();
+  }
+
+  // Endpoints exist but all transiently failed (rate-limit / overload / network).
+  if (/All endpoints failed/i.test(msg)) {
+    return providersBusyHandoff();
+  }
+
+  return unexplainedDeadEndHandoff();
 }


### PR DESCRIPTION
## What happened

A COO turn on the live install failed with

```
[agentic-loop] routeAndCall threw:
Local provider dispatch deferred: local-ci-active-capacity-reservation
```

and the owner was told *"I can't reach an AI provider at the moment"*, to open Providers & Routing, and that *"an expired sign-in or exhausted quota is the usual cause"*.

Every cloud provider was connected and healthy. The turn had been routed at `restricted` sensitivity, so none of them was eligible and the local model was the entire fallback chain. Reconnecting a provider could not have changed the outcome — the hand-off ended on a step that provably does nothing, which is a worse failure than the apology the rung replaced.

## Two causes, both here

**1. The deferral matched no branch.** `LocalProviderCapacityDeferredError` fell through to the catch-all. It is now classified explicitly, by error *name* rather than by importing routing internals into this module (BI-76651B7B), with a message fallback for a deferral that crossed a queue boundary. The reply is wait-shaped and names no settings surface, because none can clear it.

**2. The catch-all asserted a cause.** "An expired sign-in or exhausted quota is the usual cause" came from a population measurement — 114 of 196 dead ends, BI-33F1EA72 — applied as a diagnosis by a branch that, by construction, matched nothing. It now says plainly that the cause is not known from here, and offers the population prior as the first thing to **check** rather than as fact.

## Shape

`describeToolRouteFailure` moves to `inference-dead-ends.ts`, which exists for exactly this — `agentic-loop.ts` is the largest module in the repo and its size ratchet only permits shrinking. It shrinks 110 lines and re-exports the symbol, so callers and tests are unaffected. `providerUnreachableHandoff` is deleted rather than left dead.

## Verification

- 20 dead-end tests — 5 new for the deferral, 2 for the softened catch-all
- 147 tests across agentic-loop / escalation-ladder / inference-failure
- web typecheck, 50 preflight guards
- exact-tree local CI gate PASS @ `450c1505b80a`, evidence `cmt6bdr1305gi01pqv67jkvh4` (production build compiled)

## Design grounding

Kept the classifier's existing message-regex idiom and added a typed-name check alongside it, rather than threading a typed error through every `routeAndCall` caller. `dispatch-failure-class.ts` sets the precedent for name-based classification without a type dependency; followed it.

Substrate reviewed: `agentic-loop.ts`, `inference-dead-ends.ts`, `escalation-ladder.ts`, `routing/fallback.ts`, `routing/local-provider-capacity.ts`, `inference/dispatch-failure-class.ts`.

Part of `WC-9C828312`. Related: BI-463BE12A (why the turn was restricted at all), BI-94D44FDB (why local was held).

🤖 Generated with [Claude Code](https://claude.com/claude-code)