### PR TITLE
fix(code-graph): git refusing the workspace is not the same as there being no repo (BI-86EF5900)

### DIFF
--- a/apps/web/lib/build/code-graph-refresh-reconcile.test.ts
+++ b/apps/web/lib/build/code-graph-refresh-reconcile.test.ts
@@ -93,6 +93,17 @@ vi.mock("@/lib/shared/lazy-node", () => ({
 }));
 
 import { prisma } from "@dpf/db";
+
+// Git calls now carry a scoped `-c safe.directory=<root>` exception
+// (BI-86EF5900: the portal container runs as a different uid than the checkout,
+// so an unprefixed git refuses outright). These fixtures assert on the git
+// SUBCOMMAND, not on the exact invocation, so the transport-level flag does not
+// have to be restated in every mock.
+const gitSub = (command: unknown): string =>
+  typeof command === "string"
+    ? command.replace(/ -c safe\.directory=(?:"[^"]*"|\S+)/g, "")
+    : String(command);
+
 import {
   buildListTrackedFilesCommand,
   CODE_GRAPH_GRAPH_KEY,
@@ -127,16 +138,16 @@ describe("reconcileCodeGraph", () => {
     vi.mocked(prisma.codeGraphIndexState.findUnique).mockResolvedValue(null);
 
     mockExec.mockImplementation(async (command: string) => {
-      if (command === "git rev-parse HEAD") return { stdout: "head-1\n", stderr: "" };
-      if (command === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
-      if (command === "git status --porcelain") return { stdout: "", stderr: "" };
-      if (command.startsWith("git ls-files -- ")) {
+      if (gitSub(command) === "git rev-parse HEAD") return { stdout: "head-1\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
+      if (gitSub(command) === "git status --porcelain") return { stdout: "", stderr: "" };
+      if (gitSub(command).startsWith("git ls-files -- ")) {
         return {
           stdout: "apps/web/lib/integrate/change-impact.ts\npackages/db/prisma/schema.prisma\n",
           stderr: "",
         };
       }
-      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -181,16 +192,16 @@ describe("reconcileCodeGraph", () => {
     vi.mocked(prisma.codeGraphIndexState.findUnique).mockResolvedValue(null);
 
     mockExec.mockImplementation(async (command: string) => {
-      if (command === "git rev-parse HEAD") return { stdout: "head-1\n", stderr: "" };
-      if (command === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
-      if (command === "git status --porcelain") return { stdout: "", stderr: "" };
-      if (command.startsWith("git ls-files -- ")) {
+      if (gitSub(command) === "git rev-parse HEAD") return { stdout: "head-1\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
+      if (gitSub(command) === "git status --porcelain") return { stdout: "", stderr: "" };
+      if (gitSub(command).startsWith("git ls-files -- ")) {
         return {
           stdout: "apps/web/lib/integrate/multi-symbol.ts\n",
           stderr: "",
         };
       }
-      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -218,16 +229,16 @@ describe("reconcileCodeGraph", () => {
     vi.mocked(prisma.codeGraphIndexState.findUnique).mockResolvedValue(null);
 
     mockExec.mockImplementation(async (command: string) => {
-      if (command === "git rev-parse HEAD") return { stdout: "head-1\n", stderr: "" };
-      if (command === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
-      if (command === "git status --porcelain") return { stdout: "", stderr: "" };
-      if (command.startsWith("git ls-files -- ")) {
+      if (gitSub(command) === "git rev-parse HEAD") return { stdout: "head-1\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
+      if (gitSub(command) === "git status --porcelain") return { stdout: "", stderr: "" };
+      if (gitSub(command).startsWith("git ls-files -- ")) {
         return {
           stdout: "apps/web/lib/one.ts\napps/web/lib/two.ts\n",
           stderr: "",
         };
       }
-      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -259,16 +270,16 @@ describe("reconcileCodeGraph", () => {
     } as never);
 
     mockExec.mockImplementation(async (command: string) => {
-      if (command === "git rev-parse HEAD") return { stdout: "head-2\n", stderr: "" };
-      if (command === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
-      if (command === "git status --porcelain") return { stdout: "", stderr: "" };
-      if (command === "git diff --name-only head-1..head-2") {
+      if (gitSub(command) === "git rev-parse HEAD") return { stdout: "head-2\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
+      if (gitSub(command) === "git status --porcelain") return { stdout: "", stderr: "" };
+      if (gitSub(command) === "git diff --name-only head-1..head-2") {
         return {
           stdout: "apps/web/lib/integrate/change-impact.ts\napps/web/lib/integrate/removed.ts\n",
           stderr: "",
         };
       }
-      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -302,10 +313,10 @@ describe("reconcileCodeGraph", () => {
     } as never);
 
     mockExec.mockImplementation(async (command: string) => {
-      if (command === "git rev-parse HEAD") return { stdout: "head-2\n", stderr: "" };
-      if (command === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
-      if (command === "git status --porcelain") return { stdout: " M apps/web/lib/foo.ts\n", stderr: "" };
-      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse HEAD") return { stdout: "head-2\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
+      if (gitSub(command) === "git status --porcelain") return { stdout: " M apps/web/lib/foo.ts\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -330,10 +341,10 @@ describe("reconcileCodeGraph", () => {
     } as never);
 
     mockExec.mockImplementation(async (command: string) => {
-      if (command === "git rev-parse HEAD") return { stdout: "head-2\n", stderr: "" };
-      if (command === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
-      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
-      if (command === "git status --porcelain") {
+      if (gitSub(command) === "git rev-parse HEAD") return { stdout: "head-2\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
+      if (gitSub(command) === "git status --porcelain") {
         throw new Error("Command failed: git status --porcelain");
       }
       throw new Error(`Unexpected command: ${command}`);
@@ -362,16 +373,16 @@ describe("reconcileCodeGraph", () => {
     } as never);
 
     mockExec.mockImplementation(async (command: string) => {
-      if (command === "git rev-parse HEAD") return { stdout: "head-2\n", stderr: "" };
-      if (command === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
-      if (command === "git status --porcelain") return { stdout: "", stderr: "" };
-      if (command.startsWith("git ls-files -- ")) {
+      if (gitSub(command) === "git rev-parse HEAD") return { stdout: "head-2\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --abbrev-ref HEAD") return { stdout: "main\n", stderr: "" };
+      if (gitSub(command) === "git status --porcelain") return { stdout: "", stderr: "" };
+      if (gitSub(command).startsWith("git ls-files -- ")) {
         return {
           stdout: "apps/web/lib/integrate/code-graph/graph-queries.ts\n",
           stderr: "",
         };
       }
-      if (command === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
+      if (gitSub(command) === "git rev-parse --is-inside-work-tree") return { stdout: "true\n", stderr: "" };
       throw new Error(`Unexpected command: ${command}`);
     });
 

--- a/apps/web/lib/build/code-graph/git-snapshot.test.ts
+++ b/apps/web/lib/build/code-graph/git-snapshot.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { normalizeGitOutput } from "./git-snapshot";
+// vi.mock is hoisted above const declarations, so the fn must be hoisted too.
+const { execMock } = vi.hoisted(() => ({ execMock: vi.fn() }));
+
+vi.mock("@/lib/shared/lazy-node", () => ({
+  lazyExec: () => execMock,
+  lazyPath: () => ({ resolve: (...p: string[]) => p.join("/") }),
+  getCwd: () => "/cwd",
+}));
+
+import { inspectGitRoot, normalizeGitOutput } from "./git-snapshot";
+
+beforeEach(() => execMock.mockReset());
 
 describe("normalizeGitOutput", () => {
   it("trims blank lines and preserves file paths", () => {
@@ -8,5 +19,35 @@ describe("normalizeGitOutput", () => {
       "apps/web/lib/a.ts",
       "packages/db/schema.prisma",
     ]);
+  });
+});
+
+// BI-86EF5900: git REFUSING a repository is not the same as there being none.
+// The portal container runs as a different uid than the checkout it mounts, so
+// every git call there died with "detected dubious ownership" — which the old
+// boolean collapsed into "no repo", making the indexer no-op silently forever.
+describe("inspectGitRoot — refused vs absent", () => {
+  it("classifies dubious ownership as REFUSED, not absent", async () => {
+    execMock.mockRejectedValueOnce(
+      new Error("fatal: detected dubious ownership in repository at '/sandbox-workspace'"),
+    );
+    const status = await inspectGitRoot("/sandbox-workspace");
+    expect(status.kind).toBe("refused");
+  });
+
+  it("classifies a genuinely missing repository as ABSENT", async () => {
+    execMock.mockRejectedValueOnce(new Error("fatal: not a git repository (or any of the parent directories)"));
+    expect((await inspectGitRoot("/app")).kind).toBe("absent");
+  });
+
+  it("passes a scoped safe.directory exception so ownership cannot block the read", async () => {
+    execMock.mockResolvedValueOnce({ stdout: "true\n", stderr: "" });
+    await inspectGitRoot("/sandbox-workspace");
+    expect(String(execMock.mock.calls[0]?.[0])).toContain('-c safe.directory="/sandbox-workspace"');
+  });
+
+  it("reports a readable work tree", async () => {
+    execMock.mockResolvedValueOnce({ stdout: "true\n", stderr: "" });
+    expect((await inspectGitRoot("/repo")).kind).toBe("work-tree");
   });
 });

--- a/apps/web/lib/build/code-graph/git-snapshot.ts
+++ b/apps/web/lib/build/code-graph/git-snapshot.ts
@@ -1,4 +1,5 @@
 import { lazyExec, lazyPath, getCwd } from "@/lib/shared/lazy-node";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 import {
   buildListTrackedFilesCommand,
@@ -15,21 +16,69 @@ export function getGitRoot(): string {
     : resolve(getCwd(), "..", "..");
 }
 
+
 /**
- * Returns true if gitRoot is inside a real git working tree.
- * Runs fast (no file scanning) — just asks git whether it recognises the dir.
- * Returns false in production containers where only the built app is present.
+ * Every git invocation is prefixed with `-c safe.directory=<root>`.
+ *
+ * BI-86EF5900 root cause. The portal container runs as a different uid than the
+ * checkout it mounts, so git refuses EVERY command there:
+ *
+ *   fatal: detected dubious ownership in repository at '/sandbox-workspace'
+ *
+ * `isGitRepo` caught that and returned false, and reconcile's first guard turns
+ * false into `mode: "noop"` — so the code-graph indexer silently did nothing on
+ * every scheduled run. Measured live 2026-08-23: graph_node and graph_edge both
+ * ZERO for the key while CodeGraphIndexState still read "ready" for 4406 files
+ * on a branch last indexed 2026-08-22, the last day git worked.
+ *
+ * Scoping the exception to the one directory we were told to index is the fix
+ * git itself prescribes for this condition, and it is narrower than the
+ * `safe.directory=*` wildcard.
+ */
+function gitIn(gitRoot: string, args: string): string {
+  return `git -c safe.directory=${JSON.stringify(gitRoot)} ${args}`;
+}
+
+/**
+ * Why the working tree could not be read.
+ * - `work-tree`  — a real git work tree; index it.
+ * - `absent`     — no repository here. Production images ship the built app
+ *                  without source; skipping is correct and expected.
+ * - `refused`    — a repository IS here and git declined (ownership, perms,
+ *                  corruption). NOT the same as absent: skipping silently
+ *                  strands the graph forever with no signal, which is how it
+ *                  came to be empty while reporting ready.
+ */
+export type GitRootStatus =
+  | { kind: "work-tree" }
+  | { kind: "absent"; detail: string }
+  | { kind: "refused"; detail: string };
+
+export async function inspectGitRoot(gitRoot: string): Promise<GitRootStatus> {
+  try {
+    const { stdout } = await exec(gitIn(gitRoot, "rev-parse --is-inside-work-tree"), {
+      cwd: gitRoot,
+      timeout: 5_000,
+    });
+    if (stdout.trim() === "true") return { kind: "work-tree" };
+    return { kind: "absent", detail: `git did not report a work tree at ${gitRoot}.` };
+  } catch (error) {
+    const detail = getErrorMessage(error);
+    // "not a git repository" is the legitimate production case. Anything else —
+    // ownership, permissions, a broken object store — is a fault to surface.
+    if (/not a git repository|does not exist|ENOENT/i.test(detail)) {
+      return { kind: "absent", detail };
+    }
+    return { kind: "refused", detail };
+  }
+}
+
+/**
+ * True only for a readable work tree. Retained for callers that just need a
+ * boolean; `inspectGitRoot` is the one that distinguishes absent from refused.
  */
 export async function isGitRepo(gitRoot: string): Promise<boolean> {
-  try {
-    const { stdout } = await exec(
-      "git rev-parse --is-inside-work-tree",
-      { cwd: gitRoot, timeout: 5_000 },
-    );
-    return stdout.trim() === "true";
-  } catch {
-    return false;
-  }
+  return (await inspectGitRoot(gitRoot)).kind === "work-tree";
 }
 
 export function normalizeGitOutput(stdout: string): string[] {
@@ -40,18 +89,18 @@ export function normalizeGitOutput(stdout: string): string[] {
 }
 
 export async function getCurrentHeadSha(gitRoot: string): Promise<string | null> {
-  const { stdout } = await exec("git rev-parse HEAD", { cwd: gitRoot, timeout: 10_000 });
+  const { stdout } = await exec(gitIn(gitRoot, "rev-parse HEAD"), { cwd: gitRoot, timeout: 10_000 });
   return stdout.trim() || null;
 }
 
 export async function getCurrentBranch(gitRoot: string): Promise<string | null> {
-  const { stdout } = await exec("git rev-parse --abbrev-ref HEAD", { cwd: gitRoot, timeout: 10_000 });
+  const { stdout } = await exec(gitIn(gitRoot, "rev-parse --abbrev-ref HEAD"), { cwd: gitRoot, timeout: 10_000 });
   return stdout.trim() || null;
 }
 
 export async function isWorkspaceDirty(gitRoot: string): Promise<boolean> {
   try {
-    const { stdout } = await exec("git status --porcelain", { cwd: gitRoot, timeout: GIT_STATUS_TIMEOUT_MS });
+    const { stdout } = await exec(gitIn(gitRoot, "status --porcelain"), { cwd: gitRoot, timeout: GIT_STATUS_TIMEOUT_MS });
     return stdout.trim().length > 0;
   } catch {
     // Dirty-state detection is advisory telemetry. If Git status is slow on a
@@ -62,7 +111,7 @@ export async function isWorkspaceDirty(gitRoot: string): Promise<boolean> {
 }
 
 export async function listTrackedFiles(gitRoot: string): Promise<string[]> {
-  const { stdout } = await exec(buildListTrackedFilesCommand(), {
+  const { stdout } = await exec(buildListTrackedFilesCommand(gitRoot), {
     cwd: gitRoot,
     timeout: 30_000,
     maxBuffer: 1024 * 1024 * 4,
@@ -75,7 +124,7 @@ export async function getChangedFiles(
   fromSha: string,
   toSha: string,
 ): Promise<string[]> {
-  const { stdout } = await exec(`git diff --name-only ${fromSha}..${toSha}`, {
+  const { stdout } = await exec(gitIn(gitRoot, `diff --name-only ${fromSha}..${toSha}`), {
     cwd: gitRoot,
     timeout: 30_000,
     maxBuffer: 1024 * 1024,

--- a/apps/web/lib/build/code-graph/path-filter.ts
+++ b/apps/web/lib/build/code-graph/path-filter.ts
@@ -14,12 +14,19 @@ export function shouldIndexCodeGraphPath(filePath: string): boolean {
   return CODE_GRAPH_FILE_EXTENSIONS.has(lazyPath().extname(normalized).toLowerCase());
 }
 
-export function buildListTrackedFilesCommand(): string {
+/**
+ * `gitRoot` threads a scoped `safe.directory` exception through, for the same
+ * reason as every other git call here (BI-86EF5900): the portal container runs
+ * as a different uid than the checkout, so an unprefixed git refuses outright.
+ * Optional so existing callers and tests keep working unchanged.
+ */
+export function buildListTrackedFilesCommand(gitRoot?: string): string {
   const includeSpecs = Array.from(CODE_GRAPH_FILE_EXTENSIONS)
     .sort()
     .map((extension) => `"**/*${extension}"`);
   const excludeSpecs = CODE_GRAPH_TRACKED_FILE_EXCLUDES
     .map((pathspec) => `":(exclude)${pathspec}"`);
 
-  return `git ls-files -- ${[...includeSpecs, ...excludeSpecs].join(" ")}`;
+  const safe = gitRoot ? ` -c safe.directory=${JSON.stringify(gitRoot)}` : "";
+  return `git${safe} ls-files -- ${[...includeSpecs, ...excludeSpecs].join(" ")}`;
 }

--- a/apps/web/lib/build/code-graph/reconcile.ts
+++ b/apps/web/lib/build/code-graph/reconcile.ts
@@ -4,9 +4,9 @@ import { CODE_GRAPH_GRAPH_KEY, CODE_GRAPH_PROJECTION_VERSION } from "./constants
 import {
   getChangedFiles,
   getCurrentBranch,
+  inspectGitRoot,
   getCurrentHeadSha,
   getGitRoot,
-  isGitRepo,
   isWorkspaceDirty,
   listTrackedFiles,
 } from "./git-snapshot";
@@ -98,7 +98,42 @@ export async function reconcileCodeGraph(input: ReconcileCodeGraphInput): Promis
   // git repository. Running git commands in a non-git directory hangs until
   // the timeout fires (SIGTERM), marking the code graph as failed on every
   // scheduled run. Skip gracefully instead.
-  if (!(await isGitRepo(gitRoot))) {
+  // ABSENT is a legitimate skip; REFUSED is a fault that must not be silent.
+  //
+  // BI-86EF5900: these were the same branch. The portal container runs as a
+  // different uid than the checkout it mounts, so git answered every command
+  // with "fatal: detected dubious ownership in repository at
+  // '/sandbox-workspace'". That threw, isGitRepo returned false, and this guard
+  // turned it into a no-op — on EVERY scheduled run, for a day, with no record
+  // anywhere. The graph emptied and kept reporting "ready" for 4406 files
+  // because nothing ever wrote a failure. Skipping silently is exactly how an
+  // instrument dies without anyone noticing.
+  const rootStatus = await inspectGitRoot(gitRoot);
+  if (rootStatus.kind === "refused") {
+    await markCodeGraphFailed(graphKey, {
+      workspaceRoot: gitRoot,
+      // Index state is not read until after this guard, so there is no prior
+      // sha to carry here — the point of the record is the refusal itself.
+      previousHeadSha: null,
+      branch: null,
+      workspaceDirty: false,
+      observedAt,
+      error: new Error(
+        `Git refused to read the workspace at ${gitRoot}, so the code graph could not be ` +
+          `indexed. This is NOT an absent repository — the repository is there and git ` +
+          `declined. Detail: ${rootStatus.detail}`,
+      ),
+    });
+    return {
+      mode: "noop",
+      graphKey,
+      headSha: null,
+      branch: null,
+      workspaceDirty: false,
+      changedFiles: [],
+    };
+  }
+  if (rootStatus.kind === "absent") {
     return {
       mode: "noop",
       graphKey,


### PR DESCRIPTION
Root cause of the empty code graph (BI-86EF5900), found by running the indexer's own precondition inside the live portal container:

```
$ docker exec dpf-portal-1 sh -c 'cd $PROJECT_ROOT && git rev-parse --git-dir'
fatal: detected dubious ownership in repository at '/sandbox-workspace'
```

`PROJECT_ROOT` is `/sandbox-workspace`, and the container runs as a different uid than the checkout it mounts, so **git refuses every command there**. `isGitRepo` catches the throw and returns `false`, and `reconcile.ts`'s first guard turns `false` into `mode: "noop"`. The indexer has therefore done nothing on every scheduled run — silently, with no record anywhere.

That is the entire explanation for the state BI-86EF5900 reported:

| | |
|---|---|
| `graph_node` / `graph_edge` for the key | **0 / 0** |
| `CodeGraphIndexState` | `"ready"`, 4406 files |
| `lastIndexedBranch` | `my-changes`, 2026-08-22 |

The graph emptied and kept reporting `ready` because **a no-op writes no failure**, and `lastIndexedBranch` froze on the last day git still worked.

The guard was written for a real case — production images ship the built app without source, and running git in a non-git directory used to hang until the timeout marked the graph failed every night. Skipping that gracefully is correct. What it could not do is tell *"no repository here"* apart from *"the repository is here and git declined"*, so it treated a fixable permission condition as permanent absence.

## Two changes

**1.** Every git invocation now carries `-c safe.directory=<gitRoot>`, scoped to the one directory we were told to index — the fix git itself prescribes, and narrower than the `safe.directory=*` wildcard.

**2.** `inspectGitRoot` replaces the boolean and returns `work-tree | absent | refused`. `absent` still skips silently, because that is genuinely fine. **`refused` now records a failure** naming the directory and git's own message, so the next person sees why the graph stopped instead of inferring it from an empty result.

An instrument that dies quietly is the defect this whole series is about.

## Scope — please read

This makes the indexer able to **run**; it does not by itself make the graph describe `main`. `/sandbox-workspace` is checked out on `client/5727856b-3296-4e17-97f0-c59401ace4f2`, so a successful index would describe a Build Studio sandbox branch.

Which tree the portal should treat as its source of truth is the open question behind BI-6CFC5429 as well, and is an operator call — not something to decide in this diff. The trust vector already scores an off-default branch down, so whichever answer is chosen will be visible rather than silent.

## Verification

- **70 tests pass across 13 code-graph files.** Four new cases pin dubious-ownership → `refused`, a missing repo → `absent`, and assert the scoped `safe.directory` flag is actually passed.
- The 33 existing reconcile fixtures now assert on the git **subcommand** rather than the exact invocation, so a transport-level flag does not have to be restated in every mock.
- `pnpm --filter web build`: clean.
- `pregate:preflight`: 52 guards clean.
- exact-tree local CI gate: **PASS** (evidence `cmt8xjykk04iz01ph4nm6i94p`).

Fixes the root cause of BI-86EF5900.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
