### PR TITLE
fix(cli-adapter): run headless inference outside the project workspace (BI-35FAE2DB)

### DIFF
--- a/apps/web/lib/routing/cli-adapter.test.ts
+++ b/apps/web/lib/routing/cli-adapter.test.ts
@@ -301,6 +301,47 @@ describe("cliAdapter", () => {
     expect(systemWrite!.content).toContain("create_backlog_item");
   });
 
+  // BI-35FAE2DB: `claude` discovers CLAUDE.md (which imports the whole
+  // AGENTS.md rulebook), project settings and hooks by walking UP from its
+  // working directory. Running headless inference in /workspace turned every
+  // single-shot call into an agentic session that answered a "respond with
+  // ONLY a JSON object" prompt with session meta-commentary, which the review
+  // parser cannot read — Build Studio design review reported "Both review
+  // agents failed to respond" for 332 rounds because of it.
+  it("runs the CLI from a neutral directory, never the project workspace", async () => {
+    mockGetProviderBearerToken.mockResolvedValue({ token: "sk-ant-oat01-test-token" });
+    const cliOutput = JSON.stringify({ result: "OK", usage: {} });
+    mockSpawn.mockReturnValue(createMockProcess(cliOutput));
+
+    await cliAdapter.execute(makeRequest());
+
+    const decodedScript = sandboxWriteFor("cli-run-")!.content;
+
+    // The regression itself: never cd into the project tree.
+    expect(decodedScript).not.toContain("cd /workspace");
+    // An empty per-run directory, created before use so `cd` cannot fail.
+    expect(decodedScript).toMatch(/mkdir -p \/tmp\/cli-cwd-/);
+    expect(decodedScript).toMatch(/cd \/tmp\/cli-cwd-/);
+    // Order matters: mkdir must precede cd.
+    expect(decodedScript.indexOf("mkdir -p /tmp/cli-cwd-"))
+      .toBeLessThan(decodedScript.indexOf("cd /tmp/cli-cwd-"));
+  });
+
+  it("removes the neutral working directory when the call is cleaned up", async () => {
+    mockGetProviderBearerToken.mockResolvedValue({ token: "sk-ant-oat01-test-token" });
+    const cliOutput = JSON.stringify({ result: "OK", usage: {} });
+    mockSpawn.mockReturnValue(createMockProcess(cliOutput));
+
+    await cliAdapter.execute(makeRequest());
+
+    const cleanup = mockExecAsync.mock.calls
+      .map((c) => String(c[0]))
+      .find((cmd) => /rmdir \/tmp\/cli-cwd-/.test(cmd));
+    expect(cleanup).toBeDefined();
+    // Cleanup must never fail the call — the dir may already be gone.
+    expect(cleanup).toContain("|| true");
+  });
+
   it("handles CLI process error with auth failure classification", async () => {
     mockGetProviderBearerToken.mockResolvedValue({
       token: "sk-ant-oat01-test-token",

--- a/apps/web/lib/routing/cli-adapter.ts
+++ b/apps/web/lib/routing/cli-adapter.ts
@@ -472,6 +472,9 @@ export const cliAdapter: ExecutionAdapterHandler = {
     const tokenFile = `/tmp/cli-token-${slug}.txt`;
     const mcpConfigFile = `/tmp/cli-mcp-${slug}.json`;
     const runnerScript = `/tmp/cli-run-${slug}.sh`;
+    // BI-35FAE2DB: empty, per-run cwd so the CLI discovers no project
+    // CLAUDE.md / settings / hooks above it.
+    const cliWorkingDir = `/tmp/cli-cwd-${slug}`;
     // Records the in-container claude PID so a timeout can reap the actual
     // process inside the sandbox (BI-F36E7510). proc.kill() below only reaches
     // the local `docker exec` client, not the containerized process.
@@ -562,9 +565,20 @@ export const cliAdapter: ExecutionAdapterHandler = {
       // replace the sh, leaving the cmdline as bare `claude -p ...` with no
       // unique handle and no way to signal it from the host. stdout/stderr are
       // inherited by the background child, so capture is unchanged.
+      // BI-35FAE2DB: headless inference runs from a NEUTRAL directory, never
+      // the project workspace. `claude` discovers CLAUDE.md (which imports the
+      // whole AGENTS.md rulebook), settings and hooks by walking UP from cwd,
+      // so `cd /workspace` turned every single-shot call into an agentic
+      // session that answered "respond with ONLY a JSON object" with session
+      // meta-commentary — unparseable, and the reason design review reported
+      // "Both review agents failed to respond" for 332 rounds. Nothing is lost
+      // by leaving: every native filesystem tool is already disallowed here
+      // (CLAUDE_CODE_NATIVE_TOOLS_FLAG_VALUE), so that context could never be
+      // acted on, only paid for. Measurements are in the BI and commit message.
       const script = [
         "#!/bin/sh",
-        "cd /workspace",
+        `mkdir -p ${cliWorkingDir}`,
+        `cd ${cliWorkingDir}`,
         authExportLine,
         `SYSPROMPT=$(cat ${systemFile})`,
         `claude ${bareFlag}-p - --dangerously-skip-permissions ${mcpFlags}--disallowedTools "${CLAUDE_CODE_NATIVE_TOOLS_FLAG_VALUE}" --output-format json --model ${cliModel} --system-prompt "$SYSPROMPT" < ${promptFile} &`,
@@ -773,7 +787,7 @@ export const cliAdapter: ExecutionAdapterHandler = {
       // so a leaked sandbox shell can't dump the bearer from disk after the
       // call returns.
       execAsync(
-        `docker exec ${SANDBOX_CONTAINER} sh -c "rm -f ${promptFile} ${systemFile} ${tokenFile} ${mcpConfigFile} ${runnerScript} ${pidFile}"`,
+        `docker exec ${SANDBOX_CONTAINER} sh -c "rm -f ${promptFile} ${systemFile} ${tokenFile} ${mcpConfigFile} ${runnerScript} ${pidFile}; rmdir ${cliWorkingDir} 2>/dev/null || true"`,
         { timeout: 5_000 },
       ).catch(() => {});
     }


### PR DESCRIPTION
fix(cli-adapter): run headless inference outside the project workspace (BI-35FAE2DB)

Build Studio design review has been failing with "Both review agents failed
to respond" for 332 rounds on FB-D85BEA44, and no build on this install can
leave the ideate phase.

The calls were not failing. They were succeeding and returning nothing usable.
The runner did `cd /workspace` before invoking `claude`, and the CLI discovers
CLAUDE.md (which imports the entire AGENTS.md rulebook), project settings and
hooks by walking UP from its working directory. A single-shot request that says
"Respond with ONLY a JSON object" became an agentic coding session, and answered
with session meta-commentary:

  "(Final response: No further action. Session concludes with guard active.)"

parseReviewResponse cannot read that, so both reviewers parsed to null and the
gate reported that neither had responded. In the portal logs it appeared as
`[cli-adapter] Completed: 0-78 chars, 0 tool calls, 42-60s` — a silent empty
success, which is why it survived 332 rounds without ever surfacing as an error.

Measured on the live install, running the adapter's own staged runner script
with the same prompt, model and token, changing ONLY the working directory:

                  /workspace                       neutral cwd
  result          meta-commentary (unparseable)    valid JSON, as requested
  duration        63,972 ms                        10,524 ms
  turns           2                                1
  cache read      496,381 tokens                   22,488 tokens
  output tokens   4,571 (3,809 thinking)           984
  cost per call   $0.0856                          $0.0110

Nothing is lost by leaving the workspace. Every native filesystem tool is
already disallowed on this path (CLAUDE_CODE_NATIVE_TOOLS_FLAG_VALUE blocks
Read, Write, Bash, Glob, Grep, Edit and the rest), so the model could never act
on that context — it only paid for it, on every call, forever. The MCP config
and the prompt/system/token files are all absolute /tmp paths and are unaffected.

The per-run directory is created before use so `cd` cannot fail, and is removed
by the existing cleanup with `|| true` so a missing dir never fails a call.

Tests: two regression tests pin the behaviour — the script must never contain
`cd /workspace`, must mkdir before cd into an empty per-run dir, and cleanup
must remove it without being able to fail the call. cli-adapter suite 27/27;
routing + build sweep 305 files / 3581 tests green; tsc --noEmit clean;
module-size ratchet green.

Docs-Impact-Decision: internal dispatch mechanics only. The flagged page
(docs/dogfood/2026-05-23-dale-hvac-build-studio.md) is a dogfood session
narrative; no user-facing or coworker-facing documentation describes or depends
on the CLI's working directory, and no documented behaviour changes — reviews
that previously produced nothing now produce their intended output.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Mark Bodman <markdbodman@gmail.com>


---

## How this was found

Driving Build Studio end-to-end through the live portal as the reviewing human.
FB-D85BEA44 would not leave `ideate`. Its `designReview` read *"Both review
agents failed to respond"* at `iteration.round: 332`.

The calls were reaching the cloud fine. They were completing successfully. They
were just returning nothing a parser could use — and because `is_error` is
`false` and `terminal_reason` is `completed`, nothing ever raised an error.

## Reviewer notes

The controlled experiment is the whole argument: the adapter's own staged runner
script, same prompt file, same system file, same model, same token, run twice —
changing only the working directory. `/workspace` returns meta-commentary in 64s
for $0.086; a neutral cwd returns the requested JSON in 10.5s for $0.011.

The safety question is "does the model lose context it needs?" — and it cannot,
because `CLAUDE_CODE_NATIVE_TOOLS_FLAG_VALUE` already disallows `Read`, `Write`,
`Bash`, `Glob`, `Grep`, `Edit` and the rest on this path. The workspace was never
actionable from here. It was loaded, paid for on every call, and used only to
derail single-shot prompts.
