### PR TITLE
fix(ux-budget): withdraw the admin/builder reading-tier exception, its premise having been withdrawn (BI-0ED0F6B3)

### DIFF
--- a/apps/web/lib/ux-budget/budgets.ts
+++ b/apps/web/lib/ux-budget/budgets.ts
@@ -180,49 +180,37 @@ export const UX_BUDGETS: Record<UxShell, UxBudget> = {
   },
 };
 
-// ── Audience-aware reading tier (BI-1DE6F69E) ────────────────────────────────
+// ── Audience-aware reading tier: WITHDRAWN (BI-1DE6F69E → BI-0ED0F6B3) ──────
 //
-// The shell table above sets one reading tier per SHELL. That conflated two
-// different questions — what kind of surface this is, and who reads it — and the
-// result contradicted the platform's own readability policy
-// (`packages/validators/src/readability.ts`), which states: marketing/external and
-// business copy -> high school; reseller/partner -> college; architecture and
-// standards -> uncapped, "precision over simplicity".
+// This table used to re-tier `admin` and `builder` to `college` (grade 13). Its
+// justification, measured on 2026-07-31, was that EVERY /admin route failed the
+// high-school cap — /admin/archetypes 57.9, /admin/business-models 29.4,
+// /admin/data-stewardship 18.6, /admin 15.4, /admin/cockpit 12.5 — and that the
+// first NET-NEW admin route, /admin/graph-explorer, blocked at 11.0 despite being
+// the plainest admin surface in the family. A bar that only the newest route must
+// clear, and that the plainest surface cannot, is measuring the wrong thing.
 //
-// Measured consequence, from the route-budget report on 2026-07-31: EVERY /admin
-// route failed `reading-level` against the high-school cap of 9 — /admin/archetypes
-// 57.9, /admin/business-models 29.4, /admin/data-stewardship 18.6, /admin 15.4,
-// down to /admin/cockpit 12.5. They passed only because a pre-existing route gets
-// the finding as advisory, so the bar was never actually enforced anywhere. The
-// first NET-NEW admin route (/admin/graph-explorer, BI-89A149A9) measured 11.0 —
-// the lowest grade of any admin surface — and blocked, because a net-new route
-// loses the exemption. A bar that only the newest route must clear, and that the
-// plainest surface in the family cannot, is measuring the wrong thing.
+// It was. Those numbers were produced by counting full stops, not difficulty
+// (BI-0ED0F6B3): the grade was computed over the whole page flattened to one
+// string, so a screen of unpunctuated labels collapsed into a single enormous
+// "sentence". With the measure corrected, every route in that justification passes
+// at grade 9 — /admin/graph-explorer 3.4, /admin/cockpit 6.4, /admin 8.2,
+// /admin/data-stewardship 6.5, /admin/business-models 8.4 — and the sole net-new
+// route in the confirming sweep measures 8.5.
 //
-// The cause is structural, not editorial: the grade is computed over the whole
-// rendered page including shared shell chrome, and operator vocabulary an admin
-// surface cannot avoid — "Infrastructure", "Architecture", "Configuration",
-// "Diagnostics" — is polysyllabic by nature, which Flesch–Kincaid punishes
-// regardless of sentence craft.
+// The premise having been withdrawn, so is the exception. Every audience is held
+// to its shell's tier, which is what the hide-complexity-from-layman-users
+// doctrine asked for in the first place. 53 of 99 formerly-college routes still
+// read above 9 on genuine operator vocabulary; those are now visible advisory
+// findings on pre-existing routes rather than a bar quietly lowered to meet them.
 //
-// So the tier now resolves from the route's AUDIENCE as well as its shell.
-// Deliberately `college` (grade 13) rather than `uncapped`: uncapped would remove
-// the check entirely, and nine of the twelve admin routes above still fail at 13.
-// That debt stays visible as advisory findings rather than being papered over —
-// this re-tiers the bar to the honest audience, it does not delete it.
+// Evidence: sweep runs 32625564367 (before) and 32661659842 (after).
+// Decision ledger: DI-710B4860812F.
 
-/**
- * Reading tier by route audience, where it differs from the shell default.
- *
- * `admin` and `builder` are operator/architecture surfaces in the sense the
- * readability policy means. Every other audience — `owner`, `worker`, `customer`,
- * `public`, `auth-setup` — keeps the shell default, because the platform's
- * hide-complexity-from-layman-users doctrine applies to them in full.
- */
-export const AUDIENCE_READING_LEVELS: Partial<Record<RouteAudience, ReadingLevel>> = {
-  admin: "college",
-  builder: "college",
-};
+/** Reading tier by route audience. Empty: no audience currently overrides its
+ *  shell's tier. Kept as the seam, so a future exception is a data change with a
+ *  measured justification rather than a rewrite of `readingLevelFor`. */
+export const AUDIENCE_READING_LEVELS: Partial<Record<RouteAudience, ReadingLevel>> = {};
 
 /** Permissiveness order. Later entries tolerate a higher grade. */
 const READING_LEVEL_ORDER: readonly ReadingLevel[] = ["high-school", "college", "uncapped"];

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -8,6 +8,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  AUDIENCE_READING_LEVELS,
   auditUxBudget,
   budgetFor,
   countDisclosureRegions,
@@ -223,18 +224,23 @@ describe("budget axes", () => {
   });
 });
 
-describe("reading tier resolves from audience, not shell alone (BI-1DE6F69E)", () => {
+describe("reading tier resolves from audience and shell (BI-1DE6F69E, BI-0ED0F6B3)", () => {
   it("keeps the shell default for every audience without an override", () => {
-    for (const audience of ["owner", "worker", "customer", "public", "auth-setup"] as const) {
+    for (const audience of ["owner", "worker", "customer", "public", "auth-setup", "admin", "builder"] as const) {
       expect(readingLevelFor("detail", audience)).toBe("high-school");
       expect(readingLevelFor("cockpit", audience)).toBe("high-school");
     }
   });
 
-  it("gives operator surfaces the college tier the readability policy specifies", () => {
-    expect(readingLevelFor("detail", "admin")).toBe("college");
-    expect(readingLevelFor("list", "admin")).toBe("college");
-    expect(readingLevelFor("detail", "builder")).toBe("college");
+  it("holds operator surfaces to the strict tier, the re-tier having been withdrawn", () => {
+    // BI-1DE6F69E loosened admin/builder to college because EVERY /admin route
+    // failed at 9. Those grades were produced by counting full stops, not
+    // difficulty (BI-0ED0F6B3); corrected, /admin/graph-explorer reads 3.4 and
+    // /admin 8.2. The premise is withdrawn, so the exception is too.
+    expect(AUDIENCE_READING_LEVELS).toEqual({});
+    expect(readingLevelFor("detail", "admin")).toBe("high-school");
+    expect(readingLevelFor("list", "admin")).toBe("high-school");
+    expect(readingLevelFor("detail", "builder")).toBe("high-school");
   });
 
   it("falls back to the shell default when no audience is supplied", () => {
@@ -250,15 +256,16 @@ describe("reading tier resolves from audience, not shell alone (BI-1DE6F69E)", (
     expect(readingLevelFor("unclassified", "admin")).toBe("college");
   });
 
-  it("re-tiers the bar without deleting it — an operator surface still has a cap", () => {
-    // The whole point: 11.0 (the plainest admin surface measured) passes, but the
-    // family's real debt — 15.4, 18.6, 29.4, 57.9 — still fails.
+  it("holds an operator surface to grade 9, which the corrected measure lets it clear", () => {
+    // The measured admin family after BI-0ED0F6B3: graph-explorer 3.4, cockpit
+    // 6.4, data-stewardship 6.5, business-models 8.4, /admin 8.2 — all pass. The
+    // family's remaining debt (archetypes 14.9) is a visible advisory finding.
     const budget = budgetFor("detail", "admin");
-    expect(budget.readingLevel).toBe("college");
-    expect(meetsReadingLevel({ readingGradeLevel: 11 } as never, budget.readingLevel)).toBe(true);
-    expect(meetsReadingLevel({ readingGradeLevel: 13 } as never, budget.readingLevel)).toBe(true);
-    expect(meetsReadingLevel({ readingGradeLevel: 15.4 } as never, budget.readingLevel)).toBe(false);
-    expect(meetsReadingLevel({ readingGradeLevel: 57.9 } as never, budget.readingLevel)).toBe(false);
+    expect(budget.readingLevel).toBe("high-school");
+    for (const grade of [3.4, 6.4, 6.5, 8.2, 8.4]) {
+      expect(meetsReadingLevel({ readingGradeLevel: grade } as never, budget.readingLevel)).toBe(true);
+    }
+    expect(meetsReadingLevel({ readingGradeLevel: 14.9 } as never, budget.readingLevel)).toBe(false);
   });
 
   it("does not loosen a customer-facing surface", () => {

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -462,7 +462,9 @@ are part of what the owner meets on arrival.
   copy with `analyzeUtteranceReadability` against the tier in
   `apps/web/lib/ux-budget/budgets.ts`. Advisory on pre-existing routes, blocking on
   net-new ones. It is an absolute check, not a ratcheted axis, so it carries no entry
-  in `route-budget-baseline.json`.
+  in `route-budget-baseline.json`. **Every audience is held to its shell's tier** —
+  the admin/builder college exception was withdrawn once the corrected measure showed
+  every route that justified it clearing grade 9 (`/admin/graph-explorer` 11.1 → 3.4).
 - **Operator visibility (planned):** showing the live Flesch–Kincaid score to the operator while they edit marketing/storefront copy, the way a word processor does. The shared scorer (`@dpf/validators`) is ready; surfacing it in the copy editor is the remaining step.
 
 ### Coworker rule


### PR DESCRIPTION
Follow-on to #4604, which fixed the UX reading-level measure (BI-0ED0F6B3). This
withdraws the exception that the broken measure had justified.

## Why the exception existed

`AUDIENCE_READING_LEVELS` loosened `admin` and `builder` from high-school (grade 9)
to college (13). Its recorded justification, measured 2026-07-31: **every** /admin
route failed the high-school cap — `/admin/archetypes` 57.9, `/admin/business-models`
29.4, `/admin/data-stewardship` 18.6, `/admin` 15.4, `/admin/cockpit` 12.5 — and the
first **net-new** admin route, `/admin/graph-explorer`, blocked at 11.0 despite being
the plainest surface in the family. As the comment put it, a bar that only the newest
route must clear, and that the plainest surface cannot, is measuring the wrong thing.

That reasoning was sound about a number that was wrong.

## Why it goes

Those grades came from counting full stops, not difficulty. #4604 corrected the
measure. Every route named in the justification now passes at grade 9:

| route | before | after |
|---|---|---|
| `/admin/graph-explorer` — the net-new route that blocked | 11.1 | **3.4** |
| `/admin/cockpit` | 12.6 | **6.4** |
| `/admin` | 13.2 | **8.2** |
| `/admin/data-stewardship` | 18.7 | **6.5** |
| `/admin/business-models` | 29.5 | **8.4** |

The sole net-new route in the confirming sweep measures 8.5. The premise is
withdrawn, so the exception is too, and the hide-complexity-from-layman-users
doctrine holds for every audience — which is what the readability policy asked for
in the first place.

## What it costs, stated plainly

53 of 99 formerly-college routes still read above 9, on operator vocabulary an admin
console cannot avoid (`Authorization`, `Federation`, `Principals`; median 9.3, max
15.4). All are pre-existing, so `reading-level` is **advisory** on them — they become
visible findings rather than a bar quietly lowered to meet them. A future net-new
admin route must clear grade 9, which the newest one (3.4) does comfortably.

The table stays as an empty seam, so a future exception is a data change with a
measured justification rather than a rewrite of `readingLevelFor`.

## Evidence

- Sweep runs 32625564367 (before) and 32661659842 (after), 201 routes each
- `principle_decide`: recommends restoring the strict tier — high confidence, margin
  2.07, no commandment conflict. Ledger `DI-710B4860812F`. Operator-confirmed.
- local-CI gate PASS on `f7d7f8f0b011` (evidence `cmt6bqara073401pq6stb0ed3`)
- `apps/web` ux-budget / owner-first / business-journeys — 225 tests pass

Refs: BI-0ED0F6B3

Process-Spine-Decision: docs/platform-usability-standards.md updated in this PR.
