### PR TITLE
fix(routing): tell the owner when the host comes free instead of failing blind (BI-94D44FDB)

### DIFF
--- a/apps/web/lib/routing/local-provider-capacity.test.ts
+++ b/apps/web/lib/routing/local-provider-capacity.test.ts
@@ -144,6 +144,7 @@ describe("short-call capacity policy (BI-0AA939DF / DI-405E6765ED90)", () => {
     expect(status).toEqual({
       available: false,
       reason: "local-ci-active-capacity-reservation",
+      expectedFreeAt: null,
     });
   });
 
@@ -196,6 +197,102 @@ describe("short-call capacity policy (BI-0AA939DF / DI-405E6765ED90)", () => {
     expect(status).toEqual({
       available: false,
       reason: "local-ci-queued-capacity-reservation",
+      expectedFreeAt: null,
     });
+  });
+});
+
+// BI-94D44FDB. Measured over seven days on the live install: ~300 real gate
+// runs holding the host ~195s each. Short enough to wait out, far too long to
+// leave the owner staring at an unexplained failure — so the deferral carries
+// the blocking claim's own expiry.
+describe("a deferral reports when the host is due free", () => {
+  const at = (iso: string) => new Date(iso);
+  const ciLease = (status: string, expiresAt: Date | null) => ({
+    environmentKey: "local-integration-ci",
+    status,
+    expiresAt,
+  });
+
+  it("carries the active claim's expiry on the resident path", async () => {
+    const status = await inspectLocalProviderCapacity({
+      listCapacityLeases: async () => [ciLease("active", at("2026-08-23T20:17:00.000Z"))],
+    });
+
+    expect(status).toEqual({
+      available: false,
+      reason: "local-ci-active-capacity-reservation",
+      expectedFreeAt: at("2026-08-23T20:17:00.000Z"),
+    });
+  });
+
+  it("reports the SOONEST expiry when more than one claim is blocking", async () => {
+    const status = await inspectLocalProviderCapacity({
+      listCapacityLeases: async () => [
+        ciLease("active", at("2026-08-23T20:19:00.000Z")),
+        ciLease("active", at("2026-08-23T20:16:00.000Z")),
+      ],
+    });
+
+    expect(status.available).toBe(false);
+    expect(status.expectedFreeAt).toEqual(at("2026-08-23T20:16:00.000Z"));
+  });
+
+  it("carries the queued claim's expiry too", async () => {
+    const status = await inspectLocalProviderCapacity({
+      listCapacityLeases: async () => [ciLease("queued", at("2026-08-23T20:16:50.000Z"))],
+    });
+
+    expect(status.reason).toBe("local-ci-queued-capacity-reservation");
+    expect(status.expectedFreeAt).toEqual(at("2026-08-23T20:16:50.000Z"));
+  });
+
+  it("reports no window rather than a wrong one when the claim has no expiry", async () => {
+    const status = await inspectLocalProviderCapacity({
+      listCapacityLeases: async () => [ciLease("active", null)],
+    });
+
+    expect(status.expectedFreeAt).toBeNull();
+  });
+
+  it("has no window to report when capacity ownership could not be read at all", async () => {
+    const status = await inspectLocalProviderCapacity({
+      listCapacityLeases: async () => { throw new Error("db down"); },
+    });
+
+    expect(status).toEqual({
+      available: false,
+      reason: "local-ci-capacity-reservation-unavailable",
+    });
+  });
+
+  it("puts the window on the thrown error, where the reply can reach it", async () => {
+    await expect(
+      assertLocalProviderCapacityAvailable({
+        listCapacityLeases: async () => [ciLease("active", at("2026-08-23T20:17:00.000Z"))],
+      }),
+    ).rejects.toMatchObject({
+      name: "LocalProviderCapacityDeferredError",
+      reason: "local-ci-active-capacity-reservation",
+      expectedFreeAt: at("2026-08-23T20:17:00.000Z"),
+    });
+  });
+
+  // A dev-portal preview binds a port and runs no inference, so it must not
+  // reserve the GPU and must not contribute a window either (BI-D933A328).
+  // 998 of 1,006 expired claims over the measured week were dev-portal.
+  it("ignores a preview claim entirely, window included", async () => {
+    const status = await inspectLocalProviderCapacity({
+      listCapacityLeases: async () => [{
+        environmentKey: "local-integration-ci",
+        status: "active",
+        claimKey: "dev-portal:abc",
+        // Relative: the value is irrelevant here (the claim is ignored outright),
+        // and a fixed future date would become a clock bomb.
+        expiresAt: new Date(Date.now() + 3 * 60_000),
+      }],
+    });
+
+    expect(status).toEqual({ available: true, reason: null });
   });
 });

--- a/apps/web/lib/routing/local-provider-capacity.ts
+++ b/apps/web/lib/routing/local-provider-capacity.ts
@@ -7,13 +7,23 @@ export type LocalProviderCapacityDeferralReason =
   | "local-ci-capacity-reservation-unavailable";
 
 export type LocalProviderCapacityStatus =
-  | { available: true; reason: null }
-  | { available: false; reason: LocalProviderCapacityDeferralReason };
+  | { available: true; reason: null; expectedFreeAt?: null }
+  | {
+    available: false;
+    reason: LocalProviderCapacityDeferralReason;
+    /**
+     * When the blocking claim's own contract says the host comes free
+     * (BI-94D44FDB). Null when nothing is blocking us that we can read — an
+     * unproven-capacity deferral has no window to report.
+     */
+    expectedFreeAt?: Date | null;
+  };
 
 type LeaseReader = () => Promise<Array<{
   environmentKey: string;
   status?: string;
   claimKey?: string | null;
+  expiresAt?: Date | null;
 }>>;
 
 /**
@@ -37,10 +47,31 @@ function contendsForInference(lease: { claimKey?: string | null }): boolean {
 }
 
 export class LocalProviderCapacityDeferredError extends Error {
-  constructor(public readonly reason: LocalProviderCapacityDeferralReason) {
+  constructor(
+    public readonly reason: LocalProviderCapacityDeferralReason,
+    /**
+     * When the blocking claim's contract says the host comes free
+     * (BI-94D44FDB). Carried on the error so the owner-facing reply can name a
+     * window instead of an open-ended wait: measured over seven days on the
+     * live install, a real gate holds the host for ~195s on average, which is
+     * short enough to wait out and far too long to leave unexplained.
+     */
+    public readonly expectedFreeAt: Date | null = null,
+  ) {
     super(`Local provider dispatch deferred: ${reason}`);
     this.name = "LocalProviderCapacityDeferredError";
   }
+}
+
+/** The soonest a blocking claim releases the host, or null if none is readable. */
+function earliestExpiry(
+  leases: ReadonlyArray<{ expiresAt?: Date | null }>,
+): Date | null {
+  const times = leases
+    .map((lease) => lease.expiresAt)
+    .filter((value): value is Date => value instanceof Date && !Number.isNaN(value.getTime()));
+  if (times.length === 0) return null;
+  return times.reduce((soonest, next) => (next < soonest ? next : soonest));
 }
 
 /** Authoritative host-capacity policy shared by every local inference boundary. */
@@ -51,22 +82,40 @@ export async function inspectLocalProviderCapacity(input: {
     ?? (() => listCapacityReservingNonprodEnvironmentLeases({}));
   try {
     const reservations = await listCapacityLeases();
-    if (reservations.some((lease) => (
+    const blocking = (status: string) => reservations.filter((lease) => (
       lease.environmentKey === "local-integration-ci"
-      && lease.status === "active"
+      && lease.status === status
       && contendsForInference(lease)
-    ))) {
-      return { available: false, reason: "local-ci-active-capacity-reservation" };
+    ));
+
+    const active = blocking("active");
+    if (active.length > 0) {
+      return {
+        available: false,
+        reason: "local-ci-active-capacity-reservation",
+        expectedFreeAt: earliestExpiry(active),
+      };
     }
     // A live queued claim is bounded by its heartbeat/expiry contract. Giving
     // it precedence over *new* local inference reserves the next safe host
     // window without killing provider work that was already in flight.
-    if (reservations.some((lease) => (
-      lease.environmentKey === "local-integration-ci"
-      && lease.status === "queued"
-      && contendsForInference(lease)
-    ))) {
-      return { available: false, reason: "local-ci-queued-capacity-reservation" };
+    //
+    // Deliberately UNCHANGED (BI-94D44FDB). The obvious move was to drop the
+    // queued deferral here as DI-405E6765ED90 did for the short-call boundary,
+    // but the evidence does not support it: over seven days on the live install
+    // the queue held 3 rows, not a standing backlog, because BI-D933A328's
+    // contendsForInference filter already removed the dev-portal flood that
+    // made it permanently non-empty (998 of 1,006 expired claims were
+    // dev-portal). The starvation that remains is `active` holds — ~300 real
+    // gate runs averaging 195s — so changing the queued rule would trade a
+    // reasoned safety property for no measured gain.
+    const queued = blocking("queued");
+    if (queued.length > 0) {
+      return {
+        available: false,
+        reason: "local-ci-queued-capacity-reservation",
+        expectedFreeAt: earliestExpiry(queued),
+      };
     }
     return { available: true, reason: null };
   } catch {
@@ -80,7 +129,9 @@ export async function assertLocalProviderCapacityAvailable(input: {
   listCapacityLeases?: LeaseReader;
 } = {}): Promise<void> {
   const status = await inspectLocalProviderCapacity(input);
-  if (!status.available) throw new LocalProviderCapacityDeferredError(status.reason);
+  if (!status.available) {
+    throw new LocalProviderCapacityDeferredError(status.reason, status.expectedFreeAt ?? null);
+  }
 }
 
 /** Completion-adapter boundary: remote providers remain independent of host leases. */
@@ -141,10 +192,10 @@ export async function inspectShortCallLocalCapacity(input: {
   const deadline = Math.max(0, waitMs);
   let waited = 0;
   for (;;) {
-    let active: boolean;
+    let active: Array<{ expiresAt?: Date | null }>;
     try {
       const reservations = await listCapacityLeases();
-      active = reservations.some((lease) => (
+      active = reservations.filter((lease) => (
         lease.environmentKey === "local-integration-ci" && lease.status === "active"
       ));
     } catch {
@@ -153,9 +204,13 @@ export async function inspectShortCallLocalCapacity(input: {
       return { available: false, reason: "local-ci-capacity-reservation-unavailable" };
     }
 
-    if (!active) return { available: true, reason: null };
+    if (active.length === 0) return { available: true, reason: null };
     if (waited >= deadline) {
-      return { available: false, reason: "local-ci-active-capacity-reservation" };
+      return {
+        available: false,
+        reason: "local-ci-active-capacity-reservation",
+        expectedFreeAt: earliestExpiry(active),
+      };
     }
     await sleep(SHORT_CALL_POLL_MS);
     waited += SHORT_CALL_POLL_MS;
@@ -168,5 +223,7 @@ export async function assertShortCallLocalCapacityAvailable(input: {
   sleep?: (ms: number) => Promise<void>;
 } = {}): Promise<void> {
   const status = await inspectShortCallLocalCapacity(input);
-  if (!status.available) throw new LocalProviderCapacityDeferredError(status.reason);
+  if (!status.available) {
+    throw new LocalProviderCapacityDeferredError(status.reason, status.expectedFreeAt ?? null);
+  }
 }

--- a/apps/web/lib/tak/inference-dead-ends.test.ts
+++ b/apps/web/lib/tak/inference-dead-ends.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  describeCapacityWindow,
   describeToolRouteFailureOutcome,
   describeToolRouteFailure,
   localCapacityHeldHandoff,
@@ -146,5 +147,60 @@ describe("describeToolRouteFailure classifies the deferral that stranded the own
 
     expect(outcome.kind).toBe("model-missing");
     expect(outcome.message).not.toMatch(/busy|rate-limit/i);
+  });
+});
+
+// BI-94D44FDB. The owner-facing half: a deferral is a bounded wait, so say how
+// long rather than leaving them to guess or poll.
+describe("the capacity reply names the window when it knows one", () => {
+  const now = new Date("2026-08-23T20:14:00.000Z");
+
+  it("turns a lease expiry into a plain relative window", () => {
+    expect(describeCapacityWindow(new Date("2026-08-23T20:17:00.000Z"), now))
+      .toBe("about 3 minutes");
+    expect(describeCapacityWindow(new Date("2026-08-23T20:14:40.000Z"), now))
+      .toBe("about a minute");
+  });
+
+  it("says nothing rather than something wrong", () => {
+    // Already past, implausibly far out, absent, or unparseable — in every case
+    // a made-up number would be worse than the generic wait.
+    expect(describeCapacityWindow(new Date("2026-08-23T20:13:00.000Z"), now)).toBeNull();
+    expect(describeCapacityWindow(new Date("2026-08-23T22:00:00.000Z"), now)).toBeNull();
+    expect(describeCapacityWindow(null, now)).toBeNull();
+    expect(describeCapacityWindow(new Date("nonsense"), now)).toBeNull();
+  });
+
+  it("puts the window in the step, not in a separate sentence to skim past", () => {
+    const message = localCapacityHeldHandoff(false, new Date("2026-08-23T20:17:00.000Z"), now);
+    expect(message).toMatch(/^1\. Send the message again in about 3 minutes/m);
+    expect(message).toMatch(/Nothing is misconfigured/);
+  });
+
+  it("falls back to the generic wait when no window is known", () => {
+    const message = localCapacityHeldHandoff(false, null, now);
+    expect(message).toMatch(/^1\. Give it a couple of minutes/m);
+  });
+
+  it("reads the window off the thrown error the routing layer produced", () => {
+    const thrown = Object.assign(
+      new Error("Local provider dispatch deferred: local-ci-active-capacity-reservation"),
+      {
+        name: "LocalProviderCapacityDeferredError",
+        expectedFreeAt: new Date(Date.now() + 3 * 60_000),
+      },
+    );
+
+    expect(describeToolRouteFailure(thrown.message, 0, thrown)).toMatch(/about 3 minutes/);
+  });
+
+  it("survives the window arriving as a serialized string across a queue boundary", () => {
+    const thrown = {
+      name: "LocalProviderCapacityDeferredError",
+      message: "Local provider dispatch deferred: local-ci-active-capacity-reservation",
+      expectedFreeAt: new Date(Date.now() + 2 * 60_000).toISOString(),
+    };
+
+    expect(describeToolRouteFailure(thrown.message, 0, thrown)).toMatch(/about 2 minutes/);
   });
 });

--- a/apps/web/lib/tak/inference-dead-ends.ts
+++ b/apps/web/lib/tak/inference-dead-ends.ts
@@ -77,12 +77,43 @@ export function modelMissingHandoff(): string {
  * nothing is misconfigured — so this deliberately names NO settings surface.
  * Respects IDENTITY_BLOCK rule #5: no lease names, reason codes, or job ids.
  */
-export function localCapacityHeldHandoff(unprovenCapacity = false): string {
+/**
+ * "about 3 minutes" from a lease expiry, or null when there is nothing useful
+ * to say (BI-94D44FDB).
+ *
+ * Deliberately RELATIVE rather than a clock time: the reply is read in the
+ * owner's browser and the window is short, so "a couple of minutes" is both
+ * more useful and free of any timezone question. `now` is injected so the
+ * behaviour is pinned by tests rather than by the wall clock.
+ */
+export function describeCapacityWindow(
+  expectedFreeAt: Date | null | undefined,
+  now: Date,
+): string | null {
+  if (!(expectedFreeAt instanceof Date) || Number.isNaN(expectedFreeAt.getTime())) return null;
+  const remainingMs = expectedFreeAt.getTime() - now.getTime();
+  // A window already past, or implausibly far out, tells the owner nothing
+  // trustworthy — better to say the honest generic thing than a wrong number.
+  if (remainingMs <= 0 || remainingMs > 30 * 60_000) return null;
+  const minutes = Math.max(1, Math.round(remainingMs / 60_000));
+  return minutes === 1 ? "about a minute" : `about ${minutes} minutes`;
+}
+
+export function localCapacityHeldHandoff(
+  unprovenCapacity = false,
+  expectedFreeAt: Date | null = null,
+  now: Date = new Date(),
+): string {
+  const window = describeCapacityWindow(expectedFreeAt, now);
   return buildHumanHandoff({
     blocker: unprovenCapacity
       ? "I couldn't confirm the local AI model was free to use, so I held off rather than risk disrupting something else running on this machine. Nothing is misconfigured."
       : "The only AI model allowed to handle this request is tied up with a background job on this machine, so I couldn't answer. Nothing is misconfigured.",
-    steps: ["Give it a couple of minutes, then send the message again."],
+    steps: [
+      window
+        ? `Send the message again in ${window}, when that job is due to finish.`
+        : "Give it a couple of minutes, then send the message again.",
+    ],
     verify: "check the moment it frees up",
   });
 }
@@ -130,6 +161,24 @@ export function isLocalCapacityDeferral(error: unknown, message: string): boolea
 }
 
 /**
+ * The window the routing layer attached to a capacity deferral, if it survived.
+ *
+ * Read structurally rather than by importing the error class, for the same
+ * bundle reason as isLocalCapacityDeferral above. Absent when the error crossed
+ * a boundary that kept only its message.
+ */
+function readExpectedFreeAt(error: unknown): Date | null {
+  if (typeof error !== "object" || error === null || !("expectedFreeAt" in error)) return null;
+  const value = (error as { expectedFreeAt?: unknown }).expectedFreeAt;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (typeof value === "string" || typeof value === "number") {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+}
+
+/**
  * Plain-language, non-technical explanation for a turn that failed because
  * routing could not complete a tool-using call (BI-23E0714C).
  *
@@ -167,7 +216,10 @@ function describeToolRouteFailureMessage(
   // is a host-capacity state, not a configuration one, and every branch below
   // that names a settings surface would be wrong advice for it.
   if (isLocalCapacityDeferral(error, msg)) {
-    return localCapacityHeldHandoff(/capacity-reservation-unavailable/i.test(msg));
+    return localCapacityHeldHandoff(
+      /capacity-reservation-unavailable/i.test(msg),
+      readExpectedFreeAt(error),
+    );
   }
 
   // Local runner rejected the request because prompt + tool schemas exceed the


### PR DESCRIPTION
## The problem

A local-CI gate holds the host and every AI coworker on the install stops. The owner sees a failure with no sense of whether this is seconds or hours.

## What the evidence says

Seven days of `NonProductionEnvironmentLease` on the live install:

| status | count | avg hold |
|---|---|---|
| released (real pre-PR gates) | 299 | 195s |
| cancelled | 44 | 329s |
| expired | 1,006 | 999s — 998 of them dev-portal preview claims |
| queued | 3 | — |

So the starvation that remains is `active` holds: roughly 300 gate runs a week at about three minutes each. Short enough to wait out, far too long to leave unexplained.

## The change

The deferral carries the blocking claim's own expiry, and the coworker's reply turns it into a step the owner can act on — *"send the message again in about 3 minutes, when that job is due to finish"* — instead of an open-ended *"give it a couple of minutes"*.

The window is relative rather than a clock time: it is read in a browser, the interval is short, and a relative phrase raises no timezone question. It is suppressed rather than guessed whenever it would be wrong — already past, more than half an hour out, absent, or unparseable — and `now` is injected so the behaviour is pinned by tests and not by the wall clock. It survives the error crossing a queue boundary as a serialized string.

## What this deliberately does not do

**The queued-claim rule is unchanged.** Dropping it here, as `DI-405E6765ED90` did for the short-call boundary, was the obvious move and the evidence does not support it: the queue held 3 rows over the week, not a standing backlog, because `BI-D933A328`'s `contendsForInference` filter had already removed the dev-portal flood that made it permanently non-empty. Changing it would trade a reasoned safety property for no measured gain.

**Interactive-over-autonomous admission** — option 1 on BI-94D44FDB, and the real answer — is not delivered here. It belongs to `BI-285EF102` under `EP-B9DD37C7`, where the admission budget already lives. This is the second branch of that item's acceptance criterion, taken because it is the one the evidence supports today.

Anecdotally the contention is worse than the weekly average suggests: taking these three fixes through the gate hit a 7-deep queue, two contention releases and one timeout waiting on another session's sandbox processes. A named window is worth more at that level than the 195s average implied.

## Verification

15 new tests; 118 tests across the capacity, dead-end, embedding, endpoint-test and change-review suites; web typecheck; 52 preflight guards; exact-tree local CI gate PASS @ `835c6f6e9d02`, evidence `cmt8wv3cn01q901phdoxbke81`.

Part of `WC-9C828312`. Related: BI-A89E4827 (#4608), BI-463BE12A (#4616), BI-0AA939DF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)