### PR TITLE
fix(coworker): the minimum floor must not punch through the local ceiling (BI-8634F0BE)

### DIFF
--- a/apps/web/lib/actions/coworker-tool-budget.test.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.test.ts
@@ -17,6 +17,74 @@ import {
   SKILL_CATALOG_CLIFF_CAP,
 } from "./coworker-tool-budget";
 import { AUTHORIZED_SURFACE_TOOL_NAMES } from "@/lib/coworker/authorized-surface-coworker-contract";
+import { resolveLocalToolCeiling } from "@/lib/routing/local-tool-ceiling";
+
+// THE joint invariant (BI-A8BFEFCE, hardened by BI-8634F0BE).
+//
+// The attachment budget and the routing local-fallback gate are two ends of one
+// policy. Whenever a local model is in the serving path, whatever the budget
+// attaches must be something `callWithFallbackChain` will agree to run — it
+// refuses any surface above `resolveLocalToolCeiling(measured)`. When the two
+// disagree the surface is refused for exceeding a limit nothing else applied,
+// local silently leaves the fallback chain, and a cloud outage on top of that
+// produces a turn that executes no tools at all.
+//
+// Both ends were previously only tested in isolation: `fallback.test.ts` held
+// zero references to the budget, and the cases below pinned one hardcoded cap-15
+// example. This matrix is the guard that actually holds them together.
+describe("budget/gate joint invariant", () => {
+  const WINDOWS = [null, undefined, 0, 4_096, 12_000, 16_000, 24_576, 32_768, 131_072, 262_144];
+  const MEASURED = [null, undefined, -1, 0, 4, 8, 10, 12, 15, 30, 48, 200];
+  const PRESENCES = ["present", "unknown"] as const;
+
+  it("never attaches more tools than the routing gate will run locally", () => {
+    const violations: string[] = [];
+    for (const window of WINDOWS) {
+      for (const measured of MEASURED) {
+        for (const localPresence of PRESENCES) {
+          const cap = deriveCoworkerToolCap(window, {
+            localPresence,
+            measuredToolFidelityCeiling: measured,
+          });
+          const gate = resolveLocalToolCeiling(measured);
+          if (cap > gate) {
+            violations.push(
+              `window=${window} measured=${measured} presence=${localPresence} → cap=${cap} > gate=${gate}`,
+            );
+          }
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("follows a measured ceiling BELOW the minimum floor rather than overriding it", () => {
+    // The regression this guard exists for. `max(MIN, min(ceiling, fitted))` put
+    // the floor last, so a model measured at 8 was handed 12 tools and then
+    // refused by the gate at 8 — nothing ran.
+    for (const measured of [4, 8, 10]) {
+      expect(deriveCoworkerToolCap(24_576, { localPresence: "present", measuredToolFidelityCeiling: measured }))
+        .toBe(measured);
+      expect(deriveCoworkerToolCap(null, { localPresence: "unknown", measuredToolFidelityCeiling: measured }))
+        .toBe(measured);
+    }
+  });
+
+  it("still floors WINDOW-fit shrinkage at the minimum — the floor's real purpose", () => {
+    // A tiny window drives fitted below the floor; with no measured evidence the
+    // ceiling is the cliff (15), so the floor legitimately binds at 12.
+    expect(deriveCoworkerToolCap(4_096, { localPresence: "present" })).toBe(MIN_COWORKER_ATTACHED_TOOLS);
+    expect(deriveCoworkerToolCap(1_000, { localPresence: "present" })).toBe(MIN_COWORKER_ATTACHED_TOOLS);
+    expect(deriveCoworkerToolCap(16_000, { localPresence: "present" })).toBe(MIN_COWORKER_ATTACHED_TOOLS);
+  });
+
+  it("leaves a cloud turn unbounded by the local gate", () => {
+    // `absent` means local is not a candidate, so the gate never runs and the
+    // full ceiling is correct even though it exceeds the local cliff.
+    expect(deriveCoworkerToolCap(null, { localPresence: "absent" })).toBe(MAX_COWORKER_ATTACHED_TOOLS);
+    expect(deriveCoworkerToolCap(131_072, { localPresence: "absent" })).toBe(MAX_COWORKER_ATTACHED_TOOLS);
+  });
+});
 
 describe("deriveCoworkerToolCap", () => {
   it("caps an exact 32k local window at the 15-tool accuracy cliff", () => {

--- a/apps/web/lib/actions/coworker-tool-budget.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.ts
@@ -59,7 +59,13 @@ export const TOOL_SCHEMA_TOKEN_ESTIMATE = 330;
 export const COWORKER_NON_TOOL_RESERVE_TOKENS = 12_000;
 
 /** Never attach fewer than this — below it a coworker is too crippled to be
- *  useful, and the agentic loop's overflow handling covers the pathological case. */
+ *  useful, and the agentic loop's overflow handling covers the pathological case.
+ *
+ *  Scope of the floor (BI-8634F0BE): it bounds the WINDOW-FIT term only. A
+ *  MEASURED tool-fidelity ceiling below this value wins, and the cap follows the
+ *  measurement. Attaching more than a model has proven it can select from is not
+ *  a kindness — `callWithFallbackChain` refuses the surface outright, so the
+ *  coworker gets nothing instead of a small working set. */
 export const MIN_COWORKER_ATTACHED_TOOLS = 12;
 
 /**
@@ -154,11 +160,18 @@ export function deriveCoworkerToolCap(
   // Window-fit needs a real window. When the probe could not read one, the
   // selection ceiling alone binds — an unknown window must never WIDEN the
   // surface, which is the whole defect this branch exists to prevent.
-  if (!hasWindow) return Math.max(MIN_COWORKER_ATTACHED_TOOLS, ceiling);
+  if (!hasWindow) return ceiling;
 
+  // The MIN floor applies to the WINDOW-FIT term only, never on top of the
+  // ceiling (BI-8634F0BE). Written as `max(MIN, min(ceiling, fitted))` the floor
+  // came last and overrode the ceiling, so a measured fidelity below 12 attached
+  // 12 tools while the routing gate refused anything above the measured value —
+  // reinstating the exact BI-A8BFEFCE failure by a different route. The floor
+  // exists to stop window arithmetic shrinking a coworker into uselessness on a
+  // small context; it was never evidence about what the model can select from.
   const toolBudgetTokens = servedContextTokens! - COWORKER_NON_TOOL_RESERVE_TOKENS;
   const fitted = Math.floor(toolBudgetTokens / TOOL_SCHEMA_TOKEN_ESTIMATE);
-  return Math.max(MIN_COWORKER_ATTACHED_TOOLS, Math.min(ceiling, fitted));
+  return Math.min(ceiling, Math.max(MIN_COWORKER_ATTACHED_TOOLS, fitted));
 }
 
 /**


### PR DESCRIPTION
Follow-up audit of [#4663](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4663). That PR introduced the invariant that the attachment budget must never hand a local model more tools than `callWithFallbackChain` will agree to run. It closed two paths that broke it and **left a third open, in the code it shipped.**

## The defect

```ts
return Math.max(MIN_COWORKER_ATTACHED_TOOLS, Math.min(ceiling, fitted));
```

The floor is applied *after* the ceiling, so it overrides it. Whenever a measured tool-fidelity ceiling falls below `MIN_COWORKER_ATTACHED_TOOLS` (12), the budget attaches 12 while the gate refuses anything above the measured value. The unreadable-window branch had the same shape.

Checked exhaustively over windows × measured ceilings × presences — **48 violating combinations**:

```
window=24576  measured=10  presence=present  -> cap=12 but gate=10
window=null   measured=8   presence=unknown  -> cap=12 but gate=8
window=0      measured=4   presence=present  -> cap=12 but gate=4
```

This is the original failure reinstated by a different route: the surface is refused for exceeding a limit nothing else applied, local silently leaves the fallback chain, and a cloud outage on top of that produces a turn that executes nothing.

## Why it matters even though nothing is broken today

It is latent only because no install has measured fidelity yet, so every ceiling resolves to the fail-safe cliff of 15 — which sits above the floor.

It arms the moment the Phase-2 eval harness measures any local model below 12. A weak small model measuring 8 or 10 is exactly what that harness exists to detect, so the harness would have made the platform worse, silently, at the moment it started working.

## Fix

Apply the floor to the window-fit term only, then bound by the ceiling:

```ts
if (!hasWindow) return ceiling;
return Math.min(ceiling, Math.max(MIN_COWORKER_ATTACHED_TOOLS, fitted));
```

The floor's documented job is to stop window arithmetic shrinking a coworker into uselessness on a small context. It was never evidence about what the model can *select* from. That scope is now recorded at the constant's definition.

Stated plainly: a model measured below 12 now gets a cap equal to its measurement. Attaching more than it has proven it can select from is not a kindness — the gate refuses the surface outright, so the coworker gets nothing instead of a small working set.

## The guard that was missing

Both ends of this invariant were only ever tested in isolation. `fallback.test.ts` holds **zero** references to the budget; the budget tests pinned a single hardcoded cap-15 case. Nothing held them to each other — which is why #4663 could introduce the invariant and violate it in the same commit.

Added a matrix asserting `cap <= resolveLocalToolCeiling(measured)` for every window/measured/presence combination where local is in the serving path.

**Verified as a real guard, not a tautology:** reverting to the shipped formula fails it — 2 failures, both in the new block — and restoring the fix returns it to green.

All nine documented behaviours are unchanged: `131_072 → 15`, `131_072 + measured 40 → 40`, `24_576 → 15`, `16_000 → 12`, `4_096 → 12`, `1_000 → 12`, `null + absent → 48`, `null + unknown → 15`, `null + present → 15`.

## Verification

- 154 tests across 12 files pass.
- Module-size, application-boundary, plan-coverage and design-grounding guards all pass.
- Production build completed with a full route manifest. Two other attempts on this host died with a native Turbopack crash (`0xC0000409`) and a wrapper failure while 35 node processes from concurrent agent sessions were running — host contention rather than compile errors, and CI is authoritative here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
