### PR TITLE
fix: order terminal writer system context first

### DIFF
--- a/apps/web/lib/mcp-task-execution.ts
+++ b/apps/web/lib/mcp-task-execution.ts
@@ -127,10 +127,10 @@ export async function executeRemoteTaskAttempt(input: {
       systemPrompt: agent.systemPrompt,
       systemPromptInstructionSpans: coworkerBriefSpans(agent.systemPrompt),
       chatHistory: [
-        { role: "user", content: parsed.prompt },
         ...(input.resumeKind === "terminal-writer" && input.terminalWriterContext
           ? [{ role: "system" as const, content: input.terminalWriterContext }]
           : []),
+        { role: "user", content: parsed.prompt },
       ],
       sensitivity: agent.sensitivity ?? "internal",
       tools: tools.tools,

--- a/apps/web/lib/mcp-task-terminal-writer.test.ts
+++ b/apps/web/lib/mcp-task-terminal-writer.test.ts
@@ -577,11 +577,11 @@ describe("terminal writer resumption", () => {
     expect(autonomous.execute).toHaveBeenCalledWith(expect.objectContaining({
       taskRunId: "TR-MCP-WRITER-EXHAUSTED",
       chatHistory: [
-        { role: "user", content: exhaustedParams.prompt },
         expect.objectContaining({
           role: "system",
           content: expect.stringContaining("The same TaskRun preserves its immutable authority binding."),
         }),
+        { role: "user", content: exhaustedParams.prompt },
       ],
       terminalToolPolicy: expect.objectContaining({
         terminalPhase: "writer-only",

--- a/docs/superpowers/plans/2026-08-31-terminal-writer-system-message-order.md
+++ b/docs/superpowers/plans/2026-08-31-terminal-writer-system-message-order.md
@@ -1,0 +1,98 @@
+---
+status: active
+---
+
+# Terminal-writer system-message order — implementation plan
+
+Backlog item: `BI-EDC0DAF2`  
+Workroom: `WC-A291253B`  
+Design: `docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md`
+
+**For agentic workers:** execute this plan one independently reviewable backlog
+item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green
+implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate
+before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## Backlog coverage
+
+- Decision: `atomic`
+- Parent and delivery item: `BI-EDC0DAF2`
+- Receipt: pending immutable-artifact publication and governed coverage write
+- Dependencies: none
+- Rationale: the role-order regression test and the terminal-writer history
+  reorder are one safety fix. Neither is useful or safe to ship alone, and
+  acceptance requires deploying that exact combined change and replaying the
+  already-bound customer-zero TaskRun.
+
+## Change-impact contract
+
+The Workroom resolved the two claimed edit paths. Before Red, the contract
+requires graph-linked and colocated tests for
+`apps/web/lib/mcp-task-execution.ts`; those resolve to the existing
+`apps/web/lib/mcp-task-terminal-writer.test.ts` resumption coverage. Completion
+also requires the style-drift guard, `pnpm run pregate:preflight`, an exact-tree
+`pnpm run pregate`, and `pnpm pr:health` with review findings read.
+
+## Atomic delivery sequence
+
+### 1. Prove the regression
+
+- Touch: `apps/web/lib/mcp-task-terminal-writer.test.ts`.
+- Change the existing terminal-writer replay assertion to require provider
+  history in `system` then `user` order.
+- Run the focused test and retain the failure showing the current
+  `user` then `system` construction.
+- Verification reference: `AC-ORDER-RED` — the assertion fails before source
+  implementation for role order only.
+
+### 2. Correct provider-facing history
+
+- Touch: `apps/web/lib/mcp-task-execution.ts`.
+- Place hydrated terminal-writer system context before the original user
+  request. Preserve ordinary TaskRun history and every existing writer-policy,
+  immutable-binding, grant, reviewer, and idempotency contract.
+- Run the focused test and the terminal-writer/context/tool-policy suites.
+- Verification reference: `AC-ORDER-GREEN` — terminal replay is
+  `system` then `user`, while non-terminal execution remains unchanged.
+
+### 3. Prove delivery safety
+
+- Run the change-impact style guard, affected web tests, production build,
+  `pregate:preflight`, and the exact-tree pregate.
+- Commit with DCO sign-off, push, open a ready PR, inspect `pnpm pr:health`, and
+  use the merge queue.
+- Verification reference: `AC-GATE` — source, test, build, and governed PR
+  evidence all bind to the delivered SHA.
+
+### 4. Verify the customer-zero outcome
+
+- Advance the canonical runtime only through `/ops/self-upgrade`.
+- Replay TaskRun
+  `TR-MCP-Y21xamsxOWhsMDAwMDdwcnZzZm4ybTAzOQ-557F042B9990` without changing
+  its idempotency identity or immutable binding.
+- Verify its bound `record_initiative_evidence` writer executes and
+  `BI-B223F45E` research readiness becomes satisfied.
+- Verification reference: `AC-LIVE-REPLAY` — the original resumable TaskRun,
+  not a replacement, completes its governed writer.
+
+## Traceability
+
+- Requirement: `BI-EDC0DAF2#Acceptance`.
+- Contract: design `## Contract`.
+- Flow: design `## Ordered fix sequence` and this plan's atomic delivery
+  sequence.
+- Verification: `AC-ORDER-RED`, `AC-ORDER-GREEN`, `AC-GATE`, and
+  `AC-LIVE-REPLAY`.
+
+## Risks and rollback
+
+The narrow risk is changing message order for providers that accepted the old
+invalid sequence. Tests preserve the ordinary path and constrain the change to
+hydrated terminal-writer replay. Rollback is the single fix PR; if live replay
+regresses a hosted adapter, revert through the normal PR and merge queue, then
+advance the canonical runtime through `/ops/self-upgrade`. No migration or data
+rollback is involved.
+
+Documentation impact: the design and this plan are the durable contributor
+contract. The repair does not add owner-facing UX or change public product
+behavior.

--- a/docs/superpowers/plans/2026-08-31-terminal-writer-system-message-order.md
+++ b/docs/superpowers/plans/2026-08-31-terminal-writer-system-message-order.md
@@ -77,6 +77,8 @@ also requires the style-drift guard, `pnpm run pregate:preflight`, an exact-tree
 
 ## Traceability
 
+- Baseline objectives: `OBJ-TWSO-001`, `OBJ-TWSO-002`.
+- Baseline acceptance: `AC-TWSO-001`, `AC-TWSO-002`, `AC-TWSO-003`.
 - Requirement: `BI-EDC0DAF2#Acceptance`.
 - Contract: design `## Contract`.
 - Flow: design `## Ordered fix sequence` and this plan's atomic delivery

--- a/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
+++ b/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
@@ -42,9 +42,11 @@ reproduced this after reading BI-B223F45E commit
 - WC-22868A77 reconciled; other local inference continued; no matching PR exists.
 
 ## Verification mapping
-- **AC-TWSO-001** → OBJ-TWSO-001: focused test proves `system` then `user`.
-- **AC-TWSO-002** → OBJ-TWSO-002: ordinary path and fail-closed suites stay green.
-- **AC-TWSO-003** → OBJ-TWSO-001: customer-zero bound receipt succeeds live.
+| ID | Objectives | Acceptance criterion |
+| --- | --- | --- |
+| AC-TWSO-001 | OBJ-TWSO-001 | Focused test proves `system` then `user`. |
+| AC-TWSO-002 | OBJ-TWSO-002 | Ordinary path and fail-closed suites stay green. |
+| AC-TWSO-003 | OBJ-TWSO-001 | Customer-zero bound receipt succeeds live. |
 
 Documentation impact: this design is the durable internal contract. The change
 does not alter owner-facing behavior or public product documentation.

--- a/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
+++ b/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
@@ -3,7 +3,6 @@ status: active
 ---
 
 # Terminal-writer system-message order — fix design
-
 Backlog item: BI-EDC0DAF2  
 Workroom: WC-A291253B  
 Named baseline: `origin/main` at `be4c6bfcb4fd62f497167fa55c747105512a0ecd`
@@ -28,7 +27,6 @@ reproduced it after reading the immutable BI-B223F45E design at commit
 executions. Logs distinguish the ordering error from hosted capacity failures.
 
 ## Contract
-
 - Hydrated terminal-writer context is system authority and must appear before
   user content in provider-facing message history.
 - Ordinary external TaskRuns keep their existing message order.

--- a/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
+++ b/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
@@ -10,13 +10,10 @@ Named baseline: `origin/main` at `be4c6bfcb4fd62f497167fa55c747105512a0ecd`
 
 ## Problem and live evidence
 
-An external initiative-review TaskRun can complete its immutable reads and then
-resume in the writer-only phase. The resume path hydrates the verified source
-bytes into a system message, but `apps/web/lib/mcp-task-execution.ts` currently
-constructs `chatHistory` in this order:
-
-1. the original user request;
-2. the hydrated terminal-writer system context.
+An initiative-review TaskRun can complete its immutable reads and resume in the
+writer-only phase. That path hydrates source bytes into a system message, but
+`mcp-task-execution.ts` constructs `chatHistory` as user request then system
+context.
 
 That order is accepted by some hosted adapters but is invalid for the bundled
 local Qwen chat template, which requires system content to precede user
@@ -24,22 +21,19 @@ content. When hosted providers are unavailable, local fallback returns HTTP
 400 with `System message must be at the beginning`. The governed writer is
 never called and the same TaskRun remains `input-required`.
 
-Customer-zero reproduced the defect on 2026-08-31. TaskRun
-`TR-MCP-Y21xamsxOWhsMDAwMDdwcnZzZm4ybTAzOQ-557F042B9990` read all 51 lines of
-the immutable BI-B223F45E design at commit
+Customer-zero TaskRun `TR-MCP-Y21xamsxOWhsMDAwMDdwcnZzZm4ybTAzOQ-557F042B9990`
+reproduced it after reading the immutable BI-B223F45E design at commit
 `035a6335bd0e609bafbe96777ef6c5e0ea26bac0`, blob
-`b9fe8f0707291805fbc468aef62b401e0ee210a5`. Two terminal-writer replays then
-failed closed with zero writer executions. Live portal logs separate the local
-template error from concurrent hosted-provider capacity failures.
+`b9fe8f0707291805fbc468aef62b401e0ee210a5`. Two replays produced zero writer
+executions. Logs distinguish the ordering error from hosted capacity failures.
 
 ## Contract
 
 - Hydrated terminal-writer context is system authority and must appear before
   user content in provider-facing message history.
 - Ordinary external TaskRuns keep their existing message order.
-- Writer-only narrowing, immutable artifact binding, server-bound writer
-  arguments, PAT grant intersection, reviewer identity, and idempotency remain
-  unchanged.
+- Writer-only narrowing, immutable artifact binding, server-bound arguments,
+  PAT grant intersection, reviewer identity, and idempotency remain unchanged.
 - A provider failure remains fail-closed: no receipt is inferred from reads or
   prose, and the same TaskRun remains resumable.
 
@@ -57,28 +51,19 @@ template error from concurrent hosted-provider capacity failures.
    readiness becomes satisfied.
 
 ## Candidate causes ruled out
-
-- **Missing immutable source:** ruled out by four successful
-  `read_source_at_version` executions on the exact bound blob.
-- **Missing writer grant:** ruled out because the server issued the exact
-  two-tool packet to AGT-WS-BUILD and terminal replay narrowed to the bound
-  writer.
-- **Wrong Workroom identity:** ruled out by provider-verified base/head
-  reconciliation on WC-22868A77.
-- **A general local-model outage:** ruled out by the deterministic HTTP 400
-  parser response naming message order; unrelated local inference continued.
-- **An in-flight repair:** no open PR matched terminal-writer prompt ordering,
-  and `origin/main` still contains the user-then-system construction.
+- Missing source: four `read_source_at_version` calls read the bound blob.
+- Missing grant: the server issued the exact packet and narrowed to its writer.
+- Wrong Workroom: base/head reconciliation passed for WC-22868A77.
+- Local outage: HTTP 400 named message order while other inference continued.
+- In-flight repair: no matching PR exists; `origin/main` retains the defect.
 
 ## Verification mapping
-
 - Role ordering and ordinary-path preservation → focused
   `mcp-task-execution` test.
 - Terminal writer remains exact and fail-closed → existing
   `mcp-task-terminal-writer` and terminal-tool-policy suites.
 - Type and integration safety → affected web test gate and production build.
-- Functional acceptance → same TaskRun
-  `TR-MCP-Y21xamsxOWhsMDAwMDdwcnZzZm4ybTAzOQ-557F042B9990` records the bound
+- Functional acceptance → the same customer-zero TaskRun records its bound
   research receipt after canonical deployment.
 
 Documentation impact: this design is the durable internal contract. The change

--- a/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
+++ b/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
@@ -1,0 +1,85 @@
+---
+status: active
+---
+
+# Terminal-writer system-message order — fix design
+
+Backlog item: BI-EDC0DAF2  
+Workroom: WC-A291253B  
+Named baseline: `origin/main` at `be4c6bfcb4fd62f497167fa55c747105512a0ecd`
+
+## Problem and live evidence
+
+An external initiative-review TaskRun can complete its immutable reads and then
+resume in the writer-only phase. The resume path hydrates the verified source
+bytes into a system message, but `apps/web/lib/mcp-task-execution.ts` currently
+constructs `chatHistory` in this order:
+
+1. the original user request;
+2. the hydrated terminal-writer system context.
+
+That order is accepted by some hosted adapters but is invalid for the bundled
+local Qwen chat template, which requires system content to precede user
+content. When hosted providers are unavailable, local fallback returns HTTP
+400 with `System message must be at the beginning`. The governed writer is
+never called and the same TaskRun remains `input-required`.
+
+Customer-zero reproduced the defect on 2026-08-31. TaskRun
+`TR-MCP-Y21xamsxOWhsMDAwMDdwcnZzZm4ybTAzOQ-557F042B9990` read all 51 lines of
+the immutable BI-B223F45E design at commit
+`035a6335bd0e609bafbe96777ef6c5e0ea26bac0`, blob
+`b9fe8f0707291805fbc468aef62b401e0ee210a5`. Two terminal-writer replays then
+failed closed with zero writer executions. Live portal logs separate the local
+template error from concurrent hosted-provider capacity failures.
+
+## Contract
+
+- Hydrated terminal-writer context is system authority and must appear before
+  user content in provider-facing message history.
+- Ordinary external TaskRuns keep their existing message order.
+- Writer-only narrowing, immutable artifact binding, server-bound writer
+  arguments, PAT grant intersection, reviewer identity, and idempotency remain
+  unchanged.
+- A provider failure remains fail-closed: no receipt is inferred from reads or
+  prose, and the same TaskRun remains resumable.
+
+## Ordered fix sequence
+
+1. Add a failing unit test that captures `executeAutonomousAgenticLoop` input
+   for terminal-writer replay and asserts `system` precedes `user`.
+2. Reorder only the terminal-writer hydrated history in
+   `mcp-task-execution.ts`.
+3. Run the focused MCP task execution and terminal-writer suites, then the
+   affected web tests and production build.
+4. Advance the canonical runtime through `/ops/self-upgrade`.
+5. Replay the existing customer-zero TaskRun and verify that its bound
+   `record_initiative_evidence` writer executes and BI-B223F45E research
+   readiness becomes satisfied.
+
+## Candidate causes ruled out
+
+- **Missing immutable source:** ruled out by four successful
+  `read_source_at_version` executions on the exact bound blob.
+- **Missing writer grant:** ruled out because the server issued the exact
+  two-tool packet to AGT-WS-BUILD and terminal replay narrowed to the bound
+  writer.
+- **Wrong Workroom identity:** ruled out by provider-verified base/head
+  reconciliation on WC-22868A77.
+- **A general local-model outage:** ruled out by the deterministic HTTP 400
+  parser response naming message order; unrelated local inference continued.
+- **An in-flight repair:** no open PR matched terminal-writer prompt ordering,
+  and `origin/main` still contains the user-then-system construction.
+
+## Verification mapping
+
+- Role ordering and ordinary-path preservation → focused
+  `mcp-task-execution` test.
+- Terminal writer remains exact and fail-closed → existing
+  `mcp-task-terminal-writer` and terminal-tool-policy suites.
+- Type and integration safety → affected web test gate and production build.
+- Functional acceptance → same TaskRun
+  `TR-MCP-Y21xamsxOWhsMDAwMDdwcnZzZm4ybTAzOQ-557F042B9990` records the bound
+  research receipt after canonical deployment.
+
+Documentation impact: this design is the durable internal contract. The change
+does not alter owner-facing behavior or public product documentation.

--- a/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
+++ b/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
@@ -8,7 +8,6 @@ Workroom: WC-A291253B
 Named baseline: `origin/main` at `be4c6bfcb4fd62f497167fa55c747105512a0ecd`
 
 ## Problem and live evidence
-
 An initiative-review TaskRun can complete its immutable reads and resume in the
 writer-only phase. That path hydrates source bytes into a system message, but
 `mcp-task-execution.ts` constructs `chatHistory` as user request then system
@@ -36,7 +35,6 @@ executions. Logs distinguish the ordering error from hosted capacity failures.
   prose, and the same TaskRun remains resumable.
 
 ## Ordered fix sequence
-
 1. Add a failing unit test that captures `executeAutonomousAgenticLoop` input
    for terminal-writer replay and asserts `system` precedes `user`.
 2. Reorder only the terminal-writer hydrated history in

--- a/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
+++ b/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
@@ -7,23 +7,19 @@ Backlog item: BI-EDC0DAF2
 Workroom: WC-A291253B  
 Named baseline: `origin/main` at `be4c6bfcb4fd62f497167fa55c747105512a0ecd`
 
+## Objectives
+**OBJ-TWSO-001:** Put hydrated terminal-writer system authority before user content.
+**OBJ-TWSO-002:** Preserve ordinary history and every existing fail-closed control.
+
 ## Problem and live evidence
-An initiative-review TaskRun can complete its immutable reads and resume in the
-writer-only phase. That path hydrates source bytes into a system message, but
-`mcp-task-execution.ts` constructs `chatHistory` as user request then system
-context.
-
-That order is accepted by some hosted adapters but is invalid for the bundled
-local Qwen chat template, which requires system content to precede user
-content. When hosted providers are unavailable, local fallback returns HTTP
-400 with `System message must be at the beginning`. The governed writer is
-never called and the same TaskRun remains `input-required`.
-
+An initiative-review TaskRun can complete immutable reads and resume writer-only,
+but `mcp-task-execution.ts` builds history as user then hydrated system context.
+Bundled local Qwen refuses that order with HTTP 400, `System message must be at
+the beginning`; the writer is not called and the same run remains resumable.
 Customer-zero TaskRun `TR-MCP-Y21xamsxOWhsMDAwMDdwcnZzZm4ybTAzOQ-557F042B9990`
-reproduced it after reading the immutable BI-B223F45E design at commit
+reproduced this after reading BI-B223F45E commit
 `035a6335bd0e609bafbe96777ef6c5e0ea26bac0`, blob
-`b9fe8f0707291805fbc468aef62b401e0ee210a5`. Two replays produced zero writer
-executions. Logs distinguish the ordering error from hosted capacity failures.
+`b9fe8f0707291805fbc468aef62b401e0ee210a5`; two replays wrote no receipt.
 
 ## Contract
 - Hydrated terminal-writer context is system authority and must appear before
@@ -35,32 +31,20 @@ executions. Logs distinguish the ordering error from hosted capacity failures.
   prose, and the same TaskRun remains resumable.
 
 ## Ordered fix sequence
-1. Add a failing unit test that captures `executeAutonomousAgenticLoop` input
-   for terminal-writer replay and asserts `system` precedes `user`.
-2. Reorder only the terminal-writer hydrated history in
-   `mcp-task-execution.ts`.
-3. Run the focused MCP task execution and terminal-writer suites, then the
-   affected web tests and production build.
+1. Add a failing test that asserts terminal-writer `system` precedes `user`.
+2. Reorder only terminal-writer hydrated history in `mcp-task-execution.ts`.
+3. Run focused MCP suites, affected web tests, and the production build.
 4. Advance the canonical runtime through `/ops/self-upgrade`.
-5. Replay the existing customer-zero TaskRun and verify that its bound
-   `record_initiative_evidence` writer executes and BI-B223F45E research
-   readiness becomes satisfied.
+5. Replay the customer-zero run; verify its bound writer and BI-B223F45E readiness.
 
 ## Candidate causes ruled out
-- Missing source: four `read_source_at_version` calls read the bound blob.
-- Missing grant: the server issued the exact packet and narrowed to its writer.
-- Wrong Workroom: base/head reconciliation passed for WC-22868A77.
-- Local outage: HTTP 400 named message order while other inference continued.
-- In-flight repair: no matching PR exists; `origin/main` retains the defect.
+- Source and grant exist: four exact reads passed and the packet narrowed to its writer.
+- WC-22868A77 reconciled; other local inference continued; no matching PR exists.
 
 ## Verification mapping
-- Role ordering and ordinary-path preservation → focused
-  `mcp-task-execution` test.
-- Terminal writer remains exact and fail-closed → existing
-  `mcp-task-terminal-writer` and terminal-tool-policy suites.
-- Type and integration safety → affected web test gate and production build.
-- Functional acceptance → the same customer-zero TaskRun records its bound
-  research receipt after canonical deployment.
+- **AC-TWSO-001** → OBJ-TWSO-001: focused test proves `system` then `user`.
+- **AC-TWSO-002** → OBJ-TWSO-002: ordinary path and fail-closed suites stay green.
+- **AC-TWSO-003** → OBJ-TWSO-001: customer-zero bound receipt succeeds live.
 
 Documentation impact: this design is the durable internal contract. The change
 does not alter owner-facing behavior or public product documentation.


### PR DESCRIPTION
## Summary

Terminal-writer replay placed hydrated system authority after the user request. Local Qwen rejects that provider history with `System message must be at the beginning`, leaving the governed writer uncalled. This change places terminal-writer system context first while leaving ordinary TaskRun history and the existing writer, binding, grant, reviewer, and idempotency controls unchanged.

## Changes

- Assert `system` then `user` ordering in the terminal-writer replay suite.
- Reorder only the conditional terminal-writer history in `mcp-task-execution.ts`.
- Add the approved baseline objective and acceptance IDs to the atomic implementation plan.

## Test plan

- [x] **Source-only change** (isolated provider-history construction)
  - [x] Scoped TypeScript typecheck passed in the DCO pre-commit hook.
  - [x] Targeted tests: seven MCP task/recovery suites, 75/75 tests passed.
- [ ] **Runtime-bound change**
- [ ] **Verification-harness limitation acknowledged**

### Verification evidence

- TDD red: the terminal-writer test failed because current history was `user → system`.
- TDD green: `mcp-task-terminal-writer.test.ts`, 7/7 passed.
- Adjacent MCP task/recovery suites: 75/75 passed.
- `node scripts/check-style-drift.mjs`: passed.
- `pnpm run pregate:preflight`: 61/61 guards passed.
- `pnpm --filter web build`: completed successfully; existing Edge Runtime warnings remained non-fatal.
- `pnpm run pregate`: passed for `dbb67475e0e7a458eed28cba3cee9aa2d8097285`, evidence `cmthzbh021rbp01lc26ts8xo6`.
- Semantic review: pass with zero blocking findings, evidence `cmthzg9ry1vbu01lc8ax8jv62`.
- Post-merge acceptance: advance the canonical runtime through `/ops/self-upgrade`, then replay the original bound customer-zero TaskRun.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed against the final diff.
- [x] `pnpm run pregate:preflight` passed before the shared-sandbox lease.
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`.
- [x] `pnpm pr:ready -- --pr-body-file /private/tmp/terminal-writer-pr.md` will be run against this exact body before PR creation.

Local-CI-Evidence: cmthzbh021rbp01lc26ts8xo6 (fix/terminal-writer-system-order@dbb67475e0e7a458eed28cba3cee9aa2d8097285)

## Related issues / Epic

- Backlog item: `BI-EDC0DAF2`
- Workroom: `WC-A291253B`
- Epic: `EP-413F2602`

## Overlap sweep

`gh pr list --state open --limit 50` returned no open PRs. Recent `main` includes the earlier zero-reader recovery, but no change that corrects terminal-writer message order.

## Notes for the reviewer

There is no schema, migration, public API, or UI change. The live acceptance step deliberately follows merge because the canonical install advances only through `/ops/self-upgrade`; it will replay the existing TaskRun without changing its immutable binding or idempotency identity.
