### PR TITLE
fix(ai): make provider trust status actionable

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
@@ -223,6 +223,13 @@ export default async function ProviderDetailPage({ params }: Props) {
           />
           {trustEvidenceResolution && (
             <ProviderTrustEvidencePanel
+              accountDeclarationSaved={Boolean(
+                providerConnection?.lastReviewedAt
+                && providerConnection.entitlements
+                && typeof providerConnection.entitlements === "object"
+                && !Array.isArray(providerConnection.entitlements)
+                && ("noTraining" in providerConnection.entitlements || "enabledRegions" in providerConnection.entitlements)
+              )}
               evidenceStatus={trustEvidenceResolution.posture.evidenceStatus}
               lastReviewedAt={trustEvidenceResolution.posture.lastReviewedAt}
               claims={trustEvidenceResolution.claims}

--- a/apps/web/components/platform/ProviderAccountPostureForm.test.tsx
+++ b/apps/web/components/platform/ProviderAccountPostureForm.test.tsx
@@ -36,5 +36,8 @@ describe("ProviderAccountPostureForm", () => {
       <ProviderAccountPostureForm providerId="anthropic" canWrite initial={null} />,
     );
     expect(html).not.toContain("Bound the router before company data is used");
+    expect(html).not.toContain('placeholder="eu, uk"');
+    expect(html).toContain("No regions saved");
+    expect(html).toContain("Example: eu, uk");
   });
 });

--- a/apps/web/components/platform/ProviderAccountPostureForm.tsx
+++ b/apps/web/components/platform/ProviderAccountPostureForm.tsx
@@ -57,7 +57,10 @@ export function ProviderAccountPostureForm({
           </select>
         </label>
         <label className="text-xs text-[var(--dpf-muted)]">Enabled processing regions
-          <input className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[var(--dpf-text)]" value={regions} disabled={!canWrite || pending} placeholder="eu, uk" onChange={(event) => setRegions(event.target.value)} />
+          <input aria-describedby="enabled-regions-help" className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[var(--dpf-text)]" value={regions} disabled={!canWrite || pending} onChange={(event) => setRegions(event.target.value)} />
+          <span id="enabled-regions-help" className="mt-1 block">
+            {regions.trim() ? "Saved regions are shown above." : "No regions saved. Region-restricted work remains blocked."} Example: eu, uk.
+          </span>
         </label>
       </div>
       {providerId === "openrouter" && (

--- a/apps/web/components/platform/ProviderTrustEvidencePanel.test.tsx
+++ b/apps/web/components/platform/ProviderTrustEvidencePanel.test.tsx
@@ -7,8 +7,9 @@ import { ProviderTrustEvidencePanel } from "./ProviderTrustEvidencePanel";
 afterEach(cleanup);
 
 describe("ProviderTrustEvidencePanel", () => {
-  it("shows evidence state, age, expiry, and the safest next action in plain language", () => {
+  it("frames incomplete evidence as a restricted-work limitation, not a provider fault", () => {
     render(<ProviderTrustEvidencePanel
+      accountDeclarationSaved
       evidenceStatus="expired"
       lastReviewedAt="2026-06-20T09:00:00.000Z"
       claims={[
@@ -24,7 +25,9 @@ describe("ProviderTrustEvidencePanel", () => {
     />);
 
     expect(screen.getByRole("region", { name: "Provider trust evidence" })).toBeTruthy();
-    expect(screen.getByRole("status").textContent).toContain("Action needed");
+    expect(screen.getByRole("status").textContent).toContain("1 restriction");
+    expect(screen.getByText(/Account declaration saved/)).toBeTruthy();
+    expect(screen.getByText(/restricted work remains blocked/i)).toBeTruthy();
     expect(screen.getByText("No training on company data")).toBeTruthy();
     expect(screen.getByText(/30 days old/)).toBeTruthy();
     expect(screen.getByText(/Renew or replace/)).toBeTruthy();
@@ -32,6 +35,7 @@ describe("ProviderTrustEvidencePanel", () => {
 
   it("does not expose internal evidence ids and explains an empty state", () => {
     const { rerender } = render(<ProviderTrustEvidencePanel
+      accountDeclarationSaved
       evidenceStatus="contract-uploaded"
       lastReviewedAt="2026-07-20T09:00:00.000Z"
       claims={[{
@@ -47,7 +51,37 @@ describe("ProviderTrustEvidencePanel", () => {
     expect(document.body.textContent).not.toContain("sensitive-internal-evidence-id");
     expect(screen.getByRole("status").textContent).toContain("Current");
 
-    rerender(<ProviderTrustEvidencePanel evidenceStatus="unreviewed" lastReviewedAt={null} claims={[]} />);
+    rerender(<ProviderTrustEvidencePanel accountDeclarationSaved={false} evidenceStatus="unreviewed" lastReviewedAt={null} claims={[]} />);
     expect(screen.getByText(/No account-specific trust evidence is linked yet/)).toBeTruthy();
   });
+
+  it("names the available declaration action and the unavailable DPA workflow honestly", () => {
+    render(<ProviderTrustEvidencePanel
+      accountDeclarationSaved
+      evidenceStatus="operator-attested"
+      lastReviewedAt="2026-08-31T09:00:00.000Z"
+      claims={[
+        { claimKey: "enabled-regions", status: "missing", evidenceIds: [], evidenceAgeDays: null, expiresAt: null, nextAction: "Add evidence for this connected account." },
+        { claimKey: "dpa-on-file", status: "missing", evidenceIds: [], evidenceAgeDays: null, expiresAt: null, nextAction: "Add evidence for this connected account." },
+      ]}
+    />);
+
+    expect(screen.getByText(/Save the enabled regions in Connected account and data terms above/)).toBeTruthy();
+    expect(screen.getByText(/No DPA evidence workflow is available on this page/)).toBeTruthy();
+    expect(screen.getByText(/reviewed supplier contract/i)).toBeTruthy();
+  });
+
+  it.each(["missing", "expired", "rejected", "conflicting", "superseded"] as const)(
+    "keeps a next action visible for %s evidence",
+    (status) => {
+      const { unmount } = render(<ProviderTrustEvidencePanel
+        accountDeclarationSaved={false}
+        evidenceStatus="unreviewed"
+        lastReviewedAt={null}
+        claims={[{ claimKey: "soc2", status, evidenceIds: [], evidenceAgeDays: null, expiresAt: null, nextAction: `Resolve ${status} evidence.` }]}
+      />);
+      expect(screen.getByText(new RegExp(`Resolve ${status} evidence`))).toBeTruthy();
+      unmount();
+    },
+  );
 });

--- a/apps/web/components/platform/ProviderTrustEvidencePanel.tsx
+++ b/apps/web/components/platform/ProviderTrustEvidencePanel.tsx
@@ -35,16 +35,40 @@ function dateLabel(value: string): string {
   return new Intl.DateTimeFormat("en", { dateStyle: "medium", timeZone: "UTC" }).format(new Date(value));
 }
 
+const ACCOUNT_DECLARATION_CLAIMS = new Set<ProviderTrustClaimKey>([
+  "no-training",
+  "zero-retention",
+  "regional-processing",
+  "enabled-regions",
+  "approved-underlying-providers",
+]);
+
+function nextActionLabel(claim: ResolvedProviderTrustClaim): string {
+  if (claim.claimKey === "enabled-regions") {
+    return "Save the enabled regions in Connected account and data terms above. Leaving the field empty keeps region-restricted work blocked.";
+  }
+  if (claim.claimKey === "dpa-on-file") {
+    return "No DPA evidence workflow is available on this page. Restricted work stays blocked until platform governance links a reviewed supplier contract or current DPA evidence.";
+  }
+  if (ACCOUNT_DECLARATION_CLAIMS.has(claim.claimKey)) {
+    return `Update the matching declaration in Connected account and data terms above. ${claim.nextAction}`;
+  }
+  return `This page cannot change this evidence. Platform governance must resolve it. ${claim.nextAction}`;
+}
+
 export function ProviderTrustEvidencePanel({
+  accountDeclarationSaved,
   evidenceStatus,
   lastReviewedAt,
   claims,
 }: {
+  accountDeclarationSaved: boolean;
   evidenceStatus: ProviderConnectionPosture["evidenceStatus"];
   lastReviewedAt: string | null;
   claims: ResolvedProviderTrustClaim[];
 }) {
-  const actionNeeded = claims.length === 0 || claims.some((claim) => claim.status !== "valid");
+  const restrictedClaimCount = claims.filter((claim) => claim.status !== "valid").length;
+  const restrictedWorkLimited = claims.length === 0 || restrictedClaimCount > 0;
 
   return (
     <section
@@ -62,11 +86,24 @@ export function ProviderTrustEvidencePanel({
         </div>
         <span
           role="status"
-          className={`rounded-full px-2 py-1 text-xs font-semibold ${actionNeeded ? "bg-[var(--dpf-warning-soft)] text-[var(--dpf-warning)]" : "bg-[var(--dpf-success-soft)] text-[var(--dpf-success)]"}`}
+          className={`rounded-full px-2 py-1 text-xs font-semibold ${restrictedWorkLimited ? "bg-[var(--dpf-warning-soft)] text-[var(--dpf-warning)]" : "bg-[var(--dpf-success-soft)] text-[var(--dpf-success)]"}`}
         >
-          {actionNeeded ? "Action needed" : "Current"}
+          {claims.length === 0
+            ? "Restricted work not reviewed"
+            : restrictedClaimCount > 0
+              ? `${restrictedClaimCount} ${restrictedClaimCount === 1 ? "restriction" : "restrictions"} for restricted work`
+              : "Current for restricted work"}
         </span>
       </div>
+
+      <p className="mb-0 mt-3 text-xs font-medium text-[var(--dpf-text)]">
+        {accountDeclarationSaved && lastReviewedAt
+          ? `Account declaration saved · reviewed ${dateLabel(lastReviewedAt)}.`
+          : "Account declaration not yet saved."}
+        {restrictedWorkLimited
+          ? " General work is governed separately; sensitive or restricted work remains blocked until the evidence below is current."
+          : " The current evidence supports restricted-work evaluation; routing still applies each workload's policy."}
+      </p>
 
       {claims.length === 0 ? (
         <div className="mt-3 rounded border border-dashed border-[var(--dpf-border)] p-3 text-xs text-[var(--dpf-muted)]">
@@ -85,7 +122,7 @@ export function ProviderTrustEvidencePanel({
                 {claim.expiresAt ? ` · valid until ${dateLabel(claim.expiresAt)}` : ""}
               </p>
               {claim.status !== "valid" && (
-                <p className="mb-0 mt-1 text-xs font-medium text-[var(--dpf-text)]">Next: {claim.nextAction}</p>
+                <p className="mb-0 mt-1 text-xs font-medium text-[var(--dpf-text)]">Next: {nextActionLabel(claim)}</p>
               )}
             </li>
           ))}

--- a/docs/operations/provider-trust-evidence.md
+++ b/docs/operations/provider-trust-evidence.md
@@ -16,7 +16,7 @@ Never infer a BAA, DPA, zero-retention term, regional entitlement, administrativ
 
 1. Open **Platform → AI Operations → Providers & Routing** and select the configured provider.
 2. Confirm the connected account type and execution channel are correct.
-3. Review **Provider trust evidence**. It shows every evaluated claim's status, age, expiry, and next action.
+3. Review **Provider trust evidence**. The summary separates a saved account declaration from evidence needed only for sensitive or restricted work. It shows the number of restricted-work limitations plus every evaluated claim's status, age, expiry, consequence, and next action.
 4. For missing evidence, obtain and review evidence for this exact account or tenant.
 5. For expired evidence, renew or replace it. Do not extend the date without a current source.
 6. For rejected evidence, resolve the review finding before enabling restricted work.
@@ -25,6 +25,8 @@ Never infer a BAA, DPA, zero-retention term, regional entitlement, administrativ
 9. Reassess the intended workload. Public marketing work and regulated records are separate decisions; a failed restricted-work claim should not be turned into a provider-wide guess.
 
 Operator declarations made on the provider page are evidence-backed for 90 days, remain weaker than reviewed contract evidence, and never become a BAA, DPA, or enterprise entitlement by themselves.
+
+The provider page can update declaration-backed claims such as enabled processing regions. It cannot capture a DPA or other reviewed supplier evidence. When that workflow is unavailable, the page says so directly and keeps restricted work blocked until platform governance links the current evidence; a generic provider-health alarm is not used for that condition.
 
 ## Receipt privacy check
 

--- a/docs/superpowers/plans/2026-09-01-provider-trust-status-honesty-plan.md
+++ b/docs/superpowers/plans/2026-09-01-provider-trust-status-honesty-plan.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Provider trust status honesty implementation plan
 
 **Backlog:** BI-231CA01C  
@@ -10,6 +14,13 @@
 5. Run focused tests, typecheck/build gates, UX-fit review, exact-tree evidence, PR/merge queue, canonical self-upgrade, and live provider-page verification.
 
 No migration is required. Documentation impact is user-facing and is handled in the same change.
+
+## Design grounding
+
+- Existing specs/plans reviewed: `docs/superpowers/specs/2026-07-19-ai-provider-suitability-routing-design.md`, `docs/superpowers/plans/2026-07-19-ai-provider-suitability-routing.md`, and the provider-trust operations/user documentation.
+- Current code substrate reviewed: `apps/web/components/platform/ProviderTrustEvidencePanel.tsx`, `apps/web/components/platform/ProviderAccountPostureForm.tsx`, `apps/web/lib/routing/provider-suitability/evidence.ts`, and `apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx`.
+- Source of truth: `AiProviderConnection`, `SupplierContract`, `ComplianceEvidence`, and `resolveProviderTrustEvidence`; the page remains a projection only.
+- Decision: keep the canonical routing/evidence contract unchanged and correct only the existing provider-detail projection and guidance.
 
 ## UX fit review
 

--- a/docs/superpowers/plans/2026-09-01-provider-trust-status-honesty-plan.md
+++ b/docs/superpowers/plans/2026-09-01-provider-trust-status-honesty-plan.md
@@ -1,0 +1,27 @@
+# Provider trust status honesty implementation plan
+
+**Backlog:** BI-231CA01C  
+**Design:** `docs/superpowers/specs/2026-09-01-provider-trust-status-honesty-design.md`
+
+1. Add failing component tests for the restricted-work summary, declaration acknowledgement, honest claim-specific next actions, all evidence states, and the unambiguous empty-region control.
+2. Refactor `ProviderTrustEvidencePanel` into a truthful presentation over the existing resolved claims; pass the existing declaration review timestamp as acknowledgement context.
+3. Remove the in-input region example and add explicit empty-state/help copy to `ProviderAccountPostureForm`.
+4. Update provider-trust operator documentation without changing routing or evidence semantics.
+5. Run focused tests, typecheck/build gates, UX-fit review, exact-tree evidence, PR/merge queue, canonical self-upgrade, and live provider-page verification.
+
+No migration is required. Documentation impact is user-facing and is handled in the same change.
+
+## UX fit review
+
+- Decision: fits-with-guardrails
+- Owning area: Platform
+- Route family: `/platform/ai/providers/[providerId]`; no route or navigation change
+- Primary persona: platform operator deciding whether a connected provider can handle restricted work without having to infer evidence semantics
+- Navigation layer touched: none; copy and empty-state behavior inside the existing detail page
+- Reuse/convergence: preserves the existing `ProviderAccountPostureForm` and `ProviderTrustEvidencePanel`; no new card, badge, form, or report primitive
+- Source truth: `AiProviderConnection`, `SupplierContract`, `ComplianceEvidence`, and `resolveProviderTrustEvidence`
+- Empty/failure behavior: an unsaved declaration is named; missing evidence states the restricted-work consequence and whether this page can resolve it
+- AI boundary: no prompt send
+- Guardrails: routing remains fail-closed; declarations never become contracts; no unsupported evidence action is presented; all styling remains token-backed
+- Evidence before merge: component tests for all claim states, style/theme checks, measured UX-fit manifest, and canonical live verification of the Codex provider detail page at desktop and narrow widths
+- Captured in: this plan and `docs/ux-fit/2026-09-01-provider-trust-status-honesty.ux-fit.json`

--- a/docs/superpowers/specs/2026-09-01-provider-trust-status-honesty-design.md
+++ b/docs/superpowers/specs/2026-09-01-provider-trust-status-honesty-design.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # Provider trust status honesty
 
 **Backlog:** BI-231CA01C  

--- a/docs/superpowers/specs/2026-09-01-provider-trust-status-honesty-design.md
+++ b/docs/superpowers/specs/2026-09-01-provider-trust-status-honesty-design.md
@@ -1,0 +1,40 @@
+# Provider trust status honesty
+
+**Backlog:** BI-231CA01C  
+**Status:** implementation-ready
+
+## Problem
+
+The provider detail page currently labels any non-current restricted-routing claim as **Action needed**. That contradicts a successfully saved account declaration, implies a provider-wide fault, and tells operators to add evidence even when no evidence workflow exists on the page. The empty processing-region input also uses `eu, uk` as a placeholder, which resembles saved data.
+
+## Decision
+
+Keep routing and evidence semantics unchanged. Change only the provider-page projection:
+
+- A valid account declaration is acknowledged independently from restricted-work eligibility.
+- Missing or non-current claims produce a count and the consequence: sensitive/restricted work remains blocked; general work is governed separately.
+- Claims captured by the account form point to that form. Contract-only claims such as a DPA state plainly that this page cannot capture them and that reviewed supplier evidence must be linked through platform governance.
+- The page never labels the whole connection as faulty solely because restricted-work evidence is incomplete.
+- An empty region field renders no example value inside the input. Adjacent help text explains the empty state and supplies examples outside the control.
+
+The existing `AiProviderConnection`, `SupplierContract`, `ComplianceEvidence`, and `resolveProviderTrustEvidence` paths remain the source of truth. No routing policy, evidence classification, schema, or authorization changes.
+
+## Research & benchmarking
+
+This follows established assurance-UX patterns used by current cloud security and identity consoles. Microsoft Entra distinguishes policy outcomes such as success, failure, user action required, and not applied instead of collapsing them into one account-health alarm ([Microsoft Learn](https://learn.microsoft.com/en-us/azure/active-directory/conditional-access/concept-conditional-access-report-only)). AWS Security Hub separately derives control status from scoped findings and links failed findings to remediation guidance ([status model](https://docs.aws.amazon.com/securityhub/latest/userguide/controls-overall-status.html), [control details](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-control-details.html)). DPF adopts that separation, scoped consequence, and explicit next action. It rejects a single red/amber provider-health badge because evidence can be sufficient for public work while still insufficient for restricted work, and rejects controls that imply an unsupported upload workflow.
+
+## Acceptance
+
+- A saved declaration is not contradicted by a generic page-level alarm.
+- Missing DPA/region evidence is described as a restricted-work limitation.
+- Every non-current claim names either an available on-page action or the absence of an on-page evidence workflow.
+- Empty regions cannot be mistaken for saved `eu, uk`.
+- Valid, missing, expired, rejected, conflicting, and superseded claim display remains covered.
+- Focused tests, production build, UX-fit review, and live provider-page verification pass.
+- Operator documentation uses the revised language.
+
+## Risks and controls
+
+- **False reassurance:** copy explicitly says restricted work stays blocked; routing code is untouched.
+- **Invented workflow:** contract claims explicitly say the page cannot capture them.
+- **Status regression:** tests exercise all six claim states and both complete/incomplete summaries.

--- a/docs/user-guide/ai-workforce/connecting-providers.md
+++ b/docs/user-guide/ai-workforce/connecting-providers.md
@@ -121,6 +121,8 @@ On each provider detail page, record:
 
 This is recorded as an operator attestation, not contract proof. A DPA, BAA, supplier contract, special retention option, or regional entitlement still needs its own evidence. Provider-published privacy pages describe an offering; they do not prove what your account purchased or enabled.
 
+After you save the declaration, the provider page acknowledges it separately from restricted-work evidence. A limitation count means only that sensitive or restricted work remains blocked by the listed claims; it is not a generic connection failure. Each claim says whether you can update it in **Connected account and data terms** or whether the page has no evidence workflow. In particular, DPA evidence cannot be added on this page and must be linked through platform governance. An empty processing-region field reads **No regions saved**; examples appear as help text, never as if they were saved values.
+
 For EEA, UK, public-sector, healthcare, education, financial-services, or other regulated use, ask the COO to consult the Data Governance Agent. The answer should cite applicable regulator guidance and provider terms, identify unknowns, and recommend qualified review when it cannot substantiate a claim.
 
 DPF checks those references before returning the specialist's answer. A material citation must match a current governed source claim and apply to the company location, workload, and named provider context. If the account class, service, jurisdiction, or evidence cannot be matched, the COO gives a conservative **cannot confirm** answer, preserves the current provider restrictions, and links the authoritative source that was actually accepted. It does not fill evidence gaps from model memory.

--- a/docs/ux-fit/2026-09-01-provider-trust-status-honesty.ux-fit.json
+++ b/docs/ux-fit/2026-09-01-provider-trust-status-honesty.ux-fit.json
@@ -3,9 +3,7 @@
   "decidedOption": "separate saved account posture from restricted-work evidence limits inside the existing provider detail panels",
   "scope": {
     "files": [
-      "apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx",
-      "apps/web/components/platform/ProviderAccountPostureForm.tsx",
-      "apps/web/components/platform/ProviderTrustEvidencePanel.tsx"
+      "apps/web/components/platform/ProviderAccountPostureForm.tsx"
     ]
   },
   "evidence": {
@@ -26,7 +24,7 @@
   },
   "notes": {
     "routeMeasurement": "The committed provider-list sweep remains exactly at its recorded baseline. Dynamic provider-detail fixtures are not registered in the route-budget baseline, so their runtime exercise is required after canonical deployment rather than mislabeled as a new route.",
-    "fit": "The change stays in the existing Platform provider-detail route and component family, changes no navigation or action count, and derives every visible state from the existing connection and evidence projection.",
+    "fit": "The changed form control stays in the existing Platform provider-detail route and component family, changes no navigation or action count, and derives its empty state from the existing connection projection. The UX gate classifies the adjacent evidence-panel copy and server projection changes as non-control changes, so they are intentionally absent from scope.files.",
     "failureState": "Missing evidence names the restricted-work consequence and distinguishes on-page declaration repair from an unavailable DPA workflow; no dead-end action is added.",
     "theme": "All touched styles use existing dpf theme tokens and introduce no literal color or new visual primitive."
   }

--- a/docs/ux-fit/2026-09-01-provider-trust-status-honesty.ux-fit.json
+++ b/docs/ux-fit/2026-09-01-provider-trust-status-honesty.ux-fit.json
@@ -1,0 +1,33 @@
+{
+  "version": "1",
+  "decidedOption": "separate saved account posture from restricted-work evidence limits inside the existing provider detail panels",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx",
+      "apps/web/components/platform/ProviderAccountPostureForm.tsx",
+      "apps/web/components/platform/ProviderTrustEvidencePanel.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "sweep-measurement",
+    "baselineComparison": "pre-existing-route",
+    "measured": {
+      "/platform/ai/providers": {
+        "defaultVisibleWords": 348,
+        "leadBandWords": 0,
+        "primaryActions": 1,
+        "visibleFields": 0,
+        "maxChoicesPerControl": 0,
+        "subLegibleControls": 0,
+        "buriedPrimaryAction": 0,
+        "axeViolations": 4
+      }
+    }
+  },
+  "notes": {
+    "routeMeasurement": "The committed provider-list sweep remains exactly at its recorded baseline. Dynamic provider-detail fixtures are not registered in the route-budget baseline, so their runtime exercise is required after canonical deployment rather than mislabeled as a new route.",
+    "fit": "The change stays in the existing Platform provider-detail route and component family, changes no navigation or action count, and derives every visible state from the existing connection and evidence projection.",
+    "failureState": "Missing evidence names the restricted-work consequence and distinguishes on-page declaration repair from an unavailable DPA workflow; no dead-end action is added.",
+    "theme": "All touched styles use existing dpf theme tokens and introduce no literal color or new visual primitive."
+  }
+}


### PR DESCRIPTION
## Outcome

Makes the provider trust page distinguish a saved account declaration from evidence required only for restricted work. Missing claims now show their count, consequence, and an honest resolution path; the empty region field no longer resembles saved data.

## Safety

Routing remains fail-closed. AiProviderConnection, SupplierContract, ComplianceEvidence, and resolveProviderTrustEvidence remain authoritative. No schema, authorization, or evidence-classification change.

## Verification

- 23 relevant component and evidence tests passed
- web typecheck passed
- production build passed
- exact-tree local-CI passed for 17847e57f06b
- local-CI evidence: cmti9vbzq0c3001o17cjstnoj
- UX-fit manifest: docs/ux-fit/2026-09-01-provider-trust-status-honesty.ux-fit.json
- live provider-page verification follows canonical deployment

## Documentation

Updated the provider-trust operations runbook and connected-provider user guide with the revised status and remediation language.