### PR TITLE
fix(build-studio): "not started" belongs only to phases that record dispatches (BI-CE1AB982 follow-up)

### DIFF
--- a/apps/web/lib/build/customer-status-projection.test.ts
+++ b/apps/web/lib/build/customer-status-projection.test.ts
@@ -278,15 +278,48 @@ describe("reconcileBuildStudioCustomerStatus — canonical owner state", () => {
     expect(status.ownerState).not.toBe("blocked");
   });
 
-  it("does not claim work is in progress while no task or dispatch exists in ideate", () => {
+  // Corrects BI-CE1AB982's over-generalisation. ideate and plan never write
+  // BuildDispatchAttempt rows, so "no dispatch rows" says nothing about them —
+  // live repro FB-41EA43C5 reported "No research step has started" on a build
+  // whose ideate had already produced, reviewed, repaired and passed a design.
+  it("does not claim ideate has not started merely because it records no dispatch rows", () => {
     const status = reconcileBuildStudioCustomerStatus({
       phase: "ideate",
       status: base,
       progress: progress(),
     });
 
+    expect(status.ownerState).not.toBe("not-started");
+    expect(status.worker).not.toMatch(/no research step has started/i);
+  });
+
+  it("still reports not-started for build, which does record dispatch rows", () => {
+    const status = reconcileBuildStudioCustomerStatus({
+      phase: "build",
+      status: base,
+      progress: progress(),
+    });
+
     expect(status.ownerState).toBe("not-started");
-    expect(status.worker).not.toMatch(/working on this change/i);
+    expect(status.worker).toMatch(/no implementation task has started/i);
+  });
+
+  // The case the generalisation was reaching for is still covered — by the
+  // durable refusal signal, not by inferring from absent rows.
+  it("still renders a refused ideate dispatch as blocked", () => {
+    const status = reconcileBuildStudioCustomerStatus({
+      phase: "ideate",
+      status: base,
+      progress: progress({
+        dispatchBlock: {
+          blocked: true,
+          reason: "Connect, provision, or wait for one allowed Build Studio engine, then retry.",
+          observedAt: "2026-08-12T12:00:00.000Z",
+        },
+      }),
+    });
+
+    expect(status.ownerState).toBe("blocked");
   });
 
   it("shows a real in-flight dispatch with persisted elapsed time and a bounded expectation", () => {

--- a/apps/web/lib/build/owner-status-reconciliation.ts
+++ b/apps/web/lib/build/owner-status-reconciliation.ts
@@ -182,12 +182,24 @@ export function reconcileBuildStudioCustomerStatus(args: {
     };
   }
 
-  // BI-CE1AB982: this guard used to be gated to build/review, on the reasoning
-  // that ideate/plan are coworker-custody. But "no task, no dispatch, nothing in
-  // flight" means no work has started in ANY phase, and the fallthrough below
-  // resolves that to "working". Claiming progress is only honest once something
-  // has actually been dispatched, so the guard now covers every live phase.
-  if (progress.tasks.totalTasks === 0 && progress.dispatchHistory.length === 0) {
+  // Only build/review record BuildDispatchAttempt rows and task results.
+  //
+  // BI-CE1AB982 generalised this guard to every phase, on the reasoning that "no
+  // task, no dispatch, nothing in flight" means no work has started. That was
+  // wrong for ideate and plan: they never write dispatch rows at all, so the
+  // condition is vacuously true there — and a build whose ideate had ALREADY
+  // produced, reviewed, repaired and passed a design document still reported
+  // "No research step has started" (live repro FB-41EA43C5).
+  //
+  // The case that generalisation was reaching for — an ideate that never
+  // dispatched — is covered honestly by the dispatchBlock branch above, which
+  // reads a durable refusal signal rather than inferring from absent rows. So
+  // this guard belongs back on the phases whose evidence it actually reads.
+  if (
+    (phase === "build" || phase === "review")
+    && progress.tasks.totalTasks === 0
+    && progress.dispatchHistory.length === 0
+  ) {
     return {
       ...status,
       ownerState: "not-started",


### PR DESCRIPTION
## Correcting my own over-generalisation in #4664

[#4664](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4664) moved the zero-dispatch guard from `build`/`review` onto **every** phase, reasoning that "no task, no dispatch, nothing in flight" means no work has started.

It does not. **`ideate` and `plan` never write `BuildDispatchAttempt` rows or task results at all**, so the condition is vacuously true for them — and the panel reported *"Preparing / No research step has started / Build Studio has not dispatched research work yet"* on a build whose ideate had already produced, reviewed, repaired and **passed** a design document.

Live repro `FB-41EA43C5` on the Pet Rescue install, running the image that carries #4664:

```
19:53:52  ideate dispatched via codex
20:02:31  regenerated designDoc saved (153.6s)
20:06:29  Design review passed after 1 fix round
panel:    "No research step has started"
```

That is the same defect #4664 set out to fix, pointed the other way: the surface contradicting what the platform knows.

## Change

The guard goes back to the phases whose evidence it actually reads.

The case the generalisation was reaching for — an ideate that never dispatched — is **already covered** by the `dispatchBlock` branch #4664 added in the same file, which reads a durable refusal signal instead of inferring from absent rows. Nothing is lost by narrowing this.

Three tests pin the halves:
- `ideate` must not be called not-started merely for recording no dispatch rows
- `build` still is, because it does record them
- a refused ideate dispatch still renders **blocked**

## Verification

- `lib/build` + `components/build`: **240 files / 2582 tests pass**.
- The ideate case is confirmed **Red** against `origin/main`, green with the fix.
- `pnpm --filter web typecheck` clean; guard loop 37/37; docs-impact, spec/plan/doc, design-grounding clean.

Refs: BI-CE1AB982