### PR TITLE
fix(security): SOC cases carry their detections and resolve the actor's name (BI-7D1EC4B9)

### DIFF
--- a/apps/web/lib/queue/functions/siem-correlation-sweep.test.ts
+++ b/apps/web/lib/queue/functions/siem-correlation-sweep.test.ts
@@ -11,6 +11,8 @@ const {
   mockSecurityCaseFindUnique,
   mockSecurityCaseCreate,
   mockSecurityCaseUpdate,
+  mockAgentFindFirst,
+  mockUserFindUnique,
 } = vi.hoisted(() => ({
   mockDetectionRuleFindMany: vi.fn(),
   mockThreatIndicatorFindMany: vi.fn(),
@@ -21,6 +23,8 @@ const {
   mockSecurityCaseFindUnique: vi.fn(),
   mockSecurityCaseCreate: vi.fn(),
   mockSecurityCaseUpdate: vi.fn(),
+  mockAgentFindFirst: vi.fn(),
+  mockUserFindUnique: vi.fn(),
 }));
 
 vi.mock("@dpf/db", () => ({
@@ -38,6 +42,8 @@ vi.mock("@dpf/db", () => ({
       create: mockSecurityCaseCreate,
       update: mockSecurityCaseUpdate,
     },
+    agent: { findFirst: mockAgentFindFirst },
+    user: { findUnique: mockUserFindUnique },
   },
 }));
 
@@ -54,6 +60,9 @@ beforeEach(() => {
   mockDetectionUpdateMany.mockResolvedValue({ count: 0 });
   mockSecurityCaseFindUnique.mockResolvedValue(null);
   mockSecurityCaseCreate.mockResolvedValue({ id: "case_1" });
+  // Default: entity resolves to neither an agent nor a user (hostname/asset).
+  mockAgentFindFirst.mockResolvedValue(null);
+  mockUserFindUnique.mockResolvedValue(null);
 });
 
 describe("runCorrelationSweep", () => {
@@ -182,11 +191,77 @@ describe("runCorrelationSweep", () => {
     });
     expect(created.caseKey).toContain("attack:T1070.001");
     expect(created.title).toContain("HOST-1");
+    // BI-7D1EC4B9: the case carries the detections it was opened from, not {}.
+    expect(created.evidence).toMatchObject({
+      openedBy: "correlation-sweep",
+      detectionCount: 2,
+    });
+    expect(created.evidence.detectionKeys).toHaveLength(2);
     // Both detections linked to the new case, exactly once.
     expect(mockDetectionUpdateMany).toHaveBeenCalledTimes(1);
     const link = mockDetectionUpdateMany.mock.calls[0]![0];
     expect(link.data).toEqual({ securityCaseId: "case_1" });
     expect(link.where.detectionKey.in).toHaveLength(2);
+  });
+
+  it("resolves a User-id actor entity to a name in the case title (BI-7D1EC4B9)", async () => {
+    mockDetectionRuleFindMany.mockResolvedValue([]);
+    mockSecurityEventFindMany.mockResolvedValue([]);
+    // An internal authorization-denied detection whose entity is a bare User cuid.
+    mockDetectionFindMany.mockResolvedValue([
+      {
+        detectionKey: "dpf-kernel:internal-authz-denied:e1",
+        scopeKey: "organization:internal",
+        customerAccountId: null,
+        customerSiteId: null,
+        severity: "medium",
+        firstSeenAt: NOW,
+        lastSeenAt: NOW,
+        enrichment: {
+          ruleKey: "dpf-kernel:internal-authz-denied",
+          ruleName: "Internal authorization denied",
+          entityKey: "user-cuid-placeholder",
+        },
+      },
+    ]);
+    // No agent by that id; a user resolves.
+    mockAgentFindFirst.mockResolvedValue(null);
+    mockUserFindUnique.mockResolvedValue({ email: "admin@dpf.local" });
+
+    const result = await runCorrelationSweep({ seedPack: false });
+
+    expect(result.casesOpened).toBe(1);
+    const created = mockSecurityCaseCreate.mock.calls[0]![0].data;
+    expect(created.title).toBe("Internal authorization denied — admin@dpf.local");
+    expect(created.title).not.toContain("user-cuid-placeholder");
+  });
+
+  it("prefers an agent display name when the entity is an agent principal (BI-7D1EC4B9)", async () => {
+    mockDetectionRuleFindMany.mockResolvedValue([]);
+    mockSecurityEventFindMany.mockResolvedValue([]);
+    mockDetectionFindMany.mockResolvedValue([
+      {
+        detectionKey: "dpf-kernel:internal-authz-denied:e2",
+        scopeKey: "organization:internal",
+        customerAccountId: null,
+        customerSiteId: null,
+        severity: "medium",
+        firstSeenAt: NOW,
+        lastSeenAt: NOW,
+        enrichment: {
+          ruleKey: "dpf-kernel:internal-authz-denied",
+          ruleName: "Internal authorization denied",
+          entityKey: "data-architect",
+        },
+      },
+    ]);
+    mockAgentFindFirst.mockResolvedValue({ displayName: "Dana (Data Architect)", name: "data-architect", agentId: "data-architect" });
+
+    const result = await runCorrelationSweep({ seedPack: false });
+
+    expect(result.casesOpened).toBe(1);
+    const created = mockSecurityCaseCreate.mock.calls[0]![0].data;
+    expect(created.title).toBe("Internal authorization denied — Dana (Data Architect)");
   });
 
   it("merges into an existing case and ratchets severity, no duplicate", async () => {

--- a/apps/web/lib/queue/functions/siem-correlation-sweep.ts
+++ b/apps/web/lib/queue/functions/siem-correlation-sweep.ts
@@ -246,6 +246,32 @@ export async function runCorrelationSweep(opts?: {
 }
 
 /**
+ * Resolve a detection's entity to a human label when it is an actor principal.
+ * BI-7D1EC4B9: an internal-authorization detection's entity is the actor's id —
+ * an agent slug (already readable) or a bare User cuid (which rendered as an
+ * unresolvable machine id on the console). Returns null for a non-actor entity
+ * (hostname/asset) or one that resolves to neither, so the caller keeps the raw
+ * key rather than inventing a name.
+ */
+async function resolveEntityActorLabel(
+  prisma: typeof import("@dpf/db").prisma,
+  entityKey: string,
+): Promise<string | null> {
+  if (!entityKey || entityKey === "unknown") return null;
+  const agent = await prisma.agent.findFirst({
+    where: { OR: [{ agentId: entityKey }, { id: entityKey }] },
+    select: { displayName: true, name: true, agentId: true },
+  });
+  if (agent) return agent.displayName || agent.name || agent.agentId;
+  const user = await prisma.user.findUnique({
+    where: { id: entityKey },
+    select: { email: true },
+  });
+  if (user) return user.email;
+  return null;
+}
+
+/**
  * Group every OPEN, un-cased Detection into a SecurityCase. Detections already
  * linked to a case (securityCaseId set) are excluded, so each detection is
  * grouped exactly once; an existing case absorbs new same-key detections and
@@ -291,16 +317,34 @@ async function groupOpenDetectionsIntoCases(
         await prisma.securityCase.update({ where: { id: caseId }, data: { severity: merged } });
       }
     } else {
+      // BI-7D1EC4B9: resolve an actor entity (a User id rendered as a raw cuid,
+      // or an agent principal) to a human label so the title answers "who" with
+      // a name, not a machine id. A non-actor entity (hostname/asset) or an
+      // unresolvable key keeps the composed title unchanged.
+      const actorLabel = await resolveEntityActorLabel(prisma, cand.entityKey);
+      const title =
+        actorLabel && cand.entityKey !== "unknown"
+          ? `${cand.ruleName} — ${actorLabel}`
+          : cand.title;
       const created = await prisma.securityCase.create({
         data: {
           caseKey: cand.caseKey,
           scopeKey: cand.scopeKey,
           customerAccountId: cand.customerAccountId,
           customerSiteId: cand.customerSiteId,
-          title: cand.title,
+          title,
           severity: cand.severity,
           status: "new",
           verdict: "unknown",
+          // BI-7D1EC4B9: a case that demands a decision must carry the detections
+          // it was opened from, not an empty {}. The detection rows are also
+          // linked by securityCaseId below; these keys make them reachable from
+          // the case itself.
+          evidence: {
+            openedBy: "correlation-sweep",
+            detectionKeys: cand.detectionKeys,
+            detectionCount: cand.detectionKeys.length,
+          } as object,
           timeline: [
             {
               at: now.toISOString(),

--- a/apps/web/lib/security/case-grouping.test.ts
+++ b/apps/web/lib/security/case-grouping.test.ts
@@ -24,6 +24,8 @@ function det(overrides: Partial<DetectionForGrouping>): DetectionForGrouping {
     severity: "medium",
     groupingKey: deriveGroupingKey({ scopeKey: "customer:acct_1", entityKey: "HOST1", family: "credential-access" }),
     title: "Suspicious logon",
+    ruleName: "Suspicious logon",
+    entityKey: "HOST1",
     firstSeenAt: T0,
     lastSeenAt: T0,
     ...overrides,
@@ -113,6 +115,30 @@ describe("detectionFamily / detectionRowToGroupingInput (the sweep bridge)", () 
     expect(g.title).toBe("Windows audit log cleared — HOST-1");
     expect(g.severity).toBe("high");
     expect(g.detectionKey).toBe("dpf-kernel:windows-audit-log-cleared:e1");
+    // BI-7D1EC4B9: rule name + raw entity are carried separately so a persist
+    // step can re-render the title with a resolved actor label.
+    expect(g.ruleName).toBe("Windows audit log cleared");
+    expect(g.entityKey).toBe("HOST-1");
+  });
+
+  it("carries the winning detection's ruleName + entityKey onto the candidate (BI-7D1EC4B9)", () => {
+    // Same actor + family (so they group into one case), different rule + severity.
+    const base = {
+      mitreTechniques: ["T1070.001"],
+      entityKey: "cmuser0000000000000000000",
+    };
+    const low = detectionRowToGroupingInput(
+      row({ detectionKey: "k:e1", severity: "low", enrichment: { ...base, ruleKey: "r-low", ruleName: "Low signal" } }),
+    );
+    const high = detectionRowToGroupingInput(
+      row({ detectionKey: "k:e2", severity: "critical", enrichment: { ...base, ruleKey: "r-high", ruleName: "Internal authorization denied" } }),
+    );
+    const cands = groupDetectionsIntoCases([low, high]);
+    // Same entity + family → one candidate; the critical detection's title wins,
+    // so its ruleName + the carried entityKey win with it.
+    expect(cands).toHaveLength(1);
+    expect(cands[0]!.ruleName).toBe("Internal authorization denied");
+    expect(cands[0]!.entityKey).toBe("cmuser0000000000000000000");
   });
 
   it("falls back to entity 'unknown' (group by scope+family) when entity is absent", () => {

--- a/apps/web/lib/security/case-grouping.ts
+++ b/apps/web/lib/security/case-grouping.ts
@@ -47,6 +47,10 @@ export interface DetectionForGrouping {
   groupingKey: string;
   /** Short title for the case (highest-severity detection's title wins). */
   title: string;
+  /** Rule name and the raw entity, kept separate from the composed title so a
+   *  persist step can resolve an actor entity to a name (BI-7D1EC4B9). */
+  ruleName: string;
+  entityKey: string;
   firstSeenAt: Date;
   lastSeenAt: Date;
 }
@@ -57,6 +61,11 @@ export interface CaseCandidate {
   customerAccountId: string | null;
   customerSiteId: string | null;
   title: string;
+  /** The winning detection's rule name and raw entity, so the persist step can
+   *  re-render the title with a resolved actor label (BI-7D1EC4B9). "unknown"
+   *  entityKey means the detection carried no asset/actor. */
+  ruleName: string;
+  entityKey: string;
   severity: string;
   detectionKeys: string[];
   firstSeenAt: Date;
@@ -87,6 +96,8 @@ export function groupDetectionsIntoCases(
         customerAccountId: d.customerAccountId,
         customerSiteId: d.customerSiteId,
         title: d.title,
+        ruleName: d.ruleName,
+        entityKey: d.entityKey,
         severity: d.severity,
         detectionKeys: [d.detectionKey],
         firstSeenAt: d.firstSeenAt,
@@ -103,6 +114,8 @@ export function groupDetectionsIntoCases(
     // ties keep the earlier title).
     if (rank > (titleRank.get(d.groupingKey) ?? 0)) {
       existing.title = d.title;
+      existing.ruleName = d.ruleName;
+      existing.entityKey = d.entityKey;
       titleRank.set(d.groupingKey, rank);
     }
   }
@@ -171,6 +184,8 @@ export function detectionRowToGroupingInput(
     severity: row.severity,
     groupingKey: deriveGroupingKey({ scopeKey: row.scopeKey, entityKey, family }),
     title,
+    ruleName,
+    entityKey,
     firstSeenAt: row.firstSeenAt,
     lastSeenAt: row.lastSeenAt,
   };


### PR DESCRIPTION
## What & why

The mixed-time-base tile count on the SOC console was already fixed (#4779). This closes the two remaining defects the owner filed on the same surface in **BI-7D1EC4B9**:

- **Cases carried empty evidence.** A case opened by the correlation sweep demanded a decision with `evidence = {}`. It now carries the detection keys it was opened from (also linked by `securityCaseId`), so the case is reachable to its evidence.
- **The actor rendered as a raw cuid.** A case titled by an actor entity showed the raw principal id — a bare User cuid displayed as an unresolvable machine id (the operator's own account) on a console whose whole point is "who did this". The case-opening path now resolves the entity to a name (agent display name → user email), keeping the raw key only for a non-actor entity (hostname/asset).

The grouping bridge (`case-grouping.ts`) now carries the winning detection's `ruleName` + raw `entityKey` alongside the composed title, so the persist step can re-render the title with the resolved label without re-deriving it.

## Tests
- New: User-id → email title resolution, agent → display-name resolution, evidence populated with detectionKeys, candidate carries ruleName/entityKey. Existing sweep + grouping suites green. Full local-CI pregate: **PASS**.

Docs-Impact-Decision: no-docs-needed (internal SOC case-opening behavior; no user- or coworker-facing doc surface describes case titles or the evidence payload)
Process-Spine-Decision: no-contract-change (behavior fix within the existing correlation sweep; no new cron, route, or coordination contract)
Design-Grounding-Decision: extend-existing (specs/plans reviewed: docs/superpowers/specs/2026-06-24-sovereign-soc-siem-design.md; code substrate: case-grouping.ts + siem-correlation-sweep.ts + SecurityCase/Agent/User schema; carries ruleName+entityKey on the candidate and resolves the actor at case creation, no new contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)