### PR TITLE
fix(dev-harness): make the gate and its guards tell the truth (BI-DBED32FE, BI-F45A2AE2, BI-3B6DC1DC, BI-F0C4FDE0)

### DIFF
--- a/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
+++ b/apps/web/components/twin/restaurant/RestaurantFloorOperations.test.tsx
@@ -386,12 +386,17 @@ describe("RestaurantFloorOperations", () => {
     render(<RestaurantFloorOperations {...props} />);
     fireEvent.click(screen.getByRole("button", { name: "Confirm seating" }));
 
-    await waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(1));
-    const alert = screen.getByRole("alert");
+    // BI-F0C4FDE0: wait for the END STATE, not for the refresh call. The call
+    // is the trigger; the alert, the focus move and the button's removal all
+    // land in the effect that follows it. Waiting only on the call left a
+    // window where refresh had fired and React had not yet flushed the rest —
+    // which passed locally and failed intermittently on a loaded CI runner.
+    const alert = await screen.findByRole("alert");
+    await waitFor(() => expect(document.activeElement).toBe(alert));
+    expect(mocks.refresh).toHaveBeenCalledTimes(1);
     expect(alert.getAttribute("aria-live")).toBe("assertive");
     expect(alert.textContent).toContain("Floor changed before confirmation");
     expect(alert.textContent).toContain("Review refreshed choices, then retry");
-    expect(document.activeElement).toBe(alert);
     expect(screen.queryByRole("button", { name: "Confirm seating" })).toBeNull();
     expect(screen.getByText("Choose a party for a safe seating choice.")).toBeTruthy();
   });

--- a/scripts/check-no-bare-working-write.mjs
+++ b/scripts/check-no-bare-working-write.mjs
@@ -55,7 +55,46 @@ const ALLOWLIST = new Set([
   // (BI-ED117C82).
   "apps/web/lib/wiki/embedding-coverage-workroom.ts",]);
 
-const PATTERNS = [/status:\s*["']working["']/];
+const WORKING_WRITE_RE = /status:\s*["']working["']/;
+
+/**
+ * BI-3B6DC1DC: only a TASK RUN write is this guard's business.
+ *
+ * The guard exists so `TaskRun.status = "working"` always lands with
+ * `lastHeartbeatAt`, or the stall watchdog false-positives. It used to match
+ * the literal anywhere in a file, so a Workroom upsert — a different model,
+ * with no heartbeat contract at all — tripped a TaskRun guard and had to be
+ * allowlisted. Every such entry makes the allowlist a weaker signal about the
+ * thing the guard actually protects.
+ *
+ * A hit counts only when the same statement touches a taskRun delegate or a
+ * TaskRun-shaped identifier. `sliceStatement` keeps that check local: a
+ * Workroom write ten lines above a TaskRun write must not launder it.
+ */
+const TASK_RUN_CONTEXT_RE =
+  /\b(taskRun|taskRuns|TaskRun|task_run)\b|\btaskRunId\b/;
+
+/** The statement around an index — bounded by braces, semicolons or blank lines. */
+export function sliceStatement(body, index) {
+  const start = Math.max(
+    body.lastIndexOf("await ", index),
+    body.lastIndexOf("\n\n", index),
+    body.lastIndexOf(";", index),
+  );
+  const end = body.indexOf(";", index);
+  return body.slice(start === -1 ? 0 : start, end === -1 ? body.length : end + 1);
+}
+
+/** Every bare working-write in `body` that belongs to a TaskRun. */
+export function findTaskRunWorkingWrites(body) {
+  const hits = [];
+  const re = new RegExp(WORKING_WRITE_RE.source, "g");
+  for (const match of body.matchAll(re)) {
+    const statement = sliceStatement(body, match.index ?? 0);
+    if (TASK_RUN_CONTEXT_RE.test(statement)) hits.push(statement.trim().slice(0, 200));
+  }
+  return hits;
+}
 
 function* walk(dir) {
   for (const entry of readdirSync(dir)) {
@@ -83,8 +122,8 @@ for (const file of walk(SCAN_DIR)) {
   } catch {
     continue;
   }
-  const hit = PATTERNS.some((p) => p.test(body));
-  if (!hit) continue;
+  const hits = findTaskRunWorkingWrites(body);
+  if (hits.length === 0) continue;
 
   const rel = relative(ROOT, file).replace(/\\/g, "/");
   if (ALLOWLIST.has(rel)) continue;

--- a/scripts/check-no-bare-working-write.test.mjs
+++ b/scripts/check-no-bare-working-write.test.mjs
@@ -1,0 +1,55 @@
+// BI-3B6DC1DC — the guard must police TaskRun writes, and only those.
+//
+// It exists so TaskRun.status="working" always lands with lastHeartbeatAt, or
+// the stall watchdog false-positives. Matching the literal anywhere in a file
+// made a Workroom upsert trip a TaskRun guard, and every allowlist entry added
+// for a non-TaskRun model makes the allowlist a weaker signal about the thing
+// the guard actually protects.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { findTaskRunWorkingWrites } from "./check-no-bare-working-write.mjs";
+
+test("catches a bare TaskRun working-write", () => {
+  const body = `
+    await prisma.taskRun.update({
+      where: { taskRunId },
+      data: { status: "working" },
+    });
+  `;
+  assert.equal(findTaskRunWorkingWrites(body).length, 1);
+});
+
+test("catches it through updateMany and create too", () => {
+  const many = `await prisma.taskRun.updateMany({ where: { taskRunId }, data: { status: "working" } });`;
+  const created = `await prisma.taskRun.create({ data: { taskRunId, status: "working" } });`;
+  assert.equal(findTaskRunWorkingWrites(many).length, 1);
+  assert.equal(findTaskRunWorkingWrites(created).length, 1);
+});
+
+test("ignores a Workroom write, which has no heartbeat contract", () => {
+  const body = `
+    const room = await prisma.workroom.upsert({
+      where: { idempotencyKey: GOVERNANCE_ROOM_KEY },
+      create: { title: "Decision governance", status: "working" },
+    });
+  `;
+  assert.deepEqual(findTaskRunWorkingWrites(body), []);
+});
+
+test("ignores any other model's status field", () => {
+  for (const model of ["workItem", "featureBuild", "deliberationRun", "scheduledJob"]) {
+    const body = `await prisma.${model}.update({ where: { id }, data: { status: "working" } });`;
+    assert.deepEqual(findTaskRunWorkingWrites(body), [], `${model} must not trip the TaskRun guard`);
+  }
+});
+
+test("a nearby TaskRun write does not launder a Workroom write", () => {
+  const body = `
+    await prisma.taskRun.update({ where: { taskRunId }, data: { lastHeartbeatAt: new Date() } });
+
+    await prisma.workroom.upsert({ where: { key }, create: { status: "working" } });
+  `;
+  assert.deepEqual(findTaskRunWorkingWrites(body), []);
+});

--- a/scripts/check-prose-lint.test.ts
+++ b/scripts/check-prose-lint.test.ts
@@ -203,3 +203,42 @@ test("retiredVocabOnly scores lib files on the rename axis alone", () => {
   assert.equal(axes.textMass, 0);
   assert.equal(axes.longSentences, 0);
 });
+
+// BI-F45A2AE2. `/>...</` captures everything between a `>` and the next `<`,
+// which includes the code between two generic calls — so a component carrying
+// no copy at all scored textMass. The only exits were contorting the component
+// or `--update`, which bakes a false count into everyone's baseline.
+test("the span between two generics is code, not UI copy", () => {
+  const source = [
+    'const [mode, setMode] = useState<Mode>("idle");',
+    '  const [text, setText] = useState(proposal.draftText ?? "");',
+    "  const [result, setResult] = useState<{ ok: boolean }>(null);",
+  ].join("\n");
+  assert.deepEqual(extractCopySnippets(source), []);
+  assert.equal(analyzeFile("apps/web/components/Example.tsx", source).textMass, 0);
+});
+
+test("a type alias followed by a Promise generic is code, not UI copy", () => {
+  const source = [
+    "export type RuleResult = ActionResult<string>;",
+    "",
+    "export async function rule(input: RuleInput): Promise<RuleResult> {",
+  ].join("\n");
+  assert.deepEqual(extractCopySnippets(source), []);
+});
+
+test("a JSX ternary fragment is code, not UI copy", () => {
+  const source = "      ) : proposal.agreementNote ? (\n        <p>{proposal.agreementNote}</p>";
+  assert.deepEqual(extractCopySnippets(source), []);
+});
+
+test("real copy still counts, including copy that contains parentheses", () => {
+  assert.deepEqual(
+    extractCopySnippets("<p>Answer in your own words — it is saved as a draft for you to review.</p>"),
+    ["Answer in your own words — it is saved as a draft for you to review."],
+  );
+  assert.deepEqual(
+    extractCopySnippets("<span>Your coworkers were only moderately sure (worth a read).</span>"),
+    ["Your coworkers were only moderately sure (worth a read)."],
+  );
+});

--- a/scripts/check-prose-lint.ts
+++ b/scripts/check-prose-lint.ts
@@ -140,11 +140,40 @@ export function countRetiredVocabulary(snippets: string[]): number {
 // regex pass over source text is the established complexity budget for these
 // guards). Two shapes cover almost all DPF UI copy: JSX text nodes, and
 // quoted values assigned to copy-bearing props/keys.
-const JSX_TEXT_RE = />\s*([^<>{}\n][^<>{}]*?)\s*</g;
+// BI-F45A2AE2: the closing delimiter must open a REAL tag (`</` or `<Name`),
+// not a generic's type argument. On its own this is not enough — `useState<T>`
+// is followed by a letter too — so `looksLikeCode` below carries the rest.
+const JSX_TEXT_RE = />\s*([^<>{}\n][^<>{}]*?)\s*<[/A-Za-z]/g;
 const ATTR_COPY_RE =
   /\b(?:label|title|placeholder|alt|aria-label|description|heading|subheading|subtitle|helperText|helpText|summary|message|tooltip)\s*[:=]\s*(["'`])((?:(?!\1)[^\\]|\\.)*)\1/g;
 
+/**
+ * Source that the JSX-text regex captured by accident (BI-F45A2AE2).
+ *
+ * `/>...</` matches everything between a `>` and the next `<`, which includes
+ * the code between two generic calls: the span from the `>` closing
+ * `useState<Mode>` to the `<` opening `useState<{ ok: boolean }>` is captured
+ * verbatim and scored as prose. A component carrying ZERO copy measured
+ * textMass +23 that way, and the only exits were contorting the component or
+ * `--update`, which bakes the false count into everyone's baseline.
+ *
+ * Each signal below is code-only. UI copy may contain parentheses and colons,
+ * so those alone are never enough; a statement separator, an arrow, a
+ * declaration keyword or a leading close-paren is.
+ */
+function looksLikeCode(s: string): boolean {
+  if (/=>/.test(s)) return true;
+  if (/^\s*[)\]]/.test(s)) return true; // a JSX text node never opens with a closer
+  if (/;\s*(\n|$)/.test(s)) return true; // a statement ended inside the span
+  if (/\b(const|let|var|function|return|await|import|export\s+(async|function|const|type))\b/.test(s)) {
+    return true;
+  }
+  if (/\b(useState|useEffect|useMemo|useCallback|useRef|useTransition)\s*\(/.test(s)) return true;
+  return false;
+}
+
 function looksLikeCopy(s: string): boolean {
+  if (looksLikeCode(s)) return false;
   if (s.length < 8) return false;
   if (!/[a-zA-Z]{3}/.test(s)) return false;
   if (!/\s/.test(s)) return false; // require at least two words

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -37,6 +37,9 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
   source: Object.freeze([
     guard("repo-guard-loop", "Repo Guard Loop", [
       node("--test", "scripts/check-guards.test.mjs"),
+      // BI-3B6DC1DC: the TaskRun working-write guard now scopes by model, so its
+      // own behaviour is under test rather than trusted.
+      node("--test", "scripts/check-no-bare-working-write.test.mjs"),
       node("--test", "scripts/host-resource-runner.test.mjs"),
       node("scripts/check-guards.mjs"),
       node("--test", "scripts/check-capability-compose-profiles.test.mjs"),


### PR DESCRIPTION
Four defects found while shipping EP-0AF96937, grouped because they are one concern — **the development harness must be honest** — and because three of them were found by tripping over each other.

## BI-DBED32FE — the gate could not say why it failed

`summarizeLocalCiOutput()` returns a structured object; `pregate-console` did `String(summary)` on it. So every gate failure printed `! [object Object]` while the parsed `failedTests` / `failedChecks` were computed and discarded. `pregate:status` then reported *"NO recorded reason — re-run"*, which is advice to loop: **six consecutive runs on one branch were debugged blind.**

Now the structured summary renders (with an explicit `+N more` instead of a silent cap), the gate record carries `failureReason`, and the case that produced this fix — every stage green, child exited non-zero — says exactly that rather than going quiet.

The existing test passed a **string**, which is why this survived. The new one passes what the summarizer actually returns.

## BI-F45A2AE2 — prose-lint read TypeScript generics as UI copy

`/> ... </` captures everything between a `>` and the next `<`, including the code between two generic calls — so `useState<Mode>` … `useState<{` scored as prose. A component with zero copy measured textMass +23.

Retightening the baseline after the fix moved it from **1243 files / 49,495 textMass to 1167 / 37,618**. About a quarter of the repo's measured "UI copy" was code, and that phantom headroom had been silently permitting real copy growth. `readability` 74 → 50 and `longSentences` 49 → 20 were code lines too.

## BI-3B6DC1DC — the TaskRun heartbeat guard matched any model's status field

A Workroom upsert tripped a guard that exists to protect `TaskRun.lastHeartbeatAt`. It now requires a `taskRun` delegate in the same statement, so a nearby TaskRun write cannot launder a different model's, and the allowlist goes back to meaning what it says.

## BI-F0C4FDE0 — a test waited for the trigger, not the outcome

`RestaurantFloorOperations` awaited the refresh **call**, then asserted synchronously on the alert, its focus, and the button's removal — all of which land in the following effect. Green locally, intermittent on a loaded runner. Now it waits for the end state. Ran five times clean.

## Verification

- `pnpm run pregate` — **PASS** (`fix/dev-harness-truthfulness @ 3936f7b1bb5c`)
- 52 preflight guards clean; prose-lint and style-drift green after retightening
- New tests: 15 pregate-console (was 11), 26 prose-lint (was 22), 5 for the working-write guard, and the flaky test five times
- The new guard test is registered in `ci-policy-guards.mjs` — a test CI does not run is the same defect class this PR is fixing

## Note for the reviewer

`fix/local-capacity-window` and `feat/governance-triage-panel` both carry an allowlist entry for `concierge-sweep-runner.ts` added *because* of BI-3B6DC1DC. Once this lands, that entry is unnecessary and should be dropped when those branches rebase.

Docs-Impact-Decision: developer-harness guards and the local gate console have no user-guide surface; no documented route or user-facing behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)