### PR TITLE
fix(build): preserve the brief MCP actor

### DIFF
--- a/apps/web/lib/actions/build-feature-brief.test.ts
+++ b/apps/web/lib/actions/build-feature-brief.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
 
 const mocks = vi.hoisted(() => ({
   requireCapability: vi.fn(),
@@ -77,5 +78,18 @@ describe("updateFeatureBrief (BI-7175C7DB)", () => {
     expect(mocks.requireCapability).not.toHaveBeenCalled();
     expect(mocks.prisma.featureBuild.update).not.toHaveBeenCalled();
   });
-});
 
+  it("uses an explicit async facade from the use-server build action module", () => {
+    const buildActionSource = readFileSync(
+      new URL("./build.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(buildActionSource).not.toMatch(
+      /export\s*\{\s*updateFeatureBrief\s*\}\s*from/,
+    );
+    expect(buildActionSource).toMatch(
+      /export\s+async\s+function\s+updateFeatureBrief\s*\(/,
+    );
+  });
+});

--- a/apps/web/lib/actions/build-feature-brief.test.ts
+++ b/apps/web/lib/actions/build-feature-brief.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireCapability: vi.fn(),
+  prisma: {
+    featureBuild: { findUnique: vi.fn(), update: vi.fn() },
+    businessBuildBrief: { upsert: vi.fn() },
+    organization: { findFirst: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/actions/shared/guards", () => ({
+  requireCapability: mocks.requireCapability,
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }));
+
+import { updateFeatureBrief } from "./build-feature-brief";
+
+const brief = {
+  title: "Improve Build Studio intake",
+  description: "Build Studio should save a governed feature brief.",
+  portfolioContext: "Build Studio",
+  targetRoles: ["Operations lead"],
+  inputs: ["Reviewed plan"],
+  dataNeeds: "Business outcome and evidence",
+  acceptanceCriteria: ["The build owner can save the brief."],
+};
+
+describe("updateFeatureBrief (BI-7175C7DB)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireCapability.mockResolvedValue({ userId: "session-owner" });
+    mocks.prisma.featureBuild.findUnique.mockResolvedValue({
+      id: "feature-build-row-1",
+      buildId: "FB-123",
+      title: brief.title,
+      createdById: "session-owner",
+      phase: "ideate",
+    });
+    mocks.prisma.organization.findFirst.mockResolvedValue({ id: "org-1" });
+    mocks.prisma.$transaction.mockImplementation(async (callback) => callback(mocks.prisma));
+  });
+
+  it("uses the HTTP-session actor when no governed actor is supplied", async () => {
+    await updateFeatureBrief("FB-123", brief);
+
+    expect(mocks.requireCapability).toHaveBeenCalledWith("view_platform");
+    expect(mocks.prisma.featureBuild.update).toHaveBeenCalledWith({
+      where: { buildId: "FB-123" },
+      data: { brief },
+    });
+  });
+
+  it("uses an explicit governed actor without requiring an HTTP session", async () => {
+    mocks.requireCapability.mockRejectedValue(new Error("Unauthorized"));
+    mocks.prisma.featureBuild.findUnique.mockResolvedValue({
+      id: "feature-build-row-1",
+      buildId: "FB-123",
+      title: brief.title,
+      createdById: "mcp-actor-1",
+      phase: "ideate",
+    });
+
+    await updateFeatureBrief("FB-123", brief, { actorUserId: "mcp-actor-1" });
+
+    expect(mocks.requireCapability).not.toHaveBeenCalled();
+    expect(mocks.prisma.featureBuild.update).toHaveBeenCalled();
+  });
+
+  it("keeps the build-owner check for an explicit governed actor", async () => {
+    await expect(
+      updateFeatureBrief("FB-123", brief, { actorUserId: "different-actor" }),
+    ).rejects.toThrow("Forbidden");
+
+    expect(mocks.requireCapability).not.toHaveBeenCalled();
+    expect(mocks.prisma.featureBuild.update).not.toHaveBeenCalled();
+  });
+});
+

--- a/apps/web/lib/actions/build-feature-brief.ts
+++ b/apps/web/lib/actions/build-feature-brief.ts
@@ -1,0 +1,85 @@
+"use server";
+
+import { requireCapability } from "@/lib/actions/shared/guards";
+import {
+  businessBriefJsonPayload,
+} from "@/lib/build/build-actions-core";
+import {
+  legacyFeatureBuildBriefToBusinessBuildBriefInput,
+} from "@/lib/build/business-build-brief";
+import {
+  type FeatureBrief,
+  validateFeatureBrief,
+} from "@/lib/feature-build-types";
+import { prisma, type Prisma } from "@dpf/db";
+
+export async function updateFeatureBrief(
+  buildId: string,
+  brief: FeatureBrief,
+  options: { actorUserId?: string } = {},
+): Promise<void> {
+  const userId = options.actorUserId
+    ?? (await requireCapability("view_platform")).userId;
+
+  const build = await prisma.featureBuild.findUnique({ where: { buildId } });
+  if (!build) throw new Error("Build not found");
+  if (build.createdById !== userId) throw new Error("Forbidden");
+  if (build.phase !== "ideate") {
+    throw new Error("Brief can only be updated during Ideate phase");
+  }
+
+  const validation = validateFeatureBrief(brief);
+  if (!validation.valid) throw new Error(validation.errors.join(", "));
+
+  const organization = await prisma.organization.findFirst({ select: { id: true } });
+  if (!organization) {
+    throw new Error("Organization is required before saving a business build brief");
+  }
+
+  const businessBrief = legacyFeatureBuildBriefToBusinessBuildBriefInput({
+    orgId: organization.id,
+    buildId: build.buildId,
+    featureBuildId: build.id,
+    title: build.title,
+    brief,
+    submittedByUserId: userId,
+  });
+  const acceptedFields = businessBrief.status === "accepted"
+    ? { acceptedByUserId: userId, acceptedAt: new Date() }
+    : { acceptedByUserId: null, acceptedAt: null };
+  const jsonPayload = businessBriefJsonPayload(businessBrief);
+
+  await prisma.$transaction(async (tx) => {
+    await tx.featureBuild.update({
+      where: { buildId },
+      data: { brief: brief as unknown as Prisma.InputJsonValue },
+    });
+
+    await tx.businessBuildBrief.upsert({
+      where: { featureBuildId: build.id },
+      create: { ...businessBrief, ...jsonPayload, ...acceptedFields },
+      update: {
+        status: businessBrief.status,
+        intakeSource: businessBrief.intakeSource,
+        capabilityPackId: businessBrief.capabilityPackId,
+        backlogItemId: businessBrief.backlogItemId,
+        businessOutcome: businessBrief.businessOutcome,
+        affectedPeople: jsonPayload.affectedPeople,
+        affectedWorkflow: businessBrief.affectedWorkflow,
+        sourceEvidence: jsonPayload.sourceEvidence,
+        successSignals: businessBrief.successSignals,
+        constraints: businessBrief.constraints,
+        businessInterpretation: businessBrief.businessInterpretation,
+        technicalInterpretation: jsonPayload.technicalInterpretation,
+        riskProfile: jsonPayload.riskProfile,
+        hiveReadiness: jsonPayload.hiveReadiness,
+        openQuestions: businessBrief.openQuestions,
+        confidence: businessBrief.confidence,
+        confidenceRationale: businessBrief.confidenceRationale,
+        submittedByUserId: businessBrief.submittedByUserId,
+        ...acceptedFields,
+      },
+    });
+  });
+}
+

--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -184,7 +184,7 @@ vi.mock("@/lib/self-upgrade/quiescence", () => ({
 }));
 
 import { revalidatePath } from "next/cache";
-import { approveBuildStart, advanceBuildPhase, completeBuild, createFeatureBuild, recordBuildAcceptance, resumeBuildImplementation, runBuildReviewVerification, updateBusinessBuildBrief, updateFeatureBrief } from "./build";
+import { approveBuildStart, advanceBuildPhase, completeBuild, createFeatureBuild, recordBuildAcceptance, resumeBuildImplementation, runBuildReviewVerification, updateBusinessBuildBrief } from "./build";
 
 describe("governed build start approvals", () => {
   beforeEach(() => {
@@ -348,55 +348,6 @@ describe("governed build start approvals", () => {
     // Rejected before any DB write — no build row, no work capsule.
     expect(mockPrisma.featureBuild.create).not.toHaveBeenCalled();
     expect(mockPrisma.workroom.create).not.toHaveBeenCalled();
-  });
-
-  it("updateFeatureBrief writes the legacy brief and backfills the BusinessBuildBrief contract", async () => {
-    mockPrisma.featureBuild.findUnique.mockResolvedValue({
-      id: "feature-build-row-1",
-      buildId: "FB-123",
-      title: "Improve Build Studio intake",
-      createdById: "user-1",
-      phase: "ideate",
-    });
-    mockPrisma.featureBuild.update.mockResolvedValue({});
-
-    const brief = {
-      title: "Improve Build Studio intake",
-      description: "Build Studio should turn business-language requests into a brief.",
-      portfolioContext: "Build Studio",
-      targetRoles: ["Operations lead"],
-      inputs: ["Reviewed plan"],
-      dataNeeds: "Business outcome, evidence, success signals",
-      acceptanceCriteria: ["A non-developer can review the generated brief."],
-    };
-
-    await updateFeatureBrief("FB-123", brief);
-
-    expect(mockPrisma.$transaction).toHaveBeenCalledWith(expect.any(Function));
-    expect(mockPrisma.featureBuild.update).toHaveBeenCalledWith({
-      where: { buildId: "FB-123" },
-      data: { brief },
-    });
-    expect(mockPrisma.businessBuildBrief.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { featureBuildId: "feature-build-row-1" },
-        create: expect.objectContaining({
-          briefId: "BBB-FB-123",
-          orgId: "org-1",
-          featureBuildId: "feature-build-row-1",
-          capabilityPackId: "build_studio_self_development",
-          status: "accepted",
-          acceptedByUserId: "user-1",
-          acceptedAt: expect.any(Date),
-        }),
-        update: expect.objectContaining({
-          businessOutcome: brief.description,
-          confidence: "high",
-          acceptedByUserId: "user-1",
-          acceptedAt: expect.any(Date),
-        }),
-      }),
-    );
   });
 
   it("updateBusinessBuildBrief persists business edits and accepts a complete brief", async () => {

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -9,6 +9,7 @@ import {
   generateBuildId,
   bumpVersion,
   normalizeHappyPathState,
+  type FeatureBrief,
   type BuildPhase,
   type VersionBump,
   type BuildDesignDoc,
@@ -53,7 +54,7 @@ import {
 import { admitRuntimeGuardedWork } from "@/lib/platform-runtime/work-admission";
 import { assertBuildPhaseInitiativeReadiness, checkBuildPhaseInitiativeReadiness } from "@/lib/build/build-entry-gate";
 import { assertFeatureBuildCompletion } from "@/lib/backlog/initiative-readiness/build-terminal-transition";
-export { updateFeatureBrief } from "@/lib/actions/build-feature-brief";
+import { updateFeatureBrief as updateFeatureBriefAction } from "@/lib/actions/build-feature-brief";
 // ─── Auth Guard ──────────────────────────────────────────────────────────────
 
 async function requireBuildAccess(): Promise<string> {
@@ -232,6 +233,14 @@ export async function approveBuildStart(
   }
 
   return ok({ approvedAt });
+}
+
+export async function updateFeatureBrief(
+  buildId: string,
+  brief: FeatureBrief,
+  options: { actorUserId?: string } = {},
+): Promise<void> {
+  return updateFeatureBriefAction(buildId, brief, options);
 }
 
 export async function updateBusinessBuildBrief(input: {

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -4,13 +4,11 @@ import { requireCapability } from "@/lib/actions/shared/guards";
 import { prisma, type Prisma } from "@dpf/db";
 import { revalidatePath } from "next/cache";
 import {
-  validateFeatureBrief,
   canTransitionPhase,
   checkPhaseGate,
   generateBuildId,
   bumpVersion,
   normalizeHappyPathState,
-  type FeatureBrief,
   type BuildPhase,
   type VersionBump,
   type BuildDesignDoc,
@@ -36,7 +34,6 @@ import {
   type BusinessBriefEvidenceKind,
   type BusinessBuildBriefSource,
   businessBuildBriefEditToPersistence,
-  legacyFeatureBuildBriefToBusinessBuildBriefInput,
 } from "@/lib/build/business-build-brief";
 import { routeAndCall } from "@/lib/routed-inference";
 import * as crypto from "crypto";
@@ -48,7 +45,6 @@ import {
 import type { UnifiedWipDb } from "@/lib/build/unified-wip-query";
 import { revalidatePortalContextForBuild } from "@/lib/portal-context/invalidation";
 import {
-  businessBriefJsonPayload,
   readPersistedSourceCurrency,
   derivePhaseHandoffContext,
   deriveResumeImplementationMode,
@@ -57,6 +53,7 @@ import {
 import { admitRuntimeGuardedWork } from "@/lib/platform-runtime/work-admission";
 import { assertBuildPhaseInitiativeReadiness, checkBuildPhaseInitiativeReadiness } from "@/lib/build/build-entry-gate";
 import { assertFeatureBuildCompletion } from "@/lib/backlog/initiative-readiness/build-terminal-transition";
+export { updateFeatureBrief } from "@/lib/actions/build-feature-brief";
 // ─── Auth Guard ──────────────────────────────────────────────────────────────
 
 async function requireBuildAccess(): Promise<string> {
@@ -235,76 +232,6 @@ export async function approveBuildStart(
   }
 
   return ok({ approvedAt });
-}
-
-// ─── Update Feature Brief ────────────────────────────────────────────────────
-
-export async function updateFeatureBrief(
-  buildId: string,
-  brief: FeatureBrief,
-): Promise<void> {
-  const userId = await requireBuildAccess();
-
-  const build = await prisma.featureBuild.findUnique({ where: { buildId } });
-  if (!build) throw new Error("Build not found");
-  if (build.createdById !== userId) throw new Error("Forbidden");
-  if (build.phase !== "ideate") throw new Error("Brief can only be updated during Ideate phase");
-
-  const validation = validateFeatureBrief(brief);
-  if (!validation.valid) throw new Error(validation.errors.join(", "));
-
-  const organization = await prisma.organization.findFirst({ select: { id: true } });
-  if (!organization) throw new Error("Organization is required before saving a business build brief");
-
-  const businessBrief = legacyFeatureBuildBriefToBusinessBuildBriefInput({
-    orgId: organization.id,
-    buildId: build.buildId,
-    featureBuildId: build.id,
-    title: build.title,
-    brief,
-    submittedByUserId: userId,
-  });
-  const acceptedFields = businessBrief.status === "accepted"
-    ? { acceptedByUserId: userId, acceptedAt: new Date() }
-    : { acceptedByUserId: null, acceptedAt: null };
-  const jsonPayload = businessBriefJsonPayload(businessBrief);
-
-  await prisma.$transaction(async (tx) => {
-    await tx.featureBuild.update({
-      where: { buildId },
-      data: { brief: brief as unknown as Prisma.InputJsonValue },
-    });
-
-    await tx.businessBuildBrief.upsert({
-      where: { featureBuildId: build.id },
-      create: {
-        ...businessBrief,
-        ...jsonPayload,
-        ...acceptedFields,
-      },
-      update: {
-        status: businessBrief.status,
-        intakeSource: businessBrief.intakeSource,
-        capabilityPackId: businessBrief.capabilityPackId,
-        backlogItemId: businessBrief.backlogItemId,
-        businessOutcome: businessBrief.businessOutcome,
-        affectedPeople: jsonPayload.affectedPeople,
-        affectedWorkflow: businessBrief.affectedWorkflow,
-        sourceEvidence: jsonPayload.sourceEvidence,
-        successSignals: businessBrief.successSignals,
-        constraints: businessBrief.constraints,
-        businessInterpretation: businessBrief.businessInterpretation,
-        technicalInterpretation: jsonPayload.technicalInterpretation,
-        riskProfile: jsonPayload.riskProfile,
-        hiveReadiness: jsonPayload.hiveReadiness,
-        openQuestions: businessBrief.openQuestions,
-        confidence: businessBrief.confidence,
-        confidenceRationale: businessBrief.confidenceRationale,
-        submittedByUserId: businessBrief.submittedByUserId,
-        ...acceptedFields,
-      },
-    });
-  });
 }
 
 export async function updateBusinessBuildBrief(input: {

--- a/apps/web/lib/mcp/build-lifecycle-handlers.test.ts
+++ b/apps/web/lib/mcp/build-lifecycle-handlers.test.ts
@@ -1,5 +1,73 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  actionUpdateFeatureBrief: vi.fn(),
+  findUnique: vi.fn(),
+  resolveActiveBuildId: vi.fn(),
+  updateBuildHappyPathState: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    featureBuild: { findUnique: mocks.findUnique },
+  },
+}));
+
+vi.mock("@/lib/actions/build", () => ({
+  updateFeatureBrief: mocks.actionUpdateFeatureBrief,
+}));
+
+vi.mock("@/lib/mcp/build-tool-helpers", () => ({
+  extractBuildIdHint: vi.fn(() => undefined),
+  logBuildActivity: vi.fn(),
+  resolveActiveBuildId: mocks.resolveActiveBuildId,
+  updateBuildHappyPathState: mocks.updateBuildHappyPathState,
+}));
+
+vi.mock("@/lib/build/build-entry-gate", () => ({
+  enforceBuildInitiativeReadiness: vi.fn(),
+}));
+
+vi.mock("@/lib/build/ideate-build-resolution", () => ({
+  resolveIdeateBuildForToolPure: vi.fn(),
+}));
+
+import { updateFeatureBrief } from "./build-lifecycle-handlers";
 import { formatUpdateFeatureBriefError } from "./update-feature-brief-error";
+
+describe("updateFeatureBrief (BI-7175C7DB)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveActiveBuildId.mockResolvedValue("FB-123");
+    mocks.findUnique.mockResolvedValue({
+      brief: null,
+      title: "Existing title",
+      description: "Existing description",
+      phase: "ideate",
+    });
+    mocks.actionUpdateFeatureBrief.mockResolvedValue(undefined);
+    mocks.updateBuildHappyPathState.mockResolvedValue(undefined);
+  });
+
+  it("passes the server-resolved MCP actor to the brief action", async () => {
+    const result = await updateFeatureBrief({
+      description: "Updated description",
+      targetRoles: ["Shelter staff"],
+      acceptanceCriteria: ["Staff can review the brief."],
+    }, "mcp-actor-1");
+
+    expect(result.success).toBe(true);
+    expect(mocks.actionUpdateFeatureBrief).toHaveBeenCalledWith(
+      "FB-123",
+      expect.objectContaining({
+        title: "Existing title",
+        description: "Updated description",
+        targetRoles: ["Shelter staff"],
+      }),
+      { actorUserId: "mcp-actor-1" },
+    );
+  });
+});
 
 describe("formatUpdateFeatureBriefError (BI-PIR-309fb74b / BI-PIR-f8c1640b)", () => {
   it("claims past-ideate only when the underlying error is the phase gate", () => {

--- a/apps/web/lib/mcp/build-lifecycle-handlers.ts
+++ b/apps/web/lib/mcp/build-lifecycle-handlers.ts
@@ -87,6 +87,10 @@ export async function updateFeatureBrief(params: Record<string, unknown>, userId
     await updateFeatureBrief(
       buildId,
       brief as import("@/lib/feature-build-types").FeatureBrief,
+      // The MCP server resolved this actor from the authenticated subject and
+      // active build. Preserve it across the session-less action boundary;
+      // updateFeatureBrief still enforces exact build ownership.
+      { actorUserId: userId },
     );
     await updateBuildHappyPathState(userId, {
       intake: {

--- a/docs/superpowers/plans/2026-08-29-build-brief-actor-handoff.md
+++ b/docs/superpowers/plans/2026-08-29-build-brief-actor-handoff.md
@@ -1,0 +1,40 @@
+---
+status: active
+backlogItem: BI-7175C7DB
+design: docs/superpowers/specs/2026-08-29-build-brief-actor-handoff-design.md
+---
+
+# Build brief actor handoff implementation plan
+
+## Atomic deliverable
+
+One independently shippable repair maps entirely to `BI-7175C7DB`: preserve
+the governed MCP actor across `update_feature_brief` while keeping the action's
+existing UI authentication and fail-closed checks.
+
+| Deliverable | Backlog item | Objectives | Acceptance criteria | Files / verification |
+| --- | --- | --- | --- | --- |
+| Explicit brief-write actor handoff | BI-7175C7DB | OBJ-BBAH-001, OBJ-BBAH-002 | AC-BBAH-001, AC-BBAH-002, AC-BBAH-003, AC-BBAH-004 | `apps/web/lib/mcp/build-lifecycle-handlers.ts`, `apps/web/lib/actions/build.ts`, focused handler/action tests |
+
+## Test-first steps
+
+1. Add a red action test proving an explicit owner actor succeeds without
+   session lookup, plus a red non-owner test proving `Forbidden` remains.
+2. Add a red handler test proving the governed `userId` is forwarded as the
+   actor while the existing partial-brief merge remains intact.
+3. Add the optional action options object and pass it only from the MCP handler.
+4. Run the focused action and handler suites, adjacent build-lifecycle pack
+   tests, web typecheck, source-policy/preflight guards, and documentation
+   impact checks.
+5. Obtain semantic review and governed exact-tree verification, create a
+   DCO-signed commit, push, and open one protected PR.
+6. After protected merge and canonical deployment, replay the original Pet
+   Rescue brief update through the supported MCP path and verify the resulting
+   brief/taxonomy state before resuming `FB-668407A5`.
+
+## Refactoring allowance
+
+Keep the change deliberately narrow. Use an options object rather than a third
+positional identity argument so future action options remain readable, but do
+not generalize authorization across unrelated build actions in this repair.
+

--- a/docs/superpowers/specs/2026-08-29-build-brief-actor-handoff-design.md
+++ b/docs/superpowers/specs/2026-08-29-build-brief-actor-handoff-design.md
@@ -1,0 +1,74 @@
+---
+status: active
+backlogItem: BI-7175C7DB
+---
+
+# Build brief actor handoff
+
+## Problem
+
+`update_feature_brief` is a governed MCP tool. Its handler already receives the
+resolved actor and resolves only a build that actor owns, but it calls the
+session-oriented `updateFeatureBrief` action without forwarding that actor. The
+action consequently calls `auth()` in a background MCP execution and returns
+`Unauthorized` before its existing build-ownership check can run.
+
+This is reproducible on `FB-668407A5`: the authenticated Build Studio coworker
+can inspect and discuss the brief, while its direct `update_feature_brief` call
+fails with `Unauthorized` outside an HTTP request session.
+
+## Objectives
+
+**OBJ-BBAH-001:** A governed build-lifecycle MCP call preserves the exact
+server-resolved actor through the feature-brief write boundary without relying
+on an HTTP session.
+
+**OBJ-BBAH-002:** Interactive callers retain session authentication, and both
+paths retain the existing owner, phase, validation, organization, and atomic
+legacy/business-brief persistence checks.
+
+## Acceptance criteria
+
+| Acceptance criterion | Objective | Required evidence |
+| --- | --- | --- |
+| AC-BBAH-001: The MCP handler passes its resolved `userId` to `updateFeatureBrief`. | OBJ-BBAH-001 | Handler regression test |
+| AC-BBAH-002: A supplied actor skips session lookup but must still equal `FeatureBuild.createdById`. | OBJ-BBAH-001, OBJ-BBAH-002 | Action owner/non-owner tests |
+| AC-BBAH-003: Omitting the actor preserves the existing session-authenticated UI call shape. | OBJ-BBAH-002 | Existing action test plus explicit session assertion |
+| AC-BBAH-004: Brief merge semantics, Ideate-only validation, and dual brief persistence are unchanged. | OBJ-BBAH-002 | Existing governed build tests and focused regression suite |
+
+## Existing substrate and benchmarking
+
+The repository already solves the same sessionless execution boundary in
+`shipBuild`: an optional `actorUserId` is accepted by the action, while the
+handler passes the resolved MCP actor and UI callers omit it. The action still
+checks `FeatureBuild.createdById` against the resulting actor. Reusing that
+contract is preferable to adding a second authorization helper or weakening
+`requireBuildAccess`.
+
+Two alternatives were rejected:
+
+1. Making `requireBuildAccess` infer a background actor would mix HTTP-session
+   and MCP authority and make the caller identity implicit.
+2. Moving brief persistence into the MCP handler would duplicate validation and
+   transaction behavior owned by the action.
+
+## Architecture
+
+Extend `updateFeatureBrief` with a single optional options object containing
+`actorUserId`. Resolve `userId` as the supplied actor or the existing
+`requireBuildAccess()` result. The MCP handler supplies `{ actorUserId: userId }`.
+No schema, grant, capability, database, UI, or response-shape change is needed.
+
+## Security and failure behavior
+
+The explicit actor is trusted only because it is produced by the governed tool
+handler after token, subject, organization, capability, and active-build
+resolution. It is not accepted from model parameters. A missing build,
+non-owner actor, non-Ideate build, invalid brief, or missing organization still
+fails closed before persistence.
+
+## Documentation impact
+
+No user-facing documentation changes are needed. This restores the documented
+`update_feature_brief` behavior and introduces no new operator or UI contract.
+


### PR DESCRIPTION
## Summary

Restore `update_feature_brief` for governed MCP/background execution by carrying the server-resolved actor into the existing feature-brief action. The action retains exact build-owner, Ideate-phase, validation, organization, and atomic persistence checks; UI callers continue to authenticate through their HTTP session.

## Changes

- Extract the feature-brief action from the oversized build action module into a focused server-action module.
- Add an optional server-owned actor option, matching the existing `shipBuild` boundary pattern.
- Pass the authenticated MCP actor from the build-lifecycle handler; model parameters cannot supply it.
- Add red-first owner, non-owner, session fallback, and handler forwarding regressions.
- Keep the extracted action behind an explicit async facade; direct re-export from a `"use server"` module is rejected by the production bundler.
- Add canonical design and atomic implementation-plan artifacts for BI-7175C7DB.

## Test plan

- [x] **Source-only verification**
  - [x] `pnpm --filter web exec vitest run lib/actions/build-feature-brief.test.ts lib/actions/build-governed.test.ts lib/mcp/build-lifecycle-handlers.test.ts lib/mcp/packs/build-lifecycle-pack.test.ts` — 38/38 PASS
  - [x] `pnpm --filter web typecheck` — PASS
  - [x] `pnpm --filter web build` — PASS after reproducing and repairing the protected Production Build failure
  - [x] `node scripts/check-module-size.mjs` — PASS; both ratcheted modules shrink
  - [x] `pnpm pregate:preflight` — 53/53 guards PASS
  - [x] `pnpm gate:context` — reviewed against the final diff
- [x] Fresh repair-round semantic receipt `cmtdvbax5001201qxjvchulp4` — INCONCLUSIVE with zero issues solely `local-ci-active-capacity-reservation`; no PASS inferred, exact tree `adf798d4bc72e40981b3713033762ece5d70fe06`
- [ ] Protected GitHub and merge-group checks — mandatory after PR creation
- [ ] Post-deployment canonical-runtime replay of `update_feature_brief` for `FB-668407A5`

### Verification evidence

The original red fixture produced exactly three failures before implementation: background owner hit `Unauthorized`, explicit non-owner incorrectly followed the session actor, and the handler omitted the actor option. Protected CI then exposed a production-only Turbopack failure because `build.ts` directly re-exported the extracted server action; the new static regression failed before the repair. The explicit async facade is now covered, affected tests pass, the full local Next.js production build passes, and web typecheck, module-size ratchet, DCO, diff check, and all 53 deterministic preflight guards pass.

Readiness decision `IRD-0AF84C8E7C0B` returned a research recovery route without `initiativeReviewBinding` or `requiredToolNames`; no reviewer was dispatched and no receipt was inferred. The exact atomic plan writer was also attempted and returned `gate-not-authorized`. Both refusals and the bounded operator bootstrap are durably ledgered on `WC-D703BDA3`.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed
- [x] `pnpm run pregate:preflight` passed
- [x] Exact local-CI bypass is explicitly attested below; no PASS is inferred
- [x] `pnpm pr:ready -- --pr-body-file` returned READY before opening

Local-CI-Override: operator-emergency: operator authorized bypass of the known serialized local-CI bottleneck; WC-D703BDA3 records exact head `240aef7734c95ddce7b47313624c331a67d27def`, rationale, affected tests, typecheck, production build, 53 guards, the inconclusive semantic receipt with no PASS inference, and mandatory protected CI compensation

Docs-Impact-Decision: Internal authorization-boundary repair and module extraction; no user-facing route or workflow changes.

## Related issues / Epic

- BI-7175C7DB
- EP-F09D63B3

## Overlap sweep

Fresh open-PR and recent-main sweeps found no overlapping `update_feature_brief` actor-handoff repair. The Workroom is exclusively owned as `WC-D703BDA3`.

## Notes for the reviewer

- The explicit actor is accepted only from the governed handler, never from model parameters.
- No schema, capability, grant, route, response shape, or UI contract changes.
- The live Pet Rescue build remains source-pure until this repair is protected-merged, released, and deployed.
