### PR TITLE
feat(workroom): persist participant and coordinator assignments (BI-4CB2EF76)

### DIFF
--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -72,6 +72,8 @@ const room: WorkroomView = {
       sponsorPrincipalRef: null,
       authoritySummary: "May confirm an available service window",
       sourceRefs: [],
+      assignmentSource: "explicit",
+      coordinatorSource: "none",
     },
     {
       principalRef: "agent:scheduling-1",
@@ -86,6 +88,8 @@ const room: WorkroomView = {
       sponsorDisplayName: "Jamie Rivera",
       authoritySummary: "May prepare options; may not confirm externally",
       sourceRefs: [],
+      assignmentSource: "explicit",
+      coordinatorSource: "none",
     },
   ],
   activity: [

--- a/apps/web/lib/govern/data/assets.ts
+++ b/apps/web/lib/govern/data/assets.ts
@@ -37,6 +37,7 @@ import { WORKER_CLASSIFICATION_ASSETS } from "./worker-classification-assets";
 import { DECISION_TRUST_ENVELOPE_ASSETS } from "./decision-trust-envelope-assets";
 import { MCP_OAUTH_ASSETS } from "./mcp-oauth-assets";
 import { MCP_ASSETS } from "./mcp-assets";
+import { WORKROOM_PARTICIPANT_ASSETS } from "./workroom-participant-assets";
 import { INITIATIVE_GOVERNANCE_ASSETS } from "./initiative-governance-assets";
 import { FEDERATION_INTRODUCTION_ASSETS } from "./federation-introduction-assets";
 import { BUSINESS_PERFORMANCE_ASSETS } from "./business-performance-assets";
@@ -736,6 +737,7 @@ const SEED_ASSETS: readonly DataAssetDefinition[] = [
   ...DECISION_TRUST_ENVELOPE_ASSETS,
   ...MCP_OAUTH_ASSETS,
   ...MCP_ASSETS,
+  ...WORKROOM_PARTICIPANT_ASSETS,
   ...INITIATIVE_GOVERNANCE_ASSETS,
   ...FEDERATION_INTRODUCTION_ASSETS,
   ...EXTERNAL_CHANNEL_ASSETS,

--- a/apps/web/lib/govern/data/workroom-participant-assets.ts
+++ b/apps/web/lib/govern/data/workroom-participant-assets.ts
@@ -1,0 +1,31 @@
+// Data-governance registration for persisted Workroom roster rows (BI-4CB2EF76).
+// The live-schema coverage gate requires every Prisma model to be registered or
+// baselined. Fields resolve at the model-level default.
+
+import type { DataAssetDefinition } from "./assets";
+
+const CLASSIFICATION = {
+  state: "confirmed",
+  source: "manual",
+  effectiveFrom: "2026-09-01",
+} as const;
+
+export const WORKROOM_PARTICIPANT_ASSETS: readonly DataAssetDefinition[] = [
+  {
+    id: "data:workroom-participant",
+    physical: { prismaModel: "WorkroomParticipant" },
+    domain: "platform-operations",
+    ownerRole: "platform-operator",
+    stewardRole: "data-steward",
+    categories: ["operational"],
+    sensitivity: "internal",
+    criticality: "standard",
+    subjectLocators: [],
+    lifecycleClass: "operational",
+    purposeCapabilities: ["platform-operations"],
+    residencyClass: "local-only",
+    projectionClass: "structure",
+    classification: CLASSIFICATION,
+    fields: [],
+  },
+];

--- a/apps/web/lib/governance/workroom-shape-governance-hook.ts
+++ b/apps/web/lib/governance/workroom-shape-governance-hook.ts
@@ -169,6 +169,8 @@ function toParticipantViews(
     sponsorPrincipalRef: null,
     authoritySummary: "Participates within assigned room authority",
     sourceRefs: [],
+    assignmentSource: "explicit",
+    coordinatorSource: participant.roles.includes("coordinator") ? "explicit" : "none",
   }));
 }
 

--- a/apps/web/lib/mcp/packs/room-messaging-pack.ts
+++ b/apps/web/lib/mcp/packs/room-messaging-pack.ts
@@ -20,6 +20,7 @@ import { ensureAgentPrincipalIdentity, syncUserPrincipal } from "@/lib/identity/
 import { getCoworkerRoomEngagement } from "@/lib/work-management/coworker-room-engagement.server";
 import { heartbeatAgentWorkItemPresence } from "@/lib/work-management/room-agent-presence.server";
 import { postWorkItemComment, type PostCommentDb } from "@/lib/work-management/post-work-item-comment";
+import { persistExplicitWorkroomAssignmentsForWorkItem } from "@/lib/work-management/room-participant-assignment.server";
 import { appendRoomPolicyParticipant } from "@/lib/work-management/room-policy";
 import type { WorkroomParticipantRole } from "@/lib/work-management/room-types";
 import { resolveAgentRoomAccess } from "@/lib/work-management/room-agent-access.server";
@@ -244,6 +245,12 @@ async function inviteRoomParticipantHandler(
     canAct,
   });
   await prisma.workItem.update({ where: { id: item.id }, data: { evidence: newEvidence as never } });
+  await persistExplicitWorkroomAssignmentsForWorkItem({
+    workItemId: item.id,
+    principalRef: inviteePrincipalId,
+    roles,
+    enteredReason: "Invited into the room",
+  });
 
   const commentDb: PostCommentDb = {
     workItemMessage: { create: (args) => prisma.workItemMessage.create(args as never) },

--- a/apps/web/lib/work-management/federated-room.server.ts
+++ b/apps/web/lib/work-management/federated-room.server.ts
@@ -17,6 +17,7 @@ import {
   evaluateFederatedRoomAdmission,
   type FederatedRoomGateDecision,
 } from "./federated-room";
+import { persistExplicitWorkroomAssignmentsForWorkItem } from "./room-participant-assignment.server";
 import { appendRoomPolicyParticipant } from "./room-policy";
 import { decodeWorkCaseKey } from "./workspace-case-loader";
 
@@ -84,6 +85,12 @@ export async function admitFederatedRoomParticipant(input: {
     enteredReason: `Federated participant via link ${input.federationLinkId}`,
   });
   await prisma.workItem.update({ where: { id: item.id }, data: { evidence: newEvidence as never } });
+  await persistExplicitWorkroomAssignmentsForWorkItem({
+    workItemId: item.id,
+    principalRef: principal.principalId,
+    roles: ["contributor"],
+    enteredReason: `Federated participant via link ${input.federationLinkId}`,
+  });
 
   return { gate, mirroredPrincipalId: principal.principalId, workItemId: item.id };
 }

--- a/apps/web/lib/work-management/room-coordinator.test.ts
+++ b/apps/web/lib/work-management/room-coordinator.test.ts
@@ -24,6 +24,8 @@ function participant(
     sponsorPrincipalRef: null,
     authoritySummary: "",
     sourceRefs: [],
+    assignmentSource: "explicit",
+    coordinatorSource: "none",
   };
 }
 

--- a/apps/web/lib/work-management/room-coordinator.ts
+++ b/apps/web/lib/work-management/room-coordinator.ts
@@ -49,6 +49,17 @@ export function selectRoomCoordinator(
 }
 
 /**
+ * Coordinator that was persisted as an assignment. A derived coordinator may
+ * explain an old room but does not qualify it for autonomous execution.
+ */
+export function selectExplicitRoomCoordinator(
+  participants: readonly WorkroomParticipantView[],
+): WorkroomParticipantView | null {
+  const coordinator = selectRoomCoordinator(participants);
+  return coordinator?.coordinatorSource === "explicit" ? coordinator : null;
+}
+
+/**
  * Ensure the room has a Coordinator. If one is already named (by policy or
  * lineage) it is kept; otherwise the accountable principal coordinates by
  * default — the Coordinator role is added to the (single) accountable
@@ -60,22 +71,33 @@ export function selectRoomCoordinator(
 export function deriveRoomCoordinator(
   participants: readonly WorkroomParticipantView[],
 ): WorkroomParticipantView[] {
-  // Validates single-coordinator and short-circuits when one is already named.
-  if (selectRoomCoordinator(participants)) {
-    return [...participants];
+  const named = selectRoomCoordinator(participants);
+  if (named) {
+    return participants.map((participant) =>
+      isCoordinator(participant)
+        ? {
+            ...participant,
+            coordinatorSource: participant.coordinatorSource === "derived" ? "derived" : "explicit",
+          }
+        : { ...participant, coordinatorSource: "none" },
+    );
   }
 
   const accountable = participants.filter(isAccountable);
   // Only default when there is exactly one accountable to promote; ambiguous or
   // absent accountability leaves the room without a derived coordinator.
   if (accountable.length !== 1) {
-    return [...participants];
+    return participants.map((participant) => ({ ...participant, coordinatorSource: "none" }));
   }
 
   const target = accountable[0];
   return participants.map((participant) =>
     participant.principalRef === target.principalRef
-      ? { ...participant, roles: [...new Set([...participant.roles, "coordinator" as const])] }
-      : participant,
+      ? {
+          ...participant,
+          roles: [...new Set([...participant.roles, "coordinator" as const])],
+          coordinatorSource: "derived",
+        }
+      : { ...participant, coordinatorSource: "none" },
   );
 }

--- a/apps/web/lib/work-management/room-participant-assignment.server.ts
+++ b/apps/web/lib/work-management/room-participant-assignment.server.ts
@@ -1,0 +1,131 @@
+import { prisma } from "@dpf/db";
+
+import {
+  parsePersistedWorkroomParticipantAssignment,
+  type PersistedWorkroomParticipantAssignment,
+} from "./room-participant-assignment";
+import type { WorkroomParticipantRole } from "./room-types";
+
+type AssignmentDb = {
+  principal: {
+    findFirst: (args: {
+      where: { principalId: string; status?: string };
+      select: { id: true };
+    }) => Promise<{ id: string } | null>;
+  };
+  workroomParticipant: {
+    upsert: (args: unknown) => Promise<unknown>;
+  };
+};
+
+function roleKind(kind: string): "person" | "agent" | "system" | "external" {
+  if (kind === "agent") return "agent";
+  if (kind === "system" || kind === "service") return "system";
+  if (kind === "external") return "external";
+  return "person";
+}
+
+export function mapPersistedParticipantRow(row: {
+  assignmentSource: "explicit" | "legacy";
+  roles: WorkroomParticipantRole[];
+  enteredReason: string | null;
+  currentWorkSummary: string | null;
+  principal: {
+    principalId: string;
+    displayName: string;
+    kind: string;
+    authorityMode: string | null;
+    sponsorPrincipal: { principalId: string; displayName: string } | null;
+  };
+}): {
+  principalRef: string;
+  displayName: string;
+  kind: "person" | "agent" | "system" | "external";
+  roles: WorkroomParticipantRole[];
+  assignmentSource: "explicit" | "legacy";
+  enteredReason: string | null;
+  currentWorkSummary: string | null;
+  sponsorPrincipalRef: string | null;
+  sponsorDisplayName: string | null;
+  authoritySummary: string;
+} {
+  const mode = row.principal.authorityMode?.trim();
+  const kind = roleKind(row.principal.kind);
+  return {
+    principalRef: row.principal.principalId,
+    displayName: row.principal.displayName,
+    kind,
+    roles: [...row.roles],
+    assignmentSource: row.assignmentSource,
+    enteredReason: row.enteredReason,
+    currentWorkSummary: row.currentWorkSummary,
+    sponsorPrincipalRef: row.principal.sponsorPrincipal?.principalId ?? null,
+    sponsorDisplayName: row.principal.sponsorPrincipal?.displayName ?? null,
+    authoritySummary: kind === "agent"
+      ? (mode
+        ? `Acts ${mode}; consequential work remains governed`
+        : "May contribute within the room; consequential work remains governed")
+      : (mode ? `Participates with ${mode} authority` : "Participates within assigned room authority"),
+  };
+}
+
+export async function persistWorkroomParticipantAssignment(
+  input: PersistedWorkroomParticipantAssignment,
+  db: AssignmentDb = prisma as unknown as AssignmentDb,
+): Promise<{ workroomId: string; principalId: string } | null> {
+  const parsed = parsePersistedWorkroomParticipantAssignment(input);
+  const principal = await db.principal.findFirst({
+    where: { principalId: parsed.principalRef, status: "active" },
+    select: { id: true },
+  });
+  if (!principal) return null;
+  await db.workroomParticipant.upsert({
+    where: {
+      workroomId_principalId: {
+        workroomId: parsed.workroomId,
+        principalId: principal.id,
+      },
+    },
+    create: {
+      workroomId: parsed.workroomId,
+      principalId: principal.id,
+      roles: parsed.roles,
+      assignmentSource: parsed.assignmentSource,
+      enteredReason: parsed.enteredReason,
+      currentWorkSummary: parsed.currentWorkSummary,
+      lifecycle: "active",
+    },
+    update: {
+      roles: parsed.roles,
+      assignmentSource: parsed.assignmentSource,
+      enteredReason: parsed.enteredReason,
+      currentWorkSummary: parsed.currentWorkSummary,
+      lifecycle: "active",
+      lifecycleAt: null,
+      lifecycleReason: null,
+    },
+  });
+  return { workroomId: parsed.workroomId, principalId: principal.id };
+}
+
+export async function persistExplicitWorkroomAssignmentsForWorkItem(input: {
+  workItemId: string;
+  principalRef: string;
+  roles: WorkroomParticipantRole[];
+  enteredReason: string | null;
+}): Promise<void> {
+  const rooms = await prisma.workroom.findMany({
+    where: { workItemId: input.workItemId },
+    select: { id: true },
+  });
+  for (const room of rooms) {
+    await persistWorkroomParticipantAssignment({
+      workroomId: room.id,
+      principalRef: input.principalRef,
+      roles: input.roles,
+      assignmentSource: "explicit",
+      enteredReason: input.enteredReason,
+      currentWorkSummary: null,
+    });
+  }
+}

--- a/apps/web/lib/work-management/room-participant-assignment.test.ts
+++ b/apps/web/lib/work-management/room-participant-assignment.test.ts
@@ -1,0 +1,175 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  WORKROOM_PARTICIPANT_ROLES,
+  assertAssignmentDoesNotCarryProactivity,
+  parsePersistedWorkroomParticipantAssignment,
+  projectPersistedWorkroomRoster,
+  resolveCoordinatorSource,
+} from "./room-participant-assignment";
+import { deriveRoomCoordinator, selectExplicitRoomCoordinator } from "./room-coordinator";
+import type { WorkroomParticipantRole, WorkroomParticipantView } from "./room-types";
+
+function participant(
+  principalRef: string,
+  roles: WorkroomParticipantRole[],
+  extras: Partial<WorkroomParticipantView> = {},
+): WorkroomParticipantView {
+  return {
+    principalRef,
+    displayName: principalRef,
+    kind: "person",
+    roles,
+    workState: "unknown",
+    presence: "unknown",
+    currentWorkSummary: null,
+    enteredReason: null,
+    sponsorPrincipalRef: null,
+    authoritySummary: "",
+    sourceRefs: [],
+    assignmentSource: extras.assignmentSource ?? "explicit",
+    coordinatorSource: extras.coordinatorSource ?? "none",
+    ...extras,
+  };
+}
+
+describe("Workroom participant assignment contract (BI-4CB2EF76)", () => {
+  it("accepts every canonical participant role, including specialist and approver", () => {
+    expect(WORKROOM_PARTICIPANT_ROLES).toEqual([
+      "accountable",
+      "coordinator",
+      "contributor",
+      "specialist",
+      "approver",
+      "reviewer",
+      "observer",
+    ]);
+
+    const parsed = parsePersistedWorkroomParticipantAssignment({
+      workroomId: "wc-row-1",
+      principalRef: "PRN-OWNER",
+      roles: ["accountable", "coordinator", "specialist", "approver"],
+      assignmentSource: "explicit",
+      enteredReason: "Named Process Overseer",
+      currentWorkSummary: null,
+    });
+    expect(parsed.roles).toEqual(["accountable", "coordinator", "specialist", "approver"]);
+    expect(parsed.assignmentSource).toBe("explicit");
+  });
+
+  it("refuses to persist coworker-owned proactivity onto the room roster", () => {
+    expect(() =>
+      assertAssignmentDoesNotCarryProactivity({
+        workroomId: "wc-row-1",
+        principalRef: "PRN-AGENT",
+        roles: ["coordinator"],
+        assignmentSource: "explicit",
+        proactivity: { family: "obligation-assurance", cadence: "daily" },
+        coworkerPreference: { quietHours: true },
+      }),
+    ).toThrow(/proactivity/i);
+  });
+
+  it("distinguishes an explicit persisted coordinator from a derived one", () => {
+    const explicit = participant("PRN-COORD", ["coordinator"], {
+      assignmentSource: "explicit",
+      coordinatorSource: "explicit",
+    });
+    const derived = deriveRoomCoordinator([
+      participant("PRN-OWNER", ["accountable"], { assignmentSource: "legacy", coordinatorSource: "none" }),
+    ]);
+    expect(selectExplicitRoomCoordinator([explicit])?.principalRef).toBe("PRN-COORD");
+    expect(selectExplicitRoomCoordinator(derived)).toBeNull();
+    expect(derived[0]?.coordinatorSource).toBe("derived");
+    expect(derived[0]?.roles).toContain("coordinator");
+    expect(resolveCoordinatorSource({
+      roles: derived[0]!.roles,
+      assignmentSource: "legacy",
+      coordinatorWasDerived: true,
+    })).toBe("derived");
+  });
+
+  it("projects one roster from persisted assignments without a conversation overlay", () => {
+    const roster = projectPersistedWorkroomRoster({
+      assignments: [
+        {
+          workroomId: "wc-row-1",
+          principalRef: "PRN-OWNER",
+          displayName: "Mara Chen",
+          kind: "person",
+          roles: ["accountable", "coordinator"],
+          assignmentSource: "explicit",
+          enteredReason: "Named in the room",
+          currentWorkSummary: null,
+          sponsorPrincipalRef: null,
+          sponsorDisplayName: null,
+          authoritySummary: "Owns the outcome",
+        },
+        {
+          workroomId: "wc-row-1",
+          principalRef: "PRN-REVIEWER",
+          displayName: "Noah Williams",
+          kind: "person",
+          roles: ["reviewer"],
+          assignmentSource: "explicit",
+          enteredReason: "Named reviewer",
+          currentWorkSummary: null,
+          sponsorPrincipalRef: null,
+          sponsorDisplayName: null,
+          authoritySummary: "May review evidence",
+        },
+      ],
+      presencePrincipalRefs: [],
+    });
+    expect(roster.map((row) => row.principalRef)).toEqual(["PRN-OWNER", "PRN-REVIEWER"]);
+    expect(selectExplicitRoomCoordinator(roster)?.principalRef).toBe("PRN-OWNER");
+    expect(roster.find((row) => row.principalRef === "PRN-OWNER")?.assignmentSource).toBe("explicit");
+    expect(roster.find((row) => row.principalRef === "PRN-OWNER")?.coordinatorSource).toBe("explicit");
+  });
+
+  it("does not treat a legacy assignment as an explicit Process Overseer", () => {
+    const roster = projectPersistedWorkroomRoster({
+      assignments: [{
+        workroomId: "wc-row-1",
+        principalRef: "PRN-OWNER",
+        displayName: "Mara Chen",
+        kind: "person",
+        roles: ["accountable"],
+        assignmentSource: "legacy",
+        enteredReason: "Assigned to this room's work",
+        currentWorkSummary: "Approve the exception",
+        sponsorPrincipalRef: null,
+        sponsorDisplayName: null,
+        authoritySummary: "Owns the outcome",
+      }],
+      presencePrincipalRefs: [],
+    });
+    const derived = deriveRoomCoordinator(roster);
+    expect(derived[0]?.assignmentSource).toBe("legacy");
+    expect(derived[0]?.coordinatorSource).toBe("derived");
+    expect(selectExplicitRoomCoordinator(derived)).toBeNull();
+  });
+});
+
+describe("Workroom participant persistence migration (BI-4CB2EF76)", () => {
+  it("backfills live-shaped WorkItem policy participants without inventing a coordinator", () => {
+    const sql = readFileSync(
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        "../../../../packages/db/prisma/migrations/20260901040000_add_workroom_participant_assignments/migration.sql",
+      ),
+      "utf8",
+    );
+    expect(sql).toMatch(/CREATE TABLE "WorkCapsuleParticipant"/);
+    expect(sql).toMatch(/ON CONFLICT \("workroomId", "principalId"\) DO NOTHING/);
+    expect(sql).toMatch(/workroomPolicy/);
+    expect(sql).toMatch(/assignmentSource/);
+    expect(sql).toMatch(/'legacy'/);
+    expect(sql).toMatch(/'explicit'/);
+    expect(sql).not.toMatch(/accountable.*coordinator/i);
+    expect(sql).toMatch(/330|existing WorkCapsule|WorkItem/);
+  });
+});

--- a/apps/web/lib/work-management/room-participant-assignment.ts
+++ b/apps/web/lib/work-management/room-participant-assignment.ts
@@ -1,0 +1,140 @@
+/**
+ * Persisted Workroom participant assignments (BI-4CB2EF76).
+ *
+ * Canonical roster carrier: WorkroomParticipant rows on the Workroom
+ * (WorkCapsule) substrate. Explicit assignment is distinguishable from
+ * legacy WorkItem assignment and from read-model coordinator derivation.
+ * Derived coordinators are never written. Participant identity may tighten
+ * safety but cannot carry coworker-owned proactivity onto the room.
+ */
+import { isRecord } from "@/lib/shared/coerce";
+
+import {
+  WORKROOM_PARTICIPANT_ROLES,
+  type WorkroomCoordinatorSource,
+  type WorkroomParticipantAssignmentSource,
+  type WorkroomParticipantRole,
+  type WorkroomParticipantView,
+} from "./room-types";
+import { deriveRoomCoordinator } from "./room-coordinator";
+
+export { WORKROOM_PARTICIPANT_ROLES };
+
+export const PERSISTED_WORKROOM_PARTICIPANT_ASSIGNMENT_SOURCES = ["explicit", "legacy"] as const;
+export type PersistedWorkroomParticipantAssignmentSource =
+  (typeof PERSISTED_WORKROOM_PARTICIPANT_ASSIGNMENT_SOURCES)[number];
+
+const PROACTIVITY_KEYS = [
+  "proactivity",
+  "coworkerPreference",
+  "coworkerPreferences",
+  "selfTasks",
+  "COWORKER_SELF_TASKS",
+  "agentPreference",
+  "agentPreferences",
+] as const;
+
+export type PersistedWorkroomParticipantAssignment = {
+  workroomId: string;
+  principalRef: string;
+  roles: WorkroomParticipantRole[];
+  assignmentSource: PersistedWorkroomParticipantAssignmentSource;
+  enteredReason: string | null;
+  currentWorkSummary: string | null;
+};
+
+export type ProjectableWorkroomParticipantAssignment = PersistedWorkroomParticipantAssignment & {
+  displayName: string;
+  kind: WorkroomParticipantView["kind"];
+  sponsorPrincipalRef: string | null;
+  sponsorDisplayName: string | null;
+  authoritySummary: string;
+};
+
+function isParticipantRole(value: unknown): value is WorkroomParticipantRole {
+  return typeof value === "string" && (WORKROOM_PARTICIPANT_ROLES as readonly string[]).includes(value);
+}
+
+function isPersistedSource(value: unknown): value is PersistedWorkroomParticipantAssignmentSource {
+  return value === "explicit" || value === "legacy";
+}
+
+export function assertAssignmentDoesNotCarryProactivity(input: Record<string, unknown>): void {
+  const carried = PROACTIVITY_KEYS.filter((key) => key in input);
+  if (carried.length > 0) {
+    throw new Error(
+      `Workroom participant assignment cannot carry coworker-owned proactivity (${carried.join(", ")}).`,
+    );
+  }
+}
+
+export function parsePersistedWorkroomParticipantAssignment(
+  input: unknown,
+): PersistedWorkroomParticipantAssignment {
+  if (!isRecord(input)) {
+    throw new Error("Workroom participant assignment must be an object.");
+  }
+  assertAssignmentDoesNotCarryProactivity(input);
+  const workroomId = typeof input.workroomId === "string" ? input.workroomId.trim() : "";
+  const principalRef = typeof input.principalRef === "string" ? input.principalRef.trim() : "";
+  if (!workroomId) throw new Error("Workroom participant assignment requires workroomId.");
+  if (!principalRef) throw new Error("Workroom participant assignment requires principalRef.");
+  if (!isPersistedSource(input.assignmentSource)) {
+    throw new Error("Workroom participant assignment requires assignmentSource explicit|legacy.");
+  }
+  const roles = Array.isArray(input.roles) ? input.roles.filter(isParticipantRole) : [];
+  if (roles.length === 0) {
+    throw new Error("Workroom participant assignment requires at least one canonical role.");
+  }
+  return {
+    workroomId,
+    principalRef,
+    roles: [...new Set(roles)],
+    assignmentSource: input.assignmentSource,
+    enteredReason: typeof input.enteredReason === "string" ? input.enteredReason.trim() || null : null,
+    currentWorkSummary: typeof input.currentWorkSummary === "string"
+      ? input.currentWorkSummary.trim() || null
+      : null,
+  };
+}
+
+export function resolveCoordinatorSource(input: {
+  roles: readonly WorkroomParticipantRole[];
+  assignmentSource: WorkroomParticipantAssignmentSource;
+  coordinatorWasDerived?: boolean;
+}): WorkroomCoordinatorSource {
+  if (input.coordinatorWasDerived) return "derived";
+  if (input.roles.includes("coordinator")) return "explicit";
+  void input.assignmentSource;
+  return "none";
+}
+
+export function projectPersistedWorkroomRoster(input: {
+  assignments: readonly ProjectableWorkroomParticipantAssignment[];
+  presencePrincipalRefs: readonly string[];
+}): WorkroomParticipantView[] {
+  const active = new Set(input.presencePrincipalRefs);
+  const projected: WorkroomParticipantView[] = input.assignments.map((assignment) => {
+    const currentWorkSummary = assignment.currentWorkSummary;
+    return {
+      principalRef: assignment.principalRef,
+      displayName: assignment.displayName,
+      kind: assignment.kind,
+      roles: [...assignment.roles],
+      workState: currentWorkSummary ? "working" : "unknown",
+      presence: active.has(assignment.principalRef) ? "active" : "unknown",
+      currentWorkSummary,
+      enteredReason: assignment.enteredReason,
+      sponsorPrincipalRef: assignment.sponsorPrincipalRef,
+      sponsorDisplayName: assignment.sponsorDisplayName,
+      authoritySummary: assignment.authoritySummary,
+      sourceRefs: [{ kind: "evidence", id: assignment.principalRef, sourceType: "principal" }],
+      assignmentSource: assignment.assignmentSource,
+      coordinatorSource: resolveCoordinatorSource({
+        roles: assignment.roles,
+        assignmentSource: assignment.assignmentSource,
+      }),
+    };
+  });
+  return deriveRoomCoordinator(projected);
+}

--- a/apps/web/lib/work-management/room-participation-prisma.server.ts
+++ b/apps/web/lib/work-management/room-participation-prisma.server.ts
@@ -8,6 +8,7 @@ import {
   type WorkroomConversationParticipant,
   type WorkroomParticipantAssignment,
 } from "./room-participation";
+import { mapPersistedParticipantRow } from "./room-participant-assignment.server";
 import type { WorkspaceRoomParticipantLoader } from "./workspace-case-loader";
 
 type ResolvedPrincipal = {
@@ -109,61 +110,86 @@ export const loadPrismaWorkroomParticipants: WorkspaceRoomParticipantLoader = as
   );
   const assignments: WorkroomParticipantAssignment[] = [];
 
+  if (input.workroomIds.length > 0 && typeof prisma.workroomParticipant?.findMany === "function") {
+    const persisted = await prisma.workroomParticipant.findMany({
+      where: { workroomId: { in: [...input.workroomIds] }, lifecycle: "active" },
+      include: {
+        principal: {
+          select: {
+            principalId: true,
+            displayName: true,
+            kind: true,
+            authorityMode: true,
+            sponsorPrincipal: { select: { principalId: true, displayName: true } },
+          },
+        },
+      },
+    });
+    for (const row of persisted) {
+      assignments.push(mapPersistedParticipantRow(row));
+    }
+  }
+
   const policyPrincipalByRef = new Map(
     policyPrincipals.map((principal) => [principal.principalId, principal]),
   );
-  for (const participant of input.policyParticipants) {
-    const principal = policyPrincipalByRef.get(participant.principalRef);
-    if (!principal) continue;
-    assignments.push({
-      principalRef: principal.principalId,
-      displayName: principal.displayName,
-      kind: principal.kind === "agent"
-        ? "agent"
-        : principal.kind === "system" || principal.kind === "service"
-          ? "system"
-          : "person",
-      roles: [...participant.roles],
-      currentWorkSummary: participant.currentWorkSummary,
-      enteredReason: participant.enteredReason ?? "Named in this room's participation policy",
-      sponsorPrincipalRef: principal.sponsorPrincipal?.principalId ?? null,
-      sponsorDisplayName: principal.sponsorPrincipal?.displayName ?? null,
-      authoritySummary: authoritySummary(principal),
-    });
-  }
+  if (assignments.length === 0) {
+    for (const participant of input.policyParticipants) {
+      const principal = policyPrincipalByRef.get(participant.principalRef);
+      if (!principal) continue;
+      assignments.push({
+        principalRef: principal.principalId,
+        displayName: principal.displayName,
+        kind: principal.kind === "agent"
+          ? "agent"
+          : principal.kind === "system" || principal.kind === "service"
+            ? "system"
+            : "person",
+        roles: [...participant.roles],
+        currentWorkSummary: participant.currentWorkSummary,
+        enteredReason: participant.enteredReason ?? "Named in this room's participation policy",
+        sponsorPrincipalRef: principal.sponsorPrincipal?.principalId ?? null,
+        sponsorDisplayName: principal.sponsorPrincipal?.displayName ?? null,
+        authoritySummary: authoritySummary(principal),
+        assignmentSource: "explicit",
+      });
+    }
 
-  const assignedPerson = input.assignedToUserId
-    ? principalByAlias.get(`user:${input.assignedToUserId}`)
-    : null;
-  if (assignedPerson) {
-    assignments.push({
-      principalRef: assignedPerson.principalId,
-      displayName: assignedPerson.displayName,
-      kind: "person",
-      roles: ["accountable"],
-      currentWorkSummary: input.title,
-      enteredReason: "Assigned to this room's work",
-      sponsorPrincipalRef: null,
-      sponsorDisplayName: null,
-      authoritySummary: authoritySummary(assignedPerson),
-    });
-  }
+    const assignedPerson = input.assignedToUserId
+      ? principalByAlias.get(`user:${input.assignedToUserId}`)
+      : null;
+    if (assignedPerson) {
+      assignments.push({
+        principalRef: assignedPerson.principalId,
+        displayName: assignedPerson.displayName,
+        kind: "person",
+        roles: ["accountable"],
+        currentWorkSummary: input.title,
+        enteredReason: "Assigned to this room's work",
+        sponsorPrincipalRef: null,
+        sponsorDisplayName: null,
+        authoritySummary: authoritySummary(assignedPerson),
+        assignmentSource: "legacy",
+      });
+    }
 
-  const assignedAgent = input.assignedToAgentId
-    ? principalByAlias.get(`agent:${input.assignedToAgentId}`)
-    : null;
-  if (assignedAgent) {
-    assignments.push({
-      principalRef: assignedAgent.principalId,
-      displayName: assignedAgent.displayName,
-      kind: "agent",
-      roles: [assignedPerson ? "contributor" : "accountable"],
-      currentWorkSummary: input.title,
-      enteredReason: "Assigned to this room's work",
-      sponsorPrincipalRef: assignedAgent.sponsorPrincipal?.principalId ?? null,
-      sponsorDisplayName: assignedAgent.sponsorPrincipal?.displayName ?? null,
-      authoritySummary: authoritySummary(assignedAgent),
-    });
+    const assignedAgent = input.assignedToAgentId
+      ? principalByAlias.get(`agent:${input.assignedToAgentId}`)
+      : null;
+    if (assignedAgent) {
+      assignments.push({
+        principalRef: assignedAgent.principalId,
+        displayName: assignedAgent.displayName,
+        kind: "agent",
+        roles: [assignedPerson ? "contributor" : "accountable"],
+        currentWorkSummary: input.title,
+        enteredReason: "Assigned to this room's work",
+        sponsorPrincipalRef: assignedAgent.sponsorPrincipal?.principalId ?? null,
+        sponsorDisplayName: assignedAgent.sponsorPrincipal?.displayName ?? null,
+        authoritySummary: authoritySummary(assignedAgent),
+        assignmentSource: "legacy",
+      });
+    }
   }
 
   const conversationParticipants: WorkroomConversationParticipant[] = lineage.flatMap((participant) => {

--- a/apps/web/lib/work-management/room-participation.test.ts
+++ b/apps/web/lib/work-management/room-participation.test.ts
@@ -119,6 +119,7 @@ describe("Work Room participation", () => {
         enteredReason: "Assigned owner",
         sponsorPrincipalRef: null,
         authoritySummary: "May review and approve",
+        assignmentSource: "explicit",
       }, {
         principalRef: "PRN-REVIEWER",
         displayName: "Noah Williams",
@@ -128,6 +129,7 @@ describe("Work Room participation", () => {
         enteredReason: "Named reviewer",
         sponsorPrincipalRef: null,
         authoritySummary: "May review evidence",
+        assignmentSource: "explicit",
       }],
       conversationParticipants: [{
         principalRef: "PRN-AGENT",

--- a/apps/web/lib/work-management/room-participation.ts
+++ b/apps/web/lib/work-management/room-participation.ts
@@ -1,6 +1,7 @@
 import type { ActiveViewer } from "./work-item-presence";
 import { deriveRoomCoordinator } from "./room-coordinator";
 import type {
+  WorkroomParticipantAssignmentSource,
   WorkroomParticipantRole,
   WorkroomParticipantView,
 } from "./room-types";
@@ -96,11 +97,12 @@ export type WorkroomParticipantAssignment = {
   sponsorPrincipalRef: string | null;
   sponsorDisplayName?: string | null;
   authoritySummary: string;
+  assignmentSource: Exclude<WorkroomParticipantAssignmentSource, "conversation">;
 };
 
 export type WorkroomConversationParticipant = Omit<
   WorkroomParticipantView,
-  "kind" | "presence" | "sourceRefs"
+  "kind" | "presence" | "sourceRefs" | "assignmentSource" | "coordinatorSource"
 > & {
   sourceRef: WorkroomParticipantView["sourceRefs"][number];
 };
@@ -116,11 +118,12 @@ export function projectWorkroomParticipants(input: {
   for (const assignment of input.assignments) {
     const existing = projected.get(assignment.principalRef);
     const currentWorkSummary = assignment.currentWorkSummary ?? existing?.currentWorkSummary ?? null;
+    const roles = existing
+      ? [...new Set([...existing.roles, ...assignment.roles])]
+      : assignment.roles;
     projected.set(assignment.principalRef, {
       ...assignment,
-      roles: existing
-        ? [...new Set([...existing.roles, ...assignment.roles])]
-        : assignment.roles,
+      roles,
       currentWorkSummary,
       enteredReason: assignment.enteredReason ?? existing?.enteredReason ?? null,
       sponsorPrincipalRef: assignment.sponsorPrincipalRef ?? existing?.sponsorPrincipalRef ?? null,
@@ -131,18 +134,21 @@ export function projectWorkroomParticipants(input: {
         ...(existing?.sourceRefs ?? []),
         { kind: "evidence", id: assignment.principalRef, sourceType: "principal" },
       ],
+      assignmentSource: assignment.assignmentSource,
+      coordinatorSource: roles.includes("coordinator") ? "explicit" : "none",
     });
   }
 
   for (const participant of input.conversationParticipants) {
     const existing = projected.get(participant.principalRef);
+    const roles = existing
+      ? [...new Set([...existing.roles, ...participant.roles])]
+      : participant.roles;
     projected.set(participant.principalRef, {
       principalRef: participant.principalRef,
       displayName: participant.displayName,
       kind: "agent",
-      roles: existing
-        ? [...new Set([...existing.roles, ...participant.roles])]
-        : participant.roles,
+      roles,
       workState: participant.workState,
       presence: active.has(participant.principalRef) ? "active" : "unknown",
       currentWorkSummary: participant.currentWorkSummary,
@@ -154,6 +160,8 @@ export function projectWorkroomParticipants(input: {
         ...(existing?.sourceRefs ?? []),
         participant.sourceRef,
       ],
+      assignmentSource: existing?.assignmentSource ?? "conversation",
+      coordinatorSource: existing?.coordinatorSource ?? "none",
     });
   }
 

--- a/apps/web/lib/work-management/room-read-model.test.ts
+++ b/apps/web/lib/work-management/room-read-model.test.ts
@@ -79,6 +79,8 @@ describe("Work Room read model", () => {
           sponsorPrincipalRef: null,
           authoritySummary: "Can act within the approved booking scope",
           sourceRefs: [sourceRef],
+          assignmentSource: "explicit",
+          coordinatorSource: "none",
         },
       ],
       context: {
@@ -269,6 +271,8 @@ describe("Work Room read model", () => {
           sponsorPrincipalRef: null,
           authoritySummary: "Can approve and complete",
           sourceRefs: [sourceRef],
+          assignmentSource: "explicit",
+          coordinatorSource: "none",
         },
       ],
     });

--- a/apps/web/lib/work-management/room-types.ts
+++ b/apps/web/lib/work-management/room-types.ts
@@ -54,14 +54,21 @@ export type WorkroomActivityKind =
   | "cycle-closed"
   | "cycle-carried-over";
 
-export type WorkroomParticipantRole =
-  | "accountable"
-  | "coordinator"
-  | "contributor"
-  | "specialist"
-  | "approver"
-  | "reviewer"
-  | "observer";
+export const WORKROOM_PARTICIPANT_ROLES = [
+  "accountable",
+  "coordinator",
+  "contributor",
+  "specialist",
+  "approver",
+  "reviewer",
+  "observer",
+] as const;
+
+export type WorkroomParticipantRole = (typeof WORKROOM_PARTICIPANT_ROLES)[number];
+
+export type WorkroomParticipantAssignmentSource = "explicit" | "legacy" | "conversation";
+
+export type WorkroomCoordinatorSource = "explicit" | "derived" | "none";
 
 export type WorkroomParticipantWorkState =
   | "working"
@@ -162,6 +169,14 @@ export interface WorkroomParticipantView {
   sponsorDisplayName?: string | null;
   authoritySummary: string;
   sourceRefs: WorkCaseSourceRef[];
+  /** How this principal entered the roster. Conversation overlay is never persisted. */
+  assignmentSource: WorkroomParticipantAssignmentSource;
+  /**
+   * Explicit = coordinator role was persisted. Derived = read-model default from
+   * the sole accountable. None = not coordinating. Only explicit qualifies a
+   * standing room for autonomous drive (BI-3913EB49).
+   */
+  coordinatorSource: WorkroomCoordinatorSource;
 }
 
 export interface WorkroomActivityView {

--- a/apps/web/lib/work-management/workspace-case-loader.test.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.test.ts
@@ -422,6 +422,8 @@ describe("workspace Work Case loader", () => {
         sponsorPrincipalRef: "PRN-USER-1",
         authoritySummary: "May prepare options; approval remains human",
         sourceRefs: [{ kind: "evidence", id: "TR-1", sourceType: "task-run" }],
+        assignmentSource: "conversation",
+        coordinatorSource: "none",
         }];
       },
     });

--- a/apps/web/lib/work-management/workspace-case-loader.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.ts
@@ -178,6 +178,7 @@ export type WorkspaceRoomParticipantLoader = (input: {
   status: string;
   now: Date;
   policyParticipants: readonly WorkspaceRoomPolicyParticipant[];
+  workroomIds: readonly string[];
 }) => Promise<WorkroomParticipantView[]>;
 
 export type WorkspaceWorkCaseListItem = {
@@ -571,22 +572,12 @@ export async function loadWorkspaceWorkCaseDetail({
   if (access.level !== "content" && access.level !== "action") return null;
   const roomPolicy = readWorkspaceRoomPolicy(item.evidence);
 
-  const [messages, participants, capsules] = await Promise.all([
+  const [messages, capsules] = await Promise.all([
     prismaClient.workItemMessage.findMany({
       where: { workItemId: { in: [item.id, ...(item.childItems ?? []).map((child) => child.id)] } },
       orderBy: [{ createdAt: "asc" }],
       take: 20,
     }),
-    participantLoader?.({
-      workItemId: item.id,
-      assignedToUserId: item.assignedToUserId,
-      assignedToAgentId: item.assignedToAgentId ?? null,
-      assignedThreadId: item.assignedThreadId ?? null,
-      title: item.title,
-      status: item.status,
-      now,
-      policyParticipants: roomPolicy.participants ?? [],
-    }) ?? Promise.resolve([]),
     // EP-WORK-CONVERGENCE (BI-650994D7): join the capsule(s) anchored to this WorkItem
     // so a coding carrier surfaces in its case instead of as a disjoint row.
     prismaClient.workroom.findMany({
@@ -610,6 +601,17 @@ export async function loadWorkspaceWorkCaseDetail({
       orderBy: [{ updatedAt: "desc" }],
     }),
   ]);
+  const participants = await (participantLoader?.({
+    workItemId: item.id,
+    assignedToUserId: item.assignedToUserId,
+    assignedToAgentId: item.assignedToAgentId ?? null,
+    assignedThreadId: item.assignedThreadId ?? null,
+    title: item.title,
+    status: item.status,
+    now,
+    policyParticipants: roomPolicy.participants ?? [],
+    workroomIds: capsules.map((capsule) => capsule.id).filter((id): id is string => Boolean(id)),
+  }) ?? Promise.resolve([]));
   // BI-1CF7B600: the capsule's own execution journal (WorkroomActivity rows) so a
   // capsule-sourced room shows its activity instead of "No activity yet". Keyed on the
   // capsule row ids just fetched — one bounded query, newest first.

--- a/apps/web/lib/work-management/workspace-room-access.test.ts
+++ b/apps/web/lib/work-management/workspace-room-access.test.ts
@@ -69,6 +69,21 @@ describe("Workspace Work Room access", () => {
     }).level).toBe("none");
   });
 
+  it("parses specialist and approver roles on the policy roster", () => {
+    expect(readWorkspaceRoomPolicy([{ workroomPolicy: {
+      participants: [{
+        principalRef: "PRN-SPEC",
+        roles: ["specialist", "approver"],
+        enteredReason: "Named specialist-approver",
+      }],
+    } }]).participants).toEqual([{
+      principalRef: "PRN-SPEC",
+      roles: ["specialist", "approver"],
+      enteredReason: "Named specialist-approver",
+      currentWorkSummary: null,
+    }]);
+  });
+
   it("parses explicitly named participants separately from access admission", () => {
     expect(readWorkspaceRoomPolicy([{ workroomPolicy: {
       admittedPrincipalRefs: ["PRN-REVIEWER"],

--- a/apps/web/lib/work-management/workspace-room-access.ts
+++ b/apps/web/lib/work-management/workspace-room-access.ts
@@ -1,4 +1,5 @@
 import { authorizeWorkroomAccess, type WorkroomAccessDecision } from "./room-participation";
+import { WORKROOM_PARTICIPANT_ROLES, type WorkroomParticipantRole } from "./room-types";
 
 export type WorkspaceRoomPolicyMetadata = {
   admittedPrincipalRefs: string[];
@@ -10,7 +11,7 @@ export type WorkspaceRoomPolicyMetadata = {
 
 export type WorkspaceRoomPolicyParticipant = {
   principalRef: string;
-  roles: Array<"accountable" | "coordinator" | "contributor" | "reviewer" | "observer">;
+  roles: WorkroomParticipantRole[];
   enteredReason: string | null;
   currentWorkSummary: string | null;
 };
@@ -35,11 +36,10 @@ export function readWorkspaceRoomPolicy(evidence: unknown): Partial<WorkspaceRoo
             ? participant.principalRef.trim()
             : "";
           if (!principalRef) return [];
-          const validRoles = ["accountable", "coordinator", "contributor", "reviewer", "observer"];
           const roles = Array.isArray(participant.roles)
             ? participant.roles.filter(
-                (role): role is WorkspaceRoomPolicyParticipant["roles"][number] =>
-                  typeof role === "string" && validRoles.includes(role),
+                (role): role is WorkroomParticipantRole =>
+                  typeof role === "string" && (WORKROOM_PARTICIPANT_ROLES as readonly string[]).includes(role),
               )
             : [];
           return [{

--- a/changes/workroom-participant-assignments.data-impact.json
+++ b/changes/workroom-participant-assignments.data-impact.json
@@ -1,0 +1,56 @@
+{
+  "version": "1",
+  "accountableOwner": "Mark Bodman (markdbodman@gmail.com)",
+  "summary": "BI-4CB2EF76. Migration 20260901040000_add_workroom_participant_assignments adds WorkCapsuleParticipant as the canonical Workroom roster. Explicit policy-named assignments are distinguishable from legacy WorkItem assignee backfill. Derived coordinator membership is not written. Additive; existing WorkCapsule and WorkItem rows keep their current columns. Backfill is idempotent ON CONFLICT DO NOTHING against live-shaped WorkItem.evidence and PrincipalAlias rows.",
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "WorkroomParticipant",
+      "lifecycleDisposition": "retain-with-workroom",
+      "fields": [
+        {
+          "name": "principalId",
+          "resolution": "inherited",
+          "reason": "FK to the existing Principal row. Creates no second identity home; the roster points at the canonical principal.",
+          "provenance": "Resolved from workroomPolicy.participants.principalRef, invite principalRef, or PrincipalAlias for a legacy WorkItem assignee.",
+          "flags": []
+        },
+        {
+          "name": "roles",
+          "resolution": "not-applicable",
+          "reason": "Closed collaboration-role set for this room (accountable, coordinator, contributor, specialist, approver, reviewer, observer). Operational membership, not a data-subject attribute.",
+          "provenance": "Named in the room policy or invite; legacy backfill copies only accountable/contributor from WorkItem assignment and never invents coordinator.",
+          "flags": []
+        },
+        {
+          "name": "assignmentSource",
+          "resolution": "not-applicable",
+          "reason": "Provenance of the membership row (explicit vs legacy). Operational metadata used to refuse autonomous drive on a derived or legacy-only Process Overseer.",
+          "provenance": "Set to explicit for policy/invite writes; legacy for WorkItem assignee backfill.",
+          "flags": []
+        },
+        {
+          "name": "enteredReason",
+          "resolution": "not-applicable",
+          "reason": "Short operational explanation of why the principal is in the room.",
+          "provenance": "Copied from the policy snapshot or the invite writer.",
+          "flags": []
+        },
+        {
+          "name": "currentWorkSummary",
+          "resolution": "not-applicable",
+          "reason": "Optional current-work label for the room surface. Not a data-subject attribute.",
+          "provenance": "Copied from the policy snapshot or WorkItem.title for legacy assignees.",
+          "flags": []
+        },
+        {
+          "name": "lifecycle",
+          "resolution": "not-applicable",
+          "reason": "Platform record-lifecycle convention. Marks whether this membership row is currently active.",
+          "provenance": "Defaults to active; archived when membership is withdrawn.",
+          "flags": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -8,8 +8,8 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 
 | Count | Value | Source of truth |
 |---|---:|---|
-| Prisma models | 614 | `packages/db/prisma/schema/` |
-| Prisma enums | 73 | `packages/db/prisma/schema/` |
-| Migrations | 559 | `packages/db/prisma/migrations/` |
+| Prisma models | 615 | `packages/db/prisma/schema/` |
+| Prisma enums | 75 | `packages/db/prisma/schema/` |
+| Migrations | 560 | `packages/db/prisma/migrations/` |
 | Kernel principles | 99 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 642 | `apps/web/lib/ea/route-manifest.json` |

--- a/packages/db/prisma/migrations/20260901040000_add_workroom_participant_assignments/migration.sql
+++ b/packages/db/prisma/migrations/20260901040000_add_workroom_participant_assignments/migration.sql
@@ -1,0 +1,211 @@
+-- BI-4CB2EF76: persist Workroom participant and coordinator assignments on the
+-- canonical WorkCapsule substrate. Explicit policy-named roster is distinguishable
+-- from legacy WorkItem assignment. Derived Process Overseer membership is never
+-- written.
+--
+-- @migration-safety: data-safe: additive enums + new table; existing WorkCapsule
+-- and WorkItem rows are unchanged. Backfill is idempotent (ON CONFLICT DO NOTHING)
+-- and only copies named policy participants plus assigned user/agent aliases that
+-- already resolve to a Principal. No coordinator role is invented from an
+-- accountable assignment.
+--
+-- Live-shaped: applies against the existing WorkCapsule population and the
+-- WorkItem.evidence JSON those rooms already carry, not only a clean schema.
+
+-- CreateEnum
+CREATE TYPE "WorkroomParticipantRole" AS ENUM (
+  'accountable',
+  'coordinator',
+  'contributor',
+  'specialist',
+  'approver',
+  'reviewer',
+  'observer'
+);
+
+-- CreateEnum
+CREATE TYPE "WorkroomParticipantAssignmentSource" AS ENUM (
+  'explicit',
+  'legacy'
+);
+
+-- CreateTable
+CREATE TABLE "WorkCapsuleParticipant" (
+    "id" TEXT NOT NULL,
+    "workroomId" TEXT NOT NULL,
+    "principalId" TEXT NOT NULL,
+    "roles" "WorkroomParticipantRole"[] NOT NULL,
+    "assignmentSource" "WorkroomParticipantAssignmentSource" NOT NULL,
+    "enteredReason" TEXT,
+    "currentWorkSummary" TEXT,
+    "lifecycle" "RecordLifecycle" NOT NULL DEFAULT 'active',
+    "lifecycleAt" TIMESTAMP(3),
+    "lifecycleReason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WorkCapsuleParticipant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WorkCapsuleParticipant_workroomId_principalId_key"
+  ON "WorkCapsuleParticipant"("workroomId", "principalId");
+
+-- CreateIndex
+CREATE INDEX "WorkCapsuleParticipant_principalId_idx"
+  ON "WorkCapsuleParticipant"("principalId");
+
+-- CreateIndex
+CREATE INDEX "WorkCapsuleParticipant_workroomId_lifecycle_idx"
+  ON "WorkCapsuleParticipant"("workroomId", "lifecycle");
+
+-- CreateIndex
+CREATE INDEX "WorkCapsuleParticipant_assignmentSource_idx"
+  ON "WorkCapsuleParticipant"("assignmentSource");
+
+-- AddForeignKey
+ALTER TABLE "WorkCapsuleParticipant"
+  ADD CONSTRAINT "WorkCapsuleParticipant_workroomId_fkey"
+  FOREIGN KEY ("workroomId") REFERENCES "WorkCapsule"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkCapsuleParticipant"
+  ADD CONSTRAINT "WorkCapsuleParticipant_principalId_fkey"
+  FOREIGN KEY ("principalId") REFERENCES "Principal"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Backfill explicit assignments from the latest workroomPolicy snapshot on the
+-- linked WorkItem. Coordinator is copied only when the policy already named it.
+INSERT INTO "WorkCapsuleParticipant" (
+  "id",
+  "workroomId",
+  "principalId",
+  "roles",
+  "assignmentSource",
+  "enteredReason",
+  "currentWorkSummary",
+  "lifecycle",
+  "createdAt",
+  "updatedAt"
+)
+SELECT
+  gen_random_uuid()::text,
+  wc.id,
+  pr.id,
+  CASE
+    WHEN cardinality(mapped.roles) = 0 THEN ARRAY['observer']::"WorkroomParticipantRole"[]
+    ELSE mapped.roles
+  END,
+  'explicit'::"WorkroomParticipantAssignmentSource",
+  mapped.entered_reason,
+  mapped.current_work_summary,
+  'active'::"RecordLifecycle",
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+FROM "WorkCapsule" wc
+JOIN "WorkItem" wi ON wi.id = wc."workItemId"
+JOIN LATERAL (
+  SELECT elem AS policy
+  FROM jsonb_array_elements(
+    CASE
+      WHEN wi.evidence IS NULL THEN '[]'::jsonb
+      WHEN jsonb_typeof(wi.evidence::jsonb) = 'array' THEN wi.evidence::jsonb
+      ELSE jsonb_build_array(wi.evidence::jsonb)
+    END
+  ) WITH ORDINALITY AS t(elem, ord)
+  WHERE elem ? 'workroomPolicy'
+  ORDER BY ord DESC
+  LIMIT 1
+) latest ON true
+JOIN LATERAL jsonb_array_elements(COALESCE(latest.policy->'workroomPolicy'->'participants', '[]'::jsonb)) p ON true
+JOIN "Principal" pr ON pr."principalId" = btrim(p->>'principalRef') AND pr.status = 'active'
+CROSS JOIN LATERAL (
+  SELECT
+    ARRAY(
+      SELECT r::"WorkroomParticipantRole"
+      FROM jsonb_array_elements_text(COALESCE(p->'roles', '[]'::jsonb)) r
+      WHERE r IN (
+        'accountable',
+        'coordinator',
+        'contributor',
+        'specialist',
+        'approver',
+        'reviewer',
+        'observer'
+      )
+    ) AS roles,
+    NULLIF(btrim(p->>'enteredReason'), '') AS entered_reason,
+    NULLIF(btrim(p->>'currentWorkSummary'), '') AS current_work_summary
+) mapped
+ON CONFLICT ("workroomId", "principalId") DO NOTHING;
+
+-- Backfill legacy WorkItem assignees that are not already on the roster.
+INSERT INTO "WorkCapsuleParticipant" (
+  "id",
+  "workroomId",
+  "principalId",
+  "roles",
+  "assignmentSource",
+  "enteredReason",
+  "currentWorkSummary",
+  "lifecycle",
+  "createdAt",
+  "updatedAt"
+)
+SELECT
+  gen_random_uuid()::text,
+  wc.id,
+  pr.id,
+  ARRAY['accountable']::"WorkroomParticipantRole"[],
+  'legacy'::"WorkroomParticipantAssignmentSource",
+  'Assigned to this room''s work',
+  wi.title,
+  'active'::"RecordLifecycle",
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+FROM "WorkCapsule" wc
+JOIN "WorkItem" wi ON wi.id = wc."workItemId"
+JOIN "PrincipalAlias" pa
+  ON pa."aliasType" = 'user'
+ AND pa."aliasValue" = wi."assignedToUserId"
+ AND pa.issuer = ''
+JOIN "Principal" pr ON pr.id = pa."principalId"
+WHERE wi."assignedToUserId" IS NOT NULL
+ON CONFLICT ("workroomId", "principalId") DO NOTHING;
+
+INSERT INTO "WorkCapsuleParticipant" (
+  "id",
+  "workroomId",
+  "principalId",
+  "roles",
+  "assignmentSource",
+  "enteredReason",
+  "currentWorkSummary",
+  "lifecycle",
+  "createdAt",
+  "updatedAt"
+)
+SELECT
+  gen_random_uuid()::text,
+  wc.id,
+  pr.id,
+  CASE
+    WHEN wi."assignedToUserId" IS NOT NULL THEN ARRAY['contributor']::"WorkroomParticipantRole"[]
+    ELSE ARRAY['accountable']::"WorkroomParticipantRole"[]
+  END,
+  'legacy'::"WorkroomParticipantAssignmentSource",
+  'Assigned to this room''s work',
+  wi.title,
+  'active'::"RecordLifecycle",
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+FROM "WorkCapsule" wc
+JOIN "WorkItem" wi ON wi.id = wc."workItemId"
+JOIN "PrincipalAlias" pa
+  ON pa."aliasType" = 'agent'
+ AND pa."aliasValue" = wi."assignedToAgentId"
+ AND pa.issuer = ''
+JOIN "Principal" pr ON pr.id = pa."principalId"
+WHERE wi."assignedToAgentId" IS NOT NULL
+ON CONFLICT ("workroomId", "principalId") DO NOTHING;

--- a/packages/db/prisma/schema/core-identity.prisma
+++ b/packages/db/prisma/schema/core-identity.prisma
@@ -248,6 +248,7 @@ model Principal {
   leaseHeldWorkrooms                  Workroom[]                          @relation("WorkroomLeaseHolder")
   createdWorkrooms                    Workroom[]                          @relation("WorkroomCreator")
   requestedWorkrooms                  Workroom[]                          @relation("WorkroomRequester")
+  workroomParticipations              WorkroomParticipant[]               @relation("WorkroomParticipantPrincipal")
 
   @@index([sponsorPrincipalId])
   @@index([kind, authorityMode])

--- a/packages/db/prisma/schema/work-coordination.prisma
+++ b/packages/db/prisma/schema/work-coordination.prisma
@@ -314,6 +314,24 @@ model InitiativeArtifactRetentionPin {
   @@index([sourceKind, createdAt(sort: Desc)])
 }
 
+// BI-4CB2EF76: persisted Workroom roster. Coordinator on this enum is explicit
+// assignment; read-model derivation never writes a row. Hyphens are not used
+// (values match apps/web/lib/work-management/room-types.ts).
+enum WorkroomParticipantRole {
+  accountable
+  coordinator
+  contributor
+  specialist
+  approver
+  reviewer
+  observer
+}
+
+enum WorkroomParticipantAssignmentSource {
+  explicit
+  legacy
+}
+
 /// The Workroom is the canonical unit of what we claim and where we work
 /// (founder-directed 2026-08-15, renamed from WorkCapsule). @@map retains the
 /// physical table name so this rename is metadata-only over live rows; the
@@ -389,6 +407,7 @@ model Workroom {
   leaseHolderPrincipal    Principal?               @relation("WorkroomLeaseHolder", fields: [leaseHolderPrincipalId], references: [id], onDelete: SetNull)
   createdByPrincipal      Principal?               @relation("WorkroomCreator", fields: [createdByPrincipalId], references: [id], onDelete: SetNull)
   requestedByPrincipal    Principal?               @relation("WorkroomRequester", fields: [requestedByPrincipalId], references: [id], onDelete: SetNull)
+  participants            WorkroomParticipant[]    @relation("WorkroomParticipants")
 
   @@index([status, updatedAt])
   @@index([backlogItemId])
@@ -427,6 +446,32 @@ model WorkroomActivity {
   @@index([kind, recordedAt(sort: Desc)])
   @@index([recordedAt]) // retention sweep cutoff scan, apps/web/lib/operate/retention/execute.ts:99
   @@map("WorkCapsuleActivity")
+}
+
+// BI-4CB2EF76: canonical Workroom roster. One row per (room, principal).
+// Explicit vs legacy is assignment provenance; derived coordinators stay
+// read-model only. Table name matches WorkCapsule mapping.
+model WorkroomParticipant {
+  id                    String                               @id @default(cuid())
+  workroomId            String
+  workroom              Workroom                             @relation("WorkroomParticipants", fields: [workroomId], references: [id], onDelete: Cascade)
+  principalId           String
+  principal             Principal                            @relation("WorkroomParticipantPrincipal", fields: [principalId], references: [id], onDelete: Restrict)
+  roles                 WorkroomParticipantRole[]
+  assignmentSource      WorkroomParticipantAssignmentSource
+  enteredReason         String?
+  currentWorkSummary    String?
+  lifecycle             RecordLifecycle                      @default(active)
+  lifecycleAt           DateTime?
+  lifecycleReason       String?
+  createdAt             DateTime                             @default(now())
+  updatedAt             DateTime                             @updatedAt
+
+  @@unique([workroomId, principalId])
+  @@index([principalId])
+  @@index([workroomId, lifecycle])
+  @@index([assignmentSource])
+  @@map("WorkCapsuleParticipant")
 }
 
 model Epic {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -36,6 +36,10 @@ export {
   DecisionProposalStatus,
 } from "../generated/client/client";
 export {
+  WorkroomParticipantRole,
+  WorkroomParticipantAssignmentSource,
+} from "../generated/client/client";
+export {
   PRINCIPAL_SENSITIVITIES,
   isPrincipalSensitivity,
   normalizePrincipalSensitivities,

--- a/packages/db/src/table-classification.ts
+++ b/packages/db/src/table-classification.ts
@@ -76,6 +76,9 @@ export const TABLE_CLASSIFICATION: Record<string, TableSensitivity> = {
   CodebaseManifest: "internal",
   ServiceOffering: "internal",
   BacklogItem: "internal",
+  // BI-4CB2EF76: room roster is operational membership (principal FK + roles).
+  // Display names stay on Principal; this table is not a second identity store.
+  WorkroomParticipant: "internal",
   InitiativeArtifactRetentionPin: "confidential",
   Epic: "internal",
   EpicPortfolio: "internal",

--- a/scripts/platform-substrate-baseline.json
+++ b/scripts/platform-substrate-baseline.json
@@ -17,7 +17,7 @@
     },
     "prismaModelCount": {
       "direction": "non-increasing",
-      "value": 614
+      "value": 615
     },
     "prismaSchemaLines": {
       "direction": "informational",

--- a/scripts/stewardship-exemptions.txt
+++ b/scripts/stewardship-exemptions.txt
@@ -112,6 +112,7 @@ StockItem  domain-lifecycle-managed  # Operator-maintained supply master: retire
 StorefrontItemComponent  domain-lifecycle-managed  # Recipe lines follow their sellable item and stock item via cascade; an age sweep would silently delete a live product's composition.
 IncumbentCoverageAssessment  domain-lifecycle-managed  # Per-customer coverage verdicts (BI-548060D5); re-assessment supersedes the prior row, never time-aged.
 JobRequisition  domain-lifecycle-managed  # Requisitions close/fill through their own status lifecycle (open→closed/filled), not a time-based sweep (BI-F3AEBF68).
+WorkroomParticipant  domain-lifecycle-managed  # Roster rows cascade with their Workroom and are archived by membership lifecycle; a time sweep would drop a live room's Process Overseer.
 RequisitionOpening  domain-lifecycle-managed  # Headcount slots follow their parent requisition via cascade; never independently aged.
 JobPosting  domain-lifecycle-managed  # Postings are unpublished/closed by requisition lifecycle and cascade; not age-swept.
 PipelineStage  domain-lifecycle-managed  # Stage definitions follow their requisition via cascade; not independently aged.


### PR DESCRIPTION
## Summary

Persist Workroom participant and coordinator assignments on the canonical Workroom substrate (BI-4CB2EF76).

- `WorkroomParticipant` (`WorkCapsuleParticipant`) is the single roster: accountable, contributor, reviewer, observer, approver, specialist, and coordinator.
- Explicit policy/invite assignment is distinguishable from legacy WorkItem assignees and from read-model coordinator derivation.
- `selectExplicitRoomCoordinator` only returns a persisted coordinator. Derived coordinators may explain old rooms but do not qualify autonomous drive.
- Invite and federated admission write the same table. A forward-only migration backfills live-shaped `WorkItem.evidence` policy participants and assignee aliases without inventing a coordinator.
- Participant identity cannot carry coworker-owned proactivity onto the room.

This slice does **not** implement trigger runtime, grants/measures dispatch, or Process Overseer transition enforcement (BI-3913EB49 / BI-FCD639D9).

## Design grounding

- Specs/plans reviewed: `docs/superpowers/specs/2026-08-29-proactive-workrooms-design.md`, `docs/superpowers/plans/2026-08-29-proactive-workrooms.md`, `docs/superpowers/plans/2026-08-30-paaw-competence-evolution-workroom-plan.md`
- Code substrate: `Workroom`/`WorkCapsule`, `WorkroomParticipantRole`, `room-coordinator.ts`, `room-participation.ts`, `WorkItem.evidence` `workroomPolicy`
- Source of truth: `WorkroomParticipant` rows. Policy JSON remains access control plus backfill source, not a second roster.
- Decision: one Workroom-owned participant table rather than a shadow roster or JSON-only assignments.

## Docs impact

No user-facing copy change. Generated architecture counts and a data-impact manifest only. Process Overseer / drive UX is Phase G.

## Test plan

- [x] Targeted Vitest: assignment contract, explicit vs derived coordinator, specialist/approver policy roles, case loader
- [x] `pnpm run pregate:preflight` (61 guards)
- [ ] `pnpm run pregate` local-CI exact-tree evidence
- [ ] `pnpm pr:health` after PR checks

Workroom: WC-60A4380F
EOF
