### PR TITLE
fix: converge the pre-push gate at session start, not only at install

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -100,6 +100,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/scripts/hooks/converge-git-hooks.mjs\"",
+            "async": false
+          },
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PROJECT_DIR}/scripts/hooks/run-hook.mjs\" hooks/worktree-freshness",
             "async": false
           },

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1702,6 +1702,9 @@
       "docs/testing/archetype-exercise-harness.md",
       "docs/testing/archetype-exercise-playbook.md"
     ],
+    "scripts/hooks/converge-git-hooks.mjs": [
+      "docs/testing/pre-pr-gate.md"
+    ],
     "scripts/hooks/run-hook.mjs": [
       "docs/install/platform-support-watchlist.md",
       "docs/operations/session-transcript-recovery.md"
@@ -1737,14 +1740,14 @@
     "scripts/lib/compose-safety.mjs": [
       "docs/architecture/delivery-surfaces-runbook.md"
     ],
+    "scripts/lib/converge-hooks-dir.mjs": [
+      "docs/testing/pre-pr-gate.md"
+    ],
     "scripts/lib/dco-signoff.mjs": [
       "docs/architecture/build-gate-runbook.md"
     ],
     "scripts/lib/dockerfile-portal-build.test.mjs": [
       "docs/install/platform-support-watchlist.md"
-    ],
-    "scripts/lib/ensure-pre-push-hook.mjs": [
-      "docs/testing/pre-pr-gate.md"
     ],
     "scripts/lib/entry-module.mjs": [
       "docs/install/platform-support-watchlist.md"
@@ -2973,8 +2976,9 @@
       "scripts/ci-policy-guards.test.mjs",
       "scripts/gate-worktree.mjs",
       "scripts/gate-worktree.sh",
+      "scripts/hooks/converge-git-hooks.mjs",
       "scripts/lib/ci-policy-guards.mjs",
-      "scripts/lib/ensure-pre-push-hook.mjs",
+      "scripts/lib/converge-hooks-dir.mjs",
       "scripts/lib/hooks-dir.mjs",
       "scripts/lib/local-integration-ci.mjs",
       "scripts/local-ci-runner.mjs",

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -625,10 +625,15 @@ and summary remain the default diagnostic surface.
 gitignored (git-lfs generates it), so the enforced logic ships as the tracked
 [`.githooks/lib/pre-push-chained.sh`](../../.githooks/lib/pre-push-chained.sh)
 — Git LFS first, then [`.githooks/pre-push-gate`](../../.githooks/pre-push-gate)
-— and `postinstall` (`scripts/set-hooks-path.mjs` →
-`scripts/lib/ensure-pre-push-hook.mjs`) converges the local shim to delegate to
-it (a hand-rolled custom hook is never clobbered; the install prints a warning
-instead). The gate refuses a push when the latest local-CI gate record is
+— and convergence rewrites the local shim to delegate to it. Convergence runs
+in two places, both through the same sequencer
+([`scripts/lib/converge-hooks-dir.mjs`](../../scripts/lib/converge-hooks-dir.mjs)):
+`postinstall` (`scripts/set-hooks-path.mjs`) and **every session start**
+([`scripts/hooks/converge-git-hooks.mjs`](../../scripts/hooks/converge-git-hooks.mjs)),
+which also sweeps sibling worktrees. A hand-rolled custom hook is never
+clobbered — convergence reports it and leaves it alone — and a tree missing
+`.githooks/lib/pre-push-chained.sh` is skipped rather than given a shim that
+would exec a missing script and fail every push. The gate refuses a push when the latest local-CI gate record is
 missing, belongs to a different branch/SHA, has `gatePassed=false`, has no
 `expiresAt`, or is past `expiresAt`. Not everything needs a record: docs-only
 diffs vs the configured comparison base, delete/tag-only pushes, detached HEAD,
@@ -651,8 +656,26 @@ was dead by the same path. Resolution now goes through `fileURLToPath`
 convergence that cannot complete prints a warning naming the consequence rather
 than failing silently. If `postinstall` reports `could not converge
 .githooks/pre-push`, the gate is not protecting your pushes — repair it before
-relying on a green push. Verify with `head -4 .githooks/pre-push`: it must
-delegate to `.githooks/lib/pre-push-chained.sh`.
+relying on a green push.
+
+**Verify by sweeping, never by spot-checking (BI-3727106F).** `head -4
+.githooks/pre-push` answers for one tree, and one tree is not the estate: when
+this was measured on 2026-08-26, **68 of 85 worktrees** on a single install
+carried the stock shim and pushed with no gate. Two things made that possible.
+Convergence ran only at `pnpm install`, so any tree not reinstalled since a fix
+kept the dead shim; and it ran the tree's *own* copy of the converger, so a tree
+sitting on a base that predated the fix could never repair itself — the fix
+reached only trees that already had it. Session-start convergence closes both:
+the session that just started is by construction running current code, and it
+repairs its siblings. To check the whole estate at once:
+
+```bash
+for wt in $(git worktree list --porcelain | awk '/^worktree /{print substr($0,10)}'); do grep -q pre-push-chained.sh "$wt/.githooks/pre-push" 2>/dev/null || echo "UNGATED $wt"; done
+```
+
+Treat an ungated tree as a gate that has not run, not as a gate that passed: a
+clean push from an ungated tree is byte-identical to a clean push from a gated
+one, which is why the outage stayed invisible for a week.
 
 The bypass is **recorded, never silent** — the reason is persisted into the
 gate state file and surfaced by `pnpm pr:health` at PR time:

--- a/scripts/hooks/converge-git-hooks.mjs
+++ b/scripts/hooks/converge-git-hooks.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// scripts/hooks/converge-git-hooks.mjs
+//
+// SessionStart hook (BI-3727106F): make the local-CI pre-push gate self-healing.
+//
+// THE DEFECT THIS CLOSES
+//   `.githooks/pre-push` is untracked and generated; the enforcing logic is the
+//   tracked `.githooks/lib/pre-push-chained.sh`. Convergence between them ran
+//   ONLY in `pnpm install` postinstall. So:
+//     - a worktree created before a fix, or never reinstalled since, keeps the
+//       stock git-lfs shim and pushes with NO gate; and
+//     - worse, it runs its OWN copy of the converger, so a tree sitting on a
+//       base that predates the fix can never repair itself. The fix only
+//       reaches trees that already contain the fix.
+//   Measured on this install 2026-08-26: 68 of 85 worktrees were ungated, and
+//   a clean push from an ungated tree is byte-identical to a clean push from a
+//   gated one. Absence of enforcement looked exactly like satisfied enforcement.
+//
+// THE SHAPE OF THE FIX
+//   Converge at SESSION START, not install time, and sweep SIBLING worktrees
+//   from the tree that is running — because the session that just started is,
+//   by construction, running current code. A merged fix then reaches every tree
+//   by being merged, instead of by every developer remembering to reinstall.
+//
+// SAFETY
+//   - Only ever writes a shim classified `missing` or `lfs-stock`; a
+//     hand-rolled hook is reported and left alone (ensure-pre-push-hook.mjs).
+//   - Refuses to converge a tree lacking the chained script, which would turn
+//     "not gated" into "cannot push" (convergeHooksDir -> `chain-absent`).
+//   - Sibling sweep is throttled via a marker in the shared git dir, so N
+//     concurrent sessions do one sweep, not N.
+//   - NEVER blocks session start: every path exits 0, and the whole body is
+//     wrapped. A hook that breaks startup is a worse defect than the one it fixes.
+//   - Set DPF_SKIP_HOOK_CONVERGENCE=1 to opt out entirely.
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { convergeHooksDir, summarizeConvergence } from "../lib/converge-hooks-dir.mjs";
+
+/** One sweep per repo per interval, however many sessions start. */
+export const SWEEP_THROTTLE_MS = 30 * 60 * 1000;
+const MARKER_NAME = "dpf-hook-sweep.stamp";
+const GIT_TIMEOUT_MS = 10_000;
+
+// ── pure helpers (unit-tested) ───────────────────────────────────────────────
+
+/**
+ * Extract worktree paths from `git worktree list --porcelain`.
+ * @param {string} porcelain
+ * @returns {string[]}
+ */
+export function parseWorktreePaths(porcelain) {
+  return String(porcelain ?? "")
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("worktree "))
+    .map((line) => line.slice("worktree ".length).trim())
+    .filter(Boolean);
+}
+
+/**
+ * Has the throttle window elapsed? An unreadable/absent marker means "never
+ * swept" — fail toward sweeping, since the cost of an extra sweep is a few
+ * file stats and the cost of skipping one is an ungated push.
+ * @param {number | null} markerMs epoch ms of the last sweep, or null
+ * @param {number} nowMs
+ * @param {number} [throttleMs]
+ */
+export function shouldSweep(markerMs, nowMs, throttleMs = SWEEP_THROTTLE_MS) {
+  if (markerMs == null || !Number.isFinite(markerMs)) return true;
+  return nowMs - markerMs >= throttleMs;
+}
+
+// ── git helpers ──────────────────────────────────────────────────────────────
+
+function git(cwd, args) {
+  try {
+    return execFileSync("git", ["-C", cwd, ...args], {
+      encoding: "utf8",
+      timeout: GIT_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function readMarkerMs(markerPath) {
+  try {
+    return fs.statSync(markerPath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function touchMarker(markerPath) {
+  try {
+    fs.writeFileSync(markerPath, new Date().toISOString(), "utf8");
+  } catch {
+    /* throttling is best-effort; an unwritable marker just means we sweep again */
+  }
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+export function run({ cwd = process.cwd(), now = Date.now(), log = console.log } = {}) {
+  if (process.env.DPF_SKIP_HOOK_CONVERGENCE === "1") return { skipped: "opt-out" };
+
+  const topLevel = git(cwd, ["rev-parse", "--show-toplevel"]);
+  if (!topLevel) return { skipped: "not-a-git-repo" };
+
+  // core.hooksPath is repo-level config; re-assert it cheaply. Without it git
+  // reads .git/hooks and every tracked hook in .githooks is inert.
+  git(cwd, ["config", "core.hooksPath", ".githooks"]);
+
+  // 1. Always converge the tree this session is actually working in.
+  const own = convergeHooksDir(path.join(topLevel, ".githooks"));
+  const results = [own];
+
+  // 2. Sweep siblings, throttled across concurrent sessions.
+  const commonDir = git(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+  const markerPath = commonDir ? path.join(commonDir, MARKER_NAME) : null;
+  let swept = false;
+  if (markerPath && shouldSweep(readMarkerMs(markerPath), now)) {
+    const porcelain = git(cwd, ["worktree", "list", "--porcelain"]);
+    if (porcelain) {
+      swept = true;
+      touchMarker(markerPath);
+      for (const tree of parseWorktreePaths(porcelain)) {
+        if (path.resolve(tree) === path.resolve(topLevel)) continue;
+        results.push(convergeHooksDir(path.join(tree, ".githooks")));
+      }
+    }
+  }
+
+  // 3. Report only when there is something a human should know. A repair, a
+  //    refusal or a failure is news; "already converged" is not.
+  const newsworthy = results.some(
+    (r) => r.prePush === "written" || r.prePush === "chain-absent" || r.prePush === "error" || r.error,
+  );
+  if (newsworthy) log(`[dpf-hooks] ${summarizeConvergence(results)}`);
+  else if (own.prePush === "left-custom") log("[dpf-hooks] custom pre-push hook left untouched; local-CI gate is NOT chained here");
+
+  return { results, swept, reported: newsworthy };
+}
+
+// fileURLToPath, never `new URL(...).pathname` — that is BI-5CBDC146 itself:
+// on Windows the pathname is "/D:/repo/..." and every path built from it is
+// unopenable. Re-deriving it by hand here would rebuild the defect this file exists to fix.
+const invokedDirectly =
+  Boolean(process.argv[1]) && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (invokedDirectly) {
+  try {
+    run();
+  } catch (err) {
+    // Session start must never fail because a convergence hook threw.
+    console.warn(`[dpf-hooks] convergence skipped: ${err?.message ?? err}`);
+  }
+  process.exit(0);
+}

--- a/scripts/hooks/converge-git-hooks.test.mjs
+++ b/scripts/hooks/converge-git-hooks.test.mjs
@@ -1,0 +1,162 @@
+// scripts/hooks/converge-git-hooks.test.mjs
+//
+// BI-3727106F — the pre-push gate must converge at session start, sweep sibling
+// worktrees, and refuse to converge a tree that would be BROKEN by the shim.
+//
+// Measured before this landed: 68 of 85 worktrees on the dev install carried the
+// stock git-lfs shim and pushed with no gate, because convergence ran only in
+// `pnpm install` postinstall AND ran the tree's own (possibly stale) copy.
+//
+// Run: node --test scripts/hooks/converge-git-hooks.test.mjs
+
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  canConverge,
+  convergeHooksDir,
+  summarizeConvergence,
+} from "../lib/converge-hooks-dir.mjs";
+import { parseWorktreePaths, shouldSweep, SWEEP_THROTTLE_MS } from "./converge-git-hooks.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const STOCK_LFS_SHIM = `#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path."; exit 2; }
+git lfs pre-push "$@"
+`;
+
+/** @param {{ withChain?: boolean, prePush?: string | null }} opts */
+function makeHooksDir(opts = {}) {
+  const { withChain = true, prePush = null } = opts;
+  const root = mkdtempSync(join(tmpdir(), "dpf-hooks-"));
+  const hooksDir = join(root, ".githooks");
+  mkdirSync(join(hooksDir, "lib"), { recursive: true });
+  if (withChain) writeFileSync(join(hooksDir, "lib", "pre-push-chained.sh"), "#!/bin/sh\nexit 0\n");
+  if (withChain) writeFileSync(join(hooksDir, "lib", "post-checkout-chained.sh"), "#!/bin/sh\nexit 0\n");
+  if (prePush != null) writeFileSync(join(hooksDir, "pre-push"), prePush);
+  return { root, hooksDir };
+}
+
+// ── the safety property that matters most ────────────────────────────────────
+
+test("refuses to converge a tree lacking the chained script (would break push, not merely leave it ungated)", () => {
+  const { root, hooksDir } = makeHooksDir({ withChain: false, prePush: STOCK_LFS_SHIM });
+  try {
+    assert.equal(canConverge(hooksDir), false);
+    const result = convergeHooksDir(hooksDir);
+    assert.equal(result.prePush, "chain-absent");
+    // The stock shim must survive untouched: a shim that execs a missing
+    // script fails every push, which is strictly worse than not gating.
+    assert.equal(readFileSync(join(hooksDir, "pre-push"), "utf8"), STOCK_LFS_SHIM);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("replaces the stock git-lfs shim with the delegating shim", () => {
+  const { root, hooksDir } = makeHooksDir({ prePush: STOCK_LFS_SHIM });
+  try {
+    const result = convergeHooksDir(hooksDir);
+    assert.equal(result.prePush, "written");
+    assert.match(readFileSync(join(hooksDir, "pre-push"), "utf8"), /pre-push-chained\.sh/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("writes a shim when none exists, and is idempotent on a second run", () => {
+  const { root, hooksDir } = makeHooksDir({ prePush: null });
+  try {
+    assert.equal(convergeHooksDir(hooksDir).prePush, "written");
+    assert.equal(convergeHooksDir(hooksDir).prePush, "unchanged");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("never clobbers a hand-rolled hook", () => {
+  const custom = "#!/bin/sh\n# my own hook\nexit 0\n";
+  const { root, hooksDir } = makeHooksDir({ prePush: custom });
+  try {
+    assert.equal(convergeHooksDir(hooksDir).prePush, "left-custom");
+    assert.equal(readFileSync(join(hooksDir, "pre-push"), "utf8"), custom);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── sweep planning ───────────────────────────────────────────────────────────
+
+test("parseWorktreePaths reads every worktree and ignores other porcelain fields", () => {
+  const porcelain = [
+    "worktree D:/DPF-source-root",
+    "HEAD 2468ca8ba6",
+    "branch refs/heads/main",
+    "",
+    "worktree D:/DPF-worktrees/feature-a",
+    "HEAD 9f94d810cb",
+    "branch refs/heads/feat/a",
+    "",
+  ].join("\n");
+  assert.deepEqual(parseWorktreePaths(porcelain), [
+    "D:/DPF-source-root",
+    "D:/DPF-worktrees/feature-a",
+  ]);
+});
+
+test("parseWorktreePaths tolerates CRLF and empty input", () => {
+  assert.deepEqual(parseWorktreePaths("worktree /a\r\nHEAD x\r\n\r\nworktree /b\r\n"), ["/a", "/b"]);
+  assert.deepEqual(parseWorktreePaths(""), []);
+  assert.deepEqual(parseWorktreePaths(null), []);
+});
+
+test("shouldSweep fails toward sweeping when the marker is unreadable", () => {
+  // An extra sweep costs a few file stats; a skipped one costs an ungated push.
+  assert.equal(shouldSweep(null, 1_000_000), true);
+  assert.equal(shouldSweep(Number.NaN, 1_000_000), true);
+});
+
+test("shouldSweep throttles concurrent sessions but reopens after the window", () => {
+  const now = 1_000_000_000;
+  assert.equal(shouldSweep(now - 1_000, now), false);
+  assert.equal(shouldSweep(now - SWEEP_THROTTLE_MS - 1, now), true);
+});
+
+// ── reporting ────────────────────────────────────────────────────────────────
+
+test("summary names repairs and refusals; a fully converged estate is not news", () => {
+  const summary = summarizeConvergence([
+    { hooksDir: "a", prePush: "written", postCheckout: "written" },
+    { hooksDir: "b", prePush: "unchanged", postCheckout: "unchanged" },
+    { hooksDir: "c", prePush: "chain-absent", postCheckout: "chain-absent" },
+  ]);
+  assert.match(summary, /3 tree\(s\) checked/);
+  assert.match(summary, /1 pre-push gate\(s\) REPAIRED/);
+  assert.match(summary, /1 skipped/);
+
+  const quiet = summarizeConvergence([{ hooksDir: "a", prePush: "unchanged", postCheckout: "unchanged" }]);
+  assert.doesNotMatch(quiet, /REPAIRED|skipped|FAILED/);
+});
+
+// ── the regression that started all of this ──────────────────────────────────
+
+test("no hook-path source re-derives a filesystem path from URL.pathname (BI-5CBDC146)", () => {
+  // On Windows `new URL(import.meta.url).pathname` is "/D:/repo/..." and every
+  // path built from it is unopenable, so the converger threw into a bare catch
+  // and the gate silently never installed. Linux CI cannot reproduce the
+  // failure, so this source-level assertion is the only thing that catches a
+  // reintroduction.
+  for (const file of ["converge-git-hooks.mjs", join("..", "lib", "converge-hooks-dir.mjs")]) {
+    const source = readFileSync(join(here, file), "utf8");
+    const offending = source
+      .split(/\r?\n/)
+      .filter((line) => !line.trimStart().startsWith("//"))
+      .filter((line) => /URL\([^)]*\)\s*\.pathname|import\.meta\.url\s*\)\s*\.pathname/.test(line));
+    assert.deepEqual(offending, [], `${file} must resolve paths with fileURLToPath, not URL.pathname`);
+  }
+});

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -399,6 +399,16 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         // converged and a clean push meant the gate never ran. Linux CI cannot
         // reproduce it — these guards are the only thing that catches it.
         "scripts/lib/hooks-dir.test.mjs",
+        // BI-3727106F: the gate must converge at SESSION START and sweep
+        // sibling worktrees. Convergence used to run only in postinstall, and
+        // only from the tree's own copy — so a tree on a stale base could never
+        // repair itself (68 of 85 worktrees were ungated when this was measured).
+        "scripts/hooks/converge-git-hooks.test.mjs",
+        // BI-9B490215: the root postinstall must keep ZERO static local imports.
+        // The Docker deps stage copies only set-hooks-path.mjs, so a static
+        // ./lib import throws ERR_MODULE_NOT_FOUND and breaks the image build,
+        // and with it the release / self-upgrade chain for every install.
+        "scripts/set-hooks-path.no-static-imports.test.mjs",
         "scripts/lib/agent-identity.test.mjs",
         "tests/release/local-ci-gate-contract.test.mjs",
         "tests/release/pregate-node-gate-contract.test.mjs",

--- a/scripts/lib/converge-hooks-dir.mjs
+++ b/scripts/lib/converge-hooks-dir.mjs
@@ -1,0 +1,89 @@
+// Converge one repository's .githooks directory to the tracked, enforcing hooks.
+//
+// WHY THIS IS SHARED (BI-3727106F)
+//   Two callers need identical convergence semantics:
+//     1. scripts/set-hooks-path.mjs        — install time (pnpm postinstall)
+//     2. scripts/hooks/converge-git-hooks.mjs — session start, incl. sibling sweep
+//   Keeping the sequencing in one place is the single-source-of-truth rule
+//   applied to enforcement: two copies drift, and a drifted copy of a GATE
+//   installer is indistinguishable from a working one until a push slips
+//   through ungated. That is exactly how BI-5CBDC146 stayed invisible.
+//
+// THE HAZARD THIS GUARDS
+//   The generated pre-push shim does `exec sh .githooks/lib/pre-push-chained.sh`.
+//   Writing that shim into a tree whose checkout PREDATES pre-push-chained.sh
+//   would make every push in that tree fail with "No such file or directory".
+//   So convergence is refused — reported as `chain-absent`, never written —
+//   unless the tracked chained script is actually present. A tree on an old
+//   base is told to refresh, not broken.
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { ensurePrePushHook } from "./ensure-pre-push-hook.mjs";
+import { ensurePostCheckoutHook } from "./ensure-post-checkout-hook.mjs";
+
+/** Tracked script the generated pre-push shim delegates to. */
+export const CHAINED_PRE_PUSH_REL = path.join("lib", "pre-push-chained.sh");
+
+/**
+ * Is this hooks dir safe to converge? A shim that delegates to an absent
+ * script is worse than no shim: it breaks push instead of merely not gating.
+ * @param {string} hooksDir
+ * @param {{ existsSync?: (p: string) => boolean }} [io]
+ */
+export function canConverge(hooksDir, io = {}) {
+  const exists = io.existsSync ?? fs.existsSync;
+  return exists(path.join(hooksDir, CHAINED_PRE_PUSH_REL));
+}
+
+/**
+ * Converge a single .githooks directory.
+ *
+ * Never throws: a hook that breaks session start is a worse defect than the
+ * one it fixes. Every failure mode is returned as data so the caller can
+ * report it — silence is what hid BI-5CBDC146 for the life of the script.
+ *
+ * @param {string} hooksDir absolute path to a `.githooks` directory
+ * @returns {{ hooksDir: string, prePush: string, postCheckout: string, error?: string }}
+ *   prePush/postCheckout are 'written' | 'unchanged' | 'left-custom' |
+ *   'chain-absent' | 'error'.
+ */
+export function convergeHooksDir(hooksDir) {
+  if (!canConverge(hooksDir)) {
+    return { hooksDir, prePush: "chain-absent", postCheckout: "chain-absent" };
+  }
+  let prePush = "error";
+  let postCheckout = "error";
+  let error;
+  try {
+    prePush = ensurePrePushHook(hooksDir).action;
+  } catch (err) {
+    error = err?.message ?? String(err);
+  }
+  try {
+    postCheckout = ensurePostCheckoutHook(hooksDir).action;
+  } catch (err) {
+    error ??= err?.message ?? String(err);
+  }
+  return error ? { hooksDir, prePush, postCheckout, error } : { hooksDir, prePush, postCheckout };
+}
+
+/**
+ * One-line human summary of a sweep. Reports repairs and refusals; stays
+ * quiet-but-truthful when everything was already converged.
+ * @param {Array<ReturnType<typeof convergeHooksDir>>} results
+ */
+export function summarizeConvergence(results) {
+  const count = (action) => results.filter((r) => r.prePush === action).length;
+  const repaired = count("written");
+  const chainAbsent = count("chain-absent");
+  const custom = count("left-custom");
+  const errored = count("error");
+  const parts = [`${results.length} tree(s) checked`];
+  if (repaired) parts.push(`${repaired} pre-push gate(s) REPAIRED`);
+  if (custom) parts.push(`${custom} custom hook(s) left untouched`);
+  if (chainAbsent) parts.push(`${chainAbsent} skipped (base predates the chained gate — refresh from origin/main)`);
+  if (errored) parts.push(`${errored} FAILED`);
+  return parts.join(", ");
+}

--- a/scripts/set-hooks-path.mjs
+++ b/scripts/set-hooks-path.mjs
@@ -1,6 +1,22 @@
-import { execSync } from 'node:child_process';
+// Root postinstall: point git at the tracked hooks and converge the generated shims.
+//
+// ZERO STATIC LOCAL IMPORTS — THIS IS LOAD-BEARING (BI-9B490215).
+//   The Docker `deps` stage copies exactly one file out of scripts/:
+//     Dockerfile: COPY scripts/set-hooks-path.mjs ./scripts/
+//   and then runs `pnpm install --frozen-lockfile`, which runs this as
+//   postinstall. A static `import './lib/x.mjs'` is resolved at MODULE LOAD,
+//   before any try/catch can run, so it throws ERR_MODULE_NOT_FOUND, fails
+//   postinstall, and breaks the image build — and therefore the release and
+//   self-upgrade chain for every install.
+//
+//   Adding another COPY line per dependency treats the symptom and leaves the
+//   next helper to break the build again. Instead every local import here is
+//   DYNAMIC and guarded, so this file is self-sufficient by construction:
+//   where its helpers are absent it degrades to a warning, which is the right
+//   behaviour anyway — installing developer git hooks is meaningless inside an
+//   image build. `scripts/set-hooks-path.no-static-imports.test.mjs` enforces it.
 
-import { resolveHooksDir } from './lib/hooks-dir.mjs';
+import { execSync } from 'node:child_process';
 
 try {
   execSync('git config core.hooksPath .githooks', { stdio: 'ignore' });
@@ -9,37 +25,29 @@ try {
   // The pre-commit typecheck gate only matters in developer clones.
 }
 
-// Both convergences resolve through fileURLToPath (BI-5CBDC146). Reading
-// `.pathname` off the module URL produced "/D:/repo/.githooks/" on Windows,
-// which path.join turned into an unopenable "\D:\repo\.githooks\" — so every
-// hook write threw ENOENT into the bare catch below and the gate never
-// installed. A clean push then meant the gate never ran, not that it passed.
-const hooksDir = resolveHooksDir(import.meta.url);
-
-// Converge the gitignored pre-push shim to the tracked chained hook
-// (Git LFS + local-CI gate — BI-C74F4DE9). Fail-safe: never break install.
 try {
-  const { ensurePrePushHook } = await import('./lib/ensure-pre-push-hook.mjs');
-  const result = ensurePrePushHook(hooksDir);
-  if (result.action === 'written') {
-    console.log(`[set-hooks-path] converged .githooks/pre-push (was: ${result.was}) → LFS + local-CI gate chain`);
-  } else if (result.action === 'left-custom') {
+  // Both convergences resolve through fileURLToPath (BI-5CBDC146). Reading
+  // `.pathname` off the module URL produced "/D:/repo/.githooks/" on Windows,
+  // which path.join turned into an unopenable "\D:\repo\.githooks\" — so every
+  // hook write threw ENOENT into a bare catch and the gate never installed.
+  // A clean push then meant the gate never ran, not that it passed.
+  const { resolveHooksDir } = await import('./lib/hooks-dir.mjs');
+  const { convergeHooksDir, summarizeConvergence } = await import('./lib/converge-hooks-dir.mjs');
+
+  const result = convergeHooksDir(resolveHooksDir(import.meta.url));
+
+  if (result.prePush === 'written' || result.postCheckout === 'written') {
+    console.log(`[set-hooks-path] ${summarizeConvergence([result])} → LFS + local-CI gate chain`);
+  } else if (result.prePush === 'left-custom') {
     console.warn('[set-hooks-path] .githooks/pre-push is a custom hook — left untouched; chain .githooks/lib/pre-push-chained.sh manually to keep the local-CI gate.');
+  } else if (result.prePush === 'chain-absent') {
+    console.warn('[set-hooks-path] .githooks/lib/pre-push-chained.sh is absent — refusing to write a shim that would break every push. Refresh this tree from origin/main.');
+  }
+  if (result.error) {
+    console.warn(`[set-hooks-path] hook convergence reported an error — the local-CI gate may not run on push: ${result.error}`);
   }
 } catch (error) {
-  // Same non-git / read-only contexts as above: never break the install. But
-  // say so — silence here is what hid BI-5CBDC146 for the life of the script.
-  console.warn(`[set-hooks-path] could not converge .githooks/pre-push — the local-CI gate will not run on push: ${error?.message ?? error}`);
-}
-
-try {
-  const { ensurePostCheckoutHook } = await import('./lib/ensure-post-checkout-hook.mjs');
-  const result = ensurePostCheckoutHook(hooksDir);
-  if (result.action === 'written') {
-    console.log(`[set-hooks-path] converged .githooks/post-checkout (was: ${result.was}) → LFS + uncommitted-work guard chain`);
-  } else if (result.action === 'left-custom') {
-    console.warn('[set-hooks-path] .githooks/post-checkout is a custom hook — left untouched; chain .githooks/lib/post-checkout-chained.sh manually to keep the durable-artifact guard.');
-  }
-} catch (error) {
-  console.warn(`[set-hooks-path] could not converge .githooks/post-checkout — the uncommitted-work guard will not run on checkout: ${error?.message ?? error}`);
+  // Non-git / image-build / read-only contexts: never break the install. But
+  // SAY SO — silence here is what hid BI-5CBDC146 for the life of the script.
+  console.warn(`[set-hooks-path] could not converge git hooks — the local-CI gate will not run on push here: ${error?.message ?? error}`);
 }

--- a/scripts/set-hooks-path.no-static-imports.test.mjs
+++ b/scripts/set-hooks-path.no-static-imports.test.mjs
@@ -1,0 +1,65 @@
+// scripts/set-hooks-path.no-static-imports.test.mjs
+//
+// BI-9B490215 — the root postinstall must not statically import a local module.
+//
+// The Docker `deps` stage copies exactly ONE file out of scripts/:
+//   Dockerfile: COPY scripts/set-hooks-path.mjs ./scripts/
+// then runs `pnpm install --frozen-lockfile`, which runs it as postinstall.
+// A static `import './lib/x.mjs'` resolves at module load, before any
+// try/catch can run, so it throws ERR_MODULE_NOT_FOUND, fails postinstall and
+// breaks the image build — and with it the release and self-upgrade chain for
+// every install. Dynamic + guarded imports degrade to a warning instead.
+//
+// Run: node --test scripts/set-hooks-path.no-static-imports.test.mjs
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const postinstall = join(here, "set-hooks-path.mjs");
+
+test("postinstall has no static local imports", () => {
+  const source = readFileSync(postinstall, "utf8");
+  const staticLocalImports = source
+    .split(/\r?\n/)
+    .filter((line) => /^\s*import\s[^(]*\sfrom\s+['"][.\/]/.test(line));
+  assert.deepEqual(
+    staticLocalImports,
+    [],
+    "every local import in set-hooks-path.mjs must be a guarded `await import()`; a static one breaks the Docker deps stage",
+  );
+});
+
+test("postinstall survives the Docker deps stage, where only itself is present", () => {
+  // Reproduces the failing layer exactly: one file under scripts/, no
+  // scripts/lib, no .githooks, not a git repository.
+  const sandbox = mkdtempSync(join(tmpdir(), "dpf-postinstall-"));
+  try {
+    mkdirSync(join(sandbox, "scripts"), { recursive: true });
+    copyFileSync(postinstall, join(sandbox, "scripts", "set-hooks-path.mjs"));
+    writeFileSync(join(sandbox, "package.json"), '{"name":"sim","private":true}\n');
+
+    let exitCode = 0;
+    let stderr = "";
+    try {
+      execFileSync(process.execPath, ["scripts/set-hooks-path.mjs"], {
+        cwd: sandbox,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (err) {
+      exitCode = err.status ?? 1;
+      stderr = String(err.stderr ?? "");
+    }
+
+    assert.equal(exitCode, 0, `postinstall must not fail the image build. stderr:\n${stderr}`);
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## The problem

The local-CI pre-push gate was dead in **68 of 85 worktrees** on this install, with 4 more carrying no hook file at all. Only 13 were live — and the root clone, the merge/release worktree, was one of the dead ones.

A clean `git push` from an ungated tree is **byte-identical** to a clean push from a gated one. That is why this stayed invisible for a week and backed up the whole development process: nothing was lying, there was simply nothing to read.

## Two defects, one fix

**1. Convergence ran only at `pnpm install`, from the tree's own copy.**

`.githooks/pre-push` is untracked and generated; the enforcing logic is the tracked `.githooks/lib/pre-push-chained.sh`. Convergence between them ran only in postinstall. So any tree not reinstalled since a fix kept the stock git-lfs shim — and worse, it ran its *own* converger, so a tree on a base predating BI-5CBDC146 ran the buggy converger and **could never repair itself**. The fix reached only trees that already had the fix.

Measured directly: sweeping with each tree's own script repaired 8 of 68. Sweeping with the root clone's fixed converger repaired the remaining 60.

Convergence now also runs at **SessionStart** and sweeps sibling worktrees. The session that just started is by construction running current code, so a merged fix now reaches every tree *by being merged* rather than by everyone remembering to reinstall. The sweep is throttled through a marker in the shared git dir so N concurrent sessions do one sweep, and it **refuses** to converge a tree lacking `pre-push-chained.sh` — writing a shim that execs a missing script would turn "not gated" into "cannot push".

**2. BI-9B490215: the root postinstall broke the image build for every install.**

The Docker `deps` stage copies exactly one file out of `scripts/`:

```
COPY scripts/set-hooks-path.mjs ./scripts/
```

then runs `pnpm install --frozen-lockfile`, which runs it as postinstall. Its static `import './lib/hooks-dir.mjs'` resolves at module load — before any `try/catch` — so it threw `ERR_MODULE_NOT_FOUND`, failed postinstall, and broke the image build, and with it the release and self-upgrade chain.

Adding another `COPY` per dependency treats the symptom and leaves the next helper to break the build again. Every local import there is now **dynamic and guarded**, so the file is self-sufficient by construction and degrades to a warning where its helpers are absent — which is correct anyway, since installing developer git hooks is meaningless inside an image build.

Verified against a reproduction of the deps stage (one file under `scripts/`, no `scripts/lib`, not a git repo):

| | exit | output |
|---|---|---|
| before | **1** | `ERR_MODULE_NOT_FOUND ... scripts/lib/hooks-dir.mjs` |
| after | **0** | `[set-hooks-path] could not converge git hooks — the local-CI gate will not run on push here: ...` |

## Evidence

- **Estate swept 13/85 → 85/85 gated, 0 dead.** A second sweep 15 minutes later repaired **3 more** trees born ungated in the interval — a one-off sweep cannot hold, which is the argument for session-start convergence.
- `pnpm run pregate`: **gate passed**, `fix/self-healing-gate-convergence@30c9d792a669`, 15:35, evidence `cmtb1e3it09mb01o0k78v8o7k`.
- 21 affected tests pass, registered in the hand-enumerated CI inventory (unlisted = never run).
- One of those tests is a **source-level assertion that no hook-path module re-derives a filesystem path from `URL.pathname`** — the BI-5CBDC146 defect that Linux CI cannot reproduce, so a guard is the only thing that catches a reintroduction.

## Sequencing note — overlapping work

Two other sessions are fixing BI-9B490215 by adding `COPY scripts/lib/hooks-dir.mjs` to the Dockerfile (`fix/dockerfile-copies-hooks-dir`, `fix/dockerfile-copies-hooks-dir-lib`). **There is no file conflict** — those touch `Dockerfile`, this touches `scripts/set-hooks-path.mjs`. Either can merge first. Theirs closes the instance; this closes the class, after which those `COPY` lines are correct but redundant. Flagged rather than duplicated or cancelled.

## What this does not do

It does not make an absent gate *fail loudly*. Convergence closes the "gate silently missing" hole going forward, but a gate that is off still produces a clean push rather than a red PR. That is the attestation layer, tracked on BI-3727106F and shared with BI-0B292D84.

Docs-Impact-Decision: `docs/testing/pre-pr-gate.md` is updated in this branch, including replacing its `head -4 .githooks/pre-push` advice — a spot-check that answers for one tree — with an estate-wide sweep. `scripts/lib/ci-policy-guards.mjs` changed only by adding two test paths to the CI inventory, so no user-facing behaviour in `docs/architecture/context-engineering-standards.md` or the generated `docs/maintenance/staleness-report.md` changes.

Refs: BI-3727106F, BI-9B490215, BI-5CBDC146
Workroom: WC-0FF5B0E9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
