### PR TITLE
feat(scheduled-jobs): say why a coworker task runs at the cadence it runs at

### DIFF
--- a/apps/web/app/(shell)/admin/scheduled-jobs/ScheduledJobsClient.tsx
+++ b/apps/web/app/(shell)/admin/scheduled-jobs/ScheduledJobsClient.tsx
@@ -397,7 +397,7 @@ export function ScheduledJobsClient({ initialJobs }: { initialJobs: ScheduledWor
               <thead style={{ background: "var(--dpf-bg)" }}>
                 <tr>
                   <Th>What it is</Th>
-                  {l === "coworker" ? <Th>Coworker · lands on</Th> : <Th>Classification</Th>}
+                  {l === "coworker" ? <Th>Coworker · proactivity · lands on</Th> : <Th>Classification</Th>}
                   <Th>Cadence</Th>
                   <Th>Last run</Th>
                   <Th>{l === "spent" ? "Status" : "Next run"}</Th>
@@ -447,6 +447,19 @@ export function ScheduledJobsClient({ initialJobs }: { initialJobs: ScheduledWor
                             >
                               {job.agent.routeContext}
                             </a>
+                            {job.agent.proactivity && (
+                              <div className="text-dpf-caption mt-0.5" style={{ color: "var(--dpf-muted)" }}>
+                                <span style={{ color: "var(--dpf-text)" }}>
+                                  {job.agent.proactivity.level}
+                                </span>
+                                {job.agent.proactivity.registeredCadence
+                                  ? ` — self-task runs ${job.agent.proactivity.level === "assertive"
+                                      ? job.agent.proactivity.registeredCadence.assertive
+                                      : job.agent.proactivity.registeredCadence.balanced}`
+                                  : " — does not set this cadence"}
+                                {job.agent.proactivity.source === "reconcile-backfill" && " (inferred)"}
+                              </div>
+                            )}
                             {job.agent.lastTaskRunId && (
                               <div className="text-dpf-caption mt-0.5" style={{ color: "var(--dpf-muted)" }}>
                                 last run {job.agent.lastTaskRunId}

--- a/apps/web/lib/operate/scheduled-jobs/register.ts
+++ b/apps/web/lib/operate/scheduled-jobs/register.ts
@@ -6,15 +6,21 @@
 
 import { prisma } from "@dpf/db";
 
+import { PROACTIVITY_FACT_CATEGORY } from "@/lib/proactivity/proactivity-override-preferences";
+
 import { SCHEDULED_JOB_CATALOG } from "./catalog";
+import { coworkerSelfTaskCadenceInfo, isCoworkerSelfTaskId } from "./coworker-self-tasks";
 import {
   buildWorkView,
+  parseProactivityFact,
+  proactivityFactKey,
   selectRegisterIds,
   JOB_SELECT,
   TASK_SELECT,
   type AgentTaskRow,
   type JobRow,
   type ScheduledWorkView,
+  type WorkProactivity,
 } from "./work-model";
 
 export * from "./work-model";
@@ -36,11 +42,72 @@ export async function listScheduledWork(now: Date = new Date()): Promise<Schedul
   const jobById = new Map(jobRows.map((r) => [r.jobId, r]));
   const taskById = new Map(taskRows.map((t) => [t.taskId, t]));
 
+  // One bounded query for every (owner, agent) pair in the register — never a
+  // lookup per row. Only the current fact counts: a superseded row is a level
+  // the operator has already moved off.
+  const proactivityByAgent = await readProactivity(taskRows);
+
   const ids = selectRegisterIds(
     SCHEDULED_JOB_CATALOG.map((e) => e.jobId),
     jobRows,
     taskRows.map((t) => t.taskId),
   );
 
-  return ids.map((id) => buildWorkView(id, jobById.get(id), taskById.get(id), now));
+  return ids.map((id) => {
+    const task = taskById.get(id);
+    const key = task ? `${task.ownerUserId}::${task.taskId}` : null;
+    return buildWorkView(
+      id,
+      jobById.get(id),
+      task,
+      now,
+      key ? (proactivityByAgent.get(key) ?? null) : null,
+    );
+  });
+}
+
+/**
+ * Current proactivity level per (owner, agent), plus the cadence that coworker's
+ * registry entry runs at per level. Two queries total regardless of register
+ * size: one for the facts, none for the cadence (it is an in-code registry).
+ */
+async function readProactivity(
+  taskRows: readonly AgentTaskRow[],
+): Promise<Map<string, WorkProactivity>> {
+  const out = new Map<string, WorkProactivity>();
+  if (taskRows.length === 0) return out;
+
+  const owners = [...new Set(taskRows.map((t) => t.ownerUserId))];
+  const keys = [...new Set(taskRows.map((t) => proactivityFactKey(t.agentId)))];
+
+  const facts = await prisma.userFact.findMany({
+    where: {
+      userId: { in: owners },
+      category: PROACTIVITY_FACT_CATEGORY,
+      key: { in: keys },
+      supersededAt: null,
+    },
+    select: { userId: true, key: true, value: true },
+  });
+
+  const byUserKey = new Map(facts.map((f) => [`${f.userId}::${f.key}`, f.value]));
+
+  for (const task of taskRows) {
+    const raw = byUserKey.get(`${task.ownerUserId}::${proactivityFactKey(task.agentId)}`);
+    const parsed = raw === undefined ? null : parseProactivityFact(raw);
+    if (!parsed) continue;
+    // The registry cadence governs the coworker's SELF-task only. Attaching it
+    // to any other task the coworker owns implies a relationship that is not
+    // there: inventory-specialist is balanced (registry: weekly) while
+    // discovery-taxonomy-gap-triage-daily runs daily, and that task is not
+    // driven by proactivity at all.
+    const info = isCoworkerSelfTaskId(task.taskId)
+      ? coworkerSelfTaskCadenceInfo(task.agentId)
+      : { registered: false, cadence: null };
+    out.set(`${task.ownerUserId}::${task.taskId}`, {
+      ...parsed,
+      registeredCadence: info.registered ? info.cadence : null,
+    });
+  }
+  return out;
 }

--- a/apps/web/lib/operate/scheduled-jobs/work-model.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/work-model.test.ts
@@ -16,6 +16,8 @@ import {
   isQuarantined,
   isRetired,
   overdueGraceMs,
+  parseProactivityFact,
+  proactivityFactKey,
   selectRegisterIds,
   stepCronIntervalMs,
 } from "./work-model";
@@ -256,6 +258,10 @@ describe("buildWorkView", () => {
     expect(view.enabled).toBe(true);
   });
 
+  it("carries no proactivity when the pair has no stored fact", () => {
+    expect(buildWorkView(task.taskId, undefined, task, NOW).agent?.proactivity).toBeNull();
+  });
+
   it("surfaces the coworker, its route and its last run", () => {
     const view = buildWorkView(task.taskId, staleMirror, task, NOW);
     expect(view.agent).toEqual({
@@ -265,6 +271,7 @@ describe("buildWorkView", () => {
       ownerUserId: "user-1",
       lastTaskRunId: "TR-SCHED-C77B43A9",
       lastThreadId: null,
+      proactivity: null,
     });
   });
 
@@ -345,6 +352,49 @@ describe("selectRegisterIds", () => {
       ["task-c"],
     );
     expect(ids.sort()).toEqual(["cron-a", "row-b", "task-c"]);
+  });
+});
+
+describe("parseProactivityFact", () => {
+  it("reads a level the operator set, and keeps its provenance", () => {
+    // Shape taken verbatim from a live UserFact row.
+    const v = {
+      scope: "agent",
+      scopeKey: "agent:coo",
+      level: "assertive",
+      source: "manual-setting",
+      acknowledgedByUserId: "u1",
+      acknowledgedAt: "2026-08-23T18:23:34.909Z",
+    };
+    expect(parseProactivityFact(v)).toEqual({
+      level: "assertive",
+      source: "manual-setting",
+      acknowledgedAt: "2026-08-23T18:23:34.909Z",
+    });
+  });
+
+  it("distinguishes a backfilled level from one the operator chose", () => {
+    // "reconcile-backfill" is the platform inferring a level from an orphaned
+    // task; presenting it as a deliberate setting would overstate it.
+    const parsed = parseProactivityFact({ level: "balanced", source: "reconcile-backfill" });
+    expect(parsed?.source).toBe("reconcile-backfill");
+  });
+
+  it("accepts the JSON-string form the column can hold", () => {
+    expect(parseProactivityFact('{"level":"quiet"}')?.level).toBe("quiet");
+  });
+
+  it("returns null rather than guessing at an unreadable fact", () => {
+    expect(parseProactivityFact("not json")).toBeNull();
+    expect(parseProactivityFact({ level: "enthusiastic" })).toBeNull();
+    expect(parseProactivityFact(null)).toBeNull();
+    expect(parseProactivityFact({})).toBeNull();
+  });
+});
+
+describe("proactivityFactKey", () => {
+  it("matches the key the platform actually stores", () => {
+    expect(proactivityFactKey("coo")).toBe("aiCoworkerProactivity:agent:coo");
   });
 });
 

--- a/apps/web/lib/operate/scheduled-jobs/work-model.ts
+++ b/apps/web/lib/operate/scheduled-jobs/work-model.ts
@@ -42,6 +42,7 @@
 
 import { SCHEDULE_INTERVALS_MS } from "@/lib/inference/ai-provider-types";
 import { computeNextCronRun, isOneShotCron } from "@/lib/operate/cron-next-run";
+import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
 
 import { getCatalogEntry } from "./catalog";
 import type { JobCategory } from "./catalog-types";
@@ -82,6 +83,30 @@ export type WorkHealth =
   | "spent";
 
 /** The coworker behind an agent-backed unit of work. */
+/**
+ * Why a coworker task runs at the cadence it runs at.
+ *
+ * The register showed the cadence without the reason. Proactivity IS the reason:
+ * COWORKER_SELF_TASKS maps the level to a cron — quiet produces no task at all,
+ * balanced weekly, assertive daily — so a row that shows "Daily at 14:07" and
+ * nothing else is withholding the one fact that explains it.
+ *
+ * `source` matters as much as `level`: "manual-setting" means the operator chose
+ * it, "reconcile-backfill" means the platform inferred it from an orphaned task.
+ * Those warrant different confidence and the surface should not blur them.
+ */
+export interface WorkProactivity {
+  level: ProactivityLevel;
+  /** How the level came to be set, verbatim from the stored fact. */
+  source: string | null;
+  /** When it was last acknowledged, ISO. */
+  acknowledgedAt: string | null;
+  /** Cadence this coworker's registry entry runs at per level, when it has one.
+   *  Null when the coworker is not in COWORKER_SELF_TASKS — the task exists for
+   *  another reason and proactivity does not govern its cadence. */
+  registeredCadence: { balanced: string; assertive: string } | null;
+}
+
 export interface WorkAgentContext {
   agentId: string;
   /** Human title from the task itself (more specific than the job name). */
@@ -93,6 +118,8 @@ export interface WorkAgentContext {
   /** Public id of the TaskRun the last tick spawned, when there was one. */
   lastTaskRunId: string | null;
   lastThreadId: string | null;
+  /** Null when no proactivity fact exists for this (owner, agent) pair. */
+  proactivity: WorkProactivity | null;
 }
 
 /** Client-safe, fully-resolved row. Dates are ISO strings so the DTO crosses
@@ -461,6 +488,40 @@ export function isRetired(metadata: unknown): boolean {
   );
 }
 
+/** Key under which a per-agent proactivity fact is stored on UserFact. */
+export function proactivityFactKey(agentId: string): string {
+  return `aiCoworkerProactivity:agent:${agentId}`;
+}
+
+const LEVELS = new Set(["quiet", "balanced", "assertive"]);
+
+/**
+ * Parse a stored proactivity fact value. Returns null rather than guessing when
+ * the blob is unreadable or carries no recognised level — an unreadable
+ * preference must not be presented as a setting the operator made.
+ */
+export function parseProactivityFact(
+  value: unknown,
+): { level: ProactivityLevel; source: string | null; acknowledgedAt: string | null } | null {
+  let parsed: unknown = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const rec = parsed as Record<string, unknown>;
+  const level = rec.level;
+  if (typeof level !== "string" || !LEVELS.has(level)) return null;
+  return {
+    level: level as ProactivityLevel,
+    source: typeof rec.source === "string" ? rec.source : null,
+    acknowledgedAt: typeof rec.acknowledgedAt === "string" ? rec.acknowledgedAt : null,
+  };
+}
+
 /**
  * Which ids belong in the register, given the catalog and both substrates.
  *
@@ -497,6 +558,7 @@ export function buildWorkView(
   job: JobRow | undefined,
   task: AgentTaskRow | undefined,
   now: Date,
+  proactivity: WorkProactivity | null = null,
 ): ScheduledWorkView {
   const entry = getCatalogEntry(jobId);
 
@@ -540,6 +602,7 @@ export function buildWorkView(
         ownerUserId: task.ownerUserId,
         lastTaskRunId: task.taskRunId,
         lastThreadId: task.lastThreadId,
+        proactivity,
       }
     : null;
 

--- a/docs/user-guide/admin/index.md
+++ b/docs/user-guide/admin/index.md
@@ -93,6 +93,13 @@ Two labels are worth knowing:
   reads the enabled flag. The control is withheld rather than shown as a button
   that does nothing.
 
+On a coworker row, the **proactivity** level explains the cadence: a coworker set
+to assertive self-drives daily, balanced weekly, and quiet produces no scheduled
+work at all. The level is shown next to the coworker, with the cadence it implies
+for that coworker's own recurring task. A level marked *inferred* was derived by
+the platform from an existing task rather than chosen by you. Tasks that are not
+the coworker's own self-task say so, because proactivity does not set their cadence.
+
 **What is going to run** projects the live cadences over the next day, week, or
 month. Jobs that fire more often than the chart can usefully plot are listed
 below it instead. Click any name to filter the register to it.


### PR DESCRIPTION
Closes BI-D8710B6C · Decision DI-07332FC0871A · follows #4667

## The gap

The register (#4667) shows a coworker task's cadence and withholds the reason. Proactivity **is** the reason: `COWORKER_SELF_TASKS` maps the level to a cron — **quiet produces no task at all, balanced weekly, assertive daily** — so a row reading "Daily at 14:07" and nothing else omits the one fact that explains it.

The operator's words: *"the proactivity in the AI Agents should be a key indication for some, with the relevant workrooms they are going to invoke or be part of, so we know what they are for."*

## What this adds

The coworker row now carries the proactivity level and the cadence that level implies. Two things live data forced, neither obvious from the code:

**Scoped to self-tasks.** The registry cadence governs the coworker's own `self-<agent>-<user>` task and nothing else. `inventory-specialist` is *balanced* (registry: weekly) while `discovery-taxonomy-gap-triage-daily` runs *daily* — that task isn't proactivity-driven at all. Attaching "weekly at this level" to it would have invented a relationship. Other tasks now say proactivity does not set their cadence.

**Provenance is part of the fact.** Every current fact on this install reads `source="reconcile-backfill"` — the platform inferred these levels from orphaned tasks; the operator didn't choose them. A backfilled level is marked *inferred* rather than presented as a deliberate setting.

Reads are bounded: one `UserFact` query for the whole register keyed on `(owner, agent)`, never a lookup per row; the cadence side is an in-code registry with no query at all.

## The workroom half is deliberately not shipped

`WorkCapsule.taskRunId` is populated on **0 of 351 rows**. The relation exists in schema and nothing has ever written it, so a workroom column would render empty for every row, forever — reproducing the exact defect the register was built to remove.

The kernel agrees. Scored three options: composite **10.38** (this) vs **2.33** (ship an empty column) vs **6.04** (block until the substrate is wired), margin 4.34, high confidence, no commandment conflict. **`Never Fabricate` scores negative** on the empty-column option. Recorded as `DI-07332FC0871A`; the gap and its two open design questions are in **BI-D8710B6C**.

The second open question, also unshipped: a `quiet` coworker produces no task, so it has **no row** — the most useful statement ("idle because you set it to quiet") can't be a column on a row that doesn't exist. That needs a different affordance, not a wider table.

## Verification

138 scheduled-jobs tests, typecheck clean, 52/52 preflight guards. Prose and style ratchets pass **with no baseline edit** — the copy fits inside the frozen budget.

Resolution verified against live rows: 7 active coworker tasks, 7 current facts. `marketing-specialist` assertive → registry daily → runs daily at 14:07 (consistent); `inventory-specialist` balanced → registry weekly → self-task runs Tue/Fri (drift, now visible); `AGT-WS-EA` and `external-catalog-scout` are not in the registry, so their rows say proactivity does not set their cadence.

Local gate bypassed under a recorded `operator-emergency` override on the operator's instruction — local-CI slot-0 preempts a running gate mid-build and never writes a record (**BI-2F7BE7E9**). Cloud CI is the adjudicating gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
