### PR TITLE
fix(build): honour a recorded decomposition override in the owner's next action (BI-181E8776)

### DIFF
--- a/apps/web/lib/build/size-gate-decomposition-affordance.test.ts
+++ b/apps/web/lib/build/size-gate-decomposition-affordance.test.ts
@@ -13,6 +13,19 @@ function review(decision: string, sizeDecision?: string) {
   } as never;
 }
 
+function reviewWithOverride(sizeDecision: string) {
+  return {
+    decision: "pass",
+    sizeAssessment: { decision: sizeDecision },
+    decompositionOverride: {
+      rationale: "One read-only page; splitting would ship fragments nobody can use.",
+      recordedAt: "2026-08-28T19:26:04.554Z",
+      recordedByUserId: "usr_1",
+      recordedByAgentId: null,
+    },
+  } as never;
+}
+
 describe("deriveSizeGateDecompositionAffordance", () => {
   // The live repro: FB-41EA43C5 passed design review, was assessed xlarge, and
   // was offered "Advance to Plan" — which the gate then refused.
@@ -76,6 +89,41 @@ describe("deriveSizeGateDecompositionAffordance", () => {
         designDoc,
       }),
     ).toEqual({ kind: "none" });
+  });
+
+  // BI-181E8776 — the live repro: FB-1EBDEBAD was assessed decompose-required,
+  // the owner took the "Keep as one build (explain why)" lever and recorded a
+  // rationale, and the card went on offering "Split into smaller builds" as the
+  // only next action. The gate had already unblocked; only this surface had not.
+  it("stops asking once the owner has recorded an override", () => {
+    expect(
+      deriveSizeGateDecompositionAffordance({
+        phase: "ideate",
+        designReview: reviewWithOverride("decompose-required"),
+        designDoc,
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("stops asking on the advisory side too — an answered question stays answered", () => {
+    expect(
+      deriveSizeGateDecompositionAffordance({
+        phase: "ideate",
+        designReview: reviewWithOverride("decompose-recommended"),
+        designDoc,
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  // Guards the inverse: absent an override the split is still the right ask.
+  it("still offers the split when no override has been recorded", () => {
+    expect(
+      deriveSizeGateDecompositionAffordance({
+        phase: "ideate",
+        designReview: review("pass", "decompose-required"),
+        designDoc,
+      }),
+    ).toMatchObject({ kind: "decompose-now", required: true });
   });
 
   it("disables the action when there is no design to split", () => {

--- a/apps/web/lib/build/size-gate-decomposition-affordance.ts
+++ b/apps/web/lib/build/size-gate-decomposition-affordance.ts
@@ -41,6 +41,25 @@ export type SizeGateBuildInput = {
   designDoc: BuildDesignDoc | null;
 };
 
+/**
+ * True when the owner has already answered this gate with an override.
+ *
+ * `record_decomposition_override` writes the owner's rationale into
+ * `designReview.decompositionOverride` (decomposition-override.ts). The gate
+ * itself has always honoured that field — `isParkedAtDecomposeGate`
+ * (resume-pre-build-phase.ts) treats a build with an override as NOT parked,
+ * and build-design-review-handler carries a prior override across re-reviews.
+ * This affordance did not read it, so an owner who took the "Keep as one build
+ * (explain why)" lever recorded their rationale and was then shown the same
+ * "Split into smaller builds" ask, with no other move offered (BI-181E8776).
+ * The decision surface has to read the same field the gate does.
+ */
+function hasDecompositionOverride(designReview: ReviewResult | null): boolean {
+  return (
+    (designReview as { decompositionOverride?: unknown } | null)?.decompositionOverride != null
+  );
+}
+
 function sizeDecisionOf(designReview: ReviewResult | null): string | null {
   const assessment = (designReview as { sizeAssessment?: { decision?: unknown } } | null)
     ?.sizeAssessment;
@@ -63,6 +82,10 @@ export function deriveSizeGateDecompositionAffordance(
 
   const decision = sizeDecisionOf(build.designReview);
   if (decision === null || !DECOMPOSING_DECISIONS.has(decision)) return { kind: "none" };
+
+  // The owner already answered this. Keep the recorded rationale on the card —
+  // the banner renders it separately — but stop asking a settled question.
+  if (hasDecompositionOverride(build.designReview)) return { kind: "none" };
 
   return {
     kind: "decompose-now",


### PR DESCRIPTION
## What the owner saw

A build parked at the `decompose-required` size gate offers two levers: propose splits, or keep it as one build and explain why. Taking the second one records the rationale and renders "Override recorded: …" on the card — and then changes nothing. The DECOMPOSITION REQUIRED banner stays. The coworker's next action stays "Next: split this build into smaller builds." The primary button stays "Split into smaller builds".

The owner made the exact decision the UI asked them to make, and the UI kept asking.

Found running the Second Chance Animal Rescue newsletter page through Build Studio as its owner (FB-1EBDEBAD).

## Why

The override was never lost. `record_decomposition_override` writes it to `designReview.decompositionOverride`, and the gate honours it there:

- `isParkedAtDecomposeGate` (`resume-pre-build-phase.ts:219`) requires `decompositionOverride == null` to consider a build parked
- `build-design-review-handler.ts:364` computes `hasOverride` and carries a prior override across re-reviews

Only `deriveSizeGateDecompositionAffordance` failed to read the field. It decided from `designReview.decision` and `sizeAssessment.decision` alone, so the backend considered the build unblocked while the surface the owner was looking at did not.

Confirmed live: after recording the override, an `initiative_readiness_decision` for `target: plan` was evaluated on the build — the advance had already been attempted and had moved on to the readiness gate. Only the card was still asking.

## The fix

Read the same field the gate reads. `deriveSizeGateDecompositionAffordance` returns `{ kind: "none" }` when an override is present, so the ideate branch falls through to its normal "Advance to Plan" action.

Applied on both sides of the gate — an answered question stays answered whether it was `decompose-required` or `decompose-recommended`. The recorded rationale still renders; the banner owns that, and only the settled ask goes away.

The override already lives inside the `designReview` the function receives, so no signature change.

## Tests

`size-gate-decomposition-affordance.test.ts` — 10 pass, 3 new:
- stops asking once the owner has recorded an override
- stops asking on the advisory side too
- still offers the split when no override has been recorded (guards the inverse)

Local-CI gate passed on `f93b26c99751`.

Seed-Fit-Decision: reuse-existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)