### PR TITLE
fix(coworkers): stop repeated no-progress calls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,12 @@ pnpm test:e2e           # Playwright against a running portal
 pnpm test:e2e:demo      # Sandbox-preview demo profile
 ```
 
+### Local build capacity precedence
+
+Local model capacity is shared by contributor verification, Build Studio, and AI coworkers. Data-sensitivity constraints are applied first. For routed build phases, a user-configured provider takes precedence over the bundled local provider. While an exact local-CI run holds the on-box capacity lease, local Build Studio and coworker inference defer and retry instead of competing with verification or reporting the provider as broken.
+
+Configure provider choices in **Admin > AI Workforce > Providers & Routing**; do not edit seed data to change routing. See [Connecting AI providers](docs/user-guide/ai-workforce/connecting-providers.md#local-capacity-during-platform-verification) for the operator-facing behavior.
+
 ## Pull request expectations
 
 - **Scope:** one concern per PR. Refactors that ride along with a feature change are fine only if they're genuinely entangled.

--- a/packages/db/src/hive-scout-config.ts
+++ b/packages/db/src/hive-scout-config.ts
@@ -10,6 +10,7 @@ export function buildHiveScoutScheduledPrompt(): string {
   return [
     "Run the daily external catalog scout pass for autonomous coworker archetype discovery.",
     "Invoke run_hive_scout_ingest once before writing any summary.",
+    "If the call fails, do not call run_hive_scout_ingest again with the same arguments. Report the failure and the single next action instead.",
     "Report how many external catalog entries were parsed, how many gaps were detected, how many backlog suggestions were created, how many duplicates were skipped, and how many items were deferred for human review.",
     "Call out the highest-value follow-up when the run finds ambiguous patterns or new coworker opportunities.",
     "Then review the marketSources material in the same tool result: fetched excerpts from the approved product/market source list, each backed by a citable source URL (BI-B8E4317D).",

--- a/packages/db/src/seed-hive-scout.test.ts
+++ b/packages/db/src/seed-hive-scout.test.ts
@@ -45,6 +45,9 @@ describe("Hive Scout seed helper", () => {
     expect(prompt).toContain("daily");
     expect(prompt).toContain("run_hive_scout_ingest");
     expect(prompt).toContain("external catalog");
+    expect(prompt).toContain(
+      "If the call fails, do not call run_hive_scout_ingest again with the same arguments.",
+    );
   });
 
   it("directs the market-aperture pass toward design challenges, not digests (BI-B8E4317D)", () => {
@@ -105,6 +108,45 @@ describe("Hive Scout seed helper", () => {
     expect(skill.allowedTools).toContain("run_hive_scout_ingest");
     expect(prompt).toContain("name: external-catalog-scout");
     expect(prompt).toContain("run_hive_scout_ingest");
+    expect(readFileSync(skillPath, "utf8")).toContain(
+      "If the call fails, do not call `run_hive_scout_ingest` again with the same arguments.",
+    );
+    expect(prompt).toContain(
+      "If the call fails, do not call `run_hive_scout_ingest` again with the same arguments.",
+    );
+  });
+
+  it("keeps the inventory persona aliases on the same no-repeat tool policy", () => {
+    const routePersonaDirectory = join(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "prompts",
+      "route-persona",
+    );
+    const noRepeatRule =
+      "Never call `search_knowledge` again with the same query and filters after its result has been returned or the call has failed.";
+
+    const inventoryPrompt = readFileSync(
+      join(routePersonaDirectory, "inventory-specialist.prompt.md"),
+      "utf8",
+    );
+    const estatePrompt = readFileSync(
+      join(routePersonaDirectory, "estate-specialist.prompt.md"),
+      "utf8",
+    );
+
+    expect(inventoryPrompt).toContain(noRepeatRule);
+    expect(estatePrompt).toContain(noRepeatRule);
+    expect(
+      estatePrompt
+        .replace("name: estate-specialist", "name: inventory-specialist")
+        .replace(
+          "<!-- This file is intentionally a near-duplicate of inventory-specialist.prompt.md. Both names alias to agent_id AGT-WS-INVENTORY. Keep them in sync until the prompt loader supports aliasing natively. -->\n\n",
+          "",
+        ),
+    ).toBe(inventoryPrompt);
   });
 
   it("ships the seeded Hive Scout ambiguity-reviewer prompt", () => {

--- a/prompts/route-persona/estate-specialist.prompt.md
+++ b/prompts/route-persona/estate-specialist.prompt.md
@@ -81,6 +81,8 @@ Sunset analysis is structural. Products past their useful life consume resources
 
 Attribution review precedes any lifecycle recommendation. A mis-categorized product produces wrong stage-gate criteria — fix the attribution first.
 
+Never call `search_knowledge` again with the same query and filters after its result has been returned or the call has failed. Use the returned evidence, change to a materially different scoped query or tool, answer, or state the limitation.
+
 For the daily Discovery Taxonomy Gap Triage:
 
 1. Invoke `run_discovery_triage` once with the trigger cadence before writing any summary.

--- a/prompts/route-persona/external-catalog-scout.prompt.md
+++ b/prompts/route-persona/external-catalog-scout.prompt.md
@@ -61,6 +61,8 @@ The runtime grants for this coworker are intentionally narrow. The core tool is:
 
 Invoke `run_hive_scout_ingest` once before writing any summary.
 
+If the call fails, do not call `run_hive_scout_ingest` again with the same arguments. Report the failure and the single next action instead. A returned result is final for that turn; summarize it without repeating the call.
+
 Always report:
 - catalog entries parsed
 - gaps detected

--- a/prompts/route-persona/inventory-specialist.prompt.md
+++ b/prompts/route-persona/inventory-specialist.prompt.md
@@ -79,6 +79,8 @@ Sunset analysis is structural. Products past their useful life consume resources
 
 Attribution review precedes any lifecycle recommendation. A mis-categorized product produces wrong stage-gate criteria — fix the attribution first.
 
+Never call `search_knowledge` again with the same query and filters after its result has been returned or the call has failed. Use the returned evidence, change to a materially different scoped query or tool, answer, or state the limitation.
+
 For the daily Discovery Taxonomy Gap Triage:
 
 1. Invoke `run_discovery_triage` once with the trigger cadence before writing any summary.

--- a/skills/platform/scout-external-catalogs.skill.md
+++ b/skills/platform/scout-external-catalogs.skill.md
@@ -44,6 +44,7 @@ repository. The source catalog is reference material, not code to import.
 
 ## Guidelines
 
+- Invoke `run_hive_scout_ingest` once per turn. If the call fails, do not call `run_hive_scout_ingest` again with the same arguments. Report the failure and the single next action instead; if it returns a result, consume that result without repeating the call.
 - Fail loud if the upstream README format has changed — never write partial
   results.
 - Always include the source URL and the phrase "Reference only — not vendored"


### PR DESCRIPTION
## Summary

- stop External Catalog Scout after a failed or already-consumed `run_hive_scout_ingest` call
- give both inventory persona aliases the same no-repeat `search_knowledge` contract and test their full prompt parity
- document local provider and exact local-CI capacity precedence for contributors

Closes BI-CAP-D779BE29.
Closes BI-PIR-33fc603c.
Closes BI-EB1F6E81.

## Verification

- TDD: 3 regression assertions failed before implementation, then `seed-hive-scout.test.ts` passed 10/10
- adjacent skill/seed/relevance tests passed 53/53
- instruction-plane size and rule-coverage guards passed
- prose lint, scoped web/db typecheck, DCO, and secret scan passed
- `pnpm run pregate:preflight`: 52/52 guards passed
- governed exact merged-tree local CI passed for `49dfc4078666` (evidence `cmt6taleg0hme01mx42vxr0h2`): fresh migrations, full typecheck, full test suite, production Docker build

UX: not applicable — no UI surface changed.
Migration: not applicable — no schema or data shape changed.

Docs-Impact-Decision: The change only tightens seeded coworker execution guidance and contributor documentation; no documented device-identification surface behavior changes.

Seed-Fit-Decision: global-default

Seed fit rationale: Both affected coworkers and their canonical prompt and skill sources ship on every installation, so fresh installs should inherit the corrected no-repeat behavior.
