### PR TITLE
fix(inference): a field named 'discipline' is not evidence of an HR record (BI-3F608240)

### DIFF
--- a/apps/web/lib/inference/data-screening/classify-payload.test.ts
+++ b/apps/web/lib/inference/data-screening/classify-payload.test.ts
@@ -465,3 +465,92 @@ describe("a coworker's job description is instruction, not payload", () => {
     expect(result.overallSensitivity).toBe("internal");
   });
 });
+
+// BI-3F608240. Measured on the live install: of the COO's 15 turns that would
+// still route `restricted` after the prompt-provenance fix, TWELVE were this
+// single pattern — a tool-call argument NAMED `discipline`, matched as though it
+// were an employment record.
+describe("a field named 'discipline' is not evidence of an HR record", () => {
+  const disciplineToolCall = {
+    role: "assistant" as const,
+    content: "",
+    toolCalls: [{ id: "c1", name: "plan_work", arguments: { discipline: "platform-engineering" } }],
+  };
+
+  it("does not escalate on a tool argument named discipline alone", () => {
+    // The exact live shape: messages[1].toolCalls[0].arguments.discipline
+    const result = classifyInferencePayload({
+      messages: [{ role: "user", content: "What should we tackle next?" }, disciplineToolCall],
+      systemPrompt: "Be concise.",
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).not.toBe("restricted");
+  });
+
+  it("still fails closed at confidential rather than dropping to internal", () => {
+    const result = classifyInferencePayload({
+      messages: [disciplineToolCall],
+      systemPrompt: "Be concise.",
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).toBe("confidential");
+  });
+
+  it("keeps the unambiguous employment spellings escalating on their own", () => {
+    for (const key of ["disciplinary", "employeeDiscipline", "employee_discipline", "salary", "payroll"]) {
+      const result = classifyInferencePayload({
+        messages: [{
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "c1", name: "update_person", arguments: { [key]: "x" } }],
+        }],
+        systemPrompt: "Be concise.",
+        taskType: "conversation",
+      });
+
+      expect(result.overallSensitivity, `${key} must still escalate alone`).toBe("restricted");
+    }
+  });
+
+  it("still escalates when discipline is corroborated by a second distinct reason", () => {
+    // Corroboration is the point of the ambiguous tier: one ordinary word is not
+    // proof, two distinct detectors are. Note it counts distinct REASONS, so a
+    // second word from the same rule (compensation, manager) does not corroborate
+    // — that is deliberate, per BI-CD13D818: many hits of one probe is one signal.
+    const result = classifyInferencePayload({
+      messages: [{
+        role: "assistant",
+        content: "",
+        toolCalls: [{
+          id: "c1",
+          name: "plan_work",
+          arguments: { discipline: "platform-engineering", incident: "INC-4" },
+        }],
+      }],
+      systemPrompt: "Be concise.",
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).toBe("restricted");
+  });
+
+  it("does not let a second word from the SAME rule masquerade as corroboration", () => {
+    const result = classifyInferencePayload({
+      messages: [{
+        role: "assistant",
+        content: "",
+        toolCalls: [{
+          id: "c1",
+          name: "plan_work",
+          arguments: { discipline: "platform-engineering", compensation: "review" },
+        }],
+      }],
+      systemPrompt: "Be concise.",
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).toBe("confidential");
+  });
+});

--- a/apps/web/lib/inference/data-screening/classify-payload.ts
+++ b/apps/web/lib/inference/data-screening/classify-payload.ts
@@ -81,7 +81,10 @@ const CLASS_RULES: readonly ClassRule[] = [
     dataClass: "employee-records",
     reason: "employee-record-field",
     confidence: "inferred",
-    pathPattern: /\b(?:employee|salary|discipline|payroll|performance[-_ ]?review)\b/i,
+    // `disciplinary` and `employeeDiscipline` name employment records and nothing
+    // else. Bare `discipline` does not — it is a field of practice as often as an
+    // HR action — so it sits in the corroboration-gated rule below (BI-3F608240).
+    pathPattern: /\b(?:employee|salary|disciplinary|employee[-_ ]?discipline|payroll|performance[-_ ]?review)\b/i,
   },
   {
     dataClass: "employee-records",
@@ -99,7 +102,7 @@ const CLASS_RULES: readonly ClassRule[] = [
     reason: "employee-record-ambiguous-term",
     confidence: "inferred",
     ambiguousVocabulary: true,
-    pathPattern: /\b(?:worker|compensation|benefit|performance|manager)\b/i,
+    pathPattern: /\b(?:worker|compensation|benefit|performance|manager|discipline)\b/i,
     textPattern: EMPLOYEE_RECORD_AMBIGUOUS_VALUE_PATTERN,
   },
   {


### PR DESCRIPTION
## Why now

#4616 and #4657 stop a coworker's *job description* pinning it to `restricted`. Projecting 14 days of live `RouteDecisionLog` forward — counting only turns that would still carry a data-provenance restricted-class match:

| coworker | restricted today | would remain |
|---|---|---|
| coo | 85 | **15** |
| market-research-analyst | 86 | 4 |
| hr-specialist | 53 | 0 |
| finance-agent | 8 | 0 |

Twelve of the COO's remaining fifteen are one pattern:

```
messages[1].toolCalls[0].arguments.discipline   employee-record-field   12 turns
```

A tool-call argument **name**, not a value. `discipline` is a field of practice as often as an HR action, and the rule carrying it is not `ambiguousVocabulary`, so a single match denied every external provider on its own.

Fixing it takes the COO from 85 restricted turns to roughly 3 — and those three are real message content, which is the control working as intended.

## The change

The rule set already encodes this distinction; the pattern never narrowed to match its own stated intent. The `ambiguousVocabulary` comment says precise evidence is *"a field literally named `password` or `employeeDiscipline`"*, and the same rule already treats `performance[-_ ]?review` as precise while bare `performance` sits in the corroboration-gated tier.

`discipline` now follows `performance`. A lone match lands on `confidential` — still failing closed, still confining routing to confidential-cleared providers.

## What this does not loosen

- `disciplinary`, `employeeDiscipline`, `employee_discipline`, `salary` and `payroll` still escalate alone. **`disciplinary` now matches where it did not before** — `\bdiscipline\b` never matched it, because of the word boundary. So this tightens detection at the same time as it loosens the false positive. A test pins all five.
- Corroborated `discipline` still escalates via `distinctAmbiguousReasons >= 2`.

A second test pins that a second word from the *same* rule does **not** corroborate. That is deliberate per BI-CD13D818 — many hits of one probe is one signal, not two — and it is easy to misread as a bug when writing tests against it. I did exactly that and the test caught me, so it is now written down.

## Verification

5 new tests, 4 of them red without the change; 3,463 tests across `lib/inference` + `lib/routing` + `lib/tak`; web typecheck; 52 preflight guards; exact-tree local CI gate PASS @ `db602da68b9b`.

Once this and #4657 deploy, the check is live COO turns: `sensitivity` should read `confidential`, `matchProvenance` should show `path` starting `systemPrompt.instruction[`, and `excludedTrace` should stop excluding the Claude endpoints.

Part of `WC-9C828312`. Related: BI-CD13D818 (same false-positive family), #4616, #4657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)