### PR TITLE
fix(pregate): make local-CI diagnostic verdicts honest

### DIFF
--- a/scripts/ci-build-artifact-workflow.test.mjs
+++ b/scripts/ci-build-artifact-workflow.test.mjs
@@ -113,6 +113,24 @@ describe("production-build artifact workflow wiring", () => {
     );
   });
 
+  it("keeps branch-protection required contexts reporting on exact-tree reuse (BI-DAF33DF3)", () => {
+    const mergeJob = ci.match(/merge-readiness:[\s\S]*?(?=\n  [a-z0-9-]+:|\n*$)/)?.[0] || "";
+    assert.match(mergeJob, /name: Merge Readiness/);
+    assert.match(mergeJob, /if: always\(\)/);
+    assert.doesNotMatch(
+      mergeJob,
+      /reusable != 'true'/,
+      "Merge Readiness must still report when exact-tree reuse skips heavy jobs",
+    );
+    const uxJob = ci.match(/ux-route-sweep:\s*\n\s+name: UX Route Budget Sweep[\s\S]*?(?=\n  [a-z0-9-]+:|\n*$)/)?.[0] || "";
+    assert.match(uxJob, /if: always\(\)/);
+    assert.doesNotMatch(
+      uxJob,
+      /reusable != 'true'/,
+      "UX Route Budget Sweep must still report on the reuse path",
+    );
+  });
+
   it("grants only read access to workflow artifacts", () => {
     assert.match(ci, /permissions:[\s\S]*?actions: read[\s\S]*?contents: read/);
     assert.match(ux, /permissions:[\s\S]*?actions: read[\s\S]*?contents: read/);

--- a/scripts/gate-worktree.mjs
+++ b/scripts/gate-worktree.mjs
@@ -59,7 +59,7 @@ export function describeLeaseCallFailure(error) {
     + "if this box regularly runs several gates at once";
 }
 import { summarizeLocalCiOutput } from "./lib/local-ci-failure-summary.mjs";
-import { classifyGateOutcome } from "./lib/sandbox-freshness.mjs";
+import { classifyGateOutcome, EXIT_CHILD_SIGNAL_DEATH } from "./lib/sandbox-freshness.mjs";
 import { fallbackStatusForUnknown } from "./lib/local-integration-status.mjs";
 import {
   authoritySafetyMarginMs,
@@ -88,6 +88,7 @@ import { classifyBaseResilience } from "./lib/local-ci-base-freshness.mjs";
 import { runPreAdmissionDocumentationLane } from "./lib/documentation-evidence-lane.mjs";
 import {
   createLocalCiPassEvidenceValidity,
+  projectReusedPassMetadata,
   readLocalCiGateState,
   writeLocalCiGateState,
 } from "./lib/local-ci-gate-state.mjs";
@@ -1270,6 +1271,25 @@ async function main() {
         ],
         evidencePending: false,
       });
+      // BI-C6B2D404: project current HEAD onto the metadata record so
+      // pregate:status does not report STALE against the prior candidateSha.
+      if (passed && metadataFile) {
+        let prior = null;
+        try {
+          prior = JSON.parse(readFileSync(metadataFile, "utf8"));
+        } catch {
+          prior = null;
+        }
+        writeFileSync(
+          metadataFile,
+          `${JSON.stringify(projectReusedPassMetadata(prior, {
+            sha,
+            branch,
+            evidenceId,
+            leaseId: canonicalLeaseId,
+          }), null, 2)}\n`,
+        );
+      }
       process.stdout.write(`reused canonical local-CI ${admission.resultClass} evidence: ${evidenceId}\n`);
       process.exit(passed ? 0 : 1);
     }
@@ -1787,7 +1807,7 @@ async function main() {
     process.stderr.write(`gate-worktree: lease fenced (${supervised.reason}); child process tree terminated\n`);
   }
   if (receivedSignal) {
-    runResult.status = 130;
+    runResult.status = EXIT_CHILD_SIGNAL_DEATH;
     runResult.output = `${runResult.output}\ngate-worktree: received ${receivedSignal}; child process tree terminated\n`;
     process.stderr.write(`gate-worktree: received ${receivedSignal}; child process tree terminated\n`);
   }
@@ -2015,6 +2035,12 @@ async function main() {
     die(`failed to record local integration evidence: ${JSON.stringify(evidenceResponse)}`);
   }
 
+  const capturedFailureCount = (failureSummary?.failedTests?.length || 0)
+    + (failureSummary?.failedChecks?.length || 0);
+  const persistedReason = outcome.summary
+    || (capturedFailureCount === 0 && runResult.status
+      ? `no stage failed; child exited ${runResult.status} after the last completed stage`
+      : "");
   writeState(stateFile, {
     branch,
     sha,
@@ -2028,6 +2054,9 @@ async function main() {
     resilience,
     leaseEvents,
     evidencePending: false,
+    failureReason: persistedReason,
+    failureSummary,
+    childExitCode: runResult.status,
   });
 
   // BI-B1065D41 Phase 1: one bounded, stable block closes every run. On a pass
@@ -2063,6 +2092,11 @@ async function main() {
     process.stderr.write(`gate-worktree: BLOCKED (control-plane starvation): ${outcome.summary}\n`);
     process.exit(5);
   }
+  if (outcome.status === "blocked_child_signal_death") {
+    process.stderr.write(`gate-worktree: BLOCKED (child signal death): ${outcome.summary}\n`);
+    process.stderr.write("gate-worktree: this is infrastructure evidence, not a product failure; retry on a quieter host\n");
+    process.exit(EXIT_CHILD_SIGNAL_DEATH);
+  }
   die("gate failed");
 }
 
@@ -2084,6 +2118,9 @@ function writeState(stateFile, {
   recovery = null,
   queueObserver = null,
   admission = null,
+  failureReason = "",
+  failureSummary = null,
+  childExitCode = null,
 }) {
   writeLocalCiGateState(stateFile, {
     branch,
@@ -2103,6 +2140,9 @@ function writeState(stateFile, {
     recovery,
     queueObserver,
     admission,
+    failureReason,
+    failureSummary,
+    childExitCode,
   });
 }
 

--- a/scripts/lib/local-ci-failure-summary.mjs
+++ b/scripts/lib/local-ci-failure-summary.mjs
@@ -3,13 +3,40 @@ import { fileURLToPath } from "node:url";
 
 const DEFAULT_MAX_ENTRIES = 12;
 
+function stripAnsi(line) {
+  return String(line ?? "").replace(/\x1B\[[0-9;]*m/g, "");
+}
+
 function normalizeLine(line) {
-  return String(line ?? "").replace(/\s+/g, " ").trim();
+  return stripAnsi(line).replace(/\s+/g, " ").trim();
 }
 
 function makeEntry(line, index) {
   const text = normalizeLine(line);
   return text ? { line: index + 1, text } : null;
+}
+
+function isPassingLine(text) {
+  // BI-FBB86A69: a line that already classified as pass is never a failure,
+  // even when the test *title* contains the substring FAIL (FAIL-SAFE,
+  // "detects an ANSI FAIL marker line").
+  return /^[✓✔√]/.test(text) || /^(PASS|ok)\b/.test(text);
+}
+
+function isFailedTestLine(text) {
+  if (isPassingLine(text)) return false;
+  // Vitest prints FAIL at the start of the line, optionally after a status
+  // glyph. Matching FAIL anywhere (the old `\bFAIL\b`) treated passing titles
+  // that mention the word as failures.
+  if (/^(?:[×✕✖]\s+)?FAIL\b/.test(text)) return true;
+  if (/^❯\s+.*\.(test|spec)\.[cm]?[jt]sx?\b/.test(text)) return true;
+  return false;
+}
+
+function isFailedCheckLine(text) {
+  if (isPassingLine(text)) return false;
+  if (isFailedTestLine(text)) return false;
+  return /\b(Type error|TS\d{4}|Command failed|error Command failed|ELIFECYCLE|failed to solve|unhandled errors?|vitest-pool|Worker exited unexpectedly)\b/i.test(text);
 }
 
 export function summarizeLocalCiOutput(output, opts = {}) {
@@ -23,20 +50,14 @@ export function summarizeLocalCiOutput(output, opts = {}) {
     const text = normalizeLine(line);
     if (!text) continue;
 
-    const isFailedTest =
-      /\bFAIL\b/.test(text) ||
-      /^❯\s+.*\.(test|spec)\.[cm]?[jt]sx?\b/.test(text);
-    const isFailedCheck =
-      /\b(Type error|TS\d{4}|Command failed|error Command failed|ELIFECYCLE|Prisma schema|Dockerfile|failed to solve|unhandled errors?|vitest-pool|Worker exited unexpectedly)\b/i.test(text);
-
-    if (isFailedTest) {
+    if (isFailedTestLine(text)) {
       const entry = makeEntry(line, index);
       if (entry && failedTests.length < maxEntries) failedTests.push(entry);
       else omittedFailureLineCount += 1;
       continue;
     }
 
-    if (isFailedCheck) {
+    if (isFailedCheckLine(text)) {
       const entry = makeEntry(line, index);
       if (entry && failedChecks.length < maxEntries) failedChecks.push(entry);
       else omittedFailureLineCount += 1;

--- a/scripts/lib/local-ci-failure-summary.test.mjs
+++ b/scripts/lib/local-ci-failure-summary.test.mjs
@@ -42,4 +42,19 @@ describe("summarizeLocalCiOutput", () => {
     assert.match(summary.failedChecks[1].text, /vitest-pool/);
     assert.match(summary.failedChecks[2].text, /Worker exited unexpectedly/);
   });
+
+  test("does not treat FAIL inside a passing test title as a failure (BI-FBB86A69)", () => {
+    const summary = summarizeLocalCiOutput(`
+      ✓ lib/decision-perspective/evaluator.test.ts > FAIL-SAFE: lexical relevance escalates even when the apparent stance APPROVES
+      ✓ lib/build/coding-agent.test.ts > outputIndicatesTestFailure > detects an ANSI FAIL marker line
+       Test Files  2788 passed | 4 skipped (2792)
+            Tests  23925 passed | 17 skipped | 18 todo (23960)
+      [local-ci-vitest] classification=passed attempts=1 recovered=false
+      Prisma schema loaded from prisma/schema.
+    `);
+
+    assert.equal(summary.failedTests.length, 0);
+    assert.equal(summary.failedChecks.length, 0);
+    assert.equal(summary.omittedFailureLineCount, 0);
+  });
 });

--- a/scripts/lib/local-ci-gate-state.mjs
+++ b/scripts/lib/local-ci-gate-state.mjs
@@ -57,6 +57,9 @@ export function writeLocalCiGateState(stateFile, {
   recovery = null,
   queueObserver = null,
   admission = null,
+  failureReason = "",
+  failureSummary = null,
+  childExitCode = null,
 }) {
   const previous = readLocalCiGateState(stateFile);
   const retainedAdmission = admission ?? (
@@ -85,7 +88,38 @@ export function writeLocalCiGateState(stateFile, {
   if (recovery) payload.recovery = recovery;
   if (queueObserver) payload.queueObserver = queueObserver;
   if (retainedAdmission) payload.admission = retainedAdmission;
+  // BI-DBED32FE / BI-465B3D60: a failed or blocked record that cannot name
+  // its cause teaches people to re-run (or skip) the gate. Persist the
+  // structured summary so `pregate:status` can quote THIS run.
+  if (failureReason) payload.failureReason = failureReason;
+  if (failureSummary) payload.failureSummary = failureSummary;
+  if (childExitCode !== null && childExitCode !== undefined) payload.childExitCode = childExitCode;
   writeGateStateAtomically(stateFile, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+/**
+ * BI-C6B2D404. Canonical PASS reuse must project the CURRENT candidate onto
+ * the metadata record. Updating only dpf-local-ci-gate.json leaves
+ * candidateSha pointing at the prior run, and pregate:status then reports
+ * STALE for an identical tested tree.
+ */
+export function projectReusedPassMetadata(prior, { sha, branch, evidenceId, leaseId }) {
+  const previous = prior && typeof prior === "object" ? prior : {};
+  const previousExecution = previous.execution && typeof previous.execution === "object"
+    ? previous.execution
+    : {};
+  return {
+    ...previous,
+    candidateRef: branch,
+    candidateSha: sha,
+    reusedEvidenceId: evidenceId,
+    runLeaseId: leaseId || previous.runLeaseId || null,
+    execution: {
+      ...previousExecution,
+      status: "passed",
+      failedCommand: null,
+    },
+  };
 }
 
 function writeGateStateAtomically(stateFile, contents) {

--- a/scripts/lib/local-ci-gate-state.test.mjs
+++ b/scripts/lib/local-ci-gate-state.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   createLocalCiPassEvidenceValidity,
   isRecoverableInterruptedGateState,
+  projectReusedPassMetadata,
   readLocalCiGateState,
   writeLocalCiGateState,
 } from "./local-ci-gate-state.mjs";
@@ -52,6 +53,41 @@ test("local-CI gate state helper writes and reads the shared evidence shape", ()
   assert.equal(state.recovery.reason, "test");
   assert.equal(state.queueObserver.token, "observer-token");
   assert.equal(state.leaseExpiresAt, "2026-07-30T06:00:00.000Z");
+});
+
+test("a failed record persists the reason and structured summary (BI-DBED32FE, BI-465B3D60)", () => {
+  const stateFile = join(mkdtempSync(join(tmpdir(), "dpf-gate-reason-")), "gate.json");
+  writeLocalCiGateState(stateFile, {
+    branch: "fix/x",
+    sha: "a".repeat(40),
+    gatePassed: false,
+    leaseId: "NPEL-1",
+    evidenceId: "",
+    status: "failed",
+    expiresAt: "2026-08-30T06:00:00.000Z",
+    resilience: null,
+    leaseEvents: [],
+    failureReason: "no stage failed; child exited 1 after local-ci-vitest",
+    failureSummary: { schema: "dpf-local-ci-failure-summary/v1", failedTests: [], failedChecks: [] },
+    childExitCode: 1,
+  });
+  const state = readLocalCiGateState(stateFile);
+  assert.equal(state.failureReason, "no stage failed; child exited 1 after local-ci-vitest");
+  assert.equal(state.childExitCode, 1);
+  assert.equal(state.failureSummary.schema, "dpf-local-ci-failure-summary/v1");
+});
+
+test("canonical PASS reuse projects current HEAD onto metadata (BI-C6B2D404)", () => {
+  const projected = projectReusedPassMetadata(
+    { candidateSha: "oldsha", candidateRef: "feat/old", execution: { status: "passed", failedCommand: "stale" } },
+    { sha: "newsha", branch: "feat/new", evidenceId: "EXT-9", leaseId: "NPEL-9" },
+  );
+  assert.equal(projected.candidateSha, "newsha");
+  assert.equal(projected.candidateRef, "feat/new");
+  assert.equal(projected.reusedEvidenceId, "EXT-9");
+  assert.equal(projected.runLeaseId, "NPEL-9");
+  assert.equal(projected.execution.status, "passed");
+  assert.equal(projected.execution.failedCommand, null);
 });
 
 test("only matching queued/admitted/running gate states are recoverable", () => {

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -278,8 +278,12 @@ export function createLocalIntegrationPlan(input) {
   const setupCommands = [
     ...(input.fetchBase ? [["git", "fetch", "origin", "main"]] : []),
     ["git", "checkout", "-B", branch, baseRef],
-    ["git", "merge", "--no-ff", "--no-edit", input.candidateBranch],
-    ...input.siblingBranches.map((sibling) => ["git", "merge", "--no-ff", "--no-edit", sibling]),
+    // BI-4820A197: sign the merge at creation so the gated HEAD is the HEAD
+    // the pre-push DCO hook will accept. BI-E3044AEC: merge the invoking
+    // worktree's SHA when supplied, not a branch name that may resolve to
+    // origin's (behind) tip inside the shared runner workspace.
+    ["git", "merge", "--no-ff", "--no-edit", "--signoff", input.candidateSha || input.candidateBranch],
+    ...input.siblingBranches.map((sibling) => ["git", "merge", "--no-ff", "--no-edit", "--signoff", sibling]),
     // Generate the same versioned, digest-bound evidence plan used by GitHub
     // after the exact integration tree exists. Documentation plans are
     // authoritative; other local lanes remain exhaustive during rollout.

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -89,7 +89,7 @@ describe("createLocalIntegrationPlan", () => {
 
     assert.deepEqual(plan.commands.map((command) => command.join(" ")), [
       "git checkout -B local-integration/doc-build-studio-decision-skill-packs origin/main",
-      "git merge --no-ff --no-edit doc/build-studio-decision-skill-packs",
+      "git merge --no-ff --no-edit --signoff doc/build-studio-decision-skill-packs",
       "node scripts/ci-evidence-plan.mjs --event local-ci --base origin/main --head HEAD",
       "node scripts/sandbox-freshness-preflight.mjs --converge --branch local-integration/doc-build-studio-decision-skill-packs",
       "pnpm --filter @dpf/db exec prisma generate",
@@ -100,6 +100,20 @@ describe("createLocalIntegrationPlan", () => {
       "env NODE_OPTIONS=--no-experimental-webstorage node scripts/local-ci-vitest-runner.mjs --initial-workers 4 --retry-workers 2 --base origin/main",
       "env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=16384 pnpm --filter web exec next build",
     ]);
+  });
+
+  it("merges the invoking SHA when supplied, not the branch name (BI-E3044AEC)", () => {
+    const sha = "65aaf56ec10babcdef0123456789abcdef0123";
+    const plan = createLocalIntegrationPlan({
+      candidateBranch: "fix/embedding-coverage-selfheal",
+      candidateSha: sha,
+      mode: "single-branch",
+      siblingBranches: [],
+      hostPlatform: "linux",
+    });
+    const commands = plan.commands.map((command) => command.join(" "));
+    assert.ok(commands.includes(`git merge --no-ff --no-edit --signoff ${sha}`));
+    assert.ok(!commands.some((c) => c === "git merge --no-ff --no-edit --signoff fix/embedding-coverage-selfheal"));
   });
 
   it("routes Windows production builds through the bounded watchdog wrapper", () => {
@@ -173,7 +187,7 @@ describe("createLocalIntegrationPlan", () => {
 
     assert.deepEqual(plan.commands.slice(0, 2).map((command) => command.join(" ")), [
       "git checkout -B local-integration/feat-local-ci-content-evidence refs/dpf/integration/main",
-      "git merge --no-ff --no-edit feat/local-ci-content-evidence",
+      "git merge --no-ff --no-edit --signoff feat/local-ci-content-evidence",
     ]);
     assert.ok(!plan.commands.map((command) => command.join(" ")).some((command) => command.startsWith("git fetch ")));
     assert.equal(plan.baseRef, "refs/dpf/integration/main");
@@ -239,7 +253,7 @@ describe("createLocalIntegrationPlan", () => {
 
     assert.deepEqual(plan.commands.map((command) => command.join(" ")), [
       "git checkout -B local-integration/docs-gate-flow origin/main",
-      "git merge --no-ff --no-edit docs/gate-flow",
+      "git merge --no-ff --no-edit --signoff docs/gate-flow",
       "node scripts/ci-evidence-plan.mjs --event local-ci --base origin/main --head HEAD",
       "node scripts/gen-doc-index.mjs --check",
       "node scripts/check-doc-links.mjs",
@@ -296,10 +310,10 @@ describe("createLocalIntegrationPlan", () => {
 
     assert.equal(plan.integrationBranch, "local-integration/feat-build-studio-decision-skills-slice-1");
     assert.ok(plan.commands.map((command) => command.join(" ")).includes(
-      "git merge --no-ff --no-edit feat/environment-broker",
+      "git merge --no-ff --no-edit --signoff feat/environment-broker",
     ));
     assert.ok(plan.commands.map((command) => command.join(" ")).includes(
-      "git merge --no-ff --no-edit fix/build-studio-copy",
+      "git merge --no-ff --no-edit --signoff fix/build-studio-copy",
     ));
   });
 

--- a/scripts/lib/pregate-status.mjs
+++ b/scripts/lib/pregate-status.mjs
@@ -48,6 +48,17 @@ export const PREGATE_VERDICTS = Object.freeze([
 /** Statuses that mean the gate was never admitted / never finished. Not FAIL. */
 const UNFINISHED_GATE_STATUSES = new Set(["queued", "cancelled"]);
 
+/**
+ * BI-8392DA16 / BI-2AB94B5A. A `blocked_*` status is infrastructure evidence —
+ * the child was killed, the sandbox drifted, or the control plane starved.
+ * FAIL is a claim about the diff. These must never share a headline.
+ */
+const BLOCKED_GATE_STATUSES = new Set([
+  "blocked_sandbox_drift",
+  "blocked_control_plane_starvation",
+  "blocked_child_signal_death",
+]);
+
 function rank(verdict) {
   const index = PREGATE_VERDICTS.indexOf(verdict);
   return index < 0 ? -1 : index;
@@ -212,6 +223,16 @@ export function classifySlotRecord({ state, metadata, headSha, headBranch = "", 
         ...base,
         verdict: "INCONCLUSIVE",
         reason: `gate record status ${status} — the gate did not run. This is not a failure of the diff. Re-run pregate.`,
+      };
+    }
+    if (BLOCKED_GATE_STATUSES.has(status) || status.startsWith("blocked_")) {
+      const stated = state?.failureReason || state?.error || "";
+      return {
+        ...base,
+        verdict: "INCONCLUSIVE",
+        reason: stated
+          ? `gate record status ${status} — infrastructure, not a product verdict. ${stated}`
+          : `gate record status ${status} — infrastructure, not a product verdict. The run was blocked before it could grade the diff. Re-run when the host is quieter; do not treat this as a failure of the code.`,
       };
     }
     return {

--- a/scripts/lib/pregate-status.test.mjs
+++ b/scripts/lib/pregate-status.test.mjs
@@ -145,17 +145,19 @@ test("FAIL when the record exists for this SHA but did not pass", () => {
   assert.equal(exitCodeForVerdict(r.verdict), 1);
 });
 
-test("a run that gave up while queued reads FAIL, not PASS", () => {
-  // BI-2C7F51BA Defect 3: that path exits 0 having gated nothing. The record is
-  // what makes the silent exit-0 detectable.
+test("a run that gave up while queued reads INCONCLUSIVE, not PASS (BI-8392DA16)", () => {
+  // BI-2C7F51BA Defect 3: that path used to exit 0 having gated nothing. The
+  // record is what makes the silent exit-0 detectable. A `blocked_*` status
+  // is infrastructure, not a product FAIL — same class as SIGTERM.
   const r = classifySlotRecord({
     state: passingState({ gatePassed: false, status: "blocked_quiescence", evidenceRecordId: "" }),
     metadata: null,
     headSha: HEAD,
     now: NOW,
   });
-  assert.equal(r.verdict, "FAIL");
+  assert.equal(r.verdict, "INCONCLUSIVE");
   assert.match(r.reason, /blocked_quiescence/);
+  assert.match(r.reason, /infrastructure, not a product verdict/i);
 });
 
 test("PENDING when the gate passed but evidence publication is unfinished", () => {
@@ -377,6 +379,36 @@ test("a queued record that never ran is INCONCLUSIVE, not FAIL (BI-51353470)", (
   assert.match(r.reason, /did not run|never ran|not a failure of the diff/i);
   assert.doesNotMatch(r.reason, /local-ci-vitest-runner/);
   assert.equal(exitCodeForVerdict(r.verdict), 1, "inconclusive is not a green light to push");
+});
+
+test("a SIGTERM-killed / blocked_child_signal_death record is INCONCLUSIVE, not FAIL (BI-8392DA16, BI-2AB94B5A)", () => {
+  const r = classifySlotRecord({
+    state: passingState({
+      gatePassed: false,
+      status: "blocked_child_signal_death",
+      evidenceRecordId: "",
+      failureReason: "the build child was killed by SIGTERM",
+    }),
+    metadata: { candidateSha: HEAD },
+    headSha: HEAD,
+    headBranch: "claude/topic",
+    now: NOW,
+  });
+  assert.equal(r.verdict, "INCONCLUSIVE");
+  assert.match(r.reason, /infrastructure, not a product verdict/i);
+  assert.match(r.reason, /SIGTERM/);
+  assert.doesNotMatch(r.reason, /this SHA has not passed/);
+});
+
+test("blocked_sandbox_drift is INCONCLUSIVE, not FAIL (BI-2AB94B5A)", () => {
+  const r = classifySlotRecord({
+    state: passingState({ gatePassed: false, status: "blocked_sandbox_drift", evidenceRecordId: "" }),
+    metadata: { candidateSha: HEAD },
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "INCONCLUSIVE");
+  assert.match(r.reason, /infrastructure, not a product verdict/i);
 });
 
 test("a cancelled record is INCONCLUSIVE, not FAIL (BI-51353470)", () => {

--- a/scripts/lib/sandbox-freshness.mjs
+++ b/scripts/lib/sandbox-freshness.mjs
@@ -414,12 +414,26 @@ export function classifyGateOutcome({ freshnessVerdict, gateExitCode }) {
       summary: "local-CI gate blocked: the shared portal/MCP/Docker/PostgreSQL control-plane degraded during the build. This is infrastructure evidence, NOT a product build failure.",
     };
   }
-  if (gateExitCode === EXIT_CHILD_SIGNAL_DEATH) {
+  if (gateExitCode === EXIT_CHILD_SIGNAL_DEATH || gateExitCode === 130 || gateExitCode === 143) {
+    // 130/143 are the conventional 128+SIGINT/SIGTERM codes the wrapper used
+    // to stamp when the PARENT received the signal (BI-8392DA16). Those are
+    // the same infrastructure death as EXIT_CHILD_SIGNAL_DEATH — not a
+    // product failure.
     return {
       status: "blocked_child_signal_death",
       gatePassed: false,
       productEvidence: false,
       summary: "local-CI gate could not produce a verdict: the build child was killed by a signal rather than exiting. This is infrastructure evidence, NOT a product build failure — most often the host running out of memory under concurrent gate load. Re-run when the box is quieter; check the recorded signal and host pressure before treating any of it as a code defect.",
+    };
+  }
+  if (gateExitCode === 75) {
+    // BI-465B3D60: lease fencing (expiry / quiescence) used to fall through
+    // to product `failed` with no reason.
+    return {
+      status: "blocked_control_plane_starvation",
+      gatePassed: false,
+      productEvidence: false,
+      summary: "local-CI gate blocked: the lease was fenced (expired or quiesced) before the run finished. This is infrastructure evidence, NOT a product build failure. Re-run when the slot is free.",
     };
   }
   if (gateExitCode === EXIT_VITEST_RUNNER_TERMINATION) {

--- a/scripts/lib/sandbox-freshness.test.mjs
+++ b/scripts/lib/sandbox-freshness.test.mjs
@@ -386,6 +386,19 @@ test("a signal-killed child is blocked, not failed", () => {
   assert.match(outcome.summary, /NOT a product build failure/);
 });
 
+test("a parent SIGTERM (exit 130) is blocked, not a product FAIL (BI-8392DA16)", () => {
+  const outcome = classifyGateOutcome({ freshnessVerdict: "green", gateExitCode: 130 });
+  assert.equal(outcome.status, "blocked_child_signal_death");
+  assert.equal(outcome.productEvidence, false);
+});
+
+test("a fenced lease (exit 75) is blocked, not a product FAIL (BI-465B3D60)", () => {
+  const outcome = classifyGateOutcome({ freshnessVerdict: "green", gateExitCode: 75 });
+  assert.equal(outcome.status, "blocked_control_plane_starvation");
+  assert.equal(outcome.productEvidence, false);
+  assert.match(outcome.summary, /fenced/i);
+});
+
 test("the signal-death code does not collide with the other blocked codes", () => {
   const codes = new Set([
     EXIT_GREEN,
@@ -419,6 +432,9 @@ test("every status classifyGateOutcome can emit is one the recorder accepts", ()
     EXIT_CONTROL_PLANE_STARVATION,
     EXIT_VITEST_RUNNER_TERMINATION,
     EXIT_CHILD_SIGNAL_DEATH,
+    75,
+    130,
+    143,
   ];
   const verdicts = [null, "green", "drifted", "sandbox_not_ready"];
 

--- a/scripts/local-ci-runner.mjs
+++ b/scripts/local-ci-runner.mjs
@@ -379,8 +379,17 @@ export function resolveChildExit(result) {
  */
 export function clearStaleStageReceipts(metadataFile, { rm = rmSync } = {}) {
   const cleared = [];
-  for (const suffix of [".vitest.json", ".typecheck.json", ".build.json"]) {
-    const path = `${metadataFile}${suffix}`;
+  // BI-F22B4EEE: the metadata record itself is inherited across runs. A
+  // failing or killed run that never rewrote it left the previous run's
+  // candidateSha and execution.status in place. Delete it at start so neither
+  // field can be quoted as this run's verdict.
+  const paths = [
+    metadataFile,
+    `${metadataFile}.vitest.json`,
+    `${metadataFile}.typecheck.json`,
+    `${metadataFile}.build.json`,
+  ];
+  for (const path of paths) {
     try {
       rm(path, { force: true });
       cleared.push(path);

--- a/scripts/local-ci-runner.test.mjs
+++ b/scripts/local-ci-runner.test.mjs
@@ -297,11 +297,12 @@ test("clearStaleStageReceipts removes every per-stage receipt", () => {
   const cleared = clearStaleStageReceipts("/tmp/meta.json", { rm: (p) => removed.push(p) });
 
   assert.deepEqual(removed, [
+    "/tmp/meta.json",
     "/tmp/meta.json.vitest.json",
     "/tmp/meta.json.typecheck.json",
     "/tmp/meta.json.build.json",
   ]);
-  assert.equal(cleared.length, 3);
+  assert.equal(cleared.length, 4);
 });
 
 test("clearStaleStageReceipts is best-effort and never throws", () => {
@@ -318,12 +319,14 @@ test("clearStaleStageReceipts is best-effort and never throws", () => {
 test("clearStaleStageReceipts actually deletes on disk", () => {
   const dir = mkdtempSync(join(tmpdir(), "dpf-stage-receipts-"));
   const meta = join(dir, "dpf-local-ci-metadata.json");
+  writeFileSync(meta, JSON.stringify({ candidateSha: "old", execution: { status: "passed" } }));
   for (const suffix of [".vitest.json", ".typecheck.json", ".build.json"]) {
     writeFileSync(`${meta}${suffix}`, JSON.stringify({ status: "passed" }));
   }
 
   clearStaleStageReceipts(meta);
 
+  assert.equal(existsSync(meta), false, "metadata record must not survive into the next run (BI-F22B4EEE)");
   for (const suffix of [".vitest.json", ".typecheck.json", ".build.json"]) {
     assert.equal(existsSync(`${meta}${suffix}`), false, `${suffix} must not survive into the next run`);
   }

--- a/scripts/local-integration-ci.mjs
+++ b/scripts/local-integration-ci.mjs
@@ -60,6 +60,7 @@ if (!candidateBranch) {
 
 const plan = createLocalIntegrationPlan({
   candidateBranch,
+  candidateSha: candidateSha || undefined,
   baseRef,
   mode,
   siblingBranches,


### PR DESCRIPTION
## Summary

Ten related local-CI diagnostic-honesty defects, one PR. The gate was individually plausible but its failure reporting did not survive contact with a real run: passing tests named FAIL were quoted as failures, a SIGTERM-killed child was a product FAIL, reuse left stale `candidateSha`, an unsigned merge failed the next DCO hook, and a killed run inherited the previous metadata record.

| BI | Defect |
|---|---|
| BI-FBB86A69 | Summarizer matches `FAIL` inside passing test titles and `✓` lines |
| BI-DBED32FE | Failure reason not persisted; `[object Object]` class (render already on main) |
| BI-8392DA16 | SIGTERM / parent signal recorded as product FAIL |
| BI-2AB94B5A | `blocked_*` still headlines as FAIL in `pregate:status` |
| BI-C6B2D404 | Canonical reuse does not project current HEAD onto metadata → STALE |
| BI-E3044AEC | Shared runner merges the branch name (origin tip), not the invoking SHA |
| BI-4820A197 | Pregate merge has no `--signoff`, so the next DCO hook rejects it |
| BI-465B3D60 | Fenced / reasonless failed records cannot name this run's cause |
| BI-F22B4EEE | Metadata record not reset at run start, so `candidateSha`/`execution.status` inherit |
| BI-DAF33DF3 | Required CI contexts must still report on exact-tree reuse (regression lock) |

## What changed

- `summarizeLocalCiOutput` ignores passing lines and only matches `FAIL` at the start of a line.
- Gate state persists `failureReason`, `failureSummary`, and `childExitCode`.
- `pregate:status` reports `blocked_*` as **INCONCLUSIVE**, not FAIL.
- `classifyGateOutcome` treats exit 130/143 (parent SIGTERM) and 75 (lease fence) as blocked, not product failed.
- Canonical PASS reuse writes a metadata projection bound to current HEAD.
- Local-CI merge uses `--signoff` and the invoking SHA when supplied.
- Run start deletes the previous metadata record, not only per-stage receipts.
- CI workflow test locks Merge Readiness and UX Route Budget Sweep to `if: always()` on the reuse path.

## Tests

`node --test` on the affected files: 143 passed.

## Docs

Docs-Impact-Decision: contributor local-CI diagnostic honesty only; no user-facing route, prompt, or install contract changed.

Local-CI-Override: external-contribution-no-install: source-only worktree; scripts-only diagnostic honesty with unit cover.