### PR TITLE
feat(federation): resolve the organization trust anchor from the join package

### DIFF
--- a/apps/web/lib/federation/organization-trust-anchor.test.ts
+++ b/apps/web/lib/federation/organization-trust-anchor.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  resolveOrganizationTrustAnchor,
+  type JoinImportRecord,
+  type OrganizationTrustAnchorStore,
+} from "./organization-trust-anchor";
+
+const NOW = new Date("2026-08-26T00:00:00.000Z");
+const ORG = "ORG-1779558156034";
+const FULL_FINGERPRINT = "A".repeat(64);
+
+/** A join package in the exact wire form `parseOrganizationJoinPackage` accepts. */
+function joinPackage(
+  overrides: { fingerprint?: string; expiresAt?: Date; peer?: string } = {},
+): string {
+  // The real wire format: version header, `intended_hostname`, and a unix-seconds
+  // expiry. Built to the parser's contract so these tests exercise it, not a mock.
+  const expires = overrides.expiresAt ?? new Date("2026-08-26T00:10:00.000Z");
+  return [
+    "DPF_ORGANIZATION_JOIN_V2",
+    `package_id=${"a".repeat(32)}`,
+    "ca_url=https://ca.example.internal/",
+    `root_fingerprint=${overrides.fingerprint ?? FULL_FINGERPRINT}`,
+    `intended_hostname=${overrides.peer ?? "dpf-dev-01"}`,
+    "intended_sans=dpf-dev-01",
+    `expires_at=${Math.floor(expires.getTime() / 1000)}`,
+    "enrollment_token=tok_abc123",
+    "edge_client_enrollment_token=tok_edge456",
+  ].join("\n");
+}
+
+function store(overrides: Partial<OrganizationTrustAnchorStore> = {}): OrganizationTrustAnchorStore {
+  const record: JoinImportRecord = {
+    parameters: { joinPackageEnc: "enc:stored" },
+    completedAt: new Date("2026-08-20T00:00:00.000Z"),
+    createdAt: new Date("2026-08-20T00:00:00.000Z"),
+  };
+  return {
+    findLatestCompletedJoinImport: async () => record,
+    findLocalOrganizationRef: async () => ORG,
+    ...overrides,
+  };
+}
+
+const decryptTo = (plaintext: string) => () => plaintext;
+
+describe("resolveOrganizationTrustAnchor", () => {
+  it("resolves the FULL fingerprint from the package, not a truncated prefix", async () => {
+    const result = await resolveOrganizationTrustAnchor(store(), {
+      decrypt: decryptTo(joinPackage()),
+      now: NOW,
+    });
+    expect(result.established).toBe(true);
+    expect(result.anchor).toEqual({ rootFingerprint: FULL_FINGERPRINT, organizationRef: ORG });
+    // A 12-character prefix is not an identity; comparing prefixes would be the
+    // weakness this module exists to avoid.
+    expect(result.anchor.rootFingerprint).toHaveLength(64);
+  });
+
+  it("never imports the credential store — decryption is injected", async () => {
+    const decrypt = vi.fn(() => joinPackage());
+    await resolveOrganizationTrustAnchor(store(), { decrypt, now: NOW });
+    expect(decrypt).toHaveBeenCalledWith("enc:stored");
+  });
+});
+
+describe("every unreadable path fails closed to no anchor", () => {
+  async function expectAbsent(
+    overrides: Partial<OrganizationTrustAnchorStore>,
+    decrypt: (stored: string) => string | null,
+    reason: string,
+  ) {
+    const result = await resolveOrganizationTrustAnchor(store(overrides), { decrypt, now: NOW });
+    expect(result.established).toBe(false);
+    expect(result.anchor).toEqual({ rootFingerprint: null, organizationRef: null });
+    if (!result.established) expect(result.reason).toBe(reason);
+  }
+
+  it("reports no anchor when no join import exists", async () => {
+    await expectAbsent(
+      { findLatestCompletedJoinImport: async () => null },
+      decryptTo(joinPackage()),
+      "no-join-import",
+    );
+  });
+
+  it("reports no anchor when the import lookup throws", async () => {
+    await expectAbsent(
+      {
+        findLatestCompletedJoinImport: async () => {
+          throw new Error("db down");
+        },
+      },
+      decryptTo(joinPackage()),
+      "no-join-import",
+    );
+  });
+
+  it("reports no anchor when the record carries no encrypted package", async () => {
+    await expectAbsent(
+      {
+        findLatestCompletedJoinImport: async () => ({
+          parameters: {},
+          completedAt: NOW,
+          createdAt: NOW,
+        }),
+      },
+      decryptTo(joinPackage()),
+      "package-not-decryptable",
+    );
+  });
+
+  it("reports no anchor when decryption returns null (rotated key)", async () => {
+    await expectAbsent({}, () => null, "package-not-decryptable");
+  });
+
+  it("reports no anchor when decryption throws", async () => {
+    await expectAbsent(
+      {},
+      () => {
+        throw new Error("no encryption key");
+      },
+      "package-not-decryptable",
+    );
+  });
+
+  it("reports no anchor when the package does not parse", async () => {
+    await expectAbsent({}, decryptTo("not-a-join-package"), "package-unparseable");
+  });
+
+  it("reports no anchor when the package has expired", async () => {
+    // A membership window that has closed is not trust.
+    await expectAbsent(
+      {},
+      decryptTo(joinPackage({ expiresAt: new Date("2026-08-25T00:00:00.000Z") })),
+      "package-expired",
+    );
+  });
+
+  it("reports no anchor when the installation has no organization", async () => {
+    await expectAbsent(
+      { findLocalOrganizationRef: async () => null },
+      decryptTo(joinPackage()),
+      "no-local-organization",
+    );
+  });
+
+  it("reports no anchor when the organization lookup throws", async () => {
+    await expectAbsent(
+      {
+        findLocalOrganizationRef: async () => {
+          throw new Error("db down");
+        },
+      },
+      decryptTo(joinPackage()),
+      "no-local-organization",
+    );
+  });
+});
+
+describe("the absent anchor keeps enrolment honest", () => {
+  it("produces exactly the shape that yields organization-trust-not-configured", async () => {
+    // `evaluateOrganizationEnrollment` refuses on a null rootFingerprint, so an
+    // unreadable anchor costs a human confirmation rather than widening trust.
+    const result = await resolveOrganizationTrustAnchor(
+      store({ findLatestCompletedJoinImport: async () => null }),
+      { decrypt: decryptTo(joinPackage()), now: NOW },
+    );
+    expect(result.anchor.rootFingerprint).toBeNull();
+  });
+});

--- a/apps/web/lib/federation/organization-trust-anchor.ts
+++ b/apps/web/lib/federation/organization-trust-anchor.ts
@@ -1,0 +1,127 @@
+// EP-MSP-FEDERATION — read this installation's organization trust anchor.
+//
+// `evaluateOrganizationEnrollment` and `decideAutomaticPairing` both need to know
+// which organization root this installation pins, and which organization it
+// belongs to. That fact is already established when an operator imports a join
+// package: `organization.join.import` records the encrypted package and an
+// evidence blob carrying a TRUNCATED root fingerprint prefix.
+//
+// The truncation matters. Comparing prefixes would be a real weakness — a
+// 12-character prefix is not an identity — so this module decrypts the stored
+// package and parses the FULL fingerprint. An installation whose package cannot
+// be decrypted or parsed has no anchor, which routes every pairing back to a
+// human rather than trusting a partial match.
+
+import type { OrganizationTrustAnchor } from "@dpf/db/organization-federation-enrollment";
+import { parseOrganizationJoinPackage } from "@dpf/db/organization-join-action";
+
+/** The join-import record this resolver reads, narrowed to what it needs. */
+export interface JoinImportRecord {
+  parameters: unknown;
+  completedAt: Date | null;
+  createdAt: Date;
+}
+
+export interface OrganizationTrustAnchorStore {
+  /**
+   * The most recent COMPLETED `organization.join.import` action, newest first.
+   * A queued or failed import has not established trust and must not be read as
+   * though it had.
+   */
+  findLatestCompletedJoinImport(): Promise<JoinImportRecord | null>;
+  /** The organization this installation operates for, or null when unset. */
+  findLocalOrganizationRef(): Promise<string | null>;
+}
+
+/** Why no usable anchor could be resolved. Closed so callers can branch. */
+export const TRUST_ANCHOR_ABSENCE_REASONS = [
+  "no-join-import",
+  "package-not-decryptable",
+  "package-unparseable",
+  "package-expired",
+  "no-local-organization",
+] as const;
+export type TrustAnchorAbsenceReason = (typeof TRUST_ANCHOR_ABSENCE_REASONS)[number];
+
+export type TrustAnchorResolution =
+  | { anchor: OrganizationTrustAnchor; established: true }
+  | { anchor: OrganizationTrustAnchor; established: false; reason: TrustAnchorAbsenceReason };
+
+/** The anchor an installation has when nothing establishes one. */
+const NO_ANCHOR: OrganizationTrustAnchor = { rootFingerprint: null, organizationRef: null };
+
+function absent(reason: TrustAnchorAbsenceReason): TrustAnchorResolution {
+  return { anchor: NO_ANCHOR, established: false, reason };
+}
+
+function storedPackage(parameters: unknown): string | null {
+  if (typeof parameters !== "object" || parameters === null) return null;
+  const value = (parameters as Record<string, unknown>)["joinPackageEnc"];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * Resolve the organization trust anchor for this installation.
+ *
+ * Fails closed to "no anchor" on every unreadable path. That default is what
+ * keeps `evaluateOrganizationEnrollment` honest: without an anchor it returns
+ * `organization-trust-not-configured`, so a decrypt failure costs a human
+ * confirmation rather than silently widening trust.
+ *
+ * `decrypt` is injected so this module never imports the credential store, and
+ * so a decrypt failure is a value rather than a thrown error.
+ */
+export async function resolveOrganizationTrustAnchor(
+  store: OrganizationTrustAnchorStore,
+  options: {
+    decrypt: (stored: string) => string | null;
+    now?: Date;
+  },
+): Promise<TrustAnchorResolution> {
+  const now = options.now ?? new Date();
+
+  let record: JoinImportRecord | null = null;
+  try {
+    record = await store.findLatestCompletedJoinImport();
+  } catch {
+    return absent("no-join-import");
+  }
+  if (!record) return absent("no-join-import");
+
+  const stored = storedPackage(record.parameters);
+  if (!stored) return absent("package-not-decryptable");
+
+  let plaintext: string | null = null;
+  try {
+    plaintext = options.decrypt(stored);
+  } catch {
+    plaintext = null;
+  }
+  if (!plaintext) return absent("package-not-decryptable");
+
+  // Parsed with the SAME parser the import path used, so a package that would be
+  // rejected on import cannot be accepted here. The parser owns expiry, so its
+  // verdict is surfaced rather than re-checked — a second check here could only
+  // ever disagree with the authority.
+  const parsed = parseOrganizationJoinPackage(plaintext, now);
+  if (!parsed.ok) {
+    return absent(parsed.reason === "join-package-expired" ? "package-expired" : "package-unparseable");
+  }
+
+  let organizationRef: string | null = null;
+  try {
+    organizationRef = await store.findLocalOrganizationRef();
+  } catch {
+    organizationRef = null;
+  }
+  if (!organizationRef) return absent("no-local-organization");
+
+  return {
+    established: true,
+    anchor: {
+      // The FULL fingerprint from the package, never the truncated evidence prefix.
+      rootFingerprint: parsed.value.rootFingerprint,
+      organizationRef,
+    },
+  };
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -143,6 +143,14 @@ export default defineConfig({
       },
       { find: "@", replacement: webDir },
       {
+        find: "@dpf/db/organization-federation-enrollment",
+        replacement: resolve(rootDir, "packages/db/src/organization-federation-enrollment.ts"),
+      },
+      {
+        find: "@dpf/db/organization-join-action",
+        replacement: resolve(rootDir, "packages/db/src/organization-join-action.ts"),
+      },
+      {
         find: "@dpf/db/installation-peer-pairing",
         replacement: resolve(rootDir, "packages/db/src/installation-peer-pairing.ts"),
       },

--- a/docs/superpowers/specs/2026-08-23-zero-touch-organization-federation-design.md
+++ b/docs/superpowers/specs/2026-08-23-zero-touch-organization-federation-design.md
@@ -150,6 +150,30 @@ evidence costs a human confirmation rather than an unearned trust decision.
 so a caller cannot skip the pairing code by treating `operator-confirmation` as a
 pass.
 
+### 5.5 Resolving the organization trust anchor
+
+Both the enrolment decision and the pairing decision need two facts: the root
+this installation pins, and the organization it belongs to. Importing a join
+package already establishes them, but the `organization.join.import` evidence
+blob deliberately records only a **truncated 12-character fingerprint prefix**.
+
+A prefix is not an identity. `resolveOrganizationTrustAnchor` therefore decrypts
+the stored package and parses the **full 64-character fingerprint**, using the
+same parser the import path used — so a package that would be rejected on import
+cannot be accepted here. Expiry is surfaced from that parser rather than
+re-checked, because the parser owns the rule and a second check could only
+disagree with the authority.
+
+Every unreadable path fails closed to *no anchor*: no join import, an
+undecryptable package (a rotated key returns null rather than throwing), an
+unparseable or expired one, or an installation with no organization. That default
+is what keeps the rest honest — a null fingerprint makes
+`evaluateOrganizationEnrollment` return `organization-trust-not-configured`, so a
+decrypt failure costs a human confirmation instead of widening trust.
+
+Decryption is injected, so the resolver never imports the credential store and a
+failure is a value rather than a thrown error.
+
 ## 6. Lifecycle at scale
 
 The unattended cycle this enables:
@@ -172,9 +196,9 @@ the identity design remains the backstop for an install with **no** peer.
 - Discovery transport and advertisement remain owned by `nearby-candidates`;
   this design consumes its readiness signal rather than replacing it. Composing
   discovery with the trust decision is §5.4 and is no longer deferred.
-- Resolving the organization trust anchor from the recorded
-  `organization.join.import` action, and calling §5.4 from the pairing path,
-  are the remaining slices.
+- Calling §5.4 from the pairing path, so a validated same-organization peer
+  enrols without the code comparison, is the remaining slice. Trust-anchor
+  resolution is §5.5.
 
 ## 8. Acceptance criteria
 
@@ -190,6 +214,8 @@ the identity design remains the backstop for an install with **no** peer.
 6. A plain-HTTP candidate is `blocked` regardless of organization trust; an
    HTTPS-but-unvalidated candidate routes to `operator-confirmation`; only a
    chain-validated same-organization peer reaches `auto-enroll`.
+7. The trust anchor resolves the full fingerprint from the stored package, and
+   every unreadable path yields a null anchor rather than a partial match.
 
 ## 9. Decision record
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -34,6 +34,7 @@
     "./projection-egress": "./src/projection-egress.ts",
     "./remote-action-dispatch": "./src/remote-action-dispatch.ts",
     "./edge-action-envelope": "./src/edge-action-envelope.ts",
+    "./organization-federation-enrollment": "./src/organization-federation-enrollment.ts",
     "./organization-join-action": "./src/organization-join-action.ts",
     "./federated-record-sync": "./src/federated-record-sync.ts",
     "./discovery-triage": "./src/discovery-triage.ts",


### PR DESCRIPTION
## Why

`evaluateOrganizationEnrollment` (#4555) and `decideAutomaticPairing` (#4674) both need two facts: the root this installation pins, and the organization it belongs to. Nothing supplied them.

Importing a join package already establishes both — but the `organization.join.import` evidence blob deliberately records only a **truncated 12-character fingerprint prefix**.

## A prefix is not an identity

Comparing prefixes would be a real weakness, so this resolver decrypts the stored package and parses the **full 64-character fingerprint**, using the *same parser the import path used*. A package that would be rejected on import cannot be accepted here.

Expiry is surfaced from that parser rather than re-checked. The parser owns the rule, and a second check could only ever disagree with the authority — so the redundant post-check was removed in favour of mapping the parser's own `join-package-expired` verdict.

## Fails closed, everywhere

Every unreadable path yields **no anchor**: no join import, an undecryptable package (a rotated key returns `null` rather than throwing), an unparseable one, an expired one, or an installation with no organization.

That default is the point. A null fingerprint makes `evaluateOrganizationEnrollment` return `organization-trust-not-configured`, so **a decrypt failure costs a human confirmation instead of widening trust**. There's a test asserting exactly that shape.

Decryption is injected, so this module never imports the credential store and a failure is a value rather than a thrown error.

## Verification

12 tests, all against the **real parser** rather than a mock — the fixture is built to the actual wire contract (`DPF_ORGANIZATION_JOIN_V2` header, `intended_hostname`, unix-seconds expiry, enrollment tokens, private-CA URL). Building it to the real format is what caught that my first fixture was wrong; a mocked parser would have passed and lied.

All 7 guards pass locally via `node scripts/ci-policy-guards.mjs --profile pull-request`, including `spec-plan-doc-gate` — the design now carries §5.5 for this slice.

Not run: full `pnpm pregate` (unprovisioned worktree). CI gates the real typecheck.

## Scope

Resolver only — nothing calls it yet. One slice remains: calling `decideAutomaticPairing` from the pairing path so a validated same-organization peer enrols without the code comparison. That one touches security-relevant action code, so it stays separate.

Design: §5.5 of `docs/superpowers/specs/2026-08-23-zero-touch-organization-federation-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)