### PR TITLE
feat(bookkeeping): seed the standing weekly cycle — the framework's initial use (BI-DC738330)

### DIFF
--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -2225,7 +2225,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - paragraph\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - textbox\n  - combobox\n    - option [selected]\n  - button\n  - link\n  - text"
     },
     "/workspace/inbox": {
-      "defaultVisibleWords": 143,
+      "defaultVisibleWords": 415,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -2233,7 +2233,7 @@
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - main\n    - heading [level=1]\n    - paragraph\n      - text\n    - list\n      - listitem"
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - main\n    - heading [level=1]\n    - paragraph\n      - text\n    - heading [level=3]\n      - button\n        - text\n    - link\n    - heading [level=3]\n      - button\n        - text\n    - link\n    - heading [level=3]\n      - button\n        - text\n    - link\n    - complementary\n      - text"
     },
     "/workspace/my-queue": {
       "defaultVisibleWords": 116,

--- a/docs/superpowers/plans/2026-08-26-bookkeeping-triggers.md
+++ b/docs/superpowers/plans/2026-08-26-bookkeeping-triggers.md
@@ -34,7 +34,11 @@ Wire the two triggers that make the Bookkeeping Work Room recurring rather than 
 - Unit tests: period-key determinism, the pure cycle-input builder (no-fabrication stop conditions present), the weekly + on-arrival paths against a mock cycle store (opens once, idempotent on re-fire, prior-active handled, non-bookkeeping inbound passes through). Full `apps/web` typecheck clean; local-CI pregate green.
 - **Owner-gated:** the live cadence and a live inbound address require the operator's setup and real statement export — no fictitious data on the live instance. The machinery is verified with fixtures; the reconciled period waits on the owner.
 
+## Initial use (seed) — follow-up
+
+A framework is inert until something runs on it. `packages/db/src/seed-bookkeeping-cycle.ts` (config in `bookkeeping-cycle-config.ts`) seeds the standing weekly `bookkeeping-cycle` scheduled task on every install — mirroring `seed-data-model-mirror.ts` — so the cadence actually fires and opens period cycles rather than the trigger merely being available. The deterministic handler (S-TRIG, `executeBookkeepingCycleTask`) runs it off the LLM path; the reconciled period stays owner-gated on the real statement export. Wired in `seed.ts` as the `bookkeepingCycleScheduledTask` step.
+
 ## Risks & rollback
 
 - A weekly tick that fires while a prior cycle is still open is handled (treated as already-active), not an error.
-- Rollback: remove the two trigger modules + the task kind + executor branch; pure additions, no migration.
+- Rollback: remove the two trigger modules + the task kind + executor branch; pure additions, no migration. The seed task is upsert-idempotent; removing the seed step and the row rolls it back.

--- a/packages/db/src/bookkeeping-cycle-config.ts
+++ b/packages/db/src/bookkeeping-cycle-config.ts
@@ -1,0 +1,33 @@
+// packages/db/src/bookkeeping-cycle-config.ts
+// The initial use of the Bookkeeping Work Room (BI-DC738330, S-TRIG). Seeding a
+// standing weekly `bookkeeping-cycle` scheduled task is what turns the framework
+// from available into running: on cadence it opens or advances the current
+// period's cycle on the standing `bookkeeping-period` room. The deterministic
+// handler lives in apps/web's scheduler (executeScheduledAgentTask branches on
+// taskKind and runs executeBookkeepingCycleTask without an LLM loop).
+
+export const BOOKKEEPING_CYCLE_TASK_ID = "bookkeeping-cycle-weekly";
+
+// The Bookkeeper coworker (AGT-907) — the actor the opened cycle is attributed to.
+export const BOOKKEEPING_CYCLE_AGENT_ID = "AGT-907";
+
+export const BOOKKEEPING_CYCLE_TASK_TITLE = "Bookkeeping cycle (weekly)";
+export const BOOKKEEPING_CYCLE_ROUTE_CONTEXT = "/finance/banking";
+
+// Weekly, Monday 09:00 UTC. The cycle key is the ISO week, so the cadence and an
+// on-arrival statement both resolve to one idempotent period.
+export const BOOKKEEPING_CYCLE_SCHEDULE = "0 9 * * 1";
+export const BOOKKEEPING_CYCLE_DEFAULT_TIMEZONE = "UTC";
+export const BOOKKEEPING_CYCLE_SCHEDULED_JOB_NAME = "Bookkeeping Cycle Weekly";
+
+// MUST equal BOOKKEEPING_CYCLE_TASK_KIND in
+// apps/web/lib/operate/scheduled-jobs/agent-task-kind.ts — the scheduler
+// discriminates on this literal. packages/db cannot import from apps/web, so the
+// value is duplicated here behind this contract note.
+export const BOOKKEEPING_CYCLE_TASK_KIND = "bookkeeping-cycle";
+
+export const BOOKKEEPING_CYCLE_PROMPT =
+  "Open or advance the current bookkeeping period on the standing books room: gather the period's " +
+  "statements and receipts, import with provenance, categorize and match every transaction or surface " +
+  "it as an exception, reconcile the balance, and prepare the Outcome Packet for owner review. Never " +
+  "fabricate a transaction; the reconciled period is owner-gated on the real statement export.";

--- a/packages/db/src/seed-bookkeeping-cycle.test.ts
+++ b/packages/db/src/seed-bookkeeping-cycle.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { ensureBookkeepingCycleScheduledTask } from "./seed-bookkeeping-cycle";
+import {
+  BOOKKEEPING_CYCLE_AGENT_ID,
+  BOOKKEEPING_CYCLE_SCHEDULE,
+  BOOKKEEPING_CYCLE_TASK_ID,
+  BOOKKEEPING_CYCLE_TASK_KIND,
+} from "./bookkeeping-cycle-config";
+
+type Row = Record<string, unknown>;
+
+/** Minimal in-memory stand-in for the three tables the seed touches. */
+function fakePrisma(opts: { hasSuperuser?: boolean } = {}) {
+  const hasSuperuser = opts.hasSuperuser ?? true;
+  const tasks = new Map<string, Row>();
+  const jobs = new Map<string, Row>();
+  const client = {
+    user: {
+      findFirst: async () => (hasSuperuser ? { id: "user-super" } : null),
+    },
+    scheduledAgentTask: {
+      findUnique: async ({ where }: { where: { taskId: string } }) => tasks.get(where.taskId) ?? null,
+      create: async ({ data }: { data: Row }) => {
+        tasks.set(data.taskId as string, { ...data });
+        return data;
+      },
+      update: async ({ where, data }: { where: { taskId: string }; data: Row }) => {
+        tasks.set(where.taskId, { ...tasks.get(where.taskId), ...data });
+        return data;
+      },
+    },
+    scheduledJob: {
+      upsert: async ({ where, create, update }: { where: { jobId: string }; create: Row; update: Row }) => {
+        const existing = jobs.get(where.jobId);
+        jobs.set(where.jobId, existing ? { ...existing, ...update } : { ...create });
+        return jobs.get(where.jobId)!;
+      },
+    },
+  };
+  return { client: client as never, tasks, jobs };
+}
+
+describe("ensureBookkeepingCycleScheduledTask", () => {
+  it("seeds the weekly bookkeeping-cycle task with the right kind, agent, and cadence", async () => {
+    const { client, tasks, jobs } = fakePrisma();
+    const result = await ensureBookkeepingCycleScheduledTask(client, new Date("2026-08-24T00:00:00.000Z"));
+
+    expect(result.created).toBe(true);
+    const task = tasks.get(BOOKKEEPING_CYCLE_TASK_ID)!;
+    expect(task.taskKind).toBe(BOOKKEEPING_CYCLE_TASK_KIND);
+    expect(task.agentId).toBe(BOOKKEEPING_CYCLE_AGENT_ID);
+    expect(task.schedule).toBe(BOOKKEEPING_CYCLE_SCHEDULE);
+    expect(task.ownerUserId).toBe("user-super");
+    expect(task.nextRunAt).toBeInstanceOf(Date);
+    expect(jobs.get(BOOKKEEPING_CYCLE_TASK_ID)).toBeTruthy();
+  });
+
+  it("is idempotent — a second run updates rather than duplicating", async () => {
+    const { client, tasks } = fakePrisma();
+    await ensureBookkeepingCycleScheduledTask(client, new Date("2026-08-24T00:00:00.000Z"));
+    const second = await ensureBookkeepingCycleScheduledTask(client, new Date("2026-08-31T00:00:00.000Z"));
+
+    expect(second.created).toBe(false);
+    expect(tasks.size).toBe(1);
+    expect(tasks.get(BOOKKEEPING_CYCLE_TASK_ID)!.taskKind).toBe(BOOKKEEPING_CYCLE_TASK_KIND);
+  });
+
+  it("refuses to seed when no superuser owner exists", async () => {
+    const { client } = fakePrisma({ hasSuperuser: false });
+    await expect(ensureBookkeepingCycleScheduledTask(client)).rejects.toThrow(/no superuser/);
+  });
+});

--- a/packages/db/src/seed-bookkeeping-cycle.ts
+++ b/packages/db/src/seed-bookkeeping-cycle.ts
@@ -1,0 +1,111 @@
+// packages/db/src/seed-bookkeeping-cycle.ts
+// The initial use of the Bookkeeping Work Room (BI-DC738330). Seeds the standing
+// weekly `bookkeeping-cycle` scheduled task so the framework runs on every
+// install. The deterministic handler lives in apps/web's scheduler
+// (executeScheduledAgentTask branches on taskKind and runs
+// executeBookkeepingCycleTask — no LLM loop).
+import type { PrismaClient } from "../generated/client/client";
+
+import {
+  BOOKKEEPING_CYCLE_AGENT_ID,
+  BOOKKEEPING_CYCLE_DEFAULT_TIMEZONE,
+  BOOKKEEPING_CYCLE_PROMPT,
+  BOOKKEEPING_CYCLE_ROUTE_CONTEXT,
+  BOOKKEEPING_CYCLE_SCHEDULE,
+  BOOKKEEPING_CYCLE_SCHEDULED_JOB_NAME,
+  BOOKKEEPING_CYCLE_TASK_ID,
+  BOOKKEEPING_CYCLE_TASK_KIND,
+  BOOKKEEPING_CYCLE_TASK_TITLE,
+} from "./bookkeeping-cycle-config";
+
+type ScheduledTaskSeedClient = Pick<PrismaClient, "user" | "scheduledAgentTask" | "scheduledJob">;
+
+function computeNextCronRun(cronExpr: string, from: Date): Date {
+  const parts = cronExpr.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    const fallback = new Date(from);
+    fallback.setUTCDate(fallback.getUTCDate() + 1);
+    return fallback;
+  }
+  const [minPart, hourPart] = parts;
+  const minute = minPart === "*" ? 0 : parseInt(minPart!, 10);
+  const hour = hourPart === "*" ? from.getUTCHours() : parseInt(hourPart!, 10);
+  const next = new Date(from);
+  next.setUTCSeconds(0, 0);
+  next.setUTCMinutes(minute);
+  next.setUTCHours(hour);
+  if (next <= from) next.setUTCDate(next.getUTCDate() + 1);
+  return next;
+}
+
+export async function ensureBookkeepingCycleScheduledTask(
+  prisma: ScheduledTaskSeedClient,
+  now: Date = new Date(),
+): Promise<{ created: boolean }> {
+  const owner = await prisma.user.findFirst({
+    where: { isSuperuser: true },
+    orderBy: { createdAt: "asc" },
+    select: { id: true },
+  });
+  if (!owner) {
+    throw new Error("seed: no superuser found - cannot seed bookkeeping cycle scheduled task");
+  }
+
+  const timezone = process.env.INSTALL_TIMEZONE ?? BOOKKEEPING_CYCLE_DEFAULT_TIMEZONE;
+  const nextRunAt = computeNextCronRun(BOOKKEEPING_CYCLE_SCHEDULE, now);
+
+  const existing = await prisma.scheduledAgentTask.findUnique({
+    where: { taskId: BOOKKEEPING_CYCLE_TASK_ID },
+    select: { taskId: true, nextRunAt: true },
+  });
+
+  if (existing) {
+    await prisma.scheduledAgentTask.update({
+      where: { taskId: BOOKKEEPING_CYCLE_TASK_ID },
+      data: {
+        agentId: BOOKKEEPING_CYCLE_AGENT_ID,
+        title: BOOKKEEPING_CYCLE_TASK_TITLE,
+        prompt: BOOKKEEPING_CYCLE_PROMPT,
+        routeContext: BOOKKEEPING_CYCLE_ROUTE_CONTEXT,
+        schedule: BOOKKEEPING_CYCLE_SCHEDULE,
+        timezone,
+        taskKind: BOOKKEEPING_CYCLE_TASK_KIND,
+        ownerUserId: owner.id,
+        isActive: true,
+        nextRunAt: existing.nextRunAt ?? nextRunAt,
+      },
+    });
+  } else {
+    await prisma.scheduledAgentTask.create({
+      data: {
+        taskId: BOOKKEEPING_CYCLE_TASK_ID,
+        agentId: BOOKKEEPING_CYCLE_AGENT_ID,
+        title: BOOKKEEPING_CYCLE_TASK_TITLE,
+        prompt: BOOKKEEPING_CYCLE_PROMPT,
+        routeContext: BOOKKEEPING_CYCLE_ROUTE_CONTEXT,
+        schedule: BOOKKEEPING_CYCLE_SCHEDULE,
+        timezone,
+        taskKind: BOOKKEEPING_CYCLE_TASK_KIND,
+        ownerUserId: owner.id,
+        nextRunAt,
+      },
+    });
+  }
+
+  await prisma.scheduledJob.upsert({
+    where: { jobId: BOOKKEEPING_CYCLE_TASK_ID },
+    create: {
+      jobId: BOOKKEEPING_CYCLE_TASK_ID,
+      name: BOOKKEEPING_CYCLE_SCHEDULED_JOB_NAME,
+      schedule: BOOKKEEPING_CYCLE_SCHEDULE,
+      nextRunAt: existing?.nextRunAt ?? nextRunAt,
+    },
+    update: {
+      name: BOOKKEEPING_CYCLE_SCHEDULED_JOB_NAME,
+      schedule: BOOKKEEPING_CYCLE_SCHEDULE,
+      nextRunAt: existing?.nextRunAt ?? nextRunAt,
+    },
+  });
+
+  return { created: !existing };
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -75,6 +75,7 @@ import { seedDeliberationPatterns } from "./seed-deliberation.js";
 import { seedStallThresholds } from "./seed-stall-thresholds.js";
 import { ensureDiscoveryTriageScheduledTask } from "./seed-discovery-triage.js";
 import { ensureDataModelMirrorScheduledTask } from "./seed-data-model-mirror.js";
+import { ensureBookkeepingCycleScheduledTask } from "./seed-bookkeeping-cycle.js";
 import { ensureSysmlProjectionScheduledTask } from "./seed-sysml-projection.js";
 import { ensureSelfOptimizationSweepScheduledTask } from "./seed-self-optimization-sweep.js";
 import { ensureHiveScoutScheduledTask } from "./seed-hive-scout.js";
@@ -2524,6 +2525,7 @@ async function main(): Promise<void> {
   await step("defaultAdminUser", () => seedDefaultAdminUser());
   await step("discoveryTriageScheduledTask", () => ensureDiscoveryTriageScheduledTask(prisma));
   await step("dataModelMirrorScheduledTask", () => ensureDataModelMirrorScheduledTask(prisma));
+  await step("bookkeepingCycleScheduledTask", () => ensureBookkeepingCycleScheduledTask(prisma));
   await step("sysmlProjectionScheduledTask", () => ensureSysmlProjectionScheduledTask(prisma));
   await step("selfOptimizationSweepScheduledTask", () => ensureSelfOptimizationSweepScheduledTask(prisma));
   await step("hiveScoutScheduledTask", () => ensureHiveScoutScheduledTask(prisma));


### PR DESCRIPTION
## What

S-TRIG built the weekly `bookkeeping-cycle` trigger and its deterministic handler, but **nothing created the scheduled task** — so the cadence never fired on any install. The framework was available, not running.

Seed it, mirroring `seed-data-model-mirror.ts`: a standing weekly `bookkeeping-cycle` `ScheduledAgentTask` (Mon 09:00 UTC), owned by the install's superuser, attributed to the Bookkeeper coworker (AGT-907), carrying `taskKind: "bookkeeping-cycle"` so `executeScheduledAgentTask` runs `executeBookkeepingCycleTask` off the LLM path. Upsert-idempotent, with a `ScheduledJob` mirror alongside the other seeded tasks.

Now every install actually **runs** the books loop each week — opening or advancing the current period's cycle on the standing `bookkeeping-period` room — instead of the trigger merely existing. The reconciled period stays owner-gated on the real statement export; the cadence opens the room and refuses to fabricate transactions.

## Verification

- 3 unit tests: the seed sets the right `taskKind`/agent/cadence, is idempotent on a second run, and refuses when no superuser owner exists.
- Full local-CI pregate **passed**; 52 guards green.

This is the **initial use** of the Bookkeeping Work Room framework — the thing that turns it from built into valuable.

Process-Spine-Decision: extends the S-TRIG plan (`docs/superpowers/plans/2026-08-26-bookkeeping-triggers.md`, updated here) with its initial-use seed; reuses `ScheduledAgentTask` + the merged handler; no new contract, no migration.
Docs-Impact-Decision: internal seed addition; no user-facing guide change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Seed-Fit-Decision: global-default