### PR TITLE
fix(onboarding): a connected cloud provider that can serve nothing no longer reads as success (BI-575F0046)

### DIFF
--- a/apps/web/app/(shell)/workspace/page.tsx
+++ b/apps/web/app/(shell)/workspace/page.tsx
@@ -8,6 +8,8 @@ import { VerticalWorkspaceHome } from "@/components/workspace-home/VerticalWorks
 import { OperatorCockpit } from "@/components/workspace-home/OperatorCockpit";
 import { WorkspaceStorefrontAttention } from "@/components/owner-first/WorkspaceStorefrontAttention";
 import { WorkspaceTwinHero } from "@/components/workspace-home/WorkspaceTwinHero";
+import { resolveCloudProviderReadiness } from "@/lib/inference/cloud-provider-readiness";
+import { CloudProviderUnclearedNotice } from "@/components/workspace-home/CloudProviderUnclearedNotice";
 import { LocalOnlyProviderNotice } from "@/components/workspace-home/LocalOnlyProviderNotice";
 import { UnconfiguredWorkspaceHomeNotice } from "@/components/workspace-home/UnconfiguredWorkspaceHomeNotice";
 import { loadPlatformWorkspaceHomeData } from "@/lib/workspace-home/platform-loader";
@@ -48,10 +50,17 @@ export default async function WorkspacePage() {
   );
   const restaurantShift = Boolean(twinPresentation?.restaurantFloor);
 
-  const hasCloudProvider =
-    (await prisma.modelProvider.count({
-      where: { status: "active", NOT: { providerId: "local" } },
-    })) > 0;
+  // BI-575F0046: counting active non-local providers reported a fresh install as
+  // HAVING cloud AI the moment one was connected — while its clearance was
+  // `["public"]` and no turn is ever public, so nothing could use it and the
+  // local-only notice disappeared. Ask whether a provider can take work, not
+  // whether one exists.
+  const cloudReadiness = resolveCloudProviderReadiness(
+    await prisma.modelProvider.findMany({
+      where: { status: "active" },
+      select: { providerId: true, name: true, status: true, sensitivityClearance: true },
+    }),
+  );
   // Fire-and-forget — the metric increment is observability, not load-bearing,
   // and we don't want a Prometheus registry mishap to break the page render.
   void recordWorkspaceHomeResolution(
@@ -88,8 +97,11 @@ export default async function WorkspacePage() {
           /ops/installation, and the header badge — non-production only — is the
           arrival-time signal. The operator's actual work starts here. */}
       {workspaceHomeResolution.mode === "unconfigured" && <UnconfiguredWorkspaceHomeNotice />}
-      {workspaceHomeResolution.mode !== "unconfigured" && !hasCloudProvider && (
+      {workspaceHomeResolution.mode !== "unconfigured" && cloudReadiness.state === "none" && (
         <LocalOnlyProviderNotice />
+      )}
+      {workspaceHomeResolution.mode !== "unconfigured" && cloudReadiness.state === "public-only" && (
+        <CloudProviderUnclearedNotice providerNames={cloudReadiness.providerNames} />
       )}
       {twinPresentation ? (
         // Operator-confirmed placement (parent spec §9 option c): the operational

--- a/apps/web/components/workspace-home/CloudProviderUnclearedNotice.tsx
+++ b/apps/web/components/workspace-home/CloudProviderUnclearedNotice.tsx
@@ -1,0 +1,37 @@
+import { AI_PROVIDER_CONNECTIONS_ROUTE } from "@/lib/ai-provider-routes";
+import { Surface } from "@/components/ui/Surface";
+
+/**
+ * Connected, active, and cleared for nothing any turn uses (BI-575F0046).
+ *
+ * Deliberately a DIFFERENT notice from the local-only one. "Add a cloud
+ * provider" is wrong here — one is already added. The missing thing is the trust
+ * review that grants it clearance above `public`, and no turn is ever `public`,
+ * so until that happens the provider is listed, healthy and idle.
+ */
+export function CloudProviderUnclearedNotice({ providerNames }: { providerNames: string[] }) {
+  const named = providerNames.length === 1
+    ? providerNames[0]
+    : `${providerNames.length} cloud providers`;
+  return (
+    <Surface as="section" aria-label="AI provider notice" padding="sm" className="mb-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-semibold">
+            {named} is connected, but your team is still working locally
+          </p>
+          <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+            We hold a new connection back from real work until you confirm how that account
+            handles your business data. It takes a minute.
+          </p>
+        </div>
+        <a
+          href={AI_PROVIDER_CONNECTIONS_ROUTE}
+          className="inline-flex min-h-9 items-center justify-center rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 text-sm font-semibold text-[var(--dpf-text)]"
+        >
+          Confirm data handling
+        </a>
+      </div>
+    </Surface>
+  );
+}

--- a/apps/web/components/workspace-home/LocalOnlyProviderNotice.test.tsx
+++ b/apps/web/components/workspace-home/LocalOnlyProviderNotice.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import routeManifest from "@/lib/ea/route-manifest.json";
 import { AI_PROVIDER_CONNECTIONS_ROUTE } from "@/lib/ai-provider-routes";
 import { PLATFORM_FAMILIES } from "@/components/platform/platform-nav";
+import { CloudProviderUnclearedNotice } from "./CloudProviderUnclearedNotice";
 import { LocalOnlyProviderNotice } from "./LocalOnlyProviderNotice";
 
 type RouteManifest = {
@@ -33,5 +34,42 @@ describe("LocalOnlyProviderNotice", () => {
         label: "Providers & Routing",
       }),
     );
+  });
+});
+
+// BI-575F0046. Connecting a cloud provider used to remove the local-only notice
+// while the provider was cleared for `public` only — so the owner saw nothing at
+// all and a workforce that silently stayed local.
+describe("CloudProviderUnclearedNotice", () => {
+  const markup = (names: string[]) =>
+    renderToStaticMarkup(<CloudProviderUnclearedNotice providerNames={names} />);
+
+  it("says the provider is connected, not that one is missing", () => {
+    const html = markup(["ChatGPT"]);
+
+    expect(html).toContain("ChatGPT is connected");
+    // "Add a cloud provider" is the wrong instruction here — one is already added.
+    expect(html).not.toContain("Add optional cloud AI");
+  });
+
+  it("points at the data-handling confirmation, which is the actual blocker", () => {
+    const html = markup(["ChatGPT"]);
+
+    expect(html).toContain("Confirm data handling");
+    expect(html).toContain(AI_PROVIDER_CONNECTIONS_ROUTE);
+  });
+
+  it("summarises rather than listing every provider when several are waiting", () => {
+    expect(markup(["ChatGPT", "Gemini"])).toContain("2 cloud providers");
+  });
+
+  // IDENTITY_BLOCK rule #5 applies to owner-facing copy too: no clearance
+  // vocabulary, no sensitivity levels, no routing internals.
+  it("explains the hold without exposing routing vocabulary", () => {
+    const html = markup(["ChatGPT"]).toLowerCase();
+
+    for (const jargon of ["clearance", "sensitivity", "restricted", "public-only", "routing"]) {
+      expect(html, `owner-facing copy must not say "${jargon}"`).not.toContain(jargon);
+    }
   });
 });

--- a/apps/web/lib/attention/sources/provider-credential.test.ts
+++ b/apps/web/lib/attention/sources/provider-credential.test.ts
@@ -6,6 +6,8 @@ import {
   selectExpiredCredentialProviders,
   suitabilityDriftToAttentionItem,
   PROVIDER_RECONNECT_ROUTE,
+  selectUnclearedCloudProviders,
+  unclearedCloudProviderToAttentionItem,
 } from "./provider-credential";
 import type { ProviderSuitabilityDriftSignal } from "@/lib/routing/provider-suitability/telemetry";
 
@@ -223,5 +225,77 @@ describe("suitabilityDriftToAttentionItem", () => {
     expect(item.context).toContain("Restricted routing stays blocked");
     expect(item.deepLink).toBe("/platform/ai/providers/openrouter");
     expect(item.triage.decideEffort).toBe("review");
+  });
+});
+
+// BI-575F0046. The state no source detected: a cloud provider that is active,
+// authenticated and healthy, and eligible for nothing — because a new connection
+// is cleared for `public` and no route is ever `public`.
+describe("selectUnclearedCloudProviders", () => {
+  const row = (over: Record<string, unknown> = {}) => ({
+    provider: {
+      providerId: "chatgpt",
+      name: "ChatGPT",
+      status: "active",
+      endpointType: "llm",
+      sensitivityClearance: ["public"],
+      ...over,
+    },
+  });
+
+  it("flags an active cloud provider cleared only for public", () => {
+    expect(selectUnclearedCloudProviders([row()]).map((p) => p.providerId)).toEqual(["chatgpt"]);
+  });
+
+  it("treats an empty clearance as uncleared rather than unrestricted", () => {
+    expect(selectUnclearedCloudProviders([row({ sensitivityClearance: [] })])).toHaveLength(1);
+  });
+
+  it("stays quiet once the provider is cleared for internal", () => {
+    expect(
+      selectUnclearedCloudProviders([
+        row({ sensitivityClearance: ["public", "internal", "confidential"] }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("ignores the local sidecars, which never leave the machine", () => {
+    expect(
+      selectUnclearedCloudProviders([
+        row({ providerId: "local", name: "Local", sensitivityClearance: ["public"] }),
+        row({ providerId: "ollama", name: "Ollama", sensitivityClearance: ["public"] }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("ignores providers that are not active and non-routing service endpoints", () => {
+    expect(selectUnclearedCloudProviders([row({ status: "unconfigured" })])).toEqual([]);
+    expect(selectUnclearedCloudProviders([row({ endpointType: "service" })])).toEqual([]);
+  });
+});
+
+describe("unclearedCloudProviderToAttentionItem", () => {
+  const item = unclearedCloudProviderToAttentionItem({
+    providerId: "chatgpt",
+    name: "ChatGPT",
+    detectedAtIso: "2026-08-26T02:00:00.000Z",
+  });
+
+  it("does not tell the owner to reconnect — nothing has failed", () => {
+    expect(`${item.title} ${item.context}`.toLowerCase()).not.toContain("reconnect");
+    expect(item.actions[0]?.label).toBe("Confirm data handling");
+  });
+
+  it("names the consequence in the owner's terms, not routing vocabulary", () => {
+    const text = `${item.title} ${item.context}`.toLowerCase();
+
+    expect(text).toContain("local ai");
+    for (const jargon of ["clearance", "sensitivity", "restricted", "routing"]) {
+      expect(text, `owner-facing copy must not say "${jargon}"`).not.toContain(jargon);
+    }
+  });
+
+  it("is distinct from the other provider lanes so it cannot collide on id", () => {
+    expect(item.id).toBe("provider-uncleared:chatgpt");
   });
 });

--- a/apps/web/lib/attention/sources/provider-credential.ts
+++ b/apps/web/lib/attention/sources/provider-credential.ts
@@ -220,11 +220,86 @@ export function selectDisabledConnectedProviders(
  * requires active/degraded, this one requires disabled — but they share an item
  * id, so dedupe by id keeps one row per provider if that ever stops holding.
  */
+/** A cloud provider that is active but cleared for nothing any turn uses. */
+export type UnclearedCloudProvider = {
+  providerId: string;
+  name: string;
+  detectedAtIso: string;
+};
+
+/**
+ * Pure projection: an ACTIVE cloud provider whose clearance does not include
+ * `internal` → it can serve no real turn (BI-575F0046).
+ *
+ * This is the state a fresh install lands in and the one no source detected.
+ * `deriveActivationClearance` grants a newly connected cloud account `["public"]`
+ * until its trust evidence is reviewed, and no route is ever `public` —
+ * ROUTE_SENSITIVITY floors at `internal`. So the provider is listed, healthy,
+ * authenticated and eligible for nothing, and the workspace home stops showing
+ * the local-only notice precisely because a provider now exists.
+ *
+ * Distinct from the expired-credential and disabled-provider lanes: nothing has
+ * failed here. Reconnecting would not help, so the copy must not suggest it.
+ */
+export function selectUnclearedCloudProviders(
+  rows: ReadonlyArray<{
+    provider: {
+      providerId: string;
+      name: string;
+      status: string;
+      endpointType?: string | null;
+      sensitivityClearance?: readonly string[] | null;
+    };
+  }>,
+  now: Date = new Date(),
+): UnclearedCloudProvider[] {
+  const items: UnclearedCloudProvider[] = [];
+  for (const row of rows) {
+    const p = row.provider;
+    if ((p.endpointType ?? "").toLowerCase() === "service") continue; // not a routing target
+    if (p.providerId === "local" || p.providerId === "ollama") continue; // never leaves the box
+    if (p.status !== "active") continue;
+    if ((p.sensitivityClearance ?? []).includes("internal")) continue;
+
+    items.push({ providerId: p.providerId, name: p.name, detectedAtIso: now.toISOString() });
+  }
+  return items;
+}
+
+export function unclearedCloudProviderToAttentionItem(
+  provider: UnclearedCloudProvider,
+): AttentionItem {
+  const href = `/platform/ai/providers/${encodeURIComponent(provider.providerId)}`;
+  return {
+    id: `provider-uncleared:${provider.providerId}`,
+    source: "provider-credential",
+    title: `${provider.name} is connected but not yet doing any work`,
+    context:
+      `Signing in proved the connection works. It has not yet recorded how that account handles ` +
+      `your business data, so your team keeps working on the built-in local AI instead. ` +
+      `Confirming that takes about a minute and puts ${provider.name} to work on everyday tasks.`,
+    decisionClass: { scorability: "unscorable" },
+    riskClass: "bounded-write",
+    triage: {
+      timeToAct: "none",
+      residueReason: "coverage-gap",
+      blastRadius: provider.name,
+      decideEffort: "review",
+      irreversible: false,
+    },
+    createdAtIso: provider.detectedAtIso,
+    actions: [{ kind: "open-in-context", label: "Confirm data handling", href }],
+    deepLink: href,
+    audience: { operator: true },
+  };
+}
+
 export async function loadProviderCredentialItems(): Promise<AttentionItem[]> {
   const rows = await getProviders();
   const items = [
     ...selectExpiredCredentialProviders(rows).map(expiredCredentialToAttentionItem),
     ...selectDisabledConnectedProviders(rows).map(disabledConnectedProviderToAttentionItem),
+    ...selectUnclearedCloudProviders(rows).map(unclearedCloudProviderToAttentionItem),
   ];
   return [...new Map(items.map((item) => [item.id, item])).values()];
 }

--- a/apps/web/lib/inference/cloud-provider-readiness.test.ts
+++ b/apps/web/lib/inference/cloud-provider-readiness.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveCloudProviderReadiness } from "./cloud-provider-readiness";
+
+// BI-575F0046. On a fresh install the owner connects a cloud provider, sees it
+// active, and every coworker turn still runs locally — because a new connection
+// is cleared for `public` and no turn is ever `public`.
+describe("resolveCloudProviderReadiness", () => {
+  const local = {
+    providerId: "local",
+    name: "Docker Model Runner (local)",
+    status: "active",
+    sensitivityClearance: ["public", "internal", "confidential", "restricted"],
+  };
+
+  it("reports none when only the local model is active", () => {
+    expect(resolveCloudProviderReadiness([local])).toEqual({ state: "none", providerNames: [] });
+  });
+
+  it("does not count the local sidecars as cloud", () => {
+    const ollama = { ...local, providerId: "ollama", name: "Ollama" };
+    expect(resolveCloudProviderReadiness([local, ollama]).state).toBe("none");
+  });
+
+  // The shape a fresh install lands in, and the one that used to read as success.
+  it("separates 'connected' from 'usable' for a public-only provider", () => {
+    const result = resolveCloudProviderReadiness([
+      local,
+      { providerId: "chatgpt", name: "ChatGPT", status: "active", sensitivityClearance: ["public"] },
+    ]);
+
+    expect(result.state).toBe("public-only");
+    expect(result.providerNames).toEqual(["ChatGPT"]);
+  });
+
+  it("reports ready once a provider is cleared for internal", () => {
+    const result = resolveCloudProviderReadiness([
+      local,
+      {
+        providerId: "anthropic-sub",
+        name: "Claude / Anthropic",
+        status: "active",
+        sensitivityClearance: ["public", "internal", "confidential"],
+      },
+    ]);
+
+    expect(result.state).toBe("ready");
+    expect(result.providerNames).toEqual(["Claude / Anthropic"]);
+  });
+
+  // The live install's actual mix: one reviewed provider, one not.
+  it("is ready when any one provider is usable, and names only that one", () => {
+    const result = resolveCloudProviderReadiness([
+      local,
+      { providerId: "chatgpt", name: "ChatGPT", status: "active", sensitivityClearance: ["public"] },
+      {
+        providerId: "anthropic-sub",
+        name: "Claude / Anthropic",
+        status: "active",
+        sensitivityClearance: ["public", "internal", "confidential"],
+      },
+    ]);
+
+    expect(result.state).toBe("ready");
+    expect(result.providerNames).toEqual(["Claude / Anthropic"]);
+  });
+
+  it("ignores providers that are not active", () => {
+    const result = resolveCloudProviderReadiness([
+      local,
+      {
+        providerId: "anthropic-sub",
+        name: "Claude / Anthropic",
+        status: "unconfigured",
+        sensitivityClearance: ["public", "internal", "confidential"],
+      },
+    ]);
+
+    expect(result.state).toBe("none");
+  });
+
+  it("treats an empty clearance array as unusable rather than unrestricted", () => {
+    const result = resolveCloudProviderReadiness([
+      { providerId: "openai", name: "OpenAI", status: "active", sensitivityClearance: [] },
+    ]);
+
+    expect(result.state).toBe("public-only");
+  });
+});

--- a/apps/web/lib/inference/cloud-provider-readiness.ts
+++ b/apps/web/lib/inference/cloud-provider-readiness.ts
@@ -1,0 +1,71 @@
+// apps/web/lib/inference/cloud-provider-readiness.ts
+//
+// Whether a connected cloud provider can actually take any of this install's
+// work (BI-575F0046).
+//
+// The distinction this module exists for is invisible everywhere else: a cloud
+// provider can be `status: "active"`, listed, authenticated and healthy, and
+// still be eligible for exactly nothing. `deriveActivationClearance` grants a
+// freshly connected cloud account `["public"]` and withholds the rest until its
+// trust evidence is reviewed — correct, because authentication proves a
+// credential works, not that the account carries commercial data protections.
+//
+// The catch is that NO turn is ever `public`. `ROUTE_SENSITIVITY` in
+// tak/agent-sensitivity.ts starts at `internal` and its entries are only
+// `internal`, `confidential` and `restricted`; `Agent.sensitivity` defaults to
+// `internal`. So the intersection of "what a new cloud provider is cleared for"
+// and "what any turn can be" is empty, and `pipeline-v2` excludes it on every
+// request. A brand-new install runs entirely on the local model, and the only
+// signal the owner gets is that everything feels slower.
+//
+// Counting active non-local providers — which is what the workspace home did —
+// reports that install as HAVING cloud AI, and hides the local-only notice that
+// would at least have been true.
+
+/** The lowest sensitivity any real turn can carry. Nothing routes at `public`. */
+const LOWEST_ROUTED_SENSITIVITY = "internal";
+
+export type CloudProviderReadiness =
+  /** No active cloud provider at all — local-only, and honestly so. */
+  | { state: "none"; providerNames: [] }
+  /**
+   * Connected and active, but cleared only for a sensitivity no turn uses.
+   * Indistinguishable from working unless you look at the clearance array.
+   */
+  | { state: "public-only"; providerNames: string[] }
+  /** At least one cloud provider is cleared for work that actually happens. */
+  | { state: "ready"; providerNames: string[] };
+
+export type ProviderClearanceFacts = {
+  providerId: string;
+  name: string;
+  status: string;
+  sensitivityClearance: readonly string[];
+};
+
+/** Local sidecars never send data off-machine; they are not the cloud question. */
+function isLocalProvider(providerId: string): boolean {
+  return providerId === "local" || providerId === "ollama";
+}
+
+/**
+ * Classify the install's cloud AI into something an owner-facing surface can act
+ * on. Pure over rows so it is testable without a database and so the workspace
+ * home, the attention queue and setup guidance cannot drift apart.
+ */
+export function resolveCloudProviderReadiness(
+  providers: ReadonlyArray<ProviderClearanceFacts>,
+): CloudProviderReadiness {
+  const cloud = providers.filter(
+    (provider) => provider.status === "active" && !isLocalProvider(provider.providerId),
+  );
+  if (cloud.length === 0) return { state: "none", providerNames: [] };
+
+  const usable = cloud.filter((provider) =>
+    provider.sensitivityClearance.includes(LOWEST_ROUTED_SENSITIVITY),
+  );
+  if (usable.length > 0) {
+    return { state: "ready", providerNames: usable.map((provider) => provider.name) };
+  }
+  return { state: "public-only", providerNames: cloud.map((provider) => provider.name) };
+}

--- a/docs/superpowers/plans/2026-08-26-cloud-clearance-first-run.md
+++ b/docs/superpowers/plans/2026-08-26-cloud-clearance-first-run.md
@@ -1,0 +1,52 @@
+---
+status: active
+---
+
+# Cloud Clearance at First Run — Implementation Plan
+
+**Goal:** A fresh install where the owner connects one cloud provider either uses it for ordinary work, or says plainly why it cannot and what to do — instead of silently running everything on the local model.
+
+**Primary BI:** `BI-575F0046`
+**Epic:** `EP-B9DD37C7`
+**Decision:** `DI-5C13155815D2` — operator chose `guided-attestation-and-loud`; the kernel scored the same set independently and reached the same option (composite 9.668, margin 1.422, high confidence, no commandment conflict).
+
+## The defect
+
+Three correct-looking things compose into a dead install:
+
+| stage | behaviour |
+|---|---|
+| seed (`packages/db/src/seed.ts`) | LLM providers land `status: "unconfigured"`, `sensitivityClearance: []` |
+| connect (`deriveActivationClearance`) | a new cloud account gets `["public"]` until its trust evidence is reviewed |
+| every route (`ROUTE_SENSITIVITY`) | floors at `internal`; `Agent.sensitivity` defaults to `internal`; 17 seeded coworkers are `confidential` |
+| select (`pipeline-v2.ts:95`) | excludes an endpoint whose clearance lacks the turn's level |
+
+The intersection of "what a new cloud provider is cleared for" and "what any turn can be" is **empty**.
+
+The clearance policy is sound and is not being changed. Authentication proves a credential works; it does not prove the account carries commercial data protections. What was wrong is that nothing reported the resulting state — and the workspace home actively mis-reported it, computing `hasCloudProvider` by counting active non-local providers, so connecting a provider *removed* the local-only notice.
+
+Live shapes on the reference install: `anthropic-sub` `{public,internal,confidential}` (reviewed at some point) against `chatgpt` `{public}`. Every new install starts where `chatgpt` is.
+
+## Slice 1 — visibility (delivered)
+
+- `resolveCloudProviderReadiness` — pure over provider rows, returns `none | public-only | ready`. Shared so the workspace home and the attention queue cannot disagree about what "has a cloud provider" means, which is the failure being fixed.
+- Workspace home keeps the local-only notice for `none`; a distinct notice for `public-only`. Different copy on purpose: "add a cloud provider" is wrong when one is already added, and reconnecting fixes nothing.
+- `selectUnclearedCloudProviders` projects the same state into the Needs-you inbox, in its own lane — the existing provider-credential lanes cover expired credentials and routing-disabled providers, both of which are failures. This is not a failure.
+- Owner-facing copy carries no clearance or sensitivity vocabulary; tests assert that on both surfaces.
+
+## Slice 2 — guided attestation (not started)
+
+Extend the existing `ai-providers` setup step (`SETUP_STEPS`, `/platform/ai/providers`) rather than adding a step: after a provider connects, walk the owner through account class, no-training entitlement and evidence so clearance is earned during onboarding.
+
+**Binding constraint from the decision ledger.** The core principle *Zero-Click Provider Setup* scores AGAINST the chosen option and FOR the rejected `grant-internal-on-connection`. It is the only principle pulling that way and it is not wrong: an install that demands paperwork before it works is its own defect. The attestation must therefore be genuinely quick — defaults pre-filled from the connected account where they can be known, one screen, skippable with the Slice 1 notice as the consequence. If it turns into a form, it has traded a silent failure for a tedious one and should be re-scored.
+
+- [ ] Decide what can be derived rather than asked (account class from the OAuth token's plan, `noTraining` from the provider's published terms per catalog entry).
+- [ ] Extend the `ai-providers` step to surface the attestation immediately after a successful connection.
+- [ ] Let the owner defer explicitly; deferral leaves the Slice 1 notice and attention item in place.
+- [ ] `SetupContext.hasCloudProvider` becomes readiness-aware so the COO's setup guidance stops claiming cloud AI is available when it is not.
+
+## Acceptance
+
+- A fresh install + one connected cloud provider + no other action either routes ordinary coworker turns to it, or shows both the workspace notice and the attention item.
+- A regression test over seed + activation asserting post-connect clearance intersects the sensitivity of a default coworker turn, or that the uncleared state is surfaced. The check must run against seed + activation, not a hand-configured install.
+- `deriveActivationClearance` is unchanged; any change to it is a separate kernel decision.

--- a/docs/ux-fit/2026-08-26-uncleared-cloud-provider-visibility.ux-fit.json
+++ b/docs/ux-fit/2026-08-26-uncleared-cloud-provider-visibility.ux-fit.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "decidedOption": "guided-attestation-and-loud",
+  "decisionInteractionId": "DI-5C13155815D2",
+  "scope": {
+    "files": [
+      "apps/web/components/workspace-home/CloudProviderUnclearedNotice.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "guided-attestation-and-loud",
+      "loud-only",
+      "grant-internal-on-connection"
+    ],
+    "note": "A fresh install grants a newly connected cloud provider sensitivityClearance ['public'], and no route is ever public \u2014 ROUTE_SENSITIVITY floors at internal. The provider is therefore active, healthy and eligible for nothing, while the workspace home reported it as cloud AI present and dropped the local-only notice. The three options were put to the operator, who chose guided attestation plus visibility. The kernel scored the same set independently and reached the same option (composite 9.668, margin 1.422, high confidence, no commandment conflict). grant-internal-on-connection scored 4.787, opposed by 'Outbound and irreversible actions require explicit go' and 'Least privilege, deny by default'. This change delivers the visibility half: the workspace notice and the attention lane. The guided setup step is tracked on BI-575F0046. Worth recording against that step: the core principle 'Zero-Click Provider Setup' scores AGAINST both chosen options and for the rejected one, so the attestation step has to be genuinely quick or it trades one defect for another."
+  }
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -9623,6 +9623,14 @@
     "longSentences": 0,
     "textMass": 21
   },
+  "apps/web/components/workspace-home/CloudProviderUnclearedNotice.tsx": {
+    "vocabulary": 0,
+    "retiredVocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
   "apps/web/components/workspace-home/LocalOnlyProviderNotice.tsx": {
     "vocabulary": 0,
     "retiredVocabulary": 0,


### PR DESCRIPTION
## A fresh install cannot use a cloud provider at all

Not sometimes — ever, until a step nothing mentions. Three correct-looking things compose into it:

| stage | behaviour |
|---|---|
| seed | LLM providers land `status: "unconfigured"`, `sensitivityClearance: []` |
| connect (`deriveActivationClearance`) | a new cloud account gets `["public"]` until its trust evidence is reviewed |
| every route (`ROUTE_SENSITIVITY`) | floors at `internal`; `Agent.sensitivity` defaults to `internal`; 17 seeded coworkers are `confidential` |
| select (`pipeline-v2.ts:95`) | excludes an endpoint whose clearance lacks the turn's level |

The intersection of "what a new cloud provider is cleared for" and "what any turn can be" is **empty**.

Worse than silent, it read as success: the workspace home computed `hasCloudProvider` by counting active non-local providers, so connecting a provider **removed** the local-only notice while the provider could serve nothing. The owner went from an honest "you are running locally" to no message at all.

Both shapes are visible on the reference install — `anthropic-sub` `{public,internal,confidential}` (reviewed at some point) against `chatgpt` `{public}`. Every new install starts where `chatgpt` is.

## What this changes, and what it deliberately does not

The clearance policy is **untouched**. It is right, and the code says why: authentication proves a credential works, not that the account carries commercial data protections. What was wrong is that nothing reported the resulting state.

- `resolveCloudProviderReadiness` — pure over provider rows, returns `none | public-only | ready`. Shared, because two surfaces disagreeing about what "has a cloud provider" means *is* the bug.
- Workspace home keeps the local-only notice for `none`, and a distinct notice for `public-only`. Different copy on purpose: "add a cloud provider" is wrong when one is already added, and reconnecting fixes nothing.
- `selectUnclearedCloudProviders` projects the same state into the Needs-you inbox in its own lane. The existing provider-credential lanes cover expired credentials and routing-disabled providers — both failures. This is not a failure, so it must not say "reconnect".
- Owner-facing copy carries no clearance or sensitivity vocabulary; tests assert that on both surfaces.

## Decision

`DI-5C13155815D2` — the operator chose `guided-attestation-and-loud`; the kernel scored the same set independently and reached the same option (composite 9.668 against 8.246 and 4.787, margin 1.422, high confidence, no commandment conflict). `grant-internal-on-connection` is opposed by *Outbound and irreversible actions require explicit go* and *Least privilege, deny by default*.

**One tension recorded for Slice 2:** the core principle *Zero-Click Provider Setup* scores against the chosen option and for the rejected one. It is the only principle pulling that way and it is not wrong — an install that demands paperwork before it works is its own defect. The guided attestation step must therefore be genuinely quick, or it trades a silent failure for a tedious one. Captured in the plan and the UX-fit manifest.

## Scope

This is Slice 1 — visibility. Slice 2, the guided attestation step that makes a fresh install work without the owner noticing anything, is planned in `docs/superpowers/plans/2026-08-26-cloud-clearance-first-run.md` and **not** built here.

## Verification

13 new tests; 881 tests across `lib/attention` + `lib/inference` + `components/workspace-home`; web typecheck; 52 preflight guards; exact-tree local CI gate **PASS** @ `3865bf07680b` — 8:19, including `✓ Compiled successfully in 4.8min`.

This branch sat blocked behind five unattributable gate failures, which is how `BI-F22B4EEE` was found and fixed (#4703). Rebased onto that fix, it passed first time.

Part of `WC-9C828312`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)