### PR TITLE
fix(self-upgrade): while a Run History row is reconnecting, only the retry re-fetches (BI-D261F24D follow-up)

### DIFF
--- a/apps/web/components/ops/RunImpactDetail.test.tsx
+++ b/apps/web/components/ops/RunImpactDetail.test.tsx
@@ -148,4 +148,28 @@ describe("RunImpactDetail", () => {
     expect(screen.queryByText(/Portal is restarting/)).toBeNull();
     vi.useRealTimers();
   });
+
+  it("does not re-fetch on collapse+re-expand while reconnecting — the retry owns it", async () => {
+    vi.useFakeTimers();
+    getSelfUpgradeRunImpactMock.mockRejectedValue(
+      new Error("An unexpected response was received from the server."),
+    );
+    render(<RunImpactDetail runId="SUR-AAAA0001" digest={DIGEST} />);
+
+    fireEvent.click(screen.getByText("View changes"));
+    await vi.waitFor(() =>
+      expect(screen.getByText(/Portal is restarting to finish this upgrade/)).toBeTruthy(),
+    );
+    expect(getSelfUpgradeRunImpactMock).toHaveBeenCalledTimes(1);
+
+    // Collapsing stops the retry; re-expanding must not fire a second fetch
+    // alongside it — the retry effect is the only thing that re-attempts.
+    fireEvent.click(screen.getByText("Hide changes"));
+    fireEvent.click(screen.getByText("View changes"));
+    expect(getSelfUpgradeRunImpactMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(RUN_IMPACT_RETRY_MS + 50);
+    expect(getSelfUpgradeRunImpactMock).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
 });

--- a/apps/web/components/ops/RunImpactDetail.tsx
+++ b/apps/web/components/ops/RunImpactDetail.tsx
@@ -82,8 +82,9 @@ export function RunImpactDetail({
       return;
     }
     setExpanded(true);
-    // Fetch once per row — a second expand replays what is already held.
-    if (loadedRef.current || isPending) return;
+    // Fetch once per row — a second expand replays what is already held, and
+    // while reconnecting the retry effect already owns the next attempt.
+    if (loadedRef.current || isPending || reconnecting) return;
     setError(null);
     load();
   }


### PR DESCRIPTION
Follow-up to #4607, which taught a Run History row to hold a calm reconnect state when a running self-upgrade swaps the portal out mid-fetch.

## What this fixes

While the row is reconnecting, `loadedRef` is still false and `isPending` is false between retries. So collapsing and re-expanding the row re-entered the fetch path and fired its own request alongside the 3s retry timer.

Harmless in isolation — the action is read-only — but it doubles the request rate against a portal that is already restarting, which is the one moment worth being quiet. The retry effect owns re-attempts while `reconnecting` holds; `toggle` now defers to it.

## Verification

- New test is red without the component change (verified by stashing `RunImpactDetail.tsx`: 1 failed / 5 passed) and green with it.
- `pnpm --filter web exec vitest run components/ops/RunImpactDetail.test.tsx` — 6/6 pass.
- `pnpm pregate` — PASS, gated sha `8d55c0a59788`, evidence `cmt6gk9a00ux401pq1wu9s9hf` (full run: 2908 test files, 24853 tests, production build compiled).
- Semantic-review receipt recorded on WC-08D378DC for this exact tree identity. It returned `inconclusive` with reason `local-ci-active-capacity-reservation` — the local CI run for this same branch held host capacity — with `mayPublish: true`. Shadow mode; not a review finding.

## Not verified

Live UX verification was not performed and is not claimed. The reconnect state only appears during a real container swap, and driving one on a production install to observe an error branch is not a reasonable trade. It is reproduced in test against the exact sanitized Next message instead. Recorded on BI-D261F24D as a `manual_check` evidence row.

## Design grounding

- Existing specs/plans reviewed:
  - No spec owns this row; the swap-window contract lives in code — `apps/web/lib/self-upgrade/is-expected-during-swap.ts` (BI-D77BF495) and `apps/web/lib/deployment-skew.ts` (BI-D22D4607, BI-F381D902).
- Current code substrate reviewed:
  - `apps/web/components/ops/RunImpactDetail.tsx` — the reconnect+retry state added in #4607; this tightens its re-entry condition.
- Source of truth:
  - The retry effect is the single owner of re-attempts while reconnecting.
- Decision:
  - Guard the toggle path rather than deduplicating in-flight requests at the action layer — the row already holds the state that answers the question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
