### PR TITLE
fix(pregate): a queued gate is not a failed gate (BI-465B3D60)

### DIFF
--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -498,6 +498,12 @@ export async function reviveInterruptedQueuedGate({
   return { revived: false, reason: "no-queued-state" };
 }
 
+/**
+ * `gate-worktree.mjs` exits with this when the lease became a durable queue task.
+ * A queued run is not a failed run and must never be recovered as one.
+ */
+export const EXIT_DURABLE_QUEUE_WAIT = 75;
+
 export async function recoverInterruptedGate({
   args = [],
   result,
@@ -510,6 +516,24 @@ export async function recoverInterruptedGate({
   const status = result?.status ?? 1;
   if (status === 0 || args.includes("--dry-run") || args.includes("--finalize-evidence")) {
     return { recovered: false, reason: "not-a-recoverable-invocation" };
+  }
+  // BI-465B3D60. Exit 75 is the gate telling us it QUEUED, not that it broke:
+  // gate-worktree.mjs exits 75 after printing {status:"queued", code:
+  // "local_ci_durable_wait", resumeMode:"durable-task"} because the lease is a
+  // durable task that outlives this process and resumes on the next invocation.
+  //
+  // Recovery fired on any non-zero status, so it treated that as an interrupted
+  // run, tried to release a lease this process does not own
+  // (nonprod_lease_not_owner, retryable:false), and stamped the state `failed`.
+  // `pregate:status` then reported "status failed with NO recorded reason" for a
+  // lease that was queued, healthy and heartbeating — the exact category error
+  // this item was filed for ("losing a slot is not the same verdict as failing a
+  // gate"), reintroduced downstream of the classifier that already handles 75.
+  //
+  // Reproduced on a five-deep queue, unpiped and with no concurrent reader, on
+  // three consecutive invocations while the position advanced 3 -> 2.
+  if (status === EXIT_DURABLE_QUEUE_WAIT) {
+    return { recovered: false, reason: "queued-durable-task" };
   }
   let context;
   try {

--- a/scripts/pregate.test.mjs
+++ b/scripts/pregate.test.mjs
@@ -3,11 +3,13 @@ import { join, resolve } from "node:path";
 import test from "node:test";
 
 import {
+  EXIT_DURABLE_QUEUE_WAIT,
   WINDOWS_WRAPPER_TERMINATED_STATUS,
   createQueuedGateRevivalWindow,
   gateArgsForQueuedRevivalWindow,
   runGateWithQueuedRevival,
   detectWorkingShell,
+  recoverInterruptedGate,
   recoverInterruptedGateState,
   resolvePregateGateContext,
   reviveInterruptedQueuedGateState,
@@ -392,4 +394,52 @@ test("pregate recovery ignores terminal gate states", async () => {
 
   assert.equal(recovered.recovered, false);
   assert.equal(releaseCalled, false);
+});
+
+// BI-465B3D60. gate-worktree.mjs exits 75 after printing
+// {status:"queued", code:"local_ci_durable_wait", resumeMode:"durable-task"} —
+// the lease is a durable task that outlives this process. Recovery fired on any
+// non-zero status, so it read that as an interrupted run, tried to release a
+// lease it does not own, and stamped the state `failed`. `pregate:status` then
+// reported "failed with NO recorded reason" for a queued, heartbeating lease.
+test("a queued durable-task gate is not recovered as an interrupted one", async () => {
+  let contextResolved = false;
+  const recovered = await recoverInterruptedGate({
+    args: [],
+    result: { status: EXIT_DURABLE_QUEUE_WAIT },
+    spawnSyncImpl: () => {
+      contextResolved = true;
+      return { status: 0, stdout: "", stderr: "" };
+    },
+    stderr: { write: () => {} },
+  });
+
+  assert.deepEqual(recovered, { recovered: false, reason: "queued-durable-task" });
+  // It must bail before touching git or the lease at all — releasing a lease this
+  // process does not own is what produced the misleading verdict.
+  assert.equal(contextResolved, false);
+});
+
+test("a genuinely non-zero, non-queue exit still reaches recovery", async () => {
+  // The guard must be exit-75-specific. Widening it would re-hide the real
+  // interruptions this recovery exists to clean up.
+  const recovered = await recoverInterruptedGate({
+    args: [],
+    result: { status: 1 },
+    cwd: resolve(".pregate-does-not-exist"),
+    spawnSyncImpl: () => ({ status: 1, stdout: "", stderr: "not a git worktree" }),
+    stderr: { write: () => {} },
+  });
+
+  assert.notEqual(recovered.reason, "queued-durable-task");
+});
+
+test("a clean exit is still not a recovery", async () => {
+  const recovered = await recoverInterruptedGate({
+    args: [],
+    result: { status: 0 },
+    stderr: { write: () => {} },
+  });
+
+  assert.equal(recovered.reason, "not-a-recoverable-invocation");
 });


### PR DESCRIPTION
## What the gate was saying, and what the wrapper heard

`gate-worktree.mjs` exits **75** after printing:

```json
{"status":"queued","code":"local_ci_durable_wait","leaseId":"NPEL-…","resumeMode":"durable-task","queuePosition":3}
```

That is the gate reporting **"I queued"** — the lease became a durable task that outlives this process and resumes on the next invocation.

`recoverInterruptedGate` fired on *any* non-zero status. So it read that as an interrupted run, tried to release a lease this process does not own (`nonprod_lease_not_owner`, `retryable: false`), and stamped the local state `failed`. `pregate:status` then reported:

```
local-CI gate: FAIL
  reason  gate record status failed with NO recorded reason — this SHA has not passed
```

At that exact moment `list_nonprod_environment_leases` showed the lease **`status: queued`, `phase: waiting`, heartbeat current, two hours left on its TTL**. A queued, healthy, heartbeating run reported as a failed gate.

This is the precise category error BI-465B3D60 was filed for — *awaiting a slot is not the same verdict as failing a gate*. Note where it survived: `sandbox-freshness.mjs` **already** maps exit 75 to lease fencing and cites this BI by number in its own comment. The wrapper's recovery runs downstream and overwrote that correct verdict. A fix can be undone by a caller that doesn't know the fix exists.

## Why it mattered beyond one branch

On a busy host — five gates queued when I hit it — **every queued gate reported a false failure.** That is the failure mode most likely to teach contributors to distrust the gate, or route around it.

## The fix

`recoverInterruptedGate` returns early on exit 75 (`{recovered: false, reason: "queued-durable-task"}`) **before touching git or the lease**, since attempting a release it cannot perform is what produced the misleading verdict.

Deliberately exit-75-specific. Widening it to any non-zero status would re-hide the real interruptions this recovery exists to clean up, so a test pins that a plain exit 1 still reaches recovery.

## Verified by the branch on itself

Gating this fix hit the same five-deep queue, and the status now reads:

```
local-CI gate: INCONCLUSIVE
  reason  gate record status queued — the gate did not run. This is not a failure of the diff. Re-run pregate.
```

No release attempt, no false stamp. It then passed cleanly once admitted.

- local-CI gate **PASS** on `5eacab5e96d6`
- guard removed → **13/14**; guard in place → **14/14**
- 52 tests across `pregate`, `pregate-exit-honesty`, `pregate-status`
- 61 preflight guards clean

## On the reproduction

I first recorded this with two caveats — a concurrent status poller, and piping output against the tool's own "foreground, unpiped, as the sole command" instruction. I tested both rather than leaving them as hedges: reproduced three consecutive times with **no poller and no pipe**, while the queue position advanced 3 → 2. Neither confound was involved. Both caveats are retracted on the BI.

## Worth pressing on

1. **This is the third fix to the same defect at a different layer** (classifier, reader, now wrapper). The pattern is that each layer independently decides what a non-zero exit means. A single owned mapping from exit code to verdict, consulted by all three, would end the family rather than its current member.
2. **Exit 75 is a bare literal on both sides.** `gate-worktree.mjs` writes `process.exit(75)`, `sandbox-freshness.mjs` matches `=== 75`, and this PR adds a third site with a named constant. The name should move to one shared module rather than the number being re-learned per caller.

Addresses BI-465B3D60. Related: WC-F7B4CDC3 (the `[object Object]` summary, now fixed), BI-F22B4EEE (#4703).

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)