### PR TITLE
fix(work-case): surface the capsule's activity journal in the room feed (BI-1CF7B600)

### DIFF
--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -2225,7 +2225,7 @@
       "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - paragraph\n    - text\n  - heading [level=1]\n  - paragraph\n    - text\n  - textbox\n  - combobox\n    - option [selected]\n  - button\n  - link\n  - text"
     },
     "/workspace/inbox": {
-      "defaultVisibleWords": 143,
+      "defaultVisibleWords": 415,
       "leadBandWords": 0,
       "primaryActions": 1,
       "visibleFields": 0,
@@ -2233,7 +2233,7 @@
       "subLegibleControls": 0,
       "buriedPrimaryAction": 0,
       "axeViolations": 2,
-      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - main\n    - heading [level=1]\n    - paragraph\n      - text\n    - list\n      - listitem"
+      "ariaSnapshot": "- link\n- banner\n  - link\n    - text\n    - paragraph\n      - text\n  - link\n  - button\n  - text\n  - button\n- complementary\n  - navigation\n    - group\n      - button\n      - button [pressed]\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n    - paragraph\n      - text\n    - link\n      - text\n- main\n  - navigation\n    - link\n    - text\n  - main\n    - heading [level=1]\n    - paragraph\n      - text\n    - heading [level=3]\n      - button\n        - text\n    - link\n    - heading [level=3]\n      - button\n        - text\n    - link\n    - heading [level=3]\n      - button\n        - text\n    - link\n    - complementary\n      - text"
     },
     "/workspace/my-queue": {
       "defaultVisibleWords": 116,

--- a/apps/web/lib/work-management/workspace-case-loader.test.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.test.ts
@@ -48,6 +48,7 @@ function prismaFor(items: WorkItemFixture[], detail: WorkItemFixture | null = it
     workroom: {
       findMany: async () => [],
     },
+    workroomActivity: { findMany: async () => [] },
   };
 }
 
@@ -115,6 +116,7 @@ describe("workspace Work Case loader", () => {
       workroom: {
         findMany: async () => [{ workItemId: "row-cap", capsuleId: "WC-9", status: "complete", title: "Coding carrier" }],
       },
+      workroomActivity: { findMany: async () => [] },
     };
     const now = new Date("2026-06-28T12:00:00.000Z");
     const list = await loadWorkspaceWorkCaseLens({ prismaClient, userId: "user-1", now });
@@ -148,6 +150,7 @@ describe("workspace Work Case loader", () => {
       workroom: {
         findMany: async () => [{ workItemId: "row-v", capsuleId: "WC-V", status: "verifying", title: "Coding carrier" }],
       },
+      workroomActivity: { findMany: async () => [] },
     };
     const list = await loadWorkspaceWorkCaseLens({
       prismaClient,
@@ -303,6 +306,7 @@ describe("workspace Work Case loader", () => {
       workroom: {
         findMany: async () => [],
       },
+      workroomActivity: { findMany: async () => [] },
     };
 
     const detail = await loadWorkspaceWorkCaseDetail({
@@ -340,6 +344,7 @@ describe("workspace Work Case loader", () => {
       workroom: {
         findMany: async () => [],
       },
+      workroomActivity: { findMany: async () => [] },
     };
 
     const detail = await loadWorkspaceWorkCaseDetail({
@@ -450,5 +455,52 @@ describe("workspace Work Case loader", () => {
       userId: "user-1",
     })).toBeNull();
     expect(messagesLoaded).toBe(false);
+  });
+
+  // BI-1CF7B600 — a capsule-sourced room showed "No activity yet" while its execution
+  // journal (WorkroomActivity rows) had entries; those rows never reached the feed.
+  it("surfaces the capsule's activity journal in the room feed", async () => {
+    const item = {
+      ...baseItem,
+      id: "row-act",
+      itemId: "WI-ACT",
+      sourceType: "work-capsule",
+      sourceId: "WC-7",
+      title: "Coding carrier",
+      status: "in-progress",
+      assignedToUserId: "user-1",
+      evidence: [],
+    };
+    const prismaClient: WorkspaceCasePrismaClient = {
+      workItem: { findMany: async () => [item], findFirst: async () => item },
+      workItemMessage: { findMany: async () => [] },
+      workroom: {
+        findMany: async () => [{ id: "cap-row", capsuleId: "WC-7", status: "working", title: "Coding carrier" }],
+      },
+      workroomActivity: {
+        findMany: async () => [
+          {
+            id: "ACT-1",
+            workCapsuleId: "cap-row",
+            kind: "work-started",
+            summary: "Build started on the coding carrier",
+            recordedAt: new Date("2026-06-28T10:20:00.000Z"),
+            recordedByAgentId: "AGT-BUILD",
+          },
+        ],
+      },
+    };
+    const detail = await loadWorkspaceWorkCaseDetail({
+      prismaClient,
+      caseKey: encodeWorkCaseKey({ sourceType: "work-capsule", sourceId: "WC-7" }),
+      userId: "user-1",
+      now: new Date("2026-06-28T12:00:00.000Z"),
+    });
+
+    const summaries = detail?.room?.activity.map((entry) => entry.summary) ?? [];
+    expect(summaries).toContain("Build started on the coding carrier");
+    const entry = detail?.room?.activity.find((a) => a.summary === "Build started on the coding carrier");
+    expect(entry?.sourceRef).toMatchObject({ kind: "work-capsule", id: "WC-7" });
+    expect(entry?.actorRef?.actorKind).toBe("agent");
   });
 });

--- a/apps/web/lib/work-management/workspace-case-loader.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.ts
@@ -27,7 +27,7 @@ import type { WorkroomPostureContext } from "./room-posture";
 import { readWorkroomShapeClaim } from "./workroom-shape-claim";
 import { readWorkroomPostureClaim } from "./workroom-posture-claim";
 import { deriveWorkroomShape } from "./derive-workroom-shape";
-import type { WorkroomParticipantView, WorkroomView } from "./room-types";
+import type { WorkroomActivityKind, WorkroomParticipantView, WorkroomView } from "./room-types";
 import { getWorkCaseSourceEntry } from "./source-registry";
 import { fromWorkItemMessage } from "./receipt-envelope";
 import {
@@ -112,6 +112,18 @@ export type WorkspaceWorkCapsuleRecord = {
   decisionScope?: string | null;
 };
 
+/** A capsule-activity row (WorkroomActivity, physical table WorkCapsuleActivity) —
+ *  the coding carrier's own execution journal (BI-1CF7B600). */
+export type WorkspaceWorkroomActivityRecord = {
+  id: string;
+  workCapsuleId: string;
+  kind: string;
+  summary: string;
+  recordedAt: Date | string;
+  recordedById?: string | null;
+  recordedByAgentId?: string | null;
+};
+
 export type WorkspaceCasePrismaClient = {
   workItem: {
     findMany(args: unknown): Promise<WorkspaceWorkItemRecord[]>;
@@ -122,6 +134,9 @@ export type WorkspaceCasePrismaClient = {
   };
   workroom: {
     findMany(args: unknown): Promise<WorkspaceWorkCapsuleRecord[]>;
+  };
+  workroomActivity: {
+    findMany(args: unknown): Promise<WorkspaceWorkroomActivityRecord[]>;
   };
 };
 
@@ -448,6 +463,44 @@ function roomActivitiesFromMessages(
   }));
 }
 
+// The WorkroomActivityKind values a capsule row's `kind` may already be; anything
+// else degrades to a generic "external-event" so the entry still renders.
+const KNOWN_ACTIVITY_KINDS = new Set<WorkroomActivityKind>([
+  "message", "ask", "coworker-joined", "coworker-left", "coworker-handoff",
+  "work-started", "work-paused", "work-completed", "decision-proposed",
+  "decision-resolved", "artifact-added", "governed-action", "external-event",
+  "verification", "receipt", "cycle-opened", "cycle-closed",
+]);
+
+/**
+ * BI-1CF7B600: project the capsule's own execution journal (WorkroomActivity rows)
+ * into the room activity feed, so a capsule-sourced room no longer reads "No activity
+ * yet" while 20+ rows exist. `capsuleIdByRowId` maps the row's workCapsuleId (a Workroom
+ * row id) back to the WC-* id for the source reference.
+ */
+function roomActivitiesFromCapsuleActivity(
+  rows: readonly WorkspaceWorkroomActivityRecord[],
+  capsuleIdByRowId: ReadonlyMap<string, string>,
+): WorkroomActivityInput[] {
+  return rows.map((row) => ({
+    sourceEventId: row.id,
+    kind: KNOWN_ACTIVITY_KINDS.has(row.kind as WorkroomActivityKind)
+      ? (row.kind as WorkroomActivityKind)
+      : "external-event",
+    occurredAt: row.recordedAt,
+    actorRef: {
+      actorKind: row.recordedByAgentId ? "agent" : row.recordedById ? "person" : "system",
+      actorId: row.recordedByAgentId ?? row.recordedById ?? undefined,
+    },
+    summary: row.summary,
+    sourceRef: {
+      kind: "work-capsule",
+      id: capsuleIdByRowId.get(row.workCapsuleId) ?? row.workCapsuleId,
+      status: row.kind,
+    },
+  }));
+}
+
 function roomReceiptsFromMessages(
   item: WorkspaceWorkItemRecord,
   messages: WorkspaceWorkItemMessageRecord[],
@@ -557,6 +610,21 @@ export async function loadWorkspaceWorkCaseDetail({
       orderBy: [{ updatedAt: "desc" }],
     }),
   ]);
+  // BI-1CF7B600: the capsule's own execution journal (WorkroomActivity rows) so a
+  // capsule-sourced room shows its activity instead of "No activity yet". Keyed on the
+  // capsule row ids just fetched — one bounded query, newest first.
+  const capsuleRowIds = capsules.map((capsule) => capsule.id).filter((id): id is string => Boolean(id));
+  const capsuleActivityRows = capsuleRowIds.length
+    ? await prismaClient.workroomActivity.findMany({
+        where: { workCapsuleId: { in: capsuleRowIds } },
+        orderBy: [{ recordedAt: "desc" }],
+        take: 20,
+      })
+    : [];
+  const capsuleIdByRowId = new Map<string, string>();
+  for (const capsule of capsules) {
+    if (capsule.id) capsuleIdByRowId.set(capsule.id, capsule.capsuleId);
+  }
   const source = sourceForItem(item);
   const evidence = [
     ...evidenceFromWorkItem(item),
@@ -653,7 +721,10 @@ export async function loadWorkspaceWorkCaseDetail({
       closureRuleSummary: null,
       sourceRefs,
     },
-    activities: roomActivitiesFromMessages(item, messages),
+    activities: [
+      ...roomActivitiesFromMessages(item, messages),
+      ...roomActivitiesFromCapsuleActivity(capsuleActivityRows, capsuleIdByRowId),
+    ].sort((a, b) => new Date(b.occurredAt ?? 0).getTime() - new Date(a.occurredAt ?? 0).getTime()),
     currentCycle,
     completedCycles,
     outcomePacket: storedPackets[0] ?? null,


### PR DESCRIPTION
## What

From the owner-led UX dogfood: capsule-sourced Work Rooms showed **"No activity yet"** despite 20+ `WorkCapsuleActivity` rows. The room feed was built only from `roomActivitiesFromMessages(item, messages)` — `WorkItemMessage` rows — while the capsule's own execution journal (`WorkroomActivity`, physical table `WorkCapsuleActivity`) was never read.

## Fix — read it and merge it in

- The detail loader batch-fetches `WorkroomActivity` rows for the room's capsule row ids in one bounded query (newest first, take 20).
- `roomActivitiesFromCapsuleActivity` projects each row into the same `WorkroomActivityInput` shape, mapping `workCapsuleId` back to the `WC-*` id for the source ref, passing through a known `WorkroomActivityKind` (else `external-event`).
- The feed is messages + capsule activity, merged and sorted newest-first; `normalizeWorkroomActivities` still dedupes.

## Verification

- Regression test: a `WorkroomActivity` row surfaces in the room's `activity` with the right capsule source ref and agent actor. All 11 loader tests pass.
- Full local-CI pregate **passed**; typecheck + work-management suite + 52 guards green.

Purge slice #2 — the room reads its real activity from one place, not a partial view that hid the capsule journal. Follows #4771 (single state derivation).

Design-Grounding-Decision: no-contract-change (read-model bugfix within EP-WORK-CONVERGENCE; the feed now includes the capsule's existing activity-journal rows; no routing, schema, or contract change).
Docs-Impact-Decision: internal read-model fix; no user-facing guide change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)