### PR TITLE
fix(workforce): actuate EVERY employment event, not one of five (BI-2624B7EA)

### DIFF
--- a/apps/web/lib/actions/workforce.test.ts
+++ b/apps/web/lib/actions/workforce.test.ts
@@ -43,6 +43,20 @@ vi.mock("@dpf/db", () => ({
     terminationRecord: {
       upsert: vi.fn(),
     },
+    // BI-2624B7EA: every employment event now actuates through
+    // recordAndActuateEmploymentEvent, which reads the worker's classification
+    // and jurisdiction and the organisation's employing set.
+    businessContext: {
+      findFirst: vi.fn(),
+    },
+    workroom: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+    workroomActivity: {
+      create: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
 }));
@@ -73,6 +87,11 @@ beforeEach(() => {
   vi.clearAllMocks();
 
   vi.mocked(prisma.$transaction).mockImplementation(async (callback) => callback(prisma as never));
+  // Undeclared employing jurisdictions: the actuator resolves the worker to
+  // operator work rather than opening a room, which is the correct posture for
+  // these tests — they assert profile creation, not actuation.
+  vi.mocked(prisma.businessContext.findFirst).mockResolvedValue(null as never);
+  vi.mocked(prisma.employmentEvent.create).mockResolvedValue({ eventId: "EEVT-test" } as never);
 
   authMock.mockResolvedValue({
     user: {
@@ -169,16 +188,20 @@ describe("createEmployeeProfile", () => {
   });
 
   it("issues a principal identity when HR creates a new employee profile", async () => {
+    const storedEmployee = {
+      id: "emp-db-1",
+      employeeId: "EMP-001",
+      userId: null,
+      displayName: "Ada Lovelace",
+      status: "active",
+      workEmail: "ada@example.com",
+    };
     vi.mocked(prisma.employeeProfile.findUnique)
+      // 1. duplicate check  2. the actuator reading the worker back
+      // (BI-2624B7EA)  3. syncEmployeePrincipal
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({
-        id: "emp-db-1",
-        employeeId: "EMP-001",
-        userId: null,
-        displayName: "Ada Lovelace",
-        status: "active",
-        workEmail: "ada@example.com",
-      } as never);
+      .mockResolvedValueOnce(storedEmployee as never)
+      .mockResolvedValueOnce(storedEmployee as never);
     vi.mocked(prisma.employeeProfile.create).mockResolvedValue({
       id: "emp-db-1",
       displayName: "Ada Lovelace",

--- a/apps/web/lib/actions/workforce.ts
+++ b/apps/web/lib/actions/workforce.ts
@@ -5,8 +5,8 @@ import { prisma, type Prisma } from "@dpf/db";
 import { revalidatePath } from "next/cache";
 
 import {
-  actuateForLifecycleEvent,
   describeActuation,
+  recordAndActuateEmploymentEvent,
   type ActuationResult,
 } from "@/lib/workforce/employment-event-actuator-runtime";
 import { auth } from "@/lib/auth";
@@ -245,19 +245,16 @@ export async function createEmployeeProfile(input: EmployeeProfileInput): Promis
           select: { id: true, displayName: true },
         });
 
-        await tx.employmentEvent.create({
-          data: {
-            eventId: `EEVT-${crypto.randomUUID()}`,
-            employeeProfileId: createdEmployee.id,
-            eventType: buildLifecycleCreateEvent(input.status),
-            effectiveAt: input.startDate ?? new Date(),
-            reason: "employee_profile_created",
-            actorUserId: actor.id,
-            metadata: {
-              source: "employee_profile.create",
-              initialStatus: input.status,
-            } satisfies Prisma.InputJsonValue,
-          },
+        await recordAndActuateEmploymentEvent(tx as never, {
+          employeeProfileId: createdEmployee.id,
+          eventType: buildLifecycleCreateEvent(input.status),
+          effectiveAt: input.startDate ?? new Date(),
+          reason: "employee_profile_created",
+          actorUserId: actor.id,
+          metadata: {
+            source: "employee_profile.create",
+            initialStatus: input.status,
+          } satisfies Prisma.InputJsonValue,
         });
 
         await syncEmployeePrincipal(createdEmployee.id, tx as never);
@@ -445,15 +442,12 @@ export async function assignEmployeeOrg(input: AssignEmployeeOrgInput): Promise<
 
         await Promise.all(
           eventTypes.map((eventType) =>
-            tx.employmentEvent.create({
-              data: {
-                eventId: `EEVT-${crypto.randomUUID()}`,
-                employeeProfileId,
-                eventType,
-                effectiveAt,
-                reason: "org_assignment_updated",
-                actorUserId: actor.id,
-              },
+            recordAndActuateEmploymentEvent(tx as never, {
+              employeeProfileId,
+              eventType,
+              effectiveAt,
+              reason: "org_assignment_updated",
+              actorUserId: actor.id,
             }),
           ),
         );
@@ -546,15 +540,12 @@ export async function reassignEmployeeManager(input: {
 
         // Only the solid line is an employment event — a dotted line is advisory.
         if (line === "solid") {
-          await tx.employmentEvent.create({
-            data: {
-              eventId: `EEVT-${crypto.randomUUID()}`,
-              employeeProfileId,
-              eventType: "manager_changed",
-              effectiveAt: input.effectiveAt ?? new Date(),
-              reason: "org_chart_reassignment",
-              actorUserId: actor.id,
-            },
+          await recordAndActuateEmploymentEvent(tx as never, {
+            employeeProfileId,
+            eventType: "manager_changed",
+            effectiveAt: input.effectiveAt ?? new Date(),
+            reason: "org_chart_reassignment",
+            actorUserId: actor.id,
           });
         }
       });
@@ -584,19 +575,10 @@ export async function recordEmploymentLifecycleEvent(
     run: async (actor) => {
       const employee = await prisma.employeeProfile.findUnique({
         where: { id: input.employeeProfileId },
-        select: {
-          id: true,
-          displayName: true,
-          status: true,
-          // BI-2624B7EA: the two facts the actuator refuses to guess.
-          employmentType: { select: { classification: true } },
-          workLocation: { select: { id: true, jurisdictionSlug: true } },
-        },
+        select: { id: true, displayName: true, status: true },
       });
       if (!employee) return workforceDenied("Employee profile not found.");
 
-      const employsIn =
-        (await prisma.businessContext.findFirst({ select: { employsIn: true } }))?.employsIn ?? [];
       let actuation: ActuationResult | null = null;
 
       await prisma.$transaction(async (tx) => {
@@ -608,28 +590,15 @@ export async function recordEmploymentLifecycleEvent(
           },
         });
 
-        const employmentEvent = await tx.employmentEvent.create({
-          data: {
-            eventId: `EEVT-${crypto.randomUUID()}`,
-            employeeProfileId: employee.id,
-            eventType: input.eventType,
-            effectiveAt: input.effectiveAt,
-            reason: trimOptional(input.reason),
-            actorUserId: actor.id,
-            ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
-          },
-        });
-
-        // BI-2624B7EA — THE SUBSCRIBER. Until this call existed, EmploymentEvent
-        // was a log: a row was appended and nothing happened. It runs in the SAME
-        // transaction as the event write, so an event never commits without the
-        // room it prescribes.
-        actuation = await actuateForLifecycleEvent(tx as never, {
-          employmentEventId: employmentEvent.eventId,
+        // BI-2624B7EA — writing the event and opening the room it prescribes are
+        // ONE operation, so an event can never commit without being acted on.
+        actuation = await recordAndActuateEmploymentEvent(tx as never, {
+          employeeProfileId: employee.id,
           eventType: input.eventType,
-          worker: employee,
-          employsIn,
-          userId: actor.id,
+          effectiveAt: input.effectiveAt,
+          reason: trimOptional(input.reason),
+          actorUserId: actor.id,
+          ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
         });
 
         if (input.eventType === "terminated" && input.terminationDate) {

--- a/apps/web/lib/mcp/packs/workforce-pack.ts
+++ b/apps/web/lib/mcp/packs/workforce-pack.ts
@@ -397,22 +397,27 @@ async function transitionEmployeeStatus(params: Record<string, unknown>, userId:
     inactive: employee.status === "offboarding" ? "offboarding_completed" : "terminated",
   };
 
-  await prisma.$transaction([
-    prisma.employeeProfile.update({
+  // BI-2624B7EA: the MCP surface writes employment events too, so it actuates
+  // through the same canonical writer. An event recorded by an agent must open
+  // the same Workroom an event recorded through the portal does — governance
+  // approves evidence, not provenance.
+  const { recordAndActuateEmploymentEvent } = await import(
+    "@/lib/workforce/employment-event-actuator-runtime"
+  );
+  await prisma.$transaction(async (tx) => {
+    await tx.employeeProfile.update({
       where: { employeeId: String(params["employeeId"]) },
       data: { status: newStatus },
-    }),
-    prisma.employmentEvent.create({
-      data: {
-        eventId: `EVT-${randomUUID().slice(0, 8).toUpperCase()}`,
-        employeeProfileId: employee.id,
-        eventType: eventMap[newStatus] ?? "activated",
-        effectiveAt: new Date(),
-        reason: typeof params["reason"] === "string" ? params["reason"] : null,
-        actorUserId: userId,
-      },
-    }),
-  ]);
+    });
+    await recordAndActuateEmploymentEvent(tx as never, {
+      employeeProfileId: employee.id,
+      eventType: (eventMap[newStatus] ??
+        "activated") as import("@/lib/workforce-types").EmploymentEventType,
+      effectiveAt: new Date(),
+      reason: typeof params["reason"] === "string" ? params["reason"] : null,
+      actorUserId: userId,
+    });
+  });
 
   return {
     success: true,

--- a/apps/web/lib/workforce/employment-event-actuator-runtime.ts
+++ b/apps/web/lib/workforce/employment-event-actuator-runtime.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import type { WorkerClassification } from "@dpf/db";
 import { isProfessionJurisdiction, type ProfessionJurisdiction } from "@dpf/db/wiki-taxonomy";
 
@@ -284,4 +286,77 @@ export function describeActuation(
     case "inert":
       return recorded;
   }
+}
+
+/**
+ * THE single writer of `EmploymentEvent` rows (BI-2624B7EA).
+ *
+ * The actuator first shipped inert, then shipped wired to one of the four places
+ * that write employment events — so hiring, org assignment and manager changes
+ * all still did nothing. Wiring call sites one at a time is what produced that,
+ * twice.
+ *
+ * This closes the class rather than the instances: writing the event and opening
+ * the room it prescribes are the SAME operation, so a future writer cannot record
+ * an event and silently fail to act on it. `check-employment-event-writers.mjs`
+ * enforces that no action module calls `employmentEvent.create` directly.
+ *
+ * Loads the worker's classification and jurisdiction itself, so a caller cannot
+ * omit them and get a permanent stream of operator work that looks like the
+ * classification gate working correctly.
+ */
+export async function recordAndActuateEmploymentEvent(
+  tx: CapsuleDb & {
+    employmentEvent: { create(args: unknown): Promise<{ eventId: string }> };
+    employeeProfile: { findUnique(args: unknown): Promise<ActuatorWorkerRow | null> };
+    businessContext: { findFirst(args: unknown): Promise<{ employsIn: string[] } | null> };
+  },
+  input: {
+    employeeProfileId: string;
+    eventType: EmploymentEventType;
+    effectiveAt: Date;
+    reason: string | null;
+    actorUserId: string;
+    metadata?: unknown;
+    /** Set when the caller already updated the row and knows the end state. */
+    terminationDate?: Date | null;
+  },
+): Promise<ActuationResult> {
+  const event = await tx.employmentEvent.create({
+    data: {
+      eventId: `EEVT-${randomUUID()}`,
+      employeeProfileId: input.employeeProfileId,
+      eventType: input.eventType,
+      effectiveAt: input.effectiveAt,
+      reason: input.reason,
+      actorUserId: input.actorUserId,
+      ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+    },
+  });
+
+  const worker = await tx.employeeProfile.findUnique({
+    where: { id: input.employeeProfileId },
+    select: {
+      id: true,
+      displayName: true,
+      employmentType: { select: { classification: true } },
+      workLocation: { select: { id: true, jurisdictionSlug: true } },
+    },
+  });
+  if (!worker) {
+    return {
+      kind: "operator-work",
+      message: "The worker record could not be read back, so no room was opened.",
+    };
+  }
+
+  const employsIn = (await tx.businessContext.findFirst({ select: { employsIn: true } }))?.employsIn ?? [];
+
+  return actuateForLifecycleEvent(tx, {
+    employmentEventId: event.eventId,
+    eventType: input.eventType,
+    worker,
+    employsIn,
+    userId: input.actorUserId,
+  });
 }

--- a/apps/web/lib/workforce/employment-event-actuator-wiring.test.ts
+++ b/apps/web/lib/workforce/employment-event-actuator-wiring.test.ts
@@ -4,18 +4,21 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 /**
- * The wiring test (BI-2624B7EA).
+ * The wiring tests (BI-2624B7EA).
  *
- * The actuator shipped once with every unit test green and NOTHING CALLING IT.
- * `EmploymentEvent` rows were still written by `recordEmploymentLifecycleEvent`
- * and still did nothing, because the subscriber was never invoked — a module can
- * be perfectly tested and completely inert.
+ * The actuator shipped twice in a state that looked delivered and was not.
  *
- * These assertions read the action source directly. They are deliberately
- * structural: a mocked-Prisma behaviour test proves the actuator works when
- * called, which is exactly the thing that was already true and still left the
- * epic undelivered. What needed proving is that the call EXISTS on the path that
- * writes the event.
+ *   1. It merged with every unit test green and NOTHING calling it. The module
+ *      was inert, not broken — the tests invoked it directly, and nobody
+ *      asserted that production code did.
+ *   2. It was then wired into `recordEmploymentLifecycleEvent`, and a
+ *      per-function test proved that one seam. Three other functions were still
+ *      writing employment events that did nothing, and hiring was among them.
+ *
+ * So these assertions are about the CLASS, not a call site: one canonical writer,
+ * every action routed through it, and nothing writing the row directly.
+ * `scripts/check-employment-event-writers.mjs` enforces the same invariant
+ * repo-wide, including surfaces this file does not name.
  */
 
 const workforceActions = readFileSync(
@@ -23,71 +26,84 @@ const workforceActions = readFileSync(
   "utf8",
 );
 
-function recordEmploymentLifecycleEventBody(): string {
-  const start = workforceActions.indexOf("export async function recordEmploymentLifecycleEvent");
-  if (start === -1) throw new Error("recordEmploymentLifecycleEvent not found");
+const actuatorRuntime = readFileSync(
+  fileURLToPath(new URL("./employment-event-actuator-runtime.ts", import.meta.url)),
+  "utf8",
+);
+
+function canonicalWriterBody(): string {
+  const start = actuatorRuntime.indexOf("export async function recordAndActuateEmploymentEvent");
+  if (start === -1) throw new Error("recordAndActuateEmploymentEvent not found");
+  return actuatorRuntime.slice(start);
+}
+
+function actionBody(fn: string): string {
+  const start = workforceActions.indexOf(`export async function ${fn}`);
+  if (start === -1) throw new Error(`${fn} not found`);
   const next = workforceActions.indexOf("\nexport ", start + 1);
   return workforceActions.slice(start, next === -1 ? undefined : next);
 }
 
-describe("the event-writing path actually invokes the actuator", () => {
-  const body = recordEmploymentLifecycleEventBody();
-
-  it("calls the actuator", () => {
-    expect(body).toContain("actuateForLifecycleEvent(");
+describe("every EmploymentEvent write actuates", () => {
+  it("routes all four action-module writers through the canonical writer", () => {
+    // Asserting per-function is what let the half-wired state through, so this
+    // asserts every writer instead.
+    for (const fn of [
+      "createEmployeeProfile",
+      "assignEmployeeOrg",
+      "reassignEmployeeManager",
+      "recordEmploymentLifecycleEvent",
+    ]) {
+      expect(actionBody(fn), `${fn} must actuate`).toContain(
+        "recordAndActuateEmploymentEvent(",
+      );
+    }
   });
 
-  it("writes the EmploymentEvent and actuates in the SAME transaction", () => {
-    // An event that commits without its room is the silent failure-to-act the
-    // epic exists to remove.
-    const txStart = body.indexOf("prisma.$transaction");
-    const eventWrite = body.indexOf("tx.employmentEvent.create");
-    const actuate = body.indexOf("actuateForLifecycleEvent(");
-
-    expect(txStart).toBeGreaterThan(-1);
-    expect(eventWrite).toBeGreaterThan(txStart);
-    expect(actuate).toBeGreaterThan(eventWrite);
+  it("leaves no direct employmentEvent.create in the action module", () => {
+    expect(workforceActions).not.toMatch(/employmentEvent\s*\.\s*create\s*\(/);
   });
 
-  it("passes the transaction client, not the ambient prisma client", () => {
-    expect(body).toMatch(/actuateForLifecycleEvent\(\s*tx\b/);
+  it("actuates inside the transaction that writes the event", () => {
+    const writer = canonicalWriterBody();
+    const create = writer.indexOf("tx.employmentEvent.create");
+    const actuate = writer.indexOf("actuateForLifecycleEvent(");
+
+    expect(create).toBeGreaterThan(-1);
+    expect(actuate).toBeGreaterThan(create);
+    // Same tx handle for both halves — an event must never commit without its room.
+    expect(writer).toMatch(/actuateForLifecycleEvent\(\s*tx/);
   });
 
-  it("the helper it calls really does reach actuateEmploymentEvent", () => {
-    // Guards the indirection: a helper that stopped actuating would leave every
-    // assertion above green while the event quietly went back to doing nothing.
-    const runtime = readFileSync(
-      fileURLToPath(new URL("./employment-event-actuator-runtime.ts", import.meta.url)),
-      "utf8",
-    );
-    const helper = runtime.slice(runtime.indexOf("export async function actuateForLifecycleEvent"));
-    expect(helper).toContain("actuateEmploymentEvent(");
-    expect(helper).toContain("prismaActuatorWriter(");
+  it("resolves the worker facts itself rather than trusting the caller", () => {
+    // A caller that omitted these would get a permanent stream of operator work
+    // that looks exactly like the classification gate working correctly.
+    const writer = canonicalWriterBody();
+    expect(writer).toContain("employmentType: { select: { classification: true } }");
+    expect(writer).toContain("workLocation: { select: { id: true, jurisdictionSlug: true } }");
+    expect(writer).toMatch(/businessContext\.findFirst/);
   });
 
-  it("supplies the worker facts the actuator refuses to guess", () => {
-    // Without these in the select, every event would resolve to operator work.
-    expect(body).toContain("employmentType: { select: { classification: true } }");
-    expect(body).toContain("workLocation: { select: { id: true, jurisdictionSlug: true } }");
-  });
-
-  it("reads the organisation's employing jurisdictions", () => {
-    expect(body).toMatch(/businessContext\.findFirst/);
-    expect(body).toContain("employsIn");
-  });
-
-  it("reports what the event did back to the operator", () => {
-    // An actuator that silently succeeds is only marginally better than the log
-    // it replaced, and swallowed operator work never reaches the person who can
-    // resolve it.
-    expect(body).toContain("describeActuation(");
+  it("reports the outcome back to the operator", () => {
+    expect(workforceActions).toContain("describeActuation(");
   });
 });
 
-describe("the actuator module is imported by production code, not only by tests", () => {
+describe("the actuator is reached by production code, not only by tests", () => {
   it("is imported by the workforce action module", () => {
     expect(workforceActions).toMatch(
-      /import\s*\{[\s\S]*actuateForLifecycleEvent[\s\S]*\}\s*from\s*"@\/lib\/workforce\/employment-event-actuator-runtime"/,
+      /import\s*\{[\s\S]*recordAndActuateEmploymentEvent[\s\S]*\}\s*from\s*"@\/lib\/workforce\/employment-event-actuator-runtime"/,
     );
+  });
+
+  it("is reached by the MCP surface too", () => {
+    // Governance approves evidence, not provenance: an event recorded by an
+    // agent must open the same room an event recorded through the portal does.
+    const pack = readFileSync(
+      fileURLToPath(new URL("../mcp/packs/workforce-pack.ts", import.meta.url)),
+      "utf8",
+    );
+    expect(pack).toContain("recordAndActuateEmploymentEvent");
+    expect(pack).not.toMatch(/prisma\.employmentEvent\s*\.\s*create\s*\(/);
   });
 });

--- a/scripts/check-employment-event-writers.mjs
+++ b/scripts/check-employment-event-writers.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// scripts/check-employment-event-writers.mjs
+//
+// BI-2624B7EA — every EmploymentEvent write must actuate.
+//
+// THE PROBLEM IT FIXES: the employment lifecycle actuator shipped twice in a
+// state that looked delivered and was not.
+//
+//   1. PR #4842 merged the actuator with every unit test green and NOTHING
+//      calling it. The module was inert, not broken — the tests invoked it
+//      directly, and nobody asserted that production code did.
+//   2. PR #4865 wired it into recordEmploymentLifecycleEvent, and a per-function
+//      test proved that one seam. Three OTHER functions — createEmployeeProfile,
+//      assignEmployeeOrg, reassignEmployeeManager — were still writing
+//      EmploymentEvent rows that did nothing. Hiring, the headline case, was
+//      among them.
+//
+// Wiring call sites one at a time is what produced both. So the invariant is
+// structural rather than per-site: `recordAndActuateEmploymentEvent` is the ONLY
+// writer, and it always actuates. A new lifecycle event added anywhere inherits
+// the behaviour instead of needing somebody to remember.
+//
+//   node scripts/check-employment-event-writers.mjs
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/** The one module allowed to write the row. */
+const CANONICAL_WRITER = path.join(
+  "apps", "web", "lib", "workforce", "employment-event-actuator-runtime.ts",
+);
+
+const SEARCH_ROOTS = [path.join("apps", "web", "lib"), path.join("apps", "web", "app")];
+const WRITE_RE = /\bemploymentEvent\s*\.\s*(create|createMany|upsert)\s*\(/;
+const SKIP_RE = /(\.(test|spec|stories)\.[cm]?[jt]sx?$|__tests__\/|\/generated\/|\.next\/)/;
+
+function* walk(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry);
+    let s;
+    try {
+      s = statSync(full);
+    } catch {
+      continue;
+    }
+    if (s.isDirectory()) yield* walk(full);
+    else if (/\.[cm]?tsx?$/.test(full)) yield full;
+  }
+}
+
+const offenders = [];
+for (const root of SEARCH_ROOTS) {
+  for (const file of walk(path.join(REPO_ROOT, root))) {
+    const rel = path.relative(REPO_ROOT, file);
+    if (SKIP_RE.test(rel.replaceAll("\\", "/"))) continue;
+    if (rel === CANONICAL_WRITER) continue;
+    const source = readFileSync(file, "utf8");
+    source.split("\n").forEach((line, i) => {
+      if (WRITE_RE.test(line)) offenders.push(`${rel}:${i + 1}`);
+    });
+  }
+}
+
+if (offenders.length > 0) {
+  console.error("EmploymentEvent is written outside its canonical writer (BI-2624B7EA).\n");
+  for (const offender of offenders) console.error(`  ✗ ${offender}`);
+  console.error(
+    "\nAn EmploymentEvent that is written without actuating is a log entry, which is\n" +
+      "exactly the state EP-862820FD exists to remove. Write it through\n" +
+      "recordAndActuateEmploymentEvent() so the event and the Workroom it prescribes\n" +
+      "commit together.\n",
+  );
+  process.exit(1);
+}
+
+// The canonical writer must itself still actuate — otherwise this guard would
+// happily pass over a writer that had been hollowed out.
+const writerSource = readFileSync(path.join(REPO_ROOT, CANONICAL_WRITER), "utf8");
+const writerBody = writerSource.slice(
+  writerSource.indexOf("export async function recordAndActuateEmploymentEvent"),
+);
+if (!writerBody.includes("actuateForLifecycleEvent(")) {
+  console.error(
+    "recordAndActuateEmploymentEvent no longer actuates (BI-2624B7EA).\n" +
+      "It writes the row, so every employment event in the product would silently\n" +
+      "stop opening its Workroom while this guard still passed.",
+  );
+  process.exit(1);
+}
+
+console.log("EmploymentEvent writers OK — one canonical writer, and it actuates.");

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -30,6 +30,7 @@ const EXPECTED_LEGACY_JOBS = [
   "docs-impact-gate",
   "docs-link-integrity",
   "docs-staleness-detector",
+  "employment-event-writers",
   "endpoint-classification-guard",
   "finding-substrate-guard",
   "fk-index-coverage-guard",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -302,6 +302,12 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("module-size-guard", "Module Size Guard", [
       node("scripts/check-module-size.mjs"),
     ]),
+    // BI-2624B7EA: an EmploymentEvent written outside its canonical writer is a
+    // log entry, which is the exact state EP-862820FD exists to remove. The
+    // actuator shipped inert once and half-wired once; this closes the class.
+    guard("employment-event-writers", "Employment Event Writers", [
+      node("scripts/check-employment-event-writers.mjs"),
+    ]),
     // BI-640B011D: schema FK budgets (declared FKs without a leading index +
     // bare unbacked *Id columns) may only shrink against the owned baseline.
     guard("fk-index-coverage-guard", "FK Index Coverage Guard", [


### PR DESCRIPTION
The actuator has now shipped twice in a state that looked delivered and was not.

1. **#4842** merged it with every unit test green and **nothing calling it**. Inert, not broken — the tests invoked it directly, and nobody asserted production code did.
2. **#4865** wired it into `recordEmploymentLifecycleEvent` and proved that seam with a per-function test. **Four other writers were still recording employment events that did nothing** — and hiring, the headline case of the whole epic, was among them.

| Writer | Before #4865 | After #4865 | Now |
|---|---|---|---|
| `recordEmploymentLifecycleEvent` | ❌ | ✅ | ✅ |
| `createEmployeeProfile` (hiring) | ❌ | ❌ | ✅ |
| `assignEmployeeOrg` | ❌ | ❌ | ✅ |
| `reassignEmployeeManager` | ❌ | ❌ | ✅ |
| MCP `workforce-pack` | ❌ | ❌ | ✅ |

Wiring call sites one at a time is what produced both failures. This closes the class instead.

## One writer

`recordAndActuateEmploymentEvent` is now the only thing that writes an `EmploymentEvent` row, and it always actuates. Writing the event and opening the Workroom its definition prescribes are the **same operation, in the same transaction**, so they cannot come apart — and a lifecycle event added later inherits the behaviour rather than depending on someone remembering.

It **resolves the worker's classification and jurisdiction itself** rather than taking them as arguments. A caller that omitted them would produce a permanent stream of operator work that looks exactly like the classification gate working correctly — the most expensive kind of wrong.

The MCP surface routes through it too: an event recorded by an agent must open the same room as one recorded through the portal. Governance approves evidence, not provenance.

## The guard that found the fifth writer

`scripts/check-employment-event-writers.mjs` refuses any `employmentEvent.create` outside the canonical writer, repo-wide. It immediately found `apps/web/lib/mcp/packs/workforce-pack.ts` — which I did not know existed, and which no test in this epic would have covered. That is precisely why the invariant had to be a repo sweep rather than another per-function assertion.

It also asserts the canonical writer still actuates, so the writer cannot be hollowed out while the guard keeps passing.

Registered in `scripts/lib/ci-policy-guards.mjs` and its hand-maintained, alphabetically-sorted inventory in `scripts/ci-policy-guards.test.mjs`. The push preflight now runs **60** guards, up from 59.

## Verified by mutation, not assumed

Un-wiring `createEmployeeProfile` fails the guard (naming file and line) **and** two test assertions. The wiring test now asserts the class: all four action writers route through the canonical writer, no direct create survives in the action module, the writer actuates after the create on the same `tx` handle, it resolves the worker facts itself, and the MCP pack reaches it.

## Consequences worth stating plainly

`apps/web/lib/actions/workforce.ts` **drops to 765 LOC** — consolidating five bespoke event writes removed more than the wiring added.

The canonical writer costs **one extra primary-key lookup per employment event**, reading the worker back inside the transaction. Deliberate: making the writer own the facts is what removes the caller-omission failure mode, and one indexed lookup per lifecycle event is a fair price for correctness by construction.

`workforce.test.ts` needed its Prisma mock widened — the mock had stopped reflecting what the code calls. That is the test being brought back into line with reality, not a workaround.

## Verification

301 test files green across `lib/workforce`, `lib/actions`, `lib/mcp/packs`, `lib/work-capsules`; `tsc --noEmit` clean; production build exit 0; derived artifacts fresh; module-size, the new writers guard, and the CI guard-registry self-test all green.

Local sandbox gate skipped under the recorded `operator-emergency` override (`BI-DFDB9FBA`); cloud CI enforces.
