### PR TITLE
test(release): guard the STT digest watch wiring, not just its script

### DIFF
--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -495,6 +495,12 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/lib/sandbox-freshness.test.mjs",
         "scripts/sandbox-freshness-preflight.test.mjs",
         "scripts/release/re-resolve-stt-digest.test.mjs",
+        // BI-BBD60CF8: the re-pin SCRIPT was always correct and always
+        // green; the workflow driving it aborted on the script's own
+        // drift exit code, so the watch failed on every drift day and
+        // never once completed a re-pin (#4823 fixed the wiring). This
+        // guards the wiring, which is the part nothing tested.
+        "scripts/stt-digest-watch-workflow.test.mjs",
         "scripts/lib/ensure-pre-push-hook.test.mjs",
         // BI-5CBDC146: hook directories must resolve through fileURLToPath.
         // URL.pathname yields "/D:/..." on Windows, so the shim never

--- a/scripts/stt-digest-watch-workflow.test.mjs
+++ b/scripts/stt-digest-watch-workflow.test.mjs
@@ -1,0 +1,98 @@
+// BI-BBD60CF8 — the STT Digest Watch must survive its own success signal.
+//
+// `re-resolve-stt-digest.mjs --apply` exits 3 when it rewrote the pin, by
+// design: "so callers know a change was made". The workflow step runs under
+// `bash -e`, so an unguarded call aborts on the ONLY path the watch exists to
+// serve — the drift day — and every downstream line (contract tests, manifest
+// guard, commit, push, PR, auto-merge) never runs.
+//
+// The script itself was never broken and its own unit tests always passed. What
+// went untested was the WIRING, so this reads the workflow rather than the
+// script, and executes the guarded fragment against a stub that exits 3 instead
+// of asserting on the presence of `set +e`.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+const WORKFLOW_PATH = ".github/workflows/stt-digest-watch.yml";
+const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+
+/** The `run:` body of one named step, dedented. */
+function stepScript(name) {
+  const start = workflow.indexOf(`- name: ${name}`);
+  assert.notEqual(start, -1, `step "${name}" not found in ${WORKFLOW_PATH}`);
+  const runAt = workflow.indexOf("run: |", start);
+  assert.notEqual(runAt, -1, `step "${name}" has no run block`);
+  const lines = workflow.slice(workflow.indexOf("\n", runAt) + 1).split("\n");
+  const body = [];
+  for (const line of lines) {
+    // The block ends at the next line that is not blank and not indented into it.
+    if (line.trim() !== "" && !line.startsWith("          ")) break;
+    body.push(line.slice(10));
+  }
+  return body.join("\n");
+}
+
+const applyScript = stepScript("Apply re-pin and open PR");
+const checkScript = stepScript("Check pinned digest against the live registry");
+
+/**
+ * Run the leading guard of a step under `bash -e`, with the re-resolve script
+ * replaced by a stub exiting `code`, and report whether execution continued past
+ * it. Everything from the first `git config` on is dropped so the test never
+ * touches git, the network, or the registry.
+ */
+function survivesExitCode(script, code) {
+  const guard = script.slice(0, script.indexOf("git config"));
+  const stubbed = guard
+    // Replace the real invocations with a stub carrying the exit code.
+    .replace(/node scripts\/release\/re-resolve-stt-digest\.mjs[^\n]*/g, `( exit ${code} )`)
+    // The verification commands are not what this test is about.
+    .replace(/node --test[^\n]*/g, ":")
+    .replace(/node scripts\/release\/verify-compose-image-manifests\.mjs[^\n]*/g, ":");
+  const result = spawnSync("bash", ["-e", "-c", `${stubbed}\necho REACHED_END`], {
+    encoding: "utf8",
+  });
+  return { reached: (result.stdout ?? "").includes("REACHED_END"), status: result.status };
+}
+
+describe("STT Digest Watch — apply step", () => {
+  it("continues past the documented drift exit code", () => {
+    // Exit 3 means "I rewrote the pin". The step must go on to commit it.
+    const { reached } = survivesExitCode(applyScript, 3);
+    assert.equal(
+      reached,
+      true,
+      "the apply step aborted on exit 3 — the drift signal — so the re-pin is written but never committed",
+    );
+  });
+
+  it("continues when there was nothing to re-pin", () => {
+    assert.equal(survivesExitCode(applyScript, 0).reached, true);
+  });
+
+  it("still fails on a real error from the re-resolve script", () => {
+    // Exit 2 is usage / Docker Hub API failure. Tolerating everything would
+    // trade this bug for a worse one: committing a pin that was never resolved.
+    const { reached, status } = survivesExitCode(applyScript, 2);
+    assert.equal(reached, false, "exit 2 (API/usage failure) must stop the step");
+    assert.equal(status, 2, "the step should surface the script's own exit code");
+  });
+});
+
+describe("STT Digest Watch — check step", () => {
+  it("decodes the drift exit code rather than dying on it", () => {
+    // The check step was always correct; this pins that so a future edit cannot
+    // reintroduce the same inversion at the other end of the workflow.
+    assert.match(checkScript, /set \+e/);
+    assert.match(checkScript, /code=\$\?/);
+    assert.match(checkScript, /"\$code"\s*=\s*"3"/);
+    assert.match(checkScript, /drift=true/);
+  });
+
+  it("treats an unreachable registry as no-drift rather than a failure", () => {
+    assert.match(checkScript, /Docker Hub API unavailable/);
+  });
+});


### PR DESCRIPTION
## The gap

#4823 fixed the STT Digest Watch: `re-resolve-stt-digest.mjs --apply` exits 3 to mean *"a change was made"*, the apply step called it bare under `bash -e`, and that success signal killed the step before `gh pr create`. Nothing tests that it stays fixed.

The gap is specific and worth naming. **The script was never broken.** `re-resolve-stt-digest.test.mjs` and `installer-release-contract.test.mjs` — the verification #4823 cites — passed throughout the outage and would have passed through every failed run. They exercise the script; the defect was in whether the workflow could survive *calling* it.

That shape is the recurring one here: a guard that passes every test while the thing it guards is inert.

## What this adds

`scripts/stt-digest-watch-workflow.test.mjs` reads the **workflow**, extracts the apply step's `run` block, substitutes a stub exiting 0 / 3 / 2, and executes the guard under `bash -e` to see whether execution actually continues past it.

- **exit 3** (drift applied) must continue — otherwise the re-pin is written and never committed, which is exactly the 2026-08-27 failure
- **exit 0** (nothing to re-pin) must continue
- **exit 2** (usage / Docker Hub API failure) must still stop, and surface the script's own exit code. Tolerating everything would trade this bug for a worse one: committing a pin that was never resolved

Two further assertions pin the **check** step, which was always correct, so a future edit cannot reintroduce the same inversion at the other end of the workflow.

## Verified not inert

Against #4823's fix as it stands on `main`, not a reconstruction of it. With that guard removed from the workflow the suite fails on:

```
the apply step aborted on exit 3 — the drift signal — so the re-pin is written but never committed
```

and passes 5/5 with it restored. Re-confirmed after rebasing across 116 commits of drift.

Registered in the `janitor-tests` guard beside `re-resolve-stt-digest.test.mjs`. The CI test inventory is hand-enumerated, so an unregistered `*.test.mjs` silently never runs — which would have reproduced the original defect inside the test itself.

## Why it matters beyond a 104-line diff

The downstream chain is recorded on BI-E6EF0B2C: a dead pin turns Release Contract Guards + Release Image Manifest Guard red on `main` for every open PR, and freezes `:latest`, so installs are told *"you are up to date"* while reading a pointer that never moved. Community install report #1767 is the outside-facing form — a macOS/M3 reporter whose entire compose bring-up died on `manifest for hwdsl2/whisper-server@sha256:4e1d727c... not found`, unable to complete the install at all. Three rotations are on record (#3175, #4775, and the one behind #1767), each absorbed by a human.

## Pushed with a recorded gate override — please read this

The local-CI gate **never reached a product verdict** on this branch. Six attempts, none of them a failure of the diff:

| # | Outcome |
|---|---|
| 1 | A git-spawning test timed out at 15s under contention (6/6 green in isolation) → FAIL recorded |
| 2 | Retry **replayed** that recorded FAIL instead of re-running → needed a fresh SHA |
| 3 | Agent session teardown killed the gate process → never ran |
| 4 | Durable-wait queued, process exited → record stale against the new SHA |
| 5 | Ran 14:44 through the image build, then **lease fenced mid-run** → `blocked_control_plane_starvation` |
| 6 | Same fencing again |

5 and 6 are BI-ECAE03F7 (the gate cannot keep its 2-minute lease alive through a multi-minute run), amplified by BI-D908DA0A (pool pinned to 1 slot) and BI-46B03CAE (10s MCP timeout below real lease-queue cost). All three are open. The gate itself classifies the result honestly: *"infrastructure evidence, NOT a product build failure."*

What **did** run and pass:

- `ci-policy-guards.mjs --profile pull-request` — 7/7
- the pre-push guard-parity preflight on the override path — **61 guards clean in 115s**
- `node --test scripts/stt-digest-watch-workflow.test.mjs` — 5/5, and failing as designed when the guard under test is removed

Required CI on this PR is the authoritative check. If a reviewer would rather see a green local-CI record first, the branch can be re-gated when the slot is quiet — the failure is contention-dependent, not deterministic (#4828 completed a 17:39 run on the same pool earlier).

Refs: BI-E6EF0B2C

🤖 Generated with [Claude Code](https://claude.com/claude-code)
