### PR TITLE
fix(workroom): the drive capped rooms before filtering for a shape (BI-72B3FB40)

### DIFF
--- a/apps/web/lib/queue/functions/workroom-drive-selection.test.ts
+++ b/apps/web/lib/queue/functions/workroom-drive-selection.test.ts
@@ -1,0 +1,96 @@
+// Room selection for the standing drive (BI-72B3FB40).
+//
+// The drive shipped selecting rooms like this:
+//
+//   findMany({ where: { non-terminal } , take: 200 })   // no orderBy
+//     .flatMap(row => resolveWorkShapeClaim(row.scopeClaims) ? [row] : [])
+//
+// The cap therefore applied to ALL rooms and the claim filter ran afterwards,
+// in JavaScript. On the reference install that was 276 non-terminal rooms with
+// exactly one shaped room, and the drive reported `scanned: 0` on every tick
+// for seven hours — the one room that mattered sat outside an unordered
+// 200-row window. Nothing errored; the feature was simply invisible.
+//
+// The invariant these tests hold: the claim filter and the ordering belong in
+// the query, so the cap bounds rooms the drive could act on rather than rooms
+// that merely exist.
+
+import { describe, expect, it } from "vitest";
+
+import { STANDING_ROOM_SCAN_LIMIT, loadStandingRoomIds } from "./workroom-drive";
+
+/** Captures the SQL the selector issues, and returns canned ids. */
+function stubDb(rows: Array<{ id: string }> = []) {
+  const seen: string[] = [];
+  const values: unknown[] = [];
+  return {
+    seen,
+    values,
+    db: {
+      $queryRaw: (q: TemplateStringsArray, ...v: unknown[]) => {
+        seen.push(q.join("?"));
+        values.push(...v);
+        return Promise.resolve(rows);
+      },
+    },
+  };
+}
+
+describe("standing-room selection", () => {
+  it("filters for a work-shape claim in the query, not after it", async () => {
+    // This is the whole defect. If the claim filter ever moves back out of SQL,
+    // the cap silently starts hiding shaped rooms again.
+    const { db, seen } = stubDb();
+    await loadStandingRoomIds(db);
+    const sql = seen.join(" ");
+    expect(sql).toMatch(/jsonb_array_elements/i);
+    expect(sql).toContain("workShape");
+    expect(sql).toMatch(/EXISTS/i);
+  });
+
+  it("excludes terminal and archived rooms in the query", async () => {
+    const { db, seen } = stubDb();
+    await loadStandingRoomIds(db);
+    const sql = seen.join(" ");
+    expect(sql).toMatch(/"archivedAt"\s+IS\s+NULL/i);
+    for (const terminal of ["abandoned", "archived", "complete"]) {
+      expect(sql).toContain(terminal);
+    }
+  });
+
+  it("orders deterministically before applying the cap", async () => {
+    // Without ORDER BY, which rooms fall inside the cap is whatever the planner
+    // returned that day — so a room could be scanned on one tick and invisible
+    // on the next, with no change to the room itself.
+    const { db, seen, values } = stubDb();
+    await loadStandingRoomIds(db);
+    const sql = seen.join(" ");
+    expect(sql).toMatch(/ORDER\s+BY/i);
+    const orderIndex = sql.search(/ORDER\s+BY/i);
+    const limitIndex = sql.search(/LIMIT/i);
+    expect(orderIndex).toBeGreaterThan(-1);
+    expect(limitIndex).toBeGreaterThan(orderIndex);
+    expect(values).toContain(STANDING_ROOM_SCAN_LIMIT);
+  });
+
+  it("returns every id the query yielded, without post-filtering", async () => {
+    // A JS filter after the query would re-create the original bug in a new
+    // place: rows fetched, then silently discarded below the cap.
+    const rows = Array.from({ length: 25 }, (_, i) => ({ id: `room-${i}` }));
+    const { db } = stubDb(rows);
+    const ids = await loadStandingRoomIds(db);
+    expect(ids).toHaveLength(rows.length);
+    expect(ids[0]).toBe("room-0");
+    expect(ids.at(-1)).toBe("room-24");
+  });
+
+  it("handles an empty result without work", async () => {
+    const { db } = stubDb([]);
+    expect(await loadStandingRoomIds(db)).toEqual([]);
+  });
+
+  it("bounds a tick to a sane number of rooms", () => {
+    expect(STANDING_ROOM_SCAN_LIMIT).toBeGreaterThan(0);
+    expect(STANDING_ROOM_SCAN_LIMIT).toBeLessThanOrEqual(500);
+  });
+});

--- a/apps/web/lib/queue/functions/workroom-drive.ts
+++ b/apps/web/lib/queue/functions/workroom-drive.ts
@@ -90,6 +90,9 @@ export type WorkroomDriveResult = {
 
 const TERMINAL = new Set(["abandoned", "archived", "complete"]);
 
+/** Max rooms one drive tick will consider. Bounds CANDIDATES, not all rooms. */
+export const STANDING_ROOM_SCAN_LIMIT = 200;
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -310,10 +313,46 @@ export async function runWorkroomDriveJob(
   };
 }
 
+/**
+ * Ids of the rooms the drive could possibly act on: non-terminal, not archived,
+ * and actually carrying a work-shape claim.
+ *
+ * The claim lives inside the `scopeClaims` JSON, which Prisma cannot filter on
+ * for an array of objects — so this is raw SQL rather than a `findMany` where
+ * clause. That matters more than it looks: the previous implementation capped
+ * `findMany` at 200 rows and only then filtered for the claim in JavaScript, so
+ * the cap applied to ALL rooms rather than to candidates. On the reference
+ * install that meant 276 non-terminal rooms, exactly one of them shaped, and a
+ * drive that reported `scanned: 0` forever because the one shaped room fell
+ * outside an unordered 200-row window. Filtering in SQL means the cap now
+ * bounds work the drive can actually do, and `ORDER BY` makes which rooms it
+ * takes deterministic instead of whatever the planner returned.
+ */
+export async function loadStandingRoomIds(db: {
+  $queryRaw: (q: TemplateStringsArray, ...v: unknown[]) => Promise<Array<{ id: string }>>;
+}): Promise<string[]> {
+  const rows = await db.$queryRaw`
+    SELECT "id"
+    FROM "WorkCapsule"
+    WHERE "archivedAt" IS NULL
+      AND "status" NOT IN ('abandoned', 'archived', 'complete')
+      AND EXISTS (
+        SELECT 1 FROM jsonb_array_elements("scopeClaims") AS claim
+        WHERE claim ? 'workShape'
+      )
+    ORDER BY "updatedAt" ASC, "id" ASC
+    LIMIT ${STANDING_ROOM_SCAN_LIMIT}
+  `;
+  return rows.map((row) => row.id);
+}
+
 async function loadStandingRooms(): Promise<WorkroomDriveRoom[]> {
   const { prisma } = await import("@dpf/db");
+  const ids = await loadStandingRoomIds(prisma as never);
+  if (ids.length === 0) return [];
   const rows = await prisma.workroom.findMany({
     where: {
+      id: { in: ids },
       archivedAt: null,
       status: { notIn: [...TERMINAL] },
     },
@@ -342,7 +381,6 @@ async function loadStandingRooms(): Promise<WorkroomDriveRoom[]> {
         },
       },
     },
-    take: 200,
   });
 
   return rows.flatMap((row) => {

--- a/docs/architecture/work-shapes-and-the-decision-gate.md
+++ b/docs/architecture/work-shapes-and-the-decision-gate.md
@@ -79,8 +79,19 @@ A standing room declares its activity shape by passing `workShape` to `create_wo
 entry with no migration, and is read back by `readWorkShapeClaim` / `resolveWorkShapeClaim`.
 
 **This claim is what makes a room wake.** The standing-Workroom drive
-(`apps/web/lib/queue/functions/workroom-drive.ts`, every 15 minutes) loads non-terminal rooms
-and drops every one whose `scopeClaims` carry no work-shape claim. A room without it is inert
+(`apps/web/lib/queue/functions/workroom-drive.ts`, every 15 minutes) selects non-terminal,
+unarchived rooms **that carry a work-shape claim**, ordered, and bounded by
+`STANDING_ROOM_SCAN_LIMIT`.
+
+The filter is part of the query rather than a pass over the results, and the distinction is
+load-bearing ⟦runtime: corrected 2026-09-02, `BI-72B3FB40`⟧. The first implementation capped
+the row read at 200 and filtered for the claim afterwards in JavaScript, so the cap bounded
+*every* room instead of the candidates. On an install with 276 non-terminal rooms and one
+shaped room, the drive reported `scanned: 0` on every tick for seven hours: registered,
+connected, executing in 47ms, and reading the wrong set of rows. Nothing errored, which is
+why it took a direct row count to see. The ordering matters for the same reason — without it,
+which rooms fall inside the cap is whatever the query planner returned, so a room could be
+scanned on one tick and invisible on the next without changing at all. A room without it is inert
 by construction, however assertive its posture. A malformed reference is refused at
 normalization rather than stored, because a claim that can never resolve would leave the room
 looking declared and behaving inert — the exact failure this contract exists to end.


### PR DESCRIPTION
## The symptom

The standing-Workroom drive has been running every 15 minutes and reporting `scanned: 0` on every tick. Registered with Inngest, synced, connected, executing in 47ms, no errors — and completely blind to the one room that mattered.

```json
{"runId":"workroom-drive:2026-09-02T13:08:17.427Z",
 "scanned":0,"dispatched":0,"attention":0,"stopped":0,"skipped":0,"plans":[]}
```

## The cause

`loadStandingRooms` did:

```ts
findMany({ where: { non-terminal }, take: 200 })   // no orderBy
  .flatMap(row => resolveWorkShapeClaim(row.scopeClaims) ? [row] : [])
```

**The cap bounded every room; the claim filter ran afterwards, in JavaScript.** On this install that is **276 non-terminal rooms with exactly one shaped room** (verified by direct count), so the single room that could be driven fell outside an unordered 200-row window — permanently.

76 rooms were invisible to the drive on every tick, and *which* 76 was undefined by the query planner.

## The fix

The claim filters in SQL, so the cap bounds rooms the drive can act on rather than rows that merely exist. `jsonb_array_elements` is required because Prisma cannot express a filter over an array of JSON objects.

`ORDER BY` is not incidental: without it, which rooms land inside the cap is whatever the planner returned, so a room could be scanned on one tick and invisible the next without changing at all.

**Verified against the live database** — the new query returns exactly `WC-A69BCABB`, the one room carrying a claim.

I deliberately did **not** just raise the cap. That would have made the symptom disappear at 276 rooms and returned silently at 501, which is the worse fix.

## The guard

`workroom-drive-selection.test.ts` holds the invariant: the claim filter and the ordering stay in the query, `LIMIT` is applied after `ORDER BY`, and nothing post-filters the result in JS — which would recreate the same defect one layer up.

## Why it took so long to see

Nothing errored. The function was healthy by every signal I checked first — registration, app connection, signing keys, Redis, quiescence — and I twice mistook absent log lines for proof. The run output was the only thing that isolated it.

## Verification

Local-CI gate passed, evidence `cmtk5fcw989ko01mxrobwrqlb`. 756 tests across `lib/queue` and `lib/work-management`; web typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)