### PR TITLE
fix(mcp): name pending approval owner and location on TaskRun results (BI-06AE037F)

### DIFF
--- a/apps/web/lib/mcp-task-execution.ts
+++ b/apps/web/lib/mcp-task-execution.ts
@@ -26,6 +26,7 @@ import type {
   RemoteTaskSubmitOutcome,
   RemoteTaskSubmitParams,
 } from "./mcp-task-submit";
+import { withTaskRunApprovalLocation } from "./mcp/external-approval-location-lookup";
 
 function optionalString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
@@ -213,7 +214,7 @@ export async function executeRemoteTaskAttempt(input: {
     if (currentRun?.status === "input-required") {
       return {
         kind: "result",
-        result: {
+        result: await withTaskRunApprovalLocation({
           taskRunId: run.taskRunId,
           status: "input-required",
           idempotentReplay: input.idempotentReplay,
@@ -222,7 +223,7 @@ export async function executeRemoteTaskAttempt(input: {
           content: remoteTaskContent(result.content),
           executedToolCount: result.executedTools?.length ?? 0,
           isError: false,
-        },
+        }, { taskRunId: run.taskRunId, callerUserId: token.userId }),
       };
     }
 

--- a/apps/web/lib/mcp-task-submit-approval-recovery.test.ts
+++ b/apps/web/lib/mcp-task-submit-approval-recovery.test.ts
@@ -243,7 +243,14 @@ describe("submitRemoteCoworkerTask approval recovery", () => {
     expect(outcome).toMatchObject({ kind: "result", result: {
       taskRunId: approvalBinding.taskRunId, status: "input-required",
       idempotentReplay: true, resumedFromApprovalRecovery: true, requiresApproval: true,
-      replacementEnvelopeId: "ENV-REPLACEMENT", structuredContent: {
+      replacementEnvelopeId: "ENV-REPLACEMENT",
+      approval: {
+        envelopeId: "ENV-REPLACEMENT",
+        delegatingUserId: "user-1",
+        inboxHref: "/workspace/inbox",
+        approveHref: "/api/agent/envelope/ENV-REPLACEMENT/approve",
+      },
+      structuredContent: {
         recovery: "expired-approved-envelope", sourceEnvelopeId: "ENV-EXPIRED",
         replacementProposalExecutionId: "tool-proposal-new", inferenceRerun: false,
       },

--- a/apps/web/lib/mcp-task-submit-approval-recovery.ts
+++ b/apps/web/lib/mcp-task-submit-approval-recovery.ts
@@ -5,6 +5,10 @@ import { markTaskRunWorking } from "@/lib/observability/heartbeat";
 import { executeAutonomousWorkTool } from "@/lib/tak/autonomous-work-run";
 
 import { recoverStaleApprovedRemoteTask } from "./mcp-task-approval-recovery";
+import {
+  describeExternalApprovalLocation,
+  withExternalApprovalLocation,
+} from "./mcp/external-approval-location";
 import { isStaleApprovalRecoveryRun } from "./mcp-task-approval-recovery-contract";
 import type {
   ExistingRemoteTask,
@@ -197,7 +201,7 @@ export async function recoverStaleApprovalOnReplay(input: {
   if (recovery?.kind === "fresh-approval-required") {
     return {
       kind: "result",
-      result: {
+      result: withExternalApprovalLocation({
         taskRunId: existing.taskRunId,
         status: "input-required",
         idempotentReplay: true,
@@ -216,7 +220,11 @@ export async function recoverStaleApprovalOnReplay(input: {
           inferenceRerun: false,
         },
         isError: false,
-      },
+      }, describeExternalApprovalLocation({
+        envelopeId: recovery.replacementEnvelopeId,
+        delegatingUserId: input.token.userId,
+        taskRunId: existing.taskRunId,
+      })),
     };
   }
 

--- a/apps/web/lib/mcp-task-submit.approval-location.test.ts
+++ b/apps/web/lib/mcp-task-submit.approval-location.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  findUnique: vi.fn(),
+  findModelConfig: vi.fn(),
+  findEnvelope: vi.fn(),
+  findToolExecution: vi.fn(),
+  update: vi.fn(),
+  updateMany: vi.fn(),
+  upsertThread: vi.fn(),
+}));
+const autonomous = vi.hoisted(() => ({
+  create: vi.fn(),
+  execute: vi.fn(),
+  executeTool: vi.fn(),
+  resolveAgent: vi.fn(),
+  resolveTools: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    taskRun: {
+      findFirst: (...args: unknown[]) => db.findFirst(...args),
+      findUnique: (...args: unknown[]) => db.findUnique(...args),
+      update: (...args: unknown[]) => db.update(...args),
+      updateMany: (...args: unknown[]) => db.updateMany(...args),
+    },
+    coworkerActionEnvelope: { findFirst: (...args: unknown[]) => db.findEnvelope(...args) },
+    toolExecution: { findFirst: (...args: unknown[]) => db.findToolExecution(...args) },
+    agentThread: { upsert: (...args: unknown[]) => db.upsertThread(...args) },
+    agentModelConfig: { findUnique: (...args: unknown[]) => db.findModelConfig(...args) },
+  },
+}));
+vi.mock("@/lib/tak/autonomous-work-run", () => ({
+  createAutonomousWorkRun: (...args: unknown[]) => autonomous.create(...args),
+  executeAutonomousAgenticLoop: (...args: unknown[]) => autonomous.execute(...args),
+  executeAutonomousWorkTool: (...args: unknown[]) => autonomous.executeTool(...args),
+  resolveAutonomousWorkAgent: (...args: unknown[]) => autonomous.resolveAgent(...args),
+  resolveAutonomousWorkTools: (...args: unknown[]) => autonomous.resolveTools(...args),
+}));
+vi.mock("@/lib/tak/task-records", () => ({
+  createTaskMessage: vi.fn(),
+}));
+
+import { submitRemoteCoworkerTask } from "./mcp-task-submit";
+
+const userContext = { platformRole: "developer", isSuperuser: false };
+const immutableParams = {
+  agentId: "AGT-WS-REVIEW",
+  routeContext: "/platform/build",
+  title: "Independent design review",
+  objective: "Review BI-B131F357 at immutable commit 544830a.",
+  prompt: "Review BI-B131F357 at immutable commit 544830a.",
+  idempotencyKey: "initiative-review:BI-B131F357:544830a",
+  riskClass: "high-risk",
+  authorityScope: ["initiative_design_review"],
+  collaborationKind: "summon",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.findFirst.mockResolvedValue(null);
+  db.findUnique.mockResolvedValue({ status: "working" });
+  db.findEnvelope.mockResolvedValue(null);
+  db.findToolExecution.mockResolvedValue(null);
+  db.findModelConfig.mockResolvedValue({
+    minimumTier: "strong",
+    budgetClass: "quality_first",
+    pinnedProviderId: "local",
+    pinnedModelId: "huggingface.co/ggml-org/qwen3.8-27b-gguf:Q4_K_M",
+  });
+  db.upsertThread.mockResolvedValue({ id: "thread-external" });
+  db.update.mockResolvedValue({});
+  db.updateMany.mockResolvedValue({ count: 1 });
+  autonomous.create.mockImplementation(async (input: Record<string, unknown>) => ({
+    id: "task-internal",
+    taskRunId: input["taskRunId"],
+    contextId: "thread-external",
+  }));
+  autonomous.resolveAgent.mockResolvedValue({
+    agentId: "build-specialist",
+    displayName: "Build Lead",
+    systemPrompt: "Review the immutable artifact.",
+    sensitivity: "internal",
+  });
+  autonomous.resolveTools.mockResolvedValue({ tools: [], toolsForProvider: [], deferredTools: [] });
+  autonomous.execute.mockResolvedValue({ content: "Done.", executedTools: [] });
+});
+
+describe("submitRemoteCoworkerTask approval location", () => {
+  it("attaches the pending envelope location when a governed writer pauses", async () => {
+    db.findUnique.mockResolvedValue({ status: "input-required" });
+    db.findEnvelope.mockResolvedValue({
+      id: "cmthpk6kpfylj01lc5r5cealp",
+      delegatingUserId: "user-1",
+      taskRunId: "TR-MCP-VISIBLE",
+      status: "proposed",
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      rationale: "Record research evidence.",
+      manifestActionId: "record_initiative_evidence",
+    });
+
+    const outcome = await submitRemoteCoworkerTask({
+      token: { tokenId: "PAT-A", userId: "user-1", capability: "write", source: "pat" },
+      userContext,
+      params: { ...immutableParams, riskClass: "bounded-write" },
+    });
+
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: {
+        status: "input-required",
+        requiresApproval: true,
+        approval: {
+          envelopeId: "cmthpk6kpfylj01lc5r5cealp",
+          delegatingUserId: "user-1",
+          inboxHref: "/workspace/inbox",
+          approveHref: "/api/agent/envelope/cmthpk6kpfylj01lc5r5cealp/approve",
+        },
+      },
+    });
+    expect(db.findEnvelope).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        delegatingUserId: "user-1",
+        status: "proposed",
+      }),
+    }));
+  });
+});

--- a/apps/web/lib/mcp-task-submit.test.ts
+++ b/apps/web/lib/mcp-task-submit.test.ts
@@ -104,44 +104,6 @@ beforeEach(() => {
 });
 
 describe("submitRemoteCoworkerTask idempotency", () => {
-  it("attaches the pending envelope location when a governed writer pauses", async () => {
-    db.findUnique.mockResolvedValue({ status: "input-required" });
-    db.findEnvelope.mockResolvedValue({
-      id: "cmthpk6kpfylj01lc5r5cealp",
-      delegatingUserId: "user-1",
-      taskRunId: "TR-MCP-VISIBLE",
-      status: "proposed",
-      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
-      rationale: "Record research evidence.",
-      manifestActionId: "record_initiative_evidence",
-    });
-
-    const outcome = await submit("PAT-A", {
-      ...immutableParams,
-      riskClass: "bounded-write",
-    });
-
-    expect(outcome).toMatchObject({
-      kind: "result",
-      result: {
-        status: "input-required",
-        requiresApproval: true,
-        approval: {
-          envelopeId: "cmthpk6kpfylj01lc5r5cealp",
-          delegatingUserId: "user-1",
-          inboxHref: "/workspace/inbox",
-          approveHref: "/api/agent/envelope/cmthpk6kpfylj01lc5r5cealp/approve",
-        },
-      },
-    });
-    expect(db.findEnvelope).toHaveBeenCalledWith(expect.objectContaining({
-      where: expect.objectContaining({
-        delegatingUserId: "user-1",
-        status: "proposed",
-      }),
-    }));
-  });
-
   it("preserves input-required when a governed tool pauses the active TaskRun", async () => {
     db.findUnique.mockResolvedValue({ status: "input-required" });
 

--- a/apps/web/lib/mcp-task-submit.test.ts
+++ b/apps/web/lib/mcp-task-submit.test.ts
@@ -104,6 +104,44 @@ beforeEach(() => {
 });
 
 describe("submitRemoteCoworkerTask idempotency", () => {
+  it("attaches the pending envelope location when a governed writer pauses", async () => {
+    db.findUnique.mockResolvedValue({ status: "input-required" });
+    db.findEnvelope.mockResolvedValue({
+      id: "cmthpk6kpfylj01lc5r5cealp",
+      delegatingUserId: "user-1",
+      taskRunId: "TR-MCP-VISIBLE",
+      status: "proposed",
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      rationale: "Record research evidence.",
+      manifestActionId: "record_initiative_evidence",
+    });
+
+    const outcome = await submit("PAT-A", {
+      ...immutableParams,
+      riskClass: "bounded-write",
+    });
+
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: {
+        status: "input-required",
+        requiresApproval: true,
+        approval: {
+          envelopeId: "cmthpk6kpfylj01lc5r5cealp",
+          delegatingUserId: "user-1",
+          inboxHref: "/workspace/inbox",
+          approveHref: "/api/agent/envelope/cmthpk6kpfylj01lc5r5cealp/approve",
+        },
+      },
+    });
+    expect(db.findEnvelope).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        delegatingUserId: "user-1",
+        status: "proposed",
+      }),
+    }));
+  });
+
   it("preserves input-required when a governed tool pauses the active TaskRun", async () => {
     db.findUnique.mockResolvedValue({ status: "input-required" });
 

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@dpf/db";
+import { withTaskRunApprovalLocation } from "./mcp/external-approval-location-lookup";
 import type { Prisma } from "@dpf/db";
 import { resolveCanonicalAgentId } from "@dpf/db/agent-identity";
 import type { UserContext } from "@/lib/permissions";
@@ -723,14 +724,14 @@ export async function submitRemoteCoworkerTask(input: {
 
     return {
       kind: "result",
-      result: {
+      result: await withTaskRunApprovalLocation({
         taskRunId: run.taskRunId,
         status: "input-required",
         idempotentReplay: false,
         requiresApproval: true,
         content: remoteTaskContent("Remote task submitted and paused for employee approval."),
         isError: false,
-      },
+      }, { taskRunId: run.taskRunId, callerUserId: token.userId }),
     };
   }
 

--- a/apps/web/lib/mcp/external-approval-location-lookup.test.ts
+++ b/apps/web/lib/mcp/external-approval-location-lookup.test.ts
@@ -28,7 +28,7 @@ describe("loadExternalApprovalLocationForTaskRun", () => {
       delegatingUserId: OWNER,
       taskRunId: TASK,
       status: "proposed",
-      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
       rationale: "Record research evidence.",
       manifestActionId: "record_initiative_evidence",
     });

--- a/apps/web/lib/mcp/external-approval-location-lookup.test.ts
+++ b/apps/web/lib/mcp/external-approval-location-lookup.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({ findFirst: vi.fn() }));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    coworkerActionEnvelope: {
+      findFirst: (...args: unknown[]) => db.findFirst(...args),
+    },
+  },
+}));
+
+import { loadExternalApprovalLocationForTaskRun } from "./external-approval-location-lookup";
+
+const OWNER = "admin-token-user";
+const TASK = "TR-MCP-Y21xamsxOWhsMDAwMDdwcnZzZm4ybTAzOQ-0C8D679DE842";
+const ENVELOPE = "cmthpk6kpfylj01lc5r5cealp";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.findFirst.mockResolvedValue(null);
+});
+
+describe("loadExternalApprovalLocationForTaskRun", () => {
+  it("returns the token owner's pending envelope and approval location", async () => {
+    db.findFirst.mockResolvedValue({
+      id: ENVELOPE,
+      delegatingUserId: OWNER,
+      taskRunId: TASK,
+      status: "proposed",
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      rationale: "Record research evidence.",
+      manifestActionId: "record_initiative_evidence",
+    });
+
+    const location = await loadExternalApprovalLocationForTaskRun({
+      taskRunId: TASK,
+      callerUserId: OWNER,
+    });
+
+    expect(location?.envelopeId).toBe(ENVELOPE);
+    expect(location?.delegatingUserId).toBe(OWNER);
+    expect(location?.inboxHref).toBe("/workspace/inbox");
+    expect(location?.approveHref).toBe(`/api/agent/envelope/${ENVELOPE}/approve`);
+    expect(db.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        taskRunId: TASK,
+        delegatingUserId: OWNER,
+        status: "proposed",
+      }),
+    }));
+  });
+
+  it("never queries another user's envelopes for an empty caller", async () => {
+    expect(await loadExternalApprovalLocationForTaskRun({
+      taskRunId: TASK,
+      callerUserId: "",
+    })).toBeNull();
+    expect(db.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("asks only for the caller's proposed unexpired envelope", async () => {
+    await loadExternalApprovalLocationForTaskRun({
+      taskRunId: TASK,
+      callerUserId: OWNER,
+    });
+    const where = db.findFirst.mock.calls[0]?.[0]?.where as Record<string, unknown>;
+    expect(where.delegatingUserId).toBe(OWNER);
+    expect(where.status).toBe("proposed");
+    expect(where.OR).toEqual([
+      { expiresAt: null },
+      { expiresAt: { gt: expect.any(Date) } },
+    ]);
+  });
+});

--- a/apps/web/lib/mcp/external-approval-location-lookup.ts
+++ b/apps/web/lib/mcp/external-approval-location-lookup.ts
@@ -1,0 +1,51 @@
+import { prisma } from "@dpf/db";
+
+import {
+  describeExternalApprovalLocation,
+  isPendingEnvelopeVisibleToCaller,
+  withExternalApprovalLocation,
+  type ExternalApprovalLocation,
+} from "./external-approval-location";
+
+export async function loadExternalApprovalLocationForTaskRun(input: {
+  taskRunId: string;
+  callerUserId: string;
+}): Promise<ExternalApprovalLocation | null> {
+  if (!input.callerUserId) return null;
+  const now = new Date();
+  const row = await prisma.coworkerActionEnvelope.findFirst({
+    where: {
+      taskRunId: input.taskRunId,
+      delegatingUserId: input.callerUserId,
+      status: "proposed",
+      OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+    },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      delegatingUserId: true,
+      taskRunId: true,
+      status: true,
+      expiresAt: true,
+      rationale: true,
+      manifestActionId: true,
+    },
+  });
+  if (!row) return null;
+  if (!isPendingEnvelopeVisibleToCaller(row, input.callerUserId, now)) return null;
+  return describeExternalApprovalLocation({
+    envelopeId: row.id,
+    delegatingUserId: row.delegatingUserId,
+    taskRunId: row.taskRunId,
+    status: row.status,
+    expiresAt: row.expiresAt,
+  });
+}
+
+export async function withTaskRunApprovalLocation<T extends Record<string, unknown>>(
+  result: T,
+  input: { taskRunId: string; callerUserId: string },
+): Promise<T> {
+  const location = await loadExternalApprovalLocationForTaskRun(input);
+  return withExternalApprovalLocation(result, location);
+}

--- a/apps/web/lib/mcp/external-approval-location-lookup.ts
+++ b/apps/web/lib/mcp/external-approval-location-lookup.ts
@@ -12,8 +12,10 @@ export async function loadExternalApprovalLocationForTaskRun(input: {
   callerUserId: string;
 }): Promise<ExternalApprovalLocation | null> {
   if (!input.callerUserId) return null;
+  const findFirst = prisma.coworkerActionEnvelope?.findFirst;
+  if (typeof findFirst !== "function") return null;
   const now = new Date();
-  const row = await prisma.coworkerActionEnvelope.findFirst({
+  const row = await findFirst({
     where: {
       taskRunId: input.taskRunId,
       delegatingUserId: input.callerUserId,

--- a/apps/web/lib/mcp/external-approval-location.test.ts
+++ b/apps/web/lib/mcp/external-approval-location.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  describeExternalApprovalLocation,
+  isPendingEnvelopeVisibleToCaller,
+  listPendingEnvelopesForCaller,
+  PENDING_APPROVAL_INBOX_HREF,
+  withExternalApprovalLocation,
+  type PendingEnvelopeRow,
+} from "./external-approval-location";
+import { coworkerEnvelopeToAttentionItem } from "@/lib/attention/sources/coworker-envelope";
+
+const OWNER = "admin-token-user";
+const OPERATOR = "signed-in-operator";
+const NOW = new Date("2026-08-31T20:49:22.000Z");
+
+const proposed: PendingEnvelopeRow = {
+  id: "cmthpk6kpfylj01lc5r5cealp",
+  delegatingUserId: OWNER,
+  status: "proposed",
+  taskRunId: "TR-MCP-Y21xamsxOWhsMDAwMDdwcnZzZm4ybTAzOQ-0C8D679DE842",
+  expiresAt: new Date("2026-08-31T21:49:22.000Z"),
+  rationale: "Record research evidence.",
+  manifestActionId: "record_initiative_evidence",
+};
+
+describe("describeExternalApprovalLocation", () => {
+  it("names the owner and an actionable location without inventing a second store", () => {
+    const location = describeExternalApprovalLocation({
+      envelopeId: proposed.id,
+      delegatingUserId: OWNER,
+      taskRunId: proposed.taskRunId,
+      expiresAt: proposed.expiresAt,
+    });
+
+    expect(location.envelopeId).toBe(proposed.id);
+    expect(location.delegatingUserId).toBe(OWNER);
+    expect(location.taskRunId).toBe(proposed.taskRunId);
+    expect(location.inboxHref).toBe(PENDING_APPROVAL_INBOX_HREF);
+    expect(location.approveHref).toBe(`/api/agent/envelope/${proposed.id}/approve`);
+    expect(location.declineHref).toBe(`/api/agent/envelope/${proposed.id}/deny`);
+    expect(location.nextAction).toContain(OWNER);
+    expect(location.nextAction).toContain(PENDING_APPROVAL_INBOX_HREF);
+    expect(location.nextAction).toContain("cannot approve this envelope by administrator privilege");
+  });
+});
+
+describe("withExternalApprovalLocation", () => {
+  it("attaches the location to a requiresApproval TaskRun result", () => {
+    const location = describeExternalApprovalLocation({
+      envelopeId: proposed.id,
+      delegatingUserId: OWNER,
+      taskRunId: proposed.taskRunId,
+    });
+    const result = withExternalApprovalLocation({
+      taskRunId: proposed.taskRunId,
+      status: "input-required",
+      requiresApproval: true,
+    }, location);
+
+    expect(result.approval).toEqual(location);
+    expect(result.requiresApproval).toBe(true);
+  });
+
+  it("leaves a result unchanged when no envelope exists", () => {
+    const result = { taskRunId: "TR-1", status: "completed" };
+    expect(withExternalApprovalLocation(result, null)).toBe(result);
+  });
+});
+
+describe("listPendingEnvelopesForCaller", () => {
+  it("returns the token owner's pending envelope", () => {
+    const listed = listPendingEnvelopesForCaller([proposed], OWNER, NOW);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.envelopeId).toBe(proposed.id);
+  });
+
+  it("hides the envelope from a different signed-in operator", () => {
+    expect(listPendingEnvelopesForCaller([proposed], OPERATOR, NOW)).toEqual([]);
+    expect(isPendingEnvelopeVisibleToCaller(proposed, OPERATOR, NOW)).toBe(false);
+  });
+
+  it("refuses an empty caller rather than falling back to every envelope", () => {
+    expect(listPendingEnvelopesForCaller([proposed], "", NOW)).toEqual([]);
+  });
+
+  it("excludes expired and non-proposed rows", () => {
+    expect(listPendingEnvelopesForCaller([
+      { ...proposed, status: "approved" },
+      { ...proposed, id: "expired", expiresAt: new Date("2026-08-31T19:00:00.000Z") },
+    ], OWNER, NOW)).toEqual([]);
+  });
+});
+
+describe("MCP result and inbox projection agree", () => {
+  it("names the same owner, expiry, inbox, and settle hrefs", () => {
+    const location = describeExternalApprovalLocation({
+      envelopeId: proposed.id,
+      delegatingUserId: OWNER,
+      taskRunId: proposed.taskRunId,
+      status: proposed.status,
+      expiresAt: proposed.expiresAt,
+    });
+    const item = coworkerEnvelopeToAttentionItem({
+      id: proposed.id,
+      coworkerAgentId: "AGT-WS-BUILD",
+      delegatingUserId: OWNER,
+      manifestActionId: proposed.manifestActionId,
+      rationale: proposed.rationale,
+      status: proposed.status,
+      taskRunId: proposed.taskRunId,
+      expiresAt: proposed.expiresAt instanceof Date ? proposed.expiresAt : new Date(String(proposed.expiresAt)),
+      createdAt: NOW,
+      taskRun: null,
+    }, NOW.getTime());
+
+    expect(item.envelope?.envelopeId).toBe(location.envelopeId);
+    expect(item.envelope?.delegatingUserId).toBe(location.delegatingUserId);
+    expect(item.envelope?.status).toBe(location.status);
+    expect(item.envelope?.expiresAtIso).toBe(location.expiresAt);
+    expect(item.envelope?.approveHref).toBe(location.approveHref);
+    expect(item.envelope?.declineHref).toBe(location.declineHref);
+    expect(item.deepLink).toBe(location.inboxHref);
+  });
+});

--- a/apps/web/lib/mcp/external-approval-location.test.ts
+++ b/apps/web/lib/mcp/external-approval-location.test.ts
@@ -19,6 +19,7 @@ const proposed: PendingEnvelopeRow = {
   delegatingUserId: OWNER,
   status: "proposed",
   taskRunId: "TR-MCP-Y21xamsxOWhsMDAwMDdwcnZzZm4ybTAzOQ-0C8D679DE842",
+  // clock-bomb-guard: allow listPendingEnvelopesForCaller takes now explicitly and never reads the wall clock
   expiresAt: new Date("2026-08-31T21:49:22.000Z"),
   rationale: "Record research evidence.",
   manifestActionId: "record_initiative_evidence",
@@ -87,6 +88,7 @@ describe("listPendingEnvelopesForCaller", () => {
   it("excludes expired and non-proposed rows", () => {
     expect(listPendingEnvelopesForCaller([
       { ...proposed, status: "approved" },
+      // clock-bomb-guard: allow expiry comparison uses the injected NOW, not Date.now()
       { ...proposed, id: "expired", expiresAt: new Date("2026-08-31T19:00:00.000Z") },
     ], OWNER, NOW)).toEqual([]);
   });

--- a/apps/web/lib/mcp/external-approval-location.ts
+++ b/apps/web/lib/mcp/external-approval-location.ts
@@ -1,0 +1,108 @@
+// External MCP approval location.
+//
+// When a governed writer pauses for approval, the TaskRun result must name
+// the exact owner and where that owner can act. The inbox still isolates by
+// delegatingUserId; a different signed-in operator never inherits Approve
+// merely by being an administrator.
+
+import {
+  envelopeApproveRoute,
+  envelopeDeclineRoute,
+} from "@/lib/coworker/envelope-routes";
+
+export const PENDING_APPROVAL_INBOX_HREF = "/workspace/inbox";
+
+export type ExternalApprovalLocation = {
+  envelopeId: string;
+  delegatingUserId: string;
+  taskRunId: string | null;
+  status: string;
+  expiresAt: string | null;
+  approveHref: string;
+  declineHref: string;
+  inboxHref: typeof PENDING_APPROVAL_INBOX_HREF;
+  nextAction: string;
+};
+
+function iso(value: Date | string | null | undefined): string | null {
+  if (value == null) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+export function describeExternalApprovalLocation(input: {
+  envelopeId: string;
+  delegatingUserId: string;
+  taskRunId?: string | null;
+  status?: string;
+  expiresAt?: Date | string | null;
+}): ExternalApprovalLocation {
+  const approveHref = envelopeApproveRoute(input.envelopeId);
+  return {
+    envelopeId: input.envelopeId,
+    delegatingUserId: input.delegatingUserId,
+    taskRunId: input.taskRunId ?? null,
+    status: input.status ?? "proposed",
+    expiresAt: iso(input.expiresAt),
+    approveHref,
+    declineHref: envelopeDeclineRoute(input.envelopeId),
+    inboxHref: PENDING_APPROVAL_INBOX_HREF,
+    nextAction:
+      `The approval owner is user ${input.delegatingUserId}. `
+      + `Sign in as that user and open ${PENDING_APPROVAL_INBOX_HREF}, `
+      + `or POST ${approveHref}. `
+      + "A different signed-in operator cannot approve this envelope by administrator privilege.",
+  };
+}
+
+export function withExternalApprovalLocation<T extends Record<string, unknown>>(
+  result: T,
+  location: ExternalApprovalLocation | null | undefined,
+): T & { approval?: ExternalApprovalLocation } {
+  if (!location) return result;
+  return {
+    ...result,
+    requiresApproval: true,
+    approval: location,
+  };
+}
+
+export type PendingEnvelopeRow = {
+  id: string;
+  delegatingUserId: string;
+  status: string;
+  taskRunId: string | null;
+  expiresAt: Date | string | null;
+  rationale: string;
+  manifestActionId: string;
+};
+
+/** Keep list and inbox on the same isolation predicate. */
+export function isPendingEnvelopeVisibleToCaller(
+  row: PendingEnvelopeRow,
+  callerUserId: string,
+  now: Date = new Date(),
+): boolean {
+  if (!callerUserId) return false;
+  if (row.delegatingUserId !== callerUserId) return false;
+  if (row.status !== "proposed") return false;
+  const expiresAt = iso(row.expiresAt);
+  if (expiresAt && new Date(expiresAt).getTime() <= now.getTime()) return false;
+  return true;
+}
+
+export function listPendingEnvelopesForCaller(
+  rows: readonly PendingEnvelopeRow[],
+  callerUserId: string,
+  now: Date = new Date(),
+): ExternalApprovalLocation[] {
+  return rows
+    .filter((row) => isPendingEnvelopeVisibleToCaller(row, callerUserId, now))
+    .map((row) => describeExternalApprovalLocation({
+      envelopeId: row.id,
+      delegatingUserId: row.delegatingUserId,
+      taskRunId: row.taskRunId,
+      status: row.status,
+      expiresAt: row.expiresAt,
+    }));
+}

--- a/apps/web/lib/mcp/tasks-lifecycle.ts
+++ b/apps/web/lib/mcp/tasks-lifecycle.ts
@@ -17,6 +17,7 @@
 
 import { prisma } from "@dpf/db";
 import { MCP_ROUTE_TOOL_RESULT_CHAR_CAP } from "@/lib/tak/tool-result-budget";
+import { withTaskRunApprovalLocation } from "./external-approval-location-lookup";
 
 /** Phase-0 surface is on by default (read-only + auth-bound); MCP_TASKS_LIFECYCLE=off disables it. */
 export function tasksLifecycleEnabled(): boolean {
@@ -133,7 +134,17 @@ export async function handleTasksGet(
   const row = await prisma.taskRun.findUnique({ where: { taskRunId: taskId }, select: TASK_SELECT });
   if (!row) return { kind: "notfound", message: `task not found: ${taskId}` };
   if (row.userId !== userId) return { kind: "forbidden", message: "task belongs to a different auth context" };
-  return { kind: "ok", value: toTaskObject(row) };
+  const task = toTaskObject(row);
+  if (row.status !== "input-required" && row.status !== "auth-required") {
+    return { kind: "ok", value: task };
+  }
+  return {
+    kind: "ok",
+    value: await withTaskRunApprovalLocation(
+      { ...task, requiresApproval: true },
+      { taskRunId: row.taskRunId, callerUserId: userId },
+    ),
+  };
 }
 
 /** tasks/result — for terminal tasks return a CallToolResult-shaped payload; for
@@ -151,6 +162,17 @@ export async function handleTasksResult(
 
   const meta = { "io.modelcontextprotocol/related-task": { taskId } };
   if (!isTerminalTaskStatus(row.status)) {
+    const structuredContent: Record<string, unknown> = {
+      taskId,
+      status: mcpTaskStateForWire(row.status),
+      terminal: false,
+    };
+    const located = row.status === "input-required" || row.status === "auth-required"
+      ? await withTaskRunApprovalLocation(
+          { ...structuredContent, requiresApproval: true },
+          { taskRunId: row.taskRunId, callerUserId: userId },
+        )
+      : structuredContent;
     return {
       kind: "ok",
       value: {
@@ -160,7 +182,7 @@ export async function handleTasksResult(
             text: `Task ${taskId} is not yet terminal (status: ${mcpTaskStateForWire(row.status)}). Poll tasks/get until it completes.`,
           },
         ],
-        structuredContent: { taskId, status: mcpTaskStateForWire(row.status), terminal: false },
+        structuredContent: located,
         isError: false,
         _meta: meta,
       },


### PR DESCRIPTION
## Summary

External MCP `tasks/submit` results that pause for approval now name the pending envelope, the delegating user, `/workspace/inbox`, and the existing approve/deny routes. Lookup is isolated to the caller and excludes expired rows. The inbox is unchanged. A different signed-in operator still cannot approve by administrator privilege.

Fixes the live coordination dead-end on BI-06AE037F: a governed writer created envelope `cmthpk6kpfylj01lc5r5cealp` for the MCP token owner, then returned `requiresApproval: true` with no location.

## Design grounding

- Specs/plans reviewed: BI-06AE037F live evidence; existing envelope routes and inbox isolation.
- Code substrate: `CoworkerActionEnvelope`, `envelopeApproveRoute` / `envelopeDeclineRoute`, `mcp-task-submit` / execution / approval-recovery, MCP Tasks get/result.
- Source of truth: `CoworkerActionEnvelope.delegatingUserId` plus the existing settle routes. No second approval store.
- Decision: attach the existing inbox/API location to the token owner's TaskRun result; do not reassign ownership, widen inbox isolation, or auto-approve.

## Verification

- Focused Vitest: approval location, lookup, submit, recovery, and `app/api/mcp/v1/route.test.ts` (including high-risk pause).
- `pnpm run pregate:preflight`: 61 guards clean.
- Local-CI pregate: PASS for `c909be0a7b84`.

## Trailers

Design-Grounding-Decision: reproduce the live identity split (token owner vs signed-in operator) and attach the existing CoworkerActionEnvelope location to MCP results rather than widening inbox isolation or adding a second approval store.
Docs-Impact-Decision: no user-visible inbox copy or control change; MCP TaskRun results gain an approval location object for the token owner.
Process-Spine-Decision: bug fix for a live coordination dead-end; no new spec required.
