### PR TITLE
fix(build-studio): the size gate must offer the split, not a blocked advance (BI-04B112CA)

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -941,7 +941,8 @@ export function BuildStudio({
                         assessment={activeBuild.designReview?.sizeAssessment ?? null}
                         initialCandidates={activeBuild.designReview?.decompositionCandidates?.latest ?? []}
                         existingOverride={activeBuild.designReview?.decompositionOverride ?? null}
-                        planOscillationEntry
+                        // BI-04B112CA: decompose-now has two entry points now.
+                        planOscillationEntry={activeBuild.phase === "plan"}
                       />
                     )}
                     {workflowAction.kind === "amend-parent-design" && (

--- a/apps/web/components/build/build-studio-workflow-actions.test.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.test.ts
@@ -194,6 +194,49 @@ describe("deriveBuildStudioWorkflowAction", () => {
     expect(action.disabledReason).toBeNull();
   });
 
+  // BI-04B112CA / BI-97F7F599 — live repro FB-41EA43C5: the design passed review
+  // and the size gate said decompose-required, and the owner was still offered
+  // "Advance to Plan" — the one action the platform had already decided to block.
+  it("offers the split instead of Advance to Plan when the size gate says the design is too big", () => {
+    const action = deriveBuildStudioWorkflowAction({
+      build: makeBuild({
+        phase: "ideate",
+        draftApprovedAt: new Date("2026-04-25T13:00:00Z"),
+        designReview: {
+          decision: "pass",
+          issues: [],
+          sizeAssessment: { decision: "decompose-required" },
+        } as unknown as FeatureBuildRow["designReview"],
+      }),
+      governedBacklogEnabled: true,
+    });
+
+    expect(action.kind).toBe("decompose-now");
+    expect(action.primaryLabel).toBe("Split into smaller builds");
+    expect(action.targetPhase).toBeNull();
+    expect(action.disabledReason).toBeNull();
+    // Plain words, not a size label the owner has to decode.
+    expect(action.title).toMatch(/too big for one build/i);
+  });
+
+  it("still advances to Plan when the design is the right size", () => {
+    const action = deriveBuildStudioWorkflowAction({
+      build: makeBuild({
+        phase: "ideate",
+        draftApprovedAt: new Date("2026-04-25T13:00:00Z"),
+        designReview: {
+          decision: "pass",
+          issues: [],
+          sizeAssessment: { decision: "ok" },
+        } as unknown as FeatureBuildRow["designReview"],
+      }),
+      governedBacklogEnabled: true,
+    });
+
+    expect(action.kind).toBe("advance-phase");
+    expect(action.primaryLabel).toBe("Advance to Plan");
+  });
+
   it("disables Advance to Plan with the gate reason when ideate evidence is incomplete", () => {
     const action = deriveBuildStudioWorkflowAction({
       build: makeBuild({

--- a/apps/web/components/build/build-studio-workflow-actions.ts
+++ b/apps/web/components/build/build-studio-workflow-actions.ts
@@ -11,6 +11,7 @@ import {
   type NormalizedVerificationOutput,
 } from "@/lib/build/verification-output";
 import { derivePlanOscillationDecompositionAffordance } from "@/lib/build/plan-oscillation-decomposition";
+import { sizeGateDecompositionAction } from "@/lib/build/size-gate-decomposition-affordance";
 import {
   isContradictoryExecState,
   type ExecStateLike,
@@ -764,15 +765,13 @@ export function deriveBuildStudioWorkflowAction({
   }
 
   if (build.phase === "ideate") {
-    // BI-77A1973C: previously the ideate phase fell through to review-only,
-    // hiding the advance affordance even after design review passed and the
-    // intake gate auto-derived. The agent's chat said "Ready to advance to
-    // Plan? Confirm and I'll structure the decomposition" but there was no
-    // UI button to act on it — only chat-driven confirmation. Now there's an
-    // explicit Advance to Plan button that mirrors the existing plan→build
-    // pattern below. Disabled state surfaces the gate reason from
-    // checkPhaseGate so users see exactly what's blocking (missing
-    // designDoc, designReview pending, or intake anchors not satisfied).
+    // BI-04B112CA: a size-gated design gets the split, not a blocked advance.
+    const split = sizeGateDecompositionAction(build);
+    if (split) return { kind: "decompose-now", targetPhase: null, ...split };
+
+    // BI-77A1973C: ideate once fell through to review-only, hiding the advance
+    // even after design review passed. The disabled state surfaces the gate
+    // reason from checkPhaseGate so the owner sees what is blocking.
     return {
       kind: "advance-phase",
       title: "Ready for Planning",

--- a/apps/web/lib/build/size-gate-decomposition-affordance.test.ts
+++ b/apps/web/lib/build/size-gate-decomposition-affordance.test.ts
@@ -1,0 +1,90 @@
+// BI-04B112CA / BI-97F7F599 — the size gate must drive the owner's next action.
+
+import { describe, expect, it } from "vitest";
+
+import { deriveSizeGateDecompositionAffordance } from "./size-gate-decomposition-affordance";
+
+const designDoc = { problemStatement: "P" } as never;
+
+function review(decision: string, sizeDecision?: string) {
+  return {
+    decision,
+    ...(sizeDecision ? { sizeAssessment: { decision: sizeDecision } } : {}),
+  } as never;
+}
+
+describe("deriveSizeGateDecompositionAffordance", () => {
+  // The live repro: FB-41EA43C5 passed design review, was assessed xlarge, and
+  // was offered "Advance to Plan" — which the gate then refused.
+  it("offers decomposition for a passed ideate design assessed decompose-required", () => {
+    const result = deriveSizeGateDecompositionAffordance({
+      phase: "ideate",
+      designReview: review("pass", "decompose-required"),
+      designDoc,
+    });
+
+    expect(result).toMatchObject({ kind: "decompose-now", required: true, disabledReason: null });
+  });
+
+  it("offers decomposition for decompose-recommended, marked as advisory", () => {
+    const result = deriveSizeGateDecompositionAffordance({
+      phase: "ideate",
+      designReview: review("pass", "decompose-recommended"),
+      designDoc,
+    });
+
+    expect(result).toMatchObject({ kind: "decompose-now", required: false });
+  });
+
+  it("stays out of the way when the design is the right size", () => {
+    expect(
+      deriveSizeGateDecompositionAffordance({
+        phase: "ideate",
+        designReview: review("pass", "ok"),
+        designDoc,
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("stays out of the way when no size assessment was recorded", () => {
+    expect(
+      deriveSizeGateDecompositionAffordance({
+        phase: "ideate",
+        designReview: review("pass"),
+        designDoc,
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  // A failing design is the design loop's problem — splitting it would carry the
+  // unresolved issues into every child.
+  it("does not offer decomposition while the design review is failing", () => {
+    expect(
+      deriveSizeGateDecompositionAffordance({
+        phase: "ideate",
+        designReview: review("fail", "decompose-required"),
+        designDoc,
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("does not fire outside ideate — plan oscillation owns that entry point", () => {
+    expect(
+      deriveSizeGateDecompositionAffordance({
+        phase: "plan",
+        designReview: review("pass", "decompose-required"),
+        designDoc,
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("disables the action when there is no design to split", () => {
+    const result = deriveSizeGateDecompositionAffordance({
+      phase: "ideate",
+      designReview: review("pass", "decompose-required"),
+      designDoc: null,
+    });
+
+    expect(result).toMatchObject({ kind: "decompose-now", disabledReason: "Need a design doc first." });
+  });
+});

--- a/apps/web/lib/build/size-gate-decomposition-affordance.ts
+++ b/apps/web/lib/build/size-gate-decomposition-affordance.ts
@@ -1,0 +1,110 @@
+// apps/web/lib/build/size-gate-decomposition-affordance.ts
+//
+// BI-04B112CA / BI-97F7F599 — when the design-size gate says a design is too
+// large for one build, decomposition is the owner's next action.
+//
+// The decomposition affordance already existed, but only for the SECONDARY
+// entry point: a top-level `plan` build whose plan review is oscillating
+// (see plan-oscillation-decomposition.ts). The PRIMARY entry point — the one
+// the size gate itself creates — had no affordance at all, so an `ideate`
+// build with a passed design and `decompose-required` fell through to
+// "Advance to Plan", which the gate then refused.
+//
+// `propose_build_decomposition` and `approve_decomposition` have always
+// accepted this case; DecompositionCoordinator has always rendered the size
+// banner from `assessment`. Only the workflow-action resolver was missing it,
+// so the panel never mounted and the owner was handed a blocked button.
+//
+// Live repro FB-41EA43C5 on the Pet Rescue install: design passed review,
+// `decompose-required` (xlarge, 7 models, 24 ACs), and the only offered action
+// was "Advance to Plan" — which threw rather than explaining itself.
+//
+// Pure module — no Prisma, no React — so the rule is testable on its own.
+
+import type { BuildDesignDoc, BuildPhase, ReviewResult } from "@/lib/feature-build-types";
+
+/** The size decisions that call for splitting the build. */
+const DECOMPOSING_DECISIONS = new Set(["decompose-required", "decompose-recommended"]);
+
+export type SizeGateDecompositionAffordance =
+  | { kind: "none" }
+  | {
+      kind: "decompose-now";
+      /** Which side of the gate fired — `required` blocks, `recommended` advises. */
+      required: boolean;
+      disabledReason: string | null;
+    };
+
+export type SizeGateBuildInput = {
+  phase: BuildPhase;
+  designReview: ReviewResult | null;
+  designDoc: BuildDesignDoc | null;
+};
+
+function sizeDecisionOf(designReview: ReviewResult | null): string | null {
+  const assessment = (designReview as { sizeAssessment?: { decision?: unknown } } | null)
+    ?.sizeAssessment;
+  const decision = assessment?.decision;
+  return typeof decision === "string" ? decision : null;
+}
+
+/**
+ * Decide whether an ideate build should be offered decomposition.
+ *
+ * Deliberately narrow: only a build whose design has PASSED review can be
+ * split, because the child scopes are derived from that design's acceptance
+ * criteria. A failing design is the design loop's problem, not the size gate's.
+ */
+export function deriveSizeGateDecompositionAffordance(
+  build: SizeGateBuildInput,
+): SizeGateDecompositionAffordance {
+  if (build.phase !== "ideate") return { kind: "none" };
+  if (build.designReview?.decision !== "pass") return { kind: "none" };
+
+  const decision = sizeDecisionOf(build.designReview);
+  if (decision === null || !DECOMPOSING_DECISIONS.has(decision)) return { kind: "none" };
+
+  return {
+    kind: "decompose-now",
+    required: decision === "decompose-required",
+    // The child scopes are cut from the parent's acceptance criteria, so the
+    // design document has to be there to split at all.
+    disabledReason: build.designDoc ? null : "Need a design doc first.",
+  };
+}
+
+/**
+ * The owner-facing action for a design the size gate wants split.
+ *
+ * The copy lives here, beside the rule that decides it, rather than inline in
+ * the workflow-action resolver: Build Studio's component surface is under a
+ * ratchet (BI-101C107C) and this is decision text, not presentation.
+ *
+ * Returns null when the gate has nothing to say, so the caller can fall through
+ * to its normal next action.
+ */
+export function sizeGateDecompositionAction(build: SizeGateBuildInput): {
+  title: string;
+  message: string;
+  primaryLabel: string;
+  disabledReason: string | null;
+  coworkerLabel: string;
+  coworkerPrompt: string;
+} | null {
+  const affordance = deriveSizeGateDecompositionAffordance(build);
+  if (affordance.kind !== "decompose-now") return null;
+
+  return {
+    title: affordance.required
+      ? "This Design Is Too Big For One Build"
+      : "This Design Would Be Easier In Parts",
+    message: affordance.required
+      ? "The design passed review, but it covers more than one build can carry. Split it into smaller builds that each finish on their own, then plan those."
+      : "The design passed review. It is large enough that splitting it into smaller builds would likely land sooner, though you can plan it as one.",
+    primaryLabel: "Split into smaller builds",
+    disabledReason: affordance.disabledReason,
+    coworkerLabel: "Talk through the split",
+    coworkerPrompt:
+      "The design review passed but the size gate says this build is too large. Walk me through what it covers, then propose how to split it into smaller builds that each deliver something on their own.",
+  };
+}


### PR DESCRIPTION
## Problem

When the design-size gate fires in ideate, **decomposition is the owner's next action**. The resolver went straight to "Advance to Plan" — handing the owner the one button the platform had already decided to block.

Live repro `FB-41EA43C5` on the Pet Rescue install:

```
20:06:29  design-size-assessed  decompose-required. xlarge. 7 models, 24 ACs
20:06:29  phase:gate-blocked    advance blocked until decomposition
20:06:29  design_fix_loop       Design review passed after 1 fix round(s)

panel:  "Waiting on you — Next: move this design into planning. [Advance to Plan]"
click:  Minified React error #441; phase stays ideate
```

The decomposition affordance existed — but only for the **secondary** entry point: a top-level `plan` build whose plan review is oscillating. The **primary** entry point, the one the size gate itself creates, had no affordance at all. So `decompose-now` never fired in ideate and `DecompositionCoordinator` never mounted.

That component has always rendered the size banner from `assessment`, and `propose_build_decomposition` / `approve_decomposition` have always accepted an ideate build with a passed review and a `decompose-*` assessment. **Only the workflow-action resolver was missing the case** — so the owner met a dead end with two broken doors: a button that threw, and a panel that was never rendered to reach.

## Change

- New pure module `size-gate-decomposition-affordance.ts` decides the ideate case: design review **passed** and `sizeAssessment.decision` is `decompose-required` or `decompose-recommended`. Deliberately narrow — a *failing* design is the design loop's problem, and splitting it would carry the unresolved issues into every child.
- The ideate branch consults it before falling through, and returns **"Split into smaller builds"** in plain words: the design covers more than one build can carry. `required` blocks; `recommended` advises.
- `BuildStudio` passes `planOscillationEntry` only for the plan phase, so the two entry points stay distinguishable now that both reach the coordinator.

**Not fixed here:** the React #441 itself, and `propose_build_decomposition` persisting nothing when it fails — those stay with `BI-97F7F599`. This change removes the need to hit either on the primary path.

## Verification

- `lib/build` + `components/build`: **241 files / 2591 tests pass**.
- The resolver case is confirmed **Red** against `origin/main`, green with the fix.
- `pnpm --filter web typecheck` clean; guard loop 37/37; module-size, style-drift, docs-impact, spec/plan/doc, design-grounding clean.
- `pnpm --filter web build` could **not** be run locally — Turbopack rejects this worktree's shared-dependency junction (`Symlink [project]/node_modules … points out of the filesystem root`). Relying on the CI **Production Build** check, which runs on a real checkout.

Refs: BI-04B112CA, BI-97F7F599, WC-E60C43DA