### PR TITLE
feat(build): record verification-depth shadow gates

### DIFF
--- a/apps/web/app/api/agent/build/advance-phase/route.ts
+++ b/apps/web/app/api/agent/build/advance-phase/route.ts
@@ -8,12 +8,12 @@ import { can } from "@/lib/permissions";
 import { prisma } from "@dpf/db";
 import {
   canTransitionPhase,
-  checkPhaseGate,
   normalizeHappyPathState,
   type BuildDeliberationSummary,
   type BuildPhase,
   type ReviewResult,
 } from "@/lib/feature-build-types";
+import { checkBuildPhaseGate } from "@/lib/work-posture/verification-depth-gate";
 import { evaluateBuildStudioPlanAdvancementGate } from "@/lib/decision-perspective/build-studio-gate";
 import { resolvePlannedFilePaths } from "@/lib/decision-perspective/planned-file-paths";
 
@@ -61,6 +61,8 @@ export async function POST(request: NextRequest): Promise<Response> {
       planReview: true,
       verificationOut: true,
       acceptanceMet: true,
+      uxTestResults: true,
+      uxVerificationStatus: true,
       deliberationSummary: true,
       threadId: true,
     },
@@ -104,16 +106,25 @@ export async function POST(request: NextRequest): Promise<Response> {
   }
 
   const advanceBrief = build.brief as { fixContext?: import("@/lib/feature-build-types").FixContext } | null;
-  const gate = checkPhaseGate(currentPhase, targetPhase, {
-    kind: build.kind,
-    fixContext: advanceBrief?.fixContext,
-    designDoc: build.designDoc,
-    designReview: build.designReview,
-    happyPathState: normalizeHappyPathState((build.plan as Record<string, unknown> | null)?.happyPathState ?? null),
-    buildPlan: build.buildPlan,
-    planReview: build.planReview,
-    verificationOut: build.verificationOut,
-    acceptanceMet: build.acceptanceMet,
+  const advancePlan = (build.plan as Record<string, unknown> | null) ?? {};
+  const gate = await checkBuildPhaseGate({
+    buildId,
+    from: currentPhase,
+    to: targetPhase,
+    evidence: {
+      kind: build.kind,
+      processSize: (advancePlan.processSize as string | undefined) ?? "medium",
+      fixContext: advanceBrief?.fixContext,
+      designDoc: build.designDoc,
+      designReview: build.designReview,
+      happyPathState: normalizeHappyPathState(advancePlan.happyPathState ?? null),
+      buildPlan: build.buildPlan,
+      planReview: build.planReview,
+      verificationOut: build.verificationOut,
+      acceptanceMet: build.acceptanceMet,
+      uxTestResults: build.uxTestResults,
+      uxVerificationStatus: build.uxVerificationStatus,
+    },
   });
 
   if (!gate.allowed) {

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -382,7 +382,8 @@ export async function recoverContradictoryBuildExecStatesOnBoot(
 export async function advanceStrandedBuildToReview(buildId: string): Promise<boolean> {
   if (process.env.NEXT_RUNTIME && process.env.NEXT_RUNTIME !== "nodejs") return false;
   const { prisma } = await import("@dpf/db");
-  const { checkPhaseGate, canTransitionPhase } = await import("@/lib/feature-build-types");
+  const { canTransitionPhase } = await import("@/lib/feature-build-types");
+  const { checkBuildPhaseGate } = await import("@/lib/work-posture/verification-depth-gate");
 
   const build = await prisma.featureBuild.findUnique({ where: { buildId } });
   if (!build || build.phase !== "build" || !canTransitionPhase("build", "review")) {
@@ -408,8 +409,15 @@ export async function advanceStrandedBuildToReview(buildId: string): Promise<boo
     // Fall back to the raw verificationOut, exactly like the orchestrator.
   }
 
-  const gate = checkPhaseGate("build", "review", {
-    verificationOut: verificationForGate as typeof build.verificationOut,
+  const gate = await checkBuildPhaseGate({
+    buildId,
+    from: "build",
+    to: "review",
+    evidence: {
+      kind: build.kind,
+      processSize: ((build.plan as Record<string, unknown> | null)?.processSize as string | undefined) ?? "medium",
+      verificationOut: verificationForGate as typeof build.verificationOut,
+    },
   });
   if (!gate.allowed) return false;
 

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -5,7 +5,6 @@ import { prisma, type Prisma } from "@dpf/db";
 import { revalidatePath } from "next/cache";
 import {
   canTransitionPhase,
-  checkPhaseGate,
   generateBuildId,
   bumpVersion,
   normalizeHappyPathState,
@@ -17,6 +16,7 @@ import {
   type ReviewResult,
   type BuildDeliberationSummary,
 } from "@/lib/feature-build-types";
+import { checkBuildPhaseGate } from "@/lib/work-posture/verification-depth-gate";
 import { buildDesignReviewPrompt, buildPlanReviewPrompt, parseReviewResponse } from "@/lib/build-reviewers";
 import { queueBuildReviewVerification } from "@/lib/build-review-verification-trigger";
 import { saveBuildArtifactRevision, type BuildArtifactField } from "@/lib/build/build-artifact-provenance";
@@ -416,21 +416,26 @@ export async function advanceBuildPhase(
   // docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md.
   const buildPlanState = (build.plan as Record<string, unknown> | null) ?? null;
   const processSize = (buildPlanState?.["processSize"] as string | undefined) ?? "medium";
-  const gate = checkPhaseGate(currentPhase, targetPhase, {
-    kind: build.kind,
-    processSize,
-    fixContext: brief?.fixContext,
-    designDoc: build.designDoc,
-    designReview: build.designReview,
-    happyPathState: normalizeHappyPathState(buildPlanState?.happyPathState ?? null),
-    buildPlan: build.buildPlan,
-    planReview: build.planReview,
-    taskResults: build.taskResults,
-    verificationOut: build.verificationOut,
-    acceptanceMet: build.acceptanceMet,
-    uxTestResults: build.uxTestResults,
-    uxVerificationStatus: build.uxVerificationStatus,
-    acceptanceCriteria: brief?.acceptanceCriteria ?? [],
+  const gate = await checkBuildPhaseGate({
+    buildId,
+    from: currentPhase,
+    to: targetPhase,
+    evidence: {
+      kind: build.kind,
+      processSize,
+      fixContext: brief?.fixContext,
+      designDoc: build.designDoc,
+      designReview: build.designReview,
+      happyPathState: normalizeHappyPathState(buildPlanState?.happyPathState ?? null),
+      buildPlan: build.buildPlan,
+      planReview: build.planReview,
+      taskResults: build.taskResults,
+      verificationOut: build.verificationOut,
+      acceptanceMet: build.acceptanceMet,
+      uxTestResults: build.uxTestResults,
+      uxVerificationStatus: build.uxVerificationStatus,
+      acceptanceCriteria: brief?.acceptanceCriteria ?? [],
+    },
   });
 
   if (!gate.allowed) {

--- a/apps/web/lib/build/build-orchestrator.ts
+++ b/apps/web/lib/build/build-orchestrator.ts
@@ -1679,7 +1679,8 @@ export async function runBuildOrchestrator(params: {
   // NOTE: Cannot call advanceBuildPhase (server action) here because auth()
   // has no HTTP request context inside the agentic loop. Direct DB update instead.
   try {
-    const { checkPhaseGate, canTransitionPhase } = await import("@/lib/feature-build-types");
+    const { canTransitionPhase } = await import("@/lib/feature-build-types");
+    const { checkBuildPhaseGate } = await import("@/lib/work-posture/verification-depth-gate");
     const updatedBuild = await prisma.featureBuild.findUnique({ where: { buildId } });
     // The synthetic QA task (taskIndex === -1, "Full verification: tests +
     // typecheck") is dispatched to the model, which runs the full suite via
@@ -1717,8 +1718,15 @@ export async function runBuildOrchestrator(params: {
       } catch (scopeErr) {
         console.warn("[orchestrator] scoped verification for gate failed; using raw verificationOut:", (scopeErr as Error)?.message);
       }
-      const gate = checkPhaseGate("build", "review", {
-        verificationOut: verificationForGate as typeof updatedBuild.verificationOut,
+      const gate = await checkBuildPhaseGate({
+        buildId,
+        from: "build",
+        to: "review",
+        evidence: {
+          kind: updatedBuild.kind,
+          processSize: ((updatedBuild.plan as Record<string, unknown> | null)?.processSize as string | undefined) ?? "medium",
+          verificationOut: verificationForGate as typeof updatedBuild.verificationOut,
+        },
       });
       if (gate.allowed) {
         await prisma.featureBuild.update({ where: { buildId }, data: { phase: "review" } });

--- a/apps/web/lib/build/plan-to-build-transition.ts
+++ b/apps/web/lib/build/plan-to-build-transition.ts
@@ -29,9 +29,9 @@
 import { prisma, type Prisma } from "@dpf/db";
 import {
   canTransitionPhase,
-  checkPhaseGate,
   normalizeHappyPathState,
 } from "@/lib/feature-build-types";
+import { checkBuildPhaseGate } from "@/lib/work-posture/verification-depth-gate";
 import {
   deriveFeatureBuildDependencyGate,
   type FeatureBuildDependencyGateResult,
@@ -295,14 +295,19 @@ export async function performPlanToBuildTransition(params: {
 
   // Structural phase gate.
   const planRec = (build.plan as Record<string, unknown> | null) ?? {};
-  const gate = checkPhaseGate("plan", "build", {
-    kind: build.kind,
-    processSize: (planRec.processSize as string | undefined) ?? "medium",
-    deliverableSensitivity: planRec.deliverableSensitivity,
-    qualityFirst: planRec.qualityFirst === true,
-    buildPlan: build.buildPlan,
-    planReview: build.planReview,
-    happyPathState: normalizeHappyPathState(planRec.happyPathState),
+  const gate = await checkBuildPhaseGate({
+    buildId,
+    from: "plan",
+    to: "build",
+    evidence: {
+      kind: build.kind,
+      processSize: (planRec.processSize as string | undefined) ?? "medium",
+      deliverableSensitivity: planRec.deliverableSensitivity,
+      qualityFirst: planRec.qualityFirst === true,
+      buildPlan: build.buildPlan,
+      planReview: build.planReview,
+      happyPathState: normalizeHappyPathState(planRec.happyPathState),
+    },
   });
   if (!gate.allowed) {
     logBuildActivity(buildId, "phase:gate-blocked", gate.reason ?? "plan→build gate not satisfied");

--- a/apps/web/lib/build/ship-on-review-approval.ts
+++ b/apps/web/lib/build/ship-on-review-approval.ts
@@ -176,6 +176,8 @@ export async function advanceReviewedBuildToShip(
       planReview: true,
       verificationOut: true,
       acceptanceMet: true,
+      uxTestResults: true,
+      uxVerificationStatus: true,
       threadId: true,
       diffPatch: true,
       createdById: true,
@@ -281,9 +283,10 @@ export async function advanceReviewedBuildToShip(
     /* never blocks the manual/off path */
   }
 
-  const { checkPhaseGate, canTransitionPhase, normalizeHappyPathState } = await import(
+  const { canTransitionPhase, normalizeHappyPathState } = await import(
     "@/lib/feature-build-types"
   );
+  const { checkBuildPhaseGate } = await import("@/lib/work-posture/verification-depth-gate");
   if (!canTransitionPhase("review", "ship")) {
     return { kind: "skipped", reason: "transition not allowed" };
   }
@@ -296,18 +299,26 @@ export async function advanceReviewedBuildToShip(
   }
 
   const brief = build.brief as { fixContext?: unknown } | null;
-  const gate = checkPhaseGate("review", "ship", {
-    kind: build.kind,
-    fixContext: brief?.fixContext,
-    designDoc: build.designDoc,
-    designReview: build.designReview,
-    happyPathState: normalizeHappyPathState(
-      (build.plan as Record<string, unknown> | null)?.happyPathState ?? null,
-    ),
-    buildPlan: build.buildPlan,
-    planReview: build.planReview,
-    verificationOut: build.verificationOut,
-    acceptanceMet: build.acceptanceMet,
+  const gate = await checkBuildPhaseGate({
+    buildId,
+    from: "review",
+    to: "ship",
+    evidence: {
+      kind: build.kind,
+      processSize: ((build.plan as Record<string, unknown> | null)?.processSize as string | undefined) ?? "medium",
+      fixContext: brief?.fixContext,
+      designDoc: build.designDoc,
+      designReview: build.designReview,
+      happyPathState: normalizeHappyPathState(
+        (build.plan as Record<string, unknown> | null)?.happyPathState ?? null,
+      ),
+      buildPlan: build.buildPlan,
+      planReview: build.planReview,
+      verificationOut: build.verificationOut,
+      acceptanceMet: build.acceptanceMet,
+      uxTestResults: build.uxTestResults,
+      uxVerificationStatus: build.uxVerificationStatus,
+    },
   });
   if (!gate.allowed) {
     await log(`Not advanced — review→ship gate: ${gate.reason ?? "blocked"}`);

--- a/apps/web/lib/explore/build-process-matrix.test.ts
+++ b/apps/web/lib/explore/build-process-matrix.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   BUILD_PROCESS_TYPE_VALUES,
   BUILD_PROCESS_SIZES,
+  GATE_REQUIREMENTS,
+  checkRequirement,
   DELIVERABLE_SENSITIVITIES,
   deriveBuildProcessSize,
   deriveBuildProcessType,
@@ -15,6 +17,7 @@ import {
   type BuildProcessSize,
   type BuildProcessType,
 } from "./build-process-matrix";
+import { evaluateVerificationDepthShadow } from "./verification-depth-shadow";
 import { checkPhaseGate, normalizeHappyPathState, type FixContext } from "./feature-build-types";
 
 // The right-sizing matrix maps (type, size) -> a LifecyclePolicy. These tests
@@ -230,6 +233,130 @@ describe("checkPhaseGate via the matrix — back-compat invariant", () => {
 
   it("allows review->build backward transition (no gate)", () => {
     expect(checkPhaseGate("review", "build", {}).allowed).toBe(true);
+  });
+});
+
+describe("verification-depth-satisfied — shadow requirement", () => {
+  const greenVerification = {
+    testsPassed: 12,
+    testsFailed: 0,
+    typecheckPassed: true,
+    fullOutput: "green",
+    timestamp: "2026-08-29T00:00:00.000Z",
+  };
+
+  it("keeps absent and none byte-identical across absent, present, and failed evidence", () => {
+    const failedVerification = { ...greenVerification, testsFailed: 2, typecheckPassed: false };
+    for (const verificationDepth of [undefined, "none"] as const) {
+      expect(checkRequirement("verification-depth-satisfied", { verificationDepth })).toEqual({ allowed: true });
+      expect(checkRequirement("verification-depth-satisfied", {
+        verificationDepth,
+        verificationOut: greenVerification,
+      })).toEqual({ allowed: true });
+      expect(checkRequirement("verification-depth-satisfied", {
+        verificationDepth,
+        verificationOut: failedVerification,
+        uxVerificationStatus: "failed",
+      })).toEqual({ allowed: true });
+    }
+  });
+
+  it("requires a green typecheck and zero failed tests at shallow depth", () => {
+    expect(checkRequirement("verification-depth-satisfied", {
+      verificationDepth: "shallow",
+      verificationOut: greenVerification,
+    })).toEqual({ allowed: true });
+    expect(checkRequirement("verification-depth-satisfied", { verificationDepth: "shallow" })).toMatchObject({ allowed: false });
+    expect(checkRequirement("verification-depth-satisfied", {
+      verificationDepth: "shallow",
+      verificationOut: { typecheckPassed: true },
+    })).toMatchObject({ allowed: false });
+    expect(checkRequirement("verification-depth-satisfied", {
+      verificationDepth: "shallow",
+      verificationOut: { ...greenVerification, testsFailed: 1 },
+    })).toMatchObject({ allowed: false });
+    expect(checkRequirement("verification-depth-satisfied", {
+      verificationDepth: "shallow",
+      verificationOut: { ...greenVerification, typecheckPassed: false },
+    })).toMatchObject({ allowed: false });
+  });
+
+  it("requires shallow evidence plus a mechanical real-path verdict at deep depth", () => {
+    expect(checkRequirement("verification-depth-satisfied", {
+      verificationDepth: "deep",
+      verificationOut: greenVerification,
+      uxVerificationStatus: "complete",
+      uxTestResults: [{ step: "Open the affected route", passed: true }],
+    })).toEqual({ allowed: true });
+    expect(checkRequirement("verification-depth-satisfied", {
+      verificationDepth: "deep",
+      verificationOut: greenVerification,
+    })).toMatchObject({ allowed: false });
+    expect(checkRequirement("verification-depth-satisfied", {
+      verificationDepth: "deep",
+      verificationOut: greenVerification,
+      uxVerificationStatus: "failed",
+      uxTestResults: [{ step: "Open the affected route", passed: false }],
+    })).toMatchObject({ allowed: false });
+  });
+
+  it("accepts a passing golden-journey result as deep real-path evidence", () => {
+    expect(checkRequirement("verification-depth-satisfied", {
+      verificationDepth: "deep",
+      verificationOut: greenVerification,
+      goldenJourneyResult: { journeyId: "journey-1", passed: true },
+    })).toEqual({ allowed: true });
+  });
+
+  it("evaluates every transition in shadow without adding the requirement to a policy", () => {
+    for (const type of BUILD_PROCESS_TYPE_VALUES) {
+      for (const size of BUILD_PROCESS_SIZES) {
+        const policy = getProcessPolicy(type, size);
+        for (const requirements of Object.values(policy.gates)) {
+          expect(requirements).not.toContain("verification-depth-satisfied");
+        }
+      }
+    }
+    expect(GATE_REQUIREMENTS).toContain("verification-depth-satisfied");
+
+    const decision = evaluateVerificationDepthShadow("review", "ship", {
+      kind: "feature",
+      processSize: "medium",
+      verificationDepth: "shallow",
+      verificationOut: { ...greenVerification, testsFailed: 3 },
+    });
+    expect(decision).toMatchObject({
+      transition: "review->ship",
+      kind: "feature",
+      processSize: "medium",
+      declaredDepth: "shallow",
+      wouldBlock: true,
+    });
+  });
+
+  it("does not alter the default gate verdict for absent or none depth", () => {
+    const evidence = {
+      designDoc: { problemStatement: "x" },
+      buildPlan: { tasks: [] },
+      acceptanceMet: true,
+      verificationOut: { ...greenVerification, testsFailed: 4 },
+      uxVerificationStatus: "failed",
+    };
+    const today = checkPhaseGate("review", "ship", evidence);
+    for (const kind of [undefined, "feature"] as const) {
+      for (const processSize of [undefined, "medium"] as const) {
+        for (const verificationDepth of [undefined, "none"] as const) {
+          const result = checkPhaseGate("review", "ship", {
+            ...evidence,
+            kind,
+            processSize,
+            verificationDepth,
+          });
+          expect(JSON.stringify(result)).toBe(JSON.stringify(today));
+        }
+      }
+    }
+    expect(today).toEqual({ allowed: true });
   });
 });
 

--- a/apps/web/lib/explore/build-process-matrix.ts
+++ b/apps/web/lib/explore/build-process-matrix.ts
@@ -19,6 +19,7 @@
 import type { BacklogItemWithRelations } from "./backlog";
 import { BACKLOG_EFFORT_SIZES } from "./backlog";
 import type { BuildPhase, FeatureBuildKind } from "./feature-build-types";
+import { checkVerificationDepthSatisfied } from "./verification-depth-requirement";
 import {
   FEATURE_BUILD_KIND_VALUES,
 } from "./feature-build-types";
@@ -79,6 +80,7 @@ export const GATE_REQUIREMENTS = [
   "buildPlan-present",
   "planReview-passed",
   "verification-typecheck-passed",
+  "verification-depth-satisfied",
   "acceptance-evaluated",
   "acceptance-all-met-if-array",
   "uxVerification-not-blocking",
@@ -706,6 +708,9 @@ export function checkRequirement(req: GateRequirement, evidence: GateEvidence): 
       if (!verification.typecheckPassed) return { allowed: false, reason: "Typecheck must pass before review." };
       return { allowed: true };
     }
+    case "verification-depth-satisfied": {
+      return checkVerificationDepthSatisfied(evidence);
+    }
     case "acceptance-evaluated": {
       if (!evidence.acceptanceMet) return { allowed: false, reason: "Acceptance criteria not evaluated." };
       return { allowed: true };
@@ -790,9 +795,7 @@ import type { PhaseGateResult } from "./feature-build-types";
  *                          happyPathIntake-ready reason string only)
  *   (everything else)    — same as before
  */
-/** Read the additive rightsizing opts a caller threaded through the gate
- *  evidence. Returns undefined when neither field is present, so gates for
- *  callers that don't set them are byte-identical (EP-QUALITY-RIGHTSIZING). */
+/** Read additive rightsizing opts; absent fields preserve byte identity. */
 function rightsizingOptsFromEvidence(evidence: GateEvidence): RightsizingOpts | undefined {
   const qualityFirst = evidence.qualityFirst === true;
   const sensitivity = evidence.deliverableSensitivity as DeliverableSensitivity | undefined;
@@ -817,9 +820,7 @@ export function checkPhaseGate(
   const transition = `${from}->${to}` as BuildTransition;
   const required = policy.gates[transition] ?? [];
 
-  // The happyPathIntake-ready check has two callers (ideate->plan and
-  // plan->build) with different reason verbs. Surface the verb through
-  // evidence so the matrix's requirement enum stays compact.
+  // Surface the transition-specific intake verb without widening the enum.
   const verb = transition === "plan->build" ? "building" : "planning";
   const evidenceWithVerb = { ...evidence, intakeVerb: evidence.intakeVerb ?? verb };
 

--- a/apps/web/lib/explore/build-process-matrix.ts
+++ b/apps/web/lib/explore/build-process-matrix.ts
@@ -708,9 +708,8 @@ export function checkRequirement(req: GateRequirement, evidence: GateEvidence): 
       if (!verification.typecheckPassed) return { allowed: false, reason: "Typecheck must pass before review." };
       return { allowed: true };
     }
-    case "verification-depth-satisfied": {
+    case "verification-depth-satisfied":
       return checkVerificationDepthSatisfied(evidence);
-    }
     case "acceptance-evaluated": {
       if (!evidence.acceptanceMet) return { allowed: false, reason: "Acceptance criteria not evaluated." };
       return { allowed: true };

--- a/apps/web/lib/explore/verification-depth-requirement.ts
+++ b/apps/web/lib/explore/verification-depth-requirement.ts
@@ -1,0 +1,44 @@
+import type { VerificationDepth } from "@/lib/golden-triangle";
+
+type RequirementResult = { allowed: true } | { allowed: false; reason: string };
+
+/** Pure observed-evidence check for the verification-depth requirement. */
+export function checkVerificationDepthSatisfied(
+  evidence: Record<string, unknown>,
+): RequirementResult {
+  const depth = evidence.verificationDepth as VerificationDepth | undefined;
+  if (depth !== "shallow" && depth !== "deep") return { allowed: true };
+  const verification = evidence.verificationOut as {
+    testsFailed?: number;
+    typecheckPassed?: boolean;
+  } | null | undefined;
+  if (!verification?.typecheckPassed) {
+    return { allowed: false, reason: `${depth} verification requires a passing typecheck.` };
+  }
+  if (verification.testsFailed !== 0) {
+    return { allowed: false, reason: `${depth} verification requires zero failed tests.` };
+  }
+  if (depth === "shallow") return { allowed: true };
+
+  const goldenJourney = evidence.goldenJourneyResult as {
+    journeyId?: unknown;
+    passed?: unknown;
+  } | null | undefined;
+  const goldenJourneyPassed = goldenJourney?.passed === true
+    && typeof goldenJourney.journeyId === "string"
+    && goldenJourney.journeyId.trim().length > 0;
+  const uxResults = Array.isArray(evidence.uxTestResults)
+    ? evidence.uxTestResults as Array<{ step?: unknown; passed?: unknown }>
+    : [];
+  const uxPassed = evidence.uxVerificationStatus === "complete"
+    && uxResults.length > 0
+    && uxResults.every((result) =>
+      result.passed === true
+      && typeof result.step === "string"
+      && result.step.trim().length > 0);
+  if (goldenJourneyPassed || uxPassed) return { allowed: true };
+  return {
+    allowed: false,
+    reason: "Deep verification requires a passing mechanical verdict on the real path.",
+  };
+}

--- a/apps/web/lib/explore/verification-depth-shadow.ts
+++ b/apps/web/lib/explore/verification-depth-shadow.ts
@@ -1,0 +1,41 @@
+import type { VerificationDepth } from "@/lib/golden-triangle";
+import type { BuildPhase } from "./feature-build-types";
+import {
+  checkRequirement,
+  normalizeSize,
+  normalizeType,
+  type BuildProcessSize,
+  type BuildProcessType,
+} from "./build-process-matrix";
+
+export type VerificationDepthShadowDecision = {
+  transition: string;
+  kind: BuildProcessType;
+  processSize: BuildProcessSize;
+  declaredDepth: VerificationDepth;
+  wouldBlock: boolean;
+  reason?: string;
+};
+
+/** Report-only evaluation, kept outside the lifecycle policy verdict loop. */
+export function evaluateVerificationDepthShadow(
+  from: BuildPhase,
+  to: BuildPhase,
+  evidence: Record<string, unknown>,
+): VerificationDepthShadowDecision {
+  const depth = evidence.verificationDepth === "shallow" || evidence.verificationDepth === "deep"
+    ? evidence.verificationDepth
+    : "none";
+  const result = checkRequirement("verification-depth-satisfied", {
+    ...evidence,
+    verificationDepth: depth,
+  });
+  return {
+    transition: `${from}->${to}`,
+    kind: normalizeType(evidence.kind as string | undefined),
+    processSize: normalizeSize(evidence.processSize as string | undefined),
+    declaredDepth: depth,
+    wouldBlock: !result.allowed,
+    ...(!result.allowed ? { reason: result.reason } : {}),
+  };
+}

--- a/apps/web/lib/mcp/build-design-review-handler.ts
+++ b/apps/web/lib/mcp/build-design-review-handler.ts
@@ -48,7 +48,8 @@ export async function reviewDesignDoc(params: Record<string, unknown>, userId: s
       // diagnosis (fixContext) on its brief. Review the diagnosis for completeness
       // and advance ideate → plan, instead of running the feature design reviewers.
       if (build?.kind === "fix") {
-        const { isFixContextComplete, checkPhaseGate } = await import("@/lib/feature-build-types");
+        const { isFixContextComplete } = await import("@/lib/feature-build-types");
+        const { checkBuildPhaseGate } = await import("@/lib/work-posture/verification-depth-gate");
         const fixBrief = (build.brief ?? null) as import("@/lib/feature-build-types").FeatureBrief | null;
         const fixProcessSize = ((build.plan as Record<string, unknown> | null)?.processSize as string | undefined) ?? "medium";
         const fc = fixBrief?.fixContext;
@@ -67,7 +68,12 @@ export async function reviewDesignDoc(params: Record<string, unknown>, userId: s
         let fixPhaseGateBlocker: string | null = null;
         try {
           const fixPlan = (build.plan as Record<string, unknown> | null);
-          const gate = checkPhaseGate("ideate", "plan", { kind: "fix", processSize: fixProcessSize, deliverableSensitivity: fixPlan?.deliverableSensitivity, qualityFirst: fixPlan?.qualityFirst === true, fixContext: fc, designReview: review });
+          const gate = await checkBuildPhaseGate({
+            buildId,
+            from: "ideate",
+            to: "plan",
+            evidence: { kind: "fix", processSize: fixProcessSize, deliverableSensitivity: fixPlan?.deliverableSensitivity, qualityFirst: fixPlan?.qualityFirst === true, fixContext: fc, designReview: review },
+          });
           const readiness = gate.allowed
             ? await enforceBuildInitiativeReadiness({ buildId, target: "plan", targetPhase: "plan", expectedPhase: "ideate" })
             : null;
@@ -326,7 +332,8 @@ export async function reviewDesignDoc(params: Record<string, unknown>, userId: s
       //   3. Pass happyPathState to checkPhaseGate so the full intake
       //      check actually runs.
       try {
-        const { checkPhaseGate, canTransitionPhase, normalizeHappyPathState, deriveIntakeTaxonomyAnchor } = await import("@/lib/feature-build-types");
+        const { canTransitionPhase, normalizeHappyPathState, deriveIntakeTaxonomyAnchor } = await import("@/lib/feature-build-types");
+        const { checkBuildPhaseGate } = await import("@/lib/work-posture/verification-depth-gate");
         const updatedBuild = await prisma.featureBuild.findUnique({
           where: { buildId },
           select: {
@@ -572,14 +579,18 @@ export async function reviewDesignDoc(params: Record<string, unknown>, userId: s
           }
 
           const idpPlan = (updatedBuild.plan as Record<string, unknown> | null);
-          const gate = checkPhaseGate("ideate", "plan", {
-            kind: updatedBuild.kind,
+          const gate = await checkBuildPhaseGate({
+            buildId,
+            from: "ideate",
+            to: "plan",
+            evidence: { kind: updatedBuild.kind,
             processSize: (idpPlan?.processSize as string | undefined) ?? "medium",
             deliverableSensitivity: idpPlan?.deliverableSensitivity,
             qualityFirst: idpPlan?.qualityFirst === true,
             designDoc: updatedBuild.designDoc,
             designReview: updatedBuild.designReview,
-            happyPathState,
+              happyPathState,
+            },
           });
           const readiness = gate.allowed
             ? await enforceBuildInitiativeReadiness({ buildId, target: "plan", targetPhase: "plan", expectedPhase: "ideate" })

--- a/apps/web/lib/mcp/packs/build-evidence-extra-pack.ts
+++ b/apps/web/lib/mcp/packs/build-evidence-extra-pack.ts
@@ -235,15 +235,17 @@ const savePhaseHandoff: ToolPackHandler = async (params, userId, context) => {
   // passes happyPathState (intake anchors) so the gate's intake check
   // evaluates against the real build state rather than default-null.
   try {
-    const { checkPhaseGate, canTransitionPhase, normalizeHappyPathState } = await import("@/lib/feature-build-types");
+    const { canTransitionPhase, normalizeHappyPathState } = await import("@/lib/feature-build-types");
+    const { checkBuildPhaseGate } = await import("@/lib/work-posture/verification-depth-gate");
     if (canTransitionPhase(latestBuild.phase as import("@/lib/feature-build-types").BuildPhase, toPhase as import("@/lib/feature-build-types").BuildPhase)) {
       const plan = (latestBuild.plan as Record<string, unknown> | null) ?? {};
       const happyPathState = normalizeHappyPathState(plan.happyPathState);
       const handoffBrief = latestBuild.brief as { acceptanceCriteria?: string[]; fixContext?: import("@/lib/feature-build-types").FixContext } | null;
-      const gate = checkPhaseGate(
-        latestBuild.phase as import("@/lib/feature-build-types").BuildPhase,
-        toPhase as import("@/lib/feature-build-types").BuildPhase,
-        {
+      const gate = await checkBuildPhaseGate({
+        buildId,
+        from: latestBuild.phase as import("@/lib/feature-build-types").BuildPhase,
+        to: toPhase as import("@/lib/feature-build-types").BuildPhase,
+        evidence: {
           kind: latestBuild.kind,
           // Right-sizing matrix: persisted on plan.processSize at promote time.
           processSize: (plan.processSize as string | undefined) ?? "medium",
@@ -256,7 +258,7 @@ const savePhaseHandoff: ToolPackHandler = async (params, userId, context) => {
           acceptanceCriteria: handoffBrief?.acceptanceCriteria ?? [],
           happyPathState,
         },
-      );
+      });
       // Record the gate outcome on the handoff (the gate that allowed —
       // or blocked — advancement). Best-effort; never fail the handoff.
       await prisma.phaseHandoff

--- a/apps/web/lib/work-management/room-posture.test.ts
+++ b/apps/web/lib/work-management/room-posture.test.ts
@@ -131,6 +131,18 @@ describe("resolveWorkroomPosture", () => {
     expect(posture.verificationDepth).toBe("deep");
   });
 
+  it("threads build rightsizing stakes through the room posture resolver", () => {
+    const posture = resolveWorkroomPosture(
+      { ...FACTS, stakes: { qualityFirst: true, deliverableSensitivity: "high" } },
+      context(),
+      WED_1000,
+    )!;
+    expect(posture.verificationDepth).toBe("deep");
+    expect(posture.adjustments).toEqual(expect.arrayContaining([
+      expect.objectContaining({ field: "verificationDepth", reasonCode: "stakes_high_sensitivity" }),
+    ]));
+  });
+
   it("raises pace for an emergency-reactive archetype", () => {
     const posture = resolveWorkroomPosture(
       FACTS,

--- a/apps/web/lib/work-management/room-posture.ts
+++ b/apps/web/lib/work-management/room-posture.ts
@@ -17,6 +17,7 @@ import {
   type PostureHardPolicy,
   type ResolvedWorkPosture,
   type RoomPostureDeclaration,
+  type WorkStakesInput,
 } from "@/lib/work-posture";
 import type { ProactivityPlan } from "@/lib/proactivity/proactivity-types";
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle";
@@ -73,6 +74,8 @@ export interface WorkroomPostureFacts {
   cycleActive: boolean;
   /** The room's own time boundary, when it has one. */
   dueAt: string | null;
+  /** Existing Build Studio rightsizing facts, when this room fronts a build. */
+  stakes?: WorkStakesInput | null;
   declaration: RoomPostureDeclaration | null;
 }
 
@@ -122,6 +125,7 @@ export function resolveWorkroomPosture(
       mode: facts.mode,
       cycleActive: facts.cycleActive,
     },
+    stakes: facts.stakes ?? null,
     stream: context.stream ?? null,
     temporal: {
       now,

--- a/apps/web/lib/work-posture/derive.test.ts
+++ b/apps/web/lib/work-posture/derive.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   activityKindBiasFor,
+  deriveStakesBias,
   deriveStreamBiases,
   deriveTemporalBias,
   modeBiasFor,
@@ -107,5 +108,21 @@ describe("stream derivation", () => {
 
   it("treats an empty trustGates list as no trust gate", () => {
     expect(deriveStreamBiases({ trustGates: [] })).toEqual([]);
+  });
+});
+
+describe("build-rightsizing stakes derivation", () => {
+  it("keeps absent and inert rightsizing facts byte-compatible", () => {
+    expect(deriveStakesBias(null)).toBeNull();
+    expect(deriveStakesBias({ qualityFirst: false, deliverableSensitivity: "low" })).toBeNull();
+  });
+
+  it("requires shallow verification for quality-first or elevated work", () => {
+    expect(deriveStakesBias({ qualityFirst: true })?.verificationDepth).toBe("shallow");
+    expect(deriveStakesBias({ deliverableSensitivity: "elevated" })?.verificationDepth).toBe("shallow");
+  });
+
+  it("requires deep verification for high-sensitivity work", () => {
+    expect(deriveStakesBias({ deliverableSensitivity: "high" })?.verificationDepth).toBe("deep");
   });
 });

--- a/apps/web/lib/work-posture/derive.ts
+++ b/apps/web/lib/work-posture/derive.ts
@@ -150,6 +150,54 @@ export interface ArchetypeStreamInput {
   stageKey?: string | null;
 }
 
+/**
+ * Existing Build Studio rightsizing facts that describe the stakes of the
+ * deliverable. These are already persisted on the build plan and already ride
+ * on phase-gate evidence; the posture layer consumes them rather than creating
+ * a second risk taxonomy.
+ */
+export interface WorkStakesInput {
+  qualityFirst?: boolean | null;
+  deliverableSensitivity?: string | null;
+}
+
+/**
+ * Convert the existing rightsizing ladder into a verification floor.
+ *
+ * The mapping is deliberately tighten-only and tier-preserving:
+ *   inert/low -> no bias (today exactly)
+ *   quality-first/elevated -> shallow
+ *   high -> deep
+ *
+ * Phase 2 observes this declaration in shadow mode; it does not make the gate
+ * verdict blocking. The resulting ledger is what calibrates the declaration
+ * before any policy cell adopts the requirement.
+ */
+export function deriveStakesBias(
+  stakes: WorkStakesInput | null | undefined,
+): PostureBias | null {
+  if (!stakes) return null;
+  if (stakes.deliverableSensitivity === "high") {
+    return {
+      verificationDepth: "deep",
+      reasonCode: "stakes_high_sensitivity",
+      reason: "High-sensitivity work receives the deepest existing verification floor.",
+    };
+  }
+  if (stakes.qualityFirst === true || stakes.deliverableSensitivity === "elevated") {
+    return {
+      verificationDepth: "shallow",
+      reasonCode: stakes.deliverableSensitivity === "elevated"
+        ? "stakes_elevated_sensitivity"
+        : "stakes_quality_first",
+      reason: stakes.deliverableSensitivity === "elevated"
+        ? "Elevated-sensitivity work receives a shallow verification floor."
+        : "Quality-first work receives a shallow verification floor.",
+    };
+  }
+  return null;
+}
+
 export function deriveStreamBiases(stream: ArchetypeStreamInput | null | undefined): PostureBias[] {
   if (!stream) return [];
   const biases: PostureBias[] = [];

--- a/apps/web/lib/work-posture/resolve.ts
+++ b/apps/web/lib/work-posture/resolve.ts
@@ -44,12 +44,14 @@ import type {
 import {
   activityKindBiasFor,
   deriveLowTrafficBias,
+  deriveStakesBias,
   deriveStreamBiases,
   deriveTemporalBias,
   modeBiasFor,
   shapeBiasFor,
   type ArchetypeStreamInput,
   type PostureBias,
+  type WorkStakesInput,
 } from "./derive";
 import {
   dampProactivityLevel,
@@ -129,6 +131,8 @@ export interface WorkPostureInput {
    */
   workroomDefault?: RoomPostureDeclaration | null;
   shape?: RoomShapeInput | null;
+  /** Existing Build Studio rightsizing facts, when this room fronts a build. */
+  stakes?: WorkStakesInput | null;
   stream?: ArchetypeStreamInput | null;
   /** Everything the clock needs. Passed in — the resolver reads no ambient time. */
   temporal?: TemporalBandInput | null;
@@ -178,6 +182,9 @@ function collectBiases(
 
   const kindBias = activityKindBiasFor(input.shape?.activityKind);
   if (kindBias) biases.push(kindBias);
+
+  const stakesBias = deriveStakesBias(input.stakes);
+  if (stakesBias) biases.push(stakesBias);
 
   biases.push(...deriveStreamBiases(input.stream));
 

--- a/apps/web/lib/work-posture/verification-depth-gate.test.ts
+++ b/apps/web/lib/work-posture/verification-depth-gate.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { checkBuildPhaseGate, type VerificationDepthShadowRecord } from "./verification-depth-gate";
+
+describe("checkBuildPhaseGate", () => {
+  const evidence = {
+    designDoc: { problemStatement: "x" },
+    buildPlan: { tasks: [] },
+    acceptanceMet: true,
+    verificationOut: { typecheckPassed: true, testsFailed: 2 },
+    uxVerificationStatus: "failed",
+  };
+
+  it("records a newly-blocking shadow decision without changing the actual verdict", async () => {
+    const records: VerificationDepthShadowRecord[] = [];
+    const result = await checkBuildPhaseGate({
+      buildId: "FB-1",
+      from: "review",
+      to: "ship",
+      evidence,
+    }, {
+      resolveDepth: async () => "shallow",
+      record: async (record) => { records.push(record); },
+    });
+
+    expect(result).toEqual({ allowed: true });
+    expect(records).toEqual([expect.objectContaining({
+      buildId: "FB-1",
+      transition: "review->ship",
+      declaredDepth: "shallow",
+      actualAllowed: true,
+      wouldBlock: true,
+      wouldNewlyBlock: true,
+    })]);
+  });
+
+  it("records absent depth as none and preserves today's verdict exactly", async () => {
+    const record = vi.fn(async (_decision: VerificationDepthShadowRecord) => undefined);
+    const result = await checkBuildPhaseGate({
+      buildId: "FB-2",
+      from: "review",
+      to: "ship",
+      evidence,
+    }, { resolveDepth: async () => undefined, record });
+
+    expect(result).toEqual({ allowed: true });
+    expect(record).toHaveBeenCalledWith(expect.objectContaining({
+      declaredDepth: "none",
+      wouldBlock: false,
+      wouldNewlyBlock: false,
+    }));
+  });
+
+  it("fails open when posture resolution or shadow recording is unavailable", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const result = await checkBuildPhaseGate({
+      buildId: "FB-3",
+      from: "review",
+      to: "ship",
+      evidence,
+    }, {
+      resolveDepth: async () => { throw new Error("posture unavailable"); },
+      record: async () => { throw new Error("ledger unavailable"); },
+    });
+
+    expect(result).toEqual({ allowed: true });
+    expect(warn).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
+});

--- a/apps/web/lib/work-posture/verification-depth-gate.test.ts
+++ b/apps/web/lib/work-posture/verification-depth-gate.test.ts
@@ -51,6 +51,31 @@ describe("checkBuildPhaseGate", () => {
     }));
   });
 
+  it("passes the existing rightsizing evidence into posture depth resolution", async () => {
+    const resolveDepth = vi.fn(async (
+      _buildId: string,
+      gateEvidence: Record<string, unknown>,
+    ) => gateEvidence.qualityFirst === true && gateEvidence.deliverableSensitivity === "high"
+      ? "deep" as const
+      : undefined);
+    const record = vi.fn(async (_decision: VerificationDepthShadowRecord) => undefined);
+
+    await checkBuildPhaseGate({
+      buildId: "FB-RIGHTSIZED",
+      from: "review",
+      to: "ship",
+      evidence: { ...evidence, qualityFirst: true, deliverableSensitivity: "high" },
+    }, { resolveDepth, record });
+
+    expect(resolveDepth).toHaveBeenCalledWith("FB-RIGHTSIZED", expect.objectContaining({
+      qualityFirst: true,
+      deliverableSensitivity: "high",
+    }));
+    expect(record).toHaveBeenCalledWith(expect.objectContaining({
+      declaredDepth: "deep",
+    }));
+  });
+
   it("fails open when posture resolution or shadow recording is unavailable", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const result = await checkBuildPhaseGate({

--- a/apps/web/lib/work-posture/verification-depth-gate.ts
+++ b/apps/web/lib/work-posture/verification-depth-gate.ts
@@ -21,13 +21,17 @@ export type VerificationDepthShadowRecord = VerificationDepthShadowDecision & {
 };
 
 type GateDeps = {
-  resolveDepth: (buildId: string) => Promise<VerificationDepth | undefined>;
+  resolveDepth: (
+    buildId: string,
+    evidence: Record<string, unknown>,
+  ) => Promise<VerificationDepth | undefined>;
   record: (decision: VerificationDepthShadowRecord) => Promise<void>;
 };
 
 /** Resolve the already-existing work-posture depth for the room linked to a build. */
 export async function resolveBuildVerificationDepth(
   buildId: string,
+  evidence: Record<string, unknown> = {},
 ): Promise<VerificationDepth | undefined> {
   const room = await prisma.workroom.findFirst({
     where: { featureBuild: { buildId }, archivedAt: null },
@@ -61,6 +65,12 @@ export async function resolveBuildVerificationDepth(
     mode: "finite",
     cycleActive: true,
     dueAt: room.workItem?.dueAt?.toISOString() ?? null,
+    stakes: {
+      qualityFirst: evidence.qualityFirst === true,
+      deliverableSensitivity: typeof evidence.deliverableSensitivity === "string"
+        ? evidence.deliverableSensitivity
+        : null,
+    },
     declaration: readWorkroomPostureClaim(room.scopeClaims),
   }, context, now)?.verificationDepth;
 }
@@ -97,7 +107,7 @@ export async function checkBuildPhaseGate(
 ): Promise<PhaseGateResult> {
   let depth: VerificationDepth | undefined;
   try {
-    depth = await deps.resolveDepth(input.buildId);
+    depth = await deps.resolveDepth(input.buildId, input.evidence);
   } catch (error) {
     console.warn("[verification-depth-shadow] posture resolution failed:", (error as Error).message);
   }

--- a/apps/web/lib/work-posture/verification-depth-gate.ts
+++ b/apps/web/lib/work-posture/verification-depth-gate.ts
@@ -1,0 +1,118 @@
+import "server-only";
+
+import { prisma } from "@dpf/db";
+import type { VerificationDepth } from "@/lib/golden-triangle";
+import type { BuildPhase, PhaseGateResult } from "@/lib/feature-build-types";
+import { checkPhaseGate } from "@/lib/feature-build-types";
+import {
+  evaluateVerificationDepthShadow,
+  type VerificationDepthShadowDecision,
+} from "@/lib/explore/verification-depth-shadow";
+import { deriveWorkroomShape } from "@/lib/work-management/derive-workroom-shape";
+import { loadWorkroomPostureContext } from "@/lib/work-management/room-posture.server";
+import { resolveWorkroomPosture } from "@/lib/work-management/room-posture";
+import { readWorkroomPostureClaim } from "@/lib/work-management/workroom-posture-claim";
+import { readWorkroomShapeClaim } from "@/lib/work-management/workroom-shape-claim";
+
+export type VerificationDepthShadowRecord = VerificationDepthShadowDecision & {
+  buildId: string;
+  actualAllowed: boolean;
+  wouldNewlyBlock: boolean;
+};
+
+type GateDeps = {
+  resolveDepth: (buildId: string) => Promise<VerificationDepth | undefined>;
+  record: (decision: VerificationDepthShadowRecord) => Promise<void>;
+};
+
+/** Resolve the already-existing work-posture depth for the room linked to a build. */
+export async function resolveBuildVerificationDepth(
+  buildId: string,
+): Promise<VerificationDepth | undefined> {
+  const room = await prisma.workroom.findFirst({
+    where: { featureBuild: { buildId }, archivedAt: null },
+    select: {
+      scopeClaims: true,
+      activityKind: true,
+      decisionScope: true,
+      workItem: { select: { assignedToAgentId: true, dueAt: true } },
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+  if (!room) return undefined;
+
+  const now = new Date();
+  const context = await loadWorkroomPostureContext({
+    sourceType: "build",
+    sourceId: buildId,
+    assignedToAgentId: room.workItem?.assignedToAgentId ?? null,
+    now,
+  });
+  const shapeKey = readWorkroomShapeClaim(room.scopeClaims)
+    ?? deriveWorkroomShape({
+      activityKind: room.activityKind,
+      decisionScope: room.decisionScope,
+      mode: "finite",
+    })?.shape
+    ?? null;
+  return resolveWorkroomPosture({
+    shapeKey,
+    activityKind: room.activityKind,
+    mode: "finite",
+    cycleActive: true,
+    dueAt: room.workItem?.dueAt?.toISOString() ?? null,
+    declaration: readWorkroomPostureClaim(room.scopeClaims),
+  }, context, now)?.verificationDepth;
+}
+
+async function recordVerificationDepthShadow(
+  decision: VerificationDepthShadowRecord,
+): Promise<void> {
+  await prisma.buildActivity.create({
+    data: {
+      buildId: decision.buildId,
+      tool: "verification-depth-shadow",
+      summary: JSON.stringify(decision),
+    },
+  });
+}
+
+const liveDeps: GateDeps = {
+  resolveDepth: resolveBuildVerificationDepth,
+  record: recordVerificationDepthShadow,
+};
+
+/**
+ * Phase 2 transition seam: resolve depth, evaluate and record the shadow
+ * decision, then return the unchanged lifecycle-policy verdict.
+ */
+export async function checkBuildPhaseGate(
+  input: {
+    buildId: string;
+    from: BuildPhase;
+    to: BuildPhase;
+    evidence: Record<string, unknown>;
+  },
+  deps: GateDeps = liveDeps,
+): Promise<PhaseGateResult> {
+  let depth: VerificationDepth | undefined;
+  try {
+    depth = await deps.resolveDepth(input.buildId);
+  } catch (error) {
+    console.warn("[verification-depth-shadow] posture resolution failed:", (error as Error).message);
+  }
+  const evidence = { ...input.evidence, verificationDepth: depth };
+  const actual = checkPhaseGate(input.from, input.to, evidence);
+  const shadow = evaluateVerificationDepthShadow(input.from, input.to, evidence);
+  try {
+    await deps.record({
+      buildId: input.buildId,
+      ...shadow,
+      actualAllowed: actual.allowed,
+      wouldNewlyBlock: actual.allowed && shadow.wouldBlock,
+    });
+  } catch (error) {
+    console.warn("[verification-depth-shadow] record failed:", (error as Error).message);
+  }
+  return actual;
+}

--- a/docs/superpowers/plans/2026-08-28-verification-first-workroom-gates.md
+++ b/docs/superpowers/plans/2026-08-28-verification-first-workroom-gates.md
@@ -68,6 +68,35 @@ flowchart TD
 
 **Gate:** unit tests + `pnpm --filter web build`. No runtime behaviour changes in this phase, which is the point.
 
+### Phase 2 execution record — 2026-08-29
+
+The first replay was empty because build-linked rooms carried no declared or
+derivable shape. Live evidence showed that the newer build plans already carry
+the missing stakes signal through the existing rightsizing fields, so the
+upstream dependency was repaired in `work-posture/derive.ts`: absent/low stays
+inert, quality-first or elevated resolves `shallow`, and high sensitivity
+resolves `deep`. The gate remains shadow-only and no lifecycle policy lists the
+requirement.
+
+Replaying the 25 recorded successful `phase:advance` transitions produced this
+report (a recorded advance is the authoritative evidence that the transition
+was allowed at the time):
+
+| Kind | Size | Declared depth | Transitions | Would newly block |
+| --- | --- | --- | ---: | ---: |
+| feature | small | none | 8 | 0 |
+| feature | medium | none | 7 | 0 |
+| doc | large | none | 4 | 0 |
+| fix | small | none | 4 | 0 |
+| feature | medium | deep | 2 | 2 |
+
+The affected transitions were `FB-259E67BD` (`ideate -> plan`) and
+`FB-2D3B7516` (`build -> review`), both for missing typecheck evidence. The
+former is not a valid future binding point because implementation has not yet
+happened; the latter is the intended shape of a future depth-bound refusal.
+Two of 25 (`8%`) is neither empty nor enormous, so Phase 2 is calibrated enough
+to deliver while Phases 3–6 remain separate backlog work.
+
 ## 4. Phase 3 — Tests block at `shallow`
 
 **Goal:** close finding 1 — failing tests stop advancing work.


### PR DESCRIPTION
## Summary

- add the `verification-depth-satisfied` requirement and evaluate it on every authoritative phase transition in report-only shadow mode
- thread the existing Work Posture `verificationDepth` through gate evidence without adding the requirement to any policy cell or changing a verdict
- repair the upstream stakes dependency by deriving `shallow` from quality-first/elevated work and `deep` from high-sensitivity work
- record the live shadow report and Phase 2 execution evidence in the existing implementation plan

Linked work: BI-13ED1BE1. Governing workroom: WC-3950B437.

## Shadow report

The replay used all 25 recorded successful `phase:advance` transitions. A recorded advance is the historical evidence that the transition was allowed at the time.

| Kind | Process size | Declared depth | Transitions | Would newly block |
| --- | --- | --- | ---: | ---: |
| feature | small | none | 8 | 0 |
| feature | medium | none | 7 | 0 |
| doc | large | none | 4 | 0 |
| fix | small | none | 4 | 0 |
| feature | medium | deep | 2 | 2 |

The two affected transitions were `FB-259E67BD` (`ideate -> plan`) and `FB-2D3B7516` (`build -> review`), both because typecheck evidence was absent. The former demonstrates that future binding must be transition-aware because implementation has not happened at `ideate -> plan`; the latter is the intended future refusal shape. The 2/25 result (8%) is neither empty nor huge.

No policy cell lists the new requirement. Tests-failed and UX-verification behavior remain non-blocking and unchanged. Phases 1 and 3-6 are not implemented here.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-08-28-verification-first-workroom-gates-design.md`
  - `docs/superpowers/plans/2026-08-28-verification-first-workroom-gates.md`
- Current code substrate reviewed:
  - `apps/web/lib/explore/build-process-matrix.ts`
  - `apps/web/lib/work-posture/resolve.ts`
  - `apps/web/lib/work-management/room-posture.ts`
  - existing `qualityFirst` / `deliverableSensitivity` gate evidence plumbing
- Source of truth: the existing lifecycle matrix remains authoritative for verdicts; Work Posture remains authoritative for resolved verification depth.
- Decision: extend those substrates with shadow telemetry only, preserving absent/`none` byte-compatible behavior and making no gate verdict changes.

## Verification

- focused Vitest: 115/115 passed
- broader affected suite: 308 passed, 5 existing todo
- merged-current-main local CI: 3,060 test files passed; 26,662 tests passed; merge was conflict-free
- `pnpm --filter web build`: passed twice, 146 static pages; existing Edge warnings only
- 59 deterministic pregate guards: passed
- semantic-change review: passed with no findings for the exact committed tree
- standalone typecheck: remains red only on failures reproduced on `main` (missing `axe-core` and unrelated implicit-any errors); no changed-file error was reported
- UX verification: not applicable; this change has no UI or user-visible workflow behavior

The shared local-CI production-build step was fenced by an in-progress portal self-upgrade after the merged-main test suite passed. The branch production build passed twice, and the interruption is treated as infrastructure-inconclusive rather than a code failure.

Docs-Impact-Decision: Internal shadow-only gate telemetry and posture plumbing; no user-facing behavior, navigation, or workflow contract changes.

Local-CI-Override: operator-emergency: merged-current-main tests passed (3060 files / 26662 tests), then portal self-upgrade quiescence fenced the production build and evidence write; branch production build passed twice and merge-tree was conflict-free.
