### PR TITLE
fix(db): typecheck must regenerate the Prisma client before it judges (BI-5B5FEF08)

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -95,7 +95,7 @@
     "studio": "prisma studio",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "typecheck": "tsc --noEmit && tsc -p tsconfig.scripts.json --noEmit"
+    "typecheck": "prisma generate && tsc --noEmit && tsc -p tsconfig.scripts.json --noEmit"
   },
   "dependencies": {
     "@dpf/storefront-templates": "workspace:*",

--- a/scripts/check-no-nanoid-import.mjs
+++ b/scripts/check-no-nanoid-import.mjs
@@ -72,7 +72,19 @@ function* walk(dir) {
   }
   for (const entry of entries) {
     const full = join(dir, entry);
-    const s = statSync(full);
+    // An entry can vanish between readdirSync and statSync — a generator writing
+    // into a scan root (prisma generate under packages/db/generated) is enough.
+    // readdirSync and readFileSync in this file are already defensive; statSync
+    // was not, so a vanished entry threw and killed the guard. The guard loop
+    // then reported "found violations" with NO violation block printed, which is
+    // indistinguishable from a real violation — a crash must never be able to
+    // masquerade as a finding.
+    let s;
+    try {
+      s = statSync(full);
+    } catch {
+      continue;
+    }
     if (s.isDirectory()) {
       if (
         entry === "node_modules" ||


### PR DESCRIPTION
## The defect

`packages/db`'s typecheck was bare `tsc`, so it judged the tree against whatever generated Prisma client happened to be on disk. With that client stale or absent it reports **121 errors in files nobody touched**:

```
src/client.ts(1,30): error TS2307: Cannot find module '../generated/client/client'
src/coworker-service-catalog-seed.ts(483,21): error TS7006: Parameter 'portfolio' implicitly has an 'any' type
```

The `TS7006` implicit-any cascade is the dangerous half — it never mentions Prisma, so it reads as a genuine type defect in unrelated application code.

## Why it is worth fixing

**It manufactures false reds that get acted on.** In the session that found this I concluded — and reported twice — that `main` was red on typecheck in `apps/web/lib/federation/demand-read-model.ts`, and carried that as a known-broken item for hours. It was never true: CI on `main` is green on every recent run, and that file has not changed since #4116. The whole thing was a stale generated client in one worktree.

That is a **plausible wrong answer** — indistinguishable from a real one without going and checking the source. CI never sees it, because install and build regenerate the client; it lands only on contributors and external agents, who have the least context to dismiss it.

## The fix follows an existing precedent

`apps/web` already does exactly this, for exactly this reason:

```
"typecheck": "next typegen && node ../../scripts/run-tsc.mjs --noEmit"
```

Typechecking against stale generated types is meaningless, so web regenerates first. The db package skipped the equivalent step, and no `prepare`/`postinstall` filled the gap.

Verified: with `packages/db/generated/client` deleted, the old script reports 121 errors; the new one regenerates and exits 0. ~11s on a run that already takes minutes.

## Second change: a crashed guard must not read as a violation

An early gate run on this branch failed `check-no-nanoid-import.mjs` with `"1/37 guard(s) FAILED (found violations)"` and **no violation block printed** — and that guard prints a loud `ERROR:` block whenever it finds one. It had crashed, not found anything.

`walk()` wrapped `readdirSync` and `readFileSync` defensively but left `statSync` bare. The typecheck change makes that race likelier, because typecheck now runs `prisma generate`, which writes and removes temp files under `packages/db/generated` — inside a scan root. `statSync` is now guarded like its neighbours.

## No test for the guard fix, deliberately

Reproducing the race needs an entry `readdirSync` lists and `statSync` rejects. A dangling symlink is the clean way; symlink creation returns `EPERM` without elevation on this platform.

A first attempt **passed with the fix reverted** — vacuous, because `scanRepo()` only walks its `SCAN_ROOTS` and the fixture sat outside them. It was removed rather than shipped. A vacuous test is worse than no test: it reports safety that does not exist.

## Scope note

This PR originally also carried a Dockerfile fix for a missing `scripts/lib/hooks-dir.mjs` COPY that was breaking every image build. **PR #4747 landed the identical fix in parallel**, so that commit was verified redundant against `origin/main` and dropped on rebase. BI-78F52CFD is retired as a duplicate.

## Verification

- Local-CI gate **PASS** at the pushed SHA, no override code stretched.
- All 37 guards pass; `@dpf/db` and `web` typecheck 0 errors.