### PR TITLE
fix(local-ci): stop waiting on an executor that is gone (BI-40230C6F)

### DIFF
--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -35,6 +35,7 @@ const EXPECTED_LEGACY_JOBS = [
   "fk-index-coverage-guard",
   "fpaw-standard-guard",
   "fresh-install-reliability",
+  "gate-executor-liveness",
   "governed-teardown-guard",
   "host-port-range-guard",
   "installer-help-contract",

--- a/scripts/gate-worktree-executor-liveness.test.mjs
+++ b/scripts/gate-worktree-executor-liveness.test.mjs
@@ -1,0 +1,84 @@
+// BI-40230C6F — the gate must stop waiting on an executor that is gone.
+//
+// "finalizing evidence" only means the slot holder has not published yet. It does
+// NOT mean anything is still running. When the executor dies mid-run — the portal
+// restarting is enough, and it takes the local-CI admission control plane with it —
+// the evidence it owed will never arrive, and the wait loop used to poll a corpse
+// for the entire deadline. Measured: ~30 minutes of "canonical local-CI execution
+// is finalizing evidence" AFTER the gate had already logged the queue observer as
+// proven dead.
+//
+// The pool is structurally ONE slot, so that wedged wait blocks every session on
+// the host, not just the one that lost its executor.
+//
+// The safety property under test is the asymmetry: an explicit "no active lease"
+// stops the wait, but "I could not ask" must NOT — an unreachable control plane is
+// the very condition that kills the executor, so treating it as proof of death
+// would turn a transient portal blip into a hard failure on a healthy diff.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasActiveLocalCiLease } from "./gate-worktree.mjs";
+
+const ACTIVE_LEASE = {
+  leaseId: "NPEL-84D5F64D49",
+  environmentKey: "local-integration-ci",
+  slotKey: "slot-0",
+  status: "active",
+};
+
+function respond(leases) {
+  return async () => ({ success: true, data: { leases, queued: [] } });
+}
+
+test("reports the slot held while a local-CI lease is active", async () => {
+  assert.equal(await hasActiveLocalCiLease({ call: respond([ACTIVE_LEASE]) }), true);
+});
+
+test("reports the slot free when the control plane answers with no leases", async () => {
+  // This is the case that ends the wait: nothing holds the slot, so the evidence
+  // the loop is waiting for can never be published by anyone.
+  assert.equal(await hasActiveLocalCiLease({ call: respond([]) }), false);
+});
+
+test("a lease for a DIFFERENT environment does not count as the local-CI slot", async () => {
+  // Leases for other environments share this listing. Counting them would keep the
+  // gate waiting forever on an executor that does not exist, which is the original
+  // bug wearing a different hat.
+  assert.equal(
+    await hasActiveLocalCiLease({
+      call: respond([{ leaseId: "NPEL-OTHER", environmentKey: "preview", status: "active" }]),
+    }),
+    false,
+  );
+});
+
+test("an unreachable control plane is UNKNOWN, never 'the executor is gone'", async () => {
+  // The failure that motivated this item was the portal going down mid-run
+  // (ECONNREFUSED 127.0.0.1:3000). If that read as "no active lease", every
+  // transient portal blip would hard-fail a gate on a perfectly good diff.
+  const thrown = await hasActiveLocalCiLease({
+    call: async () => {
+      throw new Error("connect ECONNREFUSED 127.0.0.1:3000");
+    },
+  });
+  assert.equal(thrown, null);
+  assert.notEqual(thrown, false);
+});
+
+test("a non-success response is UNKNOWN, not proof the slot is free", async () => {
+  const refused = await hasActiveLocalCiLease({
+    call: async () => ({ success: false, error: "unauthorized" }),
+  });
+  assert.equal(refused, null);
+  assert.notEqual(refused, false);
+});
+
+test("a malformed payload is UNKNOWN rather than a stop signal", async () => {
+  // `leases` absent is not the same claim as `leases: []`. Only the latter is the
+  // control plane telling us nothing holds the slot.
+  const malformed = await hasActiveLocalCiLease({ call: async () => ({ success: true }) });
+  assert.equal(malformed, null);
+  assert.notEqual(malformed, false);
+});

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -628,6 +628,36 @@ function quiescenceBlocksWrites(status) {
     && ((status.level && status.level !== "normal") || status.writesRefused === true);
 }
 
+/**
+ * Is anything still holding the local-CI slot?
+ *
+ * Returns `true` when an active `local-integration-ci` lease exists, `false`
+ * when the control plane answers and there is none, and `null` when we could
+ * not find out.
+ *
+ * `null` is NOT `false` on purpose. Every "nothing is running" verdict has to
+ * come from an answer we actually received, because the caller turns it into a
+ * hard stop — and the failure that motivated this (BI-40230C6F) was the portal
+ * going down mid-run, which is exactly when an unreachable control plane must
+ * NOT be read as "the executor is gone".
+ */
+export async function hasActiveLocalCiLease({ mcpUrl, bearerToken, call = mcpCall }) {
+  let response;
+  try {
+    response = await call("list_nonprod_environment_leases", {}, { mcpUrl, bearerToken });
+  } catch {
+    return null;
+  }
+  if (response?.success !== true) return null;
+  const data = responseData(response);
+  // A missing `leases` key is NOT the same claim as `leases: []`. Only the latter
+  // is the control plane saying nothing holds the slot; the former is a payload we
+  // do not understand, and an unreadable answer must not stop the wait.
+  if (!Array.isArray(data?.leases)) return null;
+  return data.leases.some((lease) =>
+    (lease.environmentKey || lease.environment || lease.key) === "local-integration-ci");
+}
+
 async function cancelDeadLocalQueueObservers({
   directory,
   mcpUrl,
@@ -1352,6 +1382,29 @@ async function main() {
     ) {
       if (Date.now() >= deadline) {
         die("canonical local-CI executor ended without publishing evidence before the deadline");
+      }
+      // BI-40230C6F: "finalizing evidence" only means the slot holder has not
+      // published yet. It does NOT mean anything is still running. When the
+      // executor dies — the portal restarting mid-run is enough — the evidence
+      // it owed will never arrive, and this loop used to keep polling a corpse
+      // for the whole deadline. Measured: ~30 minutes of "finalizing evidence"
+      // after the gate had already logged the observer as proven dead.
+      //
+      // That is not merely slow. The pool is structurally ONE slot, so a wedged
+      // wait blocks every session on the host for the full deadline.
+      //
+      // Only an explicit `false` stops the wait: `null` means we could not ask,
+      // and an unreachable control plane is the very condition that kills the
+      // executor, so it must keep waiting rather than fail.
+      const slotHeld = await hasActiveLocalCiLease({
+        mcpUrl: options.mcpUrl,
+        bearerToken,
+      });
+      if (slotHeld === false) {
+        die(
+          "canonical local-CI executor is gone and its evidence will never arrive "
+            + "(no active local-integration-ci lease). Re-run pregate; this is not a verdict on the diff.",
+        );
       }
       const delayMs = retryDelayMs({ attempt: claimAttempt, pollSeconds: options.pollSeconds });
       claimAttempt += 1;

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -45,6 +45,12 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("--test", "scripts/check-capability-compose-profiles.test.mjs"),
       node("scripts/check-capability-compose-profiles.mjs"),
     ]),
+    // BI-40230C6F: the gate must stop waiting on an executor that is gone, and must
+    // NOT read an unreachable control plane as proof of death. Registered here rather
+    // than added to ci-policy-test-inventory-allowlist.txt, where it would never run.
+    guard("gate-executor-liveness", "Gate Executor Liveness", [
+      node("--test", "scripts/gate-worktree-executor-liveness.test.mjs"),
+    ]),
     guard("host-port-range-guard", "Host Port Range Guard", [
       node("--test", "scripts/check-host-port-range.test.mjs"),
     ]),


### PR DESCRIPTION
When the executor holding the local-CI slot dies mid-run, the waiting gate kept polling for evidence it would never receive, until the full admission deadline expired.

Measured 2026-08-27. The portal restarted mid-run, taking the local-CI admission control plane with it:

```
local-CI admission transport unavailable (connect ECONNREFUSED 127.0.0.1:3000); retrying...
canonical local-CI execution is finalizing evidence; observing again in 17.2s...   [x ~40]
gate-worktree: could not cancel proven-dead queue observer NPEL-3642C15C18
swept 1 leaked local-CI queue observer record(s) (same_host_observer_process_not_running)
canonical local-CI execution is finalizing evidence; observing again in 12.5s...   [continues]
gate-worktree: canonical local-CI executor ended without publishing evidence before the deadline
```

**~30 minutes of polling a corpse.** Note the ordering: the gate had *already* proven a queue observer dead and swept a leaked record, then went straight back to waiting.

## Why this is worse than a slow run

The pool is structurally **one slot** (BI-D908DA0A). The wedge does not only stall the branch that lost its executor — it holds the only queue for the whole deadline, so every other session on the machine waits behind it. A peer was queued behind this the entire time; it cost two of four gate attempts in one session.

It also ends in a misleading verdict. `"canonical local-CI executor ended without publishing evidence before the deadline"` reads like a judgement on the diff. Nothing was ever evaluated.

## Root cause

The `gate_evidence_blocked` / `missing-evidence` branch slept and retried without ever asking whether the executor that owed the evidence still existed.

The liveness machinery already existed and is well built — `createObserverLivenessProbe`, proven-dead only, deliberately conservative. But `cancelDeadLocalQueueObservers` applies it **only to `data.queued`**, the waiters. The **active** lease holder is never probed. So the gate could prove a *waiter* dead while waiting indefinitely on a dead *holder*.

## The asymmetry is the load-bearing part

`hasActiveLocalCiLease` returns `true` / `false` / `null`, and **only an explicit `false` stops the wait**.

An unreachable control plane, a non-success response, and a payload with no `leases` array all return `null`, and `null` keeps waiting — because an unreachable portal is precisely the condition that kills the executor, so reading it as proof of death would turn a transient blip into a hard failure on a healthy diff. Same "proven-dead only" discipline the observer probe already documents.

`ownerPid` is `null` on lease records, so a pid probe is not available for the holder; lease existence is the signal actually present in the data.

## Not done

This never cancels or reaps a peer's active lease. The existing design is deliberate — cancelling a live gate's lease is strictly worse than reaping a leaked record late — and this only ends **our own** futile wait. Raising the pool above one slot is BI-D908DA0A; this removes the wedge, not the contention.

## Tests

Six cases, all **proven to fail first**: against a naive implementation (any error → "slot free", ignore `environmentKey`) **4 of 6 fail**, including the `ECONNREFUSED` case that would hard-fail gates on a healthy diff.

One test initially asserted `false` for a malformed payload while its *name* said "UNKNOWN". The name was right and the implementation was wrong — a response with no `leases` key is not the control plane saying the slot is free. I fixed the code, not the test name.

Registered in `scripts/lib/ci-policy-guards.mjs` and its hand-enumerated companion list, rather than added to `ci-policy-test-inventory-allowlist.txt` where the existing `gate-worktree-lease.test.mjs` sits and therefore never runs in CI. That allowlist's own header says to prefer registration.

## Verification

Local-CI gate **PASS** at the pushed SHA, no override code stretched. 37 guards pass; the new guard makes 38.