### PR TITLE
fix(ci): fence control-plane misses per surface

### DIFF
--- a/docs/superpowers/plans/2026-08-24-local-ci-per-surface-control-plane-fencing.md
+++ b/docs/superpowers/plans/2026-08-24-local-ci-per-surface-control-plane-fencing.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Local-CI per-surface control-plane fencing
 
 Backlog item: `BI-9DC21917`  

--- a/docs/superpowers/plans/2026-08-24-local-ci-per-surface-control-plane-fencing.md
+++ b/docs/superpowers/plans/2026-08-24-local-ci-per-surface-control-plane-fencing.md
@@ -1,0 +1,34 @@
+# Local-CI per-surface control-plane fencing
+
+Backlog item: `BI-9DC21917`  
+Workroom: `WC-7E4580C0`  
+Decision: `DI-F858F9EB93E0`
+
+## Evidence and diagnosis
+
+Three exact-tree local-CI attempts for the frozen self-upgrade candidate completed substantive test and build work, then fenced as `blocked_control_plane_starvation`. Receipt-level inspection showed that a portal miss followed by an MCP miss increments one global consecutive-failure counter to its limit even though neither surface missed twice consecutively.
+
+The watchdog currently evaluates portal, MCP, Docker, and PostgreSQL together. Its sample is healthy only when every surface is healthy, but its hysteresis state is a single scalar shared by all surfaces. That conflates independent transient misses and creates a false cross-surface fence.
+
+## Required behavior
+
+- Keep the strict preflight invariant: all four surfaces must be healthy before build work starts.
+- Track consecutive misses independently for portal, MCP, Docker, and PostgreSQL during the build watchdog.
+- Reset only the counter for a surface that recovers.
+- Fence when any one surface reaches the configured consecutive-failure limit.
+- Treat an absent probe as unhealthy and preserve the existing fail-closed exit classification.
+- Report the surface or surfaces that breached the limit so the evidence is actionable.
+- Do not change the configured limit, probe cadence, product gates, or candidate under test.
+
+## Test-first implementation
+
+1. Add a failing regression where a portal-only miss is followed by an MCP-only miss. The watchdog must not fence.
+2. Add a failing regression where the same surface misses in consecutive samples. The watchdog must fence at the existing limit.
+3. Add a failing regression proving a recovered surface resets only its own counter while another surface retains its consecutive history.
+4. Preserve and run the strict all-surface preflight cases, including missing-probe behavior.
+5. Replace the shared scalar with bounded per-surface state and include the tripping surface names in the terminal result.
+6. Run the focused watchdog suite, pregate, and governed exact-tree local CI before publication.
+
+## Acceptance
+
+The repair is accepted only when the focused tests prove alternating-surface tolerance and same-surface fail-closed behavior, semantic review passes on the committed tree, and one unchanged-SHA local-CI rerun completes without the false global-counter fence.

--- a/scripts/lib/local-ci-control-plane-watchdog.mjs
+++ b/scripts/lib/local-ci-control-plane-watchdog.mjs
@@ -21,25 +21,35 @@ export async function monitorControlPlane({
   onSample = () => {},
 }) {
   const samples = [];
-  let consecutiveFailures = 0;
+  const consecutiveFailures = Object.fromEntries(
+    SURFACES.map((surface) => [surface, 0]),
+  );
   while (true) {
     const probes = await sample();
     const classification = classifyControlPlaneSample(probes);
+    for (const surface of SURFACES) {
+      consecutiveFailures[surface] = probes?.[surface]?.healthy === true
+        ? 0
+        : consecutiveFailures[surface] + 1;
+    }
     const observed = {
       observedAt: new Date().toISOString(),
       probes,
       ...classification,
+      consecutiveFailures: { ...consecutiveFailures },
     };
     samples.push(observed);
     await onSample(observed);
-    consecutiveFailures = classification.healthy
-      ? 0
-      : consecutiveFailures + 1;
-    if (consecutiveFailures >= consecutiveFailureLimit) {
+    const breachedSurfaces = SURFACES.filter(
+      (surface) => consecutiveFailures[surface] >= consecutiveFailureLimit,
+    );
+    if (breachedSurfaces.length > 0) {
       return {
         status: "blocked_control_plane_starvation",
         samples,
-        failures: classification.failures,
+        failures: breachedSurfaces.map((surface) => (
+          `${surface}:${probes?.[surface]?.reason || "unhealthy"}`
+        )),
       };
     }
     if (isComplete()) {

--- a/scripts/lib/local-ci-control-plane-watchdog.test.mjs
+++ b/scripts/lib/local-ci-control-plane-watchdog.test.mjs
@@ -51,6 +51,27 @@ test("one transient round recovers without tripping the boundary", async () => {
   assert.equal(result.samples.length, 3);
 });
 
+test("alternating single-surface misses do not form a sustained starvation breach", async () => {
+  const rounds = [
+    { ...healthy, portal: { healthy: false, reason: "timeout" } },
+    { ...healthy, mcp: { healthy: false, reason: "timeout" } },
+    healthy,
+  ];
+  let complete = false;
+  const result = await monitorControlPlane({
+    sample: async () => {
+      const value = rounds.shift();
+      if (rounds.length === 0) complete = true;
+      return value;
+    },
+    isComplete: () => complete,
+    wait: async () => {},
+    consecutiveFailureLimit: 2,
+  });
+  assert.equal(result.status, "healthy");
+  assert.equal(result.samples.length, 3);
+});
+
 test("publishes every control-plane sample for durable stage heartbeats", async () => {
   const observed = [];
   let complete = false;
@@ -81,6 +102,50 @@ test("two consecutive unhealthy rounds form a sustained starvation breach", asyn
   assert.equal(result.status, "blocked_control_plane_starvation");
   assert.equal(result.samples.length, 2);
   assert.deepEqual(result.failures, ["postgres:timeout"]);
+});
+
+test("a breach names only the surface whose consecutive limit was reached", async () => {
+  const rounds = [
+    { ...healthy, portal: { healthy: false, reason: "timeout" } },
+    {
+      ...healthy,
+      portal: { healthy: false, reason: "timeout" },
+      mcp: { healthy: false, reason: "connection-reset" },
+    },
+  ];
+  const result = await monitorControlPlane({
+    sample: async () => rounds.shift(),
+    isComplete: () => false,
+    wait: async () => {},
+    consecutiveFailureLimit: 2,
+  });
+  assert.equal(result.status, "blocked_control_plane_starvation");
+  assert.deepEqual(result.failures, ["portal:timeout"]);
+});
+
+test("a recovered surface resets only its own consecutive history", async () => {
+  const rounds = [
+    {
+      ...healthy,
+      portal: { healthy: false, reason: "timeout" },
+      mcp: { healthy: false, reason: "timeout" },
+    },
+    { ...healthy, mcp: { healthy: false, reason: "timeout" } },
+  ];
+  const observed = [];
+  const result = await monitorControlPlane({
+    sample: async () => rounds.shift(),
+    isComplete: () => false,
+    wait: async () => {},
+    onSample: async (sample) => observed.push(sample),
+    consecutiveFailureLimit: 2,
+  });
+  assert.equal(result.status, "blocked_control_plane_starvation");
+  assert.deepEqual(observed.map((sample) => sample.consecutiveFailures), [
+    { portal: 1, mcp: 1, docker: 0, postgres: 0 },
+    { portal: 0, mcp: 2, docker: 0, postgres: 0 },
+  ]);
+  assert.deepEqual(result.failures, ["mcp:timeout"]);
 });
 
 test("an unhealthy control plane blocks the build before it starts", async () => {


### PR DESCRIPTION
## Summary

- track build-time portal, MCP, Docker, and PostgreSQL misses independently
- reset only the recovered surface while preserving fail-closed same-surface fencing
- persist per-surface counters and report only the surface that crossed the configured limit
- document the governed repair under BI-9DC21917 / WC-7E4580C0 / DI-F858F9EB93E0

## Verification

- TDD red: 3 failed / 6 passed before the implementation
- focused blast-radius suite: 44 / 44 passed
- `node --check scripts/lib/local-ci-control-plane-watchdog.mjs`
- `git diff --check`
- `pnpm run pregate:preflight`: 52 / 52 guards clean
- semantic review: `cmt7vwpz40d8g01mg7u4e2ffk` (pass)
- exact-tree local CI: `cmt7wy3450ds501mgef2wj5n3` (`fix/local-ci-control-plane-fencing@7e11322d9370288ca2dabc099a19fc812efee79e`, PASS)

The first exact run preserved the same-surface fail-closed boundary and recorded a real two-sample MCP outage as infrastructure evidence. A subsequent attempt was externally fenced by a governed self-upgrade drain. After the coordinator terminated and quiescence returned to normal, the unchanged exact tree passed the full gate.

Local-CI-Evidence: cmt7wy3450ds501mgef2wj5n3 (fix/local-ci-control-plane-fencing@7e11322d9370288ca2dabc099a19fc812efee79e)
