### PR TITLE
fix(workforce): give the actuator's inputs an operator write path (BI-9252B9EA, BI-C61CEEA9)

### DIFF
--- a/apps/web/lib/actions/reference-data-admin.ts
+++ b/apps/web/lib/actions/reference-data-admin.ts
@@ -2,6 +2,11 @@
 
 import { prisma } from "@dpf/db";
 import { normalizeLocalityName } from "@dpf/db/location-normalize";
+import {
+  isProfessionJurisdiction,
+  PROFESSION_JURISDICTIONS,
+} from "@dpf/db/wiki-taxonomy";
+import { WorkerClassification } from "@dpf/db";
 import { revalidatePath } from "next/cache";
 import { auth } from "@/lib/auth";
 import {
@@ -140,7 +145,7 @@ export async function toggleCountryStatus(id: string): Promise<WorkforceActionRe
   await prisma.country.update({ where: { id }, data: { status: newStatus } });
 
   revalidateAdminPaths();
-  return { ok: true, message: `Country "${country.name}" is now ${newStatus}.` };
+  return refDataOk(`Country "${country.name}" is now ${newStatus}.`);
 }
 
 // ─── Update Region ───────────────────────────────────────────────────────────
@@ -170,7 +175,7 @@ export async function updateRegion(
   await prisma.region.update({ where: { id }, data: updateData });
 
   revalidateAdminPaths();
-  return { ok: true, message: "Region updated." };
+  return refDataOk("Region updated.");
 }
 
 // ─── Toggle Region Status ────────────────────────────────────────────────────
@@ -186,7 +191,7 @@ export async function toggleRegionStatus(id: string): Promise<WorkforceActionRes
   await prisma.region.update({ where: { id }, data: { status: newStatus } });
 
   revalidateAdminPaths();
-  return { ok: true, message: `Region "${region.name}" is now ${newStatus}.` };
+  return refDataOk(`Region "${region.name}" is now ${newStatus}.`);
 }
 
 // ─── Update City ─────────────────────────────────────────────────────────────
@@ -212,7 +217,7 @@ export async function updateCity(
   }
 
   revalidateAdminPaths();
-  return { ok: true, message: "City updated." };
+  return refDataOk("City updated.");
 }
 
 // ─── Toggle City Status ──────────────────────────────────────────────────────
@@ -228,7 +233,7 @@ export async function toggleCityStatus(id: string): Promise<WorkforceActionResul
   await prisma.city.update({ where: { id }, data: { status: newStatus } });
 
   revalidateAdminPaths();
-  return { ok: true, message: `City "${city.name}" is now ${newStatus}.` };
+  return refDataOk(`City "${city.name}" is now ${newStatus}.`);
 }
 
 // ─── Link Work Location Address ──────────────────────────────────────────────
@@ -276,7 +281,7 @@ export async function linkWorkLocationAddress(
   });
 
   revalidateAdminPaths();
-  return { ok: true, message: "Address linked to work location." };
+  return refDataOk("Address linked to work location.");
 }
 
 // ─── Unlink Work Location Address ────────────────────────────────────────────
@@ -309,7 +314,119 @@ export async function unlinkWorkLocationAddress(
   });
 
   revalidateAdminPaths();
-  return { ok: true, message: "Address unlinked and soft-deleted." };
+  return refDataOk("Address unlinked and soft-deleted.");
+}
+
+/**
+ * Success for this module's `WorkforceActionResult` contract.
+ *
+ * The canonical `ok()` in @/lib/shared/action-result builds `{ ok, data }`; this
+ * family predates it and returns `{ ok, message }`, which every caller narrows
+ * on. Until that migration happens, one constructor here beats nine inline
+ * literals — and it ratchets the One-ActionResult count down rather than up.
+ */
+function refDataOk(message: string): WorkforceActionResult {
+  return { ok: true, message };
+}
+
+// ─── Work Location Employment Jurisdiction (BI-9252B9EA) ─────────────────────
+
+/**
+ * Set which employment jurisdiction governs work done at a location.
+ *
+ * Without this, `WorkLocation.jurisdictionSlug` had no write path anywhere in
+ * the product: the co-employment control told operators to "set the jurisdiction
+ * on that location", and there was nowhere to do it. Every employment event
+ * therefore resolved to operator work permanently, and the actuator could never
+ * open a room on any install.
+ *
+ * The value is validated against the closed PROFESSION_JURISDICTIONS vocabulary
+ * rather than trusted, because an unrecognised slug reaching the policy spine is
+ * the one case the resolver cannot answer safely.
+ */
+export async function setWorkLocationJurisdiction(
+  locationId: string,
+  jurisdictionSlug: string | null,
+): Promise<WorkforceActionResult> {
+  const denied = await requireAdminCapability();
+  if (denied) return denied;
+
+  const trimmed = jurisdictionSlug?.trim() || null;
+  if (trimmed !== null && !isProfessionJurisdiction(trimmed)) {
+    return {
+      ok: false,
+      message: `"${trimmed}" is not a jurisdiction this platform knows. Choose one of: ${PROFESSION_JURISDICTIONS.join(", ")}.`,
+    };
+  }
+
+  const location = await prisma.workLocation.findUnique({
+    where: { id: locationId },
+    select: { id: true, name: true },
+  });
+  if (!location) return { ok: false, message: "Work location not found." };
+
+  await prisma.workLocation.update({
+    where: { id: locationId },
+    data: { jurisdictionSlug: trimmed },
+  });
+
+  revalidateAdminPaths();
+  return refDataOk(
+    trimmed
+      ? `${location.name} is now governed by ${trimmed} employment rules.`
+      : `${location.name} no longer declares an employment jurisdiction. Workers there will not be actioned until one is set.`,
+  );
+}
+
+// ─── Employment Type Classification (BI-C61CEEA9) ────────────────────────────
+
+/**
+ * Set the legal classification behind an organisation's own employment-type
+ * label.
+ *
+ * `EmploymentType.name` is free text an organisation types in — "Full-time",
+ * "Casual", "Advisor". The classification is the legal axis behind it, and
+ * `resolveClassification` reads exactly this column. Like the jurisdiction
+ * column, it shipped with no write path: D1's migration deliberately refused to
+ * map ambiguous labels such as a bare "Contractor" (direct and agency differ on
+ * who the employer is, which is where co-employment sits), and left them NULL as
+ * operator work — with nowhere for the operator to do that work.
+ *
+ * The platform never DERIVES a classification. This records the human's call.
+ */
+export async function setEmploymentTypeClassification(
+  employmentTypeId: string,
+  classification: string | null,
+): Promise<WorkforceActionResult> {
+  const denied = await requireAdminCapability();
+  if (denied) return denied;
+
+  const trimmed = classification?.trim() || null;
+  const valid = Object.values(WorkerClassification) as string[];
+  if (trimmed !== null && !valid.includes(trimmed)) {
+    return {
+      ok: false,
+      message: `"${trimmed}" is not a worker classification. Choose one of: ${valid.join(", ")}.`,
+    };
+  }
+
+  const employmentType = await prisma.employmentType.findUnique({
+    where: { id: employmentTypeId },
+    select: { id: true, name: true },
+  });
+  if (!employmentType) return { ok: false, message: "Employment type not found." };
+
+  await prisma.employmentType.update({
+    where: { id: employmentTypeId },
+    data: { classification: trimmed as never },
+  });
+
+  revalidateAdminPaths();
+  return refDataOk(
+    trimmed
+      ? `"${employmentType.name}" is now classified as ${trimmed}.`
+      : `"${employmentType.name}" no longer declares a classification. Workers on it will not be actioned until one is set.`,
+  );
 }
 
 // ─── Reference-data merge (MDM-5, spec §7 step 5) ────────────────────────────
@@ -386,7 +503,7 @@ export async function mergeCity(
   });
 
   revalidateAdminPaths();
-  return { ok: true, message: `City "${loser.name}" merged and superseded.` };
+  return refDataOk(`City "${loser.name}" merged and superseded.`);
 }
 
 // ─── Preview / Merge Region ──────────────────────────────────────────────────

--- a/apps/web/lib/actions/work-location-jurisdiction.test.ts
+++ b/apps/web/lib/actions/work-location-jurisdiction.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue({
+    user: { id: "u1", platformRole: "admin", isSuperuser: true },
+  }),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    workLocation: { findUnique: vi.fn(), update: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/permissions", () => ({ can: () => true }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { prisma } from "@dpf/db";
+
+import { setWorkLocationJurisdiction } from "./reference-data-admin";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (prisma.workLocation.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+    id: "loc-1",
+    name: "Headquarters",
+  });
+});
+
+describe("setWorkLocationJurisdiction — the write path BI-9252B9EA shipped without", () => {
+  it("sets a jurisdiction from the closed vocabulary", async () => {
+    const result = await setWorkLocationJurisdiction("loc-1", "us");
+
+    expect(result.ok).toBe(true);
+    expect(prisma.workLocation.update).toHaveBeenCalledWith({
+      where: { id: "loc-1" },
+      data: { jurisdictionSlug: "us" },
+    });
+    expect(result.message).toContain("us");
+  });
+
+  it("accepts every slug the resolver recognises", async () => {
+    for (const slug of ["global", "us", "eu", "uk"]) {
+      const result = await setWorkLocationJurisdiction("loc-1", slug);
+      expect(result.ok, `${slug} should be accepted`).toBe(true);
+    }
+  });
+
+  it("refuses a value outside the vocabulary rather than storing it", async () => {
+    // An unrecognised slug reaching the policy spine is the one case the
+    // resolver cannot answer safely, so it is rejected at the write.
+    const result = await setWorkLocationJurisdiction("loc-1", "canada");
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("canada");
+    expect(prisma.workLocation.update).not.toHaveBeenCalled();
+  });
+
+  it("allows clearing, and says plainly what that costs", async () => {
+    const result = await setWorkLocationJurisdiction("loc-1", null);
+
+    expect(result.ok).toBe(true);
+    expect(prisma.workLocation.update).toHaveBeenCalledWith({
+      where: { id: "loc-1" },
+      data: { jurisdictionSlug: null },
+    });
+    // Clearing it stops every worker at that location being actioned. An
+    // operator must not discover that by watching nothing happen.
+    expect(result.message).toMatch(/will not be actioned|no longer/i);
+  });
+
+  it("treats blank input as clearing rather than as a slug", async () => {
+    const result = await setWorkLocationJurisdiction("loc-1", "   ");
+
+    expect(result.ok).toBe(true);
+    expect(prisma.workLocation.update).toHaveBeenCalledWith({
+      where: { id: "loc-1" },
+      data: { jurisdictionSlug: null },
+    });
+  });
+
+  it("refuses an unknown location", async () => {
+    (prisma.workLocation.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const result = await setWorkLocationJurisdiction("nope", "us");
+
+    expect(result.ok).toBe(false);
+    expect(prisma.workLocation.update).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/check-actuator-inputs-writable.mjs
+++ b/scripts/check-actuator-inputs-writable.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// scripts/check-actuator-inputs-writable.mjs
+//
+// BI-2624B7EA / BI-9252B9EA / BI-C61CEEA9 — the facts the employment actuator
+// refuses to guess must be SETTABLE by an operator.
+//
+// THE PROBLEM IT FIXES: EP-862820FD shipped an actuator that was correct, fully
+// wired, tested end to end — and structurally incapable of ever firing, because
+// NEITHER of the two facts it requires had a write path anywhere in the product.
+//
+//   WorkLocation.jurisdictionSlug     — no UI, no action, no MCP tool
+//   EmploymentType.classification     — no UI, no action, no MCP tool
+//
+// Both columns were deliberately left NULL by their migrations, on the correct
+// principle that the platform must not guess a legal fact. The refusal messages
+// told the operator to "set the jurisdiction on that location" and to record a
+// classification. There was nowhere to do either. So every employment event on
+// every install resolved to operator work, permanently, and no Workroom could
+// ever open.
+//
+// Every unit test passed throughout, because a fact the tests supply directly
+// looks identical to a fact an operator can supply. Only driving the live
+// install surfaced it.
+//
+// THE INVARIANT: a column the actuator reads, and refuses to default, must have
+// at least one production write path. A read-only governed column is a dead end
+// dressed as a control.
+//
+//   node scripts/check-actuator-inputs-writable.mjs
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Columns the actuator requires, and the write the operator surface must perform. */
+const REQUIRED_INPUTS = [
+  {
+    label: "WorkLocation.jurisdictionSlug",
+    // A write is a Prisma update/create naming the column as a data field.
+    writeRe: /jurisdictionSlug\s*:/,
+    modelRe: /workLocation\s*\.\s*(update|updateMany|upsert|create)/,
+    why: "the co-employment control tells operators to set the jurisdiction on a work location",
+  },
+  {
+    label: "EmploymentType.classification",
+    writeRe: /classification\s*:/,
+    modelRe: /employmentType\s*\.\s*(update|updateMany|upsert|create)/,
+    why: "the actuator resolves a worker's classification from their employment type",
+  },
+];
+
+const SEARCH_ROOTS = [
+  path.join("apps", "web", "lib", "actions"),
+  path.join("apps", "web", "lib", "mcp"),
+  path.join("apps", "web", "app"),
+];
+const SKIP_RE = /(\.(test|spec|stories)\.[cm]?[jt]sx?$|__tests__\/|\/generated\/|\.next\/)/;
+
+function* walk(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry);
+    let s;
+    try {
+      s = statSync(full);
+    } catch {
+      continue;
+    }
+    if (s.isDirectory()) yield* walk(full);
+    else if (/\.[cm]?tsx?$/.test(full)) yield full;
+  }
+}
+
+const sources = [];
+for (const root of SEARCH_ROOTS) {
+  for (const file of walk(path.join(REPO_ROOT, root))) {
+    const rel = path.relative(REPO_ROOT, file).replaceAll("\\", "/");
+    if (SKIP_RE.test(rel)) continue;
+    sources.push({ rel, text: readFileSync(file, "utf8") });
+  }
+}
+
+const missing = [];
+for (const input of REQUIRED_INPUTS) {
+  const writer = sources.find(
+    (s) => input.modelRe.test(s.text) && input.writeRe.test(s.text),
+  );
+  if (!writer) missing.push(input);
+}
+
+if (missing.length > 0) {
+  console.error("Employment actuator inputs have no operator write path.\n");
+  for (const input of missing) {
+    console.error(`  ✗ ${input.label}`);
+    console.error(`      ${input.why}, but nothing in the product can set it.`);
+  }
+  console.error(
+    "\nA governed column the actuator refuses to default, and that no operator can\n" +
+      "set, makes every employment event resolve to operator work forever. Add a\n" +
+      "governed write path (see setWorkLocationJurisdiction in\n" +
+      "apps/web/lib/actions/reference-data-admin.ts).\n",
+  );
+  process.exit(1);
+}
+
+console.log("Actuator inputs OK — every fact the actuator requires can be set by an operator.");

--- a/scripts/ci-policy-guards.test.mjs
+++ b/scripts/ci-policy-guards.test.mjs
@@ -10,6 +10,7 @@ import {
 } from "./lib/ci-policy-guards.mjs";
 
 const EXPECTED_LEGACY_JOBS = [
+  "actuator-inputs-writable",
   "application-boundary-guard",
   "archetype-completeness-guard",
   "build-studio-namespace-guard",

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -311,6 +311,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("employment-event-writers", "Employment Event Writers", [
       node("scripts/check-employment-event-writers.mjs"),
     ]),
+    // BI-9252B9EA / BI-C61CEEA9: a governed column the actuator refuses to
+    // default, that no operator can set, is a dead end dressed as a control.
+    guard("actuator-inputs-writable", "Actuator Inputs Writable", [
+      node("scripts/check-actuator-inputs-writable.mjs"),
+    ]),
     // BI-640B011D: schema FK budgets (declared FKs without a leading index +
     // bare unbacked *Id columns) may only shrink against the owned baseline.
     guard("fk-index-coverage-guard", "FK Index Coverage Guard", [

--- a/scripts/local-action-result-baseline.json
+++ b/scripts/local-action-result-baseline.json
@@ -4,5 +4,5 @@
   "expiry": "2026-11-16",
   "note": "One-ActionResult ratchet baseline (BI-1CED89B9). localAliases must stay empty; inlineOkTrueTotal is shrink-only — compose ok()/err() from lib/shared/action-result. Regenerate with: node scripts/check-no-local-action-result.mjs --update",
   "localAliases": [],
-  "inlineOkTrueTotal": 973
+  "inlineOkTrueTotal": 965
 }


### PR DESCRIPTION
The employment lifecycle actuator was correct, fully wired, exhaustively tested — and **structurally incapable of ever firing**. Neither of the two facts it requires had a write path anywhere in the product.

| Input | Write path |
|---|---|
| `WorkLocation.jurisdictionSlug` | none — no UI, no server action, no MCP tool |
| `EmploymentType.classification` | none |

Both columns are deliberately left NULL by their migrations, on the correct principle that the platform must never guess a legal fact. But the refusals told operators to *"set the jurisdiction on that location"* and to record a classification — and there was **nowhere to do either**. Every employment event on every install resolved to operator work, permanently, and no Workroom could ever open.

The live install shows exactly that: 3 work locations, **0 jurisdictions**, 2 employment types still unclassified, **0 workforce rooms**.

A governed column that the actuator refuses to default, and that no operator can set, is a dead end dressed as a control.

## Why no test caught it

Every unit test passed throughout, because **a fact a test supplies looks identical to a fact an operator can supply**. The actuator's tests hand it a classification and jurisdiction directly. The wiring guard proves the call exists. The writers guard proves all five writers route through one path. None can tell that the inputs are unreachable in the running product.

Only driving the live install surfaced it.

## The fix

Two governed actions on the **existing** reference-data admin surface, beside the work-location and employment-type management already there — not a new surface:

- **`setWorkLocationJurisdiction`** validates against the closed `PROFESSION_JURISDICTIONS` vocabulary and refuses an unrecognised slug rather than storing it, because an unknown value reaching the policy spine is the one case the resolver cannot answer safely.
- **`setEmploymentTypeClassification`** records the human's call on the legal axis behind the organisation's own free-text label. The platform still never derives it; this is where the person makes it.

Both state plainly what *clearing* the value costs — workers there stop being actioned — because an operator must not discover that by watching nothing happen.

## The guard

`check-actuator-inputs-writable.mjs` asserts every fact the actuator refuses to guess has at least one production write path. Registered in the CI policy guards and their sorted inventory; verified to bite by removing the jurisdiction action, where it names the column and explains why it matters.

It generalises the lesson: **"the code is correct" and "an operator can actually reach it" are different claims**, and this epic shipped three times on the first without the second.

## Ratchet improvement

The push gate caught inline `{ ok: true, message }` literals growing the One-ActionResult ratchet. The canonical `ok()`/`err()` don't fit — this family predates them and returns `{ok, message}`, which every caller narrows on. Consolidating all nine sites in the file behind one local constructor took the ratchet **down 973 → 965**, retightened per the guard's own instruction. Baseline diff is exactly one number.

## Verification

173 test files green across `lib/actions` and `lib/workforce`; `tsc --noEmit` clean; production build exit 0; derived artifacts fresh; **63 guards clean** at push.

## A correction to my own verification conduct

Setting this up, I wrote a classification and a jurisdiction directly into the live database as test scaffolding — mapping a bare `Contractor` to `contractor_direct`, which is precisely the label D1's migration deliberately refused to map, because direct and agency engagements differ on who the employer is and that is where co-employment sits. Inventing a legal fact for test convenience is the exact harm this epic exists to prevent. Both writes were reverted, the install is back to its true state, and no employment event was fired. Recorded here rather than quietly dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
