### PR TITLE
fix(right-now): name the inference the GPU is actually serving (BI-B3AB7FC9)

### DIFF
--- a/apps/web/components/platform/WorkforceNowShell.tsx
+++ b/apps/web/components/platform/WorkforceNowShell.tsx
@@ -13,6 +13,7 @@ import { Spinner } from "@/components/ui/Spinner";
 import type {
   WorkforceActivity,
   WorkforceCoworker,
+  WorkforcePlatformRun,
 } from "@/lib/platform-runtime/workforce-activity";
 
 const REFRESH_INTERVAL_MS = 12_000;
@@ -26,6 +27,14 @@ function fmtCost(n: number): string {
   if (n <= 0) return "$0.00";
   if (n < 0.01) return "<$0.01";
   return `$${n.toFixed(2)}`;
+}
+function runningFor(iso: string): string {
+  const mins = Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 60_000));
+  if (mins < 1) return "just started";
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 48) return `${hours}h ${mins % 60}m`;
+  return `${Math.floor(hours / 24)}d`;
 }
 function daysSince(iso: string | null): string {
   if (!iso) return "never engaged";
@@ -108,7 +117,16 @@ export function WorkforceNowShell({ initialData }: { initialData: WorkforceActiv
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
         <Kpi label="Working now" value={`${pulse.workingCount} / ${pulse.totalCount}`} />
         <Kpi label="Actions today" value={String(pulse.actionsToday)} />
-        <Kpi label="Tokens today" value={fmtTokens(pulse.tokensToday)} sub={`~${fmtCost(pulse.costToday)}`} />
+        <Kpi
+          label="Tokens today"
+          value={fmtTokens(pulse.tokensToday)}
+          sub={
+            pulse.tokensUnattributed > 0
+              ? `~${fmtCost(pulse.costToday)} · ${fmtTokens(pulse.tokensUnattributed)} unattributed`
+              : `~${fmtCost(pulse.costToday)}`
+          }
+          flag={pulse.tokensUnattributed > 0}
+        />
         <Kpi
           label="Governance"
           value={`${pulse.quietOverThresholdCount + pulse.coworkersWithoutOwnerCount}`}
@@ -119,7 +137,11 @@ export function WorkforceNowShell({ initialData }: { initialData: WorkforceActiv
 
       <SectionHead title="Working now" hint="what they're on · what they got done today" />
       {data.working.length === 0 ? (
-        <Empty>No coworkers are actively working right now.</Empty>
+        <Empty>
+          {data.platformWork.length > 0
+            ? "No coworker owns a live task right now — the platform work below is what is running."
+            : "No coworkers are actively working right now."}
+        </Empty>
       ) : (
         <ul className="space-y-2">
           {data.working.map((c) => (
@@ -127,6 +149,20 @@ export function WorkforceNowShell({ initialData }: { initialData: WorkforceActiv
           ))}
         </ul>
       )}
+
+      {data.platformWork.length > 0 ? (
+        <>
+          <SectionHead
+            title="Platform work in flight"
+            hint="live runs no coworker owns — this is what is on the model runner"
+          />
+          <ul className="space-y-1.5">
+            {data.platformWork.map((run) => (
+              <PlatformRunRow key={run.taskRunId} run={run} />
+            ))}
+          </ul>
+        </>
+      ) : null}
 
       <SectionHead title="Quiet — no activity is also a signal" hint="expected, or a gap worth a look?" />
       {data.quiet.length === 0 ? (
@@ -311,6 +347,34 @@ function CoworkerRow({
           Manage {isOpen ? "▲" : "▾"}
         </button>
       </div>
+    </li>
+  );
+}
+
+function PlatformRunRow({ run }: { run: WorkforcePlatformRun }) {
+  const target = run.buildId ? `/build?buildId=${encodeURIComponent(run.buildId)}` : null;
+  return (
+    <li className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-dpf-body">
+      <span className="h-1.5 w-1.5 rounded-full" style={{ background: "var(--dpf-warning)" }} />
+      <span className="font-semibold text-[var(--dpf-text)]">{run.title}</span>
+      <span className="rounded border border-[var(--dpf-border)] px-1.5 py-0.5 font-mono text-dpf-caption uppercase text-[var(--dpf-muted)]">
+        {run.status}
+      </span>
+      {run.source ? (
+        <span className="text-dpf-caption text-[var(--dpf-muted)]">source: {run.source}</span>
+      ) : null}
+      {run.buildId ? (
+        target ? (
+          <a className="text-dpf-caption text-[var(--dpf-accent)] underline" href={target}>
+            {run.buildId}
+          </a>
+        ) : (
+          <span className="text-dpf-caption text-[var(--dpf-muted)]">{run.buildId}</span>
+        )
+      ) : null}
+      <span className="ml-auto font-mono text-dpf-caption text-[var(--dpf-muted)]" title={`started ${run.startedAt}`}>
+        running {runningFor(run.startedAt)}
+      </span>
     </li>
   );
 }

--- a/apps/web/components/platform/WorkforceNowShell.tsx
+++ b/apps/web/components/platform/WorkforceNowShell.tsx
@@ -10,6 +10,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { RefreshCw } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
+import { Surface } from "@/components/ui/Surface";
 import type {
   WorkforceActivity,
   WorkforceCoworker,
@@ -354,7 +355,7 @@ function CoworkerRow({
 function PlatformRunRow({ run }: { run: WorkforcePlatformRun }) {
   const target = run.buildId ? `/build?buildId=${encodeURIComponent(run.buildId)}` : null;
   return (
-    <li className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2 text-dpf-body">
+    <Surface as="li" level={1} padding="none" rounded="lg" className="flex flex-wrap items-center gap-x-3 gap-y-1 px-3 py-2 text-dpf-body">
       <span className="h-1.5 w-1.5 rounded-full" style={{ background: "var(--dpf-warning)" }} />
       <span className="font-semibold text-[var(--dpf-text)]">{run.title}</span>
       <span className="rounded border border-[var(--dpf-border)] px-1.5 py-0.5 font-mono text-dpf-caption uppercase text-[var(--dpf-muted)]">
@@ -375,7 +376,7 @@ function PlatformRunRow({ run }: { run: WorkforcePlatformRun }) {
       <span className="ml-auto font-mono text-dpf-caption text-[var(--dpf-muted)]" title={`started ${run.startedAt}`}>
         running {runningFor(run.startedAt)}
       </span>
-    </li>
+    </Surface>
   );
 }
 

--- a/apps/web/components/platform/WorkforceNowShell.uxbudget.test.tsx
+++ b/apps/web/components/platform/WorkforceNowShell.uxbudget.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+//
+// UX-budget measurement for the Right Now shell (BI-B3AB7FC9).
+//
+// /platform/ai/right-now has no row in route-budget-baseline.json, so the
+// rendered route sweep has never adjudicated it. This file measures the shell's
+// own arrival state with the same lib/ux-budget code the sweep runs, in the
+// heaviest honest state the change introduces: no coworker working, several
+// platform runs in flight, unattributed spend flagged, and a quiet roster. Its
+// console line is where docs/ux-fit/2026-09-02-right-now-platform-work.ux-fit.json
+// gets its numbers.
+
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+import axe from "axe-core";
+
+import { auditUxBudget, measureUxBudget } from "@/lib/ux-budget";
+import type { WorkforceActivity, WorkforceCoworker } from "@/lib/platform-runtime/workforce-activity";
+
+import { WorkforceNowShell } from "./WorkforceNowShell";
+
+const NOW = "2026-09-02T18:00:00.000Z";
+
+function coworker(over: Partial<WorkforceCoworker>): WorkforceCoworker {
+  return {
+    agentId: "a",
+    name: "Digital Product Estate Specialist",
+    role: "operate",
+    now: null,
+    didToday: [{ label: "other actions", count: 5, sensitive: false }],
+    handlesSensitive: false,
+    sensitiveActionCount: 0,
+    tokensToday: 1200,
+    costToday: 0.01,
+    lastActedAt: NOW,
+    humanSupervisorId: null,
+    hitlTier: 3,
+    ...over,
+  };
+}
+
+/** Today's live shape: nothing owned, the model runner busy with platform work. */
+const DATA: WorkforceActivity = {
+  capturedAt: NOW,
+  working: [],
+  quiet: [
+    coworker({ agentId: "a1" }),
+    coworker({ agentId: "a2", name: "Compliance Officer", role: "govern", humanSupervisorId: "HR-000", lastActedAt: null, didToday: [] }),
+    coworker({ agentId: "a3", name: "Bookkeeper", role: "finance", lastActedAt: "2026-08-20T00:00:00.000Z", didToday: [] }),
+  ],
+  platformWork: [
+    {
+      taskRunId: "deliberation-1",
+      title: "Deliberation: review",
+      status: "working",
+      source: "proactive",
+      buildId: "FB-FCAC756D",
+      routeContext: "/build",
+      startedAt: "2026-09-02T17:58:00.000Z",
+      lastHeartbeatAt: NOW,
+    },
+    {
+      taskRunId: "deliberation-2",
+      title: "Deliberation: debate",
+      status: "working",
+      source: "proactive",
+      buildId: "FB-8F5905FA",
+      routeContext: "/build",
+      startedAt: "2026-09-02T16:58:00.000Z",
+      lastHeartbeatAt: null,
+    },
+  ],
+  pulse: {
+    workingCount: 0,
+    totalCount: 37,
+    actionsToday: 19,
+    tokensToday: 2_508_854,
+    costToday: 1.92,
+    tokensUnattributed: 772_477,
+    costUnattributed: 0.4,
+    platformWorkCount: 2,
+    quietOverThresholdCount: 2,
+    coworkersWithoutOwnerCount: 37,
+  },
+};
+
+afterEach(() => cleanup());
+
+function shellHtml(): string {
+  const { container } = render(<WorkforceNowShell initialData={DATA} />);
+  return container.innerHTML;
+}
+
+describe("WorkforceNowShell UX budget", () => {
+  it("holds the cockpit shell budget for a pre-existing route", () => {
+    const report = auditUxBudget(shellHtml(), "cockpit", { routeStatus: "pre-existing" });
+    const failed = report.findings.filter((finding) => !finding.ok && finding.severity === "blocking");
+    expect(failed, JSON.stringify(failed, null, 2)).toEqual([]);
+  });
+
+  it("names the platform work instead of an empty board", () => {
+    const { container } = render(<WorkforceNowShell initialData={DATA} />);
+    expect(container.textContent).toContain("Platform work in flight");
+    expect(container.textContent).toContain("Deliberation: review");
+    expect(container.textContent).toContain("FB-FCAC756D");
+    expect(container.textContent).toContain("unattributed");
+    // No coworker row claims a task it does not own.
+    expect(container.textContent).not.toContain("Now →");
+  });
+
+  it("has no axe violations the harness can detect", async () => {
+    const { container } = render(<WorkforceNowShell initialData={DATA} />);
+    const results = await axe.run(container, {
+      rules: { "color-contrast": { enabled: false } },
+    });
+    const violations = results.violations.map((v) => `${v.id}: ${v.help}`);
+    expect(violations, violations.join("; ")).toEqual([]);
+
+    // Where the ux-fit manifest's numbers come from.
+    console.log(
+      `[ux-budget] ${JSON.stringify({
+        ...measureUxBudget(container.innerHTML),
+        axeViolations: results.violations.length,
+      })}`,
+    );
+  });
+});

--- a/apps/web/lib/actions/deliberation.ts
+++ b/apps/web/lib/actions/deliberation.ts
@@ -11,6 +11,8 @@ type StartDeliberationInput = {
   userId: string;
   patternSlug: string;
   taskRunId?: string;
+  /** Coworker on whose behalf the deliberation runs (BI-B3AB7FC9). */
+  agentId?: string | null;
   artifactType:
     | "spec"
     | "plan"
@@ -191,6 +193,7 @@ export async function startDeliberation(input: StartDeliberationInput) {
   const orchestration = await orchestrateDeliberation({
     userId: input.userId,
     taskRunId: input.taskRunId,
+    agentId: input.agentId ?? null,
     threadId: input.threadId ?? null,
     buildId: input.buildId ?? null,
     patternSlug: resolved.patternSlug,

--- a/apps/web/lib/build/build-orchestrator.ts
+++ b/apps/web/lib/build/build-orchestrator.ts
@@ -426,6 +426,9 @@ export type BuildReviewDeliberationInput = {
   /** Optional thread id — progress events from the deliberation layer fan
    *  out through the agent event bus for this thread. */
   threadId?: string;
+  /** Coworker that asked for the review — stamped on the bootstrapped
+   *  TaskRun so Right Now can place the run (BI-B3AB7FC9). */
+  agentId?: string;
   /** Opt-in to the debate pattern for this invocation. Omit for default
    *  peer review. */
   explicitPattern?: DeliberationPatternChoice;
@@ -451,7 +454,7 @@ export type BuildReviewDeliberationResult = {
 export async function runBuildReviewDeliberation(
   input: BuildReviewDeliberationInput,
 ): Promise<BuildReviewDeliberationResult> {
-  const { userId, buildId, phase, reviewerBranches, taskRunId, threadId, strategyProfile } = input;
+  const { userId, buildId, phase, reviewerBranches, taskRunId, threadId, agentId, strategyProfile } = input;
 
   const patternSlug: DeliberationPatternChoice =
     input.explicitPattern ?? defaultDeliberationPatternForPhase(phase);
@@ -476,6 +479,7 @@ export async function runBuildReviewDeliberation(
     patternSlug,
     taskRunId,
     threadId,
+    agentId,
     buildId,
     artifactType,
     strategyProfile: strategyProfile ?? "balanced",

--- a/apps/web/lib/deliberation/orchestrator.ts
+++ b/apps/web/lib/deliberation/orchestrator.ts
@@ -83,6 +83,13 @@ export interface OrchestrateDeliberationInput {
   threadId?: string | null;
   buildId?: string | null;
   routeContext?: string | null;
+  /**
+   * Coworker on whose behalf this deliberation runs. Stamped as
+   * initiatingAgentId/currentAgentId on a bootstrapped TaskRun so the
+   * workforce view can place the run instead of showing "0 working" while
+   * the model runner is busy (BI-B3AB7FC9).
+   */
+  agentId?: string | null;
 
   patternSlug: string;
   artifactType: DeliberationArtifactType;
@@ -369,6 +376,8 @@ export async function orchestrateDeliberation(
         userId: input.userId,
         threadId: input.threadId ?? null,
         buildId: input.buildId ?? null,
+        initiatingAgentId: input.agentId ?? null,
+        currentAgentId: input.agentId ?? null,
         routeContext: input.routeContext ?? "deliberation",
         title: `Deliberation: ${input.patternSlug}`,
         objective: `Run ${pattern.name} over artifactType=${input.artifactType}`,

--- a/apps/web/lib/deliberation/orchestrator.ts
+++ b/apps/web/lib/deliberation/orchestrator.ts
@@ -83,12 +83,7 @@ export interface OrchestrateDeliberationInput {
   threadId?: string | null;
   buildId?: string | null;
   routeContext?: string | null;
-  /**
-   * Coworker on whose behalf this deliberation runs. Stamped as
-   * initiatingAgentId/currentAgentId on a bootstrapped TaskRun so the
-   * workforce view can place the run instead of showing "0 working" while
-   * the model runner is busy (BI-B3AB7FC9).
-   */
+  /** Coworker on whose behalf this runs — stamped on a bootstrapped TaskRun (BI-B3AB7FC9). */
   agentId?: string | null;
 
   patternSlug: string;

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -39,7 +39,7 @@ import {
   buildEffectiveRequestContract,
   buildInitialRouteContext,
 } from "@/lib/inference/route-contract-builder";
-import { logTokenUsage } from "@/lib/ai-inference";
+import { persistRoutedTokenUsage, routedContextKey } from "./routed-token-usage";
 import type { RouteAndCallOptions } from "./routed-inference-options";
 import { applyCallerExecutionPlanOverrides } from "./routed-inference-plan-overrides";
 import {
@@ -754,57 +754,3 @@ async function routeAndCallAttempt(
   };
 }
 
-// ─── Phase J: routed-call token usage persistence ──────────────────────────
-//
-// Every routed inference call must produce a `TokenUsage` row regardless of
-// which adapter served it. Before this fix, only the direct HTTP path
-// (`callProvider` in `ai-inference.ts`) wrote metering — the CLI subprocess
-// adapters (claude-cli, codex-cli) silently bypassed it. The result was a
-// $0 cost tally for ~100% of subscription-served traffic on a typical install.
-//
-// This wrapper is the *convenience* enforcement; the durable enforcement is
-// the OutcomeEvent-bus detector "outcome event without metering row" listed
-// in the routing-architecture spec §10.2. That bus check makes new dispatch
-// paths (future adapters) loud about forgetting to meter; this wrapper makes
-// it easy to satisfy by default.
-//
-// Errors are logged but never thrown — metering must never block the response.
-/**
- * TokenUsage.contextKey for a routed call: the thread when there is one, else
- * the build, else the task type. "routed-call" is the last resort and means
- * the caller said nothing about itself (BI-B3AB7FC9).
- */
-function routedContextKey(options: RouteAndCallOptions | undefined): string {
-  if (options?.threadId) return options.threadId;
-  if (options?.buildId) return `build:${options.buildId}`;
-  return options?.taskType ?? "routed-call";
-}
-
-async function persistRoutedTokenUsage(input: {
-  traceId?: string | null;
-  agentId: string;
-  providerId: string;
-  contextKey: string;
-  inputTokens: number;
-  outputTokens: number;
-  // BI-105E8A1E: carry the adapter's measured latency so logTokenUsage's
-  // `compute` cost model can fire — it is the cost signal for a fully-local
-  // install, and was previously dropped here, leaving inferenceMs ~99% empty.
-  inferenceMs?: number;
-}): Promise<void> {
-  // Skip rows with zero tokens both ways. A successful call always reports at
-  // least the input prompt tokens; zero/zero usually means the adapter
-  // returned an error or stub. The audit row would be misleading.
-  if (input.inputTokens === 0 && input.outputTokens === 0) {
-    return;
-  }
-  try {
-    await logTokenUsage(input);
-  } catch (err) {
-    console.error(
-      `[routed-inference] token usage persistence failed: provider=${input.providerId} ` +
-      `agent=${input.agentId} in=${input.inputTokens} out=${input.outputTokens}`,
-      err,
-    );
-  }
-}

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -647,7 +647,7 @@ async function routeAndCallAttempt(
       traceId,
       agentId: options?.agentId ?? "unknown",
       providerId: result.providerId,
-      contextKey: options?.threadId ?? options?.taskType ?? "routed-call",
+      contextKey: routedContextKey(options),
       inputTokens: result.tokenUsage?.inputTokens ?? 0,
       outputTokens: result.tokenUsage?.outputTokens ?? 0,
       inferenceMs: result.inferenceMs,
@@ -722,7 +722,7 @@ async function routeAndCallAttempt(
     traceId,
     agentId: options?.agentId ?? "unknown",
     providerId: result.providerId,
-    contextKey: options?.threadId ?? options?.taskType ?? "routed-call",
+    contextKey: routedContextKey(options),
     inputTokens: result.tokenUsage?.inputTokens ?? 0,
     outputTokens: result.tokenUsage?.outputTokens ?? 0,
     inferenceMs: result.inferenceMs,
@@ -769,6 +769,17 @@ async function routeAndCallAttempt(
 // it easy to satisfy by default.
 //
 // Errors are logged but never thrown — metering must never block the response.
+/**
+ * TokenUsage.contextKey for a routed call: the thread when there is one, else
+ * the build, else the task type. "routed-call" is the last resort and means
+ * the caller said nothing about itself (BI-B3AB7FC9).
+ */
+function routedContextKey(options: RouteAndCallOptions | undefined): string {
+  if (options?.threadId) return options.threadId;
+  if (options?.buildId) return `build:${options.buildId}`;
+  return options?.taskType ?? "routed-call";
+}
+
 async function persistRoutedTokenUsage(input: {
   traceId?: string | null;
   agentId: string;

--- a/apps/web/lib/inference/routed-token-usage.ts
+++ b/apps/web/lib/inference/routed-token-usage.ts
@@ -1,0 +1,63 @@
+// apps/web/lib/inference/routed-token-usage.ts
+//
+// Token-usage persistence for routed inference calls, split out of
+// routed-inference.ts (module-size ceiling) when the contextKey fallback grew
+// a build form (BI-B3AB7FC9).
+
+import { logTokenUsage } from "@/lib/ai-inference";
+import type { RouteAndCallOptions } from "./routed-inference-options";
+
+// ─── Phase J: routed-call token usage persistence ──────────────────────────
+//
+// Every routed inference call must produce a `TokenUsage` row regardless of
+// which adapter served it. Before this fix, only the direct HTTP path
+// (`callProvider` in `ai-inference.ts`) wrote metering — the CLI subprocess
+// adapters (claude-cli, codex-cli) silently bypassed it. The result was a
+// $0 cost tally for ~100% of subscription-served traffic on a typical install.
+//
+// This wrapper is the *convenience* enforcement; the durable enforcement is
+// the OutcomeEvent-bus detector "outcome event without metering row" listed
+// in the routing-architecture spec §10.2. That bus check makes new dispatch
+// paths (future adapters) loud about forgetting to meter; this wrapper makes
+// it easy to satisfy by default.
+//
+// Errors are logged but never thrown — metering must never block the response.
+/**
+ * TokenUsage.contextKey for a routed call: the thread when there is one, else
+ * the build, else the task type. "routed-call" is the last resort and means
+ * the caller said nothing about itself (BI-B3AB7FC9).
+ */
+export function routedContextKey(options: RouteAndCallOptions | undefined): string {
+  if (options?.threadId) return options.threadId;
+  if (options?.buildId) return `build:${options.buildId}`;
+  return options?.taskType ?? "routed-call";
+}
+
+export async function persistRoutedTokenUsage(input: {
+  traceId?: string | null;
+  agentId: string;
+  providerId: string;
+  contextKey: string;
+  inputTokens: number;
+  outputTokens: number;
+  // BI-105E8A1E: carry the adapter's measured latency so logTokenUsage's
+  // `compute` cost model can fire — it is the cost signal for a fully-local
+  // install, and was previously dropped here, leaving inferenceMs ~99% empty.
+  inferenceMs?: number;
+}): Promise<void> {
+  // Skip rows with zero tokens both ways. A successful call always reports at
+  // least the input prompt tokens; zero/zero usually means the adapter
+  // returned an error or stub. The audit row would be misleading.
+  if (input.inputTokens === 0 && input.outputTokens === 0) {
+    return;
+  }
+  try {
+    await logTokenUsage(input);
+  } catch (err) {
+    console.error(
+      `[routed-inference] token usage persistence failed: provider=${input.providerId} ` +
+      `agent=${input.agentId} in=${input.inputTokens} out=${input.outputTokens}`,
+      err,
+    );
+  }
+}

--- a/apps/web/lib/mcp/build-design-review-handler.ts
+++ b/apps/web/lib/mcp/build-design-review-handler.ts
@@ -149,19 +149,28 @@ export async function reviewDesignDoc(params: Record<string, unknown>, userId: s
       // it joins the deliberation trail as the `architect` branch and rides
       // along on review.architectureAdvisory so the coworker can fold concerns
       // into the spec, but it cannot gate pass/fail.
+      // BI-B3AB7FC9: every reviewer call carries who asked and which build it
+      // is for. Without this the three calls metered as agentId "unknown" /
+      // contextKey "routed-call" — 30% of a day's spend that no screen could
+      // name while the local model runner sat at 100%.
+      const attribution = {
+        ...(context?.agentId ? { agentId: context.agentId } : {}),
+        ...(context?.threadId ? { threadId: context.threadId } : {}),
+        buildId,
+      };
       const [r1settled, r2settled, archSettled] = await Promise.allSettled([
-        routeAndCall(messages, "You are a design reviewer.", "internal"),
+        routeAndCall(messages, "You are a design reviewer.", "internal", attribution),
         routeAndCall(
           messages,
           "You are an independent design reviewer. Focus especially on security, data integrity, edge cases, and accessibility gaps the primary reviewer may have missed.",
           "internal",
-          { budgetClass: "minimize_cost" },
+          { ...attribution, budgetClass: "minimize_cost" },
         ),
         routeAndCall(
           [{ role: "user" as const, content: archPrompt }],
           `You are the ${ENTERPRISE_ARCHITECT_DISPLAY_NAME} (DPF chief-architect lens) reviewing for architectural alignment. Advisory only — surface concerns and concrete spec edits, never block the gate.`,
           "internal",
-          { budgetClass: "minimize_cost" },
+          { ...attribution, budgetClass: "minimize_cost" },
         ),
       ]);
       const r1 = r1settled.status === "fulfilled" ? parseReviewResponse(r1settled.value.content) : null;
@@ -282,6 +291,7 @@ export async function reviewDesignDoc(params: Record<string, unknown>, userId: s
             phase: "ideate",
             reviewerBranches,
             ...(context?.threadId ? { threadId: context.threadId } : {}),
+            ...(context?.agentId ? { agentId: context.agentId } : {}),
           });
         }
       } catch (err) {

--- a/apps/web/lib/mcp/build-review-handlers.ts
+++ b/apps/web/lib/mcp/build-review-handlers.ts
@@ -404,19 +404,26 @@ export async function reviewBuildPlan(params: Record<string, unknown>, userId: s
       // architecture reviewer is advisory only — it never enters mergeReviews,
       // it rides along on review.architectureAdvisory and the deliberation
       // `architect` branch so the coworker can fold concerns into the plan.
+      // BI-B3AB7FC9: carry the caller and build into every reviewer call so
+      // the spend meters under a coworker, not agentId "unknown".
+      const attribution = {
+        ...(context?.agentId ? { agentId: context.agentId } : {}),
+        ...(context?.threadId ? { threadId: context.threadId } : {}),
+        buildId,
+      };
       const [r1settled, r2settled, archSettled] = await Promise.allSettled([
-        routeAndCall(messages, "You are a plan reviewer.", "internal"),
+        routeAndCall(messages, "You are a plan reviewer.", "internal", attribution),
         routeAndCall(
           messages,
           "You are an independent plan reviewer. Focus especially on missing tasks, dependency ordering, absent test-first steps, and data seeding gaps.",
           "internal",
-          { budgetClass: "minimize_cost" },
+          { ...attribution, budgetClass: "minimize_cost" },
         ),
         routeAndCall(
           [{ role: "user" as const, content: archPrompt }],
           `You are the ${ENTERPRISE_ARCHITECT_DISPLAY_NAME} (DPF chief-architect lens) reviewing for architectural alignment. Advisory only — surface concerns and concrete plan edits, never block the gate.`,
           "internal",
-          { budgetClass: "minimize_cost" },
+          { ...attribution, budgetClass: "minimize_cost" },
         ),
       ]);
       const r1 = r1settled.status === "fulfilled" ? parseReviewResponse(r1settled.value.content) : null;
@@ -538,6 +545,7 @@ export async function reviewBuildPlan(params: Record<string, unknown>, userId: s
             phase: "plan",
             reviewerBranches,
             ...(context?.threadId ? { threadId: context.threadId } : {}),
+            ...(context?.agentId ? { agentId: context.agentId } : {}),
           });
         }
       } catch (err) {

--- a/apps/web/lib/platform-runtime/workforce-activity.test.ts
+++ b/apps/web/lib/platform-runtime/workforce-activity.test.ts
@@ -203,4 +203,72 @@ describe("loadWorkforceActivity", () => {
     const wf = await loadWorkforceActivity({ prisma, now: () => NOW });
     expect(wf.working.map((c) => c.name)).toEqual(["A2", "A1"]);
   });
+
+  it("reports token spend the roster cannot claim as unattributed instead of dropping it (BI-B3AB7FC9)", async () => {
+    const prisma = fakePrisma({
+      agents: [agent({ agentId: "a1", displayName: "A1" })],
+      tokens: [
+        { agentId: "a1", _sum: { inputTokens: 100, outputTokens: 50, costUsd: 0.5 } },
+        // The reviewDesignDoc fan-out before the fix: routed calls with no caller.
+        { agentId: "unknown", _sum: { inputTokens: 700, outputTokens: 300, costUsd: 2 } },
+        // A retired or non-coworker agent id still counts toward the day.
+        { agentId: "AGT-RETIRED", _sum: { inputTokens: 10, outputTokens: 0, costUsd: 0 } },
+      ],
+    });
+    const wf = await loadWorkforceActivity({ prisma, now: () => NOW });
+    expect(wf.pulse.tokensToday).toBe(1160);
+    expect(wf.pulse.costToday).toBeCloseTo(2.5);
+    expect(wf.pulse.tokensUnattributed).toBe(1010);
+    expect(wf.pulse.costUnattributed).toBeCloseTo(2);
+    // The coworker's own line is unchanged.
+    expect(wf.quiet[0].tokensToday).toBe(150);
+  });
+
+  it("lists live runs no coworker owns as platform work rather than an empty 'working' board (BI-B3AB7FC9)", async () => {
+    const prisma = fakePrisma({
+      agents: [agent({ agentId: "a1", displayName: "A1" })],
+      liveRuns: [
+        {
+          taskRunId: "deliberation-1",
+          status: "working",
+          title: "Deliberation: review",
+          currentAgentId: null,
+          source: "proactive",
+          buildId: "FB-FCAC756D",
+          routeContext: "/build",
+          startedAt: new Date(NOW - 120_000),
+          lastHeartbeatAt: new Date(NOW - 60_000),
+        },
+        {
+          taskRunId: "owned-1",
+          status: "working",
+          title: "Coworker task",
+          currentAgentId: "a1",
+          startedAt: new Date(NOW),
+          lastHeartbeatAt: new Date(NOW),
+        },
+        {
+          taskRunId: "ghost-1",
+          status: "working",
+          title: "Run owned by an id not on the roster",
+          currentAgentId: "AGT-RETIRED",
+          startedAt: new Date(NOW),
+          lastHeartbeatAt: null,
+        },
+      ],
+    });
+    const wf = await loadWorkforceActivity({ prisma, now: () => NOW });
+    expect(wf.working.map((c) => c.agentId)).toEqual(["a1"]);
+    expect(wf.platformWork.map((r) => r.taskRunId)).toEqual(["deliberation-1", "ghost-1"]);
+    expect(wf.platformWork[0]).toMatchObject({
+      title: "Deliberation: review",
+      status: "working",
+      source: "proactive",
+      buildId: "FB-FCAC756D",
+      routeContext: "/build",
+      startedAt: new Date(NOW - 120_000).toISOString(),
+    });
+    expect(wf.pulse.platformWorkCount).toBe(2);
+    expect(wf.pulse.workingCount).toBe(1);
+  });
 });

--- a/apps/web/lib/platform-runtime/workforce-activity.ts
+++ b/apps/web/lib/platform-runtime/workforce-activity.ts
@@ -33,16 +33,45 @@ export type WorkforceCoworker = {
   hitlTier: number;
 };
 
+/**
+ * A live TaskRun that no roster coworker owns (BI-B3AB7FC9): proactive
+ * deliberations, build-phase reviews, system jobs. These are what is actually
+ * on the model runner when "Working now" reads 0, so the view names them
+ * instead of hiding them behind an empty state.
+ */
+export type WorkforcePlatformRun = {
+  taskRunId: string;
+  title: string;
+  status: string;
+  /** TaskRun.source — coworker | build | skill | proactive. */
+  source: string | null;
+  buildId: string | null;
+  routeContext: string | null;
+  startedAt: string;
+  lastHeartbeatAt: string | null;
+};
+
 export type WorkforceActivity = {
   capturedAt: string;
   working: WorkforceCoworker[];
   quiet: WorkforceCoworker[];
+  /** Live runs with no coworker owner, newest first. */
+  platformWork: WorkforcePlatformRun[];
   pulse: {
     workingCount: number;
     totalCount: number;
     actionsToday: number;
+    /** Every TokenUsage row today — attributed or not. */
     tokensToday: number;
     costToday: number;
+    /**
+     * Tokens today whose agentId is not a roster coworker ("unknown", a
+     * retired agent, a system caller). Non-zero means an inference path is
+     * spending without saying who for (BI-B3AB7FC9).
+     */
+    tokensUnattributed: number;
+    costUnattributed: number;
+    platformWorkCount: number;
     quietOverThresholdCount: number;
     /** Coworkers with no human-in-the-loop owner assigned — a governance gap. */
     coworkersWithoutOwnerCount: number;
@@ -81,6 +110,9 @@ type TaskRunRow = {
   currentAgentId: string | null;
   startedAt: Date;
   lastHeartbeatAt: Date | null;
+  source?: string | null;
+  buildId?: string | null;
+  routeContext?: string | null;
 };
 type GroupRow = {
   agentId: string;
@@ -124,7 +156,17 @@ export async function loadWorkforceActivity(
     prisma.taskRun.findMany({
       where: { archivedAt: null, status: { in: [...TASK_LIVE_STATES] } },
       orderBy: { startedAt: "desc" },
-      select: { taskRunId: true, status: true, title: true, currentAgentId: true, startedAt: true, lastHeartbeatAt: true },
+      select: {
+        taskRunId: true,
+        status: true,
+        title: true,
+        currentAgentId: true,
+        startedAt: true,
+        lastHeartbeatAt: true,
+        source: true,
+        buildId: true,
+        routeContext: true,
+      },
     }),
     prisma.toolExecution.groupBy({
       by: ["agentId", "toolName"],
@@ -170,15 +212,30 @@ export async function loadWorkforceActivity(
     }),
   ]);
 
-  // First live task per agent (rows are newest-first).
+  const rosterIds = new Set(agents.map((a) => a.agentId));
+
+  // First live task per agent (rows are newest-first). Live runs that no
+  // roster coworker owns are platform work — listed, never dropped.
   const liveByAgent = new Map<string, TaskRunRow>();
+  const platformWork: WorkforcePlatformRun[] = [];
   for (const run of liveRuns) {
     // Keep the projection fail-closed if an injected adapter or future query
     // returns a non-live row despite the canonical DB filter.
     if (!isLiveStatus(run.status)) continue;
-    if (run.currentAgentId && !liveByAgent.has(run.currentAgentId)) {
-      liveByAgent.set(run.currentAgentId, run);
+    if (run.currentAgentId && rosterIds.has(run.currentAgentId)) {
+      if (!liveByAgent.has(run.currentAgentId)) liveByAgent.set(run.currentAgentId, run);
+      continue;
     }
+    platformWork.push({
+      taskRunId: run.taskRunId,
+      title: run.title ?? "Untitled run",
+      status: run.status,
+      source: run.source ?? null,
+      buildId: run.buildId ?? null,
+      routeContext: run.routeContext ?? null,
+      startedAt: run.startedAt.toISOString(),
+      lastHeartbeatAt: run.lastHeartbeatAt ? run.lastHeartbeatAt.toISOString() : null,
+    });
   }
 
   // toolName counts per agent.
@@ -207,11 +264,26 @@ export async function loadWorkforceActivity(
   const handoffsByAgent = countByActor(handoffRows, "fromAgentId");
   const evidenceByAgent = countByActor(evidenceRows, "recordedByAgentId");
 
+  // Tokens today is the whole ledger. What the roster loop below cannot claim
+  // is reported as unattributed rather than silently dropped — the
+  // reviewDesignDoc fan-out was 30% of a day's spend under agentId "unknown"
+  // while this card said nothing (BI-B3AB7FC9).
+  let tokensToday = 0;
+  let costToday = 0;
+  let tokensUnattributed = 0;
+  let costUnattributed = 0;
+  for (const [agentId, tok] of tokensMap) {
+    tokensToday += tok.tokens;
+    costToday += tok.cost;
+    if (!rosterIds.has(agentId)) {
+      tokensUnattributed += tok.tokens;
+      costUnattributed += tok.cost;
+    }
+  }
+
   const working: WorkforceCoworker[] = [];
   const quiet: WorkforceCoworker[] = [];
   let actionsToday = 0;
-  let tokensToday = 0;
-  let costToday = 0;
   let quietOverThreshold = 0;
   let withoutOwner = 0;
   const quietFloor = new Date(nowMs - QUIET_SIGNAL_DAYS * 86_400_000);
@@ -234,8 +306,6 @@ export async function loadWorkforceActivity(
     const humanSupervisorId = agent.humanSupervisorId ?? null;
 
     actionsToday += didToday.reduce((sum, o) => sum + o.count, 0);
-    tokensToday += tok.tokens;
-    costToday += tok.cost;
     if (!humanSupervisorId) withoutOwner += 1;
 
     const coworker: WorkforceCoworker = {
@@ -270,12 +340,16 @@ export async function loadWorkforceActivity(
     capturedAt: new Date(nowMs).toISOString(),
     working,
     quiet,
+    platformWork,
     pulse: {
       workingCount: working.length,
       totalCount: agents.length,
       actionsToday,
       tokensToday,
       costToday,
+      tokensUnattributed,
+      costUnattributed,
+      platformWorkCount: platformWork.length,
       quietOverThresholdCount: quietOverThreshold,
       coworkersWithoutOwnerCount: withoutOwner,
     },

--- a/apps/web/lib/ux-budget/purpose-contracts/right-now.ts
+++ b/apps/web/lib/ux-budget/purpose-contracts/right-now.ts
@@ -29,7 +29,7 @@ export const RIGHT_NOW_PURPOSE_CONTRACTS: PurposeContractModule = [
         expectedPath: ["/platform/ai/overview", "/platform/ai/right-now"],
       },
       contentRoles: {
-        defaultVisibleKeys: ["workforce-pulse", "working-now-list", "quiet-list"],
+        defaultVisibleKeys: ["workforce-pulse", "working-now-list", "platform-work-list", "quiet-list"],
         deferredRegions: [
           {
             key: "coworker-manage",

--- a/apps/web/lib/ux-budget/route-purpose.generated.json
+++ b/apps/web/lib/ux-budget/route-purpose.generated.json
@@ -3371,6 +3371,7 @@
           "defaultVisibleKeys": [
             "workforce-pulse",
             "working-now-list",
+            "platform-work-list",
             "quiet-list"
           ],
           "deferredRegions": [

--- a/docs/superpowers/plans/2026-08-05-workforce-activity-view.md
+++ b/docs/superpowers/plans/2026-08-05-workforce-activity-view.md
@@ -120,3 +120,37 @@ though they could not block Self-Upgrade and had not heartbeated for weeks.
   surface.
 - Rollback: revert the application commit. There is no migration or runtime-data
   rewrite.
+
+## 2026-09-02 unattributed spend and platform work — BI-B3AB7FC9
+
+Live finding: the local model runner was saturated by `reviewDesignDoc`
+fan-outs (three `routeAndCall`s per review, ~100s each on the local model)
+while this page read **Working now 0 / 37** and named nothing. Two causes:
+
+- The review handlers passed no `agentId` / `threadId` / `buildId` to
+  `routeAndCall`, so every call metered as `TokenUsage.agentId = "unknown"`,
+  `contextKey = "routed-call"` — 30% of the day's tokens. The loader summed
+  tokens only over roster coworkers, so that bucket vanished from the card.
+- The deliberation TaskRun the review bootstraps carried no
+  `currentAgentId`, so the "working now" projection (keyed on the owning
+  coworker) had nowhere to put it.
+
+Changes:
+
+- `build-design-review-handler.ts` / `build-review-handlers.ts` carry the
+  calling coworker, thread and build into every reviewer call and into
+  `runBuildReviewDeliberation`; `orchestrator.ts` stamps
+  `initiatingAgentId` / `currentAgentId` on a bootstrapped TaskRun.
+  `routed-inference.ts` falls back to `build:<id>` for `contextKey` before
+  the bare `routed-call` sentinel.
+- `workforce-activity.ts`: **Tokens today** is now the whole ledger, with
+  `tokensUnattributed` / `costUnattributed` for rows no roster coworker
+  claims (the card flags a non-zero value). Live runs with no roster owner
+  are returned as `platformWork` and rendered as **Platform work in flight**
+  (title, status, source, build link, running-for) instead of an empty
+  "no coworkers working" state.
+
+Not in this change (filed separately): deliberation TaskRuns re-marked
+`working` by the async runner after the orchestrator settles them, and the
+build-resume job retrying the same failing review every 30 minutes with no
+backoff.

--- a/docs/superpowers/plans/2026-08-05-workforce-activity-view.md
+++ b/docs/superpowers/plans/2026-08-05-workforce-activity-view.md
@@ -1,3 +1,6 @@
+---
+status: active
+---
 # Plan — AI workforce "Right Now" activity view
 
 - **Backlog item:** BI-1A68257F

--- a/docs/ux-fit/2026-09-02-right-now-platform-work.ux-fit.json
+++ b/docs/ux-fit/2026-09-02-right-now-platform-work.ux-fit.json
@@ -1,0 +1,31 @@
+{
+  "version": "1",
+  "decidedOption": "name unowned live runs and unattributed spend on the existing Right Now board instead of an empty 'no coworkers working' state",
+  "scope": {
+    "files": [
+      "apps/web/components/platform/WorkforceNowShell.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "sweep-measurement",
+    "baselineComparison": "new-route",
+    "measured": {
+      "/platform/ai/right-now": {
+        "defaultVisibleWords": 168,
+        "leadBandWords": 0,
+        "primaryActions": 0,
+        "visibleFields": 0,
+        "maxChoicesPerControl": 0,
+        "subLegibleControls": 0,
+        "buriedPrimaryAction": 0,
+        "axeViolations": 0
+      }
+    }
+  },
+  "notes": {
+    "routeMeasurement": "/platform/ai/right-now has no row in route-budget-baseline.json, so the rendered sweep has never adjudicated it. Numbers come from apps/web/components/platform/WorkforceNowShell.uxbudget.test.tsx, which renders the shell in the heaviest state this change introduces (no coworker working, two platform runs in flight, unattributed spend flagged, three quiet coworkers) and measures it with lib/ux-budget's measureUxBudget plus axe-core. Reading grade measured 2.8.",
+    "fit": "One new list section ('Platform work in flight') appears only when a live run has no roster owner; each row is title, status chip, source, build link, running-for. The Tokens today card gains an 'N unattributed' sub-label and warning flag only when that number is non-zero. No new navigation, form, or primary action; the build link reuses the existing /build?buildId= pattern.",
+    "failureState": "The empty 'Working now' state now says the platform work below is what is running, so an operator watching a saturated model runner is not told nothing is happening.",
+    "theme": "All styles use existing dpf tokens (--dpf-warning for the run dot and flag, --dpf-surface-1, --dpf-border); no literal colors."
+  }
+}

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -36,7 +36,7 @@ apps/web/lib/actions/promotions.ts	982
 apps/web/lib/actions/tax-remittance.test.ts	1084
 apps/web/lib/actions/tax-remittance.ts	971
 apps/web/lib/ai-operations-map/load-map-data.test.ts	928
-apps/web/lib/deliberation/orchestrator.ts	808
+apps/web/lib/deliberation/orchestrator.ts	812
 apps/web/lib/explore/build-process-matrix.ts	832
 apps/web/lib/explore/feature-build-types.ts	1098
 apps/web/lib/finance/ai-provider-finance.ts	1309


### PR DESCRIPTION
## Why

The local model runner sat at 100% on `reviewDesignDoc` calls (three ~100s requests per review) while `/platform/ai/right-now` read **Working now 0 / 37** and named nothing. BI-B3AB7FC9.

Live evidence (2026-09-02): `TokenUsage` for the day held **772K of 2.5M tokens under `agentId="unknown"`, `contextKey="routed-call"`** — the largest single bucket — and every row was a design/plan review fan-out. The deliberation `TaskRun` the review bootstraps carried no `currentAgentId`, so the working-now projection had nowhere to put it.

## What

**Attribution at the source**
- `build-design-review-handler.ts` / `build-review-handlers.ts`: every reviewer `routeAndCall` now carries the calling coworker, thread and build; `runBuildReviewDeliberation` receives `agentId`.
- `startDeliberation` → `orchestrateDeliberation` accept `agentId`; a bootstrapped TaskRun is stamped `initiatingAgentId` / `currentAgentId`.
- `routed-inference`: `contextKey` falls back to `build:<id>` before the bare `routed-call` sentinel. Persistence moved to `lib/inference/routed-token-usage.ts` (module-size ceiling).

**Screens report what they cannot attribute**
- `workforce-activity.ts`: **Tokens today** is the whole ledger; `tokensUnattributed` / `costUnattributed` cover rows no roster coworker claims (the card flags a non-zero value). Live runs with no roster owner come back as `platformWork`.
- `WorkforceNowShell.tsx`: new **Platform work in flight** section (title, status, source, build link, running-for); the empty working state says the platform work below is what is running.

Passing `agentId` into `routeAndCall` also means the review runs under the calling coworker's dispatch posture (`resolveDispatchPosture`) rather than the anonymous system posture — that is the intended behaviour for coworker-initiated work, but it is a routing change, not only a metering one.

## Design grounding
- Existing specs/plans reviewed: `docs/superpowers/plans/2026-08-05-workforce-activity-view.md` (extended with the 2026-09-02 section in this PR).
- Current code substrate reviewed: `apps/web/lib/platform-runtime/workforce-activity.ts`, `apps/web/lib/inference/routed-inference.ts` (`persistRoutedTokenUsage`), `apps/web/lib/deliberation/orchestrator.ts`, `apps/web/lib/mcp/build-design-review-handler.ts`, `apps/web/lib/queue/functions/deliberation-run.ts`.
- Source of truth: `TokenUsage` (per call) and `TaskRun` (per run) are the ledgers; Right Now projects them.
- Decision: extend the existing plan; no new substrate.

Design-Grounding-Decision: extend-existing-plan
Docs-Impact-Decision: Right Now has no user-guide page; the workforce-activity plan is updated here. The build-orchestrator and routed-inference edits are attribution plumbing with no user-visible workflow change.

## Verification
- `workforce-activity.test.ts` +2 (unattributed spend reported, platform work listed).
- `WorkforceNowShell.uxbudget.test.tsx` (jsdom + axe) is where `docs/ux-fit/2026-09-02-right-now-platform-work.ux-fit.json` gets its numbers; route is absent from the committed budget baseline.
- `pnpm --filter web typecheck` clean; 158 test files across `lib/mcp`, `lib/inference`, `lib/deliberation`, `lib/build`, `lib/actions` green.
- Guards: ux-fit, module-size, primitive-adoption, spec-status, docs-impact, page-purpose all OK on `origin/main...HEAD`.

## Not in this PR (filed)
- **BI-D208E70C** — deliberation TaskRuns leak in `working`: the orchestrator settles the run, then the async runner's unguarded `markTaskRunWorking()` flips it back and never re-settles. 14 zombies live; they will now show under Platform work in flight until fixed.
- **BI-96885B6B** — build-resume re-runs the same failing review every 30 minutes with no backoff while the pinned provider is rate-limited; the local reviewer hits the 4096-token output cap and the build never advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
