### PR TITLE
doc(pet-rescue): re-verify §6c on the next build, and correct one row's evidence

### DIFF
--- a/docs/architecture/archetypes/pet-rescue-operating-model.md
+++ b/docs/architecture/archetypes/pet-rescue-operating-model.md
@@ -383,6 +383,31 @@ move, and why the two numbers are reported apart.
   was corrected and the tile now totals each currency instead of refusing outright. Worth
   recording: the refusal was always correct behaviour — the defect was upstream of it.
 
+**Re-verified on the next build, `v2026.09.02` — two rows firm up, the figure does not move.**
+
+- **10:00 medical.** §6c scored this partial because a `New event` control had appeared. On
+  `v2026.09.01` that control did not actually work: the dialog closed as though it had saved and
+  the POST returned `503`, so no slot was ever recorded. On `v2026.09.02` the same booking
+  **persists across a reload**. The row was right in the end, but it had been scored from the
+  presence of a control rather than from a saved record — worth naming, because *control exists*
+  and *write succeeds* are different measurements and only the second one is the step.
+- **16:00 numbers.** The cockpit now states the population: **`Animals in care — 6 animals · 4 on
+  hold · 1 available · 1 pending`**, ahead of any money, and the adoption recorded during the run
+  moved `Animals placed` to 1. Kennels-free is still unanswerable and intakes are still not
+  recorded as intakes, so the row stays partial.
+
+Operability stays **0.40**. Both changes improved a step that was already partial rather than
+converting one, which is the pattern this whole tranche has followed: the product has become
+markedly less misleading without becoming more capable. Nothing reaches *completed*, and the two
+steps still impossible — rounds and foster placement — are both waiting on the same keystone.
+
+**A measurement caution earned during this re-run.** Three apparent defects — a `503` on the
+calendar write, an animal status change that fired no request at all, and a "Reload to reconnect"
+banner — were all one thing: the portal was mid-upgrade and restarting underneath the run. Every
+one of them would have been filed as a product defect. Before recording a failed step, confirm the
+install is healthy and serving the build you think it is; a run against a restarting container
+measures the restart.
+
 **Still measured absent, and the reason:** no volunteer or foster-carer worker class on the People
 surface, no ward or foster-home work location, and no rescue role. The archetype declares all of
 them; the seeder that applies them read a cuid where a slug was required and therefore seeded
@@ -624,4 +649,4 @@ The archetype may be described as supported when:
 
 An archetype below **0.6 coverage** must not be described as supported in external material, and
 below **0.8 operability** must not be described as operable. Current: **0.05 coverage**
-(2026-08-25), **0.30 operability** (2026-08-26).
+(2026-08-25), **0.40 operability** (2026-09-01, §6c).


### PR DESCRIPTION
## Why

§6c recorded the post-fix re-run at **0.40 operability** on 2026-09-01. Re-running the same ten steps on the next build, `v2026.09.02-capacity-proof-of-life.1`, firms up two rows and corrects how one of them was measured.

## The correction that matters

§6c scored **10:00 medical** as partial because a `New event` control had appeared on the calendar. On `v2026.09.01` that control did not work: the dialog closed as though it had saved and the POST returned `503`, so no slot was ever recorded. On `v2026.09.02` the same booking **persists across a reload**.

The row is right in the end, but it had been scored from the presence of a control rather than from a saved record. *Control exists* and *write succeeds* are different measurements, and only the second one is the step. Worth naming because it is the cheapest mistake to make when re-scoring quickly.

## What else moved

**16:00 numbers** — the cockpit now states the population: `Animals in care — 6 animals · 4 on hold · 1 available · 1 pending`, ahead of any money, and the adoption recorded during the run moved `Animals placed` to 1. Kennels-free is still unanswerable and intakes are still not recorded as intakes, so the row stays partial.

## The figure does not move

**Operability stays 0.40.** Both changes improved steps that were *already partial* rather than converting one — the pattern this whole tranche has followed. The product has become markedly less misleading without becoming more capable. Nothing reaches *completed*, and the two steps still impossible — rounds and foster placement — wait on the same keystone (`BI-4F8A484C`).

An independent scoring of the same run came out at 0.35 rather than 0.40, differing on one judgement: whether 13:00 counts as partial because the found-pet caller can now reach the rescue, or impossible because searching intake records still cannot be done. §6c's reading is kept; the disagreement is recorded here because it is the kind of boundary call that should be visible rather than silently re-decided.

## Stale headline corrected

§8 still read `0.30 operability (2026-08-26)`. §6c moved it to 0.40 on 2026-09-01 and the header had not followed. Corrected, with the section named so the two cannot drift again.

## A measurement caution, earned during this re-run

Three apparent defects — a `503` on the calendar write, an animal status change that fired **no request at all**, and a "Reload to reconnect" banner — were one thing: the portal was mid-upgrade and restarting underneath the run. All three would have been filed as product defects. The doc now says to confirm the install is healthy and serving the build you think it is before recording a failed step; a run against a restarting container measures the restart.

## Verification

Documentation only. `pregate:preflight` — 63 guards clean in 134.7s. Doc index regenerated by the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)