### PR TITLE
fix(build-studio): record which engine authored a design document (BI-2D698C7B)

### DIFF
--- a/apps/web/lib/build/authoring-engine-agent.test.ts
+++ b/apps/web/lib/build/authoring-engine-agent.test.ts
@@ -1,0 +1,27 @@
+// BI-2D698C7B — a design's author must be named truthfully, or not at all.
+
+import { describe, expect, it } from "vitest";
+
+import { authoringAgentIdForEngine } from "./authoring-engine-agent";
+
+describe("authoringAgentIdForEngine", () => {
+  it("names the registered agent for each external engine", () => {
+    expect(authoringAgentIdForEngine("codex")).toBe("AGT-EXT-CODEX");
+    expect(authoringAgentIdForEngine("claude")).toBe("AGT-EXT-CLAUDE");
+    expect(authoringAgentIdForEngine("grok")).toBe("AGT-EXT-GROK");
+  });
+
+  // The bundled local engine has no registered agent. Inventing one would put a
+  // fabricated author on a governed artifact; a null author lets the readiness
+  // gate refuse, which is the correct outcome.
+  it("returns null for an engine with no registered agent", () => {
+    expect(authoringAgentIdForEngine("opencode")).toBeNull();
+    expect(authoringAgentIdForEngine("something-new")).toBeNull();
+  });
+
+  it("returns null when no engine is known", () => {
+    expect(authoringAgentIdForEngine(null)).toBeNull();
+    expect(authoringAgentIdForEngine(undefined)).toBeNull();
+    expect(authoringAgentIdForEngine("")).toBeNull();
+  });
+});

--- a/apps/web/lib/build/authoring-engine-agent.ts
+++ b/apps/web/lib/build/authoring-engine-agent.ts
@@ -1,0 +1,42 @@
+// apps/web/lib/build/authoring-engine-agent.ts
+//
+// BI-2D698C7B — which agent authored a design document?
+//
+// resolveInitiativeArtifact requires BOTH a unique author principal and a
+// `savedByAgentId` on the revision:
+//
+//   if (!authorPrincipalId || !revision.savedByAgentId) {
+//     return authorRequired("Build artifact author provenance is incomplete
+//                            or ambiguous.");
+//   }
+//
+// Every BuildArtifactRevision on the Pet Rescue install had
+// `savedByAgentId = NULL` — 12 of 12 — because the ideate dispatch saves the
+// design through saveBuildEvidence with an empty context, so `context?.agentId`
+// is null. The engine that actually wrote the document is known at that call
+// site and simply was not carried in. ARTIFACT_AUTHOR_REQUIRED could therefore
+// never clear, and with it neither could the canonical design baseline.
+//
+// The registry (packages/db/data/agent_registry.json) holds one agent per
+// external engine. There is no registered agent for the bundled local engine,
+// and this deliberately does NOT invent one: a design whose author cannot be
+// named truthfully must keep a null author rather than a fabricated one. The
+// gate refusing such a revision is the correct outcome, not a bug to paper over.
+
+/** Build engines that have a registered agent identity. */
+const ENGINE_AGENT_IDS: Readonly<Record<string, string>> = {
+  claude: "AGT-EXT-CLAUDE",
+  codex: "AGT-EXT-CODEX",
+  grok: "AGT-EXT-GROK",
+};
+
+/**
+ * The agent id to record as the author of an artifact produced by `engine`.
+ *
+ * Returns null when the engine has no registered agent — the honest answer,
+ * and the one that leaves the readiness gate free to refuse.
+ */
+export function authoringAgentIdForEngine(engine: string | null | undefined): string | null {
+  if (!engine) return null;
+  return ENGINE_AGENT_IDS[engine] ?? null;
+}

--- a/apps/web/lib/build/ideate-on-approval.ts
+++ b/apps/web/lib/build/ideate-on-approval.ts
@@ -395,11 +395,19 @@ export async function dispatchIdeateForApprovedBuild(params: {
     // The designDoc would then persist to the wrong build while this build's
     // activity log (correct buildId in scope) records "saved", leaving this
     // build stuck at the post-ideate gate with no design doc.
+    // BI-2D698C7B: record WHICH engine authored this design. The context was
+    // empty here, so saveBuildEvidence stored savedByAgentId = null on every
+    // design Build Studio has ever written — and resolveInitiativeArtifact
+    // requires a non-null authoring agent, so ARTIFACT_AUTHOR_REQUIRED could
+    // never clear and no design could become a canonical baseline. The engine
+    // is already resolved at this point and the activity log already names it.
+    const { authoringAgentIdForEngine } = await import("@/lib/build/authoring-engine-agent");
+    const authoringAgentId = authoringAgentIdForEngine(resolvedAttempt.engine);
     const saveResult = await executeTool(
       "saveBuildEvidence",
       { buildId, field: "designDoc", value: ideateResult.designDoc },
       userId,
-      {},
+      authoringAgentId ? { agentId: authoringAgentId } : {},
     );
 
     if (!saveResult.success) {


### PR DESCRIPTION
## Problem

`resolveInitiativeArtifact` requires **both** a unique author principal and a `savedByAgentId`:

```ts
if (!authorPrincipalId || !revision.savedByAgentId) {
  return authorRequired("Build artifact author provenance is incomplete or ambiguous.");
}
```

Every `BuildArtifactRevision` on the Pet Rescue install had `savedByAgentId = NULL` — **12 of 12**. The ideate dispatch saves the design through `saveBuildEvidence` with an **empty context**, so `context?.agentId` was null — while the engine that produced the document was already resolved two lines earlier and named in the activity log (*"Dispatching ideate research via codex"*, *"Auto-dispatched and saved designDoc in 129.9s"*).

So `ARTIFACT_AUTHOR_REQUIRED` could never clear, and with it neither the canonical design baseline nor spec-approval. Because spec-approval is `independent: true`, nobody could work around it.

## The chain, each link verified as the one before it was fixed

Live on `FB-EB292B9F` (Second Chance Animal Rescue):

| | |
|---|---|
| #4792 | reviewer coworker routes at all |
| #4794 | it holds the review-phase budget |
| | it calls its writer with well-formed arguments |
| | the authority gate holds the call for employee approval |
| #4797 | approving and replaying resumes the task — `resumedFromApproval: true` |
| #4800 | the design resolves as canonical initiative text |
| **here** | the design has a named author |

Each fix moved the error to the next check, which is what confirmed the one before it.

## Change

Map the resolved engine to its registered agent, from `packages/db/data/agent_registry.json`: `AGT-EXT-CLAUDE`, `AGT-EXT-CODEX`, `AGT-EXT-GROK`.

**There is no registered agent for the bundled local engine, and this deliberately does not invent one.** A design whose author cannot be named truthfully keeps a null author, and the readiness gate refusing it is the correct outcome — not something to paper over with a fabricated identity on a governed artifact that feeds a governance decision.

## Verification

- `lib/build` + `lib/mcp`: **328 files / 3390 tests pass**; 3 new tests cover the registered engines, an engine with no agent, and no engine at all.
- `pnpm --filter web typecheck` clean; guard loop 37/37; module-size and Build Studio surface ratchets OK.
- **`pnpm run pregate` passed** — full local CI-equivalent gate.

Refs: BI-2D698C7B, BI-126441FA, BI-C5D978E9