### PR TITLE
fix(build-studio): waiting on the owner is not the platform going quiet (BI-C35F1FED)

### DIFF
--- a/apps/web/components/build/build-studio-custodian.test.ts
+++ b/apps/web/components/build/build-studio-custodian.test.ts
@@ -106,6 +106,45 @@ function progress(overrides: Partial<BuildProgressVisibility> = {}): BuildProgre
 }
 
 describe("deriveBuildStudioCustodianPrompt", () => {
+  // BI-C35F1FED — live repro FB-05946F96: "Start a new outcome" produced a build
+  // awaiting approval; ten minutes later the quiet detector replaced the
+  // approve-start CTA with "Build Studio may be stuck — review the current step
+  // and resume it if needed", leaving no control that could start the work.
+  it("stays silent while the build is waiting on the owner to approve the start", () => {
+    const build = makeBuild({
+      phase: "ideate",
+      draftApprovedAt: null,
+      // Approval is only managed for a build that came from a backlog row —
+      // which is exactly what "Start a new outcome" creates.
+      originator: {
+        id: "backlog-row-1",
+        itemId: "BI-5C3F3433",
+        title: "Show the animals waiting longest for adoption",
+        status: "in-progress",
+        triageOutcome: "build",
+        effortSize: "medium",
+        proposedOutcome: null,
+        activeBuildId: "build-row-1",
+        resolution: null,
+        abandonReason: null,
+      },
+    });
+    const action = deriveBuildStudioWorkflowAction({ build, governedBacklogEnabled: true });
+    expect(action.kind).toBe("approve-start");
+
+    const prompt = deriveBuildStudioCustodianPrompt({
+      build,
+      action,
+      // Well past the early-phase quiet threshold — the owner simply has not
+      // clicked yet, which is not the platform going quiet.
+      progressVisibility: progress({
+        quietAgent: { quiet: true, minutesQuiet: 45, lastObservableSignalAt: "2026-06-29T11:35:00.000Z" },
+      }),
+    });
+
+    expect(prompt).toBeNull();
+  });
+
   it("surfaces proactive help when UX verification failed and the next click would feel inert", () => {
     const build = makeBuild({ uxVerificationStatus: "failed" });
     const action = deriveBuildStudioWorkflowAction({ build, governedBacklogEnabled: true });

--- a/apps/web/components/build/build-studio-custodian.ts
+++ b/apps/web/components/build/build-studio-custodian.ts
@@ -1,6 +1,7 @@
 import type { BuildProgressVisibility } from "@/lib/build/progress-visibility";
 import type { FeatureBuildRow } from "@/lib/feature-build-types";
 import type { Intent } from "@/components/ui/report-kit";
+import { isAwaitingOwnerDecision } from "@/lib/build/owner-decision-pending";
 import { resolveProactivityPlan } from "@/lib/proactivity/proactivity-resolver";
 import type { ProactivityPlan, ProactivityResolverInput } from "@/lib/proactivity/proactivity-types";
 import {
@@ -124,8 +125,7 @@ export function hasNoReleasableDiff(
 /**
  * True when the system should surface the empty-diff honest card instead of a
  * generic "gone quiet" state (EP-BS-UX-HARDENING invariant 5 / BI-9C66860E).
- * Mid-coding builds with no patch yet are excluded unless they are quiet or
- * already in review/ship after coding finished.
+ * Mid-coding builds with no patch are excluded unless quiet, or past coding.
  */
 export function isEmptyDiffHonestOutcome(args: {
   build: FeatureBuildRow;
@@ -205,6 +205,7 @@ export function deriveBuildStudioCustodianPrompt({
     (build.phase === "ideate" || build.phase === "plan")
     && progressVisibility?.quietAgent.quiet === true
     && quietMinutes >= QUIET_EARLY_PHASE_THRESHOLD_MINUTES;
+  if (isAwaitingOwnerDecision(action.kind)) return null; // BI-C35F1FED
   const blockedByEvidence = action.disabledReason != null;
   const technicalRecovery =
     action.kind === "resume-implementation"
@@ -428,9 +429,8 @@ export function deriveBuildStudioCustodianPrompt({
     };
   }
 
-  // BI-9C66860E — definitive empty-diff outcome beats generic quiet copy
-  // (EP-BS-UX-HARDENING invariant 5: honest status). Retry/reset/resume kinds
-  // are handled earlier (with workflow CTA); remaining actions use coworker.
+  // BI-9C66860E — a definitive empty-diff outcome beats generic quiet copy
+  // (EP-BS-UX-HARDENING invariant 5). Recovery kinds already returned above.
   if (emptyDiff) {
     return {
       dismissKey: `${dismissKey}:empty-diff`,

--- a/apps/web/lib/build/owner-decision-pending.test.ts
+++ b/apps/web/lib/build/owner-decision-pending.test.ts
@@ -1,0 +1,17 @@
+// BI-C35F1FED — waiting on the owner is not the platform going quiet.
+
+import { describe, expect, it } from "vitest";
+
+import { isAwaitingOwnerDecision } from "./owner-decision-pending";
+
+describe("isAwaitingOwnerDecision", () => {
+  it("recognises a build waiting for the owner to approve the start", () => {
+    expect(isAwaitingOwnerDecision("approve-start")).toBe(true);
+  });
+
+  it("leaves genuine platform stalls to the quiet detector", () => {
+    for (const kind of ["advance-phase", "retry-build", "resume-implementation", "decompose-now"]) {
+      expect(isAwaitingOwnerDecision(kind)).toBe(false);
+    }
+  });
+});

--- a/apps/web/lib/build/owner-decision-pending.ts
+++ b/apps/web/lib/build/owner-decision-pending.ts
@@ -1,0 +1,24 @@
+// apps/web/lib/build/owner-decision-pending.ts
+//
+// BI-C35F1FED — is the platform waiting on the owner?
+//
+// The quiet detector measures whether the PLATFORM has gone quiet. When the
+// next action belongs to the owner, quiet is the expected state and not a
+// fault: the platform has deliberately stopped and handed over a control.
+//
+// Live repro FB-05946F96 on the Pet Rescue install. "Start a new outcome"
+// created a build awaiting approval. Ten minutes later the early-phase quiet
+// threshold fired, the custodian card REPLACED the approve-start CTA, and the
+// owner was told "Build Studio may be stuck — review the current step and
+// resume it if needed" with no control that could do either. The one button
+// that would have started the work disappeared because they had not pressed it
+// quickly enough.
+//
+// Scoped deliberately to approval. Other owner-facing actions can coexist with
+// genuine platform stalls; approval cannot, because until it is given the
+// platform has not started and has nothing to be quiet about.
+
+/** True when the build's next action is the owner's to take, not the platform's. */
+export function isAwaitingOwnerDecision(actionKind: string): boolean {
+  return actionKind === "approve-start";
+}


### PR DESCRIPTION
## The owner's main entry point produced a build that could never begin

**Start a new outcome → Continue → Start governed build.** Live repro `FB-05946F96` on the Pet Rescue install:

```
07:50:33  backlog_row_start_build  draft created from backlog row BI-5C3F3433
          (no further activity, ever — draftApprovedAt stayed null)

panel at +2min:   "Working — Build Studio is working on this change"
panel at +10min:  "Needs attention — Build Studio may be stuck.
                   NEXT: Review the current step and resume it if needed."
```

Every visible control at that point: `Ask AI Coworker to check`, `Show why`, `Snooze`, `Review outcome`, `Review proof`. **No approval affordance anywhere**, in Simple *or* Full mode. Clicking the offered action wrote no activity and changed nothing.

## Cause

The workflow resolver was doing its job — the build is approval-managed, has an originator, and `draftApprovedAt` is null, so it returns `approve-start` with a **Record Approve Start** CTA.

The custodian then overrode it. `isQuietEarlyPhase` fires for an ideate build with no progress signal past the threshold, and its card **replaces** the workflow CTA. The one button that would have started the work disappeared because the owner had not pressed it within ten minutes.

The quiet detector measures whether the **platform** has gone quiet. When the next action belongs to the owner, quiet is the expected state, not a fault — the platform has deliberately stopped and handed over a control. It has not started, and has nothing to be quiet about.

Scoped deliberately to approval: other owner-facing actions can coexist with a genuine platform stall; approval cannot.

The rule lives in `lib/build/owner-decision-pending.ts` because Build Studio's component surface is under a ratchet (BI-101C107C) and this is a decision, not presentation. The component side is one import and one guard, offset by tightening two comments in the same file — **surface stays exactly at baseline**.

## Verification

- `components/build` + `lib/build`: **243 files / 2604 tests pass**.
- New test is confirmed **Red** against `origin/main`, green with the fix.
- `pnpm --filter web typecheck` clean; guard loop 37/37; surface ratchet **OK at baseline**; module-size clean; `pnpm --filter web build` passes.
- **`pnpm run pregate` passed** — full local CI-equivalent gate, evidence `cmtb9utub02gk01qi4kyts250`, gated sha `c8ebf197c691`.

Refs: BI-C35F1FED, BI-CE1AB982