### PR TITLE
fix(review): recover expired writer proposal

### DIFF
--- a/apps/web/lib/mcp-task-approval-recovery-contract.ts
+++ b/apps/web/lib/mcp-task-approval-recovery-contract.ts
@@ -179,6 +179,8 @@ export function recoveryProgress(
         ? input.sourceEnvelopeStatus === "failed"
           ? "failed-provider-envelope"
           : "failed-prerequisite-approved-envelope"
+        : input.sourceEnvelopeStatus === "proposed"
+          ? "expired-proposed-envelope"
         : input.freshApprovalRequired
           ? "expired-approved-envelope"
           : "stale-approved-envelope",

--- a/apps/web/lib/mcp-task-approval-recovery.test.ts
+++ b/apps/web/lib/mcp-task-approval-recovery.test.ts
@@ -299,8 +299,80 @@ describe("same-TaskRun approval recovery", () => {
     }));
   });
 
+  it("supersedes an expired proposed envelope without rerunning the same TaskRun review", async () => {
+    const envelope = { ...expiredEnvelope(), status: "proposed" };
+    const { db, tx } = fakeDb(staleRun("input-required"), envelope);
+
+    const result = await recover(db);
+
+    expect(result).toEqual({
+      kind: "fresh-approval-required",
+      sourceEnvelopeId: envelope.id,
+      replacementEnvelopeId: "ENV-REPLACEMENT",
+      replacementProposalExecutionId: "tool-proposal-new",
+    });
+    expect(tx.coworkerActionEnvelope.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        taskRunId: TASK_RUN_ID,
+        status: { in: ["approved", "failed", "proposed"] },
+      }),
+    }));
+    expect(tx.coworkerActionEnvelope.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: envelope.id,
+        status: "proposed",
+        expiresAt: { lte: NOW },
+      },
+      data: { status: "cancelled", resolvedAt: NOW },
+    });
+    expect(tx.coworkerActionEnvelope.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        taskRunId: TASK_RUN_ID,
+        status: "proposed",
+        argsJson: envelope.argsJson,
+        approvalBindingFingerprint: envelope.approvalBindingFingerprint,
+      }),
+    }));
+    expect(tx.toolExecution.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        taskRunId: TASK_RUN_ID,
+        parameters: proposal().parameters,
+        executionMode: "proposal",
+      }),
+    }));
+    expect(tx.taskRun.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        status: "input-required",
+        progressPayload: expect.objectContaining({
+          approvalRecovery: expect.objectContaining({
+            kind: "expired-proposed-envelope",
+            sourceEnvelopeId: envelope.id,
+            inferenceRerun: false,
+            freshApprovalRequired: true,
+          }),
+        }),
+      }),
+    }));
+  });
+
   it("refuses to replace an unexpired approval on an input-required TaskRun", async () => {
     const envelope = { ...expiredEnvelope(), expiresAt: new Date("2026-08-28T13:50:00.000Z") };
+    const { db, tx } = fakeDb(staleRun("input-required"), envelope);
+
+    await expect(recover(db)).resolves.toBeNull();
+
+    expect(tx.coworkerActionEnvelope.updateMany).not.toHaveBeenCalled();
+    expect(tx.coworkerActionEnvelope.create).not.toHaveBeenCalled();
+    expect(tx.toolExecution.create).not.toHaveBeenCalled();
+    expect(tx.taskRun.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("refuses to replace an unexpired proposed envelope", async () => {
+    const envelope = {
+      ...expiredEnvelope(),
+      status: "proposed",
+      expiresAt: new Date("2026-08-28T13:50:00.000Z"),
+    };
     const { db, tx } = fakeDb(staleRun("input-required"), envelope);
 
     await expect(recover(db)).resolves.toBeNull();

--- a/apps/web/lib/mcp-task-approval-recovery.ts
+++ b/apps/web/lib/mcp-task-approval-recovery.ts
@@ -95,7 +95,7 @@ export async function recoverStaleApprovedRemoteTask(
           delegatingUserId: input.userId,
           coworkerAgentId: input.agentId,
           manifestActionId: input.writerToolName,
-          status: { in: ["approved", "failed"] },
+          status: { in: ["approved", "failed", "proposed"] },
         },
         orderBy: { createdAt: "desc" },
         select: {

--- a/apps/web/lib/mcp-task-submit-approval-recovery.ts
+++ b/apps/web/lib/mcp-task-submit-approval-recovery.ts
@@ -163,11 +163,12 @@ export async function resumeApprovedRemoteTask(input: {
 const RECOVERABLE_STATUSES = new Set(["working", "stalled", "input-required", "failed"]);
 
 /**
- * Recover a stale approved writer envelope on the SAME TaskRun and request
- * digest. Supersedes the expired envelope with one carrying the identical
- * stored binding and writer arguments, then requires fresh exact approval
- * before the writer runs. It never reruns inference and never creates a
- * sibling TaskRun.
+ * Recover a stale governed writer envelope on the SAME TaskRun and request
+ * digest. This includes a proposal that expired before approval as well as an
+ * approved envelope that expired before execution. Supersedes the expired
+ * envelope with one carrying the identical stored binding and writer
+ * arguments, then requires fresh exact approval before the writer runs. It
+ * never reruns inference and never creates a sibling TaskRun.
  *
  * Returns null when the run is not a recovery candidate, leaving the caller's
  * ordinary replay path untouched.

--- a/docs/superpowers/plans/2026-08-25-immutable-source-review-traversal.md
+++ b/docs/superpowers/plans/2026-08-25-immutable-source-review-traversal.md
@@ -195,3 +195,24 @@ The governed coverage writer cannot issue a receipt while the condition `no init
 | Deliverable | Requirement refs | Flow refs | Contract refs | Verification refs | Atomicity |
 | --- | --- | --- | --- | --- | --- |
 | Zero-reader same-TaskRun terminal-writer recovery | Phase 13.1, 13.3, 13.6, 13.9 | Phase 13.4, 13.5 | Phase 13.3, 13.6, 13.9 | Phase 13.2, 13.7, 13.8 | Reservation, the governed bootstrap read, persisted-row requery, hydration validation, and typed resumable failure form one fail-closed unit. Shipping any subset would either leave the preserved TaskRun unrecoverable or weaken evidence authority. |
+
+## Phase 14 — Supersede an expired unapproved writer proposal
+
+This phase extends BI-DE58CFE8 on Workroom `WC-14EA9122` for the exact PR #4891 design-review TaskRun `TR-MCP-Y210Nmg3bjg3MDBnYTAxbXhheDU2MXV2aQ-57CC78DB3778`. Its proposal envelope expired in `proposed`, leaving the same immutable review unable to obtain fresh approval or a genuine baseline.
+
+1. Preserve the TaskRun, request digest, writer proposal ToolExecution `cmthhuxly00a501qmsogavxv5`, expired envelope `cmthhuxlm00a201qmftzezz1k`, exact approval binding, and zero-receipt state as the RED fixture. Never approve the expired envelope or mint a sibling review.
+2. Add the failing transaction test proving the recovery query cannot see an expired `proposed` envelope. Add the paired refusal for an unexpired proposal.
+3. Extend the existing approval-recovery transaction, not terminal inference, to accept `proposed` only after expiry and only when TaskRun/digest/user/agent/writer/binding/proposal all match exactly.
+4. Compare-and-set the source envelope to `cancelled`, copy the stored envelope binding and proposal arguments into exactly one fresh proposal/envelope pair, and park the same TaskRun `input-required`. Roll back on any race.
+5. Preserve inference, the independent decision, grants, approval separation, writer validation, receipt semantics, and all historical rows unchanged. Refuse completed writers/receipts, conflicting or ambiguous bindings/proposals, and unexpired envelopes.
+6. Prove the exact RED then GREEN, unexpired refusal, existing approved/failed recovery cases, adjacent submission/terminal-writer tests, web typecheck, source/docs/style/preflight guards, and protected GitHub checks. Record any local or semantic infrastructure failure as non-PASS.
+7. Deliver one DCO-signed protected PR, one canonical release, and one governed live upgrade. Require exact served SHA and CAN-TEST before replaying `...57CC78DB3778` once.
+8. Accept only the fresh exact envelope, separately approved same-TaskRun writer execution, and genuine baseline. Then record atomic coverage and finish PR #4891 through its normal protected queue.
+
+### Phase 14 atomic coverage
+
+The existing BI-DE bootstrap has no initiative scope baseline, so this table remains traceability evidence rather than a fabricated coverage receipt.
+
+| Deliverable | Requirement refs | Flow refs | Contract refs | Verification refs | Atomicity |
+| --- | --- | --- | --- | --- | --- |
+| Expired proposed-envelope same-TaskRun recovery | Phase 14.1, 14.3, 14.5, 14.8 | Phase 14.3, 14.4 | Phase 14.3, 14.4, 14.5 | Phase 14.2, 14.6, 14.7 | Source-envelope cancellation, exact proposal rebinding, TaskRun parking, fresh approval, and writer receipt form one audit chain. Partial delivery would either reuse expired authority or rerun the independent review. |

--- a/docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md
+++ b/docs/superpowers/specs/2026-08-25-immutable-source-review-traversal-design.md
@@ -200,3 +200,18 @@ This is orchestration recovery, not an alternate evidence model. It changes no r
 - Live reproduction: TaskRun `...634F7FF63BF8` remained identical-key and resumable with zero ToolExecutions; no approval envelope existed to recover.
 - Code cause: `reserveTerminalWriterReplay` returned `null` solely when the persisted reader list was empty, so context hydration and its deterministic exact-bound reread were never reached.
 - Ruled out: a replacement key would split the audit identity; approval recovery was impossible without an envelope; reader validation was not the failing layer because it never ran; cached replay did not reach provider capacity or inference.
+
+## Expired proposal same-TaskRun recovery extension (2026-08-31)
+
+Live design-review TaskRun `TR-MCP-Y210Nmg3bjg3MDBnYTAxbXhheDU2MXV2aQ-57CC78DB3778` reached its independently selected terminal writer and created proposal ToolExecution `cmthhuxly00a501qmsogavxv5` plus approval envelope `cmthhuxlm00a201qmftzezz1k`. The envelope expired while still `proposed`. An identical request replay preserved the TaskRun and digest but could neither execute the writer nor create a fresh envelope: approval recovery searched only `approved` and `failed` envelopes, while terminal-writer reservation accepted a prior proposal only after it was explicitly declined. The run remained `input-required/missing-terminal-writer` with no receipt or baseline.
+
+An expired `proposed` envelope is now a recovery source under the same transaction as expired approved/failed recovery. Recovery requires the exact TaskRun, request digest, delegating user, acting agent, writer tool, stored approval-binding fingerprint, and original proposal parameters. It refuses an unexpired proposal, a conflicting binding, an absent or ambiguous proposal, or any completed writer/receipt. The transaction compare-and-sets the source envelope from `proposed` to `cancelled`, creates exactly one replacement `proposed` envelope and rebound proposal ToolExecution with the identical stored arguments, and parks the same TaskRun for fresh exact approval. A race rolls back the transaction.
+
+This recovery does not rerun inference, change the independent disposition, synthesize approval, or alter receipt validation. The expired envelope and original proposal remain immutable audit history. The replacement has a fresh bounded expiry and still requires the human approval boundary before the writer can execute.
+
+### Named-reference research
+
+- Source reference: `origin/main` at `7961b6846da00450a4ac61b93e0636677ef66292`, `recoverStaleApprovedRemoteTask` and `reserveTerminalWriterReplay`.
+- Live reproduction: TaskRun `...57CC78DB3778`, expired proposed envelope `cmthhuxlm00a201qmftzezz1k`, proposal execution `cmthhuxly00a501qmsogavxv5`, zero writer receipt/baseline.
+- Code cause: the recovery query excluded `proposed`, and reservation required the prior proposal envelope to be `declined`.
+- Ruled out: stale approval would violate expiry; a new review identity would rerun inference and split the audit chain; bypassing the receipt would fabricate governance evidence.


### PR DESCRIPTION
## Summary

Recover an initiative-review TaskRun when its independently selected writer proposal expired before human approval. The recovery stays on the same TaskRun and request digest, preserves the original proposal and envelope as audit history, and creates exactly one fresh approval envelope without rerunning inference.

This is the prerequisite that allows PR #4891 to obtain its genuine design baseline and plan-coverage receipt. It does not bypass those protected gates.

## Changes

- include an expired `proposed` envelope in the existing transactional approval-recovery lane
- verify the exact TaskRun, request digest, user, agent, writer, stored binding fingerprint, and proposal arguments before recovery
- compare-and-set the expired proposal to `cancelled`, copy its exact stored binding/arguments into one fresh proposal and envelope, and park the same TaskRun for fresh approval
- classify the durable projection as `expired-proposed-envelope`
- preserve unexpired proposals, completed writers/receipts, mismatches, and races as fail-closed
- extend the canonical BI-DE design and atomic plan traceability

## Test plan

- [x] TDD RED: exact expired-proposed fixture failed because recovery excluded `proposed`
- [x] Focused GREEN: `mcp-task-approval-recovery.test.ts`, including unexpired-proposal refusal
- [x] Adjacent submission/execution/terminal-writer suites: 3 files, 36 tests PASS
- [x] `pnpm --filter web typecheck`
- [x] `pnpm docs:index:check`
- [x] `node scripts/check-style-drift.mjs`
- [x] `git diff --check`
- [x] `pnpm run pregate:preflight`: 61 guards clean, one environment-skipped Windows path-separator fixture
- [x] `pnpm dco:check`

## Verification disposition

The local PR-health fixture `scripts/lib/gate-context-runtime-contract.test.mjs` remains a known Windows path-separator failure: the Dockerfile contains the exact required `COPY scripts/check-data-impact.mjs`, while the fixture expects a backslash-separated token. This is recorded as non-PASS on WC-14EA9122. No semantic, local-CI, baseline, coverage, or receipt PASS is inferred. All protected PR and merge-group checks remain mandatory.

Local-CI-Override: operator-emergency: exact expired-proposed TaskRun recovery is TDD green; Windows path-separator preflight fixture is environment-skipped; protected GitHub checks mandatory

## Governance and audit identity

- Backlog-Item: BI-DE58CFE8
- Workroom: WC-14EA9122
- Blocking PR: #4891
- Preserved TaskRun: `TR-MCP-Y210Nmg3bjg3MDBnYTAxbXhheDU2MXV2aQ-57CC78DB3778`
- Expired envelope: `cmthhuxlm00a201qmftzezz1k`
- Original proposal execution: `cmthhuxly00a501qmsogavxv5`
- Inference rerun: false

## Design grounding

Design-Grounding-Decision: Extend the existing same-TaskRun approval-recovery transaction. The server-owned immutable request binding and persisted proposal remain the only recovery authority; expiry revokes the old envelope, fresh human approval remains mandatory, and no alternate inference or receipt path is introduced.
