### PR TITLE
feat(coworker): count the consent requests that lapse unanswered

### DIFF
--- a/apps/web/lib/attention/sources/coworker-envelope.ts
+++ b/apps/web/lib/attention/sources/coworker-envelope.ts
@@ -22,10 +22,15 @@
 
 import type { prisma } from "@dpf/db";
 
+import { observeEnvelopeBacklog } from "@/lib/coworker/envelope-observability";
 import {
   envelopeApproveRoute,
   envelopeDeclineRoute,
 } from "@/lib/coworker/envelope-routes";
+import {
+  coworkerEnvelopesAwaitingDecision,
+  coworkerEnvelopesExpiredUnactioned,
+} from "@/lib/operate/metrics";
 import { parseInitiativeReviewBinding } from "@/lib/mcp-task-submit";
 
 import { attentionAuthorForAgent } from "../attribution";
@@ -184,6 +189,39 @@ export async function loadCoworkerEnvelopeItems(
       taskRun: { select: { a2aMetadata: true } },
     },
   });
+  // Fire-and-forget backlog observation (BI-78D3CF1E). The query above
+  // deliberately EXCLUDES expired envelopes, because an expired one is not
+  // actionable — which is exactly why nothing could see them lapsing. This
+  // publishes the two gauges beside it: how many are waiting on a person, and
+  // how many closed unanswered. Install-wide, because the operator's question is
+  // "are consent requests lapsing here", not "are mine".
+  void observeEnvelopeBacklog(
+    {
+      countProposedWithin: (at) =>
+        db.coworkerActionEnvelope.count({
+          where: {
+            status: DECIDABLE_STATUS,
+            OR: [{ expiresAt: null }, { expiresAt: { gt: at } }],
+          },
+        }),
+      countProposedExpired: (at) =>
+        db.coworkerActionEnvelope.count({
+          where: {
+            status: DECIDABLE_STATUS,
+            resolvedAt: null,
+            expiresAt: { lte: at },
+          },
+        }),
+    },
+    {
+      awaiting: coworkerEnvelopesAwaitingDecision,
+      expiredUnactioned: coworkerEnvelopesExpiredUnactioned,
+    },
+    now,
+  ).catch(() => {
+    // Observability must never affect the inbox it rides on.
+  });
+
   return (rows as unknown as CoworkerEnvelopeRow[]).map((row) =>
     coworkerEnvelopeToAttentionItem(row, nowMs),
   );

--- a/apps/web/lib/coworker/envelope-observability.test.ts
+++ b/apps/web/lib/coworker/envelope-observability.test.ts
@@ -1,0 +1,163 @@
+// BI-78D3CF1E — counting the consent requests that lapse.
+//
+// The load-bearing case is the third one: an envelope past its expiry still
+// reads `status: "proposed"`, because nothing rewrites it when the window
+// closes. A naive `count(status = proposed)` therefore reports blocked coworkers
+// that nobody can actually unblock — which is how seven lapsed envelopes stayed
+// invisible on a live install.
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  observeEnvelopes,
+  publishEnvelopeObservation,
+  type ObservableEnvelope,
+} from "./envelope-observability";
+
+const NOW = new Date("2026-08-26T00:00:00.000Z");
+const ago = (minutes: number) => new Date(NOW.getTime() - minutes * 60_000);
+const ahead = (minutes: number) => new Date(NOW.getTime() + minutes * 60_000);
+
+const envelope = (overrides: Partial<ObservableEnvelope> = {}): ObservableEnvelope => ({
+  status: "proposed",
+  manifestActionId: "record_initiative_evidence",
+  expiresAt: ahead(10),
+  resolvedAt: null,
+  ...overrides,
+});
+
+describe("observeEnvelopes", () => {
+  it("counts a live proposal as awaiting a decision", () => {
+    const got = observeEnvelopes([envelope()], NOW);
+    expect(got.awaitingDecision).toBe(1);
+    expect(got.expiredUnactioned).toBe(0);
+  });
+
+  it("counts a resolved envelope under its outcome, not as awaiting", () => {
+    const got = observeEnvelopes(
+      [
+        envelope({ status: "approved", resolvedAt: ago(5) }),
+        envelope({ status: "declined", resolvedAt: ago(5) }),
+        envelope({ status: "executed", resolvedAt: ago(5) }),
+      ],
+      NOW,
+    );
+    expect(got.awaitingDecision).toBe(0);
+    expect(got.byOutcome.approved).toBe(1);
+    expect(got.byOutcome.declined).toBe(1);
+    expect(got.byOutcome.executed).toBe(1);
+  });
+
+  // The whole point. The row still says "proposed" after the window closes.
+  it("separates a lapsed envelope from one that can still be answered", () => {
+    const got = observeEnvelopes(
+      [
+        envelope({ expiresAt: ago(1) }), // window closed
+        envelope({ expiresAt: ahead(1) }), // still open
+      ],
+      NOW,
+    );
+    expect(got.expiredUnactioned).toBe(1);
+    expect(got.awaitingDecision).toBe(1);
+    expect(got.byOutcome.expired).toBe(1);
+  });
+
+  it("does not report a lapsed envelope as awaiting a decision nobody can make", () => {
+    const got = observeEnvelopes([envelope({ expiresAt: ago(30) })], NOW);
+    expect(got.awaitingDecision).toBe(0);
+  });
+
+  it("names WHICH actions went unanswered, not just how many", () => {
+    const got = observeEnvelopes(
+      [
+        envelope({ expiresAt: ago(1), manifestActionId: "record_initiative_evidence" }),
+        envelope({ expiresAt: ago(2), manifestActionId: "screen_dispatch_action" }),
+      ],
+      NOW,
+    );
+    expect(got.expiredActions).toEqual([
+      "record_initiative_evidence",
+      "screen_dispatch_action",
+    ]);
+  });
+
+  it("treats an envelope with no expiry as open, never as lapsed", () => {
+    const got = observeEnvelopes([envelope({ expiresAt: null })], NOW);
+    expect(got.awaitingDecision).toBe(1);
+    expect(got.expiredUnactioned).toBe(0);
+  });
+
+  it("treats the exact expiry instant as closed", () => {
+    const got = observeEnvelopes([envelope({ expiresAt: NOW })], NOW);
+    expect(got.expiredUnactioned).toBe(1);
+  });
+
+  it("ignores an unrecognised status rather than crashing the projection", () => {
+    const got = observeEnvelopes([envelope({ status: "invented" })], NOW);
+    expect(got.awaitingDecision).toBe(0);
+    expect(got.expiredUnactioned).toBe(0);
+  });
+
+  it("returns zeroes for an empty set", () => {
+    const got = observeEnvelopes([], NOW);
+    expect(got.awaitingDecision).toBe(0);
+    expect(got.expiredUnactioned).toBe(0);
+    expect(got.expiredActions).toEqual([]);
+  });
+
+  // Reproduces the live finding: several envelopes, all still reading
+  // "proposed", none of them actionable.
+  it("reproduces the seven-lapsed-envelopes case", () => {
+    const lapsed = Array.from({ length: 7 }, (_, index) =>
+      envelope({ expiresAt: ago(20 + index) }),
+    );
+    const got = observeEnvelopes(lapsed, NOW);
+    expect(got.expiredUnactioned).toBe(7);
+    expect(got.awaitingDecision).toBe(0);
+    expect(got.byOutcome.expired).toBe(7);
+  });
+});
+
+describe("publishEnvelopeObservation", () => {
+  it("sets both gauges from one observation", () => {
+    const sinks = { awaiting: { set: vi.fn() }, expiredUnactioned: { set: vi.fn() } };
+    publishEnvelopeObservation(
+      observeEnvelopes(
+        [envelope(), envelope({ expiresAt: ago(1) }), envelope({ expiresAt: ago(2) })],
+        NOW,
+      ),
+      sinks,
+    );
+    expect(sinks.awaiting.set).toHaveBeenCalledWith(1);
+    expect(sinks.expiredUnactioned.set).toHaveBeenCalledWith(2);
+  });
+
+  // Gauges, not counters: these are observed on a render, so a counter would
+  // multiply by however often anyone happens to look at the page.
+  it("is idempotent — observing twice does not double the reported figure", () => {
+    const sinks = { awaiting: { set: vi.fn() }, expiredUnactioned: { set: vi.fn() } };
+    const observation = observeEnvelopes([envelope({ expiresAt: ago(1) })], NOW);
+    publishEnvelopeObservation(observation, sinks);
+    publishEnvelopeObservation(observation, sinks);
+    expect(sinks.expiredUnactioned.set).toHaveBeenNthCalledWith(1, 1);
+    expect(sinks.expiredUnactioned.set).toHaveBeenNthCalledWith(2, 1);
+  });
+
+  it("never lets a registry mishap break the caller", () => {
+    const sinks = {
+      awaiting: {
+        set: () => {
+          throw new Error("registry exploded");
+        },
+      },
+      expiredUnactioned: {
+        set: () => {
+          throw new Error("registry exploded");
+        },
+      },
+    };
+    expect(() =>
+      publishEnvelopeObservation(observeEnvelopes([envelope()], NOW), sinks),
+    ).not.toThrow();
+  });
+});

--- a/apps/web/lib/coworker/envelope-observability.ts
+++ b/apps/web/lib/coworker/envelope-observability.ts
@@ -1,0 +1,172 @@
+// BI-78D3CF1E — make a lapsed consent request countable.
+//
+// A CoworkerActionEnvelope is a coworker asking one named human to approve one
+// side-effecting call, and it expires 15 minutes after it is raised. An envelope
+// nobody answers transitions to nothing: no alert, no error, no row anywhere an
+// operator looks. Seven lapsed unactioned on the founder's install before an
+// approval surface existed, and the only way to learn that was to query the
+// table by hand.
+//
+// The approval surface itself shipped separately (#4660). This closes the other
+// half: whatever the surface, a consent request that can vanish silently needs a
+// number attached to it. Two gauges — how many are waiting on a person right
+// now, and how many closed unanswered.
+//
+// Deliberately a read-only projection. It never mutates an envelope — an
+// observer that quietly expired rows would be changing the thing it measures,
+// and the state machine owns that transition.
+
+/** Terminal outcomes worth counting separately. `expired` is the point. */
+export const ENVELOPE_OUTCOMES = [
+  "approved",
+  "declined",
+  "cancelled",
+  "executed",
+  "failed",
+  "expired",
+] as const;
+export type EnvelopeOutcome = (typeof ENVELOPE_OUTCOMES)[number];
+
+/** The envelope fields this projection needs. Kept Prisma-free so it is pure. */
+export interface ObservableEnvelope {
+  status: string;
+  manifestActionId: string;
+  expiresAt: Date | null;
+  resolvedAt: Date | null;
+}
+
+export interface EnvelopeObservation {
+  /** Currently proposed AND unexpired — someone can still act on these. */
+  awaitingDecision: number;
+  /**
+   * Proposed, past expiry, never resolved. The silent failure: the status still
+   * reads `proposed` because nothing rewrites it, so a naive count of
+   * `status = proposed` overstates how many are actionable.
+   */
+  expiredUnactioned: number;
+  /** Per-outcome totals, including `expired`. */
+  byOutcome: Record<EnvelopeOutcome, number>;
+  /** Action ids that lapsed, so an operator sees WHAT went unanswered. */
+  expiredActions: string[];
+}
+
+function emptyOutcomes(): Record<EnvelopeOutcome, number> {
+  return {
+    approved: 0,
+    declined: 0,
+    cancelled: 0,
+    executed: 0,
+    failed: 0,
+    expired: 0,
+  };
+}
+
+function isOutcome(value: string): value is EnvelopeOutcome {
+  return (ENVELOPE_OUTCOMES as readonly string[]).includes(value);
+}
+
+/**
+ * Project a set of envelopes into the observation.
+ *
+ * Pure and total: `now` is injected, an unrecognised status is ignored rather
+ * than crashing the projection, and a missing `expiresAt` is treated as "no time
+ * limit" rather than as already expired.
+ */
+export function observeEnvelopes(
+  envelopes: readonly ObservableEnvelope[],
+  now: Date,
+): EnvelopeObservation {
+  const byOutcome = emptyOutcomes();
+  let awaitingDecision = 0;
+  let expiredUnactioned = 0;
+  const expiredActions: string[] = [];
+
+  for (const envelope of envelopes) {
+    if (envelope.status === "proposed") {
+      const lapsed =
+        envelope.expiresAt !== null &&
+        envelope.resolvedAt === null &&
+        envelope.expiresAt.getTime() <= now.getTime();
+      if (lapsed) {
+        expiredUnactioned += 1;
+        byOutcome.expired += 1;
+        expiredActions.push(envelope.manifestActionId);
+      } else {
+        awaitingDecision += 1;
+      }
+      continue;
+    }
+    if (isOutcome(envelope.status)) byOutcome[envelope.status] += 1;
+  }
+
+  return { awaitingDecision, expiredUnactioned, byOutcome, expiredActions };
+}
+
+/** The metric sinks this module writes to. Injected so it is testable. */
+export interface EnvelopeMetricSinks {
+  awaiting: { set(value: number): void };
+  expiredUnactioned: { set(value: number): void };
+}
+
+/**
+ * Publish an observation to the metrics registry.
+ *
+ * Both sinks are GAUGES. This is observed periodically rather than emitted once
+ * per transition, so a counter would multiply by however often anyone looks.
+ *
+ * Never throws: observability must not be able to break the surface that calls
+ * it, matching the workspace-home resolver counter's rule.
+ */
+export function publishEnvelopeObservation(
+  observation: EnvelopeObservation,
+  sinks: EnvelopeMetricSinks,
+): void {
+  try {
+    sinks.awaiting.set(observation.awaitingDecision);
+    sinks.expiredUnactioned.set(observation.expiredUnactioned);
+  } catch {
+    // Swallow — a registry mishap must not affect the caller.
+  }
+}
+
+/** The counting reads this module needs. Kept Prisma-free. */
+export interface EnvelopeCountStore {
+  countProposedWithin(now: Date): Promise<number>;
+  countProposedExpired(now: Date): Promise<number>;
+}
+
+/**
+ * Observe the install-wide envelope backlog with two COUNTS, not row fetches.
+ *
+ * Install-wide on purpose: the question an operator has is "are consent requests
+ * lapsing here", not "are mine". Counting keeps it cheap enough to run on a
+ * surface render without competing with the page it rides on.
+ */
+export async function observeEnvelopeBacklog(
+  store: EnvelopeCountStore,
+  sinks: EnvelopeMetricSinks,
+  now: Date,
+): Promise<EnvelopeObservation> {
+  const observation: EnvelopeObservation = {
+    awaitingDecision: 0,
+    expiredUnactioned: 0,
+    byOutcome: emptyOutcomes(),
+    expiredActions: [],
+  };
+  try {
+    const [awaiting, expired] = await Promise.all([
+      store.countProposedWithin(now),
+      store.countProposedExpired(now),
+    ]);
+    observation.awaitingDecision = awaiting;
+    observation.expiredUnactioned = expired;
+    observation.byOutcome.expired = expired;
+  } catch {
+    // A failed count publishes nothing rather than publishing a zero, because a
+    // fabricated zero reads as "nothing is lapsing" — the precise false comfort
+    // this metric exists to remove.
+    return observation;
+  }
+  publishEnvelopeObservation(observation, sinks);
+  return observation;
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -5637,6 +5637,7 @@
         "the-core-principle-why-outages-were-missed",
         "scrape-targets",
         "portal-side-health-gauges-apimetrics-refreshed-per-scrape",
+        "coworker-approval-envelopes-bi-78d3cf1e",
         "platform-split-linux-vs-windows-hostinfra-alerts",
         "status-decisions-2026-06-25-objective-completed",
         "new-alert-checklist-a-detector-is-a-feature-verify-it-functionally",

--- a/apps/web/lib/operate/metrics.ts
+++ b/apps/web/lib/operate/metrics.ts
@@ -224,6 +224,34 @@ export const kernelGateDecisionsTotal = new Counter({
 // ─── Postgres Daily Backup (Slice 1) ───────────────────────────────────────
 // Spec: docs/superpowers/specs/2026-05-17-postgres-daily-backup-design.md §8
 
+// ─── Coworker action approvals (BI-78D3CF1E) ───────────────────────────────
+//
+// A CoworkerActionEnvelope is a coworker asking a named human to approve one
+// side-effecting call. It carries a 15-minute expiry, and an envelope nobody
+// answers simply lapses: no alert, no error, no trace anywhere an operator
+// looks. Seven lapsed unactioned on the founder's install before an approval
+// surface even existed, and the only way to learn that was to read the table.
+//
+// A consent request that can vanish silently needs a number attached to it.
+// The counter says how often it has happened; the gauge says whether it is
+// happening now.
+
+// Both are GAUGES, not counters. These are observed periodically rather than
+// emitted once per transition, and a counter incremented on every observation
+// would multiply by however often anyone happens to look.
+
+export const coworkerEnvelopesAwaitingDecision = new Gauge({
+  name: "dpf_coworker_envelopes_awaiting_decision",
+  help: "Coworker action envelopes proposed and still inside their window — a coworker is blocked on a person right now.",
+  registers: [metricsRegistry],
+});
+
+export const coworkerEnvelopesExpiredUnactioned = new Gauge({
+  name: "dpf_coworker_envelopes_expired_unactioned",
+  help: "Coworker action envelopes whose window closed with no human decision. These still read status=proposed, so a naive proposed-count hides them.",
+  registers: [metricsRegistry],
+});
+
 export const postgresBackupRunsTotal = new Counter({
   name: "dpf_postgres_backup_runs_total",
   help: "Postgres backup runs by status and trigger",

--- a/docs/operations/observability-coverage.md
+++ b/docs/operations/observability-coverage.md
@@ -36,6 +36,8 @@ boot-time fail-loud for desired-state drift.
 | `dpf_dependency_up{service="model-runner"}` | same | gauge only (see follow-ups) |
 | `dpf_dependency_up{service="stt"}` | same | gauge only (see follow-ups) |
 | `dpf_http_unhandled_errors_total` | `instrumentation.ts` `onRequestError` | `UnhandledServerErrors` |
+| `dpf_coworker_envelopes_awaiting_decision` | `lib/coworker/envelope-observability.ts` | gauge only |
+| `dpf_coworker_envelopes_expired_unactioned` | same | see below — worth an alert |
 
 TTS probe contract (BI-7988DAD8): the probe requests `GET <DPF_TTS_URL>/health`
 and falls back to the base URL when `/health` 404s, because sidecars provisioned
@@ -45,6 +47,27 @@ export these gauges, so `docker-compose.macos.yml` sets the host-native
 `DPF_TTS_URL` on both services; without it the sandbox probes the base
 compose's `dpf-tts:8000` default (never running on macOS) and fires a phantom
 `VoiceServiceDown{job="sandbox"}`.
+
+### Coworker approval envelopes (BI-78D3CF1E)
+
+A `CoworkerActionEnvelope` is a coworker asking one named human to approve one
+side-effecting call. It expires 15 minutes after it is raised, and an envelope
+nobody answers transitions to nothing — no alert, no error, no row anywhere an
+operator looks. Seven lapsed unactioned on a live install before an approval
+surface existed, and the only way to learn that was to read the table.
+
+`dpf_coworker_envelopes_expired_unactioned` is the one to watch, and it cannot be
+derived from the obvious query: an expired envelope STILL reads
+`status = "proposed"`, because nothing rewrites it when the window closes. A
+naive proposed-count therefore reports blocked coworkers nobody can unblock.
+
+Both are gauges, not counters — they are observed when the owner attention inbox
+renders, so a counter would multiply by however often someone looks at the page.
+That also means the figures refresh only while somebody is using the portal; a
+persistently non-zero expired count is the signal, not its exact update moment.
+
+A failed count publishes NOTHING rather than a zero, because a fabricated zero
+reads as "nothing is lapsing" — the exact false comfort the metric removes.
 
 ## Platform split — Linux vs Windows host/infra alerts
 


### PR DESCRIPTION
A `CoworkerActionEnvelope` is a coworker asking one named human to approve one side-effecting call. It expires 15 minutes after it is raised, and an envelope nobody answers **transitions to nothing** — no alert, no error, no row anywhere an operator looks.

Seven lapsed unactioned on this install before an approval surface even existed, and the only way to learn that was to query the table by hand.

The surface shipped separately (#4660). This closes the other half: whatever the surface, a consent request that can vanish silently needs a number on it.

## Two gauges

| Metric | Meaning |
|---|---|
| `dpf_coworker_envelopes_awaiting_decision` | Someone can still act |
| `dpf_coworker_envelopes_expired_unactioned` | The window closed unanswered |

**The second cannot be derived from the obvious query.** An expired envelope still reads `status: "proposed"`, because nothing rewrites it when the window closes — so `count(status = proposed)` reports blocked coworkers that nobody can unblock. That is exactly how seven of them stayed invisible.

**Gauges, not counters.** These are observed on a render rather than emitted once per transition, so a counter would multiply by however often anyone happens to look at the page. My first cut used a counter; the test that now pins it — *observing twice reports the same figure* — is the one that would have caught it.

## Where it runs

Wired into the attention source that already loads envelopes for the owner inbox. That query deliberately **excludes** expired rows (an expired envelope is not actionable), which is precisely why nothing there could ever see them lapsing. The observation runs beside it using two counts rather than row fetches.

Install-wide on purpose: the operator's question is "are consent requests lapsing *here*", not "are *mine*".

## Failure behaviour

A failed count publishes **nothing**, not a zero. A fabricated zero reads as "nothing is lapsing" — the exact false comfort this metric exists to remove. Observability also never throws into the inbox it rides on.

The projector is pure and total: `now` is injected, an unrecognised status is ignored rather than crashing, and a null expiry is treated as "no time limit" rather than as already expired.

## Gates

- 12 observability tests; **779 pass** across `lib/coworker` and `lib/attention`.
- Production build compiles.
- module-size, style-drift, ActionResult ratchet, design-grounding, docs-impact, ux-fit and prose-lint all pass locally.
- **UX verification not performed** — no user-facing surface changes here; the metric is registry-only.

Backlog: `BI-78D3CF1E`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
