### PR TITLE
fix(coworker): approving an action resumes the task waiting on it (BI-3907AF35)

### DIFF
--- a/apps/web/lib/coworker/envelope-actions-approve-resume.test.ts
+++ b/apps/web/lib/coworker/envelope-actions-approve-resume.test.ts
@@ -1,0 +1,88 @@
+// BI-3907AF35 — approving a coworker action must resume the task waiting on it.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const findUnique = vi.fn();
+const update = vi.fn();
+const resumeMock = vi.fn();
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    coworkerActionEnvelope: {
+      findUnique: (...a: unknown[]) => findUnique(...a),
+      update: (...a: unknown[]) => update(...a),
+    },
+  },
+}));
+
+vi.mock("@/lib/coworker/authority-approval-envelope", () => ({
+  resumeAuthorityApprovalTask: (...a: unknown[]) => resumeMock(...a),
+}));
+
+const DELEGATE = "user-1";
+
+function envelope(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "env-1",
+    status: "proposed",
+    delegatingUserId: DELEGATE,
+    taskRunId: "TR-1",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  findUnique.mockReset();
+  update.mockReset();
+  resumeMock.mockReset();
+});
+
+describe("approveEnvelope", () => {
+  // The live deadlock: envelope approved, task left at input-required with no
+  // retry, so the coworker's write never ran and spec-approval — which is
+  // independent:true — could be recorded by nobody.
+  it("resumes the task that was waiting on the approval", async () => {
+    findUnique.mockResolvedValue(envelope());
+    update.mockResolvedValue(envelope({ status: "approved" }));
+
+    const { approveEnvelope } = await import("./envelope-actions");
+    const result = await approveEnvelope("env-1", DELEGATE);
+
+    expect(result.ok).toBe(true);
+    expect(resumeMock).toHaveBeenCalledWith("TR-1");
+  });
+
+  it("does not try to resume an envelope with no task", async () => {
+    findUnique.mockResolvedValue(envelope({ taskRunId: null }));
+    update.mockResolvedValue(envelope({ status: "approved", taskRunId: null }));
+
+    const { approveEnvelope } = await import("./envelope-actions");
+    await approveEnvelope("env-1", DELEGATE);
+
+    expect(resumeMock).not.toHaveBeenCalled();
+  });
+
+  // The employee has already given the approval; a resume failure must not
+  // take it back.
+  it("keeps the approval when the resume fails", async () => {
+    findUnique.mockResolvedValue(envelope());
+    update.mockResolvedValue(envelope({ status: "approved" }));
+    resumeMock.mockRejectedValue(new Error("task service unavailable"));
+
+    const { approveEnvelope } = await import("./envelope-actions");
+    const result = await approveEnvelope("env-1", DELEGATE);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("does not resume when the caller is not the delegate", async () => {
+    findUnique.mockResolvedValue(envelope());
+
+    const { approveEnvelope } = await import("./envelope-actions");
+    const result = await approveEnvelope("env-1", "someone-else");
+
+    expect(result.ok).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+    expect(resumeMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/coworker/envelope-actions.ts
+++ b/apps/web/lib/coworker/envelope-actions.ts
@@ -111,6 +111,33 @@ export async function approveEnvelope(
     where: { id: envelopeId },
     data: { status: "approved" },
   });
+
+  // BI-3907AF35: approving is only half the handoff. The coworker asked for
+  // this action, was refused with `approval-required`, and its task parked at
+  // `input-required`. The authority gate finds the approved envelope on the
+  // coworker's NEXT attempt — but nothing makes it attempt again, so an
+  // approved envelope and a waiting task sit and stare at each other forever.
+  //
+  // Live repro: envelope cmtcts7a1 (record_initiative_design_review for
+  // BI-C3B5FB75) approved, task TR-...7EDD83DD497B still `input-required` with
+  // no retry; re-summoning replayed the idempotent packet without re-invoking.
+  // Nobody could record the spec approval, and spec-approval is
+  // `independent: true` so nobody else was permitted to.
+  //
+  // Marking the task working is what resumeAuthorityApprovalTask exists for.
+  // Best-effort: a failure to resume must not undo an approval the employee
+  // has already given.
+  if (updated.taskRunId) {
+    try {
+      const { resumeAuthorityApprovalTask } = await import(
+        "@/lib/coworker/authority-approval-envelope"
+      );
+      await resumeAuthorityApprovalTask(updated.taskRunId);
+    } catch {
+      // The approval stands; the task can still be resumed by any later attempt.
+    }
+  }
+
   return { ok: true, envelope: updated as EnvelopeRow };
 }
 


### PR DESCRIPTION
## Problem

Approving a coworker action was only half the handoff.

The coworker asks for an action, the authority gate refuses it with `approval-required` and parks the task at `input-required`. The gate finds the approved envelope on the coworker's **next** attempt — but nothing made it attempt again. An approved envelope and a waiting task sat and stared at each other indefinitely.

Live repro on the Pet Rescue install:

```
envelope cmtcts7a100mm01qdo5krwuld
  agent AGT-WS-REVIEW, action record_initiative_design_review,
  subject BI-C3B5FB75, status proposed → approved
task     TR-MCP-…-7EDD83DD497B   still `input-required`, no retry
```

Re-summoning replayed the idempotent packet and returned the same parked state without re-invoking the coworker — correct behaviour for an immutable request key, and therefore no way out either.

So the spec-approval receipt was never written. And because the spec-approval lane is **`independent: true`**, the delegating human is expressly forbidden from recording it instead (`reviewer-identity.ts`: *"there is deliberately no self-approval override"*).

**The approval existed, the authority was correct, and the work still could not proceed.**

## Change

`resumeAuthorityApprovalTask` already exists and does exactly the right thing — mark the parked run working so the coworker retries and the gate lets the call through. It was only ever called from the gate itself, on the retry path.

Now the approval calls it, in `approveEnvelope` rather than the route, so every caller benefits: the API route today and any approval surface added later.

Best-effort by design — the employee has already given the approval, and a failure to resume must not take it back.

## Verification

- `lib/coworker` + the envelope API route: **55 files / 515 tests pass**.
- New test is confirmed **Red** against `origin/main`, green with the fix; it also covers the no-task case, a failing resume keeping the approval, and a non-delegate caller resuming nothing.
- `pnpm --filter web typecheck` clean; guard loop 37/37; module-size and Build Studio surface ratchets OK.
- **`pnpm run pregate` passed** — full local CI-equivalent gate.

Refs: BI-3907AF35, BI-C5D978E9