### PR TITLE
fix(readiness): emit scope markers so a Build Studio design can be baselined (BI-CFD5A55A)

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/render-build-design-text.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/render-build-design-text.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 
 import { renderBuildDesignText } from "./render-build-design-text";
+import { parseInitiativeScopeManifest } from "./baseline-manifest";
 
 // The exact key set stored on FB-EB292B9F, the build this unblocked.
 const DESIGN = {
@@ -58,5 +59,83 @@ describe("renderBuildDesignText", () => {
     const text = renderBuildDesignText({ problemStatement: "Real.", reusePlan: [], accessibility: "   " })!;
     expect(text).not.toContain("## Reuse plan");
     expect(text).not.toContain("## Accessibility");
+  });
+});
+
+// BI-CFD5A55A — the rendered text must not merely resolve, it must BASELINE.
+// These assert against the real parser, because a marker that looks right and
+// does not parse is the exact failure this fixes.
+describe("scope manifest markers", () => {
+  const design = {
+    problemStatement: "Rescue staff need to see which animals have waited longest.",
+    acceptanceCriteria: [
+      "One page lists the dogs and cats that have waited longest for adoption.",
+      "Every listed animal shows how many days it has been waiting.",
+    ],
+  };
+
+  it("parses as a valid scope manifest", () => {
+    const text = renderBuildDesignText(design);
+    const parsed = parseInitiativeScopeManifest(text!);
+
+    expect(parsed.ok).toBe(true);
+    const manifest = parsed as Extract<typeof parsed, { ok: true }>;
+    expect(manifest.objectives.map((o) => o.objectiveId)).toEqual(["OBJ-1"]);
+    expect(manifest.acceptance.map((a) => a.acceptanceId)).toEqual(["AC-1", "AC-2"]);
+    expect(manifest.acceptance.every((a) => a.objectiveIds.includes("OBJ-1"))).toBe(true);
+  });
+
+  it("renders byte-identical text on every call", () => {
+    expect(renderBuildDesignText(design)).toBe(renderBuildDesignText(design));
+  });
+
+  // An acceptance cell is [^|]*, so a raw pipe would end the cell early.
+  it("does not let a pipe in a criterion malform its row", () => {
+    const text = renderBuildDesignText({
+      problemStatement: "Staff need one list.",
+      acceptanceCriteria: ["Shows species | status | days waiting for each animal."],
+    });
+    const parsed = parseInitiativeScopeManifest(text!);
+
+    expect(parsed.ok).toBe(true);
+    const manifest = parsed as Extract<typeof parsed, { ok: true }>;
+    expect(manifest.acceptance).toHaveLength(1);
+    expect(manifest.acceptance[0]!.objectiveIds).toEqual(["OBJ-1"]);
+  });
+
+  // The parser rejects an acceptance row naming an unknown objective, so
+  // criteria with no problem statement must emit no rows at all.
+  it("emits no acceptance rows when there is no objective to link them to", () => {
+    const text = renderBuildDesignText({
+      acceptanceCriteria: ["One page lists the animals."],
+    });
+
+    expect(text).not.toContain("AC-1");
+    expect(text).not.toContain("OBJ-1");
+  });
+
+  it("emits no manifest when a design states an objective but no criteria", () => {
+    const text = renderBuildDesignText({ problemStatement: "Staff need one list." });
+
+    expect(text).not.toContain("OBJ-1");
+    expect(text).toContain("## Problem statement");
+  });
+
+  // Contiguous ids: a criterion that renders to nothing must not leave a gap
+  // that shifts every later id and moves the pinned digest.
+  it("numbers the surviving criteria contiguously", () => {
+    const text = renderBuildDesignText({
+      problemStatement: "Staff need one list.",
+      acceptanceCriteria: ["First criterion.", "   ", 42, "Second criterion."],
+    });
+    const manifest = parseInitiativeScopeManifest(text!) as Extract<
+      ReturnType<typeof parseInitiativeScopeManifest>, { ok: true }
+    >;
+
+    expect(manifest.acceptance.map((a) => a.acceptanceId)).toEqual(["AC-1", "AC-2"]);
+  });
+
+  it("still returns null for a value that is not a design document", () => {
+    expect(renderBuildDesignText({ unrelated: "value" })).toBeNull();
   });
 });

--- a/apps/web/lib/backlog/initiative-readiness/render-build-design-text.ts
+++ b/apps/web/lib/backlog/initiative-readiness/render-build-design-text.ts
@@ -24,6 +24,24 @@
 // The rendering must be DETERMINISTIC. A baseline pins a digest and reviewers
 // read this text; the same stored value must always produce the same document,
 // so the section order is fixed here rather than taken from key order.
+//
+// BI-CFD5A55A — resolving as canonical text is not enough; the text has to be
+// BASELINEABLE. `spec-approval` mints the initiative scope baseline as well as
+// recording approval, and minting parses this document with
+// parseInitiativeScopeManifest, which reads two exact shapes and refuses an
+// artifact carrying neither:
+//
+//   **OBJ-<ID>:** <statement>
+//   | AC-<ID> | <OBJ-ids> | <statement> |
+//
+// This renderer emitted prose sections and a bulleted acceptance list, so every
+// Build Studio design parsed to zero objectives and failed with "the artifact
+// has no marked objective statements" — the next refusal behind BI-126441FA.
+//
+// The raw material was already here: `problemStatement` is the initiative's one
+// objective and `acceptanceCriteria` are its criteria. Only the notation was
+// missing, so the markers are DERIVED, never generated: same stored design,
+// same ids, same digest.
 
 /** Fixed section order — never derive this from Object.keys. */
 const SECTIONS: ReadonlyArray<{ key: string; heading: string }> = [
@@ -59,6 +77,56 @@ function renderValue(value: unknown): string | null {
   return null;
 }
 
+/** The single objective a Build Studio design states, in its problem statement. */
+const OBJECTIVE_ID = "OBJ-1";
+
+/**
+ * Flatten a statement onto one line and neutralise the characters the manifest
+ * grammar treats as structure.
+ *
+ * An acceptance cell is `[^|]*`, so a literal pipe inside a criterion ends the
+ * cell early and silently truncates — or malforms — the row. A newline splits
+ * one criterion across two lines and drops the remainder. Neither may be left to
+ * corrupt a manifest a baseline is about to pin.
+ */
+function asStatement(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const flattened = value.replace(/\s+/g, " ").split("|").join("\|").trim();
+  return flattened || null;
+}
+
+/**
+ * Render the marked objective and its acceptance table.
+ *
+ * Returns null unless BOTH an objective statement and at least one acceptance
+ * criterion are present. The parser rejects an acceptance row naming an unknown
+ * objective, so criteria with no problem statement must render nothing rather
+ * than rows pointing at an objective that was never emitted.
+ */
+function renderScopeManifest(doc: Record<string, unknown>): string | null {
+  const objective = asStatement(doc.problemStatement);
+  if (!objective) return null;
+
+  const criteria = Array.isArray(doc.acceptanceCriteria) ? doc.acceptanceCriteria : [];
+  const rows = criteria
+    .map(asStatement)
+    // Index the SURVIVING criteria: a criterion that renders to nothing must not
+    // leave a gap that shifts every later id and moves the baseline digest.
+    .filter((statement): statement is string => statement !== null)
+    .map((statement, index) => `| AC-${index + 1} | ${OBJECTIVE_ID} | ${statement} |`);
+  if (rows.length === 0) return null;
+
+  return [
+    "## Scope",
+    "",
+    `**${OBJECTIVE_ID}:** ${objective}`,
+    "",
+    "| ID | Objectives | Acceptance criterion |",
+    "| --- | --- | --- |",
+    ...rows,
+  ].join("\n");
+}
+
 /**
  * Render a Build Studio design document as canonical initiative text.
  *
@@ -69,6 +137,10 @@ export function renderBuildDesignText(value: unknown): string | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const doc = value as Record<string, unknown>;
   const parts: string[] = [];
+  // The scope manifest leads: it is what the baseline parses, and a reviewer
+  // should meet the objective before the prose.
+  const manifest = renderScopeManifest(doc);
+  if (manifest) parts.push(manifest);
   for (const { key, heading } of SECTIONS) {
     const rendered = renderValue(doc[key]);
     if (rendered) parts.push(`## ${heading}\n\n${rendered}`);


### PR DESCRIPTION
## The failure

With an independent reviewer finally able to record receipts, `spec-approval` on a Build Studio design refused:

> The artifact has no marked objective statements.

## Why

`spec-approval` mints the initiative scope baseline as well as recording approval — the lane table maps both `SPEC_APPROVAL_REQUIRED` and `OBJECTIVE_BASELINE_REQUIRED` to that one gate. Minting parses the canonical artifact with `parseInitiativeScopeManifest`, which reads two exact shapes and refuses an artifact carrying neither:

```
**OBJ-<ID>:** <statement>
| AC-<ID> | <OBJ-ids> | <statement> |
```

`renderBuildDesignText` emitted `##`-headed prose and a bulleted acceptance list. No `OBJ-` line, no acceptance table, so **every Build Studio design parsed to zero objectives**.

Making the design *resolve* as canonical text (BI-126441FA) was only half of it. This is the refusal waiting behind that one.

## The fix

The raw material was already there: `problemStatement` is the initiative's one objective and `acceptanceCriteria` are its criteria. The markers are **derived, never generated** — the same stored design renders the same ids and the same digest every time, which a pinned baseline requires.

Three things the grammar makes load-bearing:

- an acceptance cell is `[^|]*`, so a raw pipe in a criterion ends the cell early and silently truncates or malforms the row. Pipes are escaped and whitespace flattened.
- the parser rejects a row naming an unknown objective, so criteria with no problem statement emit **no** rows rather than rows pointing at an objective that was never written.
- ids index the **surviving** criteria, so a criterion that renders to nothing cannot leave a gap that shifts every later id and moves the digest.

The prose sections are unchanged; reviewers read this text and the markers are additive.

## Tests

13 pass. Asserted against the **real parser** rather than a shape assertion — a marker that looks right and does not parse is precisely the failure this fixes:

- the rendered design parses to a valid manifest with linked objectives
- byte-identical output across calls
- a pipe inside a criterion does not malform its row
- no acceptance rows when there is no objective to link them to
- contiguous ids when a criterion renders to nothing
- a non-design value still returns null

Also verified against the actual stored design on FB-1EBDEBAD: **1 objective, 15 acceptance criteria, manifest valid.**

Local-CI gate passed.

## Chain context

Tenth link found running one newsletter page through Build Studio as its owner. Preceding: #4792, #4794, #4800, #4802, #4804, #4812 (decomposition override was write-only), #4834 (71 of 76 agents had no Principal, so no independent lane could pass). Still open: BI-7E75F6E6 — the owner is shown six accountable role names and routed to none of them.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)