### PR TITLE
feat(work-posture): show which layer decided the room's posture, and why (BI-4EB2F1D0)

### DIFF
--- a/apps/web/components/workspace/workroom/WorkroomPosture.test.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomPosture.test.tsx
@@ -76,7 +76,11 @@ describe("WorkroomPosture", () => {
         })}
       />,
     );
-    expect(html).toContain("Unchanged for this room");
+    // BI-4EB2F1D0: the honest empty state names what IS running rather than
+    // only what is not, and renders no provenance chain for decisions nobody
+    // made.
+    expect(html).toContain("Running platform defaults");
+    expect(html).not.toContain("How this was decided");
     expect(html).toContain("open");
   });
 

--- a/apps/web/components/workspace/workroom/WorkroomPosture.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomPosture.tsx
@@ -1,6 +1,7 @@
 import { Surface } from "@/components/ui/Surface";
 
 import { WorkroomPostureControl } from "./WorkroomPostureControl";
+import { WorkroomPostureProvenance } from "./WorkroomPostureProvenance";
 import type { WorkroomView } from "@/lib/work-management/room-types";
 
 // EP-WORK-POSTURE Slice D (BI-4F468192) — make the room's posture observable.
@@ -95,20 +96,11 @@ export function WorkroomPosture({ room }: { room: WorkroomView }) {
                 </div>
               ) : null}
 
-              {posture.inert ? (
-                <p className="text-xs text-[var(--dpf-muted)]">Unchanged for this room.</p>
-              ) : (
-                <div>
-                  <p className="text-xs text-[var(--dpf-muted)]">Why</p>
-                  <ul className="mt-1 space-y-1 text-[var(--dpf-muted)]">
-                    {posture.adjustments.map((adjustment) => (
-                      <li key={`${adjustment.field}:${adjustment.reasonCode}`}>
-                        {adjustment.reason}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
+              {/* The layer-by-layer account (BI-4EB2F1D0). It subsumes the flat
+                  "Why" list this section used to render — the same reasons, now
+                  attributed to the layer that produced them — so the reasons
+                  appear once rather than twice. */}
+              <WorkroomPostureProvenance posture={posture} />
             </>
           )}
 

--- a/apps/web/components/workspace/workroom/WorkroomPostureProvenance.test.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomPostureProvenance.test.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { WorkroomPostureView } from "@/lib/work-management/room-posture";
+
+import { WorkroomPostureProvenance } from "./WorkroomPostureProvenance";
+
+const BALANCED = {
+  costWeight: 1 / 3,
+  qualityWeight: 1 / 3,
+  timeWeight: 1 / 3,
+  preset: "balanced" as const,
+};
+
+function posture(overrides: Partial<WorkroomPostureView> = {}): WorkroomPostureView {
+  return {
+    proactivityLevel: "balanced",
+    actionBoundary: "propose",
+    minimumTier: undefined,
+    verificationDepth: undefined,
+    priority: BALANCED,
+    temporalBand: "in-hours",
+    proactivitySource: "platform",
+    prioritySource: "platform",
+    adjustments: [],
+    inert: false,
+    ...overrides,
+  } as WorkroomPostureView;
+}
+
+const OVERRIDDEN_BY_POLICY = [
+  {
+    field: "actionBoundary",
+    from: "preauthorized",
+    to: "propose",
+    reasonCode: "room_declaration",
+    reason: "The room declared this action boundary when it was convened.",
+  },
+  {
+    field: "actionBoundary",
+    from: "propose",
+    to: "advise",
+    reasonCode: "regulated_ceiling",
+    reason: "This work is regulated, so the coworker advises rather than acts.",
+  },
+];
+
+describe("WorkroomPostureProvenance", () => {
+  it("renders the honest empty state for an inert posture", () => {
+    const html = renderToStaticMarkup(<WorkroomPostureProvenance posture={posture({ inert: true })} />);
+    expect(html).toContain("Running platform defaults");
+    // No chain, no layer names — nothing implying decisions nobody made.
+    expect(html).not.toContain("How this was decided");
+    expect(html).not.toContain("Policy");
+  });
+
+  it("makes every precedence layer distinguishable", () => {
+    const html = renderToStaticMarkup(
+      <WorkroomPostureProvenance posture={posture({ adjustments: OVERRIDDEN_BY_POLICY })} />,
+    );
+    for (const label of [
+      "Policy",
+      "This room",
+      "The work itself",
+      "Default for rooms",
+      "The coworker",
+      "The organisation",
+      "Platform default",
+    ]) {
+      expect(html, label).toContain(label);
+    }
+  });
+
+  it("shows the clamp reason verbatim from the adjustment", () => {
+    const html = renderToStaticMarkup(
+      <WorkroomPostureProvenance posture={posture({ adjustments: OVERRIDDEN_BY_POLICY })} />,
+    );
+    expect(html).toContain("This work is regulated, so the coworker advises rather than acts.");
+    expect(html).toContain("The room declared this action boundary when it was convened.");
+  });
+
+  // The load-bearing half: an operator whose declaration lost needs to see
+  // that it lost, not just the value that won.
+  it("marks a superseded clamp as overridden rather than hiding it", () => {
+    const html = renderToStaticMarkup(
+      <WorkroomPostureProvenance posture={posture({ adjustments: OVERRIDDEN_BY_POLICY })} />,
+    );
+    expect(html).toContain("Later overridden.");
+  });
+
+  it("names the input that drove a derived clamp", () => {
+    const html = renderToStaticMarkup(
+      <WorkroomPostureProvenance
+        posture={posture({
+          adjustments: [
+            {
+              field: "proactivityLevel",
+              from: "balanced",
+              to: "quiet",
+              reasonCode: "clock_out_of_hours",
+              reason: "The business is closed.",
+            },
+          ],
+        })}
+      />,
+    );
+    expect(html).toContain("from the clock");
+  });
+
+  it("says plainly when a layer contributed nothing", () => {
+    const html = renderToStaticMarkup(
+      <WorkroomPostureProvenance posture={posture({ adjustments: OVERRIDDEN_BY_POLICY })} />,
+    );
+    expect(html).toContain("Nothing from here.");
+  });
+
+  // AGENTS.md §9 — theme-aware styling is mandatory, so light mode, dark mode
+  // and per-org branding all work without a second code path.
+  it("uses only --dpf-* tokens for colour", () => {
+    const html = renderToStaticMarkup(
+      <WorkroomPostureProvenance posture={posture({ adjustments: OVERRIDDEN_BY_POLICY })} />,
+    );
+    expect(html).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    expect(html).not.toMatch(/text-(white|black)\b/);
+    expect(html).not.toMatch(/-gray-\d/);
+  });
+});

--- a/apps/web/components/workspace/workroom/WorkroomPostureProvenance.tsx
+++ b/apps/web/components/workspace/workroom/WorkroomPostureProvenance.tsx
@@ -1,0 +1,107 @@
+import { buildPostureProvenance, type PostureProvenanceDriver } from "@/lib/work-posture/provenance";
+import type { PostureLayer } from "@/lib/work-posture/resolve";
+import type { WorkroomPostureView } from "@/lib/work-management/room-posture";
+
+// EP-WORK-POSTURE Slice H (BI-4EB2F1D0) — the layer-by-layer account.
+//
+// Answers "why is it behaving like this" without reading code: which of the
+// precedence layers set each value, and what drove it.
+//
+// Nested inside the section's own collapsed disclosure, so it adds nothing to
+// the arrival view. The UX budget measure excises collapsed content from
+// defaultVisibleWords, and /platform/ai/assignments — the other surface this
+// epic touches — is already well over its word budget (BI-6786CE44).
+//
+// This component DECIDES NOTHING. Every reason string is carried verbatim from
+// the resolver's PolicyAdjustment chain; nothing here is re-derived.
+
+const LAYER_COPY: Record<PostureLayer, string> = {
+  "hard-policy": "Policy",
+  "room-declaration": "This room",
+  derived: "The work itself",
+  "workroom-default": "Default for rooms",
+  agent: "The coworker",
+  organization: "The organisation",
+  platform: "Platform default",
+};
+
+const FIELD_COPY: Record<string, string> = {
+  proactivityLevel: "Pace",
+  actionBoundary: "Authority",
+  minimumTier: "Model floor",
+  verificationDepth: "Checking",
+  priority: "Priority",
+};
+
+// Only the drivers that add something the layer name does not already say.
+const DRIVER_COPY: Partial<Record<PostureProvenanceDriver, string>> = {
+  "work-shape": "the shape of the work",
+  "activity-kind": "the kind of activity",
+  "archetype-stream": "the value stream",
+  clock: "the clock",
+  "room-mode": "the room mode",
+  unclassified: "an unnamed input",
+};
+
+function fieldLabel(field: string): string {
+  return FIELD_COPY[field] ?? field;
+}
+
+export function WorkroomPostureProvenance({ posture }: { posture: WorkroomPostureView }) {
+  // Honest empty state. A room that derived nothing and declared nothing gets
+  // one plain sentence, not a rich chain implying decisions nobody made.
+  if (posture.inert) {
+    return (
+      <p className="text-xs text-[var(--dpf-muted)]">
+        Running platform defaults. Nothing about this room changed them.
+      </p>
+    );
+  }
+
+  const provenance = buildPostureProvenance(posture);
+
+  return (
+    <details>
+      <summary className="min-h-11 cursor-pointer list-none py-2 text-xs font-semibold text-[var(--dpf-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]">
+        How this was decided
+      </summary>
+
+      <ol className="mt-1 space-y-2 border-l border-[var(--dpf-border)] pl-3">
+        {provenance.layers.map((layer) => (
+          <li key={layer.layer}>
+            <p className="text-xs font-medium text-[var(--dpf-text)]">
+              {LAYER_COPY[layer.layer]}
+              {layer.decidedFields.length > 0 ? (
+                <span className="font-normal text-[var(--dpf-muted)]">
+                  {" — set "}
+                  {layer.decidedFields.map(fieldLabel).join(", ").toLowerCase()}
+                </span>
+              ) : null}
+            </p>
+
+            {layer.contributed ? null : (
+              <p className="text-xs text-[var(--dpf-muted)]">Nothing from here.</p>
+            )}
+
+            {layer.steps.length > 0 ? (
+              <ul className="mt-1 space-y-1">
+                {layer.steps.map((step, index) => (
+                  <li
+                    key={`${step.field}:${step.reasonCode}:${index}`}
+                    className="text-xs text-[var(--dpf-muted)]"
+                  >
+                    <span className="text-[var(--dpf-text)]">{fieldLabel(step.field)}</span>
+                    {": "}
+                    {step.reason}
+                    {DRIVER_COPY[step.driver] ? ` (from ${DRIVER_COPY[step.driver]})` : ""}
+                    {step.decisive ? "" : " Later overridden."}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </details>
+  );
+}

--- a/apps/web/lib/work-posture/index.ts
+++ b/apps/web/lib/work-posture/index.ts
@@ -6,3 +6,4 @@ export * from "./temporal-band";
 export * from "./tighten";
 export * from "./derive";
 export * from "./resolve";
+export * from "./provenance";

--- a/apps/web/lib/work-posture/provenance.test.ts
+++ b/apps/web/lib/work-posture/provenance.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPostureProvenance,
+  driverForReasonCode,
+  layerForReasonCode,
+  POSTURE_LAYER_ORDER,
+} from "./provenance";
+import { resolveWorkPosture } from "./resolve";
+import type { ProactivityPlan } from "@/lib/proactivity/proactivity-types";
+
+function plan(overrides: Partial<ProactivityPlan> = {}): ProactivityPlan {
+  return {
+    resolvedLevel: "balanced",
+    actionBoundary: "propose",
+    evidenceRefs: [],
+    explanation: "",
+    ...overrides,
+  } as ProactivityPlan;
+}
+
+describe("reasonCode classification", () => {
+  it("attributes every layer-bearing code to its own layer", () => {
+    expect(layerForReasonCode("hard_policy_floor")).toBe("hard-policy");
+    expect(layerForReasonCode("regulated_ceiling")).toBe("hard-policy");
+    expect(layerForReasonCode("room_declaration")).toBe("room-declaration");
+    expect(layerForReasonCode("workroom_default")).toBe("workroom-default");
+  });
+
+  it("treats every derivation code as the derived layer", () => {
+    for (const code of [
+      "shape_outward_review",
+      "activity_governance",
+      "stream_trust_gate",
+      "clock_out_of_hours",
+      "mode_standing_between_cycles",
+      "derived_priority_axis",
+    ]) {
+      expect(layerForReasonCode(code), code).toBe("derived");
+    }
+  });
+
+  it("names the input that drove each derived clamp", () => {
+    expect(driverForReasonCode("shape_escalation")).toBe("work-shape");
+    expect(driverForReasonCode("activity_remediation")).toBe("activity-kind");
+    expect(driverForReasonCode("stream_urgent_demand")).toBe("archetype-stream");
+    expect(driverForReasonCode("clock_breach_imminent")).toBe("clock");
+    expect(driverForReasonCode("mode_standing_between_cycles")).toBe("room-mode");
+  });
+
+  // The honest-fallthrough property: an unrecognised code must be visibly
+  // unclassified rather than silently attributed to a plausible driver.
+  it("reports an unknown code as unclassified rather than guessing", () => {
+    expect(driverForReasonCode("task_class_tier_floor")).toBe("unclassified");
+    expect(layerForReasonCode("something_new")).toBe("derived");
+  });
+});
+
+describe("buildPostureProvenance", () => {
+  it("renders every precedence layer, contributed or not", () => {
+    const provenance = buildPostureProvenance({
+      adjustments: [],
+      inert: true,
+      proactivitySource: "platform",
+      prioritySource: "platform",
+    });
+    expect(provenance.layers.map((l) => l.layer)).toEqual([...POSTURE_LAYER_ORDER]);
+    expect(provenance.inert).toBe(true);
+  });
+
+  it("marks an inert posture's layers as having contributed nothing", () => {
+    const provenance = buildPostureProvenance({
+      adjustments: [],
+      inert: true,
+      proactivitySource: "agent",
+      prioritySource: "agent",
+    });
+    const contributed = provenance.layers.filter((l) => l.contributed).map((l) => l.layer);
+    // Only the inherited layer that actually supplied the standing values.
+    expect(contributed).toEqual(["agent"]);
+  });
+
+  it("attributes a clamp to the layer its reasonCode names", () => {
+    const provenance = buildPostureProvenance({
+      adjustments: [
+        {
+          field: "actionBoundary",
+          from: "preauthorized",
+          to: "propose",
+          reasonCode: "shape_outward_review",
+          reason: "Outward-facing review tightens authority.",
+        },
+        {
+          field: "actionBoundary",
+          from: "propose",
+          to: "advise",
+          reasonCode: "regulated_ceiling",
+          reason: "This work is regulated, so the coworker advises rather than acts.",
+        },
+      ],
+      inert: false,
+      proactivitySource: "platform",
+      prioritySource: "platform",
+    });
+
+    const derived = provenance.layers.find((l) => l.layer === "derived");
+    const hard = provenance.layers.find((l) => l.layer === "hard-policy");
+    expect(derived?.steps).toHaveLength(1);
+    expect(hard?.steps).toHaveLength(1);
+    // Hard policy applied last, so it owns the value in force.
+    expect(hard?.decidedFields).toEqual(["actionBoundary"]);
+    expect(derived?.decidedFields).toEqual([]);
+    expect(derived?.steps[0]?.decisive).toBe(false);
+    expect(hard?.steps[0]?.decisive).toBe(true);
+  });
+
+  // The load-bearing half: a superseded clamp must stay visible, because
+  // "policy overrode what this room asked for" is the answer being sought.
+  it("keeps a superseded clamp in the chain rather than dropping it", () => {
+    const provenance = buildPostureProvenance({
+      adjustments: [
+        {
+          field: "proactivityLevel",
+          from: "balanced",
+          to: "assertive",
+          reasonCode: "room_declaration",
+          reason: "The room declared this proactivity level when it was convened.",
+        },
+        {
+          field: "proactivityLevel",
+          from: "assertive",
+          to: "quiet",
+          reasonCode: "clock_out_of_hours",
+          reason: "The business is closed.",
+        },
+      ],
+      inert: false,
+      proactivitySource: "derived",
+      prioritySource: "platform",
+    });
+    const declaration = provenance.layers.find((l) => l.layer === "room-declaration");
+    expect(declaration?.steps).toHaveLength(1);
+    expect(declaration?.steps[0]?.decisive).toBe(false);
+    expect(declaration?.steps[0]?.reason).toBe(
+      "The room declared this proactivity level when it was convened.",
+    );
+  });
+
+  it("carries the clamp reason verbatim from the adjustment", () => {
+    const reason = "A policy floor applies that the posture cannot trade away.";
+    const provenance = buildPostureProvenance({
+      adjustments: [
+        { field: "minimumTier", from: undefined, to: "strong", reasonCode: "hard_policy_floor", reason },
+      ],
+      inert: false,
+      proactivitySource: "platform",
+      prioritySource: "platform",
+    });
+    const hard = provenance.layers.find((l) => l.layer === "hard-policy");
+    expect(hard?.steps[0]?.reason).toBe(reason);
+  });
+});
+
+// End-to-end over the REAL resolver, so the projection cannot drift from the
+// codes the resolver actually emits — the drift this module exists to prevent.
+describe("provenance over a real resolution", () => {
+  it("classifies every reasonCode a real resolution produces", () => {
+    const resolved = resolveWorkPosture({
+      inherited: { proactivityPlan: plan(), priority: null, source: "agent" },
+      hardPolicy: { regulated: true },
+      declaration: { proactivityLevel: "assertive" },
+      shape: { shapeKey: "outward-review", activityKind: "governance", mode: "finite", cycleActive: false },
+      stream: null,
+      temporal: null,
+    });
+
+    const provenance = buildPostureProvenance(resolved);
+    expect(resolved.adjustments.length).toBeGreaterThan(0);
+
+    // No adjustment may land in the unclassified bucket: if the resolver grows
+    // a new reasonCode, this fails rather than rendering an unexplained row.
+    const unclassified = provenance.layers
+      .flatMap((l) => l.steps)
+      .filter((s) => s.driver === "unclassified");
+    expect(unclassified, `unclassified: ${unclassified.map((s) => s.reasonCode).join(", ")}`).toEqual([]);
+
+    // Every step is reachable from exactly one layer.
+    const stepCount = provenance.layers.reduce((n, l) => n + l.steps.length, 0);
+    expect(stepCount).toBe(resolved.adjustments.length);
+  });
+
+  it("is inert for a default context, matching the resolver", () => {
+    const resolved = resolveWorkPosture({
+      inherited: { proactivityPlan: plan(), priority: null, source: "platform" },
+      shape: { shapeKey: null, activityKind: null, mode: "finite", cycleActive: false },
+      stream: null,
+      temporal: null,
+    });
+    const provenance = buildPostureProvenance(resolved);
+    expect(provenance.inert).toBe(true);
+    expect(provenance.layers.every((l) => l.steps.length === 0)).toBe(true);
+  });
+});

--- a/apps/web/lib/work-posture/provenance.ts
+++ b/apps/web/lib/work-posture/provenance.ts
@@ -1,0 +1,204 @@
+/**
+ * EP-WORK-POSTURE Slice H (BI-4EB2F1D0) — the provenance projection.
+ *
+ * Design: docs/superpowers/specs/2026-08-22-workroom-work-posture-design.md §9.
+ *
+ * The question this answers, for an operator who set a posture and is watching
+ * something else happen: WHICH LAYER decided each value, and what drove it.
+ *
+ * This module DECIDES NOTHING. `resolveWorkPosture` already emits a complete
+ * decision log — every clamp, in application order, with a stable `reasonCode`
+ * — and this is a projection over it. The layer and the driver are read from
+ * the reasonCode by lookup; they are never recomputed from the inputs, because
+ * a second derivation is a second source of truth that can disagree with the
+ * first (AGENTS.md §1).
+ *
+ * Pure: no React, no I/O, no ambient time.
+ */
+import type { PolicyAdjustment } from "@/lib/golden-triangle";
+
+import type { PostureLayer, ResolvedWorkPosture } from "./resolve";
+
+/**
+ * What actually drove a derived clamp. The derived layer is one precedence
+ * step but four distinct inputs, and "derived" alone does not tell an operator
+ * whether to change the room's shape, its hours, or nothing at all.
+ */
+export type PostureProvenanceDriver =
+  | "hard-policy"
+  | "room-declaration"
+  | "workroom-default"
+  | "work-shape"
+  | "activity-kind"
+  | "archetype-stream"
+  | "clock"
+  | "room-mode"
+  | "inherited"
+  | "unclassified";
+
+/**
+ * reasonCode → the layer that emitted it. Exhaustive over the codes
+ * `resolve.ts` and `derive.ts` actually emit; anything else falls to `derived`
+ * with an `unclassified` driver rather than being dropped or guessed at.
+ */
+const LAYER_BY_REASON_CODE: Record<string, PostureLayer> = {
+  hard_policy_floor: "hard-policy",
+  regulated_ceiling: "hard-policy",
+  room_declaration: "room-declaration",
+  workroom_default: "workroom-default",
+};
+
+/** reasonCode prefix → the input that drove it. Order matters: longest first. */
+const DRIVER_BY_PREFIX: ReadonlyArray<readonly [string, PostureProvenanceDriver]> = [
+  ["hard_policy_", "hard-policy"],
+  ["regulated_", "hard-policy"],
+  ["room_declaration", "room-declaration"],
+  ["workroom_default", "workroom-default"],
+  ["shape_", "work-shape"],
+  ["activity_", "activity-kind"],
+  ["stream_", "archetype-stream"],
+  ["clock_", "clock"],
+  ["mode_", "room-mode"],
+  // The composite priority shift. Its inputs are the accumulated axis biases,
+  // which come from several drivers at once, so it is attributed to the shape
+  // of the work as a whole — which is exactly what its reason text says.
+  ["derived_priority_axis", "work-shape"],
+];
+
+export function layerForReasonCode(reasonCode: string): PostureLayer {
+  return LAYER_BY_REASON_CODE[reasonCode] ?? "derived";
+}
+
+export function driverForReasonCode(reasonCode: string): PostureProvenanceDriver {
+  for (const [prefix, driver] of DRIVER_BY_PREFIX) {
+    if (reasonCode.startsWith(prefix)) return driver;
+  }
+  return "unclassified";
+}
+
+export interface PostureProvenanceStep {
+  field: string;
+  from: unknown;
+  to: unknown;
+  /** Carried verbatim so the view never re-words a clamp reason. */
+  reasonCode: string;
+  reason: string;
+  driver: PostureProvenanceDriver;
+  /**
+   * True when this step produced the value the room is actually running at —
+   * i.e. nothing after it moved the same field. A superseded clamp still shows,
+   * because "policy overrode what this room asked for" is the answer an
+   * operator came for.
+   */
+  decisive: boolean;
+}
+
+export interface PostureProvenanceLayer {
+  layer: PostureLayer;
+  /** Every step this layer contributed, in application order. */
+  steps: PostureProvenanceStep[];
+  /** Fields whose final value this layer is responsible for. */
+  decidedFields: string[];
+  /** False when the layer applied to this room and changed nothing. */
+  contributed: boolean;
+}
+
+export interface PostureProvenance {
+  /** EVERY layer, in precedence order, contributed or not. */
+  layers: PostureProvenanceLayer[];
+  /** True when no layer moved anything — the inherited posture stands. */
+  inert: boolean;
+}
+
+/**
+ * Precedence order, strongest first. Mirrors the ladder in `resolve.ts`'s
+ * header, with `workroom-default` in its decided position: below derivation,
+ * because what the work IS outranks a blanket preference about rooms.
+ */
+export const POSTURE_LAYER_ORDER: readonly PostureLayer[] = [
+  "hard-policy",
+  "room-declaration",
+  "derived",
+  "workroom-default",
+  "agent",
+  "organization",
+  "platform",
+];
+
+/** The layers that never emit an adjustment — they are the starting point. */
+const INHERITED_LAYERS: ReadonlySet<PostureLayer> = new Set(["agent", "organization", "platform"]);
+
+type ProvenanceSource = Pick<
+  ResolvedWorkPosture,
+  "adjustments" | "inert" | "proactivitySource" | "prioritySource"
+>;
+
+/**
+ * Project the resolver's decision log into a layer-by-layer account.
+ *
+ * The last adjustment to touch a field is the one that decided it, so decisive
+ * steps fall out of the chain's order rather than needing a second pass over
+ * the inputs.
+ */
+export function buildPostureProvenance(resolved: ProvenanceSource): PostureProvenance {
+  const adjustments: readonly PolicyAdjustment[] = resolved.adjustments;
+
+  // Index of the final adjustment per field — the decisive one.
+  const lastIndexByField = new Map<string, number>();
+  adjustments.forEach((adjustment, index) => lastIndexByField.set(adjustment.field, index));
+
+  const stepsByLayer = new Map<PostureLayer, PostureProvenanceStep[]>();
+  const decidedByLayer = new Map<PostureLayer, string[]>();
+
+  adjustments.forEach((adjustment, index) => {
+    const layer = layerForReasonCode(adjustment.reasonCode);
+    const decisive = lastIndexByField.get(adjustment.field) === index;
+    const step: PostureProvenanceStep = {
+      field: adjustment.field,
+      from: adjustment.from,
+      to: adjustment.to,
+      reasonCode: adjustment.reasonCode,
+      reason: adjustment.reason,
+      driver: driverForReasonCode(adjustment.reasonCode),
+      decisive,
+    };
+    const steps = stepsByLayer.get(layer) ?? [];
+    steps.push(step);
+    stepsByLayer.set(layer, steps);
+    if (decisive) {
+      const decided = decidedByLayer.get(layer) ?? [];
+      decided.push(adjustment.field);
+      decidedByLayer.set(layer, decided);
+    }
+  });
+
+  // The inherited layers emit no adjustments, so their responsibility is read
+  // from the resolver's own source fields — the only record that a value came
+  // from the coworker, the organization or the platform default untouched.
+  attributeInherited(decidedByLayer, resolved.proactivitySource, "proactivityLevel");
+  attributeInherited(decidedByLayer, resolved.prioritySource, "priority");
+
+  const layers = POSTURE_LAYER_ORDER.map((layer) => {
+    const steps = stepsByLayer.get(layer) ?? [];
+    const decidedFields = decidedByLayer.get(layer) ?? [];
+    return {
+      layer,
+      steps,
+      decidedFields,
+      contributed: steps.length > 0 || decidedFields.length > 0,
+    };
+  });
+
+  return { layers, inert: resolved.inert };
+}
+
+function attributeInherited(
+  decidedByLayer: Map<PostureLayer, string[]>,
+  source: PostureLayer,
+  field: string,
+): void {
+  if (!INHERITED_LAYERS.has(source)) return;
+  const decided = decidedByLayer.get(source) ?? [];
+  if (!decided.includes(field)) decided.push(field);
+  decidedByLayer.set(source, decided);
+}

--- a/docs/superpowers/plans/2026-08-22-work-posture-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-22-work-posture-implementation-plan.md
@@ -21,11 +21,27 @@ status: active
 | G | `BI-BEDAFF57` | small | Archetype posture conformance test over the whole catalogue |
 | H | `BI-4EB2F1D0` | medium | Room surface renders the posture and its provenance |
 
-## Status ⟦runtime: 2026-08-23⟧
+## Status ⟦runtime: 2026-08-28⟧
 
-Seven of eight slices have landed across five PRs (#4488, #4492, #4569, and the
-posture-governs branch). **H — the rich layer-by-layer provenance surface — has not.**
-The minimal "Pace and priority" section shipped with D; H is the full provenance chain.
+All eight slices have landed. Seven went across five PRs (#4488, #4492, #4569, and the
+posture-governs branch); **H — the rich layer-by-layer provenance surface — landed on
+`feat/work-posture-provenance`.**
+
+H is a PROJECTION, not a second resolver. `resolveWorkPosture` already emitted a complete
+decision log — every clamp, in application order, with a stable `reasonCode` — so
+`lib/work-posture/provenance.ts` reads the layer and the driving input from that code by
+lookup and never recomputes them from the inputs. A second derivation would be a second
+source of truth able to disagree with the first (AGENTS.md §1). The chain renders inside
+the room surface's existing collapsed "Pace and priority" disclosure and REPLACES the flat
+"Why" list that section used to show, so the same reasons appear once, attributed to the
+layer that produced them, and the arrival view gains no words.
+
+Two follow-on wiring gaps were found while verifying H and filed rather than built: a
+scheduled tick still does not resolve posture through the room ladder (`BI-27C8484F`), and
+a coworker's ordinary in-room proactivity still resolves from the old identity ladder
+(`BI-87C9C91C`). Both are the same "posture resolves but nothing consumes it" defect on
+different execution paths, and are worth sequencing together so the room dimension is added
+to `ProactivityResolverInput` once.
 
 Two items outside the original eight were found and closed on the way: the workroom shape
 had no write path at all (`BI-8C54B216`), and the posture was display-only

--- a/docs/ux-fit/2026-08-28-workroom-posture-provenance.ux-fit.json
+++ b/docs/ux-fit/2026-08-28-workroom-posture-provenance.ux-fit.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "decidedOption": "nested-collapsed-disclosure",
+  "decisionInteractionId": "DI-EC67B219E83A",
+  "scope": {
+    "files": [
+      "apps/web/components/workspace/workroom/WorkroomPostureProvenance.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "nested-collapsed-disclosure",
+      "new-visible-section",
+      "assignments-route"
+    ],
+    "notes": "BI-4EB2F1D0 (EP-WORK-POSTURE slice H) renders the posture provenance chain. Scored via principle_decide (DI-EC67B219E83A, profile mark-dpf-platform, 41 principles applied, structured coverage strong): nested-collapsed-disclosure composite 10.99, new-visible-section 6.11, assignments-route 2.78 — margin 4.88, confidence high, autonomy eligible with no blockers. The decisive axis is human_cognitive_load, which is a COST axis: the two rejected options raise it (0.85 and 0.95) because they put a six-layer decision chain on an arrival view. The chain is nested inside the room surface's existing 'Pace and priority' disclosure, which is already collapsed, so defaultVisibleWords for the arrival view is unchanged — the UX budget measure excises collapsed content (apps/web/lib/ux-budget/evaluate.ts:98). It also replaces the flat 'Why' list the section rendered before, so the same clamp reasons appear once rather than twice. The assignments-route option was rejected on measured grounds as well as scored ones: /platform/ai/assignments is recorded in the committed baseline at 1193 visible words against a 450 budget and 37 visible fields against a budget of 8 (BI-6786CE44), so it is the wrong place to add anything visible."
+  }
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -9871,6 +9871,14 @@
     "longSentences": 0,
     "textMass": 84
   },
+  "apps/web/components/workspace/workroom/WorkroomPostureProvenance.tsx": {
+    "vocabulary": 0,
+    "retiredVocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
   "apps/web/components/workspace/workroom/WorkroomShape.tsx": {
     "vocabulary": 0,
     "retiredVocabulary": 0,


### PR DESCRIPTION
Closes the last unbuilt slice of EP-WORK-POSTURE (slice H, BI-4EB2F1D0).

An operator who set a posture and saw different behaviour had no way to find out why. The resolver layers four inputs across six precedence levels; the room surface showed the outcome and a flat list of reasons, with no indication of which layer produced which value.

## What this is

A **projection**, not a second resolver. `resolveWorkPosture` already emitted a complete decision log — every clamp, in application order, with a stable `reasonCode`, and its own comment names this surface as the consumer. `apps/web/lib/work-posture/provenance.ts` reads the layer and the driving input from that code by lookup and never recomputes them from the inputs. A second derivation would be a second source of truth able to disagree with the first (AGENTS.md §1).

The chain renders inside the room surface's **existing** collapsed "Pace and priority" disclosure and **replaces** the flat "Why" list, so the same reasons appear once, attributed to the layer that produced them, and the arrival view gains no words.

## Acceptance, against the item

- **Every precedence layer distinguishable** — all seven are listed whether they contributed or not; a layer that applied and changed nothing says "Nothing from here."
- **A clamped value shows the clamp reason from the `reasonCode`, never re-derived** — the reason string is carried verbatim from the `PolicyAdjustment`; a test asserts this.
- **Honest empty state** — an inert posture gets one plain sentence naming what *is* running, and renders no chain implying decisions nobody made.
- **Theme-aware** — `--dpf-*` tokens only, asserted by a test that rejects hex, `text-white`/`text-black` and `*-gray-*`.

A superseded clamp stays visible and is marked overridden, because "policy overrode what this room asked for" is the answer the operator came for. An unrecognised `reasonCode` reports as `unclassified` rather than being attributed to a plausible driver, and a test over the **real** resolver fails if the resolver grows a code this projection cannot classify.

## Verification

- 428 tests across `lib/work-posture`, `lib/work-management` and the workroom components.
- Typecheck clean (0 TS errors); production build exits 0.
- 53 preflight guards clean; local-CI gate **PASS** @ `6dc1c497e7c6`, evidence `cmtdfjwme4zf401md8edl05k6`.
- Live-state check (direct DB read against `dpf-postgres-1`, stated per AGENTS.md §5): of 358 live rooms, 57 carry a shape-derivable `activityKind`, 35 of those governance or remediation, which bias the posture — so the surface has real provenance to show rather than being inert everywhere.

**UX verification is NOT claimed.** The contributor preview serves every route behind auth and entering credentials is not an agent action, so the interactive check could not be performed. Recorded here rather than asserted. The live-state read above is the substitute, and it exercises the derivation rather than the rendering.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-08-22-workroom-work-posture-design.md` §9; `docs/superpowers/plans/2026-08-22-work-posture-implementation-plan.md` slice H.
- Current code substrate reviewed: `apps/web/lib/work-posture/resolve.ts`, `apps/web/lib/work-posture/derive.ts`, `apps/web/lib/work-management/room-posture.ts`, `apps/web/components/workspace/workroom/WorkroomPosture.tsx`, and `apps/web/components/golden-triangle/posture-display.ts` (checked for an existing chip vocabulary to reuse rather than inventing a second one).
- Source of truth: the resolver's `PolicyAdjustment` chain. The view re-derives nothing.
- Decision: extend the existing design; no new contract. Placement scored via `principle_decide` `DI-EC67B219E83A` across three options — nested collapsed disclosure 10.99 vs 6.11 vs 2.78, margin 4.88, confidence high. The decisive axis is `human_cognitive_load`, a cost axis the two rejected options raise by putting a six-layer chain on an arrival view. `/platform/ai/assignments` was rejected on measured grounds too: 1193 visible words against a 450 budget (BI-6786CE44).

UX-fit evidence: `docs/ux-fit/2026-08-28-workroom-posture-provenance.ux-fit.json` (`propose-n-pick`).

## Note on the prose-lint baseline

`check-prose-lint --update` rewrote 1,594 lines across hundreds of untouched files. That was reverted; the single 8-line entry for the new file was added by hand instead, so this diff does not silently re-baseline unrelated surfaces.

## Found while verifying, filed not built

- `BI-27C8484F` — a scheduled tick still does not resolve posture through the room ladder; `scheduled-work-trigger.ts`'s only importer is the MCP pack.
- `BI-87C9C91C` — a coworker's ordinary in-room proactivity still resolves from the identity ladder; `ProactivityResolverInput` has no room dimension.

Both are the same "posture resolves but nothing consumes it" defect on different execution paths, and are worth sequencing together so the room dimension is added to the input shape once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
