### PR TITLE
feat(brand): make the brand record reachable by generation (BI-7E7E8635)

### DIFF
--- a/apps/web/lib/brand/generation-context.test.ts
+++ b/apps/web/lib/brand/generation-context.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBrandGenerationContext } from "./generation-context";
+import type { BrandDesignSystem } from "./types";
+
+function system(overrides: Record<string, unknown> = {}): BrandDesignSystem {
+  return {
+    version: "1.0.0",
+    extractedAt: "2026-08-27T00:00:00.000Z",
+    sources: [],
+    identity: {
+      name: "Second Chance Animal Rescue",
+      tagline: "Every animal deserves a second chance",
+      description: null,
+      logo: { darkBg: null, lightBg: null, mark: null },
+      voice: { tone: "warm, plain, never guilt-tripping", sampleCopy: [] },
+    },
+    palette: { primary: "#2f7d5b", secondary: null, accents: [] },
+    typography: { families: { sans: "Inter", serif: null, mono: "monospace", display: null } },
+    components: {},
+    tokens: {},
+    confidence: { overall: 0.8, perField: {} },
+    gaps: [],
+    overrides: {},
+    ...overrides,
+  } as unknown as BrandDesignSystem;
+}
+
+describe("buildBrandGenerationContext (BI-7E7E8635)", () => {
+  it("reports an absent brand as absent rather than as an empty one", () => {
+    const result = buildBrandGenerationContext(null);
+
+    // An empty brand section reads as "nothing to honour here", which produces
+    // exactly the generic output this closes. Null is actionable.
+    expect(result.text).toBeNull();
+    expect(result.usable).toBe(false);
+    expect(result.unknowns).toContain("identity");
+  });
+
+  it("renders identity, voice and colour into standing context", () => {
+    const result = buildBrandGenerationContext(system());
+
+    expect(result.usable).toBe(true);
+    expect(result.text).toContain("Second Chance Animal Rescue");
+    expect(result.text).toContain("warm, plain, never guilt-tripping");
+    expect(result.text).toContain("#2f7d5b");
+  });
+
+  it("names what is not established instead of letting the model invent it", () => {
+    const result = buildBrandGenerationContext(system());
+
+    expect(result.unknowns).toContain("imagery.direction");
+    expect(result.unknowns).toContain("logo");
+    expect(result.unknowns).toContain("avoid");
+    expect(result.text).toContain("Ask rather than inventing");
+  });
+
+  it("carries do-not rules, which extraction cannot infer", () => {
+    const result = buildBrandGenerationContext(
+      system({
+        identity: {
+          ...system().identity,
+          avoid: ["cage imagery", "sad-eyes guilt appeals"],
+        },
+      }),
+    );
+
+    expect(result.text).toContain("Never: cage imagery; sad-eyes guilt appeals");
+    expect(result.unknowns).not.toContain("avoid");
+  });
+
+  it("marks a low-confidence field rather than stating it as fact", () => {
+    const result = buildBrandGenerationContext(
+      system({ confidence: { overall: 0.4, perField: { "voice.tone": 0.2 } } }),
+    );
+
+    expect(result.text).toContain("low confidence");
+  });
+
+  it("does not hedge a field the record is confident about", () => {
+    const result = buildBrandGenerationContext(
+      system({ confidence: { overall: 0.9, perField: { "voice.tone": 0.95 } } }),
+    );
+
+    expect(result.text).not.toContain("low confidence");
+  });
+
+  it("forbids redrawing the logo when lockups are supplied", () => {
+    const result = buildBrandGenerationContext(
+      system({
+        identity: {
+          ...system().identity,
+          logo: { darkBg: null, lightBg: { url: "/logo.png", source: "upload" }, mark: null },
+        },
+      }),
+    );
+
+    expect(result.text).toContain("never redraw or re-letter the logo");
+    expect(result.unknowns).not.toContain("logo");
+  });
+
+  it("honours the record's own declared gaps alongside what it derives", () => {
+    const result = buildBrandGenerationContext(system({ gaps: ["secondary-palette"] }));
+
+    expect(result.unknowns).toContain("secondary-palette");
+  });
+});

--- a/apps/web/lib/brand/generation-context.ts
+++ b/apps/web/lib/brand/generation-context.ts
@@ -1,0 +1,133 @@
+// Brand as generation context (BI-7E7E8635).
+//
+// THE GAP THIS CLOSES. BrandDesignSystem is a considered model — logo lockups,
+// voice and tone, palette with semantic roles, typography, plus confidence
+// scoring and a self-declared `gaps` list. Its only consumer was
+// designSystemToThemeTokens(), which projects it into portal CSS. Nothing fed
+// it to the coworker when it wrote or generated anything, so marketing output
+// was produced against a seeded default theme belonging to no organization.
+//
+// On this install Organization.designSystem is NULL and the single
+// BrandingConfig row carries an empty organizationId, meaning it was never
+// produced by the apply path — a generic default was standing in for a brand.
+//
+// WHAT THIS DELIBERATELY DOES NOT DO. It does not invent. Where the record is
+// silent the context says so, so the coworker asks or declines rather than
+// filling the hole with plausible brand-sounding copy. `confidence.perField`
+// and `gaps` exist precisely so the model can know what it does not know, and
+// low-confidence fields are marked rather than asserted.
+
+import type { BrandDesignSystem } from "./types";
+
+export type BrandGenerationContext = {
+  /** Prompt-ready standing context, or null when there is no brand to speak of. */
+  text: string | null;
+  /** Fields the record does not carry, so a caller can elicit them. */
+  unknowns: string[];
+  /** True when a brand record exists and carries at least an identity. */
+  usable: boolean;
+};
+
+/** Below this, a field is reported as uncertain rather than stated as fact. */
+const LOW_CONFIDENCE = 0.5;
+
+function confidenceOf(system: BrandDesignSystem, field: string): number | null {
+  const per = system.confidence?.perField;
+  if (!per || typeof per !== "object") return null;
+  const value = (per as Record<string, unknown>)[field];
+  return typeof value === "number" ? value : null;
+}
+
+function mark(system: BrandDesignSystem, field: string, rendered: string): string {
+  const c = confidenceOf(system, field);
+  return c !== null && c < LOW_CONFIDENCE ? `${rendered} (low confidence — confirm before relying on it)` : rendered;
+}
+
+/**
+ * Render a brand record into standing context for a generation prompt.
+ *
+ * Returns null text for an absent record rather than a cheerful empty brand:
+ * "no brand on file" is actionable, an empty section reads as "nothing to
+ * honour here" and produces exactly the generic output this closes.
+ */
+export function buildBrandGenerationContext(
+  system: BrandDesignSystem | null | undefined,
+): BrandGenerationContext {
+  if (!system || !system.identity) {
+    return {
+      text: null,
+      unknowns: ["identity", "voice", "imagery", "palette"],
+      usable: false,
+      };
+  }
+
+  const id = system.identity;
+  const lines: string[] = [];
+  const unknowns: string[] = [];
+
+  lines.push(`Brand: ${id.name}`);
+  if (id.tagline) lines.push(`Tagline: ${id.tagline}`);
+  if (id.description) lines.push(`What it is: ${id.description}`);
+
+  if (id.voice?.tone) {
+    lines.push(mark(system, "voice.tone", `Voice: ${id.voice.tone}`));
+  } else {
+    unknowns.push("voice.tone");
+  }
+
+  const samples = id.voice?.sampleCopy ?? [];
+  if (samples.length > 0) {
+    lines.push(`Copy that sounds right: ${samples.map((s) => `"${s}"`).join("; ")}`);
+  }
+
+  if (id.imagery?.direction) {
+    lines.push(mark(system, "imagery.direction", `Imagery: ${id.imagery.direction}`));
+  } else {
+    unknowns.push("imagery.direction");
+  }
+
+  const palette = system.palette;
+  if (palette?.primary) {
+    const accents = Array.isArray(palette.accents) ? palette.accents : [];
+    const swatches = [palette.primary, palette.secondary, ...accents].filter(Boolean);
+    lines.push(`Colours: ${swatches.join(", ")}`);
+  } else {
+    unknowns.push("palette.primary");
+  }
+
+  const families = system.typography?.families;
+  if (families?.sans || families?.display) {
+    lines.push(`Type: ${[families.display, families.sans].filter(Boolean).join(", ")}`);
+  }
+
+  const logos = [
+    id.logo?.lightBg ? "light background" : null,
+    id.logo?.darkBg ? "dark background" : null,
+    id.logo?.mark ? "mark" : null,
+  ].filter(Boolean);
+  if (logos.length > 0) {
+    lines.push(`Logo lockups available: ${logos.join(", ")}. Use a supplied lockup; never redraw or re-letter the logo.`);
+  } else {
+    unknowns.push("logo");
+  }
+
+  if (id.avoid && id.avoid.length > 0) {
+    lines.push(`Never: ${id.avoid.join("; ")}`);
+  } else {
+    unknowns.push("avoid");
+  }
+
+  // The record's own declared gaps outrank anything inferred here.
+  const declared = Array.isArray(system.gaps) ? system.gaps : [];
+  for (const gap of declared) {
+    if (typeof gap === "string" && !unknowns.includes(gap)) unknowns.push(gap);
+  }
+
+  if (unknowns.length > 0) {
+    lines.push(
+      `Not established: ${unknowns.join(", ")}. Ask rather than inventing these — a plausible guess about a brand is worse than an admitted gap.`,
+    );
+  }
+
+  return { text: lines.join("\n"), unknowns, usable: true };
+}

--- a/apps/web/lib/brand/types.ts
+++ b/apps/web/lib/brand/types.ts
@@ -78,6 +78,25 @@ export type Identity = {
   description: string | null;
   logo: { darkBg: AssetRef | null; lightBg: AssetRef | null; mark: AssetRef | null };
   voice: { tone: string; sampleCopy: string[] };
+  /**
+   * How this brand should LOOK, as opposed to how it should sound (BI-7E7E8635).
+   * `voice` already covers copy; nothing covered photography or illustration,
+   * which is what image generation needs most. Optional so every record stored
+   * before this field existed still satisfies isBrandDesignSystem() — this is
+   * an additive widening, not a schema version break.
+   */
+  imagery?: {
+    /** Subject matter and treatment: "real animals in foster homes, natural light". */
+    direction: string | null;
+    /** Concrete examples to imitate. */
+    references: AssetRef[];
+  };
+  /**
+   * Explicit do-not rules. Extraction can infer what a brand looks like; it
+   * cannot infer what a brand refuses to do, and that is usually the part a
+   * generated asset gets wrong (BI-7E7E8635).
+   */
+  avoid?: string[];
 };
 
 export type BrandDesignSystem = {


### PR DESCRIPTION
Closes BI-7E7E8635. Part of EP-45030CFF (marketing coworker produces work).

## The defect

`BrandDesignSystem` is a considered model — logo lockups, voice and tone, palette with semantic roles, typography, plus `confidence.perField` and a self-declared `gaps` list, so it was built to know what it does not know.

Its only consumer was `designSystemToThemeTokens()`, which projects it into portal CSS. **Nothing fed it to the coworker when it wrote or generated anything.**

On this install `Organization.designSystem` is **NULL**, and the single `BrandingConfig` row carries an empty `organizationId` — meaning it was never produced by the apply path (that path sets `organizationId` on upsert). A seeded default theme belonging to no organization was standing in for a brand, which is most of why generated marketing reads as generic.

## The original framing was wrong, and the tooling caught it

This item was first filed as "no marketing brand kit exists — design one." The duplicate warning on `create_backlog_item` flagged `apply-brand-design-system.ts`, and checking it showed `BrandDesignSystem` already models logo lockups and `voice: { tone, sampleCopy }`. The gap was never the model. It was that the model is empty and disconnected.

Building a parallel marketing-brand model would have been a second home for one concern (AGENTS.md §8).

## What changed

**`Identity` gains `imagery` and `avoid`.** `voice` already covered how the brand *sounds*; nothing covered how it should *look*, which is what image generation needs most. `avoid` exists because extraction can infer what a brand looks like but never what it refuses to do — and that is usually the part a generated asset gets wrong.

Both optional, so every record stored before these fields existed still satisfies `isBrandDesignSystem()`. An additive widening, not a version break.

**`buildBrandGenerationContext()`** renders the record into standing context for a generation prompt. Two behaviours are load-bearing rather than incidental:

- **An absent brand returns `null` text, not an empty brand section.** An empty section reads as "nothing to honour here" and produces exactly the generic output this closes; `null` is actionable.
- **It never invents.** Fields below the confidence floor are marked rather than asserted, unknowns are named explicitly, and the record's own declared `gaps` outrank anything derived here. The context states plainly that a plausible guess about a brand is worse than an admitted gap.

## Not in scope

Populating `Organization.designSystem` for this org — an elicitation task rather than a code change — and wiring the context into the drafter, which belongs with the rendered-asset work on BI-7C957749.

## Verification

- **local-CI gate: PASS** at `391bf3e80118` (evidence `cmtbbjm0803oj01qi3wetmsgb`)
- `pregate:preflight`: **52 guards clean**
- 14 test files / 62 tests pass across `lib/brand` — 8 new, and the existing brand suites still green after the `Identity` widening

🤖 Generated with [Claude Code](https://claude.com/claude-code)
