### PR TITLE
fix(attention): work that is not the owner's must not fill the owner's inbox (BI-79E207B9)

### DIFF
--- a/apps/web/components/attention/CoworkerProposalActions.tsx
+++ b/apps/web/components/attention/CoworkerProposalActions.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 
 import { approveProposal, rejectProposal } from "@/lib/actions/proposals";
 
 export function CoworkerProposalActions({ proposalId }: { proposalId: string }) {
+  const router = useRouter();
   const [result, setResult] = useState<"approved" | "declined" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
@@ -26,6 +28,11 @@ export function CoworkerProposalActions({ proposalId }: { proposalId: string }) 
           : await rejectProposal(proposalId, "Owner declined this action");
       if (response.success) {
         setResult(decision === "approve" ? "approved" : "declined");
+        // The card acknowledged, but the header kept reading "40 things need you
+        // today" until a manual reload, so the rational next move was to press
+        // again (BI-79E207B9). Re-render the server tree so the count follows
+        // the decision.
+        router.refresh();
         return;
       }
       setError(response.error ?? "That decision could not be saved. Please try again.");

--- a/apps/web/components/attention/OwnerDecisionCards.test.tsx
+++ b/apps/web/components/attention/OwnerDecisionCards.test.tsx
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Deciding a card has to move the header count, not only the card
+// (BI-79E207B9), so the actions re-render the server tree.
+const refresh = vi.hoisted(() => vi.fn());
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh }) }));
 
 import { OwnerDecisionCards } from "./OwnerDecisionCards";
 import type { OwnerAttentionEntry } from "@/lib/attention/owner-projection";

--- a/apps/web/lib/attention/owner-decision-copy.ts
+++ b/apps/web/lib/attention/owner-decision-copy.ts
@@ -1,3 +1,6 @@
+// The placeholder blast-radius strings live with the type: routing reads the
+// same set to decide whether an item is the owner's at all (BI-79E207B9).
+import { GENERIC_BLAST_RADIUS } from "./types";
 import type { AttentionItem, AttentionSource } from "./types";
 
 const HEADLINE: Record<AttentionSource, string> = {
@@ -121,10 +124,6 @@ export function whyItMattersFor(item: AttentionItem): string {
       return "This technical issue matters only if it changes customer or business work.";
   }
 }
-
-// Placeholder blast-radius strings that read as vague ("a coworker task stays
-// blocked") — skip them so the consequence falls through to a source-specific line.
-const GENERIC_BLAST_RADIUS = new Set(["a coworker task", "a coworker waiting on approval"]);
 
 export function consequenceFor(item: AttentionItem): string {
   if (item.source === "reservation-exception") {

--- a/apps/web/lib/attention/owner-routing.test.ts
+++ b/apps/web/lib/attention/owner-routing.test.ts
@@ -148,3 +148,79 @@ describe("classifyOwnerAttentionLane", () => {
     });
   });
 });
+
+// Running Second Chance Animal Rescue for a day found 40 items in the owner's
+// inbox, of which 34 were paused platform task runs — "spec-approval for
+// BI-7D2C4F02", "Record the research gate for BI-2DB7254B" — and exactly ONE
+// was the rescue's own business. Every one of the 34 carried the placeholder
+// blast radius "a coworker task" and the platform's own advice to keep it with
+// the specialist (BI-79E207B9).
+describe("work the platform already knows is not the owner's", () => {
+  const pausedPlatformRun = () =>
+    item("paused-ai", {
+      title: "spec-approval for BI-7D2C4F02 at 5f4d8aacb8fc",
+      triage: {
+        timeToAct: "none",
+        residueReason: "input-required",
+        blastRadius: "a coworker task",
+        decideEffort: "judgment",
+        irreversible: false,
+      },
+    });
+
+  it("leaves the owner's count when nothing concrete is blocked", () => {
+    expect(classifyOwnerAttentionLane(pausedPlatformRun()).lane).toBe("custodian");
+  });
+
+  it("comes back the moment the run names what it is actually holding up", () => {
+    const namesIt = item("paused-ai", {
+      triage: {
+        timeToAct: "none",
+        residueReason: "input-required",
+        blastRadius: "the Vasquez adoption enquiry",
+        decideEffort: "judgment",
+        irreversible: false,
+      },
+    });
+
+    expect(classifyOwnerAttentionLane(namesIt).lane).toBe("needs-you-now");
+  });
+
+  it("treats a blank blast radius the same as a placeholder one", () => {
+    const blank = item("agent-proposal", {
+      triage: {
+        timeToAct: "none",
+        residueReason: "input-required",
+        decideEffort: "judgment",
+        irreversible: false,
+      },
+    });
+
+    expect(classifyOwnerAttentionLane(blank).lane).toBe("custodian");
+  });
+
+  it("never demotes a hard floor, however vague the blast radius", () => {
+    const vagueTriage = {
+      timeToAct: "none" as const,
+      residueReason: "policy-approval" as const,
+      blastRadius: "a coworker task",
+      decideEffort: "review" as const,
+      irreversible: false,
+    };
+    const hardFloors: AttentionSource[] = [
+      "approval-bill",
+      "approval-expense",
+      "approval-outbound",
+      "compliance-submission",
+      "reservation-exception",
+      "storefront-inquiry",
+      "coworker-envelope",
+    ];
+
+    for (const source of hardFloors) {
+      const decision = classifyOwnerAttentionLane(item(source, { triage: vagueTriage }));
+      expect(decision.lane, `${source} was demoted`).toBe("needs-you-now");
+      expect(decision.hardFloor, `${source} lost its hard floor`).toBe(true);
+    }
+  });
+});

--- a/apps/web/lib/attention/owner-routing.ts
+++ b/apps/web/lib/attention/owner-routing.ts
@@ -1,4 +1,5 @@
 import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
+import { namesNoConcreteConsequence } from "./types";
 import type { AttentionItem, AttentionSource } from "./types";
 
 export type OwnerAttentionLane = "needs-you-now" | "weekly-digest" | "custodian";
@@ -87,6 +88,22 @@ export function classifyOwnerAttentionLane(
       );
     }
     return decision("needs-you-now", "This still needs your judgment.", false, appliedLevel);
+  }
+  // A source that cannot say what is actually blocked has not established that
+  // this is the owner's decision. Running a rescue for a day found 34 of 40
+  // cards in the owner's inbox were paused platform task runs — spec approvals
+  // and research gates against backlog items — every one of them carrying the
+  // placeholder "a coworker task" and the platform's own advice to keep it with
+  // the specialist (BI-79E207B9). Nothing of the rescue's was waiting on any of
+  // them. This runs after the hard floors above, so money, a waiting guest, a
+  // waiting customer and a closing approval window still reach the owner.
+  if (namesNoConcreteConsequence(item.triage.blastRadius)) {
+    return decision(
+      "custodian",
+      "Nothing of yours is waiting on this — the specialist owns it.",
+      false,
+      appliedLevel,
+    );
   }
   if (item.triage.decideEffort === "judgment") {
     return decision("needs-you-now", "This still needs your judgment.", false, appliedLevel);

--- a/apps/web/lib/attention/sources/paused-ai.ts
+++ b/apps/web/lib/attention/sources/paused-ai.ts
@@ -71,11 +71,14 @@ export function pausedAiToAttentionItem(row: TaskRunRow): AttentionItem {
     id: `paused-ai:${row.taskRunId}`,
     source: "paused-ai",
     title: row.title,
+    // Thirty-four of these rendered the identical body, because the generic
+    // fallback was the whole story and the run's own title was thrown away
+    // (BI-79E207B9). The run names itself; say which one this is.
     context:
       readSummary(row.progressPayload) ??
       (authRequired
-        ? "A coworker is blocked on a missing credential or authority."
-        : "A coworker paused and needs your input to continue."),
+        ? `${row.title} — blocked on a missing credential or authority.`
+        : `${row.title} — paused, and needs your input to continue.`),
     decisionClass: { scorability: "unscorable" },
     riskClass: risk,
     triage: {

--- a/apps/web/lib/attention/sources/sources.test.ts
+++ b/apps/web/lib/attention/sources/sources.test.ts
@@ -150,6 +150,43 @@ describe("pausedAiToAttentionItem", () => {
     });
   });
 
+  // Thirty-four of these rendered the identical body — "A coworker paused and
+  // needs your input to continue" — with no way to tell them apart, while every
+  // run named itself in the database (BI-79E207B9).
+  it("says which run this is when the run left no summary", () => {
+    const first = pausedAiToAttentionItem({
+      ...base,
+      taskRunId: "TR-A",
+      title: "spec-approval for BI-7D2C4F02",
+      progressPayload: null,
+    });
+    const second = pausedAiToAttentionItem({
+      ...base,
+      taskRunId: "TR-B",
+      title: "Record the research gate for BI-2DB7254B",
+      progressPayload: null,
+    });
+
+    expect(first.context).toContain("spec-approval for BI-7D2C4F02");
+    expect(second.context).toContain("Record the research gate for BI-2DB7254B");
+    expect(first.context).not.toEqual(second.context);
+  });
+
+  it("names the run on a credential block too", () => {
+    const item = pausedAiToAttentionItem({
+      ...base,
+      status: "auth-required",
+      title: "Summon AGT-WS-PORTFOLIO",
+      progressPayload: null,
+    });
+    expect(item.context).toContain("Summon AGT-WS-PORTFOLIO");
+    expect(item.context).toContain("credential");
+  });
+
+  it("still prefers the run's own summary when it wrote one", () => {
+    expect(pausedAiToAttentionItem(base).context).toBe("Ready to send to 4,000 recipients.");
+  });
+
   it("treats auth-required as a missing-credential review, not judgment or irreversible", () => {
     const item = pausedAiToAttentionItem({ ...base, status: "auth-required" });
     expect(item.triage.residueReason).toBe("needs-credential");

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -225,3 +225,22 @@ export type AttentionItem = {
    * the `coworker-envelope` source (BI-7CB2CCDE). */
   envelope?: AttentionEnvelopeApproval;
 };
+
+/**
+ * Blast-radius strings that name nothing concrete (BI-79E207B9).
+ *
+ * A source that cannot say what is actually blocked writes one of these. They
+ * read as vague in owner copy, and they are the evidence that a decision has no
+ * owner-facing consequence yet — so both the copy layer and the routing layer
+ * read this one set rather than each keeping its own list.
+ */
+export const GENERIC_BLAST_RADIUS: ReadonlySet<string> = new Set([
+  "a coworker task",
+  "a coworker waiting on approval",
+]);
+
+/** True when an item names no concrete consequence. Pure. */
+export function namesNoConcreteConsequence(blastRadius: string | null | undefined): boolean {
+  const value = (blastRadius ?? "").trim().toLowerCase();
+  return value.length === 0 || GENERIC_BLAST_RADIUS.has(value);
+}

--- a/docs/architecture/archetype-operating-model-audit.md
+++ b/docs/architecture/archetype-operating-model-audit.md
@@ -174,7 +174,13 @@ Independent of archetype, because each has now failed at least once:
 
 - **The arrival surface.** Open the product as a worker starting a shift. Is what it demands the
   business's work? Count the items and classify them; an owner's attention list that is mostly
-  platform housekeeping is a defect with a number attached.
+  platform housekeeping is a defect with a number attached. *The rescue's number was 34 of 40, and
+  the classification is what fixed it: every one of the 34 was a paused platform task run carrying
+  the placeholder blast radius `a coworker task`. Resolved 2026-08-27 on `BI-79E207B9` by a rule
+  worth reusing —* **a source that cannot name what is actually blocked has not established that
+  the decision is the owner's**, *so it routes to the custodian instead of the owner's count. Ask
+  of every item on an arrival surface: what does this say is waiting? If the answer is a
+  placeholder, the item is someone else's.*
 - **Staffing.** Can the archetype hire the roles its day requires — by title, employment type and
   work location? Can a vacancy be opened at all? Are the roles on offer this business's roles, or
   the platform's?


### PR DESCRIPTION
Found by running Second Chance Animal Rescue as a business for one operating day (`docs/architecture/archetypes/pet-rescue-operating-model.md` §6b). Fixes most of `BI-79E207B9`.

## What the arrival surface actually contained

`/workspace/inbox` said **"40 things need you today"**. Counted from the live database, **34 of them were paused platform task runs**:

```
spec-approval for BI-7D2C4F02 at 5f4d8aacb8fc
Record the research gate for BI-2DB7254B — defect verified
independent spec approval for BI-F48D7059 at 2777e962d200
Summon AGT-WS-PORTFOLIO
research repair for BI-MCP-EFF-0285909C at a08cf14638a5
... 29 more
```

Exactly **one** item on the page was the rescue's own business. All 34 carried the identical body, one shared destination, and the platform's own advice to keep it with the specialist.

## Three fixes, one of which does most of the work

**Not the owner's, so not in the owner's count.** Every one of the 34 carried the placeholder blast radius `a coworker task`. That string already existed in the copy layer as one that "reads as vague"; it becomes the routing signal too, in **one shared set** rather than two lists. *A source that cannot name what is actually blocked has not established that the decision is the owner's* — so the item routes to the custodian.

The rule sits **after** the hard floors, and a test asserts that for all seven of them: money leaving the business, a waiting guest, a waiting customer, a closing approval window — none is demoted, however vague its blast radius. An item comes back to the owner the moment its source can name a real consequence; that is asserted too.

This is not a new idea in this file. `owner-routing.ts` already did exactly this for `ai-decision` (BI-348766E5 fix 4): generic residue with no blast radius is grouped away from concrete operational work. This extends the same judgement rather than inventing a second rule.

**Per-item identity.** Every run named itself in the database and the card threw the name away, falling back to *"A coworker paused and needs your input to continue"* thirty-four times. The run's title now carries into the card; a run that wrote a real summary still wins.

**An action now lands.** Decline set the card to "Action declined." and left the header reading 40 until a manual reload — so the rational next move was to press again. The actions refresh the server tree and the count follows the decision.

## What this does NOT fix

Nothing can be dismissed or snoozed. That needs somewhere to record a dismissal, and it is the remaining half of `BI-79E207B9`, which stays open. The cockpit ordering the item asked to preserve — storefront enquiries above the platform attention list — is untouched by this diff.

Defect class removed: **silent failure** (an action that reported nothing to the surface that mattered), plus an arrival surface that was mostly someone else's work.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/architecture/archetype-operating-model-audit.md` — "the arrival surface" is one of the five standing probes and says an attention list that is mostly platform housekeeping is *a defect with a number attached*. The number was 34 of 40; the resolution is recorded there as a reusable check.
  - `docs/architecture/archetypes/pet-rescue-operating-model.md` §6b — the run.
- Current code substrate reviewed:
  - `apps/web/lib/attention/owner-routing.ts` — the `ai-decision` precedent above.
  - `apps/web/lib/attention/owner-decision-copy.ts` — `GENERIC_BLAST_RADIUS` lived here; it moves to the type so routing and copy share it.
  - `apps/web/lib/attention/sources/paused-ai.ts` — `row.title` was already selected and already discarded.
  - Live evidence: 34 `TaskRun` rows at `input-required`, titles quoted above.
- Source of truth: one set of placeholder blast-radius strings, read by both layers.
- Decision: route on what the item says is waiting, not on which source produced it.

Design-Grounding-Decision: a placeholder blast radius is evidence the decision is not the owner's
Process-Spine-Decision: records the arrival-surface resolution as a reusable check in the archetype operating-model audit
