### PR TITLE
fix(governance): enable external initiative review

### DIFF
--- a/apps/web/lib/mcp-task-submit.test.ts
+++ b/apps/web/lib/mcp-task-submit.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const db = vi.hoisted(() => ({
@@ -70,7 +71,13 @@ describe("submitRemoteCoworkerTask idempotency", () => {
 
     expect(outcome).toMatchObject({ kind: "result", result: { idempotentReplay: false } });
     const createInput = autonomous.create.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(createInput["taskRunId"]).toMatch(/^TR-MCP-[A-F0-9]{12}$/);
+    expect(createInput["taskRunId"]).toMatch(/^TR-MCP-[A-Za-z0-9_-]+-[A-F0-9]{12}$/);
+    const insecureUnkeyedId = `TR-MCP-${createHash("sha256")
+      .update(`PAT-A\0${immutableParams.idempotencyKey}`)
+      .digest("hex")
+      .slice(0, 12)
+      .toUpperCase()}`;
+    expect(createInput["taskRunId"]).not.toBe(insecureUnkeyedId);
     expect(createInput).toMatchObject({
       agentId: "AGT-WS-REVIEW",
       sourceRef: { kind: "mcp-token", id: "PAT-A" },

--- a/apps/web/lib/mcp-task-submit.test.ts
+++ b/apps/web/lib/mcp-task-submit.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  update: vi.fn(),
+  upsertThread: vi.fn(),
+}));
+const autonomous = vi.hoisted(() => ({
+  create: vi.fn(),
+  execute: vi.fn(),
+  resolveAgent: vi.fn(),
+  resolveTools: vi.fn(),
+}));
+const records = vi.hoisted(() => ({ create: vi.fn() }));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    taskRun: { findFirst: (...args: unknown[]) => db.findFirst(...args), update: (...args: unknown[]) => db.update(...args) },
+    agentThread: { upsert: (...args: unknown[]) => db.upsertThread(...args) },
+  },
+}));
+vi.mock("@/lib/tak/autonomous-work-run", () => ({
+  createAutonomousWorkRun: (...args: unknown[]) => autonomous.create(...args),
+  executeAutonomousAgenticLoop: (...args: unknown[]) => autonomous.execute(...args),
+  resolveAutonomousWorkAgent: (...args: unknown[]) => autonomous.resolveAgent(...args),
+  resolveAutonomousWorkTools: (...args: unknown[]) => autonomous.resolveTools(...args),
+}));
+vi.mock("@/lib/tak/task-records", () => ({
+  createTaskMessage: (...args: unknown[]) => records.create(...args),
+}));
+
+import { submitRemoteCoworkerTask } from "./mcp-task-submit";
+
+const userContext = { platformRole: "developer", isSuperuser: false };
+const immutableParams = {
+  agentId: "AGT-WS-REVIEW",
+  routeContext: "/platform/build",
+  title: "Independent design review",
+  objective: "Review BI-B131F357 at immutable commit 544830a.",
+  prompt: "Review BI-B131F357 at immutable commit 544830a.",
+  idempotencyKey: "initiative-review:BI-B131F357:544830a",
+  riskClass: "high-risk",
+  authorityScope: ["initiative_design_review"],
+  collaborationKind: "summon",
+};
+
+function submit(tokenId: string, params: Record<string, unknown> = immutableParams) {
+  return submitRemoteCoworkerTask({
+    token: { tokenId, userId: "user-1", capability: "write", source: "pat" },
+    userContext,
+    params,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.findFirst.mockResolvedValue(null);
+  db.upsertThread.mockResolvedValue({ id: "thread-external" });
+  db.update.mockResolvedValue({});
+  autonomous.create.mockImplementation(async (input: Record<string, unknown>) => ({
+    id: "task-internal",
+    taskRunId: input["taskRunId"],
+    contextId: "thread-external",
+  }));
+});
+
+describe("submitRemoteCoworkerTask idempotency", () => {
+  it("binds a deterministic TaskRun and immutable digest to token + requestKey", async () => {
+    const outcome = await submit("PAT-A");
+
+    expect(outcome).toMatchObject({ kind: "result", result: { idempotentReplay: false } });
+    const createInput = autonomous.create.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(createInput["taskRunId"]).toMatch(/^TR-MCP-[A-F0-9]{12}$/);
+    expect(createInput).toMatchObject({
+      agentId: "AGT-WS-REVIEW",
+      sourceRef: { kind: "mcp-token", id: "PAT-A" },
+      metadata: {
+        idempotencyKey: "initiative-review:BI-B131F357:544830a",
+        collaborationKind: "summon",
+        apiTokenId: "PAT-A",
+        requestDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+      },
+    });
+    expect(db.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        userId: "user-1",
+        AND: expect.arrayContaining([
+          { a2aMetadata: { path: ["apiTokenId"], equals: "PAT-A" } },
+        ]),
+      }),
+    }));
+  });
+
+  it("replays only the same immutable request", async () => {
+    await submit("PAT-A");
+    const metadata = (autonomous.create.mock.calls[0]?.[0] as { metadata: Record<string, unknown> }).metadata;
+    vi.clearAllMocks();
+    db.findFirst.mockResolvedValue({
+      taskRunId: "TR-MCP-EXISTING",
+      status: "completed",
+      progressPayload: { summary: "approved" },
+      a2aMetadata: metadata,
+    });
+
+    const outcome = await submit("PAT-A");
+
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: { taskRunId: "TR-MCP-EXISTING", idempotentReplay: true },
+    });
+    expect(autonomous.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects reuse of a request key with a changed immutable packet", async () => {
+    db.findFirst.mockResolvedValue({
+      taskRunId: "TR-MCP-EXISTING",
+      status: "completed",
+      progressPayload: null,
+      a2aMetadata: { ...immutableParams, apiTokenId: "PAT-A", requestDigest: "0".repeat(64) },
+    });
+
+    const outcome = await submit("PAT-A");
+
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: {
+        isError: true,
+        structuredContent: { error: "idempotency_conflict", taskRunId: "TR-MCP-EXISTING" },
+      },
+    });
+    expect(autonomous.create).not.toHaveBeenCalled();
+  });
+
+  it("does not share task identity across tokens with the same request key", async () => {
+    await submit("PAT-A");
+    await submit("PAT-B");
+
+    const firstId = (autonomous.create.mock.calls[0]?.[0] as Record<string, unknown>)["taskRunId"];
+    const secondId = (autonomous.create.mock.calls[1]?.[0] as Record<string, unknown>)["taskRunId"];
+    expect(firstId).not.toBe(secondId);
+  });
+
+  it("converts a concurrent deterministic-id collision into a replay", async () => {
+    autonomous.create.mockRejectedValueOnce({ code: "P2002" });
+    db.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        taskRunId: "TR-MCP-CONCURRENT",
+        status: "working",
+        progressPayload: null,
+        // Rows from before request digests were introduced remain replayable,
+        // but the lookup is still scoped to this exact PAT.
+        a2aMetadata: { idempotencyKey: immutableParams.idempotencyKey, apiTokenId: "PAT-A" },
+      });
+
+    const outcome = await submit("PAT-A");
+
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: { taskRunId: "TR-MCP-CONCURRENT", idempotentReplay: true },
+    });
+    expect(db.findFirst).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -1,4 +1,6 @@
 import { prisma } from "@dpf/db";
+import type { Prisma } from "@dpf/db";
+import { createHash } from "crypto";
 import type { UserContext } from "@/lib/permissions";
 import {
   createAutonomousWorkRun,
@@ -21,6 +23,7 @@ export type RemoteTaskSubmitParams = {
   riskClass: RemoteRiskClass;
   threadId?: string | null;
   authorityScope?: string[];
+  collaborationKind?: "handoff" | "summon";
 };
 
 export type RemoteTaskSubmitAuth = {
@@ -74,6 +77,63 @@ export function parseRemoteTaskSubmitParams(params: Record<string, unknown> | un
     riskClass: riskClass as RemoteRiskClass,
     threadId: optionalString(params["threadId"]),
     authorityScope,
+    collaborationKind: params["collaborationKind"] === "handoff" || params["collaborationKind"] === "summon"
+      ? params["collaborationKind"]
+      : undefined,
+  };
+}
+
+function stableDigest(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function deterministicExternalTaskRunId(tokenId: string, idempotencyKey: string): string {
+  const suffix = createHash("sha256")
+    .update(`${tokenId}\0${idempotencyKey}`)
+    .digest("hex")
+    .slice(0, 12)
+    .toUpperCase();
+  return `TR-MCP-${suffix}`;
+}
+
+type ExistingRemoteTask = {
+  taskRunId: string;
+  status: string;
+  progressPayload: unknown;
+  a2aMetadata: unknown;
+};
+
+function replayOrConflict(existing: ExistingRemoteTask, requestDigest: string): RemoteTaskSubmitOutcome {
+  const metadata = existing.a2aMetadata && typeof existing.a2aMetadata === "object"
+    ? existing.a2aMetadata as Record<string, unknown>
+    : {};
+  const storedDigest = optionalString(metadata["requestDigest"]);
+  if (storedDigest && storedDigest !== requestDigest) {
+    return {
+      kind: "result",
+      result: {
+        content: remoteTaskContent(
+          "This requestKey is already bound to a different external coworker request. Retry with the original immutable packet or use a new requestKey.",
+        ),
+        structuredContent: {
+          error: "idempotency_conflict",
+          action: "Retry with the original immutable packet or use a new requestKey.",
+          taskRunId: existing.taskRunId,
+        },
+        isError: true,
+      },
+    };
+  }
+  return {
+    kind: "result",
+    result: {
+      taskRunId: existing.taskRunId,
+      status: existing.status,
+      idempotentReplay: true,
+      requiresApproval: existing.status === "input-required",
+      progressPayload: existing.progressPayload,
+      a2aMetadata: existing.a2aMetadata,
+    },
   };
 }
 
@@ -107,13 +167,25 @@ export async function submitRemoteCoworkerTask(input: {
     };
   }
 
-  const existing = await prisma.taskRun.findFirst({
+  const requestDigest = stableDigest({
+    tokenId: token.tokenId,
+    agentId: parsed.agentId,
+    routeContext: parsed.routeContext,
+    title: parsed.title,
+    objective: parsed.objective,
+    prompt: parsed.prompt,
+    riskClass: parsed.riskClass,
+    authorityScope: [...(parsed.authorityScope ?? [])].sort(),
+    collaborationKind: parsed.collaborationKind ?? null,
+  });
+  const taskRunId = deterministicExternalTaskRunId(token.tokenId, parsed.idempotencyKey);
+  const existingQuery: Prisma.TaskRunFindFirstArgs = {
     where: {
       userId: token.userId,
-      a2aMetadata: {
-        path: ["idempotencyKey"],
-        equals: parsed.idempotencyKey,
-      },
+      AND: [
+        { a2aMetadata: { path: ["idempotencyKey"], equals: parsed.idempotencyKey } },
+        { a2aMetadata: { path: ["apiTokenId"], equals: token.tokenId } },
+      ],
     },
     orderBy: [{ createdAt: "desc" }],
     select: {
@@ -122,20 +194,11 @@ export async function submitRemoteCoworkerTask(input: {
       progressPayload: true,
       a2aMetadata: true,
     },
-  });
+  };
+  const existing = await prisma.taskRun.findFirst(existingQuery);
 
   if (existing) {
-    return {
-      kind: "result",
-      result: {
-        taskRunId: existing.taskRunId,
-        status: existing.status,
-        idempotentReplay: true,
-        requiresApproval: existing.status === "input-required",
-        progressPayload: existing.progressPayload,
-        a2aMetadata: existing.a2aMetadata,
-      },
-    };
+    return replayOrConflict(existing, requestDigest);
   }
 
   const contextKey = parsed.threadId ?? `mcp:${token.tokenId}:${parsed.idempotencyKey}`;
@@ -147,25 +210,37 @@ export async function submitRemoteCoworkerTask(input: {
   });
 
   const sourceKind = token.source === "session-jwt" ? "mcp-session" : "mcp-token";
-  const run = await createAutonomousWorkRun({
-    trigger: "external-mcp",
-    userId: token.userId,
-    agentId: parsed.agentId,
-    routeContext: parsed.routeContext,
-    title: parsed.title,
-    objective: parsed.objective,
-    prompt: parsed.prompt,
-    threadId: thread.id,
-    authorityScope: parsed.authorityScope ?? [],
-    sourceRef: { kind: sourceKind, id: token.tokenId },
-    metadata: {
-      idempotencyKey: parsed.idempotencyKey,
-      riskClass: parsed.riskClass,
-      apiTokenId: token.tokenId,
-      tokenSource: token.source,
-      requestedThreadId: parsed.threadId ?? null,
-    },
-  });
+  let run: Awaited<ReturnType<typeof createAutonomousWorkRun>>;
+  try {
+    run = await createAutonomousWorkRun({
+      trigger: "external-mcp",
+      taskRunId,
+      userId: token.userId,
+      agentId: parsed.agentId,
+      routeContext: parsed.routeContext,
+      title: parsed.title,
+      objective: parsed.objective,
+      prompt: parsed.prompt,
+      threadId: thread.id,
+      authorityScope: parsed.authorityScope ?? [],
+      sourceRef: { kind: sourceKind, id: token.tokenId },
+      metadata: {
+        idempotencyKey: parsed.idempotencyKey,
+        requestDigest,
+        collaborationKind: parsed.collaborationKind ?? null,
+        riskClass: parsed.riskClass,
+        apiTokenId: token.tokenId,
+        tokenSource: token.source,
+        requestedThreadId: parsed.threadId ?? null,
+      },
+    });
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "P2002") {
+      const concurrent = await prisma.taskRun.findFirst(existingQuery);
+      if (concurrent) return replayOrConflict(concurrent, requestDigest);
+    }
+    throw error;
+  }
 
   await createTaskMessage({
     taskRunId: run.taskRunId,

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -88,12 +88,18 @@ function stableDigest(value: unknown): string {
 }
 
 function deterministicExternalTaskRunId(tokenId: string, idempotencyKey: string): string {
+  // `tokenId` is the server-owned McpApiToken row id, not the bearer secret.
+  // Keep it out of a password-shaped fast hash: CodeQL correctly cannot infer
+  // that distinction across the auth boundary. The reversible base64url
+  // namespace preserves per-token isolation while only the caller-controlled,
+  // non-secret request key is digested to keep the public id bounded.
+  const tokenNamespace = Buffer.from(tokenId, "utf8").toString("base64url");
   const suffix = createHash("sha256")
-    .update(`${tokenId}\0${idempotencyKey}`)
+    .update(idempotencyKey)
     .digest("hex")
     .slice(0, 12)
     .toUpperCase();
-  return `TR-MCP-${suffix}`;
+  return `TR-MCP-${tokenNamespace}-${suffix}`;
 }
 
 type ExistingRemoteTask = {
@@ -168,7 +174,6 @@ export async function submitRemoteCoworkerTask(input: {
   }
 
   const requestDigest = stableDigest({
-    tokenId: token.tokenId,
     agentId: parsed.agentId,
     routeContext: parsed.routeContext,
     title: parsed.title,

--- a/apps/web/lib/mcp/external-coworker-task-adapter.test.ts
+++ b/apps/web/lib/mcp/external-coworker-task-adapter.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const remote = vi.hoisted(() => ({ submit: vi.fn() }));
+vi.mock("@/lib/mcp-task-submit", () => ({
+  submitRemoteCoworkerTask: (...args: unknown[]) => remote.submit(...args),
+}));
+
+import { dispatchExternalCoworkerTask } from "./external-coworker-task-adapter";
+
+const verifiedContext = {
+  apiTokenId: "PAT-1",
+  authSource: "pat",
+  tokenScope: "write" as const,
+  tokenGrantScopes: ["initiative_design_review"],
+  callerClient: "claude-code/2.1",
+  routeContext: "/platform/build",
+  userContext: { platformRole: "developer", isSuperuser: false },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("dispatchExternalCoworkerTask", () => {
+  it("fails closed with a reachable action when verified PAT context is absent", async () => {
+    const result = await dispatchExternalCoworkerTask({
+      collaborationKind: "handoff",
+      targetAgent: "AGT-WS-REVIEW",
+      objective: "Review immutable design.",
+      requestKey: "review:one",
+      userId: "user-1",
+      context: { callerClient: "codex-cli/0.9" },
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "external_handoff_context_required",
+      data: { action: expect.stringContaining("write-capable personal access token") },
+    });
+    expect(remote.submit).not.toHaveBeenCalled();
+  });
+
+  it("requires a stable request key for a verified external caller", async () => {
+    const result = await dispatchExternalCoworkerTask({
+      collaborationKind: "summon",
+      targetAgent: "AGT-WS-REVIEW",
+      objective: "Review immutable design.",
+      userId: "user-1",
+      context: verifiedContext,
+    });
+
+    expect(result).toMatchObject({ success: false, error: "missing_requestKey" });
+    expect(remote.submit).not.toHaveBeenCalled();
+  });
+
+  it("preserves the exact reviewer packet and verified token authority", async () => {
+    remote.submit.mockResolvedValue({
+      kind: "result",
+      result: { taskRunId: "TR-MCP-123", status: "completed", isError: false },
+    });
+    const objective =
+      "Subject BI-B131F357; immutable commit 544830a220adbda0570da17e391dabd0d429b1fc; design docs/superpowers/specs/recovery.md.";
+
+    const result = await dispatchExternalCoworkerTask({
+      collaborationKind: "summon",
+      targetAgent: "AGT-WS-REVIEW",
+      objective,
+      requestKey: "initiative-review:BI-B131F357:544830a",
+      title: "Independent initiative design review",
+      userId: "user-1",
+      context: verifiedContext,
+    });
+
+    expect(result).toMatchObject({ success: true, entityId: "TR-MCP-123" });
+    expect(remote.submit).toHaveBeenCalledWith({
+      token: { tokenId: "PAT-1", userId: "user-1", capability: "write", source: "pat" },
+      userContext: verifiedContext.userContext,
+      params: {
+        agentId: "AGT-WS-REVIEW",
+        routeContext: "/platform/build",
+        title: "Independent initiative design review",
+        objective,
+        prompt: objective,
+        idempotencyKey: "initiative-review:BI-B131F357:544830a",
+        riskClass: "bounded-write",
+        authorityScope: ["initiative_design_review"],
+        collaborationKind: "summon",
+      },
+    });
+  });
+
+  it("preserves structured governance refusals from the task owner", async () => {
+    remote.submit.mockResolvedValue({
+      kind: "result",
+      result: {
+        isError: true,
+        content: [{ type: "text", text: "Issue a write MCP token, then retry." }],
+        structuredContent: { error: "insufficient_token_scope", action: "Issue a write MCP token." },
+      },
+    });
+
+    const result = await dispatchExternalCoworkerTask({
+      collaborationKind: "handoff",
+      targetAgent: "AGT-WS-REVIEW",
+      objective: "Review immutable design.",
+      requestKey: "review:read-token",
+      userId: "user-1",
+      context: { ...verifiedContext, tokenScope: "read" },
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "insufficient_token_scope",
+      message: "Issue a write MCP token, then retry.",
+    });
+  });
+
+  it("turns task-owner transport failures into an actionable typed refusal", async () => {
+    remote.submit.mockRejectedValue(new Error("task service unavailable"));
+
+    const result = await dispatchExternalCoworkerTask({
+      collaborationKind: "handoff",
+      targetAgent: "AGT-WS-REVIEW",
+      objective: "Review immutable design.",
+      requestKey: "review:retryable",
+      userId: "user-1",
+      context: verifiedContext,
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "remote_handoff_failed",
+      message: "task service unavailable",
+      data: { action: expect.stringContaining("Retry the same immutable packet") },
+    });
+  });
+});

--- a/apps/web/lib/mcp/external-coworker-task-adapter.ts
+++ b/apps/web/lib/mcp/external-coworker-task-adapter.ts
@@ -1,0 +1,123 @@
+import type { UserContext } from "@/lib/permissions";
+import type { ToolExecutionContext, ToolResult } from "@/lib/mcp-tools";
+import { submitRemoteCoworkerTask } from "@/lib/mcp-task-submit";
+
+export type ExternalCoworkerTaskInput = {
+  collaborationKind: "handoff" | "summon";
+  targetAgent: string;
+  objective: string;
+  requestKey?: string;
+  title?: string;
+  userId: string;
+  context?: ToolExecutionContext;
+};
+
+const RECONNECT_ACTION =
+  "Reconnect through the DPF MCP endpoint with a write-capable personal access token, then retry with requestKey.";
+
+function verifiedPatContext(context: ToolExecutionContext | undefined): {
+  tokenId: string;
+  capability: "read" | "write";
+  userContext: UserContext;
+} | null {
+  if (
+    context?.authSource !== "pat"
+    || typeof context.apiTokenId !== "string"
+    || context.apiTokenId.trim().length === 0
+    || !context.userContext
+  ) {
+    return null;
+  }
+  return {
+    tokenId: context.apiTokenId,
+    capability: context.tokenScope === "write" || context.tokenScope === "admin" ? "write" : "read",
+    userContext: context.userContext,
+  };
+}
+
+/**
+ * Bridges threadless, PAT-authenticated collaboration calls onto the existing
+ * governed autonomous-task owner. The caller never supplies a portal thread or
+ * a reviewer principal: the token and target coworker remain server-owned.
+ */
+export async function dispatchExternalCoworkerTask(input: ExternalCoworkerTaskInput): Promise<ToolResult> {
+  const verified = verifiedPatContext(input.context);
+  if (!verified) {
+    return {
+      success: false,
+      error: "external_handoff_context_required",
+      message: `External coworker handoff requires verified PAT context. ${RECONNECT_ACTION}`,
+      data: { action: RECONNECT_ACTION },
+    };
+  }
+
+  const requestKey = input.requestKey?.trim();
+  if (!requestKey) {
+    return {
+      success: false,
+      error: "missing_requestKey",
+      message: "External coworker handoff requires requestKey so retries are token-bound and idempotent.",
+      data: { action: "Retry with a stable requestKey for this immutable review request." },
+    };
+  }
+
+  let outcome: Awaited<ReturnType<typeof submitRemoteCoworkerTask>>;
+  try {
+    outcome = await submitRemoteCoworkerTask({
+      token: {
+        tokenId: verified.tokenId,
+        userId: input.userId,
+        capability: verified.capability,
+        source: "pat",
+      },
+      userContext: verified.userContext,
+      params: {
+        agentId: input.targetAgent,
+        routeContext: input.context?.routeContext ?? "/build",
+        title: input.title?.trim() || `${input.collaborationKind === "summon" ? "Summon" : "Request"} ${input.targetAgent}`,
+        objective: input.objective,
+        prompt: input.objective,
+        idempotencyKey: requestKey,
+        riskClass: "bounded-write",
+        authorityScope: input.context?.tokenGrantScopes ?? [],
+        collaborationKind: input.collaborationKind,
+      },
+    });
+  } catch (error) {
+    return {
+      success: false,
+      error: "remote_handoff_failed",
+      message: error instanceof Error ? error.message : "The governed external coworker task could not be submitted.",
+      data: { action: "Retry the same immutable packet and requestKey; if it repeats, inspect the MCP task service." },
+    };
+  }
+
+  if (outcome.kind === "invalid_params") {
+    return { success: false, error: "invalid_params", message: outcome.message };
+  }
+
+  const result = outcome.result;
+  const structured = result["structuredContent"];
+  if (result["isError"] === true) {
+    const error = structured && typeof structured === "object" && "error" in structured
+      ? String((structured as Record<string, unknown>)["error"])
+      : "external_handoff_failed";
+    const content = Array.isArray(result["content"])
+      ? result["content"].find((item) => item && typeof item === "object" && "text" in item)
+      : null;
+    return {
+      success: false,
+      error,
+      message: content && typeof content === "object" ? String((content as Record<string, unknown>)["text"] ?? error) : error,
+      data: result,
+    };
+  }
+
+  const taskRunId = typeof result["taskRunId"] === "string" ? result["taskRunId"] : undefined;
+  return {
+    success: true,
+    entityId: taskRunId,
+    message: `${input.collaborationKind === "summon" ? "Summoned" : "Handed off to"} ${input.targetAgent} through governed external work.`,
+    data: result,
+  };
+}

--- a/apps/web/lib/mcp/packs/coworker-pack.test.ts
+++ b/apps/web/lib/mcp/packs/coworker-pack.test.ts
@@ -4,9 +4,13 @@ const collab = vi.hoisted(() => ({
   requestCoworker: vi.fn(),
   summonCoworker: vi.fn(),
 }));
+const external = vi.hoisted(() => ({ dispatch: vi.fn() }));
 vi.mock("@/lib/tak/coworker-collaboration", () => ({
   requestCoworker: (...a: unknown[]) => collab.requestCoworker(...a),
   summonCoworker: (...a: unknown[]) => collab.summonCoworker(...a),
+}));
+vi.mock("@/lib/mcp/external-coworker-task-adapter", () => ({
+  dispatchExternalCoworkerTask: (...a: unknown[]) => external.dispatch(...a),
 }));
 
 import { coworkerPack } from "./coworker-pack";
@@ -16,6 +20,11 @@ const EXPECTED_TOOLS = ["request_coworker", "summon_coworker", "find_coworker"];
 
 beforeEach(() => {
   vi.clearAllMocks();
+  external.dispatch.mockResolvedValue({
+    success: false,
+    error: "external_handoff_context_required",
+    message: "External coworker handoff requires verified PAT context.",
+  });
 });
 
 describe("coworker pack — registration", () => {
@@ -41,19 +50,66 @@ describe("coworker pack — registration", () => {
     // discoverable/callable over MCP (BI-5FB59BC6).
     expect(TOOL_TO_GRANTS["find_coworker"]).toEqual(["backlog_read"]);
   });
+
+  it.each(["request_coworker", "summon_coworker"])("%s advertises the external request key", (toolName) => {
+    const schema = coworkerPack.definitions.find((definition) => definition.name === toolName)?.inputSchema;
+    expect(schema?.properties).toHaveProperty("requestKey");
+  });
 });
 
 describe("coworker pack — handler behavior (delegation preserved)", () => {
-  it("request_coworker requires caller thread context", async () => {
+  it("request_coworker fails closed when neither a portal thread nor verified external context exists", async () => {
     const res = await coworkerPack.handlers.request_coworker(
       { targetAgent: "ea-architect", objective: "review schema" },
       "u1",
       {},
     );
     expect(res.success).toBe(false);
-    expect(res.error).toBe("missing_threadId");
+    expect(res.error).toBe("external_handoff_context_required");
     expect(collab.requestCoworker).not.toHaveBeenCalled();
+    expect(external.dispatch).toHaveBeenCalledOnce();
   });
+
+  it.each(["codex-cli/0.9", "claude-code/2.1", "grok-cli/0.3", "dpf-embedded/1.0", "generic-mcp/1.0"])(
+    "routes a threadless %s request through the shared external adapter",
+    async (callerClient) => {
+      external.dispatch.mockResolvedValue({
+        success: true,
+        entityId: "TR-MCP-REVIEW",
+        message: "Queued governed external coworker handoff.",
+        data: { status: "completed" },
+      });
+      const objective = "Review BI-B131F357 at repo commit 544830a, design path docs/superpowers/specs/recovery.md.";
+      const res = await coworkerPack.handlers.request_coworker(
+        {
+          targetAgent: "AGT-WS-REVIEW",
+          objective,
+          questionPacketSummary: "Independent immutable design review",
+          requestKey: "initiative-review:BI-B131F357:544830a",
+        },
+        "u1",
+        {
+          apiTokenId: "token-1",
+          authSource: "pat",
+          tokenScope: "write",
+          callerClient,
+          userContext: { platformRole: null, isSuperuser: true },
+        },
+      );
+
+      expect(res).toMatchObject({ success: true, entityId: "TR-MCP-REVIEW" });
+      expect(external.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+        collaborationKind: "handoff",
+        targetAgent: "AGT-WS-REVIEW",
+        objective,
+        requestKey: "initiative-review:BI-B131F357:544830a",
+        title: "Independent immutable design review",
+        userId: "u1",
+      }));
+      expect(collab.requestCoworker).not.toHaveBeenCalled();
+      external.dispatch.mockClear();
+    },
+  );
 
   it("request_coworker rejects missing targetAgent/objective", async () => {
     const res = await coworkerPack.handlers.request_coworker(
@@ -101,14 +157,47 @@ describe("coworker pack — handler behavior (delegation preserved)", () => {
     expect(res.message).toBe("boom");
   });
 
-  it("summon_coworker requires caller thread context", async () => {
+  it("summon_coworker fails closed without verified external context", async () => {
     const res = await coworkerPack.handlers.summon_coworker(
       { targetAgent: "ea-architect", objective: "help" },
       "u1",
       {},
     );
     expect(res.success).toBe(false);
-    expect(res.error).toBe("missing_threadId");
+    expect(res.error).toBe("external_handoff_context_required");
+    expect(collab.summonCoworker).not.toHaveBeenCalled();
+  });
+
+  it("routes an external summon through the same task adapter with summon provenance", async () => {
+    external.dispatch.mockResolvedValue({
+      success: true,
+      entityId: "TR-MCP-SUMMON",
+      message: "Queued governed external coworker summon.",
+      data: { status: "working" },
+    });
+    const objective = "Independently approve the immutable initiative design and record the spec-approval receipt.";
+    const res = await coworkerPack.handlers.summon_coworker(
+      {
+        targetAgent: "AGT-WS-REVIEW",
+        objective,
+        requestKey: "initiative-review:BI-B131F357:spec-approval:544830a",
+      },
+      "u1",
+      {
+        apiTokenId: "token-1",
+        authSource: "pat",
+        tokenScope: "write",
+        callerClient: "codex-cli/0.9",
+        userContext: { platformRole: null, isSuperuser: true },
+      },
+    );
+
+    expect(res).toMatchObject({ success: true, entityId: "TR-MCP-SUMMON" });
+    expect(external.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      collaborationKind: "summon",
+      targetAgent: "AGT-WS-REVIEW",
+      objective,
+    }));
     expect(collab.summonCoworker).not.toHaveBeenCalled();
   });
 

--- a/apps/web/lib/mcp/packs/coworker-pack.ts
+++ b/apps/web/lib/mcp/packs/coworker-pack.ts
@@ -13,6 +13,7 @@
 
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
+import { dispatchExternalCoworkerTask } from "@/lib/mcp/external-coworker-task-adapter";
 
 const definitions: ToolDefinition[] = [
   {
@@ -27,6 +28,7 @@ const definitions: ToolDefinition[] = [
         questionPacketSummary: { type: "string", description: "Optional one-line summary of the intent/question shown on the handoff card." },
         tier: { type: "number", enum: [2, 3], description: "Interaction tier (default 2). Tier 3 requires depth-2 spawn support." },
         enteredVia: { type: "string", enum: ["handoff", "escalation", "spawn"], description: "How the peer is entering (default 'handoff')." },
+        requestKey: { type: "string", description: "Stable idempotency key required for threadless external MCP handoffs." },
       },
       required: ["targetAgent", "objective"],
     },
@@ -48,6 +50,7 @@ const definitions: ToolDefinition[] = [
         targetAgent: { type: "string", description: "Target coworker — canonical agentId (AGT-*) or slug alias." },
         objective: { type: "string", description: "What the summoned coworker should address." },
         tier: { type: "number", enum: [2, 3], description: "Interaction tier (default 2)." },
+        requestKey: { type: "string", description: "Stable idempotency key required for threadless external MCP summons." },
       },
       required: ["targetAgent", "objective"],
     },
@@ -85,13 +88,21 @@ async function requestCoworkerHandler(
   userId: string,
   context?: Parameters<ToolPackHandler>[2],
 ): Promise<ToolResult> {
-  if (!context?.threadId) {
-    return { success: false, error: "missing_threadId", message: "request_coworker requires caller thread context." };
-  }
   const targetAgent = String(params["targetAgent"] ?? "").trim();
   const objective = String(params["objective"] ?? "").trim();
   if (!targetAgent || !objective) {
     return { success: false, error: "invalid_params", message: "request_coworker requires targetAgent and objective." };
+  }
+  if (!context?.threadId) {
+    return dispatchExternalCoworkerTask({
+      collaborationKind: "handoff",
+      targetAgent,
+      objective,
+      requestKey: typeof params["requestKey"] === "string" ? params["requestKey"] : undefined,
+      title: typeof params["questionPacketSummary"] === "string" ? params["questionPacketSummary"] : undefined,
+      userId,
+      context,
+    });
   }
   const tierParam = Number(params["tier"]);
   const enteredViaParam = typeof params["enteredVia"] === "string" ? params["enteredVia"] : undefined;
@@ -126,13 +137,20 @@ async function summonCoworkerHandler(
   userId: string,
   context?: Parameters<ToolPackHandler>[2],
 ): Promise<ToolResult> {
-  if (!context?.threadId) {
-    return { success: false, error: "missing_threadId", message: "summon_coworker requires caller thread context." };
-  }
   const targetAgent = String(params["targetAgent"] ?? "").trim();
   const objective = String(params["objective"] ?? "").trim();
   if (!targetAgent || !objective) {
     return { success: false, error: "invalid_params", message: "summon_coworker requires targetAgent and objective." };
+  }
+  if (!context?.threadId) {
+    return dispatchExternalCoworkerTask({
+      collaborationKind: "summon",
+      targetAgent,
+      objective,
+      requestKey: typeof params["requestKey"] === "string" ? params["requestKey"] : undefined,
+      userId,
+      context,
+    });
   }
   const tierParam = Number(params["tier"]);
   const { summonCoworker } = await import("@/lib/tak/coworker-collaboration");

--- a/apps/web/lib/tak/autonomous-work-run.test.ts
+++ b/apps/web/lib/tak/autonomous-work-run.test.ts
@@ -201,6 +201,33 @@ describe("createAutonomousWorkRun", () => {
     expect(String(arg?.data?.taskRunId)).toMatch(/^TR-SCHED-/);
   });
 
+  it("uses a server-derived public identity for idempotent external work", async () => {
+    const { prisma } = await import("@dpf/db");
+    vi.mocked(prisma.taskRun.create).mockResolvedValue({
+      id: "tr_internal_external",
+      taskRunId: "TR-MCP-A1B2C3D4E5F6",
+      contextId: "thread-external",
+    } as never);
+    const { createAutonomousWorkRun } = await import("./autonomous-work-run");
+
+    await createAutonomousWorkRun({
+      trigger: "external-mcp",
+      taskRunId: "TR-MCP-A1B2C3D4E5F6",
+      userId: "user-1",
+      agentId: "AGT-WS-REVIEW",
+      routeContext: "/platform/build",
+      title: "Independent review",
+      objective: "Review immutable design.",
+      prompt: "Review immutable design.",
+      threadId: "thread-external",
+    });
+
+    expect(vi.mocked(prisma.taskRun.create).mock.calls[0]?.[0]?.data).toMatchObject({
+      taskRunId: "TR-MCP-A1B2C3D4E5F6",
+      initiatingAgentId: "AGT-WS-REVIEW",
+    });
+  });
+
   it("creates capacity-continuity TaskRuns with capacity metadata and no tool execution", async () => {
     const { prisma } = await import("@dpf/db");
     vi.mocked(prisma.taskRun.create).mockResolvedValue({

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -52,6 +52,8 @@ type AgentPromptInfo = {
 
 export type AutonomousWorkRunInput = {
   trigger: AutonomousWorkTrigger;
+  /** Server-derived public identity for idempotent external work. */
+  taskRunId?: string;
   userId: string;
   agentId: string;
   routeContext: string;
@@ -113,7 +115,7 @@ export async function createAutonomousWorkRun(
     await admitRuntimeGuardedWork(tx as never, `task-run:${source}`);
     return tx.taskRun.create({
     data: {
-      taskRunId: createPublicTaskRunId(input.trigger),
+      taskRunId: input.taskRunId ?? createPublicTaskRunId(input.trigger),
       userId: input.userId,
       threadId,
       contextId: threadId,

--- a/docs/superpowers/plans/2026-08-24-external-initiative-review-workflow.md
+++ b/docs/superpowers/plans/2026-08-24-external-initiative-review-workflow.md
@@ -1,0 +1,44 @@
+---
+status: active
+---
+
+# External initiative-review workflow repair
+
+- **Primary backlog item:** `BI-91AF30A5`
+- **Routing dependency:** `BI-6804F720`
+- **Workroom:** `WC-12BC22D4`
+- **Design:** [`2026-08-24-external-mcp-coworker-thread-context-design.md`](../specs/2026-08-24-external-mcp-coworker-thread-context-design.md)
+- **Architecture decision:** `DI-BCCA7F3AC101` — use the existing auth-bound remote-task substrate for threadless external MCP callers
+
+## Outcome
+
+An authenticated external Codex, Claude, Grok, embedded, or generic MCP caller can request or summon the independent Change Reviewer with an immutable initiative-design packet. The reviewer executes under its own Principal and `initiative_design_review` grant, so a passing `spec-approval` receipt atomically creates `initiative_scope_baseline`; the author remains unable to self-approve; plan coverage can then be recorded against the baseline.
+
+## Deliverable
+
+This is one workflow repair, not two independently shippable changes. The request and summon doors share one threadless adapter and one task-idempotency contract; shipping only one leaves the documented reviewer route client-dependent.
+
+| Key | Backlog item | Independently shippable | Depends on |
+| --- | --- | --- | --- |
+| `external-initiative-review` | `BI-91AF30A5` | no | existing coworker Principal/grant and initiative-readiness receipt writers |
+
+## Traceability
+
+- **Requirements:** `OBJ-GPCR-001`, `OBJ-GPCR-002`, `OBJ-GPCR-003`, plus the external-handoff objective baseline in the linked design.
+- **Contracts:** `request_coworker`, `summon_coworker`, `submitRemoteCoworkerTask`, `record_initiative_design_review`, `record_plan_backlog_coverage`.
+- **Flow:** external Workroom -> named reviewer task -> reviewer Principal/grant -> immutable `spec-approval` -> atomic `initiative_scope_baseline` -> plan coverage.
+- **Verification:** both external doors dispatch; exact target/artifact packet survives; retry is exactly-once and token-bound; conflicting replay refuses; portal-thread behavior is unchanged; reviewer conformance and self-review refusal remain green; coverage succeeds with a baseline; missing-baseline copy names the reachable action and no stale BI.
+
+## TDD phases
+
+1. **Red — external routing.** Replace the current `missing_threadId` expectations with failing request/summon tests for verified PAT context, deterministic `requestKey`, exact immutable reviewer packet, and the shared host matrix.
+2. **Red — idempotency.** Add focused remote-task tests for same token/key replay, conflicting envelope refusal, another token isolation, and concurrent uniqueness through a deterministic public task id.
+3. **Green — shared adapter.** Add one adapter behind both coworker handlers. Preserve the portal-thread collaboration owners and reject threadless non-PAT contexts.
+4. **Green — task identity.** Bind task identity to token plus request key and bind replay to an immutable request digest. Keep target resolution and agent grants server-side.
+5. **Refactor.** Keep transport/result/error mapping in the shared adapter and keep task-id generation in the canonical autonomous-work owner; do not duplicate either handler.
+6. **Verify.** Run the focused coworker, remote-task, autonomous-run, single-principal, baseline, and plan-coverage tests plus typecheck if the managed worktree reaches compile-ready.
+7. **Live proof after deployment.** From an external MCP client, request and summon `AGT-WS-REVIEW` against the immutable `BI-B131F357` design, capture the receipt/baseline ids, retry for idempotency, then record the existing immutable plan's coverage.
+
+## Publication exception
+
+The operator explicitly directed this repair to bypass the local/pregate gate because that gate is the blocked subject workflow. The branch will still carry DCO, focused test evidence, an independent semantic review receipt, and protected GitHub CI. No local-CI evidence will be claimed.

--- a/docs/superpowers/plans/2026-08-24-external-initiative-review-workflow.md
+++ b/docs/superpowers/plans/2026-08-24-external-initiative-review-workflow.md
@@ -4,8 +4,8 @@ status: active
 
 # External initiative-review workflow repair
 
-- **Primary backlog item:** `BI-91AF30A5`
-- **Routing dependency:** `BI-6804F720`
+- **Primary backlog item:** `BI-6804F720`
+- **Related plan-coverage defect:** `BI-0996913C`
 - **Workroom:** `WC-12BC22D4`
 - **Design:** [`2026-08-24-external-mcp-coworker-thread-context-design.md`](../specs/2026-08-24-external-mcp-coworker-thread-context-design.md)
 - **Architecture decision:** `DI-BCCA7F3AC101` — use the existing auth-bound remote-task substrate for threadless external MCP callers
@@ -20,7 +20,7 @@ This is one workflow repair, not two independently shippable changes. The reques
 
 | Key | Backlog item | Independently shippable | Depends on |
 | --- | --- | --- | --- |
-| `external-initiative-review` | `BI-91AF30A5` | no | existing coworker Principal/grant and initiative-readiness receipt writers |
+| `external-initiative-review` | `BI-6804F720` | no | existing coworker Principal/grant and initiative-readiness receipt writers |
 
 ## Traceability
 

--- a/docs/superpowers/specs/2026-08-24-external-mcp-coworker-thread-context-design.md
+++ b/docs/superpowers/specs/2026-08-24-external-mcp-coworker-thread-context-design.md
@@ -322,11 +322,34 @@ Expected implementation scope after approval:
 `apps/web/app/api/mcp/v1/route.ts`, Prisma schema, portal UI, and internal
 session-token code are not expected to change.
 
-BI-F0715C9C currently has an active scope claim on the coworker pack and an
-in-flight implementation of the `request_coworker` half of this architecture.
-This BI must not force-co-claim or duplicate that change. It will rebase after
-the owning branch lands, preserve its implementation, and complete the shared
-adapter plus `summon_coworker` acceptance on the resulting mainline.
+The overlapping external-readiness task released its coworker-pack claims on
+2026-08-23 after confirming that it had only a local, unpublished
+`request_coworker` half-change. `WC-12BC22D4` owns the complete request plus
+summon contract so both doors land against one shared adapter and immutable
+task identity. The releasing task will reconcile by normal ancestry after this
+change publishes; it will not mutate these paths in parallel.
+
+## Live evidence (development install, 2026-08-23 CDT)
+
+- `BI-B131F357` and `WC-DD1EF64C` resolve with immutable plan commit
+  `544830a220adbda0570da17e391dabd0d429b1fc` and provider blob
+  `5c1b7349c2848f6676ea8e4e075105b6526bb144`.
+- `BI-91AF30A5` is the verified tooling gap. The remediation's former
+  `BI-B9403248` citation was queried and returned `not_found`; current main no
+  longer hardcodes it.
+- Coworker discovery resolves `AGT-WS-REVIEW` (Change Reviewer). The reviewer
+  registry grants `initiative_design_review`, while the external human PAT
+  correctly does not expose `record_initiative_design_review` for self-use.
+- Both `request_coworker` and `summon_coworker`, called with the same subject
+  and immutable artifact locator, return `missing_threadId` before dispatch.
+- No spec-approval receipt or `initiative_scope_baseline` can be produced on
+  the installed runtime through that documented route. No self-approval,
+  synthetic receipt, direct database write, or reviewer-principal weakening
+  was attempted.
+- Focused source regressions prove the repaired threadless lane for Codex,
+  Claude, Grok, embedded, and generic MCP metadata. Live success evidence must
+  follow merge and governed deployment because the installed runtime still
+  serves the pre-fix implementation.
 
 ## Verification plan
 

--- a/docs/superpowers/specs/2026-08-24-external-mcp-coworker-thread-context-design.md
+++ b/docs/superpowers/specs/2026-08-24-external-mcp-coworker-thread-context-design.md
@@ -4,10 +4,10 @@ status: draft
 
 # External MCP coworker handoff through auth-bound tasks
 
-**Backlog item:** BI-6804F720  
-**Workroom:** WC-4DC4E103  
-**Blocks:** BI-2C50F548  
-**Kernel decision:** DI-BCCA7F3AC101  
+**Backlog item:** BI-6804F720
+**Workroom:** WC-4DC4E103
+**Blocks:** BI-2C50F548
+**Kernel decision:** DI-BCCA7F3AC101
 **Superseded decision:** DI-A308C6C7E47C
 
 ## Objective baseline

--- a/docs/superpowers/specs/2026-08-24-external-mcp-coworker-thread-context-design.md
+++ b/docs/superpowers/specs/2026-08-24-external-mcp-coworker-thread-context-design.md
@@ -1,0 +1,388 @@
+---
+status: draft
+---
+
+# External MCP coworker handoff through auth-bound tasks
+
+**Backlog item:** BI-6804F720  
+**Workroom:** WC-4DC4E103  
+**Blocks:** BI-2C50F548  
+**Kernel decision:** DI-BCCA7F3AC101  
+**Superseded decision:** DI-A308C6C7E47C
+
+## Objective baseline
+
+An authenticated external MCP contributor can ask or summon a named coworker
+without a portal parent thread. The server creates the canonical conversation
+identity, dispatches exactly one visible and auditable task, and returns a
+stable task handle. No caller-supplied tool argument can select an existing
+`AgentThread`.
+
+Success is observable when all of the following hold:
+
+- `request_coworker` and `summon_coworker` work for authenticated external PAT
+  calls that do not carry portal thread context;
+- the same deterministic `requestKey` replays one prior task instead of
+  dispatching a second interaction;
+- direct portal and internal-session calls preserve their current visible
+  collaboration-card behavior;
+- malformed or missing external identity inputs fail with a typed error and an
+  exact repair action;
+- shared adapter tests cover Codex, Claude, Grok, embedded, and generic MCP
+  caller classification without a host-specific dispatch implementation; and
+- the current `missing_threadId` reproduction is green end to end against the
+  live development install.
+
+## Problem
+
+The MCP route authenticates external clients with a persistent PAT. That
+identity reaches `governedExecuteTool`, but PAT authentication does not provide
+an `AgentThread`. Both named coworker handlers currently assume a portal parent
+thread and refuse before dispatch with `missing_threadId`.
+
+The refusal protects the lineage model, but the platform offers no lawful next
+step to the external caller. As a result, an external contributor can discover
+an independent reviewer and can hold the correct reviewer packet, yet cannot
+create the peer interaction required by initiative readiness.
+
+The failure is reproduced by BI-2C50F548 / WC-7B7175A9:
+
+- `find_coworker` resolved the independent Change Reviewer;
+- `request_coworker` and `summon_coworker` both returned
+  `missing_threadId`;
+- the implementation claim then correctly refused with
+  `initiative_not_ready`; and
+- no self-approval, raw database write, synthetic principal, or readiness
+  bypass was attempted.
+
+## Standards correction
+
+The repository's local MCP snapshot documents protocol revision `2025-11-25`,
+where Streamable HTTP may establish a protocol session and return
+`MCP-Session-Id`. That snapshot is not sufficient for this decision.
+
+The official `2026-07-28` MCP specification removes the
+`initialize`/`initialized` handshake and protocol-level sessions. Every request
+is self-describing. `MCP-Session-Id` is not part of the current wire contract.
+DPF's external compatibility window is current plus one prior revision, so a
+new design cannot make the retired session header its identity substrate.
+
+This evidence supersedes DI-A308C6C7E47C, which selected a server-minted
+transport session before the current standard was considered. DI-BCCA7F3AC101
+re-evaluated the options with the current standard and selected the auth-bound
+task adapter with high confidence, no commandment conflict, and autonomous
+eligibility.
+
+## Existing substrate to preserve
+
+- `McpApiToken` and the governed MCP wrapper remain the authentication,
+  capability, grant, and audit boundary.
+- `submitRemoteCoworkerTask` remains the external task entry point.
+- `AgentThread` remains the canonical conversation identity and lineage model.
+- `TaskRun` remains the durable external execution handle and status surface.
+- `requestCoworker` and `summonCoworker` remain the portal-thread interaction
+  owners.
+- The agent registry, lifecycle checks, clearance rules, and tool grants remain
+  the target-authority source of truth.
+- `requestKey` / task idempotency remains the exactly-once retry mechanism.
+- `callerClient` remains presentation and telemetry context, never authority.
+
+No new table, session store, reviewer-dispatch tool, host-specific handler, or
+caller-selectable thread identifier is introduced.
+
+## Options considered
+
+| Option | Wins on | Loses on |
+|---|---|---|
+| Auth-bound task adapter | Reuses canonical task/thread creation, works with stateless MCP, preserves authority | Requires a deterministic request key and async task result |
+| Explicit task handle before tools/call | Makes the task boundary visible to the client | Adds a two-call ceremony and requires every host/skill to compose it correctly |
+| One thread per PAT | Small implementation and no new caller input | Merges unrelated concurrent tasks that share a persistent credential |
+| Client correlation id mapped to thread | Easy host-side correlation | Lets the client define logical lineage and creates same-token collision/spoofing risk |
+
+DI-BCCA7F3AC101 selected the auth-bound task adapter. Its strongest
+contributors were Research and Use Standards and Single Source of Truth. The
+composite was `7.744`, the margin was `2.170`, and the result was stable under
+sensitivity analysis.
+
+## Decision
+
+### 1. Route only threadless external authentication through tasks
+
+The coworker tool handlers retain two explicit lanes:
+
+1. When `context.threadId` exists, call the existing portal collaboration
+   owner. This preserves cards, event-bus updates, conversation lineage, and
+   current internal behavior.
+2. When no thread exists and the execution context proves an external PAT,
+   adapt the request to `submitRemoteCoworkerTask`.
+
+All other missing-thread contexts fail closed. In particular, a malformed
+internal session is not silently reclassified as an external PAT.
+
+### 2. Share one threadless-handoff adapter
+
+Extract one small helper used by both `request_coworker` and
+`summon_coworker`. The helper owns:
+
+- PAT-context verification;
+- deterministic `requestKey` validation;
+- token and user authority projection;
+- target, title, objective, prompt, route, risk, and idempotency mapping;
+- conversion from the task-submission result to the MCP `ToolResult`; and
+- typed external-handoff failures.
+
+This is the intentional refactor portion of the BI. It removes the temptation
+to copy transport and error logic between two coordination tools and makes the
+host matrix one test seam. Portal dispatch remains in the existing handlers;
+the helper does not become a second collaboration owner.
+
+### 3. Let the server create lineage
+
+`submitRemoteCoworkerTask` derives or creates an `AgentThread` inside the
+authenticated user boundary and creates the corresponding `TaskRun`. The tool
+caller provides a deterministic request key, not a thread primary key.
+
+The key is used for idempotency and may appear in audit metadata. It must never
+be resolved as an unscoped `AgentThread.id`. Repeating a key under the same
+authenticated token returns the existing task result only when an immutable
+request digest also matches. The digest covers the token id, named target,
+route, objective/prompt, risk class, authority scope, and collaboration kind.
+Reusing a key with conflicting immutable request fields returns
+`idempotency_conflict` rather than mutating, replaying, or duplicating the prior
+interaction.
+
+The existing task lookup currently scopes a key by `userId` alone. This BI
+tightens it to the authenticated token and persisted request digest. A user may
+hold several PATs and a PAT may be used by several host processes; neither case
+may turn a guessed key into access to another task identity.
+
+### 4. Preserve the exact named target
+
+The adapter passes the canonical requested agent identity into the existing
+remote task target resolver. Lifecycle, model eligibility, sensitivity,
+clearance, and grant checks still run server-side. The adapter must never fall
+back to the first/default coworker when the named target is absent or stale.
+
+`targetAgent` remains a canonical agent id or a supported server-resolved
+alias. Host/user-agent strings are not used to select a target, model, or
+authority policy.
+
+### 5. Use one external request contract
+
+Both named coworker tools accept `requestKey` for the external threadless lane.
+It is required only when the server must create a remote task. Existing portal
+callers with `context.threadId` do not need to add it.
+
+The minimum external request is:
+
+```json
+{
+  "targetAgent": "AGT-WS-REVIEW",
+  "objective": "Review the exact initiative design artifact.",
+  "requestKey": "initiative-readiness:BI-6804F720:spec-approval:<head-sha>"
+}
+```
+
+`questionPacketSummary`, `tier`, and `enteredVia` keep their present meanings
+where supported. The adapter records an explicit route and bounded risk class;
+it does not infer approval or expand the PAT's grants.
+
+The helper supplies `collaborationKind="handoff"` for `request_coworker` and
+`collaborationKind="summon"` for `summon_coworker`. This value is audit and
+presentation metadata, not an authority input. It is included in the immutable
+request digest so the same key cannot silently change interaction semantics.
+
+### 6. Return the canonical task handle
+
+A successful external dispatch returns:
+
+- `success: true`;
+- `entityId` equal to the semantic task-run id;
+- an operator-readable message that the governed peer task was queued or
+  replayed; and
+- structured task status, idempotent-replay state, and approval requirement.
+
+The response does not claim the review passed. Clients use the existing task
+lifecycle methods to observe completion.
+
+### 7. Make failures actionable and typed
+
+The external lane distinguishes at least:
+
+| Error | Meaning | Repair |
+|---|---|---|
+| `missing_requestKey` | No deterministic external task identity was supplied | Retry with the recovery packet's `requestKey` |
+| `external_handoff_context_required` | No portal thread and no verified PAT context exist | Reconnect through the configured authenticated MCP endpoint |
+| `invalid_params` | Target, objective, key, or task payload is malformed | Correct the named field from the returned message |
+| `idempotency_conflict` | The key already names a different immutable task request | Generate the canonical key for this exact reviewer packet; do not reuse another task's key |
+| `remote_handoff_failed` | The governed task owner rejected target, authority, lifecycle, or execution | Preserve and surface its typed structured error |
+
+The current generic `missing_threadId` remains valid for internal-only tools
+that genuinely require portal conversation state. It is no longer the terminal
+answer for these two external coworker entry points.
+
+### 8. Keep host behavior shared
+
+Codex, Claude, Grok, embedded adapters, and generic MCP clients all enter the
+same PAT-authenticated MCP route and the same coworker tool pack. Host
+classification is covered as metadata and compatibility evidence; it does not
+branch the coordination implementation.
+
+The compatibility test matrix includes current and N-1 protocol envelopes. The
+current `2026-07-28` path is stateless. The `2025-11-25` path may still arrive
+through the existing initialize-compatible route, but threadless PAT handoff
+uses the same application task adapter rather than protocol session affinity.
+
+## Data and authority model
+
+No schema migration is required.
+
+The relevant identity chain is:
+
+```text
+authenticated PAT principal
+        |
+        v
+submitRemoteCoworkerTask(requestKey, named target)
+        |
+        +--> AgentThread (server-created canonical lineage)
+        |
+        +--> TaskRun (durable external handle)
+        |
+        +--> named coworker execution under its own grants
+```
+
+Authority never flows from `requestKey`, `callerClient`, `targetAgent`, or
+question text. Those fields shape a request after authentication; the governed
+wrapper and target resolver decide whether the action may run.
+
+## Concurrency and idempotency
+
+- Two retries with the same PAT, `requestKey`, and immutable request digest
+  return one task.
+- Two different keys create separate threads/tasks even when they share a PAT.
+- The same key under a different token/user cannot read or reuse another
+  principal's task.
+- The same token/key with a different target, objective, risk, scope, route, or
+  collaboration kind returns `idempotency_conflict`.
+- No process-local cache or sticky server affinity is required.
+
+The implementation must prove these rules through the existing task
+idempotency boundary rather than a handler-local mutex.
+
+## UX contract
+
+This BI changes no portal layout. Its UX surface is the co-worker response seen
+by an external contributor and, indirectly, whether a reviewer interaction
+appears in the portal.
+
+The first failure sentence names the missing or rejected concept in plain
+language. The second sentence gives one exact next action. Successful dispatch
+names the target and task state without implying approval. No raw database id
+other than the stable semantic task id is required for the operator to proceed.
+
+This prevents the contradiction reported in the onboarding BI: the platform
+must not tell the operator to open or request a review through a route that the
+same install cannot execute.
+
+## Security and privacy
+
+- Never accept `threadId` as an ordinary argument for these tools.
+- Never trust client correlation metadata as lineage authority.
+- Scope task lookup and idempotency to the authenticated principal/token.
+- Preserve the PAT's capability and grants; the adapter cannot widen them.
+- Preserve target coworker lifecycle, clearance, sensitivity, and tool-grant
+  checks.
+- Do not echo PAT material or internal primary keys in errors.
+- Record the task, target, request key, auth source, and outcome in existing
+  audit substrates.
+- Treat target resolution ambiguity as an error, not a fallback.
+
+## Scalability and operations
+
+The path performs the same indexed thread upsert and task creation already used
+by `tasks/submit`. It adds no session table, sticky routing, in-memory state, or
+per-host worker. Any web instance can process a retry from durable data.
+
+Operational telemetry distinguishes queued, idempotent replay, input required,
+target rejected, and execution failure. The metric dimension uses normalized
+caller-client classes and must not include raw request keys or objectives.
+
+## Implementation boundaries
+
+Expected implementation scope after approval:
+
+- `apps/web/lib/mcp/packs/coworker-pack.ts`
+- `apps/web/lib/mcp/packs/coworker-pack.test.ts`
+- `apps/web/lib/mcp/external-coworker-task-adapter.ts` and its focused test;
+- `apps/web/lib/mcp-task-submit.ts` and its focused tests for token-bound digest
+  replay/conflict semantics; and
+- focused route tests only for execution-context projection regressions.
+
+`apps/web/app/api/mcp/v1/route.ts`, Prisma schema, portal UI, and internal
+session-token code are not expected to change.
+
+BI-F0715C9C currently has an active scope claim on the coworker pack and an
+in-flight implementation of the `request_coworker` half of this architecture.
+This BI must not force-co-claim or duplicate that change. It will rebase after
+the owning branch lands, preserve its implementation, and complete the shared
+adapter plus `summon_coworker` acceptance on the resulting mainline.
+
+## Verification plan
+
+### Unit and integration tests
+
+- reproduce `missing_threadId` for both handlers on current main;
+- prove external request and summon calls use the auth-bound task adapter;
+- prove portal-thread calls still use their original collaboration owners;
+- prove a missing `requestKey` returns `missing_requestKey` without dispatch;
+- prove an unverified non-PAT context returns
+  `external_handoff_context_required`;
+- prove the exact target and authority fields reach remote task submission;
+- prove duplicate request keys replay one task;
+- prove another token under the same user cannot replay that task;
+- prove a conflicting immutable envelope returns `idempotency_conflict`;
+- prove task-owner typed failures survive ToolResult conversion;
+- exercise normalized Codex, Claude, Grok, embedded, and generic caller
+  metadata through one shared adapter; and
+- run related route, coworker-pack, task-submit, grant, and authorization tests.
+
+### Functional verification
+
+On the governed development install, use an authenticated external MCP task to:
+
+1. discover the independent Change Reviewer;
+2. call `request_coworker` with a deterministic packet;
+3. observe a semantic task id and one visible peer interaction;
+4. retry and confirm an idempotent replay rather than a duplicate;
+5. repeat through `summon_coworker`;
+6. inspect the completed result and audit lineage; and
+7. use the repaired path to obtain an independent review for BI-2C50F548.
+
+Structural tests alone do not satisfy this acceptance path.
+
+## Rollback
+
+The change is code-only and schema-free. Rollback restores the two handlers to
+their prior missing-thread refusal while leaving any already-created
+AgentThread and TaskRun records as immutable audit history. No destructive data
+cleanup is required.
+
+## Acceptance criteria traceability
+
+| BI acceptance criterion | Design coverage |
+|---|---|
+| Verified external task identity reaches request and summon | Auth-bound task adapter; server-created AgentThread and TaskRun |
+| Caller cannot spoof another task through ordinary arguments | No `threadId` argument; PAT-scoped task creation and lookup |
+| Missing/invalid identity is typed and actionable | Explicit error table and repair messages |
+| Codex/Claude/Grok/embedded/generic compatibility | Shared handler lane and host-metadata test matrix |
+| Regression reproduces and proves fixed propagation | Unit, integration, and live functional verification plan |
+
+## Open review questions
+
+1. Should the immutable request digest be stored in the existing `a2aMetadata`
+   JSON only, or does the task owner already expose a canonical digest field
+   that should be reused?
+2. Does the live task activity projection already render collaboration kind,
+   or does it need a read-model-only label change after the backend contract is
+   proven?

--- a/docs/superpowers/specs/2026-08-24-external-mcp-coworker-thread-context-design.md
+++ b/docs/superpowers/specs/2026-08-24-external-mcp-coworker-thread-context-design.md
@@ -334,7 +334,9 @@ change publishes; it will not mutate these paths in parallel.
 - `BI-B131F357` and `WC-DD1EF64C` resolve with immutable plan commit
   `544830a220adbda0570da17e391dabd0d429b1fc` and provider blob
   `5c1b7349c2848f6676ea8e4e075105b6526bb144`.
-- `BI-91AF30A5` is the verified tooling gap. The remediation's former
+- `BI-6804F720` is the canonical routing defect. `BI-91AF30A5` was identified
+  during reproduction and later retired as a duplicate; related plan-coverage
+  remediation remains tracked by `BI-0996913C`. The remediation's former
   `BI-B9403248` citation was queried and returned `not_found`; current main no
   longer hardcodes it.
 - Coworker discovery resolves `AGT-WS-REVIEW` (Change Reviewer). The reviewer


### PR DESCRIPTION
## Summary

- route threadless, PAT-authenticated `request_coworker` and `summon_coworker` calls through one governed remote-task adapter
- preserve the named reviewer, exact immutable artifact packet, portal-thread behavior, reviewer Principal, lifecycle checks, and reviewer grants
- bind retries to a server-derived, token-scoped task id plus an immutable request digest; conflicting reuse returns `idempotency_conflict`
- replace the unreachable `missing_threadId` terminal response with typed, executable repair actions

## Live diagnosis

On the development install, `find_coworker` resolved `AGT-WS-REVIEW`, but both reviewer doors returned `missing_threadId` for `BI-B131F357` and immutable plan commit `544830a220adbda0570da17e391dabd0d429b1fc`. `BI-6804F720` is the canonical routing defect; `BI-0996913C` tracks the related broader plan-coverage gap. The temporary duplicate `BI-91AF30A5` has been retired. The previously cited `BI-B9403248` was queried live and returned `not_found`; current `main` already removes that stale citation.

No self-approval, fabricated receipt, direct database write, or weakened reviewer independence was used. The installed runtime still serves the pre-fix code, so post-fix live receipt/baseline proof must follow merge and governed deployment.

## Verification

- TDD red: 9 workflow failures covered omitted `requestKey`, both `missing_threadId` refusals, and the external-client matrix; a separate security regression reproduced CodeQL alerts 384/385 against the unkeyed token-id hash
- focused final suite: 165/165 passing across coworker routing, adapter, token-bound task submission, autonomous work, JSON-RPC route, reviewer Principal conformance, self-approval refusal, atomic baseline creation, missing-baseline remediation, and post-baseline plan coverage
- `pnpm --filter web typecheck`: passing
- style-drift guard: passing
- `git diff --check`: passing
- exact-tree semantic receipt `cmt6qe9ot0ee601mx4x8h40o5`, specialist `AGT-181`: no findings; infrastructure-inconclusive because governed local CI held the reviewer capacity reservation; repository shadow policy returned `mayPublish=true`

The operator directed publication without local CI/pregate because that local initiative workflow is the defect under repair. Protected GitHub checks remain authoritative.

## Design grounding

Reviewed `docs/superpowers/specs/2026-08-24-external-mcp-coworker-thread-context-design.md`, the initiative-review plan, the existing `submitRemoteCoworkerTask`, `AgentThread`, `TaskRun`, autonomous-work, reviewer-grant, readiness-receipt, baseline, and plan-coverage owners. `DI-BCCA7F3AC101` selects the stateless auth-bound task adapter. No transport session, table, host-specific branch, caller-supplied thread id, or new reviewer authority is introduced.

Backlog-Item: BI-6804F720
Related-Backlog-Item: BI-0996913C
Workroom: WC-12BC22D4
Design-Grounding-Decision: DI-BCCA7F3AC101 — preserve canonical task/thread and reviewer authority owners
Local-CI-Override: operator-emergency: Operator directed bypass because the local initiative workflow gate is the defect under repair
Docs-Impact-Decision: Internal external-MCP task identity and reviewer-routing repair; no documented portal route or user-guide behavior changes


