### PR TITLE
docs(security): assess stack and design optional 1Password support (BI-E7553A1C)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 693,
+  "pageCount": 695,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -8893,6 +8893,20 @@
         "pr-index"
       ]
     },
+    "docs/security/2026-08-30-security-authentication-stack-assessment.md": {
+      "publicHref": "/security/2026-08-30-security-authentication-stack-assessment/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "security-and-authentication-stack-assessment",
+        "outcome",
+        "implemented-stack-versus-design",
+        "backlog-and-plan-conformance-findings",
+        "priority-order",
+        "security-boundary-for-1password"
+      ]
+    },
     "docs/security/README.md": {
       "publicHref": "/security/README/",
       "portalHref": null,
@@ -8994,6 +9008,27 @@
         "execution-record-2026-08-28",
         "re-evaluation",
         "sources"
+      ]
+    },
+    "docs/security/tool-evaluations/2026-08-30-1password.md": {
+      "publicHref": "/security/tool-evaluations/2026-08-30-1password/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "1password-tool-evaluation",
+        "executive-decision",
+        "what-the-product-isand-is-not",
+        "security-and-architecture-evaluation",
+        "integration-choices",
+        "chosen-first-1password-connect-rest-api",
+        "supported-later-service-accounts",
+        "rejected-op-run-inside-the-portal-image",
+        "rejected-moving-connector-credentials-into-1password",
+        "benchmarking",
+        "standards",
+        "primary-vendor-sources",
+        "re-evaluation-triggers"
       ]
     },
     "docs/specs/device-identification-and-portfolio-placement-spec.md": {

--- a/docs/security/2026-08-30-security-authentication-stack-assessment.md
+++ b/docs/security/2026-08-30-security-authentication-stack-assessment.md
@@ -47,11 +47,11 @@ The largest remaining security risks are at the edges of that architecture:
 ## Priority order
 
 1. **Now—BI-E7553A1C:** externalize startup root-secret custody behind a provider-neutral, fail-closed boundary; keep environment as default and 1Password optional.
-2. **Next—key lifecycle:** version the encrypted credential envelope, support read-old/write-new, controlled re-encryption, recovery, and compromise rotation before encouraging routine key rotation.
-3. **Next—production credential enforcement:** enforce `operator-only` at grants, host/runtime actions, diagnostics, and container-exec exposure boundaries; external vault use is defense in depth, not the enforcement mechanism.
-4. **Next—authentication assurance:** choose and implement workforce passkeys/MFA plus session/reauthentication tiers against NIST SP 800-63B-4.
-5. **Next—identity-path symmetry:** make customer/social sign-in consult the Principal spine before session issuance and migrate social-provider secrets into the canonical credential store.
-6. **Hygiene:** reconcile merged PR evidence to live BI states and replace stale spec/backlog identifiers with live pointers.
+2. **Next—BI-32935E47:** version the encrypted credential envelope, support read-old/write-new, controlled re-encryption, recovery, and compromise rotation before encouraging routine key rotation.
+3. **Next—BI-80E4A139:** enforce `operator-only` at grants, host/runtime actions, diagnostics, and container-exec exposure boundaries; external vault use is defense in depth, not the enforcement mechanism.
+4. **Next—BI-C9656270:** choose and implement workforce passkeys/MFA plus session/reauthentication tiers against NIST SP 800-63B-4.
+5. **Next—BI-E22C3D75 and BI-DD3BBD02:** make customer/social sign-in consult the Principal spine before session issuance and migrate social-provider secrets into the canonical credential store.
+6. **Hygiene—BI-FE678DA3:** reconcile merged PR evidence to live BI states and replace stale spec/backlog identifiers with live pointers.
 
 ## Security boundary for 1Password
 

--- a/docs/security/2026-08-30-security-authentication-stack-assessment.md
+++ b/docs/security/2026-08-30-security-authentication-stack-assessment.md
@@ -1,0 +1,66 @@
+# Security and authentication stack assessment
+
+**As assessed:** 2026-08-30 against `origin/main` at `005d10dab` and the live PostgreSQL backlog  
+**Backlog:** BI-E7553A1C  
+**Scope:** identity, authentication, sessions, authorization, LDAP, PKI/mTLS, machine tokens, connector credentials, and runtime root-secret custody
+
+## Outcome
+
+The architecture has converged substantially since the older enterprise-auth plans. DPF now has one Principal authorization spine, an install-owned directory projection, a real LDAPS listener, Step CA organization PKI, scoped/revocable machine tokens, OAuth 2.1 work for MCP, and a provider-neutral connector credential kernel. The correct direction is to finish and harden these systems—not replace them with 1Password or another IdP.
+
+The largest remaining security risks are at the edges of that architecture:
+
+1. root secrets are single environment values with no executable external-provider boundary and no key-version rotation path;
+2. production's `operator-only` credential stance is advisory at several host/container access boundaries rather than universally enforced;
+3. local workforce login has no native MFA/passkey assurance tier even though policy surfaces refer to step-up;
+4. customer/social authentication does not consult the Principal spine at the same sign-in boundary used by workforce credentials;
+5. some live backlog statuses and older spec references are stale relative to merged code, weakening roadmap truth.
+
+## Implemented stack versus design
+
+| Capability | Canonical intent | Current evidence | Assessment | Remaining work / live coverage |
+|---|---|---|---|---|
+| Canonical identity | `Principal` + `PrincipalAlias` is the enduring subject; credential holders are aliases, not parallel authority roots. | `core-identity.prisma`; `principal-linking.ts`; `effective-auth-context.ts`. | Strong substrate, broadly used. | Continue eliminating legacy `userId`-only authorization and close authority-model items under EP-31815F97. |
+| Workforce authentication | Verify the credential, then let the Principal spine decide whether the identity may act. | `govern/auth.ts` calls `authorizePrincipalForSession`; inactive principals are refused; deactivation is transactional. | Implemented. | Put `principalId` in the session or keep the current authoritative lookup consistently; do not add a second identity cache. |
+| Customer/social authentication | Customer identities converge to Principal and inactive principals cannot authenticate. | Customer password and Google/Apple paths issue sessions from `CustomerContact`; `loadEffectiveAuthContext` resolves aliases later. | Partial: authorization eventually resolves Principal, but the sign-in boundary is asymmetric with workforce. | File a focused successor BI after confirming desired customer/partner authority semantics. |
+| Password authentication | Strong hashes, rehash-on-login, reset/recovery, no plaintext. | `password.ts`, Auth.js credential providers, reset design and routes. | Implemented baseline. | Native MFA/passkeys and risk-based reauthentication remain absent for workforce portal login. |
+| Session security | HttpOnly, SameSite=Lax, HTTPS-aware Secure flag, JWT strategy, bounded redirect normalization. | `govern/auth.ts`. | Sound self-hosted baseline. | Explicit session lifetime/reauthentication assurance policy and root-secret versioned rotation are not complete. |
+| OAuth / MCP clients | OAuth 2.1 authorization-server metadata, scoped access, refresh rotation/revocation, step-up scope challenges. | `lib/auth/oauth-*`, `/api/mcp/v1`, MCP self-authentication design. | Substantial implementation. | Several BI ids named in the 2026-08-26 spec no longer resolve in live backlog; reconcile plan identity/status before calling it complete. |
+| Authorization | Effective authority is an intersection of Principal, role/capability, grant, sensitivity, room/case, and channel policy. | TAK grants, effective auth context, governed execute, workroom policy. | Strong and intentionally DPF-owned. | Finish the open Coworker Authority Model epic and enforce installation stance at the actual capability boundary. |
+| Directory | DPF publishes its own identity projection and remains complete without an external IdP. | Directory absorption design; projection and Principal-rooted auth merged in PR #4780. | Implemented core. | Maintain protocol and operator evidence; do not add authentik or make federation mandatory. |
+| LDAP | Bind/search/group membership over TLS from DPF's directory. | `lib/directory/ldap/*`; `instrumentation.ts`; compose port/config; PR #4825. | Implemented and runtime-wired, off by default. | Live BI-A91004A7 still reads `triaging` although its titled fix merged as PR #4825—status reconciliation required. |
+| PKI / mTLS | One organization CA issues portal/edge/directory material; no self-signed downgrade. | pinned Step CA image, bootstrap scripts, TLS overlays, PKI contract tests, LDAP TLS loader. | Implemented foundation. | Continue certificate-expiry, renewal, revocation, recovery, and canonical-runtime evidence; 1Password may hold keys but never becomes issuer/trust authority. |
+| Connector credentials | One provider-neutral store owns schemas, encrypted fields/token cache, redaction, health, reconnect, and audit. | `IntegrationCredential`; connector kernel credential store; AES-256-GCM guard. | Strong lifecycle boundary. | Ciphertext format has no key id/version; changing `CREDENTIAL_ENCRYPTION_KEY` makes old ciphertext unreadable. File separate rotation work. |
+| Social-provider secrets | Secret values should use the same protected credential boundary. | Auth sync reads `google_client_secret` and `apple_client_secret` from `PlatformConfig` into env. | Gap: this is outside the connector credential kernel and its encrypted envelope. | Migrate to the canonical credential store in a focused BI; do not route it through the 1Password bootstrap item. |
+| Runtime root secrets | Logical secrets are portable across `.env`, cloud managers, Kubernetes, and external vaults. | Deployment contract §8 says this; compose currently injects `AUTH_SECRET` and `CREDENTIAL_ENCRYPTION_KEY` from `.env`. | Design exists, adapter substrate absent. | BI-E7553A1C implements the provider boundary and first 1Password Connect adapter. |
+| Production agent access | Production credentials are operator-only and an agent cannot mint/read them merely because it can exec a container. | Installation stance reports `operator-only`; recovery backlog captured the missing enforcement problem. | Critical policy/enforcement gap; not live backlog-covered after installation replacement. | Re-file as live governed work; external custody reduces persistence but cannot protect a secret from a fully privileged process that legitimately consumes it. |
+| Assurance / MFA | Sensitive actions require real step-up, not merely an approval label. | OAuth scope challenges and channel policies model `auth-required`; GitHub upstream auth delegates 2FA to GitHub. | Partial. | DPF portal workforce MFA/passkeys and consistent AAL/session policy need design and live BI coverage. |
+
+## Backlog and plan conformance findings
+
+- EP-24741BBF is the correct live directory/identity program. Its core implementation has advanced farther than several child statuses imply.
+- BI-A91004A7 is a concrete status-drift example: the live item says `triaging`, while PR #4825 with the same title is merged and the runtime entrypoint is present on `origin/main`.
+- The 2026-08-26 MCP self-authentication spec names BI-1819D34F, BI-C7151B1B, BI-E4DFDCB0, BI-ED1BBC9E, and BI-MCP-7E53D1; none resolve in the current live backlog.
+- Older documents reference epics such as EP-1FABA22D, EP-COMPANY-IAM-FOUNDATION, EP-IAM-ADMIN-PORTAL-AUDIT, EP-TAK-3F9A21, and EP-AGENT-AUTH-VAULT; none resolve live. They must be treated as historical/superseded identifiers, not current delivery coverage.
+- The recovery bundle contains a detailed production credential-enforcement item, but the corresponding live item is absent. Recovery JSON is not live backlog and cannot satisfy the gap.
+
+## Priority order
+
+1. **Now—BI-E7553A1C:** externalize startup root-secret custody behind a provider-neutral, fail-closed boundary; keep environment as default and 1Password optional.
+2. **Next—key lifecycle:** version the encrypted credential envelope, support read-old/write-new, controlled re-encryption, recovery, and compromise rotation before encouraging routine key rotation.
+3. **Next—production credential enforcement:** enforce `operator-only` at grants, host/runtime actions, diagnostics, and container-exec exposure boundaries; external vault use is defense in depth, not the enforcement mechanism.
+4. **Next—authentication assurance:** choose and implement workforce passkeys/MFA plus session/reauthentication tiers against NIST SP 800-63B-4.
+5. **Next—identity-path symmetry:** make customer/social sign-in consult the Principal spine before session issuance and migrate social-provider secrets into the canonical credential store.
+6. **Hygiene:** reconcile merged PR evidence to live BI states and replace stale spec/backlog identifiers with live pointers.
+
+## Security boundary for 1Password
+
+1Password reduces secret persistence and centralizes custody/rotation evidence. It cannot prevent a compromised portal process or host administrator from reading secrets the process must use. The threat-model improvement is therefore:
+
+- secrets no longer need to be durable in the DPF install's `.env`;
+- vault access can be isolated and revoked independently;
+- startup access appears in vendor audit events;
+- provider outage fails startup rather than silently downgrading;
+- application semantics remain portable.
+
+It is not a sandbox, HSM, process-isolation boundary, IdP, CA, or authorization engine.

--- a/docs/security/2026-08-30-security-authentication-stack-assessment.md
+++ b/docs/security/2026-08-30-security-authentication-stack-assessment.md
@@ -40,8 +40,8 @@ The largest remaining security risks are at the edges of that architecture:
 
 - EP-24741BBF is the correct live directory/identity program. Its core implementation has advanced farther than several child statuses imply.
 - BI-A91004A7 is a concrete status-drift example: the live item says `triaging`, while PR #4825 with the same title is merged and the runtime entrypoint is present on `origin/main`.
-- The 2026-08-26 MCP self-authentication spec names BI-1819D34F, BI-C7151B1B, BI-E4DFDCB0, BI-ED1BBC9E, and BI-MCP-7E53D1; none resolve in the current live backlog.
-- Older documents reference epics such as EP-1FABA22D, EP-COMPANY-IAM-FOUNDATION, EP-IAM-ADMIN-PORTAL-AUDIT, EP-TAK-3F9A21, and EP-AGENT-AUTH-VAULT; none resolve live. They must be treated as historical/superseded identifiers, not current delivery coverage.
+- The 2026-08-26 MCP self-authentication spec names five BI references that no longer resolve in the current live backlog. The reconciliation item must preserve the original text as historical evidence while replacing its current delivery pointers with live items.
+- Older documents also name several epic references that no longer resolve live. They must be treated as historical/superseded identifiers, not current delivery coverage, and replaced by live pointers where the work remains active.
 - The recovery bundle contains a detailed production credential-enforcement item, but the corresponding live item is absent. Recovery JSON is not live backlog and cannot satisfy the gap.
 
 ## Priority order

--- a/docs/security/tool-evaluations/2026-08-30-1password.md
+++ b/docs/security/tool-evaluations/2026-08-30-1password.md
@@ -1,0 +1,89 @@
+# 1Password tool evaluation
+
+**Date:** 2026-08-30  
+**Backlog:** BI-E7553A1C  
+**Decision:** adopt as an optional bootstrap-secret provider; reject as an identity, directory, PKI, authorization, or connector-credential system of record.
+
+## Executive decision
+
+1Password fits DPF at one narrow boundary: an operator may keep the small set of runtime root secrets outside the installation and let DPF resolve them before migrations and portal startup. DPF continues to own `Principal`, `PrincipalAlias`, authentication policy, LDAP, Step CA PKI, authorization, token lifecycle, `IntegrationCredential`, encryption, redaction, and DPF audit receipts.
+
+The first adapter uses 1Password Connect's private REST API. The 1Password SDKs are not used because they remain version 0 and 1Password warns that minor releases may break compatibility. Service accounts remain a later alternative for deployment shapes where their SDK/support and rate-limit profile are acceptable.
+
+## What the product is—and is not
+
+1Password is a secrets manager and privileged-access product. It can store passwords, API keys, SSH keys, certificates, and machine secrets. It can provision users from an upstream identity provider and participate in SSO, but it does not become the authoritative directory or certificate authority in that arrangement. Its SCIM documentation explicitly starts with an identity provider, and its SSO documentation names providers such as Microsoft Entra ID and Okta as the identity authority.
+
+Therefore:
+
+- it does **not** replace DPF's LDAP service;
+- it does **not** issue, renew, revoke, or establish trust for DPF's PKI certificates;
+- it does **not** replace DPF principals, roles, groups, capabilities, or policy decisions;
+- it does **not** replace DPF's provider-neutral connector credential lifecycle or audit trail;
+- it may hold the root material that bootstraps those DPF-owned systems.
+
+## Security and architecture evaluation
+
+| Lens | Evidence and risk | DPF treatment |
+|---|---|---|
+| Least privilege | Connect access tokens are vault-scoped. Service-account access is also vault-scoped, and vault access cannot be expanded after creation. Neither is item-field scoped. | Require a dedicated DPF runtime-secrets vault containing only the item DPF needs. Never reuse a personal or broad operations vault. |
+| Bootstrap problem | Connect and service-account access both require a bearer token. Compromise of that token exposes every item in its allowed vault. | Prefer a file-mounted token supplied by the deployment wrapper; permit an environment token only for deployment shapes that cannot mount a secret. Refuse ambiguous dual configuration. Never persist or log it. |
+| Availability | Connect runs two containers (`connect-api`, `connect-sync`) and keeps a local cache. Startup still depends on the private Connect endpoint being reachable. | Resolve only at process start, use a bounded timeout, fail closed, and document recovery/rollback. A running process does not continuously depend on Connect. |
+| Rate limits | 1Password documents plan-dependent service-account request limits; Business currently documents 10,000 reads/hour, 1,000 writes/hour, and 50,000 requests/day per account. | Fetch one item once per portal start. Do not resolve per request or per connector operation. |
+| Supply chain | Connect adds two pinned runtime images if an operator self-hosts it. The SDK route would add a version-0 library with a short support window. | The first adapter calls the documented REST API with the Node runtime already shipped by DPF. DPF does not bundle Connect or add an SDK dependency. Operators manage Connect separately. |
+| Audit | 1Password Business Events Reporting includes sign-in, item usage, and audit events. DPF separately records its own startup status and operational evidence. | Treat vendor audit as custody evidence, not as a replacement for DPF action receipts. Never include secret values in either trail. |
+| Compliance | 1Password publishes SOC 2 Type 2 and ISO 27001/27017/27018/27701 assessment material. Certifications do not automatically make a customer's deployment compliant. | Record the vendor evidence as an input. The operator still owns residency, access, retention, incident response, and deployment review. |
+| Portability | A provider-specific call embedded in auth or connector code would create lock-in. | Keep one startup provider interface. `environment` remains default; deployment wrappers may later add Vault/OpenBao, cloud secret managers, or Kubernetes adapters without changing application semantics. |
+
+## Integration choices
+
+### Chosen first: 1Password Connect REST API
+
+Connect exposes a private REST API, maintains a local cache, and avoids adding a version-0 SDK to the portal. DPF fetches one explicitly identified item once before migrations, selects only allow-listed field labels, and passes the values to the child process environment without writing an intermediate file.
+
+### Supported later: service accounts
+
+Service accounts are operationally lighter than Connect, but the supported SDKs are still version 0 and their token/rate-limit lifecycle needs its own adapter review. DPF will not make a raw, undocumented call to the 1Password public API.
+
+### Rejected: `op run` inside the portal image
+
+Bundling the CLI expands the image and supply chain, couples startup to CLI output conventions, and still injects secrets into the child environment. It is acceptable as an operator-side wrapper, not as DPF's canonical runtime contract.
+
+### Rejected: moving connector credentials into 1Password
+
+`IntegrationCredential` has provider-neutral schemas, health, redaction, reconnect behavior, token caching, and DPF audit semantics. Replacing it with arbitrary vault items would split lifecycle truth and make core behavior vendor-dependent. Future adapters may support external ciphertext/key custody behind that store, but they must not move its semantics.
+
+## Benchmarking
+
+| Product | Strength worth adopting | Why it is not the first DPF adapter |
+|---|---|---|
+| HashiCorp Vault | KV v2 versioning, fine-grained policies, dynamic secrets, transit encryption, HA, and detailed audit devices. | Stronger machine-secret platform but materially heavier to operate; some deployment/replication features are commercial. DPF should remain compatible through the provider boundary. |
+| OpenBao | Open-governance Vault lineage, encrypted-at-rest secret engines, ACLs, audit-before-response security model, and HA. | Good self-hosted fit and likely second adapter; it still introduces a security-critical service the operator must initialize, unseal, back up, monitor, and upgrade. |
+| Infisical | Machine identities with Token, Universal, Kubernetes, AWS, Azure, and GCP authentication and short-lived access tokens. | Attractive workload-identity breadth, but a different operational ecosystem and another server dependency. Its machine identity model reinforces the provider-neutral boundary rather than a 1Password-only contract. |
+
+DPF adopts the shared pattern—central custody, narrow machine identity, bounded startup resolution, audit, rotation, and provider portability—not any vendor's identity model.
+
+## Standards
+
+- [NIST SP 800-57 Part 1 Rev. 5](https://csrc.nist.gov/pubs/sp/800/57/pt1/r5/final): key material needs an explicit lifecycle covering generation, storage, use, recovery, revocation, compromise, and destruction.
+- [NIST SP 800-63B-4](https://csrc.nist.gov/pubs/sp/800/63/b/4/final): authentication and authenticator lifecycle are separate from authorization and directory semantics.
+- [OWASP Secrets Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html): centralize custody, minimize scope, automate rotation, audit access, plan availability/recovery, and never log values.
+
+## Primary vendor sources
+
+- [1Password Connect overview](https://www.1password.dev/connect/)
+- [Connect server security](https://www.1password.dev/connect/security/)
+- [Service accounts](https://www.1password.dev/service-accounts/)
+- [Service-account security](https://www.1password.dev/service-accounts/security/)
+- [Service-account rate limits](https://www.1password.dev/service-accounts/rate-limits/)
+- [1Password SDKs](https://www.1password.dev/sdks/)
+- [SCIM provisioning](https://support.1password.com/scim/)
+- [Events Reporting](https://support.1password.com/events-reporting/)
+- [Security assessments](https://support.1password.com/security-assessments/)
+- [Vault KV](https://developer.hashicorp.com/vault/docs/secrets/kv), [Vault audit](https://developer.hashicorp.com/vault/docs/audit), and [Vault HA](https://developer.hashicorp.com/vault/docs/internals/high-availability)
+- [OpenBao security model](https://openbao.org/docs/internals/security/) and [OpenBao KV](https://openbao.org/docs/commands/kv/)
+- [Infisical machine identities](https://infisical.com/docs/documentation/platform/identities/machine-identities)
+
+## Re-evaluation triggers
+
+Re-evaluate before adding a service-account adapter, using the SDK, bundling Connect, writing vault items, moving connector ciphertext, or claiming compliance inherited from the vendor. Also re-evaluate when 1Password changes Connect support, SDK stability, service-account scoping, rate limits, or licensing.

--- a/docs/superpowers/plans/2026-08-30-optional-runtime-secret-provider.md
+++ b/docs/superpowers/plans/2026-08-30-optional-runtime-secret-provider.md
@@ -1,0 +1,99 @@
+# Optional runtime-secret provider implementation plan
+
+**Backlog:** BI-E7553A1C  
+**Design:** `docs/superpowers/specs/2026-08-30-optional-runtime-secret-provider-design.md`  
+**Workroom:** WC-9BD0CE91  
+**Branch:** `feat/security-auth-1password`
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Delivery boundary
+
+This plan is atomic. The assessment/evaluation/design explain the same startup boundary the code and operator documentation implement. Shipping only the adapter would create an undocumented security-critical path; shipping only the contract would repeat the existing unimplemented-provider promise; shipping the Docker wiring without the resolver would prevent existing installs from starting. The phases below are test-first sequencing inside one deployable change, not independent product outcomes.
+
+## Impact contract
+
+Workroom scope claim on 2026-08-30 returned a resolved change-impact contract:
+
+- no route, schema, migration, ratchet, or targeted-test impact was inferred;
+- runtime code requires `pnpm run pregate:preflight` and an exact-tree `pnpm run pregate`;
+- new docs require `pnpm docs:index`;
+- CI remains authoritative.
+
+## Phase 1—red contract tests
+
+**Deliverable:** failing tests encode the provider, config, fetch, field, failure, redaction, and command-execution contract.
+
+**Files:** `scripts/runtime-secret-bootstrap.test.mjs`.
+
+**Requirements:** OBJ-RSP-001, OBJ-RSP-002, OBJ-RSP-004.  
+**Contracts:** provider contract §4.1, allow-list §4.2, Connect contract §4.3–4.4.  
+**Flows:** FLOW-RSP-ENV, FLOW-RSP-1P, FLOW-RSP-REFUSE.  
+**Verification:** AC-RSP-001, AC-RSP-002, AC-RSP-003, AC-RSP-005.
+
+Run the focused Node test and record the expected module-not-found/assertion failure before implementation.
+
+## Phase 2—green provider-neutral resolver
+
+**Deliverable:** a dependency-free Node module validates startup configuration, resolves environment or 1Password Connect values through injected seams, emits only typed/value-free errors, and spawns the supplied command with an in-memory environment.
+
+**Files:** `scripts/runtime-secret-bootstrap.mjs`, focused test.
+
+**Dependencies:** Phase 1.  
+**Requirements:** OBJ-RSP-001, OBJ-RSP-002, OBJ-RSP-004.  
+**Contracts:** §§4.1–4.5.  
+**Flows:** all three flows.  
+**Verification:** focused tests green, including negative matrix and a child-process execution seam.
+
+## Phase 3—runtime and deployment wiring
+
+**Deliverable:** the production image invokes the bootstrap before `portal-migrate-boot.sh`; compose forwards only the provider-edge configuration and no longer rejects intentionally externally supplied root values before the adapter can resolve them.
+
+**Files:** `Dockerfile`, `docker-compose.yml`, deployment contract.
+
+**Dependencies:** Phase 2.  
+**Requirements:** OBJ-RSP-001, OBJ-RSP-003, OBJ-RSP-004.  
+**Contracts:** §§4 and 6.  
+**Flows:** FLOW-RSP-ENV and FLOW-RSP-REFUSE.  
+**Verification:** Dockerfile/compose contract assertions, existing image-manifest checks, production build, AC-RSP-001, AC-RSP-004, AC-RSP-005.
+
+## Phase 4—operator and security documentation
+
+**Deliverable:** current assessment, tool evaluation, deployment doctrine, and operator runbook explain what 1Password replaces, what it does not, least privilege, startup/outage behavior, recovery, and rollback.
+
+**Files:** security assessment/evaluation, design, deployment contract, `docs/install/security-authentication.md`.
+
+**Dependencies:** Phases 2–3 so docs describe real names/behavior.  
+**Requirements:** OBJ-RSP-003, OBJ-RSP-005.  
+**Contracts:** §§6–9.  
+**Flows:** FLOW-RSP-1P and FLOW-RSP-REFUSE.  
+**Verification:** docs index/link guard, secret scan, AC-RSP-006.
+
+## Phase 5—governed completion
+
+Run focused tests, affected source-local checks, `pnpm docs:index`, production web build, `pnpm run pregate:preflight`, exact-tree `pnpm run pregate`, and independent semantic review. Commit DCO-signed, push, run `pnpm pr:ready`, open a ready non-draft PR, and update BI-E7553A1C only after evidence is accepted.
+
+**Verification:** AC-RSP-007 and all workroom impact obligations.
+
+## Backlog coverage
+
+- **Decision:** atomic.
+- **Parent / implementation BI:** BI-E7553A1C.
+- **Deliverable mapping:** `runtime-secret-provider` → BI-E7553A1C.
+- **Dependencies:** none outside the current platform substrate.
+- **Rationale:** assessment, design, resolver, boot wiring, and operator contract form one security boundary and cannot be released safely in isolation.
+- **Governed receipt:** pending independent spec approval and immutable plan commit; insert the returned receipt before implementation.
+
+## Risks and rollback
+
+| Risk | Control | Rollback |
+|---|---|---|
+| Existing installs fail because compose no longer rejects missing root values itself. | Default environment provider validates before migration and tests prove no network call/unchanged values. | Restore previous CMD/compose requirements; existing `.env` values remain compatible. |
+| Secret appears in an error or test snapshot. | Errors carry stable category/name only; negative tests use canary values and assert absence. | Stop release, rotate the test/live value if exposure is real, repair redaction, rerun secret scan. |
+| Connect outage blocks restart. | Startup-only fetch, bounded timeout, explicit refusal, documented environment rollback using the same values. | Restore same logical values through protected environment injection and select `environment`. |
+| Token grants too much access. | Dedicated vault requirement, one-item fetch, no listing/writes, file token preference. | Revoke token, create dedicated vault/token, restart. |
+| Operator rotates an encryption/signing root as though provider migration were rotation. | Runbook separates custody migration from value rotation and warns about session/ciphertext effects. | Restore the prior values; execute future key-lifecycle runbook rather than improvising. |
+
+## Success evidence
+
+Success means the environment path remains byte-semantically compatible, the Connect path resolves exactly the selected fields once before migration, every failure prevents command execution without revealing values, the production image contains and invokes the resolver, documentation is indexed, and the exact committed tree passes the governed gates.

--- a/docs/superpowers/plans/2026-08-30-optional-runtime-secret-provider.md
+++ b/docs/superpowers/plans/2026-08-30-optional-runtime-secret-provider.md
@@ -1,3 +1,7 @@
+---
+status: draft
+---
+
 # Optional runtime-secret provider implementation plan
 
 **Backlog:** BI-E7553A1C  

--- a/docs/superpowers/specs/2026-08-30-optional-runtime-secret-provider-design.md
+++ b/docs/superpowers/specs/2026-08-30-optional-runtime-secret-provider-design.md
@@ -1,3 +1,7 @@
+---
+status: draft
+---
+
 # Optional runtime-secret provider design
 
 **Status:** proposed for independent review  

--- a/docs/superpowers/specs/2026-08-30-optional-runtime-secret-provider-design.md
+++ b/docs/superpowers/specs/2026-08-30-optional-runtime-secret-provider-design.md
@@ -1,0 +1,163 @@
+# Optional runtime-secret provider design
+
+**Status:** proposed for independent review  
+**Backlog:** BI-E7553A1C  
+**Epic:** EP-413F2602  
+**Decision:** DI-CB9275DCC886—optional provider adapter, high confidence
+
+## 1. Problem
+
+Deployment contract §8 says the same logical secrets may be backed by `.env`, cloud secret managers, Kubernetes Secrets, or a managed platform store. The runtime implements only the first form for its two most consequential application secrets: `AUTH_SECRET` and `CREDENTIAL_ENCRYPTION_KEY`. This turns a portability doctrine into an unimplemented promise and keeps high-value material durably beside the install.
+
+The integration must not confuse secret custody with identity or authority. DPF already owns principals, authentication policy, LDAP, Step CA PKI, authorization, connector credential lifecycle, and audit. 1Password may provide bytes at startup; it may not decide what those bytes mean.
+
+## 2. Objectives
+
+**OBJ-RSP-001:** Establish one provider-neutral, pre-migration startup boundary for logical runtime secrets while preserving the environment provider as the default.
+
+**OBJ-RSP-002:** Add an optional 1Password Connect adapter that fetches one explicitly configured item once per portal start using least privilege and value-free failures.
+
+**OBJ-RSP-003:** Preserve DPF as the sole authority for identity, LDAP, PKI, authorization, connector credential lifecycle, redaction, and platform audit.
+
+**OBJ-RSP-004:** Keep provider semantics portable so future cloud-manager, Kubernetes, OpenBao, or Vault adapters require no changes in application consumers.
+
+**OBJ-RSP-005:** Give operators truthful setup, outage, recovery, rollback, audit, and threat-boundary guidance.
+
+## 3. Research and benchmarking
+
+The tool evaluation at `docs/security/tool-evaluations/2026-08-30-1password.md` compares 1Password Connect, service accounts, HashiCorp Vault, OpenBao, and Infisical against NIST SP 800-57, NIST SP 800-63B-4, and OWASP secrets-management guidance.
+
+DPF adopts the common architecture: central custody, a narrowly scoped workload token, startup-only resolution, explicit failure, independent audit, and provider portability. It rejects Vault-like dynamic-secret semantics in this slice, rejects a version-0 1Password SDK dependency, and rejects moving connector credentials out of DPF.
+
+## 4. Architecture
+
+```text
+deployment wrapper
+  ├─ environment provider (default; current behavior)
+  └─ onepassword-connect provider (optional)
+       ├─ private Connect URL
+       ├─ dedicated-vault bearer token (file preferred)
+       └─ one vault id + one item id
+                    │ fetch once, bounded timeout
+                    ▼
+        runtime-secret bootstrap process
+          ├─ validates provider/config/allow-list
+          ├─ selects exact item field labels
+          ├─ refuses missing, duplicate, empty, or non-string values
+          └─ spawns portal boot with an in-memory child environment
+                    │
+                    ▼
+       migrations → provider registry → portal server
+```
+
+The bootstrap process is earlier than `portal-migrate-boot.sh`, Prisma, Auth.js, and application instrumentation. No resolved-value file is created. The child inherits resolved values; stdout/stderr carry names and reason codes only.
+
+### 4.1 Provider contract
+
+`DPF_SECRET_PROVIDER` is a closed startup value:
+
+- empty or `environment`: use the environment unchanged;
+- `onepassword-connect`: resolve configured logical names from one Connect item;
+- any other value: refuse startup.
+
+The implementation exposes a pure `resolveRuntimeSecrets({ env, fetch, readFile, signal })` seam plus a thin process launcher. Provider adapters return an environment overlay, never mutate databases or application state.
+
+### 4.2 Logical-secret allow-list
+
+The first allow-list is:
+
+- `AUTH_SECRET`
+- `CREDENTIAL_ENCRYPTION_KEY`
+- `DATABASE_URL`
+
+`DPF_RUNTIME_SECRET_NAMES` selects a comma-separated subset. For the 1Password provider the default is the two application root secrets. Unknown, duplicate, or empty names refuse startup. Adding a logical name is a contract change and must propagate across deployment wrappers per deployment contract §8.
+
+### 4.3 1Password Connect configuration
+
+- `DPF_ONEPASSWORD_CONNECT_HOST`: absolute HTTP(S) base URL.
+- `DPF_ONEPASSWORD_CONNECT_TOKEN_FILE`: preferred path to a file containing only the token.
+- `DPF_ONEPASSWORD_CONNECT_TOKEN`: fallback for wrappers without a secret-file mount.
+- `DPF_ONEPASSWORD_VAULT_ID`: dedicated runtime-secret vault id.
+- `DPF_ONEPASSWORD_ITEM_ID`: item id whose field labels equal logical secret names.
+- `DPF_SECRET_PROVIDER_TIMEOUT_MS`: optional bounded timeout, default 5,000 ms and capped at 30,000 ms.
+
+Supplying both token forms is ambiguous and refuses startup. URL, token, vault, and item are required. The token is never placed in request URLs or errors.
+
+### 4.4 Fetch and field rules
+
+The adapter sends one authenticated `GET /v1/vaults/{vaultId}/items/{itemId}`. It accepts one JSON object containing a `fields` array. Each requested logical name must match exactly one field `label` with a non-empty string `value`. Missing, duplicate, empty, malformed, non-2xx, timed-out, or network-failed responses refuse startup. Response bodies and values never appear in errors.
+
+### 4.5 Authority boundaries
+
+- `IntegrationCredential` remains the canonical connector store.
+- `CREDENTIAL_ENCRYPTION_KEY` still performs DPF AES-256-GCM encryption; 1Password only supplies the key.
+- Auth.js and DPF token code still interpret `AUTH_SECRET`; 1Password only supplies it.
+- Step CA still issues and validates certificates. A vault may hold exported material, but it cannot become CA authority.
+- LDAP still serves the DPF directory and Principal remains the authorization subject.
+- 1Password access/audit is custody evidence; DPF receipts remain action evidence.
+
+## 5. Flows
+
+### FLOW-RSP-ENV—existing install
+
+1. Compose starts the wrapper with no provider configured.
+2. The wrapper selects `environment` without network access.
+3. It validates required root variables are present.
+4. It spawns the existing migration/start command unchanged.
+
+### FLOW-RSP-1P—1Password-backed start
+
+1. Operator creates a dedicated vault/item and narrowly scoped Connect token.
+2. Deployment wrapper passes non-secret ids/host and a token file or token.
+3. Bootstrap validates configuration and fetches one item.
+4. Bootstrap extracts only allow-listed fields and overlays the child environment.
+5. Migrations and portal start; no value is written to disk or logs.
+
+### FLOW-RSP-REFUSE—provider unavailable or invalid
+
+1. Bootstrap encounters invalid configuration, timeout, network error, non-2xx response, malformed item, or field mismatch.
+2. It emits a stable, value-free failure naming the provider and category.
+3. It does not run migrations or the portal command.
+4. Operator restores Connect or rolls back to deliberately supplied environment values.
+
+## 6. Failure, recovery, and rollback
+
+The portal fails closed before database access. A running portal remains available if Connect later fails because this slice performs no per-request lookup. Restart requires Connect or an explicit provider rollback.
+
+Rollback is operationally simple: set `DPF_SECRET_PROVIDER=environment`, restore the same logical values through the existing protected environment mechanism, and restart. Changing either root value is **not** rollback: changing `AUTH_SECRET` invalidates sessions/tokens and changing `CREDENTIAL_ENCRYPTION_KEY` can make stored ciphertext unreadable. Key rotation is separate governed work.
+
+## 7. Security and compliance controls
+
+- dedicated vault; no personal/shared vault;
+- token file preferred, mode/access controlled by the deployment substrate;
+- no item listing, writes, arbitrary field access, or per-request fetches;
+- bounded timeout and one startup request;
+- value-free logs and errors;
+- diagnostics redact all `TOKEN`, `SECRET`, `PASSWORD`, `KEY`, and `AUTH` variables;
+- vendor audit supplements but does not replace DPF evidence;
+- no compliance claim based solely on vendor certifications;
+- no silent fallback from an explicitly configured external provider to environment.
+
+## 8. Acceptance contract
+
+| Acceptance | Objective | Statement |
+|---|---|---|
+| AC-RSP-001 | OBJ-RSP-001 | With no provider configured, startup makes no network call and executes the existing command with required environment secrets unchanged. |
+| AC-RSP-002 | OBJ-RSP-002 | A valid Connect item resolves the selected allow-listed fields before migrations and passes them only in the child process environment. |
+| AC-RSP-003 | OBJ-RSP-002, OBJ-RSP-005 | Missing/dual token configuration, unknown provider/name, timeout, network error, non-2xx response, malformed JSON, and missing/duplicate/empty fields all refuse before command execution with no secret value in output. |
+| AC-RSP-004 | OBJ-RSP-003 | No schema, Principal, LDAP, PKI, authorization, connector store, or audit ownership changes are introduced. |
+| AC-RSP-005 | OBJ-RSP-004 | Provider selection and resolution are isolated from application consumers; the default remains environment and 1Password-specific names stay at the adapter edge. |
+| AC-RSP-006 | OBJ-RSP-005 | Operator documentation states setup, dedicated-vault/token scope, outage behavior, threat limitation, rollback, and the danger of changing root values. |
+| AC-RSP-007 | OBJ-RSP-001, OBJ-RSP-002 | Focused tests, production build, exact-tree pregate, secret scan, and semantic review pass. |
+
+## 9. Non-goals and successors
+
+- native DPF workforce MFA/passkeys;
+- customer/social Principal-gate convergence;
+- encryption-envelope key ids, read-old/write-new, or re-encryption;
+- production container-exec/grant enforcement;
+- moving social-provider or connector credentials into 1Password;
+- service-account, Vault/OpenBao, cloud-manager, or Kubernetes adapters;
+- bundling or operating Connect in DPF compose.
+
+Each is independently shippable and therefore must have separate live backlog coverage rather than hiding in this plan.

--- a/docs/superpowers/specs/2026-08-30-security-authentication-hardening-successors-design.md
+++ b/docs/superpowers/specs/2026-08-30-security-authentication-hardening-successors-design.md
@@ -1,0 +1,263 @@
+# Security and authentication hardening successor design
+
+**Status:** proposed for independent review  
+**Backlog:** BI-32935E47, BI-80E4A139, BI-C9656270, BI-E22C3D75, BI-DD3BBD02, BI-FE678DA3  
+**Epic:** EP-413F2602  
+**Source assessment:** `docs/security/2026-08-30-security-authentication-stack-assessment.md`
+
+## 1. Purpose
+
+The security/authentication assessment found six independently shippable gaps around an architecture that is otherwise converging correctly. This document is their shared canonical design baseline. It keeps the gaps coordinated without turning them into one unsafe implementation batch.
+
+The governing boundary is unchanged: DPF owns Principal identity, authentication policy, authorization, LDAP, PKI, credential lifecycle, and audit. External identity providers and secret managers may supply assertions or custody, but they do not become DPF's authorization system, directory authority, certificate authority, or canonical credential store.
+
+Each backlog item below has its own objectives, acceptance contract, migration and failure boundary. Each implementation therefore requires its own plan, workroom, review, PR, verification, and completion evidence.
+
+## 2. Shared architectural constraints
+
+1. **One Principal spine.** Every human or machine session resolves to an active canonical Principal before authority is granted. Credential-holder records remain aliases or authentication sources, not parallel authorization roots.
+2. **One credential kernel.** Secret-bearing integration and social-provider configuration uses the canonical encrypted credential store, safe projection, health, reconnect, redaction, and audit semantics.
+3. **Provider-neutral custody.** Environment, 1Password, cloud managers, Kubernetes, and future vault adapters provide logical values through stable contracts. Vendor-specific concepts stop at adapter edges.
+4. **Version before rotation.** No operator workflow encourages changing `CREDENTIAL_ENCRYPTION_KEY` until ciphertext identifies its key version and read-old/write-new plus recovery are proven.
+5. **Enforcement at the boundary.** Production's operator-only stance is enforced by grants, tools, process boundaries, and deployment controls. Prompts and UI warnings are explanatory, never the control.
+6. **Assurance is session state.** Authentication methods, freshness, and assurance travel in the effective authentication context and are checked for consequential actions.
+7. **Forward-only migration.** Existing installs retain access through inline backfills, compatibility reads, verification, and explicit retirement gates. No clean-schema-only migration is acceptable.
+8. **Value-free evidence.** Logs, diagnostics, tests, and receipts may identify secret classes and failure categories but never secret values, bearer material, private keys, or recoverable ciphertext/plaintext pairs.
+
+## 3. Research and benchmarking
+
+The design adopts established patterns without importing a replacement identity platform:
+
+- [NIST SP 800-63B-4](https://pages.nist.gov/800-63-4/sp800-63b/authenticators/) treats manually entered OTPs as non-phishing-resistant and recognizes cryptographic verifier/channel binding. DPF therefore prefers WebAuthn/passkeys for workforce assurance and treats fallback methods as recovery paths with explicitly lower assurance.
+- [W3C Web Authentication Level 3](https://www.w3.org/TR/webauthn-3/) defines scoped public-key credentials and lifecycle operations. DPF adopts the browser/RP ceremony and authenticator model rather than designing a proprietary factor protocol.
+- [Keycloak's administration model](https://www.keycloak.org/docs/latest/server_admin/) demonstrates passkeys, configurable authentication flows, identity brokering, and LDAP federation. DPF adopts the separable flow and lifecycle concepts but rejects replacing its Principal, authorization, LDAP, and customer/workforce domain model with a second identity server.
+- [HashiCorp Vault Transit](https://developer.hashicorp.com/vault/docs/secrets/transit) demonstrates versioned ciphertext, read-old/write-new keyrings, minimum decrypt versions, and rewrap. DPF adopts those lifecycle invariants in its provider-neutral envelope; it does not require Vault or move application authorization into a vault.
+
+The design also carries forward the 1Password/OpenBao/Infisical comparison and NIST SP 800-57/OWASP controls recorded in `docs/security/tool-evaluations/2026-08-30-1password.md`.
+
+## 4. Target architecture
+
+```text
+authentication sources                    secret custody sources
+  password / passkey                       env / 1Password / future adapter
+  Google / Apple / upstream IdP                       |
+  LDAP bind / machine token                           v
+            |                                logical root-secret boundary
+            v                                           |
+ credential verification / assertion validation        v
+            |                                canonical credential kernel
+            v                                  + versioned crypto envelope
+ canonical Principal resolution                          |
+            |                                            v
+ active-state + assurance decision              safe projection / health
+            |                                  reconnect / audit / rotation
+            v
+ effective auth context
+            |
+            v
+ role + capability + grant + room/channel policy
+```
+
+The six slices strengthen this architecture at distinct seams. None introduces a second identity store, authorization cache, certificate authority, or vendor-owned source of truth.
+
+## 5. BI-32935E47 — versioned credential-encryption key lifecycle
+
+### Objectives
+
+**OBJ-KEY-001:** Replace unversioned AES-256-GCM payloads with a self-describing, validated envelope containing format version, algorithm, key id/version, IV, authentication tag, and ciphertext.
+
+**OBJ-KEY-002:** Resolve keys through one provider-neutral keyring contract with exactly one active write key and a bounded set of readable historical keys.
+
+**OBJ-KEY-003:** Support read-old/write-new, inventory, resumable re-encryption, verification, rollback, compromise response, and evidence-backed retirement across every encrypted field family.
+
+### Design
+
+- Introduce a canonical envelope codec in the shared credential crypto primitive; delete or delegate duplicate crypto implementations.
+- Compatibility reads recognize the legacy envelope only during a measured migration window and report legacy/version coverage without values.
+- Writes always emit the newest format with the active key id. Reads select a key only by validated envelope metadata; blind try-every-key decryption is prohibited.
+- Re-encryption is idempotent, bounded, resumable, and compares authenticated plaintext inside the protected operation before replacing a row.
+- Retirement is refused until inventory reports zero unread, legacy, failed, or old-version rows in all registered field families and backup/restore rehearsal evidence exists.
+- External custody may supply key versions, but the keyring interface and envelope remain DPF-owned.
+
+### Acceptance contract
+
+| Acceptance | Statement |
+|---|---|
+| AC-KEY-001 | Legacy ciphertext remains readable while all new writes use the active versioned envelope. |
+| AC-KEY-002 | The inventory covers `IntegrationCredential`, `CredentialEntry`, MCP encrypted token copies, and every registered encrypted field family. |
+| AC-KEY-003 | Rotation can pause, resume, verify, and roll back without losing readable credentials. |
+| AC-KEY-004 | Unknown format, algorithm, or key id fails closed with value-free diagnostics. |
+| AC-KEY-005 | Key retirement is mechanically refused until coverage, recovery, and destruction prerequisites pass. |
+
+## 6. BI-80E4A139 — production operator-only credential enforcement
+
+### Objectives
+
+**OBJ-OPS-001:** Convert the production installation credential stance from advisory metadata into deny-by-default authorization at every credential-capable boundary.
+
+**OBJ-OPS-002:** Preserve deliberate local-permitted development/test workflows without allowing environment labels or prompts to weaken production controls.
+
+**OBJ-OPS-003:** Make host/container privilege assumptions explicit and test refusals, redaction, approvals, and audit evidence.
+
+### Design
+
+- Build a closed inventory of actions that can read, mint, rotate, export, mount, diagnose, or derive credential material.
+- Centralize a production credential-action policy consumed by MCP tool visibility/execution, agent grants, admin routes, support bundles, runtime diagnostics, and host operations.
+- Hide non-advise-safe credential tools from production agents. Operator-approved workflows accept only references or redacted metadata from agents; operators supply secret values through operator-controlled surfaces.
+- Separate installation purpose/posture from deployment substrate. Production is never inferred from a user-editable request parameter.
+- Treat Docker socket, container exec, mounted `.env`, host process inspection, and backup access as deployment-level privileged boundaries. Document and reduce them; do not claim application policy can constrain a host administrator.
+- Record refusal and approval events without material values.
+
+### Acceptance contract
+
+| Acceptance | Statement |
+|---|---|
+| AC-OPS-001 | Every inventoried production credential action is denied to an unapproved agent at the earliest enforceable boundary. |
+| AC-OPS-002 | Credential-capable tools are absent or refused under intersected grants; a prompt instruction alone cannot authorize them. |
+| AC-OPS-003 | Development/test local-permitted behavior remains explicit and covered by tests. |
+| AC-OPS-004 | Diagnostics, logs, support artifacts, and receipts remain value-redacted. |
+| AC-OPS-005 | Deployment documentation states residual host-administrator and compromised-process risk accurately. |
+
+## 7. BI-C9656270 — workforce passkeys and assurance-aware reauthentication
+
+### Objectives
+
+**OBJ-MFA-001:** Add phishing-resistant workforce WebAuthn/passkey enrollment and authentication with multiple authenticators per Principal.
+
+**OBJ-MFA-002:** Carry authentication method, assurance, and freshness in the effective auth context and require current assurance for consequential actions.
+
+**OBJ-MFA-003:** Govern recovery, replacement, revocation, loss, and break-glass so they cannot silently bypass the intended assurance level.
+
+### Design
+
+- Store public credential id, public key, sign counter/backup state where applicable, transports, friendly label, creation/use/revocation timestamps, and Principal ownership. Never store authenticator private keys.
+- Bind registration and authentication challenges to the relying party, origin, Principal/session, ceremony purpose, expiry, and single use.
+- Prefer user-verifying, discoverable credentials for passwordless use. Permit password plus WebAuthn as a staged migration path; classify OTP/recovery alternatives below phishing-resistant assurance.
+- Add `methods`, `assurance`, and `authenticatedAt`/`reauthenticatedAt` to the authoritative auth context rather than a page-local session flag.
+- Define a shared consequential-action policy for credential administration, access exports, deployment, privilege/grant changes, break-glass, and other high-impact actions.
+- Recovery uses independent evidence and approval appropriate to the installation, revokes compromised authenticators, and forces fresh sessions.
+
+### Acceptance contract
+
+| Acceptance | Statement |
+|---|---|
+| AC-MFA-001 | A workforce Principal can enroll, name, use, and revoke more than one WebAuthn authenticator. |
+| AC-MFA-002 | Challenges are scoped, expiring, single-use, origin/RP validated, and replay-resistant. |
+| AC-MFA-003 | Consequential actions check current assurance and freshness server-side. |
+| AC-MFA-004 | Recovery and break-glass are independently auditable and cannot produce an unmarked high-assurance session. |
+| AC-MFA-005 | LDAP, PKI, Principal, role, capability, and optional upstream federation ownership remains unchanged. |
+
+## 8. BI-E22C3D75 — Principal-gated customer and social sign-in
+
+### Objectives
+
+**OBJ-PRI-001:** Resolve or materialize the canonical Principal and alias before customer password or social session issuance.
+
+**OBJ-PRI-002:** Apply active, conflict, tenant/account, and authentication-authority checks consistently across password, social, linking, onboarding, and deactivation flows.
+
+**OBJ-PRI-003:** Preserve customer/contact domain semantics while eliminating authorization-before-identity asymmetry.
+
+### Design
+
+- Introduce one sign-in authorization seam that accepts a verified credential/assertion and returns an authorized Principal-rooted session subject or a stable refusal.
+- CustomerContact remains the customer-domain credential/profile holder and account-scoping record; `PrincipalAlias` binds it to authority.
+- Auto-linking requires verified provider identifiers and the existing guarded linking rules. Ambiguous or conflicting aliases refuse rather than choose.
+- Onboarding creates the contact, Principal, and alias transactionally before session issuance.
+- Deactivation makes the credential holder and Principal authorization outcome consistent in the same transaction/invariant.
+- Effective auth loads by canonical principal identity and derives customer/account scope; it does not materialize another identity cache.
+
+### Acceptance contract
+
+| Acceptance | Statement |
+|---|---|
+| AC-PRI-001 | No customer password or social session is issued before an active canonical Principal authorizes it. |
+| AC-PRI-002 | Inactive, unresolved, and conflicted principals fail consistently across all sign-in/link paths. |
+| AC-PRI-003 | Onboarding and deactivation cannot leave a session-capable split state. |
+| AC-PRI-004 | Existing customer account/contact scoping is preserved and derived from the Principal-rooted context. |
+
+## 9. BI-DD3BBD02 — social-provider secrets in the credential kernel
+
+### Objectives
+
+**OBJ-SOC-001:** Make the canonical encrypted credential store the only writer and reader for Google and Apple client secrets.
+
+**OBJ-SOC-002:** Migrate existing installs forward without login loss and remove secret-bearing `PlatformConfig` projections.
+
+**OBJ-SOC-003:** Reuse provider-neutral schema, redaction, health, reconnect, and audit behavior while preserving the Auth.js initialization seam.
+
+### Design
+
+- Define Google and Apple connector credential schemas using the existing registry; safe fields and secret fields remain explicitly separated.
+- Add a forward-only migration/backfill that encrypts legacy secret values, verifies the destination, then removes or nulls the legacy source in the same governed transition.
+- During a bounded compatibility release, reads prefer the canonical store and may import a legacy value exactly once; no new write may target `PlatformConfig`.
+- Auth.js provider construction reads a safe provider-configuration adapter that resolves credential references at server initialization without copying secrets into diagnostics or safe projections.
+- Reconnect/rotation follows the credential kernel and invalidates only the affected provider configuration.
+
+### Acceptance contract
+
+| Acceptance | Statement |
+|---|---|
+| AC-SOC-001 | No Google or Apple client secret remains readable from `PlatformConfig` after migration. |
+| AC-SOC-002 | Existing configured installations retain sign-in capability through a clean forward migration and rollback plan. |
+| AC-SOC-003 | Safe projections, logs, diagnostics, errors, and audit receipts never expose the client secret. |
+| AC-SOC-004 | The credential kernel is the single writer/reader and Auth.js uses one supported adapter seam. |
+
+## 10. BI-FE678DA3 — security/identity backlog reconciliation
+
+### Objectives
+
+**OBJ-REC-001:** Reconcile live security/identity backlog state with merged source, canonical-runtime evidence, and acceptance criteria.
+
+**OBJ-REC-002:** Replace stale spec identifiers with live pointers or explicit historical/superseded annotations.
+
+**OBJ-REC-003:** Add a repeatable drift detector or governed cadence so source, docs, and PostgreSQL do not silently diverge again.
+
+### Design
+
+- Enumerate the active identity/security epics and children from live PostgreSQL, then map each to current specs, PRs, merged source, runtime verification, and unresolved acceptance.
+- Never infer `done` from a merged PR alone. Mark implementation present but runtime/acceptance evidence missing as open or in progress with the missing evidence named.
+- Preserve historical identifiers only when clearly labeled historical/superseded and linked to the live successor.
+- Add a deterministic check that extracts active BI/epic references from canonical specs and reports unresolved or mismatched live records. The check must tolerate intentionally historical references through an explicit annotation, not a broad ignore list.
+- Route every correction through MCP activity and PR evidence so both stores retain provenance.
+
+### Acceptance contract
+
+| Acceptance | Statement |
+|---|---|
+| AC-REC-001 | Every active identity/security deliverable resolves to one live BI and current epic. |
+| AC-REC-002 | Merged, runtime-verified, acceptance-verified, and done are distinguishable states. |
+| AC-REC-003 | Canonical specs do not present absent identifiers as current delivery coverage. |
+| AC-REC-004 | A repeatable check or governed cadence detects future spec/backlog reference drift. |
+
+## 11. Delivery order and dependency rules
+
+1. **BI-FE678DA3 first or in parallel with design work:** restore roadmap truth before completion claims.
+2. **BI-32935E47 before routine root-key rotation:** the optional 1Password adapter may land first, but operators must keep the same key value until versioned rotation is delivered.
+3. **BI-80E4A139 independently high priority:** external custody does not protect a secret from a process or host authorized to consume it.
+4. **BI-E22C3D75 before assurance-dependent customer actions:** canonical session identity precedes new customer assurance policy.
+5. **BI-DD3BBD02 independently migratable:** coordinate with credential-envelope work so it does not create a second crypto format.
+6. **BI-C9656270 after an implementation plan defines rollout/recovery:** passkey enrollment and recovery require explicit UX and operational verification.
+
+No slice waits for all others unless its implementation plan names a concrete dependency. This design coordinates invariants; it is not authorization for a six-item batch.
+
+## 12. Cross-cutting verification
+
+Every implementation plan must classify and exercise:
+
+- authorization and inactive/conflict refusal paths;
+- secret/value redaction and gitleaks coverage;
+- migration against populated legacy data when schema/storage changes;
+- backup, rollback, recovery, and partial-failure behavior;
+- production versus development/test posture;
+- session invalidation and reauthentication effects;
+- documentation impact for operators, users, coworkers, architecture, and external agents;
+- focused tests, production build, semantic review, exact-tree gate, and canonical-runtime UX/operational verification where applicable.
+
+## 13. Non-goals
+
+- replacing DPF LDAP with Microsoft Entra ID, Active Directory, Keycloak, or 1Password;
+- replacing Step CA or DPF organization PKI;
+- delegating DPF authorization, roles, capabilities, TAK grants, or workroom policy to an IdP or vault;
+- storing all connector credentials directly in 1Password;
+- treating vendor compliance certifications as DPF compliance;
+- merging the six backlog items into one implementation PR.

--- a/docs/superpowers/specs/2026-08-30-security-authentication-hardening-successors-design.md
+++ b/docs/superpowers/specs/2026-08-30-security-authentication-hardening-successors-design.md
@@ -1,3 +1,7 @@
+---
+status: draft
+---
+
 # Security and authentication hardening successor design
 
 **Status:** proposed for independent review  


### PR DESCRIPTION
## Summary

Assess DPF's current security and authentication stack against canonical design and live backlog, evaluate 1Password as an optional runtime-secret custody provider, and preserve the provider design, implementation plan, and coordinated design baseline for six independently shippable hardening successors.

## Changes

- Record the source- and live-backlog-grounded security/authentication assessment, including the boundary between DPF-owned Principal/LDAP/PKI/authorization and external secret or identity providers.
- Evaluate 1Password Connect, service accounts, Vault/OpenBao, and Infisical against security, portability, operations, and compliance criteria.
- Define a provider-neutral startup secret boundary with the environment provider as default and 1Password Connect as the first optional adapter.
- Add an implementation plan for BI-E7553A1C.
- Add one canonical security/authentication hardening design covering BI-32935E47, BI-80E4A139, BI-C9656270, BI-E22C3D75, BI-DD3BBD02, and BI-FE678DA3, with separate objectives and acceptance contracts.

## Test plan

- [x] **Source-only change** (documentation and generated doc index only)
  - [x] `pnpm docs:index`
  - [x] `pnpm check:prose-lint`
  - [x] `pnpm docs:index:check`
  - [x] `pnpm docs:links`
  - [x] `node scripts/check-doc-anchor-existence.mjs`
  - [x] `node scripts/check-spec-status-frontmatter.mjs`
  - [x] `pnpm run pregate:preflight` — 59 guards clean
  - [x] `git diff --check`

### Verification evidence

- Pre-commit gitleaks found no leaks.
- Pre-push DCO and derived-artifact checks passed on `feat/security-auth-1password@3806568858fd0805213cb54b67ef882c84803a06`.
- Semantic review receipt `cmtf7xhpl0sjk01qgi8c47o0z` is exact-tree and infrastructure-inconclusive because governed local CI held host capacity; the current shadow policy explicitly reports `mayPublish: true`.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed against the final diff.
- [x] `pnpm run pregate:preflight` passed.
- [x] Exact-tree local CI is not required for a docs-only diff; the pre-push gate confirmed the exemption.
- [x] `pnpm pr:ready --pr-body-file /tmp/dpf-security-auth-pr-body.md` returned `PR readiness: READY` after the final push.

Local-CI-Override: docs-only assessment, evaluation, design, and plan; no runtime code, schema, migration, deployment wiring, or UI behavior changed.

## Related issues / Epic

Parent: EP-413F2602 — Whole-platform architecture hardening & simplify-strengthen program (re-anchored)

Primary: BI-E7553A1C — Optional external bootstrap-secret provider with 1Password Connect first adapter

Design coverage: BI-32935E47, BI-80E4A139, BI-C9656270, BI-E22C3D75, BI-DD3BBD02, BI-FE678DA3.

## Epic / Backlog linkage (for multi-BI work)

This PR delivers assessment/design/plan documentation only. It does not implement or close any successor BI. Each implementation remains a separate workroom, plan, branch, PR, and verification unit.

## Overlap sweep

Reviewed all open PRs before publication. None touches these security assessment, tool-evaluation, runtime-secret design/plan, or hardening-successor design files.

## Notes for the reviewer

1Password is deliberately an optional secret-custody adapter. It does not replace DPF's Principal model, LDAP, Step CA PKI, authorization, connector credential kernel, or audit evidence. The plan remains `draft` until independent initiative design approval is available; no implementation has been started.
