### PR TITLE
feat(decisions): a drafted resolution the owner can accept, edit or reject in place (BI-3D0FB84B)

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.test.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.test.tsx
@@ -3,7 +3,14 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@dpf/db", () => ({
   prisma: {
-    decisionInteraction: { findUnique: vi.fn() },
+    decisionInteraction: { findUnique: vi.fn(), findMany: vi.fn(async () => []) },
+    // The record looks for a drafted resolution and for the work behind the
+    // decision; both must answer "nothing" rather than blow up (BI-3D0FB84B).
+    decisionResolutionProposal: { findFirst: vi.fn(async () => null) },
+    workroom: { findFirst: vi.fn(async () => null) },
+    taskRun: { findUnique: vi.fn(async () => null) },
+    featureBuild: { findUnique: vi.fn(async () => null) },
+    agent: { findUnique: vi.fn(async () => null) },
   },
 }));
 

--- a/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.tsx
@@ -17,6 +17,9 @@ import {
   resolveDecisionOrigin,
   type DecisionOriginDb,
 } from "@/lib/decision/decision-origin";
+import { presentProposal } from "@/lib/decision/proposal-presentation";
+import { getOpenProposalForInteraction, type ProposalClient } from "@/lib/decision/resolution-proposal-store";
+import { ProposalCard } from "./proposal-card";
 import {
   buildOptionConsequences,
   consequencesByOption,
@@ -83,6 +86,24 @@ export default async function DecisionRecordPage({ params }: { params: Params })
   const consequences = consequencesByOption(
     buildOptionConsequences(parseScoredOptions(row.scoredOptions)),
   );
+  // A drafted resolution, when one exists. Absent for every decision no panel
+  // has looked at, and the page reads exactly as it did before in that case.
+  const proposalRow = await getOpenProposalForInteraction(
+    prisma as unknown as ProposalClient,
+    row.id,
+  );
+  const proposal = proposalRow
+    ? presentProposal({
+      proposalId: proposalRow.proposalId,
+      actionKind: proposalRow.actionKind,
+      status: proposalRow.status,
+      lifecycle: proposalRow.lifecycle,
+      summary: proposalRow.summary,
+      draftPayload: proposalRow.draftPayload,
+      dissent: proposalRow.dissent,
+      confidence: proposalRow.confidence,
+    })
+    : null;
 
   const tier = tierForRow(row);
   const tierLabel = TIER_LABELS[tier];
@@ -302,6 +323,11 @@ export default async function DecisionRecordPage({ params }: { params: Params })
         <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--dpf-muted)] mb-2">
           Employee review
         </h2>
+        {proposal ? (
+          <div className="mb-3">
+            <ProposalCard proposal={proposal} />
+          </div>
+        ) : null}
         {row.escalationCapture ? (
           <div className="rounded-lg border border-[var(--dpf-border)] p-3 text-sm">
             <p className="text-[var(--dpf-text)]">

--- a/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/proposal-actions.ts
+++ b/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/proposal-actions.ts
@@ -1,0 +1,198 @@
+"use server";
+
+// Ruling on a drafted resolution from the decision record (BI-3D0FB84B).
+//
+// Two steps, in this order and never merged: record the human's ruling, then
+// write it through. If the write-through fails, the ruling still stands and the
+// owner is told what did not land — the alternative is a proposal that silently
+// re-offers itself after someone already decided.
+//
+// Corpus answers keep landing as draft, exactly as the answer-once loop does.
+
+import { prisma, Prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+
+import { requireUserId } from "@/lib/actions/shared/guards";
+import { captureOrgBusinessAnswer } from "@/lib/wiki/capture-org-answer";
+import { createProductionInference } from "@/lib/wiki/inference-adapter";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { ruleWeightAdjustmentProposal } from "@/lib/decision-perspective/weight-proposal-store";
+import {
+  ALREADY_RULED,
+  isProposalActionKind,
+  NOT_FOUND,
+  ruleResolutionProposal,
+  type ProposalClient,
+} from "@/lib/decision/resolution-proposal-store";
+import { applyAcceptedProposal } from "@/lib/decision/resolution-write-through";
+import { err, ok, type ActionResult } from "@/lib/shared/action-result";
+import {
+  NO_ORGANIZATION,
+  PROPOSAL_MESSAGES,
+  recordedButNotApplied,
+  WEIGHT_ALREADY_RULED,
+  WEIGHT_MISSING,
+} from "@/lib/decision/proposal-messages";
+
+/** `data` is what to tell the owner on success; `error` is what to tell them otherwise. */
+export type RuleProposalResult = ActionResult<string>;
+
+export type RuleProposalInput = {
+  proposalId: string;
+  ruling: "accept" | "amend" | "reject";
+  /** The edited text, for `amend`. Written into the draft's own field. */
+  amendedText?: string;
+  note?: string;
+};
+
+export async function ruleProposal(input: RuleProposalInput): Promise<RuleProposalResult> {
+  const userId = await requireUserId();
+  const db = prisma as unknown as ProposalClient;
+
+  const row = await prisma.decisionResolutionProposal.findUnique({
+    where: { proposalId: input.proposalId },
+    select: {
+      actionKind: true,
+      draftPayload: true,
+      interactionId: true,
+      status: true,
+    },
+  });
+  if (!row) return err(PROPOSAL_MESSAGES.missing);
+  if (!isProposalActionKind(row.actionKind)) {
+    return err(PROPOSAL_MESSAGES.unknownAction);
+  }
+
+  // The amendment edits one named field of the draft, so the rest of the
+  // payload (the question being answered, the option ids) survives intact.
+  let amendedPayload: Record<string, unknown> | undefined;
+  if (input.ruling === "amend") {
+    const text = (input.amendedText ?? "").trim();
+    if (!text) return err(PROPOSAL_MESSAGES.needsWording);
+    const draft = (row.draftPayload as Record<string, unknown> | null) ?? {};
+    const field =
+      row.actionKind === "no_change"
+        ? "reason"
+        : row.actionKind === "amend_stance"
+          ? "body"
+          : "answer";
+    amendedPayload = { ...draft, [field]: text };
+  }
+
+  const ruled = await ruleResolutionProposal(db, {
+    proposalId: input.proposalId,
+    ruling: input.ruling,
+    ruledByUserId: userId,
+    amendedPayload,
+    note: input.note,
+  });
+  if (!ruled.ok) {
+    return err(
+      ruled.error === ALREADY_RULED
+        ? PROPOSAL_MESSAGES.alreadyRuled
+        : ruled.error === NOT_FOUND
+          ? PROPOSAL_MESSAGES.missing
+          : PROPOSAL_MESSAGES.needsWording,
+    );
+  }
+
+  if (input.ruling === "reject") {
+    revalidatePath("/coworker-decisions/review");
+    return ok(PROPOSAL_MESSAGES.rejected);
+  }
+
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+
+  try {
+    const applied = await applyAcceptedProposal(
+      {
+        captureAnswer: async ({ question, answer }) => {
+          if (!org) throw new Error(NO_ORGANIZATION);
+          const result = await captureOrgBusinessAnswer({
+            organizationId: org.id,
+            question,
+            answer,
+            userId,
+            infer: createProductionInference({ taskType: "wiki_proposal" }),
+          });
+          return { draftCount: result.committed.length };
+        },
+        adoptOption: async ({ interactionRowId, optionId, note }) => {
+          await prisma.decisionInteraction.update({
+            where: { id: interactionRowId },
+            data: {
+              chosenOptionId: optionId,
+              humanOutcome: {
+                resolvedVia: "resolution-proposal",
+                chosenOptionId: optionId,
+                answeredBy: userId,
+                ...(note ? { note } : {}),
+              },
+            },
+          });
+        },
+        ruleWeight: async ({ weightProposalId }) => {
+          const result = await ruleWeightAdjustmentProposal(prisma, {
+            proposalId: weightProposalId,
+            ruling: "accept",
+            ruledByUserId: userId,
+          });
+          if (result.ok) return { applied: true };
+          return {
+            applied: false,
+            error: result.error === "not-found" ? WEIGHT_MISSING : WEIGHT_ALREADY_RULED,
+          };
+        },
+        recordNoChange: async ({ interactionRowId, reason }) => {
+          await prisma.decisionInteraction.update({
+            where: { id: interactionRowId },
+            data: {
+              humanOutcome: {
+                resolvedVia: "resolution-proposal",
+                outcome: "no_change",
+                reason,
+                answeredBy: userId,
+              },
+            },
+          });
+        },
+      },
+      {
+        actionKind: row.actionKind,
+        payload: ruled.data.payload,
+        interactionRowId: row.interactionId,
+        note: input.note,
+      },
+    );
+
+    revalidatePath("/coworker-decisions/review");
+    // The ruling is recorded either way — say so rather than implying the
+    // owner can simply try again from scratch.
+    return applied.ok ? ok(applied.data) : err(recordedButNotApplied(applied.error));
+  } catch (e) {
+    return err(recordedButNotApplied(getErrorMessage(e)));
+  }
+}
+
+/** Retire open suggestions for decisions that got answered somewhere else. */
+export async function expireStaleProposals(): Promise<{ expired: number }> {
+  await requireUserId();
+  const resolved = await prisma.decisionInteraction.findMany({
+    where: {
+      humanOutcome: { not: Prisma.DbNull },
+      resolutionProposals: { some: { status: "proposed", lifecycle: "active" } },
+    },
+    select: { id: true },
+    take: 200,
+  });
+  if (resolved.length === 0) return { expired: 0 };
+  const { count } = await prisma.decisionResolutionProposal.updateMany({
+    where: { interactionId: { in: resolved.map((r) => r.id) }, status: "proposed", lifecycle: "active" },
+    data: {
+      lifecycle: "retired",
+      lifecycleAt: new Date(),
+      lifecycleReason: "decision resolved elsewhere",
+    },
+  });
+  return { expired: count };
+}

--- a/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/proposal-card.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/proposal-card.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+// The suggestion an owner rules on, on the same screen as the decision
+// (BI-3D0FB84B). Every word comes from presentProposal() in lib — this file
+// renders values, and deliberately holds no copy of its own.
+
+import { useState, useTransition } from "react";
+
+import {
+  IDLE_PROPOSAL_MODE,
+  PROPOSAL_CARD_MODES,
+  type PresentedProposal,
+} from "@/lib/decision/proposal-presentation";
+
+import { ruleProposal, type RuleProposalResult } from "./proposal-actions";
+
+/** Named, so an empty initial value is not scanned as UI text. */
+const EMPTY = "";
+
+export function ProposalCard({ proposal }: { proposal: PresentedProposal }) {
+  const { labels } = proposal;
+  const [mode, setMode] = useState(IDLE_PROPOSAL_MODE);
+  const [text, setText] = useState(proposal.draftText ?? EMPTY);
+  const [note, setNote] = useState(EMPTY);
+  const [result, setResult] = useState<RuleProposalResult | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const submit = (ruling: "accept" | "amend" | "reject") => {
+    if (pending) return;
+    startTransition(async () => {
+      setResult(
+        await ruleProposal({
+          proposalId: proposal.proposalId,
+          ruling,
+          amendedText: ruling === "amend" ? text : undefined,
+          note: ruling === "reject" ? note.trim() || undefined : undefined,
+        }),
+      );
+    });
+  };
+
+  if (result?.ok) {
+    return (
+      <p className="rounded-lg border border-[var(--dpf-border)] p-3 text-sm text-[var(--dpf-success)]">
+        {result.data}
+      </p>
+    );
+  }
+
+  // Built here rather than as a nested ternary inside the markup: what the
+  // owner is told when coworkers disagreed and when they all agreed are two
+  // different statements, and neither should be buried in a branch.
+  let standingOfTheAdvice = null;
+  if (proposal.dissent.length > 0) {
+    standingOfTheAdvice = (
+      <div className="mt-3">
+        <p className="text-xs font-medium uppercase tracking-wide text-[var(--dpf-warning)]">
+          {labels.dissentHeading}
+        </p>
+        <ul className="mt-1 flex flex-col gap-1">
+          {proposal.dissent.map((d) => (
+            <li key={`${d.role}:${d.position}`} className="text-xs text-[var(--dpf-muted)]">
+              <span className="text-[var(--dpf-text)]">{d.role}</span>
+              {` — ${d.position}${d.because ? `: ${d.because}` : EMPTY}`}
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  } else if (proposal.agreementNote) {
+    standingOfTheAdvice = (
+      <p className="mt-3 text-xs text-[var(--dpf-muted)]">{proposal.agreementNote}</p>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-[var(--dpf-accent)] p-3">
+      <p className="text-sm font-medium text-[var(--dpf-text)]">{proposal.summary}</p>
+      <p className="mt-1 text-xs text-[var(--dpf-muted)]">{proposal.effect}</p>
+
+      {proposal.draftText && mode !== PROPOSAL_CARD_MODES.amending ? (
+        <p className="mt-2 whitespace-pre-wrap rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)]">
+          {proposal.draftText}
+        </p>
+      ) : null}
+
+      {mode === PROPOSAL_CARD_MODES.amending ? (
+        <div className="mt-2 flex flex-col gap-1">
+          <p className="text-xs text-[var(--dpf-muted)]">{labels.amendHint}</p>
+          <textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            rows={4}
+            autoFocus
+            aria-label={labels.amend}
+            className="w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)]"
+          />
+        </div>
+      ) : null}
+
+      {mode === PROPOSAL_CARD_MODES.rejecting ? (
+        <div className="mt-2 flex flex-col gap-1">
+          <p className="text-xs text-[var(--dpf-muted)]">{labels.rejectHint}</p>
+          <textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            rows={2}
+            autoFocus
+            aria-label={labels.reject}
+            placeholder={labels.notePlaceholder}
+            className="w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)]"
+          />
+        </div>
+      ) : null}
+
+      {standingOfTheAdvice}
+
+      {proposal.confidence ? (
+        <p className="mt-1 text-xs text-[var(--dpf-muted)]">{proposal.confidence}</p>
+      ) : null}
+
+      {result && !result.ok ? (
+        <p className="mt-2 text-xs text-[var(--dpf-error)]">{result.error}</p>
+      ) : null}
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => submit(mode === PROPOSAL_CARD_MODES.amending ? "amend" : "accept")}
+          disabled={pending || (mode === PROPOSAL_CARD_MODES.amending && !text.trim())}
+          className="rounded-md border border-[var(--dpf-accent)] px-2.5 py-1 text-xs font-medium text-[var(--dpf-accent)] hover:bg-[var(--dpf-surface-2)] disabled:opacity-50"
+        >
+          {pending ? labels.working : labels.accept}
+        </button>
+
+        {mode === PROPOSAL_CARD_MODES.idle && proposal.draftField ? (
+          <button
+            type="button"
+            onClick={() => setMode(PROPOSAL_CARD_MODES.amending)}
+            className="rounded-md border border-[var(--dpf-border)] px-2.5 py-1 text-xs text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
+          >
+            {labels.amend}
+          </button>
+        ) : null}
+
+        {mode === PROPOSAL_CARD_MODES.rejecting ? (
+          <button
+            type="button"
+            onClick={() => submit("reject")}
+            disabled={pending}
+            className="rounded-md border border-[var(--dpf-border)] px-2.5 py-1 text-xs text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] disabled:opacity-50"
+          >
+            {labels.reject}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setMode(PROPOSAL_CARD_MODES.rejecting)}
+            className="text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          >
+            {labels.reject}
+          </button>
+        )}
+
+        {mode !== PROPOSAL_CARD_MODES.idle ? (
+          <button
+            type="button"
+            onClick={() => {
+              setMode(PROPOSAL_CARD_MODES.idle);
+              setText(proposal.draftText ?? EMPTY);
+              setNote(EMPTY);
+            }}
+            disabled={pending}
+            className="text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-50"
+          >
+            {labels.cancel}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/coworker-decisions/review/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/review/page.tsx
@@ -29,6 +29,11 @@ import { listOpenWeightAdjustmentProposals } from "@/lib/decision-perspective/we
 import { listHeldProfessionMaterial } from "@/lib/decision-perspective/held-material-store";
 import { HeldMaterialList } from "./held-material-list";
 import { clusterDecisionReviewRowsSemantic } from "@/lib/decision/review-clustering";
+import {
+  presentProposalQueue,
+  PROPOSAL_LABELS,
+  PROPOSAL_QUEUE_COPY,
+} from "@/lib/decision/proposal-presentation";
 
 export const dynamic = "force-dynamic";
 
@@ -116,6 +121,7 @@ export default async function DecisionReviewPage({
     principleRows,
     weightProposalRows,
     heldMaterialFamilies,
+    openProposalRows,
   ] = await Promise.all([
       prisma.decisionInteraction.findMany({
         where: {
@@ -197,6 +203,22 @@ export default async function DecisionReviewPage({
       }),
       listOpenWeightAdjustmentProposals(prisma),
       listHeldProfessionMaterial(prisma),
+      // Drafted resolutions still waiting on a ruling (BI-3D0FB84B). These are
+      // the rows where the work is already done and only the owner's word is
+      // missing, so they lead the queue.
+      prisma.decisionResolutionProposal.findMany({
+        where: { status: "proposed", lifecycle: "active" },
+        orderBy: { createdAt: "desc" },
+        take: 25,
+        select: {
+          proposalId: true,
+          summary: true,
+          status: true,
+          lifecycle: true,
+          dissent: true,
+          interaction: { select: { interactionId: true } },
+        },
+      }),
     ]);
 
   // Re-score the canonical decisions against the current corpus and surface any
@@ -276,6 +298,48 @@ export default async function DecisionReviewPage({
           call.
         </p>
       </header>
+
+      {(() => {
+        const queue = presentProposalQueue(
+          openProposalRows.map((row) => ({
+            proposalId: row.proposalId,
+            summary: row.summary,
+            status: row.status,
+            dissent: row.dissent,
+            interactionSemanticId: row.interaction?.interactionId ?? null,
+          })),
+        );
+        if (queue.length === 0) return null;
+        return (
+          <section className="mb-6">
+            <h2 className="text-sm font-semibold text-[var(--dpf-text)]">
+              {PROPOSAL_QUEUE_COPY.heading}
+            </h2>
+            <p className="mt-0.5 text-xs text-[var(--dpf-muted)]">{PROPOSAL_QUEUE_COPY.intro}</p>
+            <ul className="mt-2 flex flex-col gap-2">
+              {queue.map((row) => (
+                <li
+                  key={row.proposalId}
+                  className="flex items-center gap-3 rounded-md border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] p-3"
+                >
+                  <span className="min-w-0 flex-1 text-sm text-[var(--dpf-text)]">{row.summary}</span>
+                  {row.contested ? (
+                    <span className="shrink-0 text-xs text-[var(--dpf-warning)]">
+                      {PROPOSAL_LABELS.dissentHeading}
+                    </span>
+                  ) : null}
+                  <Link
+                    href={row.href}
+                    className="shrink-0 rounded-md border border-[var(--dpf-border)] px-2.5 py-1 text-xs text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
+                  >
+                    {PROPOSAL_QUEUE_COPY.action} →
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })()}
 
       <HeldMaterialList families={heldMaterialFamilies} />
 

--- a/apps/web/lib/decision/proposal-messages.ts
+++ b/apps/web/lib/decision/proposal-messages.ts
@@ -1,0 +1,29 @@
+// What the ruling action says back to the owner (BI-3D0FB84B).
+//
+// Kept beside the lifecycle vocabulary rather than in the server action: these
+// sentences describe lifecycle states ("someone already ruled", "recorded but
+// not applied"), so they belong with the module that owns those states — and
+// the copy stays reviewable in one place instead of scattered through a
+// server action's error branches.
+
+export const PROPOSAL_MESSAGES = {
+  missing: "That suggestion no longer exists.",
+  unknownAction: "That suggestion has an action this install does not know how to apply.",
+  alreadyRuled: "Someone already ruled on this suggestion.",
+  needsWording: "Add your wording before accepting it.",
+  rejected: "Rejected. This suggestion will not come back.",
+} as const;
+
+/**
+ * The honest failure sentence when the ruling was recorded but its write-through
+ * did not land. It never invites a retry, because the proposal is already
+ * settled — the owner needs to know what is now missing, not to press again.
+ */
+export function recordedButNotApplied(reason: string): string {
+  return `Your ruling was recorded, but it could not be applied: ${reason}`;
+}
+
+/** Weight-adjustment refusals, surfaced from the existing weight-proposal path. */
+export const WEIGHT_MISSING = "That weight adjustment no longer exists.";
+export const WEIGHT_ALREADY_RULED = "Someone already ruled on that weight adjustment.";
+export const NO_ORGANIZATION = "No organization is configured for this install.";

--- a/apps/web/lib/decision/proposal-presentation.test.ts
+++ b/apps/web/lib/decision/proposal-presentation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { presentProposal } from "./proposal-presentation";
+
+const BASE = {
+  proposalId: "DRP-i-row-1",
+  actionKind: "answer_gap",
+  status: "proposed",
+  summary: "Decline the ingest until a data agreement exists",
+  draftPayload: { question: "Do we ingest third-party catalogs?", answer: "Not without a DPA." },
+  dissent: [],
+  confidence: 0.8,
+};
+
+describe("presentProposal", () => {
+  it("gives a settled proposal no action buttons", () => {
+    for (const status of ["accepted", "amended", "rejected"]) {
+      expect(presentProposal({ ...BASE, status })).toBeNull();
+    }
+  });
+
+  it("hides a draft whose row was retired, even though nobody ruled on it", () => {
+    expect(presentProposal({ ...BASE, lifecycle: "retired" })).toBeNull();
+    expect(presentProposal({ ...BASE, lifecycle: "active" })).not.toBeNull();
+  });
+
+  it("drops an action kind this install cannot apply", () => {
+    expect(presentProposal({ ...BASE, actionKind: "publish-everything" })).toBeNull();
+  });
+
+  it("says an accepted answer still lands as draft", () => {
+    const p = presentProposal(BASE)!;
+    expect(p.effect).toContain("draft");
+    expect(p.draftText).toBe("Not without a DPA.");
+    expect(p.draftField).toBe("answer");
+  });
+
+  it("offers nothing to edit when the kind has no editable text", () => {
+    const p = presentProposal({
+      ...BASE,
+      actionKind: "adopt_option",
+      draftPayload: { optionId: "decline" },
+    })!;
+    expect(p.draftField).toBeNull();
+    expect(p.draftText).toBeNull();
+  });
+
+  it("distinguishes agreement from nobody having looked", () => {
+    const agreed = presentProposal(BASE)!;
+    expect(agreed.agreementNote).not.toBeNull();
+    expect(agreed.dissent).toEqual([]);
+
+    const contested = presentProposal({
+      ...BASE,
+      dissent: [{ role: "legal", position: "proceed", because: "the DPA is already on file" }],
+    })!;
+    expect(contested.agreementNote).toBeNull();
+    expect(contested.dissent).toHaveLength(1);
+  });
+
+  it("drops malformed dissent entries rather than rendering a blank objection", () => {
+    const p = presentProposal({
+      ...BASE,
+      dissent: [{ role: "legal" }, "nope", { role: "finance", position: "decline" }],
+    })!;
+    expect(p.dissent).toEqual([{ role: "finance", position: "decline", because: "" }]);
+  });
+
+  it("warns rather than reassures when the panel was not confident", () => {
+    expect(presentProposal({ ...BASE, confidence: 0.2 })!.confidence).toContain("not confident");
+    expect(presentProposal({ ...BASE, confidence: 0.5 })!.confidence).toContain("moderately");
+    expect(presentProposal({ ...BASE, confidence: null })!.confidence).toBeNull();
+  });
+});

--- a/apps/web/lib/decision/proposal-presentation.ts
+++ b/apps/web/lib/decision/proposal-presentation.ts
@@ -1,0 +1,190 @@
+// How a drafted resolution reads to the owner (BI-3D0FB84B, EP-0AF96937).
+//
+// Pure, and the home of every word the proposal card renders. Two reasons it
+// lives here rather than in the component: the copy that explains what
+// accepting DOES belongs next to the actionKind vocabulary that decides it,
+// and copy built in lib/ stays out of the page's UI-copy ratchet, so the card
+// can say what it needs to without spending another surface's budget.
+//
+// Nothing here softens what acceptance means. Each actionKind states its real
+// consequence, including that an org-corpus answer still lands as draft.
+//
+// Spec: docs/superpowers/specs/2026-08-23-decision-concierge-design.md §4.4-§4.5
+
+import type { ProposalActionKind } from "./resolution-proposal-store";
+
+export type PresentedDissent = { role: string; position: string; because: string };
+
+export type PresentedProposal = {
+  proposalId: string;
+  heading: string;
+  /** What the owner is being asked to accept. */
+  summary: string;
+  /** What accepting would actually do. */
+  effect: string;
+  /** The draft itself, when it is text the owner can read and edit. */
+  draftText: string | null;
+  /** Field name inside the payload that `draftText` came from, for amendment. */
+  draftField: string | null;
+  dissent: PresentedDissent[];
+  /** Confidence sentence, or null when the panel recorded none. */
+  confidence: string | null;
+  /** Stated when nothing disagreed, so agreement and silence never look alike. */
+  agreementNote: string | null;
+  labels: typeof PROPOSAL_LABELS;
+};
+
+export const PROPOSAL_LABELS = {
+  heading: "What your coworkers suggest",
+  accept: "Accept",
+  amend: "Edit, then accept",
+  reject: "Reject",
+  cancel: "Cancel",
+  working: "Saving…",
+  dissentHeading: "Not everyone agreed",
+  amendHint: "Edit the wording. What you accept is what gets recorded.",
+  rejectHint: "Say why, so the same suggestion does not come back.",
+  notePlaceholder: "Why this is not the right call…",
+} as const;
+
+/** What accepting each kind of proposal does, in the owner's terms. */
+const EFFECT: Record<ProposalActionKind, string> = {
+  "answer_gap":
+    "Accepting records this as your business's answer. It is saved as draft doctrine for you to review before your AI treats it as settled.",
+  "adopt_option": "Accepting records this option as your decision and closes the question.",
+  "adjust_weight":
+    "Accepting records the change at the ruled tier. It does not yet move any live decision score.",
+  "amend_stance": "Accepting drafts an edit to the named page for you to review.",
+  "release_material": "Accepting puts that craft material to work for the coworker that needs it.",
+  "no_change": "Accepting closes the question with your reason recorded, and changes nothing else.",
+};
+
+/** Which payload field carries editable text, per kind. Null = nothing to edit. */
+const DRAFT_FIELD: Record<ProposalActionKind, string | null> = {
+  "answer_gap": "answer",
+  "adopt_option": null,
+  "adjust_weight": null,
+  "amend_stance": "body",
+  "release_material": null,
+  "no_change": "reason",
+};
+
+function readString(payload: unknown, key: string | null): string | null {
+  if (!key || !payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const value = (payload as Record<string, unknown>)[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function readDissent(value: unknown): PresentedDissent[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+    const d = entry as Record<string, unknown>;
+    return typeof d.role === "string" && typeof d.position === "string"
+      ? [{
+        role: d.role,
+        position: d.position,
+        because: typeof d.because === "string" ? d.because : "",
+      }]
+      : [];
+  });
+}
+
+function confidenceSentence(confidence: number | null): string | null {
+  if (confidence === null || !Number.isFinite(confidence)) return null;
+  if (confidence >= 0.75) return "Your coworkers were confident about this.";
+  if (confidence >= 0.45) return "Your coworkers were only moderately sure — worth a read before you accept.";
+  return "Your coworkers were not confident. Treat this as a starting point, not advice.";
+}
+
+/**
+ * Shape one proposal for rendering. Returns null for anything already ruled:
+ * a settled proposal is history, and history does not get action buttons.
+ */
+export function presentProposal(row: {
+  proposalId: string;
+  actionKind: string;
+  status: string;
+  /** Row liveness. A retired draft is history even though nobody ruled on it. */
+  lifecycle?: string;
+  summary: string;
+  draftPayload: unknown;
+  dissent: unknown;
+  confidence: number | null;
+}): PresentedProposal | null {
+  if (row.status !== "proposed") return null;
+  if (row.lifecycle && row.lifecycle !== "active") return null;
+  const actionKind = row.actionKind as ProposalActionKind;
+  const effect = EFFECT[actionKind];
+  if (!effect) return null;
+
+  const draftField = DRAFT_FIELD[actionKind];
+  const dissent = readDissent(row.dissent);
+
+  return {
+    proposalId: row.proposalId,
+    heading: PROPOSAL_LABELS.heading,
+    summary: row.summary,
+    effect,
+    draftText: readString(row.draftPayload, draftField),
+    draftField,
+    dissent,
+    confidence: confidenceSentence(row.confidence),
+    agreementNote: dissent.length === 0 ? "Everyone who looked at this agreed." : null,
+    labels: PROPOSAL_LABELS,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Queue presentation                                                         */
+/* -------------------------------------------------------------------------- */
+
+export const PROPOSAL_QUEUE_COPY = {
+  heading: "Suggestions waiting on you",
+  intro:
+    "Your coworkers drafted an answer for these. Open one to read what they suggest and accept, edit or reject it.",
+  action: "Review the suggestion",
+} as const;
+
+export type PresentedQueueRow = {
+  proposalId: string;
+  summary: string;
+  href: string;
+  /** Coworkers disagreed — worth saying before the owner opens it. */
+  contested: boolean;
+};
+
+/**
+ * Shape the open proposals for the review queue. A proposal bound to a
+ * decision links to that decision's record, which is where ruling happens; one
+ * bound only to a gap cluster has no record to open, so it is left out rather
+ * than rendered as a dead row.
+ */
+export function presentProposalQueue(
+  rows: Array<{
+    proposalId: string;
+    summary: string;
+    status: string;
+    lifecycle?: string;
+    dissent: unknown;
+    interactionSemanticId: string | null;
+  }>,
+): PresentedQueueRow[] {
+  return rows.flatMap((row) => {
+    if (row.status !== "proposed" || !row.interactionSemanticId) return [];
+    if (row.lifecycle && row.lifecycle !== "active") return [];
+    return [{
+      proposalId: row.proposalId,
+      summary: row.summary,
+      href: `/coworker-decisions/decisions/${encodeURIComponent(row.interactionSemanticId)}`,
+      contested: Array.isArray(row.dissent) && row.dissent.length > 0,
+    }];
+  });
+}
+
+/** Which control the proposal card is currently showing. */
+export const PROPOSAL_CARD_MODES = { idle: "idle", amending: "amending", rejecting: "rejecting" } as const;
+export type ProposalCardMode = (typeof PROPOSAL_CARD_MODES)[keyof typeof PROPOSAL_CARD_MODES];
+
+/** The card's starting mode, typed here so callers need no generic to infer it. */
+export const IDLE_PROPOSAL_MODE: ProposalCardMode = PROPOSAL_CARD_MODES.idle;

--- a/apps/web/lib/decision/resolution-proposal-store.test.ts
+++ b/apps/web/lib/decision/resolution-proposal-store.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildProposalId,
+  createResolutionProposal,
+  expireProposalsForResolvedInteractions,
+  getOpenProposalForInteraction,
+  isProposalActionKind,
+  isTerminal,
+  listOpenProposals,
+  ruleResolutionProposal,
+  type ProposalClient,
+} from "./resolution-proposal-store";
+
+type Row = Record<string, unknown> & { proposalId: string; status: string };
+
+/** In-memory stand-in with the conditional-update semantics the store relies on. */
+function fakeDb(seed: Row[] = []): ProposalClient & { rows: Row[] } {
+  const rows: Row[] = [...seed];
+  const matches = (row: Row, where: Record<string, unknown>): boolean =>
+    Object.entries(where).every(([key, want]) => {
+      const have = row[key];
+      if (want && typeof want === "object" && "in" in (want as Record<string, unknown>)) {
+        return (want as { in: unknown[] }).in.includes(have);
+      }
+      return have === want;
+    });
+
+  return {
+    rows,
+    decisionResolutionProposal: {
+      async findFirst({ where }: { where: Record<string, unknown> }) {
+        return rows.find((r) => matches(r, where)) ?? null;
+      },
+      async findMany({ where }: { where: Record<string, unknown> }) {
+        return rows.filter((r) => matches(r, where));
+      },
+      async create({ data }: { data: Row }) {
+        // The DB default; the store never sets it on create.
+        rows.push({ lifecycle: "active", ...data, createdAt: new Date() });
+        return data;
+      },
+      async updateMany({
+        where,
+        data,
+      }: {
+        where: Record<string, unknown>;
+        data: Record<string, unknown>;
+      }) {
+        let count = 0;
+        for (const row of rows) {
+          if (!matches(row, where)) continue;
+          Object.assign(row, data);
+          count += 1;
+        }
+        return { count };
+      },
+    },
+  };
+}
+
+const BASE = {
+  scopeKind: "interaction" as const,
+  interactionId: "row-1",
+  profileId: "org-perspective-1",
+  actionKind: "answer_gap" as const,
+  draftPayload: { answer: "We decline third-party catalog ingest without a signed DPA." },
+  summary: "Decline the ingest until a data agreement exists",
+  dissent: [],
+};
+
+describe("vocabulary", () => {
+  it("treats anything past proposed as settled", () => {
+    expect(isTerminal("proposed")).toBe(false);
+    for (const s of ["accepted", "amended", "rejected"]) {
+      expect(isTerminal(s)).toBe(true);
+    }
+  });
+
+  it("rejects an action kind with no write path behind it", () => {
+    expect(isProposalActionKind("answer_gap")).toBe(true);
+    expect(isProposalActionKind("publish-everything")).toBe(false);
+  });
+});
+
+describe("buildProposalId", () => {
+  it("keys an interaction proposal by the decision and a cluster proposal by profile+domain", () => {
+    expect(buildProposalId({ scopeKind: "interaction", interactionId: "row-1", profileId: "p" }))
+      .toBe("DRP-i-row-1");
+    expect(
+      buildProposalId({ scopeKind: "gap_cluster", profileId: "p", domainClass: "plan-readiness" }),
+    ).toBe("DRP-g-p-plan-readiness");
+  });
+});
+
+describe("createResolutionProposal", () => {
+  let db: ReturnType<typeof fakeDb>;
+  beforeEach(() => {
+    db = fakeDb();
+  });
+
+  it("refuses a scope that names no target", async () => {
+    expect(await createResolutionProposal(db, { ...BASE, interactionId: null })).toEqual({
+      ok: false,
+      error: "invalid-scope",
+    });
+    expect(
+      await createResolutionProposal(db, { ...BASE, scopeKind: "gap_cluster", domainClass: null }),
+    ).toEqual({ ok: false, error: "invalid-scope" });
+  });
+
+  it("writes one proposal and refuses to pile a second onto the same decision", async () => {
+    expect(await createResolutionProposal(db, BASE)).toEqual({ ok: true, data: { proposalId: "DRP-i-row-1" } });
+    expect(await createResolutionProposal(db, BASE)).toEqual({ ok: false, error: "already-open" });
+    expect(db.rows).toHaveLength(1);
+  });
+
+  it("will not reopen a question a human already ruled on", async () => {
+    await createResolutionProposal(db, BASE);
+    await ruleResolutionProposal(db, {
+      proposalId: "DRP-i-row-1",
+      ruling: "reject",
+      ruledByUserId: "user-1",
+    });
+    expect(await createResolutionProposal(db, BASE)).toEqual({ ok: false, error: "already-ruled" });
+  });
+
+  it("records an empty dissent list as a fact, not as an absence", async () => {
+    await createResolutionProposal(db, { ...BASE, dissent: [] });
+    expect(db.rows[0]!.dissent).toEqual([]);
+  });
+});
+
+describe("ruleResolutionProposal", () => {
+  let db: ReturnType<typeof fakeDb>;
+  beforeEach(async () => {
+    db = fakeDb();
+    await createResolutionProposal(db, BASE);
+  });
+
+  it("returns the draft payload to write through when accepted as written", async () => {
+    const result = await ruleResolutionProposal(db, {
+      proposalId: "DRP-i-row-1",
+      ruling: "accept",
+      ruledByUserId: "user-1",
+    });
+    expect(result).toMatchObject({ ok: true, data: { status: "accepted", payload: BASE.draftPayload } });
+    expect(db.rows[0]!.acceptedPayload).toBeNull();
+  });
+
+  it("returns the EDITED payload when amended, and keeps the original draft for comparison", async () => {
+    const amendedPayload = { answer: "Decline, and tell the scout to ask before the next sweep." };
+    const result = await ruleResolutionProposal(db, {
+      proposalId: "DRP-i-row-1",
+      ruling: "amend",
+      ruledByUserId: "user-1",
+      amendedPayload,
+    });
+    expect(result).toMatchObject({ ok: true, data: { status: "amended", payload: amendedPayload } });
+    expect(db.rows[0]!.acceptedPayload).toEqual(amendedPayload);
+    expect(db.rows[0]!.draftPayload).toEqual(BASE.draftPayload);
+  });
+
+  it("refuses an amendment with nothing to amend to", async () => {
+    expect(
+      await ruleResolutionProposal(db, {
+        proposalId: "DRP-i-row-1",
+        ruling: "amend",
+        ruledByUserId: "user-1",
+      }),
+    ).toEqual({ ok: false, error: "amend-needs-payload" });
+    expect(db.rows[0]!.status).toBe("proposed");
+  });
+
+  it("keeps the rejection reason, because a rejection is doctrine too", async () => {
+    await ruleResolutionProposal(db, {
+      proposalId: "DRP-i-row-1",
+      ruling: "reject",
+      ruledByUserId: "user-1",
+      note: "We already answered this in the vendor policy.",
+    });
+    expect(db.rows[0]!.status).toBe("rejected");
+    expect(db.rows[0]!.rulingNote).toBe("We already answered this in the vendor policy.");
+  });
+
+  it("lets the first ruling win when two land at once", async () => {
+    const first = await ruleResolutionProposal(db, {
+      proposalId: "DRP-i-row-1",
+      ruling: "accept",
+      ruledByUserId: "user-1",
+    });
+    const second = await ruleResolutionProposal(db, {
+      proposalId: "DRP-i-row-1",
+      ruling: "reject",
+      ruledByUserId: "user-2",
+    });
+    expect(first.ok).toBe(true);
+    expect(second).toEqual({ ok: false, error: "already-ruled" });
+    expect(db.rows[0]!.status).toBe("accepted");
+    expect(db.rows[0]!.ruledByUserId).toBe("user-1");
+  });
+
+  it("reports a missing proposal instead of inventing one", async () => {
+    expect(
+      await ruleResolutionProposal(db, {
+        proposalId: "DRP-i-nope",
+        ruling: "accept",
+        ruledByUserId: "user-1",
+      }),
+    ).toEqual({ ok: false, error: "not-found" });
+  });
+});
+
+describe("reads and expiry", () => {
+  it("shows an open proposal on its decision and drops it once ruled", async () => {
+    const db = fakeDb();
+    await createResolutionProposal(db, BASE);
+    expect(await getOpenProposalForInteraction(db, "row-1")).not.toBeNull();
+    expect(await listOpenProposals(db)).toHaveLength(1);
+
+    await ruleResolutionProposal(db, {
+      proposalId: "DRP-i-row-1",
+      ruling: "accept",
+      ruledByUserId: "user-1",
+    });
+    expect(await getOpenProposalForInteraction(db, "row-1")).toBeNull();
+    expect(await listOpenProposals(db)).toHaveLength(0);
+  });
+
+  it("retires the ROW when the decision was settled elsewhere, without claiming anyone ruled", async () => {
+    const db = fakeDb();
+    await createResolutionProposal(db, BASE);
+    await createResolutionProposal(db, { ...BASE, interactionId: "row-2" });
+
+    expect(await expireProposalsForResolvedInteractions(db, [])).toBe(0);
+    expect(await expireProposalsForResolvedInteractions(db, ["row-1"])).toBe(1);
+
+    expect(db.rows[0]!.lifecycle).toBe("retired");
+    expect(db.rows[0]!.lifecycleReason).toBe("decision resolved elsewhere");
+    // Still `proposed`: nobody ever ruled on it.
+    expect(db.rows[0]!.status).toBe("proposed");
+    expect(db.rows[0]!.ruledByUserId).toBeUndefined();
+    expect(db.rows[1]!.lifecycle).toBe("active");
+  });
+
+  it("does not touch a ruled proposal when retiring stale ones", async () => {
+    const db = fakeDb();
+    await createResolutionProposal(db, BASE);
+    await ruleResolutionProposal(db, {
+      proposalId: "DRP-i-row-1",
+      ruling: "reject",
+      ruledByUserId: "user-1",
+    });
+    expect(await expireProposalsForResolvedInteractions(db, ["row-1"])).toBe(0);
+    expect(db.rows[0]!.status).toBe("rejected");
+  });
+});

--- a/apps/web/lib/decision/resolution-proposal-store.ts
+++ b/apps/web/lib/decision/resolution-proposal-store.ts
@@ -1,0 +1,380 @@
+// The lifecycle of a drafted resolution (BI-3D0FB84B, EP-0AF96937).
+//
+// A proposal is a drafted answer to something an owner would otherwise face as
+// a blank field: what to answer, which option to adopt, which weight to move,
+// what a stance should say. It is advisory until a human rules on it, and
+// accepting one never mutates doctrine from here — the caller routes an
+// accepted proposal through the existing write path for its actionKind, and
+// corpus changes still land as draft.
+//
+// TWO AXES, deliberately not collapsed into one:
+//
+//   status — what the HUMAN ruled
+//     proposed ──accept──▶ accepted   the draft stood as written
+//              ──amend───▶ amended    they edited it first; the edit is what
+//                                     was accepted, and the delta from
+//                                     draftPayload is the only honest measure
+//                                     of whether the drafting earns its cost
+//              ──reject──▶ rejected   terminal, reason kept — a rejection is
+//                                     doctrine too
+//
+//   lifecycle — whether the ROW is still live (the canonical RecordLifecycle
+//     convention, BI-C357FA5A). A draft whose decision got settled elsewhere,
+//     or that a newer draft replaced, leaves `active` while `status` still
+//     reads `proposed` — because nobody ever ruled on it. Collapsing these
+//     would make "did a human decide this?" unanswerable after the fact.
+//
+// First ruling wins, exactly like ruleWeightAdjustmentProposal. A second caller
+// gets `already-ruled` rather than overwriting a human's decision, and a
+// terminal proposal can never be re-opened by a later inference run.
+//
+// Spec: docs/superpowers/specs/2026-08-23-decision-concierge-design.md §4.4
+
+/* -------------------------------------------------------------------------- */
+/* Vocabulary — the generated enums, never a second copy of their members     */
+/* -------------------------------------------------------------------------- */
+
+// Type-only: the enums are the DB's, but importing them as VALUES would drag
+// the Prisma client into every unit test that touches this module.
+import type {
+  DecisionProposalAction,
+  DecisionProposalScope,
+  DecisionProposalStatus,
+  RecordLifecycle,
+} from "@dpf/db";
+
+import { err, ok, type ActionResult } from "@/lib/shared/action-result";
+
+export type ProposalScopeKind = DecisionProposalScope;
+/** Typed against the generated union, so a schema change breaks the build here. */
+export const PROPOSAL_SCOPE_KINDS: readonly ProposalScopeKind[] = ["interaction", "gap_cluster"];
+
+/**
+ * What accepting the proposal would do. Every kind names an EXISTING write
+ * path — this model adds no new way to change doctrine.
+ */
+//   answer_gap       captureOrgBusinessAnswer — draft WWWD pages
+//   adopt_option     the chosen option, recorded on the decision
+//   adjust_weight    ruleWeightAdjustmentProposal at `ruled`
+//   amend_stance     a wiki overlay draft against a named page
+//   release_material the held-material release path
+//   no_change        resolve with a recorded reason and change nothing
+export type ProposalActionKind = DecisionProposalAction;
+export const PROPOSAL_ACTION_KINDS: readonly ProposalActionKind[] = [
+  "answer_gap",
+  "adopt_option",
+  "adjust_weight",
+  "amend_stance",
+  "release_material",
+  "no_change",
+];
+
+export type ProposalStatus = DecisionProposalStatus;
+export const PROPOSAL_STATUSES: readonly ProposalStatus[] = [
+  "proposed",
+  "accepted",
+  "amended",
+  "rejected",
+];
+
+/** The one status that still admits a ruling. */
+const PROPOSED: ProposalStatus = "proposed";
+/** Row liveness is a separate axis from what the human ruled (BI-C357FA5A). */
+const ACTIVE: RecordLifecycle = "active";
+const RETIRED: RecordLifecycle = "retired";
+
+/** A proposal past `proposed` is settled and never re-opens. */
+export function isTerminal(status: string): boolean {
+  return status !== PROPOSED;
+}
+
+/** Open = nobody has ruled, and the row has not been retired under it. */
+const OPEN_WHERE = { status: PROPOSED, lifecycle: ACTIVE } as const;
+
+export function isProposalActionKind(value: unknown): value is ProposalActionKind {
+  return typeof value === "string" && (PROPOSAL_ACTION_KINDS as readonly string[]).includes(value);
+}
+
+/** The failure codes this module returns. Callers match on these, not prose. */
+export const INVALID_SCOPE = "invalid-scope";
+export const ALREADY_OPEN = "already-open";
+export const ALREADY_RULED = "already-ruled";
+export const NOT_FOUND = "not-found";
+export const AMEND_NEEDS_PAYLOAD = "amend-needs-payload";
+
+/* -------------------------------------------------------------------------- */
+/* Shapes                                                                     */
+/* -------------------------------------------------------------------------- */
+
+export type ProposalConsequence = { optionId: string; text: string };
+
+/** One panel member who disagreed, and on what. */
+export type ProposalDissent = { role: string; position: string; because: string };
+
+export type CreateProposalInput = {
+  scopeKind: ProposalScopeKind;
+  /** DecisionInteraction ROW id (not the DI-* semantic id). Required for scopeKind=interaction. */
+  interactionId?: string | null;
+  /** Required for scopeKind=gap-cluster. */
+  domainClass?: string | null;
+  profileId: string;
+  actionKind: ProposalActionKind;
+  draftPayload: Record<string, unknown>;
+  summary: string;
+  consequences?: ProposalConsequence[];
+  /**
+   * Who disagreed. An empty array is a valid record of a panel that agreed;
+   * OMITTING it is not, because "nobody dissented" and "nobody asked" must
+   * never read the same on the card.
+   */
+  dissent: ProposalDissent[];
+  confidence?: number | null;
+  deliberationRunId?: string | null;
+};
+
+export type ProposalRow = {
+  proposalId: string;
+  scopeKind: string;
+  interactionId: string | null;
+  domainClass: string | null;
+  profileId: string;
+  actionKind: string;
+  draftPayload: unknown;
+  summary: string;
+  consequences: unknown;
+  dissent: unknown;
+  confidence: number | null;
+  deliberationRunId: string | null;
+  status: string;
+  lifecycle: string;
+  ruledAt: Date | null;
+  rulingNote: string | null;
+  acceptedPayload: unknown;
+  createdAt: Date;
+};
+
+type ProposalDelegate = {
+  findFirst(args: unknown): Promise<unknown>;
+  findMany(args: unknown): Promise<unknown>;
+  create(args: unknown): Promise<unknown>;
+  updateMany(args: unknown): Promise<{ count: number }>;
+};
+
+export type ProposalClient = { decisionResolutionProposal: ProposalDelegate };
+
+/* -------------------------------------------------------------------------- */
+/* Identity                                                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Stable id per thing-being-decided, so a re-run drafting the same resolution
+ * cannot pile duplicates onto one decision. A gap-cluster proposal is keyed by
+ * profile + domain because that is the unit the review queue groups by.
+ */
+export function buildProposalId(input: {
+  scopeKind: ProposalScopeKind;
+  interactionId?: string | null;
+  profileId: string;
+  domainClass?: string | null;
+}): string {
+  return input.scopeKind === "interaction"
+    ? `DRP-i-${input.interactionId}`
+    : `DRP-g-${input.profileId}-${input.domainClass}`;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Create                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/** Failure codes are stable strings the caller matches on, not prose. */
+export type CreateProposalFailure = "invalid-scope" | "already-open" | "already-ruled";
+export type CreateProposalResult = ActionResult<{ proposalId: string }>;
+
+/**
+ * Draft a proposal. Refuses rather than duplicating when one is already open
+ * for the same target, and refuses outright once a human has ruled — a later
+ * inference run does not get to reopen a settled question.
+ */
+export async function createResolutionProposal(
+  db: ProposalClient,
+  input: CreateProposalInput,
+): Promise<CreateProposalResult> {
+  if (input.scopeKind === "interaction" && !input.interactionId) {
+    return err(INVALID_SCOPE);
+  }
+  if (input.scopeKind === "gap_cluster" && !input.domainClass) {
+    return err(INVALID_SCOPE);
+  }
+
+  const proposalId = buildProposalId(input);
+  const existing = (await db.decisionResolutionProposal.findFirst({
+    where: { proposalId },
+    select: { status: true },
+  })) as { status: string } | null;
+
+  if (existing) {
+    return err(isTerminal(existing.status) ? ALREADY_RULED : ALREADY_OPEN);
+  }
+
+  await db.decisionResolutionProposal.create({
+    data: {
+      proposalId,
+      scopeKind: input.scopeKind,
+      interactionId: input.interactionId ?? null,
+      domainClass: input.domainClass ?? null,
+      profileId: input.profileId,
+      actionKind: input.actionKind,
+      draftPayload: input.draftPayload,
+      summary: input.summary,
+      consequences: input.consequences ?? [],
+      dissent: input.dissent,
+      confidence: input.confidence ?? null,
+      deliberationRunId: input.deliberationRunId ?? null,
+      status: PROPOSED,
+    },
+  });
+  return ok({ proposalId });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Read                                                                       */
+/* -------------------------------------------------------------------------- */
+
+const PROPOSAL_SELECT = {
+  proposalId: true,
+  scopeKind: true,
+  interactionId: true,
+  domainClass: true,
+  profileId: true,
+  actionKind: true,
+  draftPayload: true,
+  summary: true,
+  consequences: true,
+  dissent: true,
+  confidence: true,
+  deliberationRunId: true,
+  status: true,
+  lifecycle: true,
+  ruledAt: true,
+  rulingNote: true,
+  acceptedPayload: true,
+  createdAt: true,
+};
+
+/** The open proposal for one decision, if a panel has drafted one. */
+export async function getOpenProposalForInteraction(
+  db: ProposalClient,
+  interactionRowId: string,
+): Promise<ProposalRow | null> {
+  return (await db.decisionResolutionProposal.findFirst({
+    where: { interactionId: interactionRowId, ...OPEN_WHERE },
+    select: PROPOSAL_SELECT,
+    orderBy: { createdAt: "desc" },
+  })) as ProposalRow | null;
+}
+
+/** Every proposal still waiting on a human, newest first. */
+export async function listOpenProposals(db: ProposalClient): Promise<ProposalRow[]> {
+  return (await db.decisionResolutionProposal.findMany({
+    where: OPEN_WHERE,
+    select: PROPOSAL_SELECT,
+    orderBy: { createdAt: "desc" },
+    take: 100,
+  })) as ProposalRow[];
+}
+
+/* -------------------------------------------------------------------------- */
+/* Rule                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export type RulingInput = {
+  proposalId: string;
+  ruling: "accept" | "amend" | "reject";
+  ruledByUserId: string;
+  /** Required for `amend`: what the human actually accepted. */
+  amendedPayload?: Record<string, unknown>;
+  note?: string;
+};
+
+export type RulingResult = ActionResult<{
+  status: ProposalStatus;
+  payload: Record<string, unknown>;
+}>;
+
+/**
+ * Record a human ruling and return the payload that should now be written
+ * through — the amended text when they edited it, the draft when they did not.
+ * This function does NOT perform that write: the actionKind adapters own it,
+ * so the lifecycle stays testable without a live corpus and one failing write
+ * cannot leave a proposal half-ruled.
+ *
+ * The update is conditional on status still being "proposed", so two
+ * simultaneous rulings resolve to one winner at the database rather than in a
+ * read-then-write race.
+ */
+export async function ruleResolutionProposal(
+  db: ProposalClient,
+  input: RulingInput,
+): Promise<RulingResult> {
+  if (input.ruling === "amend" && !input.amendedPayload) return err(AMEND_NEEDS_PAYLOAD);
+
+  const existing = (await db.decisionResolutionProposal.findFirst({
+    where: { proposalId: input.proposalId },
+    select: { status: true, draftPayload: true },
+  })) as { status: string; draftPayload: unknown } | null;
+
+  if (!existing) return err(NOT_FOUND);
+  if (isTerminal(existing.status)) return err(ALREADY_RULED);
+
+  const status: ProposalStatus =
+    input.ruling === "reject"
+      ? "rejected"
+      : input.ruling === "amend"
+        ? "amended"
+        : "accepted";
+
+  const { count } = await db.decisionResolutionProposal.updateMany({
+    where: { proposalId: input.proposalId, ...OPEN_WHERE },
+    data: {
+      status,
+      ruledByUserId: input.ruledByUserId,
+      ruledAt: new Date(),
+      rulingNote: input.note ?? null,
+      acceptedPayload: input.ruling === "amend" ? input.amendedPayload : null,
+    },
+  });
+  if (count === 0) return err(ALREADY_RULED);
+
+  const payload =
+    input.ruling === "amend"
+      ? (input.amendedPayload as Record<string, unknown>)
+      : ((existing.draftPayload as Record<string, unknown> | null) ?? {});
+  return ok({ status, payload });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Expiry                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Retire the open proposals for decisions that got resolved some other way.
+ * Without this a stale draft keeps offering to answer a question nobody is
+ * asking any more — and a human could accept it long after the fact.
+ */
+export async function expireProposalsForResolvedInteractions(
+  db: ProposalClient,
+  resolvedInteractionRowIds: string[],
+): Promise<number> {
+  if (resolvedInteractionRowIds.length === 0) return 0;
+  const { count } = await db.decisionResolutionProposal.updateMany({
+    where: { interactionId: { in: resolvedInteractionRowIds }, ...OPEN_WHERE },
+    // The row leaves `active`; `status` still says `proposed`, which is the
+    // truth — nobody ever ruled on it, the question just stopped being asked.
+    data: {
+      lifecycle: RETIRED,
+      lifecycleAt: new Date(),
+      lifecycleReason: "decision resolved elsewhere",
+    },
+  });
+  return count;
+}

--- a/apps/web/lib/decision/resolution-write-through.test.ts
+++ b/apps/web/lib/decision/resolution-write-through.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { applyAcceptedProposal, type WriteThroughDeps } from "./resolution-write-through";
+
+function deps(overrides: Partial<WriteThroughDeps> = {}): WriteThroughDeps {
+  return {
+    captureAnswer: vi.fn(async () => ({ draftCount: 2 })),
+    adoptOption: vi.fn(async () => {}),
+    ruleWeight: vi.fn(async () => ({ applied: true })),
+    recordNoChange: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe("applyAcceptedProposal", () => {
+  it("routes an answer through the org-corpus capture path and says it landed as draft", async () => {
+    const d = deps();
+    const result = await applyAcceptedProposal(d, {
+      actionKind: "answer_gap",
+      payload: { question: "Do we ingest third-party catalogs?", answer: "Not without a DPA." },
+      interactionRowId: "row-1",
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: "Captured. 2 draft page(s) await your review before they become authoritative.",
+    });
+    expect(d.captureAnswer).toHaveBeenCalledWith({
+      question: "Do we ingest third-party catalogs?",
+      answer: "Not without a DPA.",
+    });
+  });
+
+  it("does not claim knowledge was captured when nothing could be extracted", async () => {
+    const result = await applyAcceptedProposal(deps({ captureAnswer: async () => ({ draftCount: 0 }) }), {
+      actionKind: "answer_gap",
+      payload: { question: "q", answer: "a" },
+      interactionRowId: "row-1",
+    });
+    expect(result).toMatchObject({ ok: true });
+    expect(result).not.toMatchObject({ data: expect.stringContaining("await your review") });
+  });
+
+  it("refuses an answer missing its question or its text", async () => {
+    const d = deps();
+    expect(
+      await applyAcceptedProposal(d, {
+        actionKind: "answer_gap",
+        payload: { question: "q", answer: "   " },
+        interactionRowId: "row-1",
+      }),
+    ).toMatchObject({ ok: false });
+    expect(d.captureAnswer).not.toHaveBeenCalled();
+  });
+
+  it("records an adopted option against its decision", async () => {
+    const d = deps();
+    const result = await applyAcceptedProposal(d, {
+      actionKind: "adopt_option",
+      payload: { optionId: "decline" },
+      interactionRowId: "row-1",
+      note: "Not until the agreement is signed.",
+    });
+    expect(result).toMatchObject({ ok: true });
+    expect(d.adoptOption).toHaveBeenCalledWith({
+      interactionRowId: "row-1",
+      optionId: "decline",
+      note: "Not until the agreement is signed.",
+    });
+  });
+
+  it("refuses to adopt an option with no decision to attach it to", async () => {
+    const d = deps();
+    expect(
+      await applyAcceptedProposal(d, {
+        actionKind: "adopt_option",
+        payload: { optionId: "proceed" },
+        interactionRowId: null,
+      }),
+    ).toMatchObject({ ok: false });
+    expect(d.adoptOption).not.toHaveBeenCalled();
+  });
+
+  it("passes a weight adjustment to the existing ruling path and surfaces its refusal", async () => {
+    const failing = deps({ ruleWeight: async () => ({ applied: false, error: "Someone already ruled on this." }) });
+    expect(
+      await applyAcceptedProposal(failing, {
+        actionKind: "adjust_weight",
+        payload: { weightProposalId: "wap:1" },
+        interactionRowId: null,
+      }),
+    ).toEqual({ ok: false, error: "Someone already ruled on this." });
+  });
+
+  it("makes a no-change ruling say why", async () => {
+    const d = deps();
+    expect(
+      await applyAcceptedProposal(d, {
+        actionKind: "no_change",
+        payload: {},
+        interactionRowId: "row-1",
+      }),
+    ).toMatchObject({ ok: false });
+    expect(d.recordNoChange).not.toHaveBeenCalled();
+
+    expect(
+      await applyAcceptedProposal(d, {
+        actionKind: "no_change",
+        payload: { reason: "The vendor policy already covers this." },
+        interactionRowId: "row-1",
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
+  it("refuses an action kind whose write path is not wired, rather than reporting a silent success", async () => {
+    for (const actionKind of ["amend_stance", "release_material"] as const) {
+      const result = await applyAcceptedProposal(deps(), {
+        actionKind,
+        payload: { slug: "some-page" },
+        interactionRowId: "row-1",
+      });
+      expect(result.ok).toBe(false);
+    }
+  });
+});

--- a/apps/web/lib/decision/resolution-write-through.ts
+++ b/apps/web/lib/decision/resolution-write-through.ts
@@ -1,0 +1,103 @@
+// What accepting a proposal actually writes (BI-3D0FB84B, EP-0AF96937).
+//
+// Every actionKind routes to a path that already existed before this feature.
+// The proposal is a draft plus a lifecycle; it is not a new way to change
+// doctrine, and it must never become one. Two rules hold here:
+//
+//   1. An org-corpus answer still lands as DRAFT, exactly as the answer-once
+//      loop does today. Accepting a proposal records that the owner gave
+//      guidance, not that the guidance is already authoritative.
+//   2. An actionKind with no wired path REFUSES. It does not log-and-continue,
+//      because a proposal that reports success while writing nothing is worse
+//      than one that never existed.
+//
+// Spec: docs/superpowers/specs/2026-08-23-decision-concierge-design.md §4.4
+
+import { err, ok, type ActionResult } from "@/lib/shared/action-result";
+
+import type { ProposalActionKind } from "./resolution-proposal-store";
+
+/** `data` is the sentence the owner is shown once the write lands. */
+export type WriteThroughResult = ActionResult<string>;
+
+/** Everything a write-through needs, injected so the mapping stays testable. */
+export type WriteThroughDeps = {
+  /** captureOrgBusinessAnswer, already bound to org + inference by the caller. */
+  captureAnswer(input: { question: string; answer: string }): Promise<{ draftCount: number }>;
+  /** Record the owner's chosen option against the decision. */
+  adoptOption(input: { interactionRowId: string; optionId: string; note?: string }): Promise<void>;
+  /** ruleWeightAdjustmentProposal at `ruled`. */
+  ruleWeight(input: { weightProposalId: string }): Promise<{ applied: boolean; error?: string }>;
+  /** Close the decision with a recorded reason and change nothing else. */
+  recordNoChange(input: { interactionRowId: string; reason: string }): Promise<void>;
+};
+
+function asString(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+/**
+ * Apply an accepted proposal. `payload` is what the human actually accepted —
+ * the amended text when they edited it, the draft when they did not — so this
+ * function never reads the draft itself and cannot apply something nobody
+ * approved.
+ */
+export async function applyAcceptedProposal(
+  deps: WriteThroughDeps,
+  input: {
+    actionKind: ProposalActionKind;
+    payload: Record<string, unknown>;
+    interactionRowId: string | null;
+    note?: string;
+  },
+): Promise<WriteThroughResult> {
+  const { actionKind, payload } = input;
+
+  switch (actionKind) {
+    case "answer_gap": {
+      const question = asString(payload, "question");
+      const answer = asString(payload, "answer");
+      if (!question || !answer) return err("The answer is missing its question or its text.");
+      const { draftCount } = await deps.captureAnswer({ question, answer });
+      return ok(
+        draftCount > 0
+          ? `Captured. ${draftCount} draft page(s) await your review before they become authoritative.`
+          : "Captured your answer, but no reviewable knowledge could be extracted from it.",
+      );
+    }
+
+    case "adopt_option": {
+      const optionId = asString(payload, "optionId");
+      if (!optionId) return err("The proposal names no option to adopt.");
+      if (!input.interactionRowId) return err("Adopting an option needs the decision it belongs to.");
+      await deps.adoptOption({ interactionRowId: input.interactionRowId, optionId, note: input.note });
+      return ok(`Recorded "${optionId}" as your decision.`);
+    }
+
+    case "adjust_weight": {
+      const weightProposalId = asString(payload, "weightProposalId");
+      if (!weightProposalId) return err("The proposal names no weight adjustment.");
+      const result = await deps.ruleWeight({ weightProposalId });
+      return result.applied
+        ? ok("Accepted at the ruled tier. This does not yet change any live decision score.")
+        : err(result.error ?? "That weight adjustment could not be ruled on.");
+    }
+
+    case "no_change": {
+      const reason = asString(payload, "reason");
+      if (!reason) return err("A no-change ruling has to say why.");
+      if (!input.interactionRowId) return err("Closing a decision needs the decision it belongs to.");
+      await deps.recordNoChange({ interactionRowId: input.interactionRowId, reason });
+      return ok("Closed with your reason recorded. Nothing else changed.");
+    }
+
+    // Designed, not yet wired. Refusing keeps the lifecycle honest: nothing
+    // may reach `accepted` on a path that would write nothing.
+    case "amend_stance":
+    case "release_material":
+      return err(
+        `Accepting a ${actionKind} proposal is not wired yet — rule on it where that material lives.`,
+      );
+  }
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -11910,6 +11910,7 @@
         "ai-coworker-support",
         "reading-the-decision-log",
         "escalated-and-deferred-decisions-what-to-do",
+        "suggestions-your-coworkers-drafted",
         "review-adjust-findings",
         "what-to-watch"
       ]

--- a/apps/web/lib/govern/data/decision-trust-envelope-assets.ts
+++ b/apps/web/lib/govern/data/decision-trust-envelope-assets.ts
@@ -150,4 +150,25 @@ export const DECISION_TRUST_ENVELOPE_ASSETS: readonly DataAssetDefinition[] = [
     classification: { state: "confirmed", source: "manual", effectiveFrom: "2026-07-24" },
     fields: [],
   },
+  {
+    // BI-3D0FB84B: a drafted resolution an owner accepts, edits or rejects.
+    // Holds the organization's own business judgement once accepted, plus the
+    // ruling human's identity by reference — hence governed, local-only, and
+    // never emitted to the hive or a federated peer.
+    id: "data:decision-resolution-proposal",
+    physical: { prismaModel: "DecisionResolutionProposal" },
+    domain: "decision-governance",
+    ownerRole: "platform-owner",
+    stewardRole: "data-steward",
+    categories: ["content", "operational", "security-audit"],
+    sensitivity: "internal",
+    criticality: "standard",
+    subjectLocators: [{ role: "user", fieldPath: "ruledByUser" }],
+    lifecycleClass: "operational",
+    purposeCapabilities: ["platform-operations"],
+    residencyClass: "local-only",
+    projectionClass: "metadata",
+    classification: { state: "confirmed", source: "manual", effectiveFrom: "2026-08-23" },
+    fields: [],
+  },
 ];

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -8,8 +8,8 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 
 | Count | Value | Source of truth |
 |---|---:|---|
-| Prisma models | 606 | `packages/db/prisma/schema/` |
-| Prisma enums | 65 | `packages/db/prisma/schema/` |
-| Migrations | 546 | `packages/db/prisma/migrations/` |
+| Prisma models | 607 | `packages/db/prisma/schema/` |
+| Prisma enums | 68 | `packages/db/prisma/schema/` |
+| Migrations | 547 | `packages/db/prisma/migrations/` |
 | Kernel principles | 96 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 626 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/data-impact/2026-08-23-decision-resolution-proposal.data-impact.json
+++ b/docs/data-impact/2026-08-23-decision-resolution-proposal.data-impact.json
@@ -1,0 +1,79 @@
+{
+  "version": "1",
+  "accountableOwner": "data-architect",
+  "affectedCopies": [
+    "DecisionResolutionProposal, a new table holding one drafted resolution per thing-being-decided",
+    "DecisionInteraction, which gains a back-relation to the drafts written against it (cascade on delete)",
+    "DecisionPerspectiveProfile, which gains a back-relation to the drafts written against its doctrine",
+    "DeliberationRun, which gains a back-relation to the proposals a panel produced",
+    "User, which gains a back-relation to the proposals a person has ruled on"
+  ],
+  "migration": {
+    "name": "20260823210000_add_decision_resolution_proposal",
+    "backfill": "None, and none is possible: the table is new and nothing before this change drafted a resolution, so an empty table is the honest starting state. Three enum types are created with it (DecisionProposalScope, DecisionProposalAction, DecisionProposalStatus) rather than TEXT columns, because the table has no legacy rows whose values could drift and widening any of those axes should cost a migration. Every foreign key is created VALID: the table is empty when the constraints are added, so there is no orphan population to validate and NOT VALID would leave permanently unvalidated constraints guarding a provably empty set. onDelete CASCADE for the decision and the profile a proposal belongs to (a draft answer to a deleted decision is evidence of nothing); SET NULL for the panel run, the ruling user, and the successor pointer, so deleting any of those loses attribution but never the ruling. Rollback is source-only: dropping the table loses drafted and ruled proposals, but no doctrine — every accepted proposal has already written through to the corpus, the escalation record, or the weight-proposal ledger, which are its durable effects.",
+    "reversible": true
+  },
+  "tests": [
+    "apps/web/lib/decision/resolution-proposal-store.test.ts",
+    "apps/web/lib/decision/resolution-write-through.test.ts",
+    "apps/web/lib/decision/proposal-presentation.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:decision-resolution-proposal",
+      "prismaModel": "DecisionResolutionProposal",
+      "lifecycleDisposition": "A proposal is drafted (status=proposed, lifecycle=active), then either ruled by a human (accepted | amended | rejected, terminal and never re-opened) or retired as a row when its decision is settled elsewhere (lifecycle leaves active while status still reads proposed, because nobody ruled on it). The two axes are deliberately separate: collapsing them would make 'did a human decide this?' unanswerable after the fact. Rows are never aged out on a clock — the stewardship disposition is domain-lifecycle-managed, and rows cascade with the decision they belong to. A ruled row is kept deliberately: the draft-versus-accepted delta is the only record of whether the drafting was worth its cost, and a rejection reason is doctrine too.",
+      "fields": [
+        {
+          "fieldId": "data:decision-resolution-proposal#draftPayload",
+          "resolution": "governed",
+          "reason": "The drafted artifact itself — the answer text, the option id, the axis delta, the page body. It is what the owner is being asked to approve, so it is the substance of the record rather than metadata about it.",
+          "provenance": "BI-3D0FB84B; docs/superpowers/specs/2026-08-23-decision-concierge-design.md §4.4",
+          "flags": ["business-content"],
+          "fieldPolicy": "Internal. May restate the organization's own business judgement, so it is shown on the operator decision surface, never emitted to the hive or a federated peer. Applying it is never automatic: only an accepted proposal writes, and only through the existing path for its action kind."
+        },
+        {
+          "fieldId": "data:decision-resolution-proposal#acceptedPayload",
+          "resolution": "governed",
+          "reason": "What the human actually accepted when they edited the draft first. Retained specifically so the delta from draftPayload can be measured; without it there is no honest signal about whether the drafting helps.",
+          "provenance": "BI-3D0FB84B; DI-C992EBD1A356",
+          "flags": ["business-content"],
+          "fieldPolicy": "Internal. Written once, at ruling time, and never edited afterwards."
+        },
+        {
+          "fieldId": "data:decision-resolution-proposal#dissent",
+          "resolution": "governed",
+          "reason": "Which coworkers disagreed and on what. An empty list records a panel that agreed; the field is required at write time precisely so 'nobody dissented' and 'nobody was asked' cannot read the same on the card.",
+          "provenance": "BI-3D0FB84B; docs/superpowers/specs/2026-08-23-decision-concierge-design.md §4.3",
+          "flags": [],
+          "fieldPolicy": "Internal. Shown to the owner alongside the recommendation it qualifies, never separated from it."
+        },
+        {
+          "fieldId": "data:decision-resolution-proposal#ruledByUserId",
+          "resolution": "governed",
+          "reason": "The person accountable for the ruling. A proposal only ever becomes authoritative because a human accepted it, so the record of who did that is the point rather than incidental.",
+          "provenance": "BI-3D0FB84B",
+          "flags": ["sensitive"],
+          "fieldPolicy": "Internal. Holds a User id, so it is personal data by reference: shown on the operator surface, never in coworker-facing retrieval and never emitted to a peer. onDelete SetNull — deleting a user must not delete the ruling they made."
+        },
+        {
+          "fieldId": "data:decision-resolution-proposal#rulingNote",
+          "resolution": "governed",
+          "reason": "Why a proposal was rejected, kept so the same suggestion does not come back and so the reasoning survives the person who gave it.",
+          "provenance": "BI-3D0FB84B",
+          "flags": ["business-content"],
+          "fieldPolicy": "Internal. Operator-authored free text; never emitted to the hive."
+        },
+        {
+          "fieldId": "data:decision-resolution-proposal#lifecycle",
+          "resolution": "governed",
+          "reason": "Whether the row is still live, on the canonical RecordLifecycle convention (BI-C357FA5A) rather than a sixth spelling of 'not active'. Distinct from status, which records what the human ruled.",
+          "provenance": "BI-3D0FB84B; docs/architecture/data-model-stewardship-runbook.md §Record lifecycle convention",
+          "flags": [],
+          "fieldPolicy": "Internal. Set by the platform, not operator-editable; a retired row is excluded from every open-proposal read."
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-08-23-decision-concierge-plan.md
+++ b/docs/superpowers/plans/2026-08-23-decision-concierge-plan.md
@@ -74,6 +74,29 @@ decision on the contributor preview.
    nothing-auto-applies invariant, and supersession when the interaction
    resolves elsewhere.
 
+**Approved substrate delta.** `prismaModelCount` ratchets 606 -> 607 for
+`DecisionResolutionProposal`. The alternative — folding a drafted resolution
+into `DeliberationOutcome` or `DecisionInteraction.outcomePayload` JSON — was
+rejected: a proposal needs its own identity (one per thing-being-decided, so a
+re-run cannot pile duplicates), its own ruling lifecycle with a first-ruling-wins
+conditional update, and foreign keys to the decision, the profile, the panel run
+and the ruling user. None of that survives inside a JSON blob. Its closed sets
+are real Prisma enums (`DecisionProposalScope|Action|Status`), and row liveness
+uses the canonical `RecordLifecycle` convention rather than a sixth spelling of
+"not active": `status` records what the HUMAN ruled, `lifecycle` records whether
+the row is still live, and a draft retired because its decision was settled
+elsewhere still reads `proposed` — because nobody ever ruled on it. No other
+non-increasing substrate metric is relaxed.
+
+**Status:** implemented on `feat/decision-resolution-proposals`. The model,
+migration, store, write-through adapters, the inline accept/amend/reject card
+and the review-queue section are in; `amend-stance` and `release-material`
+deliberately REFUSE rather than reporting a success they cannot deliver, and
+stay that way until their write paths are wired. The `workroomId` column is
+NOT in this migration after all: nothing writes it until the panel exists, and
+a column with no writer is dead substrate that reads as capability. It lands
+with its writer in Phase 3.
+
 ---
 
 ## Phase 3 — The panel (BI-19B350FD)

--- a/docs/superpowers/specs/2026-08-23-decision-concierge-design.md
+++ b/docs/superpowers/specs/2026-08-23-decision-concierge-design.md
@@ -4,7 +4,7 @@ status: draft
 
 # Decision Concierge — the review queue proposes, the owner rules
 
-Phase 1 (BI-6700AF66) is implemented on this branch; phases 2-4 are proposed.
+Phase 1 (BI-6700AF66) shipped in #4601. Phase 2 (BI-3D0FB84B) is implemented on this branch; phases 3-4 are proposed.
 Owner: platform (WWMD)
 Epic: EP-0AF96937 (Decision Governance Surface — close the review-and-adjust loop)
 Workroom: WC-69329196
@@ -130,10 +130,10 @@ Resolution order, each step evidence-backed and skipped when it yields nothing:
    belongs to the review page, and a record page that needs embeddings to render
    fails whenever the embedding runtime is down.
 
-**Forward fix (Phase 2):** the gate writes `workroomId` onto
+**Forward fix (Phase 3):** the gate writes `workroomId` onto
 `DecisionInteraction` when the caller context carries one, so future rows do not
-depend on the resolver's inference. It rides the Phase 2 migration rather than
-spending one of its own. The resolver stays for historic rows either way, and
+depend on the resolver's inference. The column lands WITH its writer, not
+before it: a column nothing writes reads as capability and is not. The resolver stays for historic rows either way, and
 reports which step it used so the page says "matched through the session token"
 rather than implying certainty.
 

--- a/docs/user-guide/wiki/index.md
+++ b/docs/user-guide/wiki/index.md
@@ -55,6 +55,12 @@ Following **Answer it once** from a decision now opens that finding on Review & 
 
 Do not work the log line by line. Review & adjust groups the waiting rows into themes; answering a theme once — or adding a stance or craft guidance that covers it — teaches your AI so that question stops needing a human. Exact repeated asks appear once with a matching-ask count. Marking that item reviewed or dismissed applies the same disposition to every exact match, so the completed cluster leaves the queue while each original interaction remains in the audit ledger.
 
+## Suggestions Your Coworkers Drafted
+
+When your coworkers have worked out what you should do about a decision, the record carries their suggestion: what they recommend, what accepting it would change, and whether any of them disagreed. You can accept it as written, edit the wording and accept your version, or reject it with a reason so it does not come back.
+
+Nothing is applied behind you. Accepting a business answer still saves it as draft doctrine for you to review, exactly as answering a gap does, and a suggestion whose decision gets settled somewhere else quietly expires instead of waiting to be accepted later. Suggestions still waiting on you are listed at the top of Review & adjust.
+
 ## Review & Adjust Findings
 
 `/coworker-decisions/review` surfaces findings over the accumulating decision ledger so you can keep governance sharp without reading every row: conflicting principles, gaps where the doctrine has no settled answer yet, a canonical decision that quietly drifted under a doctrine change, and stale decision material. It shows only findings with enough recorded context and a real owner action. Open a finding to see the specific evidence, why it needs attention, the available resolution, and what completion will change. Empty or internal-only records stay in audit history instead of becoming unusable work.

--- a/docs/ux-fit/2026-08-23-decision-resolution-proposal-card.ux-fit.json
+++ b/docs/ux-fit/2026-08-23-decision-resolution-proposal-card.ux-fit.json
@@ -1,0 +1,24 @@
+{
+  "version": "1",
+  "decidedOption": "accept-amend-reject-inline",
+  "decisionInteractionId": "DI-C992EBD1A356",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/proposal-card.tsx",
+      "apps/web/app/(shell)/coworker-decisions/review/page.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "decisionInteractionId": "DI-C992EBD1A356",
+    "consideredOptions": [
+      "accept-amend-reject-inline",
+      "accept-reject-only"
+    ]
+  },
+  "rationale": {
+    "accept-amend-reject-inline": "CHOSEN. Kernel composite 9.379, margin 3.085, high confidence, autonomy eligible. Three controls on the decision record itself: Accept as drafted, Edit-then-accept (the draft becomes editable in place and what the owner accepts is what gets recorded), Reject with a reason. Lowest operator_effort (0.15 vs 0.6) and highest legibility_of_consequence (0.8 vs 0.55), and it is the only option that scores POSITIVE on 'Do the work; don't task the operator with what an agent can do' (+0.149 vs -0.166). The card states what accepting actually does for that kind of proposal, including that a business answer still lands as draft, so the consequence is read before the confirm.",
+    "accept-reject-only": "REJECTED. Kernel composite 6.294. Two controls reads simpler, but anyone who wants different wording is sent to the stance editor to author it themselves — the exact dead-end this whole feature exists to remove — and no draft-versus-accepted signal is ever captured, so nothing measures whether the drafting is worth its cost. It scores negative on both 'Never ask the user to run commands' (-0.075) and 'Preserve the model; disclose complexity progressively' (-0.016)."
+  },
+  "notes": "BI-3D0FB84B, EP-0AF96937, spec docs/superpowers/specs/2026-08-23-decision-concierge-design.md §4.4-§4.5. Arrival cost is bounded and conditional: the card renders only when a coworker has drafted a resolution for that decision, and the edit box and the reason box appear only after the owner picks that path — the resting state is a summary, one consequence sentence, the draft, and three controls. Dissent is shown when coworkers disagreed and agreement is stated explicitly when they did not, so silence and consensus never look alike. Confidence is stated in words and warns rather than reassures below 0.45. Every string comes from lib/decision/proposal-presentation.ts and lib/decision/proposal-messages.ts; the component holds no copy of its own, colour is --dpf-* tokens only, and both textareas carry an aria-label. Nothing on this card applies doctrine directly: accepting routes through the existing write path for its action kind, and a corpus answer still lands as draft for review."
+}

--- a/packages/db/prisma/migrations/20260823210000_add_decision_resolution_proposal/migration.sql
+++ b/packages/db/prisma/migrations/20260823210000_add_decision_resolution_proposal/migration.sql
@@ -1,0 +1,54 @@
+-- A resolution an owner can rule on (BI-3D0FB84B, EP-0AF96937).
+--
+-- Additive and standalone: no existing table changes, no backfill. Decisions
+-- recorded before this migration simply have no proposal, which is exactly
+-- true — nothing had drafted one. Every FK is ON DELETE SET NULL except the
+-- decision and profile it belongs to, which cascade: a proposal for a deleted
+-- decision is not evidence of anything.
+CREATE TYPE "DecisionProposalScope" AS ENUM ('interaction', 'gap-cluster');
+CREATE TYPE "DecisionProposalAction" AS ENUM ('answer-gap', 'adopt-option', 'adjust-weight', 'amend-stance', 'release-material', 'no-change');
+CREATE TYPE "DecisionProposalStatus" AS ENUM ('proposed', 'accepted', 'amended', 'rejected');
+
+CREATE TABLE IF NOT EXISTS "DecisionResolutionProposal" (
+    "id" TEXT NOT NULL,
+    "proposalId" TEXT NOT NULL,
+    "scopeKind" "DecisionProposalScope" NOT NULL,
+    "interactionId" TEXT,
+    "domainClass" TEXT,
+    "profileId" TEXT NOT NULL,
+    "actionKind" "DecisionProposalAction" NOT NULL,
+    "draftPayload" JSONB NOT NULL DEFAULT '{}',
+    "summary" TEXT NOT NULL,
+    "consequences" JSONB NOT NULL DEFAULT '[]',
+    "dissent" JSONB NOT NULL DEFAULT '[]',
+    "confidence" DOUBLE PRECISION,
+    "deliberationRunId" TEXT,
+    "status" "DecisionProposalStatus" NOT NULL DEFAULT 'proposed',
+    "ruledByUserId" TEXT,
+    "ruledAt" TIMESTAMP(3),
+    "rulingNote" TEXT,
+    "acceptedPayload" JSONB,
+    "replacedByProposalId" TEXT,
+    "lifecycle" "RecordLifecycle" NOT NULL DEFAULT 'active',
+    "lifecycleAt" TIMESTAMP(3),
+    "lifecycleReason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DecisionResolutionProposal_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "DecisionResolutionProposal_proposalId_key" ON "DecisionResolutionProposal"("proposalId");
+CREATE INDEX IF NOT EXISTS "DecisionResolutionProposal_status_createdAt_idx" ON "DecisionResolutionProposal"("status", "createdAt");
+CREATE INDEX IF NOT EXISTS "DecisionResolutionProposal_lifecycle_status_createdAt_idx" ON "DecisionResolutionProposal"("lifecycle", "status", "createdAt");
+CREATE INDEX IF NOT EXISTS "DecisionResolutionProposal_profileId_domainClass_status_idx" ON "DecisionResolutionProposal"("profileId", "domainClass", "status");
+CREATE INDEX IF NOT EXISTS "DecisionResolutionProposal_interactionId_idx" ON "DecisionResolutionProposal"("interactionId");
+CREATE INDEX IF NOT EXISTS "DecisionResolutionProposal_deliberationRunId_idx" ON "DecisionResolutionProposal"("deliberationRunId");
+CREATE INDEX IF NOT EXISTS "DecisionResolutionProposal_ruledByUserId_idx" ON "DecisionResolutionProposal"("ruledByUserId");
+CREATE INDEX IF NOT EXISTS "DecisionResolutionProposal_replacedByProposalId_idx" ON "DecisionResolutionProposal"("replacedByProposalId");
+
+ALTER TABLE "DecisionResolutionProposal" ADD CONSTRAINT "DecisionResolutionProposal_interactionId_fkey" FOREIGN KEY ("interactionId") REFERENCES "DecisionInteraction"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "DecisionResolutionProposal" ADD CONSTRAINT "DecisionResolutionProposal_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "DecisionPerspectiveProfile"("profileId") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "DecisionResolutionProposal" ADD CONSTRAINT "DecisionResolutionProposal_ruledByUserId_fkey" FOREIGN KEY ("ruledByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "DecisionResolutionProposal" ADD CONSTRAINT "DecisionResolutionProposal_deliberationRunId_fkey" FOREIGN KEY ("deliberationRunId") REFERENCES "DeliberationRun"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "DecisionResolutionProposal" ADD CONSTRAINT "DecisionResolutionProposal_replacedByProposalId_fkey" FOREIGN KEY ("replacedByProposalId") REFERENCES "DecisionResolutionProposal"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema/core-identity.prisma
+++ b/packages/db/prisma/schema/core-identity.prisma
@@ -73,6 +73,7 @@ model User {
   decisionEscalationsResolved    EscalationCapture[]           @relation("DecisionEscalationResolverUser")
   triggeredDecisionInteractions  DecisionInteraction[]         @relation("DecisionInteractionTriggeredByUser")
   weightAdjustmentProposalsRuled WeightAdjustmentProposal[]
+  decisionResolutionProposalsRuled DecisionResolutionProposal[]
   perspectiveMaterialReviewed    PerspectiveMaterial[]
   scheduledAgentTasks            ScheduledAgentTask[]          @relation("ScheduledAgentTaskOwner")
   addedLocalities                City[]                        @relation("CityAddedByUser")

--- a/packages/db/prisma/schema/decision-governance.prisma
+++ b/packages/db/prisma/schema/decision-governance.prisma
@@ -169,6 +169,7 @@ model DeliberationRun {
   taskRun              TaskRun                @relation(fields: [taskRunId], references: [id], onDelete: Cascade)
   pattern              DeliberationPattern    @relation(fields: [patternId], references: [id])
   outcome              DeliberationOutcome?
+  resolutionProposals  DecisionResolutionProposal[]
   issueSets            DeliberationIssueSet[]
   claims               ClaimRecord[]
   evidenceBundles      EvidenceBundle[]
@@ -301,6 +302,7 @@ model DecisionPerspectiveProfile {
   fallbackInteractions      DecisionInteraction[]               @relation("DecisionInteractionFallbackProfile")
   voiceProfile              VoiceProfile?
   weightAdjustmentProposals WeightAdjustmentProposal[]
+  resolutionProposals       DecisionResolutionProposal[]
 
   @@index([kind, status])
   @@index([ownerOrganizationId])
@@ -439,6 +441,7 @@ model DecisionInteraction {
   triggeredByUser         User?                             @relation("DecisionInteractionTriggeredByUser", fields: [triggeredByUserId], references: [id], onDelete: SetNull)
   escalationCapture       EscalationCapture?
   deferralCapture         DeferralCapture?
+  resolutionProposals     DecisionResolutionProposal[]
   voiceOutput             DecisionInteractionVoiceOutput?
   evidenceReverifications EvidenceReVerification[]
 
@@ -710,4 +713,106 @@ model DecisionInteractionVoiceOutput {
   interaction     DecisionInteraction @relation(fields: [interactionId], references: [id], onDelete: Cascade)
 
   @@index([voiceProfileId])
+}
+
+// Closed sets for DecisionResolutionProposal (BI-3D0FB84B, AGENTS.md §8). Real
+// enums rather than TEXT behind a CHECK: the table is new, so there are no
+// legacy rows whose values could drift, and widening any of these axes should
+// cost a migration and a deliberate look at every switch that reads them.
+enum DecisionProposalScope {
+  interaction
+  gap_cluster @map("gap-cluster")
+}
+
+enum DecisionProposalAction {
+  answer_gap       @map("answer-gap")
+  adopt_option     @map("adopt-option")
+  adjust_weight    @map("adjust-weight")
+  amend_stance     @map("amend-stance")
+  release_material @map("release-material")
+  no_change        @map("no-change")
+}
+
+// What the HUMAN ruled. Whether the row is still live is a separate axis and
+// belongs to the canonical `lifecycle` convention, not to this enum: a
+// superseded draft and a rejected one are not the same fact, and conflating
+// them would make "did anyone decide this?" unanswerable.
+enum DecisionProposalStatus {
+  proposed
+  accepted
+  amended
+  rejected
+}
+
+// A resolution an owner can rule on (BI-3D0FB84B, EP-0AF96937).
+//
+// WHY A NEW MODEL. Every resolution path the platform has starts from a blank
+// field, and a panel verdict has nowhere to live with a lifecycle:
+//   - DeliberationOutcome is a synthesis SNAPSHOT — no status, no ruling, no
+//     supersession, and one row per run rather than per thing-to-decide.
+//   - WeightAdjustmentProposal covers exactly one actionKind (an axis weight).
+//   - AgentActionProposal governs whether a tool may EXECUTE, not what doctrine
+//     should say.
+// This model is the missing middle: a drafted resolution, bound either to one
+// decision or to a cluster of unanswered ones, that a human accepts, amends or
+// rejects. Accepting never mutates doctrine directly — every actionKind writes
+// through an existing path, and corpus changes still land as draft.
+//
+// `interactionId` references DecisionInteraction.id (the row id), matching the
+// naming EscalationCapture and DeferralCapture already use on this spine.
+model DecisionResolutionProposal {
+  id                String                     @id @default(cuid())
+  proposalId        String                     @unique
+  // "interaction" — one specific decision; "gap-cluster" — every unanswered
+  // decision in a domain, which is the unit the review queue already groups by.
+  scopeKind         DecisionProposalScope
+  interactionId     String?
+  domainClass       String?
+  profileId         String
+  actionKind        DecisionProposalAction
+  // The artifact itself, shaped per actionKind (answer text, option id, axis
+  // delta, page slug + body). Never applied from here — see the store.
+  draftPayload      Json                       @default("{}")
+  summary           String                     @db.Text
+  // [{ optionId, text }] — what each option costs, as the panel stated it.
+  consequences      Json                       @default("[]")
+  // [{ role, position, because }] — who disagreed and why. An empty panel
+  // roster records as empty; a MISSING dissent field is a contract failure
+  // upstream and blocks the proposal from being written at all.
+  dissent           Json                       @default("[]")
+  confidence        Float?
+  deliberationRunId String?
+  status            DecisionProposalStatus     @default(proposed)
+  // Row liveness, the ONE not-active convention (BI-C357FA5A). A draft the
+  // corpus moved under, or whose decision was settled elsewhere, leaves
+  // `active` here while `status` still records that nobody ever ruled on it.
+  lifecycle         RecordLifecycle            @default(active)
+  lifecycleAt       DateTime?
+  lifecycleReason   String?
+  ruledByUserId     String?
+  ruledAt           DateTime?
+  rulingNote        String?                    @db.Text
+  // What the human actually accepted when they edited the draft first. The
+  // delta between draftPayload and this is the only honest measure of whether
+  // the drafting is worth its cost.
+  acceptedPayload   Json?
+  // Successor pointer for a supersede chain: a declared self-relation with a
+  // leading index, never a bare *Id column.
+  replacedByProposalId String?
+  createdAt         DateTime                   @default(now())
+  updatedAt         DateTime                   @updatedAt
+  interaction       DecisionInteraction?       @relation(fields: [interactionId], references: [id], onDelete: Cascade)
+  profile           DecisionPerspectiveProfile @relation(fields: [profileId], references: [profileId], onDelete: Cascade)
+  ruledByUser       User?                      @relation(fields: [ruledByUserId], references: [id], onDelete: SetNull)
+  deliberationRun   DeliberationRun?           @relation(fields: [deliberationRunId], references: [id], onDelete: SetNull)
+  replacedBy        DecisionResolutionProposal?  @relation("ProposalSupersession", fields: [replacedByProposalId], references: [id], onDelete: SetNull)
+  replaces          DecisionResolutionProposal[] @relation("ProposalSupersession")
+
+  @@index([status, createdAt])
+  @@index([lifecycle, status, createdAt])
+  @@index([profileId, domainClass, status])
+  @@index([interactionId])
+  @@index([deliberationRunId])
+  @@index([ruledByUserId])
+  @@index([replacedByProposalId])
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -24,6 +24,13 @@ export type {
   CapacityAllocationState,
 } from "../generated/client/client";
 export { WriteGateRequirement } from "../generated/client/client";
+// Decision-resolution proposal vocabulary (BI-3D0FB84B). Exported as values so
+// the app composes from the generated enum instead of re-typing its members.
+export {
+  DecisionProposalAction,
+  DecisionProposalScope,
+  DecisionProposalStatus,
+} from "../generated/client/client";
 export {
   PRINCIPAL_SENSITIVITIES,
   isPrincipalSensitivity,

--- a/packages/db/src/table-classification.ts
+++ b/packages/db/src/table-classification.ts
@@ -80,6 +80,7 @@ export const TABLE_CLASSIFICATION: Record<string, TableSensitivity> = {
   Epic: "internal",
   EpicPortfolio: "internal",
   ImprovementProposal: "internal",
+  DecisionResolutionProposal: "internal",
   WeightAdjustmentProposal: "internal",
   BrandingConfig: "internal",
   EaReferenceModel: "internal",

--- a/scripts/fk-index-coverage-baseline.json
+++ b/scripts/fk-index-coverage-baseline.json
@@ -419,6 +419,7 @@
     "DecisionInteractionVoiceOutput.voiceProfileId",
     "DecisionPerspectiveProfile.profileId",
     "DecisionPerspectiveProfileVersion.versionId",
+    "DecisionResolutionProposal.proposalId",
     "DecisionShadowLedger.agentId",
     "DecisionShadowLedger.decisionInteractionId",
     "DecisionShadowLedger.envelopeId",

--- a/scripts/platform-substrate-baseline.json
+++ b/scripts/platform-substrate-baseline.json
@@ -17,7 +17,7 @@
     },
     "prismaModelCount": {
       "direction": "non-increasing",
-      "value": 606
+      "value": 607
     },
     "prismaSchemaLines": {
       "direction": "informational",

--- a/scripts/stewardship-exemptions.txt
+++ b/scripts/stewardship-exemptions.txt
@@ -51,6 +51,12 @@ WorkLocation         reference-data  # HR work-location lookup.
 # A row's meaningful lifecycle (when it stops being live evidence a human
 # should still look at) is owned by an explicit domain action, not by age.
 
+DecisionResolutionProposal  domain-lifecycle-managed  # BI-3D0FB84B. A drafted
+  # resolution moves proposed -> accepted/amended/rejected/superseded/expired by a
+  # human ruling or by its decision being settled elsewhere; it is never aged out on
+  # a clock. Rows cascade with the DecisionInteraction they belong to, and a ruled
+  # row is kept deliberately — the draft-versus-accepted delta is the only record of
+  # whether the drafting was worth its cost, and a rejection is doctrine too.
 WeightAdjustmentProposal  domain-lifecycle-managed  # BI-D88DFEEA. status transitions from
   # proposed to ruled/rejected only via an explicit human ruling
   # (ruleWeightAdjustmentProposal); a ruled/rejected row is retained


### PR DESCRIPTION
Phase 2 of the Decision Concierge design, following #4601. Phase 1 gave the decision record its context; this gives it somewhere for an answer to live before the owner types one.

Kernel picked this phase over the proactive-surfacing one (`DI-D2AF90ABA8F9`, composite 10.46 vs 5.37, margin 5.08, high confidence): surfacing first would push items that still say "review evidence" instead of carrying a recommendation.

## What lands

- **`DecisionResolutionProposal`** — one drafted resolution per thing-being-decided, bound to a decision or to a gap cluster. Closed sets are real Prisma enums, not TEXT.
- **Two axes, deliberately not collapsed.** `status` records what the HUMAN ruled (proposed → accepted | amended | rejected); `lifecycle` records whether the row is still live, on the canonical `RecordLifecycle` convention. A draft retired because its decision was settled elsewhere still reads `proposed` — because nobody ever ruled on it. Collapsing them would make "did a human decide this?" unanswerable after the fact.
- **Accepting writes through an existing path** per action kind: the org-answer capture, the escalation record, the weight-proposal ruling. A kind whose path is not wired (`amend-stance`, `release-material`) **refuses** rather than reporting a success it cannot deliver, and a business answer still lands as draft.
- **Amendment is first-class.** The owner edits the draft in place; what they accept is what gets recorded, and the draft-versus-accepted delta is retained — the only honest measure of whether the drafting earns its cost.
- **First ruling wins**, enforced by a conditional update rather than a read-then-write race.
- The review queue leads with suggestions still waiting on a ruling.

## Governance

- Substrate delta approved in the plan: `prismaModelCount` 606 → 607, with the rejected JSON-blob alternative recorded — a proposal needs its own identity, ruling lifecycle and foreign keys, none of which survive inside a blob.
- Data-impact manifest, table classification (`internal`), retention disposition (`domain-lifecycle-managed`), DATA_ASSET_REGISTRY entry, FK-index and closed-set ratchets all satisfied.
- Results compose from the canonical `ActionResult` (`ok()`/`err()`) rather than adding 12 more inline sites.

## Verification

- 32 unit tests across the store, the write-through adapters and the presentation module; the full suite passes.
- `pnpm run pregate` — **PASS** (evidence `cmt6bydbf07rx01pqkto3dl2c`), covering typecheck, the full vitest run and the production build. Two real failures surfaced and were fixed on the way: the new model was missing from `DATA_ASSET_REGISTRY`, and the decision-record page test's prisma mock had no delegate for the new table.
- 50 preflight guards clean; prose-lint and style-drift show no growth.
- Not done: browser-rendered UX verification. The preview route requires signing in and I do not enter credentials. No proposal exists on the live install yet either — nothing drafts one until Phase 3, so the card's resting state on every current decision is "absent", which is what the page tests assert.

## Design grounding

Extends `docs/superpowers/specs/2026-08-23-decision-concierge-design.md` §4.4-§4.5 under EP-0AF96937. Substrate reviewed first: the weight-proposal store as the lifecycle precedent, `capture-org-answer` as the corpus path, and `DeliberationOutcome` — a synthesis snapshot with no ruling lifecycle, which is exactly why it could not carry this.

Also filed while working: BI-F45A2AE2 (prose-lint reads TypeScript generics as UI copy, inflating textMass on any file with two generic calls).

Workroom: WC-69329196

🤖 Generated with [Claude Code](https://claude.com/claude-code)