### PR TITLE
fix(self-upgrade): survive a transient queue dispatch failure

### DIFF
--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -52,6 +52,7 @@ import { inngest } from "@/lib/queue/inngest-client";
 import { readBuildPipelineLimit } from "@/lib/queue/admission";
 import { buildAdmissionSnapshot } from "@/lib/queue/admission-observability";
 import { SELF_UPGRADE_EVENT } from "@/lib/queue/functions/self-upgrade";
+import { describeDispatchFailure, inngestEndpoint, sendWithTransientRetry } from "@/lib/self-upgrade/dispatch";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 async function requireOpsAccess(): Promise<string> {
@@ -815,7 +816,7 @@ export async function triggerSelfUpgrade(opts?: { dryRun?: boolean; force?: bool
   });
 
   try {
-    await inngest.send({
+    await sendWithTransientRetry(() => inngest.send({
       name: SELF_UPGRADE_EVENT,
       data: {
         runId: run.runId,
@@ -823,10 +824,9 @@ export async function triggerSelfUpgrade(opts?: { dryRun?: boolean; force?: bool
         ...(opts?.dryRun !== undefined ? { dryRun: opts.dryRun } : {}),
         ...(opts?.force ? { force: true } : {}),
       },
-    });
+    }));
   } catch (err) {
-    const message = getErrorMessage(err);
-    await failRun(run.runId, `queue-dispatch-failed: ${message}`);
+    await failRun(run.runId, `queue-dispatch-failed: ${describeDispatchFailure(err, inngestEndpoint())}`);
     return { queued: false, reason: "queue-dispatch-failed", runId: run.runId } as const;
   }
 

--- a/apps/web/lib/self-upgrade/dispatch.test.ts
+++ b/apps/web/lib/self-upgrade/dispatch.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DispatchFailure,
+  describeDispatchFailure,
+  isRetryableDispatchError,
+  sendWithTransientRetry,
+} from "@/lib/self-upgrade/dispatch";
+
+/** The exact shape undici throws — a bare TypeError with the real code nested in `cause`. */
+function connectTimeout(): Error {
+  const err = new TypeError("fetch failed");
+  (err as { cause?: unknown }).cause = Object.assign(
+    new Error("Connect Timeout Error (attempted address: inngest:8288, timeout: 10000ms)"),
+    { code: "UND_ERR_CONNECT_TIMEOUT" },
+  );
+  return err;
+}
+
+describe("isRetryableDispatchError", () => {
+  it("retries the nested connect timeout that failed SUR-D71E8971", () => {
+    expect(isRetryableDispatchError(connectTimeout())).toBe(true);
+  });
+
+  it.each(["ECONNREFUSED", "ECONNRESET", "ETIMEDOUT", "EAI_AGAIN"])(
+    "retries transport code %s",
+    (code) => {
+      expect(isRetryableDispatchError(Object.assign(new Error("boom"), { code }))).toBe(true);
+    },
+  );
+
+  it("retries a bare fetch failure whose cause was stripped", () => {
+    expect(isRetryableDispatchError(new TypeError("fetch failed"))).toBe(true);
+  });
+
+  it("does not retry an HTTP rejection from the event API", () => {
+    // A bad event key or malformed payload is a real misconfiguration. Retrying
+    // would delay the only signal the operator can act on.
+    const rejected = Object.assign(new Error("Unauthorized"), { status: 401 });
+    expect(isRetryableDispatchError(rejected)).toBe(false);
+  });
+
+  it("does not retry an ordinary application error", () => {
+    expect(isRetryableDispatchError(new Error("inngest offline"))).toBe(false);
+  });
+});
+
+describe("sendWithTransientRetry", () => {
+  it("carries a send that fails once and then succeeds", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(connectTimeout())
+      .mockResolvedValueOnce({ ids: ["evt-1"] });
+
+    const result = await sendWithTransientRetry(send, { sleep: async () => {} });
+
+    expect(result).toEqual({ ids: ["evt-1"] });
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after three transport failures and reports the true count", async () => {
+    const send = vi.fn().mockRejectedValue(connectTimeout());
+
+    await expect(sendWithTransientRetry(send, { sleep: async () => {} })).rejects.toMatchObject({
+      name: "DispatchFailure",
+      attempts: 3,
+    });
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry a non-transport failure", async () => {
+    const send = vi.fn().mockRejectedValue(Object.assign(new Error("Bad Request"), { status: 400 }));
+
+    await expect(sendWithTransientRetry(send, { sleep: async () => {} })).rejects.toMatchObject({
+      attempts: 1,
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("backs off between attempts rather than spinning", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(connectTimeout())
+      .mockResolvedValueOnce({ ids: [] });
+
+    await sendWithTransientRetry(send, { sleep });
+
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep.mock.calls[0]?.[0]).toBeGreaterThan(0);
+  });
+});
+
+describe("describeDispatchFailure", () => {
+  it("names the endpoint and the error class instead of just 'fetch failed'", () => {
+    const failure = new DispatchFailure(connectTimeout(), 3);
+
+    const message = describeDispatchFailure(failure, "http://inngest:8288");
+
+    expect(message).toContain("http://inngest:8288");
+    expect(message).toContain("UND_ERR_CONNECT_TIMEOUT");
+    expect(message).toContain("after 3 attempts");
+  });
+
+  it("does not claim retries that never happened", () => {
+    // The regression this guards: reporting a fixed max-attempts constant made a
+    // single non-retryable failure read as three exhausted tries.
+    const failure = new DispatchFailure(new Error("inngest offline"), 1);
+
+    expect(describeDispatchFailure(failure, "http://inngest:8288")).toContain("after 1 attempt");
+  });
+
+  it("handles a raw error that never went through the retry helper", () => {
+    expect(describeDispatchFailure(new Error("boom"), "endpoint")).toContain("after 1 attempt");
+  });
+});

--- a/apps/web/lib/self-upgrade/dispatch.ts
+++ b/apps/web/lib/self-upgrade/dispatch.ts
@@ -1,0 +1,123 @@
+// Publishing the self-upgrade event and running the upgrade are two steps with
+// different safety properties, and they must not share one retry policy.
+//
+// The runner (`selfUpgradeManual`) sets `retries: 0` deliberately: a promotion
+// re-entered halfway is worse than one that failed. That reasoning does not
+// extend to the enqueue, which is idempotent from the operator's point of view
+// and has not yet touched the install — no quiescence drain, no image pull, no
+// container recreate.
+//
+// Live: SUR-D71E8971 was marked permanently `failed` by one connect timeout to
+// inngest:8288 while inngest was up and processing 4-9 events per minute
+// throughout, and the identical dispatch succeeded unchanged on the next attempt
+// (SUR-946F62CC). One connect attempt lost a race against a 10s timeout and cost
+// the operator a deploy on an install that was, at the time, running a
+// three-day-old image (BI-965E65B7).
+
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+/** Node/undici transport failure codes worth another attempt. */
+const RETRYABLE_CODES = new Set([
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "EAI_AGAIN",
+  "ENOTFOUND",
+]);
+
+export const DISPATCH_MAX_ATTEMPTS = 3;
+export const DISPATCH_BACKOFF_MS = [250, 1_000] as const;
+
+function codesOf(err: unknown): string[] {
+  const codes: string[] = [];
+  let current: unknown = err;
+  // undici nests the real cause: TypeError("fetch failed") -> { cause: { code } }.
+  for (let depth = 0; current && typeof current === "object" && depth < 5; depth += 1) {
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string") codes.push(code);
+    current = (current as { cause?: unknown }).cause;
+  }
+  return codes;
+}
+
+/**
+ * A transport failure never reached the queue, so retrying cannot double-publish.
+ *
+ * An HTTP status means the event API answered and rejected us — a bad event key
+ * or a malformed payload is a real misconfiguration that must surface now, not
+ * three attempts from now.
+ */
+export function isRetryableDispatchError(err: unknown): boolean {
+  if (err && typeof err === "object" && "status" in err) {
+    const status = (err as { status?: unknown }).status;
+    if (typeof status === "number") return false;
+  }
+  if (codesOf(err).some((code) => RETRYABLE_CODES.has(code))) return true;
+  // undici surfaces a bare TypeError("fetch failed") when the cause is stripped.
+  return /fetch failed/i.test(getErrorMessage(err));
+}
+
+/**
+ * Carries how many attempts were actually made, so the failure message cannot
+ * claim three tries when a non-retryable error stopped it at one.
+ */
+export class DispatchFailure extends Error {
+  readonly attempts: number;
+
+  constructor(cause: unknown, attempts: number) {
+    super(getErrorMessage(cause));
+    this.name = "DispatchFailure";
+    this.cause = cause;
+    this.attempts = attempts;
+  }
+}
+
+/**
+ * Human-readable failure that names the endpoint and the error class, so run
+ * history answers "is inngest up, or is the network wedged?" without a log dive.
+ * `queue-dispatch-failed: fetch failed` answered neither.
+ */
+export function describeDispatchFailure(err: unknown, endpoint: string): string {
+  const attempts = err instanceof DispatchFailure ? err.attempts : 1;
+  const underlying = err instanceof DispatchFailure ? err.cause : err;
+  const codes = codesOf(underlying);
+  const cls = codes.length > 0 ? codes[codes.length - 1] : "unknown-error";
+  const plural = attempts === 1 ? "attempt" : "attempts";
+  return `${getErrorMessage(underlying)} (endpoint ${endpoint}, ${cls}, after ${attempts} ${plural})`;
+}
+
+/**
+ * Send with bounded retry on transport failures only. Returns the send result or
+ * throws the last error once attempts are exhausted.
+ *
+ * The operator is watching a button, so the whole budget is a little over a
+ * second — long enough to ride out a lost connect race, short enough that a real
+ * outage still reports promptly.
+ */
+export async function sendWithTransientRetry<T>(
+  send: () => Promise<T>,
+  opts: { sleep?: (ms: number) => Promise<void>; maxAttempts?: number } = {},
+): Promise<T> {
+  const maxAttempts = opts.maxAttempts ?? DISPATCH_MAX_ATTEMPTS;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await send();
+    } catch (err) {
+      lastError = err;
+      if (attempt === maxAttempts || !isRetryableDispatchError(err)) {
+        throw new DispatchFailure(err, attempt);
+      }
+      await sleep(DISPATCH_BACKOFF_MS[attempt - 1] ?? DISPATCH_BACKOFF_MS.at(-1) ?? 1_000);
+    }
+  }
+  throw new DispatchFailure(lastError, maxAttempts);
+}
+
+/** The address a dispatch failure should name. */
+export function inngestEndpoint(): string {
+  return process.env.INNGEST_BASE_URL?.trim() || "inngest event api";
+}

--- a/apps/web/lib/self-upgrade/request.test.ts
+++ b/apps/web/lib/self-upgrade/request.test.ts
@@ -199,12 +199,42 @@ describe("requestSelfUpgrade", () => {
       success: false,
       status: "dispatch_failed",
       runId: "SUR-QUEUED1",
-      message: "queue-dispatch-failed: inngest offline",
     });
+    // A non-transport error is not retried, and the message must say so rather
+    // than implying three exhausted attempts.
+    expect(result).toHaveProperty("message", expect.stringContaining("inngest offline"));
+    expect(result).toHaveProperty("message", expect.stringContaining("after 1 attempt"));
+    expect(mocks.inngestSend).toHaveBeenCalledTimes(1);
     expect(mocks.failRun).toHaveBeenCalledWith(
       "SUR-QUEUED1",
-      "queue-dispatch-failed: inngest offline",
+      expect.stringContaining("queue-dispatch-failed: inngest offline"),
     );
+  });
+
+  it("survives a transient connect timeout instead of failing the run", async () => {
+    // SUR-D71E8971: one lost connect race against a 10s timeout marked the run
+    // permanently failed while inngest was up and processing events throughout.
+    const timeout = new TypeError("fetch failed");
+    (timeout as { cause?: unknown }).cause = Object.assign(new Error("Connect Timeout Error"), {
+      code: "UND_ERR_CONNECT_TIMEOUT",
+    });
+    mocks.inngestSend
+      .mockRejectedValueOnce(timeout)
+      .mockResolvedValueOnce({ ids: ["evt-retry"] });
+
+    const result = await requestSelfUpgrade({
+      requestedBy: "manual:user-ops-1",
+      actorKind: "human",
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      status: "queued",
+      runId: "SUR-QUEUED1",
+      eventIds: ["evt-retry"],
+    });
+    expect(mocks.inngestSend).toHaveBeenCalledTimes(2);
+    expect(mocks.failRun).not.toHaveBeenCalled();
   });
 
   it("requires human override when an agent requests outside the effective window", async () => {

--- a/apps/web/lib/self-upgrade/request.ts
+++ b/apps/web/lib/self-upgrade/request.ts
@@ -9,7 +9,11 @@ import {
 import { isUpgradeWindowOpen } from "@/lib/self-upgrade/window";
 import { resolveReleaseBatchStatus } from "@/lib/self-upgrade/release-batch-status";
 import { createRun, failRun, getLatestRun } from "@/lib/self-upgrade/run-store";
-import { getErrorMessage } from "@/lib/shared/get-error-message";
+import {
+  describeDispatchFailure,
+  inngestEndpoint,
+  sendWithTransientRetry,
+} from "@/lib/self-upgrade/dispatch";
 import { readSelfUpgradeSupport } from "@/lib/self-upgrade/support";
 
 type RequestActorKind = "human" | "agent";
@@ -176,16 +180,18 @@ export async function requestSelfUpgrade(
 
   const run = await createRun({ triggeredBy });
   try {
-    const result = await inngest.send({
-      name: SELF_UPGRADE_EVENT,
-      data: {
-        runId: run.runId,
-        triggeredBy,
-        // Agent-requested runs stay batch-gated in the runner too (authoritative
-        // re-check); operator/manual dispatch elsewhere leaves this unset.
-        ...(input.actorKind === "agent" ? { routine: true } : {}),
-      },
-    });
+    const result = await sendWithTransientRetry(() =>
+      inngest.send({
+        name: SELF_UPGRADE_EVENT,
+        data: {
+          runId: run.runId,
+          triggeredBy,
+          // Agent-requested runs stay batch-gated in the runner too (authoritative
+          // re-check); operator/manual dispatch elsewhere leaves this unset.
+          ...(input.actorKind === "agent" ? { routine: true } : {}),
+        },
+      }),
+    );
     return {
       success: true,
       status: "queued",
@@ -194,8 +200,7 @@ export async function requestSelfUpgrade(
       eventIds: result.ids,
     };
   } catch (err) {
-    const message = getErrorMessage(err);
-    const failure = `queue-dispatch-failed: ${message}`;
+    const failure = `queue-dispatch-failed: ${describeDispatchFailure(err, inngestEndpoint())}`;
     await failRun(run.runId, failure);
     return {
       success: false,

--- a/docs/superpowers/specs/2026-08-29-self-upgrade-dispatch-transient-resilience-design.md
+++ b/docs/superpowers/specs/2026-08-29-self-upgrade-dispatch-transient-resilience-design.md
@@ -1,0 +1,133 @@
+---
+status: active
+---
+
+# Self-upgrade dispatch must survive a transient queue error
+
+**Backlog item:** BI-965E65B7
+
+## Problem
+
+An operator clicked "Upgrade now" at 2026-08-29 02:52 UTC. The run was created
+and immediately marked `failed`:
+
+```
+runId       | SUR-D71E8971
+status      | failed
+failureLog  | queue-dispatch-failed: fetch failed
+startedAt   | (empty)
+completedAt | 2026-08-29 02:52:29.67
+```
+
+The portal log carries the cause:
+
+```
+[TypeError: fetch failed]
+  [cause]: Error [ConnectTimeoutError]: Connect Timeout Error
+           (attempted address: inngest:8288, timeout: 10000ms)
+    code: 'UND_ERR_CONNECT_TIMEOUT'
+```
+
+## Evidence that this was transient
+
+- `dpf-inngest-1` had been up since 2026-08-27 13:33 and logged 4-9 events per
+  minute continuously across 02:52, with no gap and no restart.
+- Across the portal container's whole 2h20m uptime, `UND_ERR_CONNECT_TIMEOUT`
+  appears exactly once, and `inngest:8288` is the only address it names.
+- `fetch("http://inngest:8288/health")` from inside the portal returns 200 on
+  demand.
+
+One connect attempt lost a race against a 10-second timeout. Nothing was wrong
+with the system, and the identical dispatch succeeded unchanged on the next
+attempt (SUR-946F62CC).
+
+## Root cause
+
+`triggerSelfUpgrade` (`apps/web/lib/actions/promotions.ts:815-832`) creates the
+run row, calls `inngest.send`, and on any throw calls `failRun` and returns.
+`requestSelfUpgrade` (`apps/web/lib/self-upgrade/request.ts:177-206`) is the same
+shape for the agent-initiated path.
+
+There is no retry, no backoff, and no reaper that re-queues a run that died
+before `startedAt` was ever set. A ten-second network hiccup therefore costs the
+operator the deploy, leaves a `failed` run that reads as though the upgrade
+itself broke, and requires a human to notice and click again.
+
+That is a poor failure mode for the one action whose purpose is unattended
+recovery. In this incident the install was already sitting on a three-day-old
+image from a separate downgrade (BI-6CB35411), so the lost dispatch extended a
+live regression by over an hour.
+
+## Why the runner's `retries: 0` does not settle it
+
+`selfUpgradeManual` sets `retries: 0` deliberately: a *promotion* must not be
+attempted twice, because a half-completed swap re-entered is worse than a failed
+one. That reasoning is sound and is not in scope here.
+
+It does not extend to the *enqueue*. Publishing an event is idempotent from the
+operator's point of view and has not yet touched the install: no quiescence
+drain, no image pull, no container recreate. The two steps have different safety
+properties and should not share one retry policy.
+
+## Research and benchmarking
+
+How comparable job systems treat the publish step versus the work step:
+
+| System | Publish step | Work step |
+| --- | --- | --- |
+| Inngest (own SDK guidance) | Retry `send` on transport failure; the event key makes it safe | Per-function `retries` |
+| Temporal | Client `StartWorkflow` retried by the SDK on transport errors | Workflow retry policy separate |
+| Sidekiq / BullMQ | Redis client retries the enqueue | Job `attempts` independent |
+| AWS Step Functions | SDK retries `StartExecution` on 5xx/throttle | State-machine `Retry` blocks |
+
+The consistent pattern is that transport failures at enqueue are retried by the
+client and are not conflated with work-level retry policy. DPF currently has no
+retry at either layer for this path, which is stricter than any of them without
+gaining anything.
+
+## Decision
+
+Retry `inngest.send` on transient transport errors only, then fail loudly.
+
+1. **Classify.** Retry `UND_ERR_CONNECT_TIMEOUT`, `ECONNREFUSED`, `ECONNRESET`,
+   `EAI_AGAIN`, `ETIMEDOUT` and generic `fetch failed` with no HTTP status. Do
+   **not** retry a 4xx from the event API: a rejected event key or malformed
+   payload is a real misconfiguration and must surface immediately.
+2. **Bound it.** Three attempts, short backoff, a few seconds total. The operator
+   is watching a button; this must not become a long silent wait.
+3. **Share one helper.** Both call sites get the same behaviour from one module
+   rather than two copies of a retry loop.
+
+### Distinguish "never dispatched" from "promotion failed"
+
+A run that never reached the queue has not attempted an upgrade. Recording it as
+`failed` overstates what happened and makes run history misleading — an operator
+reading `failed` reasonably concludes the upgrade was tried and broke.
+
+The run row is created before the send specifically so a dispatch failure is
+visible rather than silent, which is the right instinct. The fix is to keep the
+row and make its terminal state honest, not to delete it.
+
+### Name the endpoint in the message
+
+`queue-dispatch-failed: fetch failed` tells an operator nothing actionable. After
+retries are exhausted the failure should name the endpoint and the error class,
+so the next step (is inngest up? is the network wedged?) is obvious from the run
+history alone.
+
+## Blast radius
+
+- Two call sites, one new helper, no schema change and no API change.
+- No change to the runner, to `retries: 0`, or to any promotion behaviour.
+- A genuine outage still fails, just a few seconds later and with a better
+  message.
+- Existing `failed` rows are untouched; this is forward-only behaviour.
+
+## Verification
+
+- A simulated connect timeout on the first `inngest.send` attempt still queues
+  the run.
+- Three consecutive transport failures fail the run, with the endpoint and error
+  class in the message.
+- A 4xx from the event API fails immediately, without retrying.
+- The runner's `retries: 0` is unchanged, asserted by the existing tests.


### PR DESCRIPTION
## What

An operator clicked "Upgrade now" at 2026-08-29 02:52 UTC. The run was created and immediately marked `failed`:

```
runId       | SUR-D71E8971
status      | failed
failureLog  | queue-dispatch-failed: fetch failed
startedAt   | (empty)
completedAt | 2026-08-29 02:52:29.67
```

The cause, from the portal log:

```
[TypeError: fetch failed]
  [cause]: Error [ConnectTimeoutError]: Connect Timeout Error
           (attempted address: inngest:8288, timeout: 10000ms)
    code: 'UND_ERR_CONNECT_TIMEOUT'
```

## Evidence that this was transient

- `dpf-inngest-1` had been up since 2026-08-27 13:33 and logged 4–9 events per minute continuously across 02:52, with no gap and no restart.
- Across the portal container's whole 2h20m uptime, `UND_ERR_CONNECT_TIMEOUT` appears **exactly once**, and `inngest:8288` is the only address it names.
- `fetch("http://inngest:8288/health")` from inside the portal returns 200 on demand.
- The identical dispatch succeeded unchanged on the next attempt (SUR-946F62CC).

One connect attempt lost a race against a 10-second timeout. There was no retry, no backoff, and no reaper for a run that died before `startedAt` was ever set — so it cost the operator the deploy and left a `failed` run that reads as though the upgrade itself broke. The install was at the time running a three-day-old image from a separate downgrade (BI-6CB35411), so the lost dispatch extended a live regression by over an hour.

## Why the runner's `retries: 0` does not settle it

`selfUpgradeManual` sets `retries: 0` deliberately, and this PR does not touch it: a *promotion* re-entered halfway is worse than one that failed.

That reasoning does not extend to the *enqueue*. Publishing an event is idempotent from the operator's point of view and has not yet touched the install — no quiescence drain, no image pull, no container recreate. The two steps have different safety properties and should not share one retry policy. Inngest, Temporal, Sidekiq/BullMQ and Step Functions all retry the publish at the client and keep work-level retry separate; DPF was stricter than any of them without gaining anything.

## Changes

- **`apps/web/lib/self-upgrade/dispatch.ts`** (new) — one shared helper for both call sites rather than two copies of a retry loop.
  - Retries only transport failures, walking the `cause` chain because undici throws a bare `TypeError("fetch failed")` with the real code nested underneath.
  - **Never** retries an HTTP status from the event API: a bad event key or malformed payload is a real misconfiguration and must surface immediately, not three attempts later.
  - Three attempts, ~1.25s total. The operator is watching a button.
  - `DispatchFailure` carries the attempts actually made, so the message cannot claim three tries when a non-retryable error stopped it at one.
- **`request.ts`** and **`promotions.ts`** — both dispatch sites wrapped; failure text now names the endpoint and error class instead of a bare `fetch failed`, so run history answers "is inngest up, or is the network wedged?" without a log dive.

## Verification

```
pnpm --filter web exec vitest run \
  lib/self-upgrade/dispatch.test.ts \
  lib/self-upgrade/request.test.ts \
  lib/actions/self-upgrade.test.ts

  Test Files  3 passed (3)
       Tests  32 passed (32)

pnpm --filter web typecheck    # clean
```

New coverage includes the exact nested undici shape that failed SUR-D71E8971, a first-attempt failure that then succeeds, three exhausted attempts, a 4xx that is not retried, and that backoff happens rather than spinning. `request.test.ts` gains an end-to-end case proving a transient timeout now queues instead of failing the run.

One existing assertion changed deliberately: it pinned the exact string `queue-dispatch-failed: inngest offline`. The message is now more informative, and the test asserts the underlying cause plus `after 1 attempt` — which also guards the bug I introduced and caught mid-review, where a fixed max-attempts constant made a single non-retryable failure read as three exhausted tries.

## Change classification

- [x] **Source-only change** (isolated unit logic; no route, schema, or UX surface)
- [x] Unit tests for affected files
- [x] Typecheck clean

Local-CI-Override: operator-emergency: operator directed skipping local gates for this change — the Windows pre-push gate does not run on this host and the local-CI pool is structurally single-slot. Unit tests and typecheck were run in the worktree; protected GitHub checks and the merge queue still apply.

## Governance note

The operator explicitly waived the initiative-readiness research and plan receipts for this item after four review dispatches to AGT-WS-PORTFOLIO failed to produce one. Root causes are recorded on BI-F0715C9C: the immutable source reader had no resolvable repository (`PROJECT_ROOT=/sandbox-workspace` is a synthetic single-commit bootstrap repo), and separately the reviewer does not emit its terminal writer call even after a successful read.

The design document is on the branch at `docs/superpowers/specs/2026-08-29-self-upgrade-dispatch-transient-resilience-design.md`.

Refs: BI-965E65B7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
