### PR TITLE
fix(proactivity): make every self-task coworker reachable from the roster (BI-B05E5D30)

### DIFF
--- a/apps/web/lib/operate/scheduled-jobs/coworker-self-task-reachability.test.ts
+++ b/apps/web/lib/operate/scheduled-jobs/coworker-self-task-reachability.test.ts
@@ -1,0 +1,86 @@
+// Reachability invariant for coworker self-tasks (BI-B05E5D30).
+//
+// The registry is keyed by slug. The proactivity roster renders through
+// collapseDualSeedDuplicates, which for a dual-seeded coworker drops the slug
+// row and keeps the canonical AGT-* one — so the fact an operator can actually
+// write may arrive under EITHER id. Before this guard, four of six registered
+// coworkers were unreachable: the toggle wrote AGT-WS-MARKETING, the sweep
+// looked up "marketing-specialist", and no self-task was ever created.
+//
+// dual-seed-coverage.pg.test.ts guards the neighbouring concern — that a
+// collapsed pair never renders TWICE. It cannot catch this, because a row that
+// collapses correctly can still orphan a downstream registry. That is the gap
+// this file closes.
+
+import { describe, expect, it } from "vitest";
+
+import { CANONICAL_AGENT_ID_TO_COWORKER_SLUG, COWORKER_SLUG_TO_CANONICAL_AGENT_ID } from "@dpf/db/agent-identity";
+
+import { COWORKER_SELF_TASKS, coworkerSelfTaskId, selfTaskRegistryKey } from "./coworker-self-tasks";
+
+describe("coworker self-task reachability (BI-B05E5D30)", () => {
+  it("resolves every registry key from whichever id the roster can actually write", () => {
+    for (const slug of Object.keys(COWORKER_SELF_TASKS)) {
+      // The slug always resolves to itself.
+      expect(selfTaskRegistryKey(slug), slug).toBe(slug);
+
+      // A dual-seeded coworker is reachable ONLY by its canonical id, because
+      // the collapse drops its slug row from the roster. That id must resolve
+      // back to the same registry key or the self-task can never be created.
+      const canonical = COWORKER_SLUG_TO_CANONICAL_AGENT_ID[slug];
+      if (canonical) {
+        expect(selfTaskRegistryKey(canonical), `${canonical} -> ${slug}`).toBe(slug);
+      }
+    }
+  });
+
+  it("keeps the task id stable whichever id form the operator's fact used", () => {
+    // Two ids, one coworker, one task. If these diverged, toggling from a
+    // different surface would create a SECOND scheduled task rather than
+    // converging on the existing one.
+    for (const slug of Object.keys(COWORKER_SELF_TASKS)) {
+      const canonical = COWORKER_SLUG_TO_CANONICAL_AGENT_ID[slug];
+      if (!canonical) continue;
+      const fromSlug = coworkerSelfTaskId(selfTaskRegistryKey(slug)!, "user-1");
+      const fromCanonical = coworkerSelfTaskId(selfTaskRegistryKey(canonical)!, "user-1");
+      expect(fromCanonical, slug).toBe(fromSlug);
+    }
+  });
+
+  it("covers the Marketing Strategist, the registry's own seed entry", () => {
+    // Named explicitly because it is the case that surfaced the defect: the
+    // module header calls it the seed entry, and it was the one coworker an
+    // operator could not switch on.
+    expect(COWORKER_SELF_TASKS["marketing-specialist"]).toBeDefined();
+    expect(selfTaskRegistryKey("AGT-WS-MARKETING")).toBe("marketing-specialist");
+  });
+
+  it("covers the other three coworkers the collapse hid", () => {
+    for (const [canonical, slug] of [
+      ["AGT-WS-INVENTORY", "inventory-specialist"],
+      ["AGT-WS-PLATFORM", "platform-engineer"],
+      ["AGT-WS-COMPLIANCE", "compliance-officer"],
+    ] as const) {
+      expect(COWORKER_SELF_TASKS[slug], slug).toBeDefined();
+      expect(selfTaskRegistryKey(canonical), canonical).toBe(slug);
+    }
+  });
+
+  it("still returns null for a coworker that has no self-task", () => {
+    // The resolver must not invent reachability — an unregistered coworker is
+    // skipped by the sweep exactly as before.
+    expect(selfTaskRegistryKey("coo")).toBeNull();
+    expect(selfTaskRegistryKey("AGT-WS-EA")).toBeNull();
+    expect(selfTaskRegistryKey("no-such-agent")).toBeNull();
+  });
+
+  it("leaves a non-dual-seeded coworker's key untouched", () => {
+    // finance-controller and doc-specialist are not in the collapse map, so
+    // their slug survives on the roster and nothing about them changes.
+    for (const slug of ["finance-controller", "doc-specialist"]) {
+      if (!COWORKER_SELF_TASKS[slug]) continue;
+      expect(CANONICAL_AGENT_ID_TO_COWORKER_SLUG[slug]).toBeUndefined();
+      expect(selfTaskRegistryKey(slug)).toBe(slug);
+    }
+  });
+});

--- a/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
+++ b/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
@@ -15,6 +15,7 @@
 // campaign brief so the Campaigns page fills itself.
 
 import { prisma } from "@dpf/db";
+import { CANONICAL_AGENT_ID_TO_COWORKER_SLUG } from "@dpf/db/agent-identity";
 import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
 import { isProactivityLevel } from "@/lib/proactivity/proactivity-types";
 import {
@@ -347,6 +348,31 @@ export function coworkerSelfTaskId(agentId: string, userId: string): string {
   return `self-${agentId}-${userId}`;
 }
 
+/**
+ * Resolve any coworker id — slug OR canonical AGT-* — to the key this registry
+ * is actually declared under (BI-B05E5D30).
+ *
+ * WHY THIS EXISTS. The registry is keyed by slug ("marketing-specialist"), but
+ * the proactivity roster renders through collapseDualSeedDuplicates, which for a
+ * dual-seeded coworker DROPS the slug row and keeps the canonical AGT-* row. So
+ * the only control the operator can reach writes the fact under
+ * "AGT-WS-MARKETING", the sweep looked up that key, found nothing, and skipped —
+ * the self-task was never created at ANY level. Four of the six registered
+ * coworkers were unreachable this way (marketing-specialist,
+ * inventory-specialist, platform-engineer, compliance-officer); the two that
+ * worked are simply the two that are not dual-seeded.
+ *
+ * Returning the REGISTRY KEY (not the incoming id) is what keeps the derived
+ * taskId stable: a fact written under either form resolves to one task, so an
+ * operator toggling from either surface never ends up with two.
+ */
+export function selfTaskRegistryKey(agentId: string): string | null {
+  if (COWORKER_SELF_TASKS[agentId]) return agentId;
+  const slug = CANONICAL_AGENT_ID_TO_COWORKER_SLUG[agentId];
+  if (slug && COWORKER_SELF_TASKS[slug]) return slug;
+  return null;
+}
+
 /** True when a taskId is a coworker self-task (see {@link coworkerSelfTaskId}). */
 export function isCoworkerSelfTaskId(taskId: string): boolean {
   return taskId.startsWith("self-");
@@ -505,10 +531,11 @@ export async function reconcileCoworkerSelfTask(
   agentId: string,
   level: ProactivityLevel,
 ): Promise<ReconcileSelfTaskResult> {
-  const entry = COWORKER_SELF_TASKS[agentId];
-  if (!entry) return { ok: true, action: "none" };
+  const registryKey = selfTaskRegistryKey(agentId);
+  if (!registryKey) return { ok: true, action: "none" };
+  const entry = COWORKER_SELF_TASKS[registryKey];
 
-  const taskId = coworkerSelfTaskId(agentId, userId);
+  const taskId = coworkerSelfTaskId(registryKey, userId);
 
   // Quiet (or any non-producing level) → stand the coworker down.
   if (level === "quiet") {
@@ -670,8 +697,10 @@ export async function reconcileAllCoworkerSelfTasks(): Promise<ReconcileAllSelfT
   const desiredActive = new Set<string>();
 
   for (const fact of facts) {
-    const agentId = fact.key.slice(PROACTIVITY_AGENT_KEY_PREFIX.length);
-    if (!COWORKER_SELF_TASKS[agentId]) continue;
+    // The fact may be written under either id form — the roster reaches the
+    // operator with the canonical one for a dual-seeded coworker (BI-B05E5D30).
+    const agentId = selfTaskRegistryKey(fact.key.slice(PROACTIVITY_AGENT_KEY_PREFIX.length));
+    if (!agentId) continue;
     const level = readSelfTaskFactLevel(fact.value);
     if (!level) continue;
 


### PR DESCRIPTION
Closes BI-B05E5D30. Part of EP-45030CFF (marketing coworker produces work).

## Symptom

The Marketing Strategist never acted on its own. Live install: `MarketingCampaign` 0, `MarketingCampaignBrief` 0, `MarketingAssetTask` 0, `MarketingReview` 0, and **no `ScheduledAgentTask` row for `marketing-specialist`**.

Not a missing capability. The autonomous self-task machinery is fully built (BI-3F09BDD4 / EP-B9DD37C7) and the Marketing Strategist is its **declared seed entry** — the module header says so: *"The seed entry is the Marketing Strategist producing/refreshing a campaign brief so the Campaigns page fills itself."* It has a complete definition, an autonomous prompt, and cadences `7 14 * * 1` / `7 14 * * *`.

## Root cause — two id spaces that never meet

`reconcileAllCoworkerSelfTasks()` is fact-driven and keyed on the **slug**:

```ts
const agentId = fact.key.slice(PROACTIVITY_AGENT_KEY_PREFIX.length);
if (!COWORKER_SELF_TASKS[agentId]) continue;   // keyed "marketing-specialist"
```

The roster at `/coworker-decisions/proactivity` renders through `collapseDualSeedDuplicates` (BI-74FD6420), which for a dual-seeded coworker **drops the slug row and keeps the canonical `AGT-*` row**:

```ts
const canonical = slugToCanonical[r.agentId];   // marketing-specialist -> AGT-WS-MARKETING
return !(canonical && canonical !== r.agentId && present.has(canonical));
```

So the only control an operator can reach writes `aiCoworkerProactivity:agent:AGT-WS-MARKETING`. The sweep looks that up, finds nothing, and `continue`s. **The self-task is never created at any level** — quiet, balanced and assertive alike.

Confirmed by driving the running portal: the roster contains "Marketing" and "Market Research Analyst" but **not "Marketing Strategist"**. Every row displays "Balanced" while nothing is scheduled — precisely the drift the module already warned about in a comment: *"the toggle silently lies about what the coworker is doing."*

## Blast radius — 4 of 6

| Self-task coworker | In collapse map | Reachable before this fix |
|---|---|---|
| `marketing-specialist` | → AGT-WS-MARKETING | **no** |
| `inventory-specialist` | → AGT-WS-INVENTORY | **no** |
| `platform-engineer` | → AGT-WS-PLATFORM | **no** |
| `compliance-officer` | → AGT-WS-COMPLIANCE | **no** |
| `finance-controller` | not in map | yes |
| `doc-specialist` | not in map | yes |

The two that worked are the two that happen not to be dual-seeded. Coincidence, not design — which is why this went unnoticed.

Corroborating: only two proactivity facts exist on the live install (`AGT-WS-EA`, `coo`), neither a registry key, so the sweep has never created a self-task on that box at all.

## The fix

One resolver, `selfTaskRegistryKey()`, applied at both lookup sites — the sweep and `reconcileCoworkerSelfTask`.

It returns the **registry key** rather than the id it was handed, and that detail is load-bearing: it keeps the derived `taskId` stable, so a fact written under either form resolves to one task. Without it, toggling from a different surface would create a *second* scheduled task for the same coworker rather than converging on the existing one.

**No migration.** The four affected coworkers have no existing self-tasks — that is the bug — and the two working ones are not in the collapse map, so their task ids are unchanged.

## The guard that was missing

A reachability invariant: every `COWORKER_SELF_TASKS` key must stay resolvable from whichever id the roster can actually write.

`dual-seed-coverage.pg.test.ts` guards the neighbouring concern — that a collapsed pair never renders *twice*. It structurally cannot catch this one, because a row can collapse perfectly correctly and still orphan a downstream registry. That is the gap.

The guard also pins the four previously-broken coworkers by name, and asserts the resolver does **not** invent reachability — an unregistered coworker (`coo`, `AGT-WS-EA`) still returns null and is skipped exactly as before.

## Verification

- **local-CI gate: PASS** at `333bee3cf447` (evidence `cmtc5ypz107e001k35rqdeotg`)
- 79 test files / 818 tests pass across `lib/operate`, `lib/proactivity`, `lib/coworker-record` and the agent task scheduler — 6 new reachability cases

## Worth a follow-on

The same collapse silently orphaned four coworkers in one registry. Whether other registries keyed on the coworker slug have the same exposure is worth a sweep beyond the one fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
