### PR TITLE
fix(docker): copy the hooks-dir lib the postinstall imports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,12 @@ CMD ["/usr/local/bin/dev-portal-entrypoint.sh"]
 FROM base AS deps
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY patches/ ./patches/
+# set-hooks-path runs as the root postinstall during `pnpm install` below, and
+# it imports resolveHooksDir from scripts/lib/hooks-dir.mjs (BI-5CBDC146). The
+# lib must land with it or the postinstall throws ERR_MODULE_NOT_FOUND and the
+# whole image build fails.
 COPY scripts/set-hooks-path.mjs ./scripts/
+COPY scripts/lib/hooks-dir.mjs ./scripts/lib/
 COPY apps/web/package.json ./apps/web/
 COPY packages/db/package.json ./packages/db/
 COPY packages/db/prisma/schema ./packages/db/prisma/schema
@@ -56,6 +61,7 @@ FROM deps AS build
 # Copy source EXCLUDING pnpm-lock.yaml (preserve the deps stage lockfile which has no expo entries)
 COPY pnpm-workspace.yaml tsconfig.base.json .gitignore ./
 COPY scripts/set-hooks-path.mjs ./scripts/
+COPY scripts/lib/hooks-dir.mjs ./scripts/lib/
 COPY scripts/capability-service-catalog.generated.json ./scripts/
 COPY scripts/lib/capability-service-projection.mjs ./scripts/lib/
 COPY scripts/lib/capability-state-hash.mjs ./scripts/lib/


### PR DESCRIPTION
## Image publishing is broken on main

Every `Publish Docker Images` run fails, so **no release artifact can be produced and no installation can self-upgrade**.

```
#31 14.26 . postinstall$ node scripts/set-hooks-path.mjs
#31 14.29 Error [ERR_MODULE_NOT_FOUND]: Cannot find module
          '/app/scripts/lib/hooks-dir.mjs'
          imported from /app/scripts/set-hooks-path.mjs
ERROR: process "/bin/sh -c pnpm install --frozen-lockfile" did not complete
       successfully: exit code: 1
```

The BI-5CBDC146 repair extracted `resolveHooksDir` into `scripts/lib/hooks-dir.mjs` so the Windows and POSIX paths could converge. The Dockerfile copies `set-hooks-path.mjs` into both the **deps** and **build** stages but was never taught about the new lib, so the root postinstall throws before `pnpm install` finishes.

The script *means* to be fail-safe — its own comment says "never break install", and its `git config` call is already wrapped in try/catch for exactly this reason. **A top-level import cannot be caught that way**, so the guarantee it documents was silently lost the moment the helper moved to its own module.

## Change

Copies the lib alongside the script in both stages.

## Verification

`docker build --target deps` completes locally (**exit 0**) on the exact stage that was failing. Pre-push guard preflight clean (52 guards).

## Follow-up worth filing

A developer-convenience postinstall should not be able to fail an image build at all, and nothing currently stops the next extracted helper from reintroducing this. That is a guard, not a COPY, so it is out of scope here.

Refs: BI-5CBDC146