### PR TITLE
fix(self-upgrade): isolate registry transport recovery

### DIFF
--- a/apps/web/lib/self-upgrade/registry-release.test.ts
+++ b/apps/web/lib/self-upgrade/registry-release.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { readRegistryReleaseCandidate } from "./registry-release";
 
 const OWNER = "opendigitalproductfactory";
@@ -142,6 +142,98 @@ function fixtureFetch(options: {
 }
 
 describe("readRegistryReleaseCandidate", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("replaces a failed process-lifetime transport and retries the complete registry read once", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("poisoned process-lifetime fetch pool");
+    }));
+    const closeFailed = vi.fn(async () => undefined);
+    const closeHealthy = vi.fn(async () => undefined);
+    const transportFactory = vi.fn()
+      .mockReturnValueOnce({
+        fetch: vi.fn(async () => {
+          throw new TypeError("fetch failed", {
+            cause: new Error("Connect Timeout Error"),
+          });
+        }) as typeof fetch,
+        close: closeFailed,
+      })
+      .mockReturnValueOnce({
+        fetch: fixtureFetch(),
+        close: closeHealthy,
+      });
+
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      transportFactory,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(transportFactory).toHaveBeenCalledTimes(2);
+    expect(closeFailed).toHaveBeenCalledOnce();
+    expect(closeHealthy).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a byte-verified candidate when transport cleanup reports an error", async () => {
+    const close = vi.fn(async () => {
+      throw new Error("dispatcher already closed");
+    });
+
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      transportFactory: () => ({ fetch: fixtureFetch(), close }),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("recovers when constructing the first isolated transport fails", async () => {
+    const close = vi.fn(async () => undefined);
+    const transportFactory = vi.fn()
+      .mockImplementationOnce(() => {
+        throw new TypeError("dispatcher construction failed");
+      })
+      .mockReturnValueOnce({ fetch: fixtureFetch(), close });
+
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      transportFactory,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(transportFactory).toHaveBeenCalledTimes(2);
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry an integrity failure on a new transport", async () => {
+    const close = vi.fn(async () => undefined);
+    const transportFactory = vi.fn(() => ({
+      fetch: fixtureFetch({ tamperChannelDigest: true }),
+      close,
+    }));
+
+    const result = await readRegistryReleaseCandidate({
+      owner: OWNER,
+      channelTag: "latest",
+      architecture: "amd64",
+      transportFactory,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "channel-digest-mismatch" });
+    expect(transportFactory).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
   it("resolves a verified channel to the immutable tag and byte identities", async () => {
     const result = await readRegistryReleaseCandidate({
       owner: OWNER,

--- a/apps/web/lib/self-upgrade/registry-release.ts
+++ b/apps/web/lib/self-upgrade/registry-release.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { Agent, fetch as undiciFetch } from "undici";
 import { ok, type ActionSuccess } from "@/lib/shared/action-result";
 
 const DEFAULT_REGISTRY_ORIGIN = "https://ghcr.io";
@@ -80,10 +81,30 @@ type RegistryConfig = {
   config?: { Labels?: Record<string, unknown> };
 };
 
+type RegistryTransport = Readonly<{
+  fetch: typeof fetch;
+  close(): Promise<void>;
+}>;
+
+type RegistryTransportFactory = () => RegistryTransport;
+
 class RegistryReadError extends Error {
   constructor(readonly reason: RegistryReleaseFailureReason) {
     super(reason);
   }
+}
+
+function createRegistryTransport(): RegistryTransport {
+  const dispatcher = new Agent();
+  const isolatedFetch = ((input: Parameters<typeof fetch>[0], init?: RequestInit) =>
+    undiciFetch(
+      input as Parameters<typeof undiciFetch>[0],
+      { ...init, dispatcher } as Parameters<typeof undiciFetch>[1],
+    ) as unknown as Promise<Response>) as typeof fetch;
+  return {
+    fetch: isolatedFetch,
+    close: () => dispatcher.close(),
+  };
 }
 
 function sha256(body: Uint8Array): string {
@@ -185,6 +206,7 @@ export async function readRegistryReleaseCandidate(input: {
   repository?: string;
   registryOrigin?: string;
   fetchImpl?: typeof fetch;
+  transportFactory?: RegistryTransportFactory;
 }): Promise<RegistryReleaseReadResult> {
   const repository = input.repository ?? DEFAULT_REPOSITORY;
   const origin = input.registryOrigin ?? DEFAULT_REGISTRY_ORIGIN;
@@ -192,10 +214,9 @@ export async function readRegistryReleaseCandidate(input: {
     return { ok: false, reason: "registry-identity-invalid" };
   }
 
-  try {
+  async function readCandidate(fetchImpl: typeof fetch): Promise<RegistryReleaseReadResult> {
     const originUrl = new URL(origin);
     if (originUrl.protocol !== "https:") throw new RegistryReadError("registry-identity-invalid");
-    const fetchImpl = input.fetchImpl ?? fetch;
     const imageName = `${input.owner.toLowerCase()}/${repository}`;
     let bearer: string | null = null;
 
@@ -394,10 +415,43 @@ export async function readRegistryReleaseCandidate(input: {
         platformArchitecture: architecture,
       }),
     };
-  } catch (error) {
-    return {
-      ok: false,
-      reason: error instanceof RegistryReadError ? error.reason : "registry-unavailable",
-    };
   }
+
+  // Next patches the process-global fetch used by server components. A failed
+  // connection during container startup can leave that long-lived transport
+  // returning timeouts even after Docker egress is healthy. Use an isolated,
+  // explicitly closed Undici dispatcher for each complete registry read, and
+  // replace it once after a transport exception. Injected fetchImpl callers
+  // keep their single-attempt deterministic contract.
+  const transportFactory = input.transportFactory
+    ?? (input.fetchImpl
+      ? () => ({ fetch: input.fetchImpl as typeof fetch, close: async () => undefined })
+      : createRegistryTransport);
+  const maxAttempts = input.fetchImpl && !input.transportFactory ? 1 : 2;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let transport: RegistryTransport | null = null;
+    try {
+      transport = transportFactory();
+      return await readCandidate(transport.fetch);
+    } catch (error) {
+      if (error instanceof RegistryReadError || attempt === maxAttempts) {
+        return {
+          ok: false,
+          reason: error instanceof RegistryReadError ? error.reason : "registry-unavailable",
+        };
+      }
+    } finally {
+      if (transport) {
+        try {
+          await transport.close();
+        } catch {
+          // The dispatcher is never reused. Cleanup cannot invalidate registry
+          // bytes whose digest and immutable identity were already verified.
+        }
+      }
+    }
+  }
+
+  return { ok: false, reason: "registry-unavailable" };
 }


### PR DESCRIPTION
## Summary

After a container starts before network egress is ready, the portal's long-lived fetch transport can keep timing out even after GHCR becomes reachable. The upgrade run then finishes correctly while the owner page reports `registry-unavailable`. This change gives each complete registry read a fresh Undici dispatcher and retries the full read once only when the transport throws.

## Changes

- Isolate every production registry read from the process-global fetch connection pool and close its dispatcher after use.
- Replay the complete registry read once on transport construction or request failure; do not retry digest, authentication, identity, or redirect failures.
- Preserve injected-fetch callers as deterministic single-attempt tests.
- Add regression coverage for a poisoned transport, constructor failure, cleanup failure, and integrity non-retry.

## Test plan

- [x] **Runtime-bound change**
  - [x] Source checks passed in the governed worktree.
  - [ ] Candidate runtime verification: the shared exact-tree environment could not admit because `host-stage-headroom-low` reduced effective capacity to zero. The operator-authorized override below applies; GitHub CI and untouched post-release verification remain mandatory.
- [x] **Verification-harness limitation acknowledged**

### Verification evidence

- `pnpm --filter web exec vitest run ...`: 196 tests passed across 7 affected suites.
- `pnpm --filter web typecheck`: passed; the DCO commit hook repeated the scoped typecheck successfully.
- `node scripts/check-style-drift.mjs`: passed.
- `pnpm run pregate:preflight`: 61 guards clean; one existing host-runtime warning remained in `gate-context-runtime-contract.test.mjs`.
- Production-path registry invocation resolved the live immutable tag, source SHA, and channel/platform/config digests without an injected fetch.
- Independent semantic review receipt `cmtgod1ya01te01qwpnp1khhq`: infrastructure-inconclusive, no findings, publication admitted by shadow policy.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and against the final diff.
- [x] `pnpm run pregate:preflight` completed before the shared-sandbox claim.
- [x] The exact-tree claim and durable TaskRun were captured; the host reported effective capacity zero, so the named operator's emergency override is recorded below.
- [x] `pnpm pr:ready -- --pr-body-file <this-body-file>` will be run against this exact pushed SHA before PR creation.

Local-CI-Override: operator-emergency: operator approved bypass after the exact-tree gate could not admit because host-stage-headroom-low reported effective capacity zero

## Related issues / Epic

- Backlog item: `BI-3FD07259`
- Workroom: `WC-49AB85B0`
- Existing acceptance contract: `AC-SUA-014`

## Overlap sweep

No open PR touches self-upgrade registry transport recovery. PR #4886 is confined to guard honesty.

## Notes for the reviewer

No schema, migration, dependency, UI, or public contract changes. The existing exact-target recovery design already requires startup convergence, so no parallel spec was added. The post-merge release must prove that a freshly swapped portal reaches both terminal upgrade state and a healthy registry target without a manual restart.
