### PR TITLE
fix(readiness): a Build Studio design resolves as canonical initiative text (BI-126441FA)

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/artifact-resolver.ts
+++ b/apps/web/lib/backlog/initiative-readiness/artifact-resolver.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 
 import { prisma } from "@dpf/db";
 
+import { renderBuildDesignText } from "./render-build-design-text";
+
 import { readDocumentBlob } from "@/lib/documents/blob-storage";
 import { resolveRepositoryArtifact } from "./repository-artifact";
 import type { InitiativeArtifactRef, ResolvedInitiativeArtifact } from "./receipt-schema";
@@ -85,7 +87,15 @@ function initiativeTextFromBuildValue(value: unknown): string | null {
   if (typeof value === "string" && value.trim()) return value;
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const markdown = (value as Record<string, unknown>).initiativeScopeMarkdown;
-  return typeof markdown === "string" && markdown.trim() ? markdown : null;
+  if (typeof markdown === "string" && markdown.trim()) return markdown;
+  // BI-126441FA: a Build Studio design document IS the initiative's design, but
+  // it is stored structured and nothing writes initiativeScopeMarkdown — so
+  // every one of them resolved to null and was refused as "not an accepted
+  // canonical initiative design", blocking spec-approval, the canonical
+  // baseline and artifact author. Render it here rather than at save time so
+  // existing revisions resolve without rewriting stored artifacts and the
+  // pinned valueDigest keeps covering exactly what the author saved.
+  return renderBuildDesignText(value);
 }
 
 function externalLocatorMatchesSubject(locator: unknown, subject: InitiativeSubject): boolean {

--- a/apps/web/lib/backlog/initiative-readiness/render-build-design-text.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/render-build-design-text.test.ts
@@ -1,0 +1,62 @@
+// BI-126441FA — a Build Studio design must resolve as canonical initiative text.
+
+import { describe, expect, it } from "vitest";
+
+import { renderBuildDesignText } from "./render-build-design-text";
+
+// The exact key set stored on FB-EB292B9F, the build this unblocked.
+const DESIGN = {
+  dataModel: { WaitlistEntry: "joinedAt, status, entityType" },
+  reusePlan: ["reuse the storefront animal list query"],
+  targetRoles: ["adoption coordinator"],
+  accessibility: "Semantic table, keyboard operable.",
+  problemStatement: "Animals waiting longest get overlooked.",
+  proposedApproach: "One page ordered by joinedAt ascending.",
+  acceptanceCriteria: ["Oldest first", "Shows days waiting"],
+  reusabilityAnalysis: "No existing surface lists waiting time.",
+  existingFunctionalityAudit: "AdoptableAnimal already stores intakeDate.",
+};
+
+describe("renderBuildDesignText", () => {
+  it("renders a Build Studio design document", () => {
+    const text = renderBuildDesignText(DESIGN)!;
+    expect(text).toContain("## Problem statement");
+    expect(text).toContain("Animals waiting longest get overlooked.");
+    expect(text).toContain("- Oldest first");
+    expect(text).toContain("**WaitlistEntry**");
+  });
+
+  // A baseline pins a digest and reviewers read this text, so the same stored
+  // value must always produce byte-identical output.
+  it("is deterministic regardless of key order", () => {
+    const shuffled = Object.fromEntries(Object.entries(DESIGN).reverse());
+    expect(renderBuildDesignText(shuffled)).toBe(renderBuildDesignText(DESIGN));
+  });
+
+  it("orders sections by the fixed contract, not by key order", () => {
+    const text = renderBuildDesignText(DESIGN)!;
+    expect(text.indexOf("## Problem statement")).toBeLessThan(text.indexOf("## Proposed approach"));
+    expect(text.indexOf("## Proposed approach")).toBeLessThan(text.indexOf("## Acceptance criteria"));
+  });
+
+  it("omits sections the design does not carry", () => {
+    const text = renderBuildDesignText({ problemStatement: "Only this." })!;
+    expect(text).toContain("## Problem statement");
+    expect(text).not.toContain("## Data model");
+  });
+
+  // An object that is not a design document must not be dressed up as one.
+  it("returns null for a value carrying no known section", () => {
+    expect(renderBuildDesignText({ unrelated: "value" })).toBeNull();
+    expect(renderBuildDesignText({})).toBeNull();
+    expect(renderBuildDesignText(null)).toBeNull();
+    expect(renderBuildDesignText("a string")).toBeNull();
+    expect(renderBuildDesignText([1, 2])).toBeNull();
+  });
+
+  it("ignores empty sections rather than emitting a bare heading", () => {
+    const text = renderBuildDesignText({ problemStatement: "Real.", reusePlan: [], accessibility: "   " })!;
+    expect(text).not.toContain("## Reuse plan");
+    expect(text).not.toContain("## Accessibility");
+  });
+});

--- a/apps/web/lib/backlog/initiative-readiness/render-build-design-text.ts
+++ b/apps/web/lib/backlog/initiative-readiness/render-build-design-text.ts
@@ -1,0 +1,77 @@
+// apps/web/lib/backlog/initiative-readiness/render-build-design-text.ts
+//
+// BI-126441FA — a Build Studio design document IS the initiative's design.
+//
+// resolveInitiativeArtifact accepted only two shapes for a canonical initiative
+// design: a plain string, or an object carrying `initiativeScopeMarkdown`.
+// Build Studio stores a structured document —
+//
+//   dataModel, reusePlan, targetRoles, accessibility, problemStatement,
+//   proposedApproach, acceptanceCriteria, reusabilityAnalysis,
+//   existingFunctionalityAudit
+//
+// — and nothing anywhere writes `initiativeScopeMarkdown`. So every Build
+// Studio design that has ever existed resolved to null content and was refused
+// as "not an accepted canonical initiative design", blocking spec-approval,
+// the canonical design baseline, and artifact author: three of the six facts
+// that gate ideate -> plan. Because spec-approval is `independent: true`, no
+// one could work around it.
+//
+// Rendering here rather than writing the field at save time is deliberate:
+// existing revisions become resolvable without rewriting stored artifacts, and
+// the pinned `valueDigest` keeps covering exactly what the author saved.
+//
+// The rendering must be DETERMINISTIC. A baseline pins a digest and reviewers
+// read this text; the same stored value must always produce the same document,
+// so the section order is fixed here rather than taken from key order.
+
+/** Fixed section order — never derive this from Object.keys. */
+const SECTIONS: ReadonlyArray<{ key: string; heading: string }> = [
+  { key: "problemStatement", heading: "Problem statement" },
+  { key: "existingFunctionalityAudit", heading: "Existing functionality audit" },
+  { key: "reusabilityAnalysis", heading: "Reusability analysis" },
+  { key: "reusePlan", heading: "Reuse plan" },
+  { key: "proposedApproach", heading: "Proposed approach" },
+  { key: "dataModel", heading: "Data model" },
+  { key: "targetRoles", heading: "Target roles" },
+  { key: "accessibility", heading: "Accessibility" },
+  { key: "acceptanceCriteria", heading: "Acceptance criteria" },
+];
+
+function renderValue(value: unknown): string | null {
+  if (typeof value === "string") return value.trim() || null;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) {
+    const items = value.map(renderValue).filter((entry): entry is string => Boolean(entry));
+    return items.length > 0 ? items.map((entry) => `- ${entry}`).join("\n") : null;
+  }
+  if (value && typeof value === "object") {
+    // Sort object keys so a stored object never renders two different ways.
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => {
+        const rendered = renderValue(child);
+        return rendered ? `- **${key}**: ${rendered.replace(/\n/g, " ")}` : null;
+      })
+      .filter((entry): entry is string => Boolean(entry));
+    return entries.length > 0 ? entries.join("\n") : null;
+  }
+  return null;
+}
+
+/**
+ * Render a Build Studio design document as canonical initiative text.
+ *
+ * Returns null when the value carries none of the known sections — an object
+ * that is not a design document must not be dressed up as one.
+ */
+export function renderBuildDesignText(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const doc = value as Record<string, unknown>;
+  const parts: string[] = [];
+  for (const { key, heading } of SECTIONS) {
+    const rendered = renderValue(doc[key]);
+    if (rendered) parts.push(`## ${heading}\n\n${rendered}`);
+  }
+  return parts.length > 0 ? parts.join("\n\n") : null;
+}


### PR DESCRIPTION
## Problem

`resolveInitiativeArtifact` accepted only two shapes for a canonical initiative design: a plain string, or an object carrying `initiativeScopeMarkdown`. Build Studio stores a **structured** document, and nothing anywhere writes that field — so **every Build Studio design that has ever existed** resolved to null content and was refused:

```
record_initiative_design_review → "Build artifact revision is not an accepted
canonical initiative design."   (CANONICAL_DESIGN_REQUIRED)
```

The revision was fine — `field: designDoc`, `status: accepted`, revision 2 of 2. Its keys:

```
problemStatement, existingFunctionalityAudit, reusabilityAnalysis, reusePlan,
proposedApproach, dataModel, targetRoles, accessibility, acceptanceCriteria
```

No `initiativeScopeMarkdown`, and no code path that writes one.

That blocked **spec-approval, the canonical design baseline, and artifact author** — three of the six facts gating `ideate → plan`. And because spec-approval is `independent: true`, nobody could work around it: the owner may not record it, and the reviewer coworker that may was refused by the resolver.

## Everything above this is already verified working

Live on `FB-EB292B9F` (Second Chance Animal Rescue), on `v2026.08.28-revert-approval-resume.1`:

- the reviewer coworker routes (#4792)
- it holds the review-phase budget (#4794)
- it calls its writer with well-formed arguments
- the authority gate holds the call for employee approval
- approving and replaying the packet resumes the task — **`resumedFromApproval: true`**

The chain terminated here.

## Change

Render at **read** time rather than writing the field at save time: existing revisions resolve without rewriting stored artifacts, and the pinned `valueDigest` keeps covering exactly what the author saved.

The rendering is deterministic by construction — a baseline pins a digest and reviewers read this text, so the same stored value must always produce the same document. Section order is a fixed contract rather than `Object.keys` order, and nested object keys are sorted. An object carrying none of the known sections returns `null`: a value that is not a design document must not be dressed up as one.

## Verification

- `lib/backlog/initiative-readiness`: **15 files / 102 tests pass**, including 6 new ones covering the render, determinism under key reordering, fixed section order, omitted empty sections, and the null cases.
- `pnpm --filter web typecheck` clean; guard loop 37/37; module-size and Build Studio surface ratchets OK.
- **`pnpm run pregate` passed** — on retry; the prior attempt returned the gate's own `BLOCKED (control-plane starvation)` verdict, which it labels *"infrastructure evidence, NOT a product build failure."*

Refs: BI-126441FA, BI-C5D978E9, BI-3907AF35