### PR TITLE
fix(workroom): enforce forward stage transitions

### DIFF
--- a/apps/web/lib/work-management/workroom-shape-conformance.test.ts
+++ b/apps/web/lib/work-management/workroom-shape-conformance.test.ts
@@ -171,6 +171,92 @@ describe("evaluateWorkroomShapeConformance (BI-3913EB49)", () => {
     expect(result.disposition).toBe("pause");
   });
 
+  it("refuses a backward stage transition even when receipts exist", () => {
+    const result = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: executableRoster,
+      currentStageKey: "review",
+      proposedStageKey: "scan",
+      receipts: [
+        { stageKey: "scan", kind: "findings" },
+        { stageKey: "review", kind: "decision" },
+      ],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+      coordinatorHasProcessCoordinationAuthority: true,
+    });
+    expect(result.deviations.map((row) => row.code)).toContain("out_of_order_stage");
+    expect(result.disposition).toBe("pause");
+  });
+
+  it("refuses a transition from an unknown non-null current stage", () => {
+    const result = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: executableRoster,
+      currentStageKey: "unknown-stage",
+      proposedStageKey: "scan",
+      receipts: [],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+      coordinatorHasProcessCoordinationAuthority: true,
+    });
+    expect(result.deviations.map((row) => row.code)).toContain("out_of_order_stage");
+    expect(result.disposition).toBe("pause");
+  });
+
+  it("allows an initial transition only to the first declared stage", () => {
+    const result = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: executableRoster,
+      currentStageKey: null,
+      proposedStageKey: "review",
+      receipts: [{ stageKey: "scan", kind: "findings" }],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+      coordinatorHasProcessCoordinationAuthority: true,
+    });
+    expect(result.deviations.map((row) => row.code)).toContain("out_of_order_stage");
+    expect(result.disposition).toBe("pause");
+  });
+
+  it("allows same-stage replay only until that stage records a receipt", () => {
+    const replay = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: executableRoster,
+      currentStageKey: "scan",
+      proposedStageKey: "scan",
+      receipts: [],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+      coordinatorHasProcessCoordinationAuthority: true,
+    });
+    expect(replay.deviations).toEqual([]);
+    expect(replay.disposition).toBe("continue");
+
+    const completed = evaluateWorkroomShapeConformance({
+      definition,
+      collaborationShape: null,
+      participants: executableRoster,
+      currentStageKey: "scan",
+      proposedStageKey: "scan",
+      receipts: [{ stageKey: "scan", kind: "findings" }],
+      budgetUsage: [],
+      stopConditionHits: [],
+      reviewDue: false,
+      coordinatorHasProcessCoordinationAuthority: true,
+    });
+    expect(completed.deviations.map((row) => row.code)).toContain("out_of_order_stage");
+    expect(completed.disposition).toBe("pause");
+  });
+
   it("stops on exhausted budget or a hit stop condition", () => {
     const budget = evaluateWorkroomShapeConformance({
       definition,

--- a/apps/web/lib/work-management/workroom-shape-conformance.ts
+++ b/apps/web/lib/work-management/workroom-shape-conformance.ts
@@ -174,6 +174,36 @@ export function evaluateWorkroomShapeConformance(
       code: "out_of_order_stage",
       summary: `Proposed stage ${input.proposedStageKey} is not on the declared shape.`,
     });
+  } else if (input.currentStageKey && currentIndex < 0) {
+    deviations.push({
+      code: "out_of_order_stage",
+      summary: `Current stage ${input.currentStageKey} is not on the declared shape.`,
+    });
+  } else if (input.proposedStageKey && !input.currentStageKey && proposedIndex !== 0) {
+    deviations.push({
+      code: "out_of_order_stage",
+      summary:
+        `An unstarted room can begin only at ${input.definition.stages[0]?.key ?? "the first declared stage"}.`,
+    });
+  } else if (
+    input.proposedStageKey &&
+    input.currentStageKey &&
+    proposedIndex < currentIndex
+  ) {
+    deviations.push({
+      code: "out_of_order_stage",
+      summary: `Stage ${input.proposedStageKey} is behind ${input.currentStageKey}.`,
+    });
+  } else if (
+    input.proposedStageKey &&
+    input.currentStageKey &&
+    proposedIndex === currentIndex &&
+    input.receipts.some((receipt) => receipt.stageKey === input.currentStageKey)
+  ) {
+    deviations.push({
+      code: "out_of_order_stage",
+      summary: `Stage ${input.currentStageKey} already has a receipt and cannot be replayed.`,
+    });
   } else if (
     input.proposedStageKey &&
     input.currentStageKey &&


### PR DESCRIPTION
## Summary

- correct the unsafe stage-order semantics introduced by #4917
- reject backward transitions, unknown current stages, and non-first initial transitions
- preserve same-stage idempotent replay only until the current stage has evidence

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-08-15-resilient-concurrent-development-process.md` and the Workrooms design in #4871.
- Current code substrate reviewed: `apps/web/lib/work-management/workroom-shape-conformance.ts` and its production caller `apps/web/lib/work-management/drive-resolution.ts`.
- Source of truth: the ordered Workroom stage contract approved in #4871.
- Decision: make transitions forward-only and fail closed for unknown state while retaining safe pre-evidence replay.

## Verification

- TDD: four new behavior tests failed before implementation.
- `workroom-shape-conformance.test.ts`: 15/15 passed.
- conformance plus `drive-resolution.test.ts`: 32/32 passed.
- `pnpm run pregate:preflight`: 61 guards clean.
- exact-tree `pnpm run pregate`: passed for `8236367f5eaf4734c366ed53b6a38302b9cfd99a`; evidence `cmtieuyf6048s01mnhtx5ruhk`.
- semantic review: infrastructure-inconclusive with zero findings; recorded as `cmtievn5z04fe01mni8o3q9se` under the repository's shadow policy.

## Documentation impact

No documentation change is needed. This correction makes runtime behavior conform to the already-approved Workrooms design and does not introduce a new user-facing contract.

Process-Spine-Decision: restore the approved forward-only Workroom transition invariant before further Workrooms phases proceed.

Design-Grounding-Decision: conform existing Process Overseer transition behavior to the approved Workrooms design.
