### PR TITLE
fix(tak): a governed initiative review earns the review-phase budget (BI-3907AF35)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -108,6 +108,7 @@ export const HARD_COMPLETION_CLAIM_PATTERN =
 
 // The dead-end classifier and its copy live in ./inference-dead-ends (BI-A89E4827).
 import { describeToolRouteFailure, describeToolRouteFailureOutcome, type InferenceDeadEndOutcome } from "./inference-dead-ends";
+import { usesGovernedReviewTools } from "./governed-review-tools";
 export { describeToolRouteFailure };
 
 // Narration patterns: agent describes code or announces intent instead of calling tools.
@@ -1558,10 +1559,14 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
       t.name === "reviewBuildPlan" || (t.name === "saveBuildEvidence" &&
         (t.args as Record<string, unknown> | undefined)?.field === "buildPlan")
     );
+    // BI-3907AF35: a governed initiative review is review-phase work too. It
+    // reads an artifact at an immutable version and writes a structured
+    // receipt; on the 120s conversation baseline the reviewer ran out of budget
+    // after four reads and never reached its writer (FB-EB292B9F).
     const hasReviewTools = executedTools.some(t =>
       t.name === "run_ux_test" || t.name === "evaluate_page" ||
       t.name === "check_deployment_windows"
-    );
+    ) || usesGovernedReviewTools(executedTools);
     const hasShipTools = executedTools.some(t =>
       t.name === "deploy_feature" || t.name === "execute_promotion" ||
       t.name === "register_digital_product_from_build" || t.name === "schedule_promotion"

--- a/apps/web/lib/tak/governed-review-tools.test.ts
+++ b/apps/web/lib/tak/governed-review-tools.test.ts
@@ -1,0 +1,29 @@
+// BI-3907AF35 — a governed review must earn the review-phase budget.
+
+import { describe, expect, it } from "vitest";
+
+import { usesGovernedReviewTools } from "./governed-review-tools";
+
+describe("usesGovernedReviewTools", () => {
+  it("recognises the governed writers", () => {
+    for (const name of [
+      "record_initiative_design_review",
+      "record_initiative_architecture_review",
+      "record_initiative_evidence",
+    ]) {
+      expect(usesGovernedReviewTools([{ name }])).toBe(true);
+    }
+  });
+
+  // The live failure: the reviewer spent its whole budget on the immutable
+  // reader and never reached a writer, so keying only on writers would raise
+  // the ceiling only after it had already timed out.
+  it("recognises the immutable reader the reviewer spends its budget on", () => {
+    expect(usesGovernedReviewTools([{ name: "read_source_at_version" }])).toBe(true);
+  });
+
+  it("leaves an ordinary conversational turn on the conversation baseline", () => {
+    expect(usesGovernedReviewTools([{ name: "wiki_query" }, { name: "get_backlog_item" }])).toBe(false);
+    expect(usesGovernedReviewTools([])).toBe(false);
+  });
+});

--- a/apps/web/lib/tak/governed-review-tools.ts
+++ b/apps/web/lib/tak/governed-review-tools.ts
@@ -1,0 +1,61 @@
+// apps/web/lib/tak/governed-review-tools.ts
+//
+// BI-3907AF35 — a governed initiative review is review-phase work, and the
+// agentic loop had no way to know that.
+//
+// The loop raises its wall-clock ceiling when executed tools reveal a heavy
+// phase (build, ship, plan, ideate, review). None of the initiative-readiness
+// tools appeared in any of those lists, so an independent reviewer fell to the
+// 120-second conversation baseline.
+//
+// Live failure reviewing FB-EB292B9F for Second Chance Animal Rescue:
+//
+//   [agentic-loop] iter=6 provider=codex model=gpt-5.4 executedTools=4
+//   [agentic-loop] nudging (tools used=4, short response, mentioned=none)
+//   [agentic-loop] hit MAX_DURATION (120000ms). executedTools=4.
+//   [agentic-loop] hit iteration ceiling (200). "may indicate the model needs more room"
+//
+// The reviewer read four tools' worth of design context and ran out of budget
+// before it could write its verdict. No receipt, so the build stayed at
+// "plan readiness: input-required" — and because spec-approval is
+// `independent: true`, nobody else may record it.
+//
+// A governed review is not a chat turn. It reads an artifact at an immutable
+// version, judges it, then writes a structured receipt carrying artifactRef,
+// profile, artifactRole, findings and resolvedFindingRefs. Build Studio's own
+// design generation is allowed ~150s for less.
+
+/**
+ * Tools whose use means the turn is performing a governed initiative review.
+ *
+ * `read_source_at_version` is included deliberately: it is the immutable reader
+ * granted alongside the writers for exactly this work, and it is what the
+ * reviewer spends its budget on BEFORE it can call a writer. Keying only on the
+ * writers would raise the ceiling only after the reviewer had already run out
+ * of time to reach one.
+ */
+const GOVERNED_REVIEW_TOOLS = new Set([
+  "read_source_at_version",
+  "record_initiative_evidence",
+  "record_initiative_design_review",
+  "record_initiative_architecture_review",
+  "record_initiative_data_review",
+  "record_initiative_ux_review",
+  "record_initiative_security_review",
+  "record_initiative_compliance_review",
+  "record_initiative_domain_review",
+  "record_initiative_archetype_review",
+]);
+
+/**
+ * True when any executed tool marks this turn as a governed initiative review.
+ *
+ * Set membership rather than a prefix test: the lane table is a closed
+ * vocabulary, and a prefix would silently capture any future record_initiative_*
+ * tool whose budget has not actually been considered.
+ */
+export function usesGovernedReviewTools(
+  executedTools: ReadonlyArray<{ name: string }>,
+): boolean {
+  return executedTools.some((tool) => GOVERNED_REVIEW_TOOLS.has(tool.name));
+}


### PR DESCRIPTION
## Problem

The agentic loop raises its wall-clock ceiling when executed tools reveal a heavy phase — build, ship, plan, ideate, review. **None of the initiative-readiness tools appear in any of those lists**, so an independent reviewer runs on the 120-second conversation baseline.

Live failure reviewing `FB-EB292B9F` for Second Chance Animal Rescue:

```
[agentic-loop] iter=6 provider=codex model=gpt-5.4 executedTools=4
[agentic-loop] nudging (tools used=4, short response, mentioned=none)
[agentic-loop] hit MAX_DURATION (120000ms). executedTools=4.
[agentic-loop] hit iteration ceiling (200). This may indicate the model needs
               more room or is stuck in a loop.
```

The reviewer read four tools' worth of design context and ran out of budget before it could write its verdict. No receipt was recorded, so the build stayed at `plan readiness: input-required` — and because spec-approval is `independent: true`, **nobody else is permitted to record it**. The loop's own message already suspected the cause: *"may indicate the model needs more room"*.

## Change

A governed review is not a chat turn. It reads an artifact at an immutable version, judges it, then writes a structured receipt carrying `artifactRef`, `profile`, `artifactRole`, `findings` and `resolvedFindingRefs`. Build Studio's own design generation is allowed ~150s for less work.

These turns now take `MAX_DURATION_REVIEW_MS` (5 min) — the ceiling that **already exists** for review work. No new budget is introduced.

`read_source_at_version` is included in the signal deliberately: it is the immutable reader granted alongside the writers for exactly this work, and it is what the reviewer spends its budget on *before* it can reach a writer. Keying only on the writers would raise the ceiling only after the reviewer had already run out of time to call one — which is precisely the failure above.

The tool set lives in its own module so the rule is unit-testable without the loop, and `agentic-loop.ts` takes two lines rather than ten.

## Verification

- `lib/tak`: **131 files / 1445 tests pass**; 3 new tests cover the writers, the reader, and an ordinary conversational turn staying on the baseline.
- `pnpm --filter web typecheck` clean; guard loop 37/37; module-size and Build Studio surface ratchets OK.
- **`pnpm run pregate` passed** — on the third attempt; the first two runs completed typecheck, the full vitest suite and the image build before being fenced mid-flight by scheduled portal self-upgrade drains (`QR-2026-08-28-7p38so2x`, `QR-2026-08-28-ft1v16ry`).

Refs: BI-3907AF35, BI-C5D978E9