### PR TITLE
fix(release): let the STT digest watch open its PR instead of dying on success (BI-E6EF0B2C)

### DIFF
--- a/.github/workflows/stt-digest-watch.yml
+++ b/.github/workflows/stt-digest-watch.yml
@@ -62,7 +62,21 @@ jobs:
       - name: Apply re-pin and open PR
         if: steps.check.outputs.drift == 'true' && steps.existing.outputs.pr == ''
         run: |
+          # --apply exits 3 to mean "a change was made" — a SUCCESS signal, the
+          # same convention --check uses above. Calling it bare under `bash -e`
+          # made that success kill the step before `gh pr create` ran, so the
+          # watch detected the drift, rewrote both files, and then died without
+          # opening the PR. Two runs on 2026-08-27 failed exactly here while
+          # :latest stayed frozen and installs reported "up to date" (BI-E6EF0B2C).
+          # Anything other than 0 or 3 is a real failure and must still stop.
+          set +e
           node scripts/release/re-resolve-stt-digest.mjs --apply
+          apply_code=$?
+          set -e
+          if [ "$apply_code" != "0" ] && [ "$apply_code" != "3" ]; then
+            echo "re-pin failed with exit $apply_code" >&2
+            exit "$apply_code"
+          fi
           node --test scripts/release/re-resolve-stt-digest.test.mjs tests/release/installer-release-contract.test.mjs
           node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned
 


### PR DESCRIPTION
Part of BI-E6EF0B2C.

## The automation already existed, and killed itself on success

`scripts/release/re-resolve-stt-digest.mjs` plus a daily cron (`stt-digest-watch.yml`, BI-A9EAEE2C) already re-pin the STT digest and open a signed PR. That machinery ran clean every day through 2026-08-26.

`--apply` exits **3** to mean *"a change was made"* — a success signal, and the same convention the `--check` step directly above it already handles with `set +e` / capture / `set -e`. The apply step called it **bare under `bash -e`**, so exit 3 killed the step before `gh pr create` ever ran.

Both runs on 2026-08-27 failed at exactly that line, after doing the work correctly:

```
[stt-digest] DRIFT: compose pins sha256:166a8c04... but
  hwdsl2/whisper-server:latest now resolves to sha256:8f76c4f9...
[stt-digest] re-pinned ... in docker-compose.yml and
  tests/release/installer-release-contract.test.mjs
##[error]Process completed with exit code 3
```

Every earlier run passed because there was no drift to apply. **The bug was invisible until the first day it mattered.**

## What it cost

The failure sits upstream of the `:latest` promotion, so `:latest` never advanced past `v2026.08.27` even though `v2026.08.28` built and published fine:

```
:latest      = sha256:c3b6ad06   ← previous release
v2026.08.28  = sha256:3c892456   ← published, unreachable
```

Installs resolve updates through `:latest`. A live install therefore reported *"Your platform is up to date. Nothing to install."* while running an image without the merged work — a red workflow on one side, a green "you're current" check on the other, and nothing connecting them.

Found because a merged fix failed to arrive on a live install.

## The change

Wrap the `--apply` call the way `--check` is already wrapped: treat exit 3 as success, and still fail the step on anything else.

```yaml
set +e
node scripts/release/re-resolve-stt-digest.mjs --apply
apply_code=$?
set -e
if [ "$apply_code" != "0" ] && [ "$apply_code" != "3" ]; then
  echo "re-pin failed with exit $apply_code" >&2
  exit "$apply_code"
fi
```

One file, 14 lines.

## Scope — deliberately narrowed

This PR is the **workflow fix only**. PR #4775, opened independently by another session, carries the digest re-pin itself (`docker-compose.yml` + the contract test).

An earlier revision of this branch also carried that re-pin; it has been dropped so the two changes are orthogonal and can land in either order. **#4775 clears today's breakage; this clears the next one.**

That earlier revision also restructured `RETIRED_STT_DIGEST` into a list, which broke the script's own round-trip test — `applyRepin` asserts it can rewrite both constants against the real repo files. The script's rotation convention (`CURRENT` becomes `RETIRED`, one digest each) was already correct. Reverted in favour of it.

## Not fixed here

BI-E6EF0B2C carries the durable work: **mirror the image into GHCR** so an outside publisher's retention policy cannot gate DPF releases, and **decouple `:latest` promotion from an optional service's manifest check** so a missing sidecar can never again silently freeze every install's update pointer.

## Verification

- **local-CI gate: PASS** at `5b1879c13963` (evidence `cmtdgxiin01kt01p2n88q82q9`)
- 21 tests pass across `re-resolve-stt-digest.test.mjs` and `installer-release-contract.test.mjs` against the re-pinned tree this fix produces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
