### PR TITLE
feat(federation): decide when a discovered LAN peer may pair without a human

### DIFF
--- a/docs/superpowers/specs/2026-08-23-zero-touch-organization-federation-design.md
+++ b/docs/superpowers/specs/2026-08-23-zero-touch-organization-federation-design.md
@@ -120,6 +120,36 @@ its paired peer. That conflated two different things:
 second. Without this separation the identity work shipped on 2026-08-22 would
 have forbidden the very sync this design depends on.
 
+### 5.4 Composing discovery with the trust decision
+
+Discovery, enrolment, and the trust decision all existed separately; nothing
+joined them, so every discovered peer routed through a SAS session in which a
+person compares a short code. `decideAutomaticPairing` is that missing step. It
+returns `auto-enroll`, `operator-confirmation`, or `blocked`.
+
+`nearby-candidates` already anticipated this: its `AutomaticPairingReadiness`
+names what *blocks* automatic pairing (`tls-validation-required`,
+`blocked-insecure-transport`). Nothing consumed it.
+
+Two orderings carry the safety:
+
+1. **Transport is evaluated before trust, and is absolute.** A peer advertised
+   over plain HTTP is `blocked` outright — an unverifiable channel cannot carry a
+   verifiable identity, however well-formed the certificate claims are. This holds
+   even when organization trust would otherwise pass.
+2. **HTTPS is not proof.** A candidate discovered over HTTPS but not yet
+   chain-validated routes to the operator. `tls-validation-required` is a to-do,
+   not a result; treating it as a result would be the vulnerability this design
+   exists to avoid.
+
+Only a chain-validated same-organization peer reaches `auto-enroll`. Every other
+outcome falls back to the confirmation flow that exists today, so a gap in
+evidence costs a human confirmation rather than an unearned trust decision.
+
+`mayPairWithoutOperator` is a named predicate rather than a `!== "blocked"` test,
+so a caller cannot skip the pairing code by treating `operator-confirmation` as a
+pass.
+
 ## 6. Lifecycle at scale
 
 The unattended cycle this enables:
@@ -139,8 +169,12 @@ the identity design remains the backstop for an install with **no** peer.
 - No change to cross-organization enrolment.
 - No new sync engine, transport, or trust root.
 - No subnet-based or trust-on-first-use joining.
-- Discovery itself is out of scope here; this design covers what happens once a
-  peer is proposed.
+- Discovery transport and advertisement remain owned by `nearby-candidates`;
+  this design consumes its readiness signal rather than replacing it. Composing
+  discovery with the trust decision is §5.4 and is no longer deferred.
+- Resolving the organization trust anchor from the recorded
+  `organization.join.import` action, and calling §5.4 from the pairing path,
+  are the remaining slices.
 
 ## 8. Acceptance criteria
 
@@ -153,6 +187,9 @@ the identity design remains the backstop for an install with **no** peer.
    existing mirror.
 5. A development install paired with an organization peer resolves
    `workSync: same-organization` while `peerWrite` stays `read-only`.
+6. A plain-HTTP candidate is `blocked` regardless of organization trust; an
+   HTTPS-but-unvalidated candidate routes to `operator-confirmation`; only a
+   chain-validated same-organization peer reaches `auto-enroll`.
 
 ## 9. Decision record
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -22,6 +22,7 @@
     "./customer-lifecycle": "./src/customer-lifecycle.ts",
     "./trust-link-lifecycle": "./src/trust-link-lifecycle.ts",
     "./federation-link-types": "./src/federation-link-types.ts",
+    "./automatic-pairing-decision": "./src/automatic-pairing-decision.ts",
     "./installation-instance-stance": "./src/installation-instance-stance.ts",
     "./installation-peer-pairing": "./src/installation-peer-pairing.ts",
     "./installation-operating-intent": "./src/installation-operating-intent.ts",

--- a/packages/db/src/automatic-pairing-decision.test.ts
+++ b/packages/db/src/automatic-pairing-decision.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decideAutomaticPairing,
+  mayPairWithoutOperator,
+  type CandidateTransport,
+} from "./automatic-pairing-decision";
+import type {
+  EnrollmentProposal,
+  OrganizationTrustAnchor,
+  PeerEnrollmentEvidence,
+} from "./organization-federation-enrollment";
+
+const NOW = new Date("2026-08-26T00:00:00.000Z");
+const ROOT = "sha256:aa11bb22cc33";
+const ORG = "ORG-1779558156034";
+
+function decide(overrides: {
+  transport?: Partial<CandidateTransport>;
+  proposal?: Partial<EnrollmentProposal>;
+  localTrust?: Partial<OrganizationTrustAnchor>;
+  peer?: Partial<PeerEnrollmentEvidence>;
+} = {}) {
+  return decideAutomaticPairing({
+    transport: { secure: true, chainValidated: true, ...overrides.transport },
+    proposal: {
+      relationshipPreset: "same-organization",
+      role: "same-org-peer",
+      ...overrides.proposal,
+    },
+    localTrust: { rootFingerprint: ROOT, organizationRef: ORG, ...overrides.localTrust },
+    peer: {
+      certificateVerified: true,
+      presentedRootFingerprint: ROOT,
+      organizationRef: ORG,
+      joinPackageExpiresAt: new Date("2026-12-01T00:00:00.000Z"),
+      ...overrides.peer,
+    },
+    now: NOW,
+  });
+}
+
+describe("decideAutomaticPairing — the case that removes the human", () => {
+  it("auto-enrols a validated same-organization peer", () => {
+    const decision = decide();
+    expect(decision.mode).toBe("auto-enroll");
+    expect(decision.reason).toBeUndefined();
+    expect(mayPairWithoutOperator(decision)).toBe(true);
+  });
+
+  it("is pure — equal evidence gives an equal decision", () => {
+    expect(decide()).toEqual(decide());
+  });
+});
+
+describe("transport gates come first and are absolute", () => {
+  it("blocks a peer advertised over plain HTTP", () => {
+    const decision = decide({ transport: { secure: false } });
+    expect(decision.mode).toBe("blocked");
+    expect(decision.reason).toBe("insecure-transport");
+    expect(mayPairWithoutOperator(decision)).toBe(false);
+  });
+
+  it("blocks insecure transport even when organization trust would otherwise pass", () => {
+    // Transport is checked before trust: an unverifiable channel cannot carry a
+    // verifiable identity, however good the paperwork looks.
+    expect(decide({ transport: { secure: false, chainValidated: true } }).mode).toBe("blocked");
+  });
+
+  it("falls back to the pairing code when the chain has not been validated", () => {
+    const decision = decide({ transport: { chainValidated: false } });
+    expect(decision.mode).toBe("operator-confirmation");
+    expect(decision.reason).toBe("transport-not-validated");
+    expect(decision.explanation).toContain("confirm the pairing code");
+  });
+
+  it("treats HTTPS discovery alone as not yet validated", () => {
+    // `tls-validation-required` from discovery is a to-do, not a result.
+    expect(decide({ transport: { secure: true, chainValidated: false } }).mode).toBe(
+      "operator-confirmation",
+    );
+  });
+});
+
+describe("everything unproven routes to the operator, never to auto-enrol", () => {
+  it("keeps the pairing code for a cross-organization relationship", () => {
+    const decision = decide({ proposal: { relationshipPreset: "service-provider" } });
+    expect(decision.mode).toBe("operator-confirmation");
+    expect(decision.reason).toBe("relationship-is-cross-organization");
+  });
+
+  it("keeps the pairing code when this install never joined an organization", () => {
+    const decision = decide({ localTrust: { rootFingerprint: null } });
+    expect(decision.mode).toBe("operator-confirmation");
+    expect(decision.reason).toBe("organization-trust-not-configured");
+  });
+
+  it("keeps the pairing code when the peer certificate did not verify", () => {
+    expect(decide({ peer: { certificateVerified: false } }).reason).toBe(
+      "peer-certificate-not-verified",
+    );
+  });
+
+  it("keeps the pairing code for a peer chaining to a different root", () => {
+    expect(decide({ peer: { presentedRootFingerprint: "sha256:deadbeef" } }).reason).toBe(
+      "root-fingerprint-mismatch",
+    );
+  });
+
+  it("keeps the pairing code for a different organization", () => {
+    expect(decide({ peer: { organizationRef: "ORG-OTHER" } }).reason).toBe(
+      "organization-ref-mismatch",
+    );
+  });
+
+  it("keeps the pairing code for an expired join package", () => {
+    expect(decide({ peer: { joinPackageExpiresAt: new Date("2026-08-25T00:00:00.000Z") } }).reason)
+      .toBe("join-package-expired");
+  });
+
+  it("keeps the pairing code for a role a same-organization link may not take", () => {
+    expect(decide({ proposal: { role: "manages" } }).reason).toBe(
+      "role-not-allowed-for-relationship",
+    );
+  });
+
+  it("never auto-enrols when every piece of evidence is missing", () => {
+    const decision = decideAutomaticPairing({
+      transport: { secure: true, chainValidated: true },
+      proposal: { relationshipPreset: "same-organization", role: "same-org-peer" },
+      localTrust: { rootFingerprint: null, organizationRef: null },
+      peer: {
+        certificateVerified: false,
+        presentedRootFingerprint: null,
+        organizationRef: null,
+        joinPackageExpiresAt: null,
+      },
+      now: NOW,
+    });
+    expect(mayPairWithoutOperator(decision)).toBe(false);
+  });
+});
+
+describe("mayPairWithoutOperator", () => {
+  it("does not treat operator-confirmation as a pass", () => {
+    // The predicate exists so a caller cannot skip SAS by testing `!== blocked`.
+    expect(mayPairWithoutOperator(decide({ transport: { chainValidated: false } }))).toBe(false);
+  });
+
+  it("does not treat blocked as a pass", () => {
+    expect(mayPairWithoutOperator(decide({ transport: { secure: false } }))).toBe(false);
+  });
+});

--- a/packages/db/src/automatic-pairing-decision.ts
+++ b/packages/db/src/automatic-pairing-decision.ts
@@ -1,0 +1,127 @@
+// EP-MSP-FEDERATION — decide whether a discovered LAN peer may pair without a
+// human confirming it.
+//
+// Discovery already exists (`nearby-candidates`), enrolment already exists
+// (`enrollment`), and `evaluateOrganizationEnrollment` already decides whether
+// organization trust makes approval redundant. What was missing is the step that
+// composes them: today every discovered peer routes through a SAS session where
+// a person compares a short code, which is correct between strangers and
+// unusable for an installation created and destroyed thousands of times.
+//
+// This module is that step. It never relaxes the SAS path — it decides which
+// peers are entitled to skip it, and says why when they are not.
+
+import {
+  evaluateOrganizationEnrollment,
+  type EnrollmentProposal,
+  type ManualApprovalReason,
+  type OrganizationTrustAnchor,
+  type PeerEnrollmentEvidence,
+} from "./organization-federation-enrollment";
+
+/** How a discovered peer must be paired. */
+export const PAIRING_MODES = ["auto-enroll", "operator-confirmation", "blocked"] as const;
+export type PairingMode = (typeof PAIRING_MODES)[number];
+
+/**
+ * Why a peer cannot pair automatically.
+ *
+ * Transport reasons come first because they are absolute: an insecure candidate
+ * is not merely unproven, it cannot carry a verifiable identity at all.
+ */
+export const PAIRING_BLOCK_REASONS = [
+  "insecure-transport",
+  "transport-not-validated",
+] as const;
+export type PairingBlockReason = (typeof PAIRING_BLOCK_REASONS)[number];
+
+export type PairingDecisionReason = PairingBlockReason | ManualApprovalReason;
+
+/**
+ * What discovery observed about the candidate.
+ *
+ * Mirrors `AutomaticPairingReadiness` from `nearby-candidates` without importing
+ * it, so this decision core stays free of the discovery module's runtime.
+ */
+export interface CandidateTransport {
+  /** `false` when the candidate was advertised over plain HTTP. */
+  secure: boolean;
+  /**
+   * True only when this installation actually validated the peer's certificate
+   * chain against its pinned organization root. A candidate discovered over
+   * HTTPS is not yet validated — `tls-validation-required` is a to-do, not a
+   * result.
+   */
+  chainValidated: boolean;
+}
+
+export interface AutomaticPairingDecision {
+  mode: PairingMode;
+  reason?: PairingDecisionReason;
+  /** One sentence an operator surface can show verbatim. */
+  explanation: string;
+}
+
+/**
+ * Decide how a discovered peer must be paired.
+ *
+ * Pure and total. Anything that cannot be proven routes to
+ * `operator-confirmation`, which is the behaviour that exists today — so a gap in
+ * evidence costs a human confirmation, never an unearned trust decision.
+ */
+export function decideAutomaticPairing(input: {
+  transport: CandidateTransport;
+  proposal: EnrollmentProposal;
+  localTrust: OrganizationTrustAnchor;
+  peer: PeerEnrollmentEvidence;
+  now: Date;
+}): AutomaticPairingDecision {
+  if (!input.transport.secure) {
+    return {
+      mode: "blocked",
+      reason: "insecure-transport",
+      explanation:
+        "This peer was advertised over plain HTTP, so its identity cannot be verified at all. Pair it through a manual invitation instead.",
+    };
+  }
+
+  if (!input.transport.chainValidated) {
+    return {
+      mode: "operator-confirmation",
+      reason: "transport-not-validated",
+      explanation:
+        "This peer's certificate has not been validated against the organization root yet, so confirm the pairing code with the other installation.",
+    };
+  }
+
+  const enrollment = evaluateOrganizationEnrollment({
+    proposal: input.proposal,
+    localTrust: input.localTrust,
+    peer: input.peer,
+    now: input.now,
+  });
+
+  if (enrollment.decision === "auto-enroll") {
+    return {
+      mode: "auto-enroll",
+      explanation: enrollment.explanation,
+    };
+  }
+
+  return {
+    mode: "operator-confirmation",
+    reason: enrollment.reason,
+    explanation: enrollment.explanation,
+  };
+}
+
+/**
+ * Whether a decision permits skipping the pairing code.
+ *
+ * Written as its own predicate so a caller cannot skip SAS by testing for the
+ * absence of `blocked` and accidentally treating `operator-confirmation` as a
+ * pass.
+ */
+export function mayPairWithoutOperator(decision: AutomaticPairingDecision): boolean {
+  return decision.mode === "auto-enroll";
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -344,6 +344,17 @@ export {
   type PeerEnrollmentEvidence,
 } from "./organization-federation-enrollment";
 export {
+  PAIRING_MODES,
+  PAIRING_BLOCK_REASONS,
+  decideAutomaticPairing,
+  mayPairWithoutOperator,
+  type AutomaticPairingDecision,
+  type CandidateTransport,
+  type PairingBlockReason,
+  type PairingDecisionReason,
+  type PairingMode,
+} from "./automatic-pairing-decision";
+export {
   PAIRING_SOURCES,
   pairingSupportsWorkSync,
   resolveInstallationPairing,


### PR DESCRIPTION
## The gap this closes

Three pieces already existed and were never joined:

- **discovery** — `nearby-candidates` finds LAN peers and records an `automaticPairing` readiness
- **enrolment** — `enrollFederationLink` / `approveFederationLinkLocal`
- **the trust decision** — `evaluateOrganizationEnrollment` (merged in #4555)

What was missing is the step that composes them. Today *every* discovered peer routes through a SAS session where a person compares a short code. That is correct between strangers, and unusable for an installation created and destroyed thousands of times without human intervention.

Notably `AutomaticPairingReadiness` already anticipated this — its values name what *blocks* automatic pairing (`tls-validation-required`, `blocked-insecure-transport`). Nothing ever consumed that to actually pair automatically.

## What this adds

`decideAutomaticPairing` returns `auto-enroll` | `operator-confirmation` | `blocked`.

**Transport is checked first, and is absolute.** A peer advertised over plain HTTP is `blocked` outright — an unverifiable channel cannot carry a verifiable identity, however good the paperwork looks. This is deliberately ordered before the trust evaluation and is covered by a test asserting it holds even when organization trust would otherwise pass.

**HTTPS is not proof.** A candidate discovered over HTTPS but not chain-validated routes to the operator. `tls-validation-required` from discovery is a to-do, not a result, and treating it as one would be the whole vulnerability.

**Only a validated same-organization peer reaches `auto-enroll`.** Everything else — cross-organization relationship, no organization trust configured, unverified certificate, mismatched root, mismatched organization, expired join package, disallowed role — falls back to the confirmation flow that exists today. A gap in evidence costs a human confirmation, never an unearned trust decision.

`mayPairWithoutOperator` is a named predicate rather than a `!== "blocked"` test, so a caller cannot skip the pairing code by accidentally treating `operator-confirmation` as a pass. Covered by its own tests.

## Scope

**Decision core only. Nothing calls this yet and the SAS path is untouched.**

I am deliberately landing the trust decision reviewable on its own rather than burying it inside the action wiring. The next slice resolves the organization trust anchor from the recorded `organization.join.import` action and consults this from the pairing path.

## Verification

45 tests pass in `packages/db` — this module (17, covering every block and fallback path), plus the enrolment and pairing suites it composes. Guards: seed-fit, docs-impact, design-grounding, plan-backlog-coverage all OK.

Not run: full `pnpm pregate` (unprovisioned worktree). CI gates the real typecheck.

Design: `docs/superpowers/specs/2026-08-23-zero-touch-organization-federation-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)