### PR TITLE
feat(workroom): model coordination relations (BI-662254C6)

### DIFF
--- a/apps/web/lib/govern/data/assets.ts
+++ b/apps/web/lib/govern/data/assets.ts
@@ -38,6 +38,7 @@ import { DECISION_TRUST_ENVELOPE_ASSETS } from "./decision-trust-envelope-assets
 import { MCP_OAUTH_ASSETS } from "./mcp-oauth-assets";
 import { MCP_ASSETS } from "./mcp-assets";
 import { WORKROOM_PARTICIPANT_ASSETS } from "./workroom-participant-assets";
+import { WORKROOM_RELATION_ASSETS } from "./workroom-relation-assets";
 import { INITIATIVE_GOVERNANCE_ASSETS } from "./initiative-governance-assets";
 import { FEDERATION_INTRODUCTION_ASSETS } from "./federation-introduction-assets";
 import { BUSINESS_PERFORMANCE_ASSETS } from "./business-performance-assets";
@@ -738,6 +739,7 @@ const SEED_ASSETS: readonly DataAssetDefinition[] = [
   ...MCP_OAUTH_ASSETS,
   ...MCP_ASSETS,
   ...WORKROOM_PARTICIPANT_ASSETS,
+  ...WORKROOM_RELATION_ASSETS,
   ...INITIATIVE_GOVERNANCE_ASSETS,
   ...FEDERATION_INTRODUCTION_ASSETS,
   ...EXTERNAL_CHANNEL_ASSETS,

--- a/apps/web/lib/govern/data/workroom-relation-assets.ts
+++ b/apps/web/lib/govern/data/workroom-relation-assets.ts
@@ -1,0 +1,29 @@
+// Data-governance registration for work-coordination relation rows (BI-662254C6).
+
+import type { DataAssetDefinition } from "./assets";
+
+const CLASSIFICATION = {
+  state: "confirmed",
+  source: "manual",
+  effectiveFrom: "2026-09-01",
+} as const;
+
+export const WORKROOM_RELATION_ASSETS: readonly DataAssetDefinition[] = [
+  {
+    id: "data:workroom-relation",
+    physical: { prismaModel: "WorkroomRelation" },
+    domain: "platform-operations",
+    ownerRole: "platform-operator",
+    stewardRole: "data-steward",
+    categories: ["operational"],
+    sensitivity: "internal",
+    criticality: "standard",
+    subjectLocators: [],
+    lifecycleClass: "operational",
+    purposeCapabilities: ["platform-operations"],
+    residencyClass: "local-only",
+    projectionClass: "structure",
+    classification: CLASSIFICATION,
+    fields: [],
+  },
+];

--- a/apps/web/lib/work-management/room-relations.test.ts
+++ b/apps/web/lib/work-management/room-relations.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  WORKROOM_RELATION_KINDS,
+  assertWorkroomRelation,
+  containsWouldCycle,
+  parseWorkroomRelation,
+  WorkroomRelationError,
+  type WorkroomRelation,
+} from "./room-relations";
+
+describe("work-coordination relations (BI-662254C6)", () => {
+  it("round-trips each of the five vocabulary relations", () => {
+    for (const relation of WORKROOM_RELATION_KINDS) {
+      const parsed = parseWorkroomRelation({
+        fromWorkroomId: "WC-A",
+        toWorkroomId: "WC-B",
+        relation,
+      });
+      expect(parsed).toEqual({
+        fromWorkroomId: "WC-A",
+        toWorkroomId: "WC-B",
+        relation,
+      });
+    }
+    expect(WORKROOM_RELATION_KINDS).toEqual([
+      "contains",
+      "spawned-from",
+      "depends-on",
+      "blocks",
+      "contributes-to",
+    ]);
+  });
+
+  it("rejects a contains cycle", () => {
+    const existing: WorkroomRelation[] = [
+      { fromWorkroomId: "WC-PARENT", toWorkroomId: "WC-CHILD", relation: "contains" },
+      { fromWorkroomId: "WC-CHILD", toWorkroomId: "WC-LEAF", relation: "contains" },
+    ];
+    expect(containsWouldCycle(existing, "WC-LEAF", "WC-PARENT")).toBe(true);
+    expect(() =>
+      assertWorkroomRelation(existing, {
+        fromWorkroomId: "WC-LEAF",
+        toWorkroomId: "WC-PARENT",
+        relation: "contains",
+      }),
+    ).toThrow(WorkroomRelationError);
+    try {
+      assertWorkroomRelation(existing, {
+        fromWorkroomId: "WC-LEAF",
+        toWorkroomId: "WC-PARENT",
+        relation: "contains",
+      });
+    } catch (error) {
+      expect((error as WorkroomRelationError).reason).toBe("contains_cycle");
+    }
+  });
+
+  it("allows a non-cyclic contains edge and non-contains cycles", () => {
+    const existing: WorkroomRelation[] = [
+      { fromWorkroomId: "WC-PARENT", toWorkroomId: "WC-CHILD", relation: "contains" },
+    ];
+    expect(
+      assertWorkroomRelation(existing, {
+        fromWorkroomId: "WC-PARENT",
+        toWorkroomId: "WC-OTHER",
+        relation: "contains",
+      }).relation,
+    ).toBe("contains");
+    expect(
+      assertWorkroomRelation(existing, {
+        fromWorkroomId: "WC-CHILD",
+        toWorkroomId: "WC-PARENT",
+        relation: "blocks",
+      }).relation,
+    ).toBe("blocks");
+  });
+
+  it("never converts a portfolio dependency into a work-coordination relation", () => {
+    for (const relation of [
+      "portfolio-depends-on",
+      "dependsOnPortfolioRoles",
+      "servesPortfolioRoles",
+      "fpaw-dependency",
+    ]) {
+      expect(() =>
+        parseWorkroomRelation({
+          fromWorkroomId: "WC-A",
+          toWorkroomId: "WC-B",
+          relation,
+        }),
+      ).toThrow(WorkroomRelationError);
+      try {
+        parseWorkroomRelation({
+          fromWorkroomId: "WC-A",
+          toWorkroomId: "WC-B",
+          relation,
+        });
+      } catch (error) {
+        expect((error as WorkroomRelationError).reason).toBe("portfolio_dependency");
+      }
+    }
+  });
+});

--- a/apps/web/lib/work-management/room-relations.ts
+++ b/apps/web/lib/work-management/room-relations.ts
@@ -1,0 +1,105 @@
+/**
+ * Work-coordination relations (BI-662254C6).
+ *
+ * Five relations, not a parent column: contains, spawned-from, depends-on,
+ * blocks, contributes-to. Portfolio dependencies stay in FPAW and are never
+ * converted into these edges.
+ */
+export const WORKROOM_RELATION_KINDS = [
+  "contains",
+  "spawned-from",
+  "depends-on",
+  "blocks",
+  "contributes-to",
+] as const;
+
+export type WorkroomRelationKind = (typeof WORKROOM_RELATION_KINDS)[number];
+
+export const PORTFOLIO_DEPENDENCY_KIND_ALIASES = [
+  "portfolio-depends-on",
+  "portfolio-serves",
+  "servesPortfolioRoles",
+  "dependsOnPortfolioRoles",
+  "fpaw-dependency",
+] as const;
+
+export type WorkroomRelation = {
+  fromWorkroomId: string;
+  toWorkroomId: string;
+  relation: WorkroomRelationKind;
+};
+
+export class WorkroomRelationError extends Error {
+  constructor(readonly reason: "unknown_kind" | "portfolio_dependency" | "contains_cycle" | "self_relation", message: string) {
+    super(message);
+    this.name = "WorkroomRelationError";
+  }
+}
+
+function isRelationKind(value: unknown): value is WorkroomRelationKind {
+  return typeof value === "string" && (WORKROOM_RELATION_KINDS as readonly string[]).includes(value);
+}
+
+export function parseWorkroomRelation(input: unknown): WorkroomRelation {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new WorkroomRelationError("unknown_kind", "Workroom relation must be an object.");
+  }
+  const row = input as Record<string, unknown>;
+  const fromWorkroomId = typeof row.fromWorkroomId === "string" ? row.fromWorkroomId.trim() : "";
+  const toWorkroomId = typeof row.toWorkroomId === "string" ? row.toWorkroomId.trim() : "";
+  if (!fromWorkroomId || !toWorkroomId) {
+    throw new WorkroomRelationError("unknown_kind", "Workroom relation requires fromWorkroomId and toWorkroomId.");
+  }
+  if (typeof row.relation === "string" && (PORTFOLIO_DEPENDENCY_KIND_ALIASES as readonly string[]).includes(row.relation)) {
+    throw new WorkroomRelationError(
+      "portfolio_dependency",
+      "Portfolio dependencies are not work-coordination relations and must not be converted.",
+    );
+  }
+  if (!isRelationKind(row.relation)) {
+    throw new WorkroomRelationError("unknown_kind", `Unknown work-coordination relation ${String(row.relation)}.`);
+  }
+  if (fromWorkroomId === toWorkroomId) {
+    throw new WorkroomRelationError("self_relation", "A Workroom cannot relate to itself.");
+  }
+  return { fromWorkroomId, toWorkroomId, relation: row.relation };
+}
+
+export function containsWouldCycle(
+  existing: readonly WorkroomRelation[],
+  fromWorkroomId: string,
+  toWorkroomId: string,
+): boolean {
+  if (fromWorkroomId === toWorkroomId) return true;
+  const children = new Map<string, string[]>();
+  for (const edge of existing) {
+    if (edge.relation !== "contains") continue;
+    const list = children.get(edge.fromWorkroomId) ?? [];
+    list.push(edge.toWorkroomId);
+    children.set(edge.fromWorkroomId, list);
+  }
+  const seen = new Set<string>();
+  const stack = [toWorkroomId];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (current === fromWorkroomId) return true;
+    if (seen.has(current)) continue;
+    seen.add(current);
+    for (const child of children.get(current) ?? []) stack.push(child);
+  }
+  return false;
+}
+
+export function assertWorkroomRelation(
+  existing: readonly WorkroomRelation[],
+  candidate: unknown,
+): WorkroomRelation {
+  const parsed = parseWorkroomRelation(candidate);
+  if (parsed.relation === "contains" && containsWouldCycle(existing, parsed.fromWorkroomId, parsed.toWorkroomId)) {
+    throw new WorkroomRelationError(
+      "contains_cycle",
+      `contains ${parsed.fromWorkroomId} → ${parsed.toWorkroomId} would cycle.`,
+    );
+  }
+  return parsed;
+}

--- a/changes/workroom-relations.data-impact.json
+++ b/changes/workroom-relations.data-impact.json
@@ -1,0 +1,35 @@
+{
+  "version": "1",
+  "accountableOwner": "Mark Bodman (markdbodman@gmail.com)",
+  "summary": "BI-662254C6. Migration 20260901070000_add_workroom_relations adds WorkCapsuleRelation for the five work-coordination relations. Additive; existing WorkCapsule rows keep their columns. No live relation graph exists to backfill; inventing edges from portfolio-role arrays is refused.",
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "WorkroomRelation",
+      "lifecycleDisposition": "retain-with-workroom",
+      "fields": [
+        {
+          "name": "fromWorkroomId",
+          "resolution": "inherited",
+          "reason": "FK to the existing WorkCapsule row that holds the relation. Not a second room identity.",
+          "provenance": "Writer-supplied Workroom id after assertWorkroomRelation.",
+          "flags": []
+        },
+        {
+          "name": "toWorkroomId",
+          "resolution": "inherited",
+          "reason": "FK to the referenced WorkCapsule row.",
+          "provenance": "Writer-supplied Workroom id after assertWorkroomRelation.",
+          "flags": []
+        },
+        {
+          "name": "relation",
+          "resolution": "not-applicable",
+          "reason": "Closed work-coordination vocabulary: contains, spawned-from, depends-on, blocks, contributes-to. Not a portfolio-dependency field.",
+          "provenance": "Named by the writer; portfolio-dependency aliases are rejected in parseWorkroomRelation.",
+          "flags": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -8,8 +8,8 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 
 | Count | Value | Source of truth |
 |---|---:|---|
-| Prisma models | 615 | `packages/db/prisma/schema/` |
-| Prisma enums | 75 | `packages/db/prisma/schema/` |
-| Migrations | 560 | `packages/db/prisma/migrations/` |
+| Prisma models | 616 | `packages/db/prisma/schema/` |
+| Prisma enums | 76 | `packages/db/prisma/schema/` |
+| Migrations | 561 | `packages/db/prisma/migrations/` |
 | Kernel principles | 99 | `docs/founder-kernel/wiki/principles/` |
 | App routes | 642 | `apps/web/lib/ea/route-manifest.json` |

--- a/packages/db/prisma/migrations/20260901070000_add_workroom_relations/migration.sql
+++ b/packages/db/prisma/migrations/20260901070000_add_workroom_relations/migration.sql
@@ -1,0 +1,62 @@
+-- BI-662254C6: five work-coordination relations on the WorkCapsule substrate.
+-- Nesting is a join, not a parentWorkroomId column, because contains,
+-- spawned-from, depends-on, blocks, and contributes-to are different facts.
+--
+-- @migration-safety: data-safe: additive enum + new table. Existing WorkCapsule
+-- rows keep their columns. No stored relation JSON exists on live rooms to
+-- copy, so backfill is a documented no-op rather than an invented graph.
+--
+-- Live-shaped: applies against the existing WorkCapsule population (currently
+-- hundreds of development-session rooms plus standing business rooms). The
+-- table is empty after apply; writers use assertWorkroomRelation so a contains
+-- cycle and a portfolio-dependency alias cannot land.
+
+-- CreateEnum
+CREATE TYPE "WorkroomRelationKind" AS ENUM (
+  'contains',
+  'spawned-from',
+  'depends-on',
+  'blocks',
+  'contributes-to'
+);
+
+-- CreateTable
+CREATE TABLE "WorkCapsuleRelation" (
+    "id" TEXT NOT NULL,
+    "fromWorkroomId" TEXT NOT NULL,
+    "toWorkroomId" TEXT NOT NULL,
+    "relation" "WorkroomRelationKind" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WorkCapsuleRelation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WorkCapsuleRelation_fromWorkroomId_toWorkroomId_relation_key"
+  ON "WorkCapsuleRelation"("fromWorkroomId", "toWorkroomId", "relation");
+
+-- CreateIndex
+CREATE INDEX "WorkCapsuleRelation_toWorkroomId_relation_idx"
+  ON "WorkCapsuleRelation"("toWorkroomId", "relation");
+
+-- CreateIndex
+CREATE INDEX "WorkCapsuleRelation_relation_idx"
+  ON "WorkCapsuleRelation"("relation");
+
+-- AddForeignKey
+ALTER TABLE "WorkCapsuleRelation"
+  ADD CONSTRAINT "WorkCapsuleRelation_fromWorkroomId_fkey"
+  FOREIGN KEY ("fromWorkroomId") REFERENCES "WorkCapsule"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkCapsuleRelation"
+  ADD CONSTRAINT "WorkCapsuleRelation_toWorkroomId_fkey"
+  FOREIGN KEY ("toWorkroomId") REFERENCES "WorkCapsule"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Backfill: none. Live WorkCapsule rows do not carry a relation graph in
+-- scopeClaims or workspaceState. Inventing contains/spawned-from edges from
+-- title text or portfolio-role arrays would silently convert FPAW portfolio
+-- dependencies into work-coordination relations — the defect this slice exists
+-- to prevent.

--- a/packages/db/prisma/schema/work-coordination.prisma
+++ b/packages/db/prisma/schema/work-coordination.prisma
@@ -408,6 +408,8 @@ model Workroom {
   createdByPrincipal      Principal?               @relation("WorkroomCreator", fields: [createdByPrincipalId], references: [id], onDelete: SetNull)
   requestedByPrincipal    Principal?               @relation("WorkroomRequester", fields: [requestedByPrincipalId], references: [id], onDelete: SetNull)
   participants            WorkroomParticipant[]    @relation("WorkroomParticipants")
+  outgoingRelations       WorkroomRelation[]       @relation("WorkroomRelationFrom")
+  incomingRelations       WorkroomRelation[]       @relation("WorkroomRelationTo")
 
   @@index([status, updatedAt])
   @@index([backlogItemId])
@@ -472,6 +474,32 @@ model WorkroomParticipant {
   @@index([workroomId, lifecycle])
   @@index([assignmentSource])
   @@map("WorkCapsuleParticipant")
+}
+
+// BI-662254C6: five work-coordination relations. Not a parent column — contains,
+// spawned-from, depends-on, blocks, and contributes-to are different facts.
+// Portfolio dependencies stay on Workroom.dependsOnPortfolioRoles.
+enum WorkroomRelationKind {
+  contains
+  spawned_from    @map("spawned-from")
+  depends_on      @map("depends-on")
+  blocks
+  contributes_to  @map("contributes-to")
+}
+
+model WorkroomRelation {
+  id              String               @id @default(cuid())
+  fromWorkroomId  String
+  toWorkroomId    String
+  relation        WorkroomRelationKind
+  createdAt       DateTime             @default(now())
+  fromWorkroom    Workroom             @relation("WorkroomRelationFrom", fields: [fromWorkroomId], references: [id], onDelete: Cascade)
+  toWorkroom      Workroom             @relation("WorkroomRelationTo", fields: [toWorkroomId], references: [id], onDelete: Cascade)
+
+  @@unique([fromWorkroomId, toWorkroomId, relation])
+  @@index([toWorkroomId, relation])
+  @@index([relation])
+  @@map("WorkCapsuleRelation")
 }
 
 model Epic {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -38,6 +38,7 @@ export {
 export {
   WorkroomParticipantRole,
   WorkroomParticipantAssignmentSource,
+  WorkroomRelationKind,
 } from "../generated/client/client";
 export {
   PRINCIPAL_SENSITIVITIES,

--- a/packages/db/src/table-classification.ts
+++ b/packages/db/src/table-classification.ts
@@ -79,6 +79,9 @@ export const TABLE_CLASSIFICATION: Record<string, TableSensitivity> = {
   // BI-4CB2EF76: room roster is operational membership (principal FK + roles).
   // Display names stay on Principal; this table is not a second identity store.
   WorkroomParticipant: "internal",
+  // BI-662254C6: work-coordination edges between rooms. Operational structure,
+  // not a second identity or portfolio-dependency store.
+  WorkroomRelation: "internal",
   InitiativeArtifactRetentionPin: "confidential",
   Epic: "internal",
   EpicPortfolio: "internal",

--- a/scripts/platform-substrate-baseline.json
+++ b/scripts/platform-substrate-baseline.json
@@ -17,7 +17,7 @@
     },
     "prismaModelCount": {
       "direction": "non-increasing",
-      "value": 615
+      "value": 616
     },
     "prismaSchemaLines": {
       "direction": "informational",

--- a/scripts/stewardship-exemptions.txt
+++ b/scripts/stewardship-exemptions.txt
@@ -113,6 +113,7 @@ StorefrontItemComponent  domain-lifecycle-managed  # Recipe lines follow their s
 IncumbentCoverageAssessment  domain-lifecycle-managed  # Per-customer coverage verdicts (BI-548060D5); re-assessment supersedes the prior row, never time-aged.
 JobRequisition  domain-lifecycle-managed  # Requisitions close/fill through their own status lifecycle (open→closed/filled), not a time-based sweep (BI-F3AEBF68).
 WorkroomParticipant  domain-lifecycle-managed  # Roster rows cascade with their Workroom and are archived by membership lifecycle; a time sweep would drop a live room's Process Overseer.
+WorkroomRelation  domain-lifecycle-managed  # Relation rows cascade with their Workrooms; a time sweep would drop a live contains/depends-on edge.
 RequisitionOpening  domain-lifecycle-managed  # Headcount slots follow their parent requisition via cascade; never independently aged.
 JobPosting  domain-lifecycle-managed  # Postings are unpublished/closed by requisition lifecycle and cascade; not age-swept.
 PipelineStage  domain-lifecycle-managed  # Stage definitions follow their requisition via cascade; not independently aged.


### PR DESCRIPTION
## Summary

- model `contains`, `spawned-from`, `depends-on`, `blocks`, and `contributes-to` as a typed Workroom-to-Workroom join rather than a parent column
- keep FPAW portfolio dependencies separate and reject their aliases at the work-coordination boundary
- reject self-relations and cyclic `contains` edges before persistence
- register the new relation model with data governance, table classification, retention stewardship, and generated architecture counts

## Verification

- Workroom relation Vitest: 4/4 passed
- related DB schema-classification Vitest: 23/23 passed
- Prisma schema validation passed
- style/token drift guard passed
- pregate preflight: 61/61 guards clean
- full exact-tree local CI passed in 4m15s, including migration deploy, exhaustive tests, typecheck, and production build
- migration `20260901070000_add_workroom_relations` applied successfully against the integration database

The independent high-assurance semantic review was infrastructure-inconclusive with no issues; policy is presently shadow mode and returned `mayPublish: true`. Receipt: `cmtic4wyh0o7k01nwepnxosy2`.

## Design grounding

This is Phase C of the approved proactive-Workrooms design in `docs/superpowers/specs/2026-08-29-proactive-workrooms-design.md` and its implementation plan. The existing `Workroom`/physical `WorkCapsule` substrate remains the identity source of truth. Relations are independent facts on one join; `dependsOnPortfolioRoles` remains the separate FPAW portfolio dependency axis.

## Data impact

The migration is additive: one enum, one join table, indexed foreign keys, and no mutation of existing Workroom rows. There is deliberately no backfill because live Workrooms do not contain a trustworthy relation graph; inferring it from titles or portfolio-role arrays would invent business meaning. Full disposition is recorded in `changes/workroom-relations.data-impact.json`.

## Documentation impact

No user-facing surface changes in this slice. Relation presentation is owned by Phase G; generated architecture counts are updated here because the schema changed.

Local-CI-Evidence: cmtic41p00o7001nw0fxqem14 (feat/phase-c-workroom-relations@1ae616871af4098860c98c20158a138a9c4d64c9)
