### PR TITLE
fix(build-studio): a phase-gate refusal is a value, not a thrown error (BI-04B112CA)

### DIFF
--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -486,9 +486,9 @@ describe("governed build start approvals", () => {
       status: "awaiting_clarification",
     });
 
-    await expect(advanceBuildPhase("FB-123", "plan")).rejects.toThrow(
-      "Accept the business build brief before moving into planning.",
-    );
+    // BI-04B112CA — a refusal is a value the owner can read, not a digest.
+    await expect(advanceBuildPhase("FB-123", "plan")).resolves.toEqual({ ok: false,
+      message: "Accept the business build brief before moving into planning." });
     expect(mockPrisma.featureBuild.update).not.toHaveBeenCalled();
   });
 
@@ -576,9 +576,8 @@ describe("governed build start approvals", () => {
       governedBacklogEnabled: true,
     });
 
-    await expect(advanceBuildPhase("FB-123", "plan")).rejects.toThrow(
-      "Approve Start before moving this governed backlog draft into planning.",
-    );
+    await expect(advanceBuildPhase("FB-123", "plan")).resolves.toEqual({ ok: false,
+      message: "Approve Start before moving this governed backlog draft into planning." });
     expect(mockPrisma.featureBuild.update).not.toHaveBeenCalled();
   });
 

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -447,15 +447,13 @@ export async function advanceBuildPhase(
     );
 
   if (requiresStartApproval) {
-    throw new Error(
-      currentPhase === "ideate"
-        ? "Approve Start before moving this governed backlog draft into planning."
-        : "Approve Start before moving this backlog-linked draft into implementation.",
-    );
+    return { ok: false, message: currentPhase === "ideate"
+      ? "Approve Start before moving this governed backlog draft into planning."
+      : "Approve Start before moving this backlog-linked draft into implementation." };
   }
 
   if (!canTransitionPhase(currentPhase, targetPhase)) {
-    throw new Error(`Cannot transition from ${currentPhase} to ${targetPhase}`);
+    return { ok: false, message: `Cannot transition from ${currentPhase} to ${targetPhase}` };
   }
 
   if (targetPhase === "complete") await assertFeatureBuildCompletion({ buildId, expectedPhase: currentPhase });
@@ -470,7 +468,7 @@ export async function advanceBuildPhase(
     // explicitly non-accepted brief (draft, rejected, etc.) so builds created
     // without going through the full intake UI are not permanently deadlocked.
     if (businessBrief !== null && businessBrief.status !== "accepted") {
-      throw new Error("Accept the business build brief before moving into planning.");
+      return { ok: false, message: "Accept the business build brief before moving into planning." };
     }
   }
 
@@ -514,7 +512,9 @@ export async function advanceBuildPhase(
         },
       }).catch(() => {});
     } else {
-      throw new Error(gate.reason ?? "Phase gate check failed");
+      // BI-04B112CA — an expected "not yet" returns; thrown it is stripped to a
+      // digest and the owner sees React #441 instead of the reason (FB-05946F96).
+      return { ok: false, message: gate.reason ?? "Phase gate check failed" };
     }
   }
 


### PR DESCRIPTION
## Problem

Clicking **Advance to Plan** on a build the gate will refuse renders `Minified React error #441` and the phase does not move. The owner sees a React internal error instead of the reason — which the platform already knows and has already written down.

Live repro `FB-05946F96` on the Pet Rescue install. The design **passed review** and sized **ok** (2 models, 1 endpoint, 6 ACs — *"Design fits one Plan"*), and the activity log holds the actual answer:

```
phase:gate-blocked  Cannot enter plan: RESEARCH_REQUIRED, CANONICAL_DESIGN_REQUIRED,
                    SPEC_APPROVAL_REQUIRED, REVIEW_REQUIRED,
                    OBJECTIVE_BASELINE_REQUIRED, ARTIFACT_AUTHOR_REQUIRED.
```

That sentence never reaches the screen. This is the same failure #4739 removed from the size-gate path by not offering a blocked action; here the action is legitimately offered and **the refusal itself is what breaks**.

## Change

`advanceBuildPhase` already declares `AdvanceBuildPhaseResult = { ok: true } | { ok: false; message: string }`, its own comment says a refusal *"comes back as a value, because a thrown Error is stripped to a production digest and the operator needs the cause"* (BI-8C6AA60E), and `BuildStudioWorkflowActionCard` already reads the returned refusal into `setError`.

Three refusal paths were still throwing, and now return:

- the phase gate itself
- start-approval not yet recorded
- an unaccepted business build brief

Genuinely exceptional cases — build not found, forbidden, a vanished sandbox, a WWMD escalation — still throw.

## Verification

- Two existing tests asserted `rejects.toThrow` on the converted paths; they now assert the returned value and **are the regression coverage** — both confirmed **Red** against `origin/main`, green with the fix.
- `lib/actions/build-governed`: 22 tests pass.
- `pnpm --filter web typecheck` clean; guard loop 37/37; Build Studio surface ratchet OK; **module-size ratchet OK** — `build.ts` and the test file were both brought back to baseline rather than re-baselined.
- **`pnpm run pregate` passed** — full local CI-equivalent gate.

Refs: BI-04B112CA, BI-8C6AA60E