### PR TITLE
feat(federation): read-only operational-posture federated record + projection (Slice 2.1, BI-0585906E)

### DIFF
--- a/apps/web/lib/federation/operational-posture-projection.test.ts
+++ b/apps/web/lib/federation/operational-posture-projection.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { OPERATIONAL_POSTURE_PROJECTION_TEMPLATE } from "@dpf/db/federated-operational-posture-contract";
+
+import { buildOperationalPostureRecord } from "./operational-posture-projection";
+
+const source = {
+  servedVersion: "2026.7.0",
+  servedSha: "deadbeefcafe",
+  patchPosture: { critical: 0, high: 2, medium: 4, low: 7 },
+  health: { status: "degraded" as const, estateItemCount: 128 },
+  runtime: { targetCount: 3, healthyCount: 2 },
+  resourceFootprint: { cpuCores: 8, memoryMb: 16_384 },
+  capturedAt: new Date("2026-07-20T06:00:00.000Z"),
+  updatedAt: new Date("2026-07-20T06:05:00.000Z"),
+};
+
+const identity = { installationId: `inst_${"a".repeat(32)}`, projectionSecret: "b".repeat(64) };
+
+describe("buildOperationalPostureRecord", () => {
+  it("projects a valid minimized posture record with a stable digest", () => {
+    const result = buildOperationalPostureRecord({ source, identity });
+
+    expect(result.violations).toEqual([]);
+    expect(result.record).toMatchObject({
+      specVersion: "dpf.operational-posture/1",
+      originInstallationId: identity.installationId,
+      servedVersion: source.servedVersion,
+      servedSha: source.servedSha,
+      patchPosture: { critical: 0, high: 2, medium: 4, low: 7 },
+      health: { status: "degraded", estateItemCount: 128 },
+      runtime: { targetCount: 3, healthyCount: 2 },
+      originVersion: source.updatedAt.getTime(),
+    });
+    expect(result.record.payloadDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it("emits no excluded egress and re-projecting an unchanged source is idempotent", () => {
+    const first = buildOperationalPostureRecord({ source, identity });
+    const second = buildOperationalPostureRecord({ source, identity });
+
+    // assertNoExcludedEgress contributes to violations; an empty list proves the
+    // projection is provably minimum-necessary.
+    expect(first.violations).toEqual([]);
+    expect(second.record.originVersion).toBe(first.record.originVersion);
+    expect(second.record.payloadDigest).toBe(first.record.payloadDigest);
+  });
+
+  it("never serializes raw or host-identifying source fields", () => {
+    const result = buildOperationalPostureRecord({
+      source: {
+        ...source,
+        hostname: "prod-node-7",
+        ipAddress: "10.1.2.3",
+        rawFindings: [{ cve: "CVE-9999", host: "prod-node-7" }],
+      } as typeof source,
+      identity,
+    });
+
+    expect(result.violations).toEqual([]);
+    const serialized = JSON.stringify(result.record);
+    expect(serialized).not.toContain("prod-node-7");
+    expect(serialized).not.toContain("10.1.2.3");
+    expect(serialized).not.toContain("CVE-9999");
+    expect(result.record).not.toHaveProperty("hostname");
+    expect(result.record).not.toHaveProperty("rawFindings");
+  });
+
+  it("honors a narrower contract that drops the optional resource footprint", () => {
+    const result = buildOperationalPostureRecord({
+      source,
+      identity,
+      contract: {
+        ...OPERATIONAL_POSTURE_PROJECTION_TEMPLATE,
+        fieldAllowList: {
+          posture: [
+            "specVersion", "originInstallationId", "originVersion", "servedVersion", "servedSha",
+            "patchPosture", "health", "runtime", "capturedAt", "payloadDigest",
+          ],
+        },
+      },
+    });
+
+    expect(result.violations).toEqual([]);
+    expect(result.record).not.toHaveProperty("resourceFootprint");
+  });
+});

--- a/apps/web/lib/federation/operational-posture-projection.ts
+++ b/apps/web/lib/federation/operational-posture-projection.ts
@@ -1,0 +1,81 @@
+import {
+  OPERATIONAL_POSTURE_PROJECTION_TEMPLATE,
+  computeOperationalPosturePayloadDigest,
+  validateOperationalPostureV1,
+  type OperationalPostureV1,
+  type PostureHealthRollupV1,
+  type PosturePatchSummaryV1,
+  type PostureResourceFootprintV1,
+  type PostureRuntimeSummaryV1,
+} from "@dpf/db/federated-operational-posture-contract";
+import {
+  assertNoExcludedEgress,
+  projectEstatePayload,
+  type ProjectionContractSpec,
+} from "@dpf/db/projection-serialization";
+
+import type { FederationIdentity } from "./demand-identity";
+
+export interface ProjectableOperationalPostureSource {
+  servedVersion: string;
+  servedSha: string;
+  patchPosture: PosturePatchSummaryV1;
+  health: PostureHealthRollupV1;
+  runtime: PostureRuntimeSummaryV1;
+  resourceFootprint?: PostureResourceFootprintV1;
+  capturedAt: Date;
+  updatedAt: Date;
+}
+
+const clampInt = (value: number): number => Math.max(0, Math.trunc(value));
+
+/**
+ * Build only the minimized, read-only posture record; the raw estate never reaches
+ * the transport. The canonical side is always `local` — the reporting install owns
+ * its posture — so there is no per-record opaque ref to derive (unlike demand): a
+ * singleton posture is identified by its origin install alone.
+ */
+export function buildOperationalPostureRecord(input: {
+  source: ProjectableOperationalPostureSource;
+  identity: FederationIdentity;
+  contract?: ProjectionContractSpec;
+}): { record: OperationalPostureV1; violations: string[] } {
+  const contract = input.contract ?? OPERATIONAL_POSTURE_PROJECTION_TEMPLATE;
+  const candidate: OperationalPostureV1 = {
+    specVersion: "dpf.operational-posture/1",
+    originInstallationId: input.identity.installationId,
+    originVersion: Math.max(1, input.source.updatedAt.getTime()),
+    servedVersion: input.source.servedVersion,
+    servedSha: input.source.servedSha,
+    patchPosture: {
+      critical: clampInt(input.source.patchPosture.critical),
+      high: clampInt(input.source.patchPosture.high),
+      medium: clampInt(input.source.patchPosture.medium),
+      low: clampInt(input.source.patchPosture.low),
+    },
+    health: {
+      status: input.source.health.status,
+      estateItemCount: clampInt(input.source.health.estateItemCount),
+    },
+    runtime: {
+      targetCount: clampInt(input.source.runtime.targetCount),
+      healthyCount: clampInt(input.source.runtime.healthyCount),
+    },
+    ...(input.source.resourceFootprint ? { resourceFootprint: input.source.resourceFootprint } : {}),
+    capturedAt: input.source.capturedAt.toISOString(),
+    payloadDigest: "sha256:pending",
+  };
+
+  const firstProjection = projectEstatePayload(contract, { posture: candidate });
+  candidate.payloadDigest = computeOperationalPosturePayloadDigest(
+    firstProjection.projected.posture as OperationalPostureV1,
+  );
+
+  const projection = projectEstatePayload(contract, { posture: candidate });
+  const record = projection.projected.posture as OperationalPostureV1;
+  const violations = [
+    ...assertNoExcludedEgress(contract, projection.projected),
+    ...validateOperationalPostureV1(record),
+  ];
+  return { record, violations };
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -30,6 +30,7 @@
     "./installation-operating-intent": "./src/installation-operating-intent.ts",
     "./federation-pairing-types": "./src/federation-pairing-types.ts",
     "./federated-demand-contract": "./src/federated-demand-contract.ts",
+    "./federated-operational-posture-contract": "./src/federated-operational-posture-contract.ts",
     "./federated-channel": "./src/federated-channel.ts",
     "./founder-shared-portfolio": "./src/founder-shared-portfolio.ts",
     "./projection-serialization": "./src/projection-serialization.ts",

--- a/packages/db/src/federated-operational-posture-contract.test.ts
+++ b/packages/db/src/federated-operational-posture-contract.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { projectEstatePayload } from "./projection-serialization";
+import {
+  OPERATIONAL_POSTURE_PROJECTION_TEMPLATE,
+  OPERATIONAL_POSTURE_SCHEMA_VERSIONS,
+  POSTURE_HEALTH_STATUSES,
+  computeOperationalPosturePayloadDigest,
+  validateOperationalPostureV1,
+  type OperationalPostureV1,
+} from "./federated-operational-posture-contract";
+
+const posture = (overrides: Partial<OperationalPostureV1> = {}): OperationalPostureV1 => {
+  const value: OperationalPostureV1 = {
+    specVersion: "dpf.operational-posture/1",
+    originInstallationId: "inst_opaque_a",
+    originVersion: 1,
+    servedVersion: "2026.7.0",
+    servedSha: "deadbeefcafe",
+    patchPosture: { critical: 0, high: 1, medium: 3, low: 5 },
+    health: { status: "healthy", estateItemCount: 42 },
+    runtime: { targetCount: 4, healthyCount: 4 },
+    resourceFootprint: { cpuCores: 8, memoryMb: 16_384 },
+    capturedAt: "2026-07-19T20:00:00.000Z",
+    payloadDigest: "sha256:pending",
+    ...overrides,
+  };
+  if (overrides.payloadDigest === undefined) value.payloadDigest = computeOperationalPosturePayloadDigest(value);
+  return value;
+};
+
+describe("federated operational-posture registries", () => {
+  it("pins the v1 schema version and health vocabulary", () => {
+    expect(OPERATIONAL_POSTURE_SCHEMA_VERSIONS).toEqual(["dpf.operational-posture/1"]);
+    expect(POSTURE_HEALTH_STATUSES).toEqual(["healthy", "degraded", "offline"]);
+  });
+});
+
+describe("validateOperationalPostureV1", () => {
+  it("accepts a conforming posture record", () => {
+    expect(validateOperationalPostureV1(posture())).toEqual([]);
+  });
+
+  it("flags a malformed posture — bad status, negative counts, healthy>target, non-advancing version", () => {
+    const invalid = {
+      ...posture(),
+      health: { status: "on-fire", estateItemCount: -1 },
+      patchPosture: { critical: -2, high: 1, medium: 3, low: 5 },
+      runtime: { targetCount: 2, healthyCount: 9 },
+    };
+    expect(validateOperationalPostureV1(invalid, { previousOriginVersion: 1 })).toEqual(expect.arrayContaining([
+      "health.status:unsupported",
+      "health.estateItemCount:invalid",
+      "patchPosture.critical:invalid",
+      "runtime.healthyCount:exceeds-target",
+      "originVersion:not-advancing",
+    ]));
+  });
+
+  it("rejects host-identifying fields so a raw estate row cannot masquerade as posture", () => {
+    expect(validateOperationalPostureV1({
+      ...posture(),
+      hostname: "prod-node-1",
+      ipAddress: "10.0.0.4",
+      findings: [{ cve: "CVE-0000", host: "prod-node-1" }],
+    })).toEqual(expect.arrayContaining([
+      "field:not-allowed:hostname",
+      "field:not-allowed:ipAddress",
+      "field:not-allowed:findings",
+    ]));
+  });
+
+  it("rejects a payload whose claimed digest does not match its content", () => {
+    expect(validateOperationalPostureV1(posture({ payloadDigest: `sha256:${"0".repeat(64)}` })))
+      .toContain("payloadDigest:mismatch");
+  });
+});
+
+describe("computeOperationalPosturePayloadDigest", () => {
+  it("is stable (idempotent) for identical input", () => {
+    expect(computeOperationalPosturePayloadDigest(posture()))
+      .toBe(computeOperationalPosturePayloadDigest(posture()));
+  });
+
+  it("changes when the posture body changes", () => {
+    const base = posture();
+    const changed = posture({ patchPosture: { critical: 1, high: 1, medium: 3, low: 5 } });
+    expect(computeOperationalPosturePayloadDigest(changed))
+      .not.toBe(computeOperationalPosturePayloadDigest(base));
+  });
+});
+
+describe("OPERATIONAL_POSTURE_PROJECTION_TEMPLATE", () => {
+  it("never projects host-identifying or raw estate state", () => {
+    const result = projectEstatePayload(OPERATIONAL_POSTURE_PROJECTION_TEMPLATE, {
+      posture: {
+        ...posture(),
+        hostname: "prod-node-1",
+        ipAddress: "10.0.0.4",
+        nodeId: "node-secret",
+      },
+      hostDetails: { hostname: "prod-node-1" },
+      estateItems: [{ id: "asset-secret" }],
+    });
+
+    expect(result.projected).toHaveProperty("posture");
+    expect(JSON.stringify(result.projected)).not.toContain("prod-node-1");
+    expect(JSON.stringify(result.projected)).not.toContain("10.0.0.4");
+    expect(JSON.stringify(result.projected)).not.toContain("node-secret");
+    expect(JSON.stringify(result.projected)).not.toContain("asset-secret");
+    expect(result.excluded.slices).toEqual(expect.arrayContaining(["hostDetails", "estateItems"]));
+  });
+});

--- a/packages/db/src/federated-operational-posture-contract.ts
+++ b/packages/db/src/federated-operational-posture-contract.ts
@@ -1,0 +1,232 @@
+// EP cross-install operational control plane · Slice 2 Increment 1
+// (BI-0585906E / parent BI-648F01A0). The federated record contract for a read-only
+// operational-posture projection: each install is canonical for its OWN posture
+// and projects a minimized, read-only rollup to same-organization peers. Mirrors
+// the demand-envelope contract (federated-demand-contract.ts): a versioned type,
+// a canonical content digest, and a pure conformance validator.
+//
+// CRITICAL minimization: this record egresses to a peer install. It carries only
+// SUMMARY rollups — severity counts, health status, coarse runtime/resource tallies
+// — never raw findings, hostnames, IPs, node IDs, or per-item estate rows. The type
+// admits no such field, the projection template allow-lists only these fields, and
+// the validator rejects host-identifying keys as a defensive double-check.
+
+import { createHash } from "node:crypto";
+
+import type { ProjectionContractSpec } from "./projection-serialization";
+
+export const OPERATIONAL_POSTURE_SCHEMA_VERSIONS = ["dpf.operational-posture/1"] as const;
+export type OperationalPostureSchemaVersion = (typeof OPERATIONAL_POSTURE_SCHEMA_VERSIONS)[number];
+
+export const POSTURE_HEALTH_STATUSES = ["healthy", "degraded", "offline"] as const;
+export type PostureHealthStatus = (typeof POSTURE_HEALTH_STATUSES)[number];
+
+/** Summary count of open patch findings by severity — counts only, never the findings. */
+export interface PosturePatchSummaryV1 {
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+}
+
+/** Small health rollup — a status band plus the size of the estate, no item rows. */
+export interface PostureHealthRollupV1 {
+  status: PostureHealthStatus;
+  estateItemCount: number;
+}
+
+/** Coarse runtime tally — counts only, never hostnames/IPs/target identities. */
+export interface PostureRuntimeSummaryV1 {
+  targetCount: number;
+  healthyCount: number;
+}
+
+/** Optional coarse numeric footprint. Every field is an optional non-negative number. */
+export interface PostureResourceFootprintV1 {
+  cpuCores?: number;
+  memoryMb?: number;
+  storageGb?: number;
+}
+
+export interface OperationalPostureV1 {
+  specVersion: "dpf.operational-posture/1";
+  /** The reporting install — canonical for its own posture. */
+  originInstallationId: string;
+  /** Derived from the source's updatedAt epoch ms, so re-projecting an unchanged
+   *  posture is idempotent (same version, same digest). */
+  originVersion: number;
+  /** The version/build the install is currently serving. */
+  servedVersion: string;
+  /** The commit/image sha the install is currently serving. */
+  servedSha: string;
+  patchPosture: PosturePatchSummaryV1;
+  health: PostureHealthRollupV1;
+  runtime: PostureRuntimeSummaryV1;
+  resourceFootprint?: PostureResourceFootprintV1;
+  capturedAt: string;
+  payloadDigest: string;
+}
+
+// Fields that must NEVER cross a federation boundary — host-identifying or raw
+// estate detail that a minimization leak would expose. Rejected on receive as a
+// defensive double-check of the sender's egress projection. Everything NOT on this
+// denylist is tolerated (forward-compatible: a newer peer's additive summary field
+// must not 422 an older receiver during a rolling upgrade). Keep in sync with the
+// excludeSlices in OPERATIONAL_POSTURE_PROJECTION_TEMPLATE.
+const FORBIDDEN_POSTURE_FIELDS = new Set([
+  "hostname",
+  "hostnames",
+  "ipAddress",
+  "ipAddresses",
+  "macAddress",
+  "nodeId",
+  "nodeName",
+  "endpoints",
+  "urls",
+  "findings",
+  "rawFindings",
+  "findingDetails",
+  "targets",
+  "targetDetails",
+  "estateItems",
+  "hostDetails",
+]);
+
+/** Minimized top-level field allow-list — only these leave the install. */
+export const OPERATIONAL_POSTURE_FIELDS = [
+  "specVersion",
+  "originInstallationId",
+  "originVersion",
+  "servedVersion",
+  "servedSha",
+  "patchPosture",
+  "health",
+  "runtime",
+  "resourceFootprint",
+  "capturedAt",
+  "payloadDigest",
+];
+
+/** Default minimum-necessary projection. Operators may narrow, never silently expand it. */
+export const OPERATIONAL_POSTURE_PROJECTION_TEMPLATE: ProjectionContractSpec = {
+  includeSlices: ["posture"],
+  excludeSlices: ["hostDetails", "estateItems", "rawFindings", "runtimeTargets", "localBacklog"],
+  fieldAllowList: { posture: OPERATIONAL_POSTURE_FIELDS },
+  retentionClass: "short",
+};
+
+export interface OperationalPostureValidationContext {
+  previousOriginVersion?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown, max: number): boolean {
+  return typeof value === "string" && value.length > 0 && value.length <= max;
+}
+
+function isNonNegativeInt(value: unknown): boolean {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
+}
+
+function isIsoTimestamp(value: unknown): boolean {
+  return typeof value === "string" && value.length <= 64 && !Number.isNaN(Date.parse(value));
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${stableJson(object[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/** Canonical content digest; the digest field itself is excluded. */
+export function computeOperationalPosturePayloadDigest(
+  value: Omit<OperationalPostureV1, "payloadDigest"> | OperationalPostureV1,
+): string {
+  const content = { ...(value as OperationalPostureV1) } as Record<string, unknown>;
+  delete content.payloadDigest;
+  return `sha256:${createHash("sha256").update(stableJson(content)).digest("hex")}`;
+}
+
+/** Pure protocol conformance check used before persistence or semantic processing. */
+export function validateOperationalPostureV1(
+  value: unknown,
+  context: OperationalPostureValidationContext = {},
+): string[] {
+  if (!isRecord(value)) return ["posture:invalid"];
+
+  const violations: string[] = [];
+  // Reject only host-identifying/raw leak fields (minimization double-check); tolerate
+  // any other unknown/additive field so a newer peer doesn't 422 an older receiver during
+  // a rolling upgrade. See FORBIDDEN_POSTURE_FIELDS.
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_POSTURE_FIELDS.has(key)) violations.push(`field:not-allowed:${key}`);
+  }
+  if (value.specVersion !== "dpf.operational-posture/1") violations.push("specVersion:unsupported");
+  if (!isNonEmptyString(value.originInstallationId, 160)) violations.push("originInstallationId:invalid");
+  if (!Number.isSafeInteger(value.originVersion) || Number(value.originVersion) < 1) {
+    violations.push("originVersion:invalid");
+  } else if (
+    context.previousOriginVersion !== undefined
+    && Number(value.originVersion) <= context.previousOriginVersion
+  ) {
+    violations.push("originVersion:not-advancing");
+  }
+  if (!isNonEmptyString(value.servedVersion, 80)) violations.push("servedVersion:invalid");
+  if (!isNonEmptyString(value.servedSha, 128)) violations.push("servedSha:invalid");
+
+  if (!isRecord(value.patchPosture)) {
+    violations.push("patchPosture:invalid");
+  } else {
+    for (const severity of ["critical", "high", "medium", "low"] as const) {
+      if (!isNonNegativeInt(value.patchPosture[severity])) violations.push(`patchPosture.${severity}:invalid`);
+    }
+  }
+
+  if (!isRecord(value.health)) {
+    violations.push("health:invalid");
+  } else {
+    if (!(POSTURE_HEALTH_STATUSES as readonly unknown[]).includes(value.health.status)) {
+      violations.push("health.status:unsupported");
+    }
+    if (!isNonNegativeInt(value.health.estateItemCount)) violations.push("health.estateItemCount:invalid");
+  }
+
+  if (!isRecord(value.runtime)) {
+    violations.push("runtime:invalid");
+  } else {
+    const targetOk = isNonNegativeInt(value.runtime.targetCount);
+    const healthyOk = isNonNegativeInt(value.runtime.healthyCount);
+    if (!targetOk) violations.push("runtime.targetCount:invalid");
+    if (!healthyOk) violations.push("runtime.healthyCount:invalid");
+    if (targetOk && healthyOk && Number(value.runtime.healthyCount) > Number(value.runtime.targetCount)) {
+      violations.push("runtime.healthyCount:exceeds-target");
+    }
+  }
+
+  if (value.resourceFootprint !== undefined) {
+    if (!isRecord(value.resourceFootprint)) {
+      violations.push("resourceFootprint:invalid");
+    } else {
+      for (const [key, footprintValue] of Object.entries(value.resourceFootprint)) {
+        if (typeof footprintValue !== "number" || !Number.isFinite(footprintValue) || footprintValue < 0) {
+          violations.push(`resourceFootprint.${key}:invalid`);
+        }
+      }
+    }
+  }
+
+  if (!isIsoTimestamp(value.capturedAt)) violations.push("capturedAt:invalid");
+  if (typeof value.payloadDigest !== "string" || !/^sha256:[a-f0-9]{64}$/.test(value.payloadDigest)) {
+    violations.push("payloadDigest:invalid");
+  } else if (computeOperationalPosturePayloadDigest(value as unknown as OperationalPostureV1) !== value.payloadDigest) {
+    violations.push("payloadDigest:mismatch");
+  }
+
+  return violations;
+}

--- a/packages/db/src/federated-record-sync.ts
+++ b/packages/db/src/federated-record-sync.ts
@@ -16,6 +16,9 @@ export const FEDERATED_RECORD_TYPES = [
   // backlog it produced dies with it.
   "backlog-item",
   "epic",
+  // Read-only operational-posture rollup: each install is canonical for its own
+  // posture and projects a minimized, read-only summary to same-organization peers.
+  "operational-posture",
 ] as const;
 export type FederatedRecordType = (typeof FEDERATED_RECORD_TYPES)[number];
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -272,6 +272,22 @@ export {
   type DemandSchemaVersion,
 } from "./federated-demand-contract";
 export {
+  OPERATIONAL_POSTURE_FIELDS,
+  OPERATIONAL_POSTURE_PROJECTION_TEMPLATE,
+  OPERATIONAL_POSTURE_SCHEMA_VERSIONS,
+  POSTURE_HEALTH_STATUSES,
+  computeOperationalPosturePayloadDigest,
+  validateOperationalPostureV1,
+  type OperationalPostureSchemaVersion,
+  type OperationalPostureV1,
+  type OperationalPostureValidationContext,
+  type PostureHealthRollupV1,
+  type PostureHealthStatus,
+  type PosturePatchSummaryV1,
+  type PostureResourceFootprintV1,
+  type PostureRuntimeSummaryV1,
+} from "./federated-operational-posture-contract";
+export {
   assertNoExcludedEgress,
   isForbiddenField,
   projectEstatePayload,


### PR DESCRIPTION
## What

**Slice 2, increment 1** of the cross-install operational control plane ([design](docs/superpowers/specs/2026-09-01-cross-install-operational-control-plane-design.md); Slice-2 BI `BI-0585906E`, parent `BI-648F01A0`). Adds a **read-only** `operational-posture` federated record type + its minimized projection, so each install can project its own version/patch/health/runtime/resource footprint to trusted same-organization peers.

Mirrors the existing **demand-envelope** pattern exactly — same minimization primitives, same idempotent digest approach — so there's one projection convention, not two.

## Changes (7 files, +532, no deletions)

- `packages/db/src/federated-record-sync.ts` — add `"operational-posture"` to `FEDERATED_RECORD_TYPES` (3 lines). **No migration** — `recordType` is a free string, and `reconcileMirror` already enforces "reporting install is canonical; a peer write is a conflict."
- `packages/db/src/federated-operational-posture-contract.ts` (new) — `OperationalPostureV1` (`dpf.operational-posture/1`) carrying **summary rollups only** (severity counts, health band + estate size, coarse runtime/resource tallies) — never raw findings, hostnames, IPs, node IDs, or per-item rows. Plus a canonical sha256 digest (idempotent: `originVersion` derives from the source `updatedAt` epoch ms) and a validator that also rejects host-identifying keys as a minimization double-check.
- `apps/web/lib/federation/operational-posture-projection.ts` (new) — `buildOperationalPostureRecord`, composing the shared `projectEstatePayload` + `assertNoExcludedEgress` egress primitives; canonical side is always local.
- Contract exported via `@dpf/db` subpath + barrel (mirrors demand); tests for both modules.

## Read-only, minimal scope

No UI, no delivery/reconciliation-job wiring, no control actions. Those are later increments; **Slice 4 (acting on a peer) is stance-gated** and out of scope here.

## Tests (real)

- `@dpf/db` vitest **8/8** (digest idempotency, malformed-posture + host-field rejection, template minimization); `federated-record-sync` still 16/16 (additive).
- `web` vitest **4/4** (valid record, no excluded egress, re-projection idempotency, host-field non-leak).
- Private-identity guard passed.

## Verification note

The full `pnpm --filter web build` / package typecheck was not run locally — the sandbox is source-only, so a bare `tsc` shows only pre-existing environmental errors (Prisma client not generated), none referencing these files. That heavy gate runs in the merge queue per the tiered build-gate rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)