### PR TITLE
fix: expose bound objective mapping schema

### DIFF
--- a/apps/web/lib/mcp-task-review-contract.test.ts
+++ b/apps/web/lib/mcp-task-review-contract.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import type { ToolDefinition } from "@/lib/mcp-tools";
+import { narrowInitiativeReviewTools } from "./mcp-task-review-contract";
+
+const binding = {
+  writerToolName: "record_initiative_evidence",
+  itemId: "BI-7D2C4F02",
+  gate: "objective-mapping",
+  expectedCurrentBaselineId: "baseline-08cecc05-02ef-4bf1-bfae-f250fc5e6da0",
+  artifactRef: {
+    kind: "repo-blob-at-commit" as const,
+    repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+    commitSha: "25934fda4591e2047bd66ac799a1e024353f03cd",
+    path: "docs/superpowers/specs/2026-08-24-platform-sbom-currency-consolidation-design.md",
+    providerBlobId: "3652f3d223fa8eb9a2a4873de7d65a8222f114c6",
+  },
+};
+
+const evidenceWriterSchema = {
+  type: "object",
+  properties: {
+    itemId: { type: "string" },
+    gate: { type: "string" },
+    decision: { type: "string", enum: ["pass", "fail", "not-applicable"] },
+    artifactRef: { type: "object" },
+    reason: { type: "string" },
+    findings: { type: "array" },
+    resolvedFindingRefs: { type: "array" },
+    operation: { type: "string", enum: ["gate-receipt", "objective-mapping"] },
+    baselineId: { type: "string" },
+    objectiveMappings: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          objectiveId: { type: "string" },
+          evidenceRefs: { type: "array", items: { type: "string" } },
+        },
+        required: ["objectiveId", "evidenceRefs"],
+      },
+    },
+  },
+  required: ["itemId", "reason"],
+};
+
+describe("narrowInitiativeReviewTools", () => {
+  it("exposes only the complete objective-mapping proposal on the bound evidence writer", () => {
+    const reader: ToolDefinition = {
+      name: "read_source_at_version",
+      description: "Read immutable source.",
+      requiredCapability: "manage_backlog",
+      inputSchema: { type: "object", properties: {} },
+    };
+    const writer: ToolDefinition = {
+      name: binding.writerToolName,
+      description: "Record initiative evidence.",
+      requiredCapability: "manage_backlog",
+      inputSchema: evidenceWriterSchema,
+    };
+    const narrowed = narrowInitiativeReviewTools({
+      tools: [reader, writer],
+      toolsForProvider: [
+        { type: "function", function: { name: reader.name, parameters: reader.inputSchema } },
+        { type: "function", function: { name: writer.name, parameters: writer.inputSchema } },
+      ],
+      deferredTools: [],
+    }, [reader.name, writer.name], binding);
+
+    const expectedWriterSchema = {
+      type: "object",
+      properties: {
+        operation: { type: "string", enum: ["objective-mapping"] },
+        baselineId: evidenceWriterSchema.properties.baselineId,
+        objectiveMappings: evidenceWriterSchema.properties.objectiveMappings,
+        reason: evidenceWriterSchema.properties.reason,
+      },
+      required: ["operation", "baselineId", "objectiveMappings", "reason"],
+      additionalProperties: false,
+    };
+    const narrowedWriter = narrowed.tools.find((tool) => tool.name === writer.name);
+    const providerWriter = narrowed.toolsForProvider.find((tool) => {
+      const fn = tool["function"] as Record<string, unknown> | undefined;
+      return fn?.["name"] === writer.name;
+    });
+
+    expect(narrowedWriter?.inputSchema).toEqual(expectedWriterSchema);
+    expect((providerWriter?.["function"] as Record<string, unknown>)?.["parameters"])
+      .toEqual(expectedWriterSchema);
+  });
+});

--- a/apps/web/lib/mcp-task-review-contract.ts
+++ b/apps/web/lib/mcp-task-review-contract.ts
@@ -104,16 +104,20 @@ export function narrowInitiativeReviewTools<T extends {
   const exactNames = new Set(requiredNames);
   const compactResearchReceipt = binding.gate === "research"
     && binding.writerToolName === "record_initiative_evidence";
-  const baseJudgmentNames = compactResearchReceipt
-    ? ["decision"]
-    : ["decision", "reason", "findings", "resolvedFindingRefs"];
-  const judgmentPropertyNames = [
-    ...baseJudgmentNames,
+  const objectiveMappingProposal = binding.gate === "objective-mapping"
+    && binding.writerToolName === "record_initiative_evidence";
+  const baseWriterNames = objectiveMappingProposal
+    ? ["operation", "baselineId", "objectiveMappings", "reason"]
+    : compactResearchReceipt
+      ? ["decision"]
+      : ["decision", "reason", "findings", "resolvedFindingRefs"];
+  const writerPropertyNames = [
+    ...baseWriterNames,
     ...(binding.gate === "spec-approval" ? ["profile", "artifactRole", "supersessionDispositions"] : []),
     ...(binding.gate === "classification" ? ["profile"] : []),
   ];
-  const requiredJudgmentNames = [
-    ...baseJudgmentNames,
+  const requiredWriterNames = [
+    ...baseWriterNames,
     ...(binding.gate === "spec-approval" ? ["profile", "artifactRole"] : []),
     ...(binding.gate === "classification" ? ["profile"] : []),
   ];
@@ -122,12 +126,17 @@ export function narrowInitiativeReviewTools<T extends {
       ? schema.properties as Record<string, unknown>
       : {};
     const narrowedProperties = Object.fromEntries(
-      judgmentPropertyNames.flatMap((name) => name in properties ? [[name, properties[name]]] : []),
+      writerPropertyNames.flatMap((name) => name in properties ? [[name, properties[name]]] : []),
     );
     return {
       type: "object",
-      properties: narrowedProperties,
-      required: requiredJudgmentNames,
+      properties: objectiveMappingProposal
+        ? {
+            ...narrowedProperties,
+            operation: { type: "string", enum: ["objective-mapping"] },
+          }
+        : narrowedProperties,
+      required: requiredWriterNames,
       additionalProperties: false,
     };
   };


### PR DESCRIPTION
## Outcome

Expose the complete, exact objective-mapping proposal payload to an immutable external Portfolio review while keeping initiative identity, artifact identity, authority, and approval server-owned.

## Change

- add a dedicated objective-mapping writer branch with operation pinned to objective-mapping
- expose only operation, baselineId, objectiveMappings, and reason
- preserve research, classification, spec-approval, reader binding, and additionalProperties=false behavior
- add a focused direct contract test for both internal and provider schemas

## Verification

- RED reproduced: objective-mapping binding exposed generic judgment fields and omitted mapping payload
- GREEN: 5 affected/adjacent Vitest files, 27 tests passed
- web typecheck passed
- git diff check passed
- style/token drift guards passed
- pre-commit gitleaks and scoped typecheck passed
- pregate preflight: 61 guards clean, one environment-skipped PR-health probe

Semantic review: INCONCLUSIVE with 0 issues; review-branch-capacity-or-transport-failure. Receipt is preserved and not represented as PASS.

Local-CI-Override: operator-emergency: admitted exact-tree lease NPEL-14DC474580 was fenced by host-memory-low at image export after tests and production compile; non-PASS evidence cmtg9khyy03ju01kwm5mm0uye; all protected checks remain mandatory.

Process-Spine-Decision: Extends existing BI-F48 AC-F48-008 objective-mapping architecture; no new product or user-facing documentation surface.