### PR TITLE
fix(operate): a governed refusal is not a tool failure

### DIFF
--- a/apps/web/lib/operate/mcp-call-efficiency/analysis.test.ts
+++ b/apps/web/lib/operate/mcp-call-efficiency/analysis.test.ts
@@ -198,3 +198,89 @@ describe("analyzeCallEfficiency (BI-A08EBAEC)", () => {
     expect(report.ledgerSufficiency.usable).toBe(false);
   });
 });
+
+// A governed refusal is not a tool failure. ToolExecution.success is false for
+// both a broken tool and a gate correctly saying no, and counting them together
+// filed `fix_instructions` findings against working gates. Measured live over
+// seven days: ~4,900 of ~5,700 failures were governed refusals.
+describe("governed refusals are not tool failures", () => {
+  it("does not raise high_failure for a gate that declines most calls", () => {
+    // The live shape: record_plan_backlog_coverage at 91% "failure", every one a
+    // readiness refusal. The tool is working; the work was not ready.
+    const events = Array.from({ length: 40 }, (_, i) =>
+      ev({
+        id: `r-${i}`,
+        toolName: "record_plan_backlog_coverage",
+        success: false,
+        governedRefusal: true,
+        createdAt: new Date(`2026-08-03T12:${String(i).padStart(2, "0")}:00.000Z`),
+      }),
+    );
+
+    const report = analyzeCallEfficiency(events);
+
+    expect(report.findings.filter((f) => f.kind === "high_failure")).toEqual([]);
+    const tool = report.topTools.find((t) => t.toolName === "record_plan_backlog_coverage");
+    expect(tool?.refusalCount).toBe(40);
+    expect(tool?.failCount).toBe(0);
+    // Nothing answerable failed, so the tool reads as reliable rather than 9%.
+    expect(tool?.successRate).toBe(1);
+  });
+
+  it("still raises high_failure for real faults mixed in with refusals", () => {
+    // The guard must not become a blanket excuse: refusals are excluded from the
+    // denominator, so genuine faults show a HIGHER rate, not a hidden one.
+    const events = [
+      ...Array.from({ length: 30 }, (_, i) =>
+        ev({ id: `ref-${i}`, toolName: "some_gate", success: false, governedRefusal: true })),
+      ...Array.from({ length: 8 }, (_, i) =>
+        ev({ id: `bad-${i}`, toolName: "some_gate", success: false })),
+      ...Array.from({ length: 2 }, (_, i) =>
+        ev({ id: `ok-${i}`, toolName: "some_gate", success: true })),
+    ];
+
+    const report = analyzeCallEfficiency(events);
+    const finding = report.findings.find((f) => f.kind === "high_failure");
+
+    expect(finding).toBeDefined();
+    // 8 failures out of 10 answerable calls, not 38 out of 40.
+    expect(finding?.title).toContain("80%");
+    expect(finding?.detail).toContain("8/10 answerable calls failed");
+    expect(finding?.detail).toContain("30 further call(s) were governed refusals");
+  });
+
+  it("an unknown error code is still counted as a failure", () => {
+    // The classification is deliberately conservative — a gap in the refusal list
+    // must never silently excuse a broken tool.
+    const events = Array.from({ length: 12 }, (_, i) =>
+      ev({ id: `u-${i}`, toolName: "mystery_tool", success: false }));
+
+    const report = analyzeCallEfficiency(events);
+
+    expect(report.findings.some((f) => f.kind === "high_failure")).toBe(true);
+    expect(report.topTools.find((t) => t.toolName === "mystery_tool")?.failCount).toBe(12);
+  });
+
+  it("names the caller's loop when a retry storm is retrying refusals", () => {
+    // The live case: 4,504 gate_evidence_blocked refusals re-claimed in one day,
+    // filed as "Fix tool errors or agent instructions" — which would have sent
+    // someone to rewrite guidance for a tool that was behaving correctly.
+    const events = Array.from({ length: 30 }, (_, i) =>
+      ev({
+        id: `s-${i}`,
+        toolName: "claim_nonprod_environment_lease",
+        success: false,
+        governedRefusal: true,
+        createdAt: new Date(Date.parse("2026-08-03T12:00:00.000Z") + i * 1000),
+      }),
+    );
+
+    const report = analyzeCallEfficiency(events);
+    const storm = report.findings.find((f) => f.kind === "retry_storm");
+
+    expect(storm).toBeDefined();
+    expect(storm?.detail).toContain("GOVERNED REFUSAL");
+    expect(storm?.detail).toContain("Fix the caller's retry loop");
+    expect(storm?.detail).not.toContain("Fix tool errors or agent instructions");
+  });
+});

--- a/apps/web/lib/operate/mcp-call-efficiency/analysis.ts
+++ b/apps/web/lib/operate/mcp-call-efficiency/analysis.ts
@@ -15,6 +15,12 @@ export type CallEfficiencyEvent = {
   agentId: string;
   userId: string;
   success: boolean;
+  /**
+   * A failed call where a policy correctly declined the action, rather than the
+   * tool breaking. Counted separately from failures so a working gate is never
+   * reported as a misbehaving tool (see refusal-codes.ts).
+   */
+  governedRefusal?: boolean;
   /** GovernedExecuteSource / ToolExecution.executionMode */
   executionMode: string;
   durationMs: number | null;
@@ -69,6 +75,8 @@ export type CallEfficiencyReport = {
     toolName: string;
     count: number;
     failCount: number;
+    /** Calls a policy correctly declined; excluded from failCount and successRate. */
+    refusalCount: number;
     successRate: number;
     avgDurationMs: number | null;
   }>;
@@ -250,6 +258,7 @@ export function analyzeCallEfficiency(
     {
       count: number;
       failCount: number;
+      refusalCount: number;
       durationSum: number;
       durationN: number;
       events: CallEfficiencyEvent[];
@@ -259,12 +268,17 @@ export function analyzeCallEfficiency(
     const row = toolMap.get(e.toolName) ?? {
       count: 0,
       failCount: 0,
+      refusalCount: 0,
       durationSum: 0,
       durationN: 0,
       events: [],
     };
     row.count += 1;
-    if (!e.success) row.failCount += 1;
+    // A governed refusal is neither a success nor a tool failure: it is the
+    // system correctly declining. Counting it as a failure is what filed
+    // `fix_instructions` findings against gates that were working.
+    if (e.governedRefusal) row.refusalCount += 1;
+    else if (!e.success) row.failCount += 1;
     if (e.durationMs != null) {
       row.durationSum += e.durationMs;
       row.durationN += 1;
@@ -277,7 +291,12 @@ export function analyzeCallEfficiency(
       toolName,
       count: v.count,
       failCount: v.failCount,
-      successRate: v.count > 0 ? (v.count - v.failCount) / v.count : 1,
+      refusalCount: v.refusalCount,
+      // Rate the TOOL on the calls it was actually responsible for. A gate that
+      // declines 90% of calls is not a 10%-reliable tool.
+      successRate: v.count - v.refusalCount > 0
+        ? (v.count - v.refusalCount - v.failCount) / (v.count - v.refusalCount)
+        : 1,
       avgDurationMs: v.durationN > 0 ? v.durationSum / v.durationN : null,
     }))
     .sort((a, b) => b.count - a.count)
@@ -327,7 +346,7 @@ export function analyzeCallEfficiency(
   // Retry storm: fail then same tool within retryWindowMs (per correlation).
   const byCorrelation = groupByCorrelation(sorted);
   for (const [correlationId, list] of byCorrelation) {
-    const pairs = new Map<string, { n: number; ids: string[]; agentId: string }>();
+    const pairs = new Map<string, { n: number; refused: number; ids: string[]; agentId: string }>();
     for (let i = 0; i < list.length - 1; i++) {
       const a = list[i]!;
       const b = list[i + 1]!;
@@ -337,10 +356,16 @@ export function analyzeCallEfficiency(
       if (dt < 0 || dt > retryWindowMs) continue;
       const row = pairs.get(a.toolName) ?? {
         n: 0,
-        ids: [],
+        refused: 0,
+        ids: [] as string[],
         agentId: a.agentId,
       };
       row.n += 1;
+      // Retrying a governed refusal is still waste — often worse, because the
+      // refusal is non-retryable and the loop cannot terminate by succeeding.
+      // But it is the CALLER's loop, not a broken tool, and saying "fix tool
+      // errors" sends the reader to the wrong place.
+      if (a.governedRefusal) row.refused += 1;
       if (row.ids.length < 5) row.ids.push(a.id, b.id);
       pairs.set(a.toolName, row);
     }
@@ -351,9 +376,14 @@ export function analyzeCallEfficiency(
         severity: row.n >= retryStormMin * 2 ? "critical" : "warning",
         toolName,
         title: `Retry storm: ${toolName} (${row.n} fail→retry pairs)`,
-        detail:
-          `Execution principal ${correlationId} retried ${toolName} after failure ${row.n} times ` +
-          `within ${retryWindowMs / 1000}s windows. Fix tool errors or agent instructions.`,
+        detail: row.refused >= row.n / 2
+          ? `Execution principal ${correlationId} retried ${toolName} ${row.n} times within `
+            + `${retryWindowMs / 1000}s windows, and ${row.refused} of those followed a GOVERNED REFUSAL `
+            + `rather than a tool failure. The policy declined the action; re-calling cannot make it `
+            + `succeed. Fix the caller's retry loop — not the tool, and not its instructions on how to `
+            + `call it correctly.`
+          : `Execution principal ${correlationId} retried ${toolName} after failure ${row.n} times `
+            + `within ${retryWindowMs / 1000}s windows. Fix tool errors or agent instructions.`,
         evidence: {
           count: row.n,
           ...(list[0]?.threadId ? { threadId: list[0].threadId } : {}),
@@ -407,23 +437,32 @@ export function analyzeCallEfficiency(
         });
       }
     }
+    // Rate the tool on the calls it was answerable for. Governed refusals are
+    // excluded from both the numerator and the denominator: a gate that declines
+    // most of what it is asked is working, and filing `fix_instructions` against
+    // it sends the next agent looking for a defect that is not there.
+    const answerableCalls = t.count - t.refusalCount;
+    const failureRate = answerableCalls > 0 ? t.failCount / answerableCalls : 0;
     if (
-      t.count >= highFailureMinSamples &&
-      t.failCount / t.count >= highFailureRate
+      answerableCalls >= highFailureMinSamples &&
+      failureRate >= highFailureRate
     ) {
       findings.push({
         kind: "high_failure",
-        severity: t.failCount / t.count >= 0.6 ? "critical" : "warning",
+        severity: failureRate >= 0.6 ? "critical" : "warning",
         toolName: t.toolName,
-        title: `High failure: ${t.toolName} (${(t.failCount / t.count * 100).toFixed(0)}%)`,
+        title: `High failure: ${t.toolName} (${(failureRate * 100).toFixed(0)}%)`,
         detail:
-          `${t.failCount}/${t.count} calls failed. Agents may be retrying blindly — ` +
-          `fix tool contract, grants, or skill guidance.`,
+          `${t.failCount}/${answerableCalls} answerable calls failed. Agents may be retrying blindly — ` +
+          `fix tool contract, grants, or skill guidance.` +
+          (t.refusalCount > 0
+            ? ` ${t.refusalCount} further call(s) were governed refusals and are excluded — the policy declined them, the tool did not fail.`
+            : ""),
         evidence: {
-          count: t.count,
+          count: answerableCalls,
           failCount: t.failCount,
           sampleIds: sorted
-            .filter((e) => e.toolName === t.toolName && !e.success)
+            .filter((e) => e.toolName === t.toolName && !e.success && !e.governedRefusal)
             .slice(0, 5)
             .map((e) => e.id),
         },

--- a/apps/web/lib/operate/mcp-call-efficiency/refusal-codes.ts
+++ b/apps/web/lib/operate/mcp-call-efficiency/refusal-codes.ts
@@ -1,0 +1,58 @@
+// A governed refusal is not a tool failure.
+//
+// `ToolExecution.success` is false for two entirely different events: a tool that
+// broke, and a gate that correctly said no. The call-efficiency scan counted both,
+// so a governed gate doing its job read as a misbehaving tool and got filed as a
+// `high_failure` finding recommending `fix_instructions` — agent guidance, for a
+// tool with nothing wrong with it.
+//
+// Measured on the live install over seven days (2026-09-02): of ~5,700 failed
+// ToolExecutions, roughly 4,900 were governed refusals — `gate_evidence_blocked`
+// alone was 4,520 — against ~235 genuine caller defects. Two of the four
+// MCP-efficiency backlog items open at the time existed only because of this
+// conflation, and each one costs the next agent a pass to discover there is
+// nothing to fix.
+//
+// The classification is deliberately CONSERVATIVE: a code is treated as a refusal
+// only when it is listed here. An unknown code counts as a failure, so a genuinely
+// broken tool is never silently excused by a gap in this list. The cost of being
+// wrong runs one way — a missed finding is re-detected on the next scan, while a
+// wrongly-excused fault goes unreported.
+
+/**
+ * Error codes where the tool worked and a policy declined the action.
+ *
+ * Add a code here only when the refusal means "the system correctly said no",
+ * never merely "this call did not succeed".
+ */
+export const GOVERNED_REFUSAL_CODES: ReadonlySet<string> = new Set([
+  // Readiness / completion policy declined the transition.
+  "initiative_not_ready",
+  "gate_evidence_blocked",
+  "traceability-incomplete",
+  "plan-artifact-invalid",
+  // The action needs a human or a higher authority first.
+  "approval_required",
+  "alignment_escalation_required",
+  "insufficient_token_scope",
+  "AUTHORIZATION_DENIED",
+  // Another holder owns the resource; declining is the correct answer.
+  "branch_occupied",
+  "scope_conflict",
+  "nonprod_lease_not_owner",
+  "lease_terminal",
+  // The request duplicates work already recorded.
+  "idempotency_conflict",
+]);
+
+/**
+ * Whether a failed ToolExecution was a governed refusal rather than a fault.
+ *
+ * Reads the tool's own error code out of its result payload. A result with no
+ * code cannot be shown to be a refusal, so it stays a failure.
+ */
+export function isGovernedRefusal(result: unknown): boolean {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return false;
+  const code = (result as { error?: unknown }).error;
+  return typeof code === "string" && GOVERNED_REFUSAL_CODES.has(code);
+}

--- a/apps/web/lib/operate/mcp-call-efficiency/report.ts
+++ b/apps/web/lib/operate/mcp-call-efficiency/report.ts
@@ -10,6 +10,7 @@ import {
   type EfficiencyFinding,
 } from "./analysis";
 import type { AiOpsHandoffResult } from "./aiops-handoff";
+import { isGovernedRefusal } from "./refusal-codes";
 
 export type LoadCallEfficiencyOptions = AnalyzeCallEfficiencyOptions & {
   /** Lookback hours (default 24, max 168). */
@@ -53,6 +54,7 @@ export async function loadCallEfficiencyEvents(
       agentId: true,
       userId: true,
       success: true,
+      result: true,
       executionMode: true,
       durationMs: true,
       createdAt: true,
@@ -72,6 +74,7 @@ export async function loadCallEfficiencyEvents(
     agentId: r.agentId,
     userId: r.userId,
     success: r.success,
+    governedRefusal: !r.success && isGovernedRefusal(r.result),
     executionMode: r.executionMode,
     durationMs: r.durationMs,
     createdAt: r.createdAt,

--- a/docs/superpowers/specs/2026-08-03-mcp-call-efficiency-loop-design.md
+++ b/docs/superpowers/specs/2026-08-03-mcp-call-efficiency-loop-design.md
@@ -32,8 +32,15 @@ External MCP clients (Claude/Codex/Grok) and in-portal coworkers burn tokens via
 ### Dimensions
 - **Surface:** `executionMode` (+ `apiTokenId` present ⇒ external PAT)
 - **Identity:** `agentId`, `userId`, `threadId`, `taskRunId`, `skillId`
-- **Tool:** `toolName`, success, `durationMs`
+- **Tool:** `toolName`, success, governed-refusal flag, `durationMs`
 - **Window:** default 24h, max 7d
+
+### A governed refusal is not a tool failure
+`ToolExecution.success` is false for two different events: a tool that broke, and a gate that correctly said no. Counting them together makes a working gate read as a misbehaving tool. Measured on the live install over seven days (2026-09-02): of ~5,700 failed executions, ~4,900 were governed refusals — `gate_evidence_blocked` alone was 4,520 — against ~235 genuine caller defects (`missing_required`, `invalid_input`, `invalid_status`).
+
+`refusal-codes.ts` holds the closed list, read from the tool's own `result.error`. Refusals are excluded from `failCount` **and** from the `high_failure` denominator, so a tool is rated on the calls it was answerable for; they are reported separately as `refusalCount`. The list is deliberately conservative — an unrecognised code stays a failure, because a missed finding is re-detected on the next scan while a wrongly-excused fault is not.
+
+A `retry_storm` whose pairs are mostly refusals is still reported (retrying a non-retryable refusal is waste, and the loop cannot end by succeeding) but is worded to point at the caller's retry loop rather than at the tool or its instructions.
 
 ### Finding kinds
 1. `thrash` — same tool ≥ N times in one thread within window  

--- a/docs/superpowers/specs/2026-08-03-mcp-call-efficiency-loop-design.md
+++ b/docs/superpowers/specs/2026-08-03-mcp-call-efficiency-loop-design.md
@@ -1,3 +1,7 @@
+---
+status: active
+---
+
 # MCP Call Efficiency Loop (BI-A08EBAEC) — Design
 
 ## Problem


### PR DESCRIPTION
`ToolExecution.success` is false for two entirely different events: **a tool that broke**, and **a gate that correctly said no**. The call-efficiency scan counted both, so a governed gate doing its job read as a misbehaving tool and got filed as a `high_failure` finding recommending `fix_instructions` — agent guidance, for a tool with nothing wrong with it.

## Measured, over seven days on the live install

| | |
|---|---|
| failed ToolExecutions | ~5,700 |
| **governed refusals** | **~4,900** (`gate_evidence_blocked` alone: 4,520) |
| genuine caller defects | ~235 (`missing_required`, `invalid_input`, `invalid_status`) |

Two of the four MCP-efficiency backlog items open at the time existed **only** because of this conflation. Each one costs the next agent a pass to discover there is nothing to fix — I nearly spent one that way, which is how this was found.

Concretely: `record_plan_backlog_coverage` reads as 91% failure and `claim_backlog_item_for_work` as 70%, and in both cases the "failures" are the readiness policy declining transitions. The tools are fine.

## The change

- **`refusal-codes.ts`** — a closed, deliberately conservative list, read from the tool's own `result.error`. An unrecognised code stays a failure: a missed finding is re-detected on the next scan, while a wrongly-excused fault is not. The cost of being wrong runs one way.
- **Refusals leave both sides of the ratio.** They are excluded from `failCount` *and* from the `high_failure` denominator, so a tool is rated on the calls it was answerable for. A gate that declines 90% of what it is asked is not a 10%-reliable tool. They surface separately as `refusalCount`.
- **Retry storms are still reported when they are refusals** — retrying a non-retryable refusal is waste, and worse than ordinary waste because the loop cannot terminate by succeeding. But the finding now names *the caller's retry loop* instead of "fix tool errors or agent instructions", which is what pointed readers at the tool.

## Verification

The `answerableCalls` denominator was reverted and the suite failed (**19/20**); restored and it passed (**20/20**). A guard I have not watched fail is a guard I have not tested.

- local-CI gate **PASS** on `58b9daf36cc4`
- **63** preflight guards clean · 20 tests · `tsc --noEmit` clean

## Worth pressing on

1. **The refusal list is a judgement, not a measurement.** Thirteen codes, chosen by reading what each one means. `idempotency_conflict` and `lease_terminal` are the two I would argue about — both are arguably "the caller asked for something already settled" rather than a policy decision. Nothing enforces that the list stays honest as codes are added.
2. **This does not fix the two items it explains.** `record_plan_backlog_coverage` at 91% still deserves someone reading the actual failing payloads to see whether callers hit *one* validation repeatedly — which would be a real contract-affordance defect — or many different ones. I deliberately did not guess at that.
3. **`(no code)` is 410 failures across 29 tools** and is untouched here. Those cannot be classified either way, and some fraction of them are probably refusals too.

Related: BI-MCP-EFF-DF344B5F, BI-MCP-EFF-A88AC25A, BI-MCP-EFF-852B5BBE, BI-MCP-EFF-C2E0686D (all re-measured and annotated 2026-09-02), and BI-B5687140.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)