### PR TITLE
fix(mcp): stop a tool pack shadowing a tool it does not define (BI-17CBD21F)

### DIFF
--- a/apps/web/lib/mcp/packs/initiative-readiness-pack.ts
+++ b/apps/web/lib/mcp/packs/initiative-readiness-pack.ts
@@ -355,9 +355,22 @@ function handlerFor(actionKey: string, lane: Lane): ToolPackHandler {
   };
 }
 
+// `LANES` is the single registry for disclosure, receipt validation AND recovery
+// routing, so it deliberately carries lanes this pack does not own as tools —
+// `record_plan_backlog_coverage` is routed here for the implementation-planner
+// role but is IMPLEMENTED by decomposition-pack with a different schema
+// (`decision: decomposed|atomic` + `deliverables`, not `gate` + `decision: pass`).
+// Deriving handlers from every lane registered a second handler under that name
+// and shadowed the real one, so the documented schema was rejected with
+// `gate-not-authorized` and no plan coverage could be recorded (BI-17CBD21F).
+// Bind handlers to the names this pack actually defines; the lane stays in
+// `LANES` so `readinessLaneForRole` still resolves its recovery route.
+const OWNED_TOOL_NAMES = definitions.map((definition) => definition.name);
+const ownedLanes = Object.entries(LANES).filter(([name]) => OWNED_TOOL_NAMES.includes(name));
+
 export const initiativeReadinessPack: ToolPack = {
   packId: "initiative-readiness",
   definitions,
-  handlers: Object.fromEntries(Object.entries(LANES).map(([name, lane]) => [name, handlerFor(name, lane)])),
-  grants: Object.fromEntries(Object.entries(LANES).map(([name, lane]) => [name, [lane.grant]])),
+  handlers: Object.fromEntries(ownedLanes.map(([name, lane]) => [name, handlerFor(name, lane)])),
+  grants: Object.fromEntries(ownedLanes.map(([name, lane]) => [name, [lane.grant]])),
 };

--- a/apps/web/lib/mcp/tool-registry.test.ts
+++ b/apps/web/lib/mcp/tool-registry.test.ts
@@ -461,3 +461,97 @@ describe("tool-pack grant coverage (registry-wide)", () => {
     expect(isToolAllowedByGrants("unknown_self_scoped_tool", ["registry_read"])).toBe(false);
   });
 });
+
+// BI-17CBD21F: a tool name must have exactly one implementation.
+//
+// `composeToolPacks` already threw on duplicate DEFINITIONS, but handlers and
+// grants overwrote silently. `initiative-readiness-pack` derived a handler for
+// every lane in `INITIATIVE_READINESS_LANES` — including
+// `record_plan_backlog_coverage`, a lane it routes for recovery but does not
+// own as a tool — and, being registered after `decomposition-pack`, shadowed
+// the real handler. Callers using the documented schema were refused with
+// `gate-not-authorized` by a handler they never addressed.
+describe("tool name ownership", () => {
+  it("registers exactly one handler and grant set per tool name", () => {
+    const seenHandlers = new Map<string, string>();
+    const seenGrants = new Map<string, string>();
+    const collisions: string[] = [];
+
+    for (const pack of TOOL_PACK_REGISTRY.packs) {
+      for (const name of Object.keys(pack.handlers)) {
+        const owner = seenHandlers.get(name);
+        if (owner) collisions.push(`handler "${name}": ${owner} and ${pack.packId}`);
+        else seenHandlers.set(name, pack.packId);
+      }
+      for (const name of Object.keys(pack.grants)) {
+        const owner = seenGrants.get(name);
+        if (owner) collisions.push(`grant "${name}": ${owner} and ${pack.packId}`);
+        else seenGrants.set(name, pack.packId);
+      }
+    }
+
+    expect(collisions).toEqual([]);
+  });
+
+  // A handler with no matching definition is legitimate for a retained alias —
+  // the Workroom rename kept the pre-rename `*capsule*` names callable, and a
+  // few deprecated names are still answered. It is NOT legitimate as a silent
+  // second implementation of a name another pack defines, which is how
+  // BI-17CBD21F happened. Pin the deliberate set so a new orphan is caught.
+  const KNOWN_UNDEFINED_HANDLERS = new Set([
+    "claim_capsule_scope",
+    "create_work_capsule",
+    "dpf_test_kernel_refuse_probe",
+    "generate_code",
+    "get_work_capsule",
+    "heartbeat_capsule",
+    "iterate_sandbox",
+    "list_work_capsules",
+    "plan_capsule_worktree",
+    "reassign_capsule_executor",
+    "record_capsule_evidence",
+    "release_capsule_scope",
+    "update_work_capsule_status",
+  ]);
+
+  it("registers a handler without a definition only for a retained alias", () => {
+    const unexpected: string[] = [];
+    for (const pack of TOOL_PACK_REGISTRY.packs) {
+      const defined = new Set(pack.definitions.map((definition) => definition.name));
+      for (const name of Object.keys(pack.handlers)) {
+        if (!defined.has(name) && !KNOWN_UNDEFINED_HANDLERS.has(name)) {
+          unexpected.push(`${pack.packId} handles undefined tool "${name}"`);
+        }
+      }
+    }
+    expect(unexpected).toEqual([]);
+  });
+
+  it("never answers a name another pack defines", () => {
+    const definedBy = new Map<string, string>();
+    for (const pack of TOOL_PACK_REGISTRY.packs) {
+      for (const definition of pack.definitions) definedBy.set(definition.name, pack.packId);
+    }
+    const shadowing: string[] = [];
+    for (const pack of TOOL_PACK_REGISTRY.packs) {
+      for (const name of Object.keys(pack.handlers)) {
+        const owner = definedBy.get(name);
+        if (owner && owner !== pack.packId) {
+          shadowing.push(`${pack.packId} handles "${name}" defined by ${owner}`);
+        }
+      }
+    }
+    expect(shadowing).toEqual([]);
+  });
+
+  it("keeps record_plan_backlog_coverage owned by the pack that implements its schema", () => {
+    const owner = TOOL_PACK_REGISTRY.packs.find((pack) =>
+      pack.definitions.some((definition) => definition.name === "record_plan_backlog_coverage"));
+    expect(owner?.packId).toBe("decomposition");
+
+    const schema = owner?.definitions.find((d) => d.name === "record_plan_backlog_coverage")?.inputSchema;
+    const properties = Object.keys((schema as { properties?: Record<string, unknown> })?.properties ?? {});
+    expect(properties).toContain("deliverables");
+    expect(properties).not.toContain("gate");
+  });
+});

--- a/apps/web/lib/mcp/tool-registry.ts
+++ b/apps/web/lib/mcp/tool-registry.ts
@@ -31,10 +31,26 @@ export function composeToolPacks(packs: ToolPack[]): ToolRegistry {
       seen.add(def.name);
       definitions.push(def);
     }
+    // Definitions already throw on collision above. Handlers and grants used to
+    // overwrite silently, which let a pack shadow a tool it did not define: the
+    // later pack's handler answered calls shaped for the earlier pack's schema
+    // and rejected them. That is invisible to a caller, who sees a valid request
+    // refused by a handler they never addressed (BI-17CBD21F). Bind the same
+    // rule to all three registries so a name has exactly one implementation.
     for (const [name, handler] of Object.entries(pack.handlers)) {
+      if (handlers[name]) {
+        throw new Error(
+          `Duplicate handler for tool "${name}" registered across tool packs; a tool name must have exactly one implementation`,
+        );
+      }
       handlers[name] = handler;
     }
     for (const [name, grant] of Object.entries(pack.grants)) {
+      if (grants[name]) {
+        throw new Error(
+          `Duplicate grant entry for tool "${name}" registered across tool packs; a tool name must have exactly one grant set`,
+        );
+      }
       grants[name] = grant;
     }
   }


### PR DESCRIPTION
Fixes `BI-17CBD21F`.

## Problem

`record_plan_backlog_coverage` could not be called with its documented schema. Every attempt returned:

```
{ "error": "gate-not-authorized",
  "message": "record_plan_backlog_coverage cannot record that gate." }
```

`composeToolPacks` threw on duplicate **definitions** but let **handlers** and **grants** overwrite silently. `initiative-readiness-pack` derives a handler for every lane in `INITIATIVE_READINESS_LANES`, including `record_plan_backlog_coverage` — a lane it routes for the `implementation-planner` recovery role but does not own as a tool. Registered after `decomposition-pack`, its handler won, and it validates a gate-receipt shape (`gate`, `decision: pass|fail|not-applicable`) rather than the coverage shape (`decision: decomposed|atomic`, `deliverables`).

The two schemas cannot both be satisfied, so no plan-coverage receipt could be recorded on any backlog item. Since `scripts/check-plan-backlog-coverage.mjs` requires a live receipt on any plan declaring a `**Backlog item:**` — and explicitly rejects `pending` and Markdown-only evidence — no correctly-formed plan could pass CI either.

Confirmed by making the error move: supplying `gate: "dependency-disposition"` changed the failure to `decision must be pass, fail, or not-applicable`, the readiness schema. Reproduced through the raw JSON-RPC transport as well as the in-session registry, so it was server-side.

## Changes

**`initiative-readiness-pack.ts`** — bind handlers and grants to the names this pack actually defines. The lane stays in `LANES` so `readinessLaneForRole("implementation-planner")` still resolves its recovery route; only the colliding handler goes.

**`tool-registry.ts`** — apply the duplicate rule to handlers and grants, not only definitions. A tool name now has exactly one implementation, and a collision throws at composition instead of silently overwriting. The silence is what made this expensive: a caller sees a valid request refused by a handler they never addressed.

## Tests

`tool-registry.test.ts` pins tool-name ownership:

- one handler and one grant set per name across every pack
- no pack answers a name another pack defines
- `record_plan_backlog_coverage` is owned by `decomposition` with `deliverables` present and `gate` absent
- a handler with no definition stays legal for the retained pre-rename `*capsule*` aliases, now enumerated so a **new** orphan is caught rather than blanket-allowed

## Build gate

- 127 test files / 1152 tests passing across `lib/mcp`
- `tsc --noEmit` clean
- `pnpm --filter web build` exit 0
- No UI or agent surface change, so no UX verification path applies
- No migration

## Design grounding

- Existing specs/plans reviewed:
  - `docs/architecture/mcp-tool-authorization-runbook.md` — the tool-authorization contract this pack participates in.
  - `AGENTS.md` §6 (tool authorization: coarse scope plus granular per-tool grants) and §12 (governance approves evidence, not provenance).
- Current code substrate reviewed:
  - `apps/web/lib/mcp/tool-registry.ts` — `composeToolPacks`, which already enforced definition uniqueness and did not enforce handler or grant uniqueness.
  - `apps/web/lib/mcp/pack-registry.ts` — pack composition order; `decompositionPack` precedes `initiativeReadinessPack`.
  - `apps/web/lib/mcp/packs/initiative-readiness-pack.ts` — handlers derived from all of `LANES` while `definitions` is hand-enumerated.
  - `apps/web/lib/tak/initiative-readiness-tool-grants.ts` — `INITIATIVE_READINESS_LANES`, the single registry driving disclosure, receipt validation and recovery routing.
  - `apps/web/lib/mcp/packs/decomposition-pack.ts` — the real `record_plan_backlog_coverage` implementation and schema.
- Source of truth:
  - `INITIATIVE_READINESS_LANES` stays the single registry for recovery routing. `definitions` stays the single statement of which tools a pack owns. Neither is duplicated; the fix makes handler binding follow the existing ownership statement instead of diverging from it.
- Decision:
  - Bind handlers and grants to the names a pack defines, and extend the existing definition-uniqueness rule in `composeToolPacks` to handlers and grants. Rejected removing the lane from `INITIATIVE_READINESS_LANES`, which would have silently dropped the `implementation-planner` recovery route — the lane is correct, only the handler derivation was wrong. Rejected renaming either tool, which would break callers of a documented name. This restores the published contract rather than altering it: `record_plan_backlog_coverage` now answers the schema it has always advertised.

Docs-Impact-Decision: Internal MCP tool-pack composition fix. No route, page, agent-visible tool schema or operator workflow changes — `record_plan_backlog_coverage` begins honouring the schema already documented in its own tool definition, so no user-guide page describes different behaviour after this change.
