### PR TITLE
fix(local-ci): a killed build is infrastructure evidence, not a product failure (BI-F22B4EEE)

### DIFF
--- a/scripts/lib/pregate-console.mjs
+++ b/scripts/lib/pregate-console.mjs
@@ -231,6 +231,43 @@ export function createGateOutputRelay({
  * }} input
  * @returns {string[]}
  */
+/**
+ * Render a failure summary as text (BI-F22B4EEE).
+ *
+ * `summarizeLocalCiOutput` returns a STRUCTURED record
+ * ({ failedTests, failedChecks, omittedFailureLineCount, … }), and this
+ * function used to do `String(input.failureSummary)` — which prints
+ * `[object Object]`. That was the single line an operator reads on a failed
+ * gate, so five consecutive failures on one branch produced no usable signal
+ * anywhere: not in the console, not in the record.
+ *
+ * Strings still pass through, because some callers hand a plain message.
+ */
+export function failureSummaryLines(summary) {
+  if (!summary) return [];
+  if (typeof summary === "string") {
+    return summary.split(/\r?\n/).filter(Boolean);
+  }
+  const lines = [];
+  for (const entry of summary.failedTests ?? []) {
+    lines.push(typeof entry === "string" ? entry : entry?.text ?? JSON.stringify(entry));
+  }
+  for (const entry of summary.failedChecks ?? []) {
+    lines.push(typeof entry === "string" ? entry : entry?.text ?? JSON.stringify(entry));
+  }
+  if (lines.length === 0) {
+    // A failed gate with nothing to attribute is itself the finding — say so
+    // rather than printing an empty line or an object.
+    lines.push(
+      "no failing test or check was captured in the log — the run may have been killed rather than failing; check the recorded signal and host pressure",
+    );
+  }
+  if (summary.omittedFailureLineCount > 0) {
+    lines.push(`… ${summary.omittedFailureLineCount} more failure line(s) omitted`);
+  }
+  return lines;
+}
+
 export function formatGateSummary(input) {
   const maxLines = input.maxLines ?? 24;
   const out = [];
@@ -249,10 +286,8 @@ export function formatGateSummary(input) {
   if (input.evidenceId) out.push(`  evidence    ${input.evidenceId}`);
   if (input.metadataFile) out.push(`  record      ${input.metadataFile}`);
   if (input.logFile) out.push(`  full log    ${input.logFile}`);
-  if (input.failureSummary) {
-    for (const line of String(input.failureSummary).split(/\r?\n/).filter(Boolean).slice(0, 8)) {
-      out.push(`  ! ${line.length > 110 ? `${line.slice(0, 109)}…` : line}`);
-    }
+  for (const line of failureSummaryLines(input.failureSummary).slice(0, 8)) {
+    out.push(`  ! ${line.length > 110 ? `${line.slice(0, 109)}…` : line}`);
   }
   out.push("  verdict     pnpm run pregate:status  (reads the record, not this text)");
   const trimmed = out.slice(0, Math.max(1, maxLines - 1));

--- a/scripts/lib/pregate-console.test.mjs
+++ b/scripts/lib/pregate-console.test.mjs
@@ -144,3 +144,56 @@ test("gate summary truncates a runaway failure summary rather than replaying the
   assert.ok(lines.length <= 24, `summary must stay bounded, got ${lines.length}`);
   assert.equal(lines.at(-1), "gate failed");
 });
+
+// BI-F22B4EEE. summarizeLocalCiOutput returns a STRUCTURED record, and the
+// summary did `String(input.failureSummary)` — printing `[object Object]` as the
+// one line an operator reads on a failed gate.
+test("formatGateSummary renders a structured failure summary as text", () => {
+  const lines = formatGateSummary({
+    branch: "fix/x",
+    sha: "abcdef1234567890",
+    verdictLine: "",
+    failureSummary: {
+      schema: "dpf-local-ci-failure-summary/v1",
+      failedTests: ["FAIL lib/a.test.ts > does the thing"],
+      failedChecks: ["Prose Lint Guard"],
+      omittedFailureLineCount: 0,
+    },
+  }).join("\n");
+
+  assert.match(lines, /FAIL lib\/a\.test\.ts/);
+  assert.match(lines, /Prose Lint Guard/);
+  assert.doesNotMatch(lines, /\[object Object\]/);
+});
+
+test("formatGateSummary says so when a failed gate captured nothing", () => {
+  // The live shape: the child was killed, so no test or check ever failed. An
+  // empty summary must not render as a blank line or an object.
+  const lines = formatGateSummary({
+    verdictLine: "",
+    failureSummary: {
+      schema: "dpf-local-ci-failure-summary/v1",
+      failedTests: [],
+      failedChecks: [],
+      omittedFailureLineCount: 0,
+    },
+  }).join("\n");
+
+  assert.match(lines, /no failing test or check was captured/);
+  assert.doesNotMatch(lines, /\[object Object\]/);
+});
+
+test("formatGateSummary still accepts a plain string summary", () => {
+  const lines = formatGateSummary({ verdictLine: "", failureSummary: "one plain line" }).join("\n");
+
+  assert.match(lines, /! one plain line/);
+});
+
+test("formatGateSummary reports omitted failure lines", () => {
+  const lines = formatGateSummary({
+    verdictLine: "",
+    failureSummary: { failedTests: ["FAIL a"], failedChecks: [], omittedFailureLineCount: 4 },
+  }).join("\n");
+
+  assert.match(lines, /4 more failure line\(s\) omitted/);
+});

--- a/scripts/lib/sandbox-freshness.mjs
+++ b/scripts/lib/sandbox-freshness.mjs
@@ -360,6 +360,23 @@ export const EXIT_SANDBOX_DRIFT = 3;
 export const EXIT_SANDBOX_NOT_READY = 4;
 export const EXIT_CONTROL_PLANE_STARVATION = 5;
 export const EXIT_VITEST_RUNNER_TERMINATION = 86;
+/**
+ * The local-CI child was killed by a SIGNAL rather than exiting (BI-F22B4EEE).
+ *
+ * `spawnSync` reports a signal death as `status: null`, and the runner used to
+ * collapse that with `result.status ?? 1` — producing exit 1, which is
+ * indistinguishable from a genuine product failure. Observed live: the child
+ * died at the vitest -> production-build boundary after 25,447 tests passed,
+ * leaving no build receipt, no error text, and a gate record that said
+ * "local-CI lease gate failed." with no reason. The box was carrying one active
+ * and nine queued gate claims at the time, and the build stage runs with a
+ * 16 GB heap allowance — an OOM kill, reported as a product verdict.
+ *
+ * 87 rather than the conventional 128+signal: the runner is reporting THAT a
+ * signal occurred, and the signal name travels in the evidence, so a single
+ * code keeps the classifier's shape.
+ */
+export const EXIT_CHILD_SIGNAL_DEATH = 87;
 
 export function exitCodeForVerdict(verdict) {
   if (verdict === "green") return EXIT_GREEN;
@@ -395,6 +412,14 @@ export function classifyGateOutcome({ freshnessVerdict, gateExitCode }) {
       gatePassed: false,
       productEvidence: false,
       summary: "local-CI gate blocked: the shared portal/MCP/Docker/PostgreSQL control-plane degraded during the build. This is infrastructure evidence, NOT a product build failure.",
+    };
+  }
+  if (gateExitCode === EXIT_CHILD_SIGNAL_DEATH) {
+    return {
+      status: "blocked_child_signal_death",
+      gatePassed: false,
+      productEvidence: false,
+      summary: "local-CI gate could not produce a verdict: the build child was killed by a signal rather than exiting. This is infrastructure evidence, NOT a product build failure — most often the host running out of memory under concurrent gate load. Re-run when the box is quieter; check the recorded signal and host pressure before treating any of it as a code defect.",
     };
   }
   if (gateExitCode === EXIT_VITEST_RUNNER_TERMINATION) {

--- a/scripts/lib/sandbox-freshness.test.mjs
+++ b/scripts/lib/sandbox-freshness.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { test } from "node:test";
 import {
   CRITICAL_PACKAGES,
+  EXIT_CHILD_SIGNAL_DEATH,
   EXIT_GREEN,
   EXIT_SANDBOX_DRIFT,
   EXIT_SANDBOX_NOT_READY,
@@ -364,4 +365,36 @@ test("classifyGateOutcome distinguishes repeated Vitest runner termination from 
   assert.equal(outcome.gatePassed, false);
   assert.equal(outcome.productEvidence, false);
   assert.match(outcome.summary, /runner evidence, NOT a product test failure/);
+});
+
+// BI-F22B4EEE. A child killed by a signal is infrastructure evidence, not a
+// product build failure. Before this, `result.status ?? 1` collapsed SIGKILL
+// into exit 1 and the gate recorded "local-CI lease gate failed." — a product
+// verdict for a host that ran out of memory.
+test("a signal-killed child is blocked, not failed", () => {
+  const outcome = classifyGateOutcome({ freshnessVerdict: "green", gateExitCode: EXIT_CHILD_SIGNAL_DEATH });
+
+  assert.equal(outcome.status, "blocked_child_signal_death");
+  assert.equal(outcome.gatePassed, false);
+  assert.equal(outcome.productEvidence, false, "a signal death must never count as product evidence");
+  assert.match(outcome.summary, /NOT a product build failure/);
+});
+
+test("the signal-death code does not collide with the other blocked codes", () => {
+  const codes = new Set([
+    EXIT_GREEN,
+    EXIT_SANDBOX_DRIFT,
+    EXIT_SANDBOX_NOT_READY,
+    EXIT_CHILD_SIGNAL_DEATH,
+  ]);
+  assert.equal(codes.size, 4, "each outcome needs its own exit code to stay distinguishable");
+});
+
+test("an ordinary non-zero exit is still a product failure", () => {
+  // The point of the change is to separate the two, not to make every failure
+  // look like infrastructure.
+  const outcome = classifyGateOutcome({ freshnessVerdict: "green", gateExitCode: 1 });
+
+  assert.equal(outcome.status, "failed");
+  assert.equal(outcome.productEvidence, true);
 });

--- a/scripts/local-ci-runner.mjs
+++ b/scripts/local-ci-runner.mjs
@@ -13,7 +13,7 @@
 
 import { spawnSync } from "node:child_process";
 import { X_OK } from "node:constants";
-import { accessSync, chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { accessSync, chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { connect } from "node:net";
 import { delimiter, dirname, join } from "node:path";
 import {
@@ -28,6 +28,7 @@ import {
   resolveBaseFreshnessPolicy,
 } from "./lib/local-ci-base-freshness.mjs";
 import { ensureFullHistory } from "./lib/git-shallow-preflight.mjs";
+import { EXIT_CHILD_SIGNAL_DEATH } from "./lib/sandbox-freshness.mjs";
 import { parseRepositoryPnpmVersion, resolvePinnedPnpmInvocation } from "./lib/pinned-pnpm.mjs";
 import { isEntryModule } from "./lib/entry-module.mjs";
 import { resolveHostCommandInvocation } from "./lib/host-command-invocation.mjs";
@@ -322,6 +323,74 @@ async function resolveDatabaseUrl(env, manifest) {
 
 export const LOCAL_CI_MISSING_DATABASE_URL = "postgresql://dpf:dpf_dev@127.0.0.1:1/dpf_local_ci_missing_database";
 
+/**
+ * Turn a spawnSync result into an exit code that says what happened
+ * (BI-F22B4EEE).
+ *
+ * `result.status ?? 1` was the whole bug. A child killed by a signal reports
+ * `status: null`, so the `?? 1` collapsed SIGKILL into exit 1 — the same code a
+ * failing test suite produces — and the signal was never read. classifyGateOutcome
+ * then recorded "local-CI lease gate failed.", a PRODUCT verdict, for a host that
+ * had run out of memory.
+ *
+ * That is the failure mode the blocked_* statuses exist to prevent, and it is the
+ * one that had no code. Observed live: the child died at the vitest ->
+ * production-build boundary after 25,447 tests passed, leaving no build receipt
+ * and no error text, on a box carrying ten concurrent gate claims.
+ *
+ * The signal name goes to stderr because the child's own output is inherited and
+ * ends mid-stream — without this line there is nothing anywhere saying a signal
+ * occurred, which is exactly how five gate runs produced no diagnosable reason.
+ */
+export function resolveChildExit(result) {
+  if (result?.signal) {
+    process.stderr.write(
+      `local-ci-runner: the build child was killed by ${result.signal} rather than exiting. ` +
+      "This is infrastructure evidence, not a product build failure — most often the host " +
+      "running out of memory under concurrent gate load. Re-run when the box is quieter.\n",
+    );
+    return EXIT_CHILD_SIGNAL_DEATH;
+  }
+  if (typeof result?.status === "number") return result.status;
+  // No status and no signal: spawn itself failed. Still not a product verdict,
+  // but we cannot claim a signal we did not observe.
+  if (result?.error) {
+    process.stderr.write(`local-ci-runner: could not run the build child: ${result.error.message}\n`);
+  }
+  return 1;
+}
+
+/**
+ * Clear the previous run's per-stage receipts before this run starts
+ * (BI-F22B4EEE).
+ *
+ * `local-integration-ci` reads `${metadataOut}.vitest.json`,
+ * `.typecheck.json` and `.build.json` back when it assembles evidence. They
+ * were never cleared between runs, so a run could find a PREVIOUS run's
+ * receipts and treat their stages as satisfied. Observed live: a "gate" that
+ * ran for 32 seconds — guard loop only, no typecheck, no vitest — and still
+ * emitted a verdict, with receipts beside it from a different tree saying
+ * `passed`.
+ *
+ * A stage that did not run in THIS run must not be able to leave evidence in
+ * it. Removal is best-effort: an absent file is the desired state, and failing
+ * the gate because a stale receipt could not be deleted would trade one wrong
+ * verdict for another.
+ */
+export function clearStaleStageReceipts(metadataFile, { rm = rmSync } = {}) {
+  const cleared = [];
+  for (const suffix of [".vitest.json", ".typecheck.json", ".build.json"]) {
+    const path = `${metadataFile}${suffix}`;
+    try {
+      rm(path, { force: true });
+      cleared.push(path);
+    } catch {
+      // Best-effort by design — see above.
+    }
+  }
+  return cleared;
+}
+
 export function createLocalIntegrationChildInvocation({
   repoTop,
   candidate,
@@ -467,6 +536,9 @@ async function main() {
   const baseSha = baseFreshness.baseSha || "";
   const baseCommitDate = baseSha ? gitOrEmpty(["-C", repoTop, "show", "-s", "--format=%cI", baseSha]) : "";
   const metadataFile = env.DPF_LOCAL_CI_METADATA_FILE || manifest.evidence.metadata;
+  // BI-F22B4EEE: a stage that does not run in THIS run must not inherit the
+  // previous run's receipt and be counted as satisfied.
+  clearStaleStageReceipts(metadataFile);
 
   if (dryRun) {
     process.stdout.write("local-ci-runner dry-run\n");
@@ -543,7 +615,7 @@ async function main() {
   }
 
   const result = spawnSync(process.execPath, invocation.args, { cwd: workspace, stdio: "inherit", env: invocation.env });
-  process.exit(result.status ?? 1);
+  process.exit(resolveChildExit(result));
 }
 
 if (isEntryModule(import.meta.url)) main();

--- a/scripts/local-ci-runner.test.mjs
+++ b/scripts/local-ci-runner.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { test } from "node:test";
@@ -14,7 +14,10 @@ import {
   executableOnPath,
   resolveLocalCiPnpmInvocation,
   resetOwnedSlotDatabase,
+  clearStaleStageReceipts,
+  resolveChildExit,
 } from "./local-ci-runner.mjs";
+import { EXIT_CHILD_SIGNAL_DEATH } from "./lib/sandbox-freshness.mjs";
 
 const cli = fileURLToPath(new URL("./local-ci-runner.mjs", import.meta.url));
 
@@ -256,4 +259,72 @@ test("local CI keeps an already-matching pnpm without a shim", () => {
 
   assert.equal(prepared.mode, "host-match");
   assert.equal(prepared.env.PATH, originalPath);
+});
+
+// BI-F22B4EEE. `result.status ?? 1` was the defect: a signal death reports
+// status null, so SIGKILL became exit 1 — indistinguishable from a failing test
+// suite. Observed live after 25,447 tests passed, with no build receipt and no
+// error text anywhere.
+test("resolveChildExit reports a signal death as its own code", () => {
+  assert.equal(resolveChildExit({ status: null, signal: "SIGKILL" }), EXIT_CHILD_SIGNAL_DEATH);
+  assert.equal(resolveChildExit({ status: null, signal: "SIGTERM" }), EXIT_CHILD_SIGNAL_DEATH);
+});
+
+test("resolveChildExit passes an ordinary exit code straight through", () => {
+  assert.equal(resolveChildExit({ status: 0, signal: null }), 0);
+  assert.equal(resolveChildExit({ status: 1, signal: null }), 1);
+  assert.equal(resolveChildExit({ status: 86, signal: null }), 86);
+});
+
+test("resolveChildExit does not claim a signal it did not observe", () => {
+  // Spawn failure: no status and no signal. Still a failure, but reporting it as
+  // a signal death would be inventing evidence.
+  assert.equal(resolveChildExit({ status: null, signal: null }), 1);
+  assert.equal(resolveChildExit({ status: null, signal: null, error: new Error("ENOENT") }), 1);
+});
+
+test("a signal death outranks a status, so a partially-reported kill is not read as a pass", () => {
+  assert.equal(resolveChildExit({ status: 0, signal: "SIGKILL" }), EXIT_CHILD_SIGNAL_DEATH);
+});
+
+// BI-F22B4EEE, second fault. local-integration-ci reads the per-stage receipts
+// back when it assembles evidence, and they were never cleared between runs — so
+// a run could find a previous run's receipts and treat those stages as done.
+// Observed live: a 32-second "gate" that ran only the guard loop and still
+// emitted a verdict, beside receipts from a different tree saying `passed`.
+test("clearStaleStageReceipts removes every per-stage receipt", () => {
+  const removed = [];
+  const cleared = clearStaleStageReceipts("/tmp/meta.json", { rm: (p) => removed.push(p) });
+
+  assert.deepEqual(removed, [
+    "/tmp/meta.json.vitest.json",
+    "/tmp/meta.json.typecheck.json",
+    "/tmp/meta.json.build.json",
+  ]);
+  assert.equal(cleared.length, 3);
+});
+
+test("clearStaleStageReceipts is best-effort and never throws", () => {
+  // Failing the gate because a stale receipt could not be deleted would trade
+  // one wrong verdict for another.
+  assert.doesNotThrow(() => clearStaleStageReceipts("/tmp/meta.json", {
+    rm: () => { throw new Error("EPERM"); },
+  }));
+  assert.deepEqual(clearStaleStageReceipts("/tmp/meta.json", {
+    rm: () => { throw new Error("EPERM"); },
+  }), []);
+});
+
+test("clearStaleStageReceipts actually deletes on disk", () => {
+  const dir = mkdtempSync(join(tmpdir(), "dpf-stage-receipts-"));
+  const meta = join(dir, "dpf-local-ci-metadata.json");
+  for (const suffix of [".vitest.json", ".typecheck.json", ".build.json"]) {
+    writeFileSync(`${meta}${suffix}`, JSON.stringify({ status: "passed" }));
+  }
+
+  clearStaleStageReceipts(meta);
+
+  for (const suffix of [".vitest.json", ".typecheck.json", ".build.json"]) {
+    assert.equal(existsSync(`${meta}${suffix}`), false, `${suffix} must not survive into the next run`);
+  }
 });


### PR DESCRIPTION
## The symptom

Five consecutive gate runs on one branch produced no diagnosable reason. The records said:

```
web-typecheck      passed
exhaustive-vitest  passed      25,447 tests, 2,962 files
gate               failed      "local-CI lease gate failed."
```

with no failure field anywhere, and the one line an operator reads was:

```
! [object Object]
```

Three faults, all in the reporting path. None touched the diff being gated, which is why the branch could not move.

## 1. A signal death was indistinguishable from a test failure

`local-ci-runner.mjs` ended with `process.exit(result.status ?? 1)`. `spawnSync` reports a signal death as `status: null`, so `?? 1` collapsed SIGKILL into exit 1 — the same code a failing suite produces — and the signal was never read. `classifyGateOutcome` then recorded a **product** verdict for a host that had run out of memory.

The log ends at `25447 passed` and stops: no production-build output, no build receipt, no error text. The child died at the vitest → build boundary — the memory-heavy stage — on a box carrying one active and nine queued gate claims with ~7.7 GB free against a 16 GB heap allowance.

`classifyGateOutcome` already had `blocked_sandbox_drift`, `blocked_control_plane_starvation` and a vitest-termination code, each with copy saying *"this is infrastructure evidence, NOT a product build failure"*. Signal death had no code, so it landed in the exact bucket those three were written to avoid.

## 2. The operator's one line was an object

`summarizeLocalCiOutput` returns a structured record; `formatGateSummary` did `String(input.failureSummary)`. Now rendered properly — and a failed gate that captured no failing test or check says exactly that, which is itself the finding and points at the killed-run case.

## 3. A stage could inherit the previous run's receipt

`local-integration-ci` reads back `${metadataOut}.{vitest,typecheck,build}.json` when it assembles evidence, and nothing cleared them between runs. Observed: a 32-second "gate" — guard loop only, no typecheck, no vitest — that still emitted a verdict, beside receipts from a different tree saying `passed`. Cleared at run start, best-effort, because failing a gate over an undeletable stale receipt would trade one wrong verdict for another.

## The live incident, replayed against the fixed path

| | before | after |
|---|---|---|
| exit code | 1 | 87 |
| status | `failed` | `blocked_child_signal_death` |
| productEvidence | **true** | false |
| operator line | `! [object Object]` | "no failing test or check was captured in the log — the run may have been killed rather than failing; check the recorded signal and host pressure" |

## What this deliberately does not do

An ordinary non-zero exit is **still** a product failure, pinned by a test — the point is to separate the two, not to make every failure look like infrastructure. Further tests pin that a signal outranks a status (so a partially-reported kill is never read as a pass) and that the runner does not claim a signal it did not observe.

## Verification

15 new tests; 81 tests across `sandbox-freshness`, `pregate-console`, `local-ci-failure-summary`, `local-ci-runner` and `sandbox-freshness-preflight`; 52 preflight guards; exact-tree local CI gate **PASS** @ `4fa45b04123e` — 6:23, including `✓ Compiled successfully in 3.0min`, the stage that was dying.

Found while `BI-575F0046` Slice 1 sat blocked behind five unattributable gate failures on this same box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)