### PR TITLE
fix(local-ci): retry a renewal we never got an answer to (BI-ECAE03F7)

### DIFF
--- a/scripts/ci-policy-test-inventory-allowlist.txt
+++ b/scripts/ci-policy-test-inventory-allowlist.txt
@@ -83,7 +83,6 @@ scripts/lib/docker-entrypoint-source-volume.test.mjs
 scripts/lib/dockerfile-portal-build.test.mjs
 scripts/lib/git-fetch-shared-safe.test.mjs
 scripts/lib/govern-capability-compose-args.test.mjs
-scripts/lib/lease-supervisor.test.mjs
 scripts/lib/lifecycle-capability-profile-contract.test.mjs
 scripts/lib/load-pinned-guard-typescript.test.mjs
 scripts/lib/local-ci-base-freshness.test.mjs

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -505,6 +505,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/lib/root-clone-refresh.test.mjs",
         "scripts/lib/compose-safety.test.mjs",
         "scripts/lib/local-integration-ci.test.mjs",
+        // BI-ECAE03F7: the supervisor that fences a long gate run was
+        // allowlisted OUT of CI, so nothing enforced its behaviour while it
+        // destroyed run after run. The allowlist is shrink-only and its own
+        // header prefers inventory listing; this is that move.
+        "scripts/lib/lease-supervisor.test.mjs",
         "scripts/lib/local-convergence-lock.test.mjs",
         "scripts/lib/sandbox-freshness.test.mjs",
         "scripts/sandbox-freshness-preflight.test.mjs",

--- a/scripts/lib/lease-supervisor.mjs
+++ b/scripts/lib/lease-supervisor.mjs
@@ -12,6 +12,28 @@ export function authoritySafetyMarginMs(ttlMs) {
   return Math.min(5_000, Math.max(1, Math.floor(ttlMs / 10)));
 }
 
+/**
+ * How long to wait before retrying a renewal whose outcome we never learned.
+ *
+ * A renewal that THROWS proves nothing: the lease service was unreachable, not
+ * lost. Waiting a full heartbeat interval to find out spends a third of the
+ * authority budget on a transport hiccup. At a 120s TTL the deadline fires 115s
+ * after the last good renewal and heartbeats land at +40s and +80s, so two slow
+ * renewals in a row killed the run -- and they are slow precisely when the run
+ * itself is saturating the host (BI-ECAE03F7).
+ *
+ * The backoff starts at a fortieth of the interval and doubles, capped at the
+ * interval itself. At a 40s interval that is 1s, 2s, 4s, 8s, 16s, 32s: six
+ * further chances inside the same budget that previously allowed one, without
+ * hammering a service that is already struggling.
+ */
+export function uncertainRetryDelayMs(ttlMs, attempt) {
+  const intervalMs = heartbeatIntervalMs(ttlMs);
+  const base = Math.max(1, Math.floor(intervalMs / 40));
+  const exponent = Math.min(Math.max(1, attempt) - 1, 5);
+  return Math.min(intervalMs, base * 2 ** exponent);
+}
+
 function parsedExpiryMs(value) {
   const parsed = typeof value === "string" ? Date.parse(value) : Number(value);
   return Number.isFinite(parsed) ? parsed : null;
@@ -36,6 +58,8 @@ export async function superviseLeaseRun({
   cancelSchedule = (timer) => clearInterval(timer),
   scheduleDeadline = (callback, delayMs) => setTimeout(callback, delayMs),
   cancelDeadline = (timer) => clearTimeout(timer),
+  scheduleRetry = (callback, delayMs) => setTimeout(callback, delayMs),
+  cancelRetry = (timer) => clearTimeout(timer),
   now = () => Date.now(),
   safetyMarginMs = authoritySafetyMarginMs(ttlMs),
   onEvent = () => {},
@@ -45,6 +69,8 @@ export async function superviseLeaseRun({
   let heartbeatInFlight = null;
   let deadlineInFlight = null;
   let deadlineTimer = null;
+  let retryTimer = null;
+  let uncertainStreak = 0;
   let knownExpiryMs = parsedExpiryMs(expiresAt) ?? now() + ttlMs;
 
   onEvent({ type: "started", at: startedAt });
@@ -84,6 +110,28 @@ export async function superviseLeaseRun({
 
   armAuthorityDeadline();
 
+  const cancelRetryTimer = () => {
+    if (retryTimer === null) return;
+    cancelRetry(retryTimer);
+    retryTimer = null;
+  };
+
+  const scheduleUncertainRetry = () => {
+    if (fencedReason) return;
+    cancelRetryTimer();
+    const delayMs = uncertainRetryDelayMs(ttlMs, uncertainStreak);
+    onEvent({
+      type: "heartbeat-retry-scheduled",
+      at: new Date().toISOString(),
+      delayMs,
+      attempt: uncertainStreak,
+    });
+    retryTimer = scheduleRetry(() => {
+      retryTimer = null;
+      return heartbeat();
+    }, delayMs);
+  };
+
   const heartbeat = async () => {
     if (fencedReason || heartbeatInFlight) return heartbeatInFlight;
     heartbeatInFlight = (async () => {
@@ -91,15 +139,22 @@ export async function superviseLeaseRun({
       try {
         response = await renew();
       } catch (error) {
+        // Unreachable, not lost. Retry soon instead of surrendering a third of
+        // the authority budget to a transport hiccup (BI-ECAE03F7).
+        uncertainStreak += 1;
         onEvent({
           type: "heartbeat-uncertain",
           at: new Date().toISOString(),
           reason: error?.message || String(error),
           expiresAt: new Date(knownExpiryMs).toISOString(),
+          attempt: uncertainStreak,
         });
+        scheduleUncertainRetry();
         return;
       }
       if (response?.success === true) {
+        uncertainStreak = 0;
+        cancelRetryTimer();
         knownExpiryMs = renewedExpiryMs(response) ?? now() + ttlMs;
         armAuthorityDeadline();
         onEvent({
@@ -109,6 +164,9 @@ export async function superviseLeaseRun({
         });
         return;
       }
+      // A response that refuses is authoritative: the lease is genuinely gone and
+      // another holder may exist. Never retry that -- only unreachability.
+      cancelRetryTimer();
       await fence(
         response?.error || "lease-renewal-failed",
         "heartbeat-lost",
@@ -128,6 +186,7 @@ export async function superviseLeaseRun({
     // finally runs once per superviseLeaseRun call — release is always owned here
     // (idempotent release is the caller's responsibility if they wrap again).
     cancelSchedule(timer);
+    cancelRetryTimer();
     if (deadlineTimer !== null) cancelDeadline(deadlineTimer);
     if (heartbeatInFlight) await heartbeatInFlight;
     if (deadlineInFlight) await deadlineInFlight;

--- a/scripts/lib/lease-supervisor.test.mjs
+++ b/scripts/lib/lease-supervisor.test.mjs
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  authoritySafetyMarginMs,
   heartbeatIntervalMs,
   superviseLeaseRun,
+  uncertainRetryDelayMs,
 } from "./lease-supervisor.mjs";
 
 function deferred() {
@@ -81,7 +83,7 @@ test("a thrown command still cancels heartbeats and releases once", async () => 
   assert.equal(releases, 1);
 });
 
-test("transient renewal uncertainty retries without immediately killing a healthy child", async () => {
+test("a single uncertain renewal does not kill a healthy child", async () => {
   const child = deferred();
   const events = [];
   const deadlines = [];
@@ -208,4 +210,171 @@ test("a fence termination error is observed without leaking an unhandled timer r
     ),
     true,
   );
+});
+
+// BI-ECAE03F7 — the supervisor must recover from a renewal it never got an
+// answer to. The test above drives its own second attempt by hand, so it passed
+// against a supervisor that scheduled no retry at all. These do not.
+
+test("an uncertain renewal schedules its own retry, without the caller driving it", async () => {
+  const child = deferred();
+  const events = [];
+  const retries = [];
+  let renewAttempt = 0;
+  let heartbeatCallback;
+
+  const resultPromise = superviseLeaseRun({
+    ttlMs: 120_000,
+    expiresAt: new Date(120_000).toISOString(),
+    now: () => 0,
+    run: () => child.promise,
+    renew: async () => {
+      renewAttempt += 1;
+      if (renewAttempt === 1) throw new Error("ETIMEDOUT");
+      return { success: true, data: { lease: { expiresAt: new Date(240_000).toISOString() } } };
+    },
+    terminate: async () => { throw new Error("must not terminate"); },
+    release: async () => {},
+    schedule: (callback) => { heartbeatCallback = callback; return "heartbeat"; },
+    cancelSchedule: () => {},
+    scheduleDeadline: () => "deadline",
+    cancelDeadline: () => {},
+    scheduleRetry: (callback, delayMs) => {
+      retries.push({ callback, delayMs });
+      return `retry-${retries.length}`;
+    },
+    cancelRetry: () => {},
+    onEvent: (event) => events.push(event),
+  });
+
+  await heartbeatCallback();
+
+  // The supervisor -- not the test -- must have armed the next attempt.
+  assert.equal(retries.length, 1, "an uncertain renewal armed no retry of its own");
+  assert.equal(retries[0].delayMs, uncertainRetryDelayMs(120_000, 1));
+  assert.equal(
+    events.some((event) => event.type === "heartbeat-retry-scheduled" && event.attempt === 1),
+    true,
+  );
+
+  // Firing the supervisor's own timer renews, with no further help from here.
+  await retries[0].callback();
+  assert.equal(renewAttempt, 2);
+  assert.equal(events.some((event) => event.type === "heartbeat-renewed"), true);
+
+  child.resolve({ status: 0 });
+  assert.equal((await resultPromise).status, "completed");
+});
+
+test("consecutive uncertainty backs off and stays inside the authority budget", async () => {
+  const child = deferred();
+  const retries = [];
+  let heartbeatCallback;
+
+  const resultPromise = superviseLeaseRun({
+    ttlMs: 120_000,
+    expiresAt: new Date(120_000).toISOString(),
+    now: () => 0,
+    run: () => child.promise,
+    renew: async () => { throw new Error("ECONNRESET"); },
+    terminate: async () => {},
+    release: async () => {},
+    schedule: (callback) => { heartbeatCallback = callback; return "heartbeat"; },
+    cancelSchedule: () => {},
+    scheduleDeadline: () => "deadline",
+    cancelDeadline: () => {},
+    scheduleRetry: (callback, delayMs) => {
+      retries.push({ callback, delayMs });
+      return `retry-${retries.length}`;
+    },
+    cancelRetry: () => {},
+    onEvent: () => {},
+  });
+
+  await heartbeatCallback();
+  for (let i = 0; i < 5; i += 1) await retries.at(-1).callback();
+
+  assert.deepEqual(
+    retries.map((retry) => retry.delayMs),
+    [1_000, 2_000, 4_000, 8_000, 16_000, 32_000],
+  );
+  // Six attempts inside the ~115s the deadline allows, where the old shape
+  // spent the whole budget on two.
+  const spentMs = retries.reduce((total, retry) => total + retry.delayMs, 0);
+  assert.ok(spentMs < 120_000 - authoritySafetyMarginMs(120_000), `backoff overran the budget: ${spentMs}ms`);
+
+  child.resolve({ status: 0 });
+  await resultPromise;
+});
+
+test("a renewal that REFUSES is authoritative and is never retried", async () => {
+  const child = deferred();
+  const events = [];
+  const retries = [];
+  let heartbeatCallback;
+
+  const resultPromise = superviseLeaseRun({
+    ttlMs: 120_000,
+    expiresAt: new Date(120_000).toISOString(),
+    now: () => 0,
+    run: () => child.promise,
+    // Not a transport failure: the service answered, and the answer is no.
+    renew: async () => ({ success: false, error: "nonprod_lease_not_owner" }),
+    terminate: async () => { events.push({ type: "terminated" }); child.resolve({ status: 143 }); },
+    release: async () => {},
+    schedule: (callback) => { heartbeatCallback = callback; return "heartbeat"; },
+    cancelSchedule: () => {},
+    scheduleDeadline: () => "deadline",
+    cancelDeadline: () => {},
+    scheduleRetry: (callback, delayMs) => { retries.push({ callback, delayMs }); return "retry"; },
+    cancelRetry: () => {},
+    onEvent: (event) => events.push(event),
+  });
+
+  await heartbeatCallback();
+  const result = await resultPromise;
+
+  assert.equal(retries.length, 0, "a refused renewal must not be retried — another holder may exist");
+  assert.equal(result.status, "fenced");
+  assert.equal(result.reason, "nonprod_lease_not_owner");
+});
+
+test("a retry armed when the run ends is cancelled, not leaked", async () => {
+  const child = deferred();
+  const cancelled = [];
+  let heartbeatCallback;
+
+  const resultPromise = superviseLeaseRun({
+    ttlMs: 120_000,
+    expiresAt: new Date(120_000).toISOString(),
+    now: () => 0,
+    run: () => child.promise,
+    renew: async () => { throw new Error("ETIMEDOUT"); },
+    terminate: async () => {},
+    release: async () => {},
+    schedule: (callback) => { heartbeatCallback = callback; return "heartbeat"; },
+    cancelSchedule: () => {},
+    scheduleDeadline: () => "deadline",
+    cancelDeadline: () => {},
+    scheduleRetry: () => "retry-timer",
+    cancelRetry: (timer) => cancelled.push(timer),
+    onEvent: () => {},
+  });
+
+  await heartbeatCallback();
+  child.resolve({ status: 0 });
+  await resultPromise;
+
+  assert.ok(cancelled.includes("retry-timer"), "the armed retry outlived the run");
+});
+
+test("the backoff is capped at the heartbeat interval and never zero", () => {
+  for (const ttlMs of [1_000, 30_000, 120_000, 600_000]) {
+    const intervalMs = Math.floor(ttlMs / 3);
+    for (let attempt = 1; attempt <= 10; attempt += 1) {
+      const delay = uncertainRetryDelayMs(ttlMs, attempt);
+      assert.ok(delay >= 1, `ttl ${ttlMs} attempt ${attempt} produced ${delay}`);
+      assert.ok(delay <= intervalMs, `ttl ${ttlMs} attempt ${attempt} exceeded the interval`);
+    }
+  }
 });


### PR DESCRIPTION
## The defect

A gate run that holds its slot legitimately, does nothing wrong, and gets most of the way through can still kill itself. It happened twice consecutively on `fix/stt-digest-watch-apply-exit`, both times after ~15 minutes of completed work, both reported as `blocked_control_plane_starvation`.

`knownExpiryMs` only advances on a renewal that returns success, and the authority deadline is armed at `knownExpiryMs - safetyMarginMs`. At the live 120s TTL:

```
heartbeat interval  = floor(120000 / 3) = 40s
safety margin       = min(5000, floor(120000 / 10)) = 5s
deadline fires      = 115s after the last good renewal
attempts in between = +40s, +80s
```

Two attempts — and the failing branch made both count for nothing:

```js
} catch (error) {
  onEvent({ type: "heartbeat-uncertain", ... });
  return;            // no retry, no re-arm, budget still draining
}
```

Two slow renewals in a row destroy the run, and they are slow precisely because the run itself is saturating the host with the full suite, Docker and Postgres — while BI-46B03CAE's fixed 10s MCP ceiling sits directly under `renewLeaseAuthority()`. That call **throws** on timeout, landing in exactly this branch. The two defects compound.

`lease-authority-deadline` is a **self**-fence. Nobody took the slot. The run could not prove to itself that it still held it.

## The fix

A renewal that throws proves nothing — the service was unreachable, not lost. It now schedules its own retry on a bounded backoff: a fortieth of the interval, doubling, capped at the interval. At a 40s interval that is 1s, 2s, 4s, 8s, 16s, 32s — six further chances inside the same budget that previously allowed one, without hammering a service already struggling.

A renewal that **responds** with a refusal is the opposite case: authoritative, another holder may exist, stop now. That path cancels any pending retry and fences, unchanged. The distinction between "cannot reach" and "no longer own" is the point.

Both consumers — `gate-worktree.mjs` and `host-resource-runner.mjs` — use the default timers, so neither needed a change.

## Deliberately not done

BI-ECAE03F7 item 1 offers "size the TTL to the workload, **or** renew on a much tighter interval relative to TTL". Lengthening the TTL buys resilience by making a genuinely dead holder block the single slot for longer — which is BI-AD9D395B's problem and BI-D908DA0A's pool. The retry gets the same resilience without that trade, so the TTL is untouched.

## The tests for this were excluded from CI

`scripts/lib/lease-supervisor.test.mjs` sat in `scripts/ci-policy-test-inventory-allowlist.txt` — the deliberate-exclusion list whose own header says *"Prefer listing the test in scripts/lib/ci-policy-guards.mjs over allowing it out."* Nothing in CI ran them while this component destroyed run after run. Moved into the `janitor-tests` guard, and the new tests are observed executing there.

And the test that looked like coverage was not. Its name was *"transient renewal uncertainty **RETRIES** without immediately killing a healthy child"*, but it drove the second attempt itself with a manual `await heartbeat()` and never asserted the supervisor scheduled one. It passed against a supervisor that retried nothing. Renamed to what it actually checks.

## Verified not inert

With the fix in place but the single `scheduleUncertainRetry()` call removed — export and helpers intact, so the failure is behavioural rather than a module-load error — exactly three tests fail:

```
✖ an uncertain renewal schedules its own retry, without the caller driving it
    "an uncertain renewal armed no retry of its own"
✖ consecutive uncertainty backs off and stays inside the authority budget
✖ a retry armed when the run ends is cancelled, not leaked
    "the armed retry outlived the run"
```

The other nine pass, including the renamed one — confirming it was blind to this.

## Checks

- `ci-policy-guards.mjs --profile pull-request` — 7/7
- `node --test scripts/lib/lease-supervisor.test.mjs` — 12/12
- source profile — 62/63 guards; the one failure is `Janitor Tests`, which fails identically on a clean tree (10 failures before and after, my 5 additions all passing) and is the known Windows-only environmental red

## Pushed with a recorded gate override

The local-CI gate never reached a product verdict on this branch. While diagnosing that, the pool turned out to be behaving in a way worth reporting separately: a waiter whose process has exited is still **admitted** when its turn comes, holds the only slot for its full ~2-minute TTL doing nothing, then expires — so a queue of exited waiters burns the slot two minutes at a time in front of live work. Observed directly on one of this branch's own rows:

```
admittedAt: 04:52:06  →  expiresAt: 04:54:05  →  status: expired
```

Required CI on this PR is the authoritative check.

Refs: BI-ECAE03F7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
