### PR TITLE
fix(routing): give confidential coworkers an accurate clearance dead-end (BI-431524DF)

### DIFF
--- a/apps/web/lib/routing/pipeline-v2.ts
+++ b/apps/web/lib/routing/pipeline-v2.ts
@@ -549,10 +549,19 @@ export async function routeEndpointV2(
       `excluded=${allCandidates.length}`,
     );
     for (const line of allExcludedReasons) console.warn(`[routing]   ✗ ${line}`);
+    // When an active, capable provider was dropped PURELY on sensitivity clearance
+    // (gate 7 in getExclusionReasonV2 returns its reason only after status,
+    // capability and quality gates have passed), the empty set is a data-governance
+    // block, not an outage. Surface that so the coworker-facing copy names the real
+    // lever (clear a business account / provision a local model) instead of sending
+    // the operator to re-check already-connected providers. (BI-431524DF)
+    const clearanceBlocked = allExcludedReasons.some((r) =>
+      /Sensitivity clearance missing/i.test(r),
+    );
     return {
       selectedEndpoint: null,
       selectedModelId: null,
-      reason: `No eligible endpoints for task type '${contract.taskType}' with sensitivity '${sensitivity}'. ${allCandidates.length} endpoint(s) excluded.`,
+      reason: `No eligible endpoints for task type '${contract.taskType}' with sensitivity '${sensitivity}'. ${allCandidates.length} endpoint(s) excluded.${clearanceBlocked ? ` No connected provider is cleared for '${sensitivity}' data.` : ""}`,
       fitnessScore: 0,
       fallbackChain: [],
       candidates: allCandidates,

--- a/apps/web/lib/tak/inference-dead-ends.test.ts
+++ b/apps/web/lib/tak/inference-dead-ends.test.ts
@@ -6,6 +6,7 @@ import {
   localCapacityHeldHandoff,
   noEligibleModelHandoff,
   providersBusyHandoff,
+  sensitivityClearanceHandoff,
   unexplainedDeadEndHandoff,
 } from "./inference-dead-ends";
 
@@ -17,6 +18,7 @@ describe("dead-end replies hand off instead of asking the user to poll", () => {
     ["no eligible model", noEligibleModelHandoff()],
     ["providers busy", providersBusyHandoff()],
     ["local capacity held", localCapacityHeldHandoff()],
+    ["sensitivity clearance", sensitivityClearanceHandoff("confidential")],
     ["unexplained dead end", unexplainedDeadEndHandoff()],
   ] as const;
 
@@ -121,6 +123,41 @@ describe("describeToolRouteFailure classifies the deferral that stranded the own
       .toBe(noEligibleModelHandoff());
     expect(describeToolRouteFailure("All endpoints failed for conversation", 0))
       .toBe(providersBusyHandoff());
+  });
+
+  // BI-431524DF. A confidential coworker's empty route is a data-governance block,
+  // not an outage — it must NOT tell the operator to re-check connected providers.
+  it("names the clearance lever when the block is sensitivity, not availability", () => {
+    const routerReason =
+      "No eligible endpoints for task type 'conversation' with sensitivity 'confidential'. " +
+      "3 endpoint(s) excluded. No connected provider is cleared for 'confidential' data.";
+    const message = describeToolRouteFailure(routerReason, 0);
+
+    expect(message).toBe(sensitivityClearanceHandoff("confidential"));
+    // The wrong advice the generic branch would give, explicitly absent.
+    expect(message).not.toMatch(/provider status/i);
+    // The real levers, present.
+    expect(message).toMatch(/no-training/i);
+    expect(message).toMatch(/local model/i);
+    // Never implies attesting a personal subscription.
+    expect(message).toMatch(/business or enterprise account/i);
+  });
+
+  it("classifies the sensitivity-clearance dead end as policy-or-capability", () => {
+    const outcome = describeToolRouteFailureOutcome(
+      "No eligible endpoints for task type 'conversation' with sensitivity 'restricted'. " +
+        "2 endpoint(s) excluded. No connected provider is cleared for 'restricted' data.",
+      0,
+    );
+    expect(outcome.kind).toBe("policy-or-capability");
+    expect(outcome.message).toBe(sensitivityClearanceHandoff("restricted"));
+  });
+
+  // Regression: an empty route with NO clearance clause stays the generic copy —
+  // the clearance branch must not swallow ordinary "no eligible endpoints" cases.
+  it("leaves a non-clearance empty route on the generic hand-off", () => {
+    expect(describeToolRouteFailure("No eligible endpoints for task type 'conversation'", 0))
+      .toBe(noEligibleModelHandoff());
   });
 
   it("falls through to the unexplained hand-off, not to a fabricated cause", () => {

--- a/apps/web/lib/tak/inference-dead-ends.ts
+++ b/apps/web/lib/tak/inference-dead-ends.ts
@@ -37,6 +37,35 @@ export function noEligibleModelHandoff(): string {
 }
 
 /**
+ * Routing eliminated every candidate specifically because no connected provider
+ * is cleared for this coworker's data sensitivity — the confidential-data fence
+ * working as designed, not an outage (BI-431524DF). The generic "no eligible
+ * model" copy sends the operator to re-check provider status, which is the wrong
+ * advice here: the providers ARE connected and active; they are held back only
+ * because a personal-subscription account carries no commercial no-training
+ * guarantee. Name the two real levers instead — clear a business cloud account,
+ * or provision a capable local model — and never imply a personal subscription
+ * should be attested.
+ */
+export function sensitivityClearanceHandoff(sensitivity: string): string {
+  return buildHumanHandoff({
+    blocker:
+      `This coworker handles ${sensitivity} work, and none of the connected AI providers are cleared for ` +
+      `${sensitivity} data. Cloud providers such as Claude or GPT stay limited to public work until their ` +
+      `account's data policy is reviewed — a personal subscription is deliberately not cleared for ${sensitivity} ` +
+      `data, so ${sensitivity} content is never sent to a provider that might train on it. The built-in local ` +
+      `model is cleared for it but is not strong enough for this request.`,
+    steps: [
+      `To let a cloud provider handle ${sensitivity} work: open Platform > AI Operations > Providers & Routing, ` +
+      `and only on a genuine business or enterprise account with a no-training agreement, attest its data policy ` +
+      `(mark it operator-attested, or upload the contract).`,
+      `To keep ${sensitivity} work fully on-premises: configure a stronger local model that is cleared for ${sensitivity} data.`,
+    ],
+    verify: `re-check which models this coworker can reach for ${sensitivity} work`,
+  });
+}
+
+/**
  * Endpoints exist but all transiently failed. Genuinely nothing to configure,
  * so the hand-off is one step — but it stays a hand-off, so the reply ends on
  * the user's next action rather than on the outage.
@@ -277,6 +306,17 @@ function describeToolRouteFailureMessage(
 
   const contextCapacityFailure = describeContextCapacityFailure(msg);
   if (contextCapacityFailure) return contextCapacityFailure;
+
+  // Data-governance gap, NOT an outage: every candidate was eliminated because no
+  // connected provider is cleared for this coworker's data sensitivity (the router
+  // appends this clause when an active, capable provider was dropped purely on
+  // clearance). Must be checked BEFORE the generic "No eligible endpoints" branch,
+  // whose copy ("re-check provider status") is wrong advice here — the providers
+  // are connected; they simply are not cleared for confidential data. (BI-431524DF)
+  const clearanceBlock = msg.match(/No connected provider is cleared for '([^']+)' data/i);
+  if (clearanceBlock) {
+    return sensitivityClearanceHandoff(clearanceBlock[1]);
+  }
 
   // Config/capacity gap: routing eliminated EVERY candidate (e.g. the cloud
   // provider's sign-in expired AND the bundled local model's context window is


### PR DESCRIPTION
## What
A CONFIDENTIAL coworker (e.g. the COO) whose only confidential-cleared provider is the too-weak local model got the generic **"No AI model can handle this request — check provider status"** dead-end. That misdiagnoses a *working* data-governance fence as an outage: Claude/Codex **are** connected and active; they sit at `["public"]` clearance because a personal-subscription OAuth account carries no commercial no-training guarantee (`deriveActivationClearance`). So the platform correctly refuses to send confidential data to them — but tells the operator to reconnect providers that are already connected.

## Fix
- **Router** (`pipeline-v2.ts`): the empty-eligible-set branch already computed per-endpoint exclusion reasons and dropped them. When an *active, capable* provider was excluded **purely** on sensitivity clearance (gate 7 fires only after status/capability/quality gates pass), the router now appends a parseable clause to the reason.
- **Classifier** (`inference-dead-ends.ts`): a new `sensitivityClearanceHandoff(sensitivity)` case, checked ahead of the generic branch, names the two real levers — attest a **business/enterprise no-training** account, or provision a **capable local model** — and never implies attesting a personal subscription.

The confidential fence itself is **unchanged**; only the diagnosis and operator guidance are corrected.

## Tests
- 33 dead-end tests pass (3 new focused cases + structural coverage): clearance clause → new message; `restricted` → same path + `policy-or-capability` kind; **regression** — a non-clearance empty route stays the generic hand-off.
- Full routing suite: 1535 tests pass. Typecheck clean. Local-CI gate green (evidence `cmtj2sf3yda8l01nurssox0tt`).

## Design grounding
- **Specs/plans reviewed:** none governs coworker dead-end copy; the classifier's own doctrine (BI-33F1EA72, BI-A89E4827) is the standing record. Searched `docs/superpowers/specs|plans` — no sensitivity-routing/dead-end-copy spec.
- **Code substrate reviewed:** `inference-dead-ends.ts`, `pipeline-v2.ts`, `govern/activate-provider.ts` (`deriveActivationClearance` — clearance-derivation source of truth).
- **Decision:** no-contract-change; more specific branch + parseable router clause. No schema/enum/type change.

Docs-Impact-Decision: internal diagnostic-string enrichment + an added coworker error-message case; docs linked to `pipeline-v2.ts` are internal architecture/strategy notes, not user guides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)