### PR TITLE
fix(tak): stop the evidence guard destroying a turn's reasoning (BI-0C0669B5)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -1919,7 +1919,10 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
           continue;
         }
         if (recovery.kind === "refuse") {
-          console.warn(`[agentic-loop] evidence-required turn unverifiable; could-not-verify (INV-1/5). route=${JSON.stringify(routeContext)}`);
+          // BI-0C0669B5: log the WITHHELD length so a turn whose reasoning was
+          // quarantined is greppable, and so the extractor's zero can be
+          // compared against what the model actually produced.
+          console.warn(`[agentic-loop] evidence-required turn unverifiable; could-not-verify (INV-1/5). route=${JSON.stringify(routeContext)} withheldChars=${recovery.withheldContent.trim().length}`);
           return {
             content: recovery.message,
             providerId: result.providerId,

--- a/apps/web/lib/tak/evidence-requirement.test.ts
+++ b/apps/web/lib/tak/evidence-requirement.test.ts
@@ -4,6 +4,8 @@ import {
   enforceEvidenceIntegrity,
   resolveEvidenceRecovery,
   INV5_UNVERIFIED_MESSAGE,
+  INV5_WITHHELD_HEADING,
+
 } from "./evidence-requirement";
 
 const OPS_DOMAIN_TOOLS = ["query_backlog", "create_backlog_item", "update_backlog_item"];
@@ -61,7 +63,11 @@ describe("enforceEvidenceIntegrity", () => {
       content: fabricated,
     });
     expect(out.blocked).toBe(true);
+    // The reply is the bare refusal — a fabricated figure must never reach the
+    // reader, labelled or not (BI-B5C358B1).
     expect(out.content).toBe(INV5_UNVERIFIED_MESSAGE);
+    // But the draft is preserved for the caller, not destroyed (BI-0C0669B5).
+    expect(out.withheldContent).toBe(fabricated);
   });
 
   it("PASSES the answer through when an authoritative tool did run", () => {
@@ -121,7 +127,10 @@ describe("resolveEvidenceRecovery", () => {
       recoveryNudgesUsed: 1,
     });
     expect(second.kind).toBe("refuse");
-    if (second.kind === "refuse") expect(second.message).toBe(INV5_UNVERIFIED_MESSAGE);
+    if (second.kind === "refuse") {
+      expect(second.message).toBe(INV5_UNVERIFIED_MESSAGE);
+      expect(second.withheldContent).toBe(fabricated);
+    }
   });
 
   it("passes when a tool ran or the turn was not evidence-required", () => {
@@ -143,5 +152,53 @@ describe("resolveEvidenceRecovery", () => {
         recoveryNudgesUsed: 0,
       }).kind,
     ).toBe("pass");
+  });
+});
+
+// BI-0C0669B5. On 2026-08-26 this guard deleted a reviewer's ~5,100-character
+// explanation of why it was declining to record a governance decision, leaving
+// only generic copy that described a different situation. The reasoning existed
+// afterwards ONLY as a truncated container-log line. The invariant is that an
+// unverified claim must not reach the reader as though verified — quarantining
+// satisfies that; deletion is not required by it and destroys the one artifact
+// a human needs to tell a blocked gate from a legitimate refusal.
+describe("an unverified turn is preserved for the operator, never destroyed (BI-0C0669B5)", () => {
+  const draft = "I read the design at the pinned commit and formed a verdict, but I am "
+    + "stopping short of recording a decision — here is why, and what I found.";
+
+  it("keeps the reply as the bare refusal so no unverified claim reaches the reader", () => {
+    const action = resolveEvidenceRecovery({
+      required: true,
+      authoritativeToolExecutions: 0,
+      content: draft,
+      recoveryNudgesUsed: 1,
+    });
+    expect(action.kind).toBe("refuse");
+    if (action.kind === "refuse") expect(action.message).toBe(INV5_UNVERIFIED_MESSAGE);
+  });
+
+  it("hands the caller the withheld draft so the reasoning survives", () => {
+    const action = resolveEvidenceRecovery({
+      required: true,
+      authoritativeToolExecutions: 0,
+      content: draft,
+      recoveryNudgesUsed: 1,
+    });
+    if (action.kind === "refuse") expect(action.withheldContent).toBe(draft);
+  });
+
+  it("preserves the draft on the integrity decision too", () => {
+    const out = enforceEvidenceIntegrity({
+      required: true,
+      authoritativeToolExecutions: 0,
+      content: draft,
+    });
+    expect(out.blocked).toBe(true);
+    expect(out.content).toBe(INV5_UNVERIFIED_MESSAGE);
+    expect(out.withheldContent).toBe(draft);
+  });
+
+  it("exposes a heading for operator surfaces that render the quarantined draft", () => {
+    expect(INV5_WITHHELD_HEADING).toContain("Unverified");
   });
 });

--- a/apps/web/lib/tak/evidence-requirement.ts
+++ b/apps/web/lib/tak/evidence-requirement.ts
@@ -23,6 +23,23 @@ export const INV5_UNVERIFIED_MESSAGE =
   "operational numbers that might be wrong. Ask me again and I'll pull the current " +
   "figures directly, or check the relevant workspace view.";
 
+/** Label for the quarantined draft wherever an operator surface renders it. */
+export const INV5_WITHHELD_HEADING = "Unverified draft (no tool evidence — do not act on it as fact):";
+
+/**
+ * BI-0C0669B5. The guard returned ONLY INV5_UNVERIFIED_MESSAGE, so the turn's
+ * real content was discarded outright. On 2026-08-26 that deleted a reviewer's
+ * ~5,100-character explanation of why it was declining to record a governance
+ * decision; the reasoning survived only as a truncated container-log line, so
+ * nobody could tell a blocked gate from a legitimate refusal.
+ *
+ * The fix deliberately does NOT put the draft back in the reply. BI-B5C358B1
+ * established that a fabricated operational figure must never reach the reader,
+ * and a labelled fabrication is still a fabrication in front of someone
+ * skimming. So the user-facing content is unchanged, and the withheld text is
+ * carried alongside for the caller to persist as an internal artifact.
+ */
+
 /** Minimum length for a reply to count as a substantive (potentially-misleading)
  *  operational answer. Below this it is a terse acknowledgement, not a claim. */
 export const SUBSTANTIVE_REPLY_MIN_CHARS = 80;
@@ -95,6 +112,9 @@ export interface EvidenceIntegrityDecision {
   content: string;
   /** True when the model's factual prose was blocked and replaced. */
   blocked: boolean;
+  /** The blocked draft, preserved for the caller to persist as an internal
+   *  artifact. Never rendered to the reader — see BI-0C0669B5. */
+  withheldContent?: string;
 }
 
 /**
@@ -122,7 +142,7 @@ export function enforceEvidenceIntegrity(params: {
   const trimmed = content.trim();
   const isSubstantive = trimmed.length >= SUBSTANTIVE_REPLY_MIN_CHARS && !trimmed.endsWith("?");
   if (!isSubstantive) return { content, blocked: false };
-  return { content: INV5_UNVERIFIED_MESSAGE, blocked: true };
+  return { content: INV5_UNVERIFIED_MESSAGE, blocked: true, withheldContent: trimmed };
 }
 
 /** The nudge that pushes a model toward fetching live data before it answers. */
@@ -136,7 +156,7 @@ export const EVIDENCE_RECOVERY_NUDGE =
 export type EvidenceRecoveryAction =
   | { kind: "pass" }
   | { kind: "nudge"; nudgeMessage: string }
-  | { kind: "refuse"; message: string };
+  | { kind: "refuse"; message: string; withheldContent: string };
 
 /**
  * Decide what the loop should do when an evidence-required turn returns text.
@@ -163,5 +183,5 @@ export function resolveEvidenceRecovery(params: {
   if (params.recoveryNudgesUsed < (params.maxRecoveryNudges ?? 1)) {
     return { kind: "nudge", nudgeMessage: EVIDENCE_RECOVERY_NUDGE };
   }
-  return { kind: "refuse", message: INV5_UNVERIFIED_MESSAGE };
+  return { kind: "refuse", message: INV5_UNVERIFIED_MESSAGE, withheldContent: params.content };
 }


### PR DESCRIPTION
When an evidence-required turn ran no authoritative tool, the INV-1/INV-5 guard
returned ONLY the could-not-verify message and discarded what the model had
actually written.

On 2026-08-26 that deleted a reviewer coworker's ~5,100-character explanation of
why it was declining to record a governance decision. The loop logged
contentLen=2536 then contentLen=2581; what reached AgentMessage was 210
characters of generic copy describing a different situation. The reasoning
survived only as a truncated container-log line, so nobody could tell a blocked
gate from a legitimate refusal of the design under review.

The reply itself is deliberately UNCHANGED. BI-B5C358B1 established that a
fabricated operational figure must never reach the reader, and its test — which
asserts the fabricated "59" is absent from the output — correctly rejected a
first attempt here that appended the draft under an "unverified" heading. A
labelled fabrication is still a fabrication in front of someone skimming.

So the draft is carried alongside instead of rendered:

- EvidenceIntegrityDecision gains optional withheldContent.
- EvidenceRecoveryAction's refuse branch carries withheldContent.
- The loop logs withheldChars so a quarantined turn is greppable and the
  extractor's executedTools=0 can be compared against what the model produced.

That last point matters: in the observed incident [tool-trace] reported
extracted=0 names=[] for adapter=claude-cli while kernel-gate-trace in the same
seconds authorised read_source_at_version, get_my_coworker_profile,
assess_my_capabilities and get_backlog_item for that turn. The guard fires on
the extractor's count, which disagreed with the gate's own record. This change
does not fix that disagreement; it makes it visible, and BI-0C0669B5 carries it.

Docs-Impact-Decision: no documented route or user-guide page changes. The
user-facing reply is byte-identical to before; the only additions are an
internal field and a log field. Behaviour is recorded on BI-0C0669B5.

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-08-23-demand-aware-model-escalation-design.md
    (§3 — measured refusals over self-report; a guard's verdict must derive from
    evidence the platform actually holds, which is the same principle this fix
    applies to the guard's own output)
- Current code substrate reviewed:
  - apps/web/lib/tak/evidence-requirement.ts (enforceEvidenceIntegrity,
    resolveEvidenceRecovery, INV5_UNVERIFIED_MESSAGE)
  - apps/web/lib/tak/agentic-loop.ts (the refuse branch that returned
    recovery.message and dropped `trimmed`)
  - apps/web/lib/tak/agentic-loop.test.ts (BI-B5C358B1's assertion that the
    fabricated figure is absent from the reply — the constraint that ruled out
    rendering the draft)
- Source of truth:
  - Live portal logs for thread cmt9ghuq100sq01lgcd36l10k on 2026-08-26:
    contentLen=2536 then 2581, against a 210-character persisted AgentMessage.
- Decision:
  - Preserve the draft as an internal field; leave the reader-facing reply
    byte-identical. Deletion was never required by the invariant, but rendering
    is forbidden by BI-B5C358B1 — so carry it, do not show it.

---

**Local CI:** `pregate:status` PASS — `aa3072736858`, evidence `cmt9i0fhb0ftx01lgix85koea`, 3:30 / 33972 log lines.

**Tests:** 1415 tak tests pass (129 files), `tsc --noEmit` clean, 52/52 preflight guards.

**The reply is byte-identical to before** — only an internal field and a log field are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)