### PR TITLE
fix(demand): let an effort estimate stand on evidence, not provenance (BI-A5697C5E)

### DIFF
--- a/apps/web/lib/demand/activation.test.ts
+++ b/apps/web/lib/demand/activation.test.ts
@@ -30,6 +30,67 @@ function demand(overrides: Partial<DemandActivationInput> = {}): DemandActivatio
   };
 }
 
+// BI-A5697C5E, founder-ratified 2026-08-26: an estimate's standing follows its
+// evidence, never its provenance. "Humans are not qualified to override an AI
+// estimate" — the confirmation the old rule demanded could only be a rubber
+// stamp, and blocked scoreReady on every agent-estimated item.
+describe("estimate standing follows evidence, not provenance", () => {
+  const grounded = {
+    demandStage: "screened" as const,
+    problemStatement: "Employment events are recorded but nothing acts on them.",
+    evidenceCount: 1,
+    scoreInputs: { reach: 40, impact: 4, confidence: 0.9, jobSize: 3 },
+    investmentBucket: "grow",
+    estimateAgreed: false,
+    estimateDiverged: false,
+  };
+
+  it("lets an unconfirmed AI estimate reach scoreReady", () => {
+    const state = buildDemandActivationState(demand({ ...grounded, estimateSource: "ai" }));
+
+    expect(state.score.provisional).toBe(false);
+    expect(state.readiness.scoreReady).toBe(true);
+    expect(state.blockers).not.toContain("Confirm or overrule the proposed AI effort estimate.");
+  });
+
+  it("scores identical grounding identically whatever produced the estimate", () => {
+    // `estimateAgreed` tracks its source realistically: only "agreed" carries a
+    // countersignature. Under the old rule that alone split the three apart — ai
+    // and human were provisional, agreed was not — which is exactly the
+    // provenance judgement this pins closed.
+    const states = ([
+      { estimateSource: "ai" as const, estimateAgreed: false },
+      { estimateSource: "human" as const, estimateAgreed: false },
+      { estimateSource: "agreed" as const, estimateAgreed: true },
+    ]).map((provenance) =>
+      buildDemandActivationState(demand({ ...grounded, ...provenance })));
+
+    const [first] = states;
+    for (const state of states) {
+      expect(state.score.score).toBe(first!.score.score);
+      expect(state.score.provisional).toBe(first!.score.provisional);
+      expect(state.readiness.scoreReady).toBe(first!.readiness.scoreReady);
+    }
+  });
+
+  it("still blocks when two estimates genuinely disagree", () => {
+    const state = buildDemandActivationState(
+      demand({ ...grounded, estimateSource: "human", estimateDiverged: true }));
+
+    expect(state.score.provisional).toBe(true);
+    expect(state.readiness.scoreReady).toBe(false);
+    expect(state.blockers).toContain("Reconcile the AI and human effort estimates.");
+  });
+
+  it("keeps the investment bucket a human decision", () => {
+    const state = buildDemandActivationState(
+      demand({ ...grounded, estimateSource: "ai", investmentBucket: null }));
+
+    expect(state.readiness.scoreReady).toBe(false);
+    expect(state.blockers).toContain("Choose an investment bucket.");
+  });
+});
+
 describe("buildDemandActivationState", () => {
   it("keeps a null stage explicitly unclassified", () => {
     const state = buildDemandActivationState(demand());

--- a/apps/web/lib/demand/activation.ts
+++ b/apps/web/lib/demand/activation.ts
@@ -102,10 +102,28 @@ export function buildDemandActivationState(
       : null;
   const evidenceReady =
     hasProblem(input.problemStatement) && input.evidenceCount > 0;
-  const provisional =
-    input.estimateDiverged ||
-    input.estimateSource === "ai" ||
-    (input.estimateSource !== null && input.estimateAgreed === false);
+  // An estimate is provisional when two estimates DISAGREE — not because of who
+  // produced it (BI-A5697C5E, founder-ratified 2026-08-26).
+  //
+  // The removed clauses judged standing by provenance. `estimateSource === "ai"`
+  // made an AI estimate permanently provisional with no disagreement and no
+  // divergence, and `estimateAgreed === false` is true for ANY single unconfirmed
+  // estimate — it means "nobody has countersigned yet", not "somebody disagreed".
+  // Together they blocked scoreReady on every agent-estimated item, which under an
+  // AI-native operating model is the default path rather than an edge case.
+  //
+  // This contradicted the AGENTS.md section 12 keystone — governance approves
+  // evidence, not provenance; a gate never asks which surface produced a field —
+  // and the commandment "Do the work; don't task the operator with what an agent
+  // can do". The confirmation it demanded could only ever be a rubber stamp: the
+  // estimator has read the schema, migration and test surface, and a confirmer who
+  // has not holds strictly less information. Ceremony that presents itself as
+  // governance is worse than no gate, because it manufactures assurance nobody
+  // actually supplied.
+  //
+  // Appetite and priority remain a human decision and are unaffected — they are
+  // the separate `validBucket` investment-bucket blocker below.
+  const provisional = input.estimateDiverged;
   const scoreReady =
     computed.score !== null &&
     confidence !== null &&
@@ -141,8 +159,6 @@ export function buildDemandActivationState(
   }
   if (input.estimateDiverged) {
     blockers.push("Reconcile the AI and human effort estimates.");
-  } else if (input.estimateSource === "ai") {
-    blockers.push("Confirm or overrule the proposed AI effort estimate.");
   }
   if (!validBucket(input.investmentBucket)) {
     blockers.push("Choose an investment bucket.");

--- a/apps/web/lib/demand/estimate-provenance.ts
+++ b/apps/web/lib/demand/estimate-provenance.ts
@@ -92,7 +92,11 @@ export function resolveEstimateProvenance(inputs: EstimateProvenanceInputs): Est
   const identical = bothPresent && ai === human;
   const agreed = inputs.agreed === true || identical;
 
-  // Human overrules AI; otherwise whichever single side estimated.
+  // Neither side wins by provenance (BI-A5697C5E). When both exist and disagree,
+  // `diverged` below marks the estimate provisional and reconciliation is required
+  // before it can be used — so this pick is never the silent tiebreaker it reads
+  // like. When only one side estimated, that estimate stands on its own grounding,
+  // whichever side produced it.
   const effectiveJobSize = human !== null ? human : ai;
 
   let source: EstimateSource | null;


### PR DESCRIPTION
Fixes `BI-A5697C5E`. Founder-ratified 2026-08-26.

## Problem

`provisional` in `activation.ts` judged an estimate by **who produced it**. Two of its three clauses had nothing to do with disagreement:

```ts
input.estimateSource === "ai"                                     // AI provenance alone
(input.estimateSource !== null && input.estimateAgreed === false) // nobody countersigned yet
```

The first made an AI estimate permanently provisional with no divergence and no dissent. The second is true for *any* single unconfirmed estimate — it means "not yet countersigned", not "somebody disagreed".

Together they blocked `scoreReady`, and therefore `fundingReady`, on **every agent-estimated item**. Under an AI-native operating model that is the default path, not an edge case, so the demand funnel stalled behind a confirmation nobody was positioned to give.

`estimate-provenance.ts` carried the same posture in a comment: `// Human overrules AI`.

## Why it's wrong

This contradicts the AGENTS.md §12 keystone — *governance approves evidence, not provenance; a gate reads its required evidence fields, it never asks which surface produced them* — and the commandment *"Do the work; don't task the operator with what an agent can do"*.

On the merits: `jobSize` is a complexity **measurement**. The estimator has read the schema, the migration surface and the test surface; a confirmer who has not holds strictly less information, so the confirmation can only be a rubber stamp. Ceremony that presents itself as governance is worse than no gate, because it manufactures assurance nobody actually supplied.

> "Humans are not qualified to override an AI estimate. the ask is irrational."

## Change

An estimate is provisional when two estimates **genuinely disagree** — which is what `estimateDiverged` already meant. The `Confirm or overrule the proposed AI effort estimate` blocker is gone; `Reconcile the AI and human effort estimates` stays.

**Appetite and priority remain human and are untouched.** That is the separate `validBucket` investment-bucket blocker, pinned by a test so it cannot drift.

## What this doesn't do

It does not invert the error by making AI authoritative over a human estimate. Where both exist and disagree, neither wins and reconciliation is required.

## Tests

**No existing test asserted the removed behaviour** — all 92 demand tests passed before these were written, so the rule was entirely uncovered. Four now pin it:

- an unconfirmed AI estimate reaches `scoreReady`
- identical grounding scores identically across `ai` / `human` / `agreed`, with `estimateAgreed` tracking its source realistically
- divergence still blocks
- the investment bucket is still required

Two fail against the old rule, verified by reverting the source and re-running.

## Build gate

- 156 test files / 1537 tests passing across `lib/demand` and `lib/actions`
- `tsc --noEmit` clean
- `pnpm --filter web build` exit 0
- Policy guards `--profile pull-request`: all 7 pass
- No migration