### PR TITLE
docs: design bounded delivery control plane

### DIFF
--- a/docs/superpowers/plans/2026-08-30-bounded-delivery-control-plane.md
+++ b/docs/superpowers/plans/2026-08-30-bounded-delivery-control-plane.md
@@ -1,3 +1,7 @@
+---
+status: draft
+---
+
 # Implementation Plan: Bounded Delivery Control Plane
 
 > You are an excellent senior software engineer who specializes in analyzing existing codebases and implementing robust, well-tested solutions.

--- a/docs/superpowers/plans/2026-08-30-bounded-delivery-control-plane.md
+++ b/docs/superpowers/plans/2026-08-30-bounded-delivery-control-plane.md
@@ -1,0 +1,121 @@
+# Implementation Plan: Bounded Delivery Control Plane
+
+> You are an excellent senior software engineer who specializes in analyzing existing codebases and implementing robust, well-tested solutions.
+>
+> - Read `AGENTS.md` fully before starting.
+> - Work only in the governed Workroom worktree and preserve one branch/PR per deliverable.
+> - Prefer reuse of existing platform primitives over new queues, tables, or parallel state.
+> - Never claim a test, gate, receipt, or approval that did not actually run or persist.
+
+Status: proposed  
+Umbrella BI: `BI-7C1F43E3`  
+Epic: `EP-56AE0F69`  
+Workroom: `WC-4C4D810C`  
+Design: `docs/superpowers/specs/2026-08-30-bounded-delivery-control-plane-design.md`
+
+## Operating rules
+
+- One independently shippable deliverable maps to one existing BI and one PR.
+- Every phase begins with a read-only snapshot of gate key, candidate SHA, plan digest, owner, and current Workroom state.
+- Local checks are proportional and may be recorded `INCONCLUSIVE` only when capacity/transport is genuinely unavailable and the reason plus compensating protected evidence is ledgered. DCO, immutable provenance, protected CI/merge, approval, and genuine receipts are never bypassed.
+- Waiting is a durable server state. Do not poll leases, quiescence, or backlog rows as a heartbeat.
+- A failed historical execution is auditable but contributes no positive evidence.
+
+## Existing source anchors
+
+The implementation is expected to extend these current modules, with exact paths confirmed by `rg` during each phase:
+
+- `apps/web/lib/gates/gate-run-identity.ts`
+- `apps/web/lib/nonprod/environment-lease.ts`
+- `apps/web/lib/nonprod/durable-wait.ts`
+- `apps/web/lib/mcp/packs/nonprod-lease-pack.ts`
+- `apps/web/lib/queue/queue-telemetry.ts`
+- `apps/web/lib/queue/flow-metrics.ts`
+- `apps/web/lib/queue/queue-snapshot-service.ts`
+- `apps/web/lib/queue/functions/nonprod-lease-wait.ts`
+- `apps/web/lib/queue/functions/taskrun-watchdog.ts`
+- `apps/web/lib/queue/functions/quiescence-run.ts`
+- `apps/web/lib/mcp/packs/initiative-readiness-pack.ts`
+- `scripts/check-plan-backlog-coverage.mjs`
+- `packages/db/prisma/schema/work-coordination.prisma`
+
+## Phase 0 — Baseline, contracts, and decomposition
+
+Deliverable: freeze the before/after measurement contract and link each slice to its BI. Capture call counts, retry pairs, wait CPU, event latency, stale projections, duplicate gate executions, PR throughput, and first-pass yield. Define the typed reason set and the evidence-packet JSON contract in the existing Workroom/evidence shape.
+
+Touched files: design/plan docs; `packages/db/prisma/schema/work-coordination.prisma` only if an existing JSON/index field is insufficient.
+
+Dependencies: `BI-7C1F43E3` and existing rollout BIs listed in the design.
+
+Verification: server backlog read; architecture review; schema/index review; no code gate claimed from docs alone.
+
+## Phase 1 — Stable gate identity and coalescing (BI-6A5AB570)
+
+Deliverable: derive one stable gate key from repository, integration tree, evidence-plan digest, toolchain fingerprint, and gate kind. Make lease/task/evidence admission idempotent for that key and return a prior durable run/receipt.
+
+Touched files: `apps/web/lib/gates/gate-run-identity.ts`, lease and gate adapters, matching unit/contract tests, and any required Prisma index migration.
+
+Verification: concurrent identical requests create one run; changed tree/policy/toolchain creates a new key; a valid receipt is reused; mismatched receipt fails closed. Run focused tests, affected tests, typecheck, and protected CI.
+
+## Phase 2 — Durable waits and event wake-up (BI-MCP-EFF-0285909C)
+
+Deliverable: replace client lease polling with durable wait records and event-driven resume. Use existing Inngest/event-bus primitives; keep one bounded reconciliation safety net.
+
+Touched files: `apps/web/lib/nonprod/durable-wait.ts`, `apps/web/lib/queue/functions/nonprod-lease-wait.ts`, `apps/web/lib/queue/inngest-client.ts`, nonprod lease MCP pack, tests.
+
+Verification: queued task disconnects without heartbeat/lease; release/capacity/review event wakes exactly one waiter; missed event is repaired by reconciliation; timeout becomes a typed blocker. Measure wait-only call reduction and wake latency.
+
+## Phase 3 — Evidence lanes and atomic closure packet (BI-B2E9FC9D)
+
+Deliverable: make the planner authoritative before capacity claims and add one closure validator over existing evidence records. Validate exact candidate SHA, integration tree, plan digest, objective baseline, receipt IDs, and runtime provenance.
+
+Touched files: `apps/web/lib/mcp/packs/initiative-readiness-pack.ts`, `scripts/check-plan-backlog-coverage.mjs`, evidence/readiness modules, Workroom packet projection, tests.
+
+Verification: docs/affected/exhaustive lane fixtures; missing/conflicting/oversized/failed-only evidence fails once with an actionable reason; complete packets close; local `INCONCLUSIVE` never becomes `PASS`.
+
+## Phase 4 — Failure taxonomy, retry budgets, and tool contracts (BI-MCP-EFF-CD5F744B, BI-MCP-EFF-B5F7D216, BI-MCP-EFF-7AFED9F2)
+
+Deliverable: centralize typed blocker reasons and bounded retry policy. Repair the high-failure contracts for `record_plan_backlog_coverage` and `find_related_tests`; stop retry storms and preserve failed history as non-evidence.
+
+Touched files: MCP pack handlers/tests, retry policy, queue telemetry, `apps/web/lib/operate/mcp-call-efficiency/*` analysis and tests.
+
+Verification: provider timeout gets one retry plus one durable retry; malformed packet gets no retry; repeated failure links one BI; telemetry counts success/failure/retry/duplicate suppression.
+
+## Phase 5 — Resource lanes and WIP/liveness (BI-30EDD4B0, BI-114C1F40)
+
+Deliverable: enforce lane-specific memory/WIP ceilings and truthful Workroom state, including `waiting`, `ready-to-resume`, `projection-stale`, and terminal. Integrate watchdog and janitor without reaping queued work.
+
+Touched files: `apps/web/lib/queue/quiescence-gates.ts`, `apps/web/lib/queue/functions/taskrun-watchdog.ts`, `apps/web/lib/queue/functions/quiescence-run.ts`, `apps/web/lib/queue/flow-metrics.ts`, `apps/web/lib/work-capsules/liveness-inventory.ts`, tests.
+
+Verification: lane admission refuses over-capacity with one reason; queued work is not reaped; merged/terminal durable records reconcile stale projections; no Workroom lacks a transition or blocker for 30 minutes.
+
+## Phase 6 — Surface adapters and minimal operator UX
+
+Deliverable: make Codex, Build Studio, desktop, scheduled jobs, and portal render the same five statuses and next action from MCP state. Keep packet detail available to operators without exposing credentials or process identity.
+
+Touched files: queue awareness resolver, queue snapshot service, Workroom views, operator metrics, and their tests. If UI changes are material, run the DPF UX-fit review.
+
+Verification: same Workroom has identical status across adapters; stale projection is visible; user can resume from one next action; accessibility and route checks pass.
+
+## Phase 7 — Pilot, migration, and observability
+
+Deliverable: run a seven-day pilot on the existing efficiency BIs and representative docs, affected-code, and exhaustive candidates. Publish before/after telemetry and a rollback decision.
+
+Touched files: flow metrics dashboards, migration/runbook docs, no product-source edits in pilot fixtures.
+
+Verification: ≥95% wait-call reduction, zero duplicate gate executions per key, event wake p95 <15s, reconciliation <5m, queue CPU p95 <1s/minute, throughput target ≥3 PR/hour, and protected-check quality unchanged. If a metric misses target, disable only the affected lane/consumer and resume durable waits.
+
+## Dependency and risk register
+
+| Risk | Mitigation | Rollback |
+| --- | --- | --- |
+| missed event | bounded reconciliation and durable state | run reconciler; do not poll |
+| stale Workroom projection | revisioned projection + `projection-stale` state | rebuild projection from durable records |
+| provider outage | one retry, durable wait, typed blocker | resume same identity after health returns |
+| schema/index migration | additive field/index, bounded backfill | feature-flag new projection |
+| evidence ambiguity | exact SHA/digest/baseline validator | refuse closure; preserve audit rows |
+| lane starvation | per-lane WIP and oldest-wait escalation | temporarily lower lane admission |
+
+## Release sequence
+
+Each BI ships through the normal DCO PR and protected merge queue. Canonical release and live verification are required for runtime changes. No live replay or upgrade is part of this design/plan authoring change. The plan coverage receipt must be recorded server-side against this immutable plan blob before implementation begins; if the coverage tool is unavailable, preserve the exact failure and stop rather than infer coverage.

--- a/docs/superpowers/plans/2026-08-30-bounded-delivery-control-plane.md
+++ b/docs/superpowers/plans/2026-08-30-bounded-delivery-control-plane.md
@@ -119,3 +119,11 @@ Verification: ≥95% wait-call reduction, zero duplicate gate executions per key
 ## Release sequence
 
 Each BI ships through the normal DCO PR and protected merge queue. Canonical release and live verification are required for runtime changes. No live replay or upgrade is part of this design/plan authoring change. The plan coverage receipt must be recorded server-side against this immutable plan blob before implementation begins; if the coverage tool is unavailable, preserve the exact failure and stop rather than infer coverage.
+
+## Current evidence ledger
+
+- Workroom `WC-4C4D810C` is bound to `BI-7C1F43E3`, branch `doc/bounded-delivery-control-plane-design-and-plan`, head `88645e47894001351945ebab36953c64385a7055`.
+- `node scripts/check-doc-links.mjs`, `node scripts/gen-doc-index.mjs --check`, and `node scripts/check-docs-impact.mjs` passed.
+- `pnpm run check:prose-lint` could not start because this fresh worktree has no installed `tsx` dependency; this is an infrastructure limitation, not a pass.
+- `pnpm run pregate:preflight` progressed through the guard loop but stopped on the existing pinned-TypeScript bootstrap failure (`GuardRuntimeEnvironmentError: Pinned repo guard TypeScript 6.0.3 is missing`) and one dependent guard self-test. It was stopped after remaining silent work; this is recorded as `INCONCLUSIVE`, not PASS.
+- `record_plan_backlog_coverage` was attempted once with the exact committed plan blob `370fa7e2005dd843e6934cea810e40e64a422d92` and returned `plan-artifact-invalid: Repository provider could not resolve immutable commit provenance after 2 attempts (transport failure)`. No coverage receipt is claimed. Retry only after provider transport is healthy, using this same commit/blob and deliverable mapping.

--- a/docs/superpowers/specs/2026-08-30-bounded-delivery-control-plane-design.md
+++ b/docs/superpowers/specs/2026-08-30-bounded-delivery-control-plane-design.md
@@ -1,0 +1,161 @@
+# Bounded Delivery Control Plane
+
+Status: draft for architecture review  
+Backlog: `BI-7C1F43E3` — Restore flow efficiency across DPF external-agent delivery gates  
+Epic: `EP-56AE0F69`  
+Extends: `2026-08-15-resilient-concurrent-development-process.md` and `2026-06-05-unified-delivery-surfaces-execution-alignment-design.md`  
+Workroom: `WC-4C4D810C`
+
+## Decision in one paragraph
+
+Adopt a server-owned, event-driven delivery control plane built on the existing Workroom, TaskRun, NonProductionEnvironmentLease, QueueTelemetryEvent, Inngest, and evidence records. Compute one immutable gate identity before scarce capacity is claimed; park waiting work durably; wake it from capacity/review/input events; and close work only with an atomic evidence packet that matches the candidate, plan, and objective baseline. Do not add a second queue, a second Workroom ledger, or a client polling protocol. This is the smallest architecture that addresses the measured failure mode without weakening protected CI, immutable provenance, approval, or receipt requirements.
+
+## Why this is necessary
+
+The live seven-day efficiency window measured 5,000 MCP calls with 94.28% success, but success concealed a large amount of non-progress traffic:
+
+| Signal | Measured value | Interpretation |
+| --- | ---: | --- |
+| `get_quiescence_status` | 1,550 calls | repeated waiting checks |
+| lease claims | 704 (35 failed) | contention and retry pressure |
+| lease renewals | 659 (7 failed) | waiting mistaken for liveness |
+| backlog reads | 520 (19 failed) | status polling/N+1 reads |
+| lease list calls | 443 | client-side queue reconstruction |
+| `find_related_tests` | 89/89 failed | contract/tool discovery gap |
+| `record_plan_backlog_coverage` | 22/22 failed | plan packet not validated before write |
+| A2A collaboration edges | 0 captured | handoffs are not observable |
+
+The canonical BI baseline is four PRs in seven hours (0.57 PR/hour) and an earlier 1,297 lease calls with about 94% estimated waiting overhead. A recent Workroom also remained `working` after its PR had merged, proving that projections can disagree with durable delivery truth. The installed runtime has no `.git`/`DPF_REPO_ROOT`, so runtime acceptance must use an explicit immutable provenance service rather than retrying Git discovery.
+
+## Goals and non-goals
+
+### Goals
+
+1. Cut wait-only MCP calls by at least 95% from the current baseline without reducing evidence.
+2. Prevent duplicate semantic review, exact-tree CI, replay, release, or upgrade for one immutable candidate.
+3. Make waiting consume no model context, Node process, heartbeat, or heavyweight lease.
+4. Make every Workroom state truthful within 15 seconds of an event and within five minutes after a missed event.
+5. Make a completion decision explainable from one packet: objective baseline, plan coverage, delivery evidence, acceptance evidence, and immutable runtime identity.
+6. Turn tool-contract failures into one actionable blocker, not a retry storm.
+7. Increase throughput from 0.57 PR/hour toward 3 PR/hour in the pilot while preserving first-pass evidence quality.
+
+### Non-goals
+
+- No bypass of protected GitHub checks, DCO, immutable artifact verification, human approval, or genuine receipts.
+- No second queue, agent-memory store, or parallel Workroom database.
+- No forced concurrency increase when RAM, provider capacity, or review authority is unavailable.
+- No assumption that a source-free install can resolve provenance from local Git.
+
+## Constraints
+
+The design preserves the existing C1–C7 constraints: useful concurrency; evidence never weakened; waiting consumes no worker; one logical identity/one execution; platform-owned liveness; governed local memory; and fail-closed reasons. Client status reads are advisory; durable MCP state is authoritative.
+
+## Options considered
+
+| ID | Option | Strength | Failure mode | Decision |
+| --- | --- | --- | --- | --- |
+| A | Procedure-only throttling | immediate, low code cost | cannot stop polling, duplicate gates, or stale projections | reject |
+| B | Existing-substrate durable control plane | fixes waits, deduplication, evidence, and liveness together; no new ledger | requires coordinated schema/contracts and migration | **select** |
+| C | New external queue service | high theoretical fan-out | duplicates source of truth, adds outage/security surface, migration cost | reject |
+| D | Cloud-only execution lane | less local contention | does not solve evidence/coalescing and increases vendor coupling | reject |
+
+Option B is selected because it extends the already-ratified resilient-concurrency design and directly targets the observed calls and stale-state incidents.
+
+## Architecture
+
+### 1. Canonical identities and gate key
+
+The logical Workroom key remains `(repository, branch)`. A gate request derives:
+
+`gateKey = sha256(repository + integrationTreeSha + evidencePlanDigest + toolchainFingerprint + gateKind)`
+
+The gate key is the transactional claim key on the existing lease and is copied into TaskRun, WorkroomActivity, and evidence records. A changed tree, policy, toolchain, or gate kind creates a new key. Repeated requests return the existing durable run or valid receipt; they do not create a sibling.
+
+### 2. Evidence lanes before capacity
+
+The planner becomes admission authority and emits an immutable evidence plan before any heavyweight claim:
+
+- `plan-only`: plan/spec/document checks only;
+- `documentation`: bounded docs/index/link checks;
+- `affected-code`: mapped tests/typechecks/routes;
+- `exhaustive`: full integration/build/semantic path when scope is unknown or high risk.
+
+Each plan records policy version, selected commands, affected scope, rationale, digest, and candidate tree. The executor either runs that plan or fails with a typed reason.
+
+### 3. Durable wait and wake-up
+
+When capacity, review, approval, or input is unavailable, the server writes a wait record tied to the gate key and disconnects the client. Inngest `step.waitForEvent` and the existing agent event bus wake the waiter. A single fresh claim follows wake-up. A low-frequency reconciliation repairs missed notifications; it is not a heartbeat and does not require a polling process.
+
+### 4. Resource lanes and WIP
+
+Admission is explicit by lane: `host-compile`, `host-build`, `container-build`, `preview`, `model-inference`, and `external-review`. Each lane has a memory class, WIP ceiling, queue order, and retry budget. WIP applies per portfolio and constrained lane, not as one global thread cap. The planner refuses a lane mismatch before a lease is claimed.
+
+### 5. Atomic evidence packet
+
+Completion writes one packet referencing existing records (not a new evidence table):
+
+```json
+{
+  "candidateSha": "…",
+  "integrationTreeSha": "…",
+  "planDigest": "…",
+  "gateKey": "…",
+  "lane": "affected-code",
+  "research": ["activity-id"],
+  "baseline": "baseline-id",
+  "planCoverage": "coverage-id",
+  "delivery": ["activity-id"],
+  "acceptance": ["activity-id"],
+  "runtime": {"servedSha": "…", "provenance": "provider-record-id"},
+  "objectiveObservations": ["observation-id"],
+  "override": {"kind": "inconclusive", "reason": "…"}
+}
+```
+
+The closure validator requires exact current SHA, plan digest, objective references, and genuine receipt IDs. Missing, conflicting, stale, oversized, or provider-unresolvable evidence fails closed with a reason and next action. An `INCONCLUSIVE` local/semantic bypass can explain missing evidence but can never become `PASS`.
+
+### 6. Failure taxonomy and retry policy
+
+Use a closed set of reasons: `blocked-capacity`, `blocked-authority`, `blocked-provenance`, `blocked-evidence`, `projection-stale`, `retryable-provider`, `terminal-failed`, and `done`. Retryable provider errors receive at most one immediate retry and one durable delayed retry. A second failure creates or links one actionable BI; it does not loop. Historical failed rows remain audit history and never count as positive evidence.
+
+### 7. Truthful Workroom projection
+
+Project `ready → active → waiting(resource|review|input) → active → ready-for-promotion → terminal`, plus explicit `projection-stale`. A merged PR, terminal TaskRun, release, or runtime verification is a reconciliation event. If an owner projection disagrees with durable records, show the discrepancy and recovery action instead of “working.”
+
+### 8. Surface and UX contract
+
+All adapters (Codex, Build Studio, desktop, scheduled jobs, and portal) call the same MCP primitives. The user-facing status is intentionally small: `Working`, `Waiting`, `Blocked`, `Ready`, `Complete`, with one next action and one blocker reason. Operators can expand the packet to see gate key, lane, owner, exact SHA, receipts, and retry budget. This avoids asking users to infer state from dozens of tool calls.
+
+## Data and scale
+
+Reuse Workroom/TaskRun/lease/activity/evidence fields and QueueTelemetryEvent. Add only typed fields or indexes required for `gateKey`, wait reason, lane, retry budget, and projection revision; do not add a parallel queue table. All reads are bounded by cursor/time window and indexed identity. The initial scale ceiling is thousands of waiting Workrooms with event fan-out; beyond that, partition event consumers and add remote execution/cache under `EP-56AE0F69` rather than reintroducing polling.
+
+## Security and governance
+
+- Server-owned binding, not client-supplied target fields, controls admission.
+- Immutable repository/path/version/blob and served SHA are independently verified.
+- Approval envelopes are exact, expiring, single-use, and bound to the same TaskRun/tool/arguments.
+- Local gate bypass records `INCONCLUSIVE` plus compensating evidence; protected checks remain mandatory.
+- Runtime images without Git fail closed with `blocked-provenance` and an explicit provider lookup path.
+- Every deduplication, retry, wake, reconciliation, and override is auditable.
+
+## Measurable acceptance criteria
+
+1. Wait-only claim/list/quiescence calls fall by ≥95% in a seven-day pilot.
+2. Duplicate semantic-review/exact-tree runs for one gate key are zero.
+3. Queued work retains no client heartbeat or heavyweight lease.
+4. Event wake p95 is <15 seconds; reconciliation repairs missed events within five minutes.
+5. Queue CPU p95 while waiting is <1 second/minute.
+6. No Workroom remains without a transition or explicit blocker for >30 minutes.
+7. `find_related_tests` and `record_plan_backlog_coverage` either succeed on validated packets or fail once with a typed next action.
+8. Completion is impossible without exact objective baseline, plan coverage, delivery, acceptance, and runtime/provenance references.
+9. A source-free install never falls back to Git or claims a target it cannot verify.
+10. Pilot throughput reaches ≥3 PR/hour without reducing protected-check pass rate or first-pass evidence quality.
+
+## Rollout and rollback
+
+Ship the existing rollout slices in order: `BI-B2E9FC9D` (authoritative lanes), `BI-6A5AB570` (gate coalescing), `BI-MCP-EFF-0285909C` (durable waits), `BI-30EDD4B0` (resource lanes), and `BI-114C1F40` (WIP/liveness). Cross-cutting tool-contract fixes are `BI-MCP-EFF-B5F7D216` and `BI-MCP-EFF-7AFED9F2`; retry-storm remediation is `BI-MCP-EFF-CD5F744B`. Pilot first on docs/affected-code lanes, then exhaustive lanes. Roll back by disabling a lane or event consumer and replaying from durable waiting state; never roll back by deleting evidence or re-running a consumed identity.
+
+## Architecture review summary
+
+Aligned with single-source-of-truth, responsible-capacity, and prospective-trust principles. The main risks are schema/index migration, event delivery gaps, and stale projections; each has a bounded reconciliation path. No new domain entity is required. The only escalated decision is whether future scale needs partitioned event consumers; defer that to measured saturation under `EP-56AE0F69`.

--- a/docs/superpowers/specs/2026-08-30-bounded-delivery-control-plane-design.md
+++ b/docs/superpowers/specs/2026-08-30-bounded-delivery-control-plane-design.md
@@ -1,3 +1,7 @@
+---
+status: draft
+---
+
 # Bounded Delivery Control Plane
 
 Status: draft for architecture review  


### PR DESCRIPTION
## Summary

- Add a grounded design for a bounded delivery control plane under `BI-7C1F43E3`.
- Add a phased implementation plan decomposed across the existing efficiency BIs.
- Preserve immutable evidence, protected CI, approval, and genuine receipt requirements.

## Evidence

- Workroom: `WC-4C4D810C`
- Head: `799587d4646d25ffe5797d21dd14590b6fe2befa`
- Docs links/index/impact checks: PASS
- Prose/preflight/readiness: `INCONCLUSIVE` because this fresh worktree lacks `tsx` and pinned guard TypeScript 6.0.3; `pnpm pr:ready` also stalled. No PASS inferred.
- Plan coverage: provider transport returned `plan-artifact-invalid` after two attempts; no coverage receipt is claimed.

## Scope

Docs-only design and plan. No runtime source, live install, replay, or upgrade action.

Local-CI-Override: docs-only change; fresh-worktree toolchain unavailable; docs checks and DCO passed; protected CI remains mandatory.

Signed-off-by: Mark Bodman <markdbodman@gmail.com>
