### PR TITLE
fix(docker): copy the postinstall's static dependency into the build context (BI-6A4FF5E7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ FROM base AS deps
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY patches/ ./patches/
 COPY scripts/set-hooks-path.mjs ./scripts/
+# The postinstall entry statically imports this leaf module, so `pnpm install`
+# below cannot run without it in the build context (BI-6A4FF5E7).
+COPY scripts/lib/hooks-dir.mjs ./scripts/lib/
 COPY apps/web/package.json ./apps/web/
 COPY packages/db/package.json ./packages/db/
 COPY packages/db/prisma/schema ./packages/db/prisma/schema
@@ -56,6 +59,9 @@ FROM deps AS build
 # Copy source EXCLUDING pnpm-lock.yaml (preserve the deps stage lockfile which has no expo entries)
 COPY pnpm-workspace.yaml tsconfig.base.json .gitignore ./
 COPY scripts/set-hooks-path.mjs ./scripts/
+# The postinstall entry statically imports this leaf module, so `pnpm install`
+# below cannot run without it in the build context (BI-6A4FF5E7).
+COPY scripts/lib/hooks-dir.mjs ./scripts/lib/
 COPY scripts/capability-service-catalog.generated.json ./scripts/
 COPY scripts/lib/capability-service-projection.mjs ./scripts/lib/
 COPY scripts/lib/capability-state-hash.mjs ./scripts/lib/
@@ -94,6 +100,9 @@ COPY docker-compose.yml docker-compose.release.yml docker-compose.pki.yml docker
 COPY uninstall-dpf.sh uninstall-dpf.ps1 uninstall-dpf.bat ./
 COPY scripts/pki/edge-client.tpl ./scripts/pki/
 COPY scripts/set-hooks-path.mjs ./scripts/
+# The postinstall entry statically imports this leaf module, so `pnpm install`
+# below cannot run without it in the build context (BI-6A4FF5E7).
+COPY scripts/lib/hooks-dir.mjs ./scripts/lib/
 COPY scripts/lib/resolve-capability-compose-profiles.mjs ./scripts/lib/
 COPY scripts/lib/govern-capability-compose-args.mjs ./scripts/lib/
 COPY scripts/lib/capability-state-hash.mjs ./scripts/lib/


### PR DESCRIPTION
## Every image build is currently broken on `main`

`pnpm install --frozen-lockfile` fails in the Docker `deps` stage, so image builds and local-CI bounded builds die before running anything:

```
. postinstall$ node scripts/set-hooks-path.mjs
. postinstall: Error [ERR_MODULE_NOT_FOUND]: Cannot find module
    '/app/scripts/lib/hooks-dir.mjs' imported from /app/scripts/set-hooks-path.mjs
ERROR: process "/bin/sh -c pnpm install --frozen-lockfile" did not complete successfully: exit code: 1
```

`postinstall` is `node scripts/set-hooks-path.mjs`, so it runs on every install including inside the image. That script now carries a **static** top-level `import { resolveHooksDir } from './lib/hooks-dir.mjs'`. Three stages copy the entry script and then install — `deps` (25→52), `build` (58→78), `init` (96→188) — and none copied its dependency.

A static import cannot be skipped. The sibling `await import('./lib/ensure-pre-push-hook.mjs')` calls further down are conditional: they warn and continue, and git hooks are meaningless inside an image, so those stay deliberately uncopied.

## Fix

`scripts/lib/hooks-dir.mjs` imports only `node:url`, so one `COPY` per stage closes it. The Dockerfile already documents this exact hazard at the deps stage — the dependency was simply missed when the import was introduced.

## Verification

Built the stage that was failing:

```
docker build --target deps   →   DONE 68.5s
  postinstall: Done
  packages/db postinstall: ✔ Generated Prisma Client (7.9.1)
```

The two remaining `could not converge .githooks/…` lines are the conditional hook installers described above — warned and non-fatal, which is the intended behaviour in an image.

## Why this escaped CI

No PR check builds images, and `Production Build` builds the Next.js app rather than the Docker image. The first thing exercising the deps stage is the local-CI bounded build, which runs behind the single `local-integration-ci` lease — so it only surfaces after waiting for that slot.

## Disclosure: pushed with a recorded `install-bootstrap-recovery` override

Local-CI evidence is produced **by** the Docker build this PR repairs. On current `main` that build cannot start, so requiring a passing local-CI run to land its own fix is circular. The override is recorded rather than silent, the guard-parity preflight ran clean (52 guards, 112.6s), and functional proof is the successful `--target deps` build above. CI gates the merge regardless.

Blocks BI-5779E8CE (and every other branch needing pregate evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
