### PR TITLE
fix(coworker): an unread local window is not a large one (BI-DBEEC15B)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -717,7 +717,7 @@ export async function sendMessage(input: {
   // Presence rides with the window: a null window cannot tell an absent local
   // model from an unread one, and the tool cap below needs that (BI-A8BFEFCE).
   const { servedContextTokens: localServedContext, presence: localPresence } = await resolveLocalServingPosture();
-  const skillCatalogCap = deriveSkillCatalogCap(localServedContext);
+  const skillCatalogCap = deriveSkillCatalogCap(localServedContext, { localPresence });
   // Computed once; an explicitly-invoked skill is pinned into the catalog so the
   // cap never breaks a `Use the <id> skill.` request (reused for telemetry below).
   const invokedSkillId = extractInvokedSkillId(input.content);

--- a/apps/web/lib/actions/coworker-tool-budget.test.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.test.ts
@@ -133,9 +133,49 @@ describe("deriveSkillCatalogCap", () => {
   });
 
   it("is uncapped when the served context is unknown (no local model / cloud)", () => {
+    // Legacy shape: with no explicit presence, an absent window still reads as a
+    // cloud turn. Callers that CAN tell absent from unread pass localPresence.
     expect(deriveSkillCatalogCap(null)).toBe(Number.POSITIVE_INFINITY);
     expect(deriveSkillCatalogCap(undefined)).toBe(Number.POSITIVE_INFINITY);
     expect(deriveSkillCatalogCap(0)).toBe(Number.POSITIVE_INFINITY);
+    // Explicit absence is the same answer, stated honestly.
+    expect(deriveSkillCatalogCap(null, { localPresence: "absent" })).toBe(
+      Number.POSITIVE_INFINITY,
+    );
+  });
+
+  it("caps an UNREADABLE window rather than uncapping it (BI-DBEEC15B)", () => {
+    // The null carries two facts — no local model, and a probe that could not
+    // read one. Only the first justifies enumerating the whole catalog. Eight
+    // agents on the live install sit above this cap (platform-engineer holds 45
+    // skills ≈ 3.8k tokens), so the uncapped path is genuinely reachable.
+    expect(deriveSkillCatalogCap(null, { localPresence: "unknown" })).toBe(
+      SKILL_CATALOG_CLIFF_CAP,
+    );
+    expect(deriveSkillCatalogCap(null, { localPresence: "present" })).toBe(
+      SKILL_CATALOG_CLIFF_CAP,
+    );
+    expect(deriveSkillCatalogCap(undefined, { localPresence: "unknown" })).toBe(
+      SKILL_CATALOG_CLIFF_CAP,
+    );
+    expect(deriveSkillCatalogCap(0, { localPresence: "unknown" })).toBe(SKILL_CATALOG_CLIFF_CAP);
+  });
+
+  it("still lets a KNOWN large local window stay uncapped — this axis is fit, not fidelity", () => {
+    // Deliberately unlike the tool cap, which binds on presence alone. A local
+    // model with room for the catalog keeps the whole catalog.
+    expect(deriveSkillCatalogCap(131_072, { localPresence: "present" })).toBe(
+      Number.POSITIVE_INFINITY,
+    );
+    expect(deriveSkillCatalogCap(24_576, { localPresence: "present" })).toBe(
+      SKILL_CATALOG_CLIFF_CAP,
+    );
+  });
+
+  it("lets explicit absence override a known window", () => {
+    expect(deriveSkillCatalogCap(24_576, { localPresence: "absent" })).toBe(
+      Number.POSITIVE_INFINITY,
+    );
   });
 });
 

--- a/apps/web/lib/actions/coworker-tool-budget.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.ts
@@ -165,25 +165,57 @@ export function deriveCoworkerToolCap(
  * Max skills to ENUMERATE in the coworker system-prompt catalog on a cliff-prone
  * small local window. The tool cap (above) sizes tool schemas to the window, but
  * the skills catalog ("- skillId: label - description" per skill) is the largest
- * UNCAPPED non-tool block: a heavy coworker (build/platform hold 36-38 skills ≈
- * ~4k tokens) can push the assembled prompt past a small local window even after
- * the tool cap. Bound it to the same selection-cliff the tool cap uses — a small
- * local model can't usefully choose from dozens of skills either — and rely on
- * per-turn re-ranking (rankSkillsByRelevance orders to the current message) to
- * surface others when a later turn is about them.
+ * UNCAPPED non-tool block, and it is heavier than this comment used to claim.
+ * Measured on the live install (2026-08-26, `SkillAssignment` joined to
+ * `SkillDefinition` on skillId, enabled + active only): platform-engineer holds
+ * 45 skills ≈ 15,281 chars ≈ 3.8k tokens, build-specialist 43 ≈ 3.5k, and EIGHT
+ * agents sit above this cap. That block can push the assembled prompt past a
+ * small local window even after the tool cap. Bound it to the same
+ * selection-cliff the tool cap uses — a small local model can't usefully choose
+ * from dozens of skills either — and rely on per-turn re-ranking
+ * (rankSkillsByRelevance orders to the current message) to surface others when a
+ * later turn is about them.
  */
 export const SKILL_CATALOG_CLIFF_CAP = 15;
 
 /**
  * Max skills to list in the coworker prompt, sized to the LOCAL served context —
- * the symmetric partner to deriveCoworkerToolCap. A cliff-prone small local window
- * (<= ACCURACY_CLIFF_PRONE_MAX_CONTEXT) enumerates only the most relevant skills;
- * a capable/unknown window (null or > cliff) is uncapped (Infinity) so cloud and
- * large-window installs are byte-identical.
+ * the symmetric partner to deriveCoworkerToolCap.
+ *
+ * PRESENCE gates it; the WINDOW then decides (BI-DBEEC15B). Note the axis differs
+ * from the tool cap deliberately: the tool cap binds on presence alone because
+ * tool-SELECTION accuracy is a property of the model class, whereas this is a
+ * question of context FIT. So a local model with a genuinely large window still
+ * gets an uncapped catalog, exactly as before.
+ *
+ * What changed is the unread case. This used to return Infinity for a null
+ * window, but that null carries two different facts — no local model, and a
+ * probe that could not read one (see `LocalPresence`). Only the first justifies
+ * uncapping. A failed probe on an install that does have a small local model
+ * used to enumerate the whole catalog, compounding with the tool-surface
+ * widening that BI-A8BFEFCE fixed: on a 24,576-token window that was ~11k extra
+ * tokens of tool schemas plus ~2.5k of catalog, from one unread value.
+ *
+ *   null + "absent" → Infinity   null + "unknown"/"present" → 15
+ *   24_576 → 15   131_072 → Infinity   null (no presence given) → Infinity
  */
-export function deriveSkillCatalogCap(servedContextTokens: number | null | undefined): number {
-  if (!servedContextTokens || servedContextTokens <= 0) return Number.POSITIVE_INFINITY;
-  return servedContextTokens <= ACCURACY_CLIFF_PRONE_MAX_CONTEXT
+export function deriveSkillCatalogCap(
+  servedContextTokens: number | null | undefined,
+  opts?: { localPresence?: LocalPresence },
+): number {
+  const hasWindow = typeof servedContextTokens === "number" && servedContextTokens > 0;
+  // Legacy callers report presence only through the window, which cannot tell an
+  // absent model from an unread one. Explicit presence always wins.
+  const presence: LocalPresence = opts?.localPresence ?? (hasWindow ? "present" : "absent");
+
+  // No local model in the serving path → cloud turn, nothing to fit inside.
+  if (presence === "absent") return Number.POSITIVE_INFINITY;
+
+  // Local IS in the path but its window is unreadable. Fail safe to the cliff
+  // cap: an unknown window must never be treated as a large one.
+  if (!hasWindow) return SKILL_CATALOG_CLIFF_CAP;
+
+  return servedContextTokens! <= ACCURACY_CLIFF_PRONE_MAX_CONTEXT
     ? SKILL_CATALOG_CLIFF_CAP
     : Number.POSITIVE_INFINITY;
 }

--- a/docs/superpowers/specs/2026-08-26-skill-catalog-cap-local-presence-design.md
+++ b/docs/superpowers/specs/2026-08-26-skill-catalog-cap-local-presence-design.md
@@ -1,0 +1,92 @@
+---
+status: active
+---
+# Skill catalog cap and local presence (`BI-DBEEC15B`)
+
+**OBJ-HONEST-WINDOW:** An unread window is not a large one.
+**OBJ-CLOUD-UNCHANGED:** Cloud-only installs keep an uncapped catalog.
+
+| AC-UNREAD-CAPS | OBJ-HONEST-WINDOW | Unknown window with local present caps the catalog. |
+| AC-ABSENT-FREE | OBJ-CLOUD-UNCHANGED | Absent local leaves the catalog uncapped. |
+| AC-PIN-SURVIVES | OBJ-CLOUD-UNCHANGED | An invoked skill is never dropped by the cap. |
+
+## Problem
+
+`deriveSkillCatalogCap` uncaps the skill catalog whenever the served window is
+null or zero:
+
+```ts
+if (!servedContextTokens || servedContextTokens <= 0) return Number.POSITIVE_INFINITY;
+```
+
+That null is the same ambiguous value `BI-A8BFEFCE` fixed for the tool cap. It
+means both "no local model" and "the probe could not read one". Only the first
+justifies uncapping. When the probe fails on an install that does have a small
+local model, the largest uncapped block in the prompt is enumerated in full.
+
+The module's own header names the stakes but understates them. It says a heavy
+coworker holds 36-38 skills; measured against the live install, the real figures
+are higher and eight agents sit above the cap:
+
+| agent | active skills | catalog chars | approx tokens |
+| --- | --- | --- | --- |
+| `platform-engineer` | 45 | 15,281 | ~3,820 |
+| `build-specialist` | 43 | 14,036 | ~3,510 |
+| `portfolio-advisor` | 22 | — | — |
+| `ops-coordinator` | 18 | 4,947 | ~1,240 |
+| `ea-architect` | 18 | 5,186 | ~1,300 |
+
+Measured by joining `SkillAssignment` to `SkillDefinition` on `skillId` where the
+assignment is enabled and the definition is active, summing the catalog line
+shape. Correct the header comment in the same change so the next reader is not
+working from the stale number.
+
+The two defects compound, and the arithmetic is the point. On this install the
+served window is 24,576 tokens with a 12,000-token non-tool reserve. A failed
+probe simultaneously widened the tool surface from 15 to 48 schemas (~11k extra
+tokens) and uncapped the catalog for the heaviest agent (~2.5k extra). That is
+roughly 13.5k of a 24.5k window consumed by a single failed read.
+
+## Why this was separated from BI-A8BFEFCE
+
+Different failure mode. The tool-cap defect made the routing layer refuse the
+local fallback outright, producing turns that executed nothing and wrote no
+evidence. This one risks context overflow, which has its own handling path
+(`describeContextCapacityFailure`, `REQUEST_TOO_LARGE`) and does not affect
+fallback eligibility. Folding it in would have widened a targeted routing fix
+into prompt assembly.
+
+## Contract
+
+**CONTRACT-CATALOG-CAP.** `deriveSkillCatalogCap` takes the same `LocalPresence`
+the tool cap consumes. `absent` returns infinity. `present` and `unknown` mean
+local is in the path: a KNOWN window still decides on fit, and an UNREAD window
+takes the cliff cap rather than infinity.
+
+Note the axis differs from the tool cap deliberately. The tool cap binds on
+presence because tool-SELECTION accuracy is a property of the model class. The
+catalog cap binds on window size because it is a question of context FIT — so a
+local model with a genuinely large window keeps an uncapped catalog, exactly as
+today. Only the unread case changes.
+
+## Scope
+
+In scope: `deriveSkillCatalogCap`, its call site in `agent-coworker.ts` (which
+already holds the resolved presence in scope), and their tests.
+
+Out of scope: any change to `capSkillCatalog` pinning behavior, to the tool cap,
+or to the posture resolver — all landed under `BI-A8BFEFCE`.
+
+## Dependency
+
+Requires `LocalPresence` and `resolveLocalServingPosture` from `BI-A8BFEFCE`
+(PR #4663). This branch bases on `main` AFTER that merges rather than stacking
+on it, because a stacked PR does not run the heavy CI on this repo and its green
+is not a real green.
+
+## Verify
+
+AC-UNREAD-CAPS: null window with `unknown` and with `present` both return the
+cliff cap. AC-ABSENT-FREE: `absent` returns infinity; the existing window
+examples (24,576 → capped; 131,072 → infinity) are unchanged. AC-PIN-SURVIVES:
+an explicitly invoked skill is still appended beyond the cap.


### PR DESCRIPTION
Follow-up to `BI-A8BFEFCE` ([#4663](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4663), merged), which fixed the same ambiguous null for the tool cap and deliberately left this consumer for its own change.

## Problem

`deriveSkillCatalogCap` uncapped the skill catalog whenever the served window was null or zero:

```ts
if (!servedContextTokens || servedContextTokens <= 0) return Number.POSITIVE_INFINITY;
```

That null carries two different facts — no local model, and a probe that could not read one. Only the first justifies enumerating the whole catalog. On an install that does have a small local model, a failed probe emitted every skill.

## The compounding, measured

On this install the served window is 24,576 tokens with a 12,000-token non-tool reserve. A single failed probe:

| effect | cost |
| --- | --- |
| tool surface 15 → 48 schemas | ~11,000 tokens (fixed in #4663) |
| catalog uncapped, heaviest agent | ~2,500 tokens (this PR) |
| **total** | **~13,500 of a 24,576 window** |

## The comment was also wrong

The module header claimed a heavy coworker holds "36-38 skills ≈ ~4k tokens". Measured against the live install — `SkillAssignment` joined to `SkillDefinition` on `skillId`, enabled assignments and active definitions only:

| agent | active skills | catalog chars | approx tokens |
| --- | --- | --- | --- |
| `platform-engineer` | **45** | 15,281 | ~3,820 |
| `build-specialist` | 43 | 14,036 | ~3,510 |
| `portfolio-advisor` | 22 | — | — |
| `ops-coordinator` | 18 | 4,947 | ~1,240 |
| `ea-architect` | 18 | 5,186 | ~1,300 |

**Eight** agents sit above the 15-skill cap, so the uncapped path is reachable in practice rather than theoretically. Comment corrected; the query is recorded on the backlog item so the number can be re-derived rather than trusted.

A note for anyone re-measuring: the catalog comes from `SkillAssignment` via `getSkillsForAgent` (`apps/web/lib/skills/runtime.ts`). The similarly-named `AgentSkillAssignment` reports a maximum of 5 per agent and would make this look like a non-issue.

## Change

`deriveSkillCatalogCap` takes the same `LocalPresence` the tool cap consumes. `absent` uncaps; `present` and `unknown` mean local is in the path.

The axis stays deliberately different from the tool cap. That one binds on presence alone, because tool-**selection** accuracy is a property of the model class. This one is a question of context **fit**, so a local model with a genuinely large window still gets an uncapped catalog — byte-identical to before. Only the unread case changes.

## Verification

- 102 tests across 8 files pass, including each presence value against an unreadable window, the known-large-window counterexample, and explicit-absence overriding a known window.
- `pnpm --filter web build` clean on a fully bootstrapped worktree.
- Module-size, application-boundary and plan-coverage guards pass. The design-grounding gate reports no UX/workflow/queue/navigation/process-spine files changed.

## Base

Branched from `main` at `aa456254b6` — after #4663 merged — rather than stacked on it, because a stacked PR runs no heavy CI on this repo and its green is not a real green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
