### PR TITLE
fix(readiness): retry immutable provider provenance

### DIFF
--- a/apps/web/lib/backlog/initiative-readiness/repository-artifact.test.ts
+++ b/apps/web/lib/backlog/initiative-readiness/repository-artifact.test.ts
@@ -74,6 +74,84 @@ function providerFetch(signOff = "Signed-off-by: Author <author@example.com>") {
 }
 
 describe("resolveRepositoryArtifact", () => {
+  it("retries one transient blob transport failure inside the same provider read", async () => {
+    const fetchImpl = vi.fn()
+      .mockRejectedValueOnce(new Error("token=must-not-leak"))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        type: "file",
+        sha: locator.providerBlobId,
+        encoding: "base64",
+        content: bytes.toString("base64"),
+      }), { status: 200 }));
+
+    await expect(readRepositoryProviderBlob({
+      repositoryFullName: locator.repositoryFullName,
+      commitSha: locator.commitSha,
+      path: locator.path,
+      expectedBlobId: locator.providerBlobId,
+      db: db() as never,
+      fetchImpl: fetchImpl as typeof fetch,
+    })).resolves.toEqual({ ok: true, data: bytes });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([408, 429, 500, 502, 503, 504])("retries retryable blob HTTP %i once", async (status) => {
+    const transient = vi.fn()
+      .mockResolvedValueOnce(new Response("temporarily unavailable", { status }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        type: "file",
+        sha: locator.providerBlobId,
+        encoding: "base64",
+        content: bytes.toString("base64"),
+      }), { status: 200 }));
+    await expect(readRepositoryProviderBlob({
+      repositoryFullName: locator.repositoryFullName,
+      commitSha: locator.commitSha,
+      path: locator.path,
+      expectedBlobId: locator.providerBlobId,
+      db: db() as never,
+      fetchImpl: transient as typeof fetch,
+    })).resolves.toEqual({ ok: true, data: bytes });
+    expect(transient).toHaveBeenCalledTimes(2);
+  });
+
+  it("refuses a permanent blob status immediately without exposing its body", async () => {
+    const permanent = vi.fn(async () => new Response("secret provider body", { status: 404 }));
+    const result = await readRepositoryProviderBlob({
+      repositoryFullName: locator.repositoryFullName,
+      commitSha: locator.commitSha,
+      path: locator.path,
+      expectedBlobId: locator.providerBlobId,
+      db: db() as never,
+      fetchImpl: permanent as typeof fetch,
+    });
+    expect(result).toMatchObject({ ok: false, code: "IMMUTABLE_SOURCE_UNAVAILABLE" });
+    if (!("error" in result)) throw new Error("expected an error result");
+    expect(result.error).toContain("HTTP 404");
+    expect(result.error).toContain("1 attempt");
+    expect(result.error).not.toContain("secret provider body");
+    expect(permanent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry an unreadable successful blob response", async () => {
+    const fetchImpl = vi.fn(async () => new Response("not-json", { status: 200 }));
+    const result = await readRepositoryProviderBlob({
+      repositoryFullName: locator.repositoryFullName,
+      commitSha: locator.commitSha,
+      path: locator.path,
+      expectedBlobId: locator.providerBlobId,
+      db: db() as never,
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "IMMUTABLE_SOURCE_UNAVAILABLE" });
+    if (!("error" in result)) throw new Error("expected an error result");
+    expect(result.error).toContain("unreadable");
+    expect(result.error).toContain("1 attempt");
+    expect(result.error).not.toContain("not-json");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("reads a bounded exact blob from the configured canonical repository without a local git object", async () => {
     const fetchImpl = providerFetch();
     const result = await readRepositoryProviderBlob({
@@ -109,6 +187,7 @@ describe("resolveRepositoryArtifact", () => {
       db: db() as never,
       fetchImpl: mismatch as typeof fetch,
     })).resolves.toMatchObject({ ok: false, code: "IMMUTABLE_BLOB_MISMATCH" });
+    expect(mismatch).toHaveBeenCalledTimes(1);
 
     const oversized = vi.fn(async () => new Response(JSON.stringify({
       type: "file",
@@ -125,6 +204,7 @@ describe("resolveRepositoryArtifact", () => {
       db: db() as never,
       fetchImpl: oversized as typeof fetch,
     })).resolves.toMatchObject({ ok: false, code: "IMMUTABLE_SOURCE_TOO_LARGE" });
+    expect(oversized).toHaveBeenCalledTimes(1);
   });
 
   it("derives bytes and SHA-256 from the exact provider blob bound to one subject capsule", async () => {
@@ -148,6 +228,92 @@ describe("resolveRepositoryArtifact", () => {
     });
     expect(fetchImpl).toHaveBeenCalledWith(expect.stringContaining(`/commits/${locator.commitSha}`), expect.any(Object));
     expect(fetchImpl).toHaveBeenCalledWith(expect.stringContaining(`/contents/docs/superpowers/plans/test.md?ref=${locator.commitSha}`), expect.objectContaining({ cache: "no-store" }));
+  });
+
+  it("retries transient commit provenance failures without creating another resolver invocation", async () => {
+    const fetchImpl = vi.fn()
+      .mockRejectedValueOnce(new Error("Authorization: Bearer must-not-leak"))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        commit: { message: "docs: canonical\n\nSigned-off-by: Author <author@example.com>" },
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        type: "file",
+        sha: locator.providerBlobId,
+        encoding: "base64",
+        content: bytes.toString("base64"),
+      }), { status: 200 }));
+
+    await expect(resolveRepositoryArtifact({
+      locator,
+      subject: { kind: "backlog-item", id: "BI-TEST" },
+      db: db() as never,
+      fetchImpl: fetchImpl as typeof fetch,
+    })).resolves.toMatchObject({ ok: true, artifact: { authorPrincipalId: "principal-author" } });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries one retryable commit status and bounds terminal transport attempts", async () => {
+    const retryable = vi.fn()
+      .mockResolvedValueOnce(new Response("provider overloaded", { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        commit: { message: "docs: canonical\n\nSigned-off-by: Author <author@example.com>" },
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        type: "file",
+        sha: locator.providerBlobId,
+        encoding: "base64",
+        content: bytes.toString("base64"),
+      }), { status: 200 }));
+    await expect(resolveRepositoryArtifact({
+      locator,
+      subject: { kind: "backlog-item", id: "BI-TEST" },
+      db: db() as never,
+      fetchImpl: retryable as typeof fetch,
+    })).resolves.toMatchObject({ ok: true });
+    expect(retryable).toHaveBeenCalledTimes(3);
+
+    const transport = vi.fn(async () => { throw new Error("credential must-not-leak"); });
+    const result = await resolveRepositoryArtifact({
+      locator,
+      subject: { kind: "backlog-item", id: "BI-TEST" },
+      db: db() as never,
+      fetchImpl: transport as typeof fetch,
+    });
+    expect(result).toMatchObject({ ok: false, code: "CANONICAL_DESIGN_REQUIRED" });
+    if (!("error" in result)) throw new Error("expected an error result");
+    expect(result.error).toContain("transport");
+    expect(result.error).toContain("2 attempts");
+    expect(result.error).not.toContain("credential must-not-leak");
+    expect(transport).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry permanent or unreadable commit provenance responses", async () => {
+    const permanent = vi.fn(async () => new Response("private details", { status: 403 }));
+    const permanentResult = await resolveRepositoryArtifact({
+      locator,
+      subject: { kind: "backlog-item", id: "BI-TEST" },
+      db: db() as never,
+      fetchImpl: permanent as typeof fetch,
+    });
+    expect(permanentResult).toMatchObject({ ok: false, code: "CANONICAL_DESIGN_REQUIRED" });
+    if (!("error" in permanentResult)) throw new Error("expected an error result");
+    expect(permanentResult.error).toContain("HTTP 403");
+    expect(permanentResult.error).toContain("1 attempt");
+    expect(permanentResult.error).not.toContain("private details");
+    expect(permanent).toHaveBeenCalledTimes(1);
+
+    const unreadable = vi.fn(async () => new Response("not-json", { status: 200 }));
+    const unreadableResult = await resolveRepositoryArtifact({
+      locator,
+      subject: { kind: "backlog-item", id: "BI-TEST" },
+      db: db() as never,
+      fetchImpl: unreadable as typeof fetch,
+    });
+    expect(unreadableResult).toMatchObject({ ok: false, code: "ARTIFACT_AUTHOR_REQUIRED" });
+    if (!("error" in unreadableResult)) throw new Error("expected an error result");
+    expect(unreadableResult.error).toContain("unreadable");
+    expect(unreadableResult.error).toContain("1 attempt");
+    expect(unreadable).toHaveBeenCalledTimes(1);
   });
 
   // BI-B9403248: the external-session shape — a human principal records every
@@ -231,6 +397,7 @@ describe("resolveRepositoryArtifact", () => {
     expect(result).toMatchObject({ ok: false, code: "ARTIFACT_AUTHOR_REQUIRED" });
     if (!("error" in result)) throw new Error("expected an error result");
     expect(result.error).toContain("Signed-off-by");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it("names the stale head and the remedy when no capsule head matches the plan commit", async () => {

--- a/apps/web/lib/backlog/initiative-readiness/repository-artifact.ts
+++ b/apps/web/lib/backlog/initiative-readiness/repository-artifact.ts
@@ -71,6 +71,72 @@ type RepositoryProviderBlobResult =
       error: string;
     };
 
+type GithubJsonFailure = {
+  ok: false;
+  kind: "transport" | "http" | "unreadable";
+  attempts: number;
+  status?: number;
+};
+
+type GithubJsonResult =
+  | ActionSuccess<unknown>
+  | GithubJsonFailure;
+
+const RETRYABLE_PROVIDER_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+const MAX_PROVIDER_ATTEMPTS = 2;
+
+function providerAttemptLabel(attempts: number): string {
+  return `${attempts} ${attempts === 1 ? "attempt" : "attempts"}`;
+}
+
+function providerFailureMessage(
+  failure: GithubJsonFailure,
+  labels: { unavailable: string; unreadable: string },
+): string {
+  const attempts = providerAttemptLabel(failure.attempts);
+  if (failure.kind === "transport") {
+    return `Repository provider could not resolve ${labels.unavailable} after ${attempts} (transport failure).`;
+  }
+  if (failure.kind === "http") {
+    return `Repository provider could not resolve ${labels.unavailable} after ${attempts} (HTTP ${failure.status}).`;
+  }
+  return `Repository provider returned unreadable ${labels.unreadable} after ${attempts}.`;
+}
+
+async function fetchGithubJson(args: {
+  url: string;
+  token: string | null;
+  fetchImpl: typeof fetch;
+}): Promise<GithubJsonResult> {
+  for (let attempt = 1; attempt <= MAX_PROVIDER_ATTEMPTS; attempt += 1) {
+    let response: Response;
+    try {
+      response = await args.fetchImpl(args.url, {
+        headers: {
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          ...(args.token ? { Authorization: `Bearer ${args.token}` } : {}),
+        },
+        cache: "no-store",
+      });
+    } catch {
+      if (attempt < MAX_PROVIDER_ATTEMPTS) continue;
+      return { ok: false, kind: "transport", attempts: attempt };
+    }
+    if (!response.ok) {
+      if (attempt < MAX_PROVIDER_ATTEMPTS && RETRYABLE_PROVIDER_STATUSES.has(response.status)) continue;
+      return { ok: false, kind: "http", attempts: attempt, status: response.status };
+    }
+    try {
+      const payload: unknown = await response.json();
+      return ok(payload);
+    } catch {
+      return { ok: false, kind: "unreadable", attempts: attempt };
+    }
+  }
+  return { ok: false, kind: "transport", attempts: MAX_PROVIDER_ATTEMPTS };
+}
+
 function decodeGithubContent(payload: unknown, expectedBlobId: string): RepositoryProviderBlobResult {
   if (!payload || typeof payload !== "object") {
     return { ok: false, code: "IMMUTABLE_SOURCE_UNAVAILABLE", error: "Repository provider returned unreadable artifact metadata." };
@@ -104,30 +170,22 @@ async function fetchRepositoryProviderBlob(args: {
   if (!encodedPath || !/^[a-f0-9]{40}$/i.test(args.commitSha) || !/^[a-f0-9]{40}$/i.test(args.expectedBlobId)) {
     return { ok: false, code: "IMMUTABLE_SOURCE_IDENTITY_INVALID", error: "Repository artifact locator is not a recognized immutable provider blob." };
   }
-  let response: Response;
-  try {
-    response = await args.fetchImpl(
-      `https://api.github.com/repos/${encodeURIComponent(args.owner)}/${encodeURIComponent(args.repo)}/contents/${encodedPath}?ref=${encodeURIComponent(args.commitSha)}`,
-      {
-        headers: {
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
-          ...(args.token ? { Authorization: `Bearer ${args.token}` } : {}),
-        },
-        cache: "no-store",
-      },
-    );
-  } catch {
-    return { ok: false, code: "IMMUTABLE_SOURCE_UNAVAILABLE", error: "Repository provider could not resolve the immutable artifact." };
+  const result = await fetchGithubJson({
+    url: `https://api.github.com/repos/${encodeURIComponent(args.owner)}/${encodeURIComponent(args.repo)}/contents/${encodedPath}?ref=${encodeURIComponent(args.commitSha)}`,
+    token: args.token,
+    fetchImpl: args.fetchImpl,
+  });
+  if (!result.ok) {
+    return {
+      ok: false,
+      code: "IMMUTABLE_SOURCE_UNAVAILABLE",
+      error: providerFailureMessage(result, {
+        unavailable: "the immutable artifact",
+        unreadable: "artifact metadata",
+      }),
+    };
   }
-  if (!response.ok) {
-    return { ok: false, code: "IMMUTABLE_SOURCE_UNAVAILABLE", error: "Repository provider could not resolve the immutable artifact." };
-  }
-  try {
-    return decodeGithubContent(await response.json(), args.expectedBlobId);
-  } catch {
-    return { ok: false, code: "IMMUTABLE_SOURCE_UNAVAILABLE", error: "Repository provider returned unreadable artifact metadata." };
-  }
+  return decodeGithubContent(result.data, args.expectedBlobId);
 }
 
 /**
@@ -274,31 +332,22 @@ export async function resolveRepositoryArtifact(args: {
   } catch {
     return { ok: false, code: "CANONICAL_DESIGN_REQUIRED", error: "Repository provider credentials are unavailable." };
   }
-  let commitResponse: Response;
-  try {
-    commitResponse = await (args.fetchImpl ?? fetch)(
-      `https://api.github.com/repos/${encodeURIComponent(expectedRepo.owner)}/${encodeURIComponent(expectedRepo.name)}/commits/${encodeURIComponent(args.locator.commitSha)}`,
-      {
-        headers: {
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
-        cache: "no-store",
-      },
-    );
-  } catch {
-    return { ok: false, code: "CANONICAL_DESIGN_REQUIRED", error: "Repository provider could not resolve immutable commit provenance." };
+  const commitResult = await fetchGithubJson({
+    url: `https://api.github.com/repos/${encodeURIComponent(expectedRepo.owner)}/${encodeURIComponent(expectedRepo.name)}/commits/${encodeURIComponent(args.locator.commitSha)}`,
+    token,
+    fetchImpl: args.fetchImpl ?? fetch,
+  });
+  if (!commitResult.ok) {
+    return {
+      ok: false,
+      code: commitResult.kind === "unreadable" ? "ARTIFACT_AUTHOR_REQUIRED" : "CANONICAL_DESIGN_REQUIRED",
+      error: providerFailureMessage(commitResult, {
+        unavailable: "immutable commit provenance",
+        unreadable: "commit provenance",
+      }),
+    };
   }
-  if (!commitResponse.ok) {
-    return { ok: false, code: "CANONICAL_DESIGN_REQUIRED", error: "Repository provider could not resolve immutable commit provenance." };
-  }
-  let commitPayload: unknown;
-  try {
-    commitPayload = await commitResponse.json();
-  } catch {
-    return { ok: false, code: "ARTIFACT_AUTHOR_REQUIRED", error: "Repository commit provenance is unreadable." };
-  }
+  const commitPayload = commitResult.data;
   const email = dcoEmail(commitPayload);
   if (!email) {
     return {

--- a/docs/superpowers/plans/2026-08-30-immutable-provider-provenance-retry.md
+++ b/docs/superpowers/plans/2026-08-30-immutable-provider-provenance-retry.md
@@ -102,3 +102,10 @@ The expired BI-E35 review envelopes remain immutable evidence only. Neither a
 placeholder/`not-applicable` call nor a correct but unapproved call satisfies
 the baseline. The next independent review must bind to the materially revised
 design blob containing the writer contract above.
+
+The first review of that amended blob completed after six immutable reads but
+never invoked the terminal writer. Preserve that TaskRun as no-receipt evidence;
+do not replay it. The canonical design is therefore refactored without semantic
+loss into a bounded complete artifact that fits one reader result plus the
+reserved writer step. Any next review must bind to this new blob and remain the
+only identity for it.

--- a/docs/superpowers/plans/2026-08-30-immutable-provider-provenance-retry.md
+++ b/docs/superpowers/plans/2026-08-30-immutable-provider-provenance-retry.md
@@ -1,0 +1,93 @@
+---
+status: active
+---
+
+# Immutable Provider Provenance Retry Implementation Plan
+
+**Backlog item:** BI-E35E1183
+**Epic:** EP-56AE0F69
+**Workroom:** WC-6D36EB1A
+**Branch:** `fix/repository-provenance-retry`
+**Design:** `docs/superpowers/specs/2026-08-30-immutable-provider-provenance-retry-design.md`
+
+## Outcome
+
+Make canonical commit and blob verification resilient to one transient provider
+failure inside the same approved initiative-writer invocation. Preserve all
+immutable identity, DCO, author, Workroom, reviewer, authority, and receipt
+checks and keep permanent failures fail closed.
+
+## Reproduced evidence
+
+The human-approved BI-F48D7059 writer replay executed once as ToolExecution
+`cmtf6vg0o01p401phwjx4tkvv` under envelope
+`cmtf6my0n01go01phujpcoxfq`. It retained the independent PASS arguments but
+failed `CANONICAL_DESIGN_REQUIRED` because the provider could not resolve commit
+provenance. No receipt or baseline was written. The exact public commit
+`2e8a2246915092b7fb8c16ba496e90613da6fbc4` resolved with HTTP 200 both from the
+host and from the live portal container afterward. The consumed identity will
+not be replayed.
+
+## Test-first implementation
+
+1. Extend `repository-artifact.test.ts` with RED cases for a thrown commit read,
+   retryable commit status, thrown blob read, and retryable blob status that each
+   succeed on the second attempt.
+2. Add RED refusal cases for permanent HTTP status, unreadable JSON, sanitized
+   terminal errors, blob mismatch, and the two-attempt ceiling.
+3. Add one module-private discriminated GitHub JSON request helper with two
+   total attempts and the explicit retryable status set.
+4. Route commit provenance and exact blob retrieval through that helper while
+   retaining their existing public error-code mappings and decode logic.
+5. Refactor under green only to remove duplicate request construction and keep
+   the provider boundary legible.
+6. Run the focused test file, web typecheck, style guard, affected-test/blast
+   checks, preflight, DCO verification, independent semantic review, and exact
+   tree verification. If a shared gate is demonstrably unavailable, preserve
+   that evidence and rely on protected CI rather than altering or weakening the
+   gate.
+7. Publish normally, open a protected PR, inspect review findings and all checks,
+   merge, ship an immutable release, and verify the live provider path.
+8. Create exactly one fresh BI-F48 reviewer identity after deployment. Require a
+   real receipt/baseline, then resume plan coverage and the downstream WordPress
+   readiness recovery without fabricating or proxying evidence.
+
+## Expected code surface
+
+- `apps/web/lib/backlog/initiative-readiness/repository-artifact.ts`
+- `apps/web/lib/backlog/initiative-readiness/repository-artifact.test.ts`
+- `docs/superpowers/specs/2026-08-30-immutable-provider-provenance-retry-design.md`
+- `docs/superpowers/plans/2026-08-30-immutable-provider-provenance-retry.md`
+
+No schema, migration, public route, receipt type, MCP tool, role, grant, or UI
+surface changes are expected. The doc index is regenerated only if the standard
+documentation guard requires it.
+
+## Risks and rollback
+
+The principal risk is retrying a failure that actually needs operator repair.
+The helper therefore retries only thrown transport failures and HTTP 408, 429,
+500, 502, 503, and 504; every other status and any unreadable success payload is
+terminal. Attempts are bounded at two and do not sleep. Rollback is the normal
+protected revert; existing provider reads return to single-attempt behavior and
+all immutable audit records remain unchanged.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: BI-E35E1183
+- Receipt: pending canonical spec baseline and provider-verified plan artifact
+- Rationale: The shared helper and its two call sites are one availability
+  contract. Shipping only the helper is unreachable; shipping only one call
+  site leaves the approval flow vulnerable at the other immutable provider
+  read. The tests and both call-site migrations must ship and roll back together.
+- Dependencies: protected deployment precedes the fresh BI-F48 reviewer replay
+
+| Deliverable key | Backlog item | Independently shippable | Requirement refs | Contract refs | Flow refs | Verification refs |
+| --- | --- | --- | --- | --- | --- | --- |
+| `provider-provenance-retry` | BI-E35E1183 | no | OBJ-PROV-001, OBJ-PROV-002, OBJ-PROV-003 | provider-request-contract, immutable-artifact-contract, fail-closed-diagnostics | commit-provenance-read, exact-blob-read, fresh-reviewer-recovery | AC-PROV-001, AC-PROV-002, AC-PROV-003, AC-PROV-004, AC-PROV-005 |
+
+The coverage receipt cannot exist before a canonical spec-approval baseline and
+a provider-readable immutable plan blob. This plan records the complete atomic
+mapping now; after the design/plan commit is published and reviewed, the
+canonical writer must replace `pending` with its real receipt and bindings.

--- a/docs/superpowers/plans/2026-08-30-immutable-provider-provenance-retry.md
+++ b/docs/superpowers/plans/2026-08-30-immutable-provider-provenance-retry.md
@@ -109,3 +109,9 @@ do not replay it. The canonical design is therefore refactored without semantic
 loss into a bounded complete artifact that fits one reader result plus the
 reserved writer step. Any next review must bind to this new blob and remain the
 only identity for it.
+
+The subsequent concise-artifact review reached a genuine `fix`/`pass` writer
+call with no findings, but its approval window expired without human approval.
+It also remains no-baseline evidence and is never approved or replayed. This
+revision makes that expiry disposition explicit; one fresh independent review
+may bind to the new artifact identity.

--- a/docs/superpowers/plans/2026-08-30-immutable-provider-provenance-retry.md
+++ b/docs/superpowers/plans/2026-08-30-immutable-provider-provenance-retry.md
@@ -46,9 +46,15 @@ not be replayed.
    tree verification. If a shared gate is demonstrably unavailable, preserve
    that evidence and rely on protected CI rather than altering or weakening the
    gate.
-7. Publish normally, open a protected PR, inspect review findings and all checks,
+7. For canonical spec approval, require the independent reviewer to read the
+   complete immutable design and call the writer once with `profile="fix"`,
+   `artifactRole="design-spec"`, and a substantive `pass` or `fail`. Preserve
+   placeholder, `not-applicable`, non-fix, truncated-read, or unapproved calls as
+   non-baseline audit evidence; never approve or replay them. A fresh review is
+   allowed only after a materially revised immutable design artifact.
+8. Publish normally, open a protected PR, inspect review findings and all checks,
    merge, ship an immutable release, and verify the live provider path.
-8. Create exactly one fresh BI-F48 reviewer identity after deployment. Require a
+9. Create exactly one fresh BI-F48 reviewer identity after deployment. Require a
    real receipt/baseline, then resume plan coverage and the downstream WordPress
    readiness recovery without fabricating or proxying evidence.
 
@@ -91,3 +97,8 @@ The coverage receipt cannot exist before a canonical spec-approval baseline and
 a provider-readable immutable plan blob. This plan records the complete atomic
 mapping now; after the design/plan commit is published and reviewed, the
 canonical writer must replace `pending` with its real receipt and bindings.
+
+The expired BI-E35 review envelopes remain immutable evidence only. Neither a
+placeholder/`not-applicable` call nor a correct but unapproved call satisfies
+the baseline. The next independent review must bind to the materially revised
+design blob containing the writer contract above.

--- a/docs/superpowers/specs/2026-08-30-immutable-provider-provenance-retry-design.md
+++ b/docs/superpowers/specs/2026-08-30-immutable-provider-provenance-retry-design.md
@@ -4,167 +4,62 @@ status: active
 
 # Immutable Provider Provenance Retry
 
-**Backlog item:** BI-E35E1183
-**Epic:** EP-56AE0F69
-**Workroom:** WC-6D36EB1A
-**Status:** Approved bounded remediation in progress
+**Backlog item:** BI-E35E1183 | **Epic:** EP-56AE0F69 |
+**Workroom:** WC-6D36EB1A | **Profile:** fix
 
-## Problem
+## Problem and decision
 
-The initiative evidence writer verifies its design artifact from the canonical
-repository provider before it persists a receipt. On BI-F48D7059, independent
-review completed and the exact human-approved writer replay reached that
-verification boundary, but the commit read failed once with
-`CANONICAL_DESIGN_REQUIRED: Repository provider could not resolve immutable
-commit provenance.` The same exact public GitHub commit resolved from the host
-and from the portal container immediately afterward.
+An approved initiative writer failed on transient GitHub commit provenance,
+consuming its single-use replay without a receipt; the same commit resolved
+immediately afterward.
 
-The provider reader currently makes one request for commit provenance and one
-request for the exact blob. A thrown fetch or retryable HTTP response becomes a
-terminal generic error. Because the approved reviewer envelope is single-use,
-that transient read consumes the only lawful replay even though neither the
-artifact identity nor the reviewer decision changed.
+Keep `repository-artifact.ts` as the single canonical boundary and add one
+module-private JSON request helper used by both commit-provenance and exact-blob
+reads. It makes at most two immediate attempts. It retries only thrown transport
+failures and HTTP 408, 429, 500, 502, 503, or 504. Other statuses and unreadable
+success JSON fail after one attempt. No sleep, queue, new abstraction, schema,
+tool, role, grant, receipt, or approval bypass is introduced.
 
-## Outcome
+## Preserved boundaries
 
-Both canonical provider reads use one bounded, fail-closed JSON request helper.
-The helper retries only transient transport failures and explicitly retryable
-HTTP statuses within the same writer invocation. Permanent provider responses,
-unreadable payloads, immutable identity mismatches, DCO conflicts, Workroom
-conflicts, and size limits continue to fail immediately. A retry never creates a
-new TaskRun, approval envelope, decision, receipt, or authority grant.
+Repository, organization, subject, credentials, and principals stay
+server-resolved; commit, path, and blob id stay immutable. Workroom head, DCO,
+reviewer/author separation, Git blob id, byte ceiling, SHA-256, and receipt
+authority remain fail closed. A retry cannot change the TaskRun, arguments,
+envelope, reviewer, organization, artifact, or audit unit, and never mints new
+governance state. Diagnostics expose only class, attempt count, and HTTP status,
+never secrets or provider content. Provider I/O stays outside transactions.
 
-## Governed scope manifest
+## Acceptance contract
 
-- **OBJ-PROV-001:** Recover a transient canonical provider read inside the same
-  approved writer invocation without consuming another reviewer identity.
-- **OBJ-PROV-002:** Keep all immutable commit, blob, DCO, Workroom, author, size,
-  repository, and subject checks fail closed.
-- **OBJ-PROV-003:** Return bounded, sanitized diagnostics that distinguish
-  transport, HTTP status, and unreadable-provider failures without exposing
-  tokens or response bodies.
-
-| Acceptance | Objectives | Statement | Design evidence |
-| --- | --- | --- | --- |
-| AC-PROV-001 | OBJ-PROV-001 | A first-attempt transport exception followed by a valid response succeeds for commit provenance and for exact blob reads within one resolver call. | Provider request contract; Verification |
-| AC-PROV-002 | OBJ-PROV-001 | Retryable HTTP responses (408, 429, 500, 502, 503, 504) receive at most one immediate retry; success on that retry continues canonical verification. | Provider request contract; Invariants |
-| AC-PROV-003 | OBJ-PROV-002 | Permanent 4xx responses, malformed success payloads, DCO ambiguity, Workroom/head mismatch, blob mismatch, and oversized content do not retry or become successful. | Invariants; Verification |
-| AC-PROV-004 | OBJ-PROV-003 | Terminal messages name failure class, attempt count, and HTTP status when available, but never include authorization headers, tokens, or response bodies. | Diagnostics contract; Verification |
-| AC-PROV-005 | OBJ-PROV-001, OBJ-PROV-002 | Commit provenance and exact blob retrieval share the same bounded provider helper; no second source-of-truth, schema, receipt type, tool, reviewer role, or bypass is introduced. | Architecture; Substrate verification |
-
-## Existing substrate
-
-`repository-artifact.ts` is already the canonical boundary for:
-
-- resolving the installation repository and GitHub credential;
-- requiring one live Workroom whose head equals the immutable commit;
-- fetching commit provenance and parsing one DCO sign-off;
-- resolving the accountable principal and optional agent context; and
-- fetching the provider blob, verifying its Git blob id, byte ceiling, and
-  SHA-256 digest.
-
-The repair stays in this module and its colocated tests. It does not add a
-provider abstraction, database record, retry queue, receipt, authority grant, or
-reviewer role.
-
-## Provider request contract
-
-Introduce one module-private GitHub JSON fetch helper with exactly two attempts.
-It uses the existing request URL, headers, token resolution, and `no-store`
-cache policy.
-
-Retry eligibility is deliberately narrow:
-
-- a thrown fetch/transport exception; or
-- HTTP 408, 429, 500, 502, 503, or 504.
-
-The retry is immediate. The writer path must not sleep inside an approval-bound
-request, and deterministic tests must not depend on wall time. HTTP 400, 401,
-403, 404, 409, and 422 are permanent for this invocation and fail after one
-attempt. A successful HTTP response whose JSON cannot be decoded is also
-terminal: retrying an unreadable success could hide a provider contract defect.
-
-The helper returns a discriminated result with `transport`, `http`, or
-`unreadable` failure kind, attempts, and status where applicable. Callers map
-that result onto their existing public error codes. Diagnostics may include the
-status and bounded attempt count; they never include the token, request headers,
-exception text, or provider response body.
-
-## Flow
-
-1. Resolve canonical repository identity and credentials server-side.
-2. Validate repository, commit, blob, path, subject, and live Workroom binding.
-3. Read commit provenance through the bounded helper.
-4. Parse the DCO sign-off and resolve the accountable Workroom principal.
-5. Read the exact blob through the same helper.
-6. Verify blob identity, byte ceiling, and content digest.
-7. Return the artifact to the existing receipt repository, which retains all
-   reviewer-authority and receipt audit checks.
-
-No retry crosses steps, mutates database state, or reuses a failed payload. The
-single writer invocation remains the audit unit.
-
-## Invariants
-
-- Repository and organization identity remain server-resolved.
-- The requested commit, path, and provider blob id remain immutable inputs.
-- A retry cannot change the TaskRun, writer arguments, envelope, reviewer,
-  subject, organization, or Workroom.
-- Only transport and the explicit retryable status set are retried.
-- All other errors remain immediate and fail closed.
-- Retry count is fixed and bounded at two total attempts per provider read.
-- Provider response bodies and credential material are never logged or returned.
-- No approval, authority, receipt, or plan-coverage requirement is skipped.
+- **AC-PROV-001 / OBJ-PROV-001:** transport and retryable-status failures for
+  commit and blob reads may succeed on the second and final attempt.
+- **AC-PROV-002 / OBJ-PROV-002:** permanent status, unreadable JSON, DCO or
+  Workroom conflict, identity mismatch, blob mismatch, and oversize content
+  remain immediate refusals.
+- **AC-PROV-003 / OBJ-PROV-003:** terminal diagnostics are bounded and sanitized.
+- **AC-PROV-004:** both reads share the helper and one audit invocation.
+- **AC-PROV-005:** no immutable, authorization, approval, or coverage control is
+  weakened or skipped.
 
 ## Independent spec-approval writer contract
 
-The independent reviewer must read the complete immutable design artifact before
-calling `record_initiative_design_review`. For this bounded remediation the
-writer call must use `profile="fix"`, `artifactRole="design-spec"`, and exactly
-one substantive terminal decision:
+The reviewer must read this entire immutable artifact before calling
+`record_initiative_design_review`. Use `profile="fix"`,
+`artifactRole="design-spec"`, and one substantive decision: `pass` with an
+evidence-based reason and no findings, or `fail` with concrete findings.
+`not-applicable`, another profile, placeholder/prospective reasoning, or
+unread/truncated evidence is invalid and non-approvable. It establishes no
+baseline and is never approved or replayed. Any later review must bind to a
+materially revised artifact and fresh deterministic request identity.
 
-- `decision="pass"` with an evidence-based reason and no findings when the
-  design satisfies the review criteria; or
-- `decision="fail"` with concrete findings when it does not.
+## Migration, rollback, and verification
 
-`decision="not-applicable"`, a non-`fix` profile, placeholder or prospective
-reasoning, and claims based on unread or truncated source are invalid for this
-spec-approval gate. Such a call is non-approvable, cannot establish a baseline,
-and must remain preserved as terminal audit evidence. It is never corrected by
-approving or replaying the invalid envelope. Any subsequent review must bind to
-a materially revised immutable design artifact and a fresh deterministic
-request identity.
-
-## Rejected alternatives
-
-- **Replay the consumed reviewer TaskRun or mint another envelope.** The exact
-  envelope is terminal evidence and must not be reused.
-- **Trust local Git or commit metadata supplied by the caller.** The receipt
-  requires provider-verified immutable repository evidence.
-- **Retry every HTTP failure.** Authentication, authorization, not-found, and
-  invalid-input responses require operator correction and remain fail closed.
-- **Add a durable retry job or provider table.** Two request attempts inside one
-  writer invocation solve the observed transient boundary without new state.
-- **Relax provider, DCO, blob, or Workroom checks.** Those controls establish
-  artifact identity and authorship; the repair changes availability only.
-
-## Migration and reconciliation
-
-No schema or data migration is required. Existing failed TaskRuns, envelopes,
-ToolExecutions, and Workroom evidence remain immutable. After a protected
-release, BI-F48D7059 must use one fresh governed reviewer identity; the failed
-TaskRun and envelope are not replayed. A successful receipt can then establish
-the canonical baseline and resume the original readiness path.
-
-## Verification
-
-Tests must prove transient transport and retryable-status recovery for both
-commit and blob reads, one-attempt refusal for permanent statuses and malformed
-payloads, sanitized terminal diagnostics, unchanged DCO and Workroom refusal,
-unchanged blob mismatch and size refusal, and a hard maximum of two attempts.
-The governed review trace must additionally show a complete immutable-source
-read and a writer call conforming to the independent spec-approval contract;
-reviewer prose or an unapproved envelope is not a receipt or baseline.
+No migration is needed; failed TaskRuns, envelopes, executions, and Workroom
+evidence remain immutable. Rollback is a protected revert. Tests cover both
+retry paths, the two-attempt ceiling, permanent/unreadable refusals, sanitized
+errors, unchanged DCO/Workroom/blob/size refusals, a complete immutable read, and
+a conforming writer. Prose or an unapproved envelope is not a baseline.
 
 The implementation plan is
 `docs/superpowers/plans/2026-08-30-immutable-provider-provenance-retry.md`.

--- a/docs/superpowers/specs/2026-08-30-immutable-provider-provenance-retry-design.md
+++ b/docs/superpowers/specs/2026-08-30-immutable-provider-provenance-retry-design.md
@@ -49,9 +49,9 @@ The reviewer must read this entire immutable artifact before calling
 `artifactRole="design-spec"`, and one substantive decision: `pass` with an
 evidence-based reason and no findings, or `fail` with concrete findings.
 `not-applicable`, another profile, placeholder/prospective reasoning, or
-unread/truncated evidence is invalid and non-approvable. It establishes no
-baseline and is never approved or replayed. Any later review must bind to a
-materially revised artifact and fresh deterministic request identity.
+unread/truncated evidence is invalid. Invalid calls and valid calls whose
+approval window expires establish no baseline; neither is approved or replayed.
+Any later review must bind to a materially revised artifact and fresh key.
 
 ## Migration, rollback, and verification
 

--- a/docs/superpowers/specs/2026-08-30-immutable-provider-provenance-retry-design.md
+++ b/docs/superpowers/specs/2026-08-30-immutable-provider-provenance-retry-design.md
@@ -1,0 +1,148 @@
+---
+status: active
+---
+
+# Immutable Provider Provenance Retry
+
+**Backlog item:** BI-E35E1183
+**Epic:** EP-56AE0F69
+**Workroom:** WC-6D36EB1A
+**Status:** Approved bounded remediation in progress
+
+## Problem
+
+The initiative evidence writer verifies its design artifact from the canonical
+repository provider before it persists a receipt. On BI-F48D7059, independent
+review completed and the exact human-approved writer replay reached that
+verification boundary, but the commit read failed once with
+`CANONICAL_DESIGN_REQUIRED: Repository provider could not resolve immutable
+commit provenance.` The same exact public GitHub commit resolved from the host
+and from the portal container immediately afterward.
+
+The provider reader currently makes one request for commit provenance and one
+request for the exact blob. A thrown fetch or retryable HTTP response becomes a
+terminal generic error. Because the approved reviewer envelope is single-use,
+that transient read consumes the only lawful replay even though neither the
+artifact identity nor the reviewer decision changed.
+
+## Outcome
+
+Both canonical provider reads use one bounded, fail-closed JSON request helper.
+The helper retries only transient transport failures and explicitly retryable
+HTTP statuses within the same writer invocation. Permanent provider responses,
+unreadable payloads, immutable identity mismatches, DCO conflicts, Workroom
+conflicts, and size limits continue to fail immediately. A retry never creates a
+new TaskRun, approval envelope, decision, receipt, or authority grant.
+
+## Governed scope manifest
+
+- **OBJ-PROV-001:** Recover a transient canonical provider read inside the same
+  approved writer invocation without consuming another reviewer identity.
+- **OBJ-PROV-002:** Keep all immutable commit, blob, DCO, Workroom, author, size,
+  repository, and subject checks fail closed.
+- **OBJ-PROV-003:** Return bounded, sanitized diagnostics that distinguish
+  transport, HTTP status, and unreadable-provider failures without exposing
+  tokens or response bodies.
+
+| Acceptance | Objectives | Statement | Design evidence |
+| --- | --- | --- | --- |
+| AC-PROV-001 | OBJ-PROV-001 | A first-attempt transport exception followed by a valid response succeeds for commit provenance and for exact blob reads within one resolver call. | Provider request contract; Verification |
+| AC-PROV-002 | OBJ-PROV-001 | Retryable HTTP responses (408, 429, 500, 502, 503, 504) receive at most one immediate retry; success on that retry continues canonical verification. | Provider request contract; Invariants |
+| AC-PROV-003 | OBJ-PROV-002 | Permanent 4xx responses, malformed success payloads, DCO ambiguity, Workroom/head mismatch, blob mismatch, and oversized content do not retry or become successful. | Invariants; Verification |
+| AC-PROV-004 | OBJ-PROV-003 | Terminal messages name failure class, attempt count, and HTTP status when available, but never include authorization headers, tokens, or response bodies. | Diagnostics contract; Verification |
+| AC-PROV-005 | OBJ-PROV-001, OBJ-PROV-002 | Commit provenance and exact blob retrieval share the same bounded provider helper; no second source-of-truth, schema, receipt type, tool, reviewer role, or bypass is introduced. | Architecture; Substrate verification |
+
+## Existing substrate
+
+`repository-artifact.ts` is already the canonical boundary for:
+
+- resolving the installation repository and GitHub credential;
+- requiring one live Workroom whose head equals the immutable commit;
+- fetching commit provenance and parsing one DCO sign-off;
+- resolving the accountable principal and optional agent context; and
+- fetching the provider blob, verifying its Git blob id, byte ceiling, and
+  SHA-256 digest.
+
+The repair stays in this module and its colocated tests. It does not add a
+provider abstraction, database record, retry queue, receipt, authority grant, or
+reviewer role.
+
+## Provider request contract
+
+Introduce one module-private GitHub JSON fetch helper with exactly two attempts.
+It uses the existing request URL, headers, token resolution, and `no-store`
+cache policy.
+
+Retry eligibility is deliberately narrow:
+
+- a thrown fetch/transport exception; or
+- HTTP 408, 429, 500, 502, 503, or 504.
+
+The retry is immediate. The writer path must not sleep inside an approval-bound
+request, and deterministic tests must not depend on wall time. HTTP 400, 401,
+403, 404, 409, and 422 are permanent for this invocation and fail after one
+attempt. A successful HTTP response whose JSON cannot be decoded is also
+terminal: retrying an unreadable success could hide a provider contract defect.
+
+The helper returns a discriminated result with `transport`, `http`, or
+`unreadable` failure kind, attempts, and status where applicable. Callers map
+that result onto their existing public error codes. Diagnostics may include the
+status and bounded attempt count; they never include the token, request headers,
+exception text, or provider response body.
+
+## Flow
+
+1. Resolve canonical repository identity and credentials server-side.
+2. Validate repository, commit, blob, path, subject, and live Workroom binding.
+3. Read commit provenance through the bounded helper.
+4. Parse the DCO sign-off and resolve the accountable Workroom principal.
+5. Read the exact blob through the same helper.
+6. Verify blob identity, byte ceiling, and content digest.
+7. Return the artifact to the existing receipt repository, which retains all
+   reviewer-authority and receipt audit checks.
+
+No retry crosses steps, mutates database state, or reuses a failed payload. The
+single writer invocation remains the audit unit.
+
+## Invariants
+
+- Repository and organization identity remain server-resolved.
+- The requested commit, path, and provider blob id remain immutable inputs.
+- A retry cannot change the TaskRun, writer arguments, envelope, reviewer,
+  subject, organization, or Workroom.
+- Only transport and the explicit retryable status set are retried.
+- All other errors remain immediate and fail closed.
+- Retry count is fixed and bounded at two total attempts per provider read.
+- Provider response bodies and credential material are never logged or returned.
+- No approval, authority, receipt, or plan-coverage requirement is skipped.
+
+## Rejected alternatives
+
+- **Replay the consumed reviewer TaskRun or mint another envelope.** The exact
+  envelope is terminal evidence and must not be reused.
+- **Trust local Git or commit metadata supplied by the caller.** The receipt
+  requires provider-verified immutable repository evidence.
+- **Retry every HTTP failure.** Authentication, authorization, not-found, and
+  invalid-input responses require operator correction and remain fail closed.
+- **Add a durable retry job or provider table.** Two request attempts inside one
+  writer invocation solve the observed transient boundary without new state.
+- **Relax provider, DCO, blob, or Workroom checks.** Those controls establish
+  artifact identity and authorship; the repair changes availability only.
+
+## Migration and reconciliation
+
+No schema or data migration is required. Existing failed TaskRuns, envelopes,
+ToolExecutions, and Workroom evidence remain immutable. After a protected
+release, BI-F48D7059 must use one fresh governed reviewer identity; the failed
+TaskRun and envelope are not replayed. A successful receipt can then establish
+the canonical baseline and resume the original readiness path.
+
+## Verification
+
+Tests must prove transient transport and retryable-status recovery for both
+commit and blob reads, one-attempt refusal for permanent statuses and malformed
+payloads, sanitized terminal diagnostics, unchanged DCO and Workroom refusal,
+unchanged blob mismatch and size refusal, and a hard maximum of two attempts.
+
+The implementation plan is
+`docs/superpowers/plans/2026-08-30-immutable-provider-provenance-retry.md`.

--- a/docs/superpowers/specs/2026-08-30-immutable-provider-provenance-retry-design.md
+++ b/docs/superpowers/specs/2026-08-30-immutable-provider-provenance-retry-design.md
@@ -116,6 +116,25 @@ single writer invocation remains the audit unit.
 - Provider response bodies and credential material are never logged or returned.
 - No approval, authority, receipt, or plan-coverage requirement is skipped.
 
+## Independent spec-approval writer contract
+
+The independent reviewer must read the complete immutable design artifact before
+calling `record_initiative_design_review`. For this bounded remediation the
+writer call must use `profile="fix"`, `artifactRole="design-spec"`, and exactly
+one substantive terminal decision:
+
+- `decision="pass"` with an evidence-based reason and no findings when the
+  design satisfies the review criteria; or
+- `decision="fail"` with concrete findings when it does not.
+
+`decision="not-applicable"`, a non-`fix` profile, placeholder or prospective
+reasoning, and claims based on unread or truncated source are invalid for this
+spec-approval gate. Such a call is non-approvable, cannot establish a baseline,
+and must remain preserved as terminal audit evidence. It is never corrected by
+approving or replaying the invalid envelope. Any subsequent review must bind to
+a materially revised immutable design artifact and a fresh deterministic
+request identity.
+
 ## Rejected alternatives
 
 - **Replay the consumed reviewer TaskRun or mint another envelope.** The exact
@@ -143,6 +162,9 @@ Tests must prove transient transport and retryable-status recovery for both
 commit and blob reads, one-attempt refusal for permanent statuses and malformed
 payloads, sanitized terminal diagnostics, unchanged DCO and Workroom refusal,
 unchanged blob mismatch and size refusal, and a hard maximum of two attempts.
+The governed review trace must additionally show a complete immutable-source
+read and a writer call conforming to the independent spec-approval contract;
+reviewer prose or an unapproved envelope is not a receipt or baseline.
 
 The implementation plan is
 `docs/superpowers/plans/2026-08-30-immutable-provider-provenance-retry.md`.


### PR DESCRIPTION
## Summary

- Retry transient repository-provider transport failures while resolving immutable commit provenance.
- Preserve fail-closed behavior for permanent provider errors and all exact commit/blob/DCO controls.

## Evidence

- BI-E35E1183 / WC-6D36EB1A
- TDD: 3 suites, 45 tests PASS; web typecheck and style drift PASS.
- Guard preflight: 59 guards clean; one Windows host-contract check is environment-skipped.
- Exact commit: `41c8f24279f9bc51c71fe861010fa7ac59406ece`
- Local-CI lane is occupied/nonperforming; this is an explicit recorded operator bypass. Protected GitHub checks remain mandatory.

Local-CI-Override: operator-emergency: local integration-CI lane occupied; protected GitHub checks remain mandatory
