### PR TITLE
doc(kernel): draft principle — validate an archetype by running its business

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 690,
+  "pageCount": 691,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -4723,6 +4723,20 @@
         "the-formula-is-invariant",
         "only-three-axes-vary",
         "the-review-altitude-check"
+      ]
+    },
+    "docs/founder-kernel/wiki/principles/validate-an-archetype-by-running-its-business.md": {
+      "publicHref": "/founder-kernel/wiki/principles/validate-an-archetype-by-running-its-business/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "applies-to",
+        "why",
+        "how-to-apply",
+        "decision-dimensions",
+        "related"
       ]
     },
     "docs/founder-kernel/wiki/principles/verify-substrate-before-proposing-new.md": {

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -11,5 +11,5 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 | Prisma models | 611 | `packages/db/prisma/schema/` |
 | Prisma enums | 71 | `packages/db/prisma/schema/` |
 | Migrations | 554 | `packages/db/prisma/migrations/` |
-| Kernel principles | 97 | `docs/founder-kernel/wiki/principles/` |
+| Kernel principles | 98 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 634 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/founder-kernel/wiki/principles/validate-an-archetype-by-running-its-business.md
+++ b/docs/founder-kernel/wiki/principles/validate-an-archetype-by-running-its-business.md
@@ -6,7 +6,7 @@ status: draft
 abstract: An archetype is validated by attempting a real operating day in the product with populated data, not by reading its schema or reviewing its screens. Feature audits on empty surfaces produce confident wrong answers.
 principleTier: principle
 principleDirection: Prefer evidence from attempting the operator's actual day with real records over evidence from schema reads, empty-surface review, or completed onboarding.
-principleDimensionVector: {"evidence_density": 1.0, "customer_value": 0.8, "long_term_maintainability": 0.4, "speed_to_value": -0.3, "blast_radius": -0.4}
+principleDimensionVector: {"evidence_density": 1.0, "product_fit": 0.8, "long_term_maintainability": 0.4, "speed_to_value": -0.3, "blast_radius": -0.4}
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
@@ -95,8 +95,9 @@ business from one that renders a business.
 
 - `evidence_density: 1.0` — the strongest pull. The principle is entirely about attempted work as
   evidence over inspected structure as evidence.
-- `customer_value: 0.8` — an archetype is a promise to an operator that they can run their
-  business. Only running it tests the promise.
+- `product_fit: 0.8` — an archetype is a promise to an operator that the product fits how their
+  business actually works. Only attempting the work tests that promise; surface review tests
+  whether the product resembles the business, which is a different and weaker claim.
 - `long_term_maintainability: 0.4` — findings from a real day are concrete and reproducible;
   findings from a schema read tend to be restated each cycle.
 - `speed_to_value: -0.3` — a modest concession. Running a day is slower than reading a schema.

--- a/docs/founder-kernel/wiki/principles/validate-an-archetype-by-running-its-business.md
+++ b/docs/founder-kernel/wiki/principles/validate-an-archetype-by-running-its-business.md
@@ -1,0 +1,112 @@
+---
+title: Validate an archetype by running its business, not by auditing its surfaces
+slug: validate-an-archetype-by-running-its-business
+pageKind: principle
+status: draft
+abstract: An archetype is validated by attempting a real operating day in the product with populated data, not by reading its schema or reviewing its screens. Feature audits on empty surfaces produce confident wrong answers.
+principleTier: principle
+principleDirection: Prefer evidence from attempting the operator's actual day with real records over evidence from schema reads, empty-surface review, or completed onboarding.
+principleDimensionVector: {"evidence_density": 1.0, "customer_value": 0.8, "long_term_maintainability": 0.4, "speed_to_value": -0.3, "blast_radius": -0.4}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleRingScope:
+  - ring-2-workflow
+  - ring-4-sandbox-prod
+principleConsumerArchetype: universal
+principleConsumerContexts:
+  - engineering-flow
+  - build-studio
+principlePublic: false
+principlePublicRationale: ""
+---
+
+## Rule
+
+To find out whether an archetype works, attempt the operator's day in the product: create the
+records, run the steps in order, and record where you get stuck. Do not substitute a schema read,
+a screen review, or a completed onboarding for that attempt.
+
+Two failure modes this rule exists to prevent:
+
+- **Assessing empty surfaces.** A surface with no data renders an empty state, and an empty state
+  hides every defect that only appears once records exist.
+- **Drifting from the business into the platform.** When a step fails, the pull is to open the
+  schema and explain why. That converts a business test into a platform investigation and the day
+  never gets run.
+
+## Applies To
+
+Anyone validating an archetype, vertical, or customer-facing capability — in-platform coworkers,
+external coding agents, and humans. It applies to a dogfooding cycle, an acceptance pass, and any
+claim that an archetype is "supported".
+
+## Why
+
+DPF's archetypes fail quietly in the direction of looking finished. The storefront carries
+archetype-appropriate vocabulary, onboarding completes, and the UX rubric passes — while the
+business underneath cannot run for a single day.
+
+A worked case: the `pet-rescue` archetype completed onboarding 11/11, published a correct public
+storefront (Donate rather than Buy, Adopt as Free/Enquire), and passed a UX review. Its
+operating-model coverage was **0.05**. It had no intake, no housing, no care round, no medical
+record, and no outcome vocabulary. Every check that ran passed.
+
+Three specific errors traceable to not running the business:
+
+1. **The operating day was written from the platform.** Reading the product first anchors the
+   noun list to what the product already does, which is the precise bias the audit exists to
+   defeat. It yielded 18 nouns; the domain has 30. The archetype scored 0.28 instead of 0.05 —
+   not a measurement error, a scope error, and it made a near-empty archetype look a third done.
+2. **The public storefront was recorded as a positive** on an instance with zero animals. Adding
+   three exposed that the listing is a dead end: no per-animal URL, no per-animal inquiry, and
+   no filtering. For a rescue that is the entire acquisition funnel, and it was invisible while
+   the surface was empty.
+3. **The consumer surface was inferred rather than researched.** The adoption listing standard —
+   the field set adopters filter on, and the 40+ syndication destinations rescues actually depend
+   on — was assumed for two cycles until it was looked up, which changed the requirements
+   materially.
+
+The generalisation: **completed onboarding is not operational validation, and a passing surface
+review is not either.** Only the attempt to work a day distinguishes an archetype that runs a
+business from one that renders a business.
+
+## How To Apply
+
+1. **Write the operating day before touching the platform.** An ordinary day, a bad day, and one
+   periodic cycle, from domain research. If the product has already been opened, the day is
+   contaminated — write it in a separate session or from a source outside the product.
+2. **Research the consumer-facing surface rather than inferring it.** Find out what the
+   equivalent real-world artifact contains and what the established interchange format is. Do not
+   derive it from what the product happens to render.
+3. **Populate before judging.** At minimum: several subject records, one transaction, one status
+   change. Follow each to every surface that should reflect it.
+4. **Attempt each step in order, in the product, as the role that does it** — including at the
+   device width that role actually uses.
+5. **When a step fails, record what a real operator would do instead** — paper, a spreadsheet,
+   a phone call, abandoning the task — and move to the next step. Do not stop to diagnose. A
+   platform blocker is a backlog item, not a detour.
+6. **Check defaults on create and every destructive control.** What state does a new record land
+   in, and who can see it? Does delete confirm? These are invisible on an empty instance.
+7. **End with one judgement:** could this business have operated today, and on what?
+
+## Decision Dimensions
+
+- `evidence_density: 1.0` — the strongest pull. The principle is entirely about attempted work as
+  evidence over inspected structure as evidence.
+- `customer_value: 0.8` — an archetype is a promise to an operator that they can run their
+  business. Only running it tests the promise.
+- `long_term_maintainability: 0.4` — findings from a real day are concrete and reproducible;
+  findings from a schema read tend to be restated each cycle.
+- `speed_to_value: -0.3` — a modest concession. Running a day is slower than reading a schema.
+  The principle accepts that because the alternative is confident wrong answers.
+- `blast_radius: -0.4` — an archetype declared supported on surface evidence radiates the error
+  into external material, roadmaps, and adopter expectations.
+
+## Related
+
+- [Test in the portal build, not just in unit tests](./test-in-the-portal-build.md) — the same
+  argument one layer down: real execution over inferred correctness.
+- [Structural verification is not functional verification](./structural-verification-is-not-functional.md)
+- `docs/architecture/archetype-operating-model-audit.md` — the method this principle governs.


### PR DESCRIPTION
Routes a founder verdict to the commons rather than leaving it in one client's private memory, where Grok and Codex cannot read it. Status is **draft** — kernel pages are ratified on merge, so this is submitted for review rather than asserted.

Companion to the design in **BI-DE1333A1**, which explains why this had to be routed here at all.

## The verdict

A thread testing the `pet-rescue` archetype failed because **it never ran the business**. It read schemas, reviewed screens, and drifted into platform-internal work, while the archetype it declared assessed could not operate for a single day.

## The rule

Attempt the operator's day in the product with real records. Do not substitute a schema read, a screen review, or a completed onboarding for that attempt.

Two failure modes it exists to prevent:

- **Assessing empty surfaces** — an empty state hides every defect that only appears once records exist.
- **Drifting from the business into the platform** — when a step fails, the pull is to open the schema and explain why, which converts a business test into a platform investigation and the day never gets run.

## Grounded in three traceable errors

1. **The operating day was written from the platform**, so it scored the 18 nouns the product made visible rather than the domain's 30. The archetype scored **0.28 instead of 0.05** — a scope error, not a measurement error, and it made a near-empty archetype look a third done.
2. **The public storefront was recorded as a positive** on an instance with **zero animals**. Adding three exposed that the listing is a dead end — no per-animal URL, no per-animal inquiry, no filtering. For a rescue that is the entire acquisition funnel, and it was invisible while the surface was empty.
3. **The consumer surface was inferred rather than researched** for two cycles. Looking it up changed the requirements materially.

The generalisation: completed onboarding is not operational validation, and a passing surface review is not either. `pet-rescue` completed onboarding 11/11, published a correct storefront, and passed a UX review at **0.05** operating-model coverage. Every check that ran passed.

## Relationship to existing doctrine

Complements [test-in-the-portal-build](docs/founder-kernel/wiki/principles/test-in-the-portal-build.md), which makes the same argument one layer down — real execution over inferred correctness — and [structural-verification-is-not-functional](docs/founder-kernel/wiki/principles/structural-verification-is-not-functional.md).

Governs the method in `docs/architecture/archetype-operating-model-audit.md`.

## Verification

- `node scripts/check-doc-links.mjs` — PASS, no error-level findings
- pre-commit golden-decisions baseline: **2 canonical decisions scored against 45 commandments, both hold** — this principle does not perturb the existing decision baseline
- `pnpm run pregate` — passed: *"documentation evidence passed without heavyweight admission"*
- doc index and architecture counts regenerated and staged by pre-commit; gitleaks clean

Docs only — no code, schema or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Seed-Fit-Decision: global-default

Rationale: this is a kernel principle governing how any agent validates any archetype on any install. It is not archetype-scoped (pet-rescue is the worked evidence, not the scope), not vertical-scoped, and not install-local. There is no parameter to extract — the rule is the same everywhere. It seeds as a global default alongside the other kernel principles.
