### PR TITLE
docs(kernel): report only the verdict you reached

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 692,
+  "pageCount": 693,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -4410,6 +4410,19 @@
         "anti-patterns",
         "related-principles",
         "spec-references"
+      ]
+    },
+    "docs/founder-kernel/wiki/principles/report-only-the-verdict-you-reached.md": {
+      "publicHref": "/founder-kernel/wiki/principles/report-only-the-verdict-you-reached/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "report-only-the-verdict-you-reached",
+        "why-this-exists",
+        "what-to-do",
+        "the-consequence-clause",
+        "related"
       ]
     },
     "docs/founder-kernel/wiki/principles/reporting-read-model-boundaries.md": {

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -11,5 +11,5 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 | Prisma models | 614 | `packages/db/prisma/schema/` |
 | Prisma enums | 73 | `packages/db/prisma/schema/` |
 | Migrations | 556 | `packages/db/prisma/migrations/` |
-| Kernel principles | 98 | `docs/founder-kernel/wiki/principles/` |
+| Kernel principles | 99 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 642 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/founder-kernel/wiki/principles/report-only-the-verdict-you-reached.md
+++ b/docs/founder-kernel/wiki/principles/report-only-the-verdict-you-reached.md
@@ -1,0 +1,95 @@
+---
+title: Report only the verdict you reached
+slug: report-only-the-verdict-you-reached
+pageKind: principle
+status: published
+abstract: A check that could not conclude must say so, not emit a conclusion. Crashing, losing its transport, or reading stale state are all "I don't know" — reporting them as "I found a problem" is a plausible wrong answer, and a check that returns those gets switched off before the day it matters.
+principleTier: core
+principleDirection: Separate "I found a problem" from "I could not tell", and emit the second as its own outcome rather than collapsing it into the first.
+principleDimensionVector: {"evidence_density": 1.0, "human_cognitive_load": -0.2, "long_term_maintainability": 0.6, "governance_compliance": 0.4}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleConsumerArchetype: universal
+principleRingScope:
+  - universal-ring
+principlePublic: false
+authoredAt: 2026-08-28
+authoredBy: mark-bodman
+---
+
+# Report only the verdict you reached
+
+**A check that could not conclude must say so, not emit a conclusion.**
+
+Every check has at least three outcomes, not two: *pass*, *fail*, and **I could
+not tell**. The third is the one implementations forget. When it is missing, the
+inconclusive case gets folded into one of the other two — and the check starts
+producing confident answers it never actually computed.
+
+This is the dual of [[make-silent-failures-observable]]. That principle says
+silence must speak. This one says the noise must not lie.
+
+## Why this exists
+
+A wrong verdict is worse than no verdict, because a verdict gets acted on.
+
+Four instances, all measured on this platform within one working session:
+
+- A guard **crashed** on an unguarded `statSync`. The runner reported
+  `1/37 guard(s) FAILED (found violations)` — with no violation block printed,
+  because there were none. The crash was rendered as a finding.
+- A gate waiting on a dead executor treated **"I cannot reach the control
+  plane"** as ordinary waiting, and polled a corpse for thirty minutes on a
+  one-slot pool, blocking every other session on the host.
+- A reconciliation check compared a distinct-node count against a summed row
+  count and reported **drift on perfectly healthy data**.
+- A typecheck run against a stale generated client reported **121 errors in
+  files nobody had touched**, in a form that read as ordinary type breakage.
+
+None of these errored. Each produced a plausible wrong answer, and each cost
+real time to a reader who had no way to tell it from a real one.
+
+## What to do
+
+**Give "I could not tell" its own outcome.** A tri-state (`true` / `false` /
+`null`), a distinct exit code, a separate log verb — whatever the surface
+allows. If a caller cannot distinguish "no problem found" from "the check did
+not run", the check is not finished.
+
+**Make the inconclusive branch fail in the safe direction, and say which
+direction that is.** Safe is not always "stop": for a liveness probe, an
+unreachable control plane must NOT read as *dead*, because unreachability is
+precisely what kills the thing being probed — so unknown keeps waiting. For a
+policy gate, unknown blocks. The direction differs; stating it explicitly is
+what does not.
+
+**Never let a crash surface as a finding.** A non-zero exit with no finding
+printed is a crash. Runners must distinguish the two, and a runner that cannot
+should report the ambiguity rather than pick.
+
+**Do not report a verdict about state you did not read.** A record from a
+previous run is evidence about that run, not this one.
+
+## The consequence clause
+
+A check that reports verdicts it did not reach **gets disabled** — by a switch,
+or by people learning to ignore it. Either way it is gone before the day it
+would have mattered. This is why a permanently-red check is worse than no
+check at all: it trains its audience out of the habit the check exists to
+create.
+
+That failure mode is why enforcement is sequenced last. A guard shipped before
+its signal is trustworthy will sit red against genuinely healthy data, and be
+switched off long before it could catch anything.
+
+## Related
+
+- [[make-silent-failures-observable]] — the dual: a path that does nothing must
+  still emit a signal.
+- [[evidence-before-diagnosis]] — the caller-side obligation: verify a suggested
+  cause against the underlying state before naming it. A check that honours this
+  principle is what makes that verification cheap.
+- [[remove-avoidable-failure-opportunities]] — better than reporting the
+  ambiguity is designing a check whose inconclusive state cannot arise.


### PR DESCRIPTION
Routes a confirmed, cross-install learning to the commons instead of leaving it in one client's local memory.

**Docs-only.** Three files: the principle page and its two regenerated derived artifacts.

## The principle

`docs/founder-kernel/wiki/principles/report-only-the-verdict-you-reached.md`

Every check has three outcomes, not two: pass, fail, and **I could not tell**. The third is the one implementations forget, and when it is missing the inconclusive case gets folded into one of the other two — so the check starts emitting confident answers it never computed.

Four measured instances, all inside one working session on this platform:

- a guard **crashed** on an unguarded `statSync`; the runner reported `1/37 guard(s) FAILED (found violations)` with no violation block, because there were none;
- a gate treated "cannot reach the control plane" as ordinary waiting and polled a dead executor for ~30 minutes on a **one-slot** pool, blocking every other session;
- a reconciliation check compared a distinct-node count with a summed row count and reported **drift on perfectly healthy data**;
- a typecheck run against a stale generated client reported **121 errors in files nobody had touched**, in a form that read as ordinary type breakage.

None errored. Each produced a plausible wrong answer.

The page states the rule — give "could not tell" its own outcome; fail in the safe direction and **say which direction that is**; never let a crash surface as a finding; never report a verdict about state you did not read — and carries the consequence clause: a check that reports verdicts it did not reach **gets disabled**. That is why a permanently-red check is worse than no check, and why enforcement sequences last.

It is the dual of `make-silent-failures-observable` (silence must speak; noise must not lie) and links `evidence-before-diagnosis` as the caller-side obligation.

**One finding did not become a principle.** "Verify shared-state claims against the shared source" is already ratified as `evidence-before-diagnosis`. The mistake that prompted it — asserting `main` was red on typecheck without checking CI — was a *violation of an existing principle*, not a gap. Per `single-source-of-truth`, no new page.

## Scope correction

An earlier revision of this branch bundled two code fixes (a guard-loop wording change and a gate liveness correction) with the page. That forced a markdown change through the shared sandbox gate and blocked it for hours on a saturated host, when `docs-only` diffs are explicitly exempt from the gate record.

The code fixes now travel separately, where the sandbox is legitimately required and they can be judged on their own merits. The derived artifacts here are regenerated from the page, not hand-edited.

## Verification

Pre-push gate took the documented exemption: `derived-artifact registry: exempt (docs diff, all affected artifacts fresh)` / `docs-only diff vs origin/main — no gate record required`. The pre-commit decision baseline re-scored the kernel with this page present: 45 commandments, both canonical decisions still hold.

Seed-Fit-Decision: global-default

Design-Grounding-Decision: no-contract-change — adds a kernel principle page and its regenerated derived artifacts; no code, schema or API surface.

Process-Spine-Decision: routes a confirmed learning to the commons per dpf-route-learning-to-commons; docs-only, no capability surface changed.

Docs-Impact-Decision: adds a founder-kernel principle page; that IS the documentation.