### PR TITLE
fix(integrations): a rendered next step names a live item or says it is not filed (BI-5BF97BAA)

### DIFF
--- a/apps/web/app/(shell)/platform/tools/integrations/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/page.tsx
@@ -1,4 +1,5 @@
 import { prisma } from "@dpf/db";
+import { resolveNextSteps } from "@/lib/backlog/next-step-pointer";
 import { IntegrationCoverageDisclosure } from "@/components/integrations/IntegrationCoverageDisclosure";
 import { PlatformSummaryCard } from "@/components/platform/PlatformSummaryCard";
 import { getMatrixByOrg } from "@/lib/actions/integration-coverage";
@@ -15,6 +16,9 @@ import {
 export default async function EnterpriseIntegrationsPage() {
   const org = await prisma.organization.findFirst({ select: { id: true } });
   const dbCoverageMatrix = org ? await getMatrixByOrg(org.id) : [];
+  const coverageNextSteps = await resolveNextSteps(
+    INTEGRATION_COVERAGE_MATRIX.map((row) => row.nextStep),
+  );
 
   const [configuredIntegrations, errorStates] = await Promise.all([
     prisma.integrationCredential.count({
@@ -245,7 +249,7 @@ export default async function EnterpriseIntegrationsPage() {
               </tr>
             </thead>
             <tbody className="divide-y divide-[var(--dpf-border)]">
-              {INTEGRATION_COVERAGE_MATRIX.map((row) => (
+              {INTEGRATION_COVERAGE_MATRIX.map((row, rowIndex) => (
                 <tr key={row.id} className="align-top">
                   <td className="py-4 pr-4">
                     <p className="font-medium text-[var(--dpf-text)]">{row.productName}</p>
@@ -303,7 +307,9 @@ export default async function EnterpriseIntegrationsPage() {
                   </td>
                   <td className="py-4 pl-4">
                     <div className="max-w-[220px] space-y-1">
-                      <p className="font-mono text-xs font-medium text-[var(--dpf-text)]">{row.nextBacklogItemId}</p>
+                      <p className="font-mono text-xs font-medium text-[var(--dpf-text)]">
+                        {coverageNextSteps[rowIndex].label}
+                      </p>
                       <p className="text-xs text-[var(--dpf-muted)]">{row.notes}</p>
                     </div>
                   </td>

--- a/apps/web/app/(shell)/platform/tools/integrations/quickbooks/page.tsx
+++ b/apps/web/app/(shell)/platform/tools/integrations/quickbooks/page.tsx
@@ -5,6 +5,7 @@ import { QuickBooksConnectPanel } from "@/components/integrations/QuickBooksConn
 import { IntegrationReadinessPanel } from "@/components/integrations/IntegrationReadinessPanel";
 import { buildQuickBooksReadinessDescriptor } from "@/lib/integrations/quickbooks/readiness";
 import { loadQuickBooksReadinessConnection } from "@/lib/integrations/quickbooks/connection-state";
+import { resolveNextSteps } from "@/lib/backlog/next-step-pointer";
 
 export default async function QuickBooksIntegrationPage() {
   const session = await auth();
@@ -21,6 +22,9 @@ export default async function QuickBooksIntegrationPage() {
 
   const initialState = await loadQuickBooksReadinessConnection();
   const readiness = buildQuickBooksReadinessDescriptor({ connection: initialState });
+  const [importReviewNextStep] = readiness.importReview
+    ? await resolveNextSteps([readiness.importReview.nextStep])
+    : [];
 
   return (
     <div className="space-y-6 p-6">
@@ -43,7 +47,7 @@ export default async function QuickBooksIntegrationPage() {
 
       <QuickBooksConnectPanel initialState={initialState} />
 
-      <IntegrationReadinessPanel descriptor={readiness} />
+      <IntegrationReadinessPanel descriptor={readiness} importReviewNextStep={importReviewNextStep} />
 
       <aside className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 text-sm">
         <h2 className="font-semibold text-[var(--dpf-text)]">What this integration enables</h2>

--- a/apps/web/components/finance/AccountantWorkLanePanel.test.tsx
+++ b/apps/web/components/finance/AccountantWorkLanePanel.test.tsx
@@ -18,7 +18,11 @@ vi.mock("next/link", () => ({
 }));
 
 import { AccountantWorkLanePanel } from "./AccountantWorkLanePanel";
-import { buildBookkeeperAccountantWorkLane } from "@/lib/finance/accountant-work-lane";
+import {
+  buildBookkeeperAccountantWorkLane,
+  type ResolvedAccountantWorkLane,
+} from "@/lib/finance/accountant-work-lane";
+import { resolveNextStep } from "@/lib/backlog/next-step-pointer";
 import type { QuickBooksReadinessConnection } from "@/lib/integrations/quickbooks/readiness";
 
 const CONNECTED: QuickBooksReadinessConnection = {
@@ -30,7 +34,22 @@ const CONNECTED: QuickBooksReadinessConnection = {
   environment: "sandbox",
 };
 
-const lane = buildBookkeeperAccountantWorkLane(CONNECTED);
+// The page resolves declared next steps before rendering. Nothing is filed for
+// this lane today, so resolve against an empty backlog — the state the panel
+// must render honestly rather than as a dead identifier (BI-5BF97BAA).
+const declared = buildBookkeeperAccountantWorkLane(CONNECTED);
+const noneFiled = new Map();
+const lane: ResolvedAccountantWorkLane = {
+  ...declared,
+  providerBoundaries: declared.providerBoundaries.map((boundary) => ({
+    ...boundary,
+    nextStep: resolveNextStep(boundary.nextStep, noneFiled),
+  })),
+  nextWorkflow: {
+    ...declared.nextWorkflow,
+    nextStep: resolveNextStep(declared.nextWorkflow.nextStep, noneFiled),
+  },
+};
 
 describe("AccountantWorkLanePanel", () => {
   it("renders the bookkeeper accountant lane with current DPF finance routes", () => {
@@ -65,9 +84,10 @@ describe("AccountantWorkLanePanel", () => {
     expect(html).toContain("Vendors");
     expect(html).toContain("Bank transactions");
     expect(html).toContain("QuickBooks reconciliation");
-    expect(html).toContain("BI-4025EF5F");
-    expect(html).toContain("BI-2DB52EAB");
-    expect(html).toContain("BI-47366954");
+    expect(html).toContain("Entity links and review queue");
+    expect(html).toContain("Fee and payout reconciliation");
+    expect(html).toContain("Provider ownership decision");
+    expect(html).not.toMatch(/BI-[0-9A-F]{8}/);
     expect(html).toContain("source-attributed");
   });
 });

--- a/apps/web/components/finance/AccountantWorkLanePanel.tsx
+++ b/apps/web/components/finance/AccountantWorkLanePanel.tsx
@@ -1,7 +1,7 @@
 import { ArrowRight, Plug, ShieldCheck, Workflow } from "lucide-react";
 import Link from "next/link";
 import {
-  type AccountantWorkLane,
+  type ResolvedAccountantWorkLane,
   type AccountantProviderBoundary,
   type AccountantWorkstream,
 } from "@/lib/finance/accountant-work-lane";
@@ -13,7 +13,7 @@ const POSTURE_LABELS: Record<AccountantProviderBoundary["posture"], string> = {
   "not-mapped": "Not mapped",
 };
 
-export function AccountantWorkLanePanel({ lane }: { lane: AccountantWorkLane }) {
+export function AccountantWorkLanePanel({ lane }: { lane: ResolvedAccountantWorkLane }) {
   return (
     <section className="mb-8 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -102,7 +102,7 @@ export function AccountantWorkLanePanel({ lane }: { lane: AccountantWorkLane }) 
                     </Link>
                     <p className="mt-1 text-xs text-[var(--dpf-muted)]">{POSTURE_LABELS[boundary.posture]}</p>
                     <p className="mt-2 font-mono text-xs text-[var(--dpf-text)]">
-                      {boundary.nextBacklogItemId}
+                      {boundary.nextStep.label}
                     </p>
                   </td>
                   <td className="px-4 py-4">
@@ -129,7 +129,7 @@ export function AccountantWorkLanePanel({ lane }: { lane: AccountantWorkLane }) 
           href={lane.nextWorkflow.route}
           className="inline-flex max-w-full items-center gap-2 rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-xs font-semibold text-white transition-opacity hover:opacity-90"
         >
-          <span className="shrink-0">{lane.nextWorkflow.backlogItemId}</span>
+          <span className="shrink-0">{lane.nextWorkflow.nextStep.label}</span>
           <span className="min-w-0 truncate">{lane.nextWorkflow.title}</span>
           <ArrowRight className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
         </Link>

--- a/apps/web/components/integrations/IntegrationReadinessPanel.test.tsx
+++ b/apps/web/components/integrations/IntegrationReadinessPanel.test.tsx
@@ -30,7 +30,10 @@ describe("IntegrationReadinessPanel", () => {
     expect(screen.getByRole("heading", { name: "Import staging posture" })).toBeVisible();
     expect(screen.getByRole("heading", { name: "Import review queue" })).toBeVisible();
     expect(screen.getByText("Non-editable")).toBeVisible();
-    expect(screen.getByText("BI-4025EF5F")).toBeVisible();
+    // Nothing is filed for the import-review queue, so the Backlog pill is not
+    // rendered at all rather than naming a dead item (BI-5BF97BAA).
+    expect(screen.queryByText("Backlog")).not.toBeInTheDocument();
+    expect(document.body.textContent ?? "").not.toMatch(/BI-[0-9A-F]{8}/);
     expect(screen.getByText("Ready for review")).toBeVisible();
     expect(screen.getByText(/Review queue records are DPF-held posture only/i)).toBeVisible();
     expect(screen.getAllByText("External-owned")).toHaveLength(9);

--- a/apps/web/components/integrations/IntegrationReadinessPanel.tsx
+++ b/apps/web/components/integrations/IntegrationReadinessPanel.tsx
@@ -6,9 +6,16 @@ import type {
 } from "@/lib/integrations/readiness";
 import type { IntegrationImportStagingDescriptor } from "@/lib/integrations/import-staging";
 import type { IntegrationImportReviewPosture } from "@/lib/integrations/import-review";
+import type { ResolvedNextStep } from "@/lib/backlog/next-step-pointer";
 
 interface IntegrationReadinessPanelProps {
   descriptor: IntegrationReadinessDescriptor;
+  /**
+   * The import-review next step after the page checked it against the backlog.
+   * Omitted where nothing is filed, which is why the pill below is conditional:
+   * a compact metric slot names a live item or it is not shown (BI-5BF97BAA).
+   */
+  importReviewNextStep?: ResolvedNextStep;
 }
 
 const STATE_LABELS: Record<IntegrationReadinessState, string> = {
@@ -23,7 +30,10 @@ const STATE_LABELS: Record<IntegrationReadinessState, string> = {
   "partner-led": "Partner led",
 };
 
-export function IntegrationReadinessPanel({ descriptor }: IntegrationReadinessPanelProps) {
+export function IntegrationReadinessPanel({
+  descriptor,
+  importReviewNextStep,
+}: IntegrationReadinessPanelProps) {
   return (
     <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
       <header className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
@@ -105,7 +115,7 @@ export function IntegrationReadinessPanel({ descriptor }: IntegrationReadinessPa
       )}
 
       {descriptor.importReview && (
-        <ImportReviewPosture posture={descriptor.importReview} />
+        <ImportReviewPosture posture={descriptor.importReview} nextStep={importReviewNextStep} />
       )}
 
       <div className="mt-4">
@@ -125,7 +135,13 @@ export function IntegrationReadinessPanel({ descriptor }: IntegrationReadinessPa
   );
 }
 
-function ImportReviewPosture({ posture }: { posture: IntegrationImportReviewPosture }) {
+function ImportReviewPosture({
+  posture,
+  nextStep,
+}: {
+  posture: IntegrationImportReviewPosture;
+  nextStep?: ResolvedNextStep;
+}) {
   return (
     <section className="mt-5 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
@@ -137,7 +153,7 @@ function ImportReviewPosture({ posture }: { posture: IntegrationImportReviewPost
         </div>
         <div className="flex flex-wrap gap-2 text-xs">
           <MetricPill label="State" value={reviewStatusLabel(posture.status)} />
-          <MetricPill label="Backlog" value={posture.nextBacklogItemId} />
+          {nextStep?.kind === "filed" && <MetricPill label="Backlog" value={nextStep.label} />}
         </div>
       </div>
 

--- a/apps/web/lib/backlog/next-step-pointer.pg.test.ts
+++ b/apps/web/lib/backlog/next-step-pointer.pg.test.ts
@@ -1,0 +1,94 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { INTEGRATION_COVERAGE_MATRIX } from "@/lib/tools/integration-coverage-matrix";
+import { buildBookkeeperAccountantWorkLane } from "@/lib/finance/accountant-work-lane";
+import { buildQuickBooksReadinessDescriptor } from "@/lib/integrations/quickbooks/readiness";
+import { declaredItemIds, type NextStepPointer } from "./next-step-pointer";
+
+// The resolve half of BI-5BF97BAA.
+//
+// The static guard (scripts/check-rendered-backlog-pointers.mjs) proves a
+// declared pointer can only reach a reader through the resolver. It cannot prove
+// that a declared id still names something — that needs the backlog.
+//
+// So this test carries the other half, and it is DB-gated on purpose. No CI
+// workflow declares a Postgres service, and check-no-ambient-host-tests.mjs
+// exists because BI-BFDCE0A9 was a test that reached for an ambient Postgres and
+// gave two verdicts on one tree. The house idiom is to skip when the resource is
+// absent, so this SKIPS in CI and RUNS wherever DATABASE_URL is set — the local
+// gate, and any install with a live backlog.
+//
+// It passes trivially while every declared next step states intent. It bites the
+// moment someone writes a real id that does not resolve.
+const databaseUrl = process.env.DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+
+/** Every next step declared anywhere in the surfaces this defect touched. */
+function declaredNextSteps(): NextStepPointer[] {
+  const lane = buildBookkeeperAccountantWorkLane({
+    status: "connected",
+    companyName: "Resolve Contract Co",
+    realmId: "realm-resolve-contract",
+    lastErrorMsg: null,
+    lastTestedAt: "2026-08-29T00:00:00.000Z",
+    environment: "sandbox",
+  });
+  const readiness = buildQuickBooksReadinessDescriptor({ connection: null });
+
+  return [
+    ...INTEGRATION_COVERAGE_MATRIX.map((row) => row.nextStep),
+    ...lane.providerBoundaries.map((boundary) => boundary.nextStep),
+    lane.nextWorkflow.nextStep,
+    ...(readiness.importReview ? [readiness.importReview.nextStep] : []),
+  ];
+}
+
+// Deliberately OUTSIDE the DB gate. The shape of a declared next step is
+// checkable anywhere, so it should not go dark in an environment without a
+// database — only the resolve check genuinely needs one.
+describe("declared next steps are well formed", () => {
+  it("every declared next step carries something a reader can act on", () => {
+    const declared = declaredNextSteps();
+    expect(declared.length).toBeGreaterThan(0);
+
+    for (const pointer of declared) {
+      if (pointer.kind === "open") {
+        expect(pointer.intent.trim().length).toBeGreaterThan(0);
+        // An id-shaped "intent" is the defect wearing the other shape.
+        expect(pointer.intent).not.toMatch(/^BI-/);
+      } else {
+        expect(pointer.itemId).toMatch(/^BI-/);
+      }
+    }
+  });
+});
+
+describeDatabase("declared next steps resolve against the live backlog", () => {
+  let prisma: typeof import("@dpf/db").prisma;
+
+  beforeAll(async () => {
+    ({ prisma } = await import("@dpf/db"));
+  });
+
+  it("every declared backlog id names an item the backlog holds", async () => {
+    const claimed = declaredItemIds(declaredNextSteps());
+
+    const filed = claimed.length
+      ? await prisma.backlogItem.findMany({
+          where: { itemId: { in: claimed } },
+          select: { itemId: true },
+        })
+      : [];
+
+    const found = new Set(filed.map((row) => row.itemId));
+    const dangling = claimed.filter((itemId) => !found.has(itemId));
+
+    expect(
+      dangling,
+      dangling.length
+        ? `these next-step ids name nothing in the backlog: ${dangling.join(", ")}. ` +
+          "Either file the item, or state the intent with openIntent() instead."
+        : "",
+    ).toEqual([]);
+  });
+});

--- a/apps/web/lib/backlog/next-step-pointer.test.ts
+++ b/apps/web/lib/backlog/next-step-pointer.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  UNRESOLVED_NEXT_STEP_LABEL,
+  backlogItem,
+  declaredItemIds,
+  openIntent,
+  resolveNextStep,
+  type FiledBacklogItem,
+  type NextStepPointer,
+} from "./next-step-pointer";
+
+function filed(...items: FiledBacklogItem[]): Map<string, FiledBacklogItem> {
+  return new Map(items.map((item) => [item.itemId, item]));
+}
+
+const OPEN_BI: FiledBacklogItem = {
+  itemId: "BI-5BF97BAA",
+  title: "Integration and finance surfaces show a next backlog item id that resolves to nothing",
+  status: "open",
+};
+
+describe("resolveNextStep", () => {
+  it("labels a filed item with its own id", () => {
+    const resolved = resolveNextStep(backlogItem("BI-5BF97BAA"), filed(OPEN_BI));
+
+    expect(resolved.kind).toBe("filed");
+    expect(resolved.label).toBe("BI-5BF97BAA");
+    if (resolved.kind !== "filed") throw new Error("expected a filed next step");
+    expect(resolved.title).toBe(OPEN_BI.title);
+    expect(resolved.status).toBe("open");
+  });
+
+  // The defect itself: BI-INT-8D4F72 and fourteen siblings survived the backlog
+  // reset of 2026-08-22 in source and kept rendering as though they were live.
+  it("never renders a declared id the backlog does not hold", () => {
+    const resolved = resolveNextStep(backlogItem("BI-INT-8D4F72"), filed(OPEN_BI));
+
+    expect(resolved.kind).toBe("unresolved");
+    expect(resolved.label).toBe(UNRESOLVED_NEXT_STEP_LABEL);
+    expect(resolved.label).not.toContain("BI-INT-8D4F72");
+  });
+
+  it("states intent when no item is filed", () => {
+    const resolved = resolveNextStep(openIntent("Entity links before write-back"), filed());
+
+    expect(resolved.kind).toBe("open");
+    expect(resolved.label).toBe("Entity links before write-back");
+  });
+
+  it("resolves an open intent without consulting the backlog at all", () => {
+    const resolved = resolveNextStep(openIntent("Bank-feed provider ownership"), filed(OPEN_BI));
+
+    expect(resolved.kind).toBe("open");
+    expect(resolved.label).toBe("Bank-feed provider ownership");
+  });
+
+  it("labels every pointer shape with something a reader can act on", () => {
+    const pointers: NextStepPointer[] = [
+      backlogItem("BI-5BF97BAA"),
+      backlogItem("BI-07D76D6B"),
+      openIntent("Fee and payout reconciliation"),
+    ];
+
+    for (const resolved of pointers.map((pointer) => resolveNextStep(pointer, filed(OPEN_BI)))) {
+      expect(resolved.label.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("declaredItemIds", () => {
+  it("collects claimed ids once each, in declaration order", () => {
+    const ids = declaredItemIds([
+      backlogItem("BI-07D76D6B"),
+      openIntent("Reconciliation parity"),
+      backlogItem("BI-5BF97BAA"),
+      backlogItem("BI-07D76D6B"),
+    ]);
+
+    expect(ids).toEqual(["BI-07D76D6B", "BI-5BF97BAA"]);
+  });
+
+  it("claims nothing when every pointer states intent", () => {
+    expect(declaredItemIds([openIntent("Channel custody boundary")])).toEqual([]);
+  });
+});

--- a/apps/web/lib/backlog/next-step-pointer.ts
+++ b/apps/web/lib/backlog/next-step-pointer.ts
@@ -1,0 +1,124 @@
+import { prisma } from "@dpf/db";
+
+// What a readiness surface promises the reader will happen next — BI-5BF97BAA.
+//
+// THE FAILURE THIS PREVENTS
+//
+// The backlog is a resettable substrate; source is not. Seventeen hardcoded
+// `nextBacklogItemId` strings across the integrations and finance surfaces
+// outlived the backlog reset of 2026-08-22 and went on rendering identifiers
+// that resolved to nothing — a "what happens next" pointer aimed at an item no
+// query could find. The reset is not the anomaly: 178 of the 233 backlog ids in
+// the last 600 commit subjects are gone too. A commit subject is a record of its
+// time and may name a dead id. A pointer offering the reader a next step may not.
+//
+// THE SHAPE
+//
+// A declared pointer is either a claim about a filed item, checked at render
+// time, or a stated intent with no item behind it yet. "Nothing is filed" is a
+// state to be said plainly, never faked with an id-shaped string. The same
+// convention already lives in the capability-lane specs, which write an open
+// slot as prose rather than inventing an identifier for it.
+
+/** A declared next step: a filed backlog item, or an intent with none yet. */
+export type NextStepPointer =
+  | { readonly kind: "backlog-item"; readonly itemId: string }
+  | { readonly kind: "open"; readonly intent: string };
+
+/** Declare a next step that names a filed backlog item. */
+export function backlogItem(itemId: string): NextStepPointer {
+  return { kind: "backlog-item", itemId };
+}
+
+/** Declare a next step that states intent because no item is filed for it. */
+export function openIntent(intent: string): NextStepPointer {
+  return { kind: "open", intent };
+}
+
+/** A backlog item the database actually holds. */
+export type FiledBacklogItem = {
+  readonly itemId: string;
+  readonly title: string;
+  readonly status: string;
+};
+
+/**
+ * A pointer after it has been checked against the database. `label` is the only
+ * field a surface should render: it is honest in all three cases, so a caller
+ * cannot accidentally print a dead identifier.
+ */
+export type ResolvedNextStep =
+  | {
+      readonly kind: "filed";
+      readonly itemId: string;
+      readonly title: string;
+      readonly status: string;
+      readonly label: string;
+    }
+  | { readonly kind: "unresolved"; readonly itemId: string; readonly label: string }
+  | { readonly kind: "open"; readonly intent: string; readonly label: string };
+
+/** Shown where a declared id names nothing the backlog holds. */
+export const UNRESOLVED_NEXT_STEP_LABEL = "Not filed";
+
+/** Every distinct backlog id these pointers claim, in declaration order. */
+export function declaredItemIds(pointers: Iterable<NextStepPointer>): string[] {
+  const seen = new Set<string>();
+  for (const pointer of pointers) {
+    if (pointer.kind === "backlog-item") seen.add(pointer.itemId);
+  }
+  return [...seen];
+}
+
+/**
+ * Resolve one declared pointer against the items known to be filed. Pure, so the
+ * honesty rule is testable without a database — the ambient-host-state guard
+ * (BI-95A83B47) exists because tests that reach for a live Postgres pass in one
+ * environment and fail in another.
+ */
+export function resolveNextStep(
+  pointer: NextStepPointer,
+  filed: ReadonlyMap<string, FiledBacklogItem>,
+): ResolvedNextStep {
+  if (pointer.kind === "open") {
+    return { kind: "open", intent: pointer.intent, label: pointer.intent };
+  }
+  const item = filed.get(pointer.itemId);
+  if (!item) {
+    return {
+      kind: "unresolved",
+      itemId: pointer.itemId,
+      label: UNRESOLVED_NEXT_STEP_LABEL,
+    };
+  }
+  return {
+    kind: "filed",
+    itemId: item.itemId,
+    title: item.title,
+    status: item.status,
+    label: item.itemId,
+  };
+}
+
+/** Read the claimed ids the backlog actually holds. The only database seam here. */
+export async function loadFiledBacklogItems(
+  itemIds: readonly string[],
+): Promise<Map<string, FiledBacklogItem>> {
+  if (itemIds.length === 0) return new Map();
+  const rows = await prisma.backlogItem.findMany({
+    where: { itemId: { in: [...itemIds] } },
+    select: { itemId: true, title: true, status: true },
+  });
+  return new Map(rows.map((row) => [row.itemId, row]));
+}
+
+/**
+ * Resolve a list of declared pointers in one query. The result is index-aligned
+ * with the input, so a surface can map its rows straight onto it.
+ */
+export async function resolveNextSteps(
+  pointers: readonly NextStepPointer[],
+): Promise<ResolvedNextStep[]> {
+  const filed = await loadFiledBacklogItems(declaredItemIds(pointers));
+  return pointers.map((pointer) => resolveNextStep(pointer, filed));
+}

--- a/apps/web/lib/finance/accountant-work-lane.test.ts
+++ b/apps/web/lib/finance/accountant-work-lane.test.ts
@@ -97,7 +97,7 @@ describe("bookkeeper accountant work lane", () => {
       ]),
     );
     expect(quickBooks?.writeBoundary).toContain("source-attributed");
-    expect(quickBooks?.nextBacklogItemId).toBe("BI-4025EF5F");
+    expect(quickBooks?.nextStep).toEqual({ kind: "open", intent: "Entity links and review queue" });
   });
 
   it("shows NO QuickBooks read coverage when the install has no real connection", () => {
@@ -118,9 +118,9 @@ describe("bookkeeper accountant work lane", () => {
     const bankFeeds = lane.providerBoundaries.find((boundary) => boundary.provider === "bank-feed-provider");
 
     expect(stripe?.missingCoverage).toContain("QuickBooks reconciliation");
-    expect(stripe?.nextBacklogItemId).toBe("BI-2DB52EAB");
+    expect(stripe?.nextStep).toEqual({ kind: "open", intent: "Fee and payout reconciliation" });
     expect(bankFeeds?.posture).toBe("not-mapped");
-    expect(bankFeeds?.nextBacklogItemId).toBe("BI-47366954");
+    expect(bankFeeds?.nextStep).toEqual({ kind: "open", intent: "Provider ownership decision" });
     expect(lane.promotionGuardrail).toContain("dual-run");
   });
 });

--- a/apps/web/lib/finance/accountant-work-lane.ts
+++ b/apps/web/lib/finance/accountant-work-lane.ts
@@ -1,4 +1,10 @@
 import {
+  openIntent,
+  resolveNextSteps,
+  type NextStepPointer,
+  type ResolvedNextStep,
+} from "@/lib/backlog/next-step-pointer";
+import {
   buildQuickBooksReadinessDescriptor,
   type QuickBooksReadinessConnection,
 } from "@/lib/integrations/quickbooks/readiness";
@@ -31,7 +37,7 @@ export type AccountantLaneHandoff = {
   boundary: string;
 };
 
-export type AccountantProviderBoundary = {
+export type AccountantProviderBoundary<Step = NextStepPointer> = {
   provider: string;
   label: string;
   href: string;
@@ -39,10 +45,10 @@ export type AccountantProviderBoundary = {
   currentCoverage: string[];
   missingCoverage: string[];
   writeBoundary: string;
-  nextBacklogItemId: string;
+  nextStep: Step;
 };
 
-export type AccountantWorkLane = {
+export type AccountantWorkLane<Step = NextStepPointer> = {
   roleId: "bookkeeper_accountant";
   roleLabel: string;
   taxonomyNodeId: string;
@@ -50,10 +56,10 @@ export type AccountantWorkLane = {
   maturityTarget: "observe";
   workstreams: AccountantWorkstream[];
   handoffs: AccountantLaneHandoff[];
-  providerBoundaries: AccountantProviderBoundary[];
+  providerBoundaries: AccountantProviderBoundary<Step>[];
   promotionGuardrail: string;
   nextWorkflow: {
-    backlogItemId: string;
+    nextStep: Step;
     title: string;
     route: string;
     reason: string;
@@ -172,7 +178,7 @@ export function buildBookkeeperAccountantWorkLane(
       missingCoverage: quickBooksMissingCoverage,
       writeBoundary:
         "QuickBooks staging is source-attributed and non-editable; no write-back or DPF-primary accounting ownership until entity links, reconciliation evidence, rollback/export, and accountant review are proven.",
-      nextBacklogItemId: "BI-4025EF5F",
+      nextStep: openIntent("Entity links and review queue"),
     },
     {
       provider: "stripe",
@@ -183,7 +189,7 @@ export function buildBookkeeperAccountantWorkLane(
       missingCoverage: ["Fees", "Payout deposits", "Invoice allocation matching", "QuickBooks reconciliation"],
       writeBoundary:
         "Stripe remains the payment processor; DPF should reconcile payment evidence before promoting billing records.",
-      nextBacklogItemId: "BI-2DB52EAB",
+      nextStep: openIntent("Fee and payout reconciliation"),
     },
     {
       provider: "bank-feed-provider",
@@ -194,13 +200,13 @@ export function buildBookkeeperAccountantWorkLane(
       missingCoverage: ["Direct bank feeds", "Statement source custody", "Automated reconciliation evidence"],
       writeBoundary:
         "Bank feeds stay unmapped until DPF chooses provider ownership and proves rollback/export expectations.",
-      nextBacklogItemId: "BI-47366954",
+      nextStep: openIntent("Provider ownership decision"),
     },
   ],
   promotionGuardrail:
     "DPF does not become the accounting system of record until read coverage, import staging, reconciliation evidence, rollback/export, and accountant review workflows are proven in dual-run.",
   nextWorkflow: {
-    backlogItemId: "BI-4025EF5F",
+    nextStep: openIntent("Entity links and review queue"),
     title: "QuickBooks import review queue and accounting entity links",
     route: "/platform/tools/integrations/quickbooks",
     reason:
@@ -209,15 +215,35 @@ export function buildBookkeeperAccountantWorkLane(
   };
 }
 
+/** The lane once every declared next step has been checked against the backlog. */
+export type ResolvedAccountantWorkLane = AccountantWorkLane<ResolvedNextStep>;
+
 /**
  * Load the accountant work lane with the install's REAL QuickBooks connection
- * state. Async because it reads the integration-credential substrate.
+ * state. Async because it reads the integration-credential substrate, and
+ * because a declared next step is a claim about the backlog that this lane
+ * checks before any surface renders it (BI-5BF97BAA).
  */
-export async function getBookkeeperAccountantWorkLane(): Promise<AccountantWorkLane> {
+export async function getBookkeeperAccountantWorkLane(): Promise<ResolvedAccountantWorkLane> {
   const quickBooksConnection = await loadQuickBooksReadinessConnection();
-  return buildBookkeeperAccountantWorkLane(quickBooksConnection);
+  const lane = buildBookkeeperAccountantWorkLane(quickBooksConnection);
+
+  const declared = [
+    ...lane.providerBoundaries.map((boundary) => boundary.nextStep),
+    lane.nextWorkflow.nextStep,
+  ];
+  const resolved = await resolveNextSteps(declared);
+
+  return {
+    ...lane,
+    providerBoundaries: lane.providerBoundaries.map((boundary, index) => ({
+      ...boundary,
+      nextStep: resolved[index],
+    })),
+    nextWorkflow: { ...lane.nextWorkflow, nextStep: resolved[resolved.length - 1] },
+  };
 }
 
-export function getAccountantLaneRouteHrefs(lane: AccountantWorkLane): string[] {
+export function getAccountantLaneRouteHrefs<Step>(lane: AccountantWorkLane<Step>): string[] {
   return Array.from(new Set(lane.workstreams.flatMap((workstream) => workstream.routes.map((route) => route.href))));
 }

--- a/apps/web/lib/integrations/import-review.ts
+++ b/apps/web/lib/integrations/import-review.ts
@@ -1,3 +1,4 @@
+import type { NextStepPointer } from "@/lib/backlog/next-step-pointer";
 import { createHash } from "crypto";
 import type {
   IntegrationImportDisplayField,
@@ -44,7 +45,7 @@ export interface IntegrationImportReviewPosture {
   status: "not-started" | "ready-to-review" | "blocked";
   sourceProvider: string;
   readOnly: true;
-  nextBacklogItemId: string;
+  nextStep: NextStepPointer;
   families: string[];
   guardrail: string;
 }

--- a/apps/web/lib/integrations/quickbooks/readiness.test.ts
+++ b/apps/web/lib/integrations/quickbooks/readiness.test.ts
@@ -59,7 +59,7 @@ describe("buildQuickBooksReadinessDescriptor", () => {
     ).toBe(true);
     expect(descriptor.importReview).toMatchObject({
       status: "ready-to-review",
-      nextBacklogItemId: "BI-4025EF5F",
+      nextStep: { kind: "open", intent: "Entity links and review queue" },
       readOnly: true,
       sourceProvider: "quickbooks",
     });
@@ -90,7 +90,7 @@ describe("buildQuickBooksReadinessDescriptor", () => {
       "Review non-editable import staging fields before creating local accounting links",
     );
     expect(descriptor.nextSafeActions).toContain(
-      "Persist reviewed import candidates through BI-4025EF5F before reconciliation",
+      "Persist reviewed import candidates before reconciliation",
     );
   });
 

--- a/apps/web/lib/integrations/quickbooks/readiness.ts
+++ b/apps/web/lib/integrations/quickbooks/readiness.ts
@@ -1,3 +1,4 @@
+import { openIntent } from "@/lib/backlog/next-step-pointer";
 import {
   normalizeReadinessCapability,
   type IntegrationReadinessCapability,
@@ -158,7 +159,7 @@ export function buildQuickBooksReadinessDescriptor({
     status: isConnected ? "ready-to-review" : "not-started",
     sourceProvider: "quickbooks",
     readOnly: true,
-    nextBacklogItemId: "BI-4025EF5F",
+    nextStep: openIntent("Entity links and review queue"),
     families: Array.from(QUICKBOOKS_IMPORT_STAGING_ENTITY_FAMILIES),
     guardrail:
       "Review queue records are DPF-held posture only; staged QuickBooks source records stay non-editable and external-owned until entity links are approved.",
@@ -247,7 +248,7 @@ function resolveNextSafeActions(status: QuickBooksReadinessConnection["status"])
       "Review mapped read coverage",
       "Use expanded QuickBooks read coverage to plan source-attributed staging before imports or writes",
       "Review non-editable import staging fields before creating local accounting links",
-      "Persist reviewed import candidates through BI-4025EF5F before reconciliation",
+      "Persist reviewed import candidates before reconciliation",
       "Keep bank feeds, tax authority, and accountant workflow blocked until their ownership gates are designed",
       "Keep write operations blocked until proposal-mode approval exists",
     ];

--- a/apps/web/lib/tools/integration-coverage-matrix.test.ts
+++ b/apps/web/lib/tools/integration-coverage-matrix.test.ts
@@ -28,8 +28,16 @@ describe("integration coverage matrix", () => {
           /^(business-capability|business-service|application-service|technical-service|service-offering)$/,
         );
         expect(row.it4itValueStreams.length).toBeGreaterThan(0);
-        expect(row.nextBacklogItemId).toMatch(/^BI-/);
-        expect(row.nextBacklogItemId).not.toBe("BI-861433C0");
+        // A declared next step states intent or names a filed item. It must NOT
+        // be forced into id shape: the old /^BI-/ assertion is what pushed 25
+        // rows into carrying identifiers nothing had filed (BI-5BF97BAA).
+        expect(row.nextStep.kind).toMatch(/^(backlog-item|open)$/);
+        if (row.nextStep.kind === "open") {
+          expect(row.nextStep.intent.trim().length).toBeGreaterThan(0);
+          expect(row.nextStep.intent).not.toMatch(/^BI-/);
+        } else {
+          expect(row.nextStep.itemId).toMatch(/^BI-[0-9A-F]{8}$/);
+        }
       }
     }
   });
@@ -42,7 +50,10 @@ describe("integration coverage matrix", () => {
       productName: "QuickBooks Online",
       maturity: "stage",
       posture: "hybrid",
-      nextBacklogItemId: "BI-07D76D6B",
+    });
+    expect(quickBooksRows[0]?.nextStep).toEqual({
+      kind: "open",
+      intent: "Entity links before write-back",
     });
     expect(quickBooksRows[0]?.employeeRoles).toContain("bookkeeper_accountant");
     expect(quickBooksRows[0]?.taxonomyNodeIds).toContain("for_employees/financial_management");

--- a/apps/web/lib/tools/integration-coverage-matrix.ts
+++ b/apps/web/lib/tools/integration-coverage-matrix.ts
@@ -1,3 +1,4 @@
+import { openIntent, type NextStepPointer } from "@/lib/backlog/next-step-pointer";
 import type { NativeIntegrationId } from "./native-integration-catalog";
 
 export type EmployeeWorkRole =
@@ -50,7 +51,7 @@ export type IntegrationCoverageMatrixRow = {
   maturity: IntegrationCoverageMaturity;
   csdmDomain: CsdmStructuralDomain;
   it4itValueStreams: It4ItValueStream[];
-  nextBacklogItemId: string;
+  nextStep: NextStepPointer;
   replacementCriteria: string;
   notes: string;
 };
@@ -124,7 +125,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "stage",
     csdmDomain: "service-offering",
     it4itValueStreams: ["strategy-to-portfolio", "request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-07D76D6B",
+    nextStep: openIntent("Entity links before write-back"),
     replacementCriteria:
       "DPF stays integration-led until source-attributed import staging, entity links, reconciliation evidence, accountant collaboration, rollback/export, and governed write-back gates prove system-of-record promotion criteria.",
     notes: "QuickBooks read coverage now feeds non-editable staging posture before any entity-link or write-back work.",
@@ -148,7 +149,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "read",
     csdmDomain: "application-service",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-07D76D6B",
+    nextStep: openIntent("Reconciliation parity with accounting"),
     replacementCriteria:
       "DPF should reconcile payments and customer invoices before promoting any local billing record as primary.",
     notes: "Stripe is a native payment anchor and a reconciliation dependency for accounting parity.",
@@ -172,7 +173,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "read",
     csdmDomain: "application-service",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-INT-F23BC6",
+    nextStep: openIntent("Payroll handoff into finance and HR"),
     replacementCriteria:
       "Payroll remains provider-led unless DPF later has compliance, tax, and payroll-control evidence for a narrow native service.",
     notes: "Payroll context belongs in finance and HR handoffs, not in a generic employee profile view.",
@@ -195,9 +196,9 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "stage",
     csdmDomain: "application-service",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-F3AEBF68",
+    nextStep: openIntent("Absorb ATS staging toward replacement"),
     replacementCriteria:
-      "Greenhouse stays integration-led until native recruiting (requisition-to-hire, converting into the worker record) reaches parity and a dual-run cutover is proven (BI-F3AEBF68).",
+      "Greenhouse stays integration-led until native recruiting (requisition-to-hire, converting into the worker record) reaches parity and a dual-run cutover is proven.",
     notes: "First ATS connector; imports jobs/candidates/applications/offers to read-only staging and lands hires into onboarding. Bridge -> absorb -> replace toward native recruiting.",
   },
   {
@@ -218,7 +219,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "read",
     csdmDomain: "business-service",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-INT-8D4F72",
+    nextStep: openIntent("Provider custody boundary for channels"),
     replacementCriteria:
       "DPF should orchestrate work and evidence while Microsoft 365 remains the provider system for mail, calendar, and Teams.",
     notes: "Communications coverage needs both worker queue consumption and provider-level custody boundaries.",
@@ -242,7 +243,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "read",
     csdmDomain: "service-offering",
     it4itValueStreams: ["strategy-to-portfolio", "request-to-fulfill"],
-    nextBacklogItemId: "BI-9A86E2A7",
+    nextStep: openIntent("One CRM lane across sales, marketing and support"),
     replacementCriteria:
       "DPF can own work queues and customer context while CRM remains provider-led until pipeline, consent, and support handoffs are explicit.",
     notes: "CRM coverage is shared by sales, marketing, and support rather than a single route.",
@@ -265,7 +266,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "read",
     csdmDomain: "application-service",
     it4itValueStreams: ["strategy-to-portfolio", "detect-to-correct"],
-    nextBacklogItemId: "BI-INT-E76A95",
+    nextStep: openIntent("Read-first signals for daily decisions"),
     replacementCriteria:
       "DPF should interpret and route marketing signals, not replace the analytics provider.",
     notes: "Marketing intelligence is a read-first signal source for owner and marketer daily decisions.",
@@ -288,7 +289,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "read",
     csdmDomain: "service-offering",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-9A86E2A7",
+    nextStep: openIntent("Local presence across marketing and support"),
     replacementCriteria:
       "DPF can stage local-presence work, but provider listings remain authoritative until write approvals and audit are designed.",
     notes: "Local presence belongs in both marketing and customer support coverage.",
@@ -311,7 +312,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "read",
     csdmDomain: "service-offering",
     it4itValueStreams: ["request-to-fulfill"],
-    nextBacklogItemId: "BI-9A86E2A7",
+    nextStep: openIntent("Land captured leads in the sales workflow"),
     replacementCriteria:
       "DPF should own lead triage and routing while Meta remains the campaign and form provider.",
     notes: "Lead capture must land in CRM/sales workflow, not just integration status.",
@@ -334,7 +335,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "read",
     csdmDomain: "service-offering",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-9A86E2A7",
+    nextStep: openIntent("Split publishing from support response"),
     replacementCriteria:
       "DPF should stage response work and evidence before any social write-back is allowed.",
     notes: "Social presence coverage crosses marketing publishing and support response work.",
@@ -357,7 +358,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "read",
     csdmDomain: "service-offering",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-INT-8D4F72",
+    nextStep: openIntent("Governance before outbound messaging"),
     replacementCriteria:
       "DPF should own messaging triage, template governance, and evidence while Meta remains the WhatsApp Cloud API provider until outbound send and webhook approvals are explicit.",
     notes: "Read-first WhatsApp phone and template readiness; outbound messaging stays out of scope until governance is explicit.",
@@ -380,7 +381,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "read",
     csdmDomain: "service-offering",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-INT-8D4F72",
+    nextStep: openIntent("Governance before social write-back"),
     replacementCriteria:
       "DPF should stage response and publishing work with evidence before any Instagram write-back is allowed; Meta remains the media and comment provider.",
     notes: "Read-first Instagram profile, media, and comment context; social write-back stays out of scope until governance is explicit.",
@@ -403,7 +404,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "read",
     csdmDomain: "application-service",
     it4itValueStreams: ["strategy-to-portfolio", "request-to-fulfill"],
-    nextBacklogItemId: "BI-INT-E76A95",
+    nextStep: openIntent("Consent boundaries before write-back"),
     replacementCriteria:
       "DPF should coordinate audiences, approvals, and outcomes while Mailchimp remains the campaign execution provider.",
     notes: "Campaign context needs consent and customer-record boundaries before write-back.",
@@ -425,7 +426,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "write-back",
     csdmDomain: "application-service",
     it4itValueStreams: ["strategy-to-portfolio", "request-to-fulfill"],
-    nextBacklogItemId: "BI-FBC9BA03",
+    nextStep: openIntent("Member-scope publishing only"),
     replacementCriteria:
       "Conduit-only personal publishing; operator brings their own LinkedIn developer app and credentials.",
     notes: "Phase 2 of the marketing execution loop. Scope w_member_social only; no company-page write, no ads.",
@@ -447,7 +448,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "write-back",
     csdmDomain: "application-service",
     it4itValueStreams: ["strategy-to-portfolio", "request-to-fulfill"],
-    nextBacklogItemId: "BI-5133E808",
+    nextStep: openIntent("Spend ceilings before adapter calls"),
     replacementCriteria:
       "Conduit-only paid placement. Operator brings their own LinkedIn ad account; DPF enforces hard weekly spend ceilings before any campaign goes live.",
     notes: "Phase 4 of the marketing execution loop. Reuses Phase 2's LinkedIn OAuth with optional r_ads/rw_ads scopes. Spend ceiling refused before adapter API call.",
@@ -470,7 +471,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "write-back",
     csdmDomain: "application-service",
     it4itValueStreams: ["strategy-to-portfolio", "request-to-fulfill"],
-    nextBacklogItemId: "BI-5133E808",
+    nextStep: openIntent("One approval path for outbound and inbound"),
     replacementCriteria:
       "Conduit-only email send + receive; operator brings their own Postmark server and signing secret.",
     notes: "Phase 3 of the marketing execution loop. Outbound send + inbound signed-webhook with classification + holding-pattern reply through the same approval queue.",
@@ -492,7 +493,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "observe",
     csdmDomain: "service-offering",
     it4itValueStreams: ["strategy-to-portfolio", "request-to-fulfill"],
-    nextBacklogItemId: "BI-INT-A5B9E3",
+    nextStep: openIntent("Adapter after QuickBooks proves the lane"),
     replacementCriteria:
       "Use Xero as a parity benchmark for accounting read breadth before considering another native connector.",
     notes: "Benchmark-only accounting product for customers that are not QuickBooks-centered.",
@@ -514,7 +515,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "observe",
     csdmDomain: "application-service",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-INT-F23BC6",
+    nextStep: openIntent("Compare SMB expectations against ADP"),
     replacementCriteria:
       "Keep payroll provider-led until HR, payroll tax, benefits, and finance posting boundaries are explicitly modeled.",
     notes: "Benchmark-only payroll product that helps compare SMB expectations against ADP coverage.",
@@ -537,7 +538,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "observe",
     csdmDomain: "business-service",
     it4itValueStreams: ["strategy-to-portfolio", "request-to-fulfill"],
-    nextBacklogItemId: "BI-9A86E2A7",
+    nextStep: openIntent("Benchmark only; no adapter planned"),
     replacementCriteria:
       "DPF should benchmark CRM breadth before deciding whether customer records become native, synchronized, or provider-led.",
     notes: "Benchmark-only CRM reference for sales pipeline, customer support, and analytics coverage.",
@@ -559,7 +560,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "observe",
     csdmDomain: "business-service",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-INT-8D4F72",
+    nextStep: openIntent("Channel-adapter decision"),
     replacementCriteria:
       "DPF should orchestrate tasks and evidence while chat remains a provider channel.",
     notes: "Benchmark-only communication provider for work queue and channel-adapter decisions.",
@@ -581,7 +582,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "observe",
     csdmDomain: "service-offering",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-9A86E2A7",
+    nextStep: openIntent("Support lane connector decision"),
     replacementCriteria:
       "DPF can become primary for lightweight support only after intake, SLA, assignment, knowledge, and customer portal coverage are native.",
     notes: "Benchmark-only support product for the customer support lane.",
@@ -603,7 +604,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "observe",
     csdmDomain: "service-offering",
     it4itValueStreams: ["strategy-to-portfolio", "request-to-fulfill"],
-    nextBacklogItemId: "BI-E1CFC8FB",
+    nextStep: openIntent("Inventory and procurement coverage decision"),
     replacementCriteria:
       "DPF should keep commerce provider-led until product catalog, inventory, order, payment, and fulfillment ownership are explicit.",
     notes: "Benchmark-only storefront product for inventory and procurement admin coverage.",
@@ -625,7 +626,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "observe",
     csdmDomain: "business-service",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-INT-1AB7D8",
+    nextStep: openIntent("CSDM reference, not an implementation target"),
     replacementCriteria:
       "DPF can borrow structural patterns while staying narrower than a CMDB/ITSM suite until service ownership and operations are native.",
     notes: "Benchmark-only service-management product and CSDM reference point, not a verbatim implementation target.",
@@ -647,7 +648,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "observe",
     csdmDomain: "application-service",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-INT-1AB7D8",
+    nextStep: openIntent("Work-queue modeling reference"),
     replacementCriteria:
       "Use as a workflow benchmark for request, incident, and change-style queue patterns before creating native equivalents.",
     notes: "Benchmark-only IT and service-ops reference for work queue modeling.",
@@ -669,7 +670,7 @@ export const INTEGRATION_COVERAGE_MATRIX: IntegrationCoverageMatrixRow[] = [
     maturity: "observe",
     csdmDomain: "technical-service",
     it4itValueStreams: ["request-to-fulfill", "detect-to-correct"],
-    nextBacklogItemId: "BI-F9E7B780",
+    nextStep: openIntent("Estate discovery before vendor RMM"),
     replacementCriteria:
       "Device and endpoint management should remain provider-led; DPF should consume posture and evidence signals.",
     notes: "Benchmark-only endpoint provider for IT/security/compliance coverage.",

--- a/scripts/check-rendered-backlog-pointers.mjs
+++ b/scripts/check-rendered-backlog-pointers.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+// Rendered-backlog-pointer guard — BI-5BF97BAA.
+//
+// THE FAILURE THIS PREVENTS
+//
+// A surface renders a backlog identifier as the reader's next step, and the
+// identifier names nothing. Seventeen references across the integrations and
+// finance surfaces did exactly that: `nextBacklogItemId` strings hardcoded in
+// source outlived the backlog reset of 2026-08-22 and kept printing ids that no
+// query could resolve. `/platform/tools/integrations`, that route's QuickBooks
+// page and `/finance` all offered a "what happens next" pointer aimed at an item
+// the database did not hold.
+//
+// The reset is not the anomaly. 178 of the 233 backlog ids in the last 600
+// commit subjects are gone too. The backlog is a resettable substrate; source is
+// not. A commit subject is a record of its time and may name a dead id. A
+// pointer offering the reader a next step may not.
+//
+// WHY THIS GUARD IS STATIC
+//
+// The obvious check — "does this id resolve?" — needs a database, and no CI
+// workflow declares a Postgres service. scripts/check-no-ambient-host-tests.mjs
+// exists because of BI-BFDCE0A9, where a test that reached for an ambient
+// Postgres was green in CI and red in the DB-less local gate; the sanctioned
+// answer is to self-gate and skip, which would leave this check inert exactly
+// where it is meant to bite. So the resolve check lives in a DB-gated test
+// (apps/web/lib/backlog/next-step-pointer.pg.test.ts) that runs where a database
+// exists, and CI enforces the structural invariant instead:
+//
+//   A declared backlog pointer reaches a reader only through the resolver.
+//
+// The resolver (apps/web/lib/backlog/next-step-pointer.ts) returns a `label`
+// that is honest in every case — the id when the item is filed, "Not filed"
+// when a declared id names nothing, the stated intent when nothing is filed
+// yet. A surface that renders `label` cannot print a dead identifier. A surface
+// that reaches past it can, so reaching past it is what this guard refuses.
+//
+// THE RULES
+//
+//   1. no-legacy-field   `nextBacklogItemId` must not appear under apps/web.
+//                        That is the field this defect lived in; the resolver's
+//                        `nextStep: NextStepPointer` replaced it.
+//   2. no-hardcoded-declaration
+//                        A backlog id frozen into a NEXT-STEP field anywhere
+//                        under apps/web. A literal is the only form that can
+//                        outlive the item it names. An id read from a query
+//                        resolves by construction, and an id in a PROVENANCE
+//                        field records what justified a decision and stays true
+//                        after the item is archived — neither is touched.
+//   3. no-raw-render     No file under apps/web/app or apps/web/components may
+//                        reach past the resolver for a declared pointer's raw id
+//                        (`{x.nextStep.itemId}`), or hardcode a backlog id into
+//                        copy a reader sees. Rendering goes through `.label`.
+//
+// A genuinely intentional finding can be annotated on, or immediately above, the
+// line with `rendered-backlog-pointer: allow <reason>` — the exemption is
+// stated, not silent.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..");
+const WEB = join(REPO_ROOT, "apps", "web");
+
+/** Directories whose files render to a person. */
+const RENDER_DIRS = ["app", "components"];
+
+const ALLOW_MARKER = "rendered-backlog-pointer: allow";
+
+/** The retired field name, in any position. */
+const LEGACY_FIELD_RE = /\bnextBacklogItemId\b/;
+
+/**
+ * Reaching past the resolver for a declared pointer's raw id.
+ *
+ * Deliberately NOT "any rendered *backlogItemId". A backlog id that came from a
+ * query resolves by construction — an escalation's linked item, a finding's
+ * item, a feature brief's intake — and those surfaces are correct as they are.
+ * What rots is an id FROZEN INTO SOURCE, which rule 2 catches at the point of
+ * declaration rather than at every place it might later be printed.
+ */
+const RAW_RENDER_RE = /\{[^{}]*\bnextStep\.itemId[^{}]*\}/;
+
+/** A backlog id, in either format the estate has used. */
+const BACKLOG_ID = String.raw`BI-(?:[0-9A-F]{8}\b|[A-Z]{2,6}-[0-9A-Z]{4,})`;
+
+/**
+ * A backlog id frozen into a NEXT-STEP field: `nextStep: "BI-…"`. This is the
+ * root shape of the defect — a literal is the only form that can outlive the
+ * item it names, and a next step is a forward-looking promise that has to still
+ * hold when someone reads it.
+ *
+ * Scoped to next-step fields on purpose. A backlog id in a PROVENANCE field —
+ * `reviewRef`, `ratifiedBy.ref`, an evidence `ref` — records which item
+ * justified a decision. That is backward-looking and stays true forever, even
+ * after the item is archived. Flagging those would be an over-reporting measure,
+ * which is a defect of its own.
+ */
+const NEXT_STEP_FIELDS = ["nextStep", "nextBacklogItemId", "nextItemId", "nextWorkflowItemId"];
+const HARDCODED_DECLARATION_RE = new RegExp(
+  String.raw`\b(?:${NEXT_STEP_FIELDS.join("|")})\s*:\s*"${BACKLOG_ID}[^"]*"`,
+);
+
+/**
+ * A backlog id sitting in rendered copy — as element text (`<span>BI-…</span>`)
+ * or as a rendered attribute (`value="BI-…"`).
+ *
+ * Deliberately NOT "any backlog id in a rendering file". Provenance ids in
+ * comments are everywhere and are correct: a comment records which item a change
+ * came from, which stays true after the item is archived. Only copy a reader
+ * sees makes a promise that has to still hold.
+ */
+const JSX_TEXT_ID_RE = new RegExp(String.raw`>[^<>{}]*\b${BACKLOG_ID}`);
+const JSX_ATTR_ID_RE = new RegExp(
+  String.raw`\b(?:value|label|title|children|placeholder)=\{?"[^"]*\b${BACKLOG_ID}`,
+);
+
+/**
+ * Drop comment text before matching, so a rule about a field is not tripped by
+ * prose describing that field. Returns one entry per input line to keep line
+ * numbers intact.
+ */
+export function stripComments(lines) {
+  let inBlock = false;
+  return lines.map((line) => {
+    let out = "";
+    let index = 0;
+    while (index < line.length) {
+      if (inBlock) {
+        const end = line.indexOf("*/", index);
+        if (end === -1) return out;
+        inBlock = false;
+        index = end + 2;
+        continue;
+      }
+      const lineComment = line.indexOf("//", index);
+      const blockComment = line.indexOf("/*", index);
+      if (blockComment !== -1 && (lineComment === -1 || blockComment < lineComment)) {
+        out += line.slice(index, blockComment);
+        inBlock = true;
+        index = blockComment + 2;
+        continue;
+      }
+      if (lineComment !== -1) return out + line.slice(index, lineComment);
+      return out + line.slice(index);
+    }
+    return out;
+  });
+}
+
+export function listSourceFiles(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry === "node_modules" || entry === ".next" || entry === "dist" || entry === ".turbo") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...listSourceFiles(full));
+    else if (/\.(ts|tsx)$/.test(entry) && !/\.(test|spec)\.(ts|tsx)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+/** True when the finding is explicitly exempted on its own line or the one above. */
+export function isAllowed(lines, index) {
+  const own = lines[index] ?? "";
+  const above = index > 0 ? lines[index - 1] : "";
+  return own.includes(ALLOW_MARKER) || above.includes(ALLOW_MARKER);
+}
+
+/**
+ * Findings for one file. `rendering` says whether the file reaches a reader,
+ * which is what makes a hardcoded id a defect rather than a note.
+ */
+export function findViolations({ file, text, rendering }) {
+  const findings = [];
+  const lines = text.split("\n");
+  const code = stripComments(lines);
+
+  code.forEach((line, index) => {
+    if (isAllowed(lines, index)) return;
+
+    if (LEGACY_FIELD_RE.test(line)) {
+      findings.push({
+        file,
+        line: index + 1,
+        rule: "no-legacy-field",
+        detail: "nextBacklogItemId is retired — declare a NextStepPointer as nextStep",
+      });
+    }
+
+    if (HARDCODED_DECLARATION_RE.test(line)) {
+      findings.push({
+        file,
+        line: index + 1,
+        rule: "no-hardcoded-declaration",
+        detail: "a backlog id frozen into source outlives the item — state intent with openIntent()",
+      });
+    }
+
+    if (!rendering) return;
+
+    if (RAW_RENDER_RE.test(line)) {
+      findings.push({
+        file,
+        line: index + 1,
+        rule: "no-raw-render",
+        detail: "render the resolved next step's label, not a declared backlog id",
+      });
+    } else if (JSX_TEXT_ID_RE.test(line) || JSX_ATTR_ID_RE.test(line)) {
+      findings.push({
+        file,
+        line: index + 1,
+        rule: "no-raw-render",
+        detail: "a backlog id hardcoded into copy cannot be checked against the backlog",
+      });
+    }
+  });
+
+  return findings;
+}
+
+export function scan(webRoot = WEB) {
+  const findings = [];
+  const roots = [
+    ...RENDER_DIRS.map((dir) => ({ dir: join(webRoot, dir), rendering: true })),
+    { dir: join(webRoot, "lib"), rendering: false },
+  ];
+
+  for (const { dir, rendering } of roots) {
+    for (const full of listSourceFiles(dir)) {
+      const file = relative(REPO_ROOT, full).replace(/\\/g, "/");
+      findings.push(...findViolations({ file, text: readFileSync(full, "utf8"), rendering }));
+    }
+  }
+
+  return findings;
+}
+
+function main() {
+  const findings = scan();
+
+  if (findings.length === 0) {
+    console.log("Rendered backlog pointers: every next step goes through the resolver.");
+    return;
+  }
+
+  console.error("Rendered backlog pointer guard failed.\n");
+  for (const finding of findings) {
+    console.error(`  ${finding.file}:${finding.line}  [${finding.rule}]  ${finding.detail}`);
+  }
+  console.error(
+    [
+      "",
+      "A next step reaches a reader only through the resolver in",
+      "apps/web/lib/backlog/next-step-pointer.ts, whose `label` is honest whether the",
+      "item is filed, missing, or not filed yet. Declare the step as a NextStepPointer,",
+      "resolve it in the server component, and render `.label`.",
+      "",
+      `Deliberate exception: annotate the line with "${ALLOW_MARKER} <reason>".`,
+    ].join("\n"),
+  );
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  main();
+}

--- a/scripts/check-rendered-backlog-pointers.test.mjs
+++ b/scripts/check-rendered-backlog-pointers.test.mjs
@@ -1,0 +1,104 @@
+// Self-test for check-rendered-backlog-pointers.mjs (BI-5BF97BAA).
+//
+// A guard that cannot fail is worse than no guard, because it reads as coverage.
+// This proves four things: it catches each shape of the real defect, it stays
+// quiet on the shapes that are correct as they are, the stated exemption works,
+// and the checked-in tree is clean.
+//
+// The precision cases are not padding. Two earlier drafts of this guard reported
+// 584 and then 9 findings that were all legitimate — provenance ids in comments,
+// then backlog ids read from a query — so the quiet cases below are the ones
+// that keep the guard honest enough to leave switched on.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { findViolations, scan } from "./check-rendered-backlog-pointers.mjs";
+
+function rendering(text) {
+  return findViolations({ file: "apps/web/components/Example.tsx", text, rendering: true });
+}
+
+function library(text) {
+  return findViolations({ file: "apps/web/lib/example.ts", text, rendering: false });
+}
+
+function rules(findings) {
+  return findings.map((finding) => finding.rule);
+}
+
+test("catches a backlog id frozen into a next-step field", () => {
+  // The exact shape of all seventeen references, post-rename.
+  assert.deepEqual(rules(library('    nextStep: "BI-4025EF5F",')), ["no-hardcoded-declaration"]);
+  // The hand-authored format that never matched the rest of the backlog.
+  assert.deepEqual(rules(library('    nextStep: "BI-INT-8D4F72",')), ["no-hardcoded-declaration"]);
+});
+
+test("catches the retired field wherever it appears", () => {
+  assert.ok(rules(library('  nextBacklogItemId: "BI-4025EF5F",')).includes("no-legacy-field"));
+  assert.ok(rules(library("  nextBacklogItemId: string;")).includes("no-legacy-field"));
+});
+
+test("catches reaching past the resolver for the raw item id", () => {
+  assert.deepEqual(rules(rendering("      <p>{row.nextStep.itemId}</p>")), ["no-raw-render"]);
+});
+
+test("catches a backlog id hardcoded into copy a reader sees", () => {
+  assert.deepEqual(rules(rendering('      <MetricPill label="Backlog" value="BI-4025EF5F" />')), [
+    "no-raw-render",
+  ]);
+  assert.deepEqual(rules(rendering("      <span>BI-INT-8D4F72</span>")), ["no-raw-render"]);
+});
+
+test("stays quiet on the resolved shape", () => {
+  assert.deepEqual(rendering("      <p>{coverageNextSteps[rowIndex].label}</p>"), []);
+  assert.deepEqual(rendering("      <p>{boundary.nextStep.label}</p>"), []);
+  assert.deepEqual(
+    rendering('      {nextStep?.kind === "filed" && <MetricPill label="Backlog" value={nextStep.label} />}'),
+    [],
+  );
+});
+
+test("stays quiet on a declared pointer that states intent", () => {
+  assert.deepEqual(library('    nextStep: openIntent("Entity links before write-back"),'), []);
+});
+
+// PRECISION — the cases an over-reporting draft got wrong.
+test("a backlog id read from a query is not a finding", () => {
+  // These resolve by construction: the row came from the backlog itself.
+  assert.deepEqual(rendering("      <span>{escalation.backlogItemId}</span>"), []);
+  assert.deepEqual(rendering("      {need.linkedBacklogItemId ? <Chip>{need.linkedBacklogItemId}</Chip> : null}"), []);
+});
+
+test("a backlog id in a provenance field is not a finding", () => {
+  // Backward-looking: which item justified this contract. Stays true after the
+  // item is archived, unlike a forward-looking next step.
+  assert.deepEqual(library('    reviewRef: "BI-3023912F",'), []);
+  assert.deepEqual(library('    ratifiedBy: { role: "owner", ref: "BI-7626A660" },'), []);
+});
+
+test("a backlog id named in a comment is not a finding", () => {
+  assert.deepEqual(library("// Fixed under BI-5BF97BAA."), []);
+  assert.deepEqual(rendering("  // Renders the resolved label (BI-5BF97BAA)."), []);
+  assert.deepEqual(library("/* nextStep: \"BI-4025EF5F\" was the old shape. */"), []);
+});
+
+test("honours a stated exemption on the line and the line above", () => {
+  assert.deepEqual(
+    rendering('      <span>BI-4025EF5F</span> {/* rendered-backlog-pointer: allow fixture copy */}'),
+    [],
+  );
+  assert.deepEqual(
+    rendering("      {/* rendered-backlog-pointer: allow fixture copy */}\n      <span>BI-4025EF5F</span>"),
+    [],
+  );
+});
+
+test("the checked-in tree passes", () => {
+  const findings = scan();
+  assert.deepEqual(
+    findings,
+    [],
+    `unexpected findings:\n${findings.map((f) => `  ${f.file}:${f.line} ${f.detail}`).join("\n")}`,
+  );
+});

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -61,6 +61,7 @@ const EXPECTED_LEGACY_JOBS = [
   "published-image-freshness",
   "release-asset-contract",
   "release-compose-pins",
+  "rendered-backlog-pointers",
   "repo-guard-loop",
   "reporting-composition-guard",
   "retention-enrollment-guard",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -431,6 +431,15 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       node("--test", "scripts/check-doc-reference-integrity.test.mjs"),
       node("scripts/check-doc-reference-integrity.mjs"),
     ]),
+    // BI-5BF97BAA: the integrations and finance surfaces rendered a "what
+    // happens next" backlog id that resolved to nothing — hardcoded strings that
+    // outlived the backlog reset. The backlog is resettable; source is not. The
+    // resolve check itself needs a database and so lives in a DB-gated test; this
+    // enforces the structural half, which is what CI can actually run.
+    guard("rendered-backlog-pointers", "Rendered Backlog Pointers", [
+      node("--test", "scripts/check-rendered-backlog-pointers.test.mjs"),
+      node("scripts/check-rendered-backlog-pointers.mjs"),
+    ]),
     guard("janitor-tests", "Janitor Tests", [
       node(
         "--test",


### PR DESCRIPTION
## Summary

The integrations and finance surfaces offered the reader a "what happens next" backlog identifier that resolved to nothing. **Eighteen references across four modules, rendered on three routes** — `/platform/tools/integrations`, that route's QuickBooks page, and `/finance`.

The ids were not placeholders. `BI-INT-8D4F72` was a real item; commit `9a3e5579` (#3111) shipped against it. They died when the backlog was reset on **2026-08-22** and source kept pointing at them. 178 of the 233 backlog ids in the last 600 commit subjects are gone the same way.

The backlog is a resettable substrate; source is not. A commit subject is a record of its time and may name a dead id. A pointer offering the reader a next step may not.

## What changed

A declared next step is now a `NextStepPointer` — a filed backlog id, or a stated intent when nothing is filed. Filed ids resolve against `BacklogItem` at render time; surfaces render the resolved `label`, honest in all three cases:

| case | rendered |
| --- | --- |
| item is filed | the id |
| declared id names nothing | `Not filed` |
| nothing filed yet | the stated intent |

All eighteen dead references became stated intent. **No items were filed to make dead pointers resolve** — several named work already shipped.

Two of the eighteen were in prose rather than a field (`"Persist reviewed import candidates through BI-4025EF5F before reconciliation"`) and were only caught by asserting on rendered output. Both sentences read fine without the id.

On the QuickBooks page the `Backlog` pill now renders only when the pointer resolves to a filed item. A compact metric slot names a live item or it is not shown.

## Why the guard is static rather than a resolve check

The obvious guard — "does this id resolve?" — needs a database, and **no CI workflow declares a Postgres service**. `scripts/check-no-ambient-host-tests.mjs` exists because of BI-BFDCE0A9, where a test that reached for an ambient Postgres was green in CI and red in the DB-less local gate; the sanctioned answer is to self-gate and skip, which would leave a resolve check inert exactly where it must bite.

So the halves are split:

- **CI** enforces the structural invariant — a declared pointer reaches a reader only through the resolver — in `scripts/check-rendered-backlog-pointers.mjs`, registered in `ci-policy-guards.mjs` so it actually runs.
- **The resolve check** lives in `next-step-pointer.pg.test.ts`, DB-gated with the house `describeDatabase` idiom. It skips in CI and runs under local-CI and anywhere `DATABASE_URL` is set. Its shape assertions sit outside the gate so they never go dark.

The guard is deliberately narrow. Two earlier drafts reported 584 and then 9 findings that were all legitimate — provenance ids in comments, then backlog ids read from a query. A backlog id in a **provenance** field (`reviewRef`, `ratifiedBy.ref`) is backward-looking and stays true after the item is archived; one read from a **query** resolves by construction. Neither is touched. The self-test pins those quiet cases so the guard stays precise enough to leave switched on.

## Design grounding

Design-Grounding-Decision: full grounding below.

- **Existing specs/plans reviewed:**
  - `docs/superpowers/specs/2026-05-24-capability-lane-customer-support-design.md` and its inventory-procurement peer already write an unfiled next step as prose (`"(open) — Channel write-back gate spec"`) rather than inventing an id. This types that convention instead of replacing it.
  - `docs/superpowers/plans/2026-07-16-connector-benchmark-coverage-matrix.md` defines the `BI-INT-*` family series and keys the matrix to it, confirming the ids were real.
- **Current code substrate reviewed:** `integration-coverage-matrix.ts` (25 rows), `accountant-work-lane.ts`, `quickbooks/readiness.ts` declare the pointers; three components render them. `apps/web/lib/backlog/` already holds the backlog helpers, so the resolver joins them rather than opening a second home.
- **Source of truth:** `BacklogItem` in Postgres. A declared id is a claim about that table, checked at render time.
- **Decision:** resolve at render with an honest unresolved state, plus a static guard. Kernel decision `DI-6FA5D515BD80` scored it **10.97** against 5.52 (hide the field) and 1.64 (file items to match the strings) — high confidence, no commandment conflict.

## Verification

```
pnpm --filter web exec vitest run   # 6 affected suites — 24/24
node --test scripts/check-rendered-backlog-pointers.test.mjs   # 11/11, incl. tree scan
pnpm --filter web build             # exit 0
node scripts/check-ci-policy-test-inventory.mjs   # ok
node scripts/check-style-drift.mjs  # ok
pnpm run check:prose-lint           # ok
```

The three render surfaces carry frozen prose-lint ratchets (textMass 300 / 44 / 21, "may shrink, never grow") and `/platform/tools/integrations` has a net-word-delta ≤ 0 rule. Display copy therefore lives in the `lib/` data modules — `lib/` is scored on the retired-vocabulary axis only — and the components render a variable, adding no source copy. Both ratchets pass.

`Janitor Tests` fails on this host, as it does on every branch: `gate-worktree.sh` bash-script and symlink tests under Windows. None of those files are in this diff.

## Docs

Docs-Impact-Decision: no user-facing route, install or coworker behaviour changes; the surfaces keep their columns and say the same thing more honestly.

Process-Spine-Decision: no new capability; an existing rendered pointer now resolves or states its absence, and a new CI guard holds that contract.

Refs: BI-5BF97BAA · Workroom WC-15233224 · EP-129D11FD
