### PR TITLE
fix(federation): supersession merges id- and address-keyed views of a peer, and trust outranks age (EP-ZERO-CONFIG-FEDERATION)

### DIFF
--- a/apps/web/lib/federation/link-supersession.test.ts
+++ b/apps/web/lib/federation/link-supersession.test.ts
@@ -6,7 +6,7 @@ import { normalizeAuthorityUrl, planSupersession, supersedeStaleSameOrgLinks, ty
 
 function row(linkId: string, overrides: Partial<SupersessionLinkRow> = {}): SupersessionLinkRow {
   return {
-    linkId, role: "same-org-peer", peerAuthorityUrl: "http://192.168.0.200:3000", peerInstallationId: null,
+    linkId, role: "same-org-peer", linkState: "trusted", peerAuthorityUrl: "http://192.168.0.200:3000", peerInstallationId: null,
     enrolledAt: new Date("2026-08-28T00:00:00Z"), createdAt: new Date("2026-08-28T00:00:00Z"), ...overrides,
   };
 }
@@ -33,6 +33,30 @@ describe("planSupersession", () => {
     ]);
     expect(plan).toEqual([{ linkId: "a", supersededBy: "b" }]);
     expect(normalizeAuthorityUrl("https://peer.example/")).toBe("peer.example:443");
+  });
+
+  it("merges the id-keyed and address-keyed views of one peer, and trust outranks age", () => {
+    const inst = `inst_${"b".repeat(32)}`;
+    // Live: a trusted link that knows the peer's id; a pending duplicate at the
+    // same address that never learned it (the live pair on 2026-09-02).
+    const plan = planSupersession([
+      row("link_pending_old", { linkState: "pending", enrolledAt: new Date("2026-08-28T04:40:26Z") }),
+      row("link_trusted", { peerInstallationId: inst, enrolledAt: new Date("2026-08-28T19:16:38Z") }),
+    ]);
+    expect(plan).toEqual([{ linkId: "link_pending_old", supersededBy: "link_trusted" }]);
+
+    // A pending re-pairing NEWER than the trusted link is in flight: left alone,
+    // and it never supersedes the trusted link.
+    expect(planSupersession([
+      row("link_trusted", { peerInstallationId: inst, enrolledAt: new Date("2026-08-28T19:16:38Z") }),
+      row("link_pending_new", { linkState: "pending", enrolledAt: new Date("2026-09-02T10:00:00Z") }),
+    ])).toEqual([]);
+
+    // An OLDER trusted link loses to a newer trusted link, whatever its id knowledge.
+    expect(planSupersession([
+      row("link_trusted_old", { enrolledAt: new Date("2026-08-01T00:00:00Z") }),
+      row("link_trusted_new", { peerInstallationId: inst, enrolledAt: new Date("2026-08-28T19:16:38Z") }),
+    ])).toEqual([{ linkId: "link_trusted_old", supersededBy: "link_trusted_new" }]);
   });
 
   it("never touches cross-organization links and is stable on ties", () => {

--- a/apps/web/lib/federation/link-supersession.ts
+++ b/apps/web/lib/federation/link-supersession.ts
@@ -4,15 +4,16 @@
 // trusted link to the same box, each pointing at a token the rebuilt peer no
 // longer recognises. Nobody could tell which was live; the panel showed
 // "waiting" for the dead ones forever. Rule: among non-revoked same-org links,
-// group by the peer's installation id when known, else by its normalised
-// authority URL; the newest enrolment wins and the rest are revoked with
-// reason `superseded-by:<linkId>`. Monotone — a revoked link is never revived.
+// group by the peer's installation id AND its normalised authority URL (merged
+// transitively); trust outranks age, then the newest enrolment wins, and the
+// rest are revoked `superseded-by:<linkId>`. Monotone — never revived.
 
 import { prisma } from "@dpf/db";
 
 export interface SupersessionLinkRow {
   linkId: string;
   role: string;
+  linkState: string;
   peerAuthorityUrl: string;
   peerInstallationId: string | null;
   enrolledAt: Date | null;
@@ -36,24 +37,71 @@ export function normalizeAuthorityUrl(value: string): string {
   }
 }
 
-/** Pure: decide which links a set of same-org links supersede. */
+function isTrusted(link: SupersessionLinkRow): boolean {
+  return link.linkState === "trusted";
+}
+
+function enrolledMs(link: SupersessionLinkRow): number {
+  return (link.enrolledAt ?? link.createdAt).getTime();
+}
+
+/**
+ * Pure: decide which links a set of same-org links supersede.
+ *
+ * Links to one peer are grouped by BOTH facts that identify it — the peer's
+ * installation id when known and its normalised authority URL — merged
+ * transitively, so a pending link that never learned the peer's id still lands
+ * in the same group as the trusted link at the same address (a reinstalled
+ * peer shows up as a new installation id at the old address).
+ *
+ * Trust outranks age: a trusted link is never superseded by a pending one. If
+ * the group holds a trusted link, the newest trusted link wins and every other
+ * link is superseded EXCEPT a pending link enrolled after the winner (a
+ * re-pairing in flight; it supersedes the old one once it becomes trusted).
+ * Without any trusted link, the newest wins.
+ */
 export function planSupersession(links: readonly SupersessionLinkRow[]): Array<{ linkId: string; supersededBy: string }> {
-  const groups = new Map<string, SupersessionLinkRow[]>();
-  for (const link of links) {
-    if (link.role !== "same-org-peer") continue;
-    const key = link.peerInstallationId ? `inst:${link.peerInstallationId}` : `url:${normalizeAuthorityUrl(link.peerAuthorityUrl)}`;
-    groups.set(key, [...(groups.get(key) ?? []), link]);
+  const sameOrg = links.filter((link) => link.role === "same-org-peer");
+  // Union-find over identity keys so a link joins every group it shares a key with.
+  const parent = new Map<string, string>();
+  const find = (key: string): string => {
+    let root = key;
+    while (parent.get(root) && parent.get(root) !== root) root = parent.get(root)!;
+    parent.set(key, root);
+    return root;
+  };
+  const union = (a: string, b: string) => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent.set(ra, rb);
+  };
+  for (const link of sameOrg) {
+    const urlKey = `url:${normalizeAuthorityUrl(link.peerAuthorityUrl)}`;
+    if (!parent.has(urlKey)) parent.set(urlKey, urlKey);
+    if (link.peerInstallationId) {
+      const instKey = `inst:${link.peerInstallationId}`;
+      if (!parent.has(instKey)) parent.set(instKey, instKey);
+      union(instKey, urlKey);
+    }
   }
+  const groups = new Map<string, SupersessionLinkRow[]>();
+  for (const link of sameOrg) {
+    const root = find(`url:${normalizeAuthorityUrl(link.peerAuthorityUrl)}`);
+    groups.set(root, [...(groups.get(root) ?? []), link]);
+  }
+
   const plan: Array<{ linkId: string; supersededBy: string }> = [];
   for (const group of groups.values()) {
     if (group.length < 2) continue;
-    const ordered = [...group].sort((a, b) => {
-      const ta = (a.enrolledAt ?? a.createdAt).getTime();
-      const tb = (b.enrolledAt ?? b.createdAt).getTime();
-      return tb - ta || a.linkId.localeCompare(b.linkId);
-    });
-    const winner = ordered[0]!;
-    for (const loser of ordered.slice(1)) plan.push({ linkId: loser.linkId, supersededBy: winner.linkId });
+    const byNewest = [...group].sort((a, b) => enrolledMs(b) - enrolledMs(a) || a.linkId.localeCompare(b.linkId));
+    const trusted = byNewest.filter(isTrusted);
+    const winner = trusted[0] ?? byNewest[0]!;
+    for (const link of byNewest) {
+      if (link.linkId === winner.linkId) continue;
+      // A pending re-pairing newer than the trusted winner is in flight; leave it.
+      if (trusted.length > 0 && !isTrusted(link) && enrolledMs(link) > enrolledMs(winner)) continue;
+      plan.push({ linkId: link.linkId, supersededBy: winner.linkId });
+    }
   }
   return plan;
 }
@@ -64,7 +112,7 @@ export async function supersedeStaleSameOrgLinks(
 ): Promise<{ revoked: Array<{ linkId: string; supersededBy: string }> }> {
   const links = await db.federationLink.findMany({
     where: { role: "same-org-peer", revokedAt: null },
-    select: { linkId: true, role: true, peerAuthorityUrl: true, peerInstallationId: true, enrolledAt: true, createdAt: true },
+    select: { linkId: true, role: true, linkState: true, peerAuthorityUrl: true, peerInstallationId: true, enrolledAt: true, createdAt: true },
   });
   const plan = planSupersession(links);
   for (const entry of plan) {

--- a/docs/superpowers/specs/2026-09-02-zero-configuration-organization-federation-design.md
+++ b/docs/superpowers/specs/2026-09-02-zero-configuration-organization-federation-design.md
@@ -121,9 +121,13 @@ peer's token in clear, which is why it is in the ledger.
 
 ### 5.3 Supersession
 
-Among non-revoked `same-org-peer` links, group by `peerInstallationId` when
-known, else by normalised `peerAuthorityUrl`. The newest `enrolledAt` wins; the
-rest are revoked with reason `superseded-by:<linkId>`. Runs at boot, on every
+Among non-revoked `same-org-peer` links, group by `peerInstallationId` and by
+normalised `peerAuthorityUrl`, merged transitively (a pending link that never
+learned the peer's id joins the trusted link at the same address). Trust
+outranks age: a trusted link is never superseded by a pending one; among
+trusted links the newest `enrolledAt` wins; a pending link enrolled after the
+winner is a re-pairing in flight and is left alone until it becomes trusted.
+The rest are revoked with reason `superseded-by:<linkId>`. Runs at boot, on every
 federation tick, and after any enrolment. On production this retires the two
 links from earlier install cycles without a click.
 


### PR DESCRIPTION
## Why

After slice 1 (#4998) deployed to the development install, its pending duplicate link to production survived the first reconcile: it never learned the peer's installation id, so it grouped by address while the trusted link grouped by id. Newest-wins would also have let a pending re-pairing outrank a trusted link.

## What

- Groups are merged transitively over both keys (installation id and normalised authority URL).
- Trust outranks age: a trusted link is never superseded by a pending one; among trusted links the newest wins; a pending link newer than the winner is a re-pairing in flight and is left alone.
- Spec §5.3 updated; three new cases in `link-supersession.test.ts`.

## Verification

`link-supersession.test.ts` 5/5. Live after deploy: the development install's pending duplicate (link_686fddaa2e444232) is revoked `superseded-by:link_37ca66f54b184bb3` on the next tick.

Epic: EP-ZERO-CONFIG-FEDERATION · Backlog: BI-DF5F045F

Design-Grounding-Decision: update-existing-spec (§5.3)
Docs-Impact-Decision: spec updated in this PR
Seed-Fit-Decision: not-applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)