### PR TITLE
fix(readiness): complete deterministic recovery routes

### DIFF
--- a/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { InitiativeReadinessDecision } from "@/lib/backlog/initiative-readiness";
+
+import { resolveInitiativeReviewerRecovery } from "./initiative-readiness-tool-grants";
+
+const decision: InitiativeReadinessDecision = {
+  decisionId: "IRD-RECOVERY",
+  policyVersion: "initiative-readiness.v2",
+  subject: { kind: "backlog-item", id: "BI-A45D744A" },
+  transitionObject: {
+    kind: "work-capsule",
+    id: "WC-04941646",
+    expectedVersion: "claim.v1",
+    targetState: "implementation",
+  },
+  profile: "fix",
+  target: "implementation",
+  verdict: "input-required",
+  satisfied: [],
+  unmet: [
+    { code: "RESEARCH_REQUIRED", state: "missing", accountableRole: "design-author", evidenceRefs: [] },
+    { code: "PLAN_REQUIRED", state: "missing", accountableRole: "implementation-planner", evidenceRefs: [] },
+  ],
+  blockers: [],
+  evaluatedAt: "2026-08-24T17:00:00.000Z",
+};
+
+const dispatchContext = {
+  workroomId: "WC-04941646",
+  repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+  branchName: "fix/wordpress-operator-regressions-recovery",
+  headSha: "21103703757a342c828dd6ef1bb9acc97a4b01f8",
+};
+
+function grantRow(grantKey: string, agentId: string, displayName: string) {
+  return {
+    grantKey,
+    agent: {
+      agentId,
+      displayName,
+      status: "active",
+      archived: false,
+      lifecycleStage: "production",
+    },
+  };
+}
+
+describe("initiative readiness recovery routing", () => {
+  it("returns deterministic executable packets for research and plan coverage without dispatching", async () => {
+    const findMany = vi.fn().mockResolvedValue([
+      grantRow("initiative_evidence_write", "AGT-WS-PORTFOLIO", "Portfolio Management"),
+      grantRow("backlog_write", "AGT-WS-PORTFOLIO", "Portfolio Management"),
+      grantRow("initiative_evidence_write", "AGT-WS-BUILD", "Build Specialist"),
+      grantRow("backlog_write", "AGT-WS-BUILD", "Build Specialist"),
+    ]);
+
+    const recovery = await resolveInitiativeReviewerRecovery({
+      decision,
+      currentAgentId: "AGT-AUTHOR",
+      db: { agentToolGrant: { findMany } },
+      dispatchContext,
+    });
+
+    expect(findMany).toHaveBeenCalledOnce();
+    expect(recovery.escalations).toEqual([]);
+    expect(recovery.reviewerRoutes).toMatchObject([
+      {
+        accountableRole: "design-author",
+        toolName: "record_initiative_evidence",
+        grant: "initiative_evidence_write",
+        gate: "research",
+        targetAgentId: "AGT-WS-BUILD",
+        requestCoworker: {
+          targetAgent: "AGT-WS-BUILD",
+          requestKey: `initiative-readiness:BI-A45D744A:research:${dispatchContext.headSha}`,
+          tier: 2,
+          enteredVia: "handoff",
+        },
+      },
+      {
+        accountableRole: "implementation-planner",
+        toolName: "record_plan_backlog_coverage",
+        grant: "backlog_write",
+        gate: "dependency-disposition",
+        targetAgentId: "AGT-WS-BUILD",
+        requestCoworker: {
+          targetAgent: "AGT-WS-BUILD",
+          requestKey: `initiative-readiness:BI-A45D744A:dependency-disposition:${dispatchContext.headSha}`,
+          tier: 2,
+          enteredVia: "handoff",
+        },
+      },
+    ]);
+  });
+
+  it("returns both exact next-action mappings when immutable dispatch identity is unavailable", async () => {
+    const recovery = await resolveInitiativeReviewerRecovery({
+      decision,
+      currentAgentId: "AGT-AUTHOR",
+      db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue([
+        grantRow("initiative_evidence_write", "AGT-WS-BUILD", "Build Specialist"),
+        grantRow("backlog_write", "AGT-WS-BUILD", "Build Specialist"),
+      ]) } },
+      dispatchContext: null,
+    });
+
+    expect(recovery.reviewerRoutes).toEqual([]);
+    expect(recovery.escalations).toMatchObject([
+      { accountableRole: "design-author", toolName: "record_initiative_evidence", grant: "initiative_evidence_write" },
+      { accountableRole: "implementation-planner", toolName: "record_plan_backlog_coverage", grant: "backlog_write" },
+    ]);
+  });
+});

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.ts
@@ -17,6 +17,7 @@ export type InitiativeReadinessLane = {
 /** One registry drives disclosure, receipt validation, and recovery routing. */
 export const INITIATIVE_READINESS_LANES: Record<string, InitiativeReadinessLane> = {
   record_initiative_evidence: { capability: "manage_backlog", grant: "initiative_evidence_write", gates: ["classification", "research", "dependency-disposition"], accountableRoles: ["design-author", "portfolio-management"], independent: false },
+  record_plan_backlog_coverage: { capability: "manage_backlog", grant: "backlog_write", gates: ["dependency-disposition"], accountableRoles: ["implementation-planner"], independent: false },
   record_initiative_design_review: { capability: "manage_backlog", grant: "initiative_design_review", gates: ["design-spec", "spec-approval", "plan-review"], accountableRoles: ["design-checklist-reviewer", "plan-reviewer"], independent: true },
   record_initiative_architecture_review: { capability: "manage_ea_model", grant: "initiative_architecture_review", gates: ["architecture-review"], accountableRoles: ["architecture-reviewer"], independent: true },
   record_initiative_data_review: { capability: "manage_ea_model", grant: "initiative_data_review", gates: ["data-review"], accountableRoles: ["data-reviewer"], independent: true },
@@ -30,6 +31,7 @@ export const INITIATIVE_READINESS_LANES: Record<string, InitiativeReadinessLane>
 /** Static mirror keeps source-policy audits and runtime disclosure on one exact grant map. */
 export const INITIATIVE_READINESS_TOOL_GRANTS: Record<string, string[]> = {
   record_initiative_evidence: ["initiative_evidence_write"],
+  record_plan_backlog_coverage: ["backlog_write"],
   record_initiative_design_review: ["initiative_design_review"],
   record_initiative_architecture_review: ["initiative_architecture_review"],
   record_initiative_data_review: ["initiative_data_review"],
@@ -138,11 +140,13 @@ export async function resolveInitiativeReviewerRecovery(input: {
         },
       })
     : [];
+  const deterministicRows = [...rows].sort((left, right) =>
+    left.agent.agentId.localeCompare(right.agent.agentId));
 
   const reviewerRoutes: InitiativeReviewerRecovery["reviewerRoutes"] = [];
   const escalations: InitiativeReviewerRecovery["escalations"] = [];
   for (const entry of distinct) {
-    const candidate = rows.find((row) =>
+    const candidate = deterministicRows.find((row) =>
       row.grantKey === entry.route.lane.grant
       && row.agent.status === "active"
       && !row.agent.archived


### PR DESCRIPTION
## What changed

- Add `record_plan_backlog_coverage` as the canonical executable recovery lane for `PLAN_REQUIRED`.
- Sort eligible grant rows by stable agent ID before choosing the reviewer, so database row order cannot change the server-issued target.
- Cover the live `BI-A45D744A` / `WC-04941646` shape: research and plan recovery both return deterministic packets, and both remain explicit escalations when immutable dispatch identity is missing.

The live claim reproduction showed that the MCP boundary already preserves the `recovery` object. This PR does not change that boundary and does not auto-dispatch a coworker.

## Evidence

- RED: 2/2 new tests failed because `PLAN_REQUIRED` had no route and research selection followed database row order.
- GREEN: 187/187 relevant recovery, decomposition, grant, and tier tests.
- Typecheck, style/token drift, and 52/52 preflight guards passed.
- Exact current-tree semantic review: `cmt7k1er2095w01mg30jemtgx` (PASS, zero issues).
- Exact-tree local CI: `cmt7l6oih09pa01mgmyo3bqox` (PASS for `4f4423ebec3109b469c9866e1c0c2fbdc149d000`).

## Design grounding

Specs/plans reviewed:
- `docs/superpowers/specs/2026-08-23-initiative-readiness-traversal-repair-design.md`
- `docs/superpowers/plans/2026-08-23-initiative-readiness-traversal-repair.md`

Code substrate reviewed:
- `apps/web/lib/tak/initiative-readiness-tool-grants.ts`
- the initiative decomposition pack
- the governed work-claim boundary

Source of truth: the readiness-lane registry remains the single map for tool disclosure, grant validation, and recovery routing. The change adds the missing plan lane there instead of creating a route-specific mapping.

## Process spine

This keeps the existing readiness and coworker-request process. It adds one missing governed lane and a stable selection rule; it does not add another dispatch path, approval path, or receipt writer.

Local-CI-Evidence: cmt7l6oih09pa01mgmyo3bqox
Semantic-Review-Evidence: cmt7k1er2095w01mg30jemtgx
Process-Spine-Decision: Preserve the initiative-readiness lane registry and existing request_coworker packet builder as the only recovery process; add the missing plan-coverage lane and deterministic selection within that spine.
Design-Grounding-Decision: Extend the reviewed initiative-readiness traversal design through the existing readiness lane registry; no new authority or dispatch substrate is introduced.
Docs-Impact-Decision: Internal recovery routing only; no user-facing workflow or operator instruction changes.