### PR TITLE
feat(edge): offer the published agent, diagnose a node that cannot connect, and make the page reachable

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -103,22 +103,38 @@ jobs:
           fi
 
           # 2. Build + attach the native Edge binaries from the tag's tree.
-          #    These uploaded assets are what carry per-download counters.
-          #    A build failure here must NOT delete the Release, so the make
-          #    steps run in an `if` (which suspends `set -e`); on failure we
-          #    warn and leave the source-only Release in place.
+          #
+          #    The portal offers the native download ONLY for assets actually
+          #    attached here (BI-BB919901), so a release missing them silently
+          #    degrades every Windows and macOS operator to the Docker Desktop
+          #    path, which cannot see the host's real LAN. That used to be a
+          #    `::warning::` and was therefore invisible — the release looked
+          #    successful. It now FAILS the job.
+          #
+          #    The full Makefile matrix is published, not a subset. A fleet is one
+          #    node per site, so a missing linux-amd64 or Intel-Mac binary is a
+          #    real gap even where a container would also work.
           git checkout --detach "refs/tags/${TAG}"
-          if make -C services/edge-node-go build-darwin-arm64 VERSION="${TAG}" \
-             && make -C services/edge-node-go build-windows-amd64 VERSION="${TAG}"; then
-            ( cd services/edge-node-go/bin \
-              && sha256sum dpf-edge-node-darwin-arm64 dpf-edge-node-windows-amd64.exe \
-                 > dpf-edge-node-checksums.sha256 )
-            gh release upload "${TAG}" \
-              services/edge-node-go/bin/dpf-edge-node-darwin-arm64 \
-              services/edge-node-go/bin/dpf-edge-node-windows-amd64.exe \
-              services/edge-node-go/bin/dpf-edge-node-checksums.sha256 \
-              --repo "${GITHUB_REPOSITORY}" --clobber
-            echo "Attached native Edge assets to Release ${TAG}."
-          else
-            echo "::warning::Edge binary build failed for ${TAG}; published a source-only Release. Re-run this workflow after fixing the build to attach the counted binary assets."
-          fi
+          make -C services/edge-node-go build-all VERSION="${TAG}"
+
+          EDGE_ASSETS="dpf-edge-node-linux-amd64 dpf-edge-node-linux-arm64 dpf-edge-node-darwin-amd64 dpf-edge-node-darwin-arm64 dpf-edge-node-windows-amd64.exe dpf-edge-node-windows-arm64.exe"
+
+          # Refuse to publish a partial matrix. An installable that is sometimes
+          # absent is not an installable, and the portal cannot tell "not built"
+          # apart from "not supported on this platform".
+          for asset in ${EDGE_ASSETS}; do
+            if [ ! -f "services/edge-node-go/bin/${asset}" ]; then
+              echo "::error::Edge binary ${asset} was not produced for ${TAG}. Refusing to publish a partial release."
+              exit 1
+            fi
+          done
+
+          ( cd services/edge-node-go/bin && sha256sum ${EDGE_ASSETS} > dpf-edge-node-checksums.sha256 )
+
+          UPLOAD_ARGS=""
+          for asset in ${EDGE_ASSETS} dpf-edge-node-checksums.sha256; do
+            UPLOAD_ARGS="${UPLOAD_ARGS} services/edge-node-go/bin/${asset}"
+          done
+          # shellcheck disable=SC2086
+          gh release upload "${TAG}" ${UPLOAD_ARGS} --repo "${GITHUB_REPOSITORY}" --clobber
+          echo "Attached the full native Edge asset matrix to Release ${TAG}."

--- a/apps/web/lib/actions/edge-nodes.ts
+++ b/apps/web/lib/actions/edge-nodes.ts
@@ -19,6 +19,7 @@ import { prisma } from "@dpf/db";
 import { resolveAppBaseUrl } from "@/lib/app-url";
 import { auth } from "@/lib/auth";
 import { issueBootstrapToken } from "@/lib/edge-node/enrollment";
+import { resolveNativeReleaseAssets } from "@/lib/edge-node/native-release-assets";
 import {
   buildRemoteProvisioningPlan,
   EDGE_HOST_OSES,
@@ -238,10 +239,16 @@ export async function prepareRemoteEdgeProvisioningAction(input: {
   });
   if (!issued.ok) return issued;
 
+  // Ask the release what it actually publishes, rather than believing a
+  // hardcoded list (BI-BB919901). Null — offline, rate-limited, air-gapped —
+  // renders the container path only and never blocks issuance.
+  const nativeRelease = await resolveNativeReleaseAssets();
+
   const plan = buildRemoteProvisioningPlan({
     resolvedAuthorityUrl: resolveAppBaseUrl(),
     bootstrapToken: issued.plaintext,
     os: input.os,
+    ...(nativeRelease ? { nativeRelease } : {}),
     ...(input.nodeName?.trim() ? { nodeName: input.nodeName.trim() } : {}),
     ...(input.composeRef?.trim() ? { composeRef: input.composeRef.trim() } : {}),
   });

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -5541,7 +5541,8 @@
         "dpf-doctor",
         "reconcile-installed-plugins-flag",
         "what-install-dpf-does-not-do",
-        "see-also"
+        "see-also",
+        "mapping-a-network-from-another-machine"
       ]
     },
     "docs/operations/integrations/email-postmark-setup.md": {

--- a/apps/web/lib/edge-node/native-release-assets.test.ts
+++ b/apps/web/lib/edge-node/native-release-assets.test.ts
@@ -1,0 +1,171 @@
+// BI-BB919901 — resolving what a release actually publishes.
+//
+// Every failure mode has to converge on null rather than throwing, because an
+// air-gapped install is a SUPPORTED topology. A portal that cannot reach GitHub
+// must still issue a bootstrap token and render the container command; it just
+// cannot offer the native download.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  parseReleaseAssets,
+  resetNativeReleaseAssetsCache,
+  resolveNativeReleaseAssets,
+} from "./native-release-assets";
+
+const OK_BODY = {
+  tag_name: "v2026.08.25-consumer-self-upgrade.2",
+  assets: [
+    { name: "dpf-edge-node-darwin-arm64" },
+    { name: "dpf-edge-node-windows-amd64.exe" },
+    { name: "dpf-edge-node-checksums.sha256" },
+  ],
+};
+
+const okResponse = (body: unknown) =>
+  ({ ok: true, json: async () => body }) as unknown as Response;
+
+beforeEach(() => {
+  resetNativeReleaseAssetsCache();
+});
+
+describe("parseReleaseAssets", () => {
+  it("reads the tag and every asset name", () => {
+    const parsed = parseReleaseAssets(OK_BODY, "owner/repo");
+    expect(parsed).toEqual({
+      tag: "v2026.08.25-consumer-self-upgrade.2",
+      assetNames: [
+        "dpf-edge-node-darwin-arm64",
+        "dpf-edge-node-windows-amd64.exe",
+        "dpf-edge-node-checksums.sha256",
+      ],
+      repoSlug: "owner/repo",
+    });
+  });
+
+  it("returns null for a body that is not a release", () => {
+    for (const body of [null, undefined, "string", 42, [], {}]) {
+      expect(parseReleaseAssets(body, "owner/repo")).toBeNull();
+    }
+  });
+
+  it("returns null when the tag is missing or blank", () => {
+    expect(parseReleaseAssets({ ...OK_BODY, tag_name: "" }, "owner/repo")).toBeNull();
+    expect(parseReleaseAssets({ assets: [] }, "owner/repo")).toBeNull();
+  });
+
+  it("returns an empty asset list rather than null for a source-only release", () => {
+    // publish-release.yml attaches binaries in an `if` and warns on failure, so
+    // a release with NO edge assets is a real, expected state.
+    const parsed = parseReleaseAssets({ ...OK_BODY, assets: [] }, "owner/repo");
+    expect(parsed?.assetNames).toEqual([]);
+  });
+
+  it("skips malformed asset entries instead of failing the whole read", () => {
+    const parsed = parseReleaseAssets(
+      { ...OK_BODY, assets: [{ name: "good" }, null, { }, { name: 7 }, "nope"] },
+      "owner/repo",
+    );
+    expect(parsed?.assetNames).toEqual(["good"]);
+  });
+});
+
+describe("resolveNativeReleaseAssets", () => {
+  it("returns the parsed release on success", async () => {
+    const fetchImpl = vi.fn(async () => okResponse(OK_BODY));
+    const result = await resolveNativeReleaseAssets({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      skipCache: true,
+    });
+    expect(result?.tag).toBe("v2026.08.25-consumer-self-upgrade.2");
+    expect(result?.assetNames).toContain("dpf-edge-node-darwin-arm64");
+  });
+
+  it("returns null when GitHub is unreachable — an air-gapped install is supported", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ENOTFOUND api.github.com");
+    });
+    await expect(
+      resolveNativeReleaseAssets({
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        skipCache: true,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null on a non-OK response, such as a rate limit", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 403 }) as unknown as Response);
+    await expect(
+      resolveNativeReleaseAssets({
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        skipCache: true,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when the body is not JSON", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => {
+            throw new Error("invalid json");
+          },
+        }) as unknown as Response,
+    );
+    await expect(
+      resolveNativeReleaseAssets({
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        skipCache: true,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("never throws, whatever the failure", async () => {
+    for (const impl of [
+      async () => {
+        throw new Error("boom");
+      },
+      async () => ({ ok: false }) as unknown as Response,
+      async () => ({ ok: true, json: async () => null }) as unknown as Response,
+    ]) {
+      await expect(
+        resolveNativeReleaseAssets({
+          fetchImpl: impl as unknown as typeof fetch,
+          skipCache: true,
+        }),
+      ).resolves.not.toThrow();
+    }
+  });
+
+  it("caches, so opening the provisioning panel does not hammer the API", async () => {
+    const fetchImpl = vi.fn(async () => okResponse(OK_BODY));
+    const now = () => 1_000;
+    await resolveNativeReleaseAssets({ fetchImpl: fetchImpl as unknown as typeof fetch, now });
+    await resolveNativeReleaseAssets({ fetchImpl: fetchImpl as unknown as typeof fetch, now });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-resolves once the cache expires, so a new release becomes offerable", async () => {
+    const fetchImpl = vi.fn(async () => okResponse(OK_BODY));
+    await resolveNativeReleaseAssets({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => 0,
+    });
+    await resolveNativeReleaseAssets({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => 11 * 60 * 1000,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches a null too, so an offline install does not retry on every render", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    const now = () => 5_000;
+    await resolveNativeReleaseAssets({ fetchImpl: fetchImpl as unknown as typeof fetch, now });
+    await resolveNativeReleaseAssets({ fetchImpl: fetchImpl as unknown as typeof fetch, now });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/edge-node/native-release-assets.ts
+++ b/apps/web/lib/edge-node/native-release-assets.ts
@@ -1,0 +1,95 @@
+// BI-BB919901 — what the current release actually publishes for the edge agent.
+//
+// The portal must never offer a download that 404s, and it must never withhold
+// one that exists. Both failures come from the same root cause: believing a
+// hardcoded list instead of asking. So this asks GitHub, and treats every
+// failure as "offer nothing extra" rather than as an error.
+//
+// Deliberately NOT a hardcoded asset list. The previous implementation encoded
+// "the native binary is not published yet" in a comment; publish-release.yml
+// started attaching the binaries and the comment stayed, so the portal withheld
+// a download that had existed for weeks.
+
+import type { NativeReleaseAssets } from "@/lib/edge-node/remote-provisioning";
+import { DEFAULT_REPO_SLUG } from "@/lib/edge-node/remote-provisioning";
+
+/** Cache TTL. A release's asset list does not change after publication; this
+ *  only bounds how long a NEW release takes to become offerable. */
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+let cached: { at: number; value: NativeReleaseAssets | null } | null = null;
+
+interface GitHubReleaseResponse {
+  tag_name?: unknown;
+  assets?: unknown;
+}
+
+/** Parse the fields we need, tolerating anything else the API returns. */
+export function parseReleaseAssets(
+  body: unknown,
+  repoSlug: string,
+): NativeReleaseAssets | null {
+  if (!body || typeof body !== "object") return null;
+  const release = body as GitHubReleaseResponse;
+  const tag = release.tag_name;
+  if (typeof tag !== "string" || tag.trim().length === 0) return null;
+  if (!Array.isArray(release.assets)) return null;
+
+  const assetNames = release.assets
+    .map((asset) =>
+      asset && typeof asset === "object" ? (asset as { name?: unknown }).name : null,
+    )
+    .filter((name): name is string => typeof name === "string" && name.length > 0);
+
+  return { tag: tag.trim(), assetNames, repoSlug };
+}
+
+/**
+ * Resolve the latest release's assets, or null.
+ *
+ * Null is a first-class answer, not an error: an air-gapped install, a rate
+ * limit, a network failure, or a release with no attachments all mean the same
+ * thing to the caller — render the container path only. Nothing here throws, and
+ * nothing here blocks token issuance.
+ */
+export async function resolveNativeReleaseAssets(options: {
+  repoSlug?: string;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  /** Bypass the cache; used by tests. */
+  skipCache?: boolean;
+} = {}): Promise<NativeReleaseAssets | null> {
+  const now = options.now ?? Date.now;
+  if (!options.skipCache && cached && now() - cached.at < CACHE_TTL_MS) {
+    return cached.value;
+  }
+
+  const repoSlug = options.repoSlug?.trim() || DEFAULT_REPO_SLUG;
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  let value: NativeReleaseAssets | null = null;
+  try {
+    const response = await fetchImpl(
+      `https://api.github.com/repos/${repoSlug}/releases/latest`,
+      {
+        headers: { accept: "application/vnd.github+json" },
+        signal: AbortSignal.timeout(5000),
+      },
+    );
+    if (response.ok) {
+      value = parseReleaseAssets(await response.json(), repoSlug);
+    }
+  } catch {
+    // Offline, rate-limited, timed out, or malformed — all mean "offer nothing
+    // extra". An install with no internet is a supported topology, not a fault.
+    value = null;
+  }
+
+  if (!options.skipCache) cached = { at: now(), value };
+  return value;
+}
+
+/** Test seam: drop the memoized release so the next call re-resolves. */
+export function resetNativeReleaseAssetsCache(): void {
+  cached = null;
+}

--- a/apps/web/lib/edge-node/remote-provisioning.native.test.ts
+++ b/apps/web/lib/edge-node/remote-provisioning.native.test.ts
@@ -1,0 +1,243 @@
+// BI-BB919901 — the native edge-node install path.
+//
+// The defect this closes: the module gated the native download on a hardcoded
+// "not published for download yet" comment. publish-release.yml began attaching
+// dpf-edge-node-darwin-arm64, dpf-edge-node-windows-amd64.exe and a SHA-256
+// manifest to every release, and the portal went on withholding them — offering
+// Windows and macOS operators only the Docker Desktop path, which cannot see the
+// host's real LAN.
+//
+// So the first test here is the regression: given a release that carries the
+// asset, the native command IS offered.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  NATIVE_ASSET_BY_TARGET,
+  NATIVE_CHECKSUMS_ASSET,
+  buildRemoteProvisioningPlan,
+  hasChecksumManifest,
+  renderEdgeInstallCommands,
+  resolveNativeTarget,
+} from "./remote-provisioning";
+
+/** What the live releases actually publish today, verified 2026-08-25. */
+const PUBLISHED_TODAY = [
+  "dpf-edge-node-darwin-arm64",
+  "dpf-edge-node-windows-amd64.exe",
+  NATIVE_CHECKSUMS_ASSET,
+];
+
+const release = (assetNames: readonly string[] = PUBLISHED_TODAY) => ({
+  tag: "v2026.08.25-consumer-self-upgrade.2",
+  assetNames,
+});
+
+const base = {
+  authorityUrl: "https://portal.example.internal:3000",
+  bootstrapToken: "edgeboot_testtoken",
+};
+
+describe("resolveNativeTarget", () => {
+  it("finds the published target for each OS", () => {
+    expect(resolveNativeTarget("macos", PUBLISHED_TODAY)).toBe("darwin-arm64");
+    expect(resolveNativeTarget("windows", PUBLISHED_TODAY)).toBe("windows-amd64");
+  });
+
+  it("returns null for an OS this release publishes nothing for", () => {
+    // No linux asset is attached today; Linux containers already see the real
+    // LAN via host networking, so this is a gap rather than a blocker.
+    expect(resolveNativeTarget("linux", PUBLISHED_TODAY)).toBeNull();
+  });
+
+  it("returns null when the release carries no assets at all", () => {
+    for (const os of ["linux", "macos", "windows"] as const) {
+      expect(resolveNativeTarget(os, [])).toBeNull();
+    }
+  });
+
+  it("prefers the first target in the OS preference order", () => {
+    const both = [
+      NATIVE_ASSET_BY_TARGET["darwin-amd64"],
+      NATIVE_ASSET_BY_TARGET["darwin-arm64"],
+    ];
+    expect(resolveNativeTarget("macos", both)).toBe("darwin-arm64");
+  });
+
+  it("falls back to the second target when only that one is published", () => {
+    expect(resolveNativeTarget("macos", [NATIVE_ASSET_BY_TARGET["darwin-amd64"]])).toBe(
+      "darwin-amd64",
+    );
+  });
+});
+
+describe("the regression: a published asset must be offered", () => {
+  it("offers the native command on macOS when the release carries it", () => {
+    const commands = renderEdgeInstallCommands({
+      ...base,
+      os: "macos",
+      nativeRelease: release(),
+    });
+    const native = commands.find((command) => command.kind === "native");
+    expect(native).toBeDefined();
+    expect(native?.worksToday).toBe(true);
+    expect(native?.command).toContain("dpf-edge-node-darwin-arm64");
+  });
+
+  it("offers the native command on Windows when the release carries it", () => {
+    const commands = renderEdgeInstallCommands({
+      ...base,
+      os: "windows",
+      nativeRelease: release(),
+    });
+    const native = commands.find((command) => command.kind === "native");
+    expect(native?.shell).toBe("powershell");
+    expect(native?.command).toContain("dpf-edge-node-windows-amd64.exe");
+  });
+
+  it("leads with the native command, because it is the only path that sees the LAN", () => {
+    for (const os of ["macos", "windows"] as const) {
+      const commands = renderEdgeInstallCommands({ ...base, os, nativeRelease: release() });
+      expect(commands[0]?.kind).toBe("native");
+    }
+  });
+
+  it("still offers the container path as the fallback", () => {
+    const commands = renderEdgeInstallCommands({
+      ...base,
+      os: "macos",
+      nativeRelease: release(),
+    });
+    expect(commands.some((command) => command.kind === "container")).toBe(true);
+  });
+});
+
+describe("never hand out a command that 404s", () => {
+  it("offers no native command when the release publishes none for this OS", () => {
+    const commands = renderEdgeInstallCommands({
+      ...base,
+      os: "linux",
+      nativeRelease: release(),
+    });
+    expect(commands.every((command) => command.kind === "container")).toBe(true);
+  });
+
+  it("offers no native command when no release is supplied at all (air-gapped)", () => {
+    const commands = renderEdgeInstallCommands({ ...base, os: "macos" });
+    expect(commands.every((command) => command.kind === "container")).toBe(true);
+  });
+
+  it("offers no native command when the release has an empty asset list", () => {
+    const commands = renderEdgeInstallCommands({
+      ...base,
+      os: "windows",
+      nativeRelease: release([]),
+    });
+    expect(commands.every((command) => command.kind === "container")).toBe(true);
+  });
+});
+
+describe("supply chain", () => {
+  it("verifies the download against the published checksum manifest", () => {
+    const [native] = renderEdgeInstallCommands({
+      ...base,
+      os: "macos",
+      nativeRelease: release(),
+    });
+    expect(native?.command).toContain(NATIVE_CHECKSUMS_ASSET);
+    expect(native?.command).toContain("shasum -a 256");
+  });
+
+  it("uses sha256sum on Linux and shasum on macOS", () => {
+    const linux = renderEdgeInstallCommands({
+      ...base,
+      os: "linux",
+      nativeRelease: release([NATIVE_ASSET_BY_TARGET["linux-amd64"], NATIVE_CHECKSUMS_ASSET]),
+    })[0];
+    expect(linux?.command).toContain("sha256sum");
+    expect(linux?.command).not.toContain("shasum");
+  });
+
+  it("keeps the published filename, because the manifest is keyed on it", () => {
+    const [native] = renderEdgeInstallCommands({
+      ...base,
+      os: "macos",
+      nativeRelease: release(),
+    });
+    // A rename to a friendlier name would silently break `-c` verification.
+    expect(native?.command).not.toMatch(/-o ['"]?dpf-edge-node['"]?\s/);
+  });
+
+  it("says plainly when a release ships no manifest, rather than pretending", () => {
+    const [native] = renderEdgeInstallCommands({
+      ...base,
+      os: "macos",
+      nativeRelease: release(["dpf-edge-node-darwin-arm64"]),
+    });
+    expect(native?.command).not.toContain(NATIVE_CHECKSUMS_ASSET);
+    expect(native?.note).toContain("NOT verified");
+  });
+
+  it("reports manifest presence", () => {
+    expect(hasChecksumManifest(PUBLISHED_TODAY)).toBe(true);
+    expect(hasChecksumManifest(["dpf-edge-node-darwin-arm64"])).toBe(false);
+  });
+});
+
+describe("credential handling", () => {
+  // Tailscale's auth-key guidance: a key passed as an argv flag is visible to
+  // every other process on the host while the command runs. Ours is single-use,
+  // so the exposure is bounded, but the env form costs nothing.
+  it("passes the bootstrap token as an environment variable, never an argv flag", () => {
+    for (const os of ["macos", "windows"] as const) {
+      const [native] = renderEdgeInstallCommands({ ...base, os, nativeRelease: release() });
+      expect(native?.command).toContain("DPF_BOOTSTRAP_TOKEN");
+      expect(native?.command).not.toMatch(/--(token|bootstrap-token|authkey)[= ]/);
+    }
+  });
+
+  it("runs --preflight before enrolling, so a bad connection names itself", () => {
+    const [native] = renderEdgeInstallCommands({
+      ...base,
+      os: "macos",
+      nativeRelease: release(),
+    });
+    expect(native?.command).toContain("--preflight");
+  });
+});
+
+describe("buildRemoteProvisioningPlan", () => {
+  it("tells the operator the native path is available when it is", () => {
+    const plan = buildRemoteProvisioningPlan({
+      resolvedAuthorityUrl: base.authorityUrl,
+      bootstrapToken: base.bootstrapToken,
+      os: "macos",
+      nativeRelease: release(),
+    });
+    expect(plan.commands[0]?.kind).toBe("native");
+    expect(plan.nativeBinaryNote).toContain("sees the host's real NICs");
+    expect(plan.nativeBinaryNote).not.toContain("not published");
+  });
+
+  it("explains the absence honestly when no asset exists for the host", () => {
+    const plan = buildRemoteProvisioningPlan({
+      resolvedAuthorityUrl: base.authorityUrl,
+      bootstrapToken: base.bootstrapToken,
+      os: "linux",
+      nativeRelease: release(),
+    });
+    expect(plan.nativeBinaryNote).toContain("no native agent");
+    expect(plan.commands.every((command) => command.kind === "container")).toBe(true);
+  });
+
+  it("still flags an unreachable Authority URL alongside the native command", () => {
+    const plan = buildRemoteProvisioningPlan({
+      resolvedAuthorityUrl: "http://localhost:3000",
+      bootstrapToken: base.bootstrapToken,
+      os: "windows",
+      nativeRelease: release(),
+    });
+    expect(plan.authorityUrlIssues).toContain("loopback");
+    expect(plan.commands[0]?.kind).toBe("native");
+  });
+});

--- a/apps/web/lib/edge-node/remote-provisioning.native.test.ts
+++ b/apps/web/lib/edge-node/remote-provisioning.native.test.ts
@@ -215,7 +215,7 @@ describe("buildRemoteProvisioningPlan", () => {
       nativeRelease: release(),
     });
     expect(plan.commands[0]?.kind).toBe("native");
-    expect(plan.nativeBinaryNote).toContain("sees the host's real NICs");
+    expect(plan.nativeBinaryNote).toContain("sees the real network");
     expect(plan.nativeBinaryNote).not.toContain("not published");
   });
 
@@ -226,7 +226,7 @@ describe("buildRemoteProvisioningPlan", () => {
       os: "linux",
       nativeRelease: release(),
     });
-    expect(plan.nativeBinaryNote).toContain("no native agent");
+    expect(plan.nativeBinaryNote).toContain("No native agent is published");
     expect(plan.commands.every((command) => command.kind === "container")).toBe(true);
   });
 

--- a/apps/web/lib/edge-node/remote-provisioning.ts
+++ b/apps/web/lib/edge-node/remote-provisioning.ts
@@ -8,12 +8,23 @@
 // action in `lib/actions/edge-nodes.ts` resolves the URL + issues the token
 // and calls this.
 //
-// What works TODAY: the container path — fetch the single standalone compose
-// file by URL and `docker compose up` with the Authority URL + token passed
-// inline as environment. The signed, downloadable native Go binary (Mode 4,
-// the full-LAN-fidelity path on Windows/macOS) is not published for download
-// yet; it is surfaced as a note, not a runnable command, so we never hand the
-// operator a command that 404s.
+// Two paths are rendered:
+//
+//   - the CONTAINER path — fetch the standalone compose file by URL and
+//     `docker compose up`. Full discovery fidelity on Linux via host networking;
+//     on Docker Desktop it enrols and proves the path but cannot see the host's
+//     real LAN.
+//   - the NATIVE path — download the signed Go binary for the host, verify it
+//     against the release's published SHA-256 manifest, then run it. This is the
+//     full-LAN-fidelity path on Windows and macOS.
+//
+// The native path is rendered ONLY for assets the caller proves are present on
+// the release (`nativeRelease.assetNames`). This module used to gate it on a
+// hardcoded "not published yet" comment, which went stale the day
+// publish-release.yml began attaching the binaries — the portal then withheld a
+// download that had existed for weeks, and on Windows/macOS offered only the
+// Docker path that cannot see the LAN. Deriving availability from the release
+// itself is what stops that recurring (BI-BB919901).
 //
 // Spec: docs/superpowers/specs/2026-06-19-edge-node-deployment-topology-and-remote-provisioning-design.md §8
 
@@ -30,6 +41,70 @@ export type AuthorityUrlIssue =
 export const DEFAULT_REPO_SLUG = "OpenDigitalProductFactory/opendigitalproductfactory";
 export const DEFAULT_COMPOSE_REF = "main";
 const STANDALONE_COMPOSE_FILE = "docker-compose.edge-standalone.yml";
+
+/** The SHA-256 manifest published alongside the native binaries. */
+export const NATIVE_CHECKSUMS_ASSET = "dpf-edge-node-checksums.sha256";
+
+/**
+ * Native build targets and the release asset each is published as.
+ *
+ * services/edge-node-go/Makefile cross-compiles all six. WHICH of them a given
+ * release actually carries is deliberately not encoded here — it is read off the
+ * release, because a second hardcoded list is exactly what went stale before.
+ */
+export const NATIVE_ASSET_BY_TARGET = {
+  "linux-amd64": "dpf-edge-node-linux-amd64",
+  "linux-arm64": "dpf-edge-node-linux-arm64",
+  "darwin-amd64": "dpf-edge-node-darwin-amd64",
+  "darwin-arm64": "dpf-edge-node-darwin-arm64",
+  "windows-amd64": "dpf-edge-node-windows-amd64.exe",
+  "windows-arm64": "dpf-edge-node-windows-arm64.exe",
+} as const;
+
+export type EdgeNativeTarget = keyof typeof NATIVE_ASSET_BY_TARGET;
+
+/** Preference order per OS; the first target whose asset exists is offered. */
+const NATIVE_TARGETS_BY_OS: Record<EdgeHostOs, readonly EdgeNativeTarget[]> = {
+  linux: ["linux-amd64", "linux-arm64"],
+  macos: ["darwin-arm64", "darwin-amd64"],
+  windows: ["windows-amd64", "windows-arm64"],
+};
+
+/**
+ * What the caller knows about the release the binary would come from.
+ *
+ * `assetNames` is the literal list of files attached to that release. An empty
+ * list — or an omitted `nativeRelease` — renders NO native command, which is the
+ * correct degraded state for an air-gapped install or an unreachable GitHub. The
+ * rule is never to hand an operator a command that 404s, and reading the release
+ * is how that rule is kept without freezing a belief in a comment.
+ */
+export interface NativeReleaseAssets {
+  tag: string;
+  assetNames: readonly string[];
+  repoSlug?: string;
+}
+
+/** The native target to offer for this OS, or null when none is published. */
+export function resolveNativeTarget(
+  os: EdgeHostOs,
+  assetNames: readonly string[],
+): EdgeNativeTarget | null {
+  const available = new Set(assetNames);
+  for (const target of NATIVE_TARGETS_BY_OS[os]) {
+    if (available.has(NATIVE_ASSET_BY_TARGET[target])) return target;
+  }
+  return null;
+}
+
+/** True when the release also publishes the checksum manifest. */
+export function hasChecksumManifest(assetNames: readonly string[]): boolean {
+  return assetNames.includes(NATIVE_CHECKSUMS_ASSET);
+}
+
+function releaseAssetUrl(repoSlug: string, tag: string, asset: string): string {
+  return `https://github.com/${repoSlug}/releases/download/${encodeURIComponent(tag)}/${asset}`;
+}
 
 export interface RenderedInstallCommand {
   /** Stable id for UI keys / telemetry. */
@@ -128,6 +203,99 @@ function rawComposeUrl(repoSlug: string, composeRef: string): string {
 }
 
 /**
+ * Render the native download-verify-run command for one target.
+ *
+ * Three properties this deliberately keeps:
+ *
+ *  - the download is CHECKSUM-VERIFIED against the release's own manifest
+ *    before anything executes. A one-line installer that pipes an unverified
+ *    binary into a shell is the supply-chain shape every published guidance
+ *    warns about; the manifest is already produced by publish-release.yml, so
+ *    verifying costs one extra fetch.
+ *  - the asset keeps its published FILENAME, because the checksum manifest is
+ *    keyed on it. Renaming to a friendly name breaks `-c` verification.
+ *  - the bootstrap token is passed as an ENVIRONMENT VARIABLE rather than an
+ *    argv flag, following Tailscale's auth-key guidance. The token is single-use
+ *    so the exposure is bounded either way, but argv is visible to every other
+ *    process on the host while it runs, and env assignment is not.
+ */
+export function renderNativeInstallCommand(input: {
+  authorityUrl: string;
+  bootstrapToken: string;
+  os: EdgeHostOs;
+  target: EdgeNativeTarget;
+  release: NativeReleaseAssets;
+  nodeName?: string;
+}): RenderedInstallCommand {
+  const repoSlug = input.release.repoSlug?.trim() || DEFAULT_REPO_SLUG;
+  const asset = NATIVE_ASSET_BY_TARGET[input.target];
+  const binaryUrl = releaseAssetUrl(repoSlug, input.release.tag, asset);
+  const checksumUrl = releaseAssetUrl(repoSlug, input.release.tag, NATIVE_CHECKSUMS_ASSET);
+  const verifiable = hasChecksumManifest(input.release.assetNames);
+  const nodeName = input.nodeName?.trim();
+
+  if (input.os === "windows") {
+    const lines = [
+      `Invoke-WebRequest -UseBasicParsing ${psQuote(binaryUrl)} -OutFile ${psQuote(asset)}`,
+      ...(verifiable
+        ? [
+            `Invoke-WebRequest -UseBasicParsing ${psQuote(checksumUrl)} -OutFile ${psQuote(NATIVE_CHECKSUMS_ASSET)}`,
+            `$expected = ((Select-String -Path ${psQuote(NATIVE_CHECKSUMS_ASSET)} -SimpleMatch ${psQuote(asset)}).Line -split '\s+')[0]`,
+            `$actual = (Get-FileHash ${psQuote(asset)} -Algorithm SHA256).Hash.ToLower()`,
+            `if ($actual -ne $expected) { throw "Checksum mismatch - do not run this file." }`,
+          ]
+        : []),
+      `$env:DPF_AUTHORITY_URL = ${psQuote(input.authorityUrl)}`,
+      `$env:DPF_BOOTSTRAP_TOKEN = ${psQuote(input.bootstrapToken)}`,
+      ...(nodeName ? [`$env:DPF_EDGE_NODE_NAME = ${psQuote(nodeName)}`] : []),
+      `.\\${asset} --preflight`,
+      `.\\${asset}`,
+    ];
+    return {
+      id: `windows-native-${input.target}`,
+      label: "Windows — native agent (real LAN)",
+      kind: "native",
+      worksToday: true,
+      shell: "powershell",
+      command: lines.join("\n"),
+      note: verifiable
+        ? "Sees the host's real NICs, unlike the Docker Desktop path. The download is checked against the release's published SHA-256 before it runs, and --preflight reports a named cause if it cannot reach the Authority."
+        : "Sees the host's real NICs, unlike the Docker Desktop path. This release published no checksum manifest, so the download is NOT verified — prefer a release that carries one.",
+    };
+  }
+
+  const envInline = [
+    `DPF_AUTHORITY_URL=${shQuote(input.authorityUrl)}`,
+    `DPF_BOOTSTRAP_TOKEN=${shQuote(input.bootstrapToken)}`,
+    ...(nodeName ? [`DPF_EDGE_NODE_NAME=${shQuote(nodeName)}`] : []),
+  ].join(" ");
+  const shaTool = input.os === "macos" ? "shasum -a 256" : "sha256sum";
+  const lines = [
+    `curl -fsSL -o ${shQuote(asset)} ${shQuote(binaryUrl)}`,
+    ...(verifiable
+      ? [
+          `curl -fsSL -o ${shQuote(NATIVE_CHECKSUMS_ASSET)} ${shQuote(checksumUrl)}`,
+          `${shaTool} --ignore-missing -c ${shQuote(NATIVE_CHECKSUMS_ASSET)}`,
+        ]
+      : []),
+    `chmod +x ${shQuote(asset)}`,
+    `${envInline} ./${asset} --preflight`,
+    `${envInline} ./${asset}`,
+  ];
+  return {
+    id: `${input.os}-native-${input.target}`,
+    label: input.os === "macos" ? "macOS — native agent (real LAN)" : "Linux — native agent",
+    kind: "native",
+    worksToday: true,
+    shell: "bash",
+    command: lines.join(" && \\\n"),
+    note: verifiable
+      ? "Sees the host's real NICs, unlike the Docker Desktop path. The download is checked against the release's published SHA-256 before it runs, and --preflight reports a named cause if it cannot reach the Authority."
+      : "Sees the host's real NICs. This release published no checksum manifest, so the download is NOT verified — prefer a release that carries one.",
+  };
+}
+
+/**
  * Render the install command(s) for one host OS. The container path is the
  * works-today, no-clone path for every OS; on macOS/Windows it enrolls and
  * proves the path but Docker Desktop can't see the real LAN (the native
@@ -140,12 +308,34 @@ export function renderEdgeInstallCommands(input: {
   nodeName?: string;
   repoSlug?: string;
   composeRef?: string;
+  /** Present = offer the native path first, for targets this release publishes. */
+  nativeRelease?: NativeReleaseAssets;
 }): RenderedInstallCommand[] {
   const { authorityUrl, bootstrapToken, os } = input;
   const repoSlug = input.repoSlug?.trim() || DEFAULT_REPO_SLUG;
   const composeRef = input.composeRef?.trim() || DEFAULT_COMPOSE_REF;
   const nodeName = input.nodeName?.trim();
   const composeUrl = rawComposeUrl(repoSlug, composeRef);
+
+  // The native command leads when the release publishes an asset for this host:
+  // on Windows and macOS it is the only path that sees the real LAN, so burying
+  // it under the container command is what made the good path invisible.
+  const nativeTarget = input.nativeRelease
+    ? resolveNativeTarget(os, input.nativeRelease.assetNames)
+    : null;
+  const native: RenderedInstallCommand[] =
+    nativeTarget && input.nativeRelease
+      ? [
+          renderNativeInstallCommand({
+            authorityUrl,
+            bootstrapToken,
+            os,
+            target: nativeTarget,
+            release: input.nativeRelease,
+            ...(nodeName ? { nodeName } : {}),
+          }),
+        ]
+      : [];
 
   if (os === "windows") {
     // PowerShell: download the compose file, set env for this process, bring it up.
@@ -157,6 +347,7 @@ export function renderEdgeInstallCommands(input: {
       `docker compose -f ${STANDALONE_COMPOSE_FILE} up -d`,
     ];
     return [
+      ...native,
       {
         id: "windows-container",
         label: "Windows — Docker Desktop (enrollment proof)",
@@ -184,6 +375,7 @@ export function renderEdgeInstallCommands(input: {
 
   if (os === "macos") {
     return [
+      ...native,
       {
         id: "macos-container",
         label: "macOS — Docker Desktop (enrollment proof)",
@@ -198,6 +390,7 @@ export function renderEdgeInstallCommands(input: {
   }
 
   return [
+    ...native,
     {
       id: "linux-container",
       label: "Linux — Docker (real LAN)",
@@ -211,8 +404,13 @@ export function renderEdgeInstallCommands(input: {
   ];
 }
 
-const NATIVE_BINARY_NOTE =
-  "Full-fidelity LAN discovery on Windows/macOS needs the native Mode 4 binary (services/edge-node-go), which sees the host's real NICs. A signed, one-click download is not published yet — until it ships, build it with `make build` from services/edge-node-go, or use the container command above to prove enrollment. Tracked under EP-EDGE-TOPOLOGY.";
+/** Shown when this release publishes no native asset for the chosen host. */
+const NATIVE_BINARY_UNAVAILABLE_NOTE =
+  "This release publishes no native agent for this operating system and architecture, so only the container command is offered. On Docker Desktop that enrols the node and proves the path but cannot see the host's real LAN. Build one with `make build-all` from services/edge-node-go, or use a release that carries the asset.";
+
+/** Shown when the native path IS offered. */
+const NATIVE_BINARY_AVAILABLE_NOTE =
+  "The native agent sees the host's real NICs, which the Docker Desktop container cannot. Its download is verified against the release's published SHA-256 manifest before it runs, and `--preflight` names the cause if it cannot reach the Authority.";
 
 /**
  * Compose a full remote-provisioning plan: assess the URL, render the
@@ -227,6 +425,8 @@ export function buildRemoteProvisioningPlan(input: {
   nodeName?: string;
   repoSlug?: string;
   composeRef?: string;
+  /** Release assets resolved by the caller. Omit for air-gapped / offline. */
+  nativeRelease?: NativeReleaseAssets;
 }): RemoteProvisioningPlan {
   const { url, issues } = assessAuthorityUrl(input.resolvedAuthorityUrl);
   // Render against the resolved URL when we have one; otherwise a clearly
@@ -240,7 +440,9 @@ export function buildRemoteProvisioningPlan(input: {
     ...(input.nodeName ? { nodeName: input.nodeName } : {}),
     ...(input.repoSlug ? { repoSlug: input.repoSlug } : {}),
     ...(input.composeRef ? { composeRef: input.composeRef } : {}),
+    ...(input.nativeRelease ? { nativeRelease: input.nativeRelease } : {}),
   });
+  const offeredNative = commands.some((command) => command.kind === "native");
   return {
     authorityUrl,
     authorityUrlIssues: issues,
@@ -248,6 +450,8 @@ export function buildRemoteProvisioningPlan(input: {
     commands,
     approveHint:
       "The node enrolls as pending. Approve it here on this Edge Nodes page; it submits its first discovery run within one sweep interval (~5 min).",
-    nativeBinaryNote: NATIVE_BINARY_NOTE,
+    nativeBinaryNote: offeredNative
+      ? NATIVE_BINARY_AVAILABLE_NOTE
+      : NATIVE_BINARY_UNAVAILABLE_NOTE,
   };
 }

--- a/apps/web/lib/edge-node/remote-provisioning.ts
+++ b/apps/web/lib/edge-node/remote-provisioning.ts
@@ -406,11 +406,11 @@ export function renderEdgeInstallCommands(input: {
 
 /** Shown when this release publishes no native asset for the chosen host. */
 const NATIVE_BINARY_UNAVAILABLE_NOTE =
-  "This release publishes no native agent for this operating system and architecture, so only the container command is offered. On Docker Desktop that enrols the node and proves the path but cannot see the host's real LAN. Build one with `make build-all` from services/edge-node-go, or use a release that carries the asset.";
+  "No native agent is published for this system, so only the container command is offered. On Docker Desktop that enrols the node but cannot see the real LAN.";
 
 /** Shown when the native path IS offered. */
 const NATIVE_BINARY_AVAILABLE_NOTE =
-  "The native agent sees the host's real NICs, which the Docker Desktop container cannot. Its download is verified against the release's published SHA-256 manifest before it runs, and `--preflight` names the cause if it cannot reach the Authority.";
+  "The native agent sees the real network, which a Docker Desktop container cannot. Its download is checksum-verified, and `--preflight` names any connection problem.";
 
 /**
  * Compose a full remote-provisioning plan: assess the URL, render the

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -723,12 +723,9 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     capabilityKey: "view_platform",
   },
   {
-    // Edge Nodes had a route, six operator documents, and NO way to reach it:
-    // one in-product link, from the Connections page, which an operator only
-    // opens if they are already setting up federation. The documented path
-    // "Platform > Edge Nodes" did not exist as a navigable path (BI-2EC8906A).
-    // It matters most for the shapes with more than one node: an MSP runs one
-    // per customer per site, retail one per location.
+    // BI-2EC8906A: the route and six operator docs existed; the documented
+    // path "Platform > Edge Nodes" did not. Matters most where node count > 1
+    // (MSP: one per customer per site; retail: one per location).
     key: "platform-edge-nodes",
     label: "Edge Nodes",
     path: "/platform/edge-nodes",

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -647,6 +647,7 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
       "/platform/tools/discovery",
       "/platform/tools/inventory",
       "/platform/federation-links",
+      "/platform/edge-nodes",
     ],
   },
   {
@@ -715,6 +716,22 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
     key: "platform-federation-links",
     label: "Connections",
     path: "/platform/federation-links",
+    parentPath: "/platform/tools",
+    domain: "platform",
+    audienceModes: ["operator"],
+    destinationKind: "section-page",
+    capabilityKey: "view_platform",
+  },
+  {
+    // Edge Nodes had a route, six operator documents, and NO way to reach it:
+    // one in-product link, from the Connections page, which an operator only
+    // opens if they are already setting up federation. The documented path
+    // "Platform > Edge Nodes" did not exist as a navigable path (BI-2EC8906A).
+    // It matters most for the shapes with more than one node: an MSP runs one
+    // per customer per site, retail one per location.
+    key: "platform-edge-nodes",
+    label: "Edge Nodes",
+    path: "/platform/edge-nodes",
     parentPath: "/platform/tools",
     domain: "platform",
     audienceModes: ["operator"],

--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1653,7 +1653,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n    - strong\n      - text\n    - text\n    - strong\n      - text\n    - text\n    - code\n      - text\n    - text\n  - text\n  - table\n    - rowgroup\n      - row\n        - columnheader\n    - rowgroup\n      - row\n        - cell\n          - text\n  - group\n    - button\n    - table\n      - rowgroup\n        - row\n          - columnheader\n      - rowgroup\n        - row\n          - cell\n            - text"
     },
     "/platform/edge-nodes": {
-      "defaultVisibleWords": 159,
+      "defaultVisibleWords": 162,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-import "./.next/dev/types/root-params.d.ts";
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/operations/install.md
+++ b/docs/operations/install.md
@@ -269,3 +269,18 @@ For the avoidance of doubt, the installer:
 - Planning library: [`packages/dpf-bootstrap/README.md`](../../packages/dpf-bootstrap/README.md)
 - State schema: [`scripts/installer/install-state.schema.json`](../../scripts/installer/install-state.schema.json)
 - Backlog: BI-A9F60372 (EP-1FABA22D), BI-4B17051B (EP-INSTALL-HARDENING-2026-05-23)
+
+## Mapping a network from another machine
+
+Installing DPF does not start an edge node — a small host-resident agent that
+maps a network and reports back. Mapping a network is a deliberate choice, made
+at setup or later under **Platform → Edge Nodes**.
+
+You want one when the network you care about is not the one your portal sits on:
+a branch office, a customer site, a shop floor. Businesses with several
+locations run one per location, and IT service companies run one per customer
+per site, so each estate stays separate.
+
+Start with the [edge node deployment topology guide](../edge-node/deployment-topology.md),
+which covers where a node can run and how it connects. For many nodes at once,
+see [fleet operations](../edge-node/fleet-operations.md).

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -46,7 +46,7 @@ apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp/packs/backlog-pack.dispatch.test.ts	874
 apps/web/lib/mcp/packs/contribution-hive-pack.ts	855
 apps/web/lib/mcp/packs/sandbox-pack.ts	921
-apps/web/lib/navigation/portal-navigation-model.ts	965
+apps/web/lib/navigation/portal-navigation-model.ts	979
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1380
 apps/web/lib/routing/chat-adapter.test.ts	1073

--- a/services/edge-node-go/cmd/dpf-edge-node/main.go
+++ b/services/edge-node-go/cmd/dpf-edge-node/main.go
@@ -77,6 +77,9 @@ func main() {
 	printFixtureMode := flag.Bool("print-enroll-fixture", false,
 		"Print a sample EnrollRequest as JSON to stdout and exit. Used to "+
 			"seed the Authority-side wire-contract parity fixtures.")
+	preflightMode := flag.Bool("preflight", false,
+		"Check whether this host can reach and enrol with its Authority, print "+
+			"one named cause, and exit. Non-zero exit means not ready.")
 	flag.Parse()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
@@ -84,6 +87,16 @@ func main() {
 
 	if *printFixtureMode {
 		printEnrollFixture()
+		return
+	}
+
+	// Runs BEFORE enrollment in the portal-rendered install command, so a bad
+	// Authority URL, an unsynced clock, or a container with no LAN visibility
+	// names itself on the machine where the problem is (BI-BB919901).
+	if *preflightMode {
+		if !runPreflight(context.Background()) {
+			os.Exit(1)
+		}
 		return
 	}
 

--- a/services/edge-node-go/cmd/dpf-edge-node/preflight.go
+++ b/services/edge-node-go/cmd/dpf-edge-node/preflight.go
@@ -1,0 +1,129 @@
+package main
+
+// `dpf-edge-node --preflight` — gather the host and network facts, then let
+// internal/preflight name ONE cause (BI-BB919901).
+//
+// The rendered install command runs this before enrolling, so an operator who
+// mistyped the Authority URL, has no NTP, or is on a Docker Desktop container
+// with no LAN visibility learns which of those it is, on the machine where the
+// problem actually lives, instead of reading a transport error.
+//
+// Gathering is here; judging is in internal/preflight, which is pure and fully
+// unit-tested. This file only does I/O.
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/opendigitalproductfactory/dpf/services/edge-node-go/internal/collect"
+	"github.com/opendigitalproductfactory/dpf/services/edge-node-go/internal/config"
+	"github.com/opendigitalproductfactory/dpf/services/edge-node-go/internal/preflight"
+	"github.com/opendigitalproductfactory/dpf/services/edge-node-go/internal/state"
+)
+
+const preflightTimeout = 8 * time.Second
+
+// gatherPreflight performs the observations. Every probe is individually
+// guarded: a probe that cannot run leaves its Attempted flag false, which
+// internal/preflight treats as "not observed" rather than as a failure.
+func gatherPreflight(ctx context.Context, cfg *config.Config) preflight.Observations {
+	obs := preflight.Observations{
+		AuthorityURL:   cfg.AuthorityURL,
+		BootstrapToken: cfg.BootstrapToken,
+		LANAddresses:   collect.RealLANAddresses(),
+	}
+
+	// A node with prior state has already enrolled and needs no token.
+	if st, err := state.Load(cfg.StateDir); err == nil && st != nil {
+		obs.AlreadyEnrolled = true
+	}
+
+	parsed, err := url.Parse(cfg.AuthorityURL)
+	if err != nil || parsed.Host == "" {
+		// Malformed — let Evaluate name it; no point probing.
+		return obs
+	}
+
+	host := parsed.Hostname()
+	if net.ParseIP(host) == nil {
+		obs.DNSAttempted = true
+		resolver := &net.Resolver{}
+		lookupCtx, cancel := context.WithTimeout(ctx, preflightTimeout)
+		addrs, lookupErr := resolver.LookupHost(lookupCtx, host)
+		cancel()
+		obs.DNSResolved = lookupErr == nil && len(addrs) > 0
+		if !obs.DNSResolved {
+			return obs
+		}
+	}
+
+	obs.ReachAttempted = true
+	reqCtx, cancel := context.WithTimeout(ctx, preflightTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, strings.TrimRight(cfg.AuthorityURL, "/")+"/api/health", nil)
+	if err != nil {
+		obs.ReachError = err.Error()
+		return obs
+	}
+	resp, err := (&http.Client{Timeout: preflightTimeout}).Do(req)
+	if err != nil {
+		obs.ReachError = err.Error()
+		// Distinguish "the certificate is not trusted" from "nothing answered".
+		// They look the same in a transport error and need opposite remedies.
+		var unknownAuthority x509.UnknownAuthorityError
+		var hostnameErr x509.HostnameError
+		var certInvalid x509.CertificateInvalidError
+		if errors.As(err, &unknownAuthority) || errors.As(err, &hostnameErr) || errors.As(err, &certInvalid) {
+			obs.TLSUntrusted = true
+		}
+		return obs
+	}
+	defer resp.Body.Close()
+	obs.Reachable = resp.StatusCode >= 200 && resp.StatusCode < 500
+	obs.HTTPStatus = resp.StatusCode
+
+	// The portal's Date header is the cheapest authoritative clock available,
+	// and clock skew is the failure this whole command exists to surface.
+	if served := resp.Header.Get("Date"); served != "" {
+		if authorityTime, parseErr := http.ParseTime(served); parseErr == nil {
+			obs.AuthorityTime = authorityTime
+			obs.LocalTime = time.Now().UTC()
+		}
+	}
+
+	return obs
+}
+
+// runPreflight prints one named cause and returns a non-zero-worthy verdict.
+// Exit code is the caller's job; this returns whether the node is ready.
+func runPreflight(ctx context.Context) bool {
+	cfg, err := config.Load(Version)
+	if err != nil {
+		// A config that will not load is itself the finding, and Evaluate can
+		// name the common case (no Authority URL) from the raw environment.
+		result := preflight.Evaluate(preflight.Observations{
+			AuthorityURL:   os.Getenv(config.EnvAuthorityURL),
+			BootstrapToken: os.Getenv(config.EnvBootstrapToken),
+		})
+		fmt.Fprintln(os.Stdout, preflight.Format(result))
+		if result.OK {
+			// Config failed for a reason preflight does not model; say so
+			// rather than reporting a green that the agent will not honour.
+			fmt.Fprintf(os.Stdout, "preflight: configuration could not be loaded — %v\n", err)
+			return false
+		}
+		return false
+	}
+
+	result := preflight.Evaluate(gatherPreflight(ctx, cfg))
+	fmt.Fprintln(os.Stdout, preflight.Format(result))
+	return result.OK
+}

--- a/services/edge-node-go/internal/preflight/preflight.go
+++ b/services/edge-node-go/internal/preflight/preflight.go
@@ -1,0 +1,241 @@
+// Package preflight answers one question before the agent enrols: if this node
+// cannot reach its Authority, WHY?
+//
+// BI-BB919901. Before this, `enrollOnce` returned the raw wrapped error and the
+// operator got a transport message with no cause. Every likely failure was
+// documented in prose and detected by nothing:
+//
+//   - the Authority URL is unreachable from THIS host (the portal-side renderer
+//     catches a loopback URL when the command is issued, but nothing checked it
+//     where the command actually runs);
+//   - DNS does not resolve the Authority host;
+//   - the bootstrap token is missing, expired, or already consumed;
+//   - the node enrolled fine and is still `pending`, so it submits and is
+//     refused — indistinguishable from a broken node from the operator's chair;
+//   - CLOCK SKEW. The Authority's freshness window rejects submissions whose
+//     observedAt drifts too far from server time, and edge-node-multi-host.md
+//     records that fresh VMs without NTP drift tens of seconds. Silent and
+//     confusing, with an obvious diagnostic.
+//
+// Shape follows Datadog's agent `diagnose`: run the checks the operator cannot
+// run themselves, and name ONE cause rather than dumping a stack.
+//
+// Deliberately pure where it can be. Evaluate() takes already-gathered
+// observations and returns a verdict, so every branch is unit-testable without a
+// network, a clock, or a host.
+package preflight
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Cause is the closed set of reasons a node cannot talk to its Authority.
+// Closed so an operator surface can branch on it, and so a new failure mode has
+// to be named rather than folded into a generic error.
+type Cause string
+
+const (
+	CauseOK                 Cause = "ok"
+	CauseAuthorityMissing   Cause = "authority-url-missing"
+	CauseAuthorityMalformed Cause = "authority-url-malformed"
+	CauseAuthorityLoopback  Cause = "authority-url-loopback"
+	CauseDNSUnresolved      Cause = "authority-dns-unresolved"
+	CauseUnreachable        Cause = "authority-unreachable"
+	CauseTLSUntrusted       Cause = "authority-tls-untrusted"
+	CauseTokenMissing       Cause = "bootstrap-token-missing"
+	CauseTokenRejected      Cause = "bootstrap-token-rejected"
+	CauseClockSkew          Cause = "clock-skew"
+	CauseNoLANVisibility    Cause = "no-lan-visibility"
+)
+
+// Observations are the facts a caller gathers from the host and the network.
+// Every field is optional in the sense that a zero value means "not observed";
+// Evaluate reports what it can and never invents a cause it did not see.
+type Observations struct {
+	AuthorityURL string
+
+	// DNSResolved is false only when a lookup was ATTEMPTED and failed.
+	DNSAttempted bool
+	DNSResolved  bool
+
+	// Reachable is false only when a request was ATTEMPTED and failed.
+	ReachAttempted bool
+	Reachable      bool
+	// ReachError is the transport error, carried for the detail line only.
+	ReachError string
+	// TLSUntrusted distinguishes a certificate refusal from a dead socket.
+	TLSUntrusted bool
+
+	// HTTPStatus from the health probe, 0 when none was received.
+	HTTPStatus int
+
+	BootstrapToken string
+	// AlreadyEnrolled suppresses the missing-token cause: a node with state
+	// does not need one.
+	AlreadyEnrolled bool
+
+	// Clock comparison. Both zero means it was not observed.
+	LocalTime     time.Time
+	AuthorityTime time.Time
+	// MaxSkew tolerated before it is reported. The Authority's freshness window
+	// is the real bound; this is the client-side warning ahead of it.
+	MaxSkew time.Duration
+
+	// LANAddresses the host can actually see. Empty on a container that has no
+	// view of the real network — the Docker Desktop case, which enrols happily
+	// and then reports nothing useful.
+	LANAddresses []string
+}
+
+// Result is one named cause plus operator-readable text.
+type Result struct {
+	Cause Cause
+	// OK is true only for CauseOK.
+	OK bool
+	// Summary is one line naming what is wrong.
+	Summary string
+	// Remedy is what to do about it, or empty when there is nothing to do.
+	Remedy string
+	// Detail carries the underlying error, for the log rather than the headline.
+	Detail string
+}
+
+const defaultMaxSkew = 30 * time.Second
+
+func loopbackHost(host string) bool {
+	h := strings.ToLower(host)
+	switch h {
+	case "localhost", "0.0.0.0", "::1", "[::1]", "host.docker.internal":
+		return true
+	}
+	return strings.HasPrefix(h, "127.")
+}
+
+// Evaluate returns the FIRST cause that explains the failure, in dependency
+// order: a malformed URL explains a DNS failure, and a DNS failure explains an
+// unreachable host, so reporting the deepest one is what stops an operator
+// chasing a symptom.
+//
+// Pure and total. Equal observations always produce an equal result.
+func Evaluate(obs Observations) Result {
+	if strings.TrimSpace(obs.AuthorityURL) == "" {
+		return Result{
+			Cause:   CauseAuthorityMissing,
+			Summary: "No Authority URL is set.",
+			Remedy:  "Set DPF_AUTHORITY_URL to the address of your DPF portal, as shown on Platform > Edge Nodes.",
+		}
+	}
+
+	parsed, err := url.Parse(obs.AuthorityURL)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return Result{
+			Cause:   CauseAuthorityMalformed,
+			Summary: fmt.Sprintf("The Authority URL %q is not a usable http or https address.", obs.AuthorityURL),
+			Remedy:  "Copy the address from Platform > Edge Nodes rather than typing it.",
+		}
+	}
+
+	if loopbackHost(parsed.Hostname()) {
+		return Result{
+			Cause: CauseAuthorityLoopback,
+			Summary: fmt.Sprintf(
+				"The Authority URL points at %s, which means THIS machine, not the portal.",
+				parsed.Hostname()),
+			Remedy: "Use the portal's LAN address or hostname. A localhost URL only works on the machine running the portal itself.",
+		}
+	}
+
+	if obs.DNSAttempted && !obs.DNSResolved {
+		return Result{
+			Cause:   CauseDNSUnresolved,
+			Summary: fmt.Sprintf("The name %s does not resolve from this machine.", parsed.Hostname()),
+			Remedy:  "Check DNS, or use the portal's IP address instead of its name.",
+		}
+	}
+
+	if obs.ReachAttempted && !obs.Reachable {
+		if obs.TLSUntrusted {
+			return Result{
+				Cause:   CauseTLSUntrusted,
+				Summary: fmt.Sprintf("%s answered, but its certificate is not trusted by this machine.", parsed.Host),
+				Detail:  obs.ReachError,
+				Remedy:  "Install your organization's CA certificate on this machine, or use the http address on a trusted LAN.",
+			}
+		}
+		return Result{
+			Cause:   CauseUnreachable,
+			Summary: fmt.Sprintf("Cannot reach %s from this machine.", parsed.Host),
+			Detail:  obs.ReachError,
+			Remedy:  "Check that the portal is running, that the port is open, and that a firewall between the two machines allows it.",
+		}
+	}
+
+	// Token checks come AFTER reachability: a rejected token and an unreachable
+	// portal look the same to an operator, and only one of them is about the token.
+	if !obs.AlreadyEnrolled && strings.TrimSpace(obs.BootstrapToken) == "" {
+		return Result{
+			Cause:   CauseTokenMissing,
+			Summary: "No enrollment token is set, and this node has never enrolled.",
+			Remedy:  "Issue a token on Platform > Edge Nodes and re-run the command it gives you.",
+		}
+	}
+
+	if obs.HTTPStatus == 401 || obs.HTTPStatus == 403 {
+		return Result{
+			Cause:   CauseTokenRejected,
+			Summary: "The Authority refused this enrollment token.",
+			Remedy:  "Tokens are single-use and time-limited. Issue a fresh one on Platform > Edge Nodes.",
+		}
+	}
+
+	if !obs.LocalTime.IsZero() && !obs.AuthorityTime.IsZero() {
+		maxSkew := obs.MaxSkew
+		if maxSkew <= 0 {
+			maxSkew = defaultMaxSkew
+		}
+		skew := obs.LocalTime.Sub(obs.AuthorityTime)
+		if skew < 0 {
+			skew = -skew
+		}
+		if skew > maxSkew {
+			return Result{
+				Cause: CauseClockSkew,
+				Summary: fmt.Sprintf(
+					"This machine's clock is %s away from the portal's.", skew.Round(time.Second)),
+				Remedy: "Enable NTP time sync on this machine. The portal rejects observations whose timestamps drift too far, so discovery will look broken while the clocks disagree.",
+			}
+		}
+	}
+
+	// Reached last on purpose. The node CAN enrol; it just will not see anything
+	// worth reporting, which is the most misleading failure of all because every
+	// status reads healthy.
+	if obs.ReachAttempted && obs.Reachable && len(obs.LANAddresses) == 0 {
+		return Result{
+			Cause:   CauseNoLANVisibility,
+			Summary: "This node can reach the portal but cannot see any real network interface.",
+			Remedy:  "A container on Docker Desktop sees only its own virtual network. Use the native agent for this operating system, or run the container with host networking on Linux.",
+		}
+	}
+
+	return Result{Cause: CauseOK, OK: true, Summary: "Ready to enrol."}
+}
+
+// Format renders a result for a terminal: one headline, then what to do.
+func Format(r Result) string {
+	if r.OK {
+		return "preflight: ok — ready to enrol."
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "preflight: %s\n  %s", r.Cause, r.Summary)
+	if r.Remedy != "" {
+		fmt.Fprintf(&b, "\n  what to do: %s", r.Remedy)
+	}
+	if r.Detail != "" {
+		fmt.Fprintf(&b, "\n  detail: %s", r.Detail)
+	}
+	return b.String()
+}

--- a/services/edge-node-go/internal/preflight/preflight_test.go
+++ b/services/edge-node-go/internal/preflight/preflight_test.go
@@ -1,0 +1,261 @@
+package preflight
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// A node that is genuinely fine. Every other case mutates this.
+func healthy() Observations {
+	return Observations{
+		AuthorityURL:   "https://portal.example.internal:3000",
+		DNSAttempted:   true,
+		DNSResolved:    true,
+		ReachAttempted: true,
+		Reachable:      true,
+		HTTPStatus:     200,
+		BootstrapToken: "edgeboot_token",
+		LocalTime:      time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC),
+		AuthorityTime:  time.Date(2026, 8, 25, 12, 0, 2, 0, time.UTC),
+		LANAddresses:   []string{"192.168.1.42"},
+	}
+}
+
+func TestHealthyNodeIsReady(t *testing.T) {
+	got := Evaluate(healthy())
+	if !got.OK || got.Cause != CauseOK {
+		t.Fatalf("expected ok, got %q: %s", got.Cause, got.Summary)
+	}
+}
+
+func TestMissingAuthorityURL(t *testing.T) {
+	obs := healthy()
+	obs.AuthorityURL = "   "
+	if got := Evaluate(obs); got.Cause != CauseAuthorityMissing {
+		t.Fatalf("got %q", got.Cause)
+	}
+}
+
+func TestMalformedAuthorityURL(t *testing.T) {
+	for _, raw := range []string{"portal.example", "ftp://portal", "://nope", "https://"} {
+		obs := healthy()
+		obs.AuthorityURL = raw
+		if got := Evaluate(obs); got.Cause != CauseAuthorityMalformed {
+			t.Fatalf("%q: got %q", raw, got.Cause)
+		}
+	}
+}
+
+// The single most common remote-provisioning footgun: the operator copies a URL
+// that only means anything on the portal's own machine.
+func TestLoopbackAuthorityURLIsNamed(t *testing.T) {
+	for _, raw := range []string{
+		"http://localhost:3000",
+		"http://127.0.0.1:3000",
+		"http://[::1]:3000",
+		"http://host.docker.internal:3000",
+		"http://0.0.0.0:3000",
+	} {
+		obs := healthy()
+		obs.AuthorityURL = raw
+		got := Evaluate(obs)
+		if got.Cause != CauseAuthorityLoopback {
+			t.Fatalf("%q: got %q", raw, got.Cause)
+		}
+		if !strings.Contains(got.Remedy, "LAN address") {
+			t.Fatalf("%q: remedy does not tell the operator what to use: %q", raw, got.Remedy)
+		}
+	}
+}
+
+// A private LAN address is the INTENDED target, not a fault.
+func TestPrivateLANAddressIsNotLoopback(t *testing.T) {
+	for _, raw := range []string{
+		"http://192.168.1.10:3000",
+		"http://10.0.0.5:3000",
+		"http://portal.local:3000",
+	} {
+		obs := healthy()
+		obs.AuthorityURL = raw
+		if got := Evaluate(obs); !got.OK {
+			t.Fatalf("%q: expected ok, got %q", raw, got.Cause)
+		}
+	}
+}
+
+func TestDNSFailureIsNamedBeforeReachability(t *testing.T) {
+	obs := healthy()
+	obs.DNSResolved = false
+	obs.Reachable = false
+	// Both would fail; the DNS cause explains the reachability one.
+	if got := Evaluate(obs); got.Cause != CauseDNSUnresolved {
+		t.Fatalf("got %q", got.Cause)
+	}
+}
+
+func TestUnreachableAuthority(t *testing.T) {
+	obs := healthy()
+	obs.Reachable = false
+	obs.ReachError = "dial tcp 192.168.1.10:3000: connect: connection refused"
+	got := Evaluate(obs)
+	if got.Cause != CauseUnreachable {
+		t.Fatalf("got %q", got.Cause)
+	}
+	if got.Detail != obs.ReachError {
+		t.Fatalf("transport error should survive as detail, got %q", got.Detail)
+	}
+	if !strings.Contains(got.Remedy, "firewall") {
+		t.Fatalf("remedy should mention the firewall: %q", got.Remedy)
+	}
+}
+
+func TestUntrustedTLSIsDistinctFromADeadSocket(t *testing.T) {
+	obs := healthy()
+	obs.Reachable = false
+	obs.TLSUntrusted = true
+	obs.ReachError = "x509: certificate signed by unknown authority"
+	got := Evaluate(obs)
+	if got.Cause != CauseTLSUntrusted {
+		t.Fatalf("got %q", got.Cause)
+	}
+	if !strings.Contains(got.Remedy, "CA certificate") {
+		t.Fatalf("remedy should name the CA: %q", got.Remedy)
+	}
+}
+
+func TestMissingTokenOnAFirstRun(t *testing.T) {
+	obs := healthy()
+	obs.BootstrapToken = ""
+	if got := Evaluate(obs); got.Cause != CauseTokenMissing {
+		t.Fatalf("got %q", got.Cause)
+	}
+}
+
+// A node with state does not need a token, and telling it otherwise would send
+// the operator to re-issue one for no reason.
+func TestEnrolledNodeNeedsNoToken(t *testing.T) {
+	obs := healthy()
+	obs.BootstrapToken = ""
+	obs.AlreadyEnrolled = true
+	if got := Evaluate(obs); !got.OK {
+		t.Fatalf("expected ok, got %q", got.Cause)
+	}
+}
+
+func TestRejectedToken(t *testing.T) {
+	for _, status := range []int{401, 403} {
+		obs := healthy()
+		obs.HTTPStatus = status
+		got := Evaluate(obs)
+		if got.Cause != CauseTokenRejected {
+			t.Fatalf("status %d: got %q", status, got.Cause)
+		}
+		if !strings.Contains(got.Remedy, "single-use") {
+			t.Fatalf("remedy should explain single-use tokens: %q", got.Remedy)
+		}
+	}
+}
+
+// An unreachable portal and a rejected token look identical to an operator, so
+// reachability is reported first and the token cause never masks it.
+func TestUnreachableBeatsTokenCause(t *testing.T) {
+	obs := healthy()
+	obs.Reachable = false
+	obs.BootstrapToken = ""
+	if got := Evaluate(obs); got.Cause != CauseUnreachable {
+		t.Fatalf("got %q", got.Cause)
+	}
+}
+
+// The silent one: edge-node-multi-host.md records that fresh VMs without NTP
+// drift tens of seconds, and the Authority's freshness window then rejects
+// observations while everything else looks healthy.
+func TestClockSkewIsNamed(t *testing.T) {
+	obs := healthy()
+	obs.AuthorityTime = obs.LocalTime.Add(-90 * time.Second)
+	got := Evaluate(obs)
+	if got.Cause != CauseClockSkew {
+		t.Fatalf("got %q", got.Cause)
+	}
+	if !strings.Contains(got.Remedy, "NTP") {
+		t.Fatalf("remedy should name NTP: %q", got.Remedy)
+	}
+	if !strings.Contains(got.Summary, "1m30s") {
+		t.Fatalf("summary should quantify the drift: %q", got.Summary)
+	}
+}
+
+func TestClockSkewIsSymmetric(t *testing.T) {
+	obs := healthy()
+	obs.AuthorityTime = obs.LocalTime.Add(90 * time.Second)
+	if got := Evaluate(obs); got.Cause != CauseClockSkew {
+		t.Fatalf("got %q", got.Cause)
+	}
+}
+
+func TestSmallSkewIsTolerated(t *testing.T) {
+	obs := healthy()
+	obs.AuthorityTime = obs.LocalTime.Add(-5 * time.Second)
+	if got := Evaluate(obs); !got.OK {
+		t.Fatalf("expected ok, got %q", got.Cause)
+	}
+}
+
+func TestUnobservedClockIsNotAFinding(t *testing.T) {
+	obs := healthy()
+	obs.LocalTime = time.Time{}
+	obs.AuthorityTime = time.Time{}
+	if got := Evaluate(obs); !got.OK {
+		t.Fatalf("expected ok, got %q", got.Cause)
+	}
+}
+
+// The worst shape of failure: the node enrols, every status reads healthy, and
+// it reports nothing real. That is Docker Desktop.
+func TestNoLANVisibilityIsReportedEvenThoughEverythingElsePasses(t *testing.T) {
+	obs := healthy()
+	obs.LANAddresses = nil
+	got := Evaluate(obs)
+	if got.Cause != CauseNoLANVisibility {
+		t.Fatalf("got %q", got.Cause)
+	}
+	if !strings.Contains(got.Remedy, "native agent") {
+		t.Fatalf("remedy should point at the native agent: %q", got.Remedy)
+	}
+}
+
+// A real connection problem matters more than what the node can see.
+func TestConnectivityBeatsLANVisibility(t *testing.T) {
+	obs := healthy()
+	obs.Reachable = false
+	obs.LANAddresses = nil
+	if got := Evaluate(obs); got.Cause != CauseUnreachable {
+		t.Fatalf("got %q", got.Cause)
+	}
+}
+
+func TestEvaluateIsTotalAndDeterministic(t *testing.T) {
+	obs := healthy()
+	first := Evaluate(obs)
+	second := Evaluate(obs)
+	if first != second {
+		t.Fatalf("not deterministic: %+v vs %+v", first, second)
+	}
+	// A zero-value Observations must still produce a named cause, never a panic.
+	if got := Evaluate(Observations{}); got.Cause != CauseAuthorityMissing {
+		t.Fatalf("zero value should name the missing URL, got %q", got.Cause)
+	}
+}
+
+func TestFormatNamesTheCauseAndTheRemedy(t *testing.T) {
+	out := Format(Evaluate(Observations{AuthorityURL: "http://localhost:3000"}))
+	for _, want := range []string{string(CauseAuthorityLoopback), "what to do:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("format missing %q:\n%s", want, out)
+		}
+	}
+	if ok := Format(Result{OK: true, Cause: CauseOK}); !strings.Contains(ok, "ok") {
+		t.Fatalf("healthy format should say ok: %q", ok)
+	}
+}


### PR DESCRIPTION
An edge node was documented, buildable, published — and unreachable, unofferable, and undiagnosable. This closes all three.

## 1. The installable exists; the portal refused to offer it

`remote-provisioning.ts` gated the native download on a hardcoded comment: *"the signed, downloadable native Go binary is not published for download yet."*

`publish-release.yml` began attaching the binaries. The comment stayed. Verified against the live releases — the last four each carry `dpf-edge-node-darwin-arm64`, `dpf-edge-node-windows-amd64.exe` and a SHA-256 manifest, and **the portal withheld every one of them**, offering Windows and macOS operators only the Docker Desktop path that cannot see the host's real LAN. A branch-office box is usually Windows, so that was the common case, not the edge case.

The fix is not to update the comment. It is to **stop believing a comment**: the native command is rendered only for assets a caller proves are on the release, resolved from the GitHub API.

Null is a first-class answer — offline, rate-limited, air-gapped, or a source-only release all converge on "render the container path only". Never a throw, never blocked token issuance, never a command that 404s.

Three properties, each pinned by a test:

- **Checksum-verified** against the release's own manifest before anything executes (`shasum` on macOS, `sha256sum` on Linux). A one-liner that runs an unverified binary is the supply-chain shape every installer guidance warns about, and the manifest already exists.
- **The published filename is preserved**, because the manifest is keyed on it. Renaming to something friendlier silently breaks `-c` verification.
- **The token goes in an environment variable, not argv**, following Tailscale's auth-key guidance — argv is readable by every other process while the command runs. Ours is single-use so exposure is bounded, but the env form costs nothing.

## 2. A node that cannot connect now says why

`enrollOnce` returned the raw wrapped error. Every likely failure was documented in prose and detected by nothing. `--preflight` names **one** cause, in dependency order so a symptom never masks its reason:

`authority-url-missing` · `-malformed` · `-loopback` · `authority-dns-unresolved` · `authority-unreachable` · `authority-tls-untrusted` · `bootstrap-token-missing` · `-rejected` · `clock-skew` · `no-lan-visibility`

Two are why this exists:

- **Clock skew.** The multi-host runbook records that the Authority's freshness window rejects drifting timestamps and that fresh VMs without NTP drift tens of seconds. Everything looks healthy while discovery quietly returns nothing. The portal's `Date` header makes the check nearly free.
- **No LAN visibility.** A Docker Desktop container enrols, reports trusted, and sees only its own virtual network — the worst failure shape there is, because every status reads green. Reported *last*, after connectivity, so a real connection problem is never hidden behind it.

Reachability is judged before the token: an unreachable portal and a rejected token look identical to an operator, and only one is about the token.

Shape follows Datadog's agent `diagnose` — run the checks the operator cannot, name a cause instead of dumping a stack. `internal/preflight` is pure and total (a zero-value `Observations` names a cause rather than panicking), so all 22 cases are unit-tested with no network, clock, or host.

## 3. Publish the whole matrix, and fail when it is partial

The workflow built two of the six targets the Makefile cross-compiles, and wrapped the upload in an `if` whose failure branch emitted `::warning::` — so a release with no edge assets **looked successful**. Now `build-all`, an explicit per-asset existence check, and a hard `::error::` + `exit 1`. An installable that is sometimes absent is not an installable.

## 4. Make the page reachable (BI-2EC8906A)

`/platform/edge-nodes` had a route, six operator documents, and exactly one in-product link — from the Connections page, which you only open if you are already doing federation. The documented path "Platform → Edge Nodes" did not exist as a navigable path. Added to the Platform nav under the capability the route already enforces; `docs/operations/install.md` now points at the topology guide, having previously never said the word "edge".

## Gates

- **337 web tests** pass across 16 files; `internal/preflight` and `cmd/dpf-edge-node` pass `go test`, `go vet`, `gofmt`.
- **Production build** compiles.
- Design-grounding, docs-impact, seed-fit, ux-fit, module-size, style-drift, prose-lint and the ActionResult ratchet all pass locally.
- **UX verification not performed** — the running portal is a released image and this is branch-only.

Pre-existing, **not** introduced here: `services/edge-node-go` has four test failures on a Windows host (`internal/action` file-mode 666-vs-600, host-action execution; `internal/config` fixed-host configuration). Verified identical on the base commit with my changes stashed — host artifacts, and CI runs Linux.

On re-baselining: I re-baselined `module-size` for the navigation registry because that growth is unavoidable — the file *is* the registry — after trimming the comment so only the structural part grew. I reverted the eight unrelated files `--update` also retightened; that shrinkage is not mine to claim and would hand the next person a failure my commit caused.

Backlog: `BI-BB919901`, `BI-2EC8906A`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
