### PR TITLE
fix(guards): remaining diff-scoped gates fail closed when origin/main is unresolvable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -158,6 +158,10 @@ COPY scripts/lib/module-size-scope.mjs ./scripts/lib/
 COPY scripts/lib/ci-policy-guards.mjs ./scripts/lib/
 COPY scripts/lib/host-command-invocation.mjs ./scripts/lib/
 COPY scripts/lib/git-fetch-shared-safe.mjs ./scripts/lib/
+# check-design-grounding-decision and check-data-impact import the shared
+# unresolvable-diff helper; without this COPY the init image dies at
+# ERR_MODULE_NOT_FOUND (BI-20599979).
+COPY scripts/lib/git-changed-files.mjs ./scripts/lib/
 COPY scripts/lib/entry-module.mjs ./scripts/lib/
 COPY scripts/lib/local-integration-status.mjs ./scripts/lib/
 COPY scripts/module-size-baseline.txt ./scripts/

--- a/scripts/check-data-impact.mjs
+++ b/scripts/check-data-impact.mjs
@@ -13,6 +13,7 @@
 
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { listChangedFiles } from "./lib/git-changed-files.mjs";
 
 // ── Persistent-surface classification (kept conservative for the first ship) ──
 export const PERSISTENT_SURFACE_RULES = [
@@ -142,12 +143,17 @@ export function runGate({
   changed,
   readFile = (f) => readFileSync(f, "utf8"),
 } = {}) {
-  const files =
-    changed ??
-    git(["diff", "--name-only", `${base}...HEAD`])
-      .split("\n")
-      .map((s) => s.trim())
-      .filter(Boolean);
+  let files = changed;
+  if (!files) {
+    const listed = listChangedFiles(base);
+    if (listed.status === "unresolvable") {
+      return {
+        ok: false,
+        message: `cannot resolve ${base} — the guard did not run. This is not a pass. Remedy: git fetch --deepen 50 origin.`,
+      };
+    }
+    files = listed.files;
+  }
 
   const surfaces = classifyChangedSurfaces(files);
   if (surfaces.length === 0) {

--- a/scripts/check-design-grounding-decision.mjs
+++ b/scripts/check-design-grounding-decision.mjs
@@ -10,6 +10,7 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fetchOriginMainSharedSafe } from "./lib/git-fetch-shared-safe.mjs";
+import { requireChangedFiles } from "./lib/git-changed-files.mjs";
 
 export const DESIGN_GROUNDING_RE = /(?:^|\n)\s*(?:#{1,6}\s*)?Design[ -]Grounding(?:-Decision)?:/i;
 export const DESIGN_GROUNDING_HEADING_RE = /(?:^|\n)\s*#{1,6}\s+Design grounding\b/i;
@@ -179,11 +180,7 @@ function main() {
   // BI-1ADD56FC: never write .git/shallow into a full shared clone.
   fetchOriginMainSharedSafe((args) => git(...args));
 
-  const changedFiles = git("diff", "--name-only", `${base}...HEAD`)
-    .split("\n")
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .map(assertSafePath);
+  const changedFiles = requireChangedFiles(base, "design-grounding-gate").map(assertSafePath);
 
   const commits = git("log", `${base}..HEAD`, "--format=%B");
   const prBody = process.env.PR_BODY || "";

--- a/scripts/check-doc-anchor-existence.mjs
+++ b/scripts/check-doc-anchor-existence.mjs
@@ -38,10 +38,13 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
+
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { formatTxtBudgetHeader, parseTxtBudgetHeader } from "./lib/baseline-budget.mjs";
+import { listChangedFiles, runGit } from "./lib/git-changed-files.mjs";
+
+export { listChangedFiles, runGit };
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const BASELINE_PATH = path.join(REPO_ROOT, "scripts", "doc-anchor-baseline.txt");
@@ -177,54 +180,6 @@ export async function verifyAnchors(pairs, lookup) {
 }
 
 const REF_RE = /^[A-Za-z0-9._\-/]{1,200}$/;
-
-/**
- * Run git in the repo. Distinguishes success from failure — never collapse a
- * failed invocation into an empty string (BI-B6433DC6).
- */
-export function runGit(args, { exec = execFileSync } = {}) {
-  try {
-    const stdout = exec("git", args, {
-      cwd: REPO_ROOT,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    return { ok: true, stdout: String(stdout ?? ""), stderr: "" };
-  } catch (e) {
-    return {
-      ok: false,
-      stdout: (e.stdout && e.stdout.toString()) || "",
-      stderr: (e.stderr && e.stderr.toString()) || e.message || "",
-      status: e.status ?? 1,
-    };
-  }
-}
-
-/**
- * Files changed vs `base`. An unresolvable ref or a failed three-dot diff is
- * `unresolvable`, never an empty list — a shallow clone can name origin/main
- * and still fail the merge-base (BI-B6433DC6).
- */
-export function listChangedFiles(base, { git = runGit } = {}) {
-  const parsed = git(["rev-parse", "--verify", `${base}^{commit}`]);
-  if (!parsed.ok) {
-    return {
-      status: "unresolvable",
-      files: [],
-      detail: (parsed.stderr || parsed.stdout || "").trim(),
-    };
-  }
-  const diff = git(["diff", "--name-only", `${base}...HEAD`]);
-  if (!diff.ok) {
-    return {
-      status: "unresolvable",
-      files: [],
-      detail: (diff.stderr || diff.stdout || "").trim(),
-    };
-  }
-  const files = diff.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
-  return { status: "ok", files, detail: "" };
-}
 
 function scanAllDocs() {
   const pairs = [];

--- a/scripts/check-docs-impact.mjs
+++ b/scripts/check-docs-impact.mjs
@@ -28,6 +28,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
+import { requireChangedFiles } from "./lib/git-changed-files.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ROUTE_MAP_TS = path.join(REPO_ROOT, "apps", "web", "lib", "docs-route-map.ts");
@@ -150,8 +151,7 @@ export function computeImpact(changedFiles, entries, codeToDocs = {}) {
 
 function main() {
   const base = assertSafeRef(process.env.BASE_SHA || "origin/main", "BASE_SHA");
-  const changed = git("diff", "--name-only", `${base}...HEAD`)
-    .split("\n").map((s) => s.trim()).filter(Boolean);
+  const changed = requireChangedFiles(base, "docs-impact-gate");
   for (const f of changed) assertSafePath(f);
 
   // Dependency-manifest-only diffs (lockfile / package.json bumps, e.g. from

--- a/scripts/check-live-blocker-references.mjs
+++ b/scripts/check-live-blocker-references.mjs
@@ -38,7 +38,8 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { callTool, DEFAULT_ENDPOINT, listChangedFiles } from "./check-doc-anchor-existence.mjs";
+import { callTool, DEFAULT_ENDPOINT } from "./check-doc-anchor-existence.mjs";
+import { listChangedFiles, runGit } from "./lib/git-changed-files.mjs";
 import { formatTxtBudgetHeader, parseTxtBudgetHeader } from "./lib/baseline-budget.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -126,8 +127,14 @@ function isScannedSource(file) {
 }
 
 function scanAllSources() {
+  const listed = runGit(["ls-files"]);
+  if (!listed.ok) {
+    console.error("[live-blocker] git ls-files failed — the --update scan did not run. This is not a pass.");
+    if (listed.stderr) console.error(`[live-blocker] git: ${listed.stderr.trim()}`);
+    process.exit(1);
+  }
   const pairs = [];
-  for (const file of git("ls-files").split("\n").map((s) => s.trim()).filter(isScannedSource)) {
+  for (const file of listed.stdout.split("\n").map((s) => s.trim()).filter(isScannedSource)) {
     const abs = path.join(REPO_ROOT, file);
     if (!fs.existsSync(abs)) continue;
     for (const id of extractLiveBlockerCitations(fs.readFileSync(abs, "utf8"))) pairs.push({ file, id });

--- a/scripts/check-plan-backlog-coverage.mjs
+++ b/scripts/check-plan-backlog-coverage.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { requireChangedFiles } from "./lib/git-changed-files.mjs";
 
 const PLAN_PATH_RE = /^docs\/superpowers\/plans\/.*\.md$/;
 
@@ -41,14 +41,9 @@ export function validatePlanText(path, text) {
   return { ok: errors.length === 0, errors };
 }
 
-function git(...args) {
-  return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
-}
-
 function main() {
   const base = process.env.BASE_SHA || "origin/main";
-  const paths = git("diff", "--name-only", "--diff-filter=AM", `${base}...HEAD`)
-    .split(/\r?\n/)
+  const paths = requireChangedFiles(base, "plan-backlog-coverage-gate")
     .filter((path) => PLAN_PATH_RE.test(path));
   const failures = paths.flatMap((path) => validatePlanText(path, readFileSync(path, "utf8")).errors);
   if (failures.length === 0) {

--- a/scripts/check-seed-fit-decision.mjs
+++ b/scripts/check-seed-fit-decision.mjs
@@ -7,6 +7,7 @@ import {
   normalizeGithubLabels,
   SEED_FIT_DECISIONS,
 } from "./lib/seed-fit-gate.mjs";
+import { requireChangedFiles } from "./lib/git-changed-files.mjs";
 
 const REF_RE = /^[A-Za-z0-9._\-/]{1,200}$/;
 
@@ -32,10 +33,7 @@ if (process.env.GITHUB_EVENT_NAME && process.env.GITHUB_EVENT_NAME !== "pull_req
 
 const base = safeRef(process.env.BASE_SHA || "origin/main", "BASE_SHA");
 git("fetch", "--no-tags", "origin", "main");
-const changedFiles = git("diff", "--name-only", `${base}...HEAD`)
-  .split("\n")
-  .map((line) => line.trim())
-  .filter(Boolean);
+const changedFiles = requireChangedFiles(base, "seed-fit-gate");
 
 let labels = [];
 try {

--- a/scripts/check-spec-plan-doc.mjs
+++ b/scripts/check-spec-plan-doc.mjs
@@ -36,7 +36,7 @@
 // interactive nudge is scripts/hooks/spec-plan-doc-precheck.mjs.
 
 import { execFileSync } from "node:child_process";
-import { listChangedFiles } from "./check-doc-anchor-existence.mjs";
+import { listChangedFiles, runGit, exitUnresolvable } from "./lib/git-changed-files.mjs";
 import { fetchOriginMainSharedSafe } from "./lib/git-fetch-shared-safe.mjs";
 // Canonical sensitivity constants (single source, shared with the gate-context
 // pack; the dpf-skill-pack precheck hook keeps a drift-guard-pinned copy).
@@ -105,11 +105,10 @@ if (changed.length === 0) {
   process.exit(0);
 }
 
+const addedDiff = runGit(["diff", "--name-only", "--diff-filter=A", `${base}...HEAD`]);
+if (!addedDiff.ok) exitUnresolvable("spec-plan-doc-gate", base, (addedDiff.stderr || addedDiff.stdout).trim());
 const addedFiles = new Set(
-  git("diff", "--name-only", "--diff-filter=A", `${base}...HEAD`)
-    .split("\n")
-    .map((s) => s.trim())
-    .filter(Boolean),
+  addedDiff.stdout.split("\n").map((s) => s.trim()).filter(Boolean),
 );
 
 // 1) Does the PR touch a durable-knowledge artifact? That satisfies the gate.

--- a/scripts/check-spec-status-frontmatter.mjs
+++ b/scripts/check-spec-status-frontmatter.mjs
@@ -43,6 +43,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { requireChangedFiles } from "./lib/git-changed-files.mjs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -189,13 +190,11 @@ function main() {
   }
 
   const base = process.env.BASE_SHA || "origin/main";
-  let changed = new Set();
-  if (REF_RE.test(base) && !base.startsWith("-")) {
-    changed = new Set(
-      git("diff", "--name-only", `${base}...HEAD`)
-        .split("\n").map((s) => s.trim()).filter(Boolean),
-    );
+  if (!REF_RE.test(base) || base.startsWith("-")) {
+    console.error(`[spec-status] refusing unsafe BASE_SHA: ${JSON.stringify(base)}`);
+    process.exit(1);
   }
+  const changed = new Set(requireChangedFiles(base, "spec-status"));
 
   const failures = [];
   for (const rel of files) {

--- a/scripts/check-ux-fit-decision.mjs
+++ b/scripts/check-ux-fit-decision.mjs
@@ -37,6 +37,7 @@
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fetchOriginMainSharedSafe } from "./lib/git-fetch-shared-safe.mjs";
+import { listChangedFiles, exitUnresolvable } from "./lib/git-changed-files.mjs";
 // Canonical sensitivity constants (single source, shared with the gate-context pack;
 // the dpf-skill-pack precheck hook keeps a drift-guard-pinned copy) — BI-2677A465.
 // `UX_FIT_ATTESTATION_RE` is deliberately NOT imported: this gate no longer reads any
@@ -471,7 +472,10 @@ function main() {
   // BI-1ADD56FC: never write .git/shallow into a full shared clone (breaks worktrees).
   fetchOriginMainSharedSafe((args) => git(...args));
 
-  const changed = lines(git("diff", "--name-only", `${base}...HEAD`, "--", "apps/web/**/*.tsx"))
+  const listed = listChangedFiles(base);
+  if (listed.status === "unresolvable") exitUnresolvable("ux-fit-gate", base, listed.detail);
+  const changed = listed.files
+    .filter((f) => f.startsWith("apps/web/") && f.endsWith(".tsx"))
     .filter((f) => !EXCLUDE_RE.test(f));
 
   const addedFiles = new Set(

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -335,6 +335,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     // live install is reachable). Closes the unbacked-doc-anchor pattern (P3).
     guard("doc-anchor-existence", "Doc Anchor Existence", [
       node("--test", "scripts/check-doc-anchor-existence.test.mjs"),
+      node("--test", "scripts/lib/git-changed-files.test.mjs"),
       node("scripts/check-doc-anchor-existence.mjs"),
     ]),
     // BI-38A353B2: doc-anchor-existence proves a cited id EXISTS; nothing

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -335,7 +335,9 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     // live install is reachable). Closes the unbacked-doc-anchor pattern (P3).
     guard("doc-anchor-existence", "Doc Anchor Existence", [
       node("--test", "scripts/check-doc-anchor-existence.test.mjs"),
-      node("--test", "scripts/lib/git-changed-files.test.mjs"),
+      // Spawns each remaining CLI against a missing BASE_SHA on the live tree,
+      // so the host-side preflight must not strip it (BI-20599979).
+      conformanceTest("scripts/lib/git-changed-files.test.mjs"),
       node("scripts/check-doc-anchor-existence.mjs"),
     ]),
     // BI-38A353B2: doc-anchor-existence proves a cited id EXISTS; nothing

--- a/scripts/lib/git-changed-files.mjs
+++ b/scripts/lib/git-changed-files.mjs
@@ -1,0 +1,72 @@
+// scripts/lib/git-changed-files.mjs
+//
+// BI-20599979 / BI-B6433DC6 — one honesty helper for every diff-scoped guard.
+// "I could not compute the diff" is not "the diff was empty".
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/**
+ * Run git in the repo. Distinguishes success from failure — never collapse a
+ * failed invocation into an empty string (BI-B6433DC6).
+ */
+export function runGit(args, { exec = execFileSync, cwd = REPO_ROOT } = {}) {
+  try {
+    const stdout = exec("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { ok: true, stdout: String(stdout ?? ""), stderr: "" };
+  } catch (e) {
+    return {
+      ok: false,
+      stdout: (e.stdout && e.stdout.toString()) || "",
+      stderr: (e.stderr && e.stderr.toString()) || e.message || "",
+      status: e.status ?? 1,
+    };
+  }
+}
+
+/**
+ * Files changed vs `base`. An unresolvable ref or a failed three-dot diff is
+ * `unresolvable`, never an empty list.
+ */
+export function listChangedFiles(base, { git = runGit } = {}) {
+  const parsed = git(["rev-parse", "--verify", `${base}^{commit}`]);
+  if (!parsed.ok) {
+    return {
+      status: "unresolvable",
+      files: [],
+      detail: (parsed.stderr || parsed.stdout || "").trim(),
+    };
+  }
+  const diff = git(["diff", "--name-only", `${base}...HEAD`]);
+  if (!diff.ok) {
+    return {
+      status: "unresolvable",
+      files: [],
+      detail: (diff.stderr || diff.stdout || "").trim(),
+    };
+  }
+  const files = diff.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+  return { status: "ok", files, detail: "" };
+}
+
+/** Print the shared unresolvable-base contract and exit 1. */
+export function exitUnresolvable(prefix, base, detail) {
+  console.error(`[${prefix}] cannot resolve ${base} — the guard did not run. This is not a pass.`);
+  console.error(`[${prefix}] Remedy: git fetch --deepen 50 origin  (or git fetch origin main) and re-run.`);
+  if (detail) console.error(`[${prefix}] git: ${detail}`);
+  process.exit(1);
+}
+
+/** listChangedFiles then exit if the base could not be resolved. */
+export function requireChangedFiles(base, prefix) {
+  const listed = listChangedFiles(base);
+  if (listed.status === "unresolvable") exitUnresolvable(prefix, base, listed.detail);
+  return listed.files;
+}

--- a/scripts/lib/git-changed-files.test.mjs
+++ b/scripts/lib/git-changed-files.test.mjs
@@ -42,7 +42,10 @@ function spawnGuard(rel) {
   return spawnSync(process.execPath, [path.join(ROOT, rel)], {
     encoding: "utf8",
     cwd: ROOT,
-    env: { ...process.env, BASE_SHA: MISSING },
+    // Run the diff-scoped guard in its applicable PR mode.  CI's merge_group
+    // event otherwise makes seed-fit legitimately exit 0 before it resolves
+    // BASE_SHA, masking the unresolvable-base contract this fixture checks.
+    env: { ...process.env, BASE_SHA: MISSING, GITHUB_EVENT_NAME: "pull_request" },
   });
 }
 

--- a/scripts/lib/git-changed-files.test.mjs
+++ b/scripts/lib/git-changed-files.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { listChangedFiles } from "./git-changed-files.mjs";
+import { runGate as runDataImpactGate } from "../check-data-impact.mjs";
+
+test("listChangedFiles: an unresolvable base is not an empty diff (BI-20599979)", () => {
+  const git = (args) => {
+    if (args[0] === "rev-parse") {
+      return { ok: false, stdout: "", stderr: "fatal: Needed a single revision" };
+    }
+    return { ok: true, stdout: "" };
+  };
+  const result = listChangedFiles("origin/main", { git });
+  assert.equal(result.status, "unresolvable");
+  assert.deepEqual(result.files, []);
+});
+
+test("listChangedFiles: a resolved ref with no files is empty, not unresolvable", () => {
+  const git = (args) => {
+    if (args[0] === "rev-parse") return { ok: true, stdout: "abc123\n" };
+    return { ok: true, stdout: "" };
+  };
+  const result = listChangedFiles("origin/main", { git });
+  assert.equal(result.status, "ok");
+  assert.deepEqual(result.files, []);
+});
+
+test("data-impact runGate names an unresolvable base instead of throwing (BI-E742EC69)", () => {
+  const result = runDataImpactGate({ base: "origin/this-ref-does-not-exist-e742ec69" });
+  assert.equal(result.ok, false);
+  assert.match(result.message, /cannot resolve/);
+});
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const MISSING = "origin/this-ref-does-not-exist-guard-honesty-sweep";
+
+function spawnGuard(rel) {
+  return spawnSync(process.execPath, [path.join(ROOT, rel)], {
+    encoding: "utf8",
+    cwd: ROOT,
+    env: { ...process.env, BASE_SHA: MISSING },
+  });
+}
+
+const CLI_CASES = [
+  ["scripts/check-docs-impact.mjs", "docs-impact-gate", "BI-39B7276B"],
+  ["scripts/check-ux-fit-decision.mjs", "ux-fit-gate", "BI-37690A7F"],
+  ["scripts/check-design-grounding-decision.mjs", "design-grounding-gate", "BI-13CBE1FC"],
+  ["scripts/check-spec-status-frontmatter.mjs", "spec-status", "BI-63D31C4E"],
+  ["scripts/check-seed-fit-decision.mjs", "seed-fit-gate", "BI-562C8D0E"],
+  ["scripts/check-plan-backlog-coverage.mjs", "plan-backlog-coverage-gate", "BI-703082B4"],
+  ["scripts/check-spec-plan-doc.mjs", "spec-plan-doc-gate", "BI-6F3BAD84"],
+];
+
+for (const [rel, prefix, bi] of CLI_CASES) {
+  test(`${prefix} must not pass when BASE_SHA is unresolvable (${bi})`, () => {
+    const result = spawnGuard(rel);
+    const out = `${result.stdout}${result.stderr}`;
+    assert.notEqual(result.status, 0, `must not exit 0; output:\n${out}`);
+    assert.match(out, /cannot resolve|did not run/i);
+    assert.doesNotMatch(out, /\bOK\.\s*$/m);
+  });
+}


### PR DESCRIPTION
## Summary

Ten leftover twins of BI-B6433DC6, one PR. A failed `git diff origin/main...HEAD` was still being treated as an empty change list, so several required gates could print OK / "nothing to gate" (or throw an uncaught git error) without running.

`listChangedFiles` now lives in `scripts/lib/git-changed-files.mjs` and every remaining diff-scoped guard uses it. Unresolvable base exits 1 and names `git fetch --deepen`. Empty diff after a resolved ref still skips.

### Items

| BI | Gate |
|---|---|
| BI-20599979 | Hoist `listChangedFiles` to `scripts/lib/git-changed-files.mjs` |
| BI-39B7276B | `check-docs-impact` |
| BI-37690A7F | `check-ux-fit-decision` |
| BI-13CBE1FC | `check-design-grounding-decision` |
| BI-63D31C4E | `check-spec-status-frontmatter` |
| BI-562C8D0E | `check-seed-fit-decision` |
| BI-E742EC69 | `check-data-impact` (named fail, not uncaught throw) |
| BI-703082B4 | `check-plan-backlog-coverage` |
| BI-6F3BAD84 | `check-spec-plan-doc` leftover `--diff-filter=A` swallow |
| BI-8E4E4A39 | `check-live-blocker-references` leftover `ls-files` swallow on `--update` |

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-08-15-resilient-concurrent-development-process.md
  - the process-spine Design Grounding / UX-Fit / Spec-Plan-Doc gates already on this branch
- Current code substrate reviewed:
  - scripts/lib/git-changed-files.mjs
  - Dockerfile init-stage COPY list
  - scripts/lib/ci-policy-guards.mjs
  - scripts/lib/gate-context-runtime-contract.test.mjs
- Source of truth:
  - the Dockerfile init-stage COPY allowlist is the image identity; an uncopied static import is ERR_MODULE_NOT_FOUND
- Decision:
  - keep the existing fail-closed unresolvable-diff contract; copy the new helper into the image; mark live-repo spawn tests as conformanceTest. No new UX, routing, or user-facing process surface.

Design-Grounding-Decision: Keep the existing fail-closed unresolvable-diff contract; no new UX, routing, or user-facing process surface.

## Verification

```
node --test scripts/lib/git-changed-files.test.mjs scripts/check-doc-anchor-existence.test.mjs scripts/check-live-blocker-references.test.mjs scripts/check-spec-plan-doc.test.mjs
node scripts/check-guard-conformance-marks.mjs
node scripts/check-dockerfile-copied-script-imports.mjs
node --test scripts/lib/gate-context-runtime-contract.test.mjs
```

Typecheck / production build / UX: not applicable (guard scripts only).

## Docs

Docs-Impact-Decision: guard scripts only; no user-facing route or user-guide page. Pre-commit regenerated `doc-impact.generated.json` because these scripts are `relatedCode` for the docs-impact page.

Process-Spine-Decision: no new capability; existing gates now fail closed on an unrun check.

## Local CI

Local-CI-Override: external-contribution-no-install: scripts-only node builtin guards; local-CI oversubscribed

Refs: BI-20599979, BI-39B7276B, BI-37690A7F, BI-13CBE1FC, BI-63D31C4E, BI-562C8D0E, BI-E742EC69, BI-703082B4, BI-6F3BAD84, BI-8E4E4A39