### PR TITLE
fix(build-studio): an unreviewable design is not a rejected one (BI-D33F968A)

### DIFF
--- a/apps/web/lib/build/ideate-on-approval.ts
+++ b/apps/web/lib/build/ideate-on-approval.ts
@@ -626,6 +626,10 @@ export async function dispatchApprovedIdeateBuilds(params: {
 /** Bounded rounds for the design-review fix loop. Operator-tunable. */
 export const DESIGN_FIX_MAX_ROUNDS = Number(process.env.DESIGN_FIX_MAX_ROUNDS) || 2;
 
+/** Bounded re-reviews when the reviewers themselves cannot return a verdict
+ *  (BI-D33F968A). Separate from the fix rounds: these attempts are not repairs. */
+export const DESIGN_REVIEW_RETRY_LIMIT = Number(process.env.DESIGN_REVIEW_RETRY_LIMIT) || 2;
+
 type DesignReviewVerdict =
   | { decision?: string; issues?: Array<{ severity: string; description: string }> }
   | null;
@@ -701,7 +705,22 @@ export async function dispatchDesignReviewFixLoop(params: {
     // regeneration that never ran is NOT self-repair exhausted, and must not be
     // treated as one.
     let regenerated = false;
+    let reviewRetries = 0;
     while (review?.decision === "fail" && round < DESIGN_FIX_MAX_ROUNDS) {
+      // BI-D33F968A: a review that could not be completed says nothing about the
+      // design. Regenerating against "Both review agents failed to respond"
+      // cannot fix anything — it just spends the budget and ends in escalation
+      // (live repro FB-05946F96). Re-run the reviewer instead, and only count a
+      // round once a real verdict exists.
+      if ((review as { reviewIncomplete?: boolean } | null)?.reviewIncomplete === true) {
+        if (reviewRetries >= DESIGN_REVIEW_RETRY_LIMIT) break;
+        reviewRetries += 1;
+        await log(`Design review could not be completed — re-reviewing (attempt ${reviewRetries}/${DESIGN_REVIEW_RETRY_LIMIT}); the design is not at fault.`);
+        await executeTool("reviewDesignDoc", { buildId }, userId, { featureBuildId: buildId, suppressDesignReviewAutoRepair: true });
+        const retried = await prisma.featureBuild.findUnique({ where: { buildId }, select: { designReview: true } });
+        review = retried?.designReview as DesignReviewVerdict;
+        continue;
+      }
       round += 1;
       await log(`Design review failed — regenerating (round ${round}/${DESIGN_FIX_MAX_ROUNDS}) against ${review.issues?.length ?? 0} issue(s)`);
       const feedback = formatPlanReviewFeedback(review.issues ?? []);
@@ -739,11 +758,15 @@ export async function dispatchDesignReviewFixLoop(params: {
     const outcomeKind = resolveReviewFixOutcome({
       reviewFailed: review?.decision === "fail",
       regenerated,
+      reviewIncomplete: (review as { reviewIncomplete?: boolean } | null)?.reviewIncomplete === true,
     });
     if (outcomeKeepsBuildRecoverable(outcomeKind)) {
       await log(
-        `Design repair could not regenerate a design in ${round} round(s) — no engine produced one. `
-        + "Leaving the build recoverable; the existing design and review are kept.",
+        outcomeKind === "blocked-review-incomplete"
+          ? "No reviewer could complete a design review, so nothing is known about this design. "
+            + "Leaving the build recoverable; the design is kept and untouched."
+          : `Design repair could not regenerate a design in ${round} round(s) — no engine produced one. `
+            + "Leaving the build recoverable; the existing design and review are kept.",
       );
       return { kind: outcomeKind, rounds: round };
     }

--- a/apps/web/lib/build/review-fix-outcome.test.ts
+++ b/apps/web/lib/build/review-fix-outcome.test.ts
@@ -45,6 +45,33 @@ describe("shared across both pre-build phases", () => {
   });
 });
 
+// BI-D33F968A — live repro FB-05946F96: both reviewers failed to respond, the
+// handler fabricated decision:"fail" with "Both review agents failed to
+// respond", and the loop spent both repair rounds regenerating a design nobody
+// had read before escalating and abandoning the build.
+describe("an unreviewable artifact is not a rejected one", () => {
+  it("does not escalate when no reviewer completed a verdict", () => {
+    expect(resolveReviewFixOutcome({ reviewFailed: true, regenerated: true, reviewIncomplete: true }))
+      .toBe("blocked-review-incomplete");
+    expect(outcomeKeepsBuildRecoverable("blocked-review-incomplete")).toBe(true);
+  });
+
+  it("still escalates a design that was genuinely reviewed and could not be repaired", () => {
+    expect(resolveReviewFixOutcome({ reviewFailed: true, regenerated: true, reviewIncomplete: false }))
+      .toBe("escalated-after-rounds");
+  });
+
+  it("treats an absent marker as a real verdict, so existing behaviour is unchanged", () => {
+    expect(resolveReviewFixOutcome({ reviewFailed: true, regenerated: true }))
+      .toBe("escalated-after-rounds");
+  });
+
+  it("reports repaired when the review passed, marker or not", () => {
+    expect(resolveReviewFixOutcome({ reviewFailed: false, regenerated: true, reviewIncomplete: true }))
+      .toBe("repaired");
+  });
+});
+
 describe("outcomeKeepsBuildRecoverable", () => {
   it("keeps the build recoverable only for the no-regeneration case", () => {
     expect(outcomeKeepsBuildRecoverable("blocked-no-regeneration")).toBe(true);

--- a/apps/web/lib/build/review-fix-outcome.ts
+++ b/apps/web/lib/build/review-fix-outcome.ts
@@ -26,6 +26,8 @@
 // dispatch stack.
 
 export type ReviewFixOutcomeKind =
+  /** No reviewer returned a usable verdict, so nothing is known about the work. */
+  | "blocked-review-incomplete"
   /** The review passed after repair. */
   | "repaired"
   /** Repair ran and the work still fails — a human decision is genuinely needed. */
@@ -45,12 +47,19 @@ export type ReviewFixOutcomeKind =
 export function resolveReviewFixOutcome(args: {
   reviewFailed: boolean;
   regenerated: boolean;
+  /** True when the final review could not be completed (BI-D33F968A). */
+  reviewIncomplete?: boolean;
 }): ReviewFixOutcomeKind {
   if (!args.reviewFailed) return "repaired";
+  // An unreviewable artifact is not a rejected one. Escalating here would tell
+  // the owner the platform tried and could not fix their design, when in truth
+  // no reviewer ever read it — live repro FB-05946F96, abandoned after two
+  // rounds spent regenerating against "Both review agents failed to respond".
+  if (args.reviewIncomplete) return "blocked-review-incomplete";
   return args.regenerated ? "escalated-after-rounds" : "blocked-no-regeneration";
 }
 
 /** True when the outcome must leave the build recoverable rather than abandoned. */
 export function outcomeKeepsBuildRecoverable(kind: ReviewFixOutcomeKind): boolean {
-  return kind === "blocked-no-regeneration";
+  return kind === "blocked-no-regeneration" || kind === "blocked-review-incomplete";
 }

--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -159,15 +159,15 @@ export type ReviewResult = SemanticReviewResult & {
      *  signal that the feature scope may be too large to converge. */
     oscillating?: boolean;
   };
-  /** Deterministic size assessment of the reviewed design. Populated by
-   *  reviewDesignDoc when designReview is the result of an Ideate-phase
-   *  review (not Plan-phase). Phase 2 of the design-time decomposition
-   *  rollout (BI-2E6CC391, spec
-   *  docs/superpowers/specs/2026-05-24-build-studio-design-time-
-   *  decomposition-design.md). Phase 3 reads this to render the gate
-   *  banner; Phase 4 reads it to gate the decomposition assistant.
-   *  Absent on Plan-phase reviews and on builds reviewed before Phase 2
-   *  shipped. */
+  /** Deterministic size assessment of the reviewed design, written by
+   *  reviewDesignDoc on Ideate-phase reviews only (BI-2E6CC391, spec
+   *  docs/superpowers/specs/2026-05-24-build-studio-design-time-decomposition-design.md).
+   *  Phase 3 renders the gate banner from it; Phase 4 gates the decomposition
+   *  assistant. Absent on Plan-phase reviews and on pre-Phase-2 builds. */
+  /** True when NO reviewer returned a usable verdict, so this says nothing
+   *  about the work (BI-D33F968A). `fail` is the safe default, never "examined
+   *  and rejected" — a repair budget spent on it destroys the build. */
+  reviewIncomplete?: boolean;
   sizeAssessment?: SizeAssessmentSnapshot;
   /** Operator override recorded when the build's size assessment is
    *  `decompose-required` but the operator chose to proceed

--- a/apps/web/lib/mcp/build-design-review-handler.ts
+++ b/apps/web/lib/mcp/build-design-review-handler.ts
@@ -151,6 +151,10 @@ export async function reviewDesignDoc(params: Record<string, unknown>, userId: s
         decision: "fail" as const,
         issues: [{ severity: "critical" as const, description: "Both review agents failed to respond" }],
         summary: "Review could not be completed — retry.",
+        // BI-D33F968A: nobody read the work. `fail` is the safe default, not a
+        // verdict — mark it so a repair loop does not spend rounds "fixing"
+        // something no reviewer looked at.
+        reviewIncomplete: true,
       };
       // BI-CE49D82E — Compute the iteration delta against the prior round and
       // attach to the ReviewResult. computeReviewDelta + isOscillating live in

--- a/apps/web/lib/mcp/build-review-handlers.ts
+++ b/apps/web/lib/mcp/build-review-handlers.ts
@@ -409,6 +409,10 @@ export async function reviewBuildPlan(params: Record<string, unknown>, userId: s
         decision: "fail" as const,
         issues: [{ severity: "critical" as const, description: "Both review agents failed to respond" }],
         summary: "Review could not be completed — retry.",
+        // BI-D33F968A: nobody read the work. `fail` is the safe default, not a
+        // verdict — mark it so a repair loop does not spend rounds "fixing"
+        // something no reviewer looked at.
+        reviewIncomplete: true,
       };
       // Deterministic kind-aware lenience: a chore/fix/docs build must not be
       // blocked by a reviewer's missing-test-first complaint (test-first is a


### PR DESCRIPTION
## Problem

When both reviewers fail to respond, the handler **fabricates a verdict**:

```ts
decision: "fail"
issues:   [{ severity: "critical", description: "Both review agents failed to respond" }]
summary:  "Review could not be completed — retry."
```

Nothing read the design. The repair loop cannot tell that apart from a real rejection, so it spends the whole budget regenerating a document nobody looked at, escalates, abandons the build, and parks the owner's backlog item.

Live repro `FB-05946F96` on the Pet Rescue install:

```
23:07:37  Dispatching ideate research via opencode (provider=local)
23:11:13  Auto-dispatched and saved designDoc in 215.8s
23:11:13  Design review: fail. Review could not be completed — retry.
23:11:14  Escalated to the owner (needs-human) after 2 self-repair round(s)
          — PIR-SOQ99. WIP freed; backlog item parked as deferred.
```

Two rounds were spent "fixing" a design against the feedback *"Both review agents failed to respond"*. The owner is then told the platform tried and could not repair their design. **It never reviewed it once.**

## Change

- `ReviewResult` carries `reviewIncomplete`, set where the fabricated verdict is built, in both the design and plan review handlers. `fail` remains the safe default; the marker records that it *is* a default and not a finding.
- The design fix loop **re-runs the reviewer** on an incomplete review instead of regenerating the design, bounded by `DESIGN_REVIEW_RETRY_LIMIT`, and does not consume a repair round for it — those attempts are not repairs.
- `review-fix-outcome`, shared by both loops, returns `blocked-review-incomplete`, which keeps the build **recoverable** rather than escalating. An artifact genuinely reviewed and unrepairable still escalates exactly as before.
- The operator line says the honest thing: no reviewer could complete a review, so nothing is known about this design, and the design is kept untouched.

The plan loop reads the same shared rule, but its handler's marker is not yet consumed by a plan-side re-review; that half is deliberately unchanged so this stays one revert.

## Verification

- `lib/build` + `lib/mcp` + `components/build`: **381 files / 3916 tests pass**.
- New test confirmed **Red** against `origin/main`, green with the fix.
- `pnpm --filter web typecheck` clean; guard loop 37/37; surface ratchet OK; **module-size ratchet OK** — the type file was brought back to baseline by tightening an adjacent comment rather than re-baselining.
- **`pnpm run pregate` passed** — full local CI-equivalent gate.

Refs: BI-D33F968A, BI-E492F313