### PR TITLE
fix(work-case): the list and the room derive one state (BI-2310EEE1)

### DIFF
--- a/apps/web/lib/work-management/workspace-case-loader.test.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.test.ts
@@ -94,6 +94,71 @@ describe("workspace Work Case loader", () => {
     expect(decodeWorkCaseKey(key)).toEqual({ sourceType: "manual-task", sourceId: "WI:42" });
   });
 
+  // BI-2310EEE1 — the list and the room must derive one state. A queued WorkItem
+  // projects "intake"; a completed capsule anchored to it projects "resolved". Before
+  // the fix the list (WorkItem only) showed "intake" while the room (with the capsule)
+  // showed "resolved" — the exact dogfood symptom "list says Intake, room says Resolved".
+  it("list and room agree on state when a capsule out-projects the WorkItem", async () => {
+    const item = {
+      ...baseItem,
+      id: "row-cap",
+      itemId: "WI-CAP",
+      sourceType: "work-capsule",
+      sourceId: "WC-9",
+      title: "Coding carrier",
+      status: "queued",
+      assignedToUserId: "user-1",
+    };
+    const prismaClient: WorkspaceCasePrismaClient = {
+      workItem: { findMany: async () => [item], findFirst: async () => item },
+      workItemMessage: { findMany: async () => [] },
+      workroom: {
+        findMany: async () => [{ workItemId: "row-cap", capsuleId: "WC-9", status: "complete", title: "Coding carrier" }],
+      },
+    };
+    const now = new Date("2026-06-28T12:00:00.000Z");
+    const list = await loadWorkspaceWorkCaseLens({ prismaClient, userId: "user-1", now });
+    const detail = await loadWorkspaceWorkCaseDetail({
+      prismaClient,
+      caseKey: encodeWorkCaseKey({ sourceType: "work-capsule", sourceId: "WC-9" }),
+      userId: "user-1",
+      now,
+    });
+
+    expect(list.cases[0]?.state).toBe("resolved");
+    expect(list.cases[0]?.state).toBe(detail?.summary.state);
+  });
+
+  // The "Active" tile counts state === active | verifying. A verifying capsule the list
+  // could not previously see read as 0 beside a listed room; now the list sees it.
+  it("the Active tile counts a verifying capsule the list can now see", async () => {
+    const item = {
+      ...baseItem,
+      id: "row-v",
+      itemId: "WI-V",
+      sourceType: "work-capsule",
+      sourceId: "WC-V",
+      title: "Coding carrier",
+      status: "queued",
+      assignedToUserId: "user-1",
+    };
+    const prismaClient: WorkspaceCasePrismaClient = {
+      workItem: { findMany: async () => [item], findFirst: async () => item },
+      workItemMessage: { findMany: async () => [] },
+      workroom: {
+        findMany: async () => [{ workItemId: "row-v", capsuleId: "WC-V", status: "verifying", title: "Coding carrier" }],
+      },
+    };
+    const list = await loadWorkspaceWorkCaseLens({
+      prismaClient,
+      userId: "user-1",
+      now: new Date("2026-06-28T12:00:00.000Z"),
+    });
+
+    expect(list.cases[0]?.state).toBe("verifying");
+    expect(list.stats.active).toBe(1);
+  });
+
   it("loads evidence-first detail from the same projected source", async () => {
     const detail = await loadWorkspaceWorkCaseDetail({
       prismaClient: prismaFor([baseItem]),

--- a/apps/web/lib/work-management/workspace-case-loader.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.ts
@@ -97,6 +97,10 @@ type WorkspaceWorkItemMessageRecord = {
 export type WorkspaceWorkCapsuleRecord = {
   /** The row the operator posture control writes back to. */
   id?: string;
+  /** The WorkItem row this capsule is anchored to — lets the list loader group a
+   *  batched capsule fetch by item so the list projects the SAME state the detail
+   *  does (BI-2310EEE1). Optional so existing fakes/selects keep compiling. */
+  workItemId?: string | null;
   capsuleId: string;
   status: string;
   title: string;
@@ -242,7 +246,12 @@ function dueSoon(dueAt: string | null, now: Date): boolean {
   return due >= now.getTime() && due <= horizon;
 }
 
-function toListItem(item: WorkspaceWorkItemRecord, userId: string, now: Date): WorkspaceWorkCaseListItem {
+function toListItem(
+  item: WorkspaceWorkItemRecord,
+  userId: string,
+  now: Date,
+  capsules: readonly WorkspaceWorkCapsuleRecord[] = [],
+): WorkspaceWorkCaseListItem {
   const source = sourceForItem(item);
   const summary = buildWorkCaseSummary({
     source,
@@ -254,6 +263,15 @@ function toListItem(item: WorkspaceWorkItemRecord, userId: string, now: Date): W
       dueAt: item.dueAt,
       assignedToUserId: item.assignedToUserId,
     },
+    // Feed the SAME capsule the detail loader projects from (BI-2310EEE1) — most
+    // recent first, matching the detail's `updatedAt desc` order — so the list and
+    // the room agree on one derived state instead of the list showing the raw
+    // WorkItem status while the detail shows the capsule-projected state.
+    capsules: capsules.map((capsule) => ({
+      capsuleId: capsule.capsuleId,
+      status: capsule.status,
+      title: capsule.title,
+    })),
   });
   const dueAt = iso(item.dueAt);
   const urgentAttention = item.urgency === "emergency" || item.urgency === "urgent";
@@ -319,7 +337,29 @@ export async function loadWorkspaceWorkCaseLens({
     take: limit,
   });
 
-  const cases = items.map((item) => toListItem(item, userId, now)).sort(sortCases);
+  // BI-2310EEE1: batch-join the capsule(s) anchored to these items in ONE query
+  // (not per-item) so the list projects the same capsule-derived state the room
+  // detail does. Bounded by the item page above — no unbounded scan.
+  const itemRowIds = items.map((item) => item.id).filter((id): id is string => Boolean(id));
+  const capsuleRows = itemRowIds.length
+    ? await prismaClient.workroom.findMany({
+        where: { workItemId: { in: itemRowIds } },
+        select: { workItemId: true, capsuleId: true, status: true, title: true },
+        orderBy: [{ updatedAt: "desc" }],
+      })
+    : [];
+  const capsulesByItem = new Map<string, WorkspaceWorkCapsuleRecord[]>();
+  for (const capsule of capsuleRows) {
+    const key = capsule.workItemId;
+    if (!key) continue;
+    const bucket = capsulesByItem.get(key);
+    if (bucket) bucket.push(capsule);
+    else capsulesByItem.set(key, [capsule]);
+  }
+
+  const cases = items
+    .map((item) => toListItem(item, userId, now, item.id ? capsulesByItem.get(item.id) ?? [] : []))
+    .sort(sortCases);
 
   return {
     generatedAt: now.toISOString(),
@@ -627,7 +667,10 @@ export async function loadWorkspaceWorkCaseDetail({
   });
 
   return {
-    summary: toListItem(item, userId, now),
+    // Same derivation as the list (BI-2310EEE1) — feed the capsules this loader
+    // already fetched so the room's headline state matches the list's instead of
+    // falling back to the raw WorkItem status.
+    summary: toListItem(item, userId, now, capsules),
     evidenceTimeline: detail.timeline,
     sourceRefs: detail.summary.sourceRefs,
     workItemId: item.id,


### PR DESCRIPTION
## What

From the owner-led UX dogfood: the workspace Work Room **state was derived twice and disagreed** — the list said *Intake* while the room said *Resolved*, and the "Active" tile read 0 beside live rooms.

Both the list and the room detail project their headline state through `toListItem → buildWorkCaseSummary`, whose state comes from a priority cascade (`decision > runtime-verification > capsule > work-item`). But only the room *fetched* the anchored capsule — and even the room's returned summary went through a **capsule-less** `toListItem`. So a queued WorkItem with a completed capsule projected `intake` (WorkItem-only) in the list and, separately, the raw WorkItem status in the room.

## Fix — one derivation, fed consistently

- `toListItem` takes the anchored capsule(s) and passes them into `buildWorkCaseSummary`, so the projection sees the same signal everywhere.
- The **list loader batch-joins** capsules for the whole item page in one query, grouped by WorkItem row id — no per-item N+1.
- The **room detail** feeds `toListItem` the capsules it already fetched.

Now the list, the room, and the Active tile agree on the capsule-derived state.

## Verification

- Regression tests reproduce the exact `list says Intake, room says Resolved` case (a `queued` item + a `complete` capsule → both `resolved`) and the Active-tile miscount (a `verifying` capsule now counted).
- Full local-CI pregate **passed**; work-management suite (320 tests) + typecheck + 52 guards green.

This is the first slice of the "purge overlapping work-forms" cleanup — one canonical work-case derivation, no second disagreeing read path.

Design-Grounding-Decision: no-contract-change (single-source read-model bugfix restoring one state derivation across list and room; no routing, schema, or contract change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)