### PR TITLE
fix(reviewer-route): a capacity deferral is not a writer failure

### DIFF
--- a/apps/web/lib/mcp-task-execution.test.ts
+++ b/apps/web/lib/mcp-task-execution.test.ts
@@ -119,3 +119,108 @@ describe("remote task terminal-writer postcondition", () => {
     });
   });
 });
+
+// BI-8B8731EE. A governed reviewer route that never reached a model is NOT a
+// writer-contract failure. The platform already knows how to report that —
+// `preInferenceResourceWait` projects a resumable `provider-capacity` wait — but
+// the terminal-writer branch ran first and `terminalWriterMissing` is true for
+// ANY governed route that executed no tools, which is exactly what a capacity
+// deferral looks like. So every deferral on a reviewer route was reported as a
+// missing receipt writer.
+//
+// Measured on the live install 2026-09-01: the terminal write landed on ~34% of
+// external-MCP reviewer dispatches (35 completed / 49 input-required / 18
+// failed). The portal log named the real cause on every stranded one:
+// "routeAndCall threw: Local provider dispatch deferred:
+// local-ci-queued-capacity-reservation" — governed local CI holding the host,
+// which clears on its own in about 195s.
+describe("a resource wait is not a missing terminal writer (BI-8B8731EE)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.findModelConfig.mockResolvedValue(null);
+    db.findTaskRun.mockResolvedValue({ status: "working" });
+    db.updateTaskRun.mockResolvedValue({});
+    autonomous.resolveAgent.mockResolvedValue({
+      agentId: "AGT-WS-PORTFOLIO",
+      displayName: "Portfolio Advisor",
+      systemPrompt: "Review independently.",
+      sensitivity: "internal",
+    });
+    autonomous.resolveTools.mockResolvedValue({ tools: [], toolsForProvider: [], deferredTools: [] });
+  });
+
+  const attempt = () => executeRemoteTaskAttempt({
+    run: { id: "run-internal", taskRunId: "TR-MCP-CAPACITY-DEFERRAL", contextId: "thread-1" },
+    threadId: "thread-1",
+    token: { tokenId: "PAT-WRITER-CAPACITY", userId: "user-1", capability: "write", source: "pat" },
+    userContext: { platformRole: "developer", isSuperuser: false },
+    parsed,
+    idempotentReplay: false,
+    capacityAttempt: 1,
+  });
+
+  it.each(["capacity", "busy"] as const)(
+    "reports a %s deferral as a resumable provider-capacity wait, not a missing writer",
+    async (failureKind) => {
+      autonomous.execute.mockResolvedValue({
+        content: "Local inference capacity is held by governed local CI.",
+        executedTools: [],
+        failure: { kind: failureKind, message: "Local inference capacity is held by governed local CI." },
+      });
+
+      const outcome = await attempt();
+
+      expect(outcome).toMatchObject({
+        kind: "result",
+        result: {
+          status: "submitted",
+          resumable: true,
+          waitReason: "provider-capacity",
+          executedToolCount: 0,
+        },
+      });
+      // The old behaviour: the caller was told the writer could not be
+      // dispatched, and went auditing grants and tool surfaces instead of
+      // waiting out a reservation.
+      expect(outcome).not.toMatchObject({ result: { waitReason: "missing-terminal-writer" } });
+
+      const payload = db.updateTaskRun.mock.calls.at(-1)?.[0]?.data?.progressPayload;
+      expect(payload).toEqual(expect.objectContaining({
+        resourceWait: expect.objectContaining({ kind: "provider-capacity", failureKind }),
+      }));
+      expect(payload).not.toHaveProperty("terminalWriterWait");
+    },
+  );
+
+  it("still parks a genuine writer no-show, where the model ran and did not write", async () => {
+    // The optimisation this fix must not undo: a reviewer that reached a model,
+    // read the artifact and then answered in prose is a real writer-contract
+    // failure and must stay `missing-terminal-writer`.
+    autonomous.execute.mockResolvedValue({
+      content: "In my assessment the design is sound.",
+      executedTools: [{ name: "read_source_at_version", result: { success: true } }],
+    });
+
+    const outcome = await attempt();
+
+    expect(outcome).toMatchObject({
+      kind: "result",
+      result: { status: "input-required", resumable: true, waitReason: "missing-terminal-writer" },
+    });
+  });
+
+  it("does not divert a capacity failure that arrived AFTER real tool work", async () => {
+    // preInferenceResourceWait is deliberately pre-inference: once the reviewer
+    // has executed tools, a late capacity error is not a clean "nothing
+    // happened yet" wait and must not masquerade as one.
+    autonomous.execute.mockResolvedValue({
+      content: "Capacity was lost partway through.",
+      executedTools: [{ name: "read_source_at_version", result: { success: true } }],
+      failure: { kind: "capacity", message: "Capacity was lost partway through." },
+    });
+
+    const outcome = await attempt();
+
+    expect(outcome).toMatchObject({ result: { waitReason: "missing-terminal-writer" } });
+  });
+});

--- a/apps/web/lib/mcp-task-execution.ts
+++ b/apps/web/lib/mcp-task-execution.ts
@@ -179,7 +179,18 @@ export async function executeRemoteTaskAttempt(input: {
         || result.proposal?.name === terminalToolPolicy.writerToolName
       : false;
     const terminalWriterMissing = terminalToolPolicy !== null && !terminalWriterWasAttempted;
-    if ((result.failure?.kind === "terminal-writer-missing" || terminalWriterMissing) && terminalToolPolicy) {
+    // BI-8B8731EE: a resource wait is NOT a writer-contract failure, and this
+    // branch would otherwise swallow it. `terminalWriterMissing` is true for any
+    // governed route that executed no tools, which is exactly what a capacity
+    // deferral looks like — so on a reviewer route the resource wait below was
+    // unreachable and every deferral was reported as a missing receipt writer.
+    // Let the resource wait win; it resumes on the same TaskRun either way.
+    const resourceWaitOwnsThisTurn = preInferenceResourceWait(result) !== null;
+    if (
+      !resourceWaitOwnsThisTurn
+      && (result.failure?.kind === "terminal-writer-missing" || terminalWriterMissing)
+      && terminalToolPolicy
+    ) {
       const terminalWriterAttempt = input.terminalWriterAttempt ?? 1;
       const terminalWriterFailureMessage = result.failure?.kind === "terminal-writer-missing"
         ? result.failure.message

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -637,6 +637,56 @@ describe("runAgenticLoop", () => {
     threadId: "thread-1",
   };
 
+  // BI-8B8731EE. On a governed reviewer route the loop used to rewrite EVERY
+  // routeAndCall throw as `terminal-writer-missing`, discarding the
+  // classification it had just computed. A local-CI capacity reservation —
+  // which clears itself in ~195s — was therefore reported as the writer failing
+  // its contract, and `preInferenceResourceWait` downstream could never see the
+  // `capacity` kind it keys on.
+  it.each([
+    ["Local provider dispatch deferred: local-ci-queued-capacity-reservation", "capacity"],
+    ["Provider is overloaded, status: 529", "busy"],
+  ])("keeps a resource deferral classified (%s) instead of blaming the writer", async (message, expectedKind) => {
+    const mockRoute = vi.mocked(routeAndCall);
+    const deferral = new Error(message);
+    deferral.name = expectedKind === "capacity" ? "LocalProviderCapacityDeferredError" : "Error";
+    mockRoute.mockRejectedValue(deferral);
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      terminalToolPolicy: {
+        writerToolName: "record_initiative_evidence",
+        readerToolNames: ["read_source_at_version"],
+        minimumSuccessfulReaderCalls: 1,
+        maximumReaderCalls: 3,
+      },
+    });
+
+    expect(result.failure?.kind).toBe(expectedKind);
+    expect(result.failure?.kind).not.toBe("terminal-writer-missing");
+    expect(result.content).not.toContain("could not be dispatched");
+  });
+
+  it("still blames the writer when the route fails for a reason it cannot classify", async () => {
+    // The unclassified path is unchanged: without a known cause there is nothing
+    // truer to say than that the receipt was not recorded.
+    const mockRoute = vi.mocked(routeAndCall);
+    mockRoute.mockRejectedValue(new Error("something entirely unexpected"));
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      terminalToolPolicy: {
+        writerToolName: "record_initiative_evidence",
+        readerToolNames: ["read_source_at_version"],
+        minimumSuccessfulReaderCalls: 1,
+        maximumReaderCalls: 3,
+      },
+    });
+
+    expect(result.failure?.kind).toBe("terminal-writer-missing");
+    expect(result.content).toContain("record_initiative_evidence");
+  });
+
   it("points to the real provider surface when no tool-capable endpoint is active", async () => {
     const mockRoute = vi.mocked(routeAndCall);
     mockRoute.mockRejectedValueOnce(new Error(

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -1702,6 +1702,28 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
       console.warn(`[agentic-loop] routeAndCall threw: ${msg}`);
       logTurnSummary("unknown", "unknown");
       if (params.terminalToolPolicy) {
+        // BI-8B8731EE. A THROW from routeAndCall means the model never ran, so
+        // this is not the reviewer declining its writer contract.
+        //
+        // `failure` above already classifies why. When that classification is a
+        // RESOURCE wait — the host is busy, or governed local CI holds the
+        // inference capacity — say so, because the platform already knows what
+        // to do with it: `preInferenceResourceWait` projects a `provider-capacity`
+        // wait that resumes on the same TaskRun. Rewriting it to
+        // `terminal-writer-missing` made that handling unreachable for every
+        // governed reviewer route and reported a reservation that clears itself
+        // in ~195s as a failure of the writer contract.
+        //
+        // Measured cost of the substitution: five dispatches spent auditing
+        // grants, autonomy tiers and tool surfaces that were correct throughout.
+        // Only PRE-INFERENCE, mirroring `preInferenceResourceWait`'s own
+        // contract. Once a reader has run, the turn is no longer "nothing
+        // happened yet": the resumable writer wait below is the better state,
+        // because the read work is banked and only the receipt is outstanding.
+        // Diverting that to a resource wait would fail the run instead.
+        if ((failure.kind === "capacity" || failure.kind === "busy") && executedTools.length === 0) {
+          return completeResult(failure.message, null, { failure });
+        }
         const message = routeOptions.toolChoice === "required"
           ? `The required governed writer ${params.terminalToolPolicy.writerToolName} could not be dispatched. The same TaskRun remains resumable. No receipt was created.`
           : `The governed review route failed before ${params.terminalToolPolicy.writerToolName} could be recorded. The same TaskRun remains resumable. No receipt was created.`;

--- a/docs/superpowers/specs/2026-09-02-capacity-deferral-is-not-a-writer-failure-design.md
+++ b/docs/superpowers/specs/2026-09-02-capacity-deferral-is-not-a-writer-failure-design.md
@@ -1,0 +1,132 @@
+---
+status: active
+title: A capacity deferral is not a writer failure — letting the governed reviewer route report why it stopped
+---
+
+# A Capacity Deferral Is Not a Writer Failure
+
+- **Date:** 2026-09-02
+- **Scope:** platform — agentic loop route-failure classification, remote task execution wait projection
+- **Backlog item:** `BI-8B8731EE`
+- **Status:** Design — implemented in this branch.
+
+> The governed reviewer route computed the true reason it stopped, then overwrote it
+> with a false one. Everything downstream acted on the false one.
+
+---
+
+## 1. What is true today
+
+Verified against `origin/main` at `0acfd06c58` and against the live install, not inferred.
+
+| # | Finding | Evidence |
+| --- | --- | --- |
+| 1 | **The loop already classifies route failures correctly.** `describeToolRouteFailureOutcome` returns `kind: "capacity"` for a local-host deferral, with copy that names the window. | `inference-dead-ends.ts`, `isLocalCapacityDeferral` |
+| 2 | **The reviewer path discarded that classification.** On any `routeAndCall` throw with a `terminalToolPolicy` set, the catch computed `failure` and then returned a hardcoded `{ kind: "terminal-writer-missing" }` instead. | `agentic-loop.ts`, `catch (routeErr)` |
+| 3 | **The platform already has the right state and it was unreachable.** `preInferenceResourceWait` projects a resumable `provider-capacity` wait — but it keys on `failure.kind === "capacity" \| "busy"`, which finding 2 had just erased. | `mcp-task-capacity-contract.ts` |
+| 4 | **A second guard closed the same door.** Even with the kind preserved, the terminal-writer branch runs first and its `terminalWriterMissing` condition is true for *any* governed route that executed no tools — exactly what a deferral looks like. | `mcp-task-execution.ts` |
+| 5 | **Measured cost.** Terminal writes landed on ~34% of external-MCP reviewer dispatches: 35 completed, 49 `input-required`, 18 failed over 5 days. | live `TaskRun` query, 2026-09-01 |
+| 6 | **The real cause was in the log the whole time.** Every stranded run: `routeAndCall threw: Local provider dispatch deferred: local-ci-queued-capacity-reservation`. | `dpf-portal-1` logs |
+| 7 | **That condition clears itself.** The routing layer attaches `expectedFreeAt`; a real gate holds the host ~195s on average. | `local-provider-capacity.ts` |
+
+### 1.1 What the substitution cost
+
+`missing-terminal-writer` describes an *outcome* — no receipt yet — and says nothing true about the
+cause. Callers act on the cause. Reading it as a writer-contract failure sends you auditing grants,
+autonomy tiers and tool surfaces, because those are what could make a writer undispatchable.
+
+That is what happened. Five dispatches for `BI-5CBDC146` were spent disproving, in order: that the
+governed path was structurally unreachable; that the provider was down; that the reviewer's
+`hitlTierDefault = 1` ("Approve each action") was blocking it; and that the writer grant was missing
+from the run's scope. Every one of those was wrong, and each was ruled out with evidence:
+`requiresApproval: false` in the response, a Tier-3 agent stranding identically, and
+`tool:record_initiative_design_review` present in the run's `authorityScope`.
+
+The condition was a transient reservation that clears in about three minutes.
+
+---
+
+## 2. Research & benchmarking
+
+The design question is narrow: **what should a gate report when the thing it was waiting for never
+ran?**
+
+- **Kubernetes pod conditions.** A pod that cannot be scheduled is `Pending` with reason
+  `Unschedulable`, never `Failed`. The *phase* stays coarse; the *reason* carries the cause, and the
+  two are separate fields. **Adopted:** the wait stays resumable, and the reason names the resource.
+- **HTTP 503 + `Retry-After`.** The canonical way to say "not now, and here is when". A server that
+  returned 400 for an overloaded backend would send clients to fix their request. **Adopted:** the
+  deferral already carries `expectedFreeAt`; routing it to the existing `provider-capacity` wait is
+  what surfaces it.
+- **The platform's own precedent.** `routed-semantic-review.ts` already handles this exact error by
+  returning `inconclusive` with a typed `inconclusiveReason` rather than a verdict. **Adopted
+  wholesale** — this change makes the reviewer route behave the way semantic review already does.
+
+**Rejected: adding a `cause` field to the terminal-writer wait.** That was the first implementation
+here and it was wrong — it would have built a second, parallel way to report a condition the platform
+already models as `provider-capacity`. Verifying the substrate first turned a new mechanism into a
+precedence fix.
+
+---
+
+## 3. Decision
+
+**Stop overwriting the classification, and let the resource wait win when nothing has run yet.**
+
+No new state, no new field, no new tool. Two conditions, both narrowing an over-broad branch.
+
+---
+
+## 4. What was built
+
+### 4.1 The loop keeps what it classified
+
+In the `terminalToolPolicy` catch, a `capacity` or `busy` classification is returned as itself
+instead of being rewritten. An unclassified failure still reports `terminal-writer-missing`, because
+without a known cause there is nothing truer to say.
+
+**Only pre-inference.** The reclassification requires `executedTools.length === 0`, mirroring
+`preInferenceResourceWait`'s own contract. This bound was not in the first draft, and an existing
+test caught it: once a reader has succeeded, the resumable writer wait is the *better* state — the
+read work is banked and only the receipt is outstanding, whereas a resource wait at that point would
+fail the run.
+
+### 4.2 The resource wait takes precedence
+
+`mcp-task-execution.ts` computes `preInferenceResourceWait` before the terminal-writer branch and
+skips that branch when a resource wait owns the turn. Both paths resume on the same TaskRun, so this
+changes only which reason is reported.
+
+### 4.3 Regression guards, verified to fail without the fix
+
+Both halves were confirmed by removing the fix and watching the tests go red:
+
+- `agentic-loop.test.ts` — a capacity deferral and a busy provider stay classified; an unclassifiable
+  failure still blames the writer.
+- `mcp-task-execution.test.ts` — a pre-inference deferral becomes a resumable `provider-capacity`
+  wait with no `terminalWriterWait` in the payload; a genuine writer no-show after a successful read
+  is unchanged; a capacity failure *after* tool work is not diverted.
+
+---
+
+## 5. Acceptance criteria (BI-8B8731EE)
+
+| criterion | status |
+| --- | --- |
+| Packet reaches its writer, or returns a typed denial identifying the unavailable provider capability | **Met** — a deferral now reports `provider-capacity` with its `failureKind` |
+| Retrying a resumable route continues the original TaskRun | **Already held** — verified live: `idempotentReplay: true`, `resumedFromTerminalWriterWait: true` |
+| Tests reproduce and prevent `missing-terminal-writer` after a valid immutable binding | **Met** — §4.3 |
+| The implementation path can obtain real receipts without a bypass | **Improved, not proven** — see §6 |
+
+---
+
+## 6. What this does not do
+
+It does not make the reviewer route succeed. A capacity reservation still defers the run; what
+changes is that the caller is told so, is told when the host frees, and can wait rather than
+investigate. The ~34% completion rate is a *capacity* question — how local inference and governed
+local CI share one host — and that is not this change.
+
+It also does not touch `hitlTierDefault`. Both reviewers are Tier 1 ("Approve each action"), which
+looked like the cause and is not; whether an independent reviewer *should* be Tier 1 is an operator
+decision about risk posture, not a defect.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -58,8 +58,8 @@ apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	940
 apps/web/lib/tak/agent-grants.ts	995
 apps/web/lib/tak/agent-routing.ts	1191
-apps/web/lib/tak/agentic-loop.test.ts	2501
-apps/web/lib/tak/agentic-loop.ts	2704
+apps/web/lib/tak/agentic-loop.test.ts	2551
+apps/web/lib/tak/agentic-loop.ts	2710
 apps/web/lib/tak/route-context-map.ts	1440
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1191
 apps/web/lib/work-capsules/work-capsule-store.ts	1052


### PR DESCRIPTION
The governed reviewer route computed the true reason it stopped, then overwrote it with a false one. Everything downstream acted on the false one.

Closes `BI-8B8731EE`. Design: [`docs/superpowers/specs/2026-09-02-capacity-deferral-is-not-a-writer-failure-design.md`](docs/superpowers/specs/2026-09-02-capacity-deferral-is-not-a-writer-failure-design.md).

## The defect

`describeToolRouteFailureOutcome` already classifies a local-host deferral as `kind: "capacity"`, with copy that names the window. The `terminalToolPolicy` catch computed that — and then returned a hardcoded `terminal-writer-missing` instead.

`preInferenceResourceWait` downstream keys on exactly the `capacity` kind that had just been erased. So the platform's own `provider-capacity` wait — resumable, already built, already used by `routed-semantic-review` for this identical error — was **unreachable for every governed reviewer route**.

A second guard closed the same door: the terminal-writer branch runs first, and its `terminalWriterMissing` condition is true for any governed route that executed no tools, which is precisely what a deferral looks like.

## Measured

Terminal writes landed on **~34%** of external-MCP reviewer dispatches — 35 completed, 49 `input-required`, 18 failed over 5 days. The portal log named the real cause on every stranded one:

```
routeAndCall threw: Local provider dispatch deferred: local-ci-queued-capacity-reservation
```

A reservation that clears itself in ~195s.

## Why it cost so much

`missing-terminal-writer` describes an *outcome* — no receipt yet — and says nothing true about the cause. Callers act on the cause.

Five dispatches for `BI-5CBDC146` were spent disproving, in order: that the governed path was structurally unreachable; that the provider was down; that the reviewers' `hitlTierDefault = 1` ("Approve each action") was blocking; and that the writer grant was missing. All four wrong, each ruled out with evidence — `requiresApproval: false`, a Tier-3 agent stranding identically, and `tool:record_initiative_design_review` present in the run's `authorityScope`.

## The fix

- The loop returns a `capacity`/`busy` classification as itself. An unclassifiable failure still reports `terminal-writer-missing` — without a known cause there is nothing truer to say.
- **Only pre-inference** (`executedTools.length === 0`), mirroring `preInferenceResourceWait`'s own contract. An existing `terminal-tool-policy` test caught the first draft over-reaching: once a reader has succeeded, the resumable writer wait is the *better* state, because the read work is banked and only the receipt is outstanding.
- `mcp-task-execution` lets the resource wait own the turn. Both paths resume on the same TaskRun, so only the reported reason changes.

**No new state, field or tool.** An earlier draft added a `cause` field to the writer wait; verifying the substrate first showed the platform already models this as `provider-capacity`, turning a new mechanism into a precedence fix.

## Verified

| check | result |
| --- | --- |
| `pregate-preflight` | **OK — 61 guards clean in 140s** (1 environment-skipped: PR Health Logic) |
| `tsc --noEmit` | clean |
| tests | **1566 pass** across `lib/tak`, the mcp-task surface, `lib/change-review` |
| regression guards | both halves confirmed by removing the fix and watching them go red |

**Not verified locally — CI adjudicates.** The local-CI sandbox gate is wedged for this host by `BI-A7EAB5AA`; pushed under a recorded operator override. The worktree also reports `ignored_builds_unclassified` for puppeteer/unrs-resolver/protobufjs — a pnpm build-approval condition on the shared workspace, not this branch (a worktree installed before today bootstraps clean on the same root). Rather than trust that classification I checked the guards actually execute here; they do, and the full preflight passes.

## What this does not do

It does not make the reviewer route succeed. A reservation still defers the run — what changes is that the caller is told so, told when the host frees, and can wait instead of investigate. The ~34% rate is a capacity question about how local inference and governed local CI share one host, and that is not this change.

It also does not touch `hitlTierDefault`. Both reviewers are Tier 1, which looked like the cause and is not; whether an independent reviewer *should* be Tier 1 is an operator decision about risk posture, not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
