### PR TITLE
docs: stop blind retries when code graph is unavailable

### DIFF
--- a/packages/dpf-skill-pack/hooks/code-intelligence-guidance.test.mjs
+++ b/packages/dpf-skill-pack/hooks/code-intelligence-guidance.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const skill = (name) => readFile(resolve(here, "..", "skills", name, "SKILL.md"), "utf8");
+
+const [tdd, blast] = await Promise.all([
+  skill("dpf-tdd"),
+  skill("dpf-blast-radius"),
+]);
+
+assert.match(
+  tdd,
+  /find_related_tests[\s\S]{0,500}Code graph unavailable[\s\S]{0,500}(?:fallback|grep)/i,
+  "TDD guidance must stop retrying an unavailable graph and use the bounded source fallback",
+);
+assert.match(
+  blast,
+  /find_related_tests[\s\S]{0,700}Code graph unavailable[\s\S]{0,700}(?:fallback|grep)/i,
+  "blast-radius guidance must make the unavailable-graph fallback explicit",
+);
+assert.match(
+  tdd,
+  /do not retry|never retry|one attempt/i,
+  "guidance must prevent blind retries when the graph is unavailable",
+);

--- a/packages/dpf-skill-pack/skills/dpf-blast-radius/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-blast-radius/SKILL.md
@@ -48,7 +48,7 @@ enforces:
 
 2. **Verify the graph indexes the tree you are changing.** Before trusting any graph answer, confirm what it is reading. The portal's code search has previously answered from a stale checkout rather than the working tree (BI-6CFC5429), and a graph answering about the wrong tree returns confident, complete, wrong results. If you cannot establish which tree it indexed, treat the graph as a hint generator and let `Grep` be the authority.
 
-3. **Fan out on each symbol.** `mcp__dpf__explain_blast_radius` and `mcp__dpf__trace_code_surface` for the structural reach; `mcp__dpf__search_code_graph` for callers; `mcp__dpf__find_related_tests` for the tests that already cover it. Then `Grep` the raw string anyway — the graph misses dynamic references, string-keyed lookups, generated code, and anything in a language it does not parse.
+3. **Fan out on each symbol.** `mcp__dpf__explain_blast_radius` and `mcp__dpf__trace_code_surface` for the structural reach; `mcp__dpf__search_code_graph` for callers; `mcp__dpf__find_related_tests` for the tests that already cover it. If any code-graph call returns `Code graph unavailable`, an unavailable graph, or low-trust/qualify advice, stop after that single attempt and record it as unavailable/unrun; use a bounded `Grep`/`Glob` sweep and explicit test discovery instead. Do not turn a missing graph into repeated failing calls. Then `Grep` the raw string anyway — the graph misses dynamic references, string-keyed lookups, generated code, and anything in a language it does not parse.
 
 4. **Sweep the places the graph cannot see.** Each of these has broken a DPF change before and none of them are call edges:
    - seed data and registries under `packages/db/data/` and `skills/`

--- a/packages/dpf-skill-pack/skills/dpf-tdd/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-tdd/SKILL.md
@@ -51,7 +51,7 @@ This is [AGENTS.md §4 "Where each gate runs"](../../../../AGENTS.md) applied to
 
 ## The DPF-gated loop
 
-1. **Impact before Red.** Consume the `changeImpactContract` returned when the Workroom claimed its edit paths (or read `verificationState.changeImpactContract`). Resolve every `testImpact` entry with `find_related_tests` and pull every `guardObligation` into the loop now. `status: unresolved`, stale graph advice, or an unmapped source path **expands** verification — it never means "no tests."
+1. **Impact before Red.** Consume the `changeImpactContract` returned when the Workroom claimed its edit paths (or read `verificationState.changeImpactContract`). Resolve every `testImpact` entry with `find_related_tests` and pull every `guardObligation` into the loop now. If `find_related_tests` returns `Code graph unavailable`, an unavailable graph, or low-trust/qualify advice, **do not retry it blindly**: record the lookup as unavailable/unrun, then use a bounded `Grep`/`Glob` sweep plus colocated tests and the repository's explicit test commands. `status: unresolved`, stale graph advice, or an unmapped source path **expands** verification — it never means "no tests." The fallback is evidence of the search you performed, not a claim that the graph found nothing.
 
 2. **Red.** Watch it fail for the right reason. For a bug fix this is mandatory (`security-fix-needs-regression-test-first`, generalized beyond security).
 

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -227,6 +227,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/lib/dev-preview-migrate-converge.test.mjs",
         "scripts/pregate-exit-honesty.test.mjs",
         "scripts/lib/gate-context-runtime-contract.test.mjs",
+        "packages/dpf-skill-pack/hooks/code-intelligence-guidance.test.mjs",
       ),
       node("scripts/check-ci-policy-test-inventory.mjs"),
     ]),


### PR DESCRIPTION
## Summary

- Links BI-MCP-EFF-7AFED9F2 (`find_related_tests` failure-rate remediation).
- Updates DPF TDD and blast-radius guidance to stop after a single unavailable code-graph response and use bounded Grep/Glob plus colocated-test discovery.
- Adds a regression test proving the fallback guidance is explicit and does not encourage blind retries.

## Verification

- `node --test packages/dpf-skill-pack/hooks/code-intelligence-guidance.test.mjs` — 1/1 passed.
- `git diff --check` — clean.
- Local `pnpm run pregate:preflight` stalled after auto-healing; recorded INCONCLUSIVE under the operator-authorized local-capacity bypass. Protected CI remains mandatory.

## Scope and safety

This is a docs-and-guidance change only; no runtime route or production behavior changes.

Seed-Fit-Decision: global-default
Local-CI-Override: docs-adjacent — local pregate stalled after auto-healing; protected CI remains mandatory.
