### PR TITLE
doc(directory): record Phase 6, and retire two stale blocker diagnoses

### DIFF
--- a/docs/superpowers/plans/2026-08-23-directory-service-identity-absorption.md
+++ b/docs/superpowers/plans/2026-08-23-directory-service-identity-absorption.md
@@ -206,6 +206,29 @@ implies the adopt stance. Update the stated 80/20 allocation wherever touched.
 implies DPF adopts authentik as a runtime service; every one of the 111 tasks has a
 recorded disposition.
 
+## Phase 6 — Serve it (`BI-A91004A7`)
+
+Phase 3 delivered the protocol and no install served it: `createLdapServer` was
+exported and never invoked outside tests. Phase 6 is the entrypoint that turns a
+built listener into a served one — `startLdapListener` composing
+`buildDirectoryProjection` with `createBindVerifier`, the `DPF_LDAP_ENABLED` gate,
+the three-state operator surface (disabled / listening / refused), the published
+compose port, and org-PKI material read through the existing `DPF_STATE_DIR` mount
+rather than a second certificate or a second mount.
+
+This phase was not in the original sequence. It exists because "no deliverable in
+this design exists only as a checkbox" has to mean *running*, not *merged* — the
+epic's own verification passed 78 unit tests and six real-`ldapsearch` runs while
+no install served LDAP, because every one of those tests starts the listener itself.
+
+**Verification:** `ldapsearch` against the **running install**, not a test-spawned
+server. Satisfied 2026-08-29 on the canonical runtime: portal log
+`[ldap] Serving the directory over LDAPS on port 636`, `:::636` bound in-container,
+TLS chain verified to the organization CA (`Verify return code: 0`), and a real
+OpenLDAP client receiving the bind verifier's own diagnostic. Survived a subsequent
+self-upgrade. A successful bind returning entries is **not** demonstrated: that
+needs a credential for a production principal, which was deliberately not minted.
+
 ## Cross-cutting verification
 
 Per the change-impact contract for this branch and AGENTS.md §4:
@@ -236,6 +259,7 @@ deliverable maps to a live backlog item — none is stored as a checkbox.
 | 3 | LDAP listener over org-PKI TLS | yes | `BI-F7317D65` | 2 |
 | 4 | Principal becomes the authentication root | yes | `BI-CEACBD0D` | 2 |
 | 5 | Supersede the 2026-04-22 plan across 10 documents | yes | `BI-5167932D` | 0 |
+| 6 | Serve the listener: runtime entrypoint, config, operator surface, org-PKI wiring | yes | `BI-A91004A7` | 3 |
 
 **Governed coverage receipt: blocked by `BI-72F368BC`.**
 
@@ -249,12 +273,24 @@ and refused:
 | 2 | `plan-artifact-invalid` — "…has no recorded head" | branch claimed via `claim_backlog_item_for_work`; capsule bound to the repo but `headSha` unset |
 | 3 | `traceability-incomplete` — "BacklogItem BI-C7362CA5 has no initiative scope baseline" | `headSha` synced to `58126dce0` via `adopt_worktree`; plan blob `77e1faf42f` pushed and confirmed on the remote |
 
-Failure 3 is the live blocker and is not surface-specific: per `BI-72F368BC`,
-**zero `initiative_scope_baseline` activities exist install-wide**, and the only
-writer (`approveInitiativeBaseline`, reachable through `record_initiative_design_review`
-gate `spec-approval`) hard-codes `requiresIndependentReviewer: true`. This install
-has one human principal, so the author can never be independent of the reviewer and
-the baseline can never be written — by any surface, Build Studio included.
+Failure 3 **was** the live blocker, and as of 2026-09-01 it no longer holds. The
+mechanism is unchanged — `approveInitiativeBaseline` (reachable through
+`record_initiative_design_review` gate `spec-approval`) still hard-codes
+`requiresIndependentReviewer: true` at `baseline-repository.ts:440` — but the two
+facts that made it unsatisfiable have both moved:
+
+| Claim when this was written | Measured 2026-09-01 |
+|---|---|
+| zero `initiative_scope_baseline` activities install-wide | **7**, minted 2026-08-31 and 2026-09-01 |
+| one human principal, so no reviewer can be independent | **3 active human principals** |
+
+So the baseline *can* now be written on this install, and has been — for other
+items. None of the seven belongs to this epic, which is why every `EP-24741BBF`
+item still reads unbaselined. The remaining work is to route this plan's gates to
+an eligible independent reviewer, not to wait on a platform fix.
+
+Do not re-derive the old conclusion from this section: it is retained because the
+sequencing lessons below are still true, not because the blocker still stands.
 
 Failures 1 and 2 were self-inflicted sequencing and are recorded because the
 ordering is not obvious: a workroom must be **repository-bound and head-synced**
@@ -265,4 +301,5 @@ before a receipt is attempted, and `create_workroom` alone does neither.
 > `BI-B9403248` was closed 2026-08-21 by PR #4422. The live blocker is
 > `BI-72F368BC`. The message should be repointed when the gate is fixed.
 
-Restore the governed receipt on this plan when `BI-72F368BC` ships.
+Restore the governed receipt on this plan by routing gate `spec-approval` to an
+eligible independent reviewer; it is no longer gated on `BI-72F368BC` shipping.

--- a/docs/superpowers/specs/2026-08-23-directory-service-identity-absorption-design.md
+++ b/docs/superpowers/specs/2026-08-23-directory-service-identity-absorption-design.md
@@ -281,7 +281,7 @@ Scope for this epic: **bind, search, group membership. Over TLS. Read-only.**
 - **TLS from the existing org PKI (Step CA).** No second CA, no self-signed fallback — a test asserts the chain.
 - **Bind** for all three classes; a service account binds as a first-class peer of a human.
 - **Search authorization is mandatory.** What a bind identity may see is filtered by §8.4 and by the binding principal's own clearance. An anonymous or low-privilege bind must not enumerate the tree. A directory that answers every search identically is an information-disclosure surface.
-- **Explicitly out of scope:** SAML, OIDC, SCIM, and LDAP write operations. Each is its own surface and its own decision. Attempting all four at once is how the predecessor plan reached 111 tasks and shipped nothing.
+- **Explicitly out of scope:** SAML, OIDC, SCIM, and LDAP write operations. Each is its own surface and its own decision. Attempting all four at once is how the predecessor plan reached 111 tasks and shipped nothing. The exclusions are recorded rather than silent: SCIM as `BI-2C44C3EF`, OIDC as `BI-88363C2C`.
 
 **Acceptance is a real client.** `ldapsearch` binds over TLS and returns correct results for a human, an agent, and a service account, against the running app. Structural verification does not count here — this is a protocol, and only a real client proves conformance.
 
@@ -302,6 +302,24 @@ The serving contract:
 - **A listener that cannot start does not take the portal with it.** It is reported, loudly, and every other surface keeps serving.
 
 Operator procedure: [serving the directory](../../install/serve-the-directory.md).
+
+**Outcome, measured 2026-08-29 on the canonical runtime.** The amended acceptance
+above is met: the running install serves LDAPS on 636 from the organization CA.
+Portal log `[ldap] Serving the directory over LDAPS on port 636`; `:::636` bound
+in-container; TLS chain verified to the org root (`Verify return code: 0`, issuer
+`DPF Organization CA Intermediate CA`); and a real OpenLDAP client received the
+bind verifier's own diagnostic, confirming request decode, verifier dispatch,
+response encode and client parse end to end. Verified again after a subsequent
+self-upgrade, so the capability is carried by configuration rather than by a
+hand-held container.
+
+Two things this deliberately does **not** claim. A successful bind returning
+published entries was not demonstrated — that needs a credential for a production
+principal, and minting one (a client certificate whose CN is a real `principalId`
+would do it) manufactures an authentication credential for a real identity, which
+is not a verification step. And the disabled case was verified before enabling:
+with `DPF_LDAP_ENABLED=0` nothing was bound in-container and a real client could
+not connect, so the published port is inert until an operator turns it on.
 
 ## 10. Authorization Stays Where It Is
 
@@ -384,8 +402,8 @@ need to make.
 ## 14. Open Questions
 
 1. **Which credential scheme for service-account binds** — shared secret, or mTLS from the org PKI only? mTLS is stronger and reuses existing substrate, but not every client that needs to bind can present a client certificate. Resolve in `BI-F7317D65`.
-2. **Does `User` survive as a table, or fold into `Principal` with a credential side-table?** D2 says side-table; the migration shape needs its own review given `User` carries ~70 relations. This is the highest-risk mechanical change in the epic.
-3. **Multi-organization installs** — one tree per `Organization`, or one tree with organizational branches? Deferred until a live install needs it; noted so it is not silently assumed away.
+2. **Does `User` survive as a table, or fold into `Principal` with a credential side-table?** D2 says side-table; the migration shape needs its own review given `User` carries ~70 relations. This is the highest-risk mechanical change in the epic. Filed as `BI-D070FC77`, deliberately alone: a migration touching ~70 relations cannot be reverted as one clean concern if it rides along with anything else.
+3. **Multi-organization installs** — one tree per `Organization`, or one tree with organizational branches? Deferred until a live install needs it; noted so it is not silently assumed away. Filed as `BI-FAF6A01E`, which names the exact assumption site: `buildDirectoryProjection` takes the first `Organization` by `createdAt`.
 4. **Absorbed protocol code provenance** — vendored with notice, or reimplemented from the RFC with `ldapjs` as reference only? Legal answer is either; the maintenance answer differs. Resolve in `BI-27E462BA`.
 
 ## 15. Relationship to Existing Work


### PR DESCRIPTION
Documentation-only. Two corrections to the directory-service design and plan, plus one stale-diagnosis retraction that would otherwise mislead the next reader into not trying.

## Phase 6 was missing from the plan

`BI-A91004A7` shipped the runtime entrypoint that turned the built LDAP listener into a served one — the phase that actually made the epic's headline outcome real. The plan still stopped at Phase 5, so that phase had no coverage row and no verification statement.

Adds the Phase 6 section and its row in **Backlog coverage**, including what the verification does *not* claim.

## The design doc never recorded whether its own acceptance was met

§9.1 amended the acceptance to "a real client against the **running install**". It never said whether that happened. It now records the measured outcome on the canonical runtime — portal log, in-container bind, TLS chain verified to the organization CA, a real OpenLDAP client reaching the bind verifier, and survival across a subsequent self-upgrade — alongside the two things deliberately not claimed:

- no successful bind returning entries (that needs a credential for a production principal; minting one is not a verification step)
- the disabled case was verified *before* enabling, so the published port is demonstrably inert until an operator turns it on

## §14's open questions had no live backlog items

Which is the exact failure mode this epic exists to correct — "no deliverable exists only as a checkbox" applies to deferred questions too. Q2 now names `BI-D070FC77`, Q3 names `BI-FAF6A01E`, and the out-of-scope protocol surfaces name `BI-2C44C3EF` (SCIM) and `BI-88363C2C` (OIDC).

## The "governed receipt is blocked" note had gone stale

The plan asserted two facts as permanent. Both have moved:

| Claim when written | Measured 2026-09-01 |
|---|---|
| zero `initiative_scope_baseline` activities install-wide | **7**, minted 2026-08-31 / 09-01 |
| one human principal, so no reviewer can be independent | **3 active human principals** |

The mechanism is unchanged (`approveInitiativeBaseline` still hard-codes `requiresIndependentReviewer: true` at `baseline-repository.ts:440`), but baselines are demonstrably being written on this install now — just none for this epic. That is a routing gap, not a platform blocker, and the note now says so. The sequencing lessons in that section are retained, because they are still true and still not obvious.

The live blocker is now filed precisely as `BI-87148687`: a server-issued reviewer packet reaches the target agent, the agent holds the grant in `AgentToolGrant`, and the dispatch still fails `missing-terminal-writer` with `executedToolCount: 0`.

## Design grounding

Corrects the existing canonical design (`docs/superpowers/specs/2026-08-23-directory-service-identity-absorption-design.md`) and its plan. No new artifact, no runtime code, no schema, no route.

## Verification

`pnpm pregate:preflight` — **61/61 guards clean**. Docs-only, so no local-CI gate record is required for the push.

Docs-Impact-Decision: design- and plan-document corrections only. No route, runtime code, schema or user-facing surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)