### PR TITLE
fix(mcp): answer schema questions from the merge target, not a moving sandbox branch (BI-6CFC5429)

### DIFF
--- a/apps/web/lib/mcp/packs/committed-schema-default-branch.test.ts
+++ b/apps/web/lib/mcp/packs/committed-schema-default-branch.test.ts
@@ -1,0 +1,114 @@
+// BI-6CFC5429: the schema reader must answer from the MERGE TARGET, not from
+// whatever tree this process happens to sit in.
+//
+// Live evidence: PROJECT_ROOT is /sandbox-workspace, a Build Studio sandbox
+// whose branch MOVES — observed on client/5727856b-… on 2026-08-26 and
+// pr-4917-head on 2026-09-01. The same question got different answers on
+// different days, and a model absent from today's sandbox branch read as absent
+// from the platform.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execMock } = vi.hoisted(() => ({ execMock: vi.fn() }));
+const readdir = vi.fn();
+const readFile = vi.fn();
+
+vi.mock("@/lib/shared/lazy-node", () => ({
+  lazyExec: () => execMock,
+  lazyFsPromises: () => ({ readdir, readFile, rm: vi.fn() }),
+  lazyPath: () => ({
+    resolve: (...p: string[]) => p.join("/"),
+    basename: (p: string) => p.split("/").filter(Boolean).pop() ?? "",
+  }),
+  lazyOs: () => ({ tmpdir: () => "/tmp" }),
+  getCwd: () => "/cwd",
+}));
+
+import { loadCommittedSchema } from "./committed-schema-source";
+
+const ok = (stdout: string) => ({ stdout, stderr: "" });
+const SHA = "ce6c2774b60525a02fc74b7190af3fc4a50386d2";
+
+beforeEach(() => {
+  execMock.mockReset();
+  readdir.mockReset();
+  readFile.mockReset();
+  process.env.PROJECT_ROOT = "/sandbox-workspace";
+});
+
+/** readGit is injected, so only resolveDefaultBranchRef goes through exec. */
+function gitReaderFor(files: Record<string, string>) {
+  return async (_root: string, args: string): Promise<string | null> => {
+    if (args.startsWith("ls-tree")) return Object.keys(files).join("\n");
+    const show = /^show [^:]+:(.+)$/.exec(args);
+    if (show) return files[show[1]] ?? null;
+    return null;
+  };
+}
+
+describe("committed schema — reads the default branch", () => {
+  it("answers from origin/main even though the working tree is on a sandbox branch", async () => {
+    execMock.mockResolvedValueOnce(ok(`${SHA}\n`)); // rev-parse --verify origin/main
+
+    const result = await loadCommittedSchema({
+      readGit: gitReaderFor({
+        "packages/db/prisma/schema/finance.prisma": "model MileageRate {}",
+        "packages/db/prisma/schema/workforce.prisma": "model PayRun {}",
+      }),
+    });
+
+    expect(result!.provenance.branch).toBe("main");
+    expect(result!.provenance.headSha).toBe(SHA);
+    expect(result!.provenance.identified).toBe(true);
+    expect(result!.provenance.schemaFileCount).toBe(2);
+    expect(result!.schema).toContain("model MileageRate");
+    // The working tree was never touched.
+    expect(readdir).not.toHaveBeenCalled();
+  });
+
+  it("scores the default branch at full freshness and high trust", async () => {
+    execMock.mockResolvedValueOnce(ok(`${SHA}\n`));
+    const result = await loadCommittedSchema({
+      readGit: gitReaderFor({ "packages/db/prisma/schema/a.prisma": "model A {}" }),
+    });
+    const freshness = result!.trust.dimensions.find((d) => d.key === "freshness");
+    expect(freshness!.score).toBe(1);
+    expect(result!.trust.tier).toBe("high");
+  });
+
+  // A ref we cannot fully read is NOT a partial schema — returning some of it
+  // would silently under-report models, which is the defect class this reader
+  // exists to prevent.
+  it("falls back to the working tree when a blob in the ref is unreadable", async () => {
+    execMock.mockResolvedValueOnce(ok(`${SHA}\n`));
+    readdir.mockResolvedValueOnce(["local.prisma"]);
+    readFile.mockResolvedValueOnce("model FromWorkingTree {}");
+
+    const result = await loadCommittedSchema({
+      readGit: async (_root, args) => {
+        if (args.startsWith("ls-tree")) return "packages/db/prisma/schema/a.prisma";
+        if (args.startsWith("show")) return null; // blob unreadable
+        return "pr-4917-head";
+      },
+      readBranchFallback: async () => "pr-4917-head",
+    });
+
+    expect(result!.schema).toContain("FromWorkingTree");
+    expect(result!.provenance.branch).toBe("pr-4917-head");
+    // and it is capped and named, not presented as authoritative
+    expect(result!.trust.dimensions.find((d) => d.key === "freshness")!.score).toBeLessThanOrEqual(0.4);
+  });
+
+  it("falls back to the working tree when no default branch resolves", async () => {
+    execMock.mockResolvedValue(ok("")); // no candidate ref resolves
+    readdir.mockResolvedValueOnce(["local.prisma"]);
+    readFile.mockResolvedValueOnce("model FromWorkingTree {}");
+
+    const result = await loadCommittedSchema({
+      readGit: async () => null,
+      readBranchFallback: async () => "client/5727856b",
+    });
+
+    expect(result!.schema).toContain("FromWorkingTree");
+    expect(result!.provenance.branch).toBe("client/5727856b");
+  });
+});

--- a/apps/web/lib/mcp/packs/committed-schema-provenance.test.ts
+++ b/apps/web/lib/mcp/packs/committed-schema-provenance.test.ts
@@ -25,6 +25,9 @@ const readFile = vi.fn();
 vi.mock("@/lib/shared/lazy-node", () => ({
   lazyFsPromises: () => ({ readdir, readFile }),
   lazyPath: () => ({ resolve: (...p: string[]) => p.join("/") }),
+  lazyExec: () => async () => {
+    throw new Error("no git in this fixture");
+  },
   getCwd: () => "/cwd",
 }));
 
@@ -38,7 +41,7 @@ async function load() {
   readFile.mockResolvedValueOnce("model User {}");
   // Explicit: git refused AND .git/HEAD was unreadable. Relying on the fs mock
   // running out of queued values would make this pass by accident.
-  return loadCommittedSchema({ readGit: noGit, readBranchFallback: async () => null });
+  return loadCommittedSchema({ skipDefaultBranch: true, readGit: noGit, readBranchFallback: async () => null });
 }
 
 describe("committed schema — unidentifiable tree", () => {
@@ -74,6 +77,7 @@ describe("committed schema — unidentifiable tree", () => {
     readdir.mockResolvedValueOnce(["a.prisma"]);
     readFile.mockResolvedValueOnce("model User {}");
     const r = await loadCommittedSchema({
+      skipDefaultBranch: true,
       readGit: async () => "main",
       readBranchFallback: async () => null,
     });

--- a/apps/web/lib/mcp/packs/committed-schema-source.test.ts
+++ b/apps/web/lib/mcp/packs/committed-schema-source.test.ts
@@ -10,6 +10,9 @@ const readFile = vi.fn();
 vi.mock("@/lib/shared/lazy-node", () => ({
   lazyFsPromises: () => ({ readdir, readFile }),
   lazyPath: () => ({ resolve: (...parts: string[]) => parts.join("/") }),
+  lazyExec: () => async () => {
+    throw new Error("no git in this fixture");
+  },
   getCwd: () => "/cwd",
 }));
 
@@ -23,12 +26,12 @@ afterEach(() => {
 describe("loadCommittedSchema", () => {
   it("returns null when the schema directory cannot be read — a read failure, not an absence", async () => {
     readdir.mockRejectedValueOnce(new Error("ENOENT"));
-    expect(await loadCommittedSchema({ readGit })).toBeNull();
+    expect(await loadCommittedSchema({ skipDefaultBranch: true, readGit })).toBeNull();
   });
 
   it("returns null when the directory holds no .prisma files", async () => {
     readdir.mockResolvedValueOnce(["README.md"]);
-    expect(await loadCommittedSchema({ readGit })).toBeNull();
+    expect(await loadCommittedSchema({ skipDefaultBranch: true, readGit })).toBeNull();
   });
 
   it("joins every domain file and reports provenance naming the tree", async () => {
@@ -36,7 +39,7 @@ describe("loadCommittedSchema", () => {
     readdir.mockResolvedValueOnce(["b.prisma", "a.prisma"]);
     readFile.mockResolvedValueOnce("model A {}").mockResolvedValueOnce("model B {}");
 
-    const result = await loadCommittedSchema({ readGit });
+    const result = await loadCommittedSchema({ skipDefaultBranch: true, readGit });
 
     expect(result).not.toBeNull();
     expect(result!.provenance.tree).toBe("committed");
@@ -51,7 +54,7 @@ describe("loadCommittedSchema", () => {
     readdir.mockResolvedValueOnce(["a.prisma"]);
     readFile.mockResolvedValueOnce("model A {}");
 
-    const result = await loadCommittedSchema({ readGit });
+    const result = await loadCommittedSchema({ skipDefaultBranch: true, readGit });
 
     expect(result!.trust.kind).toBe("data-trust-vector");
     expect(result!.trust.subject.type).toBe("committed-schema");

--- a/apps/web/lib/mcp/packs/committed-schema-source.ts
+++ b/apps/web/lib/mcp/packs/committed-schema-source.ts
@@ -28,6 +28,9 @@ import {
   OFF_DEFAULT_BRANCH_FRESHNESS_CAP,
   isOffDefaultBranch,
 } from "@/lib/trust-vector/default-branch";
+// One definition of "which ref is the default branch", shared with the code
+// graph indexer rather than restated here (BI-6CFC5429).
+import { resolveDefaultBranchRef } from "@/lib/build/code-graph/default-branch-source";
 
 /** Directory holding the split Prisma schema (there is no monolithic schema.prisma). */
 export const SCHEMA_DIR_RELATIVE = "packages/db/prisma/schema";
@@ -223,7 +226,49 @@ export type LoadCommittedSchemaDeps = {
   readGit?: GitReader;
   /** Injected in tests; defaults to reading `.git/HEAD` off disk. */
   readBranchFallback?: (root: string) => Promise<string | null>;
+  /** Test hook: skip the default-branch read and exercise the working-tree path. */
+  skipDefaultBranch?: boolean;
 };
+
+/**
+ * Read the schema files straight out of a git ref, without checking anything out.
+ *
+ * BI-6CFC5429. The reader answered from whatever PROJECT_ROOT's working tree was
+ * parked on. On the live install that is /sandbox-workspace, a Build Studio
+ * sandbox whose branch MOVES — observed on client/5727856b-… one day and
+ * pr-4917-head the next. The same question got different answers on different
+ * days, and a model absent from today's sandbox branch read as absent from the
+ * platform: the exact false absence this reader exists to prevent. It answered
+ * correctly for MileageRate only because that PR branch happened to contain it.
+ *
+ * Only ~26 files are needed, so `git show <ref>:<path>` per file is cheap and
+ * needs no worktree — unlike the code graph's 14k-file case, which earns one.
+ */
+async function readSchemaAtRef(
+  root: string,
+  ref: string,
+  readGit: GitReader,
+): Promise<{ count: number; parts: string[] } | null> {
+  const listing = await readGit(root, `ls-tree --name-only ${ref} ${SCHEMA_DIR_RELATIVE}/`);
+  if (!listing) return null;
+
+  const paths = listing
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.endsWith(".prisma"))
+    .sort();
+  if (paths.length === 0) return null;
+
+  const parts: string[] = [];
+  for (const path of paths) {
+    const content = await readGit(root, `show ${ref}:${path}`);
+    // A ref we cannot fully read is not a partial schema, it is no schema.
+    // Returning some of it would silently under-report models.
+    if (content === null) return null;
+    parts.push(content);
+  }
+  return { count: paths.length, parts };
+}
 
 export async function loadCommittedSchema(
   deps: LoadCommittedSchemaDeps = {},
@@ -235,6 +280,31 @@ export async function loadCommittedSchema(
   const root = resolveSourceRoot();
   const schemaDir = resolve(root, SCHEMA_DIR_RELATIVE);
 
+  // Prefer the DEFAULT BRANCH over the working tree. Which tree this process
+  // happens to sit in is a deployment detail; the merge target is what a caller
+  // asking "does this model exist" actually means.
+  const defaultRef = deps.skipDefaultBranch ? null : await resolveDefaultBranchRef(root);
+  if (defaultRef) {
+    const atRef = await readSchemaAtRef(root, defaultRef.ref, readGit);
+    if (atRef) {
+      const refProvenance: CommittedSchemaProvenance = {
+        root,
+        branch: defaultRef.branch,
+        headSha: defaultRef.sha,
+        schemaFileCount: atRef.count,
+        tree: "committed",
+        identified: true,
+      };
+      return {
+        schema: atRef.parts.join("\n"),
+        provenance: refProvenance,
+        trust: buildTrust(refProvenance, asOfDate.toISOString()),
+      };
+    }
+  }
+
+  // Fall back to the working tree, and let the existing scoring say so — an
+  // off-default or unidentifiable tree is capped and named, never authoritative.
   let names: string[];
   try {
     names = (await readdir(schemaDir)).filter((n) => n.endsWith(".prisma")).sort();


### PR DESCRIPTION
`describe_committed_model` read whatever `PROJECT_ROOT`'s working tree was parked on. On the live install that is `/sandbox-workspace` — a Build Studio sandbox whose branch **moves**. Observed directly, same call, same tool:

```
2026-08-26   branch client/5727856b-3296-4e17-97f0-c59401ace4f2   → MileageRate NOT found
2026-09-01   branch pr-4917-head                                  → MileageRate found
```

Nothing about the schema changed between those two readings. The tool answered correctly on 2026-09-01 **only because `pr-4917-head` happened to contain the model**.

Which tree this process sits in is a deployment detail. *"Does this model exist"* means the merge target.

## Change

The reader resolves the default-branch ref and reads the schema straight out of it — `git ls-tree` for the file list, `git show <ref>:<path>` per file. ~26 files, so this needs **no worktree**, unlike the code graph's 14k-file case which earns one (#4719).

`resolveDefaultBranchRef` is imported from the code-graph module rather than restated, so *"which ref is the default branch"* keeps one definition.

## The fallback is unchanged and still honest

If no default branch resolves, or **any** blob in the ref cannot be read, it reads the working tree and the existing scoring applies — an off-default or unidentifiable tree is capped and named, never presented as authoritative.

A ref that reads only *partially* is treated as **no schema**, not a partial one. Returning some of it would silently under-report models, which is precisely the defect class this reader exists to prevent.

## Verification

- **16 tests across 4 committed-schema files.** Four new cases prove it answers from `origin/main` while the working tree is on a sandbox branch (and never touches the working tree), scores the default branch at full freshness/high trust, and degrades to a capped-and-named working-tree read both when a blob is unreadable and when no default branch resolves.
- Existing fixtures now pass `skipDefaultBranch: true`, so they still assert the working-tree path they were written for rather than silently testing the new one.
- **1089 tests pass across 127 files** (`lib/mcp/packs`, `lib/build/code-graph`, `lib/trust-vector`).
- `pnpm --filter web build`: clean.
- `pregate:preflight`: 61 guards clean.
- exact-tree local CI gate: **PASS** (evidence `cmtj6zc5vg3rh01nup4vufhod`).

## Note on the gate

This branch was blocked twice by a pregate durable-wait loop unrelated to the diff — filed as **BI-31556F50**. The interrupted run pinned a lease id into the worktree gate state, then every retry tried to release that lease, failed `nonprod_lease_not_owner`, and re-marked the state failed. Clearing the stale state let it pass first try. Worth knowing because the failure presents as ordinary contention and retrying can never resolve it.

Closes the remaining half of BI-6CFC5429 (the code-graph half landed in #4719).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
