### PR TITLE
fix(readiness): stop binding the one lane whose writer the contract rejects (BI-9FE775F9)

### DIFF
--- a/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { InitiativeReadinessDecision } from "@/lib/backlog/initiative-readiness";
 
+import { parseInitiativeReviewBinding } from "@/lib/mcp-task-submit";
+
 import { resolveInitiativeReviewerRecovery } from "./initiative-readiness-tool-grants";
 
 const decision: InitiativeReadinessDecision = {
@@ -112,14 +114,16 @@ describe("initiative readiness recovery routing", () => {
           requestKey: `initiative-readiness:BI-A45D744A:dependency-disposition:${dispatchContext.headSha}`,
           tier: 2,
           enteredVia: "handoff",
-          requiredToolNames: ["record_plan_backlog_coverage", "read_source_at_version"],
-          initiativeReviewBinding: {
-            writerToolName: "record_plan_backlog_coverage",
-            gate: "dependency-disposition",
-          },
         },
       },
     ]);
+    // `record_plan_backlog_coverage` is not a `record_initiative_*` writer, so
+    // parseInitiativeReviewBinding would reject a binding for it. That lane
+    // reviews no immutable bytes, so it carries neither field (BI-9FE775F9).
+    const coverage = recovery.reviewerRoutes
+      .find((route) => route.toolName === "record_plan_backlog_coverage");
+    expect(coverage?.requestCoworker).not.toHaveProperty("initiativeReviewBinding");
+    expect(coverage?.requestCoworker).not.toHaveProperty("requiredToolNames");
   });
 
   it("carries the current baseline id into the binding so a superseded design cannot be reviewed", async () => {
@@ -134,7 +138,7 @@ describe("initiative readiness recovery routing", () => {
       expectedCurrentBaselineId: "IBL-7C41",
     });
 
-    expect(recovery.reviewerRoutes[0]?.requestCoworker.initiativeReviewBinding.expectedCurrentBaselineId)
+    expect(recovery.reviewerRoutes[0]?.requestCoworker.initiativeReviewBinding?.expectedCurrentBaselineId)
       .toBe("IBL-7C41");
   });
 
@@ -150,14 +154,17 @@ describe("initiative readiness recovery routing", () => {
       canonicalArtifact: { resolved: false, nextAction: "Commit the canonical design under docs/superpowers/specs/, push it, then retry." },
     });
 
-    expect(recovery.reviewerRoutes).toEqual([]);
+    // Only the lanes that need immutable bytes are blocked. Plan coverage is not
+    // one of them, so it still routes — an unresolvable design must not strand
+    // work that never depended on it (BI-9FE775F9).
+    expect(recovery.reviewerRoutes.map((route) => route.toolName))
+      .toEqual(["record_plan_backlog_coverage"]);
     expect(recovery.escalations).toMatchObject([
       {
         accountableRole: "design-author",
         reason: "no-canonical-artifact",
         nextAction: "Commit the canonical design under docs/superpowers/specs/, push it, then retry.",
       },
-      { accountableRole: "implementation-planner", reason: "no-canonical-artifact" },
     ]);
   });
 
@@ -262,5 +269,97 @@ describe("initiative readiness recovery routing", () => {
     ]);
     // Two genuinely different operator actions must not collapse to one code.
     expect(reasons).toEqual(new Set(["dispatch-context-required", "no-eligible-reviewer"]));
+  });
+});
+
+/**
+ * The producer/consumer seam, tested end to end.
+ *
+ * The defect this file's fix repaired (BI-9FE775F9) was not a wrong value — it
+ * was a packet the CALLEE rejects. Asserting the emitted shape here and the
+ * validator's rules over there let a route that no coworker could execute look
+ * correct on both sides for weeks. These tests run what the generator actually
+ * emits through the real validators, so the seam cannot silently reopen.
+ */
+describe("recovery packets are executable by the real consumer", () => {
+  // Mirrors initiativeReviewPacket in external-coworker-task-adapter.ts.
+  const ALLOWED_READERS = new Set(["read_source_at_version", "search_source_at_version"]);
+
+  it("emits bindings that parseInitiativeReviewBinding accepts", async () => {
+    const recovery = await resolveInitiativeReviewerRecovery({
+      decision,
+      currentAgentId: "AGT-AUTHOR",
+      db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue([
+        grantRow("initiative_evidence_write", "AGT-WS-BUILD", "Build Specialist"),
+        grantRow("backlog_write", "AGT-WS-BUILD", "Build Specialist"),
+      ]) } },
+      dispatchContext,
+      canonicalArtifact,
+      expectedCurrentBaselineId: null,
+    });
+
+    expect(recovery.reviewerRoutes.length).toBeGreaterThan(0);
+    for (const route of recovery.reviewerRoutes) {
+      if (route.requestCoworker.initiativeReviewBinding === undefined) {
+        // Only a non-record_initiative_* writer may go unbound.
+        expect(route.toolName.startsWith("record_initiative_")).toBe(false);
+        continue;
+      }
+      expect(
+        parseInitiativeReviewBinding(route.requestCoworker.initiativeReviewBinding),
+        `parseInitiativeReviewBinding rejected the packet for ${route.toolName}`,
+      ).not.toBeNull();
+    }
+  });
+
+  it("emits requiredToolNames the external coworker adapter will not refuse", async () => {
+    const recovery = await resolveInitiativeReviewerRecovery({
+      decision,
+      currentAgentId: "AGT-AUTHOR",
+      db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue([
+        grantRow("initiative_evidence_write", "AGT-WS-BUILD", "Build Specialist"),
+        grantRow("backlog_write", "AGT-WS-BUILD", "Build Specialist"),
+      ]) } },
+      dispatchContext,
+      canonicalArtifact,
+      expectedCurrentBaselineId: null,
+    });
+
+    for (const route of recovery.reviewerRoutes) {
+      const { requiredToolNames, initiativeReviewBinding } = route.requestCoworker;
+      if (requiredToolNames === undefined || initiativeReviewBinding === undefined) continue;
+      const names = [...new Set(requiredToolNames)];
+      // The adapter refuses anything outside the bound writer plus one or both
+      // immutable readers, and refuses fewer than 2 or more than 4 names.
+      expect(names.length).toBeGreaterThanOrEqual(2);
+      expect(names.length).toBeLessThanOrEqual(4);
+      expect(names).toContain(initiativeReviewBinding.writerToolName);
+      expect(names.some((name) => ALLOWED_READERS.has(name))).toBe(true);
+      expect(names.every((name) =>
+        name === initiativeReviewBinding.writerToolName || ALLOWED_READERS.has(name))).toBe(true);
+    }
+  });
+
+  it("never emits one of the two coupled fields without the other", async () => {
+    // The adapter rejects "supplied together" violations, so a route carrying
+    // only one is an unexecutable route — the exact original defect.
+    const recovery = await resolveInitiativeReviewerRecovery({
+      decision,
+      currentAgentId: "AGT-AUTHOR",
+      db: { agentToolGrant: { findMany: vi.fn().mockResolvedValue([
+        grantRow("initiative_evidence_write", "AGT-WS-BUILD", "Build Specialist"),
+      ]) } },
+      dispatchContext,
+      canonicalArtifact,
+      expectedCurrentBaselineId: null,
+    });
+
+    for (const route of recovery.reviewerRoutes) {
+      const hasBinding = route.requestCoworker.initiativeReviewBinding !== undefined;
+      const hasNames = route.requestCoworker.requiredToolNames !== undefined;
+      // Coupling is the invariant, not presence: the adapter refuses one
+      // without the other, so either both travel or neither does.
+      expect(hasBinding).toBe(hasNames);
+    }
   });
 });

--- a/apps/web/lib/tak/initiative-readiness-tool-grants.ts
+++ b/apps/web/lib/tak/initiative-readiness-tool-grants.ts
@@ -88,8 +88,14 @@ export type InitiativeReviewerRecovery = {
       requestKey: string;
       tier: 2;
       enteredVia: "handoff";
-      requiredToolNames: string[];
-      initiativeReviewBinding: InitiativeReviewBindingPacket;
+      /**
+       * Present together or not at all. Absent only for a lane whose writer the
+       * binding contract does not cover (`record_plan_backlog_coverage` is not a
+       * `record_initiative_*` writer, so `parseInitiativeReviewBinding` rejects
+       * it); that lane reviews no immutable bytes and needs no artifact identity.
+       */
+      requiredToolNames?: string[];
+      initiativeReviewBinding?: InitiativeReviewBindingPacket;
     };
   }>;
   escalations: Array<{
@@ -233,12 +239,19 @@ export async function resolveInitiativeReviewerRecovery(input: {
         });
         continue;
       }
-      // A route without a binding is not a lesser route — it is an unusable one:
-      // `request_coworker` rejects `requiredToolNames` unless the binding comes
-      // with it, so emitting it would spend a dispatch and a TaskRun to fail at
-      // the callee. Escalate with the remedy instead (BI-9FE775F9).
+      // Only an initiative-review writer can carry a binding: the consumer's
+      // `parseInitiativeReviewBinding` requires `record_initiative_*`, so
+      // binding `record_plan_backlog_coverage` produces a route the callee
+      // rejects — the very defect this lane routing exists to end. Plan coverage
+      // is not a review of immutable bytes, so it carries no artifact identity
+      // and is not blocked by one being unresolvable (BI-9FE775F9).
+      const bindable = entry.route.toolName.startsWith("record_initiative_");
       const artifact = input.canonicalArtifact ?? null;
-      if (!artifact || !artifact.resolved) {
+      if (bindable && (!artifact || !artifact.resolved)) {
+        // A route without a binding is not a lesser route — it is an unusable
+        // one: `request_coworker` rejects `requiredToolNames` unless the binding
+        // comes with it, so emitting it would spend a dispatch and a TaskRun to
+        // fail at the callee. Escalate with the remedy instead.
         escalations.push({
           accountableRole: entry.role,
           toolName: entry.route.toolName,
@@ -257,7 +270,7 @@ export async function resolveInitiativeReviewerRecovery(input: {
         targetAgentId: candidate.agent.agentId,
         dispatch: input.dispatchContext,
         independent: entry.route.lane.independent,
-        artifact,
+        artifact: bindable && artifact?.resolved ? artifact : null,
         expectedCurrentBaselineId: input.expectedCurrentBaselineId ?? null,
       });
       reviewerRoutes.push({
@@ -342,17 +355,28 @@ function requestCoworkerPacket(args: {
   targetAgentId: string;
   dispatch: InitiativeRecoveryDispatchContext;
   independent: boolean;
-  artifact: { path: string; providerBlobId: string };
+  /** Null for a lane whose writer the binding contract does not cover. */
+  artifact: { path: string; providerBlobId: string } | null;
   expectedCurrentBaselineId: string | null;
 }) {
   const reviewConstraint = args.independent ? "independently " : "";
-  return {
+  const base = {
     targetAgent: args.targetAgentId,
-    objective: `For ${args.decision.subject.id} in ${args.dispatch.workroomId} on ${args.dispatch.repositoryFullName}#${args.dispatch.branchName} at ${args.dispatch.headSha}, ${reviewConstraint}address ${args.gate} using ${args.toolName}. Read ${args.artifact.path} at that commit with ${IMMUTABLE_READER_TOOL}, then record a governed receipt only when the gate passes.`,
+    objective: `For ${args.decision.subject.id} in ${args.dispatch.workroomId} on ${args.dispatch.repositoryFullName}#${args.dispatch.branchName} at ${args.dispatch.headSha}, ${reviewConstraint}address ${args.gate} using ${args.toolName}.${
+      args.artifact
+        ? ` Read ${args.artifact.path} at that commit with ${IMMUTABLE_READER_TOOL},`
+        : ""
+    } record a governed receipt only when the gate passes.`,
     questionPacketSummary: `${args.gate} for ${args.decision.subject.id} at ${args.dispatch.headSha.slice(0, 12)}`,
     requestKey: `initiative-readiness:${args.decision.subject.id}:${args.gate}:${args.dispatch.headSha}`,
     tier: 2 as const,
     enteredVia: "handoff" as const,
+  };
+  // The two fields travel together or not at all: the adapter refuses one
+  // without the other, so a partial packet is an unexecutable packet.
+  if (!args.artifact) return base;
+  return {
+    ...base,
     requiredToolNames: [args.toolName, IMMUTABLE_READER_TOOL],
     initiativeReviewBinding: {
       writerToolName: args.toolName,


### PR DESCRIPTION
Follow-up to #4689. Same BI-9FE775F9.

## The defect #4689 left behind

#4689 made recovery routes executable — for **nine of the ten lanes**.

`parseInitiativeReviewBinding` requires a `record_initiative_*` writer. `record_plan_backlog_coverage` is the one lane writer that isn't. So the binding #4689 minted for the `implementation-planner` / `dependency-disposition` lane is **rejected by the callee** — the identical defect #4689 set out to end, surviving in the one lane whose unit test asserted a *shape* instead of running the packet through the real validator.

Two consequences, both fixed here:

1. **Don't bind a writer the contract doesn't cover.** Plan coverage is not a review of immutable bytes; it carries no artifact identity and now carries neither coupled field. The adapter accepts a packet with neither (it only refuses *one without the other*), so the route stays executable via generic scopes.
2. **Don't strand a lane on an artifact it never needed.** Previously an unresolvable canonical design escalated *every* lane together, including plan coverage. Now only the lanes that actually need immutable bytes are blocked.

## The tests that would have caught it

The root cause of this whole class of bug is that the producer's shape was asserted here and the consumer's rules over there, so a packet no coworker could execute looked correct on both sides. These tests close the seam:

- Every emitted binding is run through the real `parseInitiativeReviewBinding`.
- Every emitted `requiredToolNames` is run through the external coworker adapter's actual rules (2–4 names, must include the bound writer, only permitted immutable readers).
- **Coupling is the invariant, not presence** — either both fields travel or neither does.

## Verified against live data

For the actually-blocked case (`BI-7A38F667` / `WC-16B8E810` at `e5f86ccb`):

- The workroom records both `baseSha` and `headSha`.
- The real GitHub compare over that range returns **exactly one** spec — `docs/superpowers/specs/2026-08-25-pet-rescue-operating-system-and-help-recovery-design.md`, blob `77960628a7…`.
- All four emitted routes (research, design-spec, spec-approval, architecture-review) pass `parseInitiativeReviewBinding`; zero escalations.
- `ARTIFACT_AUTHOR_REQUIRED` surfaces in `unroutable` with its remedy, and its preconditions already hold (single DCO trailer, workroom owner principal present, no conflicting email alias).

## Verification

1721 tests / 167 suites pass; `pnpm --filter web typecheck` clean; `check-guards.mjs` 37/37; design-grounding, docs-impact, plan-backlog-coverage and spec-status-frontmatter gates all exit 0. No migration, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
