### PR TITLE
docs(kernel): bound autonomous directives by descent, not by effort (BI-980FE9F5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Every rule here is a one-line statement; the kernel principle behind it carries 
 - **Live state over seed data.** Query the database for current epics, backlog, users, capabilities and status. → [kernel principle](docs/professions/data-architect/wiki/live-state-over-seed-data.md)
 - **Research and use standards.** Cite sources; recommend the standard unless there is a project-specific reason to deviate. → [kernel principle](docs/founder-kernel/wiki/principles/research-and-use-standards.md)
 - **Use paid AI capacity responsibly.** → [kernel principle](docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md)
+- **An autonomous directive is bounded by descent, not effort.** Fix a blocker of the named objective; hand back at a blocker of *that* blocker, or on a second same-class failure. → [kernel principle](docs/founder-kernel/wiki/principles/autonomous-directives-are-blanket-approval.md)
 - **Self-provision before working.** A client missing its `dpf` MCP connector or `dpf-platform` skills converges before doing project work — run the bootstrap script from the repo root, then restart the client. Idempotent; covers all four CLI surfaces. → [Agent Toolchain Bootstrap](docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md)
 
 

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -3416,6 +3416,8 @@
         "autonomous-directives-are-blanket-approval",
         "why-this-exists",
         "what-counts-as-an-autonomous-directive",
+        "the-descent-bound-how-far-the-directive-carries",
+        "counterexample-the-58-hour-run-bi-980fe9f5",
         "what-still-requires-approval-even-under-autonomous-directives",
         "what-the-agent-should-do-mid-autonomous-run",
         "anti-pattern",
@@ -4449,6 +4451,7 @@
         "why",
         "applies-to",
         "how-to-apply",
+        "what-this-principle-does-not-cover",
         "decision-dimensions",
         "examples",
         "sources"

--- a/docs/founder-kernel/wiki/principles/autonomous-directives-are-blanket-approval.md
+++ b/docs/founder-kernel/wiki/principles/autonomous-directives-are-blanket-approval.md
@@ -3,9 +3,9 @@ title: Autonomous directives are blanket approval
 slug: autonomous-directives-are-blanket-approval
 pageKind: principle
 status: published
-abstract: When the operator says "drive 100%", "keep going", or any equivalent autonomous directive — that IS the approval. Stop asking between steps.
+abstract: When the operator says "drive 100%", "keep going", or any equivalent autonomous directive — that IS the approval. Stop asking between steps, and stop when the work stops being the work that was named.
 principleTier: core
-principleDirection: Treat an explicit autonomous directive as blanket approval for the named multi-step work; do not re-prompt for approval between steps inside that scope.
+principleDirection: Treat an explicit autonomous directive as blanket approval for the named multi-step work; do not re-prompt for approval between steps inside that scope, and hand back rather than descend past a blocker of that work.
 principleDimensionVector: {"human_cognitive_load": -0.9, "speed_to_value": 0.7, "governance_compliance": 0.4, "evidence_density": 0.3}
 principleAppliesTo:
   - in_platform_coworker
@@ -53,8 +53,68 @@ The operator made a decision once, at the start. Honor it.
 Any of these are full authorization for the agent to execute the entire
 plan without intermediate check-ins.
 
+## The descent bound — how far the directive carries
+
+An autonomous directive authorizes **the work that was named**. It does not
+authorize an unbounded walk away from it.
+
+Measure descent from the named objective:
+
+| Depth | What it is | Authorized? |
+| --- | --- | --- |
+| 0 | The named objective itself | Yes |
+| 1 | A blocker of the named objective | Yes — repair it and continue |
+| 2 | A blocker of *that* blocker | **No** — stop and hand back |
+
+At depth 2 the agent is no longer doing the work the operator authorized; it is
+doing the work that the work needs, which is a different decision and belongs
+to the operator. Stop and report the chain, the capacity spent so far, and the
+exact next action. Operator re-consent re-arms the directive **for the newly
+named work only** — it does not grant unbounded further descent.
+
+Two stop rules apply alongside it:
+
+- **Recurrence.** The same blocker class failing twice inside one task is a
+  stop-and-hand-back, not a third attempt. Two failures of one kind is
+  evidence about the system, not bad luck.
+- **Silence.** If the run cannot name what it will deliver next and roughly
+  what it will cost, it has already left the authorized scope.
+
+The bound is on **descent**, not on effort. A long, hard, entirely on-objective
+run needs no re-approval — that is precisely what the directive bought.
+
+### Counterexample — the 58-hour run (BI-980FE9F5)
+
+An external task was told "continue until its objectives are met". Over two
+days and 49 turns it merged ten PRs, refused every invitation to self-approve
+or fabricate a receipt, and reported honestly each of the five times it was
+asked whether it had delivered. It still did not deliver, because it had
+descended five levels:
+
+```
+Pet Rescue delivery
+  -> BI-A45D744A   (WordPress replay)
+    -> BI-FFBDDD96 (baseline/coverage receipts)
+      -> BI-47ACE2C7 (reviewer bootstrap)
+        -> BI-SIG-463E478D (reader pagination)
+          -> BI-42CE2CE7  (resumable TaskRun)
+```
+
+Nothing on that chain is the named objective. Each descent was individually
+correct and permitted; the majority of the capacity went into repairing gate
+machinery the objective merely traverses. Under this bound the task stops at
+BI-FFBDDD96 and hands the chain back, which is the outcome the operator
+actually wanted two days earlier.
+
+Note what this bound does **not** diagnose: the run was neither idle nor
+faking. [`responsible-capacity-utilization`](responsible-capacity-utilization.md)
+governs busywork and reads as satisfied throughout. Bounded descent is the
+missing half.
+
 ## What still requires approval (even under autonomous directives)
 
+- **Descent past depth 1** — see the descent bound above. Repairing a blocker
+  of a blocker is new work, not a next step.
 - **Destructive operations** that fall outside the announced plan:
   `docker compose down -v`, dropping a non-staging DB, force-pushing to
   a protected branch, deleting an entire worktree's branch. These are
@@ -90,3 +150,4 @@ This wastes a round-trip the operator already granted permission for.
 - [`do-the-work-dont-task-the-operator`](do-the-work-dont-task-the-operator.md)
 - [`state-results-directly`](state-results-directly.md)
 - [`never-ask-user-to-run-commands`](never-ask-user-to-run-commands.md)
+- [`responsible-capacity-utilization`](responsible-capacity-utilization.md)

--- a/docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md
+++ b/docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md
@@ -36,6 +36,21 @@ In-platform coworkers, external coding agents, and the humans who operate them. 
 
 Capacity use is driven by Standing Orders (durable directives from the operator), calendar / availability state, safe work queues, and existing authority controls. Coworkers may continue low-risk governed work when humans are unavailable, but must stop at approval boundaries for consequential actions. When the safe-work queue is empty, surface the blocker — "I'm idle because the backlog is empty and no review-stale specs were found" — instead of fabricating work. Periodically review what coworkers have been doing during idle stretches and tune the standing orders if the pattern is wasteful.
 
+## What this principle does NOT cover
+
+This principle separates useful work from busywork. It does not bound how far
+useful work may wander from what was asked. An agent that is genuinely active —
+producing evidence, merging PRs, refusing to fabricate — reads as satisfied here
+even while spending days on blockers of blockers and delivering nothing that was
+named. That failure mode is bounded by the descent rule in
+[`autonomous-directives-are-blanket-approval`](autonomous-directives-are-blanket-approval.md):
+depth 1 is authorized, depth 2 is a stop-and-hand-back, and the same blocker
+class failing twice is a stop rather than a third attempt.
+
+The two principles are halves of one question. This one asks "is the capacity
+producing value?"; that one asks "is it producing the value that was asked
+for?" Both must be yes.
+
 ## Decision Dimensions
 
 - `capacity_utilization: 1.0` — this is the axis the principle is named after. Maximum positive weight.

--- a/docs/superpowers/specs/2026-08-27-bounded-autonomous-blocker-descent-design.md
+++ b/docs/superpowers/specs/2026-08-27-bounded-autonomous-blocker-descent-design.md
@@ -1,0 +1,190 @@
+---
+status: active
+---
+
+# Bounded autonomous blocker-descent — design
+
+- **Backlog item:** BI-980FE9F5
+- **Work capsule:** WC-A3C9ED46
+- **Profile:** fix
+- **Authored:** 2026-08-27
+
+## Problem
+
+A single external-agent task ran approximately 58 hours of billed capacity
+across two days and 49 turns and did not deliver its named objective.
+Individual turns ran 11h43m, 10h02m, 7h32m, 5h00m and 4h13m.
+
+The task did nothing wrong by any rule then in force. It refused to
+self-approve, refused to fabricate receipts, honoured every fail-closed gate,
+merged ten PRs, and answered honestly each of the five times it was asked
+whether it had delivered. It failed structurally: it descended a chain of
+blocker-of-blocker repairs with no depth bound, no recurrence limit, and no
+cost ceiling.
+
+```
+Pet Rescue delivery                      <- named objective
+  -> BI-A45D744A     (WordPress replay)
+    -> BI-FFBDDD96   (baseline/coverage receipts)
+      -> BI-47ACE2C7 (reviewer bootstrap)
+        -> BI-SIG-463E478D (reader pagination)
+          -> BI-42CE2CE7   (resumable TaskRun)
+```
+
+Nothing below the first line is the named objective. The majority of the
+capacity went into repairing gate machinery the objective merely traverses.
+
+### Why no existing principle caught it
+
+Two principles are adjacent and neither applies.
+
+`autonomous-directives-are-blanket-approval` grants latitude for "the named
+multi-step work" and explicitly lists `"until it works"` as a qualifying
+directive. It bounds destructive operations, out-of-band scope expansion, and
+external actions — but places no bound on how far the work being done may drift
+from the work that was named. The operator said "continue until its objectives
+are met". That authorised every line above.
+
+`responsible-capacity-utilization` governs idle-versus-active and busywork:
+"when no useful, safe, evidence-producing work is available, the coworker
+records or surfaces the blocker rather than spending tokens to appear busy."
+The agent was active, safe, and evidence-producing throughout. The principle
+reads as satisfied while 58 hours produced no delivery.
+
+The gap is precise: **the platform knows how to tell work from busywork, and
+does not know how to tell the named work from work that is merely adjacent to
+it.**
+
+The task also could not detect its own recurrence. Three blocker classes
+(pre-inference provider-busy consuming an immutable review identity, split
+reviewer grants, capacity races) each failed three or more times and were
+retried rather than escalated.
+
+## Research
+
+Full-repository sweep for an existing capability found nothing:
+`blockerDepth`, `escalationBudget`, `maxBlockerDepth`, `prerequisiteDepth`,
+`metaWorkDepth`, `blocker_chain`, `escalation_budget` — zero matches across
+the tree. The principles corpus matched only the two pages named above.
+
+Adjacent filed work covers different failure modes and must not be duplicated:
+
+| Item | Covers | Why it is not this |
+| --- | --- | --- |
+| BI-7C1F43E3 | flow efficiency, request coalescing, WIP and progress SLOs | bounds *throughput and waste*, not *scope drift* |
+| BI-114C1F40 | Workroom WIP, progress SLOs, durable-wait liveness | a stalled task, not a productively-wandering one |
+| BI-MCP-EFF-0285909C | lease polling to durable wait and resume | transport, not authority |
+| BI-42CE2CE7 | transient capacity consuming a TaskRun | one instance of the chain above |
+
+The distinction that matters: every item above would have made the 58-hour run
+*cheaper*. None would have made it *stop*.
+
+### Prior art
+
+Bounded recursion with mandatory escalation is the standard shape. Erlang/OTP
+supervisors escalate to their own supervisor on `MaxRestarts` within a period
+rather than restarting forever; circuit breakers trip open after a failure
+threshold instead of retrying; incident practice escalates on the second
+recurrence rather than the Nth. All three encode the same rule this design
+adopts: repeated local failure is evidence about the system and belongs to a
+higher authority, not to another local attempt. DPF adopts the depth bound and
+the two-strike recurrence rule; it rejects a time-based or token-based ceiling,
+which would penalise a long, hard, entirely on-objective run — the exact run
+the directive was meant to buy.
+
+## Decision
+
+Bound the directive by **descent**, not by effort.
+
+| Depth | What it is | Authorized |
+| --- | --- | --- |
+| 0 | the named objective | yes |
+| 1 | a blocker of the named objective | yes |
+| 2 | a blocker of that blocker | **no — stop and hand back** |
+
+Plus two stop rules: the same blocker class failing twice is a stop, not a
+third attempt; and a run that cannot name what it will deliver next and roughly
+what it will cost has already left scope.
+
+Operator re-consent at a bound re-arms the directive for the newly named work
+only. It does not grant unbounded further descent.
+
+Considered and rejected:
+
+- **A time or token ceiling.** Penalises exactly the run the directive was
+  bought for — long, hard, on-objective. Depth is the property that actually
+  correlates with drift.
+- **A new supervisor agent.** A parallel authority to police the first is more
+  substrate, and it would need its own bound. The bound belongs in the
+  directive itself.
+- **Forbidding blocker repair entirely.** Depth 1 is genuinely the work; an
+  agent that stops at the first obstacle is useless.
+- **Raising the bound to depth 3.** The observed chain reached five. Any bound
+  above 1 re-admits the case where the operator cannot recognise the work.
+
+## Scope — this change
+
+Doctrine only.
+
+- `docs/founder-kernel/wiki/principles/autonomous-directives-are-blanket-approval.md`
+  — the descent bound, the two stop rules, the worked counterexample, and the
+  bound added to "what still requires approval". Abstract and
+  `principleDirection` updated to carry it.
+- `docs/founder-kernel/wiki/principles/responsible-capacity-utilization.md`
+  — a "what this principle does NOT cover" section naming the gap and pointing
+  at the bound, so the pair reads as two halves of one question.
+- `AGENTS.md` §1 — the one-line operative rule with its kernel pointer.
+
+`principleDimensionVector` is deliberately left unchanged. The numeric vector
+feeds `principle_decide` scoring; perturbing it would silently re-weight
+unrelated decisions, and the bound is a rule about scope rather than a new
+magnitude on an existing axis.
+
+## Deliberately not in this change
+
+The BI's acceptance criteria also require depth and lineage to be **derivable
+from live state** rather than from agent prose, and elapsed capacity per
+objective to be queryable. That is a projection over `BacklogItem`,
+`WorkCapsule`, `TaskRun` and `WorkCapsuleActivity` and is a separate slice
+against the same BI.
+
+Shipping doctrine first is not a shortcut. The observed failure was an agent
+faithfully following a rule that did not exist yet; the rule is the load-bearing
+half, and it is enforceable by review and by the agent contract the moment it
+lands. The projection makes it *measurable* and removes reliance on self-report.
+BI-980FE9F5 stays open until both land.
+
+## Verification
+
+- Doc reference integrity and the spec/plan status convention pass.
+- The claim under test is a rule, not a code path: the check is that an agent
+  reading `AGENTS.md` §1 and the kernel page reaches "stop and hand back" on
+  the counterexample chain. The counterexample is stated in the page with the
+  real BI identities so it is checkable against live backlog state.
+
+## Risk
+
+Low, and asymmetric. The failure mode of an over-tight bound is an extra
+operator round-trip; the failure mode of no bound is two days of capacity for
+no delivery, already observed once. No gate is weakened, no evidence
+requirement relaxed, nothing becomes fail-open.
+
+The one real risk is over-application: an agent reading the bound as licence to
+stop at the first difficulty. The page addresses it directly — "the bound is on
+descent, not on effort" — and depth 1 remains explicitly authorized.
+
+## Implementation sequence
+
+Single phase, single commit, no separate plan document: one deliverable mapping
+1:1 to BI-980FE9F5 with nothing deferred beyond the slice named above, which is
+already recorded on the BI.
+
+1. Extend the kernel principle with the bound, the stop rules and the
+   counterexample; update abstract, direction and related links.
+2. Add the reciprocal "does NOT cover" section to
+   `responsible-capacity-utilization`.
+3. Add the operative one-liner to `AGENTS.md` §1.
+
+## Rollback
+
+Single revert. Reverting restores unbounded descent, which is what ships today.

--- a/scripts/instruction-plane-baseline.txt
+++ b/scripts/instruction-plane-baseline.txt
@@ -1,4 +1,4 @@
-AGENTS.md	23906
-CLAUDE.md	194
+AGENTS.md	24180
+CLAUDE.md	128
 CONVENTIONS.md	244
-extracted:dpf-skill-pack-descriptions	14157
+extracted:dpf-skill-pack-descriptions	13431

--- a/scripts/instruction-plane-rule-baseline.txt
+++ b/scripts/instruction-plane-rule-baseline.txt
@@ -1,6 +1,7 @@
 docs/founder-kernel/wiki/principles/all-changes-land-via-pr.md	PR creation means ready to merge.
 docs/founder-kernel/wiki/principles/always-push-after-committing.md	Always push after committing.
 docs/founder-kernel/wiki/principles/architecture-over-shortcuts.md	Architecture over shortcuts.
+docs/founder-kernel/wiki/principles/autonomous-directives-are-blanket-approval.md	An autonomous directive is bounded by descent, not effort.
 docs/founder-kernel/wiki/principles/branch-guard-before-implementation.md	Branch guard before implementation and commit:
 docs/founder-kernel/wiki/principles/build-gate-mandatory.md
 docs/founder-kernel/wiki/principles/claim-a-workroom-before-you-work.md	Claim a workroom before you work — every surface, including the external CLIs.
@@ -23,7 +24,7 @@ docs/founder-kernel/wiki/principles/no-assumptions.md	Never assume — verify.
 docs/founder-kernel/wiki/principles/no-hardcoded-colors.md	No hardcoded colors.
 docs/founder-kernel/wiki/principles/no-native-browser-dialogs.md
 docs/founder-kernel/wiki/principles/one-common-process-three-surfaces.md	Four peer surfaces, one process.
-docs/founder-kernel/wiki/principles/one-concern-per-pr.md	All changes land via PR against `main`, one concern per branch and PR, DCO-signe
+docs/founder-kernel/wiki/principles/one-concern-per-pr.md	All changes land via PR against `main`, DCO-signed, scoped to one clean revert.
 docs/founder-kernel/wiki/principles/plan-before-install-paths.md	Plan before acting on install/seed/template paths.
 docs/founder-kernel/wiki/principles/reap-sidecars-to-upgrade-tools.md	Tooling upgrade = operator-triggered quiesce → reap → upgrade → resume.
 docs/founder-kernel/wiki/principles/research-and-use-standards.md	Research and use standards.


### PR DESCRIPTION
## Why

A single external-agent task ran **~58 hours of billed capacity over two days and 49 turns** and delivered none of its named objective.

It broke no rule. It refused to self-approve, refused to fabricate receipts, honoured every fail-closed gate, merged ten PRs, and answered honestly each of the five times it was asked whether it had delivered. It failed *structurally* — it descended five levels of blocker-of-blocker repair:

```
Pet Rescue delivery                      <- named objective
  -> BI-A45D744A     (WordPress replay)
    -> BI-FFBDDD96   (baseline/coverage receipts)
      -> BI-47ACE2C7 (reviewer bootstrap)
        -> BI-SIG-463E478D (reader pagination)
          -> BI-42CE2CE7   (resumable TaskRun)
```

Nothing below the first line is the named objective.

**Neither adjacent principle catches this.** `autonomous-directives-are-blanket-approval` lists `"until it works"` as a qualifying directive and bounds destructive actions, scope expansion and external actions — but never how far the work may drift from what was *named*. `responsible-capacity-utilization` separates work from busywork, and this agent was active, safe and evidence-producing throughout, so it reads as satisfied while nothing asked for got delivered.

The platform knew how to tell work from busywork. It did not know how to tell the named work from work merely adjacent to it.

## The rule

| Depth | What it is | Authorized |
| --- | --- | --- |
| 0 | the named objective | yes |
| 1 | a blocker of the named objective | yes |
| 2 | a blocker of that blocker | **no — stop and hand back** |

Plus: the same blocker class failing twice is a stop, not a third attempt. Re-consent re-arms the directive for the newly named work only.

**The bound is on descent, not effort.** A long, hard, entirely on-objective run needs no re-approval — that is exactly what the directive bought.

## Substrate check

Full-repo sweep for `blockerDepth` / `escalationBudget` / `maxBlockerDepth` / `prerequisiteDepth` / `metaWorkDepth` / `blocker_chain` / `escalation_budget`: **zero matches.** The principles corpus matched only the two pages edited here.

Adjacent filed work covers different failure modes and is not duplicated — BI-7C1F43E3 (flow efficiency), BI-114C1F40 (WIP/SLO), BI-MCP-EFF-0285909C (durable wait), BI-42CE2CE7 (one instance of the chain above). Every one of them would have made the 58-hour run *cheaper*. None would have made it *stop*.

## Notes for review

- `principleDimensionVector` is deliberately **unchanged** — it feeds `principle_decide` scoring, and this is a rule about scope, not a new magnitude on an existing axis. The pre-commit golden-decisions check confirms both canonical decisions still hold.
- Instruction-plane ratchet re-baselined with justification in the commit body (BI-0020D511): `AGENTS.md` 23906 → 24180, +274 bytes for one line. The rule has to live in the always-on plane to work — an agent consults it exactly when it is about to descend, which is before it would think to open a skill page.
- Guard-parity preflight: **52/52 clean**.
- Doctrine-only. No gate weakened, no evidence requirement relaxed, nothing becomes fail-open.

## Deliberately not in this PR

BI-980FE9F5 also requires depth/lineage to be derivable from **live state** rather than agent prose, and elapsed capacity per objective to be queryable — a projection over `BacklogItem` / `WorkCapsule` / `TaskRun` / `WorkCapsuleActivity`. That is a separate slice and **BI-980FE9F5 stays open until it lands.**

Doctrine first is not a shortcut: the observed failure was an agent faithfully following a rule that did not exist yet. The rule is the load-bearing half. The projection makes it measurable and removes reliance on self-report.

Backlog item: BI-980FE9F5 · Workroom: WC-A3C9ED46 · Design: `docs/superpowers/specs/2026-08-27-bounded-autonomous-blocker-descent-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Seed-Fit-Decision: global-default
