### PR TITLE
fix(federation): serve rows that have no prose — NULL column dropped 29 production epics from work sync

### DIFF
--- a/apps/web/lib/federation/work-page.test.ts
+++ b/apps/web/lib/federation/work-page.test.ts
@@ -17,7 +17,7 @@ function row(itemId: string, overrides: Partial<WorkPageItemRow> = {}): WorkPage
   };
 }
 
-function db(items: WorkPageItemRow[]): WorkPageDb & { backlogItem: { findMany: ReturnType<typeof vi.fn> } } {
+function db(items: WorkPageItemRow[]): WorkPageDb & { backlogItem: { findMany: ReturnType<typeof vi.fn> }; epic: { findMany: ReturnType<typeof vi.fn> } } {
   return {
     backlogItem: { findMany: vi.fn().mockResolvedValue(items) },
     epic: { findMany: vi.fn().mockResolvedValue([{
@@ -39,7 +39,10 @@ describe("buildFederatedWorkPage", () => {
     // Local-only sensitivities and mirrored rows are excluded at the SQL layer.
     const where = store.backlogItem.findMany.mock.calls[0]![0].where;
     expect(where.sensitivity.notIn).toEqual(["confidential", "restricted"]);
-    expect(where.NOT.body.contains).toBe("[origin:federatedWork:");
+    // A row with no prose is owned: NOT-contains alone is NULL for a NULL column.
+    expect(where.OR).toEqual([{ body: null }, { NOT: { body: { contains: "[origin:federatedWork:" } } }]);
+    const epicWhere = store.epic.findMany.mock.calls[0]![0].where;
+    expect(epicWhere.OR).toEqual([{ description: null }, { NOT: { description: { contains: "[origin:federatedWork:" } } }]);
   });
 
   it("never serves a mirror back, even when the SQL predicate let it through", async () => {

--- a/apps/web/lib/federation/work-page.ts
+++ b/apps/web/lib/federation/work-page.ts
@@ -100,10 +100,20 @@ function toEpic(row: WorkPageEpicRow): FederatedWorkEpicV1 {
   };
 }
 
-/** Where-clause shared by every reader that must skip mirrored rows. */
+/**
+ * Where-clause shared by every reader that must skip mirrored rows. The prose
+ * columns are nullable, and `NOT (col LIKE …)` is NULL — not true — for a NULL
+ * column, so a bare NOT-contains silently dropped every row that had no prose
+ * (29 production epics and 8 development epics never crossed). A row with no
+ * prose cannot carry a marker and is owned.
+ */
 export const OWNED_BACKLOG_WHERE = {
   sensitivity: { notIn: [...FEDERATED_WORK_LOCAL_ONLY_SENSITIVITIES] },
-  NOT: { body: { contains: FEDERATED_WORK_ORIGIN_MARKER_PREFIX } },
+  OR: [{ body: null }, { NOT: { body: { contains: FEDERATED_WORK_ORIGIN_MARKER_PREFIX } } }],
+} as const;
+
+export const OWNED_EPIC_WHERE = {
+  OR: [{ description: null }, { NOT: { description: { contains: FEDERATED_WORK_ORIGIN_MARKER_PREFIX } } }],
 } as const;
 
 export async function buildFederatedWorkPage(
@@ -139,7 +149,7 @@ export async function buildFederatedWorkPage(
   const epics = input.cursor
     ? []
     : (await db.epic.findMany({
-        where: { NOT: { description: { contains: FEDERATED_WORK_ORIGIN_MARKER_PREFIX } } },
+        where: OWNED_EPIC_WHERE,
         orderBy: { epicId: "asc" },
         select: {
           epicId: true, title: true, description: true, status: true, priority: true,

--- a/apps/web/lib/queue/functions/backlog-triage-drain.ts
+++ b/apps/web/lib/queue/functions/backlog-triage-drain.ts
@@ -40,8 +40,9 @@ export const backlogTriageDrain = inngest.createFunction(
         where: {
           status: "triaging",
           // A work-sync mirror is triaged by the installation that owns it;
-          // triaging the copy here would fork the record (BI-FF8A57EF).
-          NOT: { body: { contains: "[origin:federatedWork:" } },
+          // triaging the copy here would fork the record (BI-FF8A57EF). A row
+          // with no body is owned: NOT-contains alone is NULL for a NULL column.
+          OR: [{ body: null }, { NOT: { body: { contains: "[origin:federatedWork:" } } }],
         },
         orderBy: { createdAt: "asc" },
         take: MAX_PER_RUN,


### PR DESCRIPTION
## Why
After a full sync the two paired installs showed 107 vs 86 epics. Production holds 86 own epics but served only 57; development owns 32 and served 24 (before id conflicts). The missing rows all have `description IS NULL` (or `body IS NULL` for items).

`NOT (col LIKE '%[origin:federatedWork:%')` evaluates to NULL for a NULL column, so Prisma's `NOT: { col: { contains } }` excludes every row without prose.

## What
- `OWNED_BACKLOG_WHERE` and new `OWNED_EPIC_WHERE` in `apps/web/lib/federation/work-page.ts`: `OR: [{ col: null }, { NOT: { col: { contains } } }]`.
- Same fix in `backlog-triage-drain.ts` (body-less rows were skipped by triage).
- Test asserts both predicates.

Rows without prose cannot carry an origin marker, so they are owned by definition. Wire contract `dpf.work-sync/1` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
