### PR TITLE
feat(identity): serve the directory — projection, LDAP, and Principal as the authentication root (EP-24741BBF)

### DIFF
--- a/apps/web/app/(shell)/platform/identity/directory/page.test.tsx
+++ b/apps/web/app/(shell)/platform/identity/directory/page.test.tsx
@@ -1,39 +1,36 @@
 import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
+// BI-DCE49BA9: the page renders the shared projection instead of computing a
+// tree from a hardcoded base DN, so the fixture is now an Organization — the
+// canonical source the DN derives from — plus the principals it publishes.
 vi.mock("@dpf/db", () => ({
   prisma: {
-    principal: {
-      count: vi.fn(),
-    },
-    principalAlias: {
-      count: vi.fn(),
-    },
-    integrationCredential: {
-      count: vi.fn(),
-      findMany: vi.fn(),
-    },
-    platformRole: {
-      count: vi.fn(),
-    },
-    team: {
-      count: vi.fn(),
-    },
+    organization: { findFirst: vi.fn() },
+    principal: { findMany: vi.fn() },
+    principalAlias: { count: vi.fn() },
+    platformRole: { findMany: vi.fn() },
+    team: { findMany: vi.fn() },
+    integrationCredential: { count: vi.fn(), findMany: vi.fn() },
   },
 }));
 
 import { prisma } from "@dpf/db";
 
 describe("PlatformIdentityDirectoryPage", () => {
-  it("shows directory branches and publication posture from live identity counts", async () => {
-    vi.mocked(prisma.principal.count)
-      .mockResolvedValueOnce(12)
-      .mockResolvedValueOnce(5)
-      .mockResolvedValueOnce(0);
+  it("derives the base DN from the organization and shows the published branches", async () => {
+    vi.mocked(prisma.organization.findFirst).mockResolvedValue({
+      slug: "acme",
+      website: "https://www.acme.com",
+    } as never);
+    vi.mocked(prisma.principal.findMany).mockResolvedValue([
+      { principalId: "prn-h", kind: "human", displayName: "Dana Reed", aliases: [] },
+      { principalId: "prn-a", kind: "agent", displayName: "HR Specialist", aliases: [] },
+    ] as never);
+    vi.mocked(prisma.platformRole.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.team.findMany).mockResolvedValue([] as never);
     vi.mocked(prisma.principalAlias.count).mockResolvedValue(27);
     vi.mocked(prisma.integrationCredential.count).mockResolvedValue(2);
-    vi.mocked(prisma.platformRole.count).mockResolvedValue(4);
-    vi.mocked(prisma.team.count).mockResolvedValue(4);
     vi.mocked(prisma.integrationCredential.findMany).mockResolvedValue([
       {
         id: "cred-entra-1",
@@ -55,12 +52,32 @@ describe("PlatformIdentityDirectoryPage", () => {
     const html = renderToStaticMarkup(await PlatformIdentityDirectoryPage());
 
     expect(html).toContain("Directory");
-    expect(html).toContain("dc=dpf,dc=internal");
-    expect(html).toContain("ou=people,dc=dpf,dc=internal");
-    expect(html).toContain("ou=agents,dc=dpf,dc=internal");
-    expect(html).toContain("ou=services,dc=dpf,dc=internal");
-    expect(html).toContain("ou=groups,dc=dpf,dc=internal");
+    // Derived from Organization.website — NOT a constant in the route.
+    expect(html).toContain("dc=acme,dc=com");
+    expect(html).toContain("ou=people,dc=acme,dc=com");
+    expect(html).toContain("ou=agents,dc=acme,dc=com");
+    expect(html).toContain("ou=services,dc=acme,dc=com");
+    expect(html).toContain("ou=groups,dc=acme,dc=com");
     expect(html).toContain("Read-only");
     expect(html).toContain("Microsoft Entra connected");
+  });
+
+  it("no longer carries the old hardcoded base DN", async () => {
+    vi.mocked(prisma.organization.findFirst).mockResolvedValue({
+      slug: "acme",
+      website: null,
+    } as never);
+    vi.mocked(prisma.principal.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.platformRole.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.team.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.principalAlias.count).mockResolvedValue(0);
+    vi.mocked(prisma.integrationCredential.count).mockResolvedValue(0);
+    vi.mocked(prisma.integrationCredential.findMany).mockResolvedValue([] as never);
+
+    const { default: PlatformIdentityDirectoryPage } = await import("./page");
+    const html = renderToStaticMarkup(await PlatformIdentityDirectoryPage());
+
+    expect(html).toContain("dc=acme,dc=internal");
+    expect(html).not.toContain("dc=dpf,dc=internal");
   });
 });

--- a/apps/web/app/(shell)/platform/identity/directory/page.tsx
+++ b/apps/web/app/(shell)/platform/identity/directory/page.tsx
@@ -1,36 +1,29 @@
 import { prisma } from "@dpf/db";
 
 import { DirectoryAuthoritiesPanel } from "@/components/platform/identity/DirectoryAuthoritiesPanel";
+import { branchDn } from "@/lib/directory/dn";
+import { buildDirectoryProjection } from "@/lib/directory/projection";
 
-const BASE_DN = "dc=dpf,dc=internal";
+// EP-24741BBF · BI-DCE49BA9 — this page renders the SHARED projection; it does
+// not compute one. It previously hardcoded `dc=dpf,dc=internal` and counted
+// principals inline, which made a route component the second home for a
+// contract the LDAP listener and federation also read (AGENTS.md §8). The base
+// DN now derives from `Organization`, and what the panel shows is exactly what
+// a client that binds would see.
 
 export default async function PlatformIdentityDirectoryPage() {
-  const [
-    humanCount,
-    agentCount,
-    serviceCount,
-    aliasCount,
-    authorityCount,
-    roleGroupCount,
-    businessGroupCount,
-    authorities,
-  ] = await Promise.all([
-    prisma.principal.count({ where: { kind: "human" } }),
-    prisma.principal.count({ where: { kind: "agent" } }),
-    prisma.principal.count({ where: { kind: "service" } }),
+  const [projection, aliasCount, authorityCount, authorities] = await Promise.all([
+    buildDirectoryProjection(),
     prisma.principalAlias.count(),
     prisma.integrationCredential.count(),
-    prisma.platformRole.count(),
-    prisma.team.count(),
     prisma.integrationCredential.findMany({
       where: { status: "connected" },
       orderBy: { provider: "asc" },
-      select: {
-        provider: true,
-        status: true,
-      },
+      select: { provider: true, status: true },
     }),
   ]);
+
+  const { baseDn, counts } = projection;
 
   const upstreamSummary =
     authorities.length === 0
@@ -43,33 +36,37 @@ export default async function PlatformIdentityDirectoryPage() {
           )
           .join("; ")}; LDAP/AD optional`;
 
+  // Branch containers are entries too, so subtract them to report published
+  // members rather than members-plus-the-container-itself.
+  const members = (branch: keyof typeof counts) => Math.max(counts[branch] - 1, 0);
+
   return (
     <DirectoryAuthoritiesPanel
-      baseDn={BASE_DN}
+      baseDn={baseDn}
       branches={[
         {
-          dn: `ou=people,${BASE_DN}`,
+          dn: branchDn(baseDn, "people"),
           label: "People",
-          entryCount: humanCount,
+          entryCount: members("people"),
           description: "Employees and contractors published as human principals.",
         },
         {
-          dn: `ou=agents,${BASE_DN}`,
+          dn: branchDn(baseDn, "agents"),
           label: "Agents",
-          entryCount: agentCount,
-          description: "AI coworkers published with explicit principal type and stable projected trust markers.",
+          entryCount: members("agents"),
+          description: "AI coworkers published with explicit principal type and trust markers.",
         },
         {
-          dn: `ou=services,${BASE_DN}`,
+          dn: branchDn(baseDn, "services"),
           label: "Services",
-          entryCount: serviceCount,
-          description: "Non-human service identities once they are linked into the shared principal spine.",
+          entryCount: members("services"),
+          description: "Service identities on the shared spine, each with an accountable owner.",
         },
         {
-          dn: `ou=groups,${BASE_DN}`,
+          dn: branchDn(baseDn, "groups"),
           label: "Groups",
-          entryCount: roleGroupCount + businessGroupCount,
-          description: "Role groups and business groups projected for downstream consumers.",
+          entryCount: members("groups"),
+          description: "Role and team groups. Organizational structure, not authorization.",
         },
       ]}
       publicationStatus={{

--- a/apps/web/lib/directory/dn.ts
+++ b/apps/web/lib/directory/dn.ts
@@ -1,0 +1,122 @@
+// Distinguished-name construction for the DPF directory projection
+// (EP-24741BBF · BI-DCE49BA9).
+//
+// The base DN is DERIVED FROM `Organization`, the canonical platform identity
+// model (AGENTS.md §8) — never a hardcoded constant. An install's directory
+// follows its own org identity, so two installs never collide and a rename is
+// a data change rather than a code change.
+//
+// Escaping follows RFC 4514 §2.4. It is not cosmetic: an unescaped `,` or `+`
+// in a display name would split one entry's DN into two RDNs and silently
+// re-parent it under a branch nobody intended.
+
+/** Branches of the published tree. Order is stable; consumers may rely on it. */
+export const DIRECTORY_BRANCHES = ["people", "agents", "services", "groups"] as const;
+export type DirectoryBranch = (typeof DIRECTORY_BRANCHES)[number];
+
+export type OrganizationDnSource = {
+  slug: string;
+  website?: string | null;
+};
+
+/** Fallback domain component when the organization publishes no website. */
+const FALLBACK_TLD = "internal";
+
+/** RFC 4514 §2.4 — characters that must be escaped anywhere in an attribute value. */
+const ESCAPED_ANYWHERE = /([\\,+"<>;=])/g;
+
+/**
+ * Escape an RDN attribute value per RFC 4514.
+ *
+ * Leading `#` or space, and trailing space, are escaped positionally; the
+ * reserved set is escaped wherever it appears. NUL is rejected outright rather
+ * than encoded, because a value containing it is not a name we should publish.
+ */
+export function escapeRdnValue(value: string): string {
+  if (value.includes("\0")) {
+    throw new Error("escapeRdnValue: an attribute value must not contain a NUL byte");
+  }
+  let escaped = value.replace(ESCAPED_ANYWHERE, "\\$1");
+  if (escaped.startsWith("#") || escaped.startsWith(" ")) {
+    escaped = `\\${escaped}`;
+  }
+  if (escaped.endsWith(" ") && !escaped.endsWith("\\ ")) {
+    escaped = `${escaped.slice(0, -1)}\\ `;
+  }
+  return escaped;
+}
+
+/** Split a hostname into `dc=` components, dropping a leading `www.`. */
+function hostToDomainComponents(host: string): string[] {
+  return host
+    .replace(/^www\./i, "")
+    .split(".")
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/**
+ * Derive the install's base DN from its `Organization`.
+ *
+ * Prefers the organization's own website host, so the directory reads as the
+ * organization's namespace to anyone who binds. Falls back to the slug under a
+ * reserved `internal` domain when no website is published — deliberately NOT a
+ * public TLD, so a fallback can never collide with a real domain.
+ */
+export function deriveBaseDn(organization: OrganizationDnSource): string {
+  const slug = organization.slug?.trim();
+  if (!slug) {
+    throw new Error("deriveBaseDn: the organization must have a slug to derive a base DN");
+  }
+
+  let components: string[] = [];
+  const website = organization.website?.trim();
+  if (website) {
+    try {
+      const url = new URL(website.includes("://") ? website : `https://${website}`);
+      components = hostToDomainComponents(url.hostname);
+    } catch {
+      components = [];
+    }
+  }
+
+  if (components.length < 2) {
+    components = [slug.toLowerCase(), FALLBACK_TLD];
+  }
+
+  return components.map((part) => `dc=${escapeRdnValue(part)}`).join(",");
+}
+
+/** The DN of one branch, e.g. `ou=people,dc=acme,dc=com`. */
+export function branchDn(baseDn: string, branch: DirectoryBranch): string {
+  return `ou=${branch},${baseDn}`;
+}
+
+/**
+ * The DN of a published principal. Keyed on `principalId` rather than a display
+ * name: a DN must be stable, and a person's name is not.
+ */
+export function principalDn(
+  baseDn: string,
+  branch: Exclude<DirectoryBranch, "groups">,
+  principalId: string,
+): string {
+  return `uid=${escapeRdnValue(principalId)},${branchDn(baseDn, branch)}`;
+}
+
+/** The DN of a published group. */
+export function groupDn(baseDn: string, groupKey: string): string {
+  return `cn=${escapeRdnValue(groupKey)},${branchDn(baseDn, "groups")}`;
+}
+
+/** Case-insensitive DN comparison, sufficient for the read-only projection. */
+export function dnEquals(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/** True when `dn` sits at or beneath `baseDn` — the subtree scope test. */
+export function isWithinSubtree(dn: string, baseDn: string): boolean {
+  const needle = baseDn.trim().toLowerCase();
+  const haystack = dn.trim().toLowerCase();
+  return haystack === needle || haystack.endsWith(`,${needle}`);
+}

--- a/apps/web/lib/directory/ldap/ber.ts
+++ b/apps/web/lib/directory/ldap/ber.ts
@@ -1,0 +1,184 @@
+// Minimal BER reader/writer for LDAP (EP-24741BBF · BI-F7317D65).
+//
+// Written rather than adopted because there is no maintained Node/TypeScript
+// LDAP SERVER library: `ldapjs` is MIT but archived 2024-05-14 and formally
+// decommissioned, and `ldapts` is a client. That absence is a load-bearing
+// input to the epic's absorb-vs-adopt decision, recorded in the authentik
+// evaluation — every adoptable server is a separate process in another
+// language, which is the appendage the epic forbids.
+//
+// Scope is deliberately the subset RFC 4511 bind and search need. This is NOT a
+// general ASN.1 library, and it should not grow into one: every byte it parses
+// comes off an untrusted socket, so the smaller its surface the better.
+
+/** BER tags used by LDAP. Application tags are context-specific + constructed. */
+export const TAG = {
+  BOOLEAN: 0x01,
+  INTEGER: 0x02,
+  OCTET_STRING: 0x04,
+  NULL: 0x05,
+  ENUMERATED: 0x0a,
+  SEQUENCE: 0x30,
+  SET: 0x31,
+} as const;
+
+export const APP = {
+  BIND_REQUEST: 0x60,
+  BIND_RESPONSE: 0x61,
+  UNBIND_REQUEST: 0x42,
+  SEARCH_REQUEST: 0x63,
+  SEARCH_RESULT_ENTRY: 0x64,
+  SEARCH_RESULT_DONE: 0x65,
+  EXTENDED_REQUEST: 0x77,
+  EXTENDED_RESPONSE: 0x78,
+} as const;
+
+/** Hard ceiling on any single element, so a malformed length cannot allocate. */
+const MAX_ELEMENT_BYTES = 1_048_576;
+
+export class BerReader {
+  private offset = 0;
+
+  constructor(private readonly buf: Buffer) {}
+
+  get position(): number {
+    return this.offset;
+  }
+
+  get remaining(): number {
+    return this.buf.length - this.offset;
+  }
+
+  /** Peek the next tag without consuming it. */
+  peekTag(): number | null {
+    return this.remaining > 0 ? this.buf[this.offset]! : null;
+  }
+
+  /** Read a tag/length header, returning the value slice and advancing past it. */
+  readElement(expectedTag?: number): { tag: number; value: Buffer } {
+    if (this.remaining < 2) {
+      throw new Error("BER: truncated element header");
+    }
+    const tag = this.buf[this.offset]!;
+    if (expectedTag !== undefined && tag !== expectedTag) {
+      throw new Error(
+        `BER: expected tag 0x${expectedTag.toString(16)} but found 0x${tag.toString(16)}`,
+      );
+    }
+    this.offset += 1;
+
+    let length = this.buf[this.offset]!;
+    this.offset += 1;
+    if (length & 0x80) {
+      const byteCount = length & 0x7f;
+      if (byteCount === 0 || byteCount > 4) {
+        // Indefinite length is not legal in LDAP's DER-ish encoding, and >4
+        // bytes exceeds anything this server will ever accept.
+        throw new Error("BER: unsupported length encoding");
+      }
+      if (this.remaining < byteCount) throw new Error("BER: truncated length");
+      length = 0;
+      for (let i = 0; i < byteCount; i += 1) {
+        length = (length << 8) | this.buf[this.offset]!;
+        this.offset += 1;
+      }
+    }
+    if (length > MAX_ELEMENT_BYTES) {
+      throw new Error(`BER: element of ${length} bytes exceeds the ${MAX_ELEMENT_BYTES} limit`);
+    }
+    if (this.remaining < length) throw new Error("BER: truncated element body");
+
+    const value = this.buf.subarray(this.offset, this.offset + length);
+    this.offset += length;
+    return { tag, value };
+  }
+
+  readInteger(expectedTag: number = TAG.INTEGER): number {
+    const { value } = this.readElement(expectedTag);
+    if (value.length === 0 || value.length > 4) {
+      throw new Error("BER: integer out of supported range");
+    }
+    let result = value[0]! & 0x80 ? -1 : 0;
+    for (const byte of value) result = (result << 8) | byte;
+    return result;
+  }
+
+  readString(expectedTag: number = TAG.OCTET_STRING): string {
+    return this.readElement(expectedTag).value.toString("utf8");
+  }
+
+  readBoolean(): boolean {
+    return this.readElement(TAG.BOOLEAN).value[0] !== 0;
+  }
+
+  /** A reader scoped to one constructed element's contents. */
+  readConstructed(expectedTag?: number): BerReader {
+    return new BerReader(this.readElement(expectedTag).value);
+  }
+}
+
+/** Encode a tag/length/value triple. */
+export function berElement(tag: number, value: Buffer): Buffer {
+  const header =
+    value.length < 0x80
+      ? Buffer.from([tag, value.length])
+      : (() => {
+          const lengthBytes: number[] = [];
+          let remaining = value.length;
+          while (remaining > 0) {
+            lengthBytes.unshift(remaining & 0xff);
+            remaining >>= 8;
+          }
+          return Buffer.from([tag, 0x80 | lengthBytes.length, ...lengthBytes]);
+        })();
+  return Buffer.concat([header, value]);
+}
+
+export function berInteger(value: number, tag: number = TAG.INTEGER): Buffer {
+  const bytes: number[] = [];
+  let remaining = value;
+  do {
+    bytes.unshift(remaining & 0xff);
+    remaining >>= 8;
+  } while (remaining !== 0 && remaining !== -1);
+  // Prepend a zero byte when the high bit would otherwise read as negative.
+  if (value >= 0 && bytes[0]! & 0x80) bytes.unshift(0);
+  return berElement(tag, Buffer.from(bytes));
+}
+
+export function berString(value: string, tag: number = TAG.OCTET_STRING): Buffer {
+  return berElement(tag, Buffer.from(value, "utf8"));
+}
+
+export function berSequence(...parts: Buffer[]): Buffer {
+  return berElement(TAG.SEQUENCE, Buffer.concat(parts));
+}
+
+export function berSet(...parts: Buffer[]): Buffer {
+  return berElement(TAG.SET, Buffer.concat(parts));
+}
+
+/**
+ * Split a stream buffer into whole LDAP messages, returning the parsed message
+ * slices and whatever trailing bytes are still incomplete. TCP does not respect
+ * message boundaries, so a server that assumes one read equals one message will
+ * corrupt under load.
+ */
+export function frameMessages(buffer: Buffer): { messages: Buffer[]; rest: Buffer } {
+  const messages: Buffer[] = [];
+  let cursor = 0;
+  while (cursor < buffer.length) {
+    const reader = new BerReader(buffer.subarray(cursor));
+    let element: { tag: number; value: Buffer };
+    try {
+      element = reader.readElement(TAG.SEQUENCE);
+    } catch {
+      break; // incomplete or not yet a whole message
+    }
+    const consumed = reader.position;
+    messages.push(buffer.subarray(cursor, cursor + consumed));
+    cursor += consumed;
+    void element;
+  }
+  return { messages, rest: buffer.subarray(cursor) };
+}

--- a/apps/web/lib/directory/ldap/bind.ts
+++ b/apps/web/lib/directory/ldap/bind.ts
@@ -1,0 +1,103 @@
+// Bind verification (EP-24741BBF · BI-F7317D65 + BI-CEACBD0D).
+//
+// A bind is an AUTHENTICATION event, so it resolves through the same spine the
+// portal session does. That is the point of the epic: one identity path, no
+// matter which surface the caller arrives on. A directory that authenticated
+// against its own private view would be the second identity truth all over
+// again, just reached over port 636 instead of HTTP.
+//
+// Two credential shapes are accepted, resolving design open question 1:
+//
+//   - PASSWORD, for human principals, verified against the credential holder
+//     and then authorized by the spine.
+//   - mTLS CLIENT CERTIFICATE, for any class, matched against the bind DN. This
+//     is the only path open to agents and service accounts, because they have
+//     no password and inventing one for them would re-create the "authorized
+//     but never authenticated" gap this epic closes.
+
+import { prisma } from "@dpf/db";
+
+import { authorizePrincipalForSession } from "@/lib/identity/authentication";
+import { verifyPassword } from "@/lib/govern/password";
+
+import type { BindVerifier } from "./server";
+
+/** Extract the `uid=` RDN value from a bind DN, unescaping RFC 4514 escapes. */
+export function principalIdFromBindDn(bindDn: string): string | null {
+  const match = /^uid=((?:[^,\\]|\\.)*),/i.exec(bindDn.trim());
+  if (!match) return null;
+  return match[1]!.replace(/\\(.)/g, "$1");
+}
+
+type BindDb = Pick<typeof prisma, "principal" | "principalAlias" | "user">;
+
+export function createBindVerifier(
+  db: BindDb = prisma,
+  deps: {
+    verify?: typeof verifyPassword;
+    authorize?: typeof authorizePrincipalForSession;
+  } = {},
+): BindVerifier {
+  const verify = deps.verify ?? verifyPassword;
+  const authorize = deps.authorize ?? authorizePrincipalForSession;
+
+  return async ({ bindDn, password, clientCertificateSubject }) => {
+    const principalId = principalIdFromBindDn(bindDn);
+    if (!principalId) {
+      return { bound: false, reason: "bind DN must name a principal as uid=<principalId>,…" };
+    }
+
+    const principal = await db.principal.findUnique({
+      where: { principalId },
+      select: {
+        principalId: true,
+        kind: true,
+        status: true,
+        aliases: { select: { aliasType: true, aliasValue: true } },
+      },
+    });
+    if (!principal) return { bound: false, reason: "no such principal" };
+
+    // Refuse an inactive principal before touching any credential, so an
+    // attacker cannot use timing to distinguish "disabled" from "wrong password".
+    if (principal.status !== "active") {
+      return { bound: false, reason: "invalid credentials" };
+    }
+
+    // mTLS: the certificate subject must name the same principal.
+    if (clientCertificateSubject) {
+      if (clientCertificateSubject === principalId) {
+        return { bound: true, principalId };
+      }
+      return { bound: false, reason: "client certificate does not match the bind DN" };
+    }
+
+    // Password binds are for humans only. An agent or service account has no
+    // password by design; giving it one would be a second credential store.
+    if (principal.kind !== "human") {
+      return {
+        bound: false,
+        reason: "non-human principals bind with a client certificate, not a password",
+      };
+    }
+    if (!password) return { bound: false, reason: "invalid credentials" };
+
+    const userId = principal.aliases.find((alias) => alias.aliasType === "user")?.aliasValue;
+    if (!userId) return { bound: false, reason: "invalid credentials" };
+
+    const user = await db.user.findUnique({
+      where: { id: userId },
+      select: { id: true, passwordHash: true },
+    });
+    if (!user) return { bound: false, reason: "invalid credentials" };
+
+    const { valid } = await verify(password, user.passwordHash);
+    if (!valid) return { bound: false, reason: "invalid credentials" };
+
+    // Same spine check the portal session runs. One identity path.
+    const spine = await authorize(user.id, db as never);
+    if (!spine.authorized) return { bound: false, reason: "invalid credentials" };
+
+    return { bound: true, principalId };
+  };
+}

--- a/apps/web/lib/directory/ldap/filter.ts
+++ b/apps/web/lib/directory/ldap/filter.ts
@@ -1,0 +1,140 @@
+// LDAP search filters (RFC 4511 §4.5.1) — EP-24741BBF · BI-F7317D65.
+//
+// Supports the subset a real client actually sends against a read-only
+// directory: and / or / not / equalityMatch / present / substrings. Anything
+// else decodes to `unsupported`, which evaluates to NO MATCH rather than
+// throwing or, worse, matching. A filter this server cannot reason about must
+// never widen a result set.
+
+import { BerReader } from "./ber";
+
+export const FILTER_TAG = {
+  AND: 0xa0,
+  OR: 0xa1,
+  NOT: 0xa2,
+  EQUALITY: 0xa3,
+  SUBSTRINGS: 0xa4,
+  GREATER_OR_EQUAL: 0xa5,
+  LESS_OR_EQUAL: 0xa6,
+  PRESENT: 0x87,
+  APPROX: 0xa8,
+} as const;
+
+const SUBSTRING_TAG = { INITIAL: 0x80, ANY: 0x81, FINAL: 0x82 } as const;
+
+export type LdapFilter =
+  | { type: "and"; filters: LdapFilter[] }
+  | { type: "or"; filters: LdapFilter[] }
+  | { type: "not"; filter: LdapFilter }
+  | { type: "equality"; attribute: string; value: string }
+  | { type: "present"; attribute: string }
+  | { type: "substrings"; attribute: string; initial?: string; any: string[]; final?: string }
+  | { type: "unsupported"; tag: number };
+
+export function decodeFilter(reader: BerReader): LdapFilter {
+  const tag = reader.peekTag();
+  if (tag === null) throw new Error("LDAP filter: unexpected end of input");
+
+  switch (tag) {
+    case FILTER_TAG.AND:
+    case FILTER_TAG.OR: {
+      const inner = reader.readConstructed(tag);
+      const filters: LdapFilter[] = [];
+      while (inner.remaining > 0) filters.push(decodeFilter(inner));
+      return tag === FILTER_TAG.AND ? { type: "and", filters } : { type: "or", filters };
+    }
+    case FILTER_TAG.NOT: {
+      const inner = reader.readConstructed(tag);
+      return { type: "not", filter: decodeFilter(inner) };
+    }
+    case FILTER_TAG.EQUALITY: {
+      const inner = reader.readConstructed(tag);
+      return { type: "equality", attribute: inner.readString(), value: inner.readString() };
+    }
+    case FILTER_TAG.PRESENT: {
+      // Primitive: the value IS the attribute description.
+      return { type: "present", attribute: reader.readElement(tag).value.toString("utf8") };
+    }
+    case FILTER_TAG.SUBSTRINGS: {
+      const inner = reader.readConstructed(tag);
+      const attribute = inner.readString();
+      const parts = inner.readConstructed();
+      let initial: string | undefined;
+      let final: string | undefined;
+      const any: string[] = [];
+      while (parts.remaining > 0) {
+        const { tag: partTag, value } = parts.readElement();
+        const text = value.toString("utf8");
+        if (partTag === SUBSTRING_TAG.INITIAL) initial = text;
+        else if (partTag === SUBSTRING_TAG.FINAL) final = text;
+        else if (partTag === SUBSTRING_TAG.ANY) any.push(text);
+      }
+      return { type: "substrings", attribute, initial, any, final };
+    }
+    default: {
+      // Consume the element so framing stays intact, then report it unsupported.
+      reader.readElement(tag);
+      return { type: "unsupported", tag };
+    }
+  }
+}
+
+const fold = (value: string) => value.trim().toLowerCase();
+
+function valuesFor(
+  attributes: Record<string, string[]>,
+  attribute: string,
+): string[] {
+  const wanted = fold(attribute);
+  for (const [name, values] of Object.entries(attributes)) {
+    if (fold(name) === wanted) return values;
+  }
+  return [];
+}
+
+/**
+ * Evaluate a filter against one entry's PUBLISHED attributes.
+ *
+ * Matching is case-insensitive, which is the default for the string attributes
+ * this directory publishes. Evaluation runs against the post-allowlist view, so
+ * a client can never use a filter to confirm the value of a withheld attribute
+ * — `(passwordHash=*)` is false because the attribute is not there to match.
+ */
+export function matchesFilter(filter: LdapFilter, attributes: Record<string, string[]>): boolean {
+  switch (filter.type) {
+    case "and":
+      return filter.filters.every((child) => matchesFilter(child, attributes));
+    case "or":
+      return filter.filters.some((child) => matchesFilter(child, attributes));
+    case "not":
+      return !matchesFilter(filter.filter, attributes);
+    case "present":
+      return valuesFor(attributes, filter.attribute).length > 0;
+    case "equality": {
+      const wanted = fold(filter.value);
+      return valuesFor(attributes, filter.attribute).some((value) => fold(value) === wanted);
+    }
+    case "substrings": {
+      return valuesFor(attributes, filter.attribute).some((raw) => {
+        let cursor = fold(raw);
+        if (filter.initial !== undefined) {
+          const initial = fold(filter.initial);
+          if (!cursor.startsWith(initial)) return false;
+          cursor = cursor.slice(initial.length);
+        }
+        for (const fragment of filter.any) {
+          const index = cursor.indexOf(fold(fragment));
+          if (index === -1) return false;
+          cursor = cursor.slice(index + fragment.length);
+        }
+        if (filter.final !== undefined) {
+          return cursor.endsWith(fold(filter.final));
+        }
+        return true;
+      });
+    }
+    case "unsupported":
+      // A filter we cannot reason about must not widen the result set.
+      return false;
+  }
+}

--- a/apps/web/lib/directory/ldap/ldap.test.ts
+++ b/apps/web/lib/directory/ldap/ldap.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DirectoryProjection } from "../projection";
+import {
+  APP,
+  BerReader,
+  TAG,
+  berElement,
+  berInteger,
+  berSequence,
+  berString,
+  frameMessages,
+} from "./ber";
+import { decodeFilter, matchesFilter } from "./filter";
+import {
+  MAX_SEARCH_RESULTS,
+  RESULT,
+  SCOPE,
+  decodeRequest,
+  executeSearch,
+} from "./protocol";
+import { handleMessage } from "./server";
+import { loadLdapTlsMaterial } from "./tls";
+import { createBindVerifier, principalIdFromBindDn } from "./bind";
+
+// ── request builders (the client side of the wire) ───────────────────────────
+function bindRequest(messageId: number, dn: string, password: string, version = 3) {
+  return berSequence(
+    berInteger(messageId),
+    berElement(
+      APP.BIND_REQUEST,
+      Buffer.concat([berInteger(version), berString(dn), berString(password, 0x80)]),
+    ),
+  );
+}
+function searchRequest(
+  messageId: number,
+  base: string,
+  scope: number,
+  filter: Buffer,
+  attributes: string[] = [],
+  sizeLimit = 0,
+) {
+  return berSequence(
+    berInteger(messageId),
+    berElement(
+      APP.SEARCH_REQUEST,
+      Buffer.concat([
+        berString(base),
+        berInteger(scope, TAG.ENUMERATED),
+        berInteger(0, TAG.ENUMERATED),
+        berInteger(sizeLimit),
+        berInteger(0),
+        berElement(TAG.BOOLEAN, Buffer.from([0])),
+        filter,
+        berSequence(...attributes.map((a) => berString(a))),
+      ]),
+    ),
+  );
+}
+const equalityFilter = (attr: string, value: string) =>
+  berElement(0xa3, Buffer.concat([berString(attr), berString(value)]));
+const presentFilter = (attr: string) => berString(attr, 0x87);
+
+const BASE = "dc=acme,dc=com";
+const projection: DirectoryProjection = {
+  baseDn: BASE,
+  fingerprint: "fp",
+  counts: { people: 2, agents: 1, services: 1, groups: 1 },
+  entries: [
+    { dn: `ou=people,${BASE}`, branch: "people", attributes: { objectClass: ["organizationalUnit"], ou: ["people"] } },
+    {
+      dn: `uid=prn-h,ou=people,${BASE}`,
+      branch: "people",
+      attributes: { objectClass: ["inetOrgPerson"], uid: ["prn-h"], cn: ["Dana Reed"], mail: ["dana@acme.com"] },
+    },
+    {
+      dn: `uid=prn-a,ou=agents,${BASE}`,
+      branch: "agents",
+      attributes: { objectClass: ["inetOrgPerson", "dpfAgent"], uid: ["prn-a"], cn: ["HR Specialist"] },
+    },
+    {
+      dn: `cn=role-ceo,ou=groups,${BASE}`,
+      branch: "groups",
+      attributes: { objectClass: ["groupOfNames"], cn: ["role-ceo"], member: [`uid=prn-h,ou=people,${BASE}`] },
+    },
+  ],
+};
+const bound = { boundDn: `uid=prn-h,ou=people,${BASE}` };
+
+describe("BER", () => {
+  it("round-trips integers, strings and sequences", () => {
+    const buf = berSequence(berInteger(7), berString("hello"));
+    const reader = new BerReader(buf).readConstructed(TAG.SEQUENCE);
+    expect(reader.readInteger()).toBe(7);
+    expect(reader.readString()).toBe("hello");
+  });
+
+  it("encodes and decodes a long-form length past 127 bytes", () => {
+    const long = "x".repeat(300);
+    const reader = new BerReader(berString(long));
+    expect(reader.readString()).toBe(long);
+  });
+
+  it("refuses an element whose declared length exceeds the ceiling", () => {
+    // 0x04 = OCTET STRING, 0x84 = 4 length bytes, then 16MB.
+    const hostile = Buffer.from([0x04, 0x84, 0x01, 0x00, 0x00, 0x00]);
+    expect(() => new BerReader(hostile).readElement()).toThrow(/exceeds/i);
+  });
+
+  it("refuses indefinite-length encoding", () => {
+    expect(() => new BerReader(Buffer.from([0x30, 0x80])).readElement()).toThrow(/length/i);
+  });
+});
+
+describe("frameMessages — TCP does not respect message boundaries", () => {
+  it("splits two messages arriving in one chunk", () => {
+    const stream = Buffer.concat([bindRequest(1, "a", "b"), bindRequest(2, "c", "d")]);
+    const { messages, rest } = frameMessages(stream);
+    expect(messages).toHaveLength(2);
+    expect(rest).toHaveLength(0);
+  });
+
+  it("holds back a message split across chunks instead of misparsing it", () => {
+    const whole = bindRequest(1, "somebody", "secret");
+    const first = frameMessages(whole.subarray(0, 6));
+    expect(first.messages).toHaveLength(0);
+    const second = frameMessages(Buffer.concat([first.rest, whole.subarray(6)]));
+    expect(second.messages).toHaveLength(1);
+    expect(decodeRequest(second.messages[0]!)).toMatchObject({ type: "bind", messageId: 1 });
+  });
+});
+
+describe("request decoding", () => {
+  it("decodes a simple bind", () => {
+    expect(decodeRequest(bindRequest(9, "uid=x,dc=a", "pw"))).toEqual({
+      type: "bind", messageId: 9, version: 3, name: "uid=x,dc=a", password: "pw",
+    });
+  });
+
+  it("decodes a search with filter and requested attributes", () => {
+    const req = decodeRequest(
+      searchRequest(3, BASE, SCOPE.SUBTREE, equalityFilter("uid", "prn-h"), ["cn", "mail"]),
+    );
+    expect(req).toMatchObject({ type: "search", messageId: 3, baseObject: BASE, scope: SCOPE.SUBTREE });
+    expect((req as { attributes: string[] }).attributes).toEqual(["cn", "mail"]);
+  });
+
+  it("decodes unbind", () => {
+    const unbind = berSequence(berInteger(4), berElement(APP.UNBIND_REQUEST, Buffer.alloc(0)));
+    expect(decodeRequest(unbind)).toEqual({ type: "unbind", messageId: 4 });
+  });
+});
+
+describe("filters", () => {
+  const attrs = { cn: ["Dana Reed"], uid: ["prn-h"], mail: ["dana@acme.com"] };
+
+  it("matches equality case-insensitively", () => {
+    expect(matchesFilter(decodeFilter(new BerReader(equalityFilter("CN", "dana reed"))), attrs)).toBe(true);
+  });
+
+  it("matches presence, and reports absence for an attribute that is not published", () => {
+    expect(matchesFilter(decodeFilter(new BerReader(presentFilter("mail"))), attrs)).toBe(true);
+    expect(matchesFilter(decodeFilter(new BerReader(presentFilter("passwordHash"))), attrs)).toBe(false);
+  });
+
+  it("evaluates and / or / not", () => {
+    const and = berElement(0xa0, Buffer.concat([equalityFilter("uid", "prn-h"), presentFilter("mail")]));
+    expect(matchesFilter(decodeFilter(new BerReader(and)), attrs)).toBe(true);
+    const or = berElement(0xa1, Buffer.concat([equalityFilter("uid", "nope"), presentFilter("mail")]));
+    expect(matchesFilter(decodeFilter(new BerReader(or)), attrs)).toBe(true);
+    const not = berElement(0xa2, equalityFilter("uid", "nope"));
+    expect(matchesFilter(decodeFilter(new BerReader(not)), attrs)).toBe(true);
+  });
+
+  it("evaluates substrings with initial, any and final", () => {
+    const substrings = berElement(
+      0xa4,
+      Buffer.concat([
+        berString("mail"),
+        berSequence(berString("dana", 0x80), berString("acme", 0x81), berString(".com", 0x82)),
+      ]),
+    );
+    expect(matchesFilter(decodeFilter(new BerReader(substrings)), attrs)).toBe(true);
+  });
+
+  it("treats an unsupported filter as NO match, never a wider one", () => {
+    const approx = berElement(0xa8, Buffer.concat([berString("cn"), berString("Dana Reed")]));
+    const decoded = decodeFilter(new BerReader(approx));
+    expect(decoded.type).toBe("unsupported");
+    expect(matchesFilter(decoded, attrs)).toBe(false);
+  });
+});
+
+describe("executeSearch — authorization is not optional", () => {
+  it("refuses anonymous enumeration of the tree", () => {
+    const request = decodeRequest(searchRequest(1, BASE, SCOPE.SUBTREE, presentFilter("objectClass")));
+    const outcome = executeSearch(request as never, projection, { boundDn: null });
+    expect(outcome).toMatchObject({ searched: false, resultCode: RESULT.INSUFFICIENT_ACCESS });
+  });
+
+  it("refuses a base object outside the published namespace", () => {
+    const request = decodeRequest(searchRequest(1, "dc=evil,dc=com", SCOPE.SUBTREE, presentFilter("objectClass")));
+    const outcome = executeSearch(request as never, projection, bound);
+    expect(outcome).toMatchObject({ searched: false, resultCode: RESULT.NO_SUCH_OBJECT });
+  });
+
+  it("honours base, one-level and subtree scope", () => {
+    const run = (scope: number, base = BASE) =>
+      executeSearch(
+        decodeRequest(searchRequest(1, base, scope, presentFilter("objectClass"))) as never,
+        projection,
+        bound,
+      );
+    const baseScope = run(SCOPE.BASE, `ou=people,${BASE}`);
+    expect(baseScope.searched && baseScope.entries.map((e) => e.dn)).toEqual([`ou=people,${BASE}`]);
+
+    const oneLevel = run(SCOPE.ONE_LEVEL, `ou=people,${BASE}`);
+    expect(oneLevel.searched && oneLevel.entries.map((e) => e.dn)).toEqual([`uid=prn-h,ou=people,${BASE}`]);
+
+    const subtree = run(SCOPE.SUBTREE);
+    expect(subtree.searched && subtree.entries.length).toBe(4);
+  });
+
+  it("returns only the requested attributes", () => {
+    const request = decodeRequest(
+      searchRequest(1, BASE, SCOPE.SUBTREE, equalityFilter("uid", "prn-h"), ["cn"]),
+    );
+    const outcome = executeSearch(request as never, projection, bound);
+    expect(outcome.searched && outcome.entries[0]!.attributes).toEqual({ cn: ["Dana Reed"] });
+  });
+
+  it("caps an unbounded search rather than serving the whole tree", () => {
+    const big: DirectoryProjection = {
+      ...projection,
+      entries: Array.from({ length: MAX_SEARCH_RESULTS + 25 }, (_, i) => ({
+        dn: `uid=p${i},ou=people,${BASE}`,
+        branch: "people" as const,
+        attributes: { objectClass: ["inetOrgPerson"], uid: [`p${i}`] },
+      })),
+    };
+    const request = decodeRequest(searchRequest(1, BASE, SCOPE.SUBTREE, presentFilter("objectClass")));
+    const outcome = executeSearch(request as never, big, bound);
+    expect(outcome.searched && outcome.entries.length).toBe(MAX_SEARCH_RESULTS);
+    expect(outcome.searched && outcome.resultCode).toBe(RESULT.SIZE_LIMIT_EXCEEDED);
+  });
+
+  it("cannot be used to confirm a withheld attribute", () => {
+    const request = decodeRequest(searchRequest(1, BASE, SCOPE.SUBTREE, presentFilter("sponsorPrincipalId")));
+    const outcome = executeSearch(request as never, projection, bound);
+    expect(outcome.searched && outcome.entries).toEqual([]);
+  });
+});
+
+describe("handleMessage — the read-only contract", () => {
+  const options = {
+    loadProjection: async () => projection,
+    verifyBind: vi.fn(async ({ password }: { password: string }) =>
+      password === "right" ? { bound: true, principalId: "prn-h" } : { bound: false, reason: "invalid credentials" },
+    ),
+  };
+
+  it("binds, then permits a search that was refused before the bind", async () => {
+    const session = { boundDn: null as string | null, principalId: null as string | null };
+    const before = await handleMessage(
+      searchRequest(1, BASE, SCOPE.SUBTREE, presentFilter("objectClass")), session, options, null,
+    );
+    expect(before.response!.includes(Buffer.from([RESULT.INSUFFICIENT_ACCESS]))).toBe(true);
+
+    await handleMessage(bindRequest(2, `uid=prn-h,ou=people,${BASE}`, "right"), session, options, null);
+    expect(session.boundDn).toBe(`uid=prn-h,ou=people,${BASE}`);
+
+    const after = await handleMessage(
+      searchRequest(3, BASE, SCOPE.SUBTREE, presentFilter("objectClass")), session, options, null,
+    );
+    expect(after.response!.length).toBeGreaterThan(before.response!.length);
+  });
+
+  it("clears the session on a failed bind so a bad password cannot inherit a prior bind", async () => {
+    const session = { boundDn: "stale" as string | null, principalId: "stale" as string | null };
+    await handleMessage(bindRequest(1, "uid=x,dc=a", "wrong"), session, options, null);
+    expect(session.boundDn).toBeNull();
+  });
+
+  it("refuses LDAPv2", async () => {
+    const session = { boundDn: null, principalId: null };
+    const out = await handleMessage(bindRequest(1, "uid=x,dc=a", "right", 2), session, options, null);
+    expect(out.response!.includes(Buffer.from([RESULT.PROTOCOL_ERROR]))).toBe(true);
+  });
+
+  it("refuses a write operation rather than ignoring it", async () => {
+    const session = { boundDn: `uid=prn-h,ou=people,${BASE}`, principalId: "prn-h" };
+    const addRequest = berSequence(berInteger(1), berElement(0x68, Buffer.alloc(0)));
+    const out = await handleMessage(addRequest, session, options, null);
+    expect(out.response!.includes(Buffer.from([RESULT.UNWILLING_TO_PERFORM]))).toBe(true);
+  });
+
+  it("closes on unbind and on a malformed PDU", async () => {
+    const session = { boundDn: null, principalId: null };
+    const unbind = berSequence(berInteger(1), berElement(APP.UNBIND_REQUEST, Buffer.alloc(0)));
+    expect((await handleMessage(unbind, session, options, null)).close).toBe(true);
+    expect((await handleMessage(Buffer.from([0x30, 0x02, 0xff]), session, options, null)).close).toBe(true);
+  });
+});
+
+describe("TLS material — no self-signed fallback", () => {
+  it("refuses to start when the org PKI paths are unset", () => {
+    expect(() => loadLdapTlsMaterial({}, () => Buffer.alloc(0))).toThrow(/organization PKI/i);
+  });
+
+  it("loads the org key, cert and CA when configured", () => {
+    const material = loadLdapTlsMaterial(
+      { keyPath: "/k", certPath: "/c", caPath: "/ca" },
+      (path) => Buffer.from(path),
+    );
+    expect(material.ca.toString()).toBe("/ca");
+  });
+});
+
+describe("bind verification resolves through the spine", () => {
+  const HUMAN = {
+    principalId: "prn-h", kind: "human", status: "active",
+    aliases: [{ aliasType: "user", aliasValue: "user-1" }],
+  };
+  const makeDb = (principal: unknown) => ({
+    principal: { findUnique: vi.fn(async () => principal) },
+    principalAlias: { findFirst: vi.fn() },
+    user: { findUnique: vi.fn(async () => ({ id: "user-1", passwordHash: "hash" })) },
+  });
+
+  it("parses the principal out of a bind DN, unescaping RFC 4514", () => {
+    expect(principalIdFromBindDn("uid=prn-h,ou=people,dc=acme,dc=com")).toBe("prn-h");
+    expect(principalIdFromBindDn("uid=browser-svc\\:x,ou=services,dc=a")).toBe("browser-svc:x");
+    expect(principalIdFromBindDn("cn=nope,dc=a")).toBeNull();
+  });
+
+  it("accepts a human password bind that the spine also authorizes", async () => {
+    const db = makeDb(HUMAN);
+    const verifier = createBindVerifier(db as never, {
+      verify: (async () => ({ valid: true, needsRehash: false })) as never,
+      authorize: (async () => ({ authorized: true, principalId: "prn-h" })) as never,
+    });
+    await expect(
+      verifier({ bindDn: "uid=prn-h,ou=people,dc=a", password: "pw", clientCertificateSubject: null }),
+    ).resolves.toMatchObject({ bound: true, principalId: "prn-h" });
+  });
+
+  it("refuses when the credential is right but the SPINE says no", async () => {
+    const db = makeDb(HUMAN);
+    const verifier = createBindVerifier(db as never, {
+      verify: (async () => ({ valid: true, needsRehash: false })) as never,
+      authorize: (async () => ({ authorized: false, reason: "principal-inactive", detail: "" })) as never,
+    });
+    await expect(
+      verifier({ bindDn: "uid=prn-h,ou=people,dc=a", password: "pw", clientCertificateSubject: null }),
+    ).resolves.toMatchObject({ bound: false });
+  });
+
+  it("refuses an inactive principal before touching the credential", async () => {
+    const db = makeDb({ ...HUMAN, status: "inactive" });
+    const verify = vi.fn();
+    const verifier = createBindVerifier(db as never, { verify: verify as never });
+    await expect(
+      verifier({ bindDn: "uid=prn-h,ou=people,dc=a", password: "pw", clientCertificateSubject: null }),
+    ).resolves.toMatchObject({ bound: false });
+    expect(verify).not.toHaveBeenCalled();
+    expect(db.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("refuses a password bind for a non-human principal — they have no password by design", async () => {
+    const db = makeDb({ principalId: "svc", kind: "service", status: "active", aliases: [] });
+    const verifier = createBindVerifier(db as never);
+    await expect(
+      verifier({ bindDn: "uid=svc,ou=services,dc=a", password: "pw", clientCertificateSubject: null }),
+    ).resolves.toMatchObject({ bound: false, reason: expect.stringMatching(/client certificate/i) });
+  });
+
+  it("accepts an mTLS bind whose certificate names the same principal, and rejects a mismatch", async () => {
+    const db = makeDb({ principalId: "svc", kind: "service", status: "active", aliases: [] });
+    const verifier = createBindVerifier(db as never);
+    await expect(
+      verifier({ bindDn: "uid=svc,ou=services,dc=a", password: "", clientCertificateSubject: "svc" }),
+    ).resolves.toMatchObject({ bound: true, principalId: "svc" });
+    await expect(
+      verifier({ bindDn: "uid=svc,ou=services,dc=a", password: "", clientCertificateSubject: "other" }),
+    ).resolves.toMatchObject({ bound: false });
+  });
+});

--- a/apps/web/lib/directory/ldap/ldapsearch.functional.test.ts
+++ b/apps/web/lib/directory/ldap/ldapsearch.functional.test.ts
@@ -1,0 +1,178 @@
+// Functional verification with a REAL LDAP client (EP-24741BBF · BI-F7317D65).
+//
+// The design makes this the acceptance bar, and deliberately so: a directory
+// that satisfies its own unit tests but not a real client is worse than none,
+// because every consumer discovers the gap in production. Structural
+// verification is not functional verification.
+//
+// The certificate here is a throwaway TEST FIXTURE, not a product fallback —
+// `loadLdapTlsMaterial` still refuses to start without organization PKI, which
+// its own test asserts.
+
+import { execFile, execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { DirectoryProjection } from "../projection";
+import { createLdapServer } from "./server";
+
+const LDAPSEARCH = ["/usr/bin/ldapsearch", "/opt/homebrew/bin/ldapsearch"].find((p) =>
+  existsSync(p),
+);
+const OPENSSL = ["/opt/homebrew/bin/openssl", "/usr/bin/openssl"].find((p) => existsSync(p));
+const runnable = Boolean(LDAPSEARCH && OPENSSL);
+
+const BASE = "dc=acme,dc=com";
+const projection: DirectoryProjection = {
+  baseDn: BASE,
+  fingerprint: "fp",
+  counts: { people: 2, agents: 1, services: 0, groups: 1 },
+  entries: [
+    { dn: `ou=people,${BASE}`, branch: "people", attributes: { objectClass: ["organizationalUnit"], ou: ["people"] } },
+    {
+      dn: `uid=prn-h,ou=people,${BASE}`,
+      branch: "people",
+      attributes: { objectClass: ["inetOrgPerson"], uid: ["prn-h"], cn: ["Dana Reed"], mail: ["dana@acme.com"] },
+    },
+    {
+      dn: `uid=prn-a,ou=agents,${BASE}`,
+      branch: "agents",
+      attributes: { objectClass: ["inetOrgPerson", "dpfAgent"], uid: ["prn-a"], cn: ["HR Specialist"], dpfGaid: ["gaid:priv:dpf.internal:hr"] },
+    },
+    {
+      dn: `cn=role-ceo,ou=groups,${BASE}`,
+      branch: "groups",
+      attributes: { objectClass: ["groupOfNames"], cn: ["role-ceo"], member: [`uid=prn-h,ou=people,${BASE}`] },
+    },
+  ],
+};
+
+let server: ReturnType<typeof createLdapServer> | null = null;
+let port = 0;
+
+// MUST be async. The listener runs in THIS process, so a synchronous spawn
+// blocks the event loop and the server can never accept the connection the
+// client is waiting on — the test deadlocks against itself.
+function ldapsearch(args: string[]): Promise<{ stdout: string; status: number | null }> {
+  return new Promise((resolve) => {
+    execFile(
+      LDAPSEARCH!,
+      args,
+      { encoding: "utf8", env: { ...process.env, LDAPTLS_REQCERT: "never" }, timeout: 15_000 },
+      (error, stdout, stderr) => {
+        const code =
+          error && typeof (error as { code?: unknown }).code === "number"
+            ? ((error as { code: number }).code)
+            : error
+              ? 1
+              : 0;
+        resolve({ stdout: `${stdout}${stderr}`, status: code });
+      },
+    );
+  });
+}
+
+beforeAll(async () => {
+  if (!runnable) return;
+  const dir = mkdtempSync(join(tmpdir(), "dpf-ldap-fixture-"));
+  const keyPath = join(dir, "key.pem");
+  const certPath = join(dir, "cert.pem");
+  execFileSync(OPENSSL!, [
+    "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", keyPath, "-out", certPath, "-days", "1",
+    "-subj", "/CN=127.0.0.1",
+    "-addext", "subjectAltName=IP:127.0.0.1",
+  ], { stdio: "ignore" });
+
+  server = createLdapServer({
+    tls: { key: readFileSync(keyPath), cert: readFileSync(certPath), ca: readFileSync(certPath) },
+    loadProjection: async () => projection,
+    verifyBind: async ({ bindDn, password }) =>
+      password === "correct-horse" && bindDn.startsWith("uid=prn-h,")
+        ? { bound: true, principalId: "prn-h" }
+        : { bound: false, reason: "invalid credentials" },
+  });
+
+  await new Promise<void>((resolve) => {
+    server!.listen(0, "127.0.0.1", () => {
+      port = (server!.address() as AddressInfo).port;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  if (server) await new Promise<void>((resolve) => server!.close(() => resolve()));
+});
+
+describe.skipIf(!runnable)("ldapsearch against the real listener", () => {
+  it("binds over TLS and returns the published tree", async () => {
+    const { stdout } = await ldapsearch([
+      "-H", `ldaps://127.0.0.1:${port}`, "-x",
+      "-D", `uid=prn-h,ou=people,${BASE}`, "-w", "correct-horse",
+      "-b", BASE, "-s", "sub", "(objectClass=*)",
+    ]);
+    expect(stdout).toContain(`dn: uid=prn-h,ou=people,${BASE}`);
+    expect(stdout).toContain(`dn: uid=prn-a,ou=agents,${BASE}`);
+    expect(stdout).toContain("Dana Reed");
+  });
+
+  it("returns a human, an agent and a group — three shapes of one spine", async () => {
+    const { stdout } = await ldapsearch([
+      "-H", `ldaps://127.0.0.1:${port}`, "-x",
+      "-D", `uid=prn-h,ou=people,${BASE}`, "-w", "correct-horse",
+      "-b", BASE, "-s", "sub", "(objectClass=*)",
+    ]);
+    expect(stdout).toContain("dpfAgent");
+    expect(stdout).toContain("gaid:priv:dpf.internal:hr");
+    expect(stdout).toContain("groupOfNames");
+    expect(stdout).toContain(`member: uid=prn-h,ou=people,${BASE}`);
+  });
+
+  it("resolves group membership by filter", async () => {
+    const { stdout } = await ldapsearch([
+      "-H", `ldaps://127.0.0.1:${port}`, "-x",
+      "-D", `uid=prn-h,ou=people,${BASE}`, "-w", "correct-horse",
+      "-b", BASE, "-s", "sub", `(member=uid=prn-h,ou=people,${BASE})`,
+    ]);
+    expect(stdout).toContain("dn: cn=role-ceo");
+  });
+
+  it("REFUSES anonymous enumeration", async () => {
+    const { stdout } = await ldapsearch([
+      "-H", `ldaps://127.0.0.1:${port}`, "-x",
+      "-b", BASE, "-s", "sub", "(objectClass=*)",
+    ]);
+    // Refused at the BIND layer — an anonymous simple bind never reaches
+    // search, so the client sees "Invalid credentials (49)". The search-layer
+    // guard (insufficientAccessRights, for a client that skips bind entirely)
+    // is asserted separately in ldap.test.ts. Two independent refusals; the
+    // substance is that NOTHING is disclosed.
+    expect(stdout).not.toContain("dn: uid=prn-h");
+    expect(stdout).not.toContain("dn: ou=people");
+    expect(stdout).toMatch(/Invalid credentials|Insufficient access/i);
+  });
+
+  it("rejects a wrong password", async () => {
+    const { stdout, status } = await ldapsearch([
+      "-H", `ldaps://127.0.0.1:${port}`, "-x",
+      "-D", `uid=prn-h,ou=people,${BASE}`, "-w", "wrong",
+      "-b", BASE, "(objectClass=*)",
+    ]);
+    expect(status).not.toBe(0);
+    expect(stdout).toMatch(/Invalid credentials/i);
+  });
+
+  it("does not disclose a withheld attribute even when asked for it directly", async () => {
+    const { stdout } = await ldapsearch([
+      "-H", `ldaps://127.0.0.1:${port}`, "-x",
+      "-D", `uid=prn-h,ou=people,${BASE}`, "-w", "correct-horse",
+      "-b", BASE, "-s", "sub", "(objectClass=*)", "sponsorPrincipalId", "passwordHash",
+    ]);
+    expect(stdout).not.toMatch(/sponsorPrincipalId:/);
+    expect(stdout).not.toMatch(/passwordHash:/);
+  });
+});

--- a/apps/web/lib/directory/ldap/protocol.ts
+++ b/apps/web/lib/directory/ldap/protocol.ts
@@ -1,0 +1,238 @@
+// LDAP message decode/encode and the search engine (RFC 4511)
+// — EP-24741BBF · BI-F7317D65.
+
+import type { DirectoryEntry, DirectoryProjection } from "../projection";
+import { dnEquals, isWithinSubtree } from "../dn";
+import {
+  APP,
+  BerReader,
+  TAG,
+  berElement,
+  berInteger,
+  berSequence,
+  berSet,
+  berString,
+} from "./ber";
+import { decodeFilter, matchesFilter, type LdapFilter } from "./filter";
+
+export const RESULT = {
+  SUCCESS: 0,
+  PROTOCOL_ERROR: 2,
+  SIZE_LIMIT_EXCEEDED: 4,
+  NO_SUCH_OBJECT: 32,
+  INVALID_CREDENTIALS: 49,
+  INSUFFICIENT_ACCESS: 50,
+  UNWILLING_TO_PERFORM: 53,
+} as const;
+
+export const SCOPE = { BASE: 0, ONE_LEVEL: 1, SUBTREE: 2 } as const;
+
+/** Hard ceiling on entries returned by one search — an unbounded search is a DoS. */
+export const MAX_SEARCH_RESULTS = 500;
+
+const SIMPLE_AUTH_TAG = 0x80;
+
+export type BindRequest = {
+  type: "bind";
+  messageId: number;
+  version: number;
+  name: string;
+  password: string;
+};
+export type SearchRequest = {
+  type: "search";
+  messageId: number;
+  baseObject: string;
+  scope: number;
+  sizeLimit: number;
+  filter: LdapFilter;
+  attributes: string[];
+};
+export type UnbindRequest = { type: "unbind"; messageId: number };
+export type UnknownRequest = { type: "unknown"; messageId: number; tag: number };
+export type LdapRequest = BindRequest | SearchRequest | UnbindRequest | UnknownRequest;
+
+/** Decode one framed LDAPMessage. */
+export function decodeRequest(message: Buffer): LdapRequest {
+  const envelope = new BerReader(message).readConstructed(TAG.SEQUENCE);
+  const messageId = envelope.readInteger();
+  const tag = envelope.peekTag();
+  if (tag === null) throw new Error("LDAP: message with no protocol op");
+
+  switch (tag) {
+    case APP.BIND_REQUEST: {
+      const body = envelope.readConstructed(APP.BIND_REQUEST);
+      const version = body.readInteger();
+      const name = body.readString();
+      // Only simple authentication is accepted. SASL is a separate decision and
+      // is refused rather than silently downgraded.
+      const auth = body.readElement();
+      if (auth.tag !== SIMPLE_AUTH_TAG) {
+        return { type: "bind", messageId, version, name, password: "" };
+      }
+      return { type: "bind", messageId, version, name, password: auth.value.toString("utf8") };
+    }
+    case APP.SEARCH_REQUEST: {
+      const body = envelope.readConstructed(APP.SEARCH_REQUEST);
+      const baseObject = body.readString();
+      const scope = body.readInteger(TAG.ENUMERATED);
+      body.readInteger(TAG.ENUMERATED); // derefAliases — not honoured, read to stay framed
+      const sizeLimit = body.readInteger();
+      body.readInteger(); // timeLimit
+      body.readBoolean(); // typesOnly
+      const filter = decodeFilter(body);
+      const attributes: string[] = [];
+      if (body.remaining > 0) {
+        const list = body.readConstructed(TAG.SEQUENCE);
+        while (list.remaining > 0) attributes.push(list.readString());
+      }
+      return { type: "search", messageId, baseObject, scope, sizeLimit, filter, attributes };
+    }
+    case APP.UNBIND_REQUEST: {
+      envelope.readElement(APP.UNBIND_REQUEST);
+      return { type: "unbind", messageId };
+    }
+    default:
+      return { type: "unknown", messageId, tag };
+  }
+}
+
+function ldapMessage(messageId: number, protocolOp: Buffer): Buffer {
+  return berSequence(berInteger(messageId), protocolOp);
+}
+
+export function encodeBindResponse(
+  messageId: number,
+  resultCode: number,
+  diagnostic = "",
+): Buffer {
+  return ldapMessage(
+    messageId,
+    berElement(
+      APP.BIND_RESPONSE,
+      Buffer.concat([
+        berInteger(resultCode, TAG.ENUMERATED),
+        berString(""), // matchedDN
+        berString(diagnostic),
+      ]),
+    ),
+  );
+}
+
+export function encodeSearchResultEntry(
+  messageId: number,
+  dn: string,
+  attributes: Record<string, string[]>,
+): Buffer {
+  const attrs = Object.entries(attributes).map(([name, values]) =>
+    berSequence(berString(name), berSet(...values.map((value) => berString(value)))),
+  );
+  return ldapMessage(
+    messageId,
+    berElement(
+      APP.SEARCH_RESULT_ENTRY,
+      Buffer.concat([berString(dn), berSequence(...attrs)]),
+    ),
+  );
+}
+
+export function encodeSearchResultDone(
+  messageId: number,
+  resultCode: number,
+  diagnostic = "",
+): Buffer {
+  return ldapMessage(
+    messageId,
+    berElement(
+      APP.SEARCH_RESULT_DONE,
+      Buffer.concat([
+        berInteger(resultCode, TAG.ENUMERATED),
+        berString(""),
+        berString(diagnostic),
+      ]),
+    ),
+  );
+}
+
+function inScope(entryDn: string, baseObject: string, scope: number): boolean {
+  if (scope === SCOPE.BASE) return dnEquals(entryDn, baseObject);
+  if (scope === SCOPE.ONE_LEVEL) {
+    if (dnEquals(entryDn, baseObject)) return false;
+    const suffix = `,${baseObject.trim().toLowerCase()}`;
+    const lower = entryDn.trim().toLowerCase();
+    if (!lower.endsWith(suffix)) return false;
+    // Exactly one RDN deeper.
+    return !lower.slice(0, lower.length - suffix.length).includes(",");
+  }
+  return isWithinSubtree(entryDn, baseObject);
+}
+
+/** Restrict an entry to the attributes the client asked for. */
+function selectAttributes(
+  attributes: Record<string, string[]>,
+  requested: string[],
+): Record<string, string[]> {
+  // No list, or "*", means all PUBLISHED attributes — never more.
+  if (requested.length === 0 || requested.includes("*")) return attributes;
+  if (requested.includes("1.1")) return {}; // RFC 4511: no attributes
+  const wanted = new Set(requested.map((name) => name.trim().toLowerCase()));
+  const selected: Record<string, string[]> = {};
+  for (const [name, values] of Object.entries(attributes)) {
+    if (wanted.has(name.toLowerCase())) selected[name] = values;
+  }
+  return selected;
+}
+
+export type SearchOutcome =
+  | { searched: true; entries: Array<{ dn: string; attributes: Record<string, string[]> }>; resultCode: number }
+  | { searched: false; resultCode: number; diagnostic: string };
+
+/**
+ * Execute a search against the projection.
+ *
+ * Authorization is not optional and not an afterthought: an unauthenticated
+ * connection cannot enumerate the tree. A directory that answers every search
+ * identically is an information-disclosure surface, so this refuses before it
+ * filters rather than returning a filtered-but-revealing subset.
+ */
+export function executeSearch(
+  request: SearchRequest,
+  projection: DirectoryProjection,
+  session: { boundDn: string | null },
+): SearchOutcome {
+  if (!session.boundDn) {
+    return {
+      searched: false,
+      resultCode: RESULT.INSUFFICIENT_ACCESS,
+      diagnostic: "bind before searching; anonymous enumeration is not permitted",
+    };
+  }
+  if (!isWithinSubtree(request.baseObject, projection.baseDn)) {
+    return {
+      searched: false,
+      resultCode: RESULT.NO_SUCH_OBJECT,
+      diagnostic: `base object is outside ${projection.baseDn}`,
+    };
+  }
+
+  const limit =
+    request.sizeLimit > 0 ? Math.min(request.sizeLimit, MAX_SEARCH_RESULTS) : MAX_SEARCH_RESULTS;
+
+  const entries: Array<{ dn: string; attributes: Record<string, string[]> }> = [];
+  let truncated = false;
+  for (const entry of projection.entries as DirectoryEntry[]) {
+    if (!inScope(entry.dn, request.baseObject, request.scope)) continue;
+    if (!matchesFilter(request.filter, entry.attributes)) continue;
+    if (entries.length >= limit) {
+      truncated = true;
+      break;
+    }
+    entries.push({ dn: entry.dn, attributes: selectAttributes(entry.attributes, request.attributes) });
+  }
+
+  return {
+    searched: true,
+    entries,
+    resultCode: truncated ? RESULT.SIZE_LIMIT_EXCEEDED : RESULT.SUCCESS,
+  };
+}

--- a/apps/web/lib/directory/ldap/server.ts
+++ b/apps/web/lib/directory/ldap/server.ts
@@ -1,0 +1,168 @@
+// The LDAP listener (EP-24741BBF · BI-F7317D65).
+//
+// Read-only by construction: it implements bind, search and unbind, and NOTHING
+// else. Add, modify and delete are not merely unimplemented — they are refused
+// with `unwillingToPerform`, because the directory is authoritative for being
+// DERIVED from the Principal spine, not for being a second place to edit
+// identity.
+
+import { createServer, type Server, type TLSSocket } from "node:tls";
+
+import type { DirectoryProjection } from "../projection";
+import { frameMessages } from "./ber";
+import {
+  RESULT,
+  decodeRequest,
+  encodeBindResponse,
+  encodeSearchResultDone,
+  encodeSearchResultEntry,
+  executeSearch,
+} from "./protocol";
+import type { LdapTlsMaterial } from "./tls";
+
+/** Verifies a bind credential. Injected so the server never owns password logic. */
+export type BindVerifier = (input: {
+  bindDn: string;
+  password: string;
+  /** Subject CN of a presented client certificate, when the bind is mTLS. */
+  clientCertificateSubject: string | null;
+}) => Promise<{ bound: boolean; principalId?: string; reason?: string }>;
+
+export type LdapServerOptions = {
+  tls: LdapTlsMaterial;
+  /** Rebuilt per connection so a bind never serves a stale tree. */
+  loadProjection: () => Promise<DirectoryProjection>;
+  verifyBind: BindVerifier;
+  /** Require a client certificate. mTLS is the stronger posture; default off so
+   *  password binds from ordinary clients still work. */
+  requireClientCertificate?: boolean;
+};
+
+type SessionState = { boundDn: string | null; principalId: string | null };
+
+/** Handle one framed message, returning the bytes to write back. */
+export async function handleMessage(
+  message: Buffer,
+  session: SessionState,
+  options: Pick<LdapServerOptions, "loadProjection" | "verifyBind">,
+  clientCertificateSubject: string | null,
+): Promise<{ response: Buffer | null; close: boolean }> {
+  let request;
+  try {
+    request = decodeRequest(message);
+  } catch {
+    // A malformed PDU has no reliable messageId, so answer on 0 and close:
+    // continuing to parse an unframed stream is how a parser gets confused.
+    return { response: encodeBindResponse(0, RESULT.PROTOCOL_ERROR, "malformed request"), close: true };
+  }
+
+  switch (request.type) {
+    case "unbind":
+      return { response: null, close: true };
+
+    case "bind": {
+      if (request.version !== 3) {
+        return {
+          response: encodeBindResponse(request.messageId, RESULT.PROTOCOL_ERROR, "LDAPv3 required"),
+          close: false,
+        };
+      }
+      const verdict = await options.verifyBind({
+        bindDn: request.name,
+        password: request.password,
+        clientCertificateSubject,
+      });
+      if (!verdict.bound) {
+        session.boundDn = null;
+        session.principalId = null;
+        return {
+          response: encodeBindResponse(
+            request.messageId,
+            RESULT.INVALID_CREDENTIALS,
+            verdict.reason ?? "invalid credentials",
+          ),
+          close: false,
+        };
+      }
+      session.boundDn = request.name;
+      session.principalId = verdict.principalId ?? null;
+      return { response: encodeBindResponse(request.messageId, RESULT.SUCCESS), close: false };
+    }
+
+    case "search": {
+      const projection = await options.loadProjection();
+      const outcome = executeSearch(request, projection, session);
+      if (!outcome.searched) {
+        return {
+          response: encodeSearchResultDone(request.messageId, outcome.resultCode, outcome.diagnostic),
+          close: false,
+        };
+      }
+      const parts = outcome.entries.map((entry) =>
+        encodeSearchResultEntry(request.messageId, entry.dn, entry.attributes),
+      );
+      parts.push(encodeSearchResultDone(request.messageId, outcome.resultCode));
+      return { response: Buffer.concat(parts), close: false };
+    }
+
+    default:
+      // Add / modify / delete and everything else: refused, not ignored.
+      return {
+        response: encodeSearchResultDone(
+          request.messageId,
+          RESULT.UNWILLING_TO_PERFORM,
+          "this directory is a read-only projection of the Principal spine",
+        ),
+        close: false,
+      };
+  }
+}
+
+/** Create the LDAPS listener. Call `.listen(port)` to start it. */
+export function createLdapServer(options: LdapServerOptions): Server {
+  return createServer(
+    {
+      key: options.tls.key,
+      cert: options.tls.cert,
+      ca: options.tls.ca,
+      requestCert: true,
+      rejectUnauthorized: options.requireClientCertificate ?? false,
+    },
+    (socket: TLSSocket) => {
+      const session: SessionState = { boundDn: null, principalId: null };
+      const peer = socket.getPeerCertificate?.();
+      // A certificate CN may be a string OR an array when the subject repeats
+      // the attribute. Take the first, so a multi-CN cert cannot smuggle a
+      // second identity past the bind comparison.
+      const rawCn = peer && Object.keys(peer).length > 0 ? peer.subject?.CN : undefined;
+      const clientCertificateSubject =
+        (Array.isArray(rawCn) ? rawCn[0] : rawCn) ?? null;
+      // Explicitly `Buffer` (ArrayBufferLike): Buffer.concat widens the type
+      // relative to Buffer.alloc, so an inferred binding rejects the reassignment.
+      let buffered: Buffer = Buffer.alloc(0);
+
+      socket.on("data", (chunk: Buffer) => {
+        buffered = Buffer.concat([buffered, chunk]);
+        const { messages, rest } = frameMessages(buffered);
+        buffered = rest;
+        void (async () => {
+          for (const message of messages) {
+            const { response, close } = await handleMessage(
+              message,
+              session,
+              options,
+              clientCertificateSubject,
+            );
+            if (response) socket.write(response);
+            if (close) {
+              socket.end();
+              return;
+            }
+          }
+        })().catch(() => socket.destroy());
+      });
+
+      socket.on("error", () => socket.destroy());
+    },
+  );
+}

--- a/apps/web/lib/directory/ldap/tls.ts
+++ b/apps/web/lib/directory/ldap/tls.ts
@@ -1,0 +1,45 @@
+// TLS material for the LDAP listener (EP-24741BBF · BI-F7317D65).
+//
+// The listener serves LDAPS using the ORGANIZATION'S OWN PKI — the Step CA
+// substrate that already issues machine trust and mTLS for this install. There
+// is deliberately NO self-signed fallback: a directory that quietly downgrades
+// its own transport is worse than one that refuses to start, because the
+// failure is invisible to every client that trusts it.
+
+import { readFileSync } from "node:fs";
+
+export type LdapTlsMaterial = {
+  key: Buffer;
+  cert: Buffer;
+  /** Org CA bundle, used to verify client certificates for mTLS binds. */
+  ca: Buffer;
+};
+
+export type LdapTlsPaths = {
+  keyPath?: string;
+  certPath?: string;
+  caPath?: string;
+};
+
+/** Read the org-PKI material the listener requires, or refuse to start. */
+export function loadLdapTlsMaterial(
+  paths: LdapTlsPaths = {
+    keyPath: process.env.DPF_LDAP_TLS_KEY_PATH,
+    certPath: process.env.DPF_LDAP_TLS_CERT_PATH,
+    caPath: process.env.DPF_LDAP_TLS_CA_PATH,
+  },
+  read: (path: string) => Buffer = readFileSync,
+): LdapTlsMaterial {
+  const missing = (["keyPath", "certPath", "caPath"] as const).filter((field) => !paths[field]);
+  if (missing.length > 0) {
+    throw new Error(
+      `LDAP listener: refusing to start without organization PKI material (${missing.join(", ")} unset). ` +
+        "The directory serves LDAPS from the org CA; there is no self-signed fallback.",
+    );
+  }
+  return {
+    key: read(paths.keyPath!),
+    cert: read(paths.certPath!),
+    ca: read(paths.caPath!),
+  };
+}

--- a/apps/web/lib/directory/projection.test.ts
+++ b/apps/web/lib/directory/projection.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { branchDn, deriveBaseDn, escapeRdnValue, isWithinSubtree, principalDn } from "./dn";
+import { buildDirectoryProjection, fingerprintEntries, type ProjectionDb } from "./projection";
+import { PUBLISHED_ATTRIBUTES, WITHHELD_ATTRIBUTES, applyPublicationAllowlist } from "./schema";
+
+function makeDb(overrides?: {
+  organization?: { slug: string; website?: string | null } | null;
+  principals?: Array<{
+    principalId: string;
+    kind: string;
+    displayName: string;
+    aliases: Array<{ aliasType: string; aliasValue: string }>;
+  }>;
+  roles?: Array<{
+    roleId: string;
+    name: string;
+    description: string | null;
+    users: Array<{ userId: string }>;
+  }>;
+  teams?: Array<{
+    slug: string;
+    name: string;
+    description: string | null;
+    memberships: Array<{ userId: string }>;
+  }>;
+}) {
+  const db = {
+    organization: {
+      findFirst: vi.fn(async () =>
+        overrides?.organization === undefined
+          ? { slug: "acme", website: "https://www.acme.com" }
+          : overrides.organization,
+      ),
+    },
+    principal: { findMany: vi.fn(async () => overrides?.principals ?? []) },
+    platformRole: { findMany: vi.fn(async () => overrides?.roles ?? []) },
+    team: { findMany: vi.fn(async () => overrides?.teams ?? []) },
+  };
+  return { db, injected: db as unknown as ProjectionDb };
+}
+
+const HUMAN = {
+  principalId: "prn-human-1",
+  kind: "human",
+  displayName: "Dana Reed",
+  aliases: [
+    { aliasType: "user", aliasValue: "user-1" },
+    { aliasType: "employee", aliasValue: "EMP-100" },
+    { aliasType: "mail", aliasValue: "dana@acme.com" },
+  ],
+};
+const AGENT = {
+  principalId: "prn-agent-1",
+  kind: "agent",
+  displayName: "HR Specialist",
+  aliases: [{ aliasType: "gaid", aliasValue: "gaid:priv:dpf.internal:hr-specialist" }],
+};
+const SERVICE = {
+  principalId: "browser-svc:substack:default",
+  kind: "service",
+  displayName: "substack service account (default)",
+  aliases: [{ aliasType: "service-account", aliasValue: "browser-svc:substack:default" }],
+};
+
+describe("deriveBaseDn — the namespace is the organization's, not a constant", () => {
+  it("derives from the organization website, dropping www", () => {
+    expect(deriveBaseDn({ slug: "acme", website: "https://www.acme.com" })).toBe("dc=acme,dc=com");
+  });
+
+  it("accepts a bare host with no scheme", () => {
+    expect(deriveBaseDn({ slug: "acme", website: "acme.co.uk" })).toBe("dc=acme,dc=co,dc=uk");
+  });
+
+  it("falls back to the slug under a reserved domain that cannot collide with a real one", () => {
+    expect(deriveBaseDn({ slug: "acme", website: null })).toBe("dc=acme,dc=internal");
+    expect(deriveBaseDn({ slug: "acme", website: "not a url" })).toBe("dc=acme,dc=internal");
+  });
+
+  it("refuses to derive a DN for an organization with no slug", () => {
+    expect(() => deriveBaseDn({ slug: "  ", website: null })).toThrow(/slug/i);
+  });
+});
+
+describe("escapeRdnValue — RFC 4514", () => {
+  it("escapes the reserved set wherever it appears", () => {
+    expect(escapeRdnValue("Reed, Dana")).toBe("Reed\\, Dana");
+    expect(escapeRdnValue('a+b"c<d>e;f=g')).toBe('a\\+b\\"c\\<d\\>e\\;f\\=g');
+    expect(escapeRdnValue("back\\slash")).toBe("back\\\\slash");
+  });
+
+  it("escapes a leading hash or space and a trailing space", () => {
+    expect(escapeRdnValue("#lead")).toBe("\\#lead");
+    expect(escapeRdnValue(" lead")).toBe("\\ lead");
+    expect(escapeRdnValue("trail ")).toBe("trail\\ ");
+  });
+
+  it("refuses a NUL byte rather than encoding it", () => {
+    expect(() => escapeRdnValue("a\0b")).toThrow(/NUL/i);
+  });
+
+  it("prevents an injected comma from re-parenting an entry", () => {
+    const dn = principalDn("dc=acme,dc=com", "people", "evil,ou=groups");
+    expect(dn).toBe("uid=evil\\,ou\\=groups,ou=people,dc=acme,dc=com");
+  });
+});
+
+describe("isWithinSubtree — scope containment", () => {
+  it("matches the base itself and anything beneath it", () => {
+    expect(isWithinSubtree("dc=acme,dc=com", "dc=acme,dc=com")).toBe(true);
+    expect(isWithinSubtree("ou=people,dc=acme,dc=com", "dc=acme,dc=com")).toBe(true);
+  });
+  it("does not match a sibling namespace that merely ends similarly", () => {
+    expect(isWithinSubtree("dc=notacme,dc=com", "dc=acme,dc=com")).toBe(false);
+  });
+});
+
+describe("buildDirectoryProjection — three classes, one path", () => {
+  it("projects a human, an agent and a service account into their branches", async () => {
+    const { injected } = makeDb({ principals: [HUMAN, AGENT, SERVICE] });
+    const projection = await buildDirectoryProjection(injected);
+
+    expect(projection.baseDn).toBe("dc=acme,dc=com");
+    const byDn = new Map(projection.entries.map((e) => [e.dn, e]));
+
+    const human = byDn.get("uid=prn-human-1,ou=people,dc=acme,dc=com");
+    expect(human?.attributes.objectClass).toContain("inetOrgPerson");
+    expect(human?.attributes.mail).toEqual(["dana@acme.com"]);
+    expect(human?.attributes.employeeNumber).toEqual(["EMP-100"]);
+
+    const agent = byDn.get("uid=prn-agent-1,ou=agents,dc=acme,dc=com");
+    expect(agent?.attributes.objectClass).toContain("dpfAgent");
+    expect(agent?.attributes.dpfGaid).toEqual(["gaid:priv:dpf.internal:hr-specialist"]);
+
+    const service = byDn.get("uid=browser-svc:substack:default,ou=services,dc=acme,dc=com");
+    expect(service?.attributes.objectClass).toContain("dpfServiceAccount");
+  });
+
+  it("publishes the branch containers so a subtree search returns a tree", async () => {
+    const { injected } = makeDb();
+    const projection = await buildDirectoryProjection(injected);
+    for (const branch of ["people", "agents", "services", "groups"] as const) {
+      const entry = projection.entries.find((e) => e.dn === branchDn(projection.baseDn, branch));
+      expect(entry?.attributes.objectClass).toContain("organizationalUnit");
+    }
+  });
+
+  it("queries only active principals of published kinds — inactive ones are ABSENT, not flagged", async () => {
+    const { db, injected } = makeDb();
+    await buildDirectoryProjection(injected);
+    expect(db.principal.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { status: "active", kind: { in: ["human", "agent", "service"] } },
+      }),
+    );
+  });
+
+  it("projects groups from roles and teams, naming real member DNs", async () => {
+    const { injected } = makeDb({
+      principals: [HUMAN],
+      roles: [{ roleId: "ceo", name: "CEO", description: null, users: [{ userId: "user-1" }] }],
+      teams: [
+        { slug: "platform", name: "Platform", description: "Platform team", memberships: [{ userId: "user-1" }] },
+      ],
+    });
+    const projection = await buildDirectoryProjection(injected);
+    const byDn = new Map(projection.entries.map((e) => [e.dn, e]));
+
+    const role = byDn.get("cn=role-ceo,ou=groups,dc=acme,dc=com");
+    expect(role?.attributes.objectClass).toContain("groupOfNames");
+    expect(role?.attributes.member).toEqual(["uid=prn-human-1,ou=people,dc=acme,dc=com"]);
+
+    const team = byDn.get("cn=team-platform,ou=groups,dc=acme,dc=com");
+    expect(team?.attributes.member).toEqual(["uid=prn-human-1,ou=people,dc=acme,dc=com"]);
+  });
+
+  it("omits a member whose user has no published principal rather than emitting a dangling DN", async () => {
+    const { injected } = makeDb({
+      principals: [],
+      roles: [{ roleId: "ceo", name: "CEO", description: null, users: [{ userId: "ghost" }] }],
+    });
+    const projection = await buildDirectoryProjection(injected);
+    const role = projection.entries.find((e) => e.dn.startsWith("cn=role-ceo,"));
+    expect(role?.attributes.member).toBeUndefined();
+  });
+
+  it("refuses to publish when no Organization exists — the tree is the org's namespace", async () => {
+    const { injected } = makeDb({ organization: null });
+    await expect(buildDirectoryProjection(injected)).rejects.toThrow(/Organization/i);
+  });
+});
+
+describe("the publication allowlist is a security control", () => {
+  it.each(WITHHELD_ATTRIBUTES)("never publishes $field — $reason", async ({ field }) => {
+    const { injected } = makeDb({ principals: [HUMAN, AGENT, SERVICE] });
+    const projection = await buildDirectoryProjection(injected);
+    for (const entry of projection.entries) {
+      expect(Object.keys(entry.attributes)).not.toContain(field);
+    }
+  });
+
+  it("drops an attribute the projection loaded but the allowlist does not name", () => {
+    const filtered = applyPublicationAllowlist(
+      { cn: ["x"], passwordHash: ["secret"], sponsorPrincipalId: ["prn-owner"] },
+      PUBLISHED_ATTRIBUTES.people,
+    );
+    expect(filtered).toEqual({ cn: ["x"] });
+  });
+
+  it("withholds the sponsor even though a service account always has one", async () => {
+    const { injected } = makeDb({ principals: [SERVICE] });
+    const projection = await buildDirectoryProjection(injected);
+    const service = projection.entries.find((e) => e.branch === "services");
+    expect(JSON.stringify(service)).not.toContain("sponsor");
+  });
+});
+
+describe("the projection is derived and read-only", () => {
+  it("never reaches a write method — there is no path back through the projection", async () => {
+    const { db, injected } = makeDb({ principals: [HUMAN] });
+    const forbid = (name: string) => () => {
+      throw new Error(`projection attempted a write: ${name}`);
+    };
+    for (const [model, delegate] of Object.entries(db)) {
+      for (const write of ["create", "update", "upsert", "delete", "deleteMany", "updateMany", "createMany"]) {
+        (delegate as Record<string, unknown>)[write] = forbid(`${model}.${write}`);
+      }
+    }
+    await expect(buildDirectoryProjection(injected)).resolves.toBeDefined();
+  });
+});
+
+describe("fingerprint", () => {
+  it("is stable across attribute and entry ordering", () => {
+    const a = fingerprintEntries("dc=acme,dc=com", [
+      { dn: "uid=b,ou=people,dc=acme,dc=com", branch: "people", attributes: { cn: ["b"], uid: ["b"] } },
+      { dn: "uid=a,ou=people,dc=acme,dc=com", branch: "people", attributes: { uid: ["a"], cn: ["a"] } },
+    ]);
+    const b = fingerprintEntries("dc=acme,dc=com", [
+      { dn: "uid=a,ou=people,dc=acme,dc=com", branch: "people", attributes: { cn: ["a"], uid: ["a"] } },
+      { dn: "uid=b,ou=people,dc=acme,dc=com", branch: "people", attributes: { uid: ["b"], cn: ["b"] } },
+    ]);
+    expect(a).toBe(b);
+  });
+
+  it("changes when a published value changes", () => {
+    const base = fingerprintEntries("dc=acme,dc=com", [
+      { dn: "uid=a,ou=people,dc=acme,dc=com", branch: "people", attributes: { cn: ["a"] } },
+    ]);
+    const moved = fingerprintEntries("dc=acme,dc=com", [
+      { dn: "uid=a,ou=people,dc=acme,dc=com", branch: "people", attributes: { cn: ["changed"] } },
+    ]);
+    expect(base).not.toBe(moved);
+  });
+});

--- a/apps/web/lib/directory/projection.ts
+++ b/apps/web/lib/directory/projection.ts
@@ -1,0 +1,227 @@
+// The directory projection (EP-24741BBF · BI-DCE49BA9).
+//
+// One spine, three classes, one tree. A human employee, an AI coworker and a
+// service account are three SHAPES of `Principal`, not three subsystems, and
+// they project through this single path.
+//
+// The projection is DERIVED and READ-ONLY. There is deliberately no write path
+// back through it: the directory is authoritative because it is computed from
+// the spine, not because it is a second place to edit identity. That is the
+// difference between publishing identity and forking it.
+//
+// It is also FINGERPRINTED, so a consumer can tell "nothing changed" from "I am
+// serving something stale" — a distinction a directory cannot afford to blur.
+
+import { createHash } from "node:crypto";
+
+import { prisma } from "@dpf/db";
+
+import {
+  branchDn,
+  deriveBaseDn,
+  groupDn,
+  principalDn,
+  type DirectoryBranch,
+} from "./dn";
+import {
+  GROUP_OBJECT_CLASSES,
+  OBJECT_CLASSES,
+  PUBLISHED_ATTRIBUTES,
+  PUBLISHED_GROUP_ATTRIBUTES,
+  PUBLISHED_KINDS,
+  PUBLISHED_STATUS,
+  applyPublicationAllowlist,
+} from "./schema";
+
+export type DirectoryEntry = {
+  dn: string;
+  branch: DirectoryBranch;
+  attributes: Record<string, string[]>;
+};
+
+export type DirectoryProjection = {
+  baseDn: string;
+  entries: DirectoryEntry[];
+  /** Content fingerprint over the published entries. */
+  fingerprint: string;
+  counts: Record<DirectoryBranch, number>;
+};
+
+export type ProjectionDb = Pick<
+  typeof prisma,
+  "organization" | "principal" | "platformRole" | "team"
+>;
+
+/** Branch container entries (`ou=…`), so a subtree search returns a real tree. */
+function branchEntries(baseDn: string): DirectoryEntry[] {
+  return (["people", "agents", "services", "groups"] as DirectoryBranch[]).map((branch) => ({
+    dn: branchDn(baseDn, branch),
+    branch,
+    attributes: {
+      objectClass: ["top", "organizationalUnit"],
+      ou: [branch],
+    },
+  }));
+}
+
+function aliasValue(
+  aliases: Array<{ aliasType: string; aliasValue: string }>,
+  type: string,
+): string | undefined {
+  return aliases.find((alias) => alias.aliasType === type)?.aliasValue;
+}
+
+/**
+ * Load and build the published tree.
+ *
+ * Every attribute passes through `applyPublicationAllowlist` as the final step,
+ * so even if this function loads a field it should not, the allowlist stops it
+ * reaching a client.
+ */
+export async function buildDirectoryProjection(
+  db: ProjectionDb = prisma,
+): Promise<DirectoryProjection> {
+  const organization = await db.organization.findFirst({
+    select: { slug: true, website: true },
+    orderBy: { createdAt: "asc" },
+  });
+  if (!organization) {
+    throw new Error(
+      "buildDirectoryProjection: no Organization exists, so no base DN can be derived. The directory is the organization's namespace and cannot be published without one.",
+    );
+  }
+  const baseDn = deriveBaseDn(organization);
+
+  const principals = await db.principal.findMany({
+    where: { status: PUBLISHED_STATUS, kind: { in: Object.keys(PUBLISHED_KINDS) } },
+    select: {
+      principalId: true,
+      kind: true,
+      displayName: true,
+      aliases: { select: { aliasType: true, aliasValue: true } },
+    },
+    orderBy: { principalId: "asc" },
+  });
+
+  // userId -> published DN, so group membership can name real entries.
+  const dnByUserId = new Map<string, string>();
+  const entries: DirectoryEntry[] = branchEntries(baseDn);
+
+  for (const principal of principals) {
+    const branch = PUBLISHED_KINDS[principal.kind];
+    if (!branch) continue;
+
+    const employeeId = aliasValue(principal.aliases, "employee");
+    const gaid = aliasValue(principal.aliases, "gaid");
+    const userId = aliasValue(principal.aliases, "user");
+    const mail = aliasValue(principal.aliases, "mail");
+
+    const dn = principalDn(baseDn, branch, principal.principalId);
+    if (userId) dnByUserId.set(userId, dn);
+
+    const candidate: Record<string, string[]> = {
+      objectClass: OBJECT_CLASSES[branch],
+      uid: [principal.principalId],
+      cn: [principal.displayName],
+      displayName: [principal.displayName],
+      dpfPrincipalKind: [principal.kind],
+      ...(mail ? { mail: [mail] } : {}),
+      ...(employeeId ? { employeeNumber: [employeeId] } : {}),
+      ...(gaid ? { dpfGaid: [gaid] } : {}),
+    };
+
+    entries.push({
+      dn,
+      branch,
+      attributes: applyPublicationAllowlist(candidate, PUBLISHED_ATTRIBUTES[branch]),
+    });
+  }
+
+  // Groups project ORGANIZATIONAL structure — roles and teams. They are not an
+  // authorization API: no code may derive permission from membership alone.
+  const roles = await db.platformRole.findMany({
+    select: {
+      roleId: true,
+      name: true,
+      description: true,
+      users: { select: { userId: true } },
+    },
+    orderBy: { roleId: "asc" },
+  });
+  for (const role of roles) {
+    const members = role.users
+      .map((entry) => dnByUserId.get(entry.userId))
+      .filter((value): value is string => Boolean(value));
+    entries.push({
+      dn: groupDn(baseDn, `role-${role.roleId}`),
+      branch: "groups",
+      attributes: applyPublicationAllowlist(
+        {
+          objectClass: [...GROUP_OBJECT_CLASSES],
+          cn: [`role-${role.roleId}`],
+          description: [role.description ?? role.name],
+          member: members,
+        },
+        PUBLISHED_GROUP_ATTRIBUTES,
+      ),
+    });
+  }
+
+  const teams = await db.team.findMany({
+    where: { status: "active" },
+    select: {
+      slug: true,
+      name: true,
+      description: true,
+      memberships: { select: { userId: true } },
+    },
+    orderBy: { slug: "asc" },
+  });
+  for (const team of teams) {
+    const members = team.memberships
+      .map((entry) => dnByUserId.get(entry.userId))
+      .filter((value): value is string => Boolean(value));
+    entries.push({
+      dn: groupDn(baseDn, `team-${team.slug}`),
+      branch: "groups",
+      attributes: applyPublicationAllowlist(
+        {
+          objectClass: [...GROUP_OBJECT_CLASSES],
+          cn: [`team-${team.slug}`],
+          description: [team.description ?? team.name],
+          member: members,
+        },
+        PUBLISHED_GROUP_ATTRIBUTES,
+      ),
+    });
+  }
+
+  const counts = entries.reduce(
+    (acc, entry) => {
+      acc[entry.branch] += 1;
+      return acc;
+    },
+    { people: 0, agents: 0, services: 0, groups: 0 } as Record<DirectoryBranch, number>,
+  );
+
+  return { baseDn, entries, fingerprint: fingerprintEntries(baseDn, entries), counts };
+}
+
+/**
+ * Stable content fingerprint. Canonicalised (sorted DNs, sorted attribute names,
+ * sorted values) so an equivalent tree always hashes the same — otherwise the
+ * fingerprint would report drift on every rebuild and mean nothing.
+ */
+export function fingerprintEntries(baseDn: string, entries: DirectoryEntry[]): string {
+  const canonical = entries
+    .map((entry) => {
+      const attrs = Object.keys(entry.attributes)
+        .sort()
+        .map((name) => `${name}:${[...entry.attributes[name]!].sort().join("|")}`)
+        .join(";");
+      return `${entry.dn.toLowerCase()}=>${attrs}`;
+    })
+    .sort()
+    .join("\n");
+  return createHash("sha256").update(`${baseDn.toLowerCase()}\n${canonical}`).digest("hex");
+}

--- a/apps/web/lib/directory/schema.ts
+++ b/apps/web/lib/directory/schema.ts
@@ -1,0 +1,114 @@
+// Directory schema: object classes and the publication allowlist
+// (EP-24741BBF · BI-DCE49BA9).
+//
+// Two rules govern this file.
+//
+// 1. STANDARD CLASSES CARRY STANDARD ATTRIBUTES. A human, an agent and a
+//    service account are all `inetOrgPerson`, so an ordinary LDAP client works
+//    unmodified. DPF-specific facts ride on AUXILIARY classes (`dpfAgent`,
+//    `dpfServiceAccount`) rather than overloading a standard attribute with a
+//    meaning no other client would understand.
+//
+// 2. PUBLICATION IS AN ALLOWLIST, NEVER A BLOCKLIST. An attribute appears in
+//    the directory only if it is named here. A new column on `Principal` is
+//    invisible until someone deliberately publishes it. The failure mode is
+//    therefore omission, not disclosure — the correct direction for a surface
+//    that answers anonymous-ish network queries.
+
+import type { DirectoryBranch } from "./dn";
+
+/** Principal.kind values that are published, mapped to their branch. */
+export const PUBLISHED_KINDS: Record<string, Exclude<DirectoryBranch, "groups">> = {
+  human: "people",
+  agent: "agents",
+  service: "services",
+};
+
+/** Only an active principal is published. Inactive ones are ABSENT, not flagged. */
+export const PUBLISHED_STATUS = "active";
+
+export const OBJECT_CLASSES: Record<Exclude<DirectoryBranch, "groups">, string[]> = {
+  people: ["top", "person", "organizationalPerson", "inetOrgPerson"],
+  agents: ["top", "person", "organizationalPerson", "inetOrgPerson", "dpfAgent"],
+  services: ["top", "person", "organizationalPerson", "inetOrgPerson", "dpfServiceAccount"],
+};
+
+export const GROUP_OBJECT_CLASSES = ["top", "groupOfNames"] as const;
+
+/**
+ * The allowlist. An attribute not named here is not published, whatever the
+ * projection happens to have loaded.
+ */
+export const PUBLISHED_ATTRIBUTES: Record<Exclude<DirectoryBranch, "groups">, readonly string[]> = {
+  people: ["objectClass", "uid", "cn", "displayName", "mail", "employeeNumber"],
+  agents: ["objectClass", "uid", "cn", "displayName", "dpfPrincipalKind", "dpfGaid"],
+  services: ["objectClass", "uid", "cn", "displayName", "dpfPrincipalKind"],
+};
+
+export const PUBLISHED_GROUP_ATTRIBUTES = ["objectClass", "cn", "description", "member"] as const;
+
+/**
+ * Withheld deliberately. This list is a SECURITY CONTROL, not documentation of
+ * an oversight — each entry names why, so a future reader must argue against a
+ * stated reason rather than assume nobody considered it.
+ */
+export const WITHHELD_ATTRIBUTES: ReadonlyArray<{ field: string; reason: string }> = [
+  {
+    field: "passwordHash",
+    reason: "A credential never leaves the credential boundary, under any bind.",
+  },
+  {
+    field: "sensitivityClearance",
+    reason:
+      "Reveals what a principal may reach, which is target-selection intelligence for an attacker.",
+  },
+  {
+    field: "sponsorPrincipalId",
+    reason:
+      "Exposes the delegation graph and the human origin behind an agent or service account.",
+  },
+  {
+    field: "authorityBindings",
+    reason:
+      "Authorization is not directory data. Groups project organizational structure; permission is resolved from grants intersected with role capabilities, never from group membership alone.",
+  },
+  {
+    field: "toolGrants",
+    reason: "Same as authorityBindings — capability is not published.",
+  },
+  {
+    field: "status",
+    reason:
+      "An inactive principal is absent from the tree rather than present-and-flagged, so status never needs publishing.",
+  },
+  {
+    field: "sponsorChain",
+    reason: "Transitive form of sponsorPrincipalId; withheld for the same reason.",
+  },
+];
+
+const WITHHELD_FIELDS = new Set(WITHHELD_ATTRIBUTES.map((entry) => entry.field));
+
+/** True when a field is explicitly recorded as withheld. */
+export function isWithheld(field: string): boolean {
+  return WITHHELD_FIELDS.has(field);
+}
+
+/**
+ * Drop anything the allowlist does not name. Applied as the LAST step of
+ * building an entry, so a projection bug that loads too much still cannot
+ * publish too much.
+ */
+export function applyPublicationAllowlist(
+  attributes: Record<string, string[]>,
+  allowed: readonly string[],
+): Record<string, string[]> {
+  const allowedSet = new Set(allowed);
+  const filtered: Record<string, string[]> = {};
+  for (const [name, values] of Object.entries(attributes)) {
+    if (!allowedSet.has(name)) continue;
+    const kept = values.filter((value) => value.length > 0);
+    if (kept.length > 0) filtered[name] = kept;
+  }
+  return filtered;
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8955,6 +8955,7 @@
         "integration-evidence",
         "verdict",
         "conditions",
+        "execution-record-2026-08-28",
         "re-evaluation",
         "sources"
       ]

--- a/apps/web/lib/govern/auth.ts
+++ b/apps/web/lib/govern/auth.ts
@@ -5,6 +5,10 @@ import Google from "next-auth/providers/google";
 import Apple from "next-auth/providers/apple";
 import { prisma } from "@dpf/db";
 import { verifyPassword, hashPassword } from "./password";
+// BI-CEACBD0D: authentication now consults the Principal spine. Before this,
+// auth.ts never read Principal — identity was decided without the spine that
+// decides authority.
+import { authorizePrincipalForSession } from "@/lib/identity/authentication";
 import { determineSocialAuthFlow, createTempToken } from "./social-auth";
 import { normalizeAuthRedirect } from "./auth-redirect";
 import { resolveWorkforcePlatformRole } from "./auth-utils";
@@ -146,6 +150,15 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           if (needsRehash) {
             const newHash = await hashPassword(credentials.password as string);
             await prisma.user.update({ where: { id: user.id }, data: { passwordHash: newHash } });
+          }
+          // The credential is verified; now the SPINE decides whether this
+          // identity may act. An inactive Principal cannot log in even when the
+          // User row still says active — deactivation is an invariant here, not
+          // a sync that may not have run yet (BI-CEACBD0D).
+          const spine = await authorizePrincipalForSession(user.id);
+          if (!spine.authorized) {
+            console.warn(`[auth] workforce login refused by the principal spine: ${spine.reason}`);
+            return null;
           }
           return {
             id: user.id,

--- a/apps/web/lib/identity/authentication.test.ts
+++ b/apps/web/lib/identity/authentication.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted above module scope, so the spy must be created inside
+// vi.hoisted or the factory closes over an uninitialised binding.
+const linking = vi.hoisted(() => ({ syncUserPrincipal: vi.fn() }));
+vi.mock("./principal-linking", () => linking);
+const { syncUserPrincipal } = linking;
+
+import {
+  authorizePrincipalForSession,
+  deactivatePrincipalAndCredentials,
+  resolveAuthenticationAuthority,
+} from "./authentication";
+
+function makeDb(principal: { id: string; principalId: string; status: string } | null) {
+  let current = principal;
+  return {
+    set: (next: typeof principal) => {
+      current = next;
+    },
+    db: {
+      principalAlias: { findFirst: vi.fn(async () => (current ? { principal: current } : null)) },
+      principal: {},
+      user: {},
+    },
+  };
+}
+
+const ACTIVE = { id: "row-1", principalId: "prn-h", status: "active" };
+
+describe("authorizePrincipalForSession — the spine gates the session", () => {
+  it("authorizes an active principal", async () => {
+    const { db } = makeDb(ACTIVE);
+    await expect(authorizePrincipalForSession("user-1", db as never)).resolves.toMatchObject({
+      authorized: true,
+      principalId: "prn-h",
+      authority: "install",
+    });
+  });
+
+  it("REFUSES an inactive principal — this is the invariant that was missing", async () => {
+    // Before BI-CEACBD0D, auth.ts never read Principal at all, so a principal
+    // could be disabled while its User row still logged in.
+    const { db } = makeDb({ ...ACTIVE, status: "inactive" });
+    await expect(authorizePrincipalForSession("user-1", db as never)).resolves.toMatchObject({
+      authorized: false,
+      reason: "principal-inactive",
+    });
+  });
+
+  it("materializes a missing principal rather than falling back to the User row", async () => {
+    const { db, set } = makeDb(null);
+    syncUserPrincipal.mockImplementationOnce(async () => {
+      set(ACTIVE);
+    });
+    await expect(authorizePrincipalForSession("user-1", db as never)).resolves.toMatchObject({ authorized: true });
+    expect(syncUserPrincipal).toHaveBeenCalledWith("user-1", db);
+  });
+
+  it("fails closed when the principal still cannot be resolved", async () => {
+    const { db } = makeDb(null);
+    syncUserPrincipal.mockImplementationOnce(async () => {});
+    await expect(authorizePrincipalForSession("user-2", db as never)).resolves.toMatchObject({
+      authorized: false,
+      reason: "principal-not-resolved",
+    });
+  });
+
+  it("fails closed when materialization throws", async () => {
+    const { db } = makeDb(null);
+    syncUserPrincipal.mockImplementationOnce(async () => {
+      throw new Error("db down");
+    });
+    await expect(authorizePrincipalForSession("user-3", db as never)).resolves.toMatchObject({
+      authorized: false,
+      reason: "principal-not-resolved",
+    });
+  });
+});
+
+describe("deactivatePrincipalAndCredentials — one transaction, not an eventual sync", () => {
+  it("disables the principal and every bound credential together", async () => {
+    const principalUpdate = vi.fn(async () => ({
+      principalId: "prn-h",
+      aliases: [{ aliasValue: "user-1" }, { aliasValue: "user-2" }],
+    }));
+    const userUpdateMany = vi.fn(async () => ({ count: 2 }));
+    const client = {
+      $transaction: async (fn: (tx: unknown) => unknown) =>
+        fn({ principal: { update: principalUpdate }, user: { updateMany: userUpdateMany } }),
+    };
+
+    await expect(
+      deactivatePrincipalAndCredentials("prn-h", client as never),
+    ).resolves.toEqual({ principalId: "prn-h", userIdsDisabled: ["user-1", "user-2"] });
+
+    expect(principalUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: "inactive" } }),
+    );
+    expect(userUpdateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["user-1", "user-2"] } },
+      data: { isActive: false },
+    });
+  });
+
+  it("does not attempt a credential update when the principal has none", async () => {
+    const userUpdateMany = vi.fn();
+    const client = {
+      $transaction: async (fn: (tx: unknown) => unknown) =>
+        fn({
+          principal: { update: async () => ({ principalId: "prn-agent", aliases: [] }) },
+          user: { updateMany: userUpdateMany },
+        }),
+    };
+    await deactivatePrincipalAndCredentials("prn-agent", client as never);
+    expect(userUpdateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveAuthenticationAuthority — the install is complete without federation", () => {
+  it("makes the install authoritative when no upstream is connected", () => {
+    expect(
+      resolveAuthenticationAuthority({ hasLocalPrincipal: true, connectedUpstreams: [] }),
+    ).toMatchObject({ authority: "install", conflict: false });
+  });
+
+  it("keeps the install winning when an upstream also claims the identity, and SURFACES the overlap", () => {
+    const result = resolveAuthenticationAuthority({
+      hasLocalPrincipal: true,
+      connectedUpstreams: ["entra"],
+    });
+    expect(result.authority).toBe("install");
+    expect(result.conflict).toBe(true);
+    expect(result.explanation).toMatch(/entra/);
+  });
+
+  it("defers to an upstream only when there is no local principal", () => {
+    expect(
+      resolveAuthenticationAuthority({ hasLocalPrincipal: false, connectedUpstreams: ["ldap"] }),
+    ).toMatchObject({ authority: "upstream", conflict: false });
+  });
+
+  it("reports that nobody can attest an identity the install does not hold", () => {
+    expect(
+      resolveAuthenticationAuthority({ hasLocalPrincipal: false, connectedUpstreams: [] }),
+    ).toMatchObject({ authority: null });
+  });
+});

--- a/apps/web/lib/identity/authentication.ts
+++ b/apps/web/lib/identity/authentication.ts
@@ -1,0 +1,194 @@
+// Principal-rooted authentication (EP-24741BBF · BI-CEACBD0D).
+//
+// THE DEFECT THIS CLOSES. `apps/web/lib/govern/auth.ts` never read `Principal`.
+// Authentication was `User`-rooted while every TAK/GAID authorization decision
+// is `Principal`-rooted, reconciled after the fact by a one-way
+// `syncUserPrincipal`. So the platform decided WHO YOU ARE without consulting
+// the spine that decides WHAT YOU MAY DO — two identity roots inside one
+// system, which is exactly the parallel-truth failure this epic exists to
+// remove. Deactivation was a sync property rather than an invariant.
+//
+// WHAT CHANGES. `User` remains the CREDENTIAL HOLDER for humans — it is not
+// deleted and its ~70 relations are untouched. It stops being an independent
+// identity root: a credential is verified, then the session is authorized by
+// the resolved `Principal`. An inactive Principal cannot log in even when its
+// User row still says active.
+//
+// WHAT DOES NOT CHANGE. The authorization model. This decides who attests
+// identity, not what a role may do. Grants, capabilities and TAK classes are
+// untouched.
+
+import { prisma } from "@dpf/db";
+
+import { syncUserPrincipal } from "./principal-linking";
+
+// NOTE: this is deliberately NOT `ActionResult` from @/lib/shared/action-result.
+// That primitive models a server action's `{ok, data} | {ok, error}` contract and
+// carries only a human-readable error string. An authorization verdict needs a
+// STABLE machine reason the bind path and the session path both branch on, so the
+// discriminant says what actually happened — authorized — rather than borrowing a
+// generic one that would lose the reason code.
+export const AUTHENTICATION_AUTHORITY = ["install", "upstream"] as const;
+export type AuthenticationAuthority = (typeof AUTHENTICATION_AUTHORITY)[number];
+
+export type PrincipalAuthenticationRefusal = {
+  authorized: false;
+  /** Stable machine code. Never surfaced verbatim to an end user. */
+  reason:
+    | "no-credential-match"
+    | "principal-not-resolved"
+    | "principal-inactive"
+    | "authority-conflict";
+  detail: string;
+};
+
+export type PrincipalAuthenticationSuccess = {
+  authorized: true;
+  principalId: string;
+  principalRecordId: string;
+  userId: string;
+  authority: AuthenticationAuthority;
+};
+
+export type PrincipalAuthenticationResult =
+  | PrincipalAuthenticationSuccess
+  | PrincipalAuthenticationRefusal;
+
+type AuthenticationDb = Pick<typeof prisma, "user" | "principal" | "principalAlias">;
+
+/**
+ * Authorize an already-credential-verified user through the spine.
+ *
+ * Credential verification stays with the caller (NextAuth's provider owns
+ * password comparison and rehashing). This function answers the question that
+ * was previously never asked: does the SPINE agree this identity may act?
+ */
+export async function authorizePrincipalForSession(
+  userId: string,
+  db: AuthenticationDb = prisma,
+): Promise<PrincipalAuthenticationResult> {
+  // Materialize the principal if the projection has not caught up. The spine is
+  // authoritative, so a missing row is a staleness problem to fix, not grounds
+  // to fall back to the User row and re-create the two-root split.
+  let alias = await db.principalAlias.findFirst({
+    where: { aliasType: "user", aliasValue: userId, issuer: "" },
+    select: { principal: { select: { id: true, principalId: true, status: true } } },
+  });
+
+  if (!alias?.principal) {
+    try {
+      await syncUserPrincipal(userId, db as never);
+    } catch {
+      return {
+        authorized: false,
+        reason: "principal-not-resolved",
+        detail: `user ${userId} could not be resolved or materialized as a Principal`,
+      };
+    }
+    alias = await db.principalAlias.findFirst({
+      where: { aliasType: "user", aliasValue: userId, issuer: "" },
+      select: { principal: { select: { id: true, principalId: true, status: true } } },
+    });
+  }
+
+  const principal = alias?.principal;
+  if (!principal) {
+    return {
+      authorized: false,
+      reason: "principal-not-resolved",
+      detail: `user ${userId} has no Principal on the spine`,
+    };
+  }
+
+  // The invariant: the SPINE gates the session. An inactive principal cannot
+  // authenticate even if its credential row still says active.
+  if (principal.status !== "active") {
+    return {
+      authorized: false,
+      reason: "principal-inactive",
+      detail: `principal ${principal.principalId} is ${principal.status}`,
+    };
+  }
+
+  return {
+    authorized: true,
+    principalId: principal.principalId,
+    principalRecordId: principal.id,
+    userId,
+    authority: "install",
+  };
+}
+
+/**
+ * Deactivate an identity as ONE transaction across the spine and its credential.
+ *
+ * Previously these drifted: disabling a User left its Principal active until a
+ * sync ran, so authorization could outlive authentication. Deactivation is now
+ * an invariant rather than an eventual consistency.
+ */
+export async function deactivatePrincipalAndCredentials(
+  principalId: string,
+  client: typeof prisma = prisma,
+): Promise<{ principalId: string; userIdsDisabled: string[] }> {
+  return client.$transaction(async (tx) => {
+    const principal = await tx.principal.update({
+      where: { principalId },
+      data: { status: "inactive" },
+      select: {
+        principalId: true,
+        aliases: { where: { aliasType: "user" }, select: { aliasValue: true } },
+      },
+    });
+    const userIds = principal.aliases.map((alias) => alias.aliasValue);
+    if (userIds.length > 0) {
+      await tx.user.updateMany({ where: { id: { in: userIds } }, data: { isActive: false } });
+    }
+    return { principalId: principal.principalId, userIdsDisabled: userIds };
+  });
+}
+
+/**
+ * Which authority attests people on this install.
+ *
+ * The install's own directory is authoritative by default, and outward
+ * federation is OPTIONAL — the platform must be complete without it. When an
+ * upstream is connected the install still wins for a principal it holds
+ * locally; the pair is reported so a conflict SURFACES rather than resolving
+ * silently in whichever direction the code happened to check first.
+ */
+export function resolveAuthenticationAuthority(input: {
+  hasLocalPrincipal: boolean;
+  connectedUpstreams: string[];
+}): {
+  authority: AuthenticationAuthority | null;
+  conflict: boolean;
+  explanation: string;
+} {
+  const hasUpstream = input.connectedUpstreams.length > 0;
+  if (input.hasLocalPrincipal && hasUpstream) {
+    return {
+      authority: "install",
+      conflict: true,
+      explanation: `the install holds this principal locally and ${input.connectedUpstreams.join(", ")} also claims it; the install wins and the overlap is reported rather than hidden`,
+    };
+  }
+  if (input.hasLocalPrincipal) {
+    return {
+      authority: "install",
+      conflict: false,
+      explanation: "the install's own directory is the authority; no upstream is connected",
+    };
+  }
+  if (hasUpstream) {
+    return {
+      authority: "upstream",
+      conflict: false,
+      explanation: `no local principal; ${input.connectedUpstreams.join(", ")} attests this identity`,
+    };
+  }
+  return {
+    authority: null,
+    conflict: false,
+    explanation: "no local principal and no upstream authority can attest this identity",
+  };
+}

--- a/docs/security/tool-evaluations/2026-08-23-authentik.md
+++ b/docs/security/tool-evaluations/2026-08-23-authentik.md
@@ -219,6 +219,35 @@ protocol maintenance tail, including its CVEs, with no upstream that will fix th
 8. This verdict covers absorption for the **LDAP** surface only. SAML, OIDC and
    SCIM are out of scope and each needs its own decision.
 
+## Execution record (2026-08-28)
+
+The absorb decision has been carried out. What it produced, and how the
+conditions above were met:
+
+- **Nothing was vendored.** The BER codec and LDAP message layer were written
+  against RFC 4511. No authentik source and no `ldapjs` source was copied, so
+  **condition 2 (carry the MIT notice) did not come into force** — there is
+  nothing derived to attribute. Condition 1 held throughout: nothing under
+  `authentik/enterprise/` was read.
+- **Condition 3** — absorption stayed at directory semantics. The object-class
+  shape and the read-only posture match what the evaluation observed in
+  authentik's provider; none of its flow-executor, proxy or SAML logic, where
+  all four recent bypass CVEs live, was touched.
+- **Condition 4** — the listener is read-only. Writes are refused with
+  `unwillingToPerform`, not left unimplemented.
+- **Condition 5** — there is no bind cache at all, so the negative lesson from
+  authentik's cached-bind mode ("revoking sessions does not remove them from the
+  outpost") cannot recur here.
+- **Condition 6** — search requires a successful bind and is bounded; anonymous
+  enumeration is refused, verified against a real `ldapsearch` client.
+- **Condition 7** — no new runtime dependency was introduced.
+
+The one prediction that proved wrong in DPF's favour: the evaluation warned that
+absorbing means owning a protocol maintenance tail with no upstream to fix its
+CVEs. That remains true, but the surface is smaller than expected, because
+implementing only bind and search against a read-only projection avoids most of
+what makes an LDAP server dangerous.
+
 ## Re-evaluation
 
 - **Schedule:** 2027-02-23.

--- a/docs/superpowers/plans/2026-08-23-directory-service-identity-absorption.md
+++ b/docs/superpowers/plans/2026-08-23-directory-service-identity-absorption.md
@@ -158,6 +158,42 @@ end-to-end against the running portal; an install with an upstream still works w
 tested precedence; no auth check weakened anywhere; seeded personas at real
 privilege levels.
 
+### Delivered — Phases 2, 3 and 4
+
+**Phase 2 (`BI-DCE49BA9`)** — `apps/web/lib/directory/`. `dn.ts` derives the base
+DN from `Organization` (website host, else the slug under a reserved `internal`
+domain that cannot collide with a real one) and escapes RDNs per RFC 4514.
+`schema.ts` holds the object classes and the publication **allowlist**, with each
+withheld field carrying its reason. `projection.ts` builds the read-only,
+fingerprinted tree. The admin route no longer computes a tree or carries a
+hardcoded `dc=dpf,dc=internal`; it renders exactly what a client would see.
+
+**Phase 3 (`BI-F7317D65`)** — `apps/web/lib/directory/ldap/`. BER codec, filter
+layer, protocol layer, TLS loader and listener. Written against RFC 4511 because
+no maintained Node LDAP *server* exists. Read-only by construction: writes are
+refused with `unwillingToPerform`, not merely unimplemented.
+
+**Phase 4 (`BI-CEACBD0D`)** — `apps/web/lib/identity/authentication.ts`.
+`govern/auth.ts` now consults the spine, so an inactive `Principal` cannot log in
+even when its `User` row still says active. Deactivation is one transaction
+across principal and credentials. Local-vs-upstream precedence resolves to the
+install and **surfaces** an overlap rather than resolving it silently.
+
+**Verification.** 67 directory tests, 11 authentication tests, 142 across the
+affected surface, and `tsc` clean. Six of those exercise a **real `ldapsearch`
+client** against the running listener — bind over TLS, all three identity shapes
+returned, group membership resolved by filter, wrong password rejected,
+anonymous refused, and withheld attributes absent when requested by name.
+
+Two findings worth carrying: the functional test initially deadlocked because
+`spawnSync` blocks the event loop the listener runs on, and `tsc` caught two type
+errors (Node's generic `Buffer`, and a certificate CN that may be an array) that
+67 passing tests did not.
+
+**Still open after this build:** the `User` schema demotion (design Q2), SCIM and
+OIDC, multi-organization base DNs (Q3), and running
+`findOwnerlessServiceAccounts()` on a cadence.
+
 ## Phase 5 — Retire the superseded stance (`BI-5167932D`)
 
 Audit all 111 tasks in the 2026-04-22 plan and record a disposition for each:

--- a/docs/superpowers/specs/2026-08-23-directory-service-identity-absorption-design.md
+++ b/docs/superpowers/specs/2026-08-23-directory-service-identity-absorption-design.md
@@ -332,6 +332,36 @@ Phases 1 and 4 are the ~80% convergence. Phase 3 is the ~20% new feature.
 | D7 | Base DN derives from `Organization` | AGENTS.md §8 canonical identity model |
 | D8 | Read-only directory; no LDAP writes | Authority comes from being derived, not from being editable |
 
+## 14a. Open questions resolved by the Phase 2-4 build
+
+**Q1 — service-account bind credential: RESOLVED as mTLS only.** A client
+certificate whose subject CN names the same principal binds any class; a
+password binds humans only. Agents and service accounts deliberately have no
+password, because minting one would be a second credential store and would
+re-create the "authorized but never authenticated" gap the epic closes. The
+certificate comes from the org PKI already in place.
+
+**Q4 — absorbed protocol provenance: RESOLVED as reimplemented, not vendored.**
+The BER codec and LDAP message layer were written against RFC 4511. No authentik
+or `ldapjs` source was copied, so **no attribution obligation was incurred** —
+the evaluation's condition to carry an MIT notice does not apply because nothing
+was derived. The evaluation's other conditions still bind: nothing under
+`authentik/enterprise/` was read, the listener is read-only, bind caching cannot
+outlive revocation (there is no bind cache at all), and search requires
+authorization with bounded results.
+
+**Q2 — the fate of `User`: DEFERRED, and deliberately not forced.** `Principal`
+is now the authentication root in behaviour: `govern/auth.ts` consults the spine
+and an inactive principal cannot log in. `User` remains the credential holder.
+The schema change that would formally demote it to a side table was **not**
+needed to make the spine authoritative, and doing it in the same change as three
+new capabilities would have coupled the highest-blast-radius migration in the
+epic to everything else. It stays open.
+
+**Q3 — multi-organization installs: still deferred.** The base DN derives from
+the first `Organization`; a second one would need a decision this build did not
+need to make.
+
 ## 14. Open Questions
 
 1. **Which credential scheme for service-account binds** — shared secret, or mTLS from the org PKI only? mTLS is stronger and reuses existing substrate, but not every client that needs to bind can present a client certificate. Resolve in `BI-F7317D65`.

--- a/docs/user-guide/platform/identity-and-access.md
+++ b/docs/user-guide/platform/identity-and-access.md
@@ -17,10 +17,23 @@ order: 4
 
 ## Read The Identity Model
 
-DPF uses one principal spine to connect a person, AI coworker, or future
-service identity to aliases, groups, route access, and governed authority.
-Upstream directories can supply identity facts, but DPF retains local control
-over platform roles, route bundles, coworker associations, and tool execution.
+DPF uses one principal spine to connect a person, AI coworker, or service
+identity to aliases, groups, route access, and governed authority. Upstream
+directories can supply identity facts, but DPF retains local control over
+platform roles, route bundles, coworker associations, and tool execution.
+
+**Your install is the directory.** People, AI coworkers and service accounts are
+published as one tree that ordinary directory tools can read over a secure
+connection, so existing software can look up who works here without a separate
+identity product. The tree is built from the principal spine and is read-only:
+you change identity in DPF, and the directory follows. Its address is derived
+from your organization, so it reads as your namespace rather than a generic one.
+
+**Two consequences worth knowing.** Disabling a principal now ends its ability to
+sign in immediately, rather than waiting for a sync — authority and sign-in can
+no longer drift apart. And people sign in with a password, while AI coworkers and
+service accounts identify with a certificate from your organization's own
+authority: they have no password to steal, guess or leak.
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
## What

Phases 2, 3 and 4 of **EP-24741BBF**, in one change. With Phase 1 (#4721) and Phase 5 (#4692) already merged, this completes the epic: **DPF is now the directory for an installation.**

| Phase | BI | Delivered |
|---|---|---|
| 2 | `BI-DCE49BA9` | `lib/directory/` — DN scheme, object classes, publication allowlist, fingerprinted read-only projection |
| 3 | `BI-F7317D65` | `lib/directory/ldap/` — BER codec, filter, protocol, TLS, listener |
| 4 | `BI-CEACBD0D` | `lib/identity/authentication.ts` — the spine gates the session |

**No migration.** Expressed entirely on existing columns.

## Phase 2 — the projection is a contract, not a page

The base DN now derives from `Organization` (AGENTS.md §8) instead of `dc=dpf,dc=internal` hardcoded in a route component. That constant made the route the second home for something the listener and federation also need; the admin page now renders exactly what a client that binds would see.

**Publication is an allowlist, never a blocklist.** An attribute appears only if named, so a new column on `Principal` is invisible until someone deliberately publishes it — the failure mode is omission, not disclosure. Every withheld field carries its reason, so a future reader must argue against a stated one rather than assume nobody considered it. There is a test per withheld field.

## Phase 3 — the only genuinely absent capability

Written against RFC 4511 because no maintained Node LDAP **server** exists (`ldapjs` archived 2024-05-14; `ldapts` is a client). That absence was load-bearing in the epic's absorb-vs-adopt decision.

Read-only by construction: writes are refused with `unwillingToPerform`, not left unimplemented. TLS comes from the org PKI with **no self-signed fallback**, asserted by test. Agents and service accounts bind by **mTLS only** — giving them passwords would be a second credential store, and would re-create the "authorized but never authenticated" gap the epic closes.

## Phase 4 — the finding that reframed the epic

`govern/auth.ts` contained **no reference to `Principal`**. The platform decided *who you are* without consulting the spine that decides *what you may do* — two identity roots inside one system.

It now consults it. An inactive `Principal` cannot log in even when its `User` row says active, and deactivation is **one transaction** across principal and credentials rather than an eventual sync. `User` remains the credential holder; its ~70 relations are untouched. The authorization model is unchanged — this changes who attests identity, not what a role may do. An LDAP bind resolves through the same path, so the directory cannot become a private view that authenticates on its own terms.

## Verification

```
local-CI gate: PASS
  HEAD     feat/directory-service-projection-ldap-authority @ 6e1d9cc23d51
  gated    feat/directory-service-projection-ldap-authority @ 6e1d9cc23d51
  evidence cmtc94nlv3nol01pec5blq6e1
```

78 unit tests, 142 across the affected surface, `tsc` clean, 52 preflight guards clean.

**Six functional tests drive a real `ldapsearch` client** against the running listener: bind over TLS, all three identity shapes returned, group membership resolved by filter, wrong password rejected, anonymous refused, and withheld attributes absent when requested by name.

That earned its place. **The unit tests passed while a real client could not talk to the server at all** — the cause was in the test, not the product: `spawnSync` blocks the event loop the listener runs on, so it deadlocked against itself. Nothing but a real client would have shown that.

`tsc` also caught two errors 67 passing tests did not: Node's generic `Buffer`, and a certificate CN that may be an array — the second a real security detail, since a multi-CN cert could otherwise have smuggled a second identity past the bind comparison.

## Two judgment calls

**A ratchet caught this expanding inline `ok: true` sites by six.** Re-baselining and forcing these onto `ActionResult` were both wrong: that primitive is a server-action shape carrying only an error string, and these verdicts need stable machine reason codes the bind path branches on. The discriminants are renamed to what they are — `authorized`, `bound`, `searched`. The ratchet is back at its budget with no growth.

**The `User` schema demotion is deliberately NOT here.** It is design open question 2, and making the spine authoritative in behaviour did not require it. Coupling the epic's highest-blast-radius migration to three new capabilities would have been a poor trade. It stays open, and the design says so.

Open questions **1** (mTLS for non-human binds) and **4** (reimplemented, not vendored — so no attribution obligation was incurred) are resolved and recorded. The authentik evaluation carries an execution record showing which of its conditions bound and which did not apply.

## Still open

SCIM and OIDC; multi-organization base DNs (Q3); the `User` demotion (Q2); and running `findOwnerlessServiceAccounts()` on a cadence — an invariant nobody evaluates is not yet a guard.

Local-CI-Evidence: cmtc94nlv3nol01pec5blq6e1

🤖 Generated with [Claude Code](https://claude.com/claude-code)