### PR TITLE
doc(architecture): add the researched adoption-listing standard to pet-rescue requirements

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1015,6 +1015,7 @@
         "5-required-entities",
         "6-what-exists-today-measured-2026-08-25",
         "7-ux-requirements",
+        "7b-the-adoption-listing-researched-against-the-industry-standard",
         "8-definition-of-done"
       ]
     },

--- a/docs/architecture/archetypes/pet-rescue-operating-model.md
+++ b/docs/architecture/archetypes/pet-rescue-operating-model.md
@@ -276,6 +276,45 @@ given `Simple` mode still has no destination for the work they actually do.
 7. **Read the whole page for cognitive load**, including nav. The existing UX-budget gate already
    measures reading grade over the whole page including navigation.
 
+## 7b. The adoption listing — researched against the industry standard
+
+Added 2026-08-26 after the founder asked whether the listing had been researched rather than
+assumed. It had not been. This section is the corrected baseline.
+
+**This is the primary business-to-consumer interaction of the archetype.** Adoption is driven by
+a photo and a name, and the standard acquisition path is one specific animal being shared to a
+prospective adopter.
+
+**Rescues do not primarily rely on their own site.** RescueGroups.org syndicates to **40+**
+destinations including Petfinder, Adopt-a-Pet, the ASPCA and Chewy. Petfinder's animal schema is
+the de-facto standard, so listing fields must map to it or the archetype cannot reach adopters
+where they actually look.
+
+Required listing fields (Petfinder-aligned):
+
+- **type**: dog, cat, rabbit, small-furry, horse, bird, scales-fins-other, barnyard
+- **breed**: primary, secondary, mixed flag, unknown flag
+- **age**: controlled vocabulary `baby | young | adult | senior` — never free text
+- **size**: small, medium, large, xlarge · **gender** · **coat**: short, medium, long, wire,
+  hairless, curly · **colors**
+- **environment**: good_with_children, good_with_dogs, good_with_cats — typed booleans
+- **attributes**: house_trained, spayed_neutered, shots_current, special_needs, declawed
+- **status**: adoptable | adopted | found (map DPF's available/pending/hold/adopted to this)
+- **photos** (many) and **videos**; **tags**; **adoption fee**; **location + distance**
+- sort by recent and by distance; filter on every controlled field above
+
+Required listing behaviour:
+
+1. **Each animal has a stable public URL and a detail page.** Without it an animal cannot be
+   shared, and sharing is the acquisition channel.
+2. **Per-animal inquiry** carrying the animal reference, so staff know who is being asked about.
+3. **Filtering and sorting** on the typed fields.
+4. **Syndication export** to the standard schema.
+
+**Anything an adopter filters on must be a typed column.** Storing good-with/house-trained in an
+untyped `attributes` Json makes the filter impossible to build — the concrete case for the
+accommodation doctrine's rule that a cross-surface queried field graduates out of Json.
+
 ## 8. Definition of done
 
 The archetype may be described as supported when:


### PR DESCRIPTION
The pet-rescue requirements were written from domain knowledge of shelter **operations** but never researched what an adoption listing looks like **to an adopter** — which is the archetype's primary business-to-consumer interaction. This adds that baseline.

Evidence behind it is filed as **BI-3B82A5DD**.

## What research changed

**Rescues do not primarily rely on their own site.** RescueGroups.org syndicates to **40+ destinations** including Petfinder, Adopt-a-Pet, the ASPCA and Chewy. Listing fields must map to the de-facto Petfinder schema or the archetype cannot reach adopters where they actually look. Syndication was entirely absent from the earlier requirements.

**The required field set** — type (including horse, barnyard, small-furry, scales-fins-other), breed primary/secondary/mixed/unknown, **age as a controlled vocabulary** (`baby|young|adult|senior`, not free text), size, gender, coat, colors, typed `good_with_children/dogs/cats`, `house_trained`, `spayed_neutered`, `shots_current`, `special_needs`, `declawed`, photos **and videos**, tags, adoption fee, location and distance.

**The required behaviour** — a stable per-animal URL, per-animal inquiry, filtering and sort on the typed fields, and syndication export.

## The design point worth keeping

Anything an adopter filters on **must be a typed column**. Storing good-with or house-trained in an untyped `attributes` Json makes the filter impossible to build. That is the concrete case for the accommodation doctrine's rule that a field queried across surfaces graduates out of Json.

## What the live storefront actually does

Measured with three animals and one uploaded photo:

- Photo upload works, and image rendering is good — responsive `srcSet` 160→1280w, `sizes`, `loading="lazy"`, `alt` set to the animal name, and a generated placeholder for photo-less animals.
- But `AnimalsSection.tsx` contains **no `href`, no `Link`, no `button`, no `onClick`**. An animal has no page of its own, so it cannot be shared — and sharing one specific animal is the acquisition channel for this archetype.
- The only inquiry link targets a `StorefrontItem`, not an animal, so an adopter interested in a specific dog gets a generic form carrying no reference.
- The public page renders **zero form controls**, so there is no filtering or search.

## Note on the earlier assessment

`/s/rescue` was previously recorded as a positive — correct vocabulary, Donate/Adopt/Free/Enquire, no Buy/Cart. That still holds and is not retracted. It was assessed with **zero animals**, so the listing rendered an empty state and the dead end was invisible.

## Verification

- `node scripts/check-doc-links.mjs` — PASS, no error-level findings
- doc index regenerated and staged by the pre-commit hook (688 pages)
- gitleaks clean; no private-identity tokens

Docs only — no code, schema or behaviour change.

Sources: [RescueGroups syndication](https://rescuegroups.org/adoption-listing-websites/) · [Petfinder API field reference (petpy)](https://petpy.readthedocs.io/en/latest/api.html) · [Humane society website practices](https://morweb.org/post/best-humane-society-website-design-practices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)