### PR TITLE
fix(workroom): make reviewer recovery reachable from a refused claim (BI-512214EA)

### DIFF
--- a/apps/web/lib/work-capsules/governed-work-claim.test.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.test.ts
@@ -36,13 +36,22 @@ function database(activities: unknown[] = []) {
     },
     workroom: {
       create: vi.fn(),
-      findFirst: vi.fn().mockResolvedValue({
-        capsuleId: "WC-ENTRY",
-        repositoryFullName: input.repositoryFullName,
-        headBranch: input.headBranch,
-        headSha: "1111111111111111111111111111111111111111",
-        archivedAt: null,
-      }),
+      // Honour the `where` clause rather than answering unconditionally: the room
+      // on this branch carries NO item binding, which is the state a room is
+      // actually in before any claim has succeeded for its item. A mock that
+      // answers regardless of the query cannot tell the old lookup from the new
+      // one, so it would pass either way and prove nothing (BI-512214EA).
+      findFirst: vi.fn().mockImplementation((args?: { where?: { backlogItemId?: string } }) =>
+        Promise.resolve(args?.where?.backlogItemId ? null : {
+          capsuleId: "WC-ENTRY",
+          repositoryFullName: input.repositoryFullName,
+          headBranch: input.headBranch,
+          headSha: "1111111111111111111111111111111111111111",
+          archivedAt: null,
+        })),
+      // Recovery matches rooms on branch identity (BI-512214EA), so the default
+      // room here carries NO backlogItemId — the state a room is actually in
+      // before a claim has ever succeeded for its item.
       findUnique: vi.fn().mockResolvedValue({
         id: "row-wc",
         capsuleId: "WC-ENTRY",
@@ -57,7 +66,13 @@ function database(activities: unknown[] = []) {
         leaseHolderPrincipalId: actor.principalId,
         leaseExpiresAt: new Date("2099-01-01T00:00:00.000Z"),
       }),
-      findMany: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([{
+        capsuleId: "WC-ENTRY",
+        repositoryFullName: input.repositoryFullName,
+        headBranch: input.headBranch,
+        headSha: "1111111111111111111111111111111111111111",
+        backlogItemId: null,
+      }]),
       update: vi.fn(),
     },
     workroomActivity: {
@@ -91,6 +106,64 @@ function database(activities: unknown[] = []) {
 }
 
 describe("claimGovernedBacklogWorkspace", () => {
+  // BI-512214EA. Recovery used to require a Workroom already bound to the item,
+  // but that binding is written by the successful-claim path — so a refused
+  // claim could never find one, and every reviewer route came back empty. These
+  // two pin the branch-identity match and its preference order.
+  it("resolves a dispatch context from a room on the branch with no item binding", async () => {
+    const db = database();
+    const result = await claimGovernedBacklogWorkspace({
+      db,
+      input,
+      actor,
+      workIntent: null,
+      now: new Date("2026-08-22T00:00:00.000Z"),
+      dependencies: { claimWorkspace: vi.fn() },
+    });
+
+    expect(result.ok).toBe(false);
+    const routes = result.ok ? [] : result.data.recovery.reviewerRoutes;
+    expect(routes.length).toBeGreaterThan(0);
+    expect(routes.every((route) => route.workroomId === "WC-ENTRY")).toBe(true);
+    expect(result.ok ? [] : result.data.recovery.escalations)
+      .not.toContainEqual(expect.objectContaining({ reason: "dispatch-context-required" }));
+  });
+
+  it("prefers a room bound to this item over one merely sharing its branch", async () => {
+    const db = database();
+    (db as unknown as { workroom: { findMany: ReturnType<typeof vi.fn> } }).workroom.findMany
+      .mockResolvedValueOnce([
+        {
+          capsuleId: "WC-BRANCH-ONLY",
+          repositoryFullName: input.repositoryFullName,
+          headBranch: input.headBranch,
+          headSha: "2222222222222222222222222222222222222222",
+          backlogItemId: null,
+        },
+        {
+          capsuleId: "WC-BOUND",
+          repositoryFullName: input.repositoryFullName,
+          headBranch: input.headBranch,
+          headSha: "3333333333333333333333333333333333333333",
+          backlogItemId: "BI-ENTRY",
+        },
+      ]);
+
+    const result = await claimGovernedBacklogWorkspace({
+      db,
+      input,
+      actor,
+      workIntent: null,
+      now: new Date("2026-08-22T00:00:00.000Z"),
+      dependencies: { claimWorkspace: vi.fn() },
+    });
+
+    const routes = result.ok ? [] : result.data.recovery.reviewerRoutes;
+    expect(routes.length).toBeGreaterThan(0);
+    expect(routes.every((route) => route.workroomId === "WC-BOUND")).toBe(true);
+    expect(routes.every((route) => route.headSha === "3333333333333333333333333333333333333333")).toBe(true);
+  });
+
   it("records a denial without mutating workspace state for a legacy implementation claim", async () => {
     const db = database();
     const claimWorkspace = vi.fn();

--- a/apps/web/lib/work-capsules/governed-work-claim.ts
+++ b/apps/web/lib/work-capsules/governed-work-claim.ts
@@ -236,9 +236,23 @@ export async function claimGovernedBacklogWorkspace(args: {
       });
       evaluated = decisionWithId(projection.decision);
       if (projection.governed && evaluated.verdict !== "allowed") {
-        const recoveryWorkroom = await tx.workroom.findFirst({
+        // Match on the branch identity, NOT on a backlog-item binding.
+        //
+        // `Workroom.backlogItemId` is written by the successful-claim path below,
+        // so requiring it here made recovery unreachable by construction: the
+        // binding recovery needs is created by the claim, and the claim returns
+        // here precisely because it refused. Recovery exists to help an initiative
+        // BECOME ready, so it cannot depend on state that only exists once it
+        // already is (BI-512214EA).
+        //
+        // Branch identity is the right key regardless. What a reviewer dispatch
+        // needs is an exact branch at an immutable head — which is what the
+        // escalation's own nextAction asks for — and `(repository, headBranch)`
+        // is already the Workroom's durable identity. An item binding, when it
+        // exists, is preferred so a room explicitly bound to this item wins over
+        // one merely sharing its branch.
+        const recoveryWorkrooms = await tx.workroom.findMany({
           where: {
-            backlogItemId: item.itemId,
             repositoryFullName: args.input.repositoryFullName,
             headBranch: args.input.headBranch,
             archivedAt: null,
@@ -248,13 +262,21 @@ export async function claimGovernedBacklogWorkspace(args: {
             repositoryFullName: true,
             headBranch: true,
             headSha: true,
+            backlogItemId: true,
           },
-        }) as {
+        }) as Array<{
           capsuleId: string;
           repositoryFullName: string;
           headBranch: string;
           headSha: string | null;
-        } | null;
+          backlogItemId: string | null;
+        }>;
+        // Deterministic: an explicit binding to THIS item wins; otherwise the
+        // first room on this branch that carries an immutable head.
+        const recoveryWorkroom =
+          recoveryWorkrooms.find((room) => room.backlogItemId === item.itemId && room.headSha)
+          ?? recoveryWorkrooms.find((room) => room.headSha)
+          ?? null;
         const recovery = await resolveInitiativeReviewerRecovery({
           decision: evaluated,
           currentAgentId: args.actor.agentId,


### PR DESCRIPTION
Fixes `BI-512214EA`.

## Problem

Reviewer recovery could never produce a route. On a refused claim, `claimGovernedBacklogWorkspace` looked up its recovery Workroom by:

```ts
where: { backlogItemId: item.itemId, repositoryFullName, headBranch, archivedAt: null }
```

But `Workroom.backlogItemId` is written by the **successful-claim path further down the same function**. A refused claim therefore searched for state that only exists once the claim has already succeeded — so `dispatchContext` was always null, `reviewerRoutes` always empty, and every accountable role came back escalated.

Recovery exists to help an initiative *become* ready. It cannot depend on state produced by readiness.

Observed across readiness decisions `IRD-92BA60C556F4`, `IRD-B710E78028E7` and `IRD-9B1E8B873889`, with `AGT-WS-REVIEW` and the other reviewers registered, active and eligible throughout.

## Fix

Match on **branch identity** instead. `(repositoryFullName, headBranch)` is already the Workroom's durable identity, and an exact branch at an immutable head is precisely what the escalation's own `nextAction` asks for. A room explicitly bound to this item still wins over one merely sharing its branch, so no existing behaviour is lost.

## The test that was lying

The pre-existing denial test passed only because its `workroom.findFirst` mock answered unconditionally, ignoring the `where` it was handed. It could not distinguish an item-bound lookup from a branch lookup, and asserted a dispatch context the real query could not return.

The mock now honours its `where` clause. **All three tests in that file fail against the old lookup and pass against the new one** — verified by reverting the source change and re-running.

## Scope note

`BI-512214EA` also described the escalation reason being mislabelled `no-eligible-reviewer` when a candidate *was* found. That was fixed upstream before this change — the reason is already `dispatch-context-required` with a `nextAction` naming the eligible reviewer. Not touched here. The BI has been corrected.

## Build gate

- 275 test files / 2700 tests passing across `lib/work-capsules`, `lib/tak`, `lib/mcp`
- `tsc --noEmit` clean
- `pnpm --filter web build` exit 0
- Policy guards, `--profile pull-request`: all 7 pass
- No UI or agent surface change, so no UX verification path applies
- No migration

### Pre-existing failures, noted not deferred

`--profile source` reports two guards red: **PR Health Logic** and **Janitor Tests**. Both fail identically on unmodified `main` at `259a9fcd71` in a clean checkout with none of these changes. They are Windows-host limitations — `isEntryModule matches when argv[1] reaches the entry through a symlink` (symlink creation needs admin) and `ensurePrePushHook writes the delegating shim when missing, executable` (no executable bit on Windows), plus `gate-worktree.sh` and `local-ci-runner.mjs` shell suites. CI runs Linux, where they pass. Recorded here rather than silently skipped.