### PR TITLE
fix(build-studio): refuse to start, and stop claiming progress, when no engine can dispatch (BI-CE1AB982)

### DIFF
--- a/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
@@ -177,7 +177,14 @@ export function BuildStudioWorkflowActionCard({
     setLastOutcome(null);
     try {
       if (action.kind === "approve-start") {
-        await approveBuildStart(build.buildId);
+        // BI-CE1AB982: the dispatch pre-flight reports "no engine can run this"
+        // as a value, so the owner reads the real cause instead of a stripped
+        // production digest. Same contract as advance-phase below.
+        const outcome = await approveBuildStart(build.buildId);
+        if (!outcome.ok) {
+          setError(outcome.message);
+          return;
+        }
       } else if (action.kind === "record-acceptance") {
         await recordBuildAcceptance(build.buildId);
       } else if (action.kind === "run-review-verification") {

--- a/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
@@ -176,28 +176,18 @@ export function BuildStudioWorkflowActionCard({
     setError(null);
     setLastOutcome(null);
     try {
+      // BI-8C6AA60E / BI-CE1AB982: an expected operational refusal ("no releasable
+      // source changes", "no engine can run this") comes back as a value, because a
+      // thrown Error is stripped to a production digest and the operator needs the cause.
+      let refusal: { ok: boolean; message?: string; error?: string } | null = null;
       if (action.kind === "approve-start") {
-        // BI-CE1AB982: the dispatch pre-flight reports "no engine can run this"
-        // as a value, so the owner reads the real cause instead of a stripped
-        // production digest. Same contract as advance-phase below.
-        const outcome = await approveBuildStart(build.buildId);
-        if (!outcome.ok) {
-          setError(outcome.message);
-          return;
-        }
+        refusal = await approveBuildStart(build.buildId);
       } else if (action.kind === "record-acceptance") {
         await recordBuildAcceptance(build.buildId);
       } else if (action.kind === "run-review-verification") {
         await runBuildReviewVerification(build.buildId);
       } else if (action.kind === "advance-phase" && action.targetPhase) {
-        // BI-8C6AA60E: "no releasable source changes" is an expected operational
-        // state, returned as a value so the operator reads the real message
-        // instead of a stripped production digest.
-        const outcome = await advanceBuildPhase(build.buildId, action.targetPhase);
-        if (!outcome.ok) {
-          setError(outcome.message);
-          return;
-        }
+        refusal = await advanceBuildPhase(build.buildId, action.targetPhase);
       } else if (action.kind === "retry-inference") {
         // BI-F0005EB0 — the AI call errored. Re-drive the failed coworker turn
         // (the same recovery the user does by re-prompting today) by opening the
@@ -231,6 +221,7 @@ export function BuildStudioWorkflowActionCard({
           }),
         );
       }
+      if (refusal && !refusal.ok) return setError(refusal.error ?? refusal.message ?? "That could not be completed.");
 
       window.dispatchEvent(
         new CustomEvent("build-progress-update", {

--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -509,7 +509,7 @@ describe("governed build start approvals", () => {
     const result = await approveBuildStart("FB-123");
 
     expect(result.ok).toBe(true);
-    expect(result.ok && result.approvedAt).toBeInstanceOf(Date);
+    expect(result.ok && result.data.approvedAt).toBeInstanceOf(Date);
     expect(mockPrisma.featureBuild.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { buildId: "FB-123" },
@@ -543,7 +543,7 @@ describe("governed build start approvals", () => {
     const result = await approveBuildStart("FB-123");
 
     expect(result.ok).toBe(false);
-    expect(!result.ok && result.message).toContain("Connect, provision, or wait for one allowed Build Studio engine");
+    expect(!result.ok && result.error).toContain("Connect, provision, or wait for one allowed Build Studio engine");
     // The owner's approval must not be recorded for work that cannot start.
     expect(mockPrisma.featureBuild.update).not.toHaveBeenCalled();
     expect(mockPrisma.buildActivity.create).toHaveBeenCalledWith(

--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -131,6 +131,13 @@ vi.mock("@/lib/build/decision-service", () => ({
   evaluateBuildStudioDecision: mockEvaluateBuildStudioDecision,
 }));
 
+const mockGetBuildStudioConfig = vi.fn(async () => ({
+  selection: { status: "selected", selected: { engine: "opencode" }, reason: "ok", action: null },
+}));
+vi.mock("@/lib/build/build-studio-config", () => ({
+  getBuildStudioConfig: (...args: unknown[]) => mockGetBuildStudioConfig(...(args as [])),
+}));
+
 vi.mock("@/lib/build/build-entry-gate", () => ({
   enforceBuildInitiativeReadiness: mockEnforceBuildInitiativeReadiness,
   assertBuildPhaseInitiativeReadiness: mockEnforceBuildInitiativeReadiness,
@@ -501,13 +508,47 @@ describe("governed build start approvals", () => {
 
     const result = await approveBuildStart("FB-123");
 
-    expect(result.approvedAt).toBeInstanceOf(Date);
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.approvedAt).toBeInstanceOf(Date);
     expect(mockPrisma.featureBuild.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { buildId: "FB-123" },
         data: expect.objectContaining({
           draftApprovedAt: expect.any(Date),
         }),
+      }),
+    );
+  });
+
+  // BI-CE1AB982 — approval used to succeed unconditionally, so an owner
+  // approved a start that silently never dispatched and the panel then reported
+  // "working" indefinitely.
+  it("approveBuildStart refuses and does not stamp approval when no engine can run the build", async () => {
+    mockPrisma.featureBuild.findUnique.mockResolvedValue({
+      createdById: "user-1",
+      phase: "ideate",
+      originatingBacklogItemId: "backlog-row-1",
+      draftApprovedAt: null,
+    });
+    mockPrisma.platformDevConfig.findUnique.mockResolvedValue({ governedBacklogEnabled: true });
+    mockGetBuildStudioConfig.mockResolvedValueOnce({
+      selection: {
+        status: "blocked",
+        selected: null,
+        reason: "No eligible endpoints for task type 'code-gen'.",
+        action: "Connect, provision, or wait for one allowed Build Studio engine, then retry.",
+      },
+    } as never);
+
+    const result = await approveBuildStart("FB-123");
+
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.message).toContain("Connect, provision, or wait for one allowed Build Studio engine");
+    // The owner's approval must not be recorded for work that cannot start.
+    expect(mockPrisma.featureBuild.update).not.toHaveBeenCalled();
+    expect(mockPrisma.buildActivity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ tool: "dispatch_blocked" }),
       }),
     );
   });

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -134,7 +134,19 @@ export async function createFeatureBuild(input: {
   return { ok: true, buildId: result.buildId };
 }
 
-export async function approveBuildStart(buildId: string): Promise<{ approvedAt: Date }> {
+/**
+ * Record the owner's approval to start a governed backlog draft.
+ *
+ * BI-CE1AB982 — returns a result value rather than throwing for the expected
+ * "we cannot run this" case. A thrown Error is stripped to a production digest
+ * (same reason advanceBuildPhase returns its outcome, BI-8C6AA60E), and the
+ * whole point of the pre-flight is that the owner reads the real cause.
+ */
+export type ApproveBuildStartResult =
+  | { ok: true; approvedAt: Date }
+  | { ok: false; message: string };
+
+export async function approveBuildStart(buildId: string): Promise<ApproveBuildStartResult> {
   const userId = await requireBuildAccess();
 
   const [build, devConfig] = await Promise.all([
@@ -171,6 +183,33 @@ export async function approveBuildStart(buildId: string): Promise<{ approvedAt: 
   // resolver renders it solely on the backlog-link condition. Aligning here.
   void devConfig;
 
+  // BI-CE1AB982 — dispatch pre-flight. Approval used to be unconditional: we
+  // stamped draftApprovedAt, told the owner the build was under way, and only
+  // THEN discovered (inside fire-and-forget dispatch) that no engine could run
+  // it. The owner was thanked for a decision that changed nothing, and the panel
+  // reported progress indefinitely. Resolve the same selection the dispatcher
+  // will use, and refuse up front when it is already blocked.
+  //
+  // Deliberately fails OPEN: only a definitive `blocked` verdict stops the
+  // approval. If readiness cannot be resolved at all, approve as before rather
+  // than stranding an owner behind a diagnostic that is itself broken.
+  if (!build.draftApprovedAt) {
+    const preflight = await resolveDispatchPreflight();
+    if (preflight) {
+      prisma.buildActivity.create({
+        data: {
+          buildId,
+          tool: "dispatch_blocked",
+          summary: preflight,
+        },
+      }).catch(() => {});
+      return {
+        ok: false,
+        message: `Build Studio cannot start this yet: no configured AI service can run it. ${preflight}`,
+      };
+    }
+  }
+
   const approvedAt = build.draftApprovedAt ?? new Date();
   await prisma.featureBuild.update({
     where: { buildId },
@@ -205,7 +244,27 @@ export async function approveBuildStart(buildId: string): Promise<{ approvedAt: 
     })();
   }
 
-  return { approvedAt };
+  return { ok: true, approvedAt };
+}
+
+/**
+ * BI-CE1AB982 — returns the owner-facing blocking action when no allowed healthy
+ * Build Studio engine can run the work, or null when dispatch may proceed.
+ * Resolution failures return null (fail open) — see approveBuildStart.
+ */
+async function resolveDispatchPreflight(): Promise<string | null> {
+  try {
+    const { getBuildStudioConfig } = await import("@/lib/build/build-studio-config");
+    const { selection } = await getBuildStudioConfig({});
+    if (!selection) return null;
+    if (selection.status !== "blocked" && selection.selected) return null;
+    return selection.action
+      ?? selection.reason
+      ?? "No allowed healthy Build Studio engine remains. Review AI Readiness and retry.";
+  } catch (err) {
+    console.warn("[approveBuildStart] dispatch pre-flight could not be resolved:", err);
+    return null;
+  }
 }
 
 // ─── Update Feature Brief ────────────────────────────────────────────────────

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -23,6 +23,7 @@ import { queueBuildReviewVerification } from "@/lib/build-review-verification-tr
 import { saveBuildArtifactRevision, type BuildArtifactField } from "@/lib/build/build-artifact-provenance";
 import { buildAcceptanceEvidenceRecord, writeAcceptanceMet } from "@/lib/build/auto-accept";
 import { evaluateBuildStudioDecision } from "@/lib/build/decision-service";
+import { ok, err, type ActionResult } from "@/lib/shared/action-result";
 import {
   assertFeatureBuildDependencyGate,
   FEATURE_BUILD_DEPENDENCY_GATE_SELECT,
@@ -142,11 +143,9 @@ export async function createFeatureBuild(input: {
  * (same reason advanceBuildPhase returns its outcome, BI-8C6AA60E), and the
  * whole point of the pre-flight is that the owner reads the real cause.
  */
-export type ApproveBuildStartResult =
-  | { ok: true; approvedAt: Date }
-  | { ok: false; message: string };
-
-export async function approveBuildStart(buildId: string): Promise<ApproveBuildStartResult> {
+export async function approveBuildStart(
+  buildId: string,
+): Promise<ActionResult<{ approvedAt: Date }>> {
   const userId = await requireBuildAccess();
 
   const [build, devConfig] = await Promise.all([
@@ -183,17 +182,9 @@ export async function approveBuildStart(buildId: string): Promise<ApproveBuildSt
   // resolver renders it solely on the backlog-link condition. Aligning here.
   void devConfig;
 
-  // BI-CE1AB982 — dispatch pre-flight. Approval used to be unconditional: we
-  // stamped draftApprovedAt, told the owner the build was under way, and only
-  // THEN discovered (inside fire-and-forget dispatch) that no engine could run
-  // it. The owner was thanked for a decision that changed nothing, and the panel
-  // reported progress indefinitely. Resolve the same selection the dispatcher
-  // will use, and refuse up front when it is already blocked.
-  //
-  // Deliberately fails OPEN: only a definitive `blocked` verdict stops the
-  // approval. If readiness cannot be resolved at all, approve as before rather
-  // than stranding an owner behind a diagnostic that is itself broken.
+  // BI-CE1AB982 — refuse before the owner authorises work that cannot be run.
   if (!build.draftApprovedAt) {
+    const { resolveDispatchPreflight } = await import("@/lib/build/dispatch-preflight");
     const preflight = await resolveDispatchPreflight();
     if (preflight) {
       prisma.buildActivity.create({
@@ -203,10 +194,9 @@ export async function approveBuildStart(buildId: string): Promise<ApproveBuildSt
           summary: preflight,
         },
       }).catch(() => {});
-      return {
-        ok: false,
-        message: `Build Studio cannot start this yet: no configured AI service can run it. ${preflight}`,
-      };
+      return err(
+        `Build Studio cannot start this yet: no configured AI service can run it. ${preflight}`,
+      );
     }
   }
 
@@ -244,27 +234,7 @@ export async function approveBuildStart(buildId: string): Promise<ApproveBuildSt
     })();
   }
 
-  return { ok: true, approvedAt };
-}
-
-/**
- * BI-CE1AB982 — returns the owner-facing blocking action when no allowed healthy
- * Build Studio engine can run the work, or null when dispatch may proceed.
- * Resolution failures return null (fail open) — see approveBuildStart.
- */
-async function resolveDispatchPreflight(): Promise<string | null> {
-  try {
-    const { getBuildStudioConfig } = await import("@/lib/build/build-studio-config");
-    const { selection } = await getBuildStudioConfig({});
-    if (!selection) return null;
-    if (selection.status !== "blocked" && selection.selected) return null;
-    return selection.action
-      ?? selection.reason
-      ?? "No allowed healthy Build Studio engine remains. Review AI Readiness and retry.";
-  } catch (err) {
-    console.warn("[approveBuildStart] dispatch pre-flight could not be resolved:", err);
-    return null;
-  }
+  return ok({ approvedAt });
 }
 
 // ─── Update Feature Brief ────────────────────────────────────────────────────

--- a/apps/web/lib/build/customer-status-projection.test.ts
+++ b/apps/web/lib/build/customer-status-projection.test.ts
@@ -240,6 +240,55 @@ describe("reconcileBuildStudioCustomerStatus — canonical owner state", () => {
     };
   }
 
+  // BI-CE1AB982 — live repro FB-615DE356 on the Pet Rescue consumer install:
+  // approve_start recorded, ideate_dispatch skipped for want of an eligible
+  // engine, zero BuildDispatchAttempt rows — and the owner panel reported
+  // "Build Studio is working on this change" for 30+ minutes.
+  it("renders a refused-before-start dispatch as blocked, never as working", () => {
+    const status = reconcileBuildStudioCustomerStatus({
+      phase: "ideate",
+      status: base,
+      progress: progress({
+        dispatchBlock: {
+          blocked: true,
+          reason: "Connect, provision, or wait for one allowed Build Studio engine, then retry.",
+          observedAt: "2026-08-12T12:00:00.000Z",
+        },
+      }),
+    });
+
+    expect(status.ownerState).toBe("blocked");
+    expect(status.needsYou).toBe(true);
+    expect(status.worker).not.toMatch(/working on this change/i);
+    expect(status.owner).toBe("platform administrator");
+    expect(status.technicalEvidence).toContain("allowed Build Studio engine");
+  });
+
+  it("clears the refusal once a fresher dispatch proves the pipeline moved on", () => {
+    // deriveDispatchBlock owns the self-clearing rule; an already-cleared signal
+    // must not resurrect the blocked state here.
+    const status = reconcileBuildStudioCustomerStatus({
+      phase: "ideate",
+      status: base,
+      progress: progress({
+        dispatchBlock: { blocked: false, reason: null, observedAt: null },
+      }),
+    });
+
+    expect(status.ownerState).not.toBe("blocked");
+  });
+
+  it("does not claim work is in progress while no task or dispatch exists in ideate", () => {
+    const status = reconcileBuildStudioCustomerStatus({
+      phase: "ideate",
+      status: base,
+      progress: progress(),
+    });
+
+    expect(status.ownerState).toBe("not-started");
+    expect(status.worker).not.toMatch(/working on this change/i);
+  });
+
   it("shows a real in-flight dispatch with persisted elapsed time and a bounded expectation", () => {
     const status = reconcileBuildStudioCustomerStatus({
       phase: "build",

--- a/apps/web/lib/build/dispatch-preflight.ts
+++ b/apps/web/lib/build/dispatch-preflight.ts
@@ -1,0 +1,35 @@
+/**
+ * BI-CE1AB982 — can Build Studio actually dispatch work right now?
+ *
+ * approveBuildStart used to be unconditional: it stamped draftApprovedAt, told
+ * the owner the build was under way, and only THEN discovered — inside a
+ * fire-and-forget dispatch — that no engine could run it. The owner was thanked
+ * for a decision that changed nothing, and the panel reported progress
+ * indefinitely (live repro FB-615DE356).
+ *
+ * This resolves the same selection the dispatcher will use, so the refusal
+ * happens before the owner is asked to authorise anything.
+ */
+
+/**
+ * Returns the owner-facing blocking action when no allowed healthy Build Studio
+ * engine can run the work, or null when dispatch may proceed.
+ *
+ * Deliberately fails OPEN: an unresolvable readiness check returns null so a
+ * broken diagnostic can never strand an owner behind a gate of its own making.
+ * Only a definitive `blocked` verdict refuses.
+ */
+export async function resolveDispatchPreflight(): Promise<string | null> {
+  try {
+    const { getBuildStudioConfig } = await import("@/lib/build/build-studio-config");
+    const { selection } = await getBuildStudioConfig({});
+    if (!selection) return null;
+    if (selection.status !== "blocked" && selection.selected) return null;
+    return selection.action
+      ?? selection.reason
+      ?? "No allowed healthy Build Studio engine remains. Review AI Readiness and retry.";
+  } catch (err) {
+    console.warn("[dispatch-preflight] readiness could not be resolved:", err);
+    return null;
+  }
+}

--- a/apps/web/lib/build/ideate-on-approval.ts
+++ b/apps/web/lib/build/ideate-on-approval.ts
@@ -81,6 +81,15 @@ export async function dispatchIdeateForApprovedBuild(params: {
     });
   };
 
+  /** BI-CE1AB982 — durable "refused before start" marker read by progress-visibility. */
+  const recordDispatchBlocked = async (reason: string): Promise<void> => {
+    await prisma.buildActivity.create({
+      data: { buildId, tool: "dispatch_blocked", summary: reason },
+    }).catch((err) => {
+      console.warn("[ideate-on-approval] Failed to log dispatch_blocked:", { buildId, reason }, err);
+    });
+  };
+
   try {
     // Fetch the build with the linked BI and current designDoc evidence.
     // NOTE: businessContext is intentionally NOT selected here — it is not a
@@ -183,6 +192,12 @@ export async function dispatchIdeateForApprovedBuild(params: {
         reason: selection?.action ?? "No allowed healthy Build Studio engine remains. Review AI Readiness and retry.",
       };
       await logActivity(`Skipped auto-dispatch: ${outcome.reason}`);
+      // BI-CE1AB982: the line above is the ONLY trace a refused dispatch used to
+      // leave, and nothing on the owner surface reads `ideate_dispatch` prose —
+      // so the panel kept animating "Build Studio is working on this change" on a
+      // build that never started. This row is the durable, queryable signal the
+      // progress projection reads to render the build as blocked instead.
+      await recordDispatchBlocked(outcome.reason);
       return outcome;
     }
     await logActivity(formatBuildEngineSelectionEvidence(selection));

--- a/apps/web/lib/build/owner-status-reconciliation.ts
+++ b/apps/web/lib/build/owner-status-reconciliation.ts
@@ -137,6 +137,34 @@ export function reconcileBuildStudioCustomerStatus(args: {
     return { ...status, ownerState: "waiting-owner" };
   }
 
+  // BI-CE1AB982: a dispatch REFUSED before it started never produces a
+  // BuildDispatchAttempt row, an assistant turn, or a failure axis — so every
+  // signal below this point reads "nothing is wrong" and the build renders as
+  // working, forever. The owner approved a start that silently never happened.
+  // Same owner-facing shape as the `config` inference failure: this is platform
+  // setup, not something the owner can fix by waiting.
+  const dispatchBlock = progress.dispatchBlock;
+  if (dispatchBlock?.blocked) {
+    const elapsedLabel = formatElapsedLabel(
+      dispatchBlock.observedAt,
+      progress.generatedAt,
+      "Waiting",
+    );
+    return {
+      ...status,
+      ownerState: "blocked",
+      lifecyclePosition: "AI setup needs attention",
+      worker: "Build Studio has not started this change",
+      evidence: "No configured AI service can run this step, so the work was never started.",
+      technicalEvidence: dispatchBlock.reason ?? undefined,
+      nextAction: "Ask a platform administrator to check AI readiness, then start this again.",
+      owner: "platform administrator",
+      needsYou: true,
+      ...(elapsedLabel ? { elapsedLabel } : {}),
+      expectation: "This will not start on its own. Nothing is lost — the request stays here until setup is fixed.",
+    };
+  }
+
   const inFlight = latestInflightDispatch(progress);
   if (inFlight) {
     const elapsedLabel = formatElapsedLabel(inFlight.startedAt, progress.generatedAt, "Working");
@@ -154,19 +182,18 @@ export function reconcileBuildStudioCustomerStatus(args: {
     };
   }
 
-  if (
-    (phase === "build" || phase === "review")
-    && progress.tasks.totalTasks === 0
-    && progress.dispatchHistory.length === 0
-  ) {
+  // BI-CE1AB982: this guard used to be gated to build/review, on the reasoning
+  // that ideate/plan are coworker-custody. But "no task, no dispatch, nothing in
+  // flight" means no work has started in ANY phase, and the fallthrough below
+  // resolves that to "working". Claiming progress is only honest once something
+  // has actually been dispatched, so the guard now covers every live phase.
+  if (progress.tasks.totalTasks === 0 && progress.dispatchHistory.length === 0) {
     return {
       ...status,
       ownerState: "not-started",
-      lifecyclePosition: phase === "build" ? "Preparing the build" : "Preparing the checks",
-      worker: phase === "build" ? "No implementation task has started" : "No verification check has started",
-      evidence: phase === "build"
-        ? "Build Studio has not dispatched implementation work yet."
-        : "Build Studio has not dispatched verification work yet.",
+      lifecyclePosition: notStartedStageLabel(phase),
+      worker: notStartedWorkerLabel(phase),
+      evidence: notStartedEvidence(phase),
       nextAction: "No action needed unless Build Studio asks for a decision.",
       owner: "Build Studio",
       needsYou: false,
@@ -238,6 +265,37 @@ function latestInflightDispatch(progress: BuildProgressVisibility) {
   return [...progress.dispatchHistory]
     .filter((attempt) => attempt.completedAt == null)
     .sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime())[0] ?? null;
+}
+
+function notStartedStageLabel(phase: BuildPhase): string {
+  switch (phase) {
+    case "ideate": return "Preparing to understand the change";
+    case "plan": return "Preparing the plan";
+    case "build": return "Preparing the build";
+    case "review": return "Preparing the checks";
+    case "ship": return "Preparing the release";
+    default: return "Preparing";
+  }
+}
+
+function notStartedWorkerLabel(phase: BuildPhase): string {
+  switch (phase) {
+    case "ideate": return "No research step has started";
+    case "plan": return "No planning step has started";
+    case "build": return "No implementation task has started";
+    case "review": return "No verification check has started";
+    default: return "No step has started";
+  }
+}
+
+function notStartedEvidence(phase: BuildPhase): string {
+  switch (phase) {
+    case "ideate": return "Build Studio has not dispatched research work yet.";
+    case "plan": return "Build Studio has not dispatched planning work yet.";
+    case "build": return "Build Studio has not dispatched implementation work yet.";
+    case "review": return "Build Studio has not dispatched verification work yet.";
+    default: return "Build Studio has not dispatched work yet.";
+  }
 }
 
 function workingStageLabel(phase: BuildPhase): string {

--- a/apps/web/lib/build/progress-visibility.ts
+++ b/apps/web/lib/build/progress-visibility.ts
@@ -88,6 +88,27 @@ export type BuildProgressVisibility = {
     summary: string;
     observedAt: string;
   } | null;
+  /**
+   * BI-CE1AB982 — the newest dispatch that was REFUSED before it started,
+   * because no allowed healthy engine could run the phase.
+   *
+   * A skipped dispatch writes no BuildDispatchAttempt row, so it is invisible to
+   * `dispatchHistory`, to `quietAgent` (which only counts elapsed silence) and
+   * to `inferenceFailure` (which classifies an assistant turn that actually
+   * ran). Without this signal the owner panel falls through to "working" and
+   * reports progress on a build that never started, indefinitely.
+   *
+   * Self-clearing on the same rule as `inferenceFailure`: a fresher meaningful
+   * signal (task result, verification, dispatch) proves the pipeline moved on.
+   *
+   * Optional so projection literals (tests) need not supply it;
+   * getBuildProgressVisibility always populates it.
+   */
+  dispatchBlock?: {
+    blocked: boolean;
+    reason: string | null;
+    observedAt: string | null;
+  };
   /** Phase-level cost rollup; empty array when BuildPhaseRun rows don't exist yet */
   phaseRuns: PhaseRunSummary[];
   /**
@@ -116,6 +137,11 @@ export function buildProgressProjectionFromParts(args: {
   phaseRuns?: PhaseRunSummary[];
   evidenceTimeline?: UnifiedEvidenceTimelineEvent[];
   engineSelection?: { summary: string; observedAt: Date | string } | null;
+  /**
+   * BI-CE1AB982 — newest refused-before-start dispatch, if any. Optional so
+   * projection literals (tests) need not supply it — absent means "not blocked".
+   */
+  dispatchBlock?: { reason: string; observedAt: Date | string } | null;
 }): BuildProgressVisibility {
   const now = args.now ?? new Date();
   const conflicts = getProgressConflicts(args.dbTasks.source, args.chatSnapshots);
@@ -172,6 +198,7 @@ export function buildProgressProjectionFromParts(args: {
       lastMeaningfulSignalAt,
     },
     inferenceFailure,
+    dispatchBlock: deriveDispatchBlock(args.dispatchBlock, lastMeaningfulSignalAt),
     engineSelection: args.engineSelection
       ? {
           summary: args.engineSelection.summary,
@@ -180,6 +207,33 @@ export function buildProgressProjectionFromParts(args: {
       : null,
     phaseRuns: args.phaseRuns ?? [],
     evidenceTimeline: args.evidenceTimeline ?? [],
+  };
+}
+
+/**
+ * BI-CE1AB982 — resolve the refused-before-start dispatch signal.
+ *
+ * Mirrors deriveInferenceFailure's self-clearing rule: a refusal only stands
+ * while it is at least as recent as the last meaningful non-chat signal, so a
+ * later successful dispatch clears it without anyone having to reset state.
+ */
+function deriveDispatchBlock(
+  input: { reason: string; observedAt: Date | string } | null | undefined,
+  lastMeaningfulSignalAt: string | null,
+): { blocked: boolean; reason: string | null; observedAt: string | null } {
+  const empty = { blocked: false, reason: null, observedAt: null };
+  if (!input) return empty;
+  const observedAt = new Date(input.observedAt);
+  const observedMs = observedAt.getTime();
+  if (!Number.isFinite(observedMs)) return empty;
+  if (lastMeaningfulSignalAt) {
+    const signalMs = new Date(lastMeaningfulSignalAt).getTime();
+    if (Number.isFinite(signalMs) && signalMs > observedMs) return empty;
+  }
+  return {
+    blocked: true,
+    reason: input.reason,
+    observedAt: observedAt.toISOString(),
   };
 }
 
@@ -287,6 +341,13 @@ export async function getBuildProgressVisibility(buildId: string): Promise<Build
     orderBy: { createdAt: "desc" },
     select: { summary: true, createdAt: true },
   });
+  // BI-CE1AB982 — a refused-before-start dispatch leaves no BuildDispatchAttempt
+  // row, so its only durable trace is this activity row.
+  const dispatchBlockActivity = await prisma.buildActivity.findFirst({
+    where: { buildId, tool: "dispatch_blocked" },
+    orderBy: { createdAt: "desc" },
+    select: { summary: true, createdAt: true },
+  });
 
   return buildProgressProjectionFromParts({
     buildId,
@@ -303,6 +364,9 @@ export async function getBuildProgressVisibility(buildId: string): Promise<Build
     evidenceTimeline,
     engineSelection: engineSelectionActivity
       ? { summary: engineSelectionActivity.summary, observedAt: engineSelectionActivity.createdAt }
+      : null,
+    dispatchBlock: dispatchBlockActivity
+      ? { reason: dispatchBlockActivity.summary, observedAt: dispatchBlockActivity.createdAt }
       : null,
   });
 }

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -5858,6 +5858,7 @@
         "what-it-is",
         "operating-rule",
         "how-to-apply",
+        "a-phase-that-cannot-start-is-blocked-not-working",
         "see-also"
       ]
     },

--- a/docs/professions/build-studio/wiki/build-phase-lifecycle.md
+++ b/docs/professions/build-studio/wiki/build-phase-lifecycle.md
@@ -24,6 +24,25 @@ Do not collapse the lifecycle into "write code." A build is healthy only when so
 3. Capture evidence as the work moves through test, review, and ship.
 4. Stop and surface blockers when the phase cannot honestly advance.
 
+## A Phase That Cannot Start Is Blocked, Not Working
+
+A phase reports progress only once work has actually been dispatched. If no
+engine can run the phase, the honest state is blocked, and the owner is told the
+cause and who can clear it — never that the change is being worked on.
+
+Two failures look identical to the owner but are not the same:
+
+- **Work is running and quiet.** A dispatch exists and has not returned yet. The
+  quiet-agent watchdog owns this; quiet is not dead.
+- **Work never started.** No dispatch exists, because the phase was refused
+  before it began. No elapsed time will change this, so waiting is the wrong
+  advice and "nothing is wrong" is the wrong reassurance.
+
+Refuse at the gate rather than after it. Where a start is approved by a human,
+check that the phase can actually be dispatched *before* recording the approval,
+so the owner is never asked to authorise work the platform already knows it
+cannot perform.
+
 ## See Also
 
 - [[professions/build-studio/ideate-plan-build-review-ship]]

--- a/scripts/build-studio-surface-baseline.json
+++ b/scripts/build-studio-surface-baseline.json
@@ -4,5 +4,5 @@
   "expiry": "2026-11-21",
   "note": "Build Studio surface ratchet baseline (BI-101C107C). Shrink-only: the Build Studio UI surface leaves this budget by DELETING or CONVERGING components, never by expanding the baseline. A 'simplification' that adds net lines is not a simplification. Regenerate with: node scripts/check-build-studio-surface-budget.mjs --update",
   "componentCount": 70,
-  "nonTestLoc": 16342
+  "nonTestLoc": 16340
 }

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -25,8 +25,8 @@ apps/web/lib/actions/agent-coworker.ts	2810
 apps/web/lib/actions/agent-task-scheduler.test.ts	1132
 apps/web/lib/actions/agent-task-scheduler.ts	809
 apps/web/lib/actions/ai-providers.ts	914
-apps/web/lib/actions/build-governed.test.ts	1149
-apps/web/lib/actions/build.ts	1747
+apps/web/lib/actions/build-governed.test.ts	1190
+apps/web/lib/actions/build.ts	1778
 apps/web/lib/actions/compliance.ts	867
 apps/web/lib/actions/crm.ts	1043
 apps/web/lib/actions/ea.ts	918


### PR DESCRIPTION
## Problem

A non-technical owner could describe an outcome, approve the start, and be told Build Studio was building it — when nothing was dispatched and nothing ever would be.

Live repro `FB-615DE356`, captured driving the Pet Rescue consumer install through the portal as a shelter director:

```
23:55:21  backlog_row_start_build   draft created from BI-4C608C04
23:56:17  approve_start             owner approved the start
23:56:17  ideate_dispatch           Skipped auto-dispatch: Connect, provision, or wait
                                    for one allowed Build Studio engine, then retry.
```

Zero `BuildDispatchAttempt` rows. Thirty minutes later the owner panel still read **"Build Studio is working on this change"**, the coworker card said **"Nothing is wrong"**, and *Show why* said **"no evidence is missing yet"**. The only trace was inside the collapsed technical drawer.

## Root cause

A dispatch refused *before it starts* writes no `BuildDispatchAttempt` row, produces no assistant turn, and sets no failure axis — so every signal `owner-status-reconciliation` reads says "nothing is wrong" and the status falls through to `working`. The zero-dispatch guard that would have caught it was gated to `build`/`review`, so `ideate` and `plan` fell straight through.

This was knowable up front: `resolve_model_selection` already returned three `error` flags (`ideate-no-eligible-engine`, `build-no-eligible-engine`, plan `no-eligible-endpoint`), and `/platform/ai/readiness` already rendered BLOCKED. Nothing consulted either.

## Change

- **Pre-flight at approval.** `approveBuildStart` resolves the same selection the dispatcher will use and refuses up front, returning the cause **as a value** so the owner reads it — a thrown `Error` is stripped to a production digest, the same reason `advanceBuildPhase` returns its outcome (BI-8C6AA60E). Deliberately **fails open**: only a definitive `blocked` verdict stops approval, so a broken diagnostic can never strand an owner.
- **Durable signal.** The skip writes a `dispatch_blocked` `BuildActivity` row, projected into `BuildProgressVisibility.dispatchBlock` beside the existing `engine_selection` signal, self-clearing on the same rule as `inferenceFailure`.
- **Honest rendering.** The owner seam renders that as `blocked` with an owner-legible cause, next action and accountable owner, reusing the existing `config`-failure shape rather than inventing new vocabulary.
- **Generalised zero-dispatch guard.** No task, no dispatch, nothing in flight means no work has started in *any* phase.

No new tables, no migration, no new status machine.

## Verification

- `customer-status-projection` (31), `progress-visibility`, `build-governed`, `build-attention` — green.
- Full `components/build` + `lib/build` surface: **237 files / 2558 tests passed**.
- The two behavioural regression tests **fail against the previous code** (verified by restoring `origin/main`'s `owner-status-reconciliation.ts`: `2 failed | 29 passed`).
- `tsc --noEmit` on `apps/web`: **0 errors**. Style drift, docs-impact, design-grounding and plan-backlog-coverage gates: clean.
- Runtime UX verification was **not** performed: the fix is not deployed to the live install (`/ops/self-upgrade` owns that), so the rendering evidence here is the failing-then-passing tests plus the live repro above.

Refs: BI-CE1AB982, WC-8389D1EA