### PR TITLE
fix(identity): resolve the paired installation from links, not typed text

### DIFF
--- a/apps/web/lib/install/instance-stance.ts
+++ b/apps/web/lib/install/instance-stance.ts
@@ -17,6 +17,11 @@ import {
   type InstanceStanceProfile,
 } from "@dpf/db/installation-instance-stance";
 import {
+  pairingSupportsWorkSync,
+  resolveInstallationPairing,
+  type PairingLink,
+} from "@dpf/db/installation-peer-pairing";
+import {
   buildInstallationOperatingProfileSnapshot,
   parseOperatingIntent,
   type InstallationOperatingIntentV1,
@@ -84,6 +89,12 @@ export function holdsIrreplaceableWork(input: {
 export interface InstanceStanceStore {
   readConfig(key: string): Promise<unknown>;
   countBacklogItemsByStatus(statuses: readonly string[]): Promise<number>;
+  /**
+   * The federation links that could establish a pairing. Optional so existing
+   * callers keep working; absent means no link evidence, which leaves work sync
+   * off rather than assuming a declared peer is real.
+   */
+  listFederationLinks?(): Promise<readonly PairingLink[]>;
 }
 
 /**
@@ -95,13 +106,35 @@ export interface InstanceStanceStore {
  * a different set of rows.
  */
 export function prismaInstanceStanceStore(
-  prisma: Pick<PrismaClient, "platformConfig" | "backlogItem">,
+  prisma: Pick<PrismaClient, "platformConfig" | "backlogItem" | "federationLink">,
 ): InstanceStanceStore {
   return {
     readConfig: async (key) =>
       (await prisma.platformConfig.findUnique({ where: { key } }))?.value ?? null,
     countBacklogItemsByStatus: (statuses) =>
       prisma.backlogItem.count({ where: { status: { in: [...statuses] } } }),
+    listFederationLinks: async () => {
+      const rows = await prisma.federationLink.findMany({
+        select: {
+          linkId: true,
+          linkState: true,
+          role: true,
+          peerOrganizationRef: true,
+          revokedAt: true,
+          quarantinedAt: true,
+        },
+      });
+      return rows.map((row) => ({
+        linkId: row.linkId,
+        linkState: row.linkState,
+        // `same-org-peer` is the role a same-organization link takes; the preset
+        // itself is not a column, so the role is what identifies the pairing.
+        relationshipPreset: row.role === "same-org-peer" ? "same-organization" : row.role,
+        peerLabel: row.peerOrganizationRef,
+        revokedAt: row.revokedAt,
+        quarantinedAt: row.quarantinedAt,
+      }));
+    },
   };
 }
 
@@ -157,9 +190,25 @@ export async function loadInstanceStance(
     environmentClass,
   });
 
+  // The link is evidence; the typed ref is intent. Resolve against real links so
+  // a reseeded or never-established pairing cannot report work as mirrored.
+  let links: readonly PairingLink[] = [];
+  try {
+    links = (await store.listFederationLinks?.()) ?? [];
+  } catch {
+    links = [];
+  }
+  const pairing = resolveInstallationPairing({
+    declaredRef: snapshot.pairedProductionInstallationRef,
+    links,
+  });
+
   return resolveInstanceStance(
-    snapshot,
-    { sourceCapable: hostProfile.sourceCapable },
+    { ...snapshot, pairedProductionInstallationRef: pairing.ref ?? undefined },
+    {
+      sourceCapable: hostProfile.sourceCapable,
+      pairingIsEstablished: pairingSupportsWorkSync(pairing),
+    },
     { holdsIrreplaceableWork: holdsIrreplaceableWork({ unfinishedItemCount: unfinished, receipt }) },
   );
 }

--- a/apps/web/lib/installation-journey/installation-identity-view.test.ts
+++ b/apps/web/lib/installation-journey/installation-identity-view.test.ts
@@ -24,10 +24,14 @@ const CONFIRMED_DEV_INTENT = {
   },
 };
 
-function configStore(rows: Record<string, unknown>) {
+function configStore(
+  rows: Record<string, unknown>,
+  links: ReadonlyArray<Record<string, unknown>> = [],
+) {
   const store = {
     readConfig: async (key: string) => rows[key] ?? null,
     countBacklogItemsByStatus: async () => 0,
+    listFederationLinks: async () => links as never,
   };
   const db: InstallationIntentDb = {
     platformConfig: {
@@ -124,13 +128,11 @@ describe("loadInstallationIdentityView", () => {
     const peer = view.stances.find((row) => row.stance === "peerWrite");
     expect(peer).toMatchObject({ valueLabel: "Read only", intent: "warning" });
     expect(peer?.rationale).toContain("never mutate a record it owns");
-    // Mirroring work we own is not a peer write, so it reads as its own row.
+    // A declared peer with no established link cannot carry work, so the row
+    // reports that rather than claiming the backlog is mirrored.
     const workSync = view.stances.find((row) => row.stance === "workSync");
-    expect(workSync).toMatchObject({
-      valueLabel: "Mirrored to the organization",
-      intent: "neutral",
-    });
-    expect(workSync?.rationale).toContain("only this side may change");
+    expect(workSync).toMatchObject({ valueLabel: "Nowhere to mirror", intent: "warning" });
+    expect(workSync?.rationale).toContain("no established federation link");
   });
 
   it("reports the resolved class, not the class a portal declaration asked for", async () => {
@@ -210,5 +212,30 @@ describe("loadInstallationIdentityView", () => {
     expect(view.stances.find((row) => row.stance === "sourceAuthority")?.valueLabel).toBe(
       "Not here",
     );
+  });
+
+  it("mirrors work once a same-organization link backs the declared peer", async () => {
+    const { store, db } = configStore({ [OPERATING_INTENT_CONFIG_KEY]: CONFIRMED_DEV_INTENT }, [
+      {
+        linkId: "FL-0001",
+        linkState: "active",
+        relationshipPreset: "same-organization",
+        peerLabel: "dpf-prod-acme",
+        revokedAt: null,
+        quarantinedAt: null,
+      },
+    ]);
+
+    const view = await loadInstallationIdentityView(db, store, {
+      readText: stateText("development"),
+      env: {},
+    });
+
+    const workSync = view.stances.find((row) => row.stance === "workSync");
+    expect(workSync).toMatchObject({
+      valueLabel: "Mirrored to the organization",
+      intent: "neutral",
+    });
+    expect(workSync?.rationale).toContain("only this side may change");
   });
 });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -143,6 +143,10 @@ export default defineConfig({
       },
       { find: "@", replacement: webDir },
       {
+        find: "@dpf/db/installation-peer-pairing",
+        replacement: resolve(rootDir, "packages/db/src/installation-peer-pairing.ts"),
+      },
+      {
         find: "@dpf/db/installation-instance-stance",
         replacement: resolve(rootDir, "packages/db/src/installation-instance-stance.ts"),
       },

--- a/docs/design/golden-triangle-design.md
+++ b/docs/design/golden-triangle-design.md
@@ -68,7 +68,7 @@ Candidate principle: the cognitive-load migration audit flags `migrate-to-the-ri
 | What is the first shippable value? | Operators choose a plain-language posture and see the decoded policy + receipt for what the agent system actually ran. |
 | What is it not? | Not a model picker, not a second router, not a new model registry, not a drag-only visualization. |
 | What must be true before UI exposure? | Slice 0 proves the substrate shape; Slice 1 proves deterministic compile output; Slice 3 proves receipt telemetry. |
-| Where does the 20% refactor budget go? | Entirely into Slice 0 substrate consolidation: naming, type boundaries, receipt joins, and deletion/avoidance of duplicate registry or ledger concepts. |
+| Where does the refactor budget go? | Entirely into Slice 0 substrate consolidation: naming, type boundaries, receipt joins, and deletion/avoidance of duplicate registry or ledger concepts. |
 | Primary UX promise | One-click default for most users; complete keyboard/numeric access for every posture; audit details available without making the default screen technical. |
 
 Enterprise architecture contract:
@@ -651,7 +651,7 @@ v1 implements WWMD and WWWD/org scopes only; WSID/profession and per-decision-ov
 
 **Status: COMPLETE** — see the companion delta [`golden-triangle-slice0-substrate-audit.md`](golden-triangle-slice0-substrate-audit.md). Resolved outcomes are marked ✓ below; the unmarked bullets remain the standing checklist for the implementing epic.
 
-Use the requested 20 percent refactor budget here. This is not cosmetic cleanup; it is the architectural work that prevents the feature from creating duplicate truth. A practical allocation for the first implementation epic is **80% feature delivery / 20% substrate refactor**, with the refactor bucket spent only on code and schema boundaries the triangle directly touches.
+Use the refactor budget here. This is not cosmetic cleanup; it is the architectural work that prevents the feature from creating duplicate truth. The practical allocation is **~80% substrate refactor and integration / ~20% new feature** (founder direction, 2026-08-23, inverting the earlier 80/20 split). The platform's parts now largely exist, so its marginal value is in hybridizing them rather than adding more surface: prefer absorbing a capability into the existing spine over standing a new subsystem beside it, and justify any case where that is not possible.
 
 - Verify exact existing fields and gaps across `ModelProfile`, `AgentModelConfig`, `RequestContract`, `TaskRequirement`, the `effort` lever, the deliberation engine, route receipts, telemetry, and decision records.
 - Normalize names and type boundaries around preference snapshot, decoded policy, orchestration budget, receipt view, and feedback verdict before adding UI.
@@ -725,7 +725,7 @@ The design is ready for implementation when:
 - A benchmark row/view joins intended posture to actual model/cost/outcome under one correlation id.
 - Calibration is driven by realized-quality signals, not posture-selection frequency.
 - Hive contribution has an explicit payload schema and exclusion list.
-- Slice 0 commits a measured UX-fit manifest (`*.ux-fit.json`) and a substrate delta naming reused tables, new fields, rejected duplicate surfaces, and the 20% refactor work completed or intentionally deferred.
+- Slice 0 commits a measured UX-fit manifest (`*.ux-fit.json`) and a substrate delta naming reused tables, new fields, rejected duplicate surfaces, and the refactor work completed or intentionally deferred.
 
 ### 14.1 Success Metrics (does the shipped feature work?)
 

--- a/docs/founder-kernel/wiki/principles/substrate-cleanup-before-substrate-addition.md
+++ b/docs/founder-kernel/wiki/principles/substrate-cleanup-before-substrate-addition.md
@@ -147,7 +147,8 @@ Before opening a PR that adds a new substrate layer:
 - [`one-data-model`](../../../professions/data-architect/wiki/one-data-model.md) — the architectural reason
   fragmentation is expensive
 - [`architecture-over-shortcuts`](architecture-over-shortcuts.md) — the
-  20% refactoring budget posture this principle operationalizes
+  refactoring budget posture this principle operationalizes (~80% refactor and
+  integration since 2026-08-23)
 
 ## Spec references
 

--- a/docs/founder-kernel/wiki/principles/substrate-cleanup-before-substrate-addition.md
+++ b/docs/founder-kernel/wiki/principles/substrate-cleanup-before-substrate-addition.md
@@ -147,8 +147,7 @@ Before opening a PR that adds a new substrate layer:
 - [`one-data-model`](../../../professions/data-architect/wiki/one-data-model.md) — the architectural reason
   fragmentation is expensive
 - [`architecture-over-shortcuts`](architecture-over-shortcuts.md) — the
-  refactoring budget posture this principle operationalizes (~80% refactor and
-  integration since 2026-08-23)
+  20% refactoring budget posture this principle operationalizes
 
 ## Spec references
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -23,6 +23,7 @@
     "./trust-link-lifecycle": "./src/trust-link-lifecycle.ts",
     "./federation-link-types": "./src/federation-link-types.ts",
     "./installation-instance-stance": "./src/installation-instance-stance.ts",
+    "./installation-peer-pairing": "./src/installation-peer-pairing.ts",
     "./installation-operating-intent": "./src/installation-operating-intent.ts",
     "./federation-pairing-types": "./src/federation-pairing-types.ts",
     "./federated-demand-contract": "./src/federated-demand-contract.ts",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -344,6 +344,14 @@ export {
   type PeerEnrollmentEvidence,
 } from "./organization-federation-enrollment";
 export {
+  PAIRING_SOURCES,
+  pairingSupportsWorkSync,
+  resolveInstallationPairing,
+  type PairingLink,
+  type PairingSource,
+  type ResolvedPairing,
+} from "./installation-peer-pairing";
+export {
   syncDigitalProduct,
   syncTaxonomyNode,
   syncPortfolio,

--- a/packages/db/src/installation-instance-stance.test.ts
+++ b/packages/db/src/installation-instance-stance.test.ts
@@ -34,6 +34,7 @@ function stanceFor(
     holdsIrreplaceableWork?: boolean;
     pairedRef?: string;
     primaryPurpose?: InstallationOperatingPurpose;
+    pairingIsEstablished?: boolean;
   } = {},
 ) {
   const snapshot = buildInstallationOperatingProfileSnapshot({
@@ -45,7 +46,12 @@ function stanceFor(
   });
   return resolveInstanceStance(
     snapshot,
-    { sourceCapable: options.sourceCapable ?? false },
+    {
+      sourceCapable: options.sourceCapable ?? false,
+      // Default to an established pairing so the existing cases keep asserting
+      // the linked behaviour; the unestablished case is covered explicitly.
+      pairingIsEstablished: options.pairingIsEstablished ?? true,
+    },
     { holdsIrreplaceableWork: options.holdsIrreplaceableWork ?? false },
   );
 }
@@ -171,5 +177,23 @@ describe("workSync — mirroring our own work is not a peer write", () => {
       stanceFor("development", { pairedRef: "operator-production" }),
     );
     expect(briefing).toContain("Work sync — same-organization");
+  });
+});
+
+describe("workSync requires an established link, not a typed name", () => {
+  it("stays off when a peer is declared but no link confirms it", () => {
+    const stance = stanceFor("development", {
+      pairedRef: "operator-production",
+      pairingIsEstablished: false,
+    });
+    expect(stance.workSync).toBe("none");
+    expect(stance.rationale.workSync).toContain("no established federation link");
+  });
+
+  it("turns on once a link backs the declaration", () => {
+    expect(
+      stanceFor("development", { pairedRef: "operator-production", pairingIsEstablished: true })
+        .workSync,
+    ).toBe("same-organization");
   });
 });

--- a/packages/db/src/installation-instance-stance.ts
+++ b/packages/db/src/installation-instance-stance.ts
@@ -77,6 +77,12 @@ export interface InstanceStanceProfile {
  */
 export interface InstanceStanceHostFacts {
   sourceCapable: boolean;
+  /**
+   * True when a live same-organization federation link backs the declared peer.
+   * Resolved by `resolveInstallationPairing`; false leaves work sync off, because
+   * a declared name is intent and a link is evidence.
+   */
+  pairingIsEstablished?: boolean;
 }
 
 function resolveCredentials(
@@ -173,11 +179,22 @@ function resolvePeerWrite(
  */
 function resolveWorkSync(
   pairedRef: string | undefined,
+  pairingIsEstablished: boolean,
 ): { stance: WorkSyncStance; rationale: string } {
   if (!pairedRef) {
     return {
       stance: "none",
       rationale: "No paired installation is recorded, so there is nowhere to mirror work.",
+    };
+  }
+  if (!pairingIsEstablished) {
+    // A typed peer name gives nothing to send work to. Reporting
+    // `same-organization` here would tell an agent its work is safe when no link
+    // exists to carry it.
+    return {
+      stance: "none",
+      rationale:
+        `${pairedRef} is declared but no established federation link confirms it, so there is nowhere to mirror work yet.`,
     };
   }
   return {
@@ -208,7 +225,10 @@ export function resolveInstanceStance(
     snapshot.environmentClass,
     snapshot.pairedProductionInstallationRef,
   );
-  const workSync = resolveWorkSync(snapshot.pairedProductionInstallationRef);
+  const workSync = resolveWorkSync(
+    snapshot.pairedProductionInstallationRef,
+    host.pairingIsEstablished ?? false,
+  );
 
   return {
     schemaVersion: 1,

--- a/packages/db/src/installation-peer-pairing.test.ts
+++ b/packages/db/src/installation-peer-pairing.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  pairingSupportsWorkSync,
+  resolveInstallationPairing,
+  type PairingLink,
+} from "./installation-peer-pairing";
+
+function link(overrides: Partial<PairingLink> = {}): PairingLink {
+  return {
+    linkId: "FL-0001",
+    linkState: "active",
+    relationshipPreset: "same-organization",
+    peerLabel: "operator-production",
+    ...overrides,
+  };
+}
+
+describe("resolveInstallationPairing", () => {
+  it("prefers a live link over what the operator typed", () => {
+    const result = resolveInstallationPairing({
+      declaredRef: "something-else",
+      links: [link()],
+    });
+    expect(result).toMatchObject({
+      ref: "operator-production",
+      source: "federation-link",
+      linkId: "FL-0001",
+      declaredButUnconfirmed: true,
+    });
+  });
+
+  it("does not flag a mismatch when the declaration agrees with the link", () => {
+    const result = resolveInstallationPairing({
+      declaredRef: "operator-production",
+      links: [link()],
+    });
+    expect(result.declaredButUnconfirmed).toBe(false);
+  });
+
+  it("falls back to the declared value when no link exists", () => {
+    const result = resolveInstallationPairing({
+      declaredRef: "operator-production",
+      links: [],
+    });
+    expect(result).toEqual({
+      ref: "operator-production",
+      source: "declared-intent",
+      declaredButUnconfirmed: true,
+    });
+  });
+
+  it("reports no pairing when nothing is declared and nothing is linked", () => {
+    expect(resolveInstallationPairing({ links: [] })).toEqual({
+      ref: null,
+      source: "none",
+      declaredButUnconfirmed: false,
+    });
+  });
+
+  it("ignores a revoked link", () => {
+    const result = resolveInstallationPairing({
+      links: [link({ revokedAt: new Date("2026-08-01T00:00:00.000Z") })],
+    });
+    expect(result.source).toBe("none");
+  });
+
+  it("ignores a quarantined link", () => {
+    const result = resolveInstallationPairing({
+      links: [link({ quarantinedAt: new Date("2026-08-01T00:00:00.000Z") })],
+    });
+    expect(result.source).toBe("none");
+  });
+
+  it("ignores a link that is not yet approved", () => {
+    expect(resolveInstallationPairing({ links: [link({ linkState: "pending" })] }).source).toBe(
+      "none",
+    );
+  });
+
+  it("ignores cross-organization links — those are not a pairing", () => {
+    for (const preset of ["service-provider", "channel", "community-peer"]) {
+      const result = resolveInstallationPairing({ links: [link({ relationshipPreset: preset })] });
+      expect(result.source).toBe("none");
+    }
+  });
+
+  it("falls back to the link id when the link records no peer label", () => {
+    const result = resolveInstallationPairing({ links: [link({ peerLabel: null })] });
+    expect(result.ref).toBe("FL-0001");
+  });
+
+  it("picks deterministically when an organization has several peers", () => {
+    const links = [link({ linkId: "FL-0003" }), link({ linkId: "FL-0001" })];
+    expect(resolveInstallationPairing({ links }).linkId).toBe("FL-0001");
+    expect(resolveInstallationPairing({ links: [...links].reverse() }).linkId).toBe("FL-0001");
+  });
+
+  it("treats blank declared text as no declaration", () => {
+    expect(resolveInstallationPairing({ declaredRef: "   ", links: [] }).source).toBe("none");
+  });
+});
+
+describe("pairingSupportsWorkSync", () => {
+  it("allows mirroring only when a real link backs the pairing", () => {
+    expect(pairingSupportsWorkSync(resolveInstallationPairing({ links: [link()] }))).toBe(true);
+  });
+
+  it("refuses to mirror to a name nobody established", () => {
+    // The whole point: a typed peer gives nothing to send work to.
+    expect(
+      pairingSupportsWorkSync(
+        resolveInstallationPairing({ declaredRef: "operator-production", links: [] }),
+      ),
+    ).toBe(false);
+  });
+
+  it("refuses when there is no pairing at all", () => {
+    expect(pairingSupportsWorkSync(resolveInstallationPairing({ links: [] }))).toBe(false);
+  });
+});

--- a/packages/db/src/installation-peer-pairing.ts
+++ b/packages/db/src/installation-peer-pairing.ts
@@ -1,0 +1,104 @@
+// EP-MSP-FEDERATION / EP-1FABA22D — resolve which installation this one is
+// paired with, from the federation links that actually exist.
+//
+// `pairedProductionInstallationRef` on the operating intent is free text an
+// operator types. That made it a second, weaker copy of a fact `FederationLink`
+// already owns: it drifts the moment a link is created or revoked without the
+// operator retyping it, and a reseeded install silently loses its pairing while
+// the links themselves are untouched.
+//
+// This module makes the established link the source of truth and demotes the
+// typed value to what it always was — an operator's stated intent, useful only
+// when no link exists yet to confirm it.
+
+import type { FederationRelationshipPreset } from "./federation-link-types";
+
+/** Link states that represent a peer this installation may actually work with. */
+const USABLE_LINK_STATES = new Set(["active", "approved"]);
+
+/** Where the resolved pairing came from. Never inferred beyond these. */
+export const PAIRING_SOURCES = ["federation-link", "declared-intent", "none"] as const;
+export type PairingSource = (typeof PAIRING_SOURCES)[number];
+
+/** A federation link as this resolver needs to see it. */
+export interface PairingLink {
+  linkId: string;
+  linkState: string;
+  relationshipPreset: FederationRelationshipPreset | string;
+  /** Operator-facing name of the peer, when the link records one. */
+  peerLabel?: string | null;
+  revokedAt?: Date | null;
+  quarantinedAt?: Date | null;
+}
+
+export interface ResolvedPairing {
+  /** The peer to show and mirror work to, or null when there is none. */
+  ref: string | null;
+  source: PairingSource;
+  /** Set when the pairing came from a link, so callers can navigate to it. */
+  linkId?: string;
+  /**
+   * True when an operator declared a pairing that no live link corroborates.
+   * The stance stays cautious in that case: a typed name is a statement of
+   * intent, not evidence that a peer is reachable and trusted.
+   */
+  declaredButUnconfirmed: boolean;
+}
+
+function isUsable(link: PairingLink): boolean {
+  if (link.revokedAt) return false;
+  if (link.quarantinedAt) return false;
+  return USABLE_LINK_STATES.has(link.linkState);
+}
+
+/**
+ * Resolve the installation this one is paired with.
+ *
+ * A live same-organization link wins over the declared value, because the link
+ * is evidence and the declaration is an assertion. When links disagree with the
+ * declaration, the link is reported and `declaredButUnconfirmed` records that the
+ * operator's typed value did not match — surfaced rather than silently ignored.
+ *
+ * Pure and total: no database access, no clock.
+ */
+export function resolveInstallationPairing(input: {
+  declaredRef?: string | null;
+  links: readonly PairingLink[];
+}): ResolvedPairing {
+  const declared = input.declaredRef?.trim() || null;
+
+  const sameOrgLinks = input.links
+    .filter((link) => link.relationshipPreset === "same-organization")
+    .filter(isUsable);
+
+  // Deterministic pick: linkId ordering, so equal input gives equal output and
+  // a multi-peer organization does not flap between renders.
+  const chosen = [...sameOrgLinks].sort((a, b) => a.linkId.localeCompare(b.linkId))[0];
+
+  if (chosen) {
+    const ref = chosen.peerLabel?.trim() || chosen.linkId;
+    return {
+      ref,
+      source: "federation-link",
+      linkId: chosen.linkId,
+      declaredButUnconfirmed: declared !== null && declared !== ref,
+    };
+  }
+
+  if (declared) {
+    return { ref: declared, source: "declared-intent", declaredButUnconfirmed: true };
+  }
+
+  return { ref: null, source: "none", declaredButUnconfirmed: false };
+}
+
+/**
+ * Whether work may be mirrored to the resolved peer.
+ *
+ * Mirroring needs a real link: a typed name gives nothing to send work to. This
+ * is what keeps the `workSync` stance honest on an installation whose operator
+ * declared a peer that was never established.
+ */
+export function pairingSupportsWorkSync(pairing: ResolvedPairing): boolean {
+  return pairing.source === "federation-link";
+}


### PR DESCRIPTION
## The defect

`pairedProductionInstallationRef` on the operating intent is **free text an operator types**. That made it a second, weaker copy of a fact `FederationLink` already owns:

- it drifts the moment a link is created or revoked without the operator retyping it
- a reseeded installation silently loses its pairing while the links themselves are untouched

A live installation showed exactly that: a declared peer, then `Peer — none` and `Work sync — none`, with nothing having changed about federation. I initially read that as a bug in the panel's write path — it isn't. The panel has the field and the view carries it under test. The real flaw is that the pairing was only ever an assertion, with nothing to corroborate it.

## The fix

`resolveInstallationPairing` makes the **established link the source of truth** and demotes the typed value to what it always was: intent, useful only when no link exists yet to confirm it.

- Revoked, quarantined, unapproved, and cross-organization links are not a pairing
- Selection is deterministic by `linkId`, so a multi-peer organization does not flap between renders
- A declaration no link corroborates is reported via `declaredButUnconfirmed` rather than silently ignored

Pure and total — no database access, no clock.

## It also fixes a claim the stance was making without evidence

`workSync` (merged yesterday in #4555) reported `same-organization` on the strength of a typed name. **That told an agent its backlog was mirrored when nothing existed to carry it** — precisely the class of false assurance the stance layer is supposed to prevent.

`workSync` now requires an established link. A declared-but-unlinked peer resolves to `none` with a rationale saying why.

## Refactor allocation

Records the founder's inverted allocation — **~80% substrate refactor and integration / ~20% new feature** — where the practical split is stated (`golden-triangle-design.md`), and points the `substrate-cleanup-before-substrate-addition` principle at the new posture. The principle's substance is unchanged and in fact reinforced; only the number moved.

Historical audits keep their original wording — they record what was decided then, not what governs now.

## Verification

- `packages/db`: 36 tests — pairing resolver (13, covering every rejection path) plus the stance suite including the new established/unestablished cases
- `apps/web`: 82 tests across the identity surface, including a new view case proving work sync turns on once a link backs the declaration
- Guards: docs-impact, design-grounding, plan-backlog-coverage, prose-lint, FPAW standard — all OK

Not run: full `pnpm pregate` (unprovisioned worktree, no `packages/db/generated`). CI gates the real typecheck.

## Note for the queue

#4555 was dequeued nine times by a semantic conflict — a required field added on one branch, a consumer added on another, no textual conflict. I enumerated every consumer of the changed types on current `main` before pushing this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Seed-fit

This change edits a founder-kernel principle (`substrate-cleanup-before-substrate-addition`), which is seed content shipped to every installation. The edit is a one-line pointer correcting the refactor-budget number the principle operationalizes; its direction and substance are unchanged and in fact reinforced.

The inverted allocation is founder direction that governs the platform as a whole — it is not archetype-, vertical-, or install-specific — so it belongs in the global seed.

Seed-Fit-Decision: global-default
