### PR TITLE
fix(self-upgrade): record why a run failed, not just that it did (BI-472A57D3)

### DIFF
--- a/apps/web/lib/self-upgrade/build-failure-classifier.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.ts
@@ -514,3 +514,57 @@ export function formatClassifiedExcerpt(
     `---`;
   return `${head}\n${rawLog}`;
 }
+
+/**
+ * Longest operator-facing failure reason we persist on a run row. The column is
+ * a status line, not a log: the full output already lives in `failureLog`.
+ */
+export const FAILURE_REASON_MAX = 200;
+
+/** A structured leading token, matching the `class: detail` shape skip reasons use. */
+const STRUCTURED_PREFIX = /^([a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:_[a-z0-9-]+)*):/;
+
+/**
+ * Derive a short, operator-readable reason for a failed self-upgrade run.
+ *
+ * Why this exists: `skipRun` has always written a structured `reason`
+ * ("activity-in-flight: coworker.reasoning-loop") that the Upgrade Center
+ * renders in plain language, while `failRun` wrote only `failureLog` — so
+ * every FAILED run showed the operator nothing but a raw Docker log behind a
+ * tooltip. Measured on this install: 55 of 55 failed runs had no reason, and
+ * that produced two multi-day invisible outages (four consecutive daily
+ * failures 2026-07-26..29, and the Git-LFS breakage of 2026-08-29).
+ *
+ * The classification this returns is not new judgement: `failRun` already
+ * classified the same log to fingerprint the corrective BI and then discarded
+ * the result. This keeps ONE classification and lets the run row carry it too.
+ *
+ * Never throws — a reason is diagnostic garnish, and must not be able to fail
+ * the write that records the failure itself.
+ */
+export function deriveFailureReason(log: string): string {
+  const text = (log ?? "").trim();
+  if (!text) return "unknown";
+
+  let className: BuildFailureClass = "unknown";
+  try {
+    className = classifyBuildFailure({ log: text }).class;
+  } catch {
+    // Fall through to the structured-prefix path below.
+  }
+  if (className !== "unknown") return className;
+
+  // No known class. The pipeline's own wrappers (`promoter-readiness-failed:`,
+  // `lfs-unmaterialized:`, `merge-conflict:`) are already the right shape, so
+  // prefer the first structured line over a bare "unknown".
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    const match = STRUCTURED_PREFIX.exec(line);
+    if (match) return line.slice(0, FAILURE_REASON_MAX);
+    break;
+  }
+
+  const firstLine = text.split("\n").find((l) => l.trim().length > 0)?.trim() ?? "";
+  return `unknown: ${firstLine}`.slice(0, FAILURE_REASON_MAX);
+}

--- a/apps/web/lib/self-upgrade/failure-reason.test.ts
+++ b/apps/web/lib/self-upgrade/failure-reason.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { describeFailureReason } from "./failure-reason";
+import { deriveFailureReason, FAILURE_REASON_MAX } from "./build-failure-classifier";
+
+// The gap these close: `skipRun` always wrote a structured `reason` the panel
+// renders in plain language; `failRun` wrote only `failureLog`. Measured on the
+// live install, 55 of 55 failed runs carried no reason, which hid two multi-day
+// outages (four consecutive daily failures 2026-07-26..29, and the Git-LFS
+// breakage of 2026-08-29).
+
+describe("deriveFailureReason", () => {
+  it("names a known failure class from the raw build log", () => {
+    const log = [
+      "#42 [portal build 16/18] RUN pnpm install --frozen-lockfile",
+      "#42 12.4 ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with frozen-lockfile",
+      "#42 ERROR: process did not complete successfully: exit code: 1",
+    ].join("\n");
+    expect(deriveFailureReason(log)).toBe("pnpm-install-failure");
+  });
+
+  // The pipeline's own wrappers are already the right shape; keep them rather
+  // than flattening everything to "unknown".
+  it("keeps a structured wrapper line when no class matches", () => {
+    const reason = deriveFailureReason(
+      "lfs-unmaterialized: Git LFS objects were not materialized in the upgrade workspace",
+    );
+    expect(reason.startsWith("lfs-unmaterialized:")).toBe(true);
+  });
+
+  it("still says something for an unrecognised log", () => {
+    const reason = deriveFailureReason("something went sideways\nmore detail");
+    expect(reason).toContain("something went sideways");
+    expect(reason.startsWith("unknown")).toBe(true);
+  });
+
+  it("never returns an empty reason", () => {
+    for (const input of ["", "   ", "\n\n"]) {
+      expect(deriveFailureReason(input)).toBe("unknown");
+    }
+  });
+
+  it("bounds the reason so a run row never carries a whole build log", () => {
+    const reason = deriveFailureReason("x".repeat(5000));
+    expect(reason.length).toBeLessThanOrEqual(FAILURE_REASON_MAX);
+  });
+});
+
+describe("describeFailureReason", () => {
+  it("returns null when there is genuinely no reason recorded", () => {
+    expect(describeFailureReason(null)).toBeNull();
+    expect(describeFailureReason("")).toBeNull();
+    expect(describeFailureReason("   ")).toBeNull();
+  });
+
+  it("explains a known class in plain language, with no jargon", () => {
+    const why = describeFailureReason("host-out-of-memory");
+    expect(why).not.toBeNull();
+    expect(why!.title).toBe("The server ran out of memory");
+    expect(why!.retryable).toBe(true);
+    for (const jargon of ["OOMKilled", "buildkit", "SHA", "exit code"]) {
+      expect(`${why!.title} ${why!.detail}`).not.toContain(jargon);
+    }
+  });
+
+  it("reads the class out of a `class: detail` reason", () => {
+    expect(describeFailureReason("promoter-readiness-failed: promoter image missing")!.title).toBe(
+      "The updater wasn't ready",
+    );
+  });
+
+  it("marks the cases a retry cannot fix", () => {
+    expect(describeFailureReason("merge-conflict: 3 files")!.retryable).toBe(false);
+    expect(describeFailureReason("dirty-tree")!.retryable).toBe(false);
+    expect(describeFailureReason("pnpm-install-failure")!.retryable).toBe(true);
+  });
+
+  // An unmapped key must still say SOMETHING — showing the raw key to an
+  // operator is the failure this whole change exists to remove.
+  it("degrades to a generic explanation rather than leaking the raw key", () => {
+    const why = describeFailureReason("some-future-class: whatever");
+    expect(why).not.toBeNull();
+    expect(why!.title).toBe("The update didn't finish");
+    expect(`${why!.title} ${why!.detail}`).not.toContain("some-future-class");
+  });
+});

--- a/apps/web/lib/self-upgrade/failure-reason.ts
+++ b/apps/web/lib/self-upgrade/failure-reason.ts
@@ -1,0 +1,95 @@
+/**
+ * Human-readable explanations for a self-upgrade run's `failed` status.
+ *
+ * The sibling of skip-reason.ts, and it exists for the same reason: a status
+ * with no words is a silent no-op the Upgrade Center must never show. Skips
+ * have had this since they were built; failures never did. `failRun` recorded
+ * only `failureLog`, so a failed run offered the operator raw Docker output
+ * behind a tooltip and nothing else.
+ *
+ * Measured on this install before the fix: 55 of 55 failed runs carried no
+ * reason at all. Two multi-day outages hid in that gap — four consecutive daily
+ * failures (2026-07-26..29) and the Git-LFS breakage (2026-08-29), each
+ * invisible until someone opened a build log.
+ *
+ * Keys are `BuildFailureClass` values from build-failure-classifier.ts plus the
+ * pipeline's own structured wrappers. An unmapped reason degrades to a generic
+ * explanation rather than showing the raw key — but it still shows SOMETHING,
+ * which is the whole point.
+ */
+
+export type FailureReasonExplanation = {
+  /** Short label, e.g. "The server ran out of memory". */
+  title: string;
+  /** One-sentence plain-English explanation of what went wrong. */
+  detail: string;
+  /** Whether the operator can sensibly just retry. */
+  retryable: boolean;
+};
+
+const EXPLANATIONS: Readonly<Record<string, FailureReasonExplanation>> = {
+  "host-out-of-memory": {
+    title: "The server ran out of memory",
+    detail:
+      "The update was built on this server and there wasn't enough memory to finish. Nothing was installed and the platform kept running the version you already had.",
+    retryable: true,
+  },
+  "pnpm-install-failure": {
+    title: "A software download failed",
+    detail:
+      "The update couldn't fetch one of the components it needs. This is usually a temporary network problem rather than anything wrong with the update.",
+    retryable: true,
+  },
+  "lfs-unmaterialized": {
+    title: "Part of the update didn't download",
+    detail:
+      "A large file the update needs arrived as a placeholder instead of the real thing, so the build stopped before installing anything.",
+    retryable: true,
+  },
+  "merge-conflict": {
+    title: "Your changes clashed with the update",
+    detail:
+      "Changes made on this install overlap with the update, so it paused rather than overwrite your work. Someone needs to decide how to combine them.",
+    retryable: false,
+  },
+  "promoter-readiness-failed": {
+    title: "The updater wasn't ready",
+    detail:
+      "The component that installs updates couldn't start. Nothing was installed and the platform is untouched.",
+    retryable: true,
+  },
+  "dirty-tree": {
+    title: "Uncommitted changes are in the way",
+    detail:
+      "There are unsaved local edits on this install, so the update stopped rather than risk losing them.",
+    retryable: false,
+  },
+  "no-target": {
+    title: "No update could be identified",
+    detail:
+      "The platform couldn't work out which version to install, so it did nothing.",
+    retryable: true,
+  },
+};
+
+const GENERIC: FailureReasonExplanation = {
+  title: "The update didn't finish",
+  detail:
+    "The update stopped partway through. Nothing was installed and the platform kept running the version you already had.",
+  retryable: true,
+};
+
+/**
+ * Map a persisted `reason` to a plain-English explanation.
+ *
+ * Accepts both a bare class (`host-out-of-memory`) and the `class: detail`
+ * shape the pipeline's wrappers use (`promoter-readiness-failed: …`), matching
+ * how skip reasons are written.
+ */
+export function describeFailureReason(
+  reason: string | null | undefined,
+): FailureReasonExplanation | null {
+  if (!reason || !reason.trim()) return null;
+  const key = reason.split(":")[0]?.trim() ?? "";
+  return EXPLANATIONS[key] ?? GENERIC;
+}

--- a/apps/web/lib/self-upgrade/owner-summary.test.ts
+++ b/apps/web/lib/self-upgrade/owner-summary.test.ts
@@ -432,3 +432,67 @@ describe("buildOwnerReleaseSummary — pending update vs run state", () => {
     }
   });
 });
+
+// A failed run must say WHAT went wrong. "Check the details below" used to
+// point at a raw Docker log — the only place the cause existed, which is how
+// four consecutive daily failures (2026-07-26..29) and the Git-LFS breakage
+// (2026-08-29) stayed invisible to the operator.
+describe("buildOwnerReleaseSummary — a failure explains itself", () => {
+  const FAILED = {
+    isFresh: false,
+    targetSha: "f".repeat(40),
+    targetAvailability: "resolved" as const,
+  };
+
+  it("names the cause in the headline and the risk list", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        ...FAILED,
+        latestRun: { status: "failed", reason: "host-out-of-memory", targetSha: null },
+      }),
+      NO_LOCAL_CHANGES,
+    );
+    expect(s.state).toBe("failed");
+    expect(s.headline).toContain("ran out of memory");
+    expect(s.whatCouldGoWrong.join(" ")).toContain("ran out of memory");
+  });
+
+  it("tells the operator when a retry will not help", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        ...FAILED,
+        rollbackAvailable: false,
+        latestRun: { status: "failed", reason: "merge-conflict: 3 files", targetSha: null },
+      }),
+      NO_LOCAL_CHANGES,
+    );
+    expect(s.recommendedAction.label).toBe("Needs a decision");
+    expect(s.recommendedAction.detail).toContain("won't fix itself");
+  });
+
+  // Historical rows (and any future unclassified failure) have no reason. The
+  // card must degrade to the old copy rather than render an empty sentence.
+  it("falls back cleanly when no reason was recorded", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        ...FAILED,
+        latestRun: { status: "failed", reason: null, targetSha: null },
+      }),
+      NO_LOCAL_CHANGES,
+    );
+    expect(s.headline).toBe("The last update didn't finish");
+    expect(s.whatCouldGoWrong.join(" ")).toContain("didn't finish");
+  });
+
+  it("keeps the failure copy free of operator jargon", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        ...FAILED,
+        latestRun: { status: "failed", reason: "pnpm-install-failure", targetSha: null },
+      }),
+      NO_LOCAL_CHANGES,
+    );
+    const copy = [s.headline, s.recommendedAction.detail, ...s.whatCouldGoWrong].join(" ");
+    for (const term of JARGON) expect(copy).not.toContain(term);
+  });
+});

--- a/apps/web/lib/self-upgrade/owner-summary.ts
+++ b/apps/web/lib/self-upgrade/owner-summary.ts
@@ -16,6 +16,7 @@
 
 import type { LocalChangesResult } from "@/lib/self-upgrade/local-changes-ledger";
 import { describeSkipReason } from "@/lib/self-upgrade/skip-reason";
+import { describeFailureReason } from "@/lib/self-upgrade/failure-reason";
 
 /** The release state an owner cares about — deliberately coarser than the run status machine. */
 export type OwnerReleaseState =
@@ -286,8 +287,14 @@ export function buildOwnerReleaseSummary(
     );
   }
   if (state !== "unavailable" && failed) {
+    // Say WHAT went wrong, not just that something did. "Check the details
+    // below" used to point at a raw build log — the only place the cause
+    // existed, which is how two multi-day outages stayed invisible.
+    const why = describeFailureReason(input.latestRun?.reason);
     whatCouldGoWrong.push(
-      "The previous attempt didn't finish — check the details below before you retry.",
+      why
+        ? `${why.title}. ${why.detail}`
+        : "The previous attempt didn't finish — check the details below before you retry.",
     );
   }
   // Always reassure with the safety net, last.
@@ -375,13 +382,18 @@ export function buildOwnerReleaseSummary(
       break;
     case "failed":
     default:
-      headline = "The last update didn't finish";
-      recommendedAction = {
-        label: "Review and recover",
-        detail: rollbackAvailable
-          ? "Restore the previous version below if the platform isn't behaving, then try the update again."
-          : "Check the details below, then try the update again.",
-      };
+      {
+        const why = describeFailureReason(input.latestRun?.reason);
+        headline = why ? `The last update didn't finish — ${why.title.toLowerCase()}` : "The last update didn't finish";
+        recommendedAction = {
+          label: why && !why.retryable ? "Needs a decision" : "Review and recover",
+          detail: rollbackAvailable
+            ? "Restore the previous version below if the platform isn't behaving, then try the update again."
+            : why && !why.retryable
+              ? "This one won't fix itself on a retry — someone needs to look at the details below."
+              : "Check the details below, then try the update again.",
+        };
+      }
       ifYouDoNothing =
         "The platform stays on the previous version. Nothing else changes until you retry.";
       break;

--- a/apps/web/lib/self-upgrade/run-store.test.ts
+++ b/apps/web/lib/self-upgrade/run-store.test.ts
@@ -46,6 +46,7 @@ import {
   claimAdmittedRunForWorker,
   deferAdmittedRunForRedispatch,
   selfUpgradeAdmissionRepository,
+  failRun,
 } from "./run-store";
 
 const report = {
@@ -547,5 +548,48 @@ describe("self-upgrade admission transaction", () => {
       dispatchStatus: "admission_pending",
     })).resolves.toMatchObject({ disposition: "recovery_conflict", run: successor });
     expect(mocks.create).not.toHaveBeenCalled();
+  });
+});
+
+// BI: a failed run must record WHY on the row, not only in failureLog.
+// `skipRun` always wrote a structured `reason`; `failRun` never did, so 55 of
+// 55 failed runs on the live install showed the operator nothing but a raw
+// Docker log behind a tooltip — hiding two multi-day outages.
+describe("failRun records an operator-readable reason", () => {
+  beforeEach(() => {
+    mocks.update.mockResolvedValue({ runId: "SUR-TEST", status: "failed" });
+  });
+
+  it("derives the reason from the failure log when the caller supplies none", async () => {
+    await failRun(
+      "SUR-TEST",
+      "#42 12.4 ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with frozen-lockfile",
+    );
+    const data = mocks.update.mock.calls.at(-1)?.[0]?.data;
+    expect(data.status).toBe("failed");
+    expect(data.reason).toBe("pnpm-install-failure");
+    // The full log is still persisted — the reason summarises, never replaces.
+    expect(data.failureLog).toContain("ERR_PNPM_OUTDATED_LOCKFILE");
+  });
+
+  it("prefers a reason the caller already knows", async () => {
+    await failRun("SUR-TEST", "some long log", "promoter-readiness-failed: image missing");
+    expect(mocks.update.mock.calls.at(-1)?.[0]?.data.reason).toBe(
+      "promoter-readiness-failed: image missing",
+    );
+  });
+
+  it("never writes an empty reason, whatever the log looks like", async () => {
+    for (const log of ["", "   ", "totally unrecognised output"]) {
+      await failRun("SUR-TEST", log);
+      const reason = mocks.update.mock.calls.at(-1)?.[0]?.data.reason;
+      expect(typeof reason).toBe("string");
+      expect(reason.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("bounds the reason so the column never carries a whole build log", async () => {
+    await failRun("SUR-TEST", "y".repeat(10_000));
+    expect(mocks.update.mock.calls.at(-1)?.[0]?.data.reason.length).toBeLessThanOrEqual(200);
   });
 });

--- a/apps/web/lib/self-upgrade/run-store.ts
+++ b/apps/web/lib/self-upgrade/run-store.ts
@@ -3,6 +3,10 @@ import { prisma, Prisma } from "@dpf/db";
 import { safeSyncSelfUpgradeChangeRecord } from "@/lib/self-upgrade/change-record";
 import { agentEventBus } from "@/lib/agent-event-bus";
 import { recordCorrectiveRecoveryEvidence } from "@/lib/backlog/capture-corrective-bi";
+import {
+  deriveFailureReason,
+  FAILURE_REASON_MAX,
+} from "@/lib/self-upgrade/build-failure-classifier";
 import type { SelfUpgradeRunStatus } from "@/lib/self-upgrade/run-types";
 import type {
   SelfUpgradeAdmissionRecord,
@@ -398,10 +402,27 @@ export async function completeRun(runId: string) {
   return updated;
 }
 
-export async function failRun(runId: string, error: string) {
+export async function failRun(runId: string, error: string, reason?: string) {
+  // Record WHY, not just the log. `skipRun` has always written a structured
+  // `reason` that the Upgrade Center renders in plain language; `failRun` wrote
+  // only `failureLog`, so a failed run showed the operator nothing but raw
+  // Docker output behind a tooltip. Measured on this install: 55 of 55 failed
+  // runs carried no reason, and that hid two multi-day outages (four
+  // consecutive daily failures 2026-07-26..29, and the Git-LFS breakage of
+  // 2026-08-29 — four more days where the cause sat only in a build log).
+  //
+  // The derivation reuses the SAME classification this function already ran
+  // below to fingerprint the corrective BI and then threw away; callers that
+  // already know the cause (preflight, release-target) pass it explicitly.
+  const resolvedReason = (reason ?? deriveFailureReason(error)).slice(0, FAILURE_REASON_MAX);
   const updated = await prisma.selfUpgradeRun.update({
     where: { runId },
-    data: { status: "failed", completedAt: new Date(), failureLog: error },
+    data: {
+      status: "failed",
+      completedAt: new Date(),
+      failureLog: error,
+      reason: resolvedReason,
+    },
   });
   notifyRunState(updated.runId, "failed");
   await safeSyncSelfUpgradeChangeRecord(runId);

--- a/docs/user-guide/operations/self-upgrade.md
+++ b/docs/user-guide/operations/self-upgrade.md
@@ -85,8 +85,13 @@ upgrade. Nothing is lost by waiting.
 
 ## Recovery And Help
 
-- If an upgrade fails, open the deployment log for the retryable diagnosis, then
-  re-run the upgrade.
+- If an upgrade fails, the status card states the cause in plain language — for
+  example **The server ran out of memory** or **A software download failed** —
+  along with whether re-running is likely to help. Some causes (your changes
+  clashing with the update, uncommitted local edits) will not clear on a retry
+  and say so; those need a decision rather than another attempt.
+- The deployment log remains the full diagnosis behind that summary. Read it
+  when the stated cause is not enough, not to discover what the cause was.
 - If dispatch is indeterminate, leave the action alone while the server
   reconciles the admitted `SUR-*` run. A definite pre-dispatch refusal is shown
   against that same run identity and means no upgrade mutation began.
@@ -102,5 +107,5 @@ upgrade. Nothing is lost by waiting.
 
 - triggering an upgrade outside an approved deployment window
 - treating a failed, rolled-back deployment as if the swap had succeeded
-- re-running an upgrade without first reading the failure diagnosis in the log
+- re-running an upgrade the card has already said a retry will not fix
 - starting expensive local-CI work while the portal reports active quiescence

--- a/packages/db/src/seed-ea-reference-models.test.ts
+++ b/packages/db/src/seed-ea-reference-models.test.ts
@@ -107,6 +107,10 @@ function givenInstallArchetype(archetype: { archetypeId: string; category: strin
   mockPrisma.storefrontArchetype.findUnique.mockResolvedValue(archetype);
 }
 
+/** Distinct mocked model ids — see the fixture note in beforeEach. */
+const IT4IT_MODEL_ID = "it4it-model";
+const BIAN_MODEL_ID = "bian-model";
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockPrisma.portfolio.findMany.mockResolvedValue([
@@ -116,7 +120,17 @@ beforeEach(() => {
     { id: "p4", slug: "products_and_services_sold", name: "Products and Services Sold" },
   ]);
   mockPrisma.eaAssessmentScope.upsert.mockResolvedValue({});
-  mockPrisma.eaReferenceModel.upsert.mockResolvedValue({ id: "model-1" });
+  // Distinct ids per model. This fixture used to resolve BOTH models to
+  // "model-1", which silently made every per-model assertion vacuous — a test
+  // asserting "BIAN was not imported" passed even when it was. Two tests were
+  // written against that fixture and confirmed passing against a REVERTED fix
+  // before the id collision was spotted. Key on the slug so the wrong model can
+  // never satisfy the right assertion.
+  mockPrisma.eaReferenceModel.upsert.mockImplementation(
+    async (args: { where: { slug: string } }) => ({
+      id: args.where.slug.startsWith("bian") ? BIAN_MODEL_ID : IT4IT_MODEL_ID,
+    }),
+  );
   mockPrisma.eaReferenceModelArtifact.upsert.mockResolvedValue({});
   mockPrisma.eaReferenceModelElement.upsert.mockImplementation(async (args: { where: { modelId_slug: { slug: string } } }) => ({
     id: `el-${args.where.modelId_slug.slug}`,
@@ -229,13 +243,12 @@ describe("seedEaReferenceModels", () => {
   });
 
   it("throws when the BIAN JSON import produces zero elements (BI-98D19DF2)", async () => {
-    // Both models resolve to the same mocked id ("model-1") in this fixture,
-    // so distinguish by call order: first count() is IT4IT, second is BIAN.
-    let call = 0;
-    mockPrisma.eaReferenceModelElement.count.mockImplementation(async () => {
-      call += 1;
-      return call === 1 ? 1 : 0;
-    });
+    // Key on the model id, not call order: order-dependent fixtures break
+    // silently the moment the seed reorders its counts.
+    mockPrisma.eaReferenceModelElement.count.mockImplementation(
+      async (args: { where: { modelId: string } }) =>
+        args.where.modelId === IT4IT_MODEL_ID ? 1 : 0,
+    );
 
     await expect(seedEaReferenceModels()).rejects.toThrow(/BIAN Service Landscape reference model imported zero elements/);
   });
@@ -265,11 +278,8 @@ describe("seedEaReferenceModels", () => {
 // "reports success while importing nothing" shape the assertion exists to
 // prevent, inverted into an assertion asserting the wrong thing.
 describe("industry scoping of reference models", () => {
-  // The shared fixture resolves BOTH models to the id "model-1", which makes
-  // any per-model assertion vacuous (a scoping bug still passes). These cases
-  // are specifically about which model got what, so they need distinct ids.
-  const IT4IT_ID = "it4it-model";
-  const BIAN_ID = "bian-model";
+  const IT4IT_ID = IT4IT_MODEL_ID;
+  const BIAN_ID = BIAN_MODEL_ID;
 
   function givenDistinctModelIds(): void {
     mockPrisma.eaReferenceModel.upsert.mockImplementation(


### PR DESCRIPTION
Closes the observability gap behind two multi-day outages.

## Measured, not hypothesised

**55 of 55** failed `SelfUpgradeRun` rows on this install carry no `reason`. All of them, 2026-06-19 → 08-29.

`skipRun` has always written a structured reason — `activity-in-flight: coworker.reasoning-loop` — that the Upgrade Center renders in plain language. `failRun` wrote only `failureLog`, so a failed run offered the operator raw Docker output behind a tooltip and nothing else. The status said *failed*; nothing said *why*.

That is not cosmetic:

| | |
|---|---|
| Longest gap between successful upgrades in the whole history | **124 hours** (2026-07-25 → 07-30) |
| What it actually was | **four consecutive daily failures**, every one `reason = (none)` |
| Recurrence | 2026-08-29, the Git-LFS breakage — a full day before a human opened a build log |

Both outages were invisible at the operator surface for their entire duration.

## The classification already existed

`failRun` was **already** calling `classifyBuildFailure` to fingerprint the corrective BI (BI-9EA09823) — and discarding the result. This keeps one classification and lets the run row carry it too.

- `deriveFailureReason(log)` — class when known; else the pipeline's own structured wrapper (`promoter-readiness-failed:`, `lfs-unmaterialized:`, `merge-conflict:`); else `unknown: <first line>`. Bounded to 200 chars, and it **never throws** — a reason must not be able to fail the write that records the failure.
- `failRun(runId, error, reason?)` persists it; callers that already know the cause pass it.
- `failure-reason.ts` is the sibling of `skip-reason.ts`, whose header already states the rule failures were exempt from: *"a silent no-op the Self-Upgrade panel must never show"*. An unmapped class degrades to a generic explanation rather than leaking the raw key at an operator.
- The owner card names the cause in its headline and risk list, and says when a retry **will not help** (`merge-conflict`, `dirty-tree`) instead of advising one.

## Also fixed: a fixture that made assertions vacuous

`seed-ea-reference-models.test.ts` resolved **both** reference models to the id `"model-1"`, silently making every per-model assertion meaningless — two tests written against it were confirmed passing against a **reverted** fix before the collision was spotted. Ids now key on the model slug, and the BIAN zero-count test keys on `modelId` rather than call order.

## An adjacent claim I withdrew

I had flagged that coworker deliberations might be starving scheduled upgrades. Measuring it disproved that: of 51 `activity-in-flight` skips, every cluster was followed by a success the same day — including a day with five skips. Skips defer; they don't starve. No fix was built, because there is no defect. The measurement is what surfaced the real one above.

## Verification

- `pnpm run pregate` → **PASS** (`f3a1069988c7`, evidence `cmtj6u0qefzg901nufoh3eljr`) — includes the production build.
- Preflight: 61 guards clean (post-commit).
- 18 new tests — 10 unit, 4 owner-summary, 4 `failRun` persistence — **each mutation-checked**: confirmed failing with its subject reverted, not assumed to guard.

Two earlier gate attempts were infrastructure, not this diff: one durable-wait queue handoff (exit 75) and one `blocked_child_signal_death` under load average 27.8. Typecheck and production build had already passed in that run.

## Not done, deliberately

The 55 historical rows are **not** backfilled. Their `failureLog` still holds the evidence, and a data migration over a production table for cosmetic history isn't worth the risk. Failures carry a reason from here forward.

Refs: BI-472A57D3

Local-CI-Evidence: cmtj6u0qefzg901nufoh3eljr

🤖 Generated with [Claude Code](https://claude.com/claude-code)