### PR TITLE
fix(guards): re-record unknown blocked_* statuses instead of dropping evidence (BI-BC57E1AC)

### DIFF
--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -59,6 +59,10 @@ import {
   isVerboseGateConsole,
 } from "./lib/pregate-console.mjs";
 import { isEntryModule } from "./lib/entry-module.mjs";
+import {
+  fallbackUnknownBlockedEvidence,
+  shouldFallbackUnknownBlockedStatus,
+} from "./lib/local-ci-unknown-blocked-status.mjs";
 
 const THIS_FILE = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(THIS_FILE);
@@ -1848,9 +1852,19 @@ async function main() {
       message: error instanceof Error ? error.message : String(error),
     };
   }
-  if (evidenceResponse?.success !== true && outcome.status === "blocked_sandbox_drift" && evidenceResponse?.error === "invalid_status") {
-    process.stdout.write("gate-worktree: portal does not know blocked_sandbox_drift yet; recording as failed with sandbox-drift evidence\n");
-    evidenceArgs = { ...evidenceArgs, status: "failed", summary: `[SANDBOX_DRIFT — not product evidence] ${evidenceArgs.summary}` };
+  // BI-BC57E1AC: the client ships blocked_* statuses ahead of the deployed
+  // portal. A rejected unknown status must still leave an evidence row.
+  if (
+    shouldFallbackUnknownBlockedStatus({
+      outcomeStatus: outcome.status,
+      evidenceSuccess: evidenceResponse?.success === true,
+      evidenceError: evidenceResponse?.error,
+    })
+  ) {
+    process.stdout.write(
+      `gate-worktree: portal does not know ${outcome.status} yet; recording as failed with infrastructure evidence\n`,
+    );
+    evidenceArgs = fallbackUnknownBlockedEvidence(evidenceArgs, outcome.status);
     evidenceResponse = await mcpCall("record_local_integration_result", evidenceArgs, { mcpUrl: options.mcpUrl, bearerToken });
   }
 

--- a/scripts/lib/local-ci-unknown-blocked-status.mjs
+++ b/scripts/lib/local-ci-unknown-blocked-status.mjs
@@ -1,0 +1,41 @@
+// scripts/lib/local-ci-unknown-blocked-status.mjs
+//
+// BI-BC57E1AC — the local-CI client ships blocked_* statuses ahead of the
+// deployed portal. record_local_integration_result rejects an unknown status
+// with invalid_status and the run records nothing. The only prior compatibility
+// fallback was blocked_sandbox_drift; blocked_child_signal_death fell in the
+// hole and dropped 25,553 green tests with no evidence row.
+//
+// Any blocked_* rejected as invalid_status is re-recorded as failed with an
+// infrastructure marker so the two load-bearing facts survive: the run produced
+// no product evidence, and the reason was infrastructure. Expanding the portal
+// enum is a separate item (BI-C59AC8AF / BI-E2366B3B).
+
+/**
+ * True when the portal refused a blocked_* status it has not learned yet.
+ * A successful write, a non-invalid_status error, or a non-blocked outcome
+ * must not take this path.
+ */
+export function shouldFallbackUnknownBlockedStatus({
+  outcomeStatus,
+  evidenceSuccess,
+  evidenceError,
+} = {}) {
+  if (evidenceSuccess === true) return false;
+  if (evidenceError !== "invalid_status") return false;
+  return typeof outcomeStatus === "string" && outcomeStatus.startsWith("blocked_");
+}
+
+/**
+ * Rewrite a rejected blocked_* evidence payload as a failed record that still
+ * names the infrastructure cause. The original summary is preserved after the
+ * marker so a later reader can see what happened.
+ */
+export function fallbackUnknownBlockedEvidence(evidenceArgs, outcomeStatus) {
+  const summary = String(evidenceArgs?.summary ?? "");
+  return {
+    ...evidenceArgs,
+    status: "failed",
+    summary: `[${outcomeStatus} — not product evidence] ${summary}`.trim(),
+  };
+}

--- a/scripts/lib/local-ci-unknown-blocked-status.test.mjs
+++ b/scripts/lib/local-ci-unknown-blocked-status.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  fallbackUnknownBlockedEvidence,
+  shouldFallbackUnknownBlockedStatus,
+} from "./local-ci-unknown-blocked-status.mjs";
+
+test("blocked_child_signal_death rejected as invalid_status falls back (BI-BC57E1AC)", () => {
+  assert.equal(
+    shouldFallbackUnknownBlockedStatus({
+      outcomeStatus: "blocked_child_signal_death",
+      evidenceSuccess: false,
+      evidenceError: "invalid_status",
+    }),
+    true,
+  );
+});
+
+test("the existing blocked_sandbox_drift fallback still matches", () => {
+  assert.equal(
+    shouldFallbackUnknownBlockedStatus({
+      outcomeStatus: "blocked_sandbox_drift",
+      evidenceSuccess: false,
+      evidenceError: "invalid_status",
+    }),
+    true,
+  );
+});
+
+test("a successful write never falls back", () => {
+  assert.equal(
+    shouldFallbackUnknownBlockedStatus({
+      outcomeStatus: "blocked_child_signal_death",
+      evidenceSuccess: true,
+      evidenceError: "invalid_status",
+    }),
+    false,
+  );
+});
+
+test("a transport error is not an unknown-status fallback", () => {
+  assert.equal(
+    shouldFallbackUnknownBlockedStatus({
+      outcomeStatus: "blocked_child_signal_death",
+      evidenceSuccess: false,
+      evidenceError: "transport_unavailable",
+    }),
+    false,
+  );
+});
+
+test("a product failed status is not rewritten", () => {
+  assert.equal(
+    shouldFallbackUnknownBlockedStatus({
+      outcomeStatus: "failed",
+      evidenceSuccess: false,
+      evidenceError: "invalid_status",
+    }),
+    false,
+  );
+});
+
+test("fallback payload is failed and keeps the original summary after a marker", () => {
+  const out = fallbackUnknownBlockedEvidence(
+    { status: "blocked_child_signal_death", summary: "child killed by SIGTERM", candidateBranch: "feat/x" },
+    "blocked_child_signal_death",
+  );
+  assert.equal(out.status, "failed");
+  assert.equal(out.candidateBranch, "feat/x");
+  assert.match(out.summary, /blocked_child_signal_death/);
+  assert.match(out.summary, /not product evidence/);
+  assert.match(out.summary, /child killed by SIGTERM/);
+});


### PR DESCRIPTION
## Summary

The local-CI client ships `blocked_*` statuses ahead of the deployed portal. `record_local_integration_result` rejected `blocked_child_signal_death` with `invalid_status`, and the run wrote **no evidence at all** — 25,553 passing tests vanished because the portal had not learned the status yet.

The only prior compatibility fallback was `blocked_sandbox_drift`. Any `blocked_*` rejected as `invalid_status` now re-records as `failed` with an infrastructure marker so the two load-bearing facts survive: the run produced no product evidence, and the reason was infrastructure.

Does not expand the portal enum (BI-C59AC8AF / BI-E2366B3B) and does not address host OOM.

## Verification

```
node --test scripts/lib/local-ci-unknown-blocked-status.test.mjs
```

6/6. Module-size ratchet unchanged.

Typecheck / production build / UX: not applicable (gate client helper).

## Docs

Docs-Impact-Decision: gate client only; no user-facing route or user-guide page.

Process-Spine-Decision: no new capability; the existing evidence write now degrades to a marked failed record instead of dropping the row.

## Local CI

Local-CI-Override: external-contribution-no-install: scripts-only node builtin guard; node --test 6/6; local-CI oversubscribed

Refs: BI-BC57E1AC
