### PR TITLE
fix(workroom): create_workroom accepted workShape and dropped it (BI-A967717A)

### DIFF
--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -90,8 +90,14 @@ function numberParam(params: Record<string, unknown>, key: string): number | nul
 }
 
 function parseScopeInput(params: Record<string, unknown>): WorkCapsuleScopeInput {
+  // Every key the tool schema advertises under scopeProperties must appear here.
+  // This function picks fields explicitly, so a field added to the schema and to
+  // the normalizer but not to this list is accepted by the caller, dropped here,
+  // and answered `success: true` — the same defect `backlogItemId` had on
+  // adopt_worktree. scope-input-parity.test.ts is what keeps the two in step.
   return {
     workroomShape: params.workroomShape,
+    workShape: params.workShape,
     decisionScope: params.decisionScope,
     portfolioRole: params.portfolioRole,
     servedPersona: params.servedPersona,
@@ -783,3 +789,11 @@ export async function recordAgentActivityTool(
     data: { capsule: renewedCapsule },
   };
 }
+
+/**
+ * Test-only surface. `parseScopeInput` is internal, but the schema/handler
+ * parity guard has to call the real function — a test that re-implements the
+ * pick list is exactly the test that would have passed while workShape was
+ * being dropped.
+ */
+export const __testing__ = { parseScopeInput };

--- a/apps/web/lib/work-capsules/scope-input-parity.test.ts
+++ b/apps/web/lib/work-capsules/scope-input-parity.test.ts
@@ -1,0 +1,85 @@
+// Schema/handler parity for the workroom scope block.
+//
+// `parseScopeInput` picks scope fields off the MCP params ONE BY ONE. That is
+// safe against unknown input and unsafe against its own drift: a field added to
+// the tool schema and to the scope normalizer, but not to that pick list, is
+// accepted from the caller, silently dropped, and answered `success: true`.
+//
+// This is not hypothetical. `backlogItemId` had exactly this defect on
+// `adopt_worktree` (PR #4837), and `workShape` reproduced it on
+// `create_workroom` immediately after shipping — the schema advertised it, the
+// normalizer validated it, the store persisted it, and the handler in between
+// dropped it. A room was convened that reported success and could never wake.
+//
+// So the guard is structural rather than one more per-field test: every key the
+// schema advertises must be carried, and the failure names the missing key.
+
+import { describe, expect, it } from "vitest";
+
+import { workCapsulesPack } from "@/lib/mcp/packs/work-capsules-pack";
+import { normalizeWorkCapsuleScopeInput } from "@/lib/work-capsules";
+import { __testing__ } from "./mcp-handlers";
+
+/** Scope keys the create_workroom tool schema advertises to callers. */
+function advertisedScopeKeys(): string[] {
+  const tool = workCapsulesPack.definitions.find((entry) => entry.name === "create_workroom");
+  if (!tool) throw new Error("create_workroom is not in the pack");
+  const schema = tool.inputSchema as { properties?: Record<string, unknown> };
+  const properties = Object.keys(schema.properties ?? {});
+  // Non-scope fields on the same schema; everything else is scope.
+  const notScope = new Set([
+    "title",
+    "objective",
+    "source",
+    "idempotencyKey",
+    "executorKind",
+    "repositoryFullName",
+  ]);
+  return properties.filter((key) => !notScope.has(key));
+}
+
+describe("the scope block the schema advertises is the scope block the handler carries", () => {
+  it("carries every advertised scope key through parseScopeInput", () => {
+    const keys = advertisedScopeKeys();
+    expect(keys.length).toBeGreaterThan(0);
+
+    // A sentinel per key: if the handler drops one, its sentinel goes missing.
+    const params: Record<string, unknown> = {};
+    for (const key of keys) params[key] = `__sentinel_${key}__`;
+
+    const parsed = __testing__.parseScopeInput(params) as Record<string, unknown>;
+    const dropped = keys.filter((key) => parsed[key] !== `__sentinel_${key}__`);
+    expect(
+      dropped,
+      `parseScopeInput drops scope key(s) the create_workroom schema advertises: ${dropped.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("carries every scope key the normalizer understands", () => {
+    // The other half of the seam: a field the normalizer validates but the
+    // schema never advertises is unreachable, and one the handler never passes
+    // is inert. Both directions have to hold for the contract to mean anything.
+    const normalized = normalizeWorkCapsuleScopeInput();
+    const params: Record<string, unknown> = {};
+    for (const key of Object.keys(normalized)) params[key] = `__sentinel_${key}__`;
+
+    const parsed = __testing__.parseScopeInput(params) as Record<string, unknown>;
+    const dropped = Object.keys(normalized).filter(
+      (key) => parsed[key] !== `__sentinel_${key}__`,
+    );
+    expect(
+      dropped,
+      `parseScopeInput drops scope key(s) the normalizer understands: ${dropped.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("carries workShape specifically — the field that shipped broken", () => {
+    const parsed = __testing__.parseScopeInput({
+      workShape: "dependency-advisory-watch@1.0.0",
+    }) as Record<string, unknown>;
+    expect(parsed.workShape).toBe("dependency-advisory-watch@1.0.0");
+    expect(normalizeWorkCapsuleScopeInput(parsed).workShape).toBe(
+      "dependency-advisory-watch@1.0.0",
+    );
+  });
+});


### PR DESCRIPTION
## What happened

PR #4974 shipped the `workShape` claim through the schema, the normalizer and the store — and never through the handler between them. `parseScopeInput` picks scope fields one by one and did not list `workShape`, so the call answered `success: true` and convened a room with **no activity-shape claim**, which the drive skips forever.

Caught on the live install minutes after the upgrade. `WC-F46E17BE` ("Dependency and advisory watch") came back with:

```
"scopeClaims":[{"recordedAt":"...","workroomShape":"approval-sign-off"}]
```

The `workShape` I passed is simply absent.

This is the same defect the doc in that very PR describes for `backlogItemId` on `adopt_worktree` — *"accepted and dropped while the call answered `success: true`"*. I documented the pattern and then reproduced it.

## The fix

One line carries the field. The guard is the point.

`scope-input-parity.test.ts` asserts that every scope key the `create_workroom` **schema advertises**, and every key the **normalizer understands**, survives `parseScopeInput` — with the failure naming the missing key. It is structural rather than one more per-field test, because the next field added will hit exactly this seam.

**Confirmed non-vacuous.** With the fix removed, all three cases fail with `parseScopeInput drops scope key(s) the create_workroom schema advertises: workShape`.

## Why the original tests missed it

They covered normalizer → composer → reader and never crossed the handler seam. A fully green branch shipped a field that could not arrive. That gap is what the new test closes.

## Verification

Local-CI gate passed, evidence `cmtjnqfv308zf01o50wpvmozu`. 632 tests across work-capsules, work-management and the MCP pack; web typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)