### PR TITLE
fix(self-upgrade): materialize Git LFS objects in the upgrade workspace (BI-DDB48B04)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -257,7 +257,18 @@ WORKDIR /app
 # nmap powers the fast path of the arp_scan discovery collector. Without it the
 # collector falls back to a 254-host ping sweep; with it a /24 scans in seconds.
 # (See packages/db/src/discovery-collectors/arp-scan.ts — BI-4CA890B7.)
-RUN apk add --no-cache docker-cli docker-cli-buildx docker-cli-compose postgresql16-client git curl nmap
+#
+# git-lfs is load-bearing on the git-source install shape, not hygiene. This
+# stage runs the self-upgrade source preparation (lib/self-upgrade/prepare-source.ts),
+# which clones the host install clone into .upgrade-workspace and hands that
+# tree to the promoter as its build context. `git` alone smudges LFS-tracked
+# paths to ~130-byte pointer stubs, so the promoter build then dies on the
+# zip-magic assertion this Dockerfile makes over the IT4IT workbook — failing
+# every upgrade on this shape, permanently (BI-FEE26C36 follow-on). The
+# publish path materializes LFS via `actions/checkout` with `lfs: true`; this
+# is the same guarantee for the path that has no GitHub Actions runner.
+# Dockerfile.sandbox installs it for the same class of reason.
+RUN apk add --no-cache docker-cli docker-cli-buildx docker-cli-compose postgresql16-client git git-lfs curl nmap
 ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
 ENV PORT=3000

--- a/apps/web/lib/self-upgrade/lfs-materialization.test.ts
+++ b/apps/web/lib/self-upgrade/lfs-materialization.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildLfsLsFilesCommand,
+  buildLfsPullCommand,
+  describeUnmaterialized,
+  parseLfsLsFiles,
+  unmaterializedPaths,
+} from "./lfs-materialization";
+
+describe("lfs command builders", () => {
+  it("scopes both commands to the workspace and omits the leading git", () => {
+    expect(buildLfsPullCommand("/host-dpf/.upgrade-workspace")).toEqual([
+      "-C",
+      "/host-dpf/.upgrade-workspace",
+      "lfs",
+      "pull",
+    ]);
+    expect(buildLfsLsFilesCommand("/ws")).toEqual(["-C", "/ws", "lfs", "ls-files"]);
+  });
+});
+
+describe("parseLfsLsFiles", () => {
+  it("reads the materialization marker for each tracked path", () => {
+    const parsed = parseLfsLsFiles(
+      [
+        "be8951db1c * docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx",
+        "a1b2c3d4e5 - docs/Reference/Some Report.pdf",
+        "",
+      ].join("\n"),
+    );
+    expect(parsed).toEqual([
+      {
+        oid: "be8951db1c",
+        materialized: true,
+        path: "docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx",
+      },
+      { oid: "a1b2c3d4e5", materialized: false, path: "docs/Reference/Some Report.pdf" },
+    ]);
+  });
+
+  it("keeps paths containing spaces intact", () => {
+    expect(parseLfsLsFiles("aaa * docs/a b c.docx")[0].path).toBe("docs/a b c.docx");
+  });
+
+  it("ignores unparseable lines rather than failing the upgrade", () => {
+    expect(parseLfsLsFiles("git-lfs/3.5.1 (GitHub; linux amd64)\n\n")).toEqual([]);
+  });
+});
+
+describe("unmaterializedPaths", () => {
+  it("returns only the pointer stubs", () => {
+    const tracked = parseLfsLsFiles(["aaa * kept.xlsx", "bbb - stub.pdf", "ccc - other.docx"].join("\n"));
+    expect(unmaterializedPaths(tracked)).toEqual(["stub.pdf", "other.docx"]);
+  });
+
+  it("is empty when every tracked object is present", () => {
+    expect(unmaterializedPaths(parseLfsLsFiles("aaa * kept.xlsx"))).toEqual([]);
+  });
+
+  // The regression that broke every upgrade: the workbook Dockerfile COPYs and
+  // asserts arrived as a pointer, because the portal container had no git-lfs.
+  it("flags the IT4IT workbook when it arrives as a pointer", () => {
+    const tracked = parseLfsLsFiles(
+      "be8951db1c - docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx",
+    );
+    expect(unmaterializedPaths(tracked)).toEqual([
+      "docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx",
+    ]);
+  });
+});
+
+describe("describeUnmaterialized", () => {
+  it("names the paths and both known causes", () => {
+    const msg = describeUnmaterialized(["docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx"]);
+    expect(msg).toContain("IT4IT_Functional_Criteria_Taxonomy.xlsx");
+    expect(msg).toContain("git-lfs");
+    expect(msg).toContain("Docker context");
+  });
+
+  it("truncates a long list instead of dumping every path into the run reason", () => {
+    const msg = describeUnmaterialized(["a", "b", "c", "d", "e", "f", "g"]);
+    expect(msg).toContain("(+2 more)");
+  });
+});

--- a/apps/web/lib/self-upgrade/lfs-materialization.ts
+++ b/apps/web/lib/self-upgrade/lfs-materialization.ts
@@ -1,0 +1,109 @@
+// apps/web/lib/self-upgrade/lfs-materialization.ts
+//
+// Assert that the self-upgrade workspace holds REAL bytes for every Git
+// LFS-tracked path, not pointer stubs.
+//
+// Why this exists (BI-FEE26C36 follow-on). The upgrade workspace is not just a
+// git checkout — it is the promoter's Docker build context. `.gitattributes`
+// LFS-tracks *.pdf/*.xlsx/*.docx/*.pptx, and Dockerfile COPYs one of them
+// (docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx) then asserts it is a
+// real zip. So an unmaterialized pointer in the workspace is not cosmetic: it
+// fails the promoter build, and therefore the whole upgrade.
+//
+// That is exactly what happened. #4843 fixed the PUBLISH path (actions/checkout
+// with `lfs: true`) and added the zip-magic assertion to Dockerfile. The
+// git-source install shape has no GitHub Actions runner: it builds the same
+// Dockerfile from a workspace the PORTAL container clones, and that container
+// shipped without git-lfs while the git runner also forced
+// GIT_LFS_SKIP_SMUDGE=1. Every scheduled upgrade after #4843 merged failed on
+// the new assertion, ~2 minutes into a Docker build, with the cause visible
+// only in the raw build log.
+//
+// Two properties this module is built for:
+//
+//   1. GENERIC, not per-file. Dockerfile guards the one workbook it COPYs. A
+//      pointer in any other LFS-tracked path would still reach the image (or a
+//      future COPY) silently. `git lfs ls-files` enumerates every tracked path
+//      and states, per path, whether the object is materialized — so the check
+//      covers the class, not the one instance that bit us.
+//
+//   2. EARLY and NAMED. Failing here costs a git command, not a two-minute
+//      build, and it writes a self-describing reason onto the run row instead
+//      of leaving the operator to read Docker output.
+//
+// Pure parsing + command builders; the caller supplies the git runner, so this
+// stays unit-testable with no filesystem and no git binary.
+
+/** One LFS-tracked path in the workspace, and whether its real bytes are present. */
+export interface LfsTrackedPath {
+  /** Object id as `git lfs ls-files` prints it (short oid). */
+  oid: string;
+  /** Repo-relative path. */
+  path: string;
+  /** True when the working-tree file holds the object, false when it is a pointer stub. */
+  materialized: boolean;
+}
+
+/**
+ * `git lfs pull` argv (without the leading "git"), matching the GitRunner
+ * contract in prepare-source.ts.
+ *
+ * Pull rather than rely on smudge-on-checkout: the prep git runner sets
+ * GIT_LFS_SKIP_SMUDGE=1 deliberately, so the mechanical branch/merge ops stay
+ * fast and never block on the network mid-merge. Materialization is a single
+ * explicit step once the tree is final.
+ */
+export function buildLfsPullCommand(workspacePath: string): string[] {
+  return ["-C", workspacePath, "lfs", "pull"];
+}
+
+/** `git lfs ls-files` argv (without the leading "git"). */
+export function buildLfsLsFilesCommand(workspacePath: string): string[] {
+  return ["-C", workspacePath, "lfs", "ls-files"];
+}
+
+/**
+ * Parse `git lfs ls-files` stdout.
+ *
+ * Format is `<oid> <marker> <path>`, where the marker is `*` when the object is
+ * checked out into the working tree and `-` when the file is still a pointer.
+ * Paths may contain spaces, so split on the first two fields only.
+ *
+ * Unparseable lines are ignored rather than treated as failures: this check
+ * must never be the thing that blocks an otherwise-good upgrade because a
+ * future git-lfs release added a column.
+ */
+export function parseLfsLsFiles(stdout: string): LfsTrackedPath[] {
+  const out: LfsTrackedPath[] = [];
+  for (const raw of stdout.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    const match = /^(\S+)\s+([*-])\s+(.+)$/.exec(line);
+    if (!match) continue;
+    out.push({ oid: match[1], materialized: match[2] === "*", path: match[3].trim() });
+  }
+  return out;
+}
+
+/** The LFS-tracked paths still sitting in the workspace as pointer stubs. */
+export function unmaterializedPaths(tracked: LfsTrackedPath[]): string[] {
+  return tracked.filter((t) => !t.materialized).map((t) => t.path);
+}
+
+/**
+ * Operator-facing explanation for a workspace that still holds pointer stubs.
+ * Names the cause and the two things that produce it, because both have bitten:
+ * a portal image without git-lfs, and an LFS object the install clone cannot
+ * reach.
+ */
+export function describeUnmaterialized(paths: string[]): string {
+  const shown = paths.slice(0, 5).join(", ");
+  const more = paths.length > 5 ? ` (+${paths.length - 5} more)` : "";
+  return (
+    `Git LFS objects were not materialized in the upgrade workspace: ${shown}${more}. ` +
+    `The promoter builds this workspace as its Docker context and Dockerfile asserts ` +
+    `real bytes, so this would fail the image build. Usual causes: the portal image is ` +
+    `missing the git-lfs binary, or the LFS objects for the target commit cannot be ` +
+    `fetched from the configured remote.`
+  );
+}

--- a/apps/web/lib/self-upgrade/prepare-source.test.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.test.ts
@@ -106,6 +106,67 @@ describe("prepareUpgradeSource — upstream mode (isolated workspace, BI-4043A64
     ).toBe(true);
   });
 
+  // ── Git LFS materialization (BI-FEE26C36 follow-on) ──────────────────────
+  // The workspace is the promoter's Docker build context and Dockerfile asserts
+  // real bytes for the LFS-tracked IT4IT workbook (#4843). A pointer stub here
+  // fails the image build two minutes in, so prep must catch it and say why.
+  const cleanMergeRoutes: Array<[string, GitResult]> = [
+    ["rev-parse --git-dir", ok()],
+    ["config --get remote.origin.url", ok("https://github.com/x/y.git\n")],
+    ["config --get remote.upgrade-upstream.url", ok("")],
+    ["rev-parse upgrade-upstream/main", ok(`${UPSTREAM}\n`)],
+    ["diff --quiet", fail("local content delta", 1)],
+    ["rev-parse HEAD", ok(`${MERGE}\n`)],
+    ["status --porcelain", ok("")],
+  ];
+
+  it("materializes LFS objects in the workspace before stamping", async () => {
+    const git = fakeGit(cleanMergeRoutes);
+    await prepareUpgradeSource(baseWorkspace, git);
+    expect(
+      git.calls.some((c) => c.join(" ") === "-C /host-dpf/.upgrade-workspace lfs pull"),
+    ).toBe(true);
+  });
+
+  it("fails with a named reason when an LFS-tracked path is still a pointer stub", async () => {
+    const git = fakeGit([
+      ...cleanMergeRoutes,
+      [
+        "lfs ls-files",
+        ok("be8951db1c - docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx\n"),
+      ],
+    ]);
+    const r = await prepareUpgradeSource(baseWorkspace, git);
+    expect(r).toMatchObject({ ok: false, reason: "lfs-unmaterialized" });
+    if (r.ok) return;
+    expect(r.message).toContain("IT4IT_Functional_Criteria_Taxonomy.xlsx");
+    // Never push a tree the promoter cannot build.
+    expect(git.calls.some((c) => c.includes("push"))).toBe(false);
+  });
+
+  it("stops when materialization cannot be verified at all (no git-lfs binary)", async () => {
+    const git = fakeGit([
+      ...cleanMergeRoutes,
+      ["lfs ls-files", fail("git: 'lfs' is not a git command", 1)],
+    ]);
+    const r = await prepareUpgradeSource(baseWorkspace, git);
+    expect(r).toMatchObject({ ok: false, reason: "lfs-unmaterialized" });
+    if (r.ok) return;
+    expect(r.message).toMatch(/git-lfs/);
+  });
+
+  it("proceeds when every tracked object is materialized", async () => {
+    const git = fakeGit([
+      ...cleanMergeRoutes,
+      [
+        "lfs ls-files",
+        ok("be8951db1c * docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx\n"),
+      ],
+    ]);
+    const r = await prepareUpgradeSource(baseWorkspace, git);
+    expect(r).toEqual({ ok: true, mode: "upstream", stamp: MERGE, upstreamSha: UPSTREAM });
+  });
+
   it("advances an upstream-only install to the exact canonical upstream commit", async () => {
     const git = fakeGit([
       ["rev-parse --git-dir", ok()],

--- a/apps/web/lib/self-upgrade/prepare-source.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.ts
@@ -24,6 +24,13 @@ import {
   deriveDeployedStamp,
 } from "./version";
 import type { UpgradeSourceMode } from "./config";
+import {
+  buildLfsLsFilesCommand,
+  buildLfsPullCommand,
+  describeUnmaterialized,
+  parseLfsLsFiles,
+  unmaterializedPaths,
+} from "./lfs-materialization";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 /** Result of running one git command. Never throws on non-zero exit. */
@@ -74,7 +81,7 @@ export type PrepareSourceResult =
     }
   | {
       ok: false;
-      reason: "no-target" | "prep-error" | "dirty-tree";
+      reason: "no-target" | "prep-error" | "dirty-tree" | "lfs-unmaterialized";
       message: string;
     };
 
@@ -444,6 +451,37 @@ async function prepareUpgradeSourceInWorkspace(
       };
     }
 
+    // ── 4b. Materialize Git LFS objects, then assert none are left as stubs. ──
+    // The workspace tree IS the promoter's Docker build context, and Dockerfile
+    // asserts real bytes for the LFS-tracked IT4IT workbook it COPYs (#4843).
+    // The prep git runner deliberately sets GIT_LFS_SKIP_SMUDGE=1 so the
+    // mechanical branch/merge ops never block on the network, which means
+    // materialization has to be an explicit step here, once the tree is final.
+    //
+    // Failing here costs one git command instead of a two-minute promoter build
+    // that dies on a zip-magic check buried in Docker output, and it writes a
+    // named reason onto the run row. `lfs pull` is best-effort: `ls-files` is
+    // the verdict, so a pull that partially succeeds is still caught.
+    await run(buildLfsPullCommand(input.workspacePath));
+    const lsFiles = await run(buildLfsLsFilesCommand(input.workspacePath));
+    // A non-zero ls-files (no git-lfs binary, or LFS not configured) is not
+    // itself proof of stubs — but it means we cannot VERIFY, and an unverified
+    // build context is exactly what shipped the pointer. Treat it as a stop.
+    if (lsFiles.code !== 0) {
+      return {
+        ok: false,
+        reason: "lfs-unmaterialized",
+        message:
+          `cannot verify Git LFS materialization in the upgrade workspace: ` +
+          `\`git lfs ls-files\` exited ${lsFiles.code}: ${trim(lsFiles.stderr) || "(no stderr)"}. ` +
+          `The portal image must provide the git-lfs binary for the git-source upgrade shape.`,
+      };
+    }
+    const stubs = unmaterializedPaths(parseLfsLsFiles(lsFiles.stdout));
+    if (stubs.length > 0) {
+      return { ok: false, reason: "lfs-unmaterialized", message: describeUnmaterialized(stubs) };
+    }
+
     // ── 5. Stamp the merged tree's HEAD and push the new install-branch tip
     //       back to the install clone (ref-only — never touches its tree). ──
     const stamp = await readHeadStamp(run, input.workspacePath);
@@ -494,13 +532,22 @@ const GIT_RUNNER_TIMEOUT_MS = 120_000;
 export async function defaultGitRunner(args: string[]): Promise<GitResult> {
   const { execFile } = await import("node:child_process");
   // Run prep's internal git ops with repo hooks DISABLED. The host clone ships a
-  // Git LFS post-checkout/post-merge hook (the repo uses filter=lfs), but the
-  // portal container has no git-lfs binary — so the hook exits non-zero and makes
-  // an otherwise-successful `git checkout`/`merge` look like it failed, aborting
-  // the whole upgrade at prep. Prep is mechanical (move branches, merge for a
-  // build) and never needs LFS smudging, so force core.hooksPath empty and skip
-  // LFS smudge. `-c` is a git GLOBAL option and must precede the subcommand —
-  // prepend it ahead of the caller's args (which start with "-C <path> <cmd>").
+  // Git LFS post-checkout/post-merge hook (the repo uses filter=lfs); the hook is
+  // noise for mechanical prep and, on any host missing the binary, makes an
+  // otherwise-successful `git checkout`/`merge` look like it failed and aborts the
+  // whole upgrade at prep. GIT_LFS_SKIP_SMUDGE keeps branch moves and the merge
+  // off the network — they only need trees and blobs, never LFS content.
+  //
+  // Skipping smudge does NOT mean the workspace may ship pointer stubs: it is the
+  // promoter's Docker build context, and Dockerfile asserts real bytes (#4843).
+  // Materialization is deferred to one explicit `git lfs pull` + `ls-files`
+  // verification once the tree is final — see lfs-materialization.ts. Prep used
+  // to claim it "never needs LFS smudging"; that stopped being true the moment
+  // the image build began asserting the workbook's content, and every upgrade on
+  // the git-source shape failed until this was split out.
+  //
+  // `-c` is a git GLOBAL option and must precede the subcommand — prepend it
+  // ahead of the caller's args (which start with "-C <path> <cmd>").
   const safeArgs = ["-c", "core.hooksPath=/dev/null", ...args];
   return new Promise<GitResult>((resolve) => {
     execFile("git", safeArgs, {

--- a/docs/superpowers/specs/2026-08-29-release-image-lfs-asset-materialization-design.md
+++ b/docs/superpowers/specs/2026-08-29-release-image-lfs-asset-materialization-design.md
@@ -139,3 +139,47 @@ by asserting the input is present in the job that builds image contexts.
 - Removing `lfs: true` from the workflow fails the new workflow-shape test.
 - Feeding a pointer stub into the build context fails the image build with the
   named error rather than producing a publishable image.
+
+## Follow-on: the guard also fires on the git-source upgrade path
+
+**Backlog item:** BI-DDB48B04
+
+The blast radius above says "no runtime code change" and reasons entirely about
+the publish path. That is where this design was incomplete, and it broke every
+upgrade on the git-source install shape within two hours of merging.
+
+The Dockerfile assertion is enforced on **every** build of this Dockerfile, not
+only CI's. On a git-source install the self-upgrade promoter builds the same
+Dockerfile, and its build context is the `.upgrade-workspace` tree that the
+**portal container** clones in `apps/web/lib/self-upgrade/prepare-source.ts`.
+That path has no `actions/checkout`, so nothing was supplying `lfs: true`'s
+guarantee. Two things then made pointer stubs the only possible outcome:
+
+- the portal runner stage installed `git` but not `git-lfs`; and
+- `defaultGitRunner` sets `GIT_LFS_SKIP_SMUDGE=1` on purpose, so the mechanical
+  branch/merge operations never block on the network.
+
+Result: `SUR-8784ADFE` (08:02) and every scheduled run after it failed ~2 minutes
+into the promoter build, on the zip-magic assertion, with the cause visible only
+in raw Docker output and the run row's `reason` column left empty.
+
+The assertion itself was right and stays. What changed:
+
+- **`Dockerfile`** — the runner stage installs `git-lfs`, so the workspace clone
+  can materialize LFS objects at all. A shape test in
+  `scripts/publish-image-release-identity.test.mjs` ratchets it, alongside the
+  two this design already added.
+- **`apps/web/lib/self-upgrade/lfs-materialization.ts`** (new) — after the
+  workspace tree is final, `git lfs pull` then `git lfs ls-files`, and any path
+  still marked `-` fails the run with reason `lfs-unmaterialized`.
+
+Deliberately **generic**, not a second per-file check: `.gitattributes` LFS-tracks
+`*.pdf`, `*.xlsx`, `*.docx` and `*.pptx`, while the Dockerfile asserts only the
+one workbook it COPYs. A stub in any other tracked path was — and otherwise would
+remain — invisible until something read it.
+
+The wider lesson for this repo's two install shapes: a guard added for the
+published-image shape lands on the git-source shape too, because both build this
+Dockerfile. "Fail the publish, never the install" only holds if the install path
+can satisfy the assertion. Ask which shapes execute a guard before assuming the
+one you are fixing is the only one.

--- a/scripts/publish-image-release-identity.test.mjs
+++ b/scripts/publish-image-release-identity.test.mjs
@@ -82,3 +82,26 @@ test("the Dockerfile refuses to bake an unmaterialized LFS pointer", () => {
     "the COPY must be followed by a zip-magic assertion so a pointer stub fails the publish, not the install",
   );
 });
+
+test("the runner stage ships git-lfs for the git-source upgrade shape", () => {
+  const dockerfile = readFileSync("Dockerfile", "utf8");
+  const runnerIndex = dockerfile.indexOf("FROM base AS runner");
+  assert.notEqual(runnerIndex, -1, "the runner stage must exist");
+
+  // The zip-magic assertion above is enforced on EVERY build of this Dockerfile,
+  // including the one the self-upgrade promoter runs on a git-source install.
+  // That build's context is a workspace the RUNNER container clones
+  // (lib/self-upgrade/prepare-source.ts). Without git-lfs in this stage the clone
+  // can only ever produce pointer stubs, so the assertion fails the operator's
+  // upgrade instead of a publish — which is what happened to every scheduled run
+  // after #4843 merged. The publish path gets materialization from
+  // actions/checkout; this stage is that guarantee for the path with no runner.
+  const runner = dockerfile.slice(runnerIndex);
+  const apkLine = runner.split("\n").find((l) => l.startsWith("RUN apk add"));
+  assert.ok(apkLine, "the runner stage must install its OS packages via apk add");
+  assert.match(
+    apkLine,
+    /\bgit-lfs\b/,
+    "the runner stage must install git-lfs or self-upgrade cannot materialize the LFS-tracked assets it then asserts",
+  );
+});


### PR DESCRIPTION
Every self-upgrade on the **git-source install shape** has failed since #4843 merged. `SUR-8784ADFE` (08:02) and every scheduled run after it died ~2 minutes into the promoter build on the zip-magic assertion over `docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx`.

## Root cause

#4843 fixed the **published-image** shape: `actions/checkout` with `lfs: true`, plus a Dockerfile assertion so a pointer stub fails the publish rather than the install. That assertion is correct and stays.

What it missed is that the **git-source shape builds the same Dockerfile**. The promoter's build context is the `.upgrade-workspace` tree cloned by the *portal* container in `prepare-source.ts`, where no `actions/checkout` exists. Two things made a pointer stub the only possible outcome there:

1. the portal runner stage installed `git` but not `git-lfs`; and
2. `defaultGitRunner` sets `GIT_LFS_SKIP_SMUDGE=1` deliberately, so mechanical branch/merge ops never block on the network.

Verified on the live install:

| path | first bytes |
|---|---|
| `/host-dpf/docs/Reference/…xlsx` | `PK` (real zip) |
| `/host-dpf/.upgrade-workspace/docs/Reference/…xlsx` | `version https://git-lfs.github.com/spec/v1` |

`docker exec dpf-portal-1 command -v git-lfs` returns nothing.

"Fail the publish, never the install" only holds if the install path can satisfy the assertion. On this shape the promoter build **is** the install path, so the guard failed the operator's upgrade instead — permanently, with the cause visible only in raw Docker output and the run row's `reason` column left empty.

## Changes

- **`Dockerfile`** — the runner stage installs `git-lfs`, so the workspace clone can materialize LFS objects at all.
- **`apps/web/lib/self-upgrade/lfs-materialization.ts`** (new) — after the workspace tree is final, `git lfs pull` then `git lfs ls-files`; any path still marked `-` fails the run with the named reason `lfs-unmaterialized`.
- **`prepare-source.ts`** — wires the check in before the stamp/push, and corrects the now-false comment claiming prep "never needs LFS smudging".

Deliberately **generic**, not a second per-file check: `.gitattributes` LFS-tracks `*.pdf`/`*.xlsx`/`*.docx`/`*.pptx` while the Dockerfile asserts only the one workbook it COPYs, so a stub anywhere else was invisible. A non-zero `ls-files` is also a stop — it means materialization cannot be *verified*, and an unverified build context is exactly what shipped the pointer.

Failing here costs one git command instead of a two-minute build, and names the cause on the run row.

## Ratchets (each confirmed failing when its subject is reverted)

- Dockerfile-shape test: the runner stage must install `git-lfs`.
- Two `prepare-source` tests: the pointer-stub path and the missing-binary path.

## Backlog anchor backfill

#4843 cited `BI-FEE26C36` (from the spec) and `BI-98D19DF2` (from `seed-ea-reference-models.ts`), but neither was ever filed — the Doc Anchor Existence guard surfaced both when the spec was next edited. Both are filed here from the merged PR, the spec, and the shipped code comment, not reconstructed.

## Verification

- `pnpm run pregate` → **PASS** (`fix/self-upgrade-lfs-materialization@2df0243e8381`, evidence `cmteqg6isslbb01mdr97cnclr`) — includes the production build.
- Preflight: 59 guards clean.
- `apps/web` typecheck clean; new and existing unit tests green.

Refs: BI-DDB48B04, BI-FEE26C36, BI-98D19DF2

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Local-CI-Evidence: cmteqg6isslbb01mdr97cnclr
