### PR TITLE
feat(workroom): add Process Overseer shape-conformance projection (BI-3913EB49)

### DIFF
--- a/apps/web/lib/work-management/workroom-shape-conformance.test.ts
+++ b/apps/web/lib/work-management/workroom-shape-conformance.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveRoomCoordinator } from "./room-coordinator";
+import type { WorkroomParticipantRole, WorkroomParticipantView } from "./room-types";
+import type { WorkShapeDefinitionContract } from "./work-shapes";
+import { evaluateWorkroomShapeConformance } from "./workroom-shape-conformance";
+
+function participant(
+  principalRef: string,
+  roles: WorkroomParticipantRole[],
+  extras: Partial<WorkroomParticipantView> = {},
+): WorkroomParticipantView {
+  return {
+    principalRef,
+    displayName: principalRef,
+    kind: extras.kind ?? "person",
+    roles,
+    workState: "unknown",
+    presence: "unknown",
+    currentWorkSummary: null,
+    enteredReason: null,
+    sponsorPrincipalRef: null,
+    authoritySummary: "",
+    sourceRefs: [],
+    assignmentSource: extras.assignmentSource ?? "explicit",
+    coordinatorSource: extras.coordinatorSource ?? (roles.includes("coordinator") ? "explicit" : "none"),
+    ...extras,
+  };
+}
+
+const definition: WorkShapeDefinitionContract = {
+  key: "obligation-assurance-watch",
+  version: "1.0.0",
+  triggers: ["cadence"],
+  stages: [
+    { key: "scan", title: "Scan", accountablePrincipalRef: "agent:watcher", advance: { kind: "status-change", condition: "scanned" }, evidence: ["findings"] },
+    { key: "review", title: "Review", accountablePrincipalRef: "person:owner", advance: { kind: "governed-decision", condition: "accepted", decisionScope: "wwmd" }, evidence: ["decision"] },
+  ],
+  stopConditions: [
+    { kind: "success", condition: "findings dispositioned" },
+    { kind: "failure", condition: "scan failed" },
+    { kind: "budget", condition: "findings-per-run exhausted" },
+  ],
+  grants: ["tool:read"],
+  measures: [{ key: "findings-raised", description: "Findings raised this run" }],
+  budgets: [{ kind: "findings-per-run", limit: 200, unit: "findings" }],
+  reviewPoint: { everyDays: 7, description: "Weekly review" },
+};
+
+const executableRoster = [
+  participant("PRN-COORD", ["coordinator"], { kind: "agent", coordinatorSource: "explicit" }),
+  participant("PRN-OWNER", ["accountable"]),
+  participant("PRN-REVIEWER", ["reviewer"]),
+];
+
+describe("evaluateWorkroomShapeConformance (BI-3913EB49)", () => {
+  it("continues when one explicit Process Overseer is present and the stage is in order", () => {
+    const result = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: "craft-stewardship",
+      participants: executableRoster,
+      currentStageKey: "scan",
+      proposedStageKey: "review",
+      receipts: [{ stageKey: "scan", kind: "findings" }],
+      budgetUsage: [{ kind: "findings-per-run", used: 3 }],
+      stopConditionHits: [],
+      reviewDue: false,
+      coordinatorHasProcessCoordinationAuthority: true,
+    });
+    expect(result.disposition).toBe("continue");
+    expect(result.processOverseerSource).toBe("explicit");
+    expect(result.processOverseerPrincipalRef).toBe("PRN-COORD");
+    expect(result.deviations).toEqual([]);
+    expect(result.shapeKey).toBe("obligation-assurance-watch");
+    expect(result.shapeVersion).toBe("1.0.0");
+  });
+
+  it("refuses executable rooms with no coordinator", () => {
+    const result = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: [participant("PRN-OWNER", ["accountable"])],
+      currentStageKey: null,
+      proposedStageKey: "scan",
+      receipts: [],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+    });
+    expect(result.deviations.map((row) => row.code)).toContain("missing_explicit_coordinator");
+    expect(result.processOverseerSource).toBe("none");
+    expect(result.disposition).toBe("pause");
+  });
+
+  it("refuses a derived-only coordinator", () => {
+    const derived = deriveRoomCoordinator([
+      participant("PRN-OWNER", ["accountable"], { assignmentSource: "legacy", coordinatorSource: "none" }),
+    ]);
+    const result = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: derived,
+      currentStageKey: null,
+      proposedStageKey: "scan",
+      receipts: [],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+    });
+    expect(result.processOverseerSource).toBe("derived");
+    expect(result.deviations.map((row) => row.code)).toEqual(["derived_coordinator_only"]);
+    expect(result.disposition).toBe("pause");
+  });
+
+  it("escalates when more than one coordinator is named", () => {
+    const result = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: [
+        participant("PRN-A", ["coordinator"]),
+        participant("PRN-B", ["coordinator"]),
+      ],
+      currentStageKey: null,
+      proposedStageKey: "scan",
+      receipts: [],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+    });
+    expect(result.deviations.map((row) => row.code)).toEqual(["multiple_coordinators"]);
+    expect(result.disposition).toBe("escalate");
+  });
+
+  it("escalates when the overseer lacks process-coordination authority", () => {
+    const result = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: executableRoster,
+      currentStageKey: "scan",
+      proposedStageKey: "review",
+      receipts: [{ stageKey: "scan", kind: "findings" }],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+      coordinatorHasProcessCoordinationAuthority: false,
+    });
+    expect(result.deviations.map((row) => row.code)).toContain("coordinator_lacks_authority");
+    expect(result.disposition).toBe("escalate");
+  });
+
+  it("records missing required participants, skipped stages, and missing receipts", () => {
+    const result = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: executableRoster,
+      currentStageKey: null,
+      proposedStageKey: "review",
+      receipts: [],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+      requiredRoles: ["approver"],
+      coordinatorHasProcessCoordinationAuthority: true,
+    });
+    expect(result.deviations.map((row) => row.code)).toEqual(
+      expect.arrayContaining([
+        "missing_required_participant",
+        "missing_prerequisite_receipt",
+      ]),
+    );
+    expect(result.disposition).toBe("pause");
+  });
+
+  it("stops on exhausted budget or a hit stop condition", () => {
+    const budget = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: executableRoster,
+      currentStageKey: "scan",
+      proposedStageKey: "review",
+      receipts: [{ stageKey: "scan", kind: "findings" }],
+      budgetUsage: [{ kind: "findings-per-run", used: 200 }],
+      stopConditionHits: [],
+      reviewDue: false,
+      coordinatorHasProcessCoordinationAuthority: true,
+    });
+    expect(budget.deviations.map((row) => row.code)).toContain("budget_exhausted");
+    expect(budget.disposition).toBe("stop");
+
+    const stopped = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: executableRoster,
+      currentStageKey: "scan",
+      proposedStageKey: "review",
+      receipts: [{ stageKey: "scan", kind: "findings" }],
+      budgetUsage: [],
+      stopConditionHits: ["failure"],
+      reviewDue: false,
+      coordinatorHasProcessCoordinationAuthority: true,
+    });
+    expect(stopped.deviations.map((row) => row.code)).toContain("stop_condition_met");
+    expect(stopped.disposition).toBe("stop");
+  });
+
+  it("pauses when the review point is due and refuses authority widening", () => {
+    const result = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: executableRoster,
+      currentStageKey: "scan",
+      proposedStageKey: "review",
+      receipts: [{ stageKey: "scan", kind: "findings" }],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: true,
+      proposedGrants: ["tool:read", "tool:write"],
+      coordinatorHasProcessCoordinationAuthority: true,
+    });
+    expect(result.deviations.map((row) => row.code)).toEqual(
+      expect.arrayContaining(["review_due", "authority_widening"]),
+    );
+    expect(result.disposition).toBe("escalate");
+  });
+
+  it("escalates coordinator overlap with an independent evaluator or approver", () => {
+    const result = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: executableRoster,
+      currentStageKey: "scan",
+      proposedStageKey: "review",
+      receipts: [{ stageKey: "scan", kind: "findings" }],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+      coordinatorHasProcessCoordinationAuthority: true,
+      independentEvaluatorPrincipalRef: "PRN-COORD",
+      independentApproverPrincipalRef: "PRN-COORD",
+    });
+    expect(result.deviations.map((row) => row.code)).toEqual(
+      expect.arrayContaining(["coordinator_evaluator_overlap", "coordinator_approver_overlap"]),
+    );
+    expect(result.disposition).toBe("escalate");
+  });
+
+  it("refuses close while a deviation is unresolved", () => {
+    const result = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: executableRoster,
+      currentStageKey: "review",
+      proposedStageKey: null,
+      receipts: [{ stageKey: "scan", kind: "findings" }, { stageKey: "review", kind: "decision" }],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+      coordinatorHasProcessCoordinationAuthority: true,
+      closing: true,
+      unresolvedDeviationCount: 1,
+    });
+    expect(result.deviations.map((row) => row.code)).toContain("unresolved_deviation_on_close");
+    expect(result.disposition).toBe("stop");
+  });
+
+  it("is idempotent: the same observation yields one disposition", () => {
+    const input = {
+      definition,
+      collaborationShape: "craft-stewardship" as const,
+      participants: executableRoster,
+      currentStageKey: "scan",
+      proposedStageKey: "review",
+      receipts: [{ stageKey: "scan", kind: "findings" }],
+      budgetUsage: [{ kind: "findings-per-run", used: 1 }],
+      stopConditionHits: [] as string[],
+      reviewDue: false,
+      coordinatorHasProcessCoordinationAuthority: true,
+    };
+    expect(evaluateWorkroomShapeConformance(input)).toEqual(evaluateWorkroomShapeConformance(input));
+  });
+});

--- a/apps/web/lib/work-management/workroom-shape-conformance.ts
+++ b/apps/web/lib/work-management/workroom-shape-conformance.ts
@@ -1,0 +1,282 @@
+/**
+ * Workroom shape conformance — the Process Overseer projection (BI-3913EB49).
+ *
+ * Pure declared-versus-observed result. Dispatch remains default-off in this
+ * slice: callers consume the projection at convene, before/after a stage,
+ * review, and close. Never invents occupants, skips stages, or widens grants.
+ */
+import {
+  selectExplicitRoomCoordinator,
+  selectRoomCoordinator,
+  WorkroomParticipantError,
+} from "./room-coordinator";
+import type { WorkroomParticipantRole, WorkroomParticipantView } from "./room-types";
+import type { WorkShapeDefinitionContract } from "./work-shapes";
+
+export const WORKROOM_SHAPE_CONFORMANCE_DEVIATIONS = [
+  "missing_explicit_coordinator",
+  "derived_coordinator_only",
+  "multiple_coordinators",
+  "coordinator_lacks_authority",
+  "missing_required_participant",
+  "out_of_order_stage",
+  "missing_prerequisite_receipt",
+  "budget_exhausted",
+  "stop_condition_met",
+  "review_due",
+  "authority_widening",
+  "coordinator_evaluator_overlap",
+  "coordinator_approver_overlap",
+  "unresolved_deviation_on_close",
+] as const;
+
+export type WorkroomShapeConformanceDeviationCode =
+  (typeof WORKROOM_SHAPE_CONFORMANCE_DEVIATIONS)[number];
+
+export type WorkroomShapeConformanceDisposition =
+  | "continue"
+  | "pause"
+  | "escalate"
+  | "stop";
+
+export type WorkroomShapeConformanceDeviation = {
+  code: WorkroomShapeConformanceDeviationCode;
+  summary: string;
+};
+
+export type WorkroomShapeConformance = {
+  shapeKey: string;
+  shapeVersion: string;
+  collaborationShape: string | null;
+  processOverseerPrincipalRef: string | null;
+  processOverseerSource: "explicit" | "derived" | "none";
+  currentStageKey: string | null;
+  nextPermittedStageKey: string | null;
+  deviations: WorkroomShapeConformanceDeviation[];
+  disposition: WorkroomShapeConformanceDisposition;
+};
+
+export type WorkroomShapeConformanceInput = {
+  definition: WorkShapeDefinitionContract;
+  collaborationShape: string | null;
+  participants: readonly WorkroomParticipantView[];
+  currentStageKey: string | null;
+  proposedStageKey: string | null;
+  receipts: readonly { stageKey: string; kind: string }[];
+  budgetUsage: readonly { kind: string; used: number }[];
+  stopConditionHits: readonly string[];
+  reviewDue: boolean;
+  proposedGrants?: readonly string[];
+  coordinatorHasProcessCoordinationAuthority?: boolean;
+  independentEvaluatorPrincipalRef?: string | null;
+  independentApproverPrincipalRef?: string | null;
+  closing?: boolean;
+  unresolvedDeviationCount?: number;
+  requiredRoles?: readonly WorkroomParticipantRole[];
+};
+
+function stageIndex(definition: WorkShapeDefinitionContract, key: string | null): number {
+  if (!key) return -1;
+  return definition.stages.findIndex((stage) => stage.key === key);
+}
+
+function uniqueRoles(participants: readonly WorkroomParticipantView[]): Set<WorkroomParticipantRole> {
+  const roles = new Set<WorkroomParticipantRole>();
+  for (const participant of participants) {
+    for (const role of participant.roles) roles.add(role);
+  }
+  return roles;
+}
+
+export function evaluateWorkroomShapeConformance(
+  input: WorkroomShapeConformanceInput,
+): WorkroomShapeConformance {
+  const deviations: WorkroomShapeConformanceDeviation[] = [];
+  let processOverseerSource: "explicit" | "derived" | "none" = "none";
+  let processOverseerPrincipalRef: string | null = null;
+
+  try {
+    const named = selectRoomCoordinator(input.participants);
+    const explicit = selectExplicitRoomCoordinator(input.participants);
+    if (explicit) {
+      processOverseerPrincipalRef = explicit.principalRef;
+      processOverseerSource = "explicit";
+    } else if (named?.coordinatorSource === "derived") {
+      processOverseerPrincipalRef = named.principalRef;
+      processOverseerSource = "derived";
+      deviations.push({
+        code: "derived_coordinator_only",
+        summary: "A derived coordinator may explain the room but does not qualify it for execution.",
+      });
+    } else {
+      deviations.push({
+        code: "missing_explicit_coordinator",
+        summary: "An executable room requires exactly one explicit Process Overseer.",
+      });
+    }
+  } catch (error) {
+    if (error instanceof WorkroomParticipantError && error.reason === "multiple_active_coordinators") {
+      deviations.push({
+        code: "multiple_coordinators",
+        summary: "A Work Room can have only one active Process Overseer.",
+      });
+    } else {
+      throw error;
+    }
+  }
+
+  if (
+    processOverseerSource === "explicit" &&
+    input.coordinatorHasProcessCoordinationAuthority === false
+  ) {
+    deviations.push({
+      code: "coordinator_lacks_authority",
+      summary: "The Process Overseer lacks current process-coordination authority.",
+    });
+  }
+
+  if (
+    processOverseerPrincipalRef &&
+    input.independentEvaluatorPrincipalRef &&
+    processOverseerPrincipalRef === input.independentEvaluatorPrincipalRef
+  ) {
+    deviations.push({
+      code: "coordinator_evaluator_overlap",
+      summary: "The Process Overseer cannot also be the independent evaluator.",
+    });
+  }
+
+  if (
+    processOverseerPrincipalRef &&
+    input.independentApproverPrincipalRef &&
+    processOverseerPrincipalRef === input.independentApproverPrincipalRef
+  ) {
+    deviations.push({
+      code: "coordinator_approver_overlap",
+      summary: "The Process Overseer cannot also be the independent approver.",
+    });
+  }
+
+  const presentRoles = uniqueRoles(input.participants);
+  for (const role of input.requiredRoles ?? []) {
+    if (!presentRoles.has(role)) {
+      deviations.push({
+        code: "missing_required_participant",
+        summary: `Required participant role ${role} is not assigned.`,
+      });
+    }
+  }
+
+  const currentIndex = stageIndex(input.definition, input.currentStageKey);
+  const proposedIndex = stageIndex(input.definition, input.proposedStageKey);
+  if (input.proposedStageKey && proposedIndex < 0) {
+    deviations.push({
+      code: "out_of_order_stage",
+      summary: `Proposed stage ${input.proposedStageKey} is not on the declared shape.`,
+    });
+  } else if (
+    input.proposedStageKey &&
+    input.currentStageKey &&
+    proposedIndex > currentIndex + 1
+  ) {
+    deviations.push({
+      code: "out_of_order_stage",
+      summary: `Stage ${input.proposedStageKey} skips ahead of ${input.currentStageKey}.`,
+    });
+  }
+
+  if (proposedIndex > 0) {
+    const prior = input.definition.stages[proposedIndex - 1];
+    const hasReceipt = input.receipts.some((receipt) => receipt.stageKey === prior.key);
+    if (!hasReceipt) {
+      deviations.push({
+        code: "missing_prerequisite_receipt",
+        summary: `Stage ${input.proposedStageKey} lacks a receipt from ${prior.key}.`,
+      });
+    }
+  }
+
+  for (const budget of input.definition.budgets) {
+    const used = input.budgetUsage.find((entry) => entry.kind === budget.kind)?.used ?? 0;
+    if (used >= budget.limit) {
+      deviations.push({
+        code: "budget_exhausted",
+        summary: `Budget ${budget.kind} is exhausted (${used}/${budget.limit} ${budget.unit}).`,
+      });
+    }
+  }
+
+  if (input.stopConditionHits.length > 0) {
+    deviations.push({
+      code: "stop_condition_met",
+      summary: `Declared stop condition hit: ${input.stopConditionHits.join(", ")}.`,
+    });
+  }
+
+  if (input.reviewDue) {
+    deviations.push({
+      code: "review_due",
+      summary: "The shape's review point is due.",
+    });
+  }
+
+  const allowed = new Set(input.definition.grants);
+  for (const grant of input.proposedGrants ?? []) {
+    if (!allowed.has(grant)) {
+      deviations.push({
+        code: "authority_widening",
+        summary: `Proposed grant ${grant} is outside the declared shape grants.`,
+      });
+    }
+  }
+
+  if (input.closing && (input.unresolvedDeviationCount ?? deviations.length) > 0) {
+    deviations.push({
+      code: "unresolved_deviation_on_close",
+      summary: "Closure is refused while a deviation is missing from the outcome packet.",
+    });
+  }
+
+  const blocking = deviations.some((deviation) =>
+    deviation.code === "stop_condition_met" ||
+    deviation.code === "budget_exhausted" ||
+    deviation.code === "unresolved_deviation_on_close",
+  );
+  const escalate = deviations.some((deviation) =>
+    deviation.code === "authority_widening" ||
+    deviation.code === "coordinator_lacks_authority" ||
+    deviation.code === "coordinator_evaluator_overlap" ||
+    deviation.code === "coordinator_approver_overlap" ||
+    deviation.code === "multiple_coordinators",
+  );
+  const pause = deviations.length > 0;
+
+  let nextPermittedStageKey: string | null = null;
+  if (!pause && input.definition.stages.length > 0) {
+    if (!input.currentStageKey) {
+      nextPermittedStageKey = input.definition.stages[0]?.key ?? null;
+    } else if (currentIndex >= 0 && currentIndex + 1 < input.definition.stages.length) {
+      nextPermittedStageKey = input.definition.stages[currentIndex + 1]?.key ?? null;
+    }
+  }
+
+  const disposition: WorkroomShapeConformanceDisposition = blocking
+    ? "stop"
+    : escalate
+      ? "escalate"
+      : pause
+        ? "pause"
+        : "continue";
+
+  return {
+    shapeKey: input.definition.key,
+    shapeVersion: input.definition.version,
+    collaborationShape: input.collaborationShape,
+    processOverseerPrincipalRef,
+    processOverseerSource,
+    currentStageKey: input.currentStageKey,
+    nextPermittedStageKey: disposition === "continue" ? (input.proposedStageKey ?? nextPermittedStageKey) : nextPermittedStageKey,
+    deviations,
+    disposition,
+  };
+}


### PR DESCRIPTION
## Summary

Add the Process Overseer shape-conformance projection (BI-3913EB49).

- Pure declared-versus-observed result over `WorkShapeDefinitionContract` and the persisted roster.
- Executable rooms require exactly one explicit Process Overseer. Derived coordinators pause.
- Typed deviations: missing coordinator, missing participant, out-of-order stage, missing receipt, exhausted budget, stop condition, review due, grant widening, evaluator/approver overlap, unresolved deviation on close.
- Disposition is continue / pause / escalate / stop. Dispatch remains default-off.

## Design grounding

- Specs/plans: `docs/superpowers/specs/2026-08-29-proactive-workrooms-design.md`, `docs/superpowers/plans/2026-08-29-proactive-workrooms.md`, `docs/superpowers/plans/2026-08-30-paaw-competence-evolution-workroom-plan.md`
- Substrate: `selectExplicitRoomCoordinator`, `WorkShapeDefinitionContract`, `WorkroomParticipantView`
- Source of truth: one conformance projection; no second roster or definition table
- Decision: consume persisted explicit coordinator rather than infer occupants

## Docs impact

No user-facing surface. Process Overseer UX is Phase G.

## Test plan

- [x] 11 Vitest conformance cases
- [x] pregate:preflight
- [x] local-CI PASS 83705f58ecc8
- [ ] pnpm pr:health after cloud checks

Workroom: WC-AF69B124
