### PR TITLE
fix(routing): stop demoting a new model generation below the previous generation's cheapest model (BI-04DAB7FE)

### DIFF
--- a/apps/web/lib/routing/quality-tiers.test.ts
+++ b/apps/web/lib/routing/quality-tiers.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { assignTierFromModelId } from "./quality-tiers";
+import {
+  assignTierFromModelId,
+  classifyTierFromModelId,
+  QUALITY_TIERS,
+  UNMATCHED_MODEL_TIER,
+} from "./quality-tiers";
 
 describe("assignTierFromModelId", () => {
   describe("cloud models (unchanged behaviour)", () => {
@@ -112,5 +117,56 @@ describe("assignTierFromModelId", () => {
     it("returns adequate as conservative default", () => {
       expect(assignTierFromModelId("some-unknown-model")).toBe("adequate");
     });
+  });
+});
+
+// BI-07F1A95F / operator escalation: a vendor ships a new generation every few
+// weeks. A tier table keyed to one generation demotes the next one to the
+// unknown-model fallback, which sits BELOW "strong" — so a new flagship is
+// excluded by every minimumTier: "strong" floor while the previous
+// generation's cheapest model passes it. Observed live on 2026-08-23.
+describe("a new model generation is not silently demoted", () => {
+  it("classifies a Claude generation with no explicit entry", () => {
+    expect(assignTierFromModelId("claude-opus-5")).toBe("frontier");
+    expect(assignTierFromModelId("claude-sonnet-5")).toBe("frontier");
+    expect(assignTierFromModelId("claude-haiku-5")).toBe("strong");
+  });
+
+  it("keeps a flagship above the previous generation's cheapest model", () => {
+    // The live inversion this fixes: opus-5 "adequate" (measured toolFidelity
+    // 90) ranked under haiku-4-5 "strong" (measured 75).
+    const flagship = assignTierFromModelId("claude-opus-5");
+    const cheap = assignTierFromModelId("claude-haiku-4-5-20251001");
+    expect(QUALITY_TIERS.indexOf(flagship)).toBeLessThan(QUALITY_TIERS.indexOf(cheap));
+  });
+
+  it("still lets a generation-specific entry win by longest prefix", () => {
+    expect(assignTierFromModelId("claude-3-haiku-20240307")).toBe("adequate");
+    expect(assignTierFromModelId("claude-opus-4-6")).toBe("frontier");
+  });
+
+  it("survives a future generation without a code change", () => {
+    for (const id of ["claude-opus-6", "claude-opus-9-20301231", "claude-sonnet-7"]) {
+      expect(assignTierFromModelId(id)).toBe("frontier");
+    }
+  });
+
+  it("reports whether the tier was matched or merely assumed", () => {
+    const known = classifyTierFromModelId("claude-opus-5");
+    expect(known).toMatchObject({ tier: "frontier", matched: true, matchedFamily: "claude-opus" });
+
+    // "Unknown" is not "weak" — an unmatched model must be reportable as such
+    // rather than presented as an established adequate.
+    const unknown = classifyTierFromModelId("some-vendor-model-x1");
+    expect(unknown.matched).toBe(false);
+    expect(unknown.matchedFamily).toBeNull();
+    expect(unknown.tier).toBe(UNMATCHED_MODEL_TIER);
+  });
+
+  it("keeps the assumed fallback below strong, so the report is load-bearing", () => {
+    // If the fallback were ever raised to strong, an unmeasured model would
+    // silently satisfy a judging role's floor. Pin the invariant.
+    expect(QUALITY_TIERS.indexOf(UNMATCHED_MODEL_TIER))
+      .toBeGreaterThan(QUALITY_TIERS.indexOf("strong"));
   });
 });

--- a/apps/web/lib/routing/quality-tiers.ts
+++ b/apps/web/lib/routing/quality-tiers.ts
@@ -30,7 +30,18 @@ export const TIER_DESCRIPTIONS: Record<QualityTier, string> = {
 // Longest prefix match against modelId determines tier.
 
 export const FAMILY_TIERS: Record<string, QualityTier> = {
-  // Anthropic
+  // Anthropic. GENERATION-LESS entries are deliberate: a vendor ships a new
+  // generation every few weeks, and a table keyed to one generation silently
+  // demotes the next one to the unknown-model fallback — which is BELOW
+  // "strong", so a brand-new flagship ranked under the previous generation's
+  // cheapest model and was excluded by every minimumTier: "strong" floor while
+  // that cheap model passed. Observed live: claude-opus-5 and claude-sonnet-5
+  // classified "adequate" (measured toolFidelity 90 and 85) while
+  // claude-haiku-4-5 classified "strong" (measured 75). Longest-prefix match
+  // means a generation-specific entry still wins where one exists.
+  "claude-opus":      "frontier",
+  "claude-sonnet":    "frontier",
+  "claude-haiku":     "strong",
   "claude-opus-4":    "frontier",
   "claude-sonnet-4":  "frontier",
   "claude-haiku-4":   "strong",
@@ -82,23 +93,49 @@ function normaliseFamilyId(modelId: string): string {
   return s;
 }
 
+/** The tier assumed for a model no family rule matches. */
+export const UNMATCHED_MODEL_TIER: QualityTier = "adequate";
+
+export type TierClassification = {
+  tier: QualityTier;
+  /** False when no family rule matched and the fallback was assumed. */
+  matched: boolean;
+  /** The family prefix that decided the tier, or null when unmatched. */
+  matchedFamily: string | null;
+};
+
 /**
- * Assign a quality tier to a model using longest-prefix match.
- * Returns "adequate" for unknown models (conservative default).
+ * Classify a model, reporting whether a family rule actually matched.
+ *
+ * "Unknown" and "weak" are different claims, and conflating them is what makes
+ * the fallback dangerous: an unmatched model is assumed `adequate`, which sits
+ * BELOW `strong`, so an unrecognised flagship is excluded by exactly the floors
+ * that exist to guarantee capability. Callers that care — seeding, posture,
+ * routing diagnostics — should surface `matched: false` rather than presenting
+ * the assumed tier as though it were established.
  */
-export function assignTierFromModelId(modelId: string): QualityTier {
+export function classifyTierFromModelId(modelId: string): TierClassification {
   const normalised = normaliseFamilyId(modelId);
-  let bestMatch = "";
-  let bestTier: QualityTier = "adequate";
+  let matchedFamily: string | null = null;
+  let bestTier: QualityTier = UNMATCHED_MODEL_TIER;
 
   for (const [prefix, tier] of Object.entries(FAMILY_TIERS)) {
-    if (normalised.startsWith(prefix) && prefix.length > bestMatch.length) {
-      bestMatch = prefix;
+    if (normalised.startsWith(prefix) && prefix.length > (matchedFamily?.length ?? 0)) {
+      matchedFamily = prefix;
       bestTier = tier;
     }
   }
 
-  return bestTier;
+  return { tier: bestTier, matched: matchedFamily !== null, matchedFamily };
+}
+
+/**
+ * Assign a quality tier to a model using longest-prefix match.
+ * Returns "adequate" for unknown models — see classifyTierFromModelId when the
+ * caller needs to know whether that tier was matched or merely assumed.
+ */
+export function assignTierFromModelId(modelId: string): QualityTier {
+  return classifyTierFromModelId(modelId).tier;
 }
 
 // ── Tier → Dimension Baselines ─────────────────────────────────────────────


### PR DESCRIPTION
On the live install claude-opus-5 and claude-sonnet-5 were classified
"adequate" (measured toolFidelity 90 and 85) while claude-haiku-4-5 was
classified "strong" (measured 75). Every value was qualityTierSource: auto.

assignTierFromModelId longest-prefix matches FAMILY_TIERS, which was keyed to
one specific generation — "claude-opus-4", "claude-sonnet-4", "claude-haiku-4".
"claude-opus-5" starts with none of them, matches nothing, and takes the
fallback the comments call a "conservative default". It is not conservative:
"adequate" sits BELOW "strong", so an unrecognised flagship is excluded by every
minimumTier: "strong" floor while an older cheap model satisfies it. The floor
does the inverse of its purpose. KNOWN_PROVIDER_MODELS has no Claude 5 entries
at all, so these arrived through provider discovery and hit the fallback.

The operator's framing is the important part: models ship weekly across many
installs, so a catalog compiled into the app cannot track them. Adding
"claude-opus-5" fixes today and is stale next week.

- Generation-less family entries ("claude-opus", "claude-sonnet",
  "claude-haiku") sit alongside the generation-specific ones. Longest-prefix
  still lets a specific entry win, so claude-3-haiku stays "adequate", while a
  future claude-opus-6 resolves with no code change.
- classifyTierFromModelId returns { tier, matched, matchedFamily } so a caller
  can distinguish an ESTABLISHED tier from an ASSUMED one. "Unknown" and "weak"
  are different claims, and conflating them is what caused this;
  claude-fable-5 now reports matched: false rather than asserting a tier I
  cannot substantiate.
- A test pins the fallback below "strong", so raising it can never silently let
  an unmeasured model satisfy a judging role's floor.

Verified against the install's twelve real model ids: opus-5 and sonnet-5
resolve frontier, haiku-4-5 stays strong, the inversion is gone, and the two
genuinely unrecognised ids report matched: false.

No migration: discovery rewrites qualityTier whenever qualityTierSource is not
"admin" (ai-provider-internals.ts), so existing installs self-heal on the next
model sync and operator overrides are preserved; new installs get it from the
same path. audit-routing-spec-boot-invariants.ts Invariant 4 already asserts the
stored tier matches the classifier, so any row not yet re-synced is flagged.

This is the name-pattern half. The durable answer — let measurement outrank the
name, so each install calibrates the models it actually has — is designed in
BI-07F1A95F.

Docs-Impact-Decision: no documented route or user-guide page changes; this is
routing-internal tier classification. The behaviour change is recorded on
BI-04DAB7FE and in the demand-aware-model-escalation design shipped alongside.


(cherry picked from commit 798b8ecda0f9ec3781c263c4645a9f765b4c8bfb)

---

**Local CI:** `pregate:status` PASS — `72b5c0f2d9aa`, evidence `cmt8xfuvi04gd01ph0vhatjto`, 7:39 / 33454 log lines, production build compiled in 4.3min.

**Tests:** 36 tier tests, 1478 routing tests, `tsc --noEmit` clean, 52/52 preflight guards.

**Verified against the install's twelve real model ids** — opus-5 and sonnet-5 resolve `frontier`, haiku-4-5 stays `strong`, the inversion is gone, and the two genuinely unrecognised ids report `matched: false` rather than asserting a tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)