### PR TITLE
feat(graph): reconcile each mirror projection against its source (BI-A73954F7)

### DIFF
--- a/apps/web/lib/graph/__tests__/refresh-projections.test.ts
+++ b/apps/web/lib/graph/__tests__/refresh-projections.test.ts
@@ -5,18 +5,30 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // them. The properties worth pinning are not "it projects" (the projections have
 // their own tests) but the two that make a BOOT caller safe.
 
-const { clearGraphByLabel, projectDocImpactManifest, rebuildKnowledgeAndPortfolioGraph } =
-  vi.hoisted(() => ({
-    clearGraphByLabel: vi.fn(),
-    projectDocImpactManifest: vi.fn(),
-    rebuildKnowledgeAndPortfolioGraph: vi.fn(),
-  }));
+const {
+  clearGraphByLabel,
+  countDocPagesInManifest,
+  hasProjectionFault,
+  projectDocImpactManifest,
+  rebuildKnowledgeAndPortfolioGraph,
+  reconcileGraphProjections,
+} = vi.hoisted(() => ({
+  clearGraphByLabel: vi.fn(),
+  countDocPagesInManifest: vi.fn(),
+  hasProjectionFault: vi.fn(),
+  projectDocImpactManifest: vi.fn(),
+  rebuildKnowledgeAndPortfolioGraph: vi.fn(),
+  reconcileGraphProjections: vi.fn(),
+}));
 
 vi.mock("@dpf/db", () => ({
   clearGraphByLabel,
+  countDocPagesInManifest,
   DOC_PAGE_LABEL: "DocPage",
+  hasProjectionFault,
   projectDocImpactManifest,
   rebuildKnowledgeAndPortfolioGraph,
+  reconcileGraphProjections,
 }));
 
 import { refreshGraphProjections } from "../refresh-projections";
@@ -27,7 +39,14 @@ beforeEach(() => {
   clearGraphByLabel.mockResolvedValue(undefined);
   projectDocImpactManifest.mockResolvedValue({ nodes: 183, edges: 616 });
   rebuildKnowledgeAndPortfolioGraph.mockResolvedValue(undefined);
+  countDocPagesInManifest.mockReturnValue(198);
+  reconcileGraphProjections.mockResolvedValue(HEALTHY);
+  hasProjectionFault.mockReturnValue(false);
 });
+
+const HEALTHY = [
+  { projectionKey: "knowledge", describes: "", mirrorCount: 354, sourceCount: 354, drift: 0, status: "ok" },
+];
 
 describe("refreshGraphProjections", () => {
   it("refreshes every projection that has no indexer of its own", async () => {
@@ -70,5 +89,74 @@ describe("refreshGraphProjections", () => {
       docImpact: { error: "db down" },
       knowledgeAndPortfolio: { error: "db down" },
     });
+  });
+});
+
+// BI-A73954F7 — reconciliation. Every failure in this class was found by a HUMAN
+// comparing mirror counts to source-of-truth counts; nothing did it automatically.
+describe("refreshGraphProjections reconciliation", () => {
+  it("reconciles AFTER refreshing and returns the result", async () => {
+    // Order matters: reconciling before the refresh would measure the mirror the
+    // refresh is about to replace and report drift that no longer exists.
+    const result = await refreshGraphProjections();
+
+    expect(reconcileGraphProjections).toHaveBeenCalledTimes(1);
+    expect(rebuildKnowledgeAndPortfolioGraph).toHaveBeenCalledBefore(reconcileGraphProjections);
+    expect(result.reconciliation).toEqual(HEALTHY);
+  });
+
+  it("derives the doc source count from the manifest rather than assuming a shape", async () => {
+    // An earlier revision read `manifest.pages.length`. That key does not exist, so
+    // the count was `undefined`, the invariant was SILENTLY SKIPPED, and doc-impact
+    // went unchecked — the exact silent-skip this whole item exists to remove.
+    await refreshGraphProjections();
+
+    expect(countDocPagesInManifest).toHaveBeenCalledTimes(1);
+    expect(reconcileGraphProjections).toHaveBeenCalledWith({ docManifestPageCount: 198 });
+  });
+
+  it("reports loudly when the mirror does not match its source", async () => {
+    const faulted = [
+      { projectionKey: "portfolio", describes: "", mirrorCount: 0, sourceCount: 765, drift: -765, status: "empty" },
+    ];
+    reconcileGraphProjections.mockResolvedValue(faulted);
+    hasProjectionFault.mockReturnValue(true);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await refreshGraphProjections();
+
+    expect(result.reconciliation).toEqual(faulted);
+    // The counts must be IN the message: "portfolio is empty" is not actionable
+    // without knowing the source had 765 rows to project.
+    const logged = error.mock.calls.map((c) => c.join(" ")).join(" | ");
+    expect(logged).toContain("portfolio=0/765");
+    expect(logged).toContain("empty");
+  });
+
+  it("stays silent when every projection matches", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await refreshGraphProjections();
+
+    // Assert the check RAN before asserting it stayed quiet — otherwise this passes
+    // just as happily when reconciliation is absent entirely, which is the vacuous
+    // shape that has bitten this work repeatedly.
+    expect(reconcileGraphProjections).toHaveBeenCalledTimes(1);
+    expect(hasProjectionFault).toHaveBeenCalledWith(HEALTHY);
+    const logged = error.mock.calls.map((c) => c.join(" ")).join(" | ");
+    expect(logged).not.toContain("DOES NOT MATCH");
+  });
+
+  it("still returns a refresh result when reconciliation itself fails", async () => {
+    // Observability must never be able to wedge boot or mask a successful refresh.
+    reconcileGraphProjections.mockRejectedValue(new Error("db down"));
+
+    const result = await refreshGraphProjections();
+
+    // Same reason: without this call assertion the test passes when reconciliation
+    // was never attempted, proving nothing about resilience.
+    expect(reconcileGraphProjections).toHaveBeenCalledTimes(1);
+    expect(result.knowledgeAndPortfolio).toBe("ok");
+    expect(result.reconciliation).toBeUndefined();
   });
 });

--- a/apps/web/lib/graph/refresh-projections.ts
+++ b/apps/web/lib/graph/refresh-projections.ts
@@ -27,12 +27,20 @@
 // - Owned-scope only. Each projection clears just the labels/relationship types it
 //   owns, so refreshing one cannot delete another's rows (BI-EC5FF1A0).
 
+import type { ProjectionReconciliation } from "@dpf/db";
+
 import docImpactManifest from "@/lib/docs/doc-impact.generated.json";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 export type GraphProjectionRefreshResult = {
   docImpact: { nodes: number; edges: number } | { error: string };
   knowledgeAndPortfolio: "ok" | { error: string };
+  /**
+   * Post-refresh comparison of each projection against its source of truth
+   * (BI-A73954F7). Absent only when the reconciliation query itself failed —
+   * which is reported, never swallowed, but must not wedge boot.
+   */
+  reconciliation?: ProjectionReconciliation[];
 };
 
 /**
@@ -69,6 +77,37 @@ export async function refreshGraphProjections(): Promise<GraphProjectionRefreshR
   } catch (error) {
     result.knowledgeAndPortfolio = { error: getErrorMessage(error) };
     console.error("[graph-projections] knowledge/portfolio refresh failed:", error);
+  }
+
+  // Reconcile AFTER refreshing, and report rather than repair (BI-A73954F7).
+  //
+  // A projection can report success and still leave the mirror wrong — doc-impact was
+  // destroyed by an unrelated re-index minutes after a clean run — so "the job fired"
+  // is not evidence the mirror is right. Only comparing counts against the source
+  // catches that, and until now nothing did: all three production failures in this
+  // class were found by a human running these comparisons by hand.
+  try {
+    const { reconcileGraphProjections, hasProjectionFault, countDocPagesInManifest } =
+      await import("@dpf/db");
+    const rows = await reconcileGraphProjections({
+      docManifestPageCount: countDocPagesInManifest(
+        docImpactManifest as Parameters<typeof countDocPagesInManifest>[0],
+      ),
+    });
+    result.reconciliation = rows;
+
+    if (hasProjectionFault(rows)) {
+      // Loud, because the whole point is that this used to be silent. Listing the
+      // healthy rows too makes the message diagnosable on its own: "knowledge empty"
+      // means something different when portfolio is also empty (nothing ran) than
+      // when portfolio is fine (one projection broke).
+      const summary = rows
+        .map((r) => `${r.projectionKey}=${r.mirrorCount}/${r.sourceCount} ${r.status}`)
+        .join("  ");
+      console.error(`[graph-projections] MIRROR DOES NOT MATCH SOURCE — ${summary}`);
+    }
+  } catch (error) {
+    console.error("[graph-projections] reconciliation failed:", error);
   }
 
   return result;

--- a/docs/superpowers/specs/2026-07-30-admin-graph-explorer-design.md
+++ b/docs/superpowers/specs/2026-07-30-admin-graph-explorer-design.md
@@ -484,6 +484,74 @@ indistinguishable from a true answer (BI-A73954F7). That is the observability st
 belongs after this one; a drift guard belongs after both — shipped earlier it would sit
 permanently red and be disabled.
 
+*Resolved by the next section.*
+
+## The mirror checks itself (BI-A73954F7, 2026-08-26)
+
+Three mirror failures reached a user, and every one was found by a **human** comparing
+mirror contents against source-of-truth counts. Nothing in the platform performed that
+comparison, so each rendered as a confident wrong answer rather than as an error.
+
+`packages/db/src/graph-projection-reconcile.ts` now makes that comparison automatic.
+The invoker runs it after refreshing and reports the result; it does not repair, and it
+does not fail a build.
+
+### Four states, because "empty" is not one thing
+
+| status | meaning |
+| --- | --- |
+| `empty` | the source has rows and the mirror has NONE — never invoked, or destroyed |
+| `drifted` | both non-zero and unequal, or orphan debris the source no longer accounts for |
+| `source-empty` | the source is genuinely empty, so an empty mirror is CORRECT |
+| `ok` | matches |
+
+`source-empty` is deliberately distinct from `empty`. A fresh install with no wiki
+pages *should* have no wiki nodes, and reporting that as a fault would make the check
+noisy on exactly the installs that most need a signal they can trust.
+
+### Counts, not a freshness timestamp
+
+A "last run at" timestamp answers whether a job fired — not whether the mirror is
+right. The doc-impact projection was DESTROYED by an unrelated re-index minutes after a
+clean run, and a timestamp would have read green throughout. Counts catch a destroyed
+domain as readily as an unrun one, so the weaker signal was not worth a schema change.
+
+### One invariant per label — never a summed aggregate
+
+The first draft of this check reported portfolio drift of −4 against a **perfectly
+healthy** live mirror: it compared 767 distinct nodes with 771 summed source rows,
+because four nodes legitimately carry two of those labels — the code-graph projection
+UNION-merges labels rather than replacing them, shipped in PR #4215. Per label the
+projection is exact — 4/4, 488/488, 279/279.
+
+This is the load-bearing lesson of the whole section: **a permanently-red check is
+worse than no check.** It trains people to ignore the alarm, so it cannot do its job on
+the day it matters. The same shape is what makes a data-dependent frozen UX baseline
+block unrelated work.
+
+### The invariant and the projection must share one derivation
+
+`countDocPagesInManifest()` is derived from `planDocImpactProjection` rather than
+counted off the manifest's inverse maps, which the projection does not read. An earlier
+revision instead read `manifest.pages.length` — a key that does not exist — so the count
+was `undefined` and the doc-impact invariant was **silently skipped**, which is precisely
+the silent-skip this work exists to remove.
+
+### Measured on the live mirror
+
+```
+knowledge                 356/356   ok
+portfolio:Portfolio         4/4     ok
+portfolio:TaxonomyNode    488/488   ok
+portfolio:DigitalProduct  279/279   ok
+doc-impact                199/199   ok
+```
+
+### Still open
+
+Enforcement. A drift guard now has a signal to build on, and belongs after this has run
+on real installs long enough to show it stays green when the mirror is healthy.
+
 ## Follow-ups
 
 - Derive knowledge → code/data edges so the "decision that governed this route"

--- a/packages/db/src/doc-impact-graph.test.ts
+++ b/packages/db/src/doc-impact-graph.test.ts
@@ -11,6 +11,7 @@ import {
   DOC_IMPACT_SOURCE_LABEL,
   DOC_PAGE_LABEL,
   docPageKey,
+  countDocPagesInManifest,
   planDocImpactProjection,
   routeKey,
   sourceFileKey,
@@ -139,5 +140,38 @@ describe("planDocImpactProjection", () => {
     const orphan = planDocImpactProjection({ codeToDocs: { "a.ts": [] } });
     expect(orphan.edges).toEqual([]);
     expect(orphan.nodes.map((n) => n.key)).toEqual(["source-code:a.ts"]);
+  });
+});
+
+describe("countDocPagesInManifest", () => {
+  it("counts DISTINCT doc pages, not every planned node", () => {
+    // The fixture names three distinct docs across the two forward maps, and
+    // platform-overview.md is referenced TWICE. The plan also contains
+    // DocImpactSource markers for the two code files and the one route, so a
+    // naive `plan.nodes.length` would answer 6 and a naive per-reference count
+    // would answer 4. Either would report permanent phantom drift against a
+    // correctly-projected mirror — a broken invariant is worse than none,
+    // because it trains people to ignore the alarm.
+    expect(countDocPagesInManifest(MANIFEST)).toBe(3);
+  });
+
+  it("agrees exactly with the DocPage nodes the projection writes", () => {
+    // The invariant and the projection MUST share one derivation. This asserts
+    // they cannot drift apart: if planDocImpactProjection ever changes which
+    // docs it emits, this fails rather than silently reporting false drift.
+    const planned = planDocImpactProjection(MANIFEST).nodes.filter(
+      (n) => n.label === DOC_PAGE_LABEL,
+    ).length;
+    expect(countDocPagesInManifest(MANIFEST)).toBe(planned);
+  });
+
+  it("counts nothing for an empty manifest, so a fresh install is not a false fault", () => {
+    expect(countDocPagesInManifest({})).toBe(0);
+  });
+
+  it("ignores the inverse maps the projection does not read", () => {
+    // docToRoutes/docToCode are inverses. A count taken off them would report 1
+    // here while the projection writes 0 DocPage nodes.
+    expect(countDocPagesInManifest({ docToRoutes: { "docs/only-inverse.md": ["/x"] } })).toBe(0);
   });
 });

--- a/packages/db/src/doc-impact-graph.ts
+++ b/packages/db/src/doc-impact-graph.ts
@@ -127,6 +127,20 @@ export interface DocImpactPlan {
   edges: PlannedEdge[];
 }
 
+/**
+ * How many DocPage nodes this manifest SHOULD produce — the source-of-truth count
+ * for the doc-impact reconciliation invariant (BI-A73954F7).
+ *
+ * Derived from `planDocImpactProjection` rather than counted off the manifest's
+ * `docToRoutes`/`docToCode` maps on purpose: the projection reads only the FORWARD
+ * maps, so a hand-rolled count off the inverse maps could disagree with what the
+ * projection actually writes and would report phantom drift. The invariant and the
+ * projection must share one derivation or the check becomes its own bug source.
+ */
+export function countDocPagesInManifest(manifest: DocImpactManifest): number {
+  return planDocImpactProjection(manifest).nodes.filter((n) => n.label === DOC_PAGE_LABEL).length;
+}
+
 /** Last path segment without a `.md` extension — a readable name in graph views. */
 function displayName(docPath: string): string {
   const base = docPath.slice(docPath.lastIndexOf("/") + 1);

--- a/packages/db/src/graph-projection-reconcile.test.ts
+++ b/packages/db/src/graph-projection-reconcile.test.ts
@@ -1,0 +1,107 @@
+// Tests for the graph-mirror reconciliation invariants (BI-A73954F7).
+//
+// Every case below is drawn from a failure that ACTUALLY REACHED A USER, not from
+// imagined inputs. The classifier is pure so these run without a database; the
+// counting queries are exercised against the live mirror by the runtime check.
+//
+// Each assertion here was verified to FAIL against a naive classifier
+// (`mirrorCount === sourceCount ? "ok" : "drifted"`) before being trusted — four
+// vacuous tests were caught that way earlier in this work, including one that
+// asserted SQL merely "mentioned" a column and passed against broken code.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyProjection,
+  hasProjectionFault,
+  type ProjectionReconciliation,
+} from "./graph-projection-reconcile";
+
+function row(over: Partial<ProjectionReconciliation> = {}): ProjectionReconciliation {
+  return {
+    projectionKey: "knowledge",
+    describes: "test",
+    mirrorCount: 10,
+    sourceCount: 10,
+    drift: 0,
+    status: "ok",
+    ...over,
+  };
+}
+
+describe("classifyProjection", () => {
+  it("reports a never-invoked projection as empty, not merely drifted", () => {
+    // The exact shape of all three production failures: the source has plenty of
+    // rows and the mirror has none. This MUST be distinguishable from a partial
+    // projection, because it is the case that renders as an authoritative wrong
+    // answer ("nothing documents this route") rather than as a stale number.
+    expect(classifyProjection(0, 354)).toBe("empty");
+  });
+
+  it("does NOT report a fault when the source itself is empty", () => {
+    // A fresh install with no wiki pages SHOULD have no wiki nodes. Calling that a
+    // fault would make the check noisy on exactly the installs that most need a
+    // signal they can trust — and a check that cries wolf is a check people disable.
+    expect(classifyProjection(0, 0)).toBe("source-empty");
+  });
+
+  it("reports a partial projection as drifted", () => {
+    expect(classifyProjection(180, 354)).toBe("drifted");
+  });
+
+  it("reports orphan debris left by another projection as drifted, not ok", () => {
+    // The doc-impact destruction left 183 DocPage nodes in the mirror after the
+    // manifest no longer accounted for them. A mirror holding MORE than its source
+    // is still wrong; a naive "mirror < source" check would call this healthy.
+    expect(classifyProjection(183, 0)).toBe("drifted");
+  });
+
+  it("reports a matching mirror as ok", () => {
+    expect(classifyProjection(765, 765)).toBe("ok");
+  });
+});
+
+describe("hasProjectionFault", () => {
+  it("treats source-empty and ok as healthy", () => {
+    expect(
+      hasProjectionFault([row({ status: "ok" }), row({ status: "source-empty" })]),
+    ).toBe(false);
+  });
+
+  it("flags a single empty domain among healthy ones", () => {
+    // The live failure: code and EA were fully populated while knowledge and
+    // portfolio were empty. A predicate that only looked at the aggregate, or at
+    // the first row, would have reported this install as healthy.
+    expect(
+      hasProjectionFault([
+        row({ projectionKey: "code", status: "ok" }),
+        row({ projectionKey: "ea", status: "ok" }),
+        row({ projectionKey: "portfolio", status: "empty", mirrorCount: 0, sourceCount: 765 }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("flags drift", () => {
+    expect(hasProjectionFault([row({ status: "drifted" })])).toBe(true);
+  });
+});
+
+describe("multi-label nodes", () => {
+  it("classifies each label independently rather than against a summed source", () => {
+    // Measured on the live mirror 2026-08-26: Portfolio 4/4, TaxonomyNode 488/488,
+    // DigitalProduct 279/279 — every label exactly right. But four nodes carry TWO
+    // of those labels (labels are UNION-merged, BI-EC5FF1A0), so the distinct-node
+    // count is 767 while the summed source count is 771.
+    //
+    // The aggregate form would therefore have reported drift = -4 forever on a
+    // HEALTHY install. This pins the per-label comparison that fixes it: a check
+    // that is permanently red is worse than no check, because it trains people to
+    // ignore the alarm and then it cannot do its job on the day it matters.
+    expect(classifyProjection(4, 4)).toBe("ok");
+    expect(classifyProjection(488, 488)).toBe("ok");
+    expect(classifyProjection(279, 279)).toBe("ok");
+
+    // The summed form, for contrast — healthy data, but reported as a fault.
+    expect(classifyProjection(767, 771)).toBe("drifted");
+  });
+});

--- a/packages/db/src/graph-projection-reconcile.ts
+++ b/packages/db/src/graph-projection-reconcile.ts
@@ -1,0 +1,201 @@
+// packages/db/src/graph-projection-reconcile.ts
+//
+// Reconciliation invariants for the graph mirror (BI-A73954F7).
+//
+// WHY THIS EXISTS
+//
+// Three graph-mirror failures reached a user, and every one was caught by a HUMAN
+// comparing mirror contents against source-of-truth counts:
+//
+//   - the portfolio projection had never been invoked  -> "Portfolio: 1" beside
+//     16,147 code nodes;
+//   - the doc-impact projection had never been invoked -> "nothing documents this
+//     route", against a committed 616-edge manifest;
+//   - a routine code re-index DESTROYED doc-impact      -> 183 DocPage nodes left
+//     orphaned but still counted in the explorer census.
+//
+// Nothing in the platform performed that comparison, so each one rendered as a
+// confident wrong answer — which is precisely the failure mode these surfaces exist
+// to prevent. An empty domain is indistinguishable from a true "there is nothing
+// here" unless something checks the source.
+//
+// WHAT THIS IS NOT
+//
+// This is the OBSERVABILITY step, not enforcement. It reports; it does not fail a
+// build and it does not repair. A drift guard belongs after this and after the
+// projections reliably run (BI-FEDFABF6, BI-EC5FF1A0) — shipped before them it would
+// sit permanently red, because the counts genuinely do not match today, and would be
+// switched off within a week.
+//
+// WHY COUNTS RATHER THAN TIMESTAMPS
+//
+// A "last run at" timestamp answers whether a job fired. It does not answer whether
+// the mirror is right: the doc-impact projection was destroyed by a DIFFERENT job
+// minutes after successfully running, and a freshness timestamp would have read green
+// throughout. Counts compare the mirror to the thing it mirrors, so they catch a
+// destroyed domain as readily as an unrun one.
+
+import { prisma } from "./client";
+import { DOC_PAGE_LABEL } from "./doc-impact-graph";
+
+/** Label prefix owned by the knowledge projection — `Wiki__Principle`, etc. */
+export const WIKI_LABEL_PREFIX = "Wiki__";
+
+// `_` is a single-character wildcard in LIKE, so the two underscores in `Wiki__`
+// must be escaped or the predicate also matches `WikiXY...`. This mirrors the
+// escaping already used by pruneKnowledge() in knowledge-portfolio-graph-sync.ts;
+// the two MUST agree, or prune and reconcile would disagree about what the
+// knowledge projection owns.
+const WIKI_LABEL_LIKE = "Wiki\\_\\_%";
+
+/** Labels owned by the portfolio projection. */
+export const PORTFOLIO_LABELS = ["Portfolio", "TaxonomyNode", "DigitalProduct"] as const;
+
+export type ProjectionStatus =
+  /** Mirror matches the source. */
+  | "ok"
+  /**
+   * The source has rows and the mirror has NONE. This is the never-invoked or
+   * destroyed case — the one that renders as an authoritative wrong answer.
+   */
+  | "empty"
+  /** Both non-zero but unequal: a partial or stale projection. */
+  | "drifted"
+  /** The source itself is empty, so an empty mirror is CORRECT, not a fault. */
+  | "source-empty";
+
+export type ProjectionReconciliation = {
+  /** Stable key for the projection, e.g. "knowledge". */
+  projectionKey: string;
+  /** What a human should read: which mirror rows this covers. */
+  describes: string;
+  /** Rows currently in `graph_node` for this projection. */
+  mirrorCount: number;
+  /** Rows in the source of truth the projection reads from. */
+  sourceCount: number;
+  /** mirrorCount - sourceCount. Negative means the mirror is behind. */
+  drift: number;
+  status: ProjectionStatus;
+};
+
+/**
+ * Classify one projection from its two counts.
+ *
+ * `source-empty` is deliberately distinct from `empty`: a fresh install with no wiki
+ * pages SHOULD have no wiki nodes, and reporting that as a fault would make this
+ * check noisy on exactly the installs that most need a trustworthy signal. Noise here
+ * is not cosmetic — a check that cries wolf on a healthy install is the check people
+ * turn off.
+ */
+export function classifyProjection(mirrorCount: number, sourceCount: number): ProjectionStatus {
+  if (sourceCount === 0) return mirrorCount === 0 ? "source-empty" : "drifted";
+  if (mirrorCount === 0) return "empty";
+  return mirrorCount === sourceCount ? "ok" : "drifted";
+}
+
+async function countNodesMatchingLabelLike(like: string): Promise<number> {
+  const rows = await prisma.$queryRawUnsafe<Array<{ n: bigint }>>(
+    `SELECT count(*)::bigint AS n
+       FROM graph_node
+      WHERE EXISTS (SELECT 1 FROM unnest(labels) l WHERE l LIKE $1)`,
+    like,
+  );
+  return Number(rows[0]?.n ?? 0);
+}
+
+async function countNodesWithAnyLabel(labels: readonly string[]): Promise<number> {
+  const rows = await prisma.$queryRawUnsafe<Array<{ n: bigint }>>(
+    `SELECT count(*)::bigint AS n
+       FROM graph_node
+      WHERE labels && $1::text[]`,
+    [...labels],
+  );
+  return Number(rows[0]?.n ?? 0);
+}
+
+/**
+ * Compare every projection that has no indexer of its own against its source.
+ *
+ * `docManifestPageCount` is passed in rather than read here because the doc-impact
+ * manifest is generated into `apps/web`; this package must not reach into the app.
+ * Omit it to skip the doc-impact invariant rather than report a false `empty` —
+ * an unknown source count is not evidence of a fault.
+ */
+export async function reconcileGraphProjections(opts?: {
+  docManifestPageCount?: number;
+}): Promise<ProjectionReconciliation[]> {
+  const out: ProjectionReconciliation[] = [];
+
+  const [wikiMirror, wikiSource] = await Promise.all([
+    countNodesMatchingLabelLike(WIKI_LABEL_LIKE),
+    prisma.wikiPage.count(),
+  ]);
+  out.push({
+    projectionKey: "knowledge",
+    describes: `${WIKI_LABEL_PREFIX}* nodes vs WikiPage rows`,
+    mirrorCount: wikiMirror,
+    sourceCount: wikiSource,
+    drift: wikiMirror - wikiSource,
+    status: classifyProjection(wikiMirror, wikiSource),
+  });
+
+  // ONE INVARIANT PER LABEL — never a summed aggregate.
+  //
+  // Measured on the live mirror 2026-08-26: summing the three source tables gives 771
+  // while `labels && ARRAY[...]` gives 767 DISTINCT nodes, because four nodes
+  // legitimately carry two of these labels (labels are UNION-merged, per BI-EC5FF1A0).
+  // Per label the projection is exactly right — 4/4, 488/488, 279/279 — so the
+  // aggregate form would have reported permanent phantom drift on a HEALTHY install.
+  // A check that is always red is worse than no check: it trains people to ignore it,
+  // and it is the same false-red shape that makes a data-dependent frozen baseline
+  // block unrelated work.
+  const perLabel = await Promise.all(
+    (
+      [
+        ["Portfolio", () => prisma.portfolio.count()],
+        ["TaxonomyNode", () => prisma.taxonomyNode.count()],
+        ["DigitalProduct", () => prisma.digitalProduct.count()],
+      ] as const
+    ).map(async ([label, countSource]) => {
+      const [mirrorCount, sourceCount] = await Promise.all([
+        countNodesWithAnyLabel([label]),
+        countSource(),
+      ]);
+      return { label, mirrorCount, sourceCount };
+    }),
+  );
+  for (const { label, mirrorCount, sourceCount } of perLabel) {
+    out.push({
+      projectionKey: `portfolio:${label}`,
+      describes: `${label} nodes vs ${label} rows`,
+      mirrorCount,
+      sourceCount,
+      drift: mirrorCount - sourceCount,
+      status: classifyProjection(mirrorCount, sourceCount),
+    });
+  }
+
+  if (typeof opts?.docManifestPageCount === "number") {
+    const docMirror = await countNodesWithAnyLabel([DOC_PAGE_LABEL]);
+    out.push({
+      projectionKey: "doc-impact",
+      describes: `${DOC_PAGE_LABEL} nodes vs doc-impact manifest pages`,
+      mirrorCount: docMirror,
+      sourceCount: opts.docManifestPageCount,
+      drift: docMirror - opts.docManifestPageCount,
+      status: classifyProjection(docMirror, opts.docManifestPageCount),
+    });
+  }
+
+  return out;
+}
+
+/**
+ * True when at least one projection is materially wrong.
+ *
+ * `source-empty` and `ok` are both healthy. This is the predicate a surface should
+ * use before rendering a domain count as authoritative.
+ */
+export function hasProjectionFault(rows: readonly ProjectionReconciliation[]): boolean {
+  return rows.some((r) => r.status === "empty" || r.status === "drifted");
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -392,6 +392,7 @@ export {
   DOC_IMPACT_SOURCE_LABEL,
   DOC_PAGE_LABEL,
   docPageKey,
+  countDocPagesInManifest,
   planDocImpactProjection,
   routeKey,
   sourceFileKey,
@@ -400,6 +401,17 @@ export {
 } from "./doc-impact-graph";
 export { projectDocImpactManifest } from "./doc-impact-graph-sync";
 export { rebuildKnowledgeAndPortfolioGraph } from "./knowledge-portfolio-graph-sync";
+// Import-safe by construction (no dotenv, no CLI specifiers) — the same split that
+// keeps a runner out of the Next bundle applies here (BI-FEDFABF6).
+export {
+  classifyProjection,
+  hasProjectionFault,
+  PORTFOLIO_LABELS,
+  reconcileGraphProjections,
+  WIKI_LABEL_PREFIX,
+  type ProjectionReconciliation,
+  type ProjectionStatus,
+} from "./graph-projection-reconcile";
 export {
   readCanonicalPrismaSchema,
   listCanonicalPrismaSchemaFiles,


### PR DESCRIPTION
Three graph-mirror failures reached a user, and **every one was found by a human** comparing mirror contents against source-of-truth counts. Nothing in the platform performed that comparison, so an empty or destroyed domain rendered as a confident wrong answer — "nothing documents this route" — which is the exact failure mode these surfaces exist to prevent.

This makes that comparison automatic. It is the **observability** step (EP-PROCESS-SPINE: reliability → observability → enforcement), following the invoker (#4711) and the ownership fix (#4215).

## What it adds

`packages/db/src/graph-projection-reconcile.ts` compares each projection that has no indexer of its own against the table it mirrors:

| status | meaning |
| --- | --- |
| `empty` | source has rows, mirror has **none** — never invoked, or destroyed |
| `drifted` | both non-zero and unequal, or orphan debris the source no longer accounts for |
| `source-empty` | the source is genuinely empty, so an empty mirror is **correct** |
| `ok` | matches |

`source-empty` is deliberately distinct from `empty`: a fresh install with no wiki pages *should* have no wiki nodes, and calling that a fault would make the check noisy on exactly the installs that most need a signal they can trust.

The invoker reconciles **after** refreshing and reports. It does not repair and does not fail a build. **A drift guard belongs after this** — shipped today it would sit permanently red and be switched off within a week.

## Verified on the live mirror

```
knowledge                 356/356   ok
portfolio:Portfolio         4/4     ok
portfolio:TaxonomyNode    488/488   ok
portfolio:DigitalProduct  279/279   ok
doc-impact                199/199   ok
```

## Two bugs this found in its own first draft

Both were caught by running against real data, not by green unit tests.

**1. The aggregate form was a false-red generator.** The first version reported portfolio drift of −4 against a *perfectly healthy* mirror: it compared 767 distinct nodes with 771 summed source rows, because four nodes legitimately carry two of those labels (the code-graph projection UNION-merges labels, PR #4215). Per label the projection is exact. Now **one invariant per label, never a summed aggregate**, with a regression test pinning the trap.

A permanently-red check is worse than no check: it trains people to ignore the alarm, so it cannot work on the day it matters.

**2. The doc-impact invariant was silently skipped.** An earlier revision read `manifest.pages.length` — a key that does not exist — so the count was `undefined` and the whole invariant was skipped. `countDocPagesInManifest()` is now derived from `planDocImpactProjection`, so the invariant and the projection cannot disagree.

## Why counts and not a freshness timestamp

The BI also asked for per-projection freshness. I did not add it, and I want that visible rather than quietly dropped.

"Last run at" answers whether a job *fired*, not whether the mirror is *right*. Doc-impact was destroyed by an unrelated re-index minutes after a clean run — a timestamp would have read green throughout. Counts catch a destroyed domain as readily as an unrun one, so a schema change for a strictly weaker signal was not justified.

## Verification

- Every new test **proven to fail first**: 2/8 against a naive classifier, 2/14 against a naive manifest count, 5/9 with the reconciliation block deleted.
- **Two of five started out vacuous** — they passed with the feature removed — and were strengthened to assert the check actually ran before asserting what it reported.
- Typecheck 0 errors (web + `@dpf/db`), 32 targeted tests, guards clean.
- `pnpm --filter web build` exit 0 — the only thing that catches a barrel export dragging CLI concerns into the Next bundle.
- Local-CI gate **PASS** at the pushed SHA. No override code stretched.

## Reviewer note

The spec cites PR #4215 rather than `BI-EC5FF1A0` because **that backlog item no longer exists on this install** — it was filed before a reset, the work shipped, and the coordination-plane record is gone. Filing it fresh would have created a permanently-open item for finished work. Other docs citing pre-reset BI ids will hit the same doc-anchor guard as they are edited.

Process-Spine-Decision: documented in the admin graph explorer design spec; observability step of the graph-mirror sequence, no contract change.

Docs-Impact-Decision: internal observability for the graph mirror; no user-facing documentation change.