### PR TITLE
feat(workroom-closeout): delivered vs abandoned room disposition, with a resume grace (EP-WORKROOM-CLOSEOUT)

### DIFF
--- a/apps/web/lib/actions/work-capsules.test.ts
+++ b/apps/web/lib/actions/work-capsules.test.ts
@@ -133,7 +133,9 @@ describe("getWorkControlData", () => {
 
   it("returns only truly live development workrooms and a truthful summary", async () => {
     const future = new Date(Date.now() + 60_000);
-    const past = new Date(Date.now() - 60_000);
+    // >24h ago — past the token-limited resume grace, so genuinely dead/reapable
+    // (a lease that lapsed minutes ago is now `paused`, still live, on purpose).
+    const past = new Date(Date.now() - 25 * 60 * 60 * 1000);
     mockPrisma.workroom.findMany.mockResolvedValue([
       {
         capsuleId: "WC-LIVE", title: "Live branch", status: "working", source: "external-adoption",

--- a/apps/web/lib/actions/work-capsules.ts
+++ b/apps/web/lib/actions/work-capsules.ts
@@ -117,6 +117,7 @@ export async function getWorkControlData() {
         liveness: row.liveness as never,
         isLive: Boolean(row.isLive),
         isReapable: Boolean(row.isReapable),
+        disposition: (row.disposition ?? null) as never,
         reason: String(row.livenessReason),
         trueLivenessAt: row.trueLivenessAt ? new Date(String(row.trueLivenessAt)) : null,
       }),

--- a/apps/web/lib/work-capsules/backlog-workroom-ownership.test.ts
+++ b/apps/web/lib/work-capsules/backlog-workroom-ownership.test.ts
@@ -46,7 +46,7 @@ describe("backlog Workroom ownership", () => {
     const db = {
       workroom: { findMany: vi.fn().mockResolvedValue([
         room(),
-        room({ capsuleId: "WC-DEAD", headBranch: "fix/dead", leaseExpiresAt: new Date("2026-08-31T17:00:00.000Z") }),
+        room({ capsuleId: "WC-DEAD", headBranch: "fix/dead", leaseExpiresAt: new Date("2026-08-30T00:00:00.000Z") }), // >24h before now — past the resume grace
       ]) },
       featureBuild: { findMany: vi.fn().mockResolvedValue([]) },
       nonProductionEnvironmentLease: { findMany: vi.fn().mockResolvedValue([]) },

--- a/apps/web/lib/work-capsules/git-scanner.test.ts
+++ b/apps/web/lib/work-capsules/git-scanner.test.ts
@@ -1,11 +1,15 @@
+import { tmpdir } from "node:os";
+
 import { describe, expect, it } from "vitest";
 
 import {
+  isReachableFromTrunk,
   parseGitStatusPorcelain,
   parseBranchList,
   parsePrUrlFromText,
   parseWorktreeList,
   shouldSurfaceAdoptableBranch,
+  trunkRefExists,
 } from "./git-scanner";
 
 describe("git scanner parsing", () => {
@@ -66,5 +70,29 @@ describe("git scanner parsing", () => {
       lastCommitAt: new Date("2025-12-01"),
       now: new Date("2026-05-14"),
     })).toBe(false);
+  });
+});
+
+// Real-git contract tests for the workroom-closeout DELIVERED signal. Read-only
+// (rev-parse / merge-base --is-ancestor), no mutation. Environment-tolerant:
+// the trunk-dependent assertions run only where a local trunk ref is present, so
+// the file stays green in a checkout that has not fetched origin/main.
+describe("delivered-signal git helpers (procedural, local)", () => {
+  it("trunkRefExists is false for a non-repo path", async () => {
+    expect(await trunkRefExists(tmpdir())).toBe(false);
+  });
+
+  it("isReachableFromTrunk returns null for a missing sha (no git call)", async () => {
+    expect(await isReachableFromTrunk(process.cwd(), null)).toBeNull();
+    expect(await isReachableFromTrunk(process.cwd(), undefined)).toBeNull();
+  });
+
+  it("decides reachability against a present local trunk", async () => {
+    const repoRoot = process.cwd();
+    if (!(await trunkRefExists(repoRoot))) return; // no local trunk here → skip
+    // The trunk tip is trivially an ancestor of itself → reachable/merged.
+    expect(await isReachableFromTrunk(repoRoot, "origin/main")).toBe(true);
+    // A well-formed but nonexistent sha is indeterminate → null, never a false merged.
+    expect(await isReachableFromTrunk(repoRoot, "0000000000000000000000000000000000000000")).toBeNull();
   });
 });

--- a/apps/web/lib/work-capsules/git-scanner.ts
+++ b/apps/web/lib/work-capsules/git-scanner.ts
@@ -102,3 +102,53 @@ export async function getWorktreeDirtySummary(worktreePath: string): Promise<Git
   });
   return parseGitStatusPorcelain(stdout);
 }
+
+/**
+ * True when the trunk ref (default `origin/main`) resolves in this local repo —
+ * i.e. reachability checks here are meaningful. False when there is no local git
+ * repo, no fetched trunk, or git is unavailable (the portal-runtime case), so a
+ * caller can skip a whole batch of {@link isReachableFromTrunk} calls rather than
+ * fan out hundreds of failing spawns.
+ */
+export async function trunkRefExists(repoRoot: string, trunkRef = "origin/main"): Promise<boolean> {
+  try {
+    await execFileAsync("git", ["-C", repoRoot, "rev-parse", "--verify", "--quiet", `${trunkRef}^{commit}`], {
+      timeout: 5000,
+      windowsHide: true,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True when `headSha` is an ancestor of the trunk (`git merge-base --is-ancestor`
+ * exits 0) — i.e. the branch's work has landed and the room is DELIVERED. This is
+ * the workroom-closeout "done" signal, computed PROCEDURALLY from the LOCAL repo:
+ * no GitHub PR API, no LLM, and it still answers when the network / external
+ * providers are down. Returns null when it cannot decide (missing sha, sha not
+ * fetched locally, or git error) so the caller withholds the delivered verdict
+ * rather than guessing. Reads objects only — never touches a worktree.
+ */
+export async function isReachableFromTrunk(
+  repoRoot: string,
+  headSha: string | null | undefined,
+  trunkRef = "origin/main",
+): Promise<boolean | null> {
+  if (!headSha) return null;
+  try {
+    await execFileAsync(
+      "git",
+      ["-C", repoRoot, "merge-base", "--is-ancestor", headSha, trunkRef],
+      { timeout: 5000, windowsHide: true },
+    );
+    return true; // exit 0 → headSha is reachable from trunk (merged)
+  } catch (err) {
+    // exit 1 → definitively NOT an ancestor (unmerged). Any other failure
+    // (unknown sha, bad ref, git missing) → indeterminate, withhold judgment.
+    const code = (err as { code?: number } | null)?.code;
+    if (code === 1) return false;
+    return null;
+  }
+}

--- a/apps/web/lib/work-capsules/liveness-inventory.test.ts
+++ b/apps/web/lib/work-capsules/liveness-inventory.test.ts
@@ -15,7 +15,7 @@ describe("loadCapsuleLivenessInventory", () => {
     const db = {
       workroom: { findMany: vi.fn().mockResolvedValue([
         { ...base, capsuleId: "WC-LIVE", status: "working", leaseExpiresAt: new Date("2026-08-24T19:00:00.000Z") },
-        { ...base, capsuleId: "WC-EXPIRED", status: "working", leaseExpiresAt: new Date("2026-08-24T17:00:00.000Z") },
+        { ...base, capsuleId: "WC-EXPIRED", status: "working", leaseExpiresAt: new Date("2026-08-22T17:00:00.000Z") }, // ~2 days ago — past the 24h resume grace
         { ...base, capsuleId: "WC-DONE", status: "complete", leaseExpiresAt: null },
       ]) },
       featureBuild: { findMany: vi.fn().mockResolvedValue([]) },

--- a/apps/web/lib/work-capsules/liveness-inventory.ts
+++ b/apps/web/lib/work-capsules/liveness-inventory.ts
@@ -114,6 +114,7 @@ export async function loadCapsuleLivenessInventory(
       liveness: verdict.liveness,
       isLive: verdict.isLive,
       isReapable: verdict.isReapable,
+      disposition: verdict.disposition,
       livenessReason: verdict.reason,
       trueLivenessAt: verdict.trueLivenessAt ? verdict.trueLivenessAt.toISOString() : null,
     };

--- a/apps/web/lib/work-capsules/liveness.test.ts
+++ b/apps/web/lib/work-capsules/liveness.test.ts
@@ -33,7 +33,10 @@ describe("classifyWorkCapsuleLiveness", () => {
     expect(v.trueLivenessAt).toBeNull();
   });
 
-  it("treats an expired lease as dead regardless of updatedAt", () => {
+  it("treats a RECENTLY expired lease as PAUSED (token-limited session may resume), not reapable", () => {
+    // A lease that lapsed only 1h ago is within the resume grace: a token-limited
+    // Claude/Codex/Grok session commonly returns when its usage window resets, so
+    // the room must NOT be reaped yet — but it is also not confidently live.
     const v = classifyWorkCapsuleLiveness(
       row({
         executorKind: "codex-desktop",
@@ -43,10 +46,76 @@ describe("classifyWorkCapsuleLiveness", () => {
       }),
       NOW,
     );
+    expect(v.liveness).toBe("paused");
+    expect(v.isLive).toBe(true); // never shown as dead while it may resume
+    expect(v.isReapable).toBe(false); // never reaped inside the grace
+    expect(v.disposition).toBeNull();
+    expect(v.trueLivenessAt).toEqual(new Date("2026-08-05T14:00:00.000Z"));
+  });
+
+  it("treats a lease expired PAST the resume grace as dead (lease-expired → abandon)", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({
+        executorKind: "codex-desktop",
+        leaseExpiresAt: new Date("2026-08-04T00:00:00.000Z"), // ~39h ago, past 24h grace
+        updatedAt: NOW,
+      }),
+      NOW,
+    );
     expect(v.liveness).toBe("lease-expired");
     expect(v.isLive).toBe(false);
     expect(v.isReapable).toBe(true);
-    expect(v.trueLivenessAt).toEqual(new Date("2026-08-05T14:00:00.000Z"));
+    expect(v.disposition).toBe("abandoned"); // dead + UNMERGED → protect the branch
+  });
+
+  it("honours a caller-supplied pause grace (0 grace ⇒ expired lease is immediately dead)", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({ executorKind: "codex-desktop", leaseExpiresAt: new Date("2026-08-05T14:00:00.000Z") }),
+      NOW,
+      undefined,
+      0, // no grace
+    );
+    expect(v.liveness).toBe("lease-expired");
+    expect(v.isReapable).toBe(true);
+  });
+
+  it("classifies a MERGED room as DELIVERED (archive), overriding lease state — procedural, no LLM", () => {
+    // deliveredSignal is computed by the caller from LOCAL git reachability.
+    const v = classifyWorkCapsuleLiveness(
+      row({
+        executorKind: "grok-cli",
+        leaseExpiresAt: new Date("2026-08-05T14:00:00.000Z"), // within grace: would be `paused`…
+        deliveredSignal: { merged: true }, // …but merged wins.
+      }),
+      NOW,
+    );
+    expect(v.liveness).toBe("delivered");
+    expect(v.isLive).toBe(false); // delivered work is closed out, not "active"
+    expect(v.isReapable).toBe(true);
+    expect(v.disposition).toBe("delivered"); // archive, and its branch is safe to reap
+    expect(v.reason).toContain("merged");
+  });
+
+  it("delivered wins over a still-valid lease", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({
+        executorKind: "grok-cli",
+        leaseExpiresAt: new Date("2026-08-05T16:00:00.000Z"), // valid lease
+        deliveredSignal: { merged: true },
+      }),
+      NOW,
+    );
+    expect(v.liveness).toBe("delivered");
+    expect(v.disposition).toBe("delivered");
+  });
+
+  it("an UNMERGED delivered signal is inert (deliveredSignal.merged=false ⇒ normal liveness)", () => {
+    const v = classifyWorkCapsuleLiveness(
+      row({ executorKind: "grok-cli", leaseExpiresAt: new Date("2026-08-05T16:00:00.000Z"), deliveredSignal: { merged: false } }),
+      NOW,
+    );
+    expect(v.liveness).toBe("live"); // valid lease, not merged
+    expect(v.disposition).toBeNull();
   });
 
   it("treats a valid lease as live", () => {

--- a/apps/web/lib/work-capsules/liveness.ts
+++ b/apps/web/lib/work-capsules/liveness.ts
@@ -35,9 +35,19 @@ const TERMINAL_BUILD_PHASES = new Set(["complete", "failed", "abandoned"]);
 export type WorkCapsuleLiveness =
   /** Demonstrably live: valid lease, open PR, or recent real activity. */
   | "live"
+  /** Work is DELIVERED: its branch head is reachable from the trunk (merged).
+   *  The session need not resume; the room is closed out as delivered, not
+   *  abandoned. Detected procedurally from local git reachability — no LLM, no
+   *  GitHub API. */
+  | "delivered"
   /** Server-owned nonproduction capacity wait; the executor is suspended, not dead. */
   | "durable-wait"
-  /** Lease-backed executor whose lease has elapsed — the session died. */
+  /** Lease-backed external session whose lease elapsed but only recently — a
+   *  token-limited client is PAUSED, not dead, and resumes + renews when tokens
+   *  return. Withheld from reaping until past the resume grace window. */
+  | "paused"
+  /** Lease-backed executor whose lease elapsed past the resume grace — the
+   *  session is truly gone. */
   | "lease-expired"
   /** Linked Build Studio build is complete/failed/abandoned — nothing to do. */
   | "build-terminal"
@@ -48,13 +58,29 @@ export type WorkCapsuleLiveness =
   /** Null lease, no build/sync signal, but recent enough to withhold judgment. */
   | "no-signal";
 
-/** The dead states a governed reaper may act on. Excludes `terminal` (already
- *  closed) and `no-signal`/`live` (benefit of the doubt). */
+/** How a governed reaper should close a room the classifier says to act on. */
+export type WorkCapsuleDisposition =
+  /** Work merged — archive as delivered; safe to reap worktree + merged branch. */
+  | "delivered"
+  /** Session dead, work not merged — abandon; branch is UNMERGED (its commits
+   *  live only there) so it is protected from deletion pending operator review. */
+  | "abandoned";
+
+/** The states a governed reaper may act on. `delivered` closes out as delivered;
+ *  the dead states abandon. Excludes `terminal` (already closed), `paused`
+ *  (may resume), and `no-signal`/`live` (benefit of the doubt). */
 const REAPABLE_LIVENESS = new Set<WorkCapsuleLiveness>([
+  "delivered",
   "lease-expired",
   "build-terminal",
   "idle-stale",
 ]);
+
+/** Default resume grace for a lease-expired external session: a token-limited
+ *  client (Claude/Codex/Grok) may be down for a usage-window duration and will
+ *  return. Conservative — err toward NOT reaping a session that may resume. A
+ *  DELIVERED (merged) room bypasses the grace: it need not resume. */
+export const WORK_CAPSULE_PAUSE_GRACE_MS = 24 * 60 * 60 * 1000;
 
 export type CapsuleLivenessInput = {
   status: string;
@@ -72,15 +98,28 @@ export type CapsuleLivenessInput = {
    */
   featureBuild?: { phase: string | null; lastActivityAt: Date | null } | null;
   durableWait?: { state: "queued" | "active"; signaledAt: Date | null } | null;
+  /**
+   * Whether this capsule's work is DELIVERED, computed by the caller from LOCAL
+   * git reachability (branch head reachable from the trunk = merged) — never the
+   * GitHub PR API and never an LLM. When `merged` is true the room is closed out
+   * as delivered regardless of lease state. Absent/null when not computed.
+   */
+  deliveredSignal?: { merged: boolean } | null;
 };
 
 export type CapsuleLivenessVerdict = {
   liveness: WorkCapsuleLiveness;
   /** True when this should read as ACTIVE on a board. `no-signal` (recent but
-   *  unproven) counts as live so a brand-new capsule is never shown as dead. */
+   *  unproven) counts as live so a brand-new capsule is never shown as dead;
+   *  `paused` counts as live so a token-limited session that may resume is not
+   *  shown as dead. */
   isLive: boolean;
-  /** True when a governed reaper may transition this capsule to abandoned. */
+  /** True when a governed reaper may act on this capsule (close it out). See
+   *  {@link disposition} for how. */
   isReapable: boolean;
+  /** How to close out, when reapable: `delivered` (archive) vs `abandoned`. Null
+   *  when not reapable. */
+  disposition: WorkCapsuleDisposition | null;
   reason: string;
   /**
    * The timestamp that actually governs liveness — lease expiry, last build
@@ -116,6 +155,7 @@ export function classifyWorkCapsuleLiveness(
   input: CapsuleLivenessInput,
   now: Date = new Date(),
   idleMs: number = WORK_CAPSULE_IDLE_STALE_MS,
+  pauseGraceMs: number = WORK_CAPSULE_PAUSE_GRACE_MS,
 ): CapsuleLivenessVerdict {
   const verdict = (
     liveness: WorkCapsuleLiveness,
@@ -123,14 +163,38 @@ export function classifyWorkCapsuleLiveness(
     trueLivenessAt: Date | null,
   ): CapsuleLivenessVerdict => ({
     liveness,
-    isLive: liveness === "live" || liveness === "durable-wait" || liveness === "no-signal",
+    // `paused` reads as live so a token-limited session that may resume is never
+    // shown as dead or reaped; `delivered` does NOT (it should be closed out).
+    isLive:
+      liveness === "live" ||
+      liveness === "durable-wait" ||
+      liveness === "no-signal" ||
+      liveness === "paused",
     isReapable: REAPABLE_LIVENESS.has(liveness),
+    disposition:
+      liveness === "delivered"
+        ? "delivered"
+        : REAPABLE_LIVENESS.has(liveness)
+          ? "abandoned"
+          : null,
     reason,
     trueLivenessAt,
   });
 
   if (TERMINAL_STATUSES.has(input.status)) {
     return verdict("terminal", `Capsule already ${input.status}.`, null);
+  }
+
+  // DELIVERED wins over every liveness signal: if the branch head is reachable
+  // from the trunk (merged — computed locally, no GitHub API, no LLM) the work
+  // is done and the session need not resume, so close out as delivered rather
+  // than waiting on a lease or mislabelling it abandoned.
+  if (input.deliveredSignal?.merged) {
+    return verdict(
+      "delivered",
+      "Work merged (branch reachable from trunk) — closing out as delivered.",
+      input.lastSyncedAt ?? input.leaseExpiresAt ?? null,
+    );
   }
 
   // An open PR is the live artifact even if the authoring session's lease has
@@ -158,12 +222,26 @@ export function classifyWorkCapsuleLiveness(
     );
   }
 
-  // Lease-backed executor: the lease IS the liveness contract.
+  // Lease-backed executor: the lease IS the liveness contract. On expiry, a
+  // token-limited client is PAUSED (not dead) and resumes + renews when tokens
+  // return, so withhold reaping until past the resume grace window.
   if (input.leaseExpiresAt != null) {
-    const expired = input.leaseExpiresAt.getTime() <= now.getTime();
+    const elapsed = now.getTime() - input.leaseExpiresAt.getTime();
+    const expired = elapsed >= 0;
     if (expired) {
-      const age = humanAge(now.getTime() - input.leaseExpiresAt.getTime());
-      return verdict("lease-expired", `Lease expired ${age} ago — session died.`, input.leaseExpiresAt);
+      const age = humanAge(elapsed);
+      if (elapsed <= pauseGraceMs) {
+        return verdict(
+          "paused",
+          `Lease expired ${age} ago — within the ${humanAge(pauseGraceMs)} resume grace; a token-limited session may return.`,
+          input.leaseExpiresAt,
+        );
+      }
+      return verdict(
+        "lease-expired",
+        `Lease expired ${age} ago — past the ${humanAge(pauseGraceMs)} resume grace; session is gone.`,
+        input.leaseExpiresAt,
+      );
     }
     const remaining = humanAge(input.leaseExpiresAt.getTime() - now.getTime());
     return verdict("live", `Lease valid for ${remaining}.`, input.leaseExpiresAt);

--- a/apps/web/lib/work-capsules/work-capsule-presenter.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-presenter.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { presentCapsuleRow } from "./work-capsule-presenter";
 
 describe("presentCapsuleRow", () => {
-  it("marks expired leases", () => {
+  it("marks expired leases (past the resume grace)", () => {
     const row = presentCapsuleRow({
       capsuleId: "WC-1",
       title: "Adopt work",
@@ -13,12 +13,31 @@ describe("presentCapsuleRow", () => {
       headBranch: "feat/adopt",
       worktreePath: "D:/DPF-adopt",
       pullRequestUrl: null,
-      leaseExpiresAt: new Date("2026-05-14T00:00:00.000Z"),
+      leaseExpiresAt: new Date("2026-05-12T00:00:00.000Z"), // ~49h before now — past 24h grace
+      lastSyncedAt: new Date("2026-05-12T00:00:00.000Z"),
+      updatedAt: new Date("2026-05-12T00:00:00.000Z"),
+    }, new Date("2026-05-14T01:00:00.000Z"));
+
+    expect(row.health).toBe("lease-expired");
+  });
+
+  it("marks a RECENTLY expired lease as paused, not lease-expired (token-limited session may resume)", () => {
+    const row = presentCapsuleRow({
+      capsuleId: "WC-PAUSE",
+      title: "Paused session",
+      status: "working",
+      source: "external-adoption",
+      executorKind: "grok-cli",
+      headBranch: "feat/paused",
+      worktreePath: "D:/DPF-paused",
+      pullRequestUrl: null,
+      leaseExpiresAt: new Date("2026-05-14T00:00:00.000Z"), // 1h before now — inside grace
       lastSyncedAt: new Date("2026-05-14T00:00:00.000Z"),
       updatedAt: new Date("2026-05-14T00:00:00.000Z"),
     }, new Date("2026-05-14T01:00:00.000Z"));
 
-    expect(row.health).toBe("lease-expired");
+    expect(row.health).toBe("paused");
+    expect(row.isLive).toBe(true);
   });
 
   it("marks stale scanner cache when the lease is still active", () => {

--- a/apps/web/lib/work-capsules/work-capsule-presenter.ts
+++ b/apps/web/lib/work-capsules/work-capsule-presenter.ts
@@ -92,15 +92,19 @@ export function presentCapsuleRow(
   const staleCache = row.lastSyncedAt != null && now.getTime() - row.lastSyncedAt.getTime() > STALE_CACHE_MS;
 
   const health =
-    verdict.liveness === "lease-expired"
-      ? "lease-expired"
-      : verdict.liveness === "build-terminal"
-        ? "abandoned-build"
-        : verdict.liveness === "idle-stale"
-          ? "stalled"
-          : staleCache
-            ? "stale-cache"
-            : "ok";
+    verdict.liveness === "delivered"
+      ? "delivered"
+      : verdict.liveness === "paused"
+        ? "paused"
+        : verdict.liveness === "lease-expired"
+          ? "lease-expired"
+          : verdict.liveness === "build-terminal"
+            ? "abandoned-build"
+            : verdict.liveness === "idle-stale"
+              ? "stalled"
+              : staleCache
+                ? "stale-cache"
+                : "ok";
 
   return {
     capsuleId: row.capsuleId,

--- a/apps/web/lib/work-capsules/work-capsule-reaper.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-reaper.test.ts
@@ -14,6 +14,7 @@ const { prismaMock } = vi.hoisted(() => ({
 vi.mock("@dpf/db", () => ({ prisma: prismaMock }));
 
 import {
+  annotateDeliveredSignals,
   reconcileTerminalCapsuleBacklogs,
   reapStaleWorkCapsules,
   planTerminalBacklogReconciliation,
@@ -121,6 +122,7 @@ function capsule(overrides: Record<string, unknown> = {}) {
     pullRequestUrl: null,
     pullRequestNumber: null,
     headBranch: null,
+    headSha: null,
     worktreePath: null,
     featureBuildId: null,
     ...overrides,
@@ -152,6 +154,68 @@ describe("selectReapCandidates", () => {
     expect(picked).not.toContain("WC-PR");
     expect(picked).not.toContain("WC-DONE");
     expect(picked).not.toContain("WC-NEW");
+  });
+
+  it("tags each candidate's disposition: merged → delivered, dead+unmerged → abandoned", () => {
+    const rows = [
+      capsule({ capsuleId: "WC-DEAD", executorKind: "codex-desktop", leaseExpiresAt: new Date("2026-08-01T00:00:00.000Z") }),
+      capsule({
+        capsuleId: "WC-MERGED",
+        executorKind: "grok-cli",
+        leaseExpiresAt: new Date("2026-08-01T00:00:00.000Z"),
+        deliveredSignal: { merged: true }, // caller-computed from local git reachability
+      }),
+    ];
+    const picked = selectReapCandidates(rows, new Map(), NOW);
+    const byId = Object.fromEntries(picked.map((c) => [c.capsuleId, c]));
+    expect(byId["WC-DEAD"].disposition).toBe("abandoned");
+    expect(byId["WC-DEAD"].liveness).toBe("lease-expired");
+    expect(byId["WC-MERGED"].disposition).toBe("delivered");
+    expect(byId["WC-MERGED"].liveness).toBe("delivered");
+  });
+
+  it("does NOT select a token-PAUSED room (lease expired within the resume grace)", () => {
+    const rows = [
+      // Lease expired 1h ago — inside the 24h grace ⇒ paused, must be left alone.
+      capsule({ capsuleId: "WC-PAUSED", executorKind: "grok-cli", leaseExpiresAt: new Date("2026-08-05T14:00:00.000Z") }),
+    ];
+    expect(selectReapCandidates(rows, new Map(), NOW)).toHaveLength(0);
+  });
+});
+
+describe("annotateDeliveredSignals (procedural, local git — no LLM, no GitHub API)", () => {
+  it("sets deliveredSignal from injected reachability for rows with a headSha", async () => {
+    const rows = [
+      capsule({ capsuleId: "WC-MERGED", headSha: "aaa", headBranch: "feat/x" }),
+      capsule({ capsuleId: "WC-OPEN", headSha: "bbb", headBranch: "feat/y" }),
+      capsule({ capsuleId: "WC-NOSHA", headSha: null }),
+    ] as any[];
+    await annotateDeliveredSignals(rows, {
+      repoRoot: "/repo",
+      hasTrunk: async () => true,
+      reachable: async (_root, sha) => (sha === "aaa" ? true : false),
+    });
+    expect(rows[0].deliveredSignal).toEqual({ merged: true });
+    expect(rows[1].deliveredSignal).toEqual({ merged: false });
+    expect(rows[2].deliveredSignal).toBeUndefined(); // no sha → never probed
+  });
+
+  it("SHORT-CIRCUITS on a repo-less runtime (no local trunk) — leaves every signal null", async () => {
+    const rows = [capsule({ capsuleId: "WC-MERGED", headSha: "aaa" })] as any[];
+    const reachable = vi.fn();
+    await annotateDeliveredSignals(rows, { repoRoot: "/repo", hasTrunk: async () => false, reachable });
+    expect(reachable).not.toHaveBeenCalled();
+    expect(rows[0].deliveredSignal).toBeUndefined();
+  });
+
+  it("leaves a row null when reachability is indeterminate (sha not fetched locally)", async () => {
+    const rows = [capsule({ capsuleId: "WC-UNKNOWN", headSha: "ccc" })] as any[];
+    await annotateDeliveredSignals(rows, {
+      repoRoot: "/repo",
+      hasTrunk: async () => true,
+      reachable: async () => null, // git can't decide
+    });
+    expect(rows[0].deliveredSignal).toBeUndefined();
   });
 });
 
@@ -216,6 +280,33 @@ describe("reapStaleWorkCapsules", () => {
     // The live capsule is never touched.
     expect(db.workroom.update).not.toHaveBeenCalledWith(
       expect.objectContaining({ where: { capsuleId: "WC-LIVE" } }),
+    );
+  });
+
+  it("ARCHIVES a delivered (merged) room instead of abandoning it", async () => {
+    // Pre-set deliveredSignal with NO headSha so annotateDeliveredSignals leaves
+    // it intact (nothing to probe) — isolates the disposition→status branch.
+    db.workroom.findMany.mockResolvedValueOnce([
+      capsule({
+        capsuleId: "WC-MERGED",
+        executorKind: "grok-cli",
+        leaseExpiresAt: new Date("2026-08-01T00:00:00.000Z"), // dead lease, but merged wins
+        deliveredSignal: { merged: true },
+      }),
+    ]);
+    db.featureBuild.findMany.mockResolvedValueOnce([]);
+    db.workroom.findUnique.mockResolvedValue({ id: "row-merged", capsuleId: "WC-MERGED", workspaceState: {} });
+    db.workroom.update.mockResolvedValue({ id: "row-merged", capsuleId: "WC-MERGED" });
+
+    const result = await reapStaleWorkCapsules({ db: db as unknown as CapsuleDb, now: NOW, dryRun: false });
+
+    expect(result.reaped).toBe(1);
+    expect(result.candidates[0]!.disposition).toBe("delivered");
+    expect(db.workroom.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { capsuleId: "WC-MERGED" },
+        data: expect.objectContaining({ status: "archived" }), // NOT abandoned
+      }),
     );
   });
 

--- a/apps/web/lib/work-capsules/work-capsule-reaper.ts
+++ b/apps/web/lib/work-capsules/work-capsule-reaper.ts
@@ -25,8 +25,10 @@ import { WORK_CAPSULE_IDLE_STALE_MS } from "@/lib/work-capsules";
 import {
   classifyWorkCapsuleLiveness,
   type CapsuleLivenessInput,
+  type WorkCapsuleDisposition,
   type WorkCapsuleLiveness,
 } from "./liveness";
+import { isReachableFromTrunk, trunkRefExists } from "./git-scanner";
 import { updateWorkCapsuleStatus, type CapsuleDb, type WorkCapsuleActor } from "./work-capsule-store";
 
 /** Capsule statuses the reaper will never touch — already closed out. */
@@ -108,6 +110,10 @@ export type ReapCandidate = {
   headBranch: string | null;
   worktreePath: string | null;
   liveness: WorkCapsuleLiveness;
+  /** How to close out: `delivered` (merged → archive; worktree + merged branch
+   *  are safe to reap) vs `abandoned` (dead, UNMERGED → abandon; branch protected
+   *  from deletion, its commits live only there). */
+  disposition: WorkCapsuleDisposition;
   reason: string;
   trueLivenessAt: string | null;
 };
@@ -120,6 +126,7 @@ type ReaperCapsuleRow = CapsuleLivenessInput & {
   title: string;
   source: string;
   headBranch: string | null;
+  headSha: string | null;
   worktreePath: string | null;
   featureBuildId: string | null;
 };
@@ -151,6 +158,8 @@ export function selectReapCandidates(
       headBranch: row.headBranch,
       worktreePath: row.worktreePath,
       liveness: verdict.liveness,
+      // Reapable verdicts always carry a disposition; default defensively.
+      disposition: verdict.disposition ?? "abandoned",
       reason: verdict.reason,
       trueLivenessAt: verdict.trueLivenessAt ? verdict.trueLivenessAt.toISOString() : null,
     });
@@ -264,6 +273,47 @@ const NON_TERMINAL_STATUSES = [
   "ready-for-promotion",
 ];
 
+/** The local repo the reaper checks branch reachability against. */
+function resolveReaperRepoRoot(): string {
+  return process.env.DPF_REPO_ROOT || process.cwd();
+}
+
+/**
+ * PROCEDURAL delivered-detection, no LLM and no GitHub API: for every row with a
+ * headSha, set `deliveredSignal` from LOCAL git reachability (branch head an
+ * ancestor of the trunk = merged). Mutates rows in place. Best-effort by design:
+ *   - a single `trunkRefExists` probe short-circuits the whole batch when there
+ *     is no local repo/trunk (the portal runtime), so it never fans out hundreds
+ *     of failing git spawns — every row then stays null and lease/grace governs;
+ *   - a per-row null (sha not fetched locally) leaves just that row null.
+ * Injectable git fns keep the pure-ish core unit-testable.
+ */
+export async function annotateDeliveredSignals(
+  rows: ReaperCapsuleRow[],
+  deps: {
+    repoRoot?: string;
+    hasTrunk?: (root: string) => Promise<boolean>;
+    reachable?: (root: string, sha: string | null | undefined) => Promise<boolean | null>;
+  } = {},
+): Promise<void> {
+  const repoRoot = deps.repoRoot ?? resolveReaperRepoRoot();
+  const hasTrunk = deps.hasTrunk ?? trunkRefExists;
+  const reachable = deps.reachable ?? isReachableFromTrunk;
+
+  const withSha = rows.filter((r) => Boolean(r.headSha));
+  if (withSha.length === 0) return;
+  if (!(await hasTrunk(repoRoot))) return; // repo-less runtime → skip; null everywhere.
+
+  for (const row of withSha) {
+    try {
+      const merged = await reachable(repoRoot, row.headSha);
+      if (merged !== null) row.deliveredSignal = { merged };
+    } catch {
+      // Best-effort: a single git failure never aborts the sweep.
+    }
+  }
+}
+
 /**
  * DB wrapper: scan non-terminal capsules, classify each against its true
  * liveness signals, and (when `dryRun` is false) transition the dead ones to
@@ -297,11 +347,19 @@ export async function reapStaleWorkCapsules(args: {
       pullRequestUrl: true,
       pullRequestNumber: true,
       headBranch: true,
+      headSha: true,
       worktreePath: true,
       featureBuildId: true,
     },
     take: 500,
   });
+
+  // DELIVERED detection — PROCEDURAL, LOCAL, no LLM, no GitHub API: a room whose
+  // branch head is reachable from the trunk has merged and is closed out as
+  // delivered (not abandoned). Reads git objects only (never a worktree), so it
+  // is junction-safe; degrades gracefully to null (→ lease/grace logic) wherever
+  // the local repo or the trunk ref is unavailable.
+  await annotateDeliveredSignals(capsules);
 
   // Batch-load the linked FeatureBuild snapshot for the build-studio capsules
   // (their only real liveness signal). FeatureBuild.updatedAt advances on genuine
@@ -330,23 +388,36 @@ export async function reapStaleWorkCapsules(args: {
   let reaped = 0;
   const actor = args.actor ?? SYSTEM_ACTOR;
   for (const candidate of candidates) {
+    // Disposition decides the closeout, NOT a single blanket "abandoned":
+    //   - delivered (merged) → ARCHIVE as delivered. The worktree + the merged
+    //     branch are safe to reap (their commits are on the trunk); worktree
+    //     removal + branch deletion stay with their own explicitly-gated janitors
+    //     — this DB-only step never touches them.
+    //   - abandoned (dead, UNMERGED) → ABANDON, reversibly. The branch is
+    //     PROTECTED from deletion: its commits live only there, and a paused
+    //     session may still hold it. Re-promote / re-adopt to resume.
+    const delivered = candidate.disposition === "delivered";
+    const nextStatus = delivered ? "archived" : "abandoned";
+    const reason = delivered
+      ? `Auto-archived as DELIVERED by the governed Workroom reaper (EP-WORKROOM-CLOSEOUT): ${candidate.reason} ` +
+        "Branch merged to trunk; its worktree and merged branch are safe to reap by their janitors."
+      : `Auto-abandoned by the governed Workroom reaper (WS9/BI-CBAAEA94): ${candidate.reason} ` +
+        "Re-promote the backlog item or re-adopt the branch to resume. Worktree and UNMERGED branch left untouched.";
     try {
       await updateWorkCapsuleStatus({
         db: args.db,
         capsuleId: candidate.capsuleId,
-        status: "abandoned",
-        reason:
-          `Auto-abandoned by the governed Workroom reaper (WS9/BI-CBAAEA94): ${candidate.reason} ` +
-          "Re-promote the backlog item or re-adopt the branch to resume. Worktree left untouched.",
+        status: nextStatus,
+        reason,
         actor,
         now,
       });
       reaped += 1;
       console.warn(
-        `[work-capsule-reaper] abandoned ${candidate.capsuleId} (${candidate.liveness}): ${candidate.reason}`,
+        `[work-capsule-reaper] ${delivered ? "archived (delivered)" : "abandoned"} ${candidate.capsuleId} (${candidate.liveness}): ${candidate.reason}`,
       );
     } catch (err) {
-      console.warn(`[work-capsule-reaper] failed to abandon ${candidate.capsuleId}:`, err);
+      console.warn(`[work-capsule-reaper] failed to close out ${candidate.capsuleId}:`, err);
     }
   }
   const backlogRepair = await reconcileTerminalCapsuleBacklogs({ db: args.db, dryRun: false, now });

--- a/apps/web/lib/work-capsules/work-capsule-store.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.test.ts
@@ -769,7 +769,9 @@ describe("work capsule store", () => {
         id: "bi-row-1", itemId: "BI-7D20BFDF", epicId: null, claimStatus: "active",
         claimedById: "other-user", claimedByAgentId: "other-agent", claimedAt: now,
       });
-      db.workroom.findMany.mockResolvedValueOnce([ownershipRoom({ leaseExpiresAt: new Date("2026-08-31T17:00:00.000Z") })]);
+      // Lease dead ~1.75d before now — past the 24h resume grace, so genuinely dead
+      // (not a token-paused session that would be protected within the grace).
+      db.workroom.findMany.mockResolvedValueOnce([ownershipRoom({ leaseExpiresAt: new Date("2026-08-30T00:00:00.000Z") })]);
       db.workroom.findFirst.mockResolvedValueOnce(null);
       db.workroom.create.mockResolvedValueOnce({ id: "row-1", capsuleId: "WC-CLAIM03" });
       db.backlogItem.update.mockResolvedValueOnce({ id: "bi-row-1" });
@@ -779,6 +781,20 @@ describe("work capsule store", () => {
       expect(result.claimed).toBe(true);
       expect(result.conflict).toBeNull();
       expect(db.backlogItem.update).toHaveBeenCalledTimes(1);
+    });
+
+    it("PROTECTS a token-paused Workroom (lease expired within the resume grace) from being claim-stolen", async () => {
+      const now = new Date("2026-08-31T18:00:00.000Z");
+      db.backlogItem.findFirst.mockResolvedValueOnce({
+        id: "bi-row-1", itemId: "BI-7D20BFDF", epicId: null, claimStatus: "active",
+        claimedById: "other-user", claimedByAgentId: "other-agent", claimedAt: now,
+      });
+      // Lease expired 1h ago — inside the 24h grace ⇒ paused ⇒ isLive ⇒ still owned.
+      db.workroom.findMany.mockResolvedValueOnce([ownershipRoom({ leaseExpiresAt: new Date("2026-08-31T17:00:00.000Z") })]);
+
+      await expect(claimBacklogItemWorkspace({ db: capsuleDb(), input: baseInput, actor, now }))
+        .rejects.toMatchObject({ code: "backlog_item_already_claimed", backlogItemId: "BI-7D20BFDF" });
+      expect(db.workroom.create).not.toHaveBeenCalled();
     });
 
     it("allows and audits a reasoned force override", async () => {

--- a/docs/superpowers/specs/2026-09-01-workroom-closeout-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-09-01-workroom-closeout-lifecycle-design.md
@@ -1,6 +1,10 @@
+---
+status: active
+---
+
 # Workroom Closeout Lifecycle — Delivered vs. Abandoned, with a Resume Grace
 
-**Status:** design · **Date:** 2026-09-01 · **Epic:** EP-WORKROOM-CLOSEOUT
+**Date:** 2026-09-01 · **Epic:** EP-WORKROOM-CLOSEOUT
 **Backlog:** BI-9FF39058, BI-33E1E5D7, BI-154689E7, BI-75565393, BI-946E5359
 
 ## Problem

--- a/docs/superpowers/specs/2026-09-01-workroom-closeout-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-09-01-workroom-closeout-lifecycle-design.md
@@ -1,0 +1,164 @@
+# Workroom Closeout Lifecycle — Delivered vs. Abandoned, with a Resume Grace
+
+**Status:** design · **Date:** 2026-09-01 · **Epic:** EP-WORKROOM-CLOSEOUT
+**Backlog:** BI-9FF39058, BI-33E1E5D7, BI-154689E7, BI-75565393, BI-946E5359
+
+## Problem
+
+A Workroom accumulates four loose ends over its life: the **room** row (status), the
+agent **thread**, the local git **worktree**, and the remote **branch**. When work
+finishes — or a session dies — these are closed out inconsistently:
+
+1. **Delivered work is mislabelled abandoned.** The WS9 reaper (`work-capsule-reaper.ts`)
+   transitions every reapable room to `abandoned`. A room whose branch actually
+   **merged** is delivered, not abandoned — archiving it as "abandoned" corrupts the
+   backlog signal and the operator's read of what happened.
+2. **A token-limited session is reaped as dead.** A lease-backed external session
+   (Claude / Codex / Grok CLI) auto-renews its lease on every write; when the client
+   runs out of tokens the lease simply lapses. The session is **paused**, not dead —
+   it resumes and renews when the usage window resets. Reaping it (or letting another
+   agent claim-steal its room) destroys in-flight work.
+3. **The remote branch is a silent loser.** Deleting an **unmerged** branch loses
+   commits that live nowhere else; but merged-slip branches linger as orphans.
+
+This must work **regardless of client** (server/host machinery, not client cleanup
+logic), and **without any external LLM** — the delivered/abandoned/paused decision is
+**procedural**, computed from local git and lease state.
+
+## Decision
+
+Closeout is governed by a single **disposition** derived from signals that only move
+with real work, and actuated by the loose end's own safe owner — coordinated by a
+**shared, procedural merged-signal**, never by an LLM.
+
+### The disposition (pure core — `liveness.ts`)
+
+`classifyWorkCapsuleLiveness` gains two states and a `disposition`:
+
+| Liveness | Meaning | isLive | isReapable | disposition |
+|---|---|---|---|---|
+| `delivered` | branch head reachable from trunk (merged) | false | **true** | `delivered` |
+| `paused` | lease lapsed **within** the resume grace | **true** | false | — |
+| `lease-expired` | lease lapsed **past** the grace | false | true | `abandoned` |
+| `build-terminal` / `idle-stale` | dead by build/idle signal | false | true | `abandoned` |
+| `live` / `durable-wait` / `no-signal` | active or benefit-of-the-doubt | true | false | — |
+
+Precedence: terminal status → **delivered** → open PR → durable-wait → build-terminal →
+lease (expired-within-grace ⇒ `paused`, expired-past-grace ⇒ `lease-expired`, valid ⇒
+`live`) → null-lease signals → no-signal. **Delivered wins over lease state**: merged
+work is done whether or not the session could resume.
+
+The resume grace (`WORK_CAPSULE_PAUSE_GRACE_MS`, default **24h**) is injectable so the
+policy is testable and tunable. It is deliberately conservative — the cost of gracing a
+truly-dead room for a day (it lingers one extra reaper tick) is far below the cost of
+reaping a session that was about to resume.
+
+### The DELIVERED signal is procedural and local (BI-9FF39058)
+
+`deliveredSignal.merged` is computed by the **caller**, never inside the pure classifier,
+from **local git reachability**:
+
+```
+git merge-base --is-ancestor <headSha> origin/main   # exit 0 ⇒ merged
+```
+
+`git-scanner.ts` exposes `isReachableFromTrunk(repoRoot, headSha)` → `true` (merged) /
+`false` (definitively unmerged) / `null` (indeterminate — sha not fetched, no repo, git
+absent). No GitHub PR API. No LLM. It answers when the network and every external
+provider are down. It reads git **objects only** — never a worktree — so it is
+junction-safe. `trunkRefExists()` lets a caller skip the whole batch on a repo-less
+runtime, where every signal is left `null` and the lease/grace path governs.
+
+This is the **same** reachability test the host-side `worktree-janitor.mjs` already uses
+(`isMerged` → `merge-base --is-ancestor`). Two runtimes (portal TypeScript, host script)
+deliberately carry the same one-line algorithm; there is no LLM and no second source of
+truth for *what merged means*.
+
+### Coordinated closeout by shared signal (BI-154689E7, BI-75565393)
+
+The four loose ends are closed by their **safe owners**, coordinated by the shared
+disposition — not by one call that reaches across every subsystem (that call would have
+to touch the filesystem and the remote, breaking junction-safety and the no-automated-
+outward-action rule):
+
+| Loose end | Owner | Behaviour |
+|---|---|---|
+| **Room** status | `work-capsule-reaper.ts` (this change) | `delivered` → **archived**; dead → **abandoned**; `paused` → untouched. |
+| **Worktree** | `worktree-janitor.mjs` (existing) | Tier A (merged + clean + no open PR/lease/live-session/pin) → removed via junction-safe helper. Tier B (unmerged/dirty/live) → **observe only**. |
+| **Branch** | `worktree-janitor.mjs` (existing) | Merged branch → `branch -D` **after** its worktree is removed (Tier A). **Unmerged branch is never auto-deleted** — its commits live only there. |
+| **Thread** | terminal room status | The reaper acts precisely when the session is delivered or dead; a dead session's thread is already terminal. |
+
+The room reaper archives via the **plain** status path (`archived` is a terminal status
+that does **not** route through the governed-completion gate — only `complete` does). This
+is deliberate: closeout is **disposal**, not a governed `done`, and must never deadlock on
+a review receipt the direct-merge external work could never accrue.
+
+**Room-side protection mirrors the worktree side.** Because `paused` is `isLive`, the
+backlog claim-ownership path (`backlog-workroom-ownership.ts`) already treats a paused
+room as owned — so another agent cannot claim-steal a token-limited session's room inside
+the grace, exactly as the janitor's `hasLiveSession` / `hasActiveLease` facts keep its
+worktree in Tier B.
+
+### The sweep (BI-946E5359)
+
+The one-time closeout of the current delivered-but-stranded backlog **is** the scheduled
+reaper running the new logic — no separate code path. It is env-gated
+(`DPF_WORKCAPSULE_REAPER_ENABLED=1` to observe, `…_AUTO_REAP=1` to actuate), so the
+operator runs the sweep by enabling actuation and reviewing the dry-run candidate set
+first. Delivered rooms archive; genuinely-dead rooms abandon; paused rooms are left.
+
+## Degradation & safety
+
+- **Repo-less runtime.** If the reaper runs where `origin/main` is not fetched (a portal
+  image without the checkout), `trunkRefExists` is false, delivered-detection is skipped,
+  and every room falls to the lease/grace path. A merged room past the grace would then be
+  **abandoned** rather than **archived** — a terminal, reversible closeout that loses **no
+  work** (the reaper never deletes branches or worktrees). To get delivered-detection, run
+  the reaper with `DPF_REPO_ROOT` pointing at a checkout with a fetched trunk.
+- **No automated outward action.** The reaper writes DB rows only. It never pushes a
+  remote branch delete. Merged remote branches are cleaned by GitHub's delete-on-merge;
+  unmerged remote orphans are surfaced for operator review, never auto-deleted.
+- **Dry-run default.** `reapStaleWorkCapsules` writes nothing unless `dryRun:false`.
+- **Reversible.** `abandoned` is undone by re-promoting the backlog item / re-adopting the
+  branch; `archived` is a disposal record, and the merged work is on the trunk.
+
+## Research & Benchmarking
+
+- **GitHub `delete_branch_on_merge`** (industry default): auto-deletes a branch *on merge*.
+  DPF adopts it for the merged-remote case and adds the missing pieces it does **not**
+  cover — the room row, the local worktree, and merged-**slip** branches (merged outside
+  the standard flow). We reject relying on the PR API for the *delivered* decision:
+  reachability from the local trunk is faster, works offline, and is the same fact the
+  merge itself asserts.
+- **`git worktree prune`** removes worktree *administrative* entries for deleted
+  directories; it does not decide *whether* a branch's work has landed or whether a session
+  is alive. The janitor's tiered classifier (merged + clean + no live session/lease) is the
+  policy layer prune lacks. DPF keeps `prune`-equivalent removal behind the junction-safe
+  helper and adds the liveness/merged policy on top.
+- **Kubernetes TTL-after-finished / reaper controllers** (background GC of finished work):
+  the canonical pattern is *classify liveness from real signals, act only on terminal
+  state, default to observe*. DPF mirrors it (dry-run default, env-gated actuation) and
+  adds the domain nuance those controllers lack: a **paused** state distinct from
+  **finished**, because a token-limited agent session resumes — a Job pod does not.
+
+## Alternatives rejected
+
+- **LLM-judged delivered/abandoned.** Rejected: must work with external LLMs unavailable;
+  a merge is a deterministic git fact, not a judgment call.
+- **GitHub PR API for delivered.** Rejected: network- and provider-dependent; local
+  reachability is the ground truth and is offline-capable.
+- **One monolithic closeout call** that archives the room, `rm`s the worktree, and deletes
+  the branch together. Rejected: it would make the DB reaper touch the filesystem
+  (breaking junction-safety) and the remote (an automated outward action). The safe design
+  is one shared *signal* with per-owner actuation.
+- **No grace (reap on lease expiry).** Rejected: it reaps token-paused sessions and lets
+  their rooms be claim-stolen — the exact failure this epic exists to fix.
+
+## Test coverage
+
+`liveness.test.ts`, `work-capsule-reaper.test.ts`, `work-capsule-presenter.test.ts`,
+`liveness-inventory.test.ts`, `backlog-workroom-ownership.test.ts`,
+`work-capsule-store.test.ts`, `git-scanner.test.ts` — delivered overrides lease; paused
+within grace is live + not reapable + not claim-stealable; expired-past-grace abandons;
+disposition tagging; the reaper archives delivered and abandons dead; procedural
+reachability decisions + repo-less short-circuit + indeterminate-null.


### PR DESCRIPTION
## Workroom closeout lifecycle — delivered vs. abandoned, with a resume grace

Epic **EP-WORKROOM-CLOSEOUT**. One PR, all five BIs. Platform/host machinery (not client cleanup), **procedural** (no external LLM), **local-first** (works offline / with providers down), degrades safely.

A Workroom has four loose ends — the **room** row, the agent **thread**, the local **worktree**, the remote **branch**. Today the reaper closes every reapable room to `abandoned`, mislabelling **delivered** (merged) work, and reaps a **token-paused** external session that was about to resume. This adds the missing **room-side disposition** and coordinates it with the loose ends' existing safe owners via a single **procedural merged-signal**.

### What lands

**Pure core — `liveness.ts`**
- **`delivered`**: branch head reachable from trunk (merged) → closes out as delivered, overriding lease state. `isReapable`, `disposition="delivered"`. *(BI-9FF39058)*
- **`paused`**: lease lapsed **within** a 24h resume grace → a token-limited Claude/Codex/Grok session may return, so `isLive` and **not** reapable. Past the grace → `lease-expired` (dead, `disposition="abandoned"`). Grace is injectable/testable. *(BI-33E1E5D7)*
- Verdict now carries `disposition: "delivered" | "abandoned" | null`.

**Procedural delivered-signal — `git-scanner.ts`**
- `isReachableFromTrunk` = `git merge-base --is-ancestor <headSha> origin/main` → true/false/null. **No GitHub PR API, no LLM.** Reads git objects only (junction-safe). `trunkRefExists` lets a repo-less runtime skip the batch. Same signal `worktree-janitor.mjs` already uses.

**Reaper — `work-capsule-reaper.ts`**
- `annotateDeliveredSignals`: best-effort, local, per-row delivered detection (injectable git deps).
- `delivered` → **archived** (plain status path — deliberately sidesteps the governed-completion review deadlock that direct-merge external work can never satisfy); dead → **abandoned**. Writes DB rows only — never deletes a branch or touches a worktree.

### Coordination (BI-154689E7, BI-75565393) — one signal, per-owner actuation

| Loose end | Owner | Behaviour |
|---|---|---|
| Room | reaper (this PR) | delivered → archived; dead → abandoned; paused → untouched |
| Worktree | `worktree-janitor.mjs` (existing) | Tier A merged+clean → removed (junction-safe); Tier B unmerged/dirty/live → **observe** |
| Branch | `worktree-janitor.mjs` (existing) | merged → `branch -D` after worktree removal; **unmerged never auto-deleted** |
| Thread | terminal room status | the reaper acts only when delivered/dead; a dead session's thread is already terminal |

A **paused** room is `isLive`, so `backlog-workroom-ownership` already protects it from claim-steal inside the grace — mirroring the janitor's `hasLiveSession`/`hasActiveLease` worktree protection.

**Sweep (BI-946E5359):** the scheduled reaper running this logic **is** the sweep — env-gated (`DPF_WORKCAPSULE_REAPER_ENABLED` observe, `…_AUTO_REAP` actuate), dry-run default. No separate code path.

### Safety / degradation
- Repo-less runtime → `trunkRefExists` false → delivered-detection skipped → lease/grace governs. A merged room past grace is then *abandoned* not *archived* — terminal, reversible, **loses no work** (reaper never deletes branches/worktrees). Set `DPF_REPO_ROOT` to a checkout with a fetched trunk to enable delivered-detection.
- No automated outward action (no remote branch deletes). Dry-run default. `abandoned`/`archived` reversible.

### Verification
- Typecheck clean (`pnpm --filter web typecheck`, 0 errors).
- **165** work-capsule tests pass (`liveness`, `work-capsule-reaper`, `work-capsule-presenter`, `liveness-inventory`, `backlog-workroom-ownership`, `work-capsule-store`, `git-scanner`): delivered overrides lease; paused-within-grace is live + unreapable + not claim-stealable; expired-past-grace abandons; disposition tagging; reaper archives delivered vs abandons dead; procedural reachability + repo-less short-circuit + indeterminate-null.
- Local-CI sandbox gate: recorded.

Design + Research/Benchmarking: `docs/superpowers/specs/2026-09-01-workroom-closeout-lifecycle-design.md`.

Delivers: BI-9FF39058, BI-33E1E5D7, BI-154689E7, BI-75565393, BI-946E5359 (EP-WORKROOM-CLOSEOUT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
