### PR TITLE
docs(dogfood): add two failure shapes the playbook was missing

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2593,6 +2593,7 @@
         "before-you-start",
         "the-phases",
         "what-to-look-for",
+        "budget-for-the-model-download",
         "what-to-record",
         "where-findings-go",
         "augmenting-this-playbook",

--- a/docs/dogfood/reset-cycle-playbook.md
+++ b/docs/dogfood/reset-cycle-playbook.md
@@ -72,6 +72,18 @@ items is more dangerous than no bundle, because it reads as protected. Anything
 that is a snapshot goes stale — re-verify it against live state, do not trust its
 existence.
 
+**A rehearsal that skips the expensive step is not a rehearsal.** An uninstaller's
+`-DryRun` printed a clean plan; the real run aborted immediately, every time, on
+the default configuration. The dry run printed intentions without invoking the
+thing that failed, so it never exercised the failing path. When a dry run passes,
+ask which parts it did not execute.
+
+**Your tooling can hold a resource the thing under test needs.** A monitor
+tailing an installer's log held the file open; the installer then died with
+*"cannot access the file ... used by another process"* — an error that names the
+installer and blames the wrong component. Before filing a defect against
+something you are watching, check whether watching it is the cause.
+
 **Your own verification is a prime suspect.** In one cycle the checking code was
 wrong four separate times: a regex that threw on every path, a column-offset read
 that misparsed a filename with a space, a three-dot git diff that reported every
@@ -83,6 +95,18 @@ re-measure a different way before believing it.**
 11/11, published a correct public site, and had no operating model at all behind
 it. See the
 [Archetype Operating-Model Audit](../architecture/archetype-operating-model-audit.md).
+
+### Budget for the model download
+
+A zero-footprint teardown clears the Docker Model Runner store, so the next
+install re-downloads the whole local model — roughly 20 GB, and the longest
+single step in the cycle. Plan for it, or decide deliberately to retain the model
+between cycles and say so in your report.
+
+Check `docker model ls` afterwards for stub entries: a partial pull can leave a
+row that looks like an installed model but has no size, no parameters, and a
+1970-epoch creation date rendered as "56 years ago". `docker model inspect` shows
+`"created": 0` and an empty config.
 
 ## What to record
 


### PR DESCRIPTION
Cycle 4 produced both, and both wasted real time before being understood.

**"A rehearsal that skips the expensive step is not a rehearsal."** The uninstaller's `-DryRun` printed a clean plan while the real command aborted immediately, every time, on the default configuration. The dry run prints intentions without invoking the thing that failed, so it never exercised the failing path. I treated that rehearsal as evidence the teardown was safe; it was evidence of nothing.

**"Your tooling can hold a resource the thing under test needs."** A monitor tailing the installer's log held the file open, and the installer failed with *"cannot access the file … used by another process"* — an error naming the installer while blaming the wrong component. That very nearly became a filed installer defect.

Both meet the bar this document sets for a new trap: **shapes that recur across unrelated features**, not single defects. Either could catch something in a part of the product the reader has never opened.

Also adds the model-download cost to *What to record*. It's the longest step in the cycle, and a tester who hasn't budgeted for a ~20 GB pull will assume the install has hung. Includes how to spot the stub a partial pull leaves behind — a row that looks like an installed model but reports `"created": 0`, no size, and renders as "56 years ago".

Doc links pass, index regenerated.

Signed-off-by: Mark Bodman <markdbodman@gmail.com>