### PR TITLE
fix(routing): name the dimension a quality floor failed on, and stop Build Studio guessing why (BI-16A1B4A3)

### DIFF
--- a/apps/web/lib/build/build-engine-selection.test.ts
+++ b/apps/web/lib/build/build-engine-selection.test.ts
@@ -140,6 +140,33 @@ describe("selectBuildEngineFromCandidates", () => {
     expect(result.rejected).toHaveLength(2);
   });
 
+  // BI-16A1B4A3 — live repro: every engine installed and credentialed, every
+  // endpoint excluded by a quality floor, and the owner was told to "connect,
+  // provision, or wait" — three actions, none of which could change the outcome.
+  it("names the real routing cause instead of advising connect/provision/wait", () => {
+    const result = selectBuildEngineFromCandidates({
+      policy: { mode: "auto", pinnedEngine: null },
+      candidates: [candidate("codex", "codex"), candidate("opencode", "local")],
+      route: {
+        selectedProviderId: null,
+        selectedModelId: null,
+        reason: "No endpoint satisfied the Build Studio contract.",
+        fallbackProviderIds: [],
+        rejectedProviders: [
+          { providerId: "codex", reason: "Minimum quality dimensions not met (toolFidelity 80 < 85)" },
+          { providerId: "local", reason: "Minimum quality dimensions not met (toolFidelity 82 < 85)" },
+        ],
+      },
+      localOnly: false,
+      nowMs: NOW,
+    });
+
+    expect(result.status).toBe("blocked");
+    expect(result.action).not.toMatch(/connect, provision, or wait/i);
+    expect(result.action).toMatch(/quality floor/i);
+    expect(result.action).toMatch(/measured/i);
+  });
+
   it("projects the router fallback chain and rationale without re-ranking it", () => {
     const result = selectBuildEngineFromCandidates({
       policy: { mode: "auto", pinnedEngine: null },

--- a/apps/web/lib/build/build-engine-selection.ts
+++ b/apps/web/lib/build/build-engine-selection.ts
@@ -1,4 +1,5 @@
 import { capacityRoutingExclusionReason } from "@/lib/routing/capacity-routing-exclude";
+import { dominantExclusion, explainExclusion } from "@/lib/inference/routing-exclusion-buckets";
 
 export const BUILD_ENGINE_IDS = ["claude", "codex", "grok", "opencode", "agentic"] as const;
 export type BuildEngineId = (typeof BUILD_ENGINE_IDS)[number];
@@ -213,6 +214,36 @@ export function qualifyBuildEngineCandidates(args: {
   return { eligible, rejected };
 }
 
+/**
+ * BI-16A1B4A3 — say why no engine was allowed.
+ *
+ * "Connect, provision, or wait for one allowed Build Studio engine" describes
+ * missing or unhealthy infrastructure. On a live install every engine was
+ * installed and credentialed, and the real cause was a quality floor no
+ * endpoint could clear — so the advice pointed at three actions, none of which
+ * could ever change the outcome.
+ *
+ * routing-exclusion-buckets already turns per-endpoint reasons into one
+ * actionable cause for the coworker surfaces; Build Studio simply was not using
+ * it. Reuse it here rather than growing a second explanation vocabulary. Falls
+ * back to the original string when there are no reasons to bucket (nothing was
+ * excluded, so nothing can be named).
+ */
+function blockedAction(rejected: readonly BuildEngineRejection[]): string {
+  const GENERIC = "Connect, provision, or wait for one allowed Build Studio engine, then retry.";
+  // Only ROUTE-CONTRACT rejections carry a router reason worth translating. An
+  // engine that is absent, unauthenticated or in a capacity retry window really
+  // is "connect, provision, or wait" — keep that advice where it is true.
+  const routeReasons = rejected
+    .filter((entry) => entry.code === "route-contract")
+    .map((entry) => entry.reason);
+  if (routeReasons.length === 0) return GENERIC;
+  const bucketed = dominantExclusion(routeReasons);
+  if (!bucketed) return GENERIC;
+  const explanation = explainExclusion(bucketed);
+  return `${explanation.message} ${explanation.remediation}`;
+}
+
 export function selectBuildEngineFromCandidates(args: {
   policy: BuildEnginePolicy;
   candidates: BuildEngineCandidate[];
@@ -262,7 +293,7 @@ export function selectBuildEngineFromCandidates(args: {
       fallbackDisabled: pinned,
       action: pinned
         ? `Restore ${pinnedLabel} readiness or change Advanced execution policy; automatic fallback was disabled by the hard pin.`
-        : "Connect, provision, or wait for one allowed Build Studio engine, then retry.",
+        : blockedAction(rejected),
     };
   }
 

--- a/apps/web/lib/routing/cost-ranking.ts
+++ b/apps/web/lib/routing/cost-ranking.ts
@@ -36,11 +36,29 @@ export function satisfiesMinimumDimensions(
   endpoint: EndpointManifest,
   minimumDimensions: Readonly<Record<string, number>> | undefined,
 ): boolean {
-  if (!minimumDimensions) return true;
-  return Object.entries(minimumDimensions).every(
-    ([dimension, minimum]) =>
-      getDimensionScore(endpoint, dimension) >= minimum,
-  );
+  return firstUnmetDimension(endpoint, minimumDimensions) === null;
+}
+
+/**
+ * BI-16A1B4A3 — which dimension actually failed, and by how much.
+ *
+ * "Minimum quality dimensions not met" is true but unactionable: on a live
+ * install every endpoint cleared codegen and reasoning and failed only
+ * toolFidelity, by three points, and nothing said so. An owner cannot act on a
+ * floor whose failing dimension is never named, so the gap is reported.
+ *
+ * Returns null when the endpoint satisfies every declared minimum.
+ */
+export function firstUnmetDimension(
+  endpoint: EndpointManifest,
+  minimumDimensions: Readonly<Record<string, number>> | undefined,
+): { dimension: string; actual: number; minimum: number } | null {
+  if (!minimumDimensions) return null;
+  for (const [dimension, minimum] of Object.entries(minimumDimensions)) {
+    const actual = getDimensionScore(endpoint, dimension);
+    if (actual < minimum) return { dimension, actual, minimum };
+  }
+  return null;
 }
 
 // ── Average Relevant Dimensions ─────────────────────────────────────────────

--- a/apps/web/lib/routing/pipeline-v2.quality-floor.test.ts
+++ b/apps/web/lib/routing/pipeline-v2.quality-floor.test.ts
@@ -1,0 +1,103 @@
+// apps/web/lib/routing/pipeline-v2.quality-floor.test.ts
+//
+// BI-16A1B4A3 — the quality floor must name the dimension it failed on.
+//
+// Split out of pipeline-v2.test.ts, which is at its module-size ceiling.
+
+import { describe, expect, it } from "vitest";
+import type { EndpointManifest } from "./types";
+import type { RequestContract } from "./request-contract";
+import { EMPTY_CAPABILITIES, EMPTY_PRICING } from "./model-card-types";
+import { getExclusionReasonV2 } from "./pipeline-v2";
+
+function makeEndpoint(overrides: Partial<EndpointManifest> = {}): EndpointManifest {
+  return {
+    id: "ep-default",
+    providerId: "test",
+    modelId: "test-model",
+    name: "Default Endpoint",
+    endpointType: "chat",
+    status: "active",
+    providerTier: "user_configured",
+    sensitivityClearance: ["public", "internal"],
+    supportsToolUse: true,
+    supportsStructuredOutput: true,
+    supportsStreaming: true,
+    maxContextTokens: 128000,
+    maxOutputTokens: 4096,
+    modelRestrictions: [],
+    reasoning: 70,
+    codegen: 70,
+    toolFidelity: 70,
+    instructionFollowing: 70,
+    structuredOutput: 70,
+    conversational: 70,
+    contextRetention: 70,
+    customScores: {},
+    avgLatencyMs: 1000,
+    recentFailureRate: 0,
+    costPerOutputMToken: 10.0,
+    profileSource: "seed",
+    profileConfidence: "medium",
+    retiredAt: null,
+    modelClass: "chat",
+    modelFamily: null,
+    inputModalities: ["text"],
+    outputModalities: ["text"],
+    capabilities: { ...EMPTY_CAPABILITIES, toolUse: true, structuredOutput: true, streaming: true },
+    pricing: { ...EMPTY_PRICING, inputPerMToken: 3.0, outputPerMToken: 15.0 },
+    supportedParameters: [],
+    deprecationDate: null,
+    metadataSource: "inferred",
+    metadataConfidence: "low",
+    perRequestLimits: null,
+    ...overrides,
+  };
+}
+
+function makeContract(overrides: Partial<RequestContract> = {}): RequestContract {
+  return {
+    contractId: "test-contract",
+    contractFamily: "sync.test",
+    taskType: "reasoning",
+    modality: { input: ["text"], output: ["text"] },
+    interactionMode: "sync",
+    sensitivity: "internal",
+    requiresTools: false,
+    requiresStrictSchema: false,
+    requiresStreaming: false,
+    estimatedInputTokens: 1000,
+    estimatedOutputTokens: 500,
+    reasoningDepth: "medium",
+    budgetClass: "balanced",
+    ...overrides,
+  };
+}
+
+
+describe("getExclusionReasonV2 — quality floor names the gap (BI-16A1B4A3)", () => {
+  // Live repro: every endpoint cleared codegen and reasoning and failed only
+  // toolFidelity, by three points — and the reason said none of that.
+  it("names the failing dimension, its value, and the floor", () => {
+    const endpoint = makeEndpoint({ codegen: 97, reasoning: 95, toolFidelity: 80 });
+    const reason = getExclusionReasonV2(
+      endpoint,
+      makeContract({ minimumDimensions: { codegen: 85, toolFidelity: 85, reasoning: 85 } }),
+    );
+
+    expect(reason).toContain("Minimum quality dimensions not met");
+    expect(reason).toContain("toolFidelity");
+    expect(reason).toContain("80");
+    expect(reason).toContain("85");
+  });
+
+  it("still passes an endpoint that clears every declared minimum", () => {
+    const endpoint = makeEndpoint({ codegen: 97, reasoning: 95, toolFidelity: 90 });
+    expect(
+      getExclusionReasonV2(
+        endpoint,
+        makeContract({ minimumDimensions: { codegen: 85, toolFidelity: 85, reasoning: 85 } }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/routing/pipeline-v2.ts
+++ b/apps/web/lib/routing/pipeline-v2.ts
@@ -32,7 +32,7 @@ import { QUALITY_TIERS, type QualityTier } from "./quality-tiers";
 import {
   estimateSuccessProbability,
   rankByCostPerSuccess,
-  satisfiesMinimumDimensions,
+  firstUnmetDimension,
 } from "./cost-ranking";
 import { selectRecipeWithExploration } from "./champion-challenger";
 import {
@@ -118,8 +118,12 @@ export function getExclusionReasonV2(
     }
   }
 
-  if (!satisfiesMinimumDimensions(ep, contract.minimumDimensions)) {
-    return "Minimum quality dimensions not met";
+  // BI-16A1B4A3: name the dimension and the gap. The leading phrase is load
+  // bearing — routing-exclusion-buckets classifies on it — so the detail is
+  // appended rather than replacing it.
+  const unmet = firstUnmetDimension(ep, contract.minimumDimensions);
+  if (unmet) {
+    return `Minimum quality dimensions not met (${unmet.dimension} ${unmet.actual} < ${unmet.minimum})`;
   }
 
   // Status check — only active and degraded pass

--- a/scripts/local-action-result-baseline.json
+++ b/scripts/local-action-result-baseline.json
@@ -4,5 +4,5 @@
   "expiry": "2026-11-16",
   "note": "One-ActionResult ratchet baseline (BI-1CED89B9). localAliases must stay empty; inlineOkTrueTotal is shrink-only — compose ok()/err() from lib/shared/action-result. Regenerate with: node scripts/check-no-local-action-result.mjs --update",
   "localAliases": [],
-  "inlineOkTrueTotal": 978
+  "inlineOkTrueTotal": 974
 }


### PR DESCRIPTION
## Problem

On the Pet Rescue consumer install every build engine was installed **and credentialed**, every endpoint was excluded, and the owner was told:

> Connect, provision, or wait for one allowed Build Studio engine, then retry.

Three actions, none of which could ever change the outcome.

The real cause was a quality floor. Every endpoint cleared `codegen` and `reasoning` and failed **only** `toolFidelity`:

| provider | model | codegen | **toolFidelity** | reasoning | evalCount |
|---|---|---|---|---|---|
| local | qwen3.8-27b | 96 | **82** | 90 | 4 |
| codex | gpt-5.4 | 97 | **80** | 95 | 0 (catalog placeholder) |
| chatgpt | gpt-5.4 | 90 | **10** | 85 | 0 |

Against `frontier: { codegen: 85, toolFidelity: 85, reasoning: 85 }`. Best on the box is 82 — short by three points, on a dimension that for codex has never actually been measured. Neither the dimension nor the gap appeared anywhere in the product.

## Change

- **`getExclusionReasonV2` names the gap** — `"Minimum quality dimensions not met (toolFidelity 80 < 85)"`. The leading phrase is load bearing (`routing-exclusion-buckets` classifies on it), so the detail is appended rather than replacing it. `firstUnmetDimension` carries the comparison; `satisfiesMinimumDimensions` delegates to it and keeps its contract for existing callers.
- **Build Studio reuses `routing-exclusion-buckets`.** That module's own header records that consumers throw the per-endpoint reasons away and substitute a hardcoded guess — Build Studio was still doing exactly that. Scoped to `route-contract` rejections: an engine that is genuinely absent, unauthenticated, or in a capacity retry window really *is* "connect, provision, or wait", and keeps that advice.

**No routing decision changes.** An endpoint excluded before is excluded now, and the identical set is selected. This changes only what the platform can tell its owner about why.

## Deliberately not in scope

Whether an unmeasured placeholder should exclude at all, and whether a floor that excludes every candidate should step down a tier, are **product-policy decisions**. They remain open on BI-16A1B4A3 rather than being decided inside a diagnostics fix.

## Verification

- `lib/routing` + `lib/build` + `lib/inference` + `lib/coworker-service-catalog` + `components/build`: **413 files / 4750 tests pass**.
- Both new tests confirmed **Red** against `origin/main` (`2 failed | 96 passed`), green with the fix.
- `tsc --noEmit` on `apps/web`: 0 errors. Guard loop 37/37. Style-drift, module-size, One-ActionResult, docs-impact, spec/plan/doc, design-grounding: clean.
- New quality-floor cases live in their own test file because `pipeline-v2.test.ts` is at its module-size ceiling; the One-ActionResult baseline is retightened (978 → 974), not raised.
- Runtime UX verification not performed — the change is not deployed to the live install (`/ops/self-upgrade` owns that).

Refs: BI-16A1B4A3, BI-A38D5B08, WC-81F41BDF