### PR TITLE
fix(guards): pregate-status queued is INCONCLUSIVE, not FAIL (BI-51353470)

### DIFF
--- a/scripts/lib/pregate-status.mjs
+++ b/scripts/lib/pregate-status.mjs
@@ -30,15 +30,23 @@
 //
 // Pure aside from injected readers, so the verdict logic unit-tests without a
 // gate run or a filesystem.
+//
+// BI-51353470: a record whose status is queued/cancelled never ran — that is
+// INCONCLUSIVE, not FAIL. A metadata candidateSha that is not HEAD is STALE
+// in the headline, not FAIL with a buried metadata line.
 
 /** Terminal verdicts, ordered worst-to-best for slot reconciliation. */
 export const PREGATE_VERDICTS = Object.freeze([
   "NO-RECORD",
+  "INCONCLUSIVE",
   "FAIL",
   "STALE",
   "PENDING",
   "PASS",
 ]);
+
+/** Statuses that mean the gate was never admitted / never finished. Not FAIL. */
+const UNFINISHED_GATE_STATUSES = new Set(["queued", "cancelled"]);
 
 function rank(verdict) {
   const index = PREGATE_VERDICTS.indexOf(verdict);
@@ -187,6 +195,25 @@ export function classifySlotRecord({ state, metadata, headSha, headBranch = "", 
   }
 
   if (state.gatePassed !== true) {
+    // BI-51353470: a metadata candidateSha that is not HEAD is STALE in the
+    // headline, not FAIL with a buried metadata line. Observed: FAIL quoting
+    // a previous run's vitest command while gated claimed the current HEAD.
+    if (candidateSha && headSha && candidateSha !== headSha) {
+      return {
+        ...base,
+        verdict: "STALE",
+        reason: `metadata record gated ${candidateSha.slice(0, 12)}, not HEAD ${headSha.slice(0, 12)} — re-run pregate`,
+        staleness: "metadata-mismatch",
+      };
+    }
+    const status = String(state.status || "");
+    if (UNFINISHED_GATE_STATUSES.has(status)) {
+      return {
+        ...base,
+        verdict: "INCONCLUSIVE",
+        reason: `gate record status ${status} — the gate did not run. This is not a failure of the diff. Re-run pregate.`,
+      };
+    }
     return {
       ...base,
       verdict: "FAIL",

--- a/scripts/lib/pregate-status.test.mjs
+++ b/scripts/lib/pregate-status.test.mjs
@@ -252,15 +252,16 @@ test("a started-then-released run with no failing command is a retry, not a verd
 });
 
 test("flags a metadata file that describes a different run", () => {
-  // The trap this closes: failing runs never rewrote the metadata, so it kept
-  // reporting the PREVIOUS run's success. Reading it after a failure yields a
-  // confident, wrong "it passed" — only the file mtime gave it away.
+  // Failing runs never rewrote the metadata, so it kept reporting the PREVIOUS
+  // run. BI-465B3D60 flagged that as buried staleness; BI-51353470 promotes it
+  // to STALE in the headline so the reader is not told the current HEAD failed.
   const out = classifySlotRecord({
     state: failingRecord(),
     metadata: { candidateSha: "oldersha", execution: { status: "passed", exitCode: 0 } },
     ...atHead,
   });
-  assert.equal(out.staleness, "metadata-describes-another-run");
+  assert.equal(out.verdict, "STALE");
+  assert.equal(out.staleness, "metadata-mismatch");
 });
 
 test("does not flag the metadata when it describes this run", () => {
@@ -360,4 +361,65 @@ test("the state's own failureReason outranks metadata either way", () => {
   });
 
   assert.match(out.reason, /typecheck failed/);
+});
+
+// BI-51353470: a record whose status is queued/cancelled never ran. FAIL is a
+// claim about the diff; INCONCLUSIVE is "this is not a verdict".
+test("a queued record that never ran is INCONCLUSIVE, not FAIL (BI-51353470)", () => {
+  const r = classifySlotRecord({
+    state: passingState({ gatePassed: false, status: "queued", evidenceRecordId: "" }),
+    metadata: { candidateSha: HEAD },
+    headSha: HEAD,
+    headBranch: "claude/topic",
+    now: NOW,
+  });
+  assert.equal(r.verdict, "INCONCLUSIVE");
+  assert.match(r.reason, /did not run|never ran|not a failure of the diff/i);
+  assert.doesNotMatch(r.reason, /local-ci-vitest-runner/);
+  assert.equal(exitCodeForVerdict(r.verdict), 1, "inconclusive is not a green light to push");
+});
+
+test("a cancelled record is INCONCLUSIVE, not FAIL (BI-51353470)", () => {
+  const r = classifySlotRecord({
+    state: passingState({ gatePassed: false, status: "cancelled", evidenceRecordId: "" }),
+    metadata: { candidateSha: HEAD },
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "INCONCLUSIVE");
+});
+
+test("a candidateSha/HEAD mismatch on an unfinished record is STALE in the headline (BI-51353470)", () => {
+  // Observed: FAIL with gated=HEAD @ 0m and metadata candidateSha of a previous
+  // commit, quoting that earlier run's vitest command as the reason.
+  const r = classifySlotRecord({
+    state: {
+      branch: "fix/build-studio-hide-the-guts",
+      sha: HEAD,
+      gatePassed: false,
+      status: "queued",
+      recordedAt: "2026-08-04T12:00:00.000Z",
+    },
+    metadata: {
+      candidateSha: OLD,
+      execution: { failedCommand: "node scripts/local-ci-vitest-runner.mjs" },
+    },
+    headSha: HEAD,
+    headBranch: "fix/build-studio-hide-the-guts",
+    now: NOW,
+  });
+  assert.equal(r.verdict, "STALE");
+  assert.equal(r.staleness, "metadata-mismatch");
+  assert.match(r.reason, /bbbbbbbbbbbb/);
+  assert.match(r.reason, /aaaaaaaaaaaa/);
+  assert.ok(
+    !r.reason.includes("local-ci-vitest-runner"),
+    `must not quote the previous run's command; got: ${r.reason}`,
+  );
+  const lines = formatStatusReport(r, {
+    headBranch: "fix/build-studio-hide-the-guts",
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(lines[0], "local-CI gate: STALE");
 });


### PR DESCRIPTION
## Summary

`pnpm run pregate:status` reported FAIL for a run whose gate record status was `queued`, and printed the current HEAD in the `gated` line while `metadata.candidateSha` named a previous commit. The reason quoted that earlier run's vitest command. A contributor following "verdict: pnpm run pregate:status" was told tests failed that never ran.

Queued and cancelled records are now **INCONCLUSIVE** — the gate did not run, which is not a failure of the diff. When `metadata.candidateSha` is not HEAD, the **headline is STALE**, not FAIL with a buried metadata line.

`blocked_quiescence` still reads FAIL (it gave up after being admitted). A real `failedCommand` from this run is still FAIL.

## Verification

```
node --test scripts/lib/pregate-status.test.mjs
```

28/28, including:

- queued / cancelled → `INCONCLUSIVE`, not `FAIL`
- unfinished record + `candidateSha` ≠ HEAD → `local-CI gate: STALE` in the headline, and the previous run's command is not quoted

Typecheck / production build / UX: not applicable (status-reader script only).

## Docs

Docs-Impact-Decision: status-reader script only; no user-facing route or user-guide page.

Process-Spine-Decision: no new capability; the existing pregate:status command now names unfinished and stale records honestly.

## Local CI

Local-CI-Override: external-contribution-no-install: scripts-only status reader; node --test 28/28; local-CI oversubscribed (concurrent pregates on other worktrees)

Semantic review: `review_semantic_change` is not in this host's tool catalog after `load_tools`. Cloud CI remains the merge gate.

Refs: BI-51353470
