### PR TITLE
fix(local-ci): a gate verdict must not quote a record from a previous run (BI-465B3D60)

### DIFF
--- a/scripts/lib/pregate-status.mjs
+++ b/scripts/lib/pregate-status.mjs
@@ -79,8 +79,20 @@ function rank(verdict) {
  */
 function describeFailure(state, metadata) {
   const status = state?.status || "unknown";
-  const stated = state?.failureReason || state?.error || metadata?.execution?.failedCommand;
+  // Never quote a metadata record that does not describe THIS run. The gate state
+  // is written by the wrapper and is always current; the metadata is written by
+  // the sandbox run and a failing run may never rewrite it. Serving the previous
+  // run's failedCommand as this run's cause is worse than admitting the cause was
+  // not recorded — a confident wrong answer is acted on, an honest absence is
+  // re-run. The gate state's own fields stay usable either way.
+  const metadataIsForThisRun = !metadataDescribesAnotherRun(state, metadata);
+  const stated = state?.failureReason
+    || state?.error
+    || (metadataIsForThisRun ? metadata?.execution?.failedCommand : null);
   if (stated) return `gate record status ${status} — ${typeof stated === "string" ? stated : "see the gate record"}`;
+  if (!metadataIsForThisRun) {
+    return `gate record status ${status} with NO recorded reason for THIS run — the metadata file on disk describes a previous run, so it is not evidence about this one. Re-run pregate; do not treat this as a verdict on the diff.`;
+  }
 
   const events = Array.isArray(state?.leaseEvents) ? state.leaseEvents : [];
   const started = events.some((e) => e?.type === "started");
@@ -105,8 +117,27 @@ function describeFailure(state, metadata) {
  * gave it away.
  *
  * Presence of the file was always checked. Freshness never was.
+ *
+ * The SHA comparison alone was not enough (BI-465B3D60, second recurrence).
+ * Re-running the gate on an UNCHANGED commit produces runs whose candidateSha is
+ * identical by construction, so the SHAs match and this returns false while the
+ * metadata still describes a previous run. Observed live: four runs on
+ * efeb0a5a6845, three recorded failed and one passed, and the failing verdicts
+ * quoted a failedCommand from a metadata file 53 minutes older than the gate
+ * record. That sent the reader chasing a cause the run's own artifacts had
+ * already falsified.
+ *
+ * The lease is per-run, so it is the identity that actually separates two runs
+ * on one commit. Prefer it; fall back to the SHA when either side predates the
+ * stamp (an older metadata file has no runLeaseId, and an ungoverned run has no
+ * lease at all) so this never reports a false mismatch on a record that simply
+ * cannot answer.
  */
 function metadataDescribesAnotherRun(state, metadata) {
+  const boundLease = String(state?.leaseId || "");
+  const metadataLease = String(metadata?.runLeaseId || "");
+  if (boundLease && metadataLease) return boundLease !== metadataLease;
+
   const boundSha = String(state?.sha || "");
   const candidateSha = String(metadata?.candidateSha || "");
   if (!boundSha || !candidateSha) return false;

--- a/scripts/lib/pregate-status.test.mjs
+++ b/scripts/lib/pregate-status.test.mjs
@@ -271,3 +271,93 @@ test("does not flag the metadata when it describes this run", () => {
   });
   assert.equal(out.staleness, "");
 });
+
+// BI-465B3D60, second recurrence. Four gate runs on ONE unchanged commit
+// (efeb0a5a6845 live): three recorded failed, one passed. Because every run had
+// the same candidateSha, the SHA comparison could not tell them apart, and the
+// failing verdicts quoted a failedCommand from a metadata file 53 minutes stale.
+// The lease is the per-run identity that separates them.
+const LEASE_THIS_RUN = "NPEL-D4D8BCC247";
+const LEASE_PRIOR_RUN = "NPEL-098CE6A455";
+
+test("a re-run on the SAME sha does not inherit the previous run's failedCommand", () => {
+  const out = classifySlotRecord({
+    state: {
+      sha: HEAD, branch: "feat/x", status: "failed", gatePassed: false,
+      leaseId: LEASE_THIS_RUN,
+      leaseEvents: [{ type: "started" }],
+    },
+    metadata: {
+      candidateSha: HEAD, // identical — this is the case the SHA check cannot see
+      runLeaseId: LEASE_PRIOR_RUN,
+      execution: { failedCommand: "node scripts/sandbox-freshness-preflight.mjs --converge" },
+    },
+    headSha: HEAD,
+    headBranch: "feat/x",
+    now: NOW,
+  });
+
+  assert.equal(out.verdict, "FAIL");
+  assert.equal(out.staleness, "metadata-describes-another-run");
+  assert.ok(
+    !out.reason.includes("sandbox-freshness-preflight"),
+    `must not quote the previous run's command; got: ${out.reason}`,
+  );
+  assert.match(out.reason, /previous run/);
+  assert.match(out.reason, /not.*verdict on the diff/);
+});
+
+test("a failedCommand from THIS run is still reported", () => {
+  const out = classifySlotRecord({
+    state: {
+      sha: HEAD, branch: "feat/x", status: "failed", gatePassed: false,
+      leaseId: LEASE_THIS_RUN,
+    },
+    metadata: {
+      candidateSha: HEAD,
+      runLeaseId: LEASE_THIS_RUN,
+      execution: { failedCommand: "pnpm --filter web build" },
+    },
+    headSha: HEAD,
+    headBranch: "feat/x",
+    now: NOW,
+  });
+
+  assert.equal(out.verdict, "FAIL");
+  assert.equal(out.staleness, "");
+  assert.match(out.reason, /pnpm --filter web build/);
+});
+
+test("an unstamped metadata record falls back to the sha check rather than crying mismatch", () => {
+  // Metadata written before runLeaseId existed, or by an ungoverned run. It has
+  // no lease to compare, so a lease-only rule would report every such record as
+  // another run's and suppress a cause that is in fact this run's.
+  const out = classifySlotRecord({
+    state: {
+      sha: HEAD, branch: "feat/x", status: "failed", gatePassed: false,
+      leaseId: LEASE_THIS_RUN,
+    },
+    metadata: { candidateSha: HEAD, execution: { failedCommand: "pnpm --filter web build" } },
+    headSha: HEAD,
+    headBranch: "feat/x",
+    now: NOW,
+  });
+
+  assert.equal(out.staleness, "");
+  assert.match(out.reason, /pnpm --filter web build/);
+});
+
+test("the state's own failureReason outranks metadata either way", () => {
+  const out = classifySlotRecord({
+    state: {
+      sha: HEAD, branch: "feat/x", status: "failed", gatePassed: false,
+      leaseId: LEASE_THIS_RUN, failureReason: "typecheck failed",
+    },
+    metadata: { candidateSha: HEAD, runLeaseId: LEASE_PRIOR_RUN, execution: { failedCommand: "stale" } },
+    headSha: HEAD,
+    headBranch: "feat/x",
+    now: NOW,
+  });
+
+  assert.match(out.reason, /typecheck failed/);
+});

--- a/scripts/local-integration-ci.mjs
+++ b/scripts/local-integration-ci.mjs
@@ -159,6 +159,13 @@ if (metadataOut) {
     commands: plan.commands.map((command) => command.join(" ")),
     startedAt,
     completedAt: new Date().toISOString(),
+    // BI-465B3D60 — the RUN's identity, not the commit's. Re-running the gate on
+    // an unchanged SHA produces several runs whose candidateSha is identical, so
+    // a SHA cannot tell them apart; a reader comparing SHAs concludes this
+    // metadata describes the current run when it describes a previous one. The
+    // lease is per-run, so it is the thing that actually distinguishes them.
+    // Null when the runner is invoked outside a governed lease.
+    runLeaseId: process.env.DPF_NONPROD_LEASE_ID || null,
   };
   writeFileSync(metadataOut, `${JSON.stringify(payload, null, 2)}\n`);
   const artifactOut = process.env.DPF_LOCAL_CI_ARTIFACT_FILE;


### PR DESCRIPTION
## The guard existed and could not see the case

`metadataDescribesAnotherRun` already checked freshness — by comparing `state.sha` to `metadata.candidateSha`. Re-running the gate on an **unchanged commit** produces runs whose `candidateSha` is identical by construction. The SHAs matched, the guard returned false, and `describeFailure` fell straight through to `metadata.execution.failedCommand`.

Worse: even when the helper *did* fire, it only set a display field. It never gated the quote.

## What that looked like live

Four `pregate` runs on `efeb0a5a6845`, **no code change between them**. Three recorded `failed`, the fourth passed.

The failing verdicts said:

```
reason  gate record status failed — node scripts/sandbox-freshness-preflight.mjs --converge ...
```

While that same run's own `dpf-sandbox-freshness.json` said `verdict: green`, `actualBranch == requestedBranch`. The freshness step had passed. The quoted command came from a metadata file whose mtime was **53 minutes older** than the gate record — the run never rewrote it.

It cost this thread several investigation rounds chasing a sandbox-drift theory that the run's own artifacts had already falsified. The same defect cost time once before; that is what BI-465B3D60 was filed for, and why it now carries `occurrenceCount: 2`.

## The actual mistake

**Run identity was being approximated by commit identity.** A SHA cannot tell four runs on one commit apart. The lease can — it is issued per run, and `gate-worktree.mjs` was already putting it in the child's environment as `DPF_NONPROD_LEASE_ID`. Nothing new needed to be invented; the identity was already there and simply never written down.

## Changes

- **`local-integration-ci.mjs`** stamps `runLeaseId` into the metadata payload. Null when the runner is invoked outside a governed lease.
- **`metadataDescribesAnotherRun`** prefers the lease, and falls back to the SHA when either side lacks a stamp — an older metadata file has no `runLeaseId` and an ungoverned run has no lease, and neither should be reported as a false mismatch on a record that simply cannot answer.
- **`describeFailure`** no longer reads metadata that does not describe this run. It states that the cause was not recorded for THIS run and that the file on disk belongs to a previous one.

An honest absence gets re-run. A confident wrong answer gets acted on.

Unchanged: the state's own `failureReason` / `error` still outrank metadata, and a `failedCommand` from **this** run is reported exactly as before.

## Verification

Four regression tests, including the exact same-SHA case the old comparison could not see. **Proven to fail without the fix** — 24/25 with the guard reverted, 25/25 with it in place. (My first attempt to prove this used a grep that could not match `node --test`'s output format and reported a clean run having verified nothing; redone with the summary counts.)

Confirmed on this PR's own gate run rather than only in unit tests:

```
metadata.runLeaseId : NPEL-A4CDF64A6F
state.leaseId       : NPEL-A4CDF64A6F
bound to same run   : True
```

- local-CI gate **PASS** on `71f1c32457f6`, first run, full suite
- preflight **52 guards clean**
- `pregate-status` 25 tests · `pregate-exit-honesty` + `local-integration-ci` 35 tests

## Worth pressing on

1. **This is the reader, not the cause.** A run whose tests and production build both succeed still records `failed`, and this PR does not explain why — it stops the reader lying about it. The lead is `interruptedByQuiescence: true` on an earlier attempt, which points at BI-F22B4EEE (in flight). I did not assert that, because the record still does not preserve enough to distinguish an interrupted run from a failed one after the fact.
2. **`runLeaseId` is null outside a lease.** Those runs keep the old SHA-only behaviour, so the same-SHA blind spot persists for them. Acceptable — ungoverned runs are not the path that produces contributor-facing verdicts — but it is a real gap, not a rounding error.
3. **The failure summary still prints as `! [object Object]`** on every failing run. That is WC-F7B4CDC3, untouched here, and it is the other half of why a failing gate cannot be read.

Addresses BI-465B3D60 proposal 3, which the item flags as fixable independently of the root cause.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)