### PR TITLE
fix(skills): resolve seed files in both corpora, and stop reporting undetectable drift as normal (BI-5798BBA3)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/skills/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/skills/page.test.tsx
@@ -137,6 +137,12 @@ describe("PlatformAiSkillsPage", () => {
       revisions: [],
       seedDrift: {
         inSync: true,
+        seedStatus: "in-sync",
+        repoAvailable: true,
+        candidatePaths: [
+          "skills/build/build-page.skill.md",
+          "packages/dpf-skill-pack/skills/build-page/SKILL.md",
+        ],
         dbBody: "v0",
         seedBody: "v0",
         seedPath: "skills/build/build-page.skill.md",

--- a/apps/web/app/(shell)/platform/ai/skills/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/skills/page.tsx
@@ -231,7 +231,28 @@ export default async function SkillsObservatoryPage({
                   Patch the seed file in the same PR so a fresh install keeps this change.
                 </div>
               )}
-              {!review.seedDrift.inSync && review.seedDrift.seedBody === null && (
+              {review.seedDrift.seedStatus === "missing-in-repo" && (
+                <div
+                  className="mb-3 rounded border px-3 py-2 text-xs"
+                  style={{
+                    borderColor: "color-mix(in srgb, var(--dpf-warning) 35%, var(--dpf-border))",
+                    background: "color-mix(in srgb, var(--dpf-warning) 8%, transparent)",
+                    color: "var(--dpf-text)",
+                  }}
+                >
+                  <strong>Drift can&rsquo;t be checked.</strong> The repo is present but this
+                  skill has no seed file, so an approval can&rsquo;t be compared with what ships.
+                  Looked in:{" "}
+                  {review.seedDrift.candidatePaths.map((candidate, index) => (
+                    <span key={candidate}>
+                      {index > 0 && ", "}
+                      <code>{candidate}</code>
+                    </span>
+                  ))}
+                  .
+                </div>
+              )}
+              {review.seedDrift.seedStatus === "repo-unavailable" && (
                 <div
                   className="mb-3 rounded border px-3 py-2 text-xs"
                   style={{
@@ -240,8 +261,8 @@ export default async function SkillsObservatoryPage({
                     color: "var(--dpf-muted)",
                   }}
                 >
-                  Seed file not found at <code>{review.seedDrift.seedPath}</code> (normal for production
-                  installs where the repo isn&rsquo;t checked out next to the app).
+                  No repo checkout is reachable, so seed drift can&rsquo;t be checked (normal on
+                  production).
                 </div>
               )}
               <div className="mb-4">

--- a/apps/web/lib/skills/seed-parity.test.ts
+++ b/apps/web/lib/skills/seed-parity.test.ts
@@ -17,7 +17,11 @@ vi.mock("fs", () => ({
   readFileSync: readFileSyncMock,
 }));
 
-import { getSkillSeedDrift, resolveSeedPath } from "./seed-parity";
+import {
+  getSkillSeedDrift,
+  resolveSeedPath,
+  resolveSeedPathCandidates,
+} from "./seed-parity";
 
 describe("resolveSeedPath", () => {
   it("derives the seed path from category and skillId", () => {
@@ -91,5 +95,93 @@ describe("getSkillSeedDrift", () => {
     const result = await getSkillSeedDrift("build-page");
     expect(result.inSync).toBe(false);
     expect(result.seedBody).toBeNull();
+  });
+});
+
+describe("resolveSeedPathCandidates — both skill corpora (BI-5798BBA3)", () => {
+  it("offers the coworker corpus path and the dev-pack path", () => {
+    process.env.DPF_REPO_ROOT = "/repo";
+    const paths = resolveSeedPathCandidates("governance", "dpf-verify-substrate-first").map((p) =>
+      p.replace(/\\/g, "/"),
+    );
+    expect(paths).toContain("/repo/skills/governance/dpf-verify-substrate-first.skill.md");
+    expect(paths).toContain(
+      "/repo/packages/dpf-skill-pack/skills/dpf-verify-substrate-first/SKILL.md",
+    );
+  });
+});
+
+describe("resolveSeedPath — resolves a dev-pack skill (BI-5798BBA3)", () => {
+  it("returns the pack SKILL.md when only the pack file exists", () => {
+    process.env.DPF_REPO_ROOT = "/repo";
+    existsSyncMock.mockImplementation((p: string) =>
+      String(p).replace(/\\/g, "/") ===
+      "/repo/packages/dpf-skill-pack/skills/dpf-verify-substrate-first/SKILL.md",
+    );
+    const p = resolveSeedPath("governance", "dpf-verify-substrate-first").replace(/\\/g, "/");
+    expect(p).toBe("/repo/packages/dpf-skill-pack/skills/dpf-verify-substrate-first/SKILL.md");
+    existsSyncMock.mockReset();
+  });
+});
+
+describe("getSkillSeedDrift — dev-pack skills and honest absence (BI-5798BBA3)", () => {
+  it("detects drift for a dev-pack skill whose body lives in packages/dpf-skill-pack", async () => {
+    process.env.DPF_REPO_ROOT = "/repo";
+    findUnique.mockResolvedValueOnce({
+      skillId: "dpf-verify-substrate-first",
+      category: "governance",
+      skillMdContent: "# verify\n\nunfiltered hit count guardrail\n",
+    });
+    existsSyncMock.mockImplementation((p: string) => {
+      const n = String(p).replace(/\\/g, "/");
+      return (
+        n === "/repo" ||
+        n === "/repo/packages/dpf-skill-pack/skills/dpf-verify-substrate-first/SKILL.md"
+      );
+    });
+    readFileSyncMock.mockReturnValueOnce("# verify\n\nthe old body\n");
+
+    const result = await getSkillSeedDrift("dpf-verify-substrate-first");
+    expect(result.seedPath.replace(/\\/g, "/")).toBe(
+      "/repo/packages/dpf-skill-pack/skills/dpf-verify-substrate-first/SKILL.md",
+    );
+    expect(result.seedBody).toContain("the old body");
+    expect(result.inSync).toBe(false);
+    expect(result.seedStatus).toBe("drifted");
+    existsSyncMock.mockReset();
+    readFileSyncMock.mockReset();
+  });
+
+  it("reports missing-in-repo (a real warning) when the repo IS present but no candidate exists", async () => {
+    process.env.DPF_REPO_ROOT = "/repo";
+    findUnique.mockResolvedValueOnce({
+      skillId: "orphan-skill",
+      category: "governance",
+      skillMdContent: "any",
+    });
+    // Repo root exists; no seed file in either corpus.
+    existsSyncMock.mockImplementation((p: string) => String(p).replace(/\\/g, "/") === "/repo");
+
+    const result = await getSkillSeedDrift("orphan-skill");
+    expect(result.seedBody).toBeNull();
+    expect(result.seedStatus).toBe("missing-in-repo");
+    expect(result.repoAvailable).toBe(true);
+    existsSyncMock.mockReset();
+  });
+
+  it("reports repo-unavailable (the benign production case) when the repo is not checked out", async () => {
+    process.env.DPF_REPO_ROOT = "/repo";
+    findUnique.mockResolvedValueOnce({
+      skillId: "dpf-pr-with-dco",
+      category: "governance",
+      skillMdContent: "any",
+    });
+    existsSyncMock.mockImplementation(() => false);
+
+    const result = await getSkillSeedDrift("dpf-pr-with-dco");
+    expect(result.seedBody).toBeNull();
+    expect(result.seedStatus).toBe("repo-unavailable");
+    expect(result.repoAvailable).toBe(false);
+    existsSyncMock.mockReset();
   });
 });

--- a/apps/web/lib/skills/seed-parity.ts
+++ b/apps/web/lib/skills/seed-parity.ts
@@ -7,11 +7,18 @@
 // This helper detects that drift so the UI can flag it and the operator
 // can document the follow-up in the PR.
 //
-// Pure I/O over the local filesystem; the operator surface uses it as a
-// best-effort signal — `seedBody: null` means "we couldn't find the seed",
-// which on a production install (where the repo is not checked out next
-// to the app) is the normal case. The check is meaningful in dev and
-// in CI.
+// Pure I/O over the local filesystem. `seedBody: null` is NOT self-explaining:
+// it means either "the repo isn't checked out next to the app" (benign, the
+// normal production case) or "the repo IS here and we still could not locate a
+// seed for this skill" (a real warning — drift is undetectable for that skill).
+// `seedStatus` distinguishes them; callers must not render the second as normal.
+//
+// BI-5798BBA3: there are TWO skill corpora and the resolver knew only one.
+// Coworker skills live at skills/<category>/<skillId>.skill.md; dev-pack skills
+// live at packages/dpf-skill-pack/skills/<skillId>/SKILL.md — a different
+// directory AND a different filename convention. Resolving only the first meant
+// 38 of 107 SkillDefinition rows never resolved, and they were overwhelmingly
+// the dpf-* skills every external coding agent loads. Both are now candidates.
 
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
@@ -27,14 +34,57 @@ import { prisma } from "@dpf/db";
  * frontmatter exactly matches the basename. Treat that as authoritative
  * and look for `<skillId>.skill.md` first.
  */
-export function resolveSeedPath(category: string, skillId: string): string {
-  const repoRoot = process.env.DPF_REPO_ROOT ?? join(process.cwd(), "..", "..");
-  return join(repoRoot, "skills", category, `${skillId}.skill.md`);
+function repoRoot(): string {
+  return process.env.DPF_REPO_ROOT ?? join(process.cwd(), "..", "..");
 }
+
+/**
+ * Every path a skill's seed could legitimately live at, in preference order:
+ * the coworker corpus first, then the dev-pack layout.
+ */
+export function resolveSeedPathCandidates(category: string, skillId: string): string[] {
+  const root = repoRoot();
+  return [
+    join(root, "skills", category, `${skillId}.skill.md`),
+    join(root, "packages", "dpf-skill-pack", "skills", skillId, "SKILL.md"),
+  ];
+}
+
+/**
+ * The seed path for a skill: the first candidate that exists on disk, else the
+ * primary candidate so the caller still has something to name in a log.
+ */
+export function resolveSeedPath(category: string, skillId: string): string {
+  const candidates = resolveSeedPathCandidates(category, skillId);
+  return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
+}
+
+/** Is a repo checkout reachable at all? Distinguishes benign from real absence. */
+function isRepoAvailable(): boolean {
+  return existsSync(repoRoot());
+}
+
+/**
+ * Why a drift check landed where it did. `missing-in-repo` is a WARNING — the
+ * repo is present and we still found no seed, so drift for this skill cannot be
+ * detected at all. `repo-unavailable` is the benign production case.
+ */
+export type SkillSeedStatus =
+  | "in-sync"
+  | "drifted"
+  | "missing-in-repo"
+  | "repo-unavailable"
+  | "skill-unknown";
 
 export type SkillSeedDrift = {
   /** True iff the seed body matches SkillDefinition.skillMdContent verbatim. */
   inSync: boolean;
+  /** Why this result — never render `missing-in-repo` as normal. */
+  seedStatus: SkillSeedStatus;
+  /** Whether a repo checkout was reachable when the check ran. */
+  repoAvailable: boolean;
+  /** Every path checked, so a log can say where we actually looked. */
+  candidatePaths: string[];
   /** SkillDefinition.skillMdContent (or null if the skill is missing). */
   dbBody: string | null;
   /** Seed file body, or null if the file could not be located/read. */
@@ -56,28 +106,43 @@ export async function getSkillSeedDrift(skillId: string): Promise<SkillSeedDrift
   if (!skill) {
     return {
       inSync: false,
+      seedStatus: "skill-unknown",
+      repoAvailable: isRepoAvailable(),
+      candidatePaths: [],
       dbBody: null,
       seedBody: null,
       seedPath: "",
     };
   }
 
-  const seedPath = resolveSeedPath(skill.category, skill.skillId);
+  // ONE existence pass over the candidates: probe each candidate exactly once and
+  // read the first hit. Probing here and again via resolveSeedPath() would double
+  // the filesystem calls for no gain.
+  const candidatePaths = resolveSeedPathCandidates(skill.category, skill.skillId);
+  const foundPath = candidatePaths.find((candidate) => existsSync(candidate)) ?? null;
+  const seedPath = foundPath ?? candidatePaths[0];
   let seedBody: string | null = null;
-  try {
-    if (existsSync(seedPath)) {
-      seedBody = readFileSync(seedPath, "utf-8");
+  if (foundPath) {
+    try {
+      seedBody = readFileSync(foundPath, "utf-8");
+    } catch (err) {
+      console.warn(
+        `[seed-parity] could not read seed file ${foundPath}:`,
+        err instanceof Error ? err.message : err,
+      );
     }
-  } catch (err) {
-    console.warn(
-      `[seed-parity] could not read seed file ${seedPath}:`,
-      err instanceof Error ? err.message : err,
-    );
   }
 
   if (seedBody === null) {
+    // No seed found. WHICH kind of absence decides whether the operator should
+    // be reassured or warned, so resolve it explicitly rather than letting the
+    // surface guess from `seedBody: null`.
+    const repoAvailable = isRepoAvailable();
     return {
       inSync: false,
+      seedStatus: repoAvailable ? "missing-in-repo" : "repo-unavailable",
+      repoAvailable,
+      candidatePaths,
       dbBody: skill.skillMdContent,
       seedBody: null,
       seedPath,
@@ -89,6 +154,9 @@ export async function getSkillSeedDrift(skillId: string): Promise<SkillSeedDrift
 
   return {
     inSync,
+    seedStatus: inSync ? "in-sync" : "drifted",
+    repoAvailable: true,
+    candidatePaths,
     dbBody: skill.skillMdContent,
     seedBody,
     seedPath,

--- a/docs/user-guide/ai-workforce/index.md
+++ b/docs/user-guide/ai-workforce/index.md
@@ -110,7 +110,7 @@ Skills are grouped by category and collapsed. Open a category to see its skills;
 
 Search and the status/source filters work across the whole catalog, and the groups open automatically when a filter is active so you see matches straight away.
 
-If any skill has drifted from the seed, a warning appears under the summary: a fresh install would not match this one. The drift detail, along with route-level skills, observability, and the curator report, sits under **Technical details** — one control at the foot of the page. Those are diagnostics for when you are investigating something specific, not part of reading the catalog.
+If any skill has drifted from the seed, a warning appears under the summary: a fresh install would not match this one. A second warning says drift **can't be checked** for a skill — the repository is there but that skill has no seed file, so an approval can't be compared with what ships. Treat that as unresolved, not as healthy. When no repository is reachable at all, the page says so plainly; that one is normal on a production install. The drift detail, along with route-level skills, observability, and the curator report, sits under **Technical details** — one control at the foot of the page. Those are diagnostics for when you are investigating something specific, not part of reading the catalog.
 
 ## Related Routes
 


### PR DESCRIPTION
## What

Skill seed-parity knew only one of the two skill corpora, so drift was structurally undetectable for the skills every external coding agent loads — and the surface reported that blindness as normal.

Phase 1 of BI-5798BBA3, governed by **DI-36D36FEBF4BA** (`file-authoritative-pr`), which makes the seed file the thing an approval must reach. This lands the observability half first.

## Why

`resolveSeedPath` returned `<repoRoot>/skills/<category>/<skillId>.skill.md`. That is correct for the coworker corpus (1030 `.skill.md` files), but dev-pack skills live at `packages/dpf-skill-pack/skills/<skillId>/SKILL.md` — a different directory **and** a different filename convention.

Measured against the live `SkillDefinition` table: **38 of 107 rows resolved to a path that does not exist**, overwhelmingly the `dpf-*` skills — `dpf-pr-with-dco`, `dpf-decision-via-kernel`, `dpf-route-learning-to-commons`, `dpf-verify-substrate-first`. With both corpora as candidates that falls to **2**, and both remainders are `__dpf_quarantined__` rows that legitimately have no seed.

The second half is honesty. `seedBody: null` conflated two different situations — the repo isn't checked out next to the app (benign, normal production), and the repo **is** present but no seed could be located (a real warning: drift cannot be checked for that skill at all). The UI rendered both as "normal for production installs", so a skill whose drift is unobservable looked healthy.

Adds a typed `seedStatus` union (`in-sync` | `drifted` | `missing-in-repo` | `repo-unavailable` | `skill-unknown`) per AGENTS.md §3, plus `repoAvailable` and `candidatePaths`. `missing-in-repo` renders as a warning naming both paths checked; `repo-unavailable` keeps the benign copy.

Also collapses a redundant existence probe — one `existsSync` pass over the candidates, reading the first hit, instead of probing in `resolveSeedPath` and again in the caller.

## Why this matters more than it looks

While verifying, the DB body of `dpf-verify-substrate-first` was found reverted to its pre-approval snapshot (byte-identical to revision v1, updated 3 hours after the approval), while the proposal still read `reviewed`. A reseed had destroyed an approved change with no signal anywhere. Without seed-drift observability that is invisible — which is what this PR restores.

## Verification

- Test-first: 5 new tests confirmed **RED (5 failed / 6 passed)** before implementation, **GREEN (11/11)** after. The 6 pre-existing seed-parity tests are unmodified.
- `vitest` — **99 passed across 12 files** (`lib/skills` + the skills page).
- `tsc --noEmit` — clean.
- `pnpm run pregate:preflight` — **OK, 50 guards clean**.
- `pnpm run pregate` — **PASS** for this exact SHA (read via `pregate:status`, not exit code).
- Functional, against the live table: unresolved seed paths **38 → 2**.
- Docs: `docs/user-guide/ai-workforce/index.md` already documented the drift warning, so it is updated rather than attested away. Doc index fresh (680 pages); doc links PASS.

Local-CI-Evidence: cmt6c6wly091u01pqai968xvh (fix/skill-seed-path-resolution@df6c8008b0ba)

Semantic review: recorded **inconclusive** — "deferred while governed local CI owns host capacity". That is infrastructure, not a code finding, and is recorded as inconclusive rather than presented as a pass. Evidence `cmt6b4vdk04da01pqplvx3kqn`, capsule WC-C510B064.

## Scope

Phase 1 only — observability. Propagation (approval emits a branch + PR against the pack, per DI-36D36FEBF4BA) is phase 2 and stays on BI-5798BBA3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
