### PR TITLE
feat(code-graph): index the default branch, not whatever the host checkout sits on (BI-86EF5900)

### DIFF
--- a/apps/web/lib/build/code-graph/default-branch-source.test.ts
+++ b/apps/web/lib/build/code-graph/default-branch-source.test.ts
@@ -1,0 +1,123 @@
+// BI-86EF5900 acceptance 1: "The index is built from the default branch, and
+// lastIndexedBranch proves it."
+//
+// Live evidence for why: the graph was fully healthy (47,544 nodes, 56,593
+// edges) and still answered "no" for MileageRate, because PROJECT_ROOT is
+// /sandbox-workspace parked on client/5727856b-… — a Build Studio sandbox
+// branch that genuinely lacks the model.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execMock } = vi.hoisted(() => ({ execMock: vi.fn() }));
+
+vi.mock("@/lib/shared/lazy-node", () => ({
+  lazyExec: () => execMock,
+  lazyPath: () => ({ resolve: (...p: string[]) => p.join("/") }),
+  getCwd: () => "/cwd",
+}));
+
+import {
+  CODE_GRAPH_WORKTREE_DIRNAME,
+  resolveDefaultBranchRef,
+  resolveIndexSource,
+} from "./default-branch-source";
+
+const ok = (stdout: string) => ({ stdout, stderr: "" });
+const SHA = "0ad91e688c2f5f3a4512d11ce0a845c4aa63d9ca";
+
+beforeEach(() => execMock.mockReset());
+
+describe("resolveDefaultBranchRef", () => {
+  it("prefers origin/main and reports the branch label without the remote", async () => {
+    execMock.mockResolvedValueOnce(ok(`${SHA}\n`));
+    expect(await resolveDefaultBranchRef("/repo")).toEqual({
+      ref: "origin/main",
+      branch: "main",
+      sha: SHA,
+    });
+  });
+
+  it("falls through the candidate list when origin/main is absent", async () => {
+    execMock
+      .mockRejectedValueOnce(new Error("unknown revision"))   // origin/main
+      .mockRejectedValueOnce(new Error("unknown revision"))   // origin/master
+      .mockResolvedValueOnce(ok(`${SHA}\n`));                 // main
+    const r = await resolveDefaultBranchRef("/repo");
+    expect(r?.ref).toBe("main");
+    expect(r?.branch).toBe("main");
+  });
+
+  it("returns null when no default branch exists at all", async () => {
+    // Empty stdout is the same "no such ref" signal as a throw, without
+    // manufacturing rejected promises the runner reports as unhandled.
+    execMock.mockResolvedValue(ok(""));
+    expect(await resolveDefaultBranchRef("/repo")).toBeNull();
+  });
+
+  it("scopes safe.directory so container ownership cannot block resolution", async () => {
+    execMock.mockResolvedValueOnce(ok(`${SHA}\n`));
+    await resolveDefaultBranchRef("/sandbox-workspace");
+    expect(String(execMock.mock.calls[0]?.[0])).toContain('-c safe.directory="/sandbox-workspace"');
+  });
+});
+
+describe("resolveIndexSource", () => {
+  it("indexes the pinned default-branch worktree and records that branch", async () => {
+    execMock
+      .mockResolvedValueOnce(ok(`${SHA}\n`))   // rev-parse origin/main
+      .mockResolvedValueOnce(ok(`${SHA}\n`));  // rev-parse HEAD in the worktree — already pinned
+
+    const src = await resolveIndexSource("/sandbox-workspace");
+
+    expect(src.usedDefaultBranch).toBe(true);
+    expect(src.root).toBe(`/sandbox-workspace/${CODE_GRAPH_WORKTREE_DIRNAME}`);
+    expect(src.branch).toBe("main");
+    expect(src.sha).toBe(SHA);
+    expect(src.warning).toBeNull();
+  });
+
+  it("creates the worktree when none exists yet", async () => {
+    execMock
+      .mockResolvedValueOnce(ok(`${SHA}\n`))                        // rev-parse origin/main
+      .mockRejectedValueOnce(new Error("not a git repository"))     // no worktree yet
+      .mockResolvedValueOnce(ok("Preparing worktree\n"));           // worktree add
+
+    const src = await resolveIndexSource("/sandbox-workspace");
+
+    expect(src.usedDefaultBranch).toBe(true);
+    expect(String(execMock.mock.calls[2]?.[0])).toContain("worktree add --detach --force");
+  });
+
+  it("fast-forwards a worktree parked on an older sha", async () => {
+    execMock
+      .mockResolvedValueOnce(ok(`${SHA}\n`))     // origin/main
+      .mockResolvedValueOnce(ok("olddeadbeef\n")) // worktree HEAD differs
+      .mockResolvedValueOnce(ok("HEAD is now at\n"));
+
+    const src = await resolveIndexSource("/sandbox-workspace");
+    expect(src.usedDefaultBranch).toBe(true);
+    expect(String(execMock.mock.calls[2]?.[0])).toContain(`reset --hard ${SHA}`);
+  });
+
+  // Degrading to the host tree must stay possible AND explained — a graph that
+  // silently indexes the wrong branch is the defect, not the fallback.
+  it("falls back to the host tree WITH a reason when the worktree cannot be prepared", async () => {
+    execMock
+      .mockResolvedValueOnce(ok(`${SHA}\n`))                    // origin/main
+      .mockRejectedValueOnce(new Error("not a git repository")) // no worktree
+      .mockRejectedValueOnce(new Error("fatal: cannot add"))    // add fails
+      .mockRejectedValueOnce(new Error("nope"));                // worktree list
+
+    const src = await resolveIndexSource("/sandbox-workspace");
+
+    expect(src.usedDefaultBranch).toBe(false);
+    expect(src.root).toBe("/sandbox-workspace");
+    expect(src.warning).toContain("Could not prepare the default-branch worktree");
+  });
+
+  it("falls back with a reason when the repo has no default branch", async () => {
+    execMock.mockResolvedValue(ok(""));
+    const src = await resolveIndexSource("/repo");
+    expect(src.usedDefaultBranch).toBe(false);
+    expect(src.warning).toContain("No default branch");
+  });
+});

--- a/apps/web/lib/build/code-graph/default-branch-source.ts
+++ b/apps/web/lib/build/code-graph/default-branch-source.ts
@@ -1,0 +1,175 @@
+// Index the DEFAULT BRANCH, not whatever the host checkout happens to be on.
+//
+// BI-86EF5900 acceptance criterion 1: "The index is built from the default
+// branch, and lastIndexedBranch proves it."
+//
+// The indexer read `PROJECT_ROOT`'s working tree directly, so the graph
+// described whichever branch that checkout sat on. On the live install
+// PROJECT_ROOT is /sandbox-workspace — a Build Studio sandbox parked on
+// `client/5727856b-…` — so a fully healthy graph (47,544 nodes, 56,593 edges)
+// still answered "no" for MileageRate, a model that is on main. The graph
+// exists to answer "what breaks if I change this" against the MERGE TARGET;
+// pointing it at a sandbox branch makes every answer quietly off-target.
+//
+// Rather than repoint PROJECT_ROOT — which is also read by
+// describe_committed_model, read_project_file and other consumers, so moving it
+// changes what they all see — this resolves the default-branch ref and checks
+// it out into a dedicated linked worktree that only the indexer uses. The whole
+// existing read path (listTrackedFiles, readFile, the extractors) is reused
+// unchanged against that path. Kernel decision DI-B0BE15B52C46.
+
+import { lazyExec, lazyPath } from "@/lib/shared/lazy-node";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+const exec = lazyExec();
+
+/** Preference order for "the tree everyone merges into". */
+const DEFAULT_BRANCH_CANDIDATES = ["origin/main", "origin/master", "main", "master"] as const;
+
+/** Directory name of the indexer-owned worktree, kept beside the host checkout. */
+export const CODE_GRAPH_WORKTREE_DIRNAME = ".dpf-code-graph-default-branch";
+
+function gitIn(root: string, args: string): string {
+  return `git -c safe.directory=${JSON.stringify(root)} ${args}`;
+}
+
+async function tryGit(root: string, args: string, timeout = 20_000): Promise<string | null> {
+  try {
+    const { stdout } = await exec(gitIn(root, args), { cwd: root, timeout });
+    const trimmed = stdout.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+export type DefaultBranchRef = {
+  /** Ref that resolved, e.g. "origin/main". */
+  ref: string;
+  /** Branch label to record, e.g. "main" — what lastIndexedBranch should say. */
+  branch: string;
+  /** Commit the ref points at. */
+  sha: string;
+};
+
+/**
+ * Resolve the default-branch ref inside `gitRoot`. Returns null when none of
+ * the candidates exist — a repository with no main/master is a legitimate
+ * state, and the caller falls back to the working tree rather than failing.
+ */
+export async function resolveDefaultBranchRef(gitRoot: string): Promise<DefaultBranchRef | null> {
+  for (const ref of DEFAULT_BRANCH_CANDIDATES) {
+    const sha = await tryGit(gitRoot, `rev-parse --verify ${ref}`);
+    if (sha) {
+      return { ref, branch: ref.replace(/^origin\//, ""), sha };
+    }
+  }
+  return null;
+}
+
+export type DefaultBranchWorktree = {
+  path: string;
+  branch: string;
+  sha: string;
+};
+
+/**
+ * Ensure a linked worktree pinned at `target.sha`, and return its path.
+ *
+ * Created once and then fast-forwarded in place — a fresh checkout of ~13k
+ * files every 15 minutes would be wasteful, and `reset --hard` to an already
+ * matching sha is a no-op. Returns null when the worktree cannot be prepared;
+ * the caller then indexes the working tree and records THAT branch, so a
+ * failure here degrades to the previous behaviour rather than to no graph.
+ */
+export async function ensureDefaultBranchWorktree(
+  gitRoot: string,
+  target: DefaultBranchRef,
+): Promise<{ worktree: DefaultBranchWorktree | null; warning: string | null }> {
+  const { resolve } = lazyPath();
+  const path = resolve(gitRoot, CODE_GRAPH_WORKTREE_DIRNAME);
+
+  const head = await tryGit(path, "rev-parse HEAD", 10_000);
+  if (head === null) {
+    // No usable worktree yet. --force tolerates a stale registration left by a
+    // killed run; a detached checkout keeps it off the branch namespace so it
+    // can never be confused for someone's working branch.
+    const added = await tryGit(
+      gitRoot,
+      `worktree add --detach --force ${JSON.stringify(path)} ${target.sha}`,
+      120_000,
+    );
+    if (added === null) {
+      const detail = await tryGit(gitRoot, "worktree list", 10_000);
+      return {
+        worktree: null,
+        warning:
+          `Could not prepare the default-branch worktree at ${path}; indexing the host working tree instead. ` +
+          `Existing worktrees: ${detail ?? "(unreadable)"}`,
+      };
+    }
+    return { worktree: { path, branch: target.branch, sha: target.sha }, warning: null };
+  }
+
+  if (head === target.sha) {
+    return { worktree: { path, branch: target.branch, sha: target.sha }, warning: null };
+  }
+
+  const reset = await tryGit(path, `reset --hard ${target.sha}`, 120_000);
+  if (reset === null) {
+    return {
+      worktree: null,
+      warning:
+        `Default-branch worktree at ${path} is on ${head} and could not be moved to ${target.sha}; ` +
+        "indexing the host working tree instead.",
+    };
+  }
+  return { worktree: { path, branch: target.branch, sha: target.sha }, warning: null };
+}
+
+/**
+ * Full resolution: which path should the indexer read, and what branch/sha
+ * should it record? Falls back to the host working tree, with a warning, so a
+ * default-branch problem never costs the graph entirely.
+ */
+export async function resolveIndexSource(gitRoot: string): Promise<{
+  root: string;
+  branch: string | null;
+  sha: string | null;
+  usedDefaultBranch: boolean;
+  warning: string | null;
+}> {
+  try {
+    const target = await resolveDefaultBranchRef(gitRoot);
+    if (!target) {
+      return {
+        root: gitRoot,
+        branch: null,
+        sha: null,
+        usedDefaultBranch: false,
+        warning:
+          "No default branch (origin/main, origin/master, main, master) resolved in this repository; " +
+          "indexed the host working tree, so the graph describes whatever it is checked out on.",
+      };
+    }
+    const { worktree, warning } = await ensureDefaultBranchWorktree(gitRoot, target);
+    if (!worktree) {
+      return { root: gitRoot, branch: null, sha: null, usedDefaultBranch: false, warning };
+    }
+    return {
+      root: worktree.path,
+      branch: worktree.branch,
+      sha: worktree.sha,
+      usedDefaultBranch: true,
+      warning: null,
+    };
+  } catch (error) {
+    return {
+      root: gitRoot,
+      branch: null,
+      sha: null,
+      usedDefaultBranch: false,
+      warning: `Default-branch resolution failed (${getErrorMessage(error)}); indexed the host working tree.`,
+    };
+  }
+}

--- a/apps/web/lib/build/code-graph/reconcile.ts
+++ b/apps/web/lib/build/code-graph/reconcile.ts
@@ -4,12 +4,13 @@ import { CODE_GRAPH_GRAPH_KEY, CODE_GRAPH_PROJECTION_VERSION } from "./constants
 import {
   getChangedFiles,
   getCurrentBranch,
-  inspectGitRoot,
   getCurrentHeadSha,
   getGitRoot,
+  inspectGitRoot,
   isWorkspaceDirty,
   listTrackedFiles,
 } from "./git-snapshot";
+import { resolveIndexSource } from "./default-branch-source";
 import {
   clearCodeGraph,
   ensureCodeGraphNeo4jSchema,
@@ -162,16 +163,34 @@ export async function reconcileCodeGraph(input: ReconcileCodeGraphInput): Promis
     };
   }
 
+  // The graph must describe the MERGE TARGET, not whatever this host checkout
+  // is parked on (BI-86EF5900 acceptance 1). resolveIndexSource pins a
+  // dedicated worktree at the default branch and returns its path; on failure
+  // it returns the host root with a warning, so a default-branch problem
+  // degrades to the previous behaviour rather than to no graph at all.
+  const indexSource = await resolveIndexSource(gitRoot);
+  const readRoot = indexSource.root;
+  if (indexSource.warning) {
+    // Say WHY we fell back. The branch recorded below already makes an
+    // off-default index visible in the trust vector, but "which branch" is not
+    // "why not the default one", and losing the reason is how a degraded
+    // instrument becomes an unexplained one.
+    console.warn(`[code-graph] ${indexSource.warning}`);
+  }
+
   try {
     [state, headSha, branch, workspaceDirty] = await Promise.all([
       findCodeGraphIndexState(graphKey),
-      getCurrentHeadSha(gitRoot),
-      getCurrentBranch(gitRoot),
-      isWorkspaceDirty(gitRoot),
+      indexSource.sha ? Promise.resolve(indexSource.sha) : getCurrentHeadSha(readRoot),
+      indexSource.branch ? Promise.resolve(indexSource.branch) : getCurrentBranch(readRoot),
+      // A pinned default-branch worktree is checked out by us and is never
+      // "dirty" in the sense the caller cares about — that flag is about
+      // someone's uncommitted edits in the host tree.
+      indexSource.usedDefaultBranch ? Promise.resolve(false) : isWorkspaceDirty(readRoot),
     ]);
 
     await markCodeGraphIndexing(graphKey, {
-      workspaceRoot: gitRoot,
+      workspaceRoot: readRoot,
       headSha,
       branch,
       previousHeadSha: state?.lastIndexedHeadSha ?? null,
@@ -183,7 +202,7 @@ export async function reconcileCodeGraph(input: ReconcileCodeGraphInput): Promis
     let diffFailed = false;
     if (state?.lastIndexedHeadSha && headSha && state.lastIndexedHeadSha !== headSha && !input.forceFull) {
       try {
-        changedFiles = await getChangedFiles(gitRoot, state.lastIndexedHeadSha, headSha);
+        changedFiles = await getChangedFiles(readRoot, state.lastIndexedHeadSha, headSha);
       } catch {
         diffFailed = true;
       }
@@ -200,21 +219,21 @@ export async function reconcileCodeGraph(input: ReconcileCodeGraphInput): Promis
     });
 
     const files = orderCodeGraphFilesForProjection(
-      plan.mode === "full" ? await listTrackedFiles(gitRoot) : plan.changedFiles,
+      plan.mode === "full" ? await listTrackedFiles(readRoot) : plan.changedFiles,
     );
     await ensureCodeGraphNeo4jSchema();
     if (plan.mode === "full") {
       await clearCodeGraph(graphKey);
       await clearCodeGraphFileHashes(graphKey);
-      await syncTrackedFilesFull(graphKey, gitRoot, files);
+      await syncTrackedFilesFull(graphKey, readRoot, files);
     } else {
       for (const filePath of files) {
-        await syncTrackedFile(graphKey, gitRoot, filePath);
+        await syncTrackedFile(graphKey, readRoot, filePath);
       }
     }
     const indexedFileCount = await countCodeGraphFileHashes(graphKey);
     await markCodeGraphReady(graphKey, {
-      workspaceRoot: gitRoot,
+      workspaceRoot: readRoot,
       headSha,
       branch,
       workspaceDirty,


### PR DESCRIPTION
The last outstanding acceptance criterion of BI-86EF5900:

> "The index is built from the default branch, and `lastIndexedBranch` proves it."

## Why this is still open after #4655

After the dubious-ownership fix, the graph became genuinely healthy — **47,544 nodes, 56,593 edges, 4/5 relationship types** — and *still* answered "no" for `MileageRate`, a model that is on `main`.

Because the indexer reads `PROJECT_ROOT`'s working tree, and on the live install that is `/sandbox-workspace`: a Build Studio sandbox parked on `client/5727856b-3296-4e17-97f0-c59401ace4f2`. Every answer was correct about a tree nobody merges into.

The graph exists to answer *"what breaks if I change this"* against the **merge target**. Pointing it at a sandbox branch makes it quietly off-target rather than obviously wrong — the worse failure of the two.

## Why not just repoint PROJECT_ROOT

Kernel decision `DI-B0BE15B52C46` scored indexing the default branch in code far above repointing the env var — composite **11.19 vs 2.60**, margin 8.59, high confidence, no commandment conflict.

`PROJECT_ROOT` is also read by `describe_committed_model`, `read_project_file` and other consumers, so moving it changes what they *all* see. That is a large blast radius on a production install to fix one consumer — and it fixes one install rather than the product.

## How

`resolveIndexSource` resolves the default-branch ref (`origin/main` → `origin/master` → `main` → `master`) and checks it out into a dedicated linked worktree used only by the indexer. Created once, then fast-forwarded in place — a fresh 13k-file checkout every 15 minutes would be waste, and `reset --hard` to an already-matching sha is a no-op.

The entire existing read path (`listTrackedFiles`, the extractors, the projection) is reused unchanged against that path. This adds a **source resolver**, not a second way to read a tree.

## Degrades, never dies

If no default branch resolves, or the worktree cannot be prepared, it returns the host root and indexes that — the previous behaviour — **and logs why**.

The recorded branch already makes an off-default index visible in the trust vector. But *"which branch"* is not *"why not the default one"*, and dropping the reason is how a degraded instrument becomes an unexplained one.

## Verification

- **79 tests pass across 14 code-graph files.** 9 new cases cover ref preference and fallthrough, worktree creation, fast-forward of a stale worktree, the scoped `safe.directory` flag, and **both** degrade paths asserting the reason is carried.
- The 70 pre-existing tests pass unchanged — they exercise the fallback, which is itself the proof that the degrade path preserves old behaviour.
- Full suite: **25,444 tests passed**.
- `pnpm --filter web build`: clean.
- `pregate:preflight`: 52 guards clean.
- exact-tree local CI gate: **PASS** (evidence `cmt9pxsj502tv01pqwsvzeaof`).

## After deploy

The next 15-minute reconcile rebuilds from `main`, `lastIndexedBranch` says `main`, and `search_code_graph("MileageRate")` returns the model. No configuration change and no operator action required.

Closes the final acceptance criterion of BI-86EF5900.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
