### PR TITLE
fix(review): keep terminal writer resumable

### DIFF
--- a/apps/web/lib/mcp-task-execution.ts
+++ b/apps/web/lib/mcp-task-execution.ts
@@ -8,7 +8,10 @@ import {
 } from "@/lib/tak/autonomous-work-run";
 import { createTaskMessage } from "@/lib/tak/task-records";
 import { deriveEffortWarrant } from "@/lib/tak/effort-warrant";
-import { createInitiativeReviewTerminalToolPolicy } from "@/lib/tak/terminal-tool-policy";
+import {
+  createInitiativeReviewTerminalToolPolicy,
+  enterTerminalWriterPhase,
+} from "@/lib/tak/terminal-tool-policy";
 import {
   createResourceWaitProjection,
   preInferenceResourceWait,
@@ -101,13 +104,16 @@ export async function executeRemoteTaskAttempt(input: {
         messageChars: parsed.prompt.length,
       })
     : undefined;
-  const terminalToolPolicy = parsed.initiativeReviewBinding
+  const baseTerminalToolPolicy = parsed.initiativeReviewBinding
     ? createInitiativeReviewTerminalToolPolicy(
         parsed.initiativeReviewBinding.writerToolName,
         exactRequiredToolNames,
         parsed.initiativeReviewBinding.artifactRef,
       )
     : null;
+  const terminalToolPolicy = baseTerminalToolPolicy && input.resumeKind === "terminal-writer"
+    ? enterTerminalWriterPhase(baseTerminalToolPolicy)
+    : baseTerminalToolPolicy;
   const resumedFlag = !input.idempotentReplay
     ? {}
     : input.resumeKind === "terminal-writer"
@@ -185,7 +191,7 @@ export async function executeRemoteTaskAttempt(input: {
           idempotentReplay: input.idempotentReplay,
           ...resumedFlag,
           requiresApproval: false,
-          resumable: terminalWriterAttempt < 2,
+          resumable: true,
           waitReason: "missing-terminal-writer",
           content: remoteTaskContent(result.content),
           executedToolCount: result.executedTools?.length ?? 0,

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -209,7 +209,7 @@ function replayOrConflict(existing: ExistingRemoteTask, requestDigest: string): 
       idempotentReplay: true,
       requiresApproval: existing.status === "input-required" && !terminalWriterWait,
       ...(terminalWriterWait ? {
-        resumable: terminalWriterWait.attempt < 2,
+        resumable: true,
         waitReason: terminalWriterWait.kind,
       } : resourceWait ? {
         resumable: true,
@@ -229,30 +229,28 @@ async function reserveTerminalWriterReplay(input: {
   if (storedRequestDigest(input.existing) !== input.requestDigest) return null;
 
   const existingWait = parseTerminalWriterWait(input.existing.progressPayload);
-  const isProjectedWait = input.existing.status === "input-required" && existingWait?.attempt === 1;
+  const isProjectedWait = input.existing.status === "input-required" && existingWait !== null;
   const isRecoverableCompletedExit = input.existing.status === "completed" && !existingWait;
   if (!isProjectedWait && !isRecoverableCompletedExit) return null;
 
-  if (isRecoverableCompletedExit) {
-    const [successfulReader, writerAttempt] = await Promise.all([
-      prisma.toolExecution.findFirst({
-        where: {
-          taskRunId: input.existing.taskRunId,
-          toolName: { in: [...input.terminalToolPolicy.readerToolNames] },
-          success: true,
-        },
-        select: { id: true },
-      }),
-      prisma.toolExecution.findFirst({
-        where: {
-          taskRunId: input.existing.taskRunId,
-          toolName: input.terminalToolPolicy.writerToolName,
-        },
-        select: { id: true },
-      }),
-    ]);
-    if (!successfulReader || writerAttempt) return null;
-  }
+  const [successfulReader, writerAttempt] = await Promise.all([
+    prisma.toolExecution.findFirst({
+      where: {
+        taskRunId: input.existing.taskRunId,
+        toolName: { in: [...input.terminalToolPolicy.readerToolNames] },
+        success: true,
+      },
+      select: { id: true },
+    }),
+    prisma.toolExecution.findFirst({
+      where: {
+        taskRunId: input.existing.taskRunId,
+        toolName: input.terminalToolPolicy.writerToolName,
+      },
+      select: { id: true },
+    }),
+  ]);
+  if (!successfulReader || writerAttempt) return null;
 
   const progress = input.existing.progressPayload && typeof input.existing.progressPayload === "object"
     && !Array.isArray(input.existing.progressPayload)
@@ -264,7 +262,7 @@ async function reserveTerminalWriterReplay(input: {
     kind: "missing-terminal-writer",
     writerToolName: input.terminalToolPolicy.writerToolName,
     resumeMode: "same-taskrun",
-    attempt: 2,
+    attempt: existingWait ? existingWait.attempt + 1 : 2,
     observedAt: now,
   };
   const reservation = await prisma.taskRun.updateMany({

--- a/apps/web/lib/mcp-task-terminal-writer.test.ts
+++ b/apps/web/lib/mcp-task-terminal-writer.test.ts
@@ -242,6 +242,15 @@ describe("terminal writer resumption", () => {
       a2aMetadata: metadata,
     });
     db.findEnvelope.mockResolvedValue(null);
+    db.findToolExecution.mockImplementation(async (query: { where?: { toolName?: unknown } }) => {
+      const toolName = query.where?.toolName;
+      if (toolName === "record_initiative_evidence") return null;
+      return {
+        id: "reader-1",
+        toolName: "read_source_at_version",
+        success: true,
+      };
+    });
     db.updateMany.mockResolvedValue({ count: 1 });
     db.update.mockResolvedValue({});
     db.findUnique.mockResolvedValue({ status: "working" });
@@ -290,7 +299,7 @@ describe("terminal writer resumption", () => {
     });
   });
 
-  it("does not execute a third attempt after the bounded missing-writer resume", async () => {
+  it("keeps the same TaskRun resumable in a writer-only phase after attempt two", async () => {
     const exhaustedParams = { ...params, idempotencyKey: "missing-writer-resume-exhausted" };
     const metadata = await persistedMetadata("PAT-WRITER-EXHAUSTED", exhaustedParams);
     vi.clearAllMocks();
@@ -314,11 +323,34 @@ describe("terminal writer resumption", () => {
       a2aMetadata: metadata,
     });
     db.findEnvelope.mockResolvedValue(null);
+    db.findToolExecution.mockImplementation(async (query: { where?: { toolName?: unknown } }) => {
+      const toolName = query.where?.toolName;
+      if (toolName === "record_initiative_evidence") return null;
+      return {
+        id: "cmtd3zymp00hh01rtpf9ukk8z",
+        toolName: "read_source_at_version",
+        success: true,
+      };
+    });
+    autonomous.execute.mockResolvedValue({
+      content: "The independent review stopped without recording a governed assessment. No receipt was created.",
+      executedTools: [],
+      failure: {
+        kind: "terminal-writer-missing",
+        message: "The independent review stopped without recording a governed assessment. No receipt was created.",
+      },
+    });
 
     const outcome = await submit("PAT-WRITER-EXHAUSTED", exhaustedParams);
 
-    expect(autonomous.execute).not.toHaveBeenCalled();
-    expect(db.updateMany).not.toHaveBeenCalled();
+    expect(autonomous.execute).toHaveBeenCalledWith(expect.objectContaining({
+      taskRunId: "TR-MCP-WRITER-EXHAUSTED",
+      terminalToolPolicy: expect.objectContaining({
+        terminalPhase: "writer-only",
+        persistedEvidenceAvailable: true,
+      }),
+    }));
+    expect(autonomous.create).not.toHaveBeenCalled();
     expect(outcome).toMatchObject({
       kind: "result",
       result: {
@@ -326,9 +358,18 @@ describe("terminal writer resumption", () => {
         status: "input-required",
         idempotentReplay: true,
         requiresApproval: false,
-        resumable: false,
+        resumable: true,
         waitReason: "missing-terminal-writer",
       },
+    });
+    expect(db.update).toHaveBeenCalledWith({
+      where: { taskRunId: "TR-MCP-WRITER-EXHAUSTED" },
+      data: expect.objectContaining({
+        status: "input-required",
+        progressPayload: expect.objectContaining({
+          terminalWriterWait: expect.objectContaining({ attempt: 3 }),
+        }),
+      }),
     });
   });
 });

--- a/apps/web/lib/tak/terminal-tool-policy.test.ts
+++ b/apps/web/lib/tak/terminal-tool-policy.test.ts
@@ -3,6 +3,7 @@ import {
   applyTerminalToolSurface,
   buildTerminalToolReminder,
   createInitiativeReviewTerminalToolPolicy,
+  enterTerminalWriterPhase,
   normalizeTerminalToolArguments,
   resolveTerminalTextExit,
   resolveTerminalToolCall,
@@ -220,6 +221,27 @@ describe("terminal tool policy", () => {
       writerAttempted: true,
     });
   });
+
+  it("enters a writer-only terminal phase from persisted immutable evidence", () => {
+    const resumed = enterTerminalWriterPhase(policy);
+    const providerTools = [
+      { type: "function", function: { name: "read_source_at_version" } },
+      { type: "function", function: { name: "search_source_at_version" } },
+      { type: "function", function: { name: policy.writerToolName } },
+    ];
+
+    expect(summarizeTerminalToolProgress(resumed, [])).toMatchObject({
+      evidenceAvailable: true,
+      writerAttempted: false,
+    });
+    expect(applyTerminalToolSurface(resumed, [], providerTools)).toEqual([
+      { type: "function", function: { name: policy.writerToolName } },
+    ]);
+    expect(resolveTerminalToolCall(resumed, [], "read_source_at_version")).toMatchObject({
+      kind: "refuse",
+      result: { error: "terminal_writer_phase_reader_refused" },
+    });
+  });
 });
 
 describe("agent loop terminal writer integration", () => {
@@ -322,6 +344,24 @@ describe("agent loop terminal writer integration", () => {
       kind: "terminal-writer-missing",
       message: expect.stringContaining("No receipt was created"),
     });
+  });
+
+  it("starts a resumed terminal-writer turn with only the governed writer", async () => {
+    const resumedPolicy = enterTerminalWriterPhase(policy);
+    vi.mocked(routeAndCall)
+      .mockResolvedValueOnce(response("I already have the persisted evidence.") as never)
+      .mockResolvedValueOnce(response("", [{ id: "writer", name: policy.writerToolName, arguments: {} }]) as never)
+      .mockResolvedValueOnce(response("The governed writer rejected the assessment, so no receipt exists.") as never);
+
+    const result = await runAgenticLoop({ ...params, terminalToolPolicy: resumedPolicy });
+
+    const firstTools = (vi.mocked(routeAndCall).mock.calls[0]![3] as { tools: typeof providerTools }).tools;
+    const secondTools = (vi.mocked(routeAndCall).mock.calls[1]![3] as { tools: typeof providerTools }).tools;
+    expect(firstTools.map((tool) => tool.function.name)).toEqual([policy.writerToolName]);
+    expect(secondTools.map((tool) => tool.function.name)).toEqual([policy.writerToolName]);
+    expect(result.executedTools).toEqual([
+      expect.objectContaining({ name: policy.writerToolName }),
+    ]);
   });
 
   it("preserves ordinary route-failure handling when no terminal policy applies", async () => {

--- a/apps/web/lib/tak/terminal-tool-policy.ts
+++ b/apps/web/lib/tak/terminal-tool-policy.ts
@@ -4,6 +4,8 @@ export type TerminalToolPolicy = {
   minimumSuccessfulReaderCalls: number;
   maximumReaderCalls: number;
   immutableReaderArguments?: ImmutableReaderArguments;
+  terminalPhase?: "writer-only";
+  persistedEvidenceAvailable?: boolean;
 };
 
 export type ImmutableReaderArguments = {
@@ -51,6 +53,19 @@ export function createInitiativeReviewTerminalToolPolicy(
         },
       }
     : null;
+}
+
+/**
+ * Resume a review that already persisted successful immutable evidence without
+ * reopening the reader surface. The resumed turn is a bounded writer phase:
+ * the model may propose only the independently selected governed assessment.
+ */
+export function enterTerminalWriterPhase(policy: TerminalToolPolicy): TerminalToolPolicy {
+  return {
+    ...policy,
+    terminalPhase: "writer-only",
+    persistedEvidenceAvailable: true,
+  };
 }
 
 export type TerminalToolArgumentDisposition =
@@ -179,7 +194,13 @@ export function summarizeTerminalToolProgress(
 ): TerminalToolProgress {
   const readers = new Set(policy.readerToolNames);
   const readerRecords = records.filter((record) => readers.has(record.name));
-  const successfulReaderCalls = readerRecords.filter((record) => record.result.success).length;
+  const persistedReaderCalls = policy.persistedEvidenceAvailable
+    ? policy.minimumSuccessfulReaderCalls
+    : 0;
+  const successfulReaderCalls = Math.max(
+    persistedReaderCalls,
+    readerRecords.filter((record) => record.result.success).length,
+  );
   return {
     readerAttempts: readerRecords.length,
     successfulReaderCalls,
@@ -195,6 +216,16 @@ export function resolveTerminalToolCall(
   toolName: string,
 ): TerminalToolCallDisposition {
   const progress = summarizeTerminalToolProgress(policy, records);
+  if (policy.terminalPhase === "writer-only" && policy.readerToolNames.includes(toolName)) {
+    return {
+      kind: "refuse",
+      result: {
+        success: false,
+        error: "terminal_writer_phase_reader_refused",
+        message: `Immutable evidence is already persisted. Call ${policy.writerToolName} now.`,
+      },
+    };
+  }
   if (toolName === policy.writerToolName && !progress.evidenceAvailable) {
     return {
       kind: "refuse",
@@ -241,6 +272,9 @@ export function applyTerminalToolSurface(
   records: readonly TerminalToolRecord[],
   providerTools: readonly Record<string, unknown>[],
 ): Array<Record<string, unknown>> {
+  if (policy.terminalPhase === "writer-only") {
+    return selectTerminalToolSurface(providerTools, [policy.writerToolName]);
+  }
   const progress = summarizeTerminalToolProgress(policy, records);
   return progress.readerBudgetExhausted && !progress.writerAttempted
     ? selectTerminalToolSurface(providerTools, [policy.writerToolName])
@@ -252,6 +286,9 @@ export function buildTerminalToolReminder(
   records: readonly TerminalToolRecord[],
 ): string {
   const progress = summarizeTerminalToolProgress(policy, records);
+  if (policy.terminalPhase === "writer-only") {
+    return `Immutable evidence is already persisted. Call ${policy.writerToolName} now; do not read again or respond with prose first.`;
+  }
   if (progress.readerBudgetExhausted) return `Call ${policy.writerToolName} now; the bounded evidence budget is complete.`;
   const remaining = policy.maximumReaderCalls - progress.readerAttempts;
   return `Use the immutable evidence readers before ${policy.writerToolName}. ${remaining} bounded evidence calls remain; reserve the terminal step for the governed writer.`;


### PR DESCRIPTION
## Summary

- resume initiative reviews on the same TaskRun after persisted immutable reads without reopening the reader surface
- expose only the governed terminal writer during resumed terminal phases
- keep missing-writer waits resumable beyond attempt two while refusing recovery when reader proof is absent or any writer attempt exists

## Design grounding

- Existing specs/plans reviewed: docs/superpowers/specs/2026-08-26-external-reviewer-organization-authority-design.md and the BI-SIG terminal-writer acceptance contract.
- Current code substrate reviewed: pps/web/lib/tak/terminal-tool-policy.ts, pps/web/lib/mcp-task-execution.ts, and pps/web/lib/mcp-task-submit.ts.
- Source of truth: persisted successful ToolExecution rows plus the server-issued InitiativeReviewBinding.
- Decision: persisted reader evidence may authorize only a writer-only same-TaskRun phase; it cannot authorize a writer result or bypass approval.

## Verification

- focused terminal-policy and TaskRun tests: 25/25 passed
- adjacent submission, capacity, approval recovery, and agent-loop tests: 66/66 passed
- dedicated submission suite: 13/13 passed
- web typecheck passed
- style/token drift passed
- repository guard loop passed all 37 groups
- module-size ratchet passed
- governed exact-tree local CI passed: cmtd5fb4201pw01rt5gelaeig (NPEL-62A81406DC)

## Review honesty

Semantic receipt cmtd4lvmc015v01rtte997rho is a genuine FAIL because the review call transported the commit identifier rather than the actual diff payload; it contains no source finding and no PASS is inferred. The server marked the review shadow-observe/mayPublish. This self-hosting repair proceeds under the operator's recorded bootstrap authorization, with DCO and every protected PR and merge-group check mandatory.

Backlog: BI-DE58CFE8
Workroom: WC-14EA9122