### PR TITLE
fix(gate): a gate that cannot run must not brick the tree it interrupted (BI-46B03CAE, BI-0F2E42D5)

### DIFF
--- a/apps/web/lib/gates/gate-run-identity.test.ts
+++ b/apps/web/lib/gates/gate-run-identity.test.ts
@@ -194,6 +194,52 @@ describe("local-CI terminal evidence projection", () => {
     })).toEqual({ status: "rerunnable" });
   });
 
+  // BI-0F2E42D5. Observed live: a run finished its whole suite with no failures,
+  // then classified itself BLOCKED (control-plane starvation) — in the gate's own
+  // words, "infrastructure evidence, NOT a product build failure" — recorded that,
+  // and released. Reading the record back as `mismatched-evidence` bricked the
+  // tree, because the claim key hashes the tree. An honest record was strictly
+  // worse than none: a run killed before writing anything is rerunnable.
+  it("lets the gate run again when the evidence records a blocked, non-verdict status", () => {
+    for (const status of [
+      "blocked_control_plane_starvation",
+      "blocked",
+      "cancelled",
+    ]) {
+      expect(projectLocalCiTerminalEvidence({
+        claimKey: `gate:${gateKey}`,
+        evidence: {
+          id: "EXT-GATE",
+          operationType: "local_integration_ci",
+          details: {
+            gateKey,
+            status,
+            evidenceValidity: { expiresAt: "2026-08-25T12:01:00.000Z" },
+          },
+        },
+        now: new Date("2026-08-25T12:00:00.000Z"),
+      })).toEqual({ status: "rerunnable" });
+    }
+  });
+
+  // The line the fix must not cross: a record for a DIFFERENT gate is a real
+  // conclusion about this claim and still settles it, whatever its status.
+  it("still blocks a non-verdict status carried on another gate's record", () => {
+    expect(projectLocalCiTerminalEvidence({
+      claimKey: `gate:${gateKey}`,
+      evidence: {
+        id: "EXT-GATE",
+        operationType: "local_integration_ci",
+        details: {
+          gateKey: "e".repeat(64),
+          status: "blocked_control_plane_starvation",
+          evidenceValidity: { expiresAt: "2026-08-25T12:01:00.000Z" },
+        },
+      },
+      now: new Date("2026-08-25T12:00:00.000Z"),
+    })).toEqual({ status: "blocked", reason: "mismatched-evidence" });
+  });
+
   it("fails closed for expired or mismatched evidence", () => {
     expect(projectLocalCiTerminalEvidence({
       claimKey: `gate:${gateKey}`,

--- a/apps/web/lib/gates/gate-run-identity.ts
+++ b/apps/web/lib/gates/gate-run-identity.ts
@@ -116,12 +116,28 @@ export function projectLocalCiTerminalEvidence(input: {
     && !Array.isArray(details.evidenceValidity)
     ? details.evidenceValidity as Record<string, unknown>
     : null;
+  // Truly mismatched: this record does not describe this gate at all. That IS a
+  // real conclusion about the claim and still settles it.
   if (
     input.evidence.operationType !== "local_integration_ci"
     || details?.gateKey !== input.claimKey.slice("gate:".length)
-    || (details.status !== "passed" && details.status !== "failed")
   ) {
     return { status: "blocked", reason: "mismatched-evidence" };
+  }
+  // BI-0F2E42D5: the right record for the right gate, carrying a status that is
+  // not a product verdict — `blocked_control_plane_starvation` and its kin. The
+  // gate writes those to say, in its own words, "this is infrastructure
+  // evidence, NOT a product build failure", and then records them; reading one
+  // back as `mismatched-evidence` bricked the tree it interrupted, because the
+  // claim key hashes the tree.
+  //
+  // That made an HONEST record strictly worse than none: a run killed before it
+  // wrote anything is rerunnable (BI-C59AC8AF), while one that recorded why it
+  // could not finish was punished for saying so. It is the same reasoning the
+  // validity check below already applies one branch down — a run that reached no
+  // verdict has no verdict to protect, so re-running it lets nobody escape one.
+  if (details.status !== "passed" && details.status !== "failed") {
+    return { status: "rerunnable" };
   }
   // An expiry that was never STAMPED is not an expiry that lapsed. The gate
   // stamps validity only for a run that reached a product verdict, so evidence

--- a/scripts/gate-worktree-lease-timeout.test.mjs
+++ b/scripts/gate-worktree-lease-timeout.test.mjs
@@ -1,0 +1,59 @@
+// BI-46B03CAE — the lease-queue calls cost more than mcpCall's 10s default, and
+// abandoning one that was about to succeed strands a lease the gate cannot then
+// release. Guards the headroom and the operator-facing wording.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { describeLeaseCallFailure, leaseQueueCallOptions } from "./gate-worktree.mjs";
+
+test("lease-queue calls get far more headroom than mcpCall's 10s default", () => {
+  const options = leaseQueueCallOptions("http://127.0.0.1:3000/api/mcp/v1", "tok");
+
+  // The live repro measured list_nonprod_environment_leases at 10166ms — a
+  // SUCCESS the client abandoned 166ms early. Anything at or near 10s reopens it.
+  assert.ok(options.timeoutMs >= 30_000, `expected generous headroom, got ${options.timeoutMs}`);
+  assert.equal(options.mcpUrl, "http://127.0.0.1:3000/api/mcp/v1");
+  assert.equal(options.bearerToken, "tok");
+});
+
+test("the timeout is tunable without patching source", async (t) => {
+  const previous = process.env.DPF_GATE_MCP_TIMEOUT_MS;
+  t.after(() => {
+    if (previous === undefined) delete process.env.DPF_GATE_MCP_TIMEOUT_MS;
+    else process.env.DPF_GATE_MCP_TIMEOUT_MS = previous;
+  });
+
+  // Resolved once at module load, so this asserts the contract the env var
+  // feeds rather than re-importing: a positive finite override is honoured and
+  // anything else falls back to the default.
+  const resolve = (raw) => {
+    const value = Number(raw);
+    return Number.isFinite(value) && value > 0 ? value : 60_000;
+  };
+  assert.equal(resolve("120000"), 120_000);
+  assert.equal(resolve("0"), 60_000);
+  assert.equal(resolve("-1"), 60_000);
+  assert.equal(resolve("nonsense"), 60_000);
+  assert.equal(resolve(undefined), 60_000);
+});
+
+test("a timeout is reported as contention, not as an unreachable portal", () => {
+  const message = describeLeaseCallFailure(
+    new Error("mcpCall: list_nonprod_environment_leases timed out after 60000ms"),
+  );
+
+  assert.match(message, /timed out after 60000ms/);
+  assert.match(message, /reachable and merely contended/);
+  assert.match(message, /DPF_GATE_MCP_TIMEOUT_MS/);
+});
+
+test("a non-timeout failure is passed through unchanged", () => {
+  const message = describeLeaseCallFailure(new Error("ECONNREFUSED 127.0.0.1:3000"));
+
+  assert.equal(message, "ECONNREFUSED 127.0.0.1:3000");
+});
+
+test("a thrown non-Error still describes itself", () => {
+  assert.equal(describeLeaseCallFailure("plain string failure"), "plain string failure");
+});

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -14,6 +14,50 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileS
 import { dirname, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { mcpCall } from "./lib/mcp-client.mjs";
+
+// BI-46B03CAE — the lease-queue MCP calls cost more than mcpCall's 10s default.
+//
+// Their latency tracks the number of waiters, not the size of the response: with
+// four branches queued on this box, `list_nonprod_environment_leases` measured
+// 10166ms and SUCCEEDED — 166ms past the client's deadline. The portal was
+// healthy throughout (/api/health ~85ms, 4.5% CPU), so nothing was broken; the
+// gate simply stopped listening to an answer that was on its way.
+//
+// The cost of abandoning it is not one retry. A claim that times out client-side
+// after the server created the queued row leaves a gate that does not own the
+// lease it just made, so its own cleanup refuses with `nonprod_lease_not_owner`
+// (explicitly non-retryable) and the row stays queued. Each failure adds a
+// waiter to a single-slot pool, which makes the next listing slower, which
+// strands the next row. Left alone it converges on a box where no gate can ever
+// claim and every contributor is told the portal timed out.
+//
+// So these calls get real headroom, tunable without patching source. The global
+// default stays at 10s: a health probe should still fail fast.
+const LEASE_QUEUE_TIMEOUT_MS = (() => {
+  const raw = Number(process.env.DPF_GATE_MCP_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 60_000;
+})();
+
+/** Transport options for a queue call whose latency grows with the queue. */
+export function leaseQueueCallOptions(mcpUrl, bearerToken) {
+  return { mcpUrl, bearerToken, timeoutMs: LEASE_QUEUE_TIMEOUT_MS };
+}
+
+/**
+ * Describe a failed lease-queue call in the terms the operator has to act on.
+ *
+ * "timed out after 60000ms" reads as an unreachable portal and sends people to
+ * check whether the install is up. When a queue call is what timed out, the
+ * portal is usually fine and the queue is merely deep — a different problem
+ * with a different response, so say which one it is (BI-46B03CAE).
+ */
+export function describeLeaseCallFailure(error) {
+  const message = error?.message ?? String(error);
+  if (!/timed out after/.test(message)) return message;
+  return `${message} — the portal may be reachable and merely contended; `
+    + "lease-queue calls slow down as waiters accumulate. Raise DPF_GATE_MCP_TIMEOUT_MS "
+    + "if this box regularly runs several gates at once";
+}
 import { summarizeLocalCiOutput } from "./lib/local-ci-failure-summary.mjs";
 import { classifyGateOutcome } from "./lib/sandbox-freshness.mjs";
 import { fallbackStatusForUnknown } from "./lib/local-integration-status.mjs";
@@ -671,11 +715,11 @@ async function cancelDeadLocalQueueObservers({
     response = await mcpCall(
       "list_nonprod_environment_leases",
       {},
-      { mcpUrl, bearerToken },
+      leaseQueueCallOptions(mcpUrl, bearerToken),
     );
   } catch (error) {
     process.stderr.write(
-      `gate-worktree: dead-waiter reconciliation unavailable (${error.message}); queue remains fail-closed\n`,
+      `gate-worktree: dead-waiter reconciliation unavailable (${describeLeaseCallFailure(error)}); queue remains fail-closed\n`,
     );
     return;
   }
@@ -1117,7 +1161,7 @@ async function main() {
     const response = await mcpCall("release_nonprod_environment_lease", {
       leaseId,
       ownerSessionId,
-    }, { mcpUrl: options.mcpUrl, bearerToken });
+    }, leaseQueueCallOptions(options.mcpUrl, bearerToken));
     if (response?.success !== true) {
       throw new Error(`failed to release local-CI lease: ${JSON.stringify(response)}`);
     }
@@ -1178,7 +1222,7 @@ async function main() {
         branchName: branch,
         slotManifestVersion: slotManifest.schemaVersion,
         hostPressure,
-      }, { mcpUrl: options.mcpUrl, bearerToken });
+      }, leaseQueueCallOptions(options.mcpUrl, bearerToken));
     } catch (error) {
       if (!isTransientMcpError(error) || Date.now() >= deadline) throw error;
       const delayMs = retryDelayMs({ attempt: claimAttempt, pollSeconds: options.pollSeconds });
@@ -1486,7 +1530,7 @@ async function main() {
           },
         }
         : {}),
-    }, { mcpUrl: options.mcpUrl, bearerToken });
+    }, leaseQueueCallOptions(options.mcpUrl, bearerToken));
     const renewedExpiresAt = response?.data?.lease?.expiresAt;
     if (
       response?.success === true

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -50,6 +50,13 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     // than added to ci-policy-test-inventory-allowlist.txt, where it would never run.
     guard("gate-executor-liveness", "Gate Executor Liveness", [
       node("--test", "scripts/gate-worktree-executor-liveness.test.mjs"),
+      // BI-46B03CAE: the lease-queue calls cost more than mcpCall's 10s default,
+      // and abandoning one that was about to succeed strands a lease the gate
+      // then cannot release — each failure deepening a single-slot queue until
+      // no gate on the box can claim. Registered here for the same reason as the
+      // liveness test above: in ci-policy-test-inventory-allowlist.txt it would
+      // never run.
+      node("--test", "scripts/gate-worktree-lease-timeout.test.mjs"),
     ]),
     guard("host-port-range-guard", "Host Port Range Guard", [
       node("--test", "scripts/check-host-port-range.test.mjs"),


### PR DESCRIPTION
Two defects in local-CI gate admission, found while trying to gate an unrelated branch. Neither is a verdict on any diff; both stop gates running at all.

Five consecutive gate attempts on this host were killed by infrastructure rather than by a failing check.

## 1. The 10s MCP timeout is below what lease-queue calls cost (BI-46B03CAE)

```
dead-waiter reconciliation unavailable (mcpCall: list_nonprod_environment_leases timed out after 10000ms)
Error: mcpCall: claim_nonprod_environment_lease timed out after 10000ms
```

The request was not failing. Timed against the running portal with four branches queued:

```
POST /api/mcp/v1  list_nonprod_environment_leases   elapsed=10166ms   {"success": true, ...}
```

It **succeeds in 10166ms**; the client gives up at 10000ms — 166ms early. `/api/health` answered in ~85ms at 4.5% CPU throughout, so the portal was healthy. These calls' latency tracks the number of waiters, not the response size, so a fixed 10s ceiling is the wrong shape.

All five lease-queue sites (list, claim, release, renew, dead-waiter reconciliation) now use a 60s default, overridable via `DPF_GATE_MCP_TIMEOUT_MS`. The global `mcpCall` default stays 10s so health probes still fail fast. A timeout now reports contention and names the knob, instead of reading as an unreachable portal.

## 2. An infrastructure block is read as a verdict (BI-0F2E42D5)

A run finished its whole suite with **no test failures**, then classified itself:

> BLOCKED (control-plane starvation) ... This is infrastructure evidence, NOT a product build failure.

It recorded that and released. Every later claim on the same tree was refused with `mismatched-evidence` — and the claim key hashes the integration **tree**, so that tree could never be gated again.

`projectLocalCiTerminalEvidence` accepted only `passed` or `failed` as terminal and folded everything else into `mismatched-evidence`. So the record the gate wrote **to say it was not a verdict** was read back as one.

That made an honest record strictly worse than none: a run killed before writing anything is rerunnable (BI-C59AC8AF), while a run that recorded *why* it could not finish was punished for saying so.

The fix matches what BI-C59AC8AF already reasoned one branch lower, where evidence with no validity stamp is called out as *"infrastructure evidence — a killed child, a starved control plane, recorded for observability and never a verdict to reuse."* The status check simply returned before reaching it.

- a record for a different gate or operation type is still a real conclusion and still settles the claim
- a record for **this** gate carrying a non-verdict status is a run that did not conclude
- `passed` and `failed` are untouched: they settle, and are still never re-run

## Tests

- `scripts/gate-worktree-lease-timeout.test.mjs` — 5 tests: headroom well above 10s, env override resolution, timeout reported as contention, non-timeout failures passed through unchanged. Registered in `ci-policy-guards` rather than the test-inventory allowlist, where — like `gate-worktree-executor-liveness` beside it — it would never run.
- `gate-run-identity.test.ts` — 22 pass, including the line the fix must not cross: a non-verdict status on **another** gate's record still blocks.

Local-CI gate passed on `fdf8ccd8d1`.

## Not fixed here

Recorded on BI-46B03CAE: a lease that expires while its owner waits still refuses release with `nonprod_lease_not_owner` — an ownership error for what is an ordinary expiry, with `retryable: false` as advice. Verified with `ownerSessionId` matching the releasing session on its own branch. And a `claim` whose response is never read can still create a row the caller cannot prove it owns.

Also unaddressed by code: 51 evidence-less terminal gate leases had already accumulated on this host — 51 trees permanently ungateable, four branches queued with none active. BI-C59AC8AF prevents new ones but does not reclaim rows already stranded on an install that upgrades into it.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)