### PR TITLE
fix(runtime): name every drifted capability instead of one, and correct the monitoring claim

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -874,6 +874,9 @@
     "apps/web/lib/platform-runtime/capability-service-projection.ts": [
       "docs/architecture/capability-driven-runtime-profiles.md"
     ],
+    "apps/web/lib/platform-runtime/capability-state-divergence.ts": [
+      "docs/architecture/capability-driven-runtime-profiles.md"
+    ],
     "apps/web/lib/platform-runtime/operational-state.ts": [
       "docs/architecture/capability-driven-runtime-profiles.md",
       "docs/maintenance/staleness-report.md"
@@ -2318,6 +2321,7 @@
     ],
     "docs/architecture/capability-driven-runtime-profiles.md": [
       "apps/web/lib/platform-runtime/capability-service-projection.ts",
+      "apps/web/lib/platform-runtime/capability-state-divergence.ts",
       "apps/web/lib/platform-runtime/operational-state.ts",
       "packages/db/data/platform-runtime-capabilities.json",
       "scripts/capability-service-catalog.generated.json",

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1187,6 +1187,7 @@
         "install-upgrade-consumer-assets-and-rollback",
         "backup-and-health-semantics",
         "observation-and-diagnostics-boundary",
+        "diagnosing-capability-drift-bi-5acbac50",
         "safe-operating-rules"
       ]
     },

--- a/apps/web/lib/platform-runtime/capability-state-divergence.test.ts
+++ b/apps/web/lib/platform-runtime/capability-state-divergence.test.ts
@@ -1,0 +1,228 @@
+// BI-5ACBAC50 — naming the capability drift.
+//
+// The fixture is not invented. It is what a live installation reported on
+// 2026-08-26: install-state listing only `runtime:core`, the database reporting
+// six further capabilities active, and `runtime:development` disabled while its
+// services were running.
+
+import { describe, expect, it } from "vitest";
+
+import { projectCapabilityServices } from "./capability-service-projection";
+import {
+  diagnoseCapabilityStateDivergence,
+  isCapabilityStateStaleError,
+} from "./capability-state-divergence";
+
+/** Verbatim from `install-state.json` on the drifted install. */
+const LIVE_ENABLED = ["runtime:core"];
+
+/** Verbatim from `select "capabilityId", state from "PlatformCapability"`. */
+const LIVE_DB_STATE = [
+  { capabilityId: "runtime:adp-integration", state: "disabled" as const },
+  { capabilityId: "runtime:browser-automation", state: "active" as const },
+  { capabilityId: "runtime:build", state: "active" as const },
+  { capabilityId: "runtime:core", state: "active" as const },
+  { capabilityId: "runtime:deep-observability", state: "active" as const },
+  { capabilityId: "runtime:development", state: "disabled" as const },
+  { capabilityId: "runtime:durable-automation", state: "active" as const },
+  { capabilityId: "runtime:external-ai", state: "active" as const },
+  { capabilityId: "runtime:local-speech", state: "active" as const },
+];
+
+describe("the existing projection already fails closed", () => {
+  // Establishes the premise: detection is not the missing piece. A projection
+  // that guessed which authority to believe would hand backup and readiness a
+  // topology neither source claims.
+  it("throws capability_state_stale rather than guessing which authority wins", () => {
+    let thrown: unknown;
+    try {
+      projectCapabilityServices({
+        enabledRuntimeCapabilities: LIVE_ENABLED,
+        capabilityStates: LIVE_DB_STATE,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(/^capability_state_stale:/);
+    expect(isCapabilityStateStaleError(thrown)).toBe(true);
+  });
+
+  it("recognises the other stale-identity errors too", () => {
+    expect(isCapabilityStateStaleError(new Error("install_capability_state_stale"))).toBe(true);
+    expect(isCapabilityStateStaleError(new Error("install_catalog_stale"))).toBe(true);
+    expect(isCapabilityStateStaleError(new Error("something else"))).toBe(false);
+    expect(isCapabilityStateStaleError(null)).toBe(false);
+  });
+});
+
+describe("diagnoseCapabilityStateDivergence on the live drift", () => {
+  const report = diagnoseCapabilityStateDivergence({
+    enabledRuntimeCapabilities: LIVE_ENABLED,
+    capabilityStates: LIVE_DB_STATE,
+  });
+
+  it("reports drift", () => {
+    expect(report.diverged).toBe(true);
+  });
+
+  // The projection names only the FIRST mismatch it hits. An operator needs all
+  // of them, because repairing one leaves the rest.
+  it("names every drifted capability, not just the first", () => {
+    const ids = report.divergences.map((entry) => entry.capabilityId).sort();
+    expect(ids).toEqual([
+      "runtime:browser-automation",
+      "runtime:build",
+      "runtime:deep-observability",
+      "runtime:durable-automation",
+      "runtime:external-ai",
+      "runtime:local-speech",
+    ]);
+  });
+
+  it("classifies them as active-in-database but never enabled here", () => {
+    for (const entry of report.divergences) {
+      expect(entry.kind).toBe("live-active-not-enabled");
+      expect(entry.liveState).toBe("active");
+      expect(entry.enabledInInstallState).toBe(false);
+    }
+  });
+
+  // The one that made this matter: capability state read `active` while nothing
+  // was collecting, so every metric-backed surface had no source and the state
+  // that would have revealed it said everything was fine.
+  it("includes deep-observability, the case that hid an absent metrics stack", () => {
+    const ids = report.divergences.map((entry) => entry.capabilityId);
+    expect(ids).toContain("runtime:deep-observability");
+  });
+
+  it("does NOT flag capabilities the two authorities agree on", () => {
+    const ids = report.divergences.map((entry) => entry.capabilityId);
+    expect(ids).not.toContain("runtime:core");
+    expect(ids).not.toContain("runtime:adp-integration");
+    expect(ids).not.toContain("runtime:development");
+  });
+
+  it("summarises in words an operator can act on", () => {
+    expect(report.summary).toContain("drifted from the installation snapshot");
+    expect(report.summary).toContain("runtime:deep-observability");
+    expect(report.summary).toContain("never enabled them");
+  });
+});
+
+describe("the other directions", () => {
+  it("flags a capability the install enabled but the database calls disabled", () => {
+    const report = diagnoseCapabilityStateDivergence({
+      enabledRuntimeCapabilities: ["runtime:core", "runtime:build"],
+      capabilityStates: LIVE_DB_STATE.map((entry) =>
+        entry.capabilityId === "runtime:build"
+          ? { ...entry, state: "disabled" as const }
+          : entry,
+      ),
+    });
+    const build = report.divergences.find((e) => e.capabilityId === "runtime:build");
+    expect(build?.kind).toBe("enabled-not-live-active");
+    expect(report.summary).toContain("the database reports them disabled");
+  });
+
+  it("flags a capability with no database row at all", () => {
+    const report = diagnoseCapabilityStateDivergence({
+      enabledRuntimeCapabilities: LIVE_ENABLED,
+      capabilityStates: LIVE_DB_STATE.filter(
+        (entry) => entry.capabilityId !== "runtime:local-speech",
+      ),
+    });
+    const missing = report.divergences.find(
+      (e) => e.capabilityId === "runtime:local-speech",
+    );
+    expect(missing?.kind).toBe("missing-live-state");
+    expect(missing?.liveState).toBeNull();
+    expect(report.summary).toContain("no capability record exists");
+  });
+});
+
+describe("a converged installation", () => {
+  const converged = LIVE_DB_STATE.map((entry) => ({
+    ...entry,
+    state: entry.capabilityId === "runtime:core" ? ("active" as const) : ("disabled" as const),
+  }));
+
+  it("reports no drift when both authorities agree", () => {
+    const report = diagnoseCapabilityStateDivergence({
+      enabledRuntimeCapabilities: ["runtime:core"],
+      capabilityStates: converged,
+    });
+    expect(report.diverged).toBe(false);
+    expect(report.divergences).toEqual([]);
+    expect(report.summary).toContain("agrees with the installation snapshot");
+  });
+
+  it("and the projection then succeeds, proving the fixture is realistic", () => {
+    expect(() =>
+      projectCapabilityServices({
+        enabledRuntimeCapabilities: ["runtime:core"],
+        capabilityStates: converged,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("purity", () => {
+  it("is deterministic", () => {
+    const once = diagnoseCapabilityStateDivergence({
+      enabledRuntimeCapabilities: LIVE_ENABLED,
+      capabilityStates: LIVE_DB_STATE,
+    });
+    const twice = diagnoseCapabilityStateDivergence({
+      enabledRuntimeCapabilities: LIVE_ENABLED,
+      capabilityStates: LIVE_DB_STATE,
+    });
+    expect(once).toEqual(twice);
+  });
+
+  it("tolerates an unrecognised state value rather than throwing", () => {
+    const report = diagnoseCapabilityStateDivergence({
+      enabledRuntimeCapabilities: LIVE_ENABLED,
+      capabilityStates: [
+        ...LIVE_DB_STATE.filter((e) => e.capabilityId !== "runtime:build"),
+        { capabilityId: "runtime:build", state: "quarantined" as never },
+      ],
+    });
+    const build = report.divergences.find((e) => e.capabilityId === "runtime:build");
+    expect(build?.kind).toBe("missing-live-state");
+  });
+});
+
+describe("createOperationalCapabilityState surfaces the whole diagnosis", () => {
+  // The loader is what runtime-health and backup-readiness call, so this is
+  // where an operator's error message comes from.
+  it("re-raises the stale error with every drifted capability named", async () => {
+    const { createOperationalCapabilityState } = await import("./operational-state");
+    let thrown: unknown;
+    try {
+      createOperationalCapabilityState({
+        installSnapshot: {
+          enabledRuntimeCapabilities: LIVE_ENABLED,
+          capabilityCatalogHash: "f".repeat(64),
+          capabilityStateVersion: "e".repeat(64),
+        },
+        capabilityStates: LIVE_DB_STATE,
+        observedServices: {},
+        observedProviders: {},
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    const message = (thrown as Error).message;
+    // The original identifier survives, so existing matching still works.
+    expect(message).toMatch(/^capability_state_stale:/);
+    // ...and the rest of the drift is now in the same message.
+    expect(message).toContain("runtime:deep-observability");
+    expect(message).toContain("runtime:local-speech");
+    expect(message).toContain("never enabled them");
+    // Machine-readable, so a surface does not re-derive it from prose.
+    const report = (thrown as Error & { divergence?: { divergences: unknown[] } }).divergence;
+    expect(report?.divergences).toHaveLength(6);
+    expect((thrown as Error).cause).toBeInstanceOf(Error);
+  });
+});

--- a/apps/web/lib/platform-runtime/capability-state-divergence.ts
+++ b/apps/web/lib/platform-runtime/capability-state-divergence.ts
@@ -1,0 +1,166 @@
+// BI-5ACBAC50 — say WHICH capabilities have drifted, and in which direction.
+//
+// `projectCapabilityServices` already detects the drift, and correctly: it
+// throws `capability_state_stale:<id>` when `PlatformCapability.state` and
+// `install-state.json`'s `enabledRuntimeCapabilities` disagree. Fail-closed is
+// right — a projection that guessed which of the two authorities to believe
+// would hand backup and readiness a topology neither source claims.
+//
+// The problem is that the throw is ANONYMOUS to an operator. It names one
+// capability, it surfaces as a generic error on whatever page called it, and the
+// surfaces that would explain it — runtime health, backup readiness — are the
+// exact ones that cannot render because the throw happened inside their loader.
+// So the platform detects the condition and then loses it.
+//
+// This module is the diagnosis half: pure, total, and callable when the
+// projection has ALREADY thrown, so the failure can be shown rather than merely
+// logged. It changes no semantics and never decides which authority wins.
+//
+// Observed on a live install 2026-08-26: install-state listed only
+// `runtime:core`, while the database reported six further capabilities `active`
+// (build, browser-automation, deep-observability, durable-automation,
+// external-ai, local-speech) and `runtime:development` disabled while its
+// services were running. Backup, readiness and the health UI all consume this
+// projection.
+
+import catalog from "../../../../scripts/capability-service-catalog.generated.json";
+
+import type { LiveCapabilityState } from "./capability-service-projection";
+
+const generatedCatalog = catalog as unknown as {
+  capabilities: { capabilityId: string }[];
+};
+
+/**
+ * Which way a capability drifted.
+ *
+ * `live-active-not-enabled` — the database says the capability is on, the
+ * install snapshot does not list it. Anything trusting capability state believes
+ * services are running that the install never provisioned. This is the shape
+ * that made deep-observability read healthy while nothing collected.
+ *
+ * `enabled-not-live-active` — the install snapshot lists it, the database says
+ * disabled. The services may be running while the platform believes they are
+ * not, so nothing tends them.
+ */
+export type CapabilityDivergenceKind =
+  | "live-active-not-enabled"
+  | "enabled-not-live-active"
+  | "missing-live-state";
+
+export interface CapabilityDivergence {
+  capabilityId: string;
+  kind: CapabilityDivergenceKind;
+  /** What `PlatformCapability.state` says, or null when there is no row. */
+  liveState: "active" | "disabled" | null;
+  /** Whether install-state lists it in `enabledRuntimeCapabilities`. */
+  enabledInInstallState: boolean;
+}
+
+export interface CapabilityDivergenceReport {
+  diverged: boolean;
+  divergences: CapabilityDivergence[];
+  /** One line an operator can read without knowing the data model. */
+  summary: string;
+}
+
+function describe(divergences: CapabilityDivergence[]): string {
+  if (divergences.length === 0) {
+    return "Capability state agrees with the installation snapshot.";
+  }
+  const claimedOn = divergences
+    .filter((entry) => entry.kind === "live-active-not-enabled")
+    .map((entry) => entry.capabilityId);
+  const claimedOff = divergences
+    .filter((entry) => entry.kind === "enabled-not-live-active")
+    .map((entry) => entry.capabilityId);
+  const missing = divergences
+    .filter((entry) => entry.kind === "missing-live-state")
+    .map((entry) => entry.capabilityId);
+
+  const parts: string[] = [];
+  if (claimedOn.length > 0) {
+    parts.push(
+      `the database reports ${claimedOn.join(", ")} active, but this installation never enabled them`,
+    );
+  }
+  if (claimedOff.length > 0) {
+    parts.push(
+      `this installation enabled ${claimedOff.join(", ")}, but the database reports them disabled`,
+    );
+  }
+  if (missing.length > 0) {
+    parts.push(`no capability record exists for ${missing.join(", ")}`);
+  }
+  return `Capability state has drifted from the installation snapshot: ${parts.join("; ")}.`;
+}
+
+/**
+ * Compare the two authorities and name every disagreement.
+ *
+ * Pure and total. Reports rather than decides: it never says which side is
+ * right, because that is a repair decision with real consequences and belongs to
+ * whoever is doing the repair.
+ */
+export function diagnoseCapabilityStateDivergence(input: {
+  enabledRuntimeCapabilities: readonly string[];
+  capabilityStates: readonly LiveCapabilityState[];
+}): CapabilityDivergenceReport {
+  const enabled = new Set(input.enabledRuntimeCapabilities);
+  const live = new Map<string, "active" | "disabled">();
+  for (const entry of input.capabilityStates) {
+    if (entry.state === "active" || entry.state === "disabled") {
+      live.set(entry.capabilityId, entry.state);
+    }
+  }
+
+  const divergences: CapabilityDivergence[] = [];
+  for (const capability of generatedCatalog.capabilities) {
+    const id = capability.capabilityId;
+    const liveState = live.get(id) ?? null;
+    const enabledHere = enabled.has(id);
+
+    if (liveState === null) {
+      divergences.push({
+        capabilityId: id,
+        kind: "missing-live-state",
+        liveState: null,
+        enabledInInstallState: enabledHere,
+      });
+      continue;
+    }
+    if (liveState === "active" && !enabledHere) {
+      divergences.push({
+        capabilityId: id,
+        kind: "live-active-not-enabled",
+        liveState,
+        enabledInInstallState: false,
+      });
+      continue;
+    }
+    if (liveState === "disabled" && enabledHere) {
+      divergences.push({
+        capabilityId: id,
+        kind: "enabled-not-live-active",
+        liveState,
+        enabledInInstallState: true,
+      });
+    }
+  }
+
+  return {
+    diverged: divergences.length > 0,
+    divergences,
+    summary: describe(divergences),
+  };
+}
+
+/** True for the error `projectCapabilityServices` throws on drift. */
+export function isCapabilityStateStaleError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return (
+    message.startsWith("capability_state_stale:") ||
+    message === "install_capability_state_stale" ||
+    message === "install_catalog_stale"
+  );
+}

--- a/apps/web/lib/platform-runtime/operational-state.ts
+++ b/apps/web/lib/platform-runtime/operational-state.ts
@@ -9,6 +9,8 @@ import { prisma } from "@dpf/db";
 import { dockerSocketGet } from "./docker-socket.mjs";
 export { boundedDockerSocketGet } from "./docker-socket.mjs";
 
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
 import {
   diagnoseCapabilityStateDivergence,
   isCapabilityStateStaleError,
@@ -73,9 +75,7 @@ export function createOperationalCapabilityState(input: {
       enabledRuntimeCapabilities: input.installSnapshot.enabledRuntimeCapabilities,
       capabilityStates: input.capabilityStates,
     });
-    const enriched = new Error(
-      `${error instanceof Error ? error.message : String(error)} — ${report.summary}`,
-    );
+    const enriched = new Error(`${getErrorMessage(error)} — ${report.summary}`);
     // Keep the machine-readable report on the error so a caller that wants to
     // render the condition does not have to re-derive it from prose.
     (enriched as Error & { divergence?: unknown }).divergence = report;

--- a/apps/web/lib/platform-runtime/operational-state.ts
+++ b/apps/web/lib/platform-runtime/operational-state.ts
@@ -9,6 +9,11 @@ import { prisma } from "@dpf/db";
 import { dockerSocketGet } from "./docker-socket.mjs";
 export { boundedDockerSocketGet } from "./docker-socket.mjs";
 
+import {
+  diagnoseCapabilityStateDivergence,
+  isCapabilityStateStaleError,
+} from "./capability-state-divergence";
+
 export type OperationalServiceStatus = "required" | "optional_inactive" | "optional_degraded";
 export interface ObservedServiceState { composePresent: boolean; healthy: boolean | null }
 export interface ObservedProviderState {
@@ -47,10 +52,36 @@ export function createOperationalCapabilityState(input: {
   observedServices: Record<string, ObservedServiceState>;
   observedProviders: Record<string, ObservedProviderState>;
 }): OperationalCapabilityState {
-  const projection = projectCapabilityServices({
-    enabledRuntimeCapabilities: input.installSnapshot.enabledRuntimeCapabilities,
-    capabilityStates: input.capabilityStates,
-  });
+  // The projection fails closed on drift, and should: guessing which of the two
+  // authorities to believe would hand backup and readiness a topology neither
+  // source claims. But it names only the FIRST mismatch, and it throws inside
+  // the loader that the runtime-health and backup-readiness surfaces call — so
+  // the platform detected the condition and then lost it (BI-5ACBAC50).
+  //
+  // Re-raise with the full diagnosis attached: every drifted capability and the
+  // direction of each. Same failure, same fail-closed semantics, an error an
+  // operator can act on instead of one identifier out of six.
+  let projection;
+  try {
+    projection = projectCapabilityServices({
+      enabledRuntimeCapabilities: input.installSnapshot.enabledRuntimeCapabilities,
+      capabilityStates: input.capabilityStates,
+    });
+  } catch (error) {
+    if (!isCapabilityStateStaleError(error)) throw error;
+    const report = diagnoseCapabilityStateDivergence({
+      enabledRuntimeCapabilities: input.installSnapshot.enabledRuntimeCapabilities,
+      capabilityStates: input.capabilityStates,
+    });
+    const enriched = new Error(
+      `${error instanceof Error ? error.message : String(error)} — ${report.summary}`,
+    );
+    // Keep the machine-readable report on the error so a caller that wants to
+    // render the condition does not have to re-derive it from prose.
+    (enriched as Error & { divergence?: unknown }).divergence = report;
+    if (error instanceof Error) enriched.cause = error;
+    throw enriched;
+  }
   if (!/^[a-f0-9]{64}$/.test(input.installSnapshot.capabilityCatalogHash ?? "")) throw new Error("install_catalog_identity_invalid");
   if (!/^[a-f0-9]{64}$/.test(input.installSnapshot.capabilityStateVersion ?? "")) throw new Error("install_capability_state_identity_invalid");
   if (input.installSnapshot.capabilityCatalogHash !== projection.catalogHash) {

--- a/docs/architecture/capability-driven-runtime-profiles.md
+++ b/docs/architecture/capability-driven-runtime-profiles.md
@@ -121,6 +121,41 @@ The portal observes only containers in its own Docker Compose project. It discov
 
 Host diagnostics remain in installer-owned doctor and verification surfaces. They record the canonical Compose file chain, rendered configuration hash, container state, and redacted install state. Docker Engine itself is a host prerequisite and observation boundary, not a manifest service. Podman command aliases are rejected by installer preflight because the current contract requires standard Docker Engine.
 
+## Diagnosing capability drift (BI-5ACBAC50)
+
+Two authorities describe what is enabled: `enabledRuntimeCapabilities` in
+`install-state.json`, and `PlatformCapability.state` in the database. The
+transition protocol keeps them together — live state commits only after the
+signed host receipt proves the topology.
+
+When they disagree anyway, `projectCapabilityServices` throws
+`capability_state_stale:<capabilityId>` and refuses to project. That is
+deliberate: a projection that guessed which side to believe would hand backup,
+readiness and the health UI a topology neither source claims.
+
+The refusal used to name only the FIRST mismatch, and it happens inside the
+loader that runtime health and backup readiness call — so the surfaces that would
+explain the condition were the ones that could not render.
+`createOperationalCapabilityState` now re-raises that error with the full
+diagnosis from
+[`capability-state-divergence.ts`](../../apps/web/lib/platform-runtime/capability-state-divergence.ts):
+every drifted capability, and which way each drifted.
+
+- `live-active-not-enabled` — the database says on, the install snapshot does not
+  list it. Anything trusting capability state believes services are running that
+  the install never provisioned. This is the shape that let an installation
+  report `runtime:deep-observability` active while no collector existed, so every
+  metric-backed surface had no source and the state that would have revealed it
+  read healthy.
+- `enabled-not-live-active` — the install enabled it, the database says disabled.
+  The services may be running while the platform believes they are not, so
+  nothing tends them.
+- `missing-live-state` — no capability row at all.
+
+Reporting is not repair. The diagnosis says what diverged; it never decides which
+authority wins, because reconciling without first finding the writer that moved
+state outside the transition protocol leaves the cause in place.
+
 ## Safe operating rules
 
 - Change physical service facts in the substrate manifest and regenerate the catalog; do not hand-edit the generated catalog.

--- a/docs/architecture/platform-overview.md
+++ b/docs/architecture/platform-overview.md
@@ -403,7 +403,9 @@ flowchart TB
 
 ### Monitoring Stack Topology
 
-The **headless** monitoring stack (Prometheus, Loki, Alloy, and the metric exporters) runs as part of the default Docker Compose stack — these feed the platform's native UI and alert pipeline. The Grafana **UI** is opt-in (`--profile observability-ui`), since the platform renders its own context-aware dashboards and delivers alerts via the Inngest poll-bridge rather than through Grafana.
+The monitoring stack (Prometheus, Loki, Alloy, Grafana, and the metric exporters) is **capability-activated, not default**: every one of them sits behind the `runtime-deep-observability` Compose profile and starts only when the `runtime:deep-observability` capability is enabled. An installation that has not enabled it collects nothing, and the metric-backed surfaces have no source. Grafana is a further step again — the platform renders its own context-aware dashboards and delivers alerts via the Inngest poll-bridge rather than through Grafana, so the Grafana UI is for power users.
+
+⟦runtime: this paragraph previously claimed the headless stack "runs as part of the default Docker Compose stack". That was false against the Compose file and it made a real drift harder to spot — BI-5ACBAC50 found a live install whose capability state read `runtime:deep-observability: active` while no collector existed. Verify against `docker-compose.yml` profiles before restating it.⟧
 
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#1e293b', 'primaryTextColor': '#f8fafc', 'primaryBorderColor': '#334155', 'lineColor': '#64748b', 'secondaryColor': '#0f172a', 'tertiaryColor': '#1e293b', 'fontSize': '14px' }}}%%


### PR DESCRIPTION
My own backlog entry said the projection "absorbs" capability drift. Reading the code, that was **wrong**, and the truth is more useful.

`projectCapabilityServices` already detects it and throws `capability_state_stale:<id>`. Failing closed is correct — guessing which of the two authorities to believe would hand backup and readiness a topology neither source claims.

**The real defect is that the throw is anonymous.** It names ONE capability, and it happens *inside* the loader that runtime-health and backup-readiness call — so the surfaces that would explain the condition are exactly the ones that cannot render. The platform detects the drift and then loses it.

## The drift, on a live install

| Capability | `install-state.json` | Database | Running |
|---|---|---|---|
| `runtime:core` | enabled | active | yes |
| `runtime:build` | — | **active** | yes |
| `runtime:durable-automation` | — | **active** | yes |
| `runtime:deep-observability` | — | **active** | **nothing** |
| `runtime:browser-automation` | — | **active** | no |
| `runtime:local-speech` | — | **active** | no |
| `runtime:development` | — | disabled | **running** |

`runtime:deep-observability` reading `active` with no collector is why this matters: every metric-backed surface had no source, and the state that would have revealed it said everything was fine.

## What changed

A pure `diagnoseCapabilityStateDivergence` reports **every** drifted capability and the direction of each. `createOperationalCapabilityState` re-raises the stale error with that diagnosis attached — same failure, same fail-closed semantics, plus a machine-readable `divergence` on the error so a surface doesn't re-derive it from prose. The original identifier still leads the message, so existing matching keeps working.

The fixture is the live install **verbatim**, not invented. The first test asserts the *current* behaviour — the projection throws on those exact values — which is the verification I could not get from the running portal: the route redirects unauthenticated, and minting a session to read a health page is not a trade I'll make.

## The documentation half

`platform-overview.md` stated the headless monitoring stack "runs as part of the default Docker Compose stack". That is **false** against the Compose file — Prometheus, Loki, Alloy and the exporters all sit behind `runtime-deep-observability`.

The false half was load-bearing: it's why an install reporting `deep-observability: active` with no collector read as normal. Corrected, with a runtime marker telling the next reader to check the profiles before restating it.

## Deliberately not done here

- **Repairing this install's state.** A mutation to a live capability boundary.
- **Closing whichever writer moved `PlatformCapability.state` without a host receipt.** Same reason.

What lands here makes the condition legible. It does not silently reconcile it — and "whatever did that once will do it again" is precisely why reconciling without finding the writer would be the wrong move.

## Gates

- 15 divergence tests; **752 pass** across `lib/platform-runtime` and `lib/operate`.
- Production build compiles.
- module-size, style-drift, ActionResult ratchet, docs-impact, ux-fit, prose-lint, doc-links all pass locally.
- **UX verification not performed** — no user-facing surface changes; the error message and the diagnostic are the deliverable.

Backlog: `BI-5ACBAC50`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Docs-Impact-Decision: the one remaining linked page is `docs/maintenance/staleness-report.md`, which is machine-generated ("Generated by scripts/build-docs-staleness.mjs. Do not edit by hand — a weekly workflow regenerates it") and describes doc-drift candidates rather than platform behaviour. The doc that genuinely owns this code, `docs/architecture/capability-driven-runtime-profiles.md`, IS updated in this PR with the drift-diagnosis section, and `docs/architecture/platform-overview.md` has its false monitoring-stack claim corrected.
