### PR TITLE
docs(mcp): clarify plan coverage contract

### DIFF
--- a/packages/dpf-skill-pack/hooks/plan-coverage-guidance.test.mjs
+++ b/packages/dpf-skill-pack/hooks/plan-coverage-guidance.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const skillPath = new URL(
+  "../skills/dpf-writing-plans/SKILL.md",
+  import.meta.url,
+);
+
+test("plan-writing guidance uses the decomposition coverage contract", async () => {
+  const guidance = await readFile(skillPath, "utf8");
+
+  assert.match(guidance, /record_plan_backlog_coverage/);
+  assert.match(guidance, /planArtifactRef/);
+  assert.match(guidance, /decision:\s*`(?:decomposed|atomic)`/);
+  assert.match(guidance, /do not.*`gate`/is);
+  assert.match(guidance, /do not.*`pass`/is);
+  assert.match(guidance, /one corrected call|one attempt/i);
+});

--- a/packages/dpf-skill-pack/skills/dpf-writing-plans/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-writing-plans/SKILL.md
@@ -69,6 +69,20 @@ The order is fixed: **BI first, then plan.** [`dpf-file-backlog-item`](../dpf-fi
 
    Copy the returned receipt, parent BI, deliverable-to-BI mappings, and dependencies into a `## Backlog coverage` plan section. `mcp__dpf__check_plan_backlog_coverage` is the resumability check. If MCP is unavailable, the tool is missing, or the token lacks scope, stop and report that condition; Markdown checkboxes are not a fallback and planning/backlog completeness cannot be claimed.
 
+   This is the decomposition-pack contract, not the initiative-readiness review contract. The minimum shape is:
+
+   ```json
+   {
+     "itemId": "BI-...",
+     "planPath": "docs/superpowers/plans/YYYY-MM-DD-feature.md",
+     "planArtifactRef": { "kind": "repo-blob-at-commit", "repo": "owner/repo", "commitSha": "...", "path": "docs/superpowers/plans/YYYY-MM-DD-feature.md", "providerBlobId": "..." },
+     "decision": "decomposed",
+     "deliverables": [{ "title": "...", "requirementRefs": ["..."], "contractRefs": ["..."], "flowRefs": ["..."], "verificationRefs": ["..."] }]
+   }
+   ```
+
+   Use decision: `decomposed` when independently shippable deliverables map to live BIs, or decision: `atomic` with a substantive rationale when they do not. Do not send `gate`, `findings`, or `resolvedFindingRefs` from the readiness lane. Do not send `pass` or `fail` as the decision; those belong to review writers, not plan coverage. Do not send the literal `pass` decision value in this contract. Make one corrected coverage call after verifying the BI and immutable plan. If the server returns `traceability-incomplete`, change only the named prerequisite and retry once; never blind-retry. If the tool is unavailable or shadowed, record the exact refusal and stop rather than calling another lane or fabricating a receipt.
+
    Treat a rejected coverage write as a remediation contract, not a blind retry:
    - When the result is `traceability-incomplete`, add or repair the initiative baseline and mappings named by the response before making one corrected call. Do not repeat identical arguments.
    - When the result is `plan-artifact-invalid`, reconcile the Workroom to the exact current branch and head SHA, repair the artifact or provenance named by the response, then make one corrected call. Do not mint a new plan path to dodge immutable provenance.

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -210,6 +210,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/lib/documentation-evidence-lane.test.mjs",
         "scripts/ci-policy-guards.test.mjs",
         "scripts/lib/host-command-invocation.test.mjs",
+        "packages/dpf-skill-pack/hooks/plan-coverage-guidance.test.mjs",
         // BI-812C676D: every covered-root *.test.mjs must appear here or on the
         // deliberate allowlist — otherwise CI stays green while the test never runs.
         "scripts/lib/ci-policy-test-inventory.test.mjs",


### PR DESCRIPTION
## Summary
- Clarify the decomposition-pack contract for `record_plan_backlog_coverage`.
- Add a regression test and register it in the protected policy inventory.
- Explicitly prevent readiness-lane payloads and blind retries from masquerading as coverage.

## Verification
- `node --test packages/dpf-skill-pack/hooks/plan-coverage-guidance.test.mjs scripts/lib/ci-policy-test-inventory.test.mjs` (9/9 passed)
- `node scripts/check-ci-policy-test-inventory.mjs` (308 discovered, inventory/allowlist consistent)
- `pnpm pr:ready -- --skip-gates` (READY; source-only worktree has no dependency install)

Local-CI-Override: dependency-backed local gates were unavailable in the source-only worktree; local result is inconclusive and protected CI remains mandatory.
Docs-Impact-Decision: internal CI policy-test inventory registration and skill guidance; no user-facing documentation or product behavior changes.
Seed-Fit-Decision: global-default