### PR TITLE
fix(inference): a coworker's job description is instruction, not the turn's data (BI-463BE12A, BI-9C14CB5D)

### DIFF
--- a/apps/web/lib/actions/agent-coworker-external.test.ts
+++ b/apps/web/lib/actions/agent-coworker-external.test.ts
@@ -127,6 +127,7 @@ vi.mock("@/lib/route-context-map", () => ({
 
 vi.mock("@/lib/prompt-assembler", () => ({
   assembleSystemPrompt: vi.fn().mockResolvedValue("assembled prompt"),
+  assembleSystemPromptWithProvenance: vi.fn().mockResolvedValue({ text: "assembled prompt", instructionSpans: [] }),
 }));
 
 vi.mock("@/lib/permissions", async () => {
@@ -202,7 +203,7 @@ import { classifyTask } from "@/lib/task-classifier";
 import { executeTool, getAvailableTools, toolsToOpenAIFormat } from "@/lib/mcp-tools";
 import { governedExecuteTool } from "@/lib/mcp-governed-execute";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
-import { assembleSystemPrompt } from "@/lib/prompt-assembler";
+import { assembleSystemPromptWithProvenance } from "@/lib/prompt-assembler";
 import { createTaskArtifact } from "@/lib/tak/task-records";
 import { recordWorkCapsuleEvidence } from "@/lib/work-capsules/work-capsule-store";
 import { prisma } from "@dpf/db";
@@ -218,7 +219,7 @@ const mockToolsToOpenAIFormat = toolsToOpenAIFormat as ReturnType<typeof vi.fn>;
 const mockExecuteTool = executeTool as ReturnType<typeof vi.fn>;
 const mockGovernedExecuteTool = governedExecuteTool as ReturnType<typeof vi.fn>;
 const mockResolvePortalContextEnvelope = resolvePortalContextEnvelope as ReturnType<typeof vi.fn>;
-const mockAssembleSystemPrompt = assembleSystemPrompt as ReturnType<typeof vi.fn>;
+const mockAssembleSystemPrompt = assembleSystemPromptWithProvenance as ReturnType<typeof vi.fn>;
 const mockCreateTaskArtifact = createTaskArtifact as ReturnType<typeof vi.fn>;
 const mockRecordWorkCapsuleEvidence = recordWorkCapsuleEvidence as ReturnType<typeof vi.fn>;
 const mockPrisma = prisma as any;
@@ -383,6 +384,8 @@ describe("agent coworker external access", () => {
           hardEdges: ["Do not grant extra tool authority."],
           expectedArtifact: "patch",
         },
+        // BI-463BE12A: declared brief; undeclared text counts as the turn's data.
+        instructionSpans: expect.arrayContaining([expect.any(String)]),
       }),
     );
   });
@@ -432,6 +435,25 @@ describe("agent coworker external access", () => {
       "restricted",
       expect.not.objectContaining({ tools: expect.anything() }),
     );
+  });
+
+  // BI-463BE12A. USE_UNIFIED_COWORKER is off on a default install, so this is
+  // the path that decides whether a COO or HR coworker reaches a cloud provider.
+  it("declares the coworker's brief as instruction on the legacy path", async () => {
+    await sendMessage({
+      threadId: "thread-1",
+      content: "What needs my attention?",
+      routeContext: "/workspace",
+      coworkerMode: "act",
+    });
+
+    const options = mockRouteAndCall.mock.calls[0]?.[3] ?? {};
+    expect(options.systemPromptInstructionSpans).toEqual(
+      expect.arrayContaining([expect.any(String)]),
+    );
+    // Page context is DATA and must stay undeclared.
+    const declared = (options.systemPromptInstructionSpans ?? []).join("\n");
+    expect(declared).not.toContain("PAGE DATA");
   });
 
   it("strips coworker tools for terse explanation follow-ups like elaborate", async () => {

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -31,7 +31,8 @@ import { getRouteDataContext } from "@/lib/route-context";
 import { observeConversation } from "@/lib/process-observer-hook";
 import { isUnifiedCoworkerEnabled } from "@/lib/feature-flags";
 import { resolveRouteContext } from "@/lib/route-context-map";
-import { assembleSystemPrompt } from "@/lib/prompt-assembler";
+import { assembleSystemPromptWithProvenance } from "@/lib/prompt-assembler";
+import { composeCoworkerDomainContext } from "@/lib/tak/coworker-prompt-provenance";
 import { buildInitiativeBlock } from "@/lib/tak/initiative-block";
 import { getCoworkerProactivityPreference } from "@/lib/actions/proactivity";
 import { resolveReadingLevelForRoute } from "@/lib/readability/policy";
@@ -684,6 +685,7 @@ export async function sendMessage(input: {
   let professionInjectedIntoPrompt = false;
 
   let populatedPrompt: string;
+  let systemPromptInstructionSpans: string[] = [];
   // Governed Hermes learning Slice 1: active coworker skill (if any).
   // Set inside the unified-prompt branch when the user message invokes a
   // known eligible skill via the canonical `Use the <id> skill.` marker.
@@ -830,17 +832,20 @@ export async function sendMessage(input: {
     const selectedDomain = result.selected.find((s) => s.source === "domain")?.content ?? routeCtx.domainContext;
     const selectedPageData = result.selected.find((s) => s.source === "page-data")?.content?.replace("--- PAGE DATA ---\n", "") ?? null;
     const selectedAttachments = result.selected.find((s) => s.source === "attachments")?.content ?? null;
-    const selectedKnowledge = result.selected.find((s) => s.source === "knowledge")?.content ?? null;
-    const selectedMemory = result.selected.find((s) => s.source === "semantic-memory")?.content ?? null;
     // WSID Phase 3: the profession corpus block that survived arbitration (null
     // if it was dropped under budget — recorded as a usage miss below).
     const selectedProfessionContext = result.selected.find((s) => s.source === "profession-corpus")?.content ?? null;
     professionInjectedIntoPrompt = selectedProfessionContext !== null;
 
     // Merge knowledge and semantic memory into domain context if they made the budget
-    let finalDomainContext = `${selectedDomain}\n\n${AUTHORIZED_SURFACE_PROMPT}`;
-    if (selectedKnowledge) finalDomainContext += "\n\n" + selectedKnowledge;
-    if (selectedMemory) finalDomainContext += "\n\n" + selectedMemory;
+    // Knowledge and memory are recalled from the org's own records — DATA, and
+    // deliberately not declared as instruction. See coworker-prompt-provenance.
+    const domain = composeCoworkerDomainContext({
+      persona: selectedDomain,
+      surfaceInstruction: AUTHORIZED_SURFACE_PROMPT,
+      knowledge: result.selected.find((s) => s.source === "knowledge")?.content ?? null,
+      memory: result.selected.find((s) => s.source === "semantic-memory")?.content ?? null,
+    });
 
     // EP-WIKI-001 Phase 3b1: passive wiki context injection.
     // Pulls the top-K kernel + overlay pages relevant to the user's
@@ -942,14 +947,15 @@ export async function sendMessage(input: {
     });
     resolvedBuildId = coworkerExtra.resolvedBuildId;
 
-    populatedPrompt = await assembleSystemPrompt({
+    const assembled = await assembleSystemPromptWithProvenance({
+      instructionSpans: domain.instructionSpans,
       hrRole: user.platformRole ?? "none",
       grantedCapabilities: granted,
       deniedCapabilities: denied,
       mode: (input.coworkerMode as "advise" | "act") ?? "advise",
       sensitivity: routeCtx.sensitivity,
-      domainContext: finalDomainContext,
-      domainTools: [], // Already included in domain block
+      domainContext: domain.domainContext,
+      domainTools: [],
       routeData: selectedPageData,
       attachmentContext: selectedAttachments,
       professionContext: selectedProfessionContext,
@@ -958,12 +964,12 @@ export async function sendMessage(input: {
       extraSections: coworkerExtra.sections,
       skills: skillSummaries,
       questionPacket: input.questionPacket ?? null,
-      // BI-8F8C5F28: on customer-copy surfaces, hold the coworker to the org's
-      // reading level (high-school by default). Null on internal surfaces.
+      // BI-8F8C5F28 reading level; BI-E35A8AA4 proactivity → in-task initiative.
       readingLevel: await resolveReadingLevelForRoute(input.routeContext),
-      // BI-E35A8AA4: Proactivity → in-task initiative.
       proactivityLevel,
     });
+    populatedPrompt = assembled.text;
+    systemPromptInstructionSpans = assembled.instructionSpans;
 
     if (eligibleSkillIds.length > 0) {
       void recordSkillUsageEvents({
@@ -1010,6 +1016,19 @@ export async function sendMessage(input: {
     // and instead dead-ends or deflects to "ask an admin".
     const { loadLimitationResponseBlock } = await import("@/lib/tak/limitation-response-block");
     const legacyLimitationResponseBlock = await loadLimitationResponseBlock();
+    // BI-E35A8AA4: Proactivity → in-task initiative — surface-uniform with the
+    // unified path, which injects the same block via assembleSystemPrompt.
+    const legacyInitiativeBlock = buildInitiativeBlock(proactivityLevel);
+    // BI-463BE12A: the coworker's brief. Everything pushed onto promptSections
+    // below (page context, form-assist, Build Studio) is DATA and stays
+    // undeclared. This is the install default while USE_UNIFIED_COWORKER is off.
+    systemPromptInstructionSpans = [
+      agent.systemPrompt,
+      legacyDecisionRoutingBlock,
+      legacyLimitationResponseBlock,
+      legacyInitiativeBlock,
+      AUTHORIZED_SURFACE_PROMPT,
+    ].filter((span): span is string => Boolean(span?.trim()));
     const promptSections = [
       agent.systemPrompt,
       "",
@@ -1017,9 +1036,7 @@ export async function sendMessage(input: {
       "",
       legacyLimitationResponseBlock,
       "",
-      // BI-E35A8AA4: Proactivity → in-task initiative — surface-uniform with the
-      // unified path, which injects the same block via assembleSystemPrompt.
-      buildInitiativeBlock(proactivityLevel), "", AUTHORIZED_SURFACE_PROMPT,
+      legacyInitiativeBlock, "", AUTHORIZED_SURFACE_PROMPT,
       "",
       "Current context:",
       `- Route: ${input.routeContext}`,
@@ -1922,6 +1939,7 @@ export async function sendMessage(input: {
       () => executeAutonomousAgenticLoop({
         chatHistory,
         systemPrompt: populatedPrompt,
+        systemPromptInstructionSpans,
         sensitivity: agent.sensitivity,
         tools: attachedTools,
         toolsForProvider,

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -10839,6 +10839,7 @@
       "publishedPortal": true,
       "anchors": [
         "what-the-packs-do",
+        "what-counts-as-sensitive-detail-and-what-does-not",
         "possible-outcomes",
         "initial-boundaries",
         "masking-and-correctness",

--- a/apps/web/lib/inference/data-screening/classify-payload.test.ts
+++ b/apps/web/lib/inference/data-screening/classify-payload.test.ts
@@ -328,3 +328,140 @@ describe("ambiguous-vocabulary corroboration (BI-CD13D818)", () => {
     expect(result.dataClasses).toContain("unknown-governed-data");
   });
 });
+
+// BI-463BE12A / BI-9C14CB5D. Measured on the live install over seven days: coo
+// 36/36, market-research-analyst 50/50, admin-assistant 38/38, hr-specialist
+// 33/33 and finance-agent 7/7 turns routed `restricted`, solely because their
+// system prompts describe employment and finance work. `restricted` denies every
+// external provider, so those five had one endpoint and no fallback.
+describe("a coworker's job description is instruction, not payload", () => {
+  // Close to the real assembled COO persona: it names payroll and invoices
+  // because that is the job, and carries no actual employee or payment values.
+  const persona =
+    "You are the COO. You coordinate operations across the business: payroll " +
+    "runs, invoice approvals, salary review cycles, and team performance.";
+  const ask = { role: "user" as const, content: "What needs my attention this morning?" };
+
+  it("does not escalate on a declared instruction span", () => {
+    const result = classifyInferencePayload({
+      messages: [ask],
+      systemPrompt: persona,
+      systemPromptInstructionSpans: [persona],
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).toBe("internal");
+    expect(result.dataEvidencedClasses).toEqual([]);
+  });
+
+  it("still reports every detected class on the receipt", () => {
+    // Suppressed for routing, never hidden from audit.
+    const result = classifyInferencePayload({
+      messages: [ask],
+      systemPrompt: persona,
+      systemPromptInstructionSpans: [persona],
+      taskType: "conversation",
+    });
+
+    expect(result.dataClasses).toContain("employee-records");
+    expect(result.matches.some((m) => m.path.startsWith("systemPrompt.instruction["))).toBe(true);
+  });
+
+  // The load-bearing safety property. An assembly path that declares nothing —
+  // the legacy persona path, and every append made after assembly — classifies
+  // the whole prompt as data and behaves exactly as it did before this existed.
+  it("classifies the whole prompt as data when nothing is declared", () => {
+    const result = classifyInferencePayload({
+      messages: [ask],
+      systemPrompt: persona,
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).toBe("restricted");
+  });
+
+  it("escalates on a real value in an UNDECLARED part of the prompt", () => {
+    // An injected briefing or PAGE DATA block sits in the same string as the
+    // persona. Declaring the persona must not launder what surrounds it.
+    const result = classifyInferencePayload({
+      messages: [ask],
+      systemPrompt: `${persona}\n\n--- PAGE DATA ---\nDana Whitfield, salary 125000.`,
+      systemPromptInstructionSpans: [persona],
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).toBe("restricted");
+  });
+
+  it("escalates on a real value in a message", () => {
+    const result = classifyInferencePayload({
+      messages: [{ role: "user", content: "Set Dana's salary to 125000 effective Monday." }],
+      systemPrompt: persona,
+      systemPromptInstructionSpans: [persona],
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).toBe("restricted");
+  });
+
+  it("escalates on a real value in a tool-call argument", () => {
+    const result = classifyInferencePayload({
+      messages: [{
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "c1", name: "update_person", arguments: { salary: 125000 } }],
+      }],
+      systemPrompt: persona,
+      systemPromptInstructionSpans: [persona],
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).toBe("restricted");
+  });
+
+  it("leaves an explicit governed hint at full force", () => {
+    const result = classifyInferencePayload({
+      messages: [ask],
+      systemPrompt: persona,
+      systemPromptInstructionSpans: [persona],
+      taskType: "conversation",
+      governedData: [{ assetId: "asset-1", classificationKnown: true, sensitivity: "restricted" }],
+    });
+
+    expect(result.overallSensitivity).toBe("restricted");
+  });
+
+  it("ignores a declared span that assembly dropped under a token budget", () => {
+    const result = classifyInferencePayload({
+      messages: [ask],
+      systemPrompt: "Be concise.",
+      systemPromptInstructionSpans: [persona],
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).toBe("internal");
+  });
+
+  it("removes every occurrence of a span, not just the first", () => {
+    const result = classifyInferencePayload({
+      messages: [ask],
+      systemPrompt: `${persona}\n\nReminder:\n${persona}`,
+      systemPromptInstructionSpans: [persona],
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).toBe("internal");
+  });
+
+  it("matches the longest span first so a nested span cannot carve a hole", () => {
+    const outer = `${persona} Escalate anything you cannot resolve.`;
+    const result = classifyInferencePayload({
+      messages: [ask],
+      systemPrompt: outer,
+      systemPromptInstructionSpans: [persona, outer],
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).toBe("internal");
+  });
+});

--- a/apps/web/lib/inference/data-screening/classify-payload.ts
+++ b/apps/web/lib/inference/data-screening/classify-payload.ts
@@ -257,10 +257,16 @@ export function classifyInferencePayload(
 
   const dedupedMatches = dedupeMatches(matches);
   const dataClasses = uniqueSorted(dedupedMatches.map((match) => match.dataClass));
+  const dataEvidencedClasses = uniqueSorted(
+    dedupedMatches
+      .filter((match) => !isInstructionProvenance(match))
+      .map((match) => match.dataClass),
+  );
   const overallSensitivity = inferOverallSensitivity(dedupedMatches, input.governedData);
   const inputHash = hashCanonical({
     messages: input.messages,
     systemPrompt: input.systemPrompt,
+    systemPromptInstructionSpans: input.systemPromptInstructionSpans ?? [],
     tools: input.tools ?? [],
     taskType: input.taskType ?? null,
     governedData: input.governedData ?? [],
@@ -269,6 +275,7 @@ export function classifyInferencePayload(
   return {
     overallSensitivity,
     dataClasses,
+    dataEvidencedClasses,
     matches: dedupedMatches,
     receipt: {
       screenId: `screen_${inputHash.slice(0, 16)}`,
@@ -291,7 +298,18 @@ function normalizeProbePath(path: string): string {
 function collectTextProbes(input: InferencePayloadClassificationInput): TextProbe[] {
   const probes: TextProbe[] = [];
   if (input.systemPrompt) {
-    probes.push({ path: "systemPrompt", text: input.systemPrompt });
+    const split = splitPromptByProvenance(
+      input.systemPrompt,
+      input.systemPromptInstructionSpans,
+    );
+    split.instruction.forEach((span, index) => {
+      probes.push({ path: `${INSTRUCTION_PATH_PREFIX}${index}]`, text: span });
+    });
+    // The remainder keeps the bare `systemPrompt` path: it is data, and every
+    // caller that supplies no spans lands here with the whole prompt, unchanged.
+    if (split.data.trim().length > 0) {
+      probes.push({ path: "systemPrompt", text: split.data });
+    }
   }
 
   input.messages.forEach((message, index) => {
@@ -466,7 +484,88 @@ function uniqueSorted<T extends string>(values: readonly T[]): T[] {
  * 2.70, no commandment conflict); granting external clearance scored worst,
  * opposed by "Outbound and irreversible actions require explicit go" and
  * "Least privilege, deny by default".
+ *
+ * DI-BF2FEDA18D81 (2026-08-23) revisited the provenance half of that decision on
+ * live measurement DI-0A58373E26D0 did not have, and added the instruction-path
+ * rule documented on INSTRUCTION_PROBE_PATHS above. It did NOT reopen external
+ * clearance, which remains rejected for the same two commandments.
  */
+/**
+ * Probe-path prefix for a span of the system prompt the caller marked as
+ * platform-authored INSTRUCTION (BI-463BE12A / BI-9C14CB5D).
+ *
+ * A coworker's system prompt describes the job it does. A COO's says "payroll";
+ * a finance controller's says "invoice"; an HR director's says "salary". Those
+ * are `employee-records` and `payments-finance` text patterns, and because
+ * neither is `ambiguousVocabulary` they took the hasPreciseEvidence branch below
+ * and escalated the turn to `restricted` — which hard-denies every external
+ * provider. Measured on the live install over seven days: coo 36/36,
+ * hr-specialist 33/33, admin-assistant 38/38, market-research-analyst 50/50 and
+ * finance-agent 7/7 turns routed restricted, against 0/45 for platform-engineer.
+ * Those coworkers had never once reached a cloud provider, and since only
+ * `local` and `speaches` carry restricted clearance — and `speaches` offers no
+ * toolUse — their candidate pool was one endpoint with no fallback. One held
+ * lease and the turn was a dead end (BI-A89E4827).
+ *
+ * This is the same category of evidence the tool-declaration exemption already
+ * recognises in collectTextProbes: a static schema field named `payment` is not
+ * a payment. The rule stated at the top of CLASS_RULES — "text probes must
+ * contain value-shaped evidence, not merely governance or instructional
+ * vocabulary that happens to name a protected data class" — simply was not being
+ * applied to the largest block of instructional vocabulary in the payload.
+ *
+ * WHY SPANS RATHER THAN EXEMPTING THE PROMPT. The assembled prompt is a mix.
+ * `finalDomainContext` alone concatenates the coworker persona, an authorized-
+ * surface instruction, retrieved knowledge, and semantic memory into one string,
+ * and text is appended after assembly in at least two more places. Exempting the
+ * whole prompt would open a real egress path for every one of those. Naming the
+ * instruction spans instead means anything unlabelled — including any future
+ * append — is data, so the control fails closed by construction.
+ *
+ * WHY NOT DEMOTE INSTRUCTION MATCHES TO ambiguousVocabulary. That was the first
+ * approach (`prompt-corroboration`, DI-BF2FEDA18D81) and it does not work. The
+ * COO prompt produces three distinct restricted-class reasons on its own, so it
+ * satisfies `distinctAmbiguousReasons >= 2` and escalates anyway. Worse, four
+ * independent channels clamp a turn to local-only — sensitivity clearance, the
+ * per-class export decision, the vertical policy packs, and a mask obligation
+ * that clamps residencyPolicy — and only provenance at the source closes all
+ * four. See docs/superpowers/plans/2026-08-23-prompt-provenance-in-inference-screening.md.
+ */
+const INSTRUCTION_PATH_PREFIX = "systemPrompt.instruction[";
+
+function isInstructionProvenance(match: InferencePayloadMatch): boolean {
+  return match.path.startsWith(INSTRUCTION_PATH_PREFIX);
+}
+
+/**
+ * Split the prompt into instruction spans and the data remainder.
+ *
+ * Spans are matched literally and every occurrence is removed, so a block that
+ * appears twice cannot leave one copy classified as data. A span the caller
+ * names but that is not present is ignored rather than treated as an error —
+ * assembly may legitimately drop a block under a token budget.
+ */
+function splitPromptByProvenance(
+  systemPrompt: string,
+  instructionSpans: readonly string[] | undefined,
+): { instruction: string[]; data: string } {
+  const spans = (instructionSpans ?? [])
+    .map((span) => span.trim())
+    .filter((span) => span.length > 0);
+  if (spans.length === 0) return { instruction: [], data: systemPrompt };
+
+  const present: string[] = [];
+  let remainder = systemPrompt;
+  // Longest first: a short span that is a substring of a longer one must not
+  // carve a hole out of the middle of the longer span before it is matched.
+  for (const span of [...spans].sort((a, b) => b.length - a.length)) {
+    if (!remainder.includes(span)) continue;
+    present.push(span);
+    remainder = remainder.split(span).join("\n");
+  }
+  return { instruction: present, data: remainder };
+}
+
 function inferOverallSensitivity(
   matches: readonly InferencePayloadMatch[],
   governedData: readonly GovernedPayloadHint[] | undefined,
@@ -475,7 +574,20 @@ function inferOverallSensitivity(
     return "restricted";
   }
 
-  const restrictedMatches = matches.filter((match) => RESTRICTED_CLASSES.has(match.dataClass));
+  // Sensitivity rests on the turn's DATA only. Instruction-provenance matches
+  // stay in `matches` and `dataClasses` so the receipt reports everything
+  // detected, but they set no floor at all: a job description naming payroll is
+  // not evidence that payroll data is present, and holding it at `confidential`
+  // still summoned the PDP, which attached a mask obligation, which clamped
+  // residencyPolicy to local_only — the fourth of four channels, and the one
+  // that survived every narrower fix (BI-463BE12A).
+  //
+  // This is only safe BECAUSE provenance is declared at the source rather than
+  // inferred: anything the caller does not name as instruction — including an
+  // injected briefing or PAGE DATA block inside the prompt — is classified as
+  // data and escalates exactly as a message would.
+  const dataMatches = matches.filter((match) => !isInstructionProvenance(match));
+  const restrictedMatches = dataMatches.filter((match) => RESTRICTED_CLASSES.has(match.dataClass));
   const hasPreciseEvidence = restrictedMatches.some(
     (match) => !AMBIGUOUS_REASONS.has(match.reason),
   );
@@ -488,7 +600,7 @@ function inferOverallSensitivity(
     return "restricted";
   }
 
-  const dataClasses = matches.map((match) => match.dataClass);
+  const dataClasses = dataMatches.map((match) => match.dataClass);
   if (
     restrictedMatches.length > 0 ||
     governedData?.some((hint) => hint.sensitivity === "confidential") ||

--- a/apps/web/lib/inference/data-screening/evaluate-inference-policy.ts
+++ b/apps/web/lib/inference/data-screening/evaluate-inference-policy.ts
@@ -87,8 +87,14 @@ export function evaluateInferenceDispatchPolicy(
 ): InferencePolicyEvaluation {
   const classifiedDataClasses = [...input.classification.dataClasses];
   const hasGovernedHints = Boolean(input.governedData?.length);
+  // The PDP gates GOVERNED DATA leaving the install, so it is summoned by what
+  // the turn actually carries — not by a class detected only in the coworker's
+  // job description (BI-463BE12A). Running it on instruction-derived classes
+  // reached the deny-by-default arm (`no-policy-high-risk`) with no governed
+  // data anywhere in the payload, which clamped every such turn to local-only.
+  // `classifiedDataClasses` still reports the full set on the receipt.
   const needsPdp =
-    classifiedDataClasses.length > 0 ||
+    policyRelevantClasses(input.classification).length > 0 ||
     hasGovernedHints ||
     input.classification.overallSensitivity === "confidential" ||
     input.classification.overallSensitivity === "restricted";
@@ -107,12 +113,20 @@ export function evaluateInferenceDispatchPolicy(
     };
   }
 
+  // The receipt keeps every detected class (classifiedDataClasses, above), but
+  // the vertical packs load from the DATA-evidenced set (BI-463BE12A). Loading a
+  // pack for a class seen only in the coworker's job description attaches that
+  // pack's mask obligation to the turn, and a mask obligation clamps routeEffect
+  // to local-only in screen-inference-payload — a third exclusion path, separate
+  // from sensitivity clearance and from the per-class export decision, and the
+  // one that survived fixing the other two.
+  const policyRelevant = policyRelevantClasses(input.classification);
   const policyPackVersions = input.policies
     ? []
-    : policyPackVersionsForClasses(classifiedDataClasses);
+    : policyPackVersionsForClasses(policyRelevant);
   const policies = input.policies ?? [
     ...DATA_EXECUTABLE_POLICIES,
-    ...verticalSensitiveDataPoliciesForClasses(classifiedDataClasses),
+    ...verticalSensitiveDataPoliciesForClasses(policyRelevant),
   ];
   const decisions = buildPolicyContexts(input).map((ctx) =>
     evaluateDataPolicy(ctx, policies)
@@ -156,13 +170,32 @@ export function evaluateInferenceDispatchPolicy(
   };
 }
 
+/**
+ * The classes an export decision may rest on (BI-463BE12A).
+ *
+ * Falls back to the full set when the classifier predates the split, so an
+ * older cached classification still fails closed rather than opening up.
+ */
+function policyRelevantClasses(
+  classification: InferencePolicyEvaluationInput["classification"],
+): InferenceDataClass[] {
+  return classification.dataEvidencedClasses ?? classification.dataClasses;
+}
+
 function buildPolicyContexts(
   input: InferencePolicyEvaluationInput,
 ): PolicyEvaluationContext[] {
-  if (input.classification.dataClasses.length === 0) {
+  // Deliberately the DATA-evidenced set, not every detected class. A COO's
+  // system prompt names payroll because that is the job; letting that alone
+  // produce an `export` denial clamps residencyPolicy to local_only, which
+  // excludes every cloud endpoint at pipeline-v2 regardless of the sensitivity
+  // the screener settled on. Sensitivity and residency are two independent
+  // exclusions and both have to stop turning on instructional vocabulary.
+  const relevant = policyRelevantClasses(input.classification);
+  if (relevant.length === 0) {
     return [buildPolicyContext(input)];
   }
-  return uniqueSorted(input.classification.dataClasses).map((dataClass) => {
+  return uniqueSorted(relevant).map((dataClass) => {
     const pack = getVerticalSensitiveDataPolicyPack(dataClass);
     const binding = dataClass === "unknown-governed-data"
       ? pack
@@ -210,7 +243,7 @@ function buildPolicyContext(
       sensitivity: override?.sensitivity ?? input.classification.overallSensitivity,
       categories: override?.categories
         ? [...override.categories]
-        : categoriesForClasses(input.classification.dataClasses),
+        : categoriesForClasses(policyRelevantClasses(input.classification)),
     },
     environmentKnown: input.environmentKnown ?? true,
     assetVersion: input.assetVersion ?? DEFAULT_VERSION,

--- a/apps/web/lib/inference/data-screening/routed-screening.test.ts
+++ b/apps/web/lib/inference/data-screening/routed-screening.test.ts
@@ -167,3 +167,62 @@ describe("routed inference screening", () => {
     expect(replaced.screenInput.systemPrompt).toBe("Limited mode.");
   });
 });
+
+// BI-463BE12A / BI-9C14CB5D. The end-to-end assertion, at the seam routing
+// actually consumes. Four channels clamp a turn to local-only — sensitivity
+// clearance, the per-class export decision, the vertical policy packs, and a
+// mask obligation that clamps residencyPolicy — so a unit test on the
+// classifier alone proves nothing about whether a coworker can reach a provider.
+describe("prompt provenance decides whether a turn may leave the box", () => {
+  const persona =
+    "You are the COO. You coordinate operations: payroll runs, invoice approvals, " +
+    "salary review cycles, and team performance.";
+
+  const screenWith = (systemPrompt: string, content: string, spans?: string[]) =>
+    createRoutedInferenceScreen({
+      messages: [{ role: "user", content }],
+      systemPrompt,
+      systemPromptInstructionSpans: spans,
+      taskType: "conversation",
+      routeContext: { sensitivity: "confidential", residencyPolicy: "any_enabled" },
+    }).screen;
+
+  it("lets a job description with no governed data reach a cloud provider", () => {
+    const screen = screenWith(persona, "What needs my attention this morning?", [persona]);
+
+    expect(screen.receipt.routeEffect).toBe("allow");
+    expect(screen.routeContext.residencyPolicy).toBe("any_enabled");
+  });
+
+  it("keeps reporting the detected classes even when they change nothing", () => {
+    const screen = screenWith(persona, "What needs my attention this morning?", [persona]);
+
+    expect(screen.receipt.classifiedDataClasses).toContain("employee-records");
+    expect(screen.receipt.matchProvenance?.every((m) => m.path.startsWith("systemPrompt.instruction["))).toBe(true);
+  });
+
+  it("clamps to local-only for a real value in a message", () => {
+    const screen = screenWith(persona, "Set Dana's salary to 125000 Monday.", [persona]);
+
+    expect(screen.receipt.routeEffect).toBe("local-only");
+    expect(screen.routeContext.residencyPolicy).toBe("local_only");
+  });
+
+  it("clamps to local-only for a real value in an UNDECLARED prompt segment", () => {
+    const screen = screenWith(
+      `${persona}\n\n--- PAGE DATA ---\nDana Whitfield, salary 125000, payroll id 88213.`,
+      "Summarise this.",
+      [persona],
+    );
+
+    expect(screen.receipt.routeEffect).toBe("local-only");
+    expect(screen.routeContext.residencyPolicy).toBe("local_only");
+  });
+
+  it("is unchanged for a caller that declares nothing", () => {
+    const screen = screenWith(persona, "What needs my attention this morning?");
+
+    expect(screen.routeContext.sensitivity).toBe("restricted");
+    expect(screen.receipt.routeEffect).toBe("local-only");
+  });
+});

--- a/apps/web/lib/inference/data-screening/routed-screening.ts
+++ b/apps/web/lib/inference/data-screening/routed-screening.ts
@@ -19,6 +19,8 @@ import {
 type RoutedScreenInput = {
   messages: ChatMessage[];
   systemPrompt: string;
+  /** Platform-authored instruction spans within `systemPrompt` (BI-463BE12A). */
+  systemPromptInstructionSpans?: string[];
   tools?: Array<Record<string, unknown>>;
   taskType: string;
   routeContext: ScreenInferencePayloadInput["routeContext"];

--- a/apps/web/lib/inference/data-screening/screen-inference-payload.ts
+++ b/apps/web/lib/inference/data-screening/screen-inference-payload.ts
@@ -48,6 +48,8 @@ export type ScreenInferencePayloadInput = {
   organizationId?: string | null;
   messages: ChatMessage[];
   systemPrompt: string;
+  /** Platform-authored instruction spans within `systemPrompt` (BI-463BE12A). */
+  systemPromptInstructionSpans?: string[];
   tools?: Array<Record<string, unknown>>;
   taskType?: string;
   routeContext?: ScreenRouteContextInput;
@@ -85,6 +87,7 @@ export function screenInferencePayload(
   const classification = classifyInferencePayload({
     messages: input.messages,
     systemPrompt: input.systemPrompt,
+    systemPromptInstructionSpans: input.systemPromptInstructionSpans,
     tools: input.tools,
     taskType: input.taskType,
     governedData,

--- a/apps/web/lib/inference/data-screening/types.ts
+++ b/apps/web/lib/inference/data-screening/types.ts
@@ -142,6 +142,17 @@ export type GovernedPayloadHint = {
 export type InferencePayloadClassificationInput = {
   messages: ChatMessage[];
   systemPrompt: string;
+  /**
+   * Exact text spans of the system prompt that are platform-authored
+   * INSTRUCTION rather than the turn's data (BI-463BE12A / BI-9C14CB5D).
+   *
+   * Supplied by whoever knows the provenance — the prompt assembler for its own
+   * static blocks, the calling surface for the coworker persona. Everything not
+   * named here is classified as data, so an assembly path that supplies nothing
+   * behaves exactly as it did before this existed, and text appended after
+   * assembly is data by default. Fail-closed by construction.
+   */
+  systemPromptInstructionSpans?: string[];
   tools?: Array<Record<string, unknown>>;
   taskType?: string;
   governedData?: GovernedPayloadHint[];
@@ -150,6 +161,17 @@ export type InferencePayloadClassificationInput = {
 export type InferencePayloadClassification = {
   overallSensitivity: InferencePayloadSensitivity;
   dataClasses: InferenceDataClass[];
+  /**
+   * The subset of `dataClasses` evidenced somewhere OTHER than platform-authored
+   * instruction — the turn's messages, tool-call arguments, tool results, or an
+   * explicit governed hint (BI-463BE12A).
+   *
+   * `dataClasses` stays complete so the receipt reports everything detected and
+   * the classification remains auditable. The PDP evaluates THIS set, because an
+   * export decision should turn on what is being sent, not on a job description
+   * that happens to name the domain.
+   */
+  dataEvidencedClasses: InferenceDataClass[];
   matches: InferencePayloadMatch[];
   receipt: InferencePayloadReceipt;
 };

--- a/apps/web/lib/inference/routed-inference-options.ts
+++ b/apps/web/lib/inference/routed-inference-options.ts
@@ -5,6 +5,14 @@ import type { RouteDecisionActor } from "@/lib/routing/route-decision-attributio
 
 /** Caller-owned constraints and preferences for canonical routing plus dispatch. */
 export interface RouteAndCallOptions {
+  /**
+   * Exact spans of `systemPrompt` that are platform-authored INSTRUCTION rather
+   * than the turn's data (BI-463BE12A / BI-9C14CB5D). Supplied by whoever knows
+   * the provenance — the prompt assembler for its static blocks, the calling
+   * surface for the coworker persona. Anything unlabelled is classified as data,
+   * so omitting this is the safe default and changes nothing.
+   */
+  systemPromptInstructionSpans?: string[];
   tools?: Array<Record<string, unknown>>;
   taskType?: string;
   preferredProviderId?: string;

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -196,6 +196,7 @@ async function prepareRoute(
   const { screenInput, screen, rehydrationHandle } = createRoutedInferenceScreen({
     messages,
     systemPrompt,
+    systemPromptInstructionSpans: options?.systemPromptInstructionSpans,
     tools: options?.tools,
     taskType,
     routeContext: initialRouteContext,

--- a/apps/web/lib/operate/endpoint-test-runner.test.ts
+++ b/apps/web/lib/operate/endpoint-test-runner.test.ts
@@ -14,6 +14,12 @@ vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
 vi.mock("@/lib/ai-inference", () => ({ callProvider: mockCallProvider }));
 vi.mock("@/lib/prompt-assembler", () => ({
   assembleSystemPrompt: vi.fn().mockResolvedValue("system"),
+  // Enumerated so this mock does not break the day this path assembles with
+  // provenance — a factory mock fails on the first unlisted export.
+  assembleSystemPromptWithProvenance: vi.fn().mockResolvedValue({
+    text: "system",
+    instructionSpans: [],
+  }),
 }));
 vi.mock("@/lib/orchestrator-evaluator", () => ({
   evaluateResponseForTest: vi.fn().mockResolvedValue(null),

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -1142,6 +1142,8 @@ export type RunAgenticLoopParams = {
 
   chatHistory: ChatMessage[];
   systemPrompt: string;
+  /** Instruction spans in `systemPrompt`; see RouteAndCallOptions (BI-463BE12A). */
+  systemPromptInstructionSpans?: string[];
   sensitivity: import("@/lib/agent-sensitivity").RouteSensitivity;
   tools: ToolDefinition[];
   toolsForProvider: Array<Record<string, unknown>> | undefined;
@@ -1294,6 +1296,7 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
   const {
     chatHistory,
     systemPrompt,
+    systemPromptInstructionSpans,
     sensitivity,
     tools,
     toolsForProvider,
@@ -1384,6 +1387,7 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
   // Build routeAndCall options once (reused every iteration)
   const routeOptions = {
     ...(toolsForProvider ? { tools: toolsForProvider } : {}),
+    ...(systemPromptInstructionSpans?.length ? { systemPromptInstructionSpans } : {}),
     taskType: turnRoute.taskType,
     ...effectiveConfig,
     ...(requireTools ? { requireTools: true } : {}),

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -293,6 +293,8 @@ export async function resolveAutonomousWorkTools(input: {
 
 export async function executeAutonomousAgenticLoop(input: {
   systemPrompt: string;
+  /** Instruction spans within `systemPrompt`, forwarded to routing (BI-463BE12A). */
+  systemPromptInstructionSpans?: string[];
   chatHistory: ChatMessage[];
   sensitivity: RouteSensitivity;
   tools: ToolDefinition[];
@@ -430,6 +432,7 @@ export async function executeAutonomousAgenticLoop(input: {
     result = await withInferenceOrigin(inferenceOrigin, () =>
       runAgenticLoop({
         systemPrompt,
+        systemPromptInstructionSpans: input.systemPromptInstructionSpans,
         chatHistory: input.chatHistory,
         sensitivity: input.sensitivity,
         tools: input.tools,

--- a/apps/web/lib/tak/coworker-prompt-provenance.ts
+++ b/apps/web/lib/tak/coworker-prompt-provenance.ts
@@ -1,0 +1,56 @@
+// apps/web/lib/tak/coworker-prompt-provenance.ts
+//
+// Which parts of a coworker's assembled system prompt are platform- or
+// operator-authored INSTRUCTION, and which are the turn's DATA (BI-463BE12A).
+//
+// This lives away from the call site for one reason: getting it wrong in either
+// direction is consequential and the reasoning deserves to be readable. Declare
+// too little and a coworker whose job description names payroll is pinned to
+// local-only routing forever — measured at 100% of turns for five coworkers on
+// the live install. Declare too much and real governed values launder
+// themselves into a cloud provider by riding inside the prompt.
+//
+// The asymmetry decides the default: anything NOT declared here is classified
+// as data, so under-declaring costs routing quality and over-declaring costs
+// containment. When unsure, leave it out.
+
+/** The pieces that make up a coworker's domain block, by who authored them. */
+export type CoworkerDomainParts = {
+  /** The coworker's persona — what it is and what it does. Operator-authored. */
+  persona: string;
+  /** Fixed platform instruction appended to every coworker's domain block. */
+  surfaceInstruction: string;
+  /** Knowledge recalled from the organization's own records. DATA. */
+  knowledge?: string | null;
+  /** The coworker's semantic memory of prior work. DATA. */
+  memory?: string | null;
+};
+
+/**
+ * Compose the domain block AND say which parts of it are instruction.
+ *
+ * Composition and provenance live in one function because they are the same
+ * decision: whoever concatenates these four pieces into a single string is the
+ * last place that still knows which was which. Splitting them is how the
+ * knowledge and memory blocks came to be indistinguishable from the persona by
+ * the time the screener saw them.
+ *
+ * `knowledge` and `memory` are deliberately absent from the returned spans.
+ * They are recalled from the organization's own records and can carry names,
+ * salaries and account numbers.
+ */
+export function composeCoworkerDomainContext(parts: CoworkerDomainParts): {
+  domainContext: string;
+  instructionSpans: string[];
+} {
+  let domainContext = `${parts.persona}\n\n${parts.surfaceInstruction}`;
+  if (parts.knowledge) domainContext += "\n\n" + parts.knowledge;
+  if (parts.memory) domainContext += "\n\n" + parts.memory;
+
+  return {
+    domainContext,
+    instructionSpans: [parts.persona, parts.surfaceInstruction]
+      .map((span) => span?.trim())
+      .filter((span): span is string => Boolean(span)),
+  };
+}

--- a/apps/web/lib/tak/prompt-assembler.test.ts
+++ b/apps/web/lib/tak/prompt-assembler.test.ts
@@ -2,7 +2,7 @@
 // TDD RED → GREEN tests for the composable system prompt assembler.
 
 import { describe, expect, it, vi } from "vitest";
-import { assembleSystemPrompt } from "./prompt-assembler";
+import { assembleSystemPrompt, assembleSystemPromptWithProvenance } from "./prompt-assembler";
 import type { PromptInput } from "./prompt-assembler";
 
 vi.mock("./prompt-loader", () => ({
@@ -559,5 +559,77 @@ describe("assembleSystemPrompt", () => {
     // initiative sits after authority and before the sensitivity block
     expect(assertive.indexOf("INITIATIVE — HIGH")).toBeGreaterThan(assertive.indexOf("authorized to"));
     expect(assertive.indexOf("INITIATIVE — HIGH")).toBeLessThan(assertive.indexOf("classified"));
+  });
+});
+
+// BI-463BE12A / BI-9C14CB5D. The assembler declares which of its own blocks are
+// platform-authored instruction. Anything it does not declare is classified as
+// the turn's data by the inference screener, so under-declaring is safe and
+// over-declaring is an egress hole — these tests pin both directions.
+describe("assembleSystemPromptWithProvenance declares instruction, never data", () => {
+  const base = {
+    hrRole: "owner",
+    grantedCapabilities: ["read"],
+    deniedCapabilities: [],
+    mode: "act" as const,
+    sensitivity: "internal" as const,
+    domainContext: "You are the COO. You approve payroll runs.",
+    domainTools: [],
+    routeData: null,
+    attachmentContext: null,
+  };
+
+  it("declares its static contract blocks", async () => {
+    const assembled = await assembleSystemPromptWithProvenance(base);
+
+    expect(assembled.instructionSpans.length).toBeGreaterThan(0);
+    for (const span of assembled.instructionSpans) {
+      expect(assembled.text).toContain(span);
+    }
+  });
+
+  it("does NOT declare retrieved context as instruction", async () => {
+    const assembled = await assembleSystemPromptWithProvenance({
+      ...base,
+      wikiContext: "WIKI: Dana Whitfield earns 125000.",
+      workingNotes: "NOTES: invoice 88213 is overdue.",
+      professionContext: "CORPUS: payroll practice.",
+      routeData: "PAGE: salary 125000",
+      attachmentContext: "ATTACHMENT: payroll register",
+      extraSections: ["EXTRA: bank account 021000021"],
+    });
+
+    const declared = assembled.instructionSpans.join("\n");
+    for (const leak of ["WIKI:", "NOTES:", "CORPUS:", "PAGE:", "ATTACHMENT:", "EXTRA:"]) {
+      expect(declared).not.toContain(leak);
+    }
+  });
+
+  it("does NOT declare the caller's domainContext on its own initiative", async () => {
+    // domainContext arrives as one string that may concatenate the persona with
+    // retrieved knowledge and semantic memory. Only the caller can split it, so
+    // the assembler must wait to be told rather than guess.
+    const assembled = await assembleSystemPromptWithProvenance(base);
+
+    expect(assembled.instructionSpans.join("\n")).not.toContain("You approve payroll runs");
+  });
+
+  it("passes through spans the caller declares", async () => {
+    const persona = "You are the COO. You approve payroll runs.";
+    const assembled = await assembleSystemPromptWithProvenance({
+      ...base,
+      instructionSpans: [persona],
+    });
+
+    expect(assembled.instructionSpans).toContain(persona);
+  });
+
+  it("keeps assembleSystemPrompt returning the same text", async () => {
+    const [text, assembled] = await Promise.all([
+      assembleSystemPrompt(base),
+      assembleSystemPromptWithProvenance(base),
+    ]);
+
+    expect(text).toBe(assembled.text);
   });
 });

--- a/apps/web/lib/tak/prompt-assembler.ts
+++ b/apps/web/lib/tak/prompt-assembler.ts
@@ -18,6 +18,15 @@ import { readingLevelDirective, type ReadingLevel } from "@dpf/validators";
 import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY } from "./prompt-boundary";
 
 export type PromptInput = {
+  /**
+   * Spans of caller-supplied context that are platform- or operator-authored
+   * INSTRUCTION rather than the turn's data (BI-463BE12A). The assembler cannot
+   * infer these: `domainContext` arrives as one string that may concatenate the
+   * coworker persona with retrieved knowledge and semantic memory, and only the
+   * caller knows which part is which. Omitted means "all of it is data", which
+   * is the safe default.
+   */
+  instructionSpans?: string[];
   hrRole: string;
   grantedCapabilities: string[];
   deniedCapabilities: string[];
@@ -156,7 +165,31 @@ Values: Quality over speed. Transparency. Continuous improvement. Human authorit
 
 // ─── Assembler ──────────────────────────────────────────────────────────────
 
+/**
+ * The assembled prompt plus the spans of it that are platform-authored
+ * INSTRUCTION rather than the turn's data (BI-463BE12A / BI-9C14CB5D).
+ *
+ * Anything NOT listed in `instructionSpans` is classified as data by the
+ * inference screener, so this list is deliberately conservative: the static
+ * contract blocks and the fixed sentences this function generates, plus
+ * whatever the caller declares via `input.instructionSpans`. Retrieved
+ * knowledge, semantic memory, the profession corpus, wiki recall, working
+ * notes, PAGE DATA, attachments and extra sections are all data and are
+ * deliberately absent.
+ */
+export type AssembledSystemPrompt = {
+  text: string;
+  instructionSpans: string[];
+};
+
+/** Back-compatible wrapper — callers that do not care about provenance. */
 export async function assembleSystemPrompt(input: PromptInput): Promise<string> {
+  return (await assembleSystemPromptWithProvenance(input)).text;
+}
+
+export async function assembleSystemPromptWithProvenance(
+  input: PromptInput,
+): Promise<AssembledSystemPrompt> {
   // Load identity, mode, and mission blocks from DB (falls back to hardcoded constants)
   const modeSlug = input.mode === "advise" ? "advise-mode" : "act-mode";
   const loaded = await loadPrompts([
@@ -171,6 +204,9 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
 
   // --- Static blocks (cacheable across turns for same role+mode) ---
   const staticBlocks: string[] = [];
+  // Fixed sentences this function generates. Instruction, but not static, so
+  // they are collected separately from the cacheable block list.
+  const generatedInstruction: string[] = [];
 
   // Block 1: Identity (static)
   staticBlocks.push(loaded.get("platform-identity/identity-block") ?? IDENTITY_BLOCK);
@@ -211,27 +247,33 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
 
   // Current date for temporal grounding
   const today = new Date().toISOString().slice(0, 10);
-  dynamicBlocks.push(`Today's date is ${today}.`);
+  const dateBlock = `Today's date is ${today}.`;
+  dynamicBlocks.push(dateBlock);
+  generatedInstruction.push(dateBlock);
 
   // Block 2: Authority (dynamic — varies by user)
   const granted = input.grantedCapabilities.join(", ");
   const denied = input.deniedCapabilities.length > 0
     ? input.deniedCapabilities.join(", ")
     : "none — but do not assume unlimited authority";
-  dynamicBlocks.push(
-    `The employee you're working with holds role ${input.hrRole}. They are authorized to: ${granted}. They are NOT authorized to: ${denied}. All actions you take execute under their authority. Never exceed it.`
-  );
+  const authorityBlock =
+    `The employee you're working with holds role ${input.hrRole}. They are authorized to: ${granted}. They are NOT authorized to: ${denied}. All actions you take execute under their authority. Never exceed it.`;
+  dynamicBlocks.push(authorityBlock);
+  generatedInstruction.push(authorityBlock);
 
   // Block 2b: Initiative (dynamic — the employee's Proactivity choice for this
   // coworker). Scales in-task effort by level; sits after the cache boundary
   // because it varies per user/session. BI-E35A8AA4.
-  dynamicBlocks.push(buildInitiativeBlock(input.proactivityLevel));
+  const initiativeBlock = buildInitiativeBlock(input.proactivityLevel);
+  dynamicBlocks.push(initiativeBlock);
+  generatedInstruction.push(initiativeBlock);
 
   // Block 4: Sensitivity
   const level = input.sensitivity.toUpperCase();
-  dynamicBlocks.push(
-    `This page is classified ${level}. Only endpoints cleared for ${level} are handling requests. Do not include classified data in sub-tasks routed to lower-clearance endpoints.`
-  );
+  const sensitivityBlock =
+    `This page is classified ${level}. Only endpoints cleared for ${level} are handling requests. Do not include classified data in sub-tasks routed to lower-clearance endpoints.`;
+  dynamicBlocks.push(sensitivityBlock);
+  generatedInstruction.push(sensitivityBlock);
 
   const questionPacketBlock = formatQuestionPacketPromptBlock(input.questionPacket);
   if (questionPacketBlock) {
@@ -293,7 +335,24 @@ export async function assembleSystemPrompt(input: PromptInput): Promise<string> 
     }
   }
 
-  return withCoworkerInteractionContract(staticBlocks.join("\n\n")
+  const text = withCoworkerInteractionContract(staticBlocks.join("\n\n")
     + SYSTEM_PROMPT_DYNAMIC_BOUNDARY
     + dynamicBlocks.join("\n\n"));
+
+  // The reading-level directive is a written instruction to the coworker, not
+  // data, and it is embedded inside the domain block rather than pushed as its
+  // own entry — spans match literally, so being embedded is not a problem.
+  const readingLevelSpan = input.readingLevel
+    ? readingLevelDirective(input.readingLevel)
+    : null;
+
+  return {
+    text,
+    instructionSpans: [
+      ...staticBlocks,
+      ...generatedInstruction,
+      ...(readingLevelSpan ? [readingLevelSpan] : []),
+      ...(input.instructionSpans ?? []),
+    ].filter((span): span is string => Boolean(span && span.trim())),
+  };
 }

--- a/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
+++ b/docs/superpowers/plans/2026-07-26-pre-dispatch-sensitive-llm-routing.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Pre-Dispatch Sensitive LLM Routing Implementation Plan
 
 > **For agentic workers:** REQUIRED: Use the DPF-native `dpf-tdd`, `dpf-local-merge-ci-before-push`, and `dpf-pr-with-dco` skills plus the per-BI completion gate. Steps use checkbox (`- [ ]`) syntax for tracking.
@@ -433,3 +437,32 @@ The implementation is not complete until:
 - Should token maps use an existing encrypted artifact store or require a narrow new model/table? Verify existing protected-data substrate before proposing schema.
 - Which human-in-loop surface should own review decisions that originate in nested agent call chains: work item activity, coworker chat, queue branch, or all three via a common decision envelope?
 - Which provider setup route is canonical after the cognitive-load cleanup? Verify current route ownership before editing UI.
+
+## Amendment, 2026-08-23 — instruction provenance (BI-463BE12A, `DI-BF2FEDA18D81`)
+
+The screener classified the assembled **system prompt** as payload, so a coworker
+whose job description names payroll, invoices or salaries was routed at
+`restricted` on every turn — which hard-denies every external provider. Measured
+over seven days on the live install: coo 36/36, market-research-analyst 50/50,
+admin-assistant 38/38, hr-specialist 33/33 and finance-agent 7/7, against 0/45
+for platform-engineer. Five coworkers had never once reached a cloud provider.
+
+Four independent channels turned out to clamp such a turn to local-only —
+sensitivity clearance, the per-class export decision, the vertical policy packs,
+and a mask obligation that clamps `residencyPolicy`. Narrowing the sensitivity
+rule alone closes one of them.
+
+The fix declares instruction provenance at the source: the prompt assembler and
+the calling surface name the exact spans that are platform- or operator-authored
+instruction, and **everything unlabelled is data**. Sensitivity, the PDP
+summoning rule, the policy contexts and the vertical packs all key off the
+data-evidenced set; the receipt continues to report every detected class.
+
+Full design, the four-channel analysis, and the measured before/after:
+[`2026-08-23-prompt-provenance-in-inference-screening.md`](2026-08-23-prompt-provenance-in-inference-screening.md).
+
+`DI-0A58373E26D0` (2026-07-31) is not reopened. It rejected granting an external
+provider `restricted` clearance, which remains rejected for the same two
+commandments — "Outbound and irreversible actions require explicit go" and "Least
+privilege, deny by default". Only the provenance question was revisited, on live
+measurement that decision did not have.

--- a/docs/superpowers/plans/2026-08-23-prompt-provenance-in-inference-screening.md
+++ b/docs/superpowers/plans/2026-08-23-prompt-provenance-in-inference-screening.md
@@ -1,0 +1,75 @@
+---
+status: active
+---
+
+# Prompt Provenance in Inference Screening — Implementation Plan
+
+**Goal:** A coworker whose job description names payroll, invoices or salaries can reach a cloud provider, while every real governed value — including one arriving inside the system prompt — still routes exactly as it does today.
+
+**Primary BI:** `BI-463BE12A` — a coworker's system prompt pins it to `restricted` forever
+**Mechanism BI:** `BI-9C14CB5D` — separate injected data from platform instruction
+**Epic:** `EP-B9DD37C7`
+**Decision:** `DI-BF2FEDA18D81` scored `prompt-corroboration` (10.690) over `segment-prompt` (9.565). The operator selected `segment-prompt` after the evidence below showed `prompt-corroboration` cannot clear the defect without lowering protection for injected data.
+
+## Why the first approach failed
+
+`prompt-corroboration` — stop instruction matches from escalating to `restricted`, keep them holding a `confidential` floor — was implemented and unit-tested green. Driving the real screening entry point showed it does not work, because **four independent channels** clamp a turn to local-only, not one:
+
+| # | Channel | Mechanism |
+|---|---|---|
+| 1 | Sensitivity clearance | `overallSensitivity=restricted` → only `local`/`speaches` are cleared |
+| 2 | Per-class export decision | `buildPolicyContexts` builds a PDP context per detected class → `deny` → `routeEffect=local-only` |
+| 3 | Vertical policy packs | `verticalSensitiveDataPoliciesForClasses` loads a pack per detected class, contributing a mask obligation |
+| 4 | `needsPdp` → mask → residency | any detected class plus `confidential` attaches a mask obligation; `maskRequired && !prior` clamps `residencyPolicy` to `local_only`, excluded at `pipeline-v2.ts:221` |
+
+Measured after fixing 1–3:
+
+```
+COO-PROMPT-ONLY:       sensitivity=confidential  residencyPolicy=local_only  routeEffect=local-only
+REAL-VALUE-IN-MESSAGE: sensitivity=restricted    residencyPolicy=local_only  routeEffect=local-only
+INNOCUOUS:             sensitivity=confidential  residencyPolicy=any_enabled routeEffect=allow
+```
+
+Channel 4 survives, and closing it within that approach requires dropping the `confidential` floor for instruction-only evidence — which lowers protection for a real value arriving in an injected briefing segment. Provenance at the source removes all four at once, with nothing weakened.
+
+Separately observed and NOT addressed here: `transformation` stayed `none` in both the test harness and the live receipt, so the mask obligation is acting as a permanent local-only clamp rather than mask-then-send. Worth its own item.
+
+## Design
+
+**Instruction spans, not segments.** The caller supplies the exact text spans that are platform-authored instruction. The classifier subtracts those spans from the prompt and probes the remainder as data. Everything unlabelled is data.
+
+This shape was chosen over a structured segment array because:
+
+- It is **fail-closed by construction.** An assembly path that supplies nothing behaves exactly as today. The legacy persona path and every post-assembly append (setup-mode override, appended guidance) need no change and are treated as data.
+- It survives **downstream concatenation**, which the current code does in at least two places after assembly.
+- It needs no offsets, so reordering a block cannot silently mislabel one.
+
+**Provenance is supplied by whoever knows it.** `finalDomainContext` in `agent-coworker.ts` concatenates the persona, `AUTHORIZED_SURFACE_PROMPT`, retrieved knowledge, and semantic memory into one string. Only that call site knows which parts are which, so the assembler must not guess: it contributes its own static blocks and unions in caller-supplied spans.
+
+### What is instruction
+
+- The assembler's `staticBlocks`: identity, decision routing, limitation response, escalation ladder, coordinator contract, mode.
+- Generated instruction sentences: today's date, the authority statement, the initiative block, the sensitivity notice, the reading-level directive.
+- Caller-supplied: the coworker persona (`selectedDomain`) and `AUTHORIZED_SURFACE_PROMPT`.
+
+### What is data
+
+Everything else, explicitly including: company mission, retrieved knowledge, semantic memory, profession corpus, wiki recall, working notes, `--- PAGE DATA ---`, attachments, extra sections, question packet, and anything appended after assembly.
+
+## Steps
+
+- [ ] `classify-payload.ts`: accept `systemPromptInstructionSpans`; emit one instruction-provenance probe per span and one data-provenance probe for the remainder. Fallback with no spans: the whole prompt is DATA.
+- [ ] Replace the committed `INSTRUCTION_PROBE_PATHS` whole-prompt rule with the span rule (the committed fallback treats the whole prompt as instruction, which is the unsafe default).
+- [ ] `evaluate-inference-policy.ts`: keep `classifiedDataClasses` complete for the receipt; drive policy contexts, categories, and vertical packs from the data-evidenced set. (Prototyped.)
+- [ ] `prompt-assembler.ts`: return instruction spans alongside the text; keep `assembleSystemPrompt` returning the string.
+- [ ] `agent-coworker.ts`: pass persona + `AUTHORIZED_SURFACE_PROMPT` as caller spans; leave knowledge and memory unlabelled.
+- [ ] Thread spans: agentic-loop params → `routeOptions` → `RouteAndCallOptions` → `prepareRoute` → `createRoutedInferenceScreen` → `screenInferencePayload`.
+- [ ] Receipt: `matchProvenance` names the span index, not just `systemPrompt`.
+- [ ] Tests: the three probe cases above as assertions; a real value inside an unlabelled prompt segment still escalates; no spans means no behaviour change.
+
+## Acceptance
+
+- A COO-shaped turn with no governed values reaches `routeEffect=allow` and `residencyPolicy` unclamped.
+- A real salary/invoice value in a message, a tool-call argument, a governed hint, OR an unlabelled prompt segment still produces `local-only`.
+- An assembly path that supplies no spans is byte-for-byte unchanged in behaviour.
+- The receipt still reports every detected class.

--- a/docs/user-guide/ai-workforce/sensitive-data-policy-packs.md
+++ b/docs/user-guide/ai-workforce/sensitive-data-policy-packs.md
@@ -31,6 +31,26 @@ matter. It does not weaken a boundary. Clinical information receives the
 clinical boundary even when it appears in a legal, home-service, or other
 workflow.
 
+## What counts as sensitive detail, and what does not
+
+DPF looks for sensitive detail in what a coworker is actually being sent: your
+messages, the results of the tools it runs, page data, attachments, recalled
+knowledge and the coworker's own memory of prior work.
+
+It does **not** treat a coworker's job description as sensitive detail. A COO's
+description says it approves payroll runs; a finance controller's mentions
+invoices; an HR director's mentions salaries. Those words describe the job, not
+a person's pay. Treating them as sensitive detail used to confine those
+coworkers to the on-box model permanently, which left them slower and less
+capable at the work they were hired for, with no gain in protection — no salary
+was ever in the request.
+
+The distinction is drawn where the prompt is put together, so it is decided by
+the part of DPF that knows which text is the coworker's brief and which is your
+business's data. Anything DPF is not certain is a brief counts as your data. A
+real salary, invoice number or bank detail is treated as sensitive detail
+wherever it appears — including in a briefing DPF assembled for the coworker.
+
 ## Possible outcomes
 
 DPF combines all detected packs and uses the strongest outcome:

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -20,8 +20,8 @@ apps/web/components/storefront/SlotBookingFlow.tsx	1015
 apps/web/components/workbooks/Grid.tsx	1830
 apps/web/instrumentation.test.ts	945
 apps/web/instrumentation.ts	1475
-apps/web/lib/actions/agent-coworker-external.test.ts	867
-apps/web/lib/actions/agent-coworker.ts	2792
+apps/web/lib/actions/agent-coworker-external.test.ts	889
+apps/web/lib/actions/agent-coworker.ts	2810
 apps/web/lib/actions/agent-task-scheduler.test.ts	1132
 apps/web/lib/actions/agent-task-scheduler.ts	807
 apps/web/lib/actions/ai-providers.ts	914
@@ -59,7 +59,7 @@ apps/web/lib/tak/agent-grants.test.ts	940
 apps/web/lib/tak/agent-grants.ts	991
 apps/web/lib/tak/agent-routing.ts	1168
 apps/web/lib/tak/agentic-loop.test.ts	2501
-apps/web/lib/tak/agentic-loop.ts	2809
+apps/web/lib/tak/agentic-loop.ts	2806
 apps/web/lib/tak/route-context-map.ts	1390
 apps/web/lib/work-capsules/mcp-handlers.ts	847
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1191


### PR DESCRIPTION
## The defect

Five coworkers on the live install had never once reached a cloud provider. Seven days of `RouteDecisionLog`, restricted turns as a share of all turns:

| coworker | restricted / total | | coworker | restricted / total |
|---|---|---|---|---|
| coo | 36 / 36 | | platform-engineer | 0 / 45 |
| market-research-analyst | 50 / 50 | | marketing-specialist | 0 / 46 |
| admin-assistant | 38 / 38 | | security-engineer | 0 / 32 |
| hr-specialist | 33 / 33 | | | |
| finance-agent | 7 / 7 | | | |

The split is by whether the coworker's job description mentions employment or money, not by anything a turn contained. A COO's system prompt says "payroll" because that is the job; those are restricted-class text patterns, and `restricted` denies every external provider. Only `local` and `speaches` carry that clearance and `speaches` has no `toolUse`, so the candidate pool was one endpoint with no fallback. When a local-CI lease held it, the turn was a dead end and the owner was told to reconnect a provider policy had already excluded (BI-A89E4827, merged as #4608).

## Four channels, not one

Narrowing the sensitivity rule was the obvious fix and it does not work. Driving the real screening seam showed four independent clamps:

1. sensitivity clearance
2. the per-class PDP export decision
3. the vertical policy packs
4. a mask obligation that clamps `residencyPolicy` to `local_only`, excluded at `pipeline-v2.ts:221`

Closing the first three still left the turn local-only, and closing the fourth within that approach requires dropping the `confidential` floor for instruction evidence — which lowers protection for a real value arriving in an injected briefing.

## The fix

Provenance at the source. The assembler and the calling surface declare the exact spans that are platform- or operator-authored instruction; **everything unlabelled is data.** That default is the whole safety argument.

Spans rather than a structured segment array, because the assembled prompt is a mix and gets concatenated after assembly. `finalDomainContext` alone joins the persona, an authorized-surface instruction, retrieved knowledge and semantic memory into one string — so only the call site can split it. `composeCoworkerDomainContext` now composes and declares provenance together, because whoever joins those four pieces is the last code that still knows which was which.

**Both assembly paths.** `USE_UNIFIED_COWORKER` is `false` on a default install, so the legacy persona path is the one that actually decides whether the COO reaches a provider — wiring only the unified assembler would have shipped a fix that did nothing for the reported symptom.

That the persona is the carrier rather than page data is measurable: `coo` is restricted on three structurally different routes — `/performance` 32/32, `/workspace` 2/2, `/workforce/AGT-900` 2/2 — while `marketing-specialist` is 0/46 on its own route. The trigger is constant across pages; page data is not.

## Measured at the routing seam

| case | before | after |
|---|---|---|
| COO persona declared, no governed values | local-only | **allow / any_enabled** |
| real value in a message | local-only | local-only |
| real value in an **undeclared** prompt span | local-only | local-only |
| caller declares nothing (legacy default) | local-only | local-only |

Rows 2–4 are the safety properties; row 4 is why no existing path regresses.

## Decision

`DI-BF2FEDA18D81` scored `prompt-corroboration` (10.690) over `segment-prompt` (9.565). The operator selected `segment-prompt` after the four-channel evidence showed the winner cannot clear the defect. `DI-0A58373E26D0` is **not** reopened — granting an external provider `restricted` clearance stays rejected.

## Observed and not addressed

`transformation` stays `none` in both the test harness and the live receipt, so a mask obligation acts as a permanent local-only clamp rather than mask-then-send. Worth its own item.

## Notes for review

- Module-size baseline: `agent-coworker.ts` +18 (both paths declaring provenance), its test +22 (mock enumeration plus a test per path), `agentic-loop.ts` retightened −3. Itemised in the commit.
- `docs/user-guide/ai-workforce/sensitive-data-policy-packs.md` gains a plain-language section on what counts as sensitive detail and what does not — this is user-visible behaviour, so it earned a doc change rather than an attestation.

## Verification

20 new tests including the four seam cases and one per assembly path; 3,354 tests across `lib/inference` + `lib/routing` + `lib/tak`, 1,541 across `lib/actions`; web typecheck; 50 preflight guards; exact-tree local CI gate PASS @ `67cfef68eba7`, evidence `cmt6ex0c00lum01pqpc5ltxv4`.

Part of `WC-9C828312`. Plan: `docs/superpowers/plans/2026-08-23-prompt-provenance-in-inference-screening.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)