### PR TITLE
fix(cockpit): stop telling the operator things that are not true (BI-685ADDCD, BI-2777B86B, BI-AF50DBD5)

### DIFF
--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -18,7 +18,7 @@ import { SystemEventProvider } from "@/components/platform/SystemEventProvider";
 import { ShellBannerOverlay } from "@/components/shell/ShellBannerOverlay";
 import { ModelWarmup } from "@/components/shell/ModelWarmup";
 import { SetupOverlay } from "@/components/setup/SetupOverlay";
-import { getShellNavSections } from "@/lib/permissions";
+import { getGrantedCapabilities, getShellNavSections } from "@/lib/permissions";
 import { cookies } from "next/headers";
 import { getActiveOrgCapabilities } from "@/lib/storefront/org-capabilities.server";
 import { AppRail } from "@/components/shell/AppRail";
@@ -160,16 +160,17 @@ export default async function ShellLayout({ children }: { children: React.ReactN
   // "operator" = the full rail; "Simple" writes worker via the rail toggle.
   // Operator is always one toggle away, so worker mode never strands a user.
   const navMode = resolveNavModeFromCookie((await cookies()).get(NAV_MODE_COOKIE)?.value);
+  const userContext = {
+    userId: user.id,
+    platformRole: user.platformRole,
+    isSuperuser: user.isSuperuser,
+  };
   const shellNavSections = activeSetup
     ? []
-    : getShellNavSections(
-        {
-          userId: user.id,
-          platformRole: user.platformRole,
-          isSuperuser: user.isSuperuser,
-        },
-        { activeOrgCapabilities, mode: navMode },
-      );
+    : getShellNavSections(userContext, { activeOrgCapabilities, mode: navMode });
+  // The breadcrumb offers only what this principal can open. Same registry the
+  // rail filters on and the destination route enforces (BI-2777B86B).
+  const grantedCapabilities = getGrantedCapabilities(userContext);
 
   return (
     <PhoneCountryProvider country={phoneCountry}>
@@ -271,7 +272,9 @@ export default async function ShellLayout({ children }: { children: React.ReactN
                   className="mx-auto w-full"
                   style={{ maxWidth: "var(--shell-page-content-max-width, none)" }}
                 >
-                  {shellNavSections.length > 0 && <ShellBreadcrumb />}
+                  {shellNavSections.length > 0 && (
+                    <ShellBreadcrumb capabilities={grantedCapabilities} />
+                  )}
                   <UxInitialLoadBoundary>{children}</UxInitialLoadBoundary>
                 </div>
               </div>

--- a/apps/web/components/shell/ShellBreadcrumb.test.tsx
+++ b/apps/web/components/shell/ShellBreadcrumb.test.tsx
@@ -23,16 +23,27 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+import { getGrantedCapabilities } from "@/lib/permissions";
 import { ShellBreadcrumb, buildBreadcrumbTrail } from "./ShellBreadcrumb";
 
-function render(path: string) {
+// The real registry, not a second list — the whole point of the fix.
+const granted = (platformRole: string | null, isSuperuser = false) =>
+  getGrantedCapabilities({ userId: "u1", platformRole, isSuperuser }) as string[];
+
+const ADMIN = new Set(granted(null, true));
+const OPERATIONS_MANAGER = new Set(granted("HR-500"));
+const WORKFORCE_MEMBER = new Set(granted("HR-600"));
+
+function render(path: string, capabilities: ReadonlySet<string> = ADMIN) {
   pathname = path;
-  return renderToStaticMarkup(<ShellBreadcrumb />);
+  return renderToStaticMarkup(
+    <ShellBreadcrumb capabilities={[...capabilities]} />,
+  );
 }
 
 describe("buildBreadcrumbTrail", () => {
   it("walks the canonical parentPath chain to the domain root", () => {
-    expect(buildBreadcrumbTrail("/platform/ai/providers")).toEqual([
+    expect(buildBreadcrumbTrail("/platform/ai/providers", ADMIN)).toEqual([
       { label: "Platform Hub", href: "/platform" },
       { label: "AI Workforce", href: "/platform/ai" },
       { label: "Providers & Routing", href: "/platform/ai/providers" },
@@ -40,28 +51,28 @@ describe("buildBreadcrumbTrail", () => {
   });
 
   it("returns a single crumb for a domain home", () => {
-    expect(buildBreadcrumbTrail("/platform")).toEqual([
+    expect(buildBreadcrumbTrail("/platform", ADMIN)).toEqual([
       { label: "Platform Hub", href: "/platform" },
     ]);
   });
 
   it("falls back to model labels then title-cased segments for unmodeled routes", () => {
     // /admin is in the model ("Admin"); /admin/settings is not -> title-cased.
-    expect(buildBreadcrumbTrail("/admin/settings")).toEqual([
+    expect(buildBreadcrumbTrail("/admin/settings", ADMIN)).toEqual([
       { label: "Admin", href: "/admin" },
       { label: "Settings", href: "/admin/settings" },
     ]);
   });
 
   it("title-cases hyphenated unmodeled segments", () => {
-    expect(buildBreadcrumbTrail("/admin/reference-data")).toEqual([
+    expect(buildBreadcrumbTrail("/admin/reference-data", ADMIN)).toEqual([
       { label: "Admin", href: "/admin" },
       { label: "Reference Data", href: "/admin/reference-data" },
     ]);
   });
 
   it("decodes an encoded case key before presenting its fallback label", () => {
-    expect(buildBreadcrumbTrail("/workspace/cases/backlog-item%3ABI-CCE939AF")).toEqual([
+    expect(buildBreadcrumbTrail("/workspace/cases/backlog-item%3ABI-CCE939AF", ADMIN)).toEqual([
       { label: "Operations", href: "/workspace" },
       { label: "Cases", href: "/workspace/cases" },
       {
@@ -87,5 +98,46 @@ describe("ShellBreadcrumb", () => {
 
   it("renders nothing under /portfolio (it has its own breadcrumb)", () => {
     expect(render("/portfolio/product/abc123")).toBe("");
+  });
+});
+
+// An HR-500 Operations Manager and an HR-600 Workforce Member were both offered
+// a "Portal" crumb to /storefront and both got 404 from the page behind it: the
+// rail filtered on view_storefront and the trail filtered on nothing
+// (BI-2777B86B). The reachability defect itself stays with BI-4F8A484C — this
+// is only the product no longer advertising a door these roles cannot open.
+describe("a crumb is only offered to a principal who can open it", () => {
+  const portalCrumb = { label: "Portal", href: "/storefront" };
+
+  it("offers the Portal ancestor to an admin", () => {
+    expect(buildBreadcrumbTrail("/storefront/animals", ADMIN)).toContainEqual(portalCrumb);
+  });
+
+  it("withholds it from an Operations Manager, who is refused the page", () => {
+    expect(
+      buildBreadcrumbTrail("/storefront/animals", OPERATIONS_MANAGER),
+    ).not.toContainEqual(portalCrumb);
+  });
+
+  it("withholds it from a Workforce Member, who is refused the page", () => {
+    expect(
+      buildBreadcrumbTrail("/storefront/animals", WORKFORCE_MEMBER),
+    ).not.toContainEqual(portalCrumb);
+  });
+
+  it("renders no Portal link for either role", () => {
+    expect(render("/storefront/animals", OPERATIONS_MANAGER)).not.toContain(
+      'href="/storefront"',
+    );
+    expect(render("/storefront/animals", WORKFORCE_MEMBER)).not.toContain(
+      'href="/storefront"',
+    );
+  });
+
+  it("still gives every role the ancestors it can reach", () => {
+    expect(buildBreadcrumbTrail("/workspace/cases", WORKFORCE_MEMBER)).toContainEqual({
+      label: "Operations",
+      href: "/workspace",
+    });
   });
 });

--- a/apps/web/components/shell/ShellBreadcrumb.tsx
+++ b/apps/web/components/shell/ShellBreadcrumb.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useMemo } from "react";
 import { usePathname } from "next/navigation";
 import { getRouteNavRecord } from "@/lib/navigation/portal-navigation-model";
 
@@ -11,6 +12,14 @@ import { getRouteNavRecord } from "@/lib/navigation/portal-navigation-model";
 // portal-navigation-model's parentPath chain, so every shell route now shows where
 // it is and how to get back. Best-effort: routes outside the model fall back to
 // title-cased URL segments.
+//
+// The trail is filtered by the SAME capability the destination route enforces
+// (BI-2777B86B). It was not, and the model is a route inventory rather than an
+// authorization list, so an HR-500 Operations Manager and an HR-600 Workforce
+// Member both got a "Portal" crumb linking to /storefront — the one page whose
+// layout refuses them `view_storefront` and returns 404. The rail had always
+// hidden it; the crumb was a second list that drifted. Passing the principal's
+// granted keys keeps the two derived from one registry.
 
 type Crumb = { label: string; href: string };
 
@@ -26,7 +35,21 @@ function titleCase(segment: string): string {
     .replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-export function buildBreadcrumbTrail(pathname: string): Crumb[] {
+/** A crumb is offered only to a principal who can open it. The granted set is
+ *  required rather than optional: a fail-open default is how the rail and the
+ *  trail came apart in the first place. A route carrying no capability key is
+ *  open to anyone already inside the shell. */
+function canOpen(
+  capabilityKey: string | null | undefined,
+  capabilities: ReadonlySet<string>,
+): boolean {
+  return capabilityKey == null || capabilities.has(capabilityKey);
+}
+
+export function buildBreadcrumbTrail(
+  pathname: string,
+  capabilities: ReadonlySet<string>,
+): Crumb[] {
   const record = getRouteNavRecord(pathname);
 
   // Preferred path: walk the canonical parentPath chain to the domain root.
@@ -36,7 +59,9 @@ export function buildBreadcrumbTrail(pathname: string): Crumb[] {
     let current: ReturnType<typeof getRouteNavRecord> | undefined = record;
     while (current && !seen.has(current.path)) {
       seen.add(current.path);
-      trail.unshift({ label: current.label, href: current.path });
+      if (canOpen(current.capabilityKey, capabilities)) {
+        trail.unshift({ label: current.label, href: current.path });
+      }
       if (current.parentPath === current.path) break;
       current = getRouteNavRecord(current.parentPath);
     }
@@ -45,26 +70,30 @@ export function buildBreadcrumbTrail(pathname: string): Crumb[] {
 
   // Fallback: derive from URL segments, resolving labels from the model where the
   // cumulative path is known (e.g. /admin), otherwise title-casing the segment.
+  // An unmodelled segment carries no capability, so it is left alone; a modelled
+  // one is filtered on the same key as above.
   const segments = pathname.split("/").filter(Boolean);
   const trail: Crumb[] = [];
   let accumulated = "";
   for (const segment of segments) {
     accumulated += `/${segment}`;
     const known = getRouteNavRecord(accumulated);
+    if (known && !canOpen(known.capabilityKey, capabilities)) continue;
     trail.push({ label: known?.label ?? titleCase(segment), href: accumulated });
   }
   return trail;
 }
 
-export function ShellBreadcrumb() {
+export function ShellBreadcrumb({ capabilities }: { capabilities: readonly string[] }) {
   const pathname = usePathname();
+  const granted = useMemo(() => new Set(capabilities), [capabilities]);
 
   // Portfolio ships its own tree + product-header breadcrumb; rendering a second
   // global trail there would double up. Reconciled into the shared model in
   // EP-NAV-COHERENCE P5 (BI-74158F1A).
   if (pathname.startsWith("/portfolio")) return null;
 
-  const trail = buildBreadcrumbTrail(pathname);
+  const trail = buildBreadcrumbTrail(pathname, granted);
 
   // A single crumb (you are on a domain home) needs no trail.
   if (trail.length < 2) return null;

--- a/apps/web/lib/storefront/storefront-actions.test.ts
+++ b/apps/web/lib/storefront/storefront-actions.test.ts
@@ -24,6 +24,7 @@ vi.mock("@dpf/db", () => {
     productSold: { upsert: vi.fn() },
     productFulfillmentInstance: { upsert: vi.fn() },
     storefrontDonation: { create: vi.fn() },
+    orgSettings: { findFirst: vi.fn() },
     bookingHold: { findFirst: vi.fn(), delete: vi.fn() },
     $queryRaw: vi.fn(),
     // Interactive-transaction shim: run the callback against the same mock so
@@ -94,6 +95,50 @@ describe("submitDonation", () => {
       amount: 10,
     });
     expect(result.ok).toBe(false);
+  });
+
+  function acceptDonations(baseCurrency: string | null) {
+    vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue(
+      mockPublishedStorefront as never,
+    );
+    vi.mocked(prisma.orgSettings.findFirst).mockResolvedValue(
+      baseCurrency == null ? (null as never) : ({ baseCurrency } as never),
+    );
+    vi.mocked(prisma.storefrontDonation.create).mockResolvedValue({
+      donationRef: "DON-TESTREF",
+    } as never);
+  }
+
+  function storedCurrency(): string {
+    const call = vi.mocked(prisma.storefrontDonation.create).mock.calls[0]?.[0] as {
+      data: { currency: string };
+    };
+    return call.data.currency;
+  }
+
+  // `DonationForm` sends no currency, and this defaulted to a hardcoded "GBP",
+  // so a USD rescue showed the donor `$50` and wrote GBP to its books
+  // (BI-685ADDCD). Every gift on every non-GBP install was affected.
+  it("records the gift in the workspace's own currency", async () => {
+    acceptDonations("USD");
+    await submitDonation("acme-vet", { donorEmail: "d@e.com", amount: 50 });
+    expect(storedCurrency()).toBe("USD");
+  });
+
+  it("falls back to USD when the workspace has no settings row", async () => {
+    acceptDonations(null);
+    await submitDonation("acme-vet", { donorEmail: "d@e.com", amount: 50 });
+    expect(storedCurrency()).toBe("USD");
+  });
+
+  it("honours an explicit currency, so a later multi-currency flow still works", async () => {
+    acceptDonations("USD");
+    await submitDonation("acme-vet", {
+      donorEmail: "d@e.com",
+      amount: 50,
+      currency: "EUR",
+    });
+    expect(storedCurrency()).toBe("EUR");
   });
 });
 

--- a/apps/web/lib/storefront/storefront-actions.ts
+++ b/apps/web/lib/storefront/storefront-actions.ts
@@ -699,6 +699,13 @@ export async function submitOrder(
 
 // ── Donation ──────────────────────────────────────────────────────────────────
 
+/** The workspace's own base currency — the one source `/s/[slug]/donate` also
+ *  renders its symbol from. Falls back to USD, matching `resolveInquiryFormSchema`. */
+async function resolveOrgBaseCurrency(): Promise<string> {
+  const settings = await prisma.orgSettings.findFirst({ select: { baseCurrency: true } });
+  return settings?.baseCurrency ?? "USD";
+}
+
 export async function submitDonation(
   slug: string,
   data: {
@@ -722,7 +729,15 @@ export async function submitDonation(
       donorEmail: data.donorEmail,
       donorName: data.donorName,
       amount: data.amount,
-      currency: data.currency ?? "GBP",
+      // The workspace's own currency, never a hardcoded one. This read
+      // `data.currency ?? "GBP"`, and `DonationForm` passes no currency, so on
+      // every non-GBP install the donate page showed the org's symbol while the
+      // row was written GBP (BI-685ADDCD). A USD rescue took $50 and $25 and its
+      // books said GBP. Resolved on the server so the stored code cannot drift
+      // from the symbol the donor saw — the donate page derives that symbol from
+      // this same `OrgSettings.baseCurrency`. An explicit currency still wins, so
+      // a later multi-currency flow is not foreclosed.
+      currency: data.currency ?? (await resolveOrgBaseCurrency()),
       campaignId: data.campaignId,
       message: data.message,
       isAnonymous: data.isAnonymous ?? false,

--- a/apps/web/lib/twin/archetype-outcome-facts.test.ts
+++ b/apps/web/lib/twin/archetype-outcome-facts.test.ts
@@ -63,7 +63,7 @@ describe("archetype outcome facts", () => {
     );
   });
 
-  it("refuses to combine donation currencies", () => {
+  it("keeps donation currencies apart instead of combining them", () => {
     expect(
       summarizeDonations(
         [
@@ -73,8 +73,58 @@ describe("archetype outcome facts", () => {
         "USD",
       ),
     ).toEqual({
-      aggregate: null,
-      unavailableHint: "Multiple donation currencies are not combined",
+      totals: [
+        { currency: "USD", amount: 100, count: 1 },
+        { currency: "GBP", amount: 50, count: 1 },
+      ],
     });
+  });
+
+  // The tile read "Unavailable · Multiple donation currencies are not combined"
+  // over two gifts that were both GBP, because the guard compared a count of
+  // ROWS against a count of matching rows rather than counting currencies
+  // (BI-685ADDCD).
+  it("totals gifts that share one currency, even when it is not the org's", () => {
+    expect(
+      summarizeDonations(
+        [
+          { amount: 50, currency: "GBP" },
+          { amount: 25, currency: "GBP" },
+        ],
+        "USD",
+      ),
+    ).toEqual({ totals: [{ currency: "GBP", amount: 75, count: 2 }] });
+  });
+
+  it("totals gifts recorded in the org's own currency", () => {
+    expect(
+      summarizeDonations(
+        [
+          { amount: 50, currency: "USD" },
+          { amount: "25.50", currency: "USD" },
+        ],
+        "USD",
+      ),
+    ).toEqual({ totals: [{ currency: "USD", amount: 75.5, count: 2 }] });
+  });
+
+  it("reads a gift with no currency recorded as the org's own", () => {
+    expect(
+      summarizeDonations(
+        [
+          { amount: 40, currency: "" },
+          { amount: 10, currency: "USD" },
+        ],
+        "USD",
+      ),
+    ).toEqual({ totals: [{ currency: "USD", amount: 50, count: 2 }] });
+  });
+
+  it("has nothing to total before the first gift", () => {
+    expect(summarizeDonations([], "USD")).toEqual({ totals: [] });
+  });
+
+  it("stays unavailable when the donation source could not be read", () => {
+    expect(summarizeDonations(null, "USD")).toEqual({ totals: null });
   });
 });

--- a/apps/web/lib/twin/archetype-outcome-facts.ts
+++ b/apps/web/lib/twin/archetype-outcome-facts.ts
@@ -1,5 +1,5 @@
 import { moneyToNumber } from "./operations-format";
-import { buildArchetypeOutcomes } from "./archetype-outcomes";
+import { buildArchetypeOutcomes, type DonationTotal } from "./archetype-outcomes";
 
 type FindMany = (args: unknown) => Promise<unknown>;
 type Count = (args: unknown) => Promise<number>;
@@ -73,28 +73,38 @@ export async function loadArchetypeOutcomeFacts(input: {
   return { donationRows, animalsPlaced };
 }
 
-/** Never combine currencies into a misleading headline total. */
+/**
+ * Total the gifts per currency. Currencies are never added together — a
+ * headline that silently combined them would be a plausible wrong number, and
+ * that is the failure this refusal exists to prevent.
+ *
+ * What it must not do is refuse when there is nothing to refuse. This counted
+ * ROWS, not currencies: `matching.length !== rows.length` is true whenever the
+ * gifts are in a currency other than the workspace's, so a rescue whose two
+ * gifts were both stamped GBP on a USD install read "Multiple donation
+ * currencies are not combined" and showed no number at all (BI-685ADDCD). One
+ * currency is one currency wherever it came from, and it totals.
+ *
+ * A row with no currency recorded belongs to the workspace's own — the column
+ * carries a default and the donate page only ever offered one symbol.
+ */
 export function summarizeDonations(
   rows: DonationRow[] | null,
   currency: string,
-): {
-  aggregate: { amount: number; count: number } | null;
-  unavailableHint?: string;
-} {
-  if (rows == null) return { aggregate: null };
-  const matching = rows.filter((row) => row.currency === currency);
-  if (matching.length !== rows.length) {
-    return {
-      aggregate: null,
-      unavailableHint: "Multiple donation currencies are not combined",
-    };
+): { totals: DonationTotal[] | null } {
+  if (rows == null) return { totals: null };
+
+  const byCurrency = new Map<string, DonationTotal>();
+  for (const row of rows) {
+    const code = row.currency?.trim() ? row.currency.trim() : currency;
+    const running = byCurrency.get(code) ?? { currency: code, amount: 0, count: 0 };
+    running.amount += moneyToNumber(row.amount);
+    running.count += 1;
+    byCurrency.set(code, running);
   }
-  return {
-    aggregate: {
-      amount: matching.reduce((sum, row) => sum + moneyToNumber(row.amount), 0),
-      count: matching.length,
-    },
-  };
+
+  // Largest first, so a genuine mix leads with the currency carrying the money.
+  return { totals: [...byCurrency.values()].sort((a, b) => b.amount - a.amount) };
 }
 
 /** Join source facts to the pure presentation projection at one boundary. */
@@ -113,8 +123,7 @@ export function buildOutcomeProjectionFromFacts(input: {
     locale: input.locale,
     paidRevenue: input.paidRevenue,
     deliveredJobs: input.deliveredJobs,
-    donations: donations.aggregate,
-    donationsUnavailableHint: donations.unavailableHint,
+    donationTotals: donations.totals,
     animalsPlaced: input.facts.animalsPlaced,
     // There is no governed foster entity yet. Preserve that fact in the UI.
     fostersActive: null,

--- a/apps/web/lib/twin/archetype-outcomes.test.ts
+++ b/apps/web/lib/twin/archetype-outcomes.test.ts
@@ -10,7 +10,7 @@ describe("buildArchetypeOutcomes", () => {
       locale: "en-US",
       paidRevenue: 900,
       deliveredJobs: 4,
-      donations: { amount: 275, count: 3 },
+      donationTotals: [{ currency: "USD", amount: 275, count: 3 }],
       animalsPlaced: 2,
       fostersActive: null,
     });
@@ -43,20 +43,70 @@ describe("buildArchetypeOutcomes", () => {
     ]);
   });
 
-  it("explains why a rescue donation total is unavailable", () => {
+  it("says the donation source is unavailable only when it could not be read", () => {
     const projection = buildArchetypeOutcomes({
       archetypeId: "pet-rescue",
       currency: "USD",
       locale: "en-US",
       paidRevenue: 0,
       deliveredJobs: 0,
-      donations: null,
-      donationsUnavailableHint: "Multiple donation currencies are not combined",
+      donationTotals: null,
     });
 
     expect(projection.outcomes[0]).toMatchObject({
       value: "Unavailable",
-      hint: "Multiple donation currencies are not combined",
+      hint: "Donation source unavailable",
     });
+  });
+
+  // Two gifts in one currency read "Unavailable" on the live rescue install
+  // (BI-685ADDCD). The tile had the number and would not show it.
+  it("shows a single-currency total in the currency it was given in", () => {
+    const projection = buildArchetypeOutcomes({
+      archetypeId: "pet-rescue",
+      currency: "USD",
+      locale: "en-US",
+      paidRevenue: 0,
+      deliveredJobs: 0,
+      donationTotals: [{ currency: "GBP", amount: 75, count: 2 }],
+    });
+
+    expect(projection.outcomes[0]?.value).toContain("75");
+    expect(projection.outcomes[0]?.value).not.toBe("Unavailable");
+    expect(projection.outcomes[0]?.hint).toBe("2 gifts · 90 days");
+  });
+
+  it("shows every currency when the org really holds more than one", () => {
+    const projection = buildArchetypeOutcomes({
+      archetypeId: "pet-rescue",
+      currency: "USD",
+      locale: "en-US",
+      paidRevenue: 0,
+      deliveredJobs: 0,
+      donationTotals: [
+        { currency: "USD", amount: 120, count: 2 },
+        { currency: "GBP", amount: 75, count: 2 },
+      ],
+    });
+
+    expect(projection.outcomes[0]?.value).not.toBe("Unavailable");
+    expect(projection.outcomes[0]?.value).toContain("120");
+    expect(projection.outcomes[0]?.value).toContain("75");
+    expect(projection.outcomes[0]?.hint).toMatch(/4 gifts/);
+    expect(projection.outcomes[0]?.hint).toMatch(/kept apart by currency/);
+  });
+
+  it("reads zero before the first gift, not unavailable", () => {
+    const projection = buildArchetypeOutcomes({
+      archetypeId: "pet-rescue",
+      currency: "USD",
+      locale: "en-US",
+      paidRevenue: 0,
+      deliveredJobs: 0,
+      donationTotals: [],
+    });
+
+    expect(projection.outcomes[0]?.value).toContain("0");
+    expect(projection.outcomes[0]?.hint).toBe("0 gifts · 90 days");
   });
 });

--- a/apps/web/lib/twin/archetype-outcomes.ts
+++ b/apps/web/lib/twin/archetype-outcomes.ts
@@ -1,14 +1,23 @@
 import type { TwinOutcome } from "@/components/twin";
 import { formatMoney } from "@/lib/org-locale/org-locale";
 
+/** Gifts recorded in one currency. Several of these means the org genuinely
+ *  holds more than one, and each is shown rather than none. */
+export interface DonationTotal {
+  currency: string;
+  amount: number;
+  count: number;
+}
+
 export interface ArchetypeOutcomeInput {
   archetypeId: string;
   currency: string;
   locale: string;
   paidRevenue: number;
   deliveredJobs: number;
-  donations?: { amount: number; count: number } | null;
-  donationsUnavailableHint?: string;
+  /** One entry per currency the gifts were recorded in. `null` means the
+   *  donation source could not be read at all; `[]` means no gifts yet. */
+  donationTotals?: DonationTotal[] | null;
   animalsPlaced?: number | null;
   fostersActive?: number | null;
 }
@@ -23,6 +32,53 @@ function countValue(count: number | null | undefined, noun: string): string {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }
 
+function giftCount(count: number): string {
+  return `${count} gift${count === 1 ? "" : "s"} · 90 days`;
+}
+
+/**
+ * The tile withheld a total it already held: two gifts in one currency read
+ * "Unavailable · Multiple donation currencies are not combined" (BI-685ADDCD).
+ * One currency totals, whichever currency it is. Several are shown side by
+ * side rather than replaced by nothing — an operator who really does hold two
+ * currencies still gets both numbers, just never added together.
+ */
+function donationsOutcome(input: ArchetypeOutcomeInput): TwinOutcome {
+  const totals = input.donationTotals;
+  const money = (total: DonationTotal) =>
+    formatMoney(total.amount, total.currency, input.locale);
+
+  if (totals == null) {
+    return {
+      key: "donations-received",
+      label: "Donations received",
+      value: "Unavailable",
+      intent: "success",
+      hint: "Donation source unavailable",
+    };
+  }
+
+  if (totals.length > 1) {
+    return {
+      key: "donations-received",
+      label: "Donations received",
+      value: totals.map(money).join(" · "),
+      intent: "success",
+      hint: `${giftCount(totals.reduce((sum, total) => sum + total.count, 0))} · kept apart by currency`,
+    };
+  }
+
+  // No gifts yet reads as the workspace's own zero, the way it always has.
+  const only = totals[0];
+  return {
+    key: "donations-received",
+    label: "Donations received",
+    value: only ? money(only) : formatMoney(0, input.currency, input.locale),
+    intent: "success",
+    hint: giftCount(only?.count ?? 0),
+  };
+}
+
 /**
  * Project canonical aggregates into the archetype's outcome language. This is
  * intentionally a small presentation boundary, not a general metric framework:
@@ -35,19 +91,7 @@ export function buildArchetypeOutcomes(
     return {
       heading: "Mission impact",
       outcomes: [
-        {
-          key: "donations-received",
-          label: "Donations received",
-          value:
-            input.donations == null
-              ? "Unavailable"
-              : formatMoney(input.donations.amount, input.currency, input.locale),
-          intent: "success",
-          hint:
-            input.donations == null
-              ? input.donationsUnavailableHint ?? "Donation source unavailable"
-              : `${input.donations.count} gift${input.donations.count === 1 ? "" : "s"} · 90 days`,
-        },
+        donationsOutcome(input),
         {
           key: "animals-placed",
           label: "Animals placed",

--- a/docs/architecture/archetypes/pet-rescue-operating-model.md
+++ b/docs/architecture/archetypes/pet-rescue-operating-model.md
@@ -324,6 +324,22 @@ free-text event rather than an appointment against the animal. *A step recorded 
 because a control could not be found is a discoverability finding, not a capability one — check
 which before designing the fix.*
 
+**A second row needs correcting, in the other direction.** The 16:00 step recorded the outcomes as
+correct. They were correct while empty. Two gifts taken through `/s/rescue/donate` — $50 and $25,
+one currency, on a workspace that has never held a second — turned **Donations received** into
+`Unavailable · Multiple donation currencies are not combined`. Two defects met there. First,
+`submitDonation` stamped a hardcoded `GBP` on every gift while the donate page rendered the
+workspace's own symbol, so a USD install showed the donor `$50` and wrote GBP to its books; every
+gift on every non-GBP install was affected, not only this archetype. Second, `summarizeDonations`
+counted rows rather than currencies — `matching.length !== rows.length` is true whenever the gifts
+are in *any* single currency other than the workspace's — so one currency reported as several and
+the tile withheld a total it already held. Both fixed (`BI-685ADDCD`): the stored code now comes
+from `OrgSettings.baseCurrency`, the same source the symbol comes from, and gifts sharing one
+currency total wherever that currency came from. A genuine mix shows each currency side by side
+rather than nothing. **The two recorded gifts still carry `GBP`** — the platform does not silently
+rewrite the currency of an amount someone gave, so correcting them is the operator's call.
+*A metric that was honest while empty has not been measured. Populate it before scoring it.*
+
 ### What the run found that §6 could not
 
 Three findings sit outside the thirty entities entirely, and each alone prevents the business
@@ -333,6 +349,13 @@ running as more than one person with a clipboard:
    Manager` are both refused the only animal surface; only the superuser reaches it. Recruiting
    has no create control, the organization has zero departments and zero positions, and employment
    type has no volunteer. See §5b for what the day actually requires. *(BI-2777B86B, BI-A30152B6)*
+   **The navigation half was fixed 2026-08-29**: the shell breadcrumb offered both roles a *Portal*
+   crumb to `/storefront` — the one page whose layout refuses them — because the rail filtered on
+   `view_storefront` and the trail filtered on nothing. Both now read the same granted set, so the
+   product no longer advertises a door these roles cannot open. **The refusal itself stands.**
+   Granting storefront-manage to an operational role would make the 404 go away and cement animals
+   living under storefront and marketing administration, which is the actual defect
+   (`BI-4F8A484C`).
 2. **Every public inbound channel requires a donation.** Both the adoption enquiry and the
    site-wide contact form reject a submission without a donation amount, so the found-pet caller,
    the surrendering owner and the would-be volunteer are all turned away at the door. This stands
@@ -356,6 +379,9 @@ running as more than one person with a clipboard:
 - Consumer vocabulary is right — Donate, Adopt, Enquire; no price on an animal.
 - The cockpit puts storefront enquiries above the platform attention list.
 - `/performance` refuses to show numbers it has not computed.
+- The sixteen value-stream stages carry no chevron and nothing that reads as clickable, and the
+  fifteen with no queue bound to them show a dash rather than a zero no query could have produced
+  (`BI-AF50DBD5`; re-verified 2026-08-29 at 1440 and at 768x1024).
 - No horizontal overflow at 768×1024 on any surface tried.
 
 ### Two archetype-specific traps for the next run


### PR DESCRIPTION
**The cockpit must not tell the operator something untrue.** That is the one concern here. Three
surfaces in the operator's cockpit each made a false statement, found by running the pet-rescue
operating day on a live install. They revert together.

Each fix removes one of the defect classes named in
`docs/architecture/archetype-operating-model-audit.md` — the classes a full-marks noun score
survives.

| # | Surface | Defect class | Outcome |
|---|---|---|---|
| 1 | MISSION IMPACT donations tile | **Silent failure** | Fixed here |
| 2 | Shell breadcrumb offering *Portal* | **Inert affordance** | Fixed here |
| 3 | Sixteen value-stream stages | **Inert affordance** | Already shipped in #4766; re-verified, no code change |

---

## 1. The fundraising metric hid a number it had

`/workspace` MISSION IMPACT read `DONATIONS RECEIVED — Unavailable · Multiple donation currencies
are not combined` after two gifts, in one currency, on a workspace that has never held a second.
The tile was more useful empty than populated, and it failed the moment the number stopped being
zero — for the archetype whose panel is titled MISSION IMPACT.

**Diagnosed before fixing, and the guard was not the only thing wrong.** Two defects met.

**The writer stamped a currency nobody chose.** `submitDonation` read
`currency: data.currency ?? "GBP"`. `DonationForm` passes no currency — it takes a display symbol
only, and `/s/[slug]/donate` derives that symbol from `OrgSettings.baseCurrency`. So a USD
workspace showed the donor `$50` and wrote GBP. The live rows:

```
DON-FGDC5GWS | 50 | GBP | Helen Okafor
DON-3ONK_20R | 25 | GBP | Tom Ellery        OrgSettings.baseCurrency = USD
```

Every gift on every non-GBP install was affected, not only this archetype. The currency now comes
from the same `OrgSettings.baseCurrency` the symbol comes from, resolved on the server, so the
stored code cannot drift from what the donor saw. An explicit currency from a caller still wins.

**The reader counted rows, not currencies.** `summarizeDonations` refused when
`matching.length !== rows.length`, which is true whenever the gifts are in any *one* currency other
than the workspace's. One currency reported as several. It now totals per currency:

- one currency sums and displays, in the currency it was given in;
- a row with no currency recorded reads as the workspace's own;
- no gifts yet still reads as the workspace's zero;
- a genuine mix shows each currency side by side rather than nothing.

Currencies are still never added together. A silently combined headline is the plausible wrong
number the refusal exists to prevent — that part of the original design was right.

**The two recorded gifts still carry `GBP`.** The platform does not rewrite the currency of an
amount someone gave. Correcting them is the operator's call, and until they do the tile honestly
reports two currencies.

## 2. The navigation offered Portal to roles refused it

`ShellBreadcrumb` built its trail from `portal-navigation-model`, which is a route *inventory*, not
an authorization list — and filtered on nothing at all. On `/storefront/animals` an HR-500
Operations Manager and an HR-600 Workforce Member were each offered a `Portal` crumb linking to
`/storefront`, the one page whose layout refuses them `view_storefront` and returns 404.

The rail had always hidden it (`getShellNavSections` filters on `isAllowed`), and the section nav
had always hidden it (`getAccessibleSectionNavEntries`). The breadcrumb was a second list, and it
drifted.

It now filters on the granted capability set the shell already computes — the same registry the
rail filters on and the destination route enforces. The capability argument is **required** rather
than optional, because a fail-open default is how the two came apart in the first place.

**This does not close `BI-2777B86B`, and the boundary matters.** Granting storefront-manage to an
operational role would make the 404 go away and cement animals living under storefront and
marketing administration — which is the actual defect, owned by the keystone `BI-4F8A484C`. What is
fixed is that the product stops advertising a door these roles cannot open. The reachability
defect stays open.

## 3. Sixteen value-stream stages promising destinations — already fixed

`BI-AF50DBD5` was fixed and merged before this branch, in #4766 (2026-08-27, `889b47b33e`), which
is contained in the image the install is running (`d9ed4bdb9b`). No code change was needed here, so
none was invented.

**The chevron decision on record is REMOVE, not route**, and the reason stands: fifteen of the
sixteen stages have no record to route to until `BI-4F8A484C` gives an animal an existence
independent of its storefront listing.

Re-verified functionally on the live install at **1440x900 and 768x1024**: zero chevron characters
on the page, no anchor / button / `role` ancestor on any of the sixteen tiles, `cursor: auto`,
fifteen stages reading "Not tracked yet" and the one bound stage (`intake-capacity-decision`)
reading a real 0. `EP-39F60B06` exists to detect inert stages; this was a live instance of what it
was written to catch.

---

## Verification — functional, on the live install

Structural is not functional, so every claim below was driven, not read. The branch build ran
against the **live rescue database** on a governed non-prod lease (`NPEL-274BC80D87`, `:3001`), and
`localhost:3000` was left untouched.

**1. The tile.**

| State | Reads |
|---|---|
| Before (live install, `:3000`) | `Unavailable` · *Multiple donation currencies are not combined* |
| After, same two gifts | `£75` · *2 gifts · 90 days* |
| After a third gift through `/s/rescue/donate` | `£75 · $10` · *3 gifts · 90 days · kept apart by currency* |

The third gift showed `$10` on the donate page and stored `USD` (`DON-Z4KTIFLJ`), which is the
writer fix; the two older rows still read `GBP`, which is why the mix branch is exercised at all.

**2. The nav.** Signed in as both seeded accounts and as admin, asserting on links to `/storefront`
rather than on the string "404":

| Principal | Links to `/storefront` (rail + breadcrumb) | `/storefront/animals` |
|---|---|---|
| `admin@dpf.local` HR-000 | Portal present in rail and breadcrumb | reachable — *Adoptable animals*, *Add animal* |
| `dana.ops` HR-500 | none | still refused (unchanged, `BI-4F8A484C`) |
| `priya.raman` HR-600 | none | still refused (unchanged, `BI-4F8A484C`) |

**3. The stages.** No chevron and nothing interactive, at 1440x900 and at 768x1024. See §3 above.

### Nothing on the regression list is broken

| Check | Result |
|---|---|
| Photo upload and rendering | `srcSet` 160/320/640/960/1280w, `loading="lazy"`, real alt text ("Marbles", "Ranger") |
| `hold` renders publicly as "On hold" | yes |
| Donate / Adopt / Enquire vocabulary | present; no *Buy*, no *Cart* |
| Contact form takes a message with no payment | yes — `INQ-MHYYC8WU`, no amount field on the form |
| Every animal field editable after creation | yes — species, age, description, status, alt text; nothing disabled or read-only |
| No horizontal overflow at 768 or 375 | `scrollWidth == innerWidth` at both |

**Two items on that list could not be confirmed as stated, and neither is caused by this branch.**

- **ANIMALS PLACED reads 0, not 1** — identically on the live install and on the branch build.
  Marbles was changed from `adopted` back to `hold` on 2026-08-28 18:12, so the 90-day adopted
  count is correctly zero. Instance data, not a regression.
- **`adopted` removing the animal from the listing** was not exercisable without changing the
  rescue's own records, because no animal is currently `adopted`. That path is untouched by this
  diff.

### Gates

- Unit tests: **1153 passed / 146 files** across `lib/twin`, `components/shell`, `lib/storefront`,
  `lib/navigation`, `lib/govern`.
- Production build: compiled successfully.
- Style Drift Guard, Prose Lint Guard: pass.
- `pregate:preflight`: 59 guards clean.

## Design grounding

- **Existing specs/plans reviewed**
  - `docs/architecture/archetype-operating-model-audit.md` — the five defect classes, and the rule
    that a metric honest while empty has not been measured.
  - `docs/architecture/archetypes/pet-rescue-operating-model.md` §6b — the measured run these came
    from, updated here with the fundraising finding and the navigation half-fix.
- **Current code substrate reviewed**
  - `apps/web/lib/storefront/storefront-actions.ts` — the single donation writer.
  - `apps/web/components/storefront/DonationForm.tsx` — takes `currencySymbol` only, which is how
    display and record came apart.
  - `apps/web/app/(storefront)/s/[slug]/donate/page.tsx` — derives that symbol from
    `OrgSettings.baseCurrency`, now the one source for both.
  - `apps/web/lib/twin/archetype-outcome-facts.ts` and `archetype-outcomes.ts` — the fact and
    presentation boundary the tile reads.
  - `apps/web/lib/govern/permissions.ts` — the rail and section nav already filtered on the
    capability registry; the breadcrumb was the one nav surface that did not.
- **Source of truth** — `OrgSettings.baseCurrency` for both the stored code and the symbol shown;
  the capability registry behind `can()` for every nav surface.
- **Decision** — fix the writer rather than teach the reader to coerce, and derive nav visibility
  from the capability the route enforces rather than maintain a second list.

## Backlog

- `BI-685ADDCD` — fixed here.
- `BI-AF50DBD5` — delivered in #4766, re-verified here.
- `BI-2777B86B` — **stays open.** Its navigation sub-finding is resolved; the reachability defect
  remains with the keystone `BI-4F8A484C`.

Neither `BI-685ADDCD` nor `BI-AF50DBD5` could be moved to `done`: the readiness projector refuses
completion with `RESEARCH_REQUIRED, PLAN_REQUIRED, DELIVERY_EVIDENCE_REQUIRED,
ACCEPTANCE_EVIDENCE_REQUIRED, OBJECTIVE_BASELINE_REQUIRED, OBJECTIVE_RECONCILIATION_REQUIRED` for a
`fix`-profile item. That is `BI-28E8CB88`, already in flight. An enforcement refusal is a stop, not
a workaround, so no spec or plan document was fabricated to satisfy it.

## Deliberately out of scope

Same defect class, not reached: the two disagreeing attention counters (`BI-79E207B9` /
`BI-96D67485`), the calendar event that returns 200 and never appears (`BI-460BFA84`), and the
keystone-blocked tranche.

Also observed and **not** fixed here, to keep this one concern: `submitOrder` carries the same
hardcoded `?? "GBP"` default in `storefront-actions.ts`, which will misreport a revenue figure the
same way. It needs its own item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
