### PR TITLE
fix(build-studio): one failed regeneration must not destroy the build (BI-E492F313)

### DIFF
--- a/apps/web/lib/build/design-fix-outcome.test.ts
+++ b/apps/web/lib/build/design-fix-outcome.test.ts
@@ -1,0 +1,36 @@
+// BI-E492F313 — the repair loop must not destroy recoverable work.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  outcomeKeepsBuildRecoverable,
+  resolveDesignFixOutcome,
+} from "./design-fix-outcome";
+
+describe("resolveDesignFixOutcome", () => {
+  it("reports repaired when the review no longer fails", () => {
+    expect(resolveDesignFixOutcome({ reviewFailed: false, regenerated: true })).toBe("repaired");
+    expect(resolveDesignFixOutcome({ reviewFailed: false, regenerated: false })).toBe("repaired");
+  });
+
+  it("escalates only when a regeneration actually produced a design to review", () => {
+    expect(resolveDesignFixOutcome({ reviewFailed: true, regenerated: true }))
+      .toBe("escalated-after-rounds");
+  });
+
+  // The live repro: every round failed to dispatch, so the design was never
+  // re-examined — yet the platform escalated as though repair were exhausted,
+  // abandoning the build and deferring the owner's backlog item.
+  it("does NOT escalate when no round ever produced a design", () => {
+    expect(resolveDesignFixOutcome({ reviewFailed: true, regenerated: false }))
+      .toBe("blocked-no-regeneration");
+  });
+});
+
+describe("outcomeKeepsBuildRecoverable", () => {
+  it("keeps the build recoverable only for the no-regeneration case", () => {
+    expect(outcomeKeepsBuildRecoverable("blocked-no-regeneration")).toBe(true);
+    expect(outcomeKeepsBuildRecoverable("escalated-after-rounds")).toBe(false);
+    expect(outcomeKeepsBuildRecoverable("repaired")).toBe(false);
+  });
+});

--- a/apps/web/lib/build/design-fix-outcome.ts
+++ b/apps/web/lib/build/design-fix-outcome.ts
@@ -1,0 +1,47 @@
+// apps/web/lib/build/design-fix-outcome.ts
+//
+// BI-E492F313 — what should happen when the design-review fix loop ends with the
+// review still failing?
+//
+// The loop used to answer this with one branch: review still fails → escalate to
+// a human, which ABANDONS the build, frees the WIP slot and parks the owner's
+// backlog item as `deferred`. That is the right response to a design the
+// platform genuinely could not repair. It is the wrong response to "no engine
+// could produce a design to review" — nothing was learned about the design, and
+// the existing doc and review are still valid.
+//
+// Live repro FB-D23311A7 on the Pet Rescue install: round 1 drew the local
+// model, could not parse its output, and the build was destroyed — taking a
+// sound design doc and an actionable three-issue review with it.
+//
+// Pure module — no Prisma, no I/O — so the policy is testable without the
+// dispatch stack.
+
+export type DesignFixOutcomeKind =
+  /** The review passed after repair. */
+  | "repaired"
+  /** Repair ran and the design still fails — a human decision is genuinely needed. */
+  | "escalated-after-rounds"
+  /** No round ever produced a design to review — infrastructure, not exhausted repair. */
+  | "blocked-no-regeneration";
+
+/**
+ * Decide the loop's terminal outcome.
+ *
+ * `regenerated` is the load-bearing input: it records whether ANY round actually
+ * produced a new design document. Without it, a loop that never regenerated is
+ * indistinguishable from one that tried and failed on the merits — and the
+ * platform destroys recoverable work on the strength of that confusion.
+ */
+export function resolveDesignFixOutcome(args: {
+  reviewFailed: boolean;
+  regenerated: boolean;
+}): DesignFixOutcomeKind {
+  if (!args.reviewFailed) return "repaired";
+  return args.regenerated ? "escalated-after-rounds" : "blocked-no-regeneration";
+}
+
+/** True when the outcome must leave the build recoverable rather than abandoned. */
+export function outcomeKeepsBuildRecoverable(kind: DesignFixOutcomeKind): boolean {
+  return kind === "blocked-no-regeneration";
+}

--- a/apps/web/lib/build/ideate-on-approval.test.ts
+++ b/apps/web/lib/build/ideate-on-approval.test.ts
@@ -43,6 +43,7 @@ import {
   getIdeateResearchRequest,
   dispatchApprovedIdeateBuilds,
   dispatchDesignReviewFixLoop,
+  DESIGN_FIX_MAX_ROUNDS,
 } from "./ideate-on-approval";
 
 function engineSelection(
@@ -558,4 +559,50 @@ describe("dispatchDesignReviewFixLoop (design-review fix loop)", () => {
     );
     expect(mockDispatchIdeateResearch).not.toHaveBeenCalled(); // never tried to regenerate
   });
+
+  // BI-E492F313 — live repro FB-D23311A7: round 1 drew the local model, could
+  // not parse its output, and the loop `break`ed and escalated. That abandoned
+  // the build, freed the WIP slot and parked the owner's backlog item as
+  // deferred — destroying a sound design doc and an actionable review over an
+  // infrastructure failure that said nothing about the design.
+  it("spends the remaining rounds when a regeneration cannot dispatch, and does not abandon the build", async () => {
+    const failedReview = {
+      decision: "fail",
+      issues: [{ severity: "critical", description: "Concurrency invariant missing" }],
+    };
+    mockPrisma.featureBuild.findUnique.mockResolvedValue({
+      id: "ck3",
+      title: "Foster homes",
+      kind: "feature",
+      originatingBacklogItemId: "cmpcuid1",
+      designReview: failedReview,
+      designDoc: null,
+      description: "D",
+    });
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({
+      title: "BI Title", body: "Body.", effortSize: "medium", workType: "feature",
+    });
+    mockGetBuildStudioConfig.mockResolvedValue({
+      provider: "opencode",
+      claudeProviderId: "", codexProviderId: "", grokProviderId: "", opencodeProviderId: "local",
+      claudeModel: "", codexModel: "", grokModel: "", opencodeModel: "",
+      selection: engineSelection("opencode", "local"),
+    });
+    // Every attempt fails the way the local model does: it ran, but produced
+    // nothing parseable.
+    mockDispatchIdeateResearch.mockResolvedValue({
+      success: false, designDoc: null, rawOutput: "I think the design should…", durationMs: 231_800,
+      error: "Routed ideate output could not be parsed into a design document.",
+    });
+
+    const res = await dispatchDesignReviewFixLoop({ buildId: "FB-D23311A7", userId: "u-1" });
+
+    expect(res).toMatchObject({ kind: "blocked-no-regeneration" });
+    // Both rounds are spent — engine selection is re-resolved per attempt, so a
+    // later round can land on an engine that works.
+    expect(res.rounds).toBe(DESIGN_FIX_MAX_ROUNDS);
+    // The build is NOT abandoned and the backlog item is NOT deferred.
+    expect(mockEscalate).not.toHaveBeenCalled();
+  });
+
 });

--- a/apps/web/lib/build/ideate-on-approval.ts
+++ b/apps/web/lib/build/ideate-on-approval.ts
@@ -697,15 +697,28 @@ export async function dispatchDesignReviewFixLoop(params: {
     const { formatPlanReviewFeedback } = await import("@/lib/build/plan-on-approval");
     const { executeTool } = await import("@/lib/mcp-tools");
     let round = 0;
+    // BI-E492F313: did any round actually produce a new design to review? A
+    // regeneration that never ran is NOT self-repair exhausted, and must not be
+    // treated as one.
+    let regenerated = false;
     while (review?.decision === "fail" && round < DESIGN_FIX_MAX_ROUNDS) {
       round += 1;
       await log(`Design review failed — regenerating (round ${round}/${DESIGN_FIX_MAX_ROUNDS}) against ${review.issues?.length ?? 0} issue(s)`);
       const feedback = formatPlanReviewFeedback(review.issues ?? []);
       const regen = await dispatchIdeateForApprovedBuild({ buildId, userId, priorReviewFeedback: feedback });
       if (regen.kind !== "dispatched-success") {
-        await log(`Design regeneration round ${round} produced no designDoc (${regen.kind}) — stopping.`);
-        break;
+        // BI-E492F313: this used to `break`, so ONE infrastructure failure both
+        // consumed a round and abandoned the rest — the advertised "round 1/2"
+        // never happened. A regeneration that could not dispatch says nothing
+        // about the design, so spend the remaining rounds instead: engine
+        // selection is re-resolved per attempt and a later round can land on an
+        // engine that works. Live repro FB-D23311A7: round 1 drew the local
+        // model, could not parse its output, and the build was destroyed —
+        // taking a sound design doc and an actionable review with it.
+        await log(`Design regeneration round ${round} produced no designDoc (${regen.kind}) — retrying if rounds remain.`);
+        continue;
       }
+      regenerated = true;
       await executeTool(
         "reviewDesignDoc",
         { buildId },
@@ -716,12 +729,30 @@ export async function dispatchDesignReviewFixLoop(params: {
       review = fresh?.designReview as DesignReviewVerdict;
     }
 
-    if (review?.decision === "fail") {
+    // BI-E492F313: escalate-to-human ABANDONS the build, frees the WIP slot and
+    // parks the owner's backlog item as deferred. The rule for when that is
+    // warranted lives in design-fix-outcome.ts so it is testable without the
+    // dispatch stack.
+    const { resolveDesignFixOutcome, outcomeKeepsBuildRecoverable } = await import(
+      "@/lib/build/design-fix-outcome"
+    );
+    const outcomeKind = resolveDesignFixOutcome({
+      reviewFailed: review?.decision === "fail",
+      regenerated,
+    });
+    if (outcomeKeepsBuildRecoverable(outcomeKind)) {
+      await log(
+        `Design repair could not regenerate a design in ${round} round(s) — no engine produced one. `
+        + "Leaving the build recoverable; the existing design and review are kept.",
+      );
+      return { kind: outcomeKind, rounds: round };
+    }
+    if (outcomeKind === "escalated-after-rounds") {
       await escalate(build, review, round);
-      return { kind: "escalated-after-rounds", rounds: round };
+      return { kind: outcomeKind, rounds: round };
     }
     await log(`Design review passed after ${round} fix round(s).`);
-    return { kind: "repaired", rounds: round };
+    return { kind: outcomeKind, rounds: round };
   } catch (err) {
     await log(`Design fix loop error: ${String(err instanceof Error ? err.message : err).slice(0, 200)}`);
     return { kind: "error", rounds: 0 };


### PR DESCRIPTION
## Problem

The design-review fix loop advertised **"round 1/2"** and stopped after one. Any regeneration that did not return a design — including an infrastructure failure that says nothing about the design — hit `break`, and the loop then escalated to a human *as though self-repair were exhausted*. `escalateBuildToHuman` **abandons the build, frees the WIP slot, and parks the owner's backlog item as `deferred`**.

Live repro `FB-D23311A7` on the Pet Rescue install — with routing already fixed ([#4701](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4701) merged and deployed), so the original "nothing could dispatch" excuse does not apply:

```
07:00:51  designDoc saved (codex, 129.9s)
07:04:33  Design review: fail, 3 issues (2 critical, 1 important)
07:04:33  regenerating (round 1/2) against 3 issue(s)
07:04:33  Build engine selection: opencode (provider=local)
07:07:59  Design regeneration round 1 produced no designDoc (dispatched-failure) — stopping
07:08:00  Escalated to the owner (needs-human). WIP freed; backlog item parked
07:08:00  In-place design repair finished: escalated-after-rounds after 1 round(s)
```

**Round 2 was never attempted.** A sound design doc — one that correctly honoured the rescue's "no uncleared animal on the public adoption list" constraint — and a review naming three concrete integrity gaps were both destroyed, and `BI-4C608C04` left the open backlog for the second time.

## Change

- A regeneration that could not dispatch now **`continue`s instead of breaking**, so the remaining rounds are actually spent. Engine selection is re-resolved per attempt, so a later round can land on an engine that works — exactly what happened at 06:58, when auto-selection drew codex and succeeded.
- The terminal decision moves to a pure module, `design-fix-outcome.ts`. Its load-bearing input is **whether any round produced a design to review**. Without it, "never regenerated" is indistinguishable from "tried and failed on the merits" — and the platform destroys recoverable work on the strength of that confusion.
- When no regeneration ever ran, the loop returns `blocked-no-regeneration` and leaves the build **recoverable**, keeping the existing design and review.

**A design the platform genuinely could not repair still escalates exactly as before** — that path is unchanged and pinned by test.

## Verification

- `lib/build` + `lib/queue` + `components/build`: **280 files / 2907 tests pass**.
- The integration case is confirmed **Red** against `origin/main` (the old code breaks and escalates), green with the fix.
- `pnpm --filter web typecheck` clean; guard loop 37/37; module-size, style-drift, docs-impact, spec/plan/doc, design-grounding clean.
- Runtime UX verification not performed — not deployed to the live install (`/ops/self-upgrade` owns that).

Refs: BI-E492F313, WC-09F9D248