### PR TITLE
docs(governance): make the readiness plan read as executed, not pending (BI-F0715C9C)

### DIFF
--- a/docs/superpowers/plans/2026-08-23-initiative-readiness-traversal-repair.md
+++ b/docs/superpowers/plans/2026-08-23-initiative-readiness-traversal-repair.md
@@ -9,11 +9,17 @@ status: active
 **Branch:** `fix/initiative-readiness-traversal-recovery`
 **Recovery base:** `f20a78f63dc1884eea0fc171d04556b4be8de32f`
 **Design:** `docs/superpowers/specs/2026-08-23-initiative-readiness-traversal-repair-design.md`
+**Status:** active — **executed**. PR #4633 (`ddd1ae31e`, 2026-08-24) merged Tasks 2-10.
+Read the task list as the record of what was built, not as outstanding work. See Delivery status.
 
-> **For agentic workers:** execute this plan one independently reviewable backlog
-> item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green
-> implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate
-> before any success claim, and `dpf-pr-with-dco` for handoff.
+> **For agentic workers — this plan is already executed. Do not start Task 0.**
+> Tasks 2-10 shipped in PR #4633 and Task 13 is the only one still outstanding.
+> Check Delivery status before acting on anything below.
+>
+> The convention, for the tasks that remain and for plans that follow: execute one
+> independently reviewable backlog item at a time — one BI, one branch, one PR. Use
+> `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the
+> plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
 
 
 ## Delivery contract


### PR DESCRIPTION
Follow-up to #4685 and #4695. **Documentation only — one file, +11/−5.**

## The gap

#4685 gave the *design* a header line recording that PR #4633 delivered the work. The *plan* never got one. Worse, the agent-execution preamble that same PR added reads:

> execute this plan one independently reviewable backlog item at a time…

So an agent landing on this plan is told to start at Task 0 and re-implement Tasks 2–10, which merged on 2026-08-24.

This is precisely the failure the document is about — an artifact that reads as pending when the work has shipped. Leaving it in the plan that diagnoses that failure would be its own defect.

## The fix

- **Header** gains a Status line: executed, PR #4633, read the task list as the record of what was built.
- **Preamble** becomes a stop rather than a start: the plan is executed, Task 13 is the only outstanding item, check Delivery status before acting. The one-BI-one-branch-one-PR convention is preserved for the remaining task and for plans that follow it.

## Verification

`plan-backlog-coverage`, `docs-impact`, `design-grounding`, `spec-status-frontmatter`, `doc-links` — all pass locally.

Docs-Impact-Decision: documentation-only; corrects the execution state of one governed artifact. No route, prompt, install, or external-agent behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)