### PR TITLE
feat(marketing): give marketing strategy grounding a write path (BI-06BB96F0)

### DIFF
--- a/apps/web/lib/coworker-lifecycle/capability-completeness.generated.json
+++ b/apps/web/lib/coworker-lifecycle/capability-completeness.generated.json
@@ -9599,7 +9599,7 @@
           "level": 1,
           "directSkills": 0,
           "wildcardSkills": 5,
-          "reachableTools": 129,
+          "reachableTools": 130,
           "heldGrants": [
             "consumer_read",
             "registry_read",
@@ -9613,7 +9613,7 @@
           ],
           "services": 0,
           "unbackedSkillIds": [],
-          "detail": "no skill authored for it (5 wildcard only), 129 reachable tool(s)",
+          "detail": "no skill authored for it (5 wildcard only), 130 reachable tool(s)",
           "levelKey": "declared",
           "ceiling": 3,
           "atCeiling": false
@@ -9655,7 +9655,7 @@
           "plane": "toolsAndSkills",
           "level": 1,
           "ceiling": 3,
-          "detail": "no skill authored for it (5 wildcard only), 129 reachable tool(s)"
+          "detail": "no skill authored for it (5 wildcard only), 130 reachable tool(s)"
         },
         {
           "plane": "evidence",
@@ -12002,7 +12002,7 @@
           "level": 2,
           "directSkills": 7,
           "wildcardSkills": 5,
-          "reachableTools": 68,
+          "reachableTools": 69,
           "heldGrants": [
             "marketing_read",
             "marketing_write",
@@ -12013,7 +12013,7 @@
           "unbackedSkillIds": [
             "marketing-collaboration-intake"
           ],
-          "detail": "7 skill(s), 68 tool(s); 1 service backing skill(s) missing: marketing-collaboration-intake",
+          "detail": "7 skill(s), 69 tool(s); 1 service backing skill(s) missing: marketing-collaboration-intake",
           "levelKey": "reachable",
           "ceiling": 3,
           "atCeiling": false
@@ -12043,7 +12043,7 @@
           "plane": "toolsAndSkills",
           "level": 2,
           "ceiling": 3,
-          "detail": "7 skill(s), 68 tool(s); 1 service backing skill(s) missing: marketing-collaboration-intake"
+          "detail": "7 skill(s), 69 tool(s); 1 service backing skill(s) missing: marketing-collaboration-intake"
         }
       ],
       "blockedPlanes": [

--- a/apps/web/lib/marketing/strategy-grounding.test.ts
+++ b/apps/web/lib/marketing/strategy-grounding.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    marketingStrategy: {
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }));
+
+import {
+  GROUNDING_REQUIRED_FIELDS,
+  assessMarketingGrounding,
+  recordMarketingGrounding,
+} from "./strategy-grounding";
+
+const emptyStrategy = {
+  targetSegments: [],
+  idealCustomerProfiles: [],
+  proofAssets: [],
+  lastReviewedAt: null,
+  sourceSummary: "Bootstrapped from Organization, BusinessContext, and StorefrontConfig.",
+};
+
+describe("assessMarketingGrounding (BI-06BB96F0)", () => {
+  it("names the three fields the drafter actually reads", () => {
+    expect(GROUNDING_REQUIRED_FIELDS).toEqual([
+      "targetSegments",
+      "idealCustomerProfiles",
+      "proofAssets",
+    ]);
+  });
+
+  it("refuses an untouched bootstrap row and says so in the operator's terms", () => {
+    const result = assessMarketingGrounding(emptyStrategy);
+
+    expect(result.grounded).toBe(false);
+    expect(result.isBootstrapStub).toBe(true);
+    expect(result.missing).toEqual(["targetSegments", "idealCustomerProfiles", "proofAssets"]);
+    expect(result.reason).toContain("starting template");
+  });
+
+  it("distinguishes a bootstrap stub from a plan someone edited and left incomplete", () => {
+    const edited = assessMarketingGrounding({
+      ...emptyStrategy,
+      targetSegments: [{ name: "Local adopters" }],
+      lastReviewedAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
+
+    expect(edited.isBootstrapStub).toBe(false);
+    expect(edited.grounded).toBe(false);
+    expect(edited.reason).not.toContain("starting template");
+    expect(edited.missing).toEqual(["idealCustomerProfiles", "proofAssets"]);
+  });
+
+  it("passes only when audience and proof are both present", () => {
+    const grounded = assessMarketingGrounding({
+      targetSegments: [{ name: "Local adopters" }],
+      idealCustomerProfiles: [{ name: "First-time adopter" }],
+      proofAssets: [{ type: "testimonial", label: "Adopter story" }],
+      lastReviewedAt: new Date(),
+      sourceSummary: null,
+    });
+
+    expect(grounded.grounded).toBe(true);
+    expect(grounded.missing).toEqual([]);
+  });
+
+  it("does not call a row with no sourceSummary a bootstrap stub", () => {
+    // A hand-created strategy that has never been reviewed is incomplete, but it
+    // is not the archetype template — the copy must not accuse the operator of
+    // leaving a template untouched when they never had one.
+    const result = assessMarketingGrounding({ ...emptyStrategy, sourceSummary: null });
+
+    expect(result.isBootstrapStub).toBe(false);
+    expect(result.reason).toContain("not be grounded in a real audience");
+  });
+});
+
+describe("recordMarketingGrounding (BI-06BB96F0)", () => {
+  beforeEach(() => {
+    mocks.prisma.marketingStrategy.update.mockReset();
+    mocks.prisma.marketingStrategy.update.mockResolvedValue({} as never);
+  });
+
+  it("writes the fields the strategist-review path could never reach", async () => {
+    const result = await recordMarketingGrounding({
+      strategyId: "s-1",
+      grounding: {
+        targetSegments: [{ name: "Local adopters" }],
+        proofAssets: [{ type: "testimonial", label: "Adopter story" }],
+        differentiators: ["Foster-based, no kennels"],
+      },
+    });
+
+    expect(result.updatedFields).toEqual(["targetSegments", "proofAssets", "differentiators"]);
+    const data = mocks.prisma.marketingStrategy.update.mock.calls[0]?.[0]?.data;
+    expect(data.targetSegments).toEqual([{ name: "Local adopters" }]);
+    expect(data.differentiators).toEqual(["Foster-based, no kennels"]);
+  });
+
+  it("stamps lastReviewedAt so the row stops reading as an untouched stub", async () => {
+    await recordMarketingGrounding({
+      strategyId: "s-1",
+      grounding: { targetSegments: [{ name: "Local adopters" }] },
+    });
+
+    const data = mocks.prisma.marketingStrategy.update.mock.calls[0]?.[0]?.data;
+    expect(data.lastReviewedAt).toBeInstanceOf(Date);
+  });
+
+  it("writes only what was supplied, so a multi-turn interview never blanks an earlier answer", async () => {
+    await recordMarketingGrounding({
+      strategyId: "s-1",
+      grounding: { proofAssets: [{ type: "testimonial", label: "Adopter story" }] },
+    });
+
+    const data = mocks.prisma.marketingStrategy.update.mock.calls[0]?.[0]?.data;
+    expect(data).not.toHaveProperty("targetSegments");
+    expect(data).not.toHaveProperty("idealCustomerProfiles");
+    expect(data).not.toHaveProperty("differentiators");
+  });
+
+  it("treats an empty string as no answer rather than an instruction to erase", async () => {
+    const result = await recordMarketingGrounding({
+      strategyId: "s-1",
+      grounding: { geographicScope: "   ", primaryGoal: "Rehome every animal" },
+    });
+
+    expect(result.updatedFields).toEqual(["primaryGoal"]);
+    const data = mocks.prisma.marketingStrategy.update.mock.calls[0]?.[0]?.data;
+    expect(data).not.toHaveProperty("geographicScope");
+  });
+
+  it("writes nothing at all when the interview produced no answers", async () => {
+    const result = await recordMarketingGrounding({ strategyId: "s-1", grounding: {} });
+
+    expect(result.updatedFields).toEqual([]);
+    expect(mocks.prisma.marketingStrategy.update).not.toHaveBeenCalled();
+    expect(result.message).toContain("nothing was changed");
+  });
+
+  it("ignores empty arrays, which carry no information about the audience", async () => {
+    const result = await recordMarketingGrounding({
+      strategyId: "s-1",
+      grounding: { targetSegments: [], proofAssets: [] },
+    });
+
+    expect(result.updatedFields).toEqual([]);
+    expect(mocks.prisma.marketingStrategy.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/marketing/strategy-grounding.ts
+++ b/apps/web/lib/marketing/strategy-grounding.ts
@@ -1,0 +1,180 @@
+// Marketing strategy grounding (BI-06BB96F0).
+//
+// THE DEFECT THIS CLOSES. `recordMarketingStrategistReview` in lib/marketing.ts
+// is the only `prisma.marketingStrategy.update` call in the codebase, and its
+// payload covers seven fields: status, primaryChannels, secondaryChannels,
+// reviewCadence, lastReviewedAt, nextReviewAt, specialistNotes. It does not
+// touch targetSegments, idealCustomerProfiles, proofAssets, differentiators,
+// constraints, geographicScope or seasonalityNotes.
+//
+// Those are written once at bootstrap ("Bootstrapped from Organization,
+// BusinessContext, and StorefrontConfig") and were unreachable for the rest of
+// the install's life. No tool, action or UI could set them. That matters
+// because the drafter reads exactly those fields — draft-builder.ts takes
+// targetSegments[0], falls back to idealCustomerProfiles[0], and reads
+// proofAssets[0] — so on an install where they are empty, every marketing
+// asset is generated against no audience and no proof. determineStaleAreas()
+// already reported "Target segments need definition"; the platform could
+// diagnose the gap and had no way to close it.
+//
+// WHY THIS IS SEPARATE FROM A REVIEW. A review is the strategist's periodic
+// recommendation — what to do next, and it supersedes the last one. Grounding
+// is the durable business fact underneath it: who this organization serves and
+// what proof it has. Those have different authors (the operator knows the
+// grounding; the coworker proposes the review), different lifetimes, and
+// different truth conditions, so they are not folded into one write.
+//
+// This module lives here rather than in lib/marketing.ts because that file is
+// size-baselined at 1369 lines and may shrink but never grow.
+
+import { prisma } from "@dpf/db";
+import type { Prisma } from "@dpf/db";
+import type {
+  MarketingConstraintSummary,
+  MarketingNamedItem,
+  MarketingProfile,
+  MarketingProofAsset,
+} from "@/lib/marketing";
+
+/** The durable business facts a marketing plan has to stand on. */
+export type MarketingGroundingInput = {
+  primaryGoal?: string | null;
+  geographicScope?: string | null;
+  seasonalityNotes?: string | null;
+  targetSegments?: MarketingNamedItem[];
+  idealCustomerProfiles?: MarketingProfile[];
+  proofAssets?: MarketingProofAsset[];
+  differentiators?: string[];
+  constraints?: MarketingConstraintSummary | null;
+};
+
+/**
+ * The three fields the drafter actually reads. A plan missing any of them
+ * produces copy about nobody, which is the failure this gate exists to stop.
+ */
+export const GROUNDING_REQUIRED_FIELDS = Object.freeze([
+  "targetSegments",
+  "idealCustomerProfiles",
+  "proofAssets",
+]);
+
+export type GroundingAssessment = {
+  grounded: boolean;
+  missing: string[];
+  /** True when the row still looks like the untouched archetype bootstrap. */
+  isBootstrapStub: boolean;
+  reason: string;
+};
+
+type AssessableStrategy = {
+  targetSegments: unknown[];
+  idealCustomerProfiles: unknown[];
+  proofAssets: unknown[];
+  lastReviewedAt: Date | null;
+  sourceSummary: string | null;
+};
+
+/**
+ * Decide whether a strategy can support generation. Pure so the gate is
+ * testable without a database, and so a caller can explain the refusal.
+ *
+ * A bootstrap stub is recognised by lastReviewedAt === null on a row that
+ * carries a sourceSummary: the bootstrap writes the summary and never sets a
+ * review date, so the pair is a reliable "nobody has touched this" signal.
+ */
+export function assessMarketingGrounding(strategy: AssessableStrategy): GroundingAssessment {
+  const missing: string[] = [];
+  if (strategy.targetSegments.length === 0) missing.push("targetSegments");
+  if (strategy.idealCustomerProfiles.length === 0) missing.push("idealCustomerProfiles");
+  if (strategy.proofAssets.length === 0) missing.push("proofAssets");
+
+  const isBootstrapStub = strategy.lastReviewedAt === null && Boolean(strategy.sourceSummary);
+  const grounded = missing.length === 0;
+
+  if (grounded) {
+    return { grounded, missing, isBootstrapStub, reason: "Strategy carries audience and proof." };
+  }
+
+  const label = missing.join(", ");
+  return {
+    grounded,
+    missing,
+    isBootstrapStub,
+    reason: isBootstrapStub
+      ? `This marketing plan is still the starting template — ${label} were never filled in. Anything generated from it would describe a generic organization rather than this one.`
+      : `The marketing plan is missing ${label}, so generated work would not be grounded in a real audience.`,
+  };
+}
+
+/**
+ * Persist grounding facts. Only supplied fields are written, so a partial
+ * interview can be captured across several turns without a later round
+ * blanking what an earlier one established.
+ */
+export async function recordMarketingGrounding(input: {
+  grounding: MarketingGroundingInput;
+  strategyId: string;
+}): Promise<{ strategyId: string; updatedFields: string[]; message: string }> {
+  const g = input.grounding;
+  const data: Prisma.MarketingStrategyUpdateInput = {};
+  const updatedFields: string[] = [];
+
+  const setScalar = (key: "primaryGoal" | "geographicScope" | "seasonalityNotes") => {
+    const value = g[key];
+    if (value === undefined) return;
+    const trimmed = typeof value === "string" ? value.trim() : null;
+    // An explicit null clears the field; an empty string is treated as "no
+    // answer given", not as an instruction to erase what is already there.
+    if (trimmed === "") return;
+    data[key] = trimmed;
+    updatedFields.push(key);
+  };
+  setScalar("primaryGoal");
+  setScalar("geographicScope");
+  setScalar("seasonalityNotes");
+
+  const setJson = (
+    key: "targetSegments" | "idealCustomerProfiles" | "proofAssets",
+    value: unknown[] | undefined,
+  ) => {
+    if (value === undefined || value.length === 0) return;
+    data[key] = value as Prisma.InputJsonValue;
+    updatedFields.push(key);
+  };
+  setJson("targetSegments", g.targetSegments);
+  setJson("idealCustomerProfiles", g.idealCustomerProfiles);
+  setJson("proofAssets", g.proofAssets);
+
+  if (g.differentiators !== undefined && g.differentiators.length > 0) {
+    data.differentiators = g.differentiators;
+    updatedFields.push("differentiators");
+  }
+
+  if (g.constraints !== undefined && g.constraints !== null) {
+    data.constraints = g.constraints as Prisma.InputJsonValue;
+    updatedFields.push("constraints");
+  }
+
+  if (updatedFields.length === 0) {
+    return {
+      strategyId: input.strategyId,
+      updatedFields,
+      message: "No grounding supplied — nothing was changed.",
+    };
+  }
+
+  // Stamp the review clock so the row stops reading as an untouched bootstrap
+  // stub once a human has actually answered something.
+  data.lastReviewedAt = new Date();
+
+  await prisma.marketingStrategy.update({
+    where: { strategyId: input.strategyId },
+    data,
+  });
+
+  return {
+    strategyId: input.strategyId,
+    updatedFields,
+    message: `Recorded ${updatedFields.length} grounding field${updatedFields.length === 1 ? "" : "s"}: ${updatedFields.join(", ")}.`,
+  };
+}

--- a/apps/web/lib/mcp/marketing-grounding-tool.ts
+++ b/apps/web/lib/mcp/marketing-grounding-tool.ts
@@ -1,0 +1,174 @@
+// record_marketing_grounding (BI-06BB96F0) — the missing write path.
+//
+// Definition and handler live here rather than in marketing-ops-pack.ts because
+// that pack sits at 787 of its 800-line ceiling, and beside the other
+// lib/mcp/*-handler(s).ts modules rather than under packs/ so the tool-surface
+// pack count keeps measuring packs (see BI-C26FE785 for the same call).
+//
+// The tool exists because MarketingStrategy's grounding fields had no writer:
+// the strategist-review path updates seven fields and none of these, so
+// targetSegments / idealCustomerProfiles / proofAssets were bootstrap-only and
+// permanently empty on installs that never had them derived. draft-builder.ts
+// reads all three.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+
+export const recordMarketingGroundingDefinition: ToolDefinition = {
+  name: "record_marketing_grounding",
+  description:
+    "Record the durable business facts a marketing plan stands on: who this organization serves (target segments and ideal customer profiles), what proof it can point to, what makes it different, and what constrains it. Use this after the operator answers questions about their audience — NOT for a recommendation, which is save_marketing_review. Only supplied fields are written, so an interview can be captured across several turns without a later round blanking an earlier one.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      primaryGoal: { type: "string", description: "What this organization is trying to achieve through marketing, in the operator's own words" },
+      geographicScope: { type: "string", description: "Where it operates, for example a city, county or radius" },
+      seasonalityNotes: { type: "string", description: "Seasonal patterns that change demand or capacity" },
+      targetSegments: {
+        type: "array",
+        description: "The groups this organization serves. Use the archetype's own vocabulary — adopters, donors, volunteers, patients — not a generic 'customers'.",
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string", description: "Segment name" },
+            description: { type: "string", description: "Who they are and what they need" },
+          },
+          required: ["name"],
+        },
+      },
+      idealCustomerProfiles: {
+        type: "array",
+        description: "Fuller profiles for the most important segments, with traits and the pains they feel.",
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            traits: { type: "array", items: { type: "string" } },
+            painPoints: { type: "array", items: { type: "string" } },
+          },
+          required: ["name"],
+        },
+      },
+      proofAssets: {
+        type: "array",
+        description: "Evidence this organization can point to — testimonials, outcomes, credentials, press.",
+        items: {
+          type: "object",
+          properties: {
+            type: { type: "string", description: "Proof asset type" },
+            label: { type: "string", description: "Short human label" },
+            url: { type: "string", description: "Where it lives, if anywhere" },
+          },
+          required: ["type", "label"],
+        },
+      },
+      differentiators: {
+        type: "array",
+        description: "What this organization does that comparable ones do not.",
+        items: { type: "string" },
+      },
+      constraints: {
+        type: "object",
+        description: "What limits marketing: compliance rules, geography, capacity.",
+        properties: {
+          compliance: { type: "string" },
+          geography: { type: "string" },
+          capacity: { type: "string" },
+        },
+      },
+    },
+    required: [],
+  },
+  requiredCapability: "operate_marketing",
+  sideEffect: true,
+  coworkerArtifact: true,
+};
+
+export async function recordMarketingGroundingHandler(
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  const { recordMarketingGrounding, assessMarketingGrounding } = await import(
+    "@/lib/marketing/strategy-grounding"
+  );
+  const { prisma } = await import("@dpf/db");
+
+  const strategy = await prisma.marketingStrategy.findFirst({
+    select: {
+      strategyId: true,
+      targetSegments: true,
+      idealCustomerProfiles: true,
+      proofAssets: true,
+      lastReviewedAt: true,
+      sourceSummary: true,
+    },
+  });
+  if (!strategy) {
+    return {
+      success: false,
+      message: "No marketing strategy exists yet for this organization.",
+      error: "no_strategy",
+    };
+  }
+
+  const asArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
+
+  const result = await recordMarketingGrounding({
+    strategyId: strategy.strategyId,
+    grounding: {
+      primaryGoal: typeof params["primaryGoal"] === "string" ? params["primaryGoal"] : undefined,
+      geographicScope:
+        typeof params["geographicScope"] === "string" ? params["geographicScope"] : undefined,
+      seasonalityNotes:
+        typeof params["seasonalityNotes"] === "string" ? params["seasonalityNotes"] : undefined,
+      targetSegments: Array.isArray(params["targetSegments"])
+        ? (params["targetSegments"] as never)
+        : undefined,
+      idealCustomerProfiles: Array.isArray(params["idealCustomerProfiles"])
+        ? (params["idealCustomerProfiles"] as never)
+        : undefined,
+      proofAssets: Array.isArray(params["proofAssets"])
+        ? (params["proofAssets"] as never)
+        : undefined,
+      differentiators: Array.isArray(params["differentiators"])
+        ? (params["differentiators"] as string[])
+        : undefined,
+      constraints:
+        params["constraints"] && typeof params["constraints"] === "object"
+          ? (params["constraints"] as never)
+          : undefined,
+    },
+  });
+
+  // Re-read so the caller learns what is STILL missing rather than assuming the
+  // plan is now grounded because one field landed.
+  const after = await prisma.marketingStrategy.findUnique({
+    where: { strategyId: strategy.strategyId },
+    select: {
+      targetSegments: true,
+      idealCustomerProfiles: true,
+      proofAssets: true,
+      lastReviewedAt: true,
+      sourceSummary: true,
+    },
+  });
+
+  const assessment = after
+    ? assessMarketingGrounding({
+        targetSegments: asArray(after.targetSegments),
+        idealCustomerProfiles: asArray(after.idealCustomerProfiles),
+        proofAssets: asArray(after.proofAssets),
+        lastReviewedAt: after.lastReviewedAt,
+        sourceSummary: after.sourceSummary,
+      })
+    : null;
+
+  const stillMissing =
+    assessment && !assessment.grounded
+      ? ` Still missing: ${assessment.missing.join(", ")}.`
+      : " The plan now has an audience and proof to generate against.";
+
+  return {
+    success: true,
+    message: `${result.message}${stillMissing}`,
+    data: { ...result, grounded: assessment?.grounded ?? false, missing: assessment?.missing ?? [] },
+  };
+}

--- a/apps/web/lib/mcp/packs/marketing-ops-pack.test.ts
+++ b/apps/web/lib/mcp/packs/marketing-ops-pack.test.ts
@@ -41,6 +41,7 @@ const EXPECTED_TOOLS = [
   "record_marketing_kpi_checkpoint",
   "create_marketing_automation_candidate",
   "analyze_seo_opportunity",
+  "record_marketing_grounding",
 ];
 
 const READ_TOOLS = ["get_marketing_summary", "suggest_campaign_ideas", "analyze_seo_opportunity"];
@@ -51,7 +52,7 @@ beforeEach(() => {
 });
 
 describe("marketing-ops pack — registration", () => {
-  it("exposes exactly the sixteen marketing-ops tools in definitions and handlers", () => {
+  it("exposes exactly the seventeen marketing-ops tools in definitions and handlers", () => {
     expect(marketingOpsPack.definitions.map((d) => d.name).sort()).toEqual([...EXPECTED_TOOLS].sort());
     expect(Object.keys(marketingOpsPack.handlers).sort()).toEqual([...EXPECTED_TOOLS].sort());
     expect(marketingOpsPack.packId).toBe("marketing-ops");

--- a/apps/web/lib/mcp/packs/marketing-ops-pack.ts
+++ b/apps/web/lib/mcp/packs/marketing-ops-pack.ts
@@ -26,6 +26,7 @@ import {
 } from "@/lib/marketing";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import { planUpcomingMarketingDraftsHandler } from "../marketing-cadence-handler";
+import { recordMarketingGroundingDefinition, recordMarketingGroundingHandler } from "../marketing-grounding-tool";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
 
 const definitions: ToolDefinition[] = [
@@ -273,6 +274,7 @@ const definitions: ToolDefinition[] = [
     requiredCapability: "view_marketing",
     sideEffect: false,
   },
+  recordMarketingGroundingDefinition,
 ];
 
 async function getMarketingSummaryHandler(params: Record<string, unknown>): Promise<ToolResult> {
@@ -747,6 +749,7 @@ const handlers: Record<string, ToolPackHandler> = {
   record_marketing_kpi_checkpoint: (params, userId, context) => recordMarketingKpiCheckpointHandler(params, userId, context),
   create_marketing_automation_candidate: (params, userId, context) => createMarketingAutomationCandidateHandler(params, userId, context),
   analyze_seo_opportunity: () => analyzeSeoOpportunityHandler(),
+  record_marketing_grounding: (params) => recordMarketingGroundingHandler(params),
 };
 
 export const marketingOpsPack: ToolPack = {
@@ -759,6 +762,7 @@ export const marketingOpsPack: ToolPack = {
     save_marketing_review: ["marketing_write"],
     create_marketing_campaign_brief: ["marketing_write"],
     create_marketing_asset_task: ["marketing_write"],
+    record_marketing_grounding: ["marketing_write"],
     publish_to_linkedin: ["marketing_write"],
     send_marketing_email: ["marketing_write"],
     place_linkedin_ad: ["marketing_write"],

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -689,6 +689,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   save_marketing_review:        ["marketing_write"],
   create_marketing_campaign_brief: ["marketing_write"],
   create_marketing_asset_task:   ["marketing_write"],
+  record_marketing_grounding:    ["marketing_write"],
   record_marketing_kpi_checkpoint: ["marketing_write"],
   create_marketing_automation_candidate: ["marketing_write"],
   draft_marketing_asset:         ["marketing_write"],

--- a/docs/superpowers/specs/2026-05-26-marketing-execution-loop-design.md
+++ b/docs/superpowers/specs/2026-05-26-marketing-execution-loop-design.md
@@ -53,6 +53,21 @@ What exists today:
 - `IntegrationCredential` already exists as the encrypted polymorphic credential table for native integrations. It uses `fieldsEnc` and `tokenCacheEnc` encrypted by `apps/web/lib/govern/credential-crypto.ts` with `CREDENTIAL_ENCRYPTION_KEY`, not `AUTH_SECRET`.
 - `AgentActionProposal` and `ToolExecution` already exist. They should be reused for audit/proposal linkage where possible, but they do not by themselves provide a route-owned marketing approval queue.
 
+### 2.1 Strategy grounding had no write path (BI-06BB96F0, closed 2026-08-27)
+
+A defect this section's original inventory did not surface. `recordMarketingStrategistReview()` in `apps/web/lib/marketing.ts` is the only `prisma.marketingStrategy.update` call in the codebase, and its payload covers seven fields: `status`, `primaryChannels`, `secondaryChannels`, `reviewCadence`, `lastReviewedAt`, `nextReviewAt`, `specialistNotes`.
+
+It never wrote `targetSegments`, `idealCustomerProfiles`, `proofAssets`, `differentiators`, `constraints`, `geographicScope` or `seasonalityNotes`. Those were populated once at bootstrap and were then unreachable for the life of the install — no tool, server action or UI could set them.
+
+That mattered because the drafter reads exactly those fields: `draft-builder.ts` takes `targetSegments[0]`, falls back to `idealCustomerProfiles[0]`, and reads `proofAssets[0]`. On an install where the bootstrap derived nothing, every generated asset was built against an empty audience with no proof — the mechanism behind generic marketing output. `determineStaleAreas()` already reported "Target segments need definition", so the platform could diagnose the gap and had no way to close it.
+
+Closed by `record_marketing_grounding` (`apps/web/lib/mcp/marketing-grounding-tool.ts`) over `apps/web/lib/marketing/strategy-grounding.ts`. Two decisions worth keeping written down:
+
+- **Grounding is separate from a review.** A review is the strategist's periodic recommendation and supersedes the last one. Grounding is the durable business fact underneath it — who this organization serves, and what proof it has. Different authors (the operator knows the grounding, the coworker proposes the review), different lifetimes, different truth conditions. They are not folded into one write.
+- **Only supplied fields are written.** An interview runs over several turns, so a later round must never blank what an earlier one established. An empty string is treated as "no answer given" rather than an instruction to erase.
+
+`assessMarketingGrounding()` is the paired read: it reports which of the three drafter-critical fields are still empty, and distinguishes an untouched archetype bootstrap (`lastReviewedAt === null` on a row carrying a `sourceSummary`) from a plan someone edited and left incomplete, so the refusal copy can be accurate about which one the operator is looking at.
+
 What is missing:
 
 - No durable outbound draft model.

--- a/docs/superpowers/specs/2026-05-26-marketing-execution-loop-design.md
+++ b/docs/superpowers/specs/2026-05-26-marketing-execution-loop-design.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Marketing Execution Loop Design
 
 | Field | Value |

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -56,7 +56,7 @@ apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1621
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	940
-apps/web/lib/tak/agent-grants.ts	994
+apps/web/lib/tak/agent-grants.ts	995
 apps/web/lib/tak/agent-routing.ts	1191
 apps/web/lib/tak/agentic-loop.test.ts	2501
 apps/web/lib/tak/agentic-loop.ts	2704


### PR DESCRIPTION
Closes BI-06BB96F0. Part of EP-45030CFF (marketing coworker produces work).

## The defect

`MarketingStrategy`'s grounding fields had **no writer**.

`recordMarketingStrategistReview()` in `lib/marketing.ts:914` is the only `prisma.marketingStrategy.update` call in the codebase. Its payload covers seven fields — `status`, `primaryChannels`, `secondaryChannels`, `reviewCadence`, `lastReviewedAt`, `nextReviewAt`, `specialistNotes`.

It never wrote `targetSegments`, `idealCustomerProfiles`, `proofAssets`, `differentiators`, `constraints`, `geographicScope` or `seasonalityNotes`. Those were populated once at bootstrap and then unreachable for the life of the install. No tool, server action or UI could set them.

**This matters because the drafter reads exactly those fields.** `draft-builder.ts:106-110` takes `targetSegments[0]`, falls back to `idealCustomerProfiles[0]`, and reads `proofAssets[0]`; `buildIdealCustomerProfiles` (`:439`) derives ICPs *from* segments, so one empty field empties the other. On this install every marketing asset was generated against an empty audience with no proof — the mechanism behind generic output, not a prompt-quality problem.

`determineStaleAreas()` has been reporting *"Target segments need definition"* the whole time. The platform could diagnose the gap and had no way to close it.

## The original framing was wrong

This item was first filed as "nobody interviewed the operator — assign `dpf-elicit-tacit-knowledge` to marketing-specialist." Both halves were wrong:

- Interviewing would not have helped, because **there was nowhere to record the answer**.
- `dpf-elicit-tacit-knowledge` is `category: governance`, described as "use in the DPF codebase", and its tools write to the DPF wiki and build notes. It is platform-scoped; pointing a customer-facing coworker at it would capture into the wrong store entirely.

## What this adds

`record_marketing_grounding` over a new `strategy-grounding` module, plus `assessMarketingGrounding()` as the paired read for a later generation gate.

Two decisions, both recorded in the spec:

- **Grounding is separate from a review.** A review is the strategist's periodic recommendation and supersedes the last one; grounding is the durable business fact underneath it. Different authors — the operator knows the grounding, the coworker proposes the review — different lifetimes, different truth conditions. Folding them into one write would let the coworker's next suggestion overwrite the operator's own answers.
- **Only supplied fields are written.** An interview runs over several turns, so a later round must never blank what an earlier one established. An empty string is treated as "no answer given" rather than an instruction to erase.

`assessMarketingGrounding` distinguishes an untouched archetype bootstrap (`lastReviewedAt` null on a row carrying a `sourceSummary`) from a plan someone edited and left incomplete, so refusal copy can be accurate about which one the operator is looking at rather than accusing them of ignoring a template they never had.

## A real defect the gate caught in this branch

The first gate run failed with four assertion failures. I had registered the new tool in `marketingOpsPack.grants` but **not** in `TOOL_TO_GRANTS`, which is the actual gating source the pack map only mirrors.

Had it shipped, `agent-grants` denies any tool with no `TOOL_TO_GRANTS` entry, so `record_marketing_grounding` would have been **registered and invisible** — denied for every coworker while appearing present. That is a fresh instance of the exact class of bug this epic exists to fix. Three guards caught it independently: registry grant coverage, pack-to-gating drift, and tool-reachability conformance (BI-6FD78522).

Fixing it grew `agent-grants.ts` by one line against a shrink-only baseline. The growth is unavoidable — a tool without a grant line is denied by definition — so the baseline was re-cut with justification, and the diff was verified to touch exactly that one entry and mask nothing else.

## Placement

Both new modules sit outside `lib/marketing.ts` and outside `lib/mcp/packs/`. `marketing.ts` is size-baselined at 1369 lines, and every file under `packs/` counts toward the tool-surface pack metric whether or not it defines tools. Wiring cost the pack four lines: 787 → 792, under its 800 ceiling.

## Not in scope

The generation gate itself. `assessMarketingGrounding` is the predicate it will use, but wiring a refusal into `draft_marketing_asset` is a change to the drafter and is better reviewed on its own.

## Verification

- **local-CI gate: PASS** at `4ab86d715999` (evidence `cmtbafpmy02qz01qir9d1c0jd`)
- `pregate:preflight`: **52 guards clean**
- 11 new tests for the write path and assessment; 68 tests across tool-registry, marketing-ops-pack, tool-reachability conformance and strategy-grounding
- Full `apps/web` typecheck exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
