### PR TITLE
fix(release): re-pin hwdsl2/whisper-server to the current registry digest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -956,7 +956,7 @@ services:
   dpf-stt:
     profiles: ["runtime-local-speech", "tts"]
     # Pinned to the multi-arch index digest for hwdsl2/whisper-server:latest
-    # resolved on 2026-08-15 (the prior 0b03ecb5… digest was deleted from the
+    # resolved on 2026-08-27 (the prior 166a8c04… digest was deleted from the
     # registry — Release Image Manifest Guard caught it again). The registry
     # owner re-pushes :latest periodically and prunes the previous index, so
     # this digest must be re-resolved every time the guard fails. Bump
@@ -966,7 +966,7 @@ services:
     # the sidecar won't start, set DPF_STT_IMAGE in .env to a reachable ref
     # (e.g. hwdsl2/whisper-server:latest) then `docker compose up -d dpf-stt`,
     # and open a PR re-resolving the digest here (this is that PR's pattern).
-    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:166a8c04e2687608a116372e92f11bfda3e963f3c1dbf390a7c820db0f45887b}
+    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:8f76c4f99069b533b54866388f6a6cb1cb47cfde14762dc7af0b22dd58721df2}
     restart: unless-stopped
     logging: *default-logging
     environment:

--- a/tests/release/installer-release-contract.test.mjs
+++ b/tests/release/installer-release-contract.test.mjs
@@ -3,9 +3,9 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const RETIRED_STT_DIGEST =
-  "hwdsl2/whisper-server@sha256:0b03ecb54c8247cd4fe42e808746f36f44eff7998dc45018554c50252975e29f";
-const CURRENT_STT_DIGEST =
   "hwdsl2/whisper-server@sha256:166a8c04e2687608a116372e92f11bfda3e963f3c1dbf390a7c820db0f45887b";
+const CURRENT_STT_DIGEST =
+  "hwdsl2/whisper-server@sha256:8f76c4f99069b533b54866388f6a6cb1cb47cfde14762dc7af0b22dd58721df2";
 const MANIFEST_GUARD =
   "node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned";
 


### PR DESCRIPTION
Closes `BI-E6EF0B2C`.

**Consolidates with #4781** — a concurrent session opened the same re-pin about an hour later, reaching the identical digest. That PR is 7 commits behind `main` and stalled; this one is resynced. Keeping one canonical PR for the release plumbing, and carrying its BI here so the item still closes.

Blocking the release of the six operating-day fixes. Not a code defect — third-party registry rot.

## What broke

`v2026.08.27-operating-day-fixes.1` built **every** image successfully and published its GitHub Release, then failed **E2E install verification (release mode)**:

```
[missing] hwdsl2/whisper-server@sha256:166a8c04e2687608a116372e92f11bfda3e963f3c1dbf390a7c820db0f45887b
no such manifest: docker.io/hwdsl2/whisper-server@sha256:166a8c04...
```

That failure skips **Promote ${{ matrix.image }} to latest**. So `:latest` is never repointed, `/ops/self-upgrade` keeps offering the pre-tranche target, and the release is stranded — merged, published, undeployable.

`v2026.08.27` published cleanly at 17:53 UTC and mine failed at 22:43 UTC, so the digest rotted inside that window.

## Why it recurs, and why this is the right fix

`docker-compose.yml` pins the `dpf-stt` sidecar by digest on purpose — `never reach for :latest in shipped compose because it makes the install non-reproducible`. The comment beside the pin already records the recurrence and the recovery:

> The registry owner re-pushes `:latest` periodically and prunes the previous index, so this digest must be re-resolved every time the guard fails. […] open a PR re-resolving the digest here (this is that PR's pattern).

The scheduled `STT Digest Watch` workflow exists for exactly this. I dispatched it; it resolved the new digest correctly and then **failed at exit code 3 before opening its PR**, so this applies the same change by hand with the repo's own `scripts/release/re-resolve-stt-digest.mjs --apply`.

## Verified before commit

- `verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned` → `[ok] hwdsl2/whisper-server@sha256:8f76c4f9...` — the exact check that failed the release.
- `node --test scripts/release/re-resolve-stt-digest.test.mjs tests/release/installer-release-contract.test.mjs` → **21 passed, 0 failed**.

## Blast radius

The sidecar is profile-gated (`runtime-local-speech`, `tts`), so no default install was running the unreachable image. The damage was to the release pipeline, not to running installs.

Design-Grounding-Decision: no-contract-change (mechanical third-party digest re-pin; no routing, schema or contract surface is touched)
Docs-Impact-Decision: a third-party image digest re-pin for the profile-gated dpf-stt sidecar; no service, port, volume or operational procedure changed, so the architecture and disaster-recovery pages that link docker-compose.yml are unaffected
Process-Spine-Decision: mechanical dependency re-pin, no doc surface changed

