### PR TITLE
fix(test): ratchet vitest tests against cwd-based repo roots (BI-96033E25)

### DIFF
--- a/packages/db/src/healthcare-care-appointment-model.test.ts
+++ b/packages/db/src/healthcare-care-appointment-model.test.ts
@@ -8,7 +8,7 @@ import { prisma } from "./client";
 describe("healthcare care appointment Prisma substrate", () => {
   it("models one typed subject while retaining conditional clinical relations", () => {
     const schema = readFileSync(
-      resolve(process.cwd(), "prisma/schema/verticals-care.prisma"),
+      resolve(__dirname, "../prisma/schema/verticals-care.prisma"),
       "utf8",
     );
     const appointment = schema.slice(

--- a/packages/db/src/healthcare-care-intake-model.test.ts
+++ b/packages/db/src/healthcare-care-intake-model.test.ts
@@ -8,7 +8,7 @@ import { prisma } from "./client";
 describe("healthcare care intake Prisma substrate", () => {
   it("keeps packet identity subject-aware and generic evidence joins patient-optional", () => {
     const schema = readFileSync(
-      resolve(process.cwd(), "prisma/schema/verticals-care.prisma"),
+      resolve(__dirname, "../prisma/schema/verticals-care.prisma"),
       "utf8",
     );
     const packet = schema.slice(

--- a/scripts/check-test-cwd-independence.mjs
+++ b/scripts/check-test-cwd-independence.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * BI-96033E25 — CI ratchet: a vitest test must not resolve a repo path from
+ * process.cwd().
+ *
+ * THE DEFECT THIS FREEZES. `packages/db/src/skill-quality-audit.test.ts` computed
+ * its repo root as `join(process.cwd(), "..", "..")`. That is only correct when
+ * vitest is invoked with cwd = the package directory. `vitest run --root
+ * <repo>/packages/db` is a documented, commonly-used invocation — it is how a
+ * worktree-based session runs one package's tests — and it leaves process.cwd()
+ * at the REPO ROOT, so the computed root landed OUTSIDE the repository:
+ *
+ *   ENOENT: no such file or directory, open '<outside-repo>/skills/build/start-feature.skill.md'
+ *
+ * That reads as a missing skill file, not as a broken test harness. The
+ * misdiagnosis cost real time during BI-8AD9D018. The class is silent by
+ * construction: CI happens to invoke from the package directory, so it stays
+ * green while the contributor is the only one who sees it fail.
+ *
+ * THE RULE. Resolve from the test file's own location (`__dirname`), which is
+ * invocation-independent, not from the process working directory:
+ *
+ *   const rootDir = join(__dirname, "..", "..", "..");   // correct
+ *   const rootDir = join(process.cwd(), "..", "..");     // flagged
+ *
+ * SCOPE — deliberately vitest test files under apps/ and packages/ only.
+ * `scripts/**\/*.test.mjs` is EXCLUDED on purpose: those are repo-root CLIs whose
+ * cwd-dependence is by design (`export function scanRepo(root = process.cwd())`),
+ * they are invoked only as `node --test scripts/…` from package.json with no
+ * `working-directory` override anywhere in CI, and there is no supported
+ * invocation that moves their cwd. Measured 2026-08-23: 31 of them do fail when
+ * run from a foreign cwd, but that invocation is not supported and not reachable
+ * through any CI or package.json path — latent, not live. Widening this guard to
+ * cover them would force churn in working code against a hypothetical caller.
+ *
+ * Run: node scripts/check-test-cwd-independence.mjs
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const SCAN_ROOTS = ["apps", "packages"];
+export const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|mts|js|jsx)$/;
+
+/**
+ * Files that legitimately mention process.cwd() as ONE candidate among several
+ * and verify the result before using it — cwd-independent by construction.
+ * Do NOT add entries to silence a real violation; fix the resolution instead.
+ */
+export const ALLOWLIST = new Set([
+  // Probes DPF_REPO_ROOT, then cwd, then cwd/../.., and accepts the first whose
+  // skills/product-management directory actually exists. Correct from any cwd.
+  "apps/web/lib/product-management/product-management-playbook-seed.test.ts",
+]);
+
+// cwd used as the BASE of a path — the defect. Tolerates newlines, because the
+// original offenders wrapped the argument list across lines.
+const CWD_AS_PATH_BASE = /\b(?:join|resolve)\s*\(\s*process\.cwd\(\)/;
+
+// A bare repo-relative literal handed to fs — Node resolves it against cwd
+// implicitly, which is the same defect with no process.cwd() token to grep for.
+const BARE_REPO_RELATIVE_READ =
+  /\b(?:readFileSync|readdirSync|existsSync|statSync|createReadStream|openSync)\s*\(\s*["'`](?:apps|packages|scripts|docs|prisma|tests|\.github)\//;
+
+function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry === "node_modules" || entry === ".next" || entry === "dist") continue;
+    const full = join(dir, entry);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) walk(full, out);
+    else if (TEST_FILE_RE.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+/** @returns {{file: string, line: number, text: string, rule: string}[]} */
+export function scanRepo(root = process.cwd()) {
+  const violations = [];
+  for (const scanRoot of SCAN_ROOTS) {
+    for (const file of walk(join(root, scanRoot))) {
+      const rel = relative(root, file).split("\\").join("/");
+      if (ALLOWLIST.has(rel)) continue;
+      const source = readFileSync(file, "utf8");
+      if (!CWD_AS_PATH_BASE.test(source) && !BARE_REPO_RELATIVE_READ.test(source)) {
+        continue;
+      }
+      // Report precise lines. Re-join a small window so a wrapped call still
+      // reports the line the call STARTS on rather than the line cwd sits on.
+      const lines = source.split("\n");
+      for (let i = 0; i < lines.length; i += 1) {
+        const window = lines.slice(i, i + 4).join("\n");
+        const startsHere =
+          (CWD_AS_PATH_BASE.test(window) && /\b(?:join|resolve)\s*\($/.test(lines[i].trimEnd())) ||
+          CWD_AS_PATH_BASE.test(lines[i]) ||
+          BARE_REPO_RELATIVE_READ.test(lines[i]);
+        if (!startsHere) continue;
+        violations.push({
+          file: rel,
+          line: i + 1,
+          text: lines[i].trim(),
+          rule: BARE_REPO_RELATIVE_READ.test(lines[i])
+            ? "bare-repo-relative-read"
+            : "cwd-as-path-base",
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+/** Allowlist entries whose file no longer exists or no longer needs the entry. */
+export function findStaleAllowlist(root = process.cwd()) {
+  const stale = [];
+  for (const rel of ALLOWLIST) {
+    let source;
+    try {
+      source = readFileSync(join(root, rel), "utf8");
+    } catch {
+      stale.push(`${rel} (file no longer exists)`);
+      continue;
+    }
+    if (!CWD_AS_PATH_BASE.test(source) && !BARE_REPO_RELATIVE_READ.test(source)) {
+      stale.push(`${rel} (no longer resolves from cwd)`);
+    }
+  }
+  return stale;
+}
+
+function main() {
+  const violations = scanRepo();
+  const stale = findStaleAllowlist();
+
+  if (violations.length > 0) {
+    console.error("");
+    console.error("ERROR: BI-96033E25 — a vitest test resolves a repo path from process.cwd().");
+    console.error("");
+    console.error("This passes when vitest runs with cwd = the package directory and FAILS with a");
+    console.error("misleading ENOENT when it runs as `vitest run --root <repo>/<package>`, which");
+    console.error("points outside the repository. Resolve from the test file instead:");
+    console.error("");
+    console.error('  const rootDir = join(__dirname, "..", "..", "..");');
+    console.error("");
+    console.error("Offending lines:");
+    for (const v of violations) console.error(`  ${v.file}:${v.line}  [${v.rule}]  ${v.text}`);
+    console.error("");
+    process.exit(1);
+  }
+
+  if (stale.length > 0) {
+    console.error("");
+    console.error("ERROR: BI-96033E25 — the cwd-independence allowlist is stale.");
+    console.error("Delete these from ALLOWLIST in scripts/check-test-cwd-independence.mjs:");
+    for (const f of stale) console.error(`  ${f}`);
+    console.error("");
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ No vitest test resolves a repo path from process.cwd() (${ALLOWLIST.size} verified-safe exception).`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-test-cwd-independence.test.mjs
+++ b/scripts/check-test-cwd-independence.test.mjs
@@ -1,0 +1,101 @@
+/**
+ * BI-96033E25 — tests for the cwd-independence ratchet.
+ *
+ * Run: node --test scripts/check-test-cwd-independence.test.mjs
+ *
+ * NOTE: this file resolves the repo root from import.meta.url, never from
+ * process.cwd(). A test for a cwd-independence guard that itself depended on cwd
+ * would be the exact defect it exists to prevent.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ALLOWLIST,
+  scanRepo,
+  findStaleAllowlist,
+} from "./check-test-cwd-independence.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..");
+
+/** Build a throwaway repo containing one test file, and scan it. */
+function scanFixture(fileName, contents) {
+  const root = mkdtempSync(join(tmpdir(), "dpf-cwd-guard-"));
+  try {
+    const dir = join(root, "packages", "db", "src");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, fileName), contents);
+    return scanRepo(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("flags cwd used as a path base — the original BI-8AD9D018 defect", () => {
+  const found = scanFixture(
+    "offender.test.ts",
+    'const rootDir = join(process.cwd(), "..", "..");\n',
+  );
+  assert.equal(found.length, 1);
+  assert.equal(found[0].rule, "cwd-as-path-base");
+  assert.equal(found[0].line, 1);
+});
+
+test("flags the same defect when the call wraps across lines", () => {
+  const found = scanFixture(
+    "wrapped.test.ts",
+    ["const principleDir = resolve(", "  process.cwd(),", '  "../../docs",', ");", ""].join("\n"),
+  );
+  assert.ok(found.length >= 1, "a wrapped resolve(process.cwd(), …) must still be flagged");
+  assert.equal(found[0].rule, "cwd-as-path-base");
+});
+
+test("flags a bare repo-relative literal handed to fs — same defect, no cwd token", () => {
+  const found = scanFixture(
+    "bare.test.ts",
+    'const cfg = readFileSync("apps/web/vitest.config.ts", "utf8");\n',
+  );
+  assert.equal(found.length, 1);
+  assert.equal(found[0].rule, "bare-repo-relative-read");
+});
+
+test("accepts the __dirname form the fix uses", () => {
+  const found = scanFixture(
+    "fixed.test.ts",
+    'const rootDir = join(__dirname, "..", "..", "..");\n',
+  );
+  assert.deepEqual(found, []);
+});
+
+test("does not flag cwd passed as a spawn option or saved for restore", () => {
+  const found = scanFixture(
+    "legit.test.ts",
+    [
+      "const previous = process.cwd();",
+      'execFileSync("git", ["status"], { cwd: process.cwd() });',
+      "const root = resolveRootClonePath(process.cwd());",
+      "",
+    ].join("\n"),
+  );
+  assert.deepEqual(found, [], "only cwd used as a PATH BASE is a violation");
+});
+
+test("the real repository is clean — the ratchet holds at its baseline", () => {
+  assert.deepEqual(scanRepo(REPO_ROOT), []);
+});
+
+test("the allowlist is not stale", () => {
+  assert.deepEqual(findStaleAllowlist(REPO_ROOT), []);
+});
+
+test("allowlist stays small and deliberate", () => {
+  assert.ok(
+    ALLOWLIST.size <= 3,
+    "a growing allowlist means the guard is being silenced rather than obeyed",
+  );
+});

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -71,6 +71,7 @@ const EXPECTED_LEGACY_JOBS = [
   "stewardship-scope-guard",
   "style-drift-guard",
   "test-clock-bomb-guard",
+  "test-cwd-independence-guard",
   "tool-surface-guard",
   "ux-fit-gate",
   "ux-primitive-adoption-guard",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -331,6 +331,13 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("package-boundary-guard", "Package Boundary Guard", [
       node("scripts/check-package-boundaries.mjs"),
     ]),
+    // BI-96033E25 — a vitest test must resolve repo paths from __dirname, not
+    // process.cwd(), or `vitest run --root <pkg>` reads outside the repo and
+    // fails as a misleading missing file.
+    guard("test-cwd-independence-guard", "Test Cwd Independence Guard", [
+      node("--test", "scripts/check-test-cwd-independence.test.mjs"),
+      node("scripts/check-test-cwd-independence.mjs"),
+    ]),
     guard("build-studio-namespace-guard", "Build Studio Namespace Guard", [
       node("scripts/check-build-namespace.mjs"),
     ]),


### PR DESCRIPTION
Follow-up to #4582, which fixed the eight known offenders by hand. Hand-sweeping is what let this class exist, so this freezes it.

## The guard earned its place on first run

Its baseline assertion — *"the real repository is clean"* — failed immediately and named two files the manual sweep had missed:

```
packages/db/src/healthcare-care-appointment-model.test.ts:11
packages/db/src/healthcare-care-intake-model.test.ts:11
  resolve(process.cwd(), "prisma/schema/verticals-care.prisma")
```

Both are fixed here. They were missed because the sweep grepped for `process.cwd()` lines containing `..`, and these resolve a path with **no parent segment** — exactly the gap a grep-shaped sweep leaves and a guard does not. The real offender count was 10, not 8.

## What it flags

| shape | example | why |
|---|---|---|
| cwd as a path base | `join(process.cwd(), "..", "..")` | the original defect; also matches calls wrapped across lines |
| bare repo-relative fs read | `readFileSync("apps/web/vitest.config.ts")` | Node resolves against cwd implicitly — same defect, no `process.cwd()` token to grep for |

Not flagged: cwd as a spawn option, saved for restore, or handed to the subject under test. One allowlist entry (a seed test that probes several candidate roots and verifies each) with a staleness check so it can't rot.

## Scope, and why it stops where it does

Vitest tests under `apps/` and `packages/` only. `scripts/**/*.test.mjs` is excluded **deliberately**: those are repo-root CLIs whose cwd-dependence is by design —

```js
export function scanRepo(root = process.cwd())
```

— invoked only as `node --test scripts/…` from package.json, with no `working-directory` override anywhere in CI.

I measured that surface rather than assuming it: **31 of them do fail from a foreign cwd** (240 files; 228 pass / 12 fail at repo root vs 198 pass / 42 fail from `packages/db`). But no supported invocation puts them there, so it's latent, not live. Widening the guard would force churn in working code against a hypothetical caller. The measurement and the file list are recorded on BI-96033E25 so the decision is reviewable rather than buried.

## Verification

- guard unit tests **8/8**, including the red-then-green baseline assertion that caught the two extra files
- `packages/db` 287 files: **identical** results from the package dir and from the repo root with `--root`; the 5 failures are pre-existing live-Postgres tests against an empty local DB
- `apps/web` and `packages/db` `tsc --noEmit`: exit 0
- `pregate:preflight`: 52 guards clean

## Gate disclosure

Local pregate was NOT run — maintainer-directed bypass while dev-portal lease-loop contention clears; host at load-21. Pushed with a recorded `operator-emergency` override, not `--no-verify`. A pre-commit typecheck rejection was **not** overridden: it was a SIGTERM under host load, disproven by running `tsc` directly in both packages (exit 0) and by the hook passing on retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)