### PR TITLE
fix(installer): prefer curated coder model policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ COPY scripts/lib/capability-service-projection.mjs ./scripts/lib/
 COPY scripts/lib/capability-state-hash.mjs ./scripts/lib/
 COPY scripts/lib/transition-signing.mjs ./scripts/lib/
 COPY scripts/installer/resolve-host-identity.mjs ./scripts/installer/
+COPY scripts/installer/local-model-policy.json ./scripts/installer/
 COPY apps/web/ ./apps/web/
 COPY packages/ ./packages/
 COPY docs/professions/ ./docs/professions/
@@ -103,6 +104,7 @@ COPY scripts/lib/capability-state-hash.mjs ./scripts/lib/
 COPY scripts/lib/capability-service-projection.mjs ./scripts/lib/
 COPY scripts/lib/transition-signing.mjs ./scripts/lib/
 COPY scripts/installer/resolve-host-identity.mjs ./scripts/installer/
+COPY scripts/installer/local-model-policy.json ./scripts/installer/
 COPY scripts/capability-service-catalog.generated.json ./scripts/
 COPY scripts/installer/validate-install-state.mjs ./scripts/installer/
 COPY scripts/installer/install-state-transaction.mjs ./scripts/installer/
@@ -195,6 +197,7 @@ RUN mkdir -p /dpf-release-assets/scripts/lib /dpf-release-assets/scripts/install
     cp scripts/bootstrap-organization-pki.ps1 /dpf-release-assets/scripts/ && \
     cp scripts/lib/resolve-capability-compose-profiles.mjs scripts/lib/govern-capability-compose-args.mjs scripts/lib/capability-state-hash.mjs /dpf-release-assets/scripts/lib/ && \
     cp scripts/capability-service-catalog.generated.json /dpf-release-assets/scripts/ && \
+    cp scripts/installer/local-model-policy.json /dpf-release-assets/scripts/installer/ && \
     cp scripts/installer/validate-install-state.mjs /dpf-release-assets/scripts/installer/ && \
     cp scripts/installer/install-state-transaction.mjs scripts/installer/install-release-assets.mjs scripts/installer/install-state-lock-contract.json /dpf-release-assets/scripts/installer/ && \
     cp scripts/installer/install-state-schema-registry.mjs /dpf-release-assets/scripts/installer/ && \

--- a/apps/web/lib/inference/local-model-policy.test.ts
+++ b/apps/web/lib/inference/local-model-policy.test.ts
@@ -14,45 +14,12 @@ import {
   MAX_LOCAL_CONTEXT_TOKENS,
   clampServedContextTokens,
   recommendServedContextTokens,
-  expectedDigestForModel,
-  tierRequiresDigestPin,
   LOCAL_MODEL_TIERS,
 } from "./local-model-policy";
 
-describe("model integrity pinning (BI-73E9A282)", () => {
-  // A HuggingFace ref names a FILE, not an immutable revision, and
-  // `docker model pull` accepts no flags — so a mutable upstream can change
-  // under a stable id. The digest is the only detection the platform can do.
-  it("every tier sourced outside the curated ai/ namespace pins a digest", () => {
-    const unpinned = LOCAL_MODEL_TIERS.filter(
-      (t) => tierRequiresDigestPin(t) && !t.expectedDigest,
-    ).map((t) => t.model);
-    expect(unpinned).toEqual([]);
-  });
-
-  it("digests are full sha256 values, not truncated or bare hex", () => {
-    for (const tier of LOCAL_MODEL_TIERS) {
-      if (!tier.expectedDigest) continue;
-      expect(tier.expectedDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
-    }
-  });
-
-  it("looks up the pinned digest by pull-form model id", () => {
-    expect(expectedDigestForModel("hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M")).toBe(
-      "sha256:66c4f325bc71350f07fb2da4f92455553c7bbc8af5d7ee2095fbeac79b9e66c9",
-    );
-  });
-
-  it("returns null for curated ai/ tiers and for unknown ids", () => {
-    // ai/ tiers resolve through Docker Hub's content-addressed registry, which
-    // already pins bytes to a tag — no separate digest needed.
-    expect(expectedDigestForModel("ai/qwen3-coder")).toBeNull();
-    expect(expectedDigestForModel("ai/nonexistent-model")).toBeNull();
-  });
-
-  it("classifies which tiers require a pin", () => {
-    expect(tierRequiresDigestPin({ model: "ai/qwen3-coder", weightsGb: 16, label: "x" })).toBe(false);
-    expect(tierRequiresDigestPin({ model: "hf.co/org/repo:Q4", weightsGb: 1, label: "x" })).toBe(true);
+describe("fresh-install model provenance (BI-957122B4)", () => {
+  it("only recommends models from Docker's curated ai/ namespace", () => {
+    expect(LOCAL_MODEL_TIERS.every((tier) => tier.model.startsWith("ai/"))).toBe(true);
   });
 });
 
@@ -77,11 +44,11 @@ describe("recommendGenerationModel (discrete, headroom-aware)", () => {
     expect(recommendGenerationModel(0)).toBe("ai/qwen3:4B-UD-Q4_K_XL");
   });
   it("reserves headroom so a recommended model never fills the card", () => {
-    // 24 GB card → Qwen3.8-27B (18+5=23 fits). 21-22 GB still lands on the 30B
-    // coder, and nothing may select a model whose weights+headroom exceed the card:
+    // 24 GB card → Qwen3-Coder (16+5=21 fits), and nothing may select a model
+    // whose weights+headroom exceed the card:
     // that over-commit at build context is the bug this headroom rule exists for.
-    expect(recommendGenerationModel(24)).toBe("hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M");
-    expect(recommendGenerationModel(27)).toBe("hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M");
+    expect(recommendGenerationModel(24)).toBe("ai/qwen3-coder");
+    expect(recommendGenerationModel(27)).toBe("ai/qwen3-coder");
     expect(recommendGenerationModel(22)).toBe("ai/qwen3-coder");
     expect(recommendGenerationModel(21)).toBe("ai/qwen3-coder");
     expect(recommendGenerationModel(17)).toBe("ai/qwen3:14B-Q6_K");
@@ -94,16 +61,15 @@ describe("recommendGenerationModel (discrete, headroom-aware)", () => {
 });
 
 describe("recommendGenerationModelForHost (architecture-aware) + computeMemoryBudgetGb", () => {
-  it("discrete card uses VRAM directly → the 4090 lands on the dense 27B", () => {
-    // 24 GB card → Qwen3.8-27B (18+5=23 fits with a margin the 30B coder does not need).
-    expect(recommendGenerationModelForHost({ architecture: "discrete", vramGb: 24 })).toBe("hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M");
+  it("discrete card uses VRAM directly → the 4090 lands on the curated coder", () => {
+    expect(recommendGenerationModelForHost({ architecture: "discrete", vramGb: 24 })).toBe("ai/qwen3-coder");
     expect(computeMemoryBudgetGb({ architecture: "discrete", vramGb: 24 })).toBe(24);
   });
   it("unified Apple Silicon runs a far larger model than the same GB of discrete VRAM", () => {
     // 128 GB unified Mac → 80B MoE (128 * 0.75 = 96 budget; 48+5 fits).
     expect(recommendGenerationModelForHost({ architecture: "unified", totalRamGb: 128 })).toBe("ai/qwen3-coder-next");
-    // 32 GB Mac → 24 budget → the dense 27B, same as a 24 GB card.
-    expect(recommendGenerationModelForHost({ architecture: "unified", totalRamGb: 32 })).toBe("hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M");
+    // 32 GB Mac → 24 budget → the same curated coder as a 24 GB card.
+    expect(recommendGenerationModelForHost({ architecture: "unified", totalRamGb: 32 })).toBe("ai/qwen3-coder");
     expect(recommendGenerationModelForHost({ architecture: "unified", totalRamGb: 16 })).toBe("ai/qwen3:8B-Q4_K_M");
   });
   it("cpu-only reserves more system RAM for the OS", () => {

--- a/apps/web/lib/inference/local-model-policy.ts
+++ b/apps/web/lib/inference/local-model-policy.ts
@@ -14,12 +14,14 @@
 // Each picked a model independently; nothing enforced "ONE generation model at a
 // time" or noticed when two had accumulated. Docker Model Runner loads one
 // `llama-server` per model with no concurrency cap, so two big models thrash /
-// OOM the GPU. This module centralises the policy; bootstrap + the Providers UX
-// import it, and the install scripts (which cannot import TS) mirror LOCAL_MODEL_TIERS
-// with a pointer comment. detectLocalModelOverCommit() is the drift safety-net.
+// OOM the GPU. The selectors now consume one data-only install policy, while this
+// module owns the runtime guards around it. detectLocalModelOverCommit() remains
+// the safety-net for models installed outside the default policy.
 //
 // PURE module — no prisma / fs / network / server-only imports — so the client
 // OllamaManagement component can import it directly.
+
+import installModelPolicy from "../../../../scripts/installer/local-model-policy.json";
 
 /**
  * Policy: the local runtime keeps at most ONE generation (chat/coder) model
@@ -63,7 +65,7 @@ export function classifyLocalModelRole(modelId: string): LocalModelRole {
  * resident — ~4 GB over weights — and the embedder adds ~1 GB. 5 GB covers both
  * with margin and is why a 24 GB card lands on the 30B, not the 35B.
  */
-export const MODEL_HEADROOM_GB = 5;
+export const MODEL_HEADROOM_GB = installModelPolicy.modelHeadroomGb;
 
 /**
  * Fraction of UNIFIED memory (Apple Silicon) usable for the model. macOS lets
@@ -71,10 +73,10 @@ export const MODEL_HEADROOM_GB = 5;
  * the Docker stack. So a 128 GB Mac has a far larger model budget than a 24 GB
  * discrete card — it can run an 80B where the 4090 runs a 30B.
  */
-export const UNIFIED_USABLE_FRACTION = 0.75;
+export const UNIFIED_USABLE_FRACTION = installModelPolicy.unifiedUsableFraction;
 
 /** Fraction of system RAM usable for CPU-only inference (leaves room for OS + stack). */
-export const CPU_USABLE_FRACTION = 0.5;
+export const CPU_USABLE_FRACTION = installModelPolicy.cpuUsableFraction;
 
 /**
  * Served context window (tokens) the platform auto-sets for the local GENERATION
@@ -169,91 +171,20 @@ export interface HostMemory {
  * Q4 resident WEIGHT footprint; the selector adds MODEL_HEADROOM_GB for context +
  * embedder before deciding what fits.
  *
- * Mirrored (with a pointer comment) by scripts/detect-hardware-host.ts and
- * install-dpf.{ps1,sh}, which cannot import TypeScript. Keep those in sync.
+ * Defined in the data-only installer policy so browser code, host detection,
+ * and the PowerShell installer all select from the same ordered list.
  */
 export interface LocalModelTier {
   model: string;
   /** Approximate resident weight footprint, GB (Q4). */
   weightsGb: number;
   label: string;
-  /**
-   * Known-good content digest, as `docker model inspect` reports it in `id`.
-   *
-   * Set this for any tier sourced from OUTSIDE Docker's curated `ai/` namespace.
-   * A HuggingFace reference like `...:Q4_K_M` names a FILE, not an immutable
-   * revision — the publisher can replace it in place — and `docker model pull`
-   * accepts no flags, so no revision or digest can be pinned at pull time. The
-   * installers compare against this value after pulling and warn on mismatch.
-   *
-   * Model weights are a CONTROL-PLANE input: they determine tool-calling and
-   * agentic behaviour, so substituted weights are a behavioural compromise, not
-   * merely a data one. This is detection, not prevention — the honest ceiling of
-   * what the platform can do given the pull API. (BI-73E9A282.)
-   *
-   * Omitted for `ai/` tiers: those resolve through Docker Hub's content-addressed
-   * registry, which already pins bytes to a tag.
-   */
-  expectedDigest?: string;
 }
 
-export const LOCAL_MODEL_TIERS: readonly LocalModelTier[] = [
-  { model: "ai/qwen3-coder-next", weightsGb: 48, label: "Qwen3-Coder-Next 80B (MoE, 3B active)" }, // big unified (Apple 128 GB) / 64 GB+ discrete
-  // Qwen3.8-27B replaces the Qwen3.6 35B-A3B tier it outranks on task completeness.
-  // DENSE 27B (all params active per token), so it is ~4x slower per turn than the
-  // MoE tiers around it — measured 10.3s vs 2.6s mean at 30-45 attached tools on an
-  // M5 Max. That trade is deliberate: the operator criterion for the local tier is a
-  // thorough, trustworthy result rather than time-to-answer (2026-08-16).
-  //
-  // Ranked ABOVE the 30B coder despite being the newer/smaller-footprint model
-  // because the ladder is "largest that fits" and quality here does not track size:
-  // a host that could run the 35B gets this instead.
-  //
-  // Pulled from HuggingFace, not the curated `ai/` namespace — `ai/qwen3.8` publishes
-  // only the 2.4T-A95B "Max" (1.31 TB). ggml-org is llama.cpp's own org, i.e. first-
-  // party to the runtime DMR embeds. Revisit if/when an `ai/qwen3.8:27b` tag lands.
-  // Verified 2026-08-16: this id resolves to quality tier `strong` (required by
-  // default coworkers) and capability family `qwen` (toolFidelity 80) in BOTH the
-  // pull form and the runtime form DMR registers. It does NOT yet resolve as
-  // vision-capable despite being a native VLM — see BI-C2EFF855.
-  {
-    model: "hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M",
-    weightsGb: 18,
-    label: "Qwen3.8 27B (dense)",
-    // Captured on the canonical runtime 2026-08-16 from `docker model inspect`,
-    // alongside GGUF metadata: qwen35, 26.90B, MOSTLY_Q4_K_M, 17.66 GiB, 262144 ctx,
-    // general.license apache-2.0.
-    expectedDigest: "sha256:66c4f325bc71350f07fb2da4f92455553c7bbc8af5d7ee2095fbeac79b9e66c9",
-  },
-  { model: "ai/qwen3-coder", weightsGb: 16, label: "Qwen3-Coder 30B (MoE, 3B active)" }, // the 24 GB-card sweet spot (measured ~20.7 GB @ 24k ctx)
-  { model: "ai/qwen3:14B-Q6_K", weightsGb: 12, label: "Qwen3 14B" },
-  { model: "ai/qwen3:8B-Q4_K_M", weightsGb: 6, label: "Qwen3 8B" },
-  { model: "ai/qwen3:4B-UD-Q4_K_XL", weightsGb: 3, label: "Qwen3 4B" },
-] as const;
+export const LOCAL_MODEL_TIERS: readonly LocalModelTier[] = installModelPolicy.tiers;
 
 /** Smallest tier — the CPU-OK fallback when nothing larger fits the budget. */
 const SMALLEST_TIER = LOCAL_MODEL_TIERS[LOCAL_MODEL_TIERS.length - 1]!;
-
-/**
- * The known-good digest for a tier's model id, or null when the tier does not
- * pin one. Matches on the PULL form (what the tier declares) — installers
- * resolve the runtime form separately, and the digest is the same artifact
- * either way.
- */
-export function expectedDigestForModel(modelId: string): string | null {
-  const tier = LOCAL_MODEL_TIERS.find((t) => t.model === modelId);
-  return tier?.expectedDigest ?? null;
-}
-
-/**
- * True when a tier is sourced from outside Docker's curated `ai/` namespace and
- * therefore REQUIRES a pinned digest — a mutable upstream with no pull-time
- * revision pin is exactly the case the digest check exists for. Used by the
- * conformance test below so a future non-`ai/` tier cannot be added without one.
- */
-export function tierRequiresDigestPin(tier: LocalModelTier): boolean {
-  return !tier.model.startsWith("ai/");
-}
 
 /**
  * The memory budget (GB) actually available to a local model on this host:

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -119,6 +119,9 @@ single-tree mode — the current default and fully back-compat.
 7. **Workspace dependencies** — `pnpm install`.
 8. **Host hardware profile** — runs `scripts/detect-hardware-host.ts`
    (reads `/proc/cpuinfo`, `nproc`, `free -b`, `nvidia-smi` if present).
+   Model selection reads the shared `scripts/installer/local-model-policy.json`
+   policy. A 24 GB discrete GPU selects the curated `ai/qwen3-coder` tier;
+   fresh installs do not auto-provision mutable third-party model references.
 9. **`.env` generation** — only on first install; existing `.env` is
    preserved.
 10. **`docker compose up -d`** on the Linux overlay (which adds the

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -142,7 +142,10 @@ single-tree mode persists — current behavior, full back-compat.
    this.
 8. **Host hardware profile** — runs `scripts/detect-hardware-host.ts`
    and emits `DPF_HOST_PROFILE` (Apple Silicon reports
-   `architecture: "unified"` for memory).
+   `architecture: "unified"` for memory). Model selection reads the shared
+   `scripts/installer/local-model-policy.json` policy. A 32 GB unified Mac
+   selects the curated `ai/qwen3-coder` tier; fresh installs do not
+   auto-provision mutable third-party model references.
 9. **`.env` generation** — only on first install; existing `.env` is
    preserved.
 10. **Release image availability** (customer mode only) — probes the GHCR

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -1461,48 +1461,29 @@ if (-not (Test-StepDone "hardware")) {
     if ($gpuName) { $hwSummary += ", $gpuName ($gpuVRAM_GB GB VRAM)" }
     Write-OK $hwSummary
 
-    # Select the largest model that fits the GPU's VRAM WITH HEADROOM for the
-    # context window + embedder. Mirrors the canonical headroom-aware logic in
-    # apps/web/lib/inference/local-model-policy.ts (LOCAL_MODEL_TIERS) -- PowerShell
-    # cannot import TS, so keep this in sync. The Providers UX over-commit guard
-    # (same module) catches any drift.
-    #
-    # Thresholds = model weights + ~5 GB headroom (measured: a 30B at a 24k build
-    # context uses ~20.7 GB on a 24 GB card). Pinned quant tags (never bare
-    # :latest) for reproducible sizes.
-    #
-    # A 24 GB card lands on Qwen3.8-27B (17.66 GiB measured + headroom = 23). That
-    # model is DENSE, so it is ~4x slower per turn than the MoE tiers around it --
-    # a deliberate trade for thoroughness over time-to-answer.
-    #
-    # Qwen3.8 is pulled from HuggingFace (hf.co/...), not the curated ai/ namespace,
-    # because ai/qwen3.8 publishes only the 2.4T "Max". docker model pull accepts
-    # both sources; the runtime name it registers under differs (see the sh
-    # installer's normalization note).
-    if ($gpuVRAM_GB -ge 53) {
-        $selectedModel = "ai/qwen3-coder-next"
-        $modelReason = "Qwen3-Coder-Next 80B (MoE) -- top agentic coder, fits your $gpuVRAM_GB GB VRAM with headroom"
-    } elseif ($gpuVRAM_GB -ge 23) {
-        $selectedModel = "hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M"
-        # Known-good content digest for this tier. Mirrors LocalModelTier.expectedDigest
-        # and SELECTION_TIERS in scripts/detect-hardware-host.ts -- keep in sync.
-        $expectedDigest = "sha256:66c4f325bc71350f07fb2da4f92455553c7bbc8af5d7ee2095fbeac79b9e66c9"
-        $modelReason = "Qwen3.8 27B (dense, vision) -- most thorough local model, fits your $gpuVRAM_GB GB VRAM with headroom"
-    } elseif ($gpuVRAM_GB -ge 21) {
-        $selectedModel = "ai/qwen3-coder"
-        $modelReason = "Qwen3-Coder 30B (MoE) -- serves chat + code, fits your $gpuVRAM_GB GB VRAM with headroom"
-    } elseif ($gpuVRAM_GB -ge 17) {
-        $selectedModel = "ai/qwen3:14B-Q6_K"
-        $modelReason = "Qwen3 14B -- top local tool calling (F1 0.97), fits your $gpuVRAM_GB GB VRAM"
-    } elseif ($gpuVRAM_GB -ge 11) {
-        $selectedModel = "ai/qwen3:8B-Q4_K_M"
-        $modelReason = "Qwen3 8B -- matches cloud Haiku tool calling (F1 0.93), fits your $gpuVRAM_GB GB VRAM"
-    } elseif ($gpuVRAM_GB -ge 8) {
-        $selectedModel = "ai/qwen3:4B-UD-Q4_K_XL"
-        $modelReason = "Qwen3 4B -- lightweight, fits your $gpuVRAM_GB GB VRAM"
+    # Select from the same data-only policy used by the web runtime and the
+    # cross-platform host detector. This removes the hand-maintained PowerShell
+    # ladder that previously drifted from the runtime policy.
+    $modelPolicyPath = Join-Path $DPF_DIR "scripts\installer\local-model-policy.json"
+    if (-not (Test-Path -LiteralPath $modelPolicyPath)) {
+        throw "Local model policy missing: $modelPolicyPath"
+    }
+    $modelPolicy = Get-Content -LiteralPath $modelPolicyPath -Raw | ConvertFrom-Json
+    $modelHeadroomGB = [double]$modelPolicy.modelHeadroomGb
+    $selectedTier = $modelPolicy.tiers |
+        Where-Object { ([double]$_.weightsGb + $modelHeadroomGB) -le $gpuVRAM_GB } |
+        Select-Object -First 1
+    if (-not $selectedTier) {
+        $selectedTier = $modelPolicy.tiers | Select-Object -Last 1
+    }
+    if (-not $selectedTier) {
+        throw "Local model policy has no selection tiers: $modelPolicyPath"
+    }
+    $selectedModel = [string]$selectedTier.model
+    if ($gpuVRAM_GB -gt 0) {
+        $modelReason = "$($selectedTier.label) -- fits your $gpuVRAM_GB GB VRAM with $modelHeadroomGB GB headroom"
     } else {
-        $selectedModel = "ai/qwen3:4B-UD-Q4_K_XL"
-        $modelReason = "Qwen3 4B -- lightweight, runs on your hardware (CPU / low VRAM)"
+        $modelReason = "$($selectedTier.label) -- lightweight fallback for CPU or undetected VRAM"
     }
     Write-Action "Selected AI model: $selectedModel ($modelReason)"
     Write-Action "Models are managed by Docker Model Runner (built into Docker Desktop)."
@@ -2118,26 +2099,8 @@ if (-not (Test-StepDone "model")) {
     # references match exactly what the model-runner serves (prevents "model not found"
     # in inference.model-manager even when pull was executed).
     #
-    # HuggingFace sources normalize differently from the ai/ catalog. Verified on-box
-    # 2026-08-16: pulling hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M lists as
-    # huggingface.co/ggml-org/qwen3.8-27b-gguf:Q4_K_M -- host rewritten to its long
-    # form, repo path lowercased, quant tag case PRESERVED. Stripping ai/ alone is a
-    # no-op on those refs, so the post-pull presence check below could never match and
-    # the installer would warn "pull reported success but not listed" on every run.
     $pullName = $selectedModel
-    if ($pullName -match '^(hf\.co|huggingface\.co)/') {
-        if ($pullName -match '^(.*):([^:/]+)$') {
-            $hfPath = $Matches[1]
-            $hfTag  = $Matches[2]
-        } else {
-            $hfPath = $pullName
-            $hfTag  = ''
-        }
-        $hfPath = ($hfPath -replace '^hf\.co/','huggingface.co/').ToLowerInvariant()
-        if ($hfTag) { $runtimeModel = "${hfPath}:${hfTag}" } else { $runtimeModel = $hfPath }
-    } else {
-        $runtimeModel = $pullName -replace '^ai/',''
-    }
+    $runtimeModel = $pullName -replace '^ai/',''
     # Expected size upfront (manifest only) so user with known bandwidth can estimate duration.
     $sizeMB = 0
     try {
@@ -2164,31 +2127,6 @@ if (-not (Test-StepDone "model")) {
     } catch {}
     if ($isPresent) {
         $selectedModel = $runtimeModel
-        # Integrity check: a HuggingFace ref names a FILE, not an immutable
-        # revision, and `docker model pull` takes no flags, so nothing pins bytes
-        # at pull time. Model weights are a control-plane input, so a silent
-        # substitution is a behavioural compromise. DETECTION only -- warn
-        # loudly, never fail the install. (BI-73E9A282.)
-        if ($expectedDigest) {
-            $actualDigest = $null
-            try {
-                $inspected = docker model inspect $runtimeModel 2>$null | ConvertFrom-Json -ErrorAction SilentlyContinue
-                if ($inspected) { $actualDigest = $inspected.id }
-            } catch {}
-            if (-not $actualDigest) {
-                Write-Warn "Could not read the model digest to verify it; continuing."
-            } elseif ($actualDigest -eq $expectedDigest) {
-                Write-OK "Model integrity verified (digest matches the pinned value)"
-            } else {
-                Write-Warn "MODEL DIGEST MISMATCH for $runtimeModel"
-                Write-Warn "  expected: $expectedDigest"
-                Write-Warn "  actual:   $actualDigest"
-                Write-Warn "  The upstream model was republished, or the download differs from"
-                Write-Warn "  what this release pinned. The model still works, but its behaviour"
-                Write-Warn "  is no longer the version this install was tested against. Treat as"
-                Write-Warn "  a security event and re-run the tool evaluation before relying on it."
-            }
-        }
         # Persist the accurate runtime name for compose env + portal-init host_profile
         $selectedModel | Set-Content "$DPF_DIR\.selected-model" -ErrorAction SilentlyContinue
         $hpPath = "$DPF_DIR\.host-profile.json"

--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -556,9 +556,6 @@ fi
 if DPF_HOST_PROFILE_JSON="$(pnpm --filter @dpf/db exec -- tsx "$REPO_ROOT/scripts/detect-hardware-host.ts" 2>/dev/null)"; then
   export DPF_HOST_PROFILE="$DPF_HOST_PROFILE_JSON"
   DPF_SELECTED_MODEL="$(printf '%s' "$DPF_HOST_PROFILE_JSON" | sed -nE 's/.*"selectedModel"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')"
-  # Known-good content digest for the selected model, when the tier pins one.
-  # Empty for curated ai/ tiers (Docker Hub already pins bytes to a tag).
-  DPF_EXPECTED_DIGEST="$(printf '%s' "$DPF_HOST_PROFILE_JSON" | sed -nE 's/.*"expectedDigest"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')"
   if [ -n "$DPF_SELECTED_MODEL" ]; then
     ok "Hardware profile detected — selected AI model (pull form): $DPF_SELECTED_MODEL"
     info "  (Will register under short form for runtime references; normalized after pull.)"
@@ -568,38 +565,6 @@ if DPF_HOST_PROFILE_JSON="$(pnpm --filter @dpf/db exec -- tsx "$REPO_ROOT/script
 else
   warn "Host hardware detection failed (non-fatal); portal-init will skip the profile step."
 fi
-
-# Compare the pulled model's content digest against the tier's pinned value.
-# WHY: a HuggingFace reference names a FILE, not an immutable revision, and
-# `docker model pull` takes no flags, so nothing pins bytes at pull time. Model
-# weights are a control-plane input -- they decide tool-calling behaviour -- so a
-# silent substitution is a behavioural compromise, not just a data one.
-# This is DETECTION, not prevention: warn loudly, never fail the install. A
-# legitimate republish should prompt re-evaluation, not brick a new machine.
-# (BI-73E9A282.)
-verify_model_digest() {
-  _vmd_runtime="$1"
-  _vmd_expected="$2"
-  [ -n "$_vmd_expected" ] || return 0
-  _vmd_actual="$(docker model inspect "$_vmd_runtime" 2>/dev/null \
-    | sed -nE 's/.*"id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -1)"
-  if [ -z "$_vmd_actual" ]; then
-    warn "Could not read the model digest to verify it; continuing."
-    return 0
-  fi
-  if [ "$_vmd_actual" = "$_vmd_expected" ]; then
-    ok "Model integrity verified (digest matches the pinned value)"
-    return 0
-  fi
-  warn "MODEL DIGEST MISMATCH for $_vmd_runtime"
-  warn "  expected: $_vmd_expected"
-  warn "  actual:   $_vmd_actual"
-  warn "  The upstream model was republished, or the download differs from what"
-  warn "  this release pinned. The model still works, but its behaviour is no"
-  warn "  longer the version this install was tested against. Treat this as a"
-  warn "  security event and re-run the tool evaluation before relying on it."
-  return 0
-}
 
 # 8b. Set up Docker Model Runner and pull the selected chat model.
 #     Mirrors install-dpf.ps1 §Step 7 (lines 1895-1985). Docker Model
@@ -652,35 +617,11 @@ if [ "$DPF_PLATFORM" = "darwin" ] && command -v docker >/dev/null 2>&1; then
       # calls use the exact string the model-runner knows. This prevents the
       # "failed to get model: model not found" seen in inference.model-manager
       # logs even when the pull command itself was issued.
-      #
-      # HuggingFace sources normalize differently from the `ai/` catalog. Verified
-      # on-box 2026-08-16: pulling `hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M` lists as
-      # `huggingface.co/ggml-org/qwen3.8-27b-gguf:Q4_K_M` — the host is rewritten to
-      # its long form, the repo path is lowercased, and the quant tag KEEPS its case.
-      # Stripping `ai/` alone leaves the pull form unchanged for these, so the
-      # already-on-disk check never matches and the model re-downloads every run.
       _pull_name="$DPF_SELECTED_MODEL"
-      case "$_pull_name" in
-        hf.co/*|huggingface.co/*)
-          case "$_pull_name" in
-            *:*) _hf_tag="${_pull_name##*:}"; _hf_path="${_pull_name%:*}" ;;
-            *)   _hf_tag=""; _hf_path="$_pull_name" ;;
-          esac
-          _hf_path="$(printf '%s' "$_hf_path" | sed 's|^hf\.co/|huggingface.co/|' | tr '[:upper:]' '[:lower:]')"
-          if [ -n "$_hf_tag" ]; then
-            _runtime_model="${_hf_path}:${_hf_tag}"
-          else
-            _runtime_model="$_hf_path"
-          fi
-          ;;
-        *)
-          _runtime_model="$(printf '%s' "$_pull_name" | sed 's|^ai/||')"
-          ;;
-      esac
+      _runtime_model="$(printf '%s' "$_pull_name" | sed 's|^ai/||')"
       if docker model list 2>/dev/null | awk 'NR>1{print $1}' | grep -Fxq "$_runtime_model"; then
         ok "Model $_runtime_model already on disk"
         DPF_SELECTED_MODEL="$_runtime_model"
-        verify_model_digest "$_runtime_model" "${DPF_EXPECTED_DIGEST:-}"
       else
         # Print expected size upfront (user request for time estimation given
         # internet speed). Uses cheap manifest inspect (no blob download).
@@ -712,7 +653,6 @@ except Exception:
         if docker model list 2>/dev/null | awk 'NR>1{print $1}' | grep -Fxq "$_runtime_model"; then
           ok "AI Coworker model ready: $_runtime_model"
           DPF_SELECTED_MODEL="$_runtime_model"
-          verify_model_digest "$_runtime_model" "${DPF_EXPECTED_DIGEST:-}"
         else
           warn "Model pull may have failed. You can retry later: docker model pull $_pull_name"
         fi

--- a/scripts/check-release-asset-contract.test.mjs
+++ b/scripts/check-release-asset-contract.test.mjs
@@ -45,6 +45,7 @@ const REQUIRED_IN_BUNDLE = Object.freeze([
   "scripts/installer/lib/state.ps1",
   "scripts/installer/lib/compose-chain.ps1",
   "scripts/installer/install-release-assets.mjs",
+  "scripts/installer/local-model-policy.json",
   "scripts/bootstrap-organization-pki.ps1",
   // The install guides tell operators to run these by name, so a consumer install
   // that lacks them fails the documented uninstall with "file not found" — the

--- a/scripts/detect-hardware-host.ts
+++ b/scripts/detect-hardware-host.ts
@@ -35,8 +35,6 @@ type HostProfile = {
   ram: { totalGB: number };
   gpu: { name: string; vramGB: number | null } | null;
   selectedModel: string;
-  /** Known-good digest for selectedModel, when it is pinned. Null otherwise. */
-  expectedDigest: string | null;
   detectedAt: string;
   notes?: string[];
 };
@@ -168,12 +166,9 @@ function detectLinux(): HostProfile {
   };
 }
 
-// Model selection MIRRORS the canonical headroom-aware logic in
-// apps/web/lib/inference/local-model-policy.ts (LOCAL_MODEL_TIERS +
-// recommendGenerationModelForHost). This script runs via tsx in the @dpf/db
-// context and cannot import the apps/web module, so the tiers + constants are
-// duplicated here — KEEP IN SYNC. The Providers UX over-commit guard (same
-// module) catches any drift.
+// Model selection reads the same data-only policy as the web runtime and the
+// PowerShell installer. Keeping the policy free of runtime imports lets every
+// install surface share the ordered tiers without a generated mirror.
 //
 // Qwen3 — NOT Gemma — the platform tiers Qwen3 as `strong + Tool Use` while
 // Gemma tiers as `adequate`, and default coworkers require `minimumTier:
@@ -185,62 +180,46 @@ function detectLinux(): HostProfile {
 // (unified Apple Silicon shares it with the OS; CPU-only leaves even more aside).
 // Headroom reserves room for the context window + embedder so a recommended
 // model never fills the whole card and then over-commit the moment it runs.
-//   24 GB discrete  → Qwen3.8-27B (dense)          128 GB unified → ai/qwen3-coder-next (80B MoE)
-//   12 GB discrete  → ai/qwen3:8B                  32 GB unified → Qwen3.8-27B (dense)
+//   24 GB discrete  → ai/qwen3-coder               128 GB unified → ai/qwen3-coder-next (80B MoE)
+//   12 GB discrete  → ai/qwen3:8B                  32 GB unified → ai/qwen3-coder
 //    8 GB discrete  → ai/qwen3:4B                  16 GB unified → ai/qwen3:8B
-//
-// Qwen3.8-27B is DENSE, so it is markedly slower per turn than the MoE tiers it
-// sits between (~4x measured against the 30B-A3B coder). Selected anyway: the
-// operator criterion for the local tier is thoroughness over time-to-answer.
 // Tags for the ai/ Docker Model Runner namespace are case-sensitive.
-const MODEL_HEADROOM_GB = 5;            // context KV + embedder + overhead (measured on RTX 4090)
-const UNIFIED_USABLE_FRACTION = 0.75;   // Apple Silicon GPU share of unified RAM
-const CPU_USABLE_FRACTION = 0.5;
-// `expectedDigest` mirrors LocalModelTier.expectedDigest: set for any tier
-// sourced outside the curated `ai/` namespace, where the upstream reference is
-// mutable and `docker model pull` offers no revision pin (BI-73E9A282).
-const SELECTION_TIERS: { model: string; weightsGb: number; expectedDigest?: string }[] = [
-  { model: "ai/qwen3-coder-next", weightsGb: 48 },          // big unified (Apple 128 GB) / 64 GB+ discrete
-  {
-    model: "hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M",
-    weightsGb: 18,                                          // dense 27B; replaces the 35B-A3B tier
-    expectedDigest: "sha256:66c4f325bc71350f07fb2da4f92455553c7bbc8af5d7ee2095fbeac79b9e66c9",
-  },
-  { model: "ai/qwen3-coder", weightsGb: 16 },               // 24 GB-card sweet spot (measured ~20.7 GB @ 24k ctx)
-  { model: "ai/qwen3:14B-Q6_K", weightsGb: 12 },
-  { model: "ai/qwen3:8B-Q4_K_M", weightsGb: 6 },
-  { model: "ai/qwen3:4B-UD-Q4_K_XL", weightsGb: 3 },
-];
+const modelPolicy = JSON.parse(
+  fs.readFileSync(new URL("./installer/local-model-policy.json", import.meta.url), "utf8"),
+) as {
+  modelHeadroomGb: number;
+  unifiedUsableFraction: number;
+  cpuUsableFraction: number;
+  tiers: Array<{ model: string; weightsGb: number }>;
+};
 
-/** Spread-able { selectedModel, expectedDigest } so a profile picks once. */
 function selectedFields(p: {
   architecture: Architecture;
   totalGB: number;
   gpu: HostProfile["gpu"];
-}): { selectedModel: string; expectedDigest: string | null } {
-  const picked = selectModel(p);
-  return { selectedModel: picked.model, expectedDigest: picked.expectedDigest };
+}): { selectedModel: string } {
+  return { selectedModel: selectModel(p) };
 }
 
 function selectModel(p: {
   architecture: Architecture;
   totalGB: number;
   gpu: HostProfile["gpu"];
-}): { model: string; expectedDigest: string | null } {
+}): string {
   let budgetGb: number;
   if (p.architecture === "discrete" && p.gpu && typeof p.gpu.vramGB === "number") {
     budgetGb = p.gpu.vramGB;
   } else if (p.architecture === "unified") {
-    budgetGb = p.totalGB * UNIFIED_USABLE_FRACTION;
+    budgetGb = p.totalGB * modelPolicy.unifiedUsableFraction;
   } else {
-    budgetGb = p.totalGB * CPU_USABLE_FRACTION;
+    budgetGb = p.totalGB * modelPolicy.cpuUsableFraction;
   }
-  for (const tier of SELECTION_TIERS) {
-    if (tier.weightsGb + MODEL_HEADROOM_GB <= budgetGb) {
-      return { model: tier.model, expectedDigest: tier.expectedDigest ?? null };
+  for (const tier of modelPolicy.tiers) {
+    if (tier.weightsGb + modelPolicy.modelHeadroomGb <= budgetGb) {
+      return tier.model;
     }
   }
-  return { model: "ai/qwen3:4B-UD-Q4_K_XL", expectedDigest: null };
+  return modelPolicy.tiers.at(-1)?.model ?? "ai/qwen3:4B-UD-Q4_K_XL";
 }
 
 function main(): void {

--- a/scripts/installer/local-model-policy-contract.test.mjs
+++ b/scripts/installer/local-model-policy-contract.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const repoRoot = new URL("../../", import.meta.url);
+
+function read(path) {
+  return readFileSync(new URL(path, repoRoot), "utf8");
+}
+
+test("fresh-install model tiers come from one curated policy", () => {
+  const policy = JSON.parse(read("scripts/installer/local-model-policy.json"));
+
+  assert.equal(policy.modelHeadroomGb, 5);
+  assert.ok(policy.tiers.length >= 4);
+  assert.ok(policy.tiers.every((tier) => tier.model.startsWith("ai/")));
+  assert.deepEqual(
+    policy.tiers.map((tier) => tier.weightsGb),
+    [...policy.tiers].map((tier) => tier.weightsGb).sort((a, b) => b - a),
+  );
+  assert.equal(policy.tiers.find((tier) => tier.model === "ai/qwen3-coder")?.weightsGb, 16);
+});
+
+test("the web policy, host detector, and Windows installer consume the canonical policy", () => {
+  const webPolicy = read("apps/web/lib/inference/local-model-policy.ts");
+  const hostDetector = read("scripts/detect-hardware-host.ts");
+  const windowsInstaller = read("install-dpf.ps1");
+
+  assert.match(webPolicy, /local-model-policy\.json/);
+  assert.match(hostDetector, /local-model-policy\.json/);
+  assert.match(windowsInstaller, /local-model-policy\.json/);
+
+  for (const source of [webPolicy, hostDetector, windowsInstaller]) {
+    assert.doesNotMatch(source, /hf\.co\/ggml-org\/Qwen3\.8-27B/);
+    assert.doesNotMatch(source, /sha256:66c4f325/);
+  }
+});
+
+test("the default install policy cannot reintroduce mutable third-party model references", () => {
+  const policy = JSON.parse(read("scripts/installer/local-model-policy.json"));
+  const external = policy.tiers.filter((tier) => !tier.model.startsWith("ai/"));
+
+  assert.deepEqual(external, []);
+});

--- a/scripts/installer/local-model-policy.json
+++ b/scripts/installer/local-model-policy.json
@@ -1,0 +1,32 @@
+{
+  "modelHeadroomGb": 5,
+  "unifiedUsableFraction": 0.75,
+  "cpuUsableFraction": 0.5,
+  "tiers": [
+    {
+      "model": "ai/qwen3-coder-next",
+      "weightsGb": 48,
+      "label": "Qwen3-Coder-Next 80B (MoE, 3B active)"
+    },
+    {
+      "model": "ai/qwen3-coder",
+      "weightsGb": 16,
+      "label": "Qwen3-Coder 30B (MoE, 3B active)"
+    },
+    {
+      "model": "ai/qwen3:14B-Q6_K",
+      "weightsGb": 12,
+      "label": "Qwen3 14B"
+    },
+    {
+      "model": "ai/qwen3:8B-Q4_K_M",
+      "weightsGb": 6,
+      "label": "Qwen3 8B"
+    },
+    {
+      "model": "ai/qwen3:4B-UD-Q4_K_XL",
+      "weightsGb": 3,
+      "label": "Qwen3 4B"
+    }
+  ]
+}

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -57,7 +57,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("release-asset-contract", "Release Asset Contract", [
       // The consumer install has no git checkout: whatever the installer copies
       // out of the install dir must ship in the image's /dpf-release-assets.
-      node("--test", "scripts/check-release-asset-contract.test.mjs"),
+      node(
+        "--test",
+        "scripts/check-release-asset-contract.test.mjs",
+        "scripts/installer/local-model-policy-contract.test.mjs",
+      ),
     ]),
     guard("db-commandment-coverage", "DB Commandment Coverage", [
       // The never-wipe-db commandment guarded two spellings and allowed three


### PR DESCRIPTION
Fresh installs had two coupled model-policy failures. A 24 GB or 32 GB host could select the dense Hugging Face Qwen3.8 model ahead of the coder model, and a changed upstream digest only produced a warning before installation continued. The same policy was duplicated across TypeScript and PowerShell, which let the choices drift.

This PR makes `scripts/installer/local-model-policy.json` the installer policy:

- 24 GB and 32 GB unified-memory hosts now select `ai/qwen3-coder` from the curated Docker Model Runner catalog.
- Automatic provisioning no longer depends on mutable Hugging Face digests. Qwen3.8 remains available for explicit selection, but it is not a fresh-install default.
- The web inference helper, hardware detector, and PowerShell installer read the same ordered tier list and memory rules.
- The Docker build and no-checkout release bundle both carry the policy file. Contract tests fail if packaging or a consumer drifts.
- Linux and macOS install docs name the shared policy and the 24 GB/32 GB default.

The refactor removes 316 lines of duplicate tier and digest logic while adding 160 lines, including the policy and its contract test.

## Verification

- `pregate` passed for `cc897739913f` against current `origin/main`; 2,908 test files and 24,875 tests passed, followed by a production Docker image build.
- `pregate:preflight` passed all 52 guards.
- 62 local-model policy tests passed.
- 11 installer/release-asset contracts passed.
- 5 Docker build-context and source-closure guards passed.
- Web typecheck, PowerShell parser validation, `bash -n install-dpf.sh`, style-drift, module-size, docs-impact, and CI inventory checks passed.
- Independent semantic review returned no findings; the reviewer service was infrastructure-inconclusive on the final immutable tree, and its shadow policy allowed publication.

Migration: none. No schema or stored data changes.

UX: not applicable. This changes fresh-install policy and packaging, not an application surface.

Refs: BI-7A64788A, BI-957122B4

Local-CI-Evidence: cmt6oxy9t07wi01mx0yscjxwz (fix/drain-unassigned-pre-reinstall-backlog@cc897739913f)
