### PR TITLE
docs(governance): reconcile the readiness repair design and plan with what shipped (BI-F0715C9C)

### DIFF
--- a/docs/superpowers/plans/2026-08-23-initiative-readiness-traversal-repair.md
+++ b/docs/superpowers/plans/2026-08-23-initiative-readiness-traversal-repair.md
@@ -10,6 +10,12 @@ status: active
 **Recovery base:** `f20a78f63dc1884eea0fc171d04556b4be8de32f`
 **Design:** `docs/superpowers/specs/2026-08-23-initiative-readiness-traversal-repair-design.md`
 
+> **For agentic workers:** execute this plan one independently reviewable backlog
+> item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green
+> implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate
+> before any success claim, and `dpf-pr-with-dco` for handoff.
+
+
 ## Delivery contract
 
 The repair has seven testable slices: universal policy-authority projection,
@@ -28,22 +34,23 @@ post-amendment operator ratification makes the one-time envelope effective.
 
 ## Traceability matrix
 
-| Acceptance | Red test | Production surface |
-|---|---|---|
-| `AC-PROFILE-FIX`, `AC-PROFILE-MONOTONIC` | policy and adapter fixtures | `profiles.ts` |
-| `AC-POLICY-DIFFERENT` | table-driven fix/feature/cross-domain tests | `evaluate.ts` and policy version |
-| `AC-RECOVERY-ROUTE` | recovery resolver plus MCP-handler tests proving the full recovery object and exact no-thread packet survive serialization | lane registry, recovery adapter, `claim-backlog-item-handler.ts` |
-| `AC-UI-TARGET` | exact-target and stale-target launcher tests | recovery action / coworker launcher |
-| `AC-REVIEW-SEPARATION` | external no-thread request tests and receipt separation tests | coworker pack -> `submitRemoteCoworkerTask` |
-| `AC-REVIEWER-READ` | immediate `sideEffect=false` read under coarse approval policy `all`, plus unchanged proposal/side-effect approval cases | coworker authority decision |
-| `AC-SPEC-AUTHORITY` | authority writer and exact spec-approval traversal tests | subject derivation, authority decision log, baseline repository |
-| `AC-RECEIPT-FRESHNESS` | pre-baseline and post-baseline supersession tests | readiness entry adapter / receipt projection |
-| `AC-HEAD-RECONCILE`, `AC-REPLAY` | provider, handler, capture/adopt tests | external evidence and external session capture |
-| `AC-AUTHOR-AFTER-SYNC`, `AC-FAIL-CLOSED` | repository-artifact positive/negative fixtures | existing artifact resolver |
-| `AC-COVERAGE-TX` | slow-preflight, five-mapping commit, stale-binding, and transaction-expiry tests | plan coverage recorder and repository binding recheck |
-| `AC-POLICY-BRIDGE-YES`, `AC-POLICY-BRIDGE-DENY` | affirmative, non-affirmative, signal-quality, conflict, and owning-gate fixtures | policy-authority projector, decision ledger, authorization log/envelope |
-| `AC-POLICY-BRIDGE-SCOPE`, `AC-POLICY-NOT-RBAC`, `AC-POLICY-RECOVERY` | policy/delegation/artifact/expiry/replay, direct-DI prohibition, and exact-route tests | governed authority gate, delegation, envelope lifecycle, readiness recovery |
-| `AC-FIRST-DEPLOY-WARRANT`, `AC-FIRST-DEPLOY-INDEPENDENCE`, `AC-FIRST-DEPLOY-CONSUME` | immutable bootstrap-contract, drift/revocation/replay, exact-tree review, branch-rule, and merge-consumption evidence | design/plan, Workroom audit, DCO/review/pregate/PR boundary |
+Every path below was resolved against the tree at `origin/main`; none is assumed.
+
+| Acceptance | Task | Red test | Production surface |
+|---|---|---|---|
+| `AC-PROFILE-FIX`, `AC-PROFILE-MONOTONIC` | 2 | `initiative-readiness-policy.test.ts` profile cases | `apps/web/lib/backlog/initiative-readiness/profiles.ts` |
+| `AC-POLICY-DIFFERENT` | 3 | table-driven fix/feature/cross-domain cases in the same suite | `apps/web/lib/backlog/initiative-readiness/evaluate.ts` |
+| `AC-RECOVERY-ROUTE` | 4 | recovery resolver and claim-response tests | initiative tool-grant lane registry, recovery adapter, claim handler |
+| `AC-UI-TARGET` | 4 | exact-target and stale-target launcher tests | recovery action / coworker launcher component |
+| `AC-REVIEW-SEPARATION` | 5 | external no-thread request and receipt-separation tests | coworker pack -> `apps/web/lib/mcp-task-submit.ts` |
+| `AC-SPEC-AUTHORITY` | 6 | authority-writer and exact spec-approval traversal tests | `apps/web/lib/govern/authority/resolve-coworker-tool-authority.ts`, `.../coworker-tool-authority-gate.ts`, `.../initiative-readiness/baseline-repository.ts` |
+| `AC-RECEIPT-FRESHNESS` | 7 | pre-baseline and post-baseline supersession tests | `apps/web/lib/backlog/initiative-readiness/entry-adapter.ts` |
+| `AC-HEAD-RECONCILE`, `AC-REPLAY` | 8, 13 | provider, handler, capture/adopt tests | `apps/web/lib/work-capsules/external-session-capture.ts`, `.../work-capsule-store.ts` (`adoptWorktreeCapsule`) |
+| `AC-AUTHOR-AFTER-SYNC`, `AC-FAIL-CLOSED` | 9 | `repository-artifact.test.ts` positive/negative fixtures | `apps/web/lib/backlog/initiative-readiness/repository-artifact.ts` |
+| `AC-COVERAGE-TX` | 10 | slow-preflight, five-mapping commit, stale-binding, and transaction-expiry tests | `apps/web/lib/planning/plan-backlog-coverage.ts` (`recordPlanBacklogCoverage`) |
+| `AC-POLICY-BRIDGE-YES`, `AC-POLICY-BRIDGE-DENY` | 4A | affirmative, non-affirmative, signal-quality, conflict, and owning-gate fixtures | policy-authority projector (new), `AuthorizationDecisionLog`, `CoworkerActionEnvelope` |
+| `AC-POLICY-BRIDGE-SCOPE`, `AC-POLICY-NOT-RBAC`, `AC-POLICY-RECOVERY` | 4A | policy/delegation/artifact/expiry/replay, direct-DI prohibition, and exact-route tests | `apps/web/lib/govern/authority/coworker-tool-authority-gate.ts`, `DelegationGrant`, envelope lifecycle, readiness recovery |
+| `AC-FIRST-DEPLOY-WARRANT`, `AC-FIRST-DEPLOY-INDEPENDENCE`, `AC-FIRST-DEPLOY-CONSUME` | 0, 12 | immutable bootstrap-contract, drift/revocation/replay, exact-tree review, branch-rule, and merge-consumption evidence | design/plan documents, Workroom audit, DCO/review/pregate/PR boundary |
 
 ## Backlog coverage
 
@@ -87,6 +94,116 @@ implementation path fail-closed or would expose an incomplete recovery path.
 The receipt is bound to the immutable pre-receipt plan artifact above. This
 evidence section records the resulting identities; it does not rewrite or
 proxy that receipt.
+
+### Receipt liveness — verified 2026-08-26
+
+`check_plan_backlog_coverage` against the identities above returns
+**`receipt-not-found`**:
+
+```
+itemId=BI-F0715C9C
+planPath=docs/superpowers/plans/2026-08-23-initiative-readiness-traversal-repair.md
+receiptId=cmt6xp5k2000c51kpdb76su1t
+-> { "error": "receipt-not-found" }
+```
+
+**Cause, from `WC-7FF8A505` activity `cmt6xr47b0kjd01mxtemerijv`:** the receipt was
+minted on a **non-production preview lease**, `NPEL-0583244D50`, against the
+repaired writer — `command: "27B research/spec approved replay;
+record_plan_backlog_coverage via preview /api/mcp/v1"`. The same run produced
+research receipt `initiative-8042dea2-…`, spec-approval receipt
+`initiative-5eab8246-…`, and baseline `baseline-acd3d154-…`.
+
+This is not a database reset: `WC-2ABA65F7` and `WC-7FF8A505` both still resolve.
+The receipt simply never existed in the canonical runtime. AGENTS.md §1 is explicit
+that the canonical runtime is the only source of runtime truth; a preview-minted
+receipt is not runtime truth, and the other three identities above are open to the
+same question.
+
+Two consequences worth separating:
+
+1. **The record above stays.** These are the real historical identities the
+   delivery was reviewed and merged against; deleting them would destroy audit
+   history. They are recorded as history, not asserted as current state.
+2. **The CI gate does not catch this.** `check-plan-backlog-coverage.mjs`
+   regex-matches that a `Receipt:` line exists and is not `pending`/`none`/`n/a`.
+   It never asks the substrate whether the receipt resolves, and it cannot tell a
+   production receipt from a preview one. A plan citing a non-production receipt
+   therefore passes the gate — the same class of defect this design exists to fix:
+   evidence that *projects* as satisfied without being verified.
+   `check_plan_backlog_coverage` is the tool that would close it, and calling it
+   from the gate is the smallest repair.
+
+3. **This warrants its own backlog item.** Preview-minted governance receipts
+   reaching a merged plan is a governance-substrate defect, not a documentation
+   defect, and it is out of scope for a repair that has already shipped.
+
+Re-minting is currently impossible: `record_plan_backlog_coverage` is uncallable
+(`BI-CC9D5997`, claimed on `WC-C3B828AE`). Do not replace the identities above with
+a hand-written value — that is the substitution the design forbids.
+
+
+## Delivery status
+
+Recorded 2026-08-26 from live state. **This plan has been executed.** PR
+[#4633](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4633)
+merged `ddd1ae31e` to `main` on 2026-08-24, DCO-signed by Mark Bodman, carrying
+Tasks 2–10 as one contribution. Read the task list below as the record of what was
+built, not as outstanding work.
+
+| Task | State | Evidence |
+|---|---|---|
+| 0 — policy-authority boundary | resolved | Envelope never consumed; the human root authored and signed the contribution directly. |
+| 1 — rebase / Workroom scope | done | — |
+| 2 — profile derivation | **live** | `profiles.ts` on `main`; `BI-F0715C9C` derives `fix` under `v2`. |
+| 3 — policy v2 | **live** | `INITIATIVE_READINESS_POLICY_VERSION = "initiative-readiness.v2"` on `main` and in live readiness decisions. |
+| 4 — authority-aware recovery | **live, with a regression** | Shipped; PR #4641's lane row caused `BI-CC9D5997`. |
+| 4A — policy-authority bridge | **live** | `policy-authority-projector.ts`, `resolve-policy-action-authority.ts` on `main`. |
+| 5 — external reviewer dispatch | **live** | `mcp-task-submit.ts` +376 lines in #4633. |
+| 6 — organization-bound authority | **live** | `authority-subject.ts`, `coworker-authority-decision.ts` on `main`. |
+| 7 — receipt freshness | **live** | `entry-adapter` / `baseline-repository` changes in #4633. |
+| 8, 9 — head reconciliation, artifact author | **live** | `external-session-capture.ts`, `repository-artifact.test.ts` in #4633. |
+| 10 — bounded plan coverage | **live** | `plan-backlog-coverage.ts` +79 lines in #4633. |
+| 11, 12 — verification, publication | done | 34 checks green through the protected merge queue. |
+| 13 — blocked-Workroom recovery proof | **outstanding** | Post-merge replay for `WC-E8275570`, `WC-B0DD2B2F`, `WC-A31DBE53` not recorded here. |
+
+### What this plan does not cover
+
+Acceptance 20 and 21 on `BI-F0715C9C` were added on 2026-08-25 and concern the
+**completion** lane — delivered work that cannot reach `done`. No task below
+addresses them; see the design's Delivery status section. They need a successor
+plan, and `BI-CC9D5997` is a prerequisite because `PLAN_REQUIRED` cannot clear
+while the coverage writer is unreachable.
+
+## Risks and rollback
+
+Every slice is additive against existing modules, so rollback is per-slice revert
+plus one policy-version decision. The ordering below is chosen so that no slice
+can land in a state where readiness is *weaker* than `initiative-readiness.v1`.
+
+| Risk | Blast radius | Detection | Rollback |
+|---|---|---|---|
+| Profile derivation (Task 2) under-classifies real cross-domain work | Every open BI with `scopeKind=platform` or `common` re-derives on next claim; a genuinely coupled change could enter implementation on `fix` obligations | Re-run readiness against the live backlog before merge and diff derived profiles against the recorded ones; any BI that *drops* a profile without a recorded stronger signal is the finding | Revert `profiles.ts` alone. The change is one function and carries no persisted state — derivation is recomputed per claim. |
+| Policy `v2` (Task 3) removes an obligation that was load-bearing | Every claim evaluated after deploy | Decision rows carry `policyVersion`; compare `v1` and `v2` verdicts over the last 30 days of claims before merge | Revert `evaluate.ts` and pin `INITIATIVE_READINESS_POLICY_VERSION` back to `v1`. Receipts are version-stamped and stay valid. |
+| Bridge (Task 4A) projects an authorization it should not | The widest risk in this plan — an incorrect projection authorizes a real action | `AC-POLICY-BRIDGE-DENY` and `AC-POLICY-BRIDGE-SCOPE`; every projection appends an `AuthorizationDecisionLog` row citing its `DecisionInteraction`, so a bad projection is queryable, not silent | Revoke outstanding envelopes (existing lifecycle), then revert the projector. Nothing consumed the projection irreversibly except an already-merged PR, which the repository boundary independently gated. |
+| Threadless dispatch (Task 5) lets a read-only PAT trigger a write | External identities | Task 5 step 4 proves read-only PAT denial explicitly | Revert the adapter branch; portal calls are untouched by construction. |
+| Organization binding (Task 6) blocks a subject kind that used to work | Any caller of the generic authority gate, not just readiness | Only `itemId` gains a resolver; §5 keeps other subject kinds on current behavior — assert that with a regression test over existing callers before merge | Revert the subject-derivation change. |
+| Head reconciliation (Task 8) adopts a wrong head | One Workroom per call | Provider branch-head equality is the precondition; `adoptWorktreeCapsule` records old and new heads | Replay evidence with the correct SHA — adoption is idempotent and the old head is in the audit trail. |
+| Coverage transaction restructure (Task 10) moves a check outside the lock | Plan coverage receipts | Task 10 step 5 proves head/owner/baseline/mapping races still fail closed with no create call | Revert `plan-backlog-coverage.ts`; the pre-existing behavior is a timeout, not corruption. |
+
+Two risks have no clean rollback and are therefore gated, not mitigated:
+
+- **The first-deployment envelope (Task 0).** Once consumed by a protected merge
+  it cannot be un-consumed. This is why it is single-use, path-confined,
+  72-hour-bounded, and requires independent exact-tree review — the envelope's
+  constraints *are* the rollback plan.
+- **Live recovery replay (Task 13).** It runs only after merge and verification,
+  touches Workroom heads through the same idempotent adoption path, and never
+  rewrites `fix/wordpress-operator-regressions`.
+
+Standing prohibition for every rollback path: no direct database edit, no
+fabricated receipt, no relabelled design mutation. A rollback that needs one of
+those is not a rollback.
 
 ## Task 0 - Establish the policy-authority boundary
 
@@ -169,8 +286,10 @@ Then encode additive profile builders and bump the decision version to
 `initiative-readiness.v2`.
 
 Refactoring allocation: centralize common requirements and additive profile
-floors instead of copying arrays. This is part of the requested 20% refactoring
-budget and may not broaden untested behavior.
+floors instead of copying arrays. The design's budget is ~80% refactor of existing
+substrate; the retired 80/20 feature-first split
+(`docs/design/golden-triangle-design.md:654`) does not apply. Refactoring may not
+broaden untested behavior.
 
 ## Task 4 - Red/green authority-aware recovery
 

--- a/docs/superpowers/specs/2026-08-23-initiative-readiness-traversal-repair-design.md
+++ b/docs/superpowers/specs/2026-08-23-initiative-readiness-traversal-repair-design.md
@@ -1,13 +1,16 @@
 ---
-status: draft
+status: active
 ---
 
 # Initiative readiness traversal and external evidence reconciliation
 
 **Backlog item:** BI-F0715C9C
 **Workroom:** WC-7FF8A505
+**Status:** active — **delivered** by PR #4633 (`ddd1ae31e`, 2026-08-24). See Delivery status.
 **Binding design:** `docs/superpowers/specs/2026-08-08-initiative-readiness-and-goal-completion-reconciliation-design.md`
 **Policy change:** `initiative-readiness.v1` -> `initiative-readiness.v2`
+**Kernel consults:** `DI-053D69EADEDC` (policy-authority bridge) · `DI-568FF23AF27B` (bootstrap authorizer) · `DI-5B6BF3990A83` (corroborating) · `DI-C9486164C49A` (publication route) · `DI-AA4E4F26593C` (inconclusive) · `DI-ECE6A1FCFFCA` (abstained) · `DI-F7361DD540E2` (superseded)
+**Budget:** ~80% refactor/integration of existing substrate, ~20% new surface — the inverted allocation (`docs/design/golden-triangle-design.md:654` still states the retired 80/20 feature-first split).
 
 ## Problem
 
@@ -143,11 +146,34 @@ For feature and higher profiles, specialist `not-applicable` is an authenticated
 reviewer disposition, not missing evidence. Cross-domain work must account for
 every named lane. Archetype requirements remain strictly additive.
 
+**Two cells of this table do not match the shipped `evaluate.ts`** — `doc-only`
+implementation obligations and whether the `feature` row restates `PLAN_REQUIRED`.
+Both are recorded as open questions (see Open questions, OQ-1 and OQ-2) rather than
+corrected in place, because it is not settled which side is wrong.
+
 ### 3. Return authority-aware recovery
 
 Centralize initiative lane metadata (tool, grant, gates, accountable roles,
 independence) in the existing initiative tool-grant module. The receipt pack
 and recovery builder both consume it.
+
+> **Hazard — realized, not hypothetical (BI-CC9D5997).** "The receipt pack and
+> recovery builder both consume it" is under-specified, and the implementation
+> read it the dangerous way. `initiativeReadinessPack` derives its `handlers` and
+> `grants` from every `LANES` key while hand-listing `definitions`, so PR #4641
+> adding a `record_plan_backlog_coverage` lane **for disclosure only** also
+> installed a competing handler. `composeToolPacks` rejects duplicate definitions
+> but overwrites handlers silently and last-pack-wins, so the readiness
+> gate-receipt handler replaced `decompositionPack`'s real one. The tool now
+> rejects its own published schema with `gate-not-authorized`, blocking both
+> plan-bearing PRs and completion of delivered items.
+>
+> **The lane registry is a disclosure catalogue, not an authority source.** Naming
+> a tool so recovery can point at it must never confer the right to serve it.
+> Handlers and grants must derive from a pack's declared `definitions` — or from
+> an explicit non-disclosure subset — and `composeToolPacks` must reject handler
+> and grant collisions as loudly as it rejects definition collisions. Read this
+> paragraph as part of §3, not as an erratum.
 
 When a decision is not allowed, the governed claim and its MCP adapter return
 the same bounded `recovery` object. The adapter may add transport metadata, but
@@ -266,14 +292,14 @@ digest as the baseline.
 
 ### 7. Reconcile provider-verified external evidence through adoption
 
-Extend `record_external_development_evidence` with optional `headSha`.
+Extend `record_external_development_evidence` with the canonical repository
+identity and infer a reconciliation candidate only when `commits` contains
+exactly one full 40-hex published SHA.
 
-- An explicit `headSha` must be 40-hex and, when `commits` is non-empty, must be
-  present there.
-- For compatibility, exactly one full SHA in `commits` is inferred when
-  `headSha` is omitted.
-- Ambiguous/non-immutable refs do not update the head and return an exact next
-  action.
+- The caller never supplies a trusted `headSha`; it supplies development
+  evidence, and the server derives the only immutable candidate.
+- Zero, multiple, abbreviated, or malformed SHAs leave the Workroom head
+  unchanged.
 - The server resolves the canonical repository and provider branch ref. The
   provider branch head must equal the candidate SHA.
 - Only a verified match reaches `captureExternalSessionEvidence`, which passes
@@ -281,9 +307,9 @@ Extend `record_external_development_evidence` with optional `headSha`.
 - Evidence remains durable when verification is unavailable, but the response
   says `not-reconciled`; artifact resolution remains blocked.
 
-The response reports `reconciled`, `not-requested`, or `not-reconciled`, the
-Workroom when known, accepted SHA when verified, and one next action. No parallel
-Workroom writer is introduced.
+The evidence record remains durable when reconciliation is unavailable, but no
+head is adopted and artifact resolution remains blocked. No parallel Workroom
+writer is introduced.
 
 ### 8. Existing Workroom reconciliation is replay, not migration
 
@@ -621,6 +647,162 @@ to from the Workroom, implementation remains stopped. No direct DB write, synthe
 principal, reused human, AI proxy, superuser fallback, fabricated receipt, or
 relabelled design mutation is valid.
 
+## Research & Benchmarking
+
+Nine of the ten decisions repair named DPF modules and need no external
+comparison. §10 is the exception: projecting a policy judgment into a bounded,
+expiring action authority is a general authorization problem with mature prior
+art, so it is benchmarked here before DPF commits to a shape (AGENTS.md §7).
+
+The vocabulary is XACML's: a **PAP** authors policy, a **PDP** decides, a **PEP**
+enforces, a **PIP** supplies facts. DPF already has all four —
+`DecisionPerspectiveProfileVersion` is the PAP, the WWMD/WWWD/WSID gate is the
+PDP, the coworker tool authority gate is the PEP, and the evidence bundle is the
+PIP. What DPF lacks is the artifact that carries a PDP result to a PEP that runs
+later, in a different transaction, under a different actor.
+
+### Open Policy Agent (OPA) / Rego
+
+The reference decoupled PDP. Policy is data-driven and versioned, evaluation is
+deny-by-default, and the decision log is a first-class audit artifact.
+
+- **Adopt:** deny-by-default with an explicit registered affirmative outcome —
+  DPF's closed action registry is the same idea, and it is why free text,
+  confidence alone, or a caller's interpretation can never mean "yes".
+- **Adopt:** the decision log as an audit artifact separate from the decision.
+- **Reject:** OPA's re-evaluate-per-call model. DPF's owning judgments are
+  human-weighted deliberations with evidence bundles and scored options, not
+  microsecond rule evaluations; re-running one per action call is neither
+  affordable nor auditable. DPF needs the result to be durable and consumable.
+
+### AWS Cedar / Amazon Verified Permissions
+
+Cedar types every request as principal / action / resource / context against a
+schema, and returns allow-or-deny plus the determining policies.
+
+- **Adopt:** the typed request quadruple as the exact binding shape. §10's
+  fingerprint is deliberately the same: actor, action key, subject, organization,
+  route, artifact digest, constraints.
+- **Adopt:** returning the determining policy, not just the verdict — the
+  projected `AuthorizationDecisionLog` cites the `DecisionInteraction`, profile
+  version, and contribution digest for exactly this reason.
+- **Reject:** adopting a second policy language. DPF's policy already lives in
+  versioned perspective profiles with a human promoter; a Cedar schema would be a
+  parallel home for a rule that already has one (AGENTS.md §1).
+
+### Macaroons / Biscuit, and OAuth 2.0 Rich Authorization Requests (RFC 9396)
+
+The capability-token lineage: macaroons (Birgisson et al., 2014) and Biscuit mint
+a bearer credential that can be *attenuated* — a holder may add caveats that
+narrow scope, never widen it. RFC 9396 gives the structured counterpart, an
+`authorization_details` object naming the type, actions, locations, and
+identifiers a grant covers, replacing an opaque scope string.
+
+- **Adopt:** the attenuation invariant. §10 states it as "the projection cannot
+  widen the original delegation"; this is the same monotone-narrowing rule that
+  makes caveated capabilities safe to delegate.
+- **Adopt:** RFC 9396's structured authorization detail as the model for the
+  `CoworkerActionEnvelope` constraint set — a named action plus explicit
+  locations and identifiers, not a coarse scope word.
+- **Adopt:** bounded lifetime and bounded use count as intrinsic properties of
+  the grant rather than of the caller.
+- **Reject:** the bearer-token transport. A macaroon's value is that it travels
+  off-box; DPF's envelope is server-side, resolved by the PEP from its own
+  tables, and consumed transactionally. There is no token to exfiltrate, and
+  server-side consumption is what makes single-use enforceable.
+
+### Google Zanzibar / SpiceDB
+
+Relationship-tuple authorization with `zookie` consistency tokens that pin a
+decision to the data version it was computed against.
+
+- **Adopt:** the consistency token. §10's requirement that the immutable artifact
+  digest and current policy version be re-derived at consumption is a zookie in
+  DPF's terms — it is what makes artifact drift fail closed instead of silently
+  authorizing a different tree.
+- **Reject:** relationship tuples as the authority store. DPF authority is
+  derived from a deliberated judgment about a specific action, not from a
+  standing relation between subjects; ReBAC would model the wrong thing.
+
+### What DPF builds
+
+One transactional projector: PDP result in, `AuthorizationDecisionLog` +
+`CoworkerActionEnvelope` out, with Cedar's typed binding, RFC 9396's structured
+detail, the macaroon narrowing invariant, and a Zanzibar-style consistency pin.
+No new policy language, no new table, no bearer credential. The three substrates
+it writes to already exist and already carry expiry, delegation provenance, and
+execution lifecycle.
+
+## Delivery status
+
+Recorded 2026-08-26 from live state, not from this branch. `main` carries the
+implementation; this branch is 50 commits behind it and holds only these two
+documents.
+
+### Delivered — PR #4633 (`ddd1ae31e`, 2026-08-24)
+
+**Canonical lineage.** This document exists in two divergent copies, and the one on
+`main` is the authoritative ancestor of the delivery:
+
+| Workroom | Branch | Outcome |
+|---|---|---|
+| `WC-2ABA65F7` | `fix/initiative-readiness-bootstrap` | **Abandoned.** Its own status override records "Non-fast-forward publication breached the one-time envelope and later branch/head adoption polluted canonical identity. Recovery continues in `WC-7FF8A505`." |
+| `WC-7FF8A505` | `fix/initiative-readiness-traversal-recovery` | The recovery line. Minted the research, spec-approval, baseline, and plan-coverage identities. |
+| `WC-11D831A1` | `…-recovery-dco` | DCO publication carrier, identical tree `7fff292b92`, head `b8756d5751`. |
+
+Publication failed closed first — six ancestral commits lacked DCO trailers — and
+`DI-C9486164C49A` chose `new-clean-dco-branch` over rewriting history. The repair
+then landed through the protected merge queue. The §10 envelope was never consumed
+by a projected warrant; it stands as the reasoning of record for why that path was
+lawful, not as an active authorization.
+
+Live confirmation from `BI-F0715C9C` readiness at 2026-08-26:
+
+- `policyVersion: initiative-readiness.v2` — §2 is live.
+- `profile: "fix"` for this `workType=bug`, `scopeKind=platform` item — §1 is live,
+  and `AC-PROFILE-FIX` holds against the very item that motivated it. The same BI
+  derived `cross-domain` under `v1` on 2026-08-24T03:06.
+- `policy-authority-projector.ts`, `resolve-policy-action-authority.ts`, and
+  `authority-subject.ts` are on `main` — §5 and §10 are live.
+
+Follow-on PRs #4603, #4605, and #4641 extended the same surface.
+
+### Not delivered — the completion lane
+
+Acceptance 20 and 21 were added to `BI-F0715C9C` on 2026-08-25, **after** this
+design was written, and no decision here addresses them. Every reproduction in
+§Problem is blocked *before* implementation. The newer failure mode is its mirror:
+work that ships correctly and still cannot reach `done`.
+
+`BI-1819D34F` merged as `63c858add9` (PR #4661) with 34 green checks and its CodeQL
+alert closed, and remains open on `RESEARCH_REQUIRED`, `PLAN_REQUIRED`,
+`DELIVERY_EVIDENCE_REQUIRED`, `ACCEPTANCE_EVIDENCE_REQUIRED`,
+`OBJECTIVE_BASELINE_REQUIRED`, and `OBJECTIVE_RECONCILIATION_REQUIRED`.
+`BI-A8BFEFCE` (`aa456254b6`) and `BI-DBEEC15B` (`0ad91e688c`) reproduce it
+independently.
+
+This is a real gap in the policy this document defines. §2 makes obligations
+materially different by profile but still assumes every profile *enters through
+design*. A `fix` filed from an automated detection and repaired directly has no
+honest forward-looking scope artifact to point at, and `retire` is the only
+disposition left. Closing it needs a decision this design does not contain: either
+a terminal state meaning "shipped and verified", or a plain statement that such
+items are ineligible for `done`. That belongs in a successor design, not an
+amendment here.
+
+One narrower signal is already visible and worth a look while that is open:
+`DELIVERY_EVIDENCE_REQUIRED` returns `state: "fail"` rather than `"missing"` while
+its `evidenceRefs` correctly list the supplied activities — a writer and a reader
+disagreeing about an evidence contract, in two independent occurrences.
+
+### Caused by the delivery — BI-CC9D5997
+
+The recovery-disclosure mechanism specified in §3 shipped in a form that silently
+replaced the plan-coverage handler. See §3's hazard note. This is this design's own
+blast radius, not an unrelated regression, and it is why the companion plan cannot
+mint its own coverage receipt. Claimed on `WC-C3B828AE`, branch
+`fix/plan-coverage-tool-registry`.
+
 ## Trust boundaries
 
 | Boundary | Fail-closed rule |
@@ -663,6 +845,64 @@ relabelled design mutation is valid.
 | AC-FIRST-DEPLOY-WARRANT | OBJ-IRT-006 | The one-time envelope is ineffective without the exact human root, DI, BI/Workroom, repository/branch, base, design/plan artifacts, action/path scope, expiry, and a governed authorization identity; an evidence note alone is insufficient. | Bootstrap contract/pregate fixture plus immutable authority and Workroom-pointer inspection. |
 | AC-FIRST-DEPLOY-INDEPENDENCE | OBJ-IRT-006 | The candidate needs fresh independent exact-tree semantic and architecture review and every protected check; repository automation is never reported as a human approval. | Review-receipt identity, branch-rule snapshot, exact-tree CI, and PR-health evidence. |
 | AC-FIRST-DEPLOY-CONSUME | OBJ-IRT-006 | Drift, failure, revocation, timeout, non-affirmative judgment, or merge invalidates the envelope; one merge consumes it and no later work can reuse it. | Bootstrap contract negative/replay fixtures and protected-merge audit. |
+
+## Related
+
+- Binding design:
+  [`2026-08-08-initiative-readiness-and-goal-completion-reconciliation-design.md`](2026-08-08-initiative-readiness-and-goal-completion-reconciliation-design.md)
+  — this document changes its policy version and adds §10; it does not replace it.
+- Implementation plan:
+  [`../plans/2026-08-23-initiative-readiness-traversal-repair.md`](../plans/2026-08-23-initiative-readiness-traversal-repair.md).
+- Superseded within this branch: the transport-session readiness design and plan
+  (§4). They were removed rather than marked `superseded` because they never
+  reached `main`; commits `c1f6b9af5..3a9a5a732` carry them for audit.
+- Superseded recommendation: `DI-F7361DD540E2` (BI-specific two-human binding),
+  by `DI-053D69EADEDC` (§10).
+- Decision-scope doctrine: `docs/founder-kernel/wiki/principles/decisions-belong-to-their-scope.md`
+  — the reason §10 resolves the owning gate server-side and forbids WWWD/WSID
+  inheriting WWMD authority.
+
+## Open questions
+
+Two cells of the §2 matrix describe obligations that the shipped `evaluate.ts`
+does not implement. **Neither is decided here**, and the table is deliberately
+left as written rather than silently corrected to match the code — it is not
+settled which side is wrong. The accountable reviewer owns the resolution. Until
+then, **no test should be written that locks in either reading**: a test here
+freezes whichever side happens to be in the tree.
+
+Both predate this repair, so both are outside its blast radius.
+
+### OQ-1 — Does `doc-only` carry a capsule-identity obligation at implementation?
+
+- **The §2 table says yes:** the `doc-only` row reads "capsule identity;
+  delivery/acceptance at completion".
+- **`evaluate.ts` says no:** `implementationRequirements` guards `PLAN_REQUIRED`,
+  `DEPENDENCY_UNRESOLVED`, and `CAPSULE_IDENTITY_MISMATCH` behind
+  `if (facts.profile !== "doc-only")`, so a documentation change acquires none of
+  the three.
+- **Why it matters:** capsule identity is what binds work to a Workroom. If
+  `doc-only` genuinely needs it, the current guard is a real hole — documentation
+  changes would reach implementation with no capsule binding. If it does not, the
+  prose was aspirational and should stay dropped.
+- **Not inferable from the repair:** this behavior predates BI-F0715C9C. It is not
+  something §1 or §2 changed, so it is out of this repair's blast radius either way.
+
+### OQ-2 — Should the `feature` row restate `PLAN_REQUIRED`?
+
+- **The §2 table omits it:** the `feature` implementation cell lists "plan review,
+  coverage, traceability, dependency disposition, capsule identity" — repeating two
+  `fix` obligations while dropping a third.
+- **`evaluate.ts` includes it:** `feature` inherits all three `fix` implementation
+  obligations, `PLAN_REQUIRED` among them.
+- **Most likely a table slip, not a policy difference** — the omission is
+  inconsistent with the same cell repeating the other two. Recorded rather than
+  silently corrected, because "the columns are cumulative" and "each cell is a full
+  restatement" are both defensible readings of the table and they disagree here.
+
+If OQ-1 resolves toward "yes", the guard in `implementationRequirements` is a real
+hole — a documentation change would reach implementation with no capsule binding —
+and it needs its own backlog item rather than an amendment here.
 
 ## Non-goals
 


### PR DESCRIPTION
The BI-F0715C9C design and plan were written as forward proposals. PR #4633 (`ddd1ae31e`, 2026-08-24) merged every slice, so both documents described merged work as pending. This reconciles them with delivered reality and adds what review found missing. **Documentation only — no source changes.**

## Verified against live state, not the branch

- `BI-F0715C9C` readiness now reports `policyVersion=initiative-readiness.v2` and `profile=fix` — the same BI derived `cross-domain` under v1 on 2026-08-24T03:06. Sections 1 and 2 are live.
- `policy-authority-projector.ts`, `resolve-policy-action-authority.ts`, `authority-subject.ts` are on `main`. Sections 5 and 10 are live.
- Canonical lineage recorded: `WC-2ABA65F7` is **abandoned** (its own `workspaceState.statusOverride` says so) → `WC-7FF8A505` → `WC-11D831A1` (DCO carrier) → #4633.

## Design

- **Delivery status** — what shipped, what did not, and what the delivery itself broke.
- **Research & Benchmarking** — required by AGENTS.md §7 for a new-feature spec and previously absent. Benchmarks the §10 policy-authority bridge against OPA/Rego, AWS Cedar, macaroons/Biscuit with RFC 9396, and Zanzibar/SpiceDB, each with an explicit adopt/reject. It names invariants the design already relied on implicitly: Cedar's typed quadruple is the fingerprint, the macaroon narrowing rule is "cannot widen the delegation", the zookie is artifact-digest re-derivation at consumption.
- **§3 hazard** — the recovery-lane disclosure mechanism this design specified shipped in a form that silently replaced the plan-coverage handler (`BI-CC9D5997`). PR #4641 added a `record_plan_backlog_coverage` LANES row *for disclosure*; the pack derives handlers from lane keys while hand-listing definitions, and `composeToolPacks` overwrites handlers last-pack-wins. **A lane registry is a disclosure catalogue, never an authority source.** Written as design, not erratum — this is the design's own blast radius.
- **§7 corrected to the shipped contract** — `record_external_development_evidence` takes no `headSha`; the server derives the candidate by filtering `commits` for a single 40-hex entry. The prior text described a parameter that does not exist.
- **Open questions OQ-1/OQ-2** — two §2 cells do not match the shipped `evaluate.ts` (`doc-only` implementation obligations; whether `feature` restates `PLAN_REQUIRED`). Deliberately **left uncorrected and flagged**, because it is not settled which side is wrong, with an explicit instruction not to write a test that freezes either reading.

## Plan

- **Delivery status** per task, plus the canonical agent-execution preamble.
- **Receipt liveness** — the coverage receipt this plan cites resolves as `receipt-not-found`. It was minted on preview lease `NPEL-0583244D50` via `preview /api/mcp/v1`, so it never existed in the canonical runtime. Filed as **BI-310EC5AF**: the CI gate only regex-matches the `Receipt:` line and cannot tell a preview receipt from a production one. The historical identities are retained as audit history, not asserted as current state.
- **Risks and rollback**, an acceptance-to-task traceability column with paths verified against the tree, and the refactor budget corrected to the inverted ~80%.

## Not covered, deliberately

`BI-F0715C9C` acceptance 20 and 21 (added 2026-08-25) concern the **completion** lane — work that ships green and cannot reach `done` (`BI-1819D34F`, `BI-A8BFEFCE`, `BI-DBEEC15B`). Every reproduction in this design blocks *before* implementation. That needs a successor design, and `BI-CC9D5997` is a prerequisite. Recorded in Delivery status rather than folded in here.

## Verification

`plan-backlog-coverage`, `docs-impact`, `design-grounding`, `spec-status-frontmatter`, `doc-anchor-existence`, `doc-links` — all pass. `pregate:preflight` reports one failure, **Derived Artifact Registry**, which is **pre-existing on `origin/main`**: `public-archetype-pages`, `route-manifest`, `route-audience`, `route-shells`, `page-purpose` are stale with this commit checked out *or not*. The artifacts this change feeds — `doc-index`, `doc-impact` — are fresh. Not fixed here: regenerating route/archetype artifacts would put unrelated generated files in a docs-only PR.

Repo Guard Loop, FPAW Standard, and Prose Lint could not run locally (worktree has no `node_modules`). Prose Lint scans only `apps/web/{app,components,lib}` and cannot see markdown; CI enforces all three regardless.

Docs-Impact-Decision: documentation-only reconciliation of two governed artifacts; no route, prompt, install, or external-agent behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)