### PR TITLE
fix(ci): classify generated docs by source

### DIFF
--- a/config/ci-evidence-policy.json
+++ b/config/ci-evidence-policy.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "policyVersion": "2026-08-01.1",
+  "policyVersion": "2026-08-24.1",
   "plannerVersion": "1.0.0-shadow",
   "mode": "shadow",
   "selectionThresholdPercent": 70,
@@ -26,7 +26,7 @@
   ],
   "patterns": {
     "docs": [
-      "(^|/)docs/",
+      "^docs/",
       "(^|/)README\\.md$",
       "\\.mdx?$"
     ],

--- a/scripts/lib/ci-evidence-plan.mjs
+++ b/scripts/lib/ci-evidence-plan.mjs
@@ -1,6 +1,10 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import {
+  DERIVED_ARTIFACTS,
+  matchesAnyGlob,
+} from "./derived-artifacts-registry.mjs";
 
 export const CI_EVIDENCE_PLAN_SCHEMA_VERSION = 1;
 const DEFAULT_POLICY_PATH = fileURLToPath(
@@ -55,6 +59,27 @@ function classifyPath(path, compiled) {
   if (matchesAny(path, compiled.tests)) return "test";
   if (matchesAny(path, compiled.production)) return "production";
   return "other";
+}
+
+function documentationDerivedArtifacts(changedFiles, compiled) {
+  const artifacts = new Set();
+  for (const definition of DERIVED_ARTIFACTS) {
+    const changedArtifacts = changedFiles.filter((path) => (
+      matchesAnyGlob(path, definition.artifactPaths)
+    ));
+    if (changedArtifacts.length === 0) continue;
+
+    const changedSources = changedFiles.filter((path) => (
+      matchesAnyGlob(path, definition.sourceGlobs)
+    ));
+    if (
+      changedSources.length > 0
+      && changedSources.every((path) => classifyPath(path, compiled) === "docs")
+    ) {
+      changedArtifacts.forEach((path) => artifacts.add(path));
+    }
+  }
+  return artifacts;
 }
 
 function packageOwner(path, packageRoots) {
@@ -175,7 +200,11 @@ export function createEvidencePlan(input) {
     code: rule.code,
     patterns: compilePatterns(rule.patterns),
   }));
-  const kinds = new Map(changedFiles.map((path) => [path, classifyPath(path, compiled)]));
+  const documentationArtifacts = documentationDerivedArtifacts(changedFiles, compiled);
+  const kinds = new Map(changedFiles.map((path) => [
+    path,
+    documentationArtifacts.has(path) ? "docs" : classifyPath(path, compiled),
+  ]));
   const productionFiles = changedFiles.filter((path) => kinds.get(path) === "production");
   const changedTests = changedFiles.filter((path) => kinds.get(path) === "test");
   const workspaceRequired = changedFiles.some((path) => (
@@ -202,7 +231,9 @@ export function createEvidencePlan(input) {
     const kind = kinds.get(path);
     const owner = packageOwner(path, policy.packageRoots);
     if (owner) affectedPackages.add(owner);
-    const risks = riskCodesForPath(path, riskRules);
+    const risks = riskCodesForPath(path, riskRules).filter((code) => !(
+      code === "generated-contract" && documentationArtifacts.has(path)
+    ));
     for (const code of risks) addEscalation(escalations, `risk:${code}`, path);
 
     if (kind === "docs") {

--- a/scripts/lib/ci-evidence-plan.test.mjs
+++ b/scripts/lib/ci-evidence-plan.test.mjs
@@ -119,6 +119,42 @@ describe("createEvidencePlan", () => {
     assert.deepEqual(plan.escalations, []);
   });
 
+  it("keeps a docs-only change non-portal when it includes its generated doc index", () => {
+    const plan = createEvidencePlan(input({
+      changedFiles: [
+        "docs/architecture/archetype-operating-model-audit.md",
+        "docs/architecture/platform-overview.md",
+        "apps/web/lib/docs/doc-index.generated.json",
+      ],
+    }));
+
+    assert.equal(plan.scope.docsOnly, true);
+    assert.equal(plan.scope.heavy, false);
+    assert.equal(plan.fullSuite, false);
+    assert.equal(plan.uxMode, "none");
+    assert.deepEqual(plan.escalations, []);
+  });
+
+  it("does not treat runtime code under a docs-named module as documentation", () => {
+    const plan = createEvidencePlan(input({
+      changedFiles: ["apps/web/lib/docs/doc-link-resolver.mjs"],
+    }));
+
+    assert.equal(plan.scope.docsOnly, false);
+    assert.equal(plan.scope.heavy, true);
+    assert.equal(plan.fullSuite, true);
+  });
+
+  it("keeps a generated doc index exhaustive when no documentation source changed", () => {
+    const plan = createEvidencePlan(input({
+      changedFiles: ["apps/web/lib/docs/doc-index.generated.json"],
+    }));
+
+    assert.equal(plan.scope.docsOnly, false);
+    assert.equal(plan.scope.heavy, true);
+    assert.equal(plan.fullSuite, true);
+  });
+
   for (const executableStandardPath of [
     "docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md",
     "docs/architecture/four-portfolio-archetype-standard-profile-catalog.md",

--- a/scripts/pr-health.mjs
+++ b/scripts/pr-health.mjs
@@ -31,6 +31,10 @@
 
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import {
+  createEvidencePlan,
+  loadEvidencePolicy,
+} from "./lib/ci-evidence-plan.mjs";
 
 // Single SoT for override codes (BI-563F6AB6) — shared with PreToolUse guards.
 import {
@@ -64,11 +68,28 @@ export function parseLocalCiAttestation(prBody, commitMessages = []) {
   return null;
 }
 
-const DOCS_ONLY_RE = /^docs\/|^memory\/|\.md$/;
+const evidencePolicy = loadEvidencePolicy();
 
 export function isDocsOnlyFileSet(files) {
   if (!Array.isArray(files) || files.length === 0) return false;
-  return files.every((f) => DOCS_ONLY_RE.test(typeof f === "string" ? f : f?.path ?? ""));
+  const changedFiles = files.map((file) => (
+    typeof file === "string" ? file : file?.path ?? ""
+  ));
+  const plan = createEvidencePlan({
+    eventName: "pull_request",
+    baseSha: "pr-health-base",
+    headSha: "pr-health-head",
+    baseTreeSha: "pr-health-base-tree",
+    headTreeSha: "pr-health-head-tree",
+    changedFiles,
+    knownTests: [],
+    relatedTestsBySource: {},
+    routeAdviceBySource: {},
+    packageDependencies: {},
+    totalTestCount: 0,
+    policy: evidencePolicy,
+  });
+  return plan.scope.docsOnly && !plan.fullSuite;
 }
 
 /**

--- a/scripts/pr-health.test.mjs
+++ b/scripts/pr-health.test.mjs
@@ -170,6 +170,12 @@ test("classifyLocalCiOverride accepts closed codes and rejects free text (BI-563
 
 test("isDocsOnlyFileSet — docs/memory/*.md only counts, empty set does not", () => {
   assert.equal(isDocsOnlyFileSet([{ path: "docs/a.md" }, { path: "AGENTS.md" }, { path: "memory/x.md" }]), true);
+  assert.equal(isDocsOnlyFileSet([
+    { path: "docs/architecture/a.md" },
+    { path: "apps/web/lib/docs/doc-index.generated.json" },
+  ]), true);
+  assert.equal(isDocsOnlyFileSet([{ path: "apps/web/lib/docs/doc-index.generated.json" }]), false);
+  assert.equal(isDocsOnlyFileSet([{ path: "apps/web/lib/docs/doc-link-resolver.mjs" }]), false);
   assert.equal(isDocsOnlyFileSet([{ path: "docs/a.md" }, { path: "apps/web/lib/x.ts" }]), false);
   assert.equal(isDocsOnlyFileSet([]), false);
   assert.equal(isDocsOnlyFileSet(undefined), false);


### PR DESCRIPTION
## Summary

- Classify a generated documentation artifact from its changed source set instead of treating every generated contract as runtime code.
- Narrow the documentation path rule so runtime modules under `apps/web/lib/docs` remain exhaustive.
- Make PR health consume the canonical evidence planner rather than maintaining a second docs-only regex.

This replays the exact file set from PR #4441 as docs-only while keeping a standalone generated index or runtime source change fail-closed.

Closes #4529.

DPF-Backlog-Item: BI-C8973E09

## Verification

- `pnpm run pregate:preflight`: 52/52 deterministic guards passed.
- Governed exact-tree local CI passed on `92dd720451c8ac6aa32e265e98872e2c8de9733a`: exhaustive tests, typecheck, production image build/export/import, and merged-base checks.
- 89 focused and adjacent Node tests passed across the evidence planner, change-scope projection, PR health, and derived-artifact registry.
- Exact PR #4441 replay: `heavy=false`, `mobile=false`.
- `git diff --check` passed.

Local-CI-Evidence: cmt6rhxek0fmr01mxd4xmpo50 (fix/skip-exact-tree-ux-runtime@92dd720451c8ac6aa32e265e98872e2c8de9733a)
Semantic-Review-Receipt: cmt6qlwrx0eh901mxrzhlqxpm

## Impact

- UX: not applicable; this changes CI classification and PR-readiness logic, not a product route or control.
- Data/migrations: none.
- Documentation: no user-facing behavior changed; the signed commit carries the required docs-impact decision.
- Semantic review: no issues were reported. The shadow receipt is inconclusive only because governed local CI owned host capacity and permits publication.
