### PR TITLE
fix(inference): name the binding constraint, and stop advising a retry that cannot work (BI-FB184D69)

### DIFF
--- a/apps/web/lib/inference/downgrade-explanation.test.ts
+++ b/apps/web/lib/inference/downgrade-explanation.test.ts
@@ -193,7 +193,12 @@ describe("buildLocalFallbackBanner", () => {
     expect(banner).not.toContain("usually because");
   });
 
-  it("combines distinct causes without repeating one", () => {
+  // BI-FB184D69. This asserted the opposite — that both causes appear in the
+  // sentence. Co-billing them is what sent the reported owner after a capability
+  // that was never binding while residency held every route back. `excludedReasons`
+  // is in ranking order, so the first survivable cause owns the outcome; the rest
+  // are counted, not named.
+  it("names only the binding cause and counts the rest", () => {
     const banner = buildLocalFallbackBanner({
       excludedReasons: [
         "Context window too small: 24576 < 32000",
@@ -203,8 +208,23 @@ describe("buildLocalFallbackBanner", () => {
       offProviderNames: [],
     });
     expect(banner).toContain("longer than its context window");
-    expect(banner).toContain("needed a capability it doesn't offer");
+    expect(banner).not.toContain("needed a capability it doesn't offer");
+    expect(banner).toContain("One other provider was ruled out for a different reason.");
     expect(banner.match(/context window/g)).toHaveLength(1);
+  });
+
+  // The live shape from the report: eight residency exclusions, one capability.
+  it("names residency, not the single capability exclusion behind it", () => {
+    const banner = buildLocalFallbackBanner({
+      excludedReasons: [
+        ...Array.from({ length: 8 }, () =>
+          "Residency policy 'local_only' requires a local provider (Docker Model Runner or Ollama)"),
+        "Agent requires capability 'toolUse' (EP-AGENT-CAP-002)",
+      ],
+      offProviderNames: [],
+    });
+    expect(banner).toContain("data policy required this work to stay on this machine");
+    expect(banner).not.toContain("capability it doesn't offer");
   });
 
   it("drops the catch-all phrase once a specific cause is known", () => {

--- a/apps/web/lib/inference/downgrade-explanation.ts
+++ b/apps/web/lib/inference/downgrade-explanation.ts
@@ -113,6 +113,44 @@ export function escalationCameOnlyFromHistory(
   return sawEarlier;
 }
 
+/**
+ * The cause that ACTUALLY held this turn back.
+ *
+ * `excludedReasons` arrives in routing's own ranking order, so the first
+ * survivable cause belongs to the best route the owner could otherwise have
+ * used — clear it and the turn moves. The old code unioned every cause into one
+ * sentence, which read as though each were equally responsible. On the reported
+ * install eight of nine exclusions were residency and exactly one was a missing
+ * `toolUse` capability; the banner billed both, and the owner reasonably chased
+ * the capability. Only residency was binding (BI-FB184D69).
+ *
+ * A "not switched on" endpoint is never returned: that is the disabled-provider
+ * branch's story, and describing it inside "your configured providers stayed
+ * available" is the contradiction BI-F4D3B9E9(d) removed.
+ */
+export function bindingCause(excludedReasons: readonly string[]): DowngradeCause | null {
+  const causes = excludedReasons
+    .map(classifyExclusionReason)
+    .filter((cause) => cause !== "provider-off");
+  // A named cause outranks the catch-all regardless of position: "it wasn't
+  // eligible" tells the owner nothing they can act on.
+  return causes.find((cause) => cause !== "unknown") ?? causes[0] ?? null;
+}
+
+/** How many DISTINCT other causes were in play, for a count-only mention. */
+function otherCauseCount(
+  excludedReasons: readonly string[],
+  binding: DowngradeCause | null,
+): number {
+  if (!binding) return 0;
+  const distinct = new Set(
+    excludedReasons
+      .map(classifyExclusionReason)
+      .filter((cause) => cause !== "provider-off" && cause !== binding),
+  );
+  return distinct.size;
+}
+
 export type LocalFallbackBannerInput = {
   /** Excluded user-configured candidates, in routing's own ranking order. */
   excludedReasons: string[];
@@ -206,21 +244,23 @@ export function buildLocalFallbackBanner(input: LocalFallbackBannerInput): strin
       } at Platform > AI > Providers to restore full capability.`,
     );
   } else {
-    const causes = new Set(input.excludedReasons.map(classifyExclusionReason));
-    // A "not switched on" endpoint (status unconfigured/inactive) must never be
-    // described inside a "your configured providers stayed available" sentence —
-    // that reads as a contradiction, which is the whole class of bug being fixed
-    // here. Genuinely-off providers are named by the branch above instead.
-    causes.delete("provider-off");
-    // Drop "unknown" when a specific cause is also present — a named reason is
-    // strictly more useful than the catch-all phrasing.
-    if (causes.size > 1) causes.delete("unknown");
-    const phrases = [...causes].map(causePhrase);
+    const binding = bindingCause(input.excludedReasons);
+    const others = otherCauseCount(input.excludedReasons, binding);
     parts.push(
-      phrases.length > 0
-        ? `Your configured providers stayed available, but ${joinNames(phrases)}.`
+      binding
+        ? `Your configured providers stayed available, but ${causePhrase(binding)}.`
         : "Your configured providers stayed available but none was eligible for this request.",
     );
+    // Named without being co-billed. An owner who reads two causes joined by
+    // "and" cannot tell which one to act on, and acting on the wrong one costs
+    // them another failed run (BI-FB184D69).
+    if (others > 0) {
+      parts.push(
+        others === 1
+          ? "One other provider was ruled out for a different reason."
+          : `${others} other providers were ruled out for different reasons.`,
+      );
+    }
   }
 
   // BI-706530B2: when the only sensitive evidence is several turns back, the
@@ -239,12 +279,16 @@ export function buildLocalFallbackBanner(input: LocalFallbackBannerInput): strin
 }
 
 /**
- * One call for the whole local-fallback banner (BI-706530B2).
+ * One call for the whole local-fallback explanation (BI-706530B2, BI-FB184D69).
  *
  * routed-inference.ts previously assembled this inline — extract the facts,
  * compute the history provenance, spread both into the builder. That is banner
  * composition living in the routing module, and it pushed routed-inference over
  * its 800-LOC ceiling. Composition belongs beside the thing being composed.
+ *
+ * It returns the binding cause alongside the banner so the copy printed BELOW
+ * the banner argues from the same constraint the banner named, rather than
+ * re-deriving it and contradicting it.
  */
 export function describeLocalFallback(input: {
   manifests: ReadonlyArray<ManifestFacts>;
@@ -252,13 +296,17 @@ export function describeLocalFallback(input: {
   sensitivity: string;
   matchProvenance: ReadonlyArray<{ path: string }> | undefined;
   messageCount: number;
-}): string {
-  return buildLocalFallbackBanner({
-    ...extractLocalFallbackFacts({
-      manifests: input.manifests,
-      candidates: input.candidates,
-      sensitivity: input.sensitivity,
-    }),
-    historicalOnly: escalationCameOnlyFromHistory(input.matchProvenance, input.messageCount),
+}): { banner: string; cause: DowngradeCause | null } {
+  const facts = extractLocalFallbackFacts({
+    manifests: input.manifests,
+    candidates: input.candidates,
+    sensitivity: input.sensitivity,
   });
+  return {
+    banner: buildLocalFallbackBanner({
+      ...facts,
+      historicalOnly: escalationCameOnlyFromHistory(input.matchProvenance, input.messageCount),
+    }),
+    cause: bindingCause(facts.excludedReasons),
+  };
 }

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -60,7 +60,7 @@ import { soleCapabilityFloorFailure } from "@/lib/inference/routing-exclusion-at
 import { createRoutingTraceId } from "@/lib/routing/routing-trace";
 import { AI_ROUTING_ARCHITECTURE_VERSION } from "@/lib/routing/routing-architecture-version";
 import type { EndpointPreferences } from "@/lib/routing/preference-finalization";
-import { describeLocalFallback } from "./downgrade-explanation";
+import { describeLocalFallback, type DowngradeCause } from "./downgrade-explanation";
 export type { RouteAndCallOptions } from "./routed-inference-options";
 // ─── Result type ────────────────────────────────────────────────────────────
 /** Unified inference result — flat token fields, V2 metadata included. */
@@ -81,6 +81,8 @@ export interface RoutedInferenceResult {
    * assert both at once. See ./downgrade-explanation.ts (BI-F4D3B9E9d).
    */
   downgradeReason: "provider-unavailable" | "not-eligible" | null;
+  /** The constraint the banner named, so copy below it cannot contradict it (BI-FB184D69). */
+  downgradeCause?: DowngradeCause | null;
   /** True when tools were stripped due to capability degradation (local model). */
   toolsStripped: boolean;
   /**
@@ -701,7 +703,7 @@ async function routeAndCallAttempt(
   // "is active" — wrong whenever a stronger provider is disabled and a weaker one
   // is not. Both facts are already in scope, so ./downgrade-explanation.ts reads
   // them instead of guessing.
-  const localFallbackBanner = fellToLocal
+  const localFallback = fellToLocal
     ? describeLocalFallback({
       manifests,
       candidates: decision.candidates,
@@ -710,6 +712,7 @@ async function routeAndCallAttempt(
       messageCount: messages.length,
     })
     : null;
+  const localFallbackBanner = localFallback?.banner ?? null;
 
   // 6. Persist TokenUsage row for the cost ledger (Phase J).
   // Fire-and-forget because metering must not block the response. A loud log
@@ -741,6 +744,7 @@ async function routeAndCallAttempt(
       : fellToLocal
         ? "not-eligible"
         : null,
+    downgradeCause: localFallback?.cause ?? null,
     toolsStripped,
     truncated: result.truncated ?? false,
     routeDecision: decision,

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -7,7 +7,6 @@ import {
   buildRepeatedQuestionNudge,
   buildRepeatedToolStopMessage,
   buildRuntimeLimitToolLoopMessage,
-  buildMaxIterationsExhaustedMessage,
   detectToolRefusedDespiteAvailability,
   phaseRequiresToolCall,
   detectUnsavedEvidence,
@@ -279,71 +278,6 @@ describe("buildRuntimeLimitToolLoopMessage (BI-0C19AFDD)", () => {
 // configured provider is active but wasn't eligible" (banner) and "My usual AI
 // was unavailable" (this message). The message branched on the `downgraded`
 // boolean, which conflated a dispatch failure with pre-dispatch ineligibility.
-describe("buildMaxIterationsExhaustedMessage (BI-F4D3B9E9d)", () => {
-  const anyTools = [{ name: "query_backlog", result: { ok: true } as never }];
-
-  it("says 'unavailable' only when a dispatch actually failed", () => {
-    const msg = buildMaxIterationsExhaustedMessage({
-      downgradeReason: "provider-unavailable",
-      executedTools: anyTools,
-    });
-    expect(msg).toContain("My usual AI was unavailable");
-    expect(msg).toContain("query_backlog");
-  });
-
-  it("never claims 'unavailable' when the provider was merely ineligible", () => {
-    const msg = buildMaxIterationsExhaustedMessage({
-      downgradeReason: "not-eligible",
-      executedTools: anyTools,
-    });
-    // The exact contradiction with the downgrade banner.
-    expect(msg).not.toContain("was unavailable");
-    expect(msg).toContain("wasn't a fit for this particular request");
-  });
-
-  it("does not tell an owner to connect a provider they already have connected", () => {
-    const msg = buildMaxIterationsExhaustedMessage({
-      downgradeReason: "not-eligible",
-      executedTools: anyTools,
-    });
-    // Old copy: "Connecting a stronger provider (Claude, Gemini, or OpenAI)…"
-    expect(msg).not.toMatch(/connecting a stronger provider/i);
-    expect(msg).toMatch(/shorter request/i);
-  });
-
-  it("points at restoring the failed provider when one genuinely failed", () => {
-    const msg = buildMaxIterationsExhaustedMessage({
-      downgradeReason: "provider-unavailable",
-      executedTools: anyTools,
-    });
-    expect(msg).toContain("Platform > AI > Providers");
-  });
-
-  it("adds no downgrade lead at all on a healthy-provider exhaustion", () => {
-    const msg = buildMaxIterationsExhaustedMessage({
-      downgradeReason: null,
-      executedTools: anyTools,
-    });
-    expect(msg).not.toMatch(/my usual ai/i);
-    expect(msg).toMatch(/^I made several attempts/);
-    expect(msg).toMatch(/smaller piece/i);
-  });
-
-  it("falls back to a generic work note when no tools ran", () => {
-    const msg = buildMaxIterationsExhaustedMessage({
-      downgradeReason: null,
-      executedTools: [],
-    });
-    expect(msg).toContain("I worked through several attempts");
-  });
-
-  it("always names the safety limit rather than an opaque failure", () => {
-    for (const downgradeReason of ["provider-unavailable", "not-eligible", null] as const) {
-      const msg = buildMaxIterationsExhaustedMessage({ downgradeReason, executedTools: anyTools });
-      expect(msg).toContain("safety limit");
-    }
-  });
-});
 
 describe("buildToolSessionHintMessage — review-fail veto + tool-error notes in the messages tail", () => {
   // BI-56804810: these notes now ride in a per-turn user message (not tool

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -2,6 +2,7 @@
 // Agentic execution loop: LLM calls tools iteratively until it responds with text only.
 // This is the core behavioral difference between a chatbot and an agent.
 import { routeAndCall, type RouteAndCallOptions, type RoutedInferenceResult } from "@/lib/routed-inference";
+import type { DowngradeCause } from "@/lib/inference/downgrade-explanation";
 import {
   detectRepeatedToolCall,
   detectApproachingRepeatedToolCall,
@@ -532,45 +533,8 @@ export function buildRuntimeLimitToolLoopMessage(executedTools: ExecutedTool[]):
   ].join(" ");
 }
 
-/**
- * Plain-English message for when the loop hits MAX_ITERATIONS without
- * producing a text-only response. Replaces the prior generic "I ran into
- * a limit while working on this. Try breaking your request into smaller
- * steps." which obscured the actual cause (usually: preferred provider
- * unavailable → fallback model overwhelmed by the tool surface). Respects
- * IDENTITY_BLOCK rule #5 — no provider/model/tool internals exposed.
- *
- * BI-F4D3B9E9(d): this branched on `downgraded`, which conflated "a dispatch
- * failed" with "nothing was eligible" — so it printed "My usual AI was
- * unavailable" directly beneath a banner that had just said "your configured
- * provider is active but wasn't eligible". One of the two was always wrong.
- * It now branches on the routed `downgradeReason` so both statements describe
- * the same cause, and it no longer tells an owner to connect a provider they
- * already have connected.
- */
-export function buildMaxIterationsExhaustedMessage(params: {
-  downgradeReason: "provider-unavailable" | "not-eligible" | null;
-  executedTools: ExecutedTool[];
-}): string {
-  const toolSummary = summarizeExecutedToolNames(params.executedTools);
-  const downgradeLead = params.downgradeReason === "provider-unavailable"
-    ? "My usual AI was unavailable, so I worked through a backup that wasn't able to keep up. "
-    : params.downgradeReason === "not-eligible"
-      ? "My usual AI wasn't a fit for this particular request, so I worked through a backup that wasn't able to keep up. "
-      : "";
-  const workNote = toolSummary
-    ? `I made several attempts (${toolSummary}) but couldn't complete a final answer before hitting my safety limit.`
-    : "I worked through several attempts but couldn't complete a final answer before hitting my safety limit.";
-  // Honest copy (G2, 2026-05-23): no false re-route promises. Point at the fix
-  // that matches the actual cause — an owner whose providers are all connected
-  // and merely ineligible must not be told to connect one (BI-F4D3B9E9(d)).
-  const suggestion = params.downgradeReason === "provider-unavailable"
-    ? "Reconnecting or restoring that provider at Platform > AI > Providers unlocks the work I'm built for. Otherwise, try a narrower question."
-    : params.downgradeReason === "not-eligible"
-      ? "A shorter request usually routes back to the stronger model. The note above says what ruled it out."
-      : "Try the same question again, or break it into a smaller piece.";
-  return `${downgradeLead}${workNote} ${suggestion}`;
-}
+import { buildMaxIterationsExhaustedMessage } from "./max-iterations-message";
+export { buildMaxIterationsExhaustedMessage };
 
 // Pattern: response is a short clarifying question asking for a required field.
 // System prompt rule 13 allows ONE round of "I need X and Y" before acting.
@@ -2665,6 +2629,9 @@ async function _runAgenticLoop(params: RunAgenticLoopParams, tracker: { activeSk
     // that predate the field fall back to the unavailable reading only when they
     // actually reported a downgrade.
     downgradeReason: lastResult?.downgradeReason ?? (downgraded ? "provider-unavailable" : null),
+    // The same binding cause the banner named, so the advice below it addresses
+    // the constraint the owner was actually told about (BI-FB184D69).
+    cause: lastResult?.downgradeCause ?? null,
     executedTools,
   });
   return {

--- a/apps/web/lib/tak/max-iterations-message.test.ts
+++ b/apps/web/lib/tak/max-iterations-message.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMaxIterationsExhaustedMessage } from "./max-iterations-message";
+
+describe("buildMaxIterationsExhaustedMessage (BI-F4D3B9E9d)", () => {
+  const anyTools = [{ name: "query_backlog", result: { ok: true } as never }];
+
+  it("says 'unavailable' only when a dispatch actually failed", () => {
+    const msg = buildMaxIterationsExhaustedMessage({
+      downgradeReason: "provider-unavailable",
+      executedTools: anyTools,
+    });
+    expect(msg).toContain("My usual AI was unavailable");
+    // BI-FB184D69: raw tool names are engineer detail and stay on the trace.
+    expect(msg).not.toContain("query_backlog");
+  });
+
+  it("never claims 'unavailable' when the provider was merely ineligible", () => {
+    const msg = buildMaxIterationsExhaustedMessage({
+      downgradeReason: "not-eligible",
+      executedTools: anyTools,
+    });
+    // The exact contradiction with the downgrade banner.
+    expect(msg).not.toContain("was unavailable");
+    expect(msg).toContain("wasn't a fit for this particular request");
+  });
+
+  it("does not tell an owner to connect a provider they already have connected", () => {
+    const msg = buildMaxIterationsExhaustedMessage({
+      downgradeReason: "not-eligible",
+      executedTools: anyTools,
+    });
+    // Old copy: "Connecting a stronger provider (Claude, Gemini, or OpenAI)…"
+    expect(msg).not.toMatch(/connecting a stronger provider/i);
+    // BI-FB184D69: with no cause supplied it must not guess that brevity helps.
+    expect(msg).not.toMatch(/shorter request/i);
+    expect(msg).toMatch(/what ruled it out/i);
+  });
+
+  it("points at restoring the failed provider when one genuinely failed", () => {
+    const msg = buildMaxIterationsExhaustedMessage({
+      downgradeReason: "provider-unavailable",
+      executedTools: anyTools,
+    });
+    expect(msg).toContain("Platform > AI > Providers");
+  });
+
+  it("adds no downgrade lead at all on a healthy-provider exhaustion", () => {
+    const msg = buildMaxIterationsExhaustedMessage({
+      downgradeReason: null,
+      executedTools: anyTools,
+    });
+    expect(msg).not.toMatch(/my usual ai/i);
+    expect(msg).toMatch(/^I worked through several attempts/);
+    expect(msg).toMatch(/smaller piece/i);
+  });
+
+  it("falls back to a generic work note when no tools ran", () => {
+    const msg = buildMaxIterationsExhaustedMessage({
+      downgradeReason: null,
+      executedTools: [],
+    });
+    expect(msg).toContain("I couldn't complete a final answer");
+  });
+
+  // BI-FB184D69. The reported owner tested the old advice directly — a nine-word
+  // prompt — and spent six more minutes reaching the identical failure. Length is
+  // not the axis a data-boundary decision turns on.
+  it("never suggests brevity when a data boundary is what excluded the route", () => {
+    for (const cause of ["residency", "clearance"] as const) {
+      const msg = buildMaxIterationsExhaustedMessage({
+        downgradeReason: "not-eligible",
+        cause,
+        executedTools: anyTools,
+      });
+      expect(msg).not.toMatch(/shorter/i);
+      expect(msg).not.toMatch(/narrower/i);
+      expect(msg).toMatch(/data-handling rule/i);
+    }
+  });
+
+  it("does suggest brevity when the context window really was the limit", () => {
+    const msg = buildMaxIterationsExhaustedMessage({
+      downgradeReason: "not-eligible",
+      cause: "context-window",
+      executedTools: anyTools,
+    });
+    expect(msg).toMatch(/shorter/i);
+  });
+
+  it("always names the safety limit rather than an opaque failure", () => {
+    for (const downgradeReason of ["provider-unavailable", "not-eligible", null] as const) {
+      const msg = buildMaxIterationsExhaustedMessage({ downgradeReason, executedTools: anyTools });
+      expect(msg).toContain("safety limit");
+    }
+  });
+});

--- a/apps/web/lib/tak/max-iterations-message.ts
+++ b/apps/web/lib/tak/max-iterations-message.ts
@@ -1,0 +1,81 @@
+import type { DowngradeCause } from "@/lib/inference/downgrade-explanation";
+
+/** The executed-tool shape this copy needs — count only, never names. */
+type ExecutedTool = { name: string };
+
+/**
+ * Plain-English message for when the loop hits MAX_ITERATIONS without
+ * producing a text-only response. Replaces the prior generic "I ran into
+ * a limit while working on this. Try breaking your request into smaller
+ * steps." which obscured the actual cause (usually: preferred provider
+ * unavailable → fallback model overwhelmed by the tool surface). Respects
+ * IDENTITY_BLOCK rule #5 — no provider/model/tool internals exposed.
+ *
+ * BI-F4D3B9E9(d): this branched on `downgraded`, which conflated "a dispatch
+ * failed" with "nothing was eligible" — so it printed "My usual AI was
+ * unavailable" directly beneath a banner that had just said "your configured
+ * provider is active but wasn't eligible". One of the two was always wrong.
+ * It now branches on the routed `downgradeReason` so both statements describe
+ * the same cause, and it no longer tells an owner to connect a provider they
+ * already have connected.
+ */
+export function buildMaxIterationsExhaustedMessage(params: {
+  downgradeReason: "provider-unavailable" | "not-eligible" | null;
+  executedTools: ExecutedTool[];
+  /**
+   * The cause that actually excluded the preferred route, from the same
+   * `bindingCause` the banner above the message used. Optional so older callers
+   * still compile; when absent the suggestion stays cause-neutral rather than
+   * guessing (BI-FB184D69).
+   */
+  cause?: DowngradeCause | null;
+}): string {
+  const downgradeLead = params.downgradeReason === "provider-unavailable"
+    ? "My usual AI was unavailable, so I worked through a backup that wasn't able to keep up. "
+    : params.downgradeReason === "not-eligible"
+      ? "My usual AI wasn't a fit for this particular request, so I worked through a backup that wasn't able to keep up. "
+      : "";
+  // Tool names are engineer-facing. They stay on the route and tool trace, where
+  // an engineer already looks; in the owner's sentence they were noise dressed
+  // as detail (BI-FB184D69).
+  const workNote = params.executedTools.length > 0
+    ? "I worked through several attempts but couldn't complete a final answer before hitting my safety limit."
+    : "I couldn't complete a final answer before hitting my safety limit.";
+  return `${downgradeLead}${workNote} ${exhaustedSuggestion(params)}`;
+}
+
+/**
+ * What the owner should actually do about it.
+ *
+ * The old not-eligible arm always said "a shorter request usually routes back to
+ * the stronger model". Under a residency or clearance exclusion that is simply
+ * false — length is not the axis — and the owner who tested it directly spent
+ * six more minutes to reach the identical failure. Advice that cannot work costs
+ * real time every time it is followed (BI-FB184D69).
+ */
+function exhaustedSuggestion(params: {
+  downgradeReason: "provider-unavailable" | "not-eligible" | null;
+  cause?: DowngradeCause | null;
+}): string {
+  if (params.downgradeReason === "provider-unavailable") {
+    return "Reconnecting or restoring that provider at Platform > AI > Providers unlocks the work I'm built for. Otherwise, try a narrower question.";
+  }
+  if (params.downgradeReason !== "not-eligible") {
+    return "Try the same question again, or break it into a smaller piece.";
+  }
+  switch (params.cause) {
+    case "residency":
+    case "clearance":
+      // Nothing the owner can retype changes a data-boundary decision.
+      return "This is a data-handling rule, not a size limit — rewording or shortening won't change it. Asking the same thing somewhere that doesn't carry confidential data will route to the stronger model.";
+    case "rate-limit":
+      return "The stronger model was at its rate limit; the same question in a few minutes should reach it.";
+    case "context-window":
+      return "This request was longer than the stronger model's context window, so a shorter one will route back to it.";
+    case "capability":
+    case "model-class":
+      return "The stronger model isn't offered for this kind of work. The note above says what ruled it out.";
+    default:
+      return "The note above says what ruled it out.";
+  }
+}

--- a/docs/user-guide/platform/ai-operations.md
+++ b/docs/user-guide/platform/ai-operations.md
@@ -98,10 +98,24 @@ in, and they need different responses:
   it before a coworker turn degrades rather than after.
 - **"Your configured providers stayed available, but …"** — everything is
   connected and healthy; this particular request was ruled out of the stronger
-  route. The note names the actual reason (for example the request was longer
-  than the model's context window, or it needed a capability that model does not
-  offer). A shorter request, or a new thread, usually routes back to the stronger
-  model.
+  route. The note names the **one** reason that actually held the turn back, not
+  every reason in play: if several providers were ruled out for different
+  reasons, the note names the binding one and says how many others there were.
+  What to do depends on which reason you are given, and only some of them are
+  about the request itself:
+
+  - **"longer than its context window"** — a shorter request, or a new thread,
+    routes back to the stronger model.
+  - **"it had reached its rate limit"** — the same question in a few minutes
+    reaches it.
+  - **"data policy required this work to stay on this machine"** or **"it isn't
+    cleared for this data sensitivity"** — this is a data-handling rule, not a
+    size limit. Rewording or shortening will not change it, and retrying costs
+    you the wait for nothing. Ask the same thing somewhere that does not carry
+    confidential data, or change what the page in question is classified as.
+  - **"needed a capability it doesn't offer"** or **"its model isn't the class
+    this work requires"** — the stronger model is not offered for this kind of
+    work, whatever length you send.
 
 The two are mutually exclusive: a single reply never tells you a provider is both
 available and switched off. If a coworker also reports hitting its safety limit,


### PR DESCRIPTION
## What the owner read

Verbatim, from the COO panel on `/workspace/inbox`:

> Your configured providers stayed available, but data policy required this work to stay on this machine **and** this request needed a capability it doesn't offer.

> I made several attempts (query_backlog x2, get_capability_completeness, list_all_capability_needs, list_at_risk_queues, list_open_decision_reviews) but couldn't complete a final answer before hitting my safety limit. **A shorter request usually routes back to the stronger model.**

Three defects, in order of harm.

## 1. The binding constraint was not distinguished from an incidental one

`buildLocalFallbackBanner` collected every excluded candidate's cause into a `Set` and joined them, so two causes read as equally responsible. In the live trace, eight of nine excluded endpoints carried `Residency policy 'local_only'`; exactly one — a `chatgpt` endpoint — carried `Agent requires capability 'toolUse'`. Residency was binding: clear it and the turn routes to cloud. Capability was not: clear it and nothing changes. The banner gave them the same billing, and the owner reasonably chased the capability.

`excludedReasons` already arrives in routing's ranking order, so the first survivable cause owns the outcome. It is named; the rest are counted ("One other provider was ruled out for a different reason.").

## 2. The advice was false for this cause

The `not-eligible` arm always returned "A shorter request usually routes back to the stronger model." Under a residency or clearance exclusion, length is not the axis — the owner tested this directly with a nine-word prompt and spent six more minutes reaching the identical failure. Advice that cannot work costs real time every time it is followed.

The suggestion now branches on the same binding cause the banner named. Residency and clearance say so plainly: "This is a data-handling rule, not a size limit — rewording or shortening won't change it."

## 3. Raw tool names were in the owner's sentence

`query_backlog x2, get_capability_completeness, …` is engineer-facing detail in a non-technical owner's reply. It stays on the route and tool trace, where an engineer already looks.

## The user guide said it too

`docs/user-guide/platform/ai-operations.md` carried the identical false advice — "A shorter request, or a new thread, usually routes back to the stronger model" — so an owner who went to the docs for help was told the same wrong thing. Rewritten to break the guidance out per cause, with residency and clearance stated as data-handling rules that retrying will not clear.

## Structure

The cause is threaded on `RoutedInferenceResult` rather than re-derived downstream, so the banner and the message below it cannot disagree — that shape was the original cause of the contradiction BI-F4D3B9E9(d) fixed once already.

Merged with [BI-706530B2], which landed on `main` while this was in flight and independently added a `describeLocalFallback`. Both concerns now live in one function: the banner explains history-only escalation *and* names the binding cause.

## Verification

- `vitest run lib/inference lib/tak` — 2092 passed, including BI-706530B2's tests.
- Five existing tests asserted the old behaviour (the union, the tool name, `/shorter request/i`) and were rewritten to the new contract while keeping the BI-F4D3B9E9(d) invariants they also guarded.
- New tests use the live shape: 8 residency + 1 capability names residency and never capability; `/shorter/` and `/narrower/` never appear for residency or clearance; brevity is still suggested when context window really was the limit.
- `pnpm pregate:preflight` — 63 guards clean. `tsc --noEmit` — clean.
- `pnpm run pregate` — PASS, evidence `cmtjnkrcw04n601o5249fh33d`, gated sha `960446d4e3d5`.

Closes BI-FB184D69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)