### PR TITLE
fix(inference): a mask with nothing to redact must not fence the turn (BI-67CAF494)

### DIFF
--- a/apps/web/lib/inference/data-screening/classify-payload.ts
+++ b/apps/web/lib/inference/data-screening/classify-payload.ts
@@ -618,6 +618,30 @@ function isInstructionProvenance(match: InferencePayloadMatch): boolean {
 }
 
 /**
+ * True when the DATA evidence is nothing but corroboration-gated vocabulary —
+ * a domain was named and no value was found.
+ *
+ * The distinction matters at the routing seam. A mask obligation exists to
+ * redact something before it leaves the boundary; when the only evidence is the
+ * word "payroll", there is no span to redact, so masking is a no-op and
+ * clamping the turn to local-only protects nothing while making the coworker
+ * unreachable for its own subject (BI-67CAF494).
+ *
+ * Deliberately strict: ONE precise match, or any declared governed hint, and
+ * this is false. It answers "is there anything here to mask?", not "is this
+ * probably fine?".
+ */
+export function isVocabularyOnlyEvidence(
+  matches: readonly InferencePayloadMatch[],
+  governedData?: readonly GovernedPayloadHint[],
+): boolean {
+  if (governedData && governedData.length > 0) return false;
+  const dataMatches = matches.filter((match) => !isInstructionProvenance(match));
+  if (dataMatches.length === 0) return false;
+  return dataMatches.every((match) => AMBIGUOUS_REASONS.has(match.reason));
+}
+
+/**
  * Split the prompt into instruction spans and the data remainder.
  *
  * Spans are matched literally and every occurrence is removed, so a block that

--- a/apps/web/lib/inference/data-screening/screen-inference-payload.test.ts
+++ b/apps/web/lib/inference/data-screening/screen-inference-payload.test.ts
@@ -215,3 +215,64 @@ describe("screenInferencePayload", () => {
     });
   });
 });
+
+describe("a mask with nothing to redact does not fence the turn (BI-67CAF494)", () => {
+  it("lets a coworker be asked for help with payroll", () => {
+    // The live failure, after the vocabulary fix reduced it from restricted to
+    // confidential: a mask obligation attached with no value to redact, and the
+    // clamp still fenced the reviewer. RouteDecisionLog screen_2781e0797c3307ed —
+    // one match, employee-record-ambiguous-term, transformation "none".
+    const result = screenInferencePayload({
+      messages: [{ role: "user", content: "Please review the payroll tax acquisition design." }],
+      systemPrompt: "",
+      taskType: "analysis",
+      routeContext: { sensitivity: "internal", residencyPolicy: "any_enabled" },
+    });
+
+    expect(result.receipt.routeEffect).toBe("allow");
+    expect(result.routeContext.residencyPolicy).not.toBe("local_only");
+  });
+
+  it("still fences when ONE precise match sits beside the vocabulary", () => {
+    // Fails closed: a real value alongside the domain word and the clamp stands.
+    const result = screenInferencePayload({
+      messages: [{ role: "user", content: "Review the payroll and her salary band." }],
+      systemPrompt: "",
+      taskType: "analysis",
+      routeContext: { sensitivity: "internal", residencyPolicy: "any_enabled" },
+    });
+
+    expect(result.receipt.routeEffect).toBe("local-only");
+    expect(result.routeContext.residencyPolicy).toBe("local_only");
+  });
+
+  it("still fences when a governed hint declares the data", () => {
+    // A DECLARED classification is not a guess and always outranks the heuristic.
+    const result = screenInferencePayload({
+      messages: [{ role: "user", content: "Review the payroll module." }],
+      systemPrompt: "",
+      taskType: "analysis",
+      governedData: [{
+        assetId: "data:pay-run",
+        fieldIds: ["data:pay-run#grossPay"],
+        classificationKnown: true,
+        sensitivity: "confidential",
+        purpose: "service-delivery",
+      }],
+      routeContext: { sensitivity: "internal", residencyPolicy: "any_enabled" },
+    });
+
+    expect(result.routeContext.residencyPolicy).toBe("local_only");
+  });
+
+  it("still fences a restricted payload outright", () => {
+    const result = screenInferencePayload({
+      messages: [{ role: "user", content: "His SSN is on the form." }],
+      systemPrompt: "",
+      taskType: "analysis",
+      routeContext: { sensitivity: "internal", residencyPolicy: "any_enabled" },
+    });
+
+    expect(result.routeContext.residencyPolicy).toBe("local_only");
+  });
+});

--- a/apps/web/lib/inference/data-screening/screen-inference-payload.ts
+++ b/apps/web/lib/inference/data-screening/screen-inference-payload.ts
@@ -6,7 +6,7 @@ import type {
 import type { RequestContract } from "@/lib/routing/request-contract";
 import type { ActivityContract } from "@/lib/routing/activity-contract";
 import { isLocalProviderId } from "@/lib/routing/provider-locality";
-import { classifyInferencePayload } from "./classify-payload";
+import { classifyInferencePayload, isVocabularyOnlyEvidence } from "./classify-payload";
 import { evaluateInferenceDispatchPolicy } from "./evaluate-inference-policy";
 import type {
   GovernedPayloadHint,
@@ -124,9 +124,21 @@ export function screenInferencePayload(
       : classification.overallSensitivity;
   const sensitivity = strongestSensitivity(originalSensitivity, routedPayloadSensitivity);
   const maskRequired = policy.obligations.some((obligation) => obligation.kind === "mask");
+  // A mask obligation clamps the turn local so nothing leaves unredacted. That
+  // is right whenever there is something to redact — and a no-op when the only
+  // evidence is corroboration-gated vocabulary, because a domain was named and
+  // no value was found. Clamping then protects nothing and makes a coworker
+  // unreachable for its own subject: asking for help with payroll measured
+  // confidential, attached a mask with nothing to mask, and fenced the turn
+  // (BI-67CAF494, RouteDecisionLog screen_2781e0797c3307ed).
+  //
+  // Narrow by construction. One precise match, any declared governed hint, or a
+  // deny/review effect and the clamp stands.
+  const maskHasNothingToRedact =
+    maskRequired && isVocabularyOnlyEvidence(classification.matches, input.governedData);
   const routeEffect = policy.effect === "deny" ||
     policy.effect === "review" ||
-    (maskRequired && !prior)
+    (maskRequired && !prior && !maskHasNothingToRedact)
     ? "local-only"
     : "allow";
   const residencyPolicy = routeEffect === "local-only"


### PR DESCRIPTION
Follow-on to #4941. That fix moved a payroll-subject request from `restricted` to `confidential`. **It was still unreachable**, because a second channel clamped it.

## The live receipt

`screen_2781e0797c3307ed`:

```
matchProvenance: [{ reason: "employee-record-ambiguous-term", confidence: "inferred" }]
measuredSensitivity: "confidential"
policyEffect:        "allow-with-obligations"
obligationKinds:     ["mask"]
transformation:      "none"      ← nothing was masked
routeEffect:         "local-only"
```

One ambiguous vocabulary match, no value anywhere in the payload, a mask obligation attached — and the clamp fired anyway:

```js
routeEffect = deny || review || (maskRequired && !prior) ? "local-only" : "allow"
```

A mask obligation exists to redact something before it leaves the boundary. That's right whenever there *is* something to redact. When the only evidence is the word "payroll", there's no span to redact: **masking is a no-op, the clamp protects nothing, and the coworker is unreachable for its own subject.**

This is the fourth of the four channels the screening essay names — and the one it describes as having *"survived every narrower fix"*.

## The fix

`isVocabularyOnlyEvidence` answers exactly one question — *is there anything here to mask?* — and the clamp is skipped only when the answer is no. It lives next to `AMBIGUOUS_REASONS` rather than leaking that set to the routing seam.

**Narrow by construction.** One precise match, any declared governed hint, or a `deny`/`review` effect, and the clamp stands.

## Why this is safe

The condition is *"no value was found"*, not *"this looks fine"*. Every path carrying an actual value is untouched. What changes is only the case where the platform attached an obligation it had nothing to apply.

Four tests pin both directions:

| case | outcome |
|---|---|
| "review the payroll tax acquisition design" | **allow** |
| "review the payroll and her salary band" | local-only |
| payroll + a declared `governedData` hint | local-only |
| "his SSN is on the form" | local-only |

## Verification

- Local CI gate **PASS** (evidence `cmtjewmgi2nqe01nzrfqi0kpd`) — full suite and production build, **no override**
- 4,120 tests across `lib/inference`, `lib/routing`, `lib/govern`, `lib/tak`; `tsc` clean
- 61 preflight guards clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)