### PR TITLE
fix(inference): declare the authorized-surface block as instruction, not payload

### DIFF
--- a/apps/web/lib/coworker/authorized-surface-prompt-grounding.ts
+++ b/apps/web/lib/coworker/authorized-surface-prompt-grounding.ts
@@ -144,6 +144,12 @@ export async function groundPromptWithAuthorizedSurface(
   sessionId?: string;
   surfaceId?: string;
   guidanceHighlights?: string[];
+  /**
+   * The exact block appended, so the caller can declare it as an INSTRUCTION
+   * span instead of letting it be screened as payload (BI-D9D661ED). This is a
+   * projection of the platform's own UX, not customer data.
+   */
+  instructionBlock?: string;
 }> {
   const selector = {
     route: input.context.route,
@@ -178,6 +184,7 @@ export async function groundPromptWithAuthorizedSurface(
       sessionId: opened.session.sessionId,
       surfaceId: snapshot.graph.surfaceId,
       guidanceHighlights: [...(snapshot.graph.summary.highlights ?? [])],
+      instructionBlock: block,
     };
   } catch (error) {
     console.warn(

--- a/apps/web/lib/tak/autonomous-grounding-seam.test.ts
+++ b/apps/web/lib/tak/autonomous-grounding-seam.test.ts
@@ -31,6 +31,7 @@ vi.mock("@/lib/coworker/authorized-surface-prompt-grounding", () => ({
   groundPromptWithAuthorizedSurface: vi.fn(async ({ systemPrompt }: { systemPrompt: string }) => ({
     systemPrompt: `${systemPrompt}\n\nSURFACE GROUNDED`,
     grounded: true,
+    instructionBlock: "SURFACE GROUNDED",
     sessionId: "surface-session-1",
     guidanceHighlights: [
       "For SNMP choose SNMP (Generic), enter Target IP or Hostname and the write-only Community String, then use Save & Test.",
@@ -138,5 +139,72 @@ describe("executeAutonomousAgenticLoop — profession-corpus grounding gate", ()
     expect(agentic.runAgenticLoop).toHaveBeenCalledWith(
       expect.objectContaining({ systemPrompt: expect.stringContaining("BASE") }),
     );
+  });
+});
+
+
+describe("grounded prompt blocks are declared as INSTRUCTION, not payload (BI-D9D661ED)", () => {
+  beforeEach(async () => {
+    const agentic = await import("@/lib/tak/agentic-loop");
+    vi.mocked(agentic.runAgenticLoop).mockReset();
+    vi.mocked(agentic.runAgenticLoop).mockResolvedValue({ content: "ok", executedTools: [] } as never);
+  });
+
+  it("declares the authorized-surface block as an instruction span", async () => {
+    // The provenance design lists AUTHORIZED_SURFACE_PROMPT as instruction, but
+    // it is appended HERE — after the caller computed its spans from the
+    // persona — so it landed in the data remainder and was screened as payload.
+    await callLoop("autonomous");
+
+    const agentic = await import("@/lib/tak/agentic-loop");
+    const spans = vi.mocked(agentic.runAgenticLoop).mock.calls[0]![0]!
+      .systemPromptInstructionSpans;
+    expect(spans).toContain("SURFACE GROUNDED");
+  });
+
+  it("does NOT declare the profession corpus as instruction", async () => {
+    // The corpus is retrieved content that can carry real values, so the
+    // ratified design classifies it as DATA. Labelling it would open an egress
+    // path for anything the corpus happens to contain.
+    await callLoop("autonomous");
+
+    const agentic = await import("@/lib/tak/agentic-loop");
+    const spans = vi.mocked(agentic.runAgenticLoop).mock.calls[0]![0]!
+      .systemPromptInstructionSpans;
+    expect(spans).not.toContain("GROUNDED");
+    expect(spans).toEqual(["SURFACE GROUNDED"]);
+  });
+
+  it("keeps the caller's own persona spans alongside the grounded ones", async () => {
+    const { executeAutonomousAgenticLoop } = await import("./autonomous-work-run");
+    await executeAutonomousAgenticLoop({
+      systemPrompt: "PERSONA",
+      systemPromptInstructionSpans: ["PERSONA"],
+      chatHistory: [{ role: "user", content: "Do the build task." }],
+      sensitivity: "internal",
+      tools: [],
+      toolsForProvider: [],
+      userId: "user-1",
+      routeContext: "build",
+      agentId: "build-qa-engineer",
+      threadId: "thread-1",
+      interactionMode: "autonomous",
+    });
+
+    const agentic = await import("@/lib/tak/agentic-loop");
+    const spans = vi.mocked(agentic.runAgenticLoop).mock.calls.at(-1)![0]!
+      .systemPromptInstructionSpans;
+    expect(spans).toContain("PERSONA");
+    expect(spans!.length).toBeGreaterThan(1);
+  });
+
+  it("adds no spans on the chat path, which grounds its corpus upstream", async () => {
+    await callLoop("chat");
+
+    const agentic = await import("@/lib/tak/agentic-loop");
+    const spans = vi.mocked(agentic.runAgenticLoop).mock.calls.at(-1)![0]!
+      .systemPromptInstructionSpans;
+    // Chat skips profession grounding, so only the surface block is appended.
+    expect(spans).toEqual(["SURFACE GROUNDED"]);
   });
 });

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -390,6 +390,12 @@ export async function executeAutonomousAgenticLoop(input: {
   // craft knowledge. Gate on !== "chat" so chat is never double-injected. Total
   // + fail-open: on any error the original prompt is used unchanged.
   let systemPrompt = input.systemPrompt;
+  // Instruction spans are computed by the CALLER from the persona, before the
+  // groundings below append to the prompt. AUTHORIZED_SURFACE_PROMPT is listed
+  // as INSTRUCTION by the provenance design, but it is appended here — after
+  // the caller computed its spans — so it landed in the data remainder and was
+  // screened as payload (BI-D9D661ED). Collect it and declare it.
+  const groundedInstructionSpans: string[] = [];
   if (input.interactionMode !== "chat") {
     const { groundPromptWithProfessionCorpus, defaultProfessionGroundingDeps } = await import(
       "@/lib/tak/profession-grounding"
@@ -403,6 +409,10 @@ export async function executeAutonomousAgenticLoop(input: {
       },
       defaultProfessionGroundingDeps,
     ).catch(() => ({ systemPrompt, grounded: false }));
+    // The profession corpus is deliberately NOT declared instruction: the
+    // ratified provenance design lists retrieved corpus content as DATA, since
+    // a corpus can carry real values. Only statically-authored platform
+    // instruction is labelled here.
     systemPrompt = grounding.systemPrompt;
   }
 
@@ -433,6 +443,9 @@ export async function executeAutonomousAgenticLoop(input: {
     authorizedToolNames,
   }).catch(() => ({ systemPrompt, grounded: false as const }));
   systemPrompt = surfaceGrounding.systemPrompt;
+  if ("instructionBlock" in surfaceGrounding && surfaceGrounding.instructionBlock) {
+    groundedInstructionSpans.push(surfaceGrounding.instructionBlock);
+  }
   const { isAuthorizedSurfaceGuidanceRequest } = await import(
     "@/lib/coworker/authorized-surface-prompt-grounding"
   );
@@ -455,7 +468,10 @@ export async function executeAutonomousAgenticLoop(input: {
     result = await withInferenceOrigin(inferenceOrigin, () =>
       runAgenticLoop({
         systemPrompt,
-        systemPromptInstructionSpans: input.systemPromptInstructionSpans,
+        systemPromptInstructionSpans: [
+          ...(input.systemPromptInstructionSpans ?? []),
+          ...groundedInstructionSpans,
+        ],
         chatHistory: input.chatHistory,
         sensitivity: input.sensitivity,
         tools: input.tools,


### PR DESCRIPTION
Closes one half of BI-D9D661ED. Files BI-67CAF494 for the other half.

## The ordering gap

The [prompt-provenance design](docs/superpowers/plans/2026-08-23-prompt-provenance-in-inference-screening.md) lists `AUTHORIZED_SURFACE_PROMPT` as **instruction**. It wasn't being labelled as such:

1. Callers compute `systemPromptInstructionSpans` from the **persona** — `mcp-task-execution`, `agent-thread-dispatcher-runtime` and `agent-task-scheduler` all use `coworkerBriefSpans(agent.systemPrompt)`.
2. `executeAutonomousAgenticLoop` then **appends** to that prompt.
3. `splitPromptByProvenance` classifies anything outside the declared spans as **data**.

So the authorized-surface block was screened as if it were customer payload. The design already flagged this exact shape: *"text is appended after assembly in at least two more places."* This closes one of them.

## Why it matters

An inferred class on the data side can clamp a turn to `local_only`. The essay in `classify-payload.ts` records the measured impact:

> "hr-specialist 33/33, admin-assistant 38/38, market-research-analyst 50/50 and finance-agent 7/7 turns routed restricted, against 0/45 for platform-engineer. Those coworkers had never once reached a cloud provider."

## What is deliberately NOT changed

The **profession corpus** stays unlabelled. The design lists retrieved corpus content as data because a corpus can carry real values, and labelling it would open the egress path the design explicitly warns against. I initially labelled it, checked the design, and backed that out — there's now a comment and a test so the omission reads as a decision rather than an oversight.

## Scope honesty

**This does not by itself unfence the Compliance Officer.** The turn that prompted the investigation (`RouteDecisionLog cmtc46qiv36bv01peiscu9bh2`) was clamped by `vertical-youth-sensitive@1.0.0` firing on a single **inferred vocabulary** match, and I could not determine from here which prompt block carried the phrase.

That detector violates the contract stated above `CLASS_RULES` — *"Text probes must contain value-shaped evidence, not merely governance or instructional vocabulary that happens to name a protected data class"* — since `legal guardian` and `parental consent` are what a policy **calls** a category, not evidence one is present. Filed as **BI-67CAF494** rather than fixed in passing: it is a child-safety detector, loosening it wrongly creates a real egress path, and the right shape is a judgement call between three options I've written up there.

## Verification

- Local CI gate **PASS** (evidence `cmtdd7mpu3r9501mdhm77wqza`) — full suite and production build, 12:03, no override
- 2,157 tests across `lib/tak`, `lib/inference`, `lib/coworker`; `tsc` clean
- 53 preflight guards clean
- Four new assertions pin **both** halves: the surface block IS declared, the corpus is NOT

🤖 Generated with [Claude Code](https://claude.com/claude-code)