### PR TITLE
fix(self-upgrade): preserve admitted targets through registry outages

### DIFF
--- a/apps/web/lib/queue/functions/self-upgrade-handoff.test-support.ts
+++ b/apps/web/lib/queue/functions/self-upgrade-handoff.test-support.ts
@@ -45,6 +45,77 @@ export function configureReleaseUpgradeTest(input: {
   });
 }
 
+export function registerReleaseWorkerTargetRecoveryTests(input: {
+  mocks: any;
+  runSelfUpgrade: (params: any) => Promise<any>;
+  installState: string;
+}) {
+  const sourceSha = "f".repeat(40);
+  const currentConfigDigest = `sha256:${"a".repeat(64)}`;
+  const targetConfigDigest = `sha256:${"c".repeat(64)}`;
+  const candidate = {
+    tag: "v2.0.0", sourceSha, channelDigest: `sha256:${"b".repeat(64)}`,
+    platformManifestDigest: `sha256:${"c".repeat(64)}`, configDigest: targetConfigDigest,
+    platformOs: "linux", platformArchitecture: "amd64",
+  };
+  const configure = () => configureReleaseUpgradeTest({
+    mocks: input.mocks, installState: input.installState, sourceSha,
+    currentConfigDigest, targetConfigDigest,
+  });
+
+  it("uses verified target evidence when the registry is unavailable at worker start", async () => {
+    configure();
+    input.mocks.readRegistryReleaseCandidate.mockResolvedValue({ ok: false, reason: "registry-unavailable" });
+    input.mocks.loadVerifiedReleaseTargetEvidence.mockResolvedValue(candidate);
+    input.mocks.getRun.mockResolvedValue({ targetSha: sourceSha, targetTag: candidate.tag });
+    input.mocks.updateRunPlan.mockResolvedValue({ runId: "SUR-VERIFIED" });
+    try {
+      await expect(input.runSelfUpgrade({ triggeredBy: "ops", runId: "SUR-VERIFIED" }))
+        .resolves.toMatchObject({ status: "succeeded", runId: "SUR-VERIFIED" });
+      expect(input.mocks.skipRun).not.toHaveBeenCalled();
+      expect(input.mocks.deferAdmittedRunForRedispatch).not.toHaveBeenCalled();
+    } finally { vi.unstubAllEnvs(); }
+  });
+
+  it("returns an admitted run to reconciliation when no verified target is available", async () => {
+    configure();
+    input.mocks.readRegistryReleaseCandidate.mockResolvedValue({ ok: false, reason: "registry-unavailable" });
+    input.mocks.loadVerifiedReleaseTargetEvidence.mockResolvedValue(null);
+    input.mocks.deferAdmittedRunForRedispatch.mockResolvedValue(true);
+    try {
+      await expect(input.runSelfUpgrade({ triggeredBy: "ops", runId: "SUR-RECONCILE" }))
+        .resolves.toMatchObject({ reconciling: true, reason: "registry-unavailable", runId: "SUR-RECONCILE" });
+      expect(input.mocks.deferAdmittedRunForRedispatch).toHaveBeenCalledWith("SUR-RECONCILE", "release-target-registry-unavailable");
+      expect(input.mocks.skipRun).not.toHaveBeenCalled();
+      expect(input.mocks.startQuiescence).not.toHaveBeenCalled();
+    } finally { vi.unstubAllEnvs(); }
+  });
+
+  it("fails closed when the worker target differs from the durable admission", async () => {
+    configure();
+    input.mocks.getRun.mockResolvedValue({ targetSha: "e".repeat(40), targetTag: candidate.tag });
+    try {
+      await expect(input.runSelfUpgrade({ triggeredBy: "ops", runId: "SUR-DRIFT" }))
+        .resolves.toMatchObject({ ok: false, status: "failed", reason: "admission-target-drift" });
+      expect(input.mocks.failRun).toHaveBeenCalledWith("SUR-DRIFT", expect.stringContaining("admission-target-drift"));
+      expect(input.mocks.startQuiescence).not.toHaveBeenCalled();
+    } finally { vi.unstubAllEnvs(); }
+  });
+
+  it("terminalizes registry integrity failures instead of using cached evidence", async () => {
+    configure();
+    input.mocks.readRegistryReleaseCandidate.mockResolvedValue({ ok: false, reason: "config-digest-mismatch" });
+    input.mocks.loadVerifiedReleaseTargetEvidence.mockResolvedValue(candidate);
+    try {
+      await expect(input.runSelfUpgrade({ triggeredBy: "ops", runId: "SUR-INTEGRITY" }))
+        .resolves.toMatchObject({ ok: false, status: "failed", reason: "release-target-integrity-failed", releaseStatus: "config-digest-mismatch" });
+      expect(input.mocks.loadVerifiedReleaseTargetEvidence).not.toHaveBeenCalled();
+      expect(input.mocks.failRun).toHaveBeenCalledWith("SUR-INTEGRITY", "release-target-integrity-failed: config-digest-mismatch");
+      expect(input.mocks.startQuiescence).not.toHaveBeenCalled();
+    } finally { vi.unstubAllEnvs(); }
+  });
+}
+
 export function registerInstallStateHandoffTests({ mocks, runSelfUpgrade, installState, installStateHash }: TestContext) {
   it("resolves and validates readiness before quiescence, then promotes the same digest", async () => {
     const order: string[] = [];
@@ -52,7 +123,7 @@ export function registerInstallStateHandoffTests({ mocks, runSelfUpgrade, instal
     mocks.resolvePromoterArtifact.mockImplementation(async () => { order.push("resolve"); return { digest: `sha256:${"d".repeat(64)}`, sourceSha: "abc1234deadbeef", contractSchema: 1, contractDigest: `sha256:${"c".repeat(64)}`, callerProtocol: { min: 1, max: 1 } }; });
     mocks.runPromoterReadiness.mockImplementation(async () => { order.push("readiness"); return { exitCode: 0, stdout: JSON.stringify({ failures: [], sourceHash: installStateHash, projectionHash: "b".repeat(64), fromSchemaVersion: 1, toSchemaVersion: 2 }), stderr: "" }; });
     mocks.recordPromoterReadiness.mockImplementation(async (_runId: string, report: any) => { order.push("evidence"); persistedHandoff = report.migrationHandoff; return {}; });
-    mocks.startQuiescence.mockImplementation(async () => { order.push("quiescence"); return { runId: "QR-1", awaitReady: async () => ({ ok: true, outcome: "ready-to-swap", runId: "QR-1", finalSnapshot: null }) }; });
+    mocks.startQuiescence.mockImplementation(async () => { order.push("quiescence"); return { runId: "QR-1", awaitReady: async () => ({ ...ok(), outcome: "ready-to-swap", runId: "QR-1", finalSnapshot: null }) }; });
     mocks.runPromoter.mockImplementation(async (params: any) => { order.push("promotion"); expect(params.promoterImage).toBe(`sha256:${"d".repeat(64)}`); expect(params.installStateMigrationHandoff).toBe(persistedHandoff); return { exitCode: 0, stdout: "", stderr: "" }; });
     await runSelfUpgrade({ triggeredBy: "ops" });
     expect(order).toEqual(["resolve", "readiness", "evidence", "quiescence", "promotion"]);

--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createHash } from "node:crypto";
-import { configureReleaseUpgradeTest, registerCoreSelfUpgradeSuccessTest, registerInstallStateHandoffTests, registerSelfUpgradeFunctionTests } from "./self-upgrade-handoff.test-support";
+import { configureReleaseUpgradeTest, registerCoreSelfUpgradeSuccessTest, registerInstallStateHandoffTests, registerReleaseWorkerTargetRecoveryTests, registerSelfUpgradeFunctionTests } from "./self-upgrade-handoff.test-support";
 
 const TEST_INSTALL_STATE = JSON.stringify({ platform: "linux", arch: "amd64" });
 const TEST_INSTALL_STATE_HASH = createHash("sha256").update(TEST_INSTALL_STATE).digest("hex");
@@ -23,11 +23,13 @@ const mocks = vi.hoisted(() => ({
   completeRun: vi.fn(),
   failRun: vi.fn(),
   skipRun: vi.fn(),
+  deferAdmittedRunForRedispatch: vi.fn(),
   updateRunPlan: vi.fn(),
   recordRunRecoveryPoint: vi.fn(),
   recordPromoterReadiness: vi.fn(),
   getLatestRun: vi.fn(),
   getLatestSucceededRun: vi.fn(),
+  getRun: vi.fn(),
   runPromoter: vi.fn(),
   isPromoterAvailable: vi.fn().mockResolvedValue(true),
   ensurePromoterImage: vi
@@ -53,37 +55,31 @@ const mocks = vi.hoisted(() => ({
   readFile: vi.fn(async (path: string) => path.endsWith("install-state.json") ? '{"platform":"linux","arch":"amd64"}' : "s".repeat(32)),
   resolveSelfUpgradeHostIdentity: vi.fn(() => ({ platform: "linux", arch: "amd64", provenance: "explicit" })),
   readRegistryReleaseCandidate: vi.fn(),
+  loadVerifiedReleaseTargetEvidence: vi.fn(),
+  recordVerifiedReleaseTargetEvidence: vi.fn().mockResolvedValue(true),
 }));
-
 vi.mock("@/lib/self-upgrade/config", () => ({
   getSelfUpgradeConfig: mocks.getSelfUpgradeConfig,
   resolveSelfUpgradeHostIdentity: mocks.resolveSelfUpgradeHostIdentity,
 }));
-
 vi.mock("@/lib/self-upgrade/support", () => ({
   readSelfUpgradeSupport: mocks.readSelfUpgradeSupport,
 }));
-
 vi.mock("node:fs/promises", () => ({ readFile: mocks.readFile }));
-
 vi.mock("@/lib/self-upgrade/registry-release", () => ({ readRegistryReleaseCandidate: mocks.readRegistryReleaseCandidate }));
-
+vi.mock("@/lib/release-health/state", () => ({ loadVerifiedReleaseTargetEvidence: mocks.loadVerifiedReleaseTargetEvidence, recordVerifiedReleaseTargetEvidence: mocks.recordVerifiedReleaseTargetEvidence }));
 vi.mock("@/lib/self-upgrade/window", () => ({
   isUpgradeWindowOpen: mocks.isUpgradeWindowOpen,
 }));
-
 vi.mock("@/lib/operating-hours-read", () => ({
   resolveOperatingScheduleForSystem: mocks.resolveOperatingScheduleForSystem,
 }));
-
 vi.mock("@/lib/self-upgrade/auto-window", () => ({
   resolveAutoUpgradeWindow: mocks.resolveAutoUpgradeWindow,
 }));
-
 vi.mock("@/lib/self-upgrade/blackout", () => ({
   getActiveSelfUpgradeBlackout: mocks.getActiveSelfUpgradeBlackout,
 }));
-
 vi.mock("@/lib/self-upgrade/last-check", () => ({
   getLastCheckedAt: mocks.getLastCheckedAt,
   recordCheckedAt: mocks.recordCheckedAt,
@@ -126,11 +122,13 @@ vi.mock("@/lib/self-upgrade/run-store", () => ({
   completeRun: mocks.completeRun,
   failRun: mocks.failRun,
   skipRun: mocks.skipRun,
+  deferAdmittedRunForRedispatch: mocks.deferAdmittedRunForRedispatch,
   updateRunPlan: mocks.updateRunPlan,
   recordRunRecoveryPoint: mocks.recordRunRecoveryPoint,
   recordPromoterReadiness: mocks.recordPromoterReadiness,
   getLatestRun: mocks.getLatestRun,
   getLatestSucceededRun: mocks.getLatestSucceededRun,
+  getRun: mocks.getRun,
 }));
 vi.mock("@/lib/self-upgrade/delivery-admission", () => ({ rejectDuplicateSelfUpgradeDelivery: vi.fn().mockResolvedValue(null) }));
 vi.mock("@/lib/self-upgrade/promoter", async (importOriginal) => ({
@@ -301,6 +299,7 @@ describe("success path", () => {
   });
 
   registerCoreSelfUpgradeSuccessTest({ mocks, runSelfUpgrade });
+  registerReleaseWorkerTargetRecoveryTests({ mocks, runSelfUpgrade, installState: TEST_INSTALL_STATE });
 
   it("classifies a source-free consumer at the verified release as up to date without Git", async () => {
     const sourceSha = "a".repeat(40);

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -8,16 +8,9 @@ import { getActiveSelfUpgradeBlackout } from "@/lib/self-upgrade/blackout";
 import { resolveOperatingScheduleForSystem } from "@/lib/operating-hours-read";
 import { getLastCheckedAt, recordCheckedAt, isCheckIntervalElapsed } from "@/lib/self-upgrade/last-check";
 import { buildFetchCommand, buildRemoteHeadCommand } from "@/lib/self-upgrade/version";
-import {
-  loadReleaseInstallContext,
-  resolveReleaseUpgradeCandidate,
-  resolveUpgradeStrategy,
-  type ReleaseTargetResult,
-} from "@/lib/self-upgrade/release-target";
-import {
-  countPendingUpstreamCommits,
-  evaluateReleaseBatch,
-} from "@/lib/self-upgrade/release-batch";
+import { loadReleaseInstallContext, resolveUpgradeStrategy, type ReleaseTargetResult } from "@/lib/self-upgrade/release-target";
+import { resolveWorkerReleaseTarget } from "@/lib/self-upgrade/worker-release-target";
+import { countPendingUpstreamCommits, evaluateReleaseBatch } from "@/lib/self-upgrade/release-batch";
 import { prepareUpgradeSource, defaultGitRunner } from "@/lib/self-upgrade/prepare-source";
 // Pure constant only: never statically import the spawn-heavy promoter runtime
 // that is what the dynamic loadPromoterRuntime() below is for.
@@ -31,10 +24,7 @@ import {
 import { evaluateHostMemoryGuard } from "@/lib/self-upgrade/host-memory-preflight";
 import { getDeployedSha, isFeatureBuildDeployed } from "@/lib/self-upgrade/completion";
 import { readCurrentContainerConfigDigest } from "@/lib/self-upgrade/runtime-image-identity";
-import {
-  classifyBuildFailure,
-  formatClassifiedExcerpt,
-} from "@/lib/self-upgrade/build-failure-classifier";
+import { classifyBuildFailure, formatClassifiedExcerpt } from "@/lib/self-upgrade/build-failure-classifier";
 import {
   createRun,
   startRun,
@@ -332,13 +322,20 @@ export async function runSelfUpgrade(
   const deployedSha = await getDeployedSha();
   if (upgradeStrategy === "release" && releaseInstall) {
     const currentConfigDigest = await readCurrentContainerConfigDigest();
-    const target = await resolveReleaseUpgradeCandidate({
+    const resolution = await resolveWorkerReleaseTarget({
+      runId: params.runId,
       context: releaseInstall,
       currentConfigDigest,
     });
-    if (target.kind === "no-published-target") {
-      return await skipAttempt("no-published-target", `no-published-target: ${target.reason}`, { releaseStatus: target.reason });
+    if (resolution.kind === "handled") return resolution.response;
+    if (resolution.kind === "unavailable") {
+      return await skipAttempt(
+        "no-published-target",
+        `no-published-target: ${resolution.target.reason}`,
+        { releaseStatus: resolution.target.reason },
+      );
     }
+    const target = resolution.target;
     if (target.kind === "up-to-date" && !params.force && !params.dryRun) {
       return await skipAttempt("up-to-date", `up-to-date: ${target.tag}`, {
         releaseTag: target.tag,

--- a/apps/web/lib/self-upgrade/run-store.test.ts
+++ b/apps/web/lib/self-upgrade/run-store.test.ts
@@ -44,6 +44,7 @@ import {
   recordRunRecoveryPoint,
   sanitizePromoterReadinessReport,
   claimAdmittedRunForWorker,
+  deferAdmittedRunForRedispatch,
   selfUpgradeAdmissionRepository,
 } from "./run-store";
 
@@ -160,6 +161,31 @@ describe("admitted worker ownership", () => {
   it("refuses duplicate delivery after the claim is consumed", async () => {
     mocks.updateMany.mockResolvedValue({ count: 0 });
     await expect(claimAdmittedRunForWorker("SUR-ONE")).resolves.toBe("duplicate");
+  });
+
+  it("returns a claimed worker to durable reconciliation before mutation begins", async () => {
+    await expect(
+      deferAdmittedRunForRedispatch("SUR-ONE", "release-target-registry-unavailable"),
+    ).resolves.toBe(true);
+    expect(mocks.updateMany).toHaveBeenCalledWith({
+      where: {
+        runId: "SUR-ONE",
+        status: "running",
+        completedAt: null,
+        dispatchStatus: { in: ["dispatching", "dispatched"] },
+      },
+      data: {
+        status: "pending",
+        startedAt: null,
+        dispatchStatus: "indeterminate",
+        dispatchError: "release-target-registry-unavailable",
+        dispatchLeaseToken: null,
+        dispatchLeaseExpiresAt: null,
+      },
+    });
+    expect(mocks.broadcastSystem).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "SUR-ONE", status: "pending" }),
+    );
   });
 
   it("preserves the legacy path for historical queued runs", async () => {

--- a/apps/web/lib/self-upgrade/run-store.ts
+++ b/apps/web/lib/self-upgrade/run-store.ts
@@ -304,6 +304,34 @@ export async function claimAdmittedRunForWorker(
   return "claimed";
 }
 
+/**
+ * A worker may yield an admitted run only before quiescence or any physical
+ * mutation begins. The admission reconciler can then dispatch the same run id
+ * again without creating a second upgrade identity.
+ */
+export async function deferAdmittedRunForRedispatch(runId: string, reason: string) {
+  const updated = await prisma.selfUpgradeRun.updateMany({
+    where: {
+      runId,
+      status: "running",
+      completedAt: null,
+      dispatchStatus: { in: ["dispatching", "dispatched"] },
+    },
+    data: {
+      status: "pending",
+      startedAt: null,
+      dispatchStatus: "indeterminate",
+      dispatchError: reason,
+      dispatchLeaseToken: null,
+      dispatchLeaseExpiresAt: null,
+    },
+  });
+  if (updated.count !== 1) return false;
+  notifyRunState(runId, "pending");
+  await safeSyncSelfUpgradeChangeRecord(runId);
+  return true;
+}
+
 export async function updateRunPlan(
   runId: string,
   params: {

--- a/apps/web/lib/self-upgrade/status-target.test.ts
+++ b/apps/web/lib/self-upgrade/status-target.test.ts
@@ -17,7 +17,10 @@ vi.mock("./release-target", () => releaseTarget);
 vi.mock("@/lib/release-health/state", () => releaseHealth);
 vi.mock("./version", () => version);
 
-import { resolveSelfUpgradeStatusTarget } from "./status-target";
+import {
+  resolveSelfUpgradeStatusTarget,
+  resolveVerifiedReleaseUpgradeCandidate,
+} from "./status-target";
 
 const config = {
   enabled: true,
@@ -75,6 +78,18 @@ describe("resolveSelfUpgradeStatusTarget", () => {
     releaseTarget.resolveReleaseTarget.mockReturnValue(target);
     releaseHealth.loadVerifiedReleaseTargetEvidence.mockResolvedValue(null);
     releaseHealth.recordVerifiedReleaseTargetEvidence.mockResolvedValue(true);
+  });
+
+  it("exposes the same verified fallback to non-presentation consumers", async () => {
+    releaseTarget.resolveReleaseUpgradeCandidate.mockResolvedValue({
+      kind: "no-published-target",
+      reason: "registry-unavailable",
+    });
+    releaseHealth.loadVerifiedReleaseTargetEvidence.mockResolvedValue(candidate);
+
+    await expect(
+      resolveVerifiedReleaseUpgradeCandidate({ context, currentConfigDigest }),
+    ).resolves.toEqual(target);
   });
 
   it("retains an exact verified release target when a later registry read fails transiently", async () => {

--- a/apps/web/lib/self-upgrade/status-target.ts
+++ b/apps/web/lib/self-upgrade/status-target.ts
@@ -1,16 +1,12 @@
 import type { SelfUpgradeConfig } from "./config";
 import {
-  loadVerifiedReleaseTargetEvidence,
-  recordVerifiedReleaseTargetEvidence,
-} from "@/lib/release-health/state";
-import { getErrorMessage } from "@/lib/shared/get-error-message";
-import {
   loadReleaseInstallContext,
-  resolveReleaseTarget,
-  resolveReleaseUpgradeCandidate,
 } from "./release-target";
 import type { SelfUpgradeSupport } from "./support";
+import { resolveVerifiedReleaseUpgradeCandidate } from "./verified-release-target";
 import { resolveTargetSha } from "./version";
+
+export { resolveVerifiedReleaseUpgradeCandidate } from "./verified-release-target";
 
 export type SelfUpgradeStatusTarget = Readonly<{
   targetSha: string | null;
@@ -64,52 +60,13 @@ export async function resolveSelfUpgradeStatusTarget(input: {
     return UNAVAILABLE;
   }
 
-  // Registry discovery remains primary. A thrown fault is still reported even
-  // when the independently verified persisted candidate recovers the page, so
-  // intermittent process-level degradation remains observable.
-  const liveTarget = await resolveReleaseUpgradeCandidate({
+  const target = await resolveVerifiedReleaseUpgradeCandidate({
     context,
     currentConfigDigest: input.currentConfigDigest,
-  }).catch((error: unknown) => {
-    log(`release-target-resolution-threw: ${getErrorMessage(error)}`);
-    return null;
+    log,
   });
-  if (liveTarget && liveTarget.kind !== "no-published-target") {
-    const { kind: _kind, ...candidate } = liveTarget;
-    await recordVerifiedReleaseTargetEvidence({
-      candidate,
-      context,
-      currentConfigDigest: input.currentConfigDigest ?? "",
-    }).catch(() => false);
-    return {
-      targetSha: liveTarget.sourceSha,
-      targetTag: liveTarget.tag,
-      availability: "resolved",
-      unavailableReason: null,
-      releaseFreshness: liveTarget.kind === "up-to-date",
-    };
-  }
-
-  const persistedCandidate = input.currentConfigDigest
-    ? await loadVerifiedReleaseTargetEvidence({
-        context,
-        currentConfigDigest: input.currentConfigDigest,
-      }).catch(() => null)
-    : null;
-  const target = persistedCandidate
-    ? resolveReleaseTarget({
-        currentConfigDigest: input.currentConfigDigest,
-        candidate: persistedCandidate,
-      })
-    : null;
-  if (!target || target.kind === "no-published-target") {
-    const unavailableReason =
-      target?.reason ??
-      (liveTarget?.kind === "no-published-target"
-        ? liveTarget.reason
-        : "registry-unavailable");
-    log(`release-target-unavailable: ${unavailableReason}`);
-    return { ...UNAVAILABLE, unavailableReason };
+  if (target.kind === "no-published-target") {
+    return { ...UNAVAILABLE, unavailableReason: target.reason };
   }
   return {
     targetSha: target.sourceSha,

--- a/apps/web/lib/self-upgrade/verified-release-target.ts
+++ b/apps/web/lib/self-upgrade/verified-release-target.ts
@@ -1,0 +1,70 @@
+import {
+  loadVerifiedReleaseTargetEvidence,
+  recordVerifiedReleaseTargetEvidence,
+} from "@/lib/release-health/state";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+import {
+  resolveReleaseTarget,
+  resolveReleaseUpgradeCandidate,
+  type ReleaseInstallContext,
+} from "./release-target";
+
+type VerifiedReleaseTargetInput = {
+  context: ReleaseInstallContext;
+  currentConfigDigest: string | null;
+  log?: (message: string) => void;
+};
+
+/**
+ * Resolve a release target from the registry or from recent publisher-verified
+ * evidence bound to this exact install. Only transport unavailability may use
+ * the bounded fallback; any registry integrity result remains authoritative.
+ */
+export async function resolveVerifiedReleaseUpgradeCandidate(
+  input: VerifiedReleaseTargetInput,
+): Promise<Awaited<ReturnType<typeof resolveReleaseUpgradeCandidate>>> {
+  const log = input.log ?? ((message: string) => console.warn(`[self-upgrade] ${message}`));
+  const liveTarget = await resolveReleaseUpgradeCandidate({
+    context: input.context,
+    currentConfigDigest: input.currentConfigDigest,
+  }).catch((error: unknown) => {
+    log(`release-target-resolution-threw: ${getErrorMessage(error)}`);
+    return null;
+  });
+  if (liveTarget && liveTarget.kind !== "no-published-target") {
+    const { kind: _kind, ...candidate } = liveTarget;
+    await recordVerifiedReleaseTargetEvidence({
+      candidate,
+      context: input.context,
+      currentConfigDigest: input.currentConfigDigest ?? "",
+    }).catch(() => false);
+    return liveTarget;
+  }
+  if (liveTarget?.kind === "no-published-target" && liveTarget.reason !== "registry-unavailable") {
+    log(`release-target-unavailable: ${liveTarget.reason}`);
+    return liveTarget;
+  }
+  const persistedCandidate = input.currentConfigDigest
+    ? await loadVerifiedReleaseTargetEvidence({
+        context: input.context,
+        currentConfigDigest: input.currentConfigDigest,
+      }).catch(() => null)
+    : null;
+  if (!persistedCandidate) {
+    const unavailable = liveTarget ?? {
+      kind: "no-published-target" as const,
+      reason: "registry-unavailable" as const,
+    };
+    log(`release-target-unavailable: ${unavailable.reason}`);
+    return unavailable;
+  }
+  const target = resolveReleaseTarget({
+    currentConfigDigest: input.currentConfigDigest,
+    candidate: persistedCandidate,
+    unavailableReason: "registry-unavailable",
+  });
+  if (target.kind === "no-published-target") {
+    log(`release-target-unavailable: ${target.reason}`);
+  }
+  return target;
+}

--- a/apps/web/lib/self-upgrade/worker-release-target.ts
+++ b/apps/web/lib/self-upgrade/worker-release-target.ts
@@ -1,0 +1,88 @@
+import { err } from "@/lib/shared/action-result";
+import type {
+  ReleaseInstallContext,
+  ReleaseTargetResult,
+} from "@/lib/self-upgrade/release-target";
+import {
+  deferAdmittedRunForRedispatch,
+  failRun,
+  getRun,
+} from "@/lib/self-upgrade/run-store";
+import { resolveVerifiedReleaseUpgradeCandidate } from "@/lib/self-upgrade/verified-release-target";
+
+type PublishedReleaseTarget = Exclude<ReleaseTargetResult, { kind: "no-published-target" }>;
+
+export type WorkerReleaseTargetResolution =
+  | { kind: "resolved"; target: PublishedReleaseTarget }
+  | { kind: "unavailable"; target: Extract<ReleaseTargetResult, { kind: "no-published-target" }> }
+  | { kind: "handled"; response: Record<string, unknown> };
+
+/**
+ * Resolve the release target at worker start while preserving the immutable
+ * target that admission already committed to for a durable run.
+ */
+export async function resolveWorkerReleaseTarget(input: {
+  runId?: string;
+  context: ReleaseInstallContext;
+  currentConfigDigest: string | null;
+}): Promise<WorkerReleaseTargetResolution> {
+  const target = await resolveVerifiedReleaseUpgradeCandidate({
+    context: input.context,
+    currentConfigDigest: input.currentConfigDigest,
+  });
+  if (target.kind === "no-published-target") {
+    if (!input.runId) return { kind: "unavailable", target };
+    if (target.reason === "registry-unavailable") {
+      const deferred = await deferAdmittedRunForRedispatch(
+        input.runId,
+        "release-target-registry-unavailable",
+      );
+      return {
+        kind: "handled",
+        response: {
+          reconciling: deferred,
+          reason: deferred ? "registry-unavailable" : "target-recovery-not-claimable",
+          runId: input.runId,
+          releaseStatus: target.reason,
+        },
+      };
+    }
+    await failRun(input.runId, `release-target-integrity-failed: ${target.reason}`);
+    return {
+      kind: "handled",
+      response: {
+        ...err(`Release target integrity failed: ${target.reason}`),
+        status: "failed",
+        reason: "release-target-integrity-failed",
+        runId: input.runId,
+        releaseStatus: target.reason,
+      },
+    };
+  }
+
+  if (input.runId) {
+    const admitted = await getRun(input.runId);
+    if (
+      !admitted?.targetSha ||
+      !admitted.targetTag ||
+      admitted.targetSha.toLowerCase() !== target.sourceSha.toLowerCase() ||
+      admitted.targetTag !== target.tag
+    ) {
+      await failRun(
+        input.runId,
+        "admission-target-drift: worker target differs from durable admission",
+      );
+      return {
+        kind: "handled",
+        response: {
+          ...err("Worker target differs from the durable admission"),
+          status: "failed",
+          reason: "admission-target-drift",
+          runId: input.runId,
+        },
+      };
+    }
+  }
+
+  return { kind: "resolved", target };
+}

--- a/docs/superpowers/plans/2026-08-29-self-upgrade-rendered-target-admission.md
+++ b/docs/superpowers/plans/2026-08-29-self-upgrade-rendered-target-admission.md
@@ -23,6 +23,12 @@ This is a BI-EE81F61B fix layered on protected BI-3FD07259 behavior. The
 historical BI-3FD design, plan, baseline, and coverage identity are inputs and
 remain unchanged.
 
+The 2026-08-30 recurrence extends that same atomic authority chain through
+worker start: live registry discovery and bounded publisher-verified evidence
+share one resolver, the resolved SHA/tag must equal the durable admission, and
+a transport-only outage returns the same run to reconciliation before
+quiescence instead of terminally inventing “no published target.”
+
 ## Atomic implementation sequence
 
 1. Freeze the live red fixture: the page rendered
@@ -61,6 +67,11 @@ remain unchanged.
 10. Run the ordinary governed consumer start path and prove that the same
     immutable identity survives restart before unfreezing BI-F48 and the
     preserved WordPress TaskRun.
+11. Freeze the worker-stage recurrence with tests for verified-evidence
+    recovery, no-evidence redispatch, durable-binding drift, and registry digest
+    failure. Consolidate target resolution, add the pre-mutation compare-and-
+    swap back to `pending`/`indeterminate`, then repeat the graph-linked tests,
+    exact-tree gate, protected merge, release, and governed live proof.
 
 ## Expected source surface
 
@@ -74,6 +85,15 @@ remain unchanged.
 - `apps/web/lib/actions/promotions.self-upgrade.test.ts`
 - `apps/web/lib/self-upgrade/admission.ts`
 - `apps/web/lib/self-upgrade/admission.test.ts`
+- `apps/web/lib/self-upgrade/status-target.ts`
+- `apps/web/lib/self-upgrade/status-target.test.ts`
+- `apps/web/lib/self-upgrade/verified-release-target.ts`
+- `apps/web/lib/self-upgrade/worker-release-target.ts`
+- `apps/web/lib/self-upgrade/run-store.ts`
+- `apps/web/lib/self-upgrade/run-store.test.ts`
+- `apps/web/lib/queue/functions/self-upgrade.ts`
+- `apps/web/lib/queue/functions/self-upgrade.test.ts`
+- `apps/web/lib/queue/functions/self-upgrade-handoff.test-support.ts`
 - `docs/superpowers/specs/2026-08-29-self-upgrade-rendered-target-admission-design.md`
 - `docs/superpowers/plans/2026-08-29-self-upgrade-rendered-target-admission.md`
 
@@ -110,6 +130,10 @@ edit, or manual consumer environment edit is in scope.
 | AC-RTA-007 | unresolved Git-source action denial fixture |
 | AC-RTA-008 | page/control/action adjacency, web typecheck, protected CI |
 | AC-RTA-009 | canonical release, one live upgrade, CAN-TEST, identity convergence, ordinary restart |
+| AC-RTA-010 | verified-evidence worker recovery fixture |
+| AC-RTA-011 | run-store compare-and-swap plus worker reconciliation fixture |
+| AC-RTA-012 | worker durable-target drift and registry digest-failure fixtures |
+| AC-RTA-013 | existing bounded admission reconciler plus architecture review |
 
 ## Backlog coverage
 
@@ -127,7 +151,7 @@ edit, or manual consumer environment edit is in scope.
 
 | Deliverable key | Backlog item | Independently shippable | Requirement refs | Contract refs | Flow refs | Verification refs |
 | --- | --- | --- | --- | --- | --- | --- |
-| `server-owned-rendered-target-admission` | BI-EE81F61B | no | OBJ-RTA-001, OBJ-RTA-002, OBJ-RTA-003, OBJ-RTA-004, OBJ-RTA-005 | opaque-target-binding, admission-transaction, dispatch-state-machine, install-support-boundary | render-sign, client-carry, action-verify, admit, reconcile, dispatch, live-upgrade, ordinary-restart | AC-RTA-001, AC-RTA-002, AC-RTA-003, AC-RTA-004, AC-RTA-005, AC-RTA-006, AC-RTA-007, AC-RTA-008, AC-RTA-009 |
+| `server-owned-rendered-target-admission` | BI-EE81F61B | no | OBJ-RTA-001, OBJ-RTA-002, OBJ-RTA-003, OBJ-RTA-004, OBJ-RTA-005 | opaque-target-binding, admission-transaction, dispatch-state-machine, install-support-boundary | render-sign, client-carry, action-verify, admit, reconcile, dispatch, worker-verify, worker-reconcile, live-upgrade, ordinary-restart | AC-RTA-001, AC-RTA-002, AC-RTA-003, AC-RTA-004, AC-RTA-005, AC-RTA-006, AC-RTA-007, AC-RTA-008, AC-RTA-009, AC-RTA-010, AC-RTA-011, AC-RTA-012, AC-RTA-013 |
 
 ## Risks and rollback
 

--- a/docs/superpowers/specs/2026-08-29-self-upgrade-rendered-target-admission-design.md
+++ b/docs/superpowers/specs/2026-08-29-self-upgrade-rendered-target-admission-design.md
@@ -41,6 +41,16 @@ five-file/129-test draft, but architecture review rejected that draft because
 it trusted ordinary client-provided target fields. That draft is research
 evidence only and must not be published.
 
+### 2026-08-30 worker-stage recurrence
+
+The protected render/action repair admitted and dispatched
+`SUR-5B6E1FE2` for `v2026.08.30` at
+`48a7492bdc6da61682f9956a9ca185ba4c12762d`. The worker then discarded that
+durable binding, repeated mutable GHCR discovery, and terminally skipped the
+run as `no-published-target: registry-unavailable`. A later run to the same
+target succeeded when the registry responded. The worker therefore remained a
+second, inconsistent home for target authority.
+
 ## Objectives
 
 - **OBJ-RTA-001:** Preserve the exact immutable release target resolved by the
@@ -49,8 +59,9 @@ evidence only and must not be published.
   mismatched, or unbound target data from creating a durable admission.
 - **OBJ-RTA-003:** Keep admission durable and idempotent while target
   re-resolution is temporarily unavailable.
-- **OBJ-RTA-004:** Require an independent exact resolver match before physical
-  dispatch, while preserving terminal fail-closed behavior for actual drift.
+- **OBJ-RTA-004:** Require independently verified immutable image evidence
+  before physical mutation, while preserving terminal fail-closed behavior for
+  actual drift at dispatch or worker start.
 - **OBJ-RTA-005:** Preserve source-install Git discovery and all existing auth,
   quiescence, override, newer-run, and release-support boundaries.
 
@@ -65,6 +76,10 @@ evidence only and must not be published.
 | AC-RTA-007 | OBJ-RTA-005 | Git-source installs cannot use a rendered release binding and retain ordinary Git target discovery. | Git-source denial fixture |
 | AC-RTA-008 | OBJ-RTA-005 | Existing auth, force, quiescence, newer-run, and live status behavior remains green; no new user-facing control is introduced. | Adjacent tests and UX verification |
 | AC-RTA-009 | OBJ-RTA-001, OBJ-RTA-003, OBJ-RTA-004 | One governed live upgrade reaches the canonical BI-EE release, exact served SHA, CAN-TEST, and restart identity convergence across install-state, `.env`, container image, and OCI revision. | Protected/live acceptance |
+| AC-RTA-010 | OBJ-RTA-003, OBJ-RTA-004 | A worker consumes the same bounded publisher-verified candidate used by status/admission when a second registry read is transiently unavailable. | Worker recovery fixture |
+| AC-RTA-011 | OBJ-RTA-003 | If neither live nor bounded verified evidence is available, a claimed worker returns the same run to `pending`/`indeterminate` reconciliation before quiescence; it is not skipped and no second admission is created. | Worker and run-store fixtures |
+| AC-RTA-012 | OBJ-RTA-004 | A worker candidate whose SHA/tag differs from the durable admission, or whose registry proof reports an integrity failure, terminally fails with a distinct integrity outcome before quiescence. | Drift and digest fixtures |
+| AC-RTA-013 | OBJ-RTA-003 | Recovery is constant work per admitted run and uses the existing bounded reconciliation query; no fleet fan-out or unbounded collection is introduced. | Architecture review and existing reconciler bound |
 
 ## Chosen design
 
@@ -106,6 +121,21 @@ absence records `admission-target-unavailable` as indeterminate and retains
 the row for reconciliation; an exact result dispatches once; an actual
 mismatch remains terminal drift.
 
+The worker uses that same verified resolver instead of owning a parallel
+registry-only path. Live discovery remains primary. Only
+`registry-unavailable` may fall back to recent publisher-verified evidence
+bound to the exact install context and current config digest; authentication,
+manifest, digest, tag, and source-revision failures remain authoritative. The
+worker compares the resulting SHA/tag with the durable admission before any
+quiescence. If transient evidence is absent, a compare-and-swap returns the
+claimed run to `pending`/`indeterminate`, where the existing bounded admission
+reconciler redispatches the same identity. This preserves one source of target
+truth and one physical-upgrade identity.
+
+The scale ceiling remains the admission reconciler's existing bounded batch of
+recoverable runs; this repair adds O(1) work and one bounded evidence lookup per
+worker delivery. EP-56AE0F69 owns further self-upgrade lifecycle evolution.
+
 ## Rejected options
 
 - **Ordinary client fields:** rejected because a forged or stale browser can
@@ -134,6 +164,10 @@ mismatch remains terminal drift.
    diff checks, exact-tree local CI, and independent semantic review.
 7. Deliver through DCO/protected merge, one canonical release, one governed
    live action, exact served-SHA/CAN-TEST, and restart identity convergence.
+8. Add the worker-stage recurrence fixtures, consolidate registry plus bounded
+   verified-evidence resolution behind one helper, compare against the durable
+   admission, and return transport-unavailable runs to reconciliation before
+   mutation. Keep all typed integrity failures terminal.
 
 No step is independently shippable: signing without action integration is
 unused, action integration without dispatch reconciliation wedges admissions,
@@ -144,7 +178,7 @@ original authority defect.
 
 | Deliverable key | Backlog item | Independently shippable | Requirement refs | Contract refs | Flow refs | Verification refs |
 | --- | --- | --- | --- | --- | --- | --- |
-| `server-owned-rendered-target-admission` | BI-EE81F61B | no | OBJ-RTA-001, OBJ-RTA-002, OBJ-RTA-003, OBJ-RTA-004, OBJ-RTA-005 | opaque-target-binding, admission-transaction, dispatch-state-machine, install-support-boundary | render-sign, client-carry, action-verify, admit, reconcile, dispatch, live-upgrade | AC-RTA-001, AC-RTA-002, AC-RTA-003, AC-RTA-004, AC-RTA-005, AC-RTA-006, AC-RTA-007, AC-RTA-008, AC-RTA-009 |
+| `server-owned-rendered-target-admission` | BI-EE81F61B | no | OBJ-RTA-001, OBJ-RTA-002, OBJ-RTA-003, OBJ-RTA-004, OBJ-RTA-005 | opaque-target-binding, admission-transaction, dispatch-state-machine, install-support-boundary | render-sign, client-carry, action-verify, admit, reconcile, dispatch, worker-verify, worker-reconcile, live-upgrade | AC-RTA-001, AC-RTA-002, AC-RTA-003, AC-RTA-004, AC-RTA-005, AC-RTA-006, AC-RTA-007, AC-RTA-008, AC-RTA-009, AC-RTA-010, AC-RTA-011, AC-RTA-012, AC-RTA-013 |
 
 ## Scope, rollback, and root-cause prevention
 

--- a/scripts/local-action-result-baseline.json
+++ b/scripts/local-action-result-baseline.json
@@ -4,5 +4,5 @@
   "expiry": "2026-11-16",
   "note": "One-ActionResult ratchet baseline (BI-1CED89B9). localAliases must stay empty; inlineOkTrueTotal is shrink-only — compose ok()/err() from lib/shared/action-result. Regenerate with: node scripts/check-no-local-action-result.mjs --update",
   "localAliases": [],
-  "inlineOkTrueTotal": 974
+  "inlineOkTrueTotal": 973
 }


### PR DESCRIPTION
## What failed

Admission resolved and persisted an immutable release target, but the worker queried GHCR again at start. A transient registry error then terminally skipped the admitted run even though the portal already held verified target evidence. The run could also proceed against a target that no longer matched its durable SHA/tag binding.

## What changed

- Resolve release targets through one shared live-first, bounded-evidence path.
- Use cached evidence only for `registry-unavailable`; authentication, manifest, digest, tag, and revision failures remain terminal.
- Fence the worker against the exact admitted SHA and tag before quiescence.
- Return a transiently blocked admitted run to `pending/indeterminate` so the existing reconciler redispatches the same run ID.
- Split target resolution and worker admission out of the oversized worker module; the module is now below the 800-line ceiling.
- Retighten the ActionResult debt baseline from 974 to 973 inline success sites.

## Verification

- 198 affected tests passed across five files.
- Web TypeScript check passed.
- 61 deterministic preflight guards passed; one known Windows-only host assertion was classified as an environment skip.
- Exact-tree local integration gate passed against current `origin/main`, including the full test/typecheck/container-build plan.
- Independent semantic review was attempted twice and recorded infrastructure-inconclusive; the checked-in shadow policy permits publication and GitHub review remains authoritative.

Linked backlog: BI-EE81F61B
