### PR TITLE
docs(validators): correct a stale grade in the analyzeUtteranceReadability docstring

### DIFF
--- a/packages/validators/src/readability.ts
+++ b/packages/validators/src/readability.ts
@@ -97,11 +97,12 @@ export function analyzeReadability(rawText: string): ReadabilityScore {
  * carries no complexity at all.
  *
  * Measured proof (packages/validators/src/readability.test.ts): the same fifteen
- * words, at the same 1.4 syllables per word, score grade 3.9 unpunctuated and
- * grade 1.5 with a stop after each label. Identical vocabulary; the only variable
- * is punctuation the UI had no reason to carry. On a real 200-word surface the
- * same mechanism produced grades in the teens, and that inflation is what drove
- * every /admin route over the high-school cap.
+ * words, at the same 1.4 syllables per word, score grade 6.8 with no full stop at
+ * all (one "sentence") and grade 1.5 with a stop after each label. Identical
+ * vocabulary; the only variable is punctuation the UI had no reason to carry. At
+ * the 21-word length the BI measured, the same swing is 8.7 -> 5.2. On a real
+ * 200-word surface the mechanism produced grades in the teens, and that inflation
+ * is what drove every /admin route over the high-school cap.
  *
  * THE CORRECTION. In a UI the SENTENCE BOUNDARY IS THE ELEMENT BOUNDARY. Each
  * utterance — one heading, one cell, one label — is at least one sentence, and


### PR DESCRIPTION
A one-line correction to a comment that #4604 landed with a wrong number in it.

The docstring on `analyzeUtteranceReadability` said:

> the same fifteen words, at the same 1.4 syllables per word, score grade **3.9
> unpunctuated** and grade 1.5 with a stop after each label

and cited `packages/validators/src/readability.test.ts` as the measurement. But that
test asserts `flat.sentences === 1` and a gap of more than four grades — the **6.8**
case. The 3.9 figure came from an earlier input that still carried a full stop after
"sort", which makes it two sentences, so the number was both stale and wrong to
describe as unpunctuated.

The code, the test and the PR body were always right. Only the comment was not — and
a comment that cites a test while disagreeing with it is worse than no comment, because
the next reader trusts it.

Also adds the swing at the 21-word length the BI actually measured (8.7 -> 5.2), so the
docstring and BI-0ED0F6B3's proof table can be read against each other rather than
appearing to contradict.

No behaviour change. `packages/validators` 107 tests pass; local-CI gate PASS
(evidence `cmt6lbpzv1l3v01pqn9oa9bpx`).

Refs: BI-0ED0F6B3

Process-Spine-Decision: comment-only correction to a shipped docstring, no contract or doc surface changed.
