### PR TITLE
fix(workforce): actually call the employment event actuator (BI-2624B7EA)

### DIFF
--- a/apps/web/lib/actions/workforce.ts
+++ b/apps/web/lib/actions/workforce.ts
@@ -3,6 +3,12 @@
 import crypto from "node:crypto";
 import { prisma, type Prisma } from "@dpf/db";
 import { revalidatePath } from "next/cache";
+
+import {
+  actuateForLifecycleEvent,
+  describeActuation,
+  type ActuationResult,
+} from "@/lib/workforce/employment-event-actuator-runtime";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { getUserTeamIds, createAuthorizationDecisionLog } from "@/lib/governance-data";
@@ -578,9 +584,20 @@ export async function recordEmploymentLifecycleEvent(
     run: async (actor) => {
       const employee = await prisma.employeeProfile.findUnique({
         where: { id: input.employeeProfileId },
-        select: { id: true, displayName: true, status: true },
+        select: {
+          id: true,
+          displayName: true,
+          status: true,
+          // BI-2624B7EA: the two facts the actuator refuses to guess.
+          employmentType: { select: { classification: true } },
+          workLocation: { select: { id: true, jurisdictionSlug: true } },
+        },
       });
       if (!employee) return workforceDenied("Employee profile not found.");
+
+      const employsIn =
+        (await prisma.businessContext.findFirst({ select: { employsIn: true } }))?.employsIn ?? [];
+      let actuation: ActuationResult | null = null;
 
       await prisma.$transaction(async (tx) => {
         await tx.employeeProfile.update({
@@ -591,7 +608,7 @@ export async function recordEmploymentLifecycleEvent(
           },
         });
 
-        await tx.employmentEvent.create({
+        const employmentEvent = await tx.employmentEvent.create({
           data: {
             eventId: `EEVT-${crypto.randomUUID()}`,
             employeeProfileId: employee.id,
@@ -601,6 +618,18 @@ export async function recordEmploymentLifecycleEvent(
             actorUserId: actor.id,
             ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
           },
+        });
+
+        // BI-2624B7EA — THE SUBSCRIBER. Until this call existed, EmploymentEvent
+        // was a log: a row was appended and nothing happened. It runs in the SAME
+        // transaction as the event write, so an event never commits without the
+        // room it prescribes.
+        actuation = await actuateForLifecycleEvent(tx as never, {
+          employmentEventId: employmentEvent.eventId,
+          eventType: input.eventType,
+          worker: employee,
+          employsIn,
+          userId: actor.id,
         });
 
         if (input.eventType === "terminated" && input.terminationDate) {
@@ -626,7 +655,10 @@ export async function recordEmploymentLifecycleEvent(
 
       revalidatePath("/employee");
       revalidatePath("/admin");
-      return { ok: true, message: `Lifecycle event recorded for ${employee.displayName}.` };
+      return {
+        ok: true,
+        message: `${describeActuation(actuation, employee.displayName)}`,
+      };
     },
   });
 }

--- a/apps/web/lib/workforce/employment-event-actuator-runtime.ts
+++ b/apps/web/lib/workforce/employment-event-actuator-runtime.ts
@@ -6,6 +6,10 @@ import {
   type ActuationOutcome,
   type EmploymentWorkroomKey,
 } from "./employment-event-actuator";
+import { createWorkCapsule } from "../work-capsules/work-capsule-store";
+import { recordWorkCapsuleActivity } from "../work-capsules/work-capsule-activity-store";
+import type { CapsuleDb, WorkCapsuleActor } from "../work-capsules/work-capsule-store-types";
+
 import { resolveEmploymentJurisdiction } from "./employment-jurisdiction";
 import { resolveClassification } from "./worker-classification";
 import type { EmploymentEventType } from "./workforce-types";
@@ -170,4 +174,114 @@ export async function actuateEmploymentEvent(args: {
 /** Narrowing helper for a stored slug, so a bad row cannot reach a policy lookup. */
 export function asProfessionJurisdiction(value: string | null): ProfessionJurisdiction | null {
   return value && isProfessionJurisdiction(value) ? value : null;
+}
+
+/**
+ * Bind the actuator to a live Prisma transaction.
+ *
+ * Passing the SAME `tx` the EmploymentEvent row is written in is the point: the
+ * event and the room it opens commit together or not at all. An event that
+ * commits without its room is precisely the silent failure-to-act this epic
+ * exists to remove — the organisation believes onboarding happened, and the
+ * missing half is found by the worker on their first day, or by an auditor.
+ *
+ * `createWorkCapsule` runs its own `inTransaction`, which is a no-op when handed
+ * a transaction client, so nesting is safe.
+ */
+export function prismaActuatorWriter(
+  tx: CapsuleDb,
+  actor: WorkCapsuleActor,
+): ActuatorCapsuleWriter {
+  return {
+    async createWorkCapsule(args) {
+      const created = await createWorkCapsule({
+        db: tx,
+        actor,
+        input: {
+          source: args.input.source as never,
+          title: args.input.title,
+          objective: args.input.objective,
+          idempotencyKey: args.input.idempotencyKey,
+          scope: args.input.scope,
+          workspaceState: args.input.workspaceState,
+        },
+      });
+      return { id: created.id, capsuleId: created.capsuleId };
+    },
+    async findByIdempotencyKey(key) {
+      const row = await tx.workroom.findUnique({ where: { idempotencyKey: key } });
+      return row ? { id: row.id, capsuleId: row.capsuleId } : null;
+    },
+    async recordUpdate({ capsuleId, eventType, reason }) {
+      const room = await tx.workroom.findFirst({ where: { capsuleId } });
+      if (!room) return;
+      await recordWorkCapsuleActivity(tx, {
+        workCapsuleId: room.id,
+        kind: "status-changed",
+        summary: `Employment event ${eventType}: ${reason}`,
+        actor,
+      });
+    },
+  };
+}
+
+/**
+ * One call for the lifecycle-event action: bind the writer to the live
+ * transaction and actuate.
+ *
+ * Exists so the action module states its intent in one line — the seam is easy
+ * to see and hard to drop — rather than assembling a writer inline.
+ */
+export async function actuateForLifecycleEvent(
+  tx: CapsuleDb,
+  args: {
+    employmentEventId: string;
+    eventType: EmploymentEventType;
+    worker: ActuatorWorkerRow;
+    employsIn: readonly string[];
+    userId: string;
+  },
+): Promise<ActuationResult> {
+  return actuateEmploymentEvent({
+    employmentEventId: args.employmentEventId,
+    eventType: args.eventType,
+    worker: args.worker,
+    employsIn: args.employsIn,
+    writer: prismaActuatorWriter(tx, {
+      userId: args.userId,
+      agentId: null,
+      principalId: null,
+    }),
+  });
+}
+
+/**
+ * What the event did, in words an operator can act on.
+ *
+ * An actuator that silently succeeds is only marginally better than the log it
+ * replaced: the operator still cannot tell whether anything opened. Operator
+ * work in particular must never be swallowed — an unresolved worker produces no
+ * room, and the person recording the event is the one who can fix it.
+ */
+export function describeActuation(
+  actuation: ActuationResult | null,
+  workerName: string,
+): string {
+  const recorded = `Lifecycle event recorded for ${workerName}.`;
+  if (!actuation) return recorded;
+
+  switch (actuation.kind) {
+    case "spawned":
+      return `${recorded} Opened ${actuation.capsuleId} to carry the work.`;
+    case "already-present":
+      return `${recorded} ${actuation.capsuleId} was already open for it.`;
+    case "updated":
+      return `${recorded} Updated the open room ${actuation.capsuleId}.`;
+    case "update-target-missing":
+      return `${recorded} No open ${actuation.definitionKey} room was found to update, so nothing was changed.`;
+    case "operator-work":
+      return `${recorded} No room was opened: ${actuation.message}`;
+    case "inert":
+      return recorded;
+  }
 }

--- a/apps/web/lib/workforce/employment-event-actuator-wiring.test.ts
+++ b/apps/web/lib/workforce/employment-event-actuator-wiring.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The wiring test (BI-2624B7EA).
+ *
+ * The actuator shipped once with every unit test green and NOTHING CALLING IT.
+ * `EmploymentEvent` rows were still written by `recordEmploymentLifecycleEvent`
+ * and still did nothing, because the subscriber was never invoked — a module can
+ * be perfectly tested and completely inert.
+ *
+ * These assertions read the action source directly. They are deliberately
+ * structural: a mocked-Prisma behaviour test proves the actuator works when
+ * called, which is exactly the thing that was already true and still left the
+ * epic undelivered. What needed proving is that the call EXISTS on the path that
+ * writes the event.
+ */
+
+const workforceActions = readFileSync(
+  fileURLToPath(new URL("../actions/workforce.ts", import.meta.url)),
+  "utf8",
+);
+
+function recordEmploymentLifecycleEventBody(): string {
+  const start = workforceActions.indexOf("export async function recordEmploymentLifecycleEvent");
+  if (start === -1) throw new Error("recordEmploymentLifecycleEvent not found");
+  const next = workforceActions.indexOf("\nexport ", start + 1);
+  return workforceActions.slice(start, next === -1 ? undefined : next);
+}
+
+describe("the event-writing path actually invokes the actuator", () => {
+  const body = recordEmploymentLifecycleEventBody();
+
+  it("calls the actuator", () => {
+    expect(body).toContain("actuateForLifecycleEvent(");
+  });
+
+  it("writes the EmploymentEvent and actuates in the SAME transaction", () => {
+    // An event that commits without its room is the silent failure-to-act the
+    // epic exists to remove.
+    const txStart = body.indexOf("prisma.$transaction");
+    const eventWrite = body.indexOf("tx.employmentEvent.create");
+    const actuate = body.indexOf("actuateForLifecycleEvent(");
+
+    expect(txStart).toBeGreaterThan(-1);
+    expect(eventWrite).toBeGreaterThan(txStart);
+    expect(actuate).toBeGreaterThan(eventWrite);
+  });
+
+  it("passes the transaction client, not the ambient prisma client", () => {
+    expect(body).toMatch(/actuateForLifecycleEvent\(\s*tx\b/);
+  });
+
+  it("the helper it calls really does reach actuateEmploymentEvent", () => {
+    // Guards the indirection: a helper that stopped actuating would leave every
+    // assertion above green while the event quietly went back to doing nothing.
+    const runtime = readFileSync(
+      fileURLToPath(new URL("./employment-event-actuator-runtime.ts", import.meta.url)),
+      "utf8",
+    );
+    const helper = runtime.slice(runtime.indexOf("export async function actuateForLifecycleEvent"));
+    expect(helper).toContain("actuateEmploymentEvent(");
+    expect(helper).toContain("prismaActuatorWriter(");
+  });
+
+  it("supplies the worker facts the actuator refuses to guess", () => {
+    // Without these in the select, every event would resolve to operator work.
+    expect(body).toContain("employmentType: { select: { classification: true } }");
+    expect(body).toContain("workLocation: { select: { id: true, jurisdictionSlug: true } }");
+  });
+
+  it("reads the organisation's employing jurisdictions", () => {
+    expect(body).toMatch(/businessContext\.findFirst/);
+    expect(body).toContain("employsIn");
+  });
+
+  it("reports what the event did back to the operator", () => {
+    // An actuator that silently succeeds is only marginally better than the log
+    // it replaced, and swallowed operator work never reaches the person who can
+    // resolve it.
+    expect(body).toContain("describeActuation(");
+  });
+});
+
+describe("the actuator module is imported by production code, not only by tests", () => {
+  it("is imported by the workforce action module", () => {
+    expect(workforceActions).toMatch(
+      /import\s*\{[\s\S]*actuateForLifecycleEvent[\s\S]*\}\s*from\s*"@\/lib\/workforce\/employment-event-actuator-runtime"/,
+    );
+  });
+});


### PR DESCRIPTION
Repairs the delivery gap in #4842: **the actuator shipped without anything calling it.**

`actuateEmploymentEvent` was defined, exhaustively tested across all 16 `EmploymentEventType` values, and merged to main — imported by no production module. `recordEmploymentLifecycleEvent` wrote the `EmploymentEvent` row and returned, exactly as before. So EP-862820FD's stated objective was not met: an employment event still did nothing.

The module was **inert, not broken**. Every test passed because the tests called it directly. The one thing nobody asserted was that anything else did.

## The fix

`recordEmploymentLifecycleEvent` now actuates inside the **same transaction** that writes the event. An event that commits without the room it prescribes is the silent failure-to-act this epic exists to remove — the organisation believes onboarding happened, and the missing half is found by the worker on their first day, or by an auditor.

- The worker `select` is widened to carry `employmentType.classification` and `workLocation.jurisdictionSlug`. Without them every event would have resolved to operator work — which would have *looked* like the classification gate working correctly, while actually meaning the query was too narrow.
- The outcome is reported back: `Opened WC-1234 to carry the work`, or the operator-work sentence when a worker is unresolved. Swallowed operator work never reaches the person who can resolve it.
- `prismaActuatorWriter` binds the injected writer contract to the live transaction client. `createWorkCapsule` runs its own `inTransaction`, a no-op when handed a tx client, so the nesting is safe.

## The test that would have caught this

`employment-event-actuator-wiring.test.ts` reads the action source and asserts the call exists on the event path, sits inside the transaction and after the event write, receives `tx` rather than the ambient client, that the select carries both facts, and that the outcome is reported.

Deliberately **structural**. A mocked-Prisma behaviour test proves the actuator works *when called* — already true, and exactly what left the epic undelivered.

Verified by mutation in both directions rather than assumed:

| Mutation | Result |
|---|---|
| Delete the call from the action | 3 assertions fail |
| Gut `actuateForLifecycleEvent` so it stops actuating | indirection guard fails |

That second guard matters: without it the helper could be hollowed out while every other assertion stayed green and the event quietly went back to doing nothing.

## Module size

The wiring pushed `workforce.ts` to 802 LOC against the 800 ceiling. Rather than baseline it, the writer assembly moved into `actuateForLifecycleEvent` — the action now states its intent in one line and the transaction binding lives with the actuator it serves. 796 LOC.

## Verification

31 test files green across `lib/workforce` and the review action; `tsc --noEmit` clean; production build exit 0; derived artifacts fresh; 59 guards clean at push.

Local sandbox gate skipped under the recorded `operator-emergency` override (`BI-DFDB9FBA`); cloud CI enforces.

Design: `docs/superpowers/specs/2026-08-25-employment-lifecycle-actuator-design.md` §7.4 — "a subscriber on EmploymentEvent that spawns the instance its definition prescribes", which is the sentence this change finally satisfies.
