### PR TITLE
feat(mileage): price a drive on the country it happened in (BI-1C8B56DA)

### DIFF
--- a/apps/mobile/src/features/mileage/trip-detection.test.ts
+++ b/apps/mobile/src/features/mileage/trip-detection.test.ts
@@ -122,3 +122,31 @@ describe("DEFAULT_DETECTION", () => {
     expect(DEFAULT_DETECTION.stopGapMs).toBeGreaterThanOrEqual(3 * 60_000);
   });
 });
+
+describe("device-derived trip country (DI-5E5AFE040A1F)", () => {
+  it("reports the country the device resolved, uppercased", () => {
+    const fixes = drive(T0, 8).map((f) => ({ ...f, isoCountryCode: "mx" }));
+    expect(detectTrips(fixes, DEFAULT_DETECTION)[0]?.countryCode).toBe("MX");
+  });
+
+  it("is null when no fix carried a country", () => {
+    // No signal, permission withheld, or an older client. The server then
+    // prices on the driver's country of record rather than guessing.
+    expect(detectTrips(drive(T0, 8), DEFAULT_DETECTION)[0]?.countryCode).toBeNull();
+  });
+
+  it("falls forward when the device resolves a country a beat after the drive starts", () => {
+    const fixes = drive(T0, 8);
+    fixes[2] = { ...fixes[2]!, isoCountryCode: "US" };
+    expect(detectTrips(fixes, DEFAULT_DETECTION)[0]?.countryCode).toBe("US");
+  });
+
+  it("prices a border crossing on the country the drive STARTED in", () => {
+    // Documented simplification: one drive, one rate plan. Splitting needs
+    // per-segment attribution the device does not produce.
+    const fixes = drive(T0, 8);
+    fixes[0] = { ...fixes[0]!, isoCountryCode: "US" };
+    fixes[7] = { ...fixes[7]!, isoCountryCode: "MX" };
+    expect(detectTrips(fixes, DEFAULT_DETECTION)[0]?.countryCode).toBe("US");
+  });
+});

--- a/apps/mobile/src/features/mileage/trip-detection.ts
+++ b/apps/mobile/src/features/mileage/trip-detection.ts
@@ -24,6 +24,13 @@ export interface LocationFix {
   speed?: number | null;
   /** Horizontal accuracy in metres; a poor fix is treated as suspect. */
   accuracy?: number | null;
+  /**
+   * ISO 3166-1 alpha-2 the platform reverse-geocoded for this fix, when it
+   * supplied one. The DEVICE knows what country it is in — the driver is never
+   * asked. Absent on most fixes by design: reverse geocoding every fix would
+   * burn battery and quota for an answer that only changes at a border.
+   */
+  isoCountryCode?: string | null;
 }
 
 export interface DetectedTrip {
@@ -34,6 +41,17 @@ export interface DetectedTrip {
   /** Summed great-circle distance along the retained fixes, in metres. */
   distanceMetres: number;
   fixCount: number;
+  /**
+   * Where the drive BEGAN, as ISO 3166-1 alpha-2, or null when no fix carried
+   * a country.
+   *
+   * A drive that crosses a border prices on the country it started in. That is
+   * a deliberate, documented simplification rather than an oversight: splitting
+   * one drive across two rate plans needs per-segment distance attribution and
+   * a reverse geocode far denser than the one or two the device actually makes.
+   * Recording the start honestly beats inventing a split.
+   */
+  countryCode: string | null;
 }
 
 export interface DetectionOptions {
@@ -82,6 +100,20 @@ function usable(fix: LocationFix, options: DetectionOptions): boolean {
   return fix.accuracy <= options.maximumAccuracyMetres;
 }
 
+/**
+ * The first country any fix carries, scanning forward from the start.
+ *
+ * Falls forward rather than demanding the very first fix carry one, because a
+ * device commonly resolves its country a beat after the drive begins.
+ */
+function firstCountry(fixes: readonly LocationFix[]): string | null {
+  for (const fix of fixes) {
+    const code = fix.isoCountryCode?.trim().toUpperCase();
+    if (code) return code;
+  }
+  return null;
+}
+
 function buildTrip(fixes: LocationFix[], options: DetectionOptions): DetectedTrip | null {
   if (fixes.length < 2) return null;
 
@@ -100,6 +132,7 @@ function buildTrip(fixes: LocationFix[], options: DetectionOptions): DetectedTri
     end: { latitude: last.latitude, longitude: last.longitude },
     distanceMetres: Math.round(distanceMetres),
     fixCount: fixes.length,
+    countryCode: firstCountry(fixes),
   };
 }
 

--- a/apps/web/app/api/v1/mileage/trips/route.ts
+++ b/apps/web/app/api/v1/mileage/trips/route.ts
@@ -64,6 +64,7 @@ export async function POST(request: Request) {
         endPlaceLabel: body.endPlaceLabel ?? null,
         distanceMeters: body.distanceMetres,
         captureKind: body.captureKind,
+        countryCode: body.countryCode ?? null,
       },
       newId(),
     );

--- a/apps/web/lib/actions/mileage.ts
+++ b/apps/web/lib/actions/mileage.ts
@@ -19,6 +19,7 @@ import { revalidatePath } from "next/cache";
 import { requireCapability, requireUser } from "@/lib/actions/shared/guards";
 import { err, ok, type ActionResult } from "@/lib/shared/action-result";
 import { newId } from "@/lib/shared/new-id";
+import { employeeCountryOfRecord } from "@/lib/mileage/country-of-record";
 import {
   monetisePeriod,
   recordTrip,
@@ -64,6 +65,7 @@ export async function recordTripAction(
       endPlaceLabel: payload.endPlaceLabel ?? null,
       distanceMeters: payload.distanceMeters,
       captureKind: payload.captureKind,
+      countryCode: payload.countryCode ?? null,
     },
     newId(),
   );
@@ -119,7 +121,16 @@ export async function monetiseMileageAction(input: {
 
   const rateRows = await prisma.mileageRate.findMany({
     where: { plan: { lifecycle: "active" } },
-    include: { plan: { select: { isOrgOverride: true } } },
+    include: {
+      plan: {
+        select: {
+          isOrgOverride: true,
+          // The plan's country is what lets a trip driven abroad price on that
+          // country's policy rather than the employee's home rate.
+          jurisdictionReference: { select: { countryCode: true } },
+        },
+      },
+    },
   });
   const rates: ResolvableRate[] = rateRows.map((r) => ({
     id: r.id,
@@ -129,6 +140,7 @@ export async function monetiseMileageAction(input: {
     effectiveFrom: r.effectiveFrom,
     effectiveTo: r.effectiveTo,
     isOrgOverride: r.plan.isOrgOverride,
+    jurisdictionCountryCode: r.plan.jurisdictionReference?.countryCode ?? null,
   }));
 
   if (rates.length === 0) {
@@ -138,11 +150,14 @@ export async function monetiseMileageAction(input: {
   const periodStart = new Date(input.periodStart);
   const periodEnd = new Date(input.periodEnd);
 
+  const employeeCountryCode = await employeeCountryOfRecord(prisma as never, employee.id);
+
   const outcome = await monetisePeriod(prisma as never, {
     employeeProfileId: employee.id,
     periodStart,
     periodEnd,
     rates,
+    employeeCountryCode,
   });
 
   if (outcome.pricing.lines.length === 0) {

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1574,6 +1574,7 @@
         "maturity-labels-closed-set",
         "finance-matrix-snapshot",
         "payroll-absorption-stance-reversal-2026-08-22",
+        "mileage-jurisdiction-resolution-2026-08-26",
         "finance-doc-reconciliation-rules",
         "workforce-matrix-snapshot",
         "workforce-doc-reconciliation-rules",

--- a/apps/web/lib/mileage/country-of-record.test.ts
+++ b/apps/web/lib/mileage/country-of-record.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { employeeCountryOfRecord, type CountryOfRecordClient } from "./country-of-record";
+
+function client(rows: unknown[]): CountryOfRecordClient {
+  return { employeeAddress: { findMany: async () => rows as never } };
+}
+
+function addr(iso2: string, isPrimary: boolean) {
+  return { isPrimary, address: { city: { region: { country: { iso2 } } } } };
+}
+
+describe("employeeCountryOfRecord", () => {
+  it("reads the country off the primary address", async () => {
+    const got = await employeeCountryOfRecord(client([addr("US", true), addr("MX", false)]), "emp-1");
+    expect(got).toBe("US");
+  });
+
+  it("uses a lone address even when nothing is flagged primary", async () => {
+    expect(await employeeCountryOfRecord(client([addr("GB", false)]), "emp-1")).toBe("GB");
+  });
+
+  it("returns null when several addresses exist and none is primary", async () => {
+    // Ambiguous. Picking the first row would pay someone against an arbitrary
+    // address; falling back to an unscoped plan is the defensible answer.
+    const got = await employeeCountryOfRecord(client([addr("US", false), addr("MX", false)]), "emp-1");
+    expect(got).toBeNull();
+  });
+
+  it("returns null when several addresses are flagged primary", async () => {
+    const got = await employeeCountryOfRecord(client([addr("US", true), addr("MX", true)]), "emp-1");
+    expect(got).toBeNull();
+  });
+
+  it("returns null when the employee has no addresses at all", async () => {
+    expect(await employeeCountryOfRecord(client([]), "emp-1")).toBeNull();
+  });
+
+  it("ignores address rows whose reference chain is incomplete", async () => {
+    const rows = [{ isPrimary: true, address: null }, addr("MX", false)];
+    expect(await employeeCountryOfRecord(client(rows), "emp-1")).toBe("MX");
+  });
+
+  it("normalises the stored code", async () => {
+    expect(await employeeCountryOfRecord(client([addr(" mx ", true)]), "emp-1")).toBe("MX");
+  });
+});

--- a/apps/web/lib/mileage/country-of-record.ts
+++ b/apps/web/lib/mileage/country-of-record.ts
@@ -1,0 +1,62 @@
+// lib/mileage/country-of-record.ts — the employee's governing jurisdiction.
+//
+// Mileage policy is usually tied to the employee's country of record, not to
+// wherever they happen to be driving, so pricing needs that country before it
+// can pick a rate plan (DI-5E5AFE040A1F).
+//
+// There is no employeeProfile.countryCode column and this deliberately does not
+// add one. Country of record already exists in canonical MDM reference data —
+// EmployeeAddress -> Address -> City -> Region -> Country.iso2 — and a second
+// copy on the profile would be a parallel store that drifts the first time
+// someone moves. This module is the single read path onto it.
+
+import { normaliseCountryCode } from "./rates";
+
+/** The slice of Prisma this module needs, so tests need no live database. */
+export type CountryOfRecordClient = {
+  employeeAddress: {
+    findMany: (args: unknown) => Promise<
+      Array<{
+        isPrimary: boolean;
+        address: { city: { region: { country: { iso2: string } } } | null } | null;
+      }>
+    >;
+  };
+};
+
+/**
+ * ISO 3166-1 alpha-2 country of record for an employee, or null when unknown.
+ *
+ * Prefers the address flagged primary. An employee with several addresses and
+ * none flagged primary has no country of record we can defend, so this returns
+ * null rather than picking the first row — pricing then falls back to an
+ * unscoped plan instead of paying someone against an arbitrary address.
+ *
+ * Null is a legitimate answer, not an error: an org with no addresses recorded
+ * still prices trips, just on its unscoped plan.
+ */
+export async function employeeCountryOfRecord(
+  db: CountryOfRecordClient,
+  employeeProfileId: string,
+): Promise<string | null> {
+  const rows = await db.employeeAddress.findMany({
+    where: { employeeProfileId },
+    select: {
+      isPrimary: true,
+      address: { select: { city: { select: { region: { select: { country: { select: { iso2: true } } } } } } } },
+    },
+    // Primary first so the common case reads one row and stops caring about the rest.
+    orderBy: [{ isPrimary: "desc" }],
+  });
+
+  const withCountry = rows.filter((row) => Boolean(row.address?.city?.region?.country?.iso2));
+  if (withCountry.length === 0) return null;
+
+  const primary = withCountry.filter((row) => row.isPrimary);
+  // Exactly one primary is the answer. None, or several, is ambiguous.
+  if (primary.length === 1) return normaliseCountryCode(primary[0].address!.city!.region.country.iso2);
+  if (primary.length === 0 && withCountry.length === 1) {
+    return normaliseCountryCode(withCountry[0].address!.city!.region.country.iso2);
+  }
+  return null;
+}

--- a/apps/web/lib/mileage/jurisdiction-rates.test.ts
+++ b/apps/web/lib/mileage/jurisdiction-rates.test.ts
@@ -1,0 +1,129 @@
+// Jurisdiction-aware mileage rate resolution (DI-5E5AFE040A1F).
+//
+// These fixtures are deliberately synthetic. Real statutory mileage rates are
+// operator-supplied, source-cited reference data (BI-4EB27955); inventing
+// plausible ones in a test is how a fabricated rate ends up quoted as fact.
+
+import { describe, expect, it } from "vitest";
+import { normaliseCountryCode, resolveRateForTrip, type ResolvableRate } from "./rates";
+
+function rate(over: Partial<ResolvableRate> & { id: string }): ResolvableRate {
+  return {
+    purposeKind: "business",
+    amountPerMile: 1,
+    currency: "USD",
+    effectiveFrom: new Date("2026-01-01"),
+    effectiveTo: null,
+    isOrgOverride: false,
+    jurisdictionCountryCode: null,
+    ...over,
+  };
+}
+
+const ON = new Date("2026-06-15");
+
+describe("resolveRateForTrip", () => {
+  it("prices a drive on the country it happened in", () => {
+    const rates = [
+      rate({ id: "us", jurisdictionCountryCode: "US", amountPerMile: 0.7 }),
+      rate({ id: "mx", jurisdictionCountryCode: "MX", amountPerMile: 0.3 }),
+    ];
+    const got = resolveRateForTrip(rates, ON, { tripCountryCode: "MX", employeeCountryCode: "US" });
+    expect(got?.id).toBe("mx");
+  });
+
+  it("falls back to the employee's country of record when the org has no plan there", () => {
+    // The classic case: a US employee drives in Canada, where the org has no plan.
+    const rates = [rate({ id: "us", jurisdictionCountryCode: "US" })];
+    const got = resolveRateForTrip(rates, ON, { tripCountryCode: "CA", employeeCountryCode: "US" });
+    expect(got?.id).toBe("us");
+  });
+
+  it("falls back to the employee's country when the device derived no country", () => {
+    const rates = [rate({ id: "us", jurisdictionCountryCode: "US" })];
+    const got = resolveRateForTrip(rates, ON, { tripCountryCode: null, employeeCountryCode: "US" });
+    expect(got?.id).toBe("us");
+  });
+
+  it("falls back to an unscoped plan when neither country has one", () => {
+    const rates = [
+      rate({ id: "global" }),
+      rate({ id: "gb", jurisdictionCountryCode: "GB" }),
+    ];
+    const got = resolveRateForTrip(rates, ON, { tripCountryCode: "MX", employeeCountryCode: "US" });
+    expect(got?.id).toBe("global");
+  });
+
+  it("returns null rather than a wrong-country rate when nothing applies", () => {
+    // Never zero-fill and never reach for a rate from the wrong jurisdiction:
+    // an unpriceable trip must surface as unpriceable.
+    const rates = [rate({ id: "gb", jurisdictionCountryCode: "GB", effectiveFrom: new Date("2030-01-01") })];
+    expect(resolveRateForTrip(rates, ON, { tripCountryCode: "GB" })).toBeNull();
+  });
+
+  it("does not let an org override in the wrong country outrank the right country's rate", () => {
+    // The bug a single flat sort would introduce: isOrgOverride wins WITHIN a
+    // jurisdiction, never across one.
+    const rates = [
+      rate({ id: "us-override", jurisdictionCountryCode: "US", isOrgOverride: true, amountPerMile: 9 }),
+      rate({ id: "mx-statutory", jurisdictionCountryCode: "MX", amountPerMile: 0.3 }),
+    ];
+    const got = resolveRateForTrip(rates, ON, { tripCountryCode: "MX", employeeCountryCode: "US" });
+    expect(got?.id).toBe("mx-statutory");
+  });
+
+  it("still prefers an org override within the winning country", () => {
+    const rates = [
+      rate({ id: "mx-statutory", jurisdictionCountryCode: "MX" }),
+      rate({ id: "mx-override", jurisdictionCountryCode: "MX", isOrgOverride: true }),
+    ];
+    const got = resolveRateForTrip(rates, ON, { tripCountryCode: "MX" });
+    expect(got?.id).toBe("mx-override");
+  });
+
+  it("still prefers the latest effectiveFrom within the winning country", () => {
+    const rates = [
+      rate({ id: "old", jurisdictionCountryCode: "US", effectiveFrom: new Date("2026-01-01") }),
+      rate({ id: "new", jurisdictionCountryCode: "US", effectiveFrom: new Date("2026-06-01") }),
+    ];
+    expect(resolveRateForTrip(rates, ON, { tripCountryCode: "US" })?.id).toBe("new");
+  });
+
+  it("prices a trip driven on the day a rate opens, and not the day it closes", () => {
+    const rates = [
+      rate({
+        id: "window",
+        jurisdictionCountryCode: "US",
+        effectiveFrom: new Date("2026-06-15"),
+        effectiveTo: new Date("2026-06-20"), // clock-bomb-guard: allow resolveRateForTrip compares only against the `on` date passed in, never the system clock
+      }),
+    ];
+    expect(resolveRateForTrip(rates, new Date("2026-06-15"), { tripCountryCode: "US" })?.id).toBe("window");
+    expect(resolveRateForTrip(rates, new Date("2026-06-20"), { tripCountryCode: "US" })).toBeNull();
+  });
+
+  it("matches country codes case- and whitespace-insensitively", () => {
+    // A stored " us " must not silently miss and price on the fallback.
+    const rates = [rate({ id: "us", jurisdictionCountryCode: " us " })];
+    expect(resolveRateForTrip(rates, ON, { tripCountryCode: "US" })?.id).toBe("us");
+  });
+
+  it("honours purpose alongside jurisdiction", () => {
+    const rates = [
+      rate({ id: "us-business", jurisdictionCountryCode: "US", purposeKind: "business" }),
+      rate({ id: "us-medical", jurisdictionCountryCode: "US", purposeKind: "medical" }),
+    ];
+    const got = resolveRateForTrip(rates, ON, { tripCountryCode: "US", purpose: "medical" });
+    expect(got?.id).toBe("us-medical");
+  });
+});
+
+describe("normaliseCountryCode", () => {
+  it("uppercases, trims, and treats blank as unknown", () => {
+    expect(normaliseCountryCode(" mx ")).toBe("MX");
+    expect(normaliseCountryCode("")).toBeNull();
+    expect(normaliseCountryCode("   ")).toBeNull();
+    expect(normaliseCountryCode(null)).toBeNull();
+    expect(normaliseCountryCode(undefined)).toBeNull();
+  });
+});

--- a/apps/web/lib/mileage/monetisation.ts
+++ b/apps/web/lib/mileage/monetisation.ts
@@ -10,7 +10,7 @@
 // (an IRS-compliant log needs total, business and personal miles) but never
 // produce money.
 
-import { resolveRateForDate, reimbursableAmount, metresToMiles, type ResolvableRate } from "./rates";
+import { resolveRateForTrip, reimbursableAmount, metresToMiles, type ResolvableRate } from "./rates";
 import type { TripClassification } from "./classification";
 
 export type PriceableTrip = {
@@ -22,6 +22,8 @@ export type PriceableTrip = {
   startPlaceLabel: string | null;
   endPlaceLabel: string | null;
   customerAccountId: string | null;
+  /** ISO 3166-1 alpha-2 the device derived, or null when it could not. */
+  countryCode?: string | null;
 };
 
 export type MileageExpenseLine = {
@@ -68,6 +70,12 @@ export function priceTrips(
   trips: readonly PriceableTrip[],
   rates: readonly ResolvableRate[],
   currencyFallback = "USD",
+  /**
+   * The driver's country of record, governing any trip whose own country is
+   * unknown or has no plan. Undefined prices every trip on an unscoped plan,
+   * which is exactly how this behaved before jurisdictions existed.
+   */
+  employeeCountryCode?: string | null,
 ): PricingResult {
   const lines: MileageExpenseLine[] = [];
   const skipped: PricingSkip[] = [];
@@ -82,7 +90,13 @@ export function priceTrips(
       continue;
     }
 
-    const rate = resolveRateForDate(rates, trip.startedAt, "business");
+    // Where the mile was actually driven selects the plan, falling back to the
+    // employee's country of record (DI-5E5AFE040A1F).
+    const rate = resolveRateForTrip(rates, trip.startedAt, {
+      tripCountryCode: trip.countryCode,
+      employeeCountryCode,
+      purpose: "business",
+    });
     if (!rate) {
       // Cannot price yet — surfaced, never zero-filled.
       skipped.push({ tripId: trip.tripId, reason: "no-rate-in-force" });

--- a/apps/web/lib/mileage/rates.ts
+++ b/apps/web/lib/mileage/rates.ts
@@ -14,9 +14,28 @@ export const METRES_PER_MILE = 1609.344;
 
 export type MileagePurpose = "business" | "medical" | "moving" | "charitable";
 
+/**
+ * ISO 3166-1 alpha-2, uppercased, or null when unknown.
+ *
+ * Normalised at the boundary so "us", "US" and " us " cannot resolve to
+ * different plans — a country that fails to match silently prices the trip on
+ * the fallback, which is exactly the kind of quiet wrong answer money code
+ * must not produce.
+ */
+export function normaliseCountryCode(code: string | null | undefined): string | null {
+  const trimmed = code?.trim().toUpperCase();
+  return trimmed ? trimmed : null;
+}
+
 export type ResolvableRate = {
   id: string;
   purposeKind: MileagePurpose;
+  /**
+   * Country of the rate plan's jurisdiction, or null for a plan that is not
+   * scoped to one (an org-wide override, or a statutory plan seeded before
+   * jurisdictions were recorded).
+   */
+  jurisdictionCountryCode?: string | null;
   /** Money per mile, e.g. 0.725. */
   amountPerMile: number;
   currency: string;
@@ -50,14 +69,71 @@ export function resolveRateForDate(
   on: Date,
   purpose: MileagePurpose = "business",
 ): ResolvableRate | null {
-  const candidates = rates
-    .filter((r) => r.purposeKind === purpose && coversDate(r, on))
-    .sort((a, b) => {
+  return pickWithinTier(rates.filter((r) => r.purposeKind === purpose && coversDate(r, on)));
+}
+
+/**
+ * Resolve the rate for a trip, honouring where it was driven (DI-5E5AFE040A1F).
+ *
+ * The organization operates in several countries and sends people abroad, so a
+ * mile driven in Mexico may reimburse differently from one driven in the US.
+ * The governing jurisdiction is still usually the employee's country of record,
+ * which is what makes this a fallback chain rather than a single lookup:
+ *
+ *   1. a plan for the country the trip was DRIVEN in, when the org has one
+ *   2. otherwise a plan for the employee's country of record
+ *   3. otherwise an unscoped plan (org-wide override, or an unjurisdictioned
+ *      statutory plan)
+ *
+ * Within whichever tier wins, the existing rules still apply unchanged: an org
+ * override beats a statutory rate, and the latest effectiveFrom beats an older
+ * one. Tier is decided FIRST and never mixed — an org override for the wrong
+ * country must not outrank the statutory rate for the right one, which is the
+ * bug a single flat sort would introduce.
+ *
+ * `tripCountryCode` null (older client, no signal, permission withheld) simply
+ * skips tier 1. That is the whole reason the chain degrades instead of holding
+ * the trip: a driver who declined location still gets paid, at their home rate.
+ */
+export function resolveRateForTrip(
+  rates: readonly ResolvableRate[],
+  on: Date,
+  args: {
+    tripCountryCode?: string | null;
+    employeeCountryCode?: string | null;
+    purpose?: MileagePurpose;
+  } = {},
+): ResolvableRate | null {
+  const purpose = args.purpose ?? "business";
+  const trip = normaliseCountryCode(args.tripCountryCode);
+  const employee = normaliseCountryCode(args.employeeCountryCode);
+
+  const covering = rates.filter((r) => r.purposeKind === purpose && coversDate(r, on));
+  const inCountry = (country: string) =>
+    covering.filter((r) => normaliseCountryCode(r.jurisdictionCountryCode) === country);
+
+  const tiers: ResolvableRate[][] = [];
+  if (trip) tiers.push(inCountry(trip));
+  // Only a distinct home country adds a tier; when the drive is domestic the
+  // second pass would re-examine the same rates for nothing.
+  if (employee && employee !== trip) tiers.push(inCountry(employee));
+  tiers.push(covering.filter((r) => normaliseCountryCode(r.jurisdictionCountryCode) === null));
+
+  for (const tier of tiers) {
+    const winner = pickWithinTier(tier);
+    if (winner) return winner;
+  }
+  return null;
+}
+
+/** Org override first, then the latest effectiveFrom — the pre-jurisdiction rule. */
+function pickWithinTier(rates: readonly ResolvableRate[]): ResolvableRate | null {
+  return (
+    [...rates].sort((a, b) => {
       if (a.isOrgOverride !== b.isOrgOverride) return a.isOrgOverride ? -1 : 1;
       return b.effectiveFrom.getTime() - a.effectiveFrom.getTime();
-    });
-
-  return candidates[0] ?? null;
+    })[0] ?? null
+  );
 }
 
 /** Metres to miles, unrounded — rounding belongs at the money boundary only. */

--- a/apps/web/lib/mileage/trip-service.ts
+++ b/apps/web/lib/mileage/trip-service.ts
@@ -16,7 +16,7 @@
 //      again, so re-running a period cannot pay a driver twice for one drive.
 
 import { priceTrips, type PriceableTrip, type PricingResult } from "./monetisation";
-import type { ResolvableRate } from "./rates";
+import { normaliseCountryCode, type ResolvableRate } from "./rates";
 import type { TripClassification } from "./classification";
 
 /**
@@ -36,6 +36,13 @@ export type RecordTripPayload = {
   endPlaceLabel?: string | null;
   distanceMeters: number;
   captureKind: "automatic" | "manual" | "imported";
+  /**
+   * ISO 3166-1 alpha-2 the CAPTURING DEVICE derived from its own location.
+   * Never a driver choice and never a server guess — omitted when the device
+   * could not resolve one, which prices the trip on the driver's country of
+   * record instead (DI-5E5AFE040A1F).
+   */
+  countryCode?: string | null;
 };
 
 export type RecordTripInput = {
@@ -51,6 +58,8 @@ export type RecordTripInput = {
   endPlaceLabel?: string | null;
   distanceMeters: number;
   captureKind: "automatic" | "manual" | "imported";
+  /** ISO 3166-1 alpha-2 the capturing device derived; see RecordTripPayload. */
+  countryCode?: string | null;
 };
 
 /** Why a drive was refused. Closed set — a caller must be able to explain it. */
@@ -154,6 +163,7 @@ export async function recordTrip(
       endPlaceLabel: input.endPlaceLabel ?? null,
       distanceMeters: Math.round(input.distanceMeters),
       captureKind: input.captureKind,
+      countryCode: normaliseCountryCode(input.countryCode),
     },
   });
 
@@ -201,6 +211,12 @@ export async function monetisePeriod(
     periodEnd: Date;
     rates: readonly ResolvableRate[];
     currency?: string;
+    /**
+     * The driver's country of record. Governs any trip whose own country the
+     * device could not derive, or which was driven somewhere the org holds no
+     * rate plan (DI-5E5AFE040A1F).
+     */
+    employeeCountryCode?: string | null;
   },
 ): Promise<MonetisationOutcome> {
   const rows = await db.trip.findMany({
@@ -230,11 +246,12 @@ export async function monetisePeriod(
       startPlaceLabel: (row.startPlaceLabel as string | null) ?? null,
       endPlaceLabel: (row.endPlaceLabel as string | null) ?? null,
       customerAccountId: (row.customerAccountId as string | null) ?? null,
+      countryCode: (row.countryCode as string | null) ?? null,
     });
   }
 
   return {
-    pricing: priceTrips(priceable, args.rates, args.currency ?? "USD"),
+    pricing: priceTrips(priceable, args.rates, args.currency ?? "USD", args.employeeCountryCode),
     alreadyMonetised,
   };
 }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-import "./.next/dev/types/root-params.d.ts";
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -10,6 +10,6 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 |---|---:|---|
 | Prisma models | 607 | `packages/db/prisma/schema/` |
 | Prisma enums | 68 | `packages/db/prisma/schema/` |
-| Migrations | 549 | `packages/db/prisma/migrations/` |
+| Migrations | 550 | `packages/db/prisma/migrations/` |
 | Kernel principles | 97 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 634 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/architecture/finance-workforce-maturity-matrix.md
+++ b/docs/architecture/finance-workforce-maturity-matrix.md
@@ -57,6 +57,44 @@ statutory engine consumes effective-dated rules with a `sourceUrl` instead. Unti
 are seeded, **no install can run a real payroll or file a real return**, and no public
 claim may imply otherwise.
 
+### Mileage jurisdiction resolution (2026-08-26)
+
+The organization operates in several countries and sends people abroad, so a mile
+driven in Mexico may reimburse differently from one driven in the US. Kernel decision
+**DI-5E5AFE040A1F** (composite 9.355, margin 1.876, autonomy eligible) sets the
+precedence for choosing which `MileageRatePlan` prices a trip:
+
+1. a plan for the country the trip was **driven** in, when the org has one
+2. otherwise a plan for the **employee's country of record**
+3. otherwise an unscoped plan — an org-wide override, or a statutory plan carrying
+   no jurisdiction
+
+The tier is decided first and never mixed. An org override wins **within** a
+jurisdiction, never across one: a US override must not outrank the statutory rate for
+Mexico when the drive happened in Mexico.
+
+**Country is derived, never picked.** `Trip.countryCode` is ISO 3166-1 alpha-2 that the
+capturing device reverse-geocoded from its own location. No driver-facing country
+picker exists on any surface, and the server never infers a country from an address.
+NULL is a legitimate value — an older client, no signal, or a withheld location
+permission — and prices the trip on the employee's country of record rather than
+holding it. A driver who declined location still gets paid.
+
+**Country of record has no new column.** It is read through the canonical MDM chain
+`EmployeeAddress -> Address -> City -> Region -> Country.iso2`. An employee with several
+addresses and no single primary resolves to NULL rather than an arbitrary row, because
+paying someone against an arbitrary address is worse than falling back to an unscoped
+plan.
+
+**Known simplification.** A drive that crosses a border prices entirely on the country
+it started in. Splitting one drive across two plans needs per-segment distance
+attribution and a far denser reverse geocode than a device makes; recording the start
+honestly beats inventing a split. Revisit if cross-border driving becomes common.
+
+As with the payroll rows above, the mechanism is tested but the **statutory per-country
+rates are still unseeded** (BI-4EB27955). Jurisdiction-aware resolution does not by
+itself make any install able to pay a real mileage claim.
+
 ### Finance doc reconciliation rules
 
 1. **Do not** say "DPF has no ledger" — the models exist; say **experimental** or **usable-now** per row.

--- a/docs/data-impact/2026-08-26-trip-derived-country-code.data-impact.json
+++ b/docs/data-impact/2026-08-26-trip-derived-country-code.data-impact.json
@@ -1,0 +1,43 @@
+{
+  "version": "1",
+  "accountableOwner": "developer-platform",
+  "affectedCopies": [
+    "Mileage trip API responses (/api/v1/mileage/trips)",
+    "Driver mileage list at /finance/mileage",
+    "Mobile mileage capture payloads",
+    "Expense-claim mileage lines produced by period monetisation",
+    "Prisma-to-EA current-state data-model mirror"
+  ],
+  "migration": {
+    "name": "20260826032918_add_trip_derived_country_code",
+    "backfill": "none \u2014 the column is nullable and historical rows stay NULL on purpose. We do not know which country a past drive happened in, and inventing one would fabricate the very fact the column exists to record. NULL prices a trip on the employee's country of record, which is exactly how those trips price today, so no historical reimbursement changes."
+  },
+  "tests": [
+    "apps/web/lib/mileage/jurisdiction-rates.test.ts",
+    "apps/web/lib/mileage/country-of-record.test.ts",
+    "apps/web/lib/mileage/monetisation.test.ts",
+    "apps/web/lib/mileage/trip-service.test.ts",
+    "apps/mobile/src/features/mileage/trip-detection.test.ts",
+    "packages/db/src/mileage-absorption-substrate.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:trip#derived-country",
+      "prismaModel": "Trip",
+      "lifecycleDisposition": "Follows the existing Trip RecordLifecycle. Set once at capture and never edited afterwards: a trip's country is an observation of where the drive happened, not a preference to revise.",
+      "fields": [
+        {
+          "fieldId": "data:trip#countryCode",
+          "resolution": "governed",
+          "reason": "Selects which MileageRatePlan prices the drive, so a mile driven abroad reimburses on that country's policy rather than the employee's home rate (DI-5E5AFE040A1F).",
+          "provenance": "Reverse-geocoded by the capturing device from its own location and reported as ISO 3166-1 alpha-2. Never chosen by the driver \u2014 no country picker exists on any surface \u2014 and never inferred server-side from an address.",
+          "flags": [
+            "sensitive"
+          ],
+          "fieldPolicy": "Coarse location inference: a country code is a deliberately low-resolution derivative of location data the driver already consented to capture, and it is recorded only for trips captured under an active DriverLocationConsent. It is retained and disposed with its parent Trip under the same consent and retention terms; it grants no additional location precision beyond the start/end coordinates already stored, and must not be used to infer an employee's whereabouts outside mileage pricing and reporting. NULL is a legitimate value \u2014 an older client, no signal, or a withheld location permission \u2014 and must degrade to the employee's country of record rather than holding the trip or defaulting to a guessed country."
+        }
+      ]
+    }
+  ]
+}

--- a/docs/user-guide/finance/index.md
+++ b/docs/user-guide/finance/index.md
@@ -163,6 +163,16 @@ choose. You can change your mind until the drive is claimed.
 it, not today's rate. A drive that has not been priced yet says so, rather than
 showing zero — no amount yet is not the same as nothing owed.
 
+**Driving abroad.** Your phone knows which country it is in, so you are never asked
+to pick one. If your company has set a rate for the country you drove in, that rate
+is used. If it has not, you are paid at your own country's rate — the country on
+your employee record. A drive that crosses a border is paid at the rate for the
+country you set off from.
+
+If your phone could not work out the country — no signal, or you did not give it
+permission — you are still paid, at your own country's rate. You never lose a
+drive over it.
+
 **Getting paid.** Someone with finance permission turns a month of business drives
 into an expense claim. That claim can be paid on its own or added to your pay as a
 reimbursement, which is not taxed because it repays money you already spent.

--- a/packages/db/prisma/migrations/20260826032918_add_trip_derived_country_code/migration.sql
+++ b/packages/db/prisma/migrations/20260826032918_add_trip_derived_country_code/migration.sql
@@ -1,0 +1,13 @@
+-- Trip gains the country the drive actually happened in, so mileage can be
+-- priced against per-country policy rather than one global rate.
+--
+-- DERIVED, never picked: the capturing device reverse-geocodes its own location
+-- and reports the ISO 3166-1 alpha-2 code. Nullable on purpose — an older client,
+-- a withheld location permission or no signal all yield NULL, and a NULL prices
+-- the trip on the employee's country of record instead of guessing.
+--
+-- Existing rows stay NULL. That is the correct backfill: we do not know where a
+-- historical trip was driven, and inventing a country would fabricate the very
+-- fact the column exists to record. Those trips keep pricing exactly as they do
+-- today, on the employee's country of record.
+ALTER TABLE "Trip" ADD COLUMN "countryCode" TEXT;

--- a/packages/db/prisma/schema/workforce.prisma
+++ b/packages/db/prisma/schema/workforce.prisma
@@ -1442,6 +1442,12 @@ model Trip {
   endLongitude         Decimal                @db.Decimal(10, 7)
   startPlaceLabel      String?
   endPlaceLabel        String?
+  /// ISO 3166-1 alpha-2 of where the drive happened, DERIVED by the capturing
+  /// device from its own location — never chosen by the driver. NULL means the
+  /// device could not resolve one (no signal, permission withheld, an older
+  /// client), which prices the trip on the employee's country of record rather
+  /// than guessing at a country.
+  countryCode          String?
   distanceMeters       Int
   captureKind          TripCaptureKind
   classification       TripClassificationKind @default(unclassified)

--- a/packages/db/src/mileage-absorption-substrate.test.ts
+++ b/packages/db/src/mileage-absorption-substrate.test.ts
@@ -77,6 +77,9 @@ describe("mileage absorption substrate shape", () => {
       endLongitude: "-122.2712000" as unknown as Trip["endLongitude"],
       startPlaceLabel: null,
       endPlaceLabel: null,
+      // Derived by the device, so an automatic capture that could not resolve
+      // a country records null rather than a guess.
+      countryCode: null,
       distanceMeters: 21400,
       captureKind: "automatic",
       classification: "unclassified",

--- a/packages/types/src/mileage.ts
+++ b/packages/types/src/mileage.ts
@@ -38,6 +38,12 @@ export interface RecordTripRequest {
   distanceMetres: number;
   captureKind: MileageCaptureKind;
   vehicleId?: string | null;
+  /**
+   * ISO 3166-1 alpha-2 the DEVICE derived from its own location — the app
+   * reverse-geocodes, the driver never picks. Omit when the device could not
+   * resolve one; the server then prices on the driver's country of record.
+   */
+  countryCode?: string | null;
 }
 
 export interface ClassifyTripRequest {


### PR DESCRIPTION
## What this fixes

Mileage resolved on date and purpose alone, so a mile driven in Mexico paid the US rate. `MileageRatePlan` already carried `jurisdictionRefId` and resolution ignored it entirely — the substrate was there, the rule was not.

## Precedence

Per kernel decision **DI-5E5AFE040A1F** (composite 9.355, margin 1.876, high confidence, autonomy eligible, no commandment conflict):

1. a plan for the country the trip was **driven** in, when the org has one
2. otherwise a plan for the **employee's country of record**
3. otherwise an unscoped plan — org-wide override, or an unjurisdictioned statutory plan

Tier is decided first and never mixed. An org override wins **within** a jurisdiction, never across one: a US override must not outrank Mexico's statutory rate for a drive in Mexico. A single flat sort would do exactly that, so there is a test pinning it.

## Country is derived, never picked

`Trip.countryCode` is ISO 3166-1 alpha-2 that the capturing device reverse-geocoded from its own location. No country picker is added to any surface, and the server never infers one from an address.

NULL is legitimate — an older client, no signal, a withheld location permission — and prices the trip on the employee's country of record rather than holding it. **A driver who declined location still gets paid.**

## Country of record adds no column

It reads through the canonical MDM chain `EmployeeAddress → Address → City → Region → Country.iso2`. An employee with several addresses and no single primary resolves to NULL rather than an arbitrary row: falling back to an unscoped plan beats paying someone against an address nobody chose.

## Known simplification, documented rather than hidden

A drive crossing a border prices on the country it **started in**. Splitting one drive across two plans needs per-segment distance attribution and a far denser reverse geocode than a device makes. Recorded in the maturity matrix so it can be revisited if cross-border driving becomes common.

## Migration

`Trip.countryCode` is nullable and historical rows stay NULL on purpose. We do not know where a past drive was driven, and inventing a country would fabricate the very fact the column exists to record. Those trips price exactly as they do today, so **no historical reimbursement changes**.

## Verification

- Local CI gate **PASS** (evidence `cmt9kar7s0ql101lgd6v4ucvk`, lease NPEL-EB5B3AE394) — typecheck, full suite, production build compiled
- 1,493 web tests across `lib/mileage` + `lib/actions`; 24 mobile jest tests; 7 db substrate tests
- `tsc --noEmit` clean on web, mobile and db
- Data-impact manifest added and the gate satisfied; clock-bomb guard annotated with its reason

**Pre-existing and unrelated:** 19 db tests covering `AdapterCapabilityProfile`, `AdapterRunTelemetry` and `IntegrationCoverageProvider` fail identically on `main` in a worktree with no live database.

## Still not shippable to a real payroll

Statutory per-country rates remain operator-supplied and unseeded (BI-4EB27955). Jurisdiction-aware resolution does not by itself let any install pay a real mileage claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)