### PR TITLE
fix(code-graph): recover an orphaned default-branch worktree, and stop putting it in someone else's tree (BI-86EF5900)

### DIFF
--- a/apps/web/lib/build/code-graph/default-branch-source.test.ts
+++ b/apps/web/lib/build/code-graph/default-branch-source.test.ts
@@ -9,9 +9,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { execMock } = vi.hoisted(() => ({ execMock: vi.fn() }));
 
+const { rmMock } = vi.hoisted(() => ({ rmMock: vi.fn(async () => undefined) }));
+
 vi.mock("@/lib/shared/lazy-node", () => ({
   lazyExec: () => execMock,
-  lazyPath: () => ({ resolve: (...p: string[]) => p.join("/") }),
+  lazyPath: () => ({
+    resolve: (...p: string[]) => p.join("/"),
+    basename: (p: string) => p.split("/").filter(Boolean).pop() ?? "",
+  }),
+  lazyFsPromises: () => ({ rm: rmMock }),
+  lazyOs: () => ({ tmpdir: () => "/tmp" }),
   getCwd: () => "/cwd",
 }));
 
@@ -24,7 +31,11 @@ import {
 const ok = (stdout: string) => ({ stdout, stderr: "" });
 const SHA = "0ad91e688c2f5f3a4512d11ce0a845c4aa63d9ca";
 
-beforeEach(() => execMock.mockReset());
+beforeEach(() => {
+  execMock.mockReset();
+  rmMock.mockClear();
+  delete process.env.DPF_CODE_GRAPH_WORKTREE_DIR;
+});
 
 describe("resolveDefaultBranchRef", () => {
   it("prefers origin/main and reports the branch label without the remote", async () => {
@@ -69,7 +80,9 @@ describe("resolveIndexSource", () => {
     const src = await resolveIndexSource("/sandbox-workspace");
 
     expect(src.usedDefaultBranch).toBe(true);
-    expect(src.root).toBe(`/sandbox-workspace/${CODE_GRAPH_WORKTREE_DIRNAME}`);
+    expect(src.root).toBe(`/tmp/${CODE_GRAPH_WORKTREE_DIRNAME}`);
+    // Never inside the host checkout — /sandbox-workspace is a Build Studio tree.
+    expect(src.root.startsWith("/sandbox-workspace")).toBe(false);
     expect(src.branch).toBe("main");
     expect(src.sha).toBe(SHA);
     expect(src.warning).toBeNull();
@@ -78,13 +91,16 @@ describe("resolveIndexSource", () => {
   it("creates the worktree when none exists yet", async () => {
     execMock
       .mockResolvedValueOnce(ok(`${SHA}\n`))                        // rev-parse origin/main
-      .mockRejectedValueOnce(new Error("not a git repository"))     // no worktree yet
+      .mockRejectedValueOnce(new Error("not a git repository"))     // no usable worktree
+      .mockResolvedValueOnce(ok("\n"))                              // worktree prune
       .mockResolvedValueOnce(ok("Preparing worktree\n"));           // worktree add
 
     const src = await resolveIndexSource("/sandbox-workspace");
 
     expect(src.usedDefaultBranch).toBe(true);
-    expect(String(execMock.mock.calls[2]?.[0])).toContain("worktree add --detach --force");
+    const cmds = execMock.mock.calls.map((c) => String(c[0]));
+    expect(cmds.some((c) => c.includes("worktree prune"))).toBe(true);
+    expect(cmds.some((c) => c.includes("worktree add --detach --force"))).toBe(true);
   });
 
   it("fast-forwards a worktree parked on an older sha", async () => {
@@ -104,6 +120,7 @@ describe("resolveIndexSource", () => {
     execMock
       .mockResolvedValueOnce(ok(`${SHA}\n`))                    // origin/main
       .mockRejectedValueOnce(new Error("not a git repository")) // no worktree
+      .mockResolvedValueOnce(ok("\n"))                          // worktree prune
       .mockRejectedValueOnce(new Error("fatal: cannot add"))    // add fails
       .mockRejectedValueOnce(new Error("nope"));                // worktree list
 
@@ -119,5 +136,34 @@ describe("resolveIndexSource", () => {
     const src = await resolveIndexSource("/repo");
     expect(src.usedDefaultBranch).toBe(false);
     expect(src.warning).toContain("No default branch");
+  });
+});
+
+// Live failure this fix exists for: the first run checked out 101 entries, a
+// later `git worktree prune` dropped the registration, and every subsequent run
+// died on "fatal: '<path>' already exists" — because --force overrides a stale
+// REGISTRATION, not a leftover DIRECTORY.
+describe("orphaned worktree recovery", () => {
+  it("prunes and removes a leftover directory before recreating", async () => {
+    execMock
+      .mockResolvedValueOnce(ok(`${SHA}\n`))                     // origin/main
+      .mockRejectedValueOnce(new Error("not a git repository"))  // dir exists but unusable
+      .mockResolvedValueOnce(ok("\n"))                           // worktree prune
+      .mockResolvedValueOnce(ok("Preparing worktree\n"));        // worktree add succeeds
+
+    const src = await resolveIndexSource("/sandbox-workspace");
+
+    expect(rmMock).toHaveBeenCalledWith(`/tmp/${CODE_GRAPH_WORKTREE_DIRNAME}`, {
+      recursive: true,
+      force: true,
+    });
+    expect(src.usedDefaultBranch).toBe(true);
+  });
+
+  it("honours DPF_CODE_GRAPH_WORKTREE_DIR", async () => {
+    process.env.DPF_CODE_GRAPH_WORKTREE_DIR = "/dpf-state/graph-wt";
+    execMock.mockResolvedValueOnce(ok(`${SHA}\n`)).mockResolvedValueOnce(ok(`${SHA}\n`));
+    const src = await resolveIndexSource("/sandbox-workspace");
+    expect(src.root).toBe("/dpf-state/graph-wt");
   });
 });

--- a/apps/web/lib/build/code-graph/default-branch-source.ts
+++ b/apps/web/lib/build/code-graph/default-branch-source.ts
@@ -18,7 +18,7 @@
 // existing read path (listTrackedFiles, readFile, the extractors) is reused
 // unchanged against that path. Kernel decision DI-B0BE15B52C46.
 
-import { lazyExec, lazyPath } from "@/lib/shared/lazy-node";
+import { lazyExec, lazyPath, lazyFsPromises, lazyOs } from "@/lib/shared/lazy-node";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 const exec = lazyExec();
@@ -26,8 +26,28 @@ const exec = lazyExec();
 /** Preference order for "the tree everyone merges into". */
 const DEFAULT_BRANCH_CANDIDATES = ["origin/main", "origin/master", "main", "master"] as const;
 
-/** Directory name of the indexer-owned worktree, kept beside the host checkout. */
-export const CODE_GRAPH_WORKTREE_DIRNAME = ".dpf-code-graph-default-branch";
+/** Directory name of the indexer-owned worktree. */
+export const CODE_GRAPH_WORKTREE_DIRNAME = "dpf-code-graph-default-branch";
+
+/**
+ * Where the indexer-owned worktree lives.
+ *
+ * NOT inside the host checkout. The first version put it at
+ * `<gitRoot>/.dpf-code-graph-default-branch`, which on the live install meant
+ * dropping a 101-entry root-owned checkout INSIDE /sandbox-workspace — the tree
+ * Build Studio actually builds in. A private scratch checkout has no business
+ * living in someone else's working tree.
+ *
+ * Outside the repo it is also out of reach of the repo-scanning tooling that
+ * prunes stale worktree registrations, which is what orphaned the first one.
+ * Override with DPF_CODE_GRAPH_WORKTREE_DIR when tmp is unsuitable.
+ */
+export function codeGraphWorktreePath(): string {
+  const { resolve } = lazyPath();
+  const override = process.env.DPF_CODE_GRAPH_WORKTREE_DIR;
+  if (override) return resolve(override);
+  return resolve(lazyOs().tmpdir(), CODE_GRAPH_WORKTREE_DIRNAME);
+}
 
 function gitIn(root: string, args: string): string {
   return `git -c safe.directory=${JSON.stringify(root)} ${args}`;
@@ -67,6 +87,23 @@ export async function resolveDefaultBranchRef(gitRoot: string): Promise<DefaultB
   return null;
 }
 
+/**
+ * Delete a leftover indexer worktree directory so `worktree add` can recreate
+ * it. Deliberately narrow: it refuses any path that is not our own
+ * deterministically named scratch directory, because this is the one operation
+ * here that destroys data and it must never be pointed at a real checkout.
+ */
+async function removeLeftoverWorktreeDir(path: string): Promise<void> {
+  const { basename } = lazyPath();
+  if (basename(path) !== CODE_GRAPH_WORKTREE_DIRNAME) return;
+  try {
+    await lazyFsPromises().rm(path, { recursive: true, force: true });
+  } catch {
+    // Leave it; `worktree add` will report the real reason and the caller
+    // degrades to the host tree with that reason logged.
+  }
+}
+
 export type DefaultBranchWorktree = {
   path: string;
   branch: string;
@@ -86,14 +123,20 @@ export async function ensureDefaultBranchWorktree(
   gitRoot: string,
   target: DefaultBranchRef,
 ): Promise<{ worktree: DefaultBranchWorktree | null; warning: string | null }> {
-  const { resolve } = lazyPath();
-  const path = resolve(gitRoot, CODE_GRAPH_WORKTREE_DIRNAME);
+  const path = codeGraphWorktreePath();
 
   const head = await tryGit(path, "rev-parse HEAD", 10_000);
   if (head === null) {
-    // No usable worktree yet. --force tolerates a stale registration left by a
-    // killed run; a detached checkout keeps it off the branch namespace so it
-    // can never be confused for someone's working branch.
+    // No USABLE worktree — but the directory may still be sitting there.
+    //
+    // Observed live: the first run checked out 101 entries successfully, then
+    // something ran `git worktree prune` and dropped the registration, leaving
+    // an orphaned directory. Every later run failed with
+    // "fatal: '<path>' already exists", because `--force` overrides a stale
+    // REGISTRATION, not a leftover DIRECTORY. Recover from both.
+    await tryGit(gitRoot, "worktree prune", 30_000);
+    await removeLeftoverWorktreeDir(path);
+
     const added = await tryGit(
       gitRoot,
       `worktree add --detach --force ${JSON.stringify(path)} ${target.sha}`,


### PR DESCRIPTION
#4719 deployed and then degraded on **every** run. The portal said so itself:

```
[code-graph] Could not prepare the default-branch worktree at
/sandbox-workspace/.dpf-code-graph-default-branch; indexing the host
working tree instead. Existing worktrees: /sandbox-workspace 8635d00cc
[client/5727856b-3296-4e17-97f0-c59401ace4f2]
```

Reproduced in the container:

```
fatal: '/sandbox-workspace/.dpf-code-graph-default-branch' already exists
```

## Two defects, both introduced by #4719

**1. Recovery was incomplete.** The first run checked out 101 entries successfully. Something then ran `git worktree prune` — the live worktree list shows other entries already marked `prunable` — which dropped the registration and left the directory orphaned. After that, `rev-parse HEAD` inside it fails, so the code takes the create path, and `worktree add` refuses because the path exists.

`--force` overrides a stale **registration**, not a leftover **directory**. Only the first case was handled. The create path now prunes, removes the leftover, then adds.

The removal is deliberately narrow: it refuses any path whose basename is not our own deterministic scratch name. It is the only operation here that destroys data, and it must never be aimable at a real checkout.

**2. It was in the wrong place entirely.** Putting the worktree at `<gitRoot>/.dpf-code-graph-default-branch` meant dropping a 101-entry root-owned checkout **inside `/sandbox-workspace`** — the tree Build Studio actually builds in. A private scratch checkout has no business living in someone else's working tree, and being inside the repo is also what put it in reach of the pruning that orphaned it.

It now lives under `tmpdir()`, overridable via `DPF_CODE_GRAPH_WORKTREE_DIR`.

## What worked

The degrade path did exactly its job. Because #4719 logged **why** it fell back rather than only recording the branch, this took one log line and one reproduction to diagnose — instead of another round of inferring cause from an empty result.

That was the entire argument for carrying the reason through the fallback, and it paid for itself on the first failure.

## Verification

- **81 tests pass across 14 code-graph files.** Two new cases cover orphaned-directory recovery (prune → scoped `rm` → recreate) and the path override; the existing case now asserts the worktree is **not** inside the host checkout.
- `pnpm --filter web build`: clean.
- `pregate:preflight`: 53 guards clean.
- exact-tree local CI gate: **PASS** (evidence `cmtdgzcrn5pau01md9f3zky5r`).

## Operator note

The orphaned directory from the first attempt is still at `/sandbox-workspace/.dpf-code-graph-default-branch` on the live install. This change stops using that path, so nothing will clean it up on its own, and it sits inside a Build Studio working tree.

Removing it is a destructive action on a production container and is left to the operator rather than done here:

```
rm -rf /sandbox-workspace/.dpf-code-graph-default-branch
```

Repairs the mechanism delivered in #4719 for BI-86EF5900 acceptance 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
