### PR TITLE
fix(nonprod): a capacity reservation requires proof of life

### DIFF
--- a/apps/web/lib/nonprod/environment-lease-registry.test.ts
+++ b/apps/web/lib/nonprod/environment-lease-registry.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  leaseStillProvesLiveness,
+  listCapacityReservingNonprodEnvironmentLeases,
+} from "./environment-lease-registry";
+
+const NOW = new Date("2026-09-02T04:19:07.000Z");
+const at = (iso: string) => new Date(iso);
+
+// BI-DC9CA20D. Measured on the live install 2026-09-02 at 04:19: six queued
+// local-CI leases, ZERO active, every one with heartbeatAt EXACTLY equal to
+// queuedAt — not one renewal — and staleness from 10 to 53 minutes. Their
+// owning sessions were gone, so nothing was left to admit them, and they were
+// set to occupy the queue for two hours against a declared TTL of ~2 minutes.
+//
+// local-provider-capacity defers local inference whenever any lease reserves
+// the host, and dead rows arrived roughly every 7 minutes against a 2-hour
+// decay. The queue therefore could never empty: a permanent outage of the
+// platform's own AI, and the reason governed reviewer dispatches were starved.
+const DEAD_WAITERS = [
+  { leaseId: "NPEL-0BFCE35A0D", queuedAt: at("2026-09-02T03:25:59.000Z") },
+  { leaseId: "NPEL-9742BE705D", queuedAt: at("2026-09-02T03:26:12.000Z") },
+  { leaseId: "NPEL-088F40091E", queuedAt: at("2026-09-02T03:44:53.000Z") },
+  { leaseId: "NPEL-E42846763F", queuedAt: at("2026-09-02T03:47:28.000Z") },
+  { leaseId: "NPEL-5FF6215312", queuedAt: at("2026-09-02T04:06:06.000Z") },
+  { leaseId: "NPEL-19CB8E7052", queuedAt: at("2026-09-02T04:08:55.000Z") },
+].map((row) => ({
+  ...row,
+  status: "queued" as const,
+  // The signature: heartbeat never advanced past the moment it was queued.
+  heartbeatAt: row.queuedAt,
+  requestedTtlMs: 118_662,
+  // Two hours out, 60x the declared TTL — which is why expiry alone never freed the host.
+  expiresAt: new Date(row.queuedAt.getTime() + 2 * 60 * 60 * 1000),
+}));
+
+function dbReturning(rows: unknown[]) {
+  return {
+    nonProductionEnvironmentLease: {
+      findMany: async () => rows,
+    },
+  } as never;
+}
+
+describe("a capacity reservation is only as good as its last proof of life (BI-DC9CA20D)", () => {
+  it("stops the six measured dead waiters from reserving the host", async () => {
+    const reserving = await listCapacityReservingNonprodEnvironmentLeases({
+      db: dbReturning(DEAD_WAITERS),
+      now: NOW,
+    });
+    // Before this fix all six reserved the host for two hours apiece, and
+    // local inference was deferred the entire time.
+    expect(reserving).toEqual([]);
+  });
+
+  it("keeps a live waiter reserving, so a slow queue is never robbed of its slot", async () => {
+    const live = {
+      leaseId: "NPEL-LIVE",
+      status: "queued" as const,
+      queuedAt: at("2026-09-02T03:25:59.000Z"),
+      // Renewed 40s ago — this is what a live waiter looks like.
+      heartbeatAt: new Date(NOW.getTime() - 40_000),
+      requestedTtlMs: 118_662,
+      expiresAt: new Date(NOW.getTime() + 60_000),
+    };
+    const reserving = await listCapacityReservingNonprodEnvironmentLeases({
+      db: dbReturning([live, ...DEAD_WAITERS]),
+      now: NOW,
+    });
+    expect(reserving.map((row) => (row as { leaseId: string }).leaseId)).toEqual(["NPEL-LIVE"]);
+  });
+
+  it("keeps an ACTIVE lease reserving while it heartbeats", async () => {
+    // The running gate genuinely owns the host; nothing here may evict it.
+    const active = {
+      leaseId: "NPEL-ACTIVE",
+      status: "active" as const,
+      queuedAt: at("2026-09-02T03:00:00.000Z"),
+      heartbeatAt: new Date(NOW.getTime() - 30_000),
+      requestedTtlMs: 120_000,
+      expiresAt: new Date(NOW.getTime() + 90_000),
+    };
+    const reserving = await listCapacityReservingNonprodEnvironmentLeases({
+      db: dbReturning([active]),
+      now: NOW,
+    });
+    expect(reserving).toHaveLength(1);
+  });
+
+  it("does not reap a row that was only just written and has not had time to renew", () => {
+    expect(leaseStillProvesLiveness(
+      { queuedAt: NOW, heartbeatAt: null, requestedTtlMs: 118_662 },
+      NOW,
+    )).toBe(true);
+  });
+
+  it("allows three missed renewals before disbelieving a lease", () => {
+    const ttl = 60_000;
+    const beatsAgo = (ms: number) => ({ heartbeatAt: new Date(NOW.getTime() - ms), requestedTtlMs: ttl });
+    // Grace is deliberate: a genuinely slow host must not lose its reservation.
+    expect(leaseStillProvesLiveness(beatsAgo(2 * ttl), NOW)).toBe(true);
+    expect(leaseStillProvesLiveness(beatsAgo(3 * ttl - 1), NOW)).toBe(true);
+    expect(leaseStillProvesLiveness(beatsAgo(3 * ttl + 1), NOW)).toBe(false);
+  });
+
+  it("floors the liveness window so an implausibly short TTL cannot self-reap", () => {
+    // A lease declaring a 1s TTL would otherwise be disbelieved 3s later.
+    expect(leaseStillProvesLiveness(
+      { heartbeatAt: new Date(NOW.getTime() - 60_000), requestedTtlMs: 1_000 },
+      NOW,
+    )).toBe(true);
+  });
+
+  it("treats a lease with no timestamps at all as unproven", () => {
+    expect(leaseStillProvesLiveness({}, NOW)).toBe(false);
+  });
+});

--- a/apps/web/lib/nonprod/environment-lease-registry.ts
+++ b/apps/web/lib/nonprod/environment-lease-registry.ts
@@ -26,18 +26,82 @@ export async function listQueuedNonprodEnvironmentLeases(input: {
   });
 }
 
-/** One snapshot for host-capacity arbitration across active and queued work. */
+/**
+ * Grace over a lease's OWN declared TTL before we stop believing it is alive.
+ *
+ * A live waiter renews its heartbeat within its TTL — that is what the TTL is
+ * for. Three missed renewals is not a slow host, it is a dead owner.
+ */
+const LIVENESS_GRACE_FACTOR = 3;
+
+/** Floor for the liveness window, for a lease that declared an implausibly short TTL. */
+const MIN_LIVENESS_WINDOW_MS = 120_000;
+
+export type CapacityReservingLease = {
+  heartbeatAt?: Date | null;
+  queuedAt?: Date | null;
+  createdAt?: Date | null;
+  requestedTtlMs?: number | null;
+};
+
+/**
+ * Does this lease still PROVE it is alive, or is it only still present?
+ *
+ * BI-DC9CA20D. Host-capacity arbitration used to count any row whose
+ * `expiresAt` was in the future, which treats presence as liveness. Measured on
+ * the live install 2026-09-02: six queued local-CI leases, ZERO active, every
+ * one with `heartbeatAt` exactly equal to `queuedAt` — not a single renewal —
+ * and staleness from 10 to 53 minutes. They were dead waiters whose sessions
+ * had gone, and nothing was left to admit them.
+ *
+ * Because `local-provider-capacity` defers local inference whenever ANY lease
+ * reserves the host, and because dead rows arrived (~1 per 7 min) far faster
+ * than they expired, the queue could never empty: a permanent outage of the
+ * platform's own AI, which is exactly the failure `contendsForInference`
+ * already warns about for the preview case.
+ *
+ * The platform already holds this rule elsewhere and states it plainly —
+ * Workroom liveness is "derived from lease/build/sync — never updatedAt". This
+ * applies the same standard to host capacity: a reservation is only as good as
+ * its last proof of life.
+ */
+export function leaseStillProvesLiveness(
+  lease: CapacityReservingLease,
+  now: Date,
+): boolean {
+  const declaredTtlMs = typeof lease.requestedTtlMs === "number"
+    && Number.isFinite(lease.requestedTtlMs)
+    && lease.requestedTtlMs > 0
+    ? lease.requestedTtlMs
+    : MIN_LIVENESS_WINDOW_MS;
+  const windowMs = Math.max(declaredTtlMs * LIVENESS_GRACE_FACTOR, MIN_LIVENESS_WINDOW_MS);
+  // queuedAt/createdAt are the implicit first beat: a row that has only just
+  // been written has not had a chance to renew yet and must not be reaped.
+  const lastBeat = lease.heartbeatAt ?? lease.queuedAt ?? lease.createdAt ?? null;
+  if (!lastBeat) return false;
+  return now.getTime() - lastBeat.getTime() <= windowMs;
+}
+
+/**
+ * One snapshot for host-capacity arbitration across active and queued work.
+ *
+ * Only leases that still prove liveness reserve the host. A row that stopped
+ * heartbeating stops reserving — see `leaseStillProvesLiveness`. This narrows
+ * what counts as a reservation; it never widens it, so it cannot admit work
+ * that arbitration would previously have refused.
+ */
 export async function listCapacityReservingNonprodEnvironmentLeases(input: {
   db?: LeaseDb;
   now?: Date;
 }) {
   const db = input.db ?? prisma;
   const now = input.now ?? new Date();
-  return db.nonProductionEnvironmentLease.findMany({
+  const rows = await db.nonProductionEnvironmentLease.findMany({
     where: {
       status: { in: ["active", "queued"] },
       expiresAt: { gt: now },
     },
     orderBy: [{ queuedAt: "asc" }, { id: "asc" }],
   });
+  return rows.filter((row) => leaseStillProvesLiveness(row, now));
 }

--- a/docs/superpowers/specs/2026-09-02-capacity-reservation-requires-proof-of-life-design.md
+++ b/docs/superpowers/specs/2026-09-02-capacity-reservation-requires-proof-of-life-design.md
@@ -1,0 +1,124 @@
+---
+status: active
+title: A capacity reservation is only as good as its last proof of life
+---
+
+# A Capacity Reservation Is Only As Good As Its Last Proof of Life
+
+- **Date:** 2026-09-02
+- **Scope:** platform — nonproduction environment lease registry, local provider capacity arbitration
+- **Backlog item:** `BI-DC9CA20D`
+- **Status:** Design — implemented in this branch.
+
+> Six dead rows in a queue took the platform's own AI offline, and nothing about the
+> system could tell that they were dead — because nothing ever asked.
+
+---
+
+## 1. What was measured
+
+Live install, 2026-09-02 at 04:19. Not inferred.
+
+```
+leases:  []            ← nothing held the slot
+queued:  [6 entries]   ← waiting 10 to 53 minutes
+```
+
+| lease | heartbeat advance | stale for | declared TTL | occupies until |
+| --- | --- | --- | --- | --- |
+| NPEL-0BFCE35A0D | **0s** | 53m | ~2m | +2h |
+| NPEL-9742BE705D | **0s** | 53m | ~2m | +2h |
+| NPEL-088F40091E | **0s** | 34m | ~2m | +2h |
+| NPEL-E42846763F | **0s** | 32m | ~2m | +2h |
+| NPEL-5FF6215312 | **0s** | 13m | ~2m | +2h |
+| NPEL-19CB8E7052 | **0s** | 10m | ~2m | +2h |
+
+**Not one heartbeat had ever advanced.** `heartbeatAt` equalled `queuedAt` exactly, on every row.
+A live waiter renews while it waits — a successful lease earlier the same day showed `heartbeatAt`
+23 minutes ahead of its `queuedAt`. These six queued once, their sessions died, and no process
+remained to be admitted.
+
+### 1.1 Why this became permanent rather than transient
+
+Three facts compose into an outage that cannot self-heal:
+
+1. `listCapacityReservingNonprodEnvironmentLeases` counted any row with `status IN (active, queued)`
+   and `expiresAt > now`. **Presence was treated as liveness.** The heartbeat was never consulted.
+2. `local-provider-capacity` defers local inference whenever *any* lease reserves the host. One dead
+   row is enough.
+3. Dead rows arrived roughly **every 7 minutes** and decayed over **2 hours**. Arrivals outpaced
+   decay by ~17×, so the queue could never empty.
+
+The result is a permanent outage of the platform's own AI. `contendsForInference` in
+`local-provider-capacity.ts` already documents this exact failure for the preview case — its comment
+records that *"a permanently non-empty queue became a permanent outage of the platform's own AI"*.
+The same shape reached inference through a different door.
+
+### 1.2 The declared TTL was not what the row cost
+
+Every row stored `requestedTtlMs ≈ 118,700` — about two minutes — while `expiresAt` sat **two hours**
+after `queuedAt`, roughly 60× the declared TTL. So expiry alone could never have been a timely
+reaper, whatever the waiter asked for. This is recorded as an observation; §4 does not depend on it.
+
+---
+
+## 2. Research & benchmarking
+
+The question is narrow: **what evidence entitles a claimant to keep holding a shared resource?**
+
+- **Kubernetes node leases.** A node holds its lease by renewing it; the control plane marks it
+  `NotReady` on renewal failure, not on the object disappearing. Presence never implies health.
+  **Adopted:** a reservation is believed only while it is being renewed.
+- **Consul / etcd session TTLs.** A session is invalidated when its TTL lapses without renewal, and
+  everything it held is released. **Adopted in spirit**, with one deliberate difference: this change
+  does not delete rows, it stops *counting* them. Reaping is a separate concern with its own risk.
+- **The platform's own Workroom liveness rule.** `loadCapsuleLivenessInventory` states it outright —
+  liveness is *"derived from lease/build/sync — never updatedAt (a daily-heartbeat artifact)"*.
+  **Adopted wholesale.** The platform already knew this; host capacity was simply never held to it.
+
+**Rejected: reaping the dead rows.** Deleting another session's lease is destructive, races with a
+waiter that might still be alive, and would need its own safety argument. Narrowing what *counts*
+achieves the outcome with no destructive action and no possibility of losing work.
+
+---
+
+## 3. Decision
+
+**A lease reserves the host only while it proves it is alive.**
+
+The rule narrows what counts as a reservation. It can never widen it, so it cannot admit work that
+arbitration would previously have refused.
+
+---
+
+## 4. What was built
+
+`leaseStillProvesLiveness(lease, now)` — a lease is believed while its last beat is within
+`max(requestedTtlMs × 3, 120s)`.
+
+- **Three missed renewals**, not one. A live waiter renews within its own TTL by definition; three
+  misses is a dead owner, not a slow host. The grace is deliberate — a genuinely slow gate must
+  never lose its slot.
+- **A floor of 120s**, so a lease declaring an implausibly short TTL cannot self-reap seconds later.
+- **`queuedAt` / `createdAt` are the implicit first beat**, so a row written moments ago is never
+  judged before it has had a chance to renew.
+
+`listCapacityReservingNonprodEnvironmentLeases` filters its result through it. Nothing else changes:
+admission, queue ordering and the leases themselves are untouched.
+
+### 4.1 Regression guards, verified to fail without the fix
+
+Removing the filter turns two of the seven red. The suite is built from the **measured** rows — the
+six real lease ids, their real timestamps, the real 2-minute-TTL-versus-2-hour-expiry pair — so it
+reproduces the actual outage rather than an invented one. It also pins the directions that must not
+regress: a live waiter keeps its reservation, an active lease is never evicted, a just-written row is
+not reaped, and the grace boundary holds at exactly three TTLs.
+
+---
+
+## 5. What this does not do
+
+It does not delete the dead rows; they age out on their own and stop mattering the moment they stop
+being counted. It does not change admission, so a queue that was draining still drains the same way.
+And it does not address the TTL/expiry mismatch in §1.2 — that is a real oddity, recorded for its own
+decision, and this fix deliberately does not depend on it being resolved.


### PR DESCRIPTION
Six dead rows in a queue took the platform's own AI offline, and nothing could tell they were dead — because nothing ever asked.

Closes `BI-DC9CA20D`. Design: [`docs/superpowers/specs/2026-09-02-capacity-reservation-requires-proof-of-life-design.md`](docs/superpowers/specs/2026-09-02-capacity-reservation-requires-proof-of-life-design.md).

## Measured on the live install, 04:19 today

```
leases:  []            ← nothing held the slot
queued:  [6 entries]   ← waiting 10 to 53 minutes
```

| lease | heartbeat advance | stale for | declared TTL | occupies until |
| --- | --- | --- | --- | --- |
| NPEL-0BFCE35A0D | **0s** | 53m | ~2m | +2h |
| NPEL-9742BE705D | **0s** | 53m | ~2m | +2h |
| NPEL-088F40091E | **0s** | 34m | ~2m | +2h |
| NPEL-E42846763F | **0s** | 32m | ~2m | +2h |
| NPEL-5FF6215312 | **0s** | 13m | ~2m | +2h |
| NPEL-19CB8E7052 | **0s** | 10m | ~2m | +2h |

**Not one heartbeat had ever advanced** — `heartbeatAt` equalled `queuedAt` exactly on every row. A live waiter renews while it waits; a successful lease earlier the same day showed `heartbeatAt` 23 minutes ahead of its `queuedAt`. These six queued once, their sessions died, and nothing remained to be admitted.

## Why it could never self-heal

1. `listCapacityReservingNonprodEnvironmentLeases` counted any row with `status IN (active, queued)` and `expiresAt > now`. **Presence was treated as liveness.** The heartbeat was never consulted.
2. `local-provider-capacity` defers local inference whenever *any* lease reserves the host — one dead row is enough.
3. Dead rows arrived roughly **every 7 minutes** and decayed over **2 hours**, outpacing decay ~17×.

The queue could therefore never empty: a permanent outage of the platform's own AI. `contendsForInference` already documents this exact failure for the preview case; it reached inference through a different door. This is why governed reviewer dispatches were being starved.

## The fix

**A lease reserves the host only while it proves it is alive.**

`leaseStillProvesLiveness` believes a lease while its last beat is within `max(requestedTtlMs × 3, 120s)`:

- **Three missed renewals, not one** — a genuinely slow gate must never lose its slot.
- **A 120s floor**, so an implausibly short declared TTL cannot self-reap.
- **`queuedAt`/`createdAt` count as the implicit first beat**, so a just-written row is never judged before it can renew.

The platform already holds this rule and states it plainly — Workroom liveness is *"derived from lease/build/sync — never updatedAt"*. Host capacity was simply never held to the same standard.

The rule only **narrows** what counts as a reservation, so it cannot admit work arbitration would previously have refused. Admission, queue ordering and the leases themselves are untouched.

**Deliberately not reaping the dead rows.** Deleting another session's lease is destructive and races with a waiter that might still be alive. Not counting them achieves the outcome with no destructive action and no possibility of losing work.

## Also observed, recorded but not relied on

Every row stored `requestedTtlMs ≈ 2 minutes` while `expiresAt` sat **2 hours** out — ~60× the declared TTL. So expiry alone was never going to be a timely reaper. That is a separate oddity; this fix does not depend on it being resolved.

## Verified

| check | result |
| --- | --- |
| `pregate-preflight` | **OK — 63 guards clean in 101s** |
| `tsc --noEmit` | clean |
| tests | **148 pass** across `lib/nonprod`, local provider capacity, `lib/change-review` |
| regression guards | 2 of 7 confirmed red with the fix removed |

Guards are built from the **measured** rows — real lease ids, real timestamps, the real TTL/expiry pair — so they reproduce the actual outage rather than an invented one.

**Not verified locally — CI adjudicates.** The local-CI sandbox gate cannot run for this branch: six dead waiters hold the queue, which is precisely what this PR fixes, and `BI-A7EAB5AA` separately wedges the gate key on this host. Pushed under a recorded operator override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
