### PR TITLE
fix(mcp): stop describe_committed_model reporting a confident absence from a tree it cannot name (BI-F9CAF214)

### DIFF
--- a/apps/web/lib/mcp/packs/committed-schema-provenance.test.ts
+++ b/apps/web/lib/mcp/packs/committed-schema-provenance.test.ts
@@ -1,0 +1,108 @@
+// Regression for the defect this tool SHIPPED WITH.
+//
+// Live call 2026-08-23 from an external CLI session:
+//   describe_committed_model({ model_name: "MileageRate" })
+//   -> "No model named MileageRate ... on unknown branch @ unknown sha"
+//   -> trust.tier "high", overallScore 0.99
+//   -> freshness rationale: 'Schema was read from "unknown", the default branch.'
+//
+// MileageRate IS on main. The portal container has no git, so branch and
+// headSha resolve to null on EVERY production call — and null fell through to
+// full freshness marks, producing a confident wrong answer at high trust from a
+// tree the tool could not identify. That is the exact false-absence failure the
+// tool exists to prevent.
+//
+// The original suite passed `readGit: async () => "main"` and never exercised
+// the null path, so it was green against a value production never carries —
+// the same error class as a test pinned to an archetype no page uses.
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { loadCommittedSchema } from "./committed-schema-source";
+
+const readdir = vi.fn();
+const readFile = vi.fn();
+
+vi.mock("@/lib/shared/lazy-node", () => ({
+  lazyFsPromises: () => ({ readdir, readFile }),
+  lazyPath: () => ({ resolve: (...p: string[]) => p.join("/") }),
+  getCwd: () => "/cwd",
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+/** What production actually gets: a container with no git available. */
+const noGit = async () => null;
+
+async function load() {
+  readdir.mockResolvedValueOnce(["a.prisma"]);
+  readFile.mockResolvedValueOnce("model User {}");
+  // Explicit: git refused AND .git/HEAD was unreadable. Relying on the fs mock
+  // running out of queued values would make this pass by accident.
+  return loadCommittedSchema({ readGit: noGit, readBranchFallback: async () => null });
+}
+
+describe("committed schema — unidentifiable tree", () => {
+  it("does NOT assert that the unidentified tree IS the default branch", async () => {
+    const r = await load();
+    const freshness = r!.trust.dimensions.find((d) => d.key === "freshness");
+    // The shipped bug rendered: 'Schema was read from "unknown", the default branch.'
+    // Telling the caller to CONFIRM against the default branch is correct and
+    // must stay; asserting this tree is it, is the defect.
+    expect(freshness!.rationale).not.toMatch(/read from\s+"?[^"]*"?,\s*the default branch/);
+    expect(freshness!.rationale).toMatch(/could\s+NOT be determined/);
+    expect(freshness!.rationale).toMatch(/INCONCLUSIVE/);
+  });
+
+  it("does NOT score unknown provenance at full freshness", async () => {
+    const r = await load();
+    const freshness = r!.trust.dimensions.find((d) => d.key === "freshness");
+    expect(freshness!.score).toBeLessThanOrEqual(0.4);
+  });
+
+  it("does not present an unidentified tree as high trust", async () => {
+    const r = await load();
+    expect(r!.trust.tier).not.toBe("high");
+    expect(r!.trust.action).not.toBe("present");
+  });
+
+  it("marks the read inconclusive so a miss cannot be reported as an absence", async () => {
+    const r = await load();
+    expect(r!.provenance.identified).toBe(false);
+  });
+
+  it("still identifies a real branch normally", async () => {
+    readdir.mockResolvedValueOnce(["a.prisma"]);
+    readFile.mockResolvedValueOnce("model User {}");
+    const r = await loadCommittedSchema({
+      readGit: async () => "main",
+      readBranchFallback: async () => null,
+    });
+    expect(r!.provenance.identified).toBe(true);
+    expect(r!.trust.dimensions.find((d) => d.key === "freshness")!.score).toBe(1);
+  });
+});
+
+// The live condition: git is installed but every call fails with
+// "detected dubious ownership", so readGit yields null. .git/HEAD is still a
+// plain readable file naming the branch, and recovering it is strictly better
+// than reporting an unidentifiable tree.
+describe("committed schema — .git/HEAD provenance fallback", () => {
+  it("recovers the branch when git refuses, and caps it as off-default", async () => {
+    readdir.mockResolvedValueOnce(["a.prisma"]);
+    readFile.mockResolvedValueOnce("model User {}");
+
+    const r = await loadCommittedSchema({
+      readGit: noGit,
+      readBranchFallback: async () => "client/5727856b-3296-4e17-97f0-c59401ace4f2",
+    });
+
+    expect(r!.provenance.identified).toBe(true);
+    expect(r!.provenance.branch).toBe("client/5727856b-3296-4e17-97f0-c59401ace4f2");
+    const freshness = r!.trust.dimensions.find((d) => d.key === "freshness");
+    // Named side branch: capped, and NAMED in the rationale.
+    expect(freshness!.score).toBeLessThanOrEqual(0.4);
+    expect(freshness!.rationale).toContain("client/5727856b");
+    expect(freshness!.rationale).toMatch(/not the default branch/);
+    expect(r!.trust.tier).not.toBe("high");
+  });
+});

--- a/apps/web/lib/mcp/packs/committed-schema-source.ts
+++ b/apps/web/lib/mcp/packs/committed-schema-source.ts
@@ -32,6 +32,13 @@ import {
 /** Directory holding the split Prisma schema (there is no monolithic schema.prisma). */
 export const SCHEMA_DIR_RELATIVE = "packages/db/prisma/schema";
 
+/**
+ * Freshness ceiling when the tree cannot be identified at all. Deliberately
+ * BELOW the off-default-branch cap: a named side branch at least tells you what
+ * you are looking at, an unnamed tree tells you nothing.
+ */
+export const UNIDENTIFIED_TREE_FRESHNESS_CAP = 0.15;
+
 export type CommittedSchemaProvenance = {
   /** Absolute path the schema was read from. */
   root: string;
@@ -43,6 +50,12 @@ export type CommittedSchemaProvenance = {
   schemaFileCount: number;
   /** Always "committed" — this reader never reads a build sandbox. */
   tree: "committed";
+  /**
+   * False when the tree could not be identified (no git in the container, so
+   * branch and headSha are null). A miss against an UNIDENTIFIED tree is
+   * inconclusive, never an absence — see the note on buildTrust.
+   */
+  identified: boolean;
 };
 
 export type CommittedSchemaSource = {
@@ -77,9 +90,64 @@ const defaultReadGit: GitReader = async (root, args) => {
   }
 };
 
+/**
+ * SHIPPED DEFECT, fixed here. `isOffDefaultBranch(null)` returns false — null
+ * means "not applicable" to the code-graph adapter it was written for — and the
+ * original scoring did `offDefault ? CAP : 1`, so a tree with NO git resolved to
+ * full freshness marks and the rationale template rendered
+ * 'Schema was read from "unknown", the default branch.'
+ *
+ * Every production call takes that path: the portal container ships the built
+ * app without a git repository, so branch and headSha are always null. The
+ * result was a confident "model not found" at trust tier HIGH (0.99) against a
+ * tree the tool could not name — on a live call for MileageRate, which is on
+ * main. That is precisely the false absence this reader exists to prevent.
+ *
+ * Unknown provenance is now its own case, scored BELOW the off-default cap:
+ * an unnamed tree is strictly worse evidence than a named side branch, because
+ * you cannot even tell how far it has drifted.
+ */
+/**
+ * Recover the branch name by READING `.git/HEAD` when the git binary refuses.
+ *
+ * On the live portal, git is installed but every invocation fails with
+ * "fatal: detected dubious ownership in repository at '/sandbox-workspace'" —
+ * the container runs as a different uid than the checkout owner. So `readGit`
+ * returns null on EVERY production call, and the tree looked unidentifiable
+ * even though `.git/HEAD` plainly says
+ * `ref: refs/heads/client/5727856b-3296-4e17-97f0-c59401ace4f2`.
+ *
+ * Naming the branch is strictly better than admitting ignorance: it lets the
+ * off-default cap fire with the real branch in the rationale, instead of
+ * collapsing to the weaker "unidentified tree" case. Plain file read, no
+ * ownership check to trip over.
+ */
+async function readBranchFromGitHead(root: string): Promise<string | null> {
+  const { resolve } = lazyPath();
+  const { readFile } = lazyFsPromises();
+  try {
+    let gitDir = resolve(root, ".git");
+    const head = await readFile(resolve(gitDir, "HEAD"), "utf-8").catch(async () => {
+      // `.git` is a FILE in a linked worktree: "gitdir: <path>".
+      const pointer = await readFile(gitDir, "utf-8");
+      const match = /^gitdir:\s*(.+)$/m.exec(pointer);
+      if (!match) throw new Error("unparseable gitdir pointer");
+      gitDir = match[1].trim();
+      return readFile(resolve(gitDir, "HEAD"), "utf-8");
+    });
+    const ref = /^ref:\s*refs\/heads\/(.+)$/m.exec(String(head).trim());
+    if (ref) return ref[1].trim();
+    const detached = String(head).trim();
+    return /^[0-9a-f]{7,40}$/i.test(detached) ? detached : null;
+  } catch {
+    return null;
+  }
+}
+
 function buildTrust(provenance: CommittedSchemaProvenance, asOf: string): TrustAssessment {
+  const identified = provenance.identified;
   const offDefault = isOffDefaultBranch(provenance.branch);
-  const branchLabel = provenance.branch ?? "unknown";
+  const branchLabel = provenance.branch ?? "an unidentified tree";
 
   const dimensions: TrustDimensionInput[] = [
     {
@@ -95,15 +163,26 @@ function buildTrust(provenance: CommittedSchemaProvenance, asOf: string): TrustA
     {
       key: "freshness",
       label: "Freshness",
-      // An off-default branch is capped for the same reason the code graph caps
-      // it: recency of the READ says nothing about the age of what was read.
-      score: offDefault ? OFF_DEFAULT_BRANCH_FRESHNESS_CAP : 1,
+      // Unknown < off-default < default. An off-default branch is capped for the
+      // same reason the code graph caps it: recency of the READ says nothing
+      // about the age of what was read. An UNIDENTIFIED tree is worse still.
+      score: !identified
+        ? UNIDENTIFIED_TREE_FRESHNESS_CAP
+        : offDefault
+          ? OFF_DEFAULT_BRANCH_FRESHNESS_CAP
+          : 1,
       weight: 2,
-      rationale: offDefault
-        ? `Schema was read from branch "${branchLabel}", not the default branch — ` +
-          "it may not match what is merged to main. Re-read against the default " +
-          "branch before treating a null result as an absence."
-        : `Schema was read from "${branchLabel}", the default branch.`,
+      rationale: !identified
+        ? `Schema was read from ${provenance.root}, but the branch and commit could ` +
+          "NOT be determined (no git metadata available there). There is no way to " +
+          "tell how far this tree has drifted from the merge target, so a model " +
+          "missing from it is INCONCLUSIVE, not absent. Confirm against the default " +
+          "branch before recording any absence."
+        : offDefault
+          ? `Schema was read from branch "${branchLabel}", not the default branch — ` +
+            "it may not match what is merged to main. Re-read against the default " +
+            "branch before treating a null result as an absence."
+          : `Schema was read from "${branchLabel}", the default branch.`,
       measuredAt: asOf,
       evidenceRefs: [],
     },
@@ -142,6 +221,8 @@ function buildTrust(provenance: CommittedSchemaProvenance, asOf: string): TrustA
 export type LoadCommittedSchemaDeps = {
   asOf?: Date;
   readGit?: GitReader;
+  /** Injected in tests; defaults to reading `.git/HEAD` off disk. */
+  readBranchFallback?: (root: string) => Promise<string | null>;
 };
 
 export async function loadCommittedSchema(
@@ -169,10 +250,18 @@ export async function loadCommittedSchema(
     return null;
   }
 
-  const [branch, headSha] = await Promise.all([
+  let [branch, headSha] = await Promise.all([
     readGit(root, "rev-parse --abbrev-ref HEAD"),
     readGit(root, "rev-parse HEAD"),
   ]);
+  // git refused (dubious ownership in the portal container is the norm, not the
+  // exception) — recover the branch from .git/HEAD rather than report an
+  // unidentifiable tree.
+  if (branch === null) {
+    branch = deps.readBranchFallback
+      ? await deps.readBranchFallback(root)
+      : await readBranchFromGitHead(root);
+  }
 
   const provenance: CommittedSchemaProvenance = {
     root,
@@ -180,6 +269,7 @@ export async function loadCommittedSchema(
     headSha,
     schemaFileCount: names.length,
     tree: "committed",
+    identified: branch !== null || headSha !== null,
   };
 
   return {

--- a/apps/web/lib/mcp/packs/model-provider-pack.ts
+++ b/apps/web/lib/mcp/packs/model-provider-pack.ts
@@ -139,6 +139,29 @@ async function describeCommittedModelHandler(params: Record<string, unknown>): P
   const where = `${source.provenance.branch ?? "unknown branch"} @ ${source.provenance.headSha?.slice(0, 12) ?? "unknown sha"}`;
 
   if (!desc) {
+    // A miss against a tree we cannot NAME is inconclusive, not an absence.
+    // Shipped defect: this returned a flat "not found" at trust tier high for
+    // MileageRate — a model on main — because the container has no git and the
+    // unidentified tree scored full freshness marks.
+    if (!source.provenance.identified) {
+      return {
+        success: false,
+        error: `INCONCLUSIVE: "${modelName}" not present in an unidentified tree.`,
+        message:
+          `INCONCLUSIVE — NOT an absence. "${modelName}" is not in the schema read from ` +
+          `${source.provenance.root} (${source.provenance.schemaFileCount} domain files), but the ` +
+          "branch and commit of that tree could NOT be determined, so there is no way to tell how far " +
+          "it has drifted from the merge target. Do NOT record this as evidence the model does not " +
+          "exist. Confirm against the default branch — e.g. " +
+          `\`git grep -n "model ${modelName}" origin/main -- packages/db/prisma/schema/\` — before concluding anything.`,
+        data: {
+          found: false,
+          inconclusive: true,
+          source: source.provenance,
+          trust: source.trust,
+        } as unknown as Record<string, unknown>,
+      };
+    }
     return {
       success: false,
       error: `Model "${modelName}" not found on ${where}.`,
@@ -148,6 +171,7 @@ async function describeCommittedModelHandler(params: Record<string, unknown>): P
         "Check PascalCase spelling. If this tree is not the default branch, re-check against the merge target before recording an absence.",
       data: {
         found: false,
+        inconclusive: false,
         source: source.provenance,
         trust: source.trust,
       } as unknown as Record<string, unknown>,
@@ -156,7 +180,12 @@ async function describeCommittedModelHandler(params: Record<string, unknown>): P
 
   return {
     success: true,
-    message: `${formatModelDescription(desc)}\n\nRead from committed schema on ${where}. Trust: ${source.trust.tier} (${source.trust.action}) — ${source.trust.primaryRationale}`,
+    message:
+      `${formatModelDescription(desc)}\n\nRead from committed schema on ${where}` +
+      (source.provenance.identified
+        ? ""
+        : " (branch and commit could NOT be determined — the shape shown may be older than the merge target)") +
+      `. Trust: ${source.trust.tier} (${source.trust.action}) — ${source.trust.primaryRationale}`,
     data: {
       found: true,
       model: desc,


### PR DESCRIPTION
Self-inflicted. The tool shipped in #4589 **to prevent false absence**, and its first live call from an external CLI produced exactly one:

```
describe_committed_model({ model_name: "MileageRate" })
→ "No model named MileageRate ... on unknown branch @ unknown sha"
→ trust: tier "high", overallScore 0.99
→ freshness rationale: 'Schema was read from "unknown", the default branch.'
```

`MileageRate` is on main (`finance.prisma:1149`). The tool asserted that a tree it could not identify **was** the default branch, and reported high trust on a wrong answer.

## Three defects, one chain

**1. Unknown provenance scored as the default branch.** `isOffDefaultBranch(null)` returns `false` — null means "not applicable" to the code-graph adapter it was written for — and scoring did `offDefault ? CAP : 1`, so a null branch took full freshness marks and rendered the sentence above. Unknown is now its own case, capped at **0.15**: deliberately *below* the off-default cap, because an unnamed tree is worse evidence than a named side branch — you cannot tell how far it has drifted.

**2. A miss on an unidentified tree was reported as an absence.** It now returns `INCONCLUSIVE`, carries `data.inconclusive = true`, and hands back the `git grep … origin/main` that would settle it. A *hit* from such a tree is qualified too.

**3. The tree was identifiable all along.** git is installed in the portal container, but every call fails with `fatal: detected dubious ownership in repository at '/sandbox-workspace'` — the container runs as a different uid than the checkout. So `readGit` returned null on **every production call**, while `.git/HEAD` plainly read `ref: refs/heads/client/5727856b-3296-4e17-97f0-c59401ace4f2`. Added a plain-file fallback reading `.git/HEAD` (handling the `gitdir:` pointer of a linked worktree, and a detached sha). Naming the branch is strictly better than admitting ignorance: the off-default cap now fires **with the real branch in the rationale** instead of collapsing to the weaker case.

## Why the original tests missed it

Every case injected `readGit: async () => "main"`. **Production never takes that path** — git always fails there — so the suite was green against a value the runtime cannot produce.

That is the same error class this session found in the kernel attenuation lever, whose tests all passed an archetype no principle page carries. A test pinned to a value production cannot produce proves nothing about production. The regression suite here is written against the null-git path **first**, and asserts on the specific false claim (`read from "x", the default branch`) rather than on any mention of the default branch — telling the caller to *confirm* against main is correct and must stay.

## Verification

- **50 tests pass across 9 files**; the 5 new provenance cases fail against the shipped code and pass here.
- Fallback verified against the live container: `.git/HEAD` yields `client/5727856b-…`, which the tree confirms is stale (`MileageRate` absent, 26 domain files present).
- `pnpm --filter web build`: clean.
- `pregate:preflight`: 50 guards clean.
- exact-tree local CI gate: **PASS** (evidence `cmt6g4jct0ss501pqjfu8x1fm`).

## Scope

This does **not** make the portal read `main` — `/sandbox-workspace` is a Build Studio sandbox branch. It makes the tool **say so** instead of guessing. Which tree the portal should treat as source of truth is the open question behind BI-6CFC5429.

Fixes the defect introduced by #4589 (BI-F9CAF214).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
