### PR TITLE
fix(ci): bypass heavy gates for exact docs trees

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1665,6 +1665,7 @@
       "docs/testing/archetype-audit-plan.md"
     ],
     "scripts/gate-worktree.mjs": [
+      "docs/architecture/context-engineering-standards.md",
       "docs/testing/pre-pr-gate.md"
     ],
     "scripts/gate-worktree.sh": [
@@ -2315,6 +2316,7 @@
       "apps/web/lib/tool-description-hygiene.test.ts",
       "packages/dpf-skill-pack/hooks/tool-economy-precheck.mjs",
       "scripts/check-instruction-plane-size.mjs",
+      "scripts/gate-worktree.mjs",
       "scripts/lib/ci-policy-guards.mjs"
     ],
     "docs/architecture/contributor-procedure-runbook.md": [

--- a/config/ci-evidence-policy.json
+++ b/config/ci-evidence-policy.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "policyVersion": "2026-08-24.1",
-  "plannerVersion": "1.0.0-shadow",
-  "mode": "shadow",
+  "policyVersion": "2026-08-24.2",
+  "plannerVersion": "1.1.0",
+  "mode": "authoritative-docs",
   "selectionThresholdPercent": 70,
   "graphAdviceSchemaVersion": 1,
   "requiredGraphRelationships": [

--- a/docs/architecture/context-engineering-standards.md
+++ b/docs/architecture/context-engineering-standards.md
@@ -13,7 +13,7 @@ DPF is **local-first by founder strategy**: cloud frontier models are disabled b
 
 - **The local-window contract.** One DMR llama-server, one generation model, ~24,576 tokens. Anything that silently consumes that budget (an unbounded tool result, 50K of tool definitions, a forgotten plan) is an *existential* failure mode, not an inefficiency.
 - **The tool-count cliff.** Tool-selection accuracy collapses past ~15 tools on small local models — encoded as `LOCAL_FALLBACK_MAX_TOOLS = 15` (`apps/web/lib/routing/fallback.ts`). Above it, local fallback is skipped entirely.
-- **The host-capacity boundary.** While governed local CI owns the installation host, the common provider adapter defers new local completion/embedding dispatch and `fallback.ts` may continue to an eligible cloud route. This policy is grounded in the observed overlap between provider/model residency and the Windows free-memory fence; Docker model residency, GPU VRAM, WSL/shared memory, and Windows physical memory remain separate measurements.
+- **The host-capacity boundary.** While governed local CI owns the installation host, the common provider adapter defers new local completion/embedding dispatch and `fallback.ts` may continue to an eligible cloud route. Exact documentation-only trees run their planner-bound evidence before admission and never reserve that host lane; missing or ambiguous classification falls back to exhaustive CI. This policy is grounded in the observed overlap between provider/model residency and the Windows free-memory fence; Docker model residency, GPU VRAM, WSL/shared memory, and Windows physical memory remain separate measurements.
 - **The cheapest token is the one we never process.** Every reduction (just-in-time loading, in-environment filtering, concise results) compounds with caching and tiering.
 
 ## The three laws
@@ -50,6 +50,7 @@ The criteria apply to future changes automatically, not by memory:
 3. **Shift-left precheck (P5/P6).** `packages/dpf-skill-pack/hooks/tool-economy-precheck.mjs` fires (Claude/Codex/Grok) when `mcp-tools.ts`, the MCP route, the agentic loop, or the budget module is edited, re-asserting these criteria before CI.
 4. **Review tie-in.** `docs/architecture/agent-standards-dpf-conformance.md` carries a Context Economy control area so spec/architecture reviews check P1–P13.
 5. **Attachment budget on every model path.** The per-turn tool-attachment budget (`apps/web/lib/actions/coworker-tool-budget.ts` — window-fit + local selection-cliff cap, `load_tools` deferral) applies to interactive chat AND to every autonomous run: scheduled tasks, dispatcher child threads, and remote MCP task submission all budget through `resolveAutonomousWorkTools` (BI-CAP-F2D39F8F). A coworker whose grants expand past the cap keeps full authority; the long tail loads on demand.
+6. **Admission follows authoritative evidence scope.** `scripts/gate-worktree.mjs` lets an exact, clean, up-to-date documentation tree complete doc-index, link, and repository-guard evidence before the scarce `local-integration-ci` lease. The CI evidence planner is authoritative; any stale base, non-documentation path, workspace-required document, or planner uncertainty routes to exhaustive verification.
 
 ## How to apply (quick checklist when changing a model-facing surface)
 

--- a/docs/superpowers/plans/2026-08-24-resilient-gate-flow-control.md
+++ b/docs/superpowers/plans/2026-08-24-resilient-gate-flow-control.md
@@ -1,0 +1,165 @@
+# Resilient Gate Flow-Control Implementation Plan
+
+**Program:** `BI-7C1F43E3`
+
+**Decision:** `DI-83C76A3C1B58`
+
+**Canonical design:** `docs/superpowers/specs/2026-08-15-resilient-concurrent-development-process.md`
+
+## Outcome
+
+Increase delivery throughput without reducing evidence quality by moving wait state into the platform, selecting verification work before heavyweight admission, and coalescing equivalent immutable work. The measured starting point is four pull requests in seven hours and 1,222 estimated waiting calls among 1,297 nonproduction lease calls.
+
+## Invariants
+
+- A pass is valid only for its exact integration tree, evidence-plan digest, toolchain fingerprint, and gate kind.
+- Missing or untrusted impact data expands verification; it never suppresses it.
+- Queued work remains live without a client process or polling heartbeat.
+- Existing Workroom, lease, task, queue telemetry, and evidence records remain canonical.
+- Every change is independently deployable and reversible.
+- Documentation, UX, migration, and operator-facing behavior are explicit blast-radius dimensions.
+
+## Slice 1 — Authoritative evidence lanes (`BI-B2E9FC9D`)
+
+### Requirements
+
+- `REQ-LANE-1`: classify an immutable candidate/integration tree before claiming a heavyweight lease.
+- `REQ-LANE-2`: documentation-only work runs the exact documentation evidence contract without a heavyweight lease.
+- `REQ-LANE-3`: affected work runs mapped evidence; unsafe input expands to exhaustive.
+- `REQ-LANE-4`: recorded evidence contains lane, plan digest, selected commands, tree identity, and escalation reasons.
+
+### Implementation
+
+1. Add a pure execution-lane projection to `scripts/lib/ci-evidence-plan.mjs` and contract tests for documentation, affected, and exhaustive plans.
+2. Split `createLocalIntegrationPlan` into merge/setup, global guards, affected/exhaustive verification, and production-build command groups. Select groups from a supplied evidence plan rather than always appending full Vitest and build.
+3. Add a pre-admission planner step to `scripts/gate-worktree.mjs`. A clean documentation plan runs in a unique lightweight integration worktree and records evidence without calling `claim_nonprod_environment_lease`.
+4. Keep exhaustive admission fail-closed when the planner cannot resolve the base, tree, policy, derived artifacts, or graph advice.
+5. Persist the evidence-plan digest and lane in local-CI metadata and governed result evidence.
+
+### Verification
+
+- `node --test scripts/lib/ci-evidence-plan.test.mjs`
+- `node --test scripts/lib/local-integration-ci.test.mjs`
+- `node --test scripts/gate-worktree-lease.test.mjs`
+- Doc index/link/guard checks from the change-impact contract.
+- Exact-tree pregate for runtime script changes.
+
+## Slice 2 — Immutable single-flight (`BI-6A5AB570`)
+
+### Requirements
+
+- `REQ-SF-1`: one executor per `(repository, tree, plan, toolchain, gateKind)`.
+- `REQ-SF-2`: concurrent callers subscribe to or reuse the existing run.
+- `REQ-SF-3`: a new branch commit supersedes only nonterminal requests for the older tree.
+
+### Implementation
+
+1. Derive `gateKey` once. Use it as the transactional lease `claimKey`, and persist it on task/evidence activity for lookup and audit. Add a schema index only if query measurements require one.
+2. Make claim transactional: return `reused`, `admitted`, `queued`, or `blocked` with the canonical task/lease identity.
+3. Apply the same identity to independent semantic review and exact-tree CI receipts.
+4. Add concurrency race tests and immutable-receipt reuse tests.
+
+### Verification
+
+- Parallel claim test proves one executor and N subscribers.
+- Same tree/policy/toolchain reuses a valid result.
+- Any identity component change produces a distinct run.
+
+## Slice 3 — Durable wait and resume (`BI-MCP-EFF-0285909C`)
+
+### Requirements
+
+- `REQ-WAIT-1`: queued clients disconnect without losing position.
+- `REQ-WAIT-2`: release/capacity transitions wake server workflows and notify connected clients.
+- `REQ-WAIT-3`: missed notifications recover by bounded reconciliation.
+
+### Implementation
+
+1. Project lease admission as an MCP Task and expose full task state.
+2. Emit queue transition events from release, expiry, capacity change, and reconciliation paths.
+3. Suspend native workflows with Inngest `step.waitForEvent()` keyed to the task/claim.
+4. Publish MCP task status notifications over the existing Streamable HTTP/SSE path.
+5. Add a Codex host adapter that wakes the owning task; fall back to a five-minute reconciliation, never a 10-second claim loop.
+6. Move queued liveness to server-owned state and retain one fresh host-pressure claim after wake-up.
+
+### Verification
+
+- A queued task has no live client Node process after suspension.
+- One release produces one wake-up and one fresh claim.
+- Dropped SSE still resumes through reconciliation.
+- Waiting lease-call volume falls at least 95% in a soak test.
+
+## Slice 4 — Governed host resource lanes (`BI-30EDD4B0`)
+
+### Requirements
+
+- `REQ-RES-1`: TypeScript, Vitest, Next, Docker, preview, and inference declare resource class and expected memory.
+- `REQ-RES-2`: capacity uses host pressure and reserved inference memory.
+- `REQ-RES-3`: descendants terminate before resource release.
+
+### Implementation
+
+1. Extend the existing nonproduction admission policy to named resource lanes; do not create client-specific semaphores.
+2. Add measured peak working-set telemetry and configurable host reserve.
+3. Route all canonical script entry points through the resource broker.
+4. Detect ungoverned matching processes and return one actionable owner diagnostic.
+
+### Verification
+
+- Mixed compile/build/inference load stays within configured committed-memory budget.
+- A killed owner releases or expires without leaked descendants.
+- A process cannot bypass admission through an alternate client entry point.
+
+## Slice 5 — Workroom WIP and progress guarantees (`BI-114C1F40`)
+
+### Requirements
+
+- `REQ-WIP-1`: one canonical Workroom for a repository/branch across Windows path spellings.
+- `REQ-WIP-2`: waiting does not count as active execution WIP.
+- `REQ-WIP-3`: stalled work emits one deduplicated escalation with a recovery action.
+- `REQ-WIP-4`: readiness projections are versioned and self-identify stale inputs.
+
+### Implementation
+
+1. Canonicalize repository, branch, path, and root-session identity before Workroom lookup and persistence; merge safe duplicates through a governed repair.
+2. Add explicit `waiting(resource|review|input)` projections and transition timestamps.
+3. Enforce portfolio/resource-lane WIP limits at activation, not task creation.
+4. Add oldest-wait and no-transition monitors with owner routing and deduplication.
+5. Return `projection-stale` plus recomputation identity when readiness disagrees with canonical demand state.
+
+### Verification
+
+- `D:\path` and `D:/path` claims refresh one Workroom.
+- A durable waiter consumes no active execution slot.
+- A 30-minute no-transition simulation emits one alert, then resolves on progress.
+- Canonical classification cannot yield `CLASSIFICATION_REQUIRED` from the same versioned read.
+
+## Delivery and coverage map
+
+| Deliverable | Requirement refs | Contract refs | Flow refs | Verification refs | Depends on |
+| --- | --- | --- | --- | --- | --- |
+| `BI-B2E9FC9D` | `REQ-LANE-1..4` | Evidence lane table; exact evidence identity | Plan → lane → execute/claim | Slice 1 tests and exact-tree pregate | — |
+| `BI-6A5AB570` | `REQ-SF-1..3` | Gate run identity | Claim → reuse/subscribe/admit | Slice 2 race/reuse tests | `BI-B2E9FC9D` |
+| `BI-MCP-EFF-0285909C` | `REQ-WAIT-1..3` | Durable admission flow | Queue → suspend → event → fresh claim | Slice 3 disconnect/drop/soak tests | `BI-6A5AB570` |
+| `BI-30EDD4B0` | `REQ-RES-1..3` | Resource lanes | Declare → admit → supervise → release | Slice 4 memory/fence tests | `BI-B2E9FC9D` |
+| `BI-114C1F40` | `REQ-WIP-1..4` | Workroom identity and liveness | Active ↔ waiting → promotion | Slice 5 identity/SLO tests | `BI-6A5AB570`, `BI-MCP-EFF-0285909C` |
+
+## Rollout and rollback
+
+1. Ship lane selection in observe mode for non-documentation branches while making documentation bypass authoritative.
+2. Compare selected versus exhaustive evidence on a bounded sample; promote affected execution only after zero missed failures.
+3. Enable single-flight before durable client suspension so every waiter has one canonical run to observe.
+4. Enable notification adapters per client, retaining reconciliation throughout rollout.
+5. Introduce resource lanes one process family at a time and retain the existing local-CI fence as the rollback path.
+6. Enable WIP/SLO enforcement in report-only mode, then enforce after thresholds are calibrated.
+
+Rollback is configuration-first: force exhaustive planning, disable client suspension adapters, or restore one-slot resource policy. Immutable evidence and queue telemetry remain valid through rollback.
+
+## Success measures
+
+- Waiting claim/list calls reduced by at least 95%.
+- No duplicate review or CI execution for one immutable gate identity.
+- Documentation PRs do not enter the heavyweight queue.
+- Median and p95 time from implementation-complete to PR-open improve without increasing change-failure rate.
+- Host committed memory stays within the configured reserve while local inference is resident.
+- PR throughput improves from the 0.57 PR/hour baseline; report throughput together with lead time and failure rate, not as a vanity count.

--- a/docs/superpowers/plans/2026-08-24-resilient-gate-flow-control.md
+++ b/docs/superpowers/plans/2026-08-24-resilient-gate-flow-control.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Resilient Gate Flow-Control Implementation Plan
 
 **Program:** `BI-7C1F43E3`
@@ -32,7 +36,7 @@ Increase delivery throughput without reducing evidence quality by moving wait st
 
 1. Add a pure execution-lane projection to `scripts/lib/ci-evidence-plan.mjs` and contract tests for documentation, affected, and exhaustive plans.
 2. Split `createLocalIntegrationPlan` into merge/setup, global guards, affected/exhaustive verification, and production-build command groups. Select groups from a supplied evidence plan rather than always appending full Vitest and build.
-3. Add a pre-admission planner step to `scripts/gate-worktree.mjs`. A clean documentation plan runs in a unique lightweight integration worktree and records evidence without calling `claim_nonprod_environment_lease`.
+3. Add a pre-admission planner step to `scripts/gate-worktree.mjs`. When the clean candidate contains the accepted base, its tree is the exact integration tree: run documentation guards there and record evidence without calling `claim_nonprod_environment_lease`. Otherwise retain the existing exhaustive path.
 4. Keep exhaustive admission fail-closed when the planner cannot resolve the base, tree, policy, derived artifacts, or graph advice.
 5. Persist the evidence-plan digest and lane in local-CI metadata and governed result evidence.
 

--- a/docs/superpowers/specs/2026-08-15-resilient-concurrent-development-process.md
+++ b/docs/superpowers/specs/2026-08-15-resilient-concurrent-development-process.md
@@ -1,3 +1,7 @@
+---
+status: binding
+---
+
 # Resilient Concurrent Development Process
 
 **Surface-agnostic flow control for high-fan-out AI development**
@@ -70,11 +74,13 @@ The existing CI evidence planner becomes the admission authority. It evaluates t
 | Lane | Qualification | Runs | Shared heavyweight lease |
 | --- | --- | --- | --- |
 | **Plan-only** | Invalid/missing planner input or dry-run | Planner and diagnostics only; unresolved input escalates | No |
-| **Documentation** | `docsOnly=true`, no escalation | Doc index, link, derived-artifact, and repository guards in an isolated lightweight worktree | No |
+| **Documentation** | `docsOnly=true`, no escalation, clean exact candidate tree contains the accepted base | Doc index, link, derived-artifact, and repository guards in the candidate worktree | No |
 | **Affected code** | Planner is trusted and `fullSuite=false` | Global guards, affected package typechecks, mapped tests, changed-route UX evidence | Resource-specific lane only; no Docker/Next build lease |
 | **Exhaustive** | Risk escalation, unsafe graph, merge group, main, schedule, or explicit override | Full typecheck, full tests, production build, required integration and UX evidence | Yes; preferably elastic cloud execution |
 
 Documentation is not “no verification.” It is a smaller, exact, policy-defined evidence contract. An edit to workspace configuration, generated contracts, migration state, gate policy, or an unresolved derived artifact cannot enter the documentation lane.
+
+The first rollout admits the documentation lane only when `origin/main` is an ancestor of the clean candidate SHA, so the candidate tree is also the integration tree. A stale base, dirty worktree, unresolved tree, or planner escalation uses the existing exhaustive integration path. A later slice may synthesize a unique lightweight merge worktree; this slice does not claim evidence for a prospective tree it did not execute.
 
 The planner output records its lane, selected commands, reasons, affected tests/routes/packages, policy version, digest, and immutable tree. The executor must run that plan or fail; it may not silently replace an affected plan with an exhaustive one merely because exhaustive is easier to invoke.
 

--- a/docs/superpowers/specs/2026-08-15-resilient-concurrent-development-process.md
+++ b/docs/superpowers/specs/2026-08-15-resilient-concurrent-development-process.md
@@ -1,133 +1,160 @@
 # Resilient Concurrent Development Process
 
-**Surface-agnostic, enforce-by-construction pipeline for high-fan-out AI development**
+**Surface-agnostic flow control for high-fan-out AI development**
 
-- Epic: EP-056D2A5E (Resource contention & concurrency safety)
-- Gap BIs: BI-6C54223E (Stage 0) · BI-8D56F777 (Stages 2+4) · BI-3D4A7063 (Stage 3) · BI-9A353411 (Stage 5)
-- Cross-surface corpus mirror (retrievable via `doc_search`/`search_knowledge`): `DOC-C263E0C9`
-- Extends AGENTS.md §12 doctrine: "Four peer surfaces, one process" and "Governance approves evidence, not provenance."
+- Program: `BI-7C1F43E3` — Restore flow efficiency across DPF external-agent delivery gates
+- Epic: `EP-56AE0F69` — Reset/dogfood cycle 3: install, lifecycle, agent-host and CI-gate findings
+- Decision: `DI-83C76A3C1B58` — durable flow control selected with high confidence and no commandment conflict
+- Extends `AGENTS.md` doctrine: four peer surfaces, one process; governance approves evidence, not provenance.
 
----
+## 1. Problem and measured baseline
 
-## 1. Why this exists
+DPF needs high fan-out, but fan-out is useful only while work keeps moving. The current host ran continuously and produced four pull requests in seven hours: about 0.57 PR/hour. During the same investigation, nonproduction lease traffic contained 498 claims, 426 renewals, and 373 list calls. Of those 1,297 calls, 1,222 (about 94%) were estimated waiting overhead rather than useful state transitions.
 
-DPF development runs at very high fan-out — up to ~160 concurrent agent threads (2 systems × 4 clients × ~20 threads). That concurrency is the productivity multiplier (weeks-not-years) and is a **requirement, not a bug**. Two structural faults today:
+The bottleneck is not merely a two-slot gate. It is the shape of the work around the gate:
 
-1. **It is client-discretionary.** Whether a thread seeds its worktree correctly, verifies before pushing, or records evidence depends on *which* AI client (Claude/Codex/Grok/Antigravity/Build Studio) ran it and how rigorous that client was. Quality varies by surface.
-2. **It funnels every thread through one scarce, heavyweight, LOCAL resource** — a 2-slot, 16 GB-per-run Docker verification gate — which starves under high demand and exhausts host RAM.
+1. Waiting is implemented by live client processes that repeatedly call MCP.
+2. The CI evidence planner is advisory locally, so documentation and affected-only changes still enter the heavyweight lane.
+3. The same immutable tree can be reviewed or gated more than once when tasks race.
+4. Workroom identity is not canonical across path spellings. A Windows path written with `\` and `/` created two records for one branch, worktree, session, and task.
+5. Readiness projections can disagree with canonical demand state, leaving tasks unable to tell whether they should proceed, sleep, or escalate.
+6. Typecheck, Vitest, Next builds, Docker, model inference, and preview environments can compete for RAM outside one shared admission model.
 
-## 2. Binding constraints (a fix may not violate any)
+The result is a queue of active Node processes, tool traffic, memory pressure, and repeated reasoning around a small number of actual transitions.
 
-- **C1 — Concurrency is required.** Do not "run fewer threads." Preserve high fan-out.
-- **C2 — Low RAM.** Hosts cannot run many Docker images. Per-verification heavyweight Docker stacks are the wrong model.
-- **C3 — Bounded tokens.** The weekly token budget is spent in days at this fan-out. Improve throughput-per-token; do not require re-running the fan-out to validate.
+## 2. Binding constraints
 
-## 3. Governing principle: enforce by construction, not by client discretion
+- **C1 — Preserve useful concurrency.** Do not solve contention by imposing one global thread limit. Limit work-in-process at each constrained resource.
+- **C2 — Evidence may not weaken.** Every pass is bound to an immutable tree, policy, toolchain, and evidence tier. Unresolved scope expands to exhaustive verification.
+- **C3 — Waiting consumes no worker.** A task waiting for a gate must be durably suspended. It must not retain a Node process, model context, heartbeat loop, or heavyweight lease.
+- **C4 — One identity, one execution.** Equivalent review and CI requests coalesce. A retry observes the existing run instead of creating another.
+- **C5 — The platform owns liveness.** Clients may disconnect, restart, or omit advisory instructions without losing queue position or evidence.
+- **C6 — Local memory is a governed resource.** All heavyweight host processes use resource lanes; process naming or client provenance cannot bypass admission.
+- **C7 — Fail closed with a reason.** Stale projections, identity conflicts, and missing evidence block the affected transition and produce one actionable escalation.
 
-The only way *every* agent surface applies the same process is to stop relying on each client to choose to. Two layers:
+## 3. Canonical identities and state
 
-- **Advisory layer** (AGENTS.md + dpf-skill-pack skills): tells a surface what to do. A lax client may skip it.
-- **Mandatory layer** (platform gates on the worktree lifecycle, capsule/Work-Room transitions, pre-push gate, and merge queue): a surface *cannot* proceed without satisfying it. Client cooperation is not required.
+No parallel queue or evidence table is introduced. Existing `Workroom`, `NonProductionEnvironmentLease`, `QueueTelemetryEvent`, task lifecycle, and local-CI evidence records remain authoritative.
 
-**Design rule:** every stage below has a mandatory gate, so the process holds regardless of surface. This is the AGENTS.md §12 keystone ("governance approves evidence, not provenance") applied to the whole pipeline.
+### 3.1 Workroom identity
 
-## 4. The pipeline (unit of work = capsule, migrating to Work Room)
+Before lookup or persistence, normalize:
 
-Validation / user acceptance is the final stage and legitimately happens **post-deploy** (see §8).
+- repository to its canonical full name;
+- branch to the Git ref spelling used by the provider;
+- Windows paths to a resolved absolute path with one separator and case policy;
+- session aliases to the root provider session when supplied.
 
-| Stage | What happens | Mandatory gate (surface-agnostic) | Advisory (all surfaces) | Gap BI |
-|---|---|---|---|---|
-| **0 · Allocate** | Worktree comes up **guaranteed compile-ready** (deps linked, Prisma/generated client, env, MCP config, in-worktree symlinks) | Readiness gate: `.dpf-worktree-readiness.json` must be `compile-ready` for code/test intent — else auto-heal or **block** with the exact missing item | dpf-worktree-per-session | BI-6C54223E |
-| **1 · Work** | Agent edits in its isolated worktree — cheap, no Docker, fully parallel | worktree isolation + lease | dpf-worktree-per-session | — |
-| **2 · Fast local gate** | `typecheck + lint + affected tests` as plain Node — seconds, in-context, **no Docker**; catches ~90% of failures here | Scope-aware pre-push gate via `DPF_LOCAL_CI_COMMAND`; push blocked until green | dpf-local-merge-ci-before-push | BI-8D56F777 |
-| **3 · Evidence** | Thread records the minimum evidence for its work-kind | Capsule/Work-Room transition to `ready-for-review`/`ready-for-promotion` is **refused** unless required evidence is present + valid (reuse `requiredEvidence`/`evidenceCompleteness`) | dpf-external-evidence-handoff, dpf-tdd | BI-3D4A7063 |
-| **4 · Cloud safety net** | Heavy 16 GB build + integration runs **once, elastic** (GitHub merge queue) — the *rare* failure the cheap gate can't catch | Required checks (DCO, Merge Readiness, UX Route Budget) + merge queue | dpf-pr-with-dco, dpf-finishing-a-development-branch | BI-8D56F777 |
-| **5 · Liveness** | Dead thread → reap/resume; finished-but-stranded → surface for promotion; merged → auto-close | Platform reaper keyed on lease/liveness (already computed); no client cooperation needed | — | BI-9A353411 |
-| **6 · Validate (post-deploy)** | User acceptance after deploy, behind flags/canary with fast rollback | Progressive-delivery guardrails (see §8) | dpf-verify-on-live-install | (open, §8) |
+The unique logical key is `(repository, branch)`. Path and session are attributes used for liveness and conflict explanation, not alternate identities. A same-owner re-claim refreshes one Workroom.
 
-**Key rule:** Stage 4 (cloud) is a *safety net*, not where failures are discovered. Failures must surface fast at Stage 2 (local, in-context) — otherwise threads pay the slow git round-trip (push → wait → CI-red → return → fix → re-push). Stage 2 is comprehensive *because* it is plain-Node, not Docker. Docs/reconciliation branches → lint only.
+### 3.2 Gate run identity
 
-## 4a. Observed in the field (2026-08-15/16) — evidence for the Stage 2/4 split
+A gate request derives:
 
-One Claude Code session shipped five PRs (#4335, #4343, #4345, #4347, #4353) in a
-single evening while other sessions worked concurrently. It ran the heavy local
-Docker gate (`pnpm run pregate`) roughly **fourteen times to get five passes**.
-The failure distribution is the argument for §4's Stage 2/4 split, so it is
-recorded rather than left as folklore.
+`gateKey = sha256(repository + integrationTreeSha + evidencePlanDigest + toolchainFingerprint + gateKind)`
 
-**Cheap, correct failures — the preflight (~16–25 s each).** Module Size Guard,
-Derived Artifact Registry (a doc edit left `doc-impact.generated.json` stale), and
-Design Grounding Gate each failed fast, before any lease was claimed, and each was
-a real defect. This is precisely the Stage 2 behaviour the pipeline wants: plain
-Node, seconds, in-context, no Docker, no shared resource consumed.
+`GateRun` is a logical projection over existing lease, task, and evidence records. It is not a new mutable source of truth. The heavyweight lease uses `gateKey` as its transactional `claimKey`; task and evidence records carry the same value for lookup and audit. For a given `gateKey`:
 
-**Expensive, non-informative failures — the Docker stage.** Six of the fourteen
-runs died without producing build evidence:
+- one executor may be admitted;
+- any number of tasks may subscribe;
+- a valid terminal result is reused;
+- a failed or expired result may be retried with a new attempt under the same key;
+- a changed tree, policy, toolchain, or gate kind creates a new key.
 
-| Failure | Count | Cost each | Signal |
+Semantic review uses the same rule with `gateKind=semantic-review` and the committed tree SHA. Exact-tree CI cannot consume a receipt for a different tree.
+
+## 4. Evidence lanes
+
+The existing CI evidence planner becomes the admission authority. It evaluates the immutable candidate/integration tree before any heavyweight lease is claimed.
+
+| Lane | Qualification | Runs | Shared heavyweight lease |
 | --- | --- | --- | --- |
-| `blocked_sandbox_drift` (exit 3) | 3 | ~5 s + a lease cycle | none — sandbox defect, self-heals on plain re-run |
-| `received SIGTERM` mid-run (exit 1) | 3 | 0:30, 1:10, 2:06 into ~3–5 min runs | none — the log showed `fail 0` throughout |
+| **Plan-only** | Invalid/missing planner input or dry-run | Planner and diagnostics only; unresolved input escalates | No |
+| **Documentation** | `docsOnly=true`, no escalation | Doc index, link, derived-artifact, and repository guards in an isolated lightweight worktree | No |
+| **Affected code** | Planner is trusted and `fullSuite=false` | Global guards, affected package typechecks, mapped tests, changed-route UX evidence | Resource-specific lane only; no Docker/Next build lease |
+| **Exhaustive** | Risk escalation, unsafe graph, merge group, main, schedule, or explicit override | Full typecheck, full tests, production build, required integration and UX evidence | Yes; preferably elastic cloud execution |
 
-The SIGTERMs were **slot contention**, not a product failure and not a defect in
-the invocation. Host state at the time: load average 5.4, ~22 live worktrees,
-several sessions gating against the same 2-slot resource. The decisive evidence
-is that the run passed first try once `list_nonprod_environment_leases` returned
-`{leases:[],queued:[]}`.
+Documentation is not “no verification.” It is a smaller, exact, policy-defined evidence contract. An edit to workspace configuration, generated contracts, migration state, gate policy, or an unresolved derived artifact cannot enter the documentation lane.
 
-**Diagnostic rule for any surface hitting this:** on `gate-worktree: received
-SIGTERM`, do **not** retry blindly and do **not** "fix" the invocation — check
-`list_nonprod_environment_leases` and retry only when it is empty. (A plausible
-but wrong hypothesis was pursued first in this session — that redirecting the
-command's output caused it — and was disproved when an unpiped, sole-command run
-died the same way. The queue message is also mildly misleading: "previous
-local-CI lease claim was released; creating fresh admission attempt N" can print
-while another session still holds the slot.)
+The planner output records its lane, selected commands, reasons, affected tests/routes/packages, policy version, digest, and immutable tree. The executor must run that plan or fail; it may not silently replace an affected plan with an exhaustive one merely because exhaustive is easier to invoke.
 
-**Why this is evidence for the design, not an argument for a bigger gate.** Every
-defect that mattered was caught by the seconds-long preflight. The multi-minute
-Docker stage caught nothing in fourteen attempts that the cheap stage had not
-already caught, while consuming the scarce shared resource ~9 times without
-producing evidence. §1's second structural fault — one scarce heavyweight local
-resource that starves under demand — is not a projection; this is it happening at
-a fan-out of a handful of threads, well below the ~160 the pipeline targets.
+## 5. Durable admission and wake-up flow
 
-Tracked under `BI-8D56F777` (Stages 2 + 4).
+1. The client requests a gate using the immutable `gateKey` and its owner/task identity.
+2. The platform returns one of `reused`, `admitted`, `queued`, or `blocked`.
+3. On `queued`, the task stores a durable wait with the lease/task id and disconnects. Queued liveness is server-owned; client polling is not a heartbeat.
+4. Release, expiry, capacity change, or reconciliation emits a queue transition event.
+5. DPF resumes subscribed platform workflows through the existing Inngest event bus. MCP Streamable HTTP clients receive a task status notification/SSE event when supported. Codex and other clients use a host adapter that wakes the task; they do not keep the original Node command alive.
+6. Because release deliberately does not admit using stale host pressure, a woken task makes one fresh claim. The durable claim key preserves order and prevents duplication.
+7. If a notification is missed, a low-frequency reconciliation checks durable task state. Reconciliation is a safety net, not the normal wait mechanism.
 
-## 5. Cross-surface enforcement matrix
+MCP task notifications are optional by specification, so correctness never depends on delivery. The server-owned task and lease state is authoritative; events reduce latency and traffic.
 
-"Gate" = mandatory/platform; "Skill" = advisory paved road; every surface inherits both.
+## 6. Resource lanes and host memory
 
-| Stage | Claude Code | Codex | Grok | Antigravity | Build Studio |
-|---|---|---|---|---|---|
-| 0 Readiness | Gate + skill | Gate + skill | Gate + skill | Gate (+ warn) | Gate (native) |
-| 2 Fast gate | Gate (`DPF_LOCAL_CI_COMMAND`) + skill | Gate + skill | Gate + skill | Gate | Gate (native) |
-| 3 Evidence | Gate (capsule transition) + skill | Gate + handoff skill | Gate + handoff skill | Gate | Gate (native) |
-| 4 Cloud | Required checks + merge queue (identical for all) |
-| 5 Liveness | Platform reaper (identical for all — keyed on lease, not client) |
+All heavyweight developer processes must declare a lane and expected memory class:
 
-Because Stages 0/3/5 are **platform gates**, a surface that "forgets" cannot bypass them.
+| Resource lane | Examples | Default policy |
+| --- | --- | --- |
+| `host-compile` | TypeScript, affected Vitest | Bounded workers and heap; multiple only within measured RAM budget |
+| `host-build` | Next production build | Single-flight per tree; one admitted host build unless pressure policy permits more |
+| `container-build` | Docker build, local integration stack | Existing nonproduction lease and process fence |
+| `preview` | Shared portal/UX verification | Governed shared environment lease |
+| `model-inference` | Local llama.cpp model and KV cache | Reserve model/working-set memory before admitting developer processes |
 
-## 6. Alignment with mainstream practice
+Capacity is computed from available RAM, committed memory, recent peak working sets, and a safety reserve. It is not a fixed number of clients. A resource-lane holder must terminate descendants before release; ungoverned matching processes block admission and produce one owner-visible diagnostic.
 
-Converges on large-monorepo engineering (Google/Meta):
-- Trunk-based dev + short-lived branches + **merge queue** (not-rocket-science rule).
-- **Presubmit** (fast, affected-only) vs **postsubmit** (comprehensive) = Stage 2 vs Stage 4.
-- **Remote Build Execution + caching** instead of per-change local full builds = Stage 4 offload.
-- **Hermetic/reproducible dev environments** = Stage 0.
-- **Policy-as-code / required checks / SLSA provenance / Definition-of-Done** = Stage 3.
-- **Progressive delivery (flags/canary/rollback)** = Stage 6.
-References: *Software Engineering at Google* (TAP presubmit/postsubmit); *Accelerate* (DORA); SLSA.
+## 7. Workroom flow, WIP, and liveness
 
-## 7. Rollout sequencing
+Every Workroom projects one of these states:
 
-1. **Stage 0** (BI-6C54223E) first — a broken worktree poisons every later stage (spurious failures, wasted tokens, dirty evidence).
-2. **Stage 2** (BI-8D56F777) — the scope-aware lightweight `DPF_LOCAL_CI_COMMAND` gate; fastest operator-visible win, testable on a couple of threads with no build.
-3. **Stage 3** (BI-3D4A7063) — enforce the evidence contract at capsule transition.
-4. **Stage 5** (BI-9A353411) — the liveness reaper.
+`ready → active → waiting(resource|review|input) → active → ready-for-promotion → terminal`
 
-Instrument with **DORA metrics** (deploy freq, lead time, change-failure rate, MTTR) to prove each stage helps.
+Only `active` work consumes an agent execution slot. `waiting` work is persisted and resumable.
 
-## 8. Open question — Stage 6 progressive delivery
+Enforcement:
 
-Post-deploy UAT is mainstream *only if* paired with **feature flags + canary/staged rollout + fast automated rollback**. Confirm DPF's progressive-delivery story supports safe post-deploy validation before leaning on it. If absent, this is a fifth gap BI.
+- WIP limits apply per portfolio and constrained lane, not as one global thread cap.
+- A task may have one active implementation identity and one outstanding gate request per immutable tree.
+- A new commit supersedes older queued review/CI requests for that branch; completed receipts remain immutable history.
+- No-progress and oldest-wait thresholds emit one deduplicated escalation with owner, blocker, last transition, and recovery action.
+- Reapers use server state plus process/host evidence. A queued durable task is live without a client process; a duplicate path spelling is not a second task.
+- Readiness decisions must cite the exact canonical fields and versions they evaluated. A projection that conflicts with canonical state returns `projection-stale` and requests one recomputation instead of asking every client to retry.
+
+Initial service objectives:
+
+- 95% reduction in claim/list calls made only to wait;
+- p95 queued client CPU time below one second per minute of wait;
+- documentation lane starts within 30 seconds on a healthy host;
+- no duplicate semantic review or exact-tree CI execution for the same `gateKey`;
+- queued-to-admitted transition visible within 15 seconds when notifications are connected, within five minutes through reconciliation;
+- no Workroom without a state transition or explicit blocker for more than 30 minutes while its owner task is active.
+
+## 8. Cross-surface enforcement
+
+| Concern | Claude | Codex | Grok | Antigravity | Build Studio |
+| --- | --- | --- | --- | --- | --- |
+| Workroom identity/readiness | Platform | Platform | Platform | Platform | Platform |
+| Evidence lane selection | Planner | Planner | Planner | Planner | Planner |
+| Durable wait/resume | MCP task adapter | MCP task/host adapter | MCP task adapter | MCP task adapter | Native Inngest wait |
+| Gate/review single-flight | Platform | Platform | Platform | Platform | Platform |
+| Evidence acceptance | Platform | Platform | Platform | Platform | Platform |
+
+Build Studio remains an optional executor, not the workflow authority. Removing Build Studio does not remove the need for Workrooms, task state, evidence planning, or governed promotion. Conversely, retaining it does not justify a separate queue or evidence contract.
+
+## 9. Standards and comparable systems
+
+- MCP Tasks provides durable task status plus optional `notifications/tasks/status`; Streamable HTTP supports server-to-client notifications over SSE. DPF follows the notification-plus-reconciliation model because clients cannot rely on optional delivery. See [MCP Tasks](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks) and [MCP transports](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports).
+- Inngest `step.waitForEvent()` suspends a workflow until an event or timeout without retaining the client process. DPF already uses this substrate, so it is the server-side resume mechanism rather than a new queue. See [Inngest event waits](https://www.inngest.com/docs/typescript).
+- GitHub Actions concurrency groups coalesce work by a stable key and allow bounded pending work. DPF adopts stable concurrency identities but preserves immutable completed evidence instead of canceling it. See [GitHub Actions concurrency](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).
+- Nx affected uses Git plus a project graph to run only impacted tasks, and expands on dependency uncertainty. DPF's evidence planner follows this affected-first, fail-safe expansion model without adopting another build system. See [Nx affected](https://nx.dev/docs/features/ci-features/affected).
+
+## 10. Rollout and ownership
+
+1. `BI-B2E9FC9D` — make evidence lanes authoritative before heavyweight admission.
+2. `BI-6A5AB570` — coalesce semantic review and CI by immutable gate identity.
+3. `BI-MCP-EFF-0285909C` — replace lease polling with durable wait/resume and reconciliation.
+4. `BI-30EDD4B0` — converge heavyweight developer processes on governed resource lanes.
+5. `BI-114C1F40` — enforce Workroom WIP, progress SLOs, and durable-wait liveness.
+
+Each slice ships independently, preserves the evidence contract, and records before/after flow telemetry. The scale ceiling after these changes is the capacity of cloud/host executors, not the number of waiting client processes. Further scale comes from remote cache/distributed execution and more executor capacity, not more polling.

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -383,7 +383,7 @@ the reader exists (BI-B1065D41):
 
 | Signal | How it lies |
 | --- | --- |
-| The **exit code** | `pregate …; echo $?; tail …` reports *tail's* status. A run that gives up while queued, or reports 0 with no PASS record at HEAD, now exits **7** instead of 0 (BI-A9CF0D69; the historical exit-0 lie was BI-2C7F51BA) — but a chained/piped reading still surfaces someone else's status, so the record remains the verdict. |
+| The **exit code** | `pregate …; echo $?; tail …` reports *tail's* status. A run that gives up while queued, or reports 0 with no PASS record at HEAD, now exits **7** instead of 0 (the historical exit-0 lie was BI-2C7F51BA) — but a chained/piped reading still surfaces someone else's status, so the record remains the verdict. |
 | The **log tail** | A *tolerated* `GuardRuntimeEnvironmentError` prints `Error:` and a red ✖ ~28,000 lines before a **passing** verdict. A watcher grepping `Error:` fabricates a failure. |
 | **`gate passed`** | True about the run you watched; silent about whether HEAD has moved since. `pregate:status` compares. |
 
@@ -777,13 +777,12 @@ bump, restore the pin or extend the workaround. Upstream:
 Modules that probe their environment (does `.git` exist? is `package.json`
 readable? did the remote answer?) must be unit-tested against the world
 production actually is — **partial, stale, absent, empty, plural** — not only
-the healthy fixture. The dominant late-defect escape class (~30%, BI-927D64C0)
-is a probe whose every test fixture modelled the healthy world: an image-synced
-partial tree passed the availability probe and true citations were "refuted"
-(BI-EE2B243D); a federation guard "only ever passed because unit tests reused
-one linkId fixture" (BI-AF675A20); a >1MB diff crashed the default exec
-maxBuffer (BI-DC6BE37C); a transient failure was collapsed to a terminal state
-(BI-2B9E16CC).
+the healthy fixture. The dominant late-defect escape class is a probe whose
+every test fixture modelled the healthy world: an image-synced partial tree
+passed the availability probe and true citations were "refuted"; a federation
+guard only passed because unit tests reused one link-id fixture; a large diff
+exhausted the default exec buffer; and a transient failure was collapsed to a
+terminal state.
 
 Use the shared, dependency-free fixture kit
 [`apps/web/lib/testing/degenerate-env/`](../../apps/web/lib/testing/degenerate-env/index.ts)
@@ -813,7 +812,7 @@ Name them so you catch yourself.
 | Reaching for `DPF_SKIP_*` to get past a hook | Bypasses are for verified false positives only | Fix the underlying error; CI gates it anyway |
 | Verifying UX against worktree `next dev` | Not the production-bundled runtime | Use the canonical install or sandbox lease (AGENTS.md §13) |
 | Treating a local green as the merge gate | The binding gate is the CI **Unit Tests** check | Local pass = evidence; CI pass = the gate |
-| Reading a `pregate` exit code as the verdict | A pipeline surfaces the last command's status, not pregate's (an abandoned/uncorroborated run itself now exits 7, not 0 — BI-A9CF0D69) | `pnpm run pregate:status` — it reads the SHA-bound record and exits 0 only for a PASS at HEAD |
+| Reading a `pregate` exit code as the verdict | A pipeline surfaces the last command's status, not pregate's (an abandoned or uncorroborated run itself now exits 7, not 0) | `pnpm run pregate:status` — it reads the SHA-bound record and exits 0 only for a PASS at HEAD |
 | Piping `pregate` to `head`/`grep` | The verdict is the LAST line, so a truncating reader removes exactly what you wanted (and it used to SIGPIPE-kill the run mid-install) | Let it print its ~30 lines; open the log path it prints for detail |
 | Backgrounding `pregate` (`&` / `run_in_background`) | The harness caps and kills a backgrounded run mid-install | Run it in the FOREGROUND — on timeout the harness migrates it and it continues |
 | Wrapping `pregate` in `timeout` | Cuts it off mid-queue and manufactures a false green | Run it unbounded in the foreground |
@@ -829,12 +828,11 @@ cites a **closed** `BI-`/`EP-` id from user-facing text — a message that tells
 the reader a fixed defect is their live blocker.
 
 It is the missing half of Doc Anchor Existence. That guard proves a cited id
-EXISTS; nothing proved it was still OPEN. `record_plan_backlog_coverage` spent
-two days instructing every caller to "cite BI-B9403248 for the blocked
-receipt" after BI-B9403248 shipped, so contributors recorded the wrong cause in
-their plans and auditors reading those plans found a closed id and concluded the
-block was stale. Remediation text is written inline as a literal and then never
-revisited when the referenced work closes.
+EXISTS; nothing proved it was still OPEN. A coverage tool once spent two days
+instructing every caller to cite an already-shipped blocker, so contributors
+recorded the wrong cause and auditors correctly concluded the block was stale.
+Remediation text is written inline as a literal and then easily missed when the
+referenced work closes.
 
 The scope is deliberately narrow, because a guard that invents a defect is worse
 than one that hides a defect:

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -240,6 +240,24 @@ Run it standalone with `pnpm run pregate:preflight`
 still enforces every guard. Routing probes (`--dry-run`) and evidence replays
 (`--finalize-evidence`) skip the preflight automatically.
 
+**Documentation evidence lane (BI-B2E9FC9D).** After preflight and before any
+`local-integration-ci` lease claim, the Node gate checks whether the committed
+candidate is an exact documentation-only tree. This lane is deliberately
+fail-closed: `HEAD` must equal the requested SHA, the worktree must be clean,
+the candidate must contain the current `origin/main`, and the authoritative CI
+evidence planner must select `executionLane: documentation` with no full suite.
+Two architecture documents that need the workspace runtime remain excluded.
+If any check is missing, stale, or ambiguous, the gate falls through to the
+normal exhaustive sandbox path.
+
+An eligible documentation tree runs doc-index freshness, link integrity, and
+the complete repository guard loop in the worktree. It records the planner
+digest, candidate tree, commands, output, and result through
+`record_local_integration_result`, then writes the same SHA-bound local gate
+state used by `pregate:status`. Its evidence carries no lease id because it
+never enters the scarce sandbox. A failed documentation check is a failed gate;
+it does not retry by consuming the heavyweight lane.
+
 **Host-native/Node-first entry point (BI-2272D840, BI-52500C0D, BI-4BE30454).** `pregate.mjs`
 routes to `scripts/gate-worktree.mjs` by default on every host. The Node-native
 gate owns the lease-claim / heartbeat / fenced-run / descendant-quiescence /
@@ -249,14 +267,15 @@ and delegates to the Node gate; set `DPF_PREGATE_FORCE_SH=1` only for focused
 shell-adapter debugging. Missing native `sh` is therefore classified as
 **sandbox-routable, never a build blocker**.
 
-Either path produces the same evidence shape (manifest version and slot,
-branch/SHA, integration tree, database and Compose identity, production
-artifact, lease id, freshness verdict, toolchain fingerprint, expiry) and
-writes the same
-`.git/dpf-local-ci-gate.json` state file, so the pre-push gate below accepts
-either without caring which one ran. `DPF_PREGATE_FORCE_NODE=1` preserves the
-default. `DPF_PREGATE_FORCE_SH=1` is explicit legacy-shell debugging and still
-requires a working shell.
+The exhaustive Node and compatibility-shell paths produce the same sandbox
+evidence shape (manifest version and slot, branch/SHA, integration tree,
+database and Compose identity, production artifact, lease id, freshness
+verdict, toolchain fingerprint, expiry). The documentation lane produces a
+smaller planner-bound evidence record. All three write the same
+`.git/dpf-local-ci-gate.json` state file, so the pre-push gate accepts a fresh
+pass without caring which eligible lane produced it. `DPF_PREGATE_FORCE_NODE=1`
+preserves the default. `DPF_PREGATE_FORCE_SH=1` is explicit legacy-shell
+debugging and still requires a working shell.
 
 The gate claims a `local-integration-ci` lease (waiting if the sandbox is
 already leased). A canonical waiter refreshes its idempotent claim well inside

--- a/scripts/gate-worktree-lease.test.mjs
+++ b/scripts/gate-worktree-lease.test.mjs
@@ -101,6 +101,88 @@ function makeTempWorktree() {
   return dir;
 }
 
+function makeDocumentationWorktree() {
+  const dir = mkdtempSync(join(tmpdir(), "dpf-gate-doc-worktree-"));
+  const git = (args) => {
+    const result = spawnSync("git", args, { cwd: dir, encoding: "utf8" });
+    if (result.status !== 0) {
+      throw new Error(`git ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
+    }
+    return result.stdout.trim();
+  };
+  git(["init", "-q", "-b", "main"]);
+  git(["config", "user.name", "DPF Test"]);
+  git(["config", "user.email", "dpf-test@example.invalid"]);
+  spawnSync(process.execPath, ["-e", [
+    "const { mkdirSync, writeFileSync } = require('node:fs');",
+    "mkdirSync('scripts', { recursive: true });",
+    "writeFileSync('README.md', 'base\\n');",
+    "writeFileSync('scripts/ci-evidence-plan.mjs', `import { writeFileSync } from 'node:fs'; const i=process.argv.indexOf('--output'); writeFileSync(process.argv[i+1], JSON.stringify({executionLane:'documentation',digest:'doc-plan',fullSuite:false,scope:{docsOnly:true},headTreeSha:process.env.DPF_TEST_HEAD_TREE})+'\\n');`);",
+    "for (const name of ['gen-doc-index.mjs','check-doc-links.mjs','check-guards.mjs']) writeFileSync(`scripts/${name}`, 'process.exit(0);\\n');",
+  ].join(" ")], { cwd: dir, encoding: "utf8" });
+  git(["add", "."]);
+  git(["commit", "-q", "-m", "base"]);
+  git(["update-ref", "refs/remotes/origin/main", "HEAD"]);
+  git(["switch", "-q", "-c", "docs/lease-bypass"]);
+  writeFileSync(join(dir, "README.md"), "base\ndocumentation change\n");
+  git(["add", "README.md"]);
+  git(["commit", "-q", "-m", "docs"]);
+  return { dir, sha: git(["rev-parse", "HEAD"]), tree: git(["rev-parse", "HEAD^{tree}"]) };
+}
+
+test("documentation evidence completes without claiming a heavyweight lease", async () => {
+  const calls = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      const payload = JSON.parse(body);
+      calls.push(payload.params.name);
+      const result = payload.params.name === "record_local_integration_result"
+        ? { success: true, entityId: "EVIDENCE-DOC-LANE" }
+        : { success: true, data: { level: "normal" } };
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+      }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const worktree = makeDocumentationWorktree();
+
+  try {
+    const result = await run(process.execPath, [
+      "scripts/gate-worktree.mjs",
+      "--branch", "docs/lease-bypass",
+      "--sha", worktree.sha,
+      "--worktree", worktree.dir,
+      "--mcp-url", `http://127.0.0.1:${address.port}`,
+      "--no-push",
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        DPF_MCP_BEARER_TOKEN: "test-token",
+        DPF_GATE_OWNER_PROVIDER: "codex",
+        DPF_GATE_OWNER_SESSION_ID: "doc-lane-test",
+        DPF_TEST_HEAD_TREE: worktree.tree,
+      },
+    });
+
+    assert.equal(result.code, 0, result.output);
+    assert.match(result.output, /documentation evidence passed without heavyweight admission/);
+    assert.equal(calls.includes("claim_nonprod_environment_lease"), false, calls.join(", "));
+    assert.equal(calls.includes("renew_nonprod_environment_lease"), false, calls.join(", "));
+    assert.equal(calls.filter((tool) => tool === "record_local_integration_result").length, 1);
+  } finally {
+    rmSync(worktree.dir, { recursive: true, force: true });
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
 test("canonical gate heartbeats during a long command and releases once", async () => {
   const calls = [];
   const server = createServer((request, response) => {

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -40,6 +40,7 @@ import {
   resolveLocalCiRootClone,
 } from "./lib/local-ci-slot-manifest.mjs";
 import { classifyBaseResilience } from "./lib/local-ci-base-freshness.mjs";
+import { runPreAdmissionDocumentationLane } from "./lib/documentation-evidence-lane.mjs";
 import {
   createLocalCiPassEvidenceValidity,
   readLocalCiGateState,
@@ -748,6 +749,7 @@ async function cancelDeadLocalQueueObservers({
   }
 }
 
+
 function warnAboutMainFreshness({ gitBin, worktreePath }) {
   if (!gitOrEmpty(gitBin, ["rev-parse", "--verify", "origin/main"], worktreePath)) return;
   const behind = gitOrEmpty(gitBin, ["rev-list", "--count", "HEAD..origin/main"], worktreePath);
@@ -834,10 +836,6 @@ async function main() {
     }
     process.stdout.write("would call claim_nonprod_environment_lease and record_local_integration_result only when a real command or explicit stub is configured\n");
     process.exit(0); // exit-0: --dry-run routing probe; changes nothing and records nothing
-  }
-
-  if (!options.finalizeEvidence && !commandSpec && !allowStub) {
-    die("local-CI gate runner is not wired (scripts/local-ci-runner.mjs is missing); refusing to record passing stub evidence. Set DPF_LOCAL_CI_COMMAND to the canonical sandbox command, or use DPF_ALLOW_LOCAL_CI_STUB=1 only in contract tests.");
   }
 
   const bearerToken = process.env.DPF_MCP_BEARER_TOKEN;
@@ -996,6 +994,43 @@ async function main() {
     if (push.status !== 0) die(`push failed: ${push.stderr || push.stdout}`);
   }
 
+  if (!ownerProvider) {
+    die(
+      "cannot attribute this gate to a client. Pass --owner-provider "
+        + "<build-studio|claude|codex|grok|antigravity|coworker> or set "
+        + "DPF_GATE_OWNER_PROVIDER. (The lease and the evidence record use a "
+        + "closed provider vocabulary, so there is no honest default.)",
+    );
+  }
+
+  if (!options.finalizeEvidence) {
+    const documentationResult = await runPreAdmissionDocumentationLane({
+      branch,
+      sha,
+      worktreePath,
+      gitBin,
+      ownerProvider,
+      ownerSessionId,
+      mcpUrl: options.mcpUrl,
+      bearerToken,
+      stateFile,
+      planFile: resolvePath(candidateGitDir, "dpf-pre-admission-evidence-plan.json"),
+      plannerPath: resolvePath(SCRIPT_DIR, "ci-evidence-plan.mjs"),
+    });
+    if (documentationResult.handled) {
+      process.stdout.write(
+        documentationResult.status === 0
+          ? `documentation evidence passed without heavyweight admission: ${documentationResult.evidenceId}\n`
+          : `documentation evidence failed without heavyweight admission: ${documentationResult.evidenceId}\n`,
+      );
+      process.exit(documentationResult.status);
+    }
+  }
+
+  if (!options.finalizeEvidence && !commandSpec && !allowStub) {
+    die("local-CI gate runner is not wired (scripts/local-ci-runner.mjs is missing); refusing to record passing stub evidence. Set DPF_LOCAL_CI_COMMAND to the canonical sandbox command, or use DPF_ALLOW_LOCAL_CI_STUB=1 only in contract tests.");
+  }
+
   const leaseTtlMs = Math.min(
     options.expiresMinutes * 60_000,
     LOCAL_CI_ACTIVE_LEASE_TTL_MS,
@@ -1065,15 +1100,6 @@ async function main() {
   // no "unknown" member, so an unresolved provider has no honest value — refuse
   // rather than attribute this run to whichever client is most common. Everything
   // above (--dry-run, the runner-wiring check) stays runnable unattributed.
-  if (!ownerProvider) {
-    die(
-      "cannot attribute this gate to a client. Pass --owner-provider "
-        + "<build-studio|claude|codex|grok|antigravity|coworker> or set "
-        + "DPF_GATE_OWNER_PROVIDER. (The lease and the evidence record use a "
-        + "closed provider vocabulary, so there is no honest default.)",
-    );
-  }
-
   let claimAttempt = 0;
   let nextQueueReconciliationAt = 0;
   for (;;) {

--- a/scripts/lib/ci-evidence-plan.mjs
+++ b/scripts/lib/ci-evidence-plan.mjs
@@ -347,6 +347,11 @@ export function createEvidencePlan(input) {
   }
 
   const routes = sortedUnique([...affectedRoutes]);
+  const executionLane = escalations.length > 0
+    ? "exhaustive"
+    : docsOnly
+      ? "documentation"
+      : "affected";
   const semanticPlan = {
     schemaVersion: CI_EVIDENCE_PLAN_SCHEMA_VERSION,
     plannerVersion: policy.plannerVersion,
@@ -377,6 +382,7 @@ export function createEvidencePlan(input) {
     routeFamilies: sortedUnique(routes.map(routeFamily)),
     globalGuards: sortedUnique(policy.globalGuards),
     uxMode: routes.length > 0 ? "changed-routes" : "none",
+    executionLane,
     fullSuite: escalations.length > 0,
     evidenceTier: escalations.length > 0 ? "exhaustive" : "affected",
     escalations: escalations.sort((left, right) => left.code.localeCompare(right.code)),

--- a/scripts/lib/ci-evidence-plan.test.mjs
+++ b/scripts/lib/ci-evidence-plan.test.mjs
@@ -115,6 +115,7 @@ describe("createEvidencePlan", () => {
     assert.equal(plan.scope.docsOnly, true);
     assert.equal(plan.scope.heavy, false);
     assert.equal(plan.fullSuite, false);
+    assert.equal(plan.executionLane, "documentation");
     assert.equal(plan.uxMode, "none");
     assert.deepEqual(plan.escalations, []);
   });
@@ -211,6 +212,7 @@ describe("createEvidencePlan", () => {
     ]);
     assert.equal(plan.graph.trusted, true);
     assert.equal(plan.fullSuite, false);
+    assert.equal(plan.executionLane, "affected");
   });
 
   it("accepts a different commit alias when graph advice matches the exact tree", () => {
@@ -249,6 +251,7 @@ describe("createEvidencePlan", () => {
       }));
 
       assert.equal(plan.fullSuite, true);
+      assert.equal(plan.executionLane, "exhaustive");
       assert.ok(escalationCodes(plan).includes(code));
     });
   }

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -148,6 +148,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/ci-build-artifact-discovery.test.mjs",
         "scripts/lib/ci-build-artifact.test.mjs",
         "scripts/lib/ci-evidence-plan.test.mjs",
+        "scripts/lib/documentation-evidence-lane.test.mjs",
         "scripts/ci-policy-guards.test.mjs",
         "scripts/lib/host-command-invocation.test.mjs",
         // BI-812C676D: every covered-root *.test.mjs must appear here or on the

--- a/scripts/lib/documentation-evidence-lane.mjs
+++ b/scripts/lib/documentation-evidence-lane.mjs
@@ -1,0 +1,199 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { mcpCall } from "./mcp-client.mjs";
+import {
+  createLocalCiPassEvidenceValidity,
+  writeLocalCiGateState,
+} from "./local-ci-gate-state.mjs";
+
+const WORKSPACE_REQUIRED_DOCS = new Set([
+  "docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md",
+  "docs/architecture/four-portfolio-archetype-standard-profile-catalog.md",
+]);
+
+function isDocumentationSource(path) {
+  return path.startsWith("docs/") || /(^|\/)README\.md$|\.mdx?$/.test(path);
+}
+
+export function couldBeDocumentationFiles(changedFiles) {
+  const hasDocumentationSource = changedFiles.some(isDocumentationSource);
+  return changedFiles.length > 0
+    && !changedFiles.some((path) => WORKSPACE_REQUIRED_DOCS.has(path))
+    && changedFiles.every((path) => (
+      isDocumentationSource(path)
+      || (hasDocumentationSource && path === "apps/web/lib/docs/doc-index.generated.json")
+    ));
+}
+
+function gitOutput(gitBin, args, cwd) {
+  const result = spawnSync(gitBin, args, { cwd, encoding: "utf8", shell: false });
+  return result.status === 0 ? result.stdout.trim() : "";
+}
+
+function exactCandidateIsEligible({ gitBin, worktreePath, sha }) {
+  if (gitOutput(gitBin, ["rev-parse", "HEAD"], worktreePath) !== sha) return false;
+  if (gitOutput(gitBin, ["status", "--porcelain", "--untracked-files=normal"], worktreePath)) {
+    return false;
+  }
+  return spawnSync(
+    gitBin,
+    ["merge-base", "--is-ancestor", "origin/main", sha],
+    { cwd: worktreePath, shell: false },
+  ).status === 0;
+}
+
+function readCandidateFiles(gitBin, worktreePath, sha) {
+  const result = spawnSync(
+    gitBin,
+    ["diff", "--name-only", "origin/main", sha],
+    { cwd: worktreePath, encoding: "utf8", shell: false },
+  );
+  return result.status === 0
+    ? result.stdout.split(/\r?\n/).filter(Boolean)
+    : null;
+}
+
+function runDocumentationCommands(worktreePath, env) {
+  const commands = [
+    ["scripts/gen-doc-index.mjs", "--check"],
+    ["scripts/check-doc-links.mjs"],
+    ["scripts/check-guards.mjs"],
+  ];
+  const outputs = [];
+  for (const [script, ...args] of commands) {
+    const result = spawnSync(process.execPath, [resolve(worktreePath, script), ...args], {
+      cwd: worktreePath,
+      encoding: "utf8",
+      shell: false,
+      env,
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    outputs.push(result.stdout || "", result.stderr || "");
+    if (result.status !== 0) {
+      return {
+        commands,
+        exitCode: result.status ?? 1,
+        failedCommand: ["node", script, ...args].join(" "),
+        output: outputs.join("\n").slice(-12_000),
+      };
+    }
+  }
+  return {
+    commands,
+    exitCode: 0,
+    failedCommand: null,
+    output: outputs.join("\n").slice(-12_000),
+  };
+}
+
+export async function runPreAdmissionDocumentationLane({
+  branch,
+  sha,
+  worktreePath,
+  gitBin,
+  ownerProvider,
+  ownerSessionId,
+  mcpUrl,
+  bearerToken,
+  stateFile,
+  planFile,
+  plannerPath,
+  env = process.env,
+}) {
+  if (!exactCandidateIsEligible({ gitBin, worktreePath, sha })) return { handled: false };
+  const changedFiles = readCandidateFiles(gitBin, worktreePath, sha);
+  if (!changedFiles || !couldBeDocumentationFiles(changedFiles)) return { handled: false };
+
+  rmSync(planFile, { force: true });
+  const planner = spawnSync(process.execPath, [
+    plannerPath,
+    "--event", "local-ci",
+    "--base", "origin/main",
+    "--head", sha,
+    "--output", planFile,
+  ], { cwd: worktreePath, encoding: "utf8", shell: false, env });
+  if (planner.status !== 0 || !existsSync(planFile)) return { handled: false };
+
+  let plan;
+  try {
+    plan = JSON.parse(readFileSync(planFile, "utf8"));
+  } catch {
+    return { handled: false };
+  }
+  if (plan.executionLane !== "documentation" || plan.fullSuite !== false) {
+    return { handled: false, plan };
+  }
+  if (gitOutput(gitBin, ["rev-parse", `${sha}^{tree}`], worktreePath) !== plan.headTreeSha) {
+    return { handled: false, plan };
+  }
+
+  const execution = runDocumentationCommands(worktreePath, env);
+  const passed = execution.exitCode === 0;
+  const issuedAt = new Date().toISOString();
+  const evidenceValidity = passed
+    ? createLocalCiPassEvidenceValidity({ issuedAt })
+    : null;
+  const evidenceArgs = {
+    provider: ownerProvider,
+    externalSessionId: ownerSessionId,
+    routeContext: "/build",
+    candidateBranch: branch,
+    mode: "single-branch",
+    status: passed ? "passed" : "failed",
+    summary: passed
+      ? "Exact-tree documentation evidence passed without heavyweight admission."
+      : `Documentation evidence failed at ${execution.failedCommand}.`,
+    evidence: {
+      bi: "BI-B2E9FC9D",
+      phase: "pre-admission-documentation",
+      executionLane: plan.executionLane,
+      evidencePlan: {
+        digest: plan.digest,
+        plannerVersion: plan.plannerVersion,
+        policyVersion: plan.policyVersion,
+        headTreeSha: plan.headTreeSha,
+        globalGuards: plan.globalGuards,
+      },
+      branch,
+      sha,
+      integrationTreeSha: plan.headTreeSha,
+      gatePassed: passed,
+      leaseId: null,
+      commands: execution.commands.map(([script, ...args]) => (
+        ["node", script, ...args].join(" ")
+      )),
+      failedCommand: execution.failedCommand,
+      output: execution.output,
+    },
+  };
+  const evidenceResponse = await mcpCall(
+    "record_local_integration_result",
+    evidenceArgs,
+    { mcpUrl, bearerToken },
+  );
+  if (evidenceResponse?.success !== true) {
+    throw new Error(`failed to record documentation evidence: ${JSON.stringify(evidenceResponse)}`);
+  }
+
+  const evidenceId = evidenceResponse.entityId || "";
+  writeLocalCiGateState(stateFile, {
+    branch,
+    sha,
+    gatePassed: passed,
+    leaseId: "",
+    evidenceId,
+    status: passed ? "passed" : "failed",
+    expiresAt: evidenceValidity?.expiresAt || issuedAt,
+    evidenceValidity,
+    resilience: null,
+    leaseEvents: [{ type: "documentation-lane", at: issuedAt }],
+    evidencePending: false,
+  });
+  return {
+    handled: true,
+    status: passed ? 0 : execution.exitCode,
+    plan,
+    evidenceId,
+  };
+}

--- a/scripts/lib/documentation-evidence-lane.test.mjs
+++ b/scripts/lib/documentation-evidence-lane.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { couldBeDocumentationFiles } from "./documentation-evidence-lane.mjs";
+
+describe("couldBeDocumentationFiles", () => {
+  it("admits documentation plus its generated index", () => {
+    assert.equal(couldBeDocumentationFiles([
+      "docs/operations/gates.md",
+      "apps/web/lib/docs/doc-index.generated.json",
+    ]), true);
+  });
+
+  it("rejects runtime, policy, empty, and executable-standard changes", () => {
+    for (const files of [
+      [],
+      ["scripts/gate-worktree.mjs"],
+      ["config/ci-evidence-policy.json"],
+      ["docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md"],
+    ]) {
+      assert.equal(couldBeDocumentationFiles(files), false, files.join(", "));
+    }
+  });
+});

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -275,15 +275,23 @@ export function createLocalIntegrationPlan(input) {
     "HEAD",
     ...(input.evidencePlanOutput ? ["--output", input.evidencePlanOutput] : []),
   ];
-  const commands = [
+  const setupCommands = [
     ...(input.fetchBase ? [["git", "fetch", "origin", "main"]] : []),
     ["git", "checkout", "-B", branch, baseRef],
     ["git", "merge", "--no-ff", "--no-edit", input.candidateBranch],
     ...input.siblingBranches.map((sibling) => ["git", "merge", "--no-ff", "--no-edit", sibling]),
-    // Generate the same versioned, digest-bound evidence recommendation used
-    // by GitHub after the exact integration tree exists. Shadow mode records
-    // advice only; the exhaustive gate below remains the execution authority.
+    // Generate the same versioned, digest-bound evidence plan used by GitHub
+    // after the exact integration tree exists. Documentation plans are
+    // authoritative; other local lanes remain exhaustive during rollout.
     evidencePlanCommand,
+  ];
+  const guardCommands = [
+    ["node", "scripts/gen-doc-index.mjs", "--check"],
+    ["node", "scripts/check-doc-links.mjs"],
+    ["node", "scripts/check-guards.mjs"],
+  ];
+  const executionLane = input.evidencePlan?.executionLane ?? "exhaustive";
+  const exhaustiveCommands = [
     // Step-zero sandbox freshness gate (BI-ECDF9520): after the merge changes
     // pnpm-lock.yaml, node_modules must be proven to match it before any
     // test/build result counts as product evidence. Exits 3/4 (sandbox drift /
@@ -309,12 +317,8 @@ export function createLocalIntegrationPlan(input) {
     ...(input.includeMigrateDeploy
       ? [["pnpm", "--filter", "@dpf/db", "exec", "prisma", "migrate", "deploy"]]
       : []),
-    // Fast PR guard parity: these CI jobs are cheap and fail before the heavy
-    // shards when committed docs/generated indexes or repo-wide guard ratchets
-    // are stale. Run them here so local-CI catches the same failures pre-push.
-    ["node", "scripts/gen-doc-index.mjs", "--check"],
-    ["node", "scripts/check-doc-links.mjs"],
-    ["node", "scripts/check-guards.mjs"],
+    // Fast PR guard parity runs before the expensive test/build gates.
+    ...guardCommands,
     // Fail fast on the definitive compile/type-generation proof before spending
     // the shared sandbox on the exhaustive suite. A red typecheck cannot become
     // green after tests, while successful candidates still execute every gate.
@@ -341,12 +345,16 @@ export function createLocalIntegrationPlan(input) {
     ],
     productionBuildCommand,
   ];
+  const commands = executionLane === "documentation"
+    ? [...setupCommands, ...guardCommands]
+    : [...setupCommands, ...exhaustiveCommands];
   return {
     mode: input.mode,
     integrationBranch: branch,
     slotKey: input.slotKey ?? "",
     baseRef,
     buildStrategy,
+    executionLane,
     commands,
   };
 }

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -211,7 +211,7 @@ describe("createLocalIntegrationPlan", () => {
     assert.ok(preflightIndex < firstGateIndex);
   });
 
-  it("writes the shadow plan beside governed local-CI metadata when requested", () => {
+  it("writes the evidence plan beside governed local-CI metadata when requested", () => {
     const plan = createLocalIntegrationPlan({
       candidateBranch: "feat/x",
       mode: "single-branch",
@@ -223,6 +223,29 @@ describe("createLocalIntegrationPlan", () => {
     assert.ok(plan.commands.map((command) => command.join(" ")).includes(
       "node scripts/ci-evidence-plan.mjs --event local-ci --base origin/main --head HEAD --output artifacts/dpf-ci-evidence-plan.json",
     ));
+  });
+
+  it("runs only exact documentation evidence for an authoritative documentation lane", () => {
+    const plan = createLocalIntegrationPlan({
+      candidateBranch: "docs/gate-flow",
+      mode: "single-branch",
+      siblingBranches: [],
+      hostPlatform: "win32",
+      evidencePlan: {
+        executionLane: "documentation",
+        digest: "plan-digest",
+      },
+    });
+
+    assert.deepEqual(plan.commands.map((command) => command.join(" ")), [
+      "git checkout -B local-integration/docs-gate-flow origin/main",
+      "git merge --no-ff --no-edit docs/gate-flow",
+      "node scripts/ci-evidence-plan.mjs --event local-ci --base origin/main --head HEAD",
+      "node scripts/gen-doc-index.mjs --check",
+      "node scripts/check-doc-links.mjs",
+      "node scripts/check-guards.mjs",
+    ]);
+    assert.equal(plan.executionLane, "documentation");
   });
 
   it("runs fast PR guard parity before the expensive test/build gates", () => {

--- a/scripts/local-integration-ci.mjs
+++ b/scripts/local-integration-ci.mjs
@@ -134,6 +134,7 @@ if (metadataOut) {
     integrationCommitSha,
     synthesizedTreeSha,
     buildStrategy: plan.buildStrategy,
+    executionLane: evidencePlan?.executionLane ?? plan.executionLane,
     productionArtifact,
     execution: {
       status: execution.status === 0 ? "passed" : "failed",
@@ -151,6 +152,7 @@ if (metadataOut) {
       plannerVersion: evidencePlan.plannerVersion,
       policyVersion: evidencePlan.policyVersion,
       evidenceTier: evidencePlan.evidenceTier,
+      executionLane: evidencePlan.executionLane,
       fullSuite: evidencePlan.fullSuite,
     } : null,
     ...collectToolchainFingerprint({ buildStrategy: plan.buildStrategy }),

--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -228,6 +228,7 @@ test("gate-worktree.mjs refuses to run when neither an explicit command, the stu
   mkdirSync(join(temp, "apps", "web", "lib", "nonprod"), { recursive: true });
   cpSync(gateScript, join(temp, "scripts", "gate-worktree.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "mcp-client.mjs"), join(temp, "scripts", "lib", "mcp-client.mjs"));
+  cpSync(join(repoRoot, "scripts", "lib", "documentation-evidence-lane.mjs"), join(temp, "scripts", "lib", "documentation-evidence-lane.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-failure-summary.mjs"), join(temp, "scripts", "lib", "local-ci-failure-summary.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "sandbox-freshness.mjs"), join(temp, "scripts", "lib", "sandbox-freshness.mjs"));
   // gate-worktree.mjs static-imports these lease-safety modules at load time


### PR DESCRIPTION
## Summary

Stops exact documentation-only changes from occupying the single heavyweight local-CI sandbox. The gate now proves a clean, current candidate tree with the authoritative evidence planner, runs documentation evidence before admission, and falls back to exhaustive verification whenever classification is stale or ambiguous.

## Changes

- add an authoritative `documentation` execution lane and pre-admission runner with governed evidence recording
- preserve exhaustive CI for gate/config/runtime changes and every uncertain candidate
- test that documentation candidates neither claim nor renew the scarce nonprod lease
- publish the binding flow-control design, implementation plan, canonical contributor guidance, and refreshed documentation impact graph
- retain follow-up work for immutable single-flight review/CI, durable webhook wakeups, governed resource lanes, and Workroom WIP/liveness controls

## Test plan

- [x] **Source-only change**
  - [x] Typecheck passed in the governed exact-tree local-CI run
  - [x] Targeted Node suite: 92 tests, 91 passed, 1 Windows signal-handler skip, 0 failed
- [x] **Runtime-bound change**
  - [x] Source checks passed in a compile-ready worktree
  - [x] Functional verification ran in the governed shared nonprod environment
  - [x] Exact-tree gate passed for the published branch head
- [ ] **Verification-harness limitation acknowledged** — not applicable

### Verification evidence

- `pnpm run pregate:preflight` — 52 guards clean
- `pnpm run pregate` — exact-tree exhaustive gate passed; typecheck, full tests, and production build completed
- independent semantic review — 2 review branches, 0 blocking findings
- `node scripts/gen-doc-impact.mjs --check` and derived-artifact registry — fresh

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed against the final diff
- [x] `pnpm run pregate:preflight` passed before the shared-sandbox lease
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` returned `PR readiness: READY`

## Related issues / Epic

- Parent: `EP-56AE0F69`
- Implements: `BI-B2E9FC9D`
- Program: `BI-7C1F43E3`

## Overlap sweep

Open PRs were checked before implementation. No active PR owns this concern; older overlapping worktree patches are already represented on `main` under different commit identities.

## Notes for the reviewer

This PR intentionally proves its own gate changes through the exhaustive lane. The documentation shortcut activates only for exact clean trees containing current `origin/main`; every other tree follows the existing heavyweight path.

Docs-Impact-Decision: Generated staleness-report behavior is unchanged; the canonical pre-PR guide and context standard document the new lane, and the impact graph is refreshed.
