### PR TITLE
fix(readiness): issue executable initiative-readiness recovery packets (BI-9FE775F9)

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/canonical-artifact-discovery.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/canonical-artifact-discovery.test.ts
@@ -39,7 +39,7 @@ describe("canonical design artifact discovery", () => {
     const result = await discoverCanonicalDesignArtifact(args(fetchImpl as unknown as typeof fetch));
 
     expect(result).toEqual({
-      ok: true,
+      resolved: true,
       artifact: { path: "docs/superpowers/specs/2026-08-25-a-design.md", providerBlobId: BLOB_SHA },
     });
     // The compare RANGE, not the head commit: a design authored across several
@@ -54,8 +54,8 @@ describe("canonical design artifact discovery", () => {
 
     const result = await discoverCanonicalDesignArtifact(args(fetchImpl as unknown as typeof fetch));
 
-    expect(result).toMatchObject({ ok: false, code: "no-canonical-design" });
-    expect(result.ok === false && result.nextAction).toContain("docs/superpowers/specs/");
+    expect(result).toMatchObject({ resolved: false, code: "no-canonical-design" });
+    expect(result.resolved === false && result.nextAction).toContain("docs/superpowers/specs/");
   });
 
   it("refuses to choose when more than one spec changed, and names the candidates", async () => {
@@ -66,8 +66,8 @@ describe("canonical design artifact discovery", () => {
 
     const result = await discoverCanonicalDesignArtifact(args(fetchImpl as unknown as typeof fetch));
 
-    expect(result).toMatchObject({ ok: false, code: "ambiguous-canonical-design" });
-    expect(result.ok === false && result.nextAction).toContain("2026-08-25-b-design.md");
+    expect(result).toMatchObject({ resolved: false, code: "ambiguous-canonical-design" });
+    expect(result.resolved === false && result.nextAction).toContain("2026-08-25-b-design.md");
   });
 
   it("ignores a spec the branch deleted", async () => {
@@ -78,7 +78,7 @@ describe("canonical design artifact discovery", () => {
 
     const result = await discoverCanonicalDesignArtifact(args(fetchImpl as unknown as typeof fetch));
 
-    expect(result).toMatchObject({ ok: true, artifact: { providerBlobId: BLOB_SHA } });
+    expect(result).toMatchObject({ resolved: true, artifact: { providerBlobId: BLOB_SHA } });
   });
 
   it("does not call the provider when the workroom records no immutable base", async () => {
@@ -90,8 +90,8 @@ describe("canonical design artifact discovery", () => {
     });
 
     expect(fetchImpl).not.toHaveBeenCalled();
-    expect(result).toMatchObject({ ok: false, code: "provider-unavailable" });
-    expect(result.ok === false && result.nextAction).toContain("adopt_worktree");
+    expect(result).toMatchObject({ resolved: false, code: "provider-unavailable" });
+    expect(result.resolved === false && result.nextAction).toContain("adopt_worktree");
   });
 
   it("reports provider unavailability rather than guessing when the compare fails", async () => {
@@ -99,6 +99,6 @@ describe("canonical design artifact discovery", () => {
 
     const result = await discoverCanonicalDesignArtifact(args(fetchImpl as unknown as typeof fetch));
 
-    expect(result).toMatchObject({ ok: false, code: "provider-unavailable" });
+    expect(result).toMatchObject({ resolved: false, code: "provider-unavailable" });
   });
 });

--- a/apps/web/lib/backlog/initiative-readiness/canonical-artifact-discovery.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/canonical-artifact-discovery.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { discoverCanonicalDesignArtifact } from "./canonical-artifact-discovery";
+
+const BASE_SHA = "1111111111111111111111111111111111111111";
+const HEAD_SHA = "2222222222222222222222222222222222222222";
+const BLOB_SHA = "9f2c1d4e6b8a0c2e4f6a8b0c2d4e6f8a0b2c4d6e";
+const OTHER_BLOB_SHA = "0a1b2c3d4e5f60718293a4b5c6d7e8f900112233";
+
+const db = {
+  credentialEntry: { findUnique: vi.fn().mockResolvedValue(null) },
+  platformDevConfig: { findUnique: vi.fn().mockResolvedValue({ upstreamRemoteUrl: null }) },
+} as unknown as Parameters<typeof discoverCanonicalDesignArtifact>[0]["db"];
+
+function compareResponse(files: unknown) {
+  return {
+    ok: true,
+    json: async () => ({ files }),
+  } as unknown as Response;
+}
+
+function args(fetchImpl: typeof fetch) {
+  return {
+    repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+    baseSha: BASE_SHA,
+    headSha: HEAD_SHA,
+    db,
+    fetchImpl,
+  };
+}
+
+describe("canonical design artifact discovery", () => {
+  it("binds the single spec changed across the branch range, taking the blob id from the provider", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(compareResponse([
+      { filename: "apps/web/lib/thing.ts", sha: OTHER_BLOB_SHA, status: "modified" },
+      { filename: "docs/superpowers/specs/2026-08-25-a-design.md", sha: BLOB_SHA, status: "added" },
+    ]));
+
+    const result = await discoverCanonicalDesignArtifact(args(fetchImpl as unknown as typeof fetch));
+
+    expect(result).toEqual({
+      ok: true,
+      artifact: { path: "docs/superpowers/specs/2026-08-25-a-design.md", providerBlobId: BLOB_SHA },
+    });
+    // The compare RANGE, not the head commit: a design authored across several
+    // commits would be invisible to `GET /commits/{sha}`.
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toContain(`compare/${BASE_SHA}...${HEAD_SHA}`);
+  });
+
+  it("reports no canonical design when the branch changed no spec", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(compareResponse([
+      { filename: "apps/web/lib/thing.ts", sha: OTHER_BLOB_SHA, status: "modified" },
+    ]));
+
+    const result = await discoverCanonicalDesignArtifact(args(fetchImpl as unknown as typeof fetch));
+
+    expect(result).toMatchObject({ ok: false, code: "no-canonical-design" });
+    expect(result.ok === false && result.nextAction).toContain("docs/superpowers/specs/");
+  });
+
+  it("refuses to choose when more than one spec changed, and names the candidates", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(compareResponse([
+      { filename: "docs/superpowers/specs/2026-08-25-a-design.md", sha: BLOB_SHA, status: "added" },
+      { filename: "docs/superpowers/specs/2026-08-25-b-design.md", sha: OTHER_BLOB_SHA, status: "added" },
+    ]));
+
+    const result = await discoverCanonicalDesignArtifact(args(fetchImpl as unknown as typeof fetch));
+
+    expect(result).toMatchObject({ ok: false, code: "ambiguous-canonical-design" });
+    expect(result.ok === false && result.nextAction).toContain("2026-08-25-b-design.md");
+  });
+
+  it("ignores a spec the branch deleted", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(compareResponse([
+      { filename: "docs/superpowers/specs/2026-08-25-a-design.md", sha: BLOB_SHA, status: "added" },
+      { filename: "docs/superpowers/specs/2026-01-01-old-design.md", sha: OTHER_BLOB_SHA, status: "removed" },
+    ]));
+
+    const result = await discoverCanonicalDesignArtifact(args(fetchImpl as unknown as typeof fetch));
+
+    expect(result).toMatchObject({ ok: true, artifact: { providerBlobId: BLOB_SHA } });
+  });
+
+  it("does not call the provider when the workroom records no immutable base", async () => {
+    const fetchImpl = vi.fn();
+
+    const result = await discoverCanonicalDesignArtifact({
+      ...args(fetchImpl as unknown as typeof fetch),
+      baseSha: "",
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ ok: false, code: "provider-unavailable" });
+    expect(result.ok === false && result.nextAction).toContain("adopt_worktree");
+  });
+
+  it("reports provider unavailability rather than guessing when the compare fails", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false } as unknown as Response);
+
+    const result = await discoverCanonicalDesignArtifact(args(fetchImpl as unknown as typeof fetch));
+
+    expect(result).toMatchObject({ ok: false, code: "provider-unavailable" });
+  });
+});

--- a/apps/web/lib/backlog/initiative-readiness/canonical-artifact-discovery.ts
+++ b/apps/web/lib/backlog/initiative-readiness/canonical-artifact-discovery.ts
@@ -17,9 +17,9 @@ export type DiscoveredCanonicalArtifact = {
 };
 
 export type CanonicalArtifactDiscoveryResult =
-  | { ok: true; artifact: DiscoveredCanonicalArtifact }
+  | { resolved: true; artifact: DiscoveredCanonicalArtifact }
   | {
-    ok: false;
+    resolved: false;
     code: "no-canonical-design" | "ambiguous-canonical-design" | "provider-unavailable";
     nextAction: string;
   };
@@ -81,7 +81,7 @@ export async function discoverCanonicalDesignArtifact(args: {
   const db = args.db ?? (prisma as unknown as CanonicalArtifactDb);
   if (!/^[a-f0-9]{40}$/i.test(args.baseSha) || !/^[a-f0-9]{40}$/i.test(args.headSha)) {
     return {
-      ok: false,
+      resolved: false,
       code: "provider-unavailable",
       nextAction: "The workroom does not record an immutable base and head. Re-sync the branch with adopt_worktree(headBranch, headSha), then retry.",
     };
@@ -94,7 +94,7 @@ export async function discoverCanonicalDesignArtifact(args: {
     token = await resolveGithubToken(db);
   } catch {
     return {
-      ok: false,
+      resolved: false,
       code: "provider-unavailable",
       nextAction: "Repository provider credentials are unavailable, so the canonical design cannot be bound. Restore the GitHub credential in Admin > Platform Development, then retry.",
     };
@@ -102,7 +102,7 @@ export async function discoverCanonicalDesignArtifact(args: {
   const expectedFullName = `${repo.owner}/${repo.name}`;
   if (args.repositoryFullName.toLocaleLowerCase("en-US") !== expectedFullName.toLocaleLowerCase("en-US")) {
     return {
-      ok: false,
+      resolved: false,
       code: "provider-unavailable",
       nextAction: `The workroom is bound to ${args.repositoryFullName}, but this installation's canonical repository is ${expectedFullName}. Re-claim the work on the canonical repository, then retry.`,
     };
@@ -123,14 +123,14 @@ export async function discoverCanonicalDesignArtifact(args: {
     );
   } catch {
     return {
-      ok: false,
+      resolved: false,
       code: "provider-unavailable",
       nextAction: "Repository provider could not be reached to resolve the canonical design. Retry once provider access is restored.",
     };
   }
   if (!response.ok) {
     return {
-      ok: false,
+      resolved: false,
       code: "provider-unavailable",
       nextAction: `Repository provider could not compare ${args.baseSha.slice(0, 12)}...${args.headSha.slice(0, 12)}. Confirm the branch is pushed, then retry.`,
     };
@@ -141,7 +141,7 @@ export async function discoverCanonicalDesignArtifact(args: {
     payload = await response.json();
   } catch {
     return {
-      ok: false,
+      resolved: false,
       code: "provider-unavailable",
       nextAction: "Repository provider returned unreadable comparison metadata. Retry once provider access is restored.",
     };
@@ -150,7 +150,7 @@ export async function discoverCanonicalDesignArtifact(args: {
   const files = compareFiles(payload);
   if (!files) {
     return {
-      ok: false,
+      resolved: false,
       code: "provider-unavailable",
       nextAction: "Repository provider returned no comparable file list. Confirm the branch is pushed, then retry.",
     };
@@ -161,14 +161,14 @@ export async function discoverCanonicalDesignArtifact(args: {
     .sort((left, right) => left.filename.localeCompare(right.filename));
   if (candidates.length === 0) {
     return {
-      ok: false,
+      resolved: false,
       code: "no-canonical-design",
       nextAction: `No design document under ${SPEC_PREFIX} changed between ${args.baseSha.slice(0, 12)} and ${args.headSha.slice(0, 12)}. Commit the canonical design there, push it, re-sync the head with adopt_worktree, then retry.`,
     };
   }
   if (candidates.length > 1) {
     return {
-      ok: false,
+      resolved: false,
       code: "ambiguous-canonical-design",
       nextAction: `More than one design document changed on this branch (${
         candidates.map((file) => file.filename).join(", ")
@@ -177,5 +177,5 @@ export async function discoverCanonicalDesignArtifact(args: {
   }
 
   const canonical = candidates[0]!;
-  return { ok: true, artifact: { path: canonical.filename, providerBlobId: canonical.sha } };
+  return { resolved: true, artifact: { path: canonical.filename, providerBlobId: canonical.sha } };
 }

--- a/apps/web/lib/backlog/initiative-readiness/canonical-artifact-discovery.ts
+++ b/apps/web/lib/backlog/initiative-readiness/canonical-artifact-discovery.ts
@@ -1,0 +1,181 @@
+import { prisma } from "@dpf/db";
+
+import {
+  resolveGithubToken,
+  resolveRepoIdentity,
+} from "@/lib/contributor-change-lanes/github-rest-reader";
+
+/**
+ * The db surface is exactly what the shared GitHub reader needs, taken from its
+ * own signature so this module never declares a second shape for the same rows.
+ */
+type CanonicalArtifactDb = Parameters<typeof resolveGithubToken>[0];
+
+export type DiscoveredCanonicalArtifact = {
+  path: string;
+  providerBlobId: string;
+};
+
+export type CanonicalArtifactDiscoveryResult =
+  | { ok: true; artifact: DiscoveredCanonicalArtifact }
+  | {
+    ok: false;
+    code: "no-canonical-design" | "ambiguous-canonical-design" | "provider-unavailable";
+    nextAction: string;
+  };
+
+const SPEC_PREFIX = "docs/superpowers/specs/";
+
+/**
+ * GitHub pages the compare file list. A design branch that changed more files
+ * than one page is already outside what a single canonical design can mean, so
+ * the cap bounds the read rather than paginating toward an answer we would
+ * reject anyway.
+ */
+const COMPARE_FILE_LIMIT = 300;
+
+type CompareFile = { filename: string; sha: string; status: string };
+
+function compareFiles(payload: unknown): CompareFile[] | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const files = (payload as Record<string, unknown>).files;
+  if (!Array.isArray(files)) return null;
+  const rows: CompareFile[] = [];
+  for (const entry of files.slice(0, COMPARE_FILE_LIMIT)) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const row = entry as Record<string, unknown>;
+    const filename = typeof row.filename === "string" ? row.filename : "";
+    const sha = typeof row.sha === "string" ? row.sha : "";
+    const status = typeof row.status === "string" ? row.status : "";
+    if (filename && sha) rows.push({ filename, sha, status });
+  }
+  return rows;
+}
+
+function isCanonicalDesignFile(file: CompareFile): boolean {
+  return file.status !== "removed"
+    && file.filename.startsWith(SPEC_PREFIX)
+    && file.filename.endsWith(".md")
+    && /^[a-f0-9]{40}$/i.test(file.sha);
+}
+
+/**
+ * Resolve the canonical design a Workroom authored on its branch, so a readiness
+ * recovery route can bind a reviewer to exact immutable bytes.
+ *
+ * The blob id comes from the provider's own compare payload and is never derived
+ * locally — `resolveRepositoryArtifact` re-verifies it against `GET /contents`
+ * when the receipt is finally recorded, so a stale or forged locator cannot
+ * survive into a governed receipt.
+ *
+ * The compare RANGE matters: a design is routinely authored across several
+ * commits, and `GET /commits/{sha}` would report only the last one's files.
+ */
+export async function discoverCanonicalDesignArtifact(args: {
+  repositoryFullName: string;
+  baseSha: string;
+  headSha: string;
+  db?: CanonicalArtifactDb;
+  fetchImpl?: typeof fetch;
+}): Promise<CanonicalArtifactDiscoveryResult> {
+  const db = args.db ?? (prisma as unknown as CanonicalArtifactDb);
+  if (!/^[a-f0-9]{40}$/i.test(args.baseSha) || !/^[a-f0-9]{40}$/i.test(args.headSha)) {
+    return {
+      ok: false,
+      code: "provider-unavailable",
+      nextAction: "The workroom does not record an immutable base and head. Re-sync the branch with adopt_worktree(headBranch, headSha), then retry.",
+    };
+  }
+
+  let repo: Awaited<ReturnType<typeof resolveRepoIdentity>>;
+  let token: string | null;
+  try {
+    repo = await resolveRepoIdentity(db);
+    token = await resolveGithubToken(db);
+  } catch {
+    return {
+      ok: false,
+      code: "provider-unavailable",
+      nextAction: "Repository provider credentials are unavailable, so the canonical design cannot be bound. Restore the GitHub credential in Admin > Platform Development, then retry.",
+    };
+  }
+  const expectedFullName = `${repo.owner}/${repo.name}`;
+  if (args.repositoryFullName.toLocaleLowerCase("en-US") !== expectedFullName.toLocaleLowerCase("en-US")) {
+    return {
+      ok: false,
+      code: "provider-unavailable",
+      nextAction: `The workroom is bound to ${args.repositoryFullName}, but this installation's canonical repository is ${expectedFullName}. Re-claim the work on the canonical repository, then retry.`,
+    };
+  }
+
+  let response: Response;
+  try {
+    response = await (args.fetchImpl ?? fetch)(
+      `https://api.github.com/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/compare/${encodeURIComponent(args.baseSha)}...${encodeURIComponent(args.headSha)}`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        cache: "no-store",
+      },
+    );
+  } catch {
+    return {
+      ok: false,
+      code: "provider-unavailable",
+      nextAction: "Repository provider could not be reached to resolve the canonical design. Retry once provider access is restored.",
+    };
+  }
+  if (!response.ok) {
+    return {
+      ok: false,
+      code: "provider-unavailable",
+      nextAction: `Repository provider could not compare ${args.baseSha.slice(0, 12)}...${args.headSha.slice(0, 12)}. Confirm the branch is pushed, then retry.`,
+    };
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    return {
+      ok: false,
+      code: "provider-unavailable",
+      nextAction: "Repository provider returned unreadable comparison metadata. Retry once provider access is restored.",
+    };
+  }
+
+  const files = compareFiles(payload);
+  if (!files) {
+    return {
+      ok: false,
+      code: "provider-unavailable",
+      nextAction: "Repository provider returned no comparable file list. Confirm the branch is pushed, then retry.",
+    };
+  }
+
+  const candidates = files
+    .filter(isCanonicalDesignFile)
+    .sort((left, right) => left.filename.localeCompare(right.filename));
+  if (candidates.length === 0) {
+    return {
+      ok: false,
+      code: "no-canonical-design",
+      nextAction: `No design document under ${SPEC_PREFIX} changed between ${args.baseSha.slice(0, 12)} and ${args.headSha.slice(0, 12)}. Commit the canonical design there, push it, re-sync the head with adopt_worktree, then retry.`,
+    };
+  }
+  if (candidates.length > 1) {
+    return {
+      ok: false,
+      code: "ambiguous-canonical-design",
+      nextAction: `More than one design document changed on this branch (${
+        candidates.map((file) => file.filename).join(", ")
+      }), so the canonical design is ambiguous. Land the others separately, leaving exactly one on this branch, then retry.`,
+    };
+  }
+
+  const canonical = candidates[0]!;
+  return { ok: true, artifact: { path: canonical.filename, providerBlobId: canonical.sha } };
+}

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
@@ -33,6 +33,12 @@ const dispatchContext = {
   headSha: "21103703757a342c828dd6ef1bb9acc97a4b01f8",
 };
 
+const canonicalArtifact = {
+  ok: true as const,
+  path: "docs/superpowers/specs/2026-08-24-wordpress-operator-regressions-design.md",
+  providerBlobId: "9f2c1d4e6b8a0c2e4f6a8b0c2d4e6f8a0b2c4d6e",
+};
+
 function grantRow(grantKey: string, agentId: string, displayName: string) {
   return {
     grantKey,
@@ -60,10 +66,13 @@ describe("initiative readiness recovery routing", () => {
       currentAgentId: "AGT-AUTHOR",
       db: { agentToolGrant: { findMany } },
       dispatchContext,
+      canonicalArtifact,
+      expectedCurrentBaselineId: null,
     });
 
     expect(findMany).toHaveBeenCalledOnce();
     expect(recovery.escalations).toEqual([]);
+    expect(recovery.unroutable).toEqual([]);
     expect(recovery.reviewerRoutes).toMatchObject([
       {
         accountableRole: "design-author",
@@ -76,6 +85,20 @@ describe("initiative readiness recovery routing", () => {
           requestKey: `initiative-readiness:BI-A45D744A:research:${dispatchContext.headSha}`,
           tier: 2,
           enteredVia: "handoff",
+          requiredToolNames: ["record_initiative_evidence", "read_source_at_version"],
+          initiativeReviewBinding: {
+            writerToolName: "record_initiative_evidence",
+            itemId: "BI-A45D744A",
+            gate: "research",
+            expectedCurrentBaselineId: null,
+            artifactRef: {
+              kind: "repo-blob-at-commit",
+              repositoryFullName: dispatchContext.repositoryFullName,
+              commitSha: dispatchContext.headSha,
+              path: canonicalArtifact.path,
+              providerBlobId: canonicalArtifact.providerBlobId,
+            },
+          },
         },
       },
       {
@@ -89,7 +112,76 @@ describe("initiative readiness recovery routing", () => {
           requestKey: `initiative-readiness:BI-A45D744A:dependency-disposition:${dispatchContext.headSha}`,
           tier: 2,
           enteredVia: "handoff",
+          requiredToolNames: ["record_plan_backlog_coverage", "read_source_at_version"],
+          initiativeReviewBinding: {
+            writerToolName: "record_plan_backlog_coverage",
+            gate: "dependency-disposition",
+          },
         },
+      },
+    ]);
+  });
+
+  it("carries the current baseline id into the binding so a superseded design cannot be reviewed", async () => {
+    const recovery = await resolveInitiativeReviewerRecovery({
+      decision,
+      currentAgentId: "AGT-AUTHOR",
+      db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue([
+        grantRow("initiative_evidence_write", "AGT-WS-BUILD", "Build Specialist"),
+      ]) } },
+      dispatchContext,
+      canonicalArtifact,
+      expectedCurrentBaselineId: "IBL-7C41",
+    });
+
+    expect(recovery.reviewerRoutes[0]?.requestCoworker.initiativeReviewBinding.expectedCurrentBaselineId)
+      .toBe("IBL-7C41");
+  });
+
+  it("escalates with the provider remedy instead of emitting a route no coworker can execute", async () => {
+    const recovery = await resolveInitiativeReviewerRecovery({
+      decision,
+      currentAgentId: "AGT-AUTHOR",
+      db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue([
+        grantRow("initiative_evidence_write", "AGT-WS-BUILD", "Build Specialist"),
+        grantRow("backlog_write", "AGT-WS-BUILD", "Build Specialist"),
+      ]) } },
+      dispatchContext,
+      canonicalArtifact: { ok: false, nextAction: "Commit the canonical design under docs/superpowers/specs/, push it, then retry." },
+    });
+
+    expect(recovery.reviewerRoutes).toEqual([]);
+    expect(recovery.escalations).toMatchObject([
+      {
+        accountableRole: "design-author",
+        reason: "no-canonical-artifact",
+        nextAction: "Commit the canonical design under docs/superpowers/specs/, push it, then retry.",
+      },
+      { accountableRole: "implementation-planner", reason: "no-canonical-artifact" },
+    ]);
+  });
+
+  it("surfaces an unmet requirement whose accountable role owns no writer lane", async () => {
+    const recovery = await resolveInitiativeReviewerRecovery({
+      decision: {
+        ...decision,
+        unmet: [
+          { code: "ARTIFACT_AUTHOR_REQUIRED", state: "missing", accountableRole: "artifact-resolver", evidenceRefs: [] },
+        ],
+      },
+      currentAgentId: "AGT-AUTHOR",
+      db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue([]) } },
+      dispatchContext,
+      canonicalArtifact,
+    });
+
+    expect(recovery.reviewerRoutes).toEqual([]);
+    expect(recovery.escalations).toEqual([]);
+    expect(recovery.unroutable).toMatchObject([
+      {
+        accountableRole: "artifact-resolver",
+        code: "ARTIFACT_AUTHOR_REQUIRED",
+        nextAction: expect.stringContaining("git commit -s"),
       },
     ]);
   });
@@ -103,6 +195,7 @@ describe("initiative readiness recovery routing", () => {
         grantRow("backlog_write", "AGT-WS-BUILD", "Build Specialist"),
       ]) } },
       dispatchContext: null,
+      canonicalArtifact,
     });
 
     expect(recovery.reviewerRoutes).toEqual([]);

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
@@ -34,7 +34,7 @@ const dispatchContext = {
 };
 
 const canonicalArtifact = {
-  ok: true as const,
+  resolved: true as const,
   path: "docs/superpowers/specs/2026-08-24-wordpress-operator-regressions-design.md",
   providerBlobId: "9f2c1d4e6b8a0c2e4f6a8b0c2d4e6f8a0b2c4d6e",
 };
@@ -147,7 +147,7 @@ describe("initiative readiness recovery routing", () => {
         grantRow("backlog_write", "AGT-WS-BUILD", "Build Specialist"),
       ]) } },
       dispatchContext,
-      canonicalArtifact: { ok: false, nextAction: "Commit the canonical design under docs/superpowers/specs/, push it, then retry." },
+      canonicalArtifact: { resolved: false, nextAction: "Commit the canonical design under docs/superpowers/specs/, push it, then retry." },
     });
 
     expect(recovery.reviewerRoutes).toEqual([]);

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.ts
@@ -49,6 +49,25 @@ export function readinessLaneForRole(role: string): { toolName: string; lane: In
   return null;
 }
 
+/**
+ * The exact immutable identity a dispatched reviewer is bound to. Shaped to
+ * satisfy `parseInitiativeReviewBinding` so a server-issued route is executable
+ * as-issued, without the caller reshaping — or inventing — any part of it.
+ */
+export type InitiativeReviewBindingPacket = {
+  writerToolName: string;
+  itemId: string;
+  gate: InitiativeGateKey;
+  expectedCurrentBaselineId: string | null;
+  artifactRef: {
+    kind: "repo-blob-at-commit";
+    repositoryFullName: string;
+    commitSha: string;
+    path: string;
+    providerBlobId: string;
+  };
+};
+
 export type InitiativeReviewerRecovery = {
   reviewerRoutes: Array<{
     accountableRole: string;
@@ -69,6 +88,8 @@ export type InitiativeReviewerRecovery = {
       requestKey: string;
       tier: 2;
       enteredVia: "handoff";
+      requiredToolNames: string[];
+      initiativeReviewBinding: InitiativeReviewBindingPacket;
     };
   }>;
   escalations: Array<{
@@ -83,12 +104,27 @@ export type InitiativeReviewerRecovery = {
      * - "dispatch-context-required": an eligible reviewer WAS found, but no
      *   Workroom branch + immutable head was supplied to bind the request to.
      *   Nothing is wrong with the reviewer roster.
+     * - "no-canonical-artifact": an eligible reviewer AND an immutable head were
+     *   both found, but the canonical design could not be resolved from the
+     *   repository provider, so no binding can be issued. Again, nothing is
+     *   wrong with the reviewer roster.
      *
-     * These were one value until 2026-08-26. Reporting a found reviewer as
-     * "no-eligible-reviewer" reads as a permanent dead end and sends the caller
-     * hunting for missing grants instead of supplying the dispatch context.
+     * The first two were one value until 2026-08-26. Reporting a found reviewer
+     * as "no-eligible-reviewer" reads as a permanent dead end and sends the
+     * caller hunting for missing grants instead of supplying what is actually
+     * missing.
      */
-    reason: "no-eligible-reviewer" | "dispatch-context-required";
+    reason: "no-eligible-reviewer" | "dispatch-context-required" | "no-canonical-artifact";
+    nextAction: string;
+  }>;
+  /**
+   * Unmet requirements whose accountable role has no writer lane. They are
+   * reported rather than dropped: a requirement that vanishes from recovery
+   * reads as satisfied, which is the worse failure (BI-9FE775F9).
+   */
+  unroutable: Array<{
+    accountableRole: string;
+    code: ReadinessCode;
     nextAction: string;
   }>;
 };
@@ -99,6 +135,15 @@ export type InitiativeRecoveryDispatchContext = {
   branchName: string;
   headSha: string;
 };
+
+/**
+ * The canonical design the reviewer must inspect, resolved from the repository
+ * provider by the caller. This module stays free of provider I/O so it remains
+ * a pure routing decision over evidence it is handed.
+ */
+export type InitiativeRecoveryCanonicalArtifact =
+  | { ok: true; path: string; providerBlobId: string }
+  | { ok: false; nextAction: string };
 
 type ReviewerRouteDb = {
   agentToolGrant?: {
@@ -121,6 +166,8 @@ export async function resolveInitiativeReviewerRecovery(input: {
   currentAgentId: string | null;
   db: ReviewerRouteDb;
   dispatchContext: InitiativeRecoveryDispatchContext | null;
+  canonicalArtifact?: InitiativeRecoveryCanonicalArtifact | null;
+  expectedCurrentBaselineId?: string | null;
 }): Promise<InitiativeReviewerRecovery> {
   const requirements = [...input.decision.blockers, ...input.decision.unmet];
   const requested: Array<{
@@ -129,16 +176,26 @@ export async function resolveInitiativeReviewerRecovery(input: {
     route: NonNullable<ReturnType<typeof readinessLaneForRole>>;
     gate: InitiativeGateKey;
   }> = [];
+  const unroutable: InitiativeReviewerRecovery["unroutable"] = [];
   for (const entry of requirements) {
     const route = readinessLaneForRole(entry.accountableRole);
     const gate = route ? recoveryGate(entry, route.lane) : null;
-    if (route && gate) requested.push({ entry, role: entry.accountableRole, route, gate });
+    if (route && gate) {
+      requested.push({ entry, role: entry.accountableRole, route, gate });
+      continue;
+    }
+    unroutable.push({
+      accountableRole: entry.accountableRole,
+      code: entry.code,
+      nextAction: UNROUTABLE_REMEDIES[entry.code]
+        ?? `No writer lane records ${entry.code}. Resolve it through the ${entry.accountableRole} surface that owns it.`,
+    });
   }
   const distinct = [...new Map(requested.map((entry) => [
     `${entry.role}:${entry.route.toolName}:${entry.gate}`,
     entry,
   ])).values()];
-  if (distinct.length === 0) return { reviewerRoutes: [], escalations: [] };
+  if (distinct.length === 0) return { reviewerRoutes: [], escalations: [], unroutable };
 
   const grants = [...new Set(distinct.map((entry) => entry.route.lane.grant))];
   const rows = input.db.agentToolGrant
@@ -176,6 +233,23 @@ export async function resolveInitiativeReviewerRecovery(input: {
         });
         continue;
       }
+      // A route without a binding is not a lesser route — it is an unusable one:
+      // `request_coworker` rejects `requiredToolNames` unless the binding comes
+      // with it, so emitting it would spend a dispatch and a TaskRun to fail at
+      // the callee. Escalate with the remedy instead (BI-9FE775F9).
+      const artifact = input.canonicalArtifact ?? null;
+      if (!artifact || !artifact.ok) {
+        escalations.push({
+          accountableRole: entry.role,
+          toolName: entry.route.toolName,
+          grant: entry.route.lane.grant,
+          reason: "no-canonical-artifact",
+          nextAction: artifact?.ok === false
+            ? artifact.nextAction
+            : "The canonical design artifact could not be resolved from the repository provider, so no immutable reviewer binding can be issued. Resolve the canonical design, then retry.",
+        });
+        continue;
+      }
       const packet = requestCoworkerPacket({
         decision: input.decision,
         gate: entry.gate,
@@ -183,6 +257,8 @@ export async function resolveInitiativeReviewerRecovery(input: {
         targetAgentId: candidate.agent.agentId,
         dispatch: input.dispatchContext,
         independent: entry.route.lane.independent,
+        artifact,
+        expectedCurrentBaselineId: input.expectedCurrentBaselineId ?? null,
       });
       reviewerRoutes.push({
         accountableRole: entry.role,
@@ -208,8 +284,27 @@ export async function resolveInitiativeReviewerRecovery(input: {
       nextAction: `Assign or activate a production reviewer with exact grant ${entry.route.lane.grant}; do not proxy the receipt.`,
     });
   }
-  return { reviewerRoutes, escalations };
+  return { reviewerRoutes, escalations, unroutable };
 }
+
+/**
+ * Remedies for requirements whose accountable role owns no writer tool. These
+ * are not missing lanes: `ARTIFACT_AUTHOR_REQUIRED` is satisfied by the commit
+ * carrying a DCO trailer owned by the Workroom principal, not by anyone
+ * recording a receipt. Inventing a lane would invent an approver.
+ */
+const UNROUTABLE_REMEDIES: Partial<Record<ReadinessCode, string>> = {
+  ARTIFACT_AUTHOR_REQUIRED: "Sign the design commit off (git commit -s), push the rewritten sha, then re-sync the workroom head with adopt_worktree.",
+  CLASSIFICATION_REQUIRED: "Classify the demand before shaping it: set the investment bucket and score inputs on the backlog item.",
+  AUTHORIZATION_DENIED: "The caller's authority does not cover this transition. Re-run from a principal holding the required capability.",
+  CAPSULE_IDENTITY_MISMATCH: "The workroom's recorded branch and head no longer match the claim. Re-sync with adopt_worktree(headBranch, headSha).",
+  DELIVERY_EVIDENCE_REQUIRED: "Record delivery evidence for the merged change with record_execution_evidence.",
+  ACCEPTANCE_EVIDENCE_REQUIRED: "Record acceptance evidence against the objective baseline before closing the item.",
+  OBJECTIVE_RECONCILIATION_REQUIRED: "Reconcile delivered outcomes against the objective baseline with record_product_outcome_observation.",
+  OBJECTIVE_BASELINE_CONFLICT: "Two objective baselines disagree. Supersede the stale baseline, leaving exactly one chain head.",
+  READINESS_PROJECTION_FAILED: "Readiness projection failed to read this item's evidence. Report it; do not retry blindly.",
+  STALE_EVIDENCE: "Recorded evidence is bound to a superseded artifact. Re-record it against the current immutable head.",
+};
 
 const REQUIREMENT_GATES: Partial<Record<ReadinessCode, InitiativeGateKey>> = {
   CANONICAL_DESIGN_REQUIRED: "design-spec",
@@ -232,6 +327,14 @@ function recoveryGate(entry: ReadinessRequirementResult, lane: InitiativeReadine
   return lane.gates.length === 1 ? lane.gates[0] ?? null : null;
 }
 
+/**
+ * The immutable reader the dispatched coworker is granted alongside its writer.
+ * `initiativeReviewPacket` permits only `read_source_at_version` and
+ * `search_source_at_version`; a route binds one exact blob, so the point read is
+ * the whole need and the broader search grant is not issued.
+ */
+const IMMUTABLE_READER_TOOL = "read_source_at_version";
+
 function requestCoworkerPacket(args: {
   decision: InitiativeReadinessDecision;
   gate: InitiativeGateKey;
@@ -239,14 +342,30 @@ function requestCoworkerPacket(args: {
   targetAgentId: string;
   dispatch: InitiativeRecoveryDispatchContext;
   independent: boolean;
+  artifact: { path: string; providerBlobId: string };
+  expectedCurrentBaselineId: string | null;
 }) {
   const reviewConstraint = args.independent ? "independently " : "";
   return {
     targetAgent: args.targetAgentId,
-    objective: `For ${args.decision.subject.id} in ${args.dispatch.workroomId} on ${args.dispatch.repositoryFullName}#${args.dispatch.branchName} at ${args.dispatch.headSha}, ${reviewConstraint}address ${args.gate} using ${args.toolName}. Verify the canonical immutable artifact and record a governed receipt only when the gate passes.`,
+    objective: `For ${args.decision.subject.id} in ${args.dispatch.workroomId} on ${args.dispatch.repositoryFullName}#${args.dispatch.branchName} at ${args.dispatch.headSha}, ${reviewConstraint}address ${args.gate} using ${args.toolName}. Read ${args.artifact.path} at that commit with ${IMMUTABLE_READER_TOOL}, then record a governed receipt only when the gate passes.`,
     questionPacketSummary: `${args.gate} for ${args.decision.subject.id} at ${args.dispatch.headSha.slice(0, 12)}`,
     requestKey: `initiative-readiness:${args.decision.subject.id}:${args.gate}:${args.dispatch.headSha}`,
     tier: 2 as const,
     enteredVia: "handoff" as const,
+    requiredToolNames: [args.toolName, IMMUTABLE_READER_TOOL],
+    initiativeReviewBinding: {
+      writerToolName: args.toolName,
+      itemId: args.decision.subject.id,
+      gate: args.gate,
+      expectedCurrentBaselineId: args.expectedCurrentBaselineId,
+      artifactRef: {
+        kind: "repo-blob-at-commit" as const,
+        repositoryFullName: args.dispatch.repositoryFullName,
+        commitSha: args.dispatch.headSha,
+        path: args.artifact.path,
+        providerBlobId: args.artifact.providerBlobId,
+      },
+    },
   };
 }

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.ts
@@ -142,8 +142,8 @@ export type InitiativeRecoveryDispatchContext = {
  * a pure routing decision over evidence it is handed.
  */
 export type InitiativeRecoveryCanonicalArtifact =
-  | { ok: true; path: string; providerBlobId: string }
-  | { ok: false; nextAction: string };
+  | { resolved: true; path: string; providerBlobId: string }
+  | { resolved: false; nextAction: string };
 
 type ReviewerRouteDb = {
   agentToolGrant?: {
@@ -238,13 +238,13 @@ export async function resolveInitiativeReviewerRecovery(input: {
       // with it, so emitting it would spend a dispatch and a TaskRun to fail at
       // the callee. Escalate with the remedy instead (BI-9FE775F9).
       const artifact = input.canonicalArtifact ?? null;
-      if (!artifact || !artifact.ok) {
+      if (!artifact || !artifact.resolved) {
         escalations.push({
           accountableRole: entry.role,
           toolName: entry.route.toolName,
           grant: entry.route.lane.grant,
           reason: "no-canonical-artifact",
-          nextAction: artifact?.ok === false
+          nextAction: artifact?.resolved === false
             ? artifact.nextAction
             : "The canonical design artifact could not be resolved from the repository provider, so no immutable reviewer binding can be issued. Resolve the canonical design, then retry.",
         });

--- a/apps/web/lib/work-capsules/governed-work-claim.test.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.test.ts
@@ -4,6 +4,13 @@ import { claimGovernedBacklogWorkspace } from "./governed-work-claim";
 import type { CapsuleDb } from "./work-capsule-store-types";
 
 const actor = { userId: "user-1", agentId: "AGT-1", principalId: "PRN-1" };
+const CANONICAL_DESIGN_PATH = "docs/superpowers/specs/2026-08-22-entry-design.md";
+const CANONICAL_BLOB_SHA = "9f2c1d4e6b8a0c2e4f6a8b0c2d4e6f8a0b2c4d6e";
+const discoverCanonicalArtifact = vi.fn().mockResolvedValue({
+  ok: true,
+  path: CANONICAL_DESIGN_PATH,
+  providerBlobId: CANONICAL_BLOB_SHA,
+});
 const input = {
   backlogItemId: "BI-ENTRY",
   repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
@@ -47,6 +54,7 @@ function database(activities: unknown[] = []) {
           repositoryFullName: input.repositoryFullName,
           headBranch: input.headBranch,
           headSha: "1111111111111111111111111111111111111111",
+          baseSha: "3333333333333333333333333333333333333333",
           archivedAt: null,
         })),
       // Recovery matches rooms on branch identity (BI-512214EA), so the default
@@ -71,6 +79,7 @@ function database(activities: unknown[] = []) {
         repositoryFullName: input.repositoryFullName,
         headBranch: input.headBranch,
         headSha: "1111111111111111111111111111111111111111",
+        baseSha: "3333333333333333333333333333333333333333",
         backlogItemId: null,
       }]),
       update: vi.fn(),
@@ -118,7 +127,7 @@ describe("claimGovernedBacklogWorkspace", () => {
       actor,
       workIntent: null,
       now: new Date("2026-08-22T00:00:00.000Z"),
-      dependencies: { claimWorkspace: vi.fn() },
+      dependencies: { claimWorkspace: vi.fn(), discoverCanonicalArtifact },
     });
 
     expect(result.ok).toBe(false);
@@ -145,6 +154,7 @@ describe("claimGovernedBacklogWorkspace", () => {
           repositoryFullName: input.repositoryFullName,
           headBranch: input.headBranch,
           headSha: "3333333333333333333333333333333333333333",
+          baseSha: "4444444444444444444444444444444444444444",
           backlogItemId: "BI-ENTRY",
         },
       ]);
@@ -155,7 +165,7 @@ describe("claimGovernedBacklogWorkspace", () => {
       actor,
       workIntent: null,
       now: new Date("2026-08-22T00:00:00.000Z"),
-      dependencies: { claimWorkspace: vi.fn() },
+      dependencies: { claimWorkspace: vi.fn(), discoverCanonicalArtifact },
     });
 
     const routes = result.ok ? [] : result.data.recovery.reviewerRoutes;
@@ -174,9 +184,14 @@ describe("claimGovernedBacklogWorkspace", () => {
       actor,
       workIntent: null,
       now: new Date("2026-08-22T00:00:00.000Z"),
-      dependencies: { claimWorkspace },
+      dependencies: { claimWorkspace, discoverCanonicalArtifact },
     });
 
+    expect(discoverCanonicalArtifact).toHaveBeenCalledWith({
+      repositoryFullName: input.repositoryFullName,
+      baseSha: "3333333333333333333333333333333333333333",
+      headSha: "1111111111111111111111111111111111111111",
+    });
     expect(result).toMatchObject({
       ok: false,
       data: {
@@ -199,6 +214,20 @@ describe("claimGovernedBacklogWorkspace", () => {
               requestKey: "initiative-readiness:BI-ENTRY:design-spec:1111111111111111111111111111111111111111",
               tier: 2,
               enteredVia: "handoff",
+              requiredToolNames: ["record_initiative_design_review", "read_source_at_version"],
+              initiativeReviewBinding: {
+                writerToolName: "record_initiative_design_review",
+                itemId: "BI-ENTRY",
+                gate: "design-spec",
+                expectedCurrentBaselineId: null,
+                artifactRef: {
+                  kind: "repo-blob-at-commit",
+                  repositoryFullName: input.repositoryFullName,
+                  commitSha: "1111111111111111111111111111111111111111",
+                  path: CANONICAL_DESIGN_PATH,
+                  providerBlobId: CANONICAL_BLOB_SHA,
+                },
+              },
             },
           })]),
         },
@@ -241,7 +270,7 @@ describe("claimGovernedBacklogWorkspace", () => {
       actor,
       workIntent: "implementation",
       now: new Date("2026-08-22T00:00:00.000Z"),
-      dependencies: { claimWorkspace: vi.fn() },
+      dependencies: { claimWorkspace: vi.fn(), discoverCanonicalArtifact },
     });
 
     expect(result).toMatchObject({
@@ -276,7 +305,7 @@ describe("claimGovernedBacklogWorkspace", () => {
       actor,
       workIntent: "design",
       now: new Date("2026-08-22T00:00:00.000Z"),
-      dependencies: { claimWorkspace, declareIntent },
+      dependencies: { claimWorkspace, declareIntent, discoverCanonicalArtifact },
     });
 
     expect(result).toMatchObject({
@@ -327,7 +356,7 @@ describe("claimGovernedBacklogWorkspace", () => {
       actor,
       workIntent: "design",
       now: new Date("2026-08-22T00:00:00.000Z"),
-      dependencies: { claimWorkspace, declareIntent },
+      dependencies: { claimWorkspace, declareIntent, discoverCanonicalArtifact },
     });
 
     expect(result).toMatchObject({ ok: false, data: { code: "capsule_identity_mismatch" } });

--- a/apps/web/lib/work-capsules/governed-work-claim.test.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.test.ts
@@ -7,7 +7,7 @@ const actor = { userId: "user-1", agentId: "AGT-1", principalId: "PRN-1" };
 const CANONICAL_DESIGN_PATH = "docs/superpowers/specs/2026-08-22-entry-design.md";
 const CANONICAL_BLOB_SHA = "9f2c1d4e6b8a0c2e4f6a8b0c2d4e6f8a0b2c4d6e";
 const discoverCanonicalArtifact = vi.fn().mockResolvedValue({
-  ok: true,
+  resolved: true,
   path: CANONICAL_DESIGN_PATH,
   providerBlobId: CANONICAL_BLOB_SHA,
 });

--- a/apps/web/lib/work-capsules/governed-work-claim.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.ts
@@ -14,6 +14,8 @@ import {
 import { err, ok, type ActionResult } from "@/lib/shared/action-result";
 import {
   resolveInitiativeReviewerRecovery,
+  type InitiativeRecoveryCanonicalArtifact,
+  type InitiativeRecoveryDispatchContext,
   type InitiativeReviewerRecovery,
 } from "@/lib/tak/initiative-readiness-tool-grants";
 
@@ -38,7 +40,28 @@ type ClaimResult = Awaited<ReturnType<typeof claimBacklogItemWorkspace>>;
 type Dependencies = {
   claimWorkspace?: typeof claimBacklogItemWorkspace;
   declareIntent?: typeof declareWorkCapsuleIntent;
+  discoverCanonicalArtifact?: DiscoverCanonicalArtifact;
 };
+
+type DiscoverCanonicalArtifact = (args: {
+  repositoryFullName: string;
+  baseSha: string;
+  headSha: string;
+}) => Promise<InitiativeRecoveryCanonicalArtifact>;
+
+async function discoverCanonicalArtifactFromProvider(args: {
+  repositoryFullName: string;
+  baseSha: string;
+  headSha: string;
+}): Promise<InitiativeRecoveryCanonicalArtifact> {
+  const { discoverCanonicalDesignArtifact } = await import(
+    "@/lib/backlog/initiative-readiness/canonical-artifact-discovery"
+  );
+  const found = await discoverCanonicalDesignArtifact(args);
+  return found.ok
+    ? { ok: true, path: found.artifact.path, providerBlobId: found.artifact.providerBlobId }
+    : { ok: false, nextAction: found.nextAction };
+}
 
 type ExactReadback = {
   capsuleId: string;
@@ -76,6 +99,49 @@ export type GovernedClaimResult =
 
 function claimSuccess(data: GovernedClaimSuccess): GovernedClaimSuccessResult {
   return ok(data) as GovernedClaimSuccessResult;
+}
+
+const EMPTY_RECOVERY: InitiativeReviewerRecovery = { reviewerRoutes: [], escalations: [], unroutable: [] };
+
+type PendingRecovery = {
+  decision: InitiativeReadinessDecision;
+  baselineId: string | null;
+  dispatchContext: InitiativeRecoveryDispatchContext | null;
+  baseSha: string | null;
+};
+
+/**
+ * Binding a reviewer to the canonical design costs one repository-provider round
+ * trip, so it runs after the readiness transaction commits rather than holding
+ * it open (BI-9FE775F9). The decision itself is already recorded; this only
+ * shapes the recovery the blocked caller is handed back.
+ */
+async function resolveRecoveryOutsideTransaction(args: {
+  db: CapsuleDb;
+  actor: WorkCapsuleActor;
+  pending: PendingRecovery;
+  discover: DiscoverCanonicalArtifact;
+}): Promise<InitiativeReviewerRecovery> {
+  const { pending } = args;
+  const canonicalArtifact: InitiativeRecoveryCanonicalArtifact = pending.dispatchContext && pending.baseSha
+    ? await args.discover({
+      repositoryFullName: pending.dispatchContext.repositoryFullName,
+      baseSha: pending.baseSha,
+      headSha: pending.dispatchContext.headSha,
+    })
+    : {
+      ok: false,
+      nextAction: "The workroom records no immutable base and head, so no reviewer binding can be issued. Re-sync the branch with adopt_worktree(headBranch, headSha), then retry.",
+    };
+
+  return resolveInitiativeReviewerRecovery({
+    decision: pending.decision,
+    currentAgentId: args.actor.agentId,
+    db: args.db,
+    dispatchContext: pending.dispatchContext,
+    canonicalArtifact,
+    expectedCurrentBaselineId: pending.baselineId,
+  });
 }
 
 class CapsuleIdentityMismatch extends Error {
@@ -202,9 +268,10 @@ export async function claimGovernedBacklogWorkspace(args: {
     : <T>(fn: (tx: CapsuleDb) => Promise<T>) => fn(args.db);
   let backlogItemRowId = "";
   let evaluated: InitiativeReadinessDecision | null = null;
+  let pendingRecovery: PendingRecovery | null = null;
 
   try {
-    return await transact(async (tx) => {
+    const outcome = await transact(async (tx) => {
       if (!tx.backlogItem || !tx.backlogItemActivity) throw new Error("Readiness transaction lost backlog access.");
       const item = await tx.backlogItem.findFirst({
         where: { OR: [{ itemId: args.input.backlogItemId }, { id: args.input.backlogItemId }] },
@@ -263,6 +330,7 @@ export async function claimGovernedBacklogWorkspace(args: {
             headBranch: true,
             headSha: true,
             backlogItemId: true,
+            baseSha: true,
           },
         }) as Array<{
           capsuleId: string;
@@ -270,6 +338,7 @@ export async function claimGovernedBacklogWorkspace(args: {
           headBranch: string;
           headSha: string | null;
           backlogItemId: string | null;
+          baseSha: string | null;
         }>;
         // Deterministic: an explicit binding to THIS item wins; otherwise the
         // first room on this branch that carries an immutable head.
@@ -277,21 +346,30 @@ export async function claimGovernedBacklogWorkspace(args: {
           recoveryWorkrooms.find((room) => room.backlogItemId === item.itemId && room.headSha)
           ?? recoveryWorkrooms.find((room) => room.headSha)
           ?? null;
-        const recovery = await resolveInitiativeReviewerRecovery({
+        // Recovery needs a repository-provider round trip to bind the canonical
+        // design (BI-9FE775F9). That must not run inside this transaction, so
+        // the not-ready path records its decision here and resolves recovery
+        // after the commit.
+        pendingRecovery = {
           decision: evaluated,
-          currentAgentId: args.actor.agentId,
-          db: tx,
+          baselineId: projection.baselineId,
           dispatchContext: recoveryWorkroom?.headSha ? {
             workroomId: recoveryWorkroom.capsuleId,
             repositoryFullName: recoveryWorkroom.repositoryFullName,
             branchName: recoveryWorkroom.headBranch,
             headSha: recoveryWorkroom.headSha,
           } : null,
-        });
+          baseSha: recoveryWorkroom?.baseSha ?? null,
+        };
         await recordDecision({ db: tx, backlogItemRowId: item.id, decision: evaluated, workIntent, actor: args.actor });
         return {
           ...err(`Cannot start ${workIntent}: ${[...evaluated.blockers, ...evaluated.unmet].map((entry) => entry.code).join(", ")}.`),
-          data: { code: "initiative_not_ready" as const, workIntent, readiness: evaluated, recovery },
+          data: {
+            code: "initiative_not_ready" as const,
+            workIntent,
+            readiness: evaluated,
+            recovery: EMPTY_RECOVERY,
+          },
         };
       }
 
@@ -325,6 +403,19 @@ export async function claimGovernedBacklogWorkspace(args: {
       await recordDecision({ db: tx, backlogItemRowId: item.id, decision: evaluated, workIntent, actor: args.actor });
       return claimSuccess({ workIntent, readiness: evaluated, claim, readback });
     });
+    if (!pendingRecovery || outcome.ok) return outcome;
+    return {
+      ...outcome,
+      data: {
+        ...outcome.data,
+        recovery: await resolveRecoveryOutsideTransaction({
+          db: args.db,
+          actor: args.actor,
+          pending: pendingRecovery,
+          discover: args.dependencies?.discoverCanonicalArtifact ?? discoverCanonicalArtifactFromProvider,
+        }),
+      },
+    };
   } catch (error) {
     if (!(error instanceof CapsuleIdentityMismatch) || !evaluated || !backlogItemRowId) throw error;
     const priorDecision = evaluated as InitiativeReadinessDecision;
@@ -340,7 +431,7 @@ export async function claimGovernedBacklogWorkspace(args: {
         code: "capsule_identity_mismatch",
         workIntent,
         readiness: denied,
-        recovery: { reviewerRoutes: [], escalations: [] },
+        recovery: EMPTY_RECOVERY,
       },
     };
   }

--- a/apps/web/lib/work-capsules/governed-work-claim.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.ts
@@ -58,9 +58,9 @@ async function discoverCanonicalArtifactFromProvider(args: {
     "@/lib/backlog/initiative-readiness/canonical-artifact-discovery"
   );
   const found = await discoverCanonicalDesignArtifact(args);
-  return found.ok
-    ? { ok: true, path: found.artifact.path, providerBlobId: found.artifact.providerBlobId }
-    : { ok: false, nextAction: found.nextAction };
+  return found.resolved
+    ? { resolved: true, path: found.artifact.path, providerBlobId: found.artifact.providerBlobId }
+    : { resolved: false, nextAction: found.nextAction };
 }
 
 type ExactReadback = {
@@ -130,7 +130,7 @@ async function resolveRecoveryOutsideTransaction(args: {
       headSha: pending.dispatchContext.headSha,
     })
     : {
-      ok: false,
+      resolved: false,
       nextAction: "The workroom records no immutable base and head, so no reviewer binding can be issued. Re-sync the branch with adopt_worktree(headBranch, headSha), then retry.",
     };
 

--- a/docs/superpowers/specs/2026-08-25-initiative-readiness-reviewer-packet-design.md
+++ b/docs/superpowers/specs/2026-08-25-initiative-readiness-reviewer-packet-design.md
@@ -1,4 +1,5 @@
 ---
+status: active
 title: Executable initiative-readiness recovery packets
 ---
 

--- a/docs/superpowers/specs/2026-08-25-initiative-readiness-reviewer-packet-design.md
+++ b/docs/superpowers/specs/2026-08-25-initiative-readiness-reviewer-packet-design.md
@@ -202,12 +202,32 @@ which is not a hot path.
 4. Documentation impact: the MCP authorization runbook describes recovery
    routes and is updated in the same branch.
 
-## 12. Out of scope — recorded, not fixed here
+## 12. Corroborating evidence, and one open ergonomic gap
 
-Recording plain `evidence` activity does not move readiness. On `BI-7A38F667`
-the author recorded `source_verified` evidence at `2026-08-26T00:17:49Z`
-(`cmt9chl9i016a01qvyvm3jbbt`) and the readiness `factsDigest` stayed byte-
-identical at `0d69fc1daf7f...` across it and both later retries. Readiness counts
-only `initiative_gate_receipt` activities. This is a distinct defect on the same
-epic and needs its own backlog item; an executable packet is a precondition for
-fixing it, not a substitute.
+On `BI-7A38F667` the author recorded `source_verified` evidence at
+`2026-08-26T00:17:49Z` (`cmt9chl9i016a01qvyvm3jbbt`) naming the design at
+`e5f86ccb...`, and the readiness `factsDigest` stayed byte-identical at
+`0d69fc1daf7f...` across it and both later retries.
+
+That is **correct behaviour, not a second defect.** Readiness counts
+`initiative_gate_receipt` activities; a plain `evidence` row is a note, not a
+governed receipt, and must not move a gate. It is the *symptom* of the defect
+fixed here: the author could not reach `record_initiative_evidence` — no grant,
+and the recovery route that should have summoned a holder was unexecutable — so
+they recorded the nearest thing they could reach instead.
+
+The one genuine gap left is ergonomic: nothing told the author their evidence
+would not count. `record_initiative_evidence` is the governed writer, and the
+generic evidence tool is silently adjacent to it. Worth a separate item once
+this lands and the reachable path is proven; not worth guessing at now.
+
+## 13. Relationship to `BI-329AD58D`
+
+`BI-329AD58D` covers the consumer half — carrying a binding through threadless
+`request_coworker` / `summon_coworker` into `mcp-task-submit`, and narrowing the
+attached tool surface. That half is already on `main`: `coworker-pack.ts`
+declares both fields and `external-coworker-task-adapter.ts` validates and
+forwards them. This change is the producer half that half was waiting on, and it
+is what makes that item's acceptance criterion 1 — "a readiness recovery packet
+passed through threadless request/summon carries an immutable
+`initiativeReviewBinding` and exact required tool names" — reachable end to end.

--- a/docs/superpowers/specs/2026-08-25-initiative-readiness-reviewer-packet-design.md
+++ b/docs/superpowers/specs/2026-08-25-initiative-readiness-reviewer-packet-design.md
@@ -1,0 +1,213 @@
+---
+title: Executable initiative-readiness recovery packets
+---
+
+# Executable initiative-readiness recovery packets
+
+**Backlog item:** `BI-9FE775F9`
+**Epic:** `EP-129D11FD` — Initiative Readiness and Governed Completion Enforcement
+**Observed on:** `BI-7A38F667` / `WC-16B8E810` at head `e5f86ccbfb368c5cfa7571173d50a08ce66920ef`
+
+## 1. Decision summary
+
+When governed readiness refuses a claim, the server hands back reviewer routes
+so the blocked Workroom can recover without an administrative database edit.
+Those routes are not executable today. `requestCoworkerPacket` emits six fields;
+`request_coworker` needs two more — `initiativeReviewBinding` and
+`requiredToolNames` — before it will grant the dispatched coworker the writer
+tool and the immutable artifact identity. The dispatched reviewer therefore
+arrives with neither the document to inspect nor the grant to record a result.
+
+The generator is not withholding the fields. It cannot build them: an
+`initiativeReviewBinding` requires `artifactRef.path` and
+`artifactRef.providerBlobId`, and the recovery path has never known either. The
+code refuses to invent them, correctly — but it then emits an unusable packet
+instead of saying so.
+
+This change gives recovery a real canonical-artifact source, mints the binding
+from it, and makes every unroutable requirement escalate out loud.
+
+## 2. Outcomes and objective baseline
+
+| Objective | Baseline | Target |
+|---|---|---|
+| `OBJ-PACKET-EXECUTABLE` | Reviewer routes omit `initiativeReviewBinding` and `requiredToolNames`, so `request_coworker` dispatches without the writer tool. | A route carries the exact writer, the immutable readers, and a provider-verified artifact binding. |
+| `OBJ-PACKET-HONEST` | When no artifact can be bound, the route is emitted anyway and fails at the callee. | When no artifact can be bound, recovery emits an escalation naming the missing input and its remedy. |
+| `OBJ-PACKET-COMPLETE` | `artifact-resolver`, `delivery-coordinator` and `acceptance-reviewer` have no lane, so their requirements vanish from recovery. | Every unmet requirement produces a route or an escalation; none is silently dropped. |
+
+## 3. Research & benchmarking
+
+- **GitHub Checks / required reviewers.** A check run binds to an exact `head_sha`
+  and the reviewer resolves the diff itself. **Adopt:** the immutable head is the
+  binding key. **Reject:** letting the reviewer choose the artifact — DPF's
+  receipt must name the reviewed bytes, not a branch that can move.
+- **Gerrit change-ref review.** Each patchset is a distinct immutable ref, and
+  review authority is granted per-ref. **Adopt:** per-artifact authority scope
+  rather than a standing grant. **Reject:** Gerrit's separate review namespace;
+  DPF already has Workroom head identity and does not need a second one.
+- **Sigstore / in-toto attestation.** Subject digest plus predicate, verified
+  against a transparency log. **Adopt:** resolving the blob id from the provider
+  and verifying it, so the binding is provider-attested rather than caller-
+  asserted. **Reject:** a separate signing chain — the DCO trailer and Workroom
+  ownership already carry authorship, checked by `resolveRepositoryArtifact`.
+
+## 4. Current substrate audit
+
+- `apps/web/lib/tak/initiative-readiness-tool-grants.ts` — `INITIATIVE_READINESS_LANES`
+  maps accountable role to writer tool, grant and gates.
+  `resolveInitiativeReviewerRecovery` resolves eligible production agents and
+  builds routes; `requestCoworkerPacket` shapes the handoff.
+- `apps/web/lib/mcp/packs/coworker-pack.ts` — declares `requiredToolNames` and
+  `initiativeReviewBinding` on `request_coworker` and `summon_coworker`, and
+  documents them as coming from a server-issued recovery packet.
+- `apps/web/lib/mcp/external-coworker-task-adapter.ts` — `initiativeReviewPacket`
+  requires both fields together, requires the bound writer plus at least one of
+  `read_source_at_version` / `search_source_at_version`, and derives
+  `authorityScope` as `backlog-item:<itemId>` plus `tool:<name>` per name.
+- `apps/web/lib/mcp-task-submit.ts` — `parseInitiativeReviewBinding` requires a
+  `record_initiative_*` writer, a `BI-` subject, a gate, and a complete
+  `repo-blob-at-commit` ref.
+- `apps/web/lib/backlog/initiative-readiness/repository-artifact.ts` —
+  `resolveRepositoryArtifact` **validates** a locator whose `providerBlobId` the
+  caller already knows. It resolves repo identity, requires exactly one live
+  Workroom at the commit, requires a single DCO sign-off, and verifies the blob
+  id against `GET /contents`. It does not discover a path or a blob id.
+- `apps/web/lib/backlog/spec-plan-search.ts` — `searchSpecsAndPlans` scans the
+  **deployed install filesystem**. It cannot see a design authored on a feature
+  branch, so it is not a source for this binding.
+
+No existing helper reads the GitHub compare endpoint.
+
+## 5. Canonical artifact discovery
+
+New module `apps/web/lib/backlog/initiative-readiness/canonical-artifact-discovery.ts`.
+
+```
+discoverCanonicalDesignArtifact({ repositoryFullName, baseSha, headSha, db?, fetchImpl? })
+  -> { ok: true; path: string; providerBlobId: string }
+   | { ok: false; code: "no-canonical-design" | "ambiguous-canonical-design"
+                      | "provider-unavailable"; nextAction: string }
+```
+
+It reads `GET /repos/{owner}/{repo}/compare/{baseSha}...{headSha}` and keeps
+files under `docs/superpowers/specs/` with a `.md` suffix whose status is not
+`removed`. The compare payload carries `filename` and `sha` per file, so the
+blob id is provider-supplied, never derived locally.
+
+- Exactly one match → bind it.
+- Zero matches → `no-canonical-design`, remedy: commit the design under
+  `docs/superpowers/specs/`, push, re-sync the head with `adopt_worktree`.
+- More than one → `ambiguous-canonical-design`, remedy: name the canonical
+  design; the escalation lists the candidates.
+
+Repo identity and provider credentials reuse `resolveRepoIdentity` and
+`resolveGithubToken` from `repository-artifact.ts`; both are exported for reuse
+rather than reimplemented.
+
+**Why the compare range, not the head commit.** A design is frequently authored
+across several commits on a branch. `GET /commits/{sha}` returns only the last
+one's files, which would miss it. The Workroom already records `baseSha`.
+
+## 6. Binding and route shape
+
+`InitiativeRecoveryDispatchContext` gains `baseSha: string | null`.
+`resolveInitiativeReviewerRecovery` gains an optional
+`canonicalArtifact: { path: string; providerBlobId: string } | null` resolved by
+its caller, keeping this module free of provider I/O.
+
+`requestCoworkerPacket` additionally emits:
+
+```
+requiredToolNames: [<writer tool>, "read_source_at_version"]
+initiativeReviewBinding: {
+  writerToolName: <writer tool>,
+  itemId: <decision.subject.id>,
+  gate: <gate>,
+  expectedCurrentBaselineId: <current baseline id or null>,
+  artifactRef: {
+    kind: "repo-blob-at-commit",
+    repositoryFullName, commitSha: headSha, path, providerBlobId,
+  },
+}
+```
+
+This satisfies `initiativeReviewPacket`: two names, the bound writer included,
+one permitted immutable reader, no other names. The resulting `authorityScope`
+is `backlog-item:<itemId>`, `tool:<writer>`, `tool:read_source_at_version`.
+
+`expectedCurrentBaselineId` is the `baselineId` already returned by
+`projectBacklogItemReadiness`, threaded through the caller. It is `null` before
+spec-approval mints the first baseline, which the parser permits.
+
+**When `canonicalArtifact` is null the route is not emitted.** Recovery pushes an
+escalation carrying the discovery `nextAction` instead. An unusable route is
+worse than an honest refusal: it costs a dispatch, a TaskRun and an operator's
+attention before failing.
+
+## 7. Unroutable requirements
+
+`readinessLaneForRole` returns null for `artifact-resolver`,
+`delivery-coordinator`, `acceptance-reviewer`, `product-owner` and
+`platform-governance`. Today those requirements produce neither a route nor an
+escalation — `resolveInitiativeReviewerRecovery` skips them entirely, so
+`ARTIFACT_AUTHOR_REQUIRED` disappears from the recovery a blocked Workroom sees.
+
+These roles have no writer tool by design; `ARTIFACT_AUTHOR_REQUIRED`, for
+example, is satisfied by the commit carrying a DCO trailer owned by the Workroom
+principal, not by anyone recording a receipt. So the fix is not to invent lanes.
+Recovery gains a third result list:
+
+```
+unroutable: Array<{ accountableRole, code, reason, nextAction }>
+```
+
+Each unlaned requirement is reported with the concrete remedy for its code —
+for `ARTIFACT_AUTHOR_REQUIRED`, sign the commit off and re-sync the head. A
+requirement with no mapped remedy is still listed, with its code, rather than
+dropped.
+
+## 8. Security and separation of duties
+
+- No grant expansion. `authorityScope` is per-dispatch and names exactly the
+  bound writer plus one immutable reader.
+- No self-approval. The existing `independent` exclusion of `currentAgentId` is
+  untouched; `record_initiative_evidence` remains `independent: false` because it
+  is the author's own evidence, not a review.
+- No synthesized bindings. The blob id comes from the provider compare payload
+  and is re-verified by `resolveRepositoryArtifact` when the receipt is recorded.
+- No readiness bypass. This change only shapes recovery output; it does not
+  touch `evaluate.ts`, the gate projection, or any verdict.
+
+## 9. Scale
+
+One compare call per blocked claim that produces at least one lane-backed route,
+bounded by GitHub's 300-file compare page. Recovery already performs one grant
+query per claim; this adds one provider round trip on the refusal path only,
+which is not a hot path.
+
+## 10. Delivery slices and acceptance trace
+
+| Slice | Acceptance evidence |
+|---|---|
+| Canonical artifact discovery | unit tests for one/zero/many spec matches and provider failure, against a stubbed compare payload |
+| Binding minted into the packet | `resolveInitiativeReviewerRecovery` tests asserting both fields, and that `initiativeReviewPacket` accepts the result |
+| Escalation when unbindable | test asserting no route and one escalation carrying the remedy |
+| Unroutable requirements surfaced | test asserting `ARTIFACT_AUTHOR_REQUIRED` appears in `unroutable` |
+
+## 11. Verification contract
+
+1. Affected Vitest suites for the readiness, tak and mcp adapter modules.
+2. `pnpm --filter web build` — TypeScript surfaces only here.
+3. No migration; no UI surface, so no UX-fit review. Both classified explicitly.
+4. Documentation impact: the MCP authorization runbook describes recovery
+   routes and is updated in the same branch.
+
+## 12. Out of scope — recorded, not fixed here
+
+Recording plain `evidence` activity does not move readiness. On `BI-7A38F667`
+the author recorded `source_verified` evidence at `2026-08-26T00:17:49Z`
+(`cmt9chl9i016a01qvyvm3jbbt`) and the readiness `factsDigest` stayed byte-
+identical at `0d69fc1daf7f...` across it and both later retries. Readiness counts
+only `initiative_gate_receipt` activities. This is a distinct defect on the same
+epic and needs its own backlog item; an executable packet is a precondition for
+fixing it, not a substitute.


### PR DESCRIPTION
Closes BI-9FE775F9.

## The defect

When governed readiness refuses a claim, the server hands back reviewer routes so a blocked Workroom can recover without an administrative database edit. **Those routes have never been executable.**

`request_coworker` grants a dispatched coworker its writer tool and artifact identity only when `initiativeReviewBinding` and `requiredToolNames` arrive together. `requestCoworkerPacket` emitted neither — six fields, and not those two. The reviewer arrived with no grant to record a result and no document to inspect, so readiness could not advance no matter how many times the caller retried.

Reproduced on `BI-7A38F667` / `WC-16B8E810` at head `e5f86ccbfb368c5cfa7571173d50a08ce66920ef`: every reviewer route omitted both fields, and supplying `requiredToolNames` alone is rejected with *"initiativeReviewBinding and requiredToolNames must be supplied together"*. The exact server-issued route was non-executable without synthesizing a forbidden binding.

## Why it was not a two-field patch

The generator was not withholding the fields — it could not build them. A binding needs `artifactRef.path` and `artifactRef.providerBlobId`, and recovery has never known either:

- `resolveRepositoryArtifact` **validates** a locator whose blob id the caller already knows. It does not discover one.
- `searchSpecsAndPlans` scans the **deployed install filesystem**, so it cannot see a design authored on a feature branch.
- `specPlanFiles` was empty on the affected item.

The old code refused to invent them — correctly, per its own `do not synthesize reviewer artifact bindings` — but then emitted an unusable packet instead of saying so.

## The change

- **`canonical-artifact-discovery.ts`** (new) resolves the design a branch authored by comparing the Workroom's recorded `baseSha...headSha` through the repository provider. The blob id comes from the provider's compare payload, never derived locally, and is re-verified by `resolveRepositoryArtifact` when the receipt is recorded. The compare **range** matters: a design authored across several commits is invisible to `GET /commits/{sha}`.
- **Mint the binding** into the route, scoped to the bound writer plus `read_source_at_version` and nothing else.
- **Escalate instead of emitting an unusable route.** When no artifact can be bound, recovery returns the remedy — commit the design under `docs/superpowers/specs/`, resolve an ambiguous pair, restore provider credentials — rather than spending a dispatch and a TaskRun to fail at the callee.
- **Stop dropping unroutable requirements.** `ARTIFACT_AUTHOR_REQUIRED` (`artifact-resolver`), `DELIVERY_EVIDENCE_REQUIRED` and `ACCEPTANCE_EVIDENCE_REQUIRED` had no lane, so `readinessLaneForRole` returned null and they vanished from recovery entirely — which reads as satisfied. These are not missing lanes: `ARTIFACT_AUTHOR_REQUIRED` is satisfied by a DCO trailer, not by anyone recording a receipt. They now surface in a third `unroutable` list with concrete remedies rather than inventing approvers.
- **Recovery resolves after the readiness transaction commits**, so the provider round trip cannot hold it open.

## Relationship to BI-329AD58D

`BI-329AD58D` covers the consumer half — carrying a binding through threadless `request_coworker`/`summon_coworker` into `mcp-task-submit`, and narrowing the attached tool surface. That half is **already on `main`**. This is the producer half it was waiting on, and it makes that item's acceptance criterion 1 reachable end to end.

## Separation of duties

No readiness verdict, gate projection, or grant scope changes. Authority stays per-dispatch (`backlog-item:<id>`, `tool:<writer>`, `tool:read_source_at_version`). The independent-reviewer exclusion of the current agent is untouched, and `record_initiative_evidence` stays `independent: false` because it is the author's own evidence, not a review.

## Verification

- 39 affected suites / 301 tests pass (`initiative-readiness`, `tak`, `work-capsules`, `mcp-task-submit`, `coworker-pack`, `external-coworker-task-adapter`).
- `pnpm --filter web build` passes.
- `check-design-grounding-decision`, `check-docs-impact`, `check-plan-backlog-coverage` all exit 0.
- No migration (no schema change). No UI surface, so no UX-fit review.

New coverage: one/zero/many spec matches, deleted-spec exclusion, missing base sha, provider failure; binding minted into the packet; baseline id carried; escalation when unbindable; unroutable requirement surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
