### PR TITLE
feat(workforce): model worker classification as a typed legal axis (BI-C61CEEA9)

### DIFF
--- a/apps/web/lib/govern/data/assets.ts
+++ b/apps/web/lib/govern/data/assets.ts
@@ -33,6 +33,7 @@ import { LIFECYCLE_GOVERNANCE_ASSETS } from "./lifecycle-governance-assets";
 import { STOCK_COVERAGE_ASSETS } from "./stock-coverage-assets";
 import { FINANCE_INVOICE_DOCUMENT_ASSETS } from "./finance-invoice-document-assets";
 import { RECRUITING_ASSETS } from "./recruiting-assets";
+import { WORKER_CLASSIFICATION_ASSETS } from "./worker-classification-assets";
 import { DECISION_TRUST_ENVELOPE_ASSETS } from "./decision-trust-envelope-assets";
 import { MCP_ASSETS } from "./mcp-assets";
 import { INITIATIVE_GOVERNANCE_ASSETS } from "./initiative-governance-assets";
@@ -730,6 +731,7 @@ const SEED_ASSETS: readonly DataAssetDefinition[] = [
   ...FINANCE_INVOICE_DOCUMENT_ASSETS, ...BUSINESS_PERFORMANCE_ASSETS,
   ...PROCESSING_GOVERNANCE_ASSETS,
   ...RECRUITING_ASSETS,
+  ...WORKER_CLASSIFICATION_ASSETS,
   ...DECISION_TRUST_ENVELOPE_ASSETS,
   ...MCP_ASSETS,
   ...INITIATIVE_GOVERNANCE_ASSETS,

--- a/apps/web/lib/govern/data/worker-classification-assets.ts
+++ b/apps/web/lib/govern/data/worker-classification-assets.ts
@@ -1,0 +1,166 @@
+// Data-governance registration for worker classification (BI-C61CEEA9).
+//
+// A classification is a human judgement about a worker's legal status, and it
+// decides whether the organisation may direct them, whether withholding applies
+// and whether they accrue entitlements. A wrong or unaccountable value is
+// misclassification exposure for the employer and lost entitlements for the
+// worker, so these are regulated records — confidential, local, and never
+// auto-purged.
+//
+// Registered rather than added to the legacy coverage baseline: that baseline
+// grandfathers models whose governance was never stated, with a remediation BI
+// and a deadline. These models are new and their governance is known, so
+// baselining them would be filing fresh debt against a ratchet built to retire it.
+
+import type { DataAssetDefinition } from "./assets";
+import type { DataCategory, DataFieldId } from "./taxonomy";
+
+const CLASSIFICATION = {
+  state: "confirmed",
+  source: "manual",
+  effectiveFrom: "2026-08-26",
+} as const;
+
+const PROVENANCE = {
+  source: "manual",
+  state: "confirmed",
+  assertedBy: "data-steward",
+  effectiveFrom: "2026-08-26",
+} as const;
+
+/** Operational metadata: timestamps, lifecycle state and typed joins. */
+function operationalFields(assetId: string, physicalNames: readonly string[]) {
+  return physicalNames.map((physicalName) => ({
+    id: `${assetId}#${physicalName}` as DataFieldId,
+    physicalName,
+    resolution: "governed" as const,
+    resolutionReason:
+      "Operational record metadata — surrogate key, timestamps, lifecycle state or a typed join. Carries no fact about the worker beyond the row's own bookkeeping.",
+    categories: ["operational"] as DataCategory[],
+    sensitivity: "internal" as const,
+    collectionRule: "allowed" as const,
+    protection: "none" as const,
+    provenance: PROVENANCE,
+  }));
+}
+
+/**
+ * Fields that carry the employment-law judgement itself, or narrative about it.
+ *
+ * Masked on read: a classification and its reasoning are readable by the worker,
+ * their accountable manager chain and workforce administration, and by nobody
+ * else through an incidental projection.
+ */
+function judgementFields(assetId: string, physicalNames: readonly string[]) {
+  return physicalNames.map((physicalName) => ({
+    id: `${assetId}#${physicalName}` as DataFieldId,
+    physicalName,
+    resolution: "governed" as const,
+    resolutionReason:
+      "Employment-law judgement about a named worker, or the reasoning and evidence behind it. Expose only through an authorized workforce projection with masking applied; never an input to automated scoring or selection.",
+    categories: ["personal-attribute", "operational"] as DataCategory[],
+    sensitivity: "confidential" as const,
+    collectionRule: "minimize" as const,
+    protection: "mask-on-read" as const,
+    projectionOverride: "masked-content" as const,
+    provenance: PROVENANCE,
+  }));
+}
+
+/** The worker this row is about, and the human accountable for the judgement. */
+function identityFields(assetId: string, physicalNames: readonly string[]) {
+  return physicalNames.map((physicalName) => ({
+    id: `${assetId}#${physicalName}` as DataFieldId,
+    physicalName,
+    resolution: "governed" as const,
+    resolutionReason:
+      "Points at a person — the worker the determination is about, or the human accountable for making it. Identity governance is inherited from the referenced party record; this is a typed join, not a second home for identity.",
+    categories: ["identity"] as DataCategory[],
+    sensitivity: "confidential" as const,
+    collectionRule: "minimize" as const,
+    protection: "mask-on-read" as const,
+    provenance: PROVENANCE,
+  }));
+}
+
+export const WORKER_CLASSIFICATION_ASSETS: readonly DataAssetDefinition[] = [
+  {
+    id: "data:worker-classification-determination",
+    physical: { prismaModel: "WorkerClassificationDetermination" },
+    domain: "people-hcm",
+    ownerRole: "business-operator",
+    stewardRole: "data-steward",
+    categories: ["personal-attribute", "operational"],
+    sensitivity: "confidential",
+    criticality: "high",
+    subjectLocators: [{ role: "employee", fieldPath: "employeeProfile" }],
+    lifecycleClass: "regulated-record",
+    purposeCapabilities: [
+      "service-delivery",
+      "compliance-and-legal",
+    ],
+    residencyClass: "local-only",
+    projectionClass: "masked-content",
+    classification: CLASSIFICATION,
+    fields: [
+      ...judgementFields("data:worker-classification-determination", [
+        "classification",
+        "evidence",
+        "rationale",
+        "lifecycleReason",
+      ]),
+      ...identityFields("data:worker-classification-determination", [
+        "employeeProfileId",
+        "determinedByUserId",
+      ]),
+      ...operationalFields("data:worker-classification-determination", [
+        "id",
+        "workerClassificationDeterminationId",
+        "jurisdictionSlug",
+        "determinedAt",
+        "lifecycle",
+        "lifecycleAt",
+        "createdAt",
+        "updatedAt",
+      ]),
+    ],
+  },
+  {
+    id: "data:worker-engagement-term",
+    physical: { prismaModel: "WorkerEngagementTerm" },
+    domain: "people-hcm",
+    ownerRole: "business-operator",
+    stewardRole: "data-steward",
+    categories: ["personal-attribute", "operational"],
+    sensitivity: "confidential",
+    criticality: "high",
+    subjectLocators: [{ role: "employee", fieldPath: "employeeProfile" }],
+    lifecycleClass: "regulated-record",
+    purposeCapabilities: [
+      "service-delivery",
+      "compliance-and-legal",
+    ],
+    residencyClass: "local-only",
+    projectionClass: "masked-content",
+    classification: CLASSIFICATION,
+    fields: [
+      // The agreed dates are the engagement fact that reclassifies a contractor
+      // as an employee when it drifts, so they sit with the judgement, not with
+      // ordinary timestamps.
+      ...judgementFields("data:worker-engagement-term", [
+        "startsOn",
+        "endsOn",
+        "lifecycleReason",
+      ]),
+      ...identityFields("data:worker-engagement-term", ["employeeProfileId"]),
+      ...operationalFields("data:worker-engagement-term", [
+        "id",
+        "workerEngagementTermId",
+        "lifecycle",
+        "lifecycleAt",
+        "createdAt",
+        "updatedAt",
+      ]),
+    ],
+  },
+];

--- a/apps/web/lib/operate/retention/policies.ts
+++ b/apps/web/lib/operate/retention/policies.ts
@@ -591,6 +591,14 @@ export const RETAINED_DATASETS: readonly RetainedDataset[] = [
   { model: "payRun", label: "Pay runs", regulatoryBasis: "Payroll/wage record retention (IRS employment-tax + FLSA payroll recordkeeping)", minRetentionYears: 7 },
   { model: "payslip", label: "Payslips", regulatoryBasis: "Payroll/wage record retention (IRS employment-tax + FLSA payroll recordkeeping)", minRetentionYears: 7 },
 
+  // Worker classification evidence (BI-C61CEEA9). A classification decides
+  // whether the organisation may direct a worker and whether they accrue
+  // entitlements, so the determination and the engagement term behind it are
+  // the record a misclassification challenge turns on. Same statutory footing
+  // as the payroll records above.
+  { model: "workerClassificationDetermination", label: "Worker classification determinations", regulatoryBasis: "Worker-classification evidence (IRS worker-classification + FLSA employment recordkeeping)", minRetentionYears: 7 },
+  { model: "workerEngagementTerm", label: "Worker engagement terms", regulatoryBasis: "Engagement-term evidence for worker classification (IRS + FLSA employment recordkeeping)", minRetentionYears: 7 },
+
   // Tax records.
   { model: "taxRemittanceRun", label: "Tax remittance runs", regulatoryBasis: "Tax record retention", minRetentionYears: 7 },
   { model: "taxDecisionSnapshot", label: "Tax decision snapshots", regulatoryBasis: "Tax record retention", minRetentionYears: 7 },

--- a/apps/web/lib/workforce/worker-classification.test.ts
+++ b/apps/web/lib/workforce/worker-classification.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  consequencesFor,
+  engagementTermDrift,
+  resolveClassification,
+  type WorkerClassificationConsequences,
+} from "./worker-classification";
+
+const ALL = [
+  "employee",
+  "contractor_direct",
+  "contractor_agency",
+  "temp_agency_worker",
+  "eor_employee",
+  "volunteer",
+  "intern",
+  "board_member",
+] as const;
+
+describe("worker classification consequences", () => {
+  it("answers every consequence for every classification", () => {
+    const keys: (keyof WorkerClassificationConsequences)[] = [
+      "payrollWithholding",
+      "directable",
+      "accruesLeaveAndBenefits",
+      "entersReviewCycles",
+      "orgChartPlacement",
+      "expectsDefiniteTerm",
+      "employedByThirdParty",
+    ];
+    for (const classification of ALL) {
+      const c = consequencesFor(classification);
+      for (const key of keys) expect(c[key]).toBeDefined();
+    }
+  });
+
+  // The load-bearing flag. Directing a worker the organisation may not direct is
+  // the behavioural-control factor behind joint-employer findings, so this pins
+  // exactly which classes are directable — a change here is a legal change.
+  it("permits direction only for employee, EOR employee and intern", () => {
+    const directable = ALL.filter((c) => consequencesFor(c).directable);
+    expect(directable).toEqual(["employee", "eor_employee", "intern"]);
+  });
+
+  it("keeps a volunteer undirectable and unpaid", () => {
+    const volunteer = consequencesFor("volunteer");
+    expect(volunteer.directable).toBe(false);
+    expect(volunteer.payrollWithholding).toBe(false);
+    expect(volunteer.accruesLeaveAndBenefits).toBe(false);
+    expect(volunteer.entersReviewCycles).toBe(false);
+    expect(volunteer.orgChartPlacement).toBe("engaged-party");
+  });
+
+  it("places every undirectable worker as an engaged party, not a reporting line", () => {
+    for (const classification of ALL) {
+      const c = consequencesFor(classification);
+      if (!c.directable) expect(c.orgChartPlacement).toBe("engaged-party");
+    }
+  });
+
+  it("names the classes employed by a third party", () => {
+    const thirdParty = ALL.filter((c) => consequencesFor(c).employedByThirdParty);
+    expect(thirdParty).toEqual(["contractor_agency", "temp_agency_worker", "eor_employee"]);
+  });
+
+  it("withholds payroll only where this organisation is the payer", () => {
+    const withholding = ALL.filter((c) => consequencesFor(c).payrollWithholding);
+    expect(withholding).toEqual(["employee", "intern"]);
+    // An EOR arrangement is directable but the EOR withholds, so directable and
+    // withholding are genuinely independent axes rather than one flag.
+    const eor = consequencesFor("eor_employee");
+    expect(eor.directable).toBe(true);
+    expect(eor.payrollWithholding).toBe(false);
+  });
+});
+
+describe("resolveClassification", () => {
+  it("resolves a determined classification", () => {
+    expect(resolveClassification({ employmentType: { classification: "volunteer" } }))
+      .toEqual({ resolved: true, classification: "volunteer" });
+  });
+
+  // Fails loud rather than defaulting. A silent default would be a confidently
+  // wrong legal claim, and every permissive default errs toward directing
+  // someone the organisation may not direct.
+  it("reports no employment type rather than defaulting", () => {
+    expect(resolveClassification({ employmentType: null }))
+      .toEqual({ resolved: false, reason: "no-employment-type" });
+    expect(resolveClassification({}))
+      .toEqual({ resolved: false, reason: "no-employment-type" });
+  });
+
+  it("reports an unclassified employment type rather than defaulting", () => {
+    expect(resolveClassification({ employmentType: { classification: null } }))
+      .toEqual({ resolved: false, reason: "employment-type-unclassified" });
+  });
+
+  it("never resolves to employee without a recorded determination", () => {
+    for (const worker of [
+      { employmentType: null },
+      { employmentType: { classification: null } },
+      {},
+    ]) {
+      const result = resolveClassification(worker);
+      expect(result.resolved).toBe(false);
+    }
+  });
+});
+
+describe("engagementTermDrift", () => {
+  const now = new Date("2026-08-26T00:00:00.000Z");
+
+  it("ignores classes that do not expect a definite term", () => {
+    expect(engagementTermDrift("employee", null, now)).toEqual({ drifted: false });
+    expect(engagementTermDrift("volunteer", null, now)).toEqual({ drifted: false });
+  });
+
+  it("flags a contingent engagement with no recorded term", () => {
+    expect(engagementTermDrift("contractor_direct", null, now))
+      .toEqual({ drifted: true, reason: "missing-term" });
+  });
+
+  it("flags a lapsed term still running", () => {
+    expect(engagementTermDrift(
+      "contractor_direct",
+      { endsOn: new Date("2026-08-01T00:00:00.000Z"), supersededAt: null },
+      now,
+    )).toEqual({ drifted: true, reason: "term-lapsed" });
+  });
+
+  it("accepts a term still within its agreed end", () => {
+    expect(engagementTermDrift(
+      "contractor_direct",
+      { endsOn: new Date("2026-12-01T00:00:00.000Z"), supersededAt: null },
+      now,
+    )).toEqual({ drifted: false });
+  });
+
+  // An extension supersedes the prior term. The superseded row is history, not
+  // drift — the successor carries the current agreed end.
+  it("does not flag a superseded term", () => {
+    expect(engagementTermDrift(
+      "contractor_direct",
+      { endsOn: new Date("2026-08-01T00:00:00.000Z"), supersededAt: new Date("2026-07-30T00:00:00.000Z") },
+      now,
+    )).toEqual({ drifted: false });
+  });
+});

--- a/apps/web/lib/workforce/worker-classification.test.ts
+++ b/apps/web/lib/workforce/worker-classification.test.ts
@@ -124,7 +124,7 @@ describe("engagementTermDrift", () => {
   it("flags a lapsed term still running", () => {
     expect(engagementTermDrift(
       "contractor_direct",
-      { endsOn: new Date("2026-08-01T00:00:00.000Z"), supersededAt: null },
+      { endsOn: new Date("2026-08-01T00:00:00.000Z"), lifecycle: "active" as const },
       now,
     )).toEqual({ drifted: true, reason: "term-lapsed" });
   });
@@ -132,17 +132,17 @@ describe("engagementTermDrift", () => {
   it("accepts a term still within its agreed end", () => {
     expect(engagementTermDrift(
       "contractor_direct",
-      { endsOn: new Date("2026-12-01T00:00:00.000Z"), supersededAt: null },
+      { endsOn: new Date("2026-12-01T00:00:00.000Z"), lifecycle: "active" as const },
       now,
     )).toEqual({ drifted: false });
   });
 
-  // An extension supersedes the prior term. The superseded row is history, not
-  // drift — the successor carries the current agreed end.
-  it("does not flag a superseded term", () => {
+  // An extension marks the prior term superseded. That row is history, not drift
+  // - the successor carries the current agreed end.
+  it("does not flag a term whose lifecycle is superseded", () => {
     expect(engagementTermDrift(
       "contractor_direct",
-      { endsOn: new Date("2026-08-01T00:00:00.000Z"), supersededAt: new Date("2026-07-30T00:00:00.000Z") },
+      { endsOn: new Date("2026-08-01T00:00:00.000Z"), lifecycle: "superseded" as const },
       now,
     )).toEqual({ drifted: false });
   });

--- a/apps/web/lib/workforce/worker-classification.ts
+++ b/apps/web/lib/workforce/worker-classification.ts
@@ -1,4 +1,4 @@
-import type { WorkerClassification } from "@dpf/db";
+import type { RecordLifecycle, WorkerClassification } from "@dpf/db";
 
 /**
  * What a worker classification MEANS, as typed values rather than prose
@@ -187,12 +187,12 @@ export function resolveClassification(worker: {
  */
 export function engagementTermDrift(
   classification: WorkerClassification,
-  term: { endsOn: Date; supersededAt: Date | null } | null,
+  term: { endsOn: Date; lifecycle: RecordLifecycle } | null,
   now: Date,
 ): { readonly drifted: boolean; readonly reason?: "missing-term" | "term-lapsed" } {
   if (!consequencesFor(classification).expectsDefiniteTerm) return { drifted: false };
   if (!term) return { drifted: true, reason: "missing-term" };
-  if (term.supersededAt) return { drifted: false };
+  if (term.lifecycle !== "active") return { drifted: false };
   return term.endsOn.getTime() < now.getTime()
     ? { drifted: true, reason: "term-lapsed" }
     : { drifted: false };

--- a/apps/web/lib/workforce/worker-classification.ts
+++ b/apps/web/lib/workforce/worker-classification.ts
@@ -1,0 +1,199 @@
+import type { WorkerClassification } from "@dpf/db";
+
+/**
+ * What a worker classification MEANS, as typed values rather than prose
+ * (BI-C61CEEA9).
+ *
+ * The point of the classification axis is that downstream code can ask a
+ * question and get an answer. A label cannot be asked anything — reading
+ * `EmploymentType.name` and matching on "Contractor" is how a system ends up
+ * directing a contingent worker exactly like an employee, which is the
+ * behavioural-control factor behind joint-employer and misclassification
+ * findings.
+ *
+ * These consequences are the UNIVERSAL spine. Where a jurisdiction narrows one
+ * further, that is policy data resolved through `RegulatoryAutonomyPolicy`
+ * (BI-B506AD2E), not a second copy of this table. Nothing here is a legal
+ * determination: the platform never decides a worker's classification, it only
+ * makes a recorded determination consequential.
+ */
+export interface WorkerClassificationConsequences {
+  /** Payroll withholding applies to payments for this engagement. */
+  readonly payrollWithholding: boolean;
+  /**
+   * The organisation may direct HOW and WHEN the work is done — assign shifts,
+   * mandate training, set working hours. The single most load-bearing flag
+   * here: it is the behavioural-control test in nearly every jurisdiction.
+   */
+  readonly directable: boolean;
+  /** The worker accrues leave and benefit entitlements from this engagement. */
+  readonly accruesLeaveAndBenefits: boolean;
+  /** The worker enters the organisation's performance review cycles. */
+  readonly entersReviewCycles: boolean;
+  /**
+   * How the worker appears in the org chart. A `reporting-line` worker hangs
+   * off a manager; an `engaged-party` is shown as connected to the work without
+   * implying the organisation directs them.
+   */
+  readonly orgChartPlacement: "reporting-line" | "engaged-party";
+  /**
+   * The engagement is expected to carry a definite term (`WorkerEngagementTerm`).
+   * Duration is itself a reclassification factor, so an open-ended engagement in
+   * a class that expects a term is a drift signal, not a convenience.
+   */
+  readonly expectsDefiniteTerm: boolean;
+  /**
+   * Another legal entity is the employer of record. Where true, actions that
+   * assert this organisation as employer are the ones most likely to create
+   * joint-employer exposure.
+   */
+  readonly employedByThirdParty: boolean;
+}
+
+const CONSEQUENCES: Readonly<Record<WorkerClassification, WorkerClassificationConsequences>> = {
+  employee: {
+    payrollWithholding: true,
+    directable: true,
+    accruesLeaveAndBenefits: true,
+    entersReviewCycles: true,
+    orgChartPlacement: "reporting-line",
+    expectsDefiniteTerm: false,
+    employedByThirdParty: false,
+  },
+  contractor_direct: {
+    payrollWithholding: false,
+    directable: false,
+    accruesLeaveAndBenefits: false,
+    entersReviewCycles: false,
+    orgChartPlacement: "engaged-party",
+    expectsDefiniteTerm: true,
+    employedByThirdParty: false,
+  },
+  contractor_agency: {
+    payrollWithholding: false,
+    directable: false,
+    accruesLeaveAndBenefits: false,
+    entersReviewCycles: false,
+    orgChartPlacement: "engaged-party",
+    expectsDefiniteTerm: true,
+    employedByThirdParty: true,
+  },
+  temp_agency_worker: {
+    payrollWithholding: false,
+    directable: false,
+    accruesLeaveAndBenefits: false,
+    entersReviewCycles: false,
+    orgChartPlacement: "engaged-party",
+    expectsDefiniteTerm: true,
+    employedByThirdParty: true,
+  },
+  eor_employee: {
+    // The EOR withholds, not this organisation.
+    payrollWithholding: false,
+    // An EOR arrangement exists precisely so the client CAN direct day-to-day
+    // work while the EOR carries employer obligations.
+    directable: true,
+    accruesLeaveAndBenefits: false,
+    entersReviewCycles: true,
+    orgChartPlacement: "reporting-line",
+    expectsDefiniteTerm: false,
+    employedByThirdParty: true,
+  },
+  volunteer: {
+    payrollWithholding: false,
+    // The sharpest constraint in the set. An unpaid worker directed like an
+    // employee is a wage claim, and for nonprofit and community archetypes this
+    // is the MAJORITY classification rather than an edge case.
+    directable: false,
+    accruesLeaveAndBenefits: false,
+    entersReviewCycles: false,
+    orgChartPlacement: "engaged-party",
+    expectsDefiniteTerm: false,
+    employedByThirdParty: false,
+  },
+  intern: {
+    // Whether an internship may lawfully be unpaid is jurisdictional, so the
+    // universal spine assumes the paid, directable shape and lets a jurisdiction
+    // policy narrow it rather than assuming the permissive case.
+    payrollWithholding: true,
+    directable: true,
+    accruesLeaveAndBenefits: false,
+    entersReviewCycles: false,
+    orgChartPlacement: "reporting-line",
+    expectsDefiniteTerm: true,
+    employedByThirdParty: false,
+  },
+  board_member: {
+    payrollWithholding: false,
+    directable: false,
+    accruesLeaveAndBenefits: false,
+    entersReviewCycles: false,
+    orgChartPlacement: "engaged-party",
+    expectsDefiniteTerm: false,
+    employedByThirdParty: false,
+  },
+};
+
+/** Typed consequences for a recorded classification. */
+export function consequencesFor(
+  classification: WorkerClassification,
+): WorkerClassificationConsequences {
+  return CONSEQUENCES[classification];
+}
+
+/** Why a worker's classification could not be resolved. */
+export type UnresolvedClassificationReason =
+  /** The worker has no employment type recorded at all. */
+  | "no-employment-type"
+  /**
+   * The employment type exists but its legal axis was never determined — the
+   * migration could not read its label confidently and refused to guess.
+   */
+  | "employment-type-unclassified";
+
+export type ClassificationResolution =
+  | { readonly resolved: true; readonly classification: WorkerClassification }
+  | { readonly resolved: false; readonly reason: UnresolvedClassificationReason };
+
+/**
+ * Resolve a worker's classification from their employment type.
+ *
+ * Fails LOUDLY, in the same posture as `approval-routing.ts` and the employment
+ * jurisdiction resolver: an unresolved classification is operator work naming
+ * its reason, never a silent default to `employee`. A silent default here would
+ * be a confidently wrong legal claim, which is worse than no answer — and it is
+ * the permissive answer in every case, so guessing always errs toward directing
+ * someone the organisation may not direct.
+ */
+export function resolveClassification(worker: {
+  employmentType?: { classification: WorkerClassification | null } | null;
+}): ClassificationResolution {
+  const employmentType = worker.employmentType;
+  if (!employmentType) return { resolved: false, reason: "no-employment-type" };
+  if (!employmentType.classification) {
+    return { resolved: false, reason: "employment-type-unclassified" };
+  }
+  return { resolved: true, classification: employmentType.classification };
+}
+
+/**
+ * Whether an engagement's recorded term has drifted past what its classification
+ * expects, which is a re-determination trigger rather than an error.
+ *
+ * Duration is one of the factors that turns a contractor into an employee, so an
+ * engagement that expects a definite term and has none — or whose term has
+ * lapsed while the engagement continues — is exactly the drift the standing
+ * `worker-classification-review` room exists to surface.
+ */
+export function engagementTermDrift(
+  classification: WorkerClassification,
+  term: { endsOn: Date; supersededAt: Date | null } | null,
+  now: Date,
+): { readonly drifted: boolean; readonly reason?: "missing-term" | "term-lapsed" } {
+  if (!consequencesFor(classification).expectsDefiniteTerm) return { drifted: false };
+  if (!term) return { drifted: true, reason: "missing-term" };
+  if (term.supersededAt) return { drifted: false };
+  return term.endsOn.getTime() < now.getTime()
+    ? { drifted: true, reason: "term-lapsed" }
+    : { drifted: false };
+}

--- a/changes/worker-classification-axis.data-impact.json
+++ b/changes/worker-classification-axis.data-impact.json
@@ -1,0 +1,162 @@
+{
+  "version": "1",
+  "accountableOwner": "Mark Bodman (markdbodman@gmail.com)",
+  "summary": "BI-C61CEEA9, D1 of EP-862820FD. Migration 20260826190000_add_worker_classification_axis adds the legally-consequential axis behind an organisation's own EmploymentType label, plus the recorded human determination behind it and the definite term a contingent engagement carries. EmploymentType.name is free text with no legal meaning, so nothing downstream could ask whether a worker may lawfully be directed, scheduled, reviewed and provisioned as an employee. This is new information about a data subject, not a re-projection of existing values: a classification is a judgement a human makes about a worker, and it carries employment-law consequence. It is therefore governed rather than inherited, and the determination row cannot exist without a named human author. The backfill maps only labels it can read unambiguously and leaves the rest NULL as operator work, because a guess writes a legal claim into the database and every permissive guess errs toward directing someone the organisation may not direct.",
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "EmploymentType",
+      "lifecycleDisposition": "retain-for-organization-lifetime",
+      "fields": [
+        {
+          "name": "classification",
+          "resolution": "governed",
+          "reason": "The legal axis behind the organisation's display label. Not derived from the label text at read time — that is precisely the defect this replaces — and not inherited from any existing record, because no existing column carries employment-law meaning. Nullable on purpose so an unresolved type is a first-class operator-work state rather than a defaulted legal claim.",
+          "provenance": "Set by the migration only where the label reads unambiguously (volunteer, intern, board, employer-of-record, agency-qualified contractor or temp, and explicit employment shapes). Otherwise NULL, awaiting a recorded human determination. A bare 'Contractor', 'Director' or 'Temp' is deliberately not mapped.",
+          "flags": []
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "WorkerClassificationDetermination",
+      "lifecycleDisposition": "retain-for-employment-record-lifetime-then-statutory-retention",
+      "fields": [
+        {
+          "name": "classification",
+          "resolution": "governed",
+          "reason": "A judgement about a worker's legal status with direct employment-law consequence — it decides whether the organisation may direct them, whether withholding applies, and whether they accrue leave. It is an attribute of the data subject, and a wrong or unaccountable value creates misclassification exposure for the employer and lost entitlements for the worker.",
+          "provenance": "Recorded by a named human via determinedByUserId. The platform never derives, infers or defaults this value; there is no code path that writes it without a human author.",
+          "flags": ["subject"],
+          "fieldPolicy": {
+            "basis": "employment-contract-and-legal-obligation",
+            "access": "Readable by the worker themselves, their accountable manager chain, and platform roles holding workforce-administration capability. Not exposed on public or storefront surfaces.",
+            "retention": "Retained for the employment or engagement record's lifetime and any statutory retention period that follows, because it is the evidence trail for a classification challenge.",
+            "obligations": "Superseded rather than overwritten, so the worker and any auditor can see what was determined when and on what evidence. Never used as an input to any automated scoring or selection decision."
+          }
+        },
+        {
+          "name": "determinedByUserId",
+          "resolution": "inherited",
+          "reason": "Identifies the human accountable for the determination. Governance is inherited from the existing User record; this creates no second home for identity and collects nothing new about that person.",
+          "provenance": "User.id of the person recording the determination, captured at write time.",
+          "flags": []
+        },
+        {
+          "name": "jurisdictionSlug",
+          "resolution": "not-applicable",
+          "reason": "Which employment jurisdiction the determination was made under. Organisational scope rather than a data-subject attribute; the value set is the PROFESSION_JURISDICTIONS vocabulary already declared on Organization.employsIn.",
+          "provenance": "Resolved from the worker's work location by BI-9252B9EA. NULL until that lands.",
+          "flags": []
+        },
+        {
+          "name": "evidence",
+          "resolution": "governed",
+          "reason": "Free-shaped record of what the determination rested on — engagement facts, contract references, the factors weighed. Deliberately unstructured because the multi-factor tests differ by jurisdiction, which means it can hold personal data about the worker and about the engagement.",
+          "provenance": "Supplied by the human making the determination. No automated collection populates it.",
+          "flags": ["subject"],
+          "fieldPolicy": {
+            "basis": "employment-contract-and-legal-obligation",
+            "access": "Same audience as the classification itself: the worker, their accountable manager chain, and workforce administration.",
+            "retention": "Bound to its parent determination; retained and disposed with it.",
+            "obligations": "Operators must not place special-category data here. Because the shape is free, this is a stated obligation rather than a schema constraint, and it is the reason the field is flagged subject rather than not-applicable."
+          }
+        },
+        {
+          "name": "rationale",
+          "resolution": "governed",
+          "reason": "The human's stated reasoning. Narrative about a data subject's legal status, so it carries the same governance as the determination it explains.",
+          "provenance": "Written by the human making the determination.",
+          "flags": ["subject"],
+          "fieldPolicy": {
+            "basis": "employment-contract-and-legal-obligation",
+            "access": "Same audience as the classification itself.",
+            "retention": "Bound to its parent determination.",
+            "obligations": "Disclosed to the worker on request as part of the determination record."
+          }
+        },
+        {
+          "name": "determinedAt",
+          "resolution": "not-applicable",
+          "reason": "Timestamp of the determination; operational metadata, not a data-subject attribute.",
+          "provenance": "Server clock at write time.",
+          "flags": []
+        },
+        {
+          "name": "supersededAt",
+          "resolution": "not-applicable",
+          "reason": "Marks a determination replaced by a later one. Operational metadata that makes the drift history readable.",
+          "provenance": "Server clock when a successor determination is recorded.",
+          "flags": []
+        },
+        {
+          "name": "supersededById",
+          "resolution": "not-applicable",
+          "reason": "Self-relation to the successor determination. A typed join within this model, carrying no additional information about the worker.",
+          "provenance": "Set when a successor determination is recorded.",
+          "flags": []
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "WorkerEngagementTerm",
+      "lifecycleDisposition": "retain-for-employment-record-lifetime-then-statutory-retention",
+      "fields": [
+        {
+          "name": "startsOn",
+          "resolution": "governed",
+          "reason": "When the engagement was agreed to begin. An attribute of the worker's engagement rather than a re-projection of EmployeeProfile.startDate, which records when employment began — a different fact for a contingent worker whose engagement may start and end inside a longer relationship.",
+          "provenance": "Recorded from the engagement agreement by workforce administration.",
+          "flags": ["subject"],
+          "fieldPolicy": {
+            "basis": "employment-contract",
+            "access": "The worker, their accountable manager chain, and workforce administration.",
+            "retention": "Retained for the engagement record's lifetime and any statutory retention that follows.",
+            "obligations": "Never used as an input to automated selection or scoring."
+          }
+        },
+        {
+          "name": "endsOn",
+          "resolution": "governed",
+          "reason": "The agreed end of the engagement. Required, because an engagement with no end date is not a definite term and recording one as though it were is how an indefinite engagement hides. Duration is itself a factor that reclassifies a contractor as an employee, so this value has legal consequence for the worker.",
+          "provenance": "Recorded from the engagement agreement by workforce administration.",
+          "flags": ["subject"],
+          "fieldPolicy": {
+            "basis": "employment-contract",
+            "access": "The worker, their accountable manager chain, and workforce administration.",
+            "retention": "Retained for the engagement record's lifetime and any statutory retention that follows.",
+            "obligations": "A lapsed term on a continuing engagement is surfaced as drift for re-determination rather than silently extended."
+          }
+        },
+        {
+          "name": "changeReason",
+          "resolution": "governed",
+          "reason": "Why a term was extended or replaced. Narrative about the worker's engagement, forming part of the re-determination trail.",
+          "provenance": "Written by workforce administration when superseding a term.",
+          "flags": ["subject"],
+          "fieldPolicy": {
+            "basis": "employment-contract",
+            "access": "The worker, their accountable manager chain, and workforce administration.",
+            "retention": "Bound to its parent term.",
+            "obligations": "Disclosed to the worker on request as part of the engagement record."
+          }
+        },
+        {
+          "name": "supersededAt",
+          "resolution": "not-applicable",
+          "reason": "Marks a term replaced by an extension or successor. Operational metadata.",
+          "provenance": "Server clock when a successor term is recorded.",
+          "flags": []
+        },
+        {
+          "name": "supersededById",
+          "resolution": "not-applicable",
+          "reason": "Self-relation to the successor term. A typed join within this model.",
+          "provenance": "Set when a successor term is recorded.",
+          "flags": []
+        }
+      ]
+    }
+  ]
+}

--- a/changes/worker-classification-axis.data-impact.json
+++ b/changes/worker-classification-axis.data-impact.json
@@ -1,7 +1,7 @@
 {
   "version": "1",
   "accountableOwner": "Mark Bodman (markdbodman@gmail.com)",
-  "summary": "BI-C61CEEA9, D1 of EP-862820FD. Migration 20260826190000_add_worker_classification_axis adds the legally-consequential axis behind an organisation's own EmploymentType label, plus the recorded human determination behind it and the definite term a contingent engagement carries. EmploymentType.name is free text with no legal meaning, so nothing downstream could ask whether a worker may lawfully be directed, scheduled, reviewed and provisioned as an employee. This is new information about a data subject, not a re-projection of existing values: a classification is a judgement a human makes about a worker, and it carries employment-law consequence. It is therefore governed rather than inherited, and the determination row cannot exist without a named human author. The backfill maps only labels it can read unambiguously and leaves the rest NULL as operator work, because a guess writes a legal claim into the database and every permissive guess errs toward directing someone the organisation may not direct.",
+  "summary": "BI-C61CEEA9, D1 of EP-862820FD. Migration 20260826190000_add_worker_classification_axis adds the legally-consequential axis behind an organisation's own EmploymentType label, plus the recorded human determination behind it and the definite term a contingent engagement carries. EmploymentType.name is free text with no legal meaning, so nothing downstream could ask whether a worker may lawfully be directed, scheduled, reviewed and provisioned as an employee. This is new information about a data subject, not a re-projection of existing values: a classification is a judgement a human makes about a worker, and it carries employment-law consequence. It is therefore governed rather than inherited, and the determination row cannot exist without a named human author. Supersession uses the platform RecordLifecycle convention rather than a self-link, so there is no second home for a rule the platform already states. The backfill maps only labels it can read unambiguously and leaves the rest NULL as operator work, because a guess writes a legal claim into the database and every permissive guess errs toward directing someone the organisation may not direct.",
   "changes": [
     {
       "kind": "model",
@@ -27,7 +27,9 @@
           "resolution": "governed",
           "reason": "A judgement about a worker's legal status with direct employment-law consequence — it decides whether the organisation may direct them, whether withholding applies, and whether they accrue leave. It is an attribute of the data subject, and a wrong or unaccountable value creates misclassification exposure for the employer and lost entitlements for the worker.",
           "provenance": "Recorded by a named human via determinedByUserId. The platform never derives, infers or defaults this value; there is no code path that writes it without a human author.",
-          "flags": ["subject"],
+          "flags": [
+            "subject"
+          ],
           "fieldPolicy": {
             "basis": "employment-contract-and-legal-obligation",
             "access": "Readable by the worker themselves, their accountable manager chain, and platform roles holding workforce-administration capability. Not exposed on public or storefront surfaces.",
@@ -54,7 +56,9 @@
           "resolution": "governed",
           "reason": "Free-shaped record of what the determination rested on — engagement facts, contract references, the factors weighed. Deliberately unstructured because the multi-factor tests differ by jurisdiction, which means it can hold personal data about the worker and about the engagement.",
           "provenance": "Supplied by the human making the determination. No automated collection populates it.",
-          "flags": ["subject"],
+          "flags": [
+            "subject"
+          ],
           "fieldPolicy": {
             "basis": "employment-contract-and-legal-obligation",
             "access": "Same audience as the classification itself: the worker, their accountable manager chain, and workforce administration.",
@@ -67,7 +71,9 @@
           "resolution": "governed",
           "reason": "The human's stated reasoning. Narrative about a data subject's legal status, so it carries the same governance as the determination it explains.",
           "provenance": "Written by the human making the determination.",
-          "flags": ["subject"],
+          "flags": [
+            "subject"
+          ],
           "fieldPolicy": {
             "basis": "employment-contract-and-legal-obligation",
             "access": "Same audience as the classification itself.",
@@ -83,18 +89,33 @@
           "flags": []
         },
         {
-          "name": "supersededAt",
+          "name": "lifecycle",
           "resolution": "not-applicable",
-          "reason": "Marks a determination replaced by a later one. Operational metadata that makes the drift history readable.",
-          "provenance": "Server clock when a successor determination is recorded.",
+          "reason": "The platform record-lifecycle convention (BI-C357FA5A). Marks whether this row is the current one or has been superseded by a later determination. Operational state, not a data-subject attribute.",
+          "provenance": "Set to superseded when a successor row is recorded.",
           "flags": []
         },
         {
-          "name": "supersededById",
+          "name": "lifecycleAt",
           "resolution": "not-applicable",
-          "reason": "Self-relation to the successor determination. A typed join within this model, carrying no additional information about the worker.",
-          "provenance": "Set when a successor determination is recorded.",
+          "reason": "When the lifecycle state last changed. Operational metadata.",
+          "provenance": "Server clock at the lifecycle transition.",
           "flags": []
+        },
+        {
+          "name": "lifecycleReason",
+          "resolution": "governed",
+          "reason": "Why this determination was superseded. Narrative about a change in a worker legal status, so it carries the same governance as the determination it closes.",
+          "provenance": "Written by the human recording the successor determination.",
+          "flags": [
+            "subject"
+          ],
+          "fieldPolicy": {
+            "basis": "employment-contract-and-legal-obligation",
+            "access": "Same audience as the classification itself.",
+            "retention": "Bound to its parent determination.",
+            "obligations": "Disclosed to the worker on request as part of the determination record."
+          }
         }
       ]
     },
@@ -108,7 +129,9 @@
           "resolution": "governed",
           "reason": "When the engagement was agreed to begin. An attribute of the worker's engagement rather than a re-projection of EmployeeProfile.startDate, which records when employment began — a different fact for a contingent worker whose engagement may start and end inside a longer relationship.",
           "provenance": "Recorded from the engagement agreement by workforce administration.",
-          "flags": ["subject"],
+          "flags": [
+            "subject"
+          ],
           "fieldPolicy": {
             "basis": "employment-contract",
             "access": "The worker, their accountable manager chain, and workforce administration.",
@@ -121,7 +144,9 @@
           "resolution": "governed",
           "reason": "The agreed end of the engagement. Required, because an engagement with no end date is not a definite term and recording one as though it were is how an indefinite engagement hides. Duration is itself a factor that reclassifies a contractor as an employee, so this value has legal consequence for the worker.",
           "provenance": "Recorded from the engagement agreement by workforce administration.",
-          "flags": ["subject"],
+          "flags": [
+            "subject"
+          ],
           "fieldPolicy": {
             "basis": "employment-contract",
             "access": "The worker, their accountable manager chain, and workforce administration.",
@@ -130,31 +155,33 @@
           }
         },
         {
-          "name": "changeReason",
+          "name": "lifecycle",
+          "resolution": "not-applicable",
+          "reason": "The platform record-lifecycle convention (BI-C357FA5A). Marks whether this row is the current one or has been superseded by a later determination. Operational state, not a data-subject attribute.",
+          "provenance": "Set to superseded when a successor row is recorded.",
+          "flags": []
+        },
+        {
+          "name": "lifecycleAt",
+          "resolution": "not-applicable",
+          "reason": "When the lifecycle state last changed. Operational metadata.",
+          "provenance": "Server clock at the lifecycle transition.",
+          "flags": []
+        },
+        {
+          "name": "lifecycleReason",
           "resolution": "governed",
-          "reason": "Why a term was extended or replaced. Narrative about the worker's engagement, forming part of the re-determination trail.",
+          "reason": "Why a term was extended or replaced. Narrative about the worker engagement, forming part of the re-determination trail.",
           "provenance": "Written by workforce administration when superseding a term.",
-          "flags": ["subject"],
+          "flags": [
+            "subject"
+          ],
           "fieldPolicy": {
             "basis": "employment-contract",
             "access": "The worker, their accountable manager chain, and workforce administration.",
             "retention": "Bound to its parent term.",
             "obligations": "Disclosed to the worker on request as part of the engagement record."
           }
-        },
-        {
-          "name": "supersededAt",
-          "resolution": "not-applicable",
-          "reason": "Marks a term replaced by an extension or successor. Operational metadata.",
-          "provenance": "Server clock when a successor term is recorded.",
-          "flags": []
-        },
-        {
-          "name": "supersededById",
-          "resolution": "not-applicable",
-          "reason": "Self-relation to the successor term. A typed join within this model.",
-          "provenance": "Set when a successor term is recorded.",
-          "flags": []
         }
       ]
     }

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -10,6 +10,6 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 |---|---:|---|
 | Prisma models | 611 | `packages/db/prisma/schema/` |
 | Prisma enums | 71 | `packages/db/prisma/schema/` |
-| Migrations | 553 | `packages/db/prisma/migrations/` |
+| Migrations | 554 | `packages/db/prisma/migrations/` |
 | Kernel principles | 97 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 634 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -8,8 +8,8 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 
 | Count | Value | Source of truth |
 |---|---:|---|
-| Prisma models | 609 | `packages/db/prisma/schema/` |
-| Prisma enums | 70 | `packages/db/prisma/schema/` |
-| Migrations | 552 | `packages/db/prisma/migrations/` |
+| Prisma models | 611 | `packages/db/prisma/schema/` |
+| Prisma enums | 71 | `packages/db/prisma/schema/` |
+| Migrations | 553 | `packages/db/prisma/migrations/` |
 | Kernel principles | 97 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 634 | `apps/web/lib/ea/route-manifest.json` |

--- a/packages/db/prisma/migrations/20260826190000_add_worker_classification_axis/migration.sql
+++ b/packages/db/prisma/migrations/20260826190000_add_worker_classification_axis/migration.sql
@@ -1,0 +1,134 @@
+-- Worker classification: the legally-consequential axis behind an organisation's
+-- own EmploymentType label (BI-C61CEEA9).
+--
+-- EmploymentType.name is free text an organisation types in. It carries no legal
+-- meaning, so nothing downstream could ask the only question that matters — may
+-- this worker be directed, scheduled, reviewed and provisioned the way an
+-- employee is. This adds the axis that can be asked, plus the recorded human
+-- determination behind it and the definite term a contingent engagement carries.
+--
+-- BACKFILL POSTURE — the important part of this file.
+--
+-- The classification column is NULLABLE and the backfill maps only labels it can
+-- read unambiguously. Everything else is left NULL and surfaces as operator work.
+-- That is deliberate: a guess here writes a legal claim into the database, and
+-- every permissive guess errs toward directing someone the organisation may not
+-- direct. An installation with messy labels therefore has manual work on upgrade.
+-- That cost is correct.
+--
+-- Specifically NOT mapped, though it would be easy to:
+--   * a bare "Contractor" / "Consultant" label — cannot distinguish a directly
+--     engaged contractor from an agency-supplied one, and they differ on whether
+--     a third party is the employer, which is exactly where co-employment sits.
+--   * "Director" — a job title far more often than a board seat.
+--   * "Temp" alone — may be a fixed-term employee rather than agency labour.
+--
+-- Existing behaviour is unchanged for every row: nothing reads this column yet.
+
+-- CreateEnum
+CREATE TYPE "WorkerClassification" AS ENUM (
+  'employee',
+  'contractor_direct',
+  'contractor_agency',
+  'temp_agency_worker',
+  'eor_employee',
+  'volunteer',
+  'intern',
+  'board_member'
+);
+
+-- AlterTable
+ALTER TABLE "EmploymentType" ADD COLUMN "classification" "WorkerClassification";
+
+-- CreateTable
+CREATE TABLE "WorkerClassificationDetermination" (
+    "id" TEXT NOT NULL,
+    "determinationId" TEXT NOT NULL,
+    "employeeProfileId" TEXT NOT NULL,
+    "classification" "WorkerClassification" NOT NULL,
+    "determinedByUserId" TEXT NOT NULL,
+    "jurisdictionSlug" TEXT,
+    "evidence" JSONB,
+    "rationale" TEXT,
+    "determinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "supersededAt" TIMESTAMP(3),
+    "supersededById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WorkerClassificationDetermination_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WorkerEngagementTerm" (
+    "id" TEXT NOT NULL,
+    "termId" TEXT NOT NULL,
+    "employeeProfileId" TEXT NOT NULL,
+    "startsOn" TIMESTAMP(3) NOT NULL,
+    "endsOn" TIMESTAMP(3) NOT NULL,
+    "supersededAt" TIMESTAMP(3),
+    "supersededById" TEXT,
+    "changeReason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WorkerEngagementTerm_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "EmploymentType_classification_idx" ON "EmploymentType"("classification");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WorkerClassificationDetermination_determinationId_key" ON "WorkerClassificationDetermination"("determinationId");
+CREATE UNIQUE INDEX "WorkerClassificationDetermination_supersededById_key" ON "WorkerClassificationDetermination"("supersededById");
+CREATE INDEX "WorkerClassificationDetermination_employeeProfileId_determin_idx" ON "WorkerClassificationDetermination"("employeeProfileId", "determinedAt" DESC);
+CREATE INDEX "WorkerClassificationDetermination_classification_idx" ON "WorkerClassificationDetermination"("classification");
+CREATE INDEX "WorkerClassificationDetermination_supersededAt_idx" ON "WorkerClassificationDetermination"("supersededAt");
+CREATE INDEX "WorkerClassificationDetermination_determinedByUserId_idx" ON "WorkerClassificationDetermination"("determinedByUserId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WorkerEngagementTerm_termId_key" ON "WorkerEngagementTerm"("termId");
+CREATE UNIQUE INDEX "WorkerEngagementTerm_supersededById_key" ON "WorkerEngagementTerm"("supersededById");
+CREATE INDEX "WorkerEngagementTerm_employeeProfileId_startsOn_idx" ON "WorkerEngagementTerm"("employeeProfileId", "startsOn" DESC);
+CREATE INDEX "WorkerEngagementTerm_endsOn_idx" ON "WorkerEngagementTerm"("endsOn");
+CREATE INDEX "WorkerEngagementTerm_supersededAt_idx" ON "WorkerEngagementTerm"("supersededAt");
+
+-- AddForeignKey
+ALTER TABLE "WorkerClassificationDetermination" ADD CONSTRAINT "WorkerClassificationDetermination_employeeProfileId_fkey" FOREIGN KEY ("employeeProfileId") REFERENCES "EmployeeProfile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "WorkerClassificationDetermination" ADD CONSTRAINT "WorkerClassificationDetermination_determinedByUserId_fkey" FOREIGN KEY ("determinedByUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "WorkerClassificationDetermination" ADD CONSTRAINT "WorkerClassificationDetermination_supersededById_fkey" FOREIGN KEY ("supersededById") REFERENCES "WorkerClassificationDetermination"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkerEngagementTerm" ADD CONSTRAINT "WorkerEngagementTerm_employeeProfileId_fkey" FOREIGN KEY ("employeeProfileId") REFERENCES "EmployeeProfile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "WorkerEngagementTerm" ADD CONSTRAINT "WorkerEngagementTerm_supersededById_fkey" FOREIGN KEY ("supersededById") REFERENCES "WorkerEngagementTerm"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Backfill: unambiguous labels only. `\y` is a Postgres word boundary, so
+-- "intern" does not match "internal" and "board" does not match "onboarding".
+UPDATE "EmploymentType" SET "classification" = 'volunteer'
+  WHERE "classification" IS NULL AND "name" ~* '\yvolunteers?\y';
+
+UPDATE "EmploymentType" SET "classification" = 'intern'
+  WHERE "classification" IS NULL AND "name" ~* '\yinterns?\y' AND "name" !~* '\yinternal\y';
+
+UPDATE "EmploymentType" SET "classification" = 'board_member'
+  WHERE "classification" IS NULL AND "name" ~* '\yboard\y';
+
+UPDATE "EmploymentType" SET "classification" = 'eor_employee'
+  WHERE "classification" IS NULL AND ("name" ~* '\yeor\y' OR "name" ~* 'employer of record');
+
+-- Agency labour only where the label names the agency relationship itself.
+UPDATE "EmploymentType" SET "classification" = 'temp_agency_worker'
+  WHERE "classification" IS NULL
+    AND "name" ~* '\yagency\y'
+    AND "name" ~* '\y(temp|temporary|staffing)\y';
+
+UPDATE "EmploymentType" SET "classification" = 'contractor_agency'
+  WHERE "classification" IS NULL
+    AND "name" ~* '\yagency\y'
+    AND "name" ~* '\y(contractor|contract)\y';
+
+-- Employment shapes that name the employment relationship unambiguously.
+UPDATE "EmploymentType" SET "classification" = 'employee'
+  WHERE "classification" IS NULL
+    AND "name" ~* '\y(full[ -]?time|part[ -]?time|permanent|salaried|employee|staff)\y'
+    AND "name" !~* '\y(contractor|contract|agency|volunteer|intern|board)\y';

--- a/packages/db/prisma/migrations/20260826200000_align_worker_classification_to_record_lifecycle/migration.sql
+++ b/packages/db/prisma/migrations/20260826200000_align_worker_classification_to_record_lifecycle/migration.sql
@@ -1,0 +1,73 @@
+-- Align the worker-classification models to two platform conventions they should
+-- have used from the start (BI-C61CEEA9).
+--
+-- The preceding migration 20260826190000 is committed and applied, so it is
+-- immutable — modifying it would corrupt Prisma's checksum tracking and break
+-- every other environment on next migrate. This corrects it forward instead.
+--
+-- Two corrections, both caught by source policy guards rather than review:
+--
+-- 1. RECORD LIFECYCLE (BI-C357FA5A). The original modelled supersession as a
+--    supersededAt timestamp plus a supersededById self-link. The platform
+--    already has ONE record-lifecycle convention — lifecycle RecordLifecycle +
+--    lifecycleAt + lifecycleReason — in which supersession is a STATE, not a
+--    link. The original was a second home for a rule the platform already
+--    states. The current determination for a worker is now the `active` row
+--    with the newest determinedAt, and the self-relations disappear.
+--
+-- 2. IDENTITY KEY NAMING. determinationId and termId read as bare FK-shaped
+--    columns to the FK-index coverage guard, which exempts a semantic key only
+--    when it is named <lowerFirstModelName>Id and carries @unique. Renamed
+--    rather than expanding a baseline the guard explicitly says not to expand
+--    without an owned data-architecture decision.
+--
+-- SAFE ON POPULATED DATA. Both tables were created by the immediately preceding
+-- migration in the same release and nothing writes them yet, so no row can hold
+-- a supersession link to lose. The column renames preserve any rows that do
+-- exist; the dropped columns carried no data.
+
+-- Postgres truncates identifiers at 63 characters, so the unique-index name is
+-- written pre-truncated here rather than letting the server silently shorten it
+-- and leave the migration text disagreeing with what is actually stored.
+
+-- ── 1. Identity key renames ───────────────────────────────────────────────────
+ALTER TABLE "WorkerClassificationDetermination"
+  RENAME COLUMN "determinationId" TO "workerClassificationDeterminationId";
+ALTER INDEX "WorkerClassificationDetermination_determinationId_key"
+  RENAME TO "WorkerClassificationDetermination_workerClassificationDetermi_k";
+
+ALTER TABLE "WorkerEngagementTerm"
+  RENAME COLUMN "termId" TO "workerEngagementTermId";
+ALTER INDEX "WorkerEngagementTerm_termId_key"
+  RENAME TO "WorkerEngagementTerm_workerEngagementTermId_key";
+
+-- ── 2. Record-lifecycle convention ────────────────────────────────────────────
+ALTER TABLE "WorkerClassificationDetermination"
+  DROP CONSTRAINT IF EXISTS "WorkerClassificationDetermination_supersededById_fkey";
+DROP INDEX IF EXISTS "WorkerClassificationDetermination_supersededById_key";
+DROP INDEX IF EXISTS "WorkerClassificationDetermination_supersededAt_idx";
+ALTER TABLE "WorkerClassificationDetermination"
+  DROP COLUMN IF EXISTS "supersededById",
+  DROP COLUMN IF EXISTS "supersededAt",
+  ADD COLUMN "lifecycle" "RecordLifecycle" NOT NULL DEFAULT 'active',
+  ADD COLUMN "lifecycleAt" TIMESTAMP(3),
+  ADD COLUMN "lifecycleReason" TEXT;
+CREATE INDEX "WorkerClassificationDetermination_lifecycle_idx"
+  ON "WorkerClassificationDetermination"("lifecycle");
+
+ALTER TABLE "WorkerEngagementTerm"
+  DROP CONSTRAINT IF EXISTS "WorkerEngagementTerm_supersededById_fkey";
+DROP INDEX IF EXISTS "WorkerEngagementTerm_supersededById_key";
+DROP INDEX IF EXISTS "WorkerEngagementTerm_supersededAt_idx";
+ALTER TABLE "WorkerEngagementTerm"
+  DROP COLUMN IF EXISTS "supersededById",
+  DROP COLUMN IF EXISTS "supersededAt",
+  ADD COLUMN "lifecycle" "RecordLifecycle" NOT NULL DEFAULT 'active',
+  ADD COLUMN "lifecycleAt" TIMESTAMP(3),
+  ADD COLUMN "lifecycleReason" TEXT;
+CREATE INDEX "WorkerEngagementTerm_lifecycle_idx"
+  ON "WorkerEngagementTerm"("lifecycle");
+
+-- `changeReason` is superseded by the convention's `lifecycleReason`, which
+-- carries exactly the same fact — why this row stopped being current.
+ALTER TABLE "WorkerEngagementTerm" DROP COLUMN IF EXISTS "changeReason";

--- a/packages/db/prisma/schema/core-identity.prisma
+++ b/packages/db/prisma/schema/core-identity.prisma
@@ -22,6 +22,7 @@ model User {
   grantedDelegations             DelegationGrant[]             @relation("DelegationGrantGrantor")
   employeeProfile                EmployeeProfile?
   authoredEmploymentEvents       EmploymentEvent[]
+  workerClassificationsDetermined WorkerClassificationDetermination[] @relation("ClassificationDeterminedBy")
   epicSubmissions                Epic[]                        @relation("EpicSubmissions")
   externalEvidenceRecords        ExternalEvidenceRecord[]
   featureBuilds                  FeatureBuild[]

--- a/packages/db/prisma/schema/workforce.prisma
+++ b/packages/db/prisma/schema/workforce.prisma
@@ -91,6 +91,8 @@ model EmployeeProfile {
   trips                        Trip[]                        @relation("TripDriver")
   tripClassificationRules      TripClassificationRule[]      @relation("TripRuleDriver")
   driverLocationConsents       DriverLocationConsent[]       @relation("DriverConsentDriver")
+  classificationDeterminations WorkerClassificationDetermination[]
+  engagementTerms              WorkerEngagementTerm[]
 
   @@index([status])
   @@index([departmentId])
@@ -179,17 +181,132 @@ model OccupationProfile {
   @@index([isActive])
 }
 
+/// The legally-consequential axis of a worker's engagement (BI-C61CEEA9).
+///
+/// DISTINCT from `EmploymentType`, which is the organisation's own display
+/// label ("Full-time", "Casual", "Summer help"). A label carries no legal
+/// meaning; this does. Every downstream question that matters - may the org
+/// direct and schedule this person, does withholding apply, do they accrue
+/// leave, do they enter review cycles - reads this and never the label text.
+///
+/// Shape follows Workday, where `Worker` is the supertype and Contingent
+/// Worker a distinct type whose bundle of services is deliberately limited.
+/// See docs/superpowers/specs/2026-08-25-employment-lifecycle-actuator-design.md
+enum WorkerClassification {
+  /// Employed by this organisation. Withholding applies; fully directable.
+  employee
+  /// Independent contractor engaged directly. Directing them like an employee
+  /// is the behavioural-control factor behind misclassification findings.
+  contractor_direct
+  /// Contractor supplied through an agency. Co-employment exposure sits here.
+  contractor_agency
+  /// Temporary worker from a staffing agency; the agency is the employer.
+  temp_agency_worker
+  /// Employed by an employer-of-record on this organisation's behalf.
+  eor_employee
+  /// Unpaid volunteer. The majority classification for nonprofit and community
+  /// archetypes, and the sharpest constraint: an unpaid worker directed like an
+  /// employee is a wage claim.
+  volunteer
+  /// Intern. Whether the engagement may lawfully be unpaid is jurisdictional.
+  intern
+  /// Board or governance member. Not staff; not directable as staff.
+  board_member
+}
+
 model EmploymentType {
-  id               String            @id @default(cuid())
-  employmentTypeId String            @unique
+  id               String                @id @default(cuid())
+  employmentTypeId String                @unique
   name             String
-  status           String            @default("active")
-  createdAt        DateTime          @default(now())
-  updatedAt        DateTime          @updatedAt
+  status           String                @default("active")
+  /// The legal axis behind this organisation's label. NULLABLE on purpose: the
+  /// migration maps the labels it can read confidently and leaves the rest
+  /// unresolved rather than guessing, because a guess here writes a legal claim
+  /// into the database. An unresolved type is operator work, never a default.
+  classification   WorkerClassification?
+  createdAt        DateTime              @default(now())
+  updatedAt        DateTime              @updatedAt
   employees        EmployeeProfile[]
   requisitions     JobRequisition[] // BI-7ACC38CE
 
   @@index([status])
+  @@index([classification])
+}
+
+/// A recorded human determination of one worker's classification (BI-C61CEEA9).
+///
+/// The platform NEVER derives a classification. Misclassification liability sits
+/// with the employer, the tests are multi-factor and contested, and a confident
+/// automated answer would be wrong in the most damaging way available:
+/// documented, timestamped and apparently authoritative. This row exists to make
+/// the determination explicit, attributable and evidenced - `determinedByUserId`
+/// is REQUIRED, so a determination without a human author cannot be stored.
+///
+/// Superseded rather than updated: an engagement's facts drift (duration
+/// extended, direction increased, exclusivity emerged), and the history of what
+/// was determined when, on what evidence, is the audit trail.
+model WorkerClassificationDetermination {
+  id                 String               @id @default(cuid())
+  determinationId    String               @unique
+  employeeProfileId  String
+  classification     WorkerClassification
+  /// The human who made the call. Required - see the model note.
+  determinedByUserId String
+  /// Which employment jurisdiction the determination was made under, when known.
+  /// Resolved by BI-9252B9EA; null until that lands.
+  jurisdictionSlug   String?
+  /// What the determination rested on: engagement facts, contract references,
+  /// the factors weighed. Free-shaped because the tests differ by jurisdiction.
+  evidence           Json?
+  rationale          String?              @db.Text
+  determinedAt       DateTime             @default(now())
+  supersededAt       DateTime?
+  supersededById     String?              @unique
+  createdAt          DateTime             @default(now())
+  updatedAt          DateTime             @updatedAt
+
+  employeeProfile    EmployeeProfile      @relation(fields: [employeeProfileId], references: [id], onDelete: Cascade)
+  determinedBy       User                 @relation("ClassificationDeterminedBy", fields: [determinedByUserId], references: [id])
+  supersededBy       WorkerClassificationDetermination?  @relation("ClassificationSupersession", fields: [supersededById], references: [id], onDelete: SetNull)
+  supersedes         WorkerClassificationDetermination?  @relation("ClassificationSupersession")
+
+  @@index([employeeProfileId, determinedAt(sort: Desc)])
+  @@index([classification])
+  @@index([supersededAt])
+  @@index([determinedByUserId])
+}
+
+/// The definite term of a contingent engagement (BI-C61CEEA9).
+///
+/// An employee's `endDate` records when employment ended. This records that an
+/// engagement was agreed to run to a date - a different fact, and one that
+/// matters legally, because duration is itself a factor that turns a contractor
+/// into an employee. An extension is a NEW row superseding the previous one, so
+/// the drift stays visible and reads as a re-determination trigger rather than a
+/// silent continuation.
+model WorkerEngagementTerm {
+  id                String    @id @default(cuid())
+  termId            String    @unique
+  employeeProfileId String
+  startsOn          DateTime
+  /// The agreed end. Required - an engagement with no end date is not a term,
+  /// and recording one as though it were is how an indefinite engagement hides.
+  endsOn            DateTime
+  /// Set when a later term extends or replaces this one.
+  supersededAt      DateTime?
+  supersededById    String?   @unique
+  /// Why the term was extended or changed, for the re-determination trail.
+  changeReason      String?   @db.Text
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+
+  employeeProfile   EmployeeProfile       @relation(fields: [employeeProfileId], references: [id], onDelete: Cascade)
+  supersededBy      WorkerEngagementTerm? @relation("EngagementTermSupersession", fields: [supersededById], references: [id], onDelete: SetNull)
+  supersedes        WorkerEngagementTerm? @relation("EngagementTermSupersession")
+
+  @@index([employeeProfileId, startsOn(sort: Desc)])
+  @@index([endsOn])
+  @@index([supersededAt])
 }
 
 model WorkLocation {

--- a/packages/db/prisma/schema/workforce.prisma
+++ b/packages/db/prisma/schema/workforce.prisma
@@ -247,7 +247,7 @@ model EmploymentType {
 /// was determined when, on what evidence, is the audit trail.
 model WorkerClassificationDetermination {
   id                 String               @id @default(cuid())
-  determinationId    String               @unique
+  workerClassificationDeterminationId    String               @unique
   employeeProfileId  String
   classification     WorkerClassification
   /// The human who made the call. Required - see the model note.
@@ -260,19 +260,22 @@ model WorkerClassificationDetermination {
   evidence           Json?
   rationale          String?              @db.Text
   determinedAt       DateTime             @default(now())
-  supersededAt       DateTime?
-  supersededById     String?              @unique
+  /// The one record-lifecycle convention (BI-C357FA5A). A determination is
+  /// `superseded` when a later one replaces it; the current determination for a
+  /// worker is the `active` row with the newest `determinedAt`. No self-link,
+  /// because the convention already answers "is this still the one".
+  lifecycle          RecordLifecycle      @default(active)
+  lifecycleAt        DateTime?
+  lifecycleReason    String?
   createdAt          DateTime             @default(now())
   updatedAt          DateTime             @updatedAt
 
   employeeProfile    EmployeeProfile      @relation(fields: [employeeProfileId], references: [id], onDelete: Cascade)
   determinedBy       User                 @relation("ClassificationDeterminedBy", fields: [determinedByUserId], references: [id])
-  supersededBy       WorkerClassificationDetermination?  @relation("ClassificationSupersession", fields: [supersededById], references: [id], onDelete: SetNull)
-  supersedes         WorkerClassificationDetermination?  @relation("ClassificationSupersession")
 
   @@index([employeeProfileId, determinedAt(sort: Desc)])
   @@index([classification])
-  @@index([supersededAt])
+  @@index([lifecycle])
   @@index([determinedByUserId])
 }
 
@@ -286,27 +289,27 @@ model WorkerClassificationDetermination {
 /// silent continuation.
 model WorkerEngagementTerm {
   id                String    @id @default(cuid())
-  termId            String    @unique
+  workerEngagementTermId            String    @unique
   employeeProfileId String
   startsOn          DateTime
   /// The agreed end. Required - an engagement with no end date is not a term,
   /// and recording one as though it were is how an indefinite engagement hides.
   endsOn            DateTime
-  /// Set when a later term extends or replaces this one.
-  supersededAt      DateTime?
-  supersededById    String?   @unique
-  /// Why the term was extended or changed, for the re-determination trail.
-  changeReason      String?   @db.Text
+  /// The one record-lifecycle convention (BI-C357FA5A). An extension marks the
+  /// prior term `superseded` and records a new `active` one, so the drift stays
+  /// visible. `lifecycleReason` carries why it changed, for the
+  /// re-determination trail.
+  lifecycle         RecordLifecycle @default(active)
+  lifecycleAt       DateTime?
+  lifecycleReason   String?
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt
 
-  employeeProfile   EmployeeProfile       @relation(fields: [employeeProfileId], references: [id], onDelete: Cascade)
-  supersededBy      WorkerEngagementTerm? @relation("EngagementTermSupersession", fields: [supersededById], references: [id], onDelete: SetNull)
-  supersedes        WorkerEngagementTerm? @relation("EngagementTermSupersession")
+  employeeProfile   EmployeeProfile @relation(fields: [employeeProfileId], references: [id], onDelete: Cascade)
 
   @@index([employeeProfileId, startsOn(sort: Desc)])
   @@index([endsOn])
-  @@index([supersededAt])
+  @@index([lifecycle])
 }
 
 model WorkLocation {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -24,6 +24,10 @@ export type {
   CapacityAllocationState,
 } from "../generated/client/client";
 export { WriteGateRequirement } from "../generated/client/client";
+// Worker classification: the legally-consequential axis, distinct from the
+// organisation's EmploymentType label (BI-C61CEEA9). Exported as a value so the
+// app composes from the generated enum instead of re-typing its members.
+export { WorkerClassification } from "../generated/client/client";
 // Decision-resolution proposal vocabulary (BI-3D0FB84B). Exported as values so
 // the app composes from the generated enum instead of re-typing its members.
 export {

--- a/packages/db/src/table-classification.ts
+++ b/packages/db/src/table-classification.ts
@@ -206,6 +206,12 @@ export const TABLE_CLASSIFICATION: Record<string, TableSensitivity> = {
   EmployeeAddress: "confidential",
   EmploymentEvent: "confidential",
   TerminationRecord: "confidential",
+  // Employment-law judgements about a named worker (BI-C61CEEA9). A
+  // classification decides whether the organisation may direct them and
+  // whether they accrue entitlements; the evidence and rationale behind it
+  // are free-shaped and can hold personal data.
+  WorkerClassificationDetermination: "confidential",
+  WorkerEngagementTerm: "confidential",
   Team: "confidential",
   TeamMembership: "confidential",
   Agent: "confidential",

--- a/scripts/platform-substrate-baseline.json
+++ b/scripts/platform-substrate-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-08-26T06:02:18.638Z",
-  "gitSha": "a8f9e64b2b3799e03d0f99c7b8a531ddfe426706",
+  "generatedAt": "2026-08-27T02:00:43.355Z",
+  "gitSha": "73427abc92af7ed9125a3b3aa1095b185217b769",
   "manifestVersion": 2,
   "metrics": {
     "defaultRequiredServiceCount": {
@@ -17,11 +17,11 @@
     },
     "prismaModelCount": {
       "direction": "non-increasing",
-      "value": 609
+      "value": 611
     },
     "prismaSchemaLines": {
       "direction": "informational",
-      "value": 18334
+      "value": 18455
     },
     "productionModuleHotspotCount": {
       "direction": "non-increasing",


### PR DESCRIPTION
**D1 of `EP-862820FD`** — the first implementation item of the employment lifecycle actuator, against the design and plan merged in [#4676](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4676).

## Problem

`EmploymentType.name` is free text an organisation types in — "Full-time", "Casual", "Advisor". It carries no legal meaning, so nothing downstream could ask the only question that matters: **may this worker be directed, scheduled, reviewed and provisioned the way an employee is?**

Reading a label and matching on `"Contractor"` is how a system ends up directing a contingent worker exactly like an employee — the behavioural-control factor behind joint-employer and misclassification findings.

## What lands

- **`WorkerClassification` enum** — `employee`, `contractor_direct`, `contractor_agency`, `temp_agency_worker`, `eor_employee`, `volunteer`, `intern`, `board_member`. Shape follows Workday, where `Worker` is the supertype and Contingent Worker a distinct type whose bundle of services is deliberately limited.
- **`EmploymentType.classification`** — the organisation keeps its label; the label gains a legal axis behind it.
- **`WorkerClassificationDetermination`** — the recorded human call. `determinedByUserId` is **required**, so a determination with no human author cannot be stored. Rows supersede rather than update, because an engagement's facts drift and the history of what was determined when, on what evidence, is the audit trail.
- **`WorkerEngagementTerm`** — a definite term with a **required** end date. An employee's `endDate` says when employment ended; this says the engagement was agreed to run to a date. Different fact, and one that matters: duration is itself a factor that reclassifies a contractor as an employee.
- **`consequencesFor()`** — typed consequences per classification rather than prose: withholding, directability, leave accrual, review enrolment, org-chart placement, whether a definite term is expected, whether a third party is the employer.
- **`resolveClassification()`** — fails **loudly**, matching `approval-routing.ts`. An unresolved classification is operator work naming its reason, never a silent default to `employee`, because every permissive default errs toward directing someone the organisation may not direct.

## The backfill refuses to guess

It maps only labels it can read unambiguously and leaves the rest NULL as operator work. Deliberately **not** mapped:

- a bare **"Contractor"** — direct vs agency differ on whether a third party is the employer, which is exactly where co-employment sits
- **"Director"** — a job title far more often than a board seat
- **"Temp"** alone — may be a fixed-term employee rather than agency labour

Applied against this populated install: `Full-time` and `Part-time` → `employee`, `Intern` → `intern`, and **`Advisor` and `Contractor` correctly left unresolved**.

## Refines AC-ELA-001

The spec said every `EmploymentType` row resolves to exactly one classification; the plan said unmappable labels surface as operator work. Those conflict. **The plan is right** — a required column would force the migration to guess a legal claim. The column is nullable and *unresolved* is a first-class state.

## Data impact

First migration in this epic, so it carries a `*.data-impact.json` manifest. Four fields are flagged `subject` with a governed `fieldPolicy`. `evidence` is flagged subject **because** its shape is free: the multi-factor tests differ by jurisdiction so the column cannot be structured, which means an operator could place special-category data there. Recorded as a stated obligation rather than a schema constraint.

## Build gate

- 23 test files / **201 tests** passing across `lib/workforce`, 15 of them new
- `tsc --noEmit` clean
- `pnpm --filter web build` exit 0
- **Migration applied cleanly against the populated dev database** — not a clean schema
- Module-size, spec-status and data-impact guards green

`packages/db` shows 6 pre-existing DB-state failures. Unmodified `main` shows **7**, so this introduces none and fixes one.

## Not in this PR

Nothing reads the column yet — refusing an action on the basis of classification is D5 (`BI-B506AD2E`), which the ratified sequencing puts **before** the actuator so it never runs classification-blind.