### PR TITLE
fix(self-upgrade): report why a release target could not be resolved

### DIFF
--- a/apps/web/lib/self-upgrade/status-target.test.ts
+++ b/apps/web/lib/self-upgrade/status-target.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadReleaseInstallContext: vi.fn(),
+  resolveReleaseUpgradeCandidate: vi.fn(),
+  resolveTargetSha: vi.fn(),
+}));
+
+vi.mock("./release-target", () => ({
+  loadReleaseInstallContext: mocks.loadReleaseInstallContext,
+  resolveReleaseUpgradeCandidate: mocks.resolveReleaseUpgradeCandidate,
+}));
+
+vi.mock("./version", () => ({ resolveTargetSha: mocks.resolveTargetSha }));
+
+import { resolveSelfUpgradeStatusTarget } from "./status-target";
+
+const SUPPORT = {
+  configuredEnabled: true,
+  supported: true,
+  enabled: true,
+  targetKind: "release-artifact",
+  reason: "enabled",
+  message: null,
+} as const;
+
+const CONFIG = { channel: "stable", hostSourceMountPath: "/host-dpf" } as never;
+
+const CONTEXT = {
+  installMode: "consumer",
+  imageTag: "v2026.08.29-x.1",
+  channelTag: "latest",
+  installPath: "D:\\DPF",
+  composeFiles: ["docker-compose.yml"],
+  ghcrOwner: "opendigitalproductfactory",
+};
+
+function call(log: (m: string) => void) {
+  return resolveSelfUpgradeStatusTarget({
+    support: SUPPORT,
+    config: CONFIG,
+    currentConfigDigest: `sha256:${"a".repeat(64)}`,
+    log,
+  });
+}
+
+describe("resolveSelfUpgradeStatusTarget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadReleaseInstallContext.mockResolvedValue(CONTEXT);
+  });
+
+  it("reports the typed reason when the registry read fails", async () => {
+    mocks.resolveReleaseUpgradeCandidate.mockResolvedValue({
+      kind: "no-published-target",
+      reason: "registry-auth-invalid",
+    });
+    const log = vi.fn();
+
+    const result = await call(log);
+
+    expect(result.availability).toBe("unavailable");
+    expect(result.unavailableReason).toBe("registry-auth-invalid");
+    expect(log).toHaveBeenCalledWith("release-target-unavailable: registry-auth-invalid");
+  });
+
+  it("reports a thrown fault instead of silently collapsing it", async () => {
+    // The regression: a throw became a bare null, every distinct cause turned
+    // into "registry-unavailable", and nothing was logged — so a live
+    // intermittent failure was undiagnosable from outside the process.
+    mocks.resolveReleaseUpgradeCandidate.mockRejectedValue(new Error("socket hang up"));
+    const log = vi.fn();
+
+    const result = await call(log);
+
+    expect(result.availability).toBe("unavailable");
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("release-target-resolution-threw: socket hang up"),
+    );
+  });
+
+  it("reports an unresolved install context rather than returning a bare unavailable", async () => {
+    mocks.loadReleaseInstallContext.mockResolvedValue(null);
+    const log = vi.fn();
+
+    const result = await call(log);
+
+    expect(result.availability).toBe("unavailable");
+    expect(log).toHaveBeenCalledWith("release-install-context-unresolved");
+  });
+
+  it("stays silent and resolves when a target is available", async () => {
+    mocks.resolveReleaseUpgradeCandidate.mockResolvedValue({
+      kind: "target",
+      tag: "v2026.08.30-owner-release-projection.1",
+      sourceSha: "f13fcf1c568425d24e9b6dcbf44e65668a39b420",
+    });
+    const log = vi.fn();
+
+    const result = await call(log);
+
+    expect(result).toMatchObject({
+      availability: "resolved",
+      targetSha: "f13fcf1c568425d24e9b6dcbf44e65668a39b420",
+      targetTag: "v2026.08.30-owner-release-projection.1",
+      unavailableReason: null,
+      releaseFreshness: false,
+    });
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("marks an up-to-date install as fresh, still without logging", async () => {
+    mocks.resolveReleaseUpgradeCandidate.mockResolvedValue({
+      kind: "up-to-date",
+      tag: "v2026.08.29-x.1",
+      sourceSha: "b".repeat(40),
+    });
+    const log = vi.fn();
+
+    const result = await call(log);
+
+    expect(result.availability).toBe("resolved");
+    expect(result.releaseFreshness).toBe(true);
+    expect(log).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/self-upgrade/status-target.ts
+++ b/apps/web/lib/self-upgrade/status-target.ts
@@ -1,4 +1,5 @@
 import type { SelfUpgradeConfig } from "./config";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { loadReleaseInstallContext, resolveReleaseUpgradeCandidate } from "./release-target";
 import type { SelfUpgradeSupport } from "./support";
 import { resolveTargetSha } from "./version";
@@ -23,7 +24,16 @@ export async function resolveSelfUpgradeStatusTarget(input: {
   support: SelfUpgradeSupport;
   config: SelfUpgradeConfig;
   currentConfigDigest: string | null;
+  /**
+   * Sink for the reason a target could not be resolved. Injected rather than
+   * calling `console` directly so a test can assert the reason is reported at
+   * all — the defect being fixed is silence, so silence has to be testable.
+   */
+  log?: (message: string) => void;
 }): Promise<SelfUpgradeStatusTarget> {
+  // Defaulted here, not at the call sites: the point is that every caller emits
+  // the reason without having to remember to ask for it.
+  const log = input.log ?? ((message: string) => console.warn(`[self-upgrade] ${message}`));
   if (!input.support.supported) return UNAVAILABLE;
   if (input.support.targetKind === "git-source") {
     const targetSha = await resolveTargetSha(input.config.channel, input.config);
@@ -41,16 +51,31 @@ export async function resolveSelfUpgradeStatusTarget(input: {
       process.env.DPF_SELF_UPGRADE_HOST_SOURCE_MOUNT ??
       "/host-dpf",
   });
-  if (!context) return UNAVAILABLE;
+  if (!context) {
+    log("release-install-context-unresolved");
+    return UNAVAILABLE;
+  }
+  // A resolution failure has to leave a trace. `readRegistryReleaseCandidate`
+  // returns a typed {ok:false, reason}, but anything that THREW became a bare
+  // null here and every distinct cause collapsed into "registry-unavailable"
+  // with nothing logged anywhere. An install then reports "no target" while a
+  // newer release is published, and the reason is unrecoverable from outside
+  // the process — a live intermittent fault (SUR-6B312E24) could not be
+  // diagnosed at all, and the absence of any signal led to a confidently wrong
+  // root cause being recorded against working code. BI-52C6FE5A.
   const target = await resolveReleaseUpgradeCandidate({
     context,
     currentConfigDigest: input.currentConfigDigest,
-  }).catch(() => null);
+  }).catch((error: unknown) => {
+    log(
+      `release-target-resolution-threw: ${getErrorMessage(error)}`,
+    );
+    return null;
+  });
   if (!target || target.kind === "no-published-target") {
-    return {
-      ...UNAVAILABLE,
-      unavailableReason: target?.reason ?? "registry-unavailable",
-    };
+    const unavailableReason = target?.reason ?? "registry-unavailable";
+    log(`release-target-unavailable: ${unavailableReason}`);
+    return { ...UNAVAILABLE, unavailableReason };
   }
   return {
     targetSha: target.sourceSha,


### PR DESCRIPTION
## What

`resolveSelfUpgradeStatusTarget` could fail to resolve a release target and say nothing at all — no log line, no distinguishable reason. This makes it report the reason instead.

## Why

An operator reported self-upgrade failing. `/ops/self-upgrade` showed `Available: unknown`, `Target: unknown`, while GHCR `:latest` had genuinely advanced to `v2026.08.30-owner-release-projection.1` (`f13fcf1c`). The install could not see it.

Nothing in the process recorded why. `readRegistryReleaseCandidate` returns a typed `{ok: false, reason}` — but the call site collapsed everything into a bare value and logged nothing:

```js
const target = await resolveReleaseUpgradeCandidate({ … }).catch(() => null);
if (!target || target.kind === "no-published-target") {
  return { ...UNAVAILABLE, unavailableReason: target?.reason ?? "registry-unavailable" };
}
```

Anything that **threw** became `null`, and every distinct cause turned into `"registry-unavailable"`. The `unavailableReason` that did survive was only ever rendered inside a collapsed details panel.

Two concrete costs, both paid on a live install:

1. **The fault was intermittent, so silence made it undiagnosable.** Same install, same inputs, no restart between: resolution failed at 14:20 (stranding run `SUR-6B312E24` with `admission-target-unavailable`), failed again at 01:35, and succeeded at 01:57. With no log line there is no way to correlate the failures or tell which hop broke.

2. **The absence of any signal produced a confidently wrong diagnosis.** Working backwards from silence, I concluded the cause was `registry-release.ts` refusing GHCR's blob redirect, and was ready to rewrite it. It was wrong — `blob()` already issues `redirect: "manual"`, validates the `Location` against a `pkg-containers.githubusercontent.com` allowlist, and follows it. Replaying the real sequence in the running portal succeeds every time (`307` → allowlist PASS → `200`). A single log line would have prevented the wrong conclusion; that is the failure mode this PR closes.

## Changes

`apps/web/lib/self-upgrade/status-target.ts` — report the reason on all three unavailable paths:

- `release-install-context-unresolved`
- `release-target-resolution-threw: <message>` (previously swallowed entirely)
- `release-target-unavailable: <typed reason>`

The sink is an injected `log?` defaulting to `console.warn("[self-upgrade] …")`. Injected rather than calling `console` directly because the defect **is** silence — silence has to be assertable in a test. Defaulted inside the function rather than at call sites so every caller emits it without having to remember to ask.

No behavioural change to what is returned. Resolution logic, ordering and the `SelfUpgradeStatusTarget` shape are untouched; this only adds observability.

## Verification

```
pnpm --filter web exec vitest run lib/self-upgrade/
  Test Files  57 passed (57)
       Tests  753 passed (753)

pnpm --filter web typecheck    # clean
```

New `status-target.test.ts` covers the typed reason, a thrown fault, an unresolved install context, and both success paths — asserting the success paths log **nothing**, so this cannot degrade into noise on every page load.

Confirmed to fail without the fix: reverting the logging drops it to **3 failed / 2 passed**. A guard that cannot fail is not a guard.

## Scope

Deliberately only the observability gap. The other defects found in the same investigation are already fixed on main and are not touched here:

- dispatch discarding an admitted target — fixed by `?? persistedReleaseTarget(existing)`
- the watchdog asserting a dropped queue event on `dispatchAttemptCount: 0` — message no longer present
- "You're current" as a positive claim — addressed in `OwnerReleaseCard`

The remaining work — identifying the intermittent resolution fault itself — is tracked on BI-52C6FE5A and depends on this change landing first, because it needs the logs.

## Change classification

- [x] **Source-only change** (isolated unit logic; no route, schema, or UX surface)
- [x] Unit tests for affected files
- [x] Typecheck clean
- [x] Guard preflight run

Local-CI-Override: operator-emergency: operator directed skipping local gates on this host — the single-slot local-CI pool is not usable. Unit tests, typecheck and the guard preflight were run in the worktree; protected GitHub checks and the merge queue still apply.

## Governance note

The operator waived the initiative-readiness research and plan receipts for this item, as for the two earlier items in this session. Root causes for the unreachable reviewer lane are recorded on BI-F0715C9C.

Refs: BI-52C6FE5A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
