### PR TITLE
fix(build-studio): keep the model's output when local ideate cannot be parsed (BI-7AD0759A)

### DIFF
--- a/apps/web/lib/build/ideate-on-approval.ts
+++ b/apps/web/lib/build/ideate-on-approval.ts
@@ -81,6 +81,25 @@ export async function dispatchIdeateForApprovedBuild(params: {
     });
   };
 
+  /**
+   * BI-7AD0759A — keep a bounded excerpt of what the model actually said when its
+   * output could not be parsed into a design document.
+   *
+   * Head AND tail are retained: a truncated or unterminated object shows its
+   * shape at both ends, and the tail is usually where it died. An empty response
+   * is recorded as such, because "the model returned nothing" is a different
+   * diagnosis from "the model returned prose".
+   */
+  const recordIdeateOutputExcerpt = async (rawOutput: string | undefined): Promise<void> => {
+    const { describeIdeateOutput } = await import("./ideate-output-excerpt");
+    const summary = describeIdeateOutput(rawOutput);
+    await prisma.buildActivity.create({
+      data: { buildId, tool: "ideate_output_excerpt", summary },
+    }).catch((err) => {
+      console.warn("[ideate-on-approval] Failed to log ideate_output_excerpt:", { buildId }, err);
+    });
+  };
+
   /** BI-CE1AB982 — durable "refused before start" marker read by progress-visibility. */
   const recordDispatchBlocked = async (reason: string): Promise<void> => {
     await prisma.buildActivity.create({
@@ -343,6 +362,11 @@ export async function dispatchIdeateForApprovedBuild(params: {
         durationMs,
       };
       await logActivity(`Auto-dispatch failed after ${(durationMs / 1000).toFixed(1)}s: ${outcome.error.slice(0, 200)}`);
+      // BI-7AD0759A: the model's output is the ONLY thing that explains why it
+      // could not be parsed, and it was being dropped on the floor here — on a
+      // local-only install that leaves the operator a four-minute wait and a
+      // fixed sentence. Keep a bounded excerpt as evidence.
+      await recordIdeateOutputExcerpt(ideateResult.rawOutput);
       return outcome;
     }
     if (executionProfileRef) {

--- a/apps/web/lib/build/ideate-output-excerpt.test.ts
+++ b/apps/web/lib/build/ideate-output-excerpt.test.ts
@@ -1,0 +1,59 @@
+// apps/web/lib/build/ideate-output-excerpt.test.ts
+//
+// BI-7AD0759A — a local ideate run that cannot be parsed must keep what the
+// model actually said. Live repro FB-D23311A7: the local model ran twice for
+// ~4 minutes each, failed to parse, and its output was discarded — leaving a
+// local-only install with no way to see why its build would not complete.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  describeIdeateOutput,
+  excerptHeadAndTail,
+  IDEATE_EXCERPT_BUDGET,
+} from "./ideate-output-excerpt";
+
+describe("excerptHeadAndTail", () => {
+  it("returns short output whole", () => {
+    const text = '{"problemStatement":"foster roster"}';
+    expect(excerptHeadAndTail(text)).toBe(text);
+  });
+
+  it("keeps BOTH ends, because a malformed object usually dies at the tail", () => {
+    const out = excerptHeadAndTail("H".repeat(2000) + "T".repeat(2000));
+
+    expect(out.startsWith("H")).toBe(true);
+    expect(out.endsWith("T")).toBe(true);
+    expect(out).toContain("chars elided");
+  });
+
+  it("names how much was elided so an excerpt is never mistaken for the whole response", () => {
+    expect(excerptHeadAndTail("x".repeat(IDEATE_EXCERPT_BUDGET + 500)))
+      .toContain("[500 chars elided]");
+  });
+
+  it("stays within budget plus the elision marker", () => {
+    expect(excerptHeadAndTail("y".repeat(50_000)).length)
+      .toBeLessThan(IDEATE_EXCERPT_BUDGET + 100);
+  });
+
+  it("honours a caller-supplied budget", () => {
+    expect(excerptHeadAndTail("z".repeat(400), 100).length).toBeLessThan(200);
+  });
+});
+
+describe("describeIdeateOutput", () => {
+  it("reports an empty response as its own diagnosis", () => {
+    expect(describeIdeateOutput("")).toContain("no output at all");
+    expect(describeIdeateOutput(undefined)).toContain("no output at all");
+    expect(describeIdeateOutput("   ")).toContain("no output at all");
+  });
+
+  it("reports the length and the content when the model did answer", () => {
+    const out = describeIdeateOutput("Here is a design, not JSON.");
+
+    expect(out).toContain("27 chars");
+    expect(out).toContain("Here is a design, not JSON.");
+    expect(out).not.toContain("no output at all");
+  });
+});

--- a/apps/web/lib/build/ideate-output-excerpt.ts
+++ b/apps/web/lib/build/ideate-output-excerpt.ts
@@ -1,0 +1,46 @@
+// apps/web/lib/build/ideate-output-excerpt.ts
+//
+// BI-7AD0759A — keep what the model actually said when a local ideate run
+// cannot be parsed into a design document.
+//
+// Live repro FB-D23311A7 on the Pet Rescue install: with routing fixed the
+// local model genuinely ran, twice, for about four minutes each — and both
+// times `dispatchIdeateResearch` returned `rawOutput` that `ideate-on-approval`
+// never referenced. The operator was left with a four-minute wait and the fixed
+// sentence "Routed ideate output could not be parsed into a design document."
+// On a local-only install that is the whole story they get.
+//
+// Pure module — no Prisma, no I/O — so the excerpt rule is unit-testable
+// without the database, and so importing it cannot drag the DB client into a
+// test's module graph.
+
+/** Max characters of model output kept as evidence, split across head and tail. */
+export const IDEATE_EXCERPT_BUDGET = 1200;
+
+/**
+ * Bounded excerpt that keeps BOTH ends of the output.
+ *
+ * Truncating only the head hides exactly the place a malformed JSON object
+ * usually fails. Short output is returned whole; longer output keeps the first
+ * and last halves of the budget with a marker naming how much was elided, so an
+ * excerpt can never be mistaken for the complete response.
+ */
+export function excerptHeadAndTail(text: string, budget = IDEATE_EXCERPT_BUDGET): string {
+  if (text.length <= budget) return text;
+  const half = Math.floor(budget / 2);
+  const elided = text.length - budget;
+  return `${text.slice(0, half)}\n… [${elided} chars elided] …\n${text.slice(-half)}`;
+}
+
+/**
+ * The activity summary for a failed parse.
+ *
+ * An empty response is reported as such: "the model returned nothing" is a
+ * different diagnosis from "the model returned prose", and collapsing the two
+ * is how this failure stayed opaque.
+ */
+export function describeIdeateOutput(rawOutput: string | undefined | null): string {
+  const text = (rawOutput ?? "").trim();
+  if (text.length === 0) return "Ideate output excerpt: the model returned no output at all.";
+  return `Ideate output excerpt (${text.length} chars): ${excerptHeadAndTail(text)}`;
+}


### PR DESCRIPTION
## Problem

With routing fixed ([#4701](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4701)) the local model is reachable and ideate genuinely runs on it. It then fails — and the platform throws away the one artifact that explains why.

Live repro `FB-D23311A7` on the Pet Rescue install, minutes after upgrading to `v2026.08.26-consumer-self-upgrade.1`:

```
06:19:47  ideate_dispatch  engine selection: opencode (provider=local)
06:19:47  ideate_dispatch  Dispatching ideate research via opencode
06:22:45  ideate_dispatch  Auto-dispatch failed after 242.2s: Routed ideate output
                           could not be parsed into a design document.
06:23:39  ideate_dispatch  Auto-dispatch failed after 231.8s: (same)
```

`parseDesignDoc` does no schema validation — it pulls a JSON object from a fenced block or between the first `{` and last `}`, with a repair pass. So that message means **no parseable JSON object at all**, across both attempts including the reformat retry.

`dispatchIdeateResearch` returns `rawOutput` alongside the failure. `ideate-on-approval.ts` never referenced it. Nothing persisted, nothing logged. On a local-only install the operator gets a four-minute wait and a fixed sentence.

**The model is not incapable of it.** Queried directly at `http://model-runner.docker.internal/v1` with the same system prompt and a short instruction, `qwen3.8-27b` returned clean valid JSON first time (and a separate `reasoning_content` channel the chat adapter already handles). The failure is specific to the full research prompt — and could not be investigated, because the evidence was deleted on the way out.

## Change

- A failed parse records a bounded excerpt of the raw output as a `BuildActivity` row.
- **Head *and* tail are kept.** A truncated or unterminated object usually dies at the tail, so head-only truncation hides the failure. The marker names how much was elided, so an excerpt can never be mistaken for the whole response.
- **An empty response is its own diagnosis.** "The model returned nothing" is not the same finding as "the model returned prose"; collapsing them is how this stayed opaque.
- The excerpt rule lives in its own **pure module** — no Prisma, no I/O — so it is unit-testable without a database and importing it cannot drag the DB client into a test's module graph.

This preserves the evidence. It does **not** fix the underlying parse failure, which needs that evidence first — `BI-7AD0759A` carries the remainder.

## Verification

- `lib/build` + `components/build` + `lib/actions/build-governed`: **239 files / 2588 tests pass**; 7 new tests for the excerpt rule.
- `tsc --noEmit` 0 errors; guard loop 37/37; module-size, style-drift, docs-impact, spec/plan/doc, design-grounding clean.
- Runtime UX verification not performed — not deployed to the live install (`/ops/self-upgrade` owns that).

Refs: BI-7AD0759A, WC-F552840E