### PR TITLE
perf(delivery): gate on the tests the diff can reach, and let capacity follow the installation

### DIFF
--- a/apps/web/lib/nonprod/environment-lease-pool-policy.ts
+++ b/apps/web/lib/nonprod/environment-lease-pool-policy.ts
@@ -9,6 +9,7 @@ import {
   type LocalCiHostPressure,
   type ResolvedLocalCiPoolPolicy,
 } from "./local-ci-pool-policy";
+import { readLocalCiInstallationProfile } from "./local-ci-capacity-profile";
 import {
   resolveHostResourceAdmission,
   type ActiveHeavyReservation,
@@ -102,6 +103,14 @@ export async function resolveNonprodPoolPolicy(input: {
   const configValue = input.platformConfig
     ? await loadLocalCiPoolConfig({ platformConfig: input.platformConfig })
     : null;
+  // Consulted only when no valid config row exists (BI-D908DA0A). A read failure
+  // is not a reason to guess: an unreadable declaration resolves to null and the
+  // policy keeps the compatibility singleton.
+  const installation = input.platformConfig
+    ? await readLocalCiInstallationProfile({
+      platformConfig: input.platformConfig,
+    }).catch(() => null)
+    : null;
   const clientPressure = input.hostPressure ?? {};
   const preliminary = resolveLocalCiPoolPolicy({
     configValue,
@@ -110,6 +119,7 @@ export async function resolveNonprodPoolPolicy(input: {
     reserveAdmissionHeadroom: input.reserveAdmissionHeadroom,
     env: process.env,
     now: input.now,
+    installation,
   });
   // A missing/malformed config keeps the compatibility singleton and has no
   // broker contract to enforce. A valid configured singleton still requires
@@ -141,5 +151,6 @@ export async function resolveNonprodPoolPolicy(input: {
     reserveAdmissionHeadroom: input.reserveAdmissionHeadroom,
     env: process.env,
     now: input.now,
+    installation,
   });
 }

--- a/apps/web/lib/nonprod/environment-lease.test.ts
+++ b/apps/web/lib/nonprod/environment-lease.test.ts
@@ -584,7 +584,7 @@ describe("durable nonproduction admission", () => {
 
     const hostPressure = {
       observedAt: NOW.toISOString(),
-      availableMemoryBytes: 14 * gib,
+      availableMemoryBytes: 8 * gib + localCiSlotResources.hostStagePolicy.admissionReserveBytes - 1, // one byte short of a stage above the floor (BI-E58B57EC)
       sustainedCpuPercent: 20,
       diskFreeBytes: 500 * gib,
       dockerHealthy: true,

--- a/apps/web/lib/nonprod/local-ci-capacity-profile.test.ts
+++ b/apps/web/lib/nonprod/local-ci-capacity-profile.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from "vitest";
+
+import { readLocalCiInstallationProfile } from "./local-ci-capacity-profile";
+import {
+  deriveLocalCiCapacityFromInstallation,
+  derivedLocalCiPoolConfig,
+  localCiHostStageAdmissionReserveBytes,
+  localCiHostStageHeadroomCapacity,
+  localCiPoolConfigError,
+  resolveLocalCiPoolPolicy,
+} from "./local-ci-pool-policy";
+import localCiSlotResources from "./local-ci-slot-resources.json" with {
+  type: "json",
+};
+
+const GiB = 1024 ** 3;
+
+/** This host, measured 2026-08-29. */
+const measuredHost = {
+  dockerAvailableMemoryBytes: 21707272 * 1024,
+  availableMemoryBytes: Math.round(16.9 * GiB),
+  builderMemoryUsageBytes: [0, 0],
+  sustainedCpuPercent: 8.6,
+  diskFreeBytes: 400 * GiB,
+  observedAt: new Date().toISOString(),
+  dockerHealthy: true,
+  convergenceActive: false,
+  fencesHealthy: true,
+  evidenceIsolationHealthy: true,
+};
+
+const operatorRow = {
+  version: 1,
+  requestedCapacity: 1,
+  ceilings: {
+    minAvailableMemoryBytes: 4 * GiB,
+    maxSustainedCpuPercent: 85,
+    minDiskFreeBytes: 50 * GiB,
+  },
+  rollback: {
+    maxServiceDurationRegressionPercent: 15,
+    maxInfrastructureFailureRatePercent: 5,
+    evidenceMismatchTolerance: 0,
+  },
+};
+
+describe("deriveLocalCiCapacityFromInstallation", () => {
+  it("gives a development platform-build installation the second slot", () => {
+    expect(
+      deriveLocalCiCapacityFromInstallation({
+        environmentClass: "development",
+        primaryPurpose: "evolve-dpf",
+      }),
+    ).toEqual({
+      requestedCapacity: 2,
+      reason: "installation-development-platform-build",
+    });
+  });
+
+  it("counts evolve-dpf as a secondary purpose", () => {
+    expect(
+      deriveLocalCiCapacityFromInstallation({
+        environmentClass: "development",
+        primaryPurpose: "operate-organization",
+        secondaryPurposes: ["evolve-dpf"],
+      })?.requestedCapacity,
+    ).toBe(2);
+  });
+
+  it("keeps every production installation at one slot", () => {
+    const derived = deriveLocalCiCapacityFromInstallation({
+      environmentClass: "production",
+      primaryPurpose: "evolve-dpf",
+    });
+    expect(derived?.requestedCapacity).toBe(1);
+    expect(derived?.reason).toBe("installation-environment-class-production");
+  });
+
+  it("keeps a development installation that runs a business at one slot", () => {
+    const derived = deriveLocalCiCapacityFromInstallation({
+      environmentClass: "development",
+      primaryPurpose: "operate-organization",
+    });
+    expect(derived?.requestedCapacity).toBe(1);
+    expect(derived?.reason).toBe("installation-purpose-operate-organization");
+  });
+
+  it("declines to decide for an undeclared installation", () => {
+    expect(deriveLocalCiCapacityFromInstallation(null)).toBeNull();
+    expect(deriveLocalCiCapacityFromInstallation(undefined)).toBeNull();
+  });
+});
+
+describe("derivedLocalCiPoolConfig", () => {
+  it("produces a config the operator-row validator accepts", () => {
+    // A derived config must never be looser than a row an operator is allowed
+    // to write, so it has to survive the same validator.
+    expect(localCiPoolConfigError(derivedLocalCiPoolConfig(2))).toBeNull();
+    expect(localCiPoolConfigError(derivedLocalCiPoolConfig(1))).toBeNull();
+  });
+});
+
+describe("localCiHostStageAdmissionReserveBytes", () => {
+  it("reserves the calibrated figure, not the hard ceiling", () => {
+    expect(
+      localCiHostStageAdmissionReserveBytes({
+        hardCeilingBytes: localCiSlotResources.hostStagePolicy.memoryBytes,
+        calibratedReserveBytes:
+          localCiSlotResources.hostStagePolicy.admissionReserveBytes,
+      }),
+    ).toBe(6 * GiB);
+  });
+
+  it("falls back to the ceiling when calibration is missing or invalid", () => {
+    for (const calibratedReserveBytes of [0, -1, Number.NaN]) {
+      expect(
+        localCiHostStageAdmissionReserveBytes({
+          hardCeilingBytes: 8 * GiB,
+          calibratedReserveBytes,
+        }),
+      ).toBe(8 * GiB);
+    }
+  });
+
+  it("never reserves more than the hard ceiling", () => {
+    expect(
+      localCiHostStageAdmissionReserveBytes({
+        hardCeilingBytes: 8 * GiB,
+        calibratedReserveBytes: 99 * GiB,
+      }),
+    ).toBe(8 * GiB);
+  });
+
+  it("admits two host stages on the measured host, where 8 GiB admitted one", () => {
+    const shared = {
+      availableMemoryBytes: Math.round(16.9 * GiB),
+      minAvailableMemoryBytes: 4 * GiB,
+      manifestCapacity: 2,
+    };
+    expect(
+      localCiHostStageHeadroomCapacity({
+        ...shared,
+        hostStageMemoryBytes: 8 * GiB,
+      }),
+    ).toBe(1);
+    expect(
+      localCiHostStageHeadroomCapacity({
+        ...shared,
+        hostStageMemoryBytes: 6 * GiB,
+      }),
+    ).toBe(2);
+  });
+});
+
+describe("resolveLocalCiPoolPolicy with a derived installation profile", () => {
+  const resolve = (installation: unknown, configValue: unknown = null) =>
+    resolveLocalCiPoolPolicy({
+      configValue,
+      host: measuredHost,
+      manifestSlotCount: 2,
+      reserveAdmissionHeadroom: true,
+      installation: installation as never,
+    });
+
+  it("admits two slots on a development platform-build host with no config row", () => {
+    const policy = resolve({
+      environmentClass: "development",
+      primaryPurpose: "evolve-dpf",
+    });
+    expect(policy.effectiveCapacity).toBe(2);
+    expect(policy.source).toBe("installation-profile");
+    expect(policy.rollbackReason).toBeNull();
+    expect(policy.slotKeys).toEqual(["slot-0", "slot-1"]);
+  });
+
+  it("keeps a consumer installation at one slot and says why", () => {
+    const policy = resolve({
+      environmentClass: "production",
+      primaryPurpose: "operate-organization",
+    });
+    expect(policy.effectiveCapacity).toBe(1);
+    expect(policy.source).toBe("installation-profile");
+    expect(policy.rollbackReason).toBe(
+      "installation-environment-class-production",
+    );
+  });
+
+  it("keeps the compatibility singleton when nothing is declared", () => {
+    const policy = resolve(null);
+    expect(policy.effectiveCapacity).toBe(1);
+    expect(policy.source).toBe("default");
+    expect(policy.rollbackReason).toBe("config-absent");
+  });
+
+  it("lets an explicit operator row beat the derived default", () => {
+    const policy = resolve(
+      { environmentClass: "development", primaryPurpose: "evolve-dpf" },
+      operatorRow,
+    );
+    expect(policy.effectiveCapacity).toBe(1);
+    expect(policy.source).toBe("platform-config");
+    expect(policy.rollbackReason).toBe("requested-singleton");
+  });
+
+  it("clamps a derived capacity down to one when the host carries only one stage", () => {
+    // floor((12 - 4) / 6) === 1
+    const policy = resolveLocalCiPoolPolicy({
+      configValue: null,
+      host: { ...measuredHost, availableMemoryBytes: 12 * GiB },
+      manifestSlotCount: 2,
+      reserveAdmissionHeadroom: true,
+      installation: {
+        environmentClass: "development",
+        primaryPurpose: "evolve-dpf",
+      },
+    });
+    expect(policy.effectiveCapacity).toBe(1);
+    expect(policy.rollbackReason).toBe("host-stage-capacity-one");
+  });
+
+  it("closes admission entirely when the host carries no stage at all", () => {
+    // floor((6 - 4) / 6) === 0. Zero headroom shuts the gate rather than
+    // degrading to one, which is the documented host-pressure behaviour.
+    const policy = resolveLocalCiPoolPolicy({
+      configValue: null,
+      host: { ...measuredHost, availableMemoryBytes: 6 * GiB },
+      manifestSlotCount: 2,
+      reserveAdmissionHeadroom: true,
+      installation: {
+        environmentClass: "development",
+        primaryPurpose: "evolve-dpf",
+      },
+    });
+    expect(policy.effectiveCapacity).toBe(0);
+    expect(policy.rollbackReason).toBe("host-stage-headroom-low");
+  });
+
+  it("still refuses to admit on an unsafe host", () => {
+    const policy = resolveLocalCiPoolPolicy({
+      configValue: null,
+      host: { ...measuredHost, dockerHealthy: false },
+      manifestSlotCount: 2,
+      reserveAdmissionHeadroom: true,
+      installation: {
+        environmentClass: "development",
+        primaryPurpose: "evolve-dpf",
+      },
+    });
+    expect(policy.effectiveCapacity).toBe(0);
+    expect(policy.rollbackReason).toBe("docker-unhealthy");
+  });
+});
+
+describe("readLocalCiInstallationProfile", () => {
+  const reader = (rows: Record<string, unknown>) => ({
+    findUnique: async ({ where }: { where: { key: string } }) =>
+      where.key in rows ? { value: rows[where.key] } : null,
+  });
+
+  const declared = {
+    "installation.environment-class.v1": {
+      schemaVersion: 1,
+      environmentClass: "development",
+      declaredAt: "2026-08-24T00:54:48.215Z",
+    },
+    // Mirrors the live row on this installation, read 2026-08-29.
+    "installation.operating-intent.v1": {
+      schemaVersion: 1,
+      primaryPurpose: "evolve-dpf",
+      secondaryPurposes: [],
+      relationshipIntents: [],
+      confidence: "high",
+      confirmation: {
+        status: "confirmed",
+        confirmedAt: "2026-08-24T00:54:48.215Z",
+        confirmedByPrincipalId: "PRN-e0056320-5341-49a8-acfe-3be6eddb6c54",
+      },
+      evidence: [
+        {
+          claim: "The operator declared this installation: evolve-dpf in development.",
+          source: "human",
+          observedAt: "2026-08-24T00:54:48.215Z",
+        },
+      ],
+    },
+  };
+
+  it("reads a fully declared installation", async () => {
+    const profile = await readLocalCiInstallationProfile({
+      platformConfig: reader(declared) as never,
+    });
+    expect(profile?.environmentClass).toBe("development");
+    expect(profile?.primaryPurpose).toBe("evolve-dpf");
+  });
+
+  it("returns null when either declaration is absent", async () => {
+    for (const key of Object.keys(declared)) {
+      const partial = { ...declared };
+      delete (partial as Record<string, unknown>)[key];
+      expect(
+        await readLocalCiInstallationProfile({
+          platformConfig: reader(partial) as never,
+        }),
+      ).toBeNull();
+    }
+  });
+
+  it("returns null on a malformed declaration rather than guessing", async () => {
+    expect(
+      await readLocalCiInstallationProfile({
+        platformConfig: reader({
+          ...declared,
+          "installation.environment-class.v1": { environmentClass: "staging" },
+        }) as never,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/nonprod/local-ci-capacity-profile.ts
+++ b/apps/web/lib/nonprod/local-ci-capacity-profile.ts
@@ -1,0 +1,62 @@
+import {
+  isInstallationEnvironmentClass,
+  parseOperatingIntent,
+} from "@dpf/db/installation-operating-intent";
+import { ENVIRONMENT_CLASS_CONFIG_KEY } from "@/lib/install/environment-class-contract";
+import { INSTALLATION_OPERATING_INTENT_KEY } from "@/lib/installation-journey/operating-intent";
+import { isRecord } from "../shared/is-record.mjs";
+import type { LocalCiInstallationProfile } from "./local-ci-pool-policy";
+
+/**
+ * Reads what this installation has declared itself to be, for the local-CI
+ * capacity derivation in `local-ci-pool-policy` (BI-D908DA0A).
+ *
+ * The derivation itself lives in the policy module, which deliberately keeps a
+ * runtime import graph of relative `.mjs`/`.json` only so the raw-Node script
+ * tests can load it. This module is the IO edge: it owns the `@dpf/db` parsers
+ * and the path aliases, and nothing in the policy depends on it.
+ *
+ * Both keys are written by paths that already exist — the environment class by
+ * the installer or the portal identity panel, the operating intent by the
+ * identity declaration action. Neither is invented here.
+ */
+type PlatformConfigReader = {
+  findUnique: (args: {
+    where: { key: string };
+    select: { value: true };
+  }) => Promise<{ value: unknown } | null>;
+};
+
+/**
+ * Returns null when either declaration is missing or unreadable, so an
+ * installation that has not said what it is keeps the compatibility singleton
+ * rather than inheriting a guess.
+ */
+export async function readLocalCiInstallationProfile(input: {
+  platformConfig: PlatformConfigReader;
+}): Promise<LocalCiInstallationProfile | null> {
+  const [environmentRow, intentRow] = await Promise.all([
+    input.platformConfig.findUnique({
+      where: { key: ENVIRONMENT_CLASS_CONFIG_KEY },
+      select: { value: true },
+    }),
+    input.platformConfig.findUnique({
+      where: { key: INSTALLATION_OPERATING_INTENT_KEY },
+      select: { value: true },
+    }),
+  ]);
+
+  const environmentClass = isRecord(environmentRow?.value)
+    ? environmentRow.value["environmentClass"]
+    : null;
+  if (!isInstallationEnvironmentClass(environmentClass)) return null;
+
+  const intent = parseOperatingIntent(intentRow?.value);
+  if (!intent) return null;
+
+  return {
+    environmentClass,
+    primaryPurpose: intent.primaryPurpose,
+    secondaryPurposes: intent.secondaryPurposes,
+  };
+}

--- a/apps/web/lib/nonprod/local-ci-pool-policy.ts
+++ b/apps/web/lib/nonprod/local-ci-pool-policy.ts
@@ -2,6 +2,13 @@ import pilotGuardrails from "./local-ci-pilot-guardrails.json" with {
   type: "json",
 };
 import { isRecord as isRecordRuntime } from "../shared/is-record.mjs";
+// Type-only: erased at compile time, so this module keeps a runtime import
+// graph of relative .mjs/.json alone and stays loadable by the raw-Node script
+// tests in scripts/local-ci-pool-policy.test.mjs.
+import type {
+  InstallationEnvironmentClass,
+  InstallationOperatingPurpose,
+} from "@dpf/db/installation-operating-intent";
 import localCiSlotResources from "./local-ci-slot-resources.json" with {
   type: "json",
 };
@@ -14,6 +21,10 @@ export const LOCAL_CI_MAX_CAPACITY = 2;
 export type LocalCiPoolPolicySource =
   | "default"
   | "platform-config"
+  // Capacity derived from the installation's own declared environment class and
+  // operating intent when no explicit config row exists (BI-D908DA0A). Ranks
+  // below `platform-config` so an operator's row always wins.
+  | "installation-profile"
   | "test-env"
   | "break-glass-env";
 
@@ -56,6 +67,103 @@ export type ResolvedLocalCiPoolPolicy = {
   rollbackReason: string | null;
   config: LocalCiPoolConfig | null;
 };
+
+/**
+ * Capacity derived from what the installation declares itself to be
+ * (BI-D908DA0A).
+ *
+ * The pool shipped with a contraction path and no activation path: the only
+ * writer of `local_ci.sandbox_pool` is the circuit breaker, which moves capacity
+ * from 2 down to 1. Nothing ever created the row, so every installation ran at
+ * the compatibility singleton — measured 2026-08-29 as a p90 queue wait of
+ * 1053s at 45% utilisation. Adding a "seed the row" switch would keep the
+ * defect: a consumer never finds it, and a development host must hand-author
+ * JSON to get capacity its hardware already supports.
+ *
+ * Capacity is a property of THIS installation, and the installation already
+ * declares the two facts that decide it. A `development` install whose declared
+ * job is `evolve-dpf` runs many gates a day; everything else — every consumer,
+ * every production install, and anything undeclared — keeps the singleton.
+ * `UNDECLARED_ENVIRONMENT_CLASS` is `production`, so silence resolves to the
+ * conservative answer.
+ *
+ * This decides only what to REQUEST. Host headroom, the pilot guardrails and the
+ * circuit breaker all still clamp it downstream and can only reduce it.
+ */
+export const LOCAL_CI_DEVELOPMENT_PURPOSES: readonly InstallationOperatingPurpose[] =
+  Object.freeze(["evolve-dpf"]);
+
+export type LocalCiInstallationProfile = {
+  environmentClass: InstallationEnvironmentClass;
+  primaryPurpose: InstallationOperatingPurpose;
+  secondaryPurposes?: readonly InstallationOperatingPurpose[];
+};
+
+export type DerivedLocalCiCapacity = {
+  requestedCapacity: 1 | 2;
+  /** Why this capacity was chosen. Surfaced to the operator, never swallowed. */
+  reason: string;
+};
+
+/**
+ * Returns null when the installation has not declared enough to decide, so the
+ * caller keeps the compatibility singleton rather than inventing a default from
+ * silence.
+ */
+export function deriveLocalCiCapacityFromInstallation(
+  profile: LocalCiInstallationProfile | null | undefined,
+): DerivedLocalCiCapacity | null {
+  if (!profile) return null;
+  if (profile.environmentClass !== "development") {
+    return {
+      requestedCapacity: 1,
+      reason: `installation-environment-class-${profile.environmentClass}`,
+    };
+  }
+  const purposes = [
+    profile.primaryPurpose,
+    ...(profile.secondaryPurposes ?? []),
+  ];
+  if (!purposes.some((p) => LOCAL_CI_DEVELOPMENT_PURPOSES.includes(p))) {
+    return {
+      requestedCapacity: 1,
+      reason: `installation-purpose-${profile.primaryPurpose}`,
+    };
+  }
+  return {
+    requestedCapacity: 2,
+    reason: "installation-development-platform-build",
+  };
+}
+
+/**
+ * The config a derived capacity runs under.
+ *
+ * An explicit row supplies its own ceilings and rollback thresholds. A derived
+ * capacity has none, so it borrows the pilot guardrails — the same maxima
+ * `localCiPoolConfigError` enforces on a hand-authored row, so a derived config
+ * can never be looser than one an operator is allowed to write.
+ */
+export function derivedLocalCiPoolConfig(
+  requestedCapacity: 1 | 2,
+): LocalCiPoolConfig {
+  return {
+    version: 1,
+    requestedCapacity,
+    ceilings: {
+      minAvailableMemoryBytes: 4 * 1024 ** 3,
+      maxSustainedCpuPercent: 85,
+      minDiskFreeBytes: 50 * 1024 ** 3,
+    },
+    rollback: {
+      maxServiceDurationRegressionPercent:
+        pilotGuardrails.maximumMedianServiceDurationRegressionPercent,
+      maxInfrastructureFailureRatePercent:
+        pilotGuardrails.maximumInfrastructureFailureRatePercent,
+      evidenceMismatchTolerance: 0,
+    },
+  };
+}
 
 export function localCiBuildHeadroomCapacity(input: {
   dockerAvailableMemoryBytes: number;
@@ -114,6 +222,31 @@ export function localCiBuilderAdmissionReserveBytes(input: {
     return input.hardCeilingBytes;
   }
   return Math.min(input.hardCeilingBytes, input.calibratedReserveBytes);
+}
+
+/**
+ * Host-stage admission reserve, calibrated the way the builder's already was
+ * (BI-E58B57EC).
+ *
+ * `hostStagePolicy.memoryBytes` was a flat 8 GiB with no calibration block,
+ * while the builder's had been measured down from a 16 GiB ceiling to a 10 GiB
+ * reserve against an 8 GiB observed high-water. Measured 2026-08-29: peak
+ * combined node working set on the Windows host during the heaviest host-side
+ * stage was 2.27 GiB over idle baseline — a 3.5x over-reservation.
+ *
+ * That single uncalibrated number was the whole reason a second slot could not
+ * admit on a 63.7 GiB host: `floor((16.9 - 4) / 8)` is 1.
+ *
+ * Same shape as {@link localCiBuilderAdmissionReserveBytes}: the ceiling stays
+ * the hard runtime limit, admission reserves the calibrated figure, and missing
+ * or invalid calibration falls back to the ceiling so incomplete evidence can
+ * never make admission looser.
+ */
+export function localCiHostStageAdmissionReserveBytes(input: {
+  hardCeilingBytes: number;
+  calibratedReserveBytes: number;
+}): number {
+  return localCiBuilderAdmissionReserveBytes(input);
 }
 
 /**
@@ -338,24 +471,49 @@ export function resolveLocalCiPoolPolicy(input: {
   reserveAdmissionHeadroom?: boolean;
   env?: PolicyEnv;
   now?: Date;
+  /**
+   * What this installation has declared itself to be. Consulted only when no
+   * valid config row exists, so an operator's explicit row always wins.
+   */
+  installation?: LocalCiInstallationProfile | null;
 }): ResolvedLocalCiPoolPolicy {
   const manifestCapacity = Number.isFinite(input.manifestSlotCount)
     && input.manifestSlotCount >= LOCAL_CI_MIN_CAPACITY
     ? Math.min(LOCAL_CI_MAX_CAPACITY, Math.floor(input.manifestSlotCount))
     : LOCAL_CI_MIN_CAPACITY;
   const configError = localCiPoolConfigError(input.configValue);
-  if (configError) {
+
+  // No usable row. Before falling back to the compatibility singleton, ask what
+  // the installation says it is (BI-D908DA0A). A development install whose
+  // declared job is evolving the platform gets the capacity its host can carry;
+  // a consumer or production install, or one that has not declared itself, keeps
+  // the singleton. Host headroom still clamps whatever comes back.
+  const derived = configError
+    ? deriveLocalCiCapacityFromInstallation(input.installation)
+    : null;
+  if (configError && !derived) {
     return singleton({
       source: "default",
       manifestCapacity,
       reason: configError,
     });
   }
+  if (configError && derived && derived.requestedCapacity === 1) {
+    return singleton({
+      source: "installation-profile",
+      requestedCapacity: 1,
+      manifestCapacity,
+      reason: derived.reason,
+    });
+  }
 
-  const config = normalizeConfig(input.configValue);
+  const config = derived
+    ? normalizeConfig(derivedLocalCiPoolConfig(derived.requestedCapacity))
+    : normalizeConfig(input.configValue);
   const override = authorizedCapacityOverride(input.env);
   const requestedCapacity = override?.capacity ?? config.requestedCapacity;
-  const source: LocalCiPoolPolicySource = override?.source ?? "platform-config";
+  const source: LocalCiPoolPolicySource = override?.source
+    ?? (derived ? "installation-profile" : "platform-config");
 
   const rollbackReason = hostRollbackReason(
     input.host,
@@ -398,7 +556,11 @@ export function resolveLocalCiPoolPolicy(input: {
     const hostStageCapacity = localCiHostStageHeadroomCapacity({
       availableMemoryBytes: input.host.availableMemoryBytes ?? Number.NaN,
       minAvailableMemoryBytes: config.ceilings.minAvailableMemoryBytes,
-      hostStageMemoryBytes: localCiSlotResources.hostStagePolicy.memoryBytes,
+      hostStageMemoryBytes: localCiHostStageAdmissionReserveBytes({
+        hardCeilingBytes: localCiSlotResources.hostStagePolicy.memoryBytes,
+        calibratedReserveBytes:
+          localCiSlotResources.hostStagePolicy.admissionReserveBytes,
+      }),
       manifestCapacity,
     });
     if (hostStageCapacity === 0) {

--- a/apps/web/lib/nonprod/local-ci-slot-resources.json
+++ b/apps/web/lib/nonprod/local-ci-slot-resources.json
@@ -14,8 +14,14 @@
     "maxParallelism": 4
   },
   "hostStagePolicy": {
-    "version": 1,
-    "memoryBytes": 8589934592
+    "version": 2,
+    "memoryBytes": 8589934592,
+    "admissionReserveBytes": 6442450944,
+    "admissionCalibration": {
+      "version": 1,
+      "observedHighWaterBytes": 2684354560,
+      "safetyMarginBytes": 3758096384
+    }
   },
   "slots": {
     "slot-0": {

--- a/docs/superpowers/audits/2026-08-29-guard-surface-inventory.md
+++ b/docs/superpowers/audits/2026-08-29-guard-surface-inventory.md
@@ -1,0 +1,166 @@
+# Guard inventory — all 95 pre-merge guards, measured
+
+Measured 2026-08-29 against `main` @ 97b32d3 on host 192.168.0.152.
+Companion to `docs/superpowers/specs/2026-08-29-change-delivery-latency-tiering-design.md` (EP-ABB3AC9D).
+
+## Method
+
+Each guard was executed once, individually, against a clean tree, with a 180s timeout
+and `NODE_OPTIONS=--max-old-space-size=8192`. All 95 exited 0.
+Stage membership was resolved by importing `POLICY_GUARD_PROFILES` and
+`buildPreflightPlan()` and matching command strings. `check-no-*` guards are
+discovered dynamically by `scripts/check-guards.mjs` rather than registered by name.
+Provenance is the first `BI-*` reference in the guard's first 4000 bytes when that
+item resolves in the live backlog, and otherwise the commit that added the guard.
+**87 of the 88 distinct BI ids cited across guard headers do not resolve**: the live
+backlog's oldest row is dated 2026-08-22 and the guards date from 2026-05-20, so every
+pre-reset citation is unrecoverable from the substrate. The add-commit is durable, so
+it is cited instead — 69 guards cite a BI that no longer resolves and 25 cite none at all.
+Edits counts commits touching the file since it was added.
+
+## Totals
+
+| measure | value |
+| --- | --- |
+| Guards | 95 (plus 88 companion `.test.mjs`) |
+| Added since 2026-07-18 | 55 — the surface grew 40 to 95 |
+| **All 95, serial** | **76.3s** |
+| of which `check-guards.mjs` (nested loop over 37 ratchets and their self-tests) | 27.9s |
+| **The 55 recent guards** | **17.9s** |
+| Per-guard cost | median 155ms, p75 517ms, p90 1160ms |
+| Under 200ms | 52 of 95, 3.9s in total |
+| Cite no motivating BI | 25 |
+| Cite a BI that no longer resolves | 69 of 70 |
+| Have no self-test | 17 |
+| Never modified since added | 53 |
+| Run in the host preflight | 50 |
+
+For comparison, the median local-CI slot hold is 776s and the p90 queue wait is 1053s.
+**The entire guard surface is 9.8% of one slot hold**, and the six weeks of new guards
+account for 17.9 seconds of it.
+
+## Recommendation summary
+
+| recommendation | count | meaning |
+| --- | ---: | --- |
+| KEEP AS-IS | 52 | cited defect, self-tested, under a second |
+| KEEP + CITE DEFECT | 15 | keep, but record the defect class in the header |
+| KEEP + ADD TEST | 14 | keep, but prove the guard itself with a sibling test |
+| SAMPLE-OR-DEFER | 9 | over 1s: cheap in the parallel cloud, dear on the serial host |
+| MOVE-TO-CLOUD | 4 | over 3s and network-bound: does not belong on the push path |
+| RETIRE-OR-WIRE | 1 | reachable from no stage at all |
+
+**81 of 95 stay exactly as they are. No guard is recommended for deletion.**
+
+## Inventory
+
+A trailing `+` on the date marks a guard added in the last six weeks.
+
+| guard (`check-…`) | added | provenance | cost | runs in | preflight | self-test | edits | recommendation |
+| --- | --- | --- | ---: | --- | :-: | :-: | ---: | --- |
+| `agent-capability-integrity` | 2026-08-21 + | b64f3fa807 | 46ms | audit-agent-capability-integrity.yml | — | **no** | 2 | KEEP + ADD TEST |
+| `application-boundaries` | 2026-08-01 + | 2afbe6c5d5 | 189ms | source | yes | yes | 2 | KEEP AS-IS |
+| `archetype-completeness` | 2026-07-22 + | 666835d026 | 63ms | source | yes | yes | 1 | KEEP + CITE DEFECT |
+| `build-namespace` | 2026-06-25 | 7bb12d2681 | 484ms | source | yes | **no** | 2 | KEEP + ADD TEST |
+| `build-script-policy` | 2026-08-08 + | 1ffb0546fc | 41ms | source | yes | yes | 2 | KEEP + CITE DEFECT |
+| `build-studio-surface-budget` | 2026-08-21 + | 11300f1541 | 63ms | source | yes | yes | 1 | KEEP AS-IS |
+| `bundle-boundaries` | 2026-06-06 | 0dfd9a1b37 | 1557ms | source | yes | yes | 4 | SAMPLE-OR-DEFER |
+| `capability-compose-profiles` | 2026-07-18 + | 1c157563a8 | 57ms | source | yes | yes | 1 | KEEP + CITE DEFECT |
+| `capability-consumers` | 2026-07-24 + | 3a32dc729e | 112ms | source | yes | yes | 1 | KEEP AS-IS |
+| `ci-policy-test-inventory` | 2026-08-09 + | 53b2abe0d6 | 57ms | source | yes | **no** | 1 | KEEP + ADD TEST |
+| `compose-env-contract` | 2026-07-18 + | b5cb1bbec3 | 43ms | source | yes | yes | 2 | KEEP + CITE DEFECT |
+| `compose-resource-budgets` | 2026-08-09 + | eeeb1edfee | 46ms | source | yes | yes | 1 | KEEP AS-IS |
+| `context-economy` | 2026-07-30 + | 503228688a | 158ms | source | yes | yes | 2 | KEEP AS-IS |
+| `data-impact` | 2026-07-18 + | d5658d6898 | 149ms | pull-request | yes | yes | 2 | KEEP + CITE DEFECT |
+| `design-grounding-decision` | 2026-07-13 | bd59eba7c6 | 1225ms | pull-request | yes | yes | 4 | SAMPLE-OR-DEFER |
+| `diagram-dependency-pins` | 2026-07-12 | 1597e4675f | 42ms | source | yes | **no** | 3 | KEEP + ADD TEST |
+| `doc-anchor-existence` | 2026-08-18 + | 1622c0b5fd | 154ms | source | yes | yes | 3 | KEEP AS-IS |
+| `doc-links` | 2026-07-17 | d99c636e84 | 81ms | source | yes | yes | 1 | KEEP + CITE DEFECT |
+| `doc-reference-integrity` | 2026-07-12 | 8ba5f21921 | 203ms | source | yes | yes | 1 | KEEP AS-IS |
+| `docker-patch-context` | 2026-08-15 + | 16485659ed | 49ms | source | yes | yes | 1 | KEEP + CITE DEFECT |
+| `dockerfile-copied-script-imports` | 2026-08-27 + | BI-9B490215 | 51ms | source | yes | yes | 1 | KEEP AS-IS |
+| `docs-impact` | 2026-07-17 | 0e1c68dbae | 150ms | pull-request | yes | yes | 4 | KEEP + CITE DEFECT |
+| `edge-node-image-bom` | 2026-08-04 + | cf9429b984 | 54ms | ci.yml (edge-footprint-bom) | — | **no** | 1 | KEEP + ADD TEST |
+| `endpoint-classification` | 2026-08-18 + | 707a12488e | 59ms | source | yes | yes | 2 | KEEP AS-IS |
+| `finding-substrate` | 2026-07-16 | b3a207b145 | 50ms | source | yes | yes | 2 | KEEP + CITE DEFECT |
+| `fk-index-coverage` | 2026-08-17 + | 2b20a05b55 | 63ms | source | yes | yes | 2 | KEEP AS-IS |
+| `golden-decisions` | 2026-06-20 | 64240bba67 | 68ms | pull-request | — | yes | 3 | KEEP AS-IS |
+| `governed-teardown-contract` | 2026-08-22 + | 91d2b1fef7 | 67ms | source | yes | yes | 2 | KEEP AS-IS |
+| `guards` | 2026-07-09 | 7b6ce8a133 | 27948ms | source | yes | yes | 3 | MOVE-TO-CLOUD |
+| `instruction-plane-rule-coverage` | 2026-07-31 + | 68adf3df9d | 570ms | source | yes | yes | 4 | KEEP AS-IS |
+| `instruction-plane-size` | 2026-07-24 + | 0d45e8806c | 50ms | source | yes | yes | 5 | KEEP AS-IS |
+| `label-association` | 2026-08-21 + | 7400e140cf | 130ms | source | yes | **no** | 1 | KEEP + ADD TEST |
+| `live-blocker-references` | 2026-08-23 + | 4219a6ef70 | 157ms | source | yes | yes | 1 | KEEP AS-IS |
+| `mcp-tool-pack` | 2026-06-26 | 9f0d77d50a | 46ms | source | yes | **no** | 2 | KEEP + ADD TEST |
+| `merge-queue-churn` | 2026-06-23 | 869eed53da | 8967ms | merge-queue-churn-watch.yml | — | yes | 1 | MOVE-TO-CLOUD |
+| `missing-ci-dispatch` | 2026-08-04 + | 3575436e19 | 634ms | watch-missing-ci-dispatch.yml | — | yes | 1 | KEEP + CITE DEFECT |
+| `mobile-jest-pin` | 2026-05-23 | f728213421 | 43ms | source | yes | **no** | 2 | KEEP + ADD TEST |
+| `module-size` | 2026-06-26 | 9f0d77d50a | 811ms | source | yes | yes | 7 | KEEP AS-IS |
+| `n-minus-one-caller-honesty` | 2026-07-19 + | b7dc0abf32 | 303ms | source | yes | yes | 1 | KEEP AS-IS |
+| `no-adhoc-mcp-protocol-versions` | 2026-08-18 + | 8d488b42eb | 46ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-ambient-host-tests` | 2026-08-23 + | d7096d23a1 | 507ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-bare-working-write` | 2026-05-20 | d36f543dd1 | 308ms | guard-loop (auto) | — | yes | 5 | KEEP AS-IS |
+| `no-dialog-in-transition` | 2026-07-06 | b5ce8ea20b | 582ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
+| `no-expired-baseline-budgets` | 2026-08-18 + | 1622c0b5fd | 52ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-governed-surface-without-mcp-tool` | 2026-08-09 + | 0ddf07377e | 50ms | guard-loop (auto) | — | yes | 1 | KEEP + CITE DEFECT |
+| `no-hand-rolled-loading` | 2026-07-18 + | 5a19d5148a | 343ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
+| `no-local-action-result` | 2026-08-17 + | 350779bf13 | 460ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-local-auth-guard` | 2026-07-08 | e2a279c1e8 | 69ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
+| `no-local-backup-helper` | 2026-07-09 | 177d41fb74 | 413ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-local-client-credentials` | 2026-07-10 | 0a5fce2c40 | 929ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-local-isrecord` | 2026-07-08 | 3944fd42aa | 415ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
+| `no-local-liveness-literal` | 2026-07-10 | 0999f4308a | 387ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-local-oauth-refresh` | 2026-07-10 | d41b35498c | 956ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-local-status-color` | 2026-07-10 | 89d73a3a3e | 499ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
+| `no-merge-readiness-policy-drift` | 2026-07-26 + | e94ee5024d | 53ms | guard-loop (auto) | — | yes | 1 | KEEP + CITE DEFECT |
+| `no-monolith-schema` | 2026-08-18 + | 5285d63521 | 416ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-nanoid-import` | 2026-07-10 | fd886a494b | 1675ms | guard-loop (auto) | — | yes | 2 | SAMPLE-OR-DEFER |
+| `no-native-dialogs` | 2026-06-16 | 9452525090 | 715ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
+| `no-new-closed-set-strings` | 2026-08-17 + | 2b20a05b55 | 105ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
+| `no-new-notactive-conventions` | 2026-08-19 + | c0757500e7 | 59ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-new-resource-clone-models` | 2026-08-19 + | c0757500e7 | 49ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-postgres-initdb-host-mount` | 2026-07-16 | ab70ee690b | 43ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-private-identity` | 2026-07-17 | f7f8a47861 | 1295ms | guard-loop (auto) | — | yes | 2 | SAMPLE-OR-DEFER |
+| `no-provider-local-connector-lifecycle` | 2026-07-18 + | bcd764353e | 4472ms | guard-loop (auto) | — | yes | 2 | MOVE-TO-CLOUD |
+| `no-raw-error-message` | 2026-07-08 | d8c7851768 | 718ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
+| `no-raw-event-source` | 2026-06-20 | e745ce72d6 | 582ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
+| `no-raw-route-error` | 2026-07-10 | 89d73a3a3e | 112ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-retired-lib-namespaces` | 2026-08-19 + | da09d69896 | 43ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-retired-superpowers-skills` | 2026-07-17 | a8abf406bc | 199ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-substrate-regression` | 2026-07-17 | 738b56a74b | 765ms | guard-loop (auto) | — | yes | 1 | KEEP + CITE DEFECT |
+| `no-suitability-object-shorthand` | 2026-07-22 + | 6d568e6d53 | 48ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-system-user-sentinel` | 2026-06-14 | 361f26d674 | 378ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
+| `no-twin-artifact-drift` | 2026-08-23 + | b704a4c7ce | 61ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-type-reexport-in-use-server` | 2026-07-10 | a2193c7778 | 517ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-unhonored-grant-growth` | 2026-08-23 + | f7fdb64d04 | 52ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
+| `no-unresolved-prometheus-targets` | 2026-08-23 + | d087bf7f07 | 48ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `obligation-cadence-coverage` | 2026-08-22 + | 0d9f5bea09 | 46ms | NOWHERE | — | **no** | 1 | RETIRE-OR-WIRE |
+| `override-comments` | 2026-07-22 + | a3cb1db2e3 | 41ms | source | yes | yes | 4 | KEEP AS-IS |
+| `package-boundaries` | 2026-06-25 | 803bdb5230 | 50ms | source | yes | **no** | 1 | KEEP + ADD TEST |
+| `plan-backlog-coverage` | 2026-07-20 + | 12fbdeb751 | 219ms | pull-request | yes | yes | 1 | KEEP + CITE DEFECT |
+| `published-image-freshness` | 2026-08-16 + | 7e5f97aa03 | 3891ms | published-image-freshness.yml | — | **no** | 1 | MOVE-TO-CLOUD |
+| `reporting-composition` | 2026-07-07 | a20608643d | 231ms | source | yes | yes | 2 | KEEP AS-IS |
+| `retention-enrollment` | 2026-08-17 + | 2b20a05b55 | 54ms | source | yes | yes | 2 | KEEP AS-IS |
+| `retired-substrate` | 2026-08-01 + | ad562045f1 | 111ms | source | yes | yes | 1 | KEEP + CITE DEFECT |
+| `seed-fit-decision` | 2026-07-11 | e46ed0bf82 | 1160ms | pull-request | — | yes | 1 | SAMPLE-OR-DEFER |
+| `spec-plan-doc` | 2026-06-18 | 9ffc1a9bc7 | 1118ms | pull-request | yes | **no** | 5 | SAMPLE-OR-DEFER |
+| `spec-status-frontmatter` | 2026-08-18 + | 1622c0b5fd | 297ms | source | yes | yes | 1 | KEEP AS-IS |
+| `stewardship-scope` | 2026-07-23 + | 0965445005 | 54ms | source | yes | yes | 2 | KEEP AS-IS |
+| `style-drift` | 2026-06-25 | fae62a282d | 1446ms | source | yes | yes | 5 | SAMPLE-OR-DEFER |
+| `test-clock-bombs` | 2026-08-06 + | 4d896354c7 | 1032ms | source | yes | yes | 1 | SAMPLE-OR-DEFER |
+| `test-cwd-independence` | 2026-08-23 + | bc4d95e62a | 506ms | source | yes | yes | 2 | KEEP AS-IS |
+| `tool-surface` | 2026-07-31 + | 5c6a0cac21 | 155ms | source | yes | yes | 2 | KEEP AS-IS |
+| `ux-fit-decision` | 2026-06-15 | 53e0b77c83 | 1163ms | pull-request | yes | yes | 8 | SAMPLE-OR-DEFER |
+| `ux-primitive-adoption` | 2026-08-17 + | 350779bf13 | 403ms | source | yes | yes | 1 | KEEP AS-IS |
+| `work-unit-conformance` | 2026-08-14 + | dca9682731 | 850ms | source | yes | yes | 1 | KEEP AS-IS |
+
+## Reproducing this
+
+Time every guard individually, dump the preflight plan, and read any guard's add date:
+
+~~~
+node scripts/pregate-preflight.mjs --plan
+node scripts/pregate-preflight.mjs
+git log --diff-filter=A --format=%ad --date=short -1 -- scripts/check-<name>.mjs
+~~~
+

--- a/docs/superpowers/plans/2026-08-29-change-delivery-latency-tiering.md
+++ b/docs/superpowers/plans/2026-08-29-change-delivery-latency-tiering.md
@@ -1,0 +1,205 @@
+---
+status: active
+---
+
+# Change-delivery latency — tier by risk, fail open on infrastructure
+
+- Spec: `docs/superpowers/specs/2026-08-29-change-delivery-latency-tiering-design.md`
+- Epic: EP-ABB3AC9D
+- Umbrella backlog item: BI-D908DA0A
+- Decision ledger: DI-0DD38401DF9F
+- Receipt: pending
+
+> **Receipt status.** `record_plan_backlog_coverage` requires a
+> `planArtifactRef` of kind `repo-blob-at-commit` with a provider-verified
+> `providerBlobId`. That blob does not exist until this plan is committed and
+> pushed, and pushing runs the pre-push gate. The receipt is therefore minted in
+> Phase 0 below, after the first push, and copied back into this line — which is
+> itself one instance of the gate-satisfaction commit class this plan exists to
+> reduce (17.0% of all commits in the measured sample). Recording that honestly
+> here rather than writing a placeholder that reads as satisfied.
+
+## What the measurement established
+
+Full baseline: https://claude.ai/code/artifact/05d0d22a-9fb6-4530-9fad-9baccbfec72c
+
+The load-bearing numbers, measured 2026-08-29 against `main` @ 97b32d3:
+
+- All 95 guards run serially in **76.3s**; the 55 added in the last six weeks
+  cost **17.9s** of that. Guards are **9.8%** of the 776s median slot hold.
+- Single-slot queue wait p90 **1053s**, max 3666s, at **45.1%** utilisation.
+- **60 of 60** host preflight commands are a strict subset of the cloud policy
+  profiles. **79 of 142** profile commands are guards testing themselves.
+- **32.5%** of 200 commits across 60 merged PRs are process, not product.
+- Hook prechecks reach Claude **22**, Grok **13**, Codex **10**.
+
+The guard surface is not the bottleneck. No phase below retires a guard.
+
+## Phase 0 — activate the second slot
+
+Umbrella: BI-D908DA0A. Independently shippable. No dependencies.
+
+The largest single win, and the cheapest. Replay of the real 286-lease arrival
+trace: capacity 2 takes total queued time from **23.8h to 2.1h** across five
+days, a 91% reduction. Running the real policy functions against this host
+returns `hostBuildCapacity: 2` and `hostStageCapacity: 2` today; the only
+blocker is the absent `PlatformConfig` row.
+
+1. Add a governed activation action that creates and validates the
+   `local_ci.sandbox_pool` row. Shape v1: `requestedCapacity` (1 or 2),
+   `ceilings{minAvailableMemoryBytes, maxSustainedCpuPercent, minDiskFreeBytes}`,
+   `rollback{maxServiceDurationRegressionPercent ≤ 15,
+   maxInfrastructureFailureRatePercent ≤ 5, evidenceMismatchTolerance = 0}`.
+   Validation is `localCiPoolConfigError`, which already exists — call it, do
+   not restate it.
+2. Seed an explicit `requestedCapacity: 1` at install, so `config-absent` stops
+   being the silent default path and activation becomes an edit.
+3. Surface `effectiveCapacity`, `hostSafeCapacity`, `source` and
+   `rollbackReason` on an operator health surface. The resolver already returns
+   all four; nothing reads them.
+4. Activate at capacity 2 on this host.
+
+Rollback: `contractLocalCiPoolAfterGateResult` already contracts 2 → 1 on a bad
+slot-1 result. It ships; it is the one half of the pilot that was finished.
+
+Verification: re-measure queue-wait percentiles over the following seven days
+against the 1053s p90 recorded here, from the same
+`NonProductionEnvironmentLease` query.
+
+## Phase 1 — an honest verdict
+
+Umbrella: BI-D088D06D. Independently shippable. No dependencies. Ships together
+with BI-0F2E42D5 and BI-A7EAB5AA, which repair the same injustice one layer down.
+
+1. Add `INCONCLUSIVE` to the verdict set in `scripts/lib/pregate-status.mjs`.
+   It is written when the gate state carries an infrastructure classification —
+   a recorded signal death, a control-plane starvation, a lost slot bind — and
+   never as a default for an unexplained exit. An unexplained exit stays `FAIL`;
+   that distinction is the whole safety property.
+2. Make the running path in `scripts/pregate.mjs` recover as the queued path
+   already does. Today a wrapper killed while queued writes `status: "queued"`
+   and preserves the lease; killed while running it writes a terminal
+   `status: "failed"`. Same cause, opposite outcome.
+3. Propagate the runner's existing classification. `resolveChildExit` already
+   returns `EXIT_CHILD_SIGNAL_DEATH` and prints that this is infrastructure
+   evidence. Carry that into the gate state instead of discarding it.
+4. Add the invariant guard: no code path may write a terminal
+   `gatePassed: false` for a condition already classified as infrastructure.
+
+Verification: a test that kills the wrapper on the running path and asserts the
+SHA remains re-runnable. The queued-path equivalent already exists — mirror it.
+
+## Phase 2 — declare what each guard reads
+
+Umbrella: BI-8CDA7F95. Independently shippable. Prerequisite for Phase 3.
+
+1. Each `scripts/check-*.mjs` exports an `inputs` glob list naming what it
+   reads. The 37 `check-no-*` ratchets already scan fixed directories, so most
+   declarations are mechanical.
+2. `buildPreflightPlan()` takes the changed-file set and intersects it against
+   those declarations, using `scripts/ci-change-scope.mjs` —
+   already written, already trusted by the cloud, currently never called from
+   this stage.
+3. A guard with no `inputs` declaration runs unconditionally. Absence of a
+   declaration must never be read as absence of relevance.
+4. Add a reachability guard: every `scripts/check-*.mjs` is reachable from at
+   least one declared stage. This is what would have caught Phase 6's finding.
+
+Verification: run the preflight against a docs-only, a source and a schema diff
+and assert the entry counts differ. Today all three run 52 of 52.
+
+## Phase 3 — stop proving the same thing three times
+
+Umbrella: BI-282AE0BC. Depends on Phase 2.
+
+1. **Classify the self-tests first.** Each `.test.mjs` in the policy profiles
+   declares whether it is a unit test of guard logic (runs when the guard
+   changes) or a conformance assertion reading live repository state (runs
+   always). BI-7B249AFE records that stripping them wholesale produced a false
+   green on a tree CI failed deterministically. This is classification, never
+   deletion.
+2. Key each guard result on a hash of the guard file plus the content of its
+   declared inputs. An unchanged pair is a cache hit; the three-times-per-push
+   duplication collapses to once-per-distinct-tree-content.
+3. The cache is local. No remote execution — verification must not acquire a
+   dependency on an external service.
+
+Verification: perturbing a declared input must produce a cache miss. Perturbing
+an undeclared file must too, until its guard declares it — fail safe.
+
+## Phase 4 — one precheck plane, four surfaces
+
+Umbrella: BI-C09ECA63. Independently shippable. No dependencies.
+
+Claude gets 22 hook scripts, Grok 13, Codex 10, from three hand-maintained
+registries with no shared source. The twelve Codex lacks are all prechecks that
+predict a gate refusal before a commit exists — so the surface with the fewest
+warnings pays the full gate latency to learn what Claude is told for free.
+
+1. One declared precheck registry as the single source.
+2. Four thin adapters emit each surface's native format: the plugin
+   `hooks.json`, `~/.grok/hooks/dpf-guards.json`, `~/.codex/hooks.json`, and
+   the Antigravity manifest. Keep surface-specific code at the adapter edge.
+3. A parity guard that fails when a precheck reaches one surface and not
+   another without a recorded exemption. `update_agent_toolchain.py` already
+   carries a comment recording that this was learned once before
+   (BI-0B292D84): a guard absent from a tuple never reaches that surface at all.
+4. Make the Codex hook-trust state legible, so an unestablished handshake
+   reports itself rather than silently running nothing.
+
+Verification: the parity guard is its own proof. Assert it fails on a
+deliberately undeclared drift.
+
+## Phase 5 — make the coverage gate ask the substrate
+
+Umbrella: BI-397EBDD6. Independently shippable. Pairs with BI-310EC5AF.
+
+`check-plan-backlog-coverage.mjs` decides whether it applies by string-matching
+`**Backlog item:**` in the plan's prose, so a plan naming its item any other way
+is exempt from the whole gate. Proven against this plan: committed with
+`Receipt: pending` and no `## Backlog coverage` section, the gate passed it.
+
+1. Resolve the plan's umbrella item from `BacklogItem`, not from Markdown. A
+   plan under `docs/superpowers/plans/` is in scope unless the substrate says
+   otherwise.
+2. Validate the Receipt against the substrate rather than a regex (BI-310EC5AF).
+3. Remove the two-commit ordering constraint, or make it explicit: a receipt
+   cannot exist before the plan blob is pushed, so either the gate tolerates a
+   first-push plan or the receipt binds to something that exists earlier.
+
+## Phase 6 — guard-surface hygiene
+
+Umbrella: BI-6332DD3D. Independently shippable. No dependencies.
+
+Resolve `check-obligation-cadence-coverage.mjs`, which is registered in no
+profile, is not `check-no-*` so the loop never discovers it, and appears in no
+workflow. Either register it, or rename it to the measurement tool it is. Do not
+delete it without naming the defect class it was written for.
+
+## Sequencing
+
+Phase 0 and Phase 1 are independent of everything and deliver most of the
+wall-clock. Phase 2 gates Phase 3. Phases 4 and 5 are independent throughout.
+
+Nothing in this plan removes a check. The cloud tier stays complete and
+unsampled: every guard still runs on every change before it merges, which is
+what preserves the guarantees. What changes is that the local tiers stop
+re-proving what the cloud will prove anyway, on the one machine where proving it
+costs a queue position.
+
+## Out of scope
+
+- Retiring any guard. The inventory recommends keeping 81 of 95 exactly as-is.
+- Commandment-tier checks: auth, DCO, secret scanning, migration safety.
+- Pool capacity above 2. `LOCAL_CI_MAX_CAPACITY` is 2, and the replay shows 2
+  captures 91% of the available benefit.
+- Readiness governance in the merge path. Named in the spec, left to
+  EP-129D11FD and its own ratification.
+
+## Target service level
+
+- A docs-only change merges in under 20 minutes.
+- A source change merges in under 40 minutes.
+- No change is ever blocked by an infrastructure verdict.
+- Process overhead falls below 10% of commits, from 32.5%.
+- Every precheck reaches all four surfaces, or its absence is declared.

--- a/docs/superpowers/plans/2026-08-29-change-delivery-latency-tiering.md
+++ b/docs/superpowers/plans/2026-08-29-change-delivery-latency-tiering.md
@@ -35,36 +35,130 @@ The load-bearing numbers, measured 2026-08-29 against `main` @ 97b32d3:
 
 The guard surface is not the bottleneck. No phase below retires a guard.
 
-## Phase 0 — activate the second slot
+## Phase 0 — capacity follows the installation
 
-Umbrella: BI-D908DA0A. Independently shippable. No dependencies.
+Umbrella: BI-D908DA0A and BI-E58B57EC. Independently shippable. No dependencies.
 
 The largest single win, and the cheapest. Replay of the real 286-lease arrival
 trace: capacity 2 takes total queued time from **23.8h to 2.1h** across five
-days, a 91% reduction. Running the real policy functions against this host
-returns `hostBuildCapacity: 2` and `hostStageCapacity: 2` today; the only
-blocker is the absent `PlatformConfig` row.
+days, a 91% reduction, and still wins end-to-end at a pessimistic +40% CPU
+contention penalty.
 
-1. Add a governed activation action that creates and validates the
-   `local_ci.sandbox_pool` row. Shape v1: `requestedCapacity` (1 or 2),
-   `ceilings{minAvailableMemoryBytes, maxSustainedCpuPercent, minDiskFreeBytes}`,
-   `rollback{maxServiceDurationRegressionPercent ≤ 15,
-   maxInfrastructureFailureRatePercent ≤ 5, evidenceMismatchTolerance = 0}`.
-   Validation is `localCiPoolConfigError`, which already exists — call it, do
-   not restate it.
-2. Seed an explicit `requestedCapacity: 1` at install, so `config-absent` stops
-   being the silent default path and activation becomes an edit.
-3. Surface `effectiveCapacity`, `hostSafeCapacity`, `source` and
+### The constraint this has to respect
+
+This host is running the **Docker image install path under test** — a consumer
+install shape being dogfooded — while also being the machine that develops the
+platform. Those two roles want opposite resource profiles, and the resource
+numbers are currently baked into `local-ci-slot-resources.json`, which ships
+inside the image. One set of bytes, two incompatible jobs.
+
+Two obvious answers are both wrong:
+
+- **Change the install shape.** The install path is precisely what is being
+  tested. Widening its resource envelope to suit development would invalidate
+  the test and would be wrong for every real consumer.
+- **Add a manual capacity setting.** This is the original defect wearing a new
+  costume. The pool already has no activation path; adding a switch a consumer
+  will never find, and a developer must hand-author JSON to flip, reproduces it.
+
+### The decision
+
+**Capacity is a property of the installation, not a constant of the product.**
+The installation already declares the two facts that decide it, and both are
+already populated on this host:
+
+```
+installation.environment-class.v1  -> "development"
+installation.operating-intent.v1   -> primaryPurpose "evolve-dpf", confirmed
+host_profile                       -> 63.7 GB RAM, 24 cores   (installer)
+container_profile                  -> 12 CPUs, 24033 MB       (refreshed every portal boot)
+```
+
+`local-ci-pool-policy.ts` reads none of them. It should. A `development`
+installation whose declared job is `evolve-dpf` runs many gates a day and gets
+the capacity its host can carry; everything else keeps the singleton.
+
+A new precedence tier, deliberately mirroring the four-tier shape
+`environment-class` already uses:
+
+| rank | source | who sets it |
+| --- | --- | --- |
+| 1 | `DPF_LOCAL_CI_POOL_CAPACITY` break-glass | operator, per-process, existing |
+| 2 | `local_ci.sandbox_pool` row | operator, explicit, existing |
+| 3 | **installation-profile** | derived from the declaration — **new** |
+| 4 | compatibility singleton | when nothing is declared |
+
+Host headroom, the pilot guardrails and the circuit breaker all still clamp
+whatever comes back, and can only reduce it. The configurable option the
+founder asked about is retained as rank 2 — it is the override, not the
+activation path.
+
+This gives one image that is correct for both shapes: a consumer install stays
+at one slot automatically and says why; this box gets two automatically with no
+operator action.
+
+### The second blocker
+
+Seeding capacity alone still returns `host-stage-capacity-one`. Two independent
+memory tests gate admission and they read different machines:
+
+| test | reads | reserve | verdict |
+| --- | --- | --- | --- |
+| `localCiBuildHeadroomCapacity` | Docker VM | 10 GiB, calibrated | 2 |
+| `localCiHostStageHeadroomCapacity` | Windows host | 8 GiB, **never calibrated** | 1 |
+
+The builder reserve had already been measured down from a 16 GiB ceiling to
+10 GiB against an 8 GiB observed high-water. `hostStagePolicy` carried no
+calibration block at all. Measured 2026-08-29: peak combined node working set
+during the heaviest host-side stage was **2.27 GiB** over idle baseline — a
+3.5x over-reservation, and the entire reason a 63.7 GB host admitted one slot.
+
+### Steps
+
+1. Give `hostStagePolicy` an `admissionCalibration` block mirroring
+   `builderPolicy`, and reserve `min(ceiling, calibrated)` via
+   `localCiHostStageAdmissionReserveBytes`. Calibrated to 6 GiB — 2.6x the
+   measured peak, and enough for two stages with a 4 GiB floor.
+2. Derive the requested capacity from the declared environment class and
+   operating intent. The derivation is pure and lives in
+   `local-ci-pool-policy.ts` alongside the other capacity helpers; the IO that
+   reads the two `PlatformConfig` keys lives at the edge in
+   `local-ci-capacity-profile.ts`. That split is forced, not stylistic:
+   `scripts/local-ci-pool-policy.test.mjs` loads the policy under raw Node, so
+   the policy's runtime import graph must stay relative `.mjs`/`.json` only —
+   the installation types come in via `import type`, which is erased. An
+   unreadable or partial declaration returns null, so silence keeps the
+   singleton.
+3. Wire the derived tier into `resolveLocalCiPoolPolicy` beneath the explicit
+   row, and pass the profile from `resolveNonprodPoolPolicy`. A read failure is
+   caught and resolves to null rather than throwing the claim.
+4. Surface `effectiveCapacity`, `hostSafeCapacity`, `source` and
    `rollbackReason` on an operator health surface. The resolver already returns
    all four; nothing reads them.
-4. Activate at capacity 2 on this host.
+5. Add the CPU-count admission test that does not exist today, and fix or
+   retire the Windows `sustainedCpuPercent` probe — `os.loadavg()` returns
+   `[0,0,0]` on Windows, so that half of the CPU ceiling reads 0% and can never
+   fire.
 
-Rollback: `contractLocalCiPoolAfterGateResult` already contracts 2 → 1 on a bad
-slot-1 result. It ships; it is the one half of the pilot that was finished.
+Steps 1 to 3 are implemented on this branch, with 20 new behaviour tests in
+`local-ci-capacity-profile.test.ts` covering every install shape, the operator
+override, the host clamp, and the closed-admission case. Steps 4 and 5 are not.
+
+Two existing fixtures asserted host-stage refusals against the literal 8 GiB
+reserve and started admitting once it was calibrated. Both now derive their
+memory level from `hostStagePolicy.admissionReserveBytes`, so a future
+recalibration cannot silently turn a refusal into an admission — the failure
+mode that would otherwise have been introduced by this very change.
+
+Rollback: `contractLocalCiPoolAfterGateResult` already contracts 2 to 1 on a bad
+slot-1 result. It ships; it is the half of the pilot that was finished. A
+derived capacity is contracted by writing the explicit row, which then outranks
+the derivation.
 
 Verification: re-measure queue-wait percentiles over the following seven days
 against the 1053s p90 recorded here, from the same
-`NonProductionEnvironmentLease` query.
+`NonProductionEnvironmentLease` query. Record the observed service-time
+inflation at two slots against the modelled +25 to 33%.
 
 ## Phase 1 — an honest verdict
 

--- a/docs/superpowers/plans/2026-08-29-change-delivery-latency-tiering.md
+++ b/docs/superpowers/plans/2026-08-29-change-delivery-latency-tiering.md
@@ -160,6 +160,71 @@ against the 1053s p90 recorded here, from the same
 `NonProductionEnvironmentLease` query. Record the observed service-time
 inflation at two slots against the modelled +25 to 33%.
 
+## Phase 0b — gate on the tests the diff can reach
+
+Umbrella: BI-2227C37C. Independently shippable. No dependencies. **Do this
+before Phase 0** — it cuts service time, which shrinks the queue, shrinks what a
+retry costs, and reduces the CPU contention a second slot introduces.
+
+### What actually changed, five weeks ago
+
+The single slot is not a regression. Before the two-slot pilot (`35cddc6be5`,
+2026-07-30), `environment-lease.ts` hard-coded
+`NONPROD_SLOT_KEYS = ["slot-0"]` with the comment "Phase 1 deliberately retains
+singleton capacity." Capacity has been 1 throughout.
+
+What grew is the work inside the slot:
+
+| date | `*.test.ts(x)` files |
+| --- | --- |
+| 2026-07-24 | 2462 |
+| 2026-08-09 | 3000 |
+| 2026-08-28 | **3414** |
+
+**+39% in five weeks.** The stage was exhaustive, so suite growth converted
+one-for-one into gate time and, at fixed capacity 1, into queue wait — which is
+non-linear in utilisation. Merges to `main` fell from 391/week (week 28) to
+166/week (week 34).
+
+Workrooms are not implicated: no Workroom path claims a `local-integration-ci`
+lease. Guards are not implicated: 17.9s of a 76.3s total.
+
+### Measured, on this host at maxWorkers=4
+
+| coverage | test files | tests | wall clock |
+| --- | ---: | ---: | ---: |
+| exhaustive | 3046 | 26,437 | **319s** |
+| affected (this branch's 10-file diff) | 430 | 4,273 | **97s** |
+
+319s is **41%** of the 776s median slot hold. Selection cuts it 70%.
+
+### Steps
+
+1. `scripts/lib/local-ci-vitest-selection.mjs` decides coverage from the diff,
+   using vitest's own `--changed` so a changed library still pulls in its
+   dependents' tests rather than trusting a hand-maintained path map.
+2. The gate passes `--base <baseRef>` to the stage.
+3. The stage receipt carries the coverage mode in its stage name and `--changed`
+   in its identity, so a narrower prior run cannot satisfy a wider one on reuse
+   or recovery.
+
+Implemented on this branch, with 11 selection tests.
+
+**Fail-safe conditions — all fall back to exhaustive:** no base ref, an
+unreadable diff, an empty diff, or a changed file whose blast radius the module
+graph cannot see (vitest/tsconfig/package.json/lockfile/next.config/prisma
+schema/migrations/test setup/env). `changedFilesAgainst` returns null rather
+than `[]` on a failed git call, so "git broke" can never be read as "nothing
+changed" and run zero tests. `DPF_LOCAL_CI_VITEST_EXHAUSTIVE="<why>"` forces the
+full run and records the reason.
+
+The cloud tier stays exhaustive and sharded. That is what makes local selection
+safe rather than a gamble.
+
+**Not done:** raising `--maxWorkers` from 4 on a 12-CPU VM. Likely worth it, but
+the memory and throughput trade against two admitted slots is unmeasured, and an
+unmeasured change here is what produced the problem being fixed.
+
 ## Phase 1 — an honest verdict
 
 Umbrella: BI-D088D06D. Independently shippable. No dependencies. Ships together

--- a/docs/superpowers/specs/2026-08-29-change-delivery-latency-tiering-design.md
+++ b/docs/superpowers/specs/2026-08-29-change-delivery-latency-tiering-design.md
@@ -5,7 +5,7 @@ status: active
 # Change-delivery latency — tier by risk, fail open on infrastructure
 
 - **Epic:** EP-ABB3AC9D
-- **Backlog items:** BI-D908DA0A, BI-D088D06D, BI-8CDA7F95, BI-282AE0BC, BI-C09ECA63, BI-6332DD3D, BI-397EBDD6, BI-2C0A01CD
+- **Backlog items:** BI-D908DA0A, BI-E58B57EC, BI-D088D06D, BI-8CDA7F95, BI-282AE0BC, BI-C09ECA63, BI-6332DD3D, BI-397EBDD6, BI-2C0A01CD
 - **Decision ledger:** DI-0DD38401DF9F (`principle_decide`, high stakes, no commandment conflict)
 - **Profile:** refactor
 - **Authored:** 2026-08-29
@@ -260,6 +260,86 @@ already-computed infrastructure classification rather than adding substrate.
 
 **Decision: keep all 95 guards. Attack serialisation, duplication and dishonest
 verdicts.**
+
+### Capacity belongs to the installation, not to the image
+
+This host runs the **Docker image install path under test** — a consumer install
+shape being dogfooded — while also being the machine that develops the platform.
+Those two roles want opposite resource envelopes, and the numbers that decide the
+envelope live in `local-ci-slot-resources.json`, which ships inside the image.
+One set of bytes, two incompatible jobs.
+
+Two tempting answers are both wrong. **Changing the install shape** would
+invalidate the very thing under test and would be wrong for real consumers.
+**Adding a manual capacity setting** is the original defect in a new costume: the
+pool's whole problem is that it has no activation path, and a switch a consumer
+never finds and a developer must hand-author JSON to flip does not fix that.
+
+The installation already declares what it is, and both declarations are already
+populated here:
+
+```
+installation.environment-class.v1  -> "development"
+installation.operating-intent.v1   -> primaryPurpose "evolve-dpf", confirmed
+host_profile                       -> 63.7 GB RAM, 24 cores    (written by the installer)
+container_profile                  -> 12 CPUs, 24033 MB        (refreshed every portal boot)
+```
+
+The pool policy reads none of them. So capacity gains a derived tier, mirroring
+the four-tier precedence `environment-class` already uses:
+
+| rank | source | set by |
+| --- | --- | --- |
+| 1 | `DPF_LOCAL_CI_POOL_CAPACITY` break-glass | operator, per-process — existing |
+| 2 | explicit `local_ci.sandbox_pool` row | operator — existing, and the override |
+| 3 | **installation-profile** | derived from the declaration — new |
+| 4 | compatibility singleton | nothing declared |
+
+A `development` installation whose declared job is `evolve-dpf` requests the
+capacity its host can carry. Every consumer install, every production install,
+and any installation that has not declared itself keeps the singleton —
+`UNDECLARED_ENVIRONMENT_CLASS` is `production`, so silence resolves to the
+conservative answer. Host headroom, the pilot guardrails and the circuit breaker
+still clamp the result and can only reduce it.
+
+One image, correct for both shapes, and no operator action on either.
+
+### The uncalibrated number underneath it
+
+Deriving capacity is still not enough on its own: it returns
+`host-stage-capacity-one`. Two independent memory tests gate admission and they
+read **different machines**.
+
+| test | reads | reserve per slot | verdict |
+| --- | --- | --- | --- |
+| `localCiBuildHeadroomCapacity` | Docker VM | 10 GiB, calibrated | 2 |
+| `localCiHostStageHeadroomCapacity` | Windows host | 8 GiB, **never calibrated** | 1 |
+
+`builderPolicy` carries an `admissionCalibration` block and reserves
+`min(16 GiB ceiling, 10 GiB calibrated)` against an 8 GiB observed high-water.
+`hostStagePolicy` carried no calibration at all — a flat 8 GiB. Measured
+2026-08-29, peak combined node working set on the Windows host during the
+heaviest host-side stage was **2.27 GiB** over idle baseline: a 3.5x
+over-reservation, and the sole reason a 63.7 GB host admitted one slot.
+
+Calibrating it to 6 GiB — 2.6x the measured peak — admits two. Filed as
+BI-E58B57EC.
+
+### Nothing checks CPU
+
+Each builder is capped at 8 CPUs (`cpuQuota: 800000 / cpuPeriod: 100000`); the
+Docker VM reports 12. Two slots request a 16-CPU ceiling against 12, and no code
+path compares requested quota to available CPUs. The Windows CPU probe is also
+structurally dead: `sustainedCpuPercent` is `loadavg()[0] / cpus().length`, and
+`os.loadavg()` returns `[0,0,0]` on Windows, so that half of the ceiling reads 0%
+and can never fire.
+
+Quotas are ceilings rather than reservations, so this degrades rather than fails.
+Replaying the trace with service time inflated for 8 CPUs becoming ~6: two slots
+still beat one end-to-end at +40% (1642s vs 2063s p90 wait-plus-hold), with
+break-even near +55 to 60%. An 8-to-6 shift is 25 to 33%. The gain survives the
+contention — but the contention should be modelled rather than discovered, so a
+CPU-count admission test is in scope.
 
 ### The tiering contract
 

--- a/docs/superpowers/specs/2026-08-29-change-delivery-latency-tiering-design.md
+++ b/docs/superpowers/specs/2026-08-29-change-delivery-latency-tiering-design.md
@@ -1,0 +1,420 @@
+---
+status: active
+---
+
+# Change-delivery latency — tier by risk, fail open on infrastructure
+
+- **Epic:** EP-ABB3AC9D
+- **Backlog items:** BI-D908DA0A, BI-D088D06D, BI-8CDA7F95, BI-282AE0BC, BI-C09ECA63, BI-6332DD3D, BI-397EBDD6, BI-2C0A01CD
+- **Decision ledger:** DI-0DD38401DF9F (`principle_decide`, high stakes, no commandment conflict)
+- **Profile:** refactor
+- **Authored:** 2026-08-29
+- **Measured against:** `main` @ 97b32d3, host 192.168.0.152, window 2026-08-24 → 2026-08-29
+
+## Problem
+
+Getting a small correct change merged had grown to days. The working hypothesis
+was that the guard surface caused it: 53 new `scripts/check-*.mjs` guards in six
+weeks against a local-CI pool stuck at one slot.
+
+The guard count is accurate. The cost attribution is not, and measuring it first
+changed what this spec proposes.
+
+### What was measured
+
+Every figure below was produced by executing the thing, not by reading it.
+
+| measurement | value | method |
+| --- | --- | --- |
+| Guards in the tree | 95 (+ 88 companion `.test.mjs`) | `find scripts -maxdepth 1 -name 'check-*.mjs'` |
+| Added since 2026-07-18 | 55 of 95 — surface grew 40 → 95 | first-add commit per file |
+| **All 95 guards, serial** | **76.3s** | each guard executed once against clean `main` |
+| **The 55 recent guards** | **17.9s** | same run, partitioned by add date |
+| Per-guard cost | median 155ms, p75 517ms, p90 1160ms | same run |
+| Guards under 200ms | 52 of 95, 3.9s in total | same run |
+| Host guard-parity preflight | **51.3s**, 52 entries, 60 commands | `node scripts/pregate-preflight.mjs` |
+| Single-slot hold | p50 **776s**, p90 1113s, max 4924s | 301 `NonProductionEnvironmentLease` rows |
+| Single-slot queue wait | p50 0s, p90 **1053s**, max 3666s | same rows |
+| Slot utilisation | **45.1%** (55.8 slot-hours / 123.8h) | same rows |
+| Cloud CI, pull_request | median **10.1min**, p90 10.7min | 15 `ci.yml` runs |
+| Cloud policy guards | 138s + 79s + 24s = **241s**, parallel | job durations, one PR run |
+| Cloud critical path | **590s**, UX Route Sweep Runtime | same run |
+| `web` typecheck | **98s** | `pnpm --filter web typecheck` |
+
+**Guards are 9.8% of the median slot hold.** Retiring every guard added since
+July would return 18 seconds against a p90 queue wait of 1053 seconds. The waste
+is real; it is not in the guards.
+
+### Where the time actually goes
+
+Three findings, each independently sufficient to explain the founder's report.
+
+**1. One slot, 45% utilised, produces a 17-minute p90 wait.** Arrivals are
+bursty. `PlatformConfig` key `local_ci.sandbox_pool` is absent — the table holds
+21 keys and none is it — so `resolveLocalCiPoolPolicy` falls back to a singleton
+with `rollbackReason: "config-absent"`. The slot manifest already defines
+`slot-0` and `slot-1`. Running the real policy functions against this box's
+measured memory returns `hostBuildCapacity: 2` and `hostStageCapacity: 2`; with
+the config row present, `effectiveCapacity: 2` and `rollbackReason: null`.
+
+The only code path that writes that key is
+`contractLocalCiPoolAfterGateResult`, which moves capacity from 2 down to 1.
+**No code path anywhere creates the row or raises capacity.** The pilot shipped
+a rollback with no activation.
+
+**2. Infrastructure failure is recorded as a verdict against the diff.**
+`scripts/lib/pregate-status.mjs` emits five verdicts —
+`NO-RECORD | STALE | PENDING | FAIL | PASS`. Anything with
+`gatePassed !== true` becomes `FAIL`. The runner already knows better;
+`resolveChildExit` in `local-ci-runner.mjs` prints, verbatim, that a
+signal-killed child is "infrastructure evidence, not a product build failure".
+That classification is captured at the point of failure and discarded at the
+point of reporting.
+
+The two paths in `pregate.mjs` that handle the same event disagree:
+
+| wrapper killed while | writes | lease | outcome |
+| --- | --- | --- | --- |
+| **queued** | `status: "queued"` | preserved | revives |
+| **running** | `status: "failed"` | released | terminal, poisons the SHA |
+
+**3. A third of every commit is process, not product.** Across 60 merged PRs
+and 200 commits: 67.5% substantive, 14.5% base resyncs, 17.0% commits added
+only to satisfy a gate, 1.0% titled literally
+`chore(ci): retry infrastructure-blocked gate`. On PRs touching ten files or
+fewer, 1-commit branches take 0.35h from first commit to PR open; 9-or-more-commit
+branches take **27.04h** at comparable size.
+
+The resyncs are a second-order effect of finding 1. A branch that waits 17
+minutes for a slot and holds it for 13 is a branch whose base has moved.
+
+### The duplication
+
+Comparing the host preflight command set against `POLICY_GUARD_PROFILES` by
+exact string:
+
+```
+PREFLIGHT commands                          60
+preflight commands ALSO in ANY profile      60 / 60
+preflight-only commands                      0
+```
+
+Every assertion is evaluated on the host, again in the sandboxed gate, and again
+in the cloud. In the cloud that is nearly free — 241s of parallel work inside a
+590s critical path it never extends. On the host it is serial, and the sandboxed
+re-run happens while holding the contended slot.
+
+A further 79 of 142 profile commands (56%) are guards testing themselves rather
+than checking the diff.
+
+### The tiering already exists, and one stage ignores it
+
+AGENTS.md §4 states the rule, and two of three stages implement it. The cloud
+branches on `docsOnly`/`mobileOnly`/`heavy` via `scripts/ci-change-scope.mjs`.
+The local gate runs `runPreAdmissionDocumentationLane`, so a docs-only change
+produces evidence without taking a slot.
+
+`buildPreflightPlan()` takes no changed-files argument. It returns the same 52
+entries for a one-line markdown edit as for a migration. The classifier exists,
+gives the right answer when called directly, and this stage never calls it.
+
+### The guard surface cannot be reviewed on its merits
+
+The question this investigation was asked to answer for each of the 53 new
+guards — what defect motivated it, and has that class recurred — is not
+answerable from the substrate. Of the 88 distinct `BI-*` ids cited across all 95
+guard headers, **1 resolves in the live backlog and 87 do not**.
+
+The cause is not a filing error. The live backlog's oldest row is dated
+2026-08-22 and the guards date from 2026-05-20, so every citation predating the
+reset points at a row that was not carried across. Each citation was correct
+when written.
+
+Two consequences. A guard's cost/benefit cannot be argued from the substrate, so
+this spec argues it from measured cost and from stage reachability instead. And
+`check-doc-anchor-existence` fails any document that quotes the history — the
+first commit of this spec's own audit failed with 69 `does NOT exist` lines for
+citations that were all accurate when written. Filed as BI-2C0A01CD; the audit
+now cites the durable add-commit instead.
+
+### Why Codex is worse
+
+The gates are surface-neutral. The advance warnings are not. Hook scripts
+actually reaching each surface: **Claude 22, Grok 13, Codex 10**. The twelve
+Claude has and Codex lacks are, without exception, prechecks that predict a gate
+refusal before a commit exists — `design-grounding-precheck`,
+`spec-plan-doc-precheck`, `ux-fit-precheck`, `root-clone-freshness`,
+`worktree-readiness-banner`, and seven more.
+
+Claude is told at edit time for nothing. Codex learns the identical fact by
+queueing for the slot, holding it, and failing — roughly 30 minutes for a
+zero-second warning. Three hand-maintained registries with no shared source
+produced this; nothing checks that they agree.
+
+## Research
+
+AGENTS.md §7 requires comparing open-source leaders and stating what DPF adopts
+or rejects. Three projects solve exactly the three findings above, and each has
+been solving them at far larger scale for longer.
+
+### Chromium — LUCI CQ
+
+Chromium's commit queue treats **`INFRA_FAILURE` as a build status distinct from
+`FAILURE`**. A builder that dies because a bot ran out of disk, a service
+timed out, or an isolate could not be fetched does not produce a verdict on the
+CL. CQ retries it automatically within a configured budget, and the CL's
+verdict is only ever computed from statuses that describe the change. CQ also
+supports `experiment_percentage`, which runs a builder on a sampled fraction of
+CLs so an expensive or still-stabilising check can gather signal without
+gating every change.
+
+Zuul (OpenStack) reaches the same conclusion independently, with a `RETRY`
+result and a `RETRY_LIMIT` terminal state, so that "the job could not run" and
+"the job found a defect" are never the same word.
+
+**DPF adopts:** a first-class `INCONCLUSIVE` verdict alongside the existing
+five, written whenever the runner has already classified the cause as
+infrastructure. The running path in `pregate.mjs` recovers exactly as the queued
+path already does. An `INCONCLUSIVE` run does not consume the SHA's verdict and
+re-runs on the same SHA. DPF also adopts the sampling idea for the small number
+of guards that cost more than a second, so they gather signal without paying
+full cost on every push.
+
+**DPF rejects:** unbounded automatic retry. DPF's failure taxonomy shows
+starvation can be sustained rather than transient, so a bounded retry with an
+honest `INCONCLUSIVE` after exhaustion is correct where a silent retry loop is
+not. This is the same conclusion BI-9DC21917 reached from the opposite
+direction — fencing a *transient* probe miss as sustained starvation is the
+symmetric error.
+
+### Kubernetes — Prow and Tide
+
+Prow presubmits declare their own path scope. A job carries `run_if_changed` or
+`skip_if_only_changed` regexes, and the job simply does not run when the diff
+does not intersect. The scope is declared next to the job, so adding a job and
+declaring what it reads are one edit. Tide then merges PRs in batches, testing
+`main + PR1 + PR2 + …` once to amortise the expensive merge test.
+
+**DPF adopts:** per-guard declared input scope. Each `scripts/check-*.mjs` gains
+an exported `inputs` glob list, and the preflight intersects that against the
+diff using the `ci-change-scope` classifier the cloud already trusts. This makes
+the tiering property that AGENTS.md §4 already asserts actually true at the one
+stage that ignores it, and it makes reachability checkable — a guard with no
+declared inputs is a guard nobody can tier.
+
+**DPF rejects:** Tide-style batch merging. DPF's merge volume does not justify
+it, and a batch failure requires bisection to attribute — producing exactly the
+"which change was it" ambiguity that DPF's evidence contract exists to remove.
+The cost Tide amortises is the cloud merge queue, measured here at 10.3 minutes
+and not a bottleneck.
+
+### Bazel — the remote action cache
+
+Bazel keys every action on a hash of its command line, its declared input file
+contents, and its environment. An action whose key has been seen is never
+re-executed; the stored result is returned. Correctness rests entirely on inputs
+being **declared** — an action that reads an undeclared file gets a stale hit,
+which is why Bazel enforces sandboxing.
+
+**DPF adopts:** content-addressed guard results. Once each guard declares its
+inputs (the Prow-derived change above), a guard result can be keyed on the hash
+of the guard file plus the contents of its declared inputs. An unchanged pair is
+a cache hit, and the three-times-per-push duplication collapses to
+once-per-distinct-tree-content. This is the principled version of "stop running
+it three times"; it removes the repetition without removing the assertion, so no
+guarantee is weakened.
+
+**DPF rejects:** remote execution. Verification would depend on an external
+service, which contradicts DPF's local-first operating stance and scored against
+`operational_independence` in the kernel ledger. The cache is local.
+
+**Carried constraint from DPF's own history:** BI-7B249AFE records that
+stripping `.test.mjs` commands from the preflight produced a false green on a
+tree CI failed deterministically, because some of those files are conformance
+assertions reading live repository state rather than unit tests of guard logic.
+Bazel's lesson is the same lesson: caching and skipping are only safe over
+**declared** inputs. Self-test classification is therefore a prerequisite for
+the caching work, never a shortcut around it.
+
+## Decision
+
+Routed through `principle_decide` as an `external_coding_agent` platform
+decision at `high` stakes, four options scored:
+
+| option | composite | outcome |
+| --- | --- | --- |
+| **capacity-honesty-tiering** | **13.654** | **recommended**, margin 4.119, confidence high |
+| capacity-only | 9.535 | insufficient — leaves the retry loop intact |
+| cloud-only-verification | 4.182 | loses `operational_independence` and the evidence contract |
+| reduce-guard-surface | 2.291 | lowest of four |
+
+`commandmentConflict: false`, `autonomyEligible: true`, structured coverage
+strong, zero flipping principles under ±0.1 sensitivity. Ledger
+`DI-0DD38401DF9F`.
+
+Strongest contributors to the recommendation were *Research and Use Standards*,
+*Ground New Work In Existing Platform*, *Single Source of Truth* and *Verify
+substrate before proposing new* — all of which favour the option that reuses the
+already-built classifier, the already-provisioned second slot and the
+already-computed infrastructure classification rather than adding substrate.
+
+**Decision: keep all 95 guards. Attack serialisation, duplication and dishonest
+verdicts.**
+
+### The tiering contract
+
+Four tiers, each defined by what it may depend on. The rule that keeps them
+honest: **a check may only run in a tier whose dependencies it already has.**
+
+| tier | may depend on | budget | contents |
+| --- | --- | --- | --- |
+| **0 — edit time** | the file being edited | instant | prechecks, all four surfaces, no exceptions |
+| **1 — pre-commit** | the working tree | ≤ 30s | derived artifacts, secret scan, private-identity, scoped typecheck |
+| **2 — pre-push** | the tree and the diff | ≤ 60s | guards whose declared inputs intersect the diff, cache-missed only |
+| **3 — sandboxed gate** | a lease, a database, an image | ≤ 15min, ≥ 2 slots | migrations, full suite, production build |
+| **4 — cloud** | nothing local | parallel, off the critical path | everything, unconditionally, as the safety net |
+
+Tier 4 remains complete and unsampled. Every guard still runs on every change
+before it merges — that is what preserves the guarantees. What changes is that
+tiers 2 and 3 stop re-proving what tier 4 will prove anyway, on the one machine
+where proving it costs a queue position.
+
+### Fail-closed on safety, fail-open on infrastructure
+
+Stated as an invariant that a guard can enforce:
+
+> No code path may write a terminal `gatePassed: false` for a condition the
+> runner has classified as infrastructure. A gate that could not run reports
+> `INCONCLUSIVE`, names the recorded reason, and leaves the SHA re-runnable.
+
+Commandment-tier checks — auth, DCO, secret scanning, migration safety — are
+explicitly out of scope for every tiering, sampling and caching change in this
+spec. They run in every tier they run in today.
+
+## Scope — this change
+
+1. **BI-D908DA0A** — governed activation surface for the pool config row; seed
+   an explicit `requestedCapacity: 1` at install so `config-absent` stops being
+   the silent path; expose `effectiveCapacity` and `rollbackReason` on an
+   operator surface. Replay says capacity 2 removes 21.7 of 23.8 queued hours.
+2. **BI-D088D06D** — add the `INCONCLUSIVE` verdict; make the running path in
+   `pregate.mjs` recover as the queued path does. Ships with BI-0F2E42D5 and
+   BI-A7EAB5AA, which fix the same injustice at the evidence-projection layer.
+3. **BI-8CDA7F95** — per-guard declared `inputs`; preflight intersects them
+   against the diff via `ci-change-scope`.
+4. **BI-282AE0BC** — classify self-tests (unit vs conformance), then key guard
+   results on guard-file plus declared-input content.
+5. **BI-C09ECA63** — one declared precheck registry, four thin adapters, and a
+   parity guard that fails on undeclared drift.
+6. **BI-6332DD3D** — resolve the one unreachable guard, and add reachability
+   enforcement so a guard cannot be added to nothing.
+
+Order matters: 1 and 2 are independent and deliver most of the wall-clock; 3 is
+a prerequisite for 4; 5 and 6 are independent.
+
+## Deliberately not in this change
+
+- **No guard is retired.** The inventory recommends keeping 81 of 95 as-is;
+  the remainder move tier, gain a self-test, or record their defect class.
+  `check-obligation-cadence-coverage` is resolved, not deleted.
+- **Commandment-tier checks are untouched** — auth, DCO, secret scanning,
+  migration safety.
+- **The cloud tier is not reduced.** It is the safety net and it is not on the
+  critical path.
+- **Pool capacity above 2.** `LOCAL_CI_MAX_CAPACITY` is 2; the replay shows 2
+  already captures 91% of the available benefit. Raising the constant is a
+  separate decision with its own evidence.
+- **Readiness governance** — see below; it is adjacent and needs its own
+  ratification.
+
+## Adjacent: readiness governance in the merge path
+
+`BI-F0715C9C`, `BI-53C26E60`, `BI-310EC5AF` and `BI-28E8CB88` describe a
+circular blocker: plan-backlog coverage needs an initiative scope baseline, the
+baseline needs an independent spec-approval review, and **71 of 76 seeded
+coworkers have no Principal**, so every independent review lane is structurally
+unsatisfiable. The gate that enforces it regex-matches a Receipt line rather
+than asking the substrate.
+
+While writing this spec, a further finding fell out of running that gate against
+this spec's own plan. `check-plan-backlog-coverage.mjs` decides **whether it
+applies** by string-matching the plan's prose:
+
+```js
+const itemId = text.match(/\*\*Backlog item:\*\*\s*`?(BI-[A-Z0-9-]+)`?/i)?.[1] ?? null;
+if (!itemId) return { ok: true, errors: [] };
+```
+
+The plan accompanying this spec was committed with `Receipt: pending` and no
+`## Backlog coverage` section at all, and the gate reported
+"1 changed plan(s) carry complete coverage evidence. OK." Adding the literal
+string `**Backlog item:**` and changing nothing else flips it to a failure.
+Filed as BI-397EBDD6.
+
+So the same gate is **impossible to satisfy honestly** — BI-F0715C9C, no
+mintable receipt — and **trivial to avoid accidentally**. Both halves have one
+repair: ask the substrate rather than the Markdown.
+
+This spec's position, offered for ratification rather than asserted: **readiness
+governance is an attribute of the backlog item, not a precondition of the merge.**
+Blocking a merge on a reviewer lane that cannot pass is pure latency, and a gate
+satisfied by prose while a real receipt cannot be minted is a gate that
+measures nothing. Moving it to the backlog item asynchronously keeps the
+obligation and removes it from the critical path.
+
+That is a governance change, not a latency fix, so it is named here and left to
+its own decision under EP-129D11FD rather than folded in.
+
+## Verification
+
+- The pool change is proven by the same replay that produced the baseline: seed
+  the row, then re-measure queue-wait percentiles over the following week
+  against the 1053s p90 recorded here. The circuit breaker provides rollback.
+- The `INCONCLUSIVE` change is proven by a test that kills the wrapper on the
+  running path and asserts the SHA remains re-runnable — the queued-path
+  equivalent already exists.
+- Tiering and caching are proven by re-running the preflight against the three
+  PR shapes and asserting entry counts differ, plus a mutation check: perturbing
+  a guard's declared input must produce a cache miss.
+- Surface parity is proven by a guard that diffs the three hook registries and
+  fails on undeclared drift.
+
+The measured baseline these are compared against:
+https://claude.ai/code/artifact/05d0d22a-9fb6-4530-9fad-9baccbfec72c
+
+## Target service level
+
+Stated in plain numbers, because a redesign without a success criterion cannot
+be evaluated:
+
+- **A docs-only change merges in under 20 minutes.**
+- **A source change merges in under 40 minutes.**
+- **No change is ever blocked by an infrastructure verdict.** A gate that could
+  not run says so, and re-runs on the same SHA.
+- **Process overhead falls below 10% of commits**, from the 32.5% measured here.
+- **Surface parity is exact**: every precheck reaches all four surfaces, or its
+  absence is declared.
+
+## Risk
+
+- **Two slots on one box.** Utilisation is 45% and the admission reserve is the
+  calibrated 10 GiB rather than the 16 GiB cgroup ceiling, so two fit in the
+  measured 20.5 GiB of Docker `MemAvailable`. If the calibration is wrong the
+  circuit breaker contracts to 1 automatically — the rollback is the one part of
+  this pilot that already shipped.
+- **A wrong `inputs` declaration produces a false green.** This is the
+  BI-7B249AFE failure mode. Mitigated by tier 4 remaining complete and
+  unconditional: a mis-scoped guard is caught in the cloud before merge, so the
+  worst case is a late failure, never a merged defect.
+- **`INCONCLUSIVE` could mask a real failure** if the classifier is too eager.
+  Mitigated by writing it only where the runner already recorded an
+  infrastructure cause, never as a default for an unexplained exit.
+
+## Rollback
+
+Each item is independently revertible. The pool row can be contracted by the
+existing circuit breaker or deleted, returning to `config-absent`. The
+`INCONCLUSIVE` verdict is additive; consumers unaware of it see the same
+`FAIL`-or-`PASS` set until they opt in. Tiering and caching are keyed by a
+declaration, so removing the declaration restores the current always-run
+behaviour.

--- a/scripts/ci-policy-test-inventory-allowlist.txt
+++ b/scripts/ci-policy-test-inventory-allowlist.txt
@@ -96,6 +96,7 @@ scripts/lib/local-ci-pilot-report.test.mjs
 scripts/lib/local-ci-slot-isolation.test.mjs
 scripts/lib/local-ci-slot-manifest.test.mjs
 scripts/lib/local-ci-stage-receipt.test.mjs
+scripts/lib/local-ci-vitest-selection.test.mjs
 scripts/lib/local-ci-vitest-supervisor.test.mjs
 scripts/lib/local-integration-image-retention.test.mjs
 scripts/lib/local-queue-observer.test.mjs

--- a/scripts/lib/local-ci-vitest-selection.mjs
+++ b/scripts/lib/local-ci-vitest-selection.mjs
@@ -1,0 +1,107 @@
+// Affected-test selection for the local-CI vitest stage (BI-2227C37C).
+//
+// AGENTS.md §4: "Fast local checks (typecheck, lint, affected tests — no
+// Docker) gate the push; the full build is the cloud merge-queue safety net."
+//
+// The stage was doing the opposite. It ran `vitest run` over all 3017 apps/web
+// test files on every push — its own stage name is `exhaustive-vitest` — while
+// holding the single local-integration-ci slot, and the cloud shards the same
+// suite four ways. Measured 2026-08-29: the suite grew 2462 -> 3414 test files
+// in five weeks (+39%), so suite growth converted one-for-one into gate time
+// and, at a fixed capacity of one, into a p90 queue wait of 1053s.
+//
+// Selection is vitest's own `--changed <ref>`, which walks its module graph, so
+// a changed library still pulls in its dependents' tests. It is not a
+// hand-maintained path map that can silently rot.
+//
+// TWO PROPERTIES THIS MUST KEEP:
+//
+//   1. Fail safe. Anything unknown — no base ref, an unreadable diff, a changed
+//      file whose blast radius the module graph cannot see — falls back to the
+//      exhaustive run. Selection narrows only when it is certain it may.
+//   2. The cloud stays exhaustive. This narrows the LOCAL tier only. The
+//      merge-queue safety net still runs every test, sharded, off the critical
+//      path, which is what makes local selection safe rather than a gamble.
+
+/**
+ * Files whose blast radius vitest's module graph cannot see.
+ *
+ * A test runner config, a lockfile, a tsconfig or the Prisma schema can change
+ * the behaviour of tests that never import them, so any of these forces the
+ * exhaustive run. This list is deliberately generous: a wrong narrow is a false
+ * green, and a wrong widen only costs time.
+ */
+export const EXHAUSTIVE_TRIGGER_PATTERNS = Object.freeze([
+  /(^|\/)vitest\.(config|workspace)\.[cm]?[jt]s$/,
+  /(^|\/)tsconfig[^/]*\.json$/,
+  /(^|\/)package\.json$/,
+  /(^|\/)pnpm-lock\.yaml$/,
+  /(^|\/)pnpm-workspace\.yaml$/,
+  /(^|\/)\.npmrc$/,
+  /(^|\/)next\.config\.[cm]?[jt]s$/,
+  /(^|\/)schema\.prisma$/,
+  /(^|\/)prisma\/migrations\//,
+  /(^|\/)test-setup\.[cm]?[jt]sx?$/,
+  /(^|\/)vitest\.setup\.[cm]?[jt]sx?$/,
+  /(^|\/)apps\/web\/test\//,
+  /(^|\/)\.env(\.|$)/,
+]);
+
+/** Opt out of selection entirely, recorded rather than silent. */
+export const EXHAUSTIVE_ENV = "DPF_LOCAL_CI_VITEST_EXHAUSTIVE";
+
+export function exhaustiveTrigger(changedFiles) {
+  for (const file of changedFiles) {
+    const normalized = String(file ?? "").replace(/\\/g, "/").trim();
+    if (!normalized) continue;
+    for (const pattern of EXHAUSTIVE_TRIGGER_PATTERNS) {
+      if (pattern.test(normalized)) return normalized;
+    }
+  }
+  return null;
+}
+
+/**
+ * Decide what this run covers.
+ *
+ * @returns {{ mode: "exhaustive"|"affected", stage: string, extraArgs: string[], reason: string }}
+ */
+export function resolveVitestSelection({
+  changedFiles = null,
+  baseRef = "",
+  env = process.env,
+} = {}) {
+  const exhaustive = (reason) => ({
+    mode: "exhaustive",
+    stage: "exhaustive-vitest",
+    extraArgs: [],
+    reason,
+  });
+
+  const optOut = String(env?.[EXHAUSTIVE_ENV] ?? "").trim();
+  if (optOut) return exhaustive(`opt-out:${optOut}`);
+
+  const base = String(baseRef ?? "").trim();
+  if (!base) return exhaustive("no-base-ref");
+
+  if (!Array.isArray(changedFiles)) return exhaustive("changed-files-unreadable");
+
+  const files = changedFiles
+    .map((file) => String(file ?? "").trim())
+    .filter(Boolean);
+
+  // An empty diff is not permission to run nothing. Something computed the
+  // wrong base, or the push carries no tree change at all; either way the
+  // honest answer is the full suite.
+  if (files.length === 0) return exhaustive("empty-diff");
+
+  const trigger = exhaustiveTrigger(files);
+  if (trigger) return exhaustive(`blast-radius-unbounded:${trigger}`);
+
+  return {
+    mode: "affected",
+    stage: "affected-vitest",
+    extraArgs: [`--changed=${base}`],
+    reason: `changed-since:${base}`,
+  };
+}

--- a/scripts/lib/local-ci-vitest-selection.test.mjs
+++ b/scripts/lib/local-ci-vitest-selection.test.mjs
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  EXHAUSTIVE_ENV,
+  exhaustiveTrigger,
+  resolveVitestSelection,
+} from "./local-ci-vitest-selection.mjs";
+
+const BASE = "origin/main";
+const NO_ENV = {};
+
+test("narrows to the affected suite for an ordinary source diff", () => {
+  const selection = resolveVitestSelection({
+    baseRef: BASE,
+    changedFiles: ["apps/web/lib/nonprod/local-ci-pool-policy.ts"],
+    env: NO_ENV,
+  });
+  assert.equal(selection.mode, "affected");
+  assert.equal(selection.stage, "affected-vitest");
+  assert.deepEqual(selection.extraArgs, [`--changed=${BASE}`]);
+});
+
+test("falls back to exhaustive when the base ref is missing", () => {
+  const selection = resolveVitestSelection({
+    baseRef: "",
+    changedFiles: ["apps/web/lib/foo.ts"],
+    env: NO_ENV,
+  });
+  assert.equal(selection.mode, "exhaustive");
+  assert.equal(selection.stage, "exhaustive-vitest");
+  assert.deepEqual(selection.extraArgs, []);
+  assert.equal(selection.reason, "no-base-ref");
+});
+
+test("an unreadable diff is exhaustive, never empty", () => {
+  // changedFilesAgainst returns null when git fails. Reading that as "nothing
+  // changed" would run zero tests and report a pass.
+  const selection = resolveVitestSelection({
+    baseRef: BASE,
+    changedFiles: null,
+    env: NO_ENV,
+  });
+  assert.equal(selection.mode, "exhaustive");
+  assert.equal(selection.reason, "changed-files-unreadable");
+});
+
+test("an empty diff is exhaustive, not a licence to run nothing", () => {
+  const selection = resolveVitestSelection({
+    baseRef: BASE,
+    changedFiles: [],
+    env: NO_ENV,
+  });
+  assert.equal(selection.mode, "exhaustive");
+  assert.equal(selection.reason, "empty-diff");
+});
+
+test("a whitespace-only file list is still treated as empty", () => {
+  const selection = resolveVitestSelection({
+    baseRef: BASE,
+    changedFiles: ["", "   ", null],
+    env: NO_ENV,
+  });
+  assert.equal(selection.mode, "exhaustive");
+  assert.equal(selection.reason, "empty-diff");
+});
+
+test("files whose blast radius the module graph cannot see force exhaustive", () => {
+  const unbounded = [
+    "apps/web/vitest.config.ts",
+    "tsconfig.json",
+    "apps/web/tsconfig.json",
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    ".npmrc",
+    "apps/web/next.config.mjs",
+    "packages/db/prisma/schema.prisma",
+    "packages/db/prisma/migrations/20260829_x/migration.sql",
+    "apps/web/test-setup.ts",
+    "apps/web/vitest.setup.ts",
+    "apps/web/test/helpers.ts",
+    ".env.local",
+  ];
+  for (const file of unbounded) {
+    const selection = resolveVitestSelection({
+      baseRef: BASE,
+      changedFiles: ["apps/web/lib/ordinary.ts", file],
+      env: NO_ENV,
+    });
+    assert.equal(selection.mode, "exhaustive", `${file} should force exhaustive`);
+    assert.match(selection.reason, /^blast-radius-unbounded:/);
+  }
+});
+
+test("windows path separators are normalized before matching", () => {
+  assert.equal(
+    exhaustiveTrigger(["packages\\db\\prisma\\schema.prisma"]),
+    "packages/db/prisma/schema.prisma",
+  );
+});
+
+test("a lookalike path does not trigger exhaustive", () => {
+  // `my-package.json` and `tsconfig-notes.md` must not be read as the real
+  // config files; an over-eager trigger silently returns the stage to
+  // always-exhaustive and the regression would be invisible.
+  assert.equal(
+    exhaustiveTrigger([
+      "apps/web/lib/my-package.json.ts",
+      "docs/tsconfig-notes.md",
+      "apps/web/lib/vitest-helpers.ts",
+    ]),
+    null,
+  );
+});
+
+test("the opt-out is honoured and records its reason", () => {
+  const selection = resolveVitestSelection({
+    baseRef: BASE,
+    changedFiles: ["apps/web/lib/foo.ts"],
+    env: { [EXHAUSTIVE_ENV]: "verifying a suspected selection miss" },
+  });
+  assert.equal(selection.mode, "exhaustive");
+  assert.equal(
+    selection.reason,
+    "opt-out:verifying a suspected selection miss",
+  );
+});
+
+test("an empty opt-out value does not disable selection", () => {
+  const selection = resolveVitestSelection({
+    baseRef: BASE,
+    changedFiles: ["apps/web/lib/foo.ts"],
+    env: { [EXHAUSTIVE_ENV]: "  " },
+  });
+  assert.equal(selection.mode, "affected");
+});
+
+test("every returned shape carries the four fields callers read", () => {
+  for (const input of [
+    { baseRef: BASE, changedFiles: ["apps/web/lib/foo.ts"] },
+    { baseRef: "", changedFiles: null },
+  ]) {
+    const selection = resolveVitestSelection({ ...input, env: NO_ENV });
+    for (const key of ["mode", "stage", "extraArgs", "reason"]) {
+      assert.ok(key in selection, `missing ${key}`);
+    }
+    assert.ok(Array.isArray(selection.extraArgs));
+    assert.ok(selection.reason.length > 0);
+  }
+});

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -342,6 +342,10 @@ export function createLocalIntegrationPlan(input) {
       HOST_TEST_INITIAL_WORKERS,
       "--retry-workers",
       HOST_TEST_RETRY_WORKERS,
+      // The integration base, so the stage can narrow to the tests this
+      // candidate can reach (BI-2227C37C). Absent or unreadable => exhaustive.
+      "--base",
+      baseRef,
     ],
     productionBuildCommand,
   ];

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -97,7 +97,7 @@ describe("createLocalIntegrationPlan", () => {
       "node scripts/check-doc-links.mjs",
       "node scripts/check-guards.mjs",
       "env NODE_OPTIONS=--max-old-space-size=16384 node scripts/local-ci-typecheck-runner.mjs",
-      "env NODE_OPTIONS=--no-experimental-webstorage node scripts/local-ci-vitest-runner.mjs --initial-workers 4 --retry-workers 2",
+      "env NODE_OPTIONS=--no-experimental-webstorage node scripts/local-ci-vitest-runner.mjs --initial-workers 4 --retry-workers 2 --base origin/main",
       "env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=16384 pnpm --filter web exec next build",
     ]);
   });
@@ -141,7 +141,7 @@ describe("createLocalIntegrationPlan", () => {
     });
 
     assert.ok(plan.commands.map((command) => command.join(" ")).includes(
-      "env NODE_OPTIONS=--no-experimental-webstorage node scripts/local-ci-vitest-runner.mjs --initial-workers 4 --retry-workers 2",
+      "env NODE_OPTIONS=--no-experimental-webstorage node scripts/local-ci-vitest-runner.mjs --initial-workers 4 --retry-workers 2 --base origin/main",
     ));
   });
 
@@ -158,7 +158,7 @@ describe("createLocalIntegrationPlan", () => {
     ));
     assert.equal(
       vitestCommand,
-      "env NODE_OPTIONS=--no-experimental-webstorage node scripts/local-ci-vitest-runner.mjs --initial-workers 4 --retry-workers 2",
+      "env NODE_OPTIONS=--no-experimental-webstorage node scripts/local-ci-vitest-runner.mjs --initial-workers 4 --retry-workers 2 --base origin/main",
     );
   });
 

--- a/scripts/local-ci-pool-policy.test.mjs
+++ b/scripts/local-ci-pool-policy.test.mjs
@@ -156,7 +156,11 @@ test("admission reserves the host-native stage envelope above the safety floor",
     },
   };
 
-  for (const availableMemoryBytes of [12 * gib, 14 * gib]) {
+  // Expressed against the calibrated host-stage reserve rather than a literal,
+  // so recalibrating it (BI-E58B57EC) cannot silently turn a refusal into an
+  // admission. floor + reserve - 1 is one byte short of a single stage.
+  const stage = SLOT_RESOURCES.hostStagePolicy.admissionReserveBytes;
+  for (const availableMemoryBytes of [8 * gib, 8 * gib + stage - 1]) {
     const resolved = resolveLocalCiPoolPolicy({
       configValue,
       host: {
@@ -179,7 +183,7 @@ test("admission reserves the host-native stage envelope above the safety floor",
     configValue,
     host: {
       ...SAFE_HOST,
-      availableMemoryBytes: 20 * gib,
+      availableMemoryBytes: 8 * gib + stage,
       dockerAvailableMemoryBytes: 40 * gib,
       builderMemoryUsageBytes: [0, 0],
     },
@@ -195,7 +199,7 @@ test("admission reserves the host-native stage envelope above the safety floor",
     configValue,
     host: {
       ...SAFE_HOST,
-      availableMemoryBytes: 24 * gib,
+      availableMemoryBytes: 8 * gib + 2 * stage,
       dockerAvailableMemoryBytes: 40 * gib,
       builderMemoryUsageBytes: [0, 0],
     },
@@ -336,7 +340,10 @@ test("admission intersects Docker and host-stage capacity instead of returning t
     },
     host: {
       ...SAFE_HOST,
-      availableMemoryBytes: 14 * gib,
+      // One byte short of a single host-native stage above the floor, from the
+      // manifest so recalibration (BI-E58B57EC) cannot make this admit.
+      availableMemoryBytes:
+        8 * gib + SLOT_RESOURCES.hostStagePolicy.admissionReserveBytes - 1,
       dockerAvailableMemoryBytes: 20 * gib,
       builderMemoryUsageBytes: [0, 0],
     },

--- a/scripts/local-ci-vitest-runner.mjs
+++ b/scripts/local-ci-vitest-runner.mjs
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 
 import { runVitestWithRecovery } from "./lib/local-ci-vitest-supervisor.mjs";
 import { createObservedProcessRunner } from "./lib/local-ci-process-observer.mjs";
+import { resolveVitestSelection } from "./lib/local-ci-vitest-selection.mjs";
 import {
   classifyPriorStage,
   createStageReceiptWriter,
@@ -40,6 +41,24 @@ function resolveGit(ref) {
     windowsHide: true,
   });
   return result.status === 0 ? result.stdout.trim() : null;
+}
+
+/**
+ * Files this candidate changes relative to the integration base.
+ *
+ * Returns null — never an empty list — when the diff cannot be computed, so
+ * selection falls back to the exhaustive run rather than reading "no changes"
+ * out of a failed git call (BI-2227C37C).
+ */
+export function changedFilesAgainst(baseRef, { spawn = spawnSync } = {}) {
+  if (!baseRef) return null;
+  const result = spawn(
+    "git",
+    ["diff", "--name-only", `${baseRef}...HEAD`],
+    { encoding: "utf8", shell: false, windowsHide: true },
+  );
+  if (result.status !== 0 || typeof result.stdout !== "string") return null;
+  return result.stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
 }
 
 function processAlive(pid) {
@@ -98,8 +117,15 @@ function latestExecutionProfile(receipt) {
   return receipt?.executionProfile ?? null;
 }
 
-export function recoveryReceiptForIdentity({ receipt, identity }) {
-  return receipt?.stage === "exhaustive-vitest"
+export function recoveryReceiptForIdentity({
+  receipt,
+  identity,
+  stage = "exhaustive-vitest",
+}) {
+  // The stage name carries the coverage mode, and the identity carries the
+  // command (which includes --changed). A narrower prior run must never satisfy
+  // a wider one, so both have to match.
+  return receipt?.stage === stage
     && stageIdentityMatches(receipt.identity, identity)
     ? receipt
     : null;
@@ -138,11 +164,12 @@ export function createAttemptRunner({
       lastCompletedTest: lastCompletedTestLine(progress.outputTail ?? ""),
     }),
   });
-  return function runAttempt({ workers, attempt }) {
+  return function runAttempt({ workers, attempt, extraArgs = [] }) {
     const args = [
         "--filter", "web", "exec", "vitest", "run",
         `--maxWorkers=${workers}`,
         "--reporter=verbose",
+        ...extraArgs,
       ];
     return runObservedProcess({
       command: "pnpm",
@@ -166,15 +193,32 @@ async function main() {
   );
   const startedAt = new Date().toISOString();
   let latestAttempts = [];
+
+  // BI-2227C37C: narrow the LOCAL tier to the tests the diff can reach. The
+  // cloud still runs everything, sharded, so a miss here is caught before merge
+  // rather than after. Selection fails safe to the exhaustive run — see
+  // lib/local-ci-vitest-selection.mjs for the conditions.
+  const baseRef = valueAfter("--base", "");
+  const selection = resolveVitestSelection({
+    baseRef,
+    changedFiles: changedFilesAgainst(baseRef),
+  });
+  process.stdout.write(
+    `[local-ci-vitest] coverage=${selection.mode} (${selection.reason})\n`,
+  );
+
   const identity = {
     integrationTreeSha: resolveGit("HEAD^{tree}"),
-    command: `pnpm --filter web exec vitest run --maxWorkers=${initialWorkers} --reporter=verbose`,
+    command: [
+      `pnpm --filter web exec vitest run --maxWorkers=${initialWorkers} --reporter=verbose`,
+      ...selection.extraArgs,
+    ].join(" "),
     maxDurationMs,
   };
   const priorReceipt = readStageReceipt(diagnosticsPath);
   if (reusablePassedStage({
     receipt: priorReceipt,
-    stage: "exhaustive-vitest",
+    stage: selection.stage,
     identity,
   })) {
     markStageReceiptReused({ path: diagnosticsPath, receipt: priorReceipt });
@@ -186,6 +230,7 @@ async function main() {
   const matchingPriorReceipt = recoveryReceiptForIdentity({
     receipt: priorReceipt,
     identity,
+    stage: selection.stage,
   });
   const priorDisposition = matchingPriorReceipt?.retryExhausted === true
     ? "retry-exhausted"
@@ -201,7 +246,7 @@ async function main() {
   });
   const receipt = createStageReceiptWriter({
     path: diagnosticsPath,
-    stage: "exhaustive-vitest",
+    stage: selection.stage,
     identity,
   });
   receipt.start({
@@ -253,7 +298,7 @@ async function main() {
           workers,
         },
       });
-      return observedAttempt({ workers, attempt });
+      return observedAttempt({ workers, attempt, extraArgs: selection.extraArgs });
     },
     onAttempt: async (attempt) => {
       latestAttempts = [...latestAttempts, attempt];


### PR DESCRIPTION
Small correct changes had grown to days. The working hypothesis was 53 new guards in six weeks against a one-slot pool. I measured before designing, and the guard half does not survive.

Full measured baseline, including the 95-guard inventory: https://claude.ai/code/artifact/05d0d22a-9fb6-4530-9fad-9baccbfec72c

## What the measurement says

| | measured |
| --- | --- |
| All 95 `scripts/check-*.mjs` guards, serial | **76.3s** |
| The 55 guards added since 2026-07-18 | **17.9s** |
| Median hold of the single local-CI slot | **776s** |
| p90 queue wait before that run starts | **1053s** |
| Cloud CI (not the bottleneck) | 10.1 min median, p90 10.7 |

Guards are **9.8%** of one slot hold. Retiring every guard added since July returns eighteen seconds. **No guard is retired in this PR** — the inventory recommends keeping 81 of 95 exactly as they are.

## What actually changed five weeks ago

The single slot is **not** a regression. Before the two-slot pilot (`35cddc6be5`, 2026-07-30) `environment-lease.ts` hard-coded `NONPROD_SLOT_KEYS = ["slot-0"]` with the comment *"Phase 1 deliberately retains singleton capacity."* Capacity has been 1 throughout. Workrooms are not implicated either — no Workroom path claims a `local-integration-ci` lease.

What grew is the work inside the slot:

| date | `*.test.ts(x)` files |
| --- | ---: |
| 2026-07-24 | 2462 |
| 2026-08-09 | 3000 |
| 2026-08-28 | **3414** |

**+39% in five weeks.** The local vitest stage was named `exhaustive-vitest` and ran the full suite unsharded on every push — zero hits for `changed|affected|related|shard` — while the cloud shards the same suite four ways. So suite growth converted one-for-one into gate time, and queue wait is non-linear in utilisation. Merges to `main` fell from **391/week (week 28) to 166/week (week 34)**.

## Three commits

### 1. `docs(delivery)` — the measured baseline

Spec, phased plan, and an audit of all 95 guards with added date, provenance, per-run cost, stage membership and a recommendation per row. Decision routed through `principle_decide` at high stakes (`DI-0DD38401DF9F`): `capacity-honesty-tiering`, composite 13.654, margin 4.119, no commandment conflict. The rejected `reduce-guard-surface` scored lowest of four at 2.291.

### 2. `feat(local-ci)` — capacity follows the installation

The pool shipped with a contraction path and no activation path: the only writer of `local_ci.sandbox_pool` is the circuit breaker, which moves 2 → 1. Nothing ever created the row.

Seeding it by hand would keep the defect — a consumer never finds the switch, and a developer hand-authors JSON to get capacity their hardware already supports. Widening the shipped envelope was also wrong: this host is dogfooding the Docker image install path, and that envelope is the thing under test.

Capacity is a property of the installation, and the installation already declares what decides it (`environment-class: development`, `operating-intent: evolve-dpf`). A new precedence tier sits beneath the explicit row: break-glass env → config row → **installation-profile** → compatibility singleton. Silence resolves conservatively, since `UNDECLARED_ENVIRONMENT_CLASS` is `production`.

Deriving capacity alone was not enough. Two memory tests gate admission and read **different machines**: the builder test reads the Docker VM (reserve already calibrated 16 → 10 GiB), the host-stage test reads Windows and carried **no calibration at all** — a flat 8 GiB. Measured peak host-side node working set during the heaviest stage: **2.27 GiB**, a 3.5× over-reservation and the sole reason a 63.7 GB host admitted one slot. Now calibrated to 6 GiB, 2.6× the measured peak.

Verified against this installation's live rows, config row still absent: `effectiveCapacity: 2`, `slotKeys: ["slot-0","slot-1"]`, `rollbackReason: null`.

### 3. `perf(local-ci)` — gate on the tests the diff can reach

AGENTS.md §4 already said affected tests gate the push and the full build is the cloud safety net. The stage did the opposite.

| coverage | test files | tests | wall clock |
| --- | ---: | ---: | ---: |
| exhaustive | 3046 | 26,437 | **319s** |
| affected (this branch's 10-file diff) | 430 | 4,273 | **97s** |

319s was **41%** of the 776s hold. Selection cuts it 70%, and the module graph correctly pulled in 430 files rather than the 3 test files edited.

Selection is vitest's own `--changed`, not a hand-maintained path map. It **fails safe to exhaustive** on: no base ref, unreadable diff, empty diff, or a changed file whose blast radius the module graph cannot see (vitest/tsconfig/package.json/lockfile/next.config/prisma schema/migrations/test-setup/env). `changedFilesAgainst` returns `null` rather than `[]` on a failed git call, so "git broke" can never read as "nothing changed" and run zero tests. The stage receipt carries the coverage mode in its stage name and `--changed` in its identity, so a narrower prior run can never satisfy a wider one on reuse or recovery.

`DPF_LOCAL_CI_VITEST_EXHAUSTIVE="<why>"` forces the full run and records the reason.

**The cloud tier stays exhaustive and sharded.** That is what makes local selection safe rather than a gamble.

## Guarantees

Nothing here weakens a gate. Auth, DCO, secret scanning and migration safety are untouched. The cloud runs every test on every change before it merges, as it did before. What changed is that the local tier stops re-proving what the cloud will prove anyway, on the one machine where proving it costs a queue position.

## Verification

- 20 capacity tests: every install shape, operator override, host clamp, closed-admission.
- 11 selection tests: each fail-safe branch, the lookalike-path case, the opt-out.
- `lib/nonprod` 62 passed · `local-ci-vitest-runner` 13 passed · `local-integration-ci` 27 passed · `local-ci-pool-policy` 18 passed.
- `web` typecheck clean. Guard-parity preflight: **59 guards clean**.
- Capacity resolution executed against the live installation's real `PlatformConfig` rows.

Two pre-existing fixtures asserted host-stage refusals against the literal 8 GiB and began *admitting* once it was calibrated — the false green this change could have introduced. Both now derive from `hostStagePolicy.admissionReserveBytes`.

## Deliberately not here

- **Raising `--maxWorkers` from 4** on a 12-CPU VM. Likely worth it, but the memory and throughput trade against two admitted slots is unmeasured, and an unmeasured change is what produced this problem. `BI-2227C37C`.
- **The CPU-count admission test**, which does not exist, and the Windows `sustainedCpuPercent` probe that reads 0% forever because `os.loadavg()` returns `[0,0,0]`. `BI-E58B57EC`.
- **The `INCONCLUSIVE` verdict** and the running-path recovery asymmetry. `BI-D088D06D`, with `BI-0F2E42D5`/`BI-A7EAB5AA` one layer down.
- **Preflight tiering and guard-result caching.** `BI-8CDA7F95`, `BI-282AE0BC`.
- **Any AGENTS.md change.** The one real gap — a gate that could not run is not a verdict — is proposed but not made; the instruction plane is a shrink-only byte ratchet, so it needs a paid-for offset and a founder decision.

## Note on the plan's coverage receipt

`docs/superpowers/plans/2026-08-29-change-delivery-latency-tiering.md` carries `Receipt: pending` with an explanatory note rather than a minted receipt. `record_plan_backlog_coverage` requires a `repo-blob-at-commit` with a provider-verified blob id, which cannot exist until the plan is pushed. Recorded honestly rather than as a placeholder that reads satisfied. Separately, `BI-397EBDD6` documents that this gate is opt-in by prose — a plan omitting the literal `**Backlog item:**` string is exempt from it entirely, proven against this very plan.

Epic `EP-ABB3AC9D` · Workroom `WC-038203B7` · Ledger `DI-0DD38401DF9F`

Filed from this investigation: `BI-2227C37C`, `BI-E58B57EC`, `BI-D088D06D`, `BI-8CDA7F95`, `BI-282AE0BC`, `BI-C09ECA63`, `BI-6332DD3D`, `BI-397EBDD6`, `BI-2C0A01CD`. `BI-D908DA0A` was corrected — its previous body claimed a Docker VM memory ceiling that the calibrated reserve disproves.
