### PR TITLE
fix(portfolio): cockpit counts the canonical coworker roster, not raw Agent rows (BI-B939790B)

### DIFF
--- a/apps/web/components/portfolio/PortfolioOverview.tsx
+++ b/apps/web/components/portfolio/PortfolioOverview.tsx
@@ -78,7 +78,7 @@ export function PortfolioOverview({ roots, agentCounts, budgets, summary }: Prop
             label="AI Coworkers"
             value={summary.activeAgents}
             colour="var(--dpf-accent)"
-            detail={`of ${summary.totalAgents} total`}
+            detail="active roster"
           />
         </div>
       </section>

--- a/apps/web/lib/evaluate/portfolio-data.ts
+++ b/apps/web/lib/evaluate/portfolio-data.ts
@@ -3,6 +3,10 @@
 // Both layout.tsx and page.tsx call getPortfolioTree() — React deduplicates automatically.
 import { cache } from "react";
 import { prisma } from "@dpf/db";
+import {
+  SELECTABLE_COWORKER_STATE,
+  dropDualSeedAliasAgents,
+} from "@/lib/coworker-record/selectable-coworker";
 import { buildPortfolioTree, PORTFOLIO_OWNER_ROLES, type OwnerRoleInfo } from "./portfolio";
 import {
   getPortfolioBudgetMetric,
@@ -151,7 +155,7 @@ export const getPortfolioSummary = cache(async (): Promise<PortfolioSummary> => 
     statusGroups,
     backlogCounts,
     epicCounts,
-    agentCounts,
+    selectableAgentRows,
   ] = await Promise.all([
     prisma.digitalProduct.groupBy({
       by: ["lifecycleStage"],
@@ -169,11 +173,16 @@ export const getPortfolioSummary = cache(async (): Promise<PortfolioSummary> => 
       by: ["status"],
       _count: { id: true },
     }),
-    prisma.agent.groupBy({
-      by: ["status"],
-      _count: { id: true },
+    // BI-B939790B: count the SAME canonical roster the /workforce cockpit shows —
+    // selectable coworkers (active · production · not-archived) with dual-seed alias
+    // twins collapsed — instead of raw Agent rows. A raw groupBy summed alias twins,
+    // draft, and retired rows into "114 total / 97 active" beside /workforce's 76.
+    prisma.agent.findMany({
+      where: SELECTABLE_COWORKER_STATE,
+      select: { agentId: true },
     }),
   ]);
+  const rosterAgentCount = dropDualSeedAliasAgents(selectableAgentRows).length;
 
   const lifecycleStages: LifecycleStageCounts = {};
   let totalProducts = 0;
@@ -185,7 +194,6 @@ export const getPortfolioSummary = cache(async (): Promise<PortfolioSummary> => 
   const statusByName = new Map(statusGroups.map(g => [g.lifecycleStatus, g._count.id]));
   const backlogByStatus = new Map(backlogCounts.map(g => [g.status, g._count.id]));
   const epicByStatus = new Map(epicCounts.map(g => [g.status, g._count.id]));
-  const agentByStatus = new Map(agentCounts.map(g => [g.status, g._count.id]));
 
   return {
     totalProducts,
@@ -196,7 +204,7 @@ export const getPortfolioSummary = cache(async (): Promise<PortfolioSummary> => 
     openBacklogItems: backlogByStatus.get("open") ?? 0,
     inProgressBacklogItems: backlogByStatus.get("in-progress") ?? 0,
     openEpics: epicByStatus.get("open") ?? 0,
-    totalAgents: agentCounts.reduce((s, g) => s + g._count.id, 0),
-    activeAgents: agentByStatus.get("active") ?? 0,
+    totalAgents: rosterAgentCount,
+    activeAgents: rosterAgentCount,
   };
 });


### PR DESCRIPTION
## What

From the owner-led UX dogfood: `/portfolio` said **"97 of 114" AI coworkers** while `/workforce` said **76** — and 76 is right. The portfolio summary summed a raw `prisma.agent.groupBy` by status, counting dual-seed alias twins, draft, and retired rows.

## Fix

`/workforce` uses the canonical roster read-model: `SELECTABLE_COWORKER_STATE` (active · production · not-archived) then `dropDualSeedAliasAgents`. The portfolio summary now counts the same roster — query the selectable agents, collapse alias twins, report that figure. The card reads the roster with an "active roster" detail instead of "of 114 total".

The alias rows stay owned by BI-5B69D6F9's governed collapse migration; this only fixes the **count** at the cockpit.

## Verification

Uses the already-tested `dropDualSeedAliasAgents` + `SELECTABLE_COWORKER_STATE` (roster-dedupe + selectable-coworker suites); PortfolioOverview render test green. Typecheck + 53 guards + full local-CI pregate passed.

Design-Grounding-Decision: no-contract-change (routes one existing count through the canonical roster read-model instead of a raw groupBy; no routing, schema, or contract change).
Docs-Impact-Decision: internal count-honesty fix; the cockpit now matches /workforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)