### PR TITLE
fix(attention): stop rounding every deadline tag up to whole days

### DIFF
--- a/apps/web/lib/attention/owner-decision.test.ts
+++ b/apps/web/lib/attention/owner-decision.test.ts
@@ -334,6 +334,57 @@ describe("translateAttentionToOwnerDecision", () => {
     );
   });
 
+  // A deadline tag must never contradict the exact expiry printed on the same
+  // card. Every span below used to render "Due in 1 day" (BI-7CB2CCDE follow-up).
+  describe("deadline tag precision", () => {
+    const NOW = Date.parse("2026-08-25T23:35:00.000Z");
+
+    function tagFor(deadlineIso: string): string | undefined {
+      const card = translateAttentionToOwnerDecision(
+        item({
+          source: "approval-bill",
+          triage: {
+            timeToAct: "due-soon",
+            deadlineIso,
+            residueReason: "policy-approval",
+            decideEffort: "review",
+            irreversible: false,
+          },
+        }),
+        NOW,
+      );
+      return card.tags.find((tag) => tag.kind === "deadline")?.label;
+    }
+
+    it("reports a minutes-wide window in minutes, not as a day", () => {
+      expect(tagFor("2026-08-25T23:38:00.000Z")).toBe("Due in 3 minutes");
+      // The exact envelope observed on the live install: 3m30.687s remaining,
+      // which previously rendered "Due in 1 day".
+      expect(tagFor("2026-08-25T23:38:30.687Z")).toBe("Due in 4 minutes");
+    });
+
+    it("keeps a one-minute window singular and never rounds it to zero", () => {
+      expect(tagFor("2026-08-25T23:35:20.000Z")).toBe("Due in 1 minute");
+      expect(tagFor("2026-08-25T23:36:00.000Z")).toBe("Due in 1 minute");
+    });
+
+    it("reports an hours-wide window in hours", () => {
+      expect(tagFor("2026-08-26T05:35:00.000Z")).toBe("Due in 6 hours");
+      expect(tagFor("2026-08-26T00:35:00.000Z")).toBe("Due in 1 hour");
+    });
+
+    it("still reports day-scale deadlines in days", () => {
+      expect(tagFor("2026-08-28T23:35:00.000Z")).toBe("Due in 3 days");
+      expect(tagFor("2026-08-26T23:35:00.000Z")).toBe("Due in 1 day");
+    });
+
+    it("calls an elapsed deadline past due", () => {
+      expect(tagFor("2026-08-25T23:34:59.000Z")).toBe("Past due");
+      expect(tagFor("2026-08-25T23:35:00.000Z")).toBe("Past due");
+      expect(tagFor("2026-08-24T23:35:00.000Z")).toBe("Past due");
+    });
+  });
+
   it.each<AttentionSource>([
     "escalation",
     "ai-decision",

--- a/apps/web/lib/attention/owner-decision.ts
+++ b/apps/web/lib/attention/owner-decision.ts
@@ -174,12 +174,40 @@ function tagsFor(item: AttentionItem, nowMs: number): OwnerDecisionTag[] {
   return tags;
 }
 
+const MINUTE_MS = 60_000;
+const HOUR_MS = 3_600_000;
+const DAY_MS = 86_400_000;
+
+/**
+ * How long the reader has, in the largest unit that is still honest.
+ *
+ * This used to round every remaining span up to whole days, so ANY future
+ * deadline under 24h read "Due in 1 day" — and "Due today" could not fire at
+ * all, because Math.ceil of a positive fraction is never 0. That was harmless
+ * while every deadline-bearing source was day-scale (bills, filings), and
+ * actively misleading the moment one was not: a coworker approval envelope
+ * whose window closes in three minutes was labelled "Due in 1 day", directly
+ * contradicting the exact expiry printed on the same card (BI-7CB2CCDE
+ * follow-up, caught on the live install).
+ *
+ * Minutes and hours are therefore reported as minutes and hours. Day-scale
+ * deadlines keep their existing wording and rounding.
+ */
 function dueLabel(deadlineIso: string | undefined, nowMs: number): string | null {
   if (!deadlineIso) return null;
   const deadline = new Date(deadlineIso).getTime();
   if (!Number.isFinite(deadline)) return null;
-  const days = Math.ceil((deadline - nowMs) / 86_400_000);
-  if (days < 0) return "Past due";
-  if (days === 0) return "Due today";
+  const msLeft = deadline - nowMs;
+  if (msLeft <= 0) return "Past due";
+  if (msLeft < HOUR_MS) {
+    // Never round a live window down to "0 minutes" — it still needs an answer.
+    const minutes = Math.max(1, Math.round(msLeft / MINUTE_MS));
+    return `Due in ${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  if (msLeft < DAY_MS) {
+    const hours = Math.round(msLeft / HOUR_MS);
+    return `Due in ${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  const days = Math.ceil(msLeft / DAY_MS);
   return `Due in ${days} day${days === 1 ? "" : "s"}`;
 }

--- a/docs/user-guide/workspace/attention-inbox.md
+++ b/docs/user-guide/workspace/attention-inbox.md
@@ -49,7 +49,7 @@ Folding "a human must decide this now" into the backlog is a category error: the
 - **Clear or snooze the Friday review** as one batch, or review an item individually.
 - Ask your [digital coworker](../getting-started/ai-coworker.md) for a briefing on what is in the inbox and why.
 
-Deadline-bearing items show a plain tag such as **Due today** or **Due in 3 days**. Impact tags use words such as **Costs money**, **Goes public**, and **Reversible**.
+Deadline-bearing items show a plain tag such as **Due in 10 minutes**, **Due in 6 hours**, or **Due in 3 days** — always in the largest unit that is still accurate, so a short window is never dressed up as a long one. A window that has closed reads **Past due**. Impact tags use words such as **Costs money**, **Goes public**, and **Reversible**.
 
 ---
 


### PR DESCRIPTION
Follow-up to BI-7CB2CCDE, found by verifying it on the live install.

## The defect

`dueLabel` computed `Math.ceil(msLeft / 86_400_000)`, so **any** future deadline under 24 hours rendered "Due in 1 day" — and "Due today" could never fire at all, because `Math.ceil` of a positive fraction is never `0`.

That was harmless while every deadline-bearing source was day-scale (bills, expense claims, regulatory filings). It stopped being harmless the moment one was not. Observed on the live install, on a coworker approval envelope with a 15-minute authority window and about three minutes left:

```
Open until   2026-08-25T23:38:30.687Z     ← ~3 minutes away
Due in 1 day                              ← the tag
```

The tag contradicted the exact expiry printed two lines above it, on a card whose entire purpose is letting the reader see how long they have before exercising delegated authority. An approval window that is closing reads as one that is comfortably open.

This is the same class of problem as a gate whose `pending` is indistinguishable from `failed`: the state is knowable, and the surface says something else.

## The fix

Minutes and hours are reported as minutes and hours. Day-scale deadlines keep their existing wording and rounding, so nothing that reads correctly today changes. An elapsed deadline is "Past due" rather than a rounding artefact of `Math.ceil(-0.5) === -0`.

A live window never rounds down to "0 minutes" — it still needs an answer.

## Why it wasn't caught

No existing test had a sub-day deadline, because until this cycle no source produced one. 359 unit tests and five clean guard suites all passed over the broken arithmetic. The live check found it in one pass — which is the argument for verifying against real data rather than only fixtures.

## Verification

| Gate | Result |
| --- | --- |
| `lib/attention`, `components/attention` | 313 tests pass, including 5 new for the deadline tag |
| `pnpm --filter web typecheck` | clean |
| `pregate:preflight` | 52 guards clean |
| Local merged-code gate | **PASS** at `fda7fa6b4ced`, evidence `cmt9nyd7l02j401p7nejosvq8` |

New tests pin minute, hour, day and elapsed spans, including the exact envelope observed live (3m30.687s remaining, which previously rendered "Due in 1 day").

Verdict read from `pregate:status`, not the wrapper exit code.

## Docs

`docs/user-guide/workspace/attention-inbox.md` documented the old vocabulary ("Due today" / "Due in 3 days"). Updated to describe the actual behaviour — largest unit that is still accurate, and "Past due" for a closed window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
