### PR TITLE
fix(self-upgrade): persist admission before dispatch (BI-3FD07259)

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.tsx
@@ -222,6 +222,8 @@ export default async function SelfUpgradePage() {
               latestRun={clientProps.latestRun}
               quiescence={clientProps.quiescence}
               jobEngine={clientProps.jobEngine}
+              targetSha={effectiveStatus.targetSha}
+              targetTag={effectiveStatus.targetTag}
             />
           }
         />

--- a/apps/web/components/ops/SelfUpgradeTriggerControl.swap-resilience.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeTriggerControl.swap-resilience.test.tsx
@@ -124,7 +124,7 @@ describe("isExpectedDuringSwap", () => {
 // ─── Forced trigger severed by the swap ────────────────────────────────────
 
 describe("SelfUpgradeTriggerControl – forced upgrade swap resilience", () => {
-  it("shows a reconnecting state (not the crash boundary) when the forced upgrade swaps the portal mid-request", async () => {
+  it("keeps an interrupted trigger admission latched until durable server state changes", async () => {
     triggerMock.mockRejectedValue(makeE394());
 
     render(<SelfUpgradeTriggerControl {...baseProps} />);
@@ -133,17 +133,15 @@ describe("SelfUpgradeTriggerControl – forced upgrade swap resilience", () => {
     fireEvent.click(screen.getByRole("button", { name: /upgrade now/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/Applying the upgrade/i)).toBeInTheDocument();
+      expect(screen.getByText(/Admission response interrupted:/i)).toBeInTheDocument();
     });
 
-    // The raw Next transport message must never reach the operator as an error.
-    expect(
-      screen.queryByText(/An unexpected response was received from the server/i),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText(/Not queued/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /upgrade now/i })).toBeDisabled();
+    expect(screen.getByText(/do not click again/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Not admitted:/i)).not.toBeInTheDocument();
   });
 
-  it("surfaces a genuine (non-swap) trigger failure inline instead of reconnecting", async () => {
+  it("treats every thrown trigger response as indeterminate because admission may already be durable", async () => {
     triggerMock.mockRejectedValue(new Error("Unauthorized"));
 
     render(<SelfUpgradeTriggerControl {...baseProps} />);
@@ -151,10 +149,11 @@ describe("SelfUpgradeTriggerControl – forced upgrade swap resilience", () => {
     fireEvent.click(screen.getByRole("button", { name: /upgrade now/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/Not queued:/i)).toBeInTheDocument();
+      expect(screen.getByText(/Admission response interrupted:/i)).toBeInTheDocument();
     });
     expect(screen.getByText(/Unauthorized/i)).toBeInTheDocument();
     expect(screen.queryByText(/Applying the upgrade/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /upgrade now/i })).toBeDisabled();
   });
 
   it("treats a severed Force-now request during a drain as applying, not a crash", async () => {
@@ -178,7 +177,7 @@ describe("SelfUpgradeTriggerControl – forced upgrade swap resilience", () => {
     });
   });
 
-  it("clears the reconnecting banner once the swapped-in portal returns fresh data", async () => {
+  it("clears the indeterminate admission latch once a durable run appears", async () => {
     triggerMock.mockRejectedValue(makeE394());
 
     const { rerender } = render(<SelfUpgradeTriggerControl {...baseProps} />);
@@ -187,7 +186,7 @@ describe("SelfUpgradeTriggerControl – forced upgrade swap resilience", () => {
     fireEvent.click(screen.getByRole("button", { name: /upgrade now/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/Applying the upgrade/i)).toBeInTheDocument();
+      expect(screen.getByText(/Admission response interrupted:/i)).toBeInTheDocument();
     });
 
     // The poll reaches the new container: a fresh run is now visible.
@@ -201,7 +200,7 @@ describe("SelfUpgradeTriggerControl – forced upgrade swap resilience", () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByText(/Applying the upgrade/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Admission response interrupted:/i)).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/components/ops/SelfUpgradeTriggerControl.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeTriggerControl.test.tsx
@@ -167,6 +167,36 @@ describe("SelfUpgradeTriggerControl – running", () => {
     expect(html).not.toContain('aria-label="Upgrade now"');
   });
 
+  it.each([
+    ["admission_pending", "waiting for dispatch"],
+    ["dispatching", "dispatching to the worker"],
+    ["indeterminate", "dispatch outcome is being reconciled"],
+  ])("projects durable %s state with the admitted run identity", (dispatchStatus, copy) => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeTriggerControl
+        {...baseProps}
+        latestRun={makeRun("pending", { dispatchStatus, startedAt: null, completedAt: null })}
+      />,
+    );
+    expect(html).toContain("SUR-0001 admitted");
+    expect(html).toContain(copy);
+    expect(html).not.toContain('aria-label="Upgrade now"');
+  });
+
+  it("projects a durable pre-dispatch failure with its run identity", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeTriggerControl
+        {...baseProps}
+        latestRun={makeRun("failed", {
+          dispatchStatus: "dispatch_failed",
+          dispatchError: "queue-dispatch-refused",
+        })}
+      />,
+    );
+    expect(html).toContain("SUR-0001 was not dispatched");
+    expect(html).toContain("queue-dispatch-refused");
+  });
+
   it("surfaces Force now / Abort controls when the portal is draining (BI-4F3B2FA9)", () => {
     const quiescence = {
       level: "draining" as const,
@@ -218,10 +248,10 @@ describe("SelfUpgradeTriggerControl – trigger control", () => {
 // ─── Loading state ────────────────────────────────────────────────────────────
 
 describe("SelfUpgradeTriggerControl – loading", () => {
-  it("shows Upgrading... text when pending", () => {
+  it("shows durable admission text when pending", () => {
     shared.isPending = true;
     const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
-    expect(html).toContain("Upgrading...");
+    expect(html).toContain("Admitting…");
     expect(html).not.toContain(">Upgrade now<");
   });
 
@@ -241,7 +271,7 @@ describe("SelfUpgradeTriggerControl – loading", () => {
     shared.isPending = true;
     const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
     expect(html).toContain('data-upgrade-starting="true"');
-    expect(html).toContain("No need to click again");
+    expect(html).toContain("durable run will appear");
   });
 
   it("does not show the 'starting' hint once a run is already running", () => {
@@ -256,20 +286,20 @@ describe("SelfUpgradeTriggerControl – loading", () => {
 // ─── Success feedback ─────────────────────────────────────────────────────────
 
 describe("SelfUpgradeTriggerControl – success feedback", () => {
-  it("shows Upgrade queued. when trigger succeeds", () => {
+  it("shows durable admission feedback when trigger succeeds", () => {
     shared.triggerResult = { queued: true };
     const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
-    expect(html).toContain("Upgrade queued.");
+    expect(html).toContain("Upgrade admitted");
   });
 });
 
 // ─── Error feedback ───────────────────────────────────────────────────────────
 
 describe("SelfUpgradeTriggerControl – error feedback", () => {
-  it("shows Not queued message when trigger returns not queued", () => {
+  it("shows Not admitted when the durable request is refused", () => {
     shared.triggerResult = { queued: false, reason: "disabled" };
     const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
-    expect(html).toContain("Not queued:");
+    expect(html).toContain("Not admitted:");
   });
 
   it("shows the specific reason for not queuing", () => {

--- a/apps/web/components/ops/SelfUpgradeTriggerControl.tsx
+++ b/apps/web/components/ops/SelfUpgradeTriggerControl.tsx
@@ -39,6 +39,8 @@ type Props = {
   latestRun: LatestRun | null;
   quiescence?: QuiescenceActivity | null;
   jobEngine?: JobEngineHealth;
+  targetSha?: string | null;
+  targetTag?: string | null;
 };
 
 export default function SelfUpgradeTriggerControl({
@@ -49,6 +51,8 @@ export default function SelfUpgradeTriggerControl({
   latestRun: initialLatestRun,
   quiescence: initialQuiescence,
   jobEngine: initialJobEngine,
+  targetSha,
+  targetTag,
 }: Props) {
   const router = useRouter();
   const live = useOptionalSelfUpgradeLive();
@@ -57,10 +61,14 @@ export default function SelfUpgradeTriggerControl({
   const jobEngine = live?.snapshot.jobEngine ?? initialJobEngine;
   const [isPending, startTransition] = useTransition();
   const [override, setOverride] = useState(false);
-  const [justQueued, setJustQueued] = useState(false);
-  const [triggerResult, setTriggerResult] = useState<{ queued: boolean; reason?: string } | null>(
-    null,
-  );
+  const [triggerResult, setTriggerResult] = useState<{
+    queued: boolean;
+    reason?: string;
+    runId?: string;
+    dispatchStatus?: string;
+    uncertain?: boolean;
+  } | null>(null);
+  const [admissionUncertain, setAdmissionUncertain] = useState(false);
   const [forceConfirm, setForceConfirm] = useState(false);
   const [abortConfirm, setAbortConfirm] = useState(false);
   const [inFlightError, setInFlightError] = useState<string | null>(null);
@@ -69,34 +77,24 @@ export default function SelfUpgradeTriggerControl({
   // poll alive) instead of letting the page paint the global crash screen.
   const [restarting, setRestarting] = useState(false);
   const restartBaselineRef = useRef<string | null>(null);
+  const admissionBaselineRef = useRef<string | null>(null);
 
   const draining = !!quiescence && quiescence.level !== "normal";
   const queuedRun = latestRun?.status === "queued" || latestRun?.status === "pending";
   const upgradeInFlight = queuedRun || latestRun?.status === "running" || draining;
-  const triggerBusy = isPending || justQueued;
+  const triggerBusy = isPending || admissionUncertain;
   const updateAvailable = actionState === SELF_UPGRADE_ACTION_STATE.UPDATE_AVAILABLE;
-
-  // The manual trigger only *queues* an upgrade: the server action returns
-  // `{ queued: true }` in well under a second, but the worker still has to
-  // fetch + compare SHAs before the run flips to "running". Hold a
-  // "Starting…" state until the run actually appears, poll so progress shows
-  // up on its own, and time out as a safety net if the queued event never
-  // materialises (e.g. skipped for cooldown).
-  useEffect(() => {
-    if (justQueued && upgradeInFlight) setJustQueued(false);
-  }, [justQueued, upgradeInFlight]);
-
-  useEffect(() => {
-    if (!justQueued) return;
-    const timeout = setTimeout(() => setJustQueued(false), 45_000);
-    return () => clearTimeout(timeout);
-  }, [justQueued]);
 
   // A compact fingerprint of the server-derived state. When it changes after
   // a swap-induced disconnect, the new container has answered and the
   // reconnect banner can clear.
   function serverSignature(): string {
-    return [latestRun?.runId ?? "", latestRun?.status ?? "", quiescence?.level ?? ""].join("|");
+    return [
+      latestRun?.runId ?? "",
+      latestRun?.status ?? "",
+      latestRun?.dispatchStatus ?? "",
+      quiescence?.level ?? "",
+    ].join("|");
   }
 
   useEffect(() => {
@@ -122,7 +120,6 @@ export default function SelfUpgradeTriggerControl({
   function enterRestarting() {
     restartBaselineRef.current = serverSignature();
     setRestarting(true);
-    setJustQueued(true);
     refreshStatus();
   }
 
@@ -140,21 +137,44 @@ export default function SelfUpgradeTriggerControl({
     setTriggerResult(null);
     setInFlightError(null);
     const force = override;
+    admissionBaselineRef.current = serverSignature();
     startTransition(async () => {
       try {
-        const result = await triggerSelfUpgrade(force ? { force: true } : undefined);
+        const result = await triggerSelfUpgrade({
+          ...(force ? { force: true } : {}),
+          expectedTargetSha: targetSha,
+          expectedTargetTag: targetTag,
+        });
         setTriggerResult(result);
-        if (result.queued) setJustQueued(true);
+        setAdmissionUncertain(false);
+        admissionBaselineRef.current = null;
         refreshStatus();
       } catch (err) {
-        if (isExpectedDuringSwap(err)) {
-          enterRestarting();
-        } else {
-          setTriggerResult({ queued: false, reason: getErrorMessage(err) || "trigger failed" });
-        }
+        // A severed trigger response is ambiguous: the server may already
+        // have persisted the admission even though the browser never received
+        // its result. Keep the mutation latched until durable server state
+        // changes. Force/abort requests are different because they already
+        // bind an existing run and can use the bounded swap-reconnect state.
+        setAdmissionUncertain(true);
+        setTriggerResult({
+          queued: false,
+          uncertain: true,
+          reason: getErrorMessage(err) || "The admission response was interrupted.",
+        });
+        refreshStatus();
       }
     });
   }
+
+  useEffect(() => {
+    if (!admissionUncertain || admissionBaselineRef.current === null) return;
+    if (serverSignature() !== admissionBaselineRef.current) {
+      admissionBaselineRef.current = null;
+      setAdmissionUncertain(false);
+      setTriggerResult(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [admissionUncertain, latestRun?.runId, latestRun?.status, latestRun?.dispatchStatus]);
 
   // BI-4F3B2FA9: escalate the active drain to forced — coordinator bypasses
   // all blockers on its next tick (~5s) and swaps, without restarting the run.
@@ -230,6 +250,16 @@ export default function SelfUpgradeTriggerControl({
       )}
 
       <SelfUpgradeJobEngineHealthAlert jobEngine={jobEngine} />
+
+      {latestRun?.dispatchStatus === "dispatch_failed" && (
+        <div
+          className="rounded-lg border border-[var(--dpf-destructive)]/30 bg-[var(--dpf-destructive)]/10 p-3 text-sm text-[var(--dpf-destructive)]"
+          role="status"
+          data-upgrade-dispatch-failed="true"
+        >
+          Upgrade admission {latestRun.runId} was not dispatched. {latestRun.dispatchError ?? "Review job-engine health before trying again."}
+        </div>
+      )}
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
@@ -322,7 +352,13 @@ export default function SelfUpgradeTriggerControl({
                 data-upgrade-inflight="true"
               >
                 {queuedRun
-                  ? "Upgrade queued — waiting for the worker…"
+                  ? latestRun?.dispatchStatus === "indeterminate"
+                    ? `Upgrade ${latestRun.runId} admitted — dispatch outcome is being reconciled…`
+                    : latestRun?.dispatchStatus === "dispatching"
+                      ? `Upgrade ${latestRun.runId} admitted — dispatching to the worker…`
+                      : latestRun?.dispatchStatus === "admission_pending"
+                        ? `Upgrade ${latestRun.runId} admitted — waiting for dispatch…`
+                        : "Upgrade queued — waiting for the worker…"
                   : "Upgrade in progress…"}
               </span>
             )
@@ -353,10 +389,8 @@ export default function SelfUpgradeTriggerControl({
                 className="px-4 py-2 text-sm font-semibold rounded-lg bg-[var(--dpf-accent)] text-white border border-[var(--dpf-accent)] shadow-sm hover:opacity-90 transition-opacity disabled:opacity-50"
               >
                 {isPending
-                  ? "Upgrading..."
-                  : justQueued
-                    ? "Starting…"
-                    : override
+                  ? "Admitting…"
+                  : override
                       ? "Force upgrade now"
                       : "Upgrade now"}
               </button>
@@ -375,26 +409,32 @@ export default function SelfUpgradeTriggerControl({
         </div>
       </div>
 
-      {updateAvailable && triggerBusy && latestRun?.status !== "running" && !queuedRun && (
+      {updateAvailable && isPending && latestRun?.status !== "running" && !queuedRun && (
         <div
           className="text-xs text-[var(--dpf-muted)]"
           data-upgrade-starting="true"
           aria-live="polite"
         >
-          Upgrade starting — the worker is checking for a new build. This can take
-          a few seconds; progress will appear below. No need to click again.
+          Recording this upgrade before dispatch. Keep this page open; the durable
+          run will appear below as soon as admission commits.
         </div>
       )}
 
       {updateAvailable && triggerResult && (
         <div
           className={`p-3 rounded-lg text-sm ${
-            triggerResult.queued
+            triggerResult.uncertain
+              ? "bg-[var(--dpf-info)]/10 text-[var(--dpf-text)] border border-[var(--dpf-info)]/30"
+              : triggerResult.queued
               ? "bg-[var(--dpf-success)]/10 text-[var(--dpf-success)] border border-[var(--dpf-success)]/30"
               : "bg-[var(--dpf-destructive)]/10 text-[var(--dpf-destructive)] border border-[var(--dpf-destructive)]/30"
           }`}
         >
-          {triggerResult.queued ? "Upgrade queued." : `Not queued: ${triggerResult.reason}`}
+          {triggerResult.uncertain
+            ? `Admission response interrupted: ${triggerResult.reason} The server record is being checked; do not click again.`
+            : triggerResult.queued
+            ? `Upgrade admitted${triggerResult.runId ? ` as ${triggerResult.runId}` : ""}. Dispatch is tracked by this run; do not click again.`
+            : `Not admitted: ${triggerResult.reason}`}
         </div>
       )}
     </div>

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -9,6 +9,7 @@ import {
 import { isMeasurementRuntime, settleBootSync } from "@/lib/runtime/measurement-runtime";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { sweepOrphanedPromoterContainers } from "@/lib/self-upgrade/promoter-sweep";
+import { reconcileSelfUpgradeAdmissions } from "@/lib/self-upgrade/admission";
 /**
  * Logs a deprecation notice when HIVE_CONTRIBUTION_TOKEN is set in the
  * environment. Exported so the instrumentation module's startup behavior
@@ -1000,9 +1001,7 @@ export async function register() {
       // ("portal_quiescing") forever. Must run before reconciliation.
       void resetStuckQuiescenceLevelOnBoot();
 
-      // Close the loop on any self-upgrade run whose orchestrator died mid-swap
-      // (a real upgrade recreates this very container). Records succeeded when we
-      // came up on the target SHA; fails orphans so triggers aren't blocked.
+      void reconcileSelfUpgradeAdmissions().catch((error) => console.error("[self-upgrade] admission reconcile failed", error));
       void reconcileSelfUpgradeRunsOnBoot();
 
       // Periodic safety net — cron-independent (the boot reconcile above and the
@@ -1014,6 +1013,7 @@ export async function register() {
       // Staleness-guarded so a legitimately in-flight upgrade is never touched.
       setInterval(
         () => {
+          void reconcileSelfUpgradeAdmissions().catch((error) => console.error("[self-upgrade] admission reconcile failed", error));
           void reconcileSelfUpgradeRunsOnBoot(console, { staleAfterMs: 30 * 60 * 1000 });
           // Backstop: force-remove any promoter container orphaned by a portal
           // restart that killed runPromoter's own timeout timer (BI-3EC7FDB0).

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -54,9 +54,12 @@ vi.mock("@/lib/self-upgrade/completion", () => ({
 vi.mock("@/lib/self-upgrade/runtime-image-identity", () => ({ readCurrentContainerConfigDigest: vi.fn().mockResolvedValue(`sha256:${"a".repeat(64)}`) }));
 vi.mock("@/lib/self-upgrade/run-store", () => ({
   createRun: vi.fn(),
-  failRun: vi.fn(),
   getLatestRun: vi.fn(),
   getLatestSucceededRun: vi.fn(),
+}));
+vi.mock("@/lib/self-upgrade/admission", () => ({
+  resolveCurrentSelfUpgradeTarget: vi.fn(),
+  admitSelfUpgrade: vi.fn(),
 }));
 
 vi.mock("@/lib/self-upgrade/impact", () => ({
@@ -175,6 +178,10 @@ import { readSelfUpgradeSupport } from "@/lib/self-upgrade/support";
 import { loadReleaseInstallContext, resolveReleaseUpgradeCandidate } from "@/lib/self-upgrade/release-target";
 import { createRun, getLatestRun, getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
 import {
+  admitSelfUpgrade,
+  resolveCurrentSelfUpgradeTarget,
+} from "@/lib/self-upgrade/admission";
+import {
   getCurrentImpactSummaryId,
   loadRunImpactDigests,
   loadRunImpactSummary,
@@ -213,6 +220,17 @@ beforeEach(() => {
   vi.mocked(loadReleaseInstallContext).mockResolvedValue(null);
   vi.mocked(getLatestRun).mockResolvedValue(null);
   vi.mocked(getLatestSucceededRun).mockResolvedValue(null);
+  vi.mocked(resolveCurrentSelfUpgradeTarget).mockResolvedValue({
+    targetKind: "git-source",
+    targetSha: "b".repeat(40),
+    targetTag: null,
+  });
+  vi.mocked(admitSelfUpgrade).mockResolvedValue({
+    admitted: true,
+    disposition: "created",
+    runId: "SUR-QUEUED1",
+    dispatchStatus: "admission_pending",
+  });
   vi.mocked(createRun).mockResolvedValue({
     ...mockRun,
     runId: "SUR-QUEUED1",
@@ -903,19 +921,17 @@ describe("triggerSelfUpgrade – access control", () => {
 // ─── triggerSelfUpgrade – dispatch ───────────────────────────────────────────
 
 describe("triggerSelfUpgrade – dispatch", () => {
-  it("creates a durable queued run before sending the worker event", async () => {
+  it("returns the durable admission before queue dispatch", async () => {
     const result = await triggerSelfUpgrade();
 
-    expect(createRun).toHaveBeenCalledWith({
+    expect(admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({
       triggeredBy: "manual:user-ops-1",
       impactSummaryId: null,
-    });
-    expect(vi.mocked(inngest.send)).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ runId: "SUR-QUEUED1" }),
-      }),
-    );
-    expect(result).toEqual({ queued: true, runId: "SUR-QUEUED1" });
+      target: expect.objectContaining({ targetSha: "b".repeat(40) }),
+    }));
+    expect(createRun).not.toHaveBeenCalled();
+    expect(vi.mocked(inngest.send)).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ queued: true, admitted: true, runId: "SUR-QUEUED1" });
   });
 
   it("attaches the reviewed impact summary to the run when one exists", async () => {
@@ -923,45 +939,30 @@ describe("triggerSelfUpgrade – dispatch", () => {
 
     await triggerSelfUpgrade();
 
-    expect(createRun).toHaveBeenCalledWith({
+    expect(admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({
       triggeredBy: "manual:user-ops-1",
       impactSummaryId: "UIS-77",
-    });
+    }));
   });
 
-  it("sends self-upgrade event to inngest", async () => {
+  it("binds the manual actor and force posture in admission", async () => {
     await triggerSelfUpgrade();
 
-    expect(vi.mocked(inngest.send)).toHaveBeenCalledWith(
-      expect.objectContaining({ name: "ops/self-upgrade.run" }),
-    );
-  });
-
-  it("includes manual triggeredBy with user id", async () => {
-    await triggerSelfUpgrade();
-
-    expect(vi.mocked(inngest.send)).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          triggeredBy: `manual:${mockSession.user.id}`,
-        }),
-      }),
-    );
+    expect(admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({
+      triggeredBy: `manual:${mockSession.user.id}`,
+      requestedForce: false,
+    }));
   });
 
   it("passes dryRun: true when dryRun option is set", async () => {
     await triggerSelfUpgrade({ dryRun: true });
 
-    expect(vi.mocked(inngest.send)).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ dryRun: true }),
-      }),
-    );
+    expect(admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
   });
 
   it("returns { queued: true }", async () => {
     const result = await triggerSelfUpgrade();
-    expect(result).toEqual({ queued: true, runId: "SUR-QUEUED1" });
+    expect(result).toMatchObject({ queued: true, admitted: true, runId: "SUR-QUEUED1" });
   });
 });
 
@@ -975,8 +976,8 @@ describe("triggerSelfUpgrade – manual is not window-gated", () => {
 
     const result = await triggerSelfUpgrade();
 
-    expect(result).toEqual({ queued: true, runId: "SUR-QUEUED1" });
-    expect(vi.mocked(inngest.send)).toHaveBeenCalled();
+    expect(result).toMatchObject({ queued: true, admitted: true, runId: "SUR-QUEUED1" });
+    expect(admitSelfUpgrade).toHaveBeenCalled();
     // It doesn't even consult the window for a manual trigger.
     expect(vi.mocked(isUpgradeWindowOpen)).not.toHaveBeenCalled();
   });
@@ -984,19 +985,18 @@ describe("triggerSelfUpgrade – manual is not window-gated", () => {
   it("emergency override dispatches with force (bypasses the quiescence drain)", async () => {
     const result = await triggerSelfUpgrade({ force: true });
 
-    expect(result).toEqual({ queued: true, runId: "SUR-QUEUED1" });
-    expect(vi.mocked(inngest.send)).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ force: true }),
-      }),
+    expect(result).toMatchObject({ queued: true, admitted: true, runId: "SUR-QUEUED1" });
+    expect(admitSelfUpgrade).toHaveBeenCalledWith(
+      expect.objectContaining({ requestedForce: true }),
     );
   });
 
   it("does not include force in the event for a normal manual trigger", async () => {
     await triggerSelfUpgrade();
 
-    const sent = vi.mocked(inngest.send).mock.calls[0][0] as { data: Record<string, unknown> };
-    expect(sent.data).not.toHaveProperty("force");
+    expect(admitSelfUpgrade).toHaveBeenCalledWith(
+      expect.objectContaining({ requestedForce: false }),
+    );
   });
 });
 
@@ -1091,7 +1091,7 @@ describe("triggerSelfUpgrade – guard: invalid-config", () => {
 
     const result = await triggerSelfUpgrade({ dryRun: true });
 
-    expect(result).toEqual({ queued: true, runId: "SUR-QUEUED1" });
-    expect(vi.mocked(inngest.send)).toHaveBeenCalled();
+    expect(result).toMatchObject({ queued: true, admitted: true, runId: "SUR-QUEUED1" });
+    expect(admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
   });
 });

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -17,7 +17,8 @@ import { isShaFresh } from "@/lib/self-upgrade/version";
 import { getDeployedSha } from "@/lib/self-upgrade/completion";
 import { readCurrentContainerConfigDigest } from "@/lib/self-upgrade/runtime-image-identity";
 import { getJobEngineHealth } from "@/lib/queue/job-engine-health";
-import { createRun, failRun, getLatestRun, getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
+import { getLatestRun, getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
+import { admitSelfUpgrade, resolveCurrentSelfUpgradeTarget } from "@/lib/self-upgrade/admission";
 import {
   getCurrentImpactSummaryId,
   loadRunImpactDigest,
@@ -48,10 +49,8 @@ import {
 } from "@/lib/self-upgrade/quiescence";
 import { getCooldownUntil } from "@/lib/self-upgrade/cooldown";
 import { loadPlatformVersion } from "@/lib/platform/version";
-import { inngest } from "@/lib/queue/inngest-client";
 import { readBuildPipelineLimit } from "@/lib/queue/admission";
 import { buildAdmissionSnapshot } from "@/lib/queue/admission-observability";
-import { SELF_UPGRADE_EVENT } from "@/lib/queue/functions/self-upgrade";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 async function requireOpsAccess(): Promise<string> {
@@ -772,7 +771,11 @@ export async function getSelfUpgradeStatus() {
   };
 }
 
-export async function triggerSelfUpgrade(opts?: { dryRun?: boolean; force?: boolean }) {
+export async function triggerSelfUpgrade(opts?: {
+  dryRun?: boolean; force?: boolean;
+  expectedTargetSha?: string | null;
+  expectedTargetTag?: string | null;
+}) {
   const userId = await requireOpsAccess();
   const triggeredBy = `manual:${userId}`;
   const config = await getSelfUpgradeConfig();
@@ -804,33 +807,30 @@ export async function triggerSelfUpgrade(opts?: { dryRun?: boolean; force?: bool
     return { queued: false, reason: "already-queued", runId: latestRun.runId } as const;
   }
 
+  const target = await resolveCurrentSelfUpgradeTarget();
+  if (!target) return { queued: false, reason: "target-unavailable" } as const;
+  const shaChanged = opts?.expectedTargetSha && opts.expectedTargetSha !== target.targetSha;
+  const tagChanged = opts && "expectedTargetTag" in opts && opts.expectedTargetTag !== target.targetTag;
+  if (shaChanged || tagChanged) {
+    return { queued: false, reason: "target-changed" } as const;
+  }
+
   // Attach the "What's in this update?" summary the operator just reviewed (if
   // any) so the run records the changes it carried. Best effort — the upgrade
   // proceeds whether or not a summary was generated.
   const impactSummaryId = await getCurrentImpactSummaryId();
 
-  const run = await createRun({
-    triggeredBy,
+  const admission = await admitSelfUpgrade({ triggeredBy, target,
+    requestedForce: opts?.force === true,
+    dryRun: opts?.dryRun === true,
+    routine: false,
     impactSummaryId,
   });
-
-  try {
-    await inngest.send({
-      name: SELF_UPGRADE_EVENT,
-      data: {
-        runId: run.runId,
-        triggeredBy,
-        ...(opts?.dryRun !== undefined ? { dryRun: opts.dryRun } : {}),
-        ...(opts?.force ? { force: true } : {}),
-      },
-    });
-  } catch (err) {
-    const message = getErrorMessage(err);
-    await failRun(run.runId, `queue-dispatch-failed: ${message}`);
-    return { queued: false, reason: "queue-dispatch-failed", runId: run.runId } as const;
+  if (!admission.admitted) {
+    return { queued: false, reason: "already-active", runId: admission.runId } as const;
   }
-
-  return { queued: true, runId: run.runId } as const;
+  return { queued: true, admitted: true, runId: admission.runId,
+    dispatchStatus: admission.dispatchStatus } as const;
 }
 
 /**

--- a/apps/web/lib/mcp/packs/self-upgrade-pack.ts
+++ b/apps/web/lib/mcp/packs/self-upgrade-pack.ts
@@ -126,9 +126,8 @@ async function requestSelfUpgradeTool(
 
   return {
     success: false,
-    error: result.message,
-    message: result.message,
-    data: result as unknown as Record<string, unknown>,
+    error: "Unexpected self-upgrade admission state.",
+    message: "Unexpected self-upgrade admission state.",
   };
 }
 

--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -132,7 +132,7 @@ vi.mock("@/lib/self-upgrade/run-store", () => ({
   getLatestRun: mocks.getLatestRun,
   getLatestSucceededRun: mocks.getLatestSucceededRun,
 }));
-
+vi.mock("@/lib/self-upgrade/delivery-admission", () => ({ rejectDuplicateSelfUpgradeDelivery: vi.fn().mockResolvedValue(null) }));
 vi.mock("@/lib/self-upgrade/promoter", async (importOriginal) => ({
   // Keep the real pure exports (constants like PROMOTER_ALREADY_RUNNING_EXIT_CODE
   // that the orchestrator imports statically) and mock only the spawn-heavy fns.

--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -506,8 +506,8 @@ describe("success path", () => {
     await runSelfUpgrade({ triggeredBy: "ops" });
     expect(mocks.runPromoter).toHaveBeenCalledWith(
       expect.objectContaining({
-        // Promoter mounts daemon-resolved host paths, never portal paths.
         hostInstallPath: "/Users/me/dpf",
+        canonicalInstallPath: "/Users/me/dpf",
         targetSha: "abc1234deadbeef",
         backupPath: "/backups/self-upgrade/SUR-AAAABBBB",
         healthUrl: "http://localhost:3000/api/health",

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -637,10 +637,10 @@ export async function runSelfUpgrade(
       // Daemon-resolved host path, not an in-portal path; hostSourceMountPath
       // is no longer passed — runPromoter mounts to a fixed /host-source.
       // BI-A8A7CCFD — when isolated workspace is on, the promoter builds from
-      // the workspace HOST path (which holds the merged tree), not the
-      // operator's install clone. The promoter mounts whatever we hand it
+      // the workspace HOST path, not the operator install. It mounts whatever we hand it
       // here at `/host-source:ro` — same contract, just a different host dir.
       hostInstallPath: upgradeWorkspaceHostPath ?? hostInstallPathResolved,
+      canonicalInstallPath: hostInstallPathResolved,
       // The honest built identity from source prep (merge-commit SHA in upstream
       // mode, HEAD/-dirty in local mode). promote.sh re-derives this from the
       // tree's HEAD and cross-checks against it.

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -19,8 +19,7 @@ import {
   evaluateReleaseBatch,
 } from "@/lib/self-upgrade/release-batch";
 import { prepareUpgradeSource, defaultGitRunner } from "@/lib/self-upgrade/prepare-source";
-// Pure constant from a spawn-free module — the host-only ./promoter runtime must
-// NOT be statically imported into this server bundle entrypoint (BI-98AF1066);
+// Pure constant only: never statically import the spawn-heavy promoter runtime
 // that is what the dynamic loadPromoterRuntime() below is for.
 import { PROMOTER_ALREADY_RUNNING_EXIT_CODE } from "@/lib/self-upgrade/promoter-exit-codes";
 import {
@@ -67,6 +66,7 @@ import {
   signalSwapComplete,
   failQuiescenceSwap,
 } from "@/lib/self-upgrade/quiescence";
+import { rejectDuplicateSelfUpgradeDelivery } from "@/lib/self-upgrade/delivery-admission";
 import {
   SELF_UPGRADE_CRON,
   SELF_UPGRADE_EVENT,
@@ -95,6 +95,8 @@ async function loadPromoterRuntime(): Promise<PromoterRuntime> {
 export async function runSelfUpgrade(
   params: SelfUpgradeRunEventData,
 ): Promise<Record<string, unknown>> {
+  const duplicate = await rejectDuplicateSelfUpgradeDelivery(params.runId);
+  if (duplicate) return duplicate;
   const config = await getSelfUpgradeConfig();
   const now = new Date();
   const cooldownMinutes = config.cooldownMinutes ?? DEFAULT_COOLDOWN_MINUTES;

--- a/apps/web/lib/self-upgrade/admission.test.ts
+++ b/apps/web/lib/self-upgrade/admission.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createSelfUpgradeAdmissionService,
+  computeSelfUpgradeAdmissionFingerprint,
+  isDefiniteSelfUpgradeDispatchRefusal,
+  type SelfUpgradeAdmissionRecord,
+  type SelfUpgradeAdmissionRepository,
+  type SelfUpgradeTargetBinding,
+} from "./admission";
+
+const target: SelfUpgradeTargetBinding = {
+  targetKind: "release-artifact",
+  targetSha: "d9ed4bdb9b095d423a7d20b61c0798393f365be6",
+  targetTag: "v2026.08.29-review-prerequisite-recovery.1",
+};
+
+function record(overrides: Partial<SelfUpgradeAdmissionRecord> = {}): SelfUpgradeAdmissionRecord {
+  const row: SelfUpgradeAdmissionRecord = {
+    runId: "SUR-D71E8971",
+    status: "pending",
+    trigger: "manual:user-1",
+    targetSha: target.targetSha,
+    targetTag: target.targetTag,
+    requestedForce: false,
+    dryRun: false,
+    routine: false,
+    impactSummaryId: null,
+    admissionFingerprint: "",
+    dispatchStatus: "admission_pending",
+    dispatchAttemptCount: 0,
+    dispatchLeaseToken: null,
+    dispatchLeaseExpiresAt: null,
+    completedAt: null,
+    ...overrides,
+  };
+  return {
+    ...row,
+    admissionFingerprint: overrides.admissionFingerprint ?? computeSelfUpgradeAdmissionFingerprint({
+      triggeredBy: row.trigger,
+      target,
+      requestedForce: row.requestedForce,
+      dryRun: row.dryRun,
+      routine: row.routine,
+      impactSummaryId: row.impactSummaryId,
+    }),
+  };
+}
+
+function repository(initial = record()): SelfUpgradeAdmissionRepository & {
+  row: SelfUpgradeAdmissionRecord;
+} {
+  const repo: SelfUpgradeAdmissionRepository & { row: SelfUpgradeAdmissionRecord } = {
+    row: initial,
+    admit: vi.fn(async (input) => {
+      repo.row = { ...initial, ...input };
+      return { disposition: "created" as const, run: repo.row };
+    }),
+    read: vi.fn(async () => repo.row),
+    claimDispatch: vi.fn(async (input) => {
+      repo.row = {
+        ...repo.row,
+        dispatchStatus: "dispatching" as const,
+        dispatchAttemptCount: repo.row.dispatchAttemptCount + 1,
+        dispatchLeaseToken: input.leaseToken,
+        dispatchLeaseExpiresAt: input.leaseExpiresAt,
+      };
+      return { claimed: true as const, run: repo.row };
+    }),
+    acknowledgeDispatch: vi.fn(async (input) => {
+      repo.row = {
+        ...repo.row,
+        status: "queued",
+        dispatchStatus: "dispatched",
+        dispatchLeaseToken: null,
+        dispatchLeaseExpiresAt: null,
+        dispatchEventIds: input.eventIds,
+      };
+      return true;
+    }),
+    markDispatchIndeterminate: vi.fn(async () => {
+      repo.row = {
+        ...repo.row,
+        dispatchStatus: "indeterminate",
+        dispatchLeaseToken: null,
+        dispatchLeaseExpiresAt: null,
+      };
+      return true;
+    }),
+    failDispatch: vi.fn(async () => {
+      repo.row = { ...repo.row, status: "failed", dispatchStatus: "dispatch_failed" };
+      return true;
+    }),
+    listRecoverable: vi.fn(async () => [repo.row]),
+  } satisfies SelfUpgradeAdmissionRepository & { row: SelfUpgradeAdmissionRecord };
+  return repo;
+}
+
+function service(overrides: {
+  repository?: SelfUpgradeAdmissionRepository;
+  send?: (event: unknown) => Promise<{ ids: string[] }>;
+  resolveTarget?: () => Promise<SelfUpgradeTargetBinding | null>;
+  readJobEngineHealth?: () => Promise<{ status: "healthy" | "degraded" | "unknown" }>;
+  schedule?: (task: () => Promise<void>) => void;
+} = {}) {
+  const schedule = vi.fn(overrides.schedule ?? (() => undefined));
+  const send = vi.fn(overrides.send ?? (async () => ({ ids: ["evt-1"] })));
+  const resolveTarget = vi.fn(overrides.resolveTarget ?? (async () => target));
+  const readJobEngineHealth = vi.fn(
+    overrides.readJobEngineHealth ?? (async () => ({ status: "healthy" as const })),
+  );
+  return {
+    schedule,
+    send,
+    resolveTarget,
+    readJobEngineHealth,
+    coordinator: createSelfUpgradeAdmissionService({
+      repository: overrides.repository ?? repository(),
+      send,
+      resolveTarget,
+      readJobEngineHealth,
+      schedule,
+      createRunId: () => "SUR-D71E8971",
+      createLeaseToken: () => "lease-1",
+      now: () => new Date("2026-08-29T02:51:37.044Z"),
+    }),
+  };
+}
+
+describe("durable self-upgrade admission", () => {
+  it("returns a server-issued run before the post-response dispatch starts", async () => {
+    const repo = repository();
+    const { coordinator, schedule, send } = service({ repository: repo });
+
+    const accepted = await coordinator.admit({
+      triggeredBy: "manual:user-1",
+      target,
+      requestedForce: false,
+      dryRun: false,
+      routine: false,
+      impactSummaryId: null,
+    });
+
+    expect(accepted).toMatchObject({
+      admitted: true,
+      disposition: "created",
+      runId: "SUR-D71E8971",
+    });
+    expect(repo.row).toMatchObject({
+      status: "pending",
+      targetSha: target.targetSha,
+      targetTag: target.targetTag,
+      dispatchStatus: "admission_pending",
+    });
+    expect(schedule).toHaveBeenCalledOnce();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("reconciles a delayed dispatch with the same stable event identity", async () => {
+    const repo = repository();
+    const { coordinator, schedule, send } = service({ repository: repo });
+    await coordinator.admit({
+      triggeredBy: "manual:user-1",
+      target,
+      requestedForce: false,
+      dryRun: false,
+      routine: false,
+      impactSummaryId: null,
+    });
+
+    const callback = schedule.mock.calls[0]![0] as () => Promise<void>;
+    await callback();
+
+    expect(send).toHaveBeenCalledWith({
+      id: "self-upgrade:SUR-D71E8971",
+      name: "ops/self-upgrade.run",
+      data: {
+        runId: "SUR-D71E8971",
+        triggeredBy: "manual:user-1",
+      },
+    });
+    expect(repo.row).toMatchObject({ status: "queued", dispatchStatus: "dispatched" });
+  });
+
+  it("keeps a transport exception indeterminate and recoverable instead of inventing rejection", async () => {
+    const repo = repository();
+    const send = vi.fn(async () => {
+      throw new Error("fetch failed");
+    });
+    const { coordinator } = service({ repository: repo, send });
+
+    const outcome = await coordinator.dispatch("SUR-D71E8971");
+
+    expect(outcome).toEqual({ status: "indeterminate", runId: "SUR-D71E8971" });
+    expect(repo.markDispatchIndeterminate).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "SUR-D71E8971", leaseToken: "lease-1" }),
+    );
+    expect(repo.failDispatch).not.toHaveBeenCalled();
+  });
+
+  it("records a definite queue refusal without retrying an invalid event", async () => {
+    const repo = repository();
+    const send = vi.fn(async () => {
+      throw new Error("Inngest API Error: 400 Cannot process event payload");
+    });
+    const { coordinator } = service({ repository: repo, send });
+
+    expect(await coordinator.dispatch("SUR-D71E8971")).toEqual({
+      status: "failed",
+      runId: "SUR-D71E8971",
+    });
+    expect(repo.failDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: expect.stringContaining("queue-dispatch-refused") }),
+    );
+    expect(repo.markDispatchIndeterminate).not.toHaveBeenCalled();
+  });
+
+  it("waits for degraded job-engine health without consuming a send", async () => {
+    const repo = repository();
+    const { coordinator, send } = service({
+      repository: repo,
+      readJobEngineHealth: vi.fn(async () => ({ status: "degraded" as const })),
+    });
+
+    const outcome = await coordinator.dispatch("SUR-D71E8971");
+
+    expect(outcome).toEqual({ status: "indeterminate", runId: "SUR-D71E8971" });
+    expect(send).not.toHaveBeenCalled();
+    expect(repo.markDispatchIndeterminate).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "job-engine-degraded" }),
+    );
+  });
+
+  it("also keeps unknown job-engine health recoverable", async () => {
+    const repo = repository();
+    const { coordinator, send } = service({
+      repository: repo,
+      readJobEngineHealth: async () => ({ status: "unknown" as const }),
+    });
+
+    expect(await coordinator.dispatch("SUR-D71E8971")).toEqual({
+      status: "indeterminate",
+      runId: "SUR-D71E8971",
+    });
+    expect(send).not.toHaveBeenCalled();
+    expect(repo.markDispatchIndeterminate).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "job-engine-unknown" }),
+    );
+  });
+
+  it("does not dispatch a distinct request while another admission is active", async () => {
+    const repo = repository();
+    repo.admit = vi.fn(async () => ({
+      disposition: "already_active" as const,
+      run: repo.row,
+    }));
+    const { coordinator, schedule } = service({ repository: repo });
+
+    const result = await coordinator.admit({
+      triggeredBy: "manual:user-2",
+      target,
+      requestedForce: true,
+      dryRun: false,
+      routine: false,
+      impactSummaryId: null,
+    });
+
+    expect(result).toMatchObject({ admitted: false, disposition: "already_active" });
+    expect(schedule).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the current target no longer matches the admitted release", async () => {
+    const repo = repository();
+    const { coordinator, send } = service({
+      repository: repo,
+      resolveTarget: vi.fn(async () => ({ ...target, targetSha: "newer-sha" })),
+    });
+
+    const outcome = await coordinator.dispatch("SUR-D71E8971");
+
+    expect(outcome).toEqual({ status: "failed", runId: "SUR-D71E8971" });
+    expect(repo.failDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "admission-target-drift" }),
+    );
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when persisted admission fields no longer match the fingerprint", async () => {
+    const repo = repository(record({
+      requestedForce: true,
+      admissionFingerprint: record().admissionFingerprint,
+    }));
+    const { coordinator, send } = service({ repository: repo });
+
+    expect(await coordinator.dispatch("SUR-D71E8971")).toEqual({
+      status: "failed",
+      runId: "SUR-D71E8971",
+    });
+    expect(repo.failDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "admission-binding-drift" }),
+    );
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("reconciles an ambiguous row without creating a second admission", async () => {
+    const repo = repository(record({ dispatchStatus: "indeterminate", dispatchAttemptCount: 1 }));
+    const { coordinator, send } = service({ repository: repo });
+
+    const result = await coordinator.reconcile();
+
+    expect(result).toEqual({ attempted: 1, dispatched: 1, indeterminate: 0, failed: 0 });
+    expect(repo.admit).not.toHaveBeenCalled();
+    expect(send).toHaveBeenCalledOnce();
+    expect(send.mock.calls[0]![0]).toMatchObject({ id: "self-upgrade:SUR-D71E8971" });
+  });
+});
+
+describe("definite dispatch refusal classification", () => {
+  it.each([400, 401, 403, 404, 406, 409, 412, 413])("classifies Inngest %s as definite", (status) => {
+    expect(isDefiniteSelfUpgradeDispatchRefusal(new Error(`Inngest API Error: ${status} refused`))).toBe(true);
+  });
+
+  it.each([new Error("fetch failed"), new Error("Inngest API Error: 500 Internal server error")])(
+    "keeps %s ambiguous",
+    (error) => expect(isDefiniteSelfUpgradeDispatchRefusal(error)).toBe(false),
+  );
+});

--- a/apps/web/lib/self-upgrade/admission.ts
+++ b/apps/web/lib/self-upgrade/admission.ts
@@ -1,0 +1,343 @@
+import { createHash, randomUUID } from "node:crypto";
+import { after } from "next/server";
+import { inngest } from "@/lib/queue/inngest-client";
+import { getJobEngineHealth } from "@/lib/queue/job-engine-health";
+import { getSelfUpgradeConfig } from "@/lib/self-upgrade/config";
+import { readCurrentContainerConfigDigest } from "@/lib/self-upgrade/runtime-image-identity";
+import { selfUpgradeAdmissionRepository } from "@/lib/self-upgrade/run-store";
+import { resolveSelfUpgradeStatusTarget } from "@/lib/self-upgrade/status-target";
+import { readSelfUpgradeSupport } from "@/lib/self-upgrade/support";
+
+export type SelfUpgradeDispatchStatus =
+  | "admission_pending"
+  | "dispatching"
+  | "dispatched"
+  | "indeterminate"
+  | "dispatch_failed";
+
+export type SelfUpgradeTargetBinding = Readonly<{
+  targetKind: "git-source" | "release-artifact";
+  targetSha: string;
+  targetTag: string | null;
+}>;
+
+export type SelfUpgradeAdmissionRecord = Readonly<{
+  runId: string;
+  status: string;
+  trigger: string;
+  targetSha: string | null;
+  targetTag: string | null;
+  requestedForce: boolean;
+  dryRun: boolean;
+  routine: boolean;
+  impactSummaryId: string | null;
+  admissionFingerprint: string;
+  dispatchStatus: SelfUpgradeDispatchStatus;
+  dispatchAttemptCount: number;
+  dispatchLeaseToken: string | null;
+  dispatchLeaseExpiresAt: Date | null;
+  dispatchEventIds?: string[];
+  completedAt: Date | null;
+}>;
+
+export type SelfUpgradeAdmissionInput = Readonly<{
+  triggeredBy: string;
+  target: SelfUpgradeTargetBinding;
+  requestedForce: boolean;
+  dryRun: boolean;
+  routine: boolean;
+  impactSummaryId: string | null;
+}>;
+
+type PersistedAdmissionInput = SelfUpgradeAdmissionInput & {
+  runId: string;
+  admissionFingerprint: string;
+  dispatchStatus: "admission_pending";
+};
+
+export type SelfUpgradeAdmissionRepository = {
+  admit(input: PersistedAdmissionInput): Promise<{
+    disposition: "created" | "idempotent" | "already_active";
+    run: SelfUpgradeAdmissionRecord;
+  }>;
+  read(runId: string): Promise<SelfUpgradeAdmissionRecord | null>;
+  claimDispatch(input: {
+    runId: string;
+    admissionFingerprint: string;
+    leaseToken: string;
+    leaseExpiresAt: Date;
+    now: Date;
+  }): Promise<
+    | { claimed: true; run: SelfUpgradeAdmissionRecord }
+    | { claimed: false; reason: string }
+  >;
+  acknowledgeDispatch(input: {
+    runId: string;
+    leaseToken: string;
+    eventIds: string[];
+    acknowledgedAt: Date;
+  }): Promise<boolean>;
+  markDispatchIndeterminate(input: {
+    runId: string;
+    leaseToken: string | null;
+    reason: string;
+    observedAt: Date;
+  }): Promise<boolean>;
+  failDispatch(input: {
+    runId: string;
+    reason: string;
+    observedAt: Date;
+  }): Promise<boolean>;
+  listRecoverable(input: { now: Date; limit: number }): Promise<SelfUpgradeAdmissionRecord[]>;
+};
+
+type DispatchEvent = {
+  id: string;
+  name: "ops/self-upgrade.run";
+  data: {
+    runId: string;
+    triggeredBy: string;
+    force?: true;
+    dryRun?: boolean;
+    routine?: true;
+  };
+};
+
+type SelfUpgradeAdmissionDependencies = {
+  repository: SelfUpgradeAdmissionRepository;
+  send(event: DispatchEvent): Promise<{ ids: string[] }>;
+  resolveTarget(): Promise<SelfUpgradeTargetBinding | null>;
+  readJobEngineHealth(): Promise<{ status: "healthy" | "degraded" | "unknown" }>;
+  schedule(task: () => Promise<void>): void;
+  createRunId(): string;
+  createLeaseToken(): string;
+  now(): Date;
+};
+
+export type SelfUpgradeDispatchOutcome =
+  | { status: "dispatched"; runId: string }
+  | { status: "indeterminate"; runId: string }
+  | { status: "failed"; runId: string }
+  | { status: "not-claimed"; runId: string };
+
+const DISPATCH_LEASE_MS = 60_000;
+const RECONCILE_LIMIT = 10;
+
+export function computeSelfUpgradeAdmissionFingerprint(
+  input: SelfUpgradeAdmissionInput,
+): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        targetKind: input.target.targetKind,
+        targetSha: input.target.targetSha.toLowerCase(),
+        targetTag: input.target.targetTag,
+        triggeredBy: input.triggeredBy,
+        requestedForce: input.requestedForce,
+        dryRun: input.dryRun,
+        routine: input.routine,
+        impactSummaryId: input.impactSummaryId,
+      }),
+    )
+    .digest("hex");
+}
+
+function targetMatches(
+  run: SelfUpgradeAdmissionRecord,
+  target: SelfUpgradeTargetBinding | null,
+): boolean {
+  if (!target || !run.targetSha) return false;
+  return (
+    run.targetSha.toLowerCase() === target.targetSha.toLowerCase() &&
+    run.targetTag === target.targetTag
+  );
+}
+
+function fingerprintMatches(
+  run: SelfUpgradeAdmissionRecord,
+  target: SelfUpgradeTargetBinding,
+): boolean {
+  return run.admissionFingerprint === computeSelfUpgradeAdmissionFingerprint({
+    triggeredBy: run.trigger,
+    target,
+    requestedForce: run.requestedForce,
+    dryRun: run.dryRun,
+    routine: run.routine,
+    impactSummaryId: run.impactSummaryId,
+  });
+}
+
+export function isDefiniteSelfUpgradeDispatchRefusal(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /Inngest API Error: (400|401|403|404|406|409|412|413)\b/.test(message) ||
+    /couldn't find an event key/i.test(message);
+}
+
+function buildEvent(run: SelfUpgradeAdmissionRecord): DispatchEvent {
+  return {
+    id: `self-upgrade:${run.runId}`,
+    name: "ops/self-upgrade.run",
+    data: {
+      runId: run.runId,
+      triggeredBy: run.trigger,
+      ...(run.requestedForce ? { force: true as const } : {}),
+      ...(run.dryRun ? { dryRun: true } : {}),
+      ...(run.routine ? { routine: true as const } : {}),
+    },
+  };
+}
+
+export function createSelfUpgradeAdmissionService(
+  dependencies: SelfUpgradeAdmissionDependencies,
+) {
+  async function dispatch(runId: string): Promise<SelfUpgradeDispatchOutcome> {
+    const existing = await dependencies.repository.read(runId);
+    if (!existing) return { status: "not-claimed", runId };
+
+    const currentTarget = await dependencies.resolveTarget().catch(() => null);
+    if (!targetMatches(existing, currentTarget)) {
+      await dependencies.repository.failDispatch({
+        runId,
+        reason: "admission-target-drift",
+        observedAt: dependencies.now(),
+      });
+      return { status: "failed", runId };
+    }
+    if (!fingerprintMatches(existing, currentTarget!)) {
+      await dependencies.repository.failDispatch({
+        runId,
+        reason: "admission-binding-drift",
+        observedAt: dependencies.now(),
+      });
+      return { status: "failed", runId };
+    }
+
+    const health = await dependencies.readJobEngineHealth();
+    if (health.status !== "healthy") {
+      await dependencies.repository.markDispatchIndeterminate({
+        runId,
+        leaseToken: null,
+        reason: `job-engine-${health.status}`,
+        observedAt: dependencies.now(),
+      });
+      return { status: "indeterminate", runId };
+    }
+
+    const now = dependencies.now();
+    const leaseToken = dependencies.createLeaseToken();
+    const claim = await dependencies.repository.claimDispatch({
+      runId,
+      admissionFingerprint: existing.admissionFingerprint,
+      leaseToken,
+      leaseExpiresAt: new Date(now.getTime() + DISPATCH_LEASE_MS),
+      now,
+    });
+    if (!claim.claimed) return { status: "not-claimed", runId };
+
+    try {
+      const sent = await dependencies.send(buildEvent(claim.run));
+      const acknowledged = await dependencies.repository.acknowledgeDispatch({
+        runId,
+        leaseToken,
+        eventIds: sent.ids,
+        acknowledgedAt: dependencies.now(),
+      });
+      return acknowledged
+        ? { status: "dispatched", runId }
+        : { status: "not-claimed", runId };
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : "queue dispatch failed";
+      if (isDefiniteSelfUpgradeDispatchRefusal(error)) {
+        await dependencies.repository.failDispatch({
+          runId,
+          reason: `queue-dispatch-refused: ${reason}`,
+          observedAt: dependencies.now(),
+        });
+        return { status: "failed", runId };
+      }
+      await dependencies.repository.markDispatchIndeterminate({
+        runId,
+        leaseToken,
+        reason: `queue-dispatch-indeterminate: ${reason}`,
+        observedAt: dependencies.now(),
+      });
+      return { status: "indeterminate", runId };
+    }
+  }
+
+  return {
+    async admit(input: SelfUpgradeAdmissionInput) {
+      const admitted = await dependencies.repository.admit({
+        ...input,
+        runId: dependencies.createRunId(),
+        admissionFingerprint: computeSelfUpgradeAdmissionFingerprint(input),
+        dispatchStatus: "admission_pending",
+      });
+      if (admitted.disposition !== "already_active") {
+        dependencies.schedule(async () => {
+          await dispatch(admitted.run.runId);
+        });
+      }
+      return {
+        admitted: admitted.disposition !== "already_active",
+        runId: admitted.run.runId,
+        disposition: admitted.disposition,
+        dispatchStatus: admitted.run.dispatchStatus,
+      };
+    },
+    dispatch,
+    async reconcile() {
+      const rows = await dependencies.repository.listRecoverable({
+        now: dependencies.now(),
+        limit: RECONCILE_LIMIT,
+      });
+      const summary = { attempted: 0, dispatched: 0, indeterminate: 0, failed: 0 };
+      for (const row of rows) {
+        summary.attempted += 1;
+        const outcome = await dispatch(row.runId);
+        if (outcome.status === "dispatched") summary.dispatched += 1;
+        if (outcome.status === "indeterminate") summary.indeterminate += 1;
+        if (outcome.status === "failed") summary.failed += 1;
+      }
+      return summary;
+    },
+  };
+}
+
+export async function resolveCurrentSelfUpgradeTarget(): Promise<SelfUpgradeTargetBinding | null> {
+  const config = await getSelfUpgradeConfig();
+  const support = await readSelfUpgradeSupport(config.enabled);
+  if (!support.supported) return null;
+  const target = await resolveSelfUpgradeStatusTarget({
+    support,
+    config,
+    currentConfigDigest: await readCurrentContainerConfigDigest(),
+  });
+  if (target.availability !== "resolved" || !target.targetSha) return null;
+  return {
+    targetKind: support.targetKind,
+    targetSha: target.targetSha,
+    targetTag: target.targetTag,
+  };
+}
+
+function productionService(schedule: (task: () => Promise<void>) => void) {
+  return createSelfUpgradeAdmissionService({
+    repository: selfUpgradeAdmissionRepository,
+    send: (event) => inngest.send(event),
+    resolveTarget: resolveCurrentSelfUpgradeTarget,
+    readJobEngineHealth: async () => ({ status: (await getJobEngineHealth()).status }),
+    schedule,
+    createRunId: () => `SUR-${randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase()}`,
+    createLeaseToken: randomUUID,
+    now: () => new Date(),
+  });
+}
+
+export async function admitSelfUpgrade(input: SelfUpgradeAdmissionInput) {
+  return productionService((task) => after(task)).admit(input);
+}
+
+export async function reconcileSelfUpgradeAdmissions() {
+  return productionService((task) => void task()).reconcile();
+}

--- a/apps/web/lib/self-upgrade/admission.ts
+++ b/apps/web/lib/self-upgrade/admission.ts
@@ -7,6 +7,7 @@ import { readCurrentContainerConfigDigest } from "@/lib/self-upgrade/runtime-ima
 import { selfUpgradeAdmissionRepository } from "@/lib/self-upgrade/run-store";
 import { resolveSelfUpgradeStatusTarget } from "@/lib/self-upgrade/status-target";
 import { readSelfUpgradeSupport } from "@/lib/self-upgrade/support";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 export type SelfUpgradeDispatchStatus =
   | "admission_pending"
@@ -168,7 +169,7 @@ function fingerprintMatches(
 }
 
 export function isDefiniteSelfUpgradeDispatchRefusal(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = getErrorMessage(error);
   return /Inngest API Error: (400|401|403|404|406|409|412|413)\b/.test(message) ||
     /couldn't find an event key/i.test(message);
 }
@@ -246,7 +247,7 @@ export function createSelfUpgradeAdmissionService(
         ? { status: "dispatched", runId }
         : { status: "not-claimed", runId };
     } catch (error) {
-      const reason = error instanceof Error ? error.message : "queue dispatch failed";
+      const reason = getErrorMessage(error) || "queue dispatch failed";
       if (isDefiniteSelfUpgradeDispatchRefusal(error)) {
         await dependencies.repository.failDispatch({
           runId,

--- a/apps/web/lib/self-upgrade/delivery-admission.test.ts
+++ b/apps/web/lib/self-upgrade/delivery-admission.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const claimAdmittedRunForWorker = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/self-upgrade/run-store", () => ({ claimAdmittedRunForWorker }));
+
+import { rejectDuplicateSelfUpgradeDelivery } from "./delivery-admission";
+
+describe("self-upgrade event admission", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns an auditable skip for a duplicate delivery", async () => {
+    claimAdmittedRunForWorker.mockResolvedValue("duplicate");
+    await expect(rejectDuplicateSelfUpgradeDelivery("SUR-ONE")).resolves.toEqual({
+      skipped: true,
+      reason: "duplicate-delivery",
+      runId: "SUR-ONE",
+    });
+  });
+
+  it.each(["claimed", "legacy"])("continues the %s worker path", async (claim) => {
+    claimAdmittedRunForWorker.mockResolvedValue(claim);
+    await expect(rejectDuplicateSelfUpgradeDelivery("SUR-ONE")).resolves.toBeNull();
+  });
+});

--- a/apps/web/lib/self-upgrade/delivery-admission.ts
+++ b/apps/web/lib/self-upgrade/delivery-admission.ts
@@ -1,0 +1,10 @@
+import { claimAdmittedRunForWorker } from "@/lib/self-upgrade/run-store";
+
+/** Refuse a second physical execution for an already-consumed admitted event. */
+export async function rejectDuplicateSelfUpgradeDelivery(runId?: string) {
+  if (!runId) return null;
+  const claim = await claimAdmittedRunForWorker(runId);
+  return claim === "duplicate"
+    ? { skipped: true, reason: "duplicate-delivery", runId }
+    : null;
+}

--- a/apps/web/lib/self-upgrade/promoter.test.ts
+++ b/apps/web/lib/self-upgrade/promoter.test.ts
@@ -220,6 +220,7 @@ describe("buildPromoterCommand", () => {
   it("launches release promotion with a narrowly writable install and immutable release identity", () => {
     const { args } = buildPromoterCommand({
       ...BASE,
+      canonicalInstallPath: "/Users/me/canonical-dpf",
       release: {
         tag: "v2026.08.23",
         ghcrOwner: "opendigitalproductfactory",
@@ -230,8 +231,9 @@ describe("buildPromoterCommand", () => {
         platformArchitecture: "amd64",
       },
     });
-    expect(args).toContain("/Users/me/dpf:/host-source");
-    expect(args).not.toContain("/Users/me/dpf:/host-source:ro");
+    expect(args).toContain("/Users/me/dpf:/host-source:ro");
+    expect(args).toContain("/Users/me/canonical-dpf:/canonical-install");
+    expect(args).toContain("PROMOTE_INSTALL_ROOT=/canonical-install");
     expect(args).toContain("DPF_PROMOTION_MODE=release");
     expect(args).toContain("DPF_RELEASE_TAG=v2026.08.23");
     expect(args).toContain(`DPF_RELEASE_CONFIG_DIGEST=sha256:${"c".repeat(64)}`);
@@ -241,6 +243,24 @@ describe("buildPromoterCommand", () => {
     expect(args).toContain("DPF_RELEASE_PLATFORM_ARCHITECTURE=amd64");
     expect(args).toContain("GHCR_OWNER=opendigitalproductfactory");
     expect(args).toContain("PROMOTE_TARGET_SHA=abc1234");
+  });
+
+  it("keeps legacy release callers on the writable source mount when no canonical root is supplied", () => {
+    const release = {
+      tag: "v2026.08.23", ghcrOwner: "opendigitalproductfactory",
+      channelDigest: `sha256:${"a".repeat(64)}`, platformManifestDigest: `sha256:${"b".repeat(64)}`,
+      configDigest: `sha256:${"c".repeat(64)}`, platformOs: "linux", platformArchitecture: "amd64",
+    } as const;
+    const { args } = buildPromoterCommand({ ...BASE, release });
+    expect(args).toContain("/Users/me/dpf:/host-source");
+    expect(args).not.toContain("PROMOTE_INSTALL_ROOT=/canonical-install");
+    const sameRoot = buildPromoterCommand({ ...BASE, canonicalInstallPath: BASE.hostInstallPath, release }).args;
+    expect(sameRoot).toContain("PROMOTE_INSTALL_ROOT=/host-source");
+    expect(sameRoot).not.toContain("/Users/me/dpf:/canonical-install");
+  });
+
+  it("rejects an unsafe canonical install root before launching Docker", () => {
+    expect(() => buildPromoterCommand({ ...BASE, canonicalInstallPath: "../dpf" })).toThrow("invalid_canonical_install_path");
   });
 
   it("reserves host transition authority without requiring an apply envelope", () => {

--- a/apps/web/lib/self-upgrade/promoter.ts
+++ b/apps/web/lib/self-upgrade/promoter.ts
@@ -100,8 +100,10 @@ export type VerifiedReleaseIdentity = {
 };
 
 export type PromoterParams = {
-  /** HOST path of the install tree; bind-mounted into the promoter. */
+  /** HOST path of the source/build carrier; bind-mounted into the promoter. */
   hostInstallPath: string;
+  /** HOST path of the canonical consumer install root that owns durable release identity. */
+  canonicalInstallPath?: string;
   /** Git SHA to promote to. */
   targetSha: string;
   /** In-container path the promoter writes its pre-swap backup to. */
@@ -214,6 +216,7 @@ function validateRuntimeTransitionCommandInputs(params: PromoterParams): void {
   }
   if (params.installStateMigrationEnvelope && !RUNTIME_TRANSITION_ENVELOPE.test(params.installStateMigrationEnvelope)) throw new Error("invalid_install_state_migration_envelope");
   if (params.installStateMigrationSignature && !RUNTIME_TRANSITION_TOKEN.test(params.installStateMigrationSignature)) throw new Error("invalid_install_state_migration_signature");
+  if (params.canonicalInstallPath && !isSafeRuntimeHostPath(params.canonicalInstallPath)) throw new Error("invalid_canonical_install_path");
   if (params.release && (
     !RELEASE_TAG.test(params.release.tag) ||
     !REGISTRY_OWNER.test(params.release.ghcrOwner) ||
@@ -232,23 +235,17 @@ function validateRuntimeTransitionCommandInputs(params: PromoterParams): void {
  * container. Separated from runPromoter so it can be unit-tested without
  * spawning a process. Returns the command and argv exactly as spawned.
  */
-export function buildPromoterCommand(
-  params: PromoterParams,
-): { command: string; args: string[] } {
+export function buildPromoterCommand(params: PromoterParams): { command: string; args: string[] } {
   validateRuntimeTransitionCommandInputs(params);
-  const image =
-    params.promoterImage && params.promoterImage.length > 0
-      ? params.promoterImage
-      : DEFAULT_PROMOTER_IMAGE;
+  const image = params.promoterImage && params.promoterImage.length > 0 ? params.promoterImage : DEFAULT_PROMOTER_IMAGE;
 
   // The promoter runs in its own container, so the portal's "localhost" health
   // URL is unreachable (that loopback is the promoter's own). Rewrite it to
   // host.docker.internal so curl hits the portal's published host port — the
   // new portal that the promoter just recreated.
-  const healthUrl = params.healthUrl.replace(
-    /\/\/(localhost|127\.0\.0\.1)(?=[:/]|$)/,
-    "//host.docker.internal",
-  );
+  const healthUrl = params.healthUrl.replace(/\/\/(localhost|127\.0\.0\.1)(?=[:/]|$)/, "//host.docker.internal");
+  const hasCanonicalInstall = params.release && params.canonicalInstallPath;
+  const distinctCanonicalInstall = hasCanonicalInstall && params.canonicalInstallPath !== params.hostInstallPath;
 
   const args = [
     "run",
@@ -272,8 +269,10 @@ export function buildPromoterCommand(
     "/var/run/docker.sock:/var/run/docker.sock",
     // Host source tree (read-only): build context + backup source.
     "-v",
-    `${params.hostInstallPath}:${PROMOTER_CONTAINER_SOURCE}${params.release ? "" : ":ro"}`,
+    `${params.hostInstallPath}:${PROMOTER_CONTAINER_SOURCE}${params.release && !distinctCanonicalInstall ? "" : ":ro"}`,
   );
+
+  if (distinctCanonicalInstall) args.push("-v", `${params.canonicalInstallPath}:/canonical-install`);
 
   if (params.backupHostPath && params.backupHostPath.length > 0) {
     args.push("-v", `${params.backupHostPath}:/backups`);
@@ -303,6 +302,7 @@ export function buildPromoterCommand(
   );
 
   if (params.release) {
+    if (hasCanonicalInstall) args.push("-e", `PROMOTE_INSTALL_ROOT=${distinctCanonicalInstall ? "/canonical-install" : PROMOTER_CONTAINER_SOURCE}`);
     args.push(
       "-e",
       "DPF_PROMOTION_MODE=release",

--- a/apps/web/lib/self-upgrade/request.test.ts
+++ b/apps/web/lib/self-upgrade/request.test.ts
@@ -11,6 +11,8 @@ const mocks = vi.hoisted(() => ({
   failRun: vi.fn(),
   resolveReleaseBatchStatus: vi.fn(),
   readSelfUpgradeSupport: vi.fn(),
+  resolveCurrentSelfUpgradeTarget: vi.fn(),
+  admitSelfUpgrade: vi.fn(),
 }));
 
 vi.mock("@/lib/queue/inngest-client", () => ({
@@ -51,6 +53,10 @@ vi.mock("@/lib/self-upgrade/run-store", () => ({
   getLatestRun: mocks.getLatestRun,
   createRun: mocks.createRun,
   failRun: mocks.failRun,
+}));
+vi.mock("@/lib/self-upgrade/admission", () => ({
+  resolveCurrentSelfUpgradeTarget: mocks.resolveCurrentSelfUpgradeTarget,
+  admitSelfUpgrade: mocks.admitSelfUpgrade,
 }));
 
 import { requestSelfUpgrade } from "./request";
@@ -117,6 +123,17 @@ describe("requestSelfUpgrade", () => {
       reason: "enabled",
       message: null,
     });
+    mocks.resolveCurrentSelfUpgradeTarget.mockResolvedValue({
+      targetKind: "git-source",
+      targetSha: "b".repeat(40),
+      targetTag: null,
+    });
+    mocks.admitSelfUpgrade.mockResolvedValue({
+      admitted: true,
+      disposition: "created",
+      runId: "SUR-QUEUED1",
+      dispatchStatus: "admission_pending",
+    });
   });
 
   it("queues the same event as the human action in manual mode", async () => {
@@ -130,16 +147,14 @@ describe("requestSelfUpgrade", () => {
       status: "queued",
       runId: "SUR-QUEUED1",
       triggeredBy: "manual:user-ops-1",
-      eventIds: ["evt-1"],
+      eventIds: [],
+      dispatchStatus: "admission_pending",
     });
-    expect(mocks.createRun).toHaveBeenCalledWith({ triggeredBy: "manual:user-ops-1" });
-    expect(mocks.inngestSend).toHaveBeenCalledWith({
-      name: "ops/self-upgrade.run",
-      data: {
-        runId: "SUR-QUEUED1",
-        triggeredBy: "manual:user-ops-1",
-      },
-    });
+    expect(mocks.admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({
+      triggeredBy: "manual:user-ops-1",
+      routine: false,
+    }));
+    expect(mocks.inngestSend).not.toHaveBeenCalled();
     expect(mocks.isUpgradeWindowOpen).not.toHaveBeenCalled();
   });
 
@@ -163,8 +178,8 @@ describe("requestSelfUpgrade", () => {
       status: "queued",
       runId: "SUR-QUEUED1",
     });
-    expect(mocks.createRun).toHaveBeenCalled();
-    expect(mocks.inngestSend).toHaveBeenCalled();
+    expect(mocks.admitSelfUpgrade).toHaveBeenCalled();
+    expect(mocks.inngestSend).not.toHaveBeenCalled();
   });
 
   it.each(["running", "queued", "pending"])(
@@ -187,7 +202,7 @@ describe("requestSelfUpgrade", () => {
     },
   );
 
-  it("marks the queued run failed when event dispatch fails", async () => {
+  it("returns the durable admission without waiting for event dispatch", async () => {
     mocks.inngestSend.mockRejectedValueOnce(new Error("inngest offline"));
 
     const result = await requestSelfUpgrade({
@@ -195,16 +210,9 @@ describe("requestSelfUpgrade", () => {
       actorKind: "human",
     });
 
-    expect(result).toMatchObject({
-      success: false,
-      status: "dispatch_failed",
-      runId: "SUR-QUEUED1",
-      message: "queue-dispatch-failed: inngest offline",
-    });
-    expect(mocks.failRun).toHaveBeenCalledWith(
-      "SUR-QUEUED1",
-      "queue-dispatch-failed: inngest offline",
-    );
+    expect(result).toMatchObject({ success: true, status: "queued", runId: "SUR-QUEUED1" });
+    expect(mocks.inngestSend).not.toHaveBeenCalled();
+    expect(mocks.failRun).not.toHaveBeenCalled();
   });
 
   it("requires human override when an agent requests outside the effective window", async () => {
@@ -236,15 +244,11 @@ describe("requestSelfUpgrade", () => {
       runId: "SUR-QUEUED1",
       triggeredBy: "mcp:codex",
     });
-    expect(mocks.inngestSend).toHaveBeenCalledWith({
-      name: "ops/self-upgrade.run",
-      data: {
-        runId: "SUR-QUEUED1",
-        triggeredBy: "mcp:codex",
-        routine: true,
-      },
-    });
-    expect(mocks.inngestSend.mock.calls[0]?.[0].data.force).toBeUndefined();
+    expect(mocks.admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({
+      triggeredBy: "mcp:codex",
+      routine: true,
+      requestedForce: false,
+    }));
   });
 
   it("returns batch_below_threshold with the tally when an agent request is under the batch size", async () => {
@@ -297,7 +301,7 @@ describe("requestSelfUpgrade", () => {
 
     expect(result).toMatchObject({ success: true, status: "queued" });
     expect(mocks.resolveReleaseBatchStatus).not.toHaveBeenCalled();
-    expect(mocks.inngestSend).toHaveBeenCalled();
+    expect(mocks.admitSelfUpgrade).toHaveBeenCalled();
   });
 
   it("requires human override when a 24/7 install has no known timezone", async () => {

--- a/apps/web/lib/self-upgrade/request.ts
+++ b/apps/web/lib/self-upgrade/request.ts
@@ -1,5 +1,3 @@
-import { inngest } from "@/lib/queue/inngest-client";
-import { SELF_UPGRADE_EVENT } from "@/lib/queue/functions/self-upgrade";
 import { resolveOperatingScheduleForSystem } from "@/lib/operating-hours-read";
 import { resolveAutoUpgradeWindow } from "@/lib/self-upgrade/auto-window";
 import {
@@ -8,8 +6,11 @@ import {
 } from "@/lib/self-upgrade/config";
 import { isUpgradeWindowOpen } from "@/lib/self-upgrade/window";
 import { resolveReleaseBatchStatus } from "@/lib/self-upgrade/release-batch-status";
-import { createRun, failRun, getLatestRun } from "@/lib/self-upgrade/run-store";
-import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { getLatestRun } from "@/lib/self-upgrade/run-store";
+import {
+  admitSelfUpgrade,
+  resolveCurrentSelfUpgradeTarget,
+} from "@/lib/self-upgrade/admission";
 import { readSelfUpgradeSupport } from "@/lib/self-upgrade/support";
 
 type RequestActorKind = "human" | "agent";
@@ -27,6 +28,12 @@ export type RequestSelfUpgradeResult =
       runId: string;
       triggeredBy: string;
       eventIds: string[];
+      dispatchStatus:
+        | "admission_pending"
+        | "dispatching"
+        | "dispatched"
+        | "indeterminate"
+        | "dispatch_failed";
     }
   | {
       success: true;
@@ -174,34 +181,33 @@ export async function requestSelfUpgrade(
     }
   }
 
-  const run = await createRun({ triggeredBy });
-  try {
-    const result = await inngest.send({
-      name: SELF_UPGRADE_EVENT,
-      data: {
-        runId: run.runId,
-        triggeredBy,
-        // Agent-requested runs stay batch-gated in the runner too (authoritative
-        // re-check); operator/manual dispatch elsewhere leaves this unset.
-        ...(input.actorKind === "agent" ? { routine: true } : {}),
-      },
-    });
+  const target = await resolveCurrentSelfUpgradeTarget();
+  if (!target) {
     return {
       success: true,
-      status: "queued",
-      runId: run.runId,
-      triggeredBy,
-      eventIds: result.ids,
-    };
-  } catch (err) {
-    const message = getErrorMessage(err);
-    const failure = `queue-dispatch-failed: ${message}`;
-    await failRun(run.runId, failure);
-    return {
-      success: false,
-      status: "dispatch_failed",
-      runId: run.runId,
-      message: failure,
+      status: "unsupported_install_mode",
+      reason: "install-identity-unverified",
+      targetKind: "unknown",
+      message: "Self-upgrade could not resolve an immutable target.",
     };
   }
+  const admission = await admitSelfUpgrade({
+    triggeredBy,
+    target,
+    requestedForce: false,
+    dryRun: false,
+    routine: input.actorKind === "agent",
+    impactSummaryId: null,
+  });
+  if (!admission.admitted) {
+    return { success: true, status: "already_active", runId: admission.runId };
+  }
+  return {
+    success: true,
+    status: "queued",
+    runId: admission.runId,
+    triggeredBy,
+    eventIds: [],
+    dispatchStatus: admission.dispatchStatus,
+  };
 }

--- a/apps/web/lib/self-upgrade/run-store.test.ts
+++ b/apps/web/lib/self-upgrade/run-store.test.ts
@@ -3,19 +3,29 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   create: vi.fn(),
   findUnique: vi.fn(),
+  findFirst: vi.fn(),
   update: vi.fn(),
+  updateMany: vi.fn(),
+  executeRawUnsafe: vi.fn(),
   broadcastSystem: vi.fn(),
   recordCorrectiveRecoveryEvidence: vi.fn(),
 }));
 vi.mock("@dpf/db", () => ({
-  Prisma: {},
-  prisma: {
-    selfUpgradeRun: {
+  Prisma: { TransactionIsolationLevel: { Serializable: "Serializable" } },
+  prisma: (() => {
+    const selfUpgradeRun = {
       create: mocks.create,
       findUnique: mocks.findUnique,
+      findFirst: mocks.findFirst,
       update: mocks.update,
-    },
-  },
+      updateMany: mocks.updateMany,
+    };
+    return {
+      selfUpgradeRun,
+      $transaction: (callback: (tx: { selfUpgradeRun: typeof selfUpgradeRun; $executeRawUnsafe: typeof mocks.executeRawUnsafe }) => unknown) =>
+        callback({ selfUpgradeRun, $executeRawUnsafe: mocks.executeRawUnsafe }),
+    };
+  })(),
 }));
 vi.mock("@/lib/self-upgrade/change-record", () => ({ safeSyncSelfUpgradeChangeRecord: vi.fn() }));
 vi.mock("@/lib/agent-event-bus", () => ({
@@ -33,6 +43,8 @@ import {
   recordPromoterReadiness,
   recordRunRecoveryPoint,
   sanitizePromoterReadinessReport,
+  claimAdmittedRunForWorker,
+  selfUpgradeAdmissionRepository,
 } from "./run-store";
 
 const report = {
@@ -123,5 +135,133 @@ describe("self-upgrade lifecycle invalidation", () => {
     });
     expect(errorSpy).toHaveBeenCalledOnce();
     errorSpy.mockRestore();
+  });
+});
+
+describe("admitted worker ownership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findUnique.mockResolvedValue({ status: "queued", dispatchStatus: "dispatched" });
+    mocks.updateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it("claims the durable admission with one database compare-and-swap", async () => {
+    await expect(claimAdmittedRunForWorker("SUR-ONE")).resolves.toBe("claimed");
+    expect(mocks.updateMany).toHaveBeenCalledWith({
+      where: {
+        runId: "SUR-ONE",
+        status: { in: ["pending", "queued"] },
+        dispatchStatus: { in: ["dispatching", "dispatched"] },
+      },
+      data: { status: "running", startedAt: expect.any(Date) },
+    });
+  });
+
+  it("refuses duplicate delivery after the claim is consumed", async () => {
+    mocks.updateMany.mockResolvedValue({ count: 0 });
+    await expect(claimAdmittedRunForWorker("SUR-ONE")).resolves.toBe("duplicate");
+  });
+
+  it("preserves the legacy path for historical queued runs", async () => {
+    mocks.findUnique.mockResolvedValue({ status: "queued", dispatchStatus: null });
+    await expect(claimAdmittedRunForWorker("SUR-LEGACY")).resolves.toBe("legacy");
+    expect(mocks.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("records the queue acknowledgement even when the worker finishes before send returns", async () => {
+    mocks.findUnique.mockResolvedValue({
+      status: "succeeded",
+      dispatchStatus: "dispatching",
+      dispatchLeaseToken: "lease-1",
+    });
+    mocks.update.mockResolvedValue({});
+
+    await expect(
+      selfUpgradeAdmissionRepository.acknowledgeDispatch({
+        runId: "SUR-FAST",
+        leaseToken: "lease-1",
+        eventIds: ["event-1"],
+        acknowledgedAt: new Date("2026-08-29T04:00:00.000Z"),
+      }),
+    ).resolves.toBe(true);
+
+    expect(mocks.update).toHaveBeenCalledWith({
+      where: { runId: "SUR-FAST" },
+      data: expect.objectContaining({
+        dispatchStatus: "dispatched",
+        dispatchEventIds: ["event-1"],
+      }),
+    });
+    expect(mocks.update.mock.calls.at(-1)?.[0].data).not.toHaveProperty("status");
+  });
+});
+
+describe("self-upgrade admission transaction", () => {
+  const admittedRow = {
+    runId: "SUR-ADMITTED",
+    status: "pending",
+    trigger: "manual:user-1",
+    targetSha: "a".repeat(40),
+    targetTag: "v1",
+    requestedForce: false,
+    dryRun: false,
+    routine: false,
+    impactSummaryId: null,
+    admissionFingerprint: "fingerprint-1",
+    dispatchStatus: "admission_pending",
+    dispatchAttemptCount: 0,
+    dispatchLeaseToken: null,
+    dispatchLeaseExpiresAt: null,
+    dispatchEventIds: [],
+    completedAt: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findFirst.mockResolvedValue(null);
+    mocks.create.mockResolvedValue(admittedRow);
+  });
+
+  it("persists the exact binding before any dispatcher can observe the run", async () => {
+    await expect(selfUpgradeAdmissionRepository.admit({
+      runId: admittedRow.runId,
+      triggeredBy: admittedRow.trigger,
+      target: { targetKind: "release-artifact", targetSha: admittedRow.targetSha, targetTag: admittedRow.targetTag },
+      requestedForce: false,
+      dryRun: false,
+      routine: false,
+      impactSummaryId: null,
+      admissionFingerprint: admittedRow.admissionFingerprint,
+      dispatchStatus: "admission_pending",
+    })).resolves.toMatchObject({ disposition: "created", run: admittedRow });
+
+    expect(mocks.executeRawUnsafe).toHaveBeenCalledWith(
+      "SELECT pg_advisory_xact_lock(hashtext('self-upgrade-admission'))",
+    );
+    expect(mocks.create).toHaveBeenCalledWith({ data: expect.objectContaining({
+      status: "pending",
+      targetSha: admittedRow.targetSha,
+      targetTag: admittedRow.targetTag,
+      admissionFingerprint: admittedRow.admissionFingerprint,
+      dispatchStatus: "admission_pending",
+    }) });
+  });
+
+  it("returns the same active admission for the same fingerprint", async () => {
+    mocks.findFirst.mockResolvedValue(admittedRow);
+    const result = await selfUpgradeAdmissionRepository.admit({
+      runId: "SUR-IGNORED",
+      triggeredBy: admittedRow.trigger,
+      target: { targetKind: "release-artifact", targetSha: admittedRow.targetSha, targetTag: admittedRow.targetTag },
+      requestedForce: false,
+      dryRun: false,
+      routine: false,
+      impactSummaryId: null,
+      admissionFingerprint: admittedRow.admissionFingerprint,
+      dispatchStatus: "admission_pending",
+    });
+
+    expect(result).toMatchObject({ disposition: "idempotent", run: admittedRow });
+    expect(mocks.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/self-upgrade/run-store.ts
+++ b/apps/web/lib/self-upgrade/run-store.ts
@@ -4,6 +4,10 @@ import { safeSyncSelfUpgradeChangeRecord } from "@/lib/self-upgrade/change-recor
 import { agentEventBus } from "@/lib/agent-event-bus";
 import { recordCorrectiveRecoveryEvidence } from "@/lib/backlog/capture-corrective-bi";
 import type { SelfUpgradeRunStatus } from "@/lib/self-upgrade/run-types";
+import type {
+  SelfUpgradeAdmissionRecord,
+  SelfUpgradeAdmissionRepository,
+} from "@/lib/self-upgrade/admission";
 
 export type { SelfUpgradeRunStatus } from "@/lib/self-upgrade/run-types";
 
@@ -32,6 +36,221 @@ export async function createRun(params: {
   return created;
 }
 
+const ACTIVE_RUN_STATUSES = ["pending", "queued", "running"];
+
+function asAdmissionRecord(row: {
+  runId: string;
+  status: string;
+  trigger: string;
+  targetSha: string | null;
+  targetTag: string | null;
+  requestedForce: boolean;
+  dryRun: boolean;
+  routine: boolean;
+  impactSummaryId: string | null;
+  admissionFingerprint: string | null;
+  dispatchStatus: string | null;
+  dispatchAttemptCount: number;
+  dispatchLeaseToken: string | null;
+  dispatchLeaseExpiresAt: Date | null;
+  dispatchEventIds: string[];
+  completedAt: Date | null;
+}): SelfUpgradeAdmissionRecord {
+  if (!row.admissionFingerprint || !row.dispatchStatus) {
+    throw new Error(`Self-upgrade ${row.runId} has no durable admission contract`);
+  }
+  return row as SelfUpgradeAdmissionRecord;
+}
+
+/** BI-3FD07259 — the production persistence boundary for durable admission. */
+export const selfUpgradeAdmissionRepository: SelfUpgradeAdmissionRepository = {
+  async admit(input) {
+    return prisma.$transaction(async (tx) => {
+      await tx.$executeRawUnsafe(
+        "SELECT pg_advisory_xact_lock(hashtext('self-upgrade-admission'))",
+      );
+      const active = await tx.selfUpgradeRun.findFirst({
+        where: { status: { in: ACTIVE_RUN_STATUSES } },
+        orderBy: { createdAt: "desc" },
+      });
+      if (active) {
+        return {
+          disposition:
+            active.admissionFingerprint === input.admissionFingerprint
+              ? ("idempotent" as const)
+              : ("already_active" as const),
+          run: asAdmissionRecord(active),
+        };
+      }
+      const created = await tx.selfUpgradeRun.create({
+        data: {
+          runId: input.runId,
+          status: "pending",
+          trigger: input.triggeredBy,
+          targetSha: input.target.targetSha,
+          targetTag: input.target.targetTag,
+          requestedForce: input.requestedForce,
+          dryRun: input.dryRun,
+          routine: input.routine,
+          impactSummaryId: input.impactSummaryId,
+          admissionFingerprint: input.admissionFingerprint,
+          dispatchStatus: input.dispatchStatus,
+        },
+      });
+      return { disposition: "created" as const, run: asAdmissionRecord(created) };
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+  },
+
+  async read(runId) {
+    const row = await prisma.selfUpgradeRun.findUnique({ where: { runId } });
+    return row?.admissionFingerprint && row.dispatchStatus
+      ? asAdmissionRecord(row)
+      : null;
+  },
+
+  async claimDispatch(input) {
+    return prisma.$transaction(async (tx) => {
+      await tx.$executeRawUnsafe(
+        "SELECT pg_advisory_xact_lock(hashtext('self-upgrade-dispatch'))",
+      );
+      const latest = await tx.selfUpgradeRun.findFirst({
+        where: { status: { in: ACTIVE_RUN_STATUSES } },
+        orderBy: { createdAt: "desc" },
+        select: { runId: true },
+      });
+      if (latest?.runId !== input.runId) {
+        return { claimed: false as const, reason: "newer-active-run" };
+      }
+      const claimed = await tx.selfUpgradeRun.updateMany({
+        where: {
+          runId: input.runId,
+          status: "pending",
+          admissionFingerprint: input.admissionFingerprint,
+          dispatchStatus: { in: ["admission_pending", "indeterminate", "dispatching"] },
+          OR: [
+            { dispatchLeaseExpiresAt: null },
+            { dispatchLeaseExpiresAt: { lte: input.now } },
+          ],
+        },
+        data: {
+          dispatchStatus: "dispatching",
+          dispatchLeaseToken: input.leaseToken,
+          dispatchLeaseExpiresAt: input.leaseExpiresAt,
+          dispatchAttemptedAt: input.now,
+          dispatchAttemptCount: { increment: 1 },
+          dispatchError: null,
+        },
+      });
+      if (claimed.count !== 1) {
+        return { claimed: false as const, reason: "dispatch-not-claimable" };
+      }
+      const row = await tx.selfUpgradeRun.findUniqueOrThrow({ where: { runId: input.runId } });
+      return { claimed: true as const, run: asAdmissionRecord(row) };
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+  },
+
+  async acknowledgeDispatch(input) {
+    return prisma.$transaction(async (tx) => {
+      const row = await tx.selfUpgradeRun.findUnique({ where: { runId: input.runId } });
+      if (
+        !row ||
+        row.dispatchStatus !== "dispatching" ||
+        row.dispatchLeaseToken !== input.leaseToken
+      ) return false;
+      await tx.selfUpgradeRun.update({
+        where: { runId: input.runId },
+        data: {
+          ...(row.status === "pending" ? { status: "queued" } : {}),
+          dispatchStatus: "dispatched",
+          dispatchEventIds: input.eventIds,
+          dispatchAcknowledgedAt: input.acknowledgedAt,
+          dispatchLeaseToken: null,
+          dispatchLeaseExpiresAt: null,
+          dispatchError: null,
+        },
+      });
+      return true;
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+  },
+
+  async markDispatchIndeterminate(input) {
+    const updated = await prisma.selfUpgradeRun.updateMany({
+      where: {
+        runId: input.runId,
+        status: "pending",
+        dispatchStatus: { in: ["admission_pending", "dispatching", "indeterminate"] },
+        ...(input.leaseToken ? { dispatchLeaseToken: input.leaseToken } : {}),
+      },
+      data: {
+        dispatchStatus: "indeterminate",
+        dispatchLeaseToken: null,
+        dispatchLeaseExpiresAt: null,
+        dispatchError: input.reason,
+      },
+    });
+    return updated.count === 1;
+  },
+
+  async failDispatch(input) {
+    const updated = await prisma.selfUpgradeRun.updateMany({
+      where: {
+        runId: input.runId,
+        status: "pending",
+        dispatchStatus: { in: ["admission_pending", "dispatching", "indeterminate"] },
+      },
+      data: {
+        status: "failed",
+        dispatchStatus: "dispatch_failed",
+        dispatchError: input.reason,
+        failureLog: input.reason,
+        reason: input.reason,
+        completedAt: input.observedAt,
+        dispatchLeaseToken: null,
+        dispatchLeaseExpiresAt: null,
+      },
+    });
+    return updated.count === 1;
+  },
+
+  async listRecoverable(input) {
+    const rows = await prisma.selfUpgradeRun.findMany({
+      where: {
+        status: "pending",
+        dispatchStatus: { in: ["admission_pending", "indeterminate", "dispatching"] },
+        OR: [
+          { dispatchLeaseExpiresAt: null },
+          { dispatchLeaseExpiresAt: { lte: input.now } },
+        ],
+      },
+      orderBy: { createdAt: "asc" },
+      take: input.limit,
+    });
+    return rows.map(asAdmissionRecord);
+  },
+};
+
+export async function claimAdmittedRunForWorker(
+  runId: string,
+): Promise<"claimed" | "duplicate" | "legacy"> {
+  const row = await prisma.selfUpgradeRun.findUnique({
+    where: { runId },
+    select: { status: true, dispatchStatus: true },
+  });
+  if (!row?.dispatchStatus) return "legacy";
+  const claimed = await prisma.selfUpgradeRun.updateMany({
+    where: {
+      runId,
+      status: { in: ["pending", "queued"] },
+      dispatchStatus: { in: ["dispatching", "dispatched"] },
+    },
+    data: { status: "running", startedAt: new Date() },
+  });
+  if (claimed.count !== 1) return "duplicate";
+  notifyRunState(runId, "running");
+  await safeSyncSelfUpgradeChangeRecord(runId);
+  return "claimed";
+}
+
 export async function updateRunPlan(
   runId: string,
   params: {
@@ -51,6 +270,8 @@ export async function updateRunPlan(
 }
 
 export async function startRun(runId: string) {
+  const current = await prisma.selfUpgradeRun.findUnique({ where: { runId } });
+  if (current?.status === "running") return current;
   const updated = await prisma.selfUpgradeRun.update({
     where: { runId },
     data: { status: "running", startedAt: new Date() },

--- a/apps/web/lib/self-upgrade/run-types.ts
+++ b/apps/web/lib/self-upgrade/run-types.ts
@@ -34,6 +34,16 @@ export type LatestRun = {
   createdAt: Date | string;
   /** The impact summary this run carried, when one was recorded at launch. */
   impactSummaryId?: string | null;
+  targetTag?: string | null;
+  dispatchStatus?:
+    | "admission_pending"
+    | "dispatching"
+    | "dispatched"
+    | "indeterminate"
+    | "dispatch_failed"
+    | null;
+  dispatchAttemptCount?: number;
+  dispatchError?: string | null;
   /**
    * "What did this run carry?" — the headline + counts persisted with the run,
    * so Run History answers which upgrade introduced a change instead of leaving

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -9,7 +9,7 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 | Count | Value | Source of truth |
 |---|---:|---|
 | Prisma models | 614 | `packages/db/prisma/schema/` |
-| Prisma enums | 72 | `packages/db/prisma/schema/` |
-| Migrations | 555 | `packages/db/prisma/migrations/` |
+| Prisma enums | 73 | `packages/db/prisma/schema/` |
+| Migrations | 556 | `packages/db/prisma/migrations/` |
 | Kernel principles | 98 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 642 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/data-impact/2026-08-29-self-upgrade-admission-reconciliation.data-impact.json
+++ b/docs/data-impact/2026-08-29-self-upgrade-admission-reconciliation.data-impact.json
@@ -1,0 +1,55 @@
+{
+  "version": "1",
+  "accountableOwner": "developer-platform",
+  "affectedCopies": [],
+  "migration": {
+    "name": "20260829040000_self_upgrade_admission_reconciliation",
+    "backfill": "none - nullable dispatch metadata preserves historical SelfUpgradeRun rows; new admissions populate the contract"
+  },
+  "tests": [
+    "apps/web/lib/self-upgrade/admission.test.ts",
+    "apps/web/lib/self-upgrade/run-store.test.ts",
+    "apps/web/lib/queue/functions/self-upgrade.test.ts",
+    "apps/web/components/ops/SelfUpgradeTriggerControl.test.tsx"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "platform:self-upgrade-run",
+      "prismaModel": "SelfUpgradeRun",
+      "lifecycleDisposition": "operational admission and dispatch evidence retained with self-upgrade history",
+      "fields": [
+        {
+          "fieldId": "platform:self-upgrade-run#targetTag",
+          "resolution": "governed",
+          "reason": "binds a release-artifact admission to the exact immutable tag shown to the operator",
+          "provenance": "server-side self-upgrade target resolver"
+        },
+        {
+          "fieldId": "platform:self-upgrade-run#admissionFingerprint",
+          "resolution": "governed",
+          "reason": "idempotently binds target, force posture, actor, and reviewed impact to one admission",
+          "provenance": "self-upgrade admission transaction"
+        },
+        {
+          "fieldId": "platform:self-upgrade-run#dispatchStatus",
+          "resolution": "governed",
+          "reason": "projects durable admission, dispatch, ambiguity, acknowledgement, and failure state",
+          "provenance": "self-upgrade dispatcher and reconciler"
+        },
+        {
+          "fieldId": "platform:self-upgrade-run#dispatchLeaseToken",
+          "resolution": "governed",
+          "reason": "prevents concurrent reconcilers from dispatching the same admission",
+          "provenance": "transactional dispatch claim"
+        },
+        {
+          "fieldId": "platform:self-upgrade-run#dispatchEventIds",
+          "resolution": "governed",
+          "reason": "correlates the server admission with provider acknowledgement without becoming execution authority",
+          "provenance": "Inngest send acknowledgement"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/data-impact/2026-08-29-self-upgrade-admission-reconciliation.data-impact.json
+++ b/docs/data-impact/2026-08-29-self-upgrade-admission-reconciliation.data-impact.json
@@ -26,6 +26,24 @@
           "provenance": "server-side self-upgrade target resolver"
         },
         {
+          "fieldId": "platform:self-upgrade-run#requestedForce",
+          "resolution": "governed",
+          "reason": "preserves the immutable emergency-override posture admitted by the operator",
+          "provenance": "authorized self-upgrade request"
+        },
+        {
+          "fieldId": "platform:self-upgrade-run#dryRun",
+          "resolution": "governed",
+          "reason": "preserves whether the admitted worker is forbidden from mutating the runtime",
+          "provenance": "authorized self-upgrade request"
+        },
+        {
+          "fieldId": "platform:self-upgrade-run#routine",
+          "resolution": "governed",
+          "reason": "preserves batching and routine-execution policy across delayed dispatch",
+          "provenance": "self-upgrade request actor classification"
+        },
+        {
           "fieldId": "platform:self-upgrade-run#admissionFingerprint",
           "resolution": "governed",
           "reason": "idempotently binds target, force posture, actor, and reviewed impact to one admission",
@@ -38,9 +56,21 @@
           "provenance": "self-upgrade dispatcher and reconciler"
         },
         {
+          "fieldId": "platform:self-upgrade-run#dispatchAttemptCount",
+          "resolution": "governed",
+          "reason": "records every leased dispatch attempt for reconciliation audit",
+          "provenance": "transactional dispatch claim"
+        },
+        {
           "fieldId": "platform:self-upgrade-run#dispatchLeaseToken",
           "resolution": "governed",
           "reason": "prevents concurrent reconcilers from dispatching the same admission",
+          "provenance": "transactional dispatch claim"
+        },
+        {
+          "fieldId": "platform:self-upgrade-run#dispatchLeaseExpiresAt",
+          "resolution": "governed",
+          "reason": "bounds exclusive dispatch ownership so a crashed dispatcher can be recovered",
           "provenance": "transactional dispatch claim"
         },
         {
@@ -48,6 +78,24 @@
           "resolution": "governed",
           "reason": "correlates the server admission with provider acknowledgement without becoming execution authority",
           "provenance": "Inngest send acknowledgement"
+        },
+        {
+          "fieldId": "platform:self-upgrade-run#dispatchAttemptedAt",
+          "resolution": "governed",
+          "reason": "timestamps the latest dispatch attempt for operator and recovery evidence",
+          "provenance": "transactional dispatch claim"
+        },
+        {
+          "fieldId": "platform:self-upgrade-run#dispatchAcknowledgedAt",
+          "resolution": "governed",
+          "reason": "distinguishes provider acknowledgement from ambiguous transport completion",
+          "provenance": "Inngest send acknowledgement"
+        },
+        {
+          "fieldId": "platform:self-upgrade-run#dispatchError",
+          "resolution": "governed",
+          "reason": "projects the exact bounded dispatch or reconciliation failure without treating it as upgrade success",
+          "provenance": "self-upgrade dispatcher and reconciler"
         }
       ]
     }

--- a/docs/superpowers/plans/2026-08-29-self-upgrade-admission-reconciliation.md
+++ b/docs/superpowers/plans/2026-08-29-self-upgrade-admission-reconciliation.md
@@ -65,6 +65,28 @@ request is unresolved.
 - `apps/web/components/ops/SelfUpgradeTriggerControl.test.tsx`
 - `apps/web/components/ops/SelfUpgradeTriggerControl.swap-resilience.test.tsx`
 
+## Design grounding
+
+- Existing design and plan reviewed:
+  `docs/superpowers/specs/2026-08-29-self-upgrade-admission-reconciliation-design.md`
+  and this atomic implementation plan. The separate BI-6CB35411 consumer
+  start-path design remains the owner of install-tag and runtime-identity
+  convergence; it is a delivery prerequisite, not source scope for BI-3FD07259.
+- Current code substrate inspected: `SelfUpgradeRun` persistence and status
+  projection, the self-upgrade server action and request boundary, the Inngest
+  worker and boot instrumentation, and the Upgrade Center trigger control.
+- Source of truth: the server-owned `SelfUpgradeRun` admission row, including its
+  immutable release target, actor/force fingerprint, dispatch state, lease,
+  attempt, acknowledgement, and terminal failure evidence.
+- Architectural decision: commit admission before asynchronous dispatch; reuse
+  one stable event identity; reconcile ambiguous delivery against the same row;
+  acquire worker execution by compare-and-swap; and project the durable state to
+  the UI so an unknown disposition cannot re-enable the control.
+- Rejected boundary crossings: no client-generated admission identity, no
+  synthesized dispatch success, no direct queue retry that changes target or
+  force, no emergency-override expansion, and no edits to BI-6CB35411-owned
+  start/restart or install-identity paths.
+
 ## Risks and rollback
 
 The primary risk is treating an ambiguous dispatch as a rejection or allowing a

--- a/docs/superpowers/plans/2026-08-29-self-upgrade-admission-reconciliation.md
+++ b/docs/superpowers/plans/2026-08-29-self-upgrade-admission-reconciliation.md
@@ -100,7 +100,9 @@ destruction.
 
 - Decision: atomic
 - Parent: BI-3FD07259
-- Receipt: pending independent immutable design baseline and server-issued plan coverage
+- Receipt: blocked — no initiative scope baseline exists for BI-3FD07259; the
+  atomic table below records the server-submitted mapping without claiming a
+  receipt
 - Rationale: schema, admission, dispatch, reconciliation, worker CAS, and UI
   projection are one safety contract. Shipping only a subset either keeps the
   ambiguous click, creates an unrecoverable pending row, or permits duplicate

--- a/docs/superpowers/plans/2026-08-29-self-upgrade-admission-reconciliation.md
+++ b/docs/superpowers/plans/2026-08-29-self-upgrade-admission-reconciliation.md
@@ -1,0 +1,91 @@
+---
+status: active
+---
+
+# Durable Self-Upgrade Admission and Dispatch Reconciliation Plan
+
+**Backlog item:** BI-3FD07259
+**Workroom:** WC-25858CAB
+**Branch:** `fix/durable-self-upgrade-admission-and-dispatch-reco`
+
+## Outcome
+
+One server-issued `SelfUpgradeRun` identity survives response loss, delayed queue
+acceptance, dispatch failure, process restart, and duplicate delivery. The
+Upgrade Center remains truthful and cannot invite a second click while the first
+request is unresolved.
+
+## Atomic implementation
+
+1. Add the `SelfUpgradeDispatchStatus` enum and the minimal target, fingerprint,
+   force, lease, attempt, acknowledgement, and failure fields to
+   `SelfUpgradeRun`; add a forward-only migration and data-impact manifest.
+2. Write failing run-store/admission tests for atomic admission, same-fingerprint
+   reuse, active-run exclusion, dispatch leasing, acknowledgement, ambiguous
+   failure, definite failure, target drift, newer-run refusal, and worker CAS.
+3. Implement `admission.ts` as the single target-binding and dispatch state
+   boundary. Refactor action/request callers to admit first, return the run id,
+   and schedule the same dispatcher with Next.js `after()`.
+4. Give every send the stable `self-upgrade:<runId>` event id. Persist returned
+   event ids and make the worker claim the row by compare-and-swap before any
+   preflight or physical action.
+5. Add boot and periodic reconciliation for eligible pending/indeterminate rows,
+   using the same lease and dispatch function. Preserve exact target/force
+   binding and existing quiescence checks.
+6. Write failing UI tests for the two red fixtures and for every durable dispatch
+   state. Remove the 45-second local unlock and render calm, actionable status
+   from the canonical row without adding another control.
+7. Run focused and affected tests, web typecheck, migration validation,
+   data-impact/prose/style guards, preflight, semantic review, and exact-tree
+   local CI. Publish one DCO-signed PR and require every protected PR and
+   merge-group check.
+8. Create one canonical release from the protected merge, require publisher and
+   release-mode clean-install success, perform one governed self-upgrade, and
+   prove exact served SHA, data preservation, health, durable admission identity,
+   dispatch reconciliation, and CAN-TEST before resuming BI-F48.
+
+## Expected source surface
+
+- `packages/db/prisma/schema/build-delivery.prisma`
+- `packages/db/prisma/migrations/20260829040000_self_upgrade_admission_reconciliation/migration.sql`
+- `docs/data-impact/2026-08-29-self-upgrade-admission-reconciliation.data-impact.json`
+- `apps/web/lib/self-upgrade/admission.ts`
+- `apps/web/lib/self-upgrade/admission.test.ts`
+- `apps/web/lib/self-upgrade/run-store.ts`
+- `apps/web/lib/self-upgrade/run-store.test.ts`
+- `apps/web/lib/self-upgrade/request.ts`
+- `apps/web/lib/self-upgrade/request.test.ts`
+- `apps/web/lib/actions/promotions.ts`
+- `apps/web/lib/actions/promotions.self-upgrade.test.ts`
+- `apps/web/lib/queue/functions/self-upgrade.ts`
+- `apps/web/lib/queue/functions/self-upgrade.test.ts`
+- `apps/web/instrumentation.ts`
+- `apps/web/instrumentation.test.ts`
+- `apps/web/components/ops/SelfUpgradeTriggerControl.tsx`
+- `apps/web/components/ops/SelfUpgradeTriggerControl.test.tsx`
+- `apps/web/components/ops/SelfUpgradeTriggerControl.swap-resilience.test.tsx`
+
+## Risks and rollback
+
+The primary risk is treating an ambiguous dispatch as a rejection or allowing a
+stale retry to target a different release. The admission fingerprint, immutable
+stored target, stable event id, transaction lease, latest-run guard, and worker
+CAS make both paths fail closed. Rollback is a protected revert; new nullable
+dispatch metadata remains compatible with historical rows and requires no data
+destruction.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: BI-3FD07259
+- Receipt: pending independent immutable design baseline and server-issued plan coverage
+- Rationale: schema, admission, dispatch, reconciliation, worker CAS, and UI
+  projection are one safety contract. Shipping only a subset either keeps the
+  ambiguous click, creates an unrecoverable pending row, or permits duplicate
+  physical execution.
+- Dependencies: none for source delivery; BI-6CB35411 remains a separate live
+  runtime-identity prerequisite if tag/SHA/config identity does not converge.
+
+| Deliverable key | Backlog item | Independently shippable | Requirement refs | Contract refs | Flow refs | Verification refs |
+| --- | --- | --- | --- | --- | --- | --- |
+| `durable-self-upgrade-admission` | BI-3FD07259 | no | OBJ-SUA-001, OBJ-SUA-002, OBJ-SUA-003, OBJ-SUA-004 | admission-transaction, dispatch-state-machine, consumer-cas, operator-projection | admit-return, post-response-dispatch, boot-reconcile, worker-claim, live-upgrade | AC-SUA-001, AC-SUA-002, AC-SUA-003, AC-SUA-004, AC-SUA-005, AC-SUA-006, AC-SUA-007, AC-SUA-008 |

--- a/docs/superpowers/specs/2026-08-29-self-upgrade-admission-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-08-29-self-upgrade-admission-reconciliation-design.md
@@ -88,6 +88,19 @@ records and validates the target tag/SHA it is given, but it does not change
 If those identities still disagree after this repair is live, BI-6CB35411 remains
 a hard prerequisite before any reviewer replay.
 
+### Normative dependency disposition
+
+BI-6CB35411 is an explicit out-of-scope dependency, not an omitted BI-3FD07259
+requirement. A conforming BI-3FD07259 implementation **must not** edit consumer
+start/restart selection, `DPF_IMAGE_TAG`, install-state, Compose image selection,
+or OCI labels. Its responsibility ends after it durably binds and dispatches the
+exact release-artifact tag and SHA supplied by the canonical target resolver.
+BI-6CB35411 independently makes those runtime identities converge and remains a
+hard delivery prerequisite before BI-F48 resumes. A design-review finding that
+claims this design omits runtime identity convergence contradicts this normative
+scope boundary; a genuine finding must instead identify a defect inside the
+admission, dispatch, reconciliation, worker-CAS, or operator-projection contract.
+
 ## Admission transaction
 
 `admitSelfUpgrade` resolves support and the exact target on the server, then

--- a/docs/superpowers/specs/2026-08-29-self-upgrade-admission-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-08-29-self-upgrade-admission-reconciliation-design.md
@@ -65,6 +65,17 @@ failed before dispatch.
 | AC-SUA-007 | OBJ-SUA-003 | A response interruption after admission still converges from server data; no local success state is treated as evidence. | Operator projection |
 | AC-SUA-008 | OBJ-SUA-004 | Emergency override remains explicit and immutable per admission; ordinary activity/quiescence preflight remains authoritative and cannot be bypassed by reconciliation. | Authority boundary |
 
+## Governed design-review recording contract
+
+The immutable reviewer must use the canonical
+`record_initiative_design_review` disposition schema exactly. A `pass` decision
+requires both `findings = []` and `resolvedFindingRefs = []`. Positive
+observations belong only in the reviewer `reason`; they are not findings. Any
+finding requires `decision = fail` (or another canonical non-pass disposition
+supported by the server-issued schema). The writer remains fail closed when a
+proposed disposition contradicts this contract; neither approval nor replay may
+rewrite the reviewer's arguments.
+
 ## Existing substrate and ownership boundary
 
 This change extends the canonical `SelfUpgradeRun`, `triggerSelfUpgrade`,

--- a/docs/superpowers/specs/2026-08-29-self-upgrade-admission-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-08-29-self-upgrade-admission-reconciliation-design.md
@@ -1,0 +1,230 @@
+---
+status: active
+---
+
+# Durable Self-Upgrade Admission and Dispatch Reconciliation
+
+**Backlog item:** BI-3FD07259
+**Workroom:** WC-25858CAB
+**Branch:** `fix/durable-self-upgrade-admission-and-dispatch-reco`
+
+## Problem
+
+The Upgrade Center persists a `SelfUpgradeRun` before sending the manual Inngest
+event, but the server action waits for that network call before it returns an
+identity to the browser. The UI therefore cannot distinguish a slow accepted
+request from an unaccepted click. It eventually clears its local busy state on a
+timer even when the durable disposition is still unknown.
+
+Two production fixtures demonstrate the gap:
+
+1. An accepted click returned no durable outcome for about 52 seconds. The row
+   later appeared as `SUR-D71E8971` and failed before mutation with
+   `queue-dispatch-failed: fetch failed`.
+2. A replacement click settled after about 10 seconds with no `SelfUpgradeRun`
+   row and no durable UI outcome.
+
+Both outcomes invite a second click while the first physical action may still be
+admitted. That is unsafe for a workflow whose next step drains and replaces the
+running portal.
+
+## Outcome
+
+The server atomically admits one immutable self-upgrade request before any
+asynchronous dispatch. It returns the admission/run identity immediately. The
+same row records dispatch ownership, attempts, acknowledgement, ambiguity, and
+terminal failure. A post-response dispatcher plus the existing portal startup
+maintenance loop reconcile the row by the same identity. Duplicate sends use a
+stable event id, and the worker uses a database compare-and-swap before it may
+begin a physical upgrade.
+
+The Upgrade Center projects the durable state instead of a client timer. It
+keeps the action unavailable while admission disposition is unknown and explains
+whether the request is admitted, waiting for the job engine, dispatched, or
+failed before dispatch.
+
+## Governed scope manifest
+
+- **OBJ-SUA-001:** Give every accepted upgrade request a durable server-issued
+  admission identity and exact immutable target before returning to the caller.
+- **OBJ-SUA-002:** Reconcile delayed, failed, and ambiguous queue dispatch by the
+  same identity without starting a duplicate physical upgrade.
+- **OBJ-SUA-003:** Present one truthful operator state and keep the trigger
+  unavailable while the request's disposition is unknown.
+- **OBJ-SUA-004:** Preserve quiescence, emergency-override, release binding, and
+  newer-run checks as fail-closed authority boundaries.
+
+| Acceptance | Objectives | Statement | Design evidence |
+| --- | --- | --- | --- |
+| AC-SUA-001 | OBJ-SUA-001 | Manual and MCP admission persist a `pending` run with exact target SHA, target tag when applicable, force posture, actor, impact summary, fingerprint, and dispatch state before returning its run id. | Admission transaction |
+| AC-SUA-002 | OBJ-SUA-001, OBJ-SUA-002 | Dispatch uses a stable event id derived from the run id, a bounded database lease, and recorded attempt/acknowledgement fields. | Dispatch state machine |
+| AC-SUA-003 | OBJ-SUA-002, OBJ-SUA-004 | Only the latest exact-bound pending run may be dispatched; target drift, a newer run, changed force posture, or a fresh activity refusal ends or defers without mutation. | Reconciliation invariants |
+| AC-SUA-004 | OBJ-SUA-002 | A transport timeout or process loss leaves the same run recoverable; boot/periodic reconciliation retries it without a second click. | Recovery flow |
+| AC-SUA-005 | OBJ-SUA-002, OBJ-SUA-004 | The worker atomically claims an admitted row once, so queue deduplication expiry or duplicate delivery cannot start a second physical upgrade. | Consumer CAS |
+| AC-SUA-006 | OBJ-SUA-003 | The existing control shows durable pending, dispatching, queued, indeterminate, and dispatch-failed outcomes and never unlocks on a blind timer. | Operator projection |
+| AC-SUA-007 | OBJ-SUA-003 | A response interruption after admission still converges from server data; no local success state is treated as evidence. | Operator projection |
+| AC-SUA-008 | OBJ-SUA-004 | Emergency override remains explicit and immutable per admission; ordinary activity/quiescence preflight remains authoritative and cannot be bypassed by reconciliation. | Authority boundary |
+
+## Existing substrate and ownership boundary
+
+This change extends the canonical `SelfUpgradeRun`, `triggerSelfUpgrade`,
+`requestSelfUpgrade`, Inngest manual worker, and `/ops/self-upgrade` control. It
+does not introduce another queue or upgrade command.
+
+BI-6CB35411 separately owns consumer runtime identity convergence. This design
+records and validates the target tag/SHA it is given, but it does not change
+`dpf-start.ps1`, `DPF_IMAGE_TAG`, install-state, compose selection, or OCI labels.
+If those identities still disagree after this repair is live, BI-6CB35411 remains
+a hard prerequisite before any reviewer replay.
+
+## Admission transaction
+
+`admitSelfUpgrade` resolves support and the exact target on the server, then
+creates the canonical row in one transaction:
+
+- `status = pending`;
+- `targetSha` and, for a release install, `targetTag`;
+- `requestedForce`, `trigger`, and `impactSummaryId`;
+- `admissionFingerprint`, a hash of target kind, SHA, tag, force posture, actor,
+  and impact-summary identity; and
+- `dispatchStatus = admission_pending`, attempt count zero, and no lease.
+
+The transaction refuses when another `pending`, `queued`, or `running` run
+exists. A unique admission fingerprint makes a repeated server invocation for
+the same still-active request return the same row rather than create a second
+one. Closed dispatch states use a Prisma enum.
+
+The server action schedules `dispatchSelfUpgradeAdmission(runId)` with Next.js
+`after()`, which is supported in Server Functions and Docker. The response is
+not coupled to the queue round trip: the caller receives the durable run id as
+soon as admission commits. Startup and periodic maintenance are the independent
+recovery path if the process exits before or during that callback.
+
+## Dispatch state machine
+
+The row carries these dispatch states:
+
+```text
+admission_pending -> dispatching -> dispatched
+        ^                 |             |
+        |                 v             v
+        +--------- indeterminate     worker claim
+                          |
+                          v
+                   dispatch_failed
+```
+
+`claimDispatch` is a transaction that checks the stored binding, verifies this
+is still the latest nonterminal run, and acquires a short lease with a random
+token. It increments the attempt count and records `dispatching` before network
+I/O. The sender uses `id = self-upgrade:<runId>` and stores returned provider
+event ids on acknowledgement.
+
+A definite queue refusal records `dispatch_failed`, terminal run failure, and a
+safe operator explanation. A timeout, connection loss, or process exit is not
+proof that the queue rejected the event; it records or leaves `indeterminate`.
+Reconciliation reacquires only an expired lease and resends the same event id.
+It never creates a new row.
+
+Inngest event-id deduplication covers duplicate sends for 24 hours. Because that
+window is not a permanent exactly-once guarantee, `startRun` also performs a
+consumer-side compare-and-swap from the admitted/queued lifecycle to `running`.
+A duplicate delivery after the deduplication window observes an already claimed
+or terminal row and returns without preflight, drain, or swap.
+
+## Reconciliation invariants
+
+Before every dispatch or resend, the reconciler verifies:
+
+1. the row remains the latest `SelfUpgradeRun`;
+2. its status is `pending` or `queued`, without `completedAt`;
+3. its admission fingerprint still matches its stored actor, target, tag,
+   force posture, and impact summary;
+4. the canonical target resolver still returns the same target kind, SHA, and
+   tag; and
+5. no unexpired dispatch lease is owned by another process.
+
+Target drift or a newer run fails closed. Activity and quiescence are deliberately
+not predicted by admission: the existing authoritative worker preflight retains
+that responsibility and may skip safely before mutation. Reconciliation never
+sets emergency override and cannot alter the stored force posture.
+
+## Operator experience
+
+The existing Upgrade Center control remains the single action surface. It does
+not add another button or advanced operator choice.
+
+- `admission_pending` / `dispatching`: **Request accepted — connecting to the
+  upgrade engine.** The run id is visible and the action remains disabled.
+- `indeterminate`: **Request accepted — delivery is being reconciled.** The
+  action remains disabled; the operator is not told to click again.
+- `dispatched` / `queued`: **Upgrade queued.** Existing live status takes over.
+- `dispatch_failed`: **The accepted request could not reach the upgrade
+  engine.** The exact run id and durable failure are shown. A future recovery
+  attempt is system-owned, not another click.
+
+The 45-second `justQueued` unlock is removed. Client network errors trigger a
+refresh and say that admission is being checked; only server state decides
+whether the button can re-enable.
+
+## Research and benchmarking
+
+- [Inngest event idempotency](https://www.inngest.com/docs/guides/handling-idempotency)
+  deduplicates a stable event id for 24 hours. DPF adopts this at the producer
+  boundary but rejects relying on it alone because the window expires.
+- [AWS Step Functions `StartExecution`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html)
+  treats the same Standard Workflow name and input as an idempotent start while
+  it is running. DPF adopts the same stable-identity/bound-input semantics in
+  `SelfUpgradeRun`, without introducing another workflow engine.
+- [Temporal](https://docs.temporal.io/) demonstrates durable workflow recovery
+  across process and infrastructure failures. DPF adopts durable state plus
+  independent reconciliation, while retaining the existing Inngest and Prisma
+  substrate.
+- [Next.js `after`](https://nextjs.org/docs/app/api-reference/functions/after)
+  provides the supported post-response execution primitive for Server Functions
+  and Docker. DPF uses it only as the fast path; the database reconciler remains
+  authoritative if the callback never completes.
+
+## Rejected alternatives
+
+- **Await queue dispatch before returning.** This is the current ambiguity: the
+  browser loses the durable run identity when the transport is slow or reset.
+- **Let the browser retry or generate the id.** Authority and target binding
+  belong on the server, and a second click is not a recovery protocol.
+- **Mark a send exception terminal immediately.** A transport exception cannot
+  prove the queue did not accept the event.
+- **Use only Inngest event deduplication.** Its documented window is 24 hours;
+  consumer CAS is still required.
+- **Add a second dispatch table.** `SelfUpgradeRun` is already the canonical
+  admission, lifecycle, audit, and UI record.
+- **Fold in BI-6CB35411.** Runtime tag convergence is a separate consumer-start
+  defect and expands this repair beyond the dispatch boundary.
+
+## Scale ceiling and retention
+
+Self-upgrade is globally serialized and produces at most a small number of rows
+per release. The reconciler scans only nonterminal rows with indexed lifecycle
+state and a bounded batch. Lease acquisition is transactional; no polling loop
+runs faster than the existing maintenance cadence. Dispatch metadata remains on
+the run for the same operational-history retention as the upgrade itself.
+
+## Verification
+
+Tests must prove:
+
+- both exact production fixtures return or converge on one durable run identity;
+- admission is committed before the mocked dispatch starts;
+- a delayed/throwing dispatch leaves one recoverable row and a stable event id;
+- concurrent reconcilers acquire one lease and duplicate deliveries claim the
+  worker once, including after the provider dedupe window;
+- target, tag, fingerprint, force, newer-run, and lease conflicts fail closed;
+- the existing action remains disabled for pending/dispatching/indeterminate and
+  has no timer-based re-enable;
+- ordinary queued/running/succeeded/failed/skipped history remains compatible;
+- startup and periodic recovery resend only eligible rows; and
+- the migration applies to a database containing historical self-upgrade rows.
+
+Live acceptance requires one canonical release and one governed action whose
+UI returns a run id immediately, whose persisted dispatch transitions are
+observable, and whose physical upgrade completes at most once. Served SHA,
+health, preserved data, and CAN-TEST remain mandatory.

--- a/docs/user-guide/operations/self-upgrade.md
+++ b/docs/user-guide/operations/self-upgrade.md
@@ -29,16 +29,24 @@ is unavailable and does not offer or queue an upgrade.
 1. Confirm the status card shows a resolved immutable update. If it says current
    or unavailable, there is no upgrade action to trigger.
 2. Review the pending upgrade and what it will change before triggering anything.
-3. Trigger the upgrade only inside an approved deployment window. Normal changes
-   respect the window; only an emergency change may override it.
-4. Watch the deployment status — the page updates automatically while the build
-   and swap are in progress. A normal upgrade completes in a few minutes.
+3. Trigger the upgrade only inside an approved deployment window. The server
+   durably admits the request and assigns its `SUR-*` run identity before queue
+   dispatch begins. Normal changes respect the window; only an emergency change
+   may override it.
+4. Watch the deployment status — the page distinguishes a request waiting for
+   dispatch, active dispatch, indeterminate dispatch reconciliation, and a
+   definite dispatch failure. It updates automatically while the build and swap
+   are in progress. A normal upgrade completes in a few minutes.
 5. Confirm the health check passed after the swap, and read the deployment log if
    it did not.
 
 You may navigate away after the upgrade has been accepted. Leaving the page stops
 only that page's live status reads; it does not cancel or pause the durable upgrade.
 When you return, the page reloads the current run state and resumes live updates.
+If the browser loses the trigger response, do not click again. The action remains
+disabled until the server reports a durable disposition for the admitted run.
+The same `SUR-*` identity is reconciled after a delayed or ambiguous dispatch, so
+a page reload or process restart cannot create a second physical upgrade.
 
 The owner status card and upgrade action stay visible on arrival. Open
 **Deploy controls & history** only when you need technical controls, run
@@ -73,6 +81,9 @@ upgrade. Nothing is lost by waiting.
 
 - If an upgrade fails, open the deployment log for the retryable diagnosis, then
   re-run the upgrade.
+- If dispatch is indeterminate, leave the action alone while the server
+  reconciles the admitted `SUR-*` run. A definite pre-dispatch refusal is shown
+  against that same run identity and means no upgrade mutation began.
 - If update status is unavailable, read the technical reason under **Deploy
   controls & history**. Repair registry access or install identity before
   retrying; the unavailable state has not queued or mutated anything.

--- a/packages/db/prisma/migrations/20260829040000_self_upgrade_admission_reconciliation/migration.sql
+++ b/packages/db/prisma/migrations/20260829040000_self_upgrade_admission_reconciliation/migration.sql
@@ -1,0 +1,32 @@
+-- BI-3FD07259: preserve a durable admission identity before queue dispatch.
+-- Historical SelfUpgradeRun rows intentionally retain NULL dispatchStatus and
+-- admissionFingerprint; they are audit history and are not reconciliation
+-- candidates. New code writes the complete admission contract atomically.
+
+CREATE TYPE "SelfUpgradeDispatchStatus" AS ENUM (
+  'admission_pending',
+  'dispatching',
+  'dispatched',
+  'indeterminate',
+  'dispatch_failed'
+);
+
+ALTER TABLE "SelfUpgradeRun"
+  ADD COLUMN "targetTag" TEXT,
+  ADD COLUMN "requestedForce" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "dryRun" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "routine" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "admissionFingerprint" TEXT,
+  ADD COLUMN "dispatchStatus" "SelfUpgradeDispatchStatus",
+  ADD COLUMN "dispatchAttemptCount" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "dispatchLeaseToken" TEXT,
+  ADD COLUMN "dispatchLeaseExpiresAt" TIMESTAMP(3),
+  ADD COLUMN "dispatchEventIds" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  ADD COLUMN "dispatchAttemptedAt" TIMESTAMP(3),
+  ADD COLUMN "dispatchAcknowledgedAt" TIMESTAMP(3),
+  ADD COLUMN "dispatchError" TEXT;
+
+CREATE INDEX "SelfUpgradeRun_dispatchStatus_dispatchLeaseExpiresAt_idx"
+  ON "SelfUpgradeRun"("dispatchStatus", "dispatchLeaseExpiresAt");
+CREATE INDEX "SelfUpgradeRun_admissionFingerprint_idx"
+  ON "SelfUpgradeRun"("admissionFingerprint");

--- a/packages/db/prisma/schema/build-delivery.prisma
+++ b/packages/db/prisma/schema/build-delivery.prisma
@@ -1344,6 +1344,14 @@ model FeaturePack {
   updatedAt DateTime @updatedAt
 }
 
+enum SelfUpgradeDispatchStatus {
+  admission_pending
+  dispatching
+  dispatched
+  indeterminate
+  dispatch_failed
+}
+
 model SelfUpgradeRun {
   id                    String    @id @default(cuid())
   runId                 String    @unique
@@ -1361,6 +1369,22 @@ model SelfUpgradeRun {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
+  // BI-3FD07259 — durable admission precedes queue I/O. Nullable dispatch
+  // state preserves historical rows created before the admission contract.
+  targetTag              String?
+  requestedForce         Boolean                    @default(false)
+  dryRun                 Boolean                    @default(false)
+  routine                Boolean                    @default(false)
+  admissionFingerprint   String?
+  dispatchStatus         SelfUpgradeDispatchStatus?
+  dispatchAttemptCount   Int                        @default(0)
+  dispatchLeaseToken     String?
+  dispatchLeaseExpiresAt DateTime?
+  dispatchEventIds       String[]                   @default([])
+  dispatchAttemptedAt    DateTime?
+  dispatchAcknowledgedAt DateTime?
+  dispatchError          String?                    @db.Text
+
   // The "What's in this update?" summary the operator reviewed when launching
   // this upgrade — attached so the run records the changes it carried, and so
   // the summary survives the process restart the swap triggers.
@@ -1375,6 +1399,8 @@ model SelfUpgradeRun {
   changeRequest   ChangeRequest? @relation("SelfUpgradeChangeRecord", fields: [changeRequestId], references: [id])
 
   @@index([status, createdAt])
+  @@index([dispatchStatus, dispatchLeaseExpiresAt])
+  @@index([admissionFingerprint])
   @@index([targetSha])
   @@index([impactSummaryId])
 }


### PR DESCRIPTION
## Outcome

Every accepted self-upgrade action now has one durable `SUR-*` admission identity before asynchronous dispatch. Delayed, failed, or ambiguous queue delivery reconciles against the same row and stable event id, while the worker compare-and-swap prevents duplicate physical execution. The Upgrade Center projects that durable state and no longer re-enables on a blind client timer.

## Design grounding

- Reviewed `docs/superpowers/specs/2026-08-29-self-upgrade-admission-reconciliation-design.md` and `docs/superpowers/plans/2026-08-29-self-upgrade-admission-reconciliation.md`.
- Inspected the existing `SelfUpgradeRun` store/status projection, request and server-action boundaries, Inngest worker/boot maintenance, and `/ops/self-upgrade` trigger control.
- Source of truth is the server-owned `SelfUpgradeRun` admission row with immutable release binding, actor/force fingerprint, dispatch state, lease, acknowledgement, and terminal evidence.
- Decision: persist admission before dispatch, use one stable event identity, reconcile ambiguous delivery, acquire physical execution by worker CAS, and keep the existing UI control disabled until a durable disposition exists.
- BI-6CB35411 separately owns consumer start/restart and runtime-image identity convergence; this PR does not edit those paths and that BI remains a hard downstream delivery prerequisite.

## Verification

- 10 focused/adjacent Vitest files: 278 tests passed.
- Full web typecheck passed.
- Prisma schema validation and migration-safety guard passed.
- Module-size, style, data-impact, FK-index, prose, docs-impact, design-grounding, and diff guards passed.
- `pnpm pregate:preflight`: exit 0, 59 guards clean; PR Health Logic is the documented host-runtime skip and remains protected-CI enforced.
- DCO sign-offs are present on every branch commit.

## Governed dispositions

- No semantic PASS or baseline is inferred. The materially clarified review TaskRun `TR-MCP-Y210Nmg3bjg3MDBnYTAxbXhheDU2MXV2aQ-F2FD56D5BB2D` persisted exact-bound reader `cmtdxnc9703b601qxqzfj0yp0`, then ended `input-required/missing-terminal-writer` with no writer, envelope, receipt, or baseline. The exact infrastructure-inconclusive result is ledgered on `WC-25858CAB` under the operator-authorized semantic/bootstrap bypass.
- No plan-coverage receipt is claimed. The server resolved the immutable plan and refused persistence because no initiative scope baseline exists for BI-3FD07259; the plan records that exact condition and the atomic mapping table.
- No local exact-tree PASS is inferred. The operator-authorized bypass is ledgered for the inherited Windows-only Dockerfile path-separator fixture in `gate-context-runtime-contract.test.mjs`; Linux protected PR and merge-group checks are mandatory compensating verification.

Docs-Impact-Decision: Updated the self-upgrade operator guide for durable admission and reconciliation; linked architecture and CI documents retain their existing contracts.