### PR TITLE
fix(data-screening): let source code leave the host untransformed (BI-35FAE2DB)

### DIFF
--- a/apps/web/lib/inference/data-screening/source-code-untransformed-export.test.ts
+++ b/apps/web/lib/inference/data-screening/source-code-untransformed-export.test.ts
@@ -1,0 +1,81 @@
+// BI-35FAE2DB follow-up — why Build Studio design review could never complete.
+//
+// Two independent fences confined every code payload to the local engine:
+//
+//  1. The source-code pack declares `protectedExternalEffect:
+//     "allow-with-obligations"`, but the generated executable policy matched
+//     only `transformations: ["masked","tokenized"]`. Code is never masked, so
+//     the allow could not fire and evaluation fell to `no-policy-high-risk`.
+//  2. The workload binding classified source code `confidential`, which
+//     auto-attaches a `mask` obligation (profile `default-confidential`), and
+//     `screenInferencePayload` fences any turn carrying one.
+//
+// Observed live on FB-D85BEA44: design review looped 348 rounds, every attempt
+// dying with `inference admission timeout on local engine after 120000ms`.
+//
+// Driven through the real screener so classifier, policy bundle and route
+// mapping are exercised together rather than a hand-built context.
+import { describe, it, expect } from "vitest";
+import { screenInferencePayload } from "./screen-inference-payload";
+
+function screen(content: string) {
+  return screenInferencePayload({
+    systemPrompt: "You are a design reviewer.",
+    messages: [{ role: "user", content }],
+    tools: [],
+    routeContext: { sensitivity: "internal" },
+  }).receipt;
+}
+
+const CODE =
+  "export function normalizeFilePaths(paths: string[]): string[] { return paths.filter(Boolean); } "
+  + "import { prisma } from '@dpf/db';";
+
+describe("source code may leave untransformed (BI-35FAE2DB follow-up)", () => {
+  it("lets an untransformed source-code payload route off-host", () => {
+    const r = screen(CODE);
+    expect(r.classifiedDataClasses).toEqual(["source-code"]);
+    // The control for code is contractual — the pack's no-training /
+    // zero-retention / repository-authorized provider evidence — not masking.
+    expect(r.routeEffect).toBe("allow");
+  });
+
+  it("still confines regulated data in the same untransformed shape", () => {
+    const pay = screen("Wire the vendor: routing number 021000021, account number 5512338891.");
+    expect(pay.routeEffect).toBe("local-only");
+
+    const emp = screen("Employee salary band review: base salary 92000, SSN 123-45-6789.");
+    expect(emp.routeEffect).toBe("local-only");
+  });
+
+  it("does not let code launder regulated data bundled with it", () => {
+    const mixed = screen(`${CODE}\nEmployee salary band review: base salary 92000, SSN 123-45-6789.`);
+    expect(mixed.classifiedDataClasses).toContain("source-code");
+    expect(mixed.routeEffect).toBe("local-only");
+  });
+
+  it("keeps secrets on the host even when they appear inside code", () => {
+    // secrets-credentials stays `restricted` + local-only. This is the case that
+    // makes the whole change safe: reclassifying code did NOT reclassify keys.
+    const secret = screen(`${CODE}\nconst key = "sk-ant-api03-REDACTEDLOOKINGSECRETVALUE";`);
+    expect(secret.classifiedDataClasses).toContain("secrets-credentials");
+    expect(secret.routeEffect).toBe("local-only");
+  });
+
+  it("scopes the untransformed opt-in to exactly one pack", async () => {
+    // A regression here would widen PHI/payroll/customer export, so assert the
+    // opt-in is not spreading.
+    const mod = await import("./vertical-policy-packs");
+    const classes = [
+      "customer-records", "employee-records", "payments-finance", "health-phi",
+      "student-records", "youth-sensitive", "legal-privileged", "criminal-justice",
+      "safety-sensitive", "public-sector-records", "security-logs",
+      "regulated-decisioning", "source-code", "secrets-credentials",
+    ] as const;
+    const permitted = classes.filter((c) =>
+      (mod.getVerticalSensitiveDataPolicyPack(c) as unknown as {
+        untransformedExternalExport?: string;
+      }).untransformedExternalExport === "permitted");
+    expect(permitted).toEqual(["source-code"]);
+  });
+});

--- a/apps/web/lib/inference/data-screening/vertical-policy-packs.ts
+++ b/apps/web/lib/inference/data-screening/vertical-policy-packs.ts
@@ -32,6 +32,20 @@ export type VerticalSensitiveDataPolicyPack = {
   retentionPromptCode: string;
   refusalCode: string;
   requiredProviderEvidence: string[];
+  /**
+   * Whether an UNTRANSFORMED payload of this class may leave for an external
+   * service, or whether it must be masked/tokenized first (BI-35FAE2DB follow-up).
+   *
+   * Default is `requires-transformation` — the conservative platform stance, and
+   * what every regulated class keeps. `permitted` is for classes where masking
+   * destroys the very thing being sent, so the protection is CONTRACTUAL
+   * (the pack's requiredProviderEvidence: no-training / zero-retention) rather
+   * than transformational. Source code is the case: you cannot review masked
+   * code. Without this, a pack could declare `allow-with-obligations` and still
+   * deny every real payload, because the generated policy only matched
+   * transformations the class never undergoes.
+   */
+  untransformedExternalExport: "permitted" | "requires-transformation";
   authorityRefs: string[];
   policies: DataExecutablePolicy[];
 };
@@ -70,6 +84,7 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-customer-purpose-limited",
     refusalCode: "boundary-customer-protection-required",
     requiredProviderEvidence: ["no-training", "retention-reviewed", "contract-reviewed"],
+    untransformedExternalExport: "requires-transformation",
     authorityRefs: [AUTHORITY.ftcDataSecurity, AUTHORITY.nistControls],
   },
   {
@@ -83,6 +98,7 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-employee-need-to-know",
     refusalCode: "boundary-employee-authorization-required",
     requiredProviderEvidence: ["no-training", "access-controls", "contract-reviewed"],
+    untransformedExternalExport: "requires-transformation",
     authorityRefs: [AUTHORITY.eeocAda, AUTHORITY.nistControls],
   },
   {
@@ -96,6 +112,7 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-financial-schedule-required",
     refusalCode: "boundary-financial-safeguards-required",
     requiredProviderEvidence: ["financial-customer-info-reviewed", "encryption", "contract-reviewed"],
+    untransformedExternalExport: "requires-transformation",
     authorityRefs: [AUTHORITY.ftcSafeguards, AUTHORITY.nistControls],
   },
   {
@@ -109,6 +126,7 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-clinical-schedule-required",
     refusalCode: "boundary-health-safeguards-required",
     requiredProviderEvidence: ["baa-on-file", "no-training", "regional-processing"],
+    untransformedExternalExport: "requires-transformation",
     authorityRefs: [AUTHORITY.hhsHipaa, AUTHORITY.nistControls],
   },
   {
@@ -122,6 +140,7 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-student-purpose-limited",
     refusalCode: "boundary-student-disclosure-authority-required",
     requiredProviderEvidence: ["student-data-terms-reviewed", "no-training", "access-controls"],
+    untransformedExternalExport: "requires-transformation",
     authorityRefs: [AUTHORITY.ferpa, AUTHORITY.nistControls],
   },
   {
@@ -135,6 +154,7 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-youth-minimize",
     refusalCode: "boundary-youth-human-authorization-required",
     requiredProviderEvidence: ["verified-parental-or-authorized-role", "purpose-reviewed"],
+    untransformedExternalExport: "requires-transformation",
     authorityRefs: [AUTHORITY.coppa, AUTHORITY.ferpa],
   },
   {
@@ -148,6 +168,7 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-legal-hold-aware",
     refusalCode: "boundary-legal-role-review-required",
     requiredProviderEvidence: ["legal-role-authorized", "confidentiality-terms-reviewed"],
+    untransformedExternalExport: "requires-transformation",
     authorityRefs: [AUTHORITY.abaConfidentiality, AUTHORITY.nistControls],
   },
   {
@@ -161,6 +182,7 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-cjis-governed",
     refusalCode: "boundary-cjis-governed-environment-required",
     requiredProviderEvidence: ["cjis-boundary-approved"],
+    untransformedExternalExport: "requires-transformation",
     authorityRefs: [AUTHORITY.fbiCjis, AUTHORITY.nistControls],
   },
   {
@@ -174,6 +196,7 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-safety-case-controlled",
     refusalCode: "boundary-safety-human-checkpoint-required",
     requiredProviderEvidence: ["accountable-human-owner", "purpose-reviewed"],
+    untransformedExternalExport: "requires-transformation",
     authorityRefs: [AUTHORITY.nistAiRmf, AUTHORITY.nistControls],
   },
   {
@@ -187,6 +210,7 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-public-record-schedule-required",
     refusalCode: "boundary-agency-purpose-review-required",
     requiredProviderEvidence: ["agency-purpose-authorized", "regional-processing"],
+    untransformedExternalExport: "requires-transformation",
     authorityRefs: [AUTHORITY.nistControls],
   },
   {
@@ -200,6 +224,7 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-security-evidence-schedule",
     refusalCode: "boundary-security-provider-evidence-required",
     requiredProviderEvidence: ["security-controls-reviewed", "no-training", "regional-processing"],
+    untransformedExternalExport: "requires-transformation",
     authorityRefs: [AUTHORITY.nistControls],
   },
   {
@@ -213,6 +238,7 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-decision-evidence-required",
     refusalCode: "boundary-regulated-human-decision-owner-required",
     requiredProviderEvidence: ["human-decision-owner", "decision-evidence-profile"],
+    untransformedExternalExport: "requires-transformation",
     authorityRefs: [AUTHORITY.nistAiRmf],
   },
   {
@@ -226,6 +252,12 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-source-purpose-limited",
     refusalCode: "boundary-source-provider-evidence-required",
     requiredProviderEvidence: ["no-training", "zero-retention", "repository-authorized"],
+    // Masked source code cannot be reviewed, refactored or reasoned about — the
+    // transformation destroys the payload's entire purpose. This pack already
+    // states the real control: a provider carrying no-training, zero-retention
+    // and repository-authorized evidence. So untransformed export is the
+    // supported path here, and the obligation (logUse) still applies.
+    untransformedExternalExport: "permitted",
     authorityRefs: [AUTHORITY.nistControls],
   },
   {
@@ -239,6 +271,7 @@ const DEFINITIONS: readonly PackDefinition[] = [
     retentionPromptCode: "retention-credential-none",
     refusalCode: "boundary-credential-omit-and-rotate",
     requiredProviderEvidence: ["local-secret-boundary"],
+    untransformedExternalExport: "requires-transformation",
     authorityRefs: [AUTHORITY.nistControls],
   },
 ] as const;
@@ -257,6 +290,7 @@ function executablePolicy(input: {
   dataClass: InferenceDataClass;
   assetId: DataAssetId;
   effect: VerticalSensitiveDataPolicyPack["protectedExternalEffect"];
+  untransformedExternalExport: VerticalSensitiveDataPolicyPack["untransformedExternalExport"];
   authorityRef: string;
 }): DataExecutablePolicy {
   return {
@@ -267,7 +301,11 @@ function executablePolicy(input: {
       actions: ["export"],
       assets: [input.assetId],
       destinations: ["external-service"],
-      transformations: ["masked", "tokenized"],
+      // Only classes that explicitly opt in may match an untransformed payload;
+      // every regulated class keeps the masked/tokenized-only contract.
+      transformations: input.untransformedExternalExport === "permitted"
+        ? ["none", "masked", "tokenized"]
+        : ["masked", "tokenized"],
     },
     effect: input.effect,
     ...(input.effect === "allow-with-obligations"
@@ -288,6 +326,7 @@ function materialize(definition: PackDefinition): VerticalSensitiveDataPolicyPac
     categories: [...binding.categories],
     applicableArchetypeCategories: [...definition.applicableArchetypeCategories],
     requiredProviderEvidence: [...definition.requiredProviderEvidence],
+    untransformedExternalExport: definition.untransformedExternalExport,
     authorityRefs: [...definition.authorityRefs],
     policies: [executablePolicy({
       id: definition.id,
@@ -295,6 +334,7 @@ function materialize(definition: PackDefinition): VerticalSensitiveDataPolicyPac
       dataClass: definition.dataClass,
       assetId: binding.assetId,
       effect: definition.protectedExternalEffect,
+      untransformedExternalExport: definition.untransformedExternalExport,
       authorityRef: definition.authorityRefs[0],
     })],
   };
@@ -314,6 +354,7 @@ const UNKNOWN_PACK: VerticalSensitiveDataPolicyPack = {
   retentionPromptCode: "retention-unknown-classify-first",
   refusalCode: "boundary-unknown-classify-before-dispatch",
   requiredProviderEvidence: ["governed-classification"],
+  untransformedExternalExport: "requires-transformation",
   authorityRefs: [AUTHORITY.nistControls],
   policies: [executablePolicy({
     id: "vertical-unknown-governed-data",
@@ -321,6 +362,7 @@ const UNKNOWN_PACK: VerticalSensitiveDataPolicyPack = {
     dataClass: "unknown-governed-data",
     assetId: "data:inference-payload",
     effect: "deny",
+    untransformedExternalExport: "requires-transformation",
     authorityRef: AUTHORITY.nistControls,
   })],
 };

--- a/apps/web/lib/routing/provider-suitability/compile.test.ts
+++ b/apps/web/lib/routing/provider-suitability/compile.test.ts
@@ -114,7 +114,11 @@ describe("AI workload data profiles", () => {
     ["health-phi", "restricted", "region-bound"],
     ["student-records", "restricted", "region-bound"],
     ["payments-finance", "restricted", "region-bound"],
-    ["source-code", "confidential", "region-bound"],
+    // BI-35FAE2DB follow-up: source code is INTERNAL, not confidential.
+    // `confidential` auto-attaches a mask obligation, and a masked payload is
+    // useless for the one thing code is sent for — being read. Genuine secrets
+    // are unchanged on the line below, which is what keeps this safe.
+    ["source-code", "internal", "region-bound"],
     ["secrets-credentials", "restricted", "local-only"],
   ] as const)("derives %s through the governed data vocabulary", (workloadClass, sensitivity, residencyClass) => {
     const profile = deriveAiWorkloadDataProfile({ workloadClass });

--- a/apps/web/lib/routing/provider-suitability/workload-profile.ts
+++ b/apps/web/lib/routing/provider-suitability/workload-profile.ts
@@ -100,7 +100,16 @@ const WORKLOAD_BINDINGS: Readonly<Record<AiWorkloadClassKey, AiWorkloadDataBindi
   },
   "source-code": {
     assetId: "data:source-code",
-    sensitivity: "confidential",
+    // BI-35FAE2DB follow-up: source code is INTERNAL, not confidential.
+    // `confidential` on this scale means disclosure causes irreparable harm —
+    // bank details, HR records, PHI. It also auto-attaches a `mask` obligation
+    // (profile default-confidential), and a masked payload is useless for the
+    // one thing code is sent for: being read. That combination fenced every
+    // code payload to the local engine regardless of the source-code pack's
+    // declared `allow-with-obligations`. Genuine secrets are NOT reclassified —
+    // `secrets-credentials` stays `restricted` + local-only below, so keys and
+    // tokens never leave even when they appear inside a code payload.
+    sensitivity: "internal",
     categories: ["content", "configuration"],
     residencyClass: "region-bound",
   },


### PR DESCRIPTION
fix(data-screening): let source code leave the host untransformed (BI-35FAE2DB)

Build Studio design review on FB-D85BEA44 reached iteration round 348 without
ever completing. Every attempt died with:

  [callWithFallbackChain] local failed: inference admission timeout on local
  engine after 120000ms (origin=interactive, provider=local)

The reviewers were confined to the local engine, which cannot load a 27B model
inside the 120s admission window. Live receipt for those turns:

  routeEffect            local-only
  policyEffect           deny
  classifiedDataClasses  ["source-code"]

A payload whose ONLY data class is source code could not leave the host. Two
independent fences caused it, and both had to go:

1. The source-code vertical pack declares `protectedExternalEffect:
   "allow-with-obligations"`, but `executablePolicy()` hardcoded
   `transformations: ["masked","tokenized"]`. Code is never masked — masked code
   cannot be reviewed — so that allow could never match a real payload, and
   evaluation fell through to `no-policy-high-risk`, which denies. The pack was
   declaring an effect its own generated policy could never deliver.

2. The workload binding classified source code `confidential`, which
   auto-attaches a `mask` obligation (profile `default-confidential`).
   `screenInferencePayload` fences any turn carrying one, so even once (1) was
   fixed the turn was still clamped to local-only.

Fixes, both deliberately narrow:

- Add `untransformedExternalExport` to the pack definition, default
  `requires-transformation`. Only `vertical-source-code` opts in to `permitted`.
  A test asserts the opt-in list is EXACTLY ["source-code"], so a future pack
  cannot quietly widen PHI, payroll, student or customer export.

- Reclassify the source-code workload binding `confidential` -> `internal`.
  On this scale `confidential` means disclosure causes irreparable harm — bank
  details, HR records, PHI. Source code is internal: not public, not
  catastrophic. The control for it is contractual, which the pack already
  states: no-training, zero-retention, repository-authorized provider evidence.

What did NOT change, verified by test through the real screener:

  payload                          routeEffect
  source code only                 allow          <- the fix
  routing/account numbers          local-only
  employee salary + SSN            local-only
  code + employee record           local-only     <- no laundering via bundling
  code + an API key                local-only     <- secrets never leave

`secrets-credentials` stays `restricted` + `local-only`, so keys and tokens are
still confined even when they appear inside a code payload. That is what makes
reclassifying code safe: it did not reclassify secrets.

Tests: new end-to-end suite driven through screenInferencePayload (classifier +
policy bundle + route mapping together, not a hand-built context), including the
scoping assertion. Updated compile.test.ts, which pinned the old
`source-code -> confidential` value this change deliberately corrects.
405 test files / 4718 tests green; tsc --noEmit clean.

Docs-Impact-Decision: internal data-classification and policy-generation
mechanics. No user-facing or coworker-facing documentation states the
sensitivity band of source code or the transformation contract of a policy pack,
and no documented behaviour changes — reviews that previously could not run now
run.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Mark Bodman <markdbodman@gmail.com>


---

## How this was found

Driving Build Studio end-to-end through the live portal as the reviewing human,
after the previous fix (#4980) removed the first blocker. FB-D85BEA44 still
could not leave `ideate` — round 348 — and the live route decisions showed why:
a design-review payload classified purely as `source-code` was denied cloud
egress and pinned to a local 27B model that cannot load inside the 120s
admission window.

## Reviewer notes — where to push hardest

The risk in this change is scope creep across policy packs, so that is what the
tests target:

- `untransformedExternalExport` defaults to `requires-transformation`. Seven
  packs carry `allow-with-obligations` (customer-records, employee-records,
  payments-finance, health-phi, student-records, security-logs, source-code) —
  only source-code opts in, and a test asserts the permitted list equals
  exactly `["source-code"]`.
- The `confidential -> internal` reclassification is the half that actually
  unfences the turn, because `confidential` auto-attaches a `mask` obligation.
  It applies to the source-code binding ONLY. `secrets-credentials` remains
  `restricted` + `local-only`.
- The bundling cases are the ones worth reading closely: code + SSN, and code +
  an API key. Both must stay `local-only`, and both are asserted, because
  "strongest effect wins" is what stops code from laundering regulated data.
