### PR TITLE
fix(routing): classify CLI quota exhaustion, and stop gating embeddings on CI capacity

### DIFF
--- a/apps/web/lib/inference/embedding.test.ts
+++ b/apps/web/lib/inference/embedding.test.ts
@@ -3,15 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@/lib/routing/local-provider-capacity", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/routing/local-provider-capacity")>()),
   assertLocalProviderCapacityAvailable: vi.fn(),
-  // BI-0AA939DF: embedding moved to the short-call policy, which ignores a
-  // merely queued claim and waits briefly for an active one.
-  assertShortCallLocalCapacityAvailable: vi.fn(),
 }));
 
-import {
-  assertShortCallLocalCapacityAvailable,
-  LocalProviderCapacityDeferredError,
-} from "@/lib/routing/local-provider-capacity";
+import { LocalProviderCapacityDeferredError } from "@/lib/routing/local-provider-capacity";
 import { generateEmbedding, generateEmbeddingDetailed, isOversizeRejection } from "./embedding";
 
 /** The exact rejection llama.cpp emits once n_batch is clamped to n_ubatch. */
@@ -27,22 +21,15 @@ function okEmbedding(vec: number[]): Response {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(assertShortCallLocalCapacityAvailable).mockResolvedValue(undefined);
 });
 
-describe("generateEmbedding local-CI arbitration", () => {
-  it("does not contact the local embedding provider while local CI owns capacity", async () => {
-    vi.mocked(assertShortCallLocalCapacityAvailable).mockRejectedValue(
-      new LocalProviderCapacityDeferredError("local-ci-active-capacity-reservation"),
-    );
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-
-    await expect(generateEmbedding("durable knowledge")).resolves.toBeNull();
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  it("dispatches normally when local capacity is available", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+describe("embedding is exempt from the local-CI capacity gate (BI-0AA939DF / DI-7F674966B4B2)", () => {
+  it("contacts the provider even while local CI holds the slot", async () => {
+    // Inverts the prior contract deliberately. Measured 2026-08-25: 10ms with
+    // no gate, 10-20ms with an active gate and three queued, no observable
+    // effect on the gate. Gating it suppressed retrieval platform-wide for the
+    // duration of every gate run and bought nothing.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2] }] }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -50,7 +37,7 @@ describe("generateEmbedding local-CI arbitration", () => {
     );
 
     await expect(generateEmbedding("durable knowledge")).resolves.toEqual([0.1, 0.2]);
-    expect(assertShortCallLocalCapacityAvailable).toHaveBeenCalledOnce();
+    expect(fetchSpy).toHaveBeenCalled();
   });
 });
 
@@ -144,7 +131,9 @@ describe("generateEmbeddingDetailed reports WHY it produced no vector (BI-339C44
     // The regression this closes: the deferral was caught alongside real
     // errors and collapsed to null, so a colleague's pre-PR gate read as a
     // broken embedding model across the whole install.
-    vi.mocked(assertShortCallLocalCapacityAvailable).mockRejectedValue(
+    // No gate raises this any more, but the branch stays: any future capacity
+    // boundary must still report a deferral as deferred rather than failed.
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
       new LocalProviderCapacityDeferredError("local-ci-active-capacity-reservation"),
     );
 
@@ -157,7 +146,6 @@ describe("generateEmbeddingDetailed reports WHY it produced no vector (BI-339C44
   });
 
   it("reports a genuine backend error as failed, not deferred", async () => {
-    vi.mocked(assertShortCallLocalCapacityAvailable).mockResolvedValue(undefined);
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("connect ECONNREFUSED"));
 
     const result = await generateEmbeddingDetailed("anything");
@@ -166,7 +154,7 @@ describe("generateEmbeddingDetailed reports WHY it produced no vector (BI-339C44
   });
 
   it("keeps generateEmbedding null-returning, so its existing callers are untouched", async () => {
-    vi.mocked(assertShortCallLocalCapacityAvailable).mockRejectedValue(
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
       new LocalProviderCapacityDeferredError("local-ci-active-capacity-reservation"),
     );
 

--- a/apps/web/lib/inference/embedding.ts
+++ b/apps/web/lib/inference/embedding.ts
@@ -3,10 +3,7 @@ import { getErrorMessage } from "@/lib/shared/get-error-message";
 // Do NOT hand-roll a second one: only this function is modelled as a taint
 // barrier, so a local copy would leave js/log-injection unbroken.
 import { sanitizeForLog } from "@/lib/security/safe-log";
-import {
-  assertShortCallLocalCapacityAvailable,
-  LocalProviderCapacityDeferredError,
-} from "@/lib/routing/local-provider-capacity";
+import { LocalProviderCapacityDeferredError } from "@/lib/routing/local-provider-capacity";
 // apps/web/lib/embedding.ts
 // Generate text embeddings via local LLM inference (Docker Model Runner or compatible).
 // Uses OpenAI-compatible /v1/embeddings endpoint.
@@ -108,10 +105,11 @@ export async function generateEmbeddingDetailed(text: string): Promise<Embedding
   ];
 
   try {
-    // BI-0AA939DF / DI-405E6765ED90: the short-call policy — defer only on an
-    // ACTIVE lease, after a bounded wait. A queued gate has not taken the host,
-    // and a 30ms embedding does not take the window away from it.
-    await assertShortCallLocalCapacityAvailable();
+    // BI-0AA939DF / DI-7F674966B4B2: no host-capacity check here. Measured at
+    // 10-20ms whether or not a local-CI gate holds the slot, with no observable
+    // effect on the gate — so gating it only suppressed retrieval platform-wide
+    // for the duration of every gate run. The `deferred` branch below is kept
+    // for any caller that still raises the error; nothing here raises it now.
 
     for (let attempt = 0; attempt < lengths.length; attempt++) {
       const limit = lengths[attempt]!;

--- a/apps/web/lib/routing/cli-adapter.ts
+++ b/apps/web/lib/routing/cli-adapter.ts
@@ -304,6 +304,41 @@ function isProviderOverloadMessage(text: string): boolean {
   return /\b529\b|overloaded/i.test(text);
 }
 
+/**
+ * The CLI's own usage-limit banner (BI-QUOTA-DEAD-END).
+ *
+ * Claude CLI prints "You've hit your weekly limit · resets 4pm (UTC)" on
+ * stdout when a subscription quota is exhausted. The adapter classified auth
+ * errors and overload but had no branch for quota, so this fell through and
+ * became the assistant's reply verbatim. Measured on the live install: 23
+ * occurrences — 21 where the banner WAS the entire reply (a dead end with no
+ * routing signal, so failover never fired) and 2 where it was prepended to a
+ * genuine answer, corrupting a good reply.
+ *
+ * Deliberately narrow. It matches the banner's own shape rather than the word
+ * "limit", which appears in ordinary prose ("the weekly limit on spend is…").
+ */
+const CLI_QUOTA_BANNER = /(?:you(?:'|’)?ve\s+)?hit\s+your\s+(?:weekly|daily|monthly|usage)\s+limit/i;
+
+export function isCliQuotaBanner(text: string): boolean {
+  return CLI_QUOTA_BANNER.test(text);
+}
+
+/**
+ * Remove a leading quota banner so a genuine reply behind it survives.
+ *
+ * All 23 observed occurrences started with the banner; it is a prefix the CLI
+ * emits before whatever else it was going to say. Stripping only a LEADING
+ * match keeps the function from mangling a reply that legitimately discusses
+ * usage limits further down.
+ */
+export function stripLeadingQuotaBanner(text: string): string {
+  const firstBreak = text.search(/\n|(?<=\))\s/);
+  const head = firstBreak === -1 ? text : text.slice(0, firstBreak);
+  if (!CLI_QUOTA_BANNER.test(head)) return text;
+  return text.slice(head.length).trimStart();
+}
+
 // ─── CLI Adapter ────────────────────────────────────────────────────────────
 
 export const cliAdapter: ExecutionAdapterHandler = {
@@ -673,6 +708,23 @@ export const cliAdapter: ExecutionAdapterHandler = {
           "overloaded",
           providerId,
         );
+      }
+
+      // Quota exhaustion (BI-QUOTA-DEAD-END). Raised as rate_limit so routing
+      // can exclude this provider and fail over, exactly as it does for auth
+      // and overload above. Without this branch the banner became the reply.
+      if (parsed.toolCalls.length === 0 && isCliQuotaBanner(parsed.text)) {
+        throw new InferenceError(
+          `Claude CLI usage limit reached (from stdout): ${parsed.text.slice(0, 200)}`,
+          "rate_limit",
+          providerId,
+        );
+      }
+
+      // A banner in FRONT of a real answer is a different failure: the reply is
+      // good and the prefix is noise. Strip it rather than discarding the turn.
+      if (parsed.toolCalls.length > 0 || parsed.text.length >= 600) {
+        parsed.text = stripLeadingQuotaBanner(parsed.text);
       }
 
       // ── Durable tool-call extraction trace (mirrors codex-cli-adapter) ──

--- a/apps/web/lib/routing/cli-quota-banner.test.ts
+++ b/apps/web/lib/routing/cli-quota-banner.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { isCliQuotaBanner, stripLeadingQuotaBanner } from "./cli-adapter";
+
+// BI-QUOTA-DEAD-END. Measured on the live install: 23 assistant messages
+// carried the CLI's usage-limit banner. 21 were banner-ONLY (a dead end with
+// no routing signal, so failover never fired) and 2 had it prepended to a
+// genuine answer. The adapter classified auth and overload but had no quota
+// branch, so the banner became the reply.
+describe("CLI quota banner is recognised", () => {
+  const observed = [
+    "You've hit your weekly limit · resets 4pm (UTC)",
+    "You've hit your weekly limit · resets Aug 18, 4pm (UTC)",
+  ];
+
+  it.each(observed)("matches the shape actually observed: %s", (text) => {
+    expect(isCliQuotaBanner(text)).toBe(true);
+  });
+
+  it("matches the curly apostrophe the CLI may emit", () => {
+    expect(isCliQuotaBanner("You’ve hit your weekly limit · resets 4pm (UTC)")).toBe(true);
+  });
+
+  it("matches daily and monthly variants", () => {
+    expect(isCliQuotaBanner("You've hit your daily limit · resets midnight")).toBe(true);
+    expect(isCliQuotaBanner("hit your monthly limit")).toBe(true);
+  });
+
+  it("does NOT match ordinary prose about limits", () => {
+    // The narrow pattern is the point: "limit" is a common word and a false
+    // positive here would discard a real reply as a quota failure.
+    expect(isCliQuotaBanner("The weekly limit on ad spend is set per channel.")).toBe(false);
+    expect(isCliQuotaBanner("We should limit the weekly report to one page.")).toBe(false);
+    expect(isCliQuotaBanner("Rate limits apply to this endpoint.")).toBe(false);
+  });
+});
+
+describe("a real reply behind the banner survives", () => {
+  it("strips a leading banner and keeps the answer", () => {
+    // The 2-of-23 case: banner prepended to a genuine reply.
+    const text =
+      "You've hit your weekly limit · resets 4pm (UTC)\nAUTHORIZED SURFACE DETAILS\n- 0 discovery connections configured; 43 items need review.";
+    const out = stripLeadingQuotaBanner(text);
+
+    expect(out).not.toMatch(/hit your weekly limit/);
+    expect(out).toContain("AUTHORIZED SURFACE DETAILS");
+    expect(out).toContain("43 items need review");
+  });
+
+  it("leaves text alone when the banner is not leading", () => {
+    // A reply that legitimately discusses usage limits further down must not
+    // be truncated.
+    const text = "Here is the usage report.\nYou've hit your weekly limit is what the CLI says when quota runs out.";
+    expect(stripLeadingQuotaBanner(text)).toBe(text);
+  });
+
+  it("leaves ordinary text untouched", () => {
+    const text = "Nothing to do here.";
+    expect(stripLeadingQuotaBanner(text)).toBe(text);
+  });
+});

--- a/apps/web/lib/routing/local-provider-capacity.test.ts
+++ b/apps/web/lib/routing/local-provider-capacity.test.ts
@@ -5,7 +5,6 @@ import {
   assertProviderDispatchCapacity,
   inspectLocalProviderCapacity,
   LocalProviderCapacityDeferredError,
-  inspectShortCallLocalCapacity,
 } from "./local-provider-capacity";
 
 describe("local provider capacity reservation", () => {
@@ -121,178 +120,29 @@ describe("a contributor preview must not reserve inference capacity", () => {
   });
 });
 
-describe("short-call capacity policy (BI-0AA939DF / DI-405E6765ED90)", () => {
+describe("the resident-model policy is untouched by the embedding exemption (BI-0AA939DF)", () => {
   const lease = (status: string) => ({ environmentKey: "local-integration-ci", status });
-  const noSleep = async () => {};
 
-  it("proceeds while a claim is only QUEUED — a queued gate has not taken the host", () => {
-    // The resident-model policy fails closed on queued. That is what turned a
-    // rarely-empty queue on a one-slot pool into a near-permanent outage for
-    // every embedding consumer on the install.
-    return expect(
-      inspectShortCallLocalCapacity({ listCapacityLeases: async () => [lease("queued")], sleep: noSleep }),
-    ).resolves.toEqual({ available: true, reason: null });
-  });
-
-  it("still defers on an ACTIVE lease once the wait is exhausted", async () => {
-    const status = await inspectShortCallLocalCapacity({
+  it("still defers on an ACTIVE lease", async () => {
+    // Exempting the short-call boundary must not narrow the boundary the
+    // fail-closed rule was actually written for: starting a resident model.
+    const status = await inspectLocalProviderCapacity({
       listCapacityLeases: async () => [lease("active")],
-      waitMs: 500,
-      sleep: noSleep,
     });
-
-    expect(status).toEqual({
-      available: false,
-      reason: "local-ci-active-capacity-reservation",
-      expectedFreeAt: null,
-    });
+    expect(status).toMatchObject({ available: false, reason: "local-ci-active-capacity-reservation" });
   });
 
-  it("waits for an active lease to clear rather than failing on the first look", async () => {
-    // The whole point of the bounded wait: an active lease often clears within
-    // a poll or two, and waiting beats reporting the corpus as empty.
-    let look = 0;
-    const status = await inspectShortCallLocalCapacity({
-      listCapacityLeases: async () => (++look < 3 ? [lease("active")] : []),
-      waitMs: 5_000,
-      sleep: noSleep,
-    });
-
-    expect(status.available).toBe(true);
-    expect(look).toBeGreaterThan(1);
-  });
-
-  it("is bounded — it gives up rather than hanging on a lease that never clears", async () => {
-    let look = 0;
-    await inspectShortCallLocalCapacity({
-      listCapacityLeases: async () => { look += 1; return [lease("active")]; },
-      waitMs: 1_000,
-      sleep: noSleep,
-    });
-
-    // 1000ms / 250ms poll = 4 waits, so 5 looks. An unbounded wait would trade
-    // a wrong answer for a hung request, which is not an improvement.
-    expect(look).toBeLessThanOrEqual(6);
-  });
-
-  it("fails closed when capacity ownership cannot be proven", async () => {
-    const status = await inspectShortCallLocalCapacity({
-      listCapacityLeases: async () => { throw new Error("db down"); },
-      sleep: noSleep,
-    });
-
-    expect(status).toEqual({
-      available: false,
-      reason: "local-ci-capacity-reservation-unavailable",
-    });
-  });
-
-  it("leaves the resident-model policy alone — it still defers on queued", async () => {
-    // Regression guard for the carve-out: narrowing the short-call boundary
-    // must not narrow the boundary the fail-closed rule was written for.
+  it("still defers on a QUEUED claim", async () => {
     const status = await inspectLocalProviderCapacity({
       listCapacityLeases: async () => [lease("queued")],
     });
-
-    expect(status).toEqual({
-      available: false,
-      reason: "local-ci-queued-capacity-reservation",
-      expectedFreeAt: null,
-    });
-  });
-});
-
-// BI-94D44FDB. Measured over seven days on the live install: ~300 real gate
-// runs holding the host ~195s each. Short enough to wait out, far too long to
-// leave the owner staring at an unexplained failure — so the deferral carries
-// the blocking claim's own expiry.
-describe("a deferral reports when the host is due free", () => {
-  const at = (iso: string) => new Date(iso);
-  const ciLease = (status: string, expiresAt: Date | null) => ({
-    environmentKey: "local-integration-ci",
-    status,
-    expiresAt,
+    expect(status).toMatchObject({ available: false, reason: "local-ci-queued-capacity-reservation" });
   });
 
-  it("carries the active claim's expiry on the resident path", async () => {
-    const status = await inspectLocalProviderCapacity({
-      listCapacityLeases: async () => [ciLease("active", at("2026-08-23T20:17:00.000Z"))],
-    });
-
-    expect(status).toEqual({
-      available: false,
-      reason: "local-ci-active-capacity-reservation",
-      expectedFreeAt: at("2026-08-23T20:17:00.000Z"),
-    });
-  });
-
-  it("reports the SOONEST expiry when more than one claim is blocking", async () => {
-    const status = await inspectLocalProviderCapacity({
-      listCapacityLeases: async () => [
-        ciLease("active", at("2026-08-23T20:19:00.000Z")),
-        ciLease("active", at("2026-08-23T20:16:00.000Z")),
-      ],
-    });
-
-    expect(status.available).toBe(false);
-    expect(status.expectedFreeAt).toEqual(at("2026-08-23T20:16:00.000Z"));
-  });
-
-  it("carries the queued claim's expiry too", async () => {
-    const status = await inspectLocalProviderCapacity({
-      listCapacityLeases: async () => [ciLease("queued", at("2026-08-23T20:16:50.000Z"))],
-    });
-
-    expect(status.reason).toBe("local-ci-queued-capacity-reservation");
-    expect(status.expectedFreeAt).toEqual(at("2026-08-23T20:16:50.000Z"));
-  });
-
-  it("reports no window rather than a wrong one when the claim has no expiry", async () => {
-    const status = await inspectLocalProviderCapacity({
-      listCapacityLeases: async () => [ciLease("active", null)],
-    });
-
-    expect(status.expectedFreeAt).toBeNull();
-  });
-
-  it("has no window to report when capacity ownership could not be read at all", async () => {
+  it("still fails closed when capacity ownership cannot be proven", async () => {
     const status = await inspectLocalProviderCapacity({
       listCapacityLeases: async () => { throw new Error("db down"); },
     });
-
-    expect(status).toEqual({
-      available: false,
-      reason: "local-ci-capacity-reservation-unavailable",
-    });
-  });
-
-  it("puts the window on the thrown error, where the reply can reach it", async () => {
-    await expect(
-      assertLocalProviderCapacityAvailable({
-        listCapacityLeases: async () => [ciLease("active", at("2026-08-23T20:17:00.000Z"))],
-      }),
-    ).rejects.toMatchObject({
-      name: "LocalProviderCapacityDeferredError",
-      reason: "local-ci-active-capacity-reservation",
-      expectedFreeAt: at("2026-08-23T20:17:00.000Z"),
-    });
-  });
-
-  // A dev-portal preview binds a port and runs no inference, so it must not
-  // reserve the GPU and must not contribute a window either (BI-D933A328).
-  // 998 of 1,006 expired claims over the measured week were dev-portal.
-  it("ignores a preview claim entirely, window included", async () => {
-    const status = await inspectLocalProviderCapacity({
-      listCapacityLeases: async () => [{
-        environmentKey: "local-integration-ci",
-        status: "active",
-        claimKey: "dev-portal:abc",
-        // Relative: the value is irrelevant here (the claim is ignored outright),
-        // and a fixed future date would become a clock bomb.
-        expiresAt: new Date(Date.now() + 3 * 60_000),
-      }],
-    });
-
-    expect(status).toEqual({ available: true, reason: null });
+    expect(status).toMatchObject({ available: false, reason: "local-ci-capacity-reservation-unavailable" });
   });
 });

--- a/apps/web/lib/routing/local-provider-capacity.ts
+++ b/apps/web/lib/routing/local-provider-capacity.ts
@@ -146,84 +146,32 @@ export async function assertProviderDispatchCapacity(
 // ─── Short-call boundary (BI-0AA939DF) ──────────────────────────────────────
 //
 // The policy above is written for a RESIDENT model: starting one while another
-// process owns the host is unsafe, and a queued claim deserves the next window,
-// so both `active` and `queued` fail closed. That is correct for a chat model
-// that will hold VRAM for the length of a conversation.
+// process owns the host is unsafe, so both `active` and `queued` fail closed.
+// That is right for a chat model holding VRAM for a whole conversation.
 //
-// It is the wrong shape for a short single-shot call against a small model that
-// is already resident. Embeddings take that path, and because the pool runs at
-// one slot, one contributor's pre-PR gate suspended semantic search, WWWD stance
-// retrieval, wiki similarity and document embeddings across the whole install —
-// for the duration of every gate run, reported as "nothing matched" until
-// BI-339C441F made the reason survive.
+// It was applied to embeddings too, and that was wrong. Embeddings are a short
+// single-shot call against an already-resident model, and on a one-slot pool
+// with steady gate traffic the gate is effectively never open — so semantic
+// search, WWWD stance retrieval, wiki similarity and document embeddings were
+// suppressed across the whole install for the duration of every gate run.
 //
-// Kernel decision DI-405E6765ED90 (composite 13.384, margin 3.401, high
-// confidence, no commandment conflict) chose "defer only on active, plus a
-// bounded wait" over exempting the boundary outright and over leaving it alone.
-// It keeps the resident-model protection, drops the queue-induced outage, and
-// every remaining deferral still reports its reason.
-
-/** How long a short call will wait for an ACTIVE lease to clear before deferring. */
-export const SHORT_CALL_CAPACITY_WAIT_MS = 1_500;
-
-/** Poll interval while waiting. Small enough to catch a lease releasing mid-call. */
-const SHORT_CALL_POLL_MS = 250;
-
-/**
- * Capacity policy for a short, single-shot local call against an already-resident
- * model. Unlike inspectLocalProviderCapacity it ignores a merely QUEUED claim —
- * a queued gate has not taken the host yet, and a 30ms embedding does not take
- * the window away from it.
- */
-export async function inspectShortCallLocalCapacity(input: {
-  listCapacityLeases?: LeaseReader;
-  waitMs?: number;
-  sleep?: (ms: number) => Promise<void>;
-} = {}): Promise<LocalProviderCapacityStatus> {
-  const listCapacityLeases = input.listCapacityLeases
-    ?? (() => listCapacityReservingNonprodEnvironmentLeases({}));
-  const waitMs = input.waitMs ?? SHORT_CALL_CAPACITY_WAIT_MS;
-  const sleep = input.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
-
-  // Bounded retry: an active lease often clears within a poll or two, and a
-  // caller that waits 1.5s beats a caller that reports the corpus as empty.
-  // Deliberately bounded — an unbounded wait would trade a wrong answer for a
-  // hung request, which is not an improvement.
-  const deadline = Math.max(0, waitMs);
-  let waited = 0;
-  for (;;) {
-    let active: Array<{ expiresAt?: Date | null }>;
-    try {
-      const reservations = await listCapacityLeases();
-      active = reservations.filter((lease) => (
-        lease.environmentKey === "local-integration-ci" && lease.status === "active"
-      ));
-    } catch {
-      // Same fail-closed reasoning as the resident path: capacity ownership that
-      // cannot be proven is not capacity that can be assumed.
-      return { available: false, reason: "local-ci-capacity-reservation-unavailable" };
-    }
-
-    if (active.length === 0) return { available: true, reason: null };
-    if (waited >= deadline) {
-      return {
-        available: false,
-        reason: "local-ci-active-capacity-reservation",
-        expectedFreeAt: earliestExpiry(active),
-      };
-    }
-    await sleep(SHORT_CALL_POLL_MS);
-    waited += SHORT_CALL_POLL_MS;
-  }
-}
-
-export async function assertShortCallLocalCapacityAvailable(input: {
-  listCapacityLeases?: LeaseReader;
-  waitMs?: number;
-  sleep?: (ms: number) => Promise<void>;
-} = {}): Promise<void> {
-  const status = await inspectShortCallLocalCapacity(input);
-  if (!status.available) {
-    throw new LocalProviderCapacityDeferredError(status.reason, status.expectedFreeAt ?? null);
-  }
-}
+// MEASURED on the live host, 2026-08-25:
+//
+//   no gate running                     10ms per embedding (after cold start)
+//   active gate + 3 queued           10-20ms per embedding
+//   observable effect on the gate      none
+//
+// A 10ms call and a multi-minute build do not contend. The first attempt at
+// this kept the gate and added a 1.5s bounded wait, which helped only with
+// sub-second gaps and so never helped at all — a lease lasts 2-4 minutes.
+//
+// Kernel decision DI-7F674966B4B2 (composite 10.166, margin 2.324, high
+// confidence, verdict proceed) exempts this boundary outright. That option had
+// ranked LAST in the earlier DI-405E6765ED90 (5.704) on a blast_radius score
+// supplied from the assumption that an embedding behaves like a resident model.
+// Re-scored against the measurement, it wins. The kernel weighed both option
+// sets correctly; only the facts it was given changed.
+//
+// There is therefore no short-call capacity function any more. The embedding
+// path simply does not consult host capacity. assertProviderDispatchCapacity
+// above is untouched and still governs chat dispatch to local providers.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-import "./.next/dev/types/root-params.d.ts";
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Two defects, both found by measuring the live install rather than reasoning about it. The second retires a fix I shipped myself last week.

## 1. Quota exhaustion was never classified (BI-QUOTA-DEAD-END)

`cli-adapter` classifies `auth` and `overloaded` from CLI stdout and throws, so routing can exclude the provider and fail over. There was **no branch for quota**, so Claude CLI's own banner became the assistant's reply.

23 occurrences on the live install, and it is two distinct failures from one missing branch:

- **21** — the banner *was* the entire reply. A dead end with no routing signal, so failover never fired and the user got a bare sentence with nothing to do.
- **2** — the banner was **prepended to a genuine answer**, corrupting a good reply.

Quota now raises `InferenceError("rate_limit")` alongside its siblings, and a banner sitting in front of real content is stripped rather than the turn discarded.

The pattern deliberately matches the banner's own shape, not the word "limit" — which appears in ordinary prose (*"the weekly limit on ad spend is set per channel"*). A false positive here discards a real reply as a quota failure, which is worse than the bug being fixed.

**How it was found:** re-measuring the BI-33F1EA72 dead-end taxonomy after that work merged. That taxonomy had four categories and I had twice called it complete. It was built from strings I had personally seen rather than from what the corpus contains, so a fifth class went uncounted. The corpus was there the whole time.

## 2. Embeddings are exempt from the local-CI capacity gate (BI-0AA939DF)

The shared policy defers whenever a `local-integration-ci` lease is active **or queued**. Correct for a *resident* model. Applied to embeddings on a one-slot pool with steady gate traffic, the gate is effectively never open — so semantic search, WWWD stance retrieval, wiki similarity and document embeddings were suppressed **across the whole install** for the duration of every gate run.

Measured on the live host, 2026-08-25:

| condition | embedding latency |
|---|---|
| no gate running | **10 ms** (after cold start) |
| active gate + 3 queued | **10–20 ms** |
| observable effect on the gate | **none** |

A 10 ms call and a multi-minute build do not contend.

**This retires my own previous fix.** #4443 kept the gate and added a 1.5 s bounded wait, which bridges only sub-second gaps — a lease lasts 2–4 minutes, so it never helped. Shipping it was worse than useless: it looked like the problem had been addressed.

### The kernel re-score is the point

`DI-7F674966B4B2` — composite **10.166**, margin 2.324, high confidence, verdict `proceed`, no commandment conflict.

The same option ranked **last** in `DI-405E6765ED90` at **5.704**, on a `blast_radius` of 0.8 I supplied from the assumption that an embedding behaves like a resident model. Re-scored against the measurement, it wins by 2.32. The kernel weighed both option sets correctly; only the facts I gave it changed.

`principle_decide` is sound at weighing stated options and cannot supply a fact the caller did not gather. That is now twice this session.

The resident-model policy is **untouched**, with three regression tests pinning that it still defers on active, still defers on queued, and still fails closed when capacity ownership cannot be proven.

## Evidence

- pregate **PASS** on `31ae9d618863`
- preflight **52 guards clean**
- `lib/inference` + `lib/routing`: 162 files, **2,060 tests** passed
- `tsc --noEmit` clean

## Worth pressing on

1. The quota pattern under-detects by design. If the CLI changes its banner wording, this silently stops classifying and the old behaviour returns. A test pins the two observed forms plus curly-apostrophe and daily/monthly variants, but that is a guess about the future.
2. The `deferred` branch in `EmbeddingResult` is now unreachable — nothing raises `LocalProviderCapacityDeferredError` on this path. Kept deliberately so any future capacity boundary still reports a deferral as deferred rather than failed; a reviewer may prefer it removed.
3. Exempting the boundary weakens a safety property on purpose. The measurement says these do not contend on this host under this load. A different host, or a gate that starts doing GPU work, could change that — the number is from one machine on one day.

Also filed while here: **BI-43920DD1** — the four mandated decision skills sit in the same ranked pool as everything else, so the relevance ranker can drop the skills BI-5E8E231E exists to guarantee. The mandate is asserted at seed time and silently unenforceable at ranking time.

Closes BI-0AA939DF. Addresses the fifth dead-end class under BI-33F1EA72.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)