### PR TITLE
feat(identity): make service accounts a Principal subtype with a refusable owner (BI-3181909E)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/browser-sessions/actions.ts
+++ b/apps/web/app/(shell)/platform/ai/browser-sessions/actions.ts
@@ -76,6 +76,8 @@ export async function beginServiceAccountSetupAction(input: {
       siteKey,
       accountKey,
       displayName: input.displayName,
+      // The operator running the attended setup owns the account (BI-3181909E).
+      accountableOwnerUserId: session.user.id,
     });
     return {
       ok: true,

--- a/apps/web/lib/browser-drive/identity.ts
+++ b/apps/web/lib/browser-drive/identity.ts
@@ -2,49 +2,60 @@
 //
 // An autonomous browser session acts as a service Principal (kind="service"),
 // never as a fake human — the human delegate is recorded separately on the
-// session's delegatingUserId. Identity resolves through Principal/PrincipalAlias
-// per the Principal-convergence rule (AGENTS.md §11); no parallel identity table.
+// session's delegatingUserId.
+//
+// EP-24741BBF · BI-3181909E: the service-account primitive itself now lives in
+// the shared identity module (`@/lib/identity/service-account`). This file is a
+// thin, browser-drive-flavoured wrapper over it — it owns the NAMESPACE and the
+// issuer, nothing more. Keeping the primitive here made this subsystem the
+// second home for a shared concern (AGENTS.md §8); it is now one caller among
+// future peers, and a service account is a peer shape of the same Principal
+// spine as a human employee and an AI coworker.
 
-import { prisma } from "@dpf/db";
+import {
+  SERVICE_ACCOUNT_ALIAS_TYPE,
+  buildServiceAccountPrincipalId,
+  resolveServiceAccountPrincipal as resolveSharedServiceAccountPrincipal,
+} from "@/lib/identity/service-account";
 
-/** PrincipalAlias.aliasType for browser-driving service accounts. */
-export const SERVICE_ACCOUNT_ALIAS_TYPE = "service-account";
+export { SERVICE_ACCOUNT_ALIAS_TYPE };
+
 /** PrincipalAlias.issuer for aliases minted by this subsystem. */
 export const BROWSER_DRIVE_ISSUER = "browser-drive";
 
-/** Deterministic service Principal id for a (site, account) pair. */
+/** Service-account id namespace owned by browser-driving. */
+export const BROWSER_DRIVE_SERVICE_NAMESPACE = "browser-svc";
+
+/**
+ * Deterministic service Principal id for a (site, account) pair.
+ *
+ * Grammar is `browser-svc:<siteKey>:<accountKey>` and is load-bearing —
+ * browser-session integration ids embed the whole string, so changing it
+ * orphans existing credentials and bindings.
+ */
 export function serviceAccountPrincipalId(siteKey: string, accountKey: string): string {
-  return `browser-svc:${siteKey}:${accountKey}`;
+  return buildServiceAccountPrincipalId(BROWSER_DRIVE_SERVICE_NAMESPACE, [siteKey, accountKey]);
 }
 
 /**
  * Find-or-create the service Principal that a browser-driving session acts as.
- * Idempotent: re-resolving an existing account returns it without mutating the
- * alias set.
+ *
+ * `accountableOwnerUserId` is REQUIRED: a service account with no accountable
+ * human is refused at the shared module boundary, because non-human identity
+ * without a named owner is how authority escapes audit.
  */
 export async function resolveServiceAccountPrincipal(params: {
   siteKey: string;
   accountKey: string;
   displayName?: string;
+  accountableOwnerUserId: string;
 }): Promise<{ principalId: string }> {
-  const principalId = serviceAccountPrincipalId(params.siteKey, params.accountKey);
-  const principal = await prisma.principal.upsert({
-    where: { principalId },
-    create: {
-      principalId,
-      kind: "service",
-      status: "active",
-      displayName: params.displayName ?? `${params.siteKey} service account (${params.accountKey})`,
-      aliases: {
-        create: {
-          aliasType: SERVICE_ACCOUNT_ALIAS_TYPE,
-          aliasValue: principalId,
-          issuer: BROWSER_DRIVE_ISSUER,
-        },
-      },
-    },
-    update: {},
-    select: { principalId: true },
+  return resolveSharedServiceAccountPrincipal({
+    namespace: BROWSER_DRIVE_SERVICE_NAMESPACE,
+    segments: [params.siteKey, params.accountKey],
+    issuer: BROWSER_DRIVE_ISSUER,
+    displayName:
+      params.displayName ?? `${params.siteKey} service account (${params.accountKey})`,
+    accountableOwnerUserId: params.accountableOwnerUserId,
   });
-  return { principalId: principal.principalId };
 }

--- a/apps/web/lib/browser-drive/provisioning-reauth.test.ts
+++ b/apps/web/lib/browser-drive/provisioning-reauth.test.ts
@@ -2,7 +2,17 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@dpf/db", () => ({
   prisma: {
-    principal: { upsert: vi.fn().mockResolvedValue({ principalId: "browser-svc:substack:default" }) },
+    // BI-3181909E: a service account is now minted only against an accountable
+    // owner, so the provisioning path resolves the delegating human's principal
+    // first. `delegatingUserId: "user-1"` is expected to resolve.
+    principalAlias: {
+      findFirst: vi.fn().mockResolvedValue({ principal: { id: "prn-row-user-1" } }),
+    },
+    principal: {
+      findUnique: vi.fn().mockResolvedValue(null),
+      update: vi.fn().mockResolvedValue({}),
+      upsert: vi.fn().mockResolvedValue({ principalId: "browser-svc:substack:default" }),
+    },
     integrationCredential: {
       upsert: vi.fn().mockResolvedValue({}),
       update: vi.fn().mockResolvedValue({}),
@@ -48,6 +58,23 @@ describe("provisionServiceAccount (§9.2)", () => {
 
   it("refuses to provision a service account without a target-domain allowlist", async () => {
     await expect(provisionServiceAccount({ ...base, targetDomains: [] })).rejects.toThrow(/allowlist/);
+    expect(prisma.principal.upsert).not.toHaveBeenCalled();
+  });
+
+  it("binds the delegating human as the service account's accountable owner", async () => {
+    await provisionServiceAccount(base);
+    expect(prisma.principalAlias.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ aliasType: "user", aliasValue: "user-1" }),
+      }),
+    );
+    const createArg = vi.mocked(prisma.principal.upsert).mock.calls[0][0].create as Record<string, unknown>;
+    expect(createArg.sponsorPrincipalId).toBe("prn-row-user-1");
+  });
+
+  it("refuses to provision when the delegating human resolves to no principal (BI-3181909E)", async () => {
+    vi.mocked(prisma.principalAlias.findFirst).mockResolvedValueOnce(null);
+    await expect(provisionServiceAccount(base)).rejects.toThrow(/accountable owner/i);
     expect(prisma.principal.upsert).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/browser-drive/provisioning.ts
+++ b/apps/web/lib/browser-drive/provisioning.ts
@@ -50,6 +50,10 @@ export async function provisionServiceAccount(
     siteKey: input.siteKey,
     accountKey: input.accountKey,
     displayName: input.displayName,
+    // The human who performed the attended bootstrap is the accountable owner
+    // of the resulting non-human identity (BI-3181909E). Without it the shared
+    // primitive refuses to mint the account.
+    accountableOwnerUserId: input.delegatingUserId,
   });
 
   const credentialId = await saveBrowserSessionCredential({

--- a/apps/web/lib/identity/service-account.test.ts
+++ b/apps/web/lib/identity/service-account.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  SERVICE_ACCOUNT_ALIAS_TYPE,
+  buildServiceAccountPrincipalId,
+  findOwnerlessServiceAccounts,
+  resolveServiceAccountPrincipal,
+} from "./service-account";
+import type { ServiceAccountDb } from "./service-account";
+
+// A minimal in-memory stand-in for the slice of Prisma this module touches.
+// Mirrors the PrincipalDb injection pattern used by principal-linking.ts so the
+// refusal is proven at the module boundary, not in a UI validator.
+function makeDb(options?: {
+  ownerPrincipalRecordId?: string | null;
+  existing?: { principalId: string; sponsorPrincipalId: string | null };
+  ownerless?: Array<{ principalId: string; displayName: string }>;
+}) {
+  const upserts: Array<Record<string, unknown>> = [];
+  const updates: Array<Record<string, unknown>> = [];
+  const principalAlias = {
+    findFirst: vi.fn(async () =>
+      options?.ownerPrincipalRecordId === null
+        ? null
+        : { principal: { id: options?.ownerPrincipalRecordId ?? "prn-row-owner" } },
+    ),
+  };
+  const principal = {
+    findUnique: vi.fn(async () => options?.existing ?? null),
+    findMany: vi.fn(async () => options?.ownerless ?? []),
+    upsert: vi.fn(async (args: Record<string, unknown>) => {
+      upserts.push(args);
+      return { principalId: (args.where as { principalId: string }).principalId };
+    }),
+    update: vi.fn(async (args: Record<string, unknown>) => {
+      updates.push(args);
+      return { principalId: "unused" };
+    }),
+  };
+  // One cast at the seam: a full Prisma delegate type cannot be hand-built, and
+  // narrowing the module's own type to just these methods would stop the real
+  // client satisfying it.
+  const injected = { principal, principalAlias } as unknown as ServiceAccountDb;
+  return { upserts, updates, principal, principalAlias, injected };
+}
+
+const OWNED = { accountableOwnerUserId: "user-1" };
+
+describe("buildServiceAccountPrincipalId", () => {
+  it("preserves the browser-drive grammar exactly — downstream ids embed it", () => {
+    // browser-session integration ids are built from this string; changing the
+    // shape silently orphans every existing credential and binding.
+    expect(buildServiceAccountPrincipalId("browser-svc", ["substack", "default"])).toBe(
+      "browser-svc:substack:default",
+    );
+  });
+
+  it("is deterministic and injective over its segments", () => {
+    expect(buildServiceAccountPrincipalId("ns", ["a", "b"])).toBe(
+      buildServiceAccountPrincipalId("ns", ["a", "b"]),
+    );
+    expect(buildServiceAccountPrincipalId("ns", ["a"])).not.toBe(
+      buildServiceAccountPrincipalId("ns", ["b"]),
+    );
+    expect(buildServiceAccountPrincipalId("ns1", ["a"])).not.toBe(
+      buildServiceAccountPrincipalId("ns2", ["a"]),
+    );
+  });
+
+  it("refuses a namespace or segment that would make the id ambiguous", () => {
+    expect(() => buildServiceAccountPrincipalId("", ["a"])).toThrow(/namespace/i);
+    expect(() => buildServiceAccountPrincipalId("ns", [])).toThrow(/segment/i);
+    expect(() => buildServiceAccountPrincipalId("ns", ["a:b"])).toThrow(/separator/i);
+  });
+});
+
+describe("resolveServiceAccountPrincipal — accountability is refusable", () => {
+  it("refuses to mint a service account with no accountable owner", async () => {
+    const { injected, upserts } = makeDb();
+    await expect(
+      resolveServiceAccountPrincipal(
+        {
+          namespace: "browser-svc",
+          segments: ["substack", "default"],
+          issuer: "browser-drive",
+          accountableOwnerUserId: "",
+        },
+        injected,
+      ),
+    ).rejects.toThrow(/accountable owner/i);
+    expect(upserts).toHaveLength(0);
+  });
+
+  it("refuses when the named owner does not resolve to a principal", async () => {
+    const { injected, upserts } = makeDb({ ownerPrincipalRecordId: null });
+    await expect(
+      resolveServiceAccountPrincipal(
+        { namespace: "browser-svc", segments: ["s", "a"], issuer: "browser-drive", ...OWNED },
+        injected,
+      ),
+    ).rejects.toThrow(/could not be resolved/i);
+    expect(upserts).toHaveLength(0);
+  });
+
+  it("binds the resolved owner as sponsorPrincipalId on create", async () => {
+    const { injected, upserts } = makeDb();
+    await resolveServiceAccountPrincipal(
+      { namespace: "browser-svc", segments: ["substack", "default"], issuer: "browser-drive", ...OWNED },
+      injected,
+    );
+    expect(upserts).toHaveLength(1);
+    const create = upserts[0]!.create as Record<string, unknown>;
+    expect(create.kind).toBe("service");
+    expect(create.sponsorPrincipalId).toBe("prn-row-owner");
+    const alias = (create.aliases as { create: Record<string, string> }).create;
+    expect(alias.aliasType).toBe(SERVICE_ACCOUNT_ALIAS_TYPE);
+    expect(alias.issuer).toBe("browser-drive");
+  });
+
+  it("is idempotent — re-resolving an owned account does not rewrite its alias set", async () => {
+    const { injected, upserts, updates } = makeDb({
+      existing: { principalId: "browser-svc:substack:default", sponsorPrincipalId: "prn-row-owner" },
+    });
+    await resolveServiceAccountPrincipal(
+      { namespace: "browser-svc", segments: ["substack", "default"], issuer: "browser-drive", ...OWNED },
+      injected,
+    );
+    expect(upserts[0]!.update).toEqual({});
+    expect(updates).toHaveLength(0);
+  });
+
+  it("repairs forward: an existing owner-less account gains a sponsor when touched", async () => {
+    const { injected, updates } = makeDb({
+      existing: { principalId: "browser-svc:substack:default", sponsorPrincipalId: null },
+    });
+    await resolveServiceAccountPrincipal(
+      { namespace: "browser-svc", segments: ["substack", "default"], issuer: "browser-drive", ...OWNED },
+      injected,
+    );
+    expect(updates).toHaveLength(1);
+    expect((updates[0]!.data as Record<string, unknown>).sponsorPrincipalId).toBe("prn-row-owner");
+  });
+});
+
+describe("findOwnerlessServiceAccounts — the invariant guard", () => {
+  it("queries service principals with no sponsor", async () => {
+    const { injected, principal } = makeDb({ ownerless: [] });
+    await expect(findOwnerlessServiceAccounts(injected)).resolves.toEqual([]);
+    expect(principal.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { kind: "service", sponsorPrincipalId: null },
+      }),
+    );
+  });
+
+  it("surfaces an owner-less account as a defect rather than hiding it", async () => {
+    const orphan = { principalId: "browser-svc:legacy:default", displayName: "legacy" };
+    const { injected } = makeDb({ ownerless: [orphan] });
+    await expect(findOwnerlessServiceAccounts(injected)).resolves.toEqual([orphan]);
+  });
+});

--- a/apps/web/lib/identity/service-account.ts
+++ b/apps/web/lib/identity/service-account.ts
@@ -1,0 +1,187 @@
+// Service accounts as a Principal subtype (EP-24741BBF · BI-3181909E).
+//
+// A service account is one of three shapes of the SAME identity spine — a peer
+// of a human employee and an AI coworker, not a subsystem of its own. It is a
+// Principal(kind="service") whose names live on PrincipalAlias, per the
+// Principal-convergence rule (AGENTS.md §11). There is no parallel identity
+// table, and there must never be one.
+//
+// This module exists because the capability was already real but lived inside
+// ONE consumer (apps/web/lib/browser-drive/), which is the AGENTS.md §8
+// anti-pattern: a feature-local helper acting as the second home for a shared
+// concern. Moving it here is the convergence half of the epic; browser-drive
+// now delegates.
+//
+// The rule this module enforces that its predecessor did not:
+//
+//   A service account with no accountable owner must be REFUSABLE.
+//
+// Non-human identity without a named human behind it is how authority escapes
+// audit. Accountability is therefore a precondition of minting, checked at this
+// module boundary — not in a UI validator a caller can bypass.
+
+import { prisma } from "@dpf/db";
+
+/** PrincipalAlias.aliasType for service accounts, whatever mints them. */
+export const SERVICE_ACCOUNT_ALIAS_TYPE = "service-account";
+
+/** Principal.kind discriminating the service class. */
+export const SERVICE_PRINCIPAL_KIND = "service";
+
+/** PrincipalAlias.issuer used for DPF-internal aliases (see principal-linking). */
+const INTERNAL_ISSUER = "";
+
+/** Separator between the namespace and each segment of a service principal id. */
+const ID_SEPARATOR = ":";
+
+/** The slice of Prisma this module touches; injectable so the refusal is
+ *  testable at the boundary rather than only through a live database. */
+export type ServiceAccountDb = Pick<typeof prisma, "principal" | "principalAlias">;
+
+export type OwnerlessServiceAccount = {
+  principalId: string;
+  displayName: string;
+};
+
+/**
+ * Deterministic principal id for a service account.
+ *
+ * The grammar is `<namespace>:<segment>[:<segment>…]` and is LOAD-BEARING:
+ * browser-session integration ids embed the whole string, so a change silently
+ * orphans every existing credential and binding. Callers keep their own
+ * namespace so two subsystems can never collide.
+ */
+export function buildServiceAccountPrincipalId(
+  namespace: string,
+  segments: readonly string[],
+): string {
+  if (!namespace.trim()) {
+    throw new Error("buildServiceAccountPrincipalId: a namespace is required");
+  }
+  if (segments.length === 0) {
+    throw new Error("buildServiceAccountPrincipalId: at least one segment is required");
+  }
+  for (const segment of segments) {
+    if (!segment.trim()) {
+      throw new Error("buildServiceAccountPrincipalId: a segment must not be empty");
+    }
+    if (segment.includes(ID_SEPARATOR)) {
+      // Otherwise (a, b:c) and (a:b, c) would produce the same id.
+      throw new Error(
+        `buildServiceAccountPrincipalId: a segment must not contain the "${ID_SEPARATOR}" separator`,
+      );
+    }
+  }
+  if (namespace.includes(ID_SEPARATOR)) {
+    throw new Error(
+      `buildServiceAccountPrincipalId: a namespace must not contain the "${ID_SEPARATOR}" separator`,
+    );
+  }
+  return [namespace, ...segments].join(ID_SEPARATOR);
+}
+
+/**
+ * Resolve the relational Principal.id for the human accountable for a service
+ * account. Returns null when the user has no principal, which the caller must
+ * treat as a refusal rather than a soft failure.
+ */
+async function resolveAccountableOwnerRecordId(
+  userId: string,
+  db: ServiceAccountDb,
+): Promise<string | null> {
+  const alias = await db.principalAlias.findFirst({
+    where: { aliasType: "user", aliasValue: userId, issuer: INTERNAL_ISSUER },
+    include: { principal: { select: { id: true } } },
+  });
+  return alias?.principal?.id ?? null;
+}
+
+/**
+ * Find-or-create the service Principal for a (namespace, segments) pair, bound
+ * to an accountable human owner.
+ *
+ * Idempotent on the principal: re-resolving an owned account returns it without
+ * rewriting its alias set. Repairs forward: an account that predates the
+ * accountability rule gains its sponsor the next time it is touched, so the
+ * invariant converges instead of requiring a one-shot backfill to be perfect.
+ */
+export async function resolveServiceAccountPrincipal(
+  input: {
+    namespace: string;
+    segments: readonly string[];
+    issuer: string;
+    displayName?: string;
+    /** The human accountable for this non-human identity. Not optional. */
+    accountableOwnerUserId: string;
+  },
+  db: ServiceAccountDb = prisma,
+): Promise<{ principalId: string }> {
+  const principalId = buildServiceAccountPrincipalId(input.namespace, input.segments);
+
+  if (!input.accountableOwnerUserId?.trim()) {
+    throw new Error(
+      `resolveServiceAccountPrincipal: refusing to mint service account ${principalId} with no accountable owner`,
+    );
+  }
+
+  const sponsorPrincipalId = await resolveAccountableOwnerRecordId(
+    input.accountableOwnerUserId,
+    db,
+  );
+  if (!sponsorPrincipalId) {
+    throw new Error(
+      `resolveServiceAccountPrincipal: refusing to mint service account ${principalId} — its accountable owner (${input.accountableOwnerUserId}) could not be resolved to a Principal`,
+    );
+  }
+
+  const existing = await db.principal.findUnique({
+    where: { principalId },
+    select: { principalId: true, sponsorPrincipalId: true },
+  });
+
+  if (existing && !existing.sponsorPrincipalId) {
+    // Repair forward rather than leaving a known-orphaned identity in place.
+    await db.principal.update({
+      where: { principalId },
+      data: { sponsorPrincipalId },
+    });
+  }
+
+  const principal = await db.principal.upsert({
+    where: { principalId },
+    create: {
+      principalId,
+      kind: SERVICE_PRINCIPAL_KIND,
+      status: "active",
+      displayName:
+        input.displayName ?? `${input.namespace} service account (${input.segments.join(" ")})`,
+      sponsorPrincipalId,
+      aliases: {
+        create: {
+          aliasType: SERVICE_ACCOUNT_ALIAS_TYPE,
+          aliasValue: principalId,
+          issuer: input.issuer,
+        },
+      },
+    },
+    update: {},
+    select: { principalId: true },
+  });
+
+  return { principalId: principal.principalId };
+}
+
+/**
+ * The invariant guard: every service account must have an accountable owner.
+ * A non-empty result is a defect, not a report — surface it rather than
+ * letting an unowned non-human identity sit unnoticed.
+ */
+export async function findOwnerlessServiceAccounts(
+  db: ServiceAccountDb = prisma,
+): Promise<OwnerlessServiceAccount[]> {
+  return db.principal.findMany({
+    where: { kind: SERVICE_PRINCIPAL_KIND, sponsorPrincipalId: null },
+    select: { principalId: true, displayName: true },
+    orderBy: { principalId: "asc" },
+  });
+}

--- a/docs/superpowers/plans/2026-08-23-directory-service-identity-absorption.md
+++ b/docs/superpowers/plans/2026-08-23-directory-service-identity-absorption.md
@@ -72,6 +72,29 @@ for existing rows. A regression test pins it before the move.
 **Verification:** unit tests for refusal and grammar stability; a query returning
 zero owner-less service principals.
 
+### Delivered (`BI-3181909E`)
+
+`apps/web/lib/identity/service-account.ts` is the shared primitive.
+`buildServiceAccountPrincipalId(namespace, segments)` owns the grammar;
+`resolveServiceAccountPrincipal()` mints only against a resolved accountable owner
+and refuses otherwise; `findOwnerlessServiceAccounts()` is the invariant guard.
+`browser-drive/identity.ts` keeps only its namespace (`browser-svc`) and issuer.
+
+Two decisions worth carrying forward:
+
+- **Repair-forward over one-shot backfill.** An account predating the rule gains
+  its sponsor the next time it is touched, so the invariant converges rather than
+  depending on a migration being exhaustive. The guard query is what proves it.
+- **The id grammar is pinned by test, not by convention.** Browser-session
+  integration ids embed the whole `browser-svc:<site>:<account>` string, so a
+  change orphans existing credentials and bindings. `drive.ts` consumes only the
+  id builder and was deliberately left untouched.
+
+**Follow-up, not done here:** `findOwnerlessServiceAccounts()` exists but nothing
+runs it on a cadence. Wiring it into a steward sweep so an orphan surfaces without
+someone asking is a separate concern — an invariant nobody evaluates is not yet a
+guard.
+
 ## Phase 2 — The projection contract (`BI-DCE49BA9`)
 
 Extract the DN projection from `apps/web/app/(shell)/platform/identity/directory/page.tsx`

--- a/docs/superpowers/specs/2026-08-23-directory-service-identity-absorption-design.md
+++ b/docs/superpowers/specs/2026-08-23-directory-service-identity-absorption-design.md
@@ -36,7 +36,7 @@ Every claim below was checked against the tree at `cf29d511a` on 2026-08-23. **T
 | Chain of custody | `apps/web/lib/tak/chain-of-custody.ts`, `mcp-governed-execute.ts:138` | Live. Every agent action joins back to a human origin |
 | Human authentication | `packages/db/prisma/schema/core-identity.prisma:8` `User.passwordHash`, `PasswordResetToken`, NextAuth session in `apps/web/lib/govern/auth.ts` | Live |
 | Roles / groups | `PlatformRole`, `UserGroup`, `Team`, `TeamMembership` | Live |
-| Service accounts | `apps/web/lib/browser-drive/identity.ts:16` | Live but **feature-local** |
+| Service accounts | `apps/web/lib/identity/service-account.ts` | **Shared primitive** since Phase 1 (`BI-3181909E`). Was feature-local in `browser-drive`; that module is now a namespace-owning wrapper. An owner-less service account is refused at the module boundary. |
 | DN projection | `apps/web/app/(shell)/platform/identity/directory/page.tsx` | Live but **route-local**, hardcoded `dc=dpf,dc=internal` |
 | Upstream federation | `apps/web/app/(shell)/platform/identity/federation/page.tsx` | Live. `IntegrationCredential(provider: "ldap"｜"active_directory")` |
 | Org PKI | Step CA — `docs/security/tool-evaluations/2026-07-20-step-ca.md` | Live. Machine trust, mTLS |


### PR DESCRIPTION
## What

Phase 1 of **EP-24741BBF**, and the first code increment of the identity absorption.

The service-account primitive moves from `apps/web/lib/browser-drive/identity.ts` to `apps/web/lib/identity/service-account.ts`, and **an owner-less service account becomes refusable**.

## This is convergence, not greenfield

The epic brief called this "the missing primitive the rest depend on." It was not missing. `Principal(kind: "service")` and a deterministic find-or-create already existed — inside one consumer, which made `browser-drive` the second home for a shared concern (AGENTS.md §8). Filed as `refactor`, not `feature`, for that reason.

A service account is now a **peer shape of the same spine** as a human employee and an AI coworker. `browser-drive` keeps only what is genuinely its own: the `browser-svc` namespace and its issuer.

## The rule its predecessor did not enforce

Non-human identity without a named human behind it is how authority escapes audit. So accountability is a **precondition of minting**, checked at the module boundary rather than in a validator a caller can bypass:

- `resolveServiceAccountPrincipal()` refuses when no accountable owner is given, and refuses again when the named owner does not resolve to a `Principal`. Neither path reaches the upsert.
- Both call sites already had the session user; `beginServiceAccountSetupAction` simply never passed it.
- **Repair-forward over one-shot backfill**: an account predating the rule gains its sponsor the next time it is touched, so the invariant converges rather than depending on a migration being exhaustive.
- `findOwnerlessServiceAccounts()` is the guard query. A non-empty result is a defect, not a report.

## The grammar is pinned, not assumed

`browser-svc:<site>:<account>` is load-bearing: browser-session integration ids embed the whole string, so changing it orphans every existing credential and binding. A test pins it. `buildServiceAccountPrincipalId` also rejects a separator inside a segment, since `(a, b:c)` and `(a:b, c)` would otherwise collide.

Blast radius checked: `drive.ts` and the existing browser-drive test consume only the id builder, whose signature is unchanged, and are untouched.

## Verification

```
local-CI gate: PASS
  HEAD     feat/service-account-principal-primitive @ c76e6c29dd78
  gated    feat/service-account-principal-primitive @ c76e6c29dd78
  evidence cmt9qdbh804sk01pqolx0wbkf
```

Gated SHA equals HEAD. Verdict read from `pregate:status` (the record), not the exit code. Plus **42/42 unit tests**, `tsc` clean, and **52 preflight guards** clean.

Worth noting for anyone reading the test file: `tsc` caught seven type errors in the in-memory Prisma stand-in that **vitest passed over**. §4 is right that TypeScript errors surface only in the build.

**No migration** — the change is expressed entirely on existing `Principal` / `PrincipalAlias` columns. **No UX surface** — server-side identity resolution only.

## Follow-up, deliberately not in this PR

`findOwnerlessServiceAccounts()` exists but nothing runs it on a cadence. An invariant nobody evaluates is not yet a guard; wiring it into a steward sweep is its own concern and is recorded in the plan.

Follows #4575 (design + plan), #4576 (evaluation), #4692 (supersession) — all merged.

Local-CI-Evidence: cmta6mv3s1t9n01pqudsfdeg6

🤖 Generated with [Claude Code](https://claude.com/claude-code)