### PR TITLE
fix(self-upgrade): drop the flaky wall-clock ceiling from the boot watchdog test (BI-0F2A4137)

### DIFF
--- a/apps/web/lib/self-upgrade/portal-migrate-boot.test.ts
+++ b/apps/web/lib/self-upgrade/portal-migrate-boot.test.ts
@@ -291,9 +291,25 @@ describe.skipIf(!BASH_OK)("portal-migrate-boot.sh (BI-5322D025)", () => {
         subprocessTimeoutMs: 1_000,
         forcePortableWatchdog,
       });
+      // Status 124 IS the watchdog's deadline signal — both the GNU `timeout`
+      // path and the portable process-group path normalize to it (see
+      // boundedCommand above), and nothing else in this harness produces it. If
+      // the watchdog never fired, the spawnSync backstop at
+      // `subprocessTimeoutMs + 2_000` kills the process instead and the status
+      // is not 124, so these two assertions already prove prompt termination.
+      //
+      // A wall-clock ceiling used to sit here as a third check: `durationMs`
+      // under a bare 2_500 against a 1s deadline plus a 1s kill grace, leaving
+      // ~500ms for Git Bash startup, process spawn and teardown. Under local-CI
+      // load at --initial-workers 4 it went red twice in one evening, at 2559ms
+      // and 2554ms, failing whole gate runs of ~25,400 otherwise-passing tests.
+      // It was removed rather than widened: the signal it chased (did the
+      // watchdog fire at its deadline?) and the noise it measured (host
+      // scheduling) are the same order of magnitude, so no threshold separates
+      // them — and any ceiling loose enough to be stable sits above the
+      // spawnSync backstop, where it can never trip at all. BI-0F2A4137.
       expect(r.timedOut, bootDiagnostics(r)).toBe(true);
       expect(r.status, bootDiagnostics(r)).toBe(124);
-      expect(r.durationMs).toBeLessThan(2_500);
       expect(r.command).toContain("portal-migrate-boot.sh");
     } finally {
       rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
Fixes BI-0F2A4137.

## The defect

`portal-migrate-boot.test.ts` asserted `durationMs < 2_500` against a **1s** watchdog deadline plus a **1s** kill grace — leaving roughly 500ms for Git Bash startup, process spawn and teardown.

Under local-CI load at `--initial-workers 4` that is not enough. Observed twice in one evening, on trees it had no quarrel with:

| Run | Result | Rest of the suite |
| --- | --- | --- |
| `fix/coworker-envelope-owner-inbox` @ `c08b33dd` | `expected 2559 to be less than 2500` | 25,243 passed |
| `fix/deadline-tag-sub-day-precision` @ `5a581b58` | `expected 2554 to be less than 2500` | 25,416 passed |

Both re-ran green on the same tree and same commit. The file passes 9/9 in isolation on the same host.

The cost is not the re-run. It is that a red gate stops meaning anything — and this repo's whole verification posture depends on the red signal being trustworthy.

## Why removed rather than widened

I built the widened version first — a ceiling derived from `subprocessTimeoutMs + WATCHDOG_KILL_GRACE_MS + allowance` rather than a bare literal — and then discarded it, because it is decorative:

- The harness caps the subprocess at `subprocessTimeoutMs + 2_000` = **3000ms** (line 142).
- A ceiling loose enough to be stable under observed load is **4500ms**.
- 4500 > 3000, so it can never trip. An assertion that looks like coverage and isn't is worse than no assertion.

The deeper reason is that the signal and the noise are the same order of magnitude. The ceiling was chasing *"did the watchdog fire at its deadline?"* while measuring host scheduling variance, and no threshold separates those two.

## Nothing is lost

Status 124 **is** the watchdog's deadline signal. The harness comment states it directly — *"Both paths normalize a deadline to status 124"* — and nothing else in the harness produces it:

- GNU `timeout --signal=TERM --kill-after=1s` exits 124 at its deadline.
- The portable process-group branch normalizes to the same status.
- If the watchdog never fires, the `spawnSync` backstop kills the process instead and the status is **not** 124.

So the surviving assertions already prove prompt termination, and still fail if the watchdog genuinely stops terminating the process group:

```ts
expect(r.timedOut, bootDiagnostics(r)).toBe(true);
expect(r.status, bootDiagnostics(r)).toBe(124);
```

Both are exact and load-independent. Net diff is **one assertion deleted and seventeen lines explaining why**, so the next reader does not helpfully restore it.

Swept for the same shape elsewhere in `lib/self-upgrade/`: no other bare wall-clock ceiling, and none left in this file.

## Verification

| Gate | Result |
| --- | --- |
| `lib/self-upgrade/portal-migrate-boot.test.ts` | 9/9 pass |
| `pregate:preflight` | 52 guards clean |
| Local merged-code gate | **PASS** at `8dd95612c9bd`, evidence `cmt9k4prc05tv01qvtd4ax1n5` |

Verdict read from `pregate:status`, not the wrapper exit code — during this work a failing gate exited 0 while the SHA-bound record said `failed`.

Found while gating a follow-up to BI-7CB2CCDE, which this unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
