### PR TITLE
fix(upgrade): carry release identity into readiness

### DIFF
--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -500,12 +500,16 @@ export async function runSelfUpgrade(
   });
   if (!signingContext.ok) return { ok: false, status: "failed", runId: run.runId, reason: "installer-state-repair-required", excerpt: signingContext.reason };
   const { runtimeTransitionSecret, hostIdentity } = signingContext;
+  const release = releaseTag && releaseConfigDigest && releaseInstall
+    ? { tag: releaseTag, ghcrOwner: releaseInstall.ghcrOwner, configDigest: releaseConfigDigest }
+    : undefined;
   const preflight = await runCandidatePreflight({
     dryRun: params.dryRun, readinessMode: config.readinessMode, readinessOwner: config.readinessOwner,
     promoterImage: config.promoterImage, callerProtocolVersion: config.callerProtocolVersion,
-    candidatePromoterReference: releaseTag && releaseInstall
-      ? `ghcr.io/${releaseInstall.ghcrOwner}/dpf-promoter:${releaseTag}`
+    candidatePromoterReference: release
+      ? `ghcr.io/${release.ghcrOwner}/dpf-promoter:${release.tag}`
       : undefined,
+    release,
     sourcePath: upgradeWorkspaceMountPath ?? hostSourcePath,
     hostInstallPath: upgradeWorkspaceHostPath ?? hostInstallPathResolved,
     canonicalInstallPath: hostInstallPathResolved, targetSha: builtStamp, baselineSha: deployedSha,
@@ -650,13 +654,7 @@ export async function runSelfUpgrade(
       composeProject,
       healthUrl: config.healthUrl ?? process.env.PROMOTE_HEALTH_URL ?? "",
       promoterImage: resolvedPromoterDigest ?? config.promoterImage,
-      release: releaseTag && releaseConfigDigest && releaseInstall
-        ? {
-            tag: releaseTag,
-            ghcrOwner: releaseInstall.ghcrOwner,
-            configDigest: releaseConfigDigest,
-          }
-        : undefined,
+      release,
       stateDirHostPath: process.env.DPF_STATE_DIR_HOST,
       installStateMigrationEnvelope: migrationHandoff ? Buffer.from(JSON.stringify(migrationHandoff.envelope)).toString("base64url") : undefined,
       installStateMigrationSignature: migrationHandoff?.signature,

--- a/apps/web/lib/self-upgrade/preflight.test.ts
+++ b/apps/web/lib/self-upgrade/preflight.test.ts
@@ -5,12 +5,20 @@ import { resolveReadinessBackupHostPath, runCandidatePreflight } from "./preflig
 describe("candidate signed install-state handoff", () => {
   it("resolves a published release promoter without attempting a source build", async () => {
     const secret = "s".repeat(32);
+    const release = {
+      tag: "v2026.08.24-consumer-self-upgrade.4",
+      ghcrOwner: "owner",
+      configDigest: `sha256:${"c".repeat(64)}`,
+    };
     const artifact = { digest: `sha256:${"d".repeat(64)}`, contractSchema: 1, contractDigest: "c".repeat(64) } as never;
     const runtime = { buildCandidatePromoterImage: vi.fn(), resolvePromoterArtifact: vi.fn(async () => artifact), runPromoterReadiness: vi.fn(async () => ({ exitCode: 0, stdout: JSON.stringify({ sourceHash: "a".repeat(64), projectionHash: "b".repeat(64), fromSchemaVersion: 2, toSchemaVersion: 2 }), stderr: "" })) };
-    const result = await runCandidatePreflight({ candidatePromoterReference: "ghcr.io/owner/dpf-promoter:v2.0.0", sourcePath: "/source-free-install", hostInstallPath: "/host", canonicalInstallPath: "/host", targetSha: "b".repeat(40), runId: "SUR-release", composeFiles: [], healthUrl: "http://health", hostIdentity: { platform: "linux", arch: "amd64", provenance: "install-state" }, runtimeTransitionSecret: secret, runtime: async () => runtime as never, recordReadiness: vi.fn(), failRun: vi.fn(), emitFailure: vi.fn() });
+    const result = await runCandidatePreflight({ candidatePromoterReference: "ghcr.io/owner/dpf-promoter:v2.0.0", release, sourcePath: "/source-free-install", hostInstallPath: "/host", canonicalInstallPath: "/host", targetSha: "b".repeat(40), runId: "SUR-release", composeFiles: [], healthUrl: "http://health", hostIdentity: { platform: "linux", arch: "amd64", provenance: "install-state" }, runtimeTransitionSecret: secret, runtime: async () => runtime as never, recordReadiness: vi.fn(), failRun: vi.fn(), emitFailure: vi.fn() });
     expect(result.ok).toBe(true);
     expect(runtime.buildCandidatePromoterImage).not.toHaveBeenCalled();
     expect(runtime.resolvePromoterArtifact).toHaveBeenCalledWith(expect.objectContaining({ promoterImage: "ghcr.io/owner/dpf-promoter:v2.0.0", candidateReference: "ghcr.io/owner/dpf-promoter:v2.0.0", targetSha: "b".repeat(40) }));
+    expect(runtime.runPromoterReadiness).toHaveBeenCalledWith(
+      expect.objectContaining({ release }),
+    );
   });
 
   it("returns a digest-bound signed envelope from candidate readiness", async () => {

--- a/apps/web/lib/self-upgrade/preflight.ts
+++ b/apps/web/lib/self-upgrade/preflight.ts
@@ -15,6 +15,7 @@ type PromoterRuntime = Pick<
 type RecordReadiness = typeof import("./run-store").recordPromoterReadiness;
 type FailRun = typeof import("./run-store").failRun;
 type ReadinessFailure = { code: string; message: string; remediation?: string };
+type ReleaseIdentity = { tag: string; ghcrOwner: string; configDigest: string };
 
 export type CandidatePreflightResult =
   | { ok: true; resolvedPromoterDigest?: string; migrationHandoff?: InstallStateMigrationHandoff }
@@ -45,6 +46,8 @@ export async function runCandidatePreflight(params: {
   promoterImage?: string;
   /** Published immutable release promoter; bypasses source compilation. */
   candidatePromoterReference?: string;
+  /** Verified release identity carried into candidate readiness. */
+  release?: ReleaseIdentity;
   callerProtocolVersion?: number;
   sourcePath: string;
   hostInstallPath: string;
@@ -105,6 +108,7 @@ export async function runCandidatePreflight(params: {
       containerName: `dpf-promoter-readiness-${params.runId}`,
       artifact,
       hostIdentity: params.hostIdentity,
+      release: params.release,
     });
     let failures: ReadinessFailure[] = [];
     let report: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary
- carry the verified immutable release identity into candidate promoter readiness
- reuse the same release object for readiness and final promotion so N-1 consumers cannot diverge
- preserve source-mode fail-closed behavior and cover the published-release handoff

## Evidence
- semantic review: PASS (WC-91A48AED; tree 5e49d38ae2269d98f184ef0af0ff4165cf54907e)
- focused self-upgrade matrix: 145/145 PASS
- web typecheck: PASS
- pregate preflight: 52/52 PASS
- exact-tree local CI: PASS, evidence cmt79t5sn0oi101mxb9l10xb4
- live reproduction: SUR-F4D2BF8A resolved the immutable promoter but the deployed N-1 caller omitted release identity from readiness

## Contract
No manual deployment, Compose edit, source mount, database mutation, or installer bypass. The governed self-upgrade path remains fail-closed.