### PR TITLE
fix(coworker): surface tools take cap priority, not cap exemption (BI-95D74DE9)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -1390,8 +1390,8 @@ export async function sendMessage(input: {
   const { attached: budgetedTools, deferred: deferredTools } = selectCoworkerToolBudget({
     tools: availableTools,
     roleGrants,
-    pageActionNames: new Set([...pageActions.map((t) => t.name), ...routeDomainToolNames, ...brokeredToolNames]),
-    alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME, ...AUTHORIZED_SURFACE_TOOL_NAMES]),
+    pageActionNames: new Set([...pageActions.map((t) => t.name), ...routeDomainToolNames, ...brokeredToolNames, ...AUTHORIZED_SURFACE_TOOL_NAMES]),
+    alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME]),
     cap: availableTools.length > toolCap ? Math.max(1, toolCap - 1) : toolCap,
     // BI-ACE1EBA4 — when the cap forces deferral, keep the tools most relevant to
     // this turn's intent within each priority tier.

--- a/apps/web/lib/actions/coworker-tool-budget.test.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.test.ts
@@ -353,6 +353,65 @@ describe("selectCoworkerToolBudget", () => {
     expect(deferred.map((t) => t.name)).not.toContain("query_backlog");
   });
 
+  it("holds the gate bound at EVERY cap, including caps below the surface-tool count (BI-95D74DE9)", () => {
+    // The bound BI-8634F0BE's matrix could not reach. That matrix asserts the
+    // derived CAP never exceeds the routing ceiling; this asserts the ATTACHED
+    // SURFACE does not either. The two differ because selectCoworkerToolBudget
+    // attaches alwaysIncludeNames without consulting the cap — so passing the
+    // six surface tools there put a floor of 6 (+load_tools) under every
+    // surface, whatever the cap said.
+    //
+    // Unreachable until BI-8634F0BE let a measured ceiling drop the cap below
+    // 12; at cap 4 or 6 the surface became one callWithFallbackChain refuses,
+    // which is the BI-A8BFEFCE failure a layer further down.
+    const SURFACE = [...AUTHORIZED_SURFACE_TOOL_NAMES];
+    const tools = [
+      tool(LOAD_TOOLS_TOOL_NAME),
+      ...SURFACE.map((n) => tool(n)),
+      ...Array.from({ length: 80 }, (_, i) => tool(`breadth_${i}`, "misc")),
+    ];
+    const violations: string[] = [];
+    for (let cap = 1; cap <= 48; cap++) {
+      const { attached, deferred } = selectCoworkerToolBudget({
+        tools,
+        roleGrants: [],
+        // Surface tools ride as tier-0 PRIORITY, matching both call sites.
+        pageActionNames: new Set(SURFACE),
+        alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME]),
+        cap,
+      });
+      if (attached.length > cap) violations.push(`cap=${cap} → attached=${attached.length}`);
+      // The escape hatch must survive every cap, or deferred tools are lost.
+      if (deferred.length > 0 && !attached.some((t) => t.name === LOAD_TOOLS_TOOL_NAME)) {
+        violations.push(`cap=${cap} → load_tools dropped with ${deferred.length} deferred`);
+      }
+      if (attached.length + deferred.length !== tools.length) {
+        violations.push(`cap=${cap} → lost tools (authority leak)`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("still attaches the surface tools first on an ordinary cap — priority is unchanged", () => {
+    const SURFACE = [...AUTHORIZED_SURFACE_TOOL_NAMES];
+    const tools = [
+      tool(LOAD_TOOLS_TOOL_NAME),
+      ...SURFACE.map((n) => tool(n)),
+      ...Array.from({ length: 80 }, (_, i) => tool(`breadth_${i}`, "misc")),
+    ];
+    const { attached } = selectCoworkerToolBudget({
+      tools,
+      roleGrants: [],
+      pageActionNames: new Set(SURFACE),
+      alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME]),
+      cap: 15,
+    });
+    const names = attached.map((t) => t.name);
+    expect(attached.length).toBeLessThanOrEqual(15);
+    for (const n of SURFACE) expect(names).toContain(n);
+    expect(names).toContain(LOAD_TOOLS_TOOL_NAME);
+  });
+
   it("never exceeds the local-fallback gate: cap-15 + route tools + load_tools attach ≤ 15 total", () => {
     // Regression for the live TR-SCHED-7044CD4F miss: 115 authorized, cap 15,
     // 4 route domain tools + load_tools rode on top → attached=20 → routing

--- a/apps/web/lib/actions/coworker-tool-budget.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.ts
@@ -363,6 +363,17 @@ export function selectCoworkerToolBudget(params: {
   // pass past it; with the real cap floor (12) route domain tools always fit.
   // The always-include set (load_tools — the escape hatch that reaches every
   // deferred tool) attaches unconditionally and counts toward the cap.
+  //
+  // `alwaysIncludeNames` therefore holds EXACTLY ONE name (BI-95D74DE9). The six
+  // AUTHORIZED_SURFACE_TOOL_NAMES were added to it later and took the cap
+  // exemption with them, putting a floor of 6 (+load_tools) under every attached
+  // surface regardless of cap. That was masked while MIN_COWORKER_ATTACHED_TOOLS
+  // floored the cap at 12; once BI-8634F0BE let a measured ceiling drop the cap
+  // below 7, the surface exceeded what callWithFallbackChain will run locally and
+  // local left the fallback chain — the BI-A8BFEFCE failure one layer down.
+  // Route-scoped and surface tools belong in `pageActionNames`: same tier-0
+  // ranking, no exemption. Only load_tools may outrank the bound, because
+  // dropping it would strand every deferred tool with no way back.
   let attachedCount = 0;
   for (const entry of ranked) {
     if (always.has(entry.t.name)) {

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -271,12 +271,19 @@ export async function resolveAutonomousWorkTools(input: {
     const { attached, deferred } = selectCoworkerToolBudget({
       tools: authorized,
       roleGrants,
-      pageActionNames: new Set(routeDomainToolNames),
-      alwaysIncludeNames: new Set([
-        LOAD_TOOLS_TOOL_NAME,
+      // BI-95D74DE9 — surface tools and the run's required tools take tier-0
+      // PRIORITY within the cap, not exemption from it. As alwaysIncludeNames
+      // they attached unconditionally, putting a floor of up to 11 under the
+      // surface whatever the cap said, which exceeds what the routing gate will
+      // run once a measured ceiling drops the cap below that. If a cap cannot
+      // fit a run's required tools, the honest signal is a surface too small for
+      // the run — not a surface the gate then refuses outright.
+      pageActionNames: new Set([
+        ...routeDomainToolNames,
         ...AUTHORIZED_SURFACE_TOOL_NAMES,
         ...(input.requiredToolNames ?? []).slice(0, 4),
       ]),
+      alwaysIncludeNames: new Set([LOAD_TOOLS_TOOL_NAME]),
       cap: effectiveCap,
       intentQuery: input.intentQuery,
     });


### PR DESCRIPTION
Third instance of the [#4663](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4663) invariant, one layer below the previous two. Found by auditing [#4687](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4687) rather than by any gate — which is itself the point this PR's guard addresses.

## Defect

`selectCoworkerToolBudget` attaches everything in `alwaysIncludeNames` without consulting the cap:

```ts
if (always.has(entry.t.name)) { attached.push(entry); attachedCount++; }
else if (attachedCount < cap) { ... }
```

Both call sites passed the six `AUTHORIZED_SURFACE_TOOL_NAMES` there; the autonomous runner also passed up to four `requiredToolNames`. So the attached surface carried a hard floor of **7** (interactive) or up to **11** (autonomous), whatever the cap said:

```
cap=4  → attached 6 + load_tools = 7  > gate 4
cap=6  → attached 6 + load_tools = 7  > gate 6
cap=7  → 7   ok
cap=15 → 15  ok
cap=48 → 48  ok
```

Below the floor the surface is one `callWithFallbackChain` refuses, which removes local from the fallback chain — the BI-A8BFEFCE failure a layer down.

## Reachability

This was **unreachable** until #4687. `MIN_COWORKER_ATTACHED_TOOLS` floored the cap at 12, safely above 7.

#4687 correctly stopped that floor overriding a measured fidelity ceiling, allowing caps below 12 for the first time. It did not create a live defect — it removed a mask. This closes what was behind the mask, and both directions are cross-recorded on the backlog items.

## The comment already had it right

```
The always-include set (load_tools — the escape hatch that reaches every
deferred tool) attaches unconditionally and counts toward the cap.
```

Singular, for a specific reason. And two lines earlier:

```
Tier-0 (page actions) keeps top PRIORITY within the cap rather than a free
pass past it.
```

The surface tools were added to the exempt set later and took the exemption with them. Nothing flagged the divergence between the comment and the code — the same drift shape as BI-CC9D5997.

## Fix

Surface tools and `requiredToolNames` move to `pageActionNames`. They keep tier-0 ranking — on any ordinary cap they still attach first — but stop outranking the bound. `load_tools` remains the single unconditional entry, because dropping it strands every deferred tool with no route back.

Where a cap genuinely cannot fit a run's required tools, the honest signal is a surface too small for the run, not one the gate refuses outright.

## The guard #4687 could not provide

#4687's matrix bounds the derived **cap** against `resolveLocalToolCeiling`. This one sweeps every cap from 1 to 48 through `selectCoworkerToolBudget` and asserts three things on the **attached surface**:

- `attached.length <= cap`
- `load_tools` survives whenever anything defers
- `attached + deferred === tools` — no tool lost, guarding authority: a cap must *defer* a tool, never silently drop it

**Verified as a real guard:** rewiring the test to the pre-fix shape fails it; restoring the fix returns it to green.

## Verification

- 116 tests across 8 files pass.
- Module-size, application-boundary, plan-coverage and design-grounding guards pass.
- Production build completed with a full route manifest.

**Local build flakiness, recorded so nobody chases it:** an earlier attempt failed in `apps/web/lib/teardown/dispatcher.ts` on a Turbopack `child_process.spawn` tracing error — a file this change does not touch, last modified 2026-08-22. The identical tree then built cleanly. This host has also produced a native crash (`0xC0000409`) and a wrapper failure on unchanged trees while ~35 node processes from concurrent agent sessions were running. CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-08-26-local-fallback-eligibility-invariant-design.md` — the invariant this is the third instance of, and the contract that `resolveLocalToolCeiling` is the single derivation both ends share.
  - `docs/superpowers/specs/2026-08-26-skill-catalog-cap-local-presence-design.md` — the sibling consumer of the same posture, confirming which axes bind on presence versus on window fit.
- Current code substrate reviewed:
  - `apps/web/lib/actions/coworker-tool-budget.ts` — `selectCoworkerToolBudget`'s attach loop, and the comment that already recorded `load_tools` as the single unconditional entry.
  - `apps/web/lib/actions/agent-coworker.ts` and `apps/web/lib/tak/autonomous-work-run.ts` — the two call sites that pass `alwaysIncludeNames`.
  - `apps/web/lib/coworker/authorized-surface-coworker-contract.ts` — the six surface tool names and their grants.
  - `apps/web/lib/routing/fallback.ts` — the gate that refuses a surface above `resolveLocalToolCeiling`.
- Source of truth:
  - `resolveLocalToolCeiling` (`lib/routing/local-tool-ceiling.ts`) remains the one derivation of the local tool bound. This change does not add a second policy; it stops one call-site parameter from bypassing the existing one.
  - `alwaysIncludeNames` means exactly "exempt from the cap", and now holds exactly one name.
- Decision:
  - Reuse the existing tier-0 mechanism (`pageActionNames`) rather than introduce a new priority concept. Surface tools and `requiredToolNames` keep their ranking and lose only the exemption. No contract, authority or operator-visible change: deferred tools stay authorized and reachable via `load_tools`.
  - No new module, no new constant, no change to the gate itself.

**Process note.** The local pre-push run of this guard reported "nothing to gate", a false green: `check-design-grounding-decision.mjs` diffs `BASE_SHA...HEAD`, so running it before committing sees an empty diff. Re-run after the commit it correctly flagged `apps/web/lib/tak/autonomous-work-run.ts`. Worth knowing for anyone else running the guards by hand.

**CI note — do not `gh run rerun` this one.** `gh run rerun --failed` replays the ORIGINAL `pull_request` event payload, which carries the pre-edit PR body. So after fixing a Design Grounding failure by editing the body, a rerun re-reads the stale body and re-fails, overwriting the passing check that `policy-guards-recheck.yml` had already posted on the `edited` event. Editing the body is sufficient on its own; the rerun actively undoes it.

The remaining `Analyze (python)` / `Analyze (go)` failures are `API rate limit exceeded for installation` on CodeQL's status reporting — a GitHub App limit under concurrent load, not this change. `Merge Readiness` mirrors them.
