### PR TITLE
feat(federation): verify a discovered peer against the pinned organization root

### DIFF
--- a/docs/superpowers/specs/2026-08-23-zero-touch-organization-federation-design.md
+++ b/docs/superpowers/specs/2026-08-23-zero-touch-organization-federation-design.md
@@ -174,6 +174,30 @@ decrypt failure costs a human confirmation instead of widening trust.
 Decryption is injected, so the resolver never imports the credential store and a
 failure is a value rather than a thrown error.
 
+### 5.6 Verifying the peer against the pinned root
+
+§5.4 will only auto-enrol a peer whose chain was *actually* validated against the
+organization root. Nothing produced that fact: discovery reports
+`tls-validation-required`, which is a to-do, and no peer-certificate inspection
+existed anywhere in the codebase.
+
+`verifyPeerChainAgainstRoot` is the evaluation half, and it is pure — the caller
+supplies the chain it observed. Keeping it pure means the security rule is
+testable without a TLS server, and a network adapter cannot quietly change what
+"verified" means.
+
+Two details carry real weight:
+
+- **Fingerprint forms must be normalised.** Node reports `AA:BB:CC:…`; a join
+  package records 64 bare hex characters. Comparing those directly would never
+  match, so both collapse to lowercase hex, and anything that is not exactly 64
+  hex characters is rejected rather than compared loosely.
+- **Validity is checked across the whole chain**, not just the leaf. An expired
+  intermediate breaks the chain as surely as an expired leaf.
+
+Verification requires a positive match against the pinned fingerprint. There is
+no path where an absent, malformed, or unmatched value yields `verified: true`.
+
 ## 6. Lifecycle at scale
 
 The unattended cycle this enables:
@@ -198,7 +222,8 @@ the identity design remains the backstop for an install with **no** peer.
   discovery with the trust decision is §5.4 and is no longer deferred.
 - Calling §5.4 from the pairing path, so a validated same-organization peer
   enrols without the code comparison, is the remaining slice. Trust-anchor
-  resolution is §5.5.
+  resolution is §5.5; peer chain verification is §5.6. The network adapter that
+  observes a live chain is part of that final slice.
 
 ## 8. Acceptance criteria
 
@@ -216,6 +241,9 @@ the identity design remains the backstop for an install with **no** peer.
    chain-validated same-organization peer reaches `auto-enroll`.
 7. The trust anchor resolves the full fingerprint from the stored package, and
    every unreadable path yields a null anchor rather than a partial match.
+8. Peer verification matches fingerprints across colon-separated and bare hex
+   forms, rejects an expired certificate anywhere in the chain, and never reports
+   verified without a positive match against the pinned root.
 
 ## 9. Decision record
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -23,6 +23,7 @@
     "./trust-link-lifecycle": "./src/trust-link-lifecycle.ts",
     "./federation-link-types": "./src/federation-link-types.ts",
     "./automatic-pairing-decision": "./src/automatic-pairing-decision.ts",
+    "./peer-certificate-verification": "./src/peer-certificate-verification.ts",
     "./installation-instance-stance": "./src/installation-instance-stance.ts",
     "./installation-peer-pairing": "./src/installation-peer-pairing.ts",
     "./installation-operating-intent": "./src/installation-operating-intent.ts",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -355,6 +355,14 @@ export {
   type PairingMode,
 } from "./automatic-pairing-decision";
 export {
+  PEER_VERIFICATION_FAILURES,
+  normalizeFingerprint,
+  verifyPeerChainAgainstRoot,
+  type ObservedCertificate,
+  type PeerVerification,
+  type PeerVerificationFailure,
+} from "./peer-certificate-verification";
+export {
   PAIRING_SOURCES,
   pairingSupportsWorkSync,
   resolveInstallationPairing,

--- a/packages/db/src/peer-certificate-verification.test.ts
+++ b/packages/db/src/peer-certificate-verification.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeFingerprint,
+  verifyPeerChainAgainstRoot,
+  type ObservedCertificate,
+} from "./peer-certificate-verification";
+
+const NOW = new Date("2026-08-26T00:00:00.000Z");
+const ROOT_HEX = "a".repeat(64);
+const ROOT_COLONS = "AA:".repeat(31) + "AA";
+
+function cert(overrides: Partial<ObservedCertificate> = {}): ObservedCertificate {
+  return {
+    fingerprint256: "b".repeat(64),
+    selfSigned: false,
+    validFrom: new Date("2026-01-01T00:00:00.000Z"),
+    validTo: new Date("2027-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function root(overrides: Partial<ObservedCertificate> = {}): ObservedCertificate {
+  return cert({ fingerprint256: ROOT_HEX, selfSigned: true, ...overrides });
+}
+
+function verify(
+  chain: ObservedCertificate[],
+  pinned: string | null = ROOT_HEX,
+  now: Date = NOW,
+) {
+  return verifyPeerChainAgainstRoot({ chain, pinnedRootFingerprint: pinned, now });
+}
+
+describe("normalizeFingerprint", () => {
+  it("collapses Node's colon-separated form to bare lowercase hex", () => {
+    // Node reports AA:BB:…; a join package records 64 bare hex characters.
+    // Comparing those directly would never match.
+    expect(normalizeFingerprint(ROOT_COLONS)).toBe(ROOT_HEX);
+  });
+
+  it("accepts bare hex in any case", () => {
+    expect(normalizeFingerprint("A".repeat(64))).toBe(ROOT_HEX);
+  });
+
+  it("rejects anything that is not exactly 64 hex characters", () => {
+    expect(normalizeFingerprint("abc")).toBeNull();
+    expect(normalizeFingerprint("g".repeat(64))).toBeNull();
+    expect(normalizeFingerprint("a".repeat(63))).toBeNull();
+    expect(normalizeFingerprint("a".repeat(65))).toBeNull();
+    expect(normalizeFingerprint(null)).toBeNull();
+    expect(normalizeFingerprint(undefined)).toBeNull();
+  });
+});
+
+describe("verifyPeerChainAgainstRoot — the only path that verifies", () => {
+  it("verifies a chain terminating at the pinned root", () => {
+    const result = verify([cert(), root()]);
+    expect(result).toEqual({ verified: true, presentedRootFingerprint: ROOT_HEX });
+  });
+
+  it("matches across representation forms", () => {
+    // Peer presents colons, package pinned bare hex.
+    expect(verify([cert(), root({ fingerprint256: ROOT_COLONS })]).verified).toBe(true);
+  });
+
+  it("verifies a root-only chain", () => {
+    expect(verify([root()]).verified).toBe(true);
+  });
+});
+
+describe("every other path refuses", () => {
+  it("refuses when nothing is pinned", () => {
+    const result = verify([cert(), root()], null);
+    expect(result).toMatchObject({ verified: false, failure: "no-pinned-root" });
+  });
+
+  it("refuses a malformed pinned value rather than comparing loosely", () => {
+    expect(verify([cert(), root()], "not-a-fingerprint")).toMatchObject({
+      failure: "no-pinned-root",
+    });
+  });
+
+  it("refuses an empty chain", () => {
+    expect(verify([])).toMatchObject({ verified: false, failure: "empty-chain" });
+  });
+
+  it("refuses a chain with no self-signed root", () => {
+    expect(verify([cert(), cert()])).toMatchObject({ failure: "chain-has-no-root" });
+  });
+
+  it("refuses a root that chains to a different organization", () => {
+    const result = verify([cert(), root({ fingerprint256: "c".repeat(64) })]);
+    expect(result).toMatchObject({
+      verified: false,
+      failure: "root-fingerprint-mismatch",
+      presentedRootFingerprint: "c".repeat(64),
+    });
+  });
+
+  it("refuses a root whose fingerprint is malformed", () => {
+    expect(verify([root({ fingerprint256: "zz" })])).toMatchObject({
+      failure: "root-fingerprint-mismatch",
+      presentedRootFingerprint: null,
+    });
+  });
+
+  it("refuses an expired certificate anywhere in the chain", () => {
+    // An expired intermediate breaks the chain as surely as an expired leaf.
+    const expired = cert({ validTo: new Date("2026-08-25T00:00:00.000Z") });
+    expect(verify([expired, root()])).toMatchObject({ failure: "certificate-expired" });
+    expect(verify([cert(), root({ validTo: new Date("2026-08-25T00:00:00.000Z") })])).toMatchObject({
+      failure: "certificate-expired",
+    });
+  });
+
+  it("refuses a certificate that is not yet valid", () => {
+    const future = cert({ validFrom: new Date("2026-09-01T00:00:00.000Z") });
+    expect(verify([future, root()])).toMatchObject({ failure: "certificate-not-yet-valid" });
+  });
+
+  it("checks validity before matching, so an expired pinned root still refuses", () => {
+    const staleRoot = root({ validTo: new Date("2026-08-01T00:00:00.000Z") });
+    expect(verify([staleRoot]).verified).toBe(false);
+  });
+
+  it("never yields verified:true without a positive fingerprint match", () => {
+    const cases: Array<[ObservedCertificate[], string | null]> = [
+      [[], ROOT_HEX],
+      [[cert()], ROOT_HEX],
+      [[root()], null],
+      [[root({ fingerprint256: "d".repeat(64) })], ROOT_HEX],
+    ];
+    for (const [chain, pinned] of cases) {
+      expect(verify(chain, pinned).verified).toBe(false);
+    }
+  });
+});

--- a/packages/db/src/peer-certificate-verification.ts
+++ b/packages/db/src/peer-certificate-verification.ts
@@ -1,0 +1,96 @@
+// EP-MSP-FEDERATION — verify a discovered peer against the pinned organization
+// root.
+//
+// `decideAutomaticPairing` will only auto-enrol a peer whose certificate chain
+// was actually validated against this installation's organization root. Nothing
+// produced that fact: discovery reports `tls-validation-required`, which is a
+// to-do, and no peer-certificate inspection existed anywhere in the codebase.
+//
+// This module is the evaluation half. It is pure — the caller supplies the chain
+// it observed — so the security rule is testable without a TLS server, and a
+// network adapter cannot quietly change what "verified" means.
+
+/** A certificate as observed on the wire, reduced to what the rule needs. */
+export interface ObservedCertificate {
+  /** SHA-256 fingerprint. Accepted colon-separated or bare, any case. */
+  fingerprint256: string;
+  /** True for the chain's terminal (root) certificate. */
+  selfSigned: boolean;
+  subject?: string;
+  issuer?: string;
+  validFrom?: Date;
+  validTo?: Date;
+}
+
+export const PEER_VERIFICATION_FAILURES = [
+  "empty-chain",
+  "no-pinned-root",
+  "chain-has-no-root",
+  "root-fingerprint-mismatch",
+  "certificate-expired",
+  "certificate-not-yet-valid",
+] as const;
+export type PeerVerificationFailure = (typeof PEER_VERIFICATION_FAILURES)[number];
+
+export type PeerVerification =
+  | { verified: true; presentedRootFingerprint: string }
+  | { verified: false; presentedRootFingerprint: string | null; failure: PeerVerificationFailure };
+
+/**
+ * Normalise a SHA-256 fingerprint for comparison.
+ *
+ * Node reports `AA:BB:CC:…`; a join package records 64 bare hex characters.
+ * Comparing those forms directly would never match, so both collapse to lowercase
+ * hex. Anything that is not exactly 64 hex characters after normalising is
+ * rejected rather than compared loosely.
+ */
+export function normalizeFingerprint(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const collapsed = value.replace(/:/g, "").trim().toLowerCase();
+  return /^[0-9a-f]{64}$/.test(collapsed) ? collapsed : null;
+}
+
+function failed(
+  failure: PeerVerificationFailure,
+  presentedRootFingerprint: string | null = null,
+): PeerVerification {
+  return { verified: false, presentedRootFingerprint, failure };
+}
+
+/**
+ * Decide whether an observed chain terminates at the pinned organization root.
+ *
+ * Pure and total. Verification requires a positive match against the pinned
+ * fingerprint — there is no path where an absent, malformed, or unmatched value
+ * yields `verified: true`.
+ *
+ * Validity windows are checked on every certificate in the chain, not only the
+ * leaf: an expired intermediate breaks the chain just as surely.
+ */
+export function verifyPeerChainAgainstRoot(input: {
+  chain: readonly ObservedCertificate[];
+  pinnedRootFingerprint: string | null;
+  now: Date;
+}): PeerVerification {
+  const pinned = normalizeFingerprint(input.pinnedRootFingerprint);
+  if (!pinned) return failed("no-pinned-root");
+  if (input.chain.length === 0) return failed("empty-chain");
+
+  for (const certificate of input.chain) {
+    if (certificate.validTo && certificate.validTo.getTime() <= input.now.getTime()) {
+      return failed("certificate-expired");
+    }
+    if (certificate.validFrom && certificate.validFrom.getTime() > input.now.getTime()) {
+      return failed("certificate-not-yet-valid");
+    }
+  }
+
+  const root = input.chain.find((certificate) => certificate.selfSigned);
+  if (!root) return failed("chain-has-no-root");
+
+  const presented = normalizeFingerprint(root.fingerprint256);
+  if (!presented) return failed("root-fingerprint-mismatch");
+  if (presented !== pinned) return failed("root-fingerprint-mismatch", presented);
+
+  return { verified: true, presentedRootFingerprint: presented };
+}


### PR DESCRIPTION
## Why

`decideAutomaticPairing` (#4674) only auto-enrols a peer whose certificate chain was **actually validated** against the organization root. Nothing produced that fact.

Discovery reports `tls-validation-required` — a to-do, not a result — and a repository-wide search found **no peer-certificate inspection anywhere in the codebase**. Without this, the decision layer would correctly but permanently return `operator-confirmation`.

## Pure by design

`verifyPeerChainAgainstRoot` is the evaluation half: the caller supplies the chain it observed. That keeps the security rule testable without standing up a TLS server, and stops a network adapter quietly redefining what "verified" means.

## Two details that carry real weight

**Fingerprint forms must be normalised.** Node reports `AA:BB:CC:…`; a join package records 64 bare hex characters. Comparing those directly would *never match* — the verifier would silently refuse every legitimate peer. Both collapse to lowercase hex, and anything that isn't exactly 64 hex characters is rejected rather than compared loosely.

**Validity is checked across the whole chain, not just the leaf.** An expired intermediate breaks the chain as surely as an expired leaf, and is tested in both positions.

## Verification requires a positive match

There is no path where an absent, malformed, or unmatched value yields `verified: true` — asserted directly by a test over all four shapes (empty chain, no root, nothing pinned, wrong root).

Failures are a closed set so a caller can branch: `empty-chain`, `no-pinned-root`, `chain-has-no-root`, `root-fingerprint-mismatch`, `certificate-expired`, `certificate-not-yet-valid`.

## Verification

47 tests pass in `packages/db` — this module (16), plus the pairing-decision and enrolment suites it feeds. All 7 guards pass locally via `ci-policy-guards.mjs --profile pull-request`, including `spec-plan-doc-gate`; the design carries §5.6.

Not run: full `pnpm pregate` (unprovisioned worktree). CI gates the real typecheck.

## Scope

Evaluation only. The **network adapter** that observes a live chain, and the call from the pairing path, are the final slice — both touch security-relevant action code and belong in their own review.

Design: §5.6 of `docs/superpowers/specs/2026-08-23-zero-touch-organization-federation-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)