### PR TITLE
fix(inference): stop one ambiguous word clamping a coworker turn to the local model (BI-DECCF716)

### DIFF
--- a/apps/web/lib/inference/data-screening/classify-payload.test.ts
+++ b/apps/web/lib/inference/data-screening/classify-payload.test.ts
@@ -553,4 +553,66 @@ describe("a field named 'discipline' is not evidence of an HR record", () => {
 
     expect(result.overallSensitivity).toBe("confidential");
   });
+  it("does not treat an uncorroborated ambiguous match as data-evidenced (BI-DECCF716)", () => {
+    // The live /workspace/inbox shape: a real contact detail, plus one ambiguous
+    // employee-records reason echoed across a tool-call argument key and the
+    // prompt remainder. `classifiedDataClasses` must still disclose everything;
+    // `dataEvidencedClasses` is what selects the vertical packs, and one
+    // ambiguous word must not put a `restricted`-bound class in front of the PDP.
+    const result = classifyInferencePayload({
+      messages: [
+        { role: "user", content: "Group the decisions from pat@example.com's note." },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{
+            id: "c1",
+            name: "get_capability_completeness",
+            arguments: { discipline: "platform-engineering" },
+          }],
+        },
+      ],
+      systemPrompt: "You keep an eye on delivery performance.",
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).toBe("confidential");
+    expect(result.dataClasses).toContain("employee-records");
+    expect(result.dataEvidencedClasses).toEqual(["customer-records"]);
+  });
+
+  it("keeps a restricted class data-evidenced once corroboration is met", () => {
+    const result = classifyInferencePayload({
+      messages: [{
+        role: "assistant",
+        content: "",
+        toolCalls: [{
+          id: "c1",
+          name: "plan_work",
+          arguments: { discipline: "platform-engineering", incident: "INC-4" },
+        }],
+      }],
+      systemPrompt: "Be concise.",
+      taskType: "conversation",
+    });
+
+    expect(result.overallSensitivity).toBe("restricted");
+    expect(result.dataEvidencedClasses).toContain("employee-records");
+  });
+
+  it("keeps a caller-declared restricted hint data-evidenced on its own", () => {
+    const result = classifyInferencePayload({
+      messages: [{ role: "user", content: "Summarize this." }],
+      systemPrompt: "Be concise.",
+      taskType: "conversation",
+      governedData: [{
+        classificationKnown: true,
+        sensitivity: "restricted",
+        dataClasses: ["employee-records"],
+      }],
+    });
+
+    expect(result.overallSensitivity).toBe("restricted");
+    expect(result.dataEvidencedClasses).toContain("employee-records");
+  });
 });

--- a/apps/web/lib/inference/data-screening/classify-payload.ts
+++ b/apps/web/lib/inference/data-screening/classify-payload.ts
@@ -260,9 +260,23 @@ export function classifyInferencePayload(
 
   const dedupedMatches = dedupeMatches(matches);
   const dataClasses = uniqueSorted(dedupedMatches.map((match) => match.dataClass));
+  const dataMatches = dedupedMatches.filter((match) => !isInstructionProvenance(match));
+  // The corroboration bar decides BOTH verdicts a restricted class can drive.
+  // Sensitivity was gated on it from the start; the data-evidenced set was not,
+  // and that set selects the vertical policy packs — each of which asserts its
+  // own class sensitivity in the PDP context, overriding the gated one. So an
+  // uncorroborated ambiguous match still reached `restricted-external-destination`
+  // and clamped residency to local_only, voiding the gate on the harder of the
+  // two exclusions. One predicate, both verdicts (BI-DECCF716).
+  const restrictedCorroborated = restrictedEvidenceIsCorroborated(
+    dataMatches,
+    input.governedData,
+  );
   const dataEvidencedClasses = uniqueSorted(
-    dedupedMatches
-      .filter((match) => !isInstructionProvenance(match))
+    dataMatches
+      .filter((match) =>
+        restrictedCorroborated || !RESTRICTED_CLASSES.has(match.dataClass)
+      )
       .map((match) => match.dataClass),
   );
   const overallSensitivity = inferOverallSensitivity(dedupedMatches, input.governedData);
@@ -569,6 +583,28 @@ function splitPromptByProvenance(
   return { instruction: present, data: remainder };
 }
 
+/**
+ * Does the turn's DATA carry restricted-class evidence strong enough to act on?
+ *
+ * The bar itself is unchanged (see the essay above `INSTRUCTION_PATH_PREFIX`):
+ * a caller-declared restricted hint, any precise match, or two distinct
+ * ambiguous detectors agreeing. What changed is who asks. Both the sensitivity
+ * verdict and the data-evidenced class set now call this one predicate, so a
+ * lone ambiguous word can no longer clear one and fail the other.
+ */
+function restrictedEvidenceIsCorroborated(
+  dataMatches: readonly InferencePayloadMatch[],
+  governedData: readonly GovernedPayloadHint[] | undefined,
+): boolean {
+  if (governedData?.some((hint) => hint.sensitivity === "restricted")) return true;
+  const restrictedMatches = dataMatches.filter((match) =>
+    RESTRICTED_CLASSES.has(match.dataClass)
+  );
+  if (restrictedMatches.some((match) => !AMBIGUOUS_REASONS.has(match.reason))) return true;
+  // One word echoed across many probes is one signal: count distinct reasons.
+  return new Set(restrictedMatches.map((match) => match.reason)).size >= 2;
+}
+
 function inferOverallSensitivity(
   matches: readonly InferencePayloadMatch[],
   governedData: readonly GovernedPayloadHint[] | undefined,
@@ -591,15 +627,7 @@ function inferOverallSensitivity(
   // data and escalates exactly as a message would.
   const dataMatches = matches.filter((match) => !isInstructionProvenance(match));
   const restrictedMatches = dataMatches.filter((match) => RESTRICTED_CLASSES.has(match.dataClass));
-  const hasPreciseEvidence = restrictedMatches.some(
-    (match) => !AMBIGUOUS_REASONS.has(match.reason),
-  );
-  const distinctAmbiguousReasons = new Set(
-    restrictedMatches
-      .filter((match) => AMBIGUOUS_REASONS.has(match.reason))
-      .map((match) => match.reason),
-  ).size;
-  if (hasPreciseEvidence || distinctAmbiguousReasons >= 2) {
+  if (restrictedEvidenceIsCorroborated(dataMatches, governedData)) {
     return "restricted";
   }
 

--- a/apps/web/lib/inference/data-screening/routed-screening.test.ts
+++ b/apps/web/lib/inference/data-screening/routed-screening.test.ts
@@ -226,3 +226,61 @@ describe("prompt provenance decides whether a turn may leave the box", () => {
     expect(screen.receipt.routeEffect).toBe("local-only");
   });
 });
+
+// BI-DECCF716. The provenance split above covers the coworker's job description.
+// This is the panel shape it does not cover: message content and prior tool calls
+// are data by construction, so one ambiguous word there used to load the
+// employee-records pack, whose `restricted` binding sensitivity overrode the
+// corroboration-gated verdict and denied export outright.
+describe("an uncorroborated ambiguous word does not deny export", () => {
+  const persona =
+    "You are the COO. You coordinate operations: payroll runs, invoice approvals, " +
+    "salary review cycles, and team performance.";
+
+  const inboxTurn = () =>
+    createRoutedInferenceScreen({
+      messages: [
+        {
+          role: "user",
+          content: "How many distinct decisions are in my inbox today? Note from pat@example.com.",
+        },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{
+            id: "c1",
+            name: "get_capability_completeness",
+            arguments: { discipline: "platform-engineering" },
+          }],
+        },
+      ],
+      systemPrompt: persona,
+      systemPromptInstructionSpans: [persona],
+      taskType: "conversation",
+      routeContext: { sensitivity: "confidential", residencyPolicy: "any_enabled" },
+    }).screen;
+
+  it("no longer reaches the restricted export denial", () => {
+    const screen = inboxTurn();
+
+    expect(screen.receipt.policyEffect).not.toBe("deny");
+    expect(screen.receipt.explanationCodes).not.toContain("restricted-cannot-leave-boundary");
+  });
+
+  it("does not load the pack for the uncorroborated class", () => {
+    const screen = inboxTurn();
+
+    expect(screen.receipt.policyPackVersions).toEqual(["vertical-customer-records@1.0.0"]);
+    expect(screen.receipt.classifiedDataClasses).toContain("employee-records");
+  });
+
+  it("still holds the turn local for the contact detail it really carries", () => {
+    // Not a regression: the mask obligation from a real contact detail is the
+    // second, separate clamp (BI-0064680C). Asserted so a later change to that
+    // path shows up here rather than silently widening this one.
+    const screen = inboxTurn();
+
+    expect(screen.receipt.obligationKinds).toContain("mask");
+    expect(screen.routeContext.residencyPolicy).toBe("local_only");
+  });
+});


### PR DESCRIPTION
## The report

The COO coworker could not complete any request opened from `/workspace/inbox`. Two operator runs on 2026-08-28 — a long prompt and a nine-word one — each ran for minutes on the bundled local model, looped through five or six tool calls, and returned an apology at the safety limit.

## What was actually binding

Every Anthropic endpoint in the `excludedTrace` of all seven inbox turns carries the same reason:

> `Residency policy 'local_only' requires a local provider (Docker Model Runner or Ollama)`

Not provider availability, not prompt length. The screen receipt shows why: `policyEffect: deny`, `explanationCodes: [confidential-masked-before-projection, restricted-cannot-leave-boundary]`, packs `[vertical-customer-records, vertical-employee-records]`. And the employee-records evidence behind that denial was **one ambiguous reason echoed across two probes** — a tool-call argument key named `discipline` and the undeclared remainder of the prompt. `measuredSensitivity` was `confidential`: the corroboration gate had already looked at that evidence and declined to escalate.

## The defect

`classifyInferencePayload` computed `dataEvidencedClasses` as every non-instruction match, with no evidence bar. `buildPolicyContexts` then builds one PDP context per data-evidenced class with `sensitivity: binding.sensitivity` — `restricted` for employee-records — which overrides the corroboration-gated `overallSensitivity`. That context matches `restricted-external-destination`, obligations are emptied on deny so `routed-screening` cannot take the mask-then-project path, and `residencyPolicy` clamps to `local_only`.

So the bar [BI-CD13D818] put in front of the sensitivity verdict was never put in front of the residency verdict — the harder of the two exclusions. Moving `discipline` into the ambiguous rule ([BI-3F608240], already landed) demonstrably did not unblock these turns.

## The change

Hoist the corroboration test out of `inferOverallSensitivity` into one predicate, and call it from both verdicts. When restricted-class evidence is uncorroborated, no restricted class is data-evidenced, so its vertical pack is not loaded and its `restricted` binding sensitivity never reaches the PDP.

Unchanged, and covered by tests: a caller-declared restricted governed hint escalates alone; a precise match escalates alone; two distinct ambiguous reasons escalate; the receipt's `classifiedDataClasses` still discloses every detected class. The change narrows what is acted on, not what is disclosed.

## What this does not fix

The turn is still `local_only` — for the contact detail it really carries, which is the control working. `customer-records` raises a mask obligation, and `maskForContext` refuses to mask unless the caller declares `sensitiveDetailUse: "replaceable"`, which no coworker caller ever does. Filed as [BI-0064680C] and asserted as current behaviour in `routed-screening.test.ts`, so a change to that path shows up here rather than silently widening this one.

## Verification

- `vitest run lib/inference/data-screening/ lib/inference/routing-exclusion lib/govern/data` — 291 passed.
- New classifier and routed-screening tests confirmed red before the fix.
- `pnpm pregate:preflight` — 53 guards clean.
- `pnpm --filter web exec tsc --noEmit` — clean.
- `pnpm run pregate` — PASS, evidence `cmtdaec4e33c101md42ttiqm9`, gated sha `a76a8c878879`.

No docs surface documents this behaviour; the user-guide AI operations page describes classification outcomes, not the corroboration rule.

Closes BI-DECCF716.