### PR TITLE
fix(scheduling): a scheduled tick resolves its posture through the room (BI-27C8484F)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -33,6 +33,7 @@ import {
 import { assertScheduledResearchCapability, resolveScheduledTurnExternalAccess } from "@/lib/tak/scheduled-external-access";
 import { resolveUserAwareProactivityPlan } from "@/lib/proactivity/proactivity-resolver.server";
 import { resolveDelegatedPosture } from "@/lib/proactivity/delegated-posture";
+import { resolveScheduledTickPlan } from "@/lib/scheduling/scheduled-work-posture.server";
 import { applyProviderRouteModelPreference } from "@/lib/ai-provider-route-context";
 import {
   isCoworkerSelfTaskId,
@@ -430,13 +431,15 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
       },
     });
 
-    const proactivity = await resolveUserAwareProactivityPlan({
+    // BI-27C8484F: the identity ladder, then MOVED by the room's ladder when this
+    // job serves a Workroom — its declaration, the work's shape, and the
+    // obligation this tick races. A job serving no room resolves exactly as before.
+    const { plan: proactivity } = await resolveScheduledTickPlan({
       userId: task.ownerUserId,
-      input: {
-        activityFamily: "scheduled-task",
-        agentId: task.agentId,
-        routeContext: task.routeContext,
-      },
+      taskConfig: task.taskConfig,
+      agentId: task.agentId,
+      routeContext: task.routeContext,
+      now: new Date(),
     });
     resolvedPlan = proactivity;
 

--- a/apps/web/lib/scheduling/scheduled-work-posture.server.test.ts
+++ b/apps/web/lib/scheduling/scheduled-work-posture.server.test.ts
@@ -1,0 +1,214 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ProactivityPlan } from "@/lib/proactivity/proactivity-types";
+import { withScheduledWorkTrigger } from "./scheduled-work-trigger";
+
+const mocks = vi.hoisted(() => ({
+  prisma: { workroom: { findFirst: vi.fn() } },
+  loadWorkroomPostureContext: vi.fn(),
+  resolveUserAwareProactivityPlan: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }));
+vi.mock("@/lib/work-management/room-posture.server", () => ({
+  loadWorkroomPostureContext: mocks.loadWorkroomPostureContext,
+}));
+vi.mock("@/lib/proactivity/proactivity-resolver.server", () => ({
+  resolveUserAwareProactivityPlan: mocks.resolveUserAwareProactivityPlan,
+}));
+
+import { resolveScheduledTickPlan } from "./scheduled-work-posture.server";
+
+const NOW = new Date("2026-09-02T10:00:00.000Z");
+
+function plan(overrides: Partial<ProactivityPlan> = {}): ProactivityPlan {
+  return {
+    resolvedLevel: "assertive",
+    actionBoundary: "preauthorized",
+    evidenceRefs: [],
+    explanation: "",
+    ...overrides,
+  } as ProactivityPlan;
+}
+
+function room(scopeClaims: unknown[] = [], dueAt: Date | null = null) {
+  return {
+    scopeClaims,
+    activityKind: "delivery",
+    decisionScope: "wwmd",
+    workItem: { assignedToAgentId: "marketing-specialist", dueAt },
+  };
+}
+
+function tick(taskConfig: unknown) {
+  return resolveScheduledTickPlan({
+    userId: "user-1",
+    taskConfig,
+    agentId: "marketing-specialist",
+    routeContext: "/customer/marketing",
+    now: NOW,
+  });
+}
+
+function configFor(trigger: Parameters<typeof withScheduledWorkTrigger>[1]) {
+  return withScheduledWorkTrigger({}, trigger, NOW);
+}
+
+/** Set the plan the identity ladder resolves before the room moves it. */
+function inherited(overrides: Partial<ProactivityPlan> = {}) {
+  mocks.resolveUserAwareProactivityPlan.mockResolvedValue(plan(overrides));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  inherited();
+  mocks.loadWorkroomPostureContext.mockResolvedValue({
+    inherited: { proactivityPlan: plan(), priority: null, source: "platform" as const },
+    operatingHours: null,
+    stream: null,
+    activityFamily: "scheduled-task",
+    hardPolicy: null,
+  });
+});
+
+describe("resolveScheduledTickPlan — when no room governs the tick", () => {
+  it("keeps the identity-ladder plan when the task records no trigger", async () => {
+    const result = await tick({});
+    expect(result.posture).toBeNull();
+    expect(result.trigger).toBeNull();
+    expect(result.plan.resolvedLevel).toBe("assertive");
+    expect(mocks.prisma.workroom.findFirst).not.toHaveBeenCalled();
+  });
+
+  // The room ladder must never invent a room.
+  it("keeps the identity-ladder plan when the trigger names no room", async () => {
+    const result = await tick(configFor({ kind: "time" }));
+    expect(result.posture).toBeNull();
+    expect(result.plan.resolvedLevel).toBe("assertive");
+    expect(mocks.prisma.workroom.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("keeps the identity-ladder plan when the named room is gone", async () => {
+    mocks.prisma.workroom.findFirst.mockResolvedValue(null);
+    const result = await tick(configFor({ kind: "time", workroomId: "WC-GONE" }));
+    expect(result.posture).toBeNull();
+    expect(result.plan.resolvedLevel).toBe("assertive");
+  });
+
+  // Fail-open: a posture lookup must never stop a scheduled job running.
+  it("keeps the identity-ladder plan rather than throwing when the lookup fails", async () => {
+    mocks.prisma.workroom.findFirst.mockRejectedValue(new Error("db down"));
+    const result = await tick(configFor({ kind: "time", workroomId: "WC-1" }));
+    expect(result.posture).toBeNull();
+    expect(result.plan.resolvedLevel).toBe("assertive");
+  });
+});
+
+describe("resolveScheduledTickPlan — the room's declaration reaches the plan", () => {
+  // The headline defect: an operator quietens a room, a scheduled turn fires in
+  // it, and the declaration is ignored because nothing consulted the room.
+  it("applies a room's declared quiet posture to the tick's plan", async () => {
+    mocks.prisma.workroom.findFirst.mockResolvedValue(
+      room([{ workroomPosture: { proactivityLevel: "quiet" }, recordedAt: NOW.toISOString() }]),
+    );
+    inherited({ resolvedLevel: "assertive" });
+
+    const result = await tick(configFor({ kind: "time", workroomId: "WC-1" }));
+
+    expect(result.posture?.proactivityLevel).toBe("quiet");
+    expect(result.plan.resolvedLevel).toBe("quiet");
+  });
+
+  it("carries the trigger it resolved through, so the run can record why", async () => {
+    mocks.prisma.workroom.findFirst.mockResolvedValue(room());
+    const result = await tick(configFor({ kind: "detected-need", workroomId: "WC-1" }));
+    expect(result.trigger?.kind).toBe("detected-need");
+    expect(result.trigger?.workroomId).toBe("WC-1");
+  });
+
+  it("looks the room up by capsule id or row id", async () => {
+    mocks.prisma.workroom.findFirst.mockResolvedValue(room());
+    await tick(configFor({ kind: "time", workroomId: "WC-1" }));
+    const where = mocks.prisma.workroom.findFirst.mock.calls[0]![0].where;
+    expect(where.OR).toEqual([{ capsuleId: "WC-1" }, { id: "WC-1" }]);
+    expect(where.archivedAt).toBeNull();
+  });
+});
+
+describe("resolveScheduledTickPlan — the obligation drives the clock", () => {
+  // temporalInputForTrigger's reason to exist: a tick racing a 12:00 obligation
+  // is deadline work even though the ROOM carries no due date of its own.
+  it("uses the trigger's obligation as the effective due date", async () => {
+    mocks.prisma.workroom.findFirst.mockResolvedValue(room([], null));
+    inherited({ resolvedLevel: "balanced" });
+
+    const withObligation = await tick(
+      configFor({
+        kind: "time",
+        workroomId: "WC-1",
+        obligation: { dueAt: "2026-09-02T12:00:00.000Z", label: "Q3 filing" },
+      }),
+    );
+    expect(withObligation.posture?.temporalBand).toBe("pre-deadline");
+
+    // The contrast is the load-bearing half: same room, no obligation, no band.
+    const withoutObligation = await tick(configFor({ kind: "time", workroomId: "WC-1" }));
+    expect(withoutObligation.posture?.temporalBand).not.toBe("pre-deadline");
+  });
+
+  it("falls back to the room's own due date when no obligation is recorded", async () => {
+    mocks.prisma.workroom.findFirst.mockResolvedValue(
+      room([], new Date("2026-09-02T11:00:00.000Z")),
+    );
+    inherited({ resolvedLevel: "balanced" });
+    const result = await tick(configFor({ kind: "time", workroomId: "WC-1" }));
+    expect(result.posture?.temporalBand).toBe("pre-deadline");
+  });
+});
+
+describe("resolveScheduledTickPlan — tighten-only at this call site", () => {
+  // A scheduled job must never acquire MORE authority by running in a room.
+  it("never widens the inherited action boundary", async () => {
+    mocks.prisma.workroom.findFirst.mockResolvedValue(
+      room([{ workroomPosture: { actionBoundary: "preauthorized" }, recordedAt: NOW.toISOString() }]),
+    );
+    inherited({ actionBoundary: "advise" });
+
+    const result = await tick(configFor({ kind: "time", workroomId: "WC-1" }));
+    expect(result.plan.actionBoundary).toBe("advise");
+  });
+
+  it("applies a room boundary narrower than the inherited one", async () => {
+    mocks.prisma.workroom.findFirst.mockResolvedValue(
+      room([{ workroomPosture: { actionBoundary: "advise" }, recordedAt: NOW.toISOString() }]),
+    );
+    inherited({ actionBoundary: "preauthorized" });
+
+    const result = await tick(configFor({ kind: "time", workroomId: "WC-1" }));
+    expect(result.plan.actionBoundary).toBe("advise");
+  });
+});
+
+// BI-27C8484F exists because scheduled-work-trigger.ts shipped, passed its own
+// tests, and had no caller in the execution path. A module can be correct and
+// still do nothing. This asserts the seam is production-reachable — not that it
+// merely compiles.
+describe("caller existence", () => {
+  const schedulerSource = readFileSync(
+    join(__dirname, "..", "actions", "agent-task-scheduler.ts"),
+    "utf8",
+  );
+
+  it("the scheduler imports and awaits the seam", () => {
+    expect(schedulerSource).toContain('from "@/lib/scheduling/scheduled-work-posture.server"');
+    expect(schedulerSource).toContain("await resolveScheduledTickPlan(");
+  });
+
+  it("the resolved plan is what the run actually uses", () => {
+    // The call is worthless if its result is computed and discarded.
+    expect(schedulerSource).toMatch(/\{\s*plan: proactivity\s*\}\s*=\s*await resolveScheduledTickPlan/);
+    expect(schedulerSource).toContain("resolvedPlan = proactivity;");
+  });
+});

--- a/apps/web/lib/scheduling/scheduled-work-posture.server.ts
+++ b/apps/web/lib/scheduling/scheduled-work-posture.server.ts
@@ -1,0 +1,190 @@
+import "server-only";
+
+/**
+ * EP-WORK-POSTURE (BI-27C8484F) — the seam that makes a scheduled tick resolve
+ * its posture through the ROOM ladder.
+ *
+ * THE DEFECT THIS CLOSES. `scheduled-work-trigger.ts` recorded why a job exists
+ * — its trigger kind, the room it serves, the obligation it races — and shipped
+ * with tests, and had ZERO importers in the execution path. Meanwhile
+ * `executeScheduledAgentTask` resolved proactivity from the identity ladder and
+ * never mentioned a room. So an operator could tighten a room's posture, watch a
+ * scheduled turn fire inside that room, and see the untightened behaviour with no
+ * signal that the declaration had been ignored.
+ *
+ * WHAT THIS DOES NOT DO. It does not decide anything, and it does not add a
+ * second ladder. `resolveWorkPosture` remains the only place a posture is
+ * judged; this module assembles its inputs for one caller. The scheduler's own
+ * resolved plan is handed in as the INHERITED baseline, so the room's layers sit
+ * on top of what the scheduler actually resolved rather than on top of a second,
+ * separately-derived baseline that could disagree with it.
+ *
+ * TIGHTEN-ONLY, ASSERTED HERE. `resolveWorkPosture` already enforces the
+ * invariant internally, but this is a new call site on the hot path for
+ * unattended work, so the boundary is re-checked against the inherited plan
+ * before it is returned. A widening result is dropped rather than applied — a
+ * scheduled job must never be able to acquire more authority than the coworker
+ * already had by virtue of running in a room.
+ *
+ * FAIL-OPEN. Every failure returns null, which leaves the caller on exactly
+ * today's behaviour. A posture lookup must never stop a scheduled job running.
+ */
+import { prisma } from "@dpf/db";
+
+import { deriveWorkroomShape } from "@/lib/work-management/derive-workroom-shape";
+import { resolveWorkroomPosture, type WorkroomPostureView } from "@/lib/work-management/room-posture";
+import { loadWorkroomPostureContext } from "@/lib/work-management/room-posture.server";
+import { readWorkroomPostureClaim } from "@/lib/work-management/workroom-posture-claim";
+import { readWorkroomShapeClaim } from "@/lib/work-management/workroom-shape-claim";
+import { resolveProactivityPlanForLevel } from "@/lib/proactivity/proactivity-resolver";
+import { resolveUserAwareProactivityPlan } from "@/lib/proactivity/proactivity-resolver.server";
+import type { ProactivityPlan, ProactivityResolverInput } from "@/lib/proactivity/proactivity-types";
+import { tightenActionBoundary } from "@/lib/work-posture";
+
+import {
+  readScheduledWorkTrigger,
+  temporalInputForTrigger,
+  type ScheduledWorkTrigger,
+} from "./scheduled-work-trigger";
+
+export interface ScheduledTickPlan {
+  /** The plan the run executes at — the inherited plan, moved by the room. */
+  plan: ProactivityPlan;
+  /** The room's effective posture, or null when this job serves no room. */
+  posture: WorkroomPostureView | null;
+  /** The recorded trigger, or null when the task records none. */
+  trigger: ScheduledWorkTrigger | null;
+}
+
+/**
+ * The ONE question `executeScheduledAgentTask` asks about pace: what plan should
+ * this tick run at? Answered by the identity ladder, then moved by the room's
+ * ladder when the job serves a room. Keeping both halves behind one entry point
+ * stops the scheduler orchestrating two resolvers and having to know which wins.
+ */
+export async function resolveScheduledTickPlan(input: {
+  userId: string;
+  taskConfig: unknown;
+  agentId: string;
+  routeContext: string | null;
+  now: Date;
+}): Promise<ScheduledTickPlan> {
+  const resolverInput: ProactivityResolverInput = {
+    activityFamily: "scheduled-task",
+    agentId: input.agentId,
+    routeContext: input.routeContext ?? undefined,
+  };
+  const inheritedPlan = await resolveUserAwareProactivityPlan({
+    userId: input.userId,
+    input: resolverInput,
+  });
+  const room = await resolveScheduledTickPosture({
+    taskConfig: input.taskConfig,
+    resolverInput,
+    inheritedPlan,
+    now: input.now,
+  });
+  return {
+    plan: room?.plan ?? inheritedPlan,
+    posture: room?.posture ?? null,
+    trigger: room?.trigger ?? null,
+  };
+}
+
+interface ScheduledTickPosture {
+  trigger: ScheduledWorkTrigger;
+  posture: WorkroomPostureView;
+  plan: ProactivityPlan;
+}
+
+/**
+ * Resolve a scheduled tick's posture through the room that the job serves.
+ *
+ * Returns null — meaning "keep today's behaviour" — when the task records no
+ * trigger, the trigger names no room, the room is gone, or the posture context
+ * cannot be established. The room ladder never invents a room.
+ */
+async function resolveScheduledTickPosture(input: {
+  taskConfig: unknown;
+  resolverInput: ProactivityResolverInput;
+  /** The plan the scheduler already resolved. Becomes the inherited baseline. */
+  inheritedPlan: ProactivityPlan;
+  now: Date;
+}): Promise<ScheduledTickPosture | null> {
+  try {
+    const trigger = readScheduledWorkTrigger(input.taskConfig);
+    if (!trigger?.workroomId) return null;
+
+    const room = await prisma.workroom.findFirst({
+      where: {
+        archivedAt: null,
+        OR: [{ capsuleId: trigger.workroomId }, { id: trigger.workroomId }],
+      },
+      select: {
+        scopeClaims: true,
+        activityKind: true,
+        decisionScope: true,
+        workItem: { select: { assignedToAgentId: true, dueAt: true } },
+      },
+    });
+    if (!room) return null;
+
+    const context = await loadWorkroomPostureContext({
+      sourceType: "scheduled-task",
+      sourceId: trigger.workroomId,
+      assignedToAgentId: room.workItem?.assignedToAgentId ?? input.resolverInput.agentId ?? null,
+      now: input.now,
+    });
+    if (!context) return null;
+
+    // The obligation the job is racing outranks the room's own due date: a tick
+    // firing at 03:00 to discharge a 09:00 filing is pre-deadline work even when
+    // the room itself carries no deadline. This is the only consumer of
+    // temporalInputForTrigger, and the reason it exists.
+    const effectiveDueAt = temporalInputForTrigger(trigger, {
+      now: input.now,
+      schedule: null,
+      timezone: null,
+      dueAt: room.workItem?.dueAt ?? null,
+    }).dueAt;
+
+    const shapeKey = readWorkroomShapeClaim(room.scopeClaims)
+      ?? deriveWorkroomShape({
+        activityKind: room.activityKind,
+        decisionScope: room.decisionScope,
+        mode: "standing",
+      })?.shape
+      ?? null;
+
+    const posture = resolveWorkroomPosture(
+      {
+        shapeKey,
+        activityKind: room.activityKind,
+        mode: "standing",
+        cycleActive: true,
+        dueAt: effectiveDueAt?.toISOString() ?? null,
+        declaration: readWorkroomPostureClaim(room.scopeClaims),
+      },
+      // The scheduler's OWN plan is the baseline the room layers onto, so the
+      // two can never disagree about where the tick started from.
+      { ...context, inherited: { ...context.inherited, proactivityPlan: input.inheritedPlan } },
+      input.now,
+    );
+    if (!posture) return null;
+
+    // Re-assert tighten-only at this call site. A room may lower cadence freely;
+    // it may only narrow authority. If the resolved boundary is wider than the
+    // inherited one, something upstream is wrong and the safe answer is to keep
+    // the inherited boundary rather than hand a scheduled job more freedom.
+    const boundary = tightenActionBoundary(input.inheritedPlan.actionBoundary, posture.actionBoundary);
+
+    const plan: ProactivityPlan = {
+      ...resolveProactivityPlanForLevel(input.resolverInput, posture.proactivityLevel),
+      actionBoundary: boundary,
+    };
+
+    return { trigger, posture, plan };
+  } catch {
+    return null;
+  }
+}

--- a/docs/superpowers/plans/2026-08-22-work-posture-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-22-work-posture-implementation-plan.md
@@ -61,9 +61,36 @@ the room surface's existing collapsed "Pace and priority" disclosure and REPLACE
 "Why" list that section used to show, so the same reasons appear once, attributed to the
 layer that produced them, and the arrival view gains no words.
 
-Two follow-on wiring gaps were found while verifying H and filed rather than built: a
-scheduled tick still does not resolve posture through the room ladder (`BI-27C8484F`), and
-a coworker's ordinary in-room proactivity still resolves from the old identity ladder
+### Both follow-on wiring gaps are now built
+
+`BI-87C9C91C` landed as `fix/workroom-owned-proactivity` (PR #4949, squashed to main as
+`1317f126e`): the `agent:` preference scope is gone from `scopeKeysForInput`, the three
+per-coworker controls are removed, legacy `aiCoworkerProactivity:agent:*` facts are inert
+rather than migrated, and the interactive turn plus the opening briefing take the platform
+default. Its remaining scope is the interactive-turn room seam, deferred rather than
+guessed because a chat turn has no outcome-specific Workroom in scope.
+
+`BI-27C8484F` landed as `fix/scheduled-tick-room-posture`:
+`lib/scheduling/scheduled-work-posture.server.ts` reads the recorded trigger, resolves the
+room it names through `resolveWorkroomPosture`, and hands the result back to
+`executeScheduledAgentTask`. The scheduler's own resolved plan is passed in as the
+INHERITED baseline, so the room's layers move that plan rather than replacing it with a
+separately-derived one, and `temporalInputForTrigger` finally has a production caller — the
+obligation a tick is racing outranks the room's own due date. Tighten-only is re-asserted at
+the call site: a scheduled job can never acquire more authority by virtue of running in a
+room. A task naming no room keeps today's plan exactly; the room ladder never invents a room.
+
+**Reach, measured rather than claimed (live install, 2026-09-02).** 53 scheduled tasks, 12
+active. 13 carry a recorded trigger and 7 of those name a room — but **all 7 are inactive,
+and none of the 12 active tasks carries a trigger at all**. So the seam is correct and
+production-reachable and changes nothing on this install today. The inertness has moved
+from the code to the data: what is missing is now tasks created with a trigger, not wiring.
+That is a materially different problem from the one this item was filed for, and it is the
+same input-starvation shape as the room shape/posture claims.
+
+The two gaps as originally filed were: a
+scheduled tick did not resolve posture through the room ladder (`BI-27C8484F`), and
+a coworker's ordinary in-room proactivity resolved from the old identity ladder
 (`BI-87C9C91C`). The operator clarified that the latter is not merely a missing room input:
 AI-coworker identity must cease to own proactivity. That slice removes the `agent:` preference
 scope and the coworker-record, chat-dock and roster controls; room participants share the


### PR DESCRIPTION
Closes `BI-27C8484F`. Wires the last of the two follow-on gaps found while verifying EP-WORK-POSTURE's provenance slice.

## The defect

`lib/scheduling/scheduled-work-trigger.ts` recorded why a job exists — its trigger kind, the room it serves, the obligation it races — shipped with tests, and had **zero importers in the execution path**. Meanwhile `executeScheduledAgentTask` resolved proactivity from the identity ladder and never mentioned a room.

An operator could tighten a room's posture, watch a scheduled turn fire inside that room, and see the untightened behaviour with no signal the declaration had been ignored.

## The fix

`lib/scheduling/scheduled-work-posture.server.ts` answers **one question** for the scheduler: what plan should this tick run at. The identity ladder resolves it, then the room's ladder moves it when the job serves a room. Both halves sit behind a single entry point, so the scheduler no longer orchestrates two resolvers and doesn't have to know which wins.

- **No second ladder.** `resolveWorkPosture` remains the only place a posture is judged; this module assembles its inputs.
- **The room moves the plan, it doesn't replace it.** The scheduler's own resolved plan goes in as the *inherited* baseline, so the two can never disagree about where the tick started from.
- **`temporalInputForTrigger` finally has a production caller.** The obligation a tick races outranks the room's own due date — a job firing at 03:00 to discharge a 09:00 filing is pre-deadline work even when the room carries no deadline.
- **Tighten-only re-asserted here**, not trusted from the resolver, because this is a new call site on the unattended hot path. A room may lower cadence freely; it may only narrow authority.
- **Fail-open and roomless-safe.** Every failure returns the identity-ladder plan unchanged, and a task naming no room is byte-for-byte unaffected. The room ladder never invents a room.

## Reach, measured rather than claimed

The item asked for this explicitly rather than an implied broad effect. Live install, 2026-09-02:

| | count |
|---|---|
| scheduled tasks | 53 |
| active | 12 |
| carrying a recorded trigger | 13 |
| naming a room | 7 |
| **active AND naming a room** | **0** |

All 7 room-bound tasks are inactive, and none of the 12 active tasks carries a trigger at all. **This seam is correct and production-reachable and changes nothing on this install today.** The inertness has moved from the code to the data: what is missing now is tasks created with a trigger, not wiring — the same input-starvation shape as the room shape and posture claims.

## Verification

- 2022 tests across scheduling, actions, work-management, work-posture, proactivity.
- Typecheck clean (0 TS errors); production build exits 0; 61 preflight guards clean.
- Local-CI gate **PASS** @ `4e8b7b07735e`, evidence `cmtjf5xbd2sga01nzeal0dmr6`.

A caller-existence test asserts the seam is imported, awaited, and that its result is what the run actually uses — because this item exists precisely because a correct module can ship and do nothing.

**UX verification: not applicable.** No route, rendered surface or operator control changes.

## Guard environment note

The worktree probes SOURCE-ONLY because `package.json` classifies only `@scarf/scarf`, leaving `puppeteer`/`unrs-resolver`/`protobufjs` unclassified. Reproduced identically in the root clone, so it is pre-existing repo state rather than anything in this change — already filed as `BI-4D0FCF3A`. The compile-ready probe was skipped with a recorded reason; all 61 guards still ran on this exact tree.

## Design grounding

- **Specs/plans reviewed:** `2026-08-22-workroom-work-posture-design.md` §3.1 (the single precedence ladder); `2026-08-22-work-posture-implementation-plan.md`, which named this gap and is updated here with what landed and its measured reach.
- **Code substrate reviewed:** `scheduled-work-trigger.ts` (the recorder whose `workroomId`/`obligation` fields already existed for exactly this consumer); `work-posture/verification-depth-gate.ts` (the existing non-UI precedent for server-side room posture — this follows its shape rather than inventing a second assembly); `work-management/room-posture.server.ts` (reused as-is, so the tick and the room surface cannot disagree); `actions/agent-task-scheduler.ts` (the path with zero posture references).
- **Source of truth:** `resolveWorkPosture`. Nothing here judges a posture.
- **Decision:** extend the existing seam. No new table, no second resolver, no new vocabulary. Recording the posture as a *separate* field on the run is deliberately not done — the plan the run already records now reflects the room, and a second column would be a second record of the same decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
