### PR TITLE
fix: adopt_worktree records which session claimed the branch

### DIFF
--- a/apps/web/lib/mcp/packs/work-capsules-pack.test.ts
+++ b/apps/web/lib/mcp/packs/work-capsules-pack.test.ts
@@ -263,6 +263,56 @@ describe("work capsule MCP tools", () => {
     expect(result.entityId).toBe("WC-ADOPT");
   });
 
+  it("adopt_worktree records sessionRef as the workroom executorRef", async () => {
+    // Without this the guard can prove a live claim COVERS the branch but not
+    // that it is THIS session's, which is weaker than AGENTS.md 12 states.
+    // claim_backlog_item_for_work already required sessionRef for exactly this
+    // reason; adopt_worktree simply omitted it, so every worktree adopted
+    // through it stored executorRef: null.
+    mockPrisma.workroom.findFirst.mockResolvedValue(null);
+    mockPrisma.workroom.create.mockResolvedValue({ id: "row-1", capsuleId: "WC-SESSION" });
+    mockPrisma.workroomActivity.create.mockResolvedValue({ id: "activity-1" });
+
+    const { executeTool } = await import("@/lib/mcp-tools");
+    const result = await executeTool("adopt_worktree", {
+      title: "Adopt with session identity",
+      objective: "Record which session holds the claim.",
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      headBranch: "fix/session-identity",
+      worktreePath: "D:/DPF-worktrees/session-identity",
+      executorKind: "claude-desktop",
+      sessionRef: "session-abc123",
+    }, "user-1", { agentId: "claude" });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.workroom.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ executorRef: "session-abc123" }) }),
+    );
+  });
+
+  it("adopt_worktree without sessionRef still succeeds, storing a null executorRef", async () => {
+    // Optional, not required: making it required would break every existing
+    // caller and refuse claims outright, which is worse than an unattributed
+    // claim. The gap is recorded rather than forced.
+    mockPrisma.workroom.findFirst.mockResolvedValue(null);
+    mockPrisma.workroom.create.mockResolvedValue({ id: "row-1", capsuleId: "WC-NOSESSION" });
+    mockPrisma.workroomActivity.create.mockResolvedValue({ id: "activity-1" });
+
+    const { executeTool } = await import("@/lib/mcp-tools");
+    const result = await executeTool("adopt_worktree", {
+      title: "Adopt without session identity",
+      objective: "Legacy caller path.",
+      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+      headBranch: "fix/no-session",
+      worktreePath: "D:/DPF-worktrees/no-session",
+    }, "user-1", { agentId: "claude" });
+
+    expect(result.success).toBe(true);
+    expect(mockPrisma.workroom.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ executorRef: null }) }),
+    );
+  });
+
   it("adopt_worktree persists scope metadata", async () => {
     mockPrisma.workroom.findFirst.mockResolvedValue(null);
     mockPrisma.workroom.create.mockResolvedValue({ id: "row-1", capsuleId: "WC-ADOPTSCOPE" });

--- a/apps/web/lib/mcp/packs/work-capsules-pack.ts
+++ b/apps/web/lib/mcp/packs/work-capsules-pack.ts
@@ -132,6 +132,7 @@ const definitions: ToolDefinition[] = [
         baseSha: { type: "string", description: "Optional current base SHA." },
         headSha: { type: "string", description: "Optional current head SHA." },
         executorKind: { type: "string", enum: ENUMS.executors, description: "Optional executor adopting the worktree." },
+        sessionRef: { type: "string", description: "Owner/session id, stored as the workroom executorRef. Without it a claim can be shown to exist but not shown to be yours." },
         ...scopeProperties,
       },
       required: ["title", "objective", "repositoryFullName", "headBranch", "worktreePath"],

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -311,6 +311,7 @@ export async function adoptWorktreeTool(
         baseSha: stringParam(params, "baseSha") ?? null,
         headSha: stringParam(params, "headSha") ?? null,
         executorKind: validatedExecutorKind,
+        executorRef: stringParam(params, "sessionRef") ?? null, // session identity; see the tool schema
         backlogItemId: backlogItemIdFromOutcomeAnchor(params),
         scope: parseScopeInput(params),
       },

--- a/docs/architecture/mcp-tool-packs.md
+++ b/docs/architecture/mcp-tool-packs.md
@@ -86,6 +86,8 @@ a room the caller believes is shaped. Its enum is mirrored from `room-shapes.ts`
 layer must not import from `work-management`) and `shape-key-parity.test.ts` is what keeps
 the mirror honest.
 
+Not every field belongs in that shared block. `sessionRef` was added to `adopt_worktree` **alone** ⟦runtime: `BI-0B292D84`, 2026-08-28⟧ because it answers a question only the adopt path had left unanswered: *whose* claim this is. `claim_backlog_item_for_work` had required a `sessionRef` all along and stored it as `WorkCapsule.executorRef`; `adopt_worktree` omitted it, so every worktree adopted through it stored `executorRef: null` and a claim guard could prove a live claim **covered** a branch but not that it belonged to the session asking. It is optional rather than required, unlike its sibling: making it required would break existing callers and refuse claims outright, and an unattributed claim is better than none.
+
 ## Fifth pack — first inline extraction
 
 [`feedback-pack`](../../apps/web/lib/mcp/packs/feedback-pack.ts) is the first pack whose

--- a/docs/architecture/mcp-tool-packs.md
+++ b/docs/architecture/mcp-tool-packs.md
@@ -79,7 +79,7 @@ domain (static + lazy) is now extracted.**
 
 `work-capsules-pack` shares one `scopeProperties` block across `create_workroom` and
 `adopt_worktree`, so a field added there reaches both convene paths at once. That is how
-`workroomShape` landed ⟦runtime: `BI-8C54B216`, 2026-08-23⟧ — the room's collaboration
+`workroomShape` landed ⟦runtime: 2026-08-23⟧ — the room's collaboration
 shape is part of the scope it is convened with, validated against `WORK_CAPSULE_WORKROOM_SHAPES`
 and **rejected** rather than dropped when unknown, because a silently dropped shape convenes
 a room the caller believes is shaped. Its enum is mirrored from `room-shapes.ts` (the lower

--- a/scripts/lib/workroom-bind.mjs
+++ b/scripts/lib/workroom-bind.mjs
@@ -49,6 +49,30 @@ export function toPosixPath(p) {
  * than asking, so binding needs no interaction.
  * @param {string} branch
  */
+/**
+ * A stable id for the session doing the claiming, recorded as the workroom's
+ * executorRef.
+ *
+ * Without it a claim guard can prove that a live claim COVERS a branch but not
+ * that it belongs to THIS session, so two sessions on one branch would both
+ * pass. claim_backlog_item_for_work has required a sessionRef for exactly this
+ * reason; adopt_worktree omitted it, so every worktree adopted through it
+ * stored executorRef: null.
+ *
+ * Prefers whatever the host already knows. Falls back to the worktree path,
+ * which is stable for the life of the tree and unique across trees — a weaker
+ * identity than a real session id, but a truthful one, and better than null.
+ */
+export function resolveSessionRef({ worktreePath, env = process.env } = {}) {
+  return (
+    env.DPF_SESSION_REF
+    || env.CLAUDE_SESSION_ID
+    || env.CODEX_SESSION_ID
+    || env.GROK_SESSION_ID
+    || (worktreePath ? `worktree:${toPosixPath(worktreePath)}` : null)
+  );
+}
+
 export function activityKindForBranch(branch) {
   const b = String(branch ?? "");
   if (b.startsWith("fix/") || b.startsWith("hotfix/")) return "remediation";
@@ -63,7 +87,7 @@ export function activityKindForBranch(branch) {
  * than pretending to a specificity nobody supplied.
  * @param {{ branch: string, worktreePath: string, repositoryFullName: string, headSha?: string|null, baseBranch?: string }} input
  */
-export function planAdoption({ branch, worktreePath, repositoryFullName, headSha = null, baseBranch = "main" }) {
+export function planAdoption({ branch, worktreePath, repositoryFullName, headSha = null, baseBranch = "main", sessionRef = null }) {
   const slug = String(branch).split("/").slice(1).join("/") || String(branch);
   const words = slug.replace(/[-_]+/g, " ").trim();
   const title = words ? words.charAt(0).toUpperCase() + words.slice(1) : branch;
@@ -76,6 +100,7 @@ export function planAdoption({ branch, worktreePath, repositoryFullName, headSha
     baseBranch,
     ...(headSha ? { headSha } : {}),
     executorKind: "claude-desktop",
+    ...(sessionRef ? { sessionRef } : {}),
     activityKind: activityKindForBranch(branch),
     decisionScope: "wwmd",
     portfolioRole: "foundational",
@@ -149,7 +174,7 @@ export async function bindWorktreeToWorkroom({
 
   let payload;
   try {
-    payload = await call("adopt_worktree", planAdoption({ branch, worktreePath, repositoryFullName, headSha, baseBranch }), {
+    payload = await call("adopt_worktree", planAdoption({ branch, worktreePath, repositoryFullName, headSha, baseBranch, sessionRef: resolveSessionRef({ worktreePath, env }) }), {
       ...access,
       timeoutMs: BIND_TIMEOUT_MS,
     });

--- a/scripts/lib/workroom-bind.test.mjs
+++ b/scripts/lib/workroom-bind.test.mjs
@@ -22,6 +22,7 @@ import {
   markerFromAdoption,
   planAdoption,
   resolveMcpAccess,
+  resolveSessionRef,
   toPosixPath,
 } from "./workroom-bind.mjs";
 
@@ -198,4 +199,44 @@ test("a claim that succeeded but could not be cached still reports bound", async
   });
   assert.equal(r.status, "bound");
   assert.match(r.reason, /marker not cached/);
+});
+
+// ── session identity (executorRef) ───────────────────────────────────────────
+//
+// A claim guard that can prove a live claim COVERS a branch, but not that it is
+// THIS session's, enforces a weaker property than AGENTS.md 12 states: two
+// sessions on one branch would both pass. claim_backlog_item_for_work has
+// required sessionRef for exactly this reason; adopt_worktree omitted it.
+
+test("a host-provided session id is preferred over the fallback", () => {
+  for (const key of ["DPF_SESSION_REF", "CLAUDE_SESSION_ID", "CODEX_SESSION_ID", "GROK_SESSION_ID"]) {
+    assert.equal(resolveSessionRef({ worktreePath: "/wt/a", env: { [key]: "sess-1" } }), "sess-1", key);
+  }
+});
+
+test("with no host session id, the worktree path is the identity — weaker but truthful", () => {
+  // Stable for the life of the tree and unique across trees. Not a real session
+  // id, but better than null, which is what every adopted worktree stored before.
+  assert.equal(resolveSessionRef({ worktreePath: "D:\\wt\\a", env: {} }), "worktree:D:/wt/a");
+});
+
+test("with neither, the session ref is null rather than invented", () => {
+  assert.equal(resolveSessionRef({ worktreePath: null, env: {} }), null);
+});
+
+test("planAdoption sends sessionRef when there is one, and omits it when there is not", () => {
+  const withRef = planAdoption({ branch: "fix/a", worktreePath: "/wt/a", repositoryFullName: REPO, sessionRef: "s1" });
+  assert.equal(withRef.sessionRef, "s1");
+  const without = planAdoption({ branch: "fix/a", worktreePath: "/wt/a", repositoryFullName: REPO });
+  assert.ok(!("sessionRef" in without), "an absent session ref must not be sent as null");
+});
+
+test("binding threads the resolved session ref through to adopt_worktree", async () => {
+  let sent = null;
+  await bindWorktreeToWorkroom({
+    branch: "fix/a", worktreePath: "/wt/a", gitDir: null, repositoryFullName: REPO,
+    env: { DPF_MCP_BEARER_TOKEN: "t", DPF_SESSION_REF: "sess-xyz" },
+    call: async (_tool, args) => { sent = args; return capsule(); },
+  });
+  assert.equal(sent.sessionRef, "sess-xyz");
 });

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -61,7 +61,7 @@ apps/web/lib/tak/agent-routing.ts	1191
 apps/web/lib/tak/agentic-loop.test.ts	2501
 apps/web/lib/tak/agentic-loop.ts	2704
 apps/web/lib/tak/route-context-map.ts	1440
-apps/web/lib/work-capsules/mcp-handlers.ts	849
+apps/web/lib/work-capsules/mcp-handlers.ts	850
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1191
 apps/web/lib/work-capsules/work-capsule-store.ts	1051
 apps/web/lib/workbooks/platform-tables.ts	938


### PR DESCRIPTION
## The gap this closes

After #4784, a worktree is bound to a Workroom at creation and the claim guard refuses unclaimed work. But the guard could only prove that **a** live claim *covered* a branch — not that it belonged to **this** session. Two sessions on one branch would both pass.

That is weaker than AGENTS.md §12 states, and it was the last gap recorded on BI-0B292D84.

## The substrate was never the problem

| | already existed |
|---|---|
| `WorkCapsule.executorRef` | yes, in the schema |
| `work-capsule-branch-identity.ts` threading it | yes |
| `claim_backlog_item_for_work` requiring `sessionRef` | yes — *"Owner/session id, stored as the workroom executorRef"* |

`adopt_worktree` simply **omitted the parameter**, so every worktree adopted through it stored `executorRef: null`. This is one schema field, one handler line, and the client wiring — not new machinery.

## Two judgment calls

**`sessionRef` is optional here, required on its sibling.** Making it required would break every existing caller and refuse claims outright. An unattributed claim is better than no claim: the point is to record identity where it is known, not to withhold a claim where it is not.

**The fallback is labelled as weaker, not dressed up.** `workroom-bind.mjs` prefers whatever the host already knows (`DPF_SESSION_REF`, `CLAUDE_SESSION_ID`, `CODEX_SESSION_ID`, `GROK_SESSION_ID`) and otherwise falls back to the worktree path — stable for the life of the tree, unique across trees, and *not* a real session id. The code says so. Given that this whole line of work exists because surfaces overstated what they knew, quietly presenting a path as a session identity would have been the wrong instinct.

## Verified

- `work-capsules-pack.test.ts` **19/19**, including the two new cases: `executorRef` recorded as the supplied `sessionRef` (`WC-SESSION`), and `null` when none is supplied (`WC-NOSESSION`)
- `workroom-bind.test.ts` **19/19**, including that an absent session ref is *omitted* rather than sent as `null`
- scoped typecheck clean; `pregate:preflight` exit 0

## Two incidental things, handled rather than deferred

**`mcp-handlers.ts` grew one line past its size baseline.** Re-baselined with `scripts/check-module-size.mjs --update` — a single-line change to `scripts/module-size-baseline.txt`. Contorting a handler to save one line would have been worse than recording the growth.

**A pre-existing unbacked doc anchor surfaced.** Editing `docs/architecture/mcp-tool-packs.md` made the doc-anchor gate re-check the whole page, and `BI-8C54B216` resolves to nothing — not a `BacklogItem`, not an `Epic`. Removed rather than backfilled: the work it labelled (`workroomShape`) is shipped and the prose describes it accurately, so the date carries the provenance. Filing a BI to match a dangling id would invent history and govern no outstanding work. The same id is also cited in a historical plan document, left untouched.

## Why the doc change is not boilerplate

The tool-packs doc explains that `work-capsules-pack` shares one `scopeProperties` block across `create_workroom` and `adopt_worktree` *"so a field added there reaches both convene paths at once"*. `sessionRef` deliberately does **not** go there — it answers a question only the adopt path had left unanswered. A reader who knew only the sharing rule would reasonably assume otherwise, so the exception is recorded.

Refs: BI-0B292D84
Workroom: WC-04EE86C8
Follows: #4784 (bind-at-birth + enforcement), #4751, #4753, #4750

🤖 Generated with [Claude Code](https://claude.com/claude-code)
