### PR TITLE
doc(architecture): canonical minimal substrate, accommodation doctrine and archetype operating models

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 683,
+  "pageCount": 687,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -564,6 +564,26 @@
         "annex-e-suggested-receipt-verifier-pseudocode"
       ]
     },
+    "docs/architecture/accommodation-doctrine.md": {
+      "publicHref": "/architecture/accommodation-doctrine/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "accommodation-doctrine",
+        "why",
+        "the-five-patterns-already-in-the-codebase-now-named",
+        "the-classification-procedure",
+        "the-promotion-rule",
+        "worked-example-live-right-now",
+        "the-promotion-mechanic",
+        "escape-hatch-discipline",
+        "probe-discipline",
+        "recording",
+        "anti-patterns",
+        "applying-this-to-campground"
+      ]
+    },
     "docs/architecture/agent-client-capability-parity.md": {
       "publicHref": "/architecture/agent-client-capability-parity/",
       "portalHref": null,
@@ -960,6 +980,44 @@
         "8-documentation-maintenance-rule"
       ]
     },
+    "docs/architecture/archetypes/campground-operating-model.md": {
+      "publicHref": "/architecture/archetypes/campground-operating-model/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "campground-rv-park-operating-model-and-probe-result",
+        "1-the-operating-day",
+        "2-the-bad-day",
+        "3-the-periodic-cycle",
+        "4-load-bearing-obligations",
+        "5-probe-result-classification",
+        "confirmed-no-new-canonical-element",
+        "promoted-by-the-counting-rule",
+        "genuinely-new-candidates",
+        "confirmed-stress-test-long-episodes",
+        "6-doctrine-verdict",
+        "7-what-campground-still-needs-before-it-could-run",
+        "8-cross-archetype-notes"
+      ]
+    },
+    "docs/architecture/archetypes/pet-rescue-operating-model.md": {
+      "publicHref": "/architecture/archetypes/pet-rescue-operating-model/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "standing-requirements-pet-rescue-animal-shelter-archetype",
+        "1-the-operating-day",
+        "2-the-bad-day",
+        "3-the-periodic-cycle",
+        "4-load-bearing-obligations",
+        "5-required-entities",
+        "6-what-exists-today-measured-2026-08-25",
+        "7-ux-requirements",
+        "8-definition-of-done"
+      ]
+    },
     "docs/architecture/architecture-counts.generated.md": {
       "publicHref": "/architecture/architecture-counts.generated/",
       "portalHref": null,
@@ -1088,6 +1146,30 @@
         "product-operating-context-query-boundary",
         "direction-route-and-projection-boundary",
         "fleet-safe-evolution"
+      ]
+    },
+    "docs/architecture/canonical-minimal-substrate.md": {
+      "publicHref": "/architecture/canonical-minimal-substrate/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "the-canonical-minimal-substrate",
+        "headline",
+        "the-elements",
+        "what-is-already-done-and-done-well",
+        "the-capacity-substrate-is-genuinely-canonical",
+        "care-is-already-subject-agnostic-this-corrects-an-earlier-finding",
+        "the-remaining-work",
+        "7-canonical-subject-identity-the-keystone",
+        "8-occupancy-episode-lift-hospitalityserviceturn",
+        "9-episode-stagestate-and-event-ledger-already-designed-do-not-re-invent",
+        "10-concurrent-time-bound-holds-a-genuine-gap-and-an-extension-of-the-grammar",
+        "11-jurisdiction-as-a-rule-source-promoted-at-two-sightings",
+        "also-resource-to-service-capability-map",
+        "what-pet-rescue-proved-that-restaurant-could-not",
+        "sequencing",
+        "method-note-for-the-next-archetype"
       ]
     },
     "docs/architecture/capability-driven-runtime-profiles.md": {

--- a/docs/architecture/accommodation-doctrine.md
+++ b/docs/architecture/accommodation-doctrine.md
@@ -1,0 +1,192 @@
+# Accommodation doctrine
+
+How to decide, when a new archetype reveals a difference, whether it is **canonical**,
+**vertical**, or **an attribute** — and how to move it later without a rescue project.
+
+This exists so that being wrong is cheap. It is deliberately short. It is a decision procedure,
+not an architecture.
+
+---
+
+## Why
+
+Two failure modes, both already observed in this codebase.
+
+**Canonicalising too early is guessing.** Restaurant alone made the capacity substrate look
+finished. Tier, blocking holds and jurisdiction were invisible until a structurally unlike
+archetype was tried. Any design written from one probe is fiction.
+
+**Canonicalising too late is a migration.** Beauty and hospitality were cloned first. Undoing
+that required a dual-read migration carrying `sourceRef` provenance on every row. It worked, but
+that is the real price of "refactor it in as we go" at the shared layer — and it scales with
+every vertical that lands before the fix.
+
+So: keep discovering incrementally, but classify each difference *at the moment of discovery*
+using a fixed procedure, and use a standard accommodation mechanism rather than inventing one
+each time.
+
+## The five patterns (already in the codebase, now named)
+
+| # | Pattern | Mechanism | Existing use |
+|---|---|---|---|
+| 1 | **Open kind vocabulary** | a validated slug column, open set | `Resource.kindSlug` — "chair, station, treatment_room, table, kitchen, ..." |
+| 2 | **Polymorphic subject** | `<x>KindSlug` + `<x>Ref` | `CareAppointment.subjectKindSlug` + `subjectRef` |
+| 3 | **Polymorphic demand** | `demandSlug` + `demandRef` | `ResourceCapacityAllocation` — "booking, hold, service-turn, ..." |
+| 4 | **Clone-to-canonical backfill** | `sourceRef` unique provenance key | `Resource.sourceRef` — "e.g. `BeautyResource:<id>`" |
+| 5 | **Typed escape hatch** | `attributes` / `layoutState` Json | `Resource.attributes`, `OperationalSceneLayout.layoutState` |
+
+Patterns 1-3 accommodate variation **with no schema change**. Reach for them first; most
+differences are one of these three and stop there.
+
+## The classification procedure
+
+Ask in order. Stop at the first yes.
+
+**1. Is it only a word?**
+Same structure, different label — kennel / table / campsite / treatment room.
+-> **Pattern 1.** Add a slug value. No schema change, no decision to record.
+
+**2. Is it a new kind of thing attaching to something canonical?**
+An animal attaching to an intake packet; a service turn creating demand on a resource.
+-> **Pattern 2 or 3.** Register the kind, supply the owning-vertical resolution. No schema change.
+
+**3. Is it a new field that nothing outside this vertical will ever query or constrain on?**
+-> **Pattern 5.** Put it in `attributes`. **Register the key** (see below).
+
+**4. Is it a new field that must be queried, sorted, or constrained across verticals?**
+-> Needs a real column. Go to the promotion rule.
+
+**5. Is it a new structure — its own lifecycle, its own events?**
+-> Build it **in the vertical first**. Go to the promotion rule.
+
+## The promotion rule
+
+How many *independent* archetypes need it?
+
+| Sightings | Action |
+|---|---|
+| **1** | Build it in the vertical. Do not canonicalise on one example. |
+| **2** | Keep it vertical, but **shape it for promotion** and record the second sighting. |
+| **3** | **Promote to canonical.** Three independent sightings is a real invariant. |
+
+Three overrides:
+
+- **Load-bearing beats counting.** If getting it wrong is unlawful, unsafe, or corrupts
+  reporting, promote at **2**. Wrong in two places is already expensive. *Holds are the current
+  example: a restaurant hold is a convenience, a stray hold is statutory.*
+- **Keystones promote at 1.** If other elements cannot proceed without it, it is canonical by
+  definition regardless of sightings. *Subject identity is the current example.*
+- **Never promote from one probe's imagination.** A sighting means an archetype actually needs it
+  to run its day, not that it might one day.
+
+### Worked example, live right now
+
+A resource-to-capability map — "which kennels take a large dog", "which sites fit a 32ft rig",
+"which stations perform colour".
+
+- beauty — `BeautyResourceService` (built)
+- pet-rescue — kennel suitability (required, §5 of the rescue requirements)
+- campground — dimensional fit (expected)
+
+Three independent sightings from unrelated verticals. **Promote.** That decision needed no
+architecture review — it fell out of counting.
+
+## The promotion mechanic
+
+Do not invent one. This path is already proven by the hospitality/beauty -> `Resource` migration:
+
+1. Add the canonical model **alongside** the clone. Nothing is dropped.
+2. Backfill with `sourceRef = '<CloneModel>:<id>'`, unique, so the backfill is idempotent and
+   re-runnable.
+3. **Dual-read** — canonical first, clone as fallback.
+4. Cut writes to canonical.
+5. Retire the clone, with a test proving no legacy table or column was dropped prematurely and
+   that the rollback selector stays provenance-bounded.
+
+Steps 1-3 are non-breaking, which is what makes an incorrect earlier classification cheap.
+
+## Escape-hatch discipline
+
+`attributes` Json is a **staging area, not a destination**.
+
+- Anything queried or constrained across verticals **must graduate to a column**. Json is not a
+  way to avoid the promotion rule.
+- **Register every key you put in it.** This is the discipline that prevents the expensive
+  failure: `OperationalSceneLayout.layoutState` is opaque, so if pet-rescue writes `tier` for a
+  stacked cat condo and warehousing writes `level` for a rack, the two diverge silently and
+  promotion later requires reconciling both. One registry file per Json column, listing key,
+  meaning, owning vertical, and type.
+- A key used by a second vertical is a **sighting**, and counts toward promotion.
+
+## Probe discipline
+
+**Use two probes, never one.** Restaurant alone was insufficient and actively misleading. Choose
+the second probe to be **structurally unlike** the first, and treat anything only the second
+needs as a *candidate* canonical element rather than a vertical special case.
+
+**Distinguish probe types, and say which you are running:**
+
+- **Discovery probe** — structurally unlike anything built. Expected to surface new canonical
+  candidates. *pet-rescue was this.*
+- **Confirmation probe** — similar to what exists. Expected to surface **few or none**. *campground
+  is this.* If a confirmation probe surfaces many new canonical elements, the model is wrong —
+  stop and re-cut rather than absorbing them one at a time.
+
+## Recording
+
+One decision record per promotion or deliberate non-promotion. It must state:
+
+- the difference, in the archetype's own words
+- the classification and which step of the procedure produced it
+- sighting count and which archetypes
+- rejected options and why
+- for a non-promotion: what would change the answer
+
+Two threads answering the same generalise-vs-clone question differently produces a generalised
+schema under a cloned vocabulary. That has already nearly happened once
+(`BI-2C80E6EA` / `BI-51C95802`) — check for an existing decision before opening a new one.
+
+## Anti-patterns
+
+- **Canonicalising from one probe.** Every time, so far, the second probe changed the shape.
+- **Treating vocabulary as structure.** Eleven labels over one fixed process is not archetype
+  support. If the only thing that changes is a word, pattern 1 is the whole answer.
+- **Json as a destination.** Unregistered keys in a shared Json column are a future migration
+  with no provenance.
+- **Clone without `sourceRef`.** A clone that cannot be backfilled is a permanent fork.
+- **Deferring a keystone.** Anything other elements depend on blocks everything behind it;
+  resolve it inside the epic rather than after.
+- **Believing a passing UX review or a completed onboarding.** Both passed on pet-rescue at 0.05
+  operating-model coverage.
+
+## Applying this to campground
+
+Campground is a **confirmation probe**. Expected classification, to be checked rather than
+assumed:
+
+| Difference | Expected | Pattern |
+|---|---|---|
+| site / loop / pad naming | vocabulary | 1 |
+| stay = occupancy episode | existing canonical (once lifted) | — |
+| reservation, walk-in, waitlist | existing demand vocabulary | 3 |
+| ranger rounds | same round shape as kennel rounds | — |
+| campground map | `OperationalSceneLayout`, flat — will not stress tier | — |
+| hookups (30/50amp, water, sewer) | capability map | promote (3rd sighting) |
+| **dimensional fit** — does a 32ft rig fit site 14 | **candidate canonical** | see below |
+| **seasonal sites** — episodes lasting months | **stress test** | see below |
+| length-of-stay limits (statutory on public land) | jurisdiction rules | candidate, 2nd sighting |
+
+Two to watch closely:
+
+**Dimensional fit** is not capacity-as-a-count. `Resource.capacity: Int` cannot express "32 feet
+fits in 40 feet". It is constraint matching against resource attributes, and it is the same shape
+as kennel suitability and refrigerated racking — which is why it is the third sighting of the
+capability map rather than something new.
+
+**Very long episodes.** A seasonal site runs for months with sub-metered utilities billed against
+it; a restaurant turn is ninety minutes. If the episode model assumes short spans anywhere —
+index shape, conflict-window scans, `expectedEndAt` semantics — campground will find it. This is
+the single most valuable thing this probe can tell us, and it is cheap to check early.
+
+If campground produces more than one or two genuinely new canonical candidates, treat that as
+evidence the nine-element set is mis-cut, not as nine-plus-N.

--- a/docs/architecture/archetype-operating-model-audit.md
+++ b/docs/architecture/archetype-operating-model-audit.md
@@ -164,6 +164,16 @@ An archetype has been through this audit when all of the following exist:
 ## Standards basis (do not re-derive)
 
 - [UX Archetype Audit Rubric](./ux-archetype-audit-rubric.md) — the surface counterpart; run both.
+- [Accommodation Doctrine](./accommodation-doctrine.md) — how to classify a difference this audit
+  finds as canonical, vertical or attribute, and the promotion rule. **Run this on every finding**;
+  the audit surfaces gaps, the doctrine decides where they belong.
+- [Canonical Minimal Substrate](./canonical-minimal-substrate.md) — the current element set and
+  what is already built. Check here before designing anything; most gaps are reach, not absence.
+- [Canonical Lifecycle Grammar](../superpowers/specs/2026-08-15-canonical-lifecycle-grammar-design.md)
+  — stages, in-stage states and gated advancement. Any new entity with a lifecycle declares a
+  grammar rather than a new stage enum.
+- Archetype operating models: [pet-rescue](./archetypes/pet-rescue-operating-model.md) ·
+  [campground](./archetypes/campground-operating-model.md)
 - [Archetype Business Value Streams](./archetype-business-value-streams.md)
 - [Four-Portfolio Archetype AI Workforce Operating Standard](./four-portfolio-archetype-ai-workforce-operating-standard.md)
 

--- a/docs/architecture/archetypes/campground-operating-model.md
+++ b/docs/architecture/archetypes/campground-operating-model.md
@@ -1,0 +1,220 @@
+# Campground / RV park — operating model and probe result
+
+Archetype family: `campground`, `rv-park`, `glamping`, and by extension marina slips.
+Probe type: **confirmation probe** (per the [accommodation doctrine](../accommodation-doctrine.md)).
+Written 2026-08-25 as part of the archetype operating-model audit.
+
+The operating day below was written from domain research **before** classifying anything against
+the schema, per step 1 of the [audit method](../archetype-operating-model-audit.md). The
+classification in §5 was done afterwards.
+
+---
+
+## 1. The operating day
+
+**07:00 — Bathhouse and grounds.** A host cleans the two bathhouses (three times daily in
+season), empties trash on the loops, and checks the dump station. This is a **round**: a fixed
+sweep producing a per-location record.
+
+**08:00 — Departures.** Eleven sites check out by 11:00. Each needs turnover: fire ring cleaned,
+site raked, hookups checked, trash cleared. A site is not sellable again until turnover is done —
+which matters because three of those sites are booked for arrival the same afternoon.
+
+**09:00 — The overnight arrival problem.** A rig came in at 23:00 after office hours, used the
+late-arrival envelope, and parked on site 22. Site 22 was booked to someone else from tonight.
+Staff must find them, verify, and move somebody.
+
+**10:00 — Reservations.** Phone and online. Some guests book a **specific site** ("we want 14,
+we had it last year"); others book a **site class** ("any full-hookup pull-through") and get
+assigned at check-in. Both are normal, and the second is how the park keeps flexibility.
+
+Minimum stays apply — two nights on weekends, three on holidays. A one-night request on a
+Saturday is refused by policy, not by availability.
+
+**11:00 — A fit problem.** A caller has a 38-foot fifth wheel plus a tow vehicle. Half the park
+cannot take it: site length, back-in versus pull-through, overhanging trees, turning radius at
+the loop head. **Availability is not the question — fit is.** The site is empty and still wrong.
+
+**13:00 — Check-ins.** Registration takes vehicle plate, rig type and length, occupant count,
+pets, and emergency contact. In several jurisdictions guest registration is a legal requirement,
+as it is for hotels. Wristbands and a vehicle placard are issued; the site is assigned if the
+booking was class-only.
+
+**14:00 — Seasonal row.** Sites 40-58 are seasonal: occupied from April to October by the same
+guests, with **sub-metered electric** read monthly and billed separately from the site fee.
+These episodes run for **months**, not nights.
+
+**15:00 — Extension request.** The guest on site 31 wants two more nights. Site 31 is booked
+from tomorrow, so the answer is "yes, but you move to 33" — or no.
+
+**16:00 — Maintenance.** A power pedestal on the B loop has failed. Three sites are unusable
+until it is fixed; two of them have guests arriving tonight who must be relocated.
+
+**17:00 — Camp store.** Firewood, ice, propane. Retail alongside lodging, taxed differently.
+
+**20:00 — Quiet hours round.** The host drives the loops: compliance checks, noise, unregistered
+vehicles, dogs off leash, campfires during a burn ban.
+
+## 2. The bad day
+
+**Evacuation.** A flash-flood warning or an approaching wildfire. The park must know **who is on
+site right now**, on which site, with what contact number, and who has already left — within
+minutes. This is a query over open episodes, and it is life-safety.
+
+**A fire ban imposed mid-stay.** The county raises the fire-danger level at noon. Campfires
+become illegal immediately, the camp store must stop selling firewood, and every guest on site
+must be told. **The rule changed while occupancy was in flight, and it came from outside.**
+
+**Overbooking or a double-assigned site**, usually created by an after-hours arrival or a
+turnover that did not complete.
+
+**A rig that does not fit**, arriving at 21:00 having booked online without a length check.
+
+## 3. The periodic cycle
+
+- **Season opening and closing** — winterisation is a real operational cycle: blow out water
+  lines, close bathhouses, shut seasonal utilities, and reverse it in spring.
+- **Monthly** — sub-meter reads and billing for seasonal sites; occupancy statistics; **transient
+  lodging / occupancy tax** remitted to the municipality, at a different rate from retail sales
+  tax.
+- **Seasonal** — rate cards by period (peak, shoulder, off, holiday premiums).
+- **Annual/periodic** — potable water testing, septic and pool/spa inspection, health-department
+  visits, licence renewal.
+
+## 4. Load-bearing obligations
+
+| Obligation | Why |
+|---|---|
+| **Guest registration** | Legally required in several jurisdictions, as for hotels. |
+| **Evacuation roster** | Life-safety. Must answer "who is on site now" instantly. |
+| **Fire ban compliance** | Externally imposed, dynamic, and enforced. |
+| **Length-of-stay limits** | Statutory on public land (commonly 14 days, then a required absence). |
+| **Potable water testing / septic / pool inspection** | Health-department mandated. |
+| **Occupancy / lodging tax** | Remitted to the municipality; distinct from sales tax. |
+| **Food-storage rules** | Legally enforced in bear country. |
+
+## 5. Probe result — classification
+
+Using the doctrine's five-step procedure. **Confirmations dominate, as predicted for a
+confirmation probe.**
+
+### Confirmed — no new canonical element
+
+| Difference | Classification | Resolution |
+|---|---|---|
+| site / pad / loop / slip naming | pattern 1 — vocabulary | `Resource.kindSlug` |
+| site fees, extra vehicle, pet fee | vertical pricing | existing |
+| stay = occupancy episode | canonical element 8 | same shape as `HospitalityServiceTurn` |
+| reservation, walk-in, waitlist, hold | pattern 3 — demand vocabulary | `ResourceCapacityAllocation.demandSlug` |
+| host rounds, bathhouse cleaning, quiet-hours patrol | same round shape as kennel rounds | second sighting of "round" |
+| campground map with numbered sites | existing | `OperationalSceneLayout`, `spaceKind: cartesian-interior`; **flat — does not stress tier**, as predicted |
+| site turnover before re-sale | episode stage + gate | canonical lifecycle grammar (`ready` / `on-track` / `blocked`) |
+| **class booking vs specific-site booking** | **existing** | `ResourceCapacityPool` versus a specific `Resource` — the pool model already distinguishes these. **A predicted-new item that turned out to be already solved.** |
+| evacuation roster | existing | a query over open episodes; needs no new model |
+| camp store retail | existing | storefront retail |
+| guest / rig profile, repeat preference | canonical element 7 — subject | same keystone as animals |
+
+### Promoted by the counting rule
+
+**Resource-to-capability map — third independent sighting, promotes.**
+
+- beauty — `BeautyResourceService` (built)
+- pet-rescue — kennel suitability (large dog, isolation-capable)
+- **campground — hookup amperage, water, sewer, pull-through vs back-in**
+
+Three unrelated verticals. Promotes to canonical without further discussion, exactly as the
+doctrine's worked example predicted.
+
+### Genuinely new candidates
+
+Only two, which is the expected yield for a confirmation probe and is evidence the nine-element
+set is well cut.
+
+**A. Dimensional fit — capacity is not the constraint**
+
+`Resource.capacity: Int` counts. It cannot express *"a 38-foot rig plus tow vehicle fits a
+40-foot back-in pad with a tight loop-head turn."* An empty site can still be the wrong site.
+
+This is **constraint matching against resource attributes**, not counting, and it is the same
+shape as:
+
+- which kennel can hold a large dog, or is isolation-capable
+- which warehouse rack is refrigerated, or rated for the pallet weight
+- which treatment room has the required equipment
+
+Recommendation: treat as an **extension of the promoted capability map** rather than a separate
+element — the capability map answers "can this resource do/hold X", and dimensional fit is that
+question with a numeric comparison instead of a set membership. Deciding these together avoids
+two mechanisms for one question.
+
+**B. Externally-driven, dynamic jurisdictional rules — second sighting of jurisdiction**
+
+Pet-rescue needs jurisdiction for **static** rules: stray-hold length, mandatory spay/neuter,
+quarantine duration. Set at onboarding, changing rarely.
+
+Campground needs the same *plus* a **dynamic** one: a county fire-danger level that changes
+mid-occupancy and immediately restricts what guests may do and what the store may sell.
+
+That is a genuine delta — a rule source that is **external, time-varying, and must reach
+in-flight episodes**. Static jurisdiction is a configuration lookup; dynamic jurisdiction is a
+subscription with an effect on live state.
+
+**Sighting count for jurisdiction is now 2.** Under the doctrine, jurisdiction rules are
+load-bearing (unlawful to get wrong), and load-bearing promotes at 2. **Jurisdiction promotes.**
+Whether the *dynamic* variant is part of that element or a later extension should be decided when
+a third archetype needs it — transport (hours-of-service), healthcare (licensure) and public
+sector are all likely.
+
+### Confirmed stress test — long episodes
+
+Predicted and worth recording as checked. A seasonal site runs **April to October**; a restaurant
+turn runs ninety minutes. `HospitalityServiceTurn` carries `startedAt` / `expectedEndAt` /
+`closedAt`, which is span-agnostic in shape, and `ResourceCapacityAllocation` indexes on
+`([resourceId, organizationId, startsAt])` and `([startsAt, endsAt])` for conflict-window scans.
+
+**No structural short-span assumption was found in the model.** The risk is in
+*conflict-window queries*, where a six-month allocation overlaps almost every scan window — a
+performance and query-shape concern, not a schema defect. It should be load-tested before
+seasonal sites ship, not redesigned.
+
+Sub-metered utilities billed against a long episode are **vertical** on current evidence (one
+sighting; marina slips would be a second).
+
+## 6. Doctrine verdict
+
+Campground behaved as a confirmation probe should:
+
+- **eleven confirmations**, several resolving to substrate that already exists
+- **one promotion** by the counting rule, decided arithmetically rather than by debate
+- **two new candidates**, one of which folds into the promotion rather than standing alone
+- **one predicted-new item (class-vs-specific booking) that was already solved** by
+  `ResourceCapacityPool` — a good sign, and a reminder to check before proposing
+- the predicted stress test found a **query-shape** risk rather than a modelling defect
+
+The doctrine's falsification condition was *"if a confirmation probe surfaces many new canonical
+elements, the nine-element set is mis-cut."* It surfaced one-and-a-half. **The set holds.**
+
+## 7. What campground still needs before it could run
+
+Not yet scored — the archetype does not exist in the product (`grep -rli campground` returns
+nothing across `docs/`, `packages/`, `apps/`). Recorded so the eventual build is measured, not
+assumed:
+
+1. Subject identity for a guest party with a **rig profile** (element 7).
+2. Occupancy episode with a **long span** (element 8).
+3. Capability map with **dimensional fit** (promoted).
+4. Jurisdiction rules including a **dynamic** source (promoted).
+5. Turnover as a gate between episodes on the same resource — the site is not sellable until
+   turnover reaches an exit-ready state.
+6. Sub-metering and lodging tax — vertical until a second sighting.
+
+## 8. Cross-archetype notes
+
+- **"Round" is now at two sightings** (kennel care rounds, host/bathhouse rounds). A third —
+  facilities maintenance, ward rounds, or store opening checks — promotes it. Worth watching; it
+  is likely the highest-volume operator surface in several archetypes.
+- **Turnover-blocks-reuse** generalises: a hotel room, a treatment room between patients, a
+  kennel after an infectious occupant. Currently expressible as a lifecycle stage gate.
+- **Flat versus stacked layout** — campground is flat, so `layoutState` tier remains at one
+  sighting (pet-rescue). Warehousing racking would be the second. Until then, **register the key
+  rather than promoting it**, per the escape-hatch discipline.

--- a/docs/architecture/archetypes/pet-rescue-operating-model.md
+++ b/docs/architecture/archetypes/pet-rescue-operating-model.md
@@ -1,0 +1,299 @@
+# Standing requirements: `pet-rescue` / `animal-shelter` archetype
+
+Status: **standing acceptance criteria**, not a wish list. An archetype is not "supported" until
+it can run the day below. Derived from domain research, not from what the platform happens to
+do — per the audit method, the operating day is written before consulting the product.
+
+Applies to `pet-rescue` and `animal-shelter` (`nonprofit-community`), and largely to
+`veterinary-clinic`, `pet-boarding`, `mobile-vet` and the ranching archetypes, which share the
+animal-as-subject spine.
+
+---
+
+## 1. The operating day
+
+**06:30 — Rounds.** A kennel tech walks the dog ward with a tablet. Per animal: fed yes/no,
+water, stool quality, meds given and signed, visible condition, enrichment. Roughly 40 animals
+in 45 minutes. Then the cat ward, where cages are **stacked three high**, so "where is this
+animal" is a room, a row, a column and a *tier*.
+
+**07:30 — Isolation last, deliberately.** The parvo suspect in iso is done after everything
+else so the tech does not carry infection back down the ward. Order of operations is a
+biosecurity control, not a preference.
+
+**08:00 — Intake.** A member of the public arrives with a stray found on Route 9. Staff:
+scan for a microchip, photograph the animal, weigh it, record found-location and finder details,
+assign a temporary ID, start the **stray hold clock**, and place it in an intake kennel — not
+the general ward, because it is unvaccinated and unassessed. The hold clock is legally binding:
+this animal cannot be adopted, transferred or euthanised until the hold expires.
+
+**09:00 — Owner surrender appointment.** Different pathway entirely. Requires a surrender form
+transferring ownership, a reason code, and the owner's disclosure of bite history. No hold
+applies — the shelter owns the animal immediately.
+
+**09:30 — Medical.** Intake exams on yesterday's arrivals: vaccines (with due dates for
+boosters), deworming, flea treatment, and a spay/neuter slot booked. A dog with a bite history
+goes into **10-day bite quarantine**, which is a health-department obligation, not a shelter
+choice.
+
+**11:00 — Adoption floor.** Two scheduled meet-and-greets and a walk-in family. The walk-in
+falls for a dog still inside its stray hold — so the answer is "you can place a hold, not adopt
+today", and the system must know why.
+
+**13:00 — Foster coordination.** A litter of bottle babies goes to a foster with neonatal
+experience. The foster home is a **housing location that happens to be off-site**, and it
+leaves with supplies: formula, bottles, a crate, a scale.
+
+**14:00 — A found-pet call.** Someone describes a lost dog. Staff search intake records by
+description, area and date, hoping to match. If matched, the outcome is **return-to-owner**,
+not adoption — a different outcome code with its own fee and paperwork.
+
+**15:00 — Vet transport.** Three animals to the partner clinic for surgery. Costs are tracked
+per animal.
+
+**16:30 — Capacity check.** Nineteen dogs, seventeen runs. Population pressure is the number
+that drives the hardest decisions.
+
+**17:00 — Evening rounds.** The morning again, and the day's outcomes recorded.
+
+## 2. The bad day
+
+**A parvo outbreak.** One dog tests positive. Every animal in that ward is now *exposed* and
+must be traced by contact and housing history. The ward is quarantined: no adoptions from it,
+no intake into it, deep clean, staff movement restricted. Any animal already adopted out from
+that ward in the incubation window must be traced and the adopters called.
+
+This tests whether housing history is a **timeline** rather than a current-location field. If
+the system only stores "where is this animal now", contact tracing is impossible.
+
+**A hoarding seizure.** Animal control arrives with forty cats from a cruelty case. All are
+legal **evidence** — they cannot be adopted while the case is open, regardless of health or
+space. They arrive at once, exceeding capacity, requiring emergency foster placement and
+possibly a temporary annex. Each needs individual documentation to evidentiary standard.
+
+**Capacity crisis.** When intake exceeds outcomes for long enough, a shelter faces
+euthanasia-for-space decisions. This is a real, legally and ethically governed process and the
+platform must handle it rather than look away — see §4.
+
+## 3. The periodic cycle
+
+- **Monthly** — statistics: intakes by pathway, outcomes by type, average length of stay, and
+  **live release rate**, the sector's headline KPI. Many shelters report to a national dataset
+  on a standardised schema; municipal contracts usually mandate it.
+- **Monthly** — controlled-substance reconciliation. Euthanasia solution is a controlled drug
+  with a legally required log that must balance.
+- **Quarterly/annual** — facility licensing and inspection; rabies vaccination reporting to the
+  county; vaccine lot and expiry audits (cold chain); grant reporting against restricted funds.
+- **Seasonal** — kitten season. Intake can triple. Capacity planning is annual, not ad hoc.
+
+## 4. Load-bearing obligations
+
+The audit's completeness prompt: *what, if it stopped for a week, would harm an animal or break
+the law?* These are the ones that must not be optional.
+
+| Obligation | Why it is load-bearing |
+|---|---|
+| **Stray hold period** | Statutory. Adopting or euthanising inside it is unlawful and destroys an owner's property rights. Duration varies by jurisdiction and by whether the animal has ID. |
+| **Bite quarantine** | Public-health mandated, typically 10 days, reportable to the health department. |
+| **Rabies vaccination + certificate** | Legally required; certificate is a controlled document, often county-reportable. |
+| **Spay/neuter before adoption** | Statutory in many jurisdictions; where deferred, a compliance obligation follows the adopter. |
+| **Medication administration** | Missed doses harm animals. Must be scheduled, timed and signed. |
+| **Isolation / biosecurity** | An outbreak can kill an entire ward. |
+| **Controlled substance log** | Euthanasia solution must reconcile. Failure is a criminal matter. |
+| **Cruelty-case evidence chain** | Animals held as evidence cannot be rehomed; documentation must survive court. |
+| **Interstate transport health certificate** | A CVI is required to move animals across state lines. |
+| **Outcome statistics** | Usually contractual with the municipality and required for grants. |
+
+**Jurisdiction is a first-class input.** Hold length, quarantine rules, licensing, reporting and
+mandatory spay/neuter all vary by state and often by county. The rescue's location determines
+its obligations, so jurisdiction cannot be a label — it must drive rules.
+
+## 5. Required entities
+
+Grouped by dependency. Nothing below depends on anything beneath it.
+
+**Subject**
+1. **Animal** — an identity that exists independently of any public listing, from the moment of
+   first contact. Species, breed, sex, DOB estimate, colour/markings, microchip, ID tag, weight
+   series, status, jurisdiction. Must support litters (dam linkage) and community cats.
+2. **Animal photo set** — many photos over time, typed (intake, current, medical, marketing).
+   One `primaryPhotoAssetId` is a catalog field, not a record.
+3. **Identifier** — microchip number, registry, registration status, rabies tag, licence.
+
+**Arrival**
+4. **Field/stray report** — a report that precedes the animal: reporter, location, description,
+   photo, dispatch, outcome. A found-animal report may never become an intake.
+5. **Intake** — pathway (stray, surrender, transfer-in, born-in-care, seizure, return),
+   date/time, source, finder or surrenderer, condition, and the **hold clock**.
+6. **Lost-pet report and match** — searchable against intakes; produces return-to-owner.
+
+**Housing**
+7. **Housing unit** — kennel, run, cage, condo, stall, or a foster home. Capacity-bearing, with
+   species suitability, isolation capability, and **a position that includes tier** because cat
+   condos stack. Canonical analogue: `Resource` (`kindSlug`, `capacity`, `capacityUnit`).
+8. **Housing placement** — a *timeline*, not a current field. Contact tracing and length-of-stay
+   both need history.
+9. **Ward / zone / site** — grouping for biosecurity and rounds order. Foster network is a site.
+10. **Kennel layout** — a visual, editable map with an optional floor-plan underlay, supporting
+    stacked units. Canonical analogue: `OperationalSceneLayout` (`spaceKind: cartesian-interior`,
+    `layoutState`, `underlayRef`).
+
+**Care**
+11. **Care round** — a scheduled sweep producing a per-animal record: fed, watered, cleaned,
+    medicated, observed. Signed and timed. Must work one-handed on a tablet, and tolerate
+    losing signal in a concrete kennel block.
+12. **Medical record** — exams, diagnoses, weights, treatment plans.
+13. **Vaccination schedule** — protocol-driven, with due dates, boosters, lot numbers, expiry.
+14. **Medication course** — drug, dose, route, frequency, start/end, administration log.
+15. **Procedure** — spay/neuter, dental, surgery; partner practice, cost, outcome.
+16. **Behavioural assessment** — determines adoptability and handling level (the colour-coded
+    collar most shelters use), and restricts who may handle the animal.
+17. **Hold** — typed and clock-bearing: stray, bite quarantine, medical, evidence, adoption
+    reservation. Multiple holds may run at once. **A hold must be able to block an action.**
+18. **Euthanasia record** — authorisation (who may decide), reason code (medical, behavioural,
+    capacity, owner-requested), method, controlled-substance draw linked to the log, witness,
+    body disposition, and reporting. Also **died-in-care**, which is a distinct outcome.
+
+**Placement**
+19. **Adopter / applicant** — application, screening (landlord, vet reference, home check),
+    approval state.
+20. **Meet-and-greet** — appointment *and* walk-in; scheduled against animal, adopter and staff.
+21. **Adoption** — contract, fee, spay/neuter compliance, microchip re-registration, follow-up,
+    return window.
+22. **Outcome** — the standardised set: adoption, return-to-owner, transfer-out, euthanasia,
+    died-in-care, lost-in-care, returned-to-field, disposal. **Statistics depend on this being a
+    controlled vocabulary, not free text.**
+23. **Foster placement** — foster home, skills/capacity, supplies issued, check-ins, return or
+    conversion to adoption.
+24. **Transfer** — partner in/out, transport run, health certificate.
+
+**Sustaining**
+25. **Supply stock** — food, litter, bedding, medication, vaccine (lot, expiry, cold chain),
+    controlled substances (reconciled).
+26. **Funding** — donations, animal sponsorship, **restricted funds and grants with reporting
+    obligations**, municipal contracts with per-animal reimbursement, adoption fees, in-kind.
+27. **Volunteer** — shifts, training level, background check, hours.
+28. **Event** — adoption events, offsite, vaccine and TNR clinics, fundraisers.
+29. **Jurisdiction rule set** — hold lengths, quarantine, licensing, reporting, mandatory
+    spay/neuter, driven by the rescue's location.
+30. **Compliance calendar and statutory reports** — licence renewals, inspections, rabies and
+    bite reporting, monthly statistics, controlled-substance reconciliation.
+
+## 6. What exists today — measured 2026-08-25
+
+The entire animal surface in the shipped product is `/storefront/animals`:
+
+> **Adoptable animals** — "These appear in the 'Animals available for adoption' section of your
+> public storefront, each with their photos."
+> Fields: **Name\*, Species, Breed, Age, Sex, Size, Description** -> *Add animal*
+
+`AdoptableAnimal` requires `storefrontId` and cascade-deletes with the storefront. Every consumer
+is a storefront surface — the public section, the storefront admin manager, the catalog API.
+There are no operational surfaces at all.
+
+Verified absent — searches over `packages/db/prisma/schema/*.prisma` returning zero:
+`StrayReport`/`FieldReport`/`IntakeRequest`, `Kennel`, `Euthan*`, `Vaccinat*`/`Immuniz*`,
+`Microchip`, `Foster`, `WalkIn`. Apparent hits for "tier" (`riskTier`, `hitlTier`) and
+"jurisdiction" (AI-coworker `us|eu|uk` practice scopes) and `legalHold` (a care-records flag)
+are **decoys** — none relate to animal welfare.
+
+**Score: 3 of 60 — coverage 0.05.** Of 30 required entities, one is partial (Animal, as a
+catalog row = 1), one is partial (photos, single primary asset = 1), one is vertical-bound but
+reachable in principle (housing via `Resource` = 1), and 27 are absent. This supersedes the
+0.28 recorded on 2026-08-22, which scored 18 nouns drawn from a thinner operating day; that
+figure was optimistic because the day it was scored against was incomplete.
+
+**Canonical analogues that already exist and are simply unreached:**
+
+| Need | Existing model | Note |
+|---|---|---|
+| Housing unit | `Resource` | `kindSlug` is an open vocabulary; `capacity` + `capacityUnit` already generic |
+| Kennel layout | `OperationalSceneLayout` | `spaceKind: cartesian-interior`, `layoutState`, `underlayRef` floor plan — already generic, not restaurant-welded |
+| Intake / staged admission | `CareIntakePacket` (+response, access-grant, exception, status-event) | **Already subject-agnostic.** Carries required `subjectKindSlug` + `subjectRef`; `patientProfileId` is nullable. |
+| Scheduled event against a subject | `CareAppointment` | **Already subject-agnostic**, same subject-reference contract. |
+| Scheduling | `ResourceAvailability`, `ResourceCapacityAllocation` | generic |
+| Photos | `MediaAsset` / `MediaAttachment` | already many-to-one capable |
+
+Ratified direction (BI-51C95802): **generalise `verticals-care`** into a subject-agnostic care
+substrate rather than cloning it or promoting the catalog row.
+
+## 7. UX requirements
+
+The operator's standing requirement: *to the point for the intended activity, minimal cognitive
+overload, no erroneous distractions for day-to-day workers.*
+
+**Measured 2026-08-25.** In `Full` mode a logged-in user sees a platform cockpit: Portfolio,
+Backlog, Architecture, Delivery, Build Studio, AI Workforce, Platform Hub, Admin, Knowledge,
+Coworker Decision Engine. A kennel tech doing morning rounds has no business seeing a build
+pipeline.
+
+**`Simple` mode works and deserves credit.** It cuts navigation from ~25 destinations to 9,
+removing every builder and platform surface:
+
+```
+Operations (here) · Customer · People · Finance · Compliance · Portal ·
+Knowledge · Coworker Decision Engine · All docs
+```
+
+**But it is generic-business, not rescue-operational.** Of those 9: "Customer" is wrong
+vocabulary — a shelter has adopters, surrenderers and finders, not customers; "Coworker Decision
+Engine" and "All docs" are platform concepts; and **there is no animal destination at all.** No
+Animals, no Rounds, no Intake, no Kennels. The only animal surface in the product sits under the
+storefront admin at Portal -> Animals, i.e. filed under *marketing*.
+
+So the correct finding is not "the UI is cluttered" — the density problem is already solved.
+It is that **simplification reveals there is nothing operational underneath.** A kennel tech
+given `Simple` mode still has no destination for the work they actually do.
+
+**Per-role surfaces required:**
+
+- **Kennel tech (rounds)** — the highest-volume surface in the building. One ward at a time, in
+  biosecurity order, one animal per card, large touch targets, glanceable meds-due flags,
+  single-tap completion, works one-handed on a tablet, tolerates loss of signal. Must show
+  nothing about donations, marketing or the storefront.
+- **Intake staff** — a single fast flow: scan chip, photograph, weigh, record found-location,
+  start hold. Under 90 seconds with an animal in one arm.
+- **Medical** — today's treatments, meds due, surgery schedule, overdue vaccines.
+- **Adoption counsellor** — applications queue, today's meet-and-greets and walk-ins, and a
+  clear reason when an animal is **not** adoptable today.
+- **Manager** — capacity and population pressure, live release rate, length of stay, compliance
+  deadlines.
+
+**Cross-cutting UX rules:**
+
+1. **A blocked action must state its reason.** "Not adoptable — stray hold until Thu 14:00" is
+   the requirement; a greyed-out button is a failure.
+2. **Location must be legible as a place**, including tier for stacked cages. "Cat Room B, row
+   3, column 2, tier 3" or a visual map — never an opaque id.
+3. **Kennel cards must print.** A physical sheet on the door is a real artifact of this business.
+4. **Species-appropriate vocabulary.** A ranch has head of cattle, a shelter has animals in care;
+   neither has "items".
+5. **Never present an animal as priced merchandise.** Adoption fees are fees, not prices. This
+   is both a dignity issue and a legal one.
+6. **Euthanasia surfaces must be plain, unavoidable and complete** — authorisation, reason,
+   controlled-substance link, disposition. This is the most sensitive workflow in the building
+   and it must not be euphemised, hidden, or left to a free-text note.
+7. **Read the whole page for cognitive load**, including nav. The existing UX-budget gate already
+   measures reading grade over the whole page including navigation.
+
+## 8. Definition of done
+
+The archetype may be described as supported when:
+
+1. An animal exists from first contact, independent of any public listing.
+2. All six intake pathways are representable, each with its correct hold behaviour.
+3. Housing is a capacity-bearing unit with a **position including tier**, a visual layout, and a
+   **placement history**.
+4. A care round can be completed on a tablet for a full ward, signed and timed.
+5. A hold can **block** an action and explain itself in the UI.
+6. Outcomes use the standardised controlled vocabulary and produce monthly statistics including
+   live release rate.
+7. Euthanasia is fully modelled including authorisation and controlled-substance reconciliation.
+8. Jurisdiction drives rules rather than labelling them.
+9. Restricted funds and municipal contracts are distinguishable from general donations.
+10. Each role's primary surface passes a cognitive-load review with no platform-builder
+    navigation present.
+11. Coverage score re-measured and recorded, with the date.
+
+An archetype below **0.6** must not be described as supported in external material.
+Current: **0.05**.

--- a/docs/architecture/canonical-minimal-substrate.md
+++ b/docs/architecture/canonical-minimal-substrate.md
@@ -1,0 +1,257 @@
+# The canonical minimal substrate
+
+**Objective:** the smallest set of subject-agnostic models that lets every archetype run its
+business, so verticals supply vocabulary and rules rather than cloning structure.
+
+Measured against the source tree on 2026-08-25 using three probes: `restaurant` (built, the
+worked example), `pet-rescue` (empty, the discovery probe) and `campground` (the confirmation
+probe — see [campground](archetypes/campground-operating-model.md)).
+
+Classification procedure and the promotion rule: [accommodation doctrine](accommodation-doctrine.md).
+
+---
+
+## Headline
+
+**The canonical substrate is roughly two-thirds built, and further along than the pet-rescue
+audit implied.** Six of nine elements are already canonical, already subject-agnostic, or already
+designed. The keystone — a canonical **subject identity** — is what the rest hang from.
+
+Two further elements (10 and 11) were promoted by the campground probe under the doctrine's
+counting rule. Both are **extensions of existing designs**, not new mechanisms.
+
+This is a **much smaller** job than "build 30 entities for animal welfare".
+
+## The elements
+
+| # | Element | State | Where |
+|---|---|---|---|
+| 1 | Capacity-bearing resource | **canonical** | `Resource` |
+| 2 | Resource availability | **canonical** | `ResourceAvailability` |
+| 3 | Capacity pool | **canonical** | `ResourceCapacityPool` |
+| 4 | Capacity allocation | **canonical** | `ResourceCapacityAllocation` |
+| 5 | Staged admission (intake) | **subject-agnostic** | `CareIntakePacket` + response / access-grant / exception / status-event |
+| 6 | Scheduled event against a subject | **subject-agnostic** | `CareAppointment` |
+| 7 | **Subject identity** | **missing** | each vertical owns its own; animals have none |
+| 8 | **Occupancy episode** | **clone-only** | `HospitalityServiceTurn` |
+| 9 | Episode stage/state + event ledger | **already designed** | [canonical lifecycle grammar](../superpowers/specs/2026-08-15-canonical-lifecycle-grammar-design.md) + `LifecycleEvent` |
+
+Adjacent and already generic: `OperationalSceneLayout` (spatial layout, `spaceKind:
+cartesian-interior`, `layoutState`, floor-plan `underlayRef`) and `MediaAsset` /
+`MediaAttachment`.
+
+Also clone-only and worth lifting eventually: `BeautyResourceService`, the resource-to-service
+capability map.
+
+## What is already done, and done well
+
+### The capacity substrate is genuinely canonical
+
+`Resource` carries an **open** `kindSlug` — the comment enumerates "chair, station,
+treatment_room, table, kitchen, ..." — plus `capacity`, `capacityUnit` (default `units`),
+`serviceArea`, `attributes`, `lifecycle`, and `sourceRef` for clone provenance. A kennel is this
+model with `kindSlug: kennel` and `capacityUnit: animals`. Nothing new is required.
+
+`ResourceCapacityAllocation` is the strongest piece of design in the area:
+
+- `demandSlug` — *"open demand vocabulary carried verbatim from the clones: booking, hold,
+  service-turn, ..."*
+- `demandRef` — polymorphic pointer to whatever created the demand
+- `state`, `idempotencyKey`, `releasedAt`, `releaseReason`
+- `startsAt` / `endsAt` / `quantity`, plus `lifecycle` triplet
+- `sourceRef` — *"clone-row provenance key, e.g. `HospitalityCapacityAllocation:<id>`"*
+
+It already anticipates `service-turn` as a demand slug, which is the hook element 8 needs.
+
+### Care is already subject-agnostic — this corrects an earlier finding
+
+Shipped in `20260822164000_subject_agnostic_scheduling_and_resources` and
+`20260822172800_subject_reference_guard_alignment`:
+
+- `CareAppointment` and `CareIntakePacket` both carry **required** `subjectKindSlug` and
+  `subjectRef`
+- `patientProfileId` became **nullable** on both
+- existing rows were backfilled as `subjectType = 'patient-profile'`
+- guards branch on `subjectType = 'patient-profile'` versus `<> 'patient-profile'`
+
+Two consequences worth stating plainly:
+
+1. **`verticals-care` is not "built for humans" any more.** An earlier version of the pet-rescue
+   requirements doc said so; that was wrong and has been corrected. Intake and scheduling are
+   already subject-neutral.
+2. **The extension point is designed in, not forbidden.** The constraints branch on subject kind
+   rather than rejecting non-patients, so onboarding a new subject kind is an intended path.
+
+The data-impact record cites `BI-2C80E6EA` and `DI-F289DBB51DCB` as provenance. That is the
+in-progress item asking generalise-vs-clone — so that question was already answered
+**generalise**, and partly executed. The ratified decision on `BI-51C95802` is consistent with
+work already shipped rather than a new direction.
+
+The remaining gate is explicit in the field policy:
+
+> "Patient subjects must equal `patientProfileId` by database check; future subject references
+> require **owning-vertical resolution** before write."
+> "no generic non-patient read or write policy is granted by this migration."
+
+So a new subject kind needs an owning vertical identity row and a governed policy — which is
+exactly element 7.
+
+## The remaining work
+
+### 7. Canonical subject identity — the keystone
+
+There is no canonical subject. `PatientProfile` is the care vertical's identity row;
+hospitality's subject is effectively the booking party; **animals have no identity row at all**,
+only `AdoptableAnimal`, a storefront catalog row requiring `storefrontId`.
+
+Everything else waits on this. `CareIntakePacket` and `CareAppointment` are ready to accept an
+animal subject the moment one exists and is registered as a subject kind with an owning vertical.
+
+Minimum shape: a durable identity per subject kind, existing independently of any listing, with
+the identifiers and lifecycle its domain requires. Tracked as **BI-4F8A484C**; direction ratified
+in **BI-51C95802**.
+
+### 8. Occupancy episode — lift `HospitalityServiceTurn`
+
+`HospitalityServiceTurn` is not a restaurant concept. It is *"a subject occupies capacity for a
+period, in a stage"*:
+
+```
+turnId · bookingId? · staffingAssignmentId?
+demandType + demandRef          <- polymorphic subject/demand attachment
+stage (default "seated")
+startedAt · expectedEndAt · closedAt
+allocations[] · events[]
+```
+
+The same model is:
+
+| Archetype | Episode | Stages |
+|---|---|---|
+| restaurant | party at a table | seated -> ordered -> served -> paid -> closed |
+| pet-rescue | **animal in a kennel** | intake -> available -> hold -> outcome |
+| pet-boarding | boarding stay | checked-in -> in-care -> checked-out |
+| self-storage | unit rental | active -> overlocked -> released |
+| healthcare | admission | admitted -> in-treatment -> discharged |
+| 3PL / warehousing | stock in a location | received -> put-away -> picked |
+
+Rename `stage` semantics per vertical, keep the structure. Nothing here is hospitality-specific
+except the default value of one string.
+
+### 9. Episode stage/state and event ledger — **already designed; do not re-invent**
+
+An earlier draft of this document proposed lifting `HospitalityServiceTurnEvent` as a new
+canonical element. That was wrong, and it is recorded here because the correction is the point.
+
+The [canonical lifecycle grammar](../superpowers/specs/2026-08-15-canonical-lifecycle-grammar-design.md)
+already defines **Stages + in-stage States + gated Advancement**, with health bands
+(`ready` / `on-track` / `blocked`) and an extension of the existing `LifecycleEvent` ledger to
+carry the state axis. It is explicitly *"a shape, not a new table of instances"*, with a
+per-entity resolver.
+
+So the occupancy episode (element 8) supplies **the entity**; the grammar supplies **its stage,
+state, gate and event history**. Element 8 must declare a grammar and wire a resolver — it must
+not invent a parallel stage enum or a second event table.
+
+The requirement that motivated this still stands and is worth keeping visible:
+
+> A parvo outbreak requires tracing every animal that shared a ward with the index case,
+> **including animals already adopted out** inside the incubation window.
+
+With only "where is it now", contact tracing is impossible. The same argument is a restaurant's
+table-turn history, a warehouse's chain of custody, and a hospital's ward-exposure trace. The
+grammar's event ledger is where that history lives.
+
+### 10. Concurrent, time-bound holds — a genuine gap, and an *extension* of the grammar
+
+The grammar gates advancement on **in-stage state**: a transition is legal when the current state
+is exit-ready and the target is reachable. That is one `(stage, state)` point per entity.
+
+A shelter hold is not a state. An animal can simultaneously be under:
+
+- a **stray hold** until Thursday 14:00 (statutory)
+- a **bite quarantine** until next Tuesday (health department)
+- an **adoption reservation** until 17:00 today (commercial)
+
+Three concurrent constraints, each with its own clock, source, authority and expiry, each
+independently capable of blocking a different set of transitions. A single state field cannot
+express this, and collapsing them to `blocked` destroys the reason — which the UX requires:
+*"Not adoptable — stray hold until Thu 14:00"* is the requirement; a greyed-out button is a
+failure.
+
+Campground supplies a second sighting in a different shape: minimum-stay rules and statutory
+length-of-stay limits block transitions for reasons external to the entity's own state.
+
+**Classification:** load-bearing (getting it wrong is unlawful), so it promotes at two sightings
+under the doctrine. **Design it as an extension to the grammar's advancement gate** — a gate that
+consults active holds in addition to in-stage state — not as a parallel mechanism. Two ways to
+block a transition is the failure mode to avoid.
+
+### 11. Jurisdiction as a rule source — promoted at two sightings
+
+Pet-rescue needs **static** jurisdiction: stray-hold length, mandatory spay/neuter, quarantine
+duration — set once, changing rarely.
+
+Campground needs the same **plus dynamic**: a county fire-danger level that changes mid-occupancy
+and immediately restricts what guests may do and what the camp store may sell.
+
+Both are load-bearing, so jurisdiction promotes at two sightings. Whether the *dynamic* variant
+belongs in the same element or arrives as a later extension should be decided by the third
+archetype that needs it — transport (hours-of-service), healthcare (licensure) and public sector
+are all likely candidates.
+
+### Also: resource-to-service capability map
+
+`BeautyResourceService` answers "which services can this resource perform". Generalises to
+"which kennels can hold a large dog", "which rooms are isolation-capable", "which racks are
+refrigerated". Lower priority than 7-9 but the same lift.
+
+## What pet-rescue proved that restaurant could not
+
+Restaurant is a good worked example but it does not exercise everything. Three requirements only
+appear once a second, unlike archetype is tried:
+
+1. **Position needs a tier.** Cat condos stack two or three high, so location is room + row +
+   column + **tier**. A restaurant floor is flat, so the layout model was never pushed on this.
+   Warehouse racking and self-storage will push the same way. `OperationalSceneLayout.layoutState`
+   is opaque JSON so it *can* express tier, but nothing defines it — decide the contract before
+   two verticals invent different ones.
+2. **A hold must block an action and explain itself.** A restaurant hold is a convenience; a
+   shelter's stray hold is statutory, and adopting inside it is unlawful. Holds must be typed,
+   clock-bearing, simultaneous, and capable of **preventing** a transition with a reason
+   renderable in the UI. Restaurant's `BookingHold` does not carry this weight.
+3. **Jurisdiction must drive rules, not label them.** Hold length, quarantine, licensing and
+   mandatory spay/neuter vary by state and county. Restaurant never needed this. Any archetype
+   with statutory obligations does — healthcare, banking, public sector, transport.
+
+Requirements 2 and 3 are **not** in the canonical nine. They are candidates for a tenth and
+eleventh element, and the decision of whether they are canonical or vertical belongs with the
+next archetype that needs them, not with pet-rescue alone.
+
+## Sequencing
+
+Dependency order, not priority order:
+
+1. **Canonical subject identity** (element 7) — unblocks intake and scheduling for every
+   non-patient vertical. Nothing else should start first.
+2. **Occupancy episode** (element 8) — lift `HospitalityServiceTurn` using the `sourceRef`
+   clone-backfill pattern the resource canonicalisation already proved, declaring a lifecycle
+   grammar rather than a new stage enum.
+3. **Animal subject** as the first non-patient subject kind — the real test of whether element 7
+   generalised, because it must satisfy an owning-vertical policy.
+4. **Capability map** (promoted at three sightings) including dimensional fit — beauty already
+   has `BeautyResourceService` to lift from.
+5. **Holds as a grammar gate extension** (element 10) and **jurisdiction rules** (element 11),
+   both promoted at two sightings as load-bearing.
+6. Re-score all three probes. Restaurant must not regress; pet-rescue should move off 0.05;
+   campground gets its first score.
+
+## Method note for the next archetype
+
+Use two probes, never one. Restaurant alone made the capacity substrate look complete, because a
+flat floor plan and a convenience hold never stress the model. Pet-rescue exposed tier,
+blocking holds, jurisdiction and the episode timeline within a single day's analysis.
+
+**Pick the second probe to be structurally unlike the first**, then treat anything only the
+second probe needs as a candidate canonical element rather than a vertical special case. That is
+how the minimal set stays minimal without becoming insufficient.


### PR DESCRIPTION
Records the cross-archetype substrate work so specifications can cite it instead of re-deriving the domain. Epic: EP-A47377D1.

Docs only — no code, schema or behaviour change.

## What this adds

| Document | Purpose |
|---|---|
| `docs/architecture/canonical-minimal-substrate.md` | The element set measured against source, what is already built, dependency-ordered sequencing |
| `docs/architecture/accommodation-doctrine.md` | Five-step classification procedure and the sightings-based promotion rule |
| `docs/architecture/archetypes/pet-rescue-operating-model.md` | Discovery probe — operating day, 30 entities, statutory obligations, per-role UX, definition of done |
| `docs/architecture/archetypes/campground-operating-model.md` | Confirmation probe, written before classification per the audit method |

`archetype-operating-model-audit.md` gains cross-links to all four, so the audit surfaces gaps and the doctrine decides where they belong.

## Why

The pet-rescue archetype completed onboarding 11/11 and passed a UX review at **0.05** operating-model coverage. The audit method's own anti-trap fired — the operating day had been written from the platform rather than the domain, so it scored the nouns the product made visible (18) rather than the domain's (30).

The doctrine exists so that being wrong about canonical-vs-vertical is cheap. It names five accommodation patterns **already present in the codebase** and never written down: open kind vocabulary (`Resource.kindSlug`), polymorphic subject (`subjectKindSlug`/`subjectRef`), polymorphic demand (`demandSlug`/`demandRef`), clone-to-canonical backfill (`sourceRef`), and the typed escape hatch. Patterns 1-3 accommodate variation with no schema change.

## Corrections recorded in the docs

Two earlier conclusions were wrong and are corrected in place, because the corrections are the point:

- **`verticals-care` is already subject-agnostic.** `CareAppointment` and `CareIntakePacket` carry required `subjectKindSlug`/`subjectRef` since `20260822164000_subject_agnostic_scheduling_and_resources`, with `patientProfileId` nullable and guards branching on subject kind. An earlier draft said it was "built for humans and needs generalising".
- **The episode event ledger is already designed.** The canonical lifecycle grammar plus `LifecycleEvent` covers stages, in-stage states, gated advancement and the event history. An earlier draft proposed lifting `HospitalityServiceTurnEvent` as a new element. Element 8 declares a grammar rather than inventing a stage enum.

## Probe result

Campground ran as a **confirmation probe** and behaved as one should: eleven confirmations, one promotion decided arithmetically (resource-to-capability map, third independent sighting), two new candidates of which one folds into that promotion, and one predicted-new item (class-vs-specific-site booking) that turned out already solved by `ResourceCapacityPool`.

The doctrine's falsification condition was "if a confirmation probe surfaces many new canonical elements, the set is mis-cut." It surfaced one and a half. The set holds.

## Verification

Docs-tier gate per AGENTS.md §4:

- `node scripts/check-doc-links.mjs` — PASS, no error-level findings, 83 pages against 687 indexed
- `node scripts/gen-doc-index.mjs --check` — doc index fresh (687 pages)
- `BASE_SHA=origin/main node scripts/check-docs-impact.mjs` — OK
- prose-lint is out of scope: `SCAN_DIRS` is `apps/web/{app,components,lib}`, not `docs/`

Doc index regenerated and staged by the pre-commit hook. Gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)