### PR TITLE
feat(federation): confirm a same-organization pairing on trust, not a typed code

### DIFF
--- a/apps/web/lib/federation/confirm-pairing-from-organization-trust.test.ts
+++ b/apps/web/lib/federation/confirm-pairing-from-organization-trust.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  confirmPairingFromOrganizationTrust,
+  type PairingSessionRow,
+  type TrustConfirmationStore,
+} from "./confirm-pairing-from-organization-trust";
+
+type ConfirmationWrite = Parameters<TrustConfirmationStore["recordLocalConfirmation"]>[0];
+
+const NOW = new Date("2026-08-27T00:00:00.000Z");
+const AUTO_ENROLL = { mode: "auto-enroll" as const, explanation: "same organization root" };
+const EVIDENCE = {
+  presentedRootFingerprint: "a".repeat(64),
+  certificateVerified: true,
+  peerOrganizationRef: "ORG-1779558156034",
+};
+
+function session(overrides: Partial<PairingSessionRow> = {}): PairingSessionRow {
+  return {
+    id: "row-1",
+    pairingId: "pair-1",
+    direction: "outgoing",
+    status: "pending",
+    expiresAt: new Date("2026-08-27T00:10:00.000Z"),
+    sasState: { protocolVersion: 1, localDeviceId: "dev-local" },
+    ...overrides,
+  };
+}
+
+function store(row: PairingSessionRow | null = session()) {
+  const recordLocalConfirmation = vi.fn(async (_input: ConfirmationWrite) => {});
+  const impl: TrustConfirmationStore = {
+    findSession: async () => row,
+    recordLocalConfirmation,
+  };
+  return { store: impl, recordLocalConfirmation };
+}
+
+function run(overrides: {
+  decision?: { mode: "auto-enroll" | "operator-confirmation" | "blocked"; explanation: string; reason?: never };
+  row?: PairingSessionRow | null;
+  peerOk?: boolean;
+} = {}) {
+  const { store: impl, recordLocalConfirmation } = store(
+    overrides.row === undefined ? session() : overrides.row,
+  );
+  const confirmWithPeer = vi.fn(async () => ({ ok: overrides.peerOk ?? true }));
+  return {
+    recordLocalConfirmation,
+    confirmWithPeer,
+    result: confirmPairingFromOrganizationTrust({
+      pairingId: "pair-1",
+      decision: (overrides.decision ?? AUTO_ENROLL) as never,
+      evidence: EVIDENCE,
+      store: impl,
+      confirmWithPeer,
+      now: NOW,
+    }),
+  };
+}
+
+describe("confirmPairingFromOrganizationTrust — the case that skips the code", () => {
+  it("confirms a validated same-organization peer", async () => {
+    const { result, recordLocalConfirmation } = run();
+    expect(await result).toEqual({ confirmed: true, provenance: "organization-trust" });
+    expect(recordLocalConfirmation).toHaveBeenCalledOnce();
+  });
+
+  it("records that a machine confirmed it, on what basis, with no person", async () => {
+    const { result, recordLocalConfirmation } = run();
+    await result;
+    const written = recordLocalConfirmation.mock.calls[0]?.[0] as ConfirmationWrite;
+    expect(written.sasState).toMatchObject({
+      // Prior SAS state is preserved, not clobbered.
+      protocolVersion: 1,
+      localDeviceId: "dev-local",
+      confirmationProvenance: "organization-trust",
+      confirmationEvidence: {
+        certificateVerified: true,
+        presentedRootFingerprint: "a".repeat(64),
+        peerOrganizationRef: "ORG-1779558156034",
+      },
+    });
+    // No principal is written anywhere: none exists, and inventing one would
+    // make the audit trail assert something untrue.
+    expect(JSON.stringify(written)).not.toContain("PrincipalId");
+  });
+});
+
+describe("it refuses anything short of auto-enroll", () => {
+  it("refuses an operator-confirmation verdict", async () => {
+    const { result, confirmWithPeer, recordLocalConfirmation } = run({
+      decision: { mode: "operator-confirmation", explanation: "chain not validated" },
+    });
+    expect(await result).toEqual({ confirmed: false, refusal: "not-auto-enroll" });
+    // It must not even talk to the peer, let alone record a confirmation.
+    expect(confirmWithPeer).not.toHaveBeenCalled();
+    expect(recordLocalConfirmation).not.toHaveBeenCalled();
+  });
+
+  it("refuses a blocked verdict", async () => {
+    const { result } = run({ decision: { mode: "blocked", explanation: "plain HTTP" } });
+    expect(await result).toMatchObject({ confirmed: false, refusal: "not-auto-enroll" });
+  });
+});
+
+describe("every session precondition still holds", () => {
+  it("refuses when the session is missing", async () => {
+    expect(await run({ row: null }).result).toMatchObject({ refusal: "session-not-found" });
+  });
+
+  it("refuses an incoming session", async () => {
+    const { result } = run({ row: session({ direction: "incoming" }) });
+    expect(await result).toMatchObject({ refusal: "session-not-found" });
+  });
+
+  it("refuses a session that is not pending", async () => {
+    const { result } = run({ row: session({ status: "approved" }) });
+    expect(await result).toMatchObject({ refusal: "session-not-pending" });
+  });
+
+  it("refuses an expired session", async () => {
+    const { result } = run({
+      row: session({ expiresAt: new Date("2026-08-26T23:59:00.000Z") }),
+    });
+    expect(await result).toMatchObject({ refusal: "session-expired" });
+  });
+
+  it("leaves the session for a human when the peer refuses", async () => {
+    const { result, recordLocalConfirmation } = run({ peerOk: false });
+    expect(await result).toMatchObject({ refusal: "peer-confirmation-failed" });
+    expect(recordLocalConfirmation).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a session whose sasState is not an object", async () => {
+    const { result, recordLocalConfirmation } = run({ row: session({ sasState: null }) });
+    expect(await result).toMatchObject({ confirmed: true });
+    expect((recordLocalConfirmation.mock.calls[0]?.[0] as ConfirmationWrite).sasState).toMatchObject({
+      confirmationProvenance: "organization-trust",
+    });
+  });
+});

--- a/apps/web/lib/federation/confirm-pairing-from-organization-trust.ts
+++ b/apps/web/lib/federation/confirm-pairing-from-organization-trust.ts
@@ -1,0 +1,119 @@
+// EP-MSP-FEDERATION — confirm a pairing on the strength of organization trust.
+//
+// The SAS code exists to authenticate a peer this installation has no prior
+// relationship with: two people read six digits off two screens and agree they
+// match. That is the right ceremony between strangers.
+//
+// It adds nothing when the organization CA has already authenticated the peer.
+// A validated certificate chain is a stronger statement than a six-digit
+// comparison, and it is the same authority that would have issued the peer its
+// identity in the first place. Requiring both means an installation created and
+// destroyed thousands of times can never pair unattended.
+//
+// This performs the same confirmation the human path performs, and records WHY:
+// no person confirmed it, organization trust did, and here is the evidence. The
+// approving principal stays null, because none exists — writing a person's id
+// there would make the audit trail assert something untrue.
+
+import type { AutomaticPairingDecision } from "@dpf/db/automatic-pairing-decision";
+
+/** Why an organization-trust confirmation was refused. Closed for branching. */
+export const TRUST_CONFIRMATION_REFUSALS = [
+  "not-auto-enroll",
+  "session-not-found",
+  "session-not-pending",
+  "session-expired",
+  "peer-confirmation-failed",
+] as const;
+export type TrustConfirmationRefusal = (typeof TRUST_CONFIRMATION_REFUSALS)[number];
+
+export interface PairingSessionRow {
+  id: string;
+  pairingId: string;
+  direction: string;
+  status: string;
+  expiresAt: Date;
+  sasState: unknown;
+}
+
+export interface TrustConfirmationStore {
+  findSession(pairingId: string): Promise<PairingSessionRow | null>;
+  /**
+   * Record local confirmation. `approvedByPrincipalId` is deliberately absent:
+   * no person confirmed this, and the store must not invent one.
+   */
+  recordLocalConfirmation(input: {
+    id: string;
+    confirmedAt: Date;
+    sasState: Record<string, unknown>;
+  }): Promise<void>;
+}
+
+export type TrustConfirmationResult =
+  | { confirmed: true; provenance: "organization-trust" }
+  | { confirmed: false; refusal: TrustConfirmationRefusal };
+
+/** The evidence that justified skipping the code comparison. */
+export interface TrustConfirmationEvidence {
+  presentedRootFingerprint: string | null;
+  certificateVerified: boolean;
+  peerOrganizationRef: string | null;
+}
+
+function refuse(refusal: TrustConfirmationRefusal): TrustConfirmationResult {
+  return { confirmed: false, refusal };
+}
+
+/**
+ * Confirm a pending outgoing pairing because organization trust proved the peer.
+ *
+ * Refuses on anything short of `auto-enroll`. The verdict is checked by its
+ * exact value rather than by ruling out `blocked`, so an
+ * `operator-confirmation` verdict can never fall through into an automatic
+ * confirmation.
+ *
+ * The peer must still accept the confirmation; a peer that refuses leaves the
+ * session pending for a human, exactly as before.
+ */
+export async function confirmPairingFromOrganizationTrust(input: {
+  pairingId: string;
+  decision: AutomaticPairingDecision;
+  evidence: TrustConfirmationEvidence;
+  store: TrustConfirmationStore;
+  confirmWithPeer: (pairingId: string) => Promise<{ ok: boolean }>;
+  now: Date;
+}): Promise<TrustConfirmationResult> {
+  if (input.decision.mode !== "auto-enroll") return refuse("not-auto-enroll");
+
+  const session = await input.store.findSession(input.pairingId);
+  if (!session || session.direction !== "outgoing") return refuse("session-not-found");
+  if (session.status !== "pending") return refuse("session-not-pending");
+  if (session.expiresAt.getTime() <= input.now.getTime()) return refuse("session-expired");
+
+  const peer = await input.confirmWithPeer(input.pairingId);
+  if (!peer.ok) return refuse("peer-confirmation-failed");
+
+  const priorState =
+    typeof session.sasState === "object" && session.sasState !== null && !Array.isArray(session.sasState)
+      ? (session.sasState as Record<string, unknown>)
+      : {};
+
+  await input.store.recordLocalConfirmation({
+    id: session.id,
+    confirmedAt: input.now,
+    sasState: {
+      ...priorState,
+      // Stated plainly so a reader of this record knows a machine confirmed it,
+      // on what basis, and that no person was involved.
+      confirmationProvenance: "organization-trust",
+      confirmationEvidence: {
+        presentedRootFingerprint: input.evidence.presentedRootFingerprint,
+        certificateVerified: input.evidence.certificateVerified,
+        peerOrganizationRef: input.evidence.peerOrganizationRef,
+        decidedAt: input.now.toISOString(),
+      },
+    },
+  });
+
+  return { confirmed: true, provenance: "organization-trust" };
+}

--- a/docs/superpowers/specs/2026-08-23-zero-touch-organization-federation-design.md
+++ b/docs/superpowers/specs/2026-08-23-zero-touch-organization-federation-design.md
@@ -258,6 +258,38 @@ Either is defensible; inventing one silently is not. Until it is settled, the
 resolved mode and its evidence are computed and recorded, and the code comparison
 still stands.
 
+### 5.9 Confirming on organization trust, and who the record says did it
+
+The SAS code authenticates a peer this installation has no prior relationship
+with: two people read six digits off two screens and agree. That is the right
+ceremony between strangers, and it adds nothing once the organization CA has
+already authenticated the peer — a validated chain is a stronger statement than a
+six-digit comparison, from the same authority that issued the peer its identity.
+
+**Attribution was never an open question.** A federated peer is already
+`Principal(kind="federated-peer")` with `FederationLink` as its side table, per
+AGENTS.md §11 — the same shape `EdgeNode` uses. The peer HAS an identity; the
+link carries it in `principalId`. This is the ordinary mTLS/SPIFFE model, where
+the credential is the identity and the CA authorised it at issuance rather than a
+person authorising each pair.
+
+`approvedByPrincipalId` answers a different question — which PERSON on this side
+clicked approve. For an evidence-derived confirmation the honest answer is that
+none did, and the field stays null. Writing a person there would make the audit
+trail assert something untrue.
+
+What is recorded instead, on the session's `sasState`:
+
+- `confirmationProvenance: "organization-trust"`
+- the evidence — presented root fingerprint, that the chain verified, the peer
+  organization ref, and when it was decided
+
+So the record states plainly that a machine confirmed it, on what basis, and that
+no person was involved. The verdict is checked by its exact `auto-enroll` value
+rather than by ruling out `blocked`, so an `operator-confirmation` verdict can
+never fall through. A peer that refuses the confirmation leaves the session
+pending for a human, exactly as before.
+
 ## 6. Lifecycle at scale
 
 The unattended cycle this enables:


### PR DESCRIPTION
## The question I got wrong first

I spent a while designing an "attribution scheme" for automated enrolment — whether to mint a synthetic principal, add a provenance column, or reuse a non-human identity. That was **fishing**. The answer was already in the schema:

```
// EP-MSP-FEDERATION · B1 — a federated peer (another DPF deployment) is a
// Principal(kind="federated-peer") with FederationLink as its side table,
// exactly as EdgeNode is for an edge agent. No parallel identity table.
```

A peer **already is** a Principal. `FederationLink.principalId` is required and unique. This is the ordinary **mTLS / SPIFFE** model: the credential *is* the identity, and the CA authorised it at issuance rather than a person authorising each pair.

`approvedByPrincipalId` answers a *different* question — which **person on this side** clicked approve. For an evidence-derived confirmation none did, so it stays null. Writing a person's id there would make the audit trail assert something untrue.

## What this adds

The SAS code authenticates a peer with no prior relationship: two people read six digits off two screens and agree. Right between strangers; **it adds nothing once the organization CA has already authenticated the peer.** A validated chain is a stronger statement than a six-digit comparison, from the same authority that would have issued the peer its identity.

`confirmPairingFromOrganizationTrust` performs the same confirmation the human path performs, and records **why** on the session's `sasState`:

- `confirmationProvenance: "organization-trust"`
- the presented root fingerprint, that the chain verified, the peer organization ref, and when it was decided

So the record states plainly that a machine confirmed it, on what basis, and that no person was involved.

## Safety

- The verdict is matched on its **exact** `auto-enroll` value, never by ruling out `blocked` — so an `operator-confirmation` verdict cannot fall through. Tested: an operator-confirmation verdict does not even contact the peer.
- Every session precondition still holds — outgoing, pending, unexpired.
- A peer that refuses the confirmation **leaves the session pending for a human**, exactly as before.
- The entry point remains gated by `assertManagePlatform`; this changes which *ceremony* is required, not who may start one.

## Verification

10 tests covering the confirm path, all four refusal shapes, and that no principal id is written anywhere. Zero typecheck errors in the changed files. All 7 guards pass locally via `ci-policy-guards.mjs --profile pull-request`; design §5.9 records the reasoning.

## Note

`resolveCandidatePairingMode` was wired into the pairing action by #4735 while this was in progress — the verdict is computed there but not yet acted on. This supplies the acting half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)