### PR TITLE
fix: respect Codex subscription model eligibility

### DIFF
--- a/apps/web/lib/inference/routing-exclusion-buckets.test.ts
+++ b/apps/web/lib/inference/routing-exclusion-buckets.test.ts
@@ -40,6 +40,11 @@ describe("stripEndpointPrefix", () => {
 });
 
 describe("bucketExclusionReason", () => {
+  it("recognises ChatGPT account/model incompatibility", () => {
+    expect(bucketExclusionReason(
+      "ep-codex: Model 'gpt-5.3-codex' is not supported when Codex uses a ChatGPT account",
+    )).toBe("account-model-eligibility");
+  });
   it.each([
     [ALLOWLIST, "connection-excluded"],
     [CLEARANCE, "sensitivity-clearance"],

--- a/apps/web/lib/inference/routing-exclusion-buckets.ts
+++ b/apps/web/lib/inference/routing-exclusion-buckets.ts
@@ -18,6 +18,8 @@
 
 /** Coarse cause families, each with a distinct owner-facing remedy. */
 export type RoutingExclusionBucket =
+  /** The connected account cannot use this specific model on this transport. */
+  | "account-model-eligibility"
   /** Provider allow/deny list — on this platform, almost always a connection that is switched off. */
   | "connection-excluded"
   /** The endpoint is not cleared for this data class. */
@@ -65,6 +67,9 @@ export function stripEndpointPrefix(reason: string): string {
  */
 export function bucketExclusionReason(reason: string): RoutingExclusionBucket {
   const text = stripEndpointPrefix(reason).toLowerCase();
+  if (text.includes("not supported when codex uses a chatgpt account")) {
+    return "account-model-eligibility";
+  }
   if (text.includes("request allowlist") || text.includes("request denylist")) {
     return "connection-excluded";
   }
@@ -86,6 +91,7 @@ export function bucketExclusionReason(reason: string): RoutingExclusionBucket {
  * naming the actionable one first is the whole point.
  */
 const TIE_BREAK_ORDER: RoutingExclusionBucket[] = [
+  "account-model-eligibility",
   "connection-excluded",
   "sensitivity-clearance",
   "capability-floor",
@@ -147,6 +153,14 @@ export function explainExclusion(
   const dataClass = context.sensitivity ? `"${context.sensitivity}"` : "this data class";
 
   switch (bucketed.bucket) {
+    case "account-model-eligibility":
+      return {
+        message:
+          `${bucketed.count} of ${bucketed.total} endpoints use a model that the connected ChatGPT account cannot run through Codex.`,
+        remediation:
+          "Select a ChatGPT-subscription-supported Codex model such as gpt-5.4, or use an API-key Codex connection for models that require API access.",
+        href: "/platform/ai/model-assignment",
+      };
     case "connection-excluded":
       return {
         message:

--- a/apps/web/lib/routing/codex-cli-adapter.test.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.test.ts
@@ -95,7 +95,11 @@ vi.mock("@/lib/shared/lazy-node", () => ({
   }),
 }));
 
-import { writeContainerFileViaStdin, looksLikeCliAuthFailure } from "./codex-cli-adapter";
+import {
+  writeContainerFileViaStdin,
+  looksLikeCliAuthFailure,
+  looksLikeCliRateLimit,
+} from "./codex-cli-adapter";
 import type { AdapterRequest } from "./adapter-types";
 import type { RoutedExecutionPlan } from "./recipe-types";
 
@@ -326,5 +330,25 @@ describe("looksLikeCliAuthFailure", () => {
     expect(
       looksLikeCliAuthFailure("Re-authentication required (rate of failed auth attempts high)"),
     ).toBe(true);
+  });
+});
+
+describe("looksLikeCliRateLimit", () => {
+  it.each([
+    "ERROR: unexpected status 429 Too Many Requests",
+    "rate_limit_exceeded",
+    "Codex CLI rate limited",
+    "You've hit your weekly limit · resets 4pm (UTC)",
+    "usage limit reached; retry after 30 seconds",
+  ])("classifies genuine capacity exhaustion %j", (text) => {
+    expect(looksLikeCliRateLimit(text)).toBe(true);
+  });
+
+  it.each([
+    "The gpt-5.3-codex model is not supported when using Codex with a ChatGPT account. Please use a supported model (for example, gpt-5.4) or use Codex with an API key. ChatGPT subscription account access can degrade performance.",
+    "model produced an empty response",
+    "Reading prompt from stdin...",
+  ])("does not misclassify non-capacity stderr %j", (text) => {
+    expect(looksLikeCliRateLimit(text)).toBe(false);
   });
 });

--- a/apps/web/lib/routing/codex-cli-adapter.ts
+++ b/apps/web/lib/routing/codex-cli-adapter.ts
@@ -52,6 +52,27 @@ export function looksLikeCliAuthFailure(text: string): boolean {
   return CLI_AUTH_FAILURE_PATTERNS.some((p) => p.test(text));
 }
 
+/**
+ * Genuine Codex CLI capacity-exhaustion signatures.
+ *
+ * Do not use broad fragments such as `text.includes("rate")`: ordinary error
+ * prose can contain words like "degrade performance", which previously turned
+ * an unsupported-model HTTP 400 into a false rate-limit and poisoned the whole
+ * CLI pool. These signatures are intentionally tied to explicit HTTP throttle,
+ * quota, or usage-limit language.
+ */
+const CLI_RATE_LIMIT_PATTERNS: RegExp[] = [
+  /\b429\b/,
+  /too many requests/i,
+  /rate[_ -]?limit(?:ed| exceeded| reached)?/i,
+  /(?:weekly|usage|quota) limit (?:has been )?(?:reached|exceeded)/i,
+  /you(?:'|’)ve hit your (?:weekly|usage|quota) limit/i,
+];
+
+export function looksLikeCliRateLimit(text: string): boolean {
+  return CLI_RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(text));
+}
+
 // ─── Container file writer ─────────────────────────────────────────────────
 
 /**
@@ -352,7 +373,7 @@ export const codexCliAdapter: ExecutionAdapterHandler = {
                 "auth",
                 providerId,
               ));
-            } else if (stderr.includes("rate") || stderr.includes("429")) {
+            } else if (looksLikeCliRateLimit(stderr)) {
               // EP-COST Phase 4: record pool exhaustion so orchestrator can back off
               void recordCliRateLimit("codex-cli", providerId, stderr);
               reject(new InferenceError(

--- a/apps/web/lib/routing/codex-subscription-model-eligibility.test.ts
+++ b/apps/web/lib/routing/codex-subscription-model-eligibility.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { codexSubscriptionModelExclusionReason } from "./codex-subscription-model-eligibility";
+
+describe("codexSubscriptionModelExclusionReason", () => {
+  it("excludes gpt-5.3-codex for a ChatGPT-authenticated Codex connection", () => {
+    expect(codexSubscriptionModelExclusionReason({
+      providerId: "codex",
+      authMethod: "oauth2_authorization_code",
+      modelId: "gpt-5.3-codex",
+    })).toMatch(/not supported.*ChatGPT account/i);
+  });
+
+  it("keeps gpt-5.4 eligible for a ChatGPT-authenticated Codex connection", () => {
+    expect(codexSubscriptionModelExclusionReason({
+      providerId: "codex",
+      authMethod: "oauth2_authorization_code",
+      modelId: "gpt-5.4",
+    })).toBeNull();
+  });
+
+  it("does not restrict API-key Codex accounts", () => {
+    expect(codexSubscriptionModelExclusionReason({
+      providerId: "codex",
+      authMethod: "api_key",
+      modelId: "gpt-5.3-codex",
+    })).toBeNull();
+  });
+
+  it("does not apply Codex account rules to other providers", () => {
+    expect(codexSubscriptionModelExclusionReason({
+      providerId: "openai",
+      authMethod: "oauth2_authorization_code",
+      modelId: "gpt-5.3-codex",
+    })).toBeNull();
+  });
+});

--- a/apps/web/lib/routing/codex-subscription-model-eligibility.ts
+++ b/apps/web/lib/routing/codex-subscription-model-eligibility.ts
@@ -1,0 +1,24 @@
+/**
+ * Account-aware Codex CLI model eligibility.
+ *
+ * The Codex provider can be authenticated either with an API key or with a
+ * ChatGPT subscription. The CLI's model catalog is not identical across those
+ * account modes, so a model that is valid for API-key traffic can be rejected
+ * before inference for subscription traffic. Keep that distinction at the
+ * endpoint-manifest boundary so ranking, dry-run previews, and runtime health
+ * all consume the same eligibility decision.
+ */
+
+const CHATGPT_CODEX_UNSUPPORTED_MODELS = new Set(["gpt-5.3-codex"]);
+
+export function codexSubscriptionModelExclusionReason(input: {
+  providerId: string;
+  authMethod: string;
+  modelId: string;
+}): string | null {
+  if (input.providerId !== "codex") return null;
+  if (input.authMethod !== "oauth2_authorization_code") return null;
+  if (!CHATGPT_CODEX_UNSUPPORTED_MODELS.has(input.modelId)) return null;
+
+  return `Model '${input.modelId}' is not supported when Codex uses a ChatGPT account; select a subscription-supported model such as 'gpt-5.4' or connect Codex with an API key`;
+}

--- a/apps/web/lib/routing/codex-subscription-model-routing.test.ts
+++ b/apps/web/lib/routing/codex-subscription-model-routing.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_CAPABILITIES, EMPTY_PRICING } from "./model-card-types";
+import { getExclusionReasonV2, routeEndpointV2 } from "./pipeline-v2";
+import type { RequestContract } from "./request-contract";
+import type { EndpointManifest } from "./types";
+
+vi.mock("./champion-challenger", () => ({
+  selectRecipeWithExploration: vi.fn().mockResolvedValue({
+    recipe: null,
+    explorationMode: "champion",
+  }),
+}));
+
+function endpoint(overrides: Partial<EndpointManifest> = {}): EndpointManifest {
+  return {
+    id: "codex:gpt-5.4",
+    providerId: "codex",
+    modelId: "gpt-5.4",
+    name: "Codex model",
+    endpointType: "responses",
+    status: "active",
+    providerTier: "user_configured",
+    sensitivityClearance: ["public", "internal"],
+    supportsToolUse: true,
+    supportsStructuredOutput: true,
+    supportsStreaming: true,
+    maxContextTokens: 400_000,
+    maxOutputTokens: 128_000,
+    modelRestrictions: [],
+    reasoning: 90,
+    codegen: 90,
+    toolFidelity: 90,
+    instructionFollowing: 90,
+    structuredOutput: 90,
+    conversational: 90,
+    contextRetention: 90,
+    customScores: {},
+    avgLatencyMs: 1_000,
+    recentFailureRate: 0,
+    costPerOutputMToken: 14,
+    profileSource: "seed",
+    profileConfidence: "medium",
+    retiredAt: null,
+    modelClass: "code",
+    modelFamily: "gpt-5",
+    inputModalities: ["text"],
+    outputModalities: ["text"],
+    capabilities: { ...EMPTY_CAPABILITIES, toolUse: true, streaming: true },
+    pricing: { ...EMPTY_PRICING, outputPerMToken: 14 },
+    supportedParameters: [],
+    deprecationDate: null,
+    metadataSource: "catalog",
+    metadataConfidence: "high",
+    perRequestLimits: null,
+    ...overrides,
+  };
+}
+
+function contract(): RequestContract {
+  return {
+    contractId: "codex-subscription-eligibility",
+    contractFamily: "build.code",
+    taskType: "reasoning",
+    modality: { input: ["text"], output: ["text"] },
+    interactionMode: "background",
+    sensitivity: "internal",
+    requiresTools: false,
+    requiresStrictSchema: false,
+    requiresStreaming: false,
+    estimatedInputTokens: 1_000,
+    estimatedOutputTokens: 500,
+    reasoningDepth: "medium",
+    budgetClass: "quality_first",
+  };
+}
+
+beforeEach(async () => {
+  const { _resetAllTracking } = await import("./rate-tracker");
+  _resetAllTracking();
+});
+
+describe("Codex subscription model routing", () => {
+  const reason =
+    "Model 'gpt-5.3-codex' is not supported when Codex uses a ChatGPT account";
+
+  it("surfaces a loader-owned account incompatibility before ranking", () => {
+    expect(getExclusionReasonV2(endpoint({
+      modelId: "gpt-5.3-codex",
+      eligibilityExclusionReason: reason,
+    }), contract())).toBe(reason);
+  });
+
+  it("selects a supported Codex sibling without detouring to a bundled endpoint", async () => {
+    const unsupported = endpoint({
+      id: "codex:gpt-5.3-codex",
+      modelId: "gpt-5.3-codex",
+      eligibilityExclusionReason: reason,
+    });
+    const supported = endpoint();
+    const bundled = endpoint({
+      id: "ollama:qwen",
+      providerId: "ollama",
+      modelId: "qwen",
+      providerTier: "bundled",
+    });
+
+    const decision = await routeEndpointV2(
+      [unsupported, supported, bundled],
+      contract(),
+      [],
+      [],
+    );
+
+    expect(decision.selectedEndpoint).toBe("codex:gpt-5.4");
+    expect(decision.candidates.find((candidate) => candidate.endpointId === unsupported.id))
+      .toMatchObject({ excluded: true, excludedReason: reason });
+  });
+});

--- a/apps/web/lib/routing/loader.test.ts
+++ b/apps/web/lib/routing/loader.test.ts
@@ -250,6 +250,29 @@ describe("routing-loader cache (BI-OPT-ROUTING-CACHE)", () => {
     expect(mockProviderHasConfiguredCredential).toHaveBeenCalledWith("docker-model-runner", "none");
   });
 
+  it("marks unsupported ChatGPT-subscription models ineligible without hiding supported fallbacks", async () => {
+    mockPrisma.modelProfile.findMany.mockResolvedValue([
+      {
+        ...profileRow,
+        providerId: "codex",
+        modelId: "gpt-5.3-codex",
+        provider: { ...profileRow.provider, authMethod: "oauth2_authorization_code" },
+      },
+      {
+        ...profileRow,
+        id: "mp-2",
+        providerId: "codex",
+        modelId: "gpt-5.4",
+        provider: { ...profileRow.provider, authMethod: "oauth2_authorization_code" },
+      },
+    ]);
+
+    const manifests = await loadEndpointManifests(900_002);
+    expect(manifests).toHaveLength(2);
+    expect(manifests[0]?.eligibilityExclusionReason).toMatch(/not supported.*ChatGPT account/i);
+    expect(manifests[1]?.eligibilityExclusionReason).toBeUndefined();
+  });
+
   it("loads each loader's DB rows exactly once across a 200-iteration turn", async () => {
     const t0 = 1_000_000;
     // Simulate the agentic loop calling prepareRoute's loaders every iteration.

--- a/apps/web/lib/routing/loader.ts
+++ b/apps/web/lib/routing/loader.ts
@@ -82,6 +82,7 @@ import {
 } from "./route-decision-attribution";
 import { MODEL_ROUTING_ENDPOINT_TYPES } from "./provider-eligibility";
 import { serializeActivityHarnessAudit } from "./activity-harness-audit";
+import { codexSubscriptionModelExclusionReason } from "./codex-subscription-model-eligibility";
 
 /**
  * EP-MODEL-CAP-001-B: Source-priority tool use resolution.
@@ -209,6 +210,12 @@ function profileToManifest(
   mp: ProfileWithProvider,
   statusOverride?: EndpointManifest["status"],
 ): EndpointManifest {
+  const eligibilityExclusionReason = codexSubscriptionModelExclusionReason({
+    providerId: mp.providerId,
+    authMethod: mp.provider.authMethod,
+    modelId: mp.modelId,
+  });
+
   return {
     id: mp.id,
     providerId: mp.providerId,
@@ -231,6 +238,7 @@ function profileToManifest(
     maxContextTokens: mp.maxContextTokens ?? mp.provider.maxContextTokens,
     maxOutputTokens: mp.maxOutputTokens ?? mp.provider.maxOutputTokens,
     modelRestrictions: mp.provider.modelRestrictions,
+    ...(eligibilityExclusionReason ? { eligibilityExclusionReason } : {}),
     reasoning: mp.reasoning,
     codegen: mp.codegen,
     toolFidelity: mp.toolFidelity,

--- a/apps/web/lib/routing/pipeline-v2.ts
+++ b/apps/web/lib/routing/pipeline-v2.ts
@@ -108,6 +108,11 @@ export function getExclusionReasonV2(
   const providerConstraintReason = getProviderConstraintExclusionReason(ep, contract);
   if (providerConstraintReason) return providerConstraintReason;
 
+  // Account/transport compatibility is a hard platform fact, not a score.
+  // Preserve the endpoint in the excluded trace so runtime-health previews
+  // explain the incompatibility while a supported sibling model can win.
+  if (ep.eligibilityExclusionReason) return ep.eligibilityExclusionReason;
+
   // EP-AGENT-CAP-002: Agent capability floor — hard filter, non-negotiable.
   // Must run BEFORE status/graceful-degradation checks so a tool-incapable
   // endpoint is never selected even in degraded mode.

--- a/apps/web/lib/routing/types.ts
+++ b/apps/web/lib/routing/types.ts
@@ -80,6 +80,12 @@ export interface EndpointManifest {
   maxContextTokens: number | null;
   maxOutputTokens: number | null;
   modelRestrictions: string[];
+  /**
+   * Account/transport-specific hard exclusion computed by the manifest loader.
+   * The endpoint remains in the candidate trace so runtime health can explain
+   * why it was skipped and show the supported fallback that won.
+   */
+  eligibilityExclusionReason?: string;
 
   // Capability profile (0-100)
   reasoning: number;

--- a/docs/superpowers/plans/2026-09-01-codex-subscription-model-eligibility-plan.md
+++ b/docs/superpowers/plans/2026-09-01-codex-subscription-model-eligibility-plan.md
@@ -1,0 +1,59 @@
+---
+status: active
+---
+
+# Codex subscription model eligibility implementation plan
+
+| Field | Value |
+| --- | --- |
+| Backlog item | BI-37719AAB |
+| Canonical design | `docs/superpowers/specs/2026-09-01-codex-subscription-model-eligibility-design.md` |
+| Decision | Atomic |
+| Why atomic | Selection and failure classification repair one externally observable dispatch contract; shipping either alone leaves the incident reproducible. |
+
+Governance condition at authoring time: no initiative scope baseline exists for
+this item. The coverage table below is therefore the durable mapping until an
+independent passing spec-approval receipt mints that baseline and allows the
+platform coverage recorder to bind it.
+
+## Outcome
+
+A ChatGPT-authenticated Codex connection never dispatches a model the CLI has
+declared unsupported, selects a supported sibling without a local-runtime detour,
+and records only genuine capacity failures as rate limits.
+
+## Ordered implementation
+
+1. Add failing unit contracts for the exact unsupported-model stderr, genuine
+   429/weekly/usage limits, OAuth model eligibility, API-key preservation,
+   routing exclusion, and runtime-health explanation.
+2. Add a pure account/model eligibility policy at the endpoint-manifest boundary.
+3. Feed the policy result into the existing routing hard filter and exclusion
+   trace so routing previews and Runtime Health remain truthful.
+4. Replace the adapter's broad `rate` substring with explicit capacity
+   signatures while preserving auth-first classification.
+5. Run focused tests, every graph-linked routing test, typecheck, style guard,
+   preflight, and the exact-tree canonical gate.
+6. Push a DCO-signed branch, open a ready PR, verify merge readiness
+   mechanically, merge through the queue, deploy through `/ops/self-upgrade`,
+   and exercise the live ChatGPT-account route.
+
+## Verification contract
+
+- `codex-cli-adapter.test.ts`: exact HTTP 400 prose is not rate limit; 429 and
+  subscription usage exhaustion remain rate limits.
+- `codex-subscription-model-eligibility.test.ts`: OAuth excludes
+  `gpt-5.3-codex`, keeps `gpt-5.4`; API-key and other providers are unchanged.
+- `loader.test.ts` and `codex-subscription-model-routing.test.ts`: the incompatible endpoint remains
+  visible with a hard exclusion reason while supported fallbacks remain eligible.
+- `routing-exclusion-buckets.test.ts`: Runtime Health maps the reason to a
+  specific owner action.
+- Graph-linked suite from `find_related_tests`, `pnpm run pregate:preflight`,
+  and `pnpm run pregate` are the implementation and exact-tree gates.
+
+## Documentation impact
+
+The canonical CLI routing design is updated because account mode is a routing
+dimension and failure classification affects operator-visible capacity state.
+No user guide, route map, schema documentation, or migration note changes: the
+surface behavior is corrective and uses existing Runtime Health presentation.

--- a/docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md
+++ b/docs/superpowers/specs/2026-04-29-cli-execution-adapter-routing-design.md
@@ -1,3 +1,12 @@
+---
+status: active
+---
+
+BI-37719AAB's governed decision is owned by
+[2026-09-01-codex-subscription-model-eligibility-design.md](./2026-09-01-codex-subscription-model-eligibility-design.md).
+Section 13 below remains supporting routing detail, not a second approval
+artifact.
+
 # CLI Execution Adapter — Routing Design Spec
 
 | Field | Value |
@@ -686,7 +695,97 @@ Reserved through every preceding phase. Specific deliverables:
 4. Unify CLI session ID generation across `claude-dispatch.ts`, `codex-dispatch.ts`, and the new substrate adapters.
 5. Cost / quota / outcome ledger consolidation (`AdapterRunTelemetry` is canonical; `ToolExecution.duration_ms` etc. cross-reference it).
 
-## 13. Open Risks
+## 13. BI-37719AAB integrity patch — account-aware Codex model eligibility
+
+The live Codex CLI rejected `gpt-5.3-codex` with HTTP 400 when the `codex`
+provider used ChatGPT OAuth, while the same authenticated CLI accepted
+`gpt-5.4`. The existing adapter then matched the word `rate` inside
+`degrade performance` and recorded a false pool-wide rate limit. This combines
+two distinct faults: selection admitted a model the connected account could not
+run, and failure classification used an unbounded substring.
+
+### Research and reproduction record
+
+The defect is named against pre-fix ref
+`e7f618eae0b7481f37101654826cc8aad2a4a2d2`:
+
+- `apps/web/lib/routing/codex-cli-adapter.ts:355` used
+  `stderr.includes("rate") || stderr.includes("429")`; the observed HTTP 400
+  includes `degrade performance`, so the first expression is true without a
+  capacity failure.
+- `apps/web/lib/routing/loader.ts:166-193` admitted every active profile whose
+  provider had a configured credential, and `profileToManifest` at lines
+  208-233 had no account/model compatibility field.
+- `apps/web/lib/routing/types.ts:75-82` consequently had no manifest carrier for
+  an account-specific hard exclusion.
+
+The live reproduction used one healthy ChatGPT-authenticated Codex credential:
+`codex login status` reported logged in with ChatGPT,
+`codex exec -m gpt-5.3-codex` returned HTTP 400 unsupported-account-model, and
+the same prompt immediately returned `OK` with `codex exec -m gpt-5.4`.
+`CliPoolStatus` then contained a false 60-second Codex rate-limit record.
+
+The TDD red run added the exact stderr and eligibility contracts before
+production code. The focused command over the four new/affected suites reported
+10 failures and 88 passes: missing `looksLikeCliRateLimit`, missing eligibility
+module, no manifest exclusion, and no V2 hard-filter exclusion. After the
+production change, the focused five-suite run reported 127/127 passes. The
+graph-expanded run reported 323/323, and the exact-tree merged gate at candidate
+`4c5aa639d50bfd7e482bd9cef247a2c2246f65e0` reported 3,541 passing tests plus a
+successful production build.
+
+Candidate causes ruled out by execution:
+
+- **Expired or invalid auth:** ruled out because login status was healthy and
+  `gpt-5.4` succeeded with the same credential and prompt.
+- **Real capacity exhaustion:** ruled out because the response was HTTP 400,
+  not 429, and the supported sibling succeeded immediately.
+- **Provider-wide outage or local-runtime failure:** ruled out because only the
+  account/model pair changed between failure and success; no local provider was
+  involved.
+- **Catalog-wide model invalidity:** ruled out because official OpenAI API docs
+  list `gpt-5.3-codex`; the incompatibility is specifically the ChatGPT-account
+  Codex transport, so API-key eligibility must remain intact.
+
+Official OpenAI documentation establishes that both
+[`gpt-5.3-codex`](https://developers.openai.com/api/docs/models/gpt-5.3-codex)
+and [`gpt-5.4`](https://developers.openai.com/api/docs/models/gpt-5.4) are API
+models, but does not establish identical availability through a ChatGPT-account
+Codex CLI session. Therefore the account-specific compatibility rule is grounded
+in the live CLI response, while the API-key path remains governed by the API
+catalog.
+
+The fix uses the existing endpoint-manifest and exclusion-trace substrate:
+
+1. The manifest loader computes a hard `eligibilityExclusionReason` for
+   `(provider=codex, auth=oauth2_authorization_code, model=gpt-5.3-codex)`.
+2. The routing hard filter preserves that endpoint as an excluded candidate,
+   making the reason available to dry-run previews, route decisions, and Runtime
+   Health instead of silently deleting it from the candidate set.
+3. A supported sibling such as `gpt-5.4` remains eligible and can win before
+   dispatch. Codex API-key connections remain eligible for `gpt-5.3-codex`.
+4. The adapter classifies capacity only from explicit 429, Too Many Requests,
+   rate-limit, quota-limit, weekly-limit, or usage-limit signatures. Ordinary
+   prose containing `rate` is a provider error and never mutates pool capacity.
+5. Runtime-health exclusion bucketing gives account/model incompatibility a
+   distinct explanation and corrective action.
+
+Acceptance is proven by unit tests for the exact observed stderr, genuine 429
+and weekly-limit payloads, OAuth-versus-API-key model eligibility, hard-filter
+trace preservation, and owner-facing exclusion attribution. No schema migration
+or seed/catalog deletion is required.
+
+### Acceptance mapping
+
+| Backlog acceptance target | Design/implementation contract | Executable proof |
+| --- | --- | --- |
+| ChatGPT-authenticated Codex never selects `gpt-5.3-codex` when unsupported | OAuth account/model policy writes `eligibilityExclusionReason` into the manifest and V2 treats it as a hard exclusion | `codex-subscription-model-eligibility.test.ts`; `loader.test.ts`; `codex-subscription-model-routing.test.ts` |
+| `degrade performance` cannot trip rate limiting | Only explicit HTTP throttle/quota/usage signatures classify capacity | Exact live stderr case in `codex-cli-adapter.test.ts` |
+| Genuine 429 still records capacity | `looksLikeCliRateLimit` retains 429, Too Many Requests, weekly, usage, and quota signatures; the existing record path is unchanged | Genuine 429 and weekly-limit cases in `codex-cli-adapter.test.ts` |
+| `gpt-5.4` wins without local detour | Unsupported sibling remains in the excluded trace; supported user-configured sibling remains rankable ahead of bundled endpoints | Three-candidate decision in `codex-subscription-model-routing.test.ts` |
+| Runtime Health explains the rejected model and action | New `account-model-eligibility` bucket maps the router reason to model-assignment remediation | `routing-exclusion-buckets.test.ts` plus existing phase/runtime-health consumers |
+
+## 14. Open Risks
 
 1. **Codex schema instability.** The schema-drift detector + version pin is the mitigation. If drift is constant, Codex CLI is operationally untenable for the panel and we keep it Build-Studio-only.
 2. **Sandbox pool exhaustion.** Per-thread sessions pin sandbox slots. With pool size 3 and TTL 60 min, ≥3 active threads block new claims. Mitigation: pool size scales with active-thread count; ephemeral fallback when pool saturated.
@@ -696,7 +795,7 @@ Reserved through every preceding phase. Specific deliverables:
 6. **Race-mode cost amplification.** A race against three adapters costs ~3×. Mitigation: race requires explicit opt-in env flag and per-route-plan opt-in; never default.
 7. **Acceptance signal lag.** `userAccepted` may take days for asynchronous threads. Outcome scoring runs over rolling 7-day windows to absorb this lag.
 
-## 14. Telemetry & Observability
+## 15. Telemetry & Observability
 
 `AdapterRunTelemetry` is the canonical run ledger. Operator dashboards read from it:
 
@@ -719,7 +818,7 @@ adapter_health = healthy
 
 `adapter.degraded` events surface in the panel as a banner; the route planner deprioritizes degraded adapters until 5 consecutive healthy runs clear the flag.
 
-## 15. Migration & Backwards Compatibility
+## 16. Migration & Backwards Compatibility
 
 - Existing coworker threads have `cliSessionId = null`. They keep working through the HTTP adapter exactly as today.
 - The hard-coded check at [ai-inference.ts:353](../../../apps/web/lib/ai-inference.ts#L353) is replaced by registry resolution that, in absence of an explicit `executionAdapter`, defaults to the prior provider-id-driven choice. No silent behavior change.
@@ -727,7 +826,7 @@ adapter_health = healthy
 - Build Studio dispatch is unchanged. Convergence happens only when Phase H has run and only as an explicit follow-up.
 - Receipts spec landing first lets §7 mint full provenance receipts. If receipts spec slips, §7 still mints `ToolExecution` rows and the receipt linkage is added in a follow-up patch.
 
-## 16. References
+## 17. References
 
 - [Coworker Substrate Status Review](../audits/2026-04-29-cli-substrate-status-review.md) — the audit this spec promotes
 - [Codex JSONL probe evidence](../audits/evidence/2026-04-29-codex-cli-jsonl-probe.md) — empirical event taxonomy

--- a/docs/superpowers/specs/2026-09-01-codex-subscription-model-eligibility-design.md
+++ b/docs/superpowers/specs/2026-09-01-codex-subscription-model-eligibility-design.md
@@ -1,0 +1,56 @@
+---
+status: active
+---
+
+# Codex subscription model eligibility — BI-37719AAB
+
+This file is the complete approval artifact. Review it from the immutable blob;
+the broader CLI routing spec §13 is supporting detail.
+
+## Problem and evidence
+
+At pre-fix ref `e7f618eae0b7481f37101654826cc8aad2a4a2d2`, the Codex adapter treated any
+stderr containing `rate` as capacity and the endpoint loader admitted every
+configured provider/model pair. A healthy ChatGPT-authenticated Codex login
+returned HTTP 400 for `gpt-5.3-codex`; the phrase `degrade performance` was
+misclassified as a 60-second rate limit. The same credential immediately
+succeeded with `gpt-5.4`. This rules out expired authentication, real 429
+capacity exhaustion, provider outage, and catalog-wide invalidity. The
+test-first proof was 10 failed/88 passed before the fix; focused and
+graph-expanded suites then passed 127/127 and 323/323. Exact-tree SHA
+`18e443bbb2a90045037d8c944b7713d1bed0cfbd`, merged with current `main`, passed
+all tests and the production build as evidence `cmti58h4g2sft01lhjtcc0x49`.
+
+## Decision and boundaries
+
+Account compatibility is a hard rule at the existing endpoint-manifest
+boundary. For `(codex, oauth2_authorization_code, gpt-5.3-codex)`, the loader
+sets `eligibilityExclusionReason`; routing retains the candidate in its trace
+but excludes it before scoring or dispatch. OAuth `gpt-5.4`, Codex API-key
+models, and other providers are unchanged. The adapter records capacity only
+for explicit 429, Too Many Requests, rate-limit, quota-limit, weekly-limit, or
+usage-limit signatures. Runtime Health maps the exclusion to
+`account-model-eligibility` with model-assignment remediation.
+
+The change composes the existing manifest, hard filter, trace, pool-status, and
+exclusion-bucket contracts. It adds no schema, seed mutation, credential access,
+auth weakening, second router, or new UI. Selection and classification are
+atomic because either repair alone leaves the live incident reproducible.
+
+## Alternatives, risk, rollback, and acceptance
+
+Deleting the model globally would break valid API-key use. Silently dropping it
+in the loader would make routing previews and Runtime Health lie. Broad prose
+matching would repeat the false-capacity defect. Falling directly to local would
+lower quality despite a supported sibling.
+
+The compatibility rule is limited to the proven provider/auth/model tuple.
+Executable guards cover the exact stderr, genuine 429 and subscription limits,
+both auth modes, supported fallback routing, and operator attribution. Rollback
+is one PR revert; no migration or data repair is required. Acceptance is:
+
+- unsupported ChatGPT OAuth dispatch never occurs;
+- `degrade performance` never mutates capacity;
+- genuine 429 still records exhaustion;
+- `gpt-5.4` wins without a local detour; and
+- Runtime Health names the rejected model and corrective action.


### PR DESCRIPTION
## Summary

Prevent ChatGPT-authenticated Codex routes from selecting the unsupported `gpt-5.3-codex` model, and stop treating unrelated prose containing `rate` as capacity exhaustion. This keeps supported `gpt-5.4` routing available instead of falsely marking Codex as rate-limited and detouring to local inference.

## Changes

- Add a pure account/model eligibility rule at the endpoint-manifest boundary and carry its exclusion reason through routing traces.
- Restrict Codex capacity classification to explicit 429 and recognized rate/quota/usage-limit signatures.
- Map account/model incompatibility to the existing Runtime Health exclusion model with corrective guidance.
- Add exact live-stderr, genuine-capacity, auth-mode, loader, routing, and health-attribution regressions.
- Record the atomic design and implementation plan in the canonical docs corpus.

## Test plan

- [x] **Source-only change** (types, isolated unit logic, doc, schema-only)
  - [x] Typecheck passed in the canonical merged-tree gate.
  - [x] Focused routing tests: 127/127 passed; graph-expanded routing tests: 323/323 passed.

- [x] **Runtime-bound change** (server route, MCP tool, build/runtime wiring, compose, installer, prisma migration, UX surface)
  - [x] Source checks passed.
  - [x] Functional verification ran in the governed shared local-CI environment.
  - [x] Exact-tree merged-code tests and production build passed.

- [ ] **Verification-harness limitation acknowledged**

### Verification evidence

- Test-first reproduction: 10 failed / 88 passed before implementation.
- Final exact-tree SHA `7ae4e0d3bf54f5f6cfc44e8e4e8e7c03724bb996` passed the merged-code test suite and production build.
- Local-CI evidence: `cmti5ibcy30d701lh54o6mtmq`.

## Pre-PR readiness

- [x] `pnpm gate:context` reviewed before implementation and against the final diff.
- [x] `pnpm run pregate:preflight` passed.
- [x] Exact-tree local-CI evidence captured with `pnpm run pregate`.
- [x] `pnpm pr:ready --pr-body-file /tmp/bi-377-pr-body.md` returned `PR readiness: READY` after the final push.

Local-CI-Evidence: cmti5ibcy30d701lh54o6mtmq (fix/codex-subscription-model-eligibility@7ae4e0d3bf54f5f6cfc44e8e4e8e7c03724bb996)

## Related issues / Epic

- BI-37719AAB
- EP-413F2602

## Overlap sweep

No open PR matched the Codex account-model eligibility or false rate-limit classifier change. This branch is the sole worktree owner for BI-37719AAB.

## Notes for the reviewer

- No schema, migration, seed/catalog deletion, credential access, or auth weakening.
- Rollback is one PR revert; existing pool-status records expire normally.
- Semantic review produced no code finding; the final reviewer run was infrastructure-inconclusive because the current runtime exhausted its review route before returning a decision.

Docs-Impact-Decision: The canonical CLI routing design and a dedicated BI decision spec are updated. No user workflow, route map, schema guide, or migration documentation changes because this is corrective behavior on existing Runtime Health surfaces.
