### PR TITLE
feat(skills): write down the rules the skill guards already enforce

### DIFF
--- a/packages/db/src/skill-authoring-practice.test.ts
+++ b/packages/db/src/skill-authoring-practice.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+import { parseFrontmatter } from "./seed-skills";
+
+// BI-SKILL-AUTHORING. The rules that govern the skill corpus were, until now,
+// enforced ONLY as failing guards — an author discovered them by tripping a
+// ratchet, never by reading anything. dpf-writing-skills is where they are
+// written down, so these assertions pin that the written rules and the
+// mechanical ones stay the same rules.
+const repoRoot = join(__dirname, "..", "..", "..");
+const practicePath = join(
+  repoRoot, "packages", "dpf-skill-pack", "skills", "dpf-writing-skills", "SKILL.md",
+);
+
+describe("dpf-writing-skills documents what the guards enforce", () => {
+  const raw = readFileSync(practicePath, "utf-8");
+  const { frontmatter, body } = parseFrontmatter(raw);
+
+  it("names the per-turn cap constant that makes an assignment expensive", () => {
+    expect(body).toContain("DEFAULT_SKILL_SUMMARY_CAP");
+  });
+
+  it("warns that a wildcard assignment charges every coworker", () => {
+    expect(body).toMatch(/SKILL_WILDCARD_AGENT_IDS/);
+    expect(body).toMatch(/\["\*"\]/);
+  });
+
+  it("tells the author the instruction plane is shrink-only", () => {
+    // The single most surprising failure for a new skill: it fails CI on
+    // arrival because the plane is already at its baseline.
+    expect(body).toContain("check-instruction-plane-size");
+    expect(body).toMatch(/shrink only|shrink-only/i);
+  });
+
+  it("states that a description is a trigger rather than documentation", () => {
+    expect(body).toMatch(/trigger, not documentation/i);
+  });
+
+  it("points at the substrate check before an existing skill is changed", () => {
+    // The BI-5E8E231E lesson: skills carry contracts invisible in the file.
+    expect(body).toContain("dpf-verify-substrate-first");
+    expect(body).toContain("BI-5E8E231E");
+  });
+
+  it("is itself assigned narrowly rather than to the wildcard it warns about", () => {
+    // A skill that teaches the cost model and then charges all 31 coworkers
+    // would be advice its own author did not take.
+    expect(frontmatter.assignTo).not.toContain("*");
+    expect(Array.isArray(frontmatter.assignTo)).toBe(true);
+  });
+});
+
+describe("the coworker-plane authoring skill routes to the practice", () => {
+  it("add-skill points at dpf-writing-skills and states the assignment cost", () => {
+    const addSkill = readFileSync(join(repoRoot, "skills", "universal", "add-skill.skill.md"), "utf-8");
+
+    expect(addSkill).toContain("dpf-writing-skills");
+    expect(addSkill).toMatch(/twelve per-turn skill slots|per-turn skill slots/);
+    expect(addSkill).toMatch(/all 31 coworkers/);
+  });
+});

--- a/packages/dpf-skill-pack/capability-packs.json
+++ b/packages/dpf-skill-pack/capability-packs.json
@@ -16,7 +16,8 @@
       "dpf-retrieve-decision-context",
       "dpf-compare-options",
       "dpf-ux-fit-review",
-      "dpf-capture-kernel-gap"
+      "dpf-capture-kernel-gap",
+      "dpf-writing-skills"
     ]
   },
   {
@@ -48,7 +49,8 @@
       "dpf-local-merge-ci-before-push",
       "dpf-record-decision-outcome",
       "dpf-blast-radius",
-      "dpf-unslop"
+      "dpf-unslop",
+      "dpf-writing-skills"
     ]
   },
   {

--- a/packages/dpf-skill-pack/skills/dpf-pr-with-dco/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-pr-with-dco/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-pr-with-dco
-description: "Use when ready to open a DPF pull request. Encodes the full DPF PR contract, including a fresh independent semantic-review receipt for the stable local commit before pregate/first publication, DCO, overlap sweep, exact-tree local CI, and a regular non-draft ready PR."
+description: "Use when ready to open a DPF pull request."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: false

--- a/packages/dpf-skill-pack/skills/dpf-route-learning-to-commons/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-route-learning-to-commons/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-route-learning-to-commons
-description: "Use in the DPF codebase at a task or session boundary when a finding has been confirmed and is durable. Classifies the learning (decision rule -> WWMD, durable org/platform fact -> WWWD, role technique -> WSID/skill, code contract -> repo+AGENTS.md), drafts the right entry, files it through the existing governed pipeline, and contributes it to the hive so every agent and every install inherits it."
+description: "Use in the DPF codebase at a task or session boundary when a finding has been confirmed and is durable."
 disable-model-invocation: false
 user-invocable: true
 allowed-tools: mcp__dpf__propose_improvement mcp__dpf__doc_save mcp__dpf__propose_skill_improvement mcp__dpf__create_backlog_item mcp__dpf__save_build_notes mcp__dpf__contribute_to_hive mcp__dpf__escalate_feedback_upstream mcp__dpf__flag_stale_knowledge

--- a/packages/dpf-skill-pack/skills/dpf-systematic-debugging/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-systematic-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dpf-systematic-debugging
-description: "Use when a DPF symptom needs a root cause — a failing build, a wedged runtime, a stuck job, wrong output. Runs a 4-phase root-cause process, DPF-adapted: gather live evidence before any hypothesis, check whether a peer session/worktree is already acting on the same substrate before declaring it broken, verify the substrate before declaring something missing, and prove the fix functionally (a structural pass is not verification)."
+description: "Use when a DPF symptom needs a root cause — a failing build, a wedged runtime, a stuck job, wrong output."
 
 # Agent Skills standard fields (Surface A — Claude Code)
 disable-model-invocation: false

--- a/packages/dpf-skill-pack/skills/dpf-writing-skills/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-writing-skills/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: dpf-writing-skills
+description: "Use when writing a new DPF skill, editing an existing SKILL.md or .skill.md, changing a skill's assignTo, description, or invocation flags, or reviewing a PR that touches the skill corpus. Every skill costs a per-turn slot on each coworker it is assigned to and permanent bytes in the always-on instruction plane, so it is a budget decision before it is a writing one."
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Read Edit Grep Glob Bash(node scripts/check-instruction-plane-size.mjs) Bash(git *)
+category: platform
+assignTo: ["documentation-specialist", "doc-specialist", "platform-engineer", "external-coding-agent", "build-specialist"]
+capability: null
+taskType: code_generation
+triggerPattern: "write a skill|new skill|edit a skill|skill description|assignTo|skill frontmatter|skill review|add a skill|change a skill|skill corpus|instruction plane"
+userInvocable: true
+agentInvocable: false
+allowedTools: ["Read", "Edit", "Grep", "Glob", "Bash"]
+composesFrom: ["dpf-verify-substrate-first", "dpf-unslop"]
+contextRequirements: ["the skill corpus on disk", "scripts/check-instruction-plane-size.mjs runnable"]
+riskBand: medium
+enforces:
+  - kernel/principles/architecture-over-shortcuts
+  - kernel/principles/single-source-of-truth
+---
+
+# DPF Writing Skills
+
+> **Why this skill is user-invocable only.** Writing or revising a skill is a
+> deliberate act, like `dpf-establish-coworker` or `dpf-add-archetype` — not
+> something to pull into an unrelated turn. Marking it `agentInvocable: false`
+> costs zero per-turn eligibility slots on the five roles it is assigned to.
+> A skill that teaches this cost model and then charged 5 slots for ambient
+> availability would be advice its own author did not take. Reach for it by
+> name, or let `skills/universal/add-skill.skill.md` route you here.
+
+A skill is not free text. Adding one, or widening one, spends two budgets that are already at their limits, and the platform enforces both mechanically. Write to the budget first and the prose second.
+
+Everything below was measured on the live install, not assumed. The numbers are current as of 2026-08-23; re-measure rather than trusting this page if the corpus has moved.
+
+## The two budgets
+
+**1. Per-turn eligibility.** `apps/web/lib/skills/skill-relevance.ts` sets `DEFAULT_SKILL_SUMMARY_CAP = 12`. Every skill assigned to a coworker injects its one-line summary into that coworker's system prompt on **every turn**; past 12, the relevance ranker silently drops the rest. So each `assignTo` entry spends one of twelve slots for that coworker, permanently.
+
+`assignTo: ["*"]` is not a convenience. `SKILL_WILDCARD_AGENT_IDS` expands it across **31 coworkers**, including personas that appear in no `assignTo` list at all — `dispatcher`, `finance-controller`, `security-engineer`, `legal-operations-counsel` and others carry the wildcard floor and almost nothing else. A single wildcard skill is 31 charges.
+
+This went wrong once already: 14 dev-agent pack skills carried `["*"]`, real eligible sets ran 16-32 against a cap of 12, and **28 of 31 coworkers were over** — a marketing-specialist was paying a per-turn tax for `dpf-tdd` (BI-4B0C27D4). After rescoping, 4 remain over, all dev-facing roles that legitimately hold that many dev skills.
+
+**2. Always-on bytes.** `scripts/instruction-plane-manifest.json` counts every pack skill's `name` + `description` in the always-on plane, and `scripts/check-instruction-plane-size.mjs` permits that total to **shrink only**. The plane sits at its baseline. A new pack skill therefore **fails CI on arrival** unless you recover the bytes first.
+
+Recovering them is not a chore to resent — it is the same discipline the description rule below describes, applied to skills that already shipped.
+
+## Description is a trigger, not documentation
+
+The only job of `description` is to make the right agent load the file at the right moment. It is read on every turn by every agent that could use the skill; the body is read only when the skill is actually invoked.
+
+So: pack the description with the words a caller would use, and put everything else in the body.
+
+| Belongs in `description` | Belongs in the body |
+|---|---|
+| When to reach for this, in the caller's vocabulary | How the procedure works |
+| Concrete triggers: surfaces, artifacts, symptoms | What it composes with (`composesFrom` already encodes this) |
+| The boundary — when NOT to use it | Lineage: "replaces the retired X", "the DPF-native step" |
+
+A clause that names another skill, describes internals, or explains provenance is costing always-on bytes on every turn to tell an agent something it does not need in order to decide. Ten such clauses were cut for 961 bytes in BI-21A0FE70; three more for 849 bytes to make room for this file.
+
+## Two planes, two size budgets
+
+| plane | path | typical body | audience |
+|---|---|---|---|
+| coworker | `skills/**/*.skill.md` | **~2 KB** | in-portal coworkers, often on a local model |
+| dev-agent pack | `packages/dpf-skill-pack/skills/*/SKILL.md` | ~8.7 KB | Claude / Codex / Grok / Antigravity sessions |
+
+Do not port a pack-sized procedure onto the coworker plane. Local priors in `packages/db/src/local-model-capabilities.ts` put Qwen at `contextRetention: 55` and Gemma at `45` — the weakest dimension in both. A long multi-phase skill on that tier is not followed and then abandoned; it is followed *partially*, silently, mid-procedure. Coworker-plane skills should be declarative and short.
+
+The same reasoning shapes content, not just length. Prefer a bounded generation task over a multi-turn planning task: numbered questions with candidate answers beat an adaptive interview, and a formatter with named slots beats "compose a good hand-off".
+
+## Both surfaces of a pack skill must agree
+
+A pack SKILL.md carries two invocation vocabularies:
+
+- **Surface A** — `disable-model-invocation`, `user-invocable`, `allowed-tools` (read by Claude Code / Codex / Grok)
+- **Surface B** — `agentInvocable`, `userInvocable`, `allowedTools` (read by the in-portal seed loader)
+
+`validateDpfPlatformSkillFrontmatter` rejects contradictions, and `normalizeSkillFrontmatterForSeed` derives `agentInvocable` from `disable-model-invocation` when it is absent. Set them deliberately and set them together. A skill only sensible on explicit invocation should say so — otherwise it competes for an eligibility slot on every unrelated turn. That field was uniform across 101 of 102 skills and therefore carried no information at all (BI-8AD9D018).
+
+## Before you change an existing skill
+
+Run `dpf-verify-substrate-first` against the skill you are about to touch, and specifically **grep the test suite for its name**. Skills carry contracts that are not visible in the file.
+
+`BI-5E8E231E` requires four decision skills — `dpf-decision-via-kernel`, `dpf-retrieve-decision-context`, `dpf-compare-options`, `dpf-record-decision-outcome` — to stay `assignTo: ["*"]` so every persona inherits the WWMD/WWWD stack. Rescoping them broke CI and had to be reverted, because the option set that decision was made from never mentioned the constraint. A kernel ruling is only as good as the facts the caller gathered before framing it.
+
+## Steps
+
+1. **Decide the plane and the audience.** Which coworkers or which dev surfaces genuinely need this? "Everyone" is an answer that costs 31 slots; make it deliberately or not at all.
+2. **Check the budget before writing.** `node scripts/check-instruction-plane-size.mjs`. If the plane is at baseline, recover bytes first — trim non-trigger clauses from existing descriptions and land that as part of the same change.
+3. **Search for overlap and for contracts.** Existing skill with the same trigger vocabulary? Existing test asserting this skill's frontmatter?
+4. **Write the description as a trigger.** Caller's words, concrete surfaces, the boundary. No lineage, no internals.
+5. **Write the body to the plane's budget**, declarative on the coworker plane.
+6. **Set both invocation surfaces deliberately**, and register the skill in `packages/dpf-skill-pack/capability-packs.json` if it belongs to a pack.
+7. **Run the guards before pushing** — the instruction-plane ratchet, `seed-skills.test.ts`, and `skill-relevance.test.ts`.
+8. **Apply `dpf-unslop`** to the description and body. This is text a person will read.
+
+## The guards that will fail you
+
+They are the contract, not an obstacle. Each exists because the rule above was broken once.
+
+| guard | fails when |
+|---|---|
+| `check-instruction-plane-size.mjs` | pack `name`+`description` bytes grow at all |
+| `seed-skills.test.ts` | a plane's invocation classification goes uniform; the two surfaces contradict |
+| `skill-relevance.test.ts` | the wildcard set grows past its baseline, exceeds half the cap, or any role's eligible set grows |
+| `check-prose-lint.ts` | authored copy readability regresses |
+
+## Guardrails
+
+- **Never widen `assignTo` to `["*"]` to avoid deciding.** It is the single most expensive edit available in this corpus.
+- **Never add a pack skill without first recovering description bytes.** The plane is frozen; the ratchet is not negotiable.
+- **Never lengthen a description to explain the skill.** If a reader needs it to understand the skill, it belongs in the body.
+- **Never demote a skill to `agentInvocable: false` merely to fit under the cap.** That hides the cost rather than deciding it; rescope `assignTo` instead.
+- **Re-measure rather than trusting the numbers on this page.** They were true on 2026-08-23 and the corpus moves.
+
+## See also
+
+- Substrate check before claiming a skill is missing: [`dpf-verify-substrate-first`](../dpf-verify-substrate-first/SKILL.md)
+- Editing the prose once the shape is right: [`dpf-unslop`](../dpf-unslop/SKILL.md)
+- The coworker-plane authoring flow: `skills/universal/add-skill.skill.md`

--- a/skills/universal/add-skill.skill.md
+++ b/skills/universal/add-skill.skill.md
@@ -28,12 +28,13 @@ Do not use this for one-off help; use the most relevant existing skill instead. 
 | Route context | PAGE DATA | Current route, coworker, category, and likely assignment |
 | Skill seed path | packages/db/src/seed-skills.ts | Supported frontmatter fields and assignment behavior |
 | DPF rules | AGENTS.md | Skills belong to coworkers, not routes; prompts live in seeded files |
+| Cost model | dpf-writing-skills (dpf-platform pack) | What an assignment and a description actually cost |
 
 ## Steps
 
 1. Ask what repeatable action the skill should perform if the user has not already said it.
 2. Search existing skills for overlap before creating a new one.
-3. Generate a unique kebab-case `name`, clear description, category, assignment, task type, trigger pattern, allowed tools, and risk band.
+3. Generate a unique kebab-case `name`, description, category, assignment, task type, trigger pattern, allowed tools, and risk band. Two rules carry most of the weight: the description's only job is to make the right coworker load the skill, so fill it with the words a caller would use and put explanation in the body; and every coworker in `assignTo` spends one of that coworker's twelve per-turn skill slots, so assign to the roles that will actually invoke it. Never use `["*"]` to avoid choosing — it charges all 31 coworkers.
 4. Confirm the definition when the action could affect data, permissions, or workflow authority.
 5. Create the `.skill.md` file with read-first sources, steps, output template, guidelines, and example.
 6. Name any route-context or seed follow-up required for the skill to appear in the UI.
@@ -54,6 +55,8 @@ Do not use this for one-off help; use the most relevant existing skill instead. 
 - Keep one skill to one repeatable procedure.
 - Include a routing boundary in the body: "Do not use this for X; use Y instead."
 - Do not grant tools casually; list only tools needed for the skill.
+- Keep a coworker-plane skill short and declarative — around 2 KB. These run on coworkers that may be on a local model, where a long multi-phase procedure is followed partially rather than refused.
+- For a dev-agent pack skill, or any change to an existing skill's description or assignment, use `dpf-writing-skills` first: those touch a frozen byte budget and a per-turn cap that CI enforces.
 
 ## Example
 


### PR DESCRIPTION
The rules governing this corpus existed **only as failing tests**. An author discovered them by tripping a ratchet, never by reading anything.

`skills/universal/add-skill.skill.md` — the skill that writes skills — said nothing about the per-turn cap, `assignTo` cost, wildcards, or the frozen description budget. Its step 3 asked for a *"clear description, category, assignment"* with no cost model at all.

That's the same "trigger a guard to learn the rule" pattern this session flagged elsewhere. Enforcement was already complete; the explanation was missing.

## What `dpf-writing-skills` says

Each rule is stated with the measurement it came from and paired with the guard that enforces it, so the written and the mechanical stay one thing:

- every `assignTo` entry spends one of a coworker's **twelve** per-turn slots, and `["*"]` expands across **31 coworkers** via `SKILL_WILDCARD_AGENT_IDS` — including personas that appear in no `assignTo` list and carry the wildcard floor and almost nothing else
- pack `name`+`description` bytes sit in a **shrink-only** always-on plane, so a new pack skill **fails CI on arrival** unless bytes are recovered first
- a description is a **trigger, not documentation** — read every turn by every eligible agent; the body only on invocation
- two planes, two budgets (~2 KB coworker, ~8.7 KB pack), and the coworker plane runs on models whose weakest dimension is context retention, so it stays declarative
- both invocation surfaces of a pack skill are set together
- skills carry contracts invisible in the file — grep the tests before changing `assignTo` (the BI-5E8E231E revert)

`add-skill.skill.md` now carries the two rules that matter most at coworker-plane length and routes here for anything touching the byte budget or an existing skill.

## The ratchet caught this PR's own skill

The first draft was `agentInvocable: true`, which pushed `build-specialist` 29→30 and `platform-engineer` 32→33. The guard refused it and forced exactly the decision the skill teaches — rescope or justify, never quietly raise the number.

The right answer: writing a skill is a **deliberate** act, like `dpf-establish-coworker` or `dpf-add-archetype`. User-invocable only, costing **zero** eligibility slots on the five roles it's assigned to. A skill that teaches this cost model and then charged five slots for ambient availability would be advice its own author did not take — and a test asserts it is not assigned to the wildcard it warns about.

## Budget

849 bytes recovered by trimming three trailing description clauses carrying mechanism rather than trigger vocabulary (`dpf-systematic-debugging`, `dpf-route-learning-to-commons`, `dpf-pr-with-dco`). Final: **37,709 of a 38,501 baseline, no re-baseline**, 37 skills.

## Evidence

- pregate **PASS** on `48a5de1681a9`
- preflight **50 guards clean**
- `packages/db` skill suites 36 passed · `apps/web/lib/skills` 91 passed · process-spine health 7 passed · `tsc` clean
- New `skill-authoring-practice.test.ts` pins that the documented rules and the enforced rules stay the same rules

## Worth pressing on

1. The numbers in the skill are dated 2026-08-23 and the skill says to re-measure rather than trust them. If the corpus moves substantially they become stale guidance, which is the failure mode of every written rule — the paired guards are what keep it honest.
2. Five assigned roles is a judgement about who authors skills. `build-specialist` was dropped from an earlier draft on the grounds that it builds features rather than authoring skills; reasonable people could disagree.
3. This documents rather than enforces. If a rule here proves to matter and has no guard behind it, the guard is the follow-up, not more prose.

Follow-up to BI-4B0C27D4 and BI-8AD9D018.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)