### PR TITLE
fix(storefront): an animal's details must be correctable, and Delete must ask (BI-56BB6038)

### DIFF
--- a/apps/web/components/storefront-admin/AnimalsManager.test.tsx
+++ b/apps/web/components/storefront-admin/AnimalsManager.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+// The photo gallery is exercised by its own tests and fetches on mount; stub it
+// so the fetch assertions below observe only the animal record calls.
+vi.mock("./MediaUploader", () => ({
+  MediaUploader: () => null,
+}));
+
+import { AnimalsManager } from "./AnimalsManager";
+
+// Scout was recorded at intake with the finder's name, telephone number and
+// home address in the description, and the description reached the open web
+// (BI-56BB6038). Until this fix the only way to take it back was to delete the
+// animal and its photographs.
+const SCOUT = {
+  id: "animal-1",
+  name: "Scout",
+  species: "dog",
+  breed: "Collie cross",
+  age: "young",
+  sex: "male",
+  size: "medium",
+  description: "Found by Erin Vasquez, 07700 900123, 14 Mill Lane.",
+  status: "hold",
+  media: [],
+};
+
+function renderManager() {
+  return render(<AnimalsManager animals={[SCOUT]} hasAnimalsSection />);
+}
+
+/** The details disclosure, opened. */
+function openDetails() {
+  fireEvent.click(screen.getByText("Details"));
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("correcting an animal after intake", () => {
+  it("offers every descriptive field for correction, not just name and status", () => {
+    renderManager();
+    openDetails();
+
+    const details = screen.getByText("Details").closest("details") as HTMLElement;
+    expect(within(details).getByDisplayValue("Collie cross")).toBeInTheDocument();
+    expect(within(details).getByDisplayValue("young")).toBeInTheDocument();
+    expect(within(details).getByDisplayValue("male")).toBeInTheDocument();
+    expect(within(details).getByDisplayValue("medium")).toBeInTheDocument();
+    expect(within(details).getByDisplayValue(SCOUT.description)).toBeInTheDocument();
+  });
+
+  it("stores a redacted description without deleting the animal", async () => {
+    renderManager();
+    openDetails();
+
+    const field = screen.getByDisplayValue(SCOUT.description);
+    fireEvent.change(field, { target: { value: "Found as a stray on Route 9." } });
+    fireEvent.blur(field);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/storefront/admin/animals/animal-1");
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body)).toEqual({ description: "Found as a stray on Route 9." });
+    // The animal and its photographs survive the redaction.
+    expect(screen.getByDisplayValue("Scout")).toBeInTheDocument();
+  });
+
+  it("does not write to the server on every keystroke", () => {
+    renderManager();
+    openDetails();
+
+    const field = screen.getByDisplayValue("Collie cross");
+    fireEvent.change(field, { target: { value: "Collie" } });
+    fireEvent.change(field, { target: { value: "Collie x" } });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("says so and rolls the field back when the save is refused", async () => {
+    fetchMock.mockResolvedValue({ ok: false, json: async () => ({}) });
+    renderManager();
+    openDetails();
+
+    const field = screen.getByDisplayValue("Collie cross");
+    fireEvent.change(field, { target: { value: "Border collie" } });
+    fireEvent.blur(field);
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("Not saved"));
+    expect(screen.getByDisplayValue("Collie cross")).toBeInTheDocument();
+  });
+});
+
+describe("deleting an animal", () => {
+  it("asks before destroying the animal and its photographs", () => {
+    renderManager();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.getByText("Also removes the photos.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Keep" })).toBeInTheDocument();
+  });
+
+  it("keeps the animal when the confirmation is declined", () => {
+    renderManager();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    fireEvent.click(screen.getByRole("button", { name: "Keep" }));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.getByDisplayValue("Scout")).toBeInTheDocument();
+  });
+
+  it("deletes only on the second, deliberate press", async () => {
+    renderManager();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock.mock.calls[0][1].method).toBe("DELETE");
+    await waitFor(() => expect(screen.queryByDisplayValue("Scout")).not.toBeInTheDocument());
+  });
+
+  it("gives both destructive controls a 44px touch target for the tablet", () => {
+    renderManager();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    for (const name of ["Delete", "Keep"]) {
+      expect(screen.getByRole("button", { name }).style.minHeight).toBe("44px");
+    }
+  });
+});

--- a/apps/web/components/storefront-admin/AnimalsManager.tsx
+++ b/apps/web/components/storefront-admin/AnimalsManager.tsx
@@ -4,8 +4,18 @@
 // edits AdoptableAnimal records and, per animal, embeds the reusable MediaUploader
 // so each gets a photo gallery. Photos drive the public `animals-available`
 // section through the media substrate.
+//
+// Every descriptive field used to be write-once here: the list row rendered only
+// name and status, so an intake note carrying a finder's name, telephone number
+// and home address could be corrected only by deleting the animal and its
+// photographs (BI-56BB6038). The API already accepted the full patch; the surface
+// did not offer it. Details now sit behind a per-animal disclosure, so a ward of
+// forty stays scannable and a correction is one click away (DI-88E0F9374F4D).
+//
+// Delete asks first, at a target size a kennel technician can hit one-handed on
+// the tablet the work is really done on.
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { MediaUploader } from "./MediaUploader";
 
 interface MediaItem {
@@ -29,6 +39,8 @@ interface AdminAnimal {
   media: MediaItem[];
 }
 
+type SaveState = "saving" | "saved" | "error";
+
 const STATUSES = ["available", "pending", "hold", "adopted"];
 const SPECIES = ["dog", "cat", "rabbit", "bird", "other"];
 
@@ -40,6 +52,16 @@ const inputStyle: React.CSSProperties = {
 };
 
 const inputClass = "border border-[var(--dpf-border)] bg-[var(--dpf-bg)] text-[var(--dpf-text)]";
+
+/** Destructive and confirming controls are hit one-handed on a 768px tablet, so
+ *  they carry the 44px target the rest of the portal uses. */
+const touchTargetStyle: React.CSSProperties = {
+  minHeight: 44,
+  fontSize: 13,
+  padding: "8px 14px",
+  borderRadius: 6,
+  cursor: "pointer",
+};
 
 const emptyDraft = {
   name: "",
@@ -63,6 +85,14 @@ export function AnimalsManager({
   const [draft, setDraft] = useState({ ...emptyDraft });
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<Record<string, SaveState>>({});
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+
+  // Last value the server confirmed, so a rejected save can be rolled back
+  // rather than leaving the screen showing an edit that was never stored.
+  const confirmed = useRef<Record<string, AdminAnimal>>(
+    Object.fromEntries(initial.map((a) => [a.id, a])),
+  );
 
   async function createAnimal() {
     if (!draft.name.trim()) {
@@ -83,24 +113,60 @@ export function AnimalsManager({
         return;
       }
       const created = (await res.json()) as AdminAnimal;
-      setAnimals((prev) => [...prev, { ...created, media: [] }]);
+      const record = { ...created, media: [] };
+      confirmed.current[record.id] = record;
+      setAnimals((prev) => [...prev, record]);
       setDraft({ ...emptyDraft });
     } finally {
       setBusy(false);
     }
   }
 
-  async function updateAnimal(id: string, patch: Partial<AdminAnimal>) {
+  /** Type into a field without writing to the server on every keystroke. */
+  function editAnimal(id: string, patch: Partial<AdminAnimal>) {
     setAnimals((prev) => prev.map((a) => (a.id === id ? { ...a, ...patch } : a)));
-    await fetch(`/api/storefront/admin/animals/${id}`, {
+  }
+
+  /** Store the edit. A rejected save rolls the field back to the stored value and
+   *  says so, rather than leaving a correction that only looks applied. */
+  async function saveAnimal(id: string, patch: Partial<AdminAnimal>) {
+    const previous = confirmed.current[id];
+    const unchanged =
+      previous != null &&
+      Object.entries(patch).every(([key, value]) => previous[key as keyof AdminAnimal] === value);
+    if (unchanged) return;
+
+    editAnimal(id, patch);
+    setSaveState((prev) => ({ ...prev, [id]: "saving" }));
+    const res = await fetch(`/api/storefront/admin/animals/${id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(patch),
-    });
+    }).catch(() => null);
+
+    if (!res?.ok) {
+      if (previous) {
+        setAnimals((prev) =>
+          prev.map((a) => (a.id === id ? { ...previous, media: a.media } : a)),
+        );
+      }
+      setSaveState((prev) => ({ ...prev, [id]: "error" }));
+      return;
+    }
+    confirmed.current[id] = { ...(previous ?? ({ id } as AdminAnimal)), ...patch };
+    setSaveState((prev) => ({ ...prev, [id]: "saved" }));
   }
 
   async function deleteAnimal(id: string) {
-    await fetch(`/api/storefront/admin/animals/${id}`, { method: "DELETE" });
+    setPendingDelete(null);
+    const res = await fetch(`/api/storefront/admin/animals/${id}`, {
+      method: "DELETE",
+    }).catch(() => null);
+    if (!res?.ok) {
+      setSaveState((prev) => ({ ...prev, [id]: "error" }));
+      return;
+    }
+    delete confirmed.current[id];
     setAnimals((prev) => prev.filter((a) => a.id !== id));
   }
 
@@ -111,13 +177,11 @@ export function AnimalsManager({
           Adoptable animals
         </h1>
         <p className="text-[var(--dpf-muted)]" style={{ fontSize: 13 }}>
-          These appear in the “Animals available for adoption” section of your public storefront,
-          each with their photos.
+          These show on your public storefront with their photos.
         </p>
         {!hasAnimalsSection && (
           <p className="text-[var(--dpf-error)]" style={{ fontSize: 12 }}>
-            Your storefront has no “animals-available” section yet — add one in Sections to show
-            these publicly.
+            Add an “animals-available” section to show them.
           </p>
         )}
       </div>
@@ -194,27 +258,109 @@ export function AnimalsManager({
               display: "flex", flexDirection: "column", gap: 12 }}>
             <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
               <input className={inputClass} style={{ ...inputStyle, width: 200, fontWeight: 600 }} value={animal.name}
-                onChange={(e) => updateAnimal(animal.id, { name: e.target.value })} />
+                onChange={(e) => editAnimal(animal.id, { name: e.target.value })}
+                onBlur={(e) => void saveAnimal(animal.id, { name: e.target.value })} />
               <select className={inputClass} style={{ ...inputStyle, width: 140 }} value={animal.status}
-                onChange={(e) => updateAnimal(animal.id, { status: e.target.value })}>
+                onChange={(e) => void saveAnimal(animal.id, { status: e.target.value })}>
                 {STATUSES.map((s) => <option key={s} value={s}>{s}</option>)}
               </select>
               <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>
                 {[animal.species, animal.breed, animal.age].filter(Boolean).join(" · ")}
               </span>
-              <button type="button" onClick={() => void deleteAnimal(animal.id)}
-                className="border border-[var(--dpf-border)] bg-transparent text-[var(--dpf-error)]"
-                style={{ marginLeft: "auto", fontSize: 12, padding: "4px 10px",
-                  borderRadius: 6, cursor: "pointer" }}>
-                Delete
-              </button>
+              {saveState[animal.id] === "saving" && (
+                <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>Saving…</span>
+              )}
+              {saveState[animal.id] === "saved" && (
+                <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>Saved</span>
+              )}
+              {saveState[animal.id] === "error" && (
+                <span role="alert" className="text-[var(--dpf-error)]" style={{ fontSize: 12 }}>Not saved</span>
+              )}
+
+              {pendingDelete === animal.id ? (
+                <span style={{ marginLeft: "auto", display: "flex", gap: 8, alignItems: "center" }}>
+                  <span className="text-[var(--dpf-error)]" style={{ fontSize: 12 }}>
+                    Also removes the photos.
+                  </span>
+                  <button type="button" onClick={() => void deleteAnimal(animal.id)}
+                    className="border border-[var(--dpf-error)] bg-transparent text-[var(--dpf-error)]"
+                    style={touchTargetStyle}>
+                    Delete
+                  </button>
+                  <button type="button" onClick={() => setPendingDelete(null)}
+                    className="border border-[var(--dpf-border)] bg-transparent text-[var(--dpf-text)]"
+                    style={touchTargetStyle}>
+                    Keep
+                  </button>
+                </span>
+              ) : (
+                <button type="button" onClick={() => setPendingDelete(animal.id)}
+                  className="border border-[var(--dpf-border)] bg-transparent text-[var(--dpf-error)]"
+                  style={{ ...touchTargetStyle, marginLeft: "auto" }}>
+                  Delete
+                </button>
+              )}
             </div>
+
+            {/* Correcting what was typed at intake, without deleting the animal. */}
+            <details>
+              <summary className="text-[var(--dpf-muted)]"
+                style={{ fontSize: 12, cursor: "pointer", minHeight: 28 }}>
+                Details
+              </summary>
+              <div style={{
+                marginTop: 10,
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+                gap: 10,
+              }}>
+                <label>
+                  <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>Species</span>
+                  <select className={inputClass} style={inputStyle} value={animal.species ?? ""}
+                    onChange={(e) => void saveAnimal(animal.id, { species: e.target.value })}>
+                    {SPECIES.map((s) => <option key={s} value={s}>{s}</option>)}
+                  </select>
+                </label>
+                <label>
+                  <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>Breed</span>
+                  <input className={inputClass} style={inputStyle} value={animal.breed ?? ""}
+                    onChange={(e) => editAnimal(animal.id, { breed: e.target.value })}
+                    onBlur={(e) => void saveAnimal(animal.id, { breed: e.target.value })} />
+                </label>
+                <label>
+                  <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>Age</span>
+                  <input className={inputClass} style={inputStyle} value={animal.age ?? ""}
+                    onChange={(e) => editAnimal(animal.id, { age: e.target.value })}
+                    onBlur={(e) => void saveAnimal(animal.id, { age: e.target.value })} />
+                </label>
+                <label>
+                  <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>Sex</span>
+                  <input className={inputClass} style={inputStyle} value={animal.sex ?? ""}
+                    onChange={(e) => editAnimal(animal.id, { sex: e.target.value })}
+                    onBlur={(e) => void saveAnimal(animal.id, { sex: e.target.value })} />
+                </label>
+                <label>
+                  <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>Size</span>
+                  <input className={inputClass} style={inputStyle} value={animal.size ?? ""}
+                    onChange={(e) => editAnimal(animal.id, { size: e.target.value })}
+                    onBlur={(e) => void saveAnimal(animal.id, { size: e.target.value })} />
+                </label>
+                <label style={{ gridColumn: "1 / -1" }}>
+                  <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>Description</span>
+                  <textarea className={inputClass} style={{ ...inputStyle, minHeight: 56 }}
+                    value={animal.description ?? ""}
+                    onChange={(e) => editAnimal(animal.id, { description: e.target.value })}
+                    onBlur={(e) => void saveAnimal(animal.id, { description: e.target.value })} />
+                </label>
+              </div>
+            </details>
+
             <MediaUploader
               ownerType="AdoptableAnimal"
               ownerId={animal.id}
               role="gallery"
               label="Photos"
-              hint="First photo is the lead image shown on the storefront"
+              hint="First photo leads the listing."
             />
           </div>
         ))

--- a/docs/architecture/archetypes/pet-rescue-operating-model.md
+++ b/docs/architecture/archetypes/pet-rescue-operating-model.md
@@ -294,7 +294,12 @@ running as more than one person with a clipboard:
 3. **Operational notes are published, and cannot be taken back.** Recording an intake put a
    finder's name, telephone number and home address on the open web within seconds, and every
    descriptive field is write-once, so the only redaction is deleting the animal and its
-   photographs. *(BI-56BB6038)*
+   photographs. *(BI-56BB6038)* **Half fixed 2026-08-27**: species, breed, age, sex, size and
+   description are now correctable on the animal, behind a per-card disclosure, and a refused
+   save says so instead of leaving an edit that only looks applied. Publication itself is not
+   fixed — the description is still the animal's only text field and it is still public marketing
+   copy, so intake detail has nowhere private to go until `BI-4F8A484C` gives an animal an
+   existence independent of its listing.
 
 ### What worked, and is now a regression surface
 
@@ -315,8 +320,10 @@ anything. Two animals in the ward carry legally different obligations and are in
 screen. This is the concrete case for element 10 of the canonical minimal substrate.
 
 **Destructive controls are undersized for the tablet the work is done on.** At 768×1024 the
-per-animal Delete measures 59×28 px and the photo remove control 24×24, both unconfirmed, on the
-device a kennel technician holds one-handed.
+per-animal Delete measured 59×28 px and the photo remove control 24×24, both unconfirmed, on the
+device a kennel technician holds one-handed. The per-animal Delete was fixed on 2026-08-27 — it
+asks first, and both it and its confirmation carry a 44 px target. **The photo remove control is
+unchanged**: still 24×24 and still unconfirmed.
 
 ## 7. UX requirements
 

--- a/docs/ux-fit/2026-08-27-animal-record-correction.ux-fit.json
+++ b/docs/ux-fit/2026-08-27-animal-record-correction.ux-fit.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "decidedOption": "per-card-details-disclosure",
+  "decisionInteractionId": "DI-88E0F9374F4D",
+  "scope": {
+    "files": [
+      "apps/web/components/storefront-admin/AnimalsManager.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "per-card-details-disclosure",
+      "always-visible-inline-fields",
+      "per-animal-edit-route"
+    ],
+    "note": "Running the pet-rescue operating day found that an animal record is write-once: the list row rendered only name and status, so an intake note carrying a finder's name, telephone number and home address could be redacted only by deleting the animal and its photographs (BI-56BB6038). The PUT already accepted every field; the surface did not offer it. Three shapes were scored. per-card-details-disclosure won at composite 11.526 with a 2.416 margin, high confidence, no commandment conflict: it keeps a forty-animal ward scannable on the 768x1024 tablet the rounds are walked with, while putting the correction one click away. always-visible-inline-fields scored 9.110 - one click cheaper but it turns the ward into a wall of inputs, and it is the option 'human_cognitive_load' penalises. per-animal-edit-route scored 6.397: it is the right long-term home for an animal record, but it is a net-new route carrying the full UX-budget gauntlet, and the animal should not live under storefront admin at all once BI-4F8A484C gives it an existence independent of the listing. Delete is now a two-step inline confirm at a 44px target, replacing the 59x28px unconfirmed control the run measured."
+  }
+}


### PR DESCRIPTION
Found by running Second Chance Animal Rescue as a business for one operating day (`docs/architecture/archetypes/pet-rescue-operating-model.md` §6b). This is the shippable half of `BI-56BB6038`.

## What was wrong

Recording an intake put a finder's name, telephone number and home address on the open web within seconds — and left no way to take it back. The animals list rendered only **name** and **status**, so `species`, `breed`, `age`, `sex` and `description` were write-once. The only redaction available was deleting the animal **and its photographs**, on one unconfirmed press, at 59×28 px on the tablet the rounds are walked with.

The `PUT` at `apps/web/app/api/storefront/admin/animals/[id]/route.ts` already accepted every one of those fields. The surface did not offer them.

## What this changes

- **Details sit behind a per-animal disclosure.** A ward of forty stays scannable; a correction is one click away.
- **A field saves on blur, not per keystroke.** The old name input fired a `PUT` on every character and ignored the response.
- **A refused save rolls the field back and says "Not saved".** It no longer leaves a correction that only looks applied.
- **Delete asks first.** It and its confirmation carry a 44 px target.

## What this does NOT fix

Publication. The description is still the animal's only text field and it is still public marketing copy, so intake detail has nowhere private to go. That waits on `BI-4F8A484C` — an animal that can exist independently of its listing. `BI-56BB6038` stays open for that half, and §6b now records both halves and states plainly that the **photo remove control is unchanged**: still 24×24 and still unconfirmed.

Defect classes removed: **write-once** (every descriptive field) and **silent failure** (a save that reported nothing either way).

## Tests

`apps/web/components/storefront-admin/AnimalsManager.test.tsx` — 8 tests, driven from Scout's real intake record: every field offered, a redaction stored without deleting the animal, no write per keystroke, a refused save rolled back and announced, delete asked for and declined and confirmed, and both destructive controls measured at 44 px.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/architecture/archetypes/pet-rescue-operating-model.md` §6b — the run, and the trap about destructive controls at 768×1024.
  - `docs/architecture/archetype-operating-model-audit.md` — "editing after creation" is one of the five standing probes; write-once is one of the five defect classes.
  - `docs/architecture/accommodation-doctrine.md` — no new structure; a surface that was not offering what the API already accepted.
- Current code substrate reviewed:
  - `apps/web/app/api/storefront/admin/animals/[id]/route.ts` — the `PUT` already accepts the full patch.
  - `apps/web/components/storefront-admin/AnimalsManager.tsx` — the list row was the whole edit surface.
  - `apps/web/components/storefront-admin/HospitalityResourceManager.test.tsx` — the sibling manager's test shape, followed here.
- Source of truth: the animals API stays the one writer; no second update path was added.
- Decision: a per-card disclosure over always-visible fields or a net-new edit route. Scored on the kernel — composite 11.526, margin 2.416, high confidence, no commandment conflict (`DI-88E0F9374F4D`); UX-fit evidence at `docs/ux-fit/2026-08-27-animal-record-correction.ux-fit.json`. A net-new route is the right long-term home for an animal record, but it should not be built under storefront admin, which is exactly what `BI-4F8A484C` moves.

Design-Grounding-Decision: the animal is corrected where it is listed, until the keystone gives it a home of its own
Process-Spine-Decision: records both halves of the finding against §6b of the pet-rescue operating model
