### PR TITLE
fix(github): resolve a read token from the credentials the install actually has (BI-69BBC446)

### DIFF
--- a/apps/web/lib/contributor-change-lanes/github-rest-reader.test.ts
+++ b/apps/web/lib/contributor-change-lanes/github-rest-reader.test.ts
@@ -34,7 +34,7 @@ vi.mock("@/lib/credential-crypto", () => ({
   decryptSecret: mocks.decryptSecret,
 }));
 
-import { parseRepoFromUrl, readGithubPullRequests } from "./github-rest-reader";
+import { parseRepoFromUrl, readGithubPullRequests, resolveGithubToken } from "./github-rest-reader";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -245,3 +245,55 @@ function makeRawPr(n: number) {
     mergeable_state: "CLEAN",
   };
 }
+
+
+// BI-69BBC446. resolveGithubToken read exactly one credential row,
+// "github-pr-sync", which nothing in the product writes — the Contributor MCP
+// card its comment named does not exist. So it returned null on every install,
+// callers fell back to unauthenticated requests, and against a private repo
+// those fail. That killed repository provenance, and with it plan-coverage
+// receipts, spec-approval baselines and independent design review — while an
+// active "hive-contribution" credential sat one row away.
+describe("resolveGithubToken credential chain", () => {
+  function prismaWith(rows: Record<string, { secretRef: string; status: string } | null>) {
+    return {
+      credentialEntry: {
+        findUnique: vi.fn(async ({ where }: { where: { providerId: string } }) =>
+          rows[where.providerId] ?? null),
+      },
+    } as never;
+  }
+
+  it("prefers the dedicated github-pr-sync credential when one exists", async () => {
+    const token = await resolveGithubToken(prismaWith({
+      "github-pr-sync": { secretRef: "dedicated-token", status: "active" },
+      "hive-contribution": { secretRef: "hive-token", status: "active" },
+    }));
+    expect(token).toBe("dedicated-token");
+  });
+
+  it("falls back to hive-contribution when github-pr-sync is absent", async () => {
+    const token = await resolveGithubToken(prismaWith({
+      "hive-contribution": { secretRef: "hive-token", status: "active" },
+    }));
+    expect(token).toBe("hive-token");
+  });
+
+  it("falls back to git-backup when neither of the first two is active", async () => {
+    const token = await resolveGithubToken(prismaWith({
+      "hive-contribution": { secretRef: "stale", status: "revoked" },
+      "git-backup": { secretRef: "backup-token", status: "active" },
+    }));
+    expect(token).toBe("backup-token");
+  });
+
+  it("returns null when the store genuinely holds nothing usable", async () => {
+    const previous = process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    try {
+      expect(await resolveGithubToken(prismaWith({}))).toBeNull();
+    } finally {
+      if (previous !== undefined) process.env.GITHUB_TOKEN = previous;
+    }
+  });
+});

--- a/apps/web/lib/contributor-change-lanes/github-rest-reader.ts
+++ b/apps/web/lib/contributor-change-lanes/github-rest-reader.ts
@@ -2,9 +2,12 @@
 // Phase 4 of BI-063BDF1B — real GitHub REST reader.
 //
 // Replaces the Phase 2 stub. Authenticates via the CredentialEntry row
-// with providerId "github-pr-sync" (created by the Contributor MCP card
-// from PR #1204; disjoint from the "git-backup" / "hive-contribution"
-// rows used by the contribution pipeline). Etag persistence uses
+// with providerId "github-pr-sync" when one exists, falling back to the
+// contribution-pipeline rows when it does not — see the comment on
+// GITHUB_READ_CREDENTIAL_PROVIDER_IDS below. The header used to say this row
+// was "created by the Contributor MCP card from PR #1204"; no such writer
+// exists in the tree, and believing it cost a day of looking for a settings
+// page that was never built (BI-69BBC446). Etag persistence uses
 // ScheduledJob.metadata.githubPrEtag so the rate-budget protection
 // survives the ContributorInventorySnapshot 7-day retention sweep.
 //
@@ -118,12 +121,39 @@ export type PrismaLike = Pick<
   "credentialEntry" | "platformDevConfig" | "scheduledJob"
 >;
 
-// Exported for reuse by release-health (BI-3630773C) — same optional
-// "github-pr-sync" credential; callers that can read public repos treat a
-// null return as "proceed unauthenticated", not an error.
-export async function resolveGithubToken(prisma: PrismaLike): Promise<string | null> {
+/**
+ * Credentials this reader will authenticate with, best first.
+ *
+ * "github-pr-sync" stays the preferred row: the disjoint-credential intent in
+ * this file's header is a real one, and an install that sets it keeps a token
+ * scoped to exactly this job.
+ *
+ * The fallbacks exist because that intent was never reachable. Nothing in the
+ * product writes "github-pr-sync" — the Contributor MCP card named in the
+ * header does not exist in the tree. The GitHub device flow writes
+ * "hive-contribution"; the Admin > Platform Development panel writes
+ * "git-backup". So this resolver returned null on every install, and every
+ * caller degraded to an unauthenticated request, which against a private
+ * repository fails outright (BI-69BBC446).
+ *
+ * That took down the whole initiative-readiness chain: no repository
+ * provenance means no plan-coverage receipt, so no spec-approval baseline, so
+ * no reviewer binding, so no independent design review — on an install that
+ * had a perfectly good active credential sitting one row away. Preferring a
+ * dedicated credential is right; being dead without one is not.
+ *
+ * These are read-only calls against the same repository the fallback tokens
+ * already push to, so no fallback widens what the install can reach.
+ */
+const GITHUB_READ_CREDENTIAL_PROVIDER_IDS = [
+  GITHUB_PR_CREDENTIAL_PROVIDER_ID,
+  "hive-contribution",
+  "git-backup",
+] as const;
+
+async function readCredential(prisma: PrismaLike, providerId: string): Promise<string | null> {
   const cred = await prisma.credentialEntry.findUnique({
-    where: { providerId: GITHUB_PR_CREDENTIAL_PROVIDER_ID },
+    where: { providerId },
     select: { secretRef: true, status: true },
   });
   if (!cred || cred.status !== "active" || !cred.secretRef) return null;
@@ -131,13 +161,24 @@ export async function resolveGithubToken(prisma: PrismaLike): Promise<string | n
   const stored = cred.secretRef;
   try {
     const { decryptSecret } = await import("@/lib/credential-crypto");
-    if (stored.startsWith("enc:")) {
-      return decryptSecret(stored);
-    }
-    return stored;
+    // A key rotation leaves an undecryptable row: skip it and try the next
+    // credential rather than reporting "no token" for a store that has one.
+    return stored.startsWith("enc:") ? decryptSecret(stored) : stored;
   } catch {
     return null;
   }
+}
+
+// Exported for reuse by release-health (BI-3630773C); callers that can read
+// public repos treat a null return as "proceed unauthenticated", not an error.
+export async function resolveGithubToken(prisma: PrismaLike): Promise<string | null> {
+  for (const providerId of GITHUB_READ_CREDENTIAL_PROVIDER_IDS) {
+    const token = await readCredential(prisma, providerId);
+    if (token) return token;
+  }
+  // Legacy env fallback, matching resolveHiveToken's chain so the two resolvers
+  // cannot disagree about whether this install has GitHub access.
+  return process.env.GITHUB_TOKEN ?? null;
 }
 
 // Exported for reuse by release-health (BI-3630773C).


### PR DESCRIPTION
`resolveGithubToken` read exactly one `CredentialEntry` row, `github-pr-sync`. **Nothing in the product writes that row.**

- the GitHub device flow writes `hive-contribution`
- the Admin > Platform Development panel writes `git-backup`
- the "Contributor MCP card from PR #1204" this file's header credited with creating `github-pr-sync` does not exist in the tree

So the resolver returned `null` on every install and every caller quietly degraded to an unauthenticated request. Against a private repository those fail outright.

## What that took down

Repository provenance — and with it the whole initiative-readiness chain:

- `record_plan_backlog_coverage` → HTTP 422, so no coverage receipt
- no receipt → no `spec-approval` baseline
- no baseline → no reviewer binding
- no binding → no independent design review

Observed on BI-8E1FD1BD: three `summon_coworker` dispatches of AGT-WS-REVIEW created `AgentThread` rows with **0 messages and 0 children** and no error. The reviewer had nothing bindable to record against.

The install had an **active `hive-contribution` credential sitting one row away** the entire time — connected as @markdbodman since 6/16/2026, plainly shown as "GitHub connected" in the admin UI.

## The change

`github-pr-sync` stays *preferred*, so an install that sets it keeps a token scoped to exactly this job — the disjoint-credential intent in the header is a real one. It now falls through to `hive-contribution`, then `git-backup`, then `GITHUB_TOKEN`, matching `resolveHiveToken`'s existing chain so the two resolvers cannot disagree about whether this install has GitHub access.

Every call on this path is a **read** against the same repository those tokens already push to, so no fallback widens what the install can reach. A row that fails to decrypt after a key rotation is skipped rather than ending the search.

The misleading header comment is corrected in place — it is what sent a reader hunting for a settings page that was never built.

## Verification

- Local-CI gate **passed** at `5b599038873a`, evidence `cmtk6ae2h8uyk01mxve8gmdk4`
- 116 tests across 10 suites (contributor-change-lanes, release-health), including four new cases: dedicated row preferred over a present fallback, fallback to `hive-contribution`, fallback *past a revoked row* to `git-backup`, and `null` when the store holds nothing usable
- `pnpm --filter web build` exits 0

## Note on what this does not prove

The fallback makes the credential reachable. Whether that particular token is still valid is a separate question the next `record_plan_backlog_coverage` call will answer: success means valid, 401 means the operator should reconnect on the Connect GitHub card. Either way the failure becomes legible instead of surfacing as an unexplained 422.

Docs-Impact-Decision: internal credential resolution order on an existing code path. No route, contract or user-guide surface changes.

Design-Grounding-Decision: no-contract-change (widens an existing resolver's fallback order to credentials the install already stores; no new credential kind, schema or routing change)