### PR TITLE
fix(build-studio): a plan retry must not re-ask the endpoint that just failed (BI-7AD0759A)

### DIFF
--- a/apps/web/lib/build/plan-generation-retry.test.ts
+++ b/apps/web/lib/build/plan-generation-retry.test.ts
@@ -1,0 +1,50 @@
+// BI-7AD0759A — a retry must not re-ask the endpoint that just failed.
+
+import { describe, expect, it } from "vitest";
+
+import { denialForNextAttempt, denyAfterUnparseable } from "./plan-generation-retry";
+
+describe("denyAfterUnparseable", () => {
+  it("records the endpoint that returned unparseable output", () => {
+    expect(denyAfterUnparseable([], "local")).toEqual(["local"]);
+  });
+
+  it("accumulates across attempts", () => {
+    expect(denyAfterUnparseable(["local"], "codex")).toEqual(["local", "codex"]);
+  });
+
+  it("never denies the same endpoint twice", () => {
+    expect(denyAfterUnparseable(["local"], "local")).toEqual(["local"]);
+  });
+
+  it("ignores a missing or blank provider id rather than denying nothing-in-particular", () => {
+    expect(denyAfterUnparseable(["local"], "")).toEqual(["local"]);
+    expect(denyAfterUnparseable(["local"], null)).toEqual(["local"]);
+    expect(denyAfterUnparseable(["local"], undefined)).toEqual(["local"]);
+  });
+
+  it("does not mutate the list it was given", () => {
+    const denied = ["local"];
+    denyAfterUnparseable(denied, "codex");
+    expect(denied).toEqual(["local"]);
+  });
+});
+
+describe("denialForNextAttempt", () => {
+  // The first attempt must carry no denial, so routing picks its preferred
+  // endpoint exactly as before this change.
+  it("sends no denial before anything has failed", () => {
+    expect(denialForNextAttempt([])).toBeUndefined();
+  });
+
+  it("sends the failed endpoints once there are any", () => {
+    expect(denialForNextAttempt(["local"])).toEqual(["local"]);
+  });
+
+  it("copies, so a caller cannot mutate the accumulated list through the result", () => {
+    const denied = ["local"];
+    const sent = denialForNextAttempt(denied)!;
+    sent.push("codex");
+    expect(denied).toEqual(["local"]);
+  });
+});

--- a/apps/web/lib/build/plan-generation-retry.ts
+++ b/apps/web/lib/build/plan-generation-retry.ts
@@ -1,0 +1,44 @@
+// apps/web/lib/build/plan-generation-retry.ts
+//
+// BI-7AD0759A — which endpoint should a plan-generation retry ask?
+//
+// Plan generation gets two attempts. Both used to go to whatever routing picked
+// first, so an endpoint that returned unparseable JSON was asked the same
+// question again — and returned unparseable JSON again. That is not a retry,
+// it is a repetition with a different system prompt.
+//
+// Live repro FB-62D7C0EC on the Pet Rescue install: both attempts drew the
+// local model, both truncated mid-array, the revision failed, and the build was
+// lost with a plan review that had named five critical issues — while a capable
+// endpoint sat unused.
+//
+// Pure module — no routing, no I/O — so the policy is testable on its own.
+
+/**
+ * Record an endpoint that failed to return parseable output.
+ *
+ * Returns a new list; never mutates. Ignores empty ids and duplicates so a
+ * caller cannot accidentally deny the same endpoint twice or deny "".
+ */
+export function denyAfterUnparseable(
+  denied: readonly string[],
+  providerId: string | null | undefined,
+): string[] {
+  const id = (providerId ?? "").trim();
+  if (id.length === 0 || denied.includes(id)) return [...denied];
+  return [...denied, id];
+}
+
+/**
+ * The routing denial to send with the next attempt.
+ *
+ * Returns undefined when nothing has failed yet, so the first attempt carries
+ * no denial at all and routing is free to pick its preferred endpoint.
+ *
+ * Denials are advisory to routing, not a hard refusal: the platform must stay
+ * runnable on whatever hardware it has (BI-3B3F477B). Asking routing to prefer
+ * a different endpoint is the goal; refusing to run is never the goal.
+ */
+export function denialForNextAttempt(denied: readonly string[]): string[] | undefined {
+  return denied.length > 0 ? [...denied] : undefined;
+}

--- a/apps/web/lib/build/plan-on-approval.ts
+++ b/apps/web/lib/build/plan-on-approval.ts
@@ -25,6 +25,7 @@
 // Called from: reviewDesignDoc success path in mcp-tools.ts (fire-and-forget).
 
 import { prisma } from "@dpf/db";
+import { denialForNextAttempt, denyAfterUnparseable } from "@/lib/build/plan-generation-retry";
 import { normalizeBuildPlanPaths } from "./build-plan-paths";
 import { escalateBuildToHuman, SELF_FIX_CLASS } from "@/lib/build/escalate-build-to-human";
 
@@ -205,7 +206,15 @@ async function generateNormalizedPlan(args: {
 
   const PLAN_GEN_MAX_ATTEMPTS = 2;
   let planObj: { fileStructure?: unknown[]; tasks?: unknown[] } | null = null;
+  // BI-7AD0759A: an endpoint that just returned unparseable JSON is the least
+  // likely to return parseable JSON to the same prompt. Retrying it changes
+  // nothing but the wall-clock. Deny it on the next attempt so routing picks a
+  // different endpoint — live repro FB-62D7C0EC, where both attempts drew the
+  // local model, both truncated mid-array, and the build was lost while a
+  // capable endpoint sat unused.
+  let deniedProviders: string[] = [];
   for (let attempt = 1; attempt <= PLAN_GEN_MAX_ATTEMPTS && !planObj; attempt++) {
+    const denial = denialForNextAttempt(deniedProviders);
     const systemPrompt =
       attempt === 1
         ? "You are a senior software engineer creating a precise, actionable implementation plan. Respond with ONLY valid JSON."
@@ -214,7 +223,16 @@ async function generateNormalizedPlan(args: {
       [{ role: "user" as const, content: prompt }],
       systemPrompt,
       "internal",
-      { budgetClass: "quality_first", ...(args.modelTier ? { modelTier: args.modelTier } : {}), ...(args.buildId ? { buildId: args.buildId } : {}) },
+      {
+        budgetClass: "quality_first",
+        ...(args.modelTier ? { modelTier: args.modelTier } : {}),
+        ...(args.buildId ? { buildId: args.buildId } : {}),
+        // Empty on the first attempt; carries the endpoints that already failed
+        // to produce parseable JSON on later ones. If every endpoint is denied,
+        // routing falls back rather than refusing — the platform must stay
+        // runnable (BI-3B3F477B).
+        ...(denial ? { deniedProviders: denial } : {}),
+      },
     );
     planObj = parsePlanJson(response.content);
     if (!planObj) {
@@ -232,9 +250,10 @@ async function generateNormalizedPlan(args: {
       const raw = (response.content ?? "").trim();
       await args.log(
         raw.length === 0
-          ? "Plan output excerpt: the model returned no output at all."
-          : `Plan output excerpt (${raw.length} chars): ${excerptHeadAndTail(raw)}`,
+          ? `Plan output excerpt (${response.providerId}): the model returned no output at all.`
+          : `Plan output excerpt (${response.providerId}, ${raw.length} chars): ${excerptHeadAndTail(raw)}`,
       );
+      deniedProviders = denyAfterUnparseable(deniedProviders, response.providerId);
     }
   }
 


### PR DESCRIPTION
## Problem

Plan generation gets two attempts. Both went to whatever routing picked first, so an endpoint that returned unparseable JSON was asked the same question again — and returned unparseable JSON again. **That is not a retry, it is a repetition with a different system prompt.**

Live repro `FB-62D7C0EC` on the Pet Rescue install:

```
02:31:58  plan generated: 10 tasks (schema, migration, APIs, page, UI)
02:34     Plan review: FAIL — 5 critical issues + architecture advisory
02:35:27  Plan generation attempt 2/2 returned unparseable JSON
02:35:27  Plan revision round 1 failed: unparseable JSON after 2 attempts
```

Both attempts drew the local model, both truncated mid-array, and the build was lost along with a review that had named five concrete defects — while **codex**, the endpoint that produced every successful design document on this install (129.9s, 124.3s, 153.6s) *and the first plan for this very build*, sat unused.

Measured on this install: **codex 3/3, local 0/3.** The failure is specific — the local model returns clean JSON on short prompts and truncates on long ones.

## Change

The endpoint that just failed to close a JSON array is the least likely endpoint to close it on the next ask. Record it and deny it for the following attempt so routing picks a different one.

The denial is **advisory, not a refusal**:
- passed through the existing `deniedProviders` routing option — nothing new invented
- the first attempt carries no denial, so preferred routing is unchanged
- if every endpoint ends up denied, routing falls back rather than refusing — the platform must stay runnable on whatever hardware it has (BI-3B3F477B)

The failure log now names the endpoint alongside the excerpt added in #4742, so "unparseable JSON" finally says *which* endpoint produced *what*.

## Verification

- `lib/build`: **184 files / 2038 tests pass**; new pure module has 9 tests of its own.
- `pnpm --filter web typecheck` clean; guard loop 37/37; Build Studio surface ratchet OK; module-size clean.
- **`pnpm --filter web build` passes** (this worktree has real dependencies, so the production build actually runs).
- **`pnpm run pregate` passed** — full local CI-equivalent gate, evidence `cmtb53mve02sk01mrqq8lnpj3`.

Refs: BI-7AD0759A, BI-E492F313, BI-3B3F477B