### PR TITLE
fix(attention): distinguish AI recommendation from human authorization

### DIFF
--- a/apps/web/components/attention/CoworkerEnvelopeApproval.test.tsx
+++ b/apps/web/components/attention/CoworkerEnvelopeApproval.test.tsx
@@ -14,13 +14,24 @@ vi.mock("@/lib/actions/proposals", () => ({ approveProposal, rejectProposal }));
 import { CoworkerEnvelopeApproval } from "./CoworkerEnvelopeApproval";
 import { OwnerDecisionCards } from "./OwnerDecisionCards";
 import { coworkerEnvelopeToAttentionItem } from "@/lib/attention/sources/coworker-envelope";
+import { summarizeCoworkerEnvelopeDecision } from "@/lib/attention/coworker-envelope-decision";
 import { buildOwnerAttentionProjection } from "@/lib/attention/owner-projection";
 import type { AttentionEnvelopeApproval } from "@/lib/attention/types";
 
 const NOW = Date.parse("2026-08-25T20:00:00.000Z");
 
 function approval(over: Partial<AttentionEnvelopeApproval> = {}): AttentionEnvelopeApproval {
-  return {
+  const reviewBinding = Object.prototype.hasOwnProperty.call(over, "reviewBinding")
+    ? over.reviewBinding
+    : {
+        gate: "research",
+        itemId: "BI-MCP-EFF-0285909C",
+        repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+        commitSha: "89e875eb49be0604ee8fa4156d0903b6a0932e62",
+        path: "docs/superpowers/specs/2026-08-15-resilient-concurrent-development-process.md",
+        providerBlobId: "bddca7c5a0b109f9460f84b2b0d886f5d794cbb6",
+      };
+  const base: AttentionEnvelopeApproval = {
     envelopeId: "cmt932fn301el01p7vfb2gas7",
     coworkerAgentId: "AGT-WS-PORTFOLIO",
     delegatingUserId: "cmt6ejt2109n56mnw5kt1f8y0",
@@ -32,16 +43,18 @@ function approval(over: Partial<AttentionEnvelopeApproval> = {}): AttentionEnvel
     actionable: true,
     approveHref: "/api/agent/envelope/cmt932fn301el01p7vfb2gas7/approve",
     declineHref: "/api/agent/envelope/cmt932fn301el01p7vfb2gas7/deny",
-    reviewBinding: {
-      gate: "research",
-      itemId: "BI-MCP-EFF-0285909C",
-      repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
-      commitSha: "89e875eb49be0604ee8fa4156d0903b6a0932e62",
-      path: "docs/superpowers/specs/2026-08-15-resilient-concurrent-development-process.md",
-      providerBlobId: "bddca7c5a0b109f9460f84b2b0d886f5d794cbb6",
-    },
-    ...over,
+    decision: summarizeCoworkerEnvelopeDecision({
+      toolName: "record_initiative_evidence",
+      proposedParameters: { decision: "pass" },
+      reviewBinding: reviewBinding
+        ? { gate: reviewBinding.gate, itemId: reviewBinding.itemId }
+        : undefined,
+      recommenderAgentId: "AGT-WS-PORTFOLIO",
+      authorizerUserId: "cmt6ejt2109n56mnw5kt1f8y0",
+    }),
+    ...(reviewBinding ? { reviewBinding } : {}),
   };
+  return { ...base, ...over, decision: over.decision ?? base.decision };
 }
 
 let fetchMock: ReturnType<typeof vi.fn>;
@@ -60,51 +73,68 @@ afterEach(() => {
 });
 
 describe("CoworkerEnvelopeApproval", () => {
-  it("shows the coworker, the requested action, and the reason it is waiting", () => {
+  it("states the AI recommendation versus human authorization, not identity plumbing", () => {
     render(<CoworkerEnvelopeApproval approval={approval()} />);
 
-    expect(screen.getByText("AGT-WS-PORTFOLIO")).toBeTruthy();
-    expect(screen.getByText("record_initiative_evidence")).toBeTruthy();
+    expect(screen.getByText("Human authorization needed")).toBeTruthy();
     expect(
-      screen.getByText("This action is authorized to proceed only after employee approval."),
+      screen.getByText("record that receipt so implementation planning may continue."),
     ).toBeTruthy();
-    expect(screen.getByText("proposed")).toBeTruthy();
-  });
-
-  it("shows the task, the expiry, and the whole immutable review binding", () => {
-    render(<CoworkerEnvelopeApproval approval={approval()} />);
-
-    expect(
-      screen.getByText("TR-MCP-Y210Nmg3bjg3MDBnYTAxbXhheDU2MXV2aQ-7A98D78A3948"),
-    ).toBeTruthy();
-    expect(screen.getByText("2026-08-25T20:09:05.868Z")).toBeTruthy();
     expect(screen.getByText("BI-MCP-EFF-0285909C")).toBeTruthy();
     expect(screen.getByText("research")).toBeTruthy();
+    expect(screen.getByText("pass")).toBeTruthy();
+    expect(screen.getByText("None")).toBeTruthy();
+    expect(screen.getByText("Your coworker")).toBeTruthy();
+    expect(screen.getByText("You")).toBeTruthy();
+    expect(screen.queryByText("AGT-WS-PORTFOLIO")).toBeNull();
+    expect(screen.queryByText("record_initiative_evidence")).toBeNull();
+    expect(screen.queryByText("proposed")).toBeNull();
     expect(
-      screen.getByText("89e875eb49be0604ee8fa4156d0903b6a0932e62"),
-    ).toBeTruthy();
+      screen.queryByText("TR-MCP-Y210Nmg3bjg3MDBnYTAxbXhheDU2MXV2aQ-7A98D78A3948"),
+    ).toBeNull();
     expect(
-      screen.getByText(
-        "docs/superpowers/specs/2026-08-15-resilient-concurrent-development-process.md",
-      ),
-    ).toBeTruthy();
-    expect(
-      screen.getByText("bddca7c5a0b109f9460f84b2b0d886f5d794cbb6"),
-    ).toBeTruthy();
+      screen.queryByText("89e875eb49be0604ee8fa4156d0903b6a0932e62"),
+    ).toBeNull();
+    expect(screen.queryByText("bddca7c5a0b109f9460f84b2b0d886f5d794cbb6")).toBeNull();
+    expect(screen.getByRole("button", { name: "Authorize" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Decline" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Approve action" })).toBeNull();
   });
 
-  it("omits the review binding block when the envelope carries none", () => {
+  it("lists findings on a fail without calling the stages approval", () => {
+    render(
+      <CoworkerEnvelopeApproval
+        approval={approval({
+          decision: summarizeCoworkerEnvelopeDecision({
+            toolName: "record_initiative_evidence",
+            proposedParameters: {
+              decision: "fail",
+              findings: [{ issue: "The defect was not reproduced.", severity: "critical" }],
+            },
+            reviewBinding: { gate: "research", itemId: "BI-MCP-EFF-0285909C" },
+            recommenderAgentId: "AGT-WS-PORTFOLIO",
+            authorizerUserId: "cmt6ejt2109n56mnw5kt1f8y0",
+          }),
+        })}
+      />,
+    );
+
+    expect(screen.getByText("The defect was not reproduced.")).toBeTruthy();
+    expect(screen.getByText("fail")).toBeTruthy();
+    expect(screen.queryByText(/approv/i)).toBeNull();
+  });
+
+  it("omits subject and gate when the envelope carries no bound record", () => {
     render(<CoworkerEnvelopeApproval approval={approval({ reviewBinding: undefined })} />);
 
     expect(screen.queryByText("BI-MCP-EFF-0285909C")).toBeNull();
-    expect(screen.queryByText("Reviewed record")).toBeNull();
-    expect(screen.getByText("record_initiative_evidence")).toBeTruthy();
+    expect(screen.getByText("Human authorization needed")).toBeTruthy();
   });
 
   it("approves through the envelope endpoint and never the proposal actions", async () => {
     render(<CoworkerEnvelopeApproval approval={approval()} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Approve action" }));
+    fireEvent.click(screen.getByRole("button", { name: "Authorize" }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(fetchMock).toHaveBeenCalledWith(
@@ -131,7 +161,7 @@ describe("CoworkerEnvelopeApproval", () => {
 
   it("sends exactly one request when the button is pressed repeatedly", async () => {
     render(<CoworkerEnvelopeApproval approval={approval()} />);
-    const button = screen.getByRole("button", { name: "Approve action" });
+    const button = screen.getByRole("button", { name: "Authorize" });
 
     fireEvent.click(button);
     fireEvent.click(button);
@@ -152,7 +182,7 @@ describe("CoworkerEnvelopeApproval", () => {
     );
     render(<CoworkerEnvelopeApproval approval={approval()} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Approve action" }));
+    fireEvent.click(screen.getByRole("button", { name: "Authorize" }));
 
     await waitFor(() => expect(screen.getByRole("status")).toBeTruthy());
     expect(screen.queryByRole("alert")).toBeNull();
@@ -167,10 +197,10 @@ describe("CoworkerEnvelopeApproval", () => {
     );
     render(<CoworkerEnvelopeApproval approval={approval()} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Approve action" }));
+    fireEvent.click(screen.getByRole("button", { name: "Authorize" }));
 
     await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());
-    expect(screen.getByRole("button", { name: "Approve action" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Authorize" })).toBeTruthy();
   });
 
   it.each([
@@ -182,10 +212,10 @@ describe("CoworkerEnvelopeApproval", () => {
   ])("offers no decision control for a %s envelope", (_label, settled) => {
     render(<CoworkerEnvelopeApproval approval={settled} />);
 
-    expect(screen.queryByRole("button", { name: "Approve action" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Authorize" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Decline" })).toBeNull();
     // The record itself stays readable: hiding a control must not hide evidence.
-    expect(screen.getByText("record_initiative_evidence")).toBeTruthy();
+    expect(screen.getByText("Human authorization needed")).toBeTruthy();
   });
 });
 
@@ -203,7 +233,23 @@ describe("OwnerDecisionCards routing", () => {
         // clock-bomb-guard: allow projected against the pinned NOW constant, not the wall clock
         expiresAt: new Date("2026-08-25T20:09:05.868Z"),
         createdAt: new Date("2026-08-25T19:54:05.871Z"),
-        taskRun: null,
+        proposedParameters: { decision: "pass" },
+        taskRun: {
+          a2aMetadata: {
+            initiativeReviewBinding: {
+              gate: "research",
+              itemId: "BI-MCP-EFF-0285909C",
+              writerToolName: "record_initiative_evidence",
+              artifactRef: {
+                kind: "repo-blob-at-commit",
+                repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+                commitSha: "89e875eb49be0604ee8fa4156d0903b6a0932e62",
+                path: "docs/superpowers/specs/2026-08-15-resilient-concurrent-development-process.md",
+                providerBlobId: "bddca7c5a0b109f9460f84b2b0d886f5d794cbb6",
+              },
+            },
+          },
+        },
         ...over,
       },
       NOW,
@@ -214,8 +260,11 @@ describe("OwnerDecisionCards routing", () => {
   it("renders the envelope approval card, not the proposal controls", async () => {
     render(<OwnerDecisionCards entries={[entryFor()]} />);
 
-    expect(screen.getByText("record_initiative_evidence")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Approve action" }));
+    expect(screen.getByText("Authorize this research receipt?")).toBeTruthy();
+    expect(screen.getByText(/research passes with no findings/i)).toBeTruthy();
+    expect(screen.getByText("Human authorization needed")).toBeTruthy();
+    expect(screen.queryByText("record_initiative_evidence")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Authorize" }));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(fetchMock).toHaveBeenCalledWith(
@@ -225,5 +274,22 @@ describe("OwnerDecisionCards routing", () => {
     // The AgentActionProposal path must never be reachable from an envelope card.
     expect(approveProposal).not.toHaveBeenCalled();
     expect(rejectProposal).not.toHaveBeenCalled();
+  });
+
+  it("keeps identity plumbing under technical detail", () => {
+    render(<OwnerDecisionCards entries={[entryFor()]} />);
+
+    expect(screen.queryByText("record_initiative_evidence")).toBeNull();
+    expect(
+      screen.queryByText("89e875eb49be0604ee8fa4156d0903b6a0932e62"),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Technical detail/ }));
+
+    expect(screen.getByText("record_initiative_evidence")).toBeTruthy();
+    expect(
+      screen.getByText("89e875eb49be0604ee8fa4156d0903b6a0932e62"),
+    ).toBeTruthy();
+    expect(screen.getByText("bddca7c5a0b109f9460f84b2b0d886f5d794cbb6")).toBeTruthy();
   });
 });

--- a/apps/web/components/attention/CoworkerEnvelopeApproval.tsx
+++ b/apps/web/components/attention/CoworkerEnvelopeApproval.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 // The owner-facing decision surface for one proposed CoworkerActionEnvelope
-// (BI-7CB2CCDE).
+// (BI-7CB2CCDE, decision-first copy BI-F95B0795).
 //
 // Deliberately NOT CoworkerProposalActions: that component settles an
 // AgentActionProposal through the proposal server actions. An envelope is a
@@ -9,10 +9,8 @@
 // its own expiry, so it gets its own component and posts only to the
 // authenticated envelope endpoints in lib/coworker/envelope-routes.
 //
-// The block above the buttons is the point of the card. An employee cannot
-// honestly approve a commit-bound reviewer action without seeing WHICH coworker,
-// WHICH action, on WHICH commit, path and blob, for WHICH gate, and how long the
-// window stays open. Approving blind is what the defect forced.
+// The primary block is the proposed decision and the human authorization to
+// record it. Identity plumbing lives under Technical detail.
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -21,7 +19,7 @@ import { Button } from "@/components/ui/Button";
 import { Surface } from "@/components/ui/Surface";
 import type { AttentionEnvelopeApproval } from "@/lib/attention/types";
 
-type Outcome = "approved" | "declined" | "settled";
+type Outcome = "authorized" | "declined" | "settled";
 
 export function CoworkerEnvelopeApproval({
   approval,
@@ -32,6 +30,7 @@ export function CoworkerEnvelopeApproval({
   const [outcome, setOutcome] = useState<Outcome | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
+  const decision = approval.decision;
 
   async function decide(choice: "approve" | "decline") {
     // One in-flight decision per card. A second press while the first is open
@@ -45,7 +44,7 @@ export function CoworkerEnvelopeApproval({
         { method: "POST", headers: { "content-type": "application/json" } },
       );
       if (response.ok) {
-        setOutcome(choice === "approve" ? "approved" : "declined");
+        setOutcome(choice === "approve" ? "authorized" : "declined");
         router.refresh();
         return;
       }
@@ -69,31 +68,33 @@ export function CoworkerEnvelopeApproval({
   return (
     <div className="space-y-3">
       <Surface padding="sm" rounded="md">
-        <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
-          <Fact label="Coworker" value={approval.coworkerAgentId} />
-          <Fact label="Requested action" value={approval.manifestActionId} />
-          <Fact label="Status" value={approval.status} />
-          <Fact label="Open until" value={approval.expiresAtIso ?? "No time limit"} />
-          {approval.taskRunId ? <Fact label="Task" value={approval.taskRunId} /> : null}
-          <Fact label="Reason given" value={approval.rationale} wide />
+        <p className="text-dpf-caption font-semibold uppercase tracking-wider text-[var(--dpf-accent)]">
+          Human authorization needed
+        </p>
+        <p className="mt-1 text-xs leading-relaxed text-[var(--dpf-text)]">
+          {decision.authorization}.
+        </p>
+        <dl className="mt-3 grid gap-x-6 gap-y-2 sm:grid-cols-2">
+          {decision.subjectId ? <Fact label="Subject" value={decision.subjectId} /> : null}
+          {decision.gate ? <Fact label="Gate" value={decision.gate} /> : null}
+          {decision.decision ? <Fact label="Decision" value={decision.decision} /> : null}
+          <Fact
+            label="Findings"
+            value={
+              decision.findings.length === 0
+                ? "None"
+                : decision.findings.map((finding) => finding.issue).join(" ")
+            }
+            wide
+          />
+          {decision.reason ? <Fact label="Reason" value={decision.reason} wide /> : null}
+          <Fact label="Recommender" value={decision.recommenderLabel} />
+          <Fact label="Accountable authorizer" value={decision.authorizerLabel} />
         </dl>
+        <p className="mt-3 text-xs leading-relaxed text-[var(--dpf-muted)]">
+          {decision.authorizeDoes} {decision.declineDoes}
+        </p>
       </Surface>
-
-      {approval.reviewBinding ? (
-        <Surface padding="sm" rounded="md">
-          <p className="text-dpf-caption font-semibold uppercase tracking-wider text-[var(--dpf-accent)]">
-            Reviewed record
-          </p>
-          <dl className="mt-2 grid gap-x-6 gap-y-2 sm:grid-cols-2">
-            <Fact label="Subject" value={approval.reviewBinding.itemId} />
-            <Fact label="Gate" value={approval.reviewBinding.gate} />
-            <Fact label="Repository" value={approval.reviewBinding.repositoryFullName} />
-            <Fact label="Commit" value={approval.reviewBinding.commitSha} />
-            <Fact label="File" value={approval.reviewBinding.path} wide />
-            <Fact label="Blob" value={approval.reviewBinding.providerBlobId} wide />
-          </dl>
-        </Surface>
-      ) : null}
 
       {outcome ? (
         <p className="text-xs font-semibold text-[var(--dpf-text)]" role="status">
@@ -102,7 +103,7 @@ export function CoworkerEnvelopeApproval({
       ) : approval.actionable ? (
         <div className="flex flex-wrap gap-2">
           <Button size="sm" disabled={pending} onClick={() => void decide("approve")}>
-            Approve action
+            Authorize
           </Button>
           <Button
             variant="secondary"
@@ -129,8 +130,8 @@ export function CoworkerEnvelopeApproval({
 }
 
 function outcomeMessage(outcome: Outcome): string {
-  if (outcome === "approved") return "Action approved.";
-  if (outcome === "declined") return "Action declined.";
+  if (outcome === "authorized") return "Record authorized.";
+  if (outcome === "declined") return "Record declined.";
   return "This request was already settled.";
 }
 

--- a/apps/web/lib/attention/coworker-envelope-decision.test.ts
+++ b/apps/web/lib/attention/coworker-envelope-decision.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  envelopeIdFromExecutionResult,
+  originalToolParameters,
+  summarizeCoworkerEnvelopeDecision,
+} from "./coworker-envelope-decision";
+
+const RESEARCH = {
+  toolName: "record_initiative_evidence",
+  reviewBinding: { gate: "research", itemId: "BI-B3584737" },
+  recommenderAgentId: "AGT-WS-BUILD",
+  authorizerUserId: "user-1",
+};
+
+describe("summarizeCoworkerEnvelopeDecision", () => {
+  it("states a research pass with no findings as recommendation versus authorization", () => {
+    const summary = summarizeCoworkerEnvelopeDecision({
+      ...RESEARCH,
+      proposedParameters: { decision: "pass" },
+    });
+
+    expect(summary.kind).toBe("known");
+    expect(summary.headline).toBe("Authorize this research receipt?");
+    expect(summary.recommendation).toBe("research passes with no findings");
+    expect(summary.authorization).toBe(
+      "record that receipt so implementation planning may continue",
+    );
+    expect(`AI recommendation: ${summary.recommendation}. Human authorization needed: ${summary.authorization}.`)
+      .toBe(
+        "AI recommendation: research passes with no findings. Human authorization needed: record that receipt so implementation planning may continue.",
+      );
+    expect(summary.authorizeDoes).toMatch(/receipt/i);
+    expect(summary.declineDoes).toMatch(/does not record/i);
+    expect(summary.authorizeDoes.toLowerCase()).not.toContain("approv");
+    expect(summary.declineDoes.toLowerCase()).not.toContain("approv");
+    expect(summary.headline.toLowerCase()).not.toContain("approv");
+    expect(summary.decision).toBe("pass");
+    expect(summary.findings).toEqual([]);
+    expect(summary.subjectId).toBe("BI-B3584737");
+    expect(summary.gate).toBe("research");
+    expect(summary.recommenderLabel).toBe("Your coworker");
+    expect(summary.authorizerLabel).toBe("You");
+  });
+
+  it("states a research fail and lists findings without inventing a pass", () => {
+    const summary = summarizeCoworkerEnvelopeDecision({
+      ...RESEARCH,
+      proposedParameters: {
+        decision: "fail",
+        findings: [{ issue: "The defect was not reproduced on the named ref.", severity: "critical" }],
+      },
+    });
+
+    expect(summary.recommendation).toBe("research does not pass with 1 finding");
+    expect(summary.authorization).toMatch(/stays blocked/i);
+    expect(summary.findings).toEqual([
+      { issue: "The defect was not reproduced on the named ref.", severity: "critical" },
+    ]);
+    expect(summary.decision).toBe("fail");
+  });
+
+  it("states not-applicable without claiming the work passed", () => {
+    const summary = summarizeCoworkerEnvelopeDecision({
+      ...RESEARCH,
+      proposedParameters: { decision: "not-applicable", reason: "This item is documentation-only." },
+    });
+
+    expect(summary.recommendation).toBe("research is not applicable");
+    expect(summary.authorization).toMatch(/does not apply/i);
+    expect(summary.reason).toBe("This item is documentation-only.");
+    expect(summary.decision).toBe("not-applicable");
+  });
+
+  it("fails closed on an unknown tool shape and does not invent a consequence", () => {
+    const summary = summarizeCoworkerEnvelopeDecision({
+      toolName: "browser.click",
+      proposedParameters: { selector: "#pay" },
+      recommenderAgentId: "AGT-WS-BUILD",
+      authorizerUserId: "user-1",
+    });
+
+    expect(summary.kind).toBe("unknown");
+    expect(summary.recommendation).not.toMatch(/pass|fail|research/i);
+    expect(summary.authorization).not.toMatch(/implementation planning/i);
+    expect(summary.recordedIfAuthorized).toMatch(/not summarized/i);
+    expect(summary.headline.toLowerCase()).not.toContain("approv");
+  });
+
+  it("does not treat a missing decision as a pass even when the gate is bound", () => {
+    const summary = summarizeCoworkerEnvelopeDecision({
+      ...RESEARCH,
+      proposedParameters: {},
+    });
+
+    expect(summary.kind).toBe("unknown");
+    expect(summary.recommendation).not.toMatch(/passes/i);
+  });
+
+  it("reads argsJson when no ToolExecution parameters exist, ignoring the approval binding", () => {
+    const summary = summarizeCoworkerEnvelopeDecision({
+      ...RESEARCH,
+      proposedParameters: undefined,
+      argsJson: { approvalBinding: { toolName: "record_initiative_evidence" }, decision: "pass" },
+    });
+
+    expect(summary.kind).toBe("known");
+    expect(summary.recommendation).toBe("research passes with no findings");
+  });
+});
+
+describe("originalToolParameters", () => {
+  it("drops audit keys and the stored approval binding", () => {
+    expect(originalToolParameters({
+      decision: "pass",
+      approvalBinding: { toolName: "record_initiative_evidence" },
+      _surface: "mcp",
+    })).toEqual({ decision: "pass" });
+  });
+});
+
+describe("envelopeIdFromExecutionResult", () => {
+  it("reads the pending execution's envelope id", () => {
+    expect(envelopeIdFromExecutionResult({
+      success: false,
+      data: { envelopeId: "cmti2racd18zq01lht28321dp" },
+      error: "approval_required",
+    })).toBe("cmti2racd18zq01lht28321dp");
+  });
+});

--- a/apps/web/lib/attention/coworker-envelope-decision.ts
+++ b/apps/web/lib/attention/coworker-envelope-decision.ts
@@ -1,0 +1,204 @@
+// Decision-first owner copy for a proposed CoworkerActionEnvelope (BI-F95B0795).
+//
+// The envelope row stores the approval binding, not the proposed call. The
+// pending ToolExecution.parameters (and, for some envelopes, argsJson) carry
+// the exact arguments. This module projects those arguments plus bound
+// subject/gate semantics into owner language. Unknown shapes fail closed.
+
+export const GOVERNED_AUDIT_PARAMETER_KEYS = new Set([
+  "_surface",
+  "_takAlignment",
+  "_takPrecondition",
+]);
+
+const KNOWN_DECISIONS = ["pass", "fail", "not-applicable"] as const;
+export type EnvelopeRecordedDecision = (typeof KNOWN_DECISIONS)[number];
+
+export type EnvelopeFinding = {
+  issue: string;
+  severity: "critical" | "important";
+};
+
+export type EnvelopeReviewBindingSummary = {
+  gate: string;
+  itemId: string;
+};
+
+export type EnvelopeDecisionSummary = {
+  kind: "known" | "unknown";
+  headline: string;
+  recommendation: string;
+  authorization: string;
+  recordedIfAuthorized: string;
+  authorizeDoes: string;
+  declineDoes: string;
+  ifYouDoNothing: string;
+  decision?: EnvelopeRecordedDecision;
+  findings: EnvelopeFinding[];
+  reason?: string;
+  subjectId?: string;
+  gate?: string;
+  recommenderLabel: string;
+  authorizerLabel: string;
+  toolName: string;
+};
+
+export function objectRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+/** Strip governed-audit keys and the stored approval binding. */
+export function originalToolParameters(value: unknown): Record<string, unknown> | null {
+  const record = objectRecord(value);
+  if (!record) return null;
+  const entries = Object.entries(record).filter(
+    ([key]) => key !== "approvalBinding" && !GOVERNED_AUDIT_PARAMETER_KEYS.has(key),
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : null;
+}
+
+export function envelopeIdFromExecutionResult(result: unknown): string | null {
+  const data = objectRecord(objectRecord(result)?.data);
+  const envelopeId = data?.envelopeId;
+  return typeof envelopeId === "string" && envelopeId.trim() ? envelopeId : null;
+}
+
+function parseDecision(value: unknown): EnvelopeRecordedDecision | undefined {
+  return typeof value === "string" && (KNOWN_DECISIONS as readonly string[]).includes(value)
+    ? value as EnvelopeRecordedDecision
+    : undefined;
+}
+
+function parseFindings(value: unknown): EnvelopeFinding[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const findings: EnvelopeFinding[] = [];
+  for (const entry of value) {
+    const record = objectRecord(entry);
+    if (!record || typeof record.issue !== "string" || !record.issue.trim()) return undefined;
+    if (record.severity !== "critical" && record.severity !== "important") return undefined;
+    findings.push({ issue: record.issue, severity: record.severity });
+  }
+  return findings;
+}
+
+function findingsPhrase(findings: EnvelopeFinding[]): string {
+  if (findings.length === 0) return "with no findings";
+  if (findings.length === 1) return "with 1 finding";
+  return `with ${findings.length} findings`;
+}
+
+function researchRecommendation(
+  gate: string,
+  decision: EnvelopeRecordedDecision,
+  findings: EnvelopeFinding[],
+): string {
+  if (gate === "research") {
+    if (decision === "pass") return `research passes ${findingsPhrase(findings)}`;
+    if (decision === "fail") return `research does not pass ${findingsPhrase(findings)}`;
+    return "research is not applicable";
+  }
+  if (decision === "pass") return `${gate} passes ${findingsPhrase(findings)}`;
+  if (decision === "fail") return `${gate} does not pass ${findingsPhrase(findings)}`;
+  return `${gate} is not applicable`;
+}
+
+function researchAuthorization(
+  gate: string,
+  decision: EnvelopeRecordedDecision,
+): string {
+  if (gate === "research" && decision === "pass") {
+    return "record that receipt so implementation planning may continue";
+  }
+  if (gate === "research" && decision === "fail") {
+    return "record that receipt; implementation planning stays blocked until research passes";
+  }
+  if (gate === "research") {
+    return "record that research does not apply to this item";
+  }
+  return `record that ${gate} receipt`;
+}
+
+function unknownSummary(input: {
+  toolName: string;
+}): EnvelopeDecisionSummary {
+  return {
+    kind: "unknown",
+    headline: "Authorize this coworker record?",
+    recommendation: "this action needs a person to record it",
+    authorization: "record the coworker's proposed action if you accept it",
+    recordedIfAuthorized:
+      "A coworker proposed a record. The exact effect is not summarized for this action type.",
+    authorizeDoes: "Records the proposed action.",
+    declineDoes: "Does not record it. Your coworker stops.",
+    ifYouDoNothing: "the window closes and the record is not written.",
+    findings: [],
+    recommenderLabel: "Your coworker",
+    authorizerLabel: "You",
+    toolName: input.toolName,
+  };
+}
+
+export function summarizeCoworkerEnvelopeDecision(input: {
+  toolName: string;
+  proposedParameters: unknown;
+  argsJson?: unknown;
+  reviewBinding?: EnvelopeReviewBindingSummary;
+  recommenderAgentId: string;
+  authorizerUserId: string;
+}): EnvelopeDecisionSummary {
+  const fromExecution = originalToolParameters(input.proposedParameters);
+  const fromEnvelope = originalToolParameters(input.argsJson);
+  const params = fromExecution ?? fromEnvelope ?? {};
+  const toolName = input.toolName.trim();
+  const gate =
+    (typeof params.gate === "string" && params.gate.trim())
+    || input.reviewBinding?.gate.trim()
+    || "";
+  const subjectId =
+    (typeof params.itemId === "string" && params.itemId.trim())
+    || input.reviewBinding?.itemId.trim()
+    || "";
+  const decision = parseDecision(params.decision);
+  const parsedFindings = parseFindings(params.findings);
+  const findings =
+    parsedFindings
+    ?? (toolName === "record_initiative_evidence" && gate === "research" ? [] : []);
+  const reason = typeof params.reason === "string" && params.reason.trim()
+    ? params.reason.trim()
+    : undefined;
+
+  if (toolName !== "record_initiative_evidence" || !decision || !gate) {
+    return unknownSummary({ toolName });
+  }
+
+  const recommendation = researchRecommendation(gate, decision, findings);
+  const authorization = researchAuthorization(gate, decision);
+  const recordedIfAuthorized = subjectId
+    ? `${gate} on ${subjectId} will be recorded as ${decision} ${findingsPhrase(findings)}.`
+    : `${gate} will be recorded as ${decision} ${findingsPhrase(findings)}.`;
+
+  return {
+    kind: "known",
+    headline: gate === "research"
+      ? "Authorize this research receipt?"
+      : "Authorize this coworker record?",
+    recommendation,
+    authorization,
+    recordedIfAuthorized,
+    authorizeDoes: "Records the recommendation as a receipt.",
+    declineDoes: "Does not record it. Your coworker stops.",
+    ifYouDoNothing: decision === "pass" && gate === "research"
+      ? "the receipt is not recorded and implementation planning stays blocked."
+      : "the receipt is not recorded and the work stays blocked.",
+    decision,
+    findings,
+    ...(reason ? { reason } : {}),
+    ...(subjectId ? { subjectId } : {}),
+    gate,
+    recommenderLabel: "Your coworker",
+    authorizerLabel: "You",
+    toolName,
+  };
+}

--- a/apps/web/lib/attention/owner-decision-copy.test.ts
+++ b/apps/web/lib/attention/owner-decision-copy.test.ts
@@ -36,6 +36,8 @@ const ALL_SOURCES: AttentionSource[] = [
   "storefront-inquiry",
   "business-journey",
   "compliance-source-freshness",
+  "coworker-envelope",
+  "skill-proposal",
 ];
 
 /**

--- a/apps/web/lib/attention/owner-decision-copy.ts
+++ b/apps/web/lib/attention/owner-decision-copy.ts
@@ -23,7 +23,7 @@ const HEADLINE: Record<AttentionSource, string> = {
   "storefront-inquiry": "Reply to this enquiry?",
   "business-journey": "How should we fix this for customers?",
   "compliance-source-freshness": "Renew this compliance evidence?",
-  "coworker-envelope": "Approve this coworker action?",
+  "coworker-envelope": "Authorize this coworker record?",
   "skill-proposal": "Approve this change to a coworker skill?",
 };
 
@@ -78,6 +78,9 @@ const OWNER_SAFE_SITUATION: Partial<Record<AttentionSource, string>> = {
  *  the rationale the owner needs to decide — it was previously discarded. */
 export function situationFor(item: AttentionItem): string | undefined {
   if (SELF_EXPLANATORY_SOURCES.has(item.source)) return undefined;
+  if (item.source === "coworker-envelope" && item.envelope?.decision) {
+    return item.envelope.decision.recordedIfAuthorized;
+  }
   const translated = OWNER_SAFE_SITUATION[item.source];
   if (translated) return translated;
   const context = (item.context ?? "").trim();
@@ -93,6 +96,9 @@ export function headlineFor(item: AttentionItem): string {
   }
   if (item.source === "agent-proposal" && !/proactiv/i.test(item.title)) {
     return "Approve this coworker action?";
+  }
+  if (item.source === "coworker-envelope" && item.envelope?.decision) {
+    return item.envelope.decision.headline;
   }
   return HEADLINE[item.source];
 }
@@ -158,7 +164,10 @@ export function consequenceFor(item: AttentionItem): string {
     case "agent-proposal":
       return "If you do nothing, your coworker stays stuck here and the work behind it waits.";
     case "coworker-envelope":
-      return "If you do nothing, the approval window closes and your coworker stops.";
+      if (item.envelope?.decision) {
+        return `If you do nothing, ${item.envelope.decision.ifYouDoNothing}`;
+      }
+      return "If you do nothing, the window closes and the record is not written.";
     default:
       return "If you do nothing, this work stays paused while your digital team keeps it safe.";
   }
@@ -176,7 +185,8 @@ export function recommendationFor(item: AttentionItem): string {
     case "agent-proposal":
       return "accept only the stated boundary; this does not give the coworker new authority.";
     case "coworker-envelope":
-      return "check the exact record and the time left, then approve only if both are right.";
+      return item.envelope?.decision.recommendation
+        ?? "this action needs a person to record it";
     case "research-proposal":
       return "keep this in the weekly review unless it affects a decision due sooner.";
     case "coworker-memory":

--- a/apps/web/lib/attention/owner-technical-detail.ts
+++ b/apps/web/lib/attention/owner-technical-detail.ts
@@ -26,7 +26,30 @@ export function technicalFields(item: AttentionItem): OwnerTechnicalField[] {
     { label: "Risk", value: item.riskClass },
     { label: "Why it was routed", value: residueReasonLabel(item.triage.residueReason) },
     { label: "Original context", value: item.context || "No extra context recorded" },
+    ...envelopeTechnicalFields(item),
   ];
+}
+
+function envelopeTechnicalFields(item: AttentionItem): OwnerTechnicalField[] {
+  const envelope = item.envelope;
+  if (!envelope) return [];
+  const fields: OwnerTechnicalField[] = [
+    { label: "Coworker", value: envelope.coworkerAgentId },
+    { label: "Requested action", value: envelope.manifestActionId },
+    { label: "Status", value: envelope.status },
+    { label: "Open until", value: envelope.expiresAtIso ?? "No time limit" },
+  ];
+  if (envelope.taskRunId) fields.push({ label: "Task", value: envelope.taskRunId });
+  const binding = envelope.reviewBinding;
+  if (binding) {
+    fields.push(
+      { label: "Repository", value: binding.repositoryFullName },
+      { label: "Commit", value: binding.commitSha },
+      { label: "File", value: binding.path },
+      { label: "Blob", value: binding.providerBlobId },
+    );
+  }
+  return fields;
 }
 
 export function builderActions(item: AttentionItem): OwnerDecisionChoice[] {

--- a/apps/web/lib/attention/sources/coworker-envelope.test.ts
+++ b/apps/web/lib/attention/sources/coworker-envelope.test.ts
@@ -43,6 +43,7 @@ function envelope(over: Partial<CoworkerEnvelopeRow> = {}): CoworkerEnvelopeRow 
     // clock-bomb-guard: allow coworkerEnvelopeToAttentionItem takes nowMs explicitly and never reads the wall clock
     expiresAt: new Date("2026-08-25T20:09:05.868Z"),
     createdAt: new Date("2026-08-25T19:54:05.871Z"),
+    proposedParameters: { decision: "pass" },
     taskRun: { a2aMetadata: { trigger: "external-mcp", initiativeReviewBinding: reviewBinding } },
     ...over,
   };
@@ -77,6 +78,11 @@ describe("coworkerEnvelopeToAttentionItem", () => {
     );
     expect(approval?.expiresAtIso).toBe("2026-08-25T20:09:05.868Z");
     expect(approval?.actionable).toBe(true);
+    expect(approval?.decision.kind).toBe("known");
+    expect(approval?.decision.recommendation).toBe("research passes with no findings");
+    expect(approval?.decision.authorization).toBe(
+      "record that receipt so implementation planning may continue",
+    );
   });
 
   it("carries the immutable review binding: subject, gate, commit, path and blob", () => {
@@ -146,7 +152,10 @@ describe("coworkerEnvelopeToAttentionItem", () => {
     );
     const card = projection.needsYouNow[0]!.card;
 
+    expect(card.headline).toBe("Authorize this research receipt?");
     expect(card.headline.split(/\s+/).length).toBeLessThanOrEqual(8);
+    expect(card.recommendation.text).toBe("research passes with no findings");
+    expect(card.situation).toMatch(/BI-MCP-EFF-0285909C/);
     expect(
       [
         card.headline,
@@ -217,11 +226,27 @@ describe("coworkerEnvelopeToAttentionItem", () => {
 
 // Owner projection and delegating-user isolation.
 
-function stubDb(rows: CoworkerEnvelopeRow[]) {
+function stubDb(
+  rows: CoworkerEnvelopeRow[],
+  executions: Array<{
+    taskRunId: string | null;
+    toolName: string;
+    parameters: unknown;
+    result: unknown;
+  }> = [],
+) {
   const findMany = vi.fn(async (args: { where: { delegatingUserId: string } }) =>
     rows.filter((row) => row.delegatingUserId === args.where.delegatingUserId),
   );
-  return { db: { coworkerActionEnvelope: { findMany } } as never, findMany };
+  const findExecutions = vi.fn(async () => executions);
+  return {
+    db: {
+      coworkerActionEnvelope: { findMany },
+      toolExecution: { findMany: findExecutions },
+    } as never,
+    findMany,
+    findExecutions,
+  };
 }
 
 describe("loadCoworkerEnvelopeItems", () => {
@@ -260,5 +285,26 @@ describe("loadCoworkerEnvelopeItems", () => {
     expect(await loadCoworkerEnvelopeItems(db, undefined, NOW)).toEqual([]);
     expect(await loadCoworkerEnvelopeItems(db, "", NOW)).toEqual([]);
     expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("joins the pending ToolExecution parameters onto the owner decision", async () => {
+    const row = envelope({ proposedParameters: undefined });
+    const { db } = stubDb([row], [
+      {
+        taskRunId: row.taskRunId,
+        toolName: row.manifestActionId,
+        parameters: { decision: "fail", findings: [{ issue: "Not reproduced.", severity: "important" }] },
+        result: { data: { envelopeId: row.id } },
+      },
+    ]);
+
+    const items = await loadCoworkerEnvelopeItems(db, OWNER, NOW);
+
+    expect(items[0]?.envelope?.decision.recommendation).toBe(
+      "research does not pass with 1 finding",
+    );
+    expect(items[0]?.envelope?.decision.findings).toEqual([
+      { issue: "Not reproduced.", severity: "important" },
+    ]);
   });
 });

--- a/apps/web/lib/attention/sources/coworker-envelope.ts
+++ b/apps/web/lib/attention/sources/coworker-envelope.ts
@@ -31,9 +31,13 @@ import {
   coworkerEnvelopesAwaitingDecision,
   coworkerEnvelopesExpiredUnactioned,
 } from "@/lib/operate/metrics";
-import { parseInitiativeReviewBinding } from "@/lib/mcp-task-submit";
+import { parseInitiativeReviewBinding } from "@/lib/mcp-task-review-contract";
 
 import { attentionAuthorForAgent } from "../attribution";
+import {
+  envelopeIdFromExecutionResult,
+  summarizeCoworkerEnvelopeDecision,
+} from "../coworker-envelope-decision";
 import type {
   AttentionEnvelopeApproval,
   AttentionEnvelopeReviewBinding,
@@ -55,6 +59,8 @@ export type CoworkerEnvelopeRow = {
   taskRunId: string | null;
   expiresAt: Date | null;
   createdAt: Date;
+  argsJson?: unknown;
+  proposedParameters?: unknown;
   taskRun: { a2aMetadata: unknown } | null;
 };
 
@@ -100,6 +106,14 @@ export function coworkerEnvelopeToAttentionItem(
 ): AttentionItem {
   const expired = row.expiresAt !== null && row.expiresAt.getTime() <= nowMs;
   const reviewBinding = reviewBindingOf(row);
+  const decision = summarizeCoworkerEnvelopeDecision({
+    toolName: row.manifestActionId,
+    proposedParameters: row.proposedParameters,
+    argsJson: row.argsJson,
+    reviewBinding,
+    recommenderAgentId: row.coworkerAgentId,
+    authorizerUserId: row.delegatingUserId,
+  });
   const approval: AttentionEnvelopeApproval = {
     envelopeId: row.id,
     coworkerAgentId: row.coworkerAgentId,
@@ -110,6 +124,7 @@ export function coworkerEnvelopeToAttentionItem(
     taskRunId: row.taskRunId,
     expiresAtIso: row.expiresAt?.toISOString() ?? null,
     actionable: row.status === DECIDABLE_STATUS && !expired,
+    decision,
     ...(reviewBinding ? { reviewBinding } : {}),
     approveHref: envelopeApproveRoute(row.id),
     declineHref: envelopeDeclineRoute(row.id),
@@ -140,7 +155,7 @@ export function coworkerEnvelopeToAttentionItem(
     // envelope endpoints; an href here would become an owner button that
     // navigates away from the only surface that can settle the envelope.
     actions: [
-      { kind: "approve", label: "Approve action" },
+      { kind: "approve", label: "Authorize" },
       { kind: "reject", label: "Decline" },
     ],
     deepLink: "/workspace/inbox",
@@ -186,9 +201,14 @@ export async function loadCoworkerEnvelopeItems(
       taskRunId: true,
       expiresAt: true,
       createdAt: true,
+      argsJson: true,
       taskRun: { select: { a2aMetadata: true } },
     },
   });
+  const proposedByEnvelopeId = await loadProposedParameters(
+    db,
+    rows as unknown as CoworkerEnvelopeRow[],
+  );
   // Fire-and-forget backlog observation (BI-78D3CF1E). The query above
   // deliberately EXCLUDES expired envelopes, because an expired one is not
   // actionable — which is exactly why nothing could see them lapsing. This
@@ -223,6 +243,49 @@ export async function loadCoworkerEnvelopeItems(
   });
 
   return (rows as unknown as CoworkerEnvelopeRow[]).map((row) =>
-    coworkerEnvelopeToAttentionItem(row, nowMs),
+    coworkerEnvelopeToAttentionItem(
+      {
+        ...row,
+        ...(proposedByEnvelopeId.has(row.id)
+          ? { proposedParameters: proposedByEnvelopeId.get(row.id) }
+          : {}),
+      },
+      nowMs,
+    ),
   );
+}
+
+type ProposedExecutionRow = {
+  taskRunId: string | null;
+  toolName: string;
+  parameters: unknown;
+  result: unknown;
+};
+
+async function loadProposedParameters(
+  db: Db,
+  rows: CoworkerEnvelopeRow[],
+): Promise<Map<string, unknown>> {
+  const taskRunIds = rows
+    .map((row) => row.taskRunId)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+  if (taskRunIds.length === 0) return new Map();
+  const executions = await db.toolExecution.findMany({
+    where: {
+      taskRunId: { in: taskRunIds },
+      success: false,
+    },
+    orderBy: { createdAt: "desc" },
+    select: { taskRunId: true, toolName: true, parameters: true, result: true },
+  }) as ProposedExecutionRow[];
+  const proposed = new Map<string, unknown>();
+  for (const row of rows) {
+    const match = executions.find((execution) =>
+      execution.taskRunId === row.taskRunId
+      && execution.toolName === row.manifestActionId
+      && envelopeIdFromExecutionResult(execution.result) === row.id,
+    );
+    if (match) proposed.set(row.id, match.parameters);
+  }
+  return proposed;
 }

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -1,5 +1,7 @@
 // The Attention Surface — projector output types (EP-ATTENTION-SURFACE, BI-D39484E7 + BI-61B9EB88).
 // Spec: docs/superpowers/specs/2026-06-23-human-attention-surface-design.md §4.1, §4.4.
+
+import type { EnvelopeDecisionSummary } from "./coworker-envelope-decision";
 //
 // `AttentionItem` is a READ-MODEL projection, NOT a persisted entity. Each queue's
 // truth stays in its owning model (single-source-of-truth); the inbox projects over
@@ -184,6 +186,8 @@ export type AttentionEnvelopeApproval = {
    *  moment. False hides every decision control. */
   actionable: boolean;
   reviewBinding?: AttentionEnvelopeReviewBinding;
+  /** Decision-first owner summary (BI-F95B0795). Always present; unknown shapes fail closed. */
+  decision: EnvelopeDecisionSummary;
   /** The authenticated envelope state-machine routes (lib/coworker/envelope-routes). */
   approveHref: string;
   declineHref: string;

--- a/docs/superpowers/specs/2026-09-01-approval-cards-recommendation-versus-authorization-design.md
+++ b/docs/superpowers/specs/2026-09-01-approval-cards-recommendation-versus-authorization-design.md
@@ -1,0 +1,84 @@
+---
+status: active
+---
+
+# Approval cards distinguish AI recommendation from human authorization
+
+- Backlog: `BI-F95B0795`
+- Epic: `EP-31815F97`
+- Workroom: `WC-B809341F`
+- Profile: fix — this document is the research record and the ordered fix sequence
+
+## Problem
+
+The live `Needs you` card for a governed initiative-research receipt asks “Approve this coworker action?” and leads with TaskRun, agent, repository, commit, path, blob, status, and expiry. It does not tell the authorizing person the proposed decision or its effect. It also uses “approval” for two different acts: the coworker’s judgment and the employee’s authority to persist that judgment.
+
+## Research — defect on a named ref
+
+Confirmed on `origin/main` `91f50bcc65eacc3f9518a16d5302eda9d591bda5`.
+
+| Cause candidate | How it was ruled out |
+| --- | --- |
+| Envelope never reaches the inbox | Ruled out by running the colocated projector tests: `coworker-envelope.ts` already projects `coworker-envelope` items into `needs-you-now`. |
+| Cross-identity invisibility | Ruled out as a different defect: `BI-06AE037F` / PR #4908 names the approval owner and location. This item is about a *visible* envelope that is unintelligible. |
+| Proposed arguments missing from the database | Ruled out: `ToolExecution.parameters` stores `{ decision: "pass" }` on the `approval_required` audit row (`mcp-governed-execute.ts` writes that audit). `CoworkerActionEnvelope.argsJson` deliberately stores only `{ approvalBinding }` (`authority-approval-envelope.ts:116-119`). |
+| Owner card has no AI-recommendation slot | Ruled out: `OwnerDecisionCard.recommendation.lead` is already `"AI recommendation"`. The text is a generic “check the exact record and the time left”. |
+
+Actual cause, cited on that ref:
+
+- `apps/web/lib/attention/sources/coworker-envelope.ts` does not load `ToolExecution.parameters` or `argsJson`.
+- `apps/web/lib/attention/owner-decision-copy.ts:26` hard-codes `"Approve this coworker action?"`.
+- `apps/web/components/attention/CoworkerEnvelopeApproval.tsx:73-95` puts coworker, action, TaskRun, commit, path, and blob in the primary surface.
+- Colocated tests require that plumbing to be visible, so the defect is locked in.
+
+The bound handler (`initiative-readiness-pack.ts`) fills `gate`, `itemId`, `artifactRef`, empty `findings`, and reviewer `reason` for research receipts. The card must project that recorded effect, not invent a friendlier one.
+
+## Research & benchmarking
+
+Compared three HITL leaders for the owner-copy contract only:
+
+| Product | Adopt | Reject |
+| --- | --- | --- |
+| GitHub pull-request review | The primary surface states the proposed change and the reviewer’s verdict; SHAs and blob ids stay in the diff header / commits tab. | Do not copy GitHub’s “Approve” for the second act — DPF’s second act is authorization to *record* a receipt. |
+| Linear issue triage | Decision-first headline; identifiers live in a details drawer. | Do not add a second inbox. |
+| Slack workflow approval | Separate “what will happen” copy from the confirm/deny controls. | Do not add a Slack-shaped modal. |
+
+DPF already has the progressive-disclosure shell (`OwnerDecisionCards` + `Technical detail`). This fix reuses it.
+
+## Design
+
+1. Keep `CoworkerActionEnvelope.argsJson` as the approval-binding store. Do not start persisting raw tool arguments there.
+2. Project the exact proposed call from the pending `ToolExecution.parameters` (same join `resumeApprovedRemoteTask` already uses: `taskRunId` + tool name + `result.data.envelopeId`). Fall back to `argsJson` minus `approvalBinding` for envelopes that do store action args (browser-drive).
+3. A pure summarizer maps known `record_initiative_evidence` shapes (pass / fail / not-applicable, with or without findings) plus bound gate/subject semantics into owner copy. Unknown tool shapes fail closed to a truthful generic summary.
+4. Owner copy labels the first act **AI recommendation** and the second **human authorization**. Buttons are **Authorize** and **Decline**, each with a one-line effect. Neither stage is called “approval”.
+5. Agent id, TaskRun, repository, commit, blob, fingerprints, and routing metadata move under Technical detail.
+
+Acceptance shape for the live research-pass receipt:
+
+> AI recommendation: research passes with no findings. Human authorization needed: record that receipt so implementation planning may continue.
+
+## Ordered fix sequence
+
+1. Add `coworker-envelope-decision.ts` and tests for pass / fail / not-applicable, findings, unknown shapes, and recommendation-versus-authorization labels.
+2. Load proposed parameters in `coworker-envelope.ts` and attach a `decision` summary to `AttentionEnvelopeApproval`.
+3. Drive headline, situation, recommendation, and consequence from that summary.
+4. Render decision-first facts and Authorize/Decline copy on `CoworkerEnvelopeApproval`; collapse identity plumbing into `technicalFields`.
+5. Update colocated tests so they fail if plumbing returns to the primary surface.
+
+## UX fit
+
+- Owning area: Workspace inbox (`/workspace/inbox`).
+- Persona: the employee who must authorize a coworker HITL envelope.
+- Navigation layer: contextual action on an existing card. No new route.
+- Reuse: `OwnerDecisionCards`, `ExpandableCard`, `StatusBadge`, existing envelope endpoints.
+- Source truth: `CoworkerActionEnvelope` + pending `ToolExecution.parameters` + `TaskRun.a2aMetadata.initiativeReviewBinding`.
+- AI boundary: Authorize/Decline remain explicit confirmation; they do not send a prompt.
+
+## Documentation impact
+
+This spec is the design/plan artifact. User-guide copy is unchanged: `/workspace/inbox` remains the Needs-you home. No migration.
+
+## Verification
+
+- Unit: summarizer + projector + card tests listed above.
+- UX: drive a research-pass envelope on `/workspace/inbox` and confirm the primary card states the verdict and authorization effect before Technical detail is opened.


### PR DESCRIPTION
## Summary

Needs-you envelope cards led with TaskRun, commit, and blob, and used "approval" for both the coworker's verdict and the employee's authority to record it. This change projects the proposed tool arguments into decision-first copy, labels Authorize/Decline separately, and keeps identity plumbing under Technical detail.

Fixes BI-F95B0795.

## Design grounding

- specs/plans reviewed: `docs/superpowers/specs/2026-06-23-human-attention-surface-design.md` and `docs/superpowers/specs/2026-09-01-approval-cards-recommendation-versus-authorization-design.md`
- code substrate: `apps/web/lib/attention/sources/coworker-envelope.ts`, `CoworkerEnvelopeApproval.tsx`, `owner-decision-copy.ts`
- Source of truth: `CoworkerActionEnvelope` plus pending `ToolExecution.parameters` plus `TaskRun` initiative-review binding
- Decision: summarize known `record_initiative_evidence` shapes; fail closed for unknown tools; do not persist raw tool args on the envelope

## Verification

- Focused Vitest: 53 tests (decision summary, projector, Authorize/Decline card)
- Related: 34 tests (routing, aggregate, approval location)
- Style-drift and prose-lint passed
- Host preflight: 61 guards clean
- Local-CI gate passed for this branch tip

## Docs

Design spec added. User-guide inbox home is unchanged.

Design-Grounding-Decision: reuse the existing owner-card shell and envelope endpoints; summarize from pending ToolExecution.parameters plus bound gate/subject semantics.
Docs-Impact-Decision: design spec added; user-guide inbox home unchanged.