### PR TITLE
fix(scheduling): every scheduled job records why it exists (BI-5087F34F)

### DIFF
--- a/apps/web/lib/mcp/packs/scheduled-agent-task-pack.test.ts
+++ b/apps/web/lib/mcp/packs/scheduled-agent-task-pack.test.ts
@@ -85,7 +85,52 @@ describe("scheduled-agent-task pack — handler behavior (delegation preserved)"
       routeContext: "/platform",
       schedule: "0 9 * * *",
       timezone: undefined,
+      // BI-5087F34F: every job records WHY it exists. A caller that names no
+      // trigger still gets one — "time" is what a cron-created job IS.
+      taskConfig: { trigger: expect.objectContaining({ kind: "time" }) },
     });
+  });
+
+  // The record is unconditional precisely because it used to be optional: of 53
+  // live tasks only 13 carried a trigger, and none of the 12 ACTIVE ones did.
+  it("records a trigger even when the caller supplies none", async () => {
+    core.scheduleAgentTaskFor.mockResolvedValue({ success: true, taskId: "agent-task-1" });
+    await scheduledAgentTaskPack.handlers.create_scheduled_agent_task(
+      { agentId: "a", title: "t", prompt: "p", schedule: "0 9 * * *" },
+      "u1",
+    );
+    const trigger = core.scheduleAgentTaskFor.mock.calls[0][1].taskConfig.trigger;
+    expect(trigger.kind).toBe("time");
+    expect(typeof trigger.recordedAt).toBe("string");
+    // Absent facts stay absent — a default kind must not invent a room or a deadline.
+    expect(trigger.workroomId).toBeUndefined();
+    expect(trigger.obligation).toBeUndefined();
+  });
+
+  it("preserves a caller's own trigger, room and obligation", async () => {
+    const futureDueAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    core.scheduleAgentTaskFor.mockResolvedValue({ success: true, taskId: "agent-task-2" });
+    await scheduledAgentTaskPack.handlers.create_scheduled_agent_task(
+      {
+        agentId: "a",
+        title: "t",
+        prompt: "p",
+        schedule: "0 9 * * *",
+        trigger: {
+          kind: "detected-need",
+          workroomId: "WC-1",
+          // Relative, not absolute: this asserts PASS-THROUGH, so the instant is
+          // irrelevant — but a hardcoded future date silently becomes a past one
+          // and starts testing something else.
+          obligation: { dueAt: futureDueAt, label: "Q3 filing" },
+        },
+      },
+      "u1",
+    );
+    const trigger = core.scheduleAgentTaskFor.mock.calls[0][1].taskConfig.trigger;
+    expect(trigger.kind).toBe("detected-need");
+    expect(trigger.workroomId).toBe("WC-1");
+    expect(trigger.obligation.dueAt).toBe(futureDueAt);
   });
 
   it("create_scheduled_agent_task appends a de-confliction note and honors a supplied routeContext", async () => {
@@ -129,7 +174,12 @@ describe("scheduled-agent-task pack — handler behavior (delegation preserved)"
         organizationId: "org-1",
         businessProductId: "product-1",
         taskKind: "product-management-playbook",
-        taskConfig,
+        // The typed playbook config is preserved verbatim; the trigger is merged
+        // alongside it rather than replacing it.
+        taskConfig: expect.objectContaining({
+          ...taskConfig,
+          trigger: expect.objectContaining({ kind: "time" }),
+        }),
       }),
     );
   });

--- a/apps/web/lib/mcp/packs/scheduled-agent-task-pack.ts
+++ b/apps/web/lib/mcp/packs/scheduled-agent-task-pack.ts
@@ -50,7 +50,7 @@ const definitions: ToolDefinition[] = [
         },
         trigger: {
           type: "object",
-          description: "WHY this job exists, so immediacy is judgeable at fire time (BI-5087F34F).",
+          description: "WHY this job exists, so immediacy is judgeable at fire time (BI-5087F34F). Recorded either way — omit it and the job records kind 'time'. Supply workroomId to have the room's posture govern this job's pace at fire time.",
           properties: {
             kind: { type: "string", enum: [...SCHEDULED_WORK_TRIGGER_KINDS], description: "Trigger source." },
             workroomId: { type: "string", description: "Room this job serves, if any." },
@@ -177,19 +177,28 @@ async function createScheduledAgentTaskHandler(
     && !Array.isArray(triggerParam.obligation)
       ? (triggerParam.obligation as Record<string, unknown>)
       : null;
-  const taskConfig = triggerParam
-    ? withScheduledWorkTrigger(baseTaskConfig, {
-        kind: triggerParam.kind as ScheduledWorkTriggerKind,
-        workroomId: typeof triggerParam.workroomId === "string" ? triggerParam.workroomId : null,
-        obligation:
-          typeof obligationParam?.dueAt === "string"
-            ? {
-                dueAt: obligationParam.dueAt,
-                label: typeof obligationParam.label === "string" ? obligationParam.label : null,
-              }
-            : null,
-      })
-    : baseTaskConfig;
+  // BI-5087F34F set out to record WHY a job exists, not just when. Recording it
+  // only when a caller opted in left most tasks with no answer: of 53 live tasks
+  // 13 carried a trigger, and none of the 12 ACTIVE ones did. An optional
+  // provenance record is one most callers never supply.
+  //
+  // So the record is now unconditional. "time" is the honest default for a job
+  // created on a cron with no stated cause — it is what a scheduled job IS, not
+  // a guess about intent. A caller that knows better still supplies its own kind,
+  // the room it serves, and the obligation it races; nothing about that path
+  // changes. What changes is that "why does this job exist" now always has an
+  // answer, which is what the posture ladder reads at fire time.
+  const taskConfig = withScheduledWorkTrigger(baseTaskConfig, {
+    kind: (triggerParam?.kind as ScheduledWorkTriggerKind | undefined) ?? "time",
+    workroomId: typeof triggerParam?.workroomId === "string" ? triggerParam.workroomId : null,
+    obligation:
+      typeof obligationParam?.dueAt === "string"
+        ? {
+            dueAt: obligationParam.dueAt,
+            label: typeof obligationParam.label === "string" ? obligationParam.label : null,
+          }
+        : null,
+  });
   const result = await scheduleAgentTaskFor(userId, {
     agentId: String(params.agentId ?? ""),
     title: String(params.title ?? ""),


### PR DESCRIPTION
Closes the input half of `BI-5087F34F`. Pairs with [#4958](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/4958), which built the read half.

## The gap

`BI-5087F34F` set out to record **why** a job exists, not just when. It built the record correctly, tested it, and made it **optional** — merged into `taskConfig` only when a caller passed a `trigger` param.

An optional provenance record is one most callers never supply. Measured on the live install before changing anything:

| | count |
|---|---|
| scheduled tasks | 53 |
| carrying a trigger | 13 |
| **active** | **12** |
| **active AND carrying a trigger** | **0** |

So at fire time the platform could not answer "why does this job exist" for **any job actually running** — precisely the gap the item was filed to close.

## The change

The record is now unconditional. `"time"` is the honest default for a job created on a cron with no stated cause: it is what a scheduled job *is*, not a guess about intent.

**Defaulting the kind must never invent a fact.** `workroomId` and `obligation` stay unset unless the caller supplies them — a default reason must not fabricate a room to serve or a deadline to race. A caller that knows better still passes its own kind, room and obligation; that path is unchanged.

The trigger is merged **alongside** a caller's `taskConfig` rather than replacing it, asserted explicitly on the product-management playbook path that carries a permissions digest.

## Why this matters beyond provenance

The trigger is what the posture ladder reads at fire time (#4958): a job naming a room resolves its pace through that room, and an obligation outranks the room's own due date. With the record optional, that seam could only ever fire for the minority of tasks whose author opted in. This is the input half of the same loop.

## Verification

- 3526 tests across mcp, scheduling, actions, operate.
- Typecheck clean (0 TS errors); production build exits 0; 62 preflight guards clean.
- Local-CI gate **PASS** @ `533d62d3543d`, evidence `cmtjl33rw33cu01qgrfq2bfuu`.

**UX verification: not applicable.** No route, rendered surface or operator control changes. The MCP tool's `trigger` description is updated to state that the record is written either way and that supplying `workroomId` is what makes the room's posture govern the job.

## Notes for the reviewer

**A guard caught a defect in my own test.** The obligation fixture originally hardcoded an absolute future date, which would silently start testing something else once that date passed. The Test Clock Bomb Guard flagged it; the fixture is now relative, since the assertion is about pass-through and the instant is irrelevant.

**Guard environment.** The worktree probes SOURCE-ONLY because `package.json` classifies only `@scarf/scarf`, leaving `puppeteer`/`unrs-resolver`/`protobufjs` unclassified — reproduced identically in the root clone, so pre-existing repo state rather than anything here. Filed as `BI-4D0FCF3A`. The compile-ready probe was skipped with a recorded reason; all 62 guards still ran on this exact tree.

## Design grounding

- **Specs/plans reviewed:** `2026-08-22-workroom-work-posture-design.md` §3.1 and §5.1 — the trigger taxonomy is the value-stream design's four sources, not a fifth vocabulary invented here; `2026-08-22-work-posture-implementation-plan.md`, which records the read half and its measured reach.
- **Code substrate reviewed:** `scheduled-work-trigger.ts` (`withScheduledWorkTrigger` already merges into `taskConfig` preserving every other key, so making the call unconditional needed no change to the writer); `mcp/packs/scheduled-agent-task-pack.ts` (the sole create path, where the record was gated behind an optional param); `scheduling/scheduled-work-posture.server.ts` (the reader this feeds, so the default kind had to stay honest).
- **Source of truth:** the trigger record on `taskConfig`. One carrier, one writer, one reader.
- **Decision:** make the existing record unconditional rather than add a column or a second provenance store. No migration — a task with no trigger still reads as none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
