### PR TITLE
feat(marketing): give the marketing coworker a proactivity family (BI-C26FE785)

### DIFF
--- a/apps/web/lib/marketing/scheduler.test.ts
+++ b/apps/web/lib/marketing/scheduler.test.ts
@@ -160,6 +160,67 @@ describe("planUpcomingForAssetTasks", () => {
     expect(result.skipped).toBe(1);
   });
 
+  it("suppresses planning entirely under a quiet marketing posture (BI-C26FE785)", async () => {
+    const result = await planUpcomingForAssetTasks({
+      organizationId: "org-1",
+      proactivity: { level: "quiet", policyId: "proactivity:marketing-campaign:quiet" },
+    });
+
+    expect(result.scheduled).toBe(0);
+    expect(result.suppressedByPosture).toBe(true);
+    // Quiet must not even read the task list: planning then staying silent would
+    // still spend budget and fill the outbound queue behind the owner's back.
+    expect(vi.mocked(prisma.marketingAssetTask.findMany)).not.toHaveBeenCalled();
+  });
+
+  it("starts creative earlier under an assertive marketing posture (BI-C26FE785)", async () => {
+    const createdAt = new Date(Date.now() - 60 * 60 * 1000);
+    vi.mocked(prisma.marketingAssetTask.findMany).mockResolvedValue([
+      { taskId: "task-1", dueWindow: "week 5", createdAt },
+    ] as never);
+    vi.mocked(prisma.scheduledOutboundAction.findFirst).mockResolvedValue(null as never);
+    vi.mocked(prisma.scheduledOutboundAction.create).mockResolvedValue({ scheduleId: "s-1" } as never);
+
+    const result = await planUpcomingForAssetTasks({
+      organizationId: "org-1",
+      proactivity: { level: "assertive", policyId: "proactivity:marketing-campaign:assertive" },
+    });
+
+    expect(result.scheduled).toBe(1);
+    expect(result.advanceDays).toBe(6);
+    // The persisted note must state the lead time actually used, not the constant.
+    const created = vi.mocked(prisma.scheduledOutboundAction.create).mock.calls[0]?.[0] as
+      | { data?: { notes?: string } }
+      | undefined;
+    expect(created?.data?.notes).toContain("Auto-planned 6 days");
+  });
+
+  it("never schedules less under assertive than under balanced (BI-C26FE785 regression)", async () => {
+    // "week 1" resolves to createdAt itself. Created 4 days ago, so balanced
+    // (3-day lead) still lands in the future, but a naive assertive 6-day lead
+    // would land in the past and skip the task — assertive doing LESS work.
+    const createdAt = new Date(Date.now() + 4 * 24 * 60 * 60 * 1000);
+    const task = [{ taskId: "task-1", dueWindow: "week 1", createdAt }] as never;
+
+    vi.mocked(prisma.scheduledOutboundAction.findFirst).mockResolvedValue(null as never);
+    vi.mocked(prisma.scheduledOutboundAction.create).mockResolvedValue({ scheduleId: "s-1" } as never);
+
+    vi.mocked(prisma.marketingAssetTask.findMany).mockResolvedValue(task);
+    const balanced = await planUpcomingForAssetTasks({
+      organizationId: "org-1",
+      proactivity: { level: "balanced", policyId: "proactivity:marketing-campaign:balanced" },
+    });
+
+    vi.mocked(prisma.marketingAssetTask.findMany).mockResolvedValue(task);
+    const assertive = await planUpcomingForAssetTasks({
+      organizationId: "org-1",
+      proactivity: { level: "assertive", policyId: "proactivity:marketing-campaign:assertive" },
+    });
+
+    expect(balanced.scheduled).toBe(1);
+    expect(assertive.scheduled).toBeGreaterThanOrEqual(balanced.scheduled);
+  });
+
   it("skips tasks whose computed schedule date is in the past", async () => {
     const createdAt = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000); // 8 days ago
     // "week 1" → createdAt itself → schedule = createdAt - 3 days → past

--- a/apps/web/lib/marketing/scheduler.ts
+++ b/apps/web/lib/marketing/scheduler.ts
@@ -17,6 +17,7 @@ import {
   type ScheduledActionStatus,
 } from "./execution";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
 
 const ADVANCE_DAYS_FOR_DUE_WINDOW = 3;
 
@@ -155,7 +156,25 @@ async function dispatchAction(kind: ScheduledActionKind, targetId: string): Prom
  */
 export async function planUpcomingForAssetTasks(input: {
   organizationId: string;
-}): Promise<{ scheduled: number; skipped: number }> {
+  /**
+   * Resolved marketing-campaign proactivity posture (BI-C26FE785). Omitted by
+   * callers that are not cadence-driven, which keeps the pre-posture behaviour.
+   */
+  proactivity?: { level: ProactivityLevel; policyId: string } | null;
+}): Promise<{
+  scheduled: number;
+  skipped: number;
+  advanceDays?: number;
+  suppressedByPosture?: boolean;
+}> {
+  // Quiet means exactly that: produce marketing when asked and never volunteer
+  // it. Planning drafter runs anyway and merely staying silent about them would
+  // still spend model budget and fill the outbound queue behind the owner's
+  // back, so quiet suppresses the planning itself rather than its output.
+  if (input.proactivity?.level === "quiet") {
+    return { scheduled: 0, skipped: 0, suppressedByPosture: true };
+  }
+
   const tasks = await prisma.marketingAssetTask.findMany({
     where: { organizationId: input.organizationId },
     orderBy: { createdAt: "desc" },
@@ -163,7 +182,13 @@ export async function planUpcomingForAssetTasks(input: {
   });
   let scheduled = 0;
   let skipped = 0;
-  const advanceMs = ADVANCE_DAYS_FOR_DUE_WINDOW * 24 * 60 * 60 * 1000;
+  // An assertive posture starts creative earlier so a dated campaign has slack
+  // to be reviewed and redone; balanced keeps the standard lead time.
+  const advanceDays =
+    input.proactivity?.level === "assertive"
+      ? ADVANCE_DAYS_FOR_DUE_WINDOW * 2
+      : ADVANCE_DAYS_FOR_DUE_WINDOW;
+  const advanceMs = advanceDays * 24 * 60 * 60 * 1000;
 
   for (const task of tasks) {
     if (!task.dueWindow) {
@@ -175,7 +200,15 @@ export async function planUpcomingForAssetTasks(input: {
       skipped++;
       continue;
     }
-    const scheduledFor = new Date(dueDate.getTime() - advanceMs);
+    // A longer assertive lead time must never make the coworker do LESS. Taken
+    // naively, doubling the advance pushes the run further into the past and
+    // skips tasks a balanced posture would have scheduled — the opposite of
+    // what assertive means. So fall back to the standard lead time before
+    // giving up, and only skip when even that lands in the past.
+    let scheduledFor = new Date(dueDate.getTime() - advanceMs);
+    if (scheduledFor.getTime() < Date.now() && advanceDays !== ADVANCE_DAYS_FOR_DUE_WINDOW) {
+      scheduledFor = new Date(dueDate.getTime() - ADVANCE_DAYS_FOR_DUE_WINDOW * 24 * 60 * 60 * 1000);
+    }
     if (scheduledFor.getTime() < Date.now()) {
       skipped++;
       continue;
@@ -198,13 +231,13 @@ export async function planUpcomingForAssetTasks(input: {
         kind: "draft-marketing-asset",
         targetId: task.taskId,
         scheduledFor,
-        notes: `Auto-planned ${ADVANCE_DAYS_FOR_DUE_WINDOW} days before due window: ${task.dueWindow}`,
+        notes: `Auto-planned ${Math.round((dueDate.getTime() - scheduledFor.getTime()) / (24 * 60 * 60 * 1000))} days before due window: ${task.dueWindow}`,
       },
     });
     scheduled++;
   }
 
-  return { scheduled, skipped };
+  return { scheduled, skipped, advanceDays };
 }
 
 /**

--- a/apps/web/lib/mcp/marketing-cadence-handler.ts
+++ b/apps/web/lib/mcp/marketing-cadence-handler.ts
@@ -1,6 +1,9 @@
 // Marketing cadence handler (BI-C26FE785), extracted from marketing-ops-pack.ts
-// to keep that pack under the module-size ceiling. Follows the same
-// one-handler-per-sibling shape as backlog-update-item-handler.ts.
+// to keep that pack under the module-size ceiling. Lives beside the other
+// lib/mcp/*-handler(s).ts modules (build-design-review-handler,
+// deliberation-handlers) rather than inside packs/, so it does not inflate the
+// tool-surface pack count with a file that defines no tools. Follows the same
+// one-handler-per-module shape as those siblings.
 //
 // This is the seam where the marketing-campaign proactivity posture becomes an
 // actual scheduling decision. The boundary it honours: cadence only. Deciding

--- a/apps/web/lib/mcp/packs/marketing-cadence-handler.ts
+++ b/apps/web/lib/mcp/packs/marketing-cadence-handler.ts
@@ -1,0 +1,58 @@
+// Marketing cadence handler (BI-C26FE785), extracted from marketing-ops-pack.ts
+// to keep that pack under the module-size ceiling. Follows the same
+// one-handler-per-sibling shape as backlog-update-item-handler.ts.
+//
+// This is the seam where the marketing-campaign proactivity posture becomes an
+// actual scheduling decision. The boundary it honours: cadence only. Deciding
+// WHEN to prepare creative is the coworker's call; publishing it is not. Drafts
+// planned here still land in the approval queue at pending-review, per
+// docs/superpowers/specs/2026-05-26-marketing-execution-loop-design.md.
+
+import type { ToolResult } from "@/lib/mcp-tools";
+
+export type MarketingToolContext = {
+  agentId?: string | null;
+  routeContext?: string | null;
+};
+
+export async function planUpcomingMarketingDraftsHandler(
+  _params: Record<string, unknown>,
+  _userId: string,
+  context?: MarketingToolContext,
+): Promise<ToolResult> {
+  const { planUpcomingForAssetTasks } = await import("@/lib/marketing/scheduler");
+  const { resolveProactivityPlan } = await import("@/lib/proactivity/proactivity-resolver");
+  const { prisma } = await import("@dpf/db");
+
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) {
+    return { success: false, message: "No organization configured.", error: "no_org" };
+  }
+
+  const plan = resolveProactivityPlan({
+    activityFamily: "marketing-campaign",
+    agentId: context?.agentId ?? null,
+    routeContext: context?.routeContext ?? null,
+  });
+
+  const result = await planUpcomingForAssetTasks({
+    organizationId: org.id,
+    proactivity: { level: plan.resolvedLevel, policyId: plan.policyId },
+  });
+
+  const proactivity = { level: plan.resolvedLevel, policyId: plan.policyId };
+
+  if (result.suppressedByPosture) {
+    return {
+      success: true,
+      message: `No drafter runs planned — marketing proactivity is set to quiet, so campaign work is prepared only when you ask. ${plan.explanation}`,
+      data: { ...result, proactivity },
+    };
+  }
+
+  return {
+    success: true,
+    message: `Scheduled ${result.scheduled} drafter run${result.scheduled === 1 ? "" : "s"} ${result.advanceDays} days ahead of their due windows; skipped ${result.skipped}. Drafts go to the approval queue, not out.`,
+    data: { ...result, proactivity },
+  };
+}

--- a/apps/web/lib/mcp/packs/marketing-ops-pack.ts
+++ b/apps/web/lib/mcp/packs/marketing-ops-pack.ts
@@ -25,6 +25,7 @@ import {
   recordMarketingStrategistReview,
 } from "@/lib/marketing";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import { planUpcomingMarketingDraftsHandler } from "./marketing-cadence-handler";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
 
 const definitions: ToolDefinition[] = [
@@ -533,49 +534,6 @@ async function tickMarketingSchedulerHandler(): Promise<ToolResult> {
     success: true,
     message: `Scheduler tick: scanned ${result.pendingScanned}, fired ${result.fired}, failed ${result.failed}.`,
     data: result,
-  };
-}
-
-async function planUpcomingMarketingDraftsHandler(
-  _params: Record<string, unknown>,
-  _userId: string,
-  context?: { agentId?: string | null; routeContext?: string | null },
-): Promise<ToolResult> {
-  const { planUpcomingForAssetTasks } = await import("@/lib/marketing/scheduler");
-  const { resolveProactivityPlan } = await import("@/lib/proactivity/proactivity-resolver");
-  const { prisma } = await import("@dpf/db");
-  const org = await prisma.organization.findFirst({ select: { id: true } });
-  if (!org) {
-    return { success: false, message: "No organization configured.", error: "no_org" };
-  }
-
-  // BI-C26FE785: this is the marketing cadence decision, so it runs under the
-  // marketing-campaign posture rather than a fixed lead time. The boundary is
-  // cadence only — nothing here publishes; drafts still land in the approval
-  // queue at pending-review.
-  const plan = resolveProactivityPlan({
-    activityFamily: "marketing-campaign",
-    agentId: context?.agentId ?? null,
-    routeContext: context?.routeContext ?? null,
-  });
-
-  const result = await planUpcomingForAssetTasks({
-    organizationId: org.id,
-    proactivity: { level: plan.resolvedLevel, policyId: plan.policyId },
-  });
-
-  if (result.suppressedByPosture) {
-    return {
-      success: true,
-      message: `No drafter runs planned — marketing proactivity is set to quiet, so campaign work is prepared only when you ask. ${plan.explanation}`,
-      data: { ...result, proactivity: { level: plan.resolvedLevel, policyId: plan.policyId } },
-    };
-  }
-
-  return {
-    success: true,
-    message: `Scheduled ${result.scheduled} drafter run${result.scheduled === 1 ? "" : "s"} ${result.advanceDays} days ahead of their due windows; skipped ${result.skipped}. Drafts go to the approval queue, not out.`,
-    data: { ...result, proactivity: { level: plan.resolvedLevel, policyId: plan.policyId } },
   };
 }
 

--- a/apps/web/lib/mcp/packs/marketing-ops-pack.ts
+++ b/apps/web/lib/mcp/packs/marketing-ops-pack.ts
@@ -25,7 +25,7 @@ import {
   recordMarketingStrategistReview,
 } from "@/lib/marketing";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
-import { planUpcomingMarketingDraftsHandler } from "./marketing-cadence-handler";
+import { planUpcomingMarketingDraftsHandler } from "../marketing-cadence-handler";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
 
 const definitions: ToolDefinition[] = [

--- a/apps/web/lib/mcp/packs/marketing-ops-pack.ts
+++ b/apps/web/lib/mcp/packs/marketing-ops-pack.ts
@@ -536,18 +536,46 @@ async function tickMarketingSchedulerHandler(): Promise<ToolResult> {
   };
 }
 
-async function planUpcomingMarketingDraftsHandler(): Promise<ToolResult> {
+async function planUpcomingMarketingDraftsHandler(
+  _params: Record<string, unknown>,
+  _userId: string,
+  context?: { agentId?: string | null; routeContext?: string | null },
+): Promise<ToolResult> {
   const { planUpcomingForAssetTasks } = await import("@/lib/marketing/scheduler");
+  const { resolveProactivityPlan } = await import("@/lib/proactivity/proactivity-resolver");
   const { prisma } = await import("@dpf/db");
   const org = await prisma.organization.findFirst({ select: { id: true } });
   if (!org) {
     return { success: false, message: "No organization configured.", error: "no_org" };
   }
-  const result = await planUpcomingForAssetTasks({ organizationId: org.id });
+
+  // BI-C26FE785: this is the marketing cadence decision, so it runs under the
+  // marketing-campaign posture rather than a fixed lead time. The boundary is
+  // cadence only — nothing here publishes; drafts still land in the approval
+  // queue at pending-review.
+  const plan = resolveProactivityPlan({
+    activityFamily: "marketing-campaign",
+    agentId: context?.agentId ?? null,
+    routeContext: context?.routeContext ?? null,
+  });
+
+  const result = await planUpcomingForAssetTasks({
+    organizationId: org.id,
+    proactivity: { level: plan.resolvedLevel, policyId: plan.policyId },
+  });
+
+  if (result.suppressedByPosture) {
+    return {
+      success: true,
+      message: `No drafter runs planned — marketing proactivity is set to quiet, so campaign work is prepared only when you ask. ${plan.explanation}`,
+      data: { ...result, proactivity: { level: plan.resolvedLevel, policyId: plan.policyId } },
+    };
+  }
+
   return {
     success: true,
-    message: `Scheduled ${result.scheduled} drafter run${result.scheduled === 1 ? "" : "s"}; skipped ${result.skipped}.`,
-    data: result,
+    message: `Scheduled ${result.scheduled} drafter run${result.scheduled === 1 ? "" : "s"} ${result.advanceDays} days ahead of their due windows; skipped ${result.skipped}. Drafts go to the approval queue, not out.`,
+    data: { ...result, proactivity: { level: plan.resolvedLevel, policyId: plan.policyId } },
   };
 }
 
@@ -754,7 +782,8 @@ const handlers: Record<string, ToolPackHandler> = {
   place_linkedin_ad: (params, userId) => publishApprovedDraftHandler(params, userId),
   refresh_channel_kpis: (params) => refreshChannelKpisHandler(params),
   tick_marketing_scheduler: () => tickMarketingSchedulerHandler(),
-  plan_upcoming_marketing_drafts: () => planUpcomingMarketingDraftsHandler(),
+  plan_upcoming_marketing_drafts: (params, userId, context) =>
+    planUpcomingMarketingDraftsHandler(params, userId, context),
   set_marketing_autopilot_policy: (params, userId) => setMarketingAutopilotPolicyHandler(params, userId),
   draft_marketing_asset: (params, userId, context) => draftMarketingAssetHandler(params, userId, context),
   record_marketing_kpi_checkpoint: (params, userId, context) => recordMarketingKpiCheckpointHandler(params, userId, context),

--- a/apps/web/lib/proactivity/proactivity-resolver.test.ts
+++ b/apps/web/lib/proactivity/proactivity-resolver.test.ts
@@ -183,3 +183,59 @@ describe("resolveUserAwareProactivityPlan", () => {
     expect(plan.evidenceRefs).toContainEqual({ kind: "user-fact", id: "cooldown-family" });
   });
 });
+
+describe("marketing-campaign proactivity (BI-C26FE785)", () => {
+  it("is a real family the resolver knows, not a declared-but-unwired enum entry", () => {
+    expect(PROACTIVITY_ACTIVITY_FAMILIES).toContain("marketing-campaign");
+
+    const plan = resolveProactivityPlan({ activityFamily: "marketing-campaign" });
+
+    expect(plan.policyId).toBe("proactivity:marketing-campaign:balanced");
+    expect(plan.evidenceRefs).toContainEqual({ kind: "activity-family", id: "marketing-campaign" });
+  });
+
+  it("produces campaign work on a steady cadence by default", () => {
+    const plan = resolveProactivityPlan({ activityFamily: "marketing-campaign" });
+
+    expect(plan.resolvedLevel).toBe("balanced");
+    expect(plan.explanation).toContain("steady cadence");
+  });
+
+  it("raises the work sooner only when a committed campaign date is within three days", () => {
+    const near = resolveProactivityPlan({ activityFamily: "marketing-campaign", deadlineWindowDays: 2 });
+    const far = resolveProactivityPlan({ activityFamily: "marketing-campaign", deadlineWindowDays: 10 });
+
+    expect(near.resolvedLevel).toBe("assertive");
+    expect(far.resolvedLevel).toBe("balanced");
+  });
+
+  it("never grants a preauthorized boundary at any level, so marketing cannot publish or spend on its own", () => {
+    for (const level of PROACTIVITY_LEVELS) {
+      const plan = resolveProactivityPlanForLevel({ activityFamily: "marketing-campaign" }, level);
+      expect(plan.actionBoundary).not.toBe("preauthorized");
+    }
+  });
+
+  it("keeps marketing off the urgent channel even when assertive", () => {
+    const plan = resolveProactivityPlanForLevel({ activityFamily: "marketing-campaign" }, "assertive");
+
+    // Contrast: security-incident is what the urgent channel exists for.
+    const incident = resolveProactivityPlanForLevel({ activityFamily: "security-incident" }, "assertive");
+
+    expect(plan.channelPolicy).toBe("preferred-channel");
+    expect(incident.channelPolicy).toBe("urgent-channel");
+  });
+
+  it("escalates an unanswered campaign nudge to the owner, not the attention surface", () => {
+    const plan = resolveProactivityPlan({ activityFamily: "marketing-campaign" });
+
+    expect(plan.escalationTarget).toBe("owner");
+  });
+
+  it("explains quiet as produce-only-when-asked so the owner can predict the behaviour", () => {
+    const plan = resolveProactivityPlanForLevel({ activityFamily: "marketing-campaign" }, "quiet");
+
+    expect(plan.explanation).toContain("only when asked");
+    expect(plan.actionBoundary).toBe("advise");
+  });
+});

--- a/apps/web/lib/proactivity/proactivity-resolver.ts
+++ b/apps/web/lib/proactivity/proactivity-resolver.ts
@@ -73,6 +73,26 @@ export function resolveProactivityPlanForLevel(
     defaults.escalationTarget = "platform-operator";
   }
 
+  if (input.activityFamily === "marketing-campaign") {
+    // Cadence only — the same boundary crm-record-enrichment draws (BI-B2497DFB).
+    // Marketing may decide WHEN to raise creative work; it may never be the thing
+    // that publishes it or spends against it. The posture ladder only ever
+    // tightens (tightenActionBoundary picks the more restrictive of the two), so
+    // capping the boundary at "propose" here makes it a real ceiling: no room
+    // declaration, workroom default or agent preference downstream can loosen it
+    // back to "preauthorized" and let an assertive posture push an unreviewed
+    // asset to a public channel.
+    if (defaults.actionBoundary === "preauthorized") defaults.actionBoundary = "propose";
+    // Marketing spend and brand voice are the owner's call, not a queue's — an
+    // unanswered campaign nudge should reach the person accountable for the
+    // brand rather than settling on the attention surface.
+    defaults.escalationTarget = "owner";
+    // Even a missed campaign date does not earn the urgent channel. That channel
+    // is for outages and compliance; spending it on marketing trains the owner
+    // to ignore it, which costs more than the missed post.
+    if (defaults.channelPolicy === "urgent-channel") defaults.channelPolicy = "preferred-channel";
+  }
+
   if (input.regulated || input.activityFamily === "tax-compliance") {
     defaults.actionBoundary = input.regulated ? "advise" : "propose";
     defaults.spendClass = level === "assertive" ? "standard" : defaults.spendClass;
@@ -124,6 +144,17 @@ function resolveLevel(input: ProactivityResolverInput): ProactivityLevel {
     return typeof input.deadlineWindowDays === "number" && input.deadlineWindowDays <= 7 ? "assertive" : "balanced";
   }
 
+  if (input.activityFamily === "marketing-campaign") {
+    // A campaign with a committed date close enough to miss is worth warning
+    // about; routine creative production never is. Marketing that nags is the
+    // fastest way to get a coworker muted, so the assertive door is deliberately
+    // narrow — only a dated commitment opens it. Three days rather than
+    // tax-compliance's seven: an asset can be produced in a day, a filing cannot.
+    return typeof input.deadlineWindowDays === "number" && input.deadlineWindowDays <= 3
+      ? "assertive"
+      : "balanced";
+  }
+
   if (input.activityFamily === "security-incident") return "assertive";
 
   return "balanced";
@@ -157,6 +188,16 @@ function explanationFor(input: ProactivityResolverInput, level: ProactivityLevel
 
   if (input.activityFamily === "tax-compliance" && level === "assertive") {
     return "A compliance deadline is close enough to justify assertive reminders while keeping advice and filing approval-gated.";
+  }
+
+  if (input.activityFamily === "marketing-campaign") {
+    if (level === "quiet") {
+      return "Quiet: produce marketing only when asked, and never volunteer campaign work.";
+    }
+    if (level === "assertive") {
+      return "A committed campaign date is close, so the coworker should raise the work sooner — still as a proposal, and never on the urgent channel.";
+    }
+    return "Campaign and creative work is prepared on a steady cadence and offered for review; publishing and spending stay with you.";
   }
 
   if (input.activityFamily === "crm-record-enrichment") {

--- a/apps/web/lib/proactivity/proactivity-types.ts
+++ b/apps/web/lib/proactivity/proactivity-types.ts
@@ -20,6 +20,14 @@ export const PROACTIVITY_ACTIVITY_FAMILIES = [
   // enrich from public sources (permission + scope confirmed). Cadence only;
   // the write still routes through the governed apply step.
   "crm-record-enrichment",
+  // BI-C26FE785: campaign production and creative review cadence. Without this
+  // family the marketing coworker could not be described to the resolver at
+  // all, so no posture could govern it and it never acted unprompted.
+  // Deliberately NOT folded into "customer-communication": that names
+  // transactional outbound to a specific customer (a reply, a receipt), which
+  // carries a different cadence and a different approval boundary from
+  // producing campaign creative nobody asked for yet.
+  "marketing-campaign",
 ] as const;
 export type ProactivityActivityFamily = (typeof PROACTIVITY_ACTIVITY_FAMILIES)[number];
 

--- a/docs/architecture/2026-06-09-long-running-agentic-process-architecture.md
+++ b/docs/architecture/2026-06-09-long-running-agentic-process-architecture.md
@@ -260,6 +260,10 @@ Already two-thirds there (`ScheduledOutboundAction` + `tickScheduler`). To make 
 - **Measure → optimize loop** is an evaluator-optimizer workflow (Anthropic pattern): pull KPIs, evaluate against targets, propose the next round of assets back into `draft`.
 - **Operator experience** — reuse the generalized process graph, gate panel, and evidence timeline rather than building a separate marketing console; the pre-publish gate *is* `DecisionPerspectiveGatePanel`, and measure→optimize renders as KPI cards feeding the next `draft`. This instance is the proof that the §3.2 experience layer actually generalizes.
 
+**Cadence is now posture-driven (BI-C26FE785, 2026-08-26).** `planUpcomingForAssetTasks()` previously scheduled every drafter run at a fixed `ADVANCE_DAYS_FOR_DUE_WINDOW = 3`. It now takes the resolved `marketing-campaign` proactivity posture and varies the lead time with it: `quiet` suppresses planning outright (planning-then-staying-silent would still spend model budget and fill the outbound queue behind the operator's back), `balanced` keeps the standard lead time, and `assertive` starts creative earlier — falling back to the standard lead time rather than skipping when the longer one would land in the past, so a more assertive posture can never schedule *less* work than a calmer one.
+
+This matters for the DAP framing above because it makes the `brief → draft` transition a governed decision rather than a constant. The HITL gate is unchanged and now doubly enforced: the resolver caps `marketing-campaign` at an `actionBoundary` of `propose` for every level, and because the posture ladder only ever tightens, no room declaration or operator preference downstream can loosen it to `preauthorized`. Publishing therefore remains reachable only through the approval queue, which is the non-bypassable boundary this section already required.
+
 ### 7.3 Monthly financial close / "balancing the books"
 
 The highest-stakes instance, and the one where durability + auditability + idempotency matter most. The finance skills already exist (`finance:close-management`, `finance:reconciliation`, `finance:journal-entry`, `finance:financial-statements`).


### PR DESCRIPTION
Closes BI-C26FE785. Part of EP-45030CFF (marketing coworker produces work).

## The defect

`PROACTIVITY_ACTIVITY_FAMILIES` is a **closed enum of 14** families — `interactive-chat`, `tax-compliance`, `finance-close`, `security-incident`, `queue-health`, `crm-record-enrichment` and eight more. **Marketing was not one of them.**

Marketing work therefore could not be described to the resolver at all, so no posture could govern it and the coworker never acted unprompted. Measured on the live install: 0 campaigns, 0 briefs, 0 asset tasks, 0 variants, 0 reviews since install; 2 of 428 `AgentThread` rows carried a marketing context.

The proactivity module itself is complete and well-formed — resolver, delegated posture, override preferences, roster, escalation, and the full ladder in `work-posture/resolve.ts`. Marketing simply was not expressible in it.

## The approach

Follows the `crm-record-enrichment` precedent (BI-B2497DFB) exactly: family in the enum, a branch in the resolver, and `activityFamily` threaded through the pack that actually produces the cadence.

Deliberately **not** folded into the existing `customer-communication` family, which names transactional outbound to one specific customer (a reply, a receipt) and carries a different cadence and approval boundary from producing campaign creative nobody asked for yet.

## Three rules that make the boundary real

- **The action boundary is capped at `propose` at every level.** `BOUNDARY_RANK` is `preauthorized: 0 → propose: 1 → advise: 2` and `tightenActionBoundary` uses `pickHigher`, so the ladder only ever restricts. Capping here is a genuine ceiling: no room declaration, workroom default or agent preference downstream can loosen it back to `preauthorized` and let an assertive posture push unreviewed creative to a public channel. This is the marketing-execution-loop spec's own constraint — *"No autopilot policy can approve ad spend, inbound customer replies, public profile changes"* — enforced a layer earlier.
- **Marketing never takes the urgent channel**, even when assertive. That channel is for outages and compliance; spending it on marketing trains the operator to ignore it, which costs more than the missed post.
- **Assertive is reachable only via a committed campaign date within three days**, not by routine production. Three rather than tax-compliance's seven: an asset can be produced in a day, a filing cannot. Marketing that nags gets muted.

## Wired, not just declared

`customer-communication`, `finance-close` and `technology-debt` each have exactly **one** reference in the codebase — their own declaration. They were added and never wired. This one is produced and consumed:

`plan_upcoming_marketing_drafts` resolves the `marketing-campaign` posture and passes it to `planUpcomingForAssetTasks`, where `quiet` suppresses planning outright and `assertive` starts creative earlier.

Quiet suppresses the **planning**, not just its output — planning drafter runs and staying silent would still spend model budget and fill the outbound queue behind the operator's back.

## A bug caught in review of my own change

Taken naively, doubling the lead time under an assertive posture pushes `scheduledFor` further into the past, so assertive would **skip** tasks a balanced posture schedules — assertive doing *less* work. Fixed with a fallback to the standard lead time, and pinned by a regression test that fails without it.

## Two follow-on commits

Preflight guards caught two real problems, both fixed without loosening a baseline:

- Adding the handler pushed `marketing-ops-pack.ts` to 817 LOC against an 800 ceiling, taking the production hotspot count 65→66. Extracted to `lib/mcp/marketing-cadence-handler.ts`, beside the eight existing `lib/mcp/*-handler(s).ts` siblings rather than under `packs/` — every file there counts toward the tool-surface pack metric whether or not it defines tools, and this one defines none (`registry.toolDefinitions` unchanged at 405).
- The Docs Impact gate correctly flagged that the scheduler's lead time stopped being a constant. Updated §7.2 of the long-running-agentic-process architecture doc rather than attesting it away.

## Not in scope

Marketing has no work-case source type, so marketing rooms do not exist and `activityFamilyForSource` has nothing to map. That is the remaining half of BI-C26FE785 and touches the source registry — a separate concern.

## Verification

- **local-CI gate: PASS** at `aa544f733ae5` (evidence `cmtb8yo2901mi01qieafby9qq`)
- `pregate:preflight`: **52 guards clean**
- 426 tests across `lib/proactivity`, `lib/marketing`, the marketing packs and `lib/work-posture` — 10 new
- Production build exit 0; style-drift and module-size guards clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
