### PR TITLE
fix(release): materialize Git LFS assets in the published image

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -156,7 +156,18 @@ jobs:
             tag_suffix: linux-arm64
 
     steps:
+      # lfs: true is load-bearing, not hygiene. This job supplies the image build
+      # context, and `.dockerignore` deliberately admits
+      # docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx so Dockerfile can
+      # COPY it. Without an LFS fetch, checkout leaves that path as a 130-byte
+      # pointer stub, the COPY bakes the stub in, and every install's
+      # eaReferenceModels seed step dies on "invalid zip data" with the IT4IT and
+      # BIAN reference models never importing (BI-FEE26C36). The Dockerfile
+      # asserts materialization, so removing this input fails the build rather
+      # than shipping a broken release.
       - uses: actions/checkout@v7
+        with:
+          lfs: true
 
       - name: Bind promoter image to its release contract
         id: promoter-contract

--- a/Dockerfile
+++ b/Dockerfile
@@ -197,6 +197,25 @@ COPY config/ ./config/
 # seed-ea-reference-models.ts. The rest of docs/Reference/ is large
 # binary content not needed in the image.
 COPY docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx ./docs/Reference/
+# The workbook is tracked in Git LFS, so a checkout without `lfs: true` copies a
+# ~130-byte pointer stub here instead of the real file. That shipped: every
+# consumer install's eaReferenceModels seed step failed with "invalid zip data"
+# and the IT4IT and BIAN reference models never imported (BI-FEE26C36).
+#
+# seed-ea-reference-models.ts already asserts a non-zero row count for exactly
+# this case, but that guard runs AFTER the workbook read and the xlsx parser
+# throws on a stub first — a guard placed after a read cannot cover a read that
+# throws. The assertion has to sit where the bytes enter the artifact.
+#
+# Fail the PUBLISH, never the install: a release that cannot seed its reference
+# models must not become :latest. An .xlsx is a zip, so real content starts "PK".
+RUN head -c 2 docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx | grep -q '^PK' || { \
+      echo "ERROR: docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx is not a zip archive."; \
+      echo "It is almost certainly an unmaterialized Git LFS pointer. Check out with lfs: true"; \
+      echo "(or run 'git lfs pull') before building this image."; \
+      head -c 64 docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx; \
+      exit 1; \
+    }
 RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @dpf/db exec prisma generate
 # Generate capability snapshot from mcp-tools.ts (runs at build time; output bundled into runner)

--- a/docs/superpowers/specs/2026-08-29-release-image-lfs-asset-materialization-design.md
+++ b/docs/superpowers/specs/2026-08-29-release-image-lfs-asset-materialization-design.md
@@ -1,0 +1,141 @@
+---
+status: active
+---
+
+# Release images must materialize their Git LFS assets
+
+**Backlog item:** BI-FEE26C36
+
+## Problem
+
+Every install fed by a published release artifact fails one seed step:
+
+```
+  x [seed] step "eaReferenceModels" FAILED (continuing): invalid zip data
+================ SEED INCOMPLETE: 1 step(s) failed ================
+```
+
+Observed on self-upgrade SUR-946F62CC (2026-08-29, `ef3ba508` -> `d9ed4bdb`,
+`v2026.08.29-review-prerequisite-recovery.1`). It fails non-fatally, so the
+portal starts and the degradation is easy to scroll past. It has been failing on
+every upgrade, because every release ships the same bytes.
+
+## Evidence and root cause
+
+`packages/db/src/seed-ea-reference-models.ts:20` reads
+`docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx`. An `.xlsx` is a zip
+archive, so "invalid zip data" means the file is not a workbook.
+
+It is a Git LFS pointer. Inside the running release image:
+
+```
+/app/docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx   130 bytes
+  version https://git-lfs.github.com/spec/v1
+  oid sha256:be8951db1c...
+  size 5004...
+```
+
+The same path in a source checkout is 50044 bytes and starts with `PK`.
+
+The chain that produces this:
+
+- `.gitattributes` tracks `*.xlsx` through LFS.
+- `.dockerignore:30` deliberately un-ignores this one workbook, and
+  `Dockerfile:193` copies it into the image.
+- `.github/workflows/publish-image.yml` checks out with `actions/checkout@v7`
+  and no `lfs` input, in the `build` job that supplies the image context.
+
+`actions/checkout` does not fetch LFS objects unless asked, so the pointer file
+is what reaches the build context, and the COPY bakes it in. The stub's mtime
+inside the image is the image build time, which rules out a runtime mount as the
+source.
+
+Nothing downstream can recover: `EaReferenceModelElement` stays empty, so EA
+views, reference-model comparison and architecture conformance all read an empty
+table on every consumer install.
+
+## Why the existing guard does not catch it
+
+`seedEaReferenceModels` already carries a row-count assertion from BI-98D19DF2
+for precisely this scenario -- its comment names "an LFS pointer stub
+masquerading as the real .xlsx". That guard runs *after* the workbook read and
+asserts the imported row count. Here the xlsx parser throws on the stub first, so
+the anticipated failure arrives through a path the guard cannot observe.
+
+The lesson generalises: a guard placed after a read cannot cover a read that
+throws. The assertion has to sit where the bytes enter the artifact.
+
+## Research and benchmarking
+
+How comparable projects keep LFS assets out of their images by accident, and what
+each approach costs:
+
+| Approach | Used by | Cost | Fit |
+| --- | --- | --- | --- |
+| `lfs: true` on `actions/checkout` | GitHub's own documented default for LFS repos; Grafana, Godot CI | Fetches every LFS object in the repo (~11 files here: pdf, docx, pptx, xlsx) | Simple, declarative, one line |
+| `git lfs pull --include=<path>` after checkout | Unity CI templates, large game repos | Fetches only what the image needs; an extra step to keep in sync with the Dockerfile | Cheaper bandwidth, more moving parts |
+| Take the file out of LFS | Common once a "binary" turns out to be small | Changes `.gitattributes` for every `*.xlsx`; adds a new blob | Removes the failure mode rather than guarding it |
+| Fetch at container runtime | Some ML images | Network dependency at install time; breaks air-gapped installs | Rejected -- a sovereign install must not need the network to seed |
+
+DPF's own doctrine settles the tie-break. "A built image carries the identity of
+its bytes" (`AGENTS.md` §12) means the artifact must be complete at build time,
+not repaired later; and "fix the seed, not the runtime" means the correction
+belongs in the publish path.
+
+## Decision
+
+Adopt `lfs: true` on the `build` job's checkout, and add a materialization
+assertion to the Dockerfile.
+
+`lfs: true` is chosen over the targeted `git lfs pull` because the include-list
+would be a second place recording which LFS assets the image needs -- the
+`.dockerignore` allowlist and the Dockerfile COPY already say that twice, and a
+third copy is the kind of drift `AGENTS.md` §1 exists to prevent. The whole LFS
+set for this repo is small enough that the bandwidth difference does not justify
+the coupling.
+
+Taking `*.xlsx` out of LFS is attractive and is worth doing on its own merits,
+but it is a wider change to `.gitattributes` affecting files this defect does not
+touch, and it would leave the publish path still able to ship a pointer for the
+`.pdf` and `.docx` assets if one is ever COPYed. Fixing the publish path covers
+every LFS asset, present and future.
+
+## The guard
+
+A `RUN` assertion immediately after the COPY in `Dockerfile`, failing the build
+with a named error when the copied workbook is a pointer rather than a zip.
+
+This belongs in the Dockerfile, not in a repo-policy guard: in the repository the
+file is *supposed* to be a pointer, so no source-tree check can distinguish
+healthy from broken. Only the build context can. Placing it in the Dockerfile
+also means a local `docker build` is covered, not only the publish workflow.
+
+The assertion fails the *publish*, never the install. That is the correct
+direction: a release that cannot seed its reference models should not become
+`:latest`.
+
+Note that no PR check builds the image (`Production Build` runs `next build`), so
+this guard fires at publish time. A workflow-shape test covers the case the
+Dockerfile guard cannot see -- someone removing `lfs: true` from the checkout --
+by asserting the input is present in the job that builds image contexts.
+
+## Blast radius
+
+- `lfs: true` adds one LFS fetch to the `build` job. The repo's LFS set is 11
+  files; no other job changes.
+- The Dockerfile `RUN` adds no layer content of consequence and runs in the
+  `init` stage that already holds the COPY.
+- No schema change, no runtime code change, no API change.
+- Existing installs are repaired by the next upgrade: the seed step stops
+  failing and imports the IT4IT and BIAN models on first successful run.
+
+## Verification
+
+- A freshly built image holds a real workbook at
+  `/app/docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx` (zip magic,
+  ~50 KB).
+- `pnpm seed` completes with zero failed steps against a release image.
+- `EaReferenceModelElement` is non-empty for both the IT4IT and BIAN models.
+- Removing `lfs: true` from the workflow fails the new workflow-shape test.
+- Feeding a pointer stub into the build context fails the image build with the
+  named error rather than producing a publishable image.

--- a/scripts/publish-image-release-identity.test.mjs
+++ b/scripts/publish-image-release-identity.test.mjs
@@ -47,3 +47,38 @@ test("latest is promoted only from the verified immutable release tag", () => {
   assert.match(promotion, /TAG: \$\{\{ needs\.gate\.outputs\.tag \}\}/);
   assert.match(promotion, /imagetools create --tag "\$\{IMAGE\}:latest" "\$\{IMAGE\}:\$\{TAG\}"/);
 });
+
+test("the image build context materializes Git LFS assets", () => {
+  const build = jobBlock("build", "merge");
+
+  // The build job supplies the docker context. `.dockerignore` deliberately
+  // admits docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx and the
+  // Dockerfile COPYs it, but that path is tracked in Git LFS. Without this
+  // input, actions/checkout leaves a ~130-byte pointer stub, the COPY bakes it
+  // in, and every install's eaReferenceModels seed dies on "invalid zip data"
+  // (BI-FEE26C36). No PR check builds the image, so this shape test is the only
+  // thing standing between a removed input and a broken published release.
+  assert.match(
+    build,
+    /uses: actions\/checkout@v7\s*\n\s*with:\s*\n\s*lfs: true/,
+    "the build job must check out with lfs: true or the image ships LFS pointer stubs",
+  );
+});
+
+test("the Dockerfile refuses to bake an unmaterialized LFS pointer", () => {
+  const dockerfile = readFileSync("Dockerfile", "utf8");
+  const copyIndex = dockerfile.indexOf(
+    "COPY docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx",
+  );
+  assert.notEqual(copyIndex, -1, "the IT4IT workbook COPY must exist");
+
+  // The assertion has to sit where the bytes enter the artifact: the row-count
+  // guard in seed-ea-reference-models.ts runs after the workbook read, and the
+  // xlsx parser throws on a stub before it is reached.
+  const afterCopy = dockerfile.slice(copyIndex);
+  assert.match(
+    afterCopy,
+    /head -c 2 docs\/Reference\/IT4IT_Functional_Criteria_Taxonomy\.xlsx \| grep -q '\^PK'/,
+    "the COPY must be followed by a zip-magic assertion so a pointer stub fails the publish, not the install",
+  );
+});


### PR DESCRIPTION
## What

The `publish-image` build job checked out without `lfs: true`, so `docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx` reached the docker context as a 130-byte Git LFS pointer stub. `.dockerignore:30` deliberately admits that one path and `Dockerfile:193` COPYs it, so the stub was baked into every published release.

## Why it matters

On every consumer install the seed reported:

```
  x [seed] step "eaReferenceModels" FAILED (continuing): invalid zip data
================ SEED INCOMPLETE: 1 step(s) failed ================
```

An `.xlsx` is a zip archive, so "invalid zip data" means the bytes are not a workbook. Inside the running release image:

```
/app/docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx   130 bytes
  version https://git-lfs.github.com/spec/v1
  oid sha256:be8951db1c...
```

The same path in a source checkout is 50044 bytes and starts with `PK`. The stub's mtime inside the image is the image build time, which rules out a runtime mount as the source.

`EaReferenceModelElement` therefore stays empty for both the IT4IT and BIAN models on every install, so EA views, reference-model comparison and architecture conformance all read an empty table. It fails non-fatally by design — correct for the swap — which is why it survived every upgrade unnoticed.

Observed on self-upgrade SUR-946F62CC (2026-08-29, `ef3ba508` → `d9ed4bdb`).

## Why the existing guard did not catch it

`seed-ea-reference-models.ts` already carries a row-count assertion from BI-98D19DF2 whose comment names this exact scenario — "an LFS pointer stub masquerading as the real .xlsx". That guard runs *after* the workbook read, and the xlsx parser throws on a stub first.

A guard placed after a read cannot cover a read that throws. The assertion has to sit where the bytes enter the artifact.

## Changes

1. `.github/workflows/publish-image.yml` — `lfs: true` on the `build` job checkout, the job that supplies the image context.
2. `Dockerfile` — a zip-magic assertion immediately after the COPY. It fails the **publish**, never the install: a release that cannot seed its reference models must not become `:latest`.
3. `scripts/publish-image-release-identity.test.mjs` — two shape tests. No PR check builds the image, so these are the only thing standing between a removed input and a broken published release.

Chose `lfs: true` over a targeted `git lfs pull --include=<path>`: the include-list would be a third place recording which LFS assets the image needs, after the `.dockerignore` allowlist and the Dockerfile COPY. The repo's whole LFS set is 11 files, so the bandwidth saving does not justify the drift risk.

## Verification

```
node --test scripts/publish-image-release-identity.test.mjs
  ✔ published image identity uses the resolved immutable release tag
  ✔ published promoter identity is bound to its checked-out contract
  ✔ latest is promoted only from the verified immutable release tag
  ✔ the image build context materializes Git LFS assets
  ✔ the Dockerfile refuses to bake an unmaterialized LFS pointer
  pass 5  fail 0
```

Both new tests were confirmed to **fail** when their subject is reverted — removing the `lfs: true` input fails the first, removing the Dockerfile assertion fails the second. A guard that cannot fail is not a guard.

The assertion's shell logic was exercised against both inputs directly: a real LFS pointer stub exits 1, the real 50 KB workbook passes.

## Change classification

- [x] **Runtime-bound change** (CI workflow + Dockerfile: the published image build)
- [x] **Verification-harness limitation acknowledged** — no PR check builds the image, so the end-to-end proof (a built image containing a real workbook) can only come from the publish run itself. That is why both shape guards exist and why the Dockerfile assertion fails the build rather than warning.

Local-CI-Override: operator-emergency: operator directed skipping local gates for this change — the Windows pre-push gate does not run on this host and the local-CI pool is structurally single-slot. Protected GitHub checks and the merge queue still apply.

## Governance note

The operator explicitly waived the initiative-readiness research and plan receipts for this item after four review dispatches to AGT-WS-PORTFOLIO failed to produce one. Root causes recorded on BI-F0715C9C: the immutable source reader had no resolvable repository (`PROJECT_ROOT=/sandbox-workspace` is a synthetic single-commit bootstrap repo), and separately the reviewer does not emit its terminal writer call even after a successful read.

The design document for this change is on the branch at `docs/superpowers/specs/2026-08-29-release-image-lfs-asset-materialization-design.md`.

Refs: BI-FEE26C36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
