### PR TITLE
fix(governance): stop reporting a found reviewer as "no-eligible-reviewer" (BI-3AE38A1F)

### DIFF
--- a/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
@@ -106,9 +106,68 @@ describe("initiative readiness recovery routing", () => {
     });
 
     expect(recovery.reviewerRoutes).toEqual([]);
+    // The reason must NOT be "no-eligible-reviewer" here: both grants above are
+    // held by an active production agent. Reporting an absent roster when the
+    // roster is fine sends the caller hunting for missing grants instead of
+    // supplying the dispatch context, which is the one thing actually missing.
     expect(recovery.escalations).toMatchObject([
-      { accountableRole: "design-author", toolName: "record_initiative_evidence", grant: "initiative_evidence_write" },
-      { accountableRole: "implementation-planner", toolName: "record_plan_backlog_coverage", grant: "backlog_write" },
+      {
+        accountableRole: "design-author",
+        toolName: "record_initiative_evidence",
+        grant: "initiative_evidence_write",
+        reason: "dispatch-context-required",
+      },
+      {
+        accountableRole: "implementation-planner",
+        toolName: "record_plan_backlog_coverage",
+        grant: "backlog_write",
+        reason: "dispatch-context-required",
+      },
     ]);
+    // and it must name the reviewer it found, so the caller can see the roster is healthy
+    expect(recovery.escalations[0]!.nextAction).toContain("AGT-WS-BUILD");
+  });
+
+  it("reports no-eligible-reviewer ONLY when nobody holds the grant", async () => {
+    const recovery = await resolveInitiativeReviewerRecovery({
+      decision,
+      currentAgentId: "AGT-AUTHOR",
+      // Empty roster: no agent holds either grant in a production, active state.
+      db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue([]) } },
+      dispatchContext,
+    });
+
+    expect(recovery.reviewerRoutes).toEqual([]);
+    for (const escalation of recovery.escalations) {
+      expect(escalation.reason).toBe("no-eligible-reviewer");
+      expect(escalation.nextAction).toContain("Assign or activate");
+    }
+    expect(recovery.escalations.length).toBeGreaterThan(0);
+  });
+
+  it("keeps the two blocked states distinguishable from each other", async () => {
+    const roster = [
+      grantRow("initiative_evidence_write", "AGT-WS-BUILD", "Build Specialist"),
+      grantRow("backlog_write", "AGT-WS-BUILD", "Build Specialist"),
+    ];
+    const withoutDispatch = await resolveInitiativeReviewerRecovery({
+      decision,
+      currentAgentId: "AGT-AUTHOR",
+      db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue(roster) } },
+      dispatchContext: null,
+    });
+    const withoutRoster = await resolveInitiativeReviewerRecovery({
+      decision,
+      currentAgentId: "AGT-AUTHOR",
+      db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue([]) } },
+      dispatchContext,
+    });
+
+    const reasons = new Set([
+      ...withoutDispatch.escalations.map((entry) => entry.reason),
+      ...withoutRoster.escalations.map((entry) => entry.reason),
+    ]);
+    // Two genuinely different operator actions must not collapse to one code.
+    expect(reasons).toEqual(new Set(["dispatch-context-required", "no-eligible-reviewer"]));
   });
 });

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.ts
@@ -75,7 +75,20 @@ export type InitiativeReviewerRecovery = {
     accountableRole: string;
     toolName: string;
     grant: string;
-    reason: "no-eligible-reviewer";
+    /**
+     * Why the caller cannot route this gate to a reviewer.
+     *
+     * - "no-eligible-reviewer": nobody holds the grant in a production, active,
+     *   unarchived state. Somebody must be assigned or activated.
+     * - "dispatch-context-required": an eligible reviewer WAS found, but no
+     *   Workroom branch + immutable head was supplied to bind the request to.
+     *   Nothing is wrong with the reviewer roster.
+     *
+     * These were one value until 2026-08-26. Reporting a found reviewer as
+     * "no-eligible-reviewer" reads as a permanent dead end and sends the caller
+     * hunting for missing grants instead of supplying the dispatch context.
+     */
+    reason: "no-eligible-reviewer" | "dispatch-context-required";
     nextAction: string;
   }>;
 };
@@ -158,8 +171,8 @@ export async function resolveInitiativeReviewerRecovery(input: {
           accountableRole: entry.role,
           toolName: entry.route.toolName,
           grant: entry.route.lane.grant,
-          reason: "no-eligible-reviewer",
-          nextAction: "Reconcile the exact Workroom branch and immutable head before dispatch; do not synthesize reviewer artifact bindings.",
+          reason: "dispatch-context-required",
+          nextAction: `Eligible reviewer ${candidate.agent.agentId} holds ${entry.route.lane.grant}; supply the Workroom branch and immutable head to dispatch. Do not synthesize reviewer artifact bindings.`,
         });
         continue;
       }


### PR DESCRIPTION
## Summary

Closes **BI-3AE38A1F**. `resolveInitiativeReviewerRecovery` emitted the same escalation reason from two branches that mean opposite things:

| branch | actual state | reported |
|---|---|---|
| line 190 | nobody holds the grant | `no-eligible-reviewer` ✅ |
| line 157 | **an eligible reviewer WAS matched**, but no Workroom branch + immutable head was supplied | `no-eligible-reviewer` ❌ |

Only the free-text `nextAction` told them apart.

## Why this earns its own fix

The code reads as a permanent dead end — *nobody can help you*. The real state was the opposite: a reviewer was found, and one missing input stood in the way.

That mislabel cost real time on this very item. Chasing a live `no-eligible-reviewer` on BI-2DB7254B I concluded, in order, that the grant was unobtainable, that no agent held it, and that the gate had no satisfiable path for external contributors — and filed two analyses on that basis. **All of it was wrong.** Two active agents (`AGT-WS-BUILD`, `AGT-WS-PORTFOLIO`) hold `initiative_evidence_write` in the seeded registry, and the router had already matched one. The blocker was the dispatch context the `nextAction` named — which I read as boilerplate because the reason code contradicted it.

An operator hitting this goes hunting for missing grants or absent coworkers. Nothing in the roster is wrong.

## Changes

- Escalation reason widened to `"no-eligible-reviewer" | "dispatch-context-required"`.
- The found-but-unroutable branch now reports `dispatch-context-required` and **names the matched reviewer and grant**, so the caller can see the roster is healthy:
  `Eligible reviewer AGT-WS-BUILD holds initiative_evidence_write; supply the Workroom branch and immutable head to dispatch.`
- The genuine branch is untouched.
- Both values documented on the type, including why they were split.

## Why the mislabel survived

`initiative-readiness-tool-grants.test.ts` **already covered** the found-but-no-dispatch-context path. It asserted `accountableRole`, `toolName` and `grant` — but not `reason` — and `toMatchObject` ignores what it isn't asked about. The wrong value sat inside a passing test.

Now asserted, plus a test that nobody-holds-the-grant still reports `no-eligible-reviewer`, plus one asserting the two states never collapse to one code.

## Test plan

- [x] **Source-only change** (governance lib + its test)
  - [x] Red-then-green on the affected suite
  - [x] Neighbouring consumer suite
  - [x] `tsc --noEmit` on apps/web (the union widened)

### Verification evidence

**Red-then-green.** Restoring the mislabel:

```
× returns both exact next-action mappings when immutable dispatch identity is unavailable
× keeps the two blocked states distinguishable from each other
  Tests  2 failed | 2 passed (4)
```

Fix restored → `Tests 4 passed (4)`.

**Neighbouring + policy suites:** `governed-work-claim.test.ts` **4/4** (asserts the genuine branch; deliberately unchanged). Readiness suites together **24/24**. `tsc --noEmit` on apps/web **exit 0**. docs-impact **OK**, design-grounding **OK**.

**Roster evidence** (that a reviewer genuinely exists): `packages/db/data/agent_registry.json` — 9 agents hold `initiative_*` grants; `AGT-WS-BUILD` and `AGT-WS-PORTFOLIO` hold `initiative_evidence_write`, both `active`.

## Pre-PR readiness

Local-CI-Override: external-contribution-no-install: governance-lib and test-only change in a dedicated worktree, bootstrapped by junctioning node_modules and the generated Prisma client from the source root rather than a bare worktree install. The affected suites, apps/web typecheck and the source gates ran against this exact tree. CI gates this PR in full.

## Overlap sweep

`gh pr list --state open` → no open PR touches `apps/web/lib/tak/` or the initiative-readiness module.

## Notes for the reviewer

- **This does not weaken the gate and grants nobody anything.** Same conditions, same refusals — only the reported reason becomes truthful.
- BI-3AE38A1F originally proposed loosening `RESEARCH_REQUIRED` for `fix` profiles. **That proposal was withdrawn on founder direction:** a bug needs research too, and verifying the reported defect *is* that research. What remains open there is what evidence satisfies research *per profile* — a product decision, tracked in BI-9841CB61, not addressed here.
- Worth a follow-up: the claim/completion callers appear not to pass `dispatchContext` even when a Workroom branch and head are known. This PR makes that state legible; it does not yet make those callers supply it.
