### PR TITLE
fix(install): preserve deployed release identity on restart

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1256,6 +1256,9 @@
     "docs/testing/ci-observation-baseline.json": [
       "docs/testing/ci-evidence.md"
     ],
+    "dpf-start.ps1": [
+      "docs/runbooks/bet5-windows-self-upgrade.md"
+    ],
     "e2e/fixtures/evidence.ts": [
       "docs/architecture/agent-client-capability-parity.md"
     ],
@@ -2850,6 +2853,7 @@
     ],
     "docs/runbooks/bet5-windows-self-upgrade.md": [
       "apps/web/lib/self-upgrade/host-memory-preflight.ts",
+      "dpf-start.ps1",
       "scripts/promote.sh"
     ],
     "docs/security/2026-05-24-shift-left-rollout.md": [

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8795,6 +8795,7 @@
         "what-bet-5-does",
         "why-this-box-needs-a-one-time-bootstrap",
         "consumer-release-installs-artifact-native-upgrades",
+        "ordinary-restart-after-a-consumer-upgrade",
         "preconditions-capture-current-state-first",
         "step-1-bootstrap-the-promoter-from-current-main",
         "step-2-trigger-the-upgrade",

--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -5,14 +5,9 @@ import { copyFileSync, existsSync, mkdtempSync, writeFileSync, chmodSync, mkdirS
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-// High-fidelity functional proof of scripts/promote.sh: run the REAL script
-// through all six steps against a REAL git repo, faking only the external
-// boundaries — `docker` (the image build is orthogonal to the stamp logic) and
-// `curl` (the portal's /api/health/sha). The fake portal "reports" whatever
-// DPF_VERSION the build stamped, by echoing $DPF_VERSION — which is exactly how
-// the real round-trip works (DPF_VERSION build-arg → /app/.dpf-image-version →
-// /api/health/sha). So a passing sha-verify here means the same thing it means
-// in production: the running runtime reports the SHA of the code that was built.
+// High-fidelity proof of the real promote.sh against a real Git repo, faking
+// only Docker and HTTP. The fake portal reports the stamped DPF_VERSION, so
+// sha-verify exercises the production build-arg -> image -> endpoint contract.
 
 const SCRIPT = resolve(__dirname, "../../../../scripts/promote.sh");
 const REPO_ROOT = resolve(__dirname, "../../../..");
@@ -152,6 +147,7 @@ exit 0
 
 function runPromote(opts: {
   source: string;
+  installRoot?: string;
   backup: string;
   targetSha: string;
   fakeBin: string;
@@ -173,11 +169,8 @@ function runPromote(opts: {
   const secretPath = join(stateDir, "runtime-transition.secret");
   writeFileSync(secretPath, secret);
   const stateBytes = readFileSync(join(stateDir, "install-state.json"));
-  // Ask the canonical migrator for the real projection. The previous fixture
-  // asserted `projectionHash === sourceHash`, which is never true of an actual
-  // projection; it went unnoticed only because promote.sh skipped the migrator
-  // whenever the schema version did not change, so the carrier's CAS binding
-  // was never checked (BI-AA6FBAD0).
+  // Use the canonical migrator: a real projection hash differs from sourceHash,
+  // and the fixture must exercise that CAS binding (BI-AA6FBAD0).
   const projection = JSON.parse(execFileSync(process.execPath, [MIGRATOR,
     "--state", join(stateDir, "install-state.json"), "--catalog", CATALOG,
     "--host-platform", "linux", "--host-arch", "amd64"], { encoding: "utf8" })) as { sourceHash: string; projectionHash: string };
@@ -201,6 +194,7 @@ function runPromote(opts: {
     "unset DPF_STATE_DIR",
     `export PATH=${shellQuote(toBashPath(opts.fakeBin))}:"$PATH"`,
     `export PROMOTE_SOURCE=${shellQuote(toBashPath(opts.source))}`,
+    ...(opts.installRoot ? [`export PROMOTE_INSTALL_ROOT=${shellQuote(toBashPath(opts.installRoot))}`] : []),
     `export PROMOTE_TARGET_SHA=${shellQuote(opts.targetSha)}`,
     `export PROMOTE_BACKUP_PATH=${shellQuote(toBashPath(opts.backup))}`,
     `export DPF_PROMOTER_STATE_DIR=${shellQuote(toBashPath(join(opts.backup, "state")))}`,
@@ -265,11 +259,8 @@ function makeScratch(): { root: string; source: string; backup: string; fakeBin:
   const backup = join(root, "backup");
   const stateDir = join(backup, "state");
   mkdirSync(stateDir, { recursive: true });
-  // Produce the install-state the way an install actually gets one: hand a
-  // legacy state to the canonical migrator. Hand-assembling the capability
-  // snapshot here re-derived the closure by hand and drifted from the resolver;
-  // the legacy default already enables `runtime:build`, which is what the
-  // sandbox-refresh path in this fixture exercises.
+  // Produce state through the canonical legacy migrator so capability closure
+  // cannot drift from the runtime resolver.
   writeFileSync(join(stateDir, "install-state.json"), JSON.stringify({
     schemaVersion: 1, installerVersion: "functional", platform: "linux", arch: "amd64",
     installPath: "/opt/dpf", stateDir: "/dpf-state", composeProjectName: "dpf",
@@ -295,6 +286,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
   ])("promotes a verified release into a source-free install for a $caller", ({ caller, configDigest, engineImageId, platformArchitecture, enginePlatformArchitecture, frozenStrata, missingModernStratum, repoImageId, registryConfigDigest, duplicatePlatform, expectedStatus }) => {
     const { root, source, backup, fakeBin } = makeScratch();
     const targetSha = "b".repeat(40);
+    const installRoot = join(root, "canonical-install");
     const candidateAssets = join(root, "candidate-assets");
     const gitLog = join(root, "git.log");
     const dockerLog = join(root, "docker.log");
@@ -303,6 +295,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       writeFileSync(join(source, "docker-compose.release.yml"), "services: {}\n");
       writeFileSync(join(source, ".install-mode"), "consumer\n");
       writeFileSync(join(source, ".env"), "KEEP_ME=yes\nDPF_IMAGE_TAG=v1.0.0\nGHCR_OWNER=opendigitalproductfactory\n");
+      mkdirSync(installRoot, { recursive: true });
       mkdirSync(candidateAssets, { recursive: true });
       for (const relativePath of [
         "docker-compose.yml",
@@ -327,6 +320,9 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       const currentManaged = ["docker-compose.yml", "docker-compose.release.yml"];
       writeFileSync(join(source, ".verified-release-assets.sha256"), currentManaged.map(path => `${createHash("sha256").update(readFileSync(join(source, path))).digest("hex")}  ./${path}`).join("\n") + "\n");
       writeFileSync(join(source, ".verified-release-assets-version"), "v1.0.0");
+      for (const relativePath of [...currentManaged, ".env", ".verified-release-assets.sha256", ".verified-release-assets-version"]) {
+        copyFileSync(join(source, relativePath), join(installRoot, relativePath));
+      }
       const statePath = join(backup, "state", "install-state.json");
       const existing = JSON.parse(readFileSync(statePath, "utf8"));
       writeFileSync(statePath, JSON.stringify({
@@ -335,7 +331,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
         installerVersion: "v1.0.0",
         lastSuccessfulInstallVersion: "v1.0.0",
         arch: "amd64",
-        installPath: source,
+        installPath: installRoot,
         installMode: "consumer",
         composeFiles: ["docker-compose.yml", "docker-compose.release.yml"],
         imageTag: "v1.0.0",
@@ -348,7 +344,7 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
         platformManifestDigest: missingModernStratum ? undefined : `sha256:${"b".repeat(64)}`, configDigest, engineImageId, platformOs: "linux",
         platformArchitecture, enginePlatformArchitecture, frozenStrata, repoImageId, registryConfigDigest, duplicatePlatform, candidateAssets, gitLog,
       };
-      const r = runPromote({ source, backup, targetSha, fakeBin, dockerLog, release });
+      const r = runPromote({ source, installRoot, backup, targetSha, fakeBin, dockerLog, composeEnvFile: join(installRoot, ".env"), release });
       expect(r.status, r.stderr).toBe(expectedStatus);
       if (expectedStatus !== 0) {
         expect(r.stderr).toMatch(/(?:missing required variables|not a pulled repository digest|could not resolve an immutable|resolved config digest .* does not match|does not match resolved (?:config\/platform\/channel identities|candidate linux\/amd64))/);
@@ -362,8 +358,11 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       } else {
         expect(r.stdout).toContain("step=release-identity mode=legacy-bootstrap");
       }
-      expect(readFileSync(join(source, ".env"), "utf8")).toMatch(/^KEEP_ME=yes$/m);
-      expect(readFileSync(join(source, ".env"), "utf8")).toMatch(/^DPF_IMAGE_TAG=v2\.0\.0$/m);
+      expect(readFileSync(join(installRoot, ".env"), "utf8")).toMatch(/^KEEP_ME=yes$/m);
+      expect(readFileSync(join(installRoot, ".env"), "utf8")).toMatch(/^DPF_IMAGE_TAG=v2\.0\.0$/m);
+      expect(readFileSync(join(installRoot, ".verified-release-assets-version"), "utf8").trim()).toBe("v2.0.0");
+      expect(readFileSync(join(source, ".env"), "utf8")).toMatch(/^DPF_IMAGE_TAG=v1\.0\.0$/m);
+      expect(readFileSync(join(source, ".verified-release-assets-version"), "utf8").trim()).toBe("v1.0.0");
       expect(JSON.parse(readFileSync(statePath, "utf8")).imageTag).toBe("v2.0.0");
       const calls = readFileSync(dockerLog, "utf8");
       expect(calls).toContain("pull portal postgres");

--- a/apps/web/lib/self-upgrade/promote-script-legacy-bootstrap.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-legacy-bootstrap.test.ts
@@ -187,6 +187,7 @@ function runCandidate(fixture: Fixture, options: {
     "unset DPF_STATE_DIR DPF_PROMOTION_MODE DPF_RELEASE_TAG DPF_RELEASE_CONFIG_DIGEST GHCR_OWNER",
     `export PATH=${quote(bashPath(fixture.fakeBin))}:"$PATH"`,
     `export PROMOTE_SOURCE=${quote(bashPath(fixture.source))}`,
+    `export PROMOTE_INSTALL_ROOT=${quote(bashPath(fixture.source))}`,
     `export PROMOTE_TARGET_SHA=${TARGET_SHA}`,
     `export PROMOTE_BACKUP_PATH=${quote(bashPath(fixture.backup))}`,
     `export DPF_PROMOTER_STATE_DIR=${quote(bashPath(stateDir))}`,

--- a/docs/runbooks/bet5-windows-self-upgrade.md
+++ b/docs/runbooks/bet5-windows-self-upgrade.md
@@ -67,6 +67,19 @@ the page intentionally hides **Upgrade now** and queues nothing until it can pro
 A current state also has no upgrade action because the running config digest already equals the
 verified channel candidate. Both states are safe and non-mutating.
 
+### Ordinary restart after a consumer upgrade
+
+Release promotion writes the verified tag and managed assets to the canonical install directory,
+not to the temporary candidate workspace. On Windows, `dpf-start.ps1` then reads the consumer
+install's recorded `imageTag` before Compose interpolation. That immutable recorded tag overrides a
+contradictory process or root `.env` value such as `latest`, so an ordinary restart cannot silently
+replace the deployed release with older cached bytes.
+
+The start command stops before Docker mutation if a known consumer install has a missing, mutable,
+malformed, or wrong-install-path release identity. Repair that state with the governed consumer
+installer or Upgrade Center; do not edit `.env` or install-state by hand. Contributor/source installs
+retain their existing local-image behavior.
+
 ## Preconditions — capture current state first
 
 Run these and record the output before doing anything:

--- a/docs/superpowers/plans/2026-08-29-consumer-start-release-identity-convergence.md
+++ b/docs/superpowers/plans/2026-08-29-consumer-start-release-identity-convergence.md
@@ -15,6 +15,15 @@ release identity to the canonical install root, and the Windows start path must
 project that recorded identity into Compose. Shipping only one half leaves a
 silent downgrade path, so the changes and rollback evidence remain one PR.
 
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-6CB35411`
+- Receipt: pending
+- Rationale: Canonical-root promotion and state-authoritative restart projection close one release-identity invariant; either half alone leaves a consumer install able to restart onto different bytes.
+- Dependencies: protected BI-3FD07259 caller bridge PR #4840 at `7eba6d0c2485a800f8d66f31aa1521008fa9e59b`; no independent BI decomposition.
+- Consumer start release-identity convergence -> `BI-6CB35411`
+
 ## Phase 1 — Lock the source/canonical-root vocabulary
 
 1. Extend `apps/web/lib/self-upgrade/promoter.test.ts` with RED command-builder

--- a/docs/superpowers/plans/2026-08-29-consumer-start-release-identity-convergence.md
+++ b/docs/superpowers/plans/2026-08-29-consumer-start-release-identity-convergence.md
@@ -19,7 +19,7 @@ silent downgrade path, so the changes and rollback evidence remain one PR.
 
 - Decision: atomic
 - Parent: `BI-6CB35411`
-- Receipt: pending
+- Receipt: `cmte0jf1402dj01qxv20w5lsb`
 - Rationale: Canonical-root promotion and state-authoritative restart projection close one release-identity invariant; either half alone leaves a consumer install able to restart onto different bytes.
 - Dependencies: protected BI-3FD07259 caller bridge PR #4840 at `7eba6d0c2485a800f8d66f31aa1521008fa9e59b`; no independent BI decomposition.
 - Consumer start release-identity convergence -> `BI-6CB35411`

--- a/docs/superpowers/plans/2026-08-29-consumer-start-release-identity-convergence.md
+++ b/docs/superpowers/plans/2026-08-29-consumer-start-release-identity-convergence.md
@@ -1,0 +1,103 @@
+---
+status: active
+---
+
+# Consumer start-path release identity convergence implementation plan
+
+**Backlog item:** BI-6CB35411  
+**Workroom:** WC-DD034A30  
+**Design:** `docs/superpowers/specs/2026-08-29-consumer-start-release-identity-convergence-design.md`
+
+## Delivery shape
+
+Deliver one atomic release-identity contract: a promoter must commit verified
+release identity to the canonical install root, and the Windows start path must
+project that recorded identity into Compose. Shipping only one half leaves a
+silent downgrade path, so the changes and rollback evidence remain one PR.
+
+## Phase 1 — Lock the source/canonical-root vocabulary
+
+1. Extend `apps/web/lib/self-upgrade/promoter.test.ts` with RED command-builder
+   cases for a source workspace distinct from the canonical install root,
+   same-path aliasing, invalid/relative canonical paths, and readiness mode.
+2. Add `canonicalInstallPath` to `PromoterParams`; centralize host-path
+   validation and fixed mount selection in `promoter.ts` instead of adding
+   another inline Docker-argument branch.
+3. Mount a distinct canonical root read-write at `/canonical-install`, expose a
+   fixed `PROMOTE_INSTALL_ROOT`, and retain `/host-source` as the source carrier.
+4. Coordinate the one call-site addition in
+   `apps/web/lib/queue/functions/self-upgrade.ts` after BI-3FD07259 merges; do not
+   modify its admission/dispatch state machine or co-claim that file earlier.
+
+## Phase 2 — Make the release transaction target canonical
+
+1. Extend `scripts/installer/install-release-assets.test.mjs` with a RED fixture
+   whose staged source and install root are different directories.
+2. Extend `scripts/promote-install-state-rollback.test.mjs` and the focused
+   promoter functional tests to require canonical-root `.env`, release marker,
+   managed assets, install-state convergence, and exact rollback on injected
+   failure.
+3. Update `scripts/promote.sh` so release-identity commit invokes
+   `scripts/installer/install-release-assets.mjs` against
+   `PROMOTE_INSTALL_ROOT`, while source/build/backup operations continue using
+   `PROMOTE_SOURCE`.
+4. Keep `install-release-assets.mjs` as the sole atomic transaction owner;
+   refactor only shared path/tag validation and snapshot bookkeeping needed to
+   make the two roots explicit.
+
+## Phase 3 — Project install-state identity at Windows start
+
+1. Add RED cases to `scripts/lib/lifecycle-capability-profile-contract.test.mjs`
+   (and a focused PowerShell contract fixture if separation improves clarity)
+   for recorded-tag precedence over root `latest`, missing/malformed consumer
+   identity, disagreement diagnostics, and unchanged contributor behavior.
+2. Add a small pure helper in `scripts/installer/lib/state.ps1` that validates
+   and resolves the consumer release tag from canonical install-state.
+3. Invoke it in both `dpf-start.ps1` and `scripts/dpf-start.ps1` before Compose
+   arguments are resolved; set the process `DPF_IMAGE_TAG` only from a valid
+   consumer state and fail before Docker mutation otherwise.
+4. Keep legacy/source compatibility explicit; never infer that a known consumer
+   may fall back to mutable `latest`.
+
+## Phase 4 — Blast radius and refactor budget
+
+1. Audit every `runPromoter` caller and release-mode fixture; non-release runtime
+   transitions must retain read-only source mounts and unchanged behavior.
+2. Audit installer schema/migration behavior for legacy states and avoid a
+   schema change unless the existing `imageTag`/`installMode` contract proves
+   insufficient.
+3. Spend roughly one fifth of implementation effort consolidating repeated
+   release-tag validation, source-carrier/canonical-root naming, and Docker mount
+   construction. Do not broaden into admission, dispatch, publication, or UI.
+4. Run architecture and blast-radius review against the exact committed diff and
+   fold only concrete findings back into the implementation.
+
+## Phase 5 — Functional verification and protected delivery
+
+1. Run the focused promoter, installer transaction, rollback, lifecycle, and
+   public version-route suites plus web typecheck and all source-policy guards.
+2. Freeze a DCO-signed candidate, obtain one fresh semantic review, and run the
+   governed exact-tree local CI gate when capacity is available. Any authorized
+   infrastructure bypass is ledgered as non-PASS; protected GitHub checks remain
+   mandatory.
+3. Open one non-draft DCO PR, clear review findings, and enter the protected
+   merge queue.
+4. Publish one canonical immutable release and coordinate one governed live
+   upgrade only after BI-3FD admission/dispatch is live and the release identity
+   is unambiguous.
+5. Verify an ordinary `dpf-start.ps1 -NoBrowser` restart preserves the same
+   immutable tag, served SHA, health, Workrooms/backlog data, and
+   `/api/platform/version` plus `/api/platform/image-version` projection.
+
+## Verification commands
+
+```powershell
+pnpm --filter web exec vitest run lib/self-upgrade/promoter.test.ts lib/queue/functions/self-upgrade.test.ts
+node --test scripts/installer/install-release-assets.test.mjs scripts/promote-install-state-rollback.test.mjs scripts/lib/lifecycle-capability-profile-contract.test.mjs
+pnpm --filter web typecheck
+pnpm run pregate:preflight
+pnpm run pregate
+```
+
+The final two commands remain governed gates. No command in this plan edits the
+installed runtime source under `D:\DPF`.

--- a/docs/superpowers/plans/2026-08-29-consumer-start-release-identity-convergence.md
+++ b/docs/superpowers/plans/2026-08-29-consumer-start-release-identity-convergence.md
@@ -24,6 +24,10 @@ silent downgrade path, so the changes and rollback evidence remain one PR.
 - Dependencies: protected BI-3FD07259 caller bridge PR #4840 at `7eba6d0c2485a800f8d66f31aa1521008fa9e59b`; no independent BI decomposition.
 - Consumer start release-identity convergence -> `BI-6CB35411`
 
+| Deliverable | Backlog item | Requirements | Contracts | Flows | Verification | Depends on |
+| --- | --- | --- | --- | --- | --- | --- |
+| Consumer start release-identity convergence | `BI-6CB35411` | `OBJ-CSRI-001`, `OBJ-CSRI-002`, `OBJ-CSRI-003`, `OBJ-CSRI-004`, `OBJ-CSRI-005` | `AC-CSRI-001`, `AC-CSRI-002`, `AC-CSRI-003`, `AC-CSRI-004`, `AC-CSRI-005` | Phase 1, Phase 2, Phase 3, Phase 4, Phase 5 | `AC-CSRI-001`, `AC-CSRI-002`, `AC-CSRI-003`, `AC-CSRI-004`, `AC-CSRI-005` | `BI-3FD07259` |
+
 ## Phase 1 — Lock the source/canonical-root vocabulary
 
 1. Extend `apps/web/lib/self-upgrade/promoter.test.ts` with RED command-builder

--- a/docs/superpowers/specs/2026-08-29-consumer-start-release-identity-convergence-design.md
+++ b/docs/superpowers/specs/2026-08-29-consumer-start-release-identity-convergence-design.md
@@ -1,0 +1,175 @@
+---
+title: Consumer start-path release identity convergence
+status: draft
+backlog_item: BI-6CB35411
+workroom: WC-DD034A30
+---
+
+# Consumer start-path release identity convergence
+
+## Problem
+
+A successful source-isolated consumer self-upgrade commits release assets and
+`DPF_IMAGE_TAG` into the isolated upgrade workspace, while the host start path
+later runs Compose from the canonical install root. The canonical root can
+therefore retain `DPF_IMAGE_TAG=latest`. A subsequent `dpf-start.ps1` resolves
+that mutable tag and can silently replace a verified current release with an
+older cached image.
+
+This is a split-brain release identity defect. The state file records the new
+release correctly, but the install root used by Compose does not. The fix must
+make promotion and restart consume one durable identity without turning the
+consumer install into a source checkout or weakening immutable image checks.
+
+## Governed scope manifest
+
+- **OBJ-CSRI-001:** A successful release promotion commits the verified release
+  tag and managed release assets to the canonical install root used by future
+  host lifecycle commands.
+- **OBJ-CSRI-002:** The Windows start path treats validated install-state
+  `imageTag` as the authoritative release tag and cannot silently fall back to
+  a contradictory mutable `latest` value.
+- **OBJ-CSRI-003:** Identity commit and rollback remain atomic across managed
+  assets, root `.env`, release marker, and install-state.
+- **OBJ-CSRI-004:** Existing contributor/source installations and legacy
+  consumer installs retain an explicit, fail-closed compatibility path.
+- **OBJ-CSRI-005:** Operators can read the deployed source identity from the
+  existing public version endpoints after restart.
+
+| Acceptance criterion | Objective links | Required evidence |
+|---|---|---|
+| **AC-CSRI-001:** An isolated release promotion writes the candidate tag to the canonical install root `.env` and `.verified-release-assets-version`, while install-state records the same tag. | OBJ-CSRI-001, OBJ-CSRI-003 | Functional promoter fixture with distinct workspace and install-root directories. |
+| **AC-CSRI-002:** `dpf-start.ps1` exports a validated consumer `imageTag` from install-state before Compose interpolation; a contradictory root `.env` cannot select `latest`. | OBJ-CSRI-002, OBJ-CSRI-004 | PowerShell lifecycle contract test covering recorded-tag precedence. |
+| **AC-CSRI-003:** A consumer release install with missing or malformed recorded identity fails before `docker compose up`; contributor/source installs retain their existing behavior. | OBJ-CSRI-002, OBJ-CSRI-004 | Windows start-path negative and compatibility cases. |
+| **AC-CSRI-004:** Any failure during the canonical identity commit restores managed files, root `.env`, release marker, and install-state, and the promoter rollback uses the prior tag. | OBJ-CSRI-003 | Injected-failure transaction and promoter functional tests. |
+| **AC-CSRI-005:** `/api/platform/version` and `/api/platform/image-version` report the restarted container's baked SHA/version after the recorded tag is used. | OBJ-CSRI-005 | Existing route contracts plus live post-release verification. |
+
+## Evidence and root cause
+
+- `scripts/promote.sh` calls `install-release-assets.mjs --install
+  "$PROMOTE_SOURCE"` during `release-identity-commit`.
+- With isolated source enabled, `self-upgrade.ts` passes the workspace host path
+  to `runPromoter`; the promoter mounts it at `/host-source`.
+- `install-release-assets.mjs` writes `.env` and
+  `.verified-release-assets-version` beneath its `installDir`, so both writes
+  land in the workspace.
+- `dpf-start.ps1` runs Compose from `$DPF_DIR` and never reads install-state
+  `imageTag`. The release overlay therefore resolves `DPF_IMAGE_TAG` from the
+  canonical root `.env`, whose legacy value may be `latest`.
+- The running portal already exposes baked identity at
+  `/api/platform/version`, `/api/platform/image-version`, and `/api/health/sha`;
+  no new identity endpoint is required.
+
+## Decision
+
+Use a **canonical install-root identity transaction plus state-authoritative
+start projection**.
+
+The promoter receives the canonical host install path separately from its
+build/source workspace. In isolated release mode it mounts that exact directory
+at a fixed in-container path. `promote.sh` commits verified release assets and
+identity to that canonical root only after candidate health and source/content
+verification. Non-isolated release mode aliases the canonical root to
+`PROMOTE_SOURCE`, preserving the existing path.
+
+The Windows start path reads validated install-state through the existing
+`state.ps1` library. For a consumer release install it sets the process-level
+`DPF_IMAGE_TAG` to the recorded `imageTag` before invoking Compose. Process
+environment precedence deliberately prevents a stale root `.env` or mutable
+`latest` from selecting different bytes. A missing or malformed consumer tag is
+an actionable hard stop, not a fallback.
+
+## Architecture
+
+### 1. Separate source carrier from canonical install root
+
+Extend the existing promoter command contract with an optional
+`canonicalInstallPath` host path. Validate it with the same absolute-host-path
+rules used for other lifecycle mounts. When it differs from `hostInstallPath`,
+mount it read-write at `/canonical-install`; otherwise reuse `/host-source`.
+Pass only the fixed in-container path to `promote.sh`.
+
+The new mount does not create a new authority surface: the promoter already
+owns the release-assets transaction, Docker swap, and rollback. It narrows the
+write target from an accidentally isolated workspace to the install root named
+by validated install-state/configuration.
+
+### 2. Keep one release-assets transaction
+
+`install-release-assets.mjs` remains the sole transaction owner. It receives
+the canonical install directory for release mode and continues to:
+
+1. verify every staged asset against `SHA256SUMS`;
+2. snapshot managed files, `.env`, release marker, and install-state;
+3. atomically replace only manifest-managed files and release identity;
+4. update install-state under its existing transaction/CAS contract;
+5. restore every snapshot on any failure.
+
+The source workspace is never treated as durable installed identity. Promoter
+rollback composes from the same source carrier but interpolates the restored
+canonical root `.env`.
+
+### 3. Make install-state authoritative at host start
+
+After importing `state.ps1`, `dpf-start.ps1` resolves the install mode and
+recorded image tag before resolving Compose arguments.
+
+- Consumer/release install + valid recorded tag: set
+  `$env:DPF_IMAGE_TAG` to the recorded value and print the chosen immutable tag.
+- Consumer/release install + missing or invalid recorded tag: throw a named
+  `consumer_release_identity_missing` or
+  `consumer_release_identity_invalid` error before Docker mutation.
+- Contributor/source install: preserve existing local image/build behavior.
+- Explicit environment disagreement on a consumer install is reported, but the
+  validated recorded identity wins; there is no hidden downgrade override.
+
+Legacy installs whose state predates `installMode` remain on their current
+behavior until migrated by the existing installer-state migrator. Compatibility
+does not permit a known consumer with incomplete identity to use `latest`.
+
+### 4. Preserve distinct ownership boundaries
+
+- BI-3FD07259 / WC-25858CAB owns durable self-upgrade request admission,
+  dispatch, and reconciliation. This change does not edit that state machine.
+- BI-7175C7DB owns MCP actor propagation for Build Studio brief updates and is
+  already protected-merged.
+- Release publication policy for mutable `latest` is separate. This repair no
+  longer depends on `latest` being fresh, but it does not change publication.
+- No database schema or new operator control is introduced.
+
+## TDD and verification
+
+1. Add a red functional fixture with distinct workspace/canonical-root paths;
+   prove current code updates only the workspace, then require root env/marker,
+   state convergence, and rollback.
+2. Add red promoter-command tests for the canonical-root mount, fixed container
+   path, path validation, and non-isolated alias behavior.
+3. Add red PowerShell lifecycle cases for recorded-tag precedence, stale
+   `latest`, missing/malformed consumer identity, and unchanged contributor
+   behavior.
+4. Run affected promoter, installer transaction, lifecycle-contract,
+   self-upgrade orchestration, and public version-route tests plus web typecheck,
+   source policy, DCO, and exact-tree CI.
+5. Reserve roughly one fifth of implementation effort for refactoring: name the
+   source-carrier versus canonical-install concepts consistently, centralize tag
+   validation/projection, and remove duplicate ad-hoc env interpretation. Do not
+   broaden into dispatch or publication policy.
+6. After protected release, verify one governed upgrade and one ordinary
+   `dpf-start.ps1 -NoBrowser` restart preserve the same tag, SHA, health, data,
+   and public version projection.
+
+## Fail-closed conditions
+
+- Canonical install path absent, relative, contradictory, or not mountable.
+- Consumer install-state missing a valid immutable release tag.
+- Manifest, asset, OCI, or post-swap source identity disagreement.
+- Partial identity commit or rollback failure.
+- Compose resolves a tag different from the recorded consumer identity.
+
+## Non-goals
+
+- Changing self-upgrade admission/dispatch semantics.
+- Requiring a Git checkout on consumer installs.
+- Publishing or redefining the mutable `latest` channel.
+- Adding a second version endpoint or Upgrade Center control.
+- Editing installed runtime files as platform source.

--- a/docs/superpowers/specs/2026-08-29-consumer-start-release-identity-convergence-design.md
+++ b/docs/superpowers/specs/2026-08-29-consumer-start-release-identity-convergence-design.md
@@ -60,6 +60,17 @@ consumer install into a source checkout or weakening immutable image checks.
   `/api/platform/version`, `/api/platform/image-version`, and `/api/health/sha`;
   no new identity endpoint is required.
 
+## Governed artifact identity
+
+The design-review carrier is the DCO-signed commit published on
+`fix/consumer-start-path-preserves-deployed-release-i`, not a local-only object.
+Before any governed receipt is accepted, the immutable repository provider must
+resolve that exact commit, this file's exact blob, and the same Workroom head.
+A provider lookup failure is infrastructure-inconclusive: preserve the failed
+TaskRun and envelope, record the occurrence, and create a fresh immutable review
+identity only after repository provenance is demonstrably available. It must
+never be converted into a research or design PASS from prose.
+
 ## Decision
 
 Use a **canonical install-root identity transaction plus state-authoritative

--- a/docs/superpowers/specs/2026-08-29-consumer-start-release-identity-convergence-design.md
+++ b/docs/superpowers/specs/2026-08-29-consumer-start-release-identity-convergence-design.md
@@ -36,13 +36,13 @@ consumer install into a source checkout or weakening immutable image checks.
 - **OBJ-CSRI-005:** Operators can read the deployed source identity from the
   existing public version endpoints after restart.
 
-| Acceptance criterion | Objective links | Required evidence |
-|---|---|---|
-| **AC-CSRI-001:** An isolated release promotion writes the candidate tag to the canonical install root `.env` and `.verified-release-assets-version`, while install-state records the same tag. | OBJ-CSRI-001, OBJ-CSRI-003 | Functional promoter fixture with distinct workspace and install-root directories. |
-| **AC-CSRI-002:** `dpf-start.ps1` exports a validated consumer `imageTag` from install-state before Compose interpolation; a contradictory root `.env` cannot select `latest`. | OBJ-CSRI-002, OBJ-CSRI-004 | PowerShell lifecycle contract test covering recorded-tag precedence. |
-| **AC-CSRI-003:** A consumer release install with missing or malformed recorded identity fails before `docker compose up`; contributor/source installs retain their existing behavior. | OBJ-CSRI-002, OBJ-CSRI-004 | Windows start-path negative and compatibility cases. |
-| **AC-CSRI-004:** Any failure during the canonical identity commit restores managed files, root `.env`, release marker, and install-state, and the promoter rollback uses the prior tag. | OBJ-CSRI-003 | Injected-failure transaction and promoter functional tests. |
-| **AC-CSRI-005:** `/api/platform/version` and `/api/platform/image-version` report the restarted container's baked SHA/version after the recorded tag is used. | OBJ-CSRI-005 | Existing route contracts plus live post-release verification. |
+| Acceptance ID | Objective links | Acceptance statement | Required evidence |
+|---|---|---|---|
+| AC-CSRI-001 | OBJ-CSRI-001, OBJ-CSRI-003 | An isolated release promotion writes the candidate tag to the canonical install root `.env` and `.verified-release-assets-version`, while install-state records the same tag. | Functional promoter fixture with distinct workspace and install-root directories. |
+| AC-CSRI-002 | OBJ-CSRI-002, OBJ-CSRI-004 | `dpf-start.ps1` exports a validated consumer `imageTag` from install-state before Compose interpolation; a contradictory root `.env` cannot select `latest`. | PowerShell lifecycle contract test covering recorded-tag precedence. |
+| AC-CSRI-003 | OBJ-CSRI-002, OBJ-CSRI-004 | A consumer release install with missing or malformed recorded identity fails before `docker compose up`; contributor/source installs retain their existing behavior. | Windows start-path negative and compatibility cases. |
+| AC-CSRI-004 | OBJ-CSRI-003 | Any failure during the canonical identity commit restores managed files, root `.env`, release marker, and install-state, and the promoter rollback uses the prior tag. | Injected-failure transaction and promoter functional tests. |
+| AC-CSRI-005 | OBJ-CSRI-005 | `/api/platform/version` and `/api/platform/image-version` report the restarted container's baked SHA/version after the recorded tag is used. | Existing route contracts plus live post-release verification. |
 
 ## Evidence and root cause
 

--- a/dpf-start.ps1
+++ b/dpf-start.ps1
@@ -18,15 +18,20 @@ elseif ($NoEdge) { $env:DPF_INCLUDE_EDGE = '0' }
 $includeEdge = $false
 $stateLib = Join-Path $DPF_DIR "scripts\installer\lib\state.ps1"
 if (-not (Test-Path -LiteralPath $stateLib)) { $stateLib = Join-Path $DPF_DIR "installer\lib\state.ps1" }
-try {
-    if (Test-Path -LiteralPath $stateLib) {
-        . $stateLib
+if (Test-Path -LiteralPath $stateLib) {
+    . $stateLib
+    try {
         $includeEdge = Resolve-DpfEdgeEnabled -InstallDir $DPF_DIR
-    } else {
+    } catch {
         $includeEdge = ($env:DPF_INCLUDE_EDGE -eq '1')
     }
-} catch {
+} else {
     $includeEdge = ($env:DPF_INCLUDE_EDGE -eq '1')
+}
+
+$consumerReleaseTag = Resolve-DpfConsumerReleaseImageTag -InstallDir $DPF_DIR
+if ($consumerReleaseTag) {
+    Write-Host "Using recorded consumer release tag $consumerReleaseTag" -ForegroundColor Cyan
 }
 
 $capabilityProjection = Resolve-DpfCapabilityComposeProfiles -InstallDir $DPF_DIR

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -639,6 +639,10 @@ if (-not (Test-Path -LiteralPath $stateLib)) { $stateLib = Join-Path $DPF_DIR "i
 if (-not (Test-Path -LiteralPath $stateLib)) { throw "capability_state_helper_missing" }
 . $stateLib
 $includeEdge = Resolve-DpfEdgeEnabled -InstallDir $DPF_DIR
+$consumerReleaseTag = Resolve-DpfConsumerReleaseImageTag -InstallDir $DPF_DIR
+if ($consumerReleaseTag) {
+    Write-Host "Using recorded consumer release tag $consumerReleaseTag" -ForegroundColor Cyan
+}
 $capabilityProjection = Resolve-DpfCapabilityComposeProfiles -InstallDir $DPF_DIR
 $env:COMPOSE_PROFILES = (@($capabilityProjection.composeProfiles) -join ',')
 

--- a/scripts/dpf-start.ps1
+++ b/scripts/dpf-start.ps1
@@ -18,15 +18,20 @@ elseif ($NoEdge) { $env:DPF_INCLUDE_EDGE = '0' }
 $includeEdge = $false
 $stateLib = Join-Path $DPF_DIR "scripts\installer\lib\state.ps1"
 if (-not (Test-Path -LiteralPath $stateLib)) { $stateLib = Join-Path $DPF_DIR "installer\lib\state.ps1" }
-try {
-    if (Test-Path -LiteralPath $stateLib) {
-        . $stateLib
+if (Test-Path -LiteralPath $stateLib) {
+    . $stateLib
+    try {
         $includeEdge = Resolve-DpfEdgeEnabled -InstallDir $DPF_DIR
-    } else {
+    } catch {
         $includeEdge = ($env:DPF_INCLUDE_EDGE -eq '1')
     }
-} catch {
+} else {
     $includeEdge = ($env:DPF_INCLUDE_EDGE -eq '1')
+}
+
+$consumerReleaseTag = Resolve-DpfConsumerReleaseImageTag -InstallDir $DPF_DIR
+if ($consumerReleaseTag) {
+    Write-Host "Using recorded consumer release tag $consumerReleaseTag" -ForegroundColor Cyan
 }
 
 $capabilityProjection = Resolve-DpfCapabilityComposeProfiles -InstallDir $DPF_DIR

--- a/scripts/installer/install-release-assets.test.mjs
+++ b/scripts/installer/install-release-assets.test.mjs
@@ -64,6 +64,9 @@ test("verified release assets replace only managed files and converge durable id
   assert.match(env, /^DPF_IMAGE_TAG=v2\.0\.0$/m);
   assert.match(env, /^GHCR_OWNER=opendigitalproductfactory$/m);
   assert.equal(await readFile(join(f.install, ".verified-release-assets-version"), "utf8"), "v2.0.0");
+  await assert.rejects(readFile(join(f.source, ".env")), /ENOENT/);
+  await assert.rejects(readFile(join(f.source, ".verified-release-assets-version")), /ENOENT/);
+  assert.equal(await readFile(join(f.source, "docker-compose.yml"), "utf8"), "new-compose\n");
   const state = JSON.parse(await readFile(f.statePath, "utf8"));
   assert.equal(state.imageTag, "v2.0.0");
   assert.equal(state.installerVersion, "v2.0.0");
@@ -99,4 +102,10 @@ test("rejects tampering and rolls back files, env, markers, and state on injecte
   await assert.rejects(readFile(join(rollback.install, "scripts", "new.mjs")), /ENOENT/);
   assert.match(await readFile(join(rollback.install, ".env"), "utf8"), /^DPF_IMAGE_TAG=v1\.0\.0$/m);
   assert.equal(await readFile(rollback.statePath, "utf8"), priorState);
+});
+
+test("release promotion commits identity to the canonical install root, not the source carrier", async () => {
+  const source = await readFile(new URL("../promote.sh", import.meta.url), "utf8");
+  assert.match(source, /--install\s+"\$PROMOTE_INSTALL_ROOT"/);
+  assert.doesNotMatch(source, /--install\s+"\$PROMOTE_SOURCE"/);
 });

--- a/scripts/installer/lib/state.ps1
+++ b/scripts/installer/lib/state.ps1
@@ -235,6 +235,39 @@ function Get-DpfStateValue {
     return $state.$Key
 }
 
+# Resolve the immutable image tag that a known consumer install must use for
+# ordinary lifecycle commands. The persisted install-state is the transaction
+# record written by the installer/promoter; process environment precedence then
+# prevents a stale root .env (especially DPF_IMAGE_TAG=latest) from selecting
+# different bytes during Compose interpolation. Contributor and legacy states
+# remain unchanged because they do not declare a consumer install mode.
+function Resolve-DpfConsumerReleaseImageTag {
+    param([string]$InstallDir = (Get-Location).Path)
+
+    $state = Read-DpfState
+    if ($null -eq $state) { return $null }
+    $mode = if ($state.PSObject.Properties.Name -contains 'installMode') { [string]$state.installMode } else { '' }
+    if ($mode -notin @('consumer', 'customer')) { return $null }
+
+    if ($state.PSObject.Properties.Name -contains 'installPath' -and $state.installPath) {
+        $recorded = [IO.Path]::GetFullPath([string]$state.installPath).TrimEnd('\', '/')
+        $requested = [IO.Path]::GetFullPath($InstallDir).TrimEnd('\', '/')
+        if (-not $recorded.Equals($requested, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "consumer_release_install_path_mismatch"
+        }
+    }
+
+    $tag = if ($state.PSObject.Properties.Name -contains 'imageTag') { [string]$state.imageTag } else { '' }
+    if ([string]::IsNullOrWhiteSpace($tag)) { throw "consumer_release_identity_missing" }
+    if ($tag -notmatch '^v\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$') { throw "consumer_release_identity_invalid" }
+
+    if ($env:DPF_IMAGE_TAG -and $env:DPF_IMAGE_TAG -ne $tag) {
+        Write-Warning "Recorded consumer release tag '$tag' overrides environment tag '$env:DPF_IMAGE_TAG'."
+    }
+    $env:DPF_IMAGE_TAG = $tag
+    return $tag
+}
+
 # Atomically converge a related set of top-level identity values in one lock,
 # CAS, schema validation, and replace. This avoids exposing half-updated release
 # identity (for example imageTag=new while composeFiles still describe old).

--- a/scripts/lib/lifecycle-capability-profile-contract.test.mjs
+++ b/scripts/lib/lifecycle-capability-profile-contract.test.mjs
@@ -237,12 +237,69 @@ test("generated Windows start script executes the canonical adapter before Compo
     const generation = spawnSync("pwsh", ["-NoProfile", "-Command", `. '${join(root, "install-dpf.ps1")}' -LibraryOnly; [IO.File]::WriteAllText('${generated}', (Get-DPFStartScriptContent), [Text.Encoding]::ASCII)`], { encoding: "utf8" });
     assert.equal(generation.status, 0, generation.stderr);
     const source = await readFile(generated, "ascii");
+    assert.match(source, /Resolve-DpfConsumerReleaseImageTag -InstallDir \$DPF_DIR/);
+    assert.ok(source.indexOf("Resolve-DpfConsumerReleaseImageTag") < source.indexOf("docker compose"));
     assert.match(source, /Resolve-DpfCapabilityComposeProfiles/);
     assert.match(source, /COMPOSE_PROFILES/);
     assert.doesNotMatch(source, /Join-Path \$HOME "\.dpf\\install-state\.json"/);
     const installer = await readFile(join(root, "install-dpf.ps1"), "ascii");
     assert.match(installer, /Resolve-DpfCapabilityComposeProfiles -InstallDir \$DPF_DIR/);
     assert.match(installer, /dpf-start\.ps1" -Encoding ASCII/);
+    for (const checkedIn of ["dpf-start.ps1", "scripts/dpf-start.ps1"]) {
+      const checkedInSource = await readFile(join(root, checkedIn), "utf8");
+      assert.match(checkedInSource, /Resolve-DpfConsumerReleaseImageTag -InstallDir \$DPF_DIR/);
+      assert.ok(checkedInSource.indexOf("Resolve-DpfConsumerReleaseImageTag") < checkedInSource.indexOf("docker compose"));
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("Windows consumer start projects the recorded immutable release tag and fails closed without it", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "dpf-win-consumer-tag-"));
+  try {
+    const stateDir = join(dir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const statePath = join(stateDir, "install-state.json");
+    const base = {
+      schemaVersion: 2,
+      installerVersion: "v2026.08.29",
+      platform: "win32",
+      arch: "amd64",
+      enabledRuntimeCapabilities: [],
+      capabilityCatalogHash: null,
+      capabilityStateVersion: null,
+      installPath: dir,
+      installMode: "consumer",
+    };
+    await writeFile(statePath, `${JSON.stringify({ ...base, imageTag: "v2026.08.29-release.1" })}\n`);
+    const helper = join(root, "scripts", "installer", "lib", "state.ps1");
+    const resolve = [
+      `$env:DPF_STATE_DIR='${stateDir}'`,
+      `$env:DPF_IMAGE_TAG='latest'`,
+      `. '${helper}'`,
+      `$tag=Resolve-DpfConsumerReleaseImageTag -InstallDir '${dir}'`,
+      `Write-Output "$tag|$env:DPF_IMAGE_TAG"`,
+    ].join("; ");
+    const resolved = spawnSync("pwsh", ["-NoProfile", "-Command", resolve], { encoding: "utf8" });
+    assert.equal(resolved.status, 0, resolved.stderr);
+    assert.match(resolved.stdout, /overrides environment tag 'latest'/);
+    assert.match(resolved.stdout, /v2026\.08\.29-release\.1\|v2026\.08\.29-release\.1\s*$/);
+
+    await writeFile(statePath, `${JSON.stringify({ ...base, imageTag: null })}\n`);
+    const missing = spawnSync("pwsh", ["-NoProfile", "-Command", resolve], { encoding: "utf8" });
+    assert.notEqual(missing.status, 0);
+    assert.match(`${missing.stdout}\n${missing.stderr}`, /consumer_release_identity_missing/);
+
+    await writeFile(statePath, `${JSON.stringify({ ...base, imageTag: "latest" })}\n`);
+    const mutable = spawnSync("pwsh", ["-NoProfile", "-Command", resolve], { encoding: "utf8" });
+    assert.notEqual(mutable.status, 0);
+    assert.match(`${mutable.stdout}\n${mutable.stderr}`, /consumer_release_identity_invalid/);
+
+    await writeFile(statePath, `${JSON.stringify({ ...base, installMode: "contributor", imageTag: null })}\n`);
+    const contributor = spawnSync("pwsh", ["-NoProfile", "-Command", resolve], { encoding: "utf8" });
+    assert.equal(contributor.status, 0, contributor.stderr);
+    assert.equal(contributor.stdout.trim(), "|latest");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -276,6 +276,7 @@ _release_mode=0
 _release_identity_mode="legacy-no-config"
 if [[ "${DPF_PROMOTION_MODE:-source}" == "release" ]]; then
   _release_mode=1
+  [[ -n "${PROMOTE_INSTALL_ROOT:-}" ]] || _missing+=(PROMOTE_INSTALL_ROOT)
   [[ "${DPF_RELEASE_TAG:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9.-]+)?$ ]] || _missing+=(DPF_RELEASE_TAG)
   # Portals released before the registry-authoritative upgrade contract do not
   # send a config digest. Keep that one-hop bootstrap path working; repaired
@@ -897,9 +898,13 @@ fi
 # compose is rerun against the restored old tag to put the portal back too.
 emit_step release-identity-commit
 if [[ $_release_mode -eq 1 && $_dry_run -eq 0 ]]; then
+  [[ -d "$PROMOTE_INSTALL_ROOT" && -w "$PROMOTE_INSTALL_ROOT" ]] || {
+    printf 'error: canonical install root %s is not a writable directory\n' "${PROMOTE_INSTALL_ROOT:-<unset>}" >&2
+    exit 1
+  }
   if ! node "$_promoter_dir/installer/install-release-assets.mjs" \
     --source "$_release_assets" \
-    --install "$PROMOTE_SOURCE" \
+    --install "$PROMOTE_INSTALL_ROOT" \
     --state "$_install_state" \
     --tag "$DPF_RELEASE_TAG" \
     --owner "$GHCR_OWNER" \


### PR DESCRIPTION
## Summary
- keep consumer restarts pinned to the governed release recorded in install state instead of silently resolving `:latest`
- make release promotion commit release assets and identity to the canonical install root while preserving contributor/legacy behavior
- add high-fidelity Windows start, promotion, rollback, and lifecycle coverage plus the operator runbook update

## Verification
- `pnpm pr:ready` — READY (repository guard suite)
- promoter/self-upgrade/functional Vitest suite — 164 passed
- installer/rollback/lifecycle Node suite — 19 passed
- `pnpm --filter web typecheck` — passed
- `pnpm run pregate:preflight` — 59 guards clean; one inherited Windows-only path-separator environment skip
- DCO range check — passed

## Governed evidence
- research receipt: `initiative-907fa07f-6618-4146-afaa-9e5880ed9cf1`
- design baseline: `baseline-55c65e11-f22a-4d2c-a22a-11da458da237`
- atomic plan coverage: `cmte0jf1402dj01qxv20w5lsb`
- semantic review `TR-GATE-7A554936E9AB00D1FA18A1E5`: INCONCLUSIVE, zero issues, solely `local-ci-active-capacity-reservation`; no PASS inferred
- exact-tree local CI was not queued behind the already admitted/queued shared lane under the operator-authorized infrastructure bypass recorded on `WC-DD034A30`; protected GitHub and merge-group checks remain mandatory

## Impact and rollout
- no schema or data migration
- ordinary-restart behavior changes only for governed consumer/customer installs with a valid canonical install-state identity; contributor and legacy paths retain existing behavior
- after protected merge and the single canonical release/upgrade, verify one ordinary `dpf-start.ps1 -NoBrowser` restart preserves exact tag, SHA, health, endpoints, and database state

Signed-off-by: Codex <codex@openai.com>