### PR TITLE
fix(mcp): preserve threadless initiative review bindings

### DIFF
--- a/apps/web/lib/mcp-task-submit.test.ts
+++ b/apps/web/lib/mcp-task-submit.test.ts
@@ -504,6 +504,40 @@ describe("submitRemoteCoworkerTask idempotency", () => {
     }));
   });
 
+  it("rejects an immutable binding whose BI is not in the exact authority scope", async () => {
+    const outcome = await submit("PAT-BINDING-MISMATCH", {
+      agentId: "AGT-WS-BUILD",
+      routeContext: "/build/work/WC-7FF8A505",
+      objective: "Record the immutable research review.",
+      prompt: "Read the source and record the governed evidence.",
+      idempotencyKey: "research-review-binding-mismatch",
+      riskClass: "bounded-write",
+      authorityScope: [
+        "backlog-item:BI-OTHER",
+        "tool:read_source_at_version",
+        "tool:record_initiative_evidence",
+      ],
+      initiativeReviewBinding: {
+        writerToolName: "record_initiative_evidence",
+        itemId: "BI-F0715C9C",
+        gate: "research",
+        artifactRef: {
+          kind: "repo-blob-at-commit",
+          repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+          commitSha: "d47536a552c7d588b2f963e478ae99369f720783",
+          path: "docs/superpowers/specs/2026-08-23-initiative-readiness-traversal-repair-design.md",
+          providerBlobId: "fb57e087c19ce0a3c78b4d591bb5da63027c2b3b",
+        },
+      },
+    });
+
+    expect(outcome).toMatchObject({
+      kind: "invalid_params",
+      message: expect.stringContaining("item must match the backlog authority scope"),
+    });
+    expect(autonomous.resolveAgent).not.toHaveBeenCalled();
+  });
+
   it("server-binds the spec baseline precondition instead of exposing it to the reviewer model", async () => {
     const writer = {
       name: "record_initiative_design_review",

--- a/apps/web/lib/mcp-task-submit.test.ts
+++ b/apps/web/lib/mcp-task-submit.test.ts
@@ -472,6 +472,29 @@ describe("submitRemoteCoworkerTask idempotency", () => {
       "record_initiative_evidence",
     ]);
     expect(execution.deferredTools).toEqual([]);
+    const reader = execution.tools.find((tool) => tool.name === "read_source_at_version")!;
+    expect(reader.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        path: { type: "string", enum: [initiativeReviewBinding.artifactRef.path] },
+        version: { type: "string", enum: [initiativeReviewBinding.artifactRef.commitSha] },
+      },
+      required: ["path", "version"],
+      additionalProperties: false,
+    });
+    const providerReader = execution.toolsForProvider.find((tool) => tool.function?.name === "read_source_at_version")!;
+    expect(providerReader.function?.parameters).toEqual(reader.inputSchema);
+    const searchReader = execution.tools.find((tool) => tool.name === "search_source_at_version")!;
+    expect(searchReader.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        query: expect.any(Object),
+        version: { type: "string", enum: [initiativeReviewBinding.artifactRef.commitSha] },
+        glob: { type: "string", enum: [initiativeReviewBinding.artifactRef.path] },
+      },
+      required: ["query", "version", "glob"],
+      additionalProperties: false,
+    });
     const writer = execution.tools.find((tool) => tool.name === "record_initiative_evidence")!;
     expect(writer.inputSchema.properties).toEqual(expect.objectContaining({
       decision: expect.any(Object),

--- a/apps/web/lib/mcp-task-submit.test.ts
+++ b/apps/web/lib/mcp-task-submit.test.ts
@@ -498,29 +498,23 @@ describe("submitRemoteCoworkerTask idempotency", () => {
     const writer = execution.tools.find((tool) => tool.name === "record_initiative_evidence")!;
     expect(writer.inputSchema.properties).toEqual(expect.objectContaining({
       decision: expect.any(Object),
-      reason: expect.any(Object),
-      findings: expect.any(Object),
-      resolvedFindingRefs: expect.any(Object),
     }));
     expect(writer.inputSchema.properties).not.toHaveProperty("itemId");
     expect(writer.inputSchema.properties).not.toHaveProperty("gate");
     expect(writer.inputSchema.properties).not.toHaveProperty("artifactRef");
-    expect(writer.inputSchema.required).toEqual(["decision", "reason", "findings", "resolvedFindingRefs"]);
+    expect(writer.inputSchema.properties).not.toHaveProperty("findings");
+    expect(writer.inputSchema.properties).not.toHaveProperty("resolvedFindingRefs");
+    expect(writer.inputSchema.properties).not.toHaveProperty("reason");
+    expect(writer.inputSchema.required).toEqual(["decision"]);
     const providerWriter = execution.toolsForProvider.find((tool) => tool.function?.name === "record_initiative_evidence")!;
     expect(providerWriter.function?.parameters?.properties).toEqual(writer.inputSchema.properties);
     expect(providerWriter.function?.parameters?.required).toEqual(writer.inputSchema.required);
     const dryWriterArguments = JSON.stringify({
       decision: "pass",
-      reason: "Complete.",
-      findings: [],
-      resolvedFindingRefs: [],
     });
     expect(dryWriterArguments.length).toBeLessThan(138);
     expect(JSON.parse(dryWriterArguments)).toEqual({
       decision: "pass",
-      reason: "Complete.",
-      findings: [],
-      resolvedFindingRefs: [],
     });
     expect(autonomous.create).toHaveBeenCalledWith(expect.objectContaining({
       metadata: expect.objectContaining({ initiativeReviewBinding }),

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -32,7 +32,7 @@ export type RemoteTaskSubmitParams = {
   initiativeReviewBinding?: InitiativeReviewBinding;
 };
 
-type InitiativeReviewBinding = {
+export type InitiativeReviewBinding = {
   writerToolName: string;
   itemId: string;
   gate: string;
@@ -84,7 +84,7 @@ function requiresInitiativeReviewEffort(toolNames: readonly string[]): boolean {
   return researchWriterRequired || independentReviewWriterRequired;
 }
 
-function parseInitiativeReviewBinding(value: unknown): InitiativeReviewBinding | null {
+export function parseInitiativeReviewBinding(value: unknown): InitiativeReviewBinding | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const binding = value as Record<string, unknown>;
   const artifact = binding["artifactRef"];
@@ -126,6 +126,20 @@ function parseInitiativeReviewBinding(value: unknown): InitiativeReviewBinding |
       providerBlobId,
     },
   };
+}
+
+export function validateInitiativeReviewAuthorityScope(
+  binding: InitiativeReviewBinding,
+  authorityScope: readonly string[] | undefined,
+): string | null {
+  const exactTools = requiredToolNames(authorityScope);
+  if (!exactTools.includes(binding.writerToolName)) {
+    return "initiativeReviewBinding writer must match the exact tool authority scope";
+  }
+  if (!authorityScope?.includes(`backlog-item:${binding.itemId}`)) {
+    return "initiativeReviewBinding item must match the backlog authority scope";
+  }
+  return null;
 }
 
 function narrowInitiativeReviewTools<T extends {
@@ -211,11 +225,8 @@ export function parseRemoteTaskSubmitParams(params: Record<string, unknown> | un
     return "tasks/submit requires a valid immutable initiativeReviewBinding";
   }
   if (initiativeReviewBinding) {
-    const exactTools = requiredToolNames(authorityScope);
-    if (
-      !exactTools.includes(initiativeReviewBinding.writerToolName)
-      || !authorityScope?.includes(`backlog-item:${initiativeReviewBinding.itemId}`)
-    ) return "tasks/submit initiativeReviewBinding must match the exact tool and backlog authority scope";
+    const scopeError = validateInitiativeReviewAuthorityScope(initiativeReviewBinding, authorityScope);
+    if (scopeError) return `tasks/submit ${scopeError}`;
   }
 
   return {

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -177,11 +177,42 @@ function narrowInitiativeReviewTools<T extends {
       required: requiredJudgmentNames,
     };
   };
+  const narrowReaderSchema = (name: string, schema: Record<string, unknown>) => {
+    const properties = schema.properties && typeof schema.properties === "object" && !Array.isArray(schema.properties)
+      ? schema.properties as Record<string, unknown>
+      : {};
+    if (name === "read_source_at_version") {
+      return {
+        type: "object",
+        properties: {
+          path: { type: "string", enum: [binding.artifactRef.path] },
+          version: { type: "string", enum: [binding.artifactRef.commitSha] },
+        },
+        required: ["path", "version"],
+        additionalProperties: false,
+      };
+    }
+    if (name === "search_source_at_version") {
+      return {
+        type: "object",
+        properties: {
+          query: properties["query"] ?? { type: "string" },
+          version: { type: "string", enum: [binding.artifactRef.commitSha] },
+          glob: { type: "string", enum: [binding.artifactRef.path] },
+        },
+        required: ["query", "version", "glob"],
+        additionalProperties: false,
+      };
+    }
+    return schema;
+  };
+  const boundSchema = (name: string, schema: Record<string, unknown>) =>
+    name === binding.writerToolName
+      ? narrowSchema(schema)
+      : narrowReaderSchema(name, schema);
   const tools = input.tools
     .filter((tool) => exactNames.has(tool.name))
-    .map((tool) => tool.name === binding.writerToolName
-      ? { ...tool, inputSchema: narrowSchema(tool.inputSchema) }
-      : tool);
+    .map((tool) => ({ ...tool, inputSchema: boundSchema(tool.name, tool.inputSchema) }));
   const toolsForProvider = input.toolsForProvider
     .filter((entry) => {
       const fn = entry["function"];
@@ -190,9 +221,8 @@ function narrowInitiativeReviewTools<T extends {
     })
     .map((entry) => {
       const fn = entry["function"] as Record<string, unknown>;
-      return fn["name"] === binding.writerToolName
-        ? { ...entry, function: { ...fn, parameters: narrowSchema((fn["parameters"] ?? {}) as Record<string, unknown>) } }
-        : entry;
+      const name = String(fn["name"] ?? "");
+      return { ...entry, function: { ...fn, parameters: boundSchema(name, (fn["parameters"] ?? {}) as Record<string, unknown>) } };
     });
   return { ...input, tools, toolsForProvider, deferredTools: [] };
 }

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -149,19 +149,18 @@ function narrowInitiativeReviewTools<T extends {
 }>(input: T, requiredNames: readonly string[], binding: InitiativeReviewBinding | undefined): T {
   if (!binding) return input;
   const exactNames = new Set(requiredNames);
+  const compactResearchReceipt = binding.gate === "research"
+    && binding.writerToolName === "record_initiative_evidence";
+  const baseJudgmentNames = compactResearchReceipt
+    ? ["decision"]
+    : ["decision", "reason", "findings", "resolvedFindingRefs"];
   const judgmentPropertyNames = [
-    "decision",
-    "reason",
-    "findings",
-    "resolvedFindingRefs",
+    ...baseJudgmentNames,
     ...(binding.gate === "spec-approval" ? ["profile", "artifactRole", "supersessionDispositions"] : []),
     ...(binding.gate === "classification" ? ["profile"] : []),
   ];
   const requiredJudgmentNames = [
-    "decision",
-    "reason",
-    "findings",
-    "resolvedFindingRefs",
+    ...baseJudgmentNames,
     ...(binding.gate === "spec-approval" ? ["profile", "artifactRole"] : []),
     ...(binding.gate === "classification" ? ["profile"] : []),
   ];
@@ -169,12 +168,14 @@ function narrowInitiativeReviewTools<T extends {
     const properties = schema.properties && typeof schema.properties === "object" && !Array.isArray(schema.properties)
       ? schema.properties as Record<string, unknown>
       : {};
+    const narrowedProperties = Object.fromEntries(
+      judgmentPropertyNames.flatMap((name) => name in properties ? [[name, properties[name]]] : []),
+    );
     return {
       type: "object",
-      properties: Object.fromEntries(
-        judgmentPropertyNames.flatMap((name) => name in properties ? [[name, properties[name]]] : []),
-      ),
+      properties: narrowedProperties,
       required: requiredJudgmentNames,
+      additionalProperties: false,
     };
   };
   const narrowReaderSchema = (name: string, schema: Record<string, unknown>) => {

--- a/apps/web/lib/mcp/external-coworker-task-adapter.test.ts
+++ b/apps/web/lib/mcp/external-coworker-task-adapter.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const remote = vi.hoisted(() => ({ submit: vi.fn() }));
-vi.mock("@/lib/mcp-task-submit", () => ({
+vi.mock("@/lib/mcp-task-submit", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/lib/mcp-task-submit")>(),
   submitRemoteCoworkerTask: (...args: unknown[]) => remote.submit(...args),
 }));
 
@@ -15,6 +16,19 @@ const verifiedContext = {
   callerClient: "claude-code/2.1",
   routeContext: "/platform/build",
   userContext: { platformRole: "developer", isSuperuser: false },
+};
+
+const initiativeReviewBinding = {
+  writerToolName: "record_initiative_evidence",
+  itemId: "BI-9DC21917",
+  gate: "research",
+  artifactRef: {
+    kind: "repo-blob-at-commit" as const,
+    repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+    commitSha: "6dad5759f9e88176c59fecd2c13e6d5b5bdd344d",
+    path: "docs/superpowers/plans/2026-08-24-local-ci-control-plane-fencing.md",
+    providerBlobId: "a".repeat(40),
+  },
 };
 
 beforeEach(() => {
@@ -67,6 +81,8 @@ describe("dispatchExternalCoworkerTask", () => {
       objective,
       requestKey: "initiative-review:BI-B131F357:544830a",
       title: "Independent initiative design review",
+      requiredToolNames: ["read_source_at_version", "record_initiative_evidence"],
+      initiativeReviewBinding,
       userId: "user-1",
       context: verifiedContext,
     });
@@ -83,10 +99,74 @@ describe("dispatchExternalCoworkerTask", () => {
         prompt: objective,
         idempotencyKey: "initiative-review:BI-B131F357:544830a",
         riskClass: "bounded-write",
-        authorityScope: ["initiative_design_review"],
+        authorityScope: [
+          "initiative_design_review",
+          "backlog-item:BI-9DC21917",
+          "tool:read_source_at_version",
+          "tool:record_initiative_evidence",
+        ],
+        initiativeReviewBinding,
         collaborationKind: "summon",
       },
     });
+  });
+
+  it("rejects initiative-review tool widening before task submission", async () => {
+    const result = await dispatchExternalCoworkerTask({
+      collaborationKind: "handoff",
+      targetAgent: "AGT-WS-BUILD",
+      objective: "Review immutable control-plane evidence.",
+      requestKey: "initiative-review:BI-9DC21917:research:6dad5759",
+      requiredToolNames: [
+        "read_source_at_version",
+        "record_initiative_evidence",
+        "search_tool_marketplace",
+      ],
+      initiativeReviewBinding,
+      userId: "user-1",
+      context: verifiedContext,
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "invalid_initiative_review_packet",
+    });
+    expect(remote.submit).not.toHaveBeenCalled();
+  });
+
+  it("replaces generic tool and backlog scopes with the exact bound review scope", async () => {
+    remote.submit.mockResolvedValue({
+      kind: "result",
+      result: { taskRunId: "TR-MCP-BOUND", status: "working", isError: false },
+    });
+    await dispatchExternalCoworkerTask({
+      collaborationKind: "handoff",
+      targetAgent: "AGT-WS-BUILD",
+      objective: "Review immutable control-plane evidence.",
+      requestKey: "initiative-review:BI-9DC21917:research:6dad5759:bound",
+      requiredToolNames: ["read_source_at_version", "record_initiative_evidence"],
+      initiativeReviewBinding,
+      userId: "user-1",
+      context: {
+        ...verifiedContext,
+        tokenGrantScopes: [
+          "initiative_evidence_write",
+          "tool:search_tool_marketplace",
+          "backlog-item:BI-OTHER",
+        ],
+      },
+    });
+
+    expect(remote.submit).toHaveBeenCalledWith(expect.objectContaining({
+      params: expect.objectContaining({
+        authorityScope: [
+          "initiative_evidence_write",
+          "backlog-item:BI-9DC21917",
+          "tool:read_source_at_version",
+          "tool:record_initiative_evidence",
+        ],
+      }),
+    }));
   });
 
   it("preserves structured governance refusals from the task owner", async () => {

--- a/apps/web/lib/mcp/external-coworker-task-adapter.ts
+++ b/apps/web/lib/mcp/external-coworker-task-adapter.ts
@@ -1,6 +1,11 @@
 import type { UserContext } from "@/lib/permissions";
 import type { ToolExecutionContext, ToolResult } from "@/lib/mcp-tools";
-import { submitRemoteCoworkerTask } from "@/lib/mcp-task-submit";
+import {
+  parseInitiativeReviewBinding,
+  submitRemoteCoworkerTask,
+  validateInitiativeReviewAuthorityScope,
+  type InitiativeReviewBinding,
+} from "@/lib/mcp-task-submit";
 
 export type ExternalCoworkerTaskInput = {
   collaborationKind: "handoff" | "summon";
@@ -8,6 +13,8 @@ export type ExternalCoworkerTaskInput = {
   objective: string;
   requestKey?: string;
   title?: string;
+  requiredToolNames?: unknown;
+  initiativeReviewBinding?: unknown;
   userId: string;
   context?: ToolExecutionContext;
 };
@@ -33,6 +40,44 @@ function verifiedPatContext(context: ToolExecutionContext | undefined): {
     capability: context.tokenScope === "write" || context.tokenScope === "admin" ? "write" : "read",
     userContext: context.userContext,
   };
+}
+
+type InitiativeReviewPacket = {
+  binding: InitiativeReviewBinding;
+  authorityScope: string[];
+};
+
+function initiativeReviewPacket(input: ExternalCoworkerTaskInput): InitiativeReviewPacket | string | null {
+  const hasBinding = input.initiativeReviewBinding !== undefined;
+  const hasRequiredTools = input.requiredToolNames !== undefined;
+  if (!hasBinding && !hasRequiredTools) return null;
+  if (!hasBinding || !hasRequiredTools || !Array.isArray(input.requiredToolNames)) {
+    return "initiativeReviewBinding and requiredToolNames must be supplied together";
+  }
+
+  const binding = parseInitiativeReviewBinding(input.initiativeReviewBinding);
+  if (!binding) return "initiativeReviewBinding is not a valid immutable repository binding";
+  const names = [...new Set(input.requiredToolNames.flatMap((value) =>
+    typeof value === "string" && value.trim() ? [value.trim()] : []))];
+  const allowedReaders = new Set(["read_source_at_version", "search_source_at_version"]);
+  if (
+    names.length < 2
+    || names.length > 4
+    || !names.includes(binding.writerToolName)
+    || !names.some((name) => allowedReaders.has(name))
+    || names.some((name) => name !== binding.writerToolName && !allowedReaders.has(name))
+  ) {
+    return "requiredToolNames must contain only the bound writer and one or both immutable source readers";
+  }
+
+  const authorityScope = [
+    ...(input.context?.tokenGrantScopes ?? []).filter((scope) =>
+      !scope.startsWith("tool:") && !scope.startsWith("backlog-item:")),
+    `backlog-item:${binding.itemId}`,
+    ...names.map((name) => `tool:${name}`),
+  ];
+  const scopeError = validateInitiativeReviewAuthorityScope(binding, authorityScope);
+  return scopeError ? scopeError : { binding, authorityScope };
 }
 
 /**
@@ -61,6 +106,16 @@ export async function dispatchExternalCoworkerTask(input: ExternalCoworkerTaskIn
     };
   }
 
+  const reviewPacket = initiativeReviewPacket(input);
+  if (typeof reviewPacket === "string") {
+    return {
+      success: false,
+      error: "invalid_initiative_review_packet",
+      message: reviewPacket,
+      data: { action: "Use the exact server-issued readiness packet without adding tools or changing immutable identity." },
+    };
+  }
+
   let outcome: Awaited<ReturnType<typeof submitRemoteCoworkerTask>>;
   try {
     outcome = await submitRemoteCoworkerTask({
@@ -79,7 +134,8 @@ export async function dispatchExternalCoworkerTask(input: ExternalCoworkerTaskIn
         prompt: input.objective,
         idempotencyKey: requestKey,
         riskClass: "bounded-write",
-        authorityScope: input.context?.tokenGrantScopes ?? [],
+        authorityScope: reviewPacket?.authorityScope ?? input.context?.tokenGrantScopes ?? [],
+        ...(reviewPacket ? { initiativeReviewBinding: reviewPacket.binding } : {}),
         collaborationKind: input.collaborationKind,
       },
     });

--- a/apps/web/lib/mcp/packs/coworker-pack.test.ts
+++ b/apps/web/lib/mcp/packs/coworker-pack.test.ts
@@ -18,6 +18,19 @@ import { TOOL_TO_GRANTS } from "@/lib/tak/agent-grants";
 
 const EXPECTED_TOOLS = ["request_coworker", "summon_coworker", "find_coworker"];
 
+const initiativeReviewBinding = {
+  writerToolName: "record_initiative_evidence",
+  itemId: "BI-9DC21917",
+  gate: "research",
+  artifactRef: {
+    kind: "repo-blob-at-commit",
+    repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+    commitSha: "6dad5759f9e88176c59fecd2c13e6d5b5bdd344d",
+    path: "docs/superpowers/plans/2026-08-24-local-ci-control-plane-fencing.md",
+    providerBlobId: "a".repeat(40),
+  },
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   external.dispatch.mockResolvedValue({
@@ -55,6 +68,12 @@ describe("coworker pack — registration", () => {
     const schema = coworkerPack.definitions.find((definition) => definition.name === toolName)?.inputSchema;
     expect(schema?.properties).toHaveProperty("requestKey");
   });
+
+  it.each(["request_coworker", "summon_coworker"])("%s advertises the immutable initiative-review packet", (toolName) => {
+    const schema = coworkerPack.definitions.find((definition) => definition.name === toolName)?.inputSchema;
+    expect(schema?.properties).toHaveProperty("requiredToolNames");
+    expect(schema?.properties).toHaveProperty("initiativeReviewBinding");
+  });
 });
 
 describe("coworker pack — handler behavior (delegation preserved)", () => {
@@ -86,6 +105,8 @@ describe("coworker pack — handler behavior (delegation preserved)", () => {
           objective,
           questionPacketSummary: "Independent immutable design review",
           requestKey: "initiative-review:BI-B131F357:544830a",
+          requiredToolNames: ["read_source_at_version", "record_initiative_evidence"],
+          initiativeReviewBinding,
         },
         "u1",
         {
@@ -104,6 +125,8 @@ describe("coworker pack — handler behavior (delegation preserved)", () => {
         objective,
         requestKey: "initiative-review:BI-B131F357:544830a",
         title: "Independent immutable design review",
+        requiredToolNames: ["read_source_at_version", "record_initiative_evidence"],
+        initiativeReviewBinding,
         userId: "u1",
       }));
       expect(collab.requestCoworker).not.toHaveBeenCalled();
@@ -181,6 +204,8 @@ describe("coworker pack — handler behavior (delegation preserved)", () => {
         targetAgent: "AGT-WS-REVIEW",
         objective,
         requestKey: "initiative-review:BI-B131F357:spec-approval:544830a",
+        requiredToolNames: ["read_source_at_version", "record_initiative_evidence"],
+        initiativeReviewBinding,
       },
       "u1",
       {
@@ -197,6 +222,8 @@ describe("coworker pack — handler behavior (delegation preserved)", () => {
       collaborationKind: "summon",
       targetAgent: "AGT-WS-REVIEW",
       objective,
+      requiredToolNames: ["read_source_at_version", "record_initiative_evidence"],
+      initiativeReviewBinding,
     }));
     expect(collab.summonCoworker).not.toHaveBeenCalled();
   });

--- a/apps/web/lib/mcp/packs/coworker-pack.ts
+++ b/apps/web/lib/mcp/packs/coworker-pack.ts
@@ -15,6 +15,37 @@ import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
 import { dispatchExternalCoworkerTask } from "@/lib/mcp/external-coworker-task-adapter";
 
+const initiativeReviewProperties = {
+  requiredToolNames: {
+    type: "array",
+    items: { type: "string" },
+    maxItems: 4,
+    description: "Exact immutable reader and governed writer names from a server-issued initiative-readiness recovery packet.",
+  },
+  initiativeReviewBinding: {
+    type: "object",
+    properties: {
+      writerToolName: { type: "string" },
+      itemId: { type: "string" },
+      gate: { type: "string" },
+      expectedCurrentBaselineId: { type: ["string", "null"] },
+      artifactRef: {
+        type: "object",
+        properties: {
+          kind: { type: "string", enum: ["repo-blob-at-commit"] },
+          repositoryFullName: { type: "string" },
+          commitSha: { type: "string" },
+          path: { type: "string" },
+          providerBlobId: { type: "string" },
+        },
+        required: ["kind", "repositoryFullName", "commitSha", "path", "providerBlobId"],
+      },
+    },
+    required: ["writerToolName", "itemId", "gate", "artifactRef"],
+    description: "Server-validated immutable initiative-review identity. Supply only with requiredToolNames from the same recovery packet.",
+  },
+} as const;
+
 const definitions: ToolDefinition[] = [
   {
     name: "request_coworker",
@@ -29,6 +60,7 @@ const definitions: ToolDefinition[] = [
         tier: { type: "number", enum: [2, 3], description: "Interaction tier (default 2). Tier 3 requires depth-2 spawn support." },
         enteredVia: { type: "string", enum: ["handoff", "escalation", "spawn"], description: "How the peer is entering (default 'handoff')." },
         requestKey: { type: "string", description: "Stable idempotency key required for threadless external MCP handoffs." },
+        ...initiativeReviewProperties,
       },
       required: ["targetAgent", "objective"],
     },
@@ -51,6 +83,7 @@ const definitions: ToolDefinition[] = [
         objective: { type: "string", description: "What the summoned coworker should address." },
         tier: { type: "number", enum: [2, 3], description: "Interaction tier (default 2)." },
         requestKey: { type: "string", description: "Stable idempotency key required for threadless external MCP summons." },
+        ...initiativeReviewProperties,
       },
       required: ["targetAgent", "objective"],
     },
@@ -100,6 +133,8 @@ async function requestCoworkerHandler(
       objective,
       requestKey: typeof params["requestKey"] === "string" ? params["requestKey"] : undefined,
       title: typeof params["questionPacketSummary"] === "string" ? params["questionPacketSummary"] : undefined,
+      requiredToolNames: params["requiredToolNames"],
+      initiativeReviewBinding: params["initiativeReviewBinding"],
       userId,
       context,
     });
@@ -148,6 +183,8 @@ async function summonCoworkerHandler(
       targetAgent,
       objective,
       requestKey: typeof params["requestKey"] === "string" ? params["requestKey"] : undefined,
+      requiredToolNames: params["requiredToolNames"],
+      initiativeReviewBinding: params["initiativeReviewBinding"],
       userId,
       context,
     });

--- a/apps/web/lib/mcp/packs/initiative-readiness-pack.test.ts
+++ b/apps/web/lib/mcp/packs/initiative-readiness-pack.test.ts
@@ -112,9 +112,6 @@ describe("initiative readiness reviewer tools", () => {
       gate: "classification",
       artifactRef: { kind: "document-version", versionId: "spoofed" },
       decision: "pass",
-      reason: "The immutable evidence is complete.",
-      findings: [],
-      resolvedFindingRefs: [],
     }, "user-1", {
       taskRunId: "TR-MCP-BOUND",
       agentId: "AGT-WS-BUILD",
@@ -130,6 +127,9 @@ describe("initiative readiness reviewer tools", () => {
       gate: "research",
       artifactRef,
       decision: "pass",
+      findings: [],
+      resolvedFindingRefs: [],
+      reason: "Independent reviewer AGT-WS-BUILD recorded pass for the immutable research artifact bound to TaskRun TR-MCP-BOUND.",
     }));
     expect(result).toMatchObject({ success: true, entityId: "IRR-RESEARCH-1" });
   });

--- a/apps/web/lib/mcp/packs/initiative-readiness-pack.ts
+++ b/apps/web/lib/mcp/packs/initiative-readiness-pack.ts
@@ -240,6 +240,13 @@ function handlerFor(actionKey: string, lane: Lane): ToolPackHandler {
         ...(Object.prototype.hasOwnProperty.call(binding, "expectedCurrentBaselineId")
           ? { expectedCurrentBaselineId: binding.expectedCurrentBaselineId }
           : {}),
+        ...(actionKey === "record_initiative_evidence" && binding.gate === "research"
+          ? {
+              findings: [],
+              resolvedFindingRefs: [],
+              reason: `Independent reviewer ${context?.agentId ?? "unknown"} recorded ${String(params.decision ?? "unknown")} for the immutable research artifact bound to TaskRun ${context?.taskRunId ?? "unknown"}.`,
+            }
+          : {}),
       };
     }
     const operation = params.operation ?? "gate-receipt";


### PR DESCRIPTION
## Summary

- preserve the server-issued immutable initiative-review binding across threadless `request_coworker` and `summon_coworker` handoffs
- reuse `mcp-task-submit` validation and exact-tool narrowing so bundled local reviewers receive only the bound reader and writer tools
- bind source reads and derive research receipt identity fields on the server, preventing caller or model widening

## Why

The external coworker adapter discarded `initiativeReviewBinding`. The downstream task submitter therefore could not activate its existing narrow review path and exposed 16 generic tools, exceeding the bundled-local tool-surface limit before inference. The eligible evaluated Qwen3.8 27B reviewer executed zero tools and could not write governed evidence.

This change carries the existing packet through the adapter. It does not change grants, the 70/70/70 model floor, the local tool-selection cliff, or ordinary external coworker behavior.

## Verification

- focused Vitest: 45/45 passed on the current merged tree
- web typecheck passed
- pregate preflight: 52/52 passed
- governed preview: TaskRun `TR-MCP-Y210N3ZpeHBvMDAwMDJqbmRsM3JydmUydg-06BB4A44F962` executed the immutable source read and persisted receipt `initiative-314a0b5a-90ba-4600-9288-6627ed5bb9b0`
- exact-tree local CI passed for `0c43078dd103e086323b0ea957be9c5f40a4b820`

## Design grounding

Reviewed `docs/superpowers/specs/2026-08-23-initiative-readiness-traversal-repair-design.md`, `docs/superpowers/plans/2026-08-23-initiative-readiness-traversal-repair.md`, and the current `mcp-task-submit`, external coworker adapter, coworker pack, and initiative-readiness pack substrate. `mcp-task-submit` remains the authority, immutable-binding validator, and exact-tool narrowing owner; the handoff layers only preserve its existing governed packet.

Process-Spine-Decision: localized repair to an existing governed reviewer contract; no new lifecycle, policy, or documentation surface is introduced.

Design-Grounding-Decision: reviewed docs/superpowers/specs/2026-08-23-initiative-readiness-traversal-repair-design.md, docs/superpowers/plans/2026-08-23-initiative-readiness-traversal-repair.md, and code substrate apps/web/lib/mcp-task-submit.ts plus the external coworker and initiative-readiness MCP packs; reuse the existing immutable binding and narrowing authority.

Local-CI-Evidence: cmt7yi0uk0elo01mgcsurwko1 (fix/threadless-initiative-review-binding@0c43078dd103e086323b0ea957be9c5f40a4b820)

## Checklist

- [x] commits include DCO sign-off
- [x] focused tests and typecheck pass
- [x] `pnpm run pregate:preflight` passes
- [x] `pnpm run pregate` passes for the exact PR head
- [x] independent semantic review recorded; zero findings, infrastructure-inconclusive with policy `mayPublish=true`
