### PR TITLE
fix(skill): name leaseId as the release argument for shared nonprod leases

### DIFF
--- a/packages/dpf-skill-pack/skills/dpf-use-shared-nonprod-environment/SKILL.md
+++ b/packages/dpf-skill-pack/skills/dpf-use-shared-nonprod-environment/SKILL.md
@@ -50,14 +50,26 @@ If no shared environment is available and the canonical local install is the rig
 4. If the result is `queued`, do not touch the runtime. Re-observe the same
    claim with bounded backoff; reusing `claimKey` preserves FIFO position.
 5. Only an `admitted` result authorizes verification against the provided URL.
-6. Release an admitted lease when verification is complete or blocked. Release
-   a queued lease to cancel the request when the task stops waiting.
+6. Release by `leaseId` — the exact id the claim returned (`NPEL-…`). Release an
+   admitted lease when verification is complete or blocked, and release a queued
+   lease to cancel the request when the task stops waiting.
+   - `environmentKey` does NOT release anything. It names the environment, not
+     your claim on it, and the release call rejects it: `missing_required`,
+     `retryable: false`. Keep the `leaseId` from step 3; if you no longer have
+     it, list the leases and read it back.
+   - `claimKey` (step 3) is not the `leaseId` either. It preserves FIFO position
+     across re-observations; only the returned `leaseId` releases.
 
 ## Guardrails
 
 - Do not start a thread-owned preview server when a shared environment is available.
 - A successful queued response is not runtime ownership; only `admitted` is.
 - Do not hold a lease after the thread is complete, blocked, or handed off.
+- `nonprod_lease_not_owner` on release means the lease is someone else's, or it
+  is a durable queue task that outlives your process. It is not a transient
+  error and re-calling cannot fix it (`retryable: false`) — list the leases and
+  leave it alone. Blind-retrying it is how a healthy queued run gets reported as
+  a failure.
 - Do not show lease IDs or raw tool names in the default UI. Show "Shared environment ready", "in use", or "blocked."
 - Don't treat this skill as optional when runtime-bound verification is needed in a thread worktree — it IS the runtime path; the worktree is not.
 


### PR DESCRIPTION
`release_nonprod_environment_lease` fails **42%** of the time on the live install (36/85 calls in 24h). The failures split cleanly:

| failure | 7-day count | meaning |
|---|---|---|
| `missing_required` | **204** | called with `{environmentKey: "local-integration-ci"}` and no `leaseId` |
| `nonprod_lease_not_owner` | 48 | the lease belongs to someone else, or is a durable queue task |

## The tool is not at fault

Its schema already declares `required: ["leaseId"]`. Its description already says *"not the environmentKey"*. Its error message already says *"Do NOT pass environmentKey alone. Do NOT retry without a leaseId (retryable: false)."* And every caller in this repo — `pregate.mjs`, `gate-worktree.mjs` (both sites), `host-resource-runner.mjs` — passes `leaseId` correctly.

The failing calls come from agents, on `external-jsonrpc`. This skill is what they read.

## What the skill actually said

> 6. Release an admitted lease when verification is complete or blocked.

It named the *moment* to release and never the *argument*, while steps 3 and 4 talk about `claimKey`. An agent reaching for an identifier it has been told about lands on `environmentKey` or `claimKey` — and neither releases anything. Two hundred rejections in a week is what "left the reader to guess the mechanism" costs.

Step 6 now names `leaseId`, states that `environmentKey` names the environment rather than your claim on it, and separates `claimKey` (preserves FIFO position across re-observations) from `leaseId` (releases).

A guardrail covers the other half: `nonprod_lease_not_owner` is not transient, re-calling cannot fix it, and blind-retrying it is how a healthy queued run gets reported as a failure — the defect fixed caller-side in #4943.

## How this got picked

By re-measuring the MCP call-efficiency backlog items instead of working from their filed numbers. The retry storm three of them are named for — 451 fail→retry pairs on `claim_nonprod_environment_lease`, filed 2026-08-27 — **is no longer reproducing**: that tool now runs at 88.5% success. Had I taken the queue at face value I would have spent the pass on a resolved problem.

The two worst survivors, `claim_backlog_item_for_work` (67% fail) and `record_initiative_design_review` (77% fail), are both parts of the completion/review gate whose process the operator has retired, so they are deliberately untouched here.

## Evidence

- local-CI gate **PASS** on `a9b7baf5af4e`
- **61** preflight guards clean
- 25 `seed-skills` tests · 119 `lib/skills` tests

## Worth pressing on

1. **The denominator is one install's traffic.** 204 calls over seven days is this host's agents on this skill. The direction is not in doubt at that volume, but another install with different coworkers could see a different split.
2. **This does not prove the fix works** — it removes the most likely cause of a measured failure. The honest test is re-running `analyze_mcp_call_efficiency` after the skill reseeds and seeing whether `missing_required` on this tool falls. Nobody should mark it verified before that.
3. **A skill edit only reaches coworkers on the next seed**, and only reaches the CLI surfaces through the plugin. Agents already mid-thread keep the old text.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)