### PR TITLE
fix(local-ci): a gate run that dies must leave recoverable state (BI-C59AC8AF)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,9 @@ COPY scripts/capability-service-catalog.generated.json ./scripts/
 COPY scripts/lib/capability-service-projection.mjs ./scripts/lib/
 COPY scripts/lib/capability-state-hash.mjs ./scripts/lib/
 COPY scripts/lib/transition-signing.mjs ./scripts/lib/
+# The local-CI status set is shared by the gate scripts and the MCP evidence
+# handler, so the build stage needs it too (BI-C59AC8AF).
+COPY scripts/lib/local-integration-status.mjs ./scripts/lib/
 COPY scripts/installer/resolve-host-identity.mjs ./scripts/installer/
 COPY scripts/installer/local-model-policy.json ./scripts/installer/
 COPY apps/web/ ./apps/web/
@@ -156,6 +159,7 @@ COPY scripts/lib/ci-policy-guards.mjs ./scripts/lib/
 COPY scripts/lib/host-command-invocation.mjs ./scripts/lib/
 COPY scripts/lib/git-fetch-shared-safe.mjs ./scripts/lib/
 COPY scripts/lib/entry-module.mjs ./scripts/lib/
+COPY scripts/lib/local-integration-status.mjs ./scripts/lib/
 COPY scripts/module-size-baseline.txt ./scripts/
 COPY scripts/prose-lint-baseline.json ./scripts/
 COPY scripts/style-drift-baseline.json ./scripts/

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1771,6 +1771,9 @@
     "scripts/lib/local-integration-ci.mjs": [
       "docs/testing/pre-pr-gate.md"
     ],
+    "scripts/lib/local-integration-status.mjs": [
+      "docs/testing/pre-pr-gate.md"
+    ],
     "scripts/lib/mcp-client.mjs": [
       "docs/architecture/mcp-tool-authorization-runbook.md"
     ],
@@ -2985,6 +2988,7 @@
       "scripts/lib/converge-hooks-dir.mjs",
       "scripts/lib/hooks-dir.mjs",
       "scripts/lib/local-integration-ci.mjs",
+      "scripts/lib/local-integration-status.mjs",
       "scripts/local-ci-runner.mjs",
       "scripts/pr-health.mjs",
       "scripts/set-hooks-path.mjs",

--- a/apps/web/lib/gates/gate-run-identity.test.ts
+++ b/apps/web/lib/gates/gate-run-identity.test.ts
@@ -5,6 +5,7 @@ import {
   deriveSemanticReviewGateIdentity,
   normalizeGateRunIdentity,
   projectLocalCiTerminalEvidence,
+  resolveLocalCiTerminalEvidence,
 } from "./gate-run-identity";
 
 const SHA_A = "a".repeat(40);
@@ -152,6 +153,45 @@ describe("local-CI terminal evidence projection", () => {
       evidenceRecordId: "EXT-GATE",
       resultClass: "pass",
     });
+  });
+
+  // BI-C59AC8AF. A run that never reported is not a verdict, and the gate key
+  // hashes the integration TREE — so blocking here made that tree permanently
+  // ungateable, with a fresh commit of the same content landing on the same
+  // refusal. Only evidence that EXISTS and does not fit stays blocking.
+  it("lets the gate run again when the prior run left no evidence", async () => {
+    expect(projectLocalCiTerminalEvidence({
+      claimKey: `gate:${gateKey}`,
+      evidence: null,
+      now: new Date("2026-08-25T12:00:00.000Z"),
+    })).toEqual({ status: "rerunnable" });
+
+    await expect(resolveLocalCiTerminalEvidence({
+      claimKey: `gate:${gateKey}`,
+      evidenceRecordId: null,
+      now: new Date("2026-08-25T12:00:00.000Z"),
+      loadEvidence: async () => {
+        throw new Error("must not load evidence when the id is null");
+      },
+    })).resolves.toEqual({ status: "rerunnable" });
+  });
+
+  // Observed live: a gate run died on a signal, the portal rejected the status,
+  // and the client fallback recorded it as `failed` — with no validity stamp,
+  // because the run never reached a verdict. Reading that as expired would have
+  // re-bricked the tree through the other door.
+  it("lets the gate run again when the evidence carries no validity stamp", () => {
+    const infrastructure = {
+      id: "EXT-GATE",
+      operationType: "local_integration_ci",
+      details: { gateKey, status: "failed", evidenceValidity: null },
+    };
+
+    expect(projectLocalCiTerminalEvidence({
+      claimKey: `gate:${gateKey}`,
+      evidence: infrastructure,
+      now: new Date("2026-08-25T12:00:00.000Z"),
+    })).toEqual({ status: "rerunnable" });
   });
 
   it("fails closed for expired or mismatched evidence", () => {

--- a/apps/web/lib/gates/gate-run-identity.ts
+++ b/apps/web/lib/gates/gate-run-identity.ts
@@ -19,6 +19,7 @@ export type GateRunIdentity = GateRunIdentityInput & {
 
 export type LocalCiTerminalEvidenceProjection =
   | { status: "reused"; evidenceRecordId: string; resultClass: "pass" | "fail" }
+  | { status: "rerunnable" }
   | {
     status: "blocked";
     reason: "missing-evidence" | "mismatched-evidence" | "expired-evidence";
@@ -103,7 +104,9 @@ export function projectLocalCiTerminalEvidence(input: {
   } | null;
   now: Date;
 }): LocalCiTerminalEvidenceProjection {
-  if (!input.evidence) return { status: "blocked", reason: "missing-evidence" };
+  // The record id was set but the row is gone (retention, or a failed write that
+  // still stamped the lease). Same reasoning as the null-id case above.
+  if (!input.evidence) return { status: "rerunnable" };
   const details = input.evidence.details && typeof input.evidence.details === "object"
     && !Array.isArray(input.evidence.details)
     ? input.evidence.details as Record<string, unknown>
@@ -120,10 +123,17 @@ export function projectLocalCiTerminalEvidence(input: {
   ) {
     return { status: "blocked", reason: "mismatched-evidence" };
   }
+  // An expiry that was never STAMPED is not an expiry that lapsed. The gate
+  // stamps validity only for a run that reached a product verdict, so evidence
+  // without one is infrastructure evidence — a killed child, a starved control
+  // plane, recorded for observability and never a verdict to reuse. Reading it
+  // as "expired" bricked the tree the same way a dropped write did, just under a
+  // different reason (BI-C59AC8AF). Only a real timestamp in the past expires.
   const expiresAt = typeof validity?.expiresAt === "string"
     ? Date.parse(validity.expiresAt)
     : Number.NaN;
-  if (!Number.isFinite(expiresAt) || expiresAt <= input.now.getTime()) {
+  if (!Number.isFinite(expiresAt)) return { status: "rerunnable" };
+  if (expiresAt <= input.now.getTime()) {
     return { status: "blocked", reason: "expired-evidence" };
   }
   return {
@@ -143,7 +153,15 @@ export async function resolveLocalCiTerminalEvidence(input: {
     details: unknown;
   } | null>;
 }): Promise<LocalCiTerminalEvidenceProjection> {
-  if (!input.evidenceRecordId) return { status: "blocked", reason: "missing-evidence" };
+  // A terminal lease that never recorded evidence describes a run that DIED,
+  // not a verdict — the executor was killed, or the portal rejected its status
+  // write. Blocking on it made that tree permanently ungateable, because the
+  // gate key hashes the integration tree: a fresh commit of the same content
+  // lands on the same key and the same refusal (BI-C59AC8AF). Nothing is being
+  // reused here, so there is nothing to protect — the honest answer is to let
+  // the gate run again. `mismatched-evidence` and `expired-evidence` stay
+  // blocking: there, evidence EXISTS and does not fit, which is a real verdict.
+  if (!input.evidenceRecordId) return { status: "rerunnable" };
   return projectLocalCiTerminalEvidence({
     claimKey: input.claimKey,
     evidence: await input.loadEvidence(input.evidenceRecordId),

--- a/apps/web/lib/mcp/packs/build-evidence-pack.ts
+++ b/apps/web/lib/mcp/packs/build-evidence-pack.ts
@@ -23,6 +23,10 @@ import {
 } from "@/lib/backlog/execution-evidence";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
 import {
+  isLocalIntegrationStatus,
+  LOCAL_INTEGRATION_STATUSES,
+} from "../../../../../scripts/lib/local-integration-status.mjs";
+import {
   isNonprodOwnerProvider,
   NONPROD_OWNER_PROVIDERS,
 } from "@/lib/nonprod/nonprod-owner-provider";
@@ -77,7 +81,7 @@ const definitions: ToolDefinition[] = [
         taskRunId: { type: "string" },
         candidateBranch: { type: "string" },
         mode: { type: "string", enum: ["single-branch", "sibling-set", "post-merge-main"] },
-        status: { type: "string", enum: ["passed", "failed", "conflict", "blocked_sandbox_drift", "blocked_control_plane_starvation"] },
+        status: { type: "string", enum: [...LOCAL_INTEGRATION_STATUSES] },
         summary: { type: "string" },
         gateKey: { type: "string", description: "Server-derived immutable gate key returned at admission." },
         leaseId: { type: "string", description: "Canonical executor lease id returned at admission." },
@@ -235,7 +239,7 @@ async function recordLocalIntegrationResultHandler(
   if (!["single-branch", "sibling-set", "post-merge-main"].includes(mode)) {
     return { success: false, error: "invalid_mode", message: `Unsupported local integration mode: ${mode}` };
   }
-  if (!["passed", "failed", "conflict", "blocked_sandbox_drift", "blocked_control_plane_starvation"].includes(status)) {
+  if (!isLocalIntegrationStatus(status)) {
     return { success: false, error: "invalid_status", message: `Unsupported local integration status: ${status}` };
   }
 

--- a/apps/web/lib/nonprod/environment-lease-terminal-evidence.ts
+++ b/apps/web/lib/nonprod/environment-lease-terminal-evidence.ts
@@ -1,0 +1,81 @@
+import { prisma } from "@dpf/db";
+import { resolveLocalCiTerminalEvidence } from "@/lib/gates/gate-run-identity";
+import type { LocalCiTerminalEvidenceProjection } from "@/lib/gates/gate-run-identity";
+
+type LeaseModel = typeof prisma.nonProductionEnvironmentLease;
+type LeaseRow = NonNullable<Awaited<ReturnType<LeaseModel["findUnique"]>>>;
+type EvidenceTx = Pick<
+  typeof prisma,
+  "nonProductionEnvironmentLease" | "externalEvidenceRecord"
+>;
+
+/**
+ * What a terminal local-CI lease means for the claim standing in front of it.
+ *
+ * `revived` — the prior run left no usable evidence, so the dead row has been
+ * reset and the caller should continue into a normal claim with the returned
+ * lease. `settled` — the prior run reached a real conclusion; the projection is
+ * the caller's answer.
+ */
+/** Everything except `rerunnable`, which this module resolves rather than returns. */
+type SettledProjection = Exclude<
+  LocalCiTerminalEvidenceProjection,
+  { status: "rerunnable" }
+>;
+
+export type TerminalGateLeaseOutcome =
+  | { kind: "revived"; lease: LeaseRow }
+  | { kind: "settled"; projection: SettledProjection };
+
+/**
+ * Decide whether a terminal gate lease still speaks for its tree (BI-C59AC8AF).
+ *
+ * `claimKey` is unique, so a terminal row IS that tree's only route back to the
+ * gate — and the key hashes the integration tree, not the commit, so a fresh
+ * commit of identical content lands on the same row. When the run died without
+ * recording anything there is no verdict to protect, and refusing forever
+ * bricked the tree. Reset it in place instead. Evidence that exists and does not
+ * fit (mismatched, expired) is a real conclusion and still settles the claim.
+ */
+export async function settleTerminalGateLease(input: {
+  tx: EvidenceTx;
+  lease: LeaseRow;
+  claimKey: string;
+  now: Date;
+  ttlMs: number;
+}): Promise<TerminalGateLeaseOutcome> {
+  const projection = await resolveLocalCiTerminalEvidence({
+    claimKey: input.claimKey,
+    evidenceRecordId: input.lease.evidenceRecordId,
+    now: input.now,
+    loadEvidence: async (id) => input.tx.externalEvidenceRecord
+      ? input.tx.externalEvidenceRecord.findUnique({
+        where: { id },
+        select: { id: true, operationType: true, details: true },
+      })
+      : null,
+  });
+
+  if (projection.status !== "rerunnable") {
+    return { kind: "settled", projection };
+  }
+
+  return {
+    kind: "revived",
+    lease: await input.tx.nonProductionEnvironmentLease.update({
+      where: { id: input.lease.id },
+      data: {
+        status: "queued",
+        phase: "waiting",
+        admittedAt: null,
+        releasedAt: null,
+        slotKey: null,
+        activeKey: null,
+        evidenceRecordId: null,
+        requestedTtlMs: input.ttlMs,
+        heartbeatAt: input.now,
+        expiresAt: new Date(input.now.getTime() + input.ttlMs),
+      },
+    }),
+  };
+}

--- a/apps/web/lib/nonprod/environment-lease.ts
+++ b/apps/web/lib/nonprod/environment-lease.ts
@@ -14,7 +14,8 @@ import localCiSlotResources from "./local-ci-slot-resources.json";
 import { recordQueueTransition } from "@/lib/queue/queue-telemetry";
 import { gateRunDispositionsTotal } from "@/lib/operate/metrics";
 import type { NonprodOwnerProvider } from "./nonprod-owner-provider";
-import { isImmutableGateClaimKey, resolveLocalCiTerminalEvidence } from "@/lib/gates/gate-run-identity";
+import { isImmutableGateClaimKey } from "@/lib/gates/gate-run-identity";
+import { settleTerminalGateLease } from "./environment-lease-terminal-evidence";
 import { admittedLeaseTtlMs, DEFAULT_LEASE_TTL_MS, requestedTtlMs } from "./environment-lease-timing";
 export { NONPROD_OWNER_PROVIDERS, type NonprodOwnerProvider } from "./nonprod-owner-provider";
 export {
@@ -328,21 +329,17 @@ export async function claimNonprodEnvironmentLease(input: {
       && isTerminalLeaseStatus(lease.status)
       && isImmutableGateClaimKey(input.claimKey)
     ) {
-      return {
-        ...await resolveLocalCiTerminalEvidence({
-          claimKey: input.claimKey!,
-          evidenceRecordId: lease.evidenceRecordId,
-          now,
-          loadEvidence: async (id) => tx.externalEvidenceRecord
-            ? tx.externalEvidenceRecord.findUnique({
-              where: { id },
-              select: { id: true, operationType: true, details: true },
-            })
-            : null,
-        }),
+      const settlement = await settleTerminalGateLease({
+        tx,
         lease,
-        poolPolicy,
-      };
+        claimKey: input.claimKey!,
+        now,
+        ttlMs,
+      });
+      if (settlement.kind === "settled") {
+        return { ...settlement.projection, lease, poolPolicy };
+      }
+      lease = settlement.lease;
     }
 
     if (lease && isTerminalLeaseStatus(lease.status)) {

--- a/apps/web/lib/nonprod/local-ci-pool-circuit-breaker.ts
+++ b/apps/web/lib/nonprod/local-ci-pool-circuit-breaker.ts
@@ -5,12 +5,7 @@ import {
   type LocalCiPoolConfig,
 } from "./local-ci-pool-policy";
 
-type LocalCiGateStatus =
-  | "passed"
-  | "failed"
-  | "conflict"
-  | "blocked_sandbox_drift"
-  | "blocked_control_plane_starvation";
+import type { LocalIntegrationStatus as LocalCiGateStatus } from "../../../../scripts/lib/local-integration-status.mjs";
 
 export type PlatformConfigCircuitBreakerStore = {
   findUnique: (args: {
@@ -49,7 +44,14 @@ function shouldContract(
   status: LocalCiGateStatus,
   evidence: unknown,
 ): boolean {
-  if (status === "blocked_control_plane_starvation") return true;
+  // Both blocked classes are the same physical signal — the host could not
+  // sustain the run. Starvation is observed by the watchdog; a signal death is
+  // the same pressure arriving as a kill instead (BI-C59AC8AF). Contracting to
+  // one slot is the reversible response to either.
+  if (
+    status === "blocked_control_plane_starvation"
+    || status === "blocked_child_signal_death"
+  ) return true;
   return status !== "passed" && evidenceSlotKey(evidence) === "slot-1";
 }
 

--- a/apps/web/lib/nonprod/local-integration.ts
+++ b/apps/web/lib/nonprod/local-integration.ts
@@ -5,6 +5,7 @@ import {
   type PlatformConfigCircuitBreakerStore,
 } from "./local-ci-pool-circuit-breaker";
 import type { NonprodOwnerProvider } from "./nonprod-owner-provider";
+import type { LocalIntegrationStatus } from "../../../../scripts/lib/local-integration-status.mjs";
 
 export type LocalIntegrationResultInput = {
   actorUserId: string;
@@ -15,15 +16,12 @@ export type LocalIntegrationResultInput = {
   taskRunId?: string;
   candidateBranch: string;
   mode: "single-branch" | "sibling-set" | "post-merge-main";
-  // "blocked_sandbox_drift": the shared sandbox's installed dependency graph
-  // did not match the lockfile (or was mid-install), so the gate refused to
-  // produce product evidence. A sandbox defect, not a product failure (BI-ECDF9520).
-  status:
-    | "passed"
-    | "failed"
-    | "conflict"
-    | "blocked_sandbox_drift"
-    | "blocked_control_plane_starvation";
+  // Every `blocked_*` status is a gate/infrastructure defect, not a product
+  // failure: the sandbox's dependency graph did not match the lockfile
+  // (BI-ECDF9520), the control plane degraded, or the build child was killed by
+  // a signal. The set is shared with the gate scripts so the producer and the
+  // recorder cannot drift apart again (BI-C59AC8AF).
+  status: LocalIntegrationStatus;
   summary: string;
   evidence: Prisma.InputJsonValue;
   gateKey?: string;

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -240,7 +240,7 @@ Run it standalone with `pnpm run pregate:preflight`
 still enforces every guard. Routing probes (`--dry-run`) and evidence replays
 (`--finalize-evidence`) skip the preflight automatically.
 
-**Documentation evidence lane (BI-B2E9FC9D).** After preflight and before any
+**Documentation evidence lane.** After preflight and before any
 `local-integration-ci` lease claim, the Node gate checks whether the committed
 candidate is an exact documentation-only tree. This lane is deliberately
 fail-closed: `HEAD` must equal the requested SHA, the worktree must be clean,
@@ -308,7 +308,22 @@ admitted lease. A later equivalent caller receives `subscribed` and observes
 the canonical execution without renewing, releasing, recording evidence, or
 starting the command. Once the owner links a fresh terminal pass or fail
 receipt, later callers receive `reused` and stop without recomputation.
-Missing, mismatched, inconclusive, or expired evidence remains fail-closed.
+Mismatched, inconclusive, or expired evidence remains fail-closed: evidence
+exists and does not fit, which is a real conclusion.
+
+**A run that DIED is not a verdict (BI-C59AC8AF).** A terminal lease carrying no
+evidence record describes an execution that never reported — the executor was
+killed, or the portal rejected its status write. Since the immutable key hashes
+the integration *tree* rather than the commit, refusing such a claim used to
+brick that tree permanently: a fresh commit of identical content reproduces the
+key and the refusal, and `claimKey` is unique, so the dead row is the tree's only
+route back to the gate. The claim now revives that row and runs again. Nothing is
+reused, so nothing is weakened. Two rules keep it honest: the gate records
+*something* even when the portal rejects its status — an unknown status is
+recorded as `failed` with the real class in the summary — and a parity test
+asserts every status `classifyGateOutcome` can emit is one
+`record_local_integration_result` accepts, from the single closed set in
+`scripts/lib/local-integration-status.mjs`.
 
 The same identity rule coordinates assembled semantic review through the
 existing `TaskRun` carrier: one caller dispatches, concurrent callers subscribe,
@@ -643,7 +658,7 @@ changes the docs-only comparison base to a local accepted-base ref (default:
 `origin/main`); if that configured ref is missing, the hook requires the normal
 SHA-bound gate record instead of silently falling back.
 
-**Convergence failures are reported, not swallowed (BI-5CBDC146).** Until
+**Convergence failures are reported, not swallowed.** Until
 2026-08-27 this chain was never active on Windows. `set-hooks-path.mjs`
 resolved its hooks directory with `new URL('../.githooks/', import.meta.url)
 .pathname`, which returns `/D:/repo/.githooks/` on Windows; `path.join` turned
@@ -658,7 +673,7 @@ than failing silently. If `postinstall` reports `could not converge
 .githooks/pre-push`, the gate is not protecting your pushes — repair it before
 relying on a green push.
 
-**Verify by sweeping, never by spot-checking (BI-3727106F).** `head -4
+**Verify by sweeping, never by spot-checking.** `head -4
 .githooks/pre-push` answers for one tree, and one tree is not the estate: when
 this was measured on 2026-08-26, **68 of 85 worktrees** on a single install
 carried the stock shim and pushed with no gate. Two things made that possible.

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from "node:url";
 import { mcpCall } from "./lib/mcp-client.mjs";
 import { summarizeLocalCiOutput } from "./lib/local-ci-failure-summary.mjs";
 import { classifyGateOutcome } from "./lib/sandbox-freshness.mjs";
+import { fallbackStatusForUnknown } from "./lib/local-integration-status.mjs";
 import {
   authoritySafetyMarginMs,
   superviseLeaseRun,
@@ -1848,9 +1849,22 @@ async function main() {
       message: error instanceof Error ? error.message : String(error),
     };
   }
-  if (evidenceResponse?.success !== true && outcome.status === "blocked_sandbox_drift" && evidenceResponse?.error === "invalid_status") {
-    process.stdout.write("gate-worktree: portal does not know blocked_sandbox_drift yet; recording as failed with sandbox-drift evidence\n");
-    evidenceArgs = { ...evidenceArgs, status: "failed", summary: `[SANDBOX_DRIFT — not product evidence] ${evidenceArgs.summary}` };
+  // BI-C59AC8AF: generalized from the blocked_sandbox_drift-only version. An
+  // installed portal cannot know a status a newer gate emits, and dropping the
+  // write is the worst available outcome: the lease releases terminal with no
+  // evidence, and because the gate key hashes the integration tree, that tree is
+  // then permanently unable to be gated. Record SOMETHING, always — `failed` is
+  // the honest floor and the prefix keeps the real class readable.
+  if (evidenceResponse?.error === "invalid_status" && evidenceResponse?.success !== true) {
+    const fallback = fallbackStatusForUnknown(outcome.status);
+    process.stdout.write(
+      `gate-worktree: portal does not know ${outcome.status} yet; recording as ${fallback.status} with the original class in the summary\n`,
+    );
+    evidenceArgs = {
+      ...evidenceArgs,
+      status: fallback.status,
+      summary: `${fallback.summaryPrefix} ${evidenceArgs.summary}`,
+    };
     evidenceResponse = await mcpCall("record_local_integration_result", evidenceArgs, { mcpUrl: options.mcpUrl, bearerToken });
   }
 

--- a/scripts/lib/local-integration-status.d.mts
+++ b/scripts/lib/local-integration-status.d.mts
@@ -1,0 +1,19 @@
+export declare const LOCAL_INTEGRATION_STATUSES: readonly [
+  "passed",
+  "failed",
+  "conflict",
+  "blocked_sandbox_drift",
+  "blocked_control_plane_starvation",
+  "blocked_child_signal_death",
+];
+
+export type LocalIntegrationStatus = (typeof LOCAL_INTEGRATION_STATUSES)[number];
+
+export declare function isLocalIntegrationStatus(
+  value: unknown,
+): value is LocalIntegrationStatus;
+
+export declare function fallbackStatusForUnknown(status: string): {
+  status: "failed";
+  summaryPrefix: string;
+};

--- a/scripts/lib/local-integration-status.mjs
+++ b/scripts/lib/local-integration-status.mjs
@@ -1,0 +1,47 @@
+// The closed set of terminal statuses a local-CI gate run may report.
+//
+// BI-C59AC8AF. This set had four copies: the producer (classifyGateOutcome in
+// sandbox-freshness.mjs), the MCP tool schema enum, the handler's runtime
+// validation array, and the recorder's TypeScript union. #4703 added
+// `blocked_child_signal_death` to the producer alone, so a build child killed by
+// a signal reported a status the recorder rejected with `invalid_status`. The
+// write was dropped, the lease released terminal with a null evidenceRecordId,
+// and — because the gate key hashes the integration TREE, not the commit — that
+// tree could never be gated again. Re-committing the same content reproduces the
+// same key and the same refusal.
+//
+// Lives in scripts/lib so both planes read one array: the .mjs gate scripts
+// import it directly, and apps/web imports it the same way the platform-runtime
+// modules already import capability-state-hash.mjs and transition-signing.mjs.
+//
+// A `blocked_*` status is INFRASTRUCTURE evidence, never a product verdict.
+// Adding one here is half the change: give it a branch in classifyGateOutcome
+// and the parity test in sandbox-freshness.test.mjs will hold the two together.
+export const LOCAL_INTEGRATION_STATUSES = Object.freeze([
+  "passed",
+  "failed",
+  "conflict",
+  "blocked_sandbox_drift",
+  "blocked_control_plane_starvation",
+  "blocked_child_signal_death",
+]);
+
+/** True when `value` is a status the recorder will accept. */
+export function isLocalIntegrationStatus(value) {
+  return LOCAL_INTEGRATION_STATUSES.includes(value);
+}
+
+/**
+ * The status to record when the portal rejects `status` as unknown.
+ *
+ * An older portal cannot know a status a newer gate emits, and the gate must
+ * still leave evidence — an unrecorded run is what bricks the tree. `failed` is
+ * the honest floor: it is never mistaken for a pass, and the prefixed summary
+ * keeps the real class legible to a human reading the record.
+ */
+export function fallbackStatusForUnknown(status) {
+  return {
+    status: "failed",
+    summaryPrefix: `[${String(status).toUpperCase()} — not product evidence]`,
+  };
+}

--- a/scripts/lib/sandbox-freshness.test.mjs
+++ b/scripts/lib/sandbox-freshness.test.mjs
@@ -4,8 +4,14 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { test } from "node:test";
 import {
+  fallbackStatusForUnknown,
+  isLocalIntegrationStatus,
+} from "./local-integration-status.mjs";
+import {
   CRITICAL_PACKAGES,
   EXIT_CHILD_SIGNAL_DEATH,
+  EXIT_VITEST_RUNNER_TERMINATION,
+  EXIT_CONTROL_PLANE_STARVATION,
   EXIT_GREEN,
   EXIT_SANDBOX_DRIFT,
   EXIT_SANDBOX_NOT_READY,
@@ -397,4 +403,47 @@ test("an ordinary non-zero exit is still a product failure", () => {
 
   assert.equal(outcome.status, "failed");
   assert.equal(outcome.productEvidence, true);
+});
+
+// BI-C59AC8AF. The producer and the recorder are one closed set or they drift:
+// #4703 added blocked_child_signal_death to classifyGateOutcome alone, the
+// recorder rejected it as invalid_status, the write was dropped, and the tree it
+// ran on could never be gated again. This asserts the direction that actually
+// bricks things — every status the gate can PRODUCE must be recordable.
+test("every status classifyGateOutcome can emit is one the recorder accepts", () => {
+  const exitCodes = [
+    0,
+    1,
+    EXIT_SANDBOX_DRIFT,
+    EXIT_SANDBOX_NOT_READY,
+    EXIT_CONTROL_PLANE_STARVATION,
+    EXIT_VITEST_RUNNER_TERMINATION,
+    EXIT_CHILD_SIGNAL_DEATH,
+  ];
+  const verdicts = [null, "green", "drifted", "sandbox_not_ready"];
+
+  const produced = new Set();
+  for (const gateExitCode of exitCodes) {
+    for (const freshnessVerdict of verdicts) {
+      produced.add(classifyGateOutcome({ freshnessVerdict, gateExitCode }).status);
+    }
+  }
+
+  assert.ok(produced.size > 0, "expected classifyGateOutcome to produce statuses");
+  for (const status of produced) {
+    assert.ok(
+      isLocalIntegrationStatus(status),
+      `classifyGateOutcome emits "${status}", which record_local_integration_result rejects. `
+      + "Add it to LOCAL_INTEGRATION_STATUSES in scripts/lib/local-integration-status.mjs.",
+    );
+  }
+});
+
+test("a status the recorder does not know still records rather than dropping the write", () => {
+  const fallback = fallbackStatusForUnknown("blocked_something_new");
+
+  assert.equal(fallback.status, "failed");
+  assert.ok(isLocalIntegrationStatus(fallback.status));
+  assert.match(fallback.summaryPrefix, /BLOCKED_SOMETHING_NEW/);
+  assert.match(fallback.summaryPrefix, /not product evidence/);
 });

--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -249,6 +249,7 @@ test("gate-worktree.mjs refuses to run when neither an explicit command, the stu
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-base-freshness.mjs"), join(temp, "scripts", "lib", "local-ci-base-freshness.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "git-fetch-shared-safe.mjs"), join(temp, "scripts", "lib", "git-fetch-shared-safe.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "entry-module.mjs"), join(temp, "scripts", "lib", "entry-module.mjs"));
+  cpSync(join(repoRoot, "scripts", "lib", "local-integration-status.mjs"), join(temp, "scripts", "lib", "local-integration-status.mjs"));
   cpSync(
     join(repoRoot, "apps", "web", "lib", "nonprod", "local-ci-slot-resources.json"),
     join(temp, "apps", "web", "lib", "nonprod", "local-ci-slot-resources.json"),


### PR DESCRIPTION
## What was broken

`pnpm run pregate` on a branch could reach a state where it would never run again — and re-running, which is what every error message advised, could not help.

The local-integration status set had **five** copies: the producer (`classifyGateOutcome`), the MCP tool schema enum, the handler's runtime array, the recorder's TypeScript union, and the pool circuit breaker. #4703 added `blocked_child_signal_death` to the producer alone.

So a build child killed by a signal reported a status the recorder answered with `invalid_status`. The write was dropped, the lease released terminal with a null `evidenceRecordId`, and every later claim was refused `missing-evidence`. Because `deriveGateKey` hashes the integration **tree** rather than the commit, re-committing identical content lands on the same key and the same refusal. Three branches on this host were already in that state.

## Three changes, one concern — a dead run must not brick a tree

**One closed set.** `scripts/lib/local-integration-status.mjs`, read by both planes — the `.mjs` gate scripts import it directly, `apps/web` the way `platform-runtime` already imports `capability-state-hash.mjs`. A parity test asserts every status `classifyGateOutcome` can emit is one `record_local_integration_result` accepts. Deleting the new status from the set reproduces the original failure with the fix named in the message, so the guard holds the direction that actually bricks things.

**A terminal lease with no evidence is re-runnable, not blocked.** Nothing is being reused, so there is nothing to protect, and `claimKey` is unique — that dead row is the tree's only route back to the gate. `mismatched-evidence` and `expired-evidence` still block: there evidence exists and does not fit, which is a real conclusion.

**Never drop the write.** The gate's `invalid_status` compensation was hardcoded to `blocked_sandbox_drift` — this class of bug was hit before and patched one instance. Any status an older portal rejects is now recorded as `failed` with the real class in the summary.

`blocked_child_signal_death` also contracts the slot pool the way starvation does. Both are the same host pressure; one arrives as a stall, the other as a kill.

## Found by the failure, not by reading

The first gate run of this branch died on a signal — the exact defect, live. The fallback worked: the lease came back with evidence instead of a dropped write. But the fallback rewrites the status without re-stamping `evidenceValidity`, which the gate only sets for a run that reached a verdict. `projectLocalCiTerminalEvidence` read that unstamped expiry as `expired-evidence` — a permanent block through the other door.

Fixed with the rule the situation implies: **an expiry that was never stamped is not an expiry that lapsed.** Infrastructure evidence is recorded for observability and is never reusable as a verdict; only a real timestamp in the past expires. Tested with the exact live shape.

## Also in this diff

- `docs/testing/pre-pr-gate.md` documents the recovery rule, and its "missing evidence is fail-closed" sentence is corrected.
- Three dead backlog citations removed from that page — `BI-3727106F`, `BI-5CBDC146`, `BI-B2E9FC9D`, none of which exist in the live backlog. The doc-anchor guard fires on any changed doc and surfaced them. Prose kept verbatim; only the unbacked ids dropped, since filing invented items to satisfy a guard would be fabrication.
- The terminal-evidence concern moves to its own module rather than pushing `environment-lease.ts` through the 800-LOC ceiling.
- `Dockerfile` COPYs the new shared module into the build and init stages. The build-context guard caught this: without it, CI passes and the **image** fails `Module not found` at self-upgrade.

## Verification

- `vitest run lib/nonprod lib/gates lib/mcp` — 1405 passed.
- `node --test` across the gate scripts — 69 passed.
- Parity guard confirmed red when the status is removed from the set.
- `pnpm pregate:preflight` — 53 guards clean. `tsc --noEmit` — clean.
- `pnpm run pregate` — **PASS**, evidence `cmtdgp4bi5lf701mdhi3lwzhh`, gated sha `be1f5fb78aa0`.

Closes BI-C59AC8AF.