### PR TITLE
feat(cockpit): say how many animals are in the shelter, before anything else

### DIFF
--- a/apps/web/lib/twin/archetype-outcome-facts.test.ts
+++ b/apps/web/lib/twin/archetype-outcome-facts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   loadArchetypeOutcomeFacts,
+  summarizeAnimalsInCare,
   summarizeDonations,
 } from "./archetype-outcome-facts";
 
@@ -24,7 +25,11 @@ describe("archetype outcome facts", () => {
       runtime: rt,
     });
 
-    expect(facts).toEqual({ donationRows: null, animalsPlaced: null });
+    expect(facts).toEqual({
+      donationRows: null,
+      animalStatusRows: null,
+      animalsPlaced: null,
+    });
     expect(rt.unavailable).not.toHaveBeenCalled();
   });
 
@@ -126,5 +131,45 @@ describe("archetype outcome facts", () => {
 
   it("stays unavailable when the donation source could not be read", () => {
     expect(summarizeDonations(null, "USD")).toEqual({ totals: null });
+  });
+});
+
+describe("summarizeAnimalsInCare", () => {
+  it("counts every animal that has not left, split by the status staff act on", () => {
+    expect(
+      summarizeAnimalsInCare([
+        { status: "hold", _count: { _all: 5 } },
+        { status: "available", _count: { _all: 1 } },
+      ]),
+    ).toEqual({ total: 6, onHold: 5, available: 1, pending: 0 });
+  });
+
+  it("excludes adopted animals — they are an outcome, not a population", () => {
+    expect(
+      summarizeAnimalsInCare([
+        { status: "available", _count: { _all: 2 } },
+        { status: "adopted", _count: { _all: 9 } },
+      ]),
+    ).toEqual({ total: 2, onHold: 0, available: 2, pending: 0 });
+  });
+
+  it("counts an unrecognised status into the total rather than losing the animal", () => {
+    const summary = summarizeAnimalsInCare([
+      { status: "available", _count: { _all: 1 } },
+      { status: "quarantine", _count: { _all: 3 } },
+    ]);
+
+    expect(summary?.total).toBe(4);
+    expect(summary?.available).toBe(1);
+  });
+
+  it("reads an empty shelter as zero and an unreadable source as null", () => {
+    expect(summarizeAnimalsInCare([])).toEqual({
+      total: 0,
+      onHold: 0,
+      available: 0,
+      pending: 0,
+    });
+    expect(summarizeAnimalsInCare(null)).toBeNull();
   });
 });

--- a/apps/web/lib/twin/archetype-outcome-facts.ts
+++ b/apps/web/lib/twin/archetype-outcome-facts.ts
@@ -1,13 +1,24 @@
 import { moneyToNumber } from "./operations-format";
-import { buildArchetypeOutcomes, type DonationTotal } from "./archetype-outcomes";
+import {
+  buildArchetypeOutcomes,
+  type AnimalsInCare,
+  type DonationTotal,
+} from "./archetype-outcomes";
 
 type FindMany = (args: unknown) => Promise<unknown>;
 type Count = (args: unknown) => Promise<number>;
+type GroupBy = (args: unknown) => Promise<AnimalStatusGroup[]>;
 type Money = number | string | { toString(): string } | null;
 
 export interface ArchetypeOutcomeFactsClient {
   storefrontDonation?: { findMany: FindMany };
-  adoptableAnimal?: { count: Count };
+  adoptableAnimal?: { count: Count; groupBy?: GroupBy };
+}
+
+/** One `status` bucket from a grouped count of the storefront's animals. */
+export interface AnimalStatusGroup {
+  status: string | null;
+  _count: { _all: number };
 }
 
 interface OutcomeFactsRuntime {
@@ -22,6 +33,7 @@ interface DonationRow {
 
 export interface ArchetypeOutcomeFacts {
   donationRows: DonationRow[] | null;
+  animalStatusRows: AnimalStatusGroup[] | null;
   animalsPlaced: number | null;
 }
 
@@ -38,10 +50,10 @@ export async function loadArchetypeOutcomeFacts(input: {
   runtime: OutcomeFactsRuntime;
 }): Promise<ArchetypeOutcomeFacts> {
   if (!isRescue(input.archetypeId)) {
-    return { donationRows: null, animalsPlaced: null };
+    return { donationRows: null, animalStatusRows: null, animalsPlaced: null };
   }
 
-  const [donationRows, animalsPlaced] = await Promise.all([
+  const [donationRows, animalStatusRows, animalsPlaced] = await Promise.all([
     input.db.storefrontDonation?.findMany
       ? input.runtime.read(
           "donations",
@@ -55,6 +67,17 @@ export async function loadArchetypeOutcomeFacts(input: {
           null,
         )
       : (input.runtime.unavailable("donations"), Promise.resolve(null)),
+    input.db.adoptableAnimal?.groupBy
+      ? input.runtime.read(
+          "animals-in-care",
+          input.db.adoptableAnimal.groupBy({
+            by: ["status"],
+            where: { storefrontId: input.storefrontId },
+            _count: { _all: true },
+          }),
+          null,
+        )
+      : (input.runtime.unavailable("animals-in-care"), Promise.resolve(null)),
     input.db.adoptableAnimal?.count
       ? input.runtime.read(
           "adoptions",
@@ -70,7 +93,31 @@ export async function loadArchetypeOutcomeFacts(input: {
       : (input.runtime.unavailable("adoptions"), Promise.resolve(null)),
   ]);
 
-  return { donationRows, animalsPlaced };
+  return { donationRows, animalStatusRows, animalsPlaced };
+}
+
+/**
+ * An animal that has been adopted has left the building; counting it as
+ * population would overstate what the shelter is holding. Anything else counts
+ * toward the total — an unrecognised status must never make an animal vanish
+ * from the headline, even when its bucket has no name in the split.
+ */
+export function summarizeAnimalsInCare(
+  rows: AnimalStatusGroup[] | null,
+): AnimalsInCare | null {
+  if (rows == null) return null;
+
+  const summary: AnimalsInCare = { total: 0, onHold: 0, available: 0, pending: 0 };
+  for (const row of rows) {
+    const status = (row.status ?? "").toLowerCase();
+    if (status === "adopted") continue;
+    const count = row._count?._all ?? 0;
+    summary.total += count;
+    if (status === "hold") summary.onHold += count;
+    else if (status === "available") summary.available += count;
+    else if (status === "pending") summary.pending += count;
+  }
+  return summary;
 }
 
 /**
@@ -124,6 +171,7 @@ export function buildOutcomeProjectionFromFacts(input: {
     paidRevenue: input.paidRevenue,
     deliveredJobs: input.deliveredJobs,
     donationTotals: donations.totals,
+    animalsInCare: summarizeAnimalsInCare(input.facts.animalStatusRows),
     animalsPlaced: input.facts.animalsPlaced,
     // There is no governed foster entity yet. Preserve that fact in the UI.
     fostersActive: null,

--- a/apps/web/lib/twin/archetype-outcomes.test.ts
+++ b/apps/web/lib/twin/archetype-outcomes.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it } from "vitest";
 
 import { buildArchetypeOutcomes } from "./archetype-outcomes";
 
+/** Select by key: tile order is part of the design and changes deliberately,
+ *  so an assertion about donations should not break when a tile moves. */
+function outcome(
+  projection: ReturnType<typeof buildArchetypeOutcomes>,
+  key: string,
+) {
+  return projection.outcomes.find((entry) => entry.key === key);
+}
+
 describe("buildArchetypeOutcomes", () => {
   it("projects pet-rescue mission outcomes from canonical aggregates", () => {
     const projection = buildArchetypeOutcomes({
@@ -11,20 +20,91 @@ describe("buildArchetypeOutcomes", () => {
       paidRevenue: 900,
       deliveredJobs: 4,
       donationTotals: [{ currency: "USD", amount: 275, count: 3 }],
+      animalsInCare: { total: 6, onHold: 5, available: 1, pending: 0 },
       animalsPlaced: 2,
       fostersActive: null,
     });
 
     expect(projection.heading).toBe("Mission impact");
     expect(projection.outcomes.map((outcome) => outcome.label)).toEqual([
+      "Animals in care",
       "Donations received",
       "Animals placed",
       "Fosters active",
     ]);
-    expect(projection.outcomes[0]?.value).toContain("$275");
-    expect(projection.outcomes[1]?.value).toBe("2 animals");
-    expect(projection.outcomes[2]?.value).toBe("Unavailable");
-    expect(projection.outcomes[2]?.hint).toMatch(/no foster record source/i);
+    expect(projection.outcomes[1]?.value).toContain("$275");
+    expect(projection.outcomes[2]?.value).toBe("2 animals");
+    expect(projection.outcomes[3]?.value).toBe("Unavailable");
+    expect(projection.outcomes[3]?.hint).toMatch(/no foster record source/i);
+  });
+
+  it("leads the rescue projection with the animals actually in the shelter", () => {
+    const projection = buildArchetypeOutcomes({
+      archetypeId: "pet-rescue",
+      currency: "USD",
+      locale: "en-US",
+      paidRevenue: 0,
+      deliveredJobs: 0,
+      donationTotals: [],
+      animalsInCare: { total: 6, onHold: 5, available: 1, pending: 0 },
+      animalsPlaced: 0,
+      fostersActive: null,
+    });
+
+    const inCare = projection.outcomes[0];
+    expect(inCare?.key).toBe("animals-in-care");
+    expect(inCare?.value).toBe("6 animals");
+    expect(inCare?.hint).toBe("5 on hold · 1 available");
+  });
+
+  it("names every status present in the split, and omits the empty ones", () => {
+    const projection = buildArchetypeOutcomes({
+      archetypeId: "pet-rescue",
+      currency: "USD",
+      locale: "en-US",
+      paidRevenue: 0,
+      deliveredJobs: 0,
+      donationTotals: [],
+      animalsInCare: { total: 4, onHold: 1, available: 2, pending: 1 },
+      animalsPlaced: 0,
+      fostersActive: null,
+    });
+
+    expect(projection.outcomes[0]?.hint).toBe("1 on hold · 2 available · 1 pending");
+  });
+
+  it("reads an empty shelter as a real zero, not as a missing source", () => {
+    const projection = buildArchetypeOutcomes({
+      archetypeId: "pet-rescue",
+      currency: "USD",
+      locale: "en-US",
+      paidRevenue: 0,
+      deliveredJobs: 0,
+      donationTotals: [],
+      animalsInCare: { total: 0, onHold: 0, available: 0, pending: 0 },
+      animalsPlaced: 0,
+      fostersActive: null,
+    });
+
+    expect(projection.outcomes[0]?.value).toBe("0 animals");
+    expect(projection.outcomes[0]?.hint).toBe("None in care");
+  });
+
+  it("keeps an unreadable animal source visible rather than showing a false zero", () => {
+    const projection = buildArchetypeOutcomes({
+      archetypeId: "pet-rescue",
+      currency: "USD",
+      locale: "en-US",
+      paidRevenue: 0,
+      deliveredJobs: 0,
+      donationTotals: [],
+      animalsInCare: null,
+      animalsPlaced: null,
+      fostersActive: null,
+    });
+
+    expect(projection.outcomes[0]?.value).toBe("Unavailable");
+    expect(projection.outcomes[0]?.hint).toMatch(/animal source unavailable/i);
   });
 
   it("preserves revenue and delivered-work outcomes for other archetypes", () => {
@@ -53,7 +133,7 @@ describe("buildArchetypeOutcomes", () => {
       donationTotals: null,
     });
 
-    expect(projection.outcomes[0]).toMatchObject({
+    expect(outcome(projection, "donations-received")).toMatchObject({
       value: "Unavailable",
       hint: "Donation source unavailable",
     });
@@ -71,9 +151,9 @@ describe("buildArchetypeOutcomes", () => {
       donationTotals: [{ currency: "GBP", amount: 75, count: 2 }],
     });
 
-    expect(projection.outcomes[0]?.value).toContain("75");
-    expect(projection.outcomes[0]?.value).not.toBe("Unavailable");
-    expect(projection.outcomes[0]?.hint).toBe("2 gifts · 90 days");
+    expect(outcome(projection, "donations-received")?.value).toContain("75");
+    expect(outcome(projection, "donations-received")?.value).not.toBe("Unavailable");
+    expect(outcome(projection, "donations-received")?.hint).toBe("2 gifts · 90 days");
   });
 
   it("shows every currency when the org really holds more than one", () => {
@@ -89,11 +169,11 @@ describe("buildArchetypeOutcomes", () => {
       ],
     });
 
-    expect(projection.outcomes[0]?.value).not.toBe("Unavailable");
-    expect(projection.outcomes[0]?.value).toContain("120");
-    expect(projection.outcomes[0]?.value).toContain("75");
-    expect(projection.outcomes[0]?.hint).toMatch(/4 gifts/);
-    expect(projection.outcomes[0]?.hint).toMatch(/kept apart by currency/);
+    expect(outcome(projection, "donations-received")?.value).not.toBe("Unavailable");
+    expect(outcome(projection, "donations-received")?.value).toContain("120");
+    expect(outcome(projection, "donations-received")?.value).toContain("75");
+    expect(outcome(projection, "donations-received")?.hint).toMatch(/4 gifts/);
+    expect(outcome(projection, "donations-received")?.hint).toMatch(/kept apart by currency/);
   });
 
   it("reads zero before the first gift, not unavailable", () => {
@@ -106,7 +186,7 @@ describe("buildArchetypeOutcomes", () => {
       donationTotals: [],
     });
 
-    expect(projection.outcomes[0]?.value).toContain("0");
-    expect(projection.outcomes[0]?.hint).toBe("0 gifts · 90 days");
+    expect(outcome(projection, "donations-received")?.value).toContain("0");
+    expect(outcome(projection, "donations-received")?.hint).toBe("0 gifts · 90 days");
   });
 });

--- a/apps/web/lib/twin/archetype-outcomes.ts
+++ b/apps/web/lib/twin/archetype-outcomes.ts
@@ -9,6 +9,16 @@ export interface DonationTotal {
   count: number;
 }
 
+/** The population physically in the shelter right now, split by the status
+ *  staff act on. Adopted animals are an outcome, not a population, so they are
+ *  not counted here. */
+export interface AnimalsInCare {
+  total: number;
+  onHold: number;
+  available: number;
+  pending: number;
+}
+
 export interface ArchetypeOutcomeInput {
   archetypeId: string;
   currency: string;
@@ -18,6 +28,9 @@ export interface ArchetypeOutcomeInput {
   /** One entry per currency the gifts were recorded in. `null` means the
    *  donation source could not be read at all; `[]` means no gifts yet. */
   donationTotals?: DonationTotal[] | null;
+  /** `null` means the animal source could not be read; a zero total means an
+   *  empty shelter, which is a real and different answer. */
+  animalsInCare?: AnimalsInCare | null;
   animalsPlaced?: number | null;
   fostersActive?: number | null;
 }
@@ -80,6 +93,41 @@ function donationsOutcome(input: ArchetypeOutcomeInput): TwinOutcome {
 }
 
 /**
+ * The subject of the business leads. A rescue cockpit counted its workforce,
+ * its coworkers and its programs and never said how many animals were in the
+ * building (BI-E54F7F87) — so this is the first tile, before any money.
+ */
+function animalsInCareOutcome(inCare: AnimalsInCare | null | undefined): TwinOutcome {
+  if (inCare == null) {
+    return {
+      key: "animals-in-care",
+      label: "Animals in care",
+      value: "Unavailable",
+      intent: "info",
+      hint: "Animal source unavailable",
+    };
+  }
+
+  // Name only the statuses actually present: "5 on hold · 1 available" reads,
+  // and a row of zeroes does not.
+  const split = [
+    { count: inCare.onHold, label: "on hold" },
+    { count: inCare.available, label: "available" },
+    { count: inCare.pending, label: "pending" },
+  ]
+    .filter((part) => part.count > 0)
+    .map((part) => `${part.count} ${part.label}`);
+
+  return {
+    key: "animals-in-care",
+    label: "Animals in care",
+    value: `${inCare.total} animal${inCare.total === 1 ? "" : "s"}`,
+    intent: "info",
+    hint: split.length > 0 ? split.join(" · ") : "None in care",
+  };
+}
+
+/**
  * Project canonical aggregates into the archetype's outcome language. This is
  * intentionally a small presentation boundary, not a general metric framework:
  * each value must already have a real source, and missing sources stay visible.
@@ -91,6 +139,7 @@ export function buildArchetypeOutcomes(
     return {
       heading: "Mission impact",
       outcomes: [
+        animalsInCareOutcome(input.animalsInCare),
         donationsOutcome(input),
         {
           key: "animals-placed",

--- a/apps/web/lib/twin/living-business-snapshot.test.ts
+++ b/apps/web/lib/twin/living-business-snapshot.test.ts
@@ -409,20 +409,30 @@ describe("loadLivingBusinessSnapshot — loader", () => {
           { amount: 75, currency: "USD" },
         ],
       },
-      adoptableAnimal: { count: async () => 2 },
+      adoptableAnimal: {
+        count: async () => 2,
+        groupBy: async () => [
+          { status: "hold", _count: { _all: 3 } },
+          { status: "available", _count: { _all: 1 } },
+          { status: "adopted", _count: { _all: 2 } },
+        ],
+      },
     } as unknown as LivingBusinessClient;
 
     const snapshot = await loadLivingBusinessSnapshot({ db, now: NOW });
 
     expect(snapshot?.outcomesHeading).toBe("Mission impact");
     expect(snapshot?.outcomes?.map((outcome) => outcome.label)).toEqual([
+      "Animals in care",
       "Donations received",
       "Animals placed",
       "Fosters active",
     ]);
-    expect(snapshot?.outcomes?.[0]?.value).toContain("$275");
-    expect(snapshot?.outcomes?.[1]?.value).toBe("2 animals");
-    expect(snapshot?.outcomes?.[2]).toMatchObject({
+    expect(snapshot?.outcomes?.[0]?.value).toBe("4 animals");
+    expect(snapshot?.outcomes?.[0]?.hint).toBe("3 on hold · 1 available");
+    expect(snapshot?.outcomes?.[1]?.value).toContain("$275");
+    expect(snapshot?.outcomes?.[2]?.value).toBe("2 animals");
+    expect(snapshot?.outcomes?.[3]).toMatchObject({
       value: "Unavailable",
       hint: "No foster record source yet",
     });


### PR DESCRIPTION
## Why

Running the rescue as a business, the operator's home page counted 85 workforce, 81 AI coworkers, 12 programs, 0 open demand and 0 lapsing donors. Six animals were in the building and **the number six appeared nowhere on the page**.

The only animal-shaped figure was `ANIMALS PLACED` — a backward-looking 90-day outcome reading 0. So a page whose own header asks *"which mission commitment needs attention today?"* could not say what was in the kennels.

Measured on the live cockpit: 932 words, 58 numbers, 135 distinct labels, 4.3 screens — and a 51:5 ratio of platform/workforce vocabulary to the word "animal".

## What changed

Mission impact now leads with the population, before any money:

> **Animals in care** — `6 animals` · *5 on hold · 1 available*

The split names only the statuses actually present, because a row of zeroes does not read.

Three distinctions the projection keeps deliberately:

- **An adopted animal has left the building** and is not counted as population. It stays in *Animals placed*, where it belongs.
- **An empty shelter and an unreadable source are different answers.** `0 animals · None in care` versus `Unavailable`. This follows the honesty principle the neighbouring tiles already hold — the donation tile totals what it has, and `/performance` refuses to invent what it hasn't computed.
- **An unrecognised status still counts toward the total.** A future status must never make an animal vanish from the headline, even before it has a name in the split.

## Scope

Sourced from a grouped count of the storefront's own animal rows: **no migration, and no dependency on subject identity (BI-4F8A484C)**. That is what made it shippable now rather than after the keystone.

The richer figures the ward needs — kennels free, meds due, hold clocks — genuinely do wait on that work and are deliberately absent here. Filed as `BI-FB73D0B5`.

Donation assertions in the existing tests now select by outcome key rather than array index, since tile order is part of the design and will change again.

## Verification

- **181 tests pass** across 31 files in `apps/web/lib/twin`, including the new in-care projection cases, the summarizer's adopted-exclusion and unknown-status behaviour, both fail-safe paths, and an updated end-to-end snapshot case with a real `groupBy` source
- `pregate:preflight` — **63 guards clean** on the rebased head
- `tsc --noEmit` clean; style-drift guard clean

**The exact-tree local-CI gate could not be reached**, and this is stated rather than claimed as passing. Two attempts on the shared single-slot `local-integration-ci` returned INCONCLUSIVE, classified by the gate itself: first `blocked_control_plane_starvation` — *"the lease was fenced before the run finished. This is infrastructure evidence, NOT a product build failure"* — then queued at position 5 — *"the gate did not run. This is not a failure of the diff."* No FAIL is recorded against any SHA of this branch. The cloud merge queue is the enforcing heavy-build gate here, per the §4 tiering.

Closes BI-E54F7F87. Workroom WC-4D69939F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)