### PR TITLE
fix(routing): the quality floor must never make the platform unrunnable (BI-16A1B4A3)

### DIFF
--- a/apps/web/lib/routing/pipeline-v2.quality-floor.test.ts
+++ b/apps/web/lib/routing/pipeline-v2.quality-floor.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import type { EndpointManifest } from "./types";
 import type { RequestContract } from "./request-contract";
 import { EMPTY_CAPABILITIES, EMPTY_PRICING } from "./model-card-types";
-import { getExclusionReasonV2 } from "./pipeline-v2";
+import { getExclusionReasonV2, routeEndpointV2 } from "./pipeline-v2";
 
 function makeEndpoint(overrides: Partial<EndpointManifest> = {}): EndpointManifest {
   return {
@@ -99,5 +99,86 @@ describe("getExclusionReasonV2 — quality floor names the gap (BI-16A1B4A3)", (
         makeContract({ minimumDimensions: { codegen: 85, toolFidelity: 85, reasoning: 85 } }),
       ),
     ).toBeNull();
+  });
+});
+
+// BI-16A1B4A3 — founder ruling 2026-08-26: the platform must never be
+// unrunnable; the bundled local model has to work when nothing else does.
+describe("routeEndpointV2 — the quality floor never makes the system unrunnable", () => {
+  const floor = { codegen: 85, toolFidelity: 85, reasoning: 85 };
+
+  it("runs on a below-floor local endpoint rather than failing when nothing meets the floor", async () => {
+    // The live shape: everything clears codegen and reasoning and misses only
+    // toolFidelity, by a few points.
+    const local = makeEndpoint({
+      id: "local-1",
+      providerId: "local",
+      name: "qwen3.8-27b",
+      codegen: 96,
+      reasoning: 90,
+      toolFidelity: 82,
+    });
+
+    const decision = await routeEndpointV2(
+      [local],
+      makeContract({ minimumDimensions: floor }),
+      [],
+      [],
+      { skipRecipe: true, capacityByProvider: new Map() },
+    );
+
+    expect(decision.selectedEndpoint).toBe("local-1");
+    expect(decision.reason).toMatch(/no endpoint met the quality floor/i);
+  });
+
+  it("still prefers an at-floor endpoint and excludes the below-floor one", async () => {
+    const strong = makeEndpoint({
+      id: "strong-1",
+      providerId: "codex",
+      name: "at-floor",
+      codegen: 96,
+      reasoning: 95,
+      toolFidelity: 90,
+    });
+    const weak = makeEndpoint({
+      id: "weak-1",
+      providerId: "local",
+      name: "below-floor",
+      codegen: 96,
+      reasoning: 90,
+      toolFidelity: 82,
+    });
+
+    const decision = await routeEndpointV2(
+      [strong, weak],
+      makeContract({ minimumDimensions: floor }),
+      [],
+      [],
+      { skipRecipe: true, capacityByProvider: new Map() },
+    );
+
+    expect(decision.selectedEndpoint).toBe("strong-1");
+    expect(decision.reason).not.toMatch(/no endpoint met the quality floor/i);
+  });
+
+  it("does not relax a hard gate — an uncleared endpoint stays excluded", async () => {
+    const uncleared = makeEndpoint({
+      id: "uncleared-1",
+      providerId: "local",
+      codegen: 96,
+      reasoning: 90,
+      toolFidelity: 82,
+      sensitivityClearance: [],
+    });
+
+    const decision = await routeEndpointV2(
+      [uncleared],
+      makeContract({ minimumDimensions: floor, sensitivity: "restricted" }),
+      [],
+      [],
+      { skipRecipe: true, capacityByProvider: new Map() },
+    );
+
+    expect(decision.selectedEndpoint).toBeNull();
   });
 });

--- a/apps/web/lib/routing/pipeline-v2.ts
+++ b/apps/web/lib/routing/pipeline-v2.ts
@@ -240,6 +240,12 @@ export function getExclusionReasonV2(
 interface HardFilterResultV2 {
   eligible: EndpointManifest[];
   excluded: CandidateTrace[];
+  /**
+   * BI-16A1B4A3 — true when no endpoint met the tier floor and below-floor
+   * endpoints were kept so the turn could still run. Never silent: the caller
+   * records it on the decision.
+   */
+  qualityFloorRelaxed: boolean;
 }
 
 function filterHardV2(
@@ -254,12 +260,63 @@ function filterHardV2(
 ): HardFilterResultV2 {
   const eligible: EndpointManifest[] = [];
   const excluded: CandidateTrace[] = [];
+  let qualityFloorRelaxed = false;
+
+  // ── Tier quality floor — SOFT exclusion (BI-16A1B4A3) ────────────────────
+  // Founder ruling 2026-08-26: the platform must never be unrunnable. The
+  // bundled local model has to work when nothing else is available, even on
+  // modest hardware.
+  //
+  // The floor used to be a HARD gate, and on a live install it excluded EVERY
+  // endpoint: all of them cleared codegen and reasoning and failed only
+  // toolFidelity — best on the box 82 against a frontier floor of 85, and the
+  // highest-scoring endpoint's 80 had never actually been measured. A tier
+  // preference silently became a total outage.
+  //
+  // So it takes the same contract the runtime circuit breaker and the capacity
+  // snapshot already use: drop below-floor endpoints ONLY while an at-floor peer
+  // remains. When nothing meets the floor, the turn proceeds against the best
+  // available rather than failing.
+  //
+  // This is a QUALITY preference, never a safety gate. Sensitivity clearance,
+  // agent capability floors, model class, status and context window stay hard —
+  // they are evaluated below and are not relaxed by this.
+  const hardContract: RequestContract = { ...contract, minimumDimensions: undefined };
+  const belowFloor: Array<{ ep: EndpointManifest; reason: string }> = [];
 
   for (const ep of endpoints) {
-    const reason = getExclusionReasonV2(ep, contract);
+    const reason = getExclusionReasonV2(ep, hardContract);
     if (reason === null) {
+      const unmet = firstUnmetDimension(ep, contract.minimumDimensions);
+      if (unmet) {
+        belowFloor.push({
+          ep,
+          reason: `Minimum quality dimensions not met (${unmet.dimension} ${unmet.actual} < ${unmet.minimum})`,
+        });
+        continue;
+      }
       eligible.push(ep);
     } else {
+      excluded.push({
+        endpointId: ep.id,
+        providerId: ep.providerId,
+        modelId: ep.modelId,
+        endpointName: ep.name,
+        fitnessScore: 0,
+        dimensionScores: {},
+        costPerOutputMToken: ep.costPerOutputMToken,
+        excluded: true,
+        excludedReason: reason,
+      });
+    }
+  }
+
+  // Apply the soft floor: keep below-floor endpoints only when no peer met it.
+  if (eligible.length === 0 && belowFloor.length > 0) {
+    qualityFloorRelaxed = true;
+    for (const { ep } of belowFloor) eligible.push(ep);
+  } else {
+    for (const { ep, reason } of belowFloor) {
       excluded.push({
         endpointId: ep.id,
         providerId: ep.providerId,
@@ -344,10 +401,10 @@ function filterHardV2(
         excludedReason: reason,
       });
     }
-    return { eligible: cap.eligible, excluded };
+    return { eligible: cap.eligible, excluded, qualityFloorRelaxed };
   }
 
-  return { eligible: afterRuntime, excluded };
+  return { eligible: afterRuntime, excluded, qualityFloorRelaxed };
 }
 
 // ── Full pipeline: routeEndpointV2 ──────────────────────────────────────────
@@ -680,12 +737,17 @@ export async function routeEndpointV2(
     ? ` Preferences: ${preferenceSelection.resolution.applied.length} applied, ` +
       `${preferenceSelection.resolution.unavailable.length} unavailable.`
     : "";
+  // BI-16A1B4A3: a relaxed floor must never be silent — the owner is getting a
+  // below-floor model and is entitled to know that is what happened.
+  const degradedReason = hardResult.qualityFloorRelaxed
+    ? " No endpoint met the quality floor for this work, so it ran on the best available rather than not running."
+    : "";
   const reason =
     `Selected ${winner.endpoint.name} (${winner.endpoint.providerId}) for task type '${contract.taskType}' ` +
     `with rankScore ${winner.rankScore.toFixed(1)}. ` +
     `Budget: ${contract.budgetClass}, reasoning depth: ${contract.reasoningDepth}. ` +
     `${allCandidates.length} endpoint(s) excluded; ` +
-    `${ranked.length} candidate(s) ranked.${preferenceReason}`;
+    `${ranked.length} candidate(s) ranked.${preferenceReason}${degradedReason}`;
 
   return {
     selectedEndpoint: winner.endpoint.id,


### PR DESCRIPTION
## Why

Founder ruling, 2026-08-26:

> we can't have an unrunnable system, so the local processer / gpu has to work at a minimum when other options are not available.

The tier quality floor was a **hard** gate. On the Pet Rescue consumer install it excluded **every** endpoint:

| provider | model | codegen | **toolFidelity** | reasoning | evalCount |
|---|---|---|---|---|---|
| local | qwen3.8-27b | 96 | **82** | 90 | 4 |
| codex | gpt-5.4 | 97 | **80** | 95 | 0 — never measured |
| chatgpt | gpt-5.4 | 90 | **10** | 85 | 0 |

Against `frontier: { codegen: 85, toolFidelity: 85, reasoning: 85 }`. Everything cleared codegen and reasoning and missed only toolFidelity, by three points. A tier **preference** silently became a total outage — ideate, plan and build could not route at all, while design-review and plan-review (no frontier floor) ran fine.

## Change

The floor now takes **the same soft-exclusion contract already used twice in this file** — by the runtime circuit breaker and the persisted capacity snapshot:

> only drop when a peer remains eligible — graceful degradation over a hard lockout (spec risk R1)

Below-floor endpoints are dropped **only while an at-floor peer remains**. When nothing meets the floor, the turn proceeds against the best available rather than failing. The bundled local model is therefore always present as the floor of last resort.

**Still hard, and explicitly not relaxed:** sensitivity clearance, the agent capability floor, model class, endpoint status, context window. A quality preference is not a safety gate — an endpoint with no clearance for the data class is still refused, and a test pins that.

**Never silent:** the decision reason records that no endpoint met the floor and the work ran on the best available rather than not running.

## Verification

- `lib/routing` + `lib/inference` + `lib/build` + `lib/coworker-service-catalog` + `lib/tak` + `lib/agent` + `components/build`: **550 files / 6209 tests pass**.
- The key case is confirmed **Red** against `origin/main` (`1 failed | 4 passed`) and green with the fix.
- `tsc --noEmit` 0 errors, guard loop 37/37, module-size and style-drift clean, docs/spec/design gates clean.
- `route-readiness.ts` — the other `satisfiesMinimumDimensions` caller — is deliberately untouched: coworker readiness *reporting* is not a live turn and should keep stating the floor.
- Runtime UX verification not performed; the change is not deployed to the live install (`/ops/self-upgrade` owns that).

## Follow-on, not in this revert

Slow local hardware must also be *persevered with* rather than treated as failure (stall/abandon thresholds and local inference timeouts). Captured separately against BI-E492F313.

Refs: BI-16A1B4A3, WC-4C77FD84