### PR TITLE
fix(workroom): bind a backlog-item outcome anchor to the subject (BI-512214EA)

### DIFF
--- a/apps/web/lib/work-capsules/mcp-handlers.test.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { backlogItemIdFromOutcomeAnchor } from "./mcp-handlers";
+import { backlogItemIdFromOutcomeAnchor } from "./outcome-anchor";
 
 // BI-512214EA (second site). `Workroom.backlogItemId` is what every subject
 // lookup keys on — reviewer recovery, and repository-artifact.ts's subjectWhere

--- a/apps/web/lib/work-capsules/mcp-handlers.test.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { backlogItemIdFromOutcomeAnchor } from "./mcp-handlers";
+
+// BI-512214EA (second site). `Workroom.backlogItemId` is what every subject
+// lookup keys on — reviewer recovery, and repository-artifact.ts's subjectWhere
+// behind plan coverage. Its only writer was the readiness-gated claim path, so a
+// room adopted BEFORE readiness could never satisfy a subject lookup. Adoption
+// now resolves a backlog-item outcome anchor onto that binding.
+describe("adopt_worktree subject binding", () => {
+  it("resolves a backlog-item outcome anchor onto backlogItemId", () => {
+    expect(backlogItemIdFromOutcomeAnchor({
+      outcomeAnchor: { kind: "backlog-item", id: "BI-3EBFC177", label: "x" },
+    })).toBe("BI-3EBFC177");
+  });
+
+  it("ignores an anchor that does not name a backlog item", () => {
+    for (const outcomeAnchor of [
+      { kind: "epic", id: "EP-862820FD" },
+      { kind: "backlog-item" },
+      { kind: "backlog-item", id: "   " },
+      { kind: "backlog-item", id: 42 },
+      undefined,
+      null,
+      [],
+      "BI-3EBFC177",
+    ]) {
+      expect(backlogItemIdFromOutcomeAnchor({ outcomeAnchor })).toBeNull();
+    }
+  });
+});

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -30,6 +30,7 @@ import {
   type WorkCapsuleEvidenceKind,
   type WorkCapsuleScopeInput,
 } from "@/lib/work-capsules";
+import { backlogItemIdFromOutcomeAnchor } from "./outcome-anchor";
 import {
   adoptWorktreeCapsule,
   claimWorkCapsuleScope,
@@ -102,28 +103,6 @@ function stringParam(params: Record<string, unknown>, key: string): string | nul
 function numberParam(params: Record<string, unknown>, key: string): number | null {
   const value = params[key];
   return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-/**
- * Resolve a `backlog-item` outcome anchor onto the capsule's subject binding.
- *
- * `Workroom.backlogItemId` is what every subject lookup keys on — reviewer
- * recovery, and `repository-artifact.ts`'s `subjectWhere` behind plan coverage.
- * Its only writer was the successful-claim path, which is readiness-gated, so a
- * room adopted before readiness could never satisfy a subject lookup: adoption
- * recorded the anchor and the lookups never read it (BI-512214EA).
- *
- * `CapsuleAdoptionInput` already carries `backlogItemId` and already late-binds
- * it onto an existing room whose binding is null, so this only has to supply the
- * value the caller already stated.
- */
-export function backlogItemIdFromOutcomeAnchor(params: Record<string, unknown>): string | null {
-  const anchor = params.outcomeAnchor;
-  if (!anchor || typeof anchor !== "object" || Array.isArray(anchor)) return null;
-  const { kind, id } = anchor as { kind?: unknown; id?: unknown };
-  if (kind !== "backlog-item" || typeof id !== "string") return null;
-  const trimmed = id.trim();
-  return trimmed.length > 0 ? trimmed : null;
 }
 
 function parseScopeInput(params: Record<string, unknown>): WorkCapsuleScopeInput {

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -104,6 +104,28 @@ function numberParam(params: Record<string, unknown>, key: string): number | nul
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+/**
+ * Resolve a `backlog-item` outcome anchor onto the capsule's subject binding.
+ *
+ * `Workroom.backlogItemId` is what every subject lookup keys on — reviewer
+ * recovery, and `repository-artifact.ts`'s `subjectWhere` behind plan coverage.
+ * Its only writer was the successful-claim path, which is readiness-gated, so a
+ * room adopted before readiness could never satisfy a subject lookup: adoption
+ * recorded the anchor and the lookups never read it (BI-512214EA).
+ *
+ * `CapsuleAdoptionInput` already carries `backlogItemId` and already late-binds
+ * it onto an existing room whose binding is null, so this only has to supply the
+ * value the caller already stated.
+ */
+export function backlogItemIdFromOutcomeAnchor(params: Record<string, unknown>): string | null {
+  const anchor = params.outcomeAnchor;
+  if (!anchor || typeof anchor !== "object" || Array.isArray(anchor)) return null;
+  const { kind, id } = anchor as { kind?: unknown; id?: unknown };
+  if (kind !== "backlog-item" || typeof id !== "string") return null;
+  const trimmed = id.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 function parseScopeInput(params: Record<string, unknown>): WorkCapsuleScopeInput {
   return {
     workroomShape: params.workroomShape,
@@ -310,6 +332,7 @@ export async function adoptWorktreeTool(
         baseSha: stringParam(params, "baseSha") ?? null,
         headSha: stringParam(params, "headSha") ?? null,
         executorKind: validatedExecutorKind,
+        backlogItemId: backlogItemIdFromOutcomeAnchor(params),
         scope: parseScopeInput(params),
       },
       actor: await actor(userId, context),

--- a/apps/web/lib/work-capsules/outcome-anchor.ts
+++ b/apps/web/lib/work-capsules/outcome-anchor.ts
@@ -1,0 +1,25 @@
+/**
+ * Resolve a Workroom outcome anchor onto the subject binding lookups read.
+ *
+ * `Workroom.backlogItemId` is what every subject lookup keys on — reviewer
+ * recovery in `governed-work-claim.ts`, and `subjectWhere` in
+ * `backlog/initiative-readiness/repository-artifact.ts`, which sits behind plan
+ * coverage and canonical-design resolution.
+ *
+ * Its only writer was the successful-claim path, which is readiness-gated. So a
+ * room adopted BEFORE readiness could never satisfy a subject lookup: adoption
+ * recorded the caller's `outcomeAnchor` and every lookup read a column that
+ * stayed null (BI-512214EA).
+ *
+ * `CapsuleAdoptionInput` already carries `backlogItemId` and already late-binds
+ * it onto an existing room whose binding is null, so adoption only has to supply
+ * the value the caller already stated.
+ */
+export function backlogItemIdFromOutcomeAnchor(params: Record<string, unknown>): string | null {
+  const anchor = params.outcomeAnchor;
+  if (!anchor || typeof anchor !== "object" || Array.isArray(anchor)) return null;
+  const { kind, id } = anchor as { kind?: unknown; id?: unknown };
+  if (kind !== "backlog-item" || typeof id !== "string") return null;
+  const trimmed = id.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -61,7 +61,7 @@ apps/web/lib/tak/agent-routing.ts	1191
 apps/web/lib/tak/agentic-loop.test.ts	2501
 apps/web/lib/tak/agentic-loop.ts	2806
 apps/web/lib/tak/route-context-map.ts	1440
-apps/web/lib/work-capsules/mcp-handlers.ts	847
+apps/web/lib/work-capsules/mcp-handlers.ts	849
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1191
 apps/web/lib/work-capsules/work-capsule-store.ts	1052
 apps/web/lib/workbooks/platform-tables.ts	938


### PR DESCRIPTION
Second site of the circular dependency [#4709](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4709) fixed for reviewer recovery.

## Problem

`Workroom.backlogItemId` is what **every** subject lookup keys on — reviewer recovery, and `repository-artifact.ts`'s `subjectWhere`, which sits behind plan coverage:

```ts
const subjectWhere = args.subject.kind === "backlog-item"
  ? { backlogItemId: args.subject.id }
  : ...
```

Its only writer was the successful-claim path, which is readiness-gated. So a room adopted **before** readiness could never satisfy a subject lookup: `adopt_worktree` recorded the caller's `outcomeAnchor`, and every lookup read a column that stayed null.

## Found live, not theoretically

After [#4700](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4700) reached the running install, recording plan coverage for `BI-3EBFC177` against workroom `WC-980D80F2` — whose `outcomeAnchor` named that exact item — still failed:

> No live workroom for this subject is bound to `<repo>`. Claim or adopt the branch first (`claim_backlog_item_for_work` or `adopt_worktree`), then retry.

Advice the caller had already followed.

## Fix

`adopt_worktree` resolves an outcome anchor of kind `backlog-item` onto the subject binding. `CapsuleAdoptionInput` already carried `backlogItemId` and already contains explicit late-bind logic for a room whose binding is null — this only supplies the value the caller had already stated.

A non-backlog anchor, a missing or blank id, and a non-object anchor all resolve to `null` rather than guessing.

## Correction to my own filing

`BI-512214EA` originally claimed `adopt_worktree` *drops* `outcomeAnchor`, and I withdrew that as incidental when the anchor turned out to persist. **The withdrawal was wrong.** The anchor persists but was never resolved onto the column the lookups read — a different defect at the same seam, and the one that blocked plan coverage.

## Build gate

- 20 test files / 133 tests passing across `lib/work-capsules`
- `tsc --noEmit` clean
- `pnpm --filter web build` exit 0
- Policy guards `--profile pull-request`: all 7 pass
- No migration