### PR TITLE
fix(self-upgrade): bootstrap legacy release callers

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -200,6 +200,9 @@ jobs:
           build-args: |
             DPF_VERSION=${{ github.sha }}
             DPF_PLATFORM_VERSION=${{ needs.gate.outputs.tag }}
+            DPF_PROMOTER_SOURCE_SHA=${{ github.sha }}
+            DPF_PROMOTER_RELEASE_TAG=${{ needs.gate.outputs.tag }}
+            DPF_PROMOTER_RELEASE_OWNER=${{ steps.owner.outputs.value }}
             DPF_PROMOTER_CONTRACT_DIGEST=sha256:${{ steps.promoter-contract.outputs.digest }}
           # Same identity, in the OCI-standard place. /app/.dpf-image-version is inside
           # the filesystem, so reading it costs a `docker create` + `docker cp`; a label

--- a/Dockerfile.promoter
+++ b/Dockerfile.promoter
@@ -1,6 +1,11 @@
 FROM node:24-alpine
 ARG DPF_PROMOTER_SOURCE_SHA=unknown
+ARG DPF_PROMOTER_RELEASE_TAG=unknown
+ARG DPF_PROMOTER_RELEASE_OWNER=unknown
 ARG DPF_PROMOTER_CONTRACT_DIGEST=unknown
+ENV DPF_CANDIDATE_SOURCE_SHA="${DPF_PROMOTER_SOURCE_SHA}" \
+    DPF_CANDIDATE_RELEASE_TAG="${DPF_PROMOTER_RELEASE_TAG}" \
+    DPF_CANDIDATE_RELEASE_OWNER="${DPF_PROMOTER_RELEASE_OWNER}"
 LABEL org.opencontainers.image.title="DPF Promoter"
 LABEL org.opencontainers.image.description="One-shot container that executes sandbox-to-production promotions"
 LABEL org.opencontainers.image.revision="${DPF_PROMOTER_SOURCE_SHA}"

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -91,7 +91,8 @@ done
 [ -n "$DOCKER_LOG" ] && printf '%s\\n' "$*" >> "$DOCKER_LOG"
 case "$*" in
   *".Id"*) printf "%s" "$DPF_TEST_RELEASE_CONFIG_DIGEST" ;;
-  "image inspect "*) printf "%s" "$DPF_TEST_RELEASE_SHA" ;;
+  *"org.opencontainers.image.version"*) printf "%s" "$DPF_TEST_RELEASE_TAG" ;;
+  *"org.opencontainers.image.revision"*) printf "%s" "$DPF_TEST_RELEASE_SHA" ;;
   "create "*) printf "candidate-container" ;;
   "cp candidate-container:/dpf-release-assets/. "*)
     for destination in "$@"; do :; done
@@ -221,6 +222,7 @@ function runPromote(opts: {
         : ["unset DPF_RELEASE_CONFIG_DIGEST"]),
       `export GHCR_OWNER=${shellQuote(opts.release.owner)}`,
       `export DPF_TEST_RELEASE_SHA=${shellQuote(opts.targetSha)}`,
+      `export DPF_TEST_RELEASE_TAG=${shellQuote(opts.release.tag)}`,
       `export DPF_TEST_RELEASE_CONFIG_DIGEST=${shellQuote(opts.release.configDigest ?? `sha256:${"c".repeat(64)}`)}`,
       `export DPF_TEST_RELEASE_ASSETS=${shellQuote(toBashPath(opts.release.candidateAssets))}`,
       `export GIT_LOG=${shellQuote(toBashPath(opts.release.gitLog))}`,

--- a/apps/web/lib/self-upgrade/promote-script-legacy-bootstrap.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-legacy-bootstrap.test.ts
@@ -210,7 +210,16 @@ function runCandidate(fixture: Fixture, options: {
       `export DPF_PROMOTER_CONTRACT=${quote(bashPath(contract))}`,
     ] : []),
   ];
-  return spawnSync(BASH, ["-lc", `${exports.join("\n")}\nexec bash ${quote(bashPath(SCRIPT))} ${options.readiness ? "--readiness" : "--self-upgrade"}`], { encoding: "utf8" });
+  // Dockerfile.promoter normalizes the packaged entrypoint to 0755. Reproduce
+  // that image invariant for the duration of the real-script fixture, then
+  // restore the checkout mode so the test never leaves the worktree dirty.
+  const originalMode = statSync(SCRIPT).mode;
+  chmodSync(SCRIPT, originalMode | 0o111);
+  try {
+    return spawnSync(BASH, ["-lc", `${exports.join("\n")}\nexec bash ${quote(bashPath(SCRIPT))} ${options.readiness ? "--readiness" : "--self-upgrade"}`], { encoding: "utf8" });
+  } finally {
+    chmodSync(SCRIPT, originalMode);
+  }
 }
 
 describe.skipIf(!BASH_OK)("promote.sh candidate-owned legacy bootstrap", () => {

--- a/apps/web/lib/self-upgrade/promote-script-legacy-bootstrap.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-legacy-bootstrap.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(__dirname, "../../../..");
+const SCRIPT = join(REPO_ROOT, "scripts", "promote.sh");
+const MIGRATOR = join(REPO_ROOT, "scripts", "installer", "migrate-install-state.mjs");
+const CATALOG = join(REPO_ROOT, "scripts", "capability-service-catalog.generated.json");
+const gitBash = join(process.env.ProgramFiles ?? "C:\\Program Files", "Git", "bin", "bash.exe");
+const BASH = process.platform === "win32" && existsSync(gitBash) ? gitBash : "bash";
+const BASH_OK = spawnSync(BASH, ["--version"]).status === 0;
+const TARGET_SHA = "b".repeat(40);
+const RELEASE_TAG = "v2.0.0";
+const OWNER = "opendigitalproductfactory";
+const TEST_TIMEOUT_MS = 30_000;
+
+let bashDrivePrefix: string | undefined;
+function bashPath(value: string): string {
+  if (process.platform !== "win32") return value;
+  const normalized = value.replaceAll("\\", "/");
+  const drive = /^([A-Za-z]):\/(.*)$/.exec(normalized);
+  if (!drive) return normalized;
+  if (bashDrivePrefix === undefined) {
+    const cwdDrive = /^([A-Za-z]):/.exec(process.cwd())?.[1]?.toLowerCase();
+    const pwd = spawnSync(BASH, ["-lc", "pwd"], { encoding: "utf8" }).stdout.trim();
+    bashDrivePrefix = cwdDrive && pwd.startsWith(`/mnt/${cwdDrive}/`) ? "/mnt" : "";
+  }
+  return `${bashDrivePrefix}/${drive[1].toLowerCase()}/${drive[2]}`;
+}
+
+function quote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+type Fixture = {
+  root: string;
+  source: string;
+  backup: string;
+  fakeBin: string;
+  candidateAssets: string;
+  dockerLog: string;
+  gitLog: string;
+  statePath: string;
+};
+
+function writeFakeTools(root: string): string {
+  const bin = join(root, "bin");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(join(bin, "docker"), `#!/bin/sh
+[ -n "\${DOCKER_LOG:-}" ] && printf '%s\\n' "$*" >> "$DOCKER_LOG"
+case "$*" in
+  *".Id"*) printf "%s" "$DPF_TEST_RELEASE_CONFIG_DIGEST" ;;
+  *"org.opencontainers.image.version"*) printf "%s" "$DPF_TEST_RELEASE_TAG" ;;
+  *"org.opencontainers.image.revision"*) printf "%s" "$DPF_TEST_RELEASE_SHA" ;;
+  "create "*) printf "candidate-container" ;;
+  "cp candidate-container:/dpf-release-assets/. "*)
+    for destination in "$@"; do :; done
+    cp -R "$DPF_TEST_RELEASE_ASSETS"/. "$destination"
+    ;;
+  *"recover-human-principal-backfill-migration.mjs --verify-rolled-back"*) printf "verified" ;;
+  *"recover-human-principal-backfill-migration.mjs"*) printf "not-needed" ;;
+  *"recover-inventory-snapshot-migration.mjs --verify-rolled-back"*) printf "verified" ;;
+  *"recover-inventory-snapshot-migration.mjs"*) printf "not-needed" ;;
+  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;
+esac
+exit 0
+`);
+  writeFileSync(join(bin, "curl"), '#!/bin/sh\nfor a in "$@"; do url="$a"; done\ncase "$url" in */sha) printf "%s" "$DPF_VERSION" ;; *) printf "ok" ;; esac\n');
+  writeFileSync(join(bin, "jq"), `#!/bin/sh
+if [ "\${1:-}" = "-r" ]; then
+  node -e 'const fs=require("node:fs");const v=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));for(const f of v.requiredFiles??[])console.log(f)' "$3"
+else
+  node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const v=JSON.parse(s);process.stdout.write(JSON.stringify({...v,stage:"preflight",result:"ready",quiescenceBegan:false,failures:[]}))})'
+fi
+`);
+  writeFileSync(join(bin, "git"), '#!/bin/sh\nprintf "git invoked: %s\\n" "$*" >> "$GIT_LOG"\nexit 97\n');
+  for (const name of ["docker", "curl", "jq", "git"]) chmodSync(join(bin, name), 0o755);
+  return bin;
+}
+
+function makeFixture(): Fixture {
+  const root = mkdtempSync(join(realpathSync(tmpdir()), "dpf-legacy-bootstrap-"));
+  const source = join(root, "source-free-install");
+  const backup = join(root, "backup");
+  const stateDir = join(backup, "state");
+  const candidateAssets = join(root, "candidate-assets");
+  mkdirSync(join(source, "scripts", "lib"), { recursive: true });
+  mkdirSync(stateDir, { recursive: true });
+  mkdirSync(candidateAssets, { recursive: true });
+  writeFileSync(join(source, "docker-compose.yml"), "services: {}\n");
+  writeFileSync(join(source, "docker-compose.release.yml"), "services: {}\n");
+  writeFileSync(join(source, ".install-mode"), "consumer\n");
+  writeFileSync(join(source, ".env"), `KEEP_ME=yes\nDPF_IMAGE_TAG=v1.0.0\nGHCR_OWNER=${OWNER}\n`);
+  for (const relativePath of [
+    "scripts/lib/resolve-capability-compose-profiles.mjs",
+    "scripts/lib/govern-capability-compose-args.mjs",
+    "scripts/lib/capability-state-hash.mjs",
+    "scripts/capability-service-catalog.generated.json",
+  ]) {
+    const destination = join(source, relativePath);
+    mkdirSync(resolve(destination, ".."), { recursive: true });
+    copyFileSync(join(REPO_ROOT, relativePath), destination);
+  }
+  for (const relativePath of [
+    "docker-compose.yml",
+    "docker-compose.release.yml",
+    "scripts/lib/resolve-capability-compose-profiles.mjs",
+    "scripts/lib/govern-capability-compose-args.mjs",
+    "scripts/lib/capability-state-hash.mjs",
+    "scripts/capability-service-catalog.generated.json",
+  ]) {
+    const destination = join(candidateAssets, relativePath);
+    mkdirSync(resolve(destination, ".."), { recursive: true });
+    copyFileSync(join(source, relativePath), destination);
+  }
+  const assetFiles = readdirSync(candidateAssets, { recursive: true }).map(String)
+    .filter(path => statSync(join(candidateAssets, path)).isFile()).sort();
+  writeFileSync(join(candidateAssets, "SHA256SUMS"), assetFiles.map(path =>
+    `${createHash("sha256").update(readFileSync(join(candidateAssets, path))).digest("hex")}  ./${path.replaceAll("\\", "/")}`,
+  ).join("\n") + "\n");
+  for (const relativePath of ["docker-compose.yml", "docker-compose.release.yml"]) {
+    const digest = createHash("sha256").update(readFileSync(join(source, relativePath))).digest("hex");
+    writeFileSync(join(source, ".verified-release-assets.sha256"), `${digest}  ./${relativePath}\n`, { flag: "a" });
+  }
+  writeFileSync(join(source, ".verified-release-assets-version"), "v1.0.0");
+
+  const statePath = join(stateDir, "install-state.json");
+  writeFileSync(statePath, JSON.stringify({
+    schemaVersion: 1,
+    installerVersion: "functional",
+    platform: "linux",
+    arch: "amd64",
+    installPath: source,
+    stateDir: "/dpf-state",
+    composeProjectName: "dpf",
+  }));
+  execFileSync(process.execPath, [MIGRATOR, "--state", statePath, "--catalog", CATALOG,
+    "--host-platform", "linux", "--host-arch", "amd64", "--write"]);
+  const existing = JSON.parse(readFileSync(statePath, "utf8"));
+  writeFileSync(statePath, JSON.stringify({
+    ...existing,
+    schemaVersion: 2,
+    installerVersion: "v1.0.0",
+    lastSuccessfulInstallVersion: "v1.0.0",
+    installPath: source,
+    installMode: "consumer",
+    composeFiles: ["docker-compose.yml", "docker-compose.release.yml"],
+    imageTag: "v1.0.0",
+  }) + "\n");
+  writeFileSync(join(stateDir, "runtime-transition.secret"), "s".repeat(32));
+  return {
+    root,
+    source,
+    backup,
+    candidateAssets,
+    statePath,
+    fakeBin: writeFakeTools(root),
+    dockerLog: join(root, "docker.log"),
+    gitLog: join(root, "git.log"),
+  };
+}
+
+function runCandidate(fixture: Fixture, options: {
+  readiness?: boolean;
+  candidateSha?: string;
+  pulledPortalTag?: string;
+} = {}) {
+  const stateDir = join(fixture.backup, "state");
+  const contract = join(stateDir, "promoter-contract.test.json");
+  writeFileSync(contract, JSON.stringify({ requiredFiles: [] }));
+  const exports = [
+    "unset DPF_STATE_DIR DPF_PROMOTION_MODE DPF_RELEASE_TAG DPF_RELEASE_CONFIG_DIGEST GHCR_OWNER",
+    `export PATH=${quote(bashPath(fixture.fakeBin))}:"$PATH"`,
+    `export PROMOTE_SOURCE=${quote(bashPath(fixture.source))}`,
+    `export PROMOTE_TARGET_SHA=${TARGET_SHA}`,
+    `export PROMOTE_BACKUP_PATH=${quote(bashPath(fixture.backup))}`,
+    `export DPF_PROMOTER_STATE_DIR=${quote(bashPath(stateDir))}`,
+    `export DPF_RUNTIME_TRANSITION_SECRET_FILE=${quote(bashPath(join(stateDir, "runtime-transition.secret")))}`,
+    "export DPF_SELF_UPGRADE_RUN_ID=SUR-LEGACY-BOOTSTRAP",
+    `export DPF_PROMOTER_DIGEST=sha256:${"d".repeat(64)}`,
+    "export PROMOTE_HEALTH_URL=http://127.0.0.1:9/api/health",
+    "export PROMOTE_COMPOSE_PROJECT=dpf-legacy-bootstrap",
+    "export PROMOTE_COMPOSE_FILES='docker-compose.yml docker-compose.release.yml'",
+    `export DPF_CANDIDATE_SOURCE_SHA=${options.candidateSha ?? TARGET_SHA}`,
+    `export DPF_CANDIDATE_RELEASE_TAG=${RELEASE_TAG}`,
+    `export DPF_CANDIDATE_RELEASE_OWNER=${OWNER}`,
+    `export DPF_TEST_RELEASE_SHA=${TARGET_SHA}`,
+    `export DPF_TEST_RELEASE_TAG=${options.pulledPortalTag ?? RELEASE_TAG}`,
+    `export DPF_TEST_RELEASE_CONFIG_DIGEST=sha256:${"c".repeat(64)}`,
+    `export DPF_TEST_RELEASE_ASSETS=${quote(bashPath(fixture.candidateAssets))}`,
+    `export DOCKER_LOG=${quote(bashPath(fixture.dockerLog))}`,
+    `export GIT_LOG=${quote(bashPath(fixture.gitLog))}`,
+    ...(options.readiness ? [
+      "export DPF_PROMOTER_DOCKER_PREFLIGHT=ready",
+      `export DPF_PROMOTER_CONTRACT=${quote(bashPath(contract))}`,
+    ] : []),
+  ];
+  return spawnSync(BASH, ["-lc", `${exports.join("\n")}\nexec bash ${quote(bashPath(SCRIPT))} ${options.readiness ? "--readiness" : "--self-upgrade"}`], { encoding: "utf8" });
+}
+
+describe.skipIf(!BASH_OK)("promote.sh candidate-owned legacy bootstrap", () => {
+  it("returns ready with the packaged adapter for a validated consumer install", () => {
+    const fixture = makeFixture();
+    try {
+      rmSync(join(fixture.source, "scripts", "lib", "resolve-capability-compose-profiles.mjs"));
+      const result = runCandidate(fixture, { readiness: true });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain('"result":"ready"');
+      expect(result.stdout).not.toContain("capability_projection_failed");
+      expect(result.stdout).not.toContain("/host-source/scripts/lib/resolve-capability-compose-profiles.mjs");
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }, TEST_TIMEOUT_MS);
+
+  it("promotes without Git and records the candidate release identity", () => {
+    const fixture = makeFixture();
+    try {
+      const result = runCandidate(fixture);
+      expect(result.status, result.stderr).toBe(0);
+      expect(existsSync(fixture.gitLog)).toBe(false);
+      expect(result.stdout).toContain(`step=done target=${TARGET_SHA}`);
+      expect(result.stdout).toContain("step=release-identity mode=legacy-bootstrap");
+      expect(JSON.parse(readFileSync(fixture.statePath, "utf8")).imageTag).toBe(RELEASE_TAG);
+      expect(readFileSync(join(fixture.source, ".env"), "utf8")).toMatch(/^DPF_IMAGE_TAG=v2\.0\.0$/m);
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }, TEST_TIMEOUT_MS);
+
+  it("rejects candidate source identity that differs from the promotion target", () => {
+    const fixture = makeFixture();
+    try {
+      const result = runCandidate(fixture, { candidateSha: "a".repeat(40) });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("candidate release source");
+      expect(result.stderr).toContain("does not match promote target");
+      expect(existsSync(fixture.gitLog)).toBe(false);
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }, TEST_TIMEOUT_MS);
+
+  it("rejects a pulled portal whose version label differs from the candidate tag", () => {
+    const fixture = makeFixture();
+    try {
+      const result = runCandidate(fixture, { pulledPortalTag: "v2.0.0-repacked" });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("release portal version v2.0.0-repacked does not match release tag v2.0.0");
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  }, TEST_TIMEOUT_MS);
+});

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -17,6 +17,59 @@ _dry_run=0
 _readiness=0
 _promoter_dir="${DPF_PROMOTER_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 
+# A registry release promoter is selected by immutable digest before this
+# script starts. Portals released before the release-mode carrier existed can
+# launch that exact candidate but cannot pass DPF_PROMOTION_MODE or its release
+# identity. Recover only that one N-1 edge: a schema-valid source-free install
+# may consume identity baked into the candidate image. Explicit source callers
+# and source installs never enter this path.
+_candidate_release_error=""
+_resolve_candidate_release_bootstrap() {
+  _candidate_release_error=""
+
+  if [[ -n "${DPF_PROMOTION_MODE:-}" ]]; then
+    if [[ "$DPF_PROMOTION_MODE" != "source" && "$DPF_PROMOTION_MODE" != "release" ]]; then
+      _candidate_release_error="unsupported DPF_PROMOTION_MODE=$DPF_PROMOTION_MODE"
+      return 1
+    fi
+    return 0
+  fi
+
+  local _candidate_state="${DPF_PROMOTER_STATE_DIR:-/dpf-state}/install-state.json"
+  local _install_mode=""
+  [[ -r "$_candidate_state" ]] || return 0
+  _install_mode="$(node -e 'const state=JSON.parse(require("node:fs").readFileSync(process.argv[1],"utf8").replace(/^\uFEFF/,"")); process.stdout.write(typeof state.installMode==="string"?state.installMode:"")' "$_candidate_state" 2>/dev/null || true)"
+  [[ "$_install_mode" == "consumer" || "$_install_mode" == "customer" ]] || return 0
+
+  local _candidate_validator="$_promoter_dir/installer/validate-install-state.mjs"
+  local _candidate_state_error=""
+  if [[ ! -f "$_candidate_validator" ]] ||
+     ! _candidate_state_error="$(node "$_candidate_validator" "$_candidate_state" 2>&1 >/dev/null)"; then
+    _candidate_release_error="candidate release bootstrap requires valid install-state${_candidate_state_error:+: $_candidate_state_error}"
+    return 1
+  fi
+
+  if [[ ! "${DPF_CANDIDATE_RELEASE_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9.-]+)?$ ]] ||
+     [[ ! "${DPF_CANDIDATE_RELEASE_OWNER:-}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$ ]] ||
+     [[ ! "${DPF_CANDIDATE_SOURCE_SHA:-}" =~ ^[a-f0-9]{40}$ ]]; then
+    _candidate_release_error="candidate release identity is incomplete or malformed"
+    return 1
+  fi
+  if [[ "$DPF_CANDIDATE_SOURCE_SHA" != "${PROMOTE_TARGET_SHA:-}" ]]; then
+    _candidate_release_error="candidate release source $DPF_CANDIDATE_SOURCE_SHA does not match promote target ${PROMOTE_TARGET_SHA:-<unset>}"
+    return 1
+  fi
+  if [[ -n "${DPF_RELEASE_TAG:-}" && "$DPF_RELEASE_TAG" != "$DPF_CANDIDATE_RELEASE_TAG" ]] ||
+     [[ -n "${GHCR_OWNER:-}" && "$GHCR_OWNER" != "$DPF_CANDIDATE_RELEASE_OWNER" ]]; then
+    _candidate_release_error="caller release identity contradicts the immutable candidate"
+    return 1
+  fi
+
+  export DPF_PROMOTION_MODE=release
+  export DPF_RELEASE_TAG="$DPF_CANDIDATE_RELEASE_TAG"
+  export GHCR_OWNER="$DPF_CANDIDATE_RELEASE_OWNER"
+}
+
 if [[ "${1:-}" == "--runtime-transition-secret-rotation" ]]; then
   exec node "$_promoter_dir/rotate-runtime-transition-secret.mjs" --state-dir "${DPF_PROMOTER_STATE_DIR:-/dpf-state}" --rotate
 elif [[ "${1:-}" == "--runtime-transition-authority" ]]; then
@@ -69,10 +122,16 @@ if [[ $_readiness -eq 1 ]]; then
   _state_file="$_state_dir/install-state.json"
   [[ -d "$_state_dir" && -r "$_state_dir" ]] || _readiness_fail state_mount_unreadable "state mount $_state_dir is not a readable directory"
   _state_validator="$_promoter_dir/installer/validate-install-state.mjs"
+  _state_valid=0
   if [[ ! -r "$_state_file" ]] || [[ ! -f "$_state_validator" ]]; then
     _readiness_fail install_state_invalid "no readable install-state at $_state_file"
   elif ! _state_error="$(node "$_state_validator" "$_state_file" 2>&1 >/dev/null)"; then
     _readiness_fail install_state_invalid "$_state_error"
+  else
+    _state_valid=1
+  fi
+  if [[ $_state_valid -eq 1 ]] && ! _resolve_candidate_release_bootstrap; then
+    _readiness_fail release_identity_invalid "$_candidate_release_error"
   fi
   # Build-context completeness. The candidate promoter image is built FROM the
   # host source tree, so every COPY source in Dockerfile.promoter must exist
@@ -184,6 +243,11 @@ fi
 
 [[ $_self_upgrade -eq 1 ]] || { printf 'error: --self-upgrade flag required\n' >&2; exit 1; }
 
+if ! _resolve_candidate_release_bootstrap; then
+  printf 'error: %s\n' "$_candidate_release_error" >&2
+  exit 78
+fi
+
 # Validate all required variables before any mutating work
 _missing=()
 [[ -n "${PROMOTE_SOURCE:-}"      ]] || _missing+=(PROMOTE_SOURCE)
@@ -248,6 +312,11 @@ if [[ $_release_mode -eq 1 && $_dry_run -eq 0 ]]; then
   _candidate_revision="$(docker image inspect "$_candidate_portal" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' | tr -d '[:space:]')"
   [[ "$_candidate_revision" == "$PROMOTE_TARGET_SHA" ]] || {
     printf 'error: release portal revision %s does not match promote target %s\n' "${_candidate_revision:-missing}" "$PROMOTE_TARGET_SHA" >&2
+    exit 1
+  }
+  _candidate_version="$(docker image inspect "$_candidate_portal" --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' | tr -d '[:space:]')"
+  [[ "$_candidate_version" == "$DPF_RELEASE_TAG" ]] || {
+    printf 'error: release portal version %s does not match release tag %s\n' "${_candidate_version:-missing}" "$DPF_RELEASE_TAG" >&2
     exit 1
   }
   mkdir -p "$PROMOTE_BACKUP_PATH"

--- a/scripts/promoter-contract.test.mjs
+++ b/scripts/promoter-contract.test.mjs
@@ -34,7 +34,12 @@ test("promoter image embeds and labels the exact contract", async () => {
   const digest = `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
   assert.match(dockerfile, /COPY promoter-contract\.json \/app\/promoter-contract\.json/);
   assert.match(dockerfile, /ARG DPF_PROMOTER_SOURCE_SHA/);
+  assert.match(dockerfile, /ARG DPF_PROMOTER_RELEASE_TAG/);
+  assert.match(dockerfile, /ARG DPF_PROMOTER_RELEASE_OWNER/);
   assert.match(dockerfile, /ARG DPF_PROMOTER_CONTRACT_DIGEST/);
+  assert.match(dockerfile, /ENV DPF_CANDIDATE_SOURCE_SHA="\$\{DPF_PROMOTER_SOURCE_SHA\}"/);
+  assert.match(dockerfile, /DPF_CANDIDATE_RELEASE_TAG="\$\{DPF_PROMOTER_RELEASE_TAG\}"/);
+  assert.match(dockerfile, /DPF_CANDIDATE_RELEASE_OWNER="\$\{DPF_PROMOTER_RELEASE_OWNER\}"/);
   assert.match(dockerfile, /org\.opencontainers\.image\.revision="\$\{DPF_PROMOTER_SOURCE_SHA\}"/);
   assert.match(dockerfile, /org\.opendpf\.promoter\.contract-schema="1"/);
   assert.match(dockerfile, /org\.opendpf\.promoter\.contract-digest="\$\{DPF_PROMOTER_CONTRACT_DIGEST\}"/);

--- a/scripts/promoter-readiness.test.mjs
+++ b/scripts/promoter-readiness.test.mjs
@@ -14,7 +14,7 @@ test("readiness contract is non-mutating and reports every required dependency",
     "state_mount_unreadable", "install_state_invalid",
     "capability_projection_failed", "compose_identity_missing",
     "recovery_parent_unavailable", "transition_secret_parent_unavailable",
-    "promoter_build_context_incomplete",
+    "promoter_build_context_incomplete", "release_identity_invalid",
   ]) assert.match(block, new RegExp(code));
   assert.match(block, /"quiescenceBegan":false/);
   assert.match(block, /validate-install-state\.mjs.*\$_state_file/s);
@@ -46,9 +46,11 @@ test("the probe's COPY parser sees every COPY source in Dockerfile.promoter", as
     .filter((line) => line.startsWith("COPY "))
     .flatMap((line) => line.split(/\s+/).slice(1, -1).filter((a) => !a.startsWith("--")));
 
-  assert.ok(parsed.length > 10, `expected the promoter to COPY many files, parsed ${parsed.length}`);
-  // The file whose absence produced the opaque BuildKit failure this probe exists for.
-  assert.ok(parsed.includes("scripts/installer/install-release-assets.mjs"));
+  // Dockerfile.promoter intentionally copies the scripts closure as one
+  // directory so an N-1 caller does not have to predict candidate file names.
+  // promoter-build-context.test.mjs separately proves that closure contains
+  // every contract-required file.
+  assert.deepEqual(parsed, ["promoter-contract.json", "Dockerfile", "scripts/"]);
   for (const source of parsed) {
     assert.doesNotMatch(source, /^--/, `flag leaked into COPY sources: ${source}`);
     assert.doesNotMatch(source, /^\//, `destination leaked into COPY sources: ${source}`);

--- a/scripts/publish-image-release-identity.test.mjs
+++ b/scripts/publish-image-release-identity.test.mjs
@@ -35,6 +35,9 @@ test("published promoter identity is bound to its checked-out contract", () => {
     /DPF_PROMOTER_CONTRACT_DIGEST=sha256:\$\{\{ steps\.promoter-contract\.outputs\.digest \}\}/,
     "the promoter Dockerfile must receive the derived contract digest instead of its 'unknown' default",
   );
+  assert.match(build, /DPF_PROMOTER_SOURCE_SHA=\$\{\{ github\.sha \}\}/);
+  assert.match(build, /DPF_PROMOTER_RELEASE_TAG=\$\{\{ needs\.gate\.outputs\.tag \}\}/);
+  assert.match(build, /DPF_PROMOTER_RELEASE_OWNER=\$\{\{ steps\.owner\.outputs\.value \}\}/);
 });
 
 test("latest is promoted only from the verified immutable release tag", () => {


### PR DESCRIPTION
## Summary

An immutable release promoter launched by the deployed N−1 portal had the correct candidate bytes but no `DPF_PROMOTION_MODE`, so it treated a source-free consumer install as a source checkout and failed readiness at `/host-source`. This change lets only a validated consumer/customer install recover release mode from identity baked into the candidate promoter image. Source installs keep the existing fail-closed path.

## Changes

- Stamp each published promoter with the resolved release tag, normalized registry owner, and release commit SHA.
- When the caller omits promotion mode, require valid consumer/customer install-state and exact candidate/target identity before selecting the packaged capability adapter.
- Before mutation, bind the pulled portal to its config digest, source revision, and release-version label.
- Add focused readiness, no-Git promotion, and identity-mismatch regressions; update the stale promoter `COPY scripts/` closure assertion.

## Test plan

- [ ] **Source-only change** (types, isolated unit logic, doc, schema-only)
  - [x] `pnpm typecheck` (worktree OK)
  - [x] Targeted unit tests (worktree OK; name the file(s) run)

- [x] **Runtime-bound change** (server route, MCP tool, build/runtime wiring, compose, installer, prisma migration, UX surface)
  - [x] Source checks above passed where they can run in the worktree
  - [x] Functional verification ran against the **canonical runtime** — pick one:
        - [ ] root local install (`http://localhost:3000`)
        - [ ] governed shared nonprod env (lease id: ____)
        - [x] CI workflow run (link: local-CI evidence `cmt7d795f0p7z01mxoz20th0v`)
  - [x] Evidence captured below (command + observed output, screenshot, MCP record id, etc.)

- [ ] **Verification-harness limitation acknowledged**

### Verification evidence

- TDD RED: a no-mode consumer caller fell into the source/Git path; publisher contract tests showed no baked candidate identity.
- `56/56` promote contract, functional, and legacy-bootstrap tests passed. The readiness case requires exit 0 and `result:"ready"`; the promotion case completes without Git; SHA and version-label mismatches fail before mutation.
- `92/92` related self-upgrade module tests and `28/28` promoter contract/build-context/rollback Node tests passed.
- `pnpm --filter web typecheck`, `bash -n scripts/promote.sh`, and `pnpm run pregate:preflight` (`52/52` guards) passed.
- Fresh semantic review passed with zero issues: `cmt7clz3m0p1d01mxfdvp904i`.
- Exact-tree local CI passed for `8ff5890757721ba9189eca3cb84fe1fa23e8dec2` on base `a78b3ff6daf9fabbb5411dd2b8e1914895be9f93`: `cmt7d795f0p7z01mxoz20th0v`.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and again against the final diff
- [x] `pnpm run pregate:preflight` passed before requesting a shared-sandbox lease
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`, or an allowed `Local-CI-Override` is documented below
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` returned `PR readiness: READY` after the final push

Local-CI-Evidence: cmt7d795f0p7z01mxoz20th0v (fix/consumer-release-legacy-bootstrap@8ff5890757721ba9189eca3cb84fe1fa23e8dec2)

## Related issues / Epic

- BI-5AA89F68 — Consumer self-upgrade preflight requires an unavailable source-only capability adapter
- Preserves failed pre-quiescence evidence from SUR-FF186A18; the canonical verifier will run the new immutable release after protected merge.

## Epic / Backlog linkage (for multi-BI work)

This PR covers only BI-5AA89F68. The readiness and WordPress work remains unchanged and waits for the canonical self-upgrade.

## Overlap sweep

`gh pr list --state open --limit 50` found no open self-upgrade, promoter, or release PR overlapping these paths.

## Notes for the reviewer

This is a candidate-owned N−1 compatibility path. It activates only when promotion mode is absent and validated install-state says `consumer` or `customer`. Explicit source mode stays source-backed. The first canonical end-to-end proof must use the official post-merge release because the currently installed d104 caller cannot carry these fields itself.
