### PR TITLE
fix(upgrade): unblock consumer release readiness

### DIFF
--- a/apps/web/lib/self-upgrade/promote-script-contract.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-contract.test.ts
@@ -118,7 +118,12 @@ const CONTRACT_TEST_TIMEOUT_MS = 40_000;
 /** @deprecated alias kept for readiness describe block readability */
 const READINESS_SCRIPT_TIMEOUT_MS = CONTRACT_TEST_TIMEOUT_MS;
 
-function runScript(env: Record<string, string | undefined>, extraArgs: string[] = [], stateOverrides: Record<string, unknown> = {}) {
+function runScript(
+  env: Record<string, string | undefined>,
+  extraArgs: string[] = [],
+  stateOverrides: Record<string, unknown> = {},
+  options: { sourceProfileAdapter?: boolean } = {},
+) {
   const marker = basename(env.PROMOTE_SOURCE ?? "source").replace(/[^A-Za-z0-9-]/g, "-");
   const root = mkdtempSync(join(tmpdir(), `dpf-promote-contract-${marker}-`));
   try {
@@ -126,7 +131,9 @@ function runScript(env: Record<string, string | undefined>, extraArgs: string[] 
     const stateDir = join(root, "state");
     mkdirSync(join(source, "scripts", "lib"), { recursive: true });
     mkdirSync(stateDir, { recursive: true });
-    copyFileSync(join(REPO_ROOT, "scripts", "lib", "resolve-capability-compose-profiles.mjs"), join(source, "scripts", "lib", "resolve-capability-compose-profiles.mjs"));
+    if (options.sourceProfileAdapter !== false) {
+      copyFileSync(join(REPO_ROOT, "scripts", "lib", "resolve-capability-compose-profiles.mjs"), join(source, "scripts", "lib", "resolve-capability-compose-profiles.mjs"));
+    }
     copyFileSync(join(REPO_ROOT, "scripts", "lib", "govern-capability-compose-args.mjs"), join(source, "scripts", "lib", "govern-capability-compose-args.mjs"));
     copyFileSync(join(REPO_ROOT, "scripts", "lib", "capability-state-hash.mjs"), join(source, "scripts", "lib", "capability-state-hash.mjs"));
     copyFileSync(join(REPO_ROOT, "scripts", "capability-service-catalog.generated.json"), join(source, "scripts", "capability-service-catalog.generated.json"));
@@ -166,6 +173,27 @@ function assertChildDidNotTimeOut(result: ReturnType<typeof spawnSync>, label: s
 // — demanding it from the caller wedges every pre-existing install, because the upgrade that
 // teaches the caller to send it IS the blocked upgrade.
 describe.skipIf(!BASH_AVAILABLE)("promote.sh --readiness host identity", () => {
+  it("projects release-artifact capability state from the immutable promoter when the consumer install has no source adapter", () => {
+    const result = runScript(
+      { ...BASE_ENV, DPF_PROMOTION_MODE: "release" },
+      ["--readiness"],
+      { platform: "linux", arch: "amd64" },
+      { sourceProfileAdapter: false },
+    );
+    expect(result.stdout).not.toContain("capability_projection_failed");
+  }, READINESS_SCRIPT_TIMEOUT_MS);
+
+  it("still fails closed when source-backed readiness has no candidate source adapter", () => {
+    const result = runScript(
+      BASE_ENV,
+      ["--readiness"],
+      { platform: "linux", arch: "amd64" },
+      { sourceProfileAdapter: false },
+    );
+    expect(result.stdout).toContain("capability_projection_failed");
+    expect(result.stdout).toContain("candidate source has no profile adapter");
+  }, READINESS_SCRIPT_TIMEOUT_MS);
+
   it("resolves installer-owned identity when the N-1 caller sends no DPF_HOST_* env", () => {
     const result = runScript(BASE_ENV, ["--readiness"], { platform: "linux", arch: "amd64" });
     expect(result.stdout).toContain('"stage":"preflight"');

--- a/apps/web/lib/self-upgrade/promote-script-contract.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-contract.test.ts
@@ -122,7 +122,10 @@ function runScript(
   env: Record<string, string | undefined>,
   extraArgs: string[] = [],
   stateOverrides: Record<string, unknown> = {},
-  options: { sourceProfileAdapter?: boolean } = {},
+  options: {
+    recoveryPathMode?: "canonical-missing-parent" | "outside-recovery-root";
+    sourceProfileAdapter?: boolean;
+  } = {},
 ) {
   const marker = basename(env.PROMOTE_SOURCE ?? "source").replace(/[^A-Za-z0-9-]/g, "-");
   const root = mkdtempSync(join(tmpdir(), `dpf-promote-contract-${marker}-`));
@@ -145,7 +148,20 @@ function runScript(
 
     const mapped = { ...env };
     if (mapped.PROMOTE_SOURCE !== undefined) mapped.PROMOTE_SOURCE = resolveBashPath(source);
-    if (mapped.PROMOTE_BACKUP_PATH !== undefined) mapped.PROMOTE_BACKUP_PATH = resolveBashPath(join(root, basename(mapped.PROMOTE_BACKUP_PATH)));
+    if (mapped.PROMOTE_BACKUP_PATH !== undefined) {
+      if (options.recoveryPathMode) {
+        const recoveryRoot = join(root, "backups");
+        mkdirSync(recoveryRoot, { recursive: true });
+        mapped.DPF_PROMOTER_RECOVERY_ROOT = resolveBashPath(recoveryRoot);
+        mapped.PROMOTE_BACKUP_PATH = resolveBashPath(join(
+          options.recoveryPathMode === "canonical-missing-parent" ? recoveryRoot : root,
+          "self-upgrade",
+          "SUR-contract",
+        ));
+      } else {
+        mapped.PROMOTE_BACKUP_PATH = resolveBashPath(join(root, basename(mapped.PROMOTE_BACKUP_PATH)));
+      }
+    }
     const envSource: Record<string, string | undefined> = { NODE_ENV: process.env.NODE_ENV ?? "test", DPF_PROMOTER_STATE_DIR: resolveBashPath(stateDir), ...mapped };
     const envAssignments = Object.entries(envSource).flatMap(([key, value]) => value === undefined ? [] : [`${key}=${quoteForBash(value)}`]);
     const command = ["env", "-i", 'PATH="$PATH"', ...envAssignments, "bash", quoteForBash(SCRIPT), "--self-upgrade", ...extraArgs.map(quoteForBash)].join(" ");
@@ -192,6 +208,26 @@ describe.skipIf(!BASH_AVAILABLE)("promote.sh --readiness host identity", () => {
     );
     expect(result.stdout).toContain("capability_projection_failed");
     expect(result.stdout).toContain("candidate source has no profile adapter");
+  }, READINESS_SCRIPT_TIMEOUT_MS);
+
+  it("accepts a run-specific recovery path whose canonical mounted root exists", () => {
+    const result = runScript(
+      BASE_ENV,
+      ["--readiness"],
+      { platform: "linux", arch: "amd64" },
+      { recoveryPathMode: "canonical-missing-parent" },
+    );
+    expect(result.stdout).not.toContain("recovery_parent_unavailable");
+  }, READINESS_SCRIPT_TIMEOUT_MS);
+
+  it("still rejects a missing recovery parent outside the canonical mounted root", () => {
+    const result = runScript(
+      BASE_ENV,
+      ["--readiness"],
+      { platform: "linux", arch: "amd64" },
+      { recoveryPathMode: "outside-recovery-root" },
+    );
+    expect(result.stdout).toContain("recovery_parent_unavailable");
   }, READINESS_SCRIPT_TIMEOUT_MS);
 
   it("resolves installer-owned identity when the N-1 caller sends no DPF_HOST_* env", () => {

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -104,6 +104,13 @@ if [[ $_readiness -eq 1 ]]; then
     fi
   fi
   _profile_adapter="${PROMOTE_SOURCE:-}/scripts/lib/resolve-capability-compose-profiles.mjs"
+  if [[ "${DPF_PROMOTION_MODE:-source}" == "release" ]]; then
+    # A consumer install contains verified release assets, not a source tree.
+    # The candidate promoter is itself an immutable release artifact and its
+    # contract requires this adapter, so release readiness must project from
+    # that packaged closure instead of reaching through /host-source.
+    _profile_adapter="$_promoter_dir/lib/resolve-capability-compose-profiles.mjs"
+  fi
   if [[ ! -f "$_profile_adapter" ]]; then
     _readiness_fail capability_projection_failed "candidate source has no profile adapter at $_profile_adapter"
   elif ! _profile_error="$(node "$_profile_adapter" --state "$_state_file" --overlay promote --migrate 2>&1 >/dev/null)"; then

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -154,7 +154,20 @@ if [[ $_readiness -eq 1 ]]; then
     _readiness_fail host_identity_missing "${_host_identity_error:-the shipped resolver produced no host identity}"
   fi
   [[ -n "${PROMOTE_COMPOSE_PROJECT:-}" ]] || _readiness_fail compose_identity_missing "PROMOTE_COMPOSE_PROJECT is unset"
-  [[ -n "${PROMOTE_BACKUP_PATH:-}" && -d "$(dirname "${PROMOTE_BACKUP_PATH:-/missing}")" ]] || _readiness_fail recovery_parent_unavailable "no writable parent for PROMOTE_BACKUP_PATH=${PROMOTE_BACKUP_PATH:-<unset>}"
+  _recovery_path="${PROMOTE_BACKUP_PATH:-}"
+  _recovery_parent="$(dirname "${_recovery_path:-/missing}")"
+  _recovery_root="${DPF_PROMOTER_RECOVERY_ROOT:-/backups}"
+  _recovery_available=0
+  if [[ -n "$_recovery_path" && -d "$_recovery_parent" ]]; then
+    _recovery_available=1
+  elif [[ -n "$_recovery_path" && -d "$_recovery_root" && "$_recovery_path" == "${_recovery_root%/}/"* ]]; then
+    # Readiness is deliberately non-mutating and mounts recovery storage read
+    # only. The mutating run creates its self-upgrade/<run> subdirectories; the
+    # preflight proves the governed mount root exists and the target stays below
+    # it instead of requiring those future directories to pre-exist.
+    _recovery_available=1
+  fi
+  [[ $_recovery_available -eq 1 ]] || _readiness_fail recovery_parent_unavailable "no writable parent for PROMOTE_BACKUP_PATH=${PROMOTE_BACKUP_PATH:-<unset>}"
   [[ -d "$_state_dir" ]] || _readiness_fail transition_secret_parent_unavailable "state dir $_state_dir is not a directory"
   if [[ ${#_readiness_failures[@]} -gt 0 ]]; then
     _failures_json="$(


### PR DESCRIPTION
## Summary
- resolve release-artifact capability projection from the immutable promoter closure instead of `/host-source`
- accept future run-specific recovery directories only beneath an existing governed recovery mount root
- preserve source-backed adapter checks and reject missing recovery parents outside the governed root

## Verification
- TDD red reproduced both pre-quiescence failures from `SUR-F8885052`
- `pnpm --filter web exec vitest run lib/self-upgrade/promote-script-contract.test.ts lib/self-upgrade/promote-script-functional.test.ts` — 52/52 passed
- `pnpm run pregate:preflight` — 52/52 guards passed
- exact-tree local CI PASS — `cmt7770ag0nsh01mxndzr0dji` on `7202ad319e5b6545e74dead16eada6da31018a3c`
- semantic review `cmt76fqfr0nka01mxo6itwbby` — zero findings, infrastructure-inconclusive/unparseable response, policy `mayPublish=true` in shadow mode

## Governance
- Workroom: `WC-B6AC0CF8`
- Backlog item: `BI-5AA89F68`
- Docs-Impact-Decision: Internal readiness preflight authority changed; operator workflow and user-facing self-upgrade steps are unchanged.