### PR TITLE
fix(worktree-gate): parse pnpm ignored-builds by section; classify @scarf/scarf (BI-0E472AE0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,11 @@
     "node": ">=20",
     "pnpm": ">=9"
   },
+  "pnpm": {
+    "ignoredBuiltDependencies": [
+      "@scarf/scarf"
+    ]
+  },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@mermaid-js/mermaid-cli": "11.16.0",

--- a/scripts/lib/bootstrap-worktree-deps.mjs
+++ b/scripts/lib/bootstrap-worktree-deps.mjs
@@ -138,14 +138,36 @@ function run(cmd, args, cwd, opts = {}) {
   return (opts.execute ?? executeCommand)(cmd, args, cwd, opts).ok;
 }
 
+// `pnpm ignored-builds` prints several sections. Only the "Automatically
+// ignored builds during installation:" section lists build scripts that are NOT
+// covered by pnpm config — the UNCLASSIFIED set this gate must flag for a
+// dependency-policy decision. Sibling sections ("Explicitly ignored package
+// builds (via pnpm.ignoredBuiltDependencies):", the onlyBuiltDependencies
+// counterpart) are already-classified and must NOT be flagged. Package entries
+// are indented under their header; a blank line or the next non-indented
+// "…:" header ends the section; "None", bullet markers, and pnpm's "hint:"
+// advisory lines are not packages. A naive "everything after the first header"
+// parser mis-read the section headers and hint lines as package names, so an
+// operator who correctly classified a build (moving it to the Explicitly
+// section) could never converge the gate.
 export function classifyIgnoredBuilds(stdout) {
-  const lines = String(stdout ?? "").split(/\r?\n/).map((line) => line.trim());
-  const header = lines.findIndex((line) => /ignored builds during installation/i.test(line));
-  if (header < 0) return { ok: true, packages: [] };
-  const packages = lines
-    .slice(header + 1)
-    .map((line) => line.replace(/^[-*•]\s*/, ""))
-    .filter((line) => line.length > 0 && !/^none\.?$/i.test(line));
+  const packages = [];
+  let inUnclassifiedSection = false;
+  for (const raw of String(stdout ?? "").split(/\r?\n/)) {
+    if (/^\s*$/.test(raw)) {
+      inUnclassifiedSection = false; // a blank line closes the current section
+      continue;
+    }
+    const isSectionHeader = /^\S/.test(raw) && /:\s*$/.test(raw);
+    if (isSectionHeader) {
+      inUnclassifiedSection = /ignored builds during installation/i.test(raw);
+      continue;
+    }
+    if (!inUnclassifiedSection) continue;
+    const entry = raw.trim().replace(/^[-*•]\s*/, "");
+    if (!entry || /^none\.?$/i.test(entry) || /^hint:/i.test(entry)) continue;
+    packages.push(entry);
+  }
   return { ok: packages.length === 0, packages };
 }
 

--- a/scripts/lib/bootstrap-worktree-deps.test.mjs
+++ b/scripts/lib/bootstrap-worktree-deps.test.mjs
@@ -57,6 +57,31 @@ test("ignored-build readiness fails closed when pnpm reports an unclassified scr
   });
 });
 
+test("ignored-build parser ignores the Explicitly-ignored section and hint lines (BI @scarf gate)", () => {
+  // The real multi-section `pnpm ignored-builds` output once a build is
+  // classified into pnpm.ignoredBuiltDependencies. Nothing is unclassified, so
+  // the gate must pass — the naive parser used to flag the section header and
+  // the package under it, jamming every push from the worktree.
+  const classified = [
+    "Automatically ignored builds during installation:",
+    "  None",
+    "",
+    "Explicitly ignored package builds (via pnpm.ignoredBuiltDependencies):",
+    "  @scarf/scarf",
+  ].join("\n");
+  assert.deepEqual(classifyIgnoredBuilds(classified), { ok: true, packages: [] });
+
+  // Before classification: the build sits under "Automatically ignored" and pnpm
+  // appends advisory "hint:" lines. Flag the package, never the hints.
+  const unclassified = [
+    "Automatically ignored builds during installation:",
+    "  @scarf/scarf",
+    "hint: To allow the execution of build scripts, add its name to \"pnpm.onlyBuiltDependencies\".",
+    "hint: If you don't want to build a package, add it to the \"pnpm.ignoredBuiltDependencies\" list.",
+  ].join("\n");
+  assert.deepEqual(classifyIgnoredBuilds(unclassified), { ok: false, packages: ["@scarf/scarf"] });
+});
+
 test("compile-ready ONLY when deps resolved AND the cheap gate passes", () => {
   assert.equal(classifyReadiness({ hasNodeModules: true, depProbeOk: true, gateOk: true }), "compile-ready");
   assert.equal(classifyReadiness({ hasNodeModules: true, depProbeOk: true, gateOk: false }), "source-only");


### PR DESCRIPTION
## Problem

The worktree build-script classifier (`classifyIgnoredBuilds` in `scripts/lib/bootstrap-worktree-deps.mjs`) found the first "…ignored builds during installation" header and treated **every** following line as an unclassified package. Modern pnpm (10.33) prints several sections plus advisory text, so the parser swallowed the `Explicitly ignored package builds (via pnpm.ignoredBuiltDependencies):` **section header** and pnpm's `hint:` lines as package names.

Effect: the worktree stayed `source-only` (gate BLOCKED: "sandbox drift"), forcing a pre-push override on **every** push from the worktree — even after a build script was correctly classified. Surfaced repeatedly by `@scarf/scarf`, a telemetry `postinstall` pulled in transitively via `@stoplight/prism`.

## Fix

1. **Parser** — read only the `Automatically ignored builds during installation:` (unclassified) section, stop at a blank line or the next `…:` header, and skip `None`, bullets, and `hint:` lines. Already-classified sibling sections are no longer flagged.
2. **Classify `@scarf/scarf`** into `pnpm.ignoredBuiltDependencies` (root `package.json`) — denies its phone-home `postinstall` (a small dependency-sovereignty win) and moves it to the Explicitly-ignored section.
3. **Tests** — added coverage for the real multi-section output (classified → pass; unclassified-with-hints → flag only the package).

## Verification

- `node --test scripts/lib/bootstrap-worktree-deps.test.mjs` → 26 pass.
- `node scripts/lib/bootstrap-worktree-deps.mjs .` → `compile-ready` / `gateOk: true` (was `source-only`).
- Deterministic guard-parity preflight clean. Push used a recorded `install-bootstrap-recovery` override because the shared local-CI lease was contended (queue pos 5); the cloud merge queue runs the full build.

## Why it matters

This false-positive was silently forcing overrides on every worktree push — masking the exact class of thing the gate exists to catch. `@scarf/scarf` is also a concrete example of the external-dependency / vertical-integration direction (`EP-8DC217EB`, `dependency-reduction-routine`).

Tracked by BI-0E472AE0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)