### PR TITLE
fix: stop legacy terminal-writer retries at ceiling

### DIFF
--- a/apps/web/lib/mcp-task-terminal-writer-escalation.test.ts
+++ b/apps/web/lib/mcp-task-terminal-writer-escalation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { recoverTerminalWriterEscalation } from "./mcp-task-terminal-writer-escalation";
+
+function legacyWait(attempt: number) {
+  return {
+    terminalWriterWait: {
+      schemaVersion: 1,
+      kind: "missing-terminal-writer",
+      writerToolName: "record_initiative_evidence",
+      resumeMode: "same-taskrun",
+      attempt,
+      observedAt: "2026-09-01T02:22:19.237Z",
+    },
+  };
+}
+
+describe("recoverTerminalWriterEscalation", () => {
+  it("recovers an exhausted pre-marker wait without dispatching another attempt", () => {
+    expect(recoverTerminalWriterEscalation(legacyWait(4))).toMatchObject({
+      schemaVersion: 1,
+      code: "terminal_writer_retry_exhausted",
+      writerToolName: "record_initiative_evidence",
+      attempt: 4,
+      action: "select-different-reviewer-provider",
+    });
+  });
+
+  it("keeps a pre-marker wait below the retry ceiling resumable", () => {
+    expect(recoverTerminalWriterEscalation(legacyWait(2))).toBeNull();
+  });
+});

--- a/apps/web/lib/mcp-task-terminal-writer-escalation.ts
+++ b/apps/web/lib/mcp-task-terminal-writer-escalation.ts
@@ -61,25 +61,34 @@ export function recoverTerminalWriterEscalation(value: unknown): TerminalWriterE
   const progress = value as Record<string, unknown>;
   const failure = progress["terminalWriterContextFailure"];
   const wait = progress["terminalWriterWait"];
-  if (
-    !failure || typeof failure !== "object" || Array.isArray(failure)
-    || !wait || typeof wait !== "object" || Array.isArray(wait)
-  ) return null;
-  const failureRecord = failure as Record<string, unknown>;
+  if (!wait || typeof wait !== "object" || Array.isArray(wait)) return null;
   const waitRecord = wait as Record<string, unknown>;
   const writerToolName = nonEmptyString(waitRecord["writerToolName"]);
   const attempt = Number(waitRecord["attempt"]);
   if (
-    failureRecord["code"] !== "terminal_writer_context_truncated"
+    waitRecord["schemaVersion"] !== 1
+    || waitRecord["kind"] !== "missing-terminal-writer"
+    || waitRecord["resumeMode"] !== "same-taskrun"
     || !writerToolName
     || !Number.isInteger(attempt)
     || attempt < 1
   ) return null;
+  if (failure && typeof failure === "object" && !Array.isArray(failure)) {
+    const failureRecord = failure as Record<string, unknown>;
+    if (failureRecord["code"] === "terminal_writer_context_truncated") {
+      return createTerminalWriterEscalation({
+        code: "terminal_writer_context_truncated",
+        writerToolName,
+        attempt,
+        observedAt: nonEmptyString(failureRecord["observedAt"]) ?? new Date().toISOString(),
+      });
+    }
+  }
+  if (!terminalWriterRetryIsExhausted(attempt)) return null;
   return createTerminalWriterEscalation({
-    code: "terminal_writer_context_truncated",
     writerToolName,
     attempt,
-    observedAt: nonEmptyString(failureRecord["observedAt"]) ?? new Date().toISOString(),
+    observedAt: nonEmptyString(waitRecord["observedAt"]) ?? new Date().toISOString(),
   });
 }
 


### PR DESCRIPTION
## Summary

- recover preserved pre-marker terminal-writer waits already at the retry ceiling
- stop their exact replay before another provider attempt is dispatched
- preserve context-truncation escalation priority and keep below-ceiling waits resumable

## Verification

- red regression: legacy attempt 4 returned `null` before the fix
- targeted terminal-writer suites: 11/11
- style and token drift guards
- web typecheck
- production build via exact-tree local-CI
- pregate preflight: 61/61 guards
- exact-tree local-CI: `cmti6fpev081a01pl551rmi6v` at `61873f580f82`
- semantic review receipt: `cmti6a4nn043001plq8r0hxvs` (admitted, no issues)

## Runtime acceptance

After merge and canonical self-upgrade, replay the three preserved TaskRuns and verify that attempts 3/4 escalate without mutation while the context-truncated case remains non-resumable.

Backlog-Item: BI-EDC0DAF2
Workroom: WC-42B82FB3
Local-CI-Evidence: cmti6fpev081a01pl551rmi6v (fix/terminal-writer-legacy-escalation@61873f580f82c18d418c3f8ab94d3ba199efe732)
Docs-Impact-Decision: Internal preserved-state compatibility repair only; no user-facing documentation changes are needed.
Process-Spine-Decision: Follow-up compatibility repair for approved BI-EDC0DAF2 bounded escalation; no new spec is needed.
