### PR TITLE
feat(workroom): carry grants, measures, and budgets on the shape definition (BI-EFFD97B4)

### DIFF
--- a/apps/web/lib/work-management/work-shapes.test.ts
+++ b/apps/web/lib/work-management/work-shapes.test.ts
@@ -8,6 +8,7 @@ import {
   getWorkShape,
   listWorkShapes,
   projectWorkShapeCycleBoundary,
+  readWorkShapeDefinitionContract,
   validateWorkShape,
   type WorkShapeDefinition,
 } from "./work-shapes";
@@ -28,6 +29,17 @@ describe("the §8.11 conformance rules", () => {
     };
     expect(validateWorkShape(noFailureExit)).toContain(
       `${base.key}: no failure exit — only a successful one`,
+    );
+  });
+
+  it("rejects a shape that can start itself and has no budget stop", () => {
+    const base = getWorkShape(OBLIGATION_ASSURANCE_WATCH_SHAPE_KEY)!;
+    const noBudgetStop: WorkShapeDefinition = {
+      ...base,
+      stopConditions: base.stopConditions.filter((stop) => stop.kind !== "budget"),
+    };
+    expect(validateWorkShape(noBudgetStop)).toContain(
+      `${base.key}: no budget stop — a self-starting shape without a spend ceiling is unbounded`,
     );
   });
 
@@ -96,5 +108,28 @@ describe("projection onto the existing room-cycle substrate", () => {
     // Review point is carried as a real date, not left implicit.
     expect(parsed!.expectedReviewAt).toBe("2026-09-20T00:00:00.000Z");
     expect(parsed!.stopConditions.some((stop) => stop.startsWith("failure:"))).toBe(true);
+  });
+});
+
+describe("the definition-level trigger/grant/measure contract (BI-EFFD97B4)", () => {
+  it("exposes typed grants, measures, and budgets on the canonical shape — not a second table", () => {
+    const shape = getWorkShape(OBLIGATION_ASSURANCE_WATCH_SHAPE_KEY)!;
+    const contract = readWorkShapeDefinitionContract(shape);
+    expect(contract.key).toBe(shape.key);
+    expect(contract.version).toBe(shape.version);
+    expect(contract.triggers.length).toBeGreaterThan(0);
+    expect(contract.grants).toEqual(expect.arrayContaining(["tool:read"]));
+    expect(contract.measures.some((measure) => measure.key === "findings-raised")).toBe(true);
+    expect(contract.budgets.some((budget) => budget.kind === "findings-per-run" && budget.limit === 200)).toBe(true);
+    expect(contract.reviewPoint.everyDays).toBe(30);
+    expect(contract.stopConditions.some((stop) => stop.kind === "budget")).toBe(true);
+  });
+
+  it("does not smuggle a dispatcher, scheduler, or roster onto the definition contract", () => {
+    const shape = getWorkShape(OBLIGATION_ASSURANCE_WATCH_SHAPE_KEY)!;
+    const contract = readWorkShapeDefinitionContract(shape);
+    expect(contract).not.toHaveProperty("dispatch");
+    expect(contract).not.toHaveProperty("schedule");
+    expect(contract).not.toHaveProperty("participants");
   });
 });

--- a/apps/web/lib/work-management/work-shapes.ts
+++ b/apps/web/lib/work-management/work-shapes.ts
@@ -61,6 +61,20 @@ export type WorkShapeStopCondition = {
   condition: string;
 };
 
+/** Allowed tools/capabilities this activity may consume. Empty is a declaration. */
+export type WorkShapeGrant = string;
+
+export type WorkShapeMeasure = {
+  key: string;
+  description: string;
+};
+
+export type WorkShapeBudget = {
+  kind: "findings-per-run" | "cycles-per-window" | "spend";
+  limit: number;
+  unit: string;
+};
+
 export type WorkShapeDefinition = {
   key: string;
   /** Versioned: changing stages or gates is a new version, not an edit in place. */
@@ -70,11 +84,47 @@ export type WorkShapeDefinition = {
   triggers: readonly WorkShapeTriggerClass[];
   stages: readonly WorkShapeStage[];
   stopConditions: readonly WorkShapeStopCondition[];
+  /** Tools/capabilities the activity is allowed to use. Not a dispatcher. */
+  grants: readonly WorkShapeGrant[];
+  /** Named measures the activity is expected to leave on the ledger. */
+  measures: readonly WorkShapeMeasure[];
+  /** Numeric ceilings the runner must honour; pairs with the budget stop. */
+  budgets: readonly WorkShapeBudget[];
   /** The activity is examined here whether or not it progressed. */
   reviewPoint: { everyDays: number; description: string };
   /** The room shape a consequential act inside this activity binds to. */
   collaborationShape: WorkroomShapeKey | null;
 };
+
+/** The definition contract runtime consumers read. No dispatch, schedule, or roster. */
+export type WorkShapeDefinitionContract = Pick<
+  WorkShapeDefinition,
+  | "key"
+  | "version"
+  | "triggers"
+  | "stages"
+  | "stopConditions"
+  | "grants"
+  | "measures"
+  | "budgets"
+  | "reviewPoint"
+>;
+
+export function readWorkShapeDefinitionContract(
+  shape: WorkShapeDefinition,
+): WorkShapeDefinitionContract {
+  return {
+    key: shape.key,
+    version: shape.version,
+    triggers: shape.triggers,
+    stages: shape.stages,
+    stopConditions: shape.stopConditions,
+    grants: shape.grants,
+    measures: shape.measures,
+    budgets: shape.budgets,
+    reviewPoint: shape.reviewPoint,
+  };
+}
 
 // ── the registry ─────────────────────────────────────────────────────────────
 
@@ -137,6 +187,13 @@ const SHAPES: Record<string, WorkShapeDefinition> = {
       { kind: "failure", condition: "The sweep cannot read the compliance substrate (no profile, no obligations, or a query error) — it stops and reports, and does NOT raise findings from an empty read." },
       { kind: "budget", condition: "More than 200 findings would be raised in one run — the run stops and escalates, rather than burying the ledger." },
     ],
+    grants: ["tool:read"],
+    measures: [
+      { key: "findings-raised", description: "Findings opened onto the assurance ledger in one run." },
+    ],
+    budgets: [
+      { kind: "findings-per-run", limit: 200, unit: "findings" },
+    ],
     reviewPoint: {
       everyDays: 30,
       description:
@@ -194,6 +251,9 @@ export function validateWorkShape(shape: WorkShapeDefinition): string[] {
   }
   if (!shape.stopConditions.some((stop) => stop.kind === "failure")) {
     issues.push(`${shape.key}: no failure exit — only a successful one`);
+  }
+  if (!shape.stopConditions.some((stop) => stop.kind === "budget")) {
+    issues.push(`${shape.key}: no budget stop — a self-starting shape without a spend ceiling is unbounded`);
   }
   if (!(shape.reviewPoint.everyDays > 0)) issues.push(`${shape.key}: no review point`);
   return issues;


### PR DESCRIPTION
## Summary

`WorkShapeDefinition` now carries allowed grants, named measures, and numeric budgets. `validateWorkShape` requires a budget stop so a self-starting shape cannot run unbounded. Runtime consumers read one definition contract via `readWorkShapeDefinitionContract`. Dispatch, schedule, and roster stay outside this slice.

Completes the definition-level half of BI-EFFD97B4. No runner, no migration, no second table.

## Design grounding

- Specs/plans reviewed: `docs/superpowers/specs/2026-08-29-proactive-workrooms-design.md`, `docs/superpowers/plans/2026-08-29-proactive-workrooms.md`
- Code substrate: `apps/web/lib/work-management/work-shapes.ts`
- Source of truth: the existing `WorkShapeDefinition` registry
- Decision: extend that type rather than add a parallel contract store

## Verification

- `pnpm --filter web exec vitest run lib/work-management/work-shapes.test.ts` — 12 passed
- `pnpm run pregate:preflight` — 61 guards clean
- Local-CI pregate PASS for `9c84bdb494f4`

## Trailers

Design-Grounding-Decision: Phase B of the approved proactive-workrooms design; definition-level contract only, no runner.
Docs-Impact-Decision: no user-visible surface change; definition contract is consumed by later drive/overseer slices.
Process-Spine-Decision: implements already-merged spec/plan PR 4871 Phase B definition slice; no new spec required.
