### PR TITLE
fix(self-upgrade): the status target is the remote head, not a stale local ref (BI-4746F2A9)

### DIFF
--- a/apps/web/lib/self-upgrade/impact/change-set.ts
+++ b/apps/web/lib/self-upgrade/impact/change-set.ts
@@ -3,9 +3,10 @@
 // Collect the upstream change set as RawCommit[] from `git log <a>..<b>` over
 // the host clone — mirrors the no-auth read pattern used by
 // resolveTargetSha in apps/web/lib/self-upgrade/version.ts (same execFile
-// dep injection, same HOST_SOURCE_PATH default). No git fetch here — the
-// caller is expected to have already run buildFetchCommand before
-// resolveTargetSha, so the upstream ref is fresh.
+// dep injection, same HOST_SOURCE_PATH default). No git fetch here —
+// resolveTargetSha freshens the local ref itself whenever the remote head is
+// ahead of it (BI-4746F2A9), so the target's objects are present by the time
+// this range is walked.
 
 import type { RawCommit } from "./types";
 

--- a/apps/web/lib/self-upgrade/impact/index.ts
+++ b/apps/web/lib/self-upgrade/impact/index.ts
@@ -139,7 +139,7 @@ export async function summarizeUpgradeImpact(
       ok: false,
       reason: "no-target",
       detail:
-        "Could not resolve the upstream target SHA. Confirm the host clone has a fresh fetch of the configured remote/branch.",
+        "Could not resolve the upstream target SHA: the configured remote did not answer and the host clone has no local ref for the branch.",
     };
   }
   if (currentLineageSha === targetSha) {

--- a/apps/web/lib/self-upgrade/version.test.ts
+++ b/apps/web/lib/self-upgrade/version.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildRemoteHeadCommand,
@@ -10,7 +10,10 @@ import {
   compareUpgradeVersions,
   getUpgradeVersionState,
   isShaFresh,
+  parseRemoteHeadSha,
+  resetTargetShaCacheForTests,
   resolveTargetSha,
+  TARGET_SHA_CACHE_TTL_MS,
 } from "./version";
 
 describe("compareUpgradeVersions", () => {
@@ -143,43 +146,158 @@ describe("isShaFresh", () => {
   });
 });
 
-describe("resolveTargetSha", () => {
-  it("resolves the configured repository branch head as the target SHA", async () => {
-    const execFile = vi.fn().mockResolvedValue({
-      stdout: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+describe("parseRemoteHeadSha", () => {
+  const sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+  it("picks the SHA on the refs/heads/<branch> line and ignores other refs", () => {
+    const stdout = `${"c".repeat(40)}\trefs/heads/main-old\n${sha.toUpperCase()}\trefs/heads/main\n`;
+    expect(parseRemoteHeadSha(stdout, "main")).toBe(sha);
+  });
+
+  it("returns null when the branch is not listed or the SHA is malformed", () => {
+    expect(parseRemoteHeadSha("", "main")).toBeNull();
+    expect(parseRemoteHeadSha("not-a-sha\trefs/heads/main\n", "main")).toBeNull();
+    expect(parseRemoteHeadSha(`${sha}\trefs/heads/release\n`, "main")).toBeNull();
+  });
+});
+
+describe("resolveTargetSha (BI-4746F2A9: the target is the REMOTE head)", () => {
+  const remoteSha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+  const localSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const at = { hostSourceMountPath: "/host-source", repositoryRemote: "upstream", repositoryBranch: "release" };
+  const lsArgs = ["-C", "/host-source", "ls-remote", "--heads", "upstream", "release"];
+  const revParseArgs = ["-C", "/host-source", "rev-parse", "upstream/release"];
+  const fetchArgs = ["-C", "/host-source", "fetch", "upstream", "release"];
+
+  /** A fake git: answers by sub-command so the test states what each ref says. */
+  function fakeGit(answers: { lsRemote?: string | Error; local?: string | Error; fetch?: Error }) {
+    return vi.fn(async (_cmd: string, args: string[]) => {
+      const sub = args[2];
+      if (sub === "ls-remote") {
+        if (answers.lsRemote instanceof Error) throw answers.lsRemote;
+        return { stdout: answers.lsRemote ?? "" };
+      }
+      if (sub === "rev-parse") {
+        if (answers.local instanceof Error) throw answers.local;
+        return { stdout: answers.local ?? "" };
+      }
+      if (sub === "fetch") {
+        if (answers.fetch) throw answers.fetch;
+        return { stdout: "" };
+      }
+      throw new Error(`unexpected git ${args.join(" ")}`);
+    });
+  }
+
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    resetTargetShaCacheForTests();
+    consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("asks the remote, not the local ref, and freshens the local ref when it is behind", async () => {
+    const execFile = fakeGit({ lsRemote: `${remoteSha}\trefs/heads/release\n`, local: `${localSha}\n` });
+
+    await expect(resolveTargetSha("stable", at, { execFile })).resolves.toBe(remoteSha);
+
+    expect(execFile).toHaveBeenCalledWith("git", lsArgs);
+    expect(execFile).toHaveBeenCalledWith("git", revParseArgs);
+    expect(execFile).toHaveBeenCalledWith("git", fetchArgs);
+  });
+
+  it("does not fetch when the local ref already matches the remote", async () => {
+    const execFile = fakeGit({ lsRemote: `${remoteSha}\trefs/heads/release\n`, local: `${remoteSha}\n` });
+
+    await expect(resolveTargetSha("stable", at, { execFile })).resolves.toBe(remoteSha);
+
+    expect(execFile).not.toHaveBeenCalledWith("git", fetchArgs);
+  });
+
+  it("still answers with the remote SHA when the freshening fetch fails", async () => {
+    const execFile = fakeGit({
+      lsRemote: `${remoteSha}\trefs/heads/release\n`,
+      local: `${localSha}\n`,
+      fetch: new Error("index.lock held"),
     });
 
-    const result = await resolveTargetSha(
-      "stable",
-      {
-        hostSourceMountPath: "/host-source",
-        repositoryRemote: "upstream",
-        repositoryBranch: "release",
-      },
-      { execFile },
-    );
-
-    expect(result).toBe("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-    expect(execFile).toHaveBeenCalledWith(
-      "git",
-      ["-C", "/host-source", "rev-parse", "upstream/release"],
+    await expect(resolveTargetSha("stable", at, { execFile })).resolves.toBe(remoteSha);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "self-upgrade.target-fetch-skipped",
+      expect.objectContaining({ channel: "stable", message: expect.stringContaining("index.lock") }),
     );
   });
 
-  it("returns null and logs when the resolved target is not a git SHA", async () => {
-    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+  it("falls back to the local ref when the remote is unreachable, and says so", async () => {
+    const execFile = fakeGit({ lsRemote: new Error("Could not resolve host"), local: `${localSha}\n` });
 
-    const result = await resolveTargetSha(
-      "stable",
-      { hostSourceMountPath: "/host-source" },
-      { execFile: vi.fn().mockResolvedValue({ stdout: "not-a-sha\n" }) },
-    );
+    await expect(resolveTargetSha("stable", at, { execFile })).resolves.toBe(localSha);
 
-    expect(result).toBeNull();
+    expect(execFile).not.toHaveBeenCalledWith("git", fetchArgs);
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("self-upgrade.no-target"),
+      "self-upgrade.target-from-local-ref",
+      expect.objectContaining({
+        channel: "stable",
+        reason: "remote-unreachable",
+        message: expect.stringContaining("Could not resolve host"),
+      }),
+    );
+  });
+
+  it("returns null and logs when neither the remote nor the local ref yields a git SHA", async () => {
+    const execFile = fakeGit({ lsRemote: "", local: "not-a-sha\n" });
+
+    await expect(resolveTargetSha("stable", at, { execFile })).resolves.toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "self-upgrade.no-target",
       expect.objectContaining({ channel: "stable", reason: "target-not-git-sha" }),
     );
-    consoleSpy.mockRestore();
+  });
+
+  it("returns null and logs when every git call fails", async () => {
+    const execFile = fakeGit({ lsRemote: new Error("offline"), local: new Error("not a git repository") });
+
+    await expect(resolveTargetSha("stable", at, { execFile })).resolves.toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "self-upgrade.no-target",
+      expect.objectContaining({ channel: "stable", reason: "target-resolution-failed" }),
+    );
+  });
+
+  it("caches the remote answer for about a minute, then asks again", async () => {
+    const execFile = fakeGit({ lsRemote: `${remoteSha}\trefs/heads/release\n`, local: `${remoteSha}\n` });
+    let clock = 1_000_000;
+    const now = () => clock;
+
+    await resolveTargetSha("stable", at, { execFile }, { now });
+    await resolveTargetSha("stable", at, { execFile }, { now });
+    expect(execFile.mock.calls.filter(([, args]) => args[2] === "ls-remote")).toHaveLength(1);
+
+    clock += TARGET_SHA_CACHE_TTL_MS + 1;
+    await resolveTargetSha("stable", at, { execFile }, { now });
+    expect(execFile.mock.calls.filter(([, args]) => args[2] === "ls-remote")).toHaveLength(2);
+  });
+
+  it("does not cache a miss, so the next render asks the remote again", async () => {
+    const execFile = fakeGit({ lsRemote: new Error("offline"), local: "" });
+
+    await expect(resolveTargetSha("stable", at, { execFile })).resolves.toBeNull();
+    await expect(resolveTargetSha("stable", at, { execFile })).resolves.toBeNull();
+    expect(execFile.mock.calls.filter(([, args]) => args[2] === "ls-remote")).toHaveLength(2);
+  });
+
+  it("shares one in-flight remote call between concurrent renders", async () => {
+    const execFile = fakeGit({ lsRemote: `${remoteSha}\trefs/heads/release\n`, local: `${remoteSha}\n` });
+
+    const results = await Promise.all([
+      resolveTargetSha("stable", at, { execFile }),
+      resolveTargetSha("stable", at, { execFile }),
+      resolveTargetSha("stable", at, { execFile }),
+    ]);
+
+    expect(results).toEqual([remoteSha, remoteSha, remoteSha]);
+    expect(execFile.mock.calls.filter(([, args]) => args[2] === "ls-remote")).toHaveLength(1);
   });
 });

--- a/apps/web/lib/self-upgrade/version.ts
+++ b/apps/web/lib/self-upgrade/version.ts
@@ -179,37 +179,177 @@ export async function getUpgradeVersionState(
   return compareUpgradeVersions(currentSha, targetSha);
 }
 
-// ─── Compatibility Exports ────────────────────────────────────────────────────
+// ─── Remote Target Resolution (BI-4746F2A9) ───────────────────────────────────
+// The status page and the impact summary used to read `rev-parse origin/main`,
+// a LOCAL remote-tracking ref that only moves when something fetches — the
+// upgrade run itself or the 24h-throttled scheduled poll. A source-mode install
+// therefore said "up to date" (and hid "Upgrade now") for a day after a fix was
+// published. "Up to date" must be a statement about upstream, so the target is
+// asked of the remote (`git ls-remote`), which touches no local ref and holds no
+// lock, bounded by a short cache. When the local ref is behind the remote, one
+// single-ref fetch freshens it so the change-set `git log` has the objects. If
+// the remote is unreachable the local ref is the honest fallback and the reason
+// is logged. The RUN path (queue/functions/self-upgrade.ts) already fetches
+// before it resolves and is unchanged.
 
-export async function resolveTargetSha(
-  channel: string,
-  config: TargetResolverConfig = {},
-  deps: Pick<VersionStateDeps, "execFile"> = DEFAULT_DEPS,
+/** `git -C <path> ls-remote --heads <remote> <branch>` — ask upstream, not the local ref. */
+export function buildRemoteLsCommand(input: {
+  hostSourcePath: string;
+  remote: string;
+  branch: string;
+}): string[] {
+  return ["git", "-C", input.hostSourcePath, "ls-remote", "--heads", input.remote, input.branch];
+}
+
+/** The SHA on the `refs/heads/<branch>` line of `ls-remote --heads` output, or null. */
+export function parseRemoteHeadSha(stdout: string, branch: string): string | null {
+  const wanted = `refs/heads/${branch}`;
+  for (const rawLine of stdout.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const tab = line.indexOf("\t");
+    const sha = tab === -1 ? line : line.slice(0, tab);
+    const ref = tab === -1 ? "" : line.slice(tab + 1).trim();
+    if (ref === wanted && isGitSha(sha)) return sha.toLowerCase();
+  }
+  return null;
+}
+
+/** How long one remote answer stands in for every status render (~1 min). */
+export const TARGET_SHA_CACHE_TTL_MS = 60_000;
+
+export type TargetShaSource = "remote" | "local-ref";
+
+type TargetShaCacheEntry = {
+  sha: string | null;
+  source: TargetShaSource | null;
+  resolvedAt: number;
+};
+
+const targetShaCache = new Map<string, TargetShaCacheEntry>();
+const targetShaInFlight = new Map<string, Promise<TargetShaCacheEntry>>();
+
+/** Test seam: forget every cached remote answer. */
+export function resetTargetShaCacheForTests(): void {
+  targetShaCache.clear();
+  targetShaInFlight.clear();
+}
+
+async function readLocalRef(
+  at: { hostSourcePath: string; remote: string; branch: string },
+  execFile: VersionStateDeps["execFile"],
 ): Promise<string | null> {
-  const [, ...gitArgs] = buildRemoteHeadCommand({
-    hostSourcePath: config.hostSourceMountPath ?? process.env.HOST_SOURCE_PATH ?? "/workspace",
-    remote: config.repositoryRemote ?? process.env.REPO_REMOTE ?? "origin",
-    branch: config.repositoryBranch ?? process.env.REPO_BRANCH ?? "main",
-  });
+  const [, ...gitArgs] = buildRemoteHeadCommand(at);
+  const { stdout } = await execFile("git", gitArgs);
+  const sha = stdout.trim();
+  return isGitSha(sha) ? sha.toLowerCase() : null;
+}
 
+async function resolveTargetShaUncached(
+  channel: string,
+  at: { hostSourcePath: string; remote: string; branch: string },
+  execFile: VersionStateDeps["execFile"],
+): Promise<TargetShaCacheEntry> {
+  const resolvedAt = Date.now();
+  let remoteFailure: string | null = null;
   try {
-    const { stdout } = await deps.execFile("git", gitArgs);
-    const targetSha = stdout.trim();
-    if (isGitSha(targetSha)) return targetSha;
+    const [, ...lsArgs] = buildRemoteLsCommand(at);
+    const { stdout } = await execFile("git", lsArgs);
+    const remoteSha = parseRemoteHeadSha(stdout, at.branch);
+    if (remoteSha) {
+      // Freshen the local ref only when it is actually behind, so the impact
+      // summary's `git log <lineage>..<target>` can see the target's objects.
+      // Best effort: a failed fetch does not change the answer.
+      let localSha: string | null = null;
+      try {
+        localSha = await readLocalRef(at, execFile);
+      } catch {
+        localSha = null;
+      }
+      if (localSha !== remoteSha) {
+        try {
+          const [, ...fetchArgs] = buildFetchCommand(at);
+          await execFile("git", fetchArgs);
+        } catch (err) {
+          console.info("self-upgrade.target-fetch-skipped", {
+            channel,
+            message: getErrorMessage(err),
+          });
+        }
+      }
+      return { sha: remoteSha, source: "remote", resolvedAt };
+    }
+    remoteFailure = "remote-head-not-listed";
+  } catch (err) {
+    remoteFailure = getErrorMessage(err);
+  }
+
+  // The remote could not answer: the local ref is the honest fallback, and the
+  // reason it is being used is said, not swallowed.
+  try {
+    const localSha = await readLocalRef(at, execFile);
+    if (localSha) {
+      console.info("self-upgrade.target-from-local-ref", {
+        channel,
+        reason: "remote-unreachable",
+        message: remoteFailure,
+      });
+      return { sha: localSha, source: "local-ref", resolvedAt };
+    }
     console.info("self-upgrade.no-target", {
       channel,
       reason: "target-not-git-sha",
-      targetSha,
+      message: remoteFailure,
     });
-    return null;
+    return { sha: null, source: null, resolvedAt };
   } catch (err) {
     console.info("self-upgrade.no-target", {
       channel,
       reason: "target-resolution-failed",
-      message: getErrorMessage(err),
+      message: `${remoteFailure}; ${getErrorMessage(err)}`,
     });
-    return null;
+    return { sha: null, source: null, resolvedAt };
   }
+}
+
+/**
+ * Resolve the upgrade target for STATUS surfaces (the page, the impact
+ * summary): the remote branch head, cached for TARGET_SHA_CACHE_TTL_MS and
+ * shared by concurrent renders. Returns null when neither the remote nor the
+ * local ref yields a git SHA.
+ */
+export async function resolveTargetSha(
+  channel: string,
+  config: TargetResolverConfig = {},
+  deps: Pick<VersionStateDeps, "execFile"> = DEFAULT_DEPS,
+  options: { now?: () => number } = {},
+): Promise<string | null> {
+  const at = {
+    hostSourcePath: config.hostSourceMountPath ?? process.env.HOST_SOURCE_PATH ?? "/workspace",
+    remote: config.repositoryRemote ?? process.env.REPO_REMOTE ?? "origin",
+    branch: config.repositoryBranch ?? process.env.REPO_BRANCH ?? "main",
+  };
+  const key = `${at.hostSourcePath} ${at.remote} ${at.branch}`;
+  const now = options.now?.() ?? Date.now();
+  const cached = targetShaCache.get(key);
+  if (cached && cached.sha && now - cached.resolvedAt < TARGET_SHA_CACHE_TTL_MS) {
+    return cached.sha;
+  }
+  let pending = targetShaInFlight.get(key);
+  if (!pending) {
+    pending = resolveTargetShaUncached(channel, at, deps.execFile)
+      .then((entry) => {
+        // A miss is not cached: the next render asks again rather than hiding
+        // "Upgrade now" for a minute because one call happened to time out.
+        if (entry.sha) targetShaCache.set(key, { ...entry, resolvedAt: now });
+        return entry;
+      })
+      .finally(() => {
+        targetShaInFlight.delete(key);
+      });
+    targetShaInFlight.set(key, pending);
+  }
+  return (await pending).sha;
 }
 
 export function isShaFresh(deployedSha: string | null, targetSha: string): boolean {


### PR DESCRIPTION
## What

`resolveTargetSha` (the `/ops/self-upgrade` status page and the impact summary) resolved the upgrade target from `git rev-parse origin/main`, a LOCAL remote-tracking ref that only moves when something fetches (the upgrade run itself, or the scheduled poll throttled to `checkIntervalHours` = 24 h). A source-mode install therefore said "Your platform is up to date" for a day after a fix was published, with "Upgrade now" hidden the whole time.

Observed on production 192.168.0.152 on 2026-09-02: Target `c4947221` for 40+ minutes after main reached `e9f67ce2` (BI-4746F2A9).

## Fix

- Ask the remote: `git ls-remote --heads <remote> <branch>` (touches no local ref, holds no lock), cached ~1 minute, one in-flight call shared by concurrent renders.
- When the local ref is behind the remote, run one single-ref fetch so the impact summary's `git log <lineage>..<target>` can see the target's objects.
- If the remote cannot answer, fall back to the local ref and log `self-upgrade.target-from-local-ref` with the reason. A miss is not cached.
- The run path (`queue/functions/self-upgrade.ts`) already fetched before resolving and is unchanged.

## Verification

- `pnpm --filter web exec vitest run lib/self-upgrade/version.test.ts lib/self-upgrade/status-target.test.ts lib/self-upgrade/impact/index.test.ts` — 61/61.
- `pnpm --filter web typecheck` — clean.
- Local gates (design-grounding, docs-impact, plan-backlog-coverage) — OK.

Backlog: BI-4746F2A9 (EP-ZERO-CONFIG-FEDERATION).

Design-Grounding-Decision: no-contract-change (status-only read path; the run path, wire contracts and schema are untouched)
Process-Spine-Decision: localized fix inside the self-upgrade status read path; the run path, wire contracts and operator procedure are unchanged
Docs-Impact-Decision: internal target-resolution change in the self-upgrade status read path; no operator-facing procedure changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
