### PR TITLE
fix(test): extend the cwd-independence ratchet to services/ (BI-96033E25)

### DIFF
--- a/scripts/check-test-cwd-independence.mjs
+++ b/scripts/check-test-cwd-independence.mjs
@@ -23,7 +23,14 @@
  *   const rootDir = join(__dirname, "..", "..", "..");   // correct
  *   const rootDir = join(process.cwd(), "..", "..");     // flagged
  *
- * SCOPE — deliberately vitest test files under apps/ and packages/ only.
+ * SCOPE — every pnpm workspace root that runs vitest: apps/, packages/ and
+ * services/ (adp, edge-node, integration-test-harness). services/ was missed on
+ * the first cut, which left a third of the vitest surface unratcheted: it was
+ * clean at the time, so nothing failed and the omission was invisible.
+ *
+ * `scripts/*.test.ts` is EXCLUDED with the same reasoning as the .mjs CLIs
+ * below — those run through `tsx --test` from package.json at the repo root, not
+ * through vitest, and have no --root-style invocation that moves their cwd.
  * `scripts/**\/*.test.mjs` is EXCLUDED on purpose: those are repo-root CLIs whose
  * cwd-dependence is by design (`export function scanRepo(root = process.cwd())`),
  * they are invoked only as `node --test scripts/…` from package.json with no
@@ -39,7 +46,7 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { pathToFileURL } from "node:url";
 
-export const SCAN_ROOTS = ["apps", "packages"];
+export const SCAN_ROOTS = ["apps", "packages", "services"];
 export const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|mts|js|jsx)$/;
 
 /**

--- a/scripts/check-test-cwd-independence.test.mjs
+++ b/scripts/check-test-cwd-independence.test.mjs
@@ -14,8 +14,11 @@ import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { readFileSync } from "node:fs";
+
 import {
   ALLOWLIST,
+  SCAN_ROOTS,
   scanRepo,
   findStaleAllowlist,
 } from "./check-test-cwd-independence.mjs";
@@ -83,6 +86,27 @@ test("does not flag cwd passed as a spawn option or saved for restore", () => {
     ].join("\n"),
   );
   assert.deepEqual(found, [], "only cwd used as a PATH BASE is a violation");
+});
+
+test("covers every pnpm workspace root that runs vitest", () => {
+  // services/ was missing from the first cut. It was clean, so no assertion
+  // failed and the omission was invisible — the reason this test names the
+  // roots explicitly rather than trusting the constant to be complete.
+  const workspace = readFileSync(join(REPO_ROOT, "pnpm-workspace.yaml"), "utf8");
+  const vitestRoots = new Set(
+    [...workspace.matchAll(/^\s*-\s*["']?([^"'\n]+)["']?\s*$/gm)]
+      .map((m) => m[1].trim())
+      .filter((entry) => !entry.startsWith("!"))
+      .map((entry) => entry.split("/")[0])
+      .filter((top) => top && !top.startsWith(".")),
+  );
+  for (const root of vitestRoots) {
+    if (root === "scripts") continue; // tsx --test from repo root, not vitest
+    assert.ok(
+      SCAN_ROOTS.includes(root),
+      `workspace root "${root}" is not scanned by the cwd-independence guard`,
+    );
+  }
 });
 
 test("the real repository is clean — the ratchet holds at its baseline", () => {


### PR DESCRIPTION
Follow-up to #4614. That guard scanned `apps/` and `packages/`. **`services/` is the third pnpm workspace root that runs vitest** — `services/adp`, `services/edge-node`, `services/integration-test-harness`, ~35 test files — and it was not scanned.

## Why this was worth catching

The omission was invisible for the worst possible reason: `services/` happens to be clean today, so nothing failed and no assertion complained. A ratchet that silently covers two thirds of its surface has the same shape as the original defect — green for the wrong reason, discovered only when someone loses time to it.

## The fix

- `SCAN_ROOTS` now includes `services`
- a new test **derives** the expected roots from `pnpm-workspace.yaml` instead of trusting the constant to be complete, so the next workspace root added to this repo fails the guard's own suite rather than quietly falling outside it

Proven red-then-green — removing `"services"` produces:

```
AssertionError: workspace root "services" is not scanned by the cwd-independence guard
```

## Still out of scope, deliberately

`scripts/*.test.ts` runs through `tsx --test` from the repo root, not vitest, and has no `--root`-style invocation that moves its cwd — the same documented reasoning that excludes the `.mjs` CLIs.

## Verification

- guard tests **9/9**, including the red-green proof above
- registry conformance + test inventory **17/17**
- `pregate:preflight` **52 guards clean**
- guard CLI reports the repository clean

## Gate disclosure

Local pregate was NOT run — maintainer-directed bypass, recorded `operator-emergency` override, not `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)