### PR TITLE
fix(self-upgrade): reconcile engine digest strata

### DIFF
--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -283,7 +283,7 @@ describe("getSelfUpgradeStatus", () => {
     const sourceSha = "f".repeat(40);
     vi.mocked(readSelfUpgradeSupport).mockResolvedValue(consumerReleaseSupport);
     vi.mocked(loadReleaseInstallContext).mockResolvedValue(consumerReleaseContext);
-    vi.mocked(resolveReleaseUpgradeCandidate).mockResolvedValue({ kind: "target", tag: "v2.0.0", sourceSha, channelDigest: `sha256:${"b".repeat(64)}`, configDigest: `sha256:${"c".repeat(64)}` });
+    vi.mocked(resolveReleaseUpgradeCandidate).mockResolvedValue({ kind: "target", tag: "v2.0.0", sourceSha, channelDigest: `sha256:${"b".repeat(64)}`, platformManifestDigest: `sha256:${"d".repeat(64)}`, configDigest: `sha256:${"c".repeat(64)}`, platformOs: "linux", platformArchitecture: "amd64" });
     vi.mocked(getDeployedSha).mockResolvedValue("e".repeat(40));
     vi.mocked(isShaFresh).mockReturnValue(false);
     const result = await getSelfUpgradeStatus();

--- a/apps/web/lib/queue/functions/self-upgrade-handoff.test-support.ts
+++ b/apps/web/lib/queue/functions/self-upgrade-handoff.test-support.ts
@@ -41,7 +41,7 @@ export function configureReleaseUpgradeTest(input: {
   input.mocks.readCurrentContainerConfigDigest.mockResolvedValue(input.currentConfigDigest);
   input.mocks.readRegistryReleaseCandidate.mockResolvedValue({
     ...ok(),
-    candidate: { tag: "v2.0.0", sourceSha: input.sourceSha, channelDigest: `sha256:${"b".repeat(64)}`, platformManifestDigest: `sha256:${"c".repeat(64)}`, configDigest: input.targetConfigDigest },
+    candidate: { tag: "v2.0.0", sourceSha: input.sourceSha, channelDigest: `sha256:${"b".repeat(64)}`, platformManifestDigest: `sha256:${"c".repeat(64)}`, configDigest: input.targetConfigDigest, platformOs: "linux", platformArchitecture: "amd64" },
   });
 }
 

--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -330,7 +330,8 @@ describe("success path", () => {
         release: {
           tag: "v2.0.0",
           ghcrOwner: "opendigitalproductfactory",
-          configDigest: targetConfigDigest,
+          channelDigest: `sha256:${"b".repeat(64)}`, platformManifestDigest: `sha256:${"c".repeat(64)}`,
+          configDigest: targetConfigDigest, platformOs: "linux", platformArchitecture: "amd64",
         },
       }));
     } finally {

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -12,6 +12,7 @@ import {
   loadReleaseInstallContext,
   resolveReleaseUpgradeCandidate,
   resolveUpgradeStrategy,
+  type ReleaseTargetResult,
 } from "@/lib/self-upgrade/release-target";
 import {
   countPendingUpstreamCommits,
@@ -325,8 +326,7 @@ export async function runSelfUpgrade(
   const promotionComposeFiles = composeFiles ?? releaseInstall?.composeFiles;
 
   let upstreamSha: string | null = null;
-  let releaseTag: string | null = null;
-  let releaseConfigDigest: string | null = null;
+  let releaseTarget: Exclude<ReleaseTargetResult, { kind: "no-published-target" }> | null = null;
   const deployedSha = await getDeployedSha();
   if (upgradeStrategy === "release" && releaseInstall) {
     const currentConfigDigest = await readCurrentContainerConfigDigest();
@@ -344,8 +344,7 @@ export async function runSelfUpgrade(
       });
     }
     upstreamSha = target.sourceSha;
-    releaseTag = target.tag;
-    releaseConfigDigest = target.configDigest;
+    releaseTarget = target;
   } else if (config.sourceMode === "upstream") {
     await gitRun(buildFetchCommand({ hostSourcePath, remote, branch }).slice(1));
     const head = await gitRun(buildRemoteHeadCommand({ hostSourcePath, remote, branch }).slice(1));
@@ -500,8 +499,10 @@ export async function runSelfUpgrade(
   });
   if (!signingContext.ok) return { ok: false, status: "failed", runId: run.runId, reason: "installer-state-repair-required", excerpt: signingContext.reason };
   const { runtimeTransitionSecret, hostIdentity } = signingContext;
-  const release = releaseTag && releaseConfigDigest && releaseInstall
-    ? { tag: releaseTag, ghcrOwner: releaseInstall.ghcrOwner, configDigest: releaseConfigDigest }
+  const release = releaseTarget && releaseInstall
+    ? { tag: releaseTarget.tag, ghcrOwner: releaseInstall.ghcrOwner, channelDigest: releaseTarget.channelDigest,
+        platformManifestDigest: releaseTarget.platformManifestDigest, configDigest: releaseTarget.configDigest,
+        platformOs: releaseTarget.platformOs, platformArchitecture: releaseTarget.platformArchitecture }
     : undefined;
   const preflight = await runCandidatePreflight({
     dryRun: params.dryRun, readinessMode: config.readinessMode, readinessOwner: config.readinessOwner,

--- a/apps/web/lib/self-upgrade/preflight.test.ts
+++ b/apps/web/lib/self-upgrade/preflight.test.ts
@@ -8,7 +8,11 @@ describe("candidate signed install-state handoff", () => {
     const release = {
       tag: "v2026.08.24-consumer-self-upgrade.4",
       ghcrOwner: "owner",
+      channelDigest: `sha256:${"a".repeat(64)}`,
+      platformManifestDigest: `sha256:${"b".repeat(64)}`,
       configDigest: `sha256:${"c".repeat(64)}`,
+      platformOs: "linux" as const,
+      platformArchitecture: "amd64",
     };
     const artifact = { digest: `sha256:${"d".repeat(64)}`, contractSchema: 1, contractDigest: "c".repeat(64) } as never;
     const runtime = { buildCandidatePromoterImage: vi.fn(), resolvePromoterArtifact: vi.fn(async () => artifact), runPromoterReadiness: vi.fn(async () => ({ exitCode: 0, stdout: JSON.stringify({ sourceHash: "a".repeat(64), projectionHash: "b".repeat(64), fromSchemaVersion: 2, toSchemaVersion: 2 }), stderr: "" })) };

--- a/apps/web/lib/self-upgrade/preflight.ts
+++ b/apps/web/lib/self-upgrade/preflight.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
-import type { ReadinessOwner } from "./promoter";
+import type { ReadinessOwner, VerifiedReleaseIdentity } from "./promoter";
 import { signTransitionPayload } from "@/lib/platform-runtime/transition-protocol";
 import { verifyInstallStateMigrationEnvelope } from "../../../../scripts/lib/transition-signing.mjs";
 import { resolveSelfUpgradeHostIdentity, type SelfUpgradeHostIdentity } from "./config";
@@ -15,7 +15,6 @@ type PromoterRuntime = Pick<
 type RecordReadiness = typeof import("./run-store").recordPromoterReadiness;
 type FailRun = typeof import("./run-store").failRun;
 type ReadinessFailure = { code: string; message: string; remediation?: string };
-type ReleaseIdentity = { tag: string; ghcrOwner: string; configDigest: string };
 
 export type CandidatePreflightResult =
   | { ok: true; resolvedPromoterDigest?: string; migrationHandoff?: InstallStateMigrationHandoff }
@@ -47,7 +46,7 @@ export async function runCandidatePreflight(params: {
   /** Published immutable release promoter; bypasses source compilation. */
   candidatePromoterReference?: string;
   /** Verified release identity carried into candidate readiness. */
-  release?: ReleaseIdentity;
+  release?: VerifiedReleaseIdentity;
   callerProtocolVersion?: number;
   sourcePath: string;
   hostInstallPath: string;

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -289,7 +289,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
     { caller: "legacy bootstrap caller", configDigest: undefined, engineImageId: `sha256:${"c".repeat(64)}`, platformArchitecture: "amd64", expectedStatus: 0 },
     { caller: "unrecognized engine digest", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"f".repeat(64)}`, platformArchitecture: "amd64", expectedStatus: 1 },
     { caller: "wrong engine platform", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, platformArchitecture: "amd64", enginePlatformArchitecture: "arm64", expectedStatus: 1 },
-  ])("promotes a verified release into a source-free install for a $caller", ({ configDigest, engineImageId, platformArchitecture, enginePlatformArchitecture, frozenStrata, missingModernStratum, repoImageId, registryConfigDigest, expectedStatus }) => {
+  ])("promotes a verified release into a source-free install for a $caller", ({ caller, configDigest, engineImageId, platformArchitecture, enginePlatformArchitecture, frozenStrata, missingModernStratum, repoImageId, registryConfigDigest, expectedStatus }) => {
     const { root, source, backup, fakeBin } = makeScratch();
     const targetSha = "b".repeat(40);
     const candidateAssets = join(root, "candidate-assets");
@@ -353,6 +353,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       }
       expect(existsSync(gitLog)).toBe(false);
       expect(r.stdout).toContain(`step=done target=${targetSha}`);
+      if (caller.startsWith("N-1")) expect(r.stdout).toContain("step=release-identity mode=config-only");
       if (configDigest) {
         expect(r.stdout).not.toContain("mode=legacy-bootstrap");
       } else {

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -94,7 +94,7 @@ case "$*" in
   *".RepoDigests"*) printf "%s@%s\n" "$DPF_TEST_RELEASE_REPO" "\${DPF_TEST_RELEASE_REPO_ID:-$DPF_TEST_RELEASE_ENGINE_ID}" ;;
   *".Os"*) printf "%s" "\${DPF_TEST_RELEASE_OS:-linux}" ;;
   *".Architecture"*) printf "%s" "\${DPF_TEST_RELEASE_ARCHITECTURE:-amd64}" ;;
-  *"buildx imagetools inspect"*"--raw"*) case "$*" in *"@$DPF_TEST_RELEASE_PLATFORM_MANIFEST_DIGEST"*) printf '{"config":{"digest":"%s"}}' "\${DPF_TEST_RELEASE_REGISTRY_CONFIG_DIGEST:-$DPF_TEST_RELEASE_CONFIG_DIGEST}" ;; *) printf '{"manifests":[{"digest":"%s","platform":{"os":"%s","architecture":"%s"}}]}' "$DPF_TEST_RELEASE_PLATFORM_MANIFEST_DIGEST" "$DPF_TEST_RELEASE_OS" "$DPF_TEST_RELEASE_ARCHITECTURE" ;; esac ;;
+  *"buildx imagetools inspect"*"--raw"*) case "$*" in *"@$DPF_TEST_RELEASE_PLATFORM_MANIFEST_DIGEST"*) printf '{"config":{"digest":"%s"}}' "\${DPF_TEST_RELEASE_REGISTRY_CONFIG_DIGEST:-$DPF_TEST_RELEASE_CONFIG_DIGEST}" ;; *) if [ "\${DPF_TEST_DUPLICATE_PLATFORM:-no}" = yes ]; then printf '{"manifests":[{"digest":"%s","platform":{"os":"%s","architecture":"%s"}},{"digest":"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","platform":{"os":"%s","architecture":"%s"}}]}' "$DPF_TEST_RELEASE_PLATFORM_MANIFEST_DIGEST" "$DPF_TEST_RELEASE_OS" "$DPF_TEST_RELEASE_ARCHITECTURE" "$DPF_TEST_RELEASE_OS" "$DPF_TEST_RELEASE_ARCHITECTURE"; else printf '{"manifests":[{"digest":"%s","platform":{"os":"%s","architecture":"%s"}}]}' "$DPF_TEST_RELEASE_PLATFORM_MANIFEST_DIGEST" "$DPF_TEST_RELEASE_OS" "$DPF_TEST_RELEASE_ARCHITECTURE"; fi ;; esac ;;
   *"org.opencontainers.image.version"*) printf "%s" "$DPF_TEST_RELEASE_TAG" ;;
   *"org.opencontainers.image.revision"*) printf "%s" "$DPF_TEST_RELEASE_SHA" ;;
   "create "*) printf "candidate-container" ;;
@@ -163,7 +163,7 @@ function runPromote(opts: {
   principalVerifyFails?: boolean;
   release?: {
     tag: string; owner: string; channelDigest?: string; platformManifestDigest?: string;
-    configDigest?: string; engineImageId?: string; platformOs?: string; frozenStrata?: boolean; repoImageId?: string; registryConfigDigest?: string;
+    configDigest?: string; engineImageId?: string; platformOs?: string; frozenStrata?: boolean; repoImageId?: string; registryConfigDigest?: string; duplicatePlatform?: boolean;
     platformArchitecture?: string; enginePlatformArchitecture?: string;
     candidateAssets: string; gitLog: string;
   };
@@ -236,6 +236,7 @@ function runPromote(opts: {
       `export DPF_TEST_RELEASE_CONFIG_DIGEST=${shellQuote(opts.release.configDigest ?? `sha256:${"c".repeat(64)}`)}`,
       `export DPF_TEST_RELEASE_ENGINE_ID=${shellQuote(opts.release.engineImageId ?? opts.release.configDigest ?? `sha256:${"c".repeat(64)}`)}`,
       `export DPF_TEST_RELEASE_REPO_ID=${shellQuote(opts.release.repoImageId ?? "")}`, `export DPF_TEST_RELEASE_REGISTRY_CONFIG_DIGEST=${shellQuote(opts.release.registryConfigDigest ?? "")}`,
+      `export DPF_TEST_DUPLICATE_PLATFORM=${opts.release.duplicatePlatform ? "yes" : "no"}`,
       `export DPF_TEST_RELEASE_REPO=ghcr.io/${shellQuote(opts.release.owner)}/dpf-portal`,
       `export DPF_TEST_RELEASE_PLATFORM_MANIFEST_DIGEST=${shellQuote(opts.release.platformManifestDigest ?? `sha256:${"b".repeat(64)}`)}`,
       `export DPF_TEST_RELEASE_OS=${shellQuote(opts.release.platformOs ?? "linux")}`,
@@ -285,11 +286,12 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
     { caller: "N-1 config-only Docker Desktop caller", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, platformArchitecture: "amd64", frozenStrata: false, expectedStatus: 0 },
     { caller: "N-1 index absent from RepoDigests", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, repoImageId: `sha256:${"f".repeat(64)}`, platformArchitecture: "amd64", frozenStrata: false, expectedStatus: 1 },
     { caller: "N-1 registry config mismatch", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, registryConfigDigest: `sha256:${"f".repeat(64)}`, platformArchitecture: "amd64", frozenStrata: false, expectedStatus: 1 },
+    { caller: "N-1 ambiguous platform index", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, duplicatePlatform: true, platformArchitecture: "amd64", frozenStrata: false, expectedStatus: 1 },
     { caller: "partial modern packet", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, platformArchitecture: "amd64", missingModernStratum: true, expectedStatus: 1 },
     { caller: "legacy bootstrap caller", configDigest: undefined, engineImageId: `sha256:${"c".repeat(64)}`, platformArchitecture: "amd64", expectedStatus: 0 },
     { caller: "unrecognized engine digest", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"f".repeat(64)}`, platformArchitecture: "amd64", expectedStatus: 1 },
     { caller: "wrong engine platform", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, platformArchitecture: "amd64", enginePlatformArchitecture: "arm64", expectedStatus: 1 },
-  ])("promotes a verified release into a source-free install for a $caller", ({ caller, configDigest, engineImageId, platformArchitecture, enginePlatformArchitecture, frozenStrata, missingModernStratum, repoImageId, registryConfigDigest, expectedStatus }) => {
+  ])("promotes a verified release into a source-free install for a $caller", ({ caller, configDigest, engineImageId, platformArchitecture, enginePlatformArchitecture, frozenStrata, missingModernStratum, repoImageId, registryConfigDigest, duplicatePlatform, expectedStatus }) => {
     const { root, source, backup, fakeBin } = makeScratch();
     const targetSha = "b".repeat(40);
     const candidateAssets = join(root, "candidate-assets");
@@ -343,12 +345,12 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       const release = {
         tag: "v2.0.0", owner: "opendigitalproductfactory", channelDigest: `sha256:${"a".repeat(64)}`,
         platformManifestDigest: missingModernStratum ? undefined : `sha256:${"b".repeat(64)}`, configDigest, engineImageId, platformOs: "linux",
-        platformArchitecture, enginePlatformArchitecture, frozenStrata, repoImageId, registryConfigDigest, candidateAssets, gitLog,
+        platformArchitecture, enginePlatformArchitecture, frozenStrata, repoImageId, registryConfigDigest, duplicatePlatform, candidateAssets, gitLog,
       };
       const r = runPromote({ source, backup, targetSha, fakeBin, dockerLog, release });
       expect(r.status, r.stderr).toBe(expectedStatus);
       if (expectedStatus !== 0) {
-        expect(r.stderr).toMatch(/(?:missing required variables|not a pulled repository digest|resolved config digest .* does not match|does not match resolved (?:config\/platform\/channel identities|candidate linux\/amd64))/);
+        expect(r.stderr).toMatch(/(?:missing required variables|not a pulled repository digest|could not resolve an immutable|resolved config digest .* does not match|does not match resolved (?:config\/platform\/channel identities|candidate linux\/amd64))/);
         return;
       }
       expect(existsSync(gitLog)).toBe(false);

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -90,7 +90,11 @@ for arg in "$@"; do
 done
 [ -n "$DOCKER_LOG" ] && printf '%s\\n' "$*" >> "$DOCKER_LOG"
 case "$*" in
-  *".Id"*) printf "%s" "$DPF_TEST_RELEASE_CONFIG_DIGEST" ;;
+  *".Id"*) printf "%s" "\${DPF_TEST_RELEASE_ENGINE_ID:-$DPF_TEST_RELEASE_CONFIG_DIGEST}" ;;
+  *".RepoDigests"*) printf "%s@%s\n" "$DPF_TEST_RELEASE_REPO" "\${DPF_TEST_RELEASE_REPO_ID:-$DPF_TEST_RELEASE_ENGINE_ID}" ;;
+  *".Os"*) printf "%s" "\${DPF_TEST_RELEASE_OS:-linux}" ;;
+  *".Architecture"*) printf "%s" "\${DPF_TEST_RELEASE_ARCHITECTURE:-amd64}" ;;
+  *"buildx imagetools inspect"*"--raw"*) case "$*" in *"@$DPF_TEST_RELEASE_PLATFORM_MANIFEST_DIGEST"*) printf '{"config":{"digest":"%s"}}' "\${DPF_TEST_RELEASE_REGISTRY_CONFIG_DIGEST:-$DPF_TEST_RELEASE_CONFIG_DIGEST}" ;; *) printf '{"manifests":[{"digest":"%s","platform":{"os":"%s","architecture":"%s"}}]}' "$DPF_TEST_RELEASE_PLATFORM_MANIFEST_DIGEST" "$DPF_TEST_RELEASE_OS" "$DPF_TEST_RELEASE_ARCHITECTURE" ;; esac ;;
   *"org.opencontainers.image.version"*) printf "%s" "$DPF_TEST_RELEASE_TAG" ;;
   *"org.opencontainers.image.revision"*) printf "%s" "$DPF_TEST_RELEASE_SHA" ;;
   "create "*) printf "candidate-container" ;;
@@ -157,7 +161,12 @@ function runPromote(opts: {
   principalRecoveryDecision?: "recover" | "not-needed" | "blocked";
   principalResolveFails?: boolean;
   principalVerifyFails?: boolean;
-  release?: { tag: string; owner: string; configDigest?: string; candidateAssets: string; gitLog: string };
+  release?: {
+    tag: string; owner: string; channelDigest?: string; platformManifestDigest?: string;
+    configDigest?: string; engineImageId?: string; platformOs?: string; frozenStrata?: boolean; repoImageId?: string; registryConfigDigest?: string;
+    platformArchitecture?: string; enginePlatformArchitecture?: string;
+    candidateAssets: string; gitLog: string;
+  };
 }): { status: number | null; stdout: string; stderr: string } {
   const stateDir = join(opts.backup, "state");
   const secret = "s".repeat(32);
@@ -220,10 +229,17 @@ function runPromote(opts: {
       ...(opts.release.configDigest
         ? [`export DPF_RELEASE_CONFIG_DIGEST=${shellQuote(opts.release.configDigest)}`]
         : ["unset DPF_RELEASE_CONFIG_DIGEST"]),
+      ...(opts.release.frozenStrata === false || !opts.release.configDigest ? ["unset DPF_RELEASE_CHANNEL_DIGEST DPF_RELEASE_PLATFORM_MANIFEST_DIGEST DPF_RELEASE_PLATFORM_OS DPF_RELEASE_PLATFORM_ARCHITECTURE"] : [`export DPF_RELEASE_CHANNEL_DIGEST=${shellQuote(opts.release.channelDigest ?? "")}`, `export DPF_RELEASE_PLATFORM_MANIFEST_DIGEST=${shellQuote(opts.release.platformManifestDigest ?? "")}`, `export DPF_RELEASE_PLATFORM_OS=${shellQuote(opts.release.platformOs ?? "linux")}`, `export DPF_RELEASE_PLATFORM_ARCHITECTURE=${shellQuote(opts.release.platformArchitecture ?? "amd64")}`]),
       `export GHCR_OWNER=${shellQuote(opts.release.owner)}`,
       `export DPF_TEST_RELEASE_SHA=${shellQuote(opts.targetSha)}`,
       `export DPF_TEST_RELEASE_TAG=${shellQuote(opts.release.tag)}`,
       `export DPF_TEST_RELEASE_CONFIG_DIGEST=${shellQuote(opts.release.configDigest ?? `sha256:${"c".repeat(64)}`)}`,
+      `export DPF_TEST_RELEASE_ENGINE_ID=${shellQuote(opts.release.engineImageId ?? opts.release.configDigest ?? `sha256:${"c".repeat(64)}`)}`,
+      `export DPF_TEST_RELEASE_REPO_ID=${shellQuote(opts.release.repoImageId ?? "")}`, `export DPF_TEST_RELEASE_REGISTRY_CONFIG_DIGEST=${shellQuote(opts.release.registryConfigDigest ?? "")}`,
+      `export DPF_TEST_RELEASE_REPO=ghcr.io/${shellQuote(opts.release.owner)}/dpf-portal`,
+      `export DPF_TEST_RELEASE_PLATFORM_MANIFEST_DIGEST=${shellQuote(opts.release.platformManifestDigest ?? `sha256:${"b".repeat(64)}`)}`,
+      `export DPF_TEST_RELEASE_OS=${shellQuote(opts.release.platformOs ?? "linux")}`,
+      `export DPF_TEST_RELEASE_ARCHITECTURE=${shellQuote(opts.release.enginePlatformArchitecture ?? opts.release.platformArchitecture ?? "amd64")}`,
       `export DPF_TEST_RELEASE_ASSETS=${shellQuote(toBashPath(opts.release.candidateAssets))}`,
       `export GIT_LOG=${shellQuote(toBashPath(opts.release.gitLog))}`,
       "export PROMOTE_COMPOSE_FILES='docker-compose.yml docker-compose.release.yml'",
@@ -264,9 +280,16 @@ function makeScratch(): { root: string; source: string; backup: string; fakeBin:
 
 describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run", () => {
   it.each([
-    { caller: "digest-bound caller", configDigest: `sha256:${"c".repeat(64)}` },
-    { caller: "legacy bootstrap caller", configDigest: undefined },
-  ])("promotes a verified release into a source-free install for a $caller", ({ configDigest }) => {
+    { caller: "classic-store digest-bound caller", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"c".repeat(64)}`, platformArchitecture: "amd64", expectedStatus: 0 },
+    { caller: "Docker Desktop containerd index-ID caller", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, platformArchitecture: "amd64", expectedStatus: 0 },
+    { caller: "N-1 config-only Docker Desktop caller", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, platformArchitecture: "amd64", frozenStrata: false, expectedStatus: 0 },
+    { caller: "N-1 index absent from RepoDigests", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, repoImageId: `sha256:${"f".repeat(64)}`, platformArchitecture: "amd64", frozenStrata: false, expectedStatus: 1 },
+    { caller: "N-1 registry config mismatch", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, registryConfigDigest: `sha256:${"f".repeat(64)}`, platformArchitecture: "amd64", frozenStrata: false, expectedStatus: 1 },
+    { caller: "partial modern packet", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, platformArchitecture: "amd64", missingModernStratum: true, expectedStatus: 1 },
+    { caller: "legacy bootstrap caller", configDigest: undefined, engineImageId: `sha256:${"c".repeat(64)}`, platformArchitecture: "amd64", expectedStatus: 0 },
+    { caller: "unrecognized engine digest", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"f".repeat(64)}`, platformArchitecture: "amd64", expectedStatus: 1 },
+    { caller: "wrong engine platform", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, platformArchitecture: "amd64", enginePlatformArchitecture: "arm64", expectedStatus: 1 },
+  ])("promotes a verified release into a source-free install for a $caller", ({ configDigest, engineImageId, platformArchitecture, enginePlatformArchitecture, frozenStrata, missingModernStratum, repoImageId, registryConfigDigest, expectedStatus }) => {
     const { root, source, backup, fakeBin } = makeScratch();
     const targetSha = "b".repeat(40);
     const candidateAssets = join(root, "candidate-assets");
@@ -317,8 +340,17 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       writeFileSync(join(fakeBin, "git"), '#!/bin/sh\nprintf "git invoked: %s\\n" "$*" >> "$GIT_LOG"\nexit 97\n');
       chmodSync(join(fakeBin, "git"), 0o755);
 
-      const r = runPromote({ source, backup, targetSha, fakeBin, dockerLog, release: { tag: "v2.0.0", owner: "opendigitalproductfactory", configDigest, candidateAssets, gitLog } });
-      expect(r.status, r.stderr).toBe(0);
+      const release = {
+        tag: "v2.0.0", owner: "opendigitalproductfactory", channelDigest: `sha256:${"a".repeat(64)}`,
+        platformManifestDigest: missingModernStratum ? undefined : `sha256:${"b".repeat(64)}`, configDigest, engineImageId, platformOs: "linux",
+        platformArchitecture, enginePlatformArchitecture, frozenStrata, repoImageId, registryConfigDigest, candidateAssets, gitLog,
+      };
+      const r = runPromote({ source, backup, targetSha, fakeBin, dockerLog, release });
+      expect(r.status, r.stderr).toBe(expectedStatus);
+      if (expectedStatus !== 0) {
+        expect(r.stderr).toMatch(/(?:missing required variables|not a pulled repository digest|resolved config digest .* does not match|does not match resolved (?:config\/platform\/channel identities|candidate linux\/amd64))/);
+        return;
+      }
       expect(existsSync(gitLog)).toBe(false);
       expect(r.stdout).toContain(`step=done target=${targetSha}`);
       if (configDigest) {

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -283,6 +283,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
   it.each([
     { caller: "classic-store digest-bound caller", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"c".repeat(64)}`, platformArchitecture: "amd64", expectedStatus: 0 },
     { caller: "Docker Desktop containerd index-ID caller", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, platformArchitecture: "amd64", expectedStatus: 0 },
+    { caller: "modern index with cross-stratum config mismatch", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, registryConfigDigest: `sha256:${"f".repeat(64)}`, platformArchitecture: "amd64", expectedStatus: 1 },
     { caller: "N-1 config-only Docker Desktop caller", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, platformArchitecture: "amd64", frozenStrata: false, expectedStatus: 0 },
     { caller: "N-1 index absent from RepoDigests", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, repoImageId: `sha256:${"f".repeat(64)}`, platformArchitecture: "amd64", frozenStrata: false, expectedStatus: 1 },
     { caller: "N-1 registry config mismatch", configDigest: `sha256:${"c".repeat(64)}`, engineImageId: `sha256:${"a".repeat(64)}`, registryConfigDigest: `sha256:${"f".repeat(64)}`, platformArchitecture: "amd64", frozenStrata: false, expectedStatus: 1 },
@@ -373,7 +374,6 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       rmSync(root, { recursive: true, force: true });
     }
   }, PROMOTE_TEST_TIMEOUT_MS);
-
   it("stamps the source HEAD and sha-verify passes against a correctly-stamped portal", () => {
     const { root, source, backup, fakeBin, head } = makeScratch();
     try {

--- a/apps/web/lib/self-upgrade/promoter.test.ts
+++ b/apps/web/lib/self-upgrade/promoter.test.ts
@@ -223,7 +223,11 @@ describe("buildPromoterCommand", () => {
       release: {
         tag: "v2026.08.23",
         ghcrOwner: "opendigitalproductfactory",
+        channelDigest: `sha256:${"a".repeat(64)}`,
+        platformManifestDigest: `sha256:${"b".repeat(64)}`,
         configDigest: `sha256:${"c".repeat(64)}`,
+        platformOs: "linux",
+        platformArchitecture: "amd64",
       },
     });
     expect(args).toContain("/Users/me/dpf:/host-source");
@@ -231,6 +235,10 @@ describe("buildPromoterCommand", () => {
     expect(args).toContain("DPF_PROMOTION_MODE=release");
     expect(args).toContain("DPF_RELEASE_TAG=v2026.08.23");
     expect(args).toContain(`DPF_RELEASE_CONFIG_DIGEST=sha256:${"c".repeat(64)}`);
+    expect(args).toContain(`DPF_RELEASE_CHANNEL_DIGEST=sha256:${"a".repeat(64)}`);
+    expect(args).toContain(`DPF_RELEASE_PLATFORM_MANIFEST_DIGEST=sha256:${"b".repeat(64)}`);
+    expect(args).toContain("DPF_RELEASE_PLATFORM_OS=linux");
+    expect(args).toContain("DPF_RELEASE_PLATFORM_ARCHITECTURE=amd64");
     expect(args).toContain("GHCR_OWNER=opendigitalproductfactory");
     expect(args).toContain("PROMOTE_TARGET_SHA=abc1234");
   });

--- a/apps/web/lib/self-upgrade/promoter.ts
+++ b/apps/web/lib/self-upgrade/promoter.ts
@@ -89,6 +89,16 @@ export async function runPromoterReadiness(
   });
 }
 
+export type VerifiedReleaseIdentity = {
+  tag: string;
+  ghcrOwner: string;
+  channelDigest: string;
+  platformManifestDigest: string;
+  configDigest: string;
+  platformOs: "linux";
+  platformArchitecture: string;
+};
+
 export type PromoterParams = {
   /** HOST path of the install tree; bind-mounted into the promoter. */
   hostInstallPath: string;
@@ -152,7 +162,7 @@ export type PromoterParams = {
   /** Exact portal-verified carrier retained for orchestration identity/audit. */
   installStateMigrationHandoff?: InstallStateMigrationHandoff;
   /** Verified registry release promoted without a source checkout/build. */
-  release?: { tag: string; ghcrOwner: string; configDigest: string };
+  release?: VerifiedReleaseIdentity;
 };
 
 export type PromoterResult = {
@@ -168,6 +178,7 @@ const RUNTIME_HOST_PATH_SEGMENT = /^[A-Za-z0-9._ -]+$/;
 const RELEASE_TAG = /^v\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$/;
 const REGISTRY_OWNER = /^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,253}[A-Za-z0-9])?$/;
 const IMAGE_CONFIG_DIGEST = /^sha256:[a-f0-9]{64}$/;
+const RELEASE_PLATFORM_ARCHITECTURE = /^(?:amd64|arm64)$/;
 
 function isSafeRuntimeHostPath(value: string): boolean {
   if (value.length < 2 || value.length > 1024 || /[\0\r\n]/.test(value)) return false;
@@ -206,7 +217,11 @@ function validateRuntimeTransitionCommandInputs(params: PromoterParams): void {
   if (params.release && (
     !RELEASE_TAG.test(params.release.tag) ||
     !REGISTRY_OWNER.test(params.release.ghcrOwner) ||
-    !IMAGE_CONFIG_DIGEST.test(params.release.configDigest)
+    !IMAGE_CONFIG_DIGEST.test(params.release.channelDigest) ||
+    !IMAGE_CONFIG_DIGEST.test(params.release.platformManifestDigest) ||
+    !IMAGE_CONFIG_DIGEST.test(params.release.configDigest) ||
+    params.release.platformOs !== "linux" ||
+    !RELEASE_PLATFORM_ARCHITECTURE.test(params.release.platformArchitecture)
   )) {
     throw new Error("invalid_release_identity");
   }
@@ -294,7 +309,15 @@ export function buildPromoterCommand(
       "-e",
       `DPF_RELEASE_TAG=${params.release.tag}`,
       "-e",
+      `DPF_RELEASE_CHANNEL_DIGEST=${params.release.channelDigest}`,
+      "-e",
+      `DPF_RELEASE_PLATFORM_MANIFEST_DIGEST=${params.release.platformManifestDigest}`,
+      "-e",
       `DPF_RELEASE_CONFIG_DIGEST=${params.release.configDigest}`,
+      "-e",
+      `DPF_RELEASE_PLATFORM_OS=${params.release.platformOs}`,
+      "-e",
+      `DPF_RELEASE_PLATFORM_ARCHITECTURE=${params.release.platformArchitecture}`,
       "-e",
       `GHCR_OWNER=${params.release.ghcrOwner}`,
     );

--- a/apps/web/lib/self-upgrade/registry-release.test.ts
+++ b/apps/web/lib/self-upgrade/registry-release.test.ts
@@ -158,6 +158,8 @@ describe("readRegistryReleaseCandidate", () => {
         channelDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
         platformManifestDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
         configDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        platformOs: "linux",
+        platformArchitecture: "amd64",
       },
     });
   });

--- a/apps/web/lib/self-upgrade/registry-release.ts
+++ b/apps/web/lib/self-upgrade/registry-release.ts
@@ -28,6 +28,8 @@ export type RegistryReleaseCandidate = Readonly<{
   channelDigest: string;
   platformManifestDigest: string;
   configDigest: string;
+  platformOs: "linux";
+  platformArchitecture: string;
 }>;
 
 export type RegistryReleaseFailureReason =
@@ -388,6 +390,8 @@ export async function readRegistryReleaseCandidate(input: {
         channelDigest: channel.digest,
         platformManifestDigest,
         configDigest,
+        platformOs: "linux",
+        platformArchitecture: architecture,
       }),
     };
   } catch (error) {

--- a/apps/web/lib/self-upgrade/release-target.test.ts
+++ b/apps/web/lib/self-upgrade/release-target.test.ts
@@ -120,13 +120,18 @@ describe("consumer release target", () => {
         channelDigest: `sha256:${"d".repeat(64)}`,
         platformManifestDigest: `sha256:${"e".repeat(64)}`,
         configDigest: `sha256:${"c".repeat(64)}`,
+        platformOs: "linux",
+        platformArchitecture: "amd64",
       },
     })).toEqual({
       kind: "up-to-date",
       tag: "v2026.08.22",
       sourceSha: "a".repeat(40),
       channelDigest: `sha256:${"d".repeat(64)}`,
+      platformManifestDigest: `sha256:${"e".repeat(64)}`,
       configDigest: `sha256:${"c".repeat(64)}`,
+      platformOs: "linux",
+      platformArchitecture: "amd64",
     });
   });
 
@@ -140,13 +145,18 @@ describe("consumer release target", () => {
         channelDigest,
         platformManifestDigest: `sha256:${"e".repeat(64)}`,
         configDigest: `sha256:${"c".repeat(64)}`,
+        platformOs: "linux",
+        platformArchitecture: "amd64",
       },
     })).toEqual({
       kind: "up-to-date",
       tag: "v2026.08.24-consumer-self-upgrade.6",
       sourceSha: "a".repeat(40),
       channelDigest,
+      platformManifestDigest: `sha256:${"e".repeat(64)}`,
       configDigest: `sha256:${"c".repeat(64)}`,
+      platformOs: "linux",
+      platformArchitecture: "amd64",
     });
   });
 
@@ -160,6 +170,8 @@ describe("consumer release target", () => {
         channelDigest: `sha256:${"d".repeat(64)}`,
         platformManifestDigest,
         configDigest: `sha256:${"c".repeat(64)}`,
+        platformOs: "linux",
+        platformArchitecture: "amd64",
       },
     }).kind).toBe("up-to-date");
   });
@@ -173,13 +185,18 @@ describe("consumer release target", () => {
         channelDigest: `sha256:${"d".repeat(64)}`,
         platformManifestDigest: `sha256:${"e".repeat(64)}`,
         configDigest: `sha256:${"f".repeat(64)}`,
+        platformOs: "linux",
+        platformArchitecture: "amd64",
       },
     })).toEqual({
       kind: "target",
       tag: "v2026.08.22",
       sourceSha: "b".repeat(40),
       channelDigest: `sha256:${"d".repeat(64)}`,
+      platformManifestDigest: `sha256:${"e".repeat(64)}`,
       configDigest: `sha256:${"f".repeat(64)}`,
+      platformOs: "linux",
+      platformArchitecture: "amd64",
     });
   });
 

--- a/apps/web/lib/self-upgrade/release-target.ts
+++ b/apps/web/lib/self-upgrade/release-target.ts
@@ -105,8 +105,8 @@ export function resolveUpgradeStrategy(
 }
 
 export type ReleaseTargetResult =
-  | { kind: "target"; tag: string; sourceSha: string; channelDigest: string; configDigest: string }
-  | { kind: "up-to-date"; tag: string; sourceSha: string; channelDigest: string; configDigest: string }
+  | { kind: "target"; tag: string; sourceSha: string; channelDigest: string; platformManifestDigest: string; configDigest: string; platformOs: "linux"; platformArchitecture: string }
+  | { kind: "up-to-date"; tag: string; sourceSha: string; channelDigest: string; platformManifestDigest: string; configDigest: string; platformOs: "linux"; platformArchitecture: string }
   | { kind: "no-published-target"; reason: RegistryReleaseFailureReason | "current-image-identity-missing" };
 
 export function resolveReleaseTarget(input: {
@@ -137,7 +137,10 @@ export function resolveReleaseTarget(input: {
       tag: input.candidate.tag,
       sourceSha: input.candidate.sourceSha,
       channelDigest: input.candidate.channelDigest,
+      platformManifestDigest: input.candidate.platformManifestDigest,
       configDigest: input.candidate.configDigest,
+      platformOs: input.candidate.platformOs,
+      platformArchitecture: input.candidate.platformArchitecture,
     };
   }
   return {
@@ -145,7 +148,10 @@ export function resolveReleaseTarget(input: {
     tag: input.candidate.tag,
     sourceSha: input.candidate.sourceSha,
     channelDigest: input.candidate.channelDigest,
+    platformManifestDigest: input.candidate.platformManifestDigest,
     configDigest: input.candidate.configDigest,
+    platformOs: input.candidate.platformOs,
+    platformArchitecture: input.candidate.platformArchitecture,
   };
 }
 

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -24,6 +24,23 @@ _promoter_dir="${DPF_PROMOTER_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # may consume identity baked into the candidate image. Explicit source callers
 # and source installs never enter this path.
 _candidate_release_error=""
+_resolve_immutable_release_config_digest() {
+  local _immutable_ref="$1"
+  local _platform_os="$2"
+  local _platform_architecture="$3"
+  local _raw_manifest=""
+  local _platform_manifest_digest=""
+  local _repository="${_immutable_ref%@*}"
+
+  _raw_manifest="$(docker buildx imagetools inspect "$_immutable_ref" --raw)" || return 1
+  if printf '%s' "$_raw_manifest" | node -e 'const raw=require("node:fs").readFileSync(0,"utf8"); const value=JSON.parse(raw); const digest=value?.config?.digest; if(!/^sha256:[a-f0-9]{64}$/.test(digest??"")) process.exit(2); process.stdout.write(digest)'; then
+    return 0
+  fi
+  _platform_manifest_digest="$(printf '%s' "$_raw_manifest" | node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(0,"utf8")); const matches=(value.manifests??[]).filter((entry)=>entry?.platform?.os===process.argv[1]&&entry?.platform?.architecture===process.argv[2]&&/^sha256:[a-f0-9]{64}$/.test(entry?.digest??"")); if(matches.length!==1) process.exit(2); process.stdout.write(matches[0].digest)' "$_platform_os" "$_platform_architecture")" || return 1
+  _raw_manifest="$(docker buildx imagetools inspect "${_repository}@${_platform_manifest_digest}" --raw)" || return 1
+  printf '%s' "$_raw_manifest" | node -e 'const raw=require("node:fs").readFileSync(0,"utf8"); const value=JSON.parse(raw); const digest=value?.config?.digest; if(!/^sha256:[a-f0-9]{64}$/.test(digest??"")) process.exit(2); process.stdout.write(digest)'
+}
+
 _resolve_candidate_release_bootstrap() {
   _candidate_release_error=""
 
@@ -256,6 +273,7 @@ _missing=()
 [[ -n "${PROMOTE_HEALTH_URL:-}"  ]] || _missing+=(PROMOTE_HEALTH_URL)
 
 _release_mode=0
+_release_identity_mode="legacy-no-config"
 if [[ "${DPF_PROMOTION_MODE:-source}" == "release" ]]; then
   _release_mode=1
   [[ "${DPF_RELEASE_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9.-]+)?$ ]] || _missing+=(DPF_RELEASE_TAG)
@@ -264,6 +282,18 @@ if [[ "${DPF_PROMOTION_MODE:-source}" == "release" ]]; then
   # callers always send the digest and remain bound to it below.
   if [[ -n "${DPF_RELEASE_CONFIG_DIGEST:-}" && ! "${DPF_RELEASE_CONFIG_DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
     _missing+=(DPF_RELEASE_CONFIG_DIGEST)
+  fi
+  if [[ -n "${DPF_RELEASE_CONFIG_DIGEST:-}" ]]; then
+    _release_identity_mode="config-only"
+  fi
+  if [[ -n "${DPF_RELEASE_CHANNEL_DIGEST:-}" || -n "${DPF_RELEASE_PLATFORM_MANIFEST_DIGEST:-}" ||
+        -n "${DPF_RELEASE_PLATFORM_OS:-}" || -n "${DPF_RELEASE_PLATFORM_ARCHITECTURE:-}" ]]; then
+    _release_identity_mode="full"
+    [[ "${DPF_RELEASE_CONFIG_DIGEST:-}" =~ ^sha256:[a-f0-9]{64}$ ]] || _missing+=(DPF_RELEASE_CONFIG_DIGEST)
+    [[ "${DPF_RELEASE_CHANNEL_DIGEST:-}" =~ ^sha256:[a-f0-9]{64}$ ]] || _missing+=(DPF_RELEASE_CHANNEL_DIGEST)
+    [[ "${DPF_RELEASE_PLATFORM_MANIFEST_DIGEST:-}" =~ ^sha256:[a-f0-9]{64}$ ]] || _missing+=(DPF_RELEASE_PLATFORM_MANIFEST_DIGEST)
+    [[ "${DPF_RELEASE_PLATFORM_OS:-}" == "linux" ]] || _missing+=(DPF_RELEASE_PLATFORM_OS)
+    [[ "${DPF_RELEASE_PLATFORM_ARCHITECTURE:-}" =~ ^(amd64|arm64)$ ]] || _missing+=(DPF_RELEASE_PLATFORM_ARCHITECTURE)
   fi
   [[ "${GHCR_OWNER:-}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$ ]] || _missing+=(GHCR_OWNER)
 fi
@@ -297,17 +327,50 @@ _candidate_portal=""
 if [[ $_release_mode -eq 1 && $_dry_run -eq 0 ]]; then
   _candidate_portal="ghcr.io/${GHCR_OWNER}/dpf-portal:${DPF_RELEASE_TAG}"
   docker pull "$_candidate_portal" >/dev/null
-  _candidate_config_digest="$(docker image inspect "$_candidate_portal" --format '{{.Id}}' | tr -d '[:space:]')"
-  [[ "$_candidate_config_digest" =~ ^sha256:[a-f0-9]{64}$ ]] || {
-    printf 'error: release portal returned invalid config digest %s\n' "${_candidate_config_digest:-missing}" >&2
-    exit 1
-  }
-  [[ -z "${DPF_RELEASE_CONFIG_DIGEST:-}" || "$_candidate_config_digest" == "$DPF_RELEASE_CONFIG_DIGEST" ]] || {
-    printf 'error: release portal config digest %s does not match resolved candidate %s\n' "${_candidate_config_digest:-missing}" "$DPF_RELEASE_CONFIG_DIGEST" >&2
+  _candidate_engine_digest="$(docker image inspect "$_candidate_portal" --format '{{.Id}}' | tr -d '[:space:]')"
+  [[ "$_candidate_engine_digest" =~ ^sha256:[a-f0-9]{64}$ ]] || {
+    printf 'error: release portal returned invalid engine digest %s\n' "${_candidate_engine_digest:-missing}" >&2
     exit 1
   }
   if [[ -z "${DPF_RELEASE_CONFIG_DIGEST:-}" ]]; then
-    printf 'step=release-identity mode=legacy-bootstrap config-digest=%s\n' "$_candidate_config_digest"
+    printf 'step=release-identity mode=legacy-bootstrap engine-digest=%s\n' "$_candidate_engine_digest"
+  fi
+  _candidate_platform_os="$(docker image inspect "$_candidate_portal" --format '{{.Os}}' | tr -d '[:space:]')"
+  _candidate_platform_architecture="$(docker image inspect "$_candidate_portal" --format '{{.Architecture}}' | tr -d '[:space:]')"
+  if [[ "$_release_identity_mode" == "full" &&
+        ( "$_candidate_platform_os" != "$DPF_RELEASE_PLATFORM_OS" || "$_candidate_platform_architecture" != "$DPF_RELEASE_PLATFORM_ARCHITECTURE" ) ]]; then
+    printf 'error: release portal platform %s/%s does not match resolved candidate %s/%s\n' \
+      "${_candidate_platform_os:-missing}" "${_candidate_platform_architecture:-missing}" "$DPF_RELEASE_PLATFORM_OS" "$DPF_RELEASE_PLATFORM_ARCHITECTURE" >&2
+    exit 1
+  fi
+  if [[ "$_release_identity_mode" == "full" &&
+        "$_candidate_engine_digest" != "$DPF_RELEASE_CONFIG_DIGEST" &&
+        "$_candidate_engine_digest" != "$DPF_RELEASE_PLATFORM_MANIFEST_DIGEST" &&
+        "$_candidate_engine_digest" != "$DPF_RELEASE_CHANNEL_DIGEST" ]]; then
+    printf 'error: release portal engine digest %s does not match resolved config/platform/channel identities %s %s %s\n' \
+      "${_candidate_engine_digest:-missing}" "$DPF_RELEASE_CONFIG_DIGEST" "$DPF_RELEASE_PLATFORM_MANIFEST_DIGEST" "$DPF_RELEASE_CHANNEL_DIGEST" >&2
+    exit 1
+  fi
+  if [[ "$_release_identity_mode" == "config-only" && "$_candidate_engine_digest" != "$DPF_RELEASE_CONFIG_DIGEST" ]]; then
+    [[ "$_candidate_platform_os" == "linux" && "$_candidate_platform_architecture" =~ ^(amd64|arm64)$ ]] || {
+      printf 'error: release portal legacy platform %s/%s is unsupported\n' "${_candidate_platform_os:-missing}" "${_candidate_platform_architecture:-missing}" >&2
+      exit 1
+    }
+    _candidate_repository="ghcr.io/${GHCR_OWNER}/dpf-portal"
+    _candidate_immutable_ref="${_candidate_repository}@${_candidate_engine_digest}"
+    _candidate_repo_digests="$(docker image inspect "$_candidate_portal" --format '{{range .RepoDigests}}{{println .}}{{end}}' | tr -d '\r')"
+    grep -Fxq "$_candidate_immutable_ref" <<<"$_candidate_repo_digests" || {
+      printf 'error: release portal engine digest %s is not a pulled repository digest for %s\n' "$_candidate_engine_digest" "$_candidate_repository" >&2
+      exit 1
+    }
+    _candidate_resolved_config_digest="$(_resolve_immutable_release_config_digest "$_candidate_immutable_ref" "$_candidate_platform_os" "$_candidate_platform_architecture")" || {
+      printf 'error: release portal engine digest %s could not resolve an immutable %s/%s config\n' "$_candidate_engine_digest" "$_candidate_platform_os" "$_candidate_platform_architecture" >&2
+      exit 1
+    }
+    [[ "$_candidate_resolved_config_digest" == "$DPF_RELEASE_CONFIG_DIGEST" ]] || {
+      printf 'error: release portal resolved config digest %s does not match legacy caller %s\n' "$_candidate_resolved_config_digest" "$DPF_RELEASE_CONFIG_DIGEST" >&2
+      exit 1
+    }
   fi
   _candidate_revision="$(docker image inspect "$_candidate_portal" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' | tr -d '[:space:]')"
   [[ "$_candidate_revision" == "$PROMOTE_TARGET_SHA" ]] || {

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -351,6 +351,20 @@ if [[ $_release_mode -eq 1 && $_dry_run -eq 0 ]]; then
       "${_candidate_engine_digest:-missing}" "$DPF_RELEASE_CONFIG_DIGEST" "$DPF_RELEASE_PLATFORM_MANIFEST_DIGEST" "$DPF_RELEASE_CHANNEL_DIGEST" >&2
     exit 1
   fi
+  if [[ "$_release_identity_mode" == "full" && "$_candidate_engine_digest" != "$DPF_RELEASE_CONFIG_DIGEST" ]]; then
+    _candidate_repository="ghcr.io/${GHCR_OWNER}/dpf-portal"
+    _candidate_immutable_ref="${_candidate_repository}@${_candidate_engine_digest}"
+    _candidate_resolved_config_digest="$(_resolve_immutable_release_config_digest "$_candidate_immutable_ref" "$_candidate_platform_os" "$_candidate_platform_architecture")" || {
+      printf 'error: release portal engine digest %s could not resolve the frozen %s/%s config\n' \
+        "$_candidate_engine_digest" "$DPF_RELEASE_PLATFORM_OS" "$DPF_RELEASE_PLATFORM_ARCHITECTURE" >&2
+      exit 1
+    }
+    [[ "$_candidate_resolved_config_digest" == "$DPF_RELEASE_CONFIG_DIGEST" ]] || {
+      printf 'error: release portal resolved config digest %s does not match frozen release config %s\n' \
+        "$_candidate_resolved_config_digest" "$DPF_RELEASE_CONFIG_DIGEST" >&2
+      exit 1
+    }
+  fi
   if [[ "$_release_identity_mode" == "config-only" && "$_candidate_engine_digest" != "$DPF_RELEASE_CONFIG_DIGEST" ]]; then
     [[ "$_candidate_platform_os" == "linux" && "$_candidate_platform_architecture" =~ ^(amd64|arm64)$ ]] || {
       printf 'error: release portal legacy platform %s/%s is unsupported\n' "${_candidate_platform_os:-missing}" "${_candidate_platform_architecture:-missing}" >&2

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -372,6 +372,10 @@ if [[ $_release_mode -eq 1 && $_dry_run -eq 0 ]]; then
       exit 1
     }
   fi
+  if [[ "$_release_identity_mode" == "config-only" ]]; then
+    printf 'step=release-identity mode=config-only engine-digest=%s config-digest=%s platform=%s/%s\n' \
+      "$_candidate_engine_digest" "$DPF_RELEASE_CONFIG_DIGEST" "$_candidate_platform_os" "$_candidate_platform_architecture"
+  fi
   _candidate_revision="$(docker image inspect "$_candidate_portal" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' | tr -d '[:space:]')"
   [[ "$_candidate_revision" == "$PROMOTE_TARGET_SHA" ]] || {
     printf 'error: release portal revision %s does not match promote target %s\n' "${_candidate_revision:-missing}" "$PROMOTE_TARGET_SHA" >&2


### PR DESCRIPTION
## Summary

- reconcile Docker Desktop/containerd image IDs that report the multi-architecture index while preserving the immutable linux/amd64 config digest
- keep exact tag, revision, version, operating-system, architecture, channel, manifest, and config bindings fail closed
- support the installed N-1 config-only handoff through candidate-owned release identity resolution without teaching the old caller new fields
- preserve strict full-packet validation and reject ambiguous or cross-stratum identities before runtime mutation

## Verification

- TDD red/green covers the Docker Desktop index-ID case, native config-ID case, exact installed-N-1 partial packet, incomplete modern packets, ambiguous indexes, and config mismatches
- affected self-upgrade matrix: 247 / 247 passed
- `pnpm --filter web typecheck`: PASS
- `pnpm run pregate:preflight`: 52 / 52 guards clean
- semantic review: `cmt7nv5640amy01mgfmmsfdr6` (0 issues; infrastructure-inconclusive reviewer branch; governed shadow-observe policy permits publication)
- exact-tree local CI: `cmt8qpdkn0sd601mg62h4uixn` (`fix/self-upgrade-config-digest-projection@286b14ef3e70bb55a11f7cbd3b9155cc0949d491`, PASS)

The unchanged exact candidate passed the exhaustive governed gate after the bounded Vitest-stage watchdog reached `origin/main`. It synthetic-merged current main in the isolated gate; no installed runtime or database was mutated.

Local-CI-Evidence: cmt8qpdkn0sd601mg62h4uixn (fix/self-upgrade-config-digest-projection@286b14ef3e70bb55a11f7cbd3b9155cc0949d491)

Docs-Impact-Decision: No documentation change; this repairs cross-engine validation at the existing self-upgrade contract boundary.

Backlog-Item: BI-86C5082D
Workroom: WC-6A9A0D9D
