### PR TITLE
fix(guards): docs plus a fresh derived artifact is still a docs push (BI-AC48D79F)

### DIFF
--- a/scripts/derived-artifacts-gate.mjs
+++ b/scripts/derived-artifacts-gate.mjs
@@ -19,6 +19,8 @@
 //                         changed" is no longer treated as inherently
 //                         runtime-safe; a docs change that is a registered
 //                         artifact's source must pass that artifact's check.
+//                         Registered artifact OUTPUTS (BI-AC48D79F) are not
+//                         "runtime changes"; they ride with the docs source.
 //   check-all             CI: run every registered artifact's check command.
 //   list                  print the registry as JSON (debugging / CI
 //                         visibility).
@@ -30,7 +32,7 @@ import { existsSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { DERIVED_ARTIFACTS, affectedEntries } from "./lib/derived-artifacts-registry.mjs";
+import { DERIVED_ARTIFACTS, affectedEntries, matchesAnyGlob } from "./lib/derived-artifacts-registry.mjs";
 import { resolveHostCommandInvocation } from "./lib/host-command-invocation.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -72,8 +74,19 @@ export function planRegenerate(stagedFiles, registry = DERIVED_ARTIFACTS, binary
  * replaces the assumption "docs-only diff => safe" with "docs-only diff AND
  * no registered artifact invalidated by it is stale => safe".
  */
+function isRegisteredArtifactOutput(filePath, registry) {
+  return registry.some((entry) => matchesAnyGlob(filePath, entry.artifactPaths ?? []));
+}
+
 export function evaluatePushExemption(diffFiles, registry = DERIVED_ARTIFACTS, runCheck = () => true) {
-  const nonDocChanges = diffFiles.filter((f) => !/^docs\/|^memory\/|\.md$/.test(f));
+  // BI-AC48D79F: registered artifact outputs (e.g. doc-index.generated.json)
+  // are regenerated and staged by pre-commit when their docs sources change.
+  // They are not runtime sources. Counting them as "non-docs runtime" made
+  // the freshness branch unreachable, so every indexed-docs push needed a
+  // sandbox gate or an override.
+  const nonDocChanges = diffFiles.filter(
+    (f) => !isRegisteredArtifactOutput(f, registry) && !/^docs\/|^memory\/|\.md$/.test(f),
+  );
   if (nonDocChanges.length > 0) {
     return { exempt: false, reason: "non-docs runtime changes present", files: nonDocChanges };
   }

--- a/scripts/derived-artifacts-gate.test.mjs
+++ b/scripts/derived-artifacts-gate.test.mjs
@@ -130,6 +130,29 @@ test("evaluatePushExemption: a non-docs file change still gates even if a doc ar
   assert.equal(result.reason, "non-docs runtime changes present");
 });
 
+// BI-AC48D79F: pre-commit auto-stages registered artifact JSON next to the
+// docs source. Those outputs used to trip "non-docs runtime changes present"
+// and made the freshness branch unreachable.
+test("evaluatePushExemption: a docs diff plus its fresh registered artifact is exempt (BI-AC48D79F)", () => {
+  const result = evaluatePushExemption(
+    ["docs/foo.md", "apps/web/lib/docs/doc-index.generated.json"],
+    [DOC_INDEX],
+    () => true,
+  );
+  assert.equal(result.exempt, true);
+  assert.match(result.reason, /fresh|docs diff/i);
+});
+
+test("evaluatePushExemption: a docs diff plus a STALE registered artifact is not exempt (BI-AC48D79F)", () => {
+  const result = evaluatePushExemption(
+    ["docs/foo.md", "apps/web/lib/docs/doc-index.generated.json"],
+    [DOC_INDEX],
+    () => false,
+  );
+  assert.equal(result.exempt, false);
+  assert.deepEqual(result.staleArtifacts, ["doc-index"]);
+});
+
 // ── evaluateCheckAll ─────────────────────────────────────────────────────────
 
 test("evaluateCheckAll reports every entry's check result", () => {


### PR DESCRIPTION
## Summary

`evaluatePushExemption` treated any path that was not `docs/`, `memory/`, or `.md` as a runtime change. Pre-commit auto-stages registered outputs such as `doc-index.generated.json` next to the docs source, so a pure docs commit never reached the freshness branch and always needed a sandbox gate or an override.

Registered `artifactPaths` are outputs, not sources. Exclude them from the non-docs filter, then let the existing `affectedEntries` + `runCheck` branch decide freshness.

A stale artifact still refuses the exemption. An unrelated runtime file still refuses it.

## Verification

```
node --test scripts/derived-artifacts-gate.test.mjs
```

15/15.

Typecheck / production build / UX: not applicable (guard script only).

## Docs

Docs-Impact-Decision: guard script only; no user-facing route or user-guide page.

Process-Spine-Decision: no new capability; the existing push-exempt path now reaches the freshness check it already had.

## Local CI

Local-CI-Override: external-contribution-no-install: scripts-only node builtin guard; node --test 15/15; local-CI oversubscribed

Refs: BI-AC48D79F
