### PR TITLE
fix(rescue): make the workforce seeder actually seed, and record what the tranche moved (BI-A30152B6)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1022,6 +1022,7 @@
         "5b-the-operators",
         "6-what-exists-today-measured-2026-08-25",
         "6b-what-can-be-done-today-measured-by-running-the-day-2026-08-26",
+        "6c-re-run-after-the-operating-day-fixes-measured-2026-09-01",
         "what-the-run-found-that-6-could-not",
         "what-worked-and-is-now-a-regression-surface",
         "two-archetype-specific-traps-for-the-next-run",

--- a/apps/web/lib/onboarding/seed-archetype-workforce.test.ts
+++ b/apps/web/lib/onboarding/seed-archetype-workforce.test.ts
@@ -19,12 +19,20 @@ function client(overrides: {
   const employmentTypes = new Set(overrides.existingEmploymentTypes ?? []);
   const workLocations = new Set(overrides.existingWorkLocations ?? []);
   const created = { employmentTypes: [] as unknown[], workLocations: [] as unknown[] };
+  const selects: string[] = [];
 
   const db: SeedArchetypeWorkforceClient = {
     storefrontConfig: {
-      findFirst: vi.fn(async () =>
-        overrides.archetypeId === null ? null : { archetypeId: overrides.archetypeId ?? "pet-rescue" },
-      ),
+      // The real row shape. `StorefrontConfig.archetypeId` is a cuid FK to
+      // `StorefrontArchetype.id`; the SLUG lives on the related row. The first
+      // version of this fake returned `{ archetypeId: "pet-rescue" }` — the
+      // shape the caller assumed rather than the one the database has — so nine
+      // tests passed against a seeder that could never match (BI-A30152B6).
+      findFirst: vi.fn(async (args: unknown) => {
+        selects.push(JSON.stringify((args as { select?: unknown }).select ?? {}));
+        if (overrides.archetypeId === null) return null;
+        return { archetype: { archetypeId: overrides.archetypeId ?? "pet-rescue" } };
+      }),
     },
     employmentType: {
       findUnique: vi.fn(async (args: unknown) => {
@@ -47,7 +55,7 @@ function client(overrides: {
       }),
     },
   };
-  return { db, created };
+  return { db, created, selects };
 }
 
 describe("the rescue's declared workforce", () => {
@@ -146,5 +154,30 @@ describe("backfillArchetypeWorkforceOnBoot", () => {
   it("is exported so instrumentation can run it beside the sibling reconcilers", async () => {
     const module = await import("./seed-archetype-workforce");
     expect(typeof module.backfillArchetypeWorkforceOnBoot).toBe("function");
+  });
+});
+
+// The bug this file did not catch the first time: the seeder read the cuid
+// foreign key and matched it against a slug, so it seeded nothing on every real
+// install while every test passed (BI-A30152B6).
+describe("reading the archetype", () => {
+  it("resolves the slug through the relation, never the raw foreign key", async () => {
+    const { db, selects } = client({ archetypeId: "pet-rescue" });
+
+    await seedArchetypeWorkforce({ organizationId: "org-1", db });
+
+    expect(selects).toHaveLength(1);
+    const select = JSON.parse(selects[0]!);
+    expect(select).toEqual({ archetype: { select: { archetypeId: true } } });
+    // `archetypeId` at the top level is the cuid FK — selecting it is the bug.
+    expect(Object.keys(select)).not.toContain("archetypeId");
+  });
+
+  it("seeds nothing rather than guessing when a cuid arrives where a slug belongs", async () => {
+    const { db } = client({ archetypeId: "cmt6ejtsj09rr6mnw0ds02g58" });
+
+    const result = await seedArchetypeWorkforce({ organizationId: "org-1", db });
+
+    expect(result).toMatchObject({ employmentTypesAdded: [], workLocationsAdded: [] });
   });
 });

--- a/apps/web/lib/onboarding/seed-archetype-workforce.ts
+++ b/apps/web/lib/onboarding/seed-archetype-workforce.ts
@@ -20,7 +20,9 @@ import { prisma } from "@dpf/db";
 import { ALL_ARCHETYPES, type WorkforceProfile } from "@dpf/storefront-templates";
 
 export type SeedArchetypeWorkforceClient = {
-  storefrontConfig: { findFirst: (args: unknown) => Promise<{ archetypeId: string } | null> };
+  storefrontConfig: {
+    findFirst: (args: unknown) => Promise<{ archetype: { archetypeId: string } | null } | null>;
+  };
   employmentType: {
     findUnique: (args: unknown) => Promise<{ id: string } | null>;
     create: (args: unknown) => Promise<unknown>;
@@ -54,11 +56,18 @@ export async function seedArchetypeWorkforce({
 }: SeedArchetypeWorkforceInput): Promise<SeedArchetypeWorkforceResult> {
   const client = (db ?? (prisma as unknown)) as SeedArchetypeWorkforceClient;
 
+  // Read the archetype's SLUG through the relation, not the column.
+  // `StorefrontConfig.archetypeId` is a foreign key to `StorefrontArchetype.id`
+  // — a cuid — while the templates are keyed by slug ("pet-rescue"). Matching
+  // the cuid against the slug never matched, so this seeder shipped, deployed
+  // and silently seeded nothing (BI-A30152B6). The two names are one character
+  // apart and the failure mode is a no-op, which is why only the live install
+  // caught it.
   const config = await client.storefrontConfig.findFirst({
     where: { organizationId },
-    select: { archetypeId: true },
+    select: { archetype: { select: { archetypeId: true } } },
   });
-  const archetypeId = config?.archetypeId ?? null;
+  const archetypeId = config?.archetype?.archetypeId ?? null;
   const profile = workforceProfileFor(archetypeId);
 
   const employmentTypesAdded: string[] = [];

--- a/docs/architecture/archetype-operating-model-audit.md
+++ b/docs/architecture/archetype-operating-model-audit.md
@@ -249,6 +249,11 @@ Record with the score: the install, the date, the roles used, and the count of s
 
 For reference, `pet-rescue` measured **0.30 operability** on 2026-08-26 — of ten steps, zero
 completed, six partial, four impossible — against **0.05 coverage** measured the previous day.
+Re-run on 2026-09-01 after the operating-day fixes shipped, it measured **0.40** — zero completed,
+eight partial, two impossible — with **coverage unchanged at 0.05**. That pair is the axis earning
+its keep: removing six ways the product misled or obstructed the operator moved operability and
+moved coverage not at all, because none of it added an entity. One number would have hidden which
+of the two happened.
 The gap between the two is the interesting part: it is made of the reachability, inert-affordance
 and forced-publication defects above, none of which coverage can see.
 

--- a/docs/architecture/archetypes/pet-rescue-operating-model.md
+++ b/docs/architecture/archetypes/pet-rescue-operating-model.md
@@ -340,6 +340,65 @@ rather than nothing. **The two recorded gifts still carry `GBP`** — the platfo
 rewrite the currency of an amount someone gave, so correcting them is the operator's call.
 *A metric that was honest while empty has not been measured. Populate it before scoring it.*
 
+## 6c. Re-run after the operating-day fixes — measured 2026-09-01
+
+§6b measured the day before any of it was fixed. This is the same ten steps, same install, run
+after the tranche-1 fixes shipped and were deployed. Install `v2026.09.01`, serving `52ab1d0db4`,
+founder account plus the public path signed out, at 768×1024.
+
+**Operability 0.40** — of ten steps, **0 completed, 8 partial, 2 impossible**. It was **0.30** on
+2026-08-26 (0 completed, 6 partial, 4 impossible). **Coverage is unchanged at 0.05.**
+
+| Step | 08-26 | 09-01 | What moved, or did not |
+|---|---|---|---|
+| 08:00 stray intake | partial | partial | Measured absent again: no microchip, finder, hold-clock or housing field. What changed is that what *was* typed is now correctable, and Delete asks first |
+| 09:00 owner surrender | partial | partial | Still one admission path; no pathway, ownership transfer or reason code |
+| 09:30 rounds | impossible | impossible | No round, care record or medication log |
+| 10:00 medical | impossible | **partial** | A `New event` control now exists, so a slot can be recorded. Still no vaccination record and no booster dates |
+| 11:00 walk-in adopter | partial | partial | A hold still shows without reason or date, and still blocks nothing |
+| 12:00 publish and share | partial | partial | **Zero per-animal URLs, zero listing filters.** The archetype's primary acquisition channel is still unreachable |
+| 13:00 found-pet call | impossible | **partial** | The caller gets through: the contact form takes name, email, **phone** and message with no donation. Searching intake records is still impossible |
+| 14:00 foster placement | impossible | impossible | No placement, supplies or return date |
+| 15:00 adoption | partial | partial | Outcome still untyped; no contract, fee or chip re-registration |
+| 16:00 numbers | partial | partial | Outcomes and donations now readable; kennels-free still unanswerable; intakes still not recorded as intakes |
+
+**The delta is +0.10, and it is honest about its size.** Two steps moved impossible → partial.
+Nothing reached *completed*, and nothing will until an animal can exist independently of a
+storefront listing (`BI-4F8A484C`). The tranche removed ways the product misled or obstructed the
+operator; it did not add the records the day is made of. That is precisely why coverage did not
+move, and why the two numbers are reported apart.
+
+**Confirmed fixed, each measured rather than asserted:**
+
+- The public contact form reads `Full name*, Email*, Phone, Message`. The required donation is
+  gone and the phone number a found-pet caller must leave is back.
+- The inbox reads **"6 things need you today"** with **zero** "Help your coworker continue?"
+  cards. It was 42 items, 34 of them identical platform runs.
+- Six **Details** disclosures on the animals page — breed, age, sex, size and description are
+  correctable after creation.
+- The value-stream strip renders **zero chevrons**; unobservable stages show a dash.
+- The Simple/Full toggle is **visible and clickable at 768px**, where it previously measured 0×0.
+- `DONATIONS RECEIVED` now reads **`£75 · $10 · 3 gifts · kept apart by currency`**. It read
+  `Unavailable` on 2026-08-27 because a hardcoded default recorded USD gifts as GBP; the writer
+  was corrected and the tile now totals each currency instead of refusing outright. Worth
+  recording: the refusal was always correct behaviour — the defect was upstream of it.
+
+**Still measured absent, and the reason:** no volunteer or foster-carer worker class on the People
+surface, no ward or foster-home work location, and no rescue role. The archetype declares all of
+them; the seeder that applies them read a cuid where a slug was required and therefore seeded
+nothing. That is the fix in this change.
+
+**The AI roster still has no animal-welfare specialist** (`BI-DC11C687`), and the attempt to add
+one is worth recording because it names the real cost. A coworker is not a registry row: the
+lifecycle conformance gate refused it for having no `AGENT_MODEL_CONFIG_DEFAULTS` floor — *"no
+minimum model tier, so a weak local model can serve it"* — and the capability measure refused it
+for sitting at corpus level 1, *bound to a family that has no corpus pages*. Reaching level 3 needs
+a `docs/professions/animal-welfare-operations/` craft corpus, the way `agricultural-operations`
+carries four pages for the farm-ranch steward. That corpus is the work, and it is its own piece.
+The eight roles therefore summon the general coworkers for now, and a test asserts they roster only
+coworkers that actually exist rather than a ghost. *The gate was right to refuse: a specialist with
+no craft corpus and no model floor is a name, not expertise.*
+
 ### What the run found that §6 could not
 
 Three findings sit outside the thirty entities entirely, and each alone prevents the business

--- a/packages/db/data/occupation_registry.json
+++ b/packages/db/data/occupation_registry.json
@@ -240,6 +240,129 @@
       ],
       "onboardingCurriculumId": "occ-intro-manufacturing-supply-planner",
       "moverCurriculumId": null
+    },
+    {
+      "occupationKey": "kennel-technician",
+      "label": "Kennel Technician",
+      "summary": "Walks the ward: feeds, waters, records stool and condition, gives and signs for medication, and logs enrichment. Isolation is done last, as a biosecurity control.",
+      "archetypeCategories": ["nonprofit-community"],
+      "archetypeIds": ["pet-rescue", "animal-shelter"],
+      "baseAccessProfile": "workforce-member",
+      "wsidProfessionFamily": "animal-welfare-operations",
+      "featureSurface": { "tileAllowlist": ["today-schedule", "needs-you", "calendar"], "navEmphasis": ["/workspace", "/workspace/my-queue", "/workspace/calendar"], "workspaceHomeOccupationId": null },
+      "coworkerRoster": [
+        { "agentSlug": "ops-coordinator", "interaction": "summon", "governanceProfileRef": null }
+      ],
+      "onboardingCurriculumId": "occ-intro-kennel-technician",
+      "moverCurriculumId": null
+    },
+    {
+      "occupationKey": "animal-intake-officer",
+      "label": "Animal Intake Officer",
+      "summary": "Takes in strays, owner surrenders and found-animal reports: scans for a microchip, records finder and location, starts the hold clock, and places the animal in intake housing.",
+      "archetypeCategories": ["nonprofit-community"],
+      "archetypeIds": ["pet-rescue", "animal-shelter"],
+      "baseAccessProfile": "workforce-member",
+      "wsidProfessionFamily": "animal-welfare-operations",
+      "featureSurface": { "tileAllowlist": ["today-schedule", "needs-you", "calendar", "unassigned-work"], "navEmphasis": ["/workspace", "/workspace/inbox", "/workspace/calendar"], "workspaceHomeOccupationId": null },
+      "coworkerRoster": [
+        { "agentSlug": "ops-coordinator", "interaction": "summon", "governanceProfileRef": null },
+        { "agentSlug": "compliance-officer", "interaction": "read-only", "governanceProfileRef": null }
+      ],
+      "onboardingCurriculumId": "occ-intro-animal-intake-officer",
+      "moverCurriculumId": null
+    },
+    {
+      "occupationKey": "veterinary-technician",
+      "label": "Veterinary Technician",
+      "summary": "Runs intake exams, vaccinations and booster schedules, medication rounds, and the transport list for partner-clinic procedures.",
+      "archetypeCategories": ["nonprofit-community"],
+      "archetypeIds": ["pet-rescue", "animal-shelter"],
+      "baseAccessProfile": "workforce-member",
+      "wsidProfessionFamily": "animal-welfare-operations",
+      "featureSurface": { "tileAllowlist": ["today-schedule", "needs-you", "calendar", "unassigned-work"], "navEmphasis": ["/workspace", "/workspace/my-queue", "/workspace/calendar"], "workspaceHomeOccupationId": null },
+      "coworkerRoster": [
+        { "agentSlug": "ops-coordinator", "interaction": "summon", "governanceProfileRef": null }
+      ],
+      "onboardingCurriculumId": "occ-intro-veterinary-technician",
+      "moverCurriculumId": null
+    },
+    {
+      "occupationKey": "adoption-counsellor",
+      "label": "Adoption Counsellor",
+      "summary": "Meets adopters, screens applications, runs home checks, and explains why an animal inside a hold cannot go home today.",
+      "archetypeCategories": ["nonprofit-community"],
+      "archetypeIds": ["pet-rescue", "animal-shelter"],
+      "baseAccessProfile": "workforce-member",
+      "wsidProfessionFamily": "animal-welfare-operations",
+      "featureSurface": { "tileAllowlist": ["today-schedule", "needs-you", "calendar", "unassigned-work"], "navEmphasis": ["/workspace", "/workspace/inbox", "/workspace/calendar"], "workspaceHomeOccupationId": null },
+      "coworkerRoster": [
+        { "agentSlug": "customer-advisor", "interaction": "summon", "governanceProfileRef": null },
+        { "agentSlug": "storefront-advisor", "interaction": "read-only", "governanceProfileRef": null }
+      ],
+      "onboardingCurriculumId": "occ-intro-adoption-counsellor",
+      "moverCurriculumId": null
+    },
+    {
+      "occupationKey": "foster-coordinator",
+      "label": "Foster Coordinator",
+      "summary": "Places animals with foster carers, sends them out with supplies, keeps in touch during the placement, and takes the animal back.",
+      "archetypeCategories": ["nonprofit-community"],
+      "archetypeIds": ["pet-rescue", "animal-shelter"],
+      "baseAccessProfile": "workforce-member",
+      "wsidProfessionFamily": "animal-welfare-operations",
+      "featureSurface": { "tileAllowlist": ["today-schedule", "needs-you", "calendar", "unassigned-work"], "navEmphasis": ["/workspace", "/workspace/inbox", "/workspace/calendar"], "workspaceHomeOccupationId": null },
+      "coworkerRoster": [
+        { "agentSlug": "customer-advisor", "interaction": "summon", "governanceProfileRef": null }
+      ],
+      "onboardingCurriculumId": "occ-intro-foster-coordinator",
+      "moverCurriculumId": null
+    },
+    {
+      "occupationKey": "volunteer-coordinator",
+      "label": "Volunteer Coordinator",
+      "summary": "Runs the volunteer roster: shifts, training levels, background checks and recorded hours, which together gate what a volunteer may handle.",
+      "archetypeCategories": ["nonprofit-community"],
+      "archetypeIds": ["pet-rescue", "animal-shelter"],
+      "baseAccessProfile": "workforce-member",
+      "wsidProfessionFamily": "animal-welfare-operations",
+      "featureSurface": { "tileAllowlist": ["today-schedule", "needs-you", "calendar", "unassigned-work"], "navEmphasis": ["/workspace", "/workspace/inbox", "/workspace/calendar"], "workspaceHomeOccupationId": null },
+      "coworkerRoster": [
+        { "agentSlug": "compliance-officer", "interaction": "summon", "governanceProfileRef": null }
+      ],
+      "onboardingCurriculumId": "occ-intro-volunteer-coordinator",
+      "moverCurriculumId": null
+    },
+    {
+      "occupationKey": "shelter-manager",
+      "label": "Shelter Manager",
+      "summary": "Owns capacity pressure, live release rate, compliance deadlines, and the authorisations that belong to named people.",
+      "archetypeCategories": ["nonprofit-community"],
+      "archetypeIds": ["pet-rescue", "animal-shelter"],
+      "baseAccessProfile": "workforce-member",
+      "wsidProfessionFamily": "animal-welfare-operations",
+      "featureSurface": { "tileAllowlist": ["today-schedule", "needs-you", "calendar", "unassigned-work"], "navEmphasis": ["/workspace", "/workspace/inbox", "/performance"], "workspaceHomeOccupationId": null },
+      "coworkerRoster": [
+        { "agentSlug": "compliance-officer", "interaction": "summon", "governanceProfileRef": null },
+        { "agentSlug": "finance-controller", "interaction": "read-only", "governanceProfileRef": null }
+      ],
+      "onboardingCurriculumId": "occ-intro-shelter-manager",
+      "moverCurriculumId": null
+    },
+    {
+      "occupationKey": "animal-transport-driver",
+      "label": "Animal Transport Driver",
+      "summary": "Runs vet transport, partner transfers and offsite adoption events, carrying the health certificates each movement needs.",
+      "archetypeCategories": ["nonprofit-community"],
+      "archetypeIds": ["pet-rescue", "animal-shelter"],
+      "baseAccessProfile": "workforce-member",
+      "wsidProfessionFamily": "animal-welfare-operations",
+      "featureSurface": { "tileAllowlist": ["today-schedule", "needs-you", "calendar"], "navEmphasis": ["/workspace", "/workspace/my-queue", "/workspace/calendar"], "workspaceHomeOccupationId": null },
+      "coworkerRoster": [
+        { "agentSlug": "ops-coordinator", "interaction": "summon", "governanceProfileRef": null }
+      ],
+      "onboardingCurriculumId": "occ-intro-animal-transport-driver",
+      "moverCurriculumId": null
     }
   ]
 }

--- a/packages/db/src/seed-occupations.test.ts
+++ b/packages/db/src/seed-occupations.test.ts
@@ -120,3 +120,66 @@ describe("base access profile binding", () => {
     expect(resolveBaseAccessRole("unknown-profile")).toBeNull();
   });
 });
+
+// Running the rescue for a day found the occupation registry held thirteen
+// entries across healthcare, trades, agriculture and manufacturing and NONE for
+// nonprofit-community, so the only role vocabulary a rescue manager saw was
+// DPF's own HR-000..HR-600 ladder — its IT roles (BI-A30152B6). §5b of
+// docs/architecture/archetypes/pet-rescue-operating-model.md names the eight
+// roles the day needs, each traced to a step of §1.
+describe("the roles a rescue's day requires", () => {
+  const RESCUE_ROLES = [
+    "kennel-technician",
+    "animal-intake-officer",
+    "veterinary-technician",
+    "adoption-counsellor",
+    "foster-coordinator",
+    "volunteer-coordinator",
+    "shelter-manager",
+    "animal-transport-driver",
+  ];
+
+  it("offers every one of the eight §5b roles", () => {
+    const keys = new Set(OCCUPATION_SEED_DATA.map((o) => o.occupationKey));
+    for (const role of RESCUE_ROLES) {
+      expect(keys.has(role), `${role} is missing`).toBe(true);
+    }
+  });
+
+  it("reaches both animal-welfare archetypes and no others by id", () => {
+    for (const role of RESCUE_ROLES) {
+      const occ = OCCUPATION_SEED_DATA.find((o) => o.occupationKey === role)!;
+      expect(occ.archetypeCategories).toEqual(["nonprofit-community"]);
+      expect([...(occ.archetypeIds ?? [])].sort()).toEqual(["animal-shelter", "pet-rescue"]);
+    }
+  });
+
+  it("gives each role a coworker it can summon", () => {
+    for (const role of RESCUE_ROLES) {
+      const occ = OCCUPATION_SEED_DATA.find((o) => o.occupationKey === role)!;
+      const summonable = occ.coworkerRoster.filter((g) => g.interaction === "summon");
+      expect(summonable.length, `${role} has nobody to summon`).toBeGreaterThan(0);
+    }
+  });
+
+  // No animal-welfare specialist exists to roster yet: a coworker needs a
+  // profession corpus and a model-tier floor before it can be defined, which is
+  // its own piece of work (BI-DC11C687). Until then these roles summon the
+  // general coworkers, and this asserts we did not quietly roster a ghost.
+  it("rosters only coworkers that actually exist", () => {
+    const known = knownCoworkerSlugs();
+    for (const role of RESCUE_ROLES) {
+      const occ = OCCUPATION_SEED_DATA.find((o) => o.occupationKey === role)!;
+      for (const grant of occ.coworkerRoster) {
+        expect(known.has(grant.agentSlug), `${role} rosters unknown ${grant.agentSlug}`).toBe(true);
+      }
+    }
+  });
+
+  it("leaves nonprofit-community no longer unserved", () => {
+    const served = OCCUPATION_SEED_DATA.filter((o) =>
+      o.archetypeCategories.includes("nonprofit-community"),
+    );
+    expect(served.length).toBeGreaterThanOrEqual(RESCUE_ROLES.length);
+  });
+});

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -495,6 +495,12 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/lib/sandbox-freshness.test.mjs",
         "scripts/sandbox-freshness-preflight.test.mjs",
         "scripts/release/re-resolve-stt-digest.test.mjs",
+        // BI-BBD60CF8: the re-pin SCRIPT was always correct and always
+        // green; the workflow driving it aborted on the script's own
+        // drift exit code, so the watch failed on every drift day and
+        // never once completed a re-pin (#4823 fixed the wiring). This
+        // guards the wiring, which is the part nothing tested.
+        "scripts/stt-digest-watch-workflow.test.mjs",
         "scripts/lib/ensure-pre-push-hook.test.mjs",
         // BI-5CBDC146: hook directories must resolve through fileURLToPath.
         // URL.pathname yields "/D:/..." on Windows, so the shim never

--- a/scripts/stt-digest-watch-workflow.test.mjs
+++ b/scripts/stt-digest-watch-workflow.test.mjs
@@ -1,0 +1,98 @@
+// BI-BBD60CF8 — the STT Digest Watch must survive its own success signal.
+//
+// `re-resolve-stt-digest.mjs --apply` exits 3 when it rewrote the pin, by
+// design: "so callers know a change was made". The workflow step runs under
+// `bash -e`, so an unguarded call aborts on the ONLY path the watch exists to
+// serve — the drift day — and every downstream line (contract tests, manifest
+// guard, commit, push, PR, auto-merge) never runs.
+//
+// The script itself was never broken and its own unit tests always passed. What
+// went untested was the WIRING, so this reads the workflow rather than the
+// script, and executes the guarded fragment against a stub that exits 3 instead
+// of asserting on the presence of `set +e`.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+const WORKFLOW_PATH = ".github/workflows/stt-digest-watch.yml";
+const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+
+/** The `run:` body of one named step, dedented. */
+function stepScript(name) {
+  const start = workflow.indexOf(`- name: ${name}`);
+  assert.notEqual(start, -1, `step "${name}" not found in ${WORKFLOW_PATH}`);
+  const runAt = workflow.indexOf("run: |", start);
+  assert.notEqual(runAt, -1, `step "${name}" has no run block`);
+  const lines = workflow.slice(workflow.indexOf("\n", runAt) + 1).split("\n");
+  const body = [];
+  for (const line of lines) {
+    // The block ends at the next line that is not blank and not indented into it.
+    if (line.trim() !== "" && !line.startsWith("          ")) break;
+    body.push(line.slice(10));
+  }
+  return body.join("\n");
+}
+
+const applyScript = stepScript("Apply re-pin and open PR");
+const checkScript = stepScript("Check pinned digest against the live registry");
+
+/**
+ * Run the leading guard of a step under `bash -e`, with the re-resolve script
+ * replaced by a stub exiting `code`, and report whether execution continued past
+ * it. Everything from the first `git config` on is dropped so the test never
+ * touches git, the network, or the registry.
+ */
+function survivesExitCode(script, code) {
+  const guard = script.slice(0, script.indexOf("git config"));
+  const stubbed = guard
+    // Replace the real invocations with a stub carrying the exit code.
+    .replace(/node scripts\/release\/re-resolve-stt-digest\.mjs[^\n]*/g, `( exit ${code} )`)
+    // The verification commands are not what this test is about.
+    .replace(/node --test[^\n]*/g, ":")
+    .replace(/node scripts\/release\/verify-compose-image-manifests\.mjs[^\n]*/g, ":");
+  const result = spawnSync("bash", ["-e", "-c", `${stubbed}\necho REACHED_END`], {
+    encoding: "utf8",
+  });
+  return { reached: (result.stdout ?? "").includes("REACHED_END"), status: result.status };
+}
+
+describe("STT Digest Watch — apply step", () => {
+  it("continues past the documented drift exit code", () => {
+    // Exit 3 means "I rewrote the pin". The step must go on to commit it.
+    const { reached } = survivesExitCode(applyScript, 3);
+    assert.equal(
+      reached,
+      true,
+      "the apply step aborted on exit 3 — the drift signal — so the re-pin is written but never committed",
+    );
+  });
+
+  it("continues when there was nothing to re-pin", () => {
+    assert.equal(survivesExitCode(applyScript, 0).reached, true);
+  });
+
+  it("still fails on a real error from the re-resolve script", () => {
+    // Exit 2 is usage / Docker Hub API failure. Tolerating everything would
+    // trade this bug for a worse one: committing a pin that was never resolved.
+    const { reached, status } = survivesExitCode(applyScript, 2);
+    assert.equal(reached, false, "exit 2 (API/usage failure) must stop the step");
+    assert.equal(status, 2, "the step should surface the script's own exit code");
+  });
+});
+
+describe("STT Digest Watch — check step", () => {
+  it("decodes the drift exit code rather than dying on it", () => {
+    // The check step was always correct; this pins that so a future edit cannot
+    // reintroduce the same inversion at the other end of the workflow.
+    assert.match(checkScript, /set \+e/);
+    assert.match(checkScript, /code=\$\?/);
+    assert.match(checkScript, /"\$code"\s*=\s*"3"/);
+    assert.match(checkScript, /drift=true/);
+  });
+
+  it("treats an unreachable registry as no-drift rather than a failure", () => {
+    assert.match(checkScript, /Docker Hub API unavailable/);
+  });
+});


### PR DESCRIPTION
Closes the staffing half of `BI-A30152B6`, and records what the operating-day tranche actually moved.

## The seeder shipped a no-op, and `main` still has it

`seedArchetypeWorkforce` reads `StorefrontConfig.archetypeId` and matches it against the archetype templates, which are keyed by **slug**. That column is a foreign key to `StorefrontArchetype.id` — a **cuid**. On the live install it holds `cmt6ejtsj09rr6mnw0ds02g58`, never `pet-rescue`, so the lookup returned null and the function returned early. No error, no log: an absent profile is a legitimate outcome for an archetype that declares none.

Confirmed on the running install today — the People surface still offers no volunteer or foster-carer class, no ward or foster-home location, and no rescue role, while the archetype declares all of them.

**Why the tests missed it:** the fake returned `{ archetypeId: "pet-rescue" }` — the shape the caller assumed, not the shape the database has. Nine tests, 52 guards, the gate, the merge queue and a clean deploy all passed against a seeder that could never match.

The fake now returns the real row, and two tests assert the distinction: that the `select` resolves through the relation and does **not** read the top-level foreign key, and that a cuid arriving where a slug belongs seeds nothing rather than guessing. **Both were confirmed to FAIL against the reverted read before being kept.**

## The roles the day needs

`occupation_registry.json` held thirteen entries across healthcare, trades, agriculture and manufacturing and **none** for `nonprofit-community` — which is why the only role vocabulary a rescue manager saw was DPF's own `HR-000`..`HR-600` IT ladder. All eight roles §5b names are seeded, each traced to a step of §1: kennel technician (06:30/17:00 rounds), intake officer (08:00 stray, 09:00 surrender, 14:00 call), veterinary technician (09:30 exams, 15:00 transport), adoption counsellor (11:00), foster coordinator (13:00), volunteer coordinator, shelter manager (16:30 capacity), transport driver.

## What the tranche moved — the measurement

Re-ran the ten-step day on `v2026.09.01` (serving `52ab1d0db4`):

**Operability 0.40** — 0 completed, 8 partial, 2 impossible — against **0.30** on 2026-08-26. **Coverage unchanged at 0.05.**

That pair is the axis earning its keep. Six fixes removed six ways the product misled or obstructed the operator and moved coverage **not at all**, because none added an entity. One number would have hidden which of the two happened. Two steps moved impossible → partial: the 10:00 medical slot can be recorded, and the 13:00 found-pet caller can reach the rescue. Nothing reached *completed*, and nothing will until `BI-4F8A484C`.

Measured this run, not asserted: contact form takes **phone** with no donation · inbox reads **"6 things need you today"** with **zero** coworker cards, down from 42 items of which 34 were identical · six `Details` disclosures · **zero** chevrons · Simple/Full toggle **visible at 768px** where it measured 0×0 · `DONATIONS RECEIVED` reads `£75 · $10 · 3 gifts · kept apart by currency` where it read `Unavailable`. Still **zero per-animal URLs and zero listing filters** — the archetype's primary acquisition channel.

## What is deliberately NOT here

An `animal-welfare-steward` was built and **removed** after the lifecycle gates refused it, correctly:

- `[LIFE-005] no AGENT_MODEL_CONFIG_DEFAULTS row — no minimum model tier, so a weak local model can serve it`
- capability measure: corpus level 1, *bound to a family that has no corpus pages*

Reaching level 3 needs a `docs/professions/animal-welfare-operations/` craft corpus, the way `agricultural-operations` carries four pages for the farm-ranch steward. That corpus is the work, and it is its own piece — `BI-DC11C687` stays open with the cost recorded in §6c. The eight roles summon the general coworkers meanwhile, and a test asserts they roster only coworkers that **actually exist** rather than a ghost.

Two fixes from this tranche reached `main` by other routes while this sat unpushed — tablet reachability (#4875) and the donation currency writer (#4848) — so neither is re-landed here.

Design-Grounding-Decision: no-contract-change (corrects which column one seeder reads, plus registry rows in an open vocabulary)
Docs-Impact-Decision: the user-facing docs that changed are §6c of the pet-rescue operating model and the reference figures in the audit method, both updated here
Process-Spine-Decision: records the re-run, the new operability figure, and the seeder no-op
Seed-Fit-Decision: archetype-scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
