### PR TITLE
fix(install): decide backlog capture coverage by recency, not item count (BI-9CE1A6C8)

### DIFF
--- a/apps/web/lib/install/instance-stance.test.ts
+++ b/apps/web/lib/install/instance-stance.test.ts
@@ -74,6 +74,14 @@ describe("readInstallEnvironmentClass", () => {
 });
 
 describe("holdsIrreplaceableWork", () => {
+  const receipt = (capturedAt: string, unfinishedItemCount: number) => ({
+    schemaVersion: 1 as const,
+    capturedAt,
+    bundlePath: "/d/DPF-backups/backlog",
+    itemCount: unfinishedItemCount,
+    unfinishedItemCount,
+  });
+
   it("is false when there is no unfinished work", () => {
     expect(holdsIrreplaceableWork({ unfinishedItemCount: 0, receipt: null })).toBe(false);
   });
@@ -82,17 +90,12 @@ describe("holdsIrreplaceableWork", () => {
     expect(holdsIrreplaceableWork({ unfinishedItemCount: 3, receipt: null })).toBe(true);
   });
 
-  it("is false when a capture covers the current unfinished work", () => {
+  it("is false when every unfinished item predates the capture", () => {
     expect(
       holdsIrreplaceableWork({
         unfinishedItemCount: 3,
-        receipt: {
-          schemaVersion: 1,
-          capturedAt: "2026-08-22T10:00:00.000Z",
-          bundlePath: "/d/DPF-backups/backlog",
-          itemCount: 3,
-          unfinishedItemCount: 3,
-        },
+        receipt: receipt("2026-08-22T10:00:00.000Z", 3),
+        latestUnfinishedChangeAt: "2026-08-22T09:59:00.000Z",
       }),
     ).toBe(false);
   });
@@ -101,13 +104,62 @@ describe("holdsIrreplaceableWork", () => {
     expect(
       holdsIrreplaceableWork({
         unfinishedItemCount: 5,
-        receipt: {
-          schemaVersion: 1,
-          capturedAt: "2026-08-22T10:00:00.000Z",
-          bundlePath: "/d/DPF-backups/backlog",
-          itemCount: 3,
-          unfinishedItemCount: 3,
-        },
+        receipt: receipt("2026-08-22T10:00:00.000Z", 3),
+        latestUnfinishedChangeAt: "2026-08-22T11:00:00.000Z",
+      }),
+    ).toBe(true);
+  });
+
+  it("is true when an item was edited after the capture even though none were added", () => {
+    expect(
+      holdsIrreplaceableWork({
+        unfinishedItemCount: 3,
+        receipt: receipt("2026-08-22T10:00:00.000Z", 3),
+        latestUnfinishedChangeAt: "2026-08-22T10:00:00.001Z",
+      }),
+    ).toBe(true);
+  });
+
+  // BI-9CE1A6C8. The count-based predecessor returned false here, reporting
+  // "no uncaptured work" over 75 unbundled items, because the backlog had
+  // SHRUNK since the capture (111 -> 98) while its composition changed.
+  it("is true when the backlog shrank but newer work is uncaptured", () => {
+    expect(
+      holdsIrreplaceableWork({
+        unfinishedItemCount: 98,
+        receipt: receipt("2026-08-24T06:13:10.775Z", 111),
+        latestUnfinishedChangeAt: "2026-08-25T23:44:00.000Z",
+      }),
+    ).toBe(true);
+  });
+
+  // The degenerate case: close one, file one. The count never moves, so a
+  // count comparison can never detect it.
+  it("is true when the count is unchanged but an item is newer than the capture", () => {
+    expect(
+      holdsIrreplaceableWork({
+        unfinishedItemCount: 40,
+        receipt: receipt("2026-08-22T10:00:00.000Z", 40),
+        latestUnfinishedChangeAt: "2026-08-23T08:00:00.000Z",
+      }),
+    ).toBe(true);
+  });
+
+  it("fails closed when the recency instant is missing", () => {
+    expect(
+      holdsIrreplaceableWork({
+        unfinishedItemCount: 3,
+        receipt: receipt("2026-08-22T10:00:00.000Z", 3),
+      }),
+    ).toBe(true);
+  });
+
+  it("fails closed when the receipt instant is unparseable", () => {
+    expect(
+      holdsIrreplaceableWork({
+        unfinishedItemCount: 3,
+        receipt: receipt("not-a-date", 3),
+        latestUnfinishedChangeAt: "2026-08-22T09:00:00.000Z",
       }),
     ).toBe(true);
   });
@@ -120,6 +172,8 @@ describe("loadInstanceStance", () => {
         readConfig: async (key) =>
           key === OPERATING_INTENT_CONFIG_KEY ? CONFIRMED_DEV_INTENT : null,
         countBacklogItemsByStatus: async () => 42,
+        // Every unfinished item predates the capture, so the bundle covers them.
+        latestBacklogChangeByStatus: async () => new Date("2026-08-22T09:30:00.000Z"),
       }),
       {
         readText: stateText("development"),
@@ -157,6 +211,8 @@ describe("loadInstanceStance", () => {
           return null;
         },
         countBacklogItemsByStatus: async () => 42,
+        // Every unfinished item predates the capture, so the bundle covers them.
+        latestBacklogChangeByStatus: async () => new Date("2026-08-22T09:30:00.000Z"),
       }),
       {
         readText: stateText("development"),
@@ -170,6 +226,43 @@ describe("loadInstanceStance", () => {
       },
     );
     expect(stance.teardown).toBe("permitted");
+  });
+
+  // BI-9CE1A6C8: the composed stance must require capture when the backlog has
+  // SHRUNK since the capture but newer work is uncaptured. The count-based
+  // predecessor returned "permitted" here.
+  it("requires capture when the backlog shrank but holds work newer than the capture", async () => {
+    const stance = await loadInstanceStance(
+      store({
+        readConfig: async (key) => {
+          if (key === OPERATING_INTENT_CONFIG_KEY) return CONFIRMED_DEV_INTENT;
+          if (key === BACKLOG_CAPTURE_CONFIG_KEY) {
+            return {
+              schemaVersion: 1,
+              capturedAt: "2026-08-24T06:13:10.775Z",
+              bundlePath: "/backups/backlog-captures/2026-08-24-pre-reinstall-final",
+              itemCount: 69,
+              unfinishedItemCount: 111,
+            };
+          }
+          return null;
+        },
+        countBacklogItemsByStatus: async () => 98,
+        latestBacklogChangeByStatus: async () => new Date("2026-08-25T23:44:00.000Z"),
+      }),
+      {
+        readText: stateText("development"),
+        readHostProfile: async () => ({
+          kind: "consumer" as const,
+          installMode: "consumer",
+          sourceCapable: false,
+          releaseImage: true,
+          reason: "consumer-release-install" as const,
+        }),
+      },
+    );
+    expect(stance.teardown).toBe("capture-required");
+    expect(stance.holdsIrreplaceableWork).toBe(true);
   });
 
   it("falls back to the cautious stance when the store cannot be read", async () => {

--- a/apps/web/lib/install/instance-stance.ts
+++ b/apps/web/lib/install/instance-stance.ts
@@ -6,7 +6,7 @@
 //                          canonical host tier is installer state
 //   - operating intent   → PlatformConfig `installation.operating-intent.v1`
 //   - source capability  → install host profile
-//   - uncaptured work    → backlog counts vs the last recorded durable capture
+//   - uncaptured work    → backlog recency vs the last recorded durable capture
 //
 // Every read fails open to the *most cautious* answer. An installation that
 // cannot prove it is disposable is treated as production.
@@ -73,22 +73,58 @@ function parseCaptureReceipt(raw: unknown): BacklogCaptureReceiptV1 | null {
  * Decide whether this instance currently holds work that exists nowhere else.
  *
  * Work is irreplaceable when unfinished backlog items exist and the last durable
- * capture no longer covers them. A capture that recorded fewer unfinished items
- * than the instance holds today is stale by definition.
+ * capture no longer covers them. Coverage is decided by *recency*, not by count:
+ * any unfinished item created or updated after the capture instant is work the
+ * bundle does not contain.
  */
 export function holdsIrreplaceableWork(input: {
   unfinishedItemCount: number;
   receipt: BacklogCaptureReceiptV1 | null;
+  /**
+   * The most recent create/update across unfinished items, or null when there
+   * are none. Compared against the receipt instant, because a count cannot tell
+   * a captured backlog from a differently-composed one of the same size.
+   */
+  latestUnfinishedChangeAt?: Date | string | null;
 }): boolean {
   if (input.unfinishedItemCount === 0) return false;
   if (!input.receipt) return true;
-  return input.receipt.unfinishedItemCount < input.unfinishedItemCount;
+
+  // Counts do not establish coverage. A backlog only ever grows if nothing is
+  // ever closed; in practice items are closed, retired and deferred while new
+  // ones are filed, so the count can fall while the *composition* changes
+  // entirely. A falling count then reads as "captured more than we hold" — the
+  // safest possible answer — at the exact moment new work is uncaptured.
+  //
+  // Observed on a dogfood reset install (BI-9CE1A6C8): receipt recorded 111
+  // unfinished, the instance held 98, and 75 of those 98 were filed after the
+  // capture. The stance reported "no uncaptured work" over 75 unbundled items.
+  // The degenerate case is worse: close one, file one, and the count never
+  // moves at all.
+  const capturedAt = Date.parse(input.receipt.capturedAt);
+  const latestChange =
+    input.latestUnfinishedChangeAt == null
+      ? Number.NaN
+      : new Date(input.latestUnfinishedChangeAt).getTime();
+
+  // An unreadable instant on either side is unknown coverage, which is
+  // uncaptured work — the guard fails closed.
+  if (!Number.isFinite(capturedAt) || !Number.isFinite(latestChange)) return true;
+
+  return latestChange > capturedAt;
 }
 
 /** Minimal store shape so callers can pass Prisma without this module importing it. */
 export interface InstanceStanceStore {
   readConfig(key: string): Promise<unknown>;
   countBacklogItemsByStatus(statuses: readonly string[]): Promise<number>;
+  /**
+   * Most recent create/update across items in those statuses, or null when
+   * there are none. Optional so existing callers keep working; absent leaves
+   * the freshness comparison without an instant, which the resolver treats as
+   * uncaptured work rather than assuming coverage.
+   */
+  latestBacklogChangeByStatus?(statuses: readonly string[]): Promise<Date | null>;
   /**
    * The federation links that could establish a pairing. Optional so existing
    * callers keep working; absent means no link evidence, which leaves work sync
@@ -113,6 +149,25 @@ export function prismaInstanceStanceStore(
       (await prisma.platformConfig.findUnique({ where: { key } }))?.value ?? null,
     countBacklogItemsByStatus: (statuses) =>
       prisma.backlogItem.count({ where: { status: { in: [...statuses] } } }),
+    latestBacklogChangeByStatus: async (statuses) => {
+      // createdAt and updatedAt are both consulted: an item edited after the
+      // capture is as uncaptured as one filed after it.
+      const [created, updated] = await Promise.all([
+        prisma.backlogItem.aggregate({
+          where: { status: { in: [...statuses] } },
+          _max: { createdAt: true },
+        }),
+        prisma.backlogItem.aggregate({
+          where: { status: { in: [...statuses] } },
+          _max: { updatedAt: true },
+        }),
+      ]);
+      const stamps = [created._max.createdAt, updated._max.updatedAt].filter(
+        (value): value is Date => value instanceof Date,
+      );
+      if (stamps.length === 0) return null;
+      return stamps.reduce((a, b) => (a.getTime() >= b.getTime() ? a : b));
+    },
     listFederationLinks: async () => {
       const rows = await prisma.federationLink.findMany({
         select: {
@@ -167,12 +222,16 @@ export async function loadInstanceStance(
 
   let unfinished = 0;
   let receipt: BacklogCaptureReceiptV1 | null = null;
+  let latestUnfinishedChangeAt: Date | null = null;
   try {
     unfinished = await store.countBacklogItemsByStatus(UNFINISHED_STATUSES);
     receipt = parseCaptureReceipt(await store.readConfig(BACKLOG_CAPTURE_CONFIG_KEY));
+    latestUnfinishedChangeAt =
+      (await store.latestBacklogChangeByStatus?.(UNFINISHED_STATUSES)) ?? null;
   } catch {
     // Unknown backlog state is treated as uncaptured work.
     unfinished = Math.max(unfinished, 1);
+    latestUnfinishedChangeAt = null;
   }
 
   const resolvedIntent: InstallationOperatingIntentV1 = intent ?? {
@@ -209,6 +268,12 @@ export async function loadInstanceStance(
       sourceCapable: hostProfile.sourceCapable,
       pairingIsEstablished: pairingSupportsWorkSync(pairing),
     },
-    { holdsIrreplaceableWork: holdsIrreplaceableWork({ unfinishedItemCount: unfinished, receipt }) },
+    {
+      holdsIrreplaceableWork: holdsIrreplaceableWork({
+        unfinishedItemCount: unfinished,
+        receipt,
+        latestUnfinishedChangeAt,
+      }),
+    },
   );
 }


### PR DESCRIPTION
Closes the gap behind **BI-9CE1A6C8**.

## The defect

The teardown stance reported **"no uncaptured work"** on an installation holding **75 unbundled backlog items**.

`holdsIrreplaceableWork` compared counts:

```ts
return input.receipt.unfinishedItemCount < input.unfinishedItemCount;
```

That assumes a backlog only grows. In practice items are closed, retired and deferred while new ones are filed, so the count can fall while the *composition* changes entirely — and a falling count reads as "captured more than we hold", the safest possible answer, at the exact moment new work is uncaptured.

Observed live on this dogfood reset install:

| Fact | Value |
|---|---|
| Receipt `unfinishedItemCount` | 111 (captured 2026-08-24T06:13:10Z) |
| Current unfinished (`triaging`/`open`/`in-progress`) | 98 |
| Of those, created **after** the receipt | **75** |

The stance resolved to `permitted` — *"teardown and rebuild are routine"* — over 75 items in no bundle.

Two things make it worse than a display bug:

- The same string reaches AI coworkers verbatim through the MCP handshake (`Teardown — permitted`), so an agent asked to tear down finds no brake either.
- The degenerate case never triggers at all: close one item, file one item, and the count does not move.

It also gets *more* likely the more triage hygiene an install does — closing old work actively hides new uncaptured work.

## The fix

Coverage is decided by **recency** instead of counts. The store gains an optional `latestBacklogChangeByStatus` reader — `max(createdAt, updatedAt)` across unfinished items, so an item *edited* after the capture counts as uncaptured too — and the resolver returns true when that instant is later than the receipt's `capturedAt`.

The guard **fails closed** throughout: a missing reader, an absent instant, or an unparseable date on either side all resolve to "holds irreplaceable work". That matches this module's stated contract — *"Every read fails open to the most cautious answer."*

The capture path itself was not at fault. The bundle it wrote (`/backups/backlog-captures/2026-08-24-pre-reinstall-final/`, 8 epic files) was complete and correct. Only the freshness comparison was wrong.

## Tests

Count-based cases replaced with recency cases, plus regressions for:

- the observed failure — backlog shrank 111 → 98 while holding newer uncaptured work
- the degenerate equal-count case
- an item **edited** rather than added after the capture
- both fail-closed paths (missing instant, unparseable receipt date)

Covered at unit level and through the composed `loadInstanceStance`.

## Verification

- `pnpm --filter web exec vitest run lib/install/instance-stance.test.ts` — **19/19**
- the five other suites consuming this module (operating-intent actions, identity-change-impact, identity-presentation, installation-identity-view, MCP initialize identity) — **69/69**
- `pnpm --filter web build` — clean
- pre-commit: gitleaks clean, scoped typecheck ok

No schema change, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)