### PR TITLE
docs: repair public hardware decision paths

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -4974,6 +4974,7 @@
       "anchors": [
         "dpf-install-guide-macos-apple-silicon",
         "supported-environment",
+        "recommended-hardware",
         "prerequisites",
         "quick-start",
         "contributor-separate-dev-workspace-from-install-recommended-bi-0856a4ce-phase-1",
@@ -5062,6 +5063,7 @@
       "anchors": [
         "dpf-install-guide-windows-1011",
         "supported-environment",
+        "recommended-hardware",
         "prerequisites",
         "quick-start",
         "what-the-installer-does",

--- a/docs/index.html
+++ b/docs/index.html
@@ -849,13 +849,13 @@
 
   .install-grid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 12px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
   }
 
   .install-card {
     display: flex;
-    min-height: 210px;
+    min-height: 360px;
     flex-direction: column;
     padding: 22px;
     border: 1px solid var(--border);
@@ -865,7 +865,6 @@
 
   .status-badge {
     align-self: flex-start;
-    margin-bottom: auto;
     padding: 4px 8px;
     border: 1px solid var(--border-strong);
     border-radius: 999px;
@@ -881,12 +880,51 @@
   }
 
   .install-card h3 {
-    margin-top: 28px;
+    margin-top: 24px;
   }
 
   .install-card p {
     color: var(--muted);
     font-size: 0.84rem;
+  }
+
+  .install-profiles {
+    display: grid;
+    gap: 12px;
+    margin: 18px 0 22px;
+  }
+
+  .install-profile {
+    padding-top: 12px;
+    border-top: 1px solid var(--border);
+  }
+
+  .install-profile strong,
+  .install-profile span {
+    display: block;
+  }
+
+  .install-profile strong {
+    margin-bottom: 4px;
+    font-size: 0.78rem;
+  }
+
+  .install-profile span {
+    color: var(--muted);
+    font-size: 0.82rem;
+    line-height: 1.55;
+  }
+
+  .install-secondary {
+    margin-top: 14px;
+  }
+
+  .install-card.compact {
+    min-height: 180px;
+  }
+
+  .install-card.compact h3 {
+    margin-top: 20px;
   }
 
   .install-card a {
@@ -1763,47 +1801,68 @@
 
   <section id="install">
     <p class="eyebrow">Deployment choices</p>
-    <h2>Pick the host that matches your evidence tolerance.</h2>
+    <h2>Choose a machine for the way you will run DPF.</h2>
     <p class="section-intro">
-      Windows and Apple Silicon macOS are generally available. Native Linux and cloud
-      single-VM paths are available for early adopters and need broader host verification
-      before graduation. Each path preserves the same canonical platform contracts.
+      Windows and Apple Silicon macOS are the two tested customer targets. Provider-assisted
+      operations use approved external AI and need no dedicated GPU. Local-first operations
+      keep primary AI inference on the host and need more model memory.
     </p>
 
     <div class="install-grid">
-      <article class="install-card">
+      <article class="install-card" data-install-target="windows">
         <span class="status-badge">Generally available</span>
         <h3>Windows 10 / 11</h3>
-        <p>Guided PowerShell installer for a local Docker Desktop deployment.</p>
-        <a href="https://github.com/OpenDigitalProductFactory/opendigitalproductfactory#quick-install">Windows install steps &rarr;</a>
+        <p>Guided PowerShell installer for Docker Desktop with the WSL2 backend.</p>
+        <div class="install-profiles">
+          <div class="install-profile">
+            <strong>Provider-assisted operations</strong>
+            <span>32 GB system RAM · 1 TB NVMe SSD · no dedicated GPU required</span>
+          </div>
+          <div class="install-profile">
+            <strong>Local-first operations</strong>
+            <span>64 GB system RAM · 2 TB NVMe SSD · 24 GB GPU memory supported; 32 GB recommended for a new purchase</span>
+          </div>
+        </div>
+        <a href="/install/windows/">Windows hardware and install guide &rarr;</a>
       </article>
-      <article class="install-card">
+      <article class="install-card" data-install-target="macos">
         <span class="status-badge">Generally available</span>
         <h3>macOS Apple Silicon</h3>
-        <p>Native shell installer for supported Apple Silicon hosts.</p>
-        <a href="/install/macos">macOS install guide &rarr;</a>
+        <p>Native shell installer with one shared memory pool for the CPU and GPU.</p>
+        <div class="install-profiles">
+          <div class="install-profile">
+            <strong>Provider-assisted operations</strong>
+            <span>32 GB unified memory · 1 TB SSD · no separate GPU required</span>
+          </div>
+          <div class="install-profile">
+            <strong>Local-first operations</strong>
+            <span>64 GB unified memory practical · 128 GB for larger models or combined operations and development · 2 TB SSD</span>
+          </div>
+        </div>
+        <a href="/install/macos/">macOS hardware and install guide &rarr;</a>
       </article>
-      <article class="install-card">
+    </div>
+
+    <div class="install-grid install-secondary">
+      <article class="install-card compact">
         <span class="status-badge early">Early access</span>
         <h3>Native Linux</h3>
-        <p>Docker-based native host path for contributors and pilot operators.</p>
-        <a href="/install/linux">Linux install guide &rarr;</a>
+        <p>Docker-based host path for contributors and pilot operators. Validate the exact GPU backend before buying hardware.</p>
+        <a href="/install/linux/">Linux install guide &rarr;</a>
       </article>
-      <article class="install-card">
+      <article class="install-card compact">
         <span class="status-badge early">Early access</span>
         <h3>Cloud single VM</h3>
         <p>Single-tenant VM deployment patterns for AWS, Google Cloud, and Azure.</p>
-        <a href="/install/cloud-single-vm">Cloud install guide &rarr;</a>
+        <a href="/install/cloud-single-vm/">Cloud install guide &rarr;</a>
       </article>
     </div>
 
     <div class="note">
-      <strong>Ready-to-go or customizable?</strong> Choose ready-to-go when you want packaged
-      platform images. Choose customizable when you expect serious source work from an editor
-      or external agent client. Build Studio is available in both modes; it is not the only
-      supported development path. Customer operations do not need coding-workstation capacity.
-      Use the <a href="/install/hardware/">current hardware guide</a> to compare provider-assisted,
-      NVIDIA, and Apple unified-memory systems before buying a host.
+      <strong>Operations and development are different workloads.</strong> Customer operations
+      do not need coding-workstation capacity or Build Studio. Choose customizable only when the
+      host will also do serious source work, builds, tests, or local coding-model evaluation.
+      Compare current Windows and Mac machines in the <a href="/install/hardware/">complete hardware guide</a>.
     </div>
   </section>
 
@@ -1829,8 +1888,8 @@
       </a>
       <a class="doc-path" href="/install/hardware/">
         <span class="doc-kind">Install</span>
-        <strong>Hardware and deployment</strong>
-        <span>Choose a current machine, memory architecture, and provider posture before setup.</span>
+        <strong>Hardware and installation</strong>
+        <span>Compare the two AI deployment models, current Windows and Mac machines, and the guide for each tested host.</span>
       </a>
       <a class="doc-path" href="/architecture/platform-overview">
         <span class="doc-kind">Understand</span>

--- a/docs/install/hardware.md
+++ b/docs/install/hardware.md
@@ -26,7 +26,7 @@ After choosing the host, continue with the [Windows](windows.md),
 | --- | --- |
 | Provider-assisted operations | **8–12 modern CPU cores · 32 GB RAM · 1 TB NVMe SSD · no discrete GPU required.** Choose 64 GB for heavy browser or document work. This profile handles routine operations with approved external AI providers. |
 | Local-first operations, discrete GPU | **12–16 modern CPU cores · 64 GB system RAM · 2 TB NVMe SSD · 24 GB VRAM supported; 32 GB recommended for a new purchase.** This profile handles local tool-using coworkers at 32K context, with modest headroom for voice or another AI service. |
-| Local-first operations, Apple unified memory | **Apple Silicon · 2 TB SSD · 64 GB unified memory practical; 128 GB recommended for a new serious-use purchase.** This profile can run larger local models and longer context without a separate VRAM ceiling. |
+| Local-first operations, Apple unified memory | **Apple Silicon · 2 TB SSD · 64 GB unified memory practical; 128 GB recommended when the host must run larger local models or double as a development machine.** This profile can run larger local models and longer context without a separate VRAM ceiling. |
 | Contributor/development workstation | **16–24 modern CPU cores · 128 GB memory · 4 TB NVMe SSD · 32 GB VRAM or 128 GB unified memory.** This profile adds capacity for source work, worktrees, builds, tests, browser automation, and local model evaluation. |
 
 The customer profiles exclude Build Studio, local coding-model capacity, source

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -27,12 +27,31 @@ and the [deployment doctrine](../superpowers/specs/2026-05-09-deployment-contrac
 |-----------|----------|
 | OS | macOS 14 (Sonoma) or newer |
 | Architecture | Apple Silicon (`arm64`). Intel Macs are not supported. |
-| Disk | ~10 GB free (Docker Desktop + multi-arch GHCR images) |
-| RAM | 16 GB minimum for a small local model; 64 GB practical and 128 GB recommended for serious local-first use. See [Choosing Hardware for DPF](hardware.md). An external `LLM_BASE_URL` reduces local memory pressure. |
+| Disk | ~10 GB free for the application images; buy at least 1 TB, or 2 TB when local models will run on the host. |
+| RAM | 32 GB recommended with an external AI provider; 64 GB practical for local-first use; choose 128 GB for larger models or combined operations and development. |
 
 The installer refuses to run on unsupported hosts (Intel Mac, older
 macOS) unless you pass `--force-unsupported-host` — see
 [Preflight refusals](#preflight-refusals).
+
+## Recommended hardware
+
+Choose the profile that matches where primary AI inference will run:
+
+| Deployment model | Recommended Apple Silicon configuration | Best fit |
+| --- | --- | --- |
+| Provider-assisted operations | **32 GB unified memory, 1 TB SSD** | Routine DPF operations using approved external AI providers |
+| Local-first operations | **64 GB unified memory practical; 128 GB for larger models or combined operations and development; 2 TB SSD** | Local tool-using coworkers, larger models, and longer context |
+| Contributor/development workstation | **128 GB unified memory, 4 TB SSD** | Operations plus source work, builds, tests, browser automation, and local model evaluation |
+
+Apple Silicon lets the CPU and GPU share one memory pool. DPF's planning rule
+reserves 25% for macOS and the application stack, leaving about 48 GB on a
+64 GB Mac and 96 GB on a 128 GB Mac for local AI workloads. Memory cannot be
+upgraded after purchase, so buy 128 GB when the Mac must handle larger local
+models or serve as both the DPF host and a development workstation.
+
+See [Choosing Hardware for DPF](hardware.md) for current Mac and Windows machine
+examples, NVIDIA speed tradeoffs, model sizing, and purchase checks.
 
 ## Prerequisites
 

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -4,8 +4,8 @@ This is the end-user install guide for the Open Digital Product Factory
 on **Windows 10 / 11** with Docker Desktop (WSL2 backend).
 
 > **Status: GA.** Windows is DPF's primary, generally-available install
-> surface — the one CI and the maintainers exercise most. macOS (Apple
-> Silicon) and Linux are [early access](macos.md). If something here is
+> surface — the one CI and the maintainers exercise most. Apple Silicon
+> macOS is also GA; Linux remains early access. If something here is
 > wrong or stale, please [open an issue](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/issues/new).
 
 For the architectural background, see the
@@ -18,12 +18,31 @@ and the [platform support watch-list](platform-support-watchlist.md).
 |-----------|----------|
 | OS | Windows 10 (21H2+) or Windows 11, x64 |
 | Backend | Docker Desktop with the **WSL2** backend (not Hyper-V/Windows-containers) |
-| Disk | ~10 GB free (Docker Desktop + images). The installer can suggest a roomier non-`C:` drive. |
-| RAM | 16 GB host recommended for the local-LLM tier; 8 GB works with an external `LLM_BASE_URL` |
+| Disk | ~10 GB free for the application images; buy at least 1 TB, or 2 TB when local models will run on the host. The installer can suggest a roomier non-`C:` drive. |
+| RAM | 32 GB recommended with an external AI provider; 64 GB system RAM recommended for local-first operation. |
 | Docker VM memory | **≥ 6 GB (8 GB recommended)** for the **Customizable** source-build path — see [Docker memory](#docker-memory). Consumer installs pull pre-built images and are lighter. |
 
 Out of scope (per the [watch-list](platform-support-watchlist.md)):
 Windows-on-ARM, and WSL2 *without* Docker Desktop.
+
+## Recommended hardware
+
+Choose the profile that matches where primary AI inference will run:
+
+| Deployment model | Recommended Windows configuration | Best fit |
+| --- | --- | --- |
+| Provider-assisted operations | **8–12 modern CPU cores, 32 GB system RAM, 1 TB NVMe SSD, no dedicated GPU required** | Routine DPF operations using approved external AI providers |
+| Local-first operations | **12–16 modern CPU cores, 64 GB system RAM, 2 TB NVMe SSD, 24 GB GPU memory supported; 32 GB recommended for a new purchase** | Local tool-using coworkers with a practical 32K context baseline |
+| Contributor/development workstation | **16–24 modern CPU cores, 128 GB system RAM, 4 TB NVMe SSD, 32 GB GPU memory** | Source work, builds, tests, browser automation, and local model evaluation |
+
+An existing RTX 4090 with 24 GB remains capable; the RTX 5090's 32 GB is the
+new-purchase recommendation because the extra model memory provides context and
+service headroom. It does not make the same model more knowledgeable. GPU memory
+does not replace system RAM: Windows, Docker, DPF services, browser work, and
+model mappings still use the host's regular memory.
+
+See [Choosing Hardware for DPF](hardware.md) for current machine examples,
+Apple unified-memory tradeoffs, model sizing, and purchase checks.
 
 ## Prerequisites
 

--- a/docs/ux-fit/2026-08-24-customer-hardware-guide.ux-fit.json
+++ b/docs/ux-fit/2026-08-24-customer-hardware-guide.ux-fit.json
@@ -1,7 +1,7 @@
 {
   "version": "1",
-  "decidedOption": "canonical-guide-with-entry-point",
-  "decisionInteractionId": "DI-23888F11C9EC",
+  "decidedOption": "profile-summary-with-os-guides",
+  "decisionInteractionId": "DI-A80F63778943",
   "scope": {
     "files": [
       "docs/index.html"
@@ -10,9 +10,9 @@
   "evidence": {
     "kind": "propose-n-pick",
     "consideredOptions": [
-      "homepage-full-matrix",
-      "canonical-guide-with-entry-point",
-      "architecture-only"
+      "full-matrix-homepage",
+      "profile-summary-with-os-guides",
+      "guide-only-links"
     ]
   }
 }

--- a/scripts/public-docs-rendering.test.mjs
+++ b/scripts/public-docs-rendering.test.mjs
@@ -169,11 +169,10 @@ test("homepage install cards expose both customer hardware profiles for each GA 
   assert.match(windowsCard, /Local-first operations/);
   assert.match(windowsCard, /32 GB recommended for a new purchase/);
   assert.match(windowsCard, /href="\/install\/windows\/"/);
-  assert.equal(
-    windowsCard.includes("github.com"),
-    false,
-    "the Windows card must stay on the public documentation site",
+  const windowsLinks = [...windowsCard.matchAll(/href="([^"]+)"/g)].map(
+    ([, href]) => href,
   );
+  assert.deepEqual(windowsLinks, ["/install/windows/"]);
 
   assert.ok(macCard, "macOS must have a first-class install card");
   assert.match(macCard, /Provider-assisted operations/);

--- a/scripts/public-docs-rendering.test.mjs
+++ b/scripts/public-docs-rendering.test.mjs
@@ -145,3 +145,54 @@ test("homepage headings use the compact shared type scale", () => {
   assert.match(homepage, /h1\s*\{[^}]*font-size:\s*var\(--type-display\)/s);
   assert.match(homepage, /h2\s*\{[^}]*font-size:\s*var\(--type-section\)/s);
 });
+
+test("homepage install cards expose both customer hardware profiles for each GA host", () => {
+  const homepage = fs.readFileSync(
+    path.join(repoRoot, "docs", "index.html"),
+    "utf8",
+  );
+  const installSection = homepage.match(
+    /<section id="install">(?<content>[\s\S]*?)<\/section>/,
+  )?.groups?.content;
+
+  assert.ok(installSection, "the public homepage needs an install decision surface");
+  const windowsCard = installSection.match(
+    /data-install-target="windows"(?<content>[\s\S]*?)<\/article>/,
+  )?.groups?.content;
+  const macCard = installSection.match(
+    /data-install-target="macos"(?<content>[\s\S]*?)<\/article>/,
+  )?.groups?.content;
+
+  assert.ok(windowsCard, "Windows must have a first-class install card");
+  assert.match(windowsCard, /Provider-assisted operations/);
+  assert.match(windowsCard, /32 GB system RAM/);
+  assert.match(windowsCard, /Local-first operations/);
+  assert.match(windowsCard, /32 GB recommended for a new purchase/);
+  assert.match(windowsCard, /href="\/install\/windows\/"/);
+  assert.doesNotMatch(windowsCard, /github\.com/);
+
+  assert.ok(macCard, "macOS must have a first-class install card");
+  assert.match(macCard, /Provider-assisted operations/);
+  assert.match(macCard, /32 GB unified memory/);
+  assert.match(macCard, /Local-first operations/);
+  assert.match(macCard, /128 GB for larger models or combined operations and development/);
+  assert.match(macCard, /href="\/install\/macos\/"/);
+});
+
+test("both tested OS guides carry the same visible hardware decision and canonical comparison", () => {
+  const windows = fs.readFileSync(
+    path.join(repoRoot, "docs", "install", "windows.md"),
+    "utf8",
+  );
+  const macos = fs.readFileSync(
+    path.join(repoRoot, "docs", "install", "macos.md"),
+    "utf8",
+  );
+
+  for (const [name, guide] of [["Windows", windows], ["macOS", macos]]) {
+    assert.match(guide, /^## Recommended hardware$/m, `${name} guide needs hardware before setup`);
+    assert.match(guide, /Provider-assisted operations/);
+    assert.match(guide, /Local-first operations/);
+    assert.match(guide, /\[Choosing Hardware for DPF\]\(hardware\.md\)/);
+  }
+});

--- a/scripts/public-docs-rendering.test.mjs
+++ b/scripts/public-docs-rendering.test.mjs
@@ -169,7 +169,11 @@ test("homepage install cards expose both customer hardware profiles for each GA 
   assert.match(windowsCard, /Local-first operations/);
   assert.match(windowsCard, /32 GB recommended for a new purchase/);
   assert.match(windowsCard, /href="\/install\/windows\/"/);
-  assert.doesNotMatch(windowsCard, /github\.com/);
+  assert.equal(
+    windowsCard.includes("github.com"),
+    false,
+    "the Windows card must stay on the public documentation site",
+  );
 
   assert.ok(macCard, "macOS must have a first-class install card");
   assert.match(macCard, /Provider-assisted operations/);


### PR DESCRIPTION
## Summary

- Put provider-assisted and local-first hardware recommendations directly on both tested host cards.
- Route Windows and macOS to internal installation guides, each with an early hardware decision table.
- Add regression coverage for the homepage choices, internal routes, and both operating-system guides.

## Why

PR #4638 published the canonical hardware guide, but the main customer journeys still hid the recommendation: Windows left the site for a repository README, macOS used a separate path, and the deployment card opened a file listing. This follow-up makes the buying decision visible where customers actually choose an installation path.

## Verification

- `pnpm run pregate:preflight` — all 52 guards passed.
- Exact-tree local merge gate — passed against current `origin/main`, including tests and production image build.
- Independent semantic review — passed with no findings.
- `pnpm run check:doc-links` — all 24 tests passed.
- `node --test scripts/public-docs-rendering.test.mjs` — all 8 tests passed.
- Browser review at 1440×1100 and 390×844 — primary choices remained readable with no install-section overflow.

## Tracking

- Hardware guidance: `BI-5C203662`
- Generalized documentation impact-graph gap: `BI-0099B704`
- Follows #4638
