### PR TITLE
fix(local-ci): a gate that could not run must not grade the diff, and one that passed on slot-1 must be pushable

### DIFF
--- a/.githooks/pre-push-gate
+++ b/.githooks/pre-push-gate
@@ -69,6 +69,43 @@ branch="$(git rev-parse --abbrev-ref HEAD)"
 sha="$(git rev-parse HEAD)"
 state_file="$(git rev-parse --git-path dpf-local-ci-gate.json)"
 
+# BI-5529B5AC: gate state is written PER SLOT — slot-0 to dpf-local-ci-gate.json
+# and slot-1 to dpf-local-ci-gate-slot-1.json (scripts/lib/local-ci-slot-manifest.mjs).
+# `pregate:status` reconciles across slots; this hook used to read the slot-0
+# filename and nothing else, so a gate that ran and PASSED on slot-1 was
+# invisible here and the push was refused with gatePassed=false for a SHA that
+# had genuinely passed. Observed 2026-09-02 on this repository: slot-1 recorded
+# status=passed with an evidence id while a stale slot-0 record from an earlier
+# unadmitted attempt still said queued, and the push was refused.
+#
+# That defect activates exactly when the two-slot pool starts working, and it
+# presents as gate flakiness rather than as a slot bug, so it drives re-runs.
+# Prefer any slot record that passes for THIS branch and SHA; otherwise keep the
+# default file so every "no record" and "did not pass" message below is unchanged.
+if [ -f "scripts/lib/local-ci-gate-state.mjs" ] || [ -d "$(dirname "$state_file")" ]; then
+  passing_state_file="$(node -e '
+const fs = require("node:fs");
+const path = require("node:path");
+const [dir, branch, sha] = process.argv.slice(1);
+let entries = [];
+try { entries = fs.readdirSync(dir); } catch { process.exit(0); }
+for (const name of entries) {
+  if (!/^dpf-local-ci-gate.*\.json$/.test(name)) continue;
+  const file = path.join(dir, name);
+  let state;
+  try { state = JSON.parse(fs.readFileSync(file, "utf8")); } catch { continue; }
+  if (state.branch === branch && state.sha === sha && state.gatePassed === true) {
+    process.stdout.write(file);
+    break;
+  }
+}
+' "$(dirname "$state_file")" "$branch" "$sha" 2>/dev/null || true)"
+  if [ -n "$passing_state_file" ] && [ "$passing_state_file" != "$state_file" ]; then
+    echo "[pre-push-gate] using the passing slot record $(basename "$passing_state_file")"
+    state_file="$passing_state_file"
+  fi
+fi
+
 if [ "$branch" = "HEAD" ]; then
   echo "[pre-push-gate] detached HEAD — gate applies to branch pushes only; skipping."
   exit 0

--- a/docs/superpowers/audits/2026-08-29-guard-surface-inventory.md
+++ b/docs/superpowers/audits/2026-08-29-guard-surface-inventory.md
@@ -18,6 +18,27 @@ pre-reset citation is unrecoverable from the substrate. The add-commit is durabl
 it is cited instead — 69 guards cite a BI that no longer resolves and 25 cite none at all.
 Edits counts commits touching the file since it was added.
 
+## What each guard buys
+
+The brief asked, per guard, what defect motivated it and whether that class
+has recurred. The live backlog cannot answer it: 87 of 88 cited BI ids predate
+the 2026-08-22 reset. Git can. Two independent signals, over 7,105 commits on
+main:
+
+- **mentions** — commits whose message names the guard file. When a guard blocks
+  a change, the commit that unblocks it tends to name it.
+- **baseline** — commits touching the guard's ratchet baseline or allowlist.
+  Each one is the guard forcing a recorded change. A baseline with a single
+  commit was created and never touched again.
+
+**83 of 95 guards have firing evidence. 12 have none.** A guard with no trace is
+not proven inert — it may have fired and been fixed without being named — so
+"no trace" is reported as absence of evidence, never as evidence of absence.
+
+The cost/benefit conclusion is narrow: exactly **one** guard is both untraced and
+costs over a second, and exactly **one** is wired into no stage at all. The other
+93 either earn their cost or are too cheap to be worth removing.
+
 ## Totals
 
 | measure | value |
@@ -43,10 +64,10 @@ account for 17.9 seconds of it.
 
 | recommendation | count | meaning |
 | --- | ---: | --- |
-| KEEP AS-IS | 52 | cited defect, self-tested, under a second |
-| KEEP + CITE DEFECT | 15 | keep, but record the defect class in the header |
+| KEEP AS-IS | 57 | cited defect, self-tested, under a second |
+| KEEP + CITE DEFECT | 0 | keep, but record the defect class in the header |
 | KEEP + ADD TEST | 14 | keep, but prove the guard itself with a sibling test |
-| SAMPLE-OR-DEFER | 9 | over 1s: cheap in the parallel cloud, dear on the serial host |
+| SAMPLE-OR-DEFER | 0 | over 1s: cheap in the parallel cloud, dear on the serial host |
 | MOVE-TO-CLOUD | 4 | over 3s and network-bound: does not belong on the push path |
 | RETIRE-OR-WIRE | 1 | reachable from no stage at all |
 
@@ -56,103 +77,155 @@ account for 17.9 seconds of it.
 
 A trailing `+` on the date marks a guard added in the last six weeks.
 
-| guard (`check-…`) | added | provenance | cost | runs in | preflight | self-test | edits | recommendation |
-| --- | --- | --- | ---: | --- | :-: | :-: | ---: | --- |
-| `agent-capability-integrity` | 2026-08-21 + | b64f3fa807 | 46ms | audit-agent-capability-integrity.yml | — | **no** | 2 | KEEP + ADD TEST |
-| `application-boundaries` | 2026-08-01 + | 2afbe6c5d5 | 189ms | source | yes | yes | 2 | KEEP AS-IS |
-| `archetype-completeness` | 2026-07-22 + | 666835d026 | 63ms | source | yes | yes | 1 | KEEP + CITE DEFECT |
-| `build-namespace` | 2026-06-25 | 7bb12d2681 | 484ms | source | yes | **no** | 2 | KEEP + ADD TEST |
-| `build-script-policy` | 2026-08-08 + | 1ffb0546fc | 41ms | source | yes | yes | 2 | KEEP + CITE DEFECT |
-| `build-studio-surface-budget` | 2026-08-21 + | 11300f1541 | 63ms | source | yes | yes | 1 | KEEP AS-IS |
-| `bundle-boundaries` | 2026-06-06 | 0dfd9a1b37 | 1557ms | source | yes | yes | 4 | SAMPLE-OR-DEFER |
-| `capability-compose-profiles` | 2026-07-18 + | 1c157563a8 | 57ms | source | yes | yes | 1 | KEEP + CITE DEFECT |
-| `capability-consumers` | 2026-07-24 + | 3a32dc729e | 112ms | source | yes | yes | 1 | KEEP AS-IS |
-| `ci-policy-test-inventory` | 2026-08-09 + | 53b2abe0d6 | 57ms | source | yes | **no** | 1 | KEEP + ADD TEST |
-| `compose-env-contract` | 2026-07-18 + | b5cb1bbec3 | 43ms | source | yes | yes | 2 | KEEP + CITE DEFECT |
-| `compose-resource-budgets` | 2026-08-09 + | eeeb1edfee | 46ms | source | yes | yes | 1 | KEEP AS-IS |
-| `context-economy` | 2026-07-30 + | 503228688a | 158ms | source | yes | yes | 2 | KEEP AS-IS |
-| `data-impact` | 2026-07-18 + | d5658d6898 | 149ms | pull-request | yes | yes | 2 | KEEP + CITE DEFECT |
-| `design-grounding-decision` | 2026-07-13 | bd59eba7c6 | 1225ms | pull-request | yes | yes | 4 | SAMPLE-OR-DEFER |
-| `diagram-dependency-pins` | 2026-07-12 | 1597e4675f | 42ms | source | yes | **no** | 3 | KEEP + ADD TEST |
-| `doc-anchor-existence` | 2026-08-18 + | 1622c0b5fd | 154ms | source | yes | yes | 3 | KEEP AS-IS |
-| `doc-links` | 2026-07-17 | d99c636e84 | 81ms | source | yes | yes | 1 | KEEP + CITE DEFECT |
-| `doc-reference-integrity` | 2026-07-12 | 8ba5f21921 | 203ms | source | yes | yes | 1 | KEEP AS-IS |
-| `docker-patch-context` | 2026-08-15 + | 16485659ed | 49ms | source | yes | yes | 1 | KEEP + CITE DEFECT |
-| `dockerfile-copied-script-imports` | 2026-08-27 + | BI-9B490215 | 51ms | source | yes | yes | 1 | KEEP AS-IS |
-| `docs-impact` | 2026-07-17 | 0e1c68dbae | 150ms | pull-request | yes | yes | 4 | KEEP + CITE DEFECT |
-| `edge-node-image-bom` | 2026-08-04 + | cf9429b984 | 54ms | ci.yml (edge-footprint-bom) | — | **no** | 1 | KEEP + ADD TEST |
-| `endpoint-classification` | 2026-08-18 + | 707a12488e | 59ms | source | yes | yes | 2 | KEEP AS-IS |
-| `finding-substrate` | 2026-07-16 | b3a207b145 | 50ms | source | yes | yes | 2 | KEEP + CITE DEFECT |
-| `fk-index-coverage` | 2026-08-17 + | 2b20a05b55 | 63ms | source | yes | yes | 2 | KEEP AS-IS |
-| `golden-decisions` | 2026-06-20 | 64240bba67 | 68ms | pull-request | — | yes | 3 | KEEP AS-IS |
-| `governed-teardown-contract` | 2026-08-22 + | 91d2b1fef7 | 67ms | source | yes | yes | 2 | KEEP AS-IS |
-| `guards` | 2026-07-09 | 7b6ce8a133 | 27948ms | source | yes | yes | 3 | MOVE-TO-CLOUD |
-| `instruction-plane-rule-coverage` | 2026-07-31 + | 68adf3df9d | 570ms | source | yes | yes | 4 | KEEP AS-IS |
-| `instruction-plane-size` | 2026-07-24 + | 0d45e8806c | 50ms | source | yes | yes | 5 | KEEP AS-IS |
-| `label-association` | 2026-08-21 + | 7400e140cf | 130ms | source | yes | **no** | 1 | KEEP + ADD TEST |
-| `live-blocker-references` | 2026-08-23 + | 4219a6ef70 | 157ms | source | yes | yes | 1 | KEEP AS-IS |
-| `mcp-tool-pack` | 2026-06-26 | 9f0d77d50a | 46ms | source | yes | **no** | 2 | KEEP + ADD TEST |
-| `merge-queue-churn` | 2026-06-23 | 869eed53da | 8967ms | merge-queue-churn-watch.yml | — | yes | 1 | MOVE-TO-CLOUD |
-| `missing-ci-dispatch` | 2026-08-04 + | 3575436e19 | 634ms | watch-missing-ci-dispatch.yml | — | yes | 1 | KEEP + CITE DEFECT |
-| `mobile-jest-pin` | 2026-05-23 | f728213421 | 43ms | source | yes | **no** | 2 | KEEP + ADD TEST |
-| `module-size` | 2026-06-26 | 9f0d77d50a | 811ms | source | yes | yes | 7 | KEEP AS-IS |
-| `n-minus-one-caller-honesty` | 2026-07-19 + | b7dc0abf32 | 303ms | source | yes | yes | 1 | KEEP AS-IS |
-| `no-adhoc-mcp-protocol-versions` | 2026-08-18 + | 8d488b42eb | 46ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-ambient-host-tests` | 2026-08-23 + | d7096d23a1 | 507ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-bare-working-write` | 2026-05-20 | d36f543dd1 | 308ms | guard-loop (auto) | — | yes | 5 | KEEP AS-IS |
-| `no-dialog-in-transition` | 2026-07-06 | b5ce8ea20b | 582ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
-| `no-expired-baseline-budgets` | 2026-08-18 + | 1622c0b5fd | 52ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-governed-surface-without-mcp-tool` | 2026-08-09 + | 0ddf07377e | 50ms | guard-loop (auto) | — | yes | 1 | KEEP + CITE DEFECT |
-| `no-hand-rolled-loading` | 2026-07-18 + | 5a19d5148a | 343ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
-| `no-local-action-result` | 2026-08-17 + | 350779bf13 | 460ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-local-auth-guard` | 2026-07-08 | e2a279c1e8 | 69ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
-| `no-local-backup-helper` | 2026-07-09 | 177d41fb74 | 413ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-local-client-credentials` | 2026-07-10 | 0a5fce2c40 | 929ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-local-isrecord` | 2026-07-08 | 3944fd42aa | 415ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
-| `no-local-liveness-literal` | 2026-07-10 | 0999f4308a | 387ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-local-oauth-refresh` | 2026-07-10 | d41b35498c | 956ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-local-status-color` | 2026-07-10 | 89d73a3a3e | 499ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
-| `no-merge-readiness-policy-drift` | 2026-07-26 + | e94ee5024d | 53ms | guard-loop (auto) | — | yes | 1 | KEEP + CITE DEFECT |
-| `no-monolith-schema` | 2026-08-18 + | 5285d63521 | 416ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-nanoid-import` | 2026-07-10 | fd886a494b | 1675ms | guard-loop (auto) | — | yes | 2 | SAMPLE-OR-DEFER |
-| `no-native-dialogs` | 2026-06-16 | 9452525090 | 715ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
-| `no-new-closed-set-strings` | 2026-08-17 + | 2b20a05b55 | 105ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
-| `no-new-notactive-conventions` | 2026-08-19 + | c0757500e7 | 59ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-new-resource-clone-models` | 2026-08-19 + | c0757500e7 | 49ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-postgres-initdb-host-mount` | 2026-07-16 | ab70ee690b | 43ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-private-identity` | 2026-07-17 | f7f8a47861 | 1295ms | guard-loop (auto) | — | yes | 2 | SAMPLE-OR-DEFER |
-| `no-provider-local-connector-lifecycle` | 2026-07-18 + | bcd764353e | 4472ms | guard-loop (auto) | — | yes | 2 | MOVE-TO-CLOUD |
-| `no-raw-error-message` | 2026-07-08 | d8c7851768 | 718ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
-| `no-raw-event-source` | 2026-06-20 | e745ce72d6 | 582ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
-| `no-raw-route-error` | 2026-07-10 | 89d73a3a3e | 112ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-retired-lib-namespaces` | 2026-08-19 + | da09d69896 | 43ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-retired-superpowers-skills` | 2026-07-17 | a8abf406bc | 199ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-substrate-regression` | 2026-07-17 | 738b56a74b | 765ms | guard-loop (auto) | — | yes | 1 | KEEP + CITE DEFECT |
-| `no-suitability-object-shorthand` | 2026-07-22 + | 6d568e6d53 | 48ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-system-user-sentinel` | 2026-06-14 | 361f26d674 | 378ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
-| `no-twin-artifact-drift` | 2026-08-23 + | b704a4c7ce | 61ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-type-reexport-in-use-server` | 2026-07-10 | a2193c7778 | 517ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `no-unhonored-grant-growth` | 2026-08-23 + | f7fdb64d04 | 52ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
-| `no-unresolved-prometheus-targets` | 2026-08-23 + | d087bf7f07 | 48ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
-| `obligation-cadence-coverage` | 2026-08-22 + | 0d9f5bea09 | 46ms | NOWHERE | — | **no** | 1 | RETIRE-OR-WIRE |
-| `override-comments` | 2026-07-22 + | a3cb1db2e3 | 41ms | source | yes | yes | 4 | KEEP AS-IS |
-| `package-boundaries` | 2026-06-25 | 803bdb5230 | 50ms | source | yes | **no** | 1 | KEEP + ADD TEST |
-| `plan-backlog-coverage` | 2026-07-20 + | 12fbdeb751 | 219ms | pull-request | yes | yes | 1 | KEEP + CITE DEFECT |
-| `published-image-freshness` | 2026-08-16 + | 7e5f97aa03 | 3891ms | published-image-freshness.yml | — | **no** | 1 | MOVE-TO-CLOUD |
-| `reporting-composition` | 2026-07-07 | a20608643d | 231ms | source | yes | yes | 2 | KEEP AS-IS |
-| `retention-enrollment` | 2026-08-17 + | 2b20a05b55 | 54ms | source | yes | yes | 2 | KEEP AS-IS |
-| `retired-substrate` | 2026-08-01 + | ad562045f1 | 111ms | source | yes | yes | 1 | KEEP + CITE DEFECT |
-| `seed-fit-decision` | 2026-07-11 | e46ed0bf82 | 1160ms | pull-request | — | yes | 1 | SAMPLE-OR-DEFER |
-| `spec-plan-doc` | 2026-06-18 | 9ffc1a9bc7 | 1118ms | pull-request | yes | **no** | 5 | SAMPLE-OR-DEFER |
-| `spec-status-frontmatter` | 2026-08-18 + | 1622c0b5fd | 297ms | source | yes | yes | 1 | KEEP AS-IS |
-| `stewardship-scope` | 2026-07-23 + | 0965445005 | 54ms | source | yes | yes | 2 | KEEP AS-IS |
-| `style-drift` | 2026-06-25 | fae62a282d | 1446ms | source | yes | yes | 5 | SAMPLE-OR-DEFER |
-| `test-clock-bombs` | 2026-08-06 + | 4d896354c7 | 1032ms | source | yes | yes | 1 | SAMPLE-OR-DEFER |
-| `test-cwd-independence` | 2026-08-23 + | bc4d95e62a | 506ms | source | yes | yes | 2 | KEEP AS-IS |
-| `tool-surface` | 2026-07-31 + | 5c6a0cac21 | 155ms | source | yes | yes | 2 | KEEP AS-IS |
-| `ux-fit-decision` | 2026-06-15 | 53e0b77c83 | 1163ms | pull-request | yes | yes | 8 | SAMPLE-OR-DEFER |
-| `ux-primitive-adoption` | 2026-08-17 + | 350779bf13 | 403ms | source | yes | yes | 1 | KEEP AS-IS |
-| `work-unit-conformance` | 2026-08-14 + | dca9682731 | 850ms | source | yes | yes | 1 | KEEP AS-IS |
+| guard (`check-…`) | added | provenance | **fires** | cost | runs in | preflight | self-test | edits | recommendation |
+| --- | --- | --- | --- | ---: | --- | :-: | :-: | ---: | --- |
+| `agent-capability-integrity` | 2026-08-21 + | b64f3fa807 | 1 commit | 46ms | audit-agent-capability-integrity.yml | — | **no** | 2 | KEEP + ADD TEST |
+| `application-boundaries` | 2026-08-01 + | 2afbe6c5d5 | 2 commits | 189ms | source | yes | yes | 2 | KEEP AS-IS |
+| `archetype-completeness` | 2026-07-22 + | 666835d026 | 3 commits | 63ms | source | yes | yes | 1 | KEEP AS-IS |
+| `build-namespace` | 2026-06-25 | 7bb12d2681 | 3 commits | 484ms | source | yes | **no** | 2 | KEEP + ADD TEST |
+| `build-script-policy` | 2026-08-08 + | 1ffb0546fc | 2 commits | 41ms | source | yes | yes | 2 | KEEP AS-IS |
+| `build-studio-surface-budget` | 2026-08-21 + | 11300f1541 | 2 commits | 63ms | source | yes | yes | 1 | KEEP AS-IS |
+| `bundle-boundaries` | 2026-06-06 | 0dfd9a1b37 | 4 commits | 1557ms | source | yes | yes | 4 | KEEP, TIER |
+| `capability-compose-profiles` | 2026-07-18 + | 1c157563a8 | no trace | 57ms | source | yes | yes | 1 | KEEP, WATCH |
+| `capability-consumers` | 2026-07-24 + | 3a32dc729e | 1 commit | 112ms | source | yes | yes | 1 | KEEP AS-IS |
+| `ci-policy-test-inventory` | 2026-08-09 + | 53b2abe0d6 | 3 commits, baseline 14x | 57ms | source | yes | **no** | 1 | KEEP + ADD TEST |
+| `compose-env-contract` | 2026-07-18 + | b5cb1bbec3 | 1 commit | 43ms | source | yes | yes | 2 | KEEP AS-IS |
+| `compose-resource-budgets` | 2026-08-09 + | eeeb1edfee | no trace | 46ms | source | yes | yes | 1 | KEEP, WATCH |
+| `context-economy` | 2026-07-30 + | 503228688a | 2 commits | 158ms | source | yes | yes | 2 | KEEP AS-IS |
+| `data-impact` | 2026-07-18 + | d5658d6898 | 2 commits | 149ms | pull-request | yes | yes | 2 | KEEP AS-IS |
+| `design-grounding-decision` | 2026-07-13 | bd59eba7c6 | 1 commit | 1225ms | pull-request | yes | yes | 4 | KEEP, TIER |
+| `diagram-dependency-pins` | 2026-07-12 | 1597e4675f | 2 commits | 42ms | source | yes | **no** | 3 | KEEP + ADD TEST |
+| `doc-anchor-existence` | 2026-08-18 + | 1622c0b5fd | 6 commits | 154ms | source | yes | yes | 3 | KEEP AS-IS |
+| `doc-links` | 2026-07-17 | d99c636e84 | 6 commits | 81ms | source | yes | yes | 1 | KEEP AS-IS |
+| `doc-reference-integrity` | 2026-07-12 | 8ba5f21921 | 5 commits | 203ms | source | yes | yes | 1 | KEEP AS-IS |
+| `docker-patch-context` | 2026-08-15 + | 16485659ed | 2 commits | 49ms | source | yes | yes | 1 | KEEP AS-IS |
+| `dockerfile-copied-script-imports` | 2026-08-27 + | BI-9B490215 | 1 commit | 51ms | source | yes | yes | 1 | KEEP AS-IS |
+| `docs-impact` | 2026-07-17 | 0e1c68dbae | 6 commits | 150ms | pull-request | yes | yes | 4 | KEEP AS-IS |
+| `edge-node-image-bom` | 2026-08-04 + | cf9429b984 | 1 commit | 54ms | ci.yml (edge-footprint-bom) | — | **no** | 1 | KEEP + ADD TEST |
+| `endpoint-classification` | 2026-08-18 + | 707a12488e | 2 commits | 59ms | source | yes | yes | 2 | KEEP AS-IS |
+| `finding-substrate` | 2026-07-16 | b3a207b145 | 2 commits | 50ms | source | yes | yes | 2 | KEEP AS-IS |
+| `fk-index-coverage` | 2026-08-17 + | 2b20a05b55 | 2 commits | 63ms | source | yes | yes | 2 | KEEP AS-IS |
+| `golden-decisions` | 2026-06-20 | 64240bba67 | 3 commits | 68ms | pull-request | — | yes | 3 | KEEP AS-IS |
+| `governed-teardown-contract` | 2026-08-22 + | 91d2b1fef7 | no trace | 67ms | source | yes | yes | 2 | KEEP, WATCH |
+| `guards` | 2026-07-09 | 7b6ce8a133 | 19 commits | 27948ms | source | yes | yes | 3 | MOVE-TO-CLOUD |
+| `instruction-plane-rule-coverage` | 2026-07-31 + | 68adf3df9d | 2 commits, baseline 5x | 570ms | source | yes | yes | 4 | KEEP AS-IS |
+| `instruction-plane-size` | 2026-07-24 + | 0d45e8806c | 5 commits, baseline 17x | 50ms | source | yes | yes | 5 | KEEP AS-IS |
+| `label-association` | 2026-08-21 + | 7400e140cf | 1 commit | 130ms | source | yes | **no** | 1 | KEEP + ADD TEST |
+| `live-blocker-references` | 2026-08-23 + | 4219a6ef70 | 2 commits | 157ms | source | yes | yes | 1 | KEEP AS-IS |
+| `mcp-tool-pack` | 2026-06-26 | 9f0d77d50a | 2 commits | 46ms | source | yes | **no** | 2 | KEEP + ADD TEST |
+| `merge-queue-churn` | 2026-06-23 | 869eed53da | 2 commits | 8967ms | merge-queue-churn-watch.yml | — | yes | 1 | MOVE-TO-CLOUD |
+| `missing-ci-dispatch` | 2026-08-04 + | 3575436e19 | no trace | 634ms | watch-missing-ci-dispatch.yml | — | yes | 1 | KEEP, WATCH |
+| `mobile-jest-pin` | 2026-05-23 | f728213421 | 3 commits | 43ms | source | yes | **no** | 2 | KEEP + ADD TEST |
+| `module-size` | 2026-06-26 | 9f0d77d50a | 28 commits, baseline 248x | 811ms | source | yes | yes | 7 | KEEP AS-IS |
+| `n-minus-one-caller-honesty` | 2026-07-19 + | b7dc0abf32 | 1 commit | 303ms | source | yes | yes | 1 | KEEP AS-IS |
+| `no-adhoc-mcp-protocol-versions` | 2026-08-18 + | 8d488b42eb | 1 commit | 46ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-ambient-host-tests` | 2026-08-23 + | d7096d23a1 | 1 commit | 507ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-bare-working-write` | 2026-05-20 | d36f543dd1 | 2 commits | 308ms | guard-loop (auto) | — | yes | 5 | KEEP AS-IS |
+| `no-dialog-in-transition` | 2026-07-06 | b5ce8ea20b | 1 commit | 582ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
+| `no-expired-baseline-budgets` | 2026-08-18 + | 1622c0b5fd | 3 commits | 52ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-governed-surface-without-mcp-tool` | 2026-08-09 + | 0ddf07377e | no trace | 50ms | guard-loop (auto) | — | yes | 1 | KEEP, WATCH |
+| `no-hand-rolled-loading` | 2026-07-18 + | 5a19d5148a | 3 commits, baseline 3x | 343ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
+| `no-local-action-result` | 2026-08-17 + | 350779bf13 | 1 commit | 460ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-local-auth-guard` | 2026-07-08 | e2a279c1e8 | 1 commit | 69ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
+| `no-local-backup-helper` | 2026-07-09 | 177d41fb74 | 1 commit | 413ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-local-client-credentials` | 2026-07-10 | 0a5fce2c40 | 1 commit | 929ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-local-isrecord` | 2026-07-08 | 3944fd42aa | 4 commits | 415ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
+| `no-local-liveness-literal` | 2026-07-10 | 0999f4308a | 1 commit | 387ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-local-oauth-refresh` | 2026-07-10 | d41b35498c | 1 commit | 956ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-local-status-color` | 2026-07-10 | 89d73a3a3e | 1 commit | 499ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
+| `no-merge-readiness-policy-drift` | 2026-07-26 + | e94ee5024d | no trace | 53ms | guard-loop (auto) | — | yes | 1 | KEEP, WATCH |
+| `no-monolith-schema` | 2026-08-18 + | 5285d63521 | 1 commit | 416ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-nanoid-import` | 2026-07-10 | fd886a494b | 2 commits | 1675ms | guard-loop (auto) | — | yes | 2 | KEEP, TIER |
+| `no-native-dialogs` | 2026-06-16 | 9452525090 | 3 commits | 715ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
+| `no-new-closed-set-strings` | 2026-08-17 + | 2b20a05b55 | 2 commits | 105ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
+| `no-new-notactive-conventions` | 2026-08-19 + | c0757500e7 | 1 commit | 59ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-new-resource-clone-models` | 2026-08-19 + | c0757500e7 | 1 commit | 49ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-postgres-initdb-host-mount` | 2026-07-16 | ab70ee690b | 1 commit | 43ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-private-identity` | 2026-07-17 | f7f8a47861 | 4 commits | 1295ms | guard-loop (auto) | — | yes | 2 | KEEP, TIER |
+| `no-provider-local-connector-lifecycle` | 2026-07-18 + | bcd764353e | 3 commits | 4472ms | guard-loop (auto) | — | yes | 2 | MOVE-TO-CLOUD |
+| `no-raw-error-message` | 2026-07-08 | d8c7851768 | 8 commits | 718ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
+| `no-raw-event-source` | 2026-06-20 | e745ce72d6 | 2 commits | 582ms | guard-loop (auto) | — | **no** | 1 | KEEP + ADD TEST |
+| `no-raw-route-error` | 2026-07-10 | 89d73a3a3e | 6 commits, baseline 5x | 112ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-retired-lib-namespaces` | 2026-08-19 + | da09d69896 | 1 commit | 43ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-retired-superpowers-skills` | 2026-07-17 | a8abf406bc | 1 commit | 199ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-substrate-regression` | 2026-07-17 | 738b56a74b | 1 commit | 765ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-suitability-object-shorthand` | 2026-07-22 + | 6d568e6d53 | 1 commit | 48ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-system-user-sentinel` | 2026-06-14 | 361f26d674 | 1 commit | 378ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
+| `no-twin-artifact-drift` | 2026-08-23 + | b704a4c7ce | no trace | 61ms | guard-loop (auto) | — | yes | 1 | KEEP, WATCH |
+| `no-type-reexport-in-use-server` | 2026-07-10 | a2193c7778 | 2 commits | 517ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `no-unhonored-grant-growth` | 2026-08-23 + | f7fdb64d04 | 1 commit | 52ms | guard-loop (auto) | — | yes | 2 | KEEP AS-IS |
+| `no-unresolved-prometheus-targets` | 2026-08-23 + | d087bf7f07 | 1 commit | 48ms | guard-loop (auto) | — | yes | 1 | KEEP AS-IS |
+| `obligation-cadence-coverage` | 2026-08-22 + | 0d9f5bea09 | no trace | 46ms | NOWHERE | — | **no** | 1 | RETIRE-OR-WIRE |
+| `override-comments` | 2026-07-22 + | a3cb1db2e3 | 3 commits | 41ms | source | yes | yes | 4 | KEEP AS-IS |
+| `package-boundaries` | 2026-06-25 | 803bdb5230 | 1 commit | 50ms | source | yes | **no** | 1 | KEEP + ADD TEST |
+| `plan-backlog-coverage` | 2026-07-20 + | 12fbdeb751 | 2 commits | 219ms | pull-request | yes | yes | 1 | KEEP AS-IS |
+| `published-image-freshness` | 2026-08-16 + | 7e5f97aa03 | 1 commit | 3891ms | published-image-freshness.yml | — | **no** | 1 | MOVE-TO-CLOUD |
+| `reporting-composition` | 2026-07-07 | a20608643d | no trace | 231ms | source | yes | yes | 2 | KEEP, WATCH |
+| `retention-enrollment` | 2026-08-17 + | 2b20a05b55 | 2 commits | 54ms | source | yes | yes | 2 | KEEP AS-IS |
+| `retired-substrate` | 2026-08-01 + | ad562045f1 | 2 commits | 111ms | source | yes | yes | 1 | KEEP AS-IS |
+| `seed-fit-decision` | 2026-07-11 | e46ed0bf82 | no trace | 1160ms | pull-request | — | yes | 1 | SAMPLE-OR-RETIRE |
+| `spec-plan-doc` | 2026-06-18 | 9ffc1a9bc7 | 2 commits | 1118ms | pull-request | yes | **no** | 5 | KEEP, TIER |
+| `spec-status-frontmatter` | 2026-08-18 + | 1622c0b5fd | 4 commits, baseline 2x | 297ms | source | yes | yes | 1 | KEEP AS-IS |
+| `stewardship-scope` | 2026-07-23 + | 0965445005 | 2 commits, baseline 3x | 54ms | source | yes | yes | 2 | KEEP AS-IS |
+| `style-drift` | 2026-06-25 | fae62a282d | 10 commits | 1446ms | source | yes | yes | 5 | KEEP, TIER |
+| `test-clock-bombs` | 2026-08-06 + | 4d896354c7 | 1 commit | 1032ms | source | yes | yes | 1 | KEEP, TIER |
+| `test-cwd-independence` | 2026-08-23 + | bc4d95e62a | no trace | 506ms | source | yes | yes | 2 | KEEP, WATCH |
+| `tool-surface` | 2026-07-31 + | 5c6a0cac21 | 2 commits | 155ms | source | yes | yes | 2 | KEEP AS-IS |
+| `ux-fit-decision` | 2026-06-15 | 53e0b77c83 | 10 commits | 1163ms | pull-request | yes | yes | 8 | KEEP, TIER |
+| `ux-primitive-adoption` | 2026-08-17 + | 350779bf13 | 4 commits | 403ms | source | yes | yes | 1 | KEEP AS-IS |
+| `work-unit-conformance` | 2026-08-14 + | dca9682731 | no trace | 850ms | source | yes | yes | 1 | KEEP, WATCH |
+
+## End-to-end timeline, by change shape
+
+Measured 2026-09-02 over the 45 most recent merged PRs, joined to the real
+`local-integration-ci` leases that gated their branches. Median minutes.
+
+| shape | n | first commit to PR open | gate wait | gate hold | PR open to merged | **total** |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| docs | 6 | 0.8 | — | — | 21.1 | **22.9** |
+| source | 37 | 12.5 | 73.9 | 20.0 | 25.9 | **43.8** |
+| schema | 2 | — | — | — | 21.9 | **36.7** |
+
+p90 total: docs 0.6h, source 2.3h, schema 0.6h.
+
+Two caveats the numbers do not carry on their own. Only 5 of the 45 branches had
+lease rows on this host, so the gate columns are a small sample, and they are
+sums across attempts rather than per-attempt figures — a branch that gated three
+times contributes all three waits. And 4 of those 5 branches needed more than one
+lease attempt, which is the retry churn this epic exists to remove.
+
+Against the stated service level — docs under 20 minutes, source under 40 — docs
+misses by 3 minutes and source by 4. Both are close; neither is met.
+
+## Host memory during a gate stage
+
+The reserve that decides whether a second slot may admit was, until 2026-08-30, a
+number with no evidence behind it. The evidence existed: every vitest stage
+receipt carries roughly fifty host samples with free memory. `scripts/local-ci-host-stage-calibration.mjs`
+reads them.
+
+Across 90 receipts:
+
+| | minimum free memory while a stage ran |
+| --- | --- |
+| p10 | 4.39 GiB |
+| p50 | 15.47 GiB |
+| worst observed | **0.28 GiB** |
+
+The host genuinely exhausts itself during some runs. That is the finding that
+matters, because it means the reserve must **not** simply be shrunk to raise the
+two-slot fit rate — shrinking it admits a second stage onto precisely the runs
+whose free memory later collapses.
+
+Split by coverage mode, the affected-test change is already doing that work:
+
+| stage | runs | p10 free | p50 free |
+| --- | ---: | ---: | ---: |
+| `exhaustive-vitest` | 83 | 4.39 GiB | 15.47 GiB |
+| `affected-vitest` | 7 | **7.62 GiB** | **21.60 GiB** |
+
+An affected run leaves 74% more headroom at p10. The second slot becomes
+reachable as the fleet converts to affected runs, without touching the reserve.
 
 ## Reproducing this
 

--- a/scripts/ci-policy-test-inventory-allowlist.txt
+++ b/scripts/ci-policy-test-inventory-allowlist.txt
@@ -114,6 +114,7 @@ scripts/lib/transition-signing.test.mjs
 scripts/lifecycle-surface-policy.test.mjs
 scripts/local-ci-bounded-build.test.mjs
 scripts/local-ci-capacity-broker.test.mjs
+scripts/local-ci-host-stage-calibration.test.mjs
 scripts/local-ci-pool-policy.test.mjs
 scripts/local-ci-runner.test.mjs
 scripts/local-ci-slot-cleanup.test.mjs

--- a/scripts/lib/pregate-status.test.mjs
+++ b/scripts/lib/pregate-status.test.mjs
@@ -367,6 +367,28 @@ test("the state's own failureReason outranks metadata either way", () => {
 
 // BI-51353470: a record whose status is queued/cancelled never ran. FAIL is a
 // claim about the diff; INCONCLUSIVE is "this is not a verdict".
+// BI-D088D06D. The writer half of the same injustice. `pregate.mjs` recovers a
+// wrapper that exited before a terminal state; that run never graded the diff.
+// It used to write status "failed", which landed here as FAIL and consumed the
+// SHA's verdict, forcing an amend. It now writes `blocked_wrapper_exited`, and
+// this asserts the round trip actually reads as infrastructure.
+test("a wrapper that exited before grading reads INCONCLUSIVE, not FAIL (BI-D088D06D)", () => {
+  const r = classifySlotRecord({
+    state: passingState({
+      gatePassed: false,
+      status: "blocked_wrapper_exited",
+      evidenceRecordId: "",
+      recovery: { reason: "gate-wrapper-exited-before-terminal-state" },
+    }),
+    metadata: null,
+    headSha: HEAD,
+    now: NOW,
+  });
+  assert.equal(r.verdict, "INCONCLUSIVE");
+  assert.notEqual(r.verdict, "FAIL");
+  assert.match(r.reason, /infrastructure/i);
+});
+
 test("a queued record that never ran is INCONCLUSIVE, not FAIL (BI-51353470)", () => {
   const r = classifySlotRecord({
     state: passingState({ gatePassed: false, status: "queued", evidenceRecordId: "" }),

--- a/scripts/local-ci-host-stage-calibration.mjs
+++ b/scripts/local-ci-host-stage-calibration.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// Host-stage admission calibration, derived from evidence the gate already
+// records (BI-E58B57EC).
+//
+// WHY THIS EXISTS
+// `local-ci-slot-resources.json` carries two per-slot memory numbers. The
+// builder's was calibrated against an observed high-water. The host stage's was
+// a flat 8 GiB with no calibration block until 2026-08-30, when it was set to
+// 6 GiB from a single hand measurement of one stage on one afternoon. A number
+// typed by a person from one sample is exactly the kind of unevidenced constant
+// that produced the latency this epic exists to fix.
+//
+// The evidence was already on disk and unread. Every vitest stage receipt
+// carries ~50 host samples, each with `freeMemoryBytes`. This reads them.
+//
+// WHAT IT MEASURES, AND WHY THAT STATISTIC
+// Admission asks "does another stage fit?", which is a question about FREE
+// memory on the host, not about what this stage's own processes used. So the
+// decision-relevant number is the MINIMUM free memory observed while a stage was
+// running: if that stayed above `floor + N x reserve`, an Nth stage would have
+// fitted at the tightest moment of the run.
+//
+// Measured across 90 receipts on 2026-09-02: p10 4.39 GiB, p50 15.47 GiB, worst
+// 0.28 GiB free. The host genuinely exhausts itself during some gate runs, which
+// is why the reserve must NOT simply be shrunk to raise the two-slot fit rate —
+// doing so admits a second stage precisely onto the runs that later starve.
+//
+//   node scripts/local-ci-host-stage-calibration.mjs           # human report
+//   node scripts/local-ci-host-stage-calibration.mjs --json    # machine output
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
+
+import { isEntryModule } from "./lib/entry-module.mjs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import slotResources from "../apps/web/lib/nonprod/local-ci-slot-resources.json" with {
+  type: "json",
+};
+
+const GiB = 1024 ** 3;
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(SCRIPTS_DIR, "..");
+
+/** Minimum free memory observed while a stage ran, per receipt. */
+export function minFreeBytesFromReceipt(receipt) {
+  const samples = (receipt?.observations ?? [])
+    .map((o) => o?.host?.freeMemoryBytes)
+    .filter((v) => Number.isFinite(v) && v >= 0);
+  // Fewer than three samples is not a run worth calibrating from — the stage
+  // died early, or the sampler never got going.
+  if (samples.length < 3) return null;
+  return { minFreeBytes: Math.min(...samples), samples: samples.length };
+}
+
+export function percentile(values, p) {
+  if (!values.length) return Number.NaN;
+  const s = [...values].sort((a, b) => a - b);
+  return s[Math.floor(p * (s.length - 1))];
+}
+
+/**
+ * How many stages would have fitted, at each run's tightest moment, for a given
+ * reserve. This is the only honest way to compare candidate reserves: replay
+ * them against what the host actually did.
+ */
+export function fitRate(minFrees, { floorBytes, reserveBytes, stages }) {
+  if (!minFrees.length || reserveBytes <= 0) return 0;
+  const need = floorBytes + stages * reserveBytes;
+  return minFrees.filter((v) => v >= need).length / minFrees.length;
+}
+
+export function collectReceipts(worktreesDir) {
+  const out = [];
+  if (!existsSync(worktreesDir)) return out;
+  for (const wt of readdirSync(worktreesDir)) {
+    const file = join(worktreesDir, wt, "dpf-local-ci-metadata.json.vitest.json");
+    if (!existsSync(file)) continue;
+    let parsed;
+    try { parsed = JSON.parse(readFileSync(file, "utf8")); } catch { continue; }
+    const measured = minFreeBytesFromReceipt(parsed);
+    if (!measured) continue;
+    out.push({
+      worktree: wt,
+      stage: parsed.stage ?? "unknown",
+      observedAt: statSync(file).mtime.toISOString(),
+      ...measured,
+    });
+  }
+  return out;
+}
+
+/**
+ * Receipts live under the SHARED git common dir, one per linked worktree. In a
+ * linked worktree `.git` is a file pointing at the common dir, not a directory,
+ * so this must ask git rather than assume a path.
+ */
+function worktreeReceiptsDir() {
+  const result = spawnSync("git", ["rev-parse", "--git-common-dir"], {
+    cwd: REPO_ROOT, encoding: "utf8", shell: false, windowsHide: true,
+  });
+  const common = result.status === 0 ? result.stdout.trim() : "";
+  if (!common) return join(REPO_ROOT, ".git", "worktrees");
+  return join(common.startsWith(".") ? join(REPO_ROOT, common) : common, "worktrees");
+}
+
+export function buildCalibrationReport(receipts, {
+  floorBytes = 4 * GiB,
+  currentReserveBytes = slotResources.hostStagePolicy.admissionReserveBytes,
+} = {}) {
+  const minFrees = receipts.map((r) => r.minFreeBytes);
+  const byStage = {};
+  for (const r of receipts) {
+    (byStage[r.stage] ??= []).push(r.minFreeBytes);
+  }
+  return {
+    receipts: receipts.length,
+    floorBytes,
+    currentReserveBytes,
+    minFreeBytes: {
+      p10: percentile(minFrees, 0.1),
+      p50: percentile(minFrees, 0.5),
+      p90: percentile(minFrees, 0.9),
+      worst: minFrees.length ? Math.min(...minFrees) : Number.NaN,
+    },
+    twoStageFitRateAtCurrentReserve: fitRate(minFrees, {
+      floorBytes, reserveBytes: currentReserveBytes, stages: 2,
+    }),
+    byStage: Object.fromEntries(Object.entries(byStage).map(([k, v]) => [k, {
+      runs: v.length, p10: percentile(v, 0.1), p50: percentile(v, 0.5),
+    }])),
+  };
+}
+
+function g(bytes) {
+  return Number.isFinite(bytes) ? `${(bytes / GiB).toFixed(2)} GiB` : "n/a";
+}
+
+function main() {
+  const receipts = collectReceipts(worktreeReceiptsDir());
+  const report = buildCalibrationReport(receipts);
+  if (process.argv.includes("--json")) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+  if (!report.receipts) {
+    process.stdout.write(
+      "[host-stage-calibration] no vitest stage receipts with host samples found — " +
+      "run the gate at least once on this host, then re-run.\n",
+    );
+    return;
+  }
+  process.stdout.write(
+    `[host-stage-calibration] ${report.receipts} receipts\n` +
+    `  minimum free memory while a stage ran:\n` +
+    `    p10 ${g(report.minFreeBytes.p10)}   p50 ${g(report.minFreeBytes.p50)}   ` +
+    `p90 ${g(report.minFreeBytes.p90)}   worst ${g(report.minFreeBytes.worst)}\n` +
+    `  current reserve ${g(report.currentReserveBytes)}, floor ${g(report.floorBytes)}\n` +
+    `  a 2nd stage would have fitted in ` +
+    `${(report.twoStageFitRateAtCurrentReserve * 100).toFixed(0)}% of runs\n`,
+  );
+  for (const [stage, s] of Object.entries(report.byStage)) {
+    process.stdout.write(
+      `  ${stage.padEnd(18)} ${String(s.runs).padStart(3)} runs   ` +
+      `p10 ${g(s.p10)}   p50 ${g(s.p50)}\n`,
+    );
+  }
+  process.stdout.write(
+    "  NOTE: a low fit rate is not on its own a reason to shrink the reserve. " +
+    "Shrinking it admits a second stage onto exactly the runs whose free memory " +
+    "later collapses. Reduce what a stage consumes first.\n",
+  );
+}
+
+if (isEntryModule(import.meta.url)) {
+  main();
+}

--- a/scripts/local-ci-host-stage-calibration.test.mjs
+++ b/scripts/local-ci-host-stage-calibration.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildCalibrationReport,
+  fitRate,
+  minFreeBytesFromReceipt,
+  percentile,
+} from "./local-ci-host-stage-calibration.mjs";
+
+const GiB = 1024 ** 3;
+const sample = (freeGiB) => ({ host: { freeMemoryBytes: freeGiB * GiB } });
+
+test("reads the minimum free memory across a stage's host samples", () => {
+  const r = minFreeBytesFromReceipt({
+    observations: [sample(20), sample(6), sample(14)],
+  });
+  assert.equal(r.minFreeBytes, 6 * GiB);
+  assert.equal(r.samples, 3);
+});
+
+test("ignores non-finite and negative samples rather than treating them as zero free", () => {
+  // A garbage sample reading as 0 free would make every run look catastrophic
+  // and drive the reserve to nonsense.
+  const r = minFreeBytesFromReceipt({
+    observations: [sample(20), { host: { freeMemoryBytes: null } },
+      { host: { freeMemoryBytes: -1 } }, sample(12), sample(15)],
+  });
+  assert.equal(r.minFreeBytes, 12 * GiB);
+  assert.equal(r.samples, 3);
+});
+
+test("a run with fewer than three samples is not calibration evidence", () => {
+  // The stage died early or the sampler never got going. Calibrating a fleet
+  // constant off one reading is what produced the number this tool replaces.
+  assert.equal(minFreeBytesFromReceipt({ observations: [sample(9), sample(8)] }), null);
+  assert.equal(minFreeBytesFromReceipt({ observations: [] }), null);
+  assert.equal(minFreeBytesFromReceipt({}), null);
+  assert.equal(minFreeBytesFromReceipt(null), null);
+});
+
+test("observations with no host block are skipped, not counted as free memory", () => {
+  assert.equal(minFreeBytesFromReceipt({
+    observations: [{ attempt: 1 }, { classification: "passed" }, sample(11)],
+  }), null);
+});
+
+test("fitRate replays a candidate reserve against what the host actually did", () => {
+  const mins = [4, 8, 16, 20, 30].map((g) => g * GiB);
+  // floor 4 + 2x6 = 16 GiB needed for a second stage: 16, 20 and 30 clear it.
+  assert.equal(fitRate(mins, { floorBytes: 4 * GiB, reserveBytes: 6 * GiB, stages: 2 }), 3 / 5);
+  // A smaller reserve fits more runs — the seductive move this tool exists to
+  // put a number against rather than leave to intuition.
+  assert.equal(fitRate(mins, { floorBytes: 4 * GiB, reserveBytes: 2 * GiB, stages: 2 }), 4 / 5);
+});
+
+test("fitRate is zero, not NaN or a crash, on empty or absurd input", () => {
+  assert.equal(fitRate([], { floorBytes: 4 * GiB, reserveBytes: 6 * GiB, stages: 2 }), 0);
+  assert.equal(fitRate([10 * GiB], { floorBytes: 4 * GiB, reserveBytes: 0, stages: 2 }), 0);
+  assert.equal(fitRate([10 * GiB], { floorBytes: 4 * GiB, reserveBytes: -1, stages: 2 }), 0);
+});
+
+test("percentile is order-independent and handles a single value", () => {
+  assert.equal(percentile([5, 1, 3], 0), 1);
+  assert.equal(percentile([5, 1, 3], 1), 5);
+  assert.equal(percentile([7], 0.5), 7);
+  assert.ok(Number.isNaN(percentile([], 0.5)));
+});
+
+test("the report separates stages, so affected and exhaustive runs are not averaged together", () => {
+  // Averaging them would hide the whole point: an affected run leaves more
+  // headroom than an exhaustive one, and that is what changes the fit rate.
+  const report = buildCalibrationReport([
+    { stage: "exhaustive-vitest", minFreeBytes: 4 * GiB },
+    { stage: "exhaustive-vitest", minFreeBytes: 6 * GiB },
+    { stage: "affected-vitest", minFreeBytes: 22 * GiB },
+    { stage: "affected-vitest", minFreeBytes: 26 * GiB },
+  ], { floorBytes: 4 * GiB, currentReserveBytes: 6 * GiB });
+
+  assert.equal(report.receipts, 4);
+  assert.equal(report.byStage["exhaustive-vitest"].runs, 2);
+  assert.equal(report.byStage["affected-vitest"].runs, 2);
+  assert.ok(
+    report.byStage["affected-vitest"].p50 > report.byStage["exhaustive-vitest"].p50,
+    "affected runs must show more headroom than exhaustive ones",
+  );
+  assert.equal(report.twoStageFitRateAtCurrentReserve, 0.5);
+});
+
+test("an empty corpus reports zero receipts rather than inventing a reserve", () => {
+  const report = buildCalibrationReport([]);
+  assert.equal(report.receipts, 0);
+  assert.equal(report.twoStageFitRateAtCurrentReserve, 0);
+  assert.ok(Number.isNaN(report.minFreeBytes.p50));
+});

--- a/scripts/pregate.mjs
+++ b/scripts/pregate.mjs
@@ -309,13 +309,27 @@ export async function recoverInterruptedGateState({
     ...(Array.isArray(state.leaseEvents) ? state.leaseEvents : []),
     recoveryEvent,
   ];
+  // BI-D088D06D: the wrapper exiting before a terminal state is infrastructure
+  // — a killed process, a host under pressure, a lost control plane. It is NOT
+  // a grade on the diff, and it never graded the diff: the run died before it
+  // could. Writing "failed" here made pregate:status report FAIL, which reads as
+  // "your code is bad", permanently consumed that SHA's verdict, and forced an
+  // amend to a fresh SHA. Measured 2026-09-02: 4 of 5 gated branches needed more
+  // than one lease attempt.
+  //
+  // The queued path already recovers (it rewrites status "queued" and preserves
+  // the lease). The running path cannot preserve the lease — the slot must be
+  // freed for the next claimant — but it must still tell the truth about cause.
+  // `blocked_*` is the vocabulary pregate-status already classifies as
+  // INCONCLUSIVE, so this needs no reader change and inherits the honest
+  // headline the blocked statuses already earn.
   writeStateImpl(stateFile, {
     branch,
     sha,
     gatePassed: false,
     leaseId: state.leaseId,
     evidenceId: "",
-    status: "failed",
+    status: "blocked_wrapper_exited",
     expiresAt: state.expiresAt || "",
     resilience: state.resilience ?? null,
     leaseEvents,

--- a/scripts/pregate.test.mjs
+++ b/scripts/pregate.test.mjs
@@ -131,7 +131,7 @@ test("pregate shell route is explicit and still requires a working shell", () =>
   }), false);
 });
 
-test("pregate recovery releases an interrupted running gate and marks it failed", async () => {
+test("pregate recovery releases an interrupted running gate and marks it INFRASTRUCTURE, not failed (BI-D088D06D)", async () => {
   const calls = [];
   let written = null;
   const recovered = await recoverInterruptedGateState({
@@ -167,13 +167,18 @@ test("pregate recovery releases an interrupted running gate and marks it failed"
     tool: "release_nonprod_environment_lease",
     args: { leaseId: "NPEL-INTERRUPTED" },
   }]);
-  assert.equal(written.status, "failed");
+  // The wrapper dying before a terminal state never graded the diff, so it must
+  // not write a status that reads as a grade. `blocked_*` is the vocabulary
+  // pregate-status classifies as INCONCLUSIVE.
+  assert.equal(written.status, "blocked_wrapper_exited");
+  assert.match(written.status, /^blocked_/);
+  assert.notEqual(written.status, "failed");
   assert.equal(written.gatePassed, false);
   assert.equal(written.leaseEvents.at(-1).type, "pregate_interrupted_gate_recovery");
   assert.equal(written.recovery.reason, "gate-wrapper-exited-before-terminal-state");
 });
 
-test("pregate recovery releases an interrupted queued gate and marks it failed", async () => {
+test("pregate recovery releases an interrupted queued gate as INFRASTRUCTURE, not failed (BI-D088D06D)", async () => {
   const calls = [];
   let written = null;
   const recovered = await recoverInterruptedGateState({
@@ -228,7 +233,8 @@ test("pregate recovery releases an interrupted queued gate and marks it failed",
       },
     },
   ]);
-  assert.equal(written.status, "failed");
+  assert.equal(written.status, "blocked_wrapper_exited");
+  assert.notEqual(written.status, "failed");
   assert.equal(written.leaseEvents.at(-1).type, "pregate_interrupted_gate_recovery");
   assert.equal(written.recovery.childStatus, 4294967295);
   assert.equal(written.recovery.queueObserverReleaseStatus, "released");


### PR DESCRIPTION
Closes the two gaps I named when scoring this epic against its brief, and corrects one of my own recommendations with evidence.

Prior PR in this epic: #4869. Baseline: https://claude.ai/code/artifact/05d0d22a-9fb6-4530-9fad-9baccbfec72c

## 1. Infrastructure is not a verdict — the writer half

`pregate-status` already classifies `blocked_*` as `INCONCLUSIVE`; that landed separately. The **writer** had not caught up.

When the gate wrapper exits before reaching a terminal state — a killed process, a host out of memory, a lost control plane — `recoverInterruptedGateState` wrote `status: "failed"`. That run never graded the diff. It died before it could. But `FAIL` reads as *your code is bad*, it permanently consumes that SHA's verdict, and it forces an amend to a fresh SHA.

It now writes `blocked_wrapper_exited`, which the reader already treats as infrastructure. **No reader change and no new vocabulary** — the fix is to stop calling infrastructure a grade.

Both recovery paths are covered. A queued gate that gets *recovered* rather than *revived* also never graded the diff, so it gets the same treatment; that test's name and expectation changed accordingly.

Why it matters, measured 2026-09-02 across the 45 most recent merged PRs joined to their gate leases: **4 of the 5 branches with lease rows needed more than one attempt.**

## 2. The reserve is calibrated from evidence, not typed

`hostStagePolicy` carried a flat 8 GiB with no calibration until 2026-08-30, when **I** set it to 6 GiB from a single hand measurement of one stage on one afternoon. That is precisely the class of unevidenced constant this epic exists to remove, and I introduced it.

The evidence was already on disk and unread: **every vitest stage receipt carries ~50 host samples with `freeMemoryBytes`.** `scripts/local-ci-host-stage-calibration.mjs` reads them.

Across 90 receipts — minimum free memory *while a stage was running*:

| p10 | p50 | p90 | worst |
| ---: | ---: | ---: | ---: |
| 4.39 GiB | 15.47 GiB | 23.73 GiB | **0.28 GiB** |

**This corrects my own earlier recommendation.** I had proposed shrinking the reserve to lift the two-slot fit rate from 46%. The data says don't: the host genuinely exhausts itself on the tightest runs, and a smaller reserve admits a second stage onto exactly those runs. The tool prints that warning in its own output rather than leaving the next reader to rediscover it.

Split by coverage mode, the affected-test change from #4869 is already doing the work instead:

| stage | runs | p10 free | p50 free |
| --- | ---: | ---: | ---: |
| `exhaustive-vitest` | 83 | 4.39 GiB | 15.47 GiB |
| `affected-vitest` | 7 | **7.62 GiB** | **21.60 GiB** |

**74% more headroom at p10.** The second slot becomes reachable as the fleet converts to affected runs, with the reserve untouched.

## 3. What each guard buys — the audit's missing column

The brief asked, per guard, what defect motivated it and whether that class recurred. I previously reported this unanswerable: 87 of 88 cited BI ids predate the 2026-08-22 backlog reset.

The live backlog can't answer it. **Git can.** Two independent signals over 7,105 commits on `main`:

- **mentions** — commits whose message names the guard file; when a guard blocks a change, the commit that unblocks it tends to name it
- **baseline** — commits moving the guard's ratchet baseline or allowlist; each is the guard forcing a recorded change

**83 of 95 guards have firing evidence. 12 have none.** Reported as *absence of evidence*, never as evidence of absence — a guard can fire and be fixed without being named.

The cost/benefit conclusion is narrow and worth stating plainly: **exactly one** guard is both untraced and costs over a second, and **exactly one** is wired into no stage at all. The other 93 either earn their cost or are too cheap to be worth removing. That is a stronger case for the guard surface than I could make before.

## 4. End-to-end timeline by change shape

The brief asked for this and my first pass composed it from stage measurements rather than tracing real PRs. Now joined to real lease data:

| shape | n | first commit → PR open | gate wait | gate hold | PR open → merged | **total** |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| docs | 6 | 0.8 | — | — | 21.1 | **22.9** |
| source | 37 | 12.5 | 73.9 | 20.0 | 25.9 | **43.8** |
| schema | 2 | — | — | — | 21.9 | **36.7** |

Against the stated service level — docs under 20 minutes, source under 40 — **docs misses by 3 minutes and source by 4.** Close; neither met.

Caveats stated in the audit rather than buried: only 5 of 45 branches had lease rows on this host, and the gate columns are sums across attempts, not per-attempt figures.


## 5. A gate that passed on slot-1 must be pushable

Found by this branch's own push being refused, and it is the most consequential item here.

Gate state is written **per slot** — slot-0 to `dpf-local-ci-gate.json`, slot-1 to `dpf-local-ci-gate-slot-1.json`. `pregate:status` reconciles across slots. **The pre-push hook read the slot-0 filename and nothing else.**

```
pregate:status →  PASS on slot-1, evidence cmtjqm6bv038301o6142cb9id

dpf-local-ci-gate-slot-1.json   passed   gatePassed true
dpf-local-ci-gate.json          queued   gatePassed false

git push → refused: "does not pass for this HEAD ... gatePassed=false"
```

Same branch, same SHA, a genuine passing gate with a real evidence record — refused because a stale slot-0 record from an earlier unadmitted attempt shadowed it.

**This activates exactly when the two-slot pool starts working, and cancels it.** A contributor who wins slot-1 earns a PASS, cannot push, re-runs, and may then land on slot-0 and succeed — so it presents as *gate flakiness* rather than a slot bug. That is plausibly a real share of the churn this epic measured (32.5% of commits process rather than product; 4 of 5 gated branches needing more than one attempt), which I had been attributing entirely to queueing and infrastructure verdicts.

It stayed invisible because slot-1 had been used 3 times in 336 leases. This branch's own gate run was one of them.

The hook now prefers any slot record passing for this branch and SHA, and otherwise keeps the default file so every existing refusal message is byte-identical. Filed as `BI-5529B5AC`, which also records the wider repair: have the hook consume the reconciled verdict `pregate:status` already computes, and clear a losing slot record once another slot passes the same SHA.

**This push is the fix testing itself** — it went through on a slot-1 pass that would have been refused an hour ago.

## Guarantees

No guard is retired or weakened. The only behaviour change is which *status string* an already-failing recovery path writes, and it moves from a value that overstated what the gate knew to one that states it accurately. Auth, DCO, secret scanning and migration safety are untouched.

## Verification

`pregate.test.mjs` 14 passed · `pregate-status.test.mjs` 31 passed · `local-ci-host-stage-calibration.test.mjs` 9 passed · guard-parity preflight **63 guards clean**.

The calibration tests cover the traps that would make it lie: a garbage sample reading as zero free memory, fewer than three samples being treated as evidence, observations with no host block, and an empty corpus inventing a reserve.

Epic `EP-ABB3AC9D` · Workroom `WC-E2D6996E` · Refs `BI-D088D06D`, `BI-E58B57EC`, `BI-2C0A01CD`, `BI-5529B5AC`

## Still open

- **`--maxWorkers` is still 4** on a 12-CPU VM. Unmeasured, deliberately.
- **Surfacing `effectiveCapacity` / `rollbackReason`** to an operator. The resolver returns them; nothing reads them.
- **The AGENTS.md line** — *a gate that could not run is not a verdict* — proposed, not made. The instruction plane is a shrink-only ratchet, so it needs a paid-for offset and a founder decision. This PR makes the *code* true; the doctrine line would make it stated.
