### PR TITLE
feat(ci): guard the import closure of every Dockerfile-copied script (BI-9B490215)

### DIFF
--- a/scripts/check-dockerfile-copied-script-imports.mjs
+++ b/scripts/check-dockerfile-copied-script-imports.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+// check-dockerfile-copied-script-imports.mjs — BI-9B490215.
+//
+// The Dockerfile copies individual scripts by name, never `scripts/` wholesale:
+//
+//   COPY scripts/set-hooks-path.mjs ./scripts/
+//
+// That keeps the image small, but it silently couples the image to the import
+// graph of every file it names. Extract a helper out of one of those scripts and
+// the image loses it: the module still resolves in a developer clone and in every
+// `next build`, so PR CI stays green, and the break only appears when the image
+// is actually built — in local-CI, in the release publish, or in a self-upgrade.
+//
+// Measured instance: `scripts/set-hooks-path.mjs` gained a top-level
+// `import { resolveHooksDir } from './lib/hooks-dir.mjs'`, which the Dockerfile
+// never copied. Root `postinstall` runs that script, so
+// `RUN pnpm install --frozen-lockfile` died with
+// `ERR_MODULE_NOT_FOUND file:///app/scripts/lib/hooks-dir.mjs` and the whole
+// image build failed — breaking the release/self-upgrade chain for every install.
+//
+// A STATIC import fails at module-link time, so a try/catch inside the script
+// cannot contain it. Dynamic `await import(...)` inside a try/catch degrades
+// instead, which is why the sibling `ensure-pre-push-hook.mjs` /
+// `ensure-post-checkout-hook.mjs` imports in that same file never broke anything.
+// This guard therefore only inspects STATIC imports.
+//
+// Invariant: if the Dockerfile copies a `.mjs` file into a stage, every file it
+// statically imports must also land in that stage — copied there directly, or
+// inherited from a stage it is built FROM.
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { isEntryModule } from "./lib/entry-module.mjs";
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1")), "..");
+
+/** Static `import ... from "x"` / `export ... from "x"`, plus bare `import "x"`. */
+const STATIC_IMPORT_RE =
+  /(?:^|\n)\s*(?:import|export)\b[^;\n]*?\bfrom\s*["']([^"']+)["']|(?:^|\n)\s*import\s*["']([^"']+)["']/g;
+
+/** Flags that may precede COPY operands. */
+const COPY_FLAG_RE = /^--(from|chown|chmod|link|parents)=?/;
+
+/**
+ * Collapse backslash line-continuations and drop comments/blank lines.
+ * @param {string} text
+ * @returns {string[]}
+ */
+export function logicalLines(text) {
+  const out = [];
+  let buffer = "";
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trimEnd();
+    const isComment = /^\s*#/.test(line);
+    if (buffer === "" && (isComment || line.trim() === "")) continue;
+    // Continuation fragments carry their own indentation; normalise to single
+    // spaces so callers can split operands on /\s+/ without surprises.
+    const fragment = buffer === "" ? line : line.trimStart();
+    if (line.endsWith("\\")) {
+      buffer += fragment.slice(0, -1).trimEnd() + " ";
+      continue;
+    }
+    out.push((buffer + fragment).trim());
+    buffer = "";
+  }
+  if (buffer.trim()) out.push(buffer.trim());
+  return out;
+}
+
+/**
+ * Parse a Dockerfile into stages with their COPY destinations resolved to
+ * absolute in-image paths.
+ *
+ * @param {string} text
+ * @returns {{ name: string, parent: string|null, workdir: string,
+ *             copies: Array<{ src: string, imagePath: string, fromStage: string|null }> }[]}
+ */
+export function parseStages(text) {
+  const stages = [];
+  const byName = new Map();
+  let current = null;
+
+  for (const line of logicalLines(text)) {
+    const from = /^FROM\s+(\S+)(?:\s+AS\s+(\S+))?/i.exec(line);
+    if (from) {
+      const base = from[1];
+      const name = from[2] ?? `stage${stages.length}`;
+      const parent = byName.has(base) ? base : null;
+      current = {
+        name,
+        parent,
+        workdir: parent ? byName.get(parent).workdir : "/",
+        copies: [],
+      };
+      stages.push(current);
+      byName.set(name, current);
+      continue;
+    }
+    if (!current) continue;
+
+    const workdir = /^WORKDIR\s+(\S+)/i.exec(line);
+    if (workdir) {
+      current.workdir = path.posix.resolve(current.workdir, workdir[1]);
+      continue;
+    }
+
+    if (!/^COPY\s/i.test(line)) continue;
+    const operands = line.slice(4).trim().split(/\s+/);
+    let fromStage = null;
+    while (operands.length && COPY_FLAG_RE.test(operands[0])) {
+      const flag = operands.shift();
+      const m = /^--from=(.+)$/.exec(flag);
+      if (m) fromStage = m[1];
+    }
+    if (operands.length < 2) continue;
+    const dest = operands.pop();
+    const absDest = dest.startsWith("/") ? dest : path.posix.resolve(current.workdir, dest);
+    const destIsDir = dest.endsWith("/") || operands.length > 1;
+
+    for (const src of operands) {
+      const imagePath = destIsDir
+        ? path.posix.join(absDest, path.posix.basename(src))
+        : absDest;
+      current.copies.push({ src, imagePath, fromStage });
+    }
+  }
+  return stages;
+}
+
+/**
+ * Every in-image path a stage can see: its own COPYs plus those of every stage
+ * it is built FROM.
+ *
+ * @param {ReturnType<typeof parseStages>} stages
+ * @param {string} name
+ * @returns {Set<string>}
+ */
+export function visiblePaths(stages, name) {
+  const byName = new Map(stages.map((s) => [s.name, s]));
+  const seen = new Set();
+  let stage = byName.get(name);
+  while (stage) {
+    for (const copy of stage.copies) seen.add(copy.imagePath);
+    stage = stage.parent ? byName.get(stage.parent) : null;
+  }
+  return seen;
+}
+
+/**
+ * Relative specifiers statically imported by a module.
+ *
+ * @param {string} source
+ * @returns {string[]}
+ */
+export function staticRelativeImports(source) {
+  const specs = [];
+  for (const match of source.matchAll(STATIC_IMPORT_RE)) {
+    const spec = match[1] ?? match[2];
+    if (spec && (spec.startsWith("./") || spec.startsWith("../"))) specs.push(spec);
+  }
+  return specs;
+}
+
+/**
+ * @param {string} dockerfileText
+ * @param {(repoRelativePath: string) => string|null} readSource
+ *        Returns file contents, or null when the path is not a readable repo file.
+ * @returns {Array<{ stage: string, importer: string, importerSrc: string,
+ *                   specifier: string, missing: string }>}
+ */
+export function findMissingCopiedImports(dockerfileText, readSource) {
+  const stages = parseStages(dockerfileText);
+  const violations = [];
+
+  for (const stage of stages) {
+    const visible = visiblePaths(stages, stage.name);
+    for (const copy of stage.copies) {
+      // Artifacts lifted from another stage are produced there, not by this
+      // repo path; their import graph is that stage's problem, not ours.
+      if (copy.fromStage) continue;
+      if (!copy.imagePath.endsWith(".mjs")) continue;
+      const source = readSource(copy.src);
+      if (source == null) continue;
+
+      for (const spec of staticRelativeImports(source)) {
+        const target = path.posix.resolve(path.posix.dirname(copy.imagePath), spec);
+        if (visible.has(target)) continue;
+        violations.push({
+          stage: stage.name,
+          importer: copy.imagePath,
+          importerSrc: copy.src,
+          specifier: spec,
+          missing: target,
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+function main() {
+  const dockerfilePath = path.join(REPO_ROOT, "Dockerfile");
+  if (!existsSync(dockerfilePath)) {
+    console.error(`[dockerfile-script-imports] cannot read ${dockerfilePath}`);
+    process.exit(1);
+  }
+  const violations = findMissingCopiedImports(
+    readFileSync(dockerfilePath, "utf8"),
+    (src) => {
+      const abs = path.join(REPO_ROOT, src);
+      return existsSync(abs) ? readFileSync(abs, "utf8") : null;
+    },
+  );
+
+  if (violations.length === 0) {
+    console.log(
+      "[dockerfile-script-imports] OK — every statically imported module of a Dockerfile-copied script is copied too.",
+    );
+    return;
+  }
+
+  console.error(
+    "[dockerfile-script-imports] FAILED — a Dockerfile-copied script statically imports a file the image never receives.",
+  );
+  console.error(
+    "The image build dies at `pnpm install` / first run with ERR_MODULE_NOT_FOUND. `next build` and PR CI cannot see this.\n",
+  );
+  for (const v of violations) {
+    console.error(`  stage ${v.stage}: ${v.importer}`);
+    console.error(`    imports ${v.specifier} -> ${v.missing} (not copied)`);
+    console.error(`    add: COPY ${path.posix.join(path.posix.dirname(v.importerSrc), v.specifier)} <dest>\n`);
+  }
+  console.error(
+    "Fix by copying the imported file into the same stage, or make the import a dynamic\n" +
+      "`await import(...)` inside a try/catch so the image degrades instead of failing to build.",
+  );
+  process.exit(1);
+}
+
+if (isEntryModule(import.meta.url)) main();

--- a/scripts/check-dockerfile-copied-script-imports.test.mjs
+++ b/scripts/check-dockerfile-copied-script-imports.test.mjs
@@ -1,0 +1,115 @@
+// Self-test for check-dockerfile-copied-script-imports.mjs (BI-9B490215).
+//
+// The guard exists because a green PR can still ship an unbuildable image, so
+// the self-test has to prove three things: it catches the real regression, it
+// does not fire on the patterns the Dockerfile legitimately uses, and it passes
+// against the actual checked-in Dockerfile.
+
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  findMissingCopiedImports,
+  logicalLines,
+  parseStages,
+  staticRelativeImports,
+  visiblePaths,
+} from "./check-dockerfile-copied-script-imports.mjs";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1")),
+  "..",
+);
+
+test("collapses backslash continuations and drops comments", () => {
+  const lines = logicalLines("# note\nCOPY a.mjs \\\n     b.mjs \\\n     ./scripts/\n\nRUN x\n");
+  assert.deepEqual(lines, ["COPY a.mjs b.mjs ./scripts/", "RUN x"]);
+});
+
+test("resolves COPY destinations against the stage WORKDIR", () => {
+  const stages = parseStages("FROM node AS deps\nWORKDIR /app\nCOPY scripts/x.mjs ./scripts/\n");
+  assert.equal(stages[0].copies[0].imagePath, "/app/scripts/x.mjs");
+});
+
+test("a rename-style COPY (dest without trailing slash) keeps the destination name", () => {
+  const stages = parseStages("FROM node AS r\nCOPY scripts/lib/a.mjs /promoter/scripts/lib/a.mjs\n");
+  assert.equal(stages[0].copies[0].imagePath, "/promoter/scripts/lib/a.mjs");
+});
+
+test("a stage sees what the stage it is built FROM copied", () => {
+  const stages = parseStages(
+    "FROM node AS deps\nWORKDIR /app\nCOPY scripts/lib/dep.mjs ./scripts/lib/\nFROM deps AS build\nCOPY scripts/main.mjs ./scripts/\n",
+  );
+  const visible = visiblePaths(stages, "build");
+  assert.ok(visible.has("/app/scripts/lib/dep.mjs"));
+  assert.ok(visible.has("/app/scripts/main.mjs"));
+});
+
+test("reads static imports but ignores dynamic ones", () => {
+  const specs = staticRelativeImports(
+    [
+      "import { a } from './lib/a.mjs';",
+      "export { b } from '../lib/b.mjs';",
+      "import './lib/side-effect.mjs';",
+      "import fs from 'node:fs';",
+      "const { c } = await import('./lib/c.mjs');",
+    ].join("\n"),
+  );
+  assert.deepEqual(specs.sort(), ["../lib/b.mjs", "./lib/a.mjs", "./lib/side-effect.mjs"]);
+});
+
+// The measured regression: set-hooks-path.mjs gained a top-level import of
+// ./lib/hooks-dir.mjs, which no COPY line delivered.
+test("catches a copied script whose static import is never copied", () => {
+  const dockerfile = "FROM node AS deps\nWORKDIR /app\nCOPY scripts/set-hooks-path.mjs ./scripts/\n";
+  const violations = findMissingCopiedImports(dockerfile, (src) =>
+    src === "scripts/set-hooks-path.mjs"
+      ? "import { resolveHooksDir } from './lib/hooks-dir.mjs';\n"
+      : null,
+  );
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].missing, "/app/scripts/lib/hooks-dir.mjs");
+  assert.equal(violations[0].stage, "deps");
+});
+
+test("passes once the imported file is copied too", () => {
+  const dockerfile =
+    "FROM node AS deps\nWORKDIR /app\nCOPY scripts/set-hooks-path.mjs ./scripts/\nCOPY scripts/lib/hooks-dir.mjs ./scripts/lib/\n";
+  const violations = findMissingCopiedImports(dockerfile, (src) =>
+    src === "scripts/set-hooks-path.mjs"
+      ? "import { resolveHooksDir } from './lib/hooks-dir.mjs';\n"
+      : "export const x = 1;\n",
+  );
+  assert.deepEqual(violations, []);
+});
+
+test("does not flag a dynamic import — it degrades inside try/catch instead of failing the build", () => {
+  const dockerfile = "FROM node AS deps\nWORKDIR /app\nCOPY scripts/set-hooks-path.mjs ./scripts/\n";
+  const violations = findMissingCopiedImports(dockerfile, (src) =>
+    src === "scripts/set-hooks-path.mjs"
+      ? "try { const m = await import('./lib/ensure-pre-push-hook.mjs'); } catch {}\n"
+      : null,
+  );
+  assert.deepEqual(violations, []);
+});
+
+test("does not flag artifacts lifted from another stage", () => {
+  const dockerfile =
+    "FROM node AS build\nWORKDIR /app\nFROM node AS runner\nWORKDIR /app\nCOPY --from=build /app/scripts/gen.mjs ./scripts/\n";
+  const violations = findMissingCopiedImports(dockerfile, () => "import './lib/nope.mjs';\n");
+  assert.deepEqual(violations, []);
+});
+
+test("the checked-in Dockerfile satisfies the invariant", () => {
+  const dockerfilePath = path.join(REPO_ROOT, "Dockerfile");
+  const violations = findMissingCopiedImports(readFileSync(dockerfilePath, "utf8"), (src) => {
+    const abs = path.join(REPO_ROOT, src);
+    return existsSync(abs) ? readFileSync(abs, "utf8") : null;
+  });
+  assert.deepEqual(
+    violations.map((v) => `${v.stage}: ${v.importer} -> ${v.missing}`),
+    [],
+  );
+});

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -186,6 +186,13 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       // build (SUR-8AB3353C, regression from #4321).
       node("scripts/check-docker-patch-context.mjs"),
       node("--test", "scripts/check-docker-patch-context.test.mjs"),
+      // Same failure family, different input: the Dockerfile copies scripts by
+      // name, so extracting a helper out of one silently drops it from the image
+      // and `pnpm install` dies on ERR_MODULE_NOT_FOUND in postinstall
+      // (BI-9B490215). `next build` and PR CI cannot see it — no PR check builds
+      // the image — so it reaches main green and breaks the release chain.
+      node("scripts/check-dockerfile-copied-script-imports.mjs"),
+      node("--test", "scripts/check-dockerfile-copied-script-imports.test.mjs"),
     ]),
     guard("bundle-boundary-guard", "Bundle Boundary Guard", [
       node("--test", "scripts/check-bundle-boundaries.test.mjs"),


### PR DESCRIPTION
Closes BI-9B490215.

## What broke

The Dockerfile never copies `scripts/` wholesale — it names each file:

```
COPY scripts/set-hooks-path.mjs ./scripts/
```

so the image silently depends on the **import closure** of every script it names. `set-hooks-path.mjs` (root `postinstall`) gained a top-level `import { resolveHooksDir } from './lib/hooks-dir.mjs'`, the helper was never copied, and every stage running `pnpm install --frozen-lockfile` died:

```
ERR_MODULE_NOT_FOUND file:///app/scripts/lib/hooks-dir.mjs
ERROR: failed to solve: process "/bin/sh -c pnpm install --frozen-lockfile" ... exit code: 1
```

That takes down the release/self-upgrade chain — the path by which any fix reaches a consumer install. **No PR check builds the image** (`Production Build` runs `next build`), so it reached `main` green and surfaced only in the local-CI bounded build.

## This PR ships the guard, not the fix

The Dockerfile fix landed on `main` independently while this was being written. Duplicating it here would only conflict, so this commit carries just the part that keeps it from recurring.

`check-dockerfile-copied-script-imports.mjs` parses the Dockerfile into stages, resolves every COPY to its in-image path, walks `FROM` inheritance, and asserts each statically imported module of a copied `.mjs` lands in the same stage.

It inspects **only static imports** — those fail at module-link time where no `try/catch` can contain them, whereas a dynamic `await import(...)` inside a `try/catch` degrades. That is exactly why the sibling `ensure-pre-push-hook.mjs` / `ensure-post-checkout-hook.mjs` imports in that same file never broke anything, and it is the distinction that makes the guard precise instead of noisy.

**It has already earned its keep twice.** Against the pre-fix tree it reproduced the regression in all three stages and found nothing else. Against main's fix — which adds the COPY to `deps` and `build` but *not* `init` — it reports zero violations, because `init` is `FROM deps` and inherits it. That is the question a reviewer would otherwise answer by hand-reading the stage graph, and it is why the guard models inheritance rather than matching COPY lines.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/plans/2026-08-16-late-defect-detection-hardening-plan.md` §3 already settled how this class is handled: targeted guards per packaging escape (`check-release-asset-contract`, `check-docker-patch-context`, `check-edge-node-image-bom`), *"extend those on the next escape rather than pre-building generality."* This is that next escape. Cited, not edited — editing a historical plan doc trips plan-backlog-coverage.
  - No spec covers Dockerfile COPY import closure; nothing to supersede.
- Current code substrate reviewed:
  - `scripts/check-docker-patch-context.mjs` — nearest sibling (patch files missing from the build context); set the shape and the registration site.
  - `scripts/check-guards.mjs` — auto-discovers `check-*.mjs` plus its self-test.
  - `scripts/set-hooks-path.mjs` — its dynamic-import-in-try/catch pattern identified static vs dynamic as load-bearing.
- Source of truth:
  - The Dockerfile itself: because it copies scripts individually, the import closure of each copied script is part of the image contract.
- Decision:
  - Ship the guard alone, and let it certify main's fix rather than re-assert it.

Operational-Precedent: check-docker-patch-context

Seed-Fit-Decision: global-default

A CI guard applying to every install and archetype; no seeded content, assignment or capability changes.

## Verification

- Guard **fails on the pre-fix tree** (3 stages) and **passes on main's**.
- 10/10 self-tests: red case, fixed case, dynamic imports, `--from=` artifacts, WORKDIR resolution, rename-style COPY, `FROM` inheritance, continuation-line parsing, and an assertion that the checked-in Dockerfile satisfies the invariant.
- 37-guard repo loop green; all 7 pull-request policy guards green.
- CI policy test inventory green (291 discovered, 145 listed, 146 allowlisted). **Without the explicit registration the new test would have been silently unrun** — `check-guards.mjs` auto-discovery is not enough to satisfy the inventory.
- `pnpm --filter web build` deliberately not run: no `apps/web` TypeScript is touched. The build that exercises this is the Docker build, which was used to confirm the underlying breakage and its fix.

## Note for reviewers

Three defects from one thread, and they chain. **BI-5CBDC146** (Windows `URL.pathname` making the pre-push gate silently never run) was fixed by extracting `resolveHooksDir` into a new file — and that extraction is what broke the image here. The fix was right; only its packaging was incomplete, and nothing in PR CI could see it. Also filed: **BI-85FCF0BB** (pregate's own preflight fetch re-truncates a shallow clone to depth 1, after which its guards fail on `no merge base`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
