### PR TITLE
fix(govern): decide mask materiality by reversibility, not by declaration (BI-0064680C)

### DIFF
--- a/apps/web/lib/govern/data/mask-for-context.test.ts
+++ b/apps/web/lib/govern/data/mask-for-context.test.ts
@@ -261,3 +261,139 @@ describe("maskForContext", () => {
     });
   });
 });
+
+// BI-0064680C. The guard now measures what the transform DID, not what the
+// caller declared, so the tokenized projection the platform already built is
+// reachable without every caller first asserting materiality it cannot know.
+describe("materiality is decided by reversibility, not by declaration", () => {
+  const boundBinding = (pathPrefixes?: string[]): RehydrationAuthorizationBinding => ({
+    expectedActor: {
+      principalId: "PRN-1",
+      actingHumanUserId: "user-1",
+      actingAgentId: null,
+      delegationGrantId: null,
+    },
+    purpose: "customer-support",
+    surface: "private-customer",
+    subject: { kind: "account", id: "account-1" },
+    sensitivity: "confidential",
+    decisionVersions: [{
+      decisionId: "decision-mask-1",
+      assetVersion: "asset-v1",
+      classificationVersion: "classification-v1",
+      authorityVersion: "authority-v1",
+    }],
+    dataClasses: ["customer-records"],
+    ...(pathPrefixes ? { pathPrefixes } : {}),
+  });
+
+  const contactMatch = {
+    dataClass: "customer-records" as const,
+    path: "customer.email",
+    reason: "contact-detail",
+    confidence: "deterministic" as const,
+  };
+
+  it("allows an undeclared turn when every value is tokenized and bound", () => {
+    const result = maskForContext(
+      { customer: { email: "ada@example.com" } },
+      {
+        decision: maskingDecision(),
+        detailUse: "unknown",
+        rehydrationBindings: [boundBinding()],
+        matches: [contactMatch],
+      },
+    );
+
+    expect(result.transformation).toBe("tokenized");
+    expect(result.value.customer.email).toMatch(/^\[DPF_TOKEN_/);
+    expect(result.rehydrationHandle).toMatch(/^rehydration_/);
+  });
+
+  it("still refuses an undeclared turn when no binding can restore the value", () => {
+    expect(() =>
+      maskForContext(
+        { customer: { email: "ada@example.com" } },
+        {
+          decision: maskingDecision(),
+          detailUse: "unknown",
+          matches: [contactMatch],
+        },
+      )
+    ).toThrow(ContextMaskMaterialityError);
+  });
+
+  it("still refuses an undeclared turn when a binding does not cover the path", () => {
+    expect(() =>
+      maskForContext(
+        { customer: { email: "ada@example.com" } },
+        {
+          decision: maskingDecision(),
+          detailUse: "unknown",
+          rehydrationBindings: [boundBinding(["somewhere-else"])],
+          matches: [contactMatch],
+        },
+      )
+    ).toThrow(ContextMaskMaterialityError);
+  });
+
+  it("still refuses an undeclared turn for a one-way redaction", () => {
+    expect(() =>
+      maskForContext(
+        { note: "the key is sk-abcdefghijklmnop" },
+        {
+          decision: maskingDecision(),
+          detailUse: "unknown",
+          rehydrationBindings: [boundBinding()],
+          matches: [{
+            dataClass: "secrets-credentials",
+            path: "note",
+            reason: "secret-shaped-token",
+            confidence: "deterministic",
+          }],
+        },
+      )
+    ).toThrow(ContextMaskMaterialityError);
+  });
+
+  it("still refuses an undeclared turn for a lossy PDP profile", () => {
+    expect(() =>
+      maskForContext(
+        { customer: { accountNumber: "123456789" } },
+        {
+          decision: {
+            ...maskingDecision(),
+            obligations: [{ kind: "mask" as const, profileId: "context-partial" }],
+          },
+          detailUse: "unknown",
+          rehydrationBindings: [boundBinding()],
+          matches: [{
+            dataClass: "payments-finance",
+            path: "customer.accountNumber",
+            reason: "payment-or-finance-field",
+            confidence: "inferred",
+          }],
+        },
+      )
+    ).toThrow(ContextMaskMaterialityError);
+  });
+
+  it("leaves a declared-replaceable turn free to use a lossy transform", () => {
+    const result = maskForContext(
+      { note: "the key is sk-abcdefghijklmnop" },
+      {
+        decision: maskingDecision(),
+        detailUse: "replaceable",
+        matches: [{
+          dataClass: "secrets-credentials",
+          path: "note",
+          reason: "secret-shaped-token",
+          confidence: "deterministic",
+        }],
+      },
+    );
+
+    expect(result.value.note).toContain("[REDACTED]");
+    expect(result.value.note).not.toContain("sk-abcdefghijklmnop");
+  });
+});

--- a/apps/web/lib/govern/data/mask-for-context.ts
+++ b/apps/web/lib/govern/data/mask-for-context.ts
@@ -38,10 +38,27 @@ export class ContextMaskAuthorizationError extends Error {
   }
 }
 
+/**
+ * Raised when the caller has not declared the detail replaceable AND the
+ * projection would lose something (BI-0064680C).
+ *
+ * The guard used to rest on the declaration alone, which conflated two very
+ * different transforms. `redact`, `partial`, `omit` and `aggregate` are one-way:
+ * the answer comes back built on a value the model never saw, so without an
+ * explicit "replaceable" it must not run. `tokenize` is not — the value leaves
+ * as a token and `rehydrateResponse` restores it for an authorized viewer, so
+ * the answer the viewer reads is the answer the detail supports.
+ *
+ * Applying one bar to both did not make the platform safer; it made the
+ * tokenized path unreachable. No caller declares `sensitiveDetailUse`, so every
+ * coworker turn carrying so much as an email address fell to `unknown`, refused
+ * the mask, and clamped to `local_only` — with the built-and-tested token vault
+ * and response PEP sitting unused behind the refusal.
+ */
 export class ContextMaskMaterialityError extends Error {
   constructor(detailUse: SensitiveDetailUse) {
     super(
-      `Sensitive detail use is ${detailUse}; masking could make the answer misleading, so an eligible unmasked route is required.`,
+      `Sensitive detail use is ${detailUse} and this projection is not fully reversible; masking could make the answer misleading, so an eligible unmasked route is required.`,
     );
     this.name = "ContextMaskMaterialityError";
   }
@@ -95,6 +112,30 @@ export function applyContextTransform(
   }
 }
 
+/** Traversal counters. `tokenizedValueCount` is the reversible subset. */
+type MaskState = { transformedValueCount: number; tokenizedValueCount: number };
+
+/**
+ * Did this projection lose anything the viewer could not get back?
+ *
+ * Every transformed value must have been TOKENIZED — redact, partial, omit and
+ * aggregate are one-way — and every token must carry a rehydration binding with
+ * no unbound occurrence, which is exactly what `rehydrateResponse` requires
+ * before it will restore one. A projection that clears both is lossless from
+ * the viewer's side: the value leaves as a token and returns as itself.
+ */
+function isLosslessProjection(
+  state: MaskState,
+  tokenMap: ReadonlyMap<string, StoredRehydrationToken>,
+): boolean {
+  if (state.transformedValueCount === 0) return false;
+  if (state.tokenizedValueCount !== state.transformedValueCount) return false;
+  if (tokenMap.size === 0) return false;
+  return [...tokenMap.values()].every(
+    (stored) => stored.bindings.length > 0 && !stored.hasUnboundOccurrence,
+  );
+}
+
 /**
  * Apply the PDP-authorized default context mask profile to classifier-owned
  * paths. Callers cannot supply transform directives: the PDP obligation and
@@ -107,9 +148,6 @@ export function maskForContext<T>(
   assertMaskAuthorized(authority);
   if (authority.matches.length === 0) {
     return { value, transformation: "none", transformedValueCount: 0 };
-  }
-  if (authority.detailUse !== "replaceable") {
-    throw new ContextMaskMaterialityError(authority.detailUse);
   }
 
   const matchesByPath = groupMatchesByPath(authority.matches);
@@ -125,7 +163,7 @@ export function maskForContext<T>(
   }
 
   const tokenMap = new Map<string, StoredRehydrationToken>();
-  const state = { transformedValueCount: 0 };
+  const state = { transformedValueCount: 0, tokenizedValueCount: 0 };
   const transformed = visitContext(
     value,
     "",
@@ -135,6 +173,12 @@ export function maskForContext<T>(
     forcedTransform,
     authority.rehydrationBindings,
   ) as T;
+
+  // Materiality is decided on what the transform DID, not on what the caller
+  // declared. See the note on ContextMaskMaterialityError.
+  if (authority.detailUse !== "replaceable" && !isLosslessProjection(state, tokenMap)) {
+    throw new ContextMaskMaterialityError(authority.detailUse);
+  }
 
   const rehydrationHandle = tokenMap.size > 0
     ? storeRehydrationTokenMap(tokenMap)
@@ -213,7 +257,7 @@ function visitContext(
   path: string,
   matchesByPath: ReadonlyMap<string, readonly InferencePayloadMatch[]>,
   tokenMap: Map<string, StoredRehydrationToken>,
-  state: { transformedValueCount: number },
+  state: MaskState,
   forcedTransform?: ContextTransform,
   rehydrationBindings?: readonly RehydrationAuthorizationBinding[],
 ): unknown {
@@ -282,12 +326,13 @@ function applyAuthorizedTransform(
   value: unknown,
   transform: ContextTransform,
   tokenMap: Map<string, StoredRehydrationToken>,
-  state: { transformedValueCount: number },
+  state: MaskState,
   rehydrationBindings: readonly RehydrationAuthorizationBinding[],
 ): unknown {
   if (transform === "pass-through") return value;
   state.transformedValueCount += 1;
   if (transform !== "tokenize") return applyContextTransform(value, transform);
+  state.tokenizedValueCount += 1;
   const raw = typeof value === "string" ? value : JSON.stringify(value);
   const token = createRehydrationToken(raw);
   addStoredToken(tokenMap, token, raw, rehydrationBindings);
@@ -298,7 +343,7 @@ function transformMatchedString(
   value: string,
   matches: readonly InferencePayloadMatch[],
   tokenMap: Map<string, StoredRehydrationToken>,
-  state: { transformedValueCount: number },
+  state: MaskState,
   rehydrationBindings: readonly RehydrationAuthorizationBinding[],
 ): string {
   let transformed = value;
@@ -313,6 +358,7 @@ function transformMatchedString(
       const token = createRehydrationToken(raw);
       addStoredToken(tokenMap, token, raw, rehydrationBindings);
       state.transformedValueCount += 1;
+      state.tokenizedValueCount += 1;
       return token;
     });
   }
@@ -321,6 +367,7 @@ function transformMatchedString(
       const token = createRehydrationToken(raw);
       addStoredToken(tokenMap, token, raw, rehydrationBindings);
       state.transformedValueCount += 1;
+      state.tokenizedValueCount += 1;
       return token;
     });
   }


### PR DESCRIPTION
## The defect

`maskForContext` refused to run unless the caller declared `sensitiveDetailUse: "replaceable"`, applying one bar to two very different transforms.

`redact`, `partial`, `omit` and `aggregate` are one-way: the answer comes back built on a value the model never saw, so without an explicit declaration they must not run. `tokenize` is not — the value leaves as a token and `rehydrateResponse` restores it for an authorized viewer, so the answer the viewer reads is the answer the detail supports.

One bar for both did not make the platform safer. It made the tokenized path **unreachable**: no caller sets `sensitiveDetailUse` (the only setter in the tree is a test), so every coworker turn carrying so much as an email address fell to `unknown`, refused the mask, and clamped to `local_only` — with the built and unit-tested token vault and response PEP sitting unused behind the refusal.

## The change

The guard now runs after the traversal and asks what the transform actually did: every transformed value tokenized, every token carrying a rehydration binding with no unbound occurrence — the same conditions `rehydrateResponse` itself requires before restoring one. Anything lossy still refuses.

## Scope, stated plainly

**Inert until a caller supplies rehydration bindings.** With none, every token is unbound and the refusal stands exactly as before. This does not by itself return a coworker turn to cloud routing.

Wiring the coworker path needs a design decision that is deliberately not in this PR: `RehydrationRouteBinding` requires a record-scoped `subject` (`contact` / `account` / `employee` id), and a regex-matched email in inbox free text has no record id. That question is open on [BI-0064680C].

## Verification

- `vitest run lib/govern/data lib/inference/data-screening` — 270 passed.
- New positive test confirmed red before the change.
- Existing behaviour preserved by test: a declared-replaceable turn may still use a lossy transform; an undeclared turn still refuses for redaction, for a lossy PDP profile, for an unbound token, and for a binding that does not cover the path.
- `pnpm pregate:preflight` — 61 guards clean. `tsc --noEmit` — clean.
- `pnpm run pregate` — PASS, evidence `cmtj2e4sxd1nq01nupejrxrm6`, gated sha `cbd9c7e776eb`.

Rebased onto current `main` before gating.