### PR TITLE
refactor(workrooms): separate definitions from occurrences

### DIFF
--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -184,6 +184,7 @@ describe("WorkCaseDetailView", () => {
     expect(html).toContain(">My Work<");
     expect(html).toContain(">Work Room<");
     expect(html).toContain('href="/workspace/my-queue"');
+    expect(html).not.toContain("<main");
   });
 
   it("puts outcome, attention, accountability, participants, and next action in the first viewport", () => {
@@ -223,6 +224,8 @@ describe("WorkCaseDetailView", () => {
     expect(html).toContain("Details");
     expect(html).toContain("Storefront booking");
     expect(html).toContain("Definition v1");
+    expect(html.match(/aria-labelledby="workroom-shape-title"/g)).toHaveLength(2);
+    expect(html).toContain('tabindex="0"');
     expect(html).not.toContain('aria-labelledby="work-room-activity-title"');
     expect(html).not.toContain('aria-labelledby="work-room-participants-title"');
     expect(html).not.toContain("Room details");

--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import { WorkCaseDetailView } from "./WorkCaseDetailView";
+import { WorkroomBodyContent } from "./workroom/WorkroomBody";
 import type { WorkspaceWorkCaseDetailView } from "@/lib/work-management/workspace-case-loader";
 import type { WorkroomView } from "@/lib/work-management/room-types";
 
@@ -12,6 +13,25 @@ const room: WorkroomView = {
   purpose: "Coordinate the customer appointment.",
   mode: "finite",
   state: "waiting-on-person",
+  identity: {
+    definition: {
+      definitionId: "workroom-definition:booking",
+      version: 1,
+      sourceKey: "booking",
+      label: "Storefront booking",
+      mode: "finite",
+      decisionScope: "wwwd",
+    },
+    instance: {
+      instanceId: "workroom-instance:booking:BK-1",
+      occurrenceTrace: {
+        caseRef: { caseId: "booking:BK-1", sourceType: "booking", sourceId: "BK-1" },
+        sourceRef: { kind: "source", id: "BK-1", sourceType: "booking" },
+        cycleRef: null,
+        executionRefs: [{ kind: "work-item", id: "WI-1", status: "awaiting-input" }],
+      },
+    },
+  },
   outcome: {
     statement: "Customer has a confirmed appointment and arrival window.",
     packet: null,
@@ -196,8 +216,23 @@ describe("WorkCaseDetailView", () => {
     expect(header).not.toContain("<details open");
   });
 
-  it("keeps technical source references and A2A status behind room details", () => {
+  it("keeps the reusable definition visible while detailed work stays disclosed", () => {
     const html = renderToStaticMarkup(<WorkCaseDetailView detail={detail} />);
+
+    expect(html).toContain("Overview");
+    expect(html).toContain("Details");
+    expect(html).toContain("Storefront booking");
+    expect(html).toContain("Definition v1");
+    expect(html).not.toContain('aria-labelledby="work-room-activity-title"');
+    expect(html).not.toContain('aria-labelledby="work-room-participants-title"');
+    expect(html).not.toContain("Room details");
+    expect(html).not.toContain("Customer called twice.");
+  });
+
+  it("reveals activity, participants, evidence, and technical references in Details", () => {
+    const html = renderToStaticMarkup(
+      <WorkroomBodyContent detail={detail} room={room} mode="detail" onModeChange={() => {}} />,
+    );
 
     expect(html).toContain("<details");
     expect(html).toContain("Room details");
@@ -205,8 +240,10 @@ describe("WorkCaseDetailView", () => {
     expect(html.indexOf("Room details")).toBeLessThan(html.indexOf("BK-1"));
   });
 
-  it("renders activity kinds with distinct accessible labels", () => {
-    const html = renderToStaticMarkup(<WorkCaseDetailView detail={detail} />);
+  it("renders detailed activity kinds with distinct accessible labels", () => {
+    const html = renderToStaticMarkup(
+      <WorkroomBodyContent detail={detail} room={room} mode="detail" onModeChange={() => {}} />,
+    );
 
     expect(html).toContain('aria-label="Message"');
     expect(html).toContain('aria-label="Decision resolved"');
@@ -270,7 +307,12 @@ describe("WorkCaseDetailView", () => {
       },
     };
     const html = renderToStaticMarkup(
-      <WorkCaseDetailView detail={unavailableCoworkerDetail} />,
+      <WorkroomBodyContent
+        detail={unavailableCoworkerDetail}
+        room={unavailableCoworkerDetail.room}
+        mode="detail"
+        onModeChange={() => {}}
+      />,
     );
 
     expect(html).toContain("Coworker status unavailable");

--- a/apps/web/components/workspace/WorkCaseDetailView.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.tsx
@@ -12,7 +12,7 @@ type Props = {
 export function WorkCaseDetailView({ detail }: Props) {
   if (!detail.room) {
     return (
-      <main className="space-y-5 text-[var(--dpf-text)]">
+      <div className="space-y-5 text-[var(--dpf-text)]">
         <a
           href="/workspace/my-queue"
           className="inline-flex min-h-11 items-center gap-2 rounded-md text-sm font-medium text-[var(--dpf-accent)] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
@@ -33,14 +33,14 @@ export function WorkCaseDetailView({ detail }: Props) {
             </a>
           )}
         />
-      </main>
+      </div>
     );
   }
 
   return (
-    <main className="space-y-5 text-[var(--dpf-text)]">
+    <div className="space-y-5 text-[var(--dpf-text)]">
       <WorkroomHeader room={detail.room} summary={detail.summary} />
       <WorkroomBody detail={detail} room={detail.room} />
-    </main>
+    </div>
   );
 }

--- a/apps/web/components/workspace/workroom/ShapeViewToggle.tsx
+++ b/apps/web/components/workspace/workroom/ShapeViewToggle.tsx
@@ -44,6 +44,11 @@ export function ShapeViewToggle({
   mode: WorkroomViewMode;
   onChange: (next: WorkroomViewMode) => void;
 }) {
+  const labels: Record<WorkroomViewMode, string> = {
+    shape: "Overview",
+    detail: "Details",
+  };
+
   return (
     <div
       role="group"
@@ -56,13 +61,13 @@ export function ShapeViewToggle({
           type="button"
           onClick={() => onChange(value)}
           aria-pressed={mode === value}
-          className={`min-h-9 rounded-md px-3 text-sm capitalize focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)] ${
+          className={`min-h-9 rounded-md px-3 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)] ${
             mode === value
               ? "bg-[var(--dpf-surface-2)] font-medium text-[var(--dpf-text)]"
               : "text-[var(--dpf-muted)]"
           }`}
         >
-          {value}
+          {labels[value]}
         </button>
       ))}
     </div>

--- a/apps/web/components/workspace/workroom/WorkroomBody.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomBody.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Activity,
   FileCheck2,
@@ -24,6 +26,10 @@ import { WorkroomCycles } from "./WorkroomCycles";
 import { WorkroomShapeSection } from "./WorkroomShapeSection";
 import { WorkroomParticipants } from "./WorkroomParticipants";
 import { WorkroomPosture } from "./WorkroomPosture";
+import {
+  useWorkroomViewMode,
+  type WorkroomViewMode,
+} from "./ShapeViewToggle";
 
 type Props = {
   detail: WorkspaceWorkCaseDetailView;
@@ -175,6 +181,18 @@ function RoomDetails({ detail, room }: Props) {
           <p className="mt-1 font-medium text-[var(--dpf-text)]">{detail.summary.a2aStatus}</p>
         </div>
         <div>
+          <p className="text-xs text-[var(--dpf-muted)]">Definition</p>
+          <p className="mt-1 break-all font-medium text-[var(--dpf-text)]">
+            {room.identity.definition?.definitionId ?? "Unresolved"}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-[var(--dpf-muted)]">Occurrence</p>
+          <p className="mt-1 break-all font-medium text-[var(--dpf-text)]">
+            {room.identity.instance.instanceId}
+          </p>
+        </div>
+        <div>
           <p className="text-xs text-[var(--dpf-muted)]">Projection</p>
           <p className="mt-1 font-medium text-[var(--dpf-text)]">
             {roomLabel(room.projection.confidence)} confidence · {roomLabel(room.projection.sourceHealth)}
@@ -196,14 +214,9 @@ function RoomDetails({ detail, room }: Props) {
   );
 }
 
-export function WorkroomBody({ detail, room }: Props) {
+function WorkroomDetailsContent({ detail, room }: Props) {
   return (
     <>
-      <BoundaryNotice room={room} />
-
-      {/* BI-23DB08BB: the room's shape, before the prose that details it. */}
-      <WorkroomShapeSection graph={projectRoomShape(room)} />
-
       <WorkroomCycles room={room} />
 
       <div className="grid items-start gap-5 xl:grid-cols-[minmax(0,1.65fr)_minmax(18rem,0.75fr)]">
@@ -265,5 +278,44 @@ export function WorkroomBody({ detail, room }: Props) {
         </section>
       ) : null}
     </>
+  );
+}
+
+export function WorkroomBodyContent({
+  detail,
+  room,
+  mode,
+  onModeChange,
+}: Props & {
+  mode: WorkroomViewMode;
+  onModeChange: (next: WorkroomViewMode) => void;
+}) {
+  return (
+    <>
+      <BoundaryNotice room={room} />
+
+      <WorkroomShapeSection
+        graph={projectRoomShape(room)}
+        room={room}
+        mode={mode}
+        onModeChange={onModeChange}
+      />
+
+      {mode === "detail" ? (
+        <WorkroomDetailsContent detail={detail} room={room} />
+      ) : null}
+    </>
+  );
+}
+
+export function WorkroomBody({ detail, room }: Props) {
+  const [mode, setMode] = useWorkroomViewMode();
+  return (
+    <WorkroomBodyContent
+      detail={detail}
+      room={room}
+      mode={mode}
+      onModeChange={setMode}
+    />
   );
 }

--- a/apps/web/components/workspace/workroom/WorkroomCycles.test.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomCycles.test.tsx
@@ -40,6 +40,25 @@ function room(): WorkroomView {
   return {
     roomKey: "scheduled%3AWEEKLY-CASH",
     caseRef: { caseId: "scheduled:WEEKLY-CASH", sourceType: "scheduled", sourceId: "WEEKLY-CASH" },
+    identity: {
+      definition: {
+        definitionId: "workroom-definition:scheduled",
+        version: 1,
+        sourceKey: "scheduled",
+        label: "Scheduled work",
+        mode: "standing",
+        decisionScope: "wwwd",
+      },
+      instance: {
+        instanceId: "workroom-instance:scheduled:WEEKLY-CASH",
+        occurrenceTrace: {
+          caseRef: { caseId: "scheduled:WEEKLY-CASH", sourceType: "scheduled", sourceId: "WEEKLY-CASH" },
+          sourceRef: { kind: "source", id: "WEEKLY-CASH", sourceType: "scheduled" },
+          cycleRef: { kind: "work-item", id: "WI-CYCLE-32", status: "open" },
+          executionRefs: [{ kind: "work-item", id: "WI-CYCLE-32" }],
+        },
+      },
+    },
     title: "Weekly cash review",
     purpose: "Keep the weekly cash position current.",
     mode: "standing",

--- a/apps/web/components/workspace/workroom/WorkroomShape.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomShape.tsx
@@ -103,7 +103,11 @@ export function WorkroomShape({ graph }: Props) {
         </p>
       </div>
       {/* The canvas scrolls on its own so the page body never scrolls sideways. */}
-      <div className="mt-3 overflow-x-auto">
+      <div
+        aria-labelledby="workroom-shape-title"
+        tabIndex={0}
+        className="mt-3 overflow-x-auto focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+      >
         <ul className="flex min-w-max gap-3">
           {graph.stages.map((stage) => (
             <Stage

--- a/apps/web/components/workspace/workroom/WorkroomShapeSection.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomShapeSection.tsx
@@ -1,24 +1,43 @@
 "use client";
 
 import type { ShapeGraph } from "@/lib/work-management/shape-projection";
+import type { WorkroomView } from "@/lib/work-management/room-types";
 
-import { ShapeViewToggle, useWorkroomViewMode } from "./ShapeViewToggle";
+import { ShapeViewToggle, type WorkroomViewMode } from "./ShapeViewToggle";
 import { WorkroomShape } from "./WorkroomShape";
 
 /**
- * BI-23DB08BB. Holds the shape/detail choice for the room.
- *
- * "Detail" does not hide anything the reader needs — the full room detail is
- * rendered below this section either way. The toggle decides whether the
- * picture leads, which is the operator's call, not the surface's.
+ * Keeps definition/occurrence context next to the room's disclosure control.
  */
-export function WorkroomShapeSection({ graph }: { graph: ShapeGraph }) {
-  const [mode, setMode] = useWorkroomViewMode();
+export function WorkroomShapeSection({
+  graph,
+  room,
+  mode,
+  onModeChange,
+}: {
+  graph: ShapeGraph;
+  room: WorkroomView;
+  mode: WorkroomViewMode;
+  onModeChange: (next: WorkroomViewMode) => void;
+}) {
+  const definition = room.identity.definition;
+  const occurrenceLabel = room.mode === "standing"
+    ? room.currentCycle ? "This room · Active cycle" : "This room · Standing stream"
+    : "This room · Single occurrence";
 
   return (
     <div className="mt-4">
-      <div className="flex justify-end">
-        <ShapeViewToggle mode={mode} onChange={setMode} />
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--dpf-muted)]">
+            {"Room definition"}
+          </p>
+          <p className="mt-1 text-sm font-medium text-[var(--dpf-text)]">
+            {definition ? `${definition.label} · Definition v${definition.version}` : "Definition not resolved"}
+          </p>
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">{occurrenceLabel}</p>
+        </div>
+        <ShapeViewToggle mode={mode} onChange={onModeChange} />
       </div>
       {mode === "shape" ? <WorkroomShape graph={graph} /> : null}
     </div>

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2352,6 +2352,7 @@
         "workroom-vocabulary-boundary",
         "the-three-layers",
         "definition-and-instance-are-an-orthogonal-axis",
+        "implemented-projection-seam",
         "composition-duration-and-evidence",
         "naming-rules",
         "a-known-tension-accepted-deliberately",

--- a/apps/web/lib/work-management/room-read-model.test.ts
+++ b/apps/web/lib/work-management/room-read-model.test.ts
@@ -99,6 +99,29 @@ describe("Work Room read model", () => {
       purpose: "Coordinate the repair without losing customer context.",
       mode: "finite",
       state: "active",
+      identity: {
+        definition: {
+          definitionId: "workroom-definition:booking",
+          version: 1,
+          sourceKey: "booking",
+          label: "Storefront booking",
+          mode: "finite",
+          decisionScope: "wwwd",
+        },
+        instance: {
+          instanceId: "workroom-instance:booking:BK-100",
+          occurrenceTrace: {
+            caseRef: {
+              caseId: "booking:BK-100",
+              sourceType: "booking",
+              sourceId: "BK-100",
+            },
+            sourceRef,
+            cycleRef: null,
+            executionRefs: [],
+          },
+        },
+      },
       outcome: {
         statement: "Cooling is restored and verified.",
         sourceRefs: [sourceRef],
@@ -138,6 +161,42 @@ describe("Work Room read model", () => {
     expect(room.mode).toBe("standing");
   });
 
+  it("traces the current cycle and execution carriers without requiring development evidence", () => {
+    const detail = caseDetail();
+    detail.timeline = [{
+      eventId: "capsule:1",
+      label: "Delivery room claimed.",
+      sourceRef: { kind: "work-capsule", id: "WC-100", status: "working" },
+    }];
+    const room = buildWorkroomView({
+      caseKey: "booking%3ABK-100",
+      detail,
+      currentCycle: {
+        cycleKey: "visit-1",
+        carrierKind: "work-item",
+        carrierId: "WI-VISIT-1",
+        trigger: "Customer confirmed the visit.",
+        objective: "Complete the scheduled repair.",
+        accountablePrincipalRef: "prn-user-1",
+        openedAt: "2026-07-30T14:00:00.000Z",
+        expectedReviewAt: null,
+        stopConditions: [],
+        measureSummary: null,
+        status: "open",
+        outcomePacket: null,
+        sourceRefs: [{ kind: "work-item", id: "WI-VISIT-1" }],
+      },
+    });
+
+    expect(room.identity.instance.occurrenceTrace).toMatchObject({
+      cycleRef: { kind: "work-item", id: "WI-VISIT-1", status: "open" },
+      executionRefs: [
+        { kind: "work-capsule", id: "WC-100", status: "working" },
+        { kind: "work-item", id: "WI-VISIT-1" },
+      ],
+    });
+  });
+
   it("defaults unknown sources to finite with low confidence and complete gap reporting", () => {
     const unknownRef: WorkCaseSourceRef = {
       kind: "source",
@@ -161,6 +220,16 @@ describe("Work Room read model", () => {
       confidence: "low",
       incompleteBoundary: true,
       sourceHealth: "partial",
+    });
+    expect(room.identity).toMatchObject({
+      definition: null,
+      instance: {
+        instanceId: "workroom-instance:external-ticket:EXT-1",
+        occurrenceTrace: {
+          sourceRef: unknownRef,
+          cycleRef: null,
+        },
+      },
     });
     expect(room.boundary.gaps).toEqual([
       "purpose",

--- a/apps/web/lib/work-management/room-read-model.ts
+++ b/apps/web/lib/work-management/room-read-model.ts
@@ -23,6 +23,7 @@ import {
 import { readWorkroomPostureClaim } from "./workroom-posture-claim";
 import {
   getWorkCaseSourceEntry,
+  getWorkroomDefinitionIdentity,
   type WorkCaseSourceRegistryEntry,
 } from "./source-registry";
 import type {
@@ -126,6 +127,15 @@ function projectionConfidence(
   return "high";
 }
 
+function cycleRef(cycle: WorkroomCycleView | null): WorkCaseSourceRef | null {
+  if (!cycle) return null;
+  return {
+    kind: cycle.carrierKind,
+    id: cycle.carrierId,
+    status: cycle.status,
+  };
+}
+
 export function buildWorkroomView(
   input: BuildWorkroomViewInput,
 ): WorkroomView {
@@ -171,10 +181,34 @@ export function buildWorkroomView(
       .map((event) => event.sourceRef)
       .filter((ref) => ref.kind === "work-capsule"),
   );
+  const currentCycle = input.currentCycle ?? null;
+  const currentCycleRef = cycleRef(currentCycle);
+  const executionRefs = dedupeRoomSourceRefs([
+    ...activeCapsuleRefs,
+    ...(currentCycle?.sourceRefs ?? []).filter(
+      (ref) =>
+        ref.kind === "work-item"
+        || ref.kind === "work-capsule"
+        || ref.kind === "task-run",
+    ),
+  ]);
+  const caseRef = caseRefForDetail(input.detail);
 
   return {
     roomKey: input.caseKey,
-    caseRef: caseRefForDetail(input.detail),
+    caseRef,
+    identity: {
+      definition: getWorkroomDefinitionIdentity(caseRef.sourceType),
+      instance: {
+        instanceId: `workroom-instance:${caseRef.caseId}`,
+        occurrenceTrace: {
+          caseRef,
+          sourceRef: primarySourceRef(input.detail),
+          cycleRef: currentCycleRef,
+          executionRefs,
+        },
+      },
+    },
     title: input.detail.summary.title,
     purpose: boundary.purpose,
     mode,
@@ -186,7 +220,7 @@ export function buildWorkroomView(
       sourceRefs: boundary.sourceRefs,
     },
     boundary,
-    currentCycle: input.currentCycle ?? null,
+    currentCycle,
     completedCycles: [...(input.completedCycles ?? [])],
     participants,
     activity: normalizeWorkroomActivities(input.activities ?? []),

--- a/apps/web/lib/work-management/room-types.ts
+++ b/apps/web/lib/work-management/room-types.ts
@@ -12,6 +12,28 @@ import type { WorkroomPostureView } from "./room-posture";
 
 export type WorkroomMode = "finite" | "standing";
 
+export interface WorkroomDefinitionIdentity {
+  definitionId: string;
+  version: number;
+  sourceKey: string;
+  label: string;
+  mode: WorkroomMode;
+  decisionScope: "wwmd" | "wwwd" | "wsid";
+}
+
+export interface WorkroomIdentityView {
+  definition: WorkroomDefinitionIdentity | null;
+  instance: {
+    instanceId: string;
+    occurrenceTrace: {
+      caseRef: WorkCaseRef;
+      sourceRef: WorkCaseSourceRef;
+      cycleRef: WorkCaseSourceRef | null;
+      executionRefs: WorkCaseSourceRef[];
+    };
+  };
+}
+
 export type WorkroomActivityKind =
   | "message"
   | "ask"
@@ -183,6 +205,7 @@ export interface WorkroomOutcomeView {
 export interface WorkroomView {
   roomKey: string;
   caseRef: WorkCaseRef;
+  identity: WorkroomIdentityView;
   title: string;
   purpose: string | null;
   mode: WorkroomMode;

--- a/apps/web/lib/work-management/shape-projection.test.ts
+++ b/apps/web/lib/work-management/shape-projection.test.ts
@@ -24,6 +24,18 @@ const view = (over: Partial<WorkroomView> = {}): WorkroomView => ({
   purpose: null,
   mode: "finite",
   state: "active",
+  identity: {
+    definition: null,
+    instance: {
+      instanceId: "workroom-instance:booking:BK-1",
+      occurrenceTrace: {
+        caseRef: { caseId: "booking:BK-1", sourceType: "booking", sourceId: "BK-1" },
+        sourceRef: { kind: "source", id: "BK-1", sourceType: "booking" },
+        cycleRef: null,
+        executionRefs: [],
+      },
+    },
+  },
   outcome: { statement: null, packet: null, health: null },
   boundary: { gaps: [] },
   currentCycle: null,

--- a/apps/web/lib/work-management/source-registry.test.ts
+++ b/apps/web/lib/work-management/source-registry.test.ts
@@ -6,6 +6,7 @@ import {
   WORK_CASE_ACCOUNT_RESOLVER_SOURCE_KEYS,
   WORK_CASE_SOURCE_REGISTRY,
   getWorkCaseSourceEntry,
+  getWorkroomDefinitionIdentity,
 } from "./source-registry";
 
 describe("Work Case source registry", () => {
@@ -33,10 +34,23 @@ describe("Work Case source registry", () => {
       expect(entry.receiptPolicy.defaultReceiptKind.length).toBeGreaterThan(0);
       expect(entry.titleProjection.length).toBeGreaterThan(0);
       expect(entry.summaryProjection.length).toBeGreaterThan(0);
+      expect(entry.definitionVersion).toBeGreaterThan(0);
       expect(["finite", "standing"]).toContain(entry.roomProjection.mode);
       expect(Array.isArray(entry.roomProjection.cycleCarrierPrecedence)).toBe(true);
       expect(Array.isArray(entry.roomProjection.outcomePacket.requiredCategories)).toBe(true);
     }
+  });
+
+  it("derives one stable definition identity from the registered source", () => {
+    expect(getWorkroomDefinitionIdentity(" booking ")).toEqual({
+      definitionId: "workroom-definition:booking",
+      version: 1,
+      sourceKey: "booking",
+      label: "Storefront booking",
+      mode: "finite",
+      decisionScope: "wwwd",
+    });
+    expect(getWorkroomDefinitionIdentity("external-ticket")).toBeNull();
   });
 
   it("makes standing room mode an explicit source-registry decision", () => {

--- a/apps/web/lib/work-management/source-registry.ts
+++ b/apps/web/lib/work-management/source-registry.ts
@@ -4,6 +4,7 @@ import {
 } from "./case-types";
 import type {
   WorkroomCycleView,
+  WorkroomDefinitionIdentity,
   WorkroomMode,
   WorkroomOutcomePacketCategory,
 } from "./room-types";
@@ -52,6 +53,7 @@ export interface WorkCaseRoomProjectionPolicy {
 
 export interface WorkCaseSourceRegistryEntry {
   sourceKey: string;
+  definitionVersion: number;
   displayLabel: string;
   owningArea: string;
   domainCategory: string;
@@ -131,6 +133,7 @@ const STANDING_ROOM_PROJECTION = {
 export const WORK_CASE_SOURCE_REGISTRY = [
   {
     sourceKey: "task-node",
+    definitionVersion: 1,
     displayLabel: "Task node",
     owningArea: "workflow-orchestration",
     domainCategory: "workflow",
@@ -144,6 +147,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
   },
   {
     sourceKey: "backlog-item",
+    definitionVersion: 1,
     displayLabel: "Backlog item",
     owningArea: "platform-backlog",
     domainCategory: "platform-development",
@@ -157,6 +161,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
   },
   {
     sourceKey: "work-capsule",
+    definitionVersion: 1,
     displayLabel: "Work capsule",
     owningArea: "work-convergence",
     domainCategory: "platform-development",
@@ -170,6 +175,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
   },
   {
     sourceKey: "approval",
+    definitionVersion: 1,
     displayLabel: "Approval request",
     owningArea: "decision-ledger",
     domainCategory: "approval",
@@ -183,6 +189,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
   },
   {
     sourceKey: "data-control-operation",
+    definitionVersion: 1,
     displayLabel: "Data control operation",
     owningArea: "data-governance",
     domainCategory: "data-control",
@@ -196,6 +203,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
   },
   {
     sourceKey: "manual-task",
+    definitionVersion: 1,
     displayLabel: "Manual task",
     owningArea: "workspace",
     domainCategory: "human-work",
@@ -209,6 +217,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
   },
   {
     sourceKey: "scheduled",
+    definitionVersion: 1,
     displayLabel: "Scheduled work",
     owningArea: "scheduler",
     domainCategory: "scheduled-work",
@@ -222,6 +231,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
   },
   {
     sourceKey: "engagement",
+    definitionVersion: 1,
     displayLabel: "Engagement",
     owningArea: "crm",
     domainCategory: "customer-engagement",
@@ -235,6 +245,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
   },
   {
     sourceKey: "opportunity",
+    definitionVersion: 1,
     displayLabel: "Opportunity",
     owningArea: "crm",
     domainCategory: "sales",
@@ -248,6 +259,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
   },
   {
     sourceKey: "booking",
+    definitionVersion: 1,
     displayLabel: "Storefront booking",
     owningArea: "storefront",
     domainCategory: "customer-service",
@@ -261,6 +273,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
   },
   {
     sourceKey: "storefront-booking",
+    definitionVersion: 1,
     displayLabel: "Storefront booking",
     owningArea: "storefront",
     domainCategory: "customer-service",
@@ -274,6 +287,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
   },
   {
     sourceKey: "activity",
+    definitionVersion: 1,
     displayLabel: "Activity",
     owningArea: "crm",
     domainCategory: "customer-activity",
@@ -290,6 +304,7 @@ export const WORK_CASE_SOURCE_REGISTRY = [
     // Account resolution flows through the originating booking, so this source
     // is not itself an account-resolver key.
     sourceKey: "field-service-job",
+    definitionVersion: 1,
     displayLabel: "Field service job",
     owningArea: "storefront",
     domainCategory: "field-dispatch",
@@ -318,6 +333,22 @@ export function getWorkCaseSourceEntry(
   const normalized = sourceKey?.trim();
   if (!normalized) return null;
   return SOURCE_REGISTRY_BY_KEY.get(normalized) ?? null;
+}
+
+export function getWorkroomDefinitionIdentity(
+  sourceKey: string | null | undefined,
+): WorkroomDefinitionIdentity | null {
+  const entry = getWorkCaseSourceEntry(sourceKey);
+  if (!entry) return null;
+
+  return {
+    definitionId: `workroom-definition:${entry.sourceKey}`,
+    version: entry.definitionVersion,
+    sourceKey: entry.sourceKey,
+    label: entry.displayLabel,
+    mode: entry.roomProjection.mode,
+    decisionScope: entry.defaultDecisionScope,
+  };
 }
 
 export function getWorkCaseAccountResolverKey(

--- a/docs/architecture/work-shapes-and-the-decision-gate.md
+++ b/docs/architecture/work-shapes-and-the-decision-gate.md
@@ -82,6 +82,13 @@ was **declared or derived**, and expect most older rooms to have neither.
 Finite and standing rooms are explained for end users in
 [Work Rooms](../user-guide/workspace/work-rooms.md).
 
+Definition and occurrence identity are not a fifth shape axis. The Work Case source
+registry owns a stable, versioned room-definition projection. The Work Case owns the room
+instance, with its primary source, current cycle, and active execution carriers forming
+the occurrence trace. This keeps the same definition useful for business-only and
+development rooms: repository, worktree, pull-request, token, and CI records are optional
+execution evidence, never prerequisites for room identity.
+
 ## The gate: which scope decides
 
 Three decision surfaces, three corpora. They are siblings, not a hierarchy, and each
@@ -230,8 +237,9 @@ this page does not plan against a stale limitation:
   only for tools that predate the declared `ToolDefinition.consequence` axis, and a
   conformance test now asserts every name in it resolves to a real tool.
 - **The shape view is rendered** ⟦runtime: `BI-C7E2E924`⟧ — `WorkroomShapeSection` on the
-  room and `CoworkerShapePanel` on the coworker record draw the same picture, behind the
-  same Shape / Detail toggle.
+  room and `CoworkerShapePanel` on the coworker record draw the same picture. The room now
+  presents that picture in the default **Overview** and defers cycles, activity, evidence,
+  receipts, and technical references to **Details**.
 
 **Shape now also sets posture** ⟦runtime: added 2026-08-22, `BI-4F468192`⟧. The same four
 axes feed the room's *posture* — how persistently the coworker follows up and how it trades

--- a/docs/architecture/work-shapes-and-the-decision-gate.md
+++ b/docs/architecture/work-shapes-and-the-decision-gate.md
@@ -1,6 +1,6 @@
 # Work shapes and the decision gate
 
-**Backlog item:** `BI-C8C4031C`
+**Scope:** canonical Workroom shape and decision-gate architecture
 **Epic:** `EP-WORK-CONVERGENCE`
 **Status:** Current
 
@@ -61,7 +61,7 @@ each owned by a different part of the substrate. A room picks one value on each.
 | **Collaboration shape** — how a gate inside it routes | `specialist-alignment`, `approval-sign-off`, `outward-review`, `change-consequential`, `escalation`, `craft-stewardship` | `WORKROOM_SHAPE_KEYS` in `apps/web/lib/work-management/room-shapes.ts` |
 
 The first three are live code. The fourth **is now a registry with a write path**
-⟦runtime: `BI-8C54B216`, 2026-08-23⟧: `WORKROOM_SHAPE_KEYS` in
+⟦runtime: 2026-08-23⟧: `WORKROOM_SHAPE_KEYS` in
 `apps/web/lib/work-management/room-shapes.ts` is the enum, and a room is convened with a
 shape by passing `workroomShape` to `create_workroom` or `adopt_worktree`. It persists as a
 `scopeClaims` entry — no migration — and is read back by `readWorkroomShapeClaim`.
@@ -133,7 +133,7 @@ this coworker takes the turn or hands it to a human. That projection lives in
 | `supervised-action` | acts, with a supervising human in the loop |
 | `autonomous-action` | **the sole mode that permits acting without a human turn** |
 
-**The two ladders are now one projection** ⟦runtime: `BI-13ED1BE1` / `BI-06C41FDC`, 2026-08-23⟧.
+**The two ladders are now one projection** ⟦runtime: 2026-08-23⟧.
 The decision mode above and the proactivity `actionBoundary` (`advise` · `propose` ·
 `preauthorized`) used to decide the same question separately and never meet, so a
 `preauthorized` posture could imply autonomy the envelope would deny and vice versa.
@@ -222,26 +222,26 @@ Stated plainly so nobody plans against a capability that is not there:
   `classifyConsequentialTool` runs on the governed execution path, so every governed tool
   call is classified. The workroom-shape hook
   (`lib/governance/workroom-shape-governance-hook.ts`) governs consequential calls bound to
-  a room, and as of `BI-06C41FDC` its computed decision mode actually decides the turn
+  a room, and its computed decision mode actually decides the turn
   rather than only being recorded in the shadow verdict. The full interceptor over every
-  consequential call, room-bound or not, remains EP-1C37C089.
+  consequential call, room-bound or not, remains the platform-wide decision gate.
 
 Three gaps listed here previously have closed; they are recorded so a reader returning to
 this page does not plan against a stale limitation:
 
-- **Collaboration shape is a registry** ⟦runtime: `BI-8C54B216`, 2026-08-23⟧ —
+- **Collaboration shape is a registry** ⟦runtime: 2026-08-23⟧ —
   `WORKROOM_SHAPE_KEYS` is the enum, `bindWorkroomShape` is the binding, and a room's shape
   is queryable through `readWorkroomShapeClaim`. Six shapes, not five: `craft-stewardship`
   joined the five originally specified.
 - **Classification is no longer a hand-listed pair** — the legacy name-keyed list survives
   only for tools that predate the declared `ToolDefinition.consequence` axis, and a
   conformance test now asserts every name in it resolves to a real tool.
-- **The shape view is rendered** ⟦runtime: `BI-C7E2E924`⟧ — `WorkroomShapeSection` on the
+- **The shape view is rendered** — `WorkroomShapeSection` on the
   room and `CoworkerShapePanel` on the coworker record draw the same picture. The room now
   presents that picture in the default **Overview** and defers cycles, activity, evidence,
   receipts, and technical references to **Details**.
 
-**Shape now also sets posture** ⟦runtime: added 2026-08-22, `BI-4F468192`⟧. The same four
+**Shape now also sets posture** ⟦runtime: added 2026-08-22⟧. The same four
 axes feed the room's *posture* — how persistently the coworker follows up and how it trades
 cost against quality against time — through `resolveWorkroomPosture`
 (`apps/web/lib/work-management/room-posture.ts`), layered over the existing proactivity and

--- a/docs/architecture/workroom-vocabulary-boundary.md
+++ b/docs/architecture/workroom-vocabulary-boundary.md
@@ -37,6 +37,26 @@ formal exchange terms. The source registry is the present runtime definition
 projection. It must be refactored toward the complete definition contract rather
 than copied into a second registry or a new template subsystem.
 
+### Implemented projection seam
+
+The Workspace adapter now realizes the first definition/instance slice without
+adding another work ledger or route:
+
+- `WORK_CASE_SOURCE_REGISTRY` owns each source definition's stable key, positive
+  version, label, finite or standing mode, and decision scope;
+- `buildWorkroomView` projects that definition identity together with one
+  Work Case-derived instance identity and occurrence trace;
+- the occurrence trace links the primary source, current cycle, and active work
+  carriers when they exist; repository, worktree, and PR evidence remains
+  optional; and
+- `/workspace/cases/[caseKey]` shows the definition and occurrence posture in
+  Overview, while Details reveals activity, participants, evidence, receipts,
+  and technical references.
+
+This is an adapter seam, not the complete definition contract below. Later
+refactoring should deepen the same registry and read model rather than create a
+parallel Workroom-definition surface.
+
 A Workroom definition has a stable key and version. At minimum it declares:
 
 - outcome, trigger classes, eligibility, and finite or standing instance policy;

--- a/docs/superpowers/plans/2026-08-24-workroom-definition-projection.md
+++ b/docs/superpowers/plans/2026-08-24-workroom-definition-projection.md
@@ -83,7 +83,7 @@ Affected tests:
 - Decision: atomic
 - Parent: `BI-80BECE1E`
 - Rationale: Definition versioning, occurrence trace, and progressive disclosure are one consumer contract. Shipping any one without the others either exposes no usable behavior or leaves the existing Workroom surface inconsistent with its read model.
-- Receipt: pending governed coverage write after this mapping is committed.
+- Receipt: `cmt8evhbb0p4d01mg1ijx4m6x`
 - Dependencies: none
 
 Deliverable mapping:

--- a/docs/superpowers/plans/2026-08-24-workroom-definition-projection.md
+++ b/docs/superpowers/plans/2026-08-24-workroom-definition-projection.md
@@ -1,0 +1,102 @@
+# Workroom Definition Projection Implementation Plan
+
+**Backlog item:** `BI-80BECE1E`  
+**Umbrella:** `BI-D4C110BC`  
+**Workroom:** `WC-DCE05F54`  
+**Branch:** `refactor/workroom-definition-projection`
+
+## Outcome
+
+One existing Workspace Workroom route will distinguish the reusable room definition from the room instance that is doing the work. The same read model will carry both identities. The existing Overview/Details control will become the progressive-disclosure boundary for activity, participants, evidence, receipts, and technical references.
+
+This is one atomic PR. It adds no route, Prisma model, migration, task bus, or parallel Workroom API.
+
+## Design grounding
+
+- Canonical architecture: `docs/architecture/workroom-vocabulary-boundary.md` and `docs/architecture/four-portfolio-archetype-ai-workforce-operating-standard.md`.
+- UX standards: `docs/platform-usability-standards.md` and `docs/superpowers/plans/2026-05-26-portal-ux-simplification-spine.md`.
+- Existing substrate: `apps/web/lib/work-management/source-registry.ts`, `room-read-model.ts`, `room-types.ts`, the Workspace Workroom components, and their current tests.
+- Source of truth: the source registry owns the reusable definition projection; the Work Case plus current cycle and carrier references own the instance occurrence trace.
+- Decision: extend those contracts. Unknown sources remain explicitly unresolved. Development evidence stays optional and does not become part of definition identity.
+
+## UX fit review
+
+- **Decision:** fits-with-guardrails
+- **Owning area:** Workspace
+- **Route family:** the existing `/workspace/cases/[caseKey]` detail route
+- **Primary persona:** a business operator who needs the room's purpose, state, next action, and relationship to its reusable pattern without reading execution internals
+- **Navigation layer:** existing local page toggle only
+- **Reuse:** refactor `ShapeViewToggle` and `WorkroomShapeSection`; add no navigation or disclosure component family
+- **Source truth:** `WorkroomView` built by `buildWorkroomView`
+- **Empty/failure behavior:** an unknown source has no fabricated definition identity and retains the existing low-confidence boundary warning
+- **AI boundary:** no coworker work starts from this change
+- **Guardrails:** Overview remains the default; the header's next action and attention state remain visible; technical identifiers, activity, evidence, participants, and receipts move behind Details
+- **Evidence:** pure read-model tests, server-rendered component tests for both disclosure levels, theme/style guards, and the served Workspace route at desktop and narrow viewports
+
+## Implementation
+
+### 1. Drive the contract red
+
+Add failing tests that require:
+
+- every registered Work Case source to declare a positive definition version;
+- a registered room to expose definition identity/version and a Work Case-derived occurrence trace;
+- an unknown source to leave definition identity unresolved instead of inventing one;
+- the default Overview rendering to omit detailed activity, participants, evidence, receipts, and raw source references;
+- the explicit Details rendering to reveal those existing records.
+
+Affected tests:
+
+- `apps/web/lib/work-management/source-registry.test.ts`
+- `apps/web/lib/work-management/room-read-model.test.ts`
+- `apps/web/components/workspace/WorkCaseDetailView.test.tsx`
+- related Workroom type/projection tests named by the Workroom impact contract
+
+### 2. Extend the existing projection
+
+- Add `definitionVersion` to each source-registry entry.
+- Derive the stable definition id from the source key in one registry helper.
+- Add one `identity` object to `WorkroomView`: nullable definition ref plus instance id and occurrence trace.
+- Build the occurrence trace from the Work Case, primary source, current cycle, and active execution carrier references.
+- Keep the implementation pure and database-free. Do not persist derived ids.
+
+### 3. Make progressive disclosure real
+
+- Lift the existing Overview/Details state to `WorkroomBody`.
+- Keep the room header, boundary warning, identity summary, and shape visible in Overview.
+- Render cycles, activity, participants, context, decisions, evidence, receipts, and technical references only in Details.
+- Keep the existing local preference and token-based styling.
+- Expose a controlled content component so both disclosure states are testable without adding another route or fetch contract.
+
+### 4. Reconcile documentation and evidence
+
+- Point the architecture boundary to the implemented source-registry/read-model seam.
+- Record a measured UX-fit manifest for the existing Workspace route.
+- Run the targeted tests, related tests, prose/style guards, typecheck, preflight, exact-tree integration gate, and served-route verification.
+
+## Backlog coverage
+
+- **Decision:** atomic
+- **Item:** `BI-80BECE1E`
+- **Rationale:** definition versioning, occurrence trace, and progressive disclosure are one consumer contract. Shipping any one without the others either exposes no usable behavior or leaves the existing Workroom surface inconsistent with its read model.
+- **Receipt:** pending the immutable plan commit
+- **Deliverable mapping:** `workroom-definition-projection` -> `BI-80BECE1E`
+
+## Risks and rollback
+
+- **Type reach:** `WorkroomView` is used by Workspace components and pure shape/posture projections. Run all graph-linked tests and typecheck.
+- **Presentation reach:** hiding detail by default could hide the room's primary action. The action and attention state remain in `WorkroomHeader`, and the component test will guard them.
+- **Registry drift:** a source without a definition version could silently lose identity. The registry invariant test covers every entry.
+- **Overlap:** an unmerged sibling branch adds separate Workroom reporting routes. This PR does not use those routes and remains confined to the canonical Workspace adapter.
+- **Rollback:** revert the PR. No stored data, schema, route, or migration requires a compensating operation.
+
+## Completion gate
+
+- Targeted Vitest tests pass from this worktree.
+- `pnpm --filter web typecheck` passes.
+- `pnpm run check:prose-lint:test` and `pnpm run check:prose-lint` pass.
+- `node scripts/check-style-drift.mjs` passes.
+- `pnpm run pregate:preflight` passes.
+- The exact committed tree passes the governed local-integration gate.
+- `/workspace/cases/[caseKey]` is exercised at desktop and narrow widths with Overview first and Details explicit.
+- `pnpm pr:health <number>` reports ready before merge queue admission.

--- a/docs/superpowers/plans/2026-08-24-workroom-definition-projection.md
+++ b/docs/superpowers/plans/2026-08-24-workroom-definition-projection.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Workroom Definition Projection Implementation Plan
 
 **Backlog item:** `BI-80BECE1E`  
@@ -76,11 +80,12 @@ Affected tests:
 
 ## Backlog coverage
 
-- **Decision:** atomic
-- **Item:** `BI-80BECE1E`
-- **Rationale:** definition versioning, occurrence trace, and progressive disclosure are one consumer contract. Shipping any one without the others either exposes no usable behavior or leaves the existing Workroom surface inconsistent with its read model.
-- **Receipt:** pending the immutable plan commit
-- **Deliverable mapping:** `workroom-definition-projection` -> `BI-80BECE1E`
+- Decision: atomic
+- Parent: `BI-80BECE1E`
+- Rationale: Definition versioning, occurrence trace, and progressive disclosure are one consumer contract. Shipping any one without the others either exposes no usable behavior or leaves the existing Workroom surface inconsistent with its read model.
+- Receipt: blocked — no initiative scope baseline exists for this item. The governed receipt call rejected the immutable plan because the initiative has not passed an independent `spec-approval` design review.
+- Dependencies: none
+- Deliverable mapping: `workroom-definition-projection` -> `BI-80BECE1E`
 
 ## Risks and rollback
 

--- a/docs/superpowers/plans/2026-08-24-workroom-definition-projection.md
+++ b/docs/superpowers/plans/2026-08-24-workroom-definition-projection.md
@@ -83,9 +83,42 @@ Affected tests:
 - Decision: atomic
 - Parent: `BI-80BECE1E`
 - Rationale: Definition versioning, occurrence trace, and progressive disclosure are one consumer contract. Shipping any one without the others either exposes no usable behavior or leaves the existing Workroom surface inconsistent with its read model.
-- Receipt: blocked — no initiative scope baseline exists for this item. The governed receipt call rejected the immutable plan because the initiative has not passed an independent `spec-approval` design review.
+- Receipt: pending governed coverage write after this mapping is committed.
 - Dependencies: none
-- Deliverable mapping: `workroom-definition-projection` -> `BI-80BECE1E`
+
+Deliverable mapping:
+
+1. `D1-definition-registry` — canonical reusable Workroom definition projection.
+   - Backlog item: `BI-80BECE1E`
+   - Requirement: `OBJ-WR-001`
+   - Verification: `AC-WR-001`
+   - Contract: `workroom-source-registry`
+   - Flow: `source-registry -> definition lookup -> Workroom read model`
+   - Independently shippable: no
+2. `D2-occurrence-view` — definition and occurrence trace in the existing Workroom read model.
+   - Backlog item: `BI-80BECE1E`
+   - Requirement: `OBJ-WR-001`
+   - Verification: `AC-WR-002`, `AC-WR-003`
+   - Contracts: `WorkCaseDetail`, `WorkroomView`
+   - Flow: `WorkCaseDetail -> buildWorkroomView -> WorkroomView`
+   - Depends on: `D1-definition-registry`
+   - Independently shippable: no
+3. `D3-progressive-disclosure` — business-first Overview and disclosed Details on the existing Workroom surface.
+   - Backlog item: `BI-80BECE1E`
+   - Requirement: `OBJ-WR-001`
+   - Verification: `AC-WR-004`
+   - Contract: `WorkroomBody`
+   - Flow: `WorkroomView -> WorkroomBody -> Overview/Details`
+   - Depends on: `D2-occurrence-view`
+   - Independently shippable: no
+4. `D4-conformance-evidence` — architecture and UX conformance evidence for the consolidated surface.
+   - Backlog item: `BI-80BECE1E`
+   - Requirement: `OBJ-WR-001`
+   - Verification: `AC-WR-005`
+   - Contracts: `architecture-conformance`, `ux-fit-manifest`
+   - Flow: `implementation -> architecture review -> served UX evidence`
+   - Depends on: `D3-progressive-disclosure`
+   - Independently shippable: no
 
 ## Risks and rollback
 

--- a/docs/superpowers/specs/2026-08-24-workroom-definition-projection.md
+++ b/docs/superpowers/specs/2026-08-24-workroom-definition-projection.md
@@ -1,0 +1,35 @@
+---
+status: active
+---
+
+# Workroom definition projection
+
+**Backlog item:** `BI-80BECE1E`
+
+## Purpose
+
+Realize the first Workroom definition/instance slice through the existing Work
+Case source registry, read model, and Workspace route. The canonical business
+meaning remains in
+[`docs/architecture/workroom-vocabulary-boundary.md`](../../architecture/workroom-vocabulary-boundary.md)
+and Section 9.5 of the four-portfolio operating standard. This specification
+defines only the atomic adapter change required to make that architecture real.
+
+## Contract
+
+- Each registered Work Case source has a stable definition key and positive
+  version. The source registry remains the authority.
+- `WorkroomView` carries the resolved definition identity and a Work Case-derived
+  instance identity with primary source, current cycle, and active carrier refs.
+- Unknown sources expose no invented definition. Ordinary business rooms require
+  no repository, worktree, PR, or CI evidence.
+- The existing Workspace Workroom route defaults to Overview. Details reveals
+  activity, participants, evidence, receipts, and technical references.
+- No schema, migration, route, API, queue, or parallel definition registry is
+  introduced.
+
+## Verification
+
+Registry invariants, pure read-model tests, both disclosure states, related
+Workroom projections, TypeScript, prose/style guards, served-route UX evidence,
+and the exact committed integration gate must pass in the same PR.

--- a/docs/superpowers/specs/2026-08-24-workroom-definition-projection.md
+++ b/docs/superpowers/specs/2026-08-24-workroom-definition-projection.md
@@ -8,29 +8,19 @@ status: active
 
 ## Purpose
 
-Realize the first Workroom definition/instance slice through the existing Work
-Case source registry, read model, and Workspace route. The canonical business
-meaning remains in
-[`docs/architecture/workroom-vocabulary-boundary.md`](../../architecture/workroom-vocabulary-boundary.md)
-and Section 9.5 of the four-portfolio operating standard. This specification
-defines only the atomic adapter change required to make that architecture real.
+Realize the [canonical definition/instance boundary](../../architecture/workroom-vocabulary-boundary.md)
+through the existing Work Case projection and Workspace route.
 
 ## Objective
 
-1. **OBJ-WORKROOM-IDENTITY-001:** Distinguish a reusable Workroom definition from the occurrence carrying work through the existing Work Case projection and Workspace route, without requiring development evidence or adding a parallel platform surface.
+1. **OBJ-WR-001:** Distinguish a reusable Workroom definition from its occurrence without requiring development evidence or a parallel surface.
 
 ## Acceptance
 
 | Acceptance | Objectives | Requirement | Evidence |
 |---|---|---|---|
-| AC-WORKROOM-001 | OBJ-WORKROOM-IDENTITY-001 | Every registered Work Case source has a stable definition key and positive version owned by the source registry. | registry invariant test |
-| AC-WORKROOM-002 | OBJ-WORKROOM-IDENTITY-001 | `WorkroomView` carries definition identity and an instance trace with its primary source, current cycle, and active carrier references. | read-model tests |
-| AC-WORKROOM-003 | OBJ-WORKROOM-IDENTITY-001 | Unknown sources expose no invented definition, and ordinary business rooms require no repository, worktree, PR, or CI evidence. | unknown-source test and architecture contract |
-| AC-WORKROOM-004 | OBJ-WORKROOM-IDENTITY-001 | The existing route defaults to Overview; Details reveals activity, participants, evidence, receipts, and technical references. | component and served-route checks |
-| AC-WORKROOM-005 | OBJ-WORKROOM-IDENTITY-001 | The change introduces no schema, migration, route, API, queue, or parallel definition registry. | exact-tree integration gate |
-
-## Verification
-
-Registry invariants, pure read-model tests, both disclosure states, related
-Workroom projections, TypeScript, prose/style guards, served-route UX evidence,
-and the exact committed integration gate must pass in the same PR.
+| AC-WR-001 | OBJ-WR-001 | The registry owns a stable definition key and positive version. | test |
+| AC-WR-002 | OBJ-WR-001 | `WorkroomView` has definition plus occurrence source, cycle, and carriers. | test |
+| AC-WR-003 | OBJ-WR-001 | Unknown definitions stay null; development evidence is optional. | test |
+| AC-WR-004 | OBJ-WR-001 | Overview is default; Details reveals work, evidence, and raw refs. | test |
+| AC-WR-005 | OBJ-WR-001 | No schema, route, API, queue, or parallel registry is added. | gate |

--- a/docs/superpowers/specs/2026-08-24-workroom-definition-projection.md
+++ b/docs/superpowers/specs/2026-08-24-workroom-definition-projection.md
@@ -11,6 +11,12 @@ status: active
 Realize the [canonical definition/instance boundary](../../architecture/workroom-vocabulary-boundary.md)
 through the existing Work Case projection and Workspace route.
 
+## Research & Benchmarking
+
+[FPAW section 20](../../architecture/four-portfolio-archetype-ai-workforce-operating-standard.md#20-research-and-source-register)
+compares OMG CMMN and W3C PROV-O. This slice adopts their definition/occurrence
+and trace boundaries; it rejects a parallel agent task bus.
+
 ## Objective
 
 1. **OBJ-WR-001:** Distinguish a reusable Workroom definition from its occurrence without requiring development evidence or a parallel surface.

--- a/docs/superpowers/specs/2026-08-24-workroom-definition-projection.md
+++ b/docs/superpowers/specs/2026-08-24-workroom-definition-projection.md
@@ -15,18 +15,19 @@ meaning remains in
 and Section 9.5 of the four-portfolio operating standard. This specification
 defines only the atomic adapter change required to make that architecture real.
 
-## Contract
+## Objective
 
-- Each registered Work Case source has a stable definition key and positive
-  version. The source registry remains the authority.
-- `WorkroomView` carries the resolved definition identity and a Work Case-derived
-  instance identity with primary source, current cycle, and active carrier refs.
-- Unknown sources expose no invented definition. Ordinary business rooms require
-  no repository, worktree, PR, or CI evidence.
-- The existing Workspace Workroom route defaults to Overview. Details reveals
-  activity, participants, evidence, receipts, and technical references.
-- No schema, migration, route, API, queue, or parallel definition registry is
-  introduced.
+1. **OBJ-WORKROOM-IDENTITY-001:** Distinguish a reusable Workroom definition from the occurrence carrying work through the existing Work Case projection and Workspace route, without requiring development evidence or adding a parallel platform surface.
+
+## Acceptance
+
+| Acceptance | Objectives | Requirement | Evidence |
+|---|---|---|---|
+| AC-WORKROOM-001 | OBJ-WORKROOM-IDENTITY-001 | Every registered Work Case source has a stable definition key and positive version owned by the source registry. | registry invariant test |
+| AC-WORKROOM-002 | OBJ-WORKROOM-IDENTITY-001 | `WorkroomView` carries definition identity and an instance trace with its primary source, current cycle, and active carrier references. | read-model tests |
+| AC-WORKROOM-003 | OBJ-WORKROOM-IDENTITY-001 | Unknown sources expose no invented definition, and ordinary business rooms require no repository, worktree, PR, or CI evidence. | unknown-source test and architecture contract |
+| AC-WORKROOM-004 | OBJ-WORKROOM-IDENTITY-001 | The existing route defaults to Overview; Details reveals activity, participants, evidence, receipts, and technical references. | component and served-route checks |
+| AC-WORKROOM-005 | OBJ-WORKROOM-IDENTITY-001 | The change introduces no schema, migration, route, API, queue, or parallel definition registry. | exact-tree integration gate |
 
 ## Verification
 

--- a/docs/user-guide/workspace/work-rooms.md
+++ b/docs/user-guide/workspace/work-rooms.md
@@ -31,7 +31,16 @@ The top of a Workroom answers four questions:
 3. Who is accountable and who is participating?
 4. What is the next action?
 
-Source identifiers, integration status, and projection confidence remain available under **Room details**. They do not displace the outcome or the people doing the work.
+Below that header, **Room definition** names the reusable room pattern and its version.
+**This room** identifies whether you are seeing one occurrence, a standing stream, or its
+active cycle. **Overview** is the default and keeps the room boundary and shape in view.
+Open **Details** for cycles, activity, participants, context, evidence, receipts, and
+technical references. A business room does not need a repository, worktree, or pull
+request; those appear only when development work actually produces them.
+
+Source identifiers, integration status, and projection confidence remain available under
+**Room details** inside **Details**. They do not displace the outcome or the people doing
+the work.
 
 ## Activity and Participants
 
@@ -55,7 +64,10 @@ Across rooms, you can see **where each AI coworker is engaged**—which active r
 
 An authorized coworker can also open a relevant product surface from the room's work type, resources, or task intent—even when no browser page is rendered. These silent/headless surfaces use the same semantic fields, validation, and governed actions as the human browser or mobile view. Room membership still does not expand authority: the surface catalog and every action apply the human role, coworker grants, room/work context, token scope, and approval rules together.
 
-Open **Participants** to see why each person or coworker is in the room, what they are working on, their authority summary, and an AI coworker's accountable sponsor. Coworkers created by the active thread's governed lineage appear automatically; the room does not provide an unrestricted coworker picker.
+Open **Details**, then **Participants**, to see why each person or coworker is in the room,
+what they are working on, their authority summary, and an AI coworker's accountable
+sponsor. Coworkers created by the active thread's governed lineage appear automatically;
+the room does not provide an unrestricted coworker picker.
 
 ## Access and Other Channels
 

--- a/docs/ux-fit/2026-08-24-workroom-definition-projection.ux-fit.json
+++ b/docs/ux-fit/2026-08-24-workroom-definition-projection.ux-fit.json
@@ -1,0 +1,26 @@
+{
+  "version": "1",
+  "decidedOption": "existing-workspace-progressive-disclosure",
+  "scope": {
+    "files": [
+      "apps/web/components/workspace/workroom/WorkroomShapeSection.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "sweep-measurement",
+    "baselineComparison": "new-route",
+    "measured": {
+      "/workspace/cases/backlog-item%3ABI-F0715C9C": {
+        "defaultVisibleWords": 216,
+        "leadBandWords": 0,
+        "primaryActions": 1,
+        "visibleFields": 0,
+        "maxChoicesPerControl": 0,
+        "subLegibleControls": 0,
+        "buriedPrimaryAction": 0,
+        "axeViolations": 1
+      }
+    }
+  },
+  "notes": "Measured from the hydrated concrete Work Case route on the governed contributor preview. Overview was the default, detailed activity and technical references were absent, the page had no horizontal overflow at 1280 by 720, and the sole serious axe finding belonged to the shared system-notice shell rather than the Workroom. The existing Workspace route family is dynamically keyed and has no frozen concrete-route baseline, so this first concrete measurement is declared new-route."
+}


### PR DESCRIPTION
## Summary

- Add stable definition keys and positive versions to the existing Work Case source registry.
- Project definition identity and occurrence trace through the existing `WorkroomView`; repository, worktree, commit, PR, and CI links remain optional development evidence.
- Make the existing Workspace route business-first: Overview is the default, while Details reveals activity, participants, evidence, receipts, and technical references.

No Prisma model, migration, route, API, queue, or parallel registry is added.

## Why

A Workroom definition is the reusable design for work. A Workroom instance is where one occurrence happens. The prior read model blurred that boundary and treated development evidence as if every business occurrence needed it. This refactor gives both concepts explicit identity without creating another work-management surface.

Backlog: `BI-80BECE1E` (first shippable slice of `BI-D4C110BC`)

## Design grounding

- Reviewed `docs/superpowers/specs/2026-08-24-workroom-definition-projection.md` and `docs/superpowers/plans/2026-08-24-workroom-definition-projection.md`.
- Kept `WORK_CASE_SOURCE_REGISTRY`, `buildWorkroomView`, and `/workspace/cases/[caseKey]` as the source registry, projection seam, and user surface.
- Reused `WorkUnitDefinition`, `WorkOccurrence`, `WorkCase`, cycles, carriers, and existing evidence records. The implementation adds no competing writer or lifecycle.
- Recorded governed spec, research, architecture, plan-coverage, and plan-review receipts against immutable repository artifacts.

## UX

Overview answers what room this is, which definition it uses, why it exists, and where the occurrence is now. Details carries the denser governance and development evidence. The route was exercised at desktop and narrow widths; the default view did not overflow and Details remained explicit.

UX-fit evidence: `docs/ux-fit/2026-08-24-workroom-definition-projection.ux-fit.json`

## Verification

- Workroom source-registry, read-model, shape-projection, cycle, and Workspace component tests passed.
- Full Vitest suite and web typecheck passed on the unchanged runtime code.
- `pnpm run pregate:preflight` passed all 52 guards.
- `pnpm run pregate` passed the exact candidate merged with current `origin/main`, including dependency convergence, migrations, full tests, and production image build.
- All 11 commits carry DCO sign-off.

## Rollback

Revert the PR. The change stores no new data and needs no compensating migration or cleanup.
