### PR TITLE
fix(guards): live-blocker must not OK when origin/main is unresolvable (BI-B263E76C)

### DIFF
--- a/scripts/check-live-blocker-references.mjs
+++ b/scripts/check-live-blocker-references.mjs
@@ -27,6 +27,8 @@
 //   - DEGRADES GRACEFULLY: no bearer token, unreachable endpoint, or an
 //     ambiguous response ⇒ WARN and pass, printing exactly what was skipped.
 //     A gate that cannot reach the install must never invent a defect.
+//   - DOES NOT degrade on an unresolvable BASE_SHA (BI-B263E76C / twin of
+//     BI-B6433DC6). Reuses listChangedFiles from check-doc-anchor-existence.
 //
 //   node scripts/check-live-blocker-references.mjs            # check (CI)
 //   node scripts/check-live-blocker-references.mjs --update   # regenerate the baseline
@@ -36,7 +38,7 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { callTool, DEFAULT_ENDPOINT } from "./check-doc-anchor-existence.mjs";
+import { callTool, DEFAULT_ENDPOINT, listChangedFiles } from "./check-doc-anchor-existence.mjs";
 import { formatTxtBudgetHeader, parseTxtBudgetHeader } from "./lib/baseline-budget.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -159,12 +161,18 @@ async function main() {
     console.error(`[live-blocker] refusing unsafe BASE_SHA: ${JSON.stringify(base)}`);
     process.exit(1);
   }
-  const diffOutput = git("diff", "--name-only", `${base}...HEAD`);
-  if (!diffOutput.trim()) {
-    console.log(`[live-blocker] No diff against ${base} (or ref unavailable) — nothing to check. OK.`);
+  const listed = listChangedFiles(base);
+  if (listed.status === "unresolvable") {
+    console.error(`[live-blocker] cannot resolve ${base} — the guard did not run. This is not a pass.`);
+    console.error("[live-blocker] Remedy: git fetch --deepen 50 origin  (or git fetch origin main) and re-run.");
+    if (listed.detail) console.error(`[live-blocker] git: ${listed.detail}`);
+    process.exit(1);
+  }
+  if (listed.files.length === 0) {
+    console.log(`[live-blocker] No diff against ${base} — nothing to check. OK.`);
     return;
   }
-  const changed = diffOutput.split("\n").map((s) => s.trim()).filter(isScannedSource);
+  const changed = listed.files.filter(isScannedSource);
 
   const newPairs = [];
   for (const file of changed) {

--- a/scripts/check-live-blocker-references.test.mjs
+++ b/scripts/check-live-blocker-references.test.mjs
@@ -5,6 +5,9 @@
 // desirable case, so a guard that flags it would be an over-reporting measure,
 // which is itself a defect.
 
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
@@ -64,4 +67,18 @@ test("baseline round-trips", () => {
   assert.ok(parsed.has("apps/web/a.ts\tBI-00000001"));
   assert.ok(parsed.has("apps/web/b.ts\tBI-00000002"));
   assert.equal(parsed.size, 2);
+});
+
+test("an unresolvable BASE_SHA must not exit 0 with OK (BI-B263E76C)", () => {
+  const script = fileURLToPath(new URL("./check-live-blocker-references.mjs", import.meta.url));
+  const result = spawnSync(process.execPath, [script], {
+    encoding: "utf8",
+    cwd: path.resolve(path.dirname(script), ".."),
+    env: { ...process.env, BASE_SHA: "origin/this-ref-does-not-exist-b263e76c" },
+  });
+  const out = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0, `must not exit 0 when the base ref is missing; output:\n${out}`);
+  assert.doesNotMatch(out, /\bOK\.\s*$/m);
+  assert.match(out, /cannot resolve|did not run/i);
+  assert.match(out, /git fetch --deepen/);
 });


### PR DESCRIPTION
## Summary

Twin of BI-B6433DC6 / #4809. `check-live-blocker-references` swallowed a failed `git diff origin/main...HEAD` into an empty string and printed:

```
[live-blocker] No diff against origin/main (or ref unavailable) — nothing to check. OK.
```

with exit 0.

Reuse `listChangedFiles` from `check-doc-anchor-existence`. Unresolvable base exits 1 and names `git fetch --deepen`. Empty diff after a resolved ref still OKs.

## Verification

```
node --test scripts/check-live-blocker-references.test.mjs
```

8/8, including a spawn with `BASE_SHA` pointing at a missing ref.

Typecheck / production build / UX: not applicable (guard script only).

## Docs

Docs-Impact-Decision: guard script only; no user-facing route or user-guide page.

Process-Spine-Decision: no new capability; the existing live-blocker gate now fails closed on an unrun check.

## Local CI

Local-CI-Override: external-contribution-no-install: scripts-only node builtin guard; node --test 8/8; local-CI oversubscribed

Refs: BI-B263E76C
