### PR TITLE
fix(nonprod): a slot goes to a waiter on its own claim, and only if it proves it is alive (BI-B1CB7EC3)

### DIFF
--- a/apps/web/lib/nonprod/environment-lease-admission.ts
+++ b/apps/web/lib/nonprod/environment-lease-admission.ts
@@ -4,6 +4,8 @@ export type AdmissionLease = {
   slotKey: string | null;
   queuedAt: Date | null;
   expiresAt: Date;
+  /** Last proof of life. Absent on legacy rows; `queuedAt` is the implicit first beat. */
+  heartbeatAt?: Date | null;
   supportedSlotKeys?: string[];
 };
 
@@ -23,17 +25,47 @@ function compareQueued(left: AdmissionLease, right: AdmissionLease): number {
 }
 
 /**
+ * Can this waiter still hold a slot, or only a place in line?
+ *
+ * BI-B1CB7EC3. A waiter proves it is attached to a process by re-claiming
+ * (which stamps `heartbeatAt`). A waiter whose last beat is older than the
+ * window could not have kept an ADMITTED lease alive either — admitting it
+ * hands a slot to nobody, and the slot is dead until the TTL reaps it. Such a
+ * waiter keeps its FIFO position (it is not expired) but may neither take a
+ * slot nor block a younger waiter that is provably alive.
+ */
+export function waiterProvesLiveness(
+  lease: AdmissionLease,
+  now: Date,
+  livenessWindowMs: number | undefined,
+): boolean {
+  if (livenessWindowMs === undefined) return true;
+  const lastBeat = lease.heartbeatAt ?? lease.queuedAt ?? null;
+  if (!lastBeat) return false;
+  return now.getTime() - lastBeat.getTime() <= livenessWindowMs;
+}
+
+/**
  * Pure capacity reconciler for one governed nonproduction environment.
  *
  * PostgreSQL serializes the read/apply transaction; this function owns the
  * deterministic policy inside that transaction. Keeping policy pure makes FIFO
  * ordering and slot selection independently testable without weakening the
  * database uniqueness invariant.
+ *
+ * `admissibleLeaseIds` restricts WHO may be admitted on this pass without
+ * changing WHO has precedence: a live older waiter outside the set still blocks
+ * (it is woken by the durable queue and admits itself on its own next claim),
+ * but a waiter is never promoted into a slot by a stranger's transaction.
+ * Measured 2026-09-02 (BI-B1CB7EC3): 28 of 32 orphaned local-CI admissions were
+ * promoted by another session's claim and never heartbeated.
  */
 export function planEnvironmentAdmission(input: {
   leases: AdmissionLease[];
   now: Date;
   slotKeys: string[];
+  livenessWindowMs?: number;
+  admissibleLeaseIds?: string[];
 }): EnvironmentAdmissionPlan {
   const slotKeys = [...new Set(input.slotKeys)].sort((left, right) =>
     left.localeCompare(right));
@@ -56,13 +88,22 @@ export function planEnvironmentAdmission(input: {
   const waiting = input.leases
     .filter((lease) => lease.status === "queued" && !expired.has(lease.id))
     .sort(compareQueued);
+  const admissible = input.admissibleLeaseIds
+    ? new Set(input.admissibleLeaseIds)
+    : null;
   const admissions: Array<{ leaseId: string; slotKey: string }> = [];
   for (const lease of waiting) {
+    // A waiter without proof of life keeps its place but cannot hold or
+    // block a slot on this pass.
+    if (!waiterProvesLiveness(lease, input.now, input.livenessWindowMs)) continue;
     const supported = new Set(lease.supportedSlotKeys ?? slotKeys);
     const slotIndex = freeSlots.findIndex((slotKey) => supported.has(slotKey));
     // Preserve global FIFO. A later slot-aware waiter may not bypass an older
     // legacy waiter merely because the older client cannot consume slot-1.
     if (slotIndex < 0) break;
+    // A live older waiter that is not the claimant keeps precedence: nobody is
+    // admitted past it, and it is not admitted on a stranger's behalf.
+    if (admissible && !admissible.has(lease.id)) break;
     const [slotKey] = freeSlots.splice(slotIndex, 1);
     admissions.push({ leaseId: lease.id, slotKey });
   }

--- a/apps/web/lib/nonprod/environment-lease-self-admission.test.ts
+++ b/apps/web/lib/nonprod/environment-lease-self-admission.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// BI-B1CB7EC3 — a local-CI claim admits only itself, and only past waiters
+// that cannot prove they are still attached to a process.
+
+vi.mock("@/lib/queue/queue-telemetry", () => ({
+  recordQueueTransition: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/operate/metrics", () => ({
+  gateRunDispositionsTotal: { inc: vi.fn() },
+}));
+vi.mock("./durable-wait", () => ({
+  afterNonprodLeaseRelease: vi.fn().mockResolvedValue(undefined),
+  publishNonprodCapacityForHead: vi.fn().mockResolvedValue({ notified: 0, headLeaseId: null }),
+}));
+
+import {
+  claimNonprodEnvironmentLease,
+  DEFAULT_LEASE_TTL_MS,
+  LOCAL_CI_ACTIVE_LEASE_TTL_MS,
+} from "./environment-lease";
+
+const NOW = new Date("2026-09-02T18:26:07.000Z");
+
+function lease(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "row-claimant",
+    leaseId: "NPEL-CLAIMANT",
+    claimKey: "gate:session-claimant:sha",
+    environmentKey: "local-integration-ci",
+    activeKey: null,
+    slotKey: null,
+    status: "queued",
+    ownerProvider: "claude",
+    ownerSessionId: "session-claimant",
+    purpose: "CI",
+    worktreePath: null,
+    branchName: null,
+    buildId: null,
+    taskRunId: null,
+    slotManifestVersion: null,
+    url: "http://localhost:3010",
+    ports: [3010],
+    cleanupCommand: null,
+    resourceClass: null,
+    expectedMemoryBytes: null,
+    ownerPid: null,
+    ownerProcessIdentity: null,
+    evidenceRecordId: null,
+    requestedTtlMs: LOCAL_CI_ACTIVE_LEASE_TTL_MS,
+    expiresAt: new Date(NOW.getTime() + DEFAULT_LEASE_TTL_MS),
+    releasedAt: null,
+    queuedAt: NOW,
+    admittedAt: null,
+    cancelledAt: null,
+    heartbeatAt: NOW,
+    phase: "waiting",
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function db() {
+  const database = {
+    $executeRaw: vi.fn().mockResolvedValue(1),
+    nonProductionEnvironmentLease: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue(lease()),
+      update: vi.fn().mockResolvedValue(lease()),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    platformConfig: { findUnique: vi.fn().mockResolvedValue(null) },
+    externalEvidenceRecord: { findUnique: vi.fn().mockResolvedValue(null) },
+    $transaction: vi.fn(),
+  };
+  database.$transaction.mockImplementation(
+    async (body: (tx: typeof database) => Promise<unknown>) => body(database),
+  );
+  return database;
+}
+
+function claim(mockDb: ReturnType<typeof db>) {
+  return claimNonprodEnvironmentLease({
+    db: mockDb as never,
+    environmentKey: "local-integration-ci",
+    ownerProvider: "claude",
+    ownerSessionId: "session-claimant",
+    claimKey: "gate:session-claimant:sha",
+    purpose: "CI",
+    url: "http://localhost:3010",
+    ports: [3010],
+    expiresAt: new Date(NOW.getTime() + LOCAL_CI_ACTIVE_LEASE_TTL_MS),
+    now: NOW,
+  });
+}
+
+/** The head that PR #4885's durable wait leaves behind: queued once, owner gone. */
+function strandedHead(overrides: Record<string, unknown> = {}) {
+  const queuedAt = new Date(NOW.getTime() - 26 * 60_000);
+  return lease({
+    id: "row-head",
+    leaseId: "NPEL-HEAD",
+    claimKey: "gate:session-head:sha",
+    ownerSessionId: "session-head",
+    queuedAt,
+    heartbeatAt: queuedAt,
+    ...overrides,
+  });
+}
+
+describe("local-CI self-admission with proof of life", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("does not hand the free slot to a stranded head; the claimant takes it", async () => {
+    const mockDb = db();
+    const head = strandedHead();
+    const claimant = lease();
+    mockDb.nonProductionEnvironmentLease.create.mockResolvedValue(claimant);
+    mockDb.nonProductionEnvironmentLease.findMany.mockResolvedValueOnce([head, claimant]);
+    mockDb.nonProductionEnvironmentLease.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ ...claimant, status: "active", slotKey: "slot-0" });
+
+    const result = await claim(mockDb);
+
+    expect(result.status).toBe("admitted");
+    const admittedIds = mockDb.nonProductionEnvironmentLease.update.mock.calls
+      .filter(([call]) => call.data?.status === "active")
+      .map(([call]) => call.where.id);
+    expect(admittedIds).toEqual(["row-claimant"]);
+  });
+
+  it("keeps precedence for a head that beat within the admitted TTL, and does not admit it on the stranger's behalf", async () => {
+    const mockDb = db();
+    const head = strandedHead({ heartbeatAt: new Date(NOW.getTime() - 30_000) });
+    const claimant = lease();
+    mockDb.nonProductionEnvironmentLease.create.mockResolvedValue(claimant);
+    mockDb.nonProductionEnvironmentLease.findMany
+      .mockResolvedValueOnce([head, claimant])
+      .mockResolvedValueOnce([{ id: "row-head" }, { id: "row-claimant" }]);
+    mockDb.nonProductionEnvironmentLease.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(claimant);
+
+    const result = await claim(mockDb);
+
+    expect(result).toMatchObject({ status: "queued", queuePosition: 2 });
+    const admittedIds = mockDb.nonProductionEnvironmentLease.update.mock.calls
+      .filter(([call]) => call.data?.status === "active")
+      .map(([call]) => call.where.id);
+    expect(admittedIds).toEqual([]);
+  });
+
+  it("admits the head on its own claim once it is back", async () => {
+    const mockDb = db();
+    const head = strandedHead();
+    mockDb.nonProductionEnvironmentLease.findUnique
+      .mockResolvedValueOnce(head)
+      .mockResolvedValueOnce({ ...head, status: "active", slotKey: "slot-0" });
+    // The re-claim stamps heartbeatAt before reconciliation reads the queue.
+    mockDb.nonProductionEnvironmentLease.update.mockResolvedValueOnce({ ...head, heartbeatAt: NOW });
+    mockDb.nonProductionEnvironmentLease.findMany.mockResolvedValueOnce([{ ...head, heartbeatAt: NOW }]);
+
+    const result = await claimNonprodEnvironmentLease({
+      db: mockDb as never,
+      environmentKey: "local-integration-ci",
+      ownerProvider: "claude",
+      ownerSessionId: "session-head",
+      claimKey: "gate:session-head:sha",
+      purpose: "CI",
+      url: "http://localhost:3010",
+      ports: [3010],
+      expiresAt: new Date(NOW.getTime() + LOCAL_CI_ACTIVE_LEASE_TTL_MS),
+      now: NOW,
+    });
+
+    expect(result).toMatchObject({ status: "admitted", slotKey: "slot-0" });
+  });
+});

--- a/apps/web/lib/nonprod/environment-lease-slot-binding.ts
+++ b/apps/web/lib/nonprod/environment-lease-slot-binding.ts
@@ -1,0 +1,55 @@
+import localCiSlotResources from "./local-ci-slot-resources.json";
+
+type NonprodSlotKey = keyof typeof localCiSlotResources.slots;
+const NONPROD_SLOT_KEYS = Object.freeze(
+  Object.keys(localCiSlotResources.slots) as NonprodSlotKey[],
+);
+
+export type NonprodSlotBinding = {
+  manifestVersion: 1;
+  slotKey: "slot-0" | "slot-1";
+  url: string;
+  ports: number[];
+  cleanupCommand: string;
+};
+
+function expectedLocalCiSlotBinding(slotKey: NonprodSlotKey) {
+  const resources = localCiSlotResources.slots[slotKey];
+  return {
+    manifestVersion: localCiSlotResources.schemaVersion,
+    slotKey,
+    url: `http://localhost:${resources.portalPort}`,
+    ports: [resources.portalPort, resources.postgresPort],
+    cleanupCommand: `node scripts/local-ci-slot-cleanup.mjs --slot-key ${slotKey}`,
+  };
+}
+
+/**
+ * A slot-aware runner may renew only under the exact manifest binding the
+ * lease was admitted with. Throws the same contract errors the renewal path
+ * always has; extracted from environment-lease.ts unchanged.
+ */
+export function assertRenewalSlotBinding(
+  lease: { slotKey: string | null; slotManifestVersion: number | null },
+  slotBinding: NonprodSlotBinding,
+): void {
+  const slotKey = lease.slotKey as NonprodSlotKey | null;
+  if (
+    !slotKey
+    || !NONPROD_SLOT_KEYS.includes(slotKey)
+    || lease.slotManifestVersion !== slotBinding.manifestVersion
+    || slotKey !== slotBinding.slotKey
+  ) {
+    throw new Error("nonprod_slot_binding_mismatch");
+  }
+  const expected = expectedLocalCiSlotBinding(slotKey);
+  if (
+    slotBinding.manifestVersion !== expected.manifestVersion
+    || slotBinding.url !== expected.url
+    || slotBinding.cleanupCommand !== expected.cleanupCommand
+    || slotBinding.ports.length !== expected.ports.length
+    || slotBinding.ports.some((port, index) => port !== expected.ports[index])
+  ) {
+    throw new Error("nonprod_slot_resource_binding_mismatch");
+  }
+}

--- a/apps/web/lib/nonprod/environment-lease.ts
+++ b/apps/web/lib/nonprod/environment-lease.ts
@@ -11,6 +11,7 @@ import {
 } from "./environment-lease-pool-policy";
 import { isHeavyResourceClass, type HeavyResourceClass } from "./host-resource-policy";
 import localCiSlotResources from "./local-ci-slot-resources.json";
+import { assertRenewalSlotBinding, type NonprodSlotBinding } from "./environment-lease-slot-binding";
 import { recordQueueTransition } from "@/lib/queue/queue-telemetry";
 import { gateRunDispositionsTotal } from "@/lib/operate/metrics";
 import type { NonprodOwnerProvider } from "./nonprod-owner-provider";
@@ -36,17 +37,6 @@ export {
 export type NonprodEnvironmentKey = "active-candidate" | "local-integration-ci" | "host-heavy-resource";
 type NonprodSlotKey = keyof typeof localCiSlotResources.slots;
 export const NONPROD_SLOT_KEYS = Object.freeze(Object.keys(localCiSlotResources.slots) as NonprodSlotKey[]);
-
-function expectedLocalCiSlotBinding(slotKey: NonprodSlotKey) {
-  const resources = localCiSlotResources.slots[slotKey];
-  return {
-    manifestVersion: localCiSlotResources.schemaVersion,
-    slotKey,
-    url: `http://localhost:${resources.portalPort}`,
-    ports: [resources.portalPort, resources.postgresPort],
-    cleanupCommand: `node scripts/local-ci-slot-cleanup.mjs --slot-key ${slotKey}`,
-  };
-}
 
 type LeaseModel = typeof prisma.nonProductionEnvironmentLease;
 type LeaseTx = Pick<
@@ -95,6 +85,15 @@ async function inLeaseTransaction<T>(
       if (!["P2002", "P2034"].includes(code) || attempt >= 2) throw error;
     }
   }
+}
+
+/**
+ * Lanes whose queue head is WOKEN, never promoted: the head's own next claim is
+ * the only transaction that may admit it.
+ */
+function isSelfAdmittingEnvironment(environmentKey: string): boolean {
+  return environmentKey === "local-integration-ci"
+    || environmentKey === "host-heavy-resource";
 }
 
 function queueKey(environmentKey: string): string {
@@ -151,6 +150,9 @@ async function reconcileEnvironmentInTransaction(input: {
   environmentKey: string;
   now: Date;
   slotKeys: string[];
+  /** BI-B1CB7EC3: only these rows may take a slot on this pass. */
+  admissibleLeaseIds?: string[];
+  livenessWindowMs?: number;
 }): Promise<{
   expiredLeaseIds: string[];
   admittedLeaseIds: string[];
@@ -174,6 +176,8 @@ async function reconcileEnvironmentInTransaction(input: {
     })),
     now: input.now,
     slotKeys: input.slotKeys,
+    admissibleLeaseIds: input.admissibleLeaseIds,
+    livenessWindowMs: input.livenessWindowMs,
   });
 
   if (plan.expiredLeaseIds.length > 0) {
@@ -433,11 +437,21 @@ export async function claimNonprodEnvironmentLease(input: {
       created = true;
     }
 
+    // Release and reaping already wake the durable queue head instead of
+    // promoting it (see releaseNonprodEnvironmentLease). A claim follows the
+    // same rule: it admits only itself, never a waiter whose owner may have
+    // exited after a durable-wait exit 75, and only when no older waiter is
+    // provably alive (BI-B1CB7EC3).
+    const selfAdmitting = isSelfAdmittingEnvironment(input.environmentKey);
     const reconciliation = await reconcileEnvironmentInTransaction({
       tx,
       environmentKey: input.environmentKey,
       now,
       slotKeys: poolPolicy.slotKeys,
+      admissibleLeaseIds: selfAdmitting ? [lease.id] : undefined,
+      livenessWindowMs: selfAdmitting
+        ? admittedLeaseTtlMs(input.environmentKey, ttlMs)
+        : undefined,
     });
     admittedNow = reconciliation.admittedLeaseIds.includes(lease.id);
     queueDepth = reconciliation.queueDepth;
@@ -566,10 +580,7 @@ export async function releaseNonprodEnvironmentLease(input: {
       // A local-CI waiter carries the fresh client-side host observation needed
       // to prove capacity. Preserve FIFO here and wake the durable queue head;
       // its one fresh claim can admit with current pressure evidence.
-      slotKeys: current.environmentKey === "local-integration-ci"
-        || current.environmentKey === "host-heavy-resource"
-        ? []
-        : ["slot-0"],
+      slotKeys: isSelfAdmittingEnvironment(current.environmentKey) ? [] : ["slot-0"],
     });
     return {
       lease,
@@ -626,13 +637,7 @@ export async function renewNonprodEnvironmentLease(input: {
   leaseId: string;
   ownerSessionId: string;
   ttlMs?: number;
-  slotBinding?: {
-    manifestVersion: 1;
-    slotKey: "slot-0" | "slot-1";
-    url: string;
-    ports: number[];
-    cleanupCommand: string;
-  };
+  slotBinding?: NonprodSlotBinding;
   hostPressure?: LocalCiHostPressure;
   capacityBroker?: LocalCiCapacityBroker;
   now?: Date;
@@ -654,27 +659,7 @@ export async function renewNonprodEnvironmentLease(input: {
   if (lease.ownerSessionId !== input.ownerSessionId) return { status: "lost", reason: "not-owner" };
   if (lease.expiresAt.getTime() <= now.getTime()) return { status: "lost", reason: "expired" };
   if (input.slotBinding) {
-    const slotKey = lease.slotKey as NonprodSlotKey | null;
-    if (
-      !slotKey
-      || !NONPROD_SLOT_KEYS.includes(slotKey)
-      || lease.slotManifestVersion !== input.slotBinding.manifestVersion
-      || slotKey !== input.slotBinding.slotKey
-    ) {
-      throw new Error("nonprod_slot_binding_mismatch");
-    }
-    const expected = expectedLocalCiSlotBinding(slotKey);
-    if (
-      input.slotBinding.manifestVersion !== expected.manifestVersion
-      || input.slotBinding.url !== expected.url
-      || input.slotBinding.cleanupCommand !== expected.cleanupCommand
-      || input.slotBinding.ports.length !== expected.ports.length
-      || input.slotBinding.ports.some(
-        (port, index) => port !== expected.ports[index],
-      )
-    ) {
-      throw new Error("nonprod_slot_resource_binding_mismatch");
-    }
+    assertRenewalSlotBinding(lease, input.slotBinding);
   } else if (
     lease.slotManifestVersion === 1
     && lease.phase === "admitted-unbound"
@@ -750,10 +735,7 @@ export async function reapExpiredNonprodEnvironmentLeases(input: {
         tx,
         environmentKey,
         now,
-        slotKeys: environmentKey === "local-integration-ci"
-          || environmentKey === "host-heavy-resource"
-          ? []
-          : ["slot-0"],
+        slotKeys: isSelfAdmittingEnvironment(environmentKey) ? [] : ["slot-0"],
       });
       promotedLeaseIds.push(...result.admittedLeaseIds);
     });

--- a/docs/superpowers/specs/2026-09-02-lease-admission-requires-proof-of-life-design.md
+++ b/docs/superpowers/specs/2026-09-02-lease-admission-requires-proof-of-life-design.md
@@ -1,0 +1,88 @@
+---
+status: active
+title: A slot goes to a waiter on its own claim, and only if it can prove it is alive
+---
+
+# A Slot Goes to a Waiter on Its Own Claim, and Only If It Can Prove It Is Alive
+
+- **Date:** 2026-09-02
+- **Scope:** platform — nonproduction environment lease admission (`local-integration-ci`, `host-heavy-resource`)
+- **Backlog item:** `BI-B1CB7EC3`
+- **Epic:** `EP-ABB3AC9D` (change-delivery latency)
+- **Kernel ledger:** `DI-BB107914F5B0`
+- **Status:** Design — implemented in this branch.
+
+> Half of every local-CI slot handed out for three days went to a process that no longer existed.
+
+---
+
+## 1. What was measured
+
+Live install, `NonProductionEnvironmentLease`, admitted rows for `local-integration-ci` since 2026-08-30 02:25 UTC. Not inferred.
+
+| phase | admitted | expired | expiry | p50 queue wait | sessions |
+| --- | --- | --- | --- | --- | --- |
+| capacity 2 only — PR #4869 landed, PR #4885 not yet (08-30 02:25 to 20:59) | 8 | 1 | 13% | 0s | 5 |
+| after PR #4885 "make gate waits durable" (08-30 20:59 to 09-02 13:27) | 66 | 36 | 55% | 477s | 18 |
+| after PR #4989 (09-02 13:27 onward) | 1 | 0 | — | 293s | 1 |
+
+The earlier thread attributed the jump to the capacity-2 pool and expected PR #4989 to repair it. Neither holds. The pool ran at 13% expiry on its own, and #4989 changes verdict writing and the pre-push reader; it touches no lease code. The break coincides with #4885.
+
+### 1.1 The mechanism
+
+Of the 39 expired leases, 32 never heartbeated after admission: `heartbeatAt = admittedAt`. Of those 32, 28 were admitted at the exact instant another session claimed, heartbeated or released. They were promoted by a stranger's transaction, not by their own owner.
+
+Two facts compose:
+
+1. PR #4885 made `gate-worktree.mjs` exit 75 on **any** queued claim (`resumeMode: "durable-task"`). The waiter's process is gone after one claim; an AI session is expected to re-invoke it when the durable TaskRun wakes.
+2. `claimNonprodEnvironmentLease` runs `reconcileEnvironmentInTransaction` with the pool's slot keys, and `planEnvironmentAdmission` hands the oldest queued waiter any free slot, whoever is claiming and whether or not the waiter's owner still exists.
+
+So the claimant that did the work promotes the absent head into a slot with a two-minute TTL and nobody to bind it, then waits behind it. The slot is dead for up to two minutes, the pilot circuit breaker reads the expiry as infrastructure failure, and the claimant's own wait grows.
+
+The release path already states the intended rule for these lanes and passes `slotKeys: []`: *"Preserve FIFO here and wake the durable queue head; its one fresh claim can admit."* The claim path was the exception.
+
+### 1.2 Why the planner could not see it
+
+Admission overwrites `heartbeatAt` with `now`. The signal that would have said "this waiter has not been heard from in 26 minutes" is destroyed at the moment it is needed. Liveness has to be judged on the row as it stands before the pass.
+
+---
+
+## 2. Research & benchmarking
+
+- **Kubernetes Lease objects.** A holder keeps a lease by renewing `renewTime`; a controller that stops renewing loses leadership after `leaseDurationSeconds`, and nothing else can renew on its behalf. Admission here follows the same shape: the waiter proves itself, nobody proves it for the waiter.
+- **SQS visibility timeout.** A consumer that receives a message and disappears does not keep it; the message becomes visible again after the timeout. Our two-minute admitted TTL is that timeout. The defect was assigning the message to a consumer known not to be listening.
+- **The platform's own rule, already applied once.** `leaseStillProvesLiveness` (BI-DC9CA20D, PR #4976) stopped host-capacity arbitration from treating presence as liveness. This applies the same standard one step earlier, at admission.
+
+Rejected: reverting the durable wait (undoes the polling reduction it was built for), seeding the pool back to one slot (the measurement shows capacity is not the cause and a shorter queue does not remove orphans), and shortening the unbound TTL (reduces the cost of each orphan without stopping them). Kernel scoring: `DI-BB107914F5B0`, high confidence.
+
+---
+
+## 3. Decision
+
+For the lease-gated lanes (`local-integration-ci`, `host-heavy-resource`):
+
+1. **A claim admits only itself.** A waiter is never promoted into a slot by another session's transaction. Release and reaping already wake the head through the durable TaskRun; its own next claim admits it.
+2. **Precedence requires proof of life.** An older waiter keeps its place in line and blocks a younger claimant only if its last beat is within the admitted TTL for the lane (two minutes). A waiter that could not have kept an admitted lease alive cannot hold a slot hostage either. It is not expired; when its owner re-claims, the beat refreshes and it is first again.
+3. **Everything else is unchanged.** Environments that pass no liveness window or admissible set (the preview lane, and the reaper's own pass) keep the legacy FIFO promotion.
+
+---
+
+## 4. What was built
+
+- `planEnvironmentAdmission` takes `livenessWindowMs` and `admissibleLeaseIds`, both optional. `waiterProvesLiveness` reads `heartbeatAt`, falling back to `queuedAt` as the implicit first beat.
+- `claimNonprodEnvironmentLease` passes `admissibleLeaseIds: [lease.id]` and `livenessWindowMs: admittedLeaseTtlMs(...)` for the self-admitting lanes. `isSelfAdmittingEnvironment` replaces the two inline environment-key ternaries the release and reap paths already carried.
+- The slot-binding validation moved unchanged into `environment-lease-slot-binding.ts` so `environment-lease.ts` stays under the module-size ceiling.
+
+### 4.1 Regression guards, verified to fail without the fix
+
+`scripts/nonprod-environment-admission.test.mjs` (raw node): with the planner reverted, 3 of 14 fail — the stranger-does-not-promote case, the stale-head-cannot-block case, and the self-admission case.
+
+`apps/web/lib/nonprod/environment-lease-self-admission.test.ts` (vitest): a stranded head is not admitted on a stranger's claim; a head that beat within the TTL keeps precedence and the claimant queues at position 2; the head admits itself on its own return.
+
+---
+
+## 5. What this does not do
+
+- It does not stop a session from leaving a queued row behind (BI-EB864226 covers the duplicate-entry side; the two-hour queued expiry is unchanged). Such a row now costs a place in line, not a slot.
+- It does not change the client's exit-75 behaviour or the durable TaskRun wake path.
+- It does not touch the preview (`active-candidate`) lane, which has no durable-wait client.

--- a/scripts/nonprod-environment-admission.test.mjs
+++ b/scripts/nonprod-environment-admission.test.mjs
@@ -204,3 +204,100 @@ test("owner death reaps and refills only its slot while the peer remains valid",
     "healthy peer must never be reaped with the dead owner",
   );
 });
+
+// BI-B1CB7EC3 — a slot goes only to a waiter that proves it is attached to a
+// process, and only on that waiter's own claim.
+
+test("a stranger's claim does not promote the queued head; the head keeps precedence", () => {
+  const plan = planEnvironmentAdmission({
+    leases: [
+      lease({ id: "head", queuedAt: new Date("2026-07-28T20:59:00.000Z") }),
+      lease({ id: "claimant", queuedAt: new Date("2026-07-28T20:59:30.000Z") }),
+    ],
+    now: NOW,
+    slotKeys: ["slot-0"],
+    livenessWindowMs: 120_000,
+    admissibleLeaseIds: ["claimant"],
+  });
+
+  assert.deepEqual(plan.admissions, []);
+  assert.deepEqual(plan.queuePositions, [
+    { leaseId: "head", position: 1 },
+    { leaseId: "claimant", position: 2 },
+  ]);
+});
+
+test("a claimant admits itself when it is the live head", () => {
+  const plan = planEnvironmentAdmission({
+    leases: [
+      lease({ id: "claimant", queuedAt: new Date("2026-07-28T20:59:00.000Z") }),
+      lease({ id: "later", queuedAt: new Date("2026-07-28T20:59:30.000Z") }),
+    ],
+    now: NOW,
+    slotKeys: ["slot-0", "slot-1"],
+    livenessWindowMs: 120_000,
+    admissibleLeaseIds: ["claimant"],
+  });
+
+  assert.deepEqual(plan.admissions, [{ leaseId: "claimant", slotKey: "slot-0" }]);
+  assert.deepEqual(plan.queuePositions, [{ leaseId: "later", position: 1 }]);
+});
+
+test("a head whose last beat is older than the window neither takes nor blocks a slot", () => {
+  const plan = planEnvironmentAdmission({
+    leases: [
+      lease({
+        id: "dead-head",
+        queuedAt: new Date("2026-07-28T20:30:00.000Z"),
+        heartbeatAt: new Date("2026-07-28T20:57:59.000Z"),
+      }),
+      lease({
+        id: "claimant",
+        queuedAt: new Date("2026-07-28T20:59:30.000Z"),
+        heartbeatAt: NOW,
+      }),
+    ],
+    now: NOW,
+    slotKeys: ["slot-0"],
+    livenessWindowMs: 120_000,
+    admissibleLeaseIds: ["claimant"],
+  });
+
+  assert.deepEqual(plan.admissions, [{ leaseId: "claimant", slotKey: "slot-0" }]);
+  assert.deepEqual(plan.expiredLeaseIds, []);
+  assert.deepEqual(plan.queuePositions, [{ leaseId: "dead-head", position: 1 }]);
+});
+
+test("a beat exactly at the window edge still proves liveness; queuedAt is the implicit first beat", () => {
+  const plan = planEnvironmentAdmission({
+    leases: [
+      lease({
+        id: "edge",
+        queuedAt: new Date(NOW.getTime() - 120_000),
+        heartbeatAt: null,
+      }),
+    ],
+    now: NOW,
+    slotKeys: ["slot-0"],
+    livenessWindowMs: 120_000,
+    admissibleLeaseIds: ["edge"],
+  });
+
+  assert.deepEqual(plan.admissions, [{ leaseId: "edge", slotKey: "slot-0" }]);
+});
+
+test("without a liveness window or an admissible set the legacy FIFO promotion is unchanged", () => {
+  const plan = planEnvironmentAdmission({
+    leases: [
+      lease({
+        id: "stale-head",
+        queuedAt: new Date("2026-07-28T20:00:00.000Z"),
+        heartbeatAt: new Date("2026-07-28T20:00:00.000Z"),
+      }),
+    ],
+    now: NOW,
+    slotKeys: ["slot-0"],
+  });
+
+  assert.deepEqual(plan.admissions, [{ leaseId: "stale-head", slotKey: "slot-0" }]);
+});


### PR DESCRIPTION
## Outcome

Local-CI lease expiry rose from 13% to 55% and p50 queue wait from 0s to 477s across 18 sessions after PR #4885 made queued gate waits durable. Any session's claim ran FIFO reconciliation and promoted the queue head into a slot with a two-minute TTL even though the head's owner had exited after its durable-wait exit 75. 28 of 32 orphaned admissions were promoted by a stranger's transaction and never heartbeated. PR #4989 touched no lease code; capacity 2 alone measured 13%.

For `local-integration-ci` and `host-heavy-resource` a claim now admits only itself, and an older waiter keeps precedence only while its last beat is within the lane's admitted TTL. A stale waiter keeps its place in line but can neither take nor block a slot; it is admitted on its own next claim, which is the rule the release path already stated.

Spec: `docs/superpowers/specs/2026-09-02-lease-admission-requires-proof-of-life-design.md`. Kernel ledger `DI-BB107914F5B0`. Epic EP-ABB3AC9D. Workroom WC-F283E79E.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-09-02-capacity-reservation-requires-proof-of-life-design.md` (BI-DC9CA20D), `2026-08-24-resilient-gate-flow-control.md`, PR #4885's durable-wait design (BI-MCP-EFF-0285909C).
- Current code substrate reviewed: `apps/web/lib/nonprod/environment-lease.ts`, `environment-lease-admission.ts`, `environment-lease-registry.ts`, `durable-wait.ts`, `scripts/gate-worktree.mjs`, plus live `NonProductionEnvironmentLease` and `QueueTelemetryEvent` rows.
- Source of truth: the lease row's own heartbeat is the only proof of life; "wake the head, its own claim admits" extends from the release path to the claim path.
- Decision: server-side self-admission with proof of life, over reverting the durable wait, seeding capacity 1, or shortening the unbound TTL.

## Verification

- `scripts/nonprod-environment-admission.test.mjs` 14/14; 3 fail with the planner reverted.
- `apps/web` vitest `lib/nonprod` environment-lease, -self-admission, -liveness, -registry: 34/34.
- `apps/web` `tsc --noEmit` clean; check-module-size and check-style-drift clean; `pregate:preflight` 63 guards clean.
- Exact-tree local-CI gate PASS on `53656e0c4d7e`, evidence `cmtkh9jvt0r1s01nut52z6t1h`.

Docs-Impact-Decision: design doc added; no user-facing or operator runbook changes, the CLI-facing lease contract is unchanged.
Backlog-Item: BI-B1CB7EC3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
