### PR TITLE
feat(workforce): let an archetype declare its own worker classes and work locations (BI-A30152B6)

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1124,6 +1124,11 @@ export async function register() {
       await backfillOrgWwwdOnBoot();
     });
 
+    // The active archetype's worker classes + work locations, for an install that
+    // completed setup before the archetype declared them (BI-A30152B6). The WWWD
+    // backfill above runs the same chain only when a corpus is MISSING, so a
+    // healthy install short-circuits it and nothing else self-heals the rows.
+    void import("@/lib/onboarding/seed-archetype-workforce").then(({ backfillArchetypeWorkforceOnBoot }) => backfillArchetypeWorkforceOnBoot());
     void import("@/lib/onboarding/backfill-commercial-catalog-on-boot").then(({ backfillCommercialCatalogOnBoot }) => backfillCommercialCatalogOnBoot());
 
     // Discovery estate self-heal (BI-BAF38ED3 attribution + BI-B19C41B8 phantom

--- a/apps/web/lib/onboarding/seed-archetype-workforce.test.ts
+++ b/apps/web/lib/onboarding/seed-archetype-workforce.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
+
+import {
+  seedArchetypeWorkforce,
+  workforceProfileFor,
+  type SeedArchetypeWorkforceClient,
+} from "./seed-archetype-workforce";
+
+// Running the rescue for a day found the platform offered Headquarters, Remote
+// and Hybrid, and no worker class for the shelter's largest labour pool
+// (BI-A30152B6). §5b of the pet-rescue operating model names what the day needs.
+
+function client(overrides: {
+  archetypeId?: string | null;
+  existingEmploymentTypes?: string[];
+  existingWorkLocations?: string[];
+}) {
+  const employmentTypes = new Set(overrides.existingEmploymentTypes ?? []);
+  const workLocations = new Set(overrides.existingWorkLocations ?? []);
+  const created = { employmentTypes: [] as unknown[], workLocations: [] as unknown[] };
+
+  const db: SeedArchetypeWorkforceClient = {
+    storefrontConfig: {
+      findFirst: vi.fn(async () =>
+        overrides.archetypeId === null ? null : { archetypeId: overrides.archetypeId ?? "pet-rescue" },
+      ),
+    },
+    employmentType: {
+      findUnique: vi.fn(async (args: unknown) => {
+        const id = (args as { where: { employmentTypeId: string } }).where.employmentTypeId;
+        return employmentTypes.has(id) ? { id } : null;
+      }),
+      create: vi.fn(async (args: unknown) => {
+        created.employmentTypes.push((args as { data: unknown }).data);
+        return {};
+      }),
+    },
+    workLocation: {
+      findUnique: vi.fn(async (args: unknown) => {
+        const id = (args as { where: { locationId: string } }).where.locationId;
+        return workLocations.has(id) ? { id } : null;
+      }),
+      create: vi.fn(async (args: unknown) => {
+        created.workLocations.push((args as { data: unknown }).data);
+        return {};
+      }),
+    },
+  };
+  return { db, created };
+}
+
+describe("the rescue's declared workforce", () => {
+  it("names places an animal actually lives, not office arrangements", () => {
+    const profile = workforceProfileFor("pet-rescue")!;
+    const names = (profile.workLocations ?? []).map((l) => l.name);
+
+    expect(names).toContain("Dog ward");
+    expect(names).toContain("Isolation");
+    expect(names).toContain("Foster home");
+    expect(names).not.toContain("Headquarters");
+    expect(names).not.toContain("Hybrid");
+  });
+
+  it("carries the second unpaid class, classified as unpaid", () => {
+    const profile = workforceProfileFor("pet-rescue")!;
+    expect(profile.employmentTypes).toEqual([
+      { employmentTypeId: "emp-foster-carer", name: "Foster carer", classification: "volunteer" },
+    ]);
+  });
+
+  it("reaches the animal shelter too — the same day, a different name", () => {
+    expect(workforceProfileFor("animal-shelter")).toEqual(workforceProfileFor("pet-rescue"));
+  });
+
+  it("does not reach an archetype whose day is nothing like it", () => {
+    expect(workforceProfileFor("restaurant")).toBeNull();
+  });
+
+  it("declares no row an archetype could not honour", () => {
+    for (const archetype of ALL_ARCHETYPES) {
+      for (const location of archetype.workforceProfile?.workLocations ?? []) {
+        expect(location.locationId).toMatch(/^loc-[a-z0-9-]+$/);
+      }
+      for (const employmentType of archetype.workforceProfile?.employmentTypes ?? []) {
+        expect(employmentType.employmentTypeId).toMatch(/^emp-[a-z0-9-]+$/);
+      }
+    }
+  });
+});
+
+describe("seedArchetypeWorkforce", () => {
+  it("applies the rescue's rows to an install running a rescue", async () => {
+    const { db, created } = client({ archetypeId: "pet-rescue" });
+
+    const result = await seedArchetypeWorkforce({ organizationId: "org-1", db });
+
+    expect(result.employmentTypesAdded).toEqual(["emp-foster-carer"]);
+    expect(result.workLocationsAdded).toContain("loc-dog-ward");
+    expect(result.workLocationsAdded).toHaveLength(7);
+    expect(created.employmentTypes[0]).toMatchObject({
+      employmentTypeId: "emp-foster-carer",
+      classification: "volunteer",
+      status: "active",
+    });
+  });
+
+  it("gives a restaurant no cat room", async () => {
+    const { db, created } = client({ archetypeId: "restaurant" });
+
+    const result = await seedArchetypeWorkforce({ organizationId: "org-1", db });
+
+    expect(result).toMatchObject({ employmentTypesAdded: [], workLocationsAdded: [] });
+    expect(created.workLocations).toEqual([]);
+  });
+
+  it("is safe to re-run, and never rewrites a row an operator has edited", async () => {
+    const { db, created } = client({
+      archetypeId: "pet-rescue",
+      existingEmploymentTypes: ["emp-foster-carer"],
+      existingWorkLocations: ["loc-dog-ward", "loc-cat-room", "loc-isolation", "loc-intake", "loc-surgery", "loc-foster-home", "loc-adoption-event"],
+    });
+
+    const result = await seedArchetypeWorkforce({ organizationId: "org-1", db });
+
+    expect(result).toMatchObject({ employmentTypesAdded: [], workLocationsAdded: [] });
+    expect(created.employmentTypes).toEqual([]);
+    expect(created.workLocations).toEqual([]);
+  });
+
+  it("does nothing when the install has no storefront yet", async () => {
+    const { db } = client({ archetypeId: null });
+
+    const result = await seedArchetypeWorkforce({ organizationId: "org-1", db });
+
+    expect(result).toEqual({ archetypeId: null, employmentTypesAdded: [], workLocationsAdded: [] });
+  });
+});
+
+// The rows have to reach an install that finished onboarding before the
+// archetype declared them. `runSetupCompletionSeeds` is re-run on boot only by
+// the WWWD backfill, which short-circuits on a healthy corpus — so without this
+// reconciler a rescue keeps Headquarters / Remote / Hybrid forever and nothing
+// self-heals it.
+describe("backfillArchetypeWorkforceOnBoot", () => {
+  it("is exported so instrumentation can run it beside the sibling reconcilers", async () => {
+    const module = await import("./seed-archetype-workforce");
+    expect(typeof module.backfillArchetypeWorkforceOnBoot).toBe("function");
+  });
+});

--- a/apps/web/lib/onboarding/seed-archetype-workforce.ts
+++ b/apps/web/lib/onboarding/seed-archetype-workforce.ts
@@ -1,0 +1,130 @@
+// Apply the active archetype's worker classes and work locations (BI-A30152B6).
+//
+// `seedWorkforceReferenceData` in @dpf/db seeds what every install starts with:
+// Full-time, Part-time, Contractor, Intern, Advisor, Volunteer, and
+// Headquarters / Remote / Hybrid. Running a rescue for a day found that none of
+// the three locations describes anywhere an animal lives, and that a shelter's
+// second unpaid class — the foster carer who houses an animal off-site — had
+// nowhere to be recorded.
+//
+// `EmploymentType` and `WorkLocation` are open tables, not enums, so an
+// archetype contributes rows rather than the platform widening a closed set.
+// This step reads the archetype the install actually runs and applies only that
+// archetype's rows, so a restaurant never acquires a cat room.
+//
+// Idempotent, and additive only: an operator who renames or retires a row keeps
+// their edit, and `classification` is written on create only, because it is a
+// legal determination and the operator's answer outranks the seed's.
+
+import { prisma } from "@dpf/db";
+import { ALL_ARCHETYPES, type WorkforceProfile } from "@dpf/storefront-templates";
+
+export type SeedArchetypeWorkforceClient = {
+  storefrontConfig: { findFirst: (args: unknown) => Promise<{ archetypeId: string } | null> };
+  employmentType: {
+    findUnique: (args: unknown) => Promise<{ id: string } | null>;
+    create: (args: unknown) => Promise<unknown>;
+  };
+  workLocation: {
+    findUnique: (args: unknown) => Promise<{ id: string } | null>;
+    create: (args: unknown) => Promise<unknown>;
+  };
+};
+
+export type SeedArchetypeWorkforceInput = {
+  organizationId: string;
+  db?: SeedArchetypeWorkforceClient;
+};
+
+export type SeedArchetypeWorkforceResult = {
+  archetypeId: string | null;
+  employmentTypesAdded: string[];
+  workLocationsAdded: string[];
+};
+
+export function workforceProfileFor(archetypeId: string | null): WorkforceProfile | null {
+  if (!archetypeId) return null;
+  const archetype = ALL_ARCHETYPES.find((a) => a.archetypeId === archetypeId);
+  return archetype?.workforceProfile ?? null;
+}
+
+export async function seedArchetypeWorkforce({
+  organizationId,
+  db,
+}: SeedArchetypeWorkforceInput): Promise<SeedArchetypeWorkforceResult> {
+  const client = (db ?? (prisma as unknown)) as SeedArchetypeWorkforceClient;
+
+  const config = await client.storefrontConfig.findFirst({
+    where: { organizationId },
+    select: { archetypeId: true },
+  });
+  const archetypeId = config?.archetypeId ?? null;
+  const profile = workforceProfileFor(archetypeId);
+
+  const employmentTypesAdded: string[] = [];
+  const workLocationsAdded: string[] = [];
+  if (!profile) return { archetypeId, employmentTypesAdded, workLocationsAdded };
+
+  for (const employmentType of profile.employmentTypes ?? []) {
+    const existing = await client.employmentType.findUnique({
+      where: { employmentTypeId: employmentType.employmentTypeId },
+      select: { id: true },
+    });
+    if (existing) continue;
+    await client.employmentType.create({
+      data: { ...employmentType, status: "active" },
+    });
+    employmentTypesAdded.push(employmentType.employmentTypeId);
+  }
+
+  for (const workLocation of profile.workLocations ?? []) {
+    const existing = await client.workLocation.findUnique({
+      where: { locationId: workLocation.locationId },
+      select: { id: true },
+    });
+    if (existing) continue;
+    await client.workLocation.create({
+      data: { ...workLocation, status: "active" },
+    });
+    workLocationsAdded.push(workLocation.locationId);
+  }
+
+  return { archetypeId, employmentTypesAdded, workLocationsAdded };
+}
+
+/**
+ * Boot reconciler for the archetype's workforce rows.
+ *
+ * `runSetupCompletionSeeds` runs at setup completion and from the WWWD boot
+ * backfill — but that backfill short-circuits on a healthy corpus, so an install
+ * that finished onboarding before this existed would never acquire the rows and
+ * nothing would self-heal it. This mirrors `backfillOperationalValueStreamsOnBoot`:
+ * cheap once healed (one storefront read plus an existence check per declared
+ * row, no writes), idempotent, and non-fatal per organization.
+ */
+export async function backfillArchetypeWorkforceOnBoot(
+  logger: Pick<Console, "log" | "warn"> = console,
+): Promise<{ seeded: number; present: number }> {
+  const result = { seeded: 0, present: 0 };
+  const organizations = await prisma.organization.findMany({ select: { id: true } });
+
+  for (const organization of organizations) {
+    try {
+      const applied = await seedArchetypeWorkforce({ organizationId: organization.id });
+      const added = applied.employmentTypesAdded.length + applied.workLocationsAdded.length;
+      if (added === 0) {
+        result.present++;
+        continue;
+      }
+      result.seeded++;
+      logger.log(
+        `[archetype-workforce] org ${organization.id} (${applied.archetypeId}): added ` +
+          `${applied.employmentTypesAdded.length} worker class(es), ` +
+          `${applied.workLocationsAdded.length} work location(s)`,
+      );
+    } catch (err) {
+      logger.warn(`[archetype-workforce] org ${organization.id}: seed failed (non-fatal):`, err);
+    }
+  }
+  return result;
+}

--- a/apps/web/lib/onboarding/setup-completion-seeds.ts
+++ b/apps/web/lib/onboarding/setup-completion-seeds.ts
@@ -14,6 +14,7 @@ import { seedPortfolioDecomposition } from "./seed-portfolio-decomposition";
 import { seedMarketOffer } from "./seed-market-offer";
 import { seedOrgOperatingModelPages } from "./seed-org-operating-model-pages";
 import { seedRiskPosture } from "./seed-risk-posture";
+import { seedArchetypeWorkforce } from "./seed-archetype-workforce";
 import { applyRiskEnvelopeToOrgProfile } from "./apply-risk-envelope-to-profile";
 import { applyMissionPrompt } from "./apply-mission-prompt";
 
@@ -21,8 +22,8 @@ import { applyMissionPrompt } from "./apply-mission-prompt";
  * Persist the captured mission into the company-mission prompt (visible to
  * every coworker), seed the per-org WWWD corpus, persist the per-org portfolio
  * decomposition (BI-2D452667), seed the archetype-derived market offer into
- * the Goods and Services for Sale portfolio (BI-4503E6B9), project archetype
- * supply, and apply the seeded risk posture to the org WWWD profile.
+ * the Goods and Services for Sale portfolio (BI-4503E6B9), apply the archetype's
+ * worker classes and work locations (BI-A30152B6), project archetype supply, and apply the seeded risk posture to the org WWWD profile.
  *
  * Idempotent — safe to re-run on setup re-completion, replay, or boot backfill.
  */
@@ -36,6 +37,10 @@ export async function runSetupCompletionSeeds(organizationId: string): Promise<v
   await seedOrgWwwdCorpus({ organizationId });
   await seedPortfolioDecomposition({ organizationId });
   await seedMarketOffer({ organizationId });
+  // The active archetype's worker classes and work locations. Runs here so an
+  // install that completed setup before this existed acquires them on the next
+  // boot backfill (BI-A30152B6).
+  await seedArchetypeWorkforce({ organizationId });
   await projectArchetypeSupply({ organizationId });
   // Runs after the portfolio/market/supply seeds so the persisted operating-
   // model map it reads is complete (BI-44526F3E Phase B).

--- a/docs/architecture/archetypes/pet-rescue-operating-model.md
+++ b/docs/architecture/archetypes/pet-rescue-operating-model.md
@@ -210,6 +210,39 @@ fiction.
 intake, the surgery, a foster home, an offsite adoption event. Headquarters / hybrid / remote does
 not describe anywhere an animal lives.
 
+**Shipped 2026-08-27 — the vocabulary, not yet the roles** (`BI-A30152B6`). `EmploymentType` and
+`WorkLocation` are open tables, not enums, and `WorkerClassification` already carried `volunteer`
+and named it "the majority classification for nonprofit and community archetypes". So this needed
+no new structure, only rows:
+
+- **Volunteer** joins the platform defaults, because the canonical enum had already anticipated it
+  and no install could record one.
+- **Foster carer** and the seven operational locations above are declared on the archetype
+  (`workforceProfile`) and applied to the install that actually runs that archetype, so a
+  restaurant never acquires a cat room. A class an archetype needs is now a row it contributes,
+  not a closed set the platform widens.
+- A classification is written on create only. The four seeded types a migration left unresolved
+  stay unresolved: an unpaid worker directed like an employee is a wage claim, and a confident
+  wrong answer is the most damaging kind available.
+- A boot reconciler applies the rows to an install that finished onboarding before the archetype
+  declared them. Without one this fix would have been invisible on every existing install: the
+  seed chain re-runs on boot only for an organization whose WWWD corpus is missing, and a healthy
+  install short-circuits that check. *A seed that only runs at setup completion has not shipped to
+  anyone who completed setup — check for the reconciler, not just the seeder.*
+
+**Still open on `BI-A30152B6`, and why:**
+
+- **The eight roles above are not seeded.** Roles live in `packages/db/data/occupation_registry.json`,
+  which has thirteen entries across healthcare, trades, agriculture and manufacturing and **none**
+  for nonprofit-community — which is why the only role vocabulary a rescue manager sees is the
+  platform's own `HR-000`..`HR-600` ladder. Each entry carries a coworker roster, a feature
+  surface and an onboarding curriculum that must all resolve, so the eight roles are a piece of
+  work in their own right, not a list to paste in.
+- **Recruiting still has no create control**, and an employee record still grants no access — the
+  sign-in is a separate create in Admin, so the counts read "2 people / 1 user" with nothing
+  joining them.
+- **Role is still write-once** in the UI.
+
 **Authorisation follows the role, and some of it is statutory.** Euthanasia authorisation belongs
 to named people. Controlled-substance draw belongs to fewer. A behavioural assessment restricts
 who may handle an animal — the colour-coded collar is an access rule, not a label. Conversely a

--- a/packages/db/src/workforce-seed.test.ts
+++ b/packages/db/src/workforce-seed.test.ts
@@ -15,7 +15,25 @@ describe("workforce seed defaults", () => {
       "emp-contractor",
       "emp-intern",
       "emp-advisor",
+      "emp-volunteer",
     ]);
+  });
+
+  // A shelter's largest labour pool had no worker class at all, so a volunteer
+  // could not be recorded (BI-A30152B6). `WorkerClassification` already carried
+  // `volunteer` and named it the majority nonprofit case.
+  it("can record an unpaid worker, and says which legal axis that is", () => {
+    const volunteer = getDefaultEmploymentTypes().find((item) => item.name === "Volunteer");
+    expect(volunteer).toMatchObject({ classification: "volunteer" });
+  });
+
+  // The four rows whose classification a migration deliberately left unresolved
+  // stay unresolved: a guess here writes a legal claim into the database.
+  it("claims a classification only where the label states it outright", () => {
+    const unclassified = getDefaultEmploymentTypes()
+      .filter((item) => !("classification" in item))
+      .map((item) => item.name);
+    expect(unclassified).toEqual(["Full-time", "Part-time", "Contractor", "Intern", "Advisor"]);
   });
 
   it("returns a default remote work location", () => {

--- a/packages/db/src/workforce-seed.ts
+++ b/packages/db/src/workforce-seed.ts
@@ -625,6 +625,21 @@ export const ONBOARDING_AGENT_GRANTS: Record<string, readonly string[]> = {
   ],
 };
 
+/**
+ * The worker classes every install starts with.
+ *
+ * `Volunteer` belongs here rather than in one archetype: `WorkerClassification`
+ * already carries `volunteer` and names it "the majority classification for
+ * nonprofit and community archetypes", and running a rescue found the platform
+ * could not record one at all (BI-A30152B6). A class an archetype's day needs on
+ * top of these is declared on the archetype and applied per organization — see
+ * `workforceProfile` in @dpf/storefront-templates.
+ *
+ * `classification` is written on create only, never on update: it is a legal
+ * determination, and the operator's answer outranks the seed's. The four
+ * pre-existing rows that carry no classification are left alone for the same
+ * reason.
+ */
 export function getDefaultEmploymentTypes() {
   return [
     { employmentTypeId: "emp-full-time", name: "Full-time" },
@@ -632,6 +647,7 @@ export function getDefaultEmploymentTypes() {
     { employmentTypeId: "emp-contractor", name: "Contractor" },
     { employmentTypeId: "emp-intern", name: "Intern" },
     { employmentTypeId: "emp-advisor", name: "Advisor" },
+    { employmentTypeId: "emp-volunteer", name: "Volunteer", classification: "volunteer" },
   ] as const;
 }
 

--- a/packages/storefront-templates/src/archetypes/nonprofit-community.ts
+++ b/packages/storefront-templates/src/archetypes/nonprofit-community.ts
@@ -17,6 +17,36 @@ const DONATION_FORM_FIELDS = [
   { name: "notes", label: "Message", type: "textarea" as const, required: false },
 ];
 
+// Who does an animal-welfare day, and where (BI-A30152B6, requirements §5b of
+// docs/architecture/archetypes/pet-rescue-operating-model.md).
+//
+// Running the rescue for a day found the platform's answers were an office
+// business's answers. A shelter's largest labour pool is volunteers, unpaid and
+// shift-based; foster carers are a second unpaid class who house animals
+// off-site. Neither is full-time, part-time or contractor. And "where do you
+// work" is a ward, a cat room, isolation, the surgery, a foster home or an
+// offsite adoption event — headquarters / hybrid / remote does not describe
+// anywhere an animal lives.
+//
+// `classification` is set only where the label states the legal axis outright.
+// A foster carer houses an animal unpaid on the shelter's behalf, which §5b
+// records as the second unpaid class; anything an operator pays differently is
+// theirs to record, not the seed's to guess.
+const ANIMAL_WELFARE_WORKFORCE_PROFILE = {
+  employmentTypes: [
+    { employmentTypeId: "emp-foster-carer", name: "Foster carer", classification: "volunteer" as const },
+  ],
+  workLocations: [
+    { locationId: "loc-dog-ward", name: "Dog ward", locationType: "ward" },
+    { locationId: "loc-cat-room", name: "Cat room", locationType: "ward" },
+    { locationId: "loc-isolation", name: "Isolation", locationType: "ward" },
+    { locationId: "loc-intake", name: "Intake", locationType: "ward" },
+    { locationId: "loc-surgery", name: "Surgery", locationType: "clinical" },
+    { locationId: "loc-foster-home", name: "Foster home", locationType: "offsite-host" },
+    { locationId: "loc-adoption-event", name: "Offsite adoption event", locationType: "offsite-event" },
+  ],
+};
+
 const ANIMAL_WELFARE_ACTIVATION_PROFILE = {
   profileType: "standard",
   modules: [],
@@ -254,6 +284,7 @@ export const nonprofitCommunityArchetypes: ArchetypeDefinition[] = [
     ],
     formSchema: DONATION_FORM_FIELDS,
     activationProfile: ANIMAL_WELFARE_ACTIVATION_PROFILE,
+    workforceProfile: ANIMAL_WELFARE_WORKFORCE_PROFILE,
   },
   {
     archetypeId: "animal-shelter",
@@ -277,6 +308,7 @@ export const nonprofitCommunityArchetypes: ArchetypeDefinition[] = [
     ],
     formSchema: DONATION_FORM_FIELDS,
     activationProfile: ANIMAL_SHELTER_ACTIVATION_PROFILE,
+    workforceProfile: ANIMAL_WELFARE_WORKFORCE_PROFILE,
   },
   {
     archetypeId: "community-shelter",

--- a/packages/storefront-templates/src/types.ts
+++ b/packages/storefront-templates/src/types.ts
@@ -722,4 +722,54 @@ export interface ArchetypeDefinition {
    * docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md §5.
    */
   twinProfile?: TwinProfileOverride;
+  /**
+   * Optional worker classes and work locations this archetype's day requires,
+   * on top of the platform defaults. Absence is the common case.
+   *
+   * The platform seeds an office business's answers — Full-time, Part-time,
+   * Contractor, Intern, Advisor, and Headquarters / Remote / Hybrid. Running a
+   * rescue found that none of those describes anywhere an animal lives, and
+   * that a shelter's largest labour pool has no worker class at all
+   * (BI-A30152B6). Both lists are open tables, not enums, so an archetype
+   * contributes rows rather than the platform widening a closed set.
+   *
+   * Applied per organization at setup completion, so an install only ever holds
+   * the vocabulary of the business it is actually running.
+   */
+  workforceProfile?: WorkforceProfile;
+}
+
+/** A worker class this archetype's day requires. `classification` is the legal
+ *  axis behind the label, and it is set only where the label states it outright
+ *  — the platform never infers one, because a wrong answer here is a wage claim
+ *  (see `WorkerClassification` in the schema). */
+export interface ArchetypeEmploymentType {
+  employmentTypeId: string;
+  name: string;
+  classification: WorkerClassificationSlug;
+}
+
+/** A place this archetype's people actually work. */
+export interface ArchetypeWorkLocation {
+  locationId: string;
+  name: string;
+  /** Open vocabulary, matching `WorkLocation.locationType`. */
+  locationType: string;
+}
+
+/** Mirrors the `WorkerClassification` Prisma enum. Kept as a union here so the
+ *  templates package stays free of a database dependency. */
+export type WorkerClassificationSlug =
+  | "employee"
+  | "contractor_direct"
+  | "contractor_agency"
+  | "temp_agency_worker"
+  | "eor_employee"
+  | "volunteer"
+  | "intern"
+  | "board_member";
+
+export interface WorkforceProfile {
+  employmentTypes?: ArchetypeEmploymentType[];
+  workLocations?: ArchetypeWorkLocation[];
 }

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -19,13 +19,13 @@ apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	923
 apps/web/components/storefront/SlotBookingFlow.tsx	1015
 apps/web/components/workbooks/Grid.tsx	1830
 apps/web/instrumentation.test.ts	945
-apps/web/instrumentation.ts	1478
+apps/web/instrumentation.ts	1483
 apps/web/lib/actions/agent-coworker-external.test.ts	889
 apps/web/lib/actions/agent-coworker.ts	2810
 apps/web/lib/actions/agent-task-scheduler.test.ts	1132
 apps/web/lib/actions/agent-task-scheduler.ts	816
 apps/web/lib/actions/ai-providers.ts	914
-apps/web/lib/actions/build-governed.test.ts	1190
+apps/web/lib/actions/build-governed.test.ts	1189
 apps/web/lib/actions/build.ts	1776
 apps/web/lib/actions/compliance.ts	867
 apps/web/lib/actions/crm.ts	1043


### PR DESCRIPTION
Found by running Second Chance Animal Rescue as a business for one operating day (`docs/architecture/archetypes/pet-rescue-operating-model.md` §5b/§6b). Ships the workforce-vocabulary half of `BI-A30152B6`.

## What was wrong

The platform answered the rescue's staffing questions as an office business.

- **Employment type**: Full-time, Part-time, Contractor, Intern, Advisor. A shelter's largest labour pool is **volunteers** — unpaid, shift-based — and its second unpaid class is the **foster carer** who houses an animal off-site. Neither could be recorded at all.
- **Work location**: Headquarters, Remote, Hybrid. None of those describes anywhere an animal lives.

## No new structure was needed

Classified through `accommodation-doctrine.md` before choosing a mechanism. Step 1 said no — the *set* differs, not just the label. Steps 2, 3 and 4 said no. There is no new structure here:

- `EmploymentType` is a **table**, not an enum, with a nullable `WorkerClassification`.
- `WorkerClassification` **already carries `volunteer`**, and its own doc comment calls it *"the majority classification for nonprofit and community archetypes"*.
- `WorkLocation.locationType` is an open string.

Pattern 1, open kind vocabulary, with the archetype contributing rows.

## What ships

- **Volunteer** joins the platform defaults — global, because the canonical enum had already named it and no install could record one.
- **`workforceProfile`** on the archetype definition, applied by a new step in `runSetupCompletionSeeds`. `pet-rescue` and `animal-shelter` declare a foster carer and seven operational places: dog ward, cat room, isolation, intake, the surgery, a foster home, an offsite adoption event. A restaurant declares nothing and acquires nothing — asserted.
- **A boot reconciler**, without which this would have shipped and never appeared. `runSetupCompletionSeeds` is re-run on boot only by the WWWD backfill, and that backfill short-circuits on a healthy corpus — which every install that finished onboarding has. `backfillArchetypeWorkforceOnBoot` mirrors `backfillOperationalValueStreamsOnBoot`: cheap once healed, idempotent, non-fatal per org. §5b records the lesson: *a seed that only runs at setup completion has not shipped to anyone who completed setup.*
- A classification is written on **create only**. The four seeded types a migration deliberately left unresolved stay unresolved — the schema is explicit that a guess there writes a legal claim into the database, and an unpaid worker directed like an employee is a wage claim.

`instrumentation.ts` grew by five lines and its module-size baseline is retightened in the same commit (the run also picked up a one-line shrink on `build-governed.test.ts` from `main`).

## What this does NOT fix

`BI-A30152B6` stays open, and §5b now records the remainder with its evidence:

- **The eight named roles are not seeded.** Roles live in `packages/db/data/occupation_registry.json` — thirteen entries across healthcare, trades, agriculture and manufacturing, and **none** for `nonprofit-community`. That absence is exactly why the only role vocabulary a rescue manager sees is the platform's own `HR-000`..`HR-600` ladder. Each entry carries a coworker roster, a feature surface and an onboarding curriculum that must all resolve, so the eight roles are their own piece of work rather than a list to paste in.
- Recruiting still has no create control, an employee record still grants no access, and role is still write-once in the UI.

Defect class removed: a closed vocabulary that made the operator record something untrue about their own people.

## Design grounding

- Existing specs/plans reviewed: `pet-rescue-operating-model.md` §5b (the eight roles, two unpaid worker classes, work locations as operational places) · `accommodation-doctrine.md` (the classification above) · `archetype-operating-model-audit.md` (staffing is one of the five standing probes).
- Current code substrate reviewed: `packages/db/prisma/schema/workforce.prisma` · `packages/db/src/workforce-seed.ts` · `apps/web/lib/onboarding/setup-completion-seeds.ts` and `backfill-org-wwwd-on-boot.ts` (the short-circuit that made the reconciler necessary) · `apps/web/instrumentation.ts` (where the sibling reconcilers register) · `packages/db/data/occupation_registry.json`.
- Source of truth: the archetype declares, `seedArchetypeWorkforce` applies. There is no second list of worker classes anywhere.
- Decision: Volunteer is global because the canonical enum already named it; the rescue's foster carer and its wards are vertical, because one probe is not a promotion.

Design-Grounding-Decision: an archetype contributes rows to an open table; the platform does not widen a closed set
Docs-Impact-Decision: the types.ts change adds a workforce vocabulary field and touches no value stream, so docs/architecture/archetype-business-value-streams.md is unaffected; the user-facing doc that did change is §5b of the pet-rescue operating model, updated in this PR
Process-Spine-Decision: records the shipped half, the reconciler lesson, and the evidenced remainder in §5b of the pet-rescue operating model

Seed-Fit-Decision: global-default
