### PR TITLE
feat(ward): project where each animal is, and how many kennels are free

### DIFF
--- a/apps/web/lib/ward/ward-occupancy.test.ts
+++ b/apps/web/lib/ward/ward-occupancy.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWardBoard,
+  reconcileAgainstPopulation,
+  summarizeKennelCapacity,
+  UNGROUPED_AREA,
+  type KennelRow,
+  type OccupancyRow,
+} from "./ward-occupancy";
+
+function kennel(over: Partial<KennelRow> & Pick<KennelRow, "id" | "label">): KennelRow {
+  return {
+    serviceArea: "Dog ward",
+    capacity: 1,
+    blockedReason: null,
+    lifecycle: "active",
+    ...over,
+  };
+}
+
+function occupancy(over: Partial<OccupancyRow> & Pick<OccupancyRow, "resourceId" | "demandRef">): OccupancyRow {
+  return { startsAt: new Date("2026-09-01T08:00:00Z"), releasedAt: null, ...over };
+}
+
+describe("buildWardBoard", () => {
+  it("places each animal in its kennel and counts what is free", () => {
+    const board = buildWardBoard({
+      kennels: [
+        kennel({ id: "k1", label: "D1" }),
+        kennel({ id: "k2", label: "D2" }),
+        kennel({ id: "k3", label: "D3" }),
+      ],
+      occupancy: [occupancy({ resourceId: "k1", demandRef: "animal-ranger" })],
+      animalNames: new Map([["animal-ranger", "Ranger"]]),
+    });
+
+    expect(board.totalUnits).toBe(3);
+    expect(board.occupied).toBe(1);
+    expect(board.free).toBe(2);
+    const d1 = board.zones[0]?.units.find((unit) => unit.label === "D1");
+    expect(d1?.animalName).toBe("Ranger");
+    expect(d1?.state).toBe("occupied");
+    expect(board.zones[0]?.units.find((unit) => unit.label === "D2")?.state).toBe("free");
+  });
+
+  it("treats a released allocation as history, not as an occupant", () => {
+    const board = buildWardBoard({
+      kennels: [kennel({ id: "k1", label: "D1" })],
+      occupancy: [
+        occupancy({
+          resourceId: "k1",
+          demandRef: "animal-scout",
+          releasedAt: new Date("2026-09-01T17:00:00Z"),
+        }),
+      ],
+      animalNames: new Map([["animal-scout", "Scout"]]),
+    });
+
+    expect(board.occupied).toBe(0);
+    expect(board.free).toBe(1);
+    // Scout is still in care but no longer housed — that must be visible.
+    expect(board.unplaced).toEqual([{ animalRef: "animal-scout", name: "Scout" }]);
+  });
+
+  it("keeps an out-of-service unit out of the free count", () => {
+    const board = buildWardBoard({
+      kennels: [
+        kennel({ id: "k1", label: "D1", blockedReason: "Deep clean after parvo" }),
+        kennel({ id: "k2", label: "D2" }),
+      ],
+      occupancy: [],
+      animalNames: new Map(),
+    });
+
+    expect(board.free).toBe(1);
+    expect(board.outOfService).toBe(1);
+    const blocked = board.zones[0]?.units.find((unit) => unit.label === "D1");
+    expect(blocked?.state).toBe("out-of-service");
+    expect(blocked?.blockedReason).toBe("Deep clean after parvo");
+  });
+
+  it("names animals in care that have no kennel recorded", () => {
+    const board = buildWardBoard({
+      kennels: [kennel({ id: "k1", label: "D1" })],
+      occupancy: [occupancy({ resourceId: "k1", demandRef: "a1" })],
+      animalNames: new Map([
+        ["a1", "Ranger"],
+        ["a2", "Saffron"],
+        ["a3", "Pip"],
+      ]),
+    });
+
+    expect(board.occupied).toBe(1);
+    expect(board.unplaced.map((row) => row.name).sort()).toEqual(["Pip", "Saffron"]);
+  });
+
+  it("does not name a ghost when the occupant's animal row is gone", () => {
+    const board = buildWardBoard({
+      kennels: [kennel({ id: "k1", label: "D1" })],
+      occupancy: [occupancy({ resourceId: "k1", demandRef: "deleted-animal" })],
+      animalNames: new Map(),
+    });
+
+    const unit = board.zones[0]?.units[0];
+    expect(unit?.animalName).toBeNull();
+    expect(unit?.state).toBe("free");
+    expect(board.occupied).toBe(0);
+  });
+
+  it("groups by the shelter's own area names and orders units naturally", () => {
+    const board = buildWardBoard({
+      kennels: [
+        kennel({ id: "k10", label: "D10", serviceArea: "Dog ward" }),
+        kennel({ id: "k2", label: "D2", serviceArea: "Dog ward" }),
+        kennel({ id: "c1", label: "C1", serviceArea: "Cat room" }),
+      ],
+      occupancy: [],
+      animalNames: new Map(),
+    });
+
+    expect(board.zones.map((zone) => zone.area)).toEqual(["Cat room", "Dog ward"]);
+    // D2 before D10 — a shelter counts its runs, it does not sort them as text.
+    expect(board.zones[1]?.units.map((unit) => unit.label)).toEqual(["D2", "D10"]);
+  });
+
+  it("gives ungrouped housing a readable area rather than an empty heading", () => {
+    const board = buildWardBoard({
+      kennels: [kennel({ id: "k1", label: "1", serviceArea: null })],
+      occupancy: [],
+      animalNames: new Map(),
+    });
+
+    expect(board.zones[0]?.area).toBe(UNGROUPED_AREA);
+  });
+
+  it("shows the most recent occupant when a unit holds two open allocations, and strands the other", () => {
+    const board = buildWardBoard({
+      kennels: [kennel({ id: "k1", label: "D1" })],
+      occupancy: [
+        occupancy({ resourceId: "k1", demandRef: "a1", startsAt: new Date("2026-09-01T08:00:00Z") }),
+        occupancy({ resourceId: "k1", demandRef: "a2", startsAt: new Date("2026-09-01T12:00:00Z") }),
+      ],
+      animalNames: new Map([
+        ["a1", "Ranger"],
+        ["a2", "Willow"],
+      ]),
+    });
+
+    expect(board.zones[0]?.units[0]?.animalName).toBe("Willow");
+    // The double booking is not hidden: Ranger surfaces as unplaced.
+    expect(board.unplaced).toEqual([{ animalRef: "a1", name: "Ranger" }]);
+  });
+});
+
+describe("summarizeKennelCapacity", () => {
+  it("answers how many kennels are free", () => {
+    const board = buildWardBoard({
+      kennels: [
+        kennel({ id: "k1", label: "D1" }),
+        kennel({ id: "k2", label: "D2" }),
+        kennel({ id: "k3", label: "D3", blockedReason: "Repair" }),
+      ],
+      occupancy: [occupancy({ resourceId: "k1", demandRef: "a1" })],
+      animalNames: new Map([["a1", "Ranger"]]),
+    });
+
+    expect(summarizeKennelCapacity(board)).toEqual({
+      total: 3,
+      free: 1,
+      occupied: 1,
+      outOfService: 1,
+    });
+  });
+
+  it("distinguishes a shelter with no housing recorded from one with none free", () => {
+    const empty = buildWardBoard({ kennels: [], occupancy: [], animalNames: new Map() });
+    expect(summarizeKennelCapacity(empty)).toBeNull();
+    expect(summarizeKennelCapacity(null)).toBeNull();
+  });
+});
+
+describe("reconcileAgainstPopulation", () => {
+  it("reports placed against the population the cockpit already counts", () => {
+    const board = buildWardBoard({
+      kennels: [kennel({ id: "k1", label: "D1" })],
+      occupancy: [occupancy({ resourceId: "k1", demandRef: "a1" })],
+      animalNames: new Map([
+        ["a1", "Ranger"],
+        ["a2", "Saffron"],
+      ]),
+    });
+
+    expect(
+      reconcileAgainstPopulation(board, { total: 2, onHold: 1, available: 1, pending: 0 }),
+    ).toEqual({ placed: 1, unplaced: 1, inCare: 2 });
+  });
+
+  it("reconciles nothing when either side is unreadable", () => {
+    expect(reconcileAgainstPopulation(null, { total: 2, onHold: 0, available: 2, pending: 0 })).toBeNull();
+    const board = buildWardBoard({ kennels: [], occupancy: [], animalNames: new Map() });
+    expect(reconcileAgainstPopulation(board, null)).toBeNull();
+  });
+});

--- a/apps/web/lib/ward/ward-occupancy.ts
+++ b/apps/web/lib/ward/ward-occupancy.ts
@@ -1,0 +1,187 @@
+import type { AnimalsInCare } from "@/lib/twin/archetype-outcomes";
+
+/**
+ * Where an animal sleeps, projected from the canonical capacity substrate.
+ *
+ * A kennel is a `Resource` (`kindSlug: "kennel"`, `capacityUnit: "animals"`) —
+ * the same model a restaurant table and a treatment room already use. An animal
+ * occupying one is a `ResourceCapacityAllocation` carrying
+ * `demandSlug: "animal-occupancy"` and `demandRef: <animalRef>`. Neither needed
+ * a new table; the operating-day run found the substrate built and unreached.
+ *
+ * The `demandRef` is deliberately the storefront animal's own stable key. When
+ * an animal gains an identity independent of its listing (BI-4F8A484C), these
+ * rows move by `sourceRef` backfill — the clone-to-canonical path the
+ * hospitality → `Resource` migration already proved — rather than being rebuilt.
+ */
+
+export const ANIMAL_OCCUPANCY_DEMAND_SLUG = "animal-occupancy";
+export const KENNEL_KIND_SLUG = "kennel";
+
+export interface KennelRow {
+  id: string;
+  label: string;
+  /** Ward, room or site. Absent means the shelter never grouped its housing. */
+  serviceArea: string | null;
+  capacity: number;
+  /** Set while a unit is out of service — deep clean, repair, quarantine. */
+  blockedReason: string | null;
+  lifecycle: string;
+}
+
+export interface OccupancyRow {
+  resourceId: string | null;
+  demandRef: string;
+  startsAt: Date;
+  releasedAt: Date | null;
+}
+
+export interface WardUnit {
+  kennelId: string;
+  label: string;
+  /** `null` when free, or when the occupant's animal row has since gone. */
+  animalRef: string | null;
+  animalName: string | null;
+  since: Date | null;
+  blockedReason: string | null;
+  state: "occupied" | "free" | "out-of-service";
+}
+
+export interface WardZone {
+  /** The shelter's own name for the area. Never invented. */
+  area: string;
+  units: WardUnit[];
+  occupied: number;
+  free: number;
+  outOfService: number;
+}
+
+export interface WardBoard {
+  zones: WardZone[];
+  totalUnits: number;
+  occupied: number;
+  free: number;
+  outOfService: number;
+  /** Animals in care with no kennel recorded — the shelter knows it has them
+   *  and cannot say where they are. Surfaced, never silently dropped. */
+  unplaced: Array<{ animalRef: string; name: string }>;
+}
+
+/** An area label every shelter can read, for housing that was never grouped. */
+export const UNGROUPED_AREA = "Unassigned area";
+
+function unitState(kennel: KennelRow, occupantRef: string | null): WardUnit["state"] {
+  if (kennel.blockedReason) return "out-of-service";
+  return occupantRef ? "occupied" : "free";
+}
+
+/**
+ * Build the board. Pure: every input is already scoped to one organization by
+ * its caller, and nothing here reads or writes.
+ *
+ * An allocation with a `releasedAt` is history — the animal has left that unit —
+ * so only open ones place anybody. That is what makes housing a timeline rather
+ * than a current-location field, which is the property contact tracing needs
+ * (§2, the parvo case) even though tracing itself is not built yet.
+ */
+export function buildWardBoard(input: {
+  kennels: KennelRow[];
+  occupancy: OccupancyRow[];
+  animalNames: Map<string, string>;
+}): WardBoard {
+  const open = input.occupancy.filter((row) => row.releasedAt == null && row.resourceId);
+
+  // Last one wins if a unit somehow holds two open allocations: showing the most
+  // recent is closer to the truth than showing an arbitrary one, and the double
+  // booking still surfaces because the earlier animal lands in `unplaced`.
+  const byKennel = new Map<string, OccupancyRow>();
+  for (const row of open) {
+    const current = byKennel.get(row.resourceId!);
+    if (!current || row.startsAt > current.startsAt) byKennel.set(row.resourceId!, row);
+  }
+
+  const placedRefs = new Set([...byKennel.values()].map((row) => row.demandRef));
+  const zones = new Map<string, WardZone>();
+
+  for (const kennel of input.kennels) {
+    const area = kennel.serviceArea?.trim() || UNGROUPED_AREA;
+    const occupant = byKennel.get(kennel.id) ?? null;
+    const animalRef = occupant?.demandRef ?? null;
+    // An occupant whose animal row is gone leaves the unit reading free rather
+    // than naming a ghost.
+    const animalName = animalRef ? input.animalNames.get(animalRef) ?? null : null;
+    const effectiveRef = animalName ? animalRef : null;
+    const state = unitState(kennel, effectiveRef);
+
+    const unit: WardUnit = {
+      kennelId: kennel.id,
+      label: kennel.label,
+      animalRef: effectiveRef,
+      animalName,
+      since: effectiveRef ? occupant?.startsAt ?? null : null,
+      blockedReason: kennel.blockedReason,
+      state,
+    };
+
+    const zone = zones.get(area) ?? { area, units: [], occupied: 0, free: 0, outOfService: 0 };
+    zone.units.push(unit);
+    if (state === "occupied") zone.occupied += 1;
+    else if (state === "out-of-service") zone.outOfService += 1;
+    else zone.free += 1;
+    zones.set(area, zone);
+  }
+
+  const unplaced = [...input.animalNames.entries()]
+    .filter(([ref]) => !placedRefs.has(ref))
+    .map(([animalRef, name]) => ({ animalRef, name }));
+
+  const ordered = [...zones.values()].sort((a, b) => a.area.localeCompare(b.area));
+  for (const zone of ordered) zone.units.sort((a, b) => a.label.localeCompare(b.label, undefined, { numeric: true }));
+
+  return {
+    zones: ordered,
+    totalUnits: input.kennels.length,
+    occupied: ordered.reduce((sum, zone) => sum + zone.occupied, 0),
+    free: ordered.reduce((sum, zone) => sum + zone.free, 0),
+    outOfService: ordered.reduce((sum, zone) => sum + zone.outOfService, 0),
+    unplaced,
+  };
+}
+
+/**
+ * The 16:00 question the operating-day run could not answer: how many kennels
+ * are free. `null` means no housing is recorded at all — a shelter with no
+ * kennels has not answered "none free", it has not been asked yet, and the two
+ * must not render the same.
+ */
+export function summarizeKennelCapacity(board: WardBoard | null): {
+  total: number;
+  free: number;
+  occupied: number;
+  outOfService: number;
+} | null {
+  if (!board || board.totalUnits === 0) return null;
+  return {
+    total: board.totalUnits,
+    free: board.free,
+    occupied: board.occupied,
+    outOfService: board.outOfService,
+  };
+}
+
+/**
+ * Animals the shelter is holding but cannot locate. A rescue that has kennels
+ * and unplaced animals has a real gap in its own records, and the board says so
+ * rather than quietly showing a smaller population than the cockpit does.
+ */
+export function reconcileAgainstPopulation(
+  board: WardBoard | null,
+  inCare: AnimalsInCare | null,
+): { placed: number; unplaced: number; inCare: number } | null {
+  if (!board || !inCare) return null;
+  return {
+    placed: board.occupied,
+    unplaced: board.unplaced.length,
+    inCare: inCare.total,
+  };
+}

--- a/docs/superpowers/plans/2026-09-02-ward-board-housing-and-occupancy.md
+++ b/docs/superpowers/plans/2026-09-02-ward-board-housing-and-occupancy.md
@@ -1,0 +1,131 @@
+---
+status: active
+---
+
+# Ward board: housing and occupancy implementation plan
+
+> **For agentic workers:** one backlog item, one branch, one PR per phase. Red-green with
+> `dpf-tdd`, guard-parity preflight and the exact-tree gate before any success claim, and
+> `dpf-pr-with-dco` for handoff.
+
+**Backlog item:** `BI-FB73D0B5`
+**Epic:** `EP-5102F494`
+**Depends on:** `BI-2C80E6EA` (subject-agnostic substrate — merged as PR #4494)
+**Blocked-behind for later phases:** `BI-4F8A484C` (canonical subject identity)
+
+## Outcome
+
+A rescue can say **where each animal is** and **how many kennels are free** — the two questions the
+2026-08-26 operating-day run could not answer at any point in the day (§6b, steps 1 and 16:00).
+
+Design agreed with the founder against an interactive prototype: an occupancy board read like a
+hotel front desk, with a list flip, per-animal situation, and intake straight from an empty unit.
+This plan covers the data layer and the read surface. It does not build intake, rounds, holds or
+the capacity assessment.
+
+## Verified substrate — measured against `main`, 2026-09-02
+
+Most of this is reach, not absence. Nothing here needs a new table.
+
+| Need | Model | State |
+|---|---|---|
+| Housing unit | `Resource` — open `kindSlug`, `capacity`, `capacityUnit`, `serviceArea`, `blockedReason`, `attributes`, nullable `storefrontId`, `sourceRef` | exists, generic |
+| Occupancy episode | `ResourceCapacityAllocation` — `demandSlug`/`demandRef`, `startsAt`/`endsAt`, `state`, `releasedAt`/`releaseReason` | exists, generic |
+| Kennel already declared | `ANIMAL_WELFARE_ACTIVATION_PROFILE.processProfile.resourceKinds` = `[{ kindSlug: "kennel", capacityUnit: "animals", maxCapacity: 100 }]`, with `housesSubjects: true` and `subjectTypes: ["animal"]` | **already declared** |
+| Kind resolution | `resolveAdminResourceProfile()` is archetype-driven and resolves `kennel` correctly | exists |
+| Spatial layout with tier | `OperationalSceneLayout` — `spaceKind`, `layoutState`, `underlayRef`, org-scoped | exists, unused here |
+
+Two constraints found and respected:
+
+- **`ResourceDomain` is a closed enum** — `beauty | hospitality | care | provider | workforce`. No
+  shelter value. Use `care`: the care vertical is already subject-agnostic (migration
+  `20260822164000`) and animal welfare is care. Widening the enum is a migration and is not
+  justified by one archetype.
+- **The admin resources route hardcodes `const ADMIN_RESOURCE_KIND = "table"`** and is threaded
+  with `restaurant-table-attributes`. Generalising it is `BI-2C80E6EA`'s own step 1 and would
+  disturb a shipped vertical, so this plan does **not** touch it. Kennel writes get their own path.
+
+## The classification decision, recorded
+
+`demandRef` carries `AdoptableAnimal.animalRef` — the storefront row's stable unique key — rather
+than waiting for canonical subject identity.
+
+Under the accommodation doctrine this is **pattern 3, polymorphic demand**, using an existing open
+vocabulary with no schema change. It leans on a storefront-coupled row, deliberately: the
+alternative is blocking the entire ward board behind `BI-4F8A484C`, which is deferred. When subject
+identity lands, these rows migrate by `sourceRef` backfill — the same clone-to-canonical path the
+hospitality → `Resource` migration already proved, and the reason that path exists.
+
+What would change the answer: if `BI-4F8A484C` ships before phase 2, place occupancy against the
+subject directly and skip the backfill.
+
+## Backlog coverage
+
+- Decision: decomposed
+- Parent: `BI-FB73D0B5`
+- Receipt: blocked — no initiative scope baseline exists for this umbrella item, so
+  `record_plan_backlog_coverage` returns `traceability-incomplete` and writes no receipt. A baseline
+  is minted only by a passing `spec-approval` gate, which requires a reviewer independent of the
+  artifact's author; the author cannot record it. This four-way table is the documented fallback
+  the tool itself prescribes, and the blocking condition is stated here rather than as a backlog id
+  that goes stale when that id closes.
+- Dependencies: `BI-2C80E6EA` (subject-agnostic substrate, merged as PR #4494) for the canonical
+  `Resource` and `ResourceCapacityAllocation` this reads; `BI-4F8A484C` (canonical subject identity,
+  deferred) is **not** a dependency of any phase below — see the classification decision above for
+  why `demandRef` carries the storefront key and how it migrates when identity lands.
+
+| Deliverable | Independently shippable | Maps to | Requirement | Contract | Verification |
+|---|---|---|---|---|---|
+| phase-1-occupancy-projection | yes | -> `BI-FB73D0B5` | pet-rescue operating model §5 entities 7-8 | `apps/web/lib/ward/ward-occupancy.ts` | `apps/web/lib/ward/ward-occupancy.test.ts` |
+| phase-2-kennel-roster-and-placement | yes | -> `BI-D58567DC` | canonical minimal substrate, elements 1 and 4 | `packages/db/prisma/schema/resource-scheduling.prisma` | route and adapter tests, phase 2 |
+| phase-3-map-and-list-surface | yes | -> `BI-F91D0685` | pet-rescue operating model §7 per-role UX | `packages/db/prisma/schema/verticals-storefront.prisma` (`OperationalSceneLayout`) | surface tests, phase 3 |
+| phase-4-cockpit-capacity | yes | -> `BI-A67AF6F0` | pet-rescue operating model §8, the 16:00 step | `apps/web/lib/twin/archetype-outcomes.ts` | `apps/web/lib/twin/archetype-outcomes.test.ts` |
+
+Each phase ships on its own and leaves the product coherent: phase 1 is a projection nothing yet
+reads, phase 2 lets a shelter record housing without a board to show it, phase 3 shows what phases
+1-2 record, and phase 4 surfaces one number from it. No phase depends on a later one.
+
+## Phases
+
+### Phase 1 — occupancy projection *(this PR)*
+
+`apps/web/lib/ward/ward-occupancy.ts`, pure and fully unit-tested. Given kennels, allocations and
+animal names it produces the board: zones by the shelter's own `serviceArea`, units ordered
+naturally, occupied/free/out-of-service counts, and the animals in care with **no kennel recorded**.
+
+Properties the tests pin, each earned from the operating model rather than invented:
+
+- A released allocation is history, not an occupant — housing is a timeline, which is what contact
+  tracing needs (§2, the parvo case) even though tracing is not built.
+- `blockedReason` keeps a unit out of the free count. A hotel room is empty between guests; a
+  kennel awaiting a deep clean is not free, and the free count lies if it says otherwise.
+- An animal in care with no open allocation is **named**, never silently dropped. A shelter that
+  cannot locate an animal it is holding has a real gap and the board says so.
+- No housing recorded and no housing free render differently. `summarizeKennelCapacity` returns
+  `null` for the first — the same honesty the donation tile and `/performance` already keep.
+
+### Phase 2 — kennel roster and placement writes
+
+Create, rename, block and unblock a kennel; place an animal into one and release it. Kennel writes
+take their own path rather than widening the table-coupled admin route. Seed the archetype's
+declared `resourceKinds` on activation so a rescue is not asked to invent its own housing model.
+
+### Phase 3 — the board surface
+
+Map and list, occupancy header, per-unit occupant with photograph, empty unit as the intake
+affordance. `OperationalSceneLayout` supplies position and **tier** — cat condos stack, which is the
+requirement a flat restaurant floor never exercised.
+
+### Phase 4 — capacity on the cockpit
+
+`Kennels — N total · M free` beside the `Animals in care` tile shipped in PR #4972, closing the
+16:00 step. Deliberately last: it reads a model built earlier, and a tile built first correctly
+shows nothing.
+
+## Definition of done for phase 1
+
+- The projection is pure, covered, and imported by nothing that writes.
+- Free, occupied and out-of-service counts are correct with blocked units and released allocations
+  present.
+- Unplaced animals are surfaced by name.
+- No migration, no schema change, no change to any shipped vertical.


### PR DESCRIPTION
## Why

Running the rescue as a business, two questions could not be answered at any point in the day:

- **08:00** — an animal has seven fields and none of them is a place, so *"which animals were exposed to this one"* cannot be asked.
- **16:00** — *"how many kennels are free"* is unanswerable, and that is the number a capacity decision gets made on.

This is the projection those answers come from. Phase 1 of `docs/superpowers/plans/2026-09-02-ward-board-housing-and-occupancy.md`, built to a design agreed against an interactive prototype.

## No new table

| Need | Model | State |
|---|---|---|
| Housing unit | `Resource` — open `kindSlug`, `capacityUnit`, `serviceArea`, `blockedReason` | already generic |
| Occupancy episode | `ResourceCapacityAllocation` — `demandSlug`/`demandRef`, `startsAt`, `releasedAt` | already generic |
| Kennel | `ANIMAL_WELFARE_ACTIVATION_PROFILE.processProfile.resourceKinds` = `[{ kindSlug: "kennel", capacityUnit: "animals", maxCapacity: 100 }]` | **already declared** |

The substrate was built and unreached, exactly as `canonical-minimal-substrate.md` predicted. A kennel is the same model a restaurant table and a treatment room already use.

## Four properties the tests pin

Each earned from the operating model rather than invented:

- **A released allocation is history, not an occupant.** Housing is a timeline, which is the property contact tracing needs for the parvo case (§2) even though tracing is not built here.
- **`blockedReason` keeps a unit out of the free count.** A hotel room is empty between guests; a kennel awaiting a deep clean is not free, and a free count that says otherwise is a lie told to a capacity decision.
- **An animal in care with no open allocation is named, never dropped.** A shelter that cannot locate an animal it is holding has a real gap; the board must not show a smaller population than the cockpit does.
- **No housing recorded and none free render differently.** `summarizeKennelCapacity` returns `null` for the first — the same honesty the donation tile and `/performance` already keep.

Also pinned: a double-booked unit shows its most recent occupant and *strands the other into unplaced* rather than hiding it, and an occupant whose animal row is gone leaves the unit free rather than naming a ghost.

## The classification decision, recorded

`demandRef` carries `AdoptableAnimal.animalRef` rather than waiting for canonical subject identity (`BI-4F8A484C`, deferred). Under the accommodation doctrine that is **pattern 3, polymorphic demand** on an existing open vocabulary, no schema change. When subject identity lands these rows migrate by `sourceRef` backfill — the clone-to-canonical path the hospitality → `Resource` migration already proved. The plan records what would change the answer.

## What this deliberately does not touch

`/api/storefront/admin/hospitality-resources` hardcodes `ADMIN_RESOURCE_KIND = "table"` and is threaded with `restaurant-table-attributes`. Generalising it is `BI-2C80E6EA`'s own step 1 and would disturb a shipped vertical to serve a second one. Kennel writes get their own path in phase 2.

Pure projection: nothing writes, no migration, no surface yet.

## Plan coverage is recorded as blocked, not as passing

`record_plan_backlog_coverage` refuses: the umbrella item has no initiative scope baseline, and a baseline is minted only by a `spec-approval` gate requiring a reviewer independent of the author — which the author cannot self-serve. The tool names its own fallback, and that is what the plan carries: the four-way coverage table inline, with the blocking **condition** stated rather than a backlog id that goes stale.

## Verification

- 12 tests in `apps/web/lib/ward`
- `tsc --noEmit` clean; style-drift clean
- `pregate:preflight` — 63 guards clean
- **`pregate` — PASS**, gated SHA `8d148259d598`, evidence `cmtkgq3xq0q6w01nuk1crffbi`. Pushed with no override.

Refs `BI-FB73D0B5`, `EP-5102F494`. Phases 2-4: `BI-D58567DC`, `BI-F91D0685`, `BI-A67AF6F0`. Workroom `WC-6A6A27BE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)