### PR TITLE
fix(calendar): the business calendar must show the create control its link promises (BI-460BFA84)

### DIFF
--- a/apps/web/components/workspace/BusinessAgenda.test.tsx
+++ b/apps/web/components/workspace/BusinessAgenda.test.tsx
@@ -53,6 +53,14 @@ describe("BusinessAgenda", () => {
     expect(html).not.toContain("Last week booking");
   });
 
+  // The empty state used to offer "Add a booking, invoice, or appointment" and
+  // link to the business calendar, which makes none of those three (BI-460BFA84).
+  it("promises only what the calendar it links to can actually do", () => {
+    const html = renderToStaticMarkup(<BusinessAgenda events={[]} />);
+    expect(html).not.toContain("Add a booking, invoice, or appointment");
+    expect(html).toContain("Add something to the calendar");
+  });
+
   it("renders an empty state (no synthesized rows) when there are no business events", () => {
     const html = renderToStaticMarkup(<BusinessAgenda events={[]} now={NOW} />);
 

--- a/apps/web/components/workspace/BusinessAgenda.tsx
+++ b/apps/web/components/workspace/BusinessAgenda.tsx
@@ -112,7 +112,7 @@ export function BusinessAgenda({
           Nothing scheduled for the business right now.
           <br />
           <a href={fullCalendarHref} className="text-[var(--dpf-accent)] hover:underline">
-            Add a booking, invoice, or appointment
+            Add something to the calendar
           </a>{" "}
           to see it here.
         </div>

--- a/apps/web/components/workspace/WorkspaceCalendar.test.tsx
+++ b/apps/web/components/workspace/WorkspaceCalendar.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+// Running the operating day recorded the business calendar as unable to create
+// anything (BI-460BFA84). Driving the live install corrected half of that: the
+// day-click chooser does open. What was true is that the page carried no create
+// control at all, so the only way in was a gesture nothing announced.
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/workspace/calendar",
+}));
+
+// FullCalendar owns a canvas of day cells that jsdom cannot lay out. Stand in
+// for it and expose the two handlers under test, so a plain click (which fires
+// dateClick AND select) can be reproduced exactly.
+const calendarProps: Record<string, unknown> = {};
+vi.mock("@fullcalendar/react", () => ({
+  default: (props: Record<string, unknown>) => {
+    Object.assign(calendarProps, props);
+    return <div data-testid="fullcalendar" />;
+  },
+}));
+vi.mock("@fullcalendar/daygrid", () => ({ default: {} }));
+vi.mock("@fullcalendar/timegrid", () => ({ default: {} }));
+vi.mock("@fullcalendar/interaction", () => ({ default: {} }));
+vi.mock("./CalendarEventPopover", () => ({
+  CalendarEventPopover: ({ defaultDate }: { defaultDate?: string }) => (
+    <div data-testid="create-popover">{defaultDate}</div>
+  ),
+}));
+vi.mock("./CalendarDetailPopover", () => ({ CalendarDetailPopover: () => null }));
+vi.mock("./CalendarAgentScheduler", () => ({ CalendarAgentScheduler: () => null }));
+vi.mock("./CalendarSyncPanel", () => ({ CalendarSyncPanel: () => null }));
+
+import { WorkspaceCalendar } from "./WorkspaceCalendar";
+
+afterEach(() => {
+  cleanup();
+  for (const key of Object.keys(calendarProps)) delete calendarProps[key];
+});
+
+function dayRect() {
+  return { top: 100, left: 40, bottom: 140, right: 200, width: 160, height: 40 } as DOMRect;
+}
+
+describe("WorkspaceCalendar", () => {
+  it("offers a create control on the page, not only a gesture", () => {
+    render(<WorkspaceCalendar events={[]} />);
+    expect(screen.getByRole("button", { name: "New event" })).toBeInTheDocument();
+  });
+
+  it("opens the create form from that control", () => {
+    render(<WorkspaceCalendar events={[]} />);
+    expect(screen.queryByTestId("create-popover")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "New event" }));
+    expect(screen.getByTestId("create-popover")).toBeInTheDocument();
+  });
+
+  it("keeps the day chooser anchored to the day that was clicked", () => {
+    render(<WorkspaceCalendar events={[]} />);
+
+    // A plain click on a day fires dateClick, then select for the same day.
+    const dateClick = calendarProps.dateClick as (info: unknown) => void;
+    const select = calendarProps.select as (info: unknown) => void;
+    act(() => {
+      dateClick({ dateStr: "2026-08-27", dayEl: { getBoundingClientRect: dayRect } });
+      select({ startStr: "2026-08-27", endStr: "2026-08-28" });
+    });
+
+    // Anchored: the menu sits under the day cell, not in the middle of the screen.
+    const chooser = screen.getByRole("button", { name: "Create event" }).parentElement!;
+    expect(chooser.style.top).toBe("144px");
+    expect(chooser.style.transform).toBe("");
+  });
+
+  it("still centres the chooser for a real multi-day drag", () => {
+    render(<WorkspaceCalendar events={[]} />);
+
+    const select = calendarProps.select as (info: unknown) => void;
+    act(() => select({ startStr: "2026-08-27", endStr: "2026-08-30" }));
+
+    const chooser = screen.getByRole("button", { name: "Create event" }).parentElement!;
+    expect(chooser.style.transform).toBe("translate(-50%, -50%)");
+  });
+});

--- a/apps/web/components/workspace/WorkspaceCalendar.tsx
+++ b/apps/web/components/workspace/WorkspaceCalendar.tsx
@@ -104,6 +104,14 @@ export function WorkspaceCalendar({
   // automated UX measurement cannot race the server events and refreshed set.
   const [fetching, setFetching] = useState(true);
 
+  /** The month the operator is looking at, as `YYYY-MM-DD`. A new event should
+   *  land where they are, not in whatever month today happens to be. */
+  function viewDateIso(): string {
+    const api = calendarRef.current?.getApi();
+    const date = api?.getDate() ?? new Date();
+    return date.toISOString().split("T")[0]!;
+  }
+
   function toggleCategory(cat: string) {
     const next = new Set(hiddenCategories);
     if (next.has(cat)) next.delete(cat);
@@ -225,6 +233,19 @@ export function WorkspaceCalendar({
       className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
       data-dpf-ux-settle={fetching ? "pending" : undefined}
     >
+      {/* Create control. Creating an event has always been possible here, but the
+          only way in was clicking a day cell and nothing said so, while the
+          workspace agenda linked here promising exactly this (BI-460BFA84). */}
+      <div className="mb-3 flex items-center">
+        <button
+          type="button"
+          onClick={() => setCreatePopover({ date: viewDateIso() })}
+          className="rounded-md border border-[var(--dpf-accent)] px-3 py-1.5 text-dpf-caption font-medium text-[var(--dpf-accent)] hover:bg-[color-mix(in_srgb,var(--dpf-accent)_10%,transparent)]"
+        >
+          New event
+        </button>
+      </div>
+
       {/* Filter toolbar */}
       <div className="flex items-center gap-2 mb-4 flex-wrap">
         <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest mr-2">Filter:</span>
@@ -344,7 +365,14 @@ export function WorkspaceCalendar({
           setDateChooser({ date: info.dateStr, rect: info.dayEl.getBoundingClientRect() });
         }}
         select={(info) => {
-          setDateChooser({ date: info.startStr, endDate: info.endStr, rect: null });
+          // A plain click fires dateClick AND select. Keep the rect dateClick
+          // measured so the menu stays anchored to the day the operator hit;
+          // a real drag-selection starts on a different date and re-anchors.
+          setDateChooser((prev) =>
+            prev && prev.date === info.startStr
+              ? { ...prev, endDate: info.endStr }
+              : { date: info.startStr, endDate: info.endStr, rect: null },
+          );
         }}
       />
 

--- a/docs/architecture/archetypes/pet-rescue-operating-model.md
+++ b/docs/architecture/archetypes/pet-rescue-operating-model.md
@@ -278,6 +278,19 @@ previous day was 0.05. Both figures stand; they measure different things.
 | 15:00 adoption | partial | Status change worked and reached the mission metric; no contract, fee, spay/neuter compliance, chip re-registration or typed outcome | Contract on paper, fee on the card reader, chip re-registered on the registry's own site |
 | 16:00 numbers | partial | Outcomes correct; kennels-free unanswerable; intakes not recorded as intakes | Counted the ward on foot |
 
+**One row above is half wrong, and the correction is worth keeping.** The 10:00 finding recorded
+that "the calendar cannot create". Driving the live install on 2026-08-27 found that clicking a
+day *does* open a chooser offering **Create event** and **Schedule AI coworker**, with no page
+error. What is true is that the page carried **no create control at all**, so the only way in was
+a gesture nothing announced, and the workspace agenda linked here promising "a booking, invoice,
+or appointment" — three things this calendar does not make. Both were fixed (`BI-460BFA84`): the
+calendar now has a *New event* control, and the agenda promises what the calendar does. **The
+remaining half of the 10:00 step stands:** `CareAppointment` is subject-agnostic and already
+built, but the business calendar neither reads it nor writes it, so a spay/neuter slot is a
+free-text event rather than an appointment against the animal. *A step recorded as impossible
+because a control could not be found is a discoverability finding, not a capability one — check
+which before designing the fix.*
+
 ### What the run found that §6 could not
 
 Three findings sit outside the thirty entities entirely, and each alone prevents the business

--- a/docs/ux-fit/2026-08-27-calendar-create-control.ux-fit.json
+++ b/docs/ux-fit/2026-08-27-calendar-create-control.ux-fit.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "decidedOption": "visible-new-event-control",
+  "decisionInteractionId": "DI-D6BC6BA0DDC9",
+  "scope": {
+    "files": [
+      "apps/web/components/workspace/WorkspaceCalendar.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "visible-new-event-control",
+      "announce-the-day-click-only",
+      "make-the-calendar-create-bookings-and-invoices"
+    ],
+    "note": "The operating-day run recorded /workspace/calendar as unable to create anything and fell back to a paper desk diary (BI-460BFA84). Driving the live install corrects half of that: clicking a day DOES open a chooser offering Create event and Schedule AI coworker, and no page error is thrown. What is true is that there is no visible create control on the page at all, so the gesture is undiscoverable, and the agenda links here promising a booking, an invoice and an appointment - three things this calendar cannot make. visible-new-event-control won at composite 10.783 with a 2.802 margin, high confidence, no commandment conflict. announce-the-day-click-only scored 7.981: cheaper, but it leaves the only entry point as a gesture, which is what failed. make-the-calendar-create-bookings-and-invoices scored 2.939 and is opposed by 'Do the work; don't task the operator' and 'Never ask the user to run commands' - it would put three owning surfaces' required fields into one popover, and CareAppointment needs a subject this archetype cannot yet hold (BI-4F8A484C). The link's promise is corrected to match what the calendar does instead."
+  }
+}


### PR DESCRIPTION
Found by running Second Chance Animal Rescue as a business for one operating day (`docs/architecture/archetypes/pet-rescue-operating-model.md` §6b). Fixes `BI-460BFA84`.

## The finding, half corrected

The workspace agenda's empty state reads *"Add a booking, invoice, or appointment"* and links to `/workspace/calendar`. The run followed that link, found nothing to press, recorded the 10:00 step **impossible**, and fell back to a paper desk diary.

Driving the live install corrects half of that, and the correction is recorded rather than quietly dropped: **clicking a day DOES open a chooser** offering *Create event* and *Schedule AI coworker*, with no page error. Creation was there. Nothing announced it.

*A step recorded as impossible because a control could not be found is a discoverability finding, not a capability one — check which before designing the fix.* That line is now in §6b.

## What was actually wrong

**No create control on the page.** The entire control set was filter pills, view switches and an iCal link. The only way in was a gesture on a day cell. There is now a **New event** button, defaulted to the month in view rather than to whatever month today happens to be.

**The chooser threw itself into the middle of the screen.** A plain click fires `dateClick` and *then* `select`; `select` overwrote the anchoring rect with `null`, detaching the menu from the day that was pressed. It now keeps the rect for a click and re-anchors only for a real drag-selection. Both paths are asserted.

**The link promised three things the calendar does not make.** A booking, an invoice and an appointment each have their own owning surface. The agenda now promises what the calendar does.

## What is left of the 10:00 step

`CareAppointment` is subject-agnostic and already built — but `apps/web/lib/workforce/calendar-data.ts` projects twenty-two event types and **none of them is `CareAppointment`**. The business calendar neither reads it nor writes it, so a spay/neuter slot is a free-text event rather than an appointment against the animal. That half stands, and §6b records it.

Defect class removed: **inert affordance** — a link stating a capability its destination does not have.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/architecture/archetypes/pet-rescue-operating-model.md` §6b — the 10:00 row, now corrected with what the live install actually does.
  - `docs/architecture/archetype-operating-model-audit.md` — the inert-affordance class names this exact link as an example.
  - `docs/architecture/canonical-minimal-substrate.md` §6 — `CareAppointment` is already subject-agnostic, which is why teaching the calendar to create one is a real option and not new substrate. Deferred, not dismissed.
- Current code substrate reviewed:
  - `apps/web/components/workspace/WorkspaceCalendar.tsx` — `dateClick`, `select` and `CalendarEventPopover` were all already wired.
  - `apps/web/lib/workforce/calendar-data.ts` — the twenty-two event types, quoted above.
  - `apps/web/components/workspace/BusinessAgenda.tsx` — the link that made the promise.
- Source of truth: `CalendarEventPopover` stays the single create form; the new control opens the same one the day-click opens.
- Decision: make the existing capability discoverable and the promise honest, rather than teaching one popover the required fields of three owning surfaces. Scored on the kernel — composite 10.783, margin 2.802, high confidence, no commandment conflict (`DI-D6BC6BA0DDC9`); UX-fit evidence at `docs/ux-fit/2026-08-27-calendar-create-control.ux-fit.json`. The rejected "make the calendar create bookings and invoices" option scored 2.939, opposed by *Do the work; don't task the operator*.

Design-Grounding-Decision: make the capability discoverable and the promise honest, rather than widening the form
Process-Spine-Decision: corrects the 10:00 row of the pet-rescue run with what the live install does
