### PR TITLE
fix(routing): collapse union types so Gemini function calling works (BI-3907AF35)

### DIFF
--- a/apps/web/lib/routing/chat-adapter-gemini-schema.test.ts
+++ b/apps/web/lib/routing/chat-adapter-gemini-schema.test.ts
@@ -1,0 +1,67 @@
+// BI-3907AF35 — a union `type` must not take down every coworker turn.
+
+import { describe, expect, it } from "vitest";
+
+import { __testing } from "./chat-adapter";
+
+const { sanitizeGeminiSchemaNode, toGeminiFunctionDeclarations } = __testing;
+
+function sanitize(schema: unknown) {
+  return sanitizeGeminiSchemaNode(schema) as Record<string, unknown>;
+}
+
+describe("Gemini schema sanitisation", () => {
+  // The live failure: gemini rejected the whole request with
+  // "Proto field is not repeating, cannot start list" at properties[9].value,
+  // so the coworker could not run at all — not merely that one tool.
+  it("collapses a nullable union to a scalar type plus nullable", () => {
+    const out = sanitize({
+      type: "object",
+      properties: { value: { type: ["string", "null"] } },
+    });
+    const value = (out.properties as Record<string, Record<string, unknown>>).value;
+    expect(value.type).toBe("string");
+    expect(value.nullable).toBe(true);
+  });
+
+  it("collapses a union with no null to its first member", () => {
+    const out = sanitize({ type: ["string", "number"] });
+    expect(out.type).toBe("string");
+    expect(out.nullable).toBeUndefined();
+  });
+
+  it("leaves an ordinary scalar type untouched", () => {
+    const out = sanitize({ type: "string" });
+    expect(out.type).toBe("string");
+    expect(out.nullable).toBeUndefined();
+  });
+
+  // A property legitimately named "type" is a property NAME, not a schema
+  // keyword, and must survive.
+  it("does not mistake a property named type for the type keyword", () => {
+    const out = sanitize({
+      type: "object",
+      properties: { type: { type: ["string", "null"] } },
+    });
+    const prop = (out.properties as Record<string, Record<string, unknown>>).type;
+    expect(prop.type).toBe("string");
+    expect(prop.nullable).toBe(true);
+  });
+
+  it("carries the collapse through a whole function declaration", () => {
+    const [declaration] = toGeminiFunctionDeclarations([
+      {
+        type: "function",
+        function: {
+          name: "record_thing",
+          description: "d",
+          parameters: { type: "object", properties: { value: { type: ["string", "null"] } } },
+        },
+      },
+    ]) as Array<Record<string, unknown>>;
+    const params = declaration!.parameters as Record<string, unknown>;
+    const value = (params.properties as Record<string, Record<string, unknown>>).value;
+    expect(value.type).toBe("string");
+    expect(Array.isArray(value.type)).toBe(false);
+  });
+});

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -128,6 +128,33 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Collapse a JSON Schema union type to the scalar Gemini's proto accepts.
+ *
+ * `type: ["string", "null"]` is ordinary JSON Schema and every other provider
+ * takes it. Gemini's functionDeclarations are proto-backed, where `type` is a
+ * singular field, so a list is rejected outright:
+ *
+ *   Invalid JSON payload received. Unknown name "type" at
+ *   'tools[0].function_declarations[15].parameters.properties[9].value':
+ *   Proto field is not repeating, cannot start list.
+ *
+ * Returns the first non-null member as the type, and whether "null" was among
+ * them so the caller can set `nullable`. First-member choice is deliberate:
+ * a union's leading entry is the one authors write as the real type, with
+ * "null" appended, so it is the closest single type to the author's intent.
+ */
+function collapseGeminiUnionType(value: unknown): { type: unknown; nullable: boolean } | null {
+  if (!Array.isArray(value)) return null;
+  const members = value.filter((entry): entry is string => typeof entry === "string");
+  const concrete = members.filter((entry) => entry !== "null");
+  const nullable = members.length !== concrete.length;
+  // An all-null union carries no type at all; leaving it out is the only honest
+  // rendering, and Gemini treats a missing type as unconstrained.
+  if (concrete.length === 0) return nullable ? { type: undefined, nullable: true } : null;
+  return { type: concrete[0], nullable };
+}
+
 function sanitizeGeminiSchemaNode(value: unknown, propertyMap = false): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => sanitizeGeminiSchemaNode(item));
@@ -141,10 +168,23 @@ function sanitizeGeminiSchemaNode(value: unknown, propertyMap = false): unknown 
     if (!propertyMap && GEMINI_UNSUPPORTED_SCHEMA_KEYS.has(key)) {
       continue;
     }
+    // BI-3907AF35: a union `type` reaches Gemini as a list and fails the whole
+    // request, so every coworker holding such a tool cannot run at all — not
+    // just for that tool. Collapse it here rather than asking every tool author
+    // to avoid ordinary JSON Schema.
+    if (!propertyMap && key === "type") {
+      const collapsed = collapseGeminiUnionType(child);
+      if (collapsed) {
+        if (collapsed.type !== undefined) sanitized[key] = collapsed.type;
+        if (collapsed.nullable) sanitized.nullable = true;
+        continue;
+      }
+    }
     sanitized[key] = sanitizeGeminiSchemaNode(child, !propertyMap && key === "properties");
   }
   return sanitized;
 }
+
 
 function toGeminiFunctionDeclarations(tools: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
   return tools
@@ -158,6 +198,9 @@ function toGeminiFunctionDeclarations(tools: Array<Record<string, unknown>>): Ar
       };
     });
 }
+
+/** Exported for test: the union collapse is the whole point of the fix. */
+export const __testing = { sanitizeGeminiSchemaNode, toGeminiFunctionDeclarations };
 
 // ─── Chat Adapter ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Every coworker holding such a tool cannot run at all

A tool parameter typed `["string", "null"]` — ordinary JSON Schema that every other provider accepts — is rejected by Gemini, and it fails the **whole request**, not just that tool.

Live failure summoning the `change-reviewer` coworker on the Pet Rescue install:

```
routeAndCall threw: All endpoints failed for external-mcp. Attempts:
  gemini: HTTP 400 — Invalid JSON payload received. Unknown name "type" at
    'tools[0].function_declarations[15].parameters.properties[9].value':
    Proto field is not repeating, cannot start list.
  local:  skipped local fallback: 16 tools exceeds threshold for small local models
```

Gemini's `functionDeclarations` are proto-backed, where `type` is a **singular** field, so a list is a protocol violation rather than an unsupported hint. Local was the only other endpoint and declined on tool count, so the coworker had nowhere to run.

Worse, the owner-facing message blamed a provider rate limit — *"your paid AI providers are briefly unavailable… nothing is misconfigured"* — while `ProviderCapacityStatus` showed **gemini, codex and local all available**. That untruth is filed separately in BI-3907AF35.

## Change

`sanitizeGeminiSchemaNode` already stripped unsupported schema **keywords**; it never normalised a union **value**. It now collapses a `type` array to the first non-null member and sets `nullable: true` when `"null"` was among them — the representation Gemini's schema does accept. An all-null union emits no type at all, which Gemini treats as unconstrained and is the only honest rendering.

Fixed at the adapter rather than by asking every tool author to avoid a standard JSON Schema construct: the adapter is where the provider's constraint lives.

The property-map guard is preserved, so a property legitimately **named** `type` is still treated as a property name — pinned by test.

## Why this matters

This is what stops independent reviewer coworkers running, which is the only route past the `spec-approval` and `architecture-review` readiness gates (`reviewer-identity.ts`: *"there is deliberately no self-approval override"*). No coworker running means no governed build can complete.

## Verification

- `lib/routing`: **114 files / 1516 tests pass**; 5 new tests cover the collapse, the null-free union, the untouched scalar, the property-named-`type` case, and a whole function declaration.
- `pnpm --filter web typecheck` clean; guard loop 37/37; module-size ratchet OK.
- **`pnpm run pregate` passed** — full local CI-equivalent gate.

Refs: BI-3907AF35