### PR TITLE
fix(ux-budget): drop the sentence-length term from the UI reading grade (BI-0ED0F6B3 directive 2)

### DIFF
--- a/apps/web/lib/owner-first/ux-audit.ts
+++ b/apps/web/lib/owner-first/ux-audit.ts
@@ -75,7 +75,7 @@ const NAMED_TAG_RE = /<\/?([a-zA-Z][a-zA-Z0-9-]*)\b[^>]*>/g;
  * `visibleText` deliberately flattens all of that into a single space-joined
  * string, which is right for counting words and wrong for anything that needs
  * sentence boundaries: a UI carries its boundaries in its ELEMENTS, not in full
- * stops (BI-0ED0F6B3). Pair this with `analyzeUtteranceReadability`.
+ * stops (BI-0ED0F6B3). Pair this with `analyzeUiReadability`.
  */
 export function visibleUtterances(html: string): string[] {
   const marked = String(html).replace(NAMED_TAG_RE, (_m, name: string) =>

--- a/apps/web/lib/ux-budget/measure.ts
+++ b/apps/web/lib/ux-budget/measure.ts
@@ -16,7 +16,7 @@
 // CI checker must never need a database. The policy vocabulary (ReadingLevel, the
 // grade caps) is shared; only the DB-backed override resolution stays at runtime.
 
-import { analyzeUtteranceReadability, withinReadingLevel, type ReadingLevel } from "@dpf/validators";
+import { analyzeUiReadability, withinReadingLevel, type ReadingLevel } from "@dpf/validators";
 import {
   countSmallControls,
   countWords,
@@ -134,7 +134,7 @@ export function measureUxBudget(html: string): UxBudgetMetrics {
     buriedPrimaryAction: buried ? 1 : 0,
     // An empty surface has no prose to grade; report 0 rather than a fabricated score.
     readingGradeLevel:
-      utterances.length === 0 ? 0 : analyzeUtteranceReadability(utterances).gradeLevel,
+      utterances.length === 0 ? 0 : analyzeUiReadability(utterances).gradeLevel,
   };
 }
 

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -431,23 +431,38 @@ for prose, and the clearest sign the number was measuring layout rather than lan
 
 So there are **two scorers**, and picking the wrong one is a defect:
 
-| Input | Function | Sentence boundary |
+| Input | Function | What it reads |
 |---|---|---|
-| Prose — storefront copy, campaigns, docs, a marketing snippet | `analyzeReadability` | a full stop |
-| A rendered UI surface | `analyzeUtteranceReadability` | **the element boundary** |
+| Prose — storefront copy, campaigns, docs, a marketing snippet | `analyzeReadability` | full Flesch–Kincaid: sentence length **and** word difficulty |
+| A rendered UI surface | `analyzeUiReadability` | **word difficulty alone** |
 
-In a user interface the sentence boundary *is* the element boundary. Each utterance —
-one heading, one cell, one label, one list item — is at least one sentence, and real
-body copy inside an utterance still splits on its own full stops. Two consequences
-worth naming:
+Flesch–Kincaid is `0.39 × words-per-sentence + 11.8 × syllables-per-word − 15.59`.
+Its first term assumes the text has sentences. A screen does not, so for UI surfaces
+that term is **dropped** rather than repaired:
 
-- **The grade cannot be moved by punctuating labels.** Adding full stops to a screen
-  changes the number by zero. Before, it was worth five grades.
-- **The grade still rises for genuinely dense words.** A screen of one-word labels
-  reading *Infrastructure / Optimization / Administrative / Documentation* still fails
-  the high-school cap, at exactly the words-per-sentence of a screen reading *Date /
-  Route / Miles*. The measure separates difficulty from punctuation; it does not
-  excuse jargon.
+```
+UI grade = 11.8 × syllables-per-word − 15.59
+```
+
+The coefficients are FK's own, so the scale and the existing caps keep their meaning.
+Nothing about punctuation appears in the formula, which makes the measure
+punctuation-independent **by construction** — a fact about the arithmetic, not a
+property a test has to keep re-checking. Two consequences worth naming:
+
+- **No arrangement of full stops can move the grade.** Not one stop per label, not
+  none at all, not the entire screen as a single run. Under the old measure that
+  choice was worth five grades.
+- **Dense words still fail.** A screen of one-word labels reading *Infrastructure /
+  Optimization / Administrative / Documentation* fails the high-school cap; *Date /
+  Route / Miles* passes. Plain product copy runs about 1.76 syllables per word and
+  scores 5.2; genuinely dense operator prose runs about 3.57 and scores 26.5.
+
+**What this deliberately gives up.** Sentence length is a real readability signal and
+this measure is blind to it — one 60-word paragraph of simple words grades the same as
+those words in six sentences. That signal has its own home: `check-prose-lint` flags any
+copy sentence over 25 words on its `longSentences` axis, scoring one sentence at a time
+where the term is meaningful. Splitting the two concerns is what lets each be honest —
+word difficulty here, sentence length there, neither pretending to measure the other.
 
 The UI reading grade is also scored over the route's own `<main>` rather than the
 shared shell. Chrome is identical on every route and was diluting all of them equally.
@@ -459,7 +474,7 @@ are part of what the owner meets on arrival.
 - **Documentation site (today):** the `/business-types/` generator scores every page's business-facing copy at build time, warns when a page exceeds the target, writes `_readability-report.md`, and prints the grade in each page footer. Architecture and standards sections are excluded by design.
 - **Generated copy (platform) — implemented (BI-8F8C5F28):** when an AI coworker on a customer-copy surface (marketing, storefront) writes external copy, it is held to the org's readability target. The target is an **operator-adjustable policy stored on the existing `PlatformConfig` key/value table (key `content_readability_policy`) and set from the existing `/admin/settings` page — no new table or admin surface**. It is resolved at runtime (`apps/web/lib/readability/policy.ts`, honouring a per-archetype `marketingSkillRules.readingLevel` override) and injected into the coworker's prompt at **Block 5** of the assembler (`apps/web/lib/tak/prompt-assembler.ts`). The shared Flesch–Kincaid scorer + tiered-policy types live in `@dpf/validators` (`packages/validators/src/readability.ts`).
 - **Product screens (route sweep):** the UX route budget grades every page route's own
-  copy with `analyzeUtteranceReadability` against the tier in
+  copy with `analyzeUiReadability` against the tier in
   `apps/web/lib/ux-budget/budgets.ts`. Advisory on pre-existing routes, blocking on
   net-new ones. It is an absolute check, not a ratcheted axis, so it carries no entry
   in `route-budget-baseline.json`. **Every audience is held to its shell's tier** —

--- a/packages/validators/src/readability.test.ts
+++ b/packages/validators/src/readability.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   analyzeReadability,
-  analyzeUtteranceReadability,
+  analyzeUiReadability,
   countSyllables,
   parseReadabilityPolicy,
   resolveReadingLevel,
@@ -143,48 +143,49 @@ describe("analyzeReadability — the prose assumption it rests on", () => {
   });
 });
 
-describe("analyzeUtteranceReadability", () => {
-  it("scores each UI utterance as its own sentence", () => {
-    const ui = analyzeUtteranceReadability(UI_LABELS);
-    expect(ui.sentences).toBe(UI_LABELS.length);
-    expect(ui.wordsPerSentence).toBeLessThan(2);
+describe("analyzeUiReadability — BI-0ED0F6B3 directive 2", () => {
+  it("is punctuation-independent BY CONSTRUCTION, not by luck", () => {
+    // No sentence-length term exists in the formula, so no arrangement of full
+    // stops can move the result. Assert across the whole spectrum of ways a UI
+    // could be punctuated, not just one.
+    const bare = analyzeUiReadability(UI_LABELS).gradeLevel;
+    const perLabel = analyzeUiReadability(UI_LABELS.map((l) => `${l}.`)).gradeLevel;
+    const allOne = analyzeUiReadability([UI_LABELS.join(" ")]).gradeLevel;
+    const shouty = analyzeUiReadability(UI_LABELS.map((l) => `${l}!?!`)).gradeLevel;
+    expect(new Set([bare, perLabel, allOne, shouty]).size).toBe(1);
   });
 
-  it("cannot be gamed by adding full stops", () => {
-    const bare = analyzeUtteranceReadability(UI_LABELS);
-    const stopped = analyzeUtteranceReadability(UI_LABELS.map((l) => `${l}.`));
-    expect(stopped.gradeLevel).toBe(bare.gradeLevel);
-    expect(stopped.sentences).toBe(bare.sentences);
-  });
-
-  it("agrees with the prose analyzer on a single prose utterance", () => {
-    const prose = "the cat sat on the mat and the dog ran to the log";
-    expect(analyzeUtteranceReadability([prose])).toEqual(analyzeReadability(prose));
-    expect(analyzeUtteranceReadability([JARGON])).toEqual(analyzeReadability(JARGON));
-  });
-
-  it("still splits genuine prose inside one utterance on its full stops", () => {
-    const paragraph = "We sorted your drives. Three still need a category. Pick one for each.";
-    expect(analyzeUtteranceReadability([paragraph]).sentences).toBe(3);
-  });
-
-  it("still catches jargon on a label-shaped surface", () => {
-    // The point of the correction is a measure that separates plain from dense
-    // WITHOUT counting periods. Both surfaces are pure one-word labels.
-    const plain = analyzeUtteranceReadability(["Date", "Route", "Miles", "Sorted", "Owed"]);
-    const dense = analyzeUtteranceReadability([
+  it("separates plain product copy from dense operator prose", () => {
+    // The two cases the policy exists to tell apart, at IDENTICAL structure.
+    const plain = analyzeUiReadability(["Date", "Route", "Miles", "Sorted", "Owed"]);
+    const dense = analyzeUiReadability([
       "Infrastructure",
       "Optimization",
       "Administrative",
       "Documentation",
       "Organizational",
     ]);
-    expect(plain.wordsPerSentence).toBe(dense.wordsPerSentence);
     expect(withinReadingLevel(plain.gradeLevel, "high-school")).toBe(true);
     expect(withinReadingLevel(dense.gradeLevel, "high-school")).toBe(false);
   });
 
+  it("reads word difficulty on Flesch–Kincaid's own scale", () => {
+    // 11.8 * spw - 15.59. The BI's two anchors: 1.76 plain, 3.57 dense.
+    const at = (spw: number) => Math.round((11.8 * spw - 15.59) * 10) / 10;
+    expect(at(1.76)).toBe(5.2);
+    expect(at(3.57)).toBe(26.5);
+  });
+
+  it("counts every word once, whatever the utterance split", () => {
+    const split = analyzeUiReadability(["Date", "Route", "Miles"]);
+    const joined = analyzeUiReadability(["Date Route Miles"]);
+    expect(split.words).toBe(3);
+    expect(split.syllablesPerWord).toBe(joined.syllablesPerWord);
+    expect(split.utterances).toBe(3);
+    expect(joined.utterances).toBe(1);
+  });
+
   it("ignores utterances with no scoreable text", () => {
-    expect(analyzeUtteranceReadability(["  ", "—", "Date"]).sentences).toBe(1);
+    expect(analyzeUiReadability(["  ", "—", "Date"]).utterances).toBe(1);
   });
 });

--- a/packages/validators/src/readability.ts
+++ b/packages/validators/src/readability.ts
@@ -78,7 +78,7 @@ function score(text: string, sentenceCount: number): ReadabilityScore {
  * Flesch–Kincaid over PROSE — text whose sentence boundaries are full stops.
  * Correct for a paragraph, a marketing snippet, a doc body.
  *
- * DO NOT use this on a rendered UI surface. See `analyzeUtteranceReadability`.
+ * DO NOT use this on a rendered UI surface. See `analyzeUiReadability`.
  */
 export function analyzeReadability(rawText: string): ReadabilityScore {
   const text = toProse(rawText);
@@ -86,40 +86,68 @@ export function analyzeReadability(rawText: string): ReadabilityScore {
 }
 
 /**
- * Flesch–Kincaid over a UI SURFACE — BI-0ED0F6B3.
+ * A UI surface's reading grade — BI-0ED0F6B3.
  *
- * THE DEFECT THIS EXISTS TO FIX. Flesch–Kincaid divides words by sentences, and
- * `analyzeReadability` finds sentences by looking for full stops. A user
- * interface has almost none: it is headings, table cells, button labels, nav
- * items and list items, and none of those are punctuated. Flatten such a page
- * into one string and every label in it collapses into a single enormous
- * "sentence", words-per-sentence explodes, and the grade climbs for text that
- * carries no complexity at all.
+ * WHY THIS IS NOT FLESCH–KINCAID. FK is `0.39 × words-per-sentence + 11.8 ×
+ * syllables-per-word − 15.59`. The first term assumes the text HAS sentences,
+ * and a user interface does not: it is headings, table cells, button labels,
+ * nav items and list items, almost none of them punctuated. Score a screen with
+ * FK and the whole page collapses into one enormous "sentence",
+ * words-per-sentence explodes, and the grade climbs for copy carrying no
+ * difficulty at all. That is how 185 of 201 routes came to fail this check, and
+ * how `/platform/identity/agents` reached grade 377 — a figure arithmetically
+ * impossible for prose.
  *
- * Measured proof (packages/validators/src/readability.test.ts): the same fifteen
- * words, at the same 1.4 syllables per word, score grade 6.8 with no full stop at
- * all (one "sentence") and grade 1.5 with a stop after each label. Identical
- * vocabulary; the only variable is punctuation the UI had no reason to carry. At
- * the 21-word length the BI measured, the same swing is 8.7 -> 5.2. On a real
- * 200-word surface the mechanism produced grades in the teens, and that inflation
- * is what drove every /admin route over the high-school cap.
+ * Segmenting a UI into utterances fixes the inflation but keeps the dependency:
+ * the sentence-length term is still there, still moved by where full stops
+ * happen to fall. So the term is DROPPED. What remains is the half of FK that
+ * was measuring language rather than layout:
  *
- * THE CORRECTION. In a UI the SENTENCE BOUNDARY IS THE ELEMENT BOUNDARY. Each
- * utterance — one heading, one cell, one label — is at least one sentence, and
- * genuine prose inside an utterance still splits on its own full stops. Feed the
- * utterances in separately and words-per-sentence becomes what it should be: a
- * measure of how long the surface's actual phrases are.
+ *     grade = 11.8 × syllables-per-word − 15.59
  *
- * The result is dominated by syllables-per-word for a label-shaped surface, which
- * is the punctuation-independent signal that separates plain copy from jargon,
- * while still catching a genuinely long sentence in real body copy. It also
- * cannot be gamed by adding full stops — a stop inside an utterance only ever
- * splits a sentence that was already counted.
+ * The coefficients are FK's own, so the scale and the existing caps
+ * (high-school 9, college 13) keep their meaning. Nothing about punctuation
+ * appears in the formula, which makes the measure punctuation-independent BY
+ * CONSTRUCTION rather than by assertion — the property is a fact about the
+ * arithmetic, not a claim a test has to keep re-checking.
+ *
+ * It separates the cases the policy actually cares about. Plain product copy
+ * runs about 1.76 syllables per word and scores 5.2; genuinely dense operator
+ * prose runs about 3.57 and scores 26.5. Same words-per-sentence in both, which
+ * is the point.
+ *
+ * WHAT IS GIVEN UP, AND WHY THAT IS ACCEPTABLE. Sentence length is a real
+ * readability signal, and this measure is blind to it: a screen carrying one
+ * 60-word paragraph of simple words grades the same as the same words in six
+ * sentences. That signal has its own home — `scripts/check-prose-lint.ts` flags
+ * any copy sentence over 25 words on the `longSentences` axis, scoring one
+ * sentence at a time where the term is meaningful. Splitting the two concerns
+ * is what lets each measure be honest: word difficulty here, sentence length
+ * there, and neither one pretending to measure the other.
  */
-export function analyzeUtteranceReadability(utterances: readonly string[]): ReadabilityScore {
+export function analyzeUiReadability(utterances: readonly string[]): UiReadabilityScore {
   const texts = utterances.map((u) => toProse(u)).filter((t) => /[a-z0-9]/i.test(t));
-  const sentences = texts.reduce((n, t) => n + Math.max(proseSentences(t).length, 1), 0);
-  return score(texts.join(" "), sentences);
+  const words = texts.join(" ").split(/\s+/).filter((w) => /[a-z0-9]/i.test(w));
+  const wordCount = Math.max(words.length, 1);
+  const syllables = words.reduce((n, w) => n + countSyllables(w), 0);
+  const spw = syllables / wordCount;
+  return {
+    words: wordCount,
+    utterances: texts.length,
+    syllables,
+    syllablesPerWord: round2(spw),
+    gradeLevel: round1(11.8 * spw - 15.59),
+  };
+}
+
+export interface UiReadabilityScore {
+  words: number;
+  /** Distinct UI utterances scored — headings, cells, labels, list items. */
+  utterances: number;
+  syllables: number;
+  syllablesPerWord: number;
+  /** Reading grade from word difficulty alone. No sentence-length term. */
+  gradeLevel: number;
 }
 
 // ── Reading levels & the tiered policy ──────────────────────────────────────


### PR DESCRIPTION
Completes BI-0ED0F6B3. #4604 fixed the symptom; this removes the cause.

## What #4604 left behind

Flesch–Kincaid is `0.39 × words-per-sentence + 11.8 × syllables-per-word − 15.59`.
Its first term assumes the text has sentences. A UI does not — it is headings, table
cells, button labels and nav items, almost none of them punctuated — so that term was
inflating every route's grade. #4604 stopped the inflation by segmenting the page into
utterances, which made words-per-sentence small and sane.

That fixed the number while keeping the dependency. The sentence-length term was still
in the formula, still moved by where full stops happen to fall. The measure was
punctuation-*resistant*, not punctuation-*independent*, and the difference is one an
assertion in a test file was holding up rather than the arithmetic.

## What this does

Drops the term. What remains is the half of FK that was measuring language rather than
layout:

```
UI grade = 11.8 × syllables-per-word − 15.59
```

The coefficients are FK's own, so the scale and the existing caps — high-school 9,
college 13 — keep their meaning. **Nothing about punctuation appears in the formula.**
Punctuation-independence is now a fact about the arithmetic instead of a property a
test has to keep re-checking.

The test checks it anyway, across the spectrum rather than at one point: one stop per
label, no stops at all, the entire screen as a single run, and gratuitous `!?!` all
produce one identical grade.

It still separates what the policy cares about, at the BI's own anchors:

| surface | syllables/word | grade | high-school cap 9 |
|---|---|---|---|
| plain product copy | 1.76 | **5.2** | passes |
| dense operator prose | 3.57 | **26.5** | fails |

Identical structure in both. That is the whole point of the directive.

## What this gives up, deliberately

Sentence length is a real readability signal and this measure is blind to it: one
60-word paragraph of simple words grades the same as those words in six sentences.

That signal has its own home. `scripts/check-prose-lint.ts` flags any copy sentence over
25 words on its `longSentences` axis, scoring one sentence at a time — the only context
where the term is meaningful. Splitting the two concerns is what lets each measure be
honest: word difficulty here, sentence length there, neither pretending to be the other.

`analyzeUtteranceReadability` is removed rather than left beside its replacement. Two
homes for one question is how the next reader picks the wrong one.

## Verification

- `packages/validators` — 106 tests pass
- `apps/web` ux-budget / owner-first / business-journeys / platform-ai-skills — 228 pass
- `pnpm --filter web exec tsc --noEmit` — clean
- local-CI gate PASS on `a38ecb0d3661` (evidence `cmt9hvw2u0f2r01lg0tm1disd`)
- 201-route sweep — run 32924136264, success (below)

`analyzeReadability` is untouched, so prose-lint, `setup-ux` and the
marketing/storefront validators are unaffected.

## The measured effect

Run 32924136264 against run 32661659842 (the `#4604` sweep):

| | after #4604 | after this |
|---|---|---|
| median | 8.7 | **6.8** |
| p90 | 11.5 | **9.3** |
| max | 15.4 | **14.7** |
| at or under 9 | 119 / 201 | **179 / 204** |
| failing | 35 / 201 | **25 / 204** |

Worth stating in context: **every route is now judged at the strict high-school cap of
9** — the sweep reports 204/204 at that tier, #4610 having removed the admin/builder
college exception. The starting point for this BI was 185 of 201 failing *with* the
looser tier applied to half of them. A check that 92% of routes failed is now one that
12% fail, at a stricter bar.

**This is not a clean A/B.** Three days of `main` separate the two sweeps, #4610 landed
between them, and the route count moved 201 → 204. What *is* cleanly attributable is the
arithmetic: deleting a non-negative term means the grade can only fall for identical
text. Typical fall 0.4–0.9; larger falls of 3.5–4.9 land on routes whose utterances were
longer.

**One route rose** — `/workforce`, 5.2 → 6.8. That cannot be this change: removing a
non-negative term cannot raise a grade for the same text. It is copy drift on that route
between the two sweeps. It still passes. Flagged rather than glossed, because a riser is
the shape a real regression would take and the next reader should know why this one
isn't one.

The 25 that still fail read as vocabulary findings someone can act on:
`/platform/identity/authorization` 14.7, `/knowledge/new` 14.7, `/admin/archetypes` 14.1,
`/platform/identity/principals` 13.6 — operator surfaces carrying genuinely polysyllabic
domain nouns, which is exactly what a word-difficulty measure should flag and what the
punctuation-driven one could never tell apart from a page of one-syllable labels.

Refs: BI-0ED0F6B3
