### PR TITLE
fix(gate): stop a slow probe from discarding a healthy build (BI-24D5D7C2)

### DIFF
--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -82,6 +82,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       // liveness test above: in ci-policy-test-inventory-allowlist.txt it would
       // never run.
       node("--test", "scripts/gate-worktree-lease-timeout.test.mjs"),
+      // BI-24D5D7C2: the control-plane watchdog aborts a 13-minute build after
+      // two consecutive probe failures, and an inner mcpCall deadline was
+      // classified as "request-failed" — an operator reads that as a broken
+      // endpoint and hunts a connection fault that never happened.
+      node("--test", "scripts/local-ci-control-plane-probe.test.mjs"),
     ]),
     guard("host-port-range-guard", "Host Port Range Guard", [
       node("--test", "scripts/check-host-port-range.test.mjs"),

--- a/scripts/local-ci-bounded-build.mjs
+++ b/scripts/local-ci-bounded-build.mjs
@@ -200,7 +200,26 @@ function ensureBoundedBuilder(builder, log = () => {}) {
   return observed.inspection;
 }
 
-async function timedProbe(run, timeoutMs = 3_000) {
+// BI-24D5D7C2 — how long a control-plane probe may take before the build is
+// abandoned. The MCP surface is a full tool dispatch (auth, tool registry, DB),
+// not a static health handler, and it slows down under exactly the load this
+// watchdog runs during: a Docker image build. At 2.5s a 13-minute build was
+// aborted while portal answered in 19ms and docker and postgres were healthy.
+const CONTROL_PLANE_PROBE_TIMEOUT_MS = (() => {
+  const raw = Number(process.env.DPF_GATE_CONTROL_PLANE_PROBE_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 15_000;
+})();
+
+/** True when a rejection is a deadline, whoever phrased it. */
+export function isTimeoutRejection(error) {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  // mcpCall throws "mcpCall: <tool> timed out after <n>ms"; AbortSignal.timeout
+  // throws a TimeoutError; the local race throws the bare word.
+  return /timed out|timeout/i.test(message)
+    || (error instanceof Error && error.name === "TimeoutError");
+}
+
+async function timedProbe(run, timeoutMs = CONTROL_PLANE_PROBE_TIMEOUT_MS) {
   const started = Date.now();
   let timer;
   try {
@@ -219,7 +238,11 @@ async function timedProbe(run, timeoutMs = 3_000) {
     return {
       healthy: false,
       elapsedMs: Date.now() - started,
-      reason: error instanceof Error && error.message === "timeout" ? "timeout" : "request-failed",
+      // BI-24D5D7C2: only a rejection whose message is EXACTLY "timeout" counted,
+      // so an inner mcpCall deadline was reported as "request-failed" — the
+      // operator reads that as a broken endpoint and goes looking for a
+      // connection fault that never happened. A deadline is a deadline.
+      reason: isTimeoutRejection(error) ? "timeout" : "request-failed",
     };
   } finally {
     clearTimeout(timer);
@@ -285,7 +308,7 @@ async function probeControlPlane(postgresProbe) {
   const bearerToken = process.env.DPF_MCP_BEARER_TOKEN || "";
   const [portal, mcp, docker, postgres] = await Promise.all([
     timedProbe(async () => {
-      const response = await fetch(`${portalUrl}/api/health`, { signal: AbortSignal.timeout(2_500) });
+      const response = await fetch(`${portalUrl}/api/health`, { signal: AbortSignal.timeout(CONTROL_PLANE_PROBE_TIMEOUT_MS) });
       if (response.status !== 200) return false;
       const payload = await response.json();
       return ["ok", "healthy"].includes(String(payload?.status).toLowerCase());
@@ -295,11 +318,11 @@ async function probeControlPlane(postgresProbe) {
       const response = await mcpCall("get_quiescence_status", {}, {
         mcpUrl,
         bearerToken,
-        timeoutMs: 2_500,
+        timeoutMs: CONTROL_PLANE_PROBE_TIMEOUT_MS,
       });
       return response?.success === true;
     }),
-    timedProbe(() => commandHealthy("docker", ["info"], 2_500)),
+    timedProbe(() => commandHealthy("docker", ["info"], CONTROL_PLANE_PROBE_TIMEOUT_MS)),
     timedProbe(postgresProbe),
   ]);
   return { portal, mcp, docker, postgres };

--- a/scripts/local-ci-control-plane-probe.test.mjs
+++ b/scripts/local-ci-control-plane-probe.test.mjs
@@ -1,0 +1,37 @@
+// BI-24D5D7C2 — a deadline on one control-plane probe must not read as a broken
+// endpoint, and must not be tight enough to abort a build that is fine.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isTimeoutRejection } from "./local-ci-bounded-build.mjs";
+
+test("recognises an inner mcpCall deadline as a timeout", () => {
+  // The live repro: elapsedMs 2519 against a 2500ms mcpCall deadline, reported
+  // as "request-failed" because the message was not the bare word "timeout".
+  assert.equal(
+    isTimeoutRejection(new Error("mcpCall: get_quiescence_status timed out after 2500ms")),
+    true,
+  );
+});
+
+test("recognises the bare local race rejection", () => {
+  assert.equal(isTimeoutRejection(new Error("timeout")), true);
+});
+
+test("recognises an AbortSignal.timeout rejection by name", () => {
+  const error = new Error("The operation was aborted due to timeout");
+  error.name = "TimeoutError";
+  assert.equal(isTimeoutRejection(error), true);
+});
+
+test("does NOT call a genuine connection fault a timeout", () => {
+  // The distinction is the whole point: a real fault must stay reported as one.
+  assert.equal(isTimeoutRejection(new Error("ECONNREFUSED 127.0.0.1:3000")), false);
+  assert.equal(isTimeoutRejection(new Error("invalid JSON response")), false);
+});
+
+test("survives a non-Error rejection", () => {
+  assert.equal(isTimeoutRejection("timed out"), true);
+  assert.equal(isTimeoutRejection(undefined), false);
+});


### PR DESCRIPTION
Gate runs on this host kept dying at the image-build stage with:

```
BLOCKED (control-plane starvation): the shared portal/MCP/Docker/PostgreSQL control-plane
degraded during the build. This is infrastructure evidence, NOT a product build failure.
```

The recorded samples say the control plane was fine:

```
portal    healthy    18-20ms
docker    healthy   ~290ms
postgres  healthy   ~220ms
mcp       FAILED     2519ms  request-failed   <- twice, build abandoned
```

Three surfaces healthy and fast. A 13-minute build discarded because one probe took 2519ms.

## The deadline is wrong for what it measures

The MCP probe is a full tool dispatch — auth, tool registry, database — held to **2.5s**, while `/api/health` (a static handler) answered in **19ms** in the same sample. It runs *during* a Docker image build, which is exactly when the portal is most loaded, and `monitorControlPlane` aborts after **two consecutive** failures on any one surface. So roughly ten seconds of MCP slowness throws away the entire run.

A different MCP tool measured **10166ms** on this host under queue contention (BI-46B03CAE). 2.5s has no headroom for that class of call.

Now `CONTROL_PLANE_PROBE_TIMEOUT_MS`, default **15s**, overridable via `DPF_GATE_CONTROL_PLANE_PROBE_TIMEOUT_MS`, applied to all four probes — still far below the build's own runtime, so a genuinely dead control plane is caught quickly.

## A deadline was reported as a broken endpoint

```js
error instanceof Error && error.message === "timeout" ? "timeout" : "request-failed"
```

Only a rejection whose message is *exactly* `"timeout"` counted. `mcpCall` throws `"mcpCall: get_quiescence_status timed out after 2500ms"`, so its deadline was labelled `request-failed`. The elapsed 2519ms against a 2500ms deadline proves what it was.

That mislabel is not cosmetic — it cost real diagnosis time on this branch. `request-failed` reads as "MCP is erroring", so the investigation goes hunting a connection fault, a crashed route, an auth problem. There was none: the surface was alive and slow.

`isTimeoutRejection` now recognises a deadline however it is phrased — `mcpCall`'s message, `AbortSignal.timeout`'s `TimeoutError`, the bare local race — while a genuine fault (`ECONNREFUSED`, invalid JSON) stays `request-failed`. That distinction is the point, and the tests pin both sides.

## Verified

Local-CI gate **passed** on this branch — running with its own fix, through the exact image-build stage that discarded the previous three runs on the branch where this was found.

5 tests, registered in `ci-policy-guards` rather than the test-inventory allowlist where they would never run.

## Not done here

`monitorControlPlane` aborts when **any one** surface breaches. With three surfaces provably healthy, a slow-but-alive MCP arguably should not discard a build on its own — but a quorum rule is a real behaviour change deserving its own decision, and the timeout fix removes the observed trigger. Recorded on BI-24D5D7C2.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
