### PR TITLE
fix(guards): doc-anchor must not OK when origin/main is unresolvable (BI-B6433DC6)

### DIFF
--- a/scripts/check-doc-anchor-existence.mjs
+++ b/scripts/check-doc-anchor-existence.mjs
@@ -26,6 +26,9 @@
 //     ambiguous response ⇒ WARN and pass, printing exactly what was skipped.
 //     CI without a live install must never hard-fail here; the gate bites on
 //     contributor machines and installs where the portal is up.
+//   - DOES NOT degrade on an unresolvable BASE_SHA (BI-B6433DC6). "I could not
+//     compute the diff" is not "the diff was empty". That case exits non-zero
+//     and must never print OK.
 //
 //   node scripts/check-doc-anchor-existence.mjs            # check (CI)
 //   node scripts/check-doc-anchor-existence.mjs --update   # regenerate the grandfather baseline
@@ -174,12 +177,53 @@ export async function verifyAnchors(pairs, lookup) {
 }
 
 const REF_RE = /^[A-Za-z0-9._\-/]{1,200}$/;
-function git(...args) {
+
+/**
+ * Run git in the repo. Distinguishes success from failure — never collapse a
+ * failed invocation into an empty string (BI-B6433DC6).
+ */
+export function runGit(args, { exec = execFileSync } = {}) {
   try {
-    return execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+    const stdout = exec("git", args, {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { ok: true, stdout: String(stdout ?? ""), stderr: "" };
   } catch (e) {
-    return (e.stdout && e.stdout.toString()) || "";
+    return {
+      ok: false,
+      stdout: (e.stdout && e.stdout.toString()) || "",
+      stderr: (e.stderr && e.stderr.toString()) || e.message || "",
+      status: e.status ?? 1,
+    };
   }
+}
+
+/**
+ * Files changed vs `base`. An unresolvable ref or a failed three-dot diff is
+ * `unresolvable`, never an empty list — a shallow clone can name origin/main
+ * and still fail the merge-base (BI-B6433DC6).
+ */
+export function listChangedFiles(base, { git = runGit } = {}) {
+  const parsed = git(["rev-parse", "--verify", `${base}^{commit}`]);
+  if (!parsed.ok) {
+    return {
+      status: "unresolvable",
+      files: [],
+      detail: (parsed.stderr || parsed.stdout || "").trim(),
+    };
+  }
+  const diff = git(["diff", "--name-only", `${base}...HEAD`]);
+  if (!diff.ok) {
+    return {
+      status: "unresolvable",
+      files: [],
+      detail: (diff.stderr || diff.stdout || "").trim(),
+    };
+  }
+  const files = diff.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+  return { status: "ok", files, detail: "" };
 }
 
 function scanAllDocs() {
@@ -232,14 +276,18 @@ async function main() {
     console.error(`[doc-anchor] refusing unsafe BASE_SHA: ${JSON.stringify(base)}`);
     process.exit(1);
   }
-  const diffOutput = git("diff", "--name-only", `${base}...HEAD`);
-  if (!diffOutput.trim()) {
-    console.log(`[doc-anchor] No diff against ${base} (or ref unavailable) — nothing to check. OK.`);
+  const changed = listChangedFiles(base);
+  if (changed.status === "unresolvable") {
+    console.error(`[doc-anchor] cannot resolve ${base} — the guard did not run. This is not a pass.`);
+    console.error("[doc-anchor] Remedy: git fetch --deepen 50 origin  (or git fetch origin main) and re-run.");
+    if (changed.detail) console.error(`[doc-anchor] git: ${changed.detail}`);
+    process.exit(1);
+  }
+  if (changed.files.length === 0) {
+    console.log(`[doc-anchor] No diff against ${base} — nothing to check. OK.`);
     return;
   }
-  const changedDocs = diffOutput
-    .split("\n").map((s) => s.trim())
-    .filter((f) => f.startsWith("docs/") && f.endsWith(".md"));
+  const changedDocs = changed.files.filter((f) => f.startsWith("docs/") && f.endsWith(".md"));
 
   const newPairs = [];
   for (const doc of changedDocs) {

--- a/scripts/check-doc-anchor-existence.test.mjs
+++ b/scripts/check-doc-anchor-existence.test.mjs
@@ -4,10 +4,15 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import {
   classifyId,
   extractAnchorIds,
   interpretToolResponse,
+  listChangedFiles,
   parseAnchorBaseline,
   serializeAnchorBaseline,
   verifyAnchors,
@@ -143,4 +148,65 @@ test("interpretToolResponse: an error result without not_found stays unknown, ne
     },
   });
   assert.equal(interpretToolResponse("backlog-item", "BI-3F17B16B", scopeError), "unknown");
+});
+
+// BI-B6433DC6: "I could not compute the diff" is not "the diff was empty".
+// git() used to swallow a failed `git diff origin/main...HEAD` into "" and
+// main() printed "No diff against origin/main (or ref unavailable) — OK."
+test("listChangedFiles: an unresolvable base is not an empty diff", () => {
+  const git = (args) => {
+    if (args[0] === "rev-parse") {
+      return { ok: false, stdout: "", stderr: "fatal: Needed a single revision" };
+    }
+    return { ok: true, stdout: "" };
+  };
+  const result = listChangedFiles("origin/main", { git });
+  assert.equal(result.status, "unresolvable");
+  assert.deepEqual(result.files, []);
+  assert.match(result.detail, /Needed a single revision/);
+});
+
+test("listChangedFiles: a failed git diff is unresolvable even if the ref parses", () => {
+  // Shallow clones can resolve origin/main as a name and still fail the
+  // three-dot diff because the merge-base is not in the truncated history.
+  const git = (args) => {
+    if (args[0] === "rev-parse") return { ok: true, stdout: "abc123\n" };
+    return { ok: false, stdout: "", stderr: "fatal: invalid rev input" };
+  };
+  const result = listChangedFiles("origin/main", { git });
+  assert.equal(result.status, "unresolvable");
+});
+
+test("listChangedFiles: a resolved ref with no files is empty, not unresolvable", () => {
+  const git = (args) => {
+    if (args[0] === "rev-parse") return { ok: true, stdout: "abc123\n" };
+    return { ok: true, stdout: "" };
+  };
+  const result = listChangedFiles("origin/main", { git });
+  assert.equal(result.status, "ok");
+  assert.deepEqual(result.files, []);
+});
+
+test("listChangedFiles: a resolved ref with files lists them", () => {
+  const git = (args) => {
+    if (args[0] === "rev-parse") return { ok: true, stdout: "abc123\n" };
+    return { ok: true, stdout: "docs/a.md\nscripts/x.mjs\n" };
+  };
+  const result = listChangedFiles("origin/main", { git });
+  assert.equal(result.status, "ok");
+  assert.deepEqual(result.files, ["docs/a.md", "scripts/x.mjs"]);
+});
+
+test("an unresolvable BASE_SHA must not exit 0 with OK (BI-B6433DC6)", () => {
+  const script = fileURLToPath(new URL("./check-doc-anchor-existence.mjs", import.meta.url));
+  const result = spawnSync(process.execPath, [script], {
+    encoding: "utf8",
+    cwd: path.resolve(path.dirname(script), ".."),
+    env: { ...process.env, BASE_SHA: "origin/this-ref-does-not-exist-b6433dc6" },
+  });
+  const out = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0, `must not exit 0 when the base ref is missing; output:\n${out}`);
+  assert.doesNotMatch(out, /\bOK\.\s*$/m);
+  assert.match(out, /cannot resolve|did not run/i);
+  assert.match(out, /git fetch --deepen/);
 });


### PR DESCRIPTION
## Summary

`scripts/check-doc-anchor-existence.mjs` treated a failed `git diff origin/main...HEAD` as an empty diff and printed:

```
[doc-anchor] No diff against origin/main (or ref unavailable) — nothing to check. OK.
```

with exit 0. Observed live on a shallow clone: the same documents failed the guard, then passed, with no document change — only history depth. A green OK is stronger evidence than silence, so this is worse than skipping the check.

`listChangedFiles` now distinguishes:

- **unresolvable** — `rev-parse` misses, or the three-dot diff itself fails (shallow merge-base). Exit 1, names `git fetch --deepen`. Never prints `OK.`
- **empty diff** — the ref resolved and git returned no files. Still OK.

## Why this is one concern

One guard, one honesty defect. `check-live-blocker-references.mjs` still has the twin `"or ref unavailable"` phrasing; that is a follow-up, not this revert.

## Verification

```
node --test scripts/check-doc-anchor-existence.test.mjs
```

13/13, including a spawn of the CLI with `BASE_SHA` pointing at a missing ref (must not exit 0 with `OK.`).

Typecheck / production build / UX: not applicable (two Node scripts, no `apps/web` change).

## Docs

Docs-Impact-Decision: guard script only; no user-facing route or user-guide page. The contract lives in the script header.

Process-Spine-Decision: no new capability; the existing doc-anchor gate now fails closed on an unrun check.

## Local CI

Local-CI-Override: external-contribution-no-install: scripts-only node builtin guard; node --test 13/13; local-CI oversubscribed (concurrent pregates on other worktrees)

Semantic review: `review_semantic_change` loaded via MCP `load_tools` but is not in this host's tool catalog, so no receipt was recorded. Cloud CI remains the merge gate.

Refs: BI-B6433DC6
