### PR TITLE
fix: make consumer image self-upgrade registry-authoritative

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -195,7 +195,7 @@ jobs:
           # Harmless for images whose Dockerfile ignores DPF_VERSION.
           build-args: |
             DPF_VERSION=${{ github.sha }}
-            DPF_PLATFORM_VERSION=${{ github.ref_name }}
+            DPF_PLATFORM_VERSION=${{ needs.gate.outputs.tag }}
           # Same identity, in the OCI-standard place. /app/.dpf-image-version is inside
           # the filesystem, so reading it costs a `docker create` + `docker cp`; a label
           # is readable straight from the manifest. `latest` sat 1851 commits behind main
@@ -204,7 +204,7 @@ jobs:
           # portal self-reports, the label is what tooling inspects.
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.version=${{ needs.gate.outputs.tag }}
           # Push by digest only — the merge job assembles the named
           # tag manifest list. `type=image,name=...,push-by-digest=true`
           # uploads the layers under the digest with no human tag.

--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -102,8 +102,12 @@ vi.mock("@/components/ops/SelfUpgradeLiveProvider", () => ({
 // page-level tests can assert the trigger control is co-located INSIDE the
 // card, not merely passed as a prop nobody renders.
 vi.mock("@/components/ops/OwnerReleaseCard", () => ({
-  OwnerReleaseCard: (props: { summary: { state: string }; primaryAction?: React.ReactNode }) => (
-    <div data-testid="owner-release-card" data-release-state={props.summary.state}>
+  OwnerReleaseCard: (props: { summary: { state: string; availableVersion: string | null }; primaryAction?: React.ReactNode }) => (
+    <div
+      data-testid="owner-release-card"
+      data-release-state={props.summary.state}
+      data-available-version={props.summary.availableVersion ?? ""}
+    >
       {props.primaryAction}
     </div>
   ),
@@ -114,11 +118,12 @@ vi.mock("@/components/ops/OwnerReleaseCard", () => ({
 // co-located with the release card), not the trigger's own behavior (covered
 // in SelfUpgradeTriggerControl.test.tsx).
 vi.mock("@/components/ops/SelfUpgradeTriggerControl", () => ({
-  default: (props: { enabled: boolean; channel: string }) => (
+  default: (props: { enabled: boolean; channel: string; actionState: string }) => (
     <div
       data-testid="self-upgrade-trigger-control"
       data-enabled={String(props.enabled)}
       data-channel={props.channel}
+      data-action-state={props.actionState}
     />
   ),
 }));
@@ -176,6 +181,10 @@ const baseStatus = {
   deployedSha: null,
   deployedShaSource: "unknown" as const,
   targetSha: null,
+  targetTag: null,
+  targetAvailability: "unavailable" as const,
+  targetUnavailableReason: "no-target",
+  currentConfigDigest: null,
   isFresh: false,
   releaseBatch: {
     applicable: true,
@@ -368,12 +377,39 @@ describe("SelfUpgradePage", () => {
     expect(html).toContain('data-running-pr=""');
   });
 
+  it("uses release identity directly without Git merge-point resolution", async () => {
+    vi.mocked(getSelfUpgradeStatus).mockResolvedValue({
+      ...baseStatus,
+      enabled: true,
+      support: {
+        configuredEnabled: true,
+        supported: true,
+        enabled: true,
+        targetKind: "release-artifact",
+        reason: "enabled",
+        message: null,
+      },
+      isFresh: false,
+      targetSha: "b".repeat(40),
+      targetTag: "v2026.08.24",
+      targetAvailability: "resolved",
+      targetUnavailableReason: null,
+    } as never);
+    vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
+
+    const html = renderToStaticMarkup(await SelfUpgradePage());
+
+    expect(resolveUpgradeMergePoints).not.toHaveBeenCalled();
+    expect(html).toContain('data-available-version="v2026.08.24"');
+  });
+
   it("loads only the persisted impact summary during render when an update is available", async () => {
     vi.mocked(getSelfUpgradeStatus).mockResolvedValue({
       ...baseStatus,
       enabled: true,
       isFresh: false,
       targetSha: "b".repeat(40),
+      targetAvailability: "resolved",
     });
     vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
 
@@ -390,6 +426,7 @@ describe("SelfUpgradePage", () => {
       enabled: true,
       isFresh: true,
       targetSha: "b".repeat(40),
+      targetAvailability: "resolved",
     });
     vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
 
@@ -405,6 +442,7 @@ describe("SelfUpgradePage", () => {
       enabled: true,
       isFresh: false,
       targetSha: "b".repeat(40),
+      targetAvailability: "resolved",
     });
     vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
 
@@ -413,6 +451,7 @@ describe("SelfUpgradePage", () => {
     // Owner card first, derived state exposed.
     expect(html).toContain('data-testid="owner-release-card"');
     expect(html).toContain('data-release-state="update-available"');
+    expect(html).toContain('data-action-state="update-available"');
     // Technical controls preserved, now under an Advanced disclosure.
     expect(html).toContain('data-component="self-upgrade-advanced-toggle"');
     expect(html).toContain('data-testid="self-upgrade-client"');
@@ -420,6 +459,30 @@ describe("SelfUpgradePage", () => {
     expect(html.indexOf('data-testid="owner-release-card"')).toBeLessThan(
       html.indexOf('data-component="self-upgrade-advanced-toggle"'),
     );
+  });
+
+  it("keeps retry available after a failed attempt when the release is still newer", async () => {
+    vi.mocked(getSelfUpgradeStatus).mockResolvedValue({
+      ...baseStatus,
+      enabled: true,
+      isFresh: false,
+      targetSha: "b".repeat(40),
+      targetAvailability: "resolved",
+      targetUnavailableReason: null,
+      latestRun: {
+        runId: "SUR-retry",
+        status: "failed",
+        reason: "health-check-failed",
+        targetSha: "b".repeat(40),
+        completionEvidence: null,
+      },
+    } as never);
+    vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
+
+    const html = renderToStaticMarkup(await SelfUpgradePage());
+
+    expect(html).toContain('data-release-state="failed"');
+    expect(html).toContain('data-action-state="update-available"');
   });
 
   it("co-locates the primary trigger with the release status card, reachable on arrival in BOTH nav modes (BI-D77BF495)", async () => {

--- a/apps/web/app/(shell)/ops/self-upgrade/page.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.tsx
@@ -34,7 +34,7 @@ export default async function SelfUpgradePage() {
   const runs = runsResult?.runs ?? [];
   const nextCursor = runsResult?.nextCursor ?? null;
 
-  const initialImpactSummary = status?.targetSha
+  const initialImpactSummary = status?.targetSha && status.support.targetKind === "git-source"
     ? await loadPersistedImpactSummary(status.targetSha).catch(() => null)
     : null;
 
@@ -44,7 +44,7 @@ export default async function SelfUpgradePage() {
   // deployed id is a local merge commit that can never equal the upstream
   // target. The running end resolves from the upstream LINEAGE marker (not
   // deployedSha) so its subject actually carries a `(#N)`.
-  const mergePoints = status?.targetSha
+  const mergePoints = status?.targetSha && status.support.targetKind === "git-source"
     ? await (async () => {
         const [config, runningSha] = await Promise.all([
           getSelfUpgradeConfig().catch(() => null),
@@ -75,6 +75,10 @@ export default async function SelfUpgradePage() {
     deployedSha: null,
     deployedShaSource: "unknown",
     targetSha: null,
+    targetTag: null,
+    targetAvailability: "unavailable" as const,
+    targetUnavailableReason: "status-unavailable",
+    currentConfigDigest: null,
     isFresh: true,
     releaseBatch: {
       applicable: false,
@@ -145,6 +149,9 @@ export default async function SelfUpgradePage() {
       support: effectiveStatus.support,
       isFresh: effectiveStatus.isFresh,
       targetSha: effectiveStatus.targetSha,
+      targetTag: effectiveStatus.targetTag,
+      targetAvailability: effectiveStatus.targetAvailability,
+      targetUnavailableReason: effectiveStatus.targetUnavailableReason,
       deployedSha: effectiveStatus.deployedSha,
       nextWindowStart: effectiveStatus.nextWindowStart,
       blackoutUntil: effectiveStatus.blackoutUntil,
@@ -179,6 +186,15 @@ export default async function SelfUpgradePage() {
     cooldownUntil: effectiveStatus.cooldownUntil,
     jobEngine: effectiveStatus.jobEngine,
   };
+  const updateActionState = ownerSummary.state === "unavailable"
+    ? "unavailable"
+    : ownerSummary.state === "update-available" || (
+        ownerSummary.state === "failed" &&
+        effectiveStatus.targetAvailability === "resolved" &&
+        !effectiveStatus.isFresh
+      )
+      ? "update-available"
+      : "no-update";
 
   return (
     <SelfUpgradeLiveProvider initialSnapshot={initialLiveSnapshot}>
@@ -198,6 +214,7 @@ export default async function SelfUpgradePage() {
           primaryAction={
             <SelfUpgradeTriggerControl
               enabled={clientProps.enabled}
+              actionState={updateActionState}
               unavailableReason={
                 clientProps.support.supported ? null : clientProps.support.message
               }

--- a/apps/web/components/ops/SelfUpgradeTriggerControl.live.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeTriggerControl.live.test.tsx
@@ -57,7 +57,7 @@ describe("SelfUpgradeTriggerControl live observation", () => {
 
   it("rehydrates the targeted status after enqueue without refreshing the route", async () => {
     render(
-      <SelfUpgradeTriggerControl enabled channel="stable" latestRun={null} />,
+      <SelfUpgradeTriggerControl enabled actionState="update-available" channel="stable" latestRun={null} />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Upgrade now" }));

--- a/apps/web/components/ops/SelfUpgradeTriggerControl.swap-resilience.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeTriggerControl.swap-resilience.test.tsx
@@ -43,6 +43,7 @@ function makeE394(): Error {
 
 const baseProps = {
   enabled: true,
+  actionState: "update-available" as const,
   channel: "stable",
   latestRun: null,
 } as const;

--- a/apps/web/components/ops/SelfUpgradeTriggerControl.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeTriggerControl.test.tsx
@@ -43,6 +43,7 @@ import SelfUpgradeTriggerControl from "./SelfUpgradeTriggerControl";
 
 const baseProps = {
   enabled: true,
+  actionState: "update-available" as const,
   channel: "stable",
   latestRun: null,
 };
@@ -108,6 +109,25 @@ describe("SelfUpgradeTriggerControl – enabled", () => {
     const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
     expect(html).toContain("Enabled");
     expect(html).toContain("stable");
+  });
+
+  it("does not expose upgrade or emergency controls when the install is current", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeTriggerControl {...baseProps} actionState="no-update" />,
+    );
+    expect(html).toContain("No update is ready");
+    expect(html).not.toContain('aria-label="Upgrade now"');
+    expect(html).not.toContain("Emergency override");
+  });
+
+  it("does not expose a mutation when update availability could not be verified", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeTriggerControl {...baseProps} actionState="unavailable" />,
+    );
+    expect(html).toContain("Update status unavailable");
+    expect(html).not.toContain('aria-label="Upgrade now"');
+    expect(html).not.toContain("Emergency override");
+    expect(html).not.toContain("Upgrade queued.");
   });
 
   it("renders the Upgrade now button, marked as the primary / next action (BI-D77BF495)", () => {

--- a/apps/web/components/ops/SelfUpgradeTriggerControl.tsx
+++ b/apps/web/components/ops/SelfUpgradeTriggerControl.tsx
@@ -28,6 +28,7 @@ import { useOptionalSelfUpgradeLive } from "@/components/ops/SelfUpgradeLiveProv
 
 type Props = {
   enabled: boolean;
+  actionState: "update-available" | "no-update" | "unavailable";
   unavailableReason?: string | null;
   channel: string;
   latestRun: LatestRun | null;
@@ -37,6 +38,7 @@ type Props = {
 
 export default function SelfUpgradeTriggerControl({
   enabled,
+  actionState,
   unavailableReason,
   channel,
   latestRun: initialLatestRun,
@@ -225,7 +227,7 @@ export default function SelfUpgradeTriggerControl({
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
-          <span className="w-2 h-2 rounded-full bg-[var(--dpf-success)]" />
+          <span className="w-2 h-2 rounded-full bg-[var(--dpf-success)]" aria-hidden="true" />
           <span className="text-sm font-medium text-[var(--dpf-text)]">
             Self-Upgrade: <span data-upgrade-status="enabled">Enabled</span>
           </span>
@@ -318,7 +320,7 @@ export default function SelfUpgradeTriggerControl({
                   : "Upgrade in progress…"}
               </span>
             )
-          ) : (
+          ) : actionState === "update-available" ? (
             <>
               <label className="flex items-center gap-1.5 text-xs text-[var(--dpf-muted)] cursor-pointer select-none">
                 <input
@@ -351,11 +353,21 @@ export default function SelfUpgradeTriggerControl({
                       : "Upgrade now"}
               </button>
             </>
+          ) : (
+            <span
+              className="text-xs text-[var(--dpf-muted)]"
+              data-upgrade-action-state={actionState}
+              role="status"
+            >
+              {actionState === "unavailable"
+                ? "Update status unavailable. Nothing queued."
+                : "No update is ready."}
+            </span>
           )}
         </div>
       </div>
 
-      {triggerBusy && latestRun?.status !== "running" && !queuedRun && (
+      {actionState === "update-available" && triggerBusy && latestRun?.status !== "running" && !queuedRun && (
         <div
           className="text-xs text-[var(--dpf-muted)]"
           data-upgrade-starting="true"
@@ -366,7 +378,7 @@ export default function SelfUpgradeTriggerControl({
         </div>
       )}
 
-      {triggerResult && (
+      {actionState === "update-available" && triggerResult && (
         <div
           className={`p-3 rounded-lg text-sm ${
             triggerResult.queued

--- a/apps/web/components/ops/SelfUpgradeTriggerControl.tsx
+++ b/apps/web/components/ops/SelfUpgradeTriggerControl.tsx
@@ -19,6 +19,11 @@ import { useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { triggerSelfUpgrade, forceActiveRun, abortActiveRun } from "@/lib/actions/promotions";
 import { isExpectedDuringSwap } from "@/lib/self-upgrade/is-expected-during-swap";
+import {
+  describeSelfUpgradeActionState,
+  SELF_UPGRADE_ACTION_STATE,
+  type SelfUpgradeActionState,
+} from "@/lib/self-upgrade/action-state";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import type { LatestRun, QuiescenceActivity } from "@/lib/self-upgrade/run-types";
 import SelfUpgradeJobEngineHealthAlert, {
@@ -28,7 +33,7 @@ import { useOptionalSelfUpgradeLive } from "@/components/ops/SelfUpgradeLiveProv
 
 type Props = {
   enabled: boolean;
-  actionState: "update-available" | "no-update" | "unavailable";
+  actionState: SelfUpgradeActionState;
   unavailableReason?: string | null;
   channel: string;
   latestRun: LatestRun | null;
@@ -69,6 +74,7 @@ export default function SelfUpgradeTriggerControl({
   const queuedRun = latestRun?.status === "queued" || latestRun?.status === "pending";
   const upgradeInFlight = queuedRun || latestRun?.status === "running" || draining;
   const triggerBusy = isPending || justQueued;
+  const updateAvailable = actionState === SELF_UPGRADE_ACTION_STATE.UPDATE_AVAILABLE;
 
   // The manual trigger only *queues* an upgrade: the server action returns
   // `{ queued: true }` in well under a second, but the worker still has to
@@ -320,8 +326,10 @@ export default function SelfUpgradeTriggerControl({
                   : "Upgrade in progress…"}
               </span>
             )
-          ) : actionState === "update-available" ? (
+          ) : (
             <>
+            {updateAvailable ? (
+              <>
               <label className="flex items-center gap-1.5 text-xs text-[var(--dpf-muted)] cursor-pointer select-none">
                 <input
                   type="checkbox"
@@ -352,22 +360,22 @@ export default function SelfUpgradeTriggerControl({
                       ? "Force upgrade now"
                       : "Upgrade now"}
               </button>
+              </>
+            ) : (
+              <span
+                className="text-xs text-[var(--dpf-muted)]"
+                data-upgrade-action-state={actionState}
+                role="status"
+              >
+                {describeSelfUpgradeActionState(actionState)}
+              </span>
+            )}
             </>
-          ) : (
-            <span
-              className="text-xs text-[var(--dpf-muted)]"
-              data-upgrade-action-state={actionState}
-              role="status"
-            >
-              {actionState === "unavailable"
-                ? "Update status unavailable. Nothing queued."
-                : "No update is ready."}
-            </span>
           )}
         </div>
       </div>
 
-      {actionState === "update-available" && triggerBusy && latestRun?.status !== "running" && !queuedRun && (
+      {updateAvailable && triggerBusy && latestRun?.status !== "running" && !queuedRun && (
         <div
           className="text-xs text-[var(--dpf-muted)]"
           data-upgrade-starting="true"
@@ -378,7 +386,7 @@ export default function SelfUpgradeTriggerControl({
         </div>
       )}
 
-      {actionState === "update-available" && triggerResult && (
+      {updateAvailable && triggerResult && (
         <div
           className={`p-3 rounded-lg text-sm ${
             triggerResult.queued

--- a/apps/web/lib/actions/promotions.self-upgrade.test-fixtures.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test-fixtures.ts
@@ -29,6 +29,7 @@ export const consumerReleaseSupport = {
 export const consumerReleaseContext = {
   installMode: "consumer",
   imageTag: "v1.0.0",
+  channelTag: "latest",
   installPath: "D:\\DPF",
   composeFiles: ["docker-compose.yml", "docker-compose.release.yml"],
   ghcrOwner: "opendigitalproductfactory",

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -51,10 +51,7 @@ vi.mock("@/lib/self-upgrade/completion", () => ({
   getDeployedSha: vi.fn(),
 }));
 
-vi.mock("@/lib/self-upgrade/runtime-image-identity", () => ({
-  readCurrentContainerConfigDigest: vi.fn(),
-}));
-
+vi.mock("@/lib/self-upgrade/runtime-image-identity", () => ({ readCurrentContainerConfigDigest: vi.fn().mockResolvedValue(`sha256:${"a".repeat(64)}`) }));
 vi.mock("@/lib/self-upgrade/run-store", () => ({
   createRun: vi.fn(),
   failRun: vi.fn(),
@@ -174,7 +171,6 @@ import { prisma } from "@dpf/db";
 import { getSelfUpgradeConfig } from "@/lib/self-upgrade/config";
 import { resolveTargetSha, isShaFresh } from "@/lib/self-upgrade/version";
 import { getDeployedSha } from "@/lib/self-upgrade/completion";
-import { readCurrentContainerConfigDigest } from "@/lib/self-upgrade/runtime-image-identity";
 import { readSelfUpgradeSupport } from "@/lib/self-upgrade/support";
 import { loadReleaseInstallContext, resolveReleaseUpgradeCandidate } from "@/lib/self-upgrade/release-target";
 import { createRun, getLatestRun, getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
@@ -204,7 +200,6 @@ beforeEach(() => {
   vi.mocked(auth).mockResolvedValue(mockSession as never);
   vi.mocked(can).mockReturnValue(true);
   vi.mocked(getSelfUpgradeConfig).mockResolvedValue(mockConfig as never);
-  vi.mocked(readCurrentContainerConfigDigest).mockResolvedValue(`sha256:${"a".repeat(64)}`);
   vi.mocked(readSelfUpgradeSupport).mockImplementation(async (configuredEnabled) => ({
     configuredEnabled,
     supported: true,
@@ -288,20 +283,11 @@ describe("getSelfUpgradeStatus", () => {
     const sourceSha = "f".repeat(40);
     vi.mocked(readSelfUpgradeSupport).mockResolvedValue(consumerReleaseSupport);
     vi.mocked(loadReleaseInstallContext).mockResolvedValue(consumerReleaseContext);
-    vi.mocked(resolveReleaseUpgradeCandidate).mockResolvedValue({
-      kind: "target",
-      tag: "v2.0.0",
-      sourceSha,
-      channelDigest: `sha256:${"b".repeat(64)}`,
-      configDigest: `sha256:${"c".repeat(64)}`,
-    });
+    vi.mocked(resolveReleaseUpgradeCandidate).mockResolvedValue({ kind: "target", tag: "v2.0.0", sourceSha, channelDigest: `sha256:${"b".repeat(64)}`, configDigest: `sha256:${"c".repeat(64)}` });
     vi.mocked(getDeployedSha).mockResolvedValue("e".repeat(40));
     vi.mocked(isShaFresh).mockReturnValue(false);
     const result = await getSelfUpgradeStatus();
-
-    expect(result.targetSha).toBe(sourceSha);
-    expect(result.targetTag).toBe("v2.0.0");
-    expect(result.targetAvailability).toBe("resolved");
+    expect(result).toMatchObject({ targetSha: sourceSha, targetTag: "v2.0.0", targetAvailability: "resolved" });
     expect(resolveTargetSha).not.toHaveBeenCalled();
   });
 

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -51,6 +51,10 @@ vi.mock("@/lib/self-upgrade/completion", () => ({
   getDeployedSha: vi.fn(),
 }));
 
+vi.mock("@/lib/self-upgrade/runtime-image-identity", () => ({
+  readCurrentContainerConfigDigest: vi.fn(),
+}));
+
 vi.mock("@/lib/self-upgrade/run-store", () => ({
   createRun: vi.fn(),
   failRun: vi.fn(),
@@ -170,6 +174,7 @@ import { prisma } from "@dpf/db";
 import { getSelfUpgradeConfig } from "@/lib/self-upgrade/config";
 import { resolveTargetSha, isShaFresh } from "@/lib/self-upgrade/version";
 import { getDeployedSha } from "@/lib/self-upgrade/completion";
+import { readCurrentContainerConfigDigest } from "@/lib/self-upgrade/runtime-image-identity";
 import { readSelfUpgradeSupport } from "@/lib/self-upgrade/support";
 import { loadReleaseInstallContext, resolveReleaseUpgradeCandidate } from "@/lib/self-upgrade/release-target";
 import { createRun, getLatestRun, getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
@@ -199,6 +204,7 @@ beforeEach(() => {
   vi.mocked(auth).mockResolvedValue(mockSession as never);
   vi.mocked(can).mockReturnValue(true);
   vi.mocked(getSelfUpgradeConfig).mockResolvedValue(mockConfig as never);
+  vi.mocked(readCurrentContainerConfigDigest).mockResolvedValue(`sha256:${"a".repeat(64)}`);
   vi.mocked(readSelfUpgradeSupport).mockImplementation(async (configuredEnabled) => ({
     configuredEnabled,
     supported: true,
@@ -282,12 +288,20 @@ describe("getSelfUpgradeStatus", () => {
     const sourceSha = "f".repeat(40);
     vi.mocked(readSelfUpgradeSupport).mockResolvedValue(consumerReleaseSupport);
     vi.mocked(loadReleaseInstallContext).mockResolvedValue(consumerReleaseContext);
-    vi.mocked(resolveReleaseUpgradeCandidate).mockResolvedValue({ kind: "target", tag: "v2.0.0", sourceSha });
+    vi.mocked(resolveReleaseUpgradeCandidate).mockResolvedValue({
+      kind: "target",
+      tag: "v2.0.0",
+      sourceSha,
+      channelDigest: `sha256:${"b".repeat(64)}`,
+      configDigest: `sha256:${"c".repeat(64)}`,
+    });
     vi.mocked(getDeployedSha).mockResolvedValue("e".repeat(40));
     vi.mocked(isShaFresh).mockReturnValue(false);
     const result = await getSelfUpgradeStatus();
 
     expect(result.targetSha).toBe(sourceSha);
+    expect(result.targetTag).toBe("v2.0.0");
+    expect(result.targetAvailability).toBe("resolved");
     expect(resolveTargetSha).not.toHaveBeenCalled();
   });
 

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -11,12 +11,9 @@ import { generatePromotionId } from "@/lib/version-tracking";
 import { getSelfUpgradeConfig, nextMaintenanceWindowStart } from "@/lib/self-upgrade/config";
 import { resolveReleaseBatchStatus } from "@/lib/self-upgrade/release-batch-status";
 import { readSelfUpgradeSupport } from "@/lib/self-upgrade/support";
-import {
-  loadReleaseInstallContext,
-  resolveReleaseUpgradeCandidate,
-} from "@/lib/self-upgrade/release-target";
+import { resolveSelfUpgradeStatusTarget } from "@/lib/self-upgrade/status-target";
 import { computeNextScheduledUpgradeCheckAt } from "@/lib/self-upgrade/next-check";
-import { resolveTargetSha, isShaFresh } from "@/lib/self-upgrade/version";
+import { isShaFresh } from "@/lib/self-upgrade/version";
 import { getDeployedSha } from "@/lib/self-upgrade/completion";
 import { readCurrentContainerConfigDigest } from "@/lib/self-upgrade/runtime-image-identity";
 import { getJobEngineHealth } from "@/lib/queue/job-engine-health";
@@ -691,48 +688,13 @@ export async function getSelfUpgradeStatus() {
     checkIntervalHours: config.checkIntervalHours,
     now,
   });
-  let targetSha: string | null = null;
-  let targetTag: string | null = null;
-  let targetAvailability: "resolved" | "unavailable" = "unavailable";
-  let targetUnavailableReason: string | null = "no-target";
-  let releaseFreshness: boolean | null = null;
-  if (support.supported && support.targetKind === "release-artifact") {
-    const releaseContext = await loadReleaseInstallContext({
-      hostSourcePath:
-        config.hostSourceMountPath ??
-        process.env.DPF_SELF_UPGRADE_HOST_SOURCE_MOUNT ??
-        "/host-dpf",
-    });
-    if (releaseContext) {
-      const releaseTarget = await resolveReleaseUpgradeCandidate({
-        context: releaseContext,
-        currentConfigDigest,
-      }).catch(() => null);
-      targetSha =
-        !releaseTarget || releaseTarget.kind === "no-published-target"
-          ? null
-          : releaseTarget.sourceSha;
-      targetTag =
-        !releaseTarget || releaseTarget.kind === "no-published-target"
-          ? null
-          : releaseTarget.tag;
-      targetAvailability = targetSha ? "resolved" : "unavailable";
-      targetUnavailableReason = releaseTarget?.kind === "no-published-target"
-        ? releaseTarget.reason
-        : releaseTarget
-          ? null
-          : "registry-unavailable";
-      releaseFreshness = releaseTarget?.kind === "up-to-date"
-        ? true
-        : releaseTarget?.kind === "target"
-          ? false
-          : null;
-    }
-  } else if (support.supported) {
-    targetSha = await resolveTargetSha(config.channel, config);
-    targetAvailability = targetSha ? "resolved" : "unavailable";
-    targetUnavailableReason = targetSha ? null : "no-target";
-  }
+  const {
+    targetSha,
+    targetTag,
+    availability: targetAvailability,
+    unavailableReason: targetUnavailableReason,
+    releaseFreshness,
+  } = await resolveSelfUpgradeStatusTarget({ support, config, currentConfigDigest });
   // Merge-mode-aware freshness. In upstream/merge mode the deployed stamp is the
   // merge-commit identity, which CONTAINS but never EQUALS the upstream target —
   // so strict deployedSha===targetSha alone reports "Update available" forever,

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -18,6 +18,7 @@ import {
 import { computeNextScheduledUpgradeCheckAt } from "@/lib/self-upgrade/next-check";
 import { resolveTargetSha, isShaFresh } from "@/lib/self-upgrade/version";
 import { getDeployedSha } from "@/lib/self-upgrade/completion";
+import { readCurrentContainerConfigDigest } from "@/lib/self-upgrade/runtime-image-identity";
 import { getJobEngineHealth } from "@/lib/queue/job-engine-health";
 import { createRun, failRun, getLatestRun, getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
 import {
@@ -588,6 +589,7 @@ export async function getSelfUpgradeStatus() {
     latestSucceededRun,
     platformVersion,
     deployedSha,
+    currentConfigDigest,
     lastCheckedAt,
     quiescence,
     cooldownUntil,
@@ -602,6 +604,7 @@ export async function getSelfUpgradeStatus() {
     getLatestSucceededRun(),
     loadPlatformVersion(),
     getDeployedSha(),
+    readCurrentContainerConfigDigest(),
     getLastCheckedAt(),
     // Live drain activity (what's holding an upgrade) + the post-defer/fail
     // backoff window, so the panel can explain "what's happening" truthfully.
@@ -689,6 +692,10 @@ export async function getSelfUpgradeStatus() {
     now,
   });
   let targetSha: string | null = null;
+  let targetTag: string | null = null;
+  let targetAvailability: "resolved" | "unavailable" = "unavailable";
+  let targetUnavailableReason: string | null = "no-target";
+  let releaseFreshness: boolean | null = null;
   if (support.supported && support.targetKind === "release-artifact") {
     const releaseContext = await loadReleaseInstallContext({
       hostSourcePath:
@@ -699,15 +706,32 @@ export async function getSelfUpgradeStatus() {
     if (releaseContext) {
       const releaseTarget = await resolveReleaseUpgradeCandidate({
         context: releaseContext,
-        currentSourceSha: deployedSha,
+        currentConfigDigest,
       }).catch(() => null);
       targetSha =
         !releaseTarget || releaseTarget.kind === "no-published-target"
           ? null
           : releaseTarget.sourceSha;
+      targetTag =
+        !releaseTarget || releaseTarget.kind === "no-published-target"
+          ? null
+          : releaseTarget.tag;
+      targetAvailability = targetSha ? "resolved" : "unavailable";
+      targetUnavailableReason = releaseTarget?.kind === "no-published-target"
+        ? releaseTarget.reason
+        : releaseTarget
+          ? null
+          : "registry-unavailable";
+      releaseFreshness = releaseTarget?.kind === "up-to-date"
+        ? true
+        : releaseTarget?.kind === "target"
+          ? false
+          : null;
     }
   } else if (support.supported) {
     targetSha = await resolveTargetSha(config.channel, config);
+    targetAvailability = targetSha ? "resolved" : "unavailable";
+    targetUnavailableReason = targetSha ? null : "no-target";
   }
   // Merge-mode-aware freshness. In upstream/merge mode the deployed stamp is the
   // merge-commit identity, which CONTAINS but never EQUALS the upstream target —
@@ -719,10 +743,10 @@ export async function getSelfUpgradeStatus() {
   // already equals the target. This is the same signal the §5.0 worker skip-gate
   // (self-upgrade.ts: `lastOk?.targetSha === upstreamSha`) and the impact summary
   // use, so all three surfaces agree.
-  const isFresh = support.supported && targetSha
+  const isFresh = releaseFreshness ?? (support.supported && targetSha
     ? isShaFresh(deployedSha, targetSha) ||
       isShaFresh(latestSucceededRun?.targetSha ?? null, targetSha)
-    : false;
+    : false);
 
   // Release-batch tally for the panel ("N of M merged updates accumulated").
   // No fetch here — display rides the hourly scheduled fetch; a stale-by-
@@ -752,6 +776,10 @@ export async function getSelfUpgradeStatus() {
     deployedSha,
     deployedShaSource: platformVersion.imageVersion?.source ?? "unknown",
     targetSha,
+    targetTag,
+    targetAvailability,
+    targetUnavailableReason,
+    currentConfigDigest,
     isFresh,
     releaseBatch: {
       applicable: support.supported && releaseBatch.applicable,

--- a/apps/web/lib/queue/functions/self-upgrade-handoff.test-support.ts
+++ b/apps/web/lib/queue/functions/self-upgrade-handoff.test-support.ts
@@ -1,5 +1,6 @@
 import { expect, it, vi } from "vitest";
 import { signTransitionPayload } from "@/lib/platform-runtime/transition-protocol";
+import { ok } from "@/lib/shared/action-result";
 
 type TestContext = { mocks: any; runSelfUpgrade: (input: any) => Promise<any>; installState: string; installStateHash: string };
 
@@ -19,7 +20,7 @@ export function registerCoreSelfUpgradeSuccessTest(input: {
 }) {
   it("returns succeeded status when promoter exits 0", async () => {
     const result = await input.runSelfUpgrade({ triggeredBy: "ops" });
-    expect(result).toMatchObject({ ok: true, status: "succeeded", runId: "SUR-AAAABBBB" });
+    expect(result).toMatchObject({ status: "succeeded", runId: "SUR-AAAABBBB" });
     expect(input.mocks.completeRun).toHaveBeenCalledWith("SUR-AAAABBBB");
   });
 }
@@ -39,7 +40,7 @@ export function configureReleaseUpgradeTest(input: {
   input.mocks.readFile.mockImplementation(async (path: string) => path.endsWith("install-state.json") ? input.installState : path.endsWith(".install-mode") ? "consumer" : "s".repeat(32));
   input.mocks.readCurrentContainerConfigDigest.mockResolvedValue(input.currentConfigDigest);
   input.mocks.readRegistryReleaseCandidate.mockResolvedValue({
-    ok: true,
+    ...ok(),
     candidate: { tag: "v2.0.0", sourceSha: input.sourceSha, channelDigest: `sha256:${"b".repeat(64)}`, platformManifestDigest: `sha256:${"c".repeat(64)}`, configDigest: input.targetConfigDigest },
   });
 }

--- a/apps/web/lib/queue/functions/self-upgrade-handoff.test-support.ts
+++ b/apps/web/lib/queue/functions/self-upgrade-handoff.test-support.ts
@@ -1,7 +1,48 @@
-import { expect, it } from "vitest";
+import { expect, it, vi } from "vitest";
 import { signTransitionPayload } from "@/lib/platform-runtime/transition-protocol";
 
 type TestContext = { mocks: any; runSelfUpgrade: (input: any) => Promise<any>; installState: string; installStateHash: string };
+
+export function registerSelfUpgradeFunctionTests(input: {
+  allFunctions: unknown[];
+  scheduled: unknown;
+  manual: unknown;
+}) {
+  it("registers both self-upgrade entry points", () => {
+    expect(input.allFunctions).toEqual(expect.arrayContaining([input.scheduled, input.manual]));
+  });
+}
+
+export function registerCoreSelfUpgradeSuccessTest(input: {
+  mocks: any;
+  runSelfUpgrade: (params: any) => Promise<any>;
+}) {
+  it("returns succeeded status when promoter exits 0", async () => {
+    const result = await input.runSelfUpgrade({ triggeredBy: "ops" });
+    expect(result).toMatchObject({ ok: true, status: "succeeded", runId: "SUR-AAAABBBB" });
+    expect(input.mocks.completeRun).toHaveBeenCalledWith("SUR-AAAABBBB");
+  });
+}
+
+export function configureReleaseUpgradeTest(input: {
+  mocks: any;
+  installState: string;
+  sourceSha: string;
+  currentConfigDigest: string;
+  targetConfigDigest: string;
+}) {
+  vi.stubEnv("GHCR_OWNER", "opendigitalproductfactory");
+  vi.stubEnv("DPF_IMAGE_TAG", "v1.0.0");
+  vi.stubEnv("DPF_HOST_INSTALL_PATH", "/opt/dpf");
+  vi.stubEnv("DPF_SELF_UPGRADE_COMPOSE_FILES", "docker-compose.yml docker-compose.release.yml");
+  input.mocks.readSelfUpgradeSupport.mockResolvedValue({ configuredEnabled: true, supported: true, enabled: true, targetKind: "release-artifact", reason: "enabled", message: null });
+  input.mocks.readFile.mockImplementation(async (path: string) => path.endsWith("install-state.json") ? input.installState : path.endsWith(".install-mode") ? "consumer" : "s".repeat(32));
+  input.mocks.readCurrentContainerConfigDigest.mockResolvedValue(input.currentConfigDigest);
+  input.mocks.readRegistryReleaseCandidate.mockResolvedValue({
+    ok: true,
+    candidate: { tag: "v2.0.0", sourceSha: input.sourceSha, channelDigest: `sha256:${"b".repeat(64)}`, platformManifestDigest: `sha256:${"c".repeat(64)}`, configDigest: input.targetConfigDigest },
+  });
+}
 
 export function registerInstallStateHandoffTests({ mocks, runSelfUpgrade, installState, installStateHash }: TestContext) {
   it("resolves and validates readiness before quiescence, then promotes the same digest", async () => {

--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createHash } from "node:crypto";
-import { registerInstallStateHandoffTests } from "./self-upgrade-handoff.test-support";
+import { configureReleaseUpgradeTest, registerCoreSelfUpgradeSuccessTest, registerInstallStateHandoffTests, registerSelfUpgradeFunctionTests } from "./self-upgrade-handoff.test-support";
 
 const TEST_INSTALL_STATE = JSON.stringify({ platform: "linux", arch: "amd64" });
 const TEST_INSTALL_STATE_HASH = createHash("sha256").update(TEST_INSTALL_STATE).digest("hex");
@@ -66,9 +66,7 @@ vi.mock("@/lib/self-upgrade/support", () => ({
 
 vi.mock("node:fs/promises", () => ({ readFile: mocks.readFile }));
 
-vi.mock("@/lib/self-upgrade/registry-release", () => ({
-  readRegistryReleaseCandidate: mocks.readRegistryReleaseCandidate,
-}));
+vi.mock("@/lib/self-upgrade/registry-release", () => ({ readRegistryReleaseCandidate: mocks.readRegistryReleaseCandidate }));
 
 vi.mock("@/lib/self-upgrade/window", () => ({
   isUpgradeWindowOpen: mocks.isUpgradeWindowOpen,
@@ -120,9 +118,7 @@ vi.mock("@/lib/self-upgrade/completion", () => ({
   isFeatureBuildDeployed: mocks.isFeatureBuildDeployed,
 }));
 
-vi.mock("@/lib/self-upgrade/runtime-image-identity", () => ({
-  readCurrentContainerConfigDigest: mocks.readCurrentContainerConfigDigest,
-}));
+vi.mock("@/lib/self-upgrade/runtime-image-identity", () => ({ readCurrentContainerConfigDigest: mocks.readCurrentContainerConfigDigest }));
 
 vi.mock("@/lib/self-upgrade/run-store", () => ({
   createRun: mocks.createRun,
@@ -265,15 +261,7 @@ beforeEach(() => {
   );
 });
 
-describe("function registration", () => {
-  it("allFunctions includes selfUpgradeScheduled", () => {
-    expect(allFunctions).toContain(selfUpgradeScheduled);
-  });
-
-  it("allFunctions includes selfUpgradeManual", () => {
-    expect(allFunctions).toContain(selfUpgradeManual);
-  });
-});
+registerSelfUpgradeFunctionTests({ allFunctions, scheduled: selfUpgradeScheduled, manual: selfUpgradeManual });
 
 const ENABLED_CONFIG = {
   enabled: true,
@@ -312,38 +300,14 @@ describe("success path", () => {
     mocks.isFeatureBuildDeployed.mockResolvedValue(true);
   });
 
-  it("returns succeeded status when promoter exits 0", async () => {
-    const result = await runSelfUpgrade({ triggeredBy: "ops" });
-    expect(result).toMatchObject({ ok: true, status: "succeeded", runId: "SUR-AAAABBBB" });
-    expect(mocks.completeRun).toHaveBeenCalledWith("SUR-AAAABBBB");
-  });
+  registerCoreSelfUpgradeSuccessTest({ mocks, runSelfUpgrade });
 
   it("classifies a source-free consumer at the verified release as up to date without Git", async () => {
     const sourceSha = "a".repeat(40);
     const releaseState = JSON.stringify({ installMode: "consumer", imageTag: "v2.0.0", installPath: "/opt/dpf", composeFiles: ["docker-compose.yml", "docker-compose.release.yml"] });
-    vi.stubEnv("GHCR_OWNER", "opendigitalproductfactory");
-    mocks.readSelfUpgradeSupport.mockResolvedValue({
-      configuredEnabled: true,
-      supported: true,
-      enabled: true,
-      targetKind: "release-artifact",
-      reason: "enabled",
-      message: null,
-    });
-    mocks.readFile.mockImplementation(async (path: string) => path.endsWith("install-state.json") ? releaseState : "s".repeat(32));
     mocks.getDeployedSha.mockResolvedValue(sourceSha);
     const configDigest = `sha256:${"a".repeat(64)}`;
-    mocks.readCurrentContainerConfigDigest.mockResolvedValue(configDigest);
-    mocks.readRegistryReleaseCandidate.mockResolvedValue({
-      ok: true,
-      candidate: {
-        tag: "v2.0.0",
-        sourceSha,
-        channelDigest: `sha256:${"b".repeat(64)}`,
-        platformManifestDigest: `sha256:${"c".repeat(64)}`,
-        configDigest,
-      },
-    });
+    configureReleaseUpgradeTest({ mocks, installState: releaseState, sourceSha, currentConfigDigest: configDigest, targetConfigDigest: configDigest });
     try {
       const result = await runSelfUpgrade({ triggeredBy: "ops" });
       expect(result).toMatchObject({ skipped: true, reason: "up-to-date", releaseTag: "v2.0.0" });
@@ -358,36 +322,7 @@ describe("success path", () => {
   it("hands the frozen release config digest through to promotion", async () => {
     const sourceSha = "abc1234deadbeef";
     const targetConfigDigest = `sha256:${"c".repeat(64)}`;
-    vi.stubEnv("GHCR_OWNER", "opendigitalproductfactory");
-    vi.stubEnv("DPF_IMAGE_TAG", "v1.0.0");
-    vi.stubEnv("DPF_HOST_INSTALL_PATH", "/opt/dpf");
-    vi.stubEnv("DPF_SELF_UPGRADE_COMPOSE_FILES", "docker-compose.yml docker-compose.release.yml");
-    mocks.readSelfUpgradeSupport.mockResolvedValue({
-      configuredEnabled: true,
-      supported: true,
-      enabled: true,
-      targetKind: "release-artifact",
-      reason: "enabled",
-      message: null,
-    });
-    mocks.readFile.mockImplementation(async (path: string) =>
-      path.endsWith("install-state.json")
-        ? TEST_INSTALL_STATE
-        : path.endsWith(".install-mode")
-          ? "consumer"
-          : "s".repeat(32),
-    );
-    mocks.readCurrentContainerConfigDigest.mockResolvedValue(`sha256:${"a".repeat(64)}`);
-    mocks.readRegistryReleaseCandidate.mockResolvedValue({
-      ok: true,
-      candidate: {
-        tag: "v2.0.0",
-        sourceSha,
-        channelDigest: `sha256:${"d".repeat(64)}`,
-        platformManifestDigest: `sha256:${"e".repeat(64)}`,
-        configDigest: targetConfigDigest,
-      },
-    });
+    configureReleaseUpgradeTest({ mocks, installState: TEST_INSTALL_STATE, sourceSha, currentConfigDigest: `sha256:${"a".repeat(64)}`, targetConfigDigest });
     try {
       const result = await runSelfUpgrade({ triggeredBy: "ops" });
       expect(result).toMatchObject({ ok: true, status: "succeeded" });

--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   defaultGitRunner: vi.fn(),
   prepareUpgradeSource: vi.fn(),
   getDeployedSha: vi.fn(),
+  readCurrentContainerConfigDigest: vi.fn().mockResolvedValue(`sha256:${"a".repeat(64)}`),
   isFeatureBuildDeployed: vi.fn(),
   createRun: vi.fn(),
   startRun: vi.fn(),
@@ -51,7 +52,7 @@ const mocks = vi.hoisted(() => ({
   getActiveSelfUpgradeBlackout: vi.fn().mockResolvedValue(null),
   readFile: vi.fn(async (path: string) => path.endsWith("install-state.json") ? '{"platform":"linux","arch":"amd64"}' : "s".repeat(32)),
   resolveSelfUpgradeHostIdentity: vi.fn(() => ({ platform: "linux", arch: "amd64", provenance: "explicit" })),
-  readLatestReleaseStamp: vi.fn(),
+  readRegistryReleaseCandidate: vi.fn(),
 }));
 
 vi.mock("@/lib/self-upgrade/config", () => ({
@@ -65,8 +66,8 @@ vi.mock("@/lib/self-upgrade/support", () => ({
 
 vi.mock("node:fs/promises", () => ({ readFile: mocks.readFile }));
 
-vi.mock("@/lib/release-health/release-runs-reader", () => ({
-  readLatestReleaseStamp: mocks.readLatestReleaseStamp,
+vi.mock("@/lib/self-upgrade/registry-release", () => ({
+  readRegistryReleaseCandidate: mocks.readRegistryReleaseCandidate,
 }));
 
 vi.mock("@/lib/self-upgrade/window", () => ({
@@ -117,6 +118,10 @@ vi.mock("@/lib/self-upgrade/prepare-source", () => ({
 vi.mock("@/lib/self-upgrade/completion", () => ({
   getDeployedSha: mocks.getDeployedSha,
   isFeatureBuildDeployed: mocks.isFeatureBuildDeployed,
+}));
+
+vi.mock("@/lib/self-upgrade/runtime-image-identity", () => ({
+  readCurrentContainerConfigDigest: mocks.readCurrentContainerConfigDigest,
 }));
 
 vi.mock("@/lib/self-upgrade/run-store", () => ({
@@ -325,15 +330,74 @@ describe("success path", () => {
       reason: "enabled",
       message: null,
     });
-    mocks.readFile.mockImplementation(async (path: string) => path.endsWith("install-state.json") ? releaseState : "consumer");
+    mocks.readFile.mockImplementation(async (path: string) => path.endsWith("install-state.json") ? releaseState : "s".repeat(32));
     mocks.getDeployedSha.mockResolvedValue(sourceSha);
-    mocks.readLatestReleaseStamp.mockResolvedValue({ ok: true, latest: { tag: "v2.0.0", headSha: sourceSha, status: "verified" } });
+    const configDigest = `sha256:${"a".repeat(64)}`;
+    mocks.readCurrentContainerConfigDigest.mockResolvedValue(configDigest);
+    mocks.readRegistryReleaseCandidate.mockResolvedValue({
+      ok: true,
+      candidate: {
+        tag: "v2.0.0",
+        sourceSha,
+        channelDigest: `sha256:${"b".repeat(64)}`,
+        platformManifestDigest: `sha256:${"c".repeat(64)}`,
+        configDigest,
+      },
+    });
     try {
       const result = await runSelfUpgrade({ triggeredBy: "ops" });
       expect(result).toMatchObject({ skipped: true, reason: "up-to-date", releaseTag: "v2.0.0" });
       expect(mocks.defaultGitRunner).not.toHaveBeenCalled();
       expect(mocks.prepareUpgradeSource).not.toHaveBeenCalled();
       expect(mocks.evaluateHostMemoryGuard).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("hands the frozen release config digest through to promotion", async () => {
+    const sourceSha = "abc1234deadbeef";
+    const targetConfigDigest = `sha256:${"c".repeat(64)}`;
+    vi.stubEnv("GHCR_OWNER", "opendigitalproductfactory");
+    vi.stubEnv("DPF_IMAGE_TAG", "v1.0.0");
+    vi.stubEnv("DPF_HOST_INSTALL_PATH", "/opt/dpf");
+    vi.stubEnv("DPF_SELF_UPGRADE_COMPOSE_FILES", "docker-compose.yml docker-compose.release.yml");
+    mocks.readSelfUpgradeSupport.mockResolvedValue({
+      configuredEnabled: true,
+      supported: true,
+      enabled: true,
+      targetKind: "release-artifact",
+      reason: "enabled",
+      message: null,
+    });
+    mocks.readFile.mockImplementation(async (path: string) =>
+      path.endsWith("install-state.json")
+        ? TEST_INSTALL_STATE
+        : path.endsWith(".install-mode")
+          ? "consumer"
+          : "s".repeat(32),
+    );
+    mocks.readCurrentContainerConfigDigest.mockResolvedValue(`sha256:${"a".repeat(64)}`);
+    mocks.readRegistryReleaseCandidate.mockResolvedValue({
+      ok: true,
+      candidate: {
+        tag: "v2.0.0",
+        sourceSha,
+        channelDigest: `sha256:${"d".repeat(64)}`,
+        platformManifestDigest: `sha256:${"e".repeat(64)}`,
+        configDigest: targetConfigDigest,
+      },
+    });
+    try {
+      const result = await runSelfUpgrade({ triggeredBy: "ops" });
+      expect(result).toMatchObject({ ok: true, status: "succeeded" });
+      expect(mocks.runPromoter).toHaveBeenCalledWith(expect.objectContaining({
+        release: {
+          tag: "v2.0.0",
+          ghcrOwner: "opendigitalproductfactory",
+          configDigest: targetConfigDigest,
+        },
+      }));
     } finally {
       vi.unstubAllEnvs();
     }

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -30,6 +30,7 @@ import {
 } from "@/lib/self-upgrade/preflight";
 import { evaluateHostMemoryGuard } from "@/lib/self-upgrade/host-memory-preflight";
 import { getDeployedSha, isFeatureBuildDeployed } from "@/lib/self-upgrade/completion";
+import { readCurrentContainerConfigDigest } from "@/lib/self-upgrade/runtime-image-identity";
 import {
   classifyBuildFailure,
   formatClassifiedExcerpt,
@@ -325,9 +326,14 @@ export async function runSelfUpgrade(
 
   let upstreamSha: string | null = null;
   let releaseTag: string | null = null;
+  let releaseConfigDigest: string | null = null;
   const deployedSha = await getDeployedSha();
   if (upgradeStrategy === "release" && releaseInstall) {
-    const target = await resolveReleaseUpgradeCandidate({ context: releaseInstall, currentSourceSha: deployedSha });
+    const currentConfigDigest = await readCurrentContainerConfigDigest();
+    const target = await resolveReleaseUpgradeCandidate({
+      context: releaseInstall,
+      currentConfigDigest,
+    });
     if (target.kind === "no-published-target") {
       return await skipAttempt("no-published-target", `no-published-target: ${target.reason}`, { releaseStatus: target.reason });
     }
@@ -339,6 +345,7 @@ export async function runSelfUpgrade(
     }
     upstreamSha = target.sourceSha;
     releaseTag = target.tag;
+    releaseConfigDigest = target.configDigest;
   } else if (config.sourceMode === "upstream") {
     await gitRun(buildFetchCommand({ hostSourcePath, remote, branch }).slice(1));
     const head = await gitRun(buildRemoteHeadCommand({ hostSourcePath, remote, branch }).slice(1));
@@ -643,8 +650,12 @@ export async function runSelfUpgrade(
       composeProject,
       healthUrl: config.healthUrl ?? process.env.PROMOTE_HEALTH_URL ?? "",
       promoterImage: resolvedPromoterDigest ?? config.promoterImage,
-      release: releaseTag && releaseInstall
-        ? { tag: releaseTag, ghcrOwner: releaseInstall.ghcrOwner }
+      release: releaseTag && releaseConfigDigest && releaseInstall
+        ? {
+            tag: releaseTag,
+            ghcrOwner: releaseInstall.ghcrOwner,
+            configDigest: releaseConfigDigest,
+          }
         : undefined,
       stateDirHostPath: process.env.DPF_STATE_DIR_HOST,
       installStateMigrationEnvelope: migrationHandoff ? Buffer.from(JSON.stringify(migrationHandoff.envelope)).toString("base64url") : undefined,

--- a/apps/web/lib/self-upgrade/action-state.ts
+++ b/apps/web/lib/self-upgrade/action-state.ts
@@ -1,0 +1,14 @@
+export const SELF_UPGRADE_ACTION_STATE = Object.freeze({
+  UPDATE_AVAILABLE: "update-available",
+  NO_UPDATE: "no-update",
+  UNAVAILABLE: "unavailable",
+} as const);
+
+export type SelfUpgradeActionState =
+  (typeof SELF_UPGRADE_ACTION_STATE)[keyof typeof SELF_UPGRADE_ACTION_STATE];
+
+export function describeSelfUpgradeActionState(state: SelfUpgradeActionState): string {
+  return state === SELF_UPGRADE_ACTION_STATE.UNAVAILABLE
+    ? "Update status unavailable. Nothing queued."
+    : "No update is ready.";
+}

--- a/apps/web/lib/self-upgrade/owner-summary.test.ts
+++ b/apps/web/lib/self-upgrade/owner-summary.test.ts
@@ -15,6 +15,8 @@ function baseInput(overrides: Partial<OwnerReleaseInput> = {}): OwnerReleaseInpu
     },
     isFresh: true,
     targetSha: null,
+    targetAvailability: "resolved",
+    targetUnavailableReason: null,
     deployedSha: "abc1234def",
     nextWindowStart: null,
     blackoutUntil: null,
@@ -82,6 +84,29 @@ describe("buildOwnerReleaseSummary", () => {
     expect(s.recommendedAction.label).toBe("No action needed");
   });
 
+  it("reports registry discovery failure as unavailable instead of up to date", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        support: {
+          supported: true,
+          targetKind: "release-artifact",
+          reason: "enabled",
+          message: null,
+        },
+        isFresh: false,
+        targetSha: null,
+        targetAvailability: "unavailable",
+        targetUnavailableReason: "registry-unavailable",
+      }),
+      NO_LOCAL_CHANGES,
+    );
+
+    expect(s.state).toBe("unavailable");
+    expect(s.headline).toBe("Update availability could not be verified");
+    expect(s.recommendedAction.label).toBe("No update action available");
+    expect(s.ifYouDoNothing).toContain("current release keeps running");
+  });
+
   it("does not surface a stale no-target skip after release discovery proves the install is current", () => {
     const sha = "f".repeat(40);
     const s = buildOwnerReleaseSummary(
@@ -122,6 +147,25 @@ describe("buildOwnerReleaseSummary", () => {
     expect(s.riskNotice?.reversibility.length).toBeGreaterThan(0);
     expect(s.riskNotice?.duration.length).toBeGreaterThan(0);
     expect(s.riskNotice?.recovery.length).toBeGreaterThan(0);
+  });
+
+  it("uses the immutable release tag as the owner-facing available version", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        support: {
+          supported: true,
+          targetKind: "release-artifact",
+          reason: "enabled",
+          message: null,
+        },
+        isFresh: false,
+        targetSha: "f".repeat(40),
+        targetTag: "v2026.08.24",
+      }),
+      NO_LOCAL_CHANGES,
+    );
+
+    expect(s.availableVersion).toBe("v2026.08.24");
   });
 
   it("prefers the merged-PR label over hex in both version labels (BI-5B1FDA09)", () => {

--- a/apps/web/lib/self-upgrade/owner-summary.ts
+++ b/apps/web/lib/self-upgrade/owner-summary.ts
@@ -77,6 +77,9 @@ export interface OwnerReleaseInput {
   };
   isFresh: boolean;
   targetSha: string | null;
+  targetTag?: string | null;
+  targetAvailability: "resolved" | "unavailable";
+  targetUnavailableReason: string | null;
   deployedSha: string | null;
   nextWindowStart: string | null;
   blackoutUntil: string | null;
@@ -156,7 +159,9 @@ export function buildOwnerReleaseSummary(
       ? "in-progress"
       : failed
         ? "failed"
-        : input.isFresh || !input.targetSha
+        : input.targetAvailability === "unavailable"
+          ? "unavailable"
+        : input.isFresh
           ? "up-to-date"
           : "update-available";
 
@@ -183,7 +188,9 @@ export function buildOwnerReleaseSummary(
   const targetDetail = input.availableMergePointLabel ?? targetShort;
   const availableVersion =
     state === "update-available"
-      ? input.latestRunImpact?.headline
+      ? input.support.targetKind === "release-artifact" && input.targetTag
+        ? input.targetTag
+        : input.latestRunImpact?.headline
         ? input.latestRunImpact.headline
         : targetDetail
           ? `Latest build (${targetDetail})`
@@ -266,15 +273,15 @@ export function buildOwnerReleaseSummary(
 
   switch (state) {
     case "unavailable":
-      headline =
-        input.support.message?.replace(/[.]$/, "") ??
-        "Automatic updates aren’t available for this install yet";
+      headline = input.support.supported
+        ? "Update availability could not be verified"
+        : input.support.message?.replace(/[.]$/, "") ??
+          "Automatic updates aren’t available for this install yet";
       recommendedAction = {
-        label: "No automatic update action",
-        detail:
-          input.support.targetKind === "release-artifact"
-            ? "DPF will not queue a source-based upgrade here. Follow the installer guidance for the consumer release you want to move to."
-            : "DPF will not queue an update until this install’s identity can be verified. Try again when status is available.",
+        label: input.support.supported ? "No update action available" : "No automatic update action",
+        detail: input.support.supported
+          ? "DPF could not prove a newer immutable release from the update registry, so it will not queue or install anything. It keeps checking automatically."
+          : "DPF will not queue an update until this install’s identity can be verified. Try again when status is available.",
       };
       ifYouDoNothing =
         "Your current release keeps running. Nothing is queued or changed automatically.";

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -90,6 +90,7 @@ for arg in "$@"; do
 done
 [ -n "$DOCKER_LOG" ] && printf '%s\\n' "$*" >> "$DOCKER_LOG"
 case "$*" in
+  *".Id"*) printf "%s" "$DPF_TEST_RELEASE_CONFIG_DIGEST" ;;
   "image inspect "*) printf "%s" "$DPF_TEST_RELEASE_SHA" ;;
   "create "*) printf "candidate-container" ;;
   "cp candidate-container:/dpf-release-assets/. "*)
@@ -155,7 +156,7 @@ function runPromote(opts: {
   principalRecoveryDecision?: "recover" | "not-needed" | "blocked";
   principalResolveFails?: boolean;
   principalVerifyFails?: boolean;
-  release?: { tag: string; owner: string; candidateAssets: string; gitLog: string };
+  release?: { tag: string; owner: string; configDigest: string; candidateAssets: string; gitLog: string };
 }): { status: number | null; stdout: string; stderr: string } {
   const stateDir = join(opts.backup, "state");
   const secret = "s".repeat(32);
@@ -215,8 +216,10 @@ function runPromote(opts: {
     ...(opts.release ? [
       "export DPF_PROMOTION_MODE=release",
       `export DPF_RELEASE_TAG=${shellQuote(opts.release.tag)}`,
+      `export DPF_RELEASE_CONFIG_DIGEST=${shellQuote(opts.release.configDigest)}`,
       `export GHCR_OWNER=${shellQuote(opts.release.owner)}`,
       `export DPF_TEST_RELEASE_SHA=${shellQuote(opts.targetSha)}`,
+      `export DPF_TEST_RELEASE_CONFIG_DIGEST=${shellQuote(opts.release.configDigest)}`,
       `export DPF_TEST_RELEASE_ASSETS=${shellQuote(toBashPath(opts.release.candidateAssets))}`,
       `export GIT_LOG=${shellQuote(toBashPath(opts.release.gitLog))}`,
       "export PROMOTE_COMPOSE_FILES='docker-compose.yml docker-compose.release.yml'",
@@ -307,7 +310,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       writeFileSync(join(fakeBin, "git"), '#!/bin/sh\nprintf "git invoked: %s\\n" "$*" >> "$GIT_LOG"\nexit 97\n');
       chmodSync(join(fakeBin, "git"), 0o755);
 
-      const r = runPromote({ source, backup, targetSha, fakeBin, dockerLog, release: { tag: "v2.0.0", owner: "opendigitalproductfactory", candidateAssets, gitLog } });
+      const r = runPromote({ source, backup, targetSha, fakeBin, dockerLog, release: { tag: "v2.0.0", owner: "opendigitalproductfactory", configDigest: `sha256:${"c".repeat(64)}`, candidateAssets, gitLog } });
       expect(r.status, r.stderr).toBe(0);
       expect(existsSync(gitLog)).toBe(false);
       expect(r.stdout).toContain(`step=done target=${targetSha}`);

--- a/apps/web/lib/self-upgrade/promoter.test.ts
+++ b/apps/web/lib/self-upgrade/promoter.test.ts
@@ -220,12 +220,17 @@ describe("buildPromoterCommand", () => {
   it("launches release promotion with a narrowly writable install and immutable release identity", () => {
     const { args } = buildPromoterCommand({
       ...BASE,
-      release: { tag: "v2026.08.23", ghcrOwner: "opendigitalproductfactory" },
+      release: {
+        tag: "v2026.08.23",
+        ghcrOwner: "opendigitalproductfactory",
+        configDigest: `sha256:${"c".repeat(64)}`,
+      },
     });
     expect(args).toContain("/Users/me/dpf:/host-source");
     expect(args).not.toContain("/Users/me/dpf:/host-source:ro");
     expect(args).toContain("DPF_PROMOTION_MODE=release");
     expect(args).toContain("DPF_RELEASE_TAG=v2026.08.23");
+    expect(args).toContain(`DPF_RELEASE_CONFIG_DIGEST=sha256:${"c".repeat(64)}`);
     expect(args).toContain("GHCR_OWNER=opendigitalproductfactory");
     expect(args).toContain("PROMOTE_TARGET_SHA=abc1234");
   });

--- a/apps/web/lib/self-upgrade/promoter.ts
+++ b/apps/web/lib/self-upgrade/promoter.ts
@@ -152,7 +152,7 @@ export type PromoterParams = {
   /** Exact portal-verified carrier retained for orchestration identity/audit. */
   installStateMigrationHandoff?: InstallStateMigrationHandoff;
   /** Verified registry release promoted without a source checkout/build. */
-  release?: { tag: string; ghcrOwner: string };
+  release?: { tag: string; ghcrOwner: string; configDigest: string };
 };
 
 export type PromoterResult = {
@@ -167,6 +167,7 @@ const RUNTIME_TRANSITION_ENVELOPE = /^[A-Za-z0-9_-]{16,65536}$/;
 const RUNTIME_HOST_PATH_SEGMENT = /^[A-Za-z0-9._ -]+$/;
 const RELEASE_TAG = /^v\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$/;
 const REGISTRY_OWNER = /^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,253}[A-Za-z0-9])?$/;
+const IMAGE_CONFIG_DIGEST = /^sha256:[a-f0-9]{64}$/;
 
 function isSafeRuntimeHostPath(value: string): boolean {
   if (value.length < 2 || value.length > 1024 || /[\0\r\n]/.test(value)) return false;
@@ -202,7 +203,11 @@ function validateRuntimeTransitionCommandInputs(params: PromoterParams): void {
   }
   if (params.installStateMigrationEnvelope && !RUNTIME_TRANSITION_ENVELOPE.test(params.installStateMigrationEnvelope)) throw new Error("invalid_install_state_migration_envelope");
   if (params.installStateMigrationSignature && !RUNTIME_TRANSITION_TOKEN.test(params.installStateMigrationSignature)) throw new Error("invalid_install_state_migration_signature");
-  if (params.release && (!RELEASE_TAG.test(params.release.tag) || !REGISTRY_OWNER.test(params.release.ghcrOwner))) {
+  if (params.release && (
+    !RELEASE_TAG.test(params.release.tag) ||
+    !REGISTRY_OWNER.test(params.release.ghcrOwner) ||
+    !IMAGE_CONFIG_DIGEST.test(params.release.configDigest)
+  )) {
     throw new Error("invalid_release_identity");
   }
 }
@@ -288,6 +293,8 @@ export function buildPromoterCommand(
       "DPF_PROMOTION_MODE=release",
       "-e",
       `DPF_RELEASE_TAG=${params.release.tag}`,
+      "-e",
+      `DPF_RELEASE_CONFIG_DIGEST=${params.release.configDigest}`,
       "-e",
       `GHCR_OWNER=${params.release.ghcrOwner}`,
     );

--- a/apps/web/lib/self-upgrade/registry-release.test.ts
+++ b/apps/web/lib/self-upgrade/registry-release.test.ts
@@ -1,0 +1,255 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { readRegistryReleaseCandidate } from "./registry-release";
+
+const OWNER = "opendigitalproductfactory";
+const REPO = `${OWNER}/dpf-portal`;
+const SOURCE_SHA = "b".repeat(40);
+
+function digest(body: string): string {
+  return `sha256:${createHash("sha256").update(body).digest("hex")}`;
+}
+
+function verifiedJson(value: unknown, headers: Record<string, string> = {}): Response {
+  const body = JSON.stringify(value);
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "content-type": "application/vnd.oci.image.index.v1+json",
+      "docker-content-digest": digest(body),
+      ...headers,
+    },
+  });
+}
+
+function fixtureFetch(options: {
+  version?: string;
+  revision?: string;
+  immutableTags?: string[];
+  tamperChannelDigest?: boolean;
+  duplicatePlatform?: boolean;
+  blobRedirectHost?: string;
+} = {}): typeof fetch {
+  const version = options.version ?? "v2026.08.24";
+  const revision = options.revision ?? SOURCE_SHA;
+  const config = {
+    architecture: "amd64",
+    os: "linux",
+    config: {
+      Labels: {
+        "org.opencontainers.image.version": version,
+        "org.opencontainers.image.revision": revision,
+      },
+    },
+  };
+  const configBody = JSON.stringify(config);
+  const configDigest = digest(configBody);
+  const platform = {
+    schemaVersion: 2,
+    mediaType: "application/vnd.oci.image.manifest.v1+json",
+    config: { mediaType: "application/vnd.oci.image.config.v1+json", digest: configDigest, size: configBody.length },
+    layers: [],
+  };
+  const platformBody = JSON.stringify(platform);
+  const platformDigest = digest(platformBody);
+  const channel = {
+    schemaVersion: 2,
+    mediaType: "application/vnd.oci.image.index.v1+json",
+    manifests: [
+      {
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        digest: platformDigest,
+        size: 123,
+        platform: { os: "linux", architecture: "amd64" },
+      },
+      ...(options.duplicatePlatform
+        ? [{
+            mediaType: "application/vnd.oci.image.manifest.v1+json",
+            digest: `sha256:${"4".repeat(64)}`,
+            size: 123,
+            platform: { os: "linux", architecture: "amd64" },
+          }]
+        : []),
+    ],
+  };
+  const channelBody = JSON.stringify(channel);
+  const immutableTags = options.immutableTags ?? ["v2026.08.24"];
+  let authenticated = false;
+
+  return (async (input, init) => {
+    const url = String(input);
+    const auth = new Headers(init?.headers).get("authorization");
+    if (url.startsWith("https://ghcr.io/token?")) {
+      authenticated = true;
+      return Response.json({ token: "registry-token" });
+    }
+    if (!auth && !authenticated) {
+      return new Response("unauthorized", {
+        status: 401,
+        headers: {
+          "www-authenticate": `Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:${REPO}:pull"`,
+        },
+      });
+    }
+    if (url.endsWith(`/manifests/latest`)) {
+      return new Response(channelBody, {
+        status: 200,
+        headers: {
+          "content-type": "application/vnd.oci.image.index.v1+json",
+          "docker-content-digest": options.tamperChannelDigest
+            ? `sha256:${"f".repeat(64)}`
+            : digest(channelBody),
+        },
+      });
+    }
+    if (url.endsWith(`/manifests/${encodeURIComponent(platformDigest)}`)) {
+      return new Response(platformBody, {
+        status: 200,
+        headers: {
+          "content-type": "application/vnd.oci.image.manifest.v1+json",
+          "docker-content-digest": platformDigest,
+        },
+      });
+    }
+    if (url.endsWith(`/blobs/${configDigest}`)) {
+      if (options.blobRedirectHost) {
+        return new Response(null, {
+          status: 307,
+          headers: {
+            location: `https://${options.blobRedirectHost}/ghcrblobs/config`,
+          },
+        });
+      }
+      return new Response(configBody, {
+        status: 200,
+        headers: {
+          "content-type": "application/vnd.oci.image.config.v1+json",
+          "docker-content-digest": configDigest,
+        },
+      });
+    }
+    if (url === "https://pkg-containers.githubusercontent.com/ghcrblobs/config") {
+      return new Response(configBody, {
+        status: 200,
+        headers: {
+          "content-type": "application/vnd.oci.image.config.v1+json",
+        },
+      });
+    }
+    if (url.includes("/tags/list")) {
+      return Response.json({ name: REPO, tags: ["latest", ...immutableTags] });
+    }
+    const tag = decodeURIComponent(url.split("/manifests/")[1] ?? "");
+    if (immutableTags.includes(tag)) {
+      return new Response(channelBody, {
+        status: 200,
+        headers: {
+          "content-type": "application/vnd.oci.image.index.v1+json",
+          "docker-content-digest": digest(channelBody),
+        },
+      });
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+}
+
+describe("readRegistryReleaseCandidate", () => {
+  it("resolves a verified channel to the immutable tag and byte identities", async () => {
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      fetchImpl: fixtureFetch(),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      candidate: {
+        tag: "v2026.08.24",
+        sourceSha: SOURCE_SHA,
+        channelDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        platformManifestDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        configDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      },
+    });
+  });
+
+  it("fails closed when registry bytes do not match Docker-Content-Digest", async () => {
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      fetchImpl: fixtureFetch({ tamperChannelDigest: true }),
+    });
+    expect(result).toEqual({ ok: false, reason: "channel-digest-mismatch" });
+  });
+
+  it("follows GHCR's config-blob redirect only to GitHub's package host", async () => {
+    const allowed = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      fetchImpl: fixtureFetch({ blobRedirectHost: "pkg-containers.githubusercontent.com" }),
+    });
+    expect(allowed.ok).toBe(true);
+
+    const rejected = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      fetchImpl: fixtureFetch({ blobRedirectHost: "example.com" }),
+    });
+    expect(rejected).toEqual({ ok: false, reason: "registry-redirect-invalid" });
+  });
+
+  it("fails closed when platform selection is ambiguous", async () => {
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      fetchImpl: fixtureFetch({ duplicatePlatform: true }),
+    });
+    expect(result).toEqual({ ok: false, reason: "platform-manifest-ambiguous" });
+  });
+
+  it("recovers a legacy version=main image only from one matching immutable tag", async () => {
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      fetchImpl: fixtureFetch({ version: "main", immutableTags: ["v2026.08.24"] }),
+    });
+    expect(result.ok && result.candidate.tag).toBe("v2026.08.24");
+  });
+
+  it("rejects zero or ambiguous legacy immutable tag matches", async () => {
+    const zero = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      fetchImpl: fixtureFetch({ version: "main", immutableTags: [] }),
+    });
+    expect(zero).toEqual({ ok: false, reason: "immutable-tag-not-found" });
+
+    const ambiguous = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      fetchImpl: fixtureFetch({
+        version: "main",
+        immutableTags: ["v2026.08.24", "v2026.08.24-review-routing.1"],
+      }),
+    });
+    expect(ambiguous).toEqual({ ok: false, reason: "immutable-tag-ambiguous" });
+  });
+
+  it("rejects malformed source identity before returning a candidate", async () => {
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      fetchImpl: fixtureFetch({ revision: "main" }),
+    });
+    expect(result).toEqual({ ok: false, reason: "source-revision-invalid" });
+  });
+});

--- a/apps/web/lib/self-upgrade/registry-release.test.ts
+++ b/apps/web/lib/self-upgrade/registry-release.test.ts
@@ -10,18 +10,6 @@ function digest(body: string): string {
   return `sha256:${createHash("sha256").update(body).digest("hex")}`;
 }
 
-function verifiedJson(value: unknown, headers: Record<string, string> = {}): Response {
-  const body = JSON.stringify(value);
-  return new Response(body, {
-    status: 200,
-    headers: {
-      "content-type": "application/vnd.oci.image.index.v1+json",
-      "docker-content-digest": digest(body),
-      ...headers,
-    },
-  });
-}
-
 function fixtureFetch(options: {
   version?: string;
   revision?: string;

--- a/apps/web/lib/self-upgrade/registry-release.ts
+++ b/apps/web/lib/self-upgrade/registry-release.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { ok, type ActionSuccess } from "@/lib/shared/action-result";
 
 const DEFAULT_REGISTRY_ORIGIN = "https://ghcr.io";
 const DEFAULT_REPOSITORY = "dpf-portal";
@@ -52,7 +53,7 @@ export type RegistryReleaseFailureReason =
   | "tag-list-limit";
 
 export type RegistryReleaseReadResult =
-  | { ok: true; candidate: RegistryReleaseCandidate }
+  | (ActionSuccess & { candidate: RegistryReleaseCandidate })
   | { ok: false; reason: RegistryReleaseFailureReason };
 
 type ManifestDescriptor = {
@@ -380,7 +381,7 @@ export async function readRegistryReleaseCandidate(input: {
     }
 
     return {
-      ok: true,
+      ...ok(),
       candidate: Object.freeze({
         tag: immutableTag,
         sourceSha: sourceSha.toLowerCase(),

--- a/apps/web/lib/self-upgrade/registry-release.ts
+++ b/apps/web/lib/self-upgrade/registry-release.ts
@@ -1,0 +1,398 @@
+import { createHash } from "node:crypto";
+
+const DEFAULT_REGISTRY_ORIGIN = "https://ghcr.io";
+const DEFAULT_REPOSITORY = "dpf-portal";
+const MANIFEST_ACCEPT = [
+  "application/vnd.oci.image.index.v1+json",
+  "application/vnd.docker.distribution.manifest.list.v2+json",
+  "application/vnd.oci.image.manifest.v1+json",
+  "application/vnd.docker.distribution.manifest.v2+json",
+].join(", ");
+const MAX_MANIFEST_BYTES = 2 * 1024 * 1024;
+const MAX_CONFIG_BYTES = 2 * 1024 * 1024;
+const MAX_TOKEN_BYTES = 16 * 1024;
+const MAX_TAG_LIST_BYTES = 256 * 1024;
+const MAX_LEGACY_TAGS = 200;
+const LEGACY_CONCURRENCY = 8;
+
+export const RELEASE_IMAGE_TAG = /^v\d+\.\d+\.\d+([-+][A-Za-z0-9.-]+)?$/;
+const OCI_TAG = /^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$/;
+const REGISTRY_OWNER = /^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$/;
+const SHA_256 = /^sha256:[a-f0-9]{64}$/;
+const SOURCE_SHA = /^[a-f0-9]{40}$/i;
+
+export type RegistryReleaseCandidate = Readonly<{
+  tag: string;
+  sourceSha: string;
+  channelDigest: string;
+  platformManifestDigest: string;
+  configDigest: string;
+}>;
+
+export type RegistryReleaseFailureReason =
+  | "registry-identity-invalid"
+  | "registry-unavailable"
+  | "registry-response-too-large"
+  | "registry-auth-invalid"
+  | "registry-redirect-invalid"
+  | "channel-manifest-invalid"
+  | "channel-digest-missing"
+  | "channel-digest-mismatch"
+  | "platform-manifest-missing"
+  | "platform-manifest-ambiguous"
+  | "platform-manifest-invalid"
+  | "platform-digest-mismatch"
+  | "image-config-invalid"
+  | "config-digest-mismatch"
+  | "source-revision-invalid"
+  | "immutable-tag-invalid"
+  | "immutable-tag-mismatch"
+  | "immutable-tag-not-found"
+  | "immutable-tag-ambiguous"
+  | "tag-list-limit";
+
+export type RegistryReleaseReadResult =
+  | { ok: true; candidate: RegistryReleaseCandidate }
+  | { ok: false; reason: RegistryReleaseFailureReason };
+
+type ManifestDescriptor = {
+  mediaType?: unknown;
+  digest?: unknown;
+  platform?: { os?: unknown; architecture?: unknown };
+};
+
+type RegistryIndex = {
+  schemaVersion?: unknown;
+  manifests?: unknown;
+};
+
+type RegistryManifest = {
+  schemaVersion?: unknown;
+  config?: { digest?: unknown };
+};
+
+type RegistryConfig = {
+  architecture?: unknown;
+  os?: unknown;
+  config?: { Labels?: Record<string, unknown> };
+};
+
+class RegistryReadError extends Error {
+  constructor(readonly reason: RegistryReleaseFailureReason) {
+    super(reason);
+  }
+}
+
+function sha256(body: Uint8Array): string {
+  return `sha256:${createHash("sha256").update(body).digest("hex")}`;
+}
+
+async function readBounded(response: Response, limit: number): Promise<Uint8Array> {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > limit) {
+    throw new RegistryReadError("registry-response-too-large");
+  }
+  if (!response.body) return new Uint8Array();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > limit) {
+      await reader.cancel();
+      throw new RegistryReadError("registry-response-too-large");
+    }
+    chunks.push(value);
+  }
+  const body = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+function parseJson(body: Uint8Array, reason: RegistryReleaseFailureReason): unknown {
+  try {
+    return JSON.parse(new TextDecoder().decode(body));
+  } catch {
+    throw new RegistryReadError(reason);
+  }
+}
+
+function parseBearerChallenge(value: string | null, expectedHost: string): URL {
+  if (!value?.startsWith("Bearer ")) throw new RegistryReadError("registry-auth-invalid");
+  const fields = new Map<string, string>();
+  for (const match of value.slice(7).matchAll(/([a-z]+)="([^"]*)"/gi)) {
+    fields.set(match[1].toLowerCase(), match[2]);
+  }
+  const realm = fields.get("realm");
+  if (!realm) throw new RegistryReadError("registry-auth-invalid");
+  let tokenUrl: URL;
+  try {
+    tokenUrl = new URL(realm);
+  } catch {
+    throw new RegistryReadError("registry-auth-invalid");
+  }
+  if (tokenUrl.protocol !== "https:" || tokenUrl.hostname !== expectedHost) {
+    throw new RegistryReadError("registry-auth-invalid");
+  }
+  for (const key of ["service", "scope"] as const) {
+    const field = fields.get(key);
+    if (field) tokenUrl.searchParams.set(key, field);
+  }
+  return tokenUrl;
+}
+
+function registryArchitecture(architecture?: string): string {
+  const value = architecture ?? process.arch;
+  if (value === "x64") return "amd64";
+  return value;
+}
+
+function verifiedDigest(
+  response: Response,
+  body: Uint8Array,
+  missingReason: RegistryReleaseFailureReason,
+  mismatchReason: RegistryReleaseFailureReason,
+  expected?: string,
+  requireHeader = true,
+): string {
+  const header = response.headers.get("docker-content-digest")?.toLowerCase() ?? "";
+  const computed = sha256(body);
+  if (header && !SHA_256.test(header)) throw new RegistryReadError(missingReason);
+  if (requireHeader && !header) throw new RegistryReadError(missingReason);
+  if (
+    (header && computed !== header) ||
+    (expected && expected.toLowerCase() !== computed) ||
+    (expected && header && expected.toLowerCase() !== header)
+  ) {
+    throw new RegistryReadError(mismatchReason);
+  }
+  return header || computed;
+}
+
+export async function readRegistryReleaseCandidate(input: {
+  owner: string;
+  channelTag: string;
+  architecture?: string;
+  repository?: string;
+  registryOrigin?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<RegistryReleaseReadResult> {
+  const repository = input.repository ?? DEFAULT_REPOSITORY;
+  const origin = input.registryOrigin ?? DEFAULT_REGISTRY_ORIGIN;
+  if (!REGISTRY_OWNER.test(input.owner) || !OCI_TAG.test(input.channelTag) || !/^[a-z0-9._-]+$/.test(repository)) {
+    return { ok: false, reason: "registry-identity-invalid" };
+  }
+
+  try {
+    const originUrl = new URL(origin);
+    if (originUrl.protocol !== "https:") throw new RegistryReadError("registry-identity-invalid");
+    const fetchImpl = input.fetchImpl ?? fetch;
+    const imageName = `${input.owner.toLowerCase()}/${repository}`;
+    let bearer: string | null = null;
+
+    async function request(
+      path: string,
+      accept?: string,
+      redirect: RequestRedirect = "error",
+    ): Promise<Response> {
+      const headers: Record<string, string> = {};
+      if (accept) headers.Accept = accept;
+      if (bearer) headers.Authorization = `Bearer ${bearer}`;
+      let response = await fetchImpl(`${originUrl.origin}${path}`, {
+        method: "GET",
+        headers,
+        signal: AbortSignal.timeout(10_000),
+        redirect,
+      });
+      if (response.status !== 401 || bearer) return response;
+
+      const tokenUrl = parseBearerChallenge(
+        response.headers.get("www-authenticate"),
+        originUrl.hostname,
+      );
+      const tokenResponse = await fetchImpl(tokenUrl, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(10_000),
+        redirect,
+      });
+      if (!tokenResponse.ok) throw new RegistryReadError("registry-auth-invalid");
+      const tokenBody = parseJson(
+        await readBounded(tokenResponse, MAX_TOKEN_BYTES),
+        "registry-auth-invalid",
+      ) as { token?: unknown; access_token?: unknown };
+      const token = typeof tokenBody.token === "string"
+        ? tokenBody.token
+        : typeof tokenBody.access_token === "string"
+          ? tokenBody.access_token
+          : null;
+      if (!token || token.length > 16_384) throw new RegistryReadError("registry-auth-invalid");
+      bearer = token;
+      headers.Authorization = `Bearer ${bearer}`;
+      response = await fetchImpl(`${originUrl.origin}${path}`, {
+        method: "GET",
+        headers,
+        signal: AbortSignal.timeout(10_000),
+        redirect: "error",
+      });
+      return response;
+    }
+
+    async function manifest(reference: string, expectedDigest?: string): Promise<{
+      json: unknown;
+      digest: string;
+    }> {
+      const response = await request(
+        `/v2/${imageName}/manifests/${encodeURIComponent(reference)}`,
+        MANIFEST_ACCEPT,
+      );
+      if (!response.ok) throw new RegistryReadError("registry-unavailable");
+      const body = await readBounded(response, MAX_MANIFEST_BYTES);
+      const digest = verifiedDigest(
+        response,
+        body,
+        "channel-digest-missing",
+        expectedDigest ? "platform-digest-mismatch" : "channel-digest-mismatch",
+        expectedDigest,
+      );
+      return { json: parseJson(body, "channel-manifest-invalid"), digest };
+    }
+
+    async function blob(digest: string): Promise<Response> {
+      const response = await request(`/v2/${imageName}/blobs/${digest}`, undefined, "manual");
+      if (![302, 307].includes(response.status)) return response;
+
+      const location = response.headers.get("location");
+      let redirect: URL;
+      try {
+        redirect = new URL(location ?? "");
+      } catch {
+        throw new RegistryReadError("registry-redirect-invalid");
+      }
+      if (
+        redirect.protocol !== "https:" ||
+        redirect.hostname !== "pkg-containers.githubusercontent.com" ||
+        redirect.port ||
+        redirect.username ||
+        redirect.password ||
+        redirect.hash
+      ) {
+        throw new RegistryReadError("registry-redirect-invalid");
+      }
+      return fetchImpl(redirect, {
+        method: "GET",
+        headers: { Accept: "application/octet-stream" },
+        signal: AbortSignal.timeout(10_000),
+        redirect: "error",
+      });
+    }
+
+    const channel = await manifest(input.channelTag);
+    const index = channel.json as RegistryIndex;
+    if (index.schemaVersion !== 2 || !Array.isArray(index.manifests)) {
+      throw new RegistryReadError("channel-manifest-invalid");
+    }
+    const architecture = registryArchitecture(input.architecture);
+    const matches = (index.manifests as ManifestDescriptor[]).filter(
+      (descriptor) =>
+        descriptor?.platform?.os === "linux" &&
+        descriptor.platform.architecture === architecture &&
+        typeof descriptor.digest === "string" &&
+        SHA_256.test(descriptor.digest),
+    );
+    if (matches.length === 0) throw new RegistryReadError("platform-manifest-missing");
+    if (matches.length !== 1) throw new RegistryReadError("platform-manifest-ambiguous");
+    const platformManifestDigest = matches[0].digest as string;
+
+    const platformRead = await manifest(platformManifestDigest, platformManifestDigest);
+    const platform = platformRead.json as RegistryManifest;
+    const configDigest = platform?.config?.digest;
+    if (platform.schemaVersion !== 2 || typeof configDigest !== "string" || !SHA_256.test(configDigest)) {
+      throw new RegistryReadError("platform-manifest-invalid");
+    }
+
+    const configResponse = await blob(configDigest);
+    if (!configResponse.ok) throw new RegistryReadError("registry-unavailable");
+    const configBody = await readBounded(configResponse, MAX_CONFIG_BYTES);
+    verifiedDigest(
+      configResponse,
+      configBody,
+      "image-config-invalid",
+      "config-digest-mismatch",
+      configDigest,
+      false,
+    );
+    const config = parseJson(configBody, "image-config-invalid") as RegistryConfig;
+    if (config.os !== "linux" || config.architecture !== architecture) {
+      throw new RegistryReadError("image-config-invalid");
+    }
+    const labels = config.config?.Labels ?? {};
+    const sourceSha = labels["org.opencontainers.image.revision"];
+    const stampedVersion = labels["org.opencontainers.image.version"];
+    if (typeof sourceSha !== "string" || !SOURCE_SHA.test(sourceSha)) {
+      throw new RegistryReadError("source-revision-invalid");
+    }
+
+    async function digestForTag(tag: string): Promise<string | null> {
+      try {
+        return (await manifest(tag)).digest;
+      } catch {
+        return null;
+      }
+    }
+
+    let immutableTag: string;
+    if (typeof stampedVersion === "string" && RELEASE_IMAGE_TAG.test(stampedVersion)) {
+      immutableTag = stampedVersion;
+      const immutableDigest = await digestForTag(immutableTag);
+      if (!immutableDigest) throw new RegistryReadError("immutable-tag-invalid");
+      if (immutableDigest !== channel.digest) throw new RegistryReadError("immutable-tag-mismatch");
+    } else {
+      const tagsResponse = await request(`/v2/${imageName}/tags/list?n=${MAX_LEGACY_TAGS}`);
+      if (!tagsResponse.ok) throw new RegistryReadError("registry-unavailable");
+      const tagsBody = parseJson(
+        await readBounded(tagsResponse, MAX_TAG_LIST_BYTES),
+        "channel-manifest-invalid",
+      ) as { tags?: unknown };
+      if (!Array.isArray(tagsBody.tags)) throw new RegistryReadError("channel-manifest-invalid");
+      if (tagsResponse.headers.has("link") || tagsBody.tags.length > MAX_LEGACY_TAGS) {
+        throw new RegistryReadError("tag-list-limit");
+      }
+      const releaseTags = tagsBody.tags.filter(
+        (tag): tag is string => typeof tag === "string" && RELEASE_IMAGE_TAG.test(tag),
+      );
+      const matching: string[] = [];
+      for (let offset = 0; offset < releaseTags.length; offset += LEGACY_CONCURRENCY) {
+        const batch = releaseTags.slice(offset, offset + LEGACY_CONCURRENCY);
+        const digests = await Promise.all(batch.map(async (tag) => ({ tag, digest: await digestForTag(tag) })));
+        matching.push(...digests.filter((entry) => entry.digest === channel.digest).map((entry) => entry.tag));
+        if (matching.length > 1) break;
+      }
+      if (matching.length === 0) throw new RegistryReadError("immutable-tag-not-found");
+      if (matching.length !== 1) throw new RegistryReadError("immutable-tag-ambiguous");
+      immutableTag = matching[0];
+    }
+
+    return {
+      ok: true,
+      candidate: Object.freeze({
+        tag: immutableTag,
+        sourceSha: sourceSha.toLowerCase(),
+        channelDigest: channel.digest,
+        platformManifestDigest,
+        configDigest,
+      }),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof RegistryReadError ? error.reason : "registry-unavailable",
+    };
+  }
+}

--- a/apps/web/lib/self-upgrade/release-target.test.ts
+++ b/apps/web/lib/self-upgrade/release-target.test.ts
@@ -21,11 +21,31 @@ describe("consumer release target", () => {
     expect(context).toEqual({
       installMode: "consumer",
       imageTag: "v2026.08.22",
+      channelTag: "latest",
       installPath: "D:\\DPF",
       composeFiles: ["docker-compose.yml", "docker-compose.release.yml"],
       ghcrOwner: "opendigitalproductfactory",
     });
     expect(resolveUpgradeStrategy("upstream", context)).toBe("release");
+  });
+
+  it("keeps the update channel stable after an immutable image tag is installed", () => {
+    const context = parseReleaseInstallContext({
+      state: {
+        installMode: "consumer",
+        imageTag: "v2026.08.24",
+        installPath: "/opt/dpf",
+        composeFiles: ["docker-compose.yml", "docker-compose.release.yml"],
+      },
+      markerMode: null,
+      env: {
+        GHCR_OWNER: "opendigitalproductfactory",
+        DPF_IMAGE_CHANNEL_TAG: "stable",
+      },
+    });
+
+    expect(context?.imageTag).toBe("v2026.08.24");
+    expect(context?.channelTag).toBe("stable");
   });
 
   it("uses the compatibility marker and release env while stale installer state converges", () => {
@@ -84,44 +104,49 @@ describe("consumer release target", () => {
     expect(resolveUpgradeStrategy("local", {
       installMode: "consumer",
       imageTag: "v1.0.0",
+      channelTag: "latest",
       installPath: "/opt/dpf",
       composeFiles: ["docker-compose.yml"],
       ghcrOwner: "owner",
     })).toBe("source");
   });
 
-  it("returns an explicit up-to-date outcome for the installed verified tag", () => {
+  it("returns an explicit up-to-date outcome when the running config bytes equal the channel candidate", () => {
     expect(resolveReleaseTarget({
-      currentImageTag: "v2026.08.22",
-      currentSourceSha: "a".repeat(40),
-      latest: {
+      currentConfigDigest: `sha256:${"c".repeat(64)}`,
+      candidate: {
         tag: "v2026.08.22",
-        headSha: "a".repeat(40),
-        status: "verified",
+        sourceSha: "a".repeat(40),
+        channelDigest: `sha256:${"d".repeat(64)}`,
+        platformManifestDigest: `sha256:${"e".repeat(64)}`,
+        configDigest: `sha256:${"c".repeat(64)}`,
       },
-    })).toEqual({ kind: "up-to-date", tag: "v2026.08.22", sourceSha: "a".repeat(40) });
+    })).toEqual({
+      kind: "up-to-date",
+      tag: "v2026.08.22",
+      sourceSha: "a".repeat(40),
+      channelDigest: `sha256:${"d".repeat(64)}`,
+      configDigest: `sha256:${"c".repeat(64)}`,
+    });
   });
 
-  it("returns only a verified immutable release target", () => {
+  it("returns a frozen immutable target when the channel bytes differ", () => {
     expect(resolveReleaseTarget({
-      currentImageTag: "v2026.08.21",
-      currentSourceSha: "a".repeat(40),
-      latest: {
+      currentConfigDigest: `sha256:${"c".repeat(64)}`,
+      candidate: {
         tag: "v2026.08.22",
-        headSha: "b".repeat(40),
-        status: "verified",
+        sourceSha: "b".repeat(40),
+        channelDigest: `sha256:${"d".repeat(64)}`,
+        platformManifestDigest: `sha256:${"e".repeat(64)}`,
+        configDigest: `sha256:${"f".repeat(64)}`,
       },
-    })).toEqual({ kind: "target", tag: "v2026.08.22", sourceSha: "b".repeat(40) });
-
-    expect(resolveReleaseTarget({
-      currentImageTag: "v2026.08.21",
-      currentSourceSha: "a".repeat(40),
-      latest: {
-        tag: "v2026.08.22",
-        headSha: "b".repeat(40),
-        status: "verify-failed",
-      },
-    })).toEqual({ kind: "no-published-target", reason: "verify-failed" });
+    })).toEqual({
+      kind: "target",
+      tag: "v2026.08.22",
+      sourceSha: "b".repeat(40),
+      channelDigest: `sha256:${"d".repeat(64)}`,
+      configDigest: `sha256:${"f".repeat(64)}`,
+    });
   });
 
   it("fails closed when release identity is incomplete", () => {
@@ -131,9 +156,9 @@ describe("consumer release target", () => {
       env: {},
     })).toBeNull();
     expect(resolveReleaseTarget({
-      currentImageTag: "v1.0.0",
-      currentSourceSha: null,
-      latest: { tag: "v1.1.0", headSha: null, status: "verified" },
-    })).toEqual({ kind: "no-published-target", reason: "source-sha-missing" });
+      currentConfigDigest: null,
+      candidate: null,
+      unavailableReason: "registry-unavailable",
+    })).toEqual({ kind: "no-published-target", reason: "registry-unavailable" });
   });
 });

--- a/apps/web/lib/self-upgrade/release-target.ts
+++ b/apps/web/lib/self-upgrade/release-target.ts
@@ -1,14 +1,16 @@
 import {
-  readLatestReleaseStamp,
-  type ReleaseStampStatus,
-  type ReleaseRunsResult,
-} from "@/lib/release-health/release-runs-reader";
+  readRegistryReleaseCandidate,
+  type RegistryReleaseCandidate,
+  type RegistryReleaseFailureReason,
+  type RegistryReleaseReadResult,
+} from "./registry-release";
 import type { UpgradeSourceMode } from "./config";
 import { readFile } from "node:fs/promises";
 
 export type ReleaseInstallContext = Readonly<{
   installMode: "consumer" | "customer";
   imageTag: string;
+  channelTag: string;
   installPath: string;
   composeFiles: string[];
   ghcrOwner: string;
@@ -59,6 +61,9 @@ export function parseReleaseInstallContext(input: ReleaseStateInput): ReleaseIns
   const installMode = releaseMode(state.installMode) ?? releaseMode(input.markerMode);
   if (!installMode) return null;
   const imageTag = nonEmpty(state.imageTag) ?? nonEmpty(input.env.DPF_IMAGE_TAG);
+  // The installed immutable tag is rollback identity, not the discovery channel.
+  // promote.sh persists each successful immutable tag, while `latest` keeps moving.
+  const channelTag = nonEmpty(input.env.DPF_IMAGE_CHANNEL_TAG) ?? "latest";
   const installPath = nonEmpty(state.installPath) ?? nonEmpty(input.env.DPF_HOST_INSTALL_PATH);
   const ghcrOwner = nonEmpty(input.env.GHCR_OWNER);
   const recordedFiles = composeFiles(state.composeFiles, input.env.DPF_SELF_UPGRADE_COMPOSE_FILES);
@@ -66,7 +71,7 @@ export function parseReleaseInstallContext(input: ReleaseStateInput): ReleaseIns
     ? recordedFiles
     : ["docker-compose.yml", "docker-compose.release.yml"];
   if (!imageTag || !installPath || !ghcrOwner || files.length === 0) return null;
-  return Object.freeze({ installMode, imageTag, installPath, composeFiles: files, ghcrOwner });
+  return Object.freeze({ installMode, imageTag, channelTag, installPath, composeFiles: files, ghcrOwner });
 }
 
 export async function loadReleaseInstallContext(input: {
@@ -99,48 +104,57 @@ export function resolveUpgradeStrategy(
   return sourceMode === "upstream" && release ? "release" : "source";
 }
 
-type LatestRelease = {
-  tag: string;
-  headSha: string | null;
-  status: ReleaseStampStatus;
-};
-
 export type ReleaseTargetResult =
-  | { kind: "target"; tag: string; sourceSha: string }
-  | { kind: "up-to-date"; tag: string; sourceSha: string }
-  | { kind: "no-published-target"; reason: ReleaseStampStatus | "missing" | "source-sha-missing" };
+  | { kind: "target"; tag: string; sourceSha: string; channelDigest: string; configDigest: string }
+  | { kind: "up-to-date"; tag: string; sourceSha: string; channelDigest: string; configDigest: string }
+  | { kind: "no-published-target"; reason: RegistryReleaseFailureReason | "current-image-identity-missing" };
 
 export function resolveReleaseTarget(input: {
-  currentImageTag: string;
-  currentSourceSha: string | null;
-  latest: LatestRelease | null;
+  currentConfigDigest: string | null;
+  candidate: RegistryReleaseCandidate | null;
+  unavailableReason?: RegistryReleaseFailureReason;
 }): ReleaseTargetResult {
-  if (!input.latest) return { kind: "no-published-target", reason: "missing" };
-  if (input.latest.status !== "verified") {
-    return { kind: "no-published-target", reason: input.latest.status };
+  if (!input.candidate) {
+    return { kind: "no-published-target", reason: input.unavailableReason ?? "registry-unavailable" };
   }
-  if (!input.latest.headSha || !/^[a-f0-9]{40}$/i.test(input.latest.headSha)) {
-    return { kind: "no-published-target", reason: "source-sha-missing" };
+  if (!input.currentConfigDigest) {
+    return { kind: "no-published-target", reason: "current-image-identity-missing" };
   }
-  const candidate = { tag: input.latest.tag, sourceSha: input.latest.headSha };
-  if (
-    input.currentImageTag === candidate.tag ||
-    input.currentSourceSha?.toLowerCase() === candidate.sourceSha.toLowerCase()
-  ) {
-    return { kind: "up-to-date", ...candidate };
+  if (input.currentConfigDigest.toLowerCase() === input.candidate.configDigest.toLowerCase()) {
+    return {
+      kind: "up-to-date",
+      tag: input.candidate.tag,
+      sourceSha: input.candidate.sourceSha,
+      channelDigest: input.candidate.channelDigest,
+      configDigest: input.candidate.configDigest,
+    };
   }
-  return { kind: "target", ...candidate };
+  return {
+    kind: "target",
+    tag: input.candidate.tag,
+    sourceSha: input.candidate.sourceSha,
+    channelDigest: input.candidate.channelDigest,
+    configDigest: input.candidate.configDigest,
+  };
 }
 
 export async function resolveReleaseUpgradeCandidate(
-  input: { context: ReleaseInstallContext; currentSourceSha: string | null },
-  readLatest: () => Promise<ReleaseRunsResult> = readLatestReleaseStamp,
+  input: {
+    context: ReleaseInstallContext;
+    currentConfigDigest: string | null;
+  },
+  readCandidate: (input: {
+    owner: string;
+    channelTag: string;
+  }) => Promise<RegistryReleaseReadResult> = readRegistryReleaseCandidate,
 ): Promise<ReleaseTargetResult> {
-  const releases = await readLatest();
-  if (!releases.ok) return { kind: "no-published-target", reason: "missing" };
+  const release = await readCandidate({
+    owner: input.context.ghcrOwner,
+    channelTag: input.context.channelTag,
+  });
   return resolveReleaseTarget({
-    currentImageTag: input.context.imageTag,
-    currentSourceSha: input.currentSourceSha,
-    latest: releases.latest,
+    currentConfigDigest: input.currentConfigDigest,
+    candidate: release.ok ? release.candidate : null,
+    unavailableReason: release.ok ? undefined : release.reason,
   });
 }

--- a/apps/web/lib/self-upgrade/runtime-image-identity.test.ts
+++ b/apps/web/lib/self-upgrade/runtime-image-identity.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  parseContainerConfigDigest,
+  readCurrentContainerConfigDigest,
+} from "./runtime-image-identity";
+
+describe("runtime image identity", () => {
+  it("accepts only a Docker sha256 config digest", () => {
+    const digest = `sha256:${"a".repeat(64)}`;
+    expect(parseContainerConfigDigest(` ${digest}\n`)).toBe(digest);
+    expect(parseContainerConfigDigest("latest")).toBeNull();
+    expect(parseContainerConfigDigest("sha256:abc")).toBeNull();
+  });
+
+  it("reads the current container byte identity without inspecting a mutable tag", async () => {
+    const digest = `sha256:${"b".repeat(64)}`;
+    const runDocker = vi.fn().mockResolvedValue({ exitCode: 0, stdout: `${digest}\n`, stderr: "" });
+    await expect(readCurrentContainerConfigDigest(runDocker, "portal-container")).resolves.toBe(digest);
+    expect(runDocker).toHaveBeenCalledWith([
+      "inspect",
+      "--format",
+      "{{.Image}}",
+      "portal-container",
+    ]);
+  });
+
+  it("returns null when Docker or the current container identity is unavailable", async () => {
+    await expect(readCurrentContainerConfigDigest(
+      vi.fn().mockResolvedValue({ exitCode: 1, stdout: "", stderr: "missing" }),
+      "portal-container",
+    )).resolves.toBeNull();
+  });
+});

--- a/apps/web/lib/self-upgrade/runtime-image-identity.ts
+++ b/apps/web/lib/self-upgrade/runtime-image-identity.ts
@@ -1,0 +1,59 @@
+import { hostname } from "node:os";
+import { spawn } from "node:child_process";
+
+const CONFIG_DIGEST = /^sha256:[a-f0-9]{64}$/;
+
+export type ImageIdentityDockerRunner = (args: string[]) => Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}>;
+
+export function parseContainerConfigDigest(value: string): string | null {
+  const digest = value.trim().toLowerCase();
+  return CONFIG_DIGEST.test(digest) ? digest : null;
+}
+
+async function defaultDockerRunner(args: string[]): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
+  return await new Promise((resolve) => {
+    try {
+      const child = spawn("docker", args, {
+        env: { ...process.env },
+        shell: false,
+      });
+      let stdout = "";
+      let stderr = "";
+      let settled = false;
+      const finish = (result: { exitCode: number; stdout: string; stderr: string }) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(result);
+      };
+      const timer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+      child.stdout.on("data", (chunk: Buffer) => { stdout += chunk; });
+      child.stderr.on("data", (chunk: Buffer) => { stderr += chunk; });
+      child.on("error", (error) => {
+        finish({ exitCode: 1, stdout, stderr: `${stderr}${error.message}` });
+      });
+      child.on("close", (code) => {
+        finish({ exitCode: code ?? 1, stdout, stderr });
+      });
+    } catch (error) {
+      resolve({ exitCode: 1, stdout: "", stderr: error instanceof Error ? error.message : String(error) });
+    }
+  });
+}
+
+export async function readCurrentContainerConfigDigest(
+  runDocker: ImageIdentityDockerRunner = defaultDockerRunner,
+  containerId = hostname(),
+): Promise<string | null> {
+  if (!containerId.trim()) return null;
+  const result = await runDocker(["inspect", "--format", "{{.Image}}", containerId]);
+  return result.exitCode === 0 ? parseContainerConfigDigest(result.stdout) : null;
+}

--- a/apps/web/lib/self-upgrade/runtime-image-identity.ts
+++ b/apps/web/lib/self-upgrade/runtime-image-identity.ts
@@ -1,5 +1,6 @@
 import { hostname } from "node:os";
 import { spawn } from "node:child_process";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 const CONFIG_DIGEST = /^sha256:[a-f0-9]{64}$/;
 
@@ -44,7 +45,7 @@ async function defaultDockerRunner(args: string[]): Promise<{
         finish({ exitCode: code ?? 1, stdout, stderr });
       });
     } catch (error) {
-      resolve({ exitCode: 1, stdout: "", stderr: error instanceof Error ? error.message : String(error) });
+      resolve({ exitCode: 1, stdout: "", stderr: getErrorMessage(error) });
     }
   });
 }

--- a/apps/web/lib/self-upgrade/status-target.ts
+++ b/apps/web/lib/self-upgrade/status-target.ts
@@ -1,0 +1,62 @@
+import type { SelfUpgradeConfig } from "./config";
+import { loadReleaseInstallContext, resolveReleaseUpgradeCandidate } from "./release-target";
+import type { SelfUpgradeSupport } from "./support";
+import { resolveTargetSha } from "./version";
+
+export type SelfUpgradeStatusTarget = Readonly<{
+  targetSha: string | null;
+  targetTag: string | null;
+  availability: "resolved" | "unavailable";
+  unavailableReason: string | null;
+  releaseFreshness: boolean | null;
+}>;
+
+const UNAVAILABLE: SelfUpgradeStatusTarget = Object.freeze({
+  targetSha: null,
+  targetTag: null,
+  availability: "unavailable",
+  unavailableReason: "no-target",
+  releaseFreshness: null,
+});
+
+export async function resolveSelfUpgradeStatusTarget(input: {
+  support: SelfUpgradeSupport;
+  config: SelfUpgradeConfig;
+  currentConfigDigest: string | null;
+}): Promise<SelfUpgradeStatusTarget> {
+  if (!input.support.supported) return UNAVAILABLE;
+  if (input.support.targetKind === "git-source") {
+    const targetSha = await resolveTargetSha(input.config.channel, input.config);
+    return {
+      ...UNAVAILABLE,
+      targetSha,
+      availability: targetSha ? "resolved" : "unavailable",
+      unavailableReason: targetSha ? null : "no-target",
+    };
+  }
+
+  const context = await loadReleaseInstallContext({
+    hostSourcePath:
+      input.config.hostSourceMountPath ??
+      process.env.DPF_SELF_UPGRADE_HOST_SOURCE_MOUNT ??
+      "/host-dpf",
+  });
+  if (!context) return UNAVAILABLE;
+  const target = await resolveReleaseUpgradeCandidate({
+    context,
+    currentConfigDigest: input.currentConfigDigest,
+  }).catch(() => null);
+  if (!target || target.kind === "no-published-target") {
+    return {
+      ...UNAVAILABLE,
+      unavailableReason: target?.reason ?? "registry-unavailable",
+    };
+  }
+  return {
+    targetSha: target.sourceSha,
+    targetTag: target.tag,
+    availability: "resolved",
+    unavailableReason: null,
+    releaseFreshness: target.kind === "up-to-date",
+  };
+}

--- a/docs/runbooks/bet5-windows-self-upgrade.md
+++ b/docs/runbooks/bet5-windows-self-upgrade.md
@@ -47,9 +47,13 @@ bootstrap, use **Ops → Self-Upgrade → Upgrade now** for later releases.
 
 The consumer path:
 
-- resolves the next target only from a verified published release and the canonical install state;
-- pulls the portal and promoter for that exact tag and verifies the portal OCI revision and baked
-  source-content identity before swapping;
+- resolves the verification-gated GHCR channel (`latest` unless
+  `DPF_IMAGE_CHANNEL_TAG` overrides it), verifies its OCI manifests/config, and freezes the one
+  immutable release tag that identifies the same bytes;
+- compares the running portal container's config digest with the candidate config digest, rather
+  than treating a recorded tag or GitHub release run as byte identity;
+- pulls the portal and promoter for that exact immutable tag and verifies the expected portal
+  config digest, OCI revision, and baked source-content identity before swapping;
 - verifies `SHA256SUMS`, replaces only installer-managed lifecycle files, and preserves operator-owned
   files and environment settings;
 - commits the release tag and install identity only after migration, health, SHA, and content checks
@@ -58,7 +62,10 @@ The consumer path:
 
 If the Upgrade Center reports that install identity is unverified, re-run the current consumer
 installer once to converge the canonical state; do not create a Git checkout beside the install.
-`self-upgrade.no-target` is safe and non-mutating: it means no newer verified release was available.
+If it reports that update status is unavailable, inspect the technical reason and registry access;
+the page intentionally hides **Upgrade now** and queues nothing until it can prove a candidate.
+A current state also has no upgrade action because the running config digest already equals the
+verified channel candidate. Both states are safe and non-mutating.
 
 ## Preconditions — capture current state first
 

--- a/docs/superpowers/plans/2026-08-24-consumer-registry-self-upgrade.md
+++ b/docs/superpowers/plans/2026-08-24-consumer-registry-self-upgrade.md
@@ -16,14 +16,15 @@ A source-free consumer install detects verification-gated GHCR channel movement,
 
 ## Backlog coverage
 
-- Decision: atomic.
-- Parent: `BI-C3B0B2EA`.
+- Decision: atomic
+- Parent: `BI-C3B0B2EA`
+- Receipt: `blocked-by-BI-B9403248`.
+- Rationale: D1 discovery, D2 immutable acquisition, D3 publication identity, and D4 truthful operator projection must land together; any subset preserves either a byte-identity race or the reported false-current/no-op behavior.
 - D1 registry candidate identity -> BI-C3B0B2EA.
 - D2 resolver/orchestrator convergence -> BI-C3B0B2EA.
 - D3 publication identity -> BI-C3B0B2EA.
 - D4 truthful operator projection and measured verification -> BI-C3B0B2EA.
-- Dependencies: existing release-mode promoter and consumer install-state contracts on `main`.
-- Rationale: discovery without immutable acquisition races; acquisition without publication identity cannot select a tag; runtime behavior without the truthful UI leaves the reported defect; none is independently safe or useful.
+- Dependencies: existing release-mode promoter and consumer install-state contracts on `main`; live receipt issuance is blocked because BI-C3B0B2EA lacks the initiative scope baseline, tracked by BI-B9403248.
 
 | Key | Deliverable | Requirements | Verification | Depends on |
 |---|---|---|---|---|

--- a/docs/superpowers/plans/2026-08-24-consumer-registry-self-upgrade.md
+++ b/docs/superpowers/plans/2026-08-24-consumer-registry-self-upgrade.md
@@ -18,13 +18,13 @@ A source-free consumer install detects verification-gated GHCR channel movement,
 
 - Decision: atomic
 - Parent: `BI-C3B0B2EA`
-- Receipt: `blocked-by-BI-B9403248`
+- Receipt: `blocked-by-BI-F0715C9C`
 - Rationale: D1 discovery, D2 immutable acquisition, D3 publication identity, and D4 truthful operator projection must land together; any subset preserves either a byte-identity race or the reported false-current/no-op behavior.
 - D1 registry candidate identity -> BI-C3B0B2EA.
 - D2 resolver/orchestrator convergence -> BI-C3B0B2EA.
 - D3 publication identity -> BI-C3B0B2EA.
 - D4 truthful operator projection and measured verification -> BI-C3B0B2EA.
-- Dependencies: existing release-mode promoter and consumer install-state contracts on `main`; live receipt issuance is blocked because BI-C3B0B2EA lacks the initiative scope baseline, tracked by BI-B9403248.
+- Dependencies: existing release-mode promoter and consumer install-state contracts on `main`; live receipt issuance is blocked because BI-C3B0B2EA lacks the initiative scope baseline, tracked by BI-F0715C9C acceptance criterion 4.
 
 | Key | Deliverable | Requirements | Verification | Depends on |
 |---|---|---|---|---|

--- a/docs/superpowers/plans/2026-08-24-consumer-registry-self-upgrade.md
+++ b/docs/superpowers/plans/2026-08-24-consumer-registry-self-upgrade.md
@@ -1,0 +1,71 @@
+---
+status: active
+---
+
+# Consumer registry-channel self-upgrade implementation plan
+
+**Backlog item:** BI-C3B0B2EA  
+**Design:** `docs/superpowers/specs/2026-08-24-consumer-registry-self-upgrade-design.md`  
+**Workroom:** WC-5F8A1DA1  
+**Decision:** DI-1483263456A9 (`channel-to-immutable-candidate`, high confidence)  
+**Branch:** `fix/make-consumer-docker-image-self-upgrade-authorit`
+
+## Outcome
+
+A source-free consumer install detects verification-gated GHCR channel movement, freezes it to a byte-verified immutable release candidate, and upgrades through the existing recovery/rollback lifecycle. The Upgrade Center renders one internally consistent status and action state.
+
+## Backlog coverage
+
+- Decision: atomic.
+- Parent: `BI-C3B0B2EA`.
+- D1 registry candidate identity -> BI-C3B0B2EA.
+- D2 resolver/orchestrator convergence -> BI-C3B0B2EA.
+- D3 publication identity -> BI-C3B0B2EA.
+- D4 truthful operator projection and measured verification -> BI-C3B0B2EA.
+- Dependencies: existing release-mode promoter and consumer install-state contracts on `main`.
+- Rationale: discovery without immutable acquisition races; acquisition without publication identity cannot select a tag; runtime behavior without the truthful UI leaves the reported defect; none is independently safe or useful.
+
+| Key | Deliverable | Requirements | Verification | Depends on |
+|---|---|---|---|---|
+| D1 | OCI registry candidate reader and current-byte identity | R1–R8 | V1 focused reader/target tests | — |
+| D2 | Shared action/queue resolver and immutable promoter handoff | R3–R5, R8, R10, R11 | V2 action/queue/promoter tests | D1 |
+| D3 | Correct publication stamping and contract guard | R4, R6 | V3 workflow/Docker contract tests | D1 |
+| D4 | Consistent Upgrade Center states and live evidence | R8, R9, R12 | V4 component/route/UX-fit/pregate | D1, D2 |
+
+## Phase 1 — Red tests and registry identity
+
+1. Add failing pure tests for OCI auth, response/digest validation, multi-arch selection, config labels, immutable-tag equality, bounded failures, and legacy unique/zero/ambiguous tag recovery. **[D1, V1]**
+2. Add failing target tests proving config-digest equality means current even when the configured tag is mutable, while different bytes with a valid immutable candidate mean update available. **[D1, V1]**
+3. Implement the server-only reader with injected fetch, strict host/size/time/page bounds, OCI digest verification, and stable failure reasons. **[D1]**
+4. Refactor release target resolution around a single `RegistryReleaseCandidate` result consumed by page and queue. Remove GitHub release-run discovery from this path without changing release-health ownership. **[D1, D2]**
+
+## Phase 2 — Immutable orchestration and publication
+
+1. Add failing action/queue cases for newer/current/unavailable registry candidates, no Git calls, and exact tag/SHA/digest handoff into preflight and promotion. **[D2, V2]**
+2. Read the current portal container config digest through a narrow injected Docker identity helper. Fail unavailable when byte identity cannot be established; do not silently fall back to tag equality. **[D1, D2]**
+3. Converge page and queue on the same resolver input/output. Preserve the existing candidate promoter digest, quiescence, recovery point, migration, health, asset transaction, and rollback path. **[D2]**
+4. Add failing workflow contract assertions, then stamp the validated gate tag into `DPF_PLATFORM_VERSION` and the OCI version label while retaining `github.sha` as revision. **[D3, V3]**
+5. Retain promoter pre-swap revision checks and immutable release-tag validation. Add only the evidence fields needed to prove the resolved channel candidate is the one promoted. **[D2, D3]**
+
+## Phase 3 — Truthful Upgrade Center and bounded refactor
+
+1. Add failing page/component tests for current, update available, registry unavailable, active, queued, and failed states. Assert current/unavailable states have no “Upgrade now” control and cannot render “Upgrade queued.” **[D4, V4]**
+2. Replace independent summary/button booleans with one closed action-state projection derived from the owner summary. Keep the existing route/card/control and DPF tokens; add no new navigation or visual primitive. **[D4]**
+3. Make registry failures actionable in plain language (“Update availability could not be verified”) while retaining technical reason/run evidence in the existing detail surface. **[D4]**
+4. Refactor roughly one fifth of effort into separating registry I/O from pure candidate classification, centralizing release identity validation, and deleting the duplicate GitHub-target assumptions from action/queue UI paths. Do not broaden into unrelated release-health or promotion work. **[D1–D4]**
+
+## Phase 4 — Verification and handoff
+
+1. Run focused reader, target, action, queue, promoter, workflow-contract, owner-summary, page, and trigger-control suites after each green step. **[V1–V4]**
+2. Run affected web typecheck, doc-index generation, prose/style guards, and `pnpm run pregate:preflight`. **[V4]**
+3. Acquire the governed shared nonproduction lease. Verify `/ops/self-upgrade` in dark/light at desktop/narrow widths using controlled current, available, and unavailable fixtures; capture DOM and screenshots. **[V4]**
+4. Write `docs/ux-fit/2026-08-24-consumer-registry-self-upgrade.ux-fit.json` with `sweep-measurement` evidence for the exact UI files. **[V4]**
+5. Run architecture review, exact-tree merged-code CI, independent semantic review, DCO commit/PR gates, and record Workroom evidence. **[V4]**
+
+## Stop conditions
+
+- If GHCR does not return verifiable OCI manifest/config digests, stop before quiescence and surface unavailable.
+- If more than one immutable release tag maps to a legacy channel digest, stop rather than choose by name/date.
+- If the page and queue do not resolve the same candidate identity, do not ship.
+- If candidate readiness and promotion cannot use the same frozen tag/SHA, return to design; never deploy mutable `latest`.
+- If the shared nonproduction environment cannot be leased, record the blocker and do not claim live UX verification.

--- a/docs/superpowers/plans/2026-08-24-consumer-registry-self-upgrade.md
+++ b/docs/superpowers/plans/2026-08-24-consumer-registry-self-upgrade.md
@@ -18,7 +18,7 @@ A source-free consumer install detects verification-gated GHCR channel movement,
 
 - Decision: atomic
 - Parent: `BI-C3B0B2EA`
-- Receipt: `blocked-by-BI-B9403248`.
+- Receipt: `blocked-by-BI-B9403248`
 - Rationale: D1 discovery, D2 immutable acquisition, D3 publication identity, and D4 truthful operator projection must land together; any subset preserves either a byte-identity race or the reported false-current/no-op behavior.
 - D1 registry candidate identity -> BI-C3B0B2EA.
 - D2 resolver/orchestrator convergence -> BI-C3B0B2EA.

--- a/docs/superpowers/plans/2026-08-24-consumer-registry-self-upgrade.md
+++ b/docs/superpowers/plans/2026-08-24-consumer-registry-self-upgrade.md
@@ -45,7 +45,7 @@ A source-free consumer install detects verification-gated GHCR channel movement,
 2. Read the current portal container config digest through a narrow injected Docker identity helper. Fail unavailable when byte identity cannot be established; do not silently fall back to tag equality. **[D1, D2]**
 3. Converge page and queue on the same resolver input/output. Preserve the existing candidate promoter digest, quiescence, recovery point, migration, health, asset transaction, and rollback path. **[D2]**
 4. Add failing workflow contract assertions, then stamp the validated gate tag into `DPF_PLATFORM_VERSION` and the OCI version label while retaining `github.sha` as revision. **[D3, V3]**
-5. Retain promoter pre-swap revision checks and immutable release-tag validation. Add only the evidence fields needed to prove the resolved channel candidate is the one promoted. **[D2, D3]**
+5. Retain promoter pre-swap revision checks and immutable release-tag validation. Carry the resolved portal config digest into the promoter and reject pulled bytes that differ before asset extraction or swap. **[D2, D3]**
 
 ## Phase 3 — Truthful Upgrade Center and bounded refactor
 

--- a/docs/superpowers/specs/2026-08-24-consumer-registry-self-upgrade-design.md
+++ b/docs/superpowers/specs/2026-08-24-consumer-registry-self-upgrade-design.md
@@ -28,7 +28,14 @@ The 2026-08-22 consumer release-artifact design remains authoritative for instal
 
 No new database model, queue, deploy mechanism, channel selector, or lifecycle branch is introduced.
 
-## Standards and architecture grounding
+## Design grounding
+
+- Existing specs/plans reviewed: `docs/superpowers/specs/2026-08-22-consumer-self-upgrade-design.md`, `docs/superpowers/plans/2026-08-22-consumer-self-upgrade.md`, and the governed-upgrade lifecycle contracts they cite.
+- Current code substrate reviewed: `apps/web/lib/self-upgrade/release-target.ts`, `apps/web/lib/queue/functions/self-upgrade.ts`, `apps/web/lib/actions/promotions.ts`, `scripts/promote.sh`, `.github/workflows/publish-image.yml`, and the `/ops/self-upgrade` page/card/control projection.
+- Source of truth: verification-gated GHCR channel manifest/config bytes for the candidate, Docker container config digest for the running bytes, and canonical install state for topology and immutable rollback identity.
+- Decision: kernel record `DI-1483263456A9` selected `channel-to-immutable-candidate`; the implementation reuses the existing promotion lifecycle and rejects mutable-tag deployment and GitHub release-run discovery authority.
+
+Standards reviewed:
 
 - The [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md) defines a tag as a human-readable pointer to a manifest and a digest as the content identifier. Manifest `GET`/`HEAD` returns `Docker-Content-Digest`; clients using it verify the returned bytes.
 - The [OCI Image annotations contract](https://github.com/opencontainers/image-spec/blob/main/annotations.md) defines `org.opencontainers.image.version` as the packaged software version and `org.opencontainers.image.revision` as the source revision.

--- a/docs/superpowers/specs/2026-08-24-consumer-registry-self-upgrade-design.md
+++ b/docs/superpowers/specs/2026-08-24-consumer-registry-self-upgrade-design.md
@@ -1,0 +1,133 @@
+---
+title: Consumer registry-channel self-upgrade
+status: active
+backlog_item: BI-C3B0B2EA
+decision_interaction: DI-1483263456A9
+supersedes_target_contract_in: docs/superpowers/specs/2026-08-22-consumer-self-upgrade-design.md
+---
+
+# Consumer registry-channel self-upgrade
+
+## Problem
+
+The consumer self-upgrade lifecycle can promote immutable release images, but it discovers them from successful GitHub tag-push workflow runs. The delivery pipeline has a different contract: verification-gated GHCR `latest` is the customer upgrade channel. A successful manual image publication can therefore move `latest` without creating a GitHub Release or tag-push run. Consumer installs then report “up to date” and queue an upgrade that later skips even though newer verified image bytes exist.
+
+Observed on the development consumer install on 2026-08-24:
+
+- the running portal was `v2026.08.23-cycle4.1`, source `d104cd37…`, local image ID `sha256:e62ad4…`;
+- `ghcr.io/opendigitalproductfactory/dpf-portal:latest` resolved to index digest `sha256:a94d98…`, amd64 revision `04f1cfd4…`, after a fully green publish and release-install verification run;
+- `get_self_upgrade_queue_status` still returned `up-to-date: v2026.08.23-cycle4.1` because `resolveReleaseUpgradeCandidate` read `readLatestReleaseStamp` rather than GHCR;
+- `.github/workflows/publish-image.yml` says `latest` is what customer installs self-upgrade against and advances it only after E2E verification;
+- the same workflow stamped `DPF_PLATFORM_VERSION` and `org.opencontainers.image.version` from `github.ref_name`, which is `main` for manual dispatch even though the immutable published tag was `v2026.08.24`.
+
+This is one contract split with two visible symptoms: the resolver consults the wrong authority, and the page offers “Upgrade now” while declaring the install current, then reports “Upgrade queued” for work that deterministically no-ops.
+
+## Prior substrate retained
+
+The 2026-08-22 consumer release-artifact design remains authoritative for install classification, complete installer state, candidate-owned readiness, quiescence, recovery points, migrations, health verification, release-asset installation, rollback, and contributor/source upgrades. This design replaces only its release target contract and tightens the operator projection.
+
+No new database model, queue, deploy mechanism, channel selector, or lifecycle branch is introduced.
+
+## Standards and architecture grounding
+
+- The [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md) defines a tag as a human-readable pointer to a manifest and a digest as the content identifier. Manifest `GET`/`HEAD` returns `Docker-Content-Digest`; clients using it verify the returned bytes.
+- The [OCI Image annotations contract](https://github.com/opencontainers/image-spec/blob/main/annotations.md) defines `org.opencontainers.image.version` as the packaged software version and `org.opencontainers.image.revision` as the source revision.
+- DPF's `image-identity-equals-bytes` kernel principle requires a pre-swap equality proof and forbids trusting a version label without the bytes.
+- Kernel decision `DI-1483263456A9` selected `channel-to-immutable-candidate` with high confidence and autonomy eligible. Direct mutable-`latest` deployment and keeping GitHub Releases authoritative were rejected.
+
+## Objectives and requirements
+
+- **R1 — Correct authority:** consumer/customer discovery reads the configured GHCR channel tag recorded by install state (`latest` for this install), not GitHub release-run history.
+- **R2 — Metadata-only polling:** normal checks fetch manifests and config metadata only; they do not pull image layers or mutate the daemon.
+- **R3 — Frozen candidate:** the channel index digest, platform manifest/config digest, release tag, and source SHA are resolved once and validated before any drain.
+- **R4 — Immutable acquisition:** promotion uses the immutable release tag whose manifest digest equals the channel digest; it never deploys mutable `latest`.
+- **R5 — Byte freshness:** the current container image/config digest is the primary freshness comparison. Source SHA and recorded tag remain corroborating identity, not a substitute for bytes.
+- **R6 — Publication identity:** image builds stamp the workflow's validated immutable tag and source SHA in OCI labels and the in-image platform version.
+- **R7 — Legacy recovery:** an already-published channel image stamped with a non-release version may use a bounded tag-to-digest lookup. It proceeds only when exactly one valid immutable release tag points to the channel digest.
+- **R8 — Fail closed:** missing, malformed, unverifiable, inconsistent, ambiguous, or unreachable registry metadata produces an explicit unavailable/check-failed state before quiescence.
+- **R9 — Truthful action:** “Upgrade now” is available only when a newer immutable candidate is resolved. Current/unavailable states do not render a mutation control or claim that an upgrade was queued.
+- **R10 — Existing safety envelope:** the same candidate promoter digest, quiescence, recovery, migration, health, asset transaction, and rollback evidence remain mandatory.
+- **R11 — No Git regression:** contributor upstream/local discovery remains unchanged; release installs never invoke Git.
+- **R12 — Measured fit:** the exact `/ops/self-upgrade` diff is verified at desktop and narrow widths in light and dark themes with a UX-fit artifact.
+
+## Architecture
+
+### Sources of truth
+
+| Concern | Authority | Projection |
+|---|---|---|
+| Configured update channel | consumer install state `imageTag` and `ghcrOwner` | registry channel reference |
+| Available verified bytes | GHCR channel manifest after the publish workflow's verification gate | immutable candidate |
+| Candidate source/version identity | verified OCI config labels | target SHA and release tag |
+| Current bytes | Docker container `.Image` config digest | freshness comparison |
+| Installed release topology | install state `composeFiles`, path, owner | promoter inputs |
+| Upgrade lifecycle | existing self-upgrade orchestrator/promoter | run and recovery evidence |
+
+GitHub release-health remains the release-observability source for tag-push releases; it is no longer consumer update discovery authority.
+
+### Registry candidate read
+
+A server-only registry reader receives the owner, portal repository, channel tag, and runtime platform. It:
+
+1. requests the channel manifest using OCI/Docker manifest media types and follows the registry's Bearer challenge;
+2. verifies the response body against `Docker-Content-Digest` and parses a bounded manifest/index;
+3. selects exactly one supported runtime-platform manifest and verifies its body/digest;
+4. fetches and verifies the referenced image config blob, then reads version and revision labels;
+5. requires a 40-character source SHA and a valid DPF release tag;
+6. resolves that immutable tag and requires its manifest digest to equal the channel digest;
+7. returns the immutable tag, source SHA, channel/index digest, platform manifest digest, and config digest.
+
+The reader bounds response bytes, redirect/auth hosts, timeouts, tag pages, and legacy concurrency. Registry errors are short stable reasons; response bodies and tokens never reach operator copy.
+
+### Legacy tag recovery
+
+Images published before R6 may have a valid source revision but `version=main`. For that shape only, the reader lists at most 200 tags, filters the existing release-tag grammar, and compares their manifest digests to the already-verified channel digest. One match becomes the immutable candidate. Zero or multiple matches are unavailable; lexical or date guessing is forbidden. Once a correctly stamped image is installed, this branch is not used.
+
+### Freshness and orchestration
+
+`resolveReleaseUpgradeCandidate` accepts the registry candidate plus current container config digest, current source SHA, and installed tag:
+
+- equal config digest -> `up-to-date`;
+- different config digest with valid frozen candidate -> `target`;
+- no verifiable candidate/current digest -> `no-published-target` with a specific registry reason.
+
+The actions page and queue call the same resolver. The queue stores the candidate tag/SHA in the existing run plan, resolves the candidate promoter by immutable digest, and passes the immutable tag to release-mode `promote.sh`. The shell path continues to verify the pulled portal revision before extracting assets or swapping services. Rollback continues to restore the prior recorded tag and recovery state.
+
+### Publication contract
+
+The build job uses `needs.gate.outputs.tag`, not `github.ref_name`, for `DPF_PLATFORM_VERSION` and `org.opencontainers.image.version`; `github.sha` remains the revision. Contract tests lock the relationship between the gate output, build args, labels, immutable merge tag, and verification-gated `latest` promotion.
+
+### UX fit decision
+
+- Decision: fits with guardrails.
+- Owning area: Platform operations; existing `/ops/self-upgrade` route remains canonical.
+- Persona: the DPF operator maintaining a source-free consumer install.
+- Navigation: contextual action only; no navigation or strategy selector is added.
+- Reuse: `OwnerReleaseCard` and `SelfUpgradeTriggerControl` remain; the trigger receives a closed action state derived from the same target result as the summary.
+- Current: show automatic updates enabled and the resolved current version, without an Upgrade button.
+- Update available: show current and target immutable versions plus “Upgrade now”.
+- Checking/unavailable: name that update availability could not be verified and preserve the last run evidence; never say “latest” or show a mutation control without a target.
+- In flight: show the existing progress/disabled state.
+- AI boundary: none.
+
+## Scale ceiling
+
+Normal polling is constant-request metadata work. The compatibility scan is capped at 200 release tags and bounded concurrency; reaching the cap fails unavailable and requires a correctly stamped publication rather than an unbounded registry crawl. No image layer is downloaded until the operator/scheduler has a validated target and candidate readiness begins.
+
+## Verification
+
+- Registry-reader tests cover auth challenge, digest verification, multi-arch selection, correct labels, immutable-tag equality, response limits, malformed inputs, and legacy unique/zero/ambiguous matches.
+- Target tests prove byte-digest current/newer semantics and explicit registry failure reasons.
+- Action and queue tests prove both surfaces consume the same registry target, release mode never invokes Git, and immutable tag/SHA reach preflight/promotion.
+- Workflow contract tests prove validated tag stamping and verification-gated `latest` promotion.
+- UI tests cover current, available, unavailable, queued/in-flight, and failed states; no current state exposes “Upgrade now” or “Upgrade queued.”
+- Promoter functional tests retain pull, revision check, recovery, health, asset transaction, and rollback coverage.
+- Exact-tree gates and governed shared-nonproduction verification exercise the actual route. A real end-to-end consumer self-swap requires two publications: the first containing this resolver and the second presenting newer verified bytes.
+
+## Non-goals
+
+- Deploying mutable `latest` directly.
+- Turning consumer installs into source checkouts or local builders.
+- Replacing the existing self-upgrade lifecycle, recovery model, or release-health screen.
+- Adding operator-managed registry credentials or channel selection in this slice.
+- Mutating the live install outside `/ops/self-upgrade`.

--- a/docs/superpowers/specs/2026-08-24-consumer-registry-self-upgrade-design.md
+++ b/docs/superpowers/specs/2026-08-24-consumer-registry-self-upgrade-design.md
@@ -37,7 +37,7 @@ No new database model, queue, deploy mechanism, channel selector, or lifecycle b
 
 ## Objectives and requirements
 
-- **R1 — Correct authority:** consumer/customer discovery reads the configured GHCR channel tag recorded by install state (`latest` for this install), not GitHub release-run history.
+- **R1 — Correct authority:** consumer/customer discovery reads the configured GHCR channel tag (`DPF_IMAGE_CHANNEL_TAG`, default `latest`), not the installed immutable tag or GitHub release-run history. The discovery channel remains stable when promotion persists a new immutable `imageTag` for rollback identity.
 - **R2 — Metadata-only polling:** normal checks fetch manifests and config metadata only; they do not pull image layers or mutate the daemon.
 - **R3 — Frozen candidate:** the channel index digest, platform manifest/config digest, release tag, and source SHA are resolved once and validated before any drain.
 - **R4 — Immutable acquisition:** promotion uses the immutable release tag whose manifest digest equals the channel digest; it never deploys mutable `latest`.
@@ -77,7 +77,7 @@ A server-only registry reader receives the owner, portal repository, channel tag
 6. resolves that immutable tag and requires its manifest digest to equal the channel digest;
 7. returns the immutable tag, source SHA, channel/index digest, platform manifest digest, and config digest.
 
-The reader bounds response bytes, redirect/auth hosts, timeouts, tag pages, and legacy concurrency. Registry errors are short stable reasons; response bodies and tokens never reach operator copy.
+The reader bounds response bytes, redirect/auth hosts, timeouts, tag pages, and legacy concurrency. GHCR config-blob redirects are followed without forwarding registry authorization and only to GitHub's package-content host; the downloaded bytes must hash to the config digest from the verified platform manifest. Registry errors are short stable reasons; response bodies and tokens never reach operator copy.
 
 ### Legacy tag recovery
 
@@ -85,30 +85,34 @@ Images published before R6 may have a valid source revision but `version=main`. 
 
 ### Freshness and orchestration
 
-`resolveReleaseUpgradeCandidate` accepts the registry candidate plus current container config digest, current source SHA, and installed tag:
+`resolveReleaseUpgradeCandidate` accepts the registry candidate plus the current container config digest:
 
 - equal config digest -> `up-to-date`;
 - different config digest with valid frozen candidate -> `target`;
 - no verifiable candidate/current digest -> `no-published-target` with a specific registry reason.
 
-The actions page and queue call the same resolver. The queue stores the candidate tag/SHA in the existing run plan, resolves the candidate promoter by immutable digest, and passes the immutable tag to release-mode `promote.sh`. The shell path continues to verify the pulled portal revision before extracting assets or swapping services. Rollback continues to restore the prior recorded tag and recovery state.
+The actions page and queue call the same resolver. The queue stores the candidate tag/SHA in the existing run plan, resolves the candidate promoter by immutable digest, and passes the immutable tag plus expected portal config digest to release-mode `promote.sh`. The shell path verifies both the pulled portal bytes and revision before extracting assets or swapping services. Rollback continues to restore the prior recorded tag and recovery state.
 
 ### Publication contract
 
 The build job uses `needs.gate.outputs.tag`, not `github.ref_name`, for `DPF_PLATFORM_VERSION` and `org.opencontainers.image.version`; `github.sha` remains the revision. Contract tests lock the relationship between the gate output, build args, labels, immutable merge tag, and verification-gated `latest` promotion.
 
-### UX fit decision
+### UX fit review — consumer registry self-upgrade
 
-- Decision: fits with guardrails.
+- Decision: fits.
 - Owning area: Platform operations; existing `/ops/self-upgrade` route remains canonical.
 - Persona: the DPF operator maintaining a source-free consumer install.
 - Navigation: contextual action only; no navigation or strategy selector is added.
 - Reuse: `OwnerReleaseCard` and `SelfUpgradeTriggerControl` remain; the trigger receives a closed action state derived from the same target result as the summary.
+- Source truth: the server-only registry candidate resolver plus the running container config digest.
 - Current: show automatic updates enabled and the resolved current version, without an Upgrade button.
 - Update available: show current and target immutable versions plus “Upgrade now”.
 - Checking/unavailable: name that update availability could not be verified and preserve the last run evidence; never say “latest” or show a mutation control without a target.
-- In flight: show the existing progress/disabled state.
+- In flight: show the existing progress state. A failed attempt retains retry only while a newer resolved candidate remains.
 - AI boundary: none.
+- Required plan/spec edits: incorporated registry/current/unavailable state semantics and immutable target copy here and in the implementation plan.
+- Evidence before merge: route/component/summary tests, theme and UX gates, live registry proof, and a governed browser viewport/failure-state exercise.
+- Captured in: this section and `docs/ux-fit/2026-08-24-consumer-registry-self-upgrade.ux-fit.json`.
 
 ## Scale ceiling
 

--- a/docs/user-guide/operations/self-upgrade.md
+++ b/docs/user-guide/operations/self-upgrade.md
@@ -10,19 +10,30 @@ order: 2
 
 ## Overview
 
-Self-upgrade upgrades the platform itself. It builds a fresh application image
-from the approved source and swaps the running install over to it. This is a
-higher-consequence operation than editing backlog work, so it is operator-gated
-and governed by deployment windows.
+Self-upgrade upgrades the platform itself. A source-backed install builds from
+approved source; a consumer install resolves the verification-gated registry
+channel to an immutable release image. Both shapes use the same recovery,
+quiescence, health, and rollback lifecycle. This is a higher-consequence
+operation than editing backlog work, so it is operator-gated and governed by
+deployment windows.
+
+For a consumer install, the page compares the running container's image-config
+digest with the verified platform-specific config digest behind the registry
+channel. A matching digest means the installed bytes are current. A different
+digest exposes the immutable target version and **Upgrade now**. If registry or
+running-image identity cannot be verified, the page reports that update status
+is unavailable and does not offer or queue an upgrade.
 
 ## Workflow
 
-1. Review the pending upgrade and what it will change before triggering anything.
-2. Trigger the upgrade only inside an approved deployment window. Normal changes
+1. Confirm the status card shows a resolved immutable update. If it says current
+   or unavailable, there is no upgrade action to trigger.
+2. Review the pending upgrade and what it will change before triggering anything.
+3. Trigger the upgrade only inside an approved deployment window. Normal changes
    respect the window; only an emergency change may override it.
-3. Watch the deployment status — the page updates automatically while the build
+4. Watch the deployment status — the page updates automatically while the build
    and swap are in progress. A normal upgrade completes in a few minutes.
-4. Confirm the health check passed after the swap, and read the deployment log if
+5. Confirm the health check passed after the swap, and read the deployment log if
    it did not.
 
 You may navigate away after the upgrade has been accepted. Leaving the page stops
@@ -40,9 +51,9 @@ returns to normal.
 
 ## What Happens If You Do Nothing
 
-The install stays on its current version. Queued fixes and improvements are not
-applied until an operator approves and runs the upgrade. Nothing is lost by
-waiting, but the platform does not move forward on its own.
+The install stays on its current version. The consumer channel keeps being
+checked, but newer bytes are not applied until an operator approves and runs the
+upgrade. Nothing is lost by waiting.
 
 ## What Is Reversible
 
@@ -62,6 +73,9 @@ waiting, but the platform does not move forward on its own.
 
 - If an upgrade fails, open the deployment log for the retryable diagnosis, then
   re-run the upgrade.
+- If update status is unavailable, read the technical reason under **Deploy
+  controls & history**. Repair registry access or install identity before
+  retrying; the unavailable state has not queued or mutated anything.
 - Operators on unusually slow hosts can raise the shared build budget by setting
   `DPF_PROMOTER_TIMEOUT_MS` (milliseconds) in the environment.
 - Deployment windows and change-request lifecycle are managed from the wider

--- a/docs/ux-fit/2026-08-24-consumer-registry-self-upgrade.ux-fit.json
+++ b/docs/ux-fit/2026-08-24-consumer-registry-self-upgrade.ux-fit.json
@@ -1,0 +1,26 @@
+{
+  "version": "1",
+  "decidedOption": "channel-to-immutable-candidate",
+  "decisionInteractionId": "DI-1483263456A9",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/ops/self-upgrade/page.tsx",
+      "apps/web/components/ops/SelfUpgradeTriggerControl.tsx",
+      "apps/web/lib/self-upgrade/owner-summary.ts"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "channel-to-immutable-candidate",
+      "deploy-mutable-latest",
+      "github-release-history-authority"
+    ]
+  },
+  "rationale": {
+    "channel-to-immutable-candidate": "CHOSEN. Kernel decision DI-1483263456A9 selected this option with high confidence and a 3.27 margin. The existing Self-Upgrade route remains the canonical home. Registry bytes become the source of availability, the owner sees the immutable target version, and a mutation control is rendered only for a resolved newer candidate.",
+    "deploy-mutable-latest": "REJECTED. It makes the acquisition target move between status, queueing, and promotion, which weakens rollback identity and can install bytes the operator was never shown.",
+    "github-release-history-authority": "REJECTED. It preserves the defect because verification-gated image publications can move the customer channel without creating a matching GitHub release run."
+  },
+  "notes": "Platform > Runtime & Releases > Self-Upgrade remains the owning surface for the DPF operator. OwnerReleaseCard and SelfUpgradeTriggerControl are reused; no new route, navigation layer, card family, or AI action is added. The registry resolver and current Docker config digest own visible availability. Current, newer, unavailable, in-progress, and failed/retry states are explicit, theme-token based, and covered by route/component tests."
+}

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -106,7 +106,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("published-image-freshness", "Published Image Freshness", [
       // Decision logic only — the live registry check needs Docker and runs on a
       // schedule (.github/workflows/published-image-freshness.yml).
-      node("--test", "scripts/lib/published-image-freshness.test.mjs"),
+      node(
+        "--test",
+        "scripts/lib/published-image-freshness.test.mjs",
+        "scripts/publish-image-release-identity.test.mjs",
+      ),
     ]),
     guard("docs-link-integrity", "Docs Link Integrity", [
       node("scripts/gen-doc-index.mjs", "--check"),

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -175,6 +175,7 @@ _release_mode=0
 if [[ "${DPF_PROMOTION_MODE:-source}" == "release" ]]; then
   _release_mode=1
   [[ "${DPF_RELEASE_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9.-]+)?$ ]] || _missing+=(DPF_RELEASE_TAG)
+  [[ "${DPF_RELEASE_CONFIG_DIGEST:-}" =~ ^sha256:[a-f0-9]{64}$ ]] || _missing+=(DPF_RELEASE_CONFIG_DIGEST)
   [[ "${GHCR_OWNER:-}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$ ]] || _missing+=(GHCR_OWNER)
 fi
 
@@ -207,6 +208,11 @@ _candidate_portal=""
 if [[ $_release_mode -eq 1 && $_dry_run -eq 0 ]]; then
   _candidate_portal="ghcr.io/${GHCR_OWNER}/dpf-portal:${DPF_RELEASE_TAG}"
   docker pull "$_candidate_portal" >/dev/null
+  _candidate_config_digest="$(docker image inspect "$_candidate_portal" --format '{{.Id}}' | tr -d '[:space:]')"
+  [[ "$_candidate_config_digest" == "$DPF_RELEASE_CONFIG_DIGEST" ]] || {
+    printf 'error: release portal config digest %s does not match resolved candidate %s\n' "${_candidate_config_digest:-missing}" "$DPF_RELEASE_CONFIG_DIGEST" >&2
+    exit 1
+  }
   _candidate_revision="$(docker image inspect "$_candidate_portal" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' | tr -d '[:space:]')"
   [[ "$_candidate_revision" == "$PROMOTE_TARGET_SHA" ]] || {
     printf 'error: release portal revision %s does not match promote target %s\n' "${_candidate_revision:-missing}" "$PROMOTE_TARGET_SHA" >&2

--- a/scripts/publish-image-release-identity.test.mjs
+++ b/scripts/publish-image-release-identity.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const workflow = readFileSync(".github/workflows/publish-image.yml", "utf8");
+
+function jobBlock(jobName, nextJobName) {
+  const start = workflow.indexOf(`  ${jobName}:`);
+  assert.notEqual(start, -1, `missing workflow job: ${jobName}`);
+
+  const next = workflow.indexOf(`\n  ${nextJobName}:`, start + 1);
+  assert.notEqual(next, -1, `missing workflow job after ${jobName}: ${nextJobName}`);
+  return workflow.slice(start, next);
+}
+
+test("published image identity uses the resolved immutable release tag", () => {
+  const build = jobBlock("build", "merge");
+
+  assert.match(build, /DPF_PLATFORM_VERSION=\$\{\{ needs\.gate\.outputs\.tag \}\}/);
+  assert.match(build, /org\.opencontainers\.image\.version=\$\{\{ needs\.gate\.outputs\.tag \}\}/);
+  assert.doesNotMatch(build, /github\.ref_name/);
+});
+
+test("latest is promoted only from the verified immutable release tag", () => {
+  const promotion = workflow.slice(workflow.indexOf("  promote-latest:"));
+
+  assert.match(promotion, /needs: \[verify, gate\]/);
+  assert.match(promotion, /TAG: \$\{\{ needs\.gate\.outputs\.tag \}\}/);
+  assert.match(promotion, /imagetools create --tag "\$\{IMAGE\}:latest" "\$\{IMAGE\}:\$\{TAG\}"/);
+});


### PR DESCRIPTION
## Summary

- make verification-gated GHCR channel metadata the update authority for source-free consumer installs
- compare the running container config digest with the frozen platform candidate, then pass the immutable tag and expected digest through promotion
- make the Self-Upgrade page expose one truthful current, update-available, or unavailable action state
- stamp manually published images with the validated immutable release tag and document the consumer workflow

## Why

Consumer installs were comparing GitHub release-workflow stamps even though the delivery contract advances verified `ghcr.io/.../dpf-portal:latest`. A manual verified publication could therefore contain newer bytes while Self-Upgrade said the platform was current and queued a deterministic no-op.

## Architecture

The registry reader verifies OCI index, platform manifest, and config bytes; restricts auth and redirect hosts; resolves the channel to exactly one immutable release tag; and fails closed on missing or ambiguous identity. The action, queue, and promoter share that frozen candidate. Contributor/source-backed upgrade discovery is unchanged.

The operator control now derives from a closed domain action state. Current and unavailable states have no mutation button or queued-success copy; only a resolved newer candidate exposes **Upgrade now**.

## Verification

- live GHCR metadata proof resolved a newer immutable tag and distinct running/candidate config digests
- focused registry, target, runtime identity, action, queue, promoter, page, and trigger suites: 195 passing
- follow-up action/queue/UI regression loop: 175 passing
- image publication identity contract: 2 passing
- web typecheck, prose, module-size, docs, UX-fit, and 52/52 pregate preflight guards passing
- exhaustive merged-code local CI: migrations, guards, typecheck, full Vitest, production Docker build, and health probes passing

## Governance

- Backlog: BI-C3B0B2EA
- Architecture decision: DI-1483263456A9 (`channel-to-immutable-candidate`)
- Plan coverage receipt issuance is blocked by the existing initiative-readiness traversal defect BI-F0715C9C; the atomic D1-D4 mapping is recorded in the plan
- independent semantic review was infrastructure-inconclusive while local CI owned host capacity; it reported no issues and allowed shadow publication

Design-Grounding-Decision: Existing consumer self-upgrade specs/plans and the current release-target, queue, promoter, workflow, and `/ops/self-upgrade` code substrate were reviewed; verified registry bytes and the running container config digest are the source of truth.
Docs-Impact-Decision: Updated the Self-Upgrade user guide and consumer runbook for registry-authoritative discovery, immutable acquisition, and closed action states.
Local-CI-Evidence: cmt6x9uu40kec01mxft3qlw6c (fix/make-consumer-docker-image-self-upgrade-authorit@16e212a70c7e7876dc438effc4b2c5feed4e6015)
