### PR TITLE
fix(install): make the documented identity overrides actually reachable

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -5558,6 +5558,7 @@
         "agent-toolchain-only-update",
         "where-state-lives",
         "installation-operating-intent-and-environment-class",
+        "naming-the-installation-and-overriding-what-it-is",
         "diagnostics",
         "show-substrate-flag",
         "dpf-doctor",

--- a/apps/web/lib/install/env-override-reachability.test.ts
+++ b/apps/web/lib/install/env-override-reachability.test.ts
@@ -1,0 +1,61 @@
+// BI-10BF6206 — a documented process override must actually reach the portal.
+//
+// Both installation-identity contracts declare a highest-precedence process
+// override. Neither variable was listed in the portal service's `environment:`
+// allow-list, and that allow-list is the ONLY way an env var reaches the portal
+// on a consumer install: the service has no `env_file:`. So the documented top
+// tier could be set in `.env` all day and `process.env` would never see it.
+//
+// A precedence chain whose first rung is unreachable is not a precedence chain.
+// This test is the invariant that stops the next contract shipping one — the
+// "fix the seed, then add a guard" shape, where the guard is the durable half.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { ENVIRONMENT_CLASS_ENV_VAR } from "./environment-class-contract";
+import { ESTATE_NAME_ENV_VAR } from "./estate-identity-contract";
+
+const COMPOSE = readFileSync(
+  fileURLToPath(new URL("../../../../docker-compose.yml", import.meta.url)),
+  "utf8",
+);
+
+/** The portal service block, which owns the allow-list the portal process sees. */
+function portalServiceBlock(): string {
+  const start = COMPOSE.indexOf("\n  portal:\n");
+  expect(start, "portal service not found in docker-compose.yml").toBeGreaterThan(-1);
+  const rest = COMPOSE.slice(start + 1);
+  const next = rest.search(/\n {2}[a-zA-Z0-9_-]+:\n/);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+describe("documented process overrides reach the portal", () => {
+  const block = portalServiceBlock();
+
+  it.each([
+    ["environment class", ENVIRONMENT_CLASS_ENV_VAR],
+    ["estate name", ESTATE_NAME_ENV_VAR],
+  ])("%s override %s is in the portal environment allow-list", (_label, variable) => {
+    expect(
+      block.includes(`${variable}:`),
+      `${variable} is documented as a process override but is absent from the portal ` +
+        "service's environment: allow-list, so it can never reach process.env on a " +
+        "consumer install. Add it with an empty default.",
+    ).toBe(true);
+  });
+
+  it("keeps them optional, so the tier stays silent unless an operator sets it", () => {
+    for (const variable of [ENVIRONMENT_CLASS_ENV_VAR, ESTATE_NAME_ENV_VAR]) {
+      expect(block).toContain(`${variable}: \${${variable}:-}`);
+    }
+  });
+
+  // The premise. If the portal ever gains an env_file, this test's reasoning
+  // changes and it should be revisited rather than silently kept passing.
+  it("still holds the premise: the portal has no env_file", () => {
+    expect(block).not.toContain("env_file");
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,6 +204,15 @@ services:
       DPF_HOST_INSTALL_PATH: ${DPF_HOST_INSTALL_PATH:-}
       DPF_HOST_PLATFORM: ${DPF_HOST_PLATFORM:-}
       DPF_HOST_ARCH: ${DPF_HOST_ARCH:-}
+      # Installation identity process-override tier (BI-7626A660 / BI-10BF6206).
+      # `environment-class-contract` and `estate-identity-contract` both document
+      # a highest-precedence process override, and neither variable was listed
+      # here — so on a consumer install, where this allow-list is the ONLY way an
+      # env var reaches the portal, the documented top tier could never be set.
+      # A precedence chain whose first rung is unreachable is not a precedence
+      # chain. Empty default keeps the tier silent unless an operator sets it.
+      DPF_ENVIRONMENT_CLASS: ${DPF_ENVIRONMENT_CLASS:-}
+      DPF_ESTATE_NAME: ${DPF_ESTATE_NAME:-}
       # Authoritative installer opt-in state for the main installation's
       # supervised host Edge service. The portal combines this intent with
       # live enrollment/heartbeat evidence; it never treats the flag as health.

--- a/docs/operations/install.md
+++ b/docs/operations/install.md
@@ -236,6 +236,32 @@ Per EP-1FABA22D (BI-A9F60372), `install-state.json` (v2 schema) captures the can
 - **`bootstrapIntent`** — Pre-DB envelope recorded by the installer before runtime database availability. On portal runtime boot, `absorbBootstrapIntent` idempotently ingests this envelope into `PlatformConfig` under key `installation.operating-intent.v1` with `status: "suggested"` and marks `absorbedAt`.
 - **Purpose Confirmation Invariant** — Expressing operating purpose (`operate-organization`, `evolve-dpf`, `deliver-managed-services`, `grow-channel`, `participate-community`) configures platform productivity and compiles work; it **never grants identity, trust, authority, qualification, or permission**.
 
+### Naming the installation, and overriding what it is
+
+Two facts describe an installation: the **environment class** (production /
+development / test) and the **estate name** — the company or team that OPERATES
+it, which is not the business it runs for. An IT services company running
+installations for twenty customers is one estate and twenty organizations.
+
+Both resolve through the same precedence chain, highest first:
+
+```
+process override  ->  installer state  ->  portal declaration  ->  default / unset
+```
+
+The process overrides are `DPF_ENVIRONMENT_CLASS` and `DPF_ESTATE_NAME`. Set
+either in the install's `.env`; both are declared on the portal service with an
+empty default, so an unset variable leaves the tier silent and the next
+authority answers (BI-10BF6206 — before that they were absent from the portal's
+environment allow-list, which meant the documented top tier could never be set on
+a consumer install).
+
+The estate name is a label, not an authorization input: it changes what the
+header badge and connected AI coworkers CALL this installation, never what they
+may do on it. A non-production installation shows a badge beside the logo
+(`ACME DEV`); production shows none, so a badge always means "this is not
+production".
+
 ## Diagnostics
 
 ### `--show-substrate` flag


### PR DESCRIPTION
Both installation-identity contracts declare a highest-precedence process override — `DPF_ENVIRONMENT_CLASS` and `DPF_ESTATE_NAME`. **Neither appeared in any compose file.**

The portal service declares an explicit 216-entry `environment:` allow-list and has no `env_file:`. On a consumer install that allow-list is the *only* way an environment variable reaches the portal process, so a variable absent from it can be set in `.env` all day and `process.env` inside the container never sees it.

The documented top tier of both chains was unreachable on exactly the installs the chain exists for. **A precedence chain whose first rung cannot be reached is not a precedence chain** — it is three rungs and a comment.

The environment-class half is pre-existing. The estate-name half is mine: BI-7626A660 mirrored that contract faithfully, gap included — which is the argument for a guard rather than just a fix.

## How it was found

Naming this installation had **no non-UI path at all**. The override couldn't reach the container, and `declareEstateName` is a Next server action needing a browser session. The value went straight into `PlatformConfig` to deliver the outcome — which works, and bypasses the capability check the action performs.

That is worth not repeating, on a platform whose doctrine is "never ask the user to run commands".

## The guard is the durable half

`env-override-reachability.test.ts` asserts that every documented override constant appears in the portal allow-list with an empty default, and holds the premise it depends on (no `env_file`).

**Verified RED against the unfixed compose** — all three assertions fail — so it is a guard, not a tautology.

## Left for BI-10BF6206

- An installer flag (`--estate-name` / `-EstateName`) writing installer state — the tier described as "someone types it in when the instance is installed".
- A governed MCP path to declare installation identity, so an agent isn't obliged to hand the job back to a human at a browser.

## Gates

- 4 new tests; typecheck, module-size, style-drift, docs-impact, ux-fit, prose-lint, ActionResult ratchet pass locally.
- Compose YAML parses.
- **No UX verification** — this is container configuration and a test; no user-facing surface changes.

Backlog: `BI-10BF6206`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Docs-Impact-Decision: the three pages linked to `docker-compose.yml` — `2026-06-09-long-running-agentic-process-architecture.md`, `platform-overview.md` and `disaster-recovery.md` — are linked because compose is broadly referenced, and none of them describes installation-identity configuration; adding two optional environment entries changes nothing they state. The page that genuinely covers this, `docs/operations/install.md`, IS updated in this PR with the precedence chain, both variable names and the estate/organization distinction, which previously appeared nowhere an operator reads.
