### PR TITLE
feat(worktree): the platform owns, sees and bounds its own worktrees (BI-99395B29, BI-0B2F0546)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,17 @@ DPF_HOST_PLATFORM=
 DPF_HOST_ARCH=
 # Absolute host dir for Postgres backups (kept OUTSIDE the install root by design).
 DPF_BACKUPS_HOST_PATH=
+# Absolute host dir holding this install's git worktrees. The platform mounts it
+# at /host-worktrees so the server-side worktree janitor can SEE what it is
+# responsible for — without it the job scans nothing, finds nothing, and reports
+# success, which is how 528 GB accumulated on the development install
+# (BI-99395B29). The base is a SIBLING of the install root, so the /host-dpf
+# mount does not contain it.
+#
+# Leave blank to keep the historical derived default (<install path>-worktrees),
+# which is what scripts/lib/worktree-base.mjs resolves. Set it when the base
+# lives somewhere else.
+DPF_WORKTREE_BASE=
 
 # ── MCP client authentication (OAuth 2.1 authorization server) ────────────────
 # Every value here is an operator decision from

--- a/apps/web/lib/queue/functions/worktree-janitor.test.ts
+++ b/apps/web/lib/queue/functions/worktree-janitor.test.ts
@@ -11,6 +11,9 @@ import {
   WORKTREE_JANITOR_ENABLED_FLAG,
   WORKTREE_JANITOR_AUTO_REAP_FLAG,
   type ScanOutcome,
+  WORKTREE_JANITOR_MAX_FLAG,
+  DEFAULT_MAX_WORKTREES,
+  resolveMaxWorktrees,
 } from "./worktree-janitor";
 
 const ENABLED = { [WORKTREE_JANITOR_ENABLED_FLAG]: "1" };
@@ -76,7 +79,7 @@ describe("worktree-janitor schedule invariants (BI-42FA7DD8)", () => {
     });
     const result = await runWorktreeJanitor({ env: ENABLED, runScan });
     expect(result.skipped).toBe(false);
-    if (result.skipped) throw new Error("expected summary");
+    if (result.skipped || "healthy" in result) throw new Error("expected summary");
     expect(result.mode).toBe("dry-run");
     expect(result.tierA).toBe(2);
     expect(result.tierB).toBe(1);
@@ -91,19 +94,86 @@ describe("worktree-janitor schedule invariants (BI-42FA7DD8)", () => {
     });
     const result = await runWorktreeJanitor({ env: AUTO, runScan });
     expect(result.skipped).toBe(false);
-    if (result.skipped) throw new Error("expected summary");
+    if (result.skipped || "healthy" in result) throw new Error("expected summary");
     expect(result.mode).toBe("live");
     expect(result.removed).toBe(2);
   });
 
-  it("skips when scan unavailable", async () => {
+  // This test used to assert `skipped: true` for an unreachable scan. That was
+  // the defect, not the contract: a backstop that cannot see its subject
+  // reported the same shape as one that had nothing to do, so a blind janitor
+  // looked healthy while 528 GB accumulated behind it (BI-99395B29).
+  it("reports UNHEALTHY, not skipped, when it cannot see its worktree base", async () => {
     const runScan = vi.fn(async (): Promise<ScanOutcome> => ({
       available: false,
       reason: "could not resolve git root",
     }));
     const result = await runWorktreeJanitor({ env: ENABLED, runScan });
-    expect(result.skipped).toBe(true);
-    if (!result.skipped) throw new Error("expected skip");
+
+    expect(result.skipped).toBe(false);
+    if (result.skipped) throw new Error("expected an unhealthy result, not a skip");
+    expect("healthy" in result && result.healthy === false).toBe(true);
+    if (!("healthy" in result)) throw new Error("expected the unhealthy shape");
     expect(result.reason).toMatch(/git root/);
+  });
+
+  it("is distinguishable from a benign disabled skip", async () => {
+    // The whole point: "switched off" and "on but blind" must not look alike.
+    const blind = await runWorktreeJanitor({
+      env: ENABLED,
+      runScan: vi.fn(async (): Promise<ScanOutcome> => ({ available: false, reason: "no host view" })),
+    });
+    const off = await runWorktreeJanitor({
+      env: {},
+      runScan: vi.fn(async () => scanOutcome()),
+    });
+
+    expect(off.skipped).toBe(true);
+    expect(blind.skipped).toBe(false);
+  });
+
+  it("reaps Tier-A above the bound without waiting for a decision", async () => {
+    // The commandment's operative half: a default that needs a technical
+    // decision from a non-technical owner is a deferred outage, not a safe
+    // default. Over the bound, the run goes live on its own.
+    const modes: string[] = [];
+    const runScan = vi.fn(async (mode: "dry-run" | "live") => {
+      modes.push(mode);
+      return scanOutcome(mode);
+    });
+    const result = await runWorktreeJanitor({
+      env: { ...ENABLED, [WORKTREE_JANITOR_MAX_FLAG]: "1" },
+      runScan,
+    });
+
+    expect(modes).toEqual(["dry-run", "live"]);
+    expect(result.skipped).toBe(false);
+    if (result.skipped || "healthy" in result) throw new Error("expected a summary");
+    expect(result.mode).toBe("live");
+  });
+
+  it("stays an observation while under the bound", async () => {
+    const modes: string[] = [];
+    const runScan = vi.fn(async (mode: "dry-run" | "live") => {
+      modes.push(mode);
+      return scanOutcome(mode);
+    });
+    const result = await runWorktreeJanitor({
+      env: { ...ENABLED, [WORKTREE_JANITOR_MAX_FLAG]: "999" },
+      runScan,
+    });
+
+    expect(modes).toEqual(["dry-run"]);
+    expect(result.skipped).toBe(false);
+    if (result.skipped || "healthy" in result) throw new Error("expected a summary");
+    expect(result.mode).toBe("dry-run");
+  });
+
+  it("falls back to the default bound rather than disabling it on a malformed value", () => {
+    // A typo'd bound must not silently mean "never reap".
+    expect(resolveMaxWorktrees({ [WORKTREE_JANITOR_MAX_FLAG]: "abc" })).toBe(DEFAULT_MAX_WORKTREES);
+    expect(resolveMaxWorktrees({ [WORKTREE_JANITOR_MAX_FLAG]: "0" })).toBe(DEFAULT_MAX_WORKTREES);
+    expect(resolveMaxWorktrees({ [WORKTREE_JANITOR_MAX_FLAG]: "  " })).toBe(DEFAULT_MAX_WORKTREES);
+    expect(resolveMaxWorktrees({ [WORKTREE_JANITOR_MAX_FLAG]: "12" })).toBe(12);
   });
 });

--- a/apps/web/lib/queue/functions/worktree-janitor.ts
+++ b/apps/web/lib/queue/functions/worktree-janitor.ts
@@ -35,6 +35,34 @@ export const WORKTREE_JANITOR_ENABLED_FLAG = "DPF_WORKTREE_JANITOR_ENABLED";
  */
 export const WORKTREE_JANITOR_AUTO_REAP_FLAG = "DPF_WORKTREE_JANITOR_AUTO_REAP";
 
+/**
+ * Upper bound on retained worktrees, above which Tier-A reaping runs WITHOUT a
+ * human decision. This is the operative half of
+ * `platform-function-never-depends-on-a-client`: a default that requires a
+ * technical action from a non-technical owner is not a safe default, it is a
+ * deferred outage.
+ *
+ * Bounded rather than absolute — the excess is reaped oldest-first, and only
+ * Tier A, which `classifyWorktree` already defines as merged, clean, unpinned,
+ * without an open PR and without a live session heartbeat. Tier B and anything
+ * unmerged or unpushed keep explicit-go; that constraint is load-bearing, since
+ * a sweep of the development install found ~137 branches with commits never
+ * pushed and one abandoned worktree holding a finished, signed, tested commit.
+ */
+export const WORKTREE_JANITOR_MAX_FLAG = "DPF_WORKTREE_JANITOR_MAX";
+
+/** Generous enough that ordinary concurrent work never trips it; far below the
+ *  193 observed when nothing reaped at all. */
+export const DEFAULT_MAX_WORKTREES = 40;
+
+export function resolveMaxWorktrees(env: Record<string, string | undefined>): number {
+  const raw = (env[WORKTREE_JANITOR_MAX_FLAG] ?? "").trim();
+  if (raw.length === 0) return DEFAULT_MAX_WORKTREES;
+  const parsed = Number.parseInt(raw, 10);
+  // A malformed bound must not silently disable the bound.
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_WORKTREES;
+}
+
 const JANITOR_SCRIPT = "worktree-janitor.mjs";
 const SCAN_TIMEOUT_MS = 300_000;
 const SCAN_MAX_BUFFER = 8 * 1024 * 1024;
@@ -69,6 +97,13 @@ export type ScanOutcome =
 
 export type RunResult =
   | { skipped: true; reason: string }
+  /**
+   * Enabled, scheduled, and unable to see what it is responsible for. This is
+   * NOT a skip: a backstop that cannot reach its subject must never report
+   * success. Returning `skipped` here is how 528 GB accumulated behind a job
+   * that ran on time and found nothing (BI-99395B29).
+   */
+  | { skipped: false; healthy: false; reason: string }
   | {
       skipped: false;
       mode: "dry-run" | "live";
@@ -165,30 +200,34 @@ async function defaultRunScan(mode: "dry-run" | "live"): Promise<ScanOutcome> {
   }
 }
 
-export async function runWorktreeJanitor(options: RunOptions = {}): Promise<RunResult> {
-  const env = options.env ?? process.env;
-
-  if (!envFlagEnabled(env, WORKTREE_JANITOR_ENABLED_FLAG)) {
-    return {
-      skipped: true,
-      reason: `disabled (${WORKTREE_JANITOR_ENABLED_FLAG} not set)`,
-    };
+/**
+ * Worktrees this install is holding on to. Counts every decision the scan
+ * returned rather than only the reapable ones: the bound is about how much is
+ * accumulating, not about how much happens to be safe to delete right now.
+ */
+export function countRetained(scan: WorktreeJanitorScan): number {
+  // An EMPTY decisions array is "not populated", not "zero worktrees" — a scan
+  // may report only a summary. Reading empty as zero would put the install
+  // permanently under any bound, which is the same silent-success failure this
+  // whole change exists to remove.
+  if (Array.isArray(scan.decisions) && scan.decisions.length > 0) {
+    return scan.decisions.length;
   }
+  const counts = scan.summary?.counts ?? {};
+  return Object.values(counts).reduce((sum, n) => sum + (typeof n === "number" ? n : 0), 0);
+}
 
-  const autoReap =
-    envFlagEnabled(env, WORKTREE_JANITOR_AUTO_REAP_FLAG) &&
-    envFlagEnabled(env, WORKTREE_JANITOR_ENABLED_FLAG);
-  const mode: "dry-run" | "live" = autoReap ? "live" : "dry-run";
+/** A backstop that cannot reach its subject reports UNHEALTHY, never success. */
+function unhealthy(reason: string): RunResult {
+  console.error(
+    `[worktree-janitor] UNHEALTHY — enabled but cannot see its worktree base: ${reason}. ` +
+      "Nothing was scanned, so nothing being found is not evidence that nothing is there.",
+  );
+  return { skipped: false, healthy: false, reason };
+}
 
-  const runScan = options.runScan ?? defaultRunScan;
-  const outcome = await runScan(mode);
-
-  if (!outcome.available) {
-    console.warn(`[worktree-janitor] scan unavailable: ${outcome.reason}`);
-    return { skipped: true, reason: outcome.reason };
-  }
-
-  const { scan } = outcome;
+/** Shared reporting for both the observation and the live run. */
+function summarize(scan: WorktreeJanitorScan, mode: "dry-run" | "live"): RunResult {
   if (mode === "dry-run" && scan.mode !== "dry-run") {
     console.error(
       `[worktree-janitor] REFUSING unexpected scan mode "${scan.mode}" for observe run`,
@@ -230,6 +269,54 @@ export async function runWorktreeJanitor(options: RunOptions = {}): Promise<RunR
 
   console.warn(`[worktree-janitor] summary: ${JSON.stringify(result)}`);
   return result;
+}
+
+export async function runWorktreeJanitor(options: RunOptions = {}): Promise<RunResult> {
+  const env = options.env ?? process.env;
+
+  if (!envFlagEnabled(env, WORKTREE_JANITOR_ENABLED_FLAG)) {
+    return {
+      skipped: true,
+      reason: `disabled (${WORKTREE_JANITOR_ENABLED_FLAG} not set)`,
+    };
+  }
+
+  const explicitAutoReap =
+    envFlagEnabled(env, WORKTREE_JANITOR_AUTO_REAP_FLAG) &&
+    envFlagEnabled(env, WORKTREE_JANITOR_ENABLED_FLAG);
+
+  const runScan = options.runScan ?? defaultRunScan;
+
+  // An explicit auto-reap request keeps its existing contract exactly: go
+  // straight to live, one scan, no bound evaluation.
+  if (explicitAutoReap) {
+    const live = await runScan("live");
+    if (!live.available) return unhealthy(live.reason);
+    return summarize(live.scan, "live");
+  }
+
+  // Otherwise observe first. The bound is a property of what is actually there,
+  // so it cannot be evaluated before looking — and looking is never destructive.
+  const observed = await runScan("dry-run");
+  if (!observed.available) return unhealthy(observed.reason);
+
+  const retained = countRetained(observed.scan);
+  const max = resolveMaxWorktrees(env);
+
+  if (retained <= max) {
+    return summarize(observed.scan, "dry-run");
+  }
+
+  console.warn(
+    `[worktree-janitor] over bound: ${retained} worktrees retained, bound ${max} ` +
+      `(${WORKTREE_JANITOR_MAX_FLAG}). Reaping Tier-A excess without waiting for a decision — ` +
+      "Tier B and anything unmerged or unpushed still require an explicit go.",
+  );
+
+  const live = await runScan("live");
+  if (!live.available) return unhealthy(live.reason);
+  return summarize(live.scan, "live");
+
 }
 
 export const worktreeJanitor = inngest.createFunction(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,16 @@ services:
       # directory at token generation time. Requires DPF_HOST_INSTALL_PATH
       # to be set in .env (done by the installer at setup time).
       - ${DPF_HOST_INSTALL_PATH:-.}:/host-dpf
+      # The platform's own worktree base, so the server-side worktree janitor can
+      # SEE what it is responsible for. Without this the job scans nothing, finds
+      # nothing, and reports success — which is how 528 GB accumulated behind a
+      # feature that was written, shipped and defaulted off (BI-99395B29).
+      #
+      # The base is a SIBLING of the install root, so /host-dpf does not contain
+      # it. Resolution is platform-owned (scripts/lib/worktree-base.mjs); the
+      # default here reproduces that module's derived default so an install that
+      # sets nothing behaves exactly as it does today.
+      - ${DPF_WORKTREE_BASE:-${DPF_HOST_INSTALL_PATH:-.}-worktrees}:/host-worktrees
       # Signed transition receipts are host-owned; portal verifies read-only.
       # DPF_STATE_DIR MUST be an absolute, Docker-Desktop-shared host path (the
       # installer writes ~/.dpf). The ${HOME} fallback is a dev-only last resort:

--- a/docs/superpowers/specs/2026-09-02-platform-owned-client-configuration-design.md
+++ b/docs/superpowers/specs/2026-09-02-platform-owned-client-configuration-design.md
@@ -1,0 +1,242 @@
+---
+title: Platform-owned client configuration — the platform declares how work is done
+status: draft
+author: Claude (Opus 5)
+reviewers:
+  - Mark (operator review pending)
+date: 2026-09-02
+backlog:
+  - BI-99395B29 (the reaper this unblocks)
+  - BI-7F775D03 (fresh worktrees cannot run their own gate)
+epics:
+  - EP-CLIENT-CONFIG
+related:
+  - docs/founder-kernel/wiki/principles/platform-function-never-depends-on-a-client.md
+  - docs/founder-kernel/wiki/principles/worktree-selection-and-reaping.md
+  - docs/founder-kernel/wiki/principles/no-provider-pinning.md
+  - docs/superpowers/specs/2026-05-26-agent-toolchain-bootstrap-design.md
+  - docs/superpowers/specs/2026-06-02-dpf-client-hook-plane-design.md
+  - packages/dpf-bootstrap/src/agent-toolchain/
+  - apps/web/lib/queue/functions/worktree-janitor.ts
+---
+
+# Platform-owned client configuration
+
+## Purpose
+
+When any client works on DPF, the platform should configure that client to work the way the
+platform needs — starting with where work happens. Today the direction of control is inverted: the
+clients decide, and the platform infers. This spec turns it around.
+
+It extends [`2026-05-26-agent-toolchain-bootstrap-design`](2026-05-26-agent-toolchain-bootstrap-design.md),
+which established the DPF-owned install step and the per-client planners. That design settled *that*
+the platform configures clients. This one settles *what it owns* now that
+[`platform-function-never-depends-on-a-client`](../../founder-kernel/wiki/principles/platform-function-never-depends-on-a-client.md)
+draws the line.
+
+## The dividing line this inherits
+
+The commandment supplies the test, and it is the whole architecture of this spec:
+
+> **Client configuration may buy ergonomics and speed. It may never carry a guarantee.**
+
+Anything that must be *true* goes server-side. Anything that merely makes an agent faster, cheaper
+or less obstructed belongs in client config. Every item below is placed by that test, and the test
+is what keeps this epic from becoming "put more of the platform in the client."
+
+It also rules out the tempting wrong answer. The client hook plane is **contributor-only by explicit
+design** — its own spec states hooks *"live in the contributor `.claude/settings.json`, never in any
+path the customer install touches."* So "ship the hooks everywhere" is not available, and was never
+the intended safety net.
+
+## Problem statement — measured, not asserted
+
+### 1. The platform does not know where its own work happens
+
+`CANONICAL_WORKTREE_BASE = "D:\DPF-worktrees"` is a constant in
+`packages/dpf-bootstrap/src/agent-toolchain/codex-config.ts` — **client** configuration.
+`scripts/lib/local-ci-slot-manifest.mjs` independently derives the same location as
+`dirname(rootClone) + "-worktrees"`. The portal has no owned notion of the path at all.
+
+The consequence is not theoretical. The portal's worktree janitor is server-side and correct, and it
+is **structurally blind**: the portal binds the install root, and the worktree base is a *sibling* of
+it, outside every mount. Verified from inside the container — the directory does not exist there.
+Enabling `DPF_WORKTREE_JANITOR_ENABLED` and `DPF_WORKTREE_JANITOR_AUTO_REAP` today would scan
+nothing, find nothing, and report success.
+
+Measured on the development install, 2026-09-02: **193 worktrees, 528.4 GB — 45% of all used disk**,
+growing **17.6 worktrees/day**. Roughly a **15-day runway** on a 1.9 TB box. A 512 GB machine does not
+get a fortnight.
+
+### 2. Bootstrap configures no permissions
+
+No allowlist, no approval posture. Every DPF-shaped tool call risks an approval prompt, which on an
+autonomous surface is a stall rather than a nuisance. That a `fewer-permission-prompts` skill exists
+is the tell: the pain is real and is being solved per-user instead of shipped once.
+
+`approval_policy`, `sandbox_mode`, `model` and `model_reasoning_effort` are read and round-tripped by
+the Codex planner but never set.
+
+### 3. Surface coverage is uneven
+
+| Surface | Planner | Lines | State |
+|---|---|---|---|
+| Codex | `codex-config.ts` | 392 | plugin enable, competing-plugin disable, MCP disable, project trust |
+| Claude | `claude-plugins.ts` | 174 | plugin install, version pinning, stale reconciliation |
+| Grok | `grok-config.ts` | **81** | thin |
+| Antigravity | — | — | unsupported-until-proven |
+
+### 4. Doctrine routing is repo-local only
+
+`CLAUDE.md`, `CONVENTIONS.md`, `.cursor/rules/000-load-agents.mdc`, `.clinerules/000-load-agents.md`,
+`.continue/rules/000-load-agents.md` and `.github/copilot-instructions.md` all point at `AGENTS.md`
+— and all live in the **source checkout**. A session rooted at an installed instance receives none
+of them, and nothing warns that the canonical contract is absent.
+
+This one sits closest to the line. Knowing the rules is arguably a guarantee, not an ergonomic, and
+§6 treats it accordingly.
+
+## Existing substrate — what must NOT be rebuilt
+
+Verified before proposing anything, per `verify-substrate-before-proposing-new`:
+
+- `scripts/lib/worktree-janitor-core.mjs` — `classifyWorktree()` already encodes the full Tier-A /
+  Tier-B safety model: SKIP root clone, detached HEAD and `main`; honour `.worktree-pinned`; KEEP an
+  open PR; KEEP a live session heartbeat so a worktree is never reaped under a running session.
+- `scripts/lib/junction-safe-worktree-remove.mjs` — junction-safe deletion. Load-bearing: a naive
+  recursive delete follows pnpm junctions and guts the donor clone.
+- `apps/web/lib/queue/functions/worktree-janitor.ts` — already a server-side Inngest job, explicitly
+  *"NOT a CLI client cron"*.
+- `packages/dpf-bootstrap/src/agent-toolchain/` — per-client planners, MCP config, memory seeding,
+  readiness probes, smoke test, evidence queue, upstream version checks.
+
+The classifier, the safety doctrine, the deletion primitive and the server-side host all exist. This
+epic supplies what they lack: **a platform-owned location, sight of it, and a bound.**
+
+## Design
+
+### §1 — The platform owns the worktree base (keystone)
+
+The install declares its worktree base as platform configuration, resolved server-side and exposed
+through one accessor. Bootstrap **reads it from the platform** and writes it into each client's
+config, inverting today's direction. `codex-config.ts` stops being the definition and becomes a
+consumer; `local-ci-slot-manifest.mjs` stops deriving and asks.
+
+Resolution order, most specific first: explicit install configuration → an environment override →
+the current derived default (`dirname(rootClone) + "-worktrees"`), which keeps every existing install
+working unchanged.
+
+**Acceptance:** the portal can name its worktree base without consulting any client artifact, and
+`codex-config.ts` contains no hardcoded path.
+
+### §2 — The portal can see it
+
+The platform's own compose mounts the declared base into the portal, the same shape as the two host
+binds already present. The mount is shipped by the platform, not added by an operator.
+
+**Acceptance:** with the mount present, the janitor's scan returns real decisions on this install.
+
+### §3 — A blind backstop must fail loudly
+
+Today an unreachable base silently no-ops. That is a `make-silent-failures-observable` violation and
+it is how 528 GB accumulated unnoticed. When the janitor cannot see its declared base it must record
+an unhealthy result and surface it on an operator surface — never report success.
+
+**Acceptance:** with the mount removed, the job reports unhealthy rather than clean.
+
+### §4 — A bound that holds with nobody watching
+
+The commandment's operative half. A default cap — count and/or bytes — that reaps oldest Tier-A
+first, using the existing classifier and junction-safe removal, with no human decision required.
+
+Explicit-go survives exactly where it must: **Tier B, and anything unmerged or unpushed.** That
+constraint is load-bearing, not decorative — a sweep of this install found ~137 branches with commits
+never pushed, and one abandoned worktree held a finished, signed, tested commit recovered two days
+later and shipped as #4875. The sprawl is also where undelivered work hides.
+
+Disk headroom and worktree growth surface **before** exhaustion, not after.
+
+### §5 — Permissions and posture
+
+Bootstrap ships a curated allowlist per surface covering the tool calls DPF work actually requires,
+plus a deliberate `approval_policy` / `sandbox_mode` posture rather than whatever the user happened
+to pick. Pure ergonomics, squarely on the client side of the line.
+
+**Explicit non-goal: model and provider selection.** [`no-provider-pinning`](../../founder-kernel/wiki/principles/no-provider-pinning.md)
+forbids it. `model` and `model_reasoning_effort` stay the client's, and the planner continues to
+round-trip them untouched.
+
+### §6 — Doctrine reaches a client working against an install
+
+The pointers exist but are repo-local. An agent rooted at an installed instance must still be able
+to obtain the canonical contract — served by the platform rather than assumed present on disk.
+Because knowing the rules is closer to a guarantee than an ergonomic, the platform serves it; the
+client is told where to look.
+
+### §7 — Surface parity
+
+Bring Grok to the coverage Codex and Claude have, and settle Antigravity: either support it against
+the same contract or record it as unsupported with the evidence gate that would change that.
+
+## Phasing
+
+| Slice | Content | Why this order |
+|---|---|---|
+| **A** | §1 platform-owned base | Keystone. Nothing else is coherent without it |
+| **B** | §2 + §3 mount and loud no-op | Makes the existing janitor actually see; cheap once A lands |
+| **C** | §4 bounded default + headroom | The half that reclaims disk and stops the support calls |
+| **D** | §5 permissions and posture | Independent of A–C; pure ergonomics |
+| **E** | §6 doctrine reach | Needs an operator decision on served-vs-shipped |
+| **F** | §7 Grok parity, Antigravity ruling | Lowest urgency |
+
+A→B→C is the critical path for `BI-99395B29`. D can run in parallel.
+
+## Research and benchmarking
+
+- **devcontainer / `devcontainer.json`** — the tool reads the *project's* declaration of how to work,
+  rather than each editor inventing it. Adopted: the platform declares, clients consume.
+- **EditorConfig** — one project-level file many editors honour, ergonomics only, no guarantees.
+  Adopted, including its restraint about scope.
+- **`git worktree` + `core.worktree`** — git keeps the authoritative location in repository metadata,
+  not in each client's settings. Adopted as the direction of ownership.
+- **Rejected: per-client bespoke configuration as the source of truth** — the current state, and the
+  reason the platform cannot see its own worktrees.
+- **Rejected: pushing guarantees into client hooks** — forbidden by the commandment and, per the hook
+  plane spec, contributor-only by design regardless.
+
+## Risks
+
+- **A stale or wrong declared base points the reaper at the wrong directory.** Mitigated by keeping
+  the derived default, by the existing SKIP rules (root clone, `main`, detached HEAD), and by
+  junction-safe removal.
+- **The mount widens what the portal can reach on the host.** It is one directory the platform
+  already owns the lifecycle of, and the container already holds the docker socket.
+- **A bounded default deletes something wanted.** Bounded to Tier A; Tier B and anything
+  unmerged/unpushed keep explicit-go; `.worktree-pinned` remains an operator override.
+
+## Acceptance criteria
+
+1. The portal names its worktree base without reading any client artifact.
+2. No hardcoded worktree path remains in any client planner.
+3. The janitor returns real decisions on this install.
+4. With the base unreachable, the job reports unhealthy — not clean.
+5. A bound holds with no human input; Tier B and unmerged/unpushed still require explicit go.
+6. Headroom and growth are visible before exhaustion.
+7. Bootstrap ships a permission allowlist per supported surface; model selection remains unset.
+8. Every existing install keeps working with no operator action.
+
+## Open questions for the operator
+
+1. **§6 doctrine reach** — should the platform *serve* the canonical contract to any client working
+   against an install, or is that install-time file placement?
+2. **§4 bound shape** — cap by worktree count, by total bytes, or by free-space floor? A free-space
+   floor most directly targets the failure, but is the least predictable to an operator.
+3. **§7 Antigravity** — support against this contract, or record unsupported with a named evidence
+   gate?
+
+## What this is NOT
+
+- Not a change to model or provider selection.
+- Not a rebuild of the classifier, the deletion primitive, or the Inngest host — all exist.
+- Not an expansion of the client hook plane, which stays contributor-only.
+- Not a relocation of the canonical worktree base; §1 declares it, it does not move it.

--- a/packages/dpf-bootstrap/src/agent-toolchain/bridge.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/bridge.ts
@@ -101,6 +101,14 @@ export type ComputeAgentToolchainPlanOptions = {
   repoRoot: string;
   /** Path to `~/.codex/config.toml`. */
   codexConfigPath: string;
+  /**
+   * The platform's canonical worktree base, resolved by the caller through
+   * `scripts/lib/worktree-base.mjs`. Optional so existing callers keep working:
+   * when absent each planner falls back to the behaviour it had before the base
+   * became platform-owned (spec
+   * 2026-09-02-platform-owned-client-configuration-design.md §1).
+   */
+  worktreeBase?: string;
   /** Path to `~/.claude/plugins/installed_plugins.json`. */
   claudePluginsPath: string;
   /** Directory holding the canonical kernel principles (origin: repo). */
@@ -166,6 +174,9 @@ export function computeAgentToolchainPlan(
       options.repoRoot,
       options.codexConfigPath,
       options.mcpEndpoint,
+      // Platform-owned, not planner-owned: the base is resolved once and handed
+      // to each client (spec 2026-09-02-platform-owned-client-configuration §1).
+      options.worktreeBase,
     );
   }
 

--- a/packages/dpf-bootstrap/src/agent-toolchain/codex-config.ts
+++ b/packages/dpf-bootstrap/src/agent-toolchain/codex-config.ts
@@ -81,7 +81,17 @@ const GENERIC_MCP_SERVERS_TO_DISABLE = ["nanobanana-mcp", "youtube_transcript"] 
  * (S4.1 decision #1). Worktree sessions live under `D:/DPF-worktrees/<topic>`;
  * trusting the base avoids per-worktree trust friction in Codex.
  */
-const CANONICAL_WORKTREE_BASE = "D:\\DPF-worktrees";
+/**
+ * Fallback ONLY. The worktree base is platform-owned and is passed in by the
+ * caller, which resolves it through `scripts/lib/worktree-base.mjs`. This
+ * constant used to BE the definition — a client planner deciding where DPF
+ * does its work — which is why the platform could not see its own worktrees
+ * (BI-0B2F0546, BI-99395B29). It survives only so an older caller that passes
+ * nothing behaves exactly as it did before.
+ *
+ * Spec: docs/superpowers/specs/2026-09-02-platform-owned-client-configuration-design.md §1
+ */
+const LEGACY_WORKTREE_BASE_FALLBACK = "D:\\DPF-worktrees";
 
 /** Desired `[mcp_servers.dpf]` shape (secret-free -- references the env var). */
 function desiredMcpServerBlock(mcpEndpoint: string): Record<string, string> {
@@ -231,7 +241,17 @@ export function planCodexConfig(
   repoRoot: string,
   configPath: string,
   mcpEndpoint?: string,
+  /**
+   * The platform's canonical worktree base, resolved by the caller. Passed in
+   * rather than owned here: the platform declares where work happens and tells
+   * its clients, never the reverse.
+   */
+  worktreeBase?: string,
 ): CodexConfigPlan {
+  const canonicalWorktreeBase =
+    worktreeBase && worktreeBase.trim().length > 0
+      ? worktreeBase.trim()
+      : LEGACY_WORKTREE_BASE_FALLBACK;
   let normalizedTomlText = existingTomlText.replace(/^\uFEFF/, "");
   const repaired = collapseDuplicateTomlTable(normalizedTomlText, "mcp_servers.dpf");
   normalizedTomlText = repaired.text;
@@ -291,7 +311,7 @@ export function planCodexConfig(
 
   // Trust entries to add: the canonical worktree base and this worktree.
   const projects = (parsed["projects"] as Record<string, unknown> | undefined) ?? {};
-  const trustTargets = [CANONICAL_WORKTREE_BASE, repoRoot];
+  const trustTargets = [canonicalWorktreeBase, repoRoot];
   const trustToAdd = trustTargets.filter((p) => {
     const blk = projects[p] as { trust_level?: unknown } | undefined;
     return blk?.trust_level !== "trusted";

--- a/scripts/capability-service-catalog.generated.json
+++ b/scripts/capability-service-catalog.generated.json
@@ -232,6 +232,7 @@
             "${DPF_BACKUPS_HOST_PATH:-${DPF_HOST_INSTALL_PATH:-.}/backups}:/backups",
             "${DPF_HOST_INSTALL_PATH:-.}:/host-dpf",
             "${DPF_STATE_DIR:-${HOME}/.dpf}:/dpf-state:ro",
+            "${DPF_WORKTREE_BASE:-${DPF_HOST_INSTALL_PATH:-.}-worktrees}:/host-worktrees",
             "/var/run/docker.sock:/var/run/docker.sock",
             "browser_evidence:/evidence:ro",
             "dpf-source-code:/workspace",
@@ -1166,7 +1167,7 @@
       ]
     }
   ],
-  "catalogHash": "ccae8c03d44382efa1ff721439255bdf7e0bcf0c5ab926afa3dd8f05c97c0740",
+  "catalogHash": "6f6566aea2214f00403209bb8e895aa92198be96646cf653ebc464cf453b9253",
   "catalogVersion": 1,
   "substrateManifestVersion": 2
 }

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -496,6 +496,10 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         // Worktree lifecycle hygiene (plan 2026-08-11): the reaping classifier
         // (now with the liveness + abandoned-merge verdicts), the session
         // heartbeat liveness signal, and the root-clone fast-forward remedy.
+        // BI-0B2F0546: the platform's single answer to where its development
+        // surfaces work. A wrong base points the reaper at the wrong directory,
+        // so resolution order and provenance are pinned.
+        "scripts/lib/worktree-base.test.mjs",
         "scripts/lib/worktree-janitor-core.test.mjs",
         "scripts/worktree-janitor.test.mjs",
         "scripts/lib/worktree-session-heartbeat.test.mjs",

--- a/scripts/lib/local-ci-slot-manifest.mjs
+++ b/scripts/lib/local-ci-slot-manifest.mjs
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import { dirname, basename, isAbsolute, join, posix, relative, resolve, win32 } from "node:path";
+import { resolveWorktreeBase } from "./worktree-base.mjs";
 
 const require = createRequire(import.meta.url);
 const SLOT_RESOURCE_MANIFEST = require(
@@ -108,7 +109,9 @@ export function createLocalCiSlotManifest(input) {
       `rootClone must match the canonical Git common-dir root: ${canonicalRootClone}`,
     );
   }
-  const worktreeBase = join(dirname(rootClone), `${basename(rootClone)}-worktrees`);
+  // The platform owns this answer; this module no longer derives its own
+  // (spec 2026-09-02-platform-owned-client-configuration-design §1).
+  const { base: worktreeBase } = resolveWorktreeBase({ rootClone, env: process.env });
   const workspace = resources.ordinal === 0
     ? join(worktreeBase, ".local-ci-runner")
     : join(worktreeBase, `.local-ci-runner-${slotKey}`);

--- a/scripts/lib/worktree-base.mjs
+++ b/scripts/lib/worktree-base.mjs
@@ -1,0 +1,93 @@
+// The platform's own answer to "where do my development surfaces do their work?"
+//
+// This is the SINGLE place that resolves the canonical worktree base. Before it
+// existed the question had two answers and neither belonged to the platform:
+//
+//   * packages/dpf-bootstrap/src/agent-toolchain/codex-config.ts held
+//     `CANONICAL_WORKTREE_BASE = "D:\\DPF-worktrees"` — a constant in CLIENT
+//     configuration, so the location of DPF's work was defined by whichever
+//     client happened to be installed.
+//   * scripts/lib/local-ci-slot-manifest.mjs derived the same path
+//     independently.
+//
+// The portal had no notion of it at all, which is why its server-side worktree
+// janitor is structurally blind: the base is a sibling of the install root and
+// outside every container mount, so the job scans nothing and reports success.
+// 528 GB accumulated behind that (BI-99395B29).
+//
+// Direction of ownership, per `platform-function-never-depends-on-a-client`:
+// the platform declares where work happens and TELLS its clients. A client
+// planner consumes this; it never defines it. The prior art is deliberate —
+// devcontainer, EditorConfig and git's own `core.worktree` all keep the
+// authoritative location with the project rather than in each editor.
+//
+// Spec: docs/superpowers/specs/2026-09-02-platform-owned-client-configuration-design.md §1
+
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+
+/** Explicit operator/install override, highest precedence after config. */
+export const WORKTREE_BASE_ENV = "DPF_WORKTREE_BASE";
+
+/**
+ * How a base was decided. Callers surface this so an unexpected location is
+ * legible rather than mysterious — a wrong base points the reaper at the wrong
+ * directory, so the provenance is part of the answer.
+ *
+ * @typedef {"install-config" | "env" | "derived"} WorktreeBaseSource
+ */
+
+/**
+ * Resolve the canonical worktree base.
+ *
+ * Order, most specific first:
+ *   1. `installConfig` — what this install declares for itself.
+ *   2. `env[DPF_WORKTREE_BASE]` — operator override.
+ *   3. derived `dirname(rootClone)/<basename(rootClone)>-worktrees` — the
+ *      historical behaviour, kept so every existing install keeps working with
+ *      no operator action.
+ *
+ * @param {{ rootClone: string, env?: Record<string, string | undefined>, installConfig?: string | null }} input
+ * @returns {{ base: string, source: WorktreeBaseSource }}
+ */
+export function resolveWorktreeBase(input) {
+  const { rootClone, env = {}, installConfig = null } = input ?? {};
+
+  if (typeof rootClone !== "string" || rootClone.length === 0) {
+    throw new Error("resolveWorktreeBase: rootClone is required");
+  }
+
+  const declared = firstNonEmpty(installConfig);
+  if (declared) {
+    return { base: requireAbsolute(declared, "installConfig"), source: "install-config" };
+  }
+
+  const overridden = firstNonEmpty(env[WORKTREE_BASE_ENV]);
+  if (overridden) {
+    return { base: requireAbsolute(overridden, WORKTREE_BASE_ENV), source: "env" };
+  }
+
+  const root = resolve(rootClone);
+  return { base: join(dirname(root), `${basename(root)}-worktrees`), source: "derived" };
+}
+
+/** Trim to a usable value, treating blank strings as absent. */
+function firstNonEmpty(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * A relative base would resolve differently per caller — the portal, a script
+ * and a client planner all run from different working directories — so a
+ * declared base must be absolute rather than silently reinterpreted.
+ */
+function requireAbsolute(value, label) {
+  if (!isAbsolute(value)) {
+    throw new Error(
+      `resolveWorktreeBase: ${label} must be an absolute path (received "${value}"). ` +
+        "A relative base resolves differently for the portal, a script and a client planner.",
+    );
+  }
+  return resolve(value);
+}

--- a/scripts/lib/worktree-base.test.mjs
+++ b/scripts/lib/worktree-base.test.mjs
@@ -1,0 +1,78 @@
+// The platform's answer to where its development surfaces work must be stable
+// and its provenance legible: a wrong base points the reaper at the wrong
+// directory, so "which rule decided this" is part of the answer.
+//
+// Spec: docs/superpowers/specs/2026-09-02-platform-owned-client-configuration-design.md §1
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join, resolve, sep } from "node:path";
+
+import { resolveWorktreeBase, WORKTREE_BASE_ENV } from "./worktree-base.mjs";
+
+const ROOT_CLONE = resolve(`${sep}srv`, "dpf-source-root");
+const DECLARED = resolve(`${sep}srv`, "declared-worktrees");
+const OVERRIDE = resolve(`${sep}srv`, "override-worktrees");
+
+describe("resolveWorktreeBase", () => {
+  it("derives the historical location when nothing is declared", () => {
+    // Every existing install must keep working with no operator action, so the
+    // derived default has to reproduce exactly what callers computed before.
+    const { base, source } = resolveWorktreeBase({ rootClone: ROOT_CLONE, env: {} });
+    assert.equal(base, join(dirname(ROOT_CLONE), "dpf-source-root-worktrees"));
+    assert.equal(source, "derived");
+  });
+
+  it("prefers what the install declares over everything else", () => {
+    const { base, source } = resolveWorktreeBase({
+      rootClone: ROOT_CLONE,
+      env: { [WORKTREE_BASE_ENV]: OVERRIDE },
+      installConfig: DECLARED,
+    });
+    assert.equal(base, DECLARED);
+    assert.equal(source, "install-config");
+  });
+
+  it("honours the operator override when the install declares nothing", () => {
+    const { base, source } = resolveWorktreeBase({
+      rootClone: ROOT_CLONE,
+      env: { [WORKTREE_BASE_ENV]: OVERRIDE },
+    });
+    assert.equal(base, OVERRIDE);
+    assert.equal(source, "env");
+  });
+
+  it("treats a blank declaration or override as absent, not as an empty path", () => {
+    // A blank env var is the common accident. Reading it as "" would resolve to
+    // the process working directory and aim the reaper at whatever that is.
+    const { base, source } = resolveWorktreeBase({
+      rootClone: ROOT_CLONE,
+      env: { [WORKTREE_BASE_ENV]: "   " },
+      installConfig: "",
+    });
+    assert.equal(base, join(dirname(ROOT_CLONE), "dpf-source-root-worktrees"));
+    assert.equal(source, "derived");
+  });
+
+  it("refuses a relative base rather than resolving it per caller", () => {
+    // The portal, a script and a client planner all run from different working
+    // directories; a relative base would silently mean three different places.
+    assert.throws(
+      () => resolveWorktreeBase({ rootClone: ROOT_CLONE, installConfig: "./worktrees" }),
+      /must be an absolute path/,
+    );
+  });
+
+  it("requires a root clone", () => {
+    assert.throws(() => resolveWorktreeBase({ rootClone: "" }), /rootClone is required/);
+  });
+
+  it("reports provenance for every branch, so an unexpected base is explainable", () => {
+    const sources = [
+      resolveWorktreeBase({ rootClone: ROOT_CLONE, installConfig: DECLARED }).source,
+      resolveWorktreeBase({ rootClone: ROOT_CLONE, env: { [WORKTREE_BASE_ENV]: OVERRIDE } }).source,
+      resolveWorktreeBase({ rootClone: ROOT_CLONE, env: {} }).source,
+    ];
+    assert.deepEqual(sources, ["install-config", "env", "derived"]);
+  });
+});

--- a/scripts/platform-substrate-manifest.json
+++ b/scripts/platform-substrate-manifest.json
@@ -66,6 +66,7 @@
         "browser_evidence:/evidence:ro",
         "${DPF_BACKUPS_HOST_PATH:-${DPF_HOST_INSTALL_PATH:-.}/backups}:/backups",
         "${DPF_HOST_INSTALL_PATH:-.}:/host-dpf",
+        "${DPF_WORKTREE_BASE:-${DPF_HOST_INSTALL_PATH:-.}-worktrees}:/host-worktrees",
         "${DPF_STATE_DIR:-${HOME}/.dpf}:/dpf-state:ro"
       ],
       "dependsOn": [

--- a/tests/release/pregate-node-gate-contract.test.mjs
+++ b/tests/release/pregate-node-gate-contract.test.mjs
@@ -240,6 +240,11 @@ test("gate-worktree.mjs refuses to run when neither an explicit command, the stu
   cpSync(join(repoRoot, "scripts", "lib", "local-sandbox-fence.mjs"), join(temp, "scripts", "lib", "local-sandbox-fence.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-queue-observer.mjs"), join(temp, "scripts", "lib", "local-queue-observer.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-slot-manifest.mjs"), join(temp, "scripts", "lib", "local-ci-slot-manifest.mjs"));
+  // local-ci-slot-manifest.mjs imports the platform-owned worktree base
+  // resolver (BI-0B2F0546). Without it the temp tree dies on
+  // ERR_MODULE_NOT_FOUND before the stub-refusal path can run — the same
+  // copies-scripts-by-name trap the lease-safety modules above document.
+  cpSync(join(repoRoot, "scripts", "lib", "worktree-base.mjs"), join(temp, "scripts", "lib", "worktree-base.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "local-ci-gate-state.mjs"), join(temp, "scripts", "lib", "local-ci-gate-state.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "evidence-validity-policy.mjs"), join(temp, "scripts", "lib", "evidence-validity-policy.mjs"));
   cpSync(join(repoRoot, "scripts", "lib", "pregate-console.mjs"), join(temp, "scripts", "lib", "pregate-console.mjs"));


### PR DESCRIPTION
Founder direction, 2026-09-02:

> "The reaper needs to be a function of the platform itself. embedded."

This is that reaper. One concern in three parts, because any one alone reclaims nothing: the platform
must **own** where its worktrees are, **see** them, and **bound** them.

## The measured problem

| | |
|---|---|
| Worktrees on the development install | **193** (197 by the end of the session) |
| Disk | **528.4 GB — 45% of all used space** |
| Growth | **17.6 / day**, sustained over 11 days |
| Runway | roughly **15 days** on a 1.9 TB box |

A 512 GB machine does not get a fortnight. And the failure isn't untidiness — it's a full disk that
takes the install down, *including the portal that would have reported it*, on a machine whose owner
has no reason to know worktrees exist.

## Why it accumulated behind a feature that already existed

The server-side janitor was already correct and already scheduled. It was **blind**:

- The worktree base was defined by a **client** — `CANONICAL_WORKTREE_BASE` in `codex-config.ts` —
  and independently re-derived in `local-ci-slot-manifest.mjs`. The portal had no notion of it.
- That base is a **sibling** of the install root, so the `/host-dpf` mount never contained it.
  Verified from inside the container: the directory did not exist there.
- An unreachable base returned `skipped: true` — **the same shape as "disabled"**.

So the job ran on time, scanned nothing, found nothing, and reported success. Enabling both existing
flags today would have reclaimed **zero bytes**.

## What changed

### Owns

`scripts/lib/worktree-base.mjs` is the single resolver: install config → `DPF_WORKTREE_BASE` → the
historical derived default. Keeping the last means **every existing install is unaffected**.

Three details, each pinned by a test:

- It returns **provenance** with the path — a wrong base aims the reaper at the wrong directory, so
  "which rule decided this" is part of the answer.
- A **blank** override reads as absent, not as `""`, which would resolve to the process working
  directory.
- A **relative** base is refused. The portal, a script and a client planner run from three different
  working directories, so it would silently mean three different places.

`planCodexConfig` now **receives** the base instead of owning it — the inversion, achieved without a
cross-package import. The old constant survives as `LEGACY_WORKTREE_BASE_FALLBACK` purely so a caller
passing nothing behaves exactly as before; its 16 existing tests pass untouched.

### Sees

The platform's own compose mounts the base at `/host-worktrees` — shipped by the platform, not added
by an operator, defaulting to the same derived path the resolver produces.

### Bounds

Above `DPF_WORKTREE_JANITOR_MAX` (default **40**) the run goes live and reaps Tier-A excess **with no
human decision**. That is the commandment's operative half: a default requiring a technical action
from a non-technical owner is not a safe default, it is a deferred outage.

- Under the bound → stays an observation.
- Explicit `DPF_WORKTREE_JANITOR_AUTO_REAP` → keeps its exact prior contract: straight to live, one
  scan, no bound evaluation.
- **Tier B and anything unmerged or unpushed keep explicit-go.**

That last constraint is load-bearing, not decorative: a sweep of this install found **~137 branches
with commits never pushed**, and one abandoned worktree held a finished, signed, tested commit
recovered two days later and shipped as #4875. The sprawl is also where undelivered work hides.

### Fails loudly

An enabled-but-blind janitor now returns `{ skipped: false, healthy: false }` and logs **UNHEALTHY**
— never a skip. This is a `make-silent-failures-observable` fix as much as a disk one: a backstop
that cannot reach its subject must not be able to report success.

## Two defects the work surfaced in itself

**The existing test encoded the bug.** It asserted that an unreachable scan returns `skipped: true`.
That assertion *was* the defect — it made "switched off" and "on but blind" indistinguishable. It has
been rewritten, and a second test now pins the two apart so it cannot regress.

**My own helper had the same trap.** `countRetained` first read an **empty** `decisions` array as
"zero worktrees" rather than "not populated", which would have held every install permanently under
any bound. The fixture caught it; it now falls back to summary counts.

## Safety

Reaping is Tier-A only, and `classifyWorktree` already defines Tier A as: not the root clone, not
`main`, not detached, not `.worktree-pinned`, no open PR, and **no live session heartbeat** — so a
worktree is never reaped out from under a running session. Removal goes through
`junction-safe-worktree-remove.mjs`, because a naive recursive delete follows pnpm junctions and guts
the donor clone.

Reconciled with [`destructive-actions-require-explicit-go`](docs/founder-kernel/wiki/principles/destructive-actions-require-explicit-go.md)
rather than placed against it: that commandment restrains an **agent** acting outside a declared
policy and stays absolute; a bounded, declared, auditable housekeeping policy shipped with the
product is platform behaviour inside its envelope.

## Verification

- **349** queue tests, **150** bootstrap tests, **28** script tests — all green
- Production build compiled; typecheck clean
- **63** preflight guards clean
- local-CI gate **PASS** on `00839ed48dc6`

Four guard obligations satisfied along the way, each correct: spec status convention, compose env
contract (`DPF_WORKTREE_BASE` declared in `.env.example`), the substrate manifest pinning portal
volumes, and the capability service catalog.

## The one number worth a second look

`DEFAULT_MAX_WORKTREES = 40`, against 197 on the development install. The first live run therefore has
a great deal of Tier-A to work through — which is the intent, but it is a large first sweep and the
number is a judgement call. `DPF_WORKTREE_JANITOR_MAX` changes it without a code change.

Note this does not fire on merge: the mount only exists once an install takes a new image, so the
chain is merge → release → self-upgrade → next scheduled run.

## Scope

Slices A, B, C and §3 of the spec added here. **Not** included: permissions and posture
(`BI-F90A822E`), doctrine reach for install-rooted clients (`BI-4670D0A4`), Grok parity and the
Antigravity ruling (`BI-CFB1D262`) — all filed under `EP-CLIENT-CONFIG`.

`BI-99395B29` and `BI-0B2F0546` are the items this delivers.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
