### PR TITLE
fix: preserve terminal writer source for Codex

### DIFF
--- a/apps/web/lib/mcp-task-execution.ts
+++ b/apps/web/lib/mcp-task-execution.ts
@@ -129,17 +129,15 @@ export async function executeRemoteTaskAttempt(input: {
     : input.resumeKind === "terminal-writer"
       ? { resumedFromTerminalWriterWait: true }
       : { resumedFromCapacity: true };
+  const effectiveSystemPrompt = input.resumeKind === "terminal-writer" && input.terminalWriterContext
+    ? `${agent.systemPrompt}\n\n${input.terminalWriterContext}`
+    : agent.systemPrompt;
 
   try {
     const result = await executeAutonomousAgenticLoop({
-      systemPrompt: agent.systemPrompt,
+      systemPrompt: effectiveSystemPrompt,
       systemPromptInstructionSpans: coworkerBriefSpans(agent.systemPrompt),
-      chatHistory: [
-        ...(input.resumeKind === "terminal-writer" && input.terminalWriterContext
-          ? [{ role: "system" as const, content: input.terminalWriterContext }]
-          : []),
-        { role: "user", content: parsed.prompt },
-      ],
+      chatHistory: [{ role: "user", content: parsed.prompt }],
       sensitivity: agent.sensitivity ?? "internal",
       tools: tools.tools,
       toolsForProvider: tools.toolsForProvider,

--- a/apps/web/lib/mcp-task-terminal-writer.test.ts
+++ b/apps/web/lib/mcp-task-terminal-writer.test.ts
@@ -576,13 +576,10 @@ describe("terminal writer resumption", () => {
 
     expect(autonomous.execute).toHaveBeenCalledWith(expect.objectContaining({
       taskRunId: "TR-MCP-WRITER-EXHAUSTED",
-      chatHistory: [
-        expect.objectContaining({
-          role: "system",
-          content: expect.stringContaining("The same TaskRun preserves its immutable authority binding."),
-        }),
-        { role: "user", content: exhaustedParams.prompt },
-      ],
+      systemPrompt: expect.stringMatching(
+        /Review the immutable artifact\.[\s\S]*The same TaskRun preserves its immutable authority binding\./,
+      ),
+      chatHistory: [{ role: "user", content: exhaustedParams.prompt }],
       terminalToolPolicy: expect.objectContaining({
         terminalPhase: "writer-only",
         persistedEvidenceAvailable: true,

--- a/docs/superpowers/plans/2026-08-31-terminal-writer-system-message-order.md
+++ b/docs/superpowers/plans/2026-08-31-terminal-writer-system-message-order.md
@@ -5,7 +5,7 @@ status: active
 # Terminal-writer system-message order — implementation plan
 
 Backlog item: `BI-EDC0DAF2`  
-Workroom: `WC-A291253B`  
+Workroom: `WC-EF32001A`
 Design: `docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md`
 
 **For agentic workers:** execute this plan one independently reviewable backlog
@@ -98,3 +98,19 @@ rollback is involved.
 Documentation impact: the design and this plan are the durable contributor
 contract. The repair does not add owner-facing UX or change public product
 behavior.
+
+## Provider-neutral follow-up — 2026-09-01
+
+The original order-only PR merged, but live Codex replay proved its system-role
+history entry is intentionally discarded at the CLI adapter boundary. The
+remaining atomic correction is:
+
+1. RED: require hydrated immutable evidence in `systemPrompt` and user-only
+   `chatHistory` in `mcp-task-terminal-writer.test.ts`.
+2. GREEN: append the hydrated context to the coworker's system prompt only for
+   terminal-writer resume; preserve ordinary execution byte-for-byte.
+3. Run all related MCP TaskRun tests, style guard, web build, exact-tree pregate,
+   PR health, and canonical replay of the failed `BI-199F71B6` reviewer route.
+
+This follow-up satisfies `OBJ-TWSO-003` / `AC-TWSO-004`; no migration or UX
+change is involved.

--- a/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
+++ b/docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md
@@ -10,6 +10,8 @@ Named baseline: `origin/main` at `be4c6bfcb4fd62f497167fa55c747105512a0ecd`
 ## Objectives
 **OBJ-TWSO-001:** Put hydrated terminal-writer system authority before user content.
 **OBJ-TWSO-002:** Preserve ordinary history and every existing fail-closed control.
+**OBJ-TWSO-003:** Carry that authority on the provider-neutral system-prompt
+contract, including adapters that intentionally omit system-role history.
 
 ## Problem and live evidence
 An initiative-review TaskRun can complete immutable reads and resume writer-only,
@@ -21,9 +23,17 @@ reproduced this after reading BI-B223F45E commit
 `035a6335bd0e609bafbe96777ef6c5e0ea26bac0`, blob
 `b9fe8f0707291805fbc468aef62b401e0ee210a5`; two replays wrote no receipt.
 
+After the original order correction merged, Codex-only live replays for
+`BI-199F71B6` hydrated the complete immutable source but recorded three false
+spec-approval failures claiming that source was absent. The Codex CLI adapter
+correctly omits system-role history because it receives `systemPrompt`
+separately. Therefore ordering the history entry first was necessary for local
+providers but not provider-neutral; the authority must be appended to the
+actual system-prompt argument and omitted from history.
+
 ## Contract
-- Hydrated terminal-writer context is system authority and must appear before
-  user content in provider-facing message history.
+- Hydrated terminal-writer context is system authority and must be appended to
+  the provider-facing system prompt, before the separate user history.
 - Ordinary external TaskRuns keep their existing message order.
 - Writer-only narrowing, immutable artifact binding, server-bound arguments,
   PAT grant intersection, reviewer identity, and idempotency remain unchanged.
@@ -47,6 +57,7 @@ reproduced this after reading BI-B223F45E commit
 | AC-TWSO-001 | OBJ-TWSO-001 | Focused test proves `system` then `user`. |
 | AC-TWSO-002 | OBJ-TWSO-002 | Ordinary path and fail-closed suites stay green. |
 | AC-TWSO-003 | OBJ-TWSO-001 | Customer-zero bound receipt succeeds live. |
+| AC-TWSO-004 | OBJ-TWSO-003 | A Codex terminal-writer replay receives the hydrated source through `systemPrompt`, while `chatHistory` remains user-only. |
 
 Documentation impact: this design is the durable internal contract. The change
 does not alter owner-facing behavior or public product documentation.


### PR DESCRIPTION
## Summary

- carry terminal-writer immutable source evidence in the provider-neutral system prompt
- keep ordinary TaskRun history unchanged and retain every existing writer/binding/approval guard
- cover the Codex adapter case that drops system-role history by design

Closes the remaining provider-neutral acceptance gap in `BI-EDC0DAF2`.

## Design grounding

Grounded in `docs/superpowers/specs/2026-08-31-terminal-writer-system-message-order-design.md` and its implementation plan. The code substrate reviewed was `apps/web/lib/mcp-task-execution.ts`, terminal-writer hydration in `apps/web/lib/mcp-task-submit.ts`, the Codex CLI adapter's system-history handling, and `apps/web/lib/mcp-task-terminal-writer.test.ts`. The system prompt is the canonical provider-neutral authority channel; chat history remains the user/tool conversation channel.

## Verification

- TDD regression observed red before the source change, then green (9/9)
- related MCP TaskRun suites: 41/41 passed
- style-drift guard passed
- `pnpm --filter web build` passed
- pregate preflight: 61/61 guards clean
- exact merged-tree local-CI: exhaustive gate passed
- UX: not applicable; no UI change
- migration: not applicable; no schema change
