### PR TITLE
fix(storefront): no inbound channel may require a donation (BI-7F851119)

### DIFF
--- a/apps/web/app/(storefront)/s/[slug]/inquire/[itemId]/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/inquire/[itemId]/page.tsx
@@ -14,7 +14,11 @@ export default async function ItemInquirePage({
   ]);
   if (!storefront || !item) notFound();
 
-  const formSchema = await resolveInquiryFormSchema(storefront.archetypeId);
+  // A donation appeal may legitimately ask for an amount; nothing else may
+  // (BI-7F851119) — an adoption enquiry is not a donation.
+  const formSchema = await resolveInquiryFormSchema(storefront.archetypeId, {
+    itemCtaType: item.ctaType,
+  });
 
   const CTA_HEADINGS: Record<string, string> = {
     rental: "Reserve",

--- a/apps/web/lib/storefront/inquiry-fields.test.ts
+++ b/apps/web/lib/storefront/inquiry-fields.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  inquiryFieldsForItem,
+  isDonationOnlyField,
+  DONATION_ONLY_FIELD_NAMES,
+} from "./inquiry-fields";
+
+// The schema five nonprofit archetypes were seeded with, verbatim (BI-7F851119).
+const SEEDED_DONATION_SCHEMA = [
+  { name: "name", label: "Full name", type: "text", required: true },
+  { name: "email", label: "Email", type: "email", required: true },
+  { name: "donationAmount", label: "Donation amount", type: "select", required: true, options: ["£5", "Other"] },
+  { name: "customAmount", label: "Custom amount (£)", type: "text", required: false },
+  { name: "campaignId", label: "Campaign", type: "text", required: false },
+  { name: "isAnonymous", label: "Make donation anonymous?", type: "select", required: false },
+  { name: "notes", label: "Message", type: "textarea", required: false },
+];
+
+const names = (fields: { name: string }[]) => fields.map((f) => f.name);
+
+describe("isDonationOnlyField", () => {
+  it("matches the donation fields regardless of case and separators", () => {
+    for (const spelling of ["donationAmount", "donation_amount", "Donation Amount", "DONATION-AMOUNT"]) {
+      expect(isDonationOnlyField(spelling)).toBe(true);
+    }
+  });
+
+  it("leaves contact fields alone", () => {
+    for (const field of ["name", "email", "phone", "notes", "message", "reason"]) {
+      expect(isDonationOnlyField(field)).toBe(false);
+    }
+  });
+});
+
+describe("inquiryFieldsForItem", () => {
+  it("drops the donation fields from the site-wide contact form", () => {
+    expect(names(inquiryFieldsForItem(SEEDED_DONATION_SCHEMA))).toEqual([
+      "name",
+      "email",
+      "notes",
+    ]);
+  });
+
+  it("leaves no required field a stranger cannot answer without giving money", () => {
+    const required = inquiryFieldsForItem(SEEDED_DONATION_SCHEMA).filter((f) => f.required);
+    expect(names(required)).toEqual(["name", "email"]);
+    expect(required.some((f) => DONATION_ONLY_FIELD_NAMES.has(f.name.toLowerCase()))).toBe(false);
+  });
+
+  it("drops them for an enquiry about a non-donation item — adopting an animal is not a donation", () => {
+    const fields = inquiryFieldsForItem(SEEDED_DONATION_SCHEMA, { itemCtaType: "inquiry" });
+    expect(names(fields)).not.toContain("donationAmount");
+  });
+
+  it("keeps them for an enquiry about a donation item", () => {
+    const fields = inquiryFieldsForItem(SEEDED_DONATION_SCHEMA, { itemCtaType: "donation" });
+    expect(names(fields)).toEqual(names(SEEDED_DONATION_SCHEMA));
+  });
+
+  it("does not mutate the schema it was given", () => {
+    const before = names(SEEDED_DONATION_SCHEMA);
+    inquiryFieldsForItem(SEEDED_DONATION_SCHEMA);
+    expect(names(SEEDED_DONATION_SCHEMA)).toEqual(before);
+  });
+});

--- a/apps/web/lib/storefront/inquiry-fields.ts
+++ b/apps/web/lib/storefront/inquiry-fields.ts
@@ -1,0 +1,46 @@
+// What a public enquiry form is allowed to ask (BI-7F851119).
+//
+// `StorefrontArchetype.formSchema` is the *contact* form schema, and it is the
+// only inbound channel a storefront has. Five nonprofit archetypes were seeded
+// with a donation form in that slot, which put a required "Donation amount" in
+// front of every reason a stranger writes in — an adoption enquiry, a found-pet
+// report, a surrender request, an offer to volunteer. A donation prompt in front
+// of a found-pet report is the worst failure available to a rescue.
+//
+// Donations already have their own route and their own form
+// (`/s/[slug]/donate` -> `DonationForm`), so donation fields belong on an
+// enquiry only when the enquiry is about a donation item.
+//
+// Dependency-free (no prisma, no React) so the rule is unit-testable on its own,
+// matching the `slot-booking-fields.ts` precedent.
+
+/** Fields that only mean something when money is being given. Matched
+ *  case-, separator- and whitespace-insensitively, so `donation-amount`,
+ *  `Donation Amount` and `donationAmount` all resolve to the same field. */
+export const DONATION_ONLY_FIELD_NAMES: ReadonlySet<string> = new Set([
+  "donationamount",
+  "customamount",
+  "campaignid",
+  "isanonymous",
+]);
+
+function canonicalFieldName(name: string): string {
+  return name.toLowerCase().replace(/[-_\s]/g, "");
+}
+
+/** True when a field asks about a donation rather than about the enquiry. Pure. */
+export function isDonationOnlyField(name: string): boolean {
+  return DONATION_ONLY_FIELD_NAMES.has(canonicalFieldName(name));
+}
+
+/** The fields a public enquiry form should render. Donation fields survive only
+ *  when the enquiry is about a donation item; on the site-wide contact form and
+ *  on an enquiry about anything else they are dropped, so no inbound channel can
+ *  require a payment before it will accept a message. Pure. */
+export function inquiryFieldsForItem<T extends { name: string }>(
+  fields: readonly T[],
+  { itemCtaType }: { itemCtaType?: string | null } = {},
+): T[] {
+  if (itemCtaType === "donation") return [...fields];
+  return fields.filter((field) => !isDonationOnlyField(field.name));
+}

--- a/apps/web/lib/storefront/storefront-data.ts
+++ b/apps/web/lib/storefront/storefront-data.ts
@@ -4,6 +4,7 @@ import type { FormField } from "@dpf/storefront-templates";
 import { loadStorefrontOperatingTimezone } from "@/lib/storefront/storefront-operating-timezone.server";
 import { listOwnerMedia, mediaAssetUrl } from "@/lib/media";
 import { getCurrencySymbol } from "@/lib/finance/currency-symbol";
+import { inquiryFieldsForItem } from "./inquiry-fields";
 import type {
   PublicStorefrontConfig,
   PublicItem,
@@ -94,9 +95,17 @@ function isFormField(value: unknown): value is FormField {
  * definitions; without this, every archetype rendered the same generic
  * name/email/phone/message form. Falls back to DEFAULT_INQUIRY_SCHEMA when the
  * archetype is missing or has no (valid) schema.
+ *
+ * Donation fields are dropped unless the enquiry is about a donation item
+ * (BI-7F851119). Five nonprofit archetypes were seeded with a donation form in
+ * the contact-form slot, so an adoption enquiry, a found-pet report and an offer
+ * to volunteer were all refused without a donation amount. The seed is fixed,
+ * but an install seeded before that fix still holds the old JSON, so the rule is
+ * applied on read as well.
  */
 export async function resolveInquiryFormSchema(
   archetypeId: string,
+  { itemCtaType }: { itemCtaType?: string | null } = {},
 ): Promise<FormField[]> {
   if (!archetypeId) return DEFAULT_INQUIRY_SCHEMA;
   const [archetype, orgSettings] = await Promise.all([
@@ -115,6 +124,7 @@ export async function resolveInquiryFormSchema(
     const validated = (schema as unknown[]).filter(isFormField);
     if (validated.length > 0) fields = validated;
   }
+  fields = inquiryFieldsForItem(fields, { itemCtaType });
   // Substitute the GBP symbol seeded into form option labels with the
   // workspace base currency symbol so a USD install doesn't show £ in
   // budget-range / donation-amount dropdowns.

--- a/docs/architecture/archetypes/pet-rescue-operating-model.md
+++ b/docs/architecture/archetypes/pet-rescue-operating-model.md
@@ -436,8 +436,13 @@ reaches the rescue at all. A shelter's inbound traffic is not one funnel:
 Four requirements follow:
 
 1. **No inbound channel may require payment.** A donation prompt in front of a found-pet report is
-   the worst failure available to this archetype, and the same form serves all seven reasons
-   today.
+   the worst failure available to this archetype. **Met 2026-08-27** (BI-7F851119): the five
+   nonprofit archetypes were seeded with a donation form in the contact-form slot, and
+   `donationAmount` was required. They now take the contact fields, including the phone number a
+   found-pet caller has to leave, and `resolveInquiryFormSchema` drops donation fields from any
+   enquiry that is not about a donation item, so an install seeded before the fix is corrected
+   without a re-seed. Donations keep their own route and their own form. **The same form still
+   serves all seven reasons** — requirement 2 below is open.
 2. **The reason for contact is a typed field**, because it sets the queue and the clock. A cruelty
    report and a bequest enquiry cannot share a lane.
 3. **An enquiry about an animal carries that animal's reference**, or staff cannot answer it.

--- a/packages/storefront-templates/src/archetypes/archetypes.test.ts
+++ b/packages/storefront-templates/src/archetypes/archetypes.test.ts
@@ -523,3 +523,42 @@ describe("archetype catalog", () => {
     expect(kit?.activationProfile?.axes?.provisioning).toBe("reservation-and-return");
   });
 });
+
+// A storefront's `formSchema` is its contact form, and for most archetypes it is
+// the only way a stranger can reach the business at all. Five nonprofit
+// archetypes were seeded with a donation form in that slot, so a found-pet
+// report, a surrender request and an offer to volunteer were all refused without
+// a donation amount (BI-7F851119).
+describe("archetype contact forms", () => {
+  const DONATION_FIELD_NAMES = ["donationAmount", "customAmount", "campaignId", "isAnonymous"];
+
+  it("never require a donation to accept a message", () => {
+    for (const archetype of ALL_ARCHETYPES) {
+      const gated = archetype.formSchema
+        .filter((field) => field.required && DONATION_FIELD_NAMES.includes(field.name))
+        .map((field) => field.name);
+      expect(gated, `${archetype.archetypeId} gates its inbound channel behind a donation`).toEqual([]);
+    }
+  });
+
+  it("ask a donation question only where a donation is the point", () => {
+    for (const archetype of ALL_ARCHETYPES) {
+      const donationFields = archetype.formSchema
+        .filter((field) => DONATION_FIELD_NAMES.includes(field.name))
+        .map((field) => field.name);
+      expect(
+        donationFields,
+        `${archetype.archetypeId} asks about a donation on its contact form; donations have their own route`,
+      ).toEqual([]);
+    }
+  });
+
+  it("always offer a way to reach the sender back", () => {
+    for (const archetype of ALL_ARCHETYPES) {
+      const contactable = archetype.formSchema.some((field) =>
+        ["email", "phone"].includes(field.name),
+      );
+      expect(contactable, `${archetype.archetypeId} has no email or phone field`).toBe(true);
+    }
+  });
+});

--- a/packages/storefront-templates/src/archetypes/nonprofit-community.ts
+++ b/packages/storefront-templates/src/archetypes/nonprofit-community.ts
@@ -7,15 +7,12 @@ const CONTACT_FIELDS = [
   { name: "notes", label: "Message", type: "textarea" as const, required: false },
 ];
 
-const DONATION_FORM_FIELDS = [
-  { name: "name", label: "Full name", type: "text" as const, required: true },
-  { name: "email", label: "Email", type: "email" as const, required: true },
-  { name: "donationAmount", label: "Donation amount", type: "select" as const, required: true, options: ["£5", "£10", "£25", "£50", "£100", "Other"] },
-  { name: "customAmount", label: "Custom amount (£)", type: "text" as const, required: false, placeholder: "e.g. 30" },
-  { name: "campaignId", label: "Campaign", type: "text" as const, required: false },
-  { name: "isAnonymous", label: "Make donation anonymous?", type: "select" as const, required: false, options: ["No", "Yes"] },
-  { name: "notes", label: "Message", type: "textarea" as const, required: false },
-];
+// `formSchema` is the archetype's CONTACT form, and for most of these
+// organizations it is the only way a stranger reaches them at all. It carried a
+// donation form until 2026-08-27, so a found-pet report, a surrender request and
+// an offer to volunteer were each refused without a donation amount
+// (BI-7F851119). Donations have their own route and their own form
+// (`/s/[slug]/donate`), which is where a donation question belongs.
 
 const ANIMAL_WELFARE_ACTIVATION_PROFILE = {
   profileType: "standard",
@@ -252,7 +249,7 @@ export const nonprofitCommunityArchetypes: ArchetypeDefinition[] = [
       { type: "donate", title: "Make a Donation", sortOrder: 4 },
       { type: "contact", title: "Get in Touch", sortOrder: 5 },
     ],
-    formSchema: DONATION_FORM_FIELDS,
+    formSchema: CONTACT_FIELDS,
     activationProfile: ANIMAL_WELFARE_ACTIVATION_PROFILE,
   },
   {
@@ -275,7 +272,7 @@ export const nonprofitCommunityArchetypes: ArchetypeDefinition[] = [
       { type: "donate", title: "Donate Now", sortOrder: 4 },
       { type: "contact", title: "Contact Us", sortOrder: 5 },
     ],
-    formSchema: DONATION_FORM_FIELDS,
+    formSchema: CONTACT_FIELDS,
     activationProfile: ANIMAL_SHELTER_ACTIVATION_PROFILE,
   },
   {
@@ -297,7 +294,7 @@ export const nonprofitCommunityArchetypes: ArchetypeDefinition[] = [
       { type: "donate", title: "Donate", sortOrder: 3 },
       { type: "contact", title: "Get Involved", sortOrder: 4 },
     ],
-    formSchema: DONATION_FORM_FIELDS,
+    formSchema: CONTACT_FIELDS,
   },
   {
     archetypeId: "charity",
@@ -319,7 +316,7 @@ export const nonprofitCommunityArchetypes: ArchetypeDefinition[] = [
       { type: "donate", title: "Donate Now", sortOrder: 3 },
       { type: "contact", title: "Get in Touch", sortOrder: 4 },
     ],
-    formSchema: DONATION_FORM_FIELDS,
+    formSchema: CONTACT_FIELDS,
   },
   {
     archetypeId: "sports-club",
@@ -518,7 +515,7 @@ export const nonprofitCommunityArchetypes: ArchetypeDefinition[] = [
       { type: "donate", title: "Donate", sortOrder: 3 },
       { type: "contact", title: "Contact Us", sortOrder: 4 },
     ],
-    formSchema: DONATION_FORM_FIELDS,
+    formSchema: CONTACT_FIELDS,
     activationProfile: {
       profileType: "standard",
       modules: ["service-operations", "lifecycle-signals"],


### PR DESCRIPTION
Found by running Second Chance Animal Rescue as a business for one operating day (`docs/architecture/archetypes/pet-rescue-operating-model.md` §6b). Fixes `BI-7F851119`.

## What was wrong

`StorefrontArchetype.formSchema` is the archetype's **contact** form, and for most of these organizations it is the only way a stranger reaches them at all. Five nonprofit archetypes — `pet-rescue`, `animal-shelter`, `community-shelter`, `charity`, `sports-club` — were seeded with a **donation** form in that slot, with `donationAmount` required.

So every reason a stranger writes in was refused without a donation amount: an adoption enquiry, a found-pet report, a surrender request, an offer to volunteer. §7c of the operating model lists seven inbound reasons sharing this one form. A donation prompt in front of a found-pet report is the worst failure available to this archetype.

The gate was validation, not payment: `Other` + `0` already passed. Nothing was ever charged — people were just turned away at the door.

## Why the donation fields were there at all

They were not doing any work. A `donation` item routes to `/s/[slug]/donate` (`CtaButton.tsx`), which renders `DonationForm` — self-contained, and it never reads `formSchema`. The donation fields in the contact-form slot were pure leakage.

## The fix, in two layers

- **Seed** — the five archetypes take `CONTACT_FIELDS`. This also restores the **phone** field, which the donation form did not have and a found-pet caller needs.
- **Read** — `resolveInquiryFormSchema` drops donation fields unless the enquiry is about a donation item. An install seeded before this fix still holds the old JSON, so the rule is applied on read as well; the live install is corrected without a re-seed. The rule is a pure module beside `slot-booking-fields.ts`, which is the existing precedent for a name-keyed filter over this same schema.

## Tests

- `apps/web/lib/storefront/inquiry-fields.test.ts` — the filter, against the exact schema the five archetypes were seeded with.
- `packages/storefront-templates/src/archetypes/archetypes.test.ts` — every archetype's contact form, standing: none may require a donation, none may ask about one, and all must offer a way to reach the sender back.

Defect class removed: a payment gate standing in front of a non-payment channel.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/architecture/archetypes/pet-rescue-operating-model.md` §7c — the seven reasons a stranger arrives; requirement 1 is "no inbound channel may require payment".
  - `docs/architecture/archetype-operating-model-audit.md` — the public dimension and the five defect classes.
  - `docs/architecture/accommodation-doctrine.md` — pattern 1, a field-name vocabulary over an existing schema slot. No new structure.
- Current code substrate reviewed:
  - `apps/web/lib/storefront/storefront-data.ts` — the single read path for all three enquiry routes.
  - `apps/web/components/storefront/slot-booking-fields.ts` — the precedent followed.
  - `apps/web/components/storefront/CtaButton.tsx` and `DonationForm.tsx` — donations already have their own route and form.
- Source of truth: `StorefrontArchetype.formSchema` stays the one schema slot; the purpose filter is applied on read rather than duplicating the column.
- Decision: fix the seed **and** add the read-time rule, because the live install already holds the bad JSON and a re-seed is not guaranteed.

Design-Grounding-Decision: donation fields belong to the donation route; the contact form is not a payment surface
Process-Spine-Decision: records the fix against §7c requirement 1 in the pet-rescue operating model
Seed-Fit-Decision: vertical-scoped
