### PR TITLE
fix(inference): declare prompt provenance on every coworker entry point, not just chat (BI-CE93E314)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { coworkerBriefSpans } from "@/lib/tak/coworker-prompt-provenance";
 import { auth } from "@/lib/auth";
 import { prisma, DATA_MODEL_MIRROR_TASK_ID, SYSML_PROJECTION_TASK_ID, SELF_OPTIMIZATION_SWEEP_TASK_ID } from "@dpf/db";
 import {
@@ -540,6 +541,7 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
 
     const result = await executeAutonomousAgenticLoop({
       systemPrompt: agentInfo.systemPrompt,
+      systemPromptInstructionSpans: coworkerBriefSpans(agentInfo.systemPrompt),
       chatHistory,
       sensitivity: agentInfo.sensitivity ?? "internal",
       tools,

--- a/apps/web/lib/actions/agent-thread-dispatcher-runtime.ts
+++ b/apps/web/lib/actions/agent-thread-dispatcher-runtime.ts
@@ -1,3 +1,4 @@
+import { coworkerBriefSpans } from "@/lib/tak/coworker-prompt-provenance";
 import "server-only";
 
 import { prisma } from "@dpf/db";
@@ -293,6 +294,7 @@ export async function runChildThreadExecution(context: ChildRuntimeContext): Pro
     try {
       result = await executeAutonomousAgenticLoop({
         systemPrompt: agentInfo.systemPrompt,
+        systemPromptInstructionSpans: coworkerBriefSpans(agentInfo.systemPrompt),
         chatHistory,
         sensitivity: agentInfo.sensitivity ?? "internal",
         tools,

--- a/apps/web/lib/build/build-orchestrator.ts
+++ b/apps/web/lib/build/build-orchestrator.ts
@@ -21,7 +21,7 @@ import {
 } from "./task-dependency-graph";
 import { normalizeBuildPlanPaths } from "./build-plan-paths";
 import {
-  buildSpecialistPrompt,
+  buildSpecialistPromptWithProvenance,
   SPECIALIST_AGENT_IDS,
   SPECIALIST_MODEL_REQS,
   SPECIALIST_TOOLS,
@@ -942,7 +942,7 @@ async function dispatchSpecialist(params: {
   const scopedTools = allTools.filter(t => allowedToolNames.has(t.name));
   const toolsForProvider = toolsToOpenAIFormat(scopedTools);
 
-  const baseSystemPrompt = await buildSpecialistPrompt({
+  const base = await buildSpecialistPromptWithProvenance({
     role,
     taskDescription: `Task: ${task.title}\n\nFiles to work on:\n${(task.files ?? []).map(f => `- ${f.path} (${f.action}): ${f.purpose}`).join("\n") || "See task description for details."}`,
     buildContext,
@@ -950,7 +950,9 @@ async function dispatchSpecialist(params: {
   });
   // A1 (BI-C654F960) Phase 2a: govern the inline path — append the real
   // specialist Agent's corpus (BI-B31072B8). Flag-gated default-off (no-op).
-  const { prompt: systemPrompt } = await appendGovernedSpecialistCorpus(baseSystemPrompt, { role, agentId, query: task.title });
+  // BI-CE93E314: the appended corpus is retrieved DATA, so the declared spans
+  // stay exactly the role prompt from buildSpecialistPromptWithProvenance.
+  const { prompt: systemPrompt } = await appendGovernedSpecialistCorpus(base.text, { role, agentId, query: task.title });
 
   let lastResult: AgenticResult | null = null;
   let retries = 0;
@@ -963,6 +965,7 @@ async function dispatchSpecialist(params: {
     lastResult = await runAgenticLoop({
       chatHistory: [{ role: "user", content: taskPrompt }],
       systemPrompt,
+      systemPromptInstructionSpans: base.instructionSpans,
       sensitivity: "development", // code clearance; payload screening still applies
       tools: scopedTools,
       toolsForProvider,

--- a/apps/web/lib/build/build-pipeline.ts
+++ b/apps/web/lib/build/build-pipeline.ts
@@ -464,7 +464,10 @@ async function stepGenerateCode(
     designSystem,
     gateContext,
   });
-  const systemPrompt = `You are an AI coworker building a feature in the sandbox.\n${buildContext}`;
+  // BI-CE93E314: the lead sentence is the brief; buildContext is build state,
+  // i.e. the turn's DATA, and stays undeclared.
+  const buildLead = "You are an AI coworker building a feature in the sandbox.";
+  const systemPrompt = `${buildLead}\n${buildContext}`;
 
   // Get sandbox tools — scoped to build phase only.
   // Filtering by buildPhases: ["build"] gives the agent the file-editing surface
@@ -609,6 +612,7 @@ async function stepGenerateCode(
   // Run the agentic loop — this gives us iterative tool use with the full
   // read-edit-test-fix workflow instead of single-shot code generation
   const result = await runAgenticLoop({
+    systemPromptInstructionSpans: [buildLead],
     chatHistory: [{ role: "user", content: userMessage }],
     systemPrompt,
     sensitivity: "development", // code clearance; payload screening still applies

--- a/apps/web/lib/build/specialist-prompts.test.ts
+++ b/apps/web/lib/build/specialist-prompts.test.ts
@@ -12,7 +12,12 @@ import { describe, expect, it, vi } from "vitest";
 // reads the static prompt record, so stub the loader seam.
 vi.mock("@/lib/tak/prompt-loader", () => ({ loadPrompt: vi.fn() }));
 
-import { SPECIALIST_PROMPTS } from "./specialist-prompts";
+import { loadPrompt } from "@/lib/tak/prompt-loader";
+import {
+  buildSpecialistPrompt,
+  buildSpecialistPromptWithProvenance,
+  SPECIALIST_PROMPTS,
+} from "./specialist-prompts";
 
 const FRONTEND_ENGINEER_PROMPT = SPECIALIST_PROMPTS["frontend-engineer"];
 
@@ -69,5 +74,53 @@ describe("specialist prompt vs enforced-guard consistency (BI-8213E88B)", () => 
   it("routes loading states through the components/ui primitives", () => {
     expect(FRONTEND_ENGINEER_PROMPT).toContain("components/ui/Spinner");
     expect(FRONTEND_ENGINEER_PROMPT).toContain("components/ui/Skeleton");
+  });
+});
+
+// BI-CE93E314. The specialist prompt concatenates the platform-authored role
+// prompt with build state, the assigned task, and another specialist's output.
+// Only the first is the brief; declaring more would let real values ride into a
+// cloud provider inside the prompt.
+describe("buildSpecialistPromptWithProvenance declares the role prompt only", () => {
+  it("declares the role prompt", async () => {
+    vi.mocked(loadPrompt).mockResolvedValue("ROLE: you implement engineering tasks.");
+
+    const result = await buildSpecialistPromptWithProvenance({
+      role: "software-engineer",
+      taskDescription: "Add an endpoint.",
+      buildContext: "BUILD STATE",
+    });
+
+    expect(result.instructionSpans).toHaveLength(1);
+    expect(result.instructionSpans[0]).toContain("ROLE: you implement engineering tasks.");
+    expect(result.text).toContain(result.instructionSpans[0]!);
+  });
+
+  it("does NOT declare build context, the task, or prior specialist output", async () => {
+    vi.mocked(loadPrompt).mockResolvedValue("ROLE: you implement engineering tasks.");
+
+    const result = await buildSpecialistPromptWithProvenance({
+      role: "software-engineer",
+      taskDescription: "Set Dana's salary to 125000.",
+      buildContext: "BUILD STATE: invoice 88213",
+      priorResults: "PRIOR: bank account 021000021",
+    });
+
+    const declared = result.instructionSpans.join("\n");
+    expect(declared).not.toContain("125000");
+    expect(declared).not.toContain("88213");
+    expect(declared).not.toContain("021000021");
+  });
+
+  it("keeps buildSpecialistPrompt returning the same text", async () => {
+    vi.mocked(loadPrompt).mockResolvedValue("ROLE: you implement engineering tasks.");
+    const params = {
+      role: "software-engineer" as const,
+      taskDescription: "Add an endpoint.",
+      buildContext: "BUILD STATE",
+    };
+
+    expect(await buildSpecialistPrompt(params))
+      .toBe((await buildSpecialistPromptWithProvenance(params)).text);
   });
 });

--- a/apps/web/lib/build/specialist-prompts.ts
+++ b/apps/web/lib/build/specialist-prompts.ts
@@ -280,12 +280,25 @@ export const SPECIALIST_TOOLS: Record<SpecialistRole, string[]> = {
  * Build the full system prompt for a specialist.
  * Composes: role prompt + task description + build context + prior results.
  */
-export async function buildSpecialistPrompt(params: {
+type SpecialistPromptParams = {
   role: SpecialistRole;
   taskDescription: string;
   buildContext: string;
   priorResults?: string;
-}): Promise<string> {
+};
+
+/**
+ * The specialist prompt plus the span of it that is platform-authored
+ * INSTRUCTION (BI-CE93E314).
+ *
+ * Only the role prompt qualifies. `buildContext`, `taskDescription` and
+ * `priorResults` are build state and another specialist's output — the turn's
+ * DATA — and are deliberately absent, so the inference screener still escalates
+ * on a real value found in any of them.
+ */
+export async function buildSpecialistPromptWithProvenance(
+  params: SpecialistPromptParams,
+): Promise<{ text: string; instructionSpans: string[] }> {
   const hardcoded = SPECIALIST_PROMPTS[params.role];
   const specialistPrompt = withCoworkerInteractionContract(await loadPrompt("specialist", params.role, hardcoded));
   const parts = [specialistPrompt];
@@ -300,5 +313,9 @@ export async function buildSpecialistPrompt(params: {
     parts.push(`\n--- Results from Prior Specialists ---\n${params.priorResults}`);
   }
 
-  return parts.join("\n\n");
+  return { text: parts.join("\n\n"), instructionSpans: [specialistPrompt] };
+}
+
+export async function buildSpecialistPrompt(params: SpecialistPromptParams): Promise<string> {
+  return (await buildSpecialistPromptWithProvenance(params)).text;
 }

--- a/apps/web/lib/coworker-lifecycle/certification-runner.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.ts
@@ -18,6 +18,7 @@
 // writes are the governed ToolExecution audit rows and the assurance records
 // this module owns.
 
+import { coworkerBriefSpans } from "@/lib/tak/coworker-prompt-provenance";
 import { prisma } from "@dpf/db";
 import { COWORKER_AGENT_SEEDS } from "@dpf/db/workforce-seed";
 import { runAgenticLoop } from "@/lib/tak/agentic-loop";
@@ -110,6 +111,8 @@ export type CertificationDeps = {
   runLoop: (params: {
     journey: GoldenJourney;
     systemPrompt: string;
+    /** Instruction spans within systemPrompt (BI-CE93E314). */
+    systemPromptInstructionSpans?: string[];
     sensitivity: RouteSensitivity;
     tools: Parameters<typeof toolsToOpenAIFormat>[0];
     toolsForProvider: Array<Record<string, unknown>>;
@@ -145,6 +148,7 @@ async function defaultRunLoop(
   const result = await runAgenticLoop({
     chatHistory: [{ role: "user", content: params.journey.prompt }],
     systemPrompt: params.systemPrompt,
+    systemPromptInstructionSpans: params.systemPromptInstructionSpans,
     sensitivity: params.sensitivity,
     tools: params.tools,
     toolsForProvider: params.toolsForProvider,
@@ -298,6 +302,7 @@ async function executeJourney(
     const loop = await deps.runLoop({
       journey,
       systemPrompt: agentInfo.systemPrompt,
+      systemPromptInstructionSpans: coworkerBriefSpans(agentInfo.systemPrompt),
       sensitivity: agentInfo.sensitivity ?? "internal",
       tools: readOnlyTools,
       toolsForProvider,

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -1,3 +1,4 @@
+import { coworkerBriefSpans } from "@/lib/tak/coworker-prompt-provenance";
 import { prisma } from "@dpf/db";
 import type { Prisma } from "@dpf/db";
 import { resolveCanonicalAgentId } from "@dpf/db/agent-identity";
@@ -693,6 +694,7 @@ export async function submitRemoteCoworkerTask(input: {
   try {
     const result = await executeAutonomousAgenticLoop({
       systemPrompt: agent.systemPrompt,
+      systemPromptInstructionSpans: coworkerBriefSpans(agent.systemPrompt),
       chatHistory: [{ role: "user", content: parsed.prompt }],
       sensitivity: agent.sensitivity ?? "internal",
       tools: tools.tools,

--- a/apps/web/lib/tak/coworker-prompt-provenance.ts
+++ b/apps/web/lib/tak/coworker-prompt-provenance.ts
@@ -54,3 +54,22 @@ export function composeCoworkerDomainContext(parts: CoworkerDomainParts): {
       .filter((span): span is string => Boolean(span)),
   };
 }
+
+/**
+ * The instruction spans for a prompt that is ENTIRELY the coworker's brief
+ * (BI-CE93E314).
+ *
+ * `loadPromptBackplane` composes the identity block, company mission, platform
+ * preamble and route persona — four authored prompt templates, with no
+ * runtime-injected business data anywhere in them. Callers that hand that string
+ * straight to the agentic loop (the scheduled runner, the thread dispatcher, the
+ * MCP task path, the certification runner) can declare the whole thing.
+ *
+ * Named rather than inlined at each call site so there is one place to correct
+ * if the backplane ever starts injecting recalled data — at which point this
+ * function must narrow, and every caller narrows with it.
+ */
+export function coworkerBriefSpans(systemPrompt: string | null | undefined): string[] {
+  const brief = systemPrompt?.trim();
+  return brief ? [brief] : [];
+}

--- a/apps/web/lib/tak/prompt-provenance-coverage.test.ts
+++ b/apps/web/lib/tak/prompt-provenance-coverage.test.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+// BI-CE93E314. BI-463BE12A shipped prompt provenance and wired it into exactly
+// one of seven entry points. It merged, deployed, and changed nothing: on the
+// live install, ZERO turns carried instruction spans, because the coworkers that
+// were broken run on the SCHEDULED path, not on interactive chat.
+//
+// The failure was silent by construction. A caller that declares nothing is not
+// an error — it means "the whole prompt is the turn's data", which is the safe
+// default and exactly why nobody notices. So the coverage has to be asserted,
+// not remembered.
+//
+// This test enumerates every call site that starts an agentic turn and requires
+// each one to have made a provenance decision. To add a caller, either pass
+// `systemPromptInstructionSpans`, or add it to DELIBERATELY_UNDECLARED below
+// with a reason. Both are fine; silence is not.
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const LOOP_ENTRY = /\b(?:runAgenticLoop|executeAutonomousAgenticLoop)\(\{/;
+
+/**
+ * Call sites that intentionally declare nothing, with why. A prompt built
+ * entirely from the turn's own data has no instruction span to name, and
+ * declaring one would be the egress hole this whole mechanism exists to close.
+ */
+const DELIBERATELY_UNDECLARED: Record<string, string> = {
+  // Re-dispatches a prompt its caller already built and already declared for.
+  "apps/web/lib/tak/autonomous-work-run.ts":
+    "forwards input.systemPromptInstructionSpans from its caller",
+};
+
+function trackedFiles(): string[] {
+  return execFileSync("git", ["ls-files", "apps/web/**/*.ts"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  })
+    .split("\n")
+    .filter((f) => f && !f.includes(".test.") && !f.endsWith(".d.ts"));
+}
+
+describe("every agentic-turn entry point has decided its prompt provenance", () => {
+  const callers = trackedFiles().filter((file) =>
+    LOOP_ENTRY.test(readFileSync(join(REPO_ROOT, file), "utf8")),
+  );
+
+  it("finds the call sites at all, so a rename cannot quietly empty this test", () => {
+    // If the loop entry points are renamed, this list goes to zero and every
+    // assertion below passes vacuously. Fail loudly instead.
+    expect(callers.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it.each(callers.map((f) => [f]))("%s declares provenance or says why not", (file) => {
+    const source = readFileSync(join(REPO_ROOT, file), "utf8");
+    const declares = source.includes("systemPromptInstructionSpans");
+    const exempt = Object.hasOwn(DELIBERATELY_UNDECLARED, file);
+
+    expect(
+      declares || exempt,
+      `${file} starts an agentic turn without deciding prompt provenance.\n` +
+        "Pass systemPromptInstructionSpans naming the platform-authored spans of " +
+        "the system prompt, or add this file to DELIBERATELY_UNDECLARED with a " +
+        "reason. Declaring nothing means the whole prompt is screened as the " +
+        "turn's data, which pins finance- and people-facing coworkers to " +
+        "local-only routing (BI-463BE12A).",
+    ).toBe(true);
+  });
+
+  it("keeps the exemption list honest — no entries for files that are gone", () => {
+    for (const file of Object.keys(DELIBERATELY_UNDECLARED)) {
+      expect(callers, `${file} is exempted but no longer starts an agentic turn`)
+        .toContain(file);
+    }
+  });
+});

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -23,7 +23,7 @@ apps/web/instrumentation.ts	1475
 apps/web/lib/actions/agent-coworker-external.test.ts	889
 apps/web/lib/actions/agent-coworker.ts	2810
 apps/web/lib/actions/agent-task-scheduler.test.ts	1132
-apps/web/lib/actions/agent-task-scheduler.ts	807
+apps/web/lib/actions/agent-task-scheduler.ts	809
 apps/web/lib/actions/ai-providers.ts	914
 apps/web/lib/actions/build-governed.test.ts	1149
 apps/web/lib/actions/build.ts	1747


### PR DESCRIPTION
## BI-463BE12A merged and changed nothing

#4616 shipped prompt provenance. The deployed image contains it — `grep` inside `dpf-portal-1` finds both new symbols in `/app`. `RouteDecisionLog` for turns since that image was built:

| agent | restricted | turns | carrying instruction spans |
|---|---|---|---|
| coo | 5 | 5 | **0** |
| market-research-analyst | 3 | 3 | **0** |
| hr-specialist | 2 | 2 | **0** |

Every receipt still reads `"path": "systemPrompt"`, never `"systemPrompt.instruction[0]"`.

## Why

BI-463BE12A wired provenance into `agent-coworker.ts` — both its unified and legacy branches. Both serve `sendMessage`, the interactive chat path. The turns these coworkers actually run are **scheduled**: `actorKind=agent`, `routeContext=/performance`, `taskType=conversation`, fired on a cadence. They never touch `sendMessage`.

Six of seven entry points declared nothing. Declaring nothing is not an error — it means "the whole prompt is the turn's data", which is the safe default, and exactly why nobody noticed.

## Now wired

| caller | declared |
|---|---|
| `agent-task-scheduler.ts` | backplane prompt, whole string |
| `agent-thread-dispatcher-runtime.ts` | backplane prompt, whole string |
| `mcp-task-submit.ts` | backplane prompt, whole string |
| `certification-runner.ts` | backplane prompt, whole string |
| `build-orchestrator.ts` | role prompt only — the appended corpus is retrieved DATA |
| `build-pipeline.ts` | the lead sentence only — `buildContext` is build state |

`loadPromptBackplane` composes the identity block, company mission, platform preamble and route persona: four authored templates with no runtime-injected business data, so the whole string is the brief. The four callers that pass it share `coworkerBriefSpans()` rather than repeating the literal — one place to narrow if the backplane ever starts injecting recalled data.

`buildSpecialistPrompt` gains a provenance-aware sibling with a single implementation. `taskDescription`, `buildContext` and `priorResults` stay undeclared, and a test puts a salary, an invoice number and a bank account in those fields and asserts none reaches the declared spans.

## The coverage guard

The failure mode here is silent, so coverage is asserted rather than remembered. `prompt-provenance-coverage` enumerates every `runAgenticLoop` / `executeAutonomousAgenticLoop` call site in the repo and requires each to pass `systemPromptInstructionSpans` or appear in `DELIBERATELY_UNDECLARED` with a reason. It fails naming the file and what to do about it.

Two details that make it worth having:

- It asserts it found **at least six** call sites, so renaming the loop entry points cannot quietly empty the test into a vacuous pass.
- It fails if an exemption outlives the file it exempts.

Verified red by deleting one declaration.

This is the part that generalises. BI-463BE12A was verified at the classifier, at the routing seam, and against both branches of the one caller that had been traced. All three passed. None of them can detect an *absent* declaration somewhere else — only an enumeration can prove absence.

## Note on the baseline

`check-module-size.mjs --update` also wanted to retighten eight unrelated files that other branches have shrunk since the baseline was written. Reverted that and hand-edited only this PR's line (`agent-task-scheduler.ts` +2), since dragging the rest in could trip in-flight work sitting between the old and new numbers.

## Verification

6,938 tests across `lib/build` + `lib/actions` + `lib/coworker-lifecycle` + `lib/tak` + `lib/inference` + `lib/routing`; web typecheck; 52 preflight guards; exact-tree local CI gate PASS @ `d50023aa01de`, evidence `cmt8xxd3v064401phkp2epder`.

Once this deploys the check is one live COO turn showing `matchProvenance` with `path` starting `systemPrompt.instruction[`.

Part of `WC-9C828312`. Completes the acceptance of `docs/superpowers/plans/2026-08-23-prompt-provenance-in-inference-screening.md`. Follow-on to #4616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)