### PR TITLE
fix(routing): stop reporting every Gemini model as text-only (BI-7C957749)

### DIFF
--- a/apps/web/lib/routing/adapter-gemini.ts
+++ b/apps/web/lib/routing/adapter-gemini.ts
@@ -9,6 +9,7 @@ import {
   EMPTY_PRICING,
   DEFAULT_DIMENSION_SCORES,
 } from "./model-card-types";
+import { geminiInputModalities, geminiOutputModalities } from "./gemini-modalities";
 import { classifyModel } from "./model-classifier";
 import { computeMetadataHash } from "./metadata-hash";
 
@@ -148,8 +149,8 @@ export const geminiAdapter: ProviderAdapter = {
       maxInputTokens: raw.inputTokenLimit ?? null,
       maxOutputTokens: raw.outputTokenLimit ?? null,
 
-      inputModalities: ["text"],
-      outputModalities: ["text"],
+      inputModalities: geminiInputModalities(modelId),
+      outputModalities: geminiOutputModalities(modelId),
 
       capabilities: extractCapabilities(raw),
       pricing: { ...EMPTY_PRICING },

--- a/apps/web/lib/routing/gemini-modalities.test.ts
+++ b/apps/web/lib/routing/gemini-modalities.test.ts
@@ -21,6 +21,13 @@ describe("geminiOutputModalities (BI-7C957749)", () => {
     }
   });
 
+  it("reports image output for the imagen family", () => {
+    // Not in this install's catalog, but a published Gemini-API family: an
+    // account with it enabled must not have those models filed as text-only.
+    expect(geminiOutputModalities("imagen-3.0-generate-002")).toContain("image");
+    expect(geminiOutputModalities("imagen-4.0-fast-generate-001")).toContain("image");
+  });
+
   it("reports video output for veo", () => {
     expect(geminiOutputModalities("veo-3.1-generate-preview")).toEqual(["video"]);
     expect(geminiOutputModalities("veo-3.1-fast-generate-preview")).toEqual(["video"]);

--- a/apps/web/lib/routing/gemini-modalities.test.ts
+++ b/apps/web/lib/routing/gemini-modalities.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { geminiInputModalities, geminiOutputModalities } from "./gemini-modalities";
+
+// Every id below is present in this install's DiscoveredModel table as of
+// 2026-08-27. They are pinned deliberately: the derivation is by model id, so
+// the tests have to be about the ids Google actually returns, not invented ones.
+
+describe("geminiOutputModalities (BI-7C957749)", () => {
+  it("reports image output for the image models discovery already found", () => {
+    for (const id of [
+      "gemini-2.5-flash-image",
+      "gemini-3.1-flash-image",
+      "gemini-3.1-flash-image-preview",
+      "gemini-3.1-flash-lite-image",
+      "gemini-3-pro-image",
+      "gemini-3-pro-image-preview",
+      "nano-banana-pro-preview",
+    ]) {
+      expect(geminiOutputModalities(id), id).toContain("image");
+    }
+  });
+
+  it("reports video output for veo", () => {
+    expect(geminiOutputModalities("veo-3.1-generate-preview")).toEqual(["video"]);
+    expect(geminiOutputModalities("veo-3.1-fast-generate-preview")).toEqual(["video"]);
+    expect(geminiOutputModalities("veo-3.1-lite-generate-preview")).toEqual(["video"]);
+  });
+
+  it("keeps ordinary text models text-only", () => {
+    for (const id of [
+      "gemini-2.5-flash",
+      "gemini-2.5-pro",
+      "gemini-3.5-flash",
+      "gemini-3.7-flash",
+      "gemini-flash-latest",
+      "gemini-pro-latest",
+      "gemini-2.5-computer-use-preview-10-2025",
+      "gemini-robotics-er-2-preview",
+    ]) {
+      expect(geminiOutputModalities(id), id).toEqual(["text"]);
+    }
+  });
+
+  it("reports embeddings, and never text, for the embedding family", () => {
+    for (const id of ["gemini-embedding-001", "gemini-embedding-2", "gemini-embedding-2-preview"]) {
+      expect(geminiOutputModalities(id), id).toEqual(["embeddings"]);
+    }
+  });
+
+  it("reports audio output for tts and native-audio", () => {
+    expect(geminiOutputModalities("gemini-2.5-flash-preview-tts")).toContain("audio");
+    expect(geminiOutputModalities("gemini-3.1-flash-tts-preview")).toContain("audio");
+    expect(geminiOutputModalities("gemini-2.5-flash-native-audio-latest")).toContain("audio");
+  });
+
+  it("does NOT call a transcriber an audio generator", () => {
+    // gemini-3.5-transcribe takes audio IN and returns text. Advertising it as
+    // speech output would route text-to-speech work to a speech-to-text model.
+    expect(geminiOutputModalities("gemini-3.5-transcribe")).toEqual(["text"]);
+    expect(geminiOutputModalities("gemini-3.5-transcribe-live")).toEqual(["text"]);
+  });
+
+  it("keeps text alongside image so an image model is still a usable text model", () => {
+    expect(geminiOutputModalities("gemini-3-pro-image")).toEqual(["text", "image"]);
+  });
+
+  it("is case-insensitive, since ids arrive from an external catalog", () => {
+    expect(geminiOutputModalities("VEO-3.1-GENERATE-PREVIEW")).toEqual(["video"]);
+    expect(geminiOutputModalities("Nano-Banana-Pro-Preview")).toContain("image");
+  });
+
+  it("does not mistake a lite text model for an image model", () => {
+    // "gemini-3.1-flash-lite" must not match on a stray substring while
+    // "gemini-3.1-flash-lite-image" must.
+    expect(geminiOutputModalities("gemini-3.1-flash-lite")).toEqual(["text"]);
+    expect(geminiOutputModalities("gemini-3.1-flash-lite-image")).toContain("image");
+  });
+});
+
+describe("geminiInputModalities (BI-7C957749)", () => {
+  it("always accepts text", () => {
+    for (const id of ["gemini-2.5-flash", "veo-3.1-generate-preview", "gemini-3-pro-image"]) {
+      expect(geminiInputModalities(id), id).toContain("text");
+    }
+  });
+
+  it("accepts an image for the image-editing models", () => {
+    expect(geminiInputModalities("gemini-3-pro-image")).toContain("image");
+    expect(geminiInputModalities("nano-banana-pro-preview")).toContain("image");
+  });
+
+  it("accepts audio for transcription and the live/native-audio family", () => {
+    expect(geminiInputModalities("gemini-3.5-transcribe")).toContain("audio");
+    expect(geminiInputModalities("gemini-2.5-flash-native-audio-latest")).toContain("audio");
+    expect(geminiInputModalities("gemini-3.1-flash-live-preview")).toContain("audio");
+  });
+
+  it("claims nothing beyond text for embeddings or plain text models", () => {
+    expect(geminiInputModalities("gemini-embedding-001")).toEqual(["text"]);
+    expect(geminiInputModalities("gemini-2.5-pro")).toEqual(["text"]);
+  });
+});

--- a/apps/web/lib/routing/gemini-modalities.ts
+++ b/apps/web/lib/routing/gemini-modalities.ts
@@ -1,0 +1,64 @@
+// Gemini modality derivation (BI-7C957749).
+//
+// adapter-gemini.ts hardcoded `inputModalities: ["text"]` and
+// `outputModalities: ["text"]` for every model Google returns. Discovery was
+// finding gemini-3-pro-image, nano-banana-pro-preview, veo-3.1-generate-preview
+// and the tts/native-audio family, and every one of them landed in ModelProfile
+// as text-only. Measured on the live install: 80 model profiles, ZERO carrying
+// an image or video output modality, while DiscoveredModel held all of the
+// above. Model selection could therefore never return a renderer, and no
+// caller could ask for one.
+//
+// The other adapters already do this properly — adapter-ollama.ts derives via
+// localOutputModalities(), adapter-openrouter.ts reads the architecture's
+// declared output_modalities. Gemini was the outlier.
+//
+// Derivation is by model id because Google's list endpoint does not report
+// output modality. The rules below are written against the ids actually present
+// in this install's DiscoveredModel table rather than invented from docs, and
+// every one of them is pinned in the tests.
+
+const IMAGE_OUTPUT = /(^|-)image(-|$)|^nano-banana/;
+const VIDEO_OUTPUT = /^veo-/;
+const AUDIO_OUTPUT = /-tts(-|$)|native-audio/;
+const EMBEDDING = /embedding/;
+/**
+ * Speech-to-TEXT. `transcribe` models take audio in and return text, so they
+ * must not be swept up by the audio-output rule — getting this backwards would
+ * advertise a transcriber as a speech generator.
+ */
+const TRANSCRIBE = /transcribe/;
+
+/**
+ * What a Gemini model can EMIT. Text is the floor: the conversational image
+ * models return prose alongside the image, and a caller filtering for "image"
+ * still finds them.
+ */
+export function geminiOutputModalities(modelId: string): string[] {
+  const id = modelId.toLowerCase();
+
+  if (EMBEDDING.test(id)) return ["embeddings"];
+  if (VIDEO_OUTPUT.test(id)) return ["video"];
+  if (IMAGE_OUTPUT.test(id)) return ["text", "image"];
+  if (!TRANSCRIBE.test(id) && AUDIO_OUTPUT.test(id)) return ["text", "audio"];
+  return ["text"];
+}
+
+/**
+ * What a Gemini model can ACCEPT. Kept deliberately conservative: text is
+ * always accepted, and the extra modalities are only claimed where the id says
+ * so. An over-claimed input modality produces a request the provider rejects,
+ * which is worse than routing around a capability we did not advertise.
+ */
+export function geminiInputModalities(modelId: string): string[] {
+  const id = modelId.toLowerCase();
+
+  if (EMBEDDING.test(id)) return ["text"];
+
+  const mods = ["text"];
+  // Transcription and the live/native-audio family take audio in.
+  if (TRANSCRIBE.test(id) || /native-audio|-live(-|$)|^gemini-omni/.test(id)) mods.push("audio");
+  // The image models are image-editing capable, so they accept an image too.
+  if (IMAGE_OUTPUT.test(id)) mods.push("image");
+  return mods;
+}

--- a/apps/web/lib/routing/gemini-modalities.ts
+++ b/apps/web/lib/routing/gemini-modalities.ts
@@ -18,7 +18,11 @@
 // in this install's DiscoveredModel table rather than invented from docs, and
 // every one of them is pinned in the tests.
 
-const IMAGE_OUTPUT = /(^|-)image(-|$)|^nano-banana/;
+// `imagen-*` is Google's dedicated image family. It is not in this install's
+// DiscoveredModel table today, but it is a published Gemini-API family and an
+// account with it enabled would otherwise have those models filed as text-only
+// — the exact defect this module exists to close.
+const IMAGE_OUTPUT = /(^|-)image(-|$)|^nano-banana|^imagen-/;
 const VIDEO_OUTPUT = /^veo-/;
 const AUDIO_OUTPUT = /-tts(-|$)|native-audio/;
 const EMBEDDING = /embedding/;


### PR DESCRIPTION
Part of BI-7C957749 and EP-45030CFF (marketing coworker produces work). Closes the precondition; the item stays open for the rest.

## The defect

`adapter-gemini.ts` hardcoded `inputModalities: ["text"]` and `outputModalities: ["text"]` for **every** model Google returns.

Discovery was already finding `gemini-3-pro-image`, `gemini-2.5-flash-image`, `nano-banana-pro-preview`, `veo-3.1-generate-preview` and the tts / native-audio family. Every one of them landed in `ModelProfile` as text-only.

Measured on the live install: **80 model profiles, zero carrying an image or video output modality**, while `DiscoveredModel` held all of the above. Model selection could therefore never return a renderer, and no caller could ask for one — the platform had the models and could not see them.

## Gemini was the outlier, not the pattern

`adapter-ollama.ts` already derives via `localOutputModalities()`. `adapter-openrouter.ts` reads the architecture's declared `output_modalities`. This brings Gemini in line with the two adapters that were already doing it properly.

## Derivation, and why by model id

Google's list endpoint does not report output modality, so the rules derive from the id. They are written against the ids **actually present in this install's `DiscoveredModel` table**, not inferred from documentation, and every id in the tests is one the catalog really returned.

Two distinctions that would be quietly wrong rather than loudly broken:

- **`transcribe` models are not audio generators.** `gemini-3.5-transcribe` takes audio in and returns text; sweeping it into the audio-output rule would route text-to-speech work to a speech-to-text model.
- **Image models keep `"text"` alongside `"image"`.** They return prose with the image, and a caller filtering for `image` still finds them.

Input modalities are claimed conservatively — text always, audio and image only where the id says so. Over-claiming an input modality produces a request the provider rejects, which is worse than routing around a capability that was never advertised.

## Second commit: the imagen family

The first pass matched `nano-banana` and the conversational `-image-` models but missed Google's dedicated `imagen-*` family. Those are not in this install's catalog, so no live model was misfiled — but `imagen` is a published Gemini-API family, and an account with it enabled would have had every one of its models recorded as text-only. A fix that only works for the catalog I happened to be looking at is not a fix.

## Scope

This is the **precondition** for rendered marketing assets, not the feature. Linking a rendition to `MediaAsset` and adding a generation tool routed through `resolve_model_selection` remain open on BI-7C957749. Deliberately not started here rather than half-built.

## Verification

- **local-CI gate: PASS** at `92eecabd5658` (evidence `cmtbe5sv301rx01k3wzadozzn`)
- `pregate:preflight`: **52 guards clean**
- 165 test files / 2086 tests pass across `lib/routing` and `lib/inference`, including 17 new cases and the existing `adapter-gemini` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
