### PR TITLE
fix(self-upgrade): stop the owner card claiming currency while an update waits (BI-B99C7487)

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.tsx
@@ -187,13 +187,16 @@ export default async function SelfUpgradePage() {
     cooldownUntil: effectiveStatus.cooldownUntil,
     jobEngine: effectiveStatus.jobEngine,
   };
+  // Single source of truth for "is there something to install": the summary's
+  // own updatePending, derived from support/target/freshness rather than from
+  // its run-state machine. This used to re-derive the failed case here
+  // (`state === "failed" && targetAvailability === "resolved" && !isFresh`),
+  // which enabled the button correctly but left the card above it still
+  // claiming "You're current" — the workaround was applied to the action and
+  // never pushed back into the summary it contradicted.
   const updateActionState = ownerSummary.state === "unavailable"
     ? "unavailable"
-    : ownerSummary.state === "update-available" || (
-        ownerSummary.state === "failed" &&
-        effectiveStatus.targetAvailability === "resolved" &&
-        !effectiveStatus.isFresh
-      )
+    : ownerSummary.updatePending
       ? "update-available"
       : "no-update";
   let targetBinding: string | null = null;

--- a/apps/web/components/ops/OwnerReleaseCard.test.tsx
+++ b/apps/web/components/ops/OwnerReleaseCard.test.tsx
@@ -15,6 +15,8 @@ const baseSummary: OwnerReleaseSummary = {
   headline: "An update is ready.",
   currentVersion: "1.0.0",
   availableVersion: "1.1.0",
+  updatePending: true,
+  availableVersionLabel: "Update ready",
   recommendedAction: { label: "Install when ready.", detail: "Takes a few minutes." },
   canKeepWorking: { ok: true, detail: "Yes, work continues during the update." },
   keptLocally: { count: 0, detail: "Nothing customised locally." },
@@ -61,5 +63,72 @@ describe("OwnerReleaseCard – primary action slot", () => {
   it("still renders the release-state marker other pages/tests key off", () => {
     const html = renderToStaticMarkup(<OwnerReleaseCard summary={baseSummary} />);
     expect(html).toContain('data-release-state="update-available"');
+  });
+});
+
+// Regression cover for the contradiction on /ops/self-upgrade: the tile read
+// "You're current" in success green while an update was pending and the
+// "Upgrade now" button beside it was enabled. "You're current" is a positive
+// claim and must never be the fallback for a missing label.
+describe("OwnerReleaseCard – never claims currency while an update is pending", () => {
+  function render(summary: OwnerReleaseSummary) {
+    return renderToStaticMarkup(<OwnerReleaseCard summary={summary} />);
+  }
+
+  it("shows the pending build, not \"You're current\", while a run is in flight", () => {
+    const html = render({
+      ...baseSummary,
+      state: "in-progress",
+      tone: "info",
+      availableVersion: "Latest build (PR #4854)",
+      availableVersionLabel: "Installing now",
+      updatePending: true,
+      riskNotice: null,
+    });
+    expect(html).toContain("PR #4854");
+    expect(html).toContain("Installing now");
+    expect(html).not.toContain("You&#x27;re current");
+  });
+
+  it("shows the pending build, not \"You're current\", after a run fails", () => {
+    const html = render({
+      ...baseSummary,
+      state: "failed",
+      tone: "danger",
+      availableVersion: "Latest build (PR #4854)",
+      availableVersionLabel: "Update still pending",
+      updatePending: true,
+      riskNotice: null,
+    });
+    expect(html).toContain("PR #4854");
+    expect(html).toContain("Update still pending");
+    expect(html).not.toContain("You&#x27;re current");
+  });
+
+  it("says \"You're current\" only when nothing is pending", () => {
+    const html = render({
+      ...baseSummary,
+      state: "up-to-date",
+      tone: "success",
+      availableVersion: null,
+      availableVersionLabel: "Update ready",
+      updatePending: false,
+      riskNotice: null,
+    });
+    expect(html).toContain("You&#x27;re current");
+  });
+
+  it("still reports an unsupported install distinctly", () => {
+    const html = render({
+      ...baseSummary,
+      state: "unavailable",
+      tone: "warning",
+      availableVersion: null,
+      availableVersionLabel: "Update ready",
+      updatePending: false,
+      riskNotice: null,
+    });
+    expect(html).toContain("Not available on this install");
+    expect(html).not.toContain("You&#x27;re current");
   });
 });

--- a/apps/web/components/ops/OwnerReleaseCard.tsx
+++ b/apps/web/components/ops/OwnerReleaseCard.tsx
@@ -64,21 +64,37 @@ export function OwnerReleaseCard({
           value={<span className="text-base font-semibold">{summary.currentVersion}</span>}
           intent="neutral"
         />
+        {/*
+          "You're current" is a POSITIVE CLAIM and must be rendered only when
+          the summary actually says the install is up to date — never as the
+          fallback for a missing label. It used to be exactly that fallback,
+          and because availableVersion was gated on
+          `state === "update-available"`, a run that was merely running or
+          failed collapsed it to null: the card then told the operator they
+          were current, in success green, directly above an enabled "Upgrade
+          now" button for the update it was denying existed.
+
+          Read updatePending, which is derived from the facts (support, target
+          resolution, freshness) rather than from the run state machine, so a
+          pending update stays visible while a run is in flight or after one
+          fails. The label carries the state; the value carries the identity.
+        */}
         <StatCard
-          label="Update ready"
+          label={summary.availableVersionLabel}
           value={
             <span className="text-base font-semibold">
-              {summary.availableVersion ??
-                (summary.state === "unavailable"
-                  ? "Not available on this install"
-                  : "You're current")}
+              {summary.state === "unavailable"
+                ? "Not available on this install"
+                : summary.updatePending
+                  ? summary.availableVersion ?? "Latest build"
+                  : "You're current"}
             </span>
           }
           intent={
-            summary.state === "update-available"
-              ? TONE_INTENT.info
-              : summary.state === "unavailable"
-                ? TONE_INTENT.warning
+            summary.state === "unavailable"
+              ? TONE_INTENT.warning
+              : summary.updatePending
+                ? TONE_INTENT.info
                 : "success"
           }
         />

--- a/apps/web/lib/self-upgrade/owner-summary.test.ts
+++ b/apps/web/lib/self-upgrade/owner-summary.test.ts
@@ -332,3 +332,103 @@ describe("buildOwnerReleaseSummary", () => {
     }
   });
 });
+
+// ── The pending update must survive the run state machine ────────────────────
+//
+// Regression cover for the contradiction an operator hit on /ops/self-upgrade:
+// the card's top tile read "Update ready: You're current" in success green
+// while the banner below it read "Update available", and the "Upgrade now"
+// button directly under the tile was enabled. `availableVersion` was gated on
+// `state === "update-available"`, and state precedence puts in-progress and
+// failed ahead of it — so a pending update vanished from the summary exactly
+// when a run was working on it or had just failed to.
+//
+// The existing in-progress/failed tests asserted state, tone, rollback and
+// canKeepWorking, and never asserted availableVersion. That is the gap.
+describe("buildOwnerReleaseSummary — pending update vs run state", () => {
+  const PENDING = {
+    isFresh: false,
+    targetSha: "f".repeat(40),
+    targetAvailability: "resolved" as const,
+    availableMergePointLabel: "PR #4854",
+  };
+
+  it("keeps the available build visible while a run is in flight", () => {
+    for (const status of ["queued", "pending", "running", "completing"]) {
+      const s = buildOwnerReleaseSummary(
+        baseInput({ ...PENDING, latestRun: { status, reason: null, targetSha: null } }),
+        NO_LOCAL_CHANGES,
+      );
+      expect(s.state).toBe("in-progress");
+      expect(s.updatePending).toBe(true);
+      expect(s.availableVersion).toContain("PR #4854");
+      expect(s.availableVersionLabel).toBe("Installing now");
+    }
+  });
+
+  it("keeps the available build visible after a run fails", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        ...PENDING,
+        latestRun: { status: "failed", reason: null, targetSha: null },
+      }),
+      NO_LOCAL_CHANGES,
+    );
+    expect(s.state).toBe("failed");
+    expect(s.updatePending).toBe(true);
+    expect(s.availableVersion).toContain("PR #4854");
+    expect(s.availableVersionLabel).toBe("Update still pending");
+  });
+
+  it("reports no pending update when the build is genuinely fresh", () => {
+    const s = buildOwnerReleaseSummary(baseInput({ isFresh: true }), NO_LOCAL_CHANGES);
+    expect(s.updatePending).toBe(false);
+    expect(s.availableVersion).toBeNull();
+  });
+
+  it("reports no pending update when the target cannot be resolved", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        isFresh: false,
+        targetAvailability: "unavailable",
+        targetUnavailableReason: "registry-unreachable",
+      }),
+      NO_LOCAL_CHANGES,
+    );
+    expect(s.updatePending).toBe(false);
+    expect(s.availableVersion).toBeNull();
+  });
+
+  it("reports no pending update when self-upgrade is unsupported on this install", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        ...PENDING,
+        support: {
+          supported: false,
+          targetKind: "unknown",
+          reason: "install-identity-unverified",
+          message: "Automatic updates are unavailable.",
+        },
+      }),
+      NO_LOCAL_CHANGES,
+    );
+    expect(s.updatePending).toBe(false);
+    expect(s.availableVersion).toBeNull();
+  });
+
+  // The two halves of the page must never disagree: the banner in
+  // SelfUpgradeClient renders "Update available" from `!isFresh` directly, so
+  // updatePending has to track the same fact for every run status.
+  it("agrees with the freshness flag the technical banner reads, whatever the run is doing", () => {
+    for (const status of [null, "queued", "running", "failed", "skipped", "succeeded"]) {
+      const s = buildOwnerReleaseSummary(
+        baseInput({
+          ...PENDING,
+          latestRun: status ? { status, reason: null, targetSha: null } : null,
+        }),
+        NO_LOCAL_CHANGES,
+      );
+      expect(s.updatePending).toBe(true);
+    }
+  });
+});

--- a/apps/web/lib/self-upgrade/owner-summary.ts
+++ b/apps/web/lib/self-upgrade/owner-summary.ts
@@ -45,6 +45,24 @@ export interface OwnerReleaseSummary {
   currentVersion: string;
   /** Human label for the update that's ready, or null when there's nothing newer. */
   availableVersion: string | null;
+  /**
+   * Whether a newer build is genuinely waiting, independent of what the run
+   * state machine is doing about it.
+   *
+   * This is deliberately NOT derived from `state`. `state` answers "what is
+   * happening right now", and its precedence puts in-progress and failed ahead
+   * of update-available — so a pending update disappears from `state` the
+   * moment a run starts or fails, which is exactly when the operator most needs
+   * to see it. Callers deciding whether to offer an install action read this,
+   * never `state === "update-available"`.
+   */
+  updatePending: boolean;
+  /**
+   * Label for the "update" side of the version pair, phrased for the current
+   * state ("Update ready" / "Installing now" / "Update still pending"). Keeps
+   * the presenter from having to infer wording from a null.
+   */
+  availableVersionLabel: string;
   /** The single next thing (if any) the owner should do, in plain words. */
   recommendedAction: { label: string; detail: string };
   /** Can the business keep working through this? */
@@ -184,18 +202,41 @@ export function buildOwnerReleaseSummary(
     ? `${input.platformVersion.version} (${currentDetail})`
     : input.platformVersion.version;
 
+  // Is a newer build actually waiting? Read from the facts — support, target
+  // resolution, freshness — never from `state`.
+  //
+  // The bug this replaces: `availableVersion` was gated on
+  // `state === "update-available"`, so a run that was merely RUNNING or FAILED
+  // collapsed it to null, and OwnerReleaseCard rendered that null as the
+  // positive claim "You're current" in success green. On a failed upgrade the
+  // card asserted the operator was up to date directly above an enabled
+  // "Upgrade now" button. page.tsx had already patched around it for the
+  // button alone (a `state === "failed" && ... && !isFresh` special case),
+  // which left the contradiction on screen and two sources of truth in the code.
+  const updatePending =
+    input.support.supported && input.targetAvailability === "resolved" && !input.isFresh;
+
   const targetShort = shortSha(input.targetSha);
   const targetDetail = input.availableMergePointLabel ?? targetShort;
-  const availableVersion =
-    state === "update-available"
-      ? input.support.targetKind === "release-artifact" && input.targetTag
-        ? input.targetTag
-        : input.latestRunImpact?.headline
-        ? input.latestRunImpact.headline
-        : targetDetail
-          ? `Latest build (${targetDetail})`
-          : "Latest build"
-      : null;
+  const availableVersion = updatePending
+    ? input.support.targetKind === "release-artifact" && input.targetTag
+      ? input.targetTag
+      : input.latestRunImpact?.headline
+      ? input.latestRunImpact.headline
+      : targetDetail
+        ? `Latest build (${targetDetail})`
+        : "Latest build"
+    : null;
+
+  // Same value, different thing being said about it, so the operator is never
+  // left to guess why an update is listed while nothing appears to happen.
+  const availableVersionLabel = !updatePending
+    ? "Update ready"
+    : inFlight
+      ? "Installing now"
+      : failed
+        ? "Update still pending"
+        : "Update ready";
 
   // "Why nothing happened" copy for the routine no-op path (run skipped).
   // A resolved, fresh target is newer evidence than an older skipped run. Do
@@ -352,6 +393,8 @@ export function buildOwnerReleaseSummary(
     headline,
     currentVersion,
     availableVersion,
+    updatePending,
+    availableVersionLabel,
     recommendedAction,
     canKeepWorking,
     keptLocally,

--- a/docs/user-guide/operations/self-upgrade.md
+++ b/docs/user-guide/operations/self-upgrade.md
@@ -26,8 +26,14 @@ is unavailable and does not offer or queue an upgrade.
 
 ## Workflow
 
-1. Confirm the status card shows a resolved immutable update. If it says current
-   or unavailable, there is no upgrade action to trigger.
+1. Confirm the status card shows a resolved immutable update. The card reports
+   **You’re current** only when nothing newer is waiting; if it says that, or
+   says updates are unavailable on this install, there is no upgrade action to
+   trigger.
+
+   A waiting update stays named on the card while an upgrade is running
+   (**Installing now**) and after one fails (**Update still pending**), so a
+   failed or in-progress attempt never reads as being up to date.
 2. Review the pending upgrade and what it will change before triggering anything.
 3. Trigger the upgrade only inside an approved deployment window. The server
    durably admits the request and assigns its `SUR-*` run identity before queue


### PR DESCRIPTION
Reported from `/ops/self-upgrade`: *"the top of this screen says I'm current, down further, it says there is an update available."* Both halves read the same data; only the lower one told the truth.

## The defect

`availableVersion` was gated on `state === "update-available"`. State precedence runs `in-progress → failed → unavailable → up-to-date → update-available`, so the moment a run started or failed, `state` stopped being `update-available` and `availableVersion` collapsed to `null` — while `isFresh` was still false and the target still resolved.

`OwnerReleaseCard` then rendered that `null` as a **positive claim**:

```
availableVersion ?? (state === "unavailable" ? "Not available on this install" : "You're current")
```

…with `intent` falling through to `"success"` (green). Absence of a label was presented as a fact.

The banner further down (`SelfUpgradeClient`) reads `!isFresh` directly and correctly showed "Update available" / "Behind by: N merged PRs".

## It contradicted itself inside one card

`page.tsx` already knew the state machine was lying here, and patched around it **for the button alone**:

```
state === "update-available" || (state === "failed" && targetAvailability === "resolved" && !isFresh)
```

So on a failed run an enabled **Upgrade now** sat directly under a green tile reading "You're current". The workaround was applied to the action and never pushed back into the summary it contradicted — leaving two sources of truth.

Reproduced from live state: latest run `running`, last succeeded run absorbed `a650a126`, current target `d4c5f604` ⇒ `isFresh` false. Also live earlier the same day with a `failed` run.

## The fix

- `updatePending` is derived from the **facts** — `support.supported && targetAvailability === "resolved" && !isFresh` — never from the state machine. `state` answers *"what is happening"*; `updatePending` answers *"is something waiting"*.
- `availableVersion` keys off it, so a pending update stays visible through in-flight and failed runs.
- New `availableVersionLabel` (**Installing now** / **Update still pending**) carries the state, so the value can carry the identity.
- The card says "You're current" only when nothing is pending, and reserves success green for that case.
- `page.tsx`'s duplicated derivation is deleted in favour of the single source.

No new component, no new state, no new route — `owner-summary.ts` keeps sole ownership of the wording and the card stays a thin presenter.

## The coverage gap that let it ship

`owner-summary.test.ts` already exercised `in-progress` and `failed`, but asserted only `state`, `tone`, `rollback` and `canKeepWorking` — **never `availableVersion`**. The only `availableVersion === null` assertion was on the genuinely-fresh case, where it is correct.

New tests assert it for every run status, including that `updatePending` tracks the same `isFresh` the technical banner reads, so the two halves of the page cannot disagree again. Card-level tests assert "You're current" never renders while an update is pending. Confirmed failing when the derivation is reverted to the state-gated form.

## Docs

`docs/user-guide/operations/self-upgrade.md` step 1 told operators *"if it says current… there is no upgrade action to trigger"* — advice that was actively wrong under this bug. Updated to state that "You're current" appears only when nothing is waiting, and that a pending update stays named while a run is in flight or after one fails.

## Verification

- `pnpm run pregate` → **PASS** (`fix/self-upgrade-owner-card-freshness@19c0a4172cd4`, evidence `cmteqo59hsorl01mdwhvcdqik`) — includes the production build.
- Preflight: 59 guards clean (post-commit).
- `apps/web` typecheck clean; 25 owner-summary + 8 card tests green.

Related: the upgrade was failing for an unrelated reason (#4862 / BI-DDB48B04), which is what drove the card into the failed and in-progress states where this defect is visible.

Refs: BI-B99C7487

Local-CI-Evidence: cmteqo59hsorl01mdwhvcdqik

🤖 Generated with [Claude Code](https://claude.com/claude-code)