### PR TITLE
fix(self-upgrade): type terminal recovery successors

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -279,6 +279,7 @@ describe("SelfUpgradePage", () => {
   it("passes history runs and cursor to SelfUpgradeClient", async () => {
     const run: SelfUpgradeRunDto = {
       runId: "run-1",
+      recoveryOfRunId: null,
       status: "succeeded",
       trigger: null,
       currentSha: "abc123",

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -192,6 +192,7 @@ import { getLastCheckedAt } from "@/lib/self-upgrade/last-check";
 import { inngest } from "@/lib/queue/inngest-client";
 import { revalidatePath } from "next/cache";
 import { runSelfUpgradeRollback, SelfUpgradeRollbackError } from "@/lib/self-upgrade/rollback";
+import { createSelfUpgradeTargetBinding } from "@/lib/self-upgrade/target-binding";
 import {
   getSelfUpgradeRunImpact,
   getSelfUpgradeStatus,
@@ -258,6 +259,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllEnvs();
 });
 
 // ─── Permission Guard ─────────────────────────────────────────────────────────
@@ -917,45 +919,43 @@ describe("triggerSelfUpgrade – access control", () => {
   });
 });
 
-// ─── triggerSelfUpgrade – dispatch ───────────────────────────────────────────
-
 describe("triggerSelfUpgrade – dispatch", () => {
-  it("returns the durable admission before queue dispatch", async () => {
+  it("does not grant recovery authority to a plain failed-run retry", async () => {
+    vi.mocked(getLatestRun).mockResolvedValue({ ...mockRun, runId: "SUR-6B312E24", status: "failed" } as never);
     const result = await triggerSelfUpgrade();
-
+    expect(admitSelfUpgrade).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ queued: false, reason: "recovery-binding-required", runId: "SUR-6B312E24" });
+  });
+  it("uses the authenticated operator action as the sole typed recovery boundary", async () => {
+    const releaseTarget = { targetKind: "release-artifact" as const, targetSha: "c137e6cdb1fe82d00565841ec683cec5c80710ab",
+      targetTag: "v2026.08.29-source-free-upgrade-reconciliation.1" };
+    vi.stubEnv("DPF_SELF_UPGRADE_TARGET_BINDING_SECRET", "test-target-binding-secret");
+    vi.mocked(readSelfUpgradeSupport).mockResolvedValue(consumerReleaseSupport);
+    vi.mocked(resolveCurrentSelfUpgradeTarget).mockResolvedValue(null);
+    vi.mocked(getLatestRun).mockResolvedValue({ ...mockRun, runId: "SUR-6B312E24", status: "failed" } as never);
+    const result = await triggerSelfUpgrade({ targetBinding: createSelfUpgradeTargetBinding(releaseTarget) });
     expect(admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({
-      triggeredBy: "manual:user-ops-1",
-      impactSummaryId: null,
-      target: expect.objectContaining({ targetSha: "b".repeat(40) }),
+      triggeredBy: "manual:user-ops-1", target: releaseTarget, recoveryOfRunId: "SUR-6B312E24",
     }));
-    expect(createRun).not.toHaveBeenCalled();
-    expect(vi.mocked(inngest.send)).not.toHaveBeenCalled();
     expect(result).toMatchObject({ queued: true, admitted: true, runId: "SUR-QUEUED1" });
   });
-
   it("attaches the reviewed impact summary to the run when one exists", async () => {
     vi.mocked(getCurrentImpactSummaryId).mockResolvedValueOnce("UIS-77");
-
     await triggerSelfUpgrade();
-
     expect(admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({
       triggeredBy: "manual:user-ops-1",
       impactSummaryId: "UIS-77",
     }));
   });
-
   it("binds the manual actor and force posture in admission", async () => {
     await triggerSelfUpgrade();
-
     expect(admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({
       triggeredBy: `manual:${mockSession.user.id}`,
       requestedForce: false,
     }));
   });
-
   it("passes dryRun: true when dryRun option is set", async () => {
     await triggerSelfUpgrade({ dryRun: true });
-
     expect(admitSelfUpgrade).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
   });
 

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -492,6 +492,7 @@ export async function getPromotionWindowStatus(promotionId: string) {
 
 export type SelfUpgradeRunDto = {
   runId: string;
+  recoveryOfRunId: string | null;
   status: string;
   trigger: string | null;       // schema: trigger (was: triggeredBy)
   currentSha: string | null;    // schema: currentSha (was: fromVersion)
@@ -528,6 +529,7 @@ export async function listSelfUpgradeRuns(opts?: {
     take: limit + 1,
     select: {
       runId: true,
+      recoveryOfRunId: true,
       status: true,
       trigger: true,
       currentSha: true,
@@ -780,7 +782,6 @@ export async function triggerSelfUpgrade(opts?: {
   const triggeredBy = `manual:${userId}`;
   const config = await getSelfUpgradeConfig();
   const support = await readSelfUpgradeSupport(config.enabled);
-
   if (!support.supported) {
     return {
       queued: false,
@@ -788,7 +789,6 @@ export async function triggerSelfUpgrade(opts?: {
       message: support.message,
     } as const;
   }
-
   if (!opts?.dryRun) {
     if (!support.enabled) {
       return { queued: false, reason: "disabled" } as const;
@@ -798,7 +798,6 @@ export async function triggerSelfUpgrade(opts?: {
     // scheduled poll (runSelfUpgrade skips the window for non-scheduled runs).
     // `force` is reserved for bypassing the quiescence drain in an emergency.
   }
-
   const latestRun = await getLatestRun();
   if (latestRun?.status === "running") {
     return { queued: false, reason: "already-running", runId: latestRun.runId } as const;
@@ -806,7 +805,7 @@ export async function triggerSelfUpgrade(opts?: {
   if (latestRun?.status === "queued" || latestRun?.status === "pending") {
     return { queued: false, reason: "already-queued", runId: latestRun.runId } as const;
   }
-
+  if (latestRun?.status === "failed" && !opts?.targetBinding) return { queued: false, reason: "recovery-binding-required", runId: latestRun.runId } as const;
   const resolvedTarget = await resolveCurrentSelfUpgradeTarget();
   const selection = selectSelfUpgradeAdmissionTarget({
     targetBinding: opts?.targetBinding,
@@ -819,16 +818,16 @@ export async function triggerSelfUpgrade(opts?: {
   // any) so the run records the changes it carried. Best effort — the upgrade
   // proceeds whether or not a summary was generated.
   const impactSummaryId = await getCurrentImpactSummaryId();
-
-  const admission = await admitSelfUpgrade({ triggeredBy, target,
+  const admission = await admitSelfUpgrade({ triggeredBy, target, recoveryOfRunId: latestRun?.status === "failed" ? latestRun.runId : null,
     requestedForce: opts?.force === true,
     dryRun: opts?.dryRun === true,
     routine: false,
     impactSummaryId,
   });
-  if (!admission.admitted) {
-    return { queued: false, reason: "already-active", runId: admission.runId } as const;
-  }
+  if (!admission.admitted) return { queued: false,
+    reason: admission.disposition === "recovery_conflict" ? "recovery-conflict"
+      : admission.disposition === "recovery_refused" ? admission.reason : "already-active",
+    runId: admission.runId } as const;
   return { queued: true, admitted: true, runId: admission.runId,
     dispatchStatus: admission.dispatchStatus } as const;
 }

--- a/apps/web/lib/self-upgrade/admission.test.ts
+++ b/apps/web/lib/self-upgrade/admission.test.ts
@@ -17,6 +17,7 @@ const target: SelfUpgradeTargetBinding = {
 function record(overrides: Partial<SelfUpgradeAdmissionRecord> = {}): SelfUpgradeAdmissionRecord {
   const row: SelfUpgradeAdmissionRecord = {
     runId: "SUR-D71E8971",
+    recoveryOfRunId: null,
     status: "pending",
     trigger: "manual:user-1",
     targetSha: target.targetSha,
@@ -381,6 +382,26 @@ describe("durable self-upgrade admission", () => {
     expect(repo.failDispatch).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "admission-binding-drift" }),
     );
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("does not mutate a terminal old-target row during reconciliation", async () => {
+    const repo = repository(record({
+      runId: "SUR-6B312E24",
+      status: "failed",
+      dispatchStatus: "dispatch_failed",
+      targetSha: "0".repeat(40),
+      targetTag: "v2026.08.29-terminal-writer-failed-reader-history.1",
+      completedAt: new Date("2026-08-29T14:45:34.380Z"),
+    }));
+    const { coordinator, send } = service({ repository: repo });
+
+    expect(await coordinator.dispatch("SUR-6B312E24")).toEqual({
+      status: "failed",
+      runId: "SUR-6B312E24",
+    });
+    expect(repo.failDispatch).not.toHaveBeenCalled();
+    expect(repo.markDispatchIndeterminate).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
   });
 

--- a/apps/web/lib/self-upgrade/admission.ts
+++ b/apps/web/lib/self-upgrade/admission.ts
@@ -24,6 +24,7 @@ export type SelfUpgradeTargetBinding = Readonly<{
 
 export type SelfUpgradeAdmissionRecord = Readonly<{
   runId: string;
+  recoveryOfRunId: string | null;
   status: string;
   trigger: string;
   targetSha: string | null;
@@ -44,6 +45,7 @@ export type SelfUpgradeAdmissionRecord = Readonly<{
 export type SelfUpgradeAdmissionInput = Readonly<{
   triggeredBy: string;
   target: SelfUpgradeTargetBinding;
+  recoveryOfRunId?: string | null;
   requestedForce: boolean;
   dryRun: boolean;
   routine: boolean;
@@ -58,8 +60,18 @@ type PersistedAdmissionInput = SelfUpgradeAdmissionInput & {
 
 export type SelfUpgradeAdmissionRepository = {
   admit(input: PersistedAdmissionInput): Promise<{
-    disposition: "created" | "idempotent" | "already_active";
+    disposition: "created" | "idempotent" | "already_active" | "recovery_conflict";
     run: SelfUpgradeAdmissionRecord;
+  } | {
+    disposition: "recovery_refused";
+    reason:
+      | "recovery-target-invalid"
+      | "recovery-predecessor-missing"
+      | "recovery-predecessor-not-terminal"
+      | "recovery-predecessor-ambiguous"
+      | "recovery-target-not-distinct"
+      | "recovery-predecessor-not-latest";
+    run: null;
   }>;
   read(runId: string): Promise<SelfUpgradeAdmissionRecord | null>;
   claimDispatch(input: {
@@ -207,6 +219,14 @@ export function createSelfUpgradeAdmissionService(
     const existing = await dependencies.repository.read(runId);
     if (!existing) return { status: "not-claimed", runId };
 
+    // Terminal rows are immutable history.  In particular, a failed row bound
+    // to an older release must never be rewritten or dispatched toward a newer
+    // target. A separately admitted recovery uses a new immutable target and
+    // typed successor relation; it never reopens this historical row.
+    if (existing.completedAt || ["failed", "succeeded", "skipped"].includes(existing.status)) {
+      return { status: "failed", runId };
+    }
+
     const resolvedTarget = await dependencies.resolveTarget().catch(() => null);
     const currentTarget = resolvedTarget ?? persistedReleaseTarget(existing);
     if (!currentTarget) {
@@ -296,26 +316,37 @@ export function createSelfUpgradeAdmissionService(
     }
   }
 
-  return {
-    async admit(input: SelfUpgradeAdmissionInput) {
+  async function admit(input: SelfUpgradeAdmissionInput) {
       const admitted = await dependencies.repository.admit({
         ...input,
         runId: dependencies.createRunId(),
         admissionFingerprint: computeSelfUpgradeAdmissionFingerprint(input),
         dispatchStatus: "admission_pending",
       });
-      if (admitted.disposition !== "already_active") {
+      if (admitted.disposition === "recovery_refused") {
+        return {
+          admitted: false as const,
+          runId: input.recoveryOfRunId ?? "unadmitted",
+          disposition: admitted.disposition,
+          reason: admitted.reason,
+          dispatchStatus: "dispatch_failed" as const,
+        };
+      }
+      if (["created", "idempotent"].includes(admitted.disposition)) {
         dependencies.schedule(async () => {
           await dispatch(admitted.run.runId);
         });
       }
       return {
-        admitted: admitted.disposition !== "already_active",
+        admitted: ["created", "idempotent"].includes(admitted.disposition),
         runId: admitted.run.runId,
         disposition: admitted.disposition,
         dispatchStatus: admitted.run.dispatchStatus,
       };
-    },
+  }
+
+  return {
+    admit,
     dispatch,
     async reconcile() {
       const rows = await dependencies.repository.listRecoverable({

--- a/apps/web/lib/self-upgrade/request.test.ts
+++ b/apps/web/lib/self-upgrade/request.test.ts
@@ -182,6 +182,28 @@ describe("requestSelfUpgrade", () => {
     expect(mocks.inngestSend).not.toHaveBeenCalled();
   });
 
+  it("does not grant recovery authority to a plain request after a terminal failure", async () => {
+    mocks.getLatestRun.mockResolvedValue({
+      runId: "SUR-6B312E24",
+      status: "failed",
+      targetSha: "04b0b9d84251c2a91ae519bf79eedd86b662f604",
+      targetTag: "v2026.08.29-terminal-writer-failed-reader-history.1",
+      deployedSha: null,
+      completedAt: new Date("2026-08-29T14:45:34.380Z"),
+    });
+    const result = await requestSelfUpgrade({
+      requestedBy: "manual:user-ops-1",
+      actorKind: "human",
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      status: "human_override_required",
+      reason: "terminal-recovery-needs-operator-binding",
+    });
+    expect(mocks.admitSelfUpgrade).not.toHaveBeenCalled();
+  });
+
   it.each(["running", "queued", "pending"])(
     "does not dispatch a duplicate event when latest run is %s",
     async (status) => {

--- a/apps/web/lib/self-upgrade/request.ts
+++ b/apps/web/lib/self-upgrade/request.ts
@@ -43,7 +43,7 @@ export type RequestSelfUpgradeResult =
   | {
       success: true;
       status: "human_override_required";
-      reason: "outside-window" | "no-window-needs-timezone";
+      reason: "outside-window" | "no-window-needs-timezone" | "terminal-recovery-needs-operator-binding";
       message: string;
     }
   | {
@@ -131,6 +131,14 @@ export async function requestSelfUpgrade(
       success: true,
       status: "already_active",
       runId: latestRun.runId,
+    };
+  }
+  if (latestRun?.status === "failed") {
+    return {
+      success: true,
+      status: "human_override_required",
+      reason: "terminal-recovery-needs-operator-binding",
+      message: "A terminal upgrade can only be recovered from the operator page with the current authenticated release binding.",
     };
   }
 

--- a/apps/web/lib/self-upgrade/run-store.test.ts
+++ b/apps/web/lib/self-upgrade/run-store.test.ts
@@ -199,6 +199,7 @@ describe("admitted worker ownership", () => {
 describe("self-upgrade admission transaction", () => {
   const admittedRow = {
     runId: "SUR-ADMITTED",
+    recoveryOfRunId: null,
     status: "pending",
     trigger: "manual:user-1",
     targetSha: "a".repeat(40),
@@ -213,6 +214,7 @@ describe("self-upgrade admission transaction", () => {
     dispatchLeaseToken: null,
     dispatchLeaseExpiresAt: null,
     dispatchEventIds: [],
+    dispatchAcknowledgedAt: null,
     completedAt: null,
   };
 
@@ -262,6 +264,210 @@ describe("self-upgrade admission transaction", () => {
     });
 
     expect(result).toMatchObject({ disposition: "idempotent", run: admittedRow });
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it("creates one typed recovery successor without mutating the terminal predecessor", async () => {
+    mocks.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        runId: "SUR-6B312E24",
+        status: "failed",
+        completedAt: new Date("2026-08-29T14:45:34.380Z"),
+      });
+    mocks.findUnique
+      .mockResolvedValueOnce({
+        ...admittedRow,
+        runId: "SUR-6B312E24",
+        status: "failed",
+        targetSha: "0".repeat(40),
+        targetTag: "v-old",
+        completedAt: new Date("2026-08-29T14:45:34.380Z"),
+      })
+      .mockResolvedValueOnce(null);
+
+    await selfUpgradeAdmissionRepository.admit({
+      runId: "SUR-C137BOOT",
+      triggeredBy: admittedRow.trigger,
+      target: {
+        targetKind: "release-artifact",
+        targetSha: "c137e6cdb1fe82d00565841ec683cec5c80710ab",
+        targetTag: "v2026.08.29-source-free-upgrade-reconciliation.1",
+      },
+      recoveryOfRunId: "SUR-6B312E24",
+      requestedForce: false,
+      dryRun: false,
+      routine: false,
+      impactSummaryId: null,
+      admissionFingerprint: "successor-fingerprint",
+      dispatchStatus: "admission_pending",
+    });
+
+    expect(mocks.create).toHaveBeenCalledWith({ data: expect.objectContaining({
+      runId: "SUR-C137BOOT",
+      status: "pending",
+      recoveryOfRunId: "SUR-6B312E24",
+      targetSha: "c137e6cdb1fe82d00565841ec683cec5c80710ab",
+    }) });
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses a recovery successor when the predecessor is not the latest run", async () => {
+    mocks.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ runId: "SUR-NEWER", status: "failed", completedAt: new Date() });
+    mocks.findUnique.mockResolvedValueOnce({
+      ...admittedRow,
+      runId: "SUR-6B312E24",
+      status: "failed",
+      targetSha: "0".repeat(40),
+      targetTag: "v-old",
+      completedAt: new Date(),
+    });
+
+    await expect(selfUpgradeAdmissionRepository.admit({
+      runId: "SUR-C137BOOT",
+      triggeredBy: admittedRow.trigger,
+      target: { targetKind: "release-artifact", targetSha: "c".repeat(40), targetTag: "v-new" },
+      recoveryOfRunId: "SUR-6B312E24",
+      requestedForce: false,
+      dryRun: false,
+      routine: false,
+      impactSummaryId: null,
+      admissionFingerprint: "successor-fingerprint",
+      dispatchStatus: "admission_pending",
+    })).resolves.toMatchObject({ disposition: "recovery_refused", reason: "recovery-predecessor-not-latest" });
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it("refuses an untagged recovery target before persistence", async () => {
+    mocks.findFirst.mockResolvedValueOnce(null);
+
+    await expect(selfUpgradeAdmissionRepository.admit({
+      runId: "SUR-INVALID",
+      triggeredBy: admittedRow.trigger,
+      target: { targetKind: "git-source", targetSha: "c".repeat(40), targetTag: null },
+      recoveryOfRunId: "SUR-6B312E24",
+      requestedForce: false,
+      dryRun: false,
+      routine: false,
+      impactSummaryId: null,
+      admissionFingerprint: "invalid-fingerprint",
+      dispatchStatus: "admission_pending",
+    })).resolves.toMatchObject({ disposition: "recovery_refused", reason: "recovery-target-invalid" });
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["same SHA", "0".repeat(40), "v-new"],
+    ["same tag", "c".repeat(40), "v-old"],
+    ["same SHA and tag", "0".repeat(40), "v-old"],
+  ])("refuses a successor that reuses the predecessor's %s", async (_case, targetSha, targetTag) => {
+    const predecessor = {
+      ...admittedRow,
+      runId: "SUR-6B312E24",
+      status: "failed",
+      targetSha: "0".repeat(40),
+      targetTag: "v-old",
+      completedAt: new Date(),
+    };
+    mocks.findFirst.mockResolvedValueOnce(null);
+    mocks.findUnique.mockResolvedValueOnce(predecessor);
+
+    await expect(selfUpgradeAdmissionRepository.admit({
+      runId: "SUR-SAME",
+      triggeredBy: admittedRow.trigger,
+      target: { targetKind: "release-artifact", targetSha, targetTag },
+      recoveryOfRunId: predecessor.runId,
+      requestedForce: false,
+      dryRun: false,
+      routine: false,
+      impactSummaryId: null,
+      admissionFingerprint: "same-target-fingerprint",
+      dispatchStatus: "admission_pending",
+    })).resolves.toMatchObject({ disposition: "recovery_refused", reason: "recovery-target-not-distinct" });
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it("refuses a malformed terminal predecessor without throwing", async () => {
+    mocks.findFirst.mockResolvedValueOnce(null);
+    mocks.findUnique.mockResolvedValueOnce({ ...admittedRow, runId: "SUR-BAD", status: "failed", completedAt: null });
+
+    await expect(selfUpgradeAdmissionRepository.admit({
+      runId: "SUR-REFUSED",
+      triggeredBy: admittedRow.trigger,
+      target: { targetKind: "release-artifact", targetSha: "c".repeat(40), targetTag: "v-new" },
+      recoveryOfRunId: "SUR-BAD",
+      requestedForce: false,
+      dryRun: false,
+      routine: false,
+      impactSummaryId: null,
+      admissionFingerprint: "refused-fingerprint",
+      dispatchStatus: "admission_pending",
+    })).resolves.toMatchObject({ disposition: "recovery_refused", reason: "recovery-predecessor-not-terminal" });
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it("refuses a terminal predecessor with ambiguous dispatch evidence", async () => {
+    mocks.findFirst.mockResolvedValueOnce(null);
+    mocks.findUnique.mockResolvedValueOnce({
+      ...admittedRow,
+      runId: "SUR-AMBIGUOUS",
+      status: "failed",
+      targetSha: "0".repeat(40),
+      targetTag: "v-old",
+      completedAt: new Date(),
+      dispatchAttemptCount: 1,
+    });
+
+    await expect(selfUpgradeAdmissionRepository.admit({
+      runId: "SUR-REFUSED",
+      triggeredBy: admittedRow.trigger,
+      target: { targetKind: "release-artifact", targetSha: "c".repeat(40), targetTag: "v-new" },
+      recoveryOfRunId: "SUR-AMBIGUOUS",
+      requestedForce: false,
+      dryRun: false,
+      routine: false,
+      impactSummaryId: null,
+      admissionFingerprint: "refused-fingerprint",
+      dispatchStatus: "admission_pending",
+    })).resolves.toMatchObject({ disposition: "recovery_refused", reason: "recovery-predecessor-ambiguous" });
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it("returns the existing typed successor instead of creating a second one", async () => {
+    const predecessor = {
+      ...admittedRow,
+      runId: "SUR-6B312E24",
+      status: "failed",
+      targetSha: "0".repeat(40),
+      targetTag: "v-old",
+      completedAt: new Date(),
+    };
+    const successor = {
+      ...admittedRow,
+      runId: "SUR-EXISTING",
+      recoveryOfRunId: predecessor.runId,
+    };
+    mocks.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(predecessor);
+    mocks.findUnique
+      .mockResolvedValueOnce(predecessor)
+      .mockResolvedValueOnce(successor);
+
+    await expect(selfUpgradeAdmissionRepository.admit({
+      runId: "SUR-SECOND",
+      triggeredBy: admittedRow.trigger,
+      target: { targetKind: "release-artifact", targetSha: "c".repeat(40), targetTag: "v-new" },
+      recoveryOfRunId: predecessor.runId,
+      requestedForce: false,
+      dryRun: false,
+      routine: false,
+      impactSummaryId: null,
+      admissionFingerprint: "second-fingerprint",
+      dispatchStatus: "admission_pending",
+    })).resolves.toMatchObject({ disposition: "recovery_conflict", run: successor });
     expect(mocks.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/self-upgrade/run-store.ts
+++ b/apps/web/lib/self-upgrade/run-store.ts
@@ -40,6 +40,7 @@ const ACTIVE_RUN_STATUSES = ["pending", "queued", "running"];
 
 function asAdmissionRecord(row: {
   runId: string;
+  recoveryOfRunId: string | null;
   status: string;
   trigger: string;
   targetSha: string | null;
@@ -82,9 +83,61 @@ export const selfUpgradeAdmissionRepository: SelfUpgradeAdmissionRepository = {
           run: asAdmissionRecord(active),
         };
       }
+      if (input.recoveryOfRunId) {
+        if (input.target.targetKind !== "release-artifact" || !input.target.targetTag) {
+          return { disposition: "recovery_refused" as const, reason: "recovery-target-invalid" as const, run: null };
+        }
+        const predecessor = await tx.selfUpgradeRun.findUnique({
+          where: { runId: input.recoveryOfRunId },
+        });
+        if (
+          !predecessor ||
+          predecessor.completedAt === null ||
+          predecessor.status !== "failed"
+        ) {
+          return {
+            disposition: "recovery_refused" as const,
+            reason: predecessor ? "recovery-predecessor-not-terminal" as const : "recovery-predecessor-missing" as const,
+            run: null,
+          };
+        }
+        if (
+          !predecessor.admissionFingerprint ||
+          !predecessor.dispatchStatus ||
+          !predecessor.targetSha ||
+          !predecessor.targetTag ||
+          predecessor.dispatchAttemptCount !== 0 ||
+          predecessor.dispatchAcknowledgedAt !== null ||
+          predecessor.dispatchEventIds.length !== 0
+        ) {
+          return { disposition: "recovery_refused" as const, reason: "recovery-predecessor-ambiguous" as const, run: null };
+        }
+        if (
+          predecessor.targetSha.toLowerCase() === input.target.targetSha.toLowerCase() ||
+          predecessor.targetTag === input.target.targetTag
+        ) {
+          return { disposition: "recovery_refused" as const, reason: "recovery-target-not-distinct" as const, run: null };
+        }
+        const latest = await tx.selfUpgradeRun.findFirst({
+          orderBy: { createdAt: "desc" },
+        });
+        if (latest?.runId !== predecessor.runId) {
+          return { disposition: "recovery_refused" as const, reason: "recovery-predecessor-not-latest" as const, run: null };
+        }
+        const existingSuccessor = await tx.selfUpgradeRun.findUnique({
+          where: { recoveryOfRunId: predecessor.runId },
+        });
+        if (existingSuccessor) {
+          return {
+            disposition: "recovery_conflict" as const,
+            run: asAdmissionRecord(existingSuccessor),
+          };
+        }
+      }
       const created = await tx.selfUpgradeRun.create({
         data: {
           runId: input.runId,
+          recoveryOfRunId: input.recoveryOfRunId ?? null,
           status: "pending",
           trigger: input.triggeredBy,
           targetSha: input.target.targetSha,

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -10,6 +10,6 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 |---|---:|---|
 | Prisma models | 614 | `packages/db/prisma/schema/` |
 | Prisma enums | 73 | `packages/db/prisma/schema/` |
-| Migrations | 558 | `packages/db/prisma/migrations/` |
+| Migrations | 559 | `packages/db/prisma/migrations/` |
 | Kernel principles | 99 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 642 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/data-impact/2026-08-29-self-upgrade-recovery-successor.data-impact.json
+++ b/docs/data-impact/2026-08-29-self-upgrade-recovery-successor.data-impact.json
@@ -1,0 +1,32 @@
+{
+  "version": "1",
+  "accountableOwner": "developer-platform",
+  "affectedCopies": [],
+  "migration": {
+    "name": "20260829160000_self_upgrade_recovery_successor",
+    "backfill": "fail-closed bootstrap only - when exactly one authenticated manual release admission is in flight, link it to the immediately preceding failed pre-dispatch run; otherwise leave every historical row unchanged"
+  },
+  "tests": [
+    "apps/web/lib/self-upgrade/admission.test.ts",
+    "apps/web/lib/self-upgrade/run-store.test.ts",
+    "apps/web/lib/actions/promotions.self-upgrade.test.ts",
+    "apps/web/lib/self-upgrade/request.test.ts",
+    "packages/db/src/self-upgrade-recovery-successor-migration.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "platform:self-upgrade-run",
+      "prismaModel": "SelfUpgradeRun",
+      "lifecycleDisposition": "operational recovery linkage retained with immutable self-upgrade history",
+      "fields": [
+        {
+          "fieldId": "platform:self-upgrade-run#recoveryOfRunId",
+          "resolution": "governed",
+          "reason": "audit-only linkage to the independently authorized successor admission; never grants dispatch authority or reopens/rebinds the predecessor",
+          "provenance": "serialized self-upgrade admission transaction"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-08-29-self-upgrade-admission-reconciliation.md
+++ b/docs/superpowers/plans/2026-08-29-self-upgrade-admission-reconciliation.md
@@ -138,3 +138,37 @@ destruction.
 6. On exact served-SHA/CAN-TEST, observe only the existing reconciler advancing
    `SUR-6B312E24`; require stable event identity, one dispatch acknowledgement,
    truthful terminal state, and no replacement row before unfreezing BI-F48.
+
+## Terminal old-target correction
+
+The accepted live fixture is terminal and bound to a superseded release. Add a
+first-failing admission test proving reconciliation does not mutate or dispatch
+that row. Use the existing authenticated operator action as the sole bootstrap
+contract: it accepts only a terminal superseded run plus a verified signed tagged
+release target, creates a new
+admission through the existing transaction, and persists a unique typed
+`recoveryOfRunId` self-relation to the prior run. Reject active/ambiguous or
+non-latest prior rows, an existing successor, same/untagged/Git targets, forged
+or expired bindings, and target drift. This narrowly supersedes the old
+"no replacement run" step: the terminal predecessor remains immutable, while
+one separately fingerprinted successor becomes the only lawful bootstrap
+identity. It is not a browser retry or rebind; protected CI and the existing
+quiescence/worker-CAS gates remain mandatory.
+
+Publish the protected repair without deploying the superseded c137 release.
+Before the one physical action, capture a fresh server-signed binding for the
+repair tag/SHA and prove the latest row is still the unchanged terminal
+`SUR-6B312E24`. The old runtime admits one new manual run through its existing
+authenticated path. During new-container startup, the additive migration may
+link that one in-flight run to the exact predecessor only when the singleton,
+ordering, terminal, pre-dispatch, tagged-target, and distinct-target predicates
+all hold. Verify the typed link plus served SHA/CAN-TEST and restart coherence;
+otherwise stop without a second action.
+
+Treat the typed link as audit metadata only. The successor's signed target
+verification and recomputed admission fingerprint remain the sole dispatch
+authority. Record that the SQL migration checks structural predecessor evidence
+without cryptographically recomputing the historical fingerprint, and that its
+tests are static SQL contract assertions rather than an executed migration
+fixture. In live acceptance, read back both immutable rows and the link, then
+verify the successor's independent admission and dispatch evidence.

--- a/docs/superpowers/specs/2026-08-29-self-upgrade-admission-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-08-29-self-upgrade-admission-reconciliation-design.md
@@ -305,3 +305,56 @@ compare-and-swap contracts.
 - Live proof uses no second click or replacement run: the already persisted
   `SUR-6B312E24` must reach a truthful terminal dispatch/result through
   reconciliation.
+
+### Terminal old-target and source-free bootstrap correction
+
+The live `SUR-6B312E24` fixture closed in `failed` with an immutable target from
+an older release. A terminal row is historical evidence, not a mutable retry
+slot: reconciliation must return a fail-closed terminal disposition without
+rewriting its target, status, fingerprint, or failure evidence. It must never
+dispatch that row toward a later release.
+
+When the current release target is available only through a server-owned,
+authenticated release binding, the existing operator action is the sole
+bootstrap boundary. There is no second bootstrap export or alternate admission
+path. The action verifies the signed, expiring release binding before it supplies
+`recoveryOfRunId` to the transaction; the ordinary request path cannot supply
+that field. This boundary proves that the superseded row is the exact latest terminal run,
+accepts only a distinct tagged `release-artifact` target from the authenticated
+server binding, and creates one separately fingerprinted admission through the
+same atomic transaction. `SelfUpgradeRun.recoveryOfRunId` is a unique typed
+self-relation, so a predecessor can have at most one successor and the
+predecessor's target, status, fingerprint, failure, and timestamps remain
+untouched. This supersedes the earlier "no replacement run" acceptance only for
+the proven terminal-old-target case; predecessor immutability remains normative.
+No client-provided SHA/tag, Git fallback, row reopening, downgrade, emergency
+override, or direct queue send is accepted. Active or ambiguous predecessors,
+newer runs, an existing successor, untagged/Git targets, target drift, and
+missing or expired authentication all remain fail closed. The normal
+worker/quiescence gates still decide whether the new admission can perform a
+physical upgrade.
+
+`recoveryOfRunId` is audit metadata, not dispatch authority. Dispatch authority
+comes only from the successor admission's independently verified signed target
+binding and its own recomputed admission fingerprint. The additive migration
+checks structural predecessor evidence but does not cryptographically recompute
+the historical predecessor fingerprint. Its trust premise is the integrity of
+server-created historical rows; the residual risk is a previously corrupted
+predecessor being linked for audit. That link cannot authorize, retarget, or
+dispatch either row. Migration tests statically assert the SQL contract; live
+acceptance must separately inspect the migrated rows and the independently
+authorized successor dispatch.
+
+### Bootstrap ordering
+
+The current source-free runtime predates `recoveryOfRunId`, so publication alone
+cannot prove this contract live. After the protected repair release is published,
+the existing operator page must render a fresh signed binding for that exact tag
+and SHA. One separately authorized click may then use the already-live durable
+admission path to create and dispatch a new, separately fingerprinted run; a
+plain retry without the signed binding is refused. When the new container starts,
+the additive migration links that singular in-flight manual release admission to
+the immediately preceding failed pre-dispatch run only when every CAS predicate
+holds. Any ambiguity leaves the relation null and fails live acceptance. Served
+SHA, CAN-TEST, the successor relation, the unchanged predecessor row, and ordinary
+restart coherence are all required before downstream recovery resumes.

--- a/packages/db/prisma/migrations/20260829160000_self_upgrade_recovery_successor/migration.sql
+++ b/packages/db/prisma/migrations/20260829160000_self_upgrade_recovery_successor/migration.sql
@@ -1,0 +1,70 @@
+-- BI-3FD07259: terminal self-upgrade admissions remain immutable history.
+-- A nullable, unique self-reference records the one separately fingerprinted
+-- successor admitted to recover from a terminal predecessor. Historical rows
+-- intentionally remain NULL; no target, status, or failure evidence is changed.
+
+ALTER TABLE "SelfUpgradeRun"
+  ADD COLUMN "recoveryOfRunId" TEXT;
+
+-- @migration-safety: data-safe: recoveryOfRunId is a newly added nullable column, so every existing row is non-conflicting; the only backfill value is a unique link to an existing SelfUpgradeRun selected below.
+CREATE UNIQUE INDEX "SelfUpgradeRun_recoveryOfRunId_key"
+  ON "SelfUpgradeRun"("recoveryOfRunId");
+
+ALTER TABLE "SelfUpgradeRun"
+  ADD CONSTRAINT "SelfUpgradeRun_recoveryOfRunId_fkey"
+  FOREIGN KEY ("recoveryOfRunId") REFERENCES "SelfUpgradeRun"("runId")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Source-free bootstrap ordering: this audit-only relation grants no dispatch
+-- authority. This migration is first executed by the new
+-- container after the previous runtime has admitted and dispatched the one
+-- authenticated operator action. Link only that singular in-flight admission
+-- to the immediately preceding pre-dispatch terminal failure. Every predicate
+-- is structurally fail-closed: no active ambiguity, no untagged/Git target, no same-target
+-- retry, no prior dispatch acknowledgement, and no existing successor.
+WITH "active_count" AS (
+  SELECT COUNT(*)::INTEGER AS "count"
+  FROM "SelfUpgradeRun"
+  WHERE "status" IN ('pending', 'queued', 'running')
+),
+"candidate" AS (
+  SELECT
+    "successor"."id" AS "successorId",
+    "predecessor"."runId" AS "predecessorRunId"
+  FROM "SelfUpgradeRun" AS "successor"
+  CROSS JOIN "active_count"
+  JOIN LATERAL (
+    SELECT "prior".*
+    FROM "SelfUpgradeRun" AS "prior"
+    WHERE "prior"."createdAt" < "successor"."createdAt"
+    ORDER BY "prior"."createdAt" DESC
+    LIMIT 1
+  ) AS "predecessor" ON TRUE
+  WHERE "active_count"."count" = 1
+    AND "successor"."status" IN ('pending', 'queued', 'running')
+    AND "successor"."completedAt" IS NULL
+    AND "successor"."trigger" LIKE 'manual:%'
+    AND "successor"."targetTag" IS NOT NULL
+    AND "successor"."admissionFingerprint" IS NOT NULL
+    AND "successor"."dispatchStatus" IN ('dispatching', 'dispatched')
+    AND "predecessor"."status" = 'failed'
+    AND "predecessor"."completedAt" IS NOT NULL
+    AND "predecessor"."dispatchAttemptCount" = 0
+    AND "predecessor"."admissionFingerprint" IS NOT NULL
+    AND "predecessor"."dispatchStatus" IS NOT NULL
+    AND "predecessor"."dispatchAcknowledgedAt" IS NULL
+    AND cardinality("predecessor"."dispatchEventIds") = 0
+    AND "predecessor"."targetSha" IS NOT NULL
+    AND "predecessor"."targetTag" IS NOT NULL
+    AND LOWER("predecessor"."targetSha") <> LOWER("successor"."targetSha")
+    AND "predecessor"."targetTag" <> "successor"."targetTag"
+    AND NOT EXISTS (
+      SELECT 1
+      FROM "SelfUpgradeRun" AS "existing"
+      WHERE "existing"."recoveryOfRunId" = "predecessor"."runId"
+    )
+)
+UPDATE "SelfUpgradeRun" AS "successor"
+SET "recoveryOfRunId" = "candidate"."predecessorRunId"
+FROM "candidate"
+WHERE "successor"."id" = "candidate"."successorId";

--- a/packages/db/prisma/schema/build-delivery.prisma
+++ b/packages/db/prisma/schema/build-delivery.prisma
@@ -1369,6 +1369,12 @@ model SelfUpgradeRun {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
+  // A recovery admission never rewrites its terminal predecessor. The unique
+  // self-relation makes the one permitted successor explicit and auditable.
+  recoveryOfRunId String?         @unique
+  recoveryOf      SelfUpgradeRun? @relation("SelfUpgradeRecovery", fields: [recoveryOfRunId], references: [runId], onDelete: Restrict, onUpdate: Cascade)
+  recoveredBy     SelfUpgradeRun? @relation("SelfUpgradeRecovery")
+
   // BI-3FD07259 — durable admission precedes queue I/O. Nullable dispatch
   // state preserves historical rows created before the admission contract.
   targetTag              String?

--- a/packages/db/src/self-upgrade-recovery-successor-migration.test.ts
+++ b/packages/db/src/self-upgrade-recovery-successor-migration.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migrationSql = readFileSync(
+  new URL(
+    "../prisma/migrations/20260829160000_self_upgrade_recovery_successor/migration.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe("SelfUpgradeRun recovery successor migration", () => {
+  it("statically asserts one unique audit relation and the bootstrap SQL predicates", () => {
+    expect(migrationSql).toContain('CREATE UNIQUE INDEX "SelfUpgradeRun_recoveryOfRunId_key"');
+    expect(migrationSql).toContain('"active_count"."count" = 1');
+    expect(migrationSql).toContain('"predecessor"."status" = \'failed\'');
+    expect(migrationSql).toContain('"predecessor"."dispatchAttemptCount" = 0');
+    expect(migrationSql).toContain('cardinality("predecessor"."dispatchEventIds") = 0');
+    expect(migrationSql).toContain('"successor"."trigger" LIKE \'manual:%\'');
+    expect(migrationSql).toContain('"successor"."dispatchStatus" IN (\'dispatching\', \'dispatched\')');
+  });
+
+  it("does not hard-code or rewrite the terminal predecessor", () => {
+    expect(migrationSql).not.toContain("SUR-6B312E24");
+    expect(migrationSql).not.toMatch(/SET\s+"(?:targetSha|targetTag|status|admissionFingerprint)"/i);
+    expect(migrationSql).toContain('SET "recoveryOfRunId" = "candidate"."predecessorRunId"');
+  });
+});


### PR DESCRIPTION
## Summary

- preserve terminal `SelfUpgradeRun` rows as immutable historical records and model an exceptional recovery as one separately fingerprinted successor
- require a fresh, server-signed release-artifact binding at the authenticated operations boundary; ordinary retry requests cannot acquire recovery authority
- serialize successor admission with a database advisory lock and a unique predecessor relation, rejecting active, ambiguous, same-target, drifted, malformed, or duplicate recovery attempts
- add nullable audit linkage plus a fail-closed structural migration backfill and document the source-free bootstrap ordering

## Design grounding

Reviewed `docs/superpowers/specs/2026-08-29-self-upgrade-admission-reconciliation-design.md` and `docs/superpowers/plans/2026-08-29-self-upgrade-admission-reconciliation.md` against the existing admission, request, operations action, and run-store substrates. The authenticated `triggerSelfUpgrade` operations action remains the sole recovery bootstrap boundary. `recoveryOfRunId` is audit metadata only; dispatch authority derives from the independently validated signed successor admission and its own admission fingerprint.

## Verification

- focused web tests: 7 files / 137 tests passed
- migration SQL contract tests: 2 / 2 passed
- web and database TypeScript checks passed
- module-size, data-impact, derived-artifact, prose, style, DCO, and guard preflight checks passed
- `pnpm pr:ready`: READY; one known source-only-host PR-health check was environment-skipped and remains CI-authoritative
- exact-tree local CI lease `NPEL-B9C611D8F3` fenced at its authority deadline after preflight and 1,979 log lines; it recorded no failing command. Evidence: `cmtelkuit072601pgjkdj3k2z`. This is not a PASS; protected checks remain mandatory.
- semantic review produced no qualifying receipt and is not claimed as PASS; protected review/check enforcement remains authoritative

## Data impact

Adds a nullable unique self-relation on `SelfUpgradeRun`. The migration only backfills a structurally eligible one-to-one historical relation and remains fail-closed for ambiguity. Its tests are static SQL contract assertions, not an executed database-migration fixture. The migration does not cryptographically recompute a predecessor fingerprint; historical relation integrity remains an explicitly documented trust premise, while dispatch authority remains independently validated on the successor admission.

## Deployment boundary

This PR supplies the typed successor source path only. It does not authorize a live upgrade or replay downstream review tasks. After a canonical release is published, the source-free bootstrap requires a separately authorized, single authenticated operations action with a fresh server-owned signed target binding; acceptance requires a distinct successor identity, exact served SHA, CAN-TEST, and restart/install identity convergence.

Signed-off-by: Mark Bodman <markdbodman@gmail.com>
Docs-Impact-Decision: Internal self-upgrade admission persistence and audit metadata; no operator workflow or documented route changes.
Local-CI-Override: install-bootstrap-recovery: NPEL-B9C611D8F3/cmtelkuit072601pgjkdj3k2z fenced at authority deadline after preflight and 1979 log lines; no failing command was recorded; protected checks remain mandatory.
