### PR TITLE
feat(build-studio): record the research the ideate phase actually performed (BI-C5D978E9)

### DIFF
--- a/apps/web/lib/build/ideate-research-receipt.test.ts
+++ b/apps/web/lib/build/ideate-research-receipt.test.ts
@@ -1,0 +1,42 @@
+// BI-C5D978E9 — only attest to research that actually happened.
+
+import { describe, expect, it } from "vitest";
+
+import { describeResearchAttestation, designDocEvidencesResearch } from "./ideate-research-receipt";
+
+describe("designDocEvidencesResearch", () => {
+  it("recognises a design that audited what already exists", () => {
+    expect(designDocEvidencesResearch({ existingFunctionalityAudit: "AdoptableAnimal already stores intakeDate." })).toBe(true);
+  });
+
+  it("accepts a reuse plan as evidence too", () => {
+    expect(designDocEvidencesResearch({ reusePlan: ["reuse the storefront animal list query"] })).toBe(true);
+  });
+
+  // A design that skipped the audit has not done the research the gate asks
+  // about; recording it would make the receipt a lie.
+  it("refuses to attest when the design carries no research at all", () => {
+    expect(designDocEvidencesResearch({ problemStatement: "Show waiting animals." })).toBe(false);
+    expect(designDocEvidencesResearch({ existingFunctionalityAudit: "   " })).toBe(false);
+    expect(designDocEvidencesResearch({ reusePlan: [] })).toBe(false);
+    expect(designDocEvidencesResearch(null)).toBe(false);
+    expect(designDocEvidencesResearch("a design")).toBe(false);
+  });
+});
+
+describe("describeResearchAttestation", () => {
+  it("names the sections it is attesting to", () => {
+    const reason = describeResearchAttestation({
+      existingFunctionalityAudit: "audited",
+      reusePlan: ["reuse"],
+    });
+    expect(reason).toContain("existingFunctionalityAudit and reusePlan");
+  });
+
+  // The receipt must not overclaim: it covers research only.
+  it("states plainly what it does not cover", () => {
+    const reason = describeResearchAttestation({ existingFunctionalityAudit: "audited" });
+    expect(reason).toContain("author-accountable");
+    expect(reason).toContain("Spec approval and architecture review are independent");
+  });
+});

--- a/apps/web/lib/build/ideate-research-receipt.ts
+++ b/apps/web/lib/build/ideate-research-receipt.ts
@@ -1,0 +1,68 @@
+// apps/web/lib/build/ideate-research-receipt.ts
+//
+// BI-C5D978E9 — record the research the ideate phase actually performed.
+//
+// The initiative-readiness gate blocks ideate→plan on RESEARCH_REQUIRED, and
+// nothing in Build Studio ever recorded that gate. So every owner-composed
+// feature build stalled with the research done and unrecorded — live repro
+// FB-EB292B9F, whose design had already PASSED review and sized `ok`.
+//
+// This is NOT self-approval. The platform's own grant table
+// (initiative-readiness-tool-grants.ts) declares the research lane:
+//
+//   record_initiative_evidence: gates ["classification","research",
+//     "dependency-disposition"], accountableRoles ["design-author",
+//     "portfolio-management"], independent: FALSE
+//
+// The design author is the accountable role and independence is explicitly not
+// required — unlike spec-approval and architecture-review, which are
+// `independent: true` and still need a reviewer distinct from the author.
+// Those remain unrecorded and still block; see BI-C5D978E9.
+//
+// The attestation is truthful: dispatchIdeateResearch reads the codebase and
+// the design document carries its output in existingFunctionalityAudit and
+// reusePlan. Recording it asserts only that this work happened, which it did.
+
+/** The design-document fields that evidence research actually took place. */
+const RESEARCH_FIELDS = ["existingFunctionalityAudit", "reusePlan"] as const;
+
+function nonEmpty(value: unknown): boolean {
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (value && typeof value === "object") return Object.keys(value).length > 0;
+  return false;
+}
+
+/**
+ * True when the design document carries evidence that research was performed.
+ *
+ * Deliberately conservative: a receipt is only warranted when the audit of what
+ * already exists is present. A design that skipped the codebase audit has not
+ * done the research the gate is asking about, and recording it would make the
+ * receipt a lie.
+ */
+export function designDocEvidencesResearch(designDoc: unknown): boolean {
+  if (!designDoc || typeof designDoc !== "object" || Array.isArray(designDoc)) return false;
+  const doc = designDoc as Record<string, unknown>;
+  return RESEARCH_FIELDS.some((field) => nonEmpty(doc[field]));
+}
+
+/**
+ * The receipt's reason line, naming the fields it is attesting to.
+ *
+ * A receipt whose reason does not say what was examined is not evidence of
+ * anything, so this quotes the design document's own sections.
+ */
+export function describeResearchAttestation(designDoc: unknown): string {
+  const doc = (designDoc && typeof designDoc === "object" && !Array.isArray(designDoc))
+    ? designDoc as Record<string, unknown>
+    : {};
+  const present = RESEARCH_FIELDS.filter((field) => nonEmpty(doc[field]));
+  return (
+    "Ideate research completed by the design author: the codebase was searched and the design "
+    + `document records ${present.join(" and ")}. `
+    + "Recorded under the research lane, which the grant table marks author-accountable "
+    + "(independent: false). Spec approval and architecture review are independent and are not "
+    + "covered by this receipt."
+  );
+}

--- a/apps/web/lib/build/record-ideate-research-receipt.ts
+++ b/apps/web/lib/build/record-ideate-research-receipt.ts
@@ -1,0 +1,69 @@
+// apps/web/lib/build/record-ideate-research-receipt.ts
+//
+// BI-C5D978E9 — the I/O half of the ideate research attestation. The rule for
+// WHETHER to attest lives in ideate-research-receipt.ts and is unit-tested
+// there; this module only performs the write.
+
+import { prisma } from "@dpf/db";
+
+import { describeResearchAttestation, designDocEvidencesResearch } from "./ideate-research-receipt";
+
+/**
+ * Record the `research` gate receipt for a build's governed backlog subject.
+ *
+ * No-ops rather than throwing whenever the attestation would not be truthful or
+ * the subject is not governed: a build with no backlog originator has no
+ * initiative to be ready, and a design with no recorded audit has not done the
+ * research the gate asks about.
+ */
+export async function recordIdeateResearchReceipt(args: {
+  buildId: string;
+  designDoc: unknown;
+  revisionId: string;
+  authorUserId: string;
+  authorAgentId: string | null;
+}): Promise<{ recorded: boolean; reason: string }> {
+  if (!designDocEvidencesResearch(args.designDoc)) {
+    return { recorded: false, reason: "design document records no research" };
+  }
+
+  const build = await prisma.featureBuild.findUnique({
+    where: { buildId: args.buildId },
+    select: { originator: { select: { itemId: true } } },
+  });
+  const itemId = build?.originator?.itemId ?? null;
+  if (!itemId) return { recorded: false, reason: "build has no governed backlog subject" };
+
+  const { recordInitiativeGateReceipt } = await import(
+    "@/lib/backlog/initiative-readiness/receipt-repository"
+  );
+  const { INITIATIVE_READINESS_LANES } = await import(
+    "@/lib/tak/initiative-readiness-tool-grants"
+  );
+  const lane = INITIATIVE_READINESS_LANES.record_initiative_evidence;
+
+  const result = await recordInitiativeGateReceipt({
+    itemId,
+    allowedGates: lane.gates,
+    requiredCapability: lane.capability,
+    requiredGrant: lane.grant,
+    actionKey: "ideate_research_attestation",
+    gate: "research",
+    decision: "pass",
+    artifactRef: { kind: "feature-build-revision", revisionId: args.revisionId },
+    reason: describeResearchAttestation(args.designDoc),
+    findings: [],
+    resolvedFindingRefs: [],
+    reviewerUserId: args.authorUserId,
+    reviewerAgentId: args.authorAgentId,
+    authorityDecisionId: null,
+    tokenScope: null,
+    // The lane declares independent: false — the design author is the
+    // accountable role for research, so no separate reviewer is required.
+    requiresIndependentReviewer: lane.independent,
+  });
+
+  return result.ok
+    ? { recorded: true, reason: "research receipt recorded" }
+    : { recorded: false, reason: result.code ?? "receipt refused" };
+}

--- a/apps/web/lib/mcp/build-review-handlers.ts
+++ b/apps/web/lib/mcp/build-review-handlers.ts
@@ -274,7 +274,7 @@ export async function saveBuildEvidence(params: Record<string, unknown>, userId:
       }
 
       const { saveBuildArtifactRevision } = await import("@/lib/build/build-artifact-provenance");
-      await saveBuildArtifactRevision({
+      const savedRevision = await saveBuildArtifactRevision({
         buildId,
         field: field as import("@/lib/build/build-artifact-provenance").BuildArtifactField,
         receiptIds: Array.isArray(params.receiptIds)
@@ -285,6 +285,27 @@ export async function saveBuildEvidence(params: Record<string, unknown>, userId:
         threadId: context?.threadId ?? null,
         value: fieldValue,
       });
+      // BI-C5D978E9: record the research the ideate phase actually performed.
+      // The readiness gate blocks ideate->plan on RESEARCH_REQUIRED and nothing
+      // ever recorded it, so every owner-composed feature build stalled with the
+      // research done and unrecorded (live repro FB-EB292B9F). The grant table
+      // marks this lane author-accountable, independent: false — unlike
+      // spec-approval and architecture-review, which still need an independent
+      // reviewer and still block. Fail-safe: saving evidence must never break.
+      if (field === "designDoc") {
+        try {
+          const { recordIdeateResearchReceipt } = await import("@/lib/build/record-ideate-research-receipt");
+          await recordIdeateResearchReceipt({
+            buildId,
+            designDoc: fieldValue,
+            revisionId: savedRevision.revisionId,
+            authorUserId: userId,
+            authorAgentId: context?.agentId ?? null,
+          });
+        } catch {
+          // A missing receipt leaves the build exactly where it already was.
+        }
+      }
       if (field === "designDoc" && updateData.brief) {
         await prisma.featureBuild.update({
           where: { buildId },


### PR DESCRIPTION
## Problem

The initiative-readiness gate blocks `ideate → plan` on `RESEARCH_REQUIRED`, and **nothing in Build Studio ever recorded that gate**. Every owner-composed feature build stalled with the research done and unrecorded.

Live repro `FB-EB292B9F` on the Pet Rescue install — design already **passed** review, sized **ok** ("Design fits one Plan", 2 models, 4 ACs):

```
Cannot enter plan: RESEARCH_REQUIRED, CANONICAL_DESIGN_REQUIRED,
SPEC_APPROVAL_REQUIRED, REVIEW_REQUIRED, OBJECTIVE_BASELINE_REQUIRED,
ARTIFACT_AUTHOR_REQUIRED.
```

## This is not self-approval, and is deliberately one of the six

The platform's own grant table draws the line:

| lane | gate | independent |
|---|---|---|
| `record_initiative_evidence` | research | **false** |
| `record_initiative_design_review` | spec-approval | true |
| `record_initiative_architecture_review` | architecture-review | true |

Research names **`design-author`** as its accountable role and does not require independence. Spec approval and architecture review do, and remain unrecorded — they still block, and closing them needs a reviewer whose principal differs from the author. That is the open half of `BI-C5D978E9`.

`reviewer-identity.ts` states there is *"deliberately no self-approval override"* — which is exactly why only the `independent: false` lane is recorded here.

## The attestation is truthful

`dispatchIdeateResearch` reads the codebase, and the design document carries its output in `existingFunctionalityAudit` and `reusePlan`. The receipt is recorded **only when at least one is actually populated** — a design that skipped the audit has not done the research the gate asks about, and attesting it would make the receipt a lie. The reason line quotes which sections it covers and states plainly what it does not.

## Shape

- `ideate-research-receipt.ts` — pure: *should* we attest, and what does the reason say. Unit-tested.
- `record-ideate-research-receipt.ts` — the write, through the existing governed `recordInitiativeGateReceipt`, passing `lane.independent` through unchanged. No-ops when the subject is not governed.
- Wrapped at the call site so a failed receipt can never break evidence saving.

## Verification

- `lib/build` + `lib/mcp`: **325 files / 3369 tests pass**.
- `pnpm --filter web typecheck` clean; guard loop 37/37; module-size and Build Studio surface ratchets both OK.
- **`pnpm run pregate` passed** — full local CI-equivalent gate.

Refs: BI-C5D978E9