### PR TITLE
fix(inference): stop classifying git authorship emails as customer records (BI-EBE25715)

### DIFF
--- a/apps/web/lib/inference/data-screening/classify-payload-authorship-email.test.ts
+++ b/apps/web/lib/inference/data-screening/classify-payload-authorship-email.test.ts
@@ -1,0 +1,66 @@
+// BI-EBE25715 — an address carried as authorship metadata is not a customer
+// contact record.
+//
+// Live failure this pins: a Build Studio code-gen turn was classified
+// `customer-records` (deterministic, reason `contact-detail`) purely because the
+// payload embedded commit history. That escalated declaredSensitivity `internal`
+// to measuredSensitivity `confidential`, the vertical customer-records pack
+// returned `policyEffect: "deny"`, screening set `routeEffect: "local-only"`,
+// and routing then excluded every cloud endpoint with "Residency policy
+// 'local_only' requires a local provider". The turn died whenever local-CI held
+// the host capacity reservation, while eligible cloud models sat idle.
+import { describe, expect, it } from "vitest";
+
+import { classifyInferencePayload } from "./classify-payload";
+
+function classify(text: string) {
+  return classifyInferencePayload({
+    systemPrompt: "",
+    messages: [{ role: "user", content: text }],
+  } as Parameters<typeof classifyInferencePayload>[0]);
+}
+
+const contactMatches = (text: string) =>
+  classify(text).matches.filter((m) => m.reason === "contact-detail");
+
+describe("contact-detail exempts authorship metadata (BI-EBE25715)", () => {
+  it("does not classify a DCO sign-off as a customer record", () => {
+    expect(contactMatches("Signed-off-by: Mark Bodman <markdbodman@gmail.com>")).toHaveLength(0);
+  });
+
+  it("does not classify a Co-Authored-By trailer as a customer record", () => {
+    expect(
+      contactMatches("Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"),
+    ).toHaveLength(0);
+  });
+
+  it("does not classify a noreply address as a customer record", () => {
+    expect(contactMatches("mail sent from <no-reply@example.com>")).toHaveLength(0);
+  });
+
+  it("does not classify the acting account identifier as a customer record", () => {
+    expect(contactMatches("createdById: admin@dpf.local")).toHaveLength(0);
+  });
+
+  it("STILL classifies a bare address that is not authorship metadata", () => {
+    expect(contactMatches("the customer wrote in from jane.doe@acme.com")).toHaveLength(1);
+  });
+
+  it("STILL classifies a real address that appears alongside a trailer", () => {
+    const text = [
+      "Signed-off-by: Mark Bodman <markdbodman@gmail.com>",
+      "Customer contact: jane.doe@acme.com",
+    ].join("\n");
+    expect(contactMatches(text)).toHaveLength(1);
+  });
+
+  it("STILL classifies a phone number — the exemption is email-shaped only", () => {
+    expect(contactMatches("reach them on 415-555-0132")).toHaveLength(1);
+  });
+
+  it("leaves a payload with no contact detail alone", () => {
+    expect(
+      contactMatches("gate-worktree.mjs:1556 assigns summarizeLocalCiOutput to failureSummary"),
+    ).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/inference/data-screening/classify-payload.ts
+++ b/apps/web/lib/inference/data-screening/classify-payload.ts
@@ -22,6 +22,14 @@ type ClassRule = {
   pathPattern?: RegExp;
   textPattern?: RegExp;
   /**
+   * Occurrences matching this are removed from the probe text BEFORE
+   * `textPattern` is evaluated, so the rule fires only on evidence that is NOT
+   * exempt. Strip-then-retest rather than skip-if-present on purpose: a payload
+   * carrying both a DCO trailer and a genuine customer address must still
+   * match on the genuine one (BI-EBE25715).
+   */
+  textExemptionPattern?: RegExp;
+  /**
    * BI-CD13D818 — this rule is built from vocabulary that is ALSO ordinary
    * English outside its protected domain ("performance", "benefits", "manager",
    * "incident"). On its own such a match may not escalate a turn to
@@ -42,6 +50,12 @@ type ClassRule = {
 // Split by precision (BI-CD13D818). The first set names employment data and
 // nothing else; the second is real HR vocabulary that is ALSO everyday English
 // on an AI-operations, capacity, or product surface, so it needs corroboration.
+// Addresses that identify a COMMIT AUTHOR or the acting account, not a customer.
+// Matched with the surrounding trailer/identifier so a bare address elsewhere in
+// the same payload is still classified normally (BI-EBE25715).
+const GIT_AUTHORSHIP_EMAIL_PATTERN =
+  /(?:signed-off-by|co-authored-by|author|committer|reported-by|reviewed-by|acked-by|createdby(?:id)?|actorid)\s*:?\s*[^\n<]*<?[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}>?|<(?:noreply|no-reply|do-not-reply)@[A-Z0-9.-]+\.[A-Z]{2,}>/i;
+
 const EMPLOYEE_RECORD_VALUE_PATTERN =
   /\b(?:salary|performance review|disciplinary|manager-only|payroll)\b/i;
 const EMPLOYEE_RECORD_AMBIGUOUS_VALUE_PATTERN =
@@ -70,6 +84,20 @@ const CLASS_RULES: readonly ClassRule[] = [
     confidence: "deterministic",
     textPattern:
       /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b|\b(?:\+?1[-.\s]?)?\(?[2-9]\d{2}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/i,
+    // BI-EBE25715: an address carried as AUTHORSHIP METADATA is not a customer
+    // contact record. Build Studio payloads routinely embed commit history —
+    // `Signed-off-by:` (the DCO the repo requires on every commit),
+    // `Co-Authored-By:`, `Author:` — plus the operator's own account id. Those
+    // matched `contact-detail` deterministically, which is precise evidence, so
+    // it escalated the turn to `confidential` on its own and the vertical
+    // customer-records pack denied external routing. The observed effect was
+    // that ordinary source-code turns were pinned to `local_only` and then died
+    // whenever local-CI held the host reservation.
+    //
+    // Scope is deliberately narrow: the address must sit in a recognised
+    // trailer/identifier position. A bare address anywhere else still matches,
+    // so a real customer email pasted into a message is unaffected.
+    textExemptionPattern: GIT_AUTHORSHIP_EMAIL_PATTERN,
   },
   {
     dataClass: "customer-records",
@@ -234,6 +262,19 @@ const CONFIDENTIAL_CLASSES = new Set<InferenceDataClass>([
   "source-code",
 ]);
 
+/**
+ * Remove every occurrence of `exemption` from `text` so a rule's own pattern is
+ * evaluated against the remainder only. Returns the text unchanged when the
+ * exemption never matches, so the common path costs one failed regex test.
+ */
+function stripExemptSpans(text: string, exemption: RegExp): string {
+  const global = exemption.global
+    ? exemption
+    : new RegExp(exemption.source, `${exemption.flags}g`);
+  global.lastIndex = 0;
+  return text.replace(global, " ");
+}
+
 export function classifyInferencePayload(
   input: InferencePayloadClassificationInput,
 ): InferencePayloadClassification {
@@ -242,9 +283,12 @@ export function classifyInferencePayload(
 
   for (const probe of probes) {
     for (const rule of CLASS_RULES) {
+      const probeText = rule.textExemptionPattern
+        ? stripExemptSpans(probe.text, rule.textExemptionPattern)
+        : probe.text;
       if (
         rule.pathPattern?.test(normalizeProbePath(probe.path)) ||
-        rule.textPattern?.test(probe.text)
+        rule.textPattern?.test(probeText)
       ) {
         matches.push({
           dataClass: rule.dataClass,

--- a/apps/web/lib/tak/inference-dead-ends.test.ts
+++ b/apps/web/lib/tak/inference-dead-ends.test.ts
@@ -173,13 +173,23 @@ describe("the capacity reply names the window when it knows one", () => {
 
   it("puts the window in the step, not in a separate sentence to skim past", () => {
     const message = localCapacityHeldHandoff(false, new Date("2026-08-23T20:17:00.000Z"), now);
-    expect(message).toMatch(/^1\. Send the message again in about 3 minutes/m);
+    expect(message).toMatch(/^1\. Send the message again in about 3 minutes at the earliest/m);
     expect(message).toMatch(/Nothing is misconfigured/);
   });
 
-  it("falls back to the generic wait when no window is known", () => {
+  // BI-EBE25715: with no window we do not know how long the host stays
+  // reserved, and a queue behind the current claim can make it indefinite.
+  // Saying "a couple of minutes" was a promise the platform cannot keep.
+  it("admits it cannot tell how long when no window is known", () => {
     const message = localCapacityHeldHandoff(false, null, now);
-    expect(message).toMatch(/^1\. Give it a couple of minutes/m);
+    expect(message).toMatch(/I can't tell from here how long that will be/);
+    expect(message).not.toMatch(/couple of minutes/);
+  });
+
+  it("frames a known window as the EARLIEST it could free, not a promise", () => {
+    const message = localCapacityHeldHandoff(false, new Date("2026-08-23T20:17:00.000Z"), now);
+    expect(message).toMatch(/at the earliest/);
+    expect(message).toMatch(/nothing else is waiting for this machine/);
   });
 
   it("reads the window off the thrown error the routing layer produced", () => {

--- a/apps/web/lib/tak/inference-dead-ends.ts
+++ b/apps/web/lib/tak/inference-dead-ends.ts
@@ -110,11 +110,18 @@ export function localCapacityHeldHandoff(
       ? "I couldn't confirm the local AI model was free to use, so I held off rather than risk disrupting something else running on this machine. Nothing is misconfigured."
       : "The only AI model allowed to handle this request is tied up with a background job on this machine, so I couldn't answer. Nothing is misconfigured.",
     steps: [
+      // BI-EBE25715: `expectedFreeAt` is ONE lease's expiry, not the time until
+      // the host is actually free. When other claims are waiting behind it the
+      // reservation is re-taken the moment it clears, so "send again in about
+      // two minutes" reads as a promise the platform cannot keep — observed on
+      // a host running 9-46 queued claims, where the same turn was refused for
+      // over an hour on that advice. Name the window as the earliest it COULD
+      // free, and say plainly that it depends on what else is queued.
       window
-        ? `Send the message again in ${window}, when that job is due to finish.`
-        : "Give it a couple of minutes, then send the message again.",
+        ? `Send the message again in ${window} at the earliest — sooner only if nothing else is waiting for this machine.`
+        : "It frees up when that job finishes. I can't tell from here how long that will be, so send the message again when you want me to retry.",
     ],
-    verify: "check the moment it frees up",
+    verify: "check whether it has freed up",
   });
 }
 


### PR DESCRIPTION
fix(inference): stop classifying git authorship emails as customer records (BI-EBE25715)

Build Studio coworker turns were dying with "The only AI model allowed to
handle this request is tied up with a background job on this machine",
and staying dead for over an hour on advice to retry in ~2 minutes.

Root cause: the `contact-detail` screening rule matched ANY email address
deterministically. Build Studio payloads carry git trailers and acting-account
identifiers (Signed-off-by, Co-Authored-By, createdById, noreply addresses),
so every such payload classified as `customer-records`, which the vertical
policy pack denies, which maps to routeEffect `local-only`, which excludes
every cloud endpoint, leaving a chain of one local engine that a
`local-integration-ci` capacity reservation was holding.

A commit author's address is authorship metadata already public in the
repository's own git history -- not a customer record.

- classify-payload: add `textExemptionPattern` to ClassRule and apply
  GIT_AUTHORSHIP_EMAIL_PATTERN to `contact-detail`. Strip-then-retest, so a
  bare address elsewhere in the same payload is still classified. The pattern
  requires the surrounding trailer/identifier keyword or a noreply mailbox;
  it does not exempt bare addresses, and phone matching is untouched.

- inference-dead-ends: `expectedFreeAt` is one lease's expiry, not the time
  until the host is free -- a queue behind it re-takes the reservation
  immediately. State a known window as the earliest it could free, and when
  no window is known say plainly that the wait cannot be estimated instead
  of guessing "a couple of minutes".

Deliberately NOT done: making code-gen fall back to cloud when local is
capacity-reserved. That routes around a deny decision rather than fixing the
wrong decision. The control stays intact; the false positive is corrected.

Tests: 8 new assertions (trailers exempt; bare address, real address beside a
trailer, and phone numbers all still classified). Affected sweep 141 files /
1560 tests green, including 7 pre-existing screening suites -- the exemption
does not weaken the control. Typecheck clean.

Docs impact: none -- internal classification rule and operator-facing copy
whose behaviour is asserted in tests; no user or coworker doc describes
either string.

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-07-27-vertical-sensitive-policy-packs-design.md
    — owns the class -> policyEffect mapping this false positive was feeding.
      The deny for `customer-records` is correct; the input classification was not.
  - docs/superpowers/specs/2026-07-03-coworker-limitation-response-contract-design.md
    — owns the limitation-response copy. The revised message still honours the
      contract: one named next step ("send the message again"), no menu, no
      deflection to "an administrator", no tool-name or grant-key jargon.
  - docs/superpowers/specs/2026-07-19-ai-provider-suitability-routing-design.md
    — confirms residency exclusion is by policy, not preference, so the fix
      belongs at classification and not at the routing layer.

- Current code substrate reviewed:
  - apps/web/lib/inference/data-screening/classify-payload.ts — CLASS_RULES and
    the deterministic vs. ambiguousVocabulary corroboration paths.
  - apps/web/lib/inference/data-screening/screen-inference-payload.ts — the
    deny -> routeEffect `local-only` mapping and the existing source-code carve-out.
  - apps/web/lib/routing/fallback.ts — confirmed the chain only rethrows when
    EVERY entry deferred, which is why the message's "only model allowed"
    clause is accurate and only the wait estimate needed correcting.
  - apps/web/lib/routing/local-provider-capacity.ts — confirmed `expectedFreeAt`
    is a single lease expiry and that queued claims re-take the reservation.

- Source of truth:
  - The vertical policy pack stays the authority on what a class costs; this
    change only corrects which class the payload is.

- Decision:
  - Fix the false-positive classification, not the routing policy. Deliberately
    rejected the alternative of letting code-gen fall back to cloud when local
    is capacity-reserved -- that routes around a deny decision rather than
    correcting the wrong decision that produced it.

Design-Grounding-Decision: corrects a classification false positive; the deny
policy and residency enforcement are unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Mark Bodman <markdbodman@gmail.com>


---

## How this was found

Driving Build Studio through the live portal as a non-technical user. Coworker
turns died with a message that read as "nothing is wrong, wait two minutes",
and stayed dead for over an hour. Tracing it produced the chain in the commit
message: an email address in a git trailer was enough to classify a pure-code
payload as customer records and deny cloud egress.

## Reviewer notes

The exemption is deliberately narrow. It is **strip-then-retest**: exempt spans
are blanked out and the `contact-detail` rule is re-run against what remains, so
a payload containing both a sign-off trailer and a genuine customer address is
still classified. The pattern requires the surrounding trailer/identifier keyword
(`Signed-off-by`, `Co-Authored-By`, `author`, `committer`, `Reported-by`,
`Reviewed-by`, `Acked-by`, `createdById`, `actorId`) or a `noreply`-style mailbox.
A bare address on its own line is untouched, and phone-number matching is not
modified.

Tests assert exactly those boundaries, including the negative cases.

---

## Scope correction (added after measuring live data)

This PR was originally written believing this false positive was what blocked
Build Studio dispatch. **It is not.** Measured against `RouteDecisionLog` over
14 days:

- 1481 decisions resolved to `local-only`.
- 116 involved `customer-records`; it was the **decisive** class in only **32**
  (~2%).
- For `AGT-WS-BUILD` specifically, **zero** local-only decisions involved
  `customer-records`.

The Build Studio blocker is a different defect: `employee-records` and
`payments-finance` match on the **systemPrompt** — the coworker's own
instructional vocabulary, not user data — which raises `measuredSensitivity`
to `restricted` and yields `restricted-cannot-leave-boundary`. The code already
names this failure mode at `evaluate-inference-policy.ts:188`; the fix there
addressed residency but not the sensitivity rise. That work is in flight
separately on `fix/domain-vocabulary-not-restricted`.

So this PR should be read as what it is: a narrow, independently correct
screening fix worth ~32 real decisions, plus an honesty fix to the capacity
dead-end copy. It does not unblock Build Studio and should not be credited
with doing so.
