### PR TITLE
fix(portfolio): count products with no taxonomy node instead of dropping them (BI-A5576D1A)

### DIFF
--- a/apps/web/lib/evaluate/portfolio.test.ts
+++ b/apps/web/lib/evaluate/portfolio.test.ts
@@ -53,6 +53,29 @@ describe("buildPortfolioTree()", () => {
     expect(foundational.directCount).toBe(2);
   });
 
+  // BI-A5576D1A — products with a null taxonomyNodeId were dropped from the tree, so the
+  // estate total undercounted (225 of 375). They now surface under an Uncategorized root.
+  it("surfaces null-taxonomy products under an Uncategorized root and counts them", () => {
+    const countsWithUncategorized = [...COUNTS, { taxonomyNodeId: null, _count: { id: 150 } }];
+    const activeWithUncategorized = [...ACTIVE_COUNTS, { taxonomyNodeId: null, _count: { id: 120 } }];
+
+    const baseTotal = buildPortfolioTree(NODES, COUNTS, ACTIVE_COUNTS).reduce((s, r) => s + r.totalCount, 0);
+    const roots = buildPortfolioTree(NODES, countsWithUncategorized, activeWithUncategorized);
+
+    const uncategorized = roots.find((r) => r.nodeId === "__uncategorized__");
+    expect(uncategorized).toBeDefined();
+    expect(uncategorized!.totalCount).toBe(150);
+    expect(uncategorized!.activeCount).toBe(120);
+
+    const total = roots.reduce((s, r) => s + r.totalCount, 0);
+    expect(total).toBe(baseTotal + 150);
+  });
+
+  it("adds no Uncategorized root when every product is placed in the taxonomy", () => {
+    const roots = buildPortfolioTree(NODES, COUNTS, ACTIVE_COUNTS);
+    expect(roots.find((r) => r.nodeId === "__uncategorized__")).toBeUndefined();
+  });
+
   it("sets totalCount as sum of subtree directCounts", () => {
     const roots = buildPortfolioTree(NODES, COUNTS);
     const foundational = roots.find((r) => r.nodeId === "foundational")!;

--- a/apps/web/lib/evaluate/portfolio.ts
+++ b/apps/web/lib/evaluate/portfolio.ts
@@ -138,6 +138,30 @@ export function buildPortfolioTree(
   }
   for (const root of roots) sumSubtree(root);
 
+  // BI-A5576D1A: products with a null taxonomyNodeId are real portfolio products that
+  // simply have not been placed in the taxonomy yet. The counts above skip them (the
+  // `if (c.taxonomyNodeId)` guards), so the tree total silently undercounted the estate
+  // (225 of 375). Surface them under a synthetic "Uncategorized" root so they are both
+  // counted and visible, instead of vanishing.
+  const uncategorizedTotal = totalCounts.find((c) => c.taxonomyNodeId === null)?._count.id ?? 0;
+  const uncategorizedActive = activeCounts.find((c) => c.taxonomyNodeId === null)?._count.id ?? 0;
+  if (uncategorizedTotal > 0) {
+    roots.push({
+      id: "__uncategorized__",
+      nodeId: "__uncategorized__",
+      name: "Uncategorized",
+      parentId: null,
+      portfolioId: null,
+      directCount: uncategorizedTotal,
+      totalCount: uncategorizedTotal,
+      activeCount: uncategorizedActive,
+      description: "Products not yet placed in the taxonomy.",
+      governance: null,
+      enrichment: null,
+      children: [],
+    });
+  }
+
   const { pruneEmpty = false, flattenThreshold = 20 } = options;
 
   // Prune empty branches: remove children (recursively) that have totalCount === 0.


### PR DESCRIPTION
## What

From the owner-led UX dogfood: the portfolio **hid 150 of 375 products**. `buildPortfolioTree` counts products by `taxonomyNodeId`, and both count-map builds guard on `if (c.taxonomyNodeId)` — so every `DigitalProduct` with a null `taxonomyNodeId` (not yet placed in the taxonomy) vanished from the tree, and the estate total silently read 225.

## Fix

When the count set carries a null-taxonomy group, add a synthetic **"Uncategorized"** root holding those products — so they are both counted in the estate total and visible, rather than disappearing. No synthetic root when every product is placed.

## Verification

- Regression tests: null-taxonomy products appear under Uncategorized with the right total/active counts and lift the estate total by exactly their number; a fully-placed estate gets no Uncategorized root. 29 portfolio tests pass.
- Typecheck + 53 guards + full local-CI pregate green.

Design-Grounding-Decision: no-contract-change (adds a synthetic root to an existing tree builder so null-taxonomy products are counted; no routing, schema, or contract change).
Docs-Impact-Decision: internal count-honesty fix; the portfolio now counts the full estate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)