### PR TITLE
fix(installer): a fresh consumer install dies at step 7 of 10

### DIFF
--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -155,16 +155,25 @@ function Write-DPFImageIdentity {
     }
 }
 
-function Import-DPFComposeChain {
+# Returns the compose-chain module PATH for the caller to dot-source itself.
+#
+# It deliberately does NOT dot-source here. Dot-sourcing inside a function scopes
+# every definition to that function, so the caller never sees them: the module
+# defines three interdependent helpers (Test-DPFEnvFlag, Add-DPFComposeFile,
+# Get-DPFComposeArgs) and all three vanish when this returns. Callers must write
+#
+#     . (Resolve-DPFComposeChainModule -InstallDir $Dir)
+#
+# which is the same script-scope pattern the already-working call sites use.
+function Resolve-DPFComposeChainModule {
     param([Parameter(Mandatory)][string]$InstallDir)
-    if (Get-Command Get-DPFComposeArgs -ErrorAction SilentlyContinue) { return }
     $candidates = @(
         (Join-Path $InstallDir "scripts\installer\lib\compose-chain.ps1"),
         (Join-Path $PSScriptRoot "scripts\installer\lib\compose-chain.ps1")
     )
     $module = $candidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1
     if (-not $module) { throw "compose_chain_helper_missing" }
-    . $module
+    return $module
 }
 
 function Get-Progress {
@@ -725,7 +734,7 @@ function Invoke-DPFEdgeNodeConvergence {
 
     $edgeModule = Resolve-DPFNativeEdgeModulePath -InstallDir $InstallDir
     . $edgeModule
-    Import-DPFComposeChain -InstallDir $InstallDir
+    . (Resolve-DPFComposeChainModule -InstallDir $InstallDir)
     $edgeComposeArgs = Get-DPFComposeArgs -InstallDir $InstallDir -IncludeEdge:$false
 
     Write-Action "Converging this installation's Edge Node..."
@@ -780,7 +789,7 @@ function Invoke-DPFEdgeNodeConvergence {
         Write-OK "Existing Edge enrollment found; preserving its machine identity"
     }
     if (Install-DPFNativeEdgeNode -InstallDir $InstallDir -BootstrapToken $edgeToken -Version $Version) {
-        Import-DPFComposeChain -InstallDir $InstallDir
+        . (Resolve-DPFComposeChainModule -InstallDir $InstallDir)
         $legacyComposeArgs = Get-DPFComposeArgs -InstallDir $InstallDir -IncludeEdge:$true
         docker compose @legacyComposeArgs stop edge-node 2>&1 | Out-Null
         return $true
@@ -1746,7 +1755,7 @@ if (-not (Test-StepDone "started")) {
     }
     $capabilityProjection = Resolve-DpfCapabilityComposeProfiles -InstallDir $DPF_DIR
     $env:COMPOSE_PROFILES = (@($capabilityProjection.composeProfiles) -join ',')
-    Import-DPFComposeChain -InstallDir $DPF_DIR
+    . (Resolve-DPFComposeChainModule -InstallDir $DPF_DIR)
     $coreComposeArgs = Get-DPFComposeArgs -InstallDir $DPF_DIR -IncludeEdge:$false -IncludeRelease:($InstallMode -eq "consumer")
     $recordedComposeFiles = @()
     for ($i = 0; $i -lt $coreComposeArgs.Count; $i++) {

--- a/scripts/installer/lib/compose-chain.ps1
+++ b/scripts/installer/lib/compose-chain.ps1
@@ -33,17 +33,36 @@ function Get-DPFComposeArgs {
 
     $chain = @("-f", "docker-compose.yml")
     if ($Purpose -eq "Stop") {
-        # Down must name every overlay that may have created resources. Docker
-        # Compose safely ignores services that were never started.
+        # Down should name every overlay that may have created resources, BUT an
+        # overlay is only safe to name if its required variables are set.
+        #
+        # Compose ignores services that were never started; it does NOT ignore
+        # variable interpolation. Every file handed to `compose down` is parsed and
+        # interpolated first, so an overlay declaring `${VAR:?msg}` aborts the whole
+        # command when that feature was never configured:
+        #
+        #   error while interpolating services.portal.volumes.[]: required variable
+        #   DPF_EDGE_ACTION_SIGNING_PRIVATE_KEY_FILE is missing a value
+        #
+        # That made `uninstall-dpf.ps1 -Purge` fail on every plain consumer install --
+        # the default configuration -- before it removed anything. Three overlays
+        # declare required variables (edge-actions, organization-trust, pki), so they
+        # get the SAME guards the Start path already applies.
         foreach ($overlay in @(
             "docker-compose.release.yml",
             "docker-compose.override.yml",
             "docker-compose.edge.yml",
-            "docker-compose.edge-actions.yml",
-            "docker-compose.organization-trust.yml",
-            "docker-compose.pki.yml",
             "docker-compose.tls.yml"
         )) { $chain = Add-DPFComposeFile -ComposeArgs $chain -InstallDir $InstallDir -Name $overlay }
+        if (Test-DPFEnvFlag -InstallDir $InstallDir -Name "DPF_EDGE_ACTION_DISPATCH_CONFIGURED") {
+            $chain = Add-DPFComposeFile -ComposeArgs $chain -InstallDir $InstallDir -Name "docker-compose.edge-actions.yml"
+        }
+        if (Test-DPFEnvFlag -InstallDir $InstallDir -Name "DPF_ORGANIZATION_TRUST_ENABLED") {
+            $chain = Add-DPFComposeFile -ComposeArgs $chain -InstallDir $InstallDir -Name "docker-compose.organization-trust.yml"
+        }
+        if (Test-DPFEnvFlag -InstallDir $InstallDir -Name "DPF_PKI_ENABLED") {
+            $chain = Add-DPFComposeFile -ComposeArgs $chain -InstallDir $InstallDir -Name "docker-compose.pki.yml"
+        }
         return $chain
     }
 


### PR DESCRIPTION
## The failure

A clean `-Headless -Consumer` install fails at **Step 7 of 10, "Starting the platform"**:

```
Get-DPFComposeArgs : The term 'Get-DPFComposeArgs' is not recognized as the name
of a cmdlet, function, script file, or operable program.
At install-dpf.ps1:1750
```

Steps 1–6 pass cleanly. This is the GA Windows path — the recommended install for a non-technical operator — dying two-thirds of the way through with a PowerShell error naming an internal helper, and no remediation an operator could act on.

## Why it happens

The loader **is** called on the line immediately above, and the helper file **is** on disk. The defect is scoping:

```powershell
function Import-DPFComposeChain {
    ...
    . $module      # ← dot-sources into THIS function's scope
}
```

Dot-sourcing inside a function scopes every definition to that function. When it returns, the helpers go out of scope with it. Proven rather than inferred:

```powershell
function Load { . $module }; Load
Get-Command Get-DPFComposeArgs   # -> not found
```

Promoting one helper isn't enough either — the module defines **three interdependent functions** (`Test-DPFEnvFlag`, `Add-DPFComposeFile`, `Get-DPFComposeArgs`) that call each other, so a partial fix just moves the error to the next name. I confirmed that the hard way with a first patch that got as far as `Add-DPFComposeFile`.

## The fix

Follows the pattern the working call sites already use. Lines 636 and 686 dot-source at script scope and work; the three routing through the function did not. `Import-DPFComposeChain` becomes `Resolve-DPFComposeChainModule`, returning the path for the caller to dot-source:

```powershell
. (Resolve-DPFComposeChainModule -InstallDir $Dir)
```

The `if (Get-Command ...) { return }` short-circuit goes with it — it could never fire usefully, since the function was structurally incapable of populating the caller scope it was testing.

## Verification

Via the script's own `-LibraryOnly` mode: resolver defined, old name gone, all three helpers visible after the caller dot-sources, and the chain builds — `-f docker-compose.yml -f docker-compose.release.yml`. Parse check clean.

Also validated against a live consumer install: with an equivalent local patch, the install proceeds past Step 7 to "All services healthy" and on to Step 8.

## Why no gate caught it

The uninstaller dot-sources the same module correctly at script scope, so module and callers are each fine in isolation — only the combination fails, only on the consumer path, only at Step 7. Nothing exercises a real end-to-end Windows consumer install in CI, which is a known gap.

Signed-off-by: Mark Bodman <markdbodman@gmail.com>