### PR TITLE
fix(seed): scope industry reference models to the install's archetype (BI-4F186358)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,5 +28,13 @@ docs/Reference/
 # IT4IT functional criteria workbook is needed at seed time; the rest of
 # docs/Reference/ is large binary content we intentionally exclude.
 !docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx
+# The BIAN Service Landscape is read at seed time too, on a BANKING install
+# (seed-ea-reference-models.ts gates the import on the install's archetype).
+# It was excluded, so seedBianReferenceModel's readFileSync always threw, was
+# swallowed by its own catch, and the model imported zero elements on every
+# install including the banking ones it exists for. 81 KB of JSON, not the
+# large binary content this block is aimed at.
+!docs/Reference/bian/
+!docs/Reference/bian/bian-v14-service-landscape.json
 docs/architecture/
 apps/mobile/

--- a/Dockerfile
+++ b/Dockerfile
@@ -197,6 +197,8 @@ COPY config/ ./config/
 # seed-ea-reference-models.ts. The rest of docs/Reference/ is large
 # binary content not needed in the image.
 COPY docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx ./docs/Reference/
+# The BIAN Service Landscape, read at seed time on a banking install.
+COPY docs/Reference/bian/bian-v14-service-landscape.json ./docs/Reference/bian/
 # The workbook is tracked in Git LFS, so a checkout without `lfs: true` copies a
 # ~130-byte pointer stub here instead of the real file. That shipped: every
 # consumer install's eaReferenceModels seed step failed with "invalid zip data"
@@ -214,6 +216,19 @@ RUN head -c 2 docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx | grep -q '
       echo "It is almost certainly an unmaterialized Git LFS pointer. Check out with lfs: true"; \
       echo "(or run 'git lfs pull') before building this image."; \
       head -c 64 docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx; \
+      exit 1; \
+    }
+# Same rule for the BIAN landscape: assert the bytes where they enter the
+# artifact. This one is plain JSON (not LFS), and it was simply absent from the
+# image for its whole life — seedBianReferenceModel caught the read error and
+# returned, so a banking install imported zero Service Domains and the seed's
+# own row-count guard fired into a non-fatal catch. A missing or truncated file
+# must fail the build, not the bank.
+RUN head -c 1 docs/Reference/bian/bian-v14-service-landscape.json | grep -q '{' || { \
+      echo "ERROR: docs/Reference/bian/bian-v14-service-landscape.json is not a JSON object."; \
+      echo "seed-ea-reference-models.ts reads this at seed time on a banking install;"; \
+      echo "a missing or truncated file imports zero BIAN Service Domains."; \
+      head -c 64 docs/Reference/bian/bian-v14-service-landscape.json; \
       exit 1; \
     }
 RUN pnpm install --frozen-lockfile

--- a/packages/db/src/ea-reference-model-applicability.test.ts
+++ b/packages/db/src/ea-reference-model-applicability.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { referenceModelAppliesToInstall } from "./seed-ea-reference-models.js";
+
+// BI-DDB48B04 follow-on. The eaReferenceModels seed used to import the BIAN
+// Service Landscape and then ASSERT a non-zero element count for it on every
+// install, regardless of archetype. Since seed steps are caught and logged
+// rather than fatal (seed.ts `step()`), that assertion failed silently on
+// every non-banking install, on every boot and every upgrade.
+//
+// Applicability is expressed the way RegulationApplicability.archetypes already
+// expresses it — entries match either an archetype CATEGORY slug or a specific
+// archetype id — so there is one rule for "is this vertical content mine?".
+const ARCHETYPES = {
+  bian_service_landscape_v14_0_0: ["banking-financial-services"],
+  // A finer-grained model, to prove id-level matching is not category-only.
+  ncua_credit_union_pack: ["credit-union"],
+} as const;
+
+describe("referenceModelAppliesToInstall", () => {
+  it("applies a universal model to every install", () => {
+    // IT4IT declares no archetypes: IT management describes any org running IT.
+    for (const install of [
+      { category: "software-platform", archetypeId: "software-platform" },
+      { category: "banking-financial-services", archetypeId: "community-bank" },
+      { category: null, archetypeId: null },
+    ]) {
+      expect(referenceModelAppliesToInstall("it4it_v3_0_1", install, ARCHETYPES)).toBe(true);
+    }
+  });
+
+  it("applies a banking model on a banking-category install", () => {
+    expect(
+      referenceModelAppliesToInstall(
+        "bian_service_landscape_v14_0_0",
+        { category: "banking-financial-services", archetypeId: "community-bank" },
+        ARCHETYPES,
+      ),
+    ).toBe(true);
+  });
+
+  // The reported case: this operator install is a software platform and was
+  // asserting a banking hierarchy.
+  it("does NOT apply a banking model on a software-platform install", () => {
+    expect(
+      referenceModelAppliesToInstall(
+        "bian_service_landscape_v14_0_0",
+        { category: "software-platform", archetypeId: "software-platform" },
+        ARCHETYPES,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not apply a banking model to any other archetype", () => {
+    for (const category of ["dry-cleaning", "field-service", "education-training", "beauty-personal-care"]) {
+      expect(
+        referenceModelAppliesToInstall(
+          "bian_service_landscape_v14_0_0",
+          { category, archetypeId: category },
+          ARCHETYPES,
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("matches on a specific archetype id, not only the category", () => {
+    expect(
+      referenceModelAppliesToInstall(
+        "ncua_credit_union_pack",
+        { category: "banking-financial-services", archetypeId: "credit-union" },
+        ARCHETYPES,
+      ),
+    ).toBe(true);
+    // Same category, different archetype id — must NOT match.
+    expect(
+      referenceModelAppliesToInstall(
+        "ncua_credit_union_pack",
+        { category: "banking-financial-services", archetypeId: "community-bank" },
+        ARCHETYPES,
+      ),
+    ).toBe(false);
+  });
+
+  // Setup has not run yet. Treat as not-applicable rather than applicable:
+  // seeding a banking hierarchy onto an install that has not said it is a bank
+  // is the defect being fixed. The seed is idempotent and re-runs every boot,
+  // so an install that later declares banking picks it up.
+  it("treats an undeclared archetype as not applicable for industry models", () => {
+    expect(
+      referenceModelAppliesToInstall(
+        "bian_service_landscape_v14_0_0",
+        { category: null, archetypeId: null },
+        ARCHETYPES,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/db/src/seed-ea-reference-models.test.ts
+++ b/packages/db/src/seed-ea-reference-models.test.ts
@@ -57,6 +57,12 @@ vi.mock("./client.js", () => ({
     eaReferenceModel: { upsert: vi.fn() },
     eaReferenceModelArtifact: { upsert: vi.fn() },
     eaReferenceModelElement: { upsert: vi.fn(), count: vi.fn() },
+    // BI-DDB48B04 follow-on: the seed now resolves the install's archetype to
+    // decide whether an industry-specific reference model applies. A mock that
+    // omits these throws "Cannot read properties of undefined" from inside the
+    // seed, which reads as a seed bug rather than a stale fixture.
+    storefrontConfig: { findFirst: vi.fn() },
+    storefrontArchetype: { findUnique: vi.fn() },
   },
 }));
 
@@ -89,7 +95,17 @@ const mockPrisma = prisma as unknown as {
   eaReferenceModel: { upsert: ReturnType<typeof vi.fn> };
   eaReferenceModelArtifact: { upsert: ReturnType<typeof vi.fn> };
   eaReferenceModelElement: { upsert: ReturnType<typeof vi.fn>; count: ReturnType<typeof vi.fn> };
+  storefrontConfig: { findFirst: ReturnType<typeof vi.fn> };
+  storefrontArchetype: { findUnique: ReturnType<typeof vi.fn> };
 };
+
+/** Declare the install's setup-chosen archetype for a test. */
+function givenInstallArchetype(archetype: { archetypeId: string; category: string } | null): void {
+  mockPrisma.storefrontConfig.findFirst.mockResolvedValue(
+    archetype ? { archetypeId: "storefront-config-cuid" } : null,
+  );
+  mockPrisma.storefrontArchetype.findUnique.mockResolvedValue(archetype);
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -110,6 +126,10 @@ beforeEach(() => {
   // existing tests don't need to know about the assertion unless they're
   // specifically exercising it.
   mockPrisma.eaReferenceModelElement.count.mockResolvedValue(1);
+  // These cases assert the BIAN hierarchy IS imported, so they describe a
+  // banking install. Non-banking scoping is covered in
+  // ea-reference-model-applicability.test.ts and by the case at the end here.
+  givenInstallArchetype({ archetypeId: "community-bank", category: "banking-financial-services" });
 
   mockReadWorkbook.mockResolvedValue([
     {
@@ -233,5 +253,95 @@ describe("seedEaReferenceModels", () => {
     // tags like @v7.0.0 (#2251). Match any tag version (major or exact) so bumps
     // stay green while the LFS wiring stays enforced.
     expect(workflow).toMatch(/uses:\s*actions\/checkout@v[\d.]+\s*\n\s*with:\s*\n(?:\s*#.*\n)*\s*lfs:\s*true/);
+  });
+});
+
+// BI-DDB48B04 follow-on — the reported defect, end to end through the seed.
+//
+// The eaReferenceModels step imported the BIAN Service Landscape and then
+// asserted a non-zero element count for it on EVERY install. seed.ts `step()`
+// catches and logs rather than aborting, so on a software-platform install the
+// step threw and failed silently on every boot and every upgrade — the same
+// "reports success while importing nothing" shape the assertion exists to
+// prevent, inverted into an assertion asserting the wrong thing.
+describe("industry scoping of reference models", () => {
+  // The shared fixture resolves BOTH models to the id "model-1", which makes
+  // any per-model assertion vacuous (a scoping bug still passes). These cases
+  // are specifically about which model got what, so they need distinct ids.
+  const IT4IT_ID = "it4it-model";
+  const BIAN_ID = "bian-model";
+
+  function givenDistinctModelIds(): void {
+    mockPrisma.eaReferenceModel.upsert.mockImplementation(
+      async (args: { where: { slug: string } }) => ({
+        id: args.where.slug.startsWith("bian") ? BIAN_ID : IT4IT_ID,
+      }),
+    );
+    // IT4IT imported rows; BIAN has none because it was never imported.
+    mockPrisma.eaReferenceModelElement.count.mockImplementation(
+      async (args: { where: { modelId: string } }) => (args.where.modelId === IT4IT_ID ? 1 : 0),
+    );
+  }
+
+  /** Element rows written against the BIAN model id. */
+  function bianElementUpserts(): unknown[] {
+    return mockPrisma.eaReferenceModelElement.upsert.mock.calls.filter((call: unknown[]) => {
+      const args = call[0] as { where: { modelId_slug: { modelId: string } } };
+      return args.where.modelId_slug.modelId === BIAN_ID;
+    });
+  }
+
+  it("does not import or assert BIAN on a software-platform install", async () => {
+    givenInstallArchetype({ archetypeId: "software-platform", category: "software-platform" });
+    givenDistinctModelIds();
+
+    // Under the old unconditional assertion, a zero BIAN count threw here.
+    await expect(seedEaReferenceModels()).resolves.not.toThrow();
+    expect(bianElementUpserts()).toHaveLength(0);
+  });
+
+  it("imports BIAN on a banking install", async () => {
+    givenInstallArchetype({ archetypeId: "community-bank", category: "banking-financial-services" });
+    mockPrisma.eaReferenceModel.upsert.mockImplementation(
+      async (args: { where: { slug: string } }) => ({
+        id: args.where.slug.startsWith("bian") ? BIAN_ID : IT4IT_ID,
+      }),
+    );
+    mockPrisma.eaReferenceModelElement.count.mockResolvedValue(1);
+
+    await seedEaReferenceModels();
+    expect(bianElementUpserts().length).toBeGreaterThan(0);
+  });
+
+  it("still catches a genuinely empty BIAN import on a banking install", async () => {
+    givenInstallArchetype({ archetypeId: "community-bank", category: "banking-financial-services" });
+    mockPrisma.eaReferenceModel.upsert.mockImplementation(
+      async (args: { where: { slug: string } }) => ({
+        id: args.where.slug.startsWith("bian") ? BIAN_ID : IT4IT_ID,
+      }),
+    );
+    // IT4IT fine, BIAN empty — the case the assertion exists for must still fire.
+    mockPrisma.eaReferenceModelElement.count.mockImplementation(
+      async (args: { where: { modelId: string } }) => (args.where.modelId === IT4IT_ID ? 1 : 0),
+    );
+
+    await expect(seedEaReferenceModels()).rejects.toThrow(/BIAN Service Landscape reference model imported zero/);
+  });
+
+  // The catalogue row is always upserted, so a non-banking install can still
+  // see that BIAN exists and what industry it serves — matching how
+  // seed-banking-compliance.ts seeds banking regulations everywhere and scopes
+  // them at consumption. Only the element payload is gated.
+  it("still records the BIAN catalogue entry on a non-banking install", async () => {
+    givenInstallArchetype({ archetypeId: "software-platform", category: "software-platform" });
+    givenDistinctModelIds();
+
+    await seedEaReferenceModels();
+
+    const seededBianCatalogue = mockPrisma.eaReferenceModel.upsert.mock.calls.some((call: unknown[]) => {
+      const args = call[0] as { create?: { primaryIndustry?: string } };
+      return args.create?.primaryIndustry === "banking-financial-services";
+    });
+    expect(seededBianCatalogue).toBe(true);
   });
 });

--- a/packages/db/src/seed-ea-reference-models.ts
+++ b/packages/db/src/seed-ea-reference-models.ts
@@ -168,6 +168,71 @@ const BIAN_SD_TO_CAPABILITY_KEY: Readonly<Record<string, string>> = {
   "Fraud Resolution": "bian-fraud-resolution",
 };
 
+/**
+ * Which archetypes an industry-specific reference model serves.
+ *
+ * Entries may be archetype CATEGORY slugs (`banking-financial-services`) or
+ * specific archetype ids (`credit-union`), matching either — the same contract
+ * `RegulationApplicability.archetypes` already uses, so an operator reads one
+ * rule for "is this vertical content mine?", not two.
+ *
+ * An empty/absent list means universal: IT4IT describes IT management for any
+ * organisation that runs IT, which is every install.
+ */
+const REFERENCE_MODEL_ARCHETYPES: Readonly<Record<string, readonly string[]>> = {
+  bian_service_landscape_v14_0_0: ["banking-financial-services"],
+};
+
+/** The install's declared archetype, as category slug + specific archetype id. */
+interface InstallArchetype {
+  category: string | null;
+  archetypeId: string | null;
+}
+
+/**
+ * Read the install's setup-chosen archetype. `StorefrontConfig.archetypeId` is a
+ * cuid FK, not a slug, so the join to StorefrontArchetype is required to reach
+ * the category/id slugs the applicability lists are written in.
+ *
+ * Returns nulls when setup has not run yet. That is treated as "not applicable"
+ * below rather than "applicable": seeding a banking hierarchy onto an install
+ * that has not said it is a bank is the defect being fixed. The seed is
+ * idempotent and runs on every boot and upgrade, so an install that later
+ * declares banking imports the hierarchy on its next seed.
+ */
+async function resolveInstallArchetype(): Promise<InstallArchetype> {
+  const config = await prisma.storefrontConfig.findFirst({
+    select: { archetypeId: true },
+  });
+  if (!config) return { category: null, archetypeId: null };
+  const archetype = await prisma.storefrontArchetype.findUnique({
+    where: { id: config.archetypeId },
+    select: { archetypeId: true, category: true },
+  });
+  return {
+    category: archetype?.category ?? null,
+    archetypeId: archetype?.archetypeId ?? null,
+  };
+}
+
+/**
+ * Does this install need the element hierarchy for `modelSlug`?
+ *
+ * Universal models (no declared archetypes) always apply. An industry model
+ * applies only when the install's category or archetype id is in its list.
+ */
+export function referenceModelAppliesToInstall(
+  modelSlug: string,
+  install: InstallArchetype,
+  archetypesBySlug: Readonly<Record<string, readonly string[]>> = REFERENCE_MODEL_ARCHETYPES,
+): boolean {
+  const archetypes = archetypesBySlug[modelSlug];
+  if (!archetypes || archetypes.length === 0) return true;
+  return archetypes.some(
+    (a) => a === install.category || a === install.archetypeId,
+  );
+}
+
 async function seedBianReferenceModel(modelId: string): Promise<void> {
   const BIAN_JSON_PATH = join(REFERENCE_ROOT, "bian", "bian-v14-service-landscape.json");
 
@@ -466,26 +531,52 @@ export async function seedEaReferenceModels(): Promise<void> {
     },
   });
 
-  await seedBianReferenceModel(bianModel.id);
+  // The MODEL ROW above is catalogue and is always upserted — it carries
+  // primaryIndustry, so a non-banking install can still see that BIAN exists
+  // and what it is for. That mirrors seed-banking-compliance.ts, which seeds
+  // banking regulations everywhere and scopes them at consumption.
+  //
+  // The ELEMENT HIERARCHY is different: it is ~390 rows of banking-specific
+  // structure that a software-platform, dry-cleaning or field-service install
+  // has no use for, and — until now — a zero count for it FAILED the seed on
+  // every one of those installs. Import it only where it applies.
+  const install = await resolveInstallArchetype();
+  const bianApplies = referenceModelAppliesToInstall(bianSlug, install);
+  if (bianApplies) {
+    await seedBianReferenceModel(bianModel.id);
+  }
 
-  // BI-98D19DF2: a workbook read that silently yields zero rows (e.g. an
-  // LFS pointer stub masquerading as the real .xlsx, or a JSON schema
-  // change that empties every extracted row) must fail loudly here rather
-  // than let the seed report success while a fresh install imports
-  // nothing. Row-count assertion, not just absence of a thrown error.
-  const [it4itElementCount, bianElementCount] = await Promise.all([
-    prisma.eaReferenceModelElement.count({ where: { modelId: model.id } }),
-    prisma.eaReferenceModelElement.count({ where: { modelId: bianModel.id } }),
-  ]);
-
+  // BI-98D19DF2: a workbook/JSON read that silently yields zero rows (e.g. an
+  // LFS pointer stub masquerading as the real .xlsx, or a schema change that
+  // empties every extracted row) must fail loudly here rather than let the
+  // seed report success while a fresh install imports nothing. Row-count
+  // assertion, not just absence of a thrown error.
+  //
+  // BI-DDB48B04 follow-on: assert only over models this install actually
+  // needs. The original assertion demanded a non-zero BIAN count from every
+  // install, so on any non-banking install the eaReferenceModels step threw
+  // and — because seed steps are caught and logged, not fatal (seed.ts
+  // `step()`) — failed silently on every boot and every upgrade. That is the
+  // same "seed reports success while importing nothing" shape this assertion
+  // was written to prevent, inverted: an assertion asserting the wrong thing
+  // is as blind as no assertion at all.
+  const it4itElementCount = await prisma.eaReferenceModelElement.count({
+    where: { modelId: model.id },
+  });
   if (it4itElementCount === 0) {
     throw new Error(
       `IT4IT reference model imported zero elements from ${IT4IT_WORKBOOK_PATH} — the workbook read did not throw but produced no rows (check for an LFS pointer stub or an empty/relabelled sheet).`
     );
   }
-  if (bianElementCount === 0) {
-    throw new Error(
-      "BIAN Service Landscape reference model imported zero elements — the JSON read did not throw but produced no business areas/domains/service domains (check docs/Reference/bian/bian-v14-service-landscape.json)."
-    );
+
+  if (bianApplies) {
+    const bianElementCount = await prisma.eaReferenceModelElement.count({
+      where: { modelId: bianModel.id },
+    });
+    if (bianElementCount === 0) {
+      throw new Error(
+        "BIAN Service Landscape reference model imported zero elements — the JSON read did not throw but produced no business areas/domains/service domains (check docs/Reference/bian/bian-v14-service-landscape.json)."
+      );
+    }
   }
 }

--- a/scripts/publish-image-release-identity.test.mjs
+++ b/scripts/publish-image-release-identity.test.mjs
@@ -105,3 +105,31 @@ test("the runner stage ships git-lfs for the git-source upgrade shape", () => {
     "the runner stage must install git-lfs or self-upgrade cannot materialize the LFS-tracked assets it then asserts",
   );
 });
+
+test("the image carries the BIAN landscape the banking seed reads", () => {
+  const dockerfile = readFileSync("Dockerfile", "utf8");
+  const dockerignore = readFileSync(".dockerignore", "utf8");
+
+  // .dockerignore excludes docs/Reference/ wholesale. The BIAN JSON was never
+  // re-admitted, so seedBianReferenceModel's readFileSync threw on every
+  // install, its own catch swallowed the error, and the model imported zero
+  // Service Domains — including on the banking installs it exists for. The
+  // negation and the COPY have to move together or the build context loses it.
+  assert.match(
+    dockerignore,
+    /^!docs\/Reference\/bian\//m,
+    "the BIAN landscape must be re-admitted to the build context",
+  );
+
+  const copyIndex = dockerfile.indexOf(
+    "COPY docs/Reference/bian/bian-v14-service-landscape.json",
+  );
+  assert.notEqual(copyIndex, -1, "the BIAN landscape COPY must exist");
+
+  // Assert the bytes where they enter the artifact, same rule as the workbook.
+  assert.match(
+    dockerfile.slice(copyIndex),
+    /head -c 1 docs\/Reference\/bian\/bian-v14-service-landscape\.json \| grep -q '\{'/,
+    "the COPY must be followed by a JSON-shape assertion so a missing or truncated file fails the build",
+  );
+});


### PR DESCRIPTION
> *"BIAN is applicable for a banking industry, not for us. Or any other archetype. So, why are we dealing with BIAN here?"*

Two defects behind one symptom: on a software-platform install, `EaReferenceModelElement` counts are **IT4IT 711, BIAN 0**.

## 1. Not archetype-scoped

`seedEaReferenceModels` imported the BIAN Service Landscape and then asserted a non-zero element count for it on **every** install. `seed.ts step()` catches and logs rather than aborting, so on any non-banking install the `eaReferenceModels` step threw and failed **silently, on every boot and every upgrade**.

That is the same *"reports success while importing nothing"* shape the assertion (BI-98D19DF2) exists to prevent, inverted — an assertion asserting the wrong thing is as blind as no assertion at all.

## 2. The data was never shipped

`.dockerignore` excludes `docs/Reference/` wholesale and re-admitted only the IT4IT workbook. `seedBianReferenceModel`'s `readFileSync` therefore always threw, its own `catch` swallowed it and returned — so BIAN imported zero elements **even on the banking installs it exists for**. 81 KB of JSON, not the large binary content that exclusion targets.

## The scoping substrate already existed and was ignored

| Substrate | Scoped? |
|---|---|
| `business-capability-category-corpus.ts` | ✅ keys `banking-financial-services` → `BIAN_BANKING_V14`, per-org |
| `seed-banking-compliance.ts` + `regulation-applicability.ts` | ✅ seeds banking regulations everywhere, scopes at consumption |
| `EaReferenceModel.primaryIndustry` | ⚠️ BIAN already tagged — **and nothing reads the field** |
| `seedEaReferenceModels` | ❌ imported and asserted unconditionally |

The same body of knowledge was properly archetype-scoped in one substrate and force-fed in another.

## Change

- **`referenceModelAppliesToInstall`** reuses the `RegulationApplicability.archetypes` contract — entries match either an archetype **category** slug or a specific **archetype id** — rather than inventing a second scoping mechanism.
- **`resolveInstallArchetype`** joins `StorefrontConfig.archetypeId` (a cuid FK, not a slug) to `StorefrontArchetype`. An undeclared archetype is **not** applicable; the seed is idempotent and re-runs each boot, so an install that later declares banking picks the hierarchy up then.
- **The catalogue row is still upserted everywhere** — it carries `primaryIndustry`, so a non-banking install can still see the model exists and what it serves, matching the `seed-banking-compliance` precedent. Only the ~390-row element payload and its assertion are gated.
- **`.dockerignore` + `Dockerfile`** now carry the BIAN JSON with a shape assertion, so the banking case actually works.

## Decision

Routed through the kernel rather than chosen ad hoc — `principle_decide`, ledger `DI-8DAA15FE7E0D`, across archetype-gated / ship-and-always-import / drop-BIAN. Recommendation **archetype-gated**, composite 11.73, margin 5.87, high confidence, autonomy-eligible. Top contributors: Research and Use Standards, Single Source of Truth, Ground New Work In Existing Platform.

## A fixture weakness worth knowing

`seed-ea-reference-models.test.ts` resolves **both** models to the id `"model-1"`, which makes any per-model assertion vacuous. The first version of these end-to-end tests **passed against the reverted fix**. They were rewritten with distinct model ids and now fail correctly when the gate is disabled. Anyone writing per-model assertions against that fixture should override the ids.

## Verification

- `pnpm run pregate` → **PASS** (`104a2f925a77`, evidence `cmtf62uvj74as01ogp4n8497q`) — includes the production build.
- Preflight: 59 guards clean (post-commit).
- 26,615 tests green; 6 new applicability tests + 4 new end-to-end seed tests, all confirmed failing when the gate is reverted.
- New Dockerfile/`.dockerignore` ratchet confirmed failing when the re-admission is removed.

Refs: BI-4F186358

Local-CI-Evidence: cmtf6fuye7b7901og5wfg85lm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Seed-Fit-Decision: archetype-scoped

