### PR TITLE
doc(workroom): retarget stale definition/instance anchors to live epic

### DIFF
--- a/docs/architecture/workroom-vocabulary-boundary.md
+++ b/docs/architecture/workroom-vocabulary-boundary.md
@@ -3,7 +3,7 @@
 **Backlog item:** `BI-C2C16582`
 **Epic:** `EP-WORK-CONVERGENCE`
 **Status:** Current
-**Definition/instance realization:** `BI-D4C110BC` under `EP-1FABA22D`
+**Definition/instance realization:** shipped in PR #4648 under `EP-WORK-CONVERGENCE`; design and plan in [the workroom definition projection spec](../superpowers/specs/2026-08-24-workroom-definition-projection.md)
 
 Founder-directed 2026-08-15: **Workroom** is the canonical name for what we claim
 and how we work. This page is the single place that says what the word means at


### PR DESCRIPTION
## What

`docs/architecture/workroom-vocabulary-boundary.md` line 6 cited `BI-D4C110BC` under `EP-1FABA22D` as the "Definition/instance realization". **Neither id exists in the live backlog**, so the Doc Anchor Existence guard (`scripts/check-doc-anchor-existence.mjs`) failed whenever the file was touched.

The anchors were also *mismatched* from the start: `EP-1FABA22D` is the Purpose-Aware Installation & Ecosystem Productivity program and `BI-D4C110BC` its work-packet/leases item — both unrelated to this page and both since removed from the live backlog.

## Fix

The definition/occurrence separation actually shipped in **PR #4648** under **`EP-WORK-CONVERGENCE`** — this page's own epic (line 4), a live named-slug epic. The citation now points at that epic and the canonical [projection spec](../superpowers/specs/2026-08-24-workroom-definition-projection.md) instead of the two dead hex anchors.

The realization BI (`BI-80BECE1E`) is itself unbacked in the live backlog, so it is referenced through its shipped PR and spec rather than re-cited (citing it would fail the same guard).

## Verification

- `node scripts/check-doc-anchor-existence.mjs` → `OK` (exit 0). The remaining anchors (`BI-0702869B`, `BI-C2C16582`) are both baselined and both exist live.

Docs-only; one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)