### PR TITLE
fix(twin): the value stream must not promise destinations it does not have (BI-AF50DBD5)

### DIFF
--- a/apps/web/components/twin/ValueStreamStrip.test.tsx
+++ b/apps/web/components/twin/ValueStreamStrip.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { ValueStreamStrip } from "./ValueStreamStrip";
+import type { TwinStageFlow } from "./snapshot";
+
+// Running the pet-rescue operating day found sixteen correctly named stages,
+// every one reading 0, every one carrying a chevron, none of them clickable
+// (BI-AF50DBD5). Exactly one of the sixteen has a queue or a zone bound to it,
+// so fifteen of those zeros were counts nothing had ever been able to produce.
+function stage(over: Partial<TwinStageFlow> & { stageKey: string }): TwinStageFlow {
+  return {
+    label: over.stageKey,
+    order: 0,
+    loadBearing: false,
+    observable: false,
+    count: 0,
+    ...over,
+  };
+}
+
+const RESCUE_STAGES: TwinStageFlow[] = [
+  stage({ stageKey: "intake-report-handoff", label: "Report, retrieval, or handoff", order: 110 }),
+  stage({
+    stageKey: "intake-capacity-decision",
+    label: "Make the capacity decision",
+    order: 130,
+    loadBearing: true,
+    observable: true,
+    count: 2,
+  }),
+  stage({ stageKey: "welfare-daily-care", label: "Deliver daily care", order: 210, loadBearing: true }),
+];
+
+afterEach(cleanup);
+
+describe("ValueStreamStrip", () => {
+  it("renders no chevron — the tiles are not controls and never were", () => {
+    const { container } = render(<ValueStreamStrip stages={RESCUE_STAGES} />);
+    expect(container.textContent).not.toContain("›");
+  });
+
+  it("offers nothing clickable, so it promises no destination", () => {
+    render(<ValueStreamStrip stages={RESCUE_STAGES} />);
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  it("prints a count only for a stage something can actually record", () => {
+    render(<ValueStreamStrip stages={RESCUE_STAGES} />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("shows the absence of a measurement as an absence, not as zero", () => {
+    const { container } = render(<ValueStreamStrip stages={RESCUE_STAGES} />);
+    const untracked = container.querySelectorAll('[data-stage-observable="false"]');
+    expect(untracked).toHaveLength(2);
+    for (const tile of untracked) {
+      expect(tile.textContent).toContain("—");
+    }
+    // and it is legible to a screen reader, not only to the eye
+    expect(screen.getAllByText("Not tracked yet")).toHaveLength(2);
+  });
+
+  it("still names every stage of the operator's day", () => {
+    render(<ValueStreamStrip stages={RESCUE_STAGES} />);
+    for (const s of RESCUE_STAGES) {
+      expect(screen.getByText(s.label)).toBeInTheDocument();
+    }
+  });
+
+  it("explains the dash once, and only when there is one", () => {
+    const { rerender } = render(<ValueStreamStrip stages={RESCUE_STAGES} />);
+    expect(screen.getByText("A dash means nothing records that stage yet.")).toBeInTheDocument();
+
+    rerender(<ValueStreamStrip stages={RESCUE_STAGES.filter((s) => s.observable)} />);
+    expect(
+      screen.queryByText("A dash means nothing records that stage yet."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the archetype has no stages", () => {
+    const { container } = render(<ValueStreamStrip stages={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/components/twin/ValueStreamStrip.tsx
+++ b/apps/web/components/twin/ValueStreamStrip.tsx
@@ -5,6 +5,20 @@
 // longest wait overlaid, so the twin's animation view and the architecture view
 // are one picture. Load-bearing stages — where this archetype's value is actually
 // captured — are accented. Presentational; driven by TwinSnapshot.stageFlow.
+//
+// Two things this strip used to claim and could not deliver (BI-AF50DBD5):
+//
+//   1. A chevron after every stage. It was a decorative separator, but it reads
+//      as "open this", and there is nothing behind it — the tiles are not
+//      controls and never were. It is gone; the flow now reads from the layout.
+//   2. A count of 0 on a stage nothing binds to. Of pet-rescue's sixteen stages
+//      exactly one has a queue or a zone bound to it, so fifteen printed a zero
+//      no query had ever been in a position to produce. An unobservable stage
+//      now shows a dash: the stage is named, and the absence of a measurement is
+//      shown as an absence.
+//
+// Naming the operator's day correctly while promising sixteen destinations reads
+// as further along than saying nothing. That is the illusion this removes.
 
 import type { TwinStageFlow } from "./snapshot";
 
@@ -15,45 +29,55 @@ export interface ValueStreamStripProps {
 
 export function ValueStreamStrip({ stages, className = "" }: ValueStreamStripProps) {
   if (stages.length === 0) return null;
+  const anyUntracked = stages.some((stage) => !stage.observable);
 
   return (
-    <div
-      className={`flex items-stretch gap-1 overflow-x-auto rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface)] p-2 ${className}`.trim()}
-      aria-label="Value stream"
-    >
-      {stages.map((stage, i) => (
-        <div key={stage.stageKey} className="flex items-stretch gap-1">
+    <div className={className}>
+      <div
+        className="flex items-stretch gap-px overflow-x-auto rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface)] p-2"
+        aria-label="Value stream"
+      >
+        {stages.map((stage) => (
           <div
+            key={stage.stageKey}
             className={`flex min-w-[92px] flex-col justify-between rounded-md px-2.5 py-1.5 ${
               stage.loadBearing
                 ? "bg-[var(--dpf-accent-soft,var(--dpf-surface-2))] ring-1 ring-[var(--dpf-accent)]"
                 : "bg-[var(--dpf-surface-2)]"
-            }`}
+            } ${stage.observable ? "" : "opacity-60"}`.trim()}
             title={stage.loadBearing ? `${stage.label} — load-bearing stage` : stage.label}
+            data-stage-observable={stage.observable ? "true" : "false"}
           >
             <div className="text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)] leading-tight">
               {stage.label}
             </div>
             <div className="mt-1 flex items-baseline justify-between gap-1">
-              <span
-                className={`text-sm font-semibold ${
-                  stage.count > 0 ? "text-[var(--dpf-text)]" : "text-[var(--dpf-muted)]"
-                }`}
-              >
-                {stage.count}
-              </span>
+              {stage.observable ? (
+                <span
+                  className={`text-sm font-semibold ${
+                    stage.count > 0 ? "text-[var(--dpf-text)]" : "text-[var(--dpf-muted)]"
+                  }`}
+                >
+                  {stage.count}
+                </span>
+              ) : (
+                <span className="text-sm font-semibold text-[var(--dpf-muted)]">
+                  <span aria-hidden>—</span>
+                  <span className="sr-only">Not tracked yet</span>
+                </span>
+              )}
               {stage.longestWait ? (
                 <span className="text-[10px] text-[var(--dpf-warning)]">{stage.longestWait}</span>
               ) : null}
             </div>
           </div>
-          {i < stages.length - 1 ? (
-            <span className="self-center text-[var(--dpf-muted)]" aria-hidden>
-              ›
-            </span>
-          ) : null}
-        </div>
-      ))}
+        ))}
+      </div>
+      {anyUntracked ? (
+        <p className="mt-1 text-dpf-caption text-[var(--dpf-muted)]">
+          A dash means nothing records that stage yet.
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/components/twin/snapshot.ts
+++ b/apps/web/components/twin/snapshot.ts
@@ -48,6 +48,11 @@ export interface TwinStageFlow {
   label: string;
   order: number;
   loadBearing: boolean;
+  /** Whether any twin queue or zone binds to this stage. A stage nothing binds
+   *  can never hold a record, so its count is not a measurement of zero — it is
+   *  the absence of one, and the strip must say so rather than print 0
+   *  (BI-AF50DBD5). */
+  observable: boolean;
   /** Demand units currently at this stage. */
   count: number;
   /** Longest wait among demand at this stage ("8m", "2d"); omitted when none waits. */

--- a/apps/web/lib/twin/operations-snapshot.test.ts
+++ b/apps/web/lib/twin/operations-snapshot.test.ts
@@ -15,7 +15,7 @@ import {
 function twinFixture(): TwinSnapshot {
   return {
     capacityChips: [{ key: "open", label: "Tables open", value: 4 }],
-    stageFlow: [{ stageKey: "serve", label: "Serve", order: 1, loadBearing: true, count: 2 }],
+    stageFlow: [{ stageKey: "serve", label: "Serve", order: 1, loadBearing: true, observable: true, count: 2 }],
     outcomes: [{ key: "served", label: "Served", value: "12" }],
     outcomesHeading: "Guest outcomes",
     zones: [{ key: "floor", units: [{ key: "t1", label: "Table 1", state: "Available" }] }],

--- a/apps/web/lib/twin/stage-flow.test.ts
+++ b/apps/web/lib/twin/stage-flow.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
+import { deriveTwinValueStreamBinding } from "@dpf/storefront-templates";
+
+import { buildStageFlow } from "./stage-flow";
+
+function bindingFor(archetypeId: string) {
+  const archetype = ALL_ARCHETYPES.find((a) => a.archetypeId === archetypeId);
+  if (!archetype) throw new Error(`no archetype ${archetypeId}`);
+  return deriveTwinValueStreamBinding(archetype);
+}
+
+describe("buildStageFlow", () => {
+  it("marks a stage observable only when a queue or a zone binds to it", () => {
+    const binding = bindingFor("pet-rescue");
+    const flow = buildStageFlow(binding, {});
+
+    for (const stage of flow) {
+      const bound = binding.stages.find((s) => s.stageKey === stage.stageKey)!;
+      expect(stage.observable).toBe(bound.queueKeys.length > 0 || bound.zoneKeys.length > 0);
+    }
+  });
+
+  it("finds pet-rescue's day is almost entirely unobservable — the reason the strip read all zeros", () => {
+    const flow = buildStageFlow(bindingFor("pet-rescue"), {});
+
+    expect(flow).toHaveLength(16);
+    const observable = flow.filter((s) => s.observable).map((s) => s.stageKey);
+    expect(observable).toEqual(["intake-capacity-decision"]);
+  });
+
+  it("still carries the demand it is given for a stage that is observed", () => {
+    const flow = buildStageFlow(bindingFor("pet-rescue"), {
+      "intake-capacity-decision": { count: 3, longestWaitMs: 90 * 60_000 },
+    });
+
+    const stage = flow.find((s) => s.stageKey === "intake-capacity-decision")!;
+    expect(stage).toMatchObject({ observable: true, count: 3, longestWait: "2h" });
+  });
+
+  it("does not report an archetype as fully unobservable when it is not", () => {
+    const flow = buildStageFlow(bindingFor("restaurant"), {});
+    expect(flow.filter((s) => s.observable).length).toBeGreaterThan(0);
+    expect(flow.filter((s) => !s.observable).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/lib/twin/stage-flow.ts
+++ b/apps/web/lib/twin/stage-flow.ts
@@ -30,6 +30,11 @@ function fmtWait(ms: number): string {
  * Project a per-stage demand map onto the archetype's ordered value-stream
  * backbone. Every stage the archetype has appears (count 0 where no demand), so
  * the strip always shows the full stream with the live/demo demand overlaid.
+ *
+ * A stage carries `observable` when some twin queue or zone binds to it. Most do
+ * not: of pet-rescue's sixteen stages exactly one is bound, so fifteen of them
+ * were reporting a count of 0 that no query had ever been able to produce
+ * (BI-AF50DBD5).
  */
 export function buildStageFlow(
   binding: TwinValueStreamBinding,
@@ -42,6 +47,7 @@ export function buildStageFlow(
       label: s.stageLabel,
       order: s.order,
       loadBearing: s.loadBearing,
+      observable: s.queueKeys.length > 0 || s.zoneKeys.length > 0,
       count: d?.count ?? 0,
       ...(d?.longestWaitMs && d.longestWaitMs > 0 ? { longestWait: fmtWait(d.longestWaitMs) } : {}),
     };

--- a/docs/architecture/archetype-operating-model-audit.md
+++ b/docs/architecture/archetype-operating-model-audit.md
@@ -280,6 +280,16 @@ quarantine and place, deliver daily care, transfer custody. Every stage reads ze
 clickable. A surface that names the work correctly reads as further along than one that says
 Quotes and Orders, and is not.
 
+**A count of zero on a stage nothing can reach is not a measurement.** Resolved 2026-08-27 on
+`BI-AF50DBD5`, and the way it was resolved generalises. The rescue's sixteen stages each printed
+`0`; a binding check showed **one** of the sixteen has any queue or zone bound to it, so fifteen
+zeros were counts no query had ever been in a position to produce. Both honest options were on
+the table — route the stages to the work, or stop claiming a destination. The second was taken,
+because the records those stages would route to do not exist yet (`BI-4F8A484C`). The chevron is
+gone, and an unobservable stage now shows a dash rather than a zero. **When auditing any strip,
+tile or funnel, ask what would have to be true for the number to be non-zero; if nothing could
+make it move, the number is decoration.**
+
 **Assess the operators, or you assess a demo.** Every judgement made from a single founder account
 is a judgement about a business with one employee. If the instance has no worker persona, creating
 one is part of the audit, not preparation for it.

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -9173,7 +9173,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 2
+    "textMass": 13
   },
   "apps/web/components/twin/WorkItem.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
Found by running Second Chance Animal Rescue as a business for one operating day (`docs/architecture/archetypes/pet-rescue-operating-model.md` §6b). Fixes `BI-AF50DBD5`.

## What was wrong

`/workspace` names all sixteen stages of a rescue's day correctly — report and handoff, identify and triage, deliver daily care, transfer custody — gives each a trailing chevron, reads **0** on every one, and does nothing when clicked. The tiles are bare `<div>`s. A worker presses "DELIVER DAILY CARE" to start rounds and gets nothing.

The audit calls this the more convincing illusion: a surface that names the work correctly reads as further along than one that says Quotes and Orders, and is not.

## Two claims, neither true

**The chevron.** A decorative separator that reads as "open this". Gone; the flow now reads from the layout.

**The zeros.** A binding check settles what was actually wrong. Of pet-rescue's sixteen stages, exactly **one** — `intake-capacity-decision` — has any twin queue or zone bound to it:

```
110 intake-report-handoff        q=0 z=0
130 intake-capacity-decision     q=3 z=2   <- the only one
210 welfare-daily-care           q=0 z=0
... 13 more, all q=0 z=0
```

Fifteen stages printed a count of 0 that no query had ever been in a position to produce. `TwinStageFlow` now carries `observable`, derived from the archetype's own stage binding, and an unobservable stage shows a dash instead of a zero. The stage keeps its name — the vocabulary was the part that was right.

## The decision, recorded

Both honest options were open: route the stages to the work, or stop claiming a destination. **The second**, because the records those stages would route to do not exist yet — an animal cannot exist independently of a storefront listing (`BI-4F8A484C`), so there is nothing for fifteen of the sixteen to open. Routing becomes the right fix once the keystone lands.

Feeds `EP-39F60B06`, which exists to detect inert stages: `observable` is that signal, computed rather than asserted.

The audit doc records the generalisable check this produced — *ask what would have to be true for a number to be non-zero; if nothing could make it move, the number is decoration.*

Defect class removed: **inert affordance**.

## Not a regression

`restaurant` keeps a mix of observable and unobservable stages, asserted in `stage-flow.test.ts`, so the change does not simply blank every strip. 11 new tests; the full `lib/twin` + `components/twin` surface (41 files, 214 tests) is green.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/architecture/archetype-operating-model-audit.md` — the inert-affordance class names this exact surface as its example.
  - `docs/architecture/archetypes/pet-rescue-operating-model.md` §6b — the run.
  - `docs/architecture/canonical-minimal-substrate.md` §7 — why the records behind these stages are missing.
- Current code substrate reviewed:
  - `packages/storefront-templates/src/twin-value-stream.ts` — `TwinStageBinding` already carries `queueKeys`/`zoneKeys`, so observability is derivable and needed no new substrate.
  - `apps/web/lib/twin/stage-flow.ts` — the single producer of `stageFlow`, shared by the live projection and the demo bridge.
  - `apps/web/components/twin/TwinView.tsx` — the only consumer.
- Source of truth: the archetype's stage binding stays the one thing that knows what is bound; the strip reads it rather than inferring from the count.
- Decision: remove the affordance now, route the stages when there is somewhere to route to.

The incumbent practice this lane models is lean value-stream mapping, which the module already cites as its lens ("queue depth + wait per stage"). A VSM draws a step whose data box was never measured with the box **empty**; it does not write a zero. That is exactly the distinction restored here.

Design-Grounding-Decision: a stage nothing can reach shows an absence, not a zero
Operational-Precedent: value-stream-mapping
Process-Spine-Decision: records the resolution and the generalisable check in the archetype operating-model audit
