### PR TITLE
fix(storefront): software-platform archetype gets its own item vocabulary (BI-35753C53)

### DIFF
--- a/apps/web/lib/storefront/archetype-vocabulary.test.ts
+++ b/apps/web/lib/storefront/archetype-vocabulary.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { getVocabulary } from "./archetype-vocabulary";
+
+describe("archetype vocabulary", () => {
+  // BI-35753C53 — DPF's own archetype is software-platform. With no entry it fell to the
+  // default and the storefront rendered "Items & items".
+  it("gives software-platform a real item vocabulary instead of the generic default", () => {
+    const vocab = getVocabulary("software-platform");
+    expect(vocab.itemsLabel).toBe("Products");
+    expect(vocab.singleItemLabel).toBe("Product");
+    // The tell of the bug: the generic default labels.
+    expect(vocab.itemsLabel).not.toBe("Items");
+    expect(vocab.singleItemLabel).not.toBe("Item");
+  });
+
+  it("still falls back to the default for an unknown category", () => {
+    const vocab = getVocabulary("no-such-category");
+    expect(vocab.itemsLabel).toBe("Items");
+  });
+
+  it("lets a custom vocabulary override the software-platform labels", () => {
+    const vocab = getVocabulary("software-platform", { itemsLabel: "Modules" });
+    expect(vocab.itemsLabel).toBe("Modules");
+    expect(vocab.singleItemLabel).toBe("Product");
+  });
+});

--- a/apps/web/lib/storefront/archetype-vocabulary.ts
+++ b/apps/web/lib/storefront/archetype-vocabulary.ts
@@ -59,6 +59,16 @@ const VOCABULARY: Record<string, ArchetypeVocabulary> = {
     portalLabel: "Storefront", stakeholderLabel: "Customers",
     teamLabel: "Team", inboxLabel: "Inbox", agentName: "Marketing Specialist",
   },
+  // BI-35753C53: DPF's own archetype is software-platform. Without an entry it fell to
+  // DEFAULT_VOCABULARY and the storefront rendered "Items & items". A software platform
+  // sells products on a storefront; the labels reuse existing vocabulary terms so no new
+  // hardcoded-term collisions (e.g. "Platform") are introduced into the platform UI.
+  "software-platform": {
+    itemsLabel: "Products", singleItemLabel: "Product", addButtonLabel: "Add product",
+    categoryLabel: "Category", priceLabel: "Price",
+    portalLabel: "Storefront", stakeholderLabel: "Customers",
+    teamLabel: "Team", inboxLabel: "Inbox", agentName: "Marketing Specialist",
+  },
   "healthcare-wellness": {
     itemsLabel: "Services", singleItemLabel: "Service", addButtonLabel: "Add service",
     categoryLabel: "Department", priceLabel: "Fee",


### PR DESCRIPTION
## What

From the owner-led UX dogfood: storefront setup rendered **"Items & items"**. DPF's own archetype is `software-platform`, but `archetype-vocabulary.ts` had no entry for it (21 category entries, none for software), so `getVocabulary` fell to `DEFAULT_VOCABULARY` — `itemsLabel: "Items"`, `singleItemLabel: "Item"`.

Add a `software-platform` entry. A software platform sells products on a storefront, so it **reuses existing vocabulary terms** (Products / Product / Storefront) rather than introducing new ones — notably **not** "Platform", which would flag every `platform/*` UI file as a hardcoded archetype term under the prose-lint vocabulary axis (caught and avoided during this fix).

## Verification

- 3 tests: `getVocabulary("software-platform")` returns real product labels not the generic default; unknown categories still fall back to the default; a `customVocabulary` still overrides.
- Full local-CI pregate **passed**; 52 guards green (incl. prose-lint).

Design-Grounding-Decision: no-contract-change (one archetype-vocabulary map entry on an existing keyed record; no routing, schema, or contract change).
Docs-Impact-Decision: internal label-vocabulary entry; storefront now reads correct item labels for this archetype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)