### PR TITLE
fix: make coworker routing and voice status truthful

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/page.tsx
@@ -129,7 +129,7 @@ export default async function ProvidersPage() {
       category: p.category,
       serviceKind: p.serviceKind ?? null,
       authMethod: p.authMethod,
-      hasCredential: !!pw.credential,
+      hasCredential: pw.credential?.hasUsableMaterial ?? false,
       credentialExpired,
       discoveredModelCount: summary?.totalModels ?? 0,
       cliPoolExhausted: pool?.isExhausted ?? false,

--- a/apps/web/app/api/voice/service-status/route.test.ts
+++ b/apps/web/app/api/voice/service-status/route.test.ts
@@ -8,12 +8,13 @@ vi.mock("@/lib/auth", () => ({
 // (for isVoiceNarrationEnabled). The route itself never queries it, so a thin
 // mock keeps this test hermetic.
 vi.mock("@dpf/db", () => ({
-  prisma: { voiceProfile: { count: vi.fn(async () => 0) } },
+  prisma: { voiceProfile: { count: vi.fn(async () => 0), findMany: vi.fn(async () => [{ profile: { voiceEnabled: true } }]) } },
 }))
 
 // Keep defaultProvider real (env-driven) so the route resolves the probe URL
 // exactly as production does.
 import { auth } from "@/lib/auth"
+import { prisma } from "@dpf/db"
 import { GET } from "./route"
 
 describe("GET /api/voice/service-status", () => {
@@ -21,6 +22,7 @@ describe("GET /api/voice/service-status", () => {
     vi.restoreAllMocks()
     vi.unstubAllEnvs()
     vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never)
+    vi.mocked(prisma.voiceProfile.findMany).mockResolvedValue([{ profile: { voiceEnabled: true } }] as never)
     // DPF_TTS_URL intentionally left unset so the route's `?? default` applies;
     // the mlx test below stubs it explicitly. (Stubbing "" would defeat `??`.)
     vi.stubEnv("TTS_PROVIDER", "chatterbox")
@@ -41,12 +43,22 @@ describe("GET /api/voice/service-status", () => {
     const body = await res.json()
 
     expect(res.status).toBe(200)
-    expect(body).toEqual({ available: true, provider: "chatterbox", reason: null })
+    expect(body).toEqual({ available: true, state: "ready", provider: "chatterbox", reason: null })
     // Probes the default Docker-network sidecar address.
     expect(global.fetch).toHaveBeenCalledWith(
       "http://dpf-tts:8000/health",
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
+  })
+
+  it("forwards preview purpose without requiring narration preference", async () => {
+    vi.mocked(prisma.voiceProfile.findMany).mockResolvedValue([{ profile: { voiceEnabled: false } }] as never)
+    global.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ status: "healthy", model_loaded: true }), { status: 200 }),
+    ) as typeof fetch
+
+    const res = await GET(new Request("http://localhost/api/voice/service-status?purpose=preview"))
+    expect(await res.json()).toMatchObject({ available: true, state: "ready" })
   })
 
   it("reports unavailable when the sidecar is unreachable", async () => {
@@ -59,6 +71,7 @@ describe("GET /api/voice/service-status", () => {
 
     expect(res.status).toBe(200)
     expect(body.available).toBe(false)
+    expect(body.state).toBe("service_unavailable")
     expect(body.reason).toMatch(/not running/i)
   })
 
@@ -81,7 +94,7 @@ describe("GET /api/voice/service-status", () => {
     const res = await GET()
     const body = await res.json()
 
-    expect(body).toEqual({ available: true, provider: "cartesia", reason: null })
+    expect(body).toEqual({ available: true, state: "ready", provider: "cartesia", reason: null })
     expect(global.fetch).not.toHaveBeenCalled()
   })
 

--- a/apps/web/app/api/voice/service-status/route.ts
+++ b/apps/web/app/api/voice/service-status/route.ts
@@ -7,26 +7,18 @@
 
 import { NextResponse } from "next/server"
 import { auth } from "@/lib/auth"
-import { resolveTtsServiceUp } from "@/lib/voice-synthesis/service-status"
+import { resolveVoicePlaybackCapability, type VoicePlaybackCapability } from "@/lib/voice-synthesis/service-status"
 
 export const dynamic = "force-dynamic"
 
-interface ServiceStatus {
-  available: boolean
-  provider: string
-  reason: string | null
-}
-
-export async function GET(): Promise<NextResponse<ServiceStatus | { error: string }>> {
+export async function GET(request?: Request): Promise<NextResponse<VoicePlaybackCapability | { error: string }>> {
   const session = await auth()
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 
-  const status = await resolveTtsServiceUp()
-  return NextResponse.json({
-    available: status.up,
-    provider: status.provider,
-    reason: status.reason,
-  })
+  const purpose = request && new URL(request.url).searchParams.get("purpose") === "preview"
+    ? "preview"
+    : "coworker"
+  return NextResponse.json(await resolveVoicePlaybackCapability({ purpose }))
 }

--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -26,7 +26,7 @@ import { CoworkerHealthStatus } from "@/components/monitoring/CoworkerHealthStat
 import { SetupActionButtonsWrapper } from "@/components/setup/SetupActionButtonsWrapper";
 import { resolveCoworkerRuntimeMode } from "./coworker-runtime-mode";
 import type { QuestionPacket } from "@/lib/tak/question-packet";
-import { presentStandingCoo, resolveCooPresentationName } from "@/lib/coworker-presentation/coo-name";
+import { isStandingCooAgentId, presentStandingCoo, resolveCooPresentationIdentity, resolveCooPresentationName } from "@/lib/coworker-presentation/coo-name";
 import {
   loadElevatedAssistPreference,
   saveElevatedAssistPreference,
@@ -279,6 +279,7 @@ export function AgentCoworkerPanel({
 
   const routeAgent: AgentInfo = resolveAgentForRouteSync(effectiveRoute, userContext);
   const agent = presentStandingCoo(routeAgent, cooConversationalName);
+  const agentIdentity = resolveCooPresentationIdentity({ agentId: agent.agentId, canonicalName: agent.agentName, conversationalName: cooConversationalName });
   const webAccessAvailable = agentHoldsWebSearchGrant(agent.agentId);
   const canUseDev = userContext.isSuperuser || userContext.platformRole === "HR-000" || userContext.platformRole === "HR-300";
   const preferenceUserKey = userContext.userId ?? `${userContext.isSuperuser ? "super" : "role"}:${userContext.platformRole ?? "none"}`;
@@ -935,6 +936,7 @@ export function AgentCoworkerPanel({
         marketingSkillRules={marketingSkillRules}
         isDocked={isDocked}
         routeContextLabel={resolvePanelRouteContextLabel(effectiveRoute)}
+        presentationIdentity={agentIdentity}
       />
 
       {/* Voice activity indicator — shown when voice synthesis is active */}
@@ -979,11 +981,6 @@ export function AgentCoworkerPanel({
         />
       )}
 
-      {/* EP-A2A: collapsed/summarized sub-agent activity disclosure (quiet for
-          1-1). Visibility only — shows what the active coworker is tasking and
-          a summary of what each peer is doing. The human does NOT pick or task
-          coworkers; the active coworker decides that via request_coworker /
-          summon_coworker. */}
       <CollaborationActivityPanel participants={participants} cards={collaborationCardsToShow} />
 
       <div
@@ -995,11 +992,10 @@ export function AgentCoworkerPanel({
       >
         {messages.map((msg, i) => {
           const prevAgentId = i > 0 ? messages[i - 1]?.agentId : null;
-          const showAgentLabel = msg.role === "assistant" && msg.agentId !== prevAgentId;
-          // Button-decisions are actionable only on the latest turn while idle:
-          // clicking submits the option as the human's reply and continues the
-          // turn. Superseded decisions (a newer message exists) or an in-flight
-          // turn (isBusy) render without buttons — the prose closeout still shows.
+          const activeAgent = msg.agentId === agent.agentId
+            || (isStandingCooAgentId(msg.agentId) && isStandingCooAgentId(agent.agentId));
+          const showAgentLabel = msg.role === "assistant" && !activeAgent && msg.agentId !== prevAgentId;
+          // Decisions are actionable only on the latest idle turn.
           const isLatest = i === messages.length - 1;
           const decisionActive = isLatest && !isBusy && msg.role === "assistant";
           return (
@@ -1007,7 +1003,7 @@ export function AgentCoworkerPanel({
               key={msg.id}
               message={msg}
               showAgentLabel={showAgentLabel}
-              agentName={showAgentLabel && msg.agentId ? resolveCooPresentationName({
+              agentName={msg.agentId ? resolveCooPresentationName({
                 agentId: msg.agentId,
                 canonicalName: AGENT_NAME_MAP[msg.agentId] ?? msg.agentId,
                 conversationalName: cooConversationalName,
@@ -1067,12 +1063,12 @@ export function AgentCoworkerPanel({
                   : orchestratorStatus
                     ? orchestratorStatus
                     : currentTool
-                      ? `${agent.agentName} is using ${currentTool.replace(/_/g, " ")}...`
+                      ? `${agentIdentity.primaryName} is using ${currentTool.replace(/_/g, " ")}...`
                       : thinkingSeconds < 5
-                        ? `${agent.agentName} is thinking`
+                        ? `${agentIdentity.primaryName} is thinking`
                         : thinkingSeconds < 15
-                          ? `${agent.agentName} is working on it`
-                          : `${agent.agentName} is still working (${thinkingSeconds}s)`}
+                          ? `${agentIdentity.primaryName} is working on it`
+                          : `${agentIdentity.primaryName} is still working (${thinkingSeconds}s)`}
               </span>
               {/* Animated bouncing dots */}
               <span style={{ display: "inline-flex", gap: 2, alignItems: "center" }}>
@@ -1297,6 +1293,7 @@ export function AgentCoworkerPanel({
         onFileUploaded={setPendingAttachment}
         onFileClear={() => setPendingAttachment(null)}
         voiceSynthAvailable={voiceSynth.available}
+        voiceSynthChecking={voiceSynth.checking}
         voicePlaybackUnavailableReason={voiceSynth.unavailableReason}
         voicePlaybackEnabled={voicePlaybackEnabled}
         onVoicePlaybackToggle={toggleVoicePlayback}

--- a/apps/web/components/agent/AgentMessageBubble.test.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.test.tsx
@@ -85,7 +85,8 @@ describe("AgentMessageBubble", () => {
         message={{
           id: "routing-failed",
           role: "system",
-          content: "The selected AI model is unavailable. Open Providers & Routing.",
+          content:
+            "The selected AI model is no longer available from its provider, so the platform could not answer this turn. Open Providers & Routing.",
           agentId: null,
           routeContext: "/workspace",
           createdAt: "2026-08-24T00:00:00.000Z",
@@ -97,6 +98,25 @@ describe("AgentMessageBubble", () => {
     expect(html).toContain('data-message-role="system"');
     expect(html).toContain('data-testid="agent-provider-reconnect-cta"');
     expect(html).not.toContain('data-message-role="assistant"');
+  });
+
+  it("does not add recovery controls to unrelated system notices that mention provider routing", () => {
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "build-studio-routing-note",
+          role: "system",
+          content: "Build Runtime and Providers & Routing govern different phases.",
+          agentId: null,
+          routeContext: "/platform/ai/build-studio",
+          createdAt: "2026-08-24T00:00:00.000Z",
+        }}
+        showAgentLabel={false}
+        agentName={null}
+      />,
+    );
+    expect(html).toContain('data-message-role="system"');
+    expect(html).not.toContain('data-testid="agent-provider-reconnect-cta"');
   });
 
   it("renders assistant markdown as structured HTML", () => {

--- a/apps/web/components/agent/AgentMessageBubble.test.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.test.tsx
@@ -97,6 +97,7 @@ describe("AgentMessageBubble", () => {
     );
     expect(html).toContain('data-message-role="system"');
     expect(html).toContain('data-testid="agent-provider-reconnect-cta"');
+    expect(html.match(/Providers &amp; Routing/g)).toHaveLength(1);
     expect(html).not.toContain('data-message-role="assistant"');
   });
 

--- a/apps/web/components/agent/AgentMessageBubble.test.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.test.tsx
@@ -79,6 +79,26 @@ describe("AgentMessageBubble", () => {
     expect(html).toContain("Provider posture was not changed");
   });
 
+  it("renders provider recovery as a system card without coworker attribution", () => {
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "routing-failed",
+          role: "system",
+          content: "The selected AI model is unavailable. Open Providers & Routing.",
+          agentId: null,
+          routeContext: "/workspace",
+          createdAt: "2026-08-24T00:00:00.000Z",
+        }}
+        showAgentLabel={false}
+        agentName={null}
+      />,
+    );
+    expect(html).toContain('data-message-role="system"');
+    expect(html).toContain('data-testid="agent-provider-reconnect-cta"');
+    expect(html).not.toContain('data-message-role="assistant"');
+  });
+
   it("renders assistant markdown as structured HTML", () => {
     const html = renderToStaticMarkup(
       <AgentMessageBubble
@@ -100,6 +120,26 @@ describe("AgentMessageBubble", () => {
     expect(html).toContain("<ul");
     expect(html).toContain("automation</li>");
     expect(html).not.toContain("**Agents**");
+  });
+
+  it("keeps assistant authorship accessible when the visual label is suppressed", () => {
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "msg-accessible-author",
+          role: "assistant",
+          content: "I can help with that.",
+          agentId: "AGT-ORCH-000",
+          routeContext: "/workspace",
+          createdAt: "2026-08-24T00:00:00.000Z",
+        }}
+        showAgentLabel={false}
+        agentName="Coolio"
+      />,
+    );
+
+    expect(html).toContain('aria-label="Message from Coolio"');
+    expect(html).not.toMatch(/>Coolio<\/span>/);
   });
 
   it("keeps user messages as plain text bubbles", () => {

--- a/apps/web/components/agent/AgentMessageBubble.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.tsx
@@ -122,6 +122,34 @@ export function referencesProviderRoutingSurface(content: string): boolean {
   return /Providers\s*&\s*Routing/i.test(content);
 }
 
+function ProviderRoutingCta() {
+  return (
+    <div style={{ marginTop: 8 }}>
+      <Link
+        href={PROVIDER_ROUTING_ROUTE}
+        data-testid="agent-provider-reconnect-cta"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          border: "1px solid color-mix(in srgb, var(--dpf-accent) 45%, transparent)",
+          background: "color-mix(in srgb, var(--dpf-accent) 14%, transparent)",
+          borderRadius: 999,
+          color: "var(--dpf-accent)",
+          fontSize: 11,
+          fontWeight: 600,
+          lineHeight: 1,
+          padding: "6px 10px",
+          textDecoration: "none",
+        }}
+      >
+        <PlugZap size={12} aria-hidden="true" />
+        Open Providers &amp; Routing
+      </Link>
+    </div>
+  );
+}
+
 function formatProposalParams(
   actionType: string,
   params: Record<string, unknown>,
@@ -359,6 +387,7 @@ export function AgentMessageBubble({
         }}
       >
         {message.content}
+        {referencesProviderRoutingSurface(message.content) && <ProviderRoutingCta />}
       </div>
     );
   }
@@ -575,6 +604,7 @@ export function AgentMessageBubble({
       data-testid="agent-message"
       data-message-role={isUser ? "user" : "assistant"}
       data-message-error={isAssistantError ? "true" : undefined}
+      aria-label={!isUser && agentName ? `Message from ${agentName}` : undefined}
       style={{
         display: "flex",
         flexDirection: "column",
@@ -665,31 +695,7 @@ export function AgentMessageBubble({
                 ))}
               </div>
             )}
-            {referencesProviderRoutingSurface(message.content) && (
-              <div style={{ marginTop: 8 }}>
-                <Link
-                  href={PROVIDER_ROUTING_ROUTE}
-                  data-testid="agent-provider-reconnect-cta"
-                  style={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: 6,
-                    border: "1px solid color-mix(in srgb, var(--dpf-accent) 45%, transparent)",
-                    background: "color-mix(in srgb, var(--dpf-accent) 14%, transparent)",
-                    borderRadius: 999,
-                    color: "var(--dpf-accent)",
-                    fontSize: 11,
-                    fontWeight: 600,
-                    lineHeight: 1,
-                    padding: "6px 10px",
-                    textDecoration: "none",
-                  }}
-                >
-                  <PlugZap size={12} aria-hidden="true" />
-                  Open Providers &amp; Routing
-                </Link>
-              </div>
-            )}
+            {referencesProviderRoutingSurface(message.content) && <ProviderRoutingCta />}
           </div>
         )}
         {message.attachments && message.attachments.length > 0 && (

--- a/apps/web/components/agent/AgentMessageBubble.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.tsx
@@ -110,13 +110,15 @@ function extractManagedDocumentIds(content: string): string[] {
 export const PROVIDER_ROUTING_ROUTE = AI_PROVIDER_CONNECTIONS_ROUTE;
 
 /**
- * True when an assistant message steers the operator to reconnect or activate an
- * AI provider. Every provider-config failure branch (describeToolRouteFailure in
+ * True when a message steers the operator to reconnect or activate an AI
+ * provider. Every provider-config failure branch (describeToolRouteFailure in
  * agentic-loop.ts, and the credential-gap messages in agent-coworker.ts) names
  * the "Providers & Routing" surface. BI-282C39D5: rather than make the user hunt
  * the menu, render a one-click chip straight to it — hand the fix, don't just
- * describe it. Benign on the rare false positive: the chip only links to a page
- * the message already names. Assistant-only; user text is never scanned.
+ * describe it. Assistant messages retain the established chip treatment;
+ * terminal system messages link the words already present in their copy so a
+ * recovery action does not duplicate first-viewport prose. User text is never
+ * scanned.
  */
 export function referencesProviderRoutingSurface(content: string): boolean {
   return /Providers\s*&\s*Routing/i.test(content);
@@ -153,6 +155,27 @@ function ProviderRoutingCta() {
         Open Providers &amp; Routing
       </Link>
     </div>
+  );
+}
+
+function ProviderRoutingInlineRecovery({ content }: { content: string }): ReactNode {
+  const match = /Providers\s*&\s*Routing/i.exec(content);
+  if (!match || match.index === undefined) return content;
+  const before = content.slice(0, match.index);
+  const after = content.slice(match.index + match[0].length);
+
+  return (
+    <>
+      {before}
+      <Link
+        href={PROVIDER_ROUTING_ROUTE}
+        data-testid="agent-provider-reconnect-cta"
+        style={{ color: "var(--dpf-accent)", fontWeight: 600 }}
+      >
+        {match[0]}
+      </Link>
+      {after}
+    </>
   );
 }
 
@@ -392,8 +415,9 @@ export function AgentMessageBubble({
           fontStyle: "italic",
         }}
       >
-        {message.content}
-        {referencesTerminalProviderRecovery(message.content) && <ProviderRoutingCta />}
+        {referencesTerminalProviderRecovery(message.content)
+          ? <ProviderRoutingInlineRecovery content={message.content} />
+          : message.content}
       </div>
     );
   }

--- a/apps/web/components/agent/AgentMessageBubble.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.tsx
@@ -122,6 +122,12 @@ export function referencesProviderRoutingSurface(content: string): boolean {
   return /Providers\s*&\s*Routing/i.test(content);
 }
 
+export function referencesTerminalProviderRecovery(content: string): boolean {
+  if (!referencesProviderRoutingSurface(content)) return false;
+  return /^(?:The selected AI model is no longer available|No AI model (?:can handle|that supports tools is active)|No AI provider credentials are configured|No AI provider is available to handle|I couldn't get an answer from any AI model)/i
+    .test(content.trim());
+}
+
 function ProviderRoutingCta() {
   return (
     <div style={{ marginTop: 8 }}>
@@ -387,7 +393,7 @@ export function AgentMessageBubble({
         }}
       >
         {message.content}
-        {referencesProviderRoutingSurface(message.content) && <ProviderRoutingCta />}
+        {referencesTerminalProviderRecovery(message.content) && <ProviderRoutingCta />}
       </div>
     );
   }

--- a/apps/web/components/agent/AgentMessageInput.test.tsx
+++ b/apps/web/components/agent/AgentMessageInput.test.tsx
@@ -113,6 +113,19 @@ describe("AgentMessageInput — mic button is mounted", () => {
 });
 
 describe("AgentMessageInput — voice playback affordance", () => {
+  it("announces capability checking separately from an unavailable service", () => {
+    render(
+      <AgentMessageInput
+        {...defaultProps}
+        voiceSynthChecking
+        voiceSynthAvailable={false}
+        voicePlaybackEnabled={true}
+        onVoicePlaybackToggle={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /checking voice playback/i })).toBeTruthy();
+  });
+
   it("keeps the speaker control visible but disabled when voice synthesis is unavailable", () => {
     render(
       <AgentMessageInput

--- a/apps/web/components/agent/AgentMessageInput.tsx
+++ b/apps/web/components/agent/AgentMessageInput.tsx
@@ -31,6 +31,7 @@ type Props = {
   onFileClear: () => void;
   /** Whether a ready voice profile is available for synthesis. */
   voiceSynthAvailable?: boolean;
+  voiceSynthChecking?: boolean;
   /** Short explanation to show when voice synthesis is unavailable. */
   voicePlaybackUnavailableReason?: string | null;
   /** Current playback preference set by the user. */
@@ -92,7 +93,7 @@ function truncate(value: string, max = 32): string {
   return `${value.slice(0, max - 1)}…`;
 }
 
-export function AgentMessageInput({ onSend, composerState, busy, threadId, pendingFile, onFileUploaded, onFileClear, voiceSynthAvailable, voicePlaybackUnavailableReason, voicePlaybackEnabled, onVoicePlaybackToggle, elevatedAssistEnabled, onToggleElevatedAssist, externalAccessEnabled, onToggleExternalAccess, webAccessAvailable = true, coworkerMode, onToggleCoworkerMode, useUnified }: Props) {
+export function AgentMessageInput({ onSend, composerState, busy, threadId, pendingFile, onFileUploaded, onFileClear, voiceSynthAvailable, voiceSynthChecking, voicePlaybackUnavailableReason, voicePlaybackEnabled, onVoicePlaybackToggle, elevatedAssistEnabled, onToggleElevatedAssist, externalAccessEnabled, onToggleExternalAccess, webAccessAvailable = true, coworkerMode, onToggleCoworkerMode, useUnified }: Props) {
   const disabled = composerInputDisabled(composerState);
   const [value, setValue] = useState("");
   const [intentCenter, setIntentCenter] = useState("");
@@ -359,9 +360,9 @@ export function AgentMessageInput({ onSend, composerState, busy, threadId, pendi
   }
 
   const overLimit = value.trim().length > MAX_MESSAGE_LENGTH;
-  const voicePlaybackUnavailable = voiceSynthAvailable === false;
+  const voicePlaybackUnavailable = voiceSynthChecking || voiceSynthAvailable === false;
   const voicePlaybackUnavailableTitle =
-    voicePlaybackUnavailableReason ?? "Voice playback unavailable. Start the text-to-speech service or replace the voice sample.";
+    voiceSynthChecking ? "Checking voice playback availability." : voicePlaybackUnavailableReason ?? "Voice playback is unavailable.";
   const hasAnyChip =
     !!pendingFile ||
     !!intentCenter ||
@@ -707,13 +708,7 @@ export function AgentMessageInput({ onSend, composerState, busy, threadId, pendi
 
   return (
     <div style={{ borderTop: "1px solid var(--dpf-border)", padding: "8px 10px" }}>
-      {/*
-        Voice Slice 2 follow-up: surface voice errors INLINE, not just in the
-        button tooltip. Operators were clicking the mic, getting silent
-        failures (red ring on a small button), and concluding "nothing
-        happened". The error banner shows the failure reason + the next
-        actionable step in plain language.
-      */}
+      {/* Voice-input errors stay inline so the next action is visible. */}
       {voice.state === "error" && voice.error && (
         <div
           role="alert"
@@ -903,13 +898,15 @@ export function AgentMessageInput({ onSend, composerState, busy, threadId, pendi
                     : "Unmute voice playback"
               }
               aria-label={
-                voicePlaybackUnavailable
+                voiceSynthChecking
+                  ? "Checking voice playback"
+                  : voicePlaybackUnavailable
                   ? "Voice playback unavailable"
                   : voicePlaybackEnabled
                     ? "Mute voice playback"
                     : "Unmute voice playback"
               }
-              aria-pressed={voicePlaybackEnabled}
+              aria-pressed={!!voicePlaybackEnabled && !voicePlaybackUnavailable}
               disabled={voicePlaybackUnavailable}
               style={{
                 background: "none",

--- a/apps/web/components/agent/AgentPanelHeader.test.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.test.tsx
@@ -43,6 +43,18 @@ describe("AgentPanelHeader", () => {
     expect(screen.queryByText("Edit fields on this page")).toBeNull();
   });
 
+  it("renders a conversational name as primary and the coworker role once as secondary", () => {
+    render(
+      <AgentPanelHeader
+        {...baseProps}
+        presentationIdentity={{ primaryName: "Coolio", roleName: "AI COO" }}
+      />,
+    );
+    expect(screen.getByText("Coolio")).toBeTruthy();
+    expect(screen.getAllByText("AI COO")).toHaveLength(1);
+    expect(screen.queryByText("Coolio · AI COO")).toBeNull();
+  });
+
   it("moves profile, diagnostics, and erase into the overflow menu and points dev work to Build Studio", () => {
     const onOpenClearConfirm = vi.fn();
     render(

--- a/apps/web/components/agent/AgentPanelHeader.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.tsx
@@ -5,6 +5,7 @@ import type { AgentInfo } from "@/lib/agent-coworker-types";
 import type { UserContext } from "@/lib/permissions";
 import { AgentSkillsDropdown } from "./AgentSkillsDropdown";
 import { SHELL_TAP_TARGET_CLASS } from "@/lib/shell/shell-action-contract";
+import type { CoworkerPresentationIdentity } from "@/lib/coworker-presentation/coo-name";
 
 function formatSensitivityLabel(value: AgentInfo["sensitivity"]): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
@@ -41,6 +42,7 @@ type Props = {
    * carried across a navigation.
    */
   routeContextLabel?: string;
+  presentationIdentity?: CoworkerPresentationIdentity;
 };
 
 /** A single action row inside the overflow menu. */
@@ -112,6 +114,7 @@ export function AgentPanelHeader({
   marketingSkillRules,
   isDocked = false,
   routeContextLabel,
+  presentationIdentity,
 }: Props) {
   const rootRef = useRef<HTMLDivElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -160,7 +163,7 @@ export function AgentPanelHeader({
               whiteSpace: "nowrap",
             }}
           >
-            {agent.agentName}
+            {presentationIdentity?.primaryName ?? agent.agentName}
           </span>
           <AgentSkillsDropdown
             skills={agent.skills}
@@ -173,6 +176,11 @@ export function AgentPanelHeader({
           />
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 6, marginLeft: 12, minWidth: 0 }}>
+          {presentationIdentity?.roleName && (
+            <span style={{ fontSize: 10, color: "var(--dpf-muted)", flex: "0 0 auto" }}>
+              {presentationIdentity.roleName}
+            </span>
+          )}
           {routeContextLabel && (
             <span
               data-testid="panel-route-context"

--- a/apps/web/components/agent/MicButton.tsx
+++ b/apps/web/components/agent/MicButton.tsx
@@ -113,15 +113,15 @@ export function MicButton(props: MicButtonProps) {
     ariaLabel = "Stop dictation";
     title = "Click to stop dictation";
     dataState = "recording";
-    iconColor = "var(--dpf-error, #d33)";
-    borderColor = "var(--dpf-error, #d33)";
+    iconColor = "var(--dpf-error)";
+    borderColor = "var(--dpf-error)";
   } else if (isError) {
     icon = <Mic size={16} />;
     ariaLabel = "Voice input error — click to retry";
     title = errorMessage ?? "Voice input failed. Click to retry.";
     dataState = "error";
-    iconColor = "var(--dpf-error, #d33)";
-    borderColor = "var(--dpf-error, #d33)";
+    iconColor = "var(--dpf-error)";
+    borderColor = "var(--dpf-error)";
   } else {
     // idle / result
     icon = <Mic size={16} />;
@@ -152,8 +152,8 @@ export function MicButton(props: MicButtonProps) {
         style={{
           position: "relative",
           background: isRecording
-            ? "color-mix(in srgb, var(--dpf-error, #d33) 15%, transparent)"
-            : "var(--dpf-surface-2, #f3f3f3)",
+            ? "color-mix(in srgb, var(--dpf-error) 15%, transparent)"
+            : "var(--dpf-surface-2)",
           border: `1px solid ${borderColor}`,
           borderRadius: 6,
           padding: "0 8px",
@@ -180,7 +180,7 @@ export function MicButton(props: MicButtonProps) {
               width: 6,
               height: 6,
               borderRadius: "50%",
-              background: "var(--dpf-error, #d33)",
+              background: "var(--dpf-error)",
               animation: "dpf-voice-pulse 1.2s ease-in-out infinite",
             }}
           />

--- a/apps/web/components/agent/hooks/useVoiceSynth.test.ts
+++ b/apps/web/components/agent/hooks/useVoiceSynth.test.ts
@@ -59,10 +59,10 @@ describe("useVoiceSynth (streaming)", () => {
     const readable = new ReadableStream({
       start(controller) { controller.enqueue(chunk); controller.close() },
     })
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true, body: readable,
-      headers: new Headers({ "X-Sentence-Count": "1" }),
-    }) as unknown as typeof fetch
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => String(input).includes("service-status")
+      ? new Response(JSON.stringify({ available: true, state: "ready", reason: null }), { status: 200 })
+      : ({ ok: true, body: readable, headers: new Headers({ "X-Sentence-Count": "1" }) } as Response)
+    ) as typeof fetch
 
     const { result } = renderHook(() => useVoiceSynth())
     await act(async () => { await result.current.synthesize("Hello world") })
@@ -74,23 +74,27 @@ describe("useVoiceSynth (streaming)", () => {
   })
 
   it("marks available false on 503 tts_unavailable", async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: false, status: 503,
-      json: () => Promise.resolve({ code: "tts_unavailable" }),
-    }) as unknown as typeof fetch
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => String(input).includes("service-status")
+      ? new Response(JSON.stringify({ available: true, state: "ready", reason: null }), { status: 200 })
+      : ({ ok: false, status: 503, json: () => Promise.resolve({ code: "tts_unavailable" }) } as Response)
+    ) as typeof fetch
 
     const { result } = renderHook(() => useVoiceSynth())
+    await waitFor(() => expect(result.current.checking).toBe(false))
     await act(async () => { await result.current.synthesize("Hello") })
 
     await waitFor(() => {
       expect(result.current.available).toBe(false)
-      expect(result.current.unavailableReason).toBe("Text-to-speech service is not running.")
+      expect(result.current.unavailableReason).toBe("Text-to-speech is unavailable.")
     })
   })
 
   it("stop() aborts the stream and clears state", async () => {
     let abortCalled = false
-    global.fetch = vi.fn().mockImplementation((_url: string, opts: RequestInit) => {
+    global.fetch = vi.fn().mockImplementation((url: string, opts: RequestInit) => {
+      if (url.includes("service-status")) {
+        return Promise.resolve(new Response(JSON.stringify({ available: true, state: "ready", reason: null }), { status: 200 }))
+      }
       (opts.signal as AbortSignal).addEventListener("abort", () => { abortCalled = true })
       return new Promise(() => {})
     }) as unknown as typeof fetch
@@ -102,5 +106,37 @@ describe("useVoiceSynth (streaming)", () => {
     expect(abortCalled).toBe(true)
     expect(result.current.isPlaying).toBe(false)
     expect(result.current.isSynthesizing).toBe(false)
+  })
+
+  it("probes playback capability on mount before enabling the speaker", async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({
+      available: false,
+      state: "profile_missing",
+      reason: "No ready voice profile is available.",
+    }), { status: 200 })) as typeof fetch
+
+    const { result } = renderHook(() => useVoiceSynth())
+    expect(result.current.checking).toBe(true)
+    expect(result.current.available).toBe(false)
+    await waitFor(() => expect(result.current.checking).toBe(false))
+    expect(result.current.readinessState).toBe("profile_missing")
+    expect(result.current.unavailableReason).toMatch(/No ready voice profile/)
+  })
+
+  it("requests preview readiness without requiring narration to be enabled", async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({
+      available: true,
+      state: "ready",
+      reason: null,
+    }), { status: 200 })) as typeof fetch
+
+    const { result } = renderHook(() => useVoiceSynth({ purpose: "preview" }))
+    await waitFor(() => expect(result.current.checking).toBe(false))
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/voice/service-status?purpose=preview",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+    expect(result.current.available).toBe(true)
   })
 })

--- a/apps/web/components/agent/hooks/useVoiceSynth.ts
+++ b/apps/web/components/agent/hooks/useVoiceSynth.ts
@@ -1,6 +1,7 @@
 "use client"
 
-import { useCallback, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { VoicePlaybackState } from "@/lib/voice-synthesis/service-status"
 
 // Minimal valid silent WAV (44-byte header, zero samples). Used to unlock the
 // AudioContext within the user-gesture call stack so scheduled playback is not
@@ -15,12 +16,17 @@ export interface VoiceSynthSettings {
   temperature?: number
 }
 
+export interface VoiceSynthOptions {
+  purpose?: "coworker" | "preview"
+}
+
 export interface VoiceSynthHook {
   synthesize: (text: string, voiceProfileId?: string, settings?: VoiceSynthSettings) => Promise<void>
   isPlaying: boolean
   isSynthesizing: boolean
-  /** false when synthesis cannot run until service/configuration changes */
   available: boolean
+  checking: boolean
+  readinessState: VoicePlaybackState | "checking"
   unavailableReason: string | null
   lastErrorCode: string | null
   stop: () => void
@@ -29,12 +35,12 @@ export interface VoiceSynthHook {
 function getUnavailableReason(code: string | undefined): string | null {
   switch (code) {
     case "tts_unavailable":
-      return "Text-to-speech service is not running."
+      return "Text-to-speech is unavailable."
     case "reference_missing":
-      return "Reference voice sample is missing. Replace or re-register the voice sample."
+      return "Reference voice sample is missing. Replace it."
     case "no_voice_profile":
     case "voice_profile_not_ready":
-      return "No ready voice profile is available."
+      return "No ready voice profile."
     default:
       return null
   }
@@ -75,10 +81,12 @@ function parseNextChunk(buf: Uint8Array<ArrayBuffer>): { wav: ArrayBuffer; rest:
  * Autoplay unlock: AudioContext.resume() is called synchronously within the
  * user-gesture call stack before any await, satisfying Safari/Chrome policy.
  */
-export function useVoiceSynth(): VoiceSynthHook {
+export function useVoiceSynth(options: VoiceSynthOptions = {}): VoiceSynthHook {
   const [isSynthesizing, setIsSynthesizing] = useState(false)
   const [isPlaying, setIsPlaying] = useState(false)
-  const [available, setAvailable] = useState(true)
+  const [available, setAvailable] = useState(false)
+  const [checking, setChecking] = useState(true)
+  const [readinessState, setReadinessState] = useState("checking" as VoicePlaybackState | "checking")
   const [unavailableReason, setUnavailableReason] = useState<string | null>(null)
   const [lastErrorCode, setLastErrorCode] = useState<string | null>(null)
 
@@ -90,6 +98,28 @@ export function useVoiceSynth(): VoiceSynthHook {
   const nextStartRef = useRef<number>(0)
   // AbortController for the current fetch stream.
   const abortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const statusUrl = options.purpose === "preview"
+      ? "/api/voice/service-status?purpose=preview"
+      : "/api/voice/service-status"
+    void fetch(statusUrl, { signal: controller.signal })
+      .then(async (response) => response.ok ? response.json() : Promise.reject())
+      .then((status: { available: boolean; state: VoicePlaybackState; reason: string | null }) => {
+        setAvailable(status.available)
+        setReadinessState(status.state)
+        setUnavailableReason(status.reason)
+      })
+      .catch((error) => {
+        if (error instanceof Error && error.name === "AbortError") return
+        setAvailable(false)
+        setReadinessState("service_unavailable")
+        setUnavailableReason(getUnavailableReason("tts_unavailable"))
+      })
+      .finally(() => setChecking(false))
+    return () => controller.abort()
+  }, [options.purpose])
 
   const stop = useCallback(() => {
     // Cancel the in-flight fetch.
@@ -155,6 +185,7 @@ export function useVoiceSynth(): VoiceSynthHook {
           setLastErrorCode(code ?? null)
           if (reason) {
             setAvailable(false)
+            setReadinessState(code === "no_voice_profile" || code === "voice_profile_not_ready" ? "profile_missing" : "service_unavailable")
             setUnavailableReason(reason)
           }
           console.warn("[useVoiceSynth] stream synthesis failed", res.status, json)
@@ -162,6 +193,7 @@ export function useVoiceSynth(): VoiceSynthHook {
         }
 
         setAvailable(true)
+        setReadinessState("ready")
         setUnavailableReason(null)
         setLastErrorCode(null)
 
@@ -246,5 +278,5 @@ export function useVoiceSynth(): VoiceSynthHook {
     [stop],
   )
 
-  return { synthesize, isPlaying, isSynthesizing, available, unavailableReason, lastErrorCode, stop }
+  return { synthesize, isPlaying, isSynthesizing, available, checking, readinessState, unavailableReason, lastErrorCode, stop }
 }

--- a/apps/web/components/platform/BuildStudioConfigForm.test.ts
+++ b/apps/web/components/platform/BuildStudioConfigForm.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { shouldShowPinnedEngineMissingWarning } from "@/components/platform/build-studio-config-form-model";
+import {
+  describeBuildEngineSelection,
+  shouldShowPinnedEngineMissingWarning,
+} from "@/components/platform/build-studio-config-form-model";
 import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "@/components/platform/build-studio-route-copy";
 
 describe("Build Studio runtime route copy", () => {
@@ -12,6 +15,30 @@ describe("Build Studio runtime route copy", () => {
 });
 
 describe("Build Studio engine readiness projection", () => {
+  it("projects variable router diagnostics into stable owner-facing readiness", () => {
+    expect(describeBuildEngineSelection({
+      status: "selected",
+      policy: { mode: "auto", pinnedEngine: null },
+      selected: null,
+      reason: "No eligible endpoints for task type 'code-gen' with sensitivity 'development'. 0 endpoint(s) excluded.",
+      rejected: [],
+      fallbackChain: [],
+      fallbackDisabled: false,
+      action: null,
+    })).toBe("Ready under current routing and policy.");
+
+    expect(describeBuildEngineSelection({
+      status: "blocked",
+      policy: { mode: "auto", pinnedEngine: null },
+      selected: null,
+      reason: "Internal routing diagnostic with provider identifiers.",
+      rejected: [],
+      fallbackChain: [],
+      fallbackDisabled: false,
+      action: "Connect a provider.",
+    })).toBe("No engine currently meets readiness and policy.");
+  });
+
   it("does not describe a legacy engine choice as selected while Auto chose another engine", () => {
     expect(shouldShowPinnedEngineMissingWarning({
       enginePolicy: "auto",

--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -14,7 +14,7 @@ import {
   ProviderRadio,
   type EngineReadinessBadge,
 } from "./BuildStudioProviderControls";
-import { CLAUDE_MODELS, describeOpenCodeProvider, shouldShowPinnedEngineMissingWarning, type BuildStudioConfigFormProps } from "./build-studio-config-form-model";
+import { CLAUDE_MODELS, describeBuildEngineSelection, describeOpenCodeProvider, shouldShowPinnedEngineMissingWarning, type BuildStudioConfigFormProps } from "./build-studio-config-form-model";
 
 export function BuildStudioConfigForm({
   config,
@@ -330,7 +330,7 @@ export function BuildStudioConfigForm({
           <span>
             <strong style={{ color: "var(--dpf-text)", fontSize: 12 }}>Auto (recommended)</strong>
             <span style={{ display: "block", color: "var(--dpf-muted)", fontSize: 11, marginTop: 2 }}>
-              Selected now: {config.selection?.selected?.engine ?? config.provider}. {config.selection?.reason ?? "Selection updates from live readiness and routing evidence."}
+              Selected now: {config.selection?.selected?.engine ?? config.provider}. {describeBuildEngineSelection(config.selection)}
             </span>
             {config.selection && config.selection.fallbackChain.length > 0 && (
               <span style={{ display: "block", color: "var(--dpf-muted)", fontSize: 10, marginTop: 2 }}>

--- a/apps/web/components/platform/OAuthConnectionStatus.test.tsx
+++ b/apps/web/components/platform/OAuthConnectionStatus.test.tsx
@@ -23,6 +23,7 @@ function credentialFixture(overrides: Partial<CredentialRow> = {}): CredentialRo
     status: "ok",
     tokenExpiresAt: null,
     hasRefreshToken: false,
+    hasUsableMaterial: true,
     ...overrides,
   };
 }

--- a/apps/web/components/platform/ProviderDetailForm.test.tsx
+++ b/apps/web/components/platform/ProviderDetailForm.test.tsx
@@ -68,6 +68,7 @@ const providerFixture: ProviderWithCredential = {
     status: "ok",
     tokenExpiresAt: null,
     hasRefreshToken: false,
+    hasUsableMaterial: true,
   },
 };
 

--- a/apps/web/components/platform/build-studio-config-form-model.ts
+++ b/apps/web/components/platform/build-studio-config-form-model.ts
@@ -46,3 +46,19 @@ export function shouldShowPinnedEngineMissingWarning(input: {
     && !input.probing
     && input.present === false;
 }
+
+/**
+ * Keep the owner-facing readiness line stable and legible. The routing reason is
+ * diagnostic evidence: it can contain task-type, sensitivity, endpoint counts,
+ * and provider identifiers, and its wording changes as the candidate pool does.
+ * Build Studio retains that evidence on `config.selection`; the first viewport
+ * answers only whether the resolved engine is ready under the current contract.
+ */
+export function describeBuildEngineSelection(
+  selection: BuildStudioDispatchConfig["selection"],
+): string {
+  if (!selection) return "Selection updates from live readiness evidence.";
+  return selection.status === "selected"
+    ? "Ready under current routing and policy."
+    : "No engine currently meets readiness and policy.";
+}

--- a/apps/web/components/wiki/VoiceProfileSetup.tsx
+++ b/apps/web/components/wiki/VoiceProfileSetup.tsx
@@ -61,7 +61,7 @@ export function VoiceProfileSetup({
   const [enabled, setEnabled] = useState(voiceEnabled)
   const [isPending, startTransition] = useTransition()
   const [resetting, setResetting] = useState(false)
-  const voiceSynth = useVoiceSynth()
+  const voiceSynth = useVoiceSynth({ purpose: "preview" })
 
   // Per-profile voice tuning (sliders). Seed from saved settings, else defaults.
   const [tuning, setTuning] = useState<Required<VoiceTuning>>({

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -561,8 +561,7 @@ export async function sendMessage(input: {
     take: RECENT_WINDOW,
     select: { id: true, role: true, content: true },
   });
-  // Token-aware trimming: keep newest messages up to a token budget.
-  // Prevents 8 long messages from overwhelming context.
+  // Keep newest messages within a token budget.
   const CHAT_HISTORY_TOKEN_BUDGET = isBuildPhase ? 4000 : 2000;
   const reversed = recentMessages.reverse();
   let historyTokens = 0;
@@ -574,7 +573,6 @@ export async function sendMessage(input: {
     trimmedMessages.unshift(reversed[i]!);
     historyTokens += msgTokens;
   }
-  // Track message IDs for semantic recall dedup
   const windowMessageIds = new Set(trimmedMessages.map((m) => m.id));
   let chatHistory: ChatMessage[] = trimmedMessages.map((m) => ({
     role: m.role as ChatMessage["role"],
@@ -620,10 +618,12 @@ export async function sendMessage(input: {
     }
   }
   const recentContentForClassification = chatHistory
+    .filter((m) => m.role === "user")
     .slice(-3)
     .map((m) => typeof m.content === "string" ? m.content : JSON.stringify(m.content));
   const taskClassification = classifyTask(trimmedContent, recentContentForClassification);
   let taskTypeId: string = taskClassification.taskType;
+  if (taskTypeId === "onboarding" && !input.routeContext.startsWith("/setup")) taskTypeId = "unknown";
 
   // Enrich the last user message with file content so the LLM sees it inline,
   // not just in the system prompt. LLMs pay more attention to message content
@@ -1737,6 +1737,7 @@ export async function sendMessage(input: {
   let responseContent = "";
   let responseProviderId: string | null = null;
   let responseModelId: string | null = null;
+  let responseIsSystemFailure = false;
   let formAssistUpdate: Record<string, unknown> | undefined;
   let systemMessage: AgentMessageRow | undefined;
   // Pre-allocate the assistant AgentMessage id so adapter telemetry rows
@@ -2009,10 +2010,7 @@ export async function sendMessage(input: {
       return { userMessage: serializeMessage(userMsg), agentMessage: serializeMessage(agentMsg, proposal) };
     }
 
-    // Map agentic result to the downstream shape. The Golden Triangle review runs
-    // inside executeAutonomousAgenticLoop — the single seam
-    // for both chat and autonomous turns — so agenticResult.content is already
-    // reviewed when the coworker's posture calls for it.)
+    // The Golden Triangle review already ran inside executeAutonomousAgenticLoop.
     const result = {
       content: agenticResult.content,
       providerId: agenticResult.providerId,
@@ -2024,6 +2022,7 @@ export async function sendMessage(input: {
       inferenceMs: 0,
       toolCalls: undefined as undefined, // already handled by loop
     };
+    responseIsSystemFailure = Boolean(agenticResult.failure);
 
     // Caveat a blind local answer, but not one grounded in authoritative ASC state.
     responseContent = applyLocalDegradationCaveat(result.content, {
@@ -2393,18 +2392,17 @@ export async function sendMessage(input: {
     }
   }
 
-  // Persist agent response
   const agentMsg = await prisma.agentMessage.create({
     data: {
       id: pendingAgentMessageId,
       threadId: input.threadId,
-      role: "assistant",
+      role: responseIsSystemFailure ? "system" : "assistant",
       taskRunId: currentTaskRun?.taskRunId ?? null,
       content: responseContent,
-      agentId: agent.agentId,
+      agentId: responseIsSystemFailure ? null : agent.agentId,
       routeContext: input.routeContext,
-      providerId: responseProviderId,
-      modelId: responseModelId,
+      providerId: responseIsSystemFailure ? null : responseProviderId,
+      modelId: responseIsSystemFailure ? null : responseModelId,
       taskType: taskTypeId !== "unknown" ? taskTypeId : null,
       routedEndpointId: null, // EP-INF-009b: routing is per-iteration via routeAndCall
       contextTrace, // BI-3E218D80 — plain-response path (see also the proposal write)
@@ -2456,7 +2454,7 @@ export async function sendMessage(input: {
       storeConversationMemory({ ...memBase, messageId: userMsg.id, content: trimmedContent, role: "user" })
         .catch((e) => console.warn("[memory-store] user:", getErrorMessage(e)));
     }
-    if (isSubstantive(responseContent)) {
+    if (isSubstantive(responseContent) && !responseIsSystemFailure) {
       storeConversationMemory({ ...memBase, messageId: agentMsg.id, content: responseContent, role: "assistant" })
         .catch((e) => console.warn("[memory-store] assistant:", getErrorMessage(e)));
     }

--- a/apps/web/lib/coworker-presentation/coo-name.test.ts
+++ b/apps/web/lib/coworker-presentation/coo-name.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   COO_NAME_SUGGESTION_GROUPS,
   resolveCooPresentationName,
+  resolveCooPresentationIdentity,
   validateCooConversationalName,
 } from "./coo-name";
 
@@ -77,5 +78,13 @@ describe("COO conversational-name policy", () => {
       canonicalName: "COO",
       conversationalName: null,
     })).toBe("COO");
+  });
+
+  it("separates a standing COO's conversational name from the role", () => {
+    expect(resolveCooPresentationIdentity({
+      agentId: "AGT-ORCH-000",
+      canonicalName: "COO",
+      conversationalName: "Coolio",
+    })).toEqual({ primaryName: "Coolio", roleName: "AI COO" });
   });
 });

--- a/apps/web/lib/coworker-presentation/coo-name.ts
+++ b/apps/web/lib/coworker-presentation/coo-name.ts
@@ -73,6 +73,27 @@ export function isStandingCooAgentId(agentId: string | null | undefined): boolea
   return agentId === "AGT-ORCH-000" || agentId === "coo";
 }
 
+export type CoworkerPresentationIdentity = {
+  primaryName: string;
+  roleName: string | null;
+};
+
+export function resolveCooPresentationIdentity({
+  agentId,
+  canonicalName,
+  conversationalName,
+}: {
+  agentId: string | null | undefined;
+  canonicalName: string;
+  conversationalName: string | null | undefined;
+}): CoworkerPresentationIdentity {
+  if (!isStandingCooAgentId(agentId)) return { primaryName: canonicalName, roleName: null };
+  const primaryName = normalizeCooConversationalName(conversationalName);
+  return primaryName
+    ? { primaryName, roleName: "AI COO" }
+    : { primaryName: canonicalName, roleName: null };
+}
+
 export function resolveCooPresentationName({
   agentId,
   canonicalName,
@@ -82,9 +103,8 @@ export function resolveCooPresentationName({
   canonicalName: string;
   conversationalName: string | null | undefined;
 }): string {
-  if (!isStandingCooAgentId(agentId)) return canonicalName;
-  const normalized = normalizeCooConversationalName(conversationalName);
-  return normalized ? `${normalized} · AI COO` : canonicalName;
+  const identity = resolveCooPresentationIdentity({ agentId, canonicalName, conversationalName });
+  return identity.roleName ? `${identity.primaryName} · ${identity.roleName}` : identity.primaryName;
 }
 
 export function presentStandingCoo<T extends { agentId: string; agentName: string }>(

--- a/apps/web/lib/inference/ai-provider-data.test.ts
+++ b/apps/web/lib/inference/ai-provider-data.test.ts
@@ -47,6 +47,34 @@ import {
 beforeEach(() => { vi.clearAllMocks(); });
 
 describe("getProviders", () => {
+  it("distinguishes an empty credential row from usable dispatch material", async () => {
+    mockPrisma.modelProvider.findMany.mockResolvedValue([{
+      providerId: "openai",
+      name: "OpenAI",
+      families: [],
+      enabledFamilies: [],
+      supportedAuthMethods: ["api_key"],
+      catalogVisibility: "visible",
+      sensitivityClearance: [],
+      taskTags: [],
+    }]);
+    mockPrisma.credentialEntry.findMany.mockResolvedValue([{
+      providerId: "openai",
+      secretRef: null,
+      clientId: null,
+      clientSecret: null,
+      cachedToken: null,
+      tokenEndpoint: null,
+      scope: null,
+      status: "ok",
+      tokenExpiresAt: null,
+      refreshToken: null,
+    }]);
+
+    const result = await getProviders();
+    expect(result[0]?.credential?.hasUsableMaterial).toBe(false);
+  });
+
   it("does not include hidden execution endpoints in the normal provider catalog", async () => {
     mockPrisma.modelProvider.findMany.mockResolvedValue([
       {

--- a/apps/web/lib/inference/ai-provider-data.ts
+++ b/apps/web/lib/inference/ai-provider-data.ts
@@ -36,6 +36,7 @@ function maskCredential(cred: {
   secretRef: string | null;
   clientId: string | null;
   clientSecret: string | null;
+  cachedToken?: string | null;
   tokenEndpoint: string | null;
   scope: string | null;
   status: string;
@@ -52,6 +53,9 @@ function maskCredential(cred: {
     status:           cred.status,
     tokenExpiresAt:   cred.tokenExpiresAt?.toISOString() ?? null,
     hasRefreshToken:  cred.refreshToken != null && cred.refreshToken !== "",
+    hasUsableMaterial: Boolean(
+      cred.secretRef || cred.clientSecret || cred.cachedToken || cred.refreshToken,
+    ),
   };
 }
 

--- a/apps/web/lib/inference/ai-provider-types.ts
+++ b/apps/web/lib/inference/ai-provider-types.ts
@@ -101,6 +101,8 @@ export type CredentialRow = {
   status: string;
   tokenExpiresAt: string | null;
   hasRefreshToken: boolean;
+  /** Whether the row contains material that can authenticate a dispatch. */
+  hasUsableMaterial: boolean;
 };
 
 export type ProviderWithCredential = {

--- a/apps/web/lib/inference/provider-reconciliation.test.ts
+++ b/apps/web/lib/inference/provider-reconciliation.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  ProviderReconciliationRequiredError,
   shouldDegradeModelForInterfaceDrift,
   shouldReconcileProviderAfterError,
+  withProviderReconciliationRetry,
 } from "./provider-reconciliation";
 
 describe("provider reconciliation heuristics", () => {
@@ -39,5 +41,21 @@ describe("provider reconciliation heuristics", () => {
     expect(
       shouldReconcileProviderAfterError("network", "ECONNRESET"),
     ).toBe(false);
+  });
+
+  it("retries one route build after reconciliation and never loops", async () => {
+    const reconcile = vi.fn();
+    const attempt = vi.fn()
+      .mockRejectedValueOnce(new ProviderReconciliationRequiredError(["openai"], []))
+      .mockResolvedValueOnce("recovered");
+
+    await expect(withProviderReconciliationRetry(attempt, reconcile)).resolves.toBe("recovered");
+    expect(attempt).toHaveBeenCalledTimes(2);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+
+    attempt.mockReset().mockRejectedValue(new ProviderReconciliationRequiredError(["openai"], []));
+    await expect(withProviderReconciliationRetry(attempt, reconcile))
+      .rejects.toBeInstanceOf(ProviderReconciliationRequiredError);
+    expect(attempt).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/lib/inference/provider-reconciliation.ts
+++ b/apps/web/lib/inference/provider-reconciliation.ts
@@ -14,6 +14,39 @@ const INTERFACE_DRIFT_PATTERNS = [
   /does not support[^.]*response/i,
 ];
 
+/** Signals that model discovery changed the candidate pool and routing may retry once. */
+export class ProviderReconciliationRequiredError extends Error {
+  readonly providerIds: string[];
+
+  constructor(providerIds: Iterable<string>, attempts: unknown) {
+    const ids = [...new Set(providerIds)];
+    super(`Provider model inventory changed for ${ids.join(", ")}. Attempts: ${JSON.stringify(attempts)}`);
+    this.name = "ProviderReconciliationRequiredError";
+    this.providerIds = ids;
+  }
+}
+
+export function isProviderReconciliationRequiredError(
+  error: unknown,
+): error is ProviderReconciliationRequiredError {
+  return error instanceof ProviderReconciliationRequiredError
+    || (typeof error === "object" && error !== null
+      && "name" in error && error.name === "ProviderReconciliationRequiredError");
+}
+
+export async function withProviderReconciliationRetry<T>(
+  attempt: () => Promise<T>,
+  beforeRetry: () => void,
+): Promise<T> {
+  try {
+    return await attempt();
+  } catch (error) {
+    if (!isProviderReconciliationRequiredError(error)) throw error;
+    beforeRetry();
+    return attempt();
+  }
+}
+
 export function shouldDegradeModelForInterfaceDrift(
   code: string,
   message: string,

--- a/apps/web/lib/inference/routed-inference.activity-overrides.test.ts
+++ b/apps/web/lib/inference/routed-inference.activity-overrides.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   loadEndpointManifests: vi.fn(),
   loadPolicyRules: vi.fn(),
   loadOverrides: vi.fn(),
+  invalidateRoutingLoaderCache: vi.fn(),
   persistRouteDecision: vi.fn(),
   updateProviderSuitabilityReceipt: vi.fn(),
   inferContract: vi.fn(),
@@ -34,6 +35,7 @@ vi.mock("@/lib/routing/loader", () => ({
   loadEndpointManifests: mocks.loadEndpointManifests,
   loadPolicyRules: mocks.loadPolicyRules,
   loadOverrides: mocks.loadOverrides,
+  invalidateRoutingLoaderCache: mocks.invalidateRoutingLoaderCache,
   persistRouteDecision: mocks.persistRouteDecision,
   // Mirror the real gating so the persistDecision:false test observes the
   // same contract the production helper enforces (BI-F4D3B9E9(c)).
@@ -77,6 +79,7 @@ vi.mock("@/lib/routing/provider-suitability/provider-onboarding-data", () => ({
 
 import { routeAndCall } from "./routed-inference";
 import { previewRoute } from "./routed-inference";
+import { ProviderReconciliationRequiredError } from "./provider-reconciliation";
 
 describe("routeAndCall activity harness overrides", () => {
   beforeEach(() => {
@@ -272,6 +275,48 @@ describe("routeAndCall activity harness overrides", () => {
     expect(mocks.logTokenUsage).toHaveBeenCalledWith(
       expect.objectContaining({ inferenceMs: 1234 }),
     );
+  });
+
+  it("rebuilds the route once after provider model reconciliation", async () => {
+    mocks.callWithFallbackChain
+      .mockRejectedValueOnce(new ProviderReconciliationRequiredError(["openai"], []))
+      .mockResolvedValueOnce({
+        providerId: "openai",
+        modelId: "gpt-4o-mini",
+        content: "recovered",
+        toolCalls: [],
+        tokenUsage: { inputTokens: 12, outputTokens: 4 },
+        inferenceMs: 12,
+        downgraded: false,
+        downgradeMessage: null,
+      });
+
+    const result = await routeAndCall(
+      [{ role: "user", content: "Continue" }],
+      "You help.",
+      "internal",
+      { taskType: "conversation", persistDecision: false },
+    );
+
+    expect(result.content).toBe("recovered");
+    expect(mocks.invalidateRoutingLoaderCache).toHaveBeenCalledTimes(1);
+    expect(mocks.loadEndpointManifests).toHaveBeenCalledTimes(2);
+    expect(mocks.callWithFallbackChain).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not loop when the rebuilt route also requests reconciliation", async () => {
+    mocks.callWithFallbackChain.mockRejectedValue(
+      new ProviderReconciliationRequiredError(["openai"], []),
+    );
+
+    await expect(routeAndCall(
+      [{ role: "user", content: "Continue" }],
+      "You help.",
+      "internal",
+      { taskType: "conversation", persistDecision: false },
+    )).rejects.toBeInstanceOf(ProviderReconciliationRequiredError);
+
+    expect(mocks.callWithFallbackChain).toHaveBeenCalledTimes(2);
   });
 
   it("keeps preview routing deterministic by not loading approved overrides", async () => {

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -21,9 +21,11 @@ import {
   loadEndpointManifests,
   loadPolicyRules,
   loadOverrides,
+  invalidateRoutingLoaderCache,
   persistRouteDecision,
   persistFailedRouteDecision,
 } from "@/lib/routing/loader";
+import { withProviderReconciliationRetry } from "@/lib/inference/provider-reconciliation";
 import { routeEndpointV2 } from "@/lib/routing/pipeline-v2";
 import {
   ACTIVITY_HARNESS_CONFIDENCE_OVERRIDE_ACTION,
@@ -353,12 +355,8 @@ export async function previewRoute(
 /**
  * Route and execute an LLM inference call through the V2 pipeline.
  *
- * This is the sole entry point for inference after EP-INF-009b.
- * It replaces `callWithFailover` by running:
- *   1. Contract inference (from task type + messages)
- *   2. Endpoint manifest loading
- *   3. V2 routing (capability filter, cost-per-success ranking, recipes)
- *   4. Fallback chain dispatch
+ * This is the sole inference entry point after EP-INF-009b: contract,
+ * manifests, V2 routing, then fallback dispatch.
  *
  * Throws `NoEligibleEndpointsError` if no endpoints qualify — no silent
  * degradation to a different routing mechanism.
@@ -368,6 +366,18 @@ export async function routeAndCall(
   systemPrompt: string,
   sensitivity: RouteSensitivity = "internal",
   options?: RouteAndCallOptions,
+): Promise<RoutedInferenceResult> {
+  return withProviderReconciliationRetry(
+    () => routeAndCallAttempt(messages, systemPrompt, sensitivity, options),
+    invalidateRoutingLoaderCache,
+  );
+}
+
+async function routeAndCallAttempt(
+  messages: ChatMessage[],
+  systemPrompt: string,
+  sensitivity: RouteSensitivity,
+  options: RouteAndCallOptions | undefined,
 ): Promise<RoutedInferenceResult> {
   // 1-3. Contract inference, routing-data load, and V2 endpoint selection —
   // shared with previewRoute() via prepareRoute() so a model-selection
@@ -632,10 +642,7 @@ export async function routeAndCall(
       };
     }
 
-    // Adapter didn't return operation ID — treat as sync result.
-    // Phase J (BI-28858D2F follow-up / cost-ledger): every dispatch persists
-    // a TokenUsage row regardless of which adapter served it. The CLI
-    // subprocess paths (claude-cli, codex-cli) previously bypassed this.
+    // Every adapter dispatch persists TokenUsage (BI-28858D2F).
     void persistRoutedTokenUsage({
       traceId,
       agentId: options?.agentId ?? "unknown",
@@ -680,16 +687,8 @@ export async function routeAndCall(
 
   // 5c. Local-fallback signal.
   //
-  // The fallback chain sets downgraded=true when i>0 (we skipped the winner
-  // due to failure). That covers the "preferred provider rate-limited, fell
-  // to local" case. But when the pipeline's STAGE-5b tier sort lands on
-  // bundled because all user_configured endpoints were already excluded
-  // (status=unconfigured/disabled, hard-constraint violations, etc.), i=0
-  // and downgraded stays false — so the user has no signal that the turn
-  // ran on the local model. Patch that gap here so the observability is
-  // correct regardless of whether we fell through at ranking or runtime.
-  // `decision.selectedEndpoint` is a string id — look up the corresponding
-  // manifest to read its tier. `manifests` is already in scope.
+  // Runtime fallback marks i>0 as downgraded. Ranking can select bundled at
+  // i=0 after excluding configured endpoints, so detect that case here.
   const selectedManifest = decision.selectedEndpoint
     ? manifests.find((m) => m.id === decision.selectedEndpoint)
     : null;

--- a/apps/web/lib/routing/fallback.test.ts
+++ b/apps/web/lib/routing/fallback.test.ts
@@ -1,10 +1,4 @@
-/**
- * EP-INF-004: Fallback behavior tests — model-level degradation, auto-recovery,
- * rate tracking in the callWithFallbackChain dispatch loop.
- */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-// ── Mocks (must be declared before imports) ──────────────────────────────────
 
 vi.mock("@dpf/db", () => ({
   prisma: {
@@ -50,9 +44,6 @@ vi.mock("./rate-recovery", () => ({
   scheduleRecovery: vi.fn(),
 }));
 
-// BI-OPT-ROUTING-CACHE: fallback.ts busts the request-scoped routing-loader
-// cache when it degrades a model / cools an endpoint. Mock the loader so we can
-// assert the bust is wired without exercising the real DB-backed loaders.
 vi.mock("./loader", () => ({
   invalidateRoutingLoaderCache: vi.fn(),
 }));
@@ -61,8 +52,6 @@ vi.mock("@/lib/ai-provider-internals", () => ({
   autoDiscoverAndProfile: vi.fn(),
 }));
 
-// fallback.ts dynamically imports refreshOAuthToken to self-heal a lapsed OAuth
-// token on an auth error before disabling the provider.
 vi.mock("@/lib/provider-oauth", () => ({
   refreshOAuthToken: vi.fn(),
 }));
@@ -71,9 +60,8 @@ vi.mock("./route-outcome", () => ({
   recordRouteOutcome: vi.fn(() => Promise.resolve()),
 }));
 
-// ── Imports (after mocks) ────────────────────────────────────────────────────
-
 import { buildFallbackPlan, callWithFallbackChain } from "./fallback";
+import { ProviderReconciliationRequiredError } from "@/lib/inference/provider-reconciliation";
 import { prisma } from "@dpf/db";
 import { callProvider, InferenceError } from "@/lib/ai-inference";
 import {
@@ -90,8 +78,6 @@ import { recordRouteOutcome } from "./route-outcome";
 import { refreshOAuthToken } from "@/lib/provider-oauth";
 import type { RouteDecision } from "./types";
 import type { SensitivityLevel } from "./types";
-
-// ── Helpers ──────────────────────────────────────────────────────────────────
 
 const makeDecision = (providerId: string, modelId: string): RouteDecision => ({
   selectedEndpoint: providerId,
@@ -184,19 +170,15 @@ const mockClearEndpointUnavailable = clearEndpointUnavailable as ReturnType<type
 const mockInvalidateRoutingLoaderCache = invalidateRoutingLoaderCache as ReturnType<typeof vi.fn>;
 const mockRefreshOAuthToken = refreshOAuthToken as ReturnType<typeof vi.fn>;
 
-// ── Setup ────────────────────────────────────────────────────────────────────
-
 beforeEach(() => {
   vi.useFakeTimers();
   vi.clearAllMocks();
 
-  // Default: provider lookup returns a valid provider
   mockPrisma.modelProvider.findUnique.mockResolvedValue({
     providerId: "test-provider",
     name: "Test Provider",
   });
 
-  // Default: prisma writes succeed
   mockPrisma.modelProfile.updateMany.mockResolvedValue({ count: 1 });
   mockPrisma.modelProvider.update.mockResolvedValue({});
   mockAutoDiscoverAndProfile.mockResolvedValue({
@@ -205,10 +187,7 @@ beforeEach(() => {
   });
   mockRecordRouteOutcome.mockResolvedValue(undefined);
 
-  // Default: extractRetryAfterMs returns undefined (fallback to 60s)
   mockExtractRetryAfterMs.mockReturnValue(undefined);
-
-  // Default: OAuth token refresh succeeds
   mockRefreshOAuthToken.mockResolvedValue({ token: "fresh-token" });
 });
 
@@ -216,11 +195,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-// ── Tests ────────────────────────────────────────────────────────────────────
-
 describe("callWithFallbackChain — EP-INF-004 error handling", () => {
-  // ── Success path ─────────────────────────────────────────────────────────
-
   describe("successful call", () => {
     it("records request with token count on success", async () => {
       mockCallProvider.mockResolvedValue({
@@ -477,8 +452,6 @@ describe("callWithFallbackChain — EP-INF-004 error handling", () => {
     });
   });
 
-  // ── model_not_found ──────────────────────────────────────────────────────
-
   describe("model_not_found", () => {
     function throwModelNotFound() {
       const err = new InferenceError(
@@ -537,6 +510,32 @@ describe("callWithFallbackChain — EP-INF-004 error handling", () => {
       ).rejects.toThrow();
 
       expect(mockAutoDiscoverAndProfile).toHaveBeenCalledWith("prov1");
+    });
+
+    it("awaits reconciliation before requesting one fresh route", async () => {
+      let finishReconciliation!: () => void;
+      mockAutoDiscoverAndProfile.mockReturnValue(
+        new Promise((resolve) => {
+          finishReconciliation = () => resolve({ discovered: 1, profiled: 1 });
+        }),
+      );
+      throwModelNotFound();
+
+      const pending = callWithFallbackChain(
+        makeDecision("prov1", "model1"),
+        [{ role: "user", content: "hi" }],
+        "system",
+      );
+      let settled = false;
+      void pending.then(
+        () => { settled = true; },
+        () => { settled = true; },
+      );
+      await vi.waitFor(() => expect(mockAutoDiscoverAndProfile).toHaveBeenCalledWith("prov1"));
+      expect(settled).toBe(false);
+
+      finishReconciliation();
+      await expect(pending).rejects.toBeInstanceOf(ProviderReconciliationRequiredError);
     });
   });
 

--- a/apps/web/lib/routing/fallback.ts
+++ b/apps/web/lib/routing/fallback.ts
@@ -27,6 +27,7 @@ import { invalidateRoutingLoaderCache } from "./loader";
 import { recordRouteOutcome } from "./route-outcome";
 import { autoDiscoverAndProfile } from "@/lib/ai-provider-internals";
 import {
+  ProviderReconciliationRequiredError,
   shouldDegradeModelForInterfaceDrift,
   shouldReconcileProviderAfterError,
 } from "@/lib/inference/provider-reconciliation";
@@ -249,6 +250,7 @@ export async function callWithFallbackChain(
   });
 
   const attempts: Array<{ endpointId: string; error: string }> = [];
+  const reconciledProviders = new Set<string>();
   const capacityDeferrals: LocalProviderCapacityDeferredError[] = [];
   let rateLimitRetried = false;
   let overloadRetried = false;
@@ -509,7 +511,9 @@ export async function callWithFallbackChain(
             );
 
           if (shouldReconcileProviderAfterError(e.code, e.message)) {
-            autoDiscoverAndProfile(entry.providerId).catch((err) =>
+            await autoDiscoverAndProfile(entry.providerId).then(() => {
+              reconciledProviders.add(entry.providerId);
+            }).catch((err) =>
               console.error(
                 `[callWithFallbackChain] failed to reconcile ${entry.providerId} after model_not_found:`,
                 err,
@@ -628,6 +632,10 @@ export async function callWithFallbackChain(
 
   if (capacityDeferrals.length === chain.length) {
     throw capacityDeferrals.at(-1)!;
+  }
+
+  if (reconciledProviders.size > 0) {
+    throw new ProviderReconciliationRequiredError(reconciledProviders, attempts);
   }
 
   throw new Error(

--- a/apps/web/lib/routing/loader.test.ts
+++ b/apps/web/lib/routing/loader.test.ts
@@ -10,7 +10,7 @@ import type { InferenceDataScreenReceipt } from "@/lib/inference/data-screening/
 import type { RouteDecision } from "./types";
 import { MODEL_ROUTING_ENDPOINT_TYPES } from "./provider-eligibility";
 
-const { mockPrisma } = vi.hoisted(() => ({
+const { mockPrisma, mockProviderHasConfiguredCredential } = vi.hoisted(() => ({
   mockPrisma: {
     routeDecisionLog: {
       create: vi.fn().mockResolvedValue({ id: "decision-log-1" }),
@@ -25,9 +25,13 @@ const { mockPrisma } = vi.hoisted(() => ({
       findMany: vi.fn().mockResolvedValue([]),
     },
   },
+  mockProviderHasConfiguredCredential: vi.fn(),
 }));
 
 vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/ai-provider-internals", () => ({
+  providerHasConfiguredCredential: mockProviderHasConfiguredCredential,
+}));
 
 describe("persistRouteDecision", () => {
   beforeEach(() => {
@@ -122,6 +126,7 @@ describe("loadEndpointManifests", () => {
     vi.clearAllMocks();
     invalidateRoutingLoaderCache();
     mockPrisma.modelProfile.findMany.mockResolvedValue([]);
+    mockProviderHasConfiguredCredential.mockResolvedValue(true);
   });
 
   it("loads all model-routing endpoint types, including responses providers", async () => {
@@ -218,6 +223,31 @@ describe("routing-loader cache (BI-OPT-ROUTING-CACHE)", () => {
     mockPrisma.modelProfile.findMany.mockResolvedValue([profileRow]);
     mockPrisma.policyRule.findMany.mockResolvedValue([policyRow]);
     mockPrisma.endpointTaskPerformance.findMany.mockResolvedValue([overrideRow]);
+    mockProviderHasConfiguredCredential.mockResolvedValue(true);
+  });
+
+  it("excludes a credentialed provider that has no usable credential material", async () => {
+    mockPrisma.modelProfile.findMany.mockResolvedValue([
+      { ...profileRow, provider: { ...profileRow.provider, authMethod: "api_key" } },
+    ]);
+    mockProviderHasConfiguredCredential.mockResolvedValue(false);
+
+    expect(await loadEndpointManifests(900_000)).toEqual([]);
+    expect(mockProviderHasConfiguredCredential).toHaveBeenCalledWith("anthropic", "api_key");
+  });
+
+  it("keeps a no-auth local provider eligible", async () => {
+    mockPrisma.modelProfile.findMany.mockResolvedValue([
+      {
+        ...profileRow,
+        providerId: "docker-model-runner",
+        provider: { ...profileRow.provider, authMethod: "none" },
+      },
+    ]);
+
+    const manifests = await loadEndpointManifests(900_001);
+    expect(manifests).toHaveLength(1);
+    expect(mockProviderHasConfiguredCredential).toHaveBeenCalledWith("docker-model-runner", "none");
   });
 
   it("loads each loader's DB rows exactly once across a 200-iteration turn", async () => {

--- a/apps/web/lib/routing/loader.ts
+++ b/apps/web/lib/routing/loader.ts
@@ -3,6 +3,7 @@
  * Converts Prisma rows into the routing pipeline's type system.
  */
 import { prisma } from "@dpf/db";
+import { providerHasConfiguredCredential } from "@/lib/ai-provider-internals";
 import type {
   EndpointManifest,
   ProviderTier,
@@ -177,7 +178,19 @@ async function queryEndpointManifests(): Promise<EndpointManifest[]> {
     },
   });
 
-  return profiles.map((mp) => profileToManifest(mp));
+  const providers = new Map(
+    profiles.map((profile) => [profile.providerId, profile.provider.authMethod] as const),
+  );
+  const readiness = new Map(await Promise.all(
+    [...providers].map(async ([providerId, authMethod]) => [
+      providerId,
+      await providerHasConfiguredCredential(providerId, authMethod),
+    ] as const),
+  ));
+
+  return profiles
+    .filter((profile) => readiness.get(profile.providerId) === true)
+    .map((profile) => profileToManifest(profile));
 }
 
 type ProfileWithProvider = Awaited<

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -649,7 +649,6 @@ describe("runAgenticLoop", () => {
       agentId: "admin-assistant",
     });
 
-    // Genuine config gap → name the REAL surface, not the old "Model Assignment".
     expect(result.content).toContain("No AI model that supports tools is active");
     expect(result.content).toContain("Providers & Routing");
     expect(result.content).not.toContain("Model Assignment");
@@ -766,7 +765,7 @@ describe("runAgenticLoop", () => {
     expect(result.modelId).toBe("unknown");
   });
 
-  it("treats a generic all-endpoints-failed as a transient retry, not a config error", async () => {
+  it("types a rate-limited all-endpoints failure as busy", async () => {
     const mockRoute = vi.mocked(routeAndCall);
     mockRoute.mockRejectedValueOnce(new Error(
       'All endpoints failed for conversation. Attempts: [{"endpointId":"anthropic-sub","error":"429 rate limited"}]',
@@ -780,6 +779,7 @@ describe("runAgenticLoop", () => {
 
     expect(result.content).toMatch(/Nothing is misconfigured/); // BI-33F1EA72 hand-off
     expect(result.content).not.toContain("Model Assignment");
+    expect(result.failure?.kind).toBe("busy");
   });
 
   it("does not accept a max_tokens-truncated response as a complete answer — continues generation (BI-1D144CC1)", async () => {

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -59,10 +59,6 @@ import {
 // Re-export for importers (certification-oracles, tests) that pull from agentic-loop.
 export { detectToolRefusedDespiteAvailability } from "./tool-refused-recovery";
 
-// Safety ceiling — NOT a behavioral limit. The loop terminates when the model
-// responds with text only (no tool calls), matching the Anthropic API pattern
-// where the loop runs until stop_reason === "end_turn". This limit only prevents
-// runaway loops. The model decides when it's done.
 // Safety ceiling — the loop exits naturally when the model responds with text-only
 // (no tool calls). This limit only catches true infinite loops from bugs.
 // The actual guardrails are: sandbox circuit breaker, repetition detector, duration
@@ -102,7 +98,7 @@ export const HARD_COMPLETION_CLAIM_PATTERN =
   /\bI(?:'ve| have| just)?\s*(?:have\s+)?(?:saved|created|published|posted|sent|scheduled|recorded|queued|logged|added|drafted and saved|placed)\b|\b(?:saved|published|posted|sent|scheduled|queued|added|recorded)\s+(?:it|that|your|the)\b|\b(?:is|are|has been|have been)\s+(?:now\s+)?(?:live|saved|published|sent|scheduled|posted|queued|recorded)\b|in\s+(?:your\s+)?approval\s+queue|\b(?:prospect\s+)?account\s+created\b|\bACCT-[A-Z0-9]{4,}\b/i;
 
 // The dead-end classifier and its copy live in ./inference-dead-ends (BI-A89E4827).
-import { describeToolRouteFailure } from "./inference-dead-ends";
+import { describeToolRouteFailure, describeToolRouteFailureOutcome, type InferenceDeadEndOutcome } from "./inference-dead-ends";
 export { describeToolRouteFailure };
 
 // Narration patterns: agent describes code or announces intent instead of calling tools.
@@ -792,6 +788,7 @@ export type AgenticResult = {
   executedTools: ExecutedTool[];
   /** If a proposal tool was called, return it for approval card rendering */
   proposal: { name: string; arguments: Record<string, unknown>; content: string } | null;
+  failure?: InferenceDeadEndOutcome;
   /**
    * BI-2AC48661: the execution plan as it stood when the loop returned, when
    * `enableExecutionPlan` was set. Null when planning was off or the model
@@ -1687,10 +1684,11 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
       }
     } catch (routeErr) {
       const msg = routeErr instanceof Error ? routeErr.message : String(routeErr);
+      const failure = describeToolRouteFailureOutcome(msg, routeOptions.tools?.length ?? 0, routeErr);
       console.warn(`[agentic-loop] routeAndCall threw: ${msg}`);
       logTurnSummary("unknown", "unknown");
       return {
-        content: describeToolRouteFailure(msg, routeOptions.tools?.length ?? 0, routeErr),
+        content: failure.message,
         providerId: "unknown",
         modelId: "unknown",
         downgraded: false,
@@ -1699,6 +1697,7 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
         totalOutputTokens,
         executedTools,
         proposal: null,
+        failure,
       };
     }
     // Track response ID for conversation chaining (Responses API)

--- a/apps/web/lib/tak/inference-dead-ends.test.ts
+++ b/apps/web/lib/tak/inference-dead-ends.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  describeToolRouteFailureOutcome,
   describeToolRouteFailure,
   localCapacityHeldHandoff,
   noEligibleModelHandoff,
@@ -124,5 +125,26 @@ describe("describeToolRouteFailure classifies the deferral that stranded the own
   it("falls through to the unexplained hand-off, not to a fabricated cause", () => {
     expect(describeToolRouteFailure("ECONNRESET talking to the model host", 0))
       .toBe(unexplainedDeadEndHandoff());
+  });
+
+  it("does not call a missing model busy", () => {
+    const outcome = describeToolRouteFailureOutcome(
+      'All endpoints failed for conversation. Attempts: [{"endpointId":"docker-model-runner","error":"Model not found"}]',
+      0,
+    );
+
+    expect(outcome.kind).toBe("model-missing");
+    expect(outcome.message).not.toMatch(/busy|rate-limit/i);
+    expect(outcome.message).toMatch(/model.*unavailable|available model/i);
+  });
+
+  it("keeps the bounded reconciliation signal classified as model-missing", () => {
+    const outcome = describeToolRouteFailureOutcome(
+      "Provider model inventory changed for docker-model-runner. Attempts: []",
+      0,
+    );
+
+    expect(outcome.kind).toBe("model-missing");
+    expect(outcome.message).not.toMatch(/busy|rate-limit/i);
   });
 });

--- a/apps/web/lib/tak/inference-dead-ends.ts
+++ b/apps/web/lib/tak/inference-dead-ends.ts
@@ -50,6 +50,14 @@ export function providersBusyHandoff(): string {
   });
 }
 
+export function modelMissingHandoff(): string {
+  return buildHumanHandoff({
+    blocker: "The selected AI model is no longer available from its provider, so the platform could not answer this turn.",
+    steps: ["Open Platform > AI Operations > Providers & Routing and refresh that provider's models."],
+    verify: "re-check the available models and pick this straight back up",
+  });
+}
+
 
 /**
  * The local model is present and healthy, but a background job on this host
@@ -144,7 +152,7 @@ export function isLocalCapacityDeferral(error: unknown, message: string): boolea
  *  - genuinely no tool-capable endpoint active → point to the REAL surface.
  *  - anything else → say we do not know, and offer the check.
  */
-export function describeToolRouteFailure(
+function describeToolRouteFailureMessage(
   errorMessage: string,
   toolCount: number,
   error?: unknown,
@@ -233,4 +241,44 @@ export function describeToolRouteFailure(
   }
 
   return unexplainedDeadEndHandoff();
+}
+
+export type InferenceDeadEndKind =
+  | "model-missing"
+  | "credentials"
+  | "capacity"
+  | "policy-or-capability"
+  | "context"
+  | "busy"
+  | "unknown";
+
+export type InferenceDeadEndOutcome = {
+  kind: InferenceDeadEndKind;
+  message: string;
+};
+
+export function describeToolRouteFailureOutcome(
+  errorMessage: string,
+  toolCount: number,
+  error?: unknown,
+): InferenceDeadEndOutcome {
+  const msg = errorMessage ?? "";
+  if (/model[_ ]not[_ ]found|model not found|provider model inventory changed/i.test(msg)) {
+    return { kind: "model-missing", message: modelMissingHandoff() };
+  }
+  const message = describeToolRouteFailureMessage(msg, toolCount, error);
+  if (/REQUEST_TOO_LARGE|exceed_context_size|available context size/i.test(msg)) return { kind: "context", message };
+  if (isLocalCapacityDeferral(error, msg)) return { kind: "capacity", message };
+  if (/No credential|auth(?:entication|orization)? (?:failed|error)|unauthorized/i.test(msg)) return { kind: "credentials", message };
+  if (/No eligible endpoints|toolUse required|tool-capable/i.test(msg)) return { kind: "policy-or-capability", message };
+  if (/rate.?limit|overload|\bbusy\b|status(?:Code)?[\"']?:\s*(?:429|529)/i.test(msg)) return { kind: "busy", message };
+  return { kind: "unknown", message };
+}
+
+export function describeToolRouteFailure(
+  errorMessage: string,
+  toolCount: number,
+  error?: unknown,
+): string {
+  return describeToolRouteFailureOutcome(errorMessage, toolCount, error).message;
 }

--- a/apps/web/lib/tak/task-classifier.test.ts
+++ b/apps/web/lib/tak/task-classifier.test.ts
@@ -73,6 +73,14 @@ describe("classifyTask", () => {
     expect(result.taskType).toBe("reasoning");
   });
 
+  it("does not treat misconfigured in a prior fallback as platform onboarding", () => {
+    const result = classifyTask("It's not busy", [
+      "Every AI provider is busy right now. Nothing is misconfigured.",
+    ]);
+
+    expect(result.taskType).not.toBe("onboarding");
+  });
+
   it("returns high confidence (0.8) when a single type matches clearly", () => {
     const result = classifyTask("Hello there!", []);
     expect(result.confidence).toBe(0.8);

--- a/apps/web/lib/tak/task-classifier.ts
+++ b/apps/web/lib/tak/task-classifier.ts
@@ -47,6 +47,15 @@ export function classifyTask(
 
   for (const taskType of TASK_TYPES) {
     let matchCount = 0;
+    if (taskType.id === "onboarding") {
+      const onboardingPattern = /\b(?:setup|onboarding|getting started|configure(?:d|s|ing)?)\b/i;
+      if (onboardingPattern.test(message)) matchCount = 1;
+      else if (conversationContext.length > 0 && onboardingPattern.test(combinedText)) matchCount = 0.5;
+      if (matchCount > 0) {
+        scores.push({ id: taskType.id, matchCount, totalPatterns: taskType.heuristicPatterns.length });
+      }
+      continue;
+    }
     for (const pattern of taskType.heuristicPatterns) {
       if (pattern.test(message)) {
         matchCount++;

--- a/apps/web/lib/voice-synthesis/service-status.test.ts
+++ b/apps/web/lib/voice-synthesis/service-status.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("@dpf/db", () => ({
-  prisma: { voiceProfile: { count: vi.fn(async () => 0) } },
+  prisma: { voiceProfile: { count: vi.fn(async () => 0), findMany: vi.fn(async () => []) } },
 }))
 
 import { prisma } from "@dpf/db"
@@ -9,6 +9,7 @@ import {
   resolveTtsServiceUp,
   isVoiceNarrationEnabled,
   refreshVoiceTtsMetrics,
+  resolveVoicePlaybackCapability,
 } from "./service-status"
 import { voiceTtsUp, voiceTtsEnabled } from "@/lib/metrics"
 
@@ -24,6 +25,7 @@ describe("voice service-status helper", () => {
     // DPF_TTS_URL intentionally unset so the route's `?? default` applies.
     vi.stubEnv("TTS_PROVIDER", "chatterbox")
     vi.mocked(prisma.voiceProfile.count).mockResolvedValue(0 as never)
+    vi.mocked(prisma.voiceProfile.findMany).mockResolvedValue([] as never)
   })
 
   it("reports up when the chatterbox /health is healthy", async () => {
@@ -110,5 +112,18 @@ describe("voice service-status helper", () => {
     await refreshVoiceTtsMetrics()
     expect(await gaugeValue(voiceTtsUp)).toBe(0)
     expect(await gaugeValue(voiceTtsEnabled)).toBe(0)
+  })
+
+  it("distinguishes missing, preference-off, and service-unavailable playback", async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({ model_loaded: true }), { status: 200 })) as typeof fetch
+    expect((await resolveVoicePlaybackCapability()).state).toBe("profile_missing")
+
+    vi.mocked(prisma.voiceProfile.findMany).mockResolvedValue([{ profile: { voiceEnabled: false } }] as never)
+    expect((await resolveVoicePlaybackCapability()).state).toBe("preference_disabled")
+    expect((await resolveVoicePlaybackCapability({ purpose: "preview" })).state).toBe("ready")
+
+    vi.mocked(prisma.voiceProfile.findMany).mockResolvedValue([{ profile: { voiceEnabled: true } }] as never)
+    global.fetch = vi.fn(async () => { throw new Error("down") }) as typeof fetch
+    expect((await resolveVoicePlaybackCapability()).state).toBe("service_unavailable")
   })
 })

--- a/apps/web/lib/voice-synthesis/service-status.ts
+++ b/apps/web/lib/voice-synthesis/service-status.ts
@@ -21,6 +21,19 @@ export interface TtsServiceStatus {
   reason: string | null
 }
 
+export type VoicePlaybackState =
+  | "ready"
+  | "preference_disabled"
+  | "profile_missing"
+  | "service_unavailable"
+
+export interface VoicePlaybackCapability {
+  available: boolean
+  state: VoicePlaybackState
+  provider: string
+  reason: string | null
+}
+
 /** Health URL for self-hosted sidecars, or null for providers we don't probe. */
 function selfHostedHealthUrl(provider: string): string | null {
   if (provider === "chatterbox") {
@@ -80,6 +93,28 @@ export async function isVoiceNarrationEnabled(): Promise<boolean> {
     where: { status: "ready", profile: { voiceEnabled: true } },
   })
   return n > 0
+}
+
+export async function resolveVoicePlaybackCapability(
+  options: { purpose?: "coworker" | "preview" } = {},
+): Promise<VoicePlaybackCapability> {
+  const provider = defaultProvider()
+  const profiles = await prisma.voiceProfile.findMany({
+    where: { status: "ready", providerVoiceId: { not: null } },
+    select: { profile: { select: { voiceEnabled: true } } },
+    take: 20,
+  })
+  if (profiles.length === 0) {
+    return { available: false, state: "profile_missing", provider, reason: "No ready voice profile is available." }
+  }
+  if (options.purpose !== "preview" && !profiles.some((entry) => entry.profile.voiceEnabled)) {
+    return { available: false, state: "preference_disabled", provider, reason: "Voice narration is off for this coworker." }
+  }
+  const service = await resolveTtsServiceUp()
+  if (!service.up) {
+    return { available: false, state: "service_unavailable", provider: service.provider, reason: service.reason }
+  }
+  return { available: true, state: "ready", provider: service.provider, reason: null }
 }
 
 /**

--- a/docs/superpowers/plans/2026-08-24-coworker-routing-readiness-and-voice-truth.md
+++ b/docs/superpowers/plans/2026-08-24-coworker-routing-readiness-and-voice-truth.md
@@ -1,0 +1,129 @@
+# Coworker routing readiness and voice truth implementation plan
+
+Date: 2026-08-24  
+Epic: `EP-56AE0F69`  
+Backlog items: `BI-D25F867D`, `BI-45B95929`  
+Workroom: `WC-BB6874E6`
+
+## Outcome
+
+One cohesive PR will repair the dogfood failure captured in decision thread `DI-2B3156C625AD`: routing will recover once from a stale model, report the actual terminal constraint as a platform failure, keep standing coworker conversation out of setup routing, establish coworker identity once, and expose voice controls only when their independent capabilities are usable.
+
+The two deliverables remain independently testable and retain separate backlog ownership. They share one PR because the operator explicitly requested one delivery and because both defects meet at the same coworker turn boundary.
+
+## Design grounding
+
+- Existing routing authority: `loadEndpointManifests`, `routeEndpointV2`, `callWithFallbackChain`, `NoEligibleEndpointsError`, `ProviderCapacityStatus`, `DiscoveredModel`, `ModelProfile`, `ModelProvider`, `AiProviderConnection`, and `CredentialEntry`.
+- Existing presentation authority: `AgentPanelHeader`, `AgentCoworkerPanel`, `AgentMessageBubble`, `AgentMessageInput`, `presentStandingCoo`, `useVoiceSynth`, and `/api/voice/service-status`.
+- Existing provider UX authority: `deriveRoutingEligibility`; runtime and admin projections must consume the same credential/model facts instead of creating a second readiness state.
+- No new table, enum, route family, or parallel provider-health store is required.
+- Related work remains separate: `BI-1FFDF4B1` owns local model install/delete, `BI-BB337746` owns local compliance policy, `BI-2EFF90F2` owns the discovery-sweep decision gate, and `BI-2C50F548` owns attention projection.
+- Open-PR sweep on 2026-08-24 found no overlapping routing/coworker PR. The unmerged `fix/local-model-ux` worktree is outside this edit scope.
+
+## Change-impact contract
+
+The Workroom returned `status=resolved` for all claimed paths.
+
+- Large-module ratchets: `AgentCoworkerPanel.tsx`, `AgentMessageInput.tsx`, `agent-coworker.ts`, and `agentic-loop.ts` must not grow.
+- Provider route budget: `/platform/ai/providers` has zero visible-word growth and must preserve heading/landmark shape.
+- Required guards: `pnpm run check:prose-lint:test`, `pnpm run check:prose-lint`, and `node scripts/check-style-drift.mjs`.
+- Required gate: affected unit tests, `pnpm run pregate:preflight`, exact-tree `pnpm run pregate`, then `pnpm pr:health`.
+- The source-code graph is missing, so every colocated and directly imported test suite named below is in scope.
+
+## Phase 1 — Red: reproduce routing and attribution failures
+
+Deliverable: `BI-D25F867D` behavior is executable as failing tests before production edits.
+
+Tests:
+
+- `apps/web/lib/routing/fallback.test.ts`: a selected model returning `model_not_found` completes reconciliation before signaling one route rebuild.
+- `apps/web/lib/inference/routed-inference.activity-overrides.test.ts`: foreground dispatch rebuilds the route once, never loops, and can select the newly discovered model.
+- `apps/web/lib/routing/loader.test.ts`: active providers without usable credentials do not become runtime manifests; no-auth local endpoints remain eligible.
+- `apps/web/lib/tak/inference-dead-ends.test.ts`: model missing, credentials, capacity, policy/capability, context, busy, and unknown failures produce different typed outcomes.
+- `apps/web/lib/tak/task-classifier.test.ts`: “misconfigured” in an assistant fallback cannot classify a standing thread as platform onboarding.
+- `apps/web/components/agent/AgentMessageBubble.test.tsx`: a platform inference failure is a system recovery card with no coworker or provider attribution.
+
+Verification: run each targeted test and confirm it fails for the intended missing behavior.
+
+## Phase 2 — Green/refactor: canonical executable routing
+
+Deliverable: stale routes self-heal once and provider readiness is honest.
+
+Implementation:
+
+- Make provider/model reconciliation an awaited dispatch boundary and emit a typed reroute signal only when the fixed fallback chain cannot recover.
+- Rebuild the route once from fresh manifests; the second failure is terminal.
+- Reuse credential-material resolution in `loadEndpointManifests` and the provider admin projection, keeping no-auth local endpoints valid.
+- Add a typed dead-end outcome while preserving the existing string helper for compatible callers.
+- Carry the failure outcome through `AgenticResult`; persist it as a system message with null agent/provider/model attribution.
+- Classify task context from user turns and gate the platform-onboarding task to `/setup`.
+- Refactor duplicated failure-copy branches into the typed outcome presenter.
+
+Verification: rerun Phase 1 tests, routing loader tests, provider eligibility/data tests, agentic-loop tests, and agent-coworker tests.
+
+## Phase 3 — Red: reproduce identity and voice capability failures
+
+Deliverable: `BI-45B95929` behavior is executable as failing tests before production edits.
+
+Tests:
+
+- `apps/web/lib/coworker-presentation/coo-name.test.ts`: standing COO presentation exposes primary name and secondary role separately.
+- `apps/web/components/agent/AgentPanelHeader.test.tsx`: the header renders that hierarchy once.
+- `apps/web/components/agent/AgentMessageBubble.test.tsx`: same-agent turns retain accessible authorship without repeated visual labels.
+- `apps/web/components/agent/AgentMessageInput.test.tsx`: playback distinguishes checking, preference-off, missing profile, and TTS unavailable; dictation remains independent.
+- `apps/web/app/api/voice/service-status/route.test.ts` and `apps/web/lib/voice-synthesis/service-status.test.ts`: the capability response combines profile readiness with service health.
+- `apps/web/components/agent/hooks/useVoiceSynth.test.ts`: mount-time capability probing disables playback before the first failed synthesis call.
+
+Verification: run each targeted test and confirm it fails for the intended missing behavior.
+
+## Phase 4 — Green/refactor: identity hierarchy and truthful voice controls
+
+Deliverable: the coworker panel establishes identity once and presents independent voice capabilities.
+
+Implementation:
+
+- Add one shared presentation-identity resolver; keep canonical identity and audit fields unchanged.
+- Render conversational name as primary and `AI COO` as secondary in the header.
+- Suppress the active header coworker’s repeated visual label while keeping per-message accessible authorship; continue labeling genuinely different collaborators.
+- Extend the existing voice status response with ready-profile state and an explicit reason.
+- Probe playback capability on mount in `useVoiceSynth`; expose checking, available, and unavailable states.
+- Keep microphone support/state independent of playback health.
+- Normalize action labels and `aria-pressed`; remove hardcoded color fallbacks from the touched mic control.
+- Extract state derivation so the large panel/input modules shrink or stay flat.
+
+Verification: rerun Phase 3 tests plus coworker-panel UX smoke and accessibility-focused component suites in light/dark compatible tokens.
+
+## Phase 5 — Functional and blast-radius verification
+
+- Run all affected Vitest files with the absolute worktree root and reconcile reported counts.
+- Run web typecheck, prose guards, style-drift guard, and `pnpm run pregate:preflight`.
+- Apply the DPF blast-radius review to routing callers, persisted message shape, provider admin status, and both voice surfaces.
+- Apply the DPF UX-fit review to first viewport, identity hierarchy, disabled reasons, keyboard focus, accessible names, and light/dark themes.
+- Claim the shared nonproduction lease, run exact-tree `pnpm run pregate`, and exercise the original coworker-decision path in the portal.
+- Confirm a stale local model reroutes once; no-route failures are system cards; the COO label is not repeated; TTS-down/STT-up remains truthful.
+
+## Phase 6 — One-PR delivery
+
+- Record Workroom evidence for tests, guards, UX, and runtime behavior.
+- Commit with DCO sign-off, obtain an independent semantic review of the stable commit, and run local merged-code CI.
+- Re-sweep open PRs immediately before push.
+- Push `fix/coworker-routing-readiness-and-voice-truth`, open one ready PR referencing both BIs, and run `pnpm pr:health`.
+
+## Backlog coverage
+
+Decision: `decomposed` — each independently shippable deliverable maps to its live BI; operator direction binds them into one PR.
+
+- `routing-readiness`: `BI-D25F867D`; independent; verifies route reconciliation, readiness, classification, and system attribution.
+- `identity-voice`: `BI-45B95929`; independent; verifies identity hierarchy and independent TTS/STT capability states.
+
+Coverage receipt: pending committed plan artifact.
+
+## Risks and rollback
+
+- Credential preflight could exclude a provider that uses a nonstandard credential parent. Mitigation: reuse `resolveCredentialProviderId` and keep no-auth endpoints explicit; rollback the loader filter independently.
+- Discovery can fail during reconciliation. Mitigation: only one reroute is allowed; terminal copy states model/service unavailability without claiming “busy.”
+- Changing persisted failure role can affect message consumers. Mitigation: retain the existing `AgentMessage` schema and exercise serializers, SSE recovery, and transcript rendering; rollback the role projection without reverting typed classification.
+- Voice health probing adds one authenticated GET on panel mount. Mitigation: lightweight no-synthesis probe, fail closed with an explanation, and no polling loop.
+- Identity suppression could hide collaborator provenance. Mitigation: suppress only the panel’s active header agent and retain accessible names plus labels for other agents.
+
+No migration is required. Rollback is a normal PR revert; no data rewrite or destructive runtime action is involved.

--- a/docs/superpowers/plans/2026-08-24-coworker-routing-readiness-and-voice-truth.md
+++ b/docs/superpowers/plans/2026-08-24-coworker-routing-readiness-and-voice-truth.md
@@ -116,7 +116,26 @@ Decision: `decomposed` — each independently shippable deliverable maps to its 
 - `routing-readiness`: `BI-D25F867D`; independent; verifies route reconciliation, readiness, classification, and system attribution.
 - `identity-voice`: `BI-45B95929`; independent; verifies identity hierarchy and independent TTS/STT capability states.
 
-Coverage receipt: pending committed plan artifact.
+Coverage receipt: blocked by `BI-B9403248`. The live coverage service resolved the signed,
+provider-verified plan blob at commit `2bb0b9772d7af23e9def4ea7a34be5a47c909829`,
+then reported that `BI-D25F867D` has no initiative-scope baseline and that this baseline is
+not currently recordable from an MCP session. Per the service's required fallback, this
+section is the authoritative coverage table until that tool gap is repaired.
+
+Traceability:
+
+- `routing-readiness` -> `BI-D25F867D`; contracts: Workroom `WC-BB6874E6` impact contract
+  and the BI acceptance contract; requirements: executable readiness, system attribution,
+  and onboarding isolation; flows: route -> fallback -> reconciliation -> bounded reroute,
+  then agentic loop -> typed dead-end -> system timeline message; verification: Phase 1 and
+  Phase 2 suites.
+- `identity-voice` -> `BI-45B95929`; contracts: Workroom `WC-BB6874E6` impact contract and
+  the BI acceptance contract; requirements: identity hierarchy, accessible authorship, and
+  independent TTS/STT readiness; flows: standing-COO presentation -> header/message
+  authorship and voice status -> synthesis hook -> speaker control; verification: Phase 3
+  and Phase 4 suites.
+- Dependencies: neither deliverable depends on the other for correctness; the shared PR is
+  an operator-requested delivery boundary.
 
 ## Risks and rollback
 

--- a/docs/superpowers/plans/2026-08-24-coworker-routing-readiness-and-voice-truth.md
+++ b/docs/superpowers/plans/2026-08-24-coworker-routing-readiness-and-voice-truth.md
@@ -150,6 +150,10 @@ Architecture decision: aligned.
   It adds no schema, enum, route family, provider-health store, or second identity source.
 - Reconciliation is bounded to one route rebuild. Credential checks are deduplicated by
   provider before execution, so profile count does not multiply credential lookups.
+- Build Studio retains the full route-selection reason as diagnostic evidence, while its
+  first viewport projects that variable internal text to a stable ready/blocked sentence.
+  Credential truth can therefore change without leaking task types, provider identifiers,
+  or endpoint counts into the operator-facing setup summary.
 - Terminal platform failures remain in the existing timeline as `system` messages and are
   excluded from coworker semantic memory. This preserves the audit trail without teaching
   later turns that the coworker authored a platform failure.

--- a/docs/superpowers/plans/2026-08-24-coworker-routing-readiness-and-voice-truth.md
+++ b/docs/superpowers/plans/2026-08-24-coworker-routing-readiness-and-voice-truth.md
@@ -4,9 +4,9 @@ status: active
 
 # Coworker routing readiness and voice truth implementation plan
 
-Date: 2026-08-24  
-Epic: `EP-56AE0F69`  
-Backlog items: `BI-D25F867D`, `BI-45B95929`  
+Date: 2026-08-24
+Epic: `EP-56AE0F69`
+Backlog items: `BI-D25F867D`, `BI-45B95929`
 Workroom: `WC-BB6874E6`
 
 ## Outcome

--- a/docs/superpowers/plans/2026-08-24-coworker-routing-readiness-and-voice-truth.md
+++ b/docs/superpowers/plans/2026-08-24-coworker-routing-readiness-and-voice-truth.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Coworker routing readiness and voice truth implementation plan
 
 Date: 2026-08-24  
@@ -99,8 +103,8 @@ Verification: rerun Phase 3 tests plus coworker-panel UX smoke and accessibility
 - Run web typecheck, prose guards, style-drift guard, and `pnpm run pregate:preflight`.
 - Apply the DPF blast-radius review to routing callers, persisted message shape, provider admin status, and both voice surfaces.
 - Apply the DPF UX-fit review to first viewport, identity hierarchy, disabled reasons, keyboard focus, accessible names, and light/dark themes.
-- Claim the shared nonproduction lease, run exact-tree `pnpm run pregate`, and exercise the original coworker-decision path in the portal.
-- Confirm a stale local model reroutes once; no-route failures are system cards; the COO label is not repeated; TTS-down/STT-up remains truthful.
+- Run exact-tree `pnpm run pregate` through the shared local-integration lease and require the recorded candidate SHA to match the committed head.
+- Treat post-merge live-install exercise of the original coworker-decision path as release verification, not as pre-PR evidence.
 
 ## Phase 6 — One-PR delivery
 
@@ -116,11 +120,11 @@ Decision: `decomposed` — each independently shippable deliverable maps to its 
 - `routing-readiness`: `BI-D25F867D`; independent; verifies route reconciliation, readiness, classification, and system attribution.
 - `identity-voice`: `BI-45B95929`; independent; verifies identity hierarchy and independent TTS/STT capability states.
 
-Coverage receipt: blocked by `BI-B9403248`. The live coverage service resolved the signed,
+Coverage receipt: blocked by `BI-MCP-EFF-3E441834`. The live coverage service resolved the signed,
 provider-verified plan blob at commit `2bb0b9772d7af23e9def4ea7a34be5a47c909829`,
 then reported that `BI-D25F867D` has no initiative-scope baseline and that this baseline is
 not currently recordable from an MCP session. Per the service's required fallback, this
-section is the authoritative coverage table until that tool gap is repaired.
+section is the authoritative coverage table until that live MCP-efficiency gap is repaired.
 
 Traceability:
 
@@ -136,6 +140,29 @@ Traceability:
   and Phase 4 suites.
 - Dependencies: neither deliverable depends on the other for correctness; the shared PR is
   an operator-requested delivery boundary.
+
+## Architecture and UX review
+
+Architecture decision: aligned.
+
+- The repair extends the existing route/fallback boundary, `AgentMessage` role projection,
+  provider credential authority, standing-COO presenter, and voice service-status endpoint.
+  It adds no schema, enum, route family, provider-health store, or second identity source.
+- Reconciliation is bounded to one route rebuild. Credential checks are deduplicated by
+  provider before execution, so profile count does not multiply credential lookups.
+- Terminal platform failures remain in the existing timeline as `system` messages and are
+  excluded from coworker semantic memory. This preserves the audit trail without teaching
+  later turns that the coworker authored a platform failure.
+- The voice endpoint now distinguishes coworker playback from profile preview. Narration
+  preference governs the speaker; a ready profile can still be previewed while narration is
+  off. Dictation continues to use its independent capture capability.
+
+UX-fit decision: `truthful-contextual-recovery`, recorded as `DI-ADB42335FC3E` with a high-
+confidence kernel margin of 7.336. The review is `fits-with-guardrails`: keep the existing
+panel and controls, establish name and role once, preserve accessible authorship, present
+terminal inference failures as platform status with one contextual recovery link, and state
+why playback is checking or unavailable. The measured decision manifest is
+`docs/ux-fit/2026-08-24-coworker-routing-readiness-and-voice-truth.ux-fit.json`.
 
 ## Risks and rollback
 

--- a/docs/ux-fit/2026-08-24-coworker-routing-readiness-and-voice-truth.ux-fit.json
+++ b/docs/ux-fit/2026-08-24-coworker-routing-readiness-and-voice-truth.ux-fit.json
@@ -1,0 +1,24 @@
+{
+  "version": "1",
+  "decidedOption": "truthful-contextual-recovery",
+  "decisionInteractionId": "DI-ADB42335FC3E",
+  "scope": {
+    "files": [
+      "apps/web/components/agent/AgentMessageBubble.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "truthful-contextual-recovery",
+      "generic-coworker-error",
+      "remove-recovery-controls"
+    ]
+  },
+  "rationale": {
+    "truthful-contextual-recovery": "CHOSEN. The kernel review scored 13.378 with a 7.336 margin and high confidence. It keeps the existing coworker panel, separates the coworker's name from the role, retains accessible message authorship, presents terminal inference failure as platform status, offers one contextual recovery destination, and derives speaker readiness from the existing profile, preference, and TTS health sources. The microphone and profile preview remain independent.",
+    "generic-coworker-error": "REJECTED. A wording-only repair leaves stale routes, repeated identity, and click-to-discover playback failure intact. It still asks the operator to infer whether the coworker, provider, profile, or service failed.",
+    "remove-recovery-controls": "REJECTED. Removing the controls reduces visible surface area but creates a dead end: the operator must remember where provider and voice settings live and cannot see why a capability is unavailable."
+  },
+  "notes": "Fits with guardrails. Owning area: the existing common-shell coworker panel, with the existing Platform > AI > Providers route as recovery. Primary persona: an organization owner using a named AI coworker. No navigation, route family, dashboard, or component family is added. Failure copy is typed from the inference outcome; identity comes from the standing-COO presentation resolver; provider readiness comes from executable credential and model facts; voice readiness comes from the existing voice profile, preference, and service probe. Existing semantic link/button controls, DPF tokens, distinct checking/unavailable labels, accessible authorship, and independent microphone/preview behavior are retained."
+}


### PR DESCRIPTION
## Summary

- make provider readiness reflect executable credentials and current model inventory, with one bounded reconciliation/re-route when a provider reports a missing model
- preserve typed inference failures so the coworker reports the real capacity, credential, capability, policy, context, or model problem and offers provider recovery only when relevant
- present the coworker's name and role once, keep accessible message authorship, and make narration availability reflect voice profile, preference, and service health while leaving the microphone and profile preview independent
- refactor retry, failure presentation, credential-readiness, identity, and provider-recovery logic into shared typed helpers

Backlog: BI-D25F867D, BI-45B95929

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/plans/2026-08-24-coworker-routing-readiness-and-voice-truth.md`, platform usability standards, and the portal UX spine.
- Current code substrate reviewed: routing fallback and provider reconciliation, provider credential authority, `AgentMessage` system-role rendering, standing-COO presentation identity, and voice service-status paths.
- Source of truth: existing credential and model state, typed inference outcomes, coworker presentation identity, and voice profile/preference/service health. This change adds no schema, route family, or state store.
- Decision: keep the existing coworker panel, show contextual recovery only when supported by failure evidence, separate name from role, and enable narration only when all existing capability facts are ready.

## UX fit

The selected `truthful-contextual-recovery` option fits with guardrails: it keeps the current surface and navigation, removes repeated identity, uses a single contextual provider action for terminal system failures, and explains why narration is unavailable. The measured option record is in `docs/ux-fit/2026-08-24-coworker-routing-readiness-and-voice-truth.ux-fit.json`.

## Documentation impact

Provider readiness, coworker failure guidance, and speaker availability now behave truthfully. The existing provider guide and linked architecture documents remain accurate because no setup workflow, route, or operator procedure changes.

## Verification

- 18 affected Vitest files passed on the final merged tree (341 tests)
- corrective message-rendering suite passed (29 tests), including negative coverage for unrelated Build Studio notices and single-copy inline recovery for terminal failures
- web typecheck passed
- prose, style-drift, UX-fit, docs-impact, design-grounding, module-size, and substrate-complexity guards passed
- pregate preflight passed all 52 guards
- independent semantic review passed with three review branches and no findings for the exact final tree
- exact merged-code pregate passed with exhaustive/full-suite evidence, migrations, web typecheck, and a production Docker image build for commit `6dc71f1cb70332f87c03d6d38faee2e77ea148e8` (evidence `cmt6wp8kr0k4401mxu3v07dyc`)
