### PR TITLE
fix(federation): the work-sync marker prefilter no longer hides an owned item that mentions the marker in prose (BI-C97CE534)

### DIFF
--- a/apps/web/lib/federation/channel-demand.ts
+++ b/apps/web/lib/federation/channel-demand.ts
@@ -8,6 +8,7 @@ import {
   type ChannelDemandPolicy,
 } from "@dpf/db/federated-channel";
 import { DEMAND_PROJECTION_TEMPLATES } from "@dpf/db/federated-demand-contract";
+import { hasFederatedWorkOriginMarker } from "@dpf/db/federated-work-contract";
 import {
   isFederationRole,
   type FederationRole,
@@ -264,7 +265,7 @@ export async function selectLocalDemandForLink(
   if ((item.body ?? "").includes("[origin:federatedDemand:")) {
     throw new Error("Adopted demand must use governed forwarding so original provenance is preserved.");
   }
-  if ((item.body ?? "").includes("[origin:federatedWork:")) {
+  if (hasFederatedWorkOriginMarker(item.body)) {
     throw new Error("This item is mirrored from another installation in your organization; share it from the installation that owns it.");
   }
   // Cross-org gate (BI-DC4E526E, kernel DI-3E77E48D5710) — CONTEXT-DERIVED, so no

--- a/apps/web/lib/federation/demand-read-model.ts
+++ b/apps/web/lib/federation/demand-read-model.ts
@@ -1,6 +1,7 @@
 import { cache } from "react";
 
 import { prisma } from "@dpf/db";
+import { FEDERATED_WORK_ORIGIN_MARKER_SQL_PREFIX } from "@dpf/db/federated-work-contract";
 
 import { decodeDemandMirrorPayload, type DemandDisposition } from "./demand-exchange";
 import { decodeDemandResponseMirrorPayload } from "./demand-response";
@@ -181,7 +182,7 @@ export const getDemandShareContext = cache(async (): Promise<DemandShareContext>
         NOT: [
           { body: { contains: "[origin:federatedDemand:" } },
           // A work-sync mirror is not local demand to share (BI-FF8A57EF).
-          { body: { contains: "[origin:federatedWork:" } },
+          { body: { contains: FEDERATED_WORK_ORIGIN_MARKER_SQL_PREFIX } },
         ],
       },
       select: { itemId: true, title: true, status: true },

--- a/apps/web/lib/federation/work-page.test.ts
+++ b/apps/web/lib/federation/work-page.test.ts
@@ -40,9 +40,20 @@ describe("buildFederatedWorkPage", () => {
     const where = store.backlogItem.findMany.mock.calls[0]![0].where;
     expect(where.sensitivity.notIn).toEqual(["confidential", "restricted"]);
     // A row with no prose is owned: NOT-contains alone is NULL for a NULL column.
-    expect(where.OR).toEqual([{ body: null }, { NOT: { body: { contains: "[origin:federatedWork:" } } }]);
+    expect(where.OR).toEqual([{ body: null }, { NOT: { body: { contains: "[origin:federatedWork:inst_" } } }]);
     const epicWhere = store.epic.findMany.mock.calls[0]![0].where;
-    expect(epicWhere.OR).toEqual([{ description: null }, { NOT: { description: { contains: "[origin:federatedWork:" } } }]);
+    expect(epicWhere.OR).toEqual([{ description: null }, { NOT: { description: { contains: "[origin:federatedWork:inst_" } } }]);
+  });
+
+  it("serves an owned row whose prose merely mentions the marker (BI-C97CE534)", async () => {
+    // BI-FF8A57EF describes the mechanism as `[origin:federatedWork:<inst>:<id>]`;
+    // that text must not hide the item from the paired installation.
+    const prose = row("BI-FF8A57EF", { body: "Mirrors carry a `[origin:federatedWork:<inst>:<id>]` last line." });
+    const store = db([row("BI-A"), prose]);
+    const page = await buildFederatedWorkPage(store, { originInstallationId: origin, cursor: null, limit: 10, now: at });
+    expect(page.items.map((i) => i.itemId)).toEqual(["BI-A", "BI-FF8A57EF"]);
+    const prefix = store.backlogItem.findMany.mock.calls[0]![0].where.OR[1].NOT.body.contains;
+    expect("Mirrors carry a `[origin:federatedWork:<inst>:<id>]` last line.".includes(prefix)).toBe(false);
   });
 
   it("never serves a mirror back, even when the SQL predicate let it through", async () => {

--- a/apps/web/lib/federation/work-page.ts
+++ b/apps/web/lib/federation/work-page.ts
@@ -9,7 +9,7 @@
 
 import {
   FEDERATED_WORK_LOCAL_ONLY_SENSITIVITIES,
-  FEDERATED_WORK_ORIGIN_MARKER_PREFIX,
+  FEDERATED_WORK_ORIGIN_MARKER_SQL_PREFIX,
   FEDERATED_WORK_SPEC_VERSION,
   hasFederatedWorkOriginMarker,
   type FederatedWorkEpicV1,
@@ -109,11 +109,11 @@ function toEpic(row: WorkPageEpicRow): FederatedWorkEpicV1 {
  */
 export const OWNED_BACKLOG_WHERE = {
   sensitivity: { notIn: [...FEDERATED_WORK_LOCAL_ONLY_SENSITIVITIES] },
-  OR: [{ body: null }, { NOT: { body: { contains: FEDERATED_WORK_ORIGIN_MARKER_PREFIX } } }],
+  OR: [{ body: null }, { NOT: { body: { contains: FEDERATED_WORK_ORIGIN_MARKER_SQL_PREFIX } } }],
 } as const;
 
 export const OWNED_EPIC_WHERE = {
-  OR: [{ description: null }, { NOT: { description: { contains: FEDERATED_WORK_ORIGIN_MARKER_PREFIX } } }],
+  OR: [{ description: null }, { NOT: { description: { contains: FEDERATED_WORK_ORIGIN_MARKER_SQL_PREFIX } } }],
 } as const;
 
 export async function buildFederatedWorkPage(

--- a/apps/web/lib/queue/functions/backlog-triage-drain.ts
+++ b/apps/web/lib/queue/functions/backlog-triage-drain.ts
@@ -1,4 +1,5 @@
 import { cron } from "inngest";
+import { FEDERATED_WORK_ORIGIN_MARKER_SQL_PREFIX } from "@dpf/db/federated-work-contract";
 import { inngest } from "../inngest-client";
 import { gateAtEntry } from "../quiescence-gates";
 
@@ -42,7 +43,7 @@ export const backlogTriageDrain = inngest.createFunction(
           // A work-sync mirror is triaged by the installation that owns it;
           // triaging the copy here would fork the record (BI-FF8A57EF). A row
           // with no body is owned: NOT-contains alone is NULL for a NULL column.
-          OR: [{ body: null }, { NOT: { body: { contains: "[origin:federatedWork:" } } }],
+          OR: [{ body: null }, { NOT: { body: { contains: FEDERATED_WORK_ORIGIN_MARKER_SQL_PREFIX } } }],
         },
         orderBy: { createdAt: "asc" },
         take: MAX_PER_RUN,

--- a/packages/db/src/federated-work-contract.ts
+++ b/packages/db/src/federated-work-contract.ts
@@ -88,8 +88,21 @@ export function federatedWorkOriginMarker(originInstallationId: string, recordId
   return `[origin:${ORIGIN_MARKER_KIND}:${originInstallationId}:${recordId}]`;
 }
 
-/** SQL-usable prefix for `NOT { body: { contains } }` exclusions. */
+/** The marker's opening text; used to parse a marker line, never as a SQL predicate. */
 export const FEDERATED_WORK_ORIGIN_MARKER_PREFIX = ORIGIN_MARKER_PREFIX;
+
+/**
+ * SQL prefilter for `NOT { body: { contains } }` exclusions (BI-C97CE534).
+ * A real marker always names an installation id, which the platform mints as
+ * `inst_<hex>`; prose that merely writes `[origin:federatedWork:<inst>:<id>]`
+ * to describe the mechanism does not match this longer prefix, so an owned
+ * row is not hidden from the wire for mentioning it. The predicate is only a
+ * prefilter: every reader re-checks with `hasFederatedWorkOriginMarker`, which
+ * is exact (the marker is a standalone line). A body that quotes a literal
+ * `inst_`-prefixed marker in prose is still excluded here; that is the price
+ * of a substring predicate and is documented, not hidden.
+ */
+export const FEDERATED_WORK_ORIGIN_MARKER_SQL_PREFIX = `${ORIGIN_MARKER_PREFIX}inst_`;
 
 export function hasFederatedWorkOriginMarker(text: string | null | undefined): boolean {
   return (text ?? "").split(/\r?\n/).some((line) => ORIGIN_MARKER_LINE.test(line.trim()));


### PR DESCRIPTION
## What

Every reader that skips work-sync mirrors used `NOT body contains "[origin:federatedWork:"` as its SQL predicate. A real marker is a standalone last line that names an installation id (`inst_<hex>`), but the substring predicate also hid an owned item whose prose merely described the mechanism. BI-FF8A57EF, the item that introduced work sync, never reached the paired installation (BI-C97CE534).

## Fix

- One SQL prefilter, `FEDERATED_WORK_ORIGIN_MARKER_SQL_PREFIX = "[origin:federatedWork:inst_"`, exported from `@dpf/db/federated-work-contract` and used by the work page (items and epics), the demand read model and the triage drain.
- Correctness stays with the exact standalone-line check `hasFederatedWorkOriginMarker`; channel sharing now uses it instead of a bare substring test.
- Measured on the development install: 1,622 rows mention the bare prefix, 1,621 the `inst_` prefix, 1,620 are real mirrors. The fix serves BI-FF8A57EF; the remaining hidden row is BI-C97CE534 itself, which quotes a literal `inst_` marker in prose (documented on the constant).

## Verification

- `vitest run lib/federation/work-page.test.ts lib/federation/work-sync.test.ts lib/federation/channel-demand lib/federation/demand-read-model lib/queue/functions/backlog-triage-drain` — 27/27; `@dpf/db` federated-work-contract — 7/7.
- `pnpm --filter web typecheck` — clean.

Backlog: BI-C97CE534 (EP-ZERO-CONFIG-FEDERATION).

Design-Grounding-Decision: no-contract-change (a SQL prefilter prefix and one call site; the wire contract, marker format and schema are untouched)
Process-Spine-Decision: localized fix in the federation read predicates; no operator procedure or doc surface changed
Docs-Impact-Decision: internal read-predicate change; no user-facing route or procedure changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
