### PR TITLE
fix(performance): tell the truth when an archetype has no metrics engine (BI-F359E1E9)

### DIFF
--- a/apps/web/app/(shell)/performance/page.test.tsx
+++ b/apps/web/app/(shell)/performance/page.test.tsx
@@ -26,6 +26,7 @@ describe("PerformancePage", () => {
       asOf: null,
       metricValues: [],
       source: "business-performance-read-model",
+      applicable: true,
     });
   });
 
@@ -43,6 +44,26 @@ describe("PerformancePage", () => {
     expect(html).toContain("data-dpf-primary-action");
     expect(html).not.toContain(">0<");
     expect(loadBusinessPerformance).toHaveBeenCalledWith({ userId: "user-owner" });
+  });
+
+  it("says the surface is unavailable (not pending) when the archetype has no metrics engine", async () => {
+    // BI-F359E1E9: the not-applicable state must not imply a snapshot is coming.
+    vi.mocked(loadBusinessPerformance).mockResolvedValue({
+      status: "not-configured",
+      reason:
+        "Performance snapshots are not available for this business type yet — the metrics engine currently covers hospitality operations.",
+      asOf: null,
+      metricValues: [],
+      source: "business-performance-read-model",
+      applicable: false,
+    });
+
+    const html = renderToStaticMarkup(await PerformancePage());
+
+    expect(html).toContain("Performance isn&#x27;t available for this business type");
+    expect(html).toContain("not available for this business type yet");
+    expect(html).not.toContain("Performance history is not ready yet");
+    expect(html).not.toContain("We will not show made-up numbers.");
   });
 
   it("does not add a second primary or local navigation component", async () => {

--- a/apps/web/app/(shell)/performance/page.tsx
+++ b/apps/web/app/(shell)/performance/page.tsx
@@ -48,8 +48,16 @@ export default async function PerformancePage({
         <BusinessPerformanceDashboard performance={performance} watches={watches} />
       ) : (
         <EmptyState
-          title="Performance history is not ready yet"
-          description={`${performance.reason} We will not show made-up numbers.`}
+          title={
+            performance.applicable
+              ? "Performance history is not ready yet"
+              : "Performance isn't available for this business type"
+          }
+          description={
+            performance.applicable
+              ? `${performance.reason} We will not show made-up numbers.`
+              : performance.reason
+          }
           action={
             <Link
               href="/workspace"

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -568,7 +568,7 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     inngestId: "business/metrics-aggregator",
     name: "Business metrics aggregator",
     purpose:
-      "Builds tenant-scoped owner/manager performance snapshots from canonical operational evidence. The Performance view stays fast and preserves its last valid snapshot when a refresh fails.",
+      "Builds tenant-scoped owner/manager performance snapshots from canonical operational evidence for archetypes the metrics engine covers (hospitality today). On an install with no covered storefront it refreshes nothing by design. The Performance view stays fast and preserves its last valid snapshot when a refresh fails.",
     cron: "17 * * * *",
     cadence: "Hourly at :17",
     category: "editable",

--- a/apps/web/lib/performance/business-analysis-watch.server.test.ts
+++ b/apps/web/lib/performance/business-analysis-watch.server.test.ts
@@ -73,7 +73,7 @@ describe("evaluateBusinessAnalysisWatchTask", () => {
       organizationId: "org-old",
       taskConfig: taskConfig(),
     }, {
-      loadPerformance: async () => ({ status: "not-configured", reason: "ambiguous", asOf: null, metricValues: [], source: "business-performance-read-model" }),
+      loadPerformance: async () => ({ status: "not-configured", reason: "ambiguous", asOf: null, metricValues: [], source: "business-performance-read-model", applicable: true }),
     })).rejects.toThrow(/organization/i);
   });
 });

--- a/apps/web/lib/performance/business-metric-rollup.server.test.ts
+++ b/apps/web/lib/performance/business-metric-rollup.server.test.ts
@@ -53,7 +53,7 @@ describe("defaultBusinessMetricRollupDeps", () => {
     await deps.loadRestaurantSource(context!, window, window.end);
 
     expect(mocks.storefrontFindMany).toHaveBeenCalledWith(expect.objectContaining({
-      where: { archetype: { archetypeId: "restaurant" } },
+      where: { archetype: { archetypeId: { in: ["restaurant"] } } },
     }));
     for (const sourceMock of [
       mocks.resourceFindMany,

--- a/apps/web/lib/performance/business-metric-rollup.server.ts
+++ b/apps/web/lib/performance/business-metric-rollup.server.ts
@@ -4,6 +4,7 @@ import type {
   BusinessMetricRollupDeps,
   RestaurantMetricContext,
 } from "./business-metric-rollup";
+import { PERFORMANCE_METRIC_ARCHETYPES } from "./performance-metric-support";
 
 /** Prisma adapter kept separate from the deterministic projection math. */
 export function defaultBusinessMetricRollupDeps(): BusinessMetricRollupDeps {
@@ -11,7 +12,12 @@ export function defaultBusinessMetricRollupDeps(): BusinessMetricRollupDeps {
     async listRestaurantContexts() {
       const [storefronts, profile] = await Promise.all([
         prisma.storefrontConfig.findMany({
-          where: { archetype: { archetypeId: "restaurant" } },
+          // Only archetypes the engine has a source loader for — kept in one
+          // place so the surface's "not available for this business type" copy
+          // and this scan can never disagree. BI-F359E1E9.
+          where: {
+            archetype: { archetypeId: { in: [...PERFORMANCE_METRIC_ARCHETYPES] } },
+          },
           select: { id: true, organizationId: true, timezone: true },
         }),
         prisma.businessProfile.findFirst({

--- a/apps/web/lib/performance/business-performance-provider.test.ts
+++ b/apps/web/lib/performance/business-performance-provider.test.ts
@@ -124,6 +124,7 @@ describe("loadBusinessPerformance", () => {
             asOf: null,
             metricValues: [],
             source: "business-performance-read-model",
+            applicable: true,
           };
         },
       }),
@@ -164,6 +165,59 @@ describe("loadBusinessPerformance", () => {
     expect(db.businessMetricRollup.findMany).toHaveBeenCalledWith(expect.objectContaining({
       where: { organizationId: "org-current" },
     }));
+  });
+
+  it("tells the truth (and reads no rollups) when the archetype has no metrics engine", async () => {
+    // BI-F359E1E9: a non-hospitality install would never produce a snapshot, so
+    // the surface must say "not available for this business type", not imply one
+    // is pending — and it must not run the rollup query at all.
+    const db = {
+      platformSetupProgress: {
+        findUnique: vi.fn(async () => ({ organizationId: "org-platform" })),
+      },
+      storefrontConfig: {
+        findUnique: vi.fn(async () => ({
+          organizationId: "org-platform",
+          archetype: { archetypeId: "software-platform" },
+        })),
+        findMany: vi.fn(),
+      },
+      businessMetricRollup: {
+        findMany: vi.fn(),
+      },
+    };
+
+    const result = await createBusinessPerformanceProvider(db as never).load({ userId: "user-owner" });
+
+    expect(result).toMatchObject({
+      status: "not-configured",
+      applicable: false,
+      reason: expect.stringContaining("not available for this business type"),
+    });
+    expect(db.businessMetricRollup.findMany).not.toHaveBeenCalled();
+  });
+
+  it("keeps the pending (applicable) state for a supported archetype with no snapshot yet", async () => {
+    const db = {
+      platformSetupProgress: {
+        findUnique: vi.fn(async () => ({ organizationId: "org-current" })),
+      },
+      storefrontConfig: {
+        findUnique: vi.fn(async () => ({
+          organizationId: "org-current",
+          archetype: { archetypeId: "restaurant" },
+        })),
+        findMany: vi.fn(),
+      },
+      businessMetricRollup: {
+        findMany: vi.fn(async () => []),
+      },
+    };
+
+    const result = await createBusinessPerformanceProvider(db as never).load({ userId: "user-owner" });
+
+    expect(result).toMatchObject({ status: "not-configured", applicable: true });
+    expect(db.businessMetricRollup.findMany).toHaveBeenCalled();
   });
 
   it("refuses an unmapped user in a multi-organization install without reading any rollups", async () => {

--- a/apps/web/lib/performance/business-performance-provider.ts
+++ b/apps/web/lib/performance/business-performance-provider.ts
@@ -7,6 +7,7 @@ import {
   resolvePerformanceOrganizationContext,
   type PerformanceOrganizationContextDataSource,
 } from "./performance-organization-context";
+import { archetypeHasPerformanceMetrics } from "./performance-metric-support";
 
 export interface UnconfiguredBusinessPerformance {
   status: "not-configured";
@@ -14,6 +15,13 @@ export interface UnconfiguredBusinessPerformance {
   asOf: null;
   metricValues: readonly [];
   source: "business-performance-read-model";
+  /**
+   * Whether a snapshot could ever appear here. `true` (default) means the data
+   * is simply pending — the honest "not computed yet" case. `false` means the
+   * metrics engine has no source loader for this install's archetype, so the
+   * surface will never populate and the copy must not imply otherwise.
+   */
+  applicable: boolean;
 }
 
 export interface PersistedMetricRow {
@@ -108,13 +116,17 @@ export interface BusinessPerformanceDataSource
   };
 }
 
-function unconfigured(reason: string): UnconfiguredBusinessPerformance {
+function unconfigured(
+  reason: string,
+  opts: { applicable?: boolean } = {},
+): UnconfiguredBusinessPerformance {
   return {
     status: "not-configured",
     reason,
     asOf: null,
     metricValues: [],
     source: "business-performance-read-model",
+    applicable: opts.applicable ?? true,
   };
 }
 
@@ -271,6 +283,16 @@ export function createBusinessPerformanceProvider(
     async load(input) {
       const context = await resolvePerformanceOrganizationContext(db, input.userId);
       if (context.status === "unconfigured") return unconfigured(context.reason);
+
+      // The metrics engine only has a source loader for some archetypes. On an
+      // install whose archetype has none, no snapshot will ever be produced, so
+      // say that plainly instead of implying a pending computation. BI-F359E1E9.
+      if (!archetypeHasPerformanceMetrics(context.archetypeId)) {
+        return unconfigured(
+          "Performance snapshots are not available for this business type yet — the metrics engine currently covers hospitality operations.",
+          { applicable: false },
+        );
+      }
 
       const rows = await db.businessMetricRollup.findMany({
         where: { organizationId: context.organizationId },

--- a/apps/web/lib/performance/performance-metric-support.test.ts
+++ b/apps/web/lib/performance/performance-metric-support.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PERFORMANCE_METRIC_ARCHETYPES,
+  archetypeHasPerformanceMetrics,
+} from "./performance-metric-support";
+
+describe("archetypeHasPerformanceMetrics", () => {
+  it("is true for every archetype the engine has a source loader for", () => {
+    for (const archetypeId of PERFORMANCE_METRIC_ARCHETYPES) {
+      expect(archetypeHasPerformanceMetrics(archetypeId)).toBe(true);
+    }
+  });
+
+  it("is false for an archetype with no source loader", () => {
+    expect(archetypeHasPerformanceMetrics("software-platform")).toBe(false);
+    expect(archetypeHasPerformanceMetrics("field-service")).toBe(false);
+  });
+
+  it("includes restaurant as the currently-registered loader", () => {
+    expect(PERFORMANCE_METRIC_ARCHETYPES).toContain("restaurant");
+  });
+});

--- a/apps/web/lib/performance/performance-metric-support.ts
+++ b/apps/web/lib/performance/performance-metric-support.ts
@@ -1,0 +1,26 @@
+// Single source of truth for which business archetypes the performance-metrics
+// engine can actually produce snapshots for.
+//
+// The engine only has a source loader for hospitality today (loadRestaurantSource
+// in business-metric-rollup.server.ts reads HospitalityResource / ServiceTurn /
+// CapacityAllocation / StorefrontBooking). An install on any other archetype has
+// no rows to read, so the hourly aggregator would scan nothing and the
+// /performance surface would sit at "not computed yet" forever.
+//
+// Both sides read this one set so they cannot drift: the aggregator uses it to
+// decide which storefront contexts to scan, and the surface uses it to tell the
+// owner the truth — a pending snapshot ("not computed yet") versus a surface that
+// is simply not available for this business type yet.
+//
+// BI-F359E1E9: before this, the aggregator was hardcoded to "restaurant" and the
+// surface always implied a snapshot was pending, on installs that would never
+// produce one.
+export const PERFORMANCE_METRIC_ARCHETYPES = ["restaurant"] as const;
+
+export type PerformanceMetricArchetype =
+  (typeof PERFORMANCE_METRIC_ARCHETYPES)[number];
+
+/** True when the performance-metrics engine has a source loader for this archetype. */
+export function archetypeHasPerformanceMetrics(archetypeId: string): boolean {
+  return (PERFORMANCE_METRIC_ARCHETYPES as readonly string[]).includes(archetypeId);
+}

--- a/apps/web/lib/queue/functions/business-metrics-aggregator.ts
+++ b/apps/web/lib/queue/functions/business-metrics-aggregator.ts
@@ -29,8 +29,13 @@ export const businessMetricsAggregator = inngest.createFunction(
       const result = await aggregateBusinessMetrics(
         defaultBusinessMetricRollupDeps(),
       );
+      // Distinguish "did nothing because no install matched the engine" from a
+      // real refresh, so an operator auditing scheduled jobs is not misled by a
+      // green run that produced zero rollups. BI-F359E1E9.
       console.log(
-        `[business-metrics] refreshed ${result.upserted} rollups across ${result.organizations} organization(s)`,
+        result.organizations === 0
+          ? "[business-metrics] no storefronts matched the metrics engine (covers hospitality); nothing to refresh"
+          : `[business-metrics] refreshed ${result.upserted} rollups across ${result.organizations} organization(s)`,
       );
       return result;
     });


### PR DESCRIPTION
## What & why

`/performance` sat forever at "the first snapshot has not been computed yet" on every non-restaurant install — implying a pending computation that would never arrive. The business-metrics aggregator only has a source loader for hospitality (restaurant); on any other archetype it scans nothing, upserts nothing, and reports a clean success.

This is the owner-filed **BI-F359E1E9**, option 2 of the owner's acceptance criteria (honest surface + honest job signal for the current restaurant-only scope).

## Changes

- **One source of truth** — `PERFORMANCE_METRIC_ARCHETYPES` (`performance-metric-support.ts`). The aggregator scans only covered archetypes; the surface reads the same set to decide its copy. They cannot drift.
- **Honest surface** — the provider adds an `applicable` discriminator. A covered archetype with no snapshot yet still reads "not computed yet" (pending); a non-covered archetype reads "Performance isn't available for this business type" (permanent), never implying a pending computation.
- **Honest job signal** — the hourly job logs a distinguishable "nothing matched the engine" line instead of a bare "0 rollups across 0 organizations".
- **Docs** — the scheduled-jobs catalog purpose now states the hospitality-today scope instead of archetype-neutral language.

## Tests
- `performance-metric-support.test.ts` (new), provider not-applicable + still-pending paths, page not-applicable rendering. Full local-CI pregate: **PASS** (production build compiled, all shards green).

## Design grounding

- Specs/plans reviewed: docs/superpowers/plans/2026-07-28-business-operations-and-performance-views-plan.md (Performance packs resolve by archetype; restaurant FLOOR proof first, others follow — a non-covered archetype having no snapshot is the designed interim state).
- Code substrate: business-metric-rollup.server.ts (only loadRestaurantSource exists), business-performance-provider.ts (unconfigured fallback), performance page EmptyState.
- Decision: extend the existing honest-empty-state pattern; no new user-facing contract.

Design-Grounding-Decision: extend-existing (specs/plans reviewed: docs/superpowers/plans/2026-07-28-business-operations-and-performance-views-plan.md; code substrate: business-metric-rollup.server.ts + business-performance-provider.ts + performance page; adds an internal applicable discriminator and a single-source archetype set, no new user-facing contract)
Docs-Impact-Decision: updated (scheduled-jobs catalog purpose corrected to the hospitality-today scope)
Process-Spine-Decision: no-contract-change (new performance-metric-support.ts is an internal single-source helper for an existing capability; no new route, tool, or coordination contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)