### PR TITLE
fix(upgrade): reconcile Docker image identity strata

### DIFF
--- a/apps/web/lib/self-upgrade/release-target.test.ts
+++ b/apps/web/lib/self-upgrade/release-target.test.ts
@@ -130,6 +130,40 @@ describe("consumer release target", () => {
     });
   });
 
+  it("returns up to date when Docker exposes the running multi-arch channel digest", () => {
+    const channelDigest = `sha256:${"d".repeat(64)}`;
+    expect(resolveReleaseTarget({
+      currentConfigDigest: channelDigest,
+      candidate: {
+        tag: "v2026.08.24-consumer-self-upgrade.6",
+        sourceSha: "a".repeat(40),
+        channelDigest,
+        platformManifestDigest: `sha256:${"e".repeat(64)}`,
+        configDigest: `sha256:${"c".repeat(64)}`,
+      },
+    })).toEqual({
+      kind: "up-to-date",
+      tag: "v2026.08.24-consumer-self-upgrade.6",
+      sourceSha: "a".repeat(40),
+      channelDigest,
+      configDigest: `sha256:${"c".repeat(64)}`,
+    });
+  });
+
+  it("returns up to date when Docker exposes the running platform manifest digest", () => {
+    const platformManifestDigest = `sha256:${"e".repeat(64)}`;
+    expect(resolveReleaseTarget({
+      currentConfigDigest: platformManifestDigest,
+      candidate: {
+        tag: "v2026.08.24-consumer-self-upgrade.6",
+        sourceSha: "a".repeat(40),
+        channelDigest: `sha256:${"d".repeat(64)}`,
+        platformManifestDigest,
+        configDigest: `sha256:${"c".repeat(64)}`,
+      },
+    }).kind).toBe("up-to-date");
+  });
+
   it("returns a frozen immutable target when the channel bytes differ", () => {
     expect(resolveReleaseTarget({
       currentConfigDigest: `sha256:${"c".repeat(64)}`,

--- a/apps/web/lib/self-upgrade/release-target.ts
+++ b/apps/web/lib/self-upgrade/release-target.ts
@@ -120,7 +120,18 @@ export function resolveReleaseTarget(input: {
   if (!input.currentConfigDigest) {
     return { kind: "no-published-target", reason: "current-image-identity-missing" };
   }
-  if (input.currentConfigDigest.toLowerCase() === input.candidate.configDigest.toLowerCase()) {
+  // Docker's `.Image` field is an immutable content identity, but its stratum
+  // varies by image store: classic stores expose the config digest, while the
+  // containerd store can expose the platform manifest or multi-arch index.
+  // Registry discovery verifies and freezes all three identities, so matching
+  // any one of them proves that the running bytes are the published candidate.
+  const currentDigest = input.currentConfigDigest.toLowerCase();
+  const candidateDigests = [
+    input.candidate.configDigest,
+    input.candidate.platformManifestDigest,
+    input.candidate.channelDigest,
+  ];
+  if (candidateDigests.some((digest) => digest.toLowerCase() === currentDigest)) {
     return {
       kind: "up-to-date",
       tag: input.candidate.tag,


### PR DESCRIPTION
## Summary

Reconcile Docker's equivalent immutable image-identity strata after a successful consumer self-upgrade. Docker Desktop can report the running container by the multi-architecture channel digest while the release target also carries architecture manifest and config digests. Treating only the config digest as current left the page advertising another update when Running and Available were the same release.

## Changes

- Accept the verified release config, platform-manifest, or multi-architecture channel digest as the current immutable image identity.
- Add regression coverage for channel-digest and platform-manifest-digest current-state projection while retaining unequal-identity update discovery.

## Test plan

- [ ] **Source-only change** (not applicable; this affects a runtime-bound self-upgrade status projection)
- [x] **Runtime-bound change**
  - [x] Source checks passed in the governed worktree
  - [x] Functional verification ran against CI workflow/local-CI equivalent (governed exact-tree local CI)
  - [x] Evidence captured below
- [ ] **Verification-harness limitation acknowledged** (not applicable)

### Verification evidence

- TDD RED: a running Docker container exposing the verified multi-architecture channel digest was classified as target/update-available.
- Focused self-upgrade/status/action/queue matrix: 272/272 passed.
- Full self-upgrade suite: 658 passed, 9 skipped.
- Web typecheck, style drift, token drift, and diff checks passed.
- Current-main semantic review: PASS, zero issues, receipt cmt7i4cqc08bu01mgz6ig0b4g.
- Exact-tree local CI: PASS for df15e56f4d18371744e148c95ffc8d3d0c563bdb, evidence cmt7iruku08n901mgwfxm34nr.
- Live failing receipt motivating the repair: live-self-upgrade-SUR-E29FB6F9-post-state-ux. Post-release live success verification remains required before BI acceptance.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and against the final two-file diff
- [x] `pnpm run pregate:preflight` passed (52 guards)
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` returned `PR readiness: READY` after the final push

Local-CI-Evidence: cmt7iruku08n901mgwfxm34nr (fix/consumer-self-upgrade-current-state@df15e56f4d18371744e148c95ffc8d3d0c563bdb)

## Related issues / Epic

- BI-5AA89F68
- WC-5B49E778
- Reconciles failed live receipt `live-self-upgrade-SUR-E29FB6F9-post-state-ux`.

## Epic / Backlog linkage (for multi-BI work)

Not applicable; this is a bounded acceptance repair for BI-5AA89F68.

## Overlap sweep

`gh pr list --state open --limit 50` found only PR #4602 (`feat/payroll-tax-jurisdictions`), with no overlapping self-upgrade paths.

## Notes for the reviewer

The candidate release registry already verifies and freezes all three digest strata. This change does not trust source SHA or caller-supplied metadata, and it does not weaken the governed upgrade action: a current digest matching none of the verified candidate identities still projects an available update.
