### PR TITLE
fix(mcp): bound terminal writer recovery

### DIFF
--- a/apps/web/lib/mcp-task-execution.ts
+++ b/apps/web/lib/mcp-task-execution.ts
@@ -27,6 +27,13 @@ import type {
   RemoteTaskSubmitParams,
 } from "./mcp-task-submit";
 import { withTaskRunApprovalLocation } from "./mcp/external-approval-location-lookup";
+import {
+  createTerminalWriterEscalation,
+  terminalWriterEscalationMessage,
+  terminalWriterEscalationStructuredContent,
+  terminalWriterEscalationWaitReason,
+  terminalWriterRetryIsExhausted,
+} from "./mcp-task-terminal-writer-escalation";
 
 function optionalString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
@@ -171,6 +178,12 @@ export async function executeRemoteTaskAttempt(input: {
         });
     if (result.failure?.kind === "terminal-writer-missing" && terminalToolPolicy) {
       const terminalWriterAttempt = input.terminalWriterAttempt ?? 1;
+      const escalation = terminalWriterRetryIsExhausted(terminalWriterAttempt)
+        ? createTerminalWriterEscalation({
+            writerToolName: terminalToolPolicy.writerToolName,
+            attempt: terminalWriterAttempt,
+          })
+        : null;
       await prisma.taskRun.update({
         where: { taskRunId: run.taskRunId },
         data: {
@@ -192,6 +205,7 @@ export async function executeRemoteTaskAttempt(input: {
                 ? { noncompliance: "prose-without-required-writer" }
                 : {}),
             },
+            ...(escalation ? { terminalWriterEscalation: escalation } : {}),
           },
         },
       });
@@ -203,9 +217,16 @@ export async function executeRemoteTaskAttempt(input: {
           idempotentReplay: input.idempotentReplay,
           ...resumedFlag,
           requiresApproval: false,
-          resumable: true,
-          waitReason: "missing-terminal-writer",
-          content: remoteTaskContent(result.content),
+          resumable: escalation ? false : true,
+          waitReason: escalation
+            ? terminalWriterEscalationWaitReason(escalation)
+            : "missing-terminal-writer",
+          content: remoteTaskContent(
+            escalation ? terminalWriterEscalationMessage(escalation) : result.content,
+          ),
+          ...(escalation
+            ? { structuredContent: terminalWriterEscalationStructuredContent(escalation) }
+            : {}),
           executedToolCount: result.executedTools?.length ?? 0,
           isError: false,
         },

--- a/apps/web/lib/mcp-task-submit.ts
+++ b/apps/web/lib/mcp-task-submit.ts
@@ -34,6 +34,13 @@ import {
   hydrateTerminalWriterContext,
   type PersistedTerminalReaderExecution,
 } from "./mcp-task-terminal-writer-context";
+import {
+  createTerminalWriterEscalation,
+  recoverTerminalWriterEscalation,
+  terminalWriterEscalationMessage,
+  terminalWriterEscalationStructuredContent,
+  terminalWriterEscalationWaitReason,
+} from "./mcp-task-terminal-writer-escalation";
 
 export {
   parseInitiativeReviewBinding,
@@ -224,6 +231,7 @@ function replayOrConflict(existing: ExistingRemoteTask, requestDigest: string): 
       },
     };
   }
+  const terminalWriterEscalation = recoverTerminalWriterEscalation(existing.progressPayload);
   const terminalWriterWait = parseTerminalWriterWait(existing.progressPayload);
   const resourceWait = parseResourceWaitProjection(existing.progressPayload);
   return {
@@ -232,8 +240,14 @@ function replayOrConflict(existing: ExistingRemoteTask, requestDigest: string): 
       taskRunId: existing.taskRunId,
       status: existing.status,
       idempotentReplay: true,
-      requiresApproval: existing.status === "input-required" && !terminalWriterWait,
-      ...(terminalWriterWait ? {
+      requiresApproval: existing.status === "input-required" && !terminalWriterWait && !terminalWriterEscalation,
+      ...(terminalWriterEscalation ? {
+        resumable: false,
+        waitReason: terminalWriterEscalationWaitReason(terminalWriterEscalation),
+        content: remoteTaskContent(terminalWriterEscalationMessage(terminalWriterEscalation)),
+        structuredContent: terminalWriterEscalationStructuredContent(terminalWriterEscalation),
+        isError: false,
+      } : terminalWriterWait ? {
         resumable: true,
         waitReason: terminalWriterWait.kind,
       } : resourceWait ? {
@@ -256,6 +270,7 @@ async function reserveTerminalWriterReplay(input: {
   bootstrapReaderEvidence: boolean;
 } | null> {
   if (storedRequestDigest(input.existing) !== input.requestDigest) return null;
+  if (recoverTerminalWriterEscalation(input.existing.progressPayload)) return null;
 
   const existingWait = parseTerminalWriterWait(input.existing.progressPayload);
   const isProjectedWait = input.existing.status === "input-required" && existingWait !== null;
@@ -474,6 +489,10 @@ export async function submitRemoteCoworkerTask(input: {
     const replay = replayOrConflict(existing, requestDigest);
     if (
       storedRequestDigest(existing) === requestDigest
+      && recoverTerminalWriterEscalation(existing.progressPayload)
+    ) return replay;
+    if (
+      storedRequestDigest(existing) === requestDigest
       && existing.status === "input-required"
     ) {
       const resumed = await resumeApprovedRemoteTask({
@@ -578,6 +597,13 @@ export async function submitRemoteCoworkerTask(input: {
         ? existing.progressPayload as Record<string, unknown>
         : {};
       if (!hydration.ok) {
+        const escalation = hydration.code === "terminal_writer_context_truncated"
+          ? createTerminalWriterEscalation({
+              code: "terminal_writer_context_truncated",
+              writerToolName: terminalToolPolicy.writerToolName,
+              attempt: terminalWriterReservation.wait.attempt,
+            })
+          : null;
         await prisma.taskRun.update({
           where: { taskRunId: existing.taskRunId },
           data: {
@@ -593,6 +619,7 @@ export async function submitRemoteCoworkerTask(input: {
                 message: hydration.error,
                 observedAt: new Date().toISOString(),
               },
+              ...(escalation ? { terminalWriterEscalation: escalation } : {}),
             },
           },
         });
@@ -604,11 +631,17 @@ export async function submitRemoteCoworkerTask(input: {
             idempotentReplay: true,
             resumedFromTerminalWriterWait: false,
             requiresApproval: false,
-            resumable: true,
-            waitReason: "terminal-writer-context-unavailable",
-            content: remoteTaskContent(hydration.error),
-            structuredContent: { error: hydration.code },
-            isError: true,
+            resumable: escalation ? false : true,
+            waitReason: escalation
+              ? terminalWriterEscalationWaitReason(escalation)
+              : "terminal-writer-context-unavailable",
+            content: remoteTaskContent(
+              escalation ? terminalWriterEscalationMessage(escalation) : hydration.error,
+            ),
+            structuredContent: escalation
+              ? terminalWriterEscalationStructuredContent(escalation)
+              : { error: hydration.code },
+            isError: escalation ? false : true,
           },
         };
       }

--- a/apps/web/lib/mcp-task-terminal-writer-escalation.ts
+++ b/apps/web/lib/mcp-task-terminal-writer-escalation.ts
@@ -1,0 +1,106 @@
+export const TERMINAL_WRITER_MAX_ATTEMPTS = 3;
+
+export type TerminalWriterEscalation = {
+  schemaVersion: 1;
+  code: "terminal_writer_retry_exhausted" | "terminal_writer_context_truncated";
+  writerToolName: string;
+  attempt: number;
+  action: "select-different-reviewer-provider";
+  observedAt: string;
+};
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function terminalWriterRetryIsExhausted(attempt: number): boolean {
+  return Number.isInteger(attempt) && attempt >= TERMINAL_WRITER_MAX_ATTEMPTS;
+}
+
+export function createTerminalWriterEscalation(args: {
+  writerToolName: string;
+  attempt: number;
+  code?: TerminalWriterEscalation["code"];
+  observedAt?: string;
+}): TerminalWriterEscalation {
+  return {
+    schemaVersion: 1,
+    code: args.code ?? "terminal_writer_retry_exhausted",
+    writerToolName: args.writerToolName,
+    attempt: args.attempt,
+    action: "select-different-reviewer-provider",
+    observedAt: args.observedAt ?? new Date().toISOString(),
+  };
+}
+
+export function parseTerminalWriterEscalation(value: unknown): TerminalWriterEscalation | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const candidate = (value as Record<string, unknown>)["terminalWriterEscalation"];
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+  const escalation = candidate as Record<string, unknown>;
+  if (
+    escalation["schemaVersion"] !== 1
+    || !["terminal_writer_retry_exhausted", "terminal_writer_context_truncated"].includes(String(escalation["code"]))
+    || !nonEmptyString(escalation["writerToolName"])
+    || !Number.isInteger(escalation["attempt"])
+    || Number(escalation["attempt"]) < 1
+    || escalation["action"] !== "select-different-reviewer-provider"
+    || !nonEmptyString(escalation["observedAt"])
+  ) return null;
+  if (
+    escalation["code"] === "terminal_writer_retry_exhausted"
+    && Number(escalation["attempt"]) < TERMINAL_WRITER_MAX_ATTEMPTS
+  ) return null;
+  return escalation as TerminalWriterEscalation;
+}
+
+export function recoverTerminalWriterEscalation(value: unknown): TerminalWriterEscalation | null {
+  const explicit = parseTerminalWriterEscalation(value);
+  if (explicit) return explicit;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const progress = value as Record<string, unknown>;
+  const failure = progress["terminalWriterContextFailure"];
+  const wait = progress["terminalWriterWait"];
+  if (
+    !failure || typeof failure !== "object" || Array.isArray(failure)
+    || !wait || typeof wait !== "object" || Array.isArray(wait)
+  ) return null;
+  const failureRecord = failure as Record<string, unknown>;
+  const waitRecord = wait as Record<string, unknown>;
+  const writerToolName = nonEmptyString(waitRecord["writerToolName"]);
+  const attempt = Number(waitRecord["attempt"]);
+  if (
+    failureRecord["code"] !== "terminal_writer_context_truncated"
+    || !writerToolName
+    || !Number.isInteger(attempt)
+    || attempt < 1
+  ) return null;
+  return createTerminalWriterEscalation({
+    code: "terminal_writer_context_truncated",
+    writerToolName,
+    attempt,
+    observedAt: nonEmptyString(failureRecord["observedAt"]) ?? new Date().toISOString(),
+  });
+}
+
+export function terminalWriterEscalationWaitReason(escalation: TerminalWriterEscalation): string {
+  return escalation.code === "terminal_writer_context_truncated"
+    ? "terminal-writer-context-exhausted"
+    : "terminal-writer-retry-exhausted";
+}
+
+export function terminalWriterEscalationStructuredContent(escalation: TerminalWriterEscalation) {
+  return {
+    error: escalation.code,
+    attempt: escalation.attempt,
+    writerToolName: escalation.writerToolName,
+    action: escalation.action,
+  };
+}
+
+export function terminalWriterEscalationMessage(escalation: TerminalWriterEscalation): string {
+  if (escalation.code === "terminal_writer_context_truncated") {
+    return "The immutable review packet is larger than the safe hydration limit. Stop replaying this TaskRun and select a different eligible reviewer/provider for the same review packet.";
+  }
+  return "The required writer was omitted on three attempts. Stop replaying this TaskRun and select a different eligible reviewer/provider for the same immutable review packet.";
+}

--- a/apps/web/lib/mcp-task-terminal-writer.test.ts
+++ b/apps/web/lib/mcp-task-terminal-writer.test.ts
@@ -479,7 +479,7 @@ describe("terminal writer resumption", () => {
     });
   });
 
-  it("keeps the same TaskRun resumable in a writer-only phase after attempt two", async () => {
+  it("stops replaying and returns a governed escalation after the third missing-writer attempt", async () => {
     const exhaustedParams = { ...params, idempotencyKey: "missing-writer-resume-exhausted" };
     const metadata = await persistedMetadata("PAT-WRITER-EXHAUSTED", exhaustedParams);
     vi.clearAllMocks();
@@ -605,8 +605,14 @@ describe("terminal writer resumption", () => {
         status: "input-required",
         idempotentReplay: true,
         requiresApproval: false,
-        resumable: true,
-        waitReason: "missing-terminal-writer",
+        resumable: false,
+        waitReason: "terminal-writer-retry-exhausted",
+        structuredContent: {
+          error: "terminal_writer_retry_exhausted",
+          attempt: 3,
+          writerToolName: "record_initiative_evidence",
+          action: "select-different-reviewer-provider",
+        },
       },
     });
     expect(db.update).toHaveBeenCalledWith({
@@ -619,8 +625,110 @@ describe("terminal writer resumption", () => {
             dispatchContract: "required-tool-call",
             noncompliance: "prose-without-required-writer",
           }),
+          terminalWriterEscalation: expect.objectContaining({
+            schemaVersion: 1,
+            code: "terminal_writer_retry_exhausted",
+            attempt: 3,
+            writerToolName: "record_initiative_evidence",
+            action: "select-different-reviewer-provider",
+          }),
         }),
       }),
+    });
+  });
+
+  it("replays an exhausted terminal-writer escalation without starting another attempt", async () => {
+    const exhaustedParams = { ...params, idempotencyKey: "missing-writer-already-escalated" };
+    const metadata = await persistedMetadata("PAT-WRITER-ALREADY-ESCALATED", exhaustedParams);
+    vi.clearAllMocks();
+    db.findFirst.mockResolvedValue({
+      id: "task-internal", taskRunId: "TR-MCP-WRITER-ALREADY-ESCALATED",
+      threadId: "thread-external", contextId: "thread-external", status: "input-required",
+      updatedAt: new Date("2026-09-01T02:22:19.238Z"),
+      progressPayload: {
+        terminalWriterWait: {
+          schemaVersion: 1, kind: "missing-terminal-writer",
+          writerToolName: "record_initiative_evidence", resumeMode: "same-taskrun", attempt: 3,
+          observedAt: "2026-09-01T02:22:19.237Z",
+        },
+        terminalWriterEscalation: {
+          schemaVersion: 1, code: "terminal_writer_retry_exhausted",
+          writerToolName: "record_initiative_evidence", attempt: 3,
+          action: "select-different-reviewer-provider",
+          observedAt: "2026-09-01T02:22:19.237Z",
+        },
+      },
+      a2aMetadata: metadata,
+    });
+
+    const outcome = await submit("PAT-WRITER-ALREADY-ESCALATED", exhaustedParams);
+
+    expect(db.updateMany).not.toHaveBeenCalled();
+    expect(autonomous.executeTool).not.toHaveBeenCalled();
+    expect(autonomous.execute).not.toHaveBeenCalled();
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: {
+        taskRunId: "TR-MCP-WRITER-ALREADY-ESCALATED",
+        status: "input-required",
+        idempotentReplay: true,
+        requiresApproval: false,
+        resumable: false,
+        waitReason: "terminal-writer-retry-exhausted",
+        structuredContent: {
+          error: "terminal_writer_retry_exhausted",
+          attempt: 3,
+          writerToolName: "record_initiative_evidence",
+          action: "select-different-reviewer-provider",
+        },
+      },
+    });
+  });
+
+  it("turns a preserved bounded-hydration truncation into a concrete non-resumable escalation", async () => {
+    const truncatedParams = { ...params, idempotencyKey: "terminal-writer-context-truncated" };
+    const metadata = await persistedMetadata("PAT-WRITER-CONTEXT-TRUNCATED", truncatedParams);
+    vi.clearAllMocks();
+    db.findFirst.mockResolvedValue({
+      id: "task-internal", taskRunId: "TR-MCP-WRITER-CONTEXT-TRUNCATED",
+      threadId: "thread-external", contextId: "thread-external", status: "input-required",
+      updatedAt: new Date("2026-09-01T01:18:36.677Z"),
+      progressPayload: {
+        terminalWriterWait: {
+          schemaVersion: 1, kind: "missing-terminal-writer",
+          writerToolName: "record_initiative_evidence", resumeMode: "same-taskrun", attempt: 2,
+          observedAt: "2026-09-01T01:18:33.353Z",
+        },
+        terminalWriterContextFailure: {
+          code: "terminal_writer_context_truncated",
+          message: "The immutable source remained truncated after the bounded hydration budget.",
+          observedAt: "2026-09-01T01:18:36.676Z",
+        },
+      },
+      a2aMetadata: metadata,
+    });
+
+    const outcome = await submit("PAT-WRITER-CONTEXT-TRUNCATED", truncatedParams);
+
+    expect(db.updateMany).not.toHaveBeenCalled();
+    expect(autonomous.executeTool).not.toHaveBeenCalled();
+    expect(autonomous.execute).not.toHaveBeenCalled();
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: {
+        taskRunId: "TR-MCP-WRITER-CONTEXT-TRUNCATED",
+        status: "input-required",
+        idempotentReplay: true,
+        requiresApproval: false,
+        resumable: false,
+        waitReason: "terminal-writer-context-exhausted",
+        structuredContent: {
+          error: "terminal_writer_context_truncated",
+          attempt: 2,
+          writerToolName: "record_initiative_evidence",
+          action: "select-different-reviewer-provider",
+        },
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

- stop exact TaskRun replay after the third missing terminal-writer attempt
- preserve the safe hydration ceiling and surface oversized immutable packets as a non-resumable provider-selection escalation
- recover preserved retry/truncation state without starting another attempt

## Verification

- terminal-writer regression suite: 9/9
- related MCP suites: 44/44
- web typecheck
- production build
- pregate preflight: 61/61 guards
- exact-tree local-CI: `cmti4uaro2jjg01lheb3d66we` at `8f4b4e0f061b`
- semantic review receipt: `cmti4xf7j2nfx01lhjhi6uamx` (admitted, no issues; shadow-mode infrastructure inconclusive)

## Runtime acceptance

After merge and canonical self-upgrade, replay the three preserved TaskRuns to confirm bounded escalation on live served bytes.

Backlog-Item: BI-EDC0DAF2
Workroom: WC-5AF14F3D