### PR TITLE
fix(skills): write the seed on approval so a reseed stops reverting it (BI-5798BBA3)

### DIFF
--- a/apps/web/components/platform/SkillProposalsPanel.tsx
+++ b/apps/web/components/platform/SkillProposalsPanel.tsx
@@ -169,7 +169,19 @@ function ProposalRow({
                   onClick={() =>
                     startTransition(async () => {
                       const result = await approveSkillProposalAction(proposal.proposalId);
-                      setFeedback(result.ok ? "Approved." : `Failed: ${result.error}`);
+                      if (!result.ok) {
+                        setFeedback(`Failed: ${result.error}`);
+                        return;
+                      }
+                      // Never report a bare success: an approval that did not
+                      // reach the seed file is reverted by the next reseed
+                      // (BI-5798BBA3), so say which happened.
+                      const p = result.data.propagation;
+                      setFeedback(
+                        p.status === "written"
+                          ? `Approved, and written to ${p.path}. Commit that file so the change survives a reseed.`
+                          : `Approved in the catalog only — NOT written to the shipped skill (${p.reason ?? p.status}). A reseed will revert it.`,
+                      );
                     })
                   }
                   style={primaryBtn}

--- a/apps/web/lib/skills/proposals.test.ts
+++ b/apps/web/lib/skills/proposals.test.ts
@@ -1,10 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// The approval now writes the seed file post-commit (BI-5798BBA3). Mock `fs` so
+// the unit tests exercise that path without touching a real checkout.
+const { existsSyncMock, writeFileSyncMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn((_path?: unknown) => false),
+  writeFileSyncMock: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  existsSync: existsSyncMock,
+  writeFileSync: writeFileSyncMock,
+  readFileSync: vi.fn(),
+}));
+
 // In-memory state for the mock transaction so atomicity can be exercised
 // without a live database. Each test resets it via the beforeEach hook.
 const state = vi.hoisted(() => {
   return {
-    skills: new Map<string, { skillId: string; skillMdContent: string }>(),
+    skills: new Map<string, { skillId: string; category: string; skillMdContent: string }>(),
     proposals: new Map<string, Record<string, unknown>>(),
     revisions: new Map<string, Record<string, unknown>>(),
     revisionRows: [] as Array<Record<string, unknown>>,
@@ -151,6 +164,7 @@ beforeEach(() => {
   state.failOnNthCreateRevision = null;
   state.createRevisionCallCount = 0;
   state.skills.set("build-page", {
+    category: "build",
     skillId: "build-page",
     skillMdContent: "v0 body — original",
   });
@@ -462,5 +476,70 @@ describe("listSkillRevisions / listSkillProposals", () => {
     const out = await listSkillProposals("build-page");
     expect(out).toHaveLength(1);
     expect(out[0]?.proposedContent).toBe("v1");
+  });
+});
+
+describe("approveSkillImprovementProposal — seed propagation (BI-5798BBA3)", () => {
+  it("reports propagation when the seed file was written", async () => {
+    process.env.DPF_REPO_ROOT = "/repo";
+    const seed = "/repo/skills/build/build-page.skill.md";
+    existsSyncMock.mockImplementation((p: unknown) => {
+      const n = String(p).replace(/\\/g, "/");
+      return n === "/repo" || n === seed;
+    });
+
+    const { proposalId } = await submitSkillImprovementProposal({
+      skillId: "build-page",
+      proposedContent: "v1 body — proposed",
+      title: "t",
+      description: "d",
+      submittedById: "user-1",
+      agentId: "AGT-1",
+      routeContext: "/r",
+    });
+
+    const result = await approveSkillImprovementProposal({
+      proposalId,
+      reviewerId: "reviewer-1",
+    });
+
+    expect(result.propagation.status).toBe("written");
+    expect(result.propagation.path?.replace(/\\/g, "/")).toBe(seed);
+    expect(writeFileSyncMock).toHaveBeenCalled();
+    const [, body] = writeFileSyncMock.mock.calls[0];
+    expect(body).toBe("v1 body — proposed");
+    existsSyncMock.mockImplementation(() => false);
+    writeFileSyncMock.mockReset();
+  });
+
+  it("still commits the approval when the seed cannot be written, and says so", async () => {
+    process.env.DPF_REPO_ROOT = "/repo";
+    // Repo present, but this skill has no seed file in either corpus.
+    existsSyncMock.mockImplementation(
+      (p: unknown) => String(p).replace(/\\/g, "/") === "/repo",
+    );
+
+    const { proposalId } = await submitSkillImprovementProposal({
+      skillId: "build-page",
+      proposedContent: "v1 body — proposed",
+      title: "t",
+      description: "d",
+      submittedById: "user-1",
+      agentId: "AGT-1",
+      routeContext: "/r",
+    });
+
+    const result = await approveSkillImprovementProposal({
+      proposalId,
+      reviewerId: "reviewer-1",
+    });
+
+    // The DB half is durable regardless of the filesystem outcome.
+    expect(result.newVersion).toBeGreaterThan(0);
+    expect(state.skills.get("build-page")?.skillMdContent).toBe("v1 body — proposed");
+    // ...and the caller is told the approval did NOT reach what ships.
+    expect(result.propagation.status).toBe("no-seed-file");
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+    existsSyncMock.mockImplementation(() => false);
   });
 });

--- a/apps/web/lib/skills/proposals.ts
+++ b/apps/web/lib/skills/proposals.ts
@@ -20,6 +20,8 @@ function makeRevisionId(): string {
   return `${REVISION_ID_PREFIX}-${randomUUID().slice(0, 8).toUpperCase()}`;
 }
 
+import { writeSkillSeed, type SkillSeedWriteResult } from "./seed-writeback";
+
 export type SubmitSkillImprovementProposalInput = {
   /** SkillDefinition.skillId (business id). */
   skillId: string;
@@ -100,6 +102,13 @@ export type ApproveSkillImprovementProposalInput = {
 };
 
 export type ApproveSkillImprovementProposalResult = {
+  /**
+   * Whether the approved body reached the SEED FILE — the authoritative copy
+   * (DI-36D36FEBF4BA). Only `status: "written"` means the approval is durable;
+   * anything else will be reverted by the next reseed, and callers MUST say so
+   * rather than reporting a bare success.
+   */
+  propagation: SkillSeedWriteResult;
   proposalId: string;
   skillId: string;
   snapshotRevisionId: string;
@@ -117,7 +126,7 @@ export type ApproveSkillImprovementProposalResult = {
 export async function approveSkillImprovementProposal(
   input: ApproveSkillImprovementProposalInput,
 ): Promise<ApproveSkillImprovementProposalResult> {
-  return prisma.$transaction(async (tx) => {
+  const applied = await prisma.$transaction(async (tx) => {
     const proposal = await tx.improvementProposal.findUnique({
       where: { proposalId: input.proposalId },
     });
@@ -148,7 +157,7 @@ export async function approveSkillImprovementProposal(
 
     const skill = await tx.skillDefinition.findUnique({
       where: { skillId: proposal.targetSkillId },
-      select: { skillId: true, skillMdContent: true },
+      select: { skillId: true, category: true, skillMdContent: true },
     });
     if (!skill) {
       throw new Error(
@@ -209,11 +218,32 @@ export async function approveSkillImprovementProposal(
     return {
       proposalId: proposal.proposalId,
       skillId: skill.skillId,
+      category: skill.category,
+      approvedContent: proposedContent,
       snapshotRevisionId,
       appliedRevisionId,
       newVersion: appliedVersion,
     };
   });
+
+  // POST-COMMIT, deliberately. The approval is already durable in the DB; a
+  // filesystem failure here must be reported, never allowed to unwind it.
+  // Writing the seed is what stops the next reseed reverting the approval
+  // (BI-5798BBA3), because the seed file is the authoritative copy.
+  const propagation = writeSkillSeed(
+    applied.category,
+    applied.skillId,
+    applied.approvedContent,
+  );
+
+  return {
+    proposalId: applied.proposalId,
+    skillId: applied.skillId,
+    snapshotRevisionId: applied.snapshotRevisionId,
+    appliedRevisionId: applied.appliedRevisionId,
+    newVersion: applied.newVersion,
+    propagation,
+  };
 }
 
 export type RejectSkillImprovementProposalInput = {

--- a/apps/web/lib/skills/seed-writeback.test.ts
+++ b/apps/web/lib/skills/seed-writeback.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { existsSyncMock, writeFileSyncMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn(),
+  writeFileSyncMock: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  existsSync: existsSyncMock,
+  writeFileSync: writeFileSyncMock,
+  readFileSync: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+
+import { writeSkillSeed } from "./seed-writeback";
+
+describe("writeSkillSeed (BI-5798BBA3 phase 2)", () => {
+  it("writes the approved body to the dev-pack seed when that is where the skill lives", () => {
+    process.env.DPF_REPO_ROOT = "/repo";
+    const packPath = "/repo/packages/dpf-skill-pack/skills/dpf-verify-substrate-first/SKILL.md";
+    existsSyncMock.mockImplementation((p: string) => {
+      const n = String(p).replace(/\\/g, "/");
+      return n === "/repo" || n === packPath;
+    });
+
+    const result = writeSkillSeed("governance", "dpf-verify-substrate-first", "# new body\n");
+
+    expect(result.status).toBe("written");
+    expect(result.path?.replace(/\\/g, "/")).toBe(packPath);
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
+    const [calledPath, calledBody] = writeFileSyncMock.mock.calls[0];
+    expect(String(calledPath).replace(/\\/g, "/")).toBe(packPath);
+    expect(calledBody).toBe("# new body\n");
+    existsSyncMock.mockReset();
+    writeFileSyncMock.mockReset();
+  });
+
+  it("does NOT write when no repo checkout is reachable — the benign production case", () => {
+    process.env.DPF_REPO_ROOT = "/repo";
+    existsSyncMock.mockImplementation(() => false);
+
+    const result = writeSkillSeed("governance", "dpf-pr-with-dco", "# body\n");
+
+    expect(result.status).toBe("repo-unavailable");
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+    existsSyncMock.mockReset();
+    writeFileSyncMock.mockReset();
+  });
+
+  it("does NOT invent a seed file when the repo is present but the skill has none", () => {
+    process.env.DPF_REPO_ROOT = "/repo";
+    existsSyncMock.mockImplementation((p: string) => String(p).replace(/\\/g, "/") === "/repo");
+
+    const result = writeSkillSeed("governance", "orphan-skill", "# body\n");
+
+    expect(result.status).toBe("no-seed-file");
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+    existsSyncMock.mockReset();
+    writeFileSyncMock.mockReset();
+  });
+
+  it("reports write-failed rather than throwing when the filesystem refuses", () => {
+    process.env.DPF_REPO_ROOT = "/repo";
+    const packPath = "/repo/packages/dpf-skill-pack/skills/s1/SKILL.md";
+    existsSyncMock.mockImplementation((p: string) => {
+      const n = String(p).replace(/\\/g, "/");
+      return n === "/repo" || n === packPath;
+    });
+    writeFileSyncMock.mockImplementation(() => {
+      throw new Error("EROFS: read-only file system");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const result = writeSkillSeed("governance", "s1", "# body\n");
+
+    expect(result.status).toBe("write-failed");
+    expect(result.reason).toContain("EROFS");
+    existsSyncMock.mockReset();
+    writeFileSyncMock.mockReset();
+  });
+
+  it("treats only 'written' as landed — every other status leaves the approval unpropagated", () => {
+    expect(["repo-unavailable", "no-seed-file", "write-failed"]).not.toContain("written");
+  });
+});

--- a/apps/web/lib/skills/seed-writeback.ts
+++ b/apps/web/lib/skills/seed-writeback.ts
@@ -1,0 +1,84 @@
+// apps/web/lib/skills/seed-writeback.ts
+//
+// Propagate an approved skill body to the SEED FILE, which is the authoritative
+// copy (decision DI-36D36FEBF4BA, `file-authoritative-pr`).
+//
+// Why this exists: approving a skill proposal used to update only
+// SkillDefinition.skillMdContent. The next reseed rewrites that column from the
+// seed file, so an approval survived only until the next seed run — observed
+// live on 2026-08-23, where an approved body was restored to its pre-approval
+// snapshot roughly three hours later while the proposal still read "reviewed".
+// Writing the seed is what makes an approval durable.
+//
+// This module deliberately does NOT create the seed file when none exists.
+// Inventing a path would guess which corpus a skill belongs to and could seed a
+// file the loader never reads; the caller surfaces `no-seed-file` instead so the
+// gap stays visible rather than being papered over.
+
+import { writeFileSync } from "fs";
+
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+import { resolveSeedPathCandidates } from "./seed-parity";
+import { existsSync } from "fs";
+
+/**
+ * Outcome of a seed write. ONLY `written` means the approval reached the copy
+ * that ships; every other status leaves it unpropagated and revertible by the
+ * next reseed, and callers must say so rather than reporting success.
+ */
+export type SkillSeedWriteStatus =
+  | "written"
+  | "repo-unavailable"
+  | "no-seed-file"
+  | "write-failed";
+
+export type SkillSeedWriteResult = {
+  status: SkillSeedWriteStatus;
+  /** The seed file written, or the path that would have been written. */
+  path: string | null;
+  /** Human-readable detail when the write did not happen. */
+  reason: string | null;
+};
+
+function repoRoot(): string {
+  return process.env.DPF_REPO_ROOT ?? `${process.cwd()}/../..`;
+}
+
+/**
+ * Write an approved skill body to its seed file. Best-effort and non-throwing:
+ * the caller has already committed the DB transaction, so a filesystem failure
+ * must be reported, never allowed to unwind an approval that already happened.
+ */
+export function writeSkillSeed(
+  category: string,
+  skillId: string,
+  content: string,
+): SkillSeedWriteResult {
+  if (!existsSync(repoRoot())) {
+    return {
+      status: "repo-unavailable",
+      path: null,
+      reason: "No repository checkout is reachable from this app instance.",
+    };
+  }
+
+  const candidates = resolveSeedPathCandidates(category, skillId);
+  const target = candidates.find((candidate) => existsSync(candidate)) ?? null;
+  if (!target) {
+    return {
+      status: "no-seed-file",
+      path: null,
+      reason: `No seed file exists for this skill. Looked in: ${candidates.join(", ")}.`,
+    };
+  }
+
+  try {
+    writeFileSync(target, content, "utf-8");
+    return { status: "written", path: target, reason: null };
+  } catch (err) {
+    const reason = getErrorMessage(err);
+    console.warn(`[seed-writeback] could not write seed file ${target}:`, reason);
+    return { status: "write-failed", path: target, reason };
+  }
+}

--- a/docs/user-guide/ai-workforce/index.md
+++ b/docs/user-guide/ai-workforce/index.md
@@ -110,7 +110,9 @@ Skills are grouped by category and collapsed. Open a category to see its skills;
 
 Search and the status/source filters work across the whole catalog, and the groups open automatically when a filter is active so you see matches straight away.
 
-If any skill has drifted from the seed, a warning appears under the summary: a fresh install would not match this one. A second warning says drift **can't be checked** for a skill — the repository is there but that skill has no seed file, so an approval can't be compared with what ships. Treat that as unresolved, not as healthy. When no repository is reachable at all, the page says so plainly; that one is normal on a production install. The drift detail, along with route-level skills, observability, and the curator report, sits under **Technical details** — one control at the foot of the page. Those are diagnostics for when you are investigating something specific, not part of reading the catalog.
+If any skill has drifted from the seed, a warning appears under the summary: a fresh install would not match this one. A second warning says drift **can't be checked** for a skill — the repository is there but that skill has no seed file, so an approval can't be compared with what ships. Treat that as unresolved, not as healthy. When no repository is reachable at all, the page says so plainly; that one is normal on a production install. Approving a skill proposal writes the approved text to that skill's seed file, because the seed is the copy that ships. The panel names the file it wrote and asks you to commit it. If it could not write — no repository is reachable, or the skill has no seed file — it says the approval landed in the catalog only and a reseed will revert it. Read that as unfinished: the change is not yet in what your coworkers load.
+
+The drift detail, along with route-level skills, observability, and the curator report, sits under **Technical details** — one control at the foot of the page. Those are diagnostics for when you are investigating something specific, not part of reading the catalog.
 
 ## Related Routes
 


### PR DESCRIPTION
## What

Approving a skill proposal updated only `SkillDefinition.skillMdContent`. The **seed file** is what a reseed rewrites that column from, so an approval survived only until the next seed run.

Phase 2a of BI-5798BBA3, governed by **DI-36D36FEBF4BA** (`file-authoritative-pr`).

## Why — this was observed destroying a real approval

`IP-SKL-7A9CA2C7` was approved at 17:46 on 2026-08-23. By 20:50 the skill body was **byte-identical to its own pre-approval snapshot** (revision v1), while the proposal still read `reviewed`. The approved revision v2 still existed as a record, but the live body — and everything loaded from it — was back to the old text. Nothing anywhere said so.

## How

- **`writeSkillSeed()`** resolves the skill's seed across **both corpora** (coworker `skills/<category>/<id>.skill.md` and dev-pack `packages/dpf-skill-pack/skills/<id>/SKILL.md`, using the resolver landed in #4613) and writes the approved body there.
- **Post-commit, never throws.** The approval is already durable in the DB; a filesystem failure must be reported, not allowed to unwind it.
- `approveSkillImprovementProposal` returns a typed `propagation` result — `written` | `repo-unavailable` | `no-seed-file` | `write-failed`. **Only `written` means the approval reached what ships.**
- It deliberately does **not** create a missing seed file. Inventing a path would guess which corpus a skill belongs to and could seed a file the loader never reads; `no-seed-file` keeps that gap visible.
- The review panel stops reporting a bare "Approved." It names the file it wrote and asks for it to be committed, or states plainly that the approval landed in the catalog only, will be reverted by a reseed, and why.

## Verification

- **Test-first**: 5 failing tests for `writeSkillSeed` (both corpora, repo-unavailable, no-seed-file, write-failed, only-`written`-counts) confirmed RED before implementation, then 2 more on approve — propagation reported on success, and the DB half still committed with an honest status when the seed cannot be written.
- `vitest` — **108 passed across 13 files**; full suite **24,880 passed** in local CI.
- `tsc --noEmit` clean; `pregate:preflight` **52 guards clean**.
- **Functional check against a real filesystem** (unit tests mock `fs`): wrote a dev-pack `SKILL.md` and a coworker `.skill.md` and both file contents changed; an orphan skill returned `no-seed-file` and created nothing; an unreachable repo returned `repo-unavailable`.
- Rebased onto current `origin/main` (39 commits) and re-verified after the rebase.

Local-CI-Evidence: cmt8xqpyh05ej01phaexsrsju (fix/skill-approval-seed-writeback@f2154fb2fc42)

Semantic review: recorded **inconclusive** — "deferred while governed local CI owns host capacity". Infrastructure, not a code finding; recorded as inconclusive rather than presented as a pass. Evidence `cmt8w0t5y3rj101szlqq3z8oc`, capsule WC-27A2569E.

## Scope

Phase 2a. Emitting a branch + PR for the written seed is **2b** and needs the sandbox (`create_portal_pr` requires `sandbox_execute`), so it stays on BI-5798BBA3 rather than being half-built here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
