### PR TITLE
fix(mcp): the committed-schema reader's own git calls were missing safe.directory (BI-6CFC5429)

### DIFF
--- a/apps/web/lib/mcp/packs/committed-schema-default-branch.test.ts
+++ b/apps/web/lib/mcp/packs/committed-schema-default-branch.test.ts
@@ -112,3 +112,17 @@ describe("committed schema — reads the default branch", () => {
     expect(result!.provenance.branch).toBe("client/5727856b");
   });
 });
+
+// The default git reader is the ONLY path production takes — every other test
+// here injects readGit, which is exactly why the missing safe.directory flag
+// shipped in #4951 and degraded every live call in silence.
+describe("default git reader", () => {
+  it("carries a scoped safe.directory so container ownership cannot block the read", async () => {
+    const { buildCommittedSchemaGitCommand } = await import("./committed-schema-source");
+    const cmd = buildCommittedSchemaGitCommand("/sandbox-workspace", "ls-tree --name-only origin/main");
+    expect(cmd).toContain('-c safe.directory="/sandbox-workspace"');
+    expect(cmd).toContain("ls-tree --name-only origin/main");
+    // The flag must precede the subcommand, or git rejects it.
+    expect(cmd.indexOf("safe.directory")).toBeLessThan(cmd.indexOf("ls-tree"));
+  });
+});

--- a/apps/web/lib/mcp/packs/committed-schema-source.ts
+++ b/apps/web/lib/mcp/packs/committed-schema-source.ts
@@ -77,15 +77,36 @@ export function resolveSourceRoot(): string {
 
 export type GitReader = (root: string, args: string) => Promise<string | null>;
 
-/** Default git reader. Injected in tests (RunDeps idiom) so the unit suite
- *  never shells out — a real `git` call in a unit test is a 10s timeout, not a
- *  test. */
+/**
+ * Default git reader. Injected in tests (RunDeps idiom) so the unit suite never
+ * shells out — a real `git` call in a unit test is a 10s timeout, not a test.
+ *
+ * Carries the scoped `-c safe.directory=<root>` exception, for the same reason
+ * every other git call in the platform does: the portal container runs as a
+ * different uid than the checkout it mounts, so an unprefixed git dies with
+ * "fatal: detected dubious ownership in repository at '/sandbox-workspace'".
+ *
+ * SHIPPED DEFECT (this fix). #4951 made this reader prefer the default branch,
+ * importing resolveDefaultBranchRef — which DOES carry the flag. So the ref
+ * resolved fine, and then `ls-tree` / `show` went through THIS reader, which did
+ * not, failed, and fell back to the working tree on every production call. The
+ * live tool went on answering from whatever branch the sandbox was parked on
+ * (observed: pr-4917-head) while reporting medium trust — correct about the
+ * tree it read, and not the tree anyone asked about.
+ */
+export function buildCommittedSchemaGitCommand(root: string, args: string): string {
+  return `git -c safe.directory=${JSON.stringify(root)} ${args}`;
+}
+
 const defaultReadGit: GitReader = async (root, args) => {
   try {
     const { promisify } = await import("node:util");
     const { exec: nodeExec } = await import("node:child_process");
     const exec = promisify(nodeExec);
-    const { stdout } = await exec(`git ${args}`, { cwd: root, timeout: 10_000 });
+    const { stdout } = await exec(buildCommittedSchemaGitCommand(root, args), {
+      cwd: root,
+      timeout: 10_000,
+    });
     const trimmed = stdout.trim();
     return trimmed.length > 0 ? trimmed : null;
   } catch {
@@ -305,6 +326,17 @@ export async function loadCommittedSchema(
 
   // Fall back to the working tree, and let the existing scoring say so — an
   // off-default or unidentifiable tree is capped and named, never authoritative.
+  //
+  // Say WHY. The scoring already makes an off-default read visible, but "which
+  // branch" is not "why not the merge target": a silent fallback is how #4951
+  // looked deployed-and-working while every call was degrading. The code-graph
+  // reader logs its fallback reason; this one did not, and that asymmetry cost a
+  // full deploy cycle to notice.
+  console.warn(
+    `[committed-schema] Could not read the schema from ${
+      defaultRef ? `the default branch (${defaultRef.ref})` : "any default-branch ref"
+    }; falling back to the working tree at ${root}.`,
+  );
   let names: string[];
   try {
     names = (await readdir(schemaDir)).filter((n) => n.endsWith(".prisma")).sort();


### PR DESCRIPTION
#4951 made `describe_committed_model` prefer the default branch. It shipped, deployed, and **degraded on every single production call**.

Verified live after that deploy:

```
describe_committed_model({ model_name: "MileageRate" })
→ source.branch  "pr-4917-head"    ← the sandbox working tree, never main
→ trust           medium 0.69
```

## Root cause

`resolveDefaultBranchRef` — imported from the code-graph module — carries `-c safe.directory=<root>`, so it resolved `origin/main` correctly. The follow-up `ls-tree` and `show` calls go through **this** module's `defaultReadGit`, which ran a bare `git ${args}`.

In the portal container that dies with `fatal: detected dubious ownership in repository at '/sandbox-workspace'`. `readSchemaAtRef` returned null, and the reader fell back to the working tree — correctly scored and named, and about the wrong tree.

I reused the safe-directory-aware resolver and left this module's own git calls bare.

## Why the tests didn't catch it

Every existing case injects `readGit`, so `defaultReadGit` — **the only path production takes** — was never exercised.

This is the third time this session a suite stayed green against a path the runtime cannot reach: the kernel attenuation lever tested an archetype no page carries, and the provenance scoring tested a git reader that always succeeds where production's always fails.

The command construction now sits behind an exported seam, pinned by a test asserting the flag is present **and** precedes the subcommand.

## Why it was invisible

The fallback was silent. The code-graph reader logs its fallback reason; this one did not, and that asymmetry is why the tool looked deployed-and-working while every call degraded. It now logs which ref it could not read and where it fell back to.

*"Which branch"* is not *"why not the merge target"*.

## Verification

- **17 tests** across 4 committed-schema files, including the new production-path case
- `pnpm --filter web build`: clean
- `pregate:preflight`: 61 guards clean
- exact-tree local CI gate: **PASS** (evidence `cmtk6fjac8z6001mx4r3gfhl8`)

Preflight required `DPF_SKIP_COMPILE_READY_GATE` for **BI-4D0FCF3A** — the pristine root clone reports the same `ignored_builds_unclassified` (puppeteer, unrs-resolver, protobufjs), so it is main-wide and not caused by this diff. Tests and the production build both ran here.

Closes the remaining half of BI-6CFC5429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
