### PR TITLE
fix(build-studio): say why a build cannot advance, in the owner's language (BI-C5D978E9)

### DIFF
--- a/apps/web/lib/build/build-entry-gate.ts
+++ b/apps/web/lib/build/build-entry-gate.ts
@@ -1,3 +1,4 @@
+import { describeReadinessRefusal } from "@/lib/build/readiness-refusal-message";
 import { randomUUID } from "node:crypto";
 
 import { prisma } from "@dpf/db";
@@ -133,8 +134,10 @@ export async function enforceBuildInitiativeReadiness(args: {
   return {
     allowed: !blocked,
     ...(blocked ? { error: "initiative_not_ready" as const } : {}),
+    // BI-C5D978E9: the owner reads this. The raw enum list told a shelter
+    // director nothing — least of all that none of it was waiting on them.
     message: blocked
-      ? `Cannot enter ${args.targetPhase}: ${codes(decision).join(", ")}.`
+      ? describeReadinessRefusal(args.targetPhase, [...decision.blockers, ...decision.unmet])
       : `${args.target} readiness allowed.`,
     decision,
   };

--- a/apps/web/lib/build/readiness-refusal-message.test.ts
+++ b/apps/web/lib/build/readiness-refusal-message.test.ts
@@ -1,0 +1,44 @@
+// BI-C5D978E9 — the owner must be able to read a readiness refusal.
+
+import { describe, expect, it } from "vitest";
+
+import { describeReadinessRefusal } from "./readiness-refusal-message";
+
+describe("describeReadinessRefusal", () => {
+  // The live repro: FB-EB292B9F, whose design had PASSED review and sized ok.
+  it("turns the six-code plan refusal into something a shelter director can read", () => {
+    const message = describeReadinessRefusal("plan", [
+      { code: "RESEARCH_REQUIRED", accountableRole: "design-author" },
+      { code: "CANONICAL_DESIGN_REQUIRED", accountableRole: "design-checklist-reviewer" },
+      { code: "SPEC_APPROVAL_REQUIRED", accountableRole: "design-checklist-reviewer" },
+      { code: "REVIEW_REQUIRED", accountableRole: "architecture-reviewer" },
+      { code: "OBJECTIVE_BASELINE_REQUIRED", accountableRole: "design-checklist-reviewer" },
+      { code: "ARTIFACT_AUTHOR_REQUIRED", accountableRole: "artifact-resolver" },
+    ]);
+
+    expect(message).toContain("cannot move into plan yet");
+    expect(message).toContain("the research behind this design has not been recorded");
+    expect(message).toContain("an architecture reviewer");
+    // The load-bearing sentence: it is not the owner who is holding this up.
+    expect(message).toContain("nothing here is waiting on your input");
+    // No raw enum codes survive.
+    expect(message).not.toMatch(/[A-Z]+_REQUIRED/);
+  });
+
+  it("reads naturally for a single missing requirement", () => {
+    const message = describeReadinessRefusal("plan", [
+      { code: "REVIEW_REQUIRED", accountableRole: "architecture-reviewer" },
+    ]);
+    expect(message).toContain("because an independent review has not been recorded (an architecture reviewer)");
+    expect(message).not.toContain(";");
+  });
+
+  it("still renders an unknown code rather than dropping it", () => {
+    const message = describeReadinessRefusal("build", [{ code: "SOMETHING_NEW" }]);
+    expect(message).toContain("SOMETHING_NEW");
+  });
+
+  it("says something when there is nothing to describe", () => {
+    expect(describeReadinessRefusal("plan", [])).toBe("Cannot enter plan.");
+  });
+});

--- a/apps/web/lib/build/readiness-refusal-message.ts
+++ b/apps/web/lib/build/readiness-refusal-message.ts
@@ -1,0 +1,83 @@
+// apps/web/lib/build/readiness-refusal-message.ts
+//
+// BI-C5D978E9 — what the owner is told when initiative readiness blocks a phase.
+//
+// The refusal used to be the raw enum list:
+//
+//   Cannot enter plan: RESEARCH_REQUIRED, CANONICAL_DESIGN_REQUIRED,
+//   SPEC_APPROVAL_REQUIRED, REVIEW_REQUIRED, OBJECTIVE_BASELINE_REQUIRED,
+//   ARTIFACT_AUTHOR_REQUIRED.
+//
+// Six codes, no roles, no verbs. A shelter director reads that and cannot tell
+// whether they forgot something, whether the platform is broken, or what would
+// make it go. Live repro FB-EB292B9F, whose design had PASSED review and sized
+// `ok` — nothing was wrong with their request at all.
+//
+// Every requirement already carries the role accountable for it
+// (`evaluate.ts` builds `{ code, state, accountableRole }`); `codes()` simply
+// discarded it. This turns the same decision into a sentence that says what is
+// missing, who records it, and — decisively — that it is not the owner's input
+// that is outstanding.
+//
+// Pure module — no Prisma, no I/O.
+
+/** What each requirement means, in the owner's language. */
+const MEANING: Record<string, string> = {
+  RESEARCH_REQUIRED: "the research behind this design has not been recorded",
+  CANONICAL_DESIGN_REQUIRED: "no canonical design document is pinned for this work",
+  SPEC_APPROVAL_REQUIRED: "the design has not been approved against that document",
+  REVIEW_REQUIRED: "an independent review has not been recorded",
+  OBJECTIVE_BASELINE_REQUIRED: "this work is not yet tied to a measurable objective",
+  ARTIFACT_AUTHOR_REQUIRED: "the design document has no recorded author",
+  CLASSIFICATION_REQUIRED: "this work has not been classified",
+  AUTHORIZATION_DENIED: "authorization for this work was refused",
+  REVIEW_FAILED: "a recorded review did not pass",
+};
+
+/** Roles rendered as something a person recognises. */
+const ROLE_LABEL: Record<string, string> = {
+  "design-author": "the design author",
+  "design-checklist-reviewer": "a design reviewer",
+  "architecture-reviewer": "an architecture reviewer",
+  "artifact-resolver": "the artifact resolver",
+  "data-reviewer": "a data reviewer",
+  "ux-reviewer": "a UX reviewer",
+  "security-reviewer": "a security reviewer",
+  "compliance-reviewer": "a compliance reviewer",
+  "domain-reviewer": "a domain reviewer",
+  "product-owner": "the product owner",
+  "platform-governance": "platform governance",
+};
+
+export type UnmetRequirement = { code: string; accountableRole?: string | null };
+
+function describe(entry: UnmetRequirement): string {
+  const meaning = MEANING[entry.code] ?? entry.code;
+  const role = entry.accountableRole ? ROLE_LABEL[entry.accountableRole] ?? entry.accountableRole : null;
+  return role ? `${meaning} (${role})` : meaning;
+}
+
+/**
+ * The owner-facing refusal.
+ *
+ * Deliberately says these are recorded by reviewers. The single most useful
+ * fact for the owner is that nothing is waiting on them — the previous message
+ * left them hunting for an input they were never asked for.
+ *
+ * Falls back to the bare code list only when there is nothing to describe, so a
+ * caller can always render something.
+ */
+export function describeReadinessRefusal(
+  targetPhase: string,
+  unmet: readonly UnmetRequirement[],
+): string {
+  if (unmet.length === 0) return `Cannot enter ${targetPhase}.`;
+  const parts = unmet.map(describe);
+  const list = parts.length === 1
+    ? parts[0]
+    : `${parts.slice(0, -1).join("; ")}; and ${parts[parts.length - 1]}`;
+  return (
+    `This cannot move into ${targetPhase} yet because ${list}. `
+    + "These are recorded by reviewers, not by you — nothing here is waiting on your input."
+  );
+}


### PR DESCRIPTION
## Problem

The initiative-readiness refusal was the raw enum list:

```
Cannot enter plan: RESEARCH_REQUIRED, CANONICAL_DESIGN_REQUIRED,
SPEC_APPROVAL_REQUIRED, REVIEW_REQUIRED, OBJECTIVE_BASELINE_REQUIRED,
ARTIFACT_AUTHOR_REQUIRED.
```

Six codes, no roles, no verbs. A shelter director reads that and cannot tell whether they forgot something, whether the platform is broken, or what would make it go.

Live repro `FB-EB292B9F` on the Pet Rescue install: the design had **passed** review and sized **ok** — *"Design fits one Plan"*, 2 models, 4 acceptance criteria. Nothing was wrong with the request. The owner had no way to know that.

## Change

Every requirement already carries the role accountable for it — `evaluate.ts` builds `{ code, state, accountableRole }` for each — and `codes()` discarded it. The same decision now reads:

> This cannot move into plan yet because the research behind this design has not been recorded (the design author); no canonical design document is pinned for this work (a design reviewer); … and the design document has no recorded author (the artifact resolver). **These are recorded by reviewers, not by you — nothing here is waiting on your input.**

That last sentence is the load-bearing one. The previous message left the owner hunting for an input they were never asked for.

This changes **what the gate says, not what it decides.**

## The underlying blocker is not fixed here

Build Studio's ideate phase never dispatches the governed reviewer tasks that would record these facts, so **no owner-composed feature build can reach plan**. That is `BI-C5D978E9` and needs a founder decision — `reviewer-identity.ts` states there is *"deliberately no self-approval override"*, so the platform cannot simply record its own receipts.

## Verification

- `lib/build` + `lib/actions/build-governed`: **187 files / 2070 tests pass**.
- `pnpm --filter web typecheck` clean; guard loop 37/37; module-size ratchet OK; Build Studio surface ratchet OK (new logic lives in `lib/`, component surface untouched).
- **`pnpm run pregate` passed** — full local CI-equivalent gate.

Refs: BI-C5D978E9, BI-8C6AA60E