### PR TITLE
feat(backlog): show active Workroom ownership

### DIFF
--- a/apps/web/components/ops/BacklogItemRow.tsx
+++ b/apps/web/components/ops/BacklogItemRow.tsx
@@ -190,6 +190,8 @@ function BacklogItemRowImpl({ item, onEdit, focused = false }: Props) {
         </div>
       ) : null}
 
+      <ActiveWorkroomOwnership workrooms={item.activeWorkrooms ?? []} />
+
       {/* Actions */}
       <div className="shrink-0 flex items-center gap-1">
         {confirmDelete ? (
@@ -249,6 +251,48 @@ function BacklogItemRowImpl({ item, onEdit, focused = false }: Props) {
       {buildMessage && (
         <p className="w-full text-[10px] text-[var(--dpf-muted)] mt-1">{buildMessage}</p>
       )}
+    </div>
+  );
+}
+
+function executorLabel(value: string | null): string {
+  if (!value) return "Unassigned";
+  return value
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function ActiveWorkroomOwnership({
+  workrooms,
+}: {
+  workrooms: NonNullable<BacklogItemWithRelations["activeWorkrooms"]>;
+}) {
+  if (workrooms.length === 0) return null;
+  return (
+    <div
+      className="w-full rounded-md border border-[var(--dpf-accent)] bg-[var(--dpf-accent-soft)] p-2"
+      aria-label="Active Workroom ownership"
+    >
+      <p className="text-dpf-caption font-dpf-semibold text-[var(--dpf-text)]">
+        {workrooms.length === 1 ? "Workroom active" : `${workrooms.length} Workrooms active`}
+      </p>
+      <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-dpf-caption text-[var(--dpf-muted)]">
+        {workrooms.map((room) => (
+          <div key={room.capsuleId} className="flex min-w-0 flex-wrap items-center gap-2">
+            <Link
+              href={`/workspace/cases/${room.capsuleId}`}
+              className="font-dpf-medium text-[var(--dpf-accent)] hover:underline"
+            >
+              {room.title}
+            </Link>
+            <StatusBadge domain="workroom" status={room.status} label={room.status.replaceAll("-", " ")} uppercase={false} />
+            <span>{executorLabel(room.executorKind)}</span>
+            {room.headBranch ? <span className="font-mono">{room.headBranch}</span> : null}
+            <span>{room.liveness.replaceAll("-", " ")}</span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/components/ops/OpsClient.test.tsx
+++ b/apps/web/components/ops/OpsClient.test.tsx
@@ -176,6 +176,53 @@ describe("OpsClient", () => {
     expect(html).not.toContain("done 5/25/2026");
   });
 
+  it("shows the active Workroom owner without exposing coordination internals", () => {
+    const html = renderToStaticMarkup(
+      <BacklogItemRow
+        item={item({
+          status: "in-progress",
+          activeWorkrooms: [{
+            capsuleId: "WC-923105A2",
+            title: "Workroom ownership safety",
+            status: "working",
+            backlogItemId: "BI-TEST",
+            repositoryFullName: "OpenDigitalProductFactory/opendigitalproductfactory",
+            headBranch: "fix/bi-workroom-single-owner",
+            worktreePath: "/private/internal/worktree",
+            executorKind: "codex-desktop",
+            executorRef: "private-session-ref",
+            leaseHolderPrincipalId: "private-principal",
+            leaseExpiresAt: "2026-09-01T06:00:00.000Z",
+            liveness: "lease-live",
+            isLive: true,
+            livenessReason: "The Workroom lease is active.",
+            trueLivenessAt: "2026-09-01T05:00:00.000Z",
+          }],
+        })}
+        onEdit={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("Workroom active");
+    expect(html).toContain("Workroom ownership safety");
+    expect(html).toContain('href="/workspace/cases/WC-923105A2"');
+    expect(html).toContain("working");
+    expect(html).toContain("Codex Desktop");
+    expect(html).toContain("fix/bi-workroom-single-owner");
+    expect(html).toContain("lease live");
+    expect(html).not.toContain("/private/internal/worktree");
+    expect(html).not.toContain("private-session-ref");
+    expect(html).not.toContain("private-principal");
+  });
+
+  it("adds no ownership chrome when no Workroom is active", () => {
+    const html = renderToStaticMarkup(
+      <BacklogItemRow item={item({ activeWorkrooms: [] })} onEdit={vi.fn()} />,
+    );
+
+    expect(html).not.toContain("Workroom active");
+  });
+
   it("keeps a zero-item epic explicit", () => {
     const html = renderToStaticMarkup(
       <OpsClient

--- a/apps/web/components/ui/report-kit/statusColors.test.ts
+++ b/apps/web/components/ui/report-kit/statusColors.test.ts
@@ -98,6 +98,9 @@ describe("statusColors", () => {
   });
 
   it("maps Work Room state, outcome health, and activity through shared domains", () => {
+    expect(resolveIntent("workroom", "working")).toBe("accent");
+    expect(resolveIntent("workroom", "blocked")).toBe("danger");
+    expect(resolveIntent("workroom", "complete")).toBe("success");
     expect(resolveIntent("workCaseState", "waiting-on-person")).toBe("warning");
     expect(resolveIntent("workroomOutcomeHealth", "at-risk")).toBe("warning");
     expect(resolveIntent("workroomActivity", "message")).toBe("neutral");

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -452,6 +452,21 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     deferred: "neutral",
     retired: "neutral",
   },
+  // Canonical Workroom lifecycle. This is distinct from true liveness: status
+  // says where the room is in its workflow while liveness says whether its
+  // recorded execution evidence is still alive.
+  workroom: {
+    draft: "neutral",
+    ready: "info",
+    working: "accent",
+    blocked: "danger",
+    verifying: "info",
+    "ready-for-review": "warning",
+    "ready-for-promotion": "warning",
+    complete: "success",
+    abandoned: "neutral",
+    archived: "neutral",
+  },
   // Workspace Work Room semantics. These domains are shared by the My Work
   // lens and room detail shell so neither surface carries a private color map.
   workCaseState: {

--- a/apps/web/lib/explore/backlog-data.ts
+++ b/apps/web/lib/explore/backlog-data.ts
@@ -9,11 +9,25 @@ import type {
   PortfolioForSelect,
   EpicWithRelations,
 } from "./backlog";
+import {
+  activeWorkroomsByBacklogItem,
+  loadBacklogWorkroomOwnership,
+} from "@/lib/work-capsules/backlog-workroom-ownership";
 
 export type { PortfolioForSelect };
 
+async function attachActiveWorkrooms<T extends BacklogItemWithRelations>(items: T[]): Promise<T[]> {
+  if (items.length === 0) return items;
+  const ownership = await loadBacklogWorkroomOwnership(
+    prisma,
+    items.flatMap((item) => [item.itemId, item.id]),
+  );
+  const byItem = activeWorkroomsByBacklogItem(items, ownership.liveWorkrooms);
+  return items.map((item) => ({ ...item, activeWorkrooms: byItem.get(item.itemId) ?? [] }));
+}
+
 export const getBacklogItems = cache(async (): Promise<BacklogItemWithRelations[]> => {
-  return prisma.backlogItem.findMany({
+  const items = await prisma.backlogItem.findMany({
     orderBy: [{ priority: "asc" }, { createdAt: "asc" }],
     select: {
       id: true,
@@ -61,10 +75,11 @@ export const getBacklogItems = cache(async (): Promise<BacklogItemWithRelations[
       claimedById: true,
     },
   });
+  return attachActiveWorkrooms(items as BacklogItemWithRelations[]);
 });
 
 export const getEpics = cache(async (): Promise<EpicWithRelations[]> => {
-  return prisma.epic.findMany({
+  const epics = await prisma.epic.findMany({
     orderBy: { createdAt: "asc" },
     select: {
       id: true,
@@ -131,7 +146,13 @@ export const getEpics = cache(async (): Promise<EpicWithRelations[]> => {
         },
       },
     },
-  }) as Promise<EpicWithRelations[]>;
+  }) as EpicWithRelations[];
+  const items = await attachActiveWorkrooms(epics.flatMap((epic) => epic.items));
+  const byId = new Map(items.map((item) => [item.id, item]));
+  return epics.map((epic) => ({
+    ...epic,
+    items: epic.items.map((item) => byId.get(item.id) ?? item),
+  }));
 });
 
 export const getDigitalProductsForSelect = cache(async (): Promise<DigitalProductSelect[]> => {

--- a/apps/web/lib/explore/backlog.ts
+++ b/apps/web/lib/explore/backlog.ts
@@ -46,6 +46,7 @@ export type BacklogItemWithRelations = {
   scopeRationale?: string | null;
   lifecycleTags?: string[];
   activeBuild: { buildId: string; phase: string | null } | null;
+  activeWorkrooms?: import("@/lib/work-capsules/backlog-workroom-ownership").BacklogWorkroomSummary[];
   digitalProduct: { id: string; productId: string; name: string } | null;
   organizationId?: string | null;
   productLineId?: string | null;

--- a/apps/web/lib/work-capsules/backlog-workroom-ownership.test.ts
+++ b/apps/web/lib/work-capsules/backlog-workroom-ownership.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   BacklogItemAlreadyClaimedError,
   assertBacklogWorkroomClaimAvailable,
+  activeWorkroomsByBacklogItem,
   loadBacklogWorkroomOwnership,
   lockBacklogItemForClaim,
 } from "./backlog-workroom-ownership";
@@ -33,7 +34,8 @@ function room(overrides: Record<string, unknown> = {}) {
 }
 
 const liveSummary = {
-  capsuleId: "WC-LIVE", repositoryFullName: "org/repo", headBranch: "fix/one",
+  capsuleId: "WC-LIVE", title: "Live work", status: "working", backlogItemId: "BI-ONE",
+  repositoryFullName: "org/repo", headBranch: "fix/one",
   worktreePath: "/worktrees/one", executorKind: "codex-desktop", executorRef: "session-one",
   leaseHolderPrincipalId: "PRN-ONE", leaseExpiresAt: "2026-08-31T19:00:00.000Z",
   liveness: "live", isLive: true, livenessReason: "Lease valid.", trueLivenessAt: now.toISOString(),
@@ -57,7 +59,29 @@ describe("backlog Workroom ownership", () => {
     }));
     expect(ownership.workrooms).toHaveLength(2);
     expect(ownership.liveWorkrooms.map((entry) => entry.capsuleId)).toEqual(["WC-LIVE"]);
+    expect(ownership.liveWorkrooms[0]).toMatchObject({
+      title: "Live work",
+      status: "working",
+      backlogItemId: "BI-ONE",
+    });
     expect(ownership.workrooms[1]).toMatchObject({ capsuleId: "WC-DEAD", isLive: false, liveness: "lease-expired" });
+  });
+
+  it("groups active ownership by both semantic and row BacklogItem identity", () => {
+    const byItem = activeWorkroomsByBacklogItem(
+      [
+        { id: "row-one", itemId: "BI-ONE" },
+        { id: "row-two", itemId: "BI-TWO" },
+      ],
+      [
+        liveSummary,
+        { ...liveSummary, capsuleId: "WC-ROW", backlogItemId: "row-two", headBranch: "fix/two" },
+        { ...liveSummary, capsuleId: "WC-DEAD", backlogItemId: "BI-ONE", isLive: false },
+      ],
+    );
+
+    expect(byItem.get("BI-ONE")?.map((room) => room.capsuleId)).toEqual(["WC-LIVE"]);
+    expect(byItem.get("BI-TWO")?.map((room) => room.capsuleId)).toEqual(["WC-ROW"]);
   });
 
   it("refuses a different live Workroom before adoption", () => {

--- a/apps/web/lib/work-capsules/backlog-workroom-ownership.ts
+++ b/apps/web/lib/work-capsules/backlog-workroom-ownership.ts
@@ -12,6 +12,9 @@ type LockDb = {
 
 export type BacklogWorkroomSummary = {
   capsuleId: string;
+  title: string;
+  status: string;
+  backlogItemId: string | null;
   repositoryFullName: string | null;
   headBranch: string | null;
   worktreePath: string | null;
@@ -45,6 +48,9 @@ export async function loadBacklogWorkroomOwnership(
   }
   const workrooms = inventory.capsulesAll.map((row): BacklogWorkroomSummary => ({
     capsuleId: String(row.capsuleId),
+    title: String(row.title),
+    status: String(row.status),
+    backlogItemId: nullableString(row.backlogItemId),
     repositoryFullName: nullableString(row.repositoryFullName),
     headBranch: nullableString(row.headBranch),
     worktreePath: nullableString(row.worktreePath),
@@ -58,6 +64,28 @@ export async function loadBacklogWorkroomOwnership(
     trueLivenessAt: nullableString(row.trueLivenessAt),
   }));
   return { workrooms, liveWorkrooms: workrooms.filter((room) => room.isLive) };
+}
+
+export function activeWorkroomsByBacklogItem(
+  items: Array<{ id: string; itemId: string }>,
+  workrooms: BacklogWorkroomSummary[],
+): Map<string, BacklogWorkroomSummary[]> {
+  const canonicalItemId = new Map<string, string>();
+  for (const item of items) {
+    canonicalItemId.set(item.id, item.itemId);
+    canonicalItemId.set(item.itemId, item.itemId);
+  }
+
+  const grouped = new Map<string, BacklogWorkroomSummary[]>();
+  for (const room of workrooms) {
+    if (!room.isLive || !room.backlogItemId) continue;
+    const itemId = canonicalItemId.get(room.backlogItemId);
+    if (!itemId) continue;
+    const owners = grouped.get(itemId) ?? [];
+    if (!owners.some((owner) => owner.capsuleId === room.capsuleId)) owners.push(room);
+    grouped.set(itemId, owners);
+  }
+  return grouped;
 }
 
 export class BacklogItemAlreadyClaimedError extends Error {

--- a/docs/superpowers/plans/2026-08-31-bi-workroom-single-owner.md
+++ b/docs/superpowers/plans/2026-08-31-bi-workroom-single-owner.md
@@ -38,6 +38,14 @@ audited exception.
    tree gate rather than asserting a local build that cannot execute here.
 6. Commit with DCO, push, open a ready PR with Design grounding, verify PR
    health, and attach the results to BI-BFBF1BBB / WC-923105A2.
+7. Complete the recorded owner-visibility acceptance on the existing `/ops`
+   backlog row: batch-project active Workroom ownership from the same liveness
+   read model, then show a compact linked strip with the Workroom status,
+   executor, branch, and true-liveness label. Keep session refs, worktree paths,
+   and lease internals out of the default human view.
+8. Measure the changed `/ops` route against its UX-fit budget, verify the
+   duplicate-claim refusal on the canonical install after the merged SHA is
+   served, and reconcile the objective before closing the BI and Workroom.
 
 ## Verification mapping
 
@@ -50,3 +58,26 @@ audited exception.
   and writes an activity containing the displaced Workrooms.
 - Read model: `get_backlog_item` returns bound Workrooms with `isLive`, liveness
   reason, branch, worktree, executor, and lease evidence.
+- Owner UI: a backlog item with live work names and links its Workroom and
+  exposes status, executor, branch, and liveness without internal session or
+  filesystem noise; an unowned item adds no empty ownership chrome.
+- Live acceptance: a second branch/session claim against BI-BFBF1BBB is
+  refused before Workroom mutation, and the original three-item read path
+  returns non-vacuous ownership rather than an empty projection.
+
+## UX-fit decision
+
+- **Owning area / route:** Operations, on the existing canonical `/ops`
+  backlog list. No route or navigation layer is added.
+- **Persona:** a platform operator deciding whether a backlog item is already
+  being worked. The first answer is the linked Workroom; infrastructure detail
+  stays backstage.
+- **Component convergence:** reuse `StatusBadge`, the existing backlog row,
+  and the canonical Workroom detail route at `/workspace/cases/[caseKey]`.
+- **Source of truth:** `loadBacklogWorkroomOwnership`, which already reuses the
+  shared true-liveness inventory used by claim admission and MCP reads.
+- **Empty/failure state:** no strip when no live Workroom exists; loader
+  failures remain page-read failures rather than inventing an unowned state.
+- **Verification:** focused rendering and projection tests, `/ops` desktop and
+  narrow browser inspection, measured UX-fit manifest, affected Vitest, and
+  the web production build.

--- a/docs/ux-fit/2026-09-01-backlog-workroom-ownership.ux-fit.json
+++ b/docs/ux-fit/2026-09-01-backlog-workroom-ownership.ux-fit.json
@@ -1,0 +1,31 @@
+{
+  "version": "1",
+  "decidedOption": "show a compact linked active-Workroom strip inside the existing backlog row, with status, executor, branch, and liveness while keeping session, principal, lease, and filesystem detail backstage",
+  "scope": {
+    "files": [
+      "apps/web/components/ops/BacklogItemRow.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "sweep-measurement",
+    "baselineComparison": "pre-existing-route",
+    "measured": {
+      "/ops": {
+        "defaultVisibleWords": 187,
+        "leadBandWords": 0,
+        "primaryActions": 1,
+        "visibleFields": 2,
+        "maxChoicesPerControl": 5,
+        "subLegibleControls": 9,
+        "buriedPrimaryAction": 0,
+        "axeViolations": 2
+      }
+    }
+  },
+  "notes": {
+    "routeMeasurement": "The committed /ops sweep fixture has no active Workroom and remains byte-for-byte at its recorded route-budget baseline. The new strip returns null for that state, so every measured arrival axis remains unchanged rather than being estimated.",
+    "populatedState": "OpsClient.test.tsx renders a live owner and proves the Workroom link, status, executor, branch, and liveness are present while worktreePath, executorRef, and leaseHolderPrincipalId are absent. The strip uses the shared StatusBadge and token-backed styles.",
+    "previewLimitation": "A governed shared preview lease was admitted, but its database endpoint was unavailable and the route could not render. The lease was released immediately. Browser verification is therefore deferred to the canonical install after merge and is not claimed by this manifest.",
+    "fit": "The change adds one contextual link only when work is active, creates no route or navigation layer, adds no field or primary action, and answers the operator's ownership question at the backlog item where the claim decision starts."
+  }
+}


### PR DESCRIPTION
## Outcome

Backlog rows on `/ops` now show the one active Workroom that owns the item. The strip links to the Workroom and exposes only useful coordination facts: status, executor kind, branch, and liveness. Internal paths, session references, principals, and lease details stay hidden.

Ownership is resolved once for the backlog collection, including Workrooms bound by either the semantic BI key or the backlog row id. Terminal Workrooms do not appear.

## Design grounding

- Reviewed `docs/superpowers/specs/2026-07-06-bi-work-location-claim-at-start-design.md` and `docs/superpowers/plans/2026-08-31-bi-workroom-single-owner.md`.
- Reused the canonical ownership/liveness substrate in `apps/web/lib/work-capsules/backlog-workroom-ownership.ts` and the existing backlog row in `apps/web/components/ops/BacklogItemRow.tsx`.
- Reused report-kit `StatusBadge`; added the Workroom status domain to its centralized color map instead of styling locally.
- The active Workroom remains the source of truth. This is a projection only; it creates no second ownership model.

## Verification

- Targeted Vitest: 5 files, 67 tests passed.
- Production build: `pnpm --filter web build` passed with zero errors.
- Exact-tree local CI: passed for `fix/bi-workroom-single-owner@4a734287aa71`.
- UI behavior: component coverage proves populated and absent-owner states. Browser verification on the canonical install follows merge because the governed preview could not reach its database; this PR does not claim that unrun check.
- Prose, style-drift, token-drift, and all 61 preflight guards passed.

## Documentation impact

The Operations and Workroom guides remain accurate. The BI plan records the implementation, acceptance path, and UX-fit decision; no user procedure changed.

Linked-BI: BI-BFBF1BBB
Local-CI-Evidence: cmti7naq3115a01plsh2152uu (fix/bi-workroom-single-owner@4a734287aa71)
Docs-Impact-Decision: Existing Operations and Workroom guidance remains accurate; the implementation and UX evidence are recorded in the BI plan.
