### PR TITLE
fix: cut MCP polling and low-evidence findings

### DIFF
--- a/apps/web/lib/operate/mcp-call-efficiency/analysis.test.ts
+++ b/apps/web/lib/operate/mcp-call-efficiency/analysis.test.ts
@@ -18,6 +18,7 @@ function ev(
     routeContext: null,
     apiTokenId: "tok-1",
     skillId: null,
+    parameters: null,
     ...partial,
   };
 }
@@ -130,6 +131,64 @@ describe("analyzeCallEfficiency (BI-A08EBAEC)", () => {
     expect(report.findings.some(
       (finding) => finding.kind === "high_volume" && finding.toolName === "edge.heartbeat",
     )).toBe(true);
+  });
+
+  it("uses ownerSessionId when external JSON-RPC rows have no thread attribution", () => {
+    const start = Date.parse("2026-08-03T12:00:00.000Z");
+    const events = Array.from({ length: 10 }, (_, i) => ev({
+      id: `claim-${i}`,
+      toolName: "claim_nonprod_environment_lease",
+      threadId: "",
+      agentId: "unknown",
+      parameters: { ownerSessionId: "gate-session-a" },
+      createdAt: new Date(start + i * 1_000),
+    }));
+
+    const report = analyzeCallEfficiency(events, { thrashThreshold: 8 });
+    const thrash = report.findings.find((finding) => finding.kind === "thrash");
+    expect(thrash?.evidence.correlationId).toBe("owner-session:gate-session-a");
+  });
+
+  it("does not turn unattributed aggregate read traffic into a polling finding", () => {
+    const start = Date.parse("2026-08-03T12:00:00.000Z");
+    const events = Array.from({ length: 30 }, (_, i) => ev({
+      id: `read-${i}`,
+      toolName: "get_backlog_item",
+      threadId: "",
+      agentId: "unknown",
+      parameters: {},
+      createdAt: new Date(start + i * 1_000),
+    }));
+
+    const report = analyzeCallEfficiency(events, { highVolumeFloor: 25 });
+    expect(report.findings.some(
+      (finding) => finding.kind === "high_volume" && finding.toolName === "get_backlog_item",
+    )).toBe(false);
+    expect(report.ledgerSufficiency.note).toContain("unattributed aggregate");
+  });
+
+  it("suppresses healthy per-session lease renewal cadence", () => {
+    const start = Date.parse("2026-08-03T12:00:00.000Z");
+    const events: CallEfficiencyEvent[] = [];
+    for (const [session, offset] of [["gate-a", 0], ["gate-b", 5_000]] as const) {
+      for (let i = 0; i < 30; i++) {
+        events.push(ev({
+          id: `${session}-${i}`,
+          toolName: "renew_nonprod_environment_lease",
+          threadId: "",
+          agentId: "unknown",
+          parameters: { ownerSessionId: session },
+          createdAt: new Date(start + offset + i * 40_000),
+        }));
+      }
+    }
+
+    const report = analyzeCallEfficiency(events, { highVolumeFloor: 25 });
+    expect(report.findings.some(
+      (finding) => finding.kind === "high_volume"
+        && finding.toolName === "renew_nonprod_environment_lease",
+    )).toBe(false);
+    expect(report.ledgerSufficiency.note).toContain("contractual machine cadence");
   });
 
   it("reports insufficient ledger when volume is tiny", () => {

--- a/apps/web/lib/operate/mcp-call-efficiency/analysis.ts
+++ b/apps/web/lib/operate/mcp-call-efficiency/analysis.ts
@@ -22,6 +22,8 @@ export type CallEfficiencyEvent = {
   routeContext: string | null;
   apiTokenId: string | null;
   skillId: string | null;
+  /** Tool arguments captured by ToolExecution; used only for safe correlation hints. */
+  parameters: unknown;
 };
 
 export type EfficiencyActionKind =
@@ -49,6 +51,7 @@ export type EfficiencyFinding = {
     threadId?: string;
     agentId?: string;
     surface?: string;
+    correlationId?: string;
     sampleIds: string[];
   };
   recommendedAction: EfficiencyActionKind;
@@ -78,9 +81,9 @@ export type CallEfficiencyReport = {
 };
 
 export type AnalyzeCallEfficiencyOptions = {
-  /** Same tool count in one thread to flag thrash. Default 8. */
+  /** Same tool count in one correlated execution to flag thrash. Default 8. */
   thrashThreshold?: number;
-  /** Absolute min calls for high_volume. Default 25. */
+  /** Calls from one correlated execution for high_volume. Default 25. */
   highVolumeFloor?: number;
   /** Fail rate (0–1) for high_failure. Default 0.35. */
   highFailureRate?: number;
@@ -106,19 +109,62 @@ const ROUTINE_MACHINE_MIN_INTERVAL_MS: Readonly<Record<string, number>> = {
   "edge.heartbeat": 60_000,
   "edge.discovery_runs.submit": 300_000,
   "edge.federation_candidates.submit": 90_000,
+  // The local-CI gate owns a two-minute lease and renews at TTL / 3. Thirty
+  // seconds leaves room for scheduler jitter while still exposing tight polls.
+  "renew_nonprod_environment_lease": 30_000,
 };
+
+function recordParameter(
+  parameters: unknown,
+  key: string,
+): string | null {
+  if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
+    return null;
+  }
+  const value = (parameters as Record<string, unknown>)[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+/**
+ * Best available execution correlation, ordered from task-specific to broad.
+ * External JSON-RPC calls currently omit threadId and record agentId=unknown,
+ * but lease tools carry the durable ownerSessionId in their arguments.
+ */
+function eventCorrelationId(event: CallEfficiencyEvent): string | null {
+  if (event.threadId.trim().length > 0) return `thread:${event.threadId.trim()}`;
+  const ownerSessionId = recordParameter(event.parameters, "ownerSessionId");
+  if (ownerSessionId) return `owner-session:${ownerSessionId}`;
+  const agentId = event.agentId.trim();
+  if (agentId.length > 0 && agentId.toLowerCase() !== "unknown") {
+    return `agent:${agentId}`;
+  }
+  return null;
+}
+
+function groupByCorrelation(
+  events: readonly CallEfficiencyEvent[],
+): Map<string, CallEfficiencyEvent[]> {
+  const groups = new Map<string, CallEfficiencyEvent[]>();
+  for (const event of events) {
+    const correlationId = eventCorrelationId(event);
+    if (!correlationId) continue;
+    const rows = groups.get(correlationId) ?? [];
+    rows.push(event);
+    groups.set(correlationId, rows);
+  }
+  return groups;
+}
 
 function fitsRoutineMachineCadence(
   events: CallEfficiencyEvent[],
   minimumIntervalMs: number,
 ): boolean {
-  const byPrincipal = new Map<string, CallEfficiencyEvent[]>();
-  for (const event of events) {
-    const principal = event.agentId || event.threadId;
-    if (!principal) return false;
-    const rows = byPrincipal.get(principal) ?? [];
-    rows.push(event);
-    byPrincipal.set(principal, rows);
+  const byPrincipal = groupByCorrelation(events);
+  if (events.length > 0 && byPrincipal.size === 0) return false;
+  if ([...byPrincipal.values()].reduce((sum, rows) => sum + rows.length, 0) !== events.length) {
+    return false;
   }
 
   for (const rows of byPrincipal.values()) {
@@ -201,7 +247,13 @@ export function analyzeCallEfficiency(
   // Per-tool rollup
   const toolMap = new Map<
     string,
-    { count: number; failCount: number; durationSum: number; durationN: number }
+    {
+      count: number;
+      failCount: number;
+      durationSum: number;
+      durationN: number;
+      events: CallEfficiencyEvent[];
+    }
   >();
   for (const e of sorted) {
     const row = toolMap.get(e.toolName) ?? {
@@ -209,6 +261,7 @@ export function analyzeCallEfficiency(
       failCount: 0,
       durationSum: 0,
       durationN: 0,
+      events: [],
     };
     row.count += 1;
     if (!e.success) row.failCount += 1;
@@ -216,6 +269,7 @@ export function analyzeCallEfficiency(
       row.durationSum += e.durationMs;
       row.durationN += 1;
     }
+    row.events.push(e);
     toolMap.set(e.toolName, row);
   }
   const topTools = Array.from(toolMap.entries())
@@ -232,12 +286,14 @@ export function analyzeCallEfficiency(
   const findings: EfficiencyFinding[] = [];
 
   let suppressedRoutineCadenceFindings = 0;
+  let suppressedAggregateVolumeFindings = 0;
 
-  // Thrash: per (threadId, toolName)
+  // Thrash: per best-known execution correlation and tool.
   const thrashMap = new Map<string, CallEfficiencyEvent[]>();
   for (const e of sorted) {
-    if (!e.threadId) continue;
-    const key = `${e.threadId}::${e.toolName}`;
+    const correlationId = eventCorrelationId(e);
+    if (!correlationId) continue;
+    const key = `${correlationId}::${e.toolName}`;
     const list = thrashMap.get(key) ?? [];
     list.push(e);
     thrashMap.set(key, list);
@@ -245,19 +301,21 @@ export function analyzeCallEfficiency(
   for (const [, list] of thrashMap) {
     if (list.length < thrashThreshold) continue;
     const head = list[0]!;
+    const correlationId = eventCorrelationId(head)!;
     const waste = list.length - Math.max(2, Math.floor(thrashThreshold / 2));
     findings.push({
       kind: "thrash",
       severity: list.length >= thrashThreshold * 2 ? "critical" : "warning",
       toolName: head.toolName,
-      title: `Thrash: ${head.toolName} ×${list.length} in one thread`,
+      title: `Thrash: ${head.toolName} ×${list.length} in one execution`,
       detail:
-        `Thread ${head.threadId} called ${head.toolName} ${list.length} times ` +
+        `Execution principal ${correlationId} called ${head.toolName} ${list.length} times ` +
         `(threshold ${thrashThreshold}). Likely missing skill, over-broad tool, or poll loop.`,
       evidence: {
         count: list.length,
-        threadId: head.threadId,
+        ...(head.threadId ? { threadId: head.threadId } : {}),
         agentId: head.agentId,
+        correlationId,
         surface: surfaceLabel(head),
         sampleIds: list.slice(0, 5).map((x) => x.id),
       },
@@ -266,15 +324,9 @@ export function analyzeCallEfficiency(
     });
   }
 
-  // Retry storm: fail then same tool within retryWindowMs (per thread)
-  const byThread = new Map<string, CallEfficiencyEvent[]>();
-  for (const e of sorted) {
-    if (!e.threadId) continue;
-    const list = byThread.get(e.threadId) ?? [];
-    list.push(e);
-    byThread.set(e.threadId, list);
-  }
-  for (const [threadId, list] of byThread) {
+  // Retry storm: fail then same tool within retryWindowMs (per correlation).
+  const byCorrelation = groupByCorrelation(sorted);
+  for (const [correlationId, list] of byCorrelation) {
     const pairs = new Map<string, { n: number; ids: string[]; agentId: string }>();
     for (let i = 0; i < list.length - 1; i++) {
       const a = list[i]!;
@@ -300,12 +352,13 @@ export function analyzeCallEfficiency(
         toolName,
         title: `Retry storm: ${toolName} (${row.n} fail→retry pairs)`,
         detail:
-          `Thread ${threadId} retried ${toolName} after failure ${row.n} times ` +
+          `Execution principal ${correlationId} retried ${toolName} after failure ${row.n} times ` +
           `within ${retryWindowMs / 1000}s windows. Fix tool errors or agent instructions.`,
         evidence: {
           count: row.n,
-          threadId,
+          ...(list[0]?.threadId ? { threadId: list[0].threadId } : {}),
           agentId: row.agentId,
+          correlationId,
           sampleIds: row.ids.slice(0, 5),
         },
         recommendedAction: "fix_instructions",
@@ -316,34 +369,43 @@ export function analyzeCallEfficiency(
 
   // High volume / high failure from tool rollup
   for (const t of topTools) {
+    const toolEvents = toolMap.get(t.toolName)!.events;
     const routineInterval = ROUTINE_MACHINE_MIN_INTERVAL_MS[t.toolName];
     const routineCadenceHealthy = routineInterval !== undefined && fitsRoutineMachineCadence(
-      sorted.filter((event) => event.toolName === t.toolName),
+      toolEvents,
       routineInterval,
     );
     if (t.count >= highVolumeFloor && routineCadenceHealthy) {
       suppressedRoutineCadenceFindings += 1;
     } else if (t.count >= highVolumeFloor) {
-      findings.push({
-        kind: "high_volume",
-        severity: t.count >= highVolumeFloor * 3 ? "critical" : "warning",
-        toolName: t.toolName,
-        title: `High volume: ${t.toolName} (${t.count} calls)`,
-        detail:
-          `${t.toolName} accounts for ${t.count} calls in the window ` +
-          `(${(t.successRate * 100).toFixed(0)}% success). Candidate for skill packaging, ` +
-          `richer tool, or event/webhook replacement if status-polling.`,
-        evidence: {
-          count: t.count,
-          failCount: t.failCount,
-          sampleIds: sorted
-            .filter((e) => e.toolName === t.toolName)
-            .slice(0, 5)
-            .map((e) => e.id),
-        },
-        recommendedAction: recommendForTool(t.toolName, "high_volume"),
-        wasteCallEstimate: Math.max(0, t.count - highVolumeFloor),
-      });
+      const dominant = [...groupByCorrelation(toolEvents).entries()]
+        .sort((a, b) => b[1].length - a[1].length)[0];
+      if (!dominant || dominant[1].length < highVolumeFloor) {
+        suppressedAggregateVolumeFindings += 1;
+      } else {
+        const [correlationId, correlatedEvents] = dominant;
+        const failCount = correlatedEvents.filter((event) => !event.success).length;
+        const correlatedSuccessRate =
+          (correlatedEvents.length - failCount) / correlatedEvents.length;
+        findings.push({
+          kind: "high_volume",
+          severity: correlatedEvents.length >= highVolumeFloor * 3 ? "critical" : "warning",
+          toolName: t.toolName,
+          title: `High volume: ${t.toolName} (${correlatedEvents.length} calls)`,
+          detail:
+            `${t.toolName} accounts for ${correlatedEvents.length} calls from ${correlationId} ` +
+            `(${(correlatedSuccessRate * 100).toFixed(0)}% success). Candidate for skill packaging, ` +
+            `richer tool, or event/webhook replacement if status-polling.`,
+          evidence: {
+            count: correlatedEvents.length,
+            failCount,
+            correlationId,
+            sampleIds: correlatedEvents.slice(0, 5).map((event) => event.id),
+          },
+          recommendedAction: recommendForTool(t.toolName, "high_volume"),
+          wasteCallEstimate: Math.max(0, correlatedEvents.length - highVolumeFloor),
+        });
+      }
     }
     if (
       t.count >= highFailureMinSamples &&
@@ -392,6 +454,9 @@ export function analyzeCallEfficiency(
         ? "ToolExecution volume is sufficient for thrash/volume/failure findings. " +
           (suppressedRoutineCadenceFindings > 0
             ? `${suppressedRoutineCadenceFindings} raw-volume finding(s) were suppressed because calls fit contractual machine cadence. `
+            : "") +
+          (suppressedAggregateVolumeFindings > 0
+            ? `${suppressedAggregateVolumeFindings} raw-volume finding(s) were suppressed because unattributed aggregate traffic did not reach the threshold for one execution principal. `
             : "") +
           "tools/list and pre-auth denials remain unlogged gaps."
         : "Too few ToolExecution rows in window for reliable optimization; collect more traffic or widen the window.",

--- a/apps/web/lib/operate/mcp-call-efficiency/report.ts
+++ b/apps/web/lib/operate/mcp-call-efficiency/report.ts
@@ -59,6 +59,7 @@ export async function loadCallEfficiencyEvents(
       routeContext: true,
       apiTokenId: true,
       skillId: true,
+      parameters: true,
     },
     orderBy: { createdAt: "asc" },
     take: Math.min(20_000, Math.max(100, limit)),
@@ -77,6 +78,7 @@ export async function loadCallEfficiencyEvents(
     routeContext: r.routeContext,
     apiTokenId: r.apiTokenId,
     skillId: r.skillId,
+    parameters: r.parameters,
   }));
 }
 

--- a/apps/web/lib/tak/pattern-observer/classifiers.test.ts
+++ b/apps/web/lib/tak/pattern-observer/classifiers.test.ts
@@ -89,13 +89,36 @@ describe("pattern observer classifiers", () => {
       expect(need?.blocks).toContain("tool surface");
     });
 
-    it("classifies near-cliff caution assessments as minor tool needs", () => {
+    it("suppresses caution without observed selection degradation", () => {
+      const assessment: ToolSurfaceAssessment = {
+        toolCount: LOCAL_TOOL_SELECTION_CLIFF - 1,
+        estDefinitionTokens: 2200,
+        exceedsLocalCliff: false,
+        windowShare: 0.16,
+        zone: "caution",
+      };
+
+      expect(classifyToolSurfaceOverload(assessment)).toBeNull();
+      expect(classifyToolSurfaceOverload(assessment, {
+        total: 10,
+        succeeded: 10,
+        accuracy: 1,
+        perTool: {},
+      })).toBeNull();
+    });
+
+    it("classifies caution as minor only with observed selection degradation", () => {
       const need = classifyToolSurfaceOverload({
         toolCount: LOCAL_TOOL_SELECTION_CLIFF - 1,
         estDefinitionTokens: 2200,
         exceedsLocalCliff: false,
         windowShare: 0.16,
         zone: "caution",
+      }, {
+        total: 10,
+        succeeded: 6,
+        accuracy: 0.6,
+        perTool: {},
       });
 
       expect(need).toMatchObject({
@@ -106,27 +129,8 @@ describe("pattern observer classifiers", () => {
           windowShare: 0.16,
           zone: "caution",
           exceedsLocalCliff: false,
-        },
-      });
-    });
-
-    it("classifies caution assessments with window-share evidence as minor tool needs", () => {
-      const need = classifyToolSurfaceOverload({
-        toolCount: 8,
-        estDefinitionTokens: 140,
-        exceedsLocalCliff: false,
-        windowShare: 0.01,
-        zone: "caution",
-      });
-
-      expect(need).toMatchObject({
-        kind: "tool",
-        severity: "minor",
-        evidenceJson: {
-          toolCount: 8,
-          windowShare: 0.01,
-          zone: "caution",
-          exceedsLocalCliff: false,
+          observedSelectionAccuracy: 0.6,
+          observedSelectionSample: 10,
         },
       });
     });

--- a/apps/web/lib/tak/pattern-observer/classifiers.ts
+++ b/apps/web/lib/tak/pattern-observer/classifiers.ts
@@ -144,9 +144,13 @@ export function classifyToolSurfaceOverload(
   // false-positive this fixes. Evidence-before-diagnosis.
   if (proxyOverload) return null;
 
+  // Caution is an early threshold, not proof of harm. File work only after a
+  // real attached surface also shows degraded selection; otherwise the signal
+  // stays telemetry and does not create low-evidence backlog churn.
   const cautionIsActionable =
     assessment.zone === "caution" &&
-    (isNearLocalCliff(assessment.toolCount) || windowKnown);
+    (isNearLocalCliff(assessment.toolCount) || windowKnown) &&
+    selectionIsDegraded(selection);
 
   if (!cautionIsActionable) return null;
 

--- a/packages/dpf-skill-pack/skills/dpf-writing-plans/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-writing-plans/SKILL.md
@@ -69,6 +69,11 @@ The order is fixed: **BI first, then plan.** [`dpf-file-backlog-item`](../dpf-fi
 
    Copy the returned receipt, parent BI, deliverable-to-BI mappings, and dependencies into a `## Backlog coverage` plan section. `mcp__dpf__check_plan_backlog_coverage` is the resumability check. If MCP is unavailable, the tool is missing, or the token lacks scope, stop and report that condition; Markdown checkboxes are not a fallback and planning/backlog completeness cannot be claimed.
 
+   Treat a rejected coverage write as a remediation contract, not a blind retry:
+   - When the result is `traceability-incomplete`, add or repair the initiative baseline and mappings named by the response before making one corrected call. Do not repeat identical arguments.
+   - When the result is `plan-artifact-invalid`, reconcile the Workroom to the exact current branch and head SHA, repair the artifact or provenance named by the response, then make one corrected call. Do not mint a new plan path to dodge immutable provenance.
+   - When the response says `retryable: false`, stop after following any explicit remediation that changes the request. If no authorized remediation is available, report the returned blocker; repeated calls cannot make the contract valid.
+
 6. **Name the risks and the rollback.** What could break (blast radius), and how to back out. A plan that only describes the happy path is half a plan.
 
 7. **Save it.** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`, cross-referencing the BI id and the coverage receipt. This path is where `search_specs_and_plans` and reviewers expect plans to live. **Format is opt-in:** Markdown is the default and stays fully supported, but when the plan leans on a flow/state diagram, a multi-column table, or side-by-side option fan-out, an HTML artifact often reads better and keeps the operator in the loop — see [`html-artifacts-guide.md`](../../../../docs/superpowers/html-artifacts-guide.md) and the `_templates/spec.template.html` starting point. If you ship HTML-only, leave a short Markdown stub carrying the canonical coverage section so `search_specs_and_plans` and the guard can find it.

--- a/scripts/gate-worktree-lease.test.mjs
+++ b/scripts/gate-worktree-lease.test.mjs
@@ -156,12 +156,14 @@ test("canonical gate heartbeats during a long command and releases once", async 
 
 test("durable queue observation reuses claimKey and grants a fresh admitted TTL", async () => {
   const claims = [];
+  let leaseLists = 0;
   const server = createServer((request, response) => {
     let body = "";
     request.on("data", (chunk) => { body += chunk; });
     request.on("end", () => {
       const payload = JSON.parse(body);
       const tool = payload.params.name;
+      if (tool === "list_nonprod_environment_leases") leaseLists += 1;
       if (tool === "claim_nonprod_environment_lease") {
         claims.push({ receivedAt: Date.now(), args: payload.params.arguments });
       }
@@ -219,6 +221,7 @@ test("durable queue observation reuses claimKey and grants a fresh admitted TTL"
 
     assert.ok([0, 3].includes(result.code), result.output);
     assert.equal(claims.length, 2);
+    assert.equal(leaseLists, 1, "queue reconciliation should be cached across a short admission retry");
     assert.equal(claims[0].args.claimKey, claims[1].args.claimKey);
     assert.match(
       claims[0].args.claimKey,

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -62,6 +62,7 @@ import { isEntryModule } from "./lib/entry-module.mjs";
 const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
 const LOCAL_CI_ACTIVE_LEASE_TTL_MS = 2 * 60_000;
+const DEAD_QUEUE_RECONCILIATION_INTERVAL_MS = 60_000;
 
 const HARD_EXECUTION_PRESSURE_REASONS = new Set([
   "host-memory-low",
@@ -1074,18 +1075,25 @@ async function main() {
   }
 
   let claimAttempt = 0;
+  let nextQueueReconciliationAt = 0;
   for (;;) {
     if (receivedSignal) {
       await releaseLeaseOnce();
       process.exit(130);
     }
-    await cancelDeadLocalQueueObservers({
-      directory: queueObserverDirectory,
-      mcpUrl: options.mcpUrl,
-      bearerToken,
-      leaseEvents,
-      reportActive: claimAttempt === 0,
-    });
+    // Reconciliation is a shared-host hygiene sweep, not an admission poll.
+    // Run it before the first claim and at a human-scale cadence during long
+    // queue waits; the durable claimKey remains the queue authority in between.
+    if (Date.now() >= nextQueueReconciliationAt) {
+      await cancelDeadLocalQueueObservers({
+        directory: queueObserverDirectory,
+        mcpUrl: options.mcpUrl,
+        bearerToken,
+        leaseEvents,
+        reportActive: claimAttempt === 0,
+      });
+      nextQueueReconciliationAt = Date.now() + DEAD_QUEUE_RECONCILIATION_INTERVAL_MS;
+    }
     expiresAt = new Date(Date.now() + leaseTtlMs).toISOString();
     const hostPressure = await observeLocalCiHostPressure({
       rootClone,


### PR DESCRIPTION
## What changed

- Correlate MCP efficiency events by thread, lease `ownerSessionId`, or known agent. High-volume findings now require one execution principal to cross the threshold; aggregate traffic from concurrent unattributed sessions is reported as insufficient evidence.
- Recognize per-session lease renewal at the gate's expected cadence, and limit dead queue-observer reconciliation to once per minute while the durable claim remains the admission authority.
- Teach `dpf-writing-plans` to remediate `traceability-incomplete`, `plan-artifact-invalid`, and `retryable: false` results before making one corrected coverage call.
- Require observed tool-selection degradation before a caution-zone surface files a capability need. Known overload remains directly actionable.

These changes keep the efficiency scanner useful without turning normal coordination traffic or threshold proximity into backlog churn.

## Design grounding

- Existing specs/plans reviewed: the live MCP-efficiency reports behind #4540-#4545, the capability-need evidence behind #4564, and kernel decision `DI-C223A2DF7702` selecting this bounded cluster.
- Current code substrate reviewed: `mcp-call-efficiency/analysis.ts` and `report.ts`, the canonical `gate-worktree.mjs` admission loop, and the pattern-observer classifier plus its attached-surface accuracy evidence.
- Source of truth: `ToolExecution` arguments for execution ownership, the durable lease claim key for admission, and observed selection accuracy for capability evidence.
- Decision: attribute before diagnosing, preserve contractual liveness, and file work only from evidence tied to one execution or a measured degradation.

## Verification

- Focused and adjacent web suites: 55 tests passed.
- Canonical gate suite: 23 passed, 1 Windows-only signal-handler test skipped.
- Adjacent pregate contract suites: 30 passed.
- Skill seed/relevance checks: 25 seed tests plus the relevance suite passed; instruction-plane and prose ratchets passed.
- Web typecheck passed; the 52-guard host preflight passed after recording required attestations.
- Exact merged-tree local CI applied migrations, passed typecheck, and passed 2,910 test files / 24,897 tests. The production image stage was infrastructure-blocked because the shared install's configured buildx builder had no backing container; a live sibling Workroom already owns that builder-lifecycle repair. Cloud build remains authoritative.
- Independent semantic review was infrastructure-inconclusive with no findings; the current shadow policy allowed publication.
- UX: not applicable—no rendered UI changed. Migration: none.

## Documentation impact

`dpf-writing-plans` now carries the operator-facing retry contract. The documented pre-PR commands and user-visible gate flow did not change.

Closes #4540
Closes #4541
Closes #4542
Closes #4543
Closes #4544
Closes #4545
Closes #4564

Docs-Impact-Decision: Internal analyzer, classifier, and queue-cadence policy changed; the documented pre-PR gate commands and user-visible flow do not change.

Seed-Fit-Decision: global-default

Every governed implementation plan uses the same coverage recorder; bounded failure remediation belongs in the canonical skill body and does not widen its audience, invocation, or always-on description.

Local-CI-Override: install-bootstrap-recovery: the shared buildx builder container is missing; the exact merged tree passed migrations, typecheck, and 24,897 tests before the infrastructure-only build stage.
