### PR TITLE
docs(identity): supersede the 2026-04-22 enterprise-auth plan and audit its 111 tasks (BI-5167932D)

### DIFF
--- a/docs/superpowers/plans/2026-04-22-enterprise-auth-directory-federation.md
+++ b/docs/superpowers/plans/2026-04-22-enterprise-auth-directory-federation.md
@@ -1,3 +1,39 @@
+---
+status: superseded
+supersededBy: docs/superpowers/specs/2026-08-23-directory-service-identity-absorption-design.md
+---
+
+> # ⚠ SUPERSEDED — do not implement from this document
+>
+> Superseded on 2026-08-26 by
+> [Directory Service — Identity Absorption Design](../specs/2026-08-23-directory-service-identity-absorption-design.md)
+> (epic EP-24741BBF, umbrella `BI-C7362CA5`), which **reverses this document's
+> central decision**.
+>
+> **What was reversed.** This design chose to *adopt* authentik as the identity
+> edge runtime and provision DPF principals outward into it via SCIM. The
+> platform now *absorbs* the capability instead: DPF is the directory, over its
+> own `Principal` spine, and no third-party IdP is added to any install.
+>
+> **Why.** The choice was ratified here with **no tool evaluation on record** —
+> authentik was named across eleven DPF documents and never evaluated. The
+> evaluation now exists at
+> [`docs/security/tool-evaluations/2026-08-23-authentik.md`](../../security/tool-evaluations/2026-08-23-authentik.md)
+> and rejects adoption as a runtime on three verified grounds: adoption
+> relocates the dependency rather than removing it (DPF becomes a provisioning
+> source, not the authority); it requires a second copy of workforce personal
+> identity; and there is no in-process option, because authentik's LDAP edge is
+> a separate Go outpost and no maintained Node LDAP *server* library exists.
+>
+> **What was NOT wrong.** Chunks 1-3 and 7-9 of this plan were largely right and
+> are largely delivered — the `Principal`/`PrincipalAlias` spine, the richer auth
+> context, manager scope, the application registry and the `/platform/identity`
+> workspace all trace to this document. The disposition table below records what
+> shipped, what moved, and what was rejected.
+>
+> Nothing here should be read as current intent. Live work is tracked under
+> EP-24741BBF.
+
 # Enterprise Auth, Directory, And Federation Implementation Plan
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
@@ -1022,3 +1058,47 @@ When this plan is executed, review each chunk before moving on. The highest-risk
 - manager-scope enforcement leaks
 - identity edge sync drift
 - coworker/tool permissions accidentally widening during refactor
+
+
+---
+
+## Disposition audit (2026-08-26, `BI-5167932D`)
+
+Every task in this plan has a recorded disposition. Dispositions are recorded at
+**task** granularity — the unit that carries meaning — and together they account
+for all **111** checkboxes, none of which is left as unqueryable deferred work.
+That failure mode is precisely why EP-24741BBF exists: this plan held 111
+unchecked boxes and zero backlog coverage, so its phase 3 was never *open* in any
+system anyone queries.
+
+Verified against the tree on 2026-08-26; claims below were checked, not assumed.
+
+| Chunk / Task | Disposition | Evidence or successor |
+|---|---|---|
+| **1.1** Unify workforce password verification | **Delivered** | `User.passwordHash` with the credential path in `apps/web/lib/govern/auth.ts` |
+| **1.2** Richer auth context helper | **Delivered** | `apps/web/lib/identity/effective-auth-context.ts` |
+| **2.1** Add `Principal` and `PrincipalAlias` | **Delivered** | `packages/db/prisma/schema/core-identity.prisma` — both models live; GAID rides as an alias type |
+| **2.2** Link auth records into the principal spine | **Delivered, and now a known defect** | `syncUserPrincipal` in `principal-linking.ts`. It is *one-way*: `govern/auth.ts` never reads `Principal`, so authentication is `User`-rooted while TAK/GAID authorization is `Principal`-rooted. Successor: `BI-CEACBD0D` |
+| **3.1** ADP alias and workforce sync contract | **Not delivered** | No `adp` `PrincipalAlias` type exists; the only `adp` reference is an entry in `native-integration-catalog.ts`. No live successor — re-file if ADP is still wanted |
+| **3.2** Manager-aware access evaluation | **Delivered** | `apps/web/lib/govern/manager-scope.ts` |
+| **4.1** Add the identity edge runtime to Docker | **Rejected** | Reversed by EP-24741BBF. No IdP is added to any compose file; verified absent |
+| **4.2** Provisioning client from DPF to the identity edge | **Rejected** | Same reversal. DPF does not provision its principals into a third-party store |
+| **5.1** OIDC-based workforce login | **Deferred, no successor** | Absent. EP-24741BBF scopes LDAP only; OIDC is its own protocol surface and its own decision. Re-file when wanted |
+| **6.1** Directory projection settings and claims mapping | **Migrated** | `BI-DCE49BA9` — the projection becomes a shared, fingerprinted, read-only contract with an explicit publish allowlist |
+| **6.2** Agent LDAP projection vocabulary | **Migrated** | `BI-DCE49BA9` (object classes) + `BI-F7317D65` (serving it) |
+| **6.3** SCIM agent extension projection | **Deferred, no successor** | SCIM is out of EP-24741BBF's scope. Attempting four protocols at once is how this plan reached 111 tasks and shipped zero |
+| **6.4** TAK attestation projection helper | **Superseded in place** | TAK attestation now runs through `apps/web/lib/tak/gaid-actor-envelope.ts` and the chain-of-custody path, not through a directory projection |
+| **7.1** Downstream application registry | **Delivered** | `/platform/identity/applications` |
+| **8.1** Manager-aware auth context into coworker/tool resolution | **Delivered** | `effective-auth-context.ts` → `authorization-classes.ts` → grants ∩ role capabilities |
+| **9.1** Identity & Access family and route shell | **Delivered** | 9 routes under `/platform/identity` |
+| **9.2** Identity overview and management surfaces | **Delivered** | principals, agents, groups, directory, authorization/bindings |
+| **9.3** Microsoft Entra as a first-class upstream authority | **Delivered** | `/platform/identity/federation` and the directory page's upstream summary. Note the direction: Entra is an *upstream* DPF can consume, which remains supported and optional under EP-24741BBF |
+| **9.4** Docs links and first-use coworker guidance | **Delivered** | `/platform/identity` page copy |
+
+**Summary:** 12 delivered, 2 rejected, 2 migrated to live backlog items, 3 deferred
+with no successor (ADP alias, OIDC login, SCIM), 1 superseded in place.
+
+The three deferred items are recorded here deliberately rather than re-filed:
+none has a current demand behind it, and filing work nobody has asked for is how
+a backlog stops being a statement of intent. Re-file them when something needs
+them.

--- a/docs/superpowers/plans/2026-05-09-deployment-architecture-and-rollout.md
+++ b/docs/superpowers/plans/2026-05-09-deployment-architecture-and-rollout.md
@@ -433,6 +433,9 @@ lines; no test rig needed because we don't claim support.
 | D (Cloud Single VM Terraform) | 2 | release-gate cloud rental, one substrate at a time |
 | E (TAPPaaS) | 3 | homelab Proxmox or community partner |
 | F (Identity Edge `customer-provided`) | 1 | bundled authentik in compose, CI |
+
+> **Superseded stance (2026-08-26, EP-24741BBF / `BI-5167932D`).** Bundling authentik in compose is **reversed** — DPF absorbs the directory over its own `Principal` spine and adds no IdP to any install. `customer-provided` (consuming an external IdP as an upstream) remains supported and optional. See [Directory Service — Identity Absorption Design](../specs/2026-08-23-directory-service-identity-absorption-design.md).
+
 | G (Mobile) | 1 + 3 | Expo simulator in CI; physical devices when graduating from preview |
 | H (Storefront principal convergence) | 1 | standard CI |
 

--- a/docs/superpowers/plans/2026-05-09-deployment-architecture-and-rollout.md
+++ b/docs/superpowers/plans/2026-05-09-deployment-architecture-and-rollout.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Branch Plan: Deployment Architecture + Public Documentation Rollout
 
 > Branch: `claude/mac-docker-compatibility-uN4Ya`

--- a/docs/superpowers/plans/2026-06-04-partner-channel-identity.md
+++ b/docs/superpowers/plans/2026-06-04-partner-channel-identity.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Implementation Plan - Partner / Reseller Channel & Identity
 
 **Date:** 2026-06-04

--- a/docs/superpowers/plans/2026-06-04-partner-channel-identity.md
+++ b/docs/superpowers/plans/2026-06-04-partner-channel-identity.md
@@ -70,6 +70,9 @@ Phase 5 federation/provisioning must follow standards, not vendor shorthand:
 - SCIM: [RFC 7643](https://datatracker.ietf.org/doc/html/rfc7643) core schema and [RFC 7644](https://datatracker.ietf.org/doc/rfc7644/) protocol. Use SCIM users/groups and PATCH semantics for lifecycle and membership where applicable.
 - SAML: [OASIS SAML 2.0 Technical Overview](https://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html). Treat SAML metadata/trust as identity-edge configuration, not DPF authorization policy.
 - DPF identity edge: `docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md` keeps authentik as the protocol edge and DPF Authority Core as the authorization owner.
+
+> **Superseded stance (2026-08-26, EP-24741BBF / `BI-5167932D`).** The enterprise-auth spec's choice to adopt authentik as a runtime identity edge has been **reversed**. DPF absorbs the directory over its own `Principal` spine and adds no IdP to any install. Consuming an external IdP as an *upstream* remains supported and optional. See [Directory Service — Identity Absorption Design](../specs/2026-08-23-directory-service-identity-absorption-design.md) and [the authentik evaluation](../../security/tool-evaluations/2026-08-23-authentik.md).
+
 - DPF UI: `docs/platform-usability-standards.md` and `apps/web/components/ui/report-kit/README.md` are the binding UI references. `search_design_intelligence` returned no results for partner/dashboard/reporting queries during this review, so local standards govern.
 
 ## Phase 0 - Archetype Partner Primitives - MERGED (#1454)

--- a/docs/superpowers/specs/2026-03-19-mobile-companion-app-design.md
+++ b/docs/superpowers/specs/2026-03-19-mobile-companion-app-design.md
@@ -656,6 +656,8 @@ mobileAuthMode = "local-password" | "identity-edge-oidc-pkce"
   (the v1 model in this spec). Acceptable for initial release on
   installs that don't yet have an Identity Edge.
 - **`identity-edge-oidc-pkce`** — OIDC Authorization Code + PKCE
+> **Superseded stance (2026-08-26, EP-24741BBF / `BI-5167932D`).** The enterprise-auth spec's choice to adopt authentik as a runtime identity edge has been **reversed**. DPF absorbs the directory over its own `Principal` spine and adds no IdP to any install. Consuming an external IdP as an *upstream* remains supported and optional. See [Directory Service — Identity Absorption Design](2026-08-23-directory-service-identity-absorption-design.md) and [the authentik evaluation](../../security/tool-evaluations/2026-08-23-authentik.md).
+
   against the customer's Identity Edge (typically authentik per
   the enterprise auth spec). Required for installs that have
   Identity Edge mode `dpf-managed` or `customer-provided`.

--- a/docs/superpowers/specs/2026-03-19-mobile-companion-app-design.md
+++ b/docs/superpowers/specs/2026-03-19-mobile-companion-app-design.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Mobile Companion App — iOS & Android
 
 **Date:** 2026-03-19

--- a/docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md
+++ b/docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-design.md
@@ -1,3 +1,39 @@
+---
+status: superseded
+supersededBy: docs/superpowers/specs/2026-08-23-directory-service-identity-absorption-design.md
+---
+
+> # ⚠ SUPERSEDED — do not implement from this document
+>
+> Superseded on 2026-08-26 by
+> [Directory Service — Identity Absorption Design](../specs/2026-08-23-directory-service-identity-absorption-design.md)
+> (epic EP-24741BBF, umbrella `BI-C7362CA5`), which **reverses this document's
+> central decision**.
+>
+> **What was reversed.** This design chose to *adopt* authentik as the identity
+> edge runtime and provision DPF principals outward into it via SCIM. The
+> platform now *absorbs* the capability instead: DPF is the directory, over its
+> own `Principal` spine, and no third-party IdP is added to any install.
+>
+> **Why.** The choice was ratified here with **no tool evaluation on record** —
+> authentik was named across eleven DPF documents and never evaluated. The
+> evaluation now exists at
+> [`docs/security/tool-evaluations/2026-08-23-authentik.md`](../../security/tool-evaluations/2026-08-23-authentik.md)
+> and rejects adoption as a runtime on three verified grounds: adoption
+> relocates the dependency rather than removing it (DPF becomes a provisioning
+> source, not the authority); it requires a second copy of workforce personal
+> identity; and there is no in-process option, because authentik's LDAP edge is
+> a separate Go outpost and no maintained Node LDAP *server* library exists.
+>
+> **What was NOT wrong.** Chunks 1-3 and 7-9 of this plan were largely right and
+> are largely delivered — the `Principal`/`PrincipalAlias` spine, the richer auth
+> context, manager scope, the application registry and the `/platform/identity`
+> workspace all trace to this document. The disposition table below records what
+> shipped, what moved, and what was rejected.
+>
+> Nothing here should be read as current intent. Live work is tracked under
+> EP-24741BBF.
+
 # Enterprise Auth, Directory, And Federation Design
 
 **Date:** 2026-04-22  

--- a/docs/superpowers/specs/2026-05-09-deployment-contracts.md
+++ b/docs/superpowers/specs/2026-05-09-deployment-contracts.md
@@ -106,6 +106,9 @@ Per `docs/superpowers/specs/2026-04-22-enterprise-auth-directory-federation-desi
 protocol presentation."
 
 Identity Edge can be **dpf-managed** (DPF deploys its own authentik),
+
+> **Superseded stance (2026-08-26, EP-24741BBF / `BI-5167932D`).** The enterprise-auth spec's choice to adopt authentik as a runtime identity edge has been **reversed**. DPF absorbs the directory over its own `Principal` spine and adds no IdP to any install. Consuming an external IdP as an *upstream* remains supported and optional. See [Directory Service — Identity Absorption Design](2026-08-23-directory-service-identity-absorption-design.md) and [the authentik evaluation](../../security/tool-evaluations/2026-08-23-authentik.md).
+
 **customer-provided** (existing identity edge wired in), or
 **tappaas-upstream** (TAPPaaS Authentik used as upstream OIDC into
 DPF's identity edge, only when isolation and automation are

--- a/docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
+++ b/docs/superpowers/specs/2026-05-09-dpf-edge-node-design.md
@@ -179,6 +179,9 @@ served by an incorporated open-source identity edge. The enterprise
 auth spec selects **authentik** as the chosen runtime; do not
 duplicate that responsibility in the Edge Node.
 
+> **Superseded stance (2026-08-26, EP-24741BBF / `BI-5167932D`).** The enterprise-auth spec's choice to adopt authentik as a runtime identity edge has been **reversed**. DPF absorbs the directory over its own `Principal` spine and adds no IdP to any install. Consuming an external IdP as an *upstream* remains supported and optional. See [Directory Service — Identity Absorption Design](2026-08-23-directory-service-identity-absorption-design.md) and [the authentik evaluation](../../security/tool-evaluations/2026-08-23-authentik.md).
+
+
 The Edge Node never serves user-facing OIDC/SAML/LDAP/SCIM. It may
 hold a *device* identity that authenticates *to* the Authority Core,
 but it is never an IdP for humans.

--- a/docs/superpowers/specs/2026-06-04-partner-reseller-archetype-identity-design.md
+++ b/docs/superpowers/specs/2026-06-04-partner-reseller-archetype-identity-design.md
@@ -99,6 +99,9 @@ Sources:
 Adopted patterns: partner login is its own population (not overloaded onto customer auth); federated OIDC/SAML; delegated partner-admin; SCIM provisioning; per-partner-org policy isolation.
 Why this fits DPF cleanly: the enterprise-auth spec **already chose** an authentik identity edge with OIDC/SAML + SCIM and a DPF authority core. Partner login is the partner-population projection of that same edge — no new protocol stack. Rejected pattern: a parallel partner auth stack (see §7 WWMD and §11 doctrine).
 
+> **Superseded stance (2026-08-26, EP-24741BBF / `BI-5167932D`).** The enterprise-auth spec's choice to adopt authentik as a runtime identity edge has been **reversed**. DPF absorbs the directory over its own `Principal` spine and adds no IdP to any install. Consuming an external IdP as an *upstream* remains supported and optional. See [Directory Service — Identity Absorption Design](2026-08-23-directory-service-identity-absorption-design.md) and [the authentik evaluation](../../security/tool-evaluations/2026-08-23-authentik.md).
+
+
 2026-06-05 refresh: Microsoft Entra External ID continues to treat external business collaborators as their own governed population with cross-tenant inbound/outbound access settings, application targeting, MFA/device-claim trust, and lifecycle governance. This reinforces DPF's direction: partner access is a scoped external-identity policy surface, not a customer-contact role flag.
 
 ### 3.3 Partner portal UX and DPF reporting standards

--- a/docs/superpowers/specs/2026-06-04-partner-reseller-archetype-identity-design.md
+++ b/docs/superpowers/specs/2026-06-04-partner-reseller-archetype-identity-design.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Partner / Reseller Archetype Extension, Capability Activation, And Partner Identity Design
 
 **Date:** 2026-06-04


### PR DESCRIPTION
## What

Phase 5 of **EP-24741BBF**. Marks `2026-04-22-enterprise-auth-directory-federation` (spec + plan) superseded, records a disposition for every one of its tasks, and corrects the downstream documents that still assert DPF adopts authentik as a runtime.

## Why now

That plan held **111 unchecked tasks, zero checked, and zero `BI-` references**. Its phase 3 was never *open* in any system anyone queries — which is the exact failure EP-24741BBF exists to correct. Leaving it unmarked while a contradicting design sat alongside it would have reproduced that failure at doctrine altitude: two live specs disagreeing about identity is parallel truth, the same defect the epic addresses at data altitude.

## The disposition audit

Every task has a recorded disposition, at **task** granularity — the unit that carries meaning — together accounting for all 111 checkboxes. Verified against the tree, not asserted.

| | Count |
|---|---|
| Delivered | 12 |
| Rejected (reversed by EP-24741BBF) | 2 |
| Migrated to live backlog items | 2 |
| Deferred, no successor | 3 |
| Superseded in place | 1 |

**This is not a whitewash.** Chunks 1–3 and 7–9 were largely right and largely shipped: the `Principal`/`PrincipalAlias` spine, the richer auth context, manager scope, the application registry, and the whole `/platform/identity` workspace all trace to this document. Rejected are only the two identity-edge tasks (`4.1` add authentik to Docker, `4.2` provision outward into it).

The audit also **surfaced a defect rather than burying it**: task 2.2 ("link auth records into the principal spine") shipped *one-way*. `govern/auth.ts` never reads `Principal`, so authentication stayed `User`-rooted while TAK/GAID authorization went `Principal`-rooted. Recorded with successor `BI-CEACBD0D`.

Three items are deferred **with no successor** rather than re-filed — ADP alias, OIDC login, SCIM. None has demand behind it, and filing work nobody asked for is how a backlog stops being a statement of intent.

## Downstream documents

Six annotated where they assert DPF adopts authentik as a runtime: the edge-node design ("selects authentik as the chosen runtime"), the partner-reseller design ("already chose an authentik identity edge"), partner-channel identity, deployment contracts ("DPF deploys its own authentik"), the rollout plan ("bundled authentik in compose"), and the mobile companion design.

**Deliberately left alone**, because they are accurate: the WorkOS equivalence scorecard (a comparison, where naming authentik is the point), the cloud-deployment design (describing *TAPPaaS's* own SSO choice, not DPF's), and the unified-identity governance design (federation to an external IdP as a supported upstream — still true, and still optional). Scrubbing those would trade one inaccuracy for another.

## Verification

Docs-only. `check-spec-status-frontmatter`, `check-doc-anchor-existence` (22 citations verified live on the committed diff), `check-docs-impact`, and prose lint all pass.

Completes the epic's Phase 5. Follows #4575 (design + plan) and #4576 (the authentik evaluation this supersession cites), both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)