### PR TITLE
fix(inference): preserve governed local reviewer

### DIFF
--- a/apps/web/app/api/platform/ai/local-models/status/route.test.ts
+++ b/apps/web/app/api/platform/ai/local-models/status/route.test.ts
@@ -3,11 +3,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   requireCapability: vi.fn(),
   getSnapshot: vi.fn(),
+  getServedContextInfo: vi.fn(),
 }));
 
 vi.mock("@/lib/actions/shared/guards", () => ({ requireCapability: mocks.requireCapability }));
 vi.mock("@/lib/inference/local-model-operations", () => ({
   getLocalModelStatusSnapshot: mocks.getSnapshot,
+}));
+vi.mock("@/lib/inference/local-model-context-reconcile", () => ({
+  resolveServedContextInfo: mocks.getServedContextInfo,
 }));
 
 import { GET } from "./route";
@@ -16,6 +20,15 @@ describe("GET /api/platform/ai/local-models/status", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.requireCapability.mockResolvedValue({ userId: "operator-1" });
+    mocks.getServedContextInfo.mockResolvedValue({
+      served: 131_072,
+      target: 131_072,
+      ceiling: 131_072,
+      reasoningEnvelope: 30_720,
+      reasoningEligible: true,
+      host: { architecture: "discrete", vramGb: 24 },
+      selectedModel: "hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M",
+    });
   });
 
   it("returns a no-store authoritative snapshot", async () => {
@@ -26,7 +39,19 @@ describe("GET /api/platform/ai/local-models/status", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-store, max-age=0");
-    await expect(response.json()).resolves.toEqual(snapshot);
+    await expect(response.json()).resolves.toEqual({
+      ...snapshot,
+      runtime: {
+        reviewer: expect.objectContaining({
+          role: "high-trust-reviewer",
+          effectiveTimeoutMs: 600_000,
+        }),
+        servedContext: expect.objectContaining({
+          servedTokens: 131_072,
+          selectedModel: "hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M",
+        }),
+      },
+    });
     expect(mocks.requireCapability).toHaveBeenCalledWith("manage_provider_connections");
   });
 

--- a/apps/web/app/api/platform/ai/local-models/status/route.ts
+++ b/apps/web/app/api/platform/ai/local-models/status/route.ts
@@ -3,6 +3,8 @@ import { randomUUID } from "node:crypto";
 import { NextResponse } from "next/server";
 import { requireCapability } from "@/lib/actions/shared/guards";
 import { getLocalModelStatusSnapshot } from "@/lib/inference/local-model-operations";
+import { resolveServedContextInfo } from "@/lib/inference/local-model-context-reconcile";
+import { resolveLocalReviewerRuntimeDiagnostics } from "@/lib/routing/local-inference-runtime-policy";
 
 export const dynamic = "force-dynamic";
 
@@ -12,8 +14,27 @@ const INSTANCE = "/api/platform/ai/local-models/status";
 export async function GET(): Promise<Response> {
   try {
     await requireCapability("manage_provider_connections");
-    const snapshot = await getLocalModelStatusSnapshot();
-    return NextResponse.json(snapshot, {
+    const [snapshot, context] = await Promise.all([
+      getLocalModelStatusSnapshot(),
+      resolveServedContextInfo(),
+    ]);
+    return NextResponse.json({
+      ...snapshot,
+      runtime: {
+        reviewer: resolveLocalReviewerRuntimeDiagnostics({
+          defaultTimeoutMs: process.env.DPF_INFERENCE_TIMEOUT_MS,
+          localTimeoutMs: process.env.DPF_LOCAL_INFERENCE_TIMEOUT_MS,
+        }),
+        servedContext: {
+          servedTokens: context.served,
+          targetTokens: context.target,
+          ceilingTokens: context.ceiling,
+          reasoningEnvelopeTokens: context.reasoningEnvelope,
+          reasoningEligible: context.reasoningEligible,
+          selectedModel: context.selectedModel,
+        },
+      },
+    }, {
       headers: { "Cache-Control": CACHE_CONTROL },
     });
   } catch (error) {

--- a/apps/web/components/platform/OllamaManagement.test.tsx
+++ b/apps/web/components/platform/OllamaManagement.test.tsx
@@ -82,6 +82,13 @@ describe("OllamaManagement", () => {
     expect(container.textContent).not.toMatch(/copy|terminal|powershell|docker model/i);
   });
 
+  it("identifies Qwen3.8 27B as the high-trust reviewer without recommending 8B", () => {
+    const { container } = render(<OllamaManagement canWrite vramGb={24} providerId="local" />);
+
+    expect(screen.getByText("High-trust reviewer")).toBeTruthy();
+    expect(container.textContent).not.toContain("★ Qwen3 8B");
+  });
+
   it("makes the embedding consequence explicit before removing Nomic", async () => {
     render(<OllamaManagement canWrite vramGb={24} providerId="local" />);
 

--- a/apps/web/components/platform/OllamaManagement.tsx
+++ b/apps/web/components/platform/OllamaManagement.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { deleteOllamaModel, pullOllamaModel } from "@/lib/actions/ollama-management";
 import { useBackgroundOperationObserver } from "@/lib/hooks/useBackgroundOperationObserver";
+import { StatusBadge } from "@/components/ui/report-kit";
 import type { LocalModelOperation, LocalModelStatusSnapshot } from "@/lib/inference/local-model-operations";
 import {
   formatModelBytes,
@@ -249,7 +250,12 @@ function CatalogRow({ model, installed, operation, canWrite, busy, hardwareFit, 
     <article style={{ border: "1px solid var(--dpf-border)", borderRadius: 7, display: "flex", gap: 12,
       justifyContent: "space-between", opacity: hardwareFit ? 1 : 0.62, padding: "11px 12px" }}>
       <div>
-        <div style={{ color: "var(--dpf-text)", fontSize: 12, fontWeight: 600 }}>{model.recommended ? "★ " : ""}{model.name}</div>
+        <div style={{ alignItems: "center", color: "var(--dpf-text)", display: "flex", flexWrap: "wrap", fontSize: 12, fontWeight: 600, gap: 6 }}>
+          <span>{model.name}</span>
+          {model.governanceRole === "high-trust-reviewer" && (
+            <StatusBadge intent="accent" label="High-trust reviewer" uppercase={false} variant="soft" />
+          )}
+        </div>
         <div style={{ color: "var(--dpf-muted)", fontSize: 10, marginTop: 3 }}>
           {model.vramGb} GB graphics memory · {model.contextK}K context{model.toolUse ? " · Tool use" : ""}{!hardwareFit ? " · Exceeds detected memory" : ""}
         </div>

--- a/apps/web/lib/inference/local-model-catalog.test.ts
+++ b/apps/web/lib/inference/local-model-catalog.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { GOVERNED_LOCAL_REVIEWER } from "@/lib/routing/local-inference-runtime-policy";
+import { LOCAL_MODEL_CATALOG } from "./local-model-catalog";
+
+describe("local model catalog policy", () => {
+  it("distinguishes the governed 27B reviewer from low-memory catalog choices", () => {
+    const eightB = LOCAL_MODEL_CATALOG.find((model) => model.id === "ai/qwen3:8B-Q4_K_M");
+    const reviewer = LOCAL_MODEL_CATALOG.find((model) => model.id === GOVERNED_LOCAL_REVIEWER.modelId);
+
+    expect(eightB).not.toHaveProperty("recommended");
+    expect(eightB?.governanceRole).toBeUndefined();
+    expect(reviewer).toEqual(expect.objectContaining({ governanceRole: "high-trust-reviewer" }));
+  });
+});

--- a/apps/web/lib/inference/local-model-catalog.ts
+++ b/apps/web/lib/inference/local-model-catalog.ts
@@ -1,14 +1,16 @@
+import { GOVERNED_LOCAL_REVIEWER } from "@/lib/routing/local-inference-runtime-policy";
+
 export type LocalModelCategory = "coworkers" | "coding" | "embeddings" | "general";
 
 export type LocalCatalogModel = {
   id: string; name: string; description: string; vramGb: number; contextK: number;
-  toolUse: boolean; category: LocalModelCategory; recommended?: boolean;
+  toolUse: boolean; category: LocalModelCategory; governanceRole?: "high-trust-reviewer";
 };
 
 export const LOCAL_MODEL_CATALOG: LocalCatalogModel[] = [
-  { id: "ai/qwen3:8B-Q4_K_M", name: "Qwen3 8B", description: "Fast coworker model with strong tool use. Runs on most recent GPUs.", vramGb: 6, contextK: 32, toolUse: true, category: "coworkers", recommended: true },
+  { id: "ai/qwen3:8B-Q4_K_M", name: "Qwen3 8B", description: "Strong tool use on most recent GPUs.", vramGb: 6, contextK: 32, toolUse: true, category: "coworkers" },
   { id: "ai/qwen3:14B-Q6_K", name: "Qwen3 14B", description: "Stronger tool use with more memory pressure.", vramGb: 12, contextK: 32, toolUse: true, category: "coworkers" },
-  { id: "hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M", name: "Qwen3.8 27B", description: "Thorough long-context model. Best with 24 GB or more graphics memory.", vramGb: 18, contextK: 262, toolUse: true, category: "coworkers" },
+  { id: GOVERNED_LOCAL_REVIEWER.modelId, name: "Qwen3.8 27B", description: "Governed high-trust reviewer for thorough long-context work. Best with 24 GB or more graphics memory.", vramGb: 18, contextK: 262, toolUse: true, category: "coworkers", governanceRole: GOVERNED_LOCAL_REVIEWER.role },
   { id: "ai/qwen3.6:35B-A3B-UD-Q4_K_M", name: "Qwen3.6 35B-A3B", description: "Faster mixture-of-experts model for high-memory systems.", vramGb: 22, contextK: 32, toolUse: true, category: "coworkers" },
   { id: "ai/qwen2.5-coder:14b", name: "Qwen2.5 Coder 14B", description: "Coding-focused model with long context and structured output.", vramGb: 10, contextK: 128, toolUse: true, category: "coding" },
   { id: "ai/qwen2.5-coder:7b", name: "Qwen2.5 Coder 7B", description: "Lighter coding model for smaller GPUs.", vramGb: 6, contextK: 128, toolUse: true, category: "coding" },

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -34,19 +34,15 @@ import { withLocalInferenceLock } from "@/lib/queue/resource-lane";
 import { buildAnthropicSystem } from "./anthropic-cache";
 import { parseOpenRouterRoutingEvidence } from "./provider-suitability/openrouter-policy";
 import { resolveOpenAiCompatibleApiBase } from "./openai-base";
+import {
+  createInferenceTimeoutSignal,
+  resolveInferenceRuntimePolicy,
+} from "./local-inference-runtime-policy";
 
 // ─── Inference HTTP timeouts ──────────────────────────────────────────────────
-// A hung local Docker Model Runner endpoint must fail fast so callWithFallbackChain
-// can advance to a cloud endpoint (or surface a clear error) instead of leaving the
-// coworker on a "still working" spinner for three minutes — the failure observed in
-// the fresh-install audit (R1-*-O-001). Cloud providers keep the longer ceiling.
-// Both are env-overridable for operators on slow local hardware / cold model loads.
-const DEFAULT_INFERENCE_TIMEOUT_MS = Number(process.env.DPF_INFERENCE_TIMEOUT_MS) || 180_000;
-const LOCAL_INFERENCE_TIMEOUT_MS = Number(process.env.DPF_LOCAL_INFERENCE_TIMEOUT_MS) || 120_000;
-
-function resolveInferenceTimeoutMs(providerId: string): number {
-  return providerId === "local" ? LOCAL_INFERENCE_TIMEOUT_MS : DEFAULT_INFERENCE_TIMEOUT_MS;
-}
+// The runtime-policy module separates the governed, deliberately slower 27B
+// reviewer from generic local models. Both operator overrides and defaults stay
+// bounded, while the reviewer always receives its approved ten-minute window.
 
 // A single-GPU local endpoint (Docker Model Runner / Ollama) serves ONE request
 // at a time. The platform routinely fires inference concurrently — reviewBuildPlan
@@ -383,7 +379,10 @@ export const chatAdapter: ExecutionAdapterHandler = {
         method: "POST",
         headers: requestHeaders,
         body: JSON.stringify(body),
-        signal: AbortSignal.timeout(resolveInferenceTimeoutMs(providerId)),
+        signal: createInferenceTimeoutSignal(resolveInferenceRuntimePolicy(providerId, modelId, {
+          defaultTimeoutMs: process.env.DPF_INFERENCE_TIMEOUT_MS,
+          localTimeoutMs: process.env.DPF_LOCAL_INFERENCE_TIMEOUT_MS,
+        }).effectiveTimeoutMs),
       });
       res = providerId === "local" ? await withLocalInferenceLock(doFetch) : await doFetch();
     } catch (e) {

--- a/apps/web/lib/routing/local-inference-runtime-policy.test.ts
+++ b/apps/web/lib/routing/local-inference-runtime-policy.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  GOVERNED_LOCAL_REVIEWER,
+  LOCAL_INFERENCE_TIMEOUT_CEILING_MS,
+  createInferenceTimeoutSignal,
+  resolveInferenceRuntimePolicy,
+  resolveLocalReviewerRuntimeDiagnostics,
+} from "./local-inference-runtime-policy";
+
+describe("local inference runtime policy", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("gives the governed Qwen3.8 27B reviewer a 600000ms timeout by default", () => {
+    expect(resolveInferenceRuntimePolicy("local", GOVERNED_LOCAL_REVIEWER.modelId, {})).toEqual({
+      effectiveTimeoutMs: 600_000,
+      timeoutCeilingMs: 600_000,
+      source: "governed-reviewer-policy",
+      role: "high-trust-reviewer",
+    });
+  });
+
+  it("keeps an explicit 600000ms local timeout observable and bounded", () => {
+    expect(resolveInferenceRuntimePolicy("local", "ai/qwen3:8B-Q4_K_M", {
+      localTimeoutMs: "600000",
+    })).toEqual({
+      effectiveTimeoutMs: 600_000,
+      timeoutCeilingMs: 600_000,
+      source: "operator-local-timeout",
+      role: "general-local",
+    });
+    expect(resolveInferenceRuntimePolicy("local", "ai/qwen3:8B-Q4_K_M", {
+      localTimeoutMs: "900000",
+    }).effectiveTimeoutMs).toBe(LOCAL_INFERENCE_TIMEOUT_CEILING_MS);
+  });
+
+  it("does not abort a governed reviewer response after the old 120000ms ceiling", async () => {
+    vi.useFakeTimers();
+    const factory = vi.fn((timeoutMs: number) => {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), timeoutMs);
+      return controller.signal;
+    });
+    const policy = resolveInferenceRuntimePolicy("local", GOVERNED_LOCAL_REVIEWER.modelId, {});
+    const signal = createInferenceTimeoutSignal(policy.effectiveTimeoutMs, factory);
+
+    await vi.advanceTimersByTimeAsync(120_001);
+
+    expect(signal.aborted).toBe(false);
+    expect(factory).toHaveBeenCalledWith(600_000);
+  });
+
+  it("exposes the effective governed reviewer configuration", () => {
+    expect(resolveLocalReviewerRuntimeDiagnostics({ localTimeoutMs: "600000" })).toEqual({
+      modelId: GOVERNED_LOCAL_REVIEWER.modelId,
+      role: "high-trust-reviewer",
+      effectiveTimeoutMs: 600_000,
+      timeoutCeilingMs: 600_000,
+      timeoutSource: "governed-reviewer-policy",
+    });
+  });
+});

--- a/apps/web/lib/routing/local-inference-runtime-policy.ts
+++ b/apps/web/lib/routing/local-inference-runtime-policy.ts
@@ -1,0 +1,121 @@
+/**
+ * Canonical runtime policy for governed local inference.
+ *
+ * Installer selection and reviewer trust answer different questions. The
+ * installer chooses a broadly compatible model for a host; this policy keeps
+ * the explicitly selected, slower 27B reviewer usable without letting generic
+ * timeout configuration wait forever.
+ */
+
+export const LOCAL_INFERENCE_TIMEOUT_CEILING_MS = 600_000;
+export const DEFAULT_LOCAL_INFERENCE_TIMEOUT_MS = 120_000;
+export const DEFAULT_CLOUD_INFERENCE_TIMEOUT_MS = 180_000;
+
+export const GOVERNED_LOCAL_REVIEWER = {
+  modelId: "hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M",
+  role: "high-trust-reviewer",
+  inferenceTimeoutMs: LOCAL_INFERENCE_TIMEOUT_CEILING_MS,
+} as const;
+
+export type InferenceRuntimePolicy = {
+  effectiveTimeoutMs: number;
+  timeoutCeilingMs: number | null;
+  source: "governed-reviewer-policy" | "operator-local-timeout" | "local-default" | "operator-default-timeout" | "provider-default";
+  role: "high-trust-reviewer" | "general-local" | "provider";
+};
+
+type TimeoutConfiguration = {
+  localTimeoutMs?: string | number | null;
+  defaultTimeoutMs?: string | number | null;
+};
+
+function modelComparisonKey(modelId: string): string {
+  return modelId
+    .trim()
+    .replace(/^docker\.io\//i, "")
+    .replace(/^huggingface\.co\//i, "hf.co/")
+    .replace(/:latest$/i, "")
+    .toLowerCase();
+}
+
+function boundedTimeout(
+  raw: string | number | null | undefined,
+  fallback: number,
+  ceiling: number | null,
+): {
+  value: number;
+  configured: boolean;
+} {
+  const parsed = raw == null || raw === "" ? Number.NaN : Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return { value: fallback, configured: false };
+  return {
+    value: ceiling === null ? Math.trunc(parsed) : Math.min(ceiling, Math.trunc(parsed)),
+    configured: true,
+  };
+}
+
+export function resolveInferenceRuntimePolicy(
+  providerId: string,
+  modelId: string,
+  configuration: TimeoutConfiguration,
+): InferenceRuntimePolicy {
+  if (
+    providerId === "local"
+    && modelComparisonKey(modelId) === modelComparisonKey(GOVERNED_LOCAL_REVIEWER.modelId)
+  ) {
+    return {
+      effectiveTimeoutMs: GOVERNED_LOCAL_REVIEWER.inferenceTimeoutMs,
+      timeoutCeilingMs: LOCAL_INFERENCE_TIMEOUT_CEILING_MS,
+      source: "governed-reviewer-policy",
+      role: GOVERNED_LOCAL_REVIEWER.role,
+    };
+  }
+
+  if (providerId === "local") {
+    const timeout = boundedTimeout(
+      configuration.localTimeoutMs,
+      DEFAULT_LOCAL_INFERENCE_TIMEOUT_MS,
+      LOCAL_INFERENCE_TIMEOUT_CEILING_MS,
+    );
+    return {
+      effectiveTimeoutMs: timeout.value,
+      timeoutCeilingMs: LOCAL_INFERENCE_TIMEOUT_CEILING_MS,
+      source: timeout.configured ? "operator-local-timeout" : "local-default",
+      role: "general-local",
+    };
+  }
+
+  const timeout = boundedTimeout(configuration.defaultTimeoutMs, DEFAULT_CLOUD_INFERENCE_TIMEOUT_MS, null);
+  return {
+    effectiveTimeoutMs: timeout.value,
+    timeoutCeilingMs: null,
+    source: timeout.configured ? "operator-default-timeout" : "provider-default",
+    role: "provider",
+  };
+}
+
+export function createInferenceTimeoutSignal(
+  timeoutMs: number,
+  factory: (milliseconds: number) => AbortSignal = AbortSignal.timeout,
+): AbortSignal {
+  return factory(timeoutMs);
+}
+
+export function resolveLocalReviewerRuntimeDiagnostics(
+  configuration: TimeoutConfiguration,
+): {
+  modelId: string;
+  role: "high-trust-reviewer";
+  effectiveTimeoutMs: number;
+  timeoutCeilingMs: number;
+  timeoutSource: InferenceRuntimePolicy["source"];
+} {
+  const policy = resolveInferenceRuntimePolicy("local", GOVERNED_LOCAL_REVIEWER.modelId, configuration);
+  return {
+    modelId: GOVERNED_LOCAL_REVIEWER.modelId,
+    role: GOVERNED_LOCAL_REVIEWER.role,
+    effectiveTimeoutMs: policy.effectiveTimeoutMs,
+    timeoutCeilingMs: policy.timeoutCeilingMs ?? LOCAL_INFERENCE_TIMEOUT_CEILING_MS,
+    timeoutSource: policy.source,
+  };
+}

--- a/docs/superpowers/plans/2026-08-24-local-model-management.md
+++ b/docs/superpowers/plans/2026-08-24-local-model-management.md
@@ -21,6 +21,7 @@ The existing local-provider route becomes an honest, fully in-product control su
 - D2 durable model-install operation -> `BI-1FFDF4B1`
 - D3 local-tailored provider UX -> `BI-1FFDF4B1`
 - D4 measured verification and generated projections -> `BI-1FFDF4B1`
+- D5 governed 27B reviewer runtime and diagnostics -> `BI-1FFDF4B1`
 - Dependencies: none
 - Receipt: `cmt6julqc01vl01mxqlrsaz15`
 - Rationale: Native management, durable execution, the tailored operator surface, and routing reconciliation are one end-to-end correction; no phase is independently useful or safe to ship.
@@ -40,6 +41,7 @@ All phases therefore ship and verify as one cohesive behavior slice.
 | D2 | Durable model-install operation | R4, R5, R8, R10, R11 | C3 manual-job receipt; C4 queue execution | F2 install | V2 queue/action tests | D1 |
 | D3 | Local-tailored provider UX | R1, R3, R4, R6, R7, R9, R11 | C5 locality composition; C6 honest view model | F1–F3 | V3 component/route tests | D1, D2 |
 | D4 | Measured verification and generated projections | R8, R12, R13 | C7 UX-fit and route projection | F4 verification | V4 guards/live sweep | D1, D2, D3 |
+| D5 | Governed 27B reviewer runtime and diagnostics | R14–R16 | C8 policy separation; C9 timeout resolver | Existing chat dispatch and status read flows | V5 reviewer runtime tests | D1, D3 |
 
 Contract, flow, and verification identifiers refer to the matching sections in the design document.
 
@@ -78,6 +80,14 @@ The deliverable table above is the four-way traceability record for this atomic 
 4. Acquire the governed shared nonproduction environment, verify the actual route in dark/light at desktop/narrow sizes, and exercise one small reversible install/remove path if the runtime supports it. Capture DOM/state assertions as well as screenshots. **[D4, R12, V4]**
 5. Write `docs/ux-fit/2026-08-24-local-model-management.ux-fit.json` with `sweep-measurement` evidence for the exact UI diff and route budget axes. **[D4, R12, C7]**
 6. Run exact-tree local merged-code CI, independent semantic review, DCO commit/PR gates, record Workroom/external evidence, and hand off a regular ready PR. **[D4, V4]**
+
+## Phase 5 — Governed reviewer runtime correction
+
+1. Add failing tests for the governed 27B identity, unset/default and explicit 600,000 ms timeout behavior, the 600,000 ms upper bound, and a response that remains live beyond the former 120-second abort. **[D5, R14, R15, V5]**
+2. Add one pure reviewer-runtime policy consumed by chat dispatch and diagnostics. Keep PR #4624's installer tiers unchanged: initial host selection and high-trust review are separate decisions. **[D5, C8, C9]**
+3. Remove the catalog's generic 8B recommendation and label Qwen3.8 27B as the high-trust reviewer without changing its explicit-install workflow. **[D5, R14]**
+4. Extend the authenticated local-model status projection with the effective reviewer timeout and DMR-backed served-context facts. Do not expose raw environment values or cross into BI-F0715C9C's readiness envelope. **[D5, R16]**
+5. Run the focused runtime, catalog, route, component, and full chat-adapter suites before the repository guards and exact-tree gate. **[D5, V5]**
 
 ## Refactor allocation
 

--- a/docs/superpowers/specs/2026-08-24-local-model-management-design.md
+++ b/docs/superpowers/specs/2026-08-24-local-model-management-design.md
@@ -54,6 +54,9 @@ The DPF unified connector kernel is adjacent but not the ownership boundary: DMR
 - **R11 — Observable async UX:** actions use the shared busy/status patterns, live-region announcements, disabled duplicate controls, and bounded background-state observation.
 - **R12 — Measured fit:** the exact route is verified in dark and light themes at desktop and narrow widths, with a measured UX-fit artifact.
 - **R13 — Safe HTTP failures:** the net-new JSON status route returns bounded `application/problem+json` failures with a stable DPF problem type and request correlation ID.
+- **R14 — Governed reviewer:** Qwen3.8 27B remains the governed high-trust local reviewer. The catalog names that role explicitly; a low-memory catalog choice cannot override it through a generic recommendation flag.
+- **R15 — Bounded reviewer latency:** the governed reviewer receives an effective 600,000 ms inference window. Generic local overrides remain capped at that value, while unrelated provider timeouts retain their existing behavior.
+- **R16 — Observable runtime:** the authenticated status projection exposes the reviewer model, effective timeout, timeout source, ceiling, and live served-context facts without exposing environment values.
 
 ## Architecture
 
@@ -66,6 +69,9 @@ The DPF unified connector kernel is adjacent but not the ownership boundary: DMR
 | Background execution | Existing Inngest event/function substrate | DMR `POST /models/create` |
 | Routable model catalog | Existing `DiscoveredModel` and `ModelProfile` records | Provider routing and model cards |
 | Local/cloud classification | Existing `isLocalProviderId` routing primitive | Provider detail composition |
+| Fresh-install model choice | `scripts/installer/local-model-policy.json` from PR #4624 | Installers and host detection |
+| Governed reviewer runtime | `lib/routing/local-inference-runtime-policy.ts` | Chat adapter and authenticated diagnostics |
+| Effective served context | DMR `_configure` through `resolveServedContextInfo` | Authenticated diagnostics |
 
 No new database model, provider, or host-shell capability is introduced. `ScheduledJob` already carries manually triggered inference evaluation/probe state; a deterministic `local-model-install:<sha256>` job ID gives each model one bounded, retry-safe operation row. Its metadata contains only the validated model reference, requested-by ID, byte progress, total bytes, message, and timestamps.
 
@@ -80,6 +86,8 @@ The operation states are a closed TypeScript union—`queued`, `running`, `compl
 - **C5 — Locality composition:** the canonical `isLocalProviderId` primitive decides whether cloud posture controls apply.
 - **C6 — Honest view model:** byte counts remain nullable end to end and unknown data is named, never converted to zero.
 - **C7 — UX and route projection:** the existing provider route owns the workflow; generated route/doc projections and measured UX-fit evidence change with it.
+- **C8 — Separate policy questions:** the installer selects a broadly compatible initial model; the reviewer-runtime policy identifies the trusted reviewer and its latency budget. Neither is projected as the other's recommendation.
+- **C9 — One timeout resolver:** chat dispatch and diagnostics consume the same pure runtime-policy resolver, so the displayed effective timeout cannot drift from the abort signal.
 
 ### F1 — Read flow
 
@@ -120,6 +128,18 @@ DMR's local policy permits one generation model plus small supporting models, an
 
 **Decision: fits with guardrails.** This is a contextual management workflow on the existing Platform provider-detail route, not a new top-level destination.
 
+### UX fit review — governed reviewer label
+
+- **Decision:** fits.
+- **Owning area / route:** Platform, on the existing `/platform/ai/providers/local` detail family.
+- **Primary persona:** platform operator choosing an on-box model; they should not need to infer trust from model size or an unexplained star.
+- **Navigation / AI boundary:** no navigation layer changes and the label starts no coworker work.
+- **Reuse:** the existing catalog row and report-kit `StatusBadge`; no new badge primitive or color map.
+- **Source truth:** `lib/routing/local-inference-runtime-policy.ts` owns the reviewer identity and timeout; DMR owns served context; PR #4624's installer policy remains a separate initial-selection authority.
+- **Empty/failure behavior:** unchanged. The label appears only on the governed catalog entry; existing unavailable, permission, and management failure states remain authoritative.
+- **Evidence before merge:** catalog/component/route tests, prose/style/module guards, exact-tree gate, and the existing measured UX-fit manifest.
+- **Captured in:** this section and `docs/ux-fit/2026-08-24-local-model-management.ux-fit.json`.
+
 - **Persona:** founder/operator or platform operator managing on-box AI capacity.
 - **Primary question:** “What is installed, how much space does it use, and can I change it here?”
 - **First viewport:** local status and installed inventory, followed by the model catalog. Cloud contract questions are absent.
@@ -144,6 +164,7 @@ DMR's local policy permits one generation model plus small supporting models, an
 - **V2 — Queue lifecycle:** queue-function tests cover canonical states, progress, concurrency/idempotency behavior, success, failure, and reconciliation.
 - **V3 — Route and components:** tests cover local/cloud form branching, honest sizes, Install/Remove behavior, embedding consequence copy, async announcements, safe Problem Details, and absence of terminal/script/clipboard instructions.
 - **V4 — Repository and live:** existing provider, routing, event-provider, queue registry, prose, style-drift, route-manifest, type, and exact-tree guards run before governed live verification on `/platform/ai/providers/local` in dark/light themes and desktop/narrow viewports. The live path includes one reversible small-model install/remove flow where practical.
+- **V5 — Reviewer runtime:** tests cover the unset/default 27B policy, an explicit 600,000 ms local override, upper-bound clamping, survival beyond the former 120,000 ms abort, catalog-role reconciliation, and status diagnostics containing the effective timeout plus served context. Infrastructure timeout evidence remains a runtime/configuration finding and never changes reviewer trust.
 
 ## Alternatives considered
 


### PR DESCRIPTION
## Summary

- Preserve `hf.co/ggml-org/Qwen3.8-27B-GGUF:Q4_K_M` as the governed high-trust local reviewer.
- Give that reviewer an effective 600,000 ms inference timeout, while keeping the ordinary local default at 120,000 ms and capping explicit local overrides at 600,000 ms.
- Remove the generic `recommended: true` signal from Qwen3.8 8B and expose the 27B governance role in the local-model catalog and status UI.
- Report the effective reviewer timeout and served context from the local-model status endpoint so runtime policy is observable.

## Policy reconciliation

PR #4624 remains the fresh-install selection policy: it may choose the curated coder model appropriate to detected hardware. This change is a separate runtime-review policy and does not alter installer selection or BI-F0715C9C's immutable readiness envelope.

Cloud-provider timeout behavior is unchanged. Other local models retain the 120,000 ms default; only the exact governed 27B reviewer receives 600,000 ms independent of the generic local default.

## Design grounding

- Extends the existing local-model catalog, provider status route, and routing adapter rather than adding a new provider or readiness contract.
- Keeps the canonical reviewer runtime policy in `apps/web/lib/routing` to preserve application-boundary direction.
- Uses the existing report-kit `StatusBadge` for the high-trust reviewer label.
- Updates the committed design and implementation plan for BI-1FFDF4B1.

## Verification

- TDD covers the 120,000 ms ordinary local default, explicit local overrides capped at 600,000 ms, exact 600,000 ms behavior for the governed 27B reviewer, and a request surviving beyond 120 seconds.
- Targeted suite: 5 files / 46 tests passed.
- Expanded local-model, routing, context, admission, and status blast-radius suite: 16 files / 196 tests passed.
- Web typecheck and repository boundary, style, prose, documentation-anchor, context, and UX-fit guards passed.
- Exact-tree merged-code pregate passed for the current `main` base, including production compilation and container packaging.

## Deliberate follow-up

The newly observed generic 8-tool small-local-model spinning guard is not changed here. Open PR #4627 already owns `apps/web/lib/tak/agentic-loop.ts` and its tests, and this Workroom does not claim those paths. A linked follow-up must make that guard model/profile- and successful-progress-aware for the 27B reviewer while preserving protection for actual small local fallback spinning; no quality or tool limit should be lowered.

DPF-Backlog-Item: BI-1FFDF4B1
