### PR TITLE
fix(worktree): anchor the worktree base on the repository, not the caller (BI-541156EE)

### DIFF
--- a/scripts/check-single-worktree-base.mjs
+++ b/scripts/check-single-worktree-base.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// One worktree base, or none (BI-541156EE).
+//
+// Every location decider in the repo applies the same formula —
+// `<dirname(root)>/<basename(root)>-worktrees` — so two bases can only appear
+// when they are handed different roots. That is exactly what happened: a client
+// hook derived its base from the installed instance (`D:\DPF`, which is not a
+// git repository at all) and produced one pile of 141, while the source scripts
+// derived it from the clone and produced another of 31.
+//
+// The resolver is now anchored on `git rev-parse --git-common-dir`, so there is
+// one answer from anywhere. This guard makes the invariant enforceable rather
+// than merely intended: if git reports linked worktrees under more than one
+// parent directory, a second base has returned and something is deriving its
+// location from the caller instead of the repository.
+//
+// Advisory by default — an existing install can legitimately be mid-migration —
+// and strict under --strict for CI once a repo is converged.
+
+import { execFileSync } from "node:child_process";
+import { isEntryModule } from "./lib/entry-module.mjs";
+import { dirname, resolve } from "node:path";
+
+/** Parse `git worktree list --porcelain` into absolute worktree paths. */
+export function parseWorktreePaths(porcelain) {
+  return String(porcelain ?? "")
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("worktree "))
+    .map((line) => line.slice("worktree ".length).trim())
+    .filter(Boolean);
+}
+
+/**
+ * Group linked worktrees by their parent directory. The main worktree (the
+ * clone itself) is excluded: it is not IN a base, it OWNS one.
+ *
+ * @returns {{ bases: Map<string, string[]>, mainWorktree: string | null }}
+ */
+export function groupByBase(paths) {
+  const normalized = paths.map((p) => resolve(p.replace(/\\/g, "/")));
+  const mainWorktree = normalized.length > 0 ? normalized[0] : null;
+  const bases = new Map();
+  for (const path of normalized.slice(1)) {
+    const base = dirname(path);
+    if (!bases.has(base)) bases.set(base, []);
+    bases.get(base).push(path);
+  }
+  return { bases, mainWorktree };
+}
+
+function main(argv) {
+  const strict = argv.includes("--strict");
+  let porcelain;
+  try {
+    porcelain = execFileSync("git", ["worktree", "list", "--porcelain"], { encoding: "utf8" });
+  } catch (err) {
+    // Not a repository, or git unavailable: nothing to assert about bases.
+    console.log("[single-worktree-base] no git worktree list available — skipping.");
+    return 0;
+  }
+
+  const { bases } = groupByBase(parseWorktreePaths(porcelain));
+
+  if (bases.size <= 1) {
+    const only = [...bases.keys()][0];
+    console.log(
+      bases.size === 0
+        ? "[single-worktree-base] OK — no linked worktrees."
+        : `[single-worktree-base] OK — one base: ${only} (${bases.get(only).length} worktree(s)).`,
+    );
+    return 0;
+  }
+
+  const ordered = [...bases.entries()].sort((a, b) => b[1].length - a[1].length);
+  console.error(`[single-worktree-base] ${bases.size} worktree bases in use — expected 1:`);
+  for (const [base, list] of ordered) {
+    console.error(`  ${list.length.toString().padStart(4)}  ${base}`);
+  }
+  console.error(
+    "\nEvery decider derives <dirname(root)>/<basename(root)>-worktrees, so more than one base\n" +
+      "means something resolved `root` from the caller's directory rather than from the repository.\n" +
+      "Fix the decider to use resolveWorktreeBase() in scripts/lib/worktree-base.mjs, which anchors\n" +
+      "on `git rev-parse --git-common-dir` and gives one answer from anywhere (BI-541156EE).",
+  );
+
+  if (!strict) {
+    console.error("\nAdvisory (no --strict): an install mid-migration can legitimately hold both.");
+    return 0;
+  }
+  return 1;
+}
+
+// Windows drive letters make the naive `file://${argv[1]}` comparison fail
+// (file://D:/... vs file:///D:/...), which silently turns a guard into a no-op.
+if (isEntryModule(import.meta.url)) {
+  process.exit(main(process.argv.slice(2)));
+}
+
+export { main };

--- a/scripts/check-single-worktree-base.test.mjs
+++ b/scripts/check-single-worktree-base.test.mjs
@@ -1,0 +1,92 @@
+// One worktree base, or none (BI-541156EE).
+//
+// The guard exists because seven bases were found on a single host, all
+// produced by the SAME formula handed different roots. These tests pin the two
+// things that make it useful: it groups by parent directory, and it does not
+// count the main worktree as living in a base.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+
+import { parseWorktreePaths, groupByBase } from "./check-single-worktree-base.mjs";
+
+const PORCELAIN = [
+  "worktree D:/DPF-source-root",
+  "HEAD 1111111111111111111111111111111111111111",
+  "branch refs/heads/main",
+  "",
+  "worktree D:/DPF-worktrees/alpha",
+  "HEAD 2222222222222222222222222222222222222222",
+  "branch refs/heads/fix/alpha",
+  "",
+  "worktree D:/DPF-worktrees/beta",
+  "HEAD 3333333333333333333333333333333333333333",
+  "",
+  "worktree D:/DPF-source-root-worktrees/gamma",
+  "HEAD 4444444444444444444444444444444444444444",
+  "",
+].join("\n");
+
+describe("parseWorktreePaths", () => {
+  it("takes only the worktree lines, not HEAD or branch", () => {
+    assert.deepEqual(parseWorktreePaths(PORCELAIN), [
+      "D:/DPF-source-root",
+      "D:/DPF-worktrees/alpha",
+      "D:/DPF-worktrees/beta",
+      "D:/DPF-source-root-worktrees/gamma",
+    ]);
+  });
+
+  it("survives empty or absent input rather than throwing", () => {
+    assert.deepEqual(parseWorktreePaths(""), []);
+    assert.deepEqual(parseWorktreePaths(undefined), []);
+  });
+});
+
+describe("groupByBase", () => {
+  it("groups linked worktrees by parent and excludes the main worktree", () => {
+    // The clone is not IN a base — it OWNS one. Counting it would report a
+    // phantom extra base on every healthy repository.
+    const { bases, mainWorktree } = groupByBase(parseWorktreePaths(PORCELAIN));
+    assert.equal(mainWorktree, resolve("D:/DPF-source-root"));
+    assert.equal(bases.size, 2);
+    assert.equal(bases.get(resolve("D:/DPF-worktrees")).length, 2);
+    assert.equal(bases.get(resolve("D:/DPF-source-root-worktrees")).length, 1);
+  });
+
+  it("reports a single base when everything is converged", () => {
+    const converged = [
+      "worktree D:/DPF-source-root",
+      "",
+      "worktree D:/DPF-source-root-worktrees/one",
+      "",
+      "worktree D:/DPF-source-root-worktrees/two",
+      "",
+    ].join("\n");
+    const { bases } = groupByBase(parseWorktreePaths(converged));
+    assert.equal(bases.size, 1);
+  });
+
+  it("reports no bases for a clone with no linked worktrees", () => {
+    const { bases } = groupByBase(parseWorktreePaths("worktree D:/DPF-source-root\n"));
+    assert.equal(bases.size, 0);
+  });
+
+  it("catches a worktree nested inside another worktree", () => {
+    // Four of the seven bases found on the real host were this: a worktree
+    // created while standing inside a scratch copy, so the formula produced a
+    // base there. The guard must see it as a distinct base, not fold it in.
+    const nested = [
+      "worktree D:/DPF-source-root",
+      "",
+      "worktree D:/DPF-worktrees/alpha",
+      "",
+      "worktree D:/DPF-scratch/copy-a/nested",
+      "",
+    ].join("\n");
+    const { bases } = groupByBase(parseWorktreePaths(nested));
+    assert.equal(bases.size, 2);
+    assert.ok(bases.has(resolve("D:/DPF-scratch/copy-a")));
+  });
+});

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -501,6 +501,9 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         // surfaces work. A wrong base points the reaper at the wrong directory,
         // so resolution order and provenance are pinned.
         "scripts/lib/worktree-base.test.mjs",
+        // BI-541156EE: one worktree base, or none. Seven were found on a single
+        // host, all from the same formula handed different roots.
+        "scripts/check-single-worktree-base.test.mjs",
         "scripts/lib/worktree-janitor-core.test.mjs",
         "scripts/worktree-janitor.test.mjs",
         "scripts/lib/worktree-session-heartbeat.test.mjs",

--- a/scripts/lib/worktree-base.mjs
+++ b/scripts/lib/worktree-base.mjs
@@ -23,10 +23,64 @@
 //
 // Spec: docs/superpowers/specs/2026-09-02-platform-owned-client-configuration-design.md §1
 
+import { execFileSync } from "node:child_process";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 
 /** Explicit operator/install override, highest precedence after config. */
 export const WORKTREE_BASE_ENV = "DPF_WORKTREE_BASE";
+
+/**
+ * The repository that OWNS the worktrees, resolved from git rather than from
+ * wherever the caller happens to be standing.
+ *
+ * This is the whole fix for BI-541156EE. Every decider already applied the same
+ * formula — `<dirname(root)>/<basename(root)>-worktrees` — and they disagreed
+ * only about what `root` was. A Claude Code hook derived it from the client's
+ * project directory (`D:\DPF`, the installed instance) and produced
+ * `D:\DPF-worktrees`, holding 141 worktrees; the source scripts derived it from
+ * the clone (`D:\DPF-source-root`) and produced `D:\DPF-source-root-worktrees`,
+ * holding 31. Two piles from one rule.
+ *
+ * `D:\DPF` is not a git repository at all, so that base was computed from a
+ * directory that cannot own a worktree. Anchoring on the git common dir gives
+ * ONE answer from anywhere — including from inside a worktree, where the common
+ * dir still points at the owning clone — and refuses outside a repository
+ * instead of inventing a base.
+ *
+ * @param {{ cwd?: string, exec?: (cmd: string, args: string[], opts: object) => string }} [options]
+ * @returns {string} absolute path of the owning clone
+ */
+export function resolveOwningClone(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const exec =
+    options.exec ??
+    ((cmd, args, opts) => execFileSync(cmd, args, { ...opts, encoding: "utf8" }));
+
+  let common;
+  try {
+    common = String(exec("git", ["rev-parse", "--git-common-dir"], { cwd })).trim();
+  } catch (err) {
+    throw new Error(
+      `resolveOwningClone: ${cwd} is not inside a git repository, so it cannot own worktrees. ` +
+        "A worktree base derived from a non-repository is how two bases appeared (BI-541156EE). " +
+        `(${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+
+  if (!common) {
+    throw new Error(`resolveOwningClone: git returned no common dir for ${cwd}`);
+  }
+
+  // `--git-common-dir` is the OWNING clone's .git even when called from inside a
+  // linked worktree, which is exactly the property that makes it unambiguous.
+  //
+  // Normalised through resolve() because git does not answer in one form: on
+  // this host the same clone came back as `D:\DPF-source-root` from the clone
+  // and `D:/DPF-source-root` from a worktree. Two spellings of one directory
+  // defeat every comparison downstream, including the single-base guard.
+  const absolute = isAbsolute(common) ? common : resolve(cwd, common);
+  return resolve(dirname(absolute));
+}
 
 /**
  * How a base was decided. Callers surface this so an unexpected location is
@@ -50,7 +104,12 @@ export const WORKTREE_BASE_ENV = "DPF_WORKTREE_BASE";
  * @returns {{ base: string, source: WorktreeBaseSource }}
  */
 export function resolveWorktreeBase(input) {
-  const { rootClone, env = {}, installConfig = null } = input ?? {};
+  const { env = {}, installConfig = null } = input ?? {};
+
+  // The owning clone, never the caller's directory. An explicit rootClone is
+  // still honoured so existing callers and tests can pass one, but it must be
+  // the repository that owns the worktrees, not wherever a client is rooted.
+  const rootClone = input?.rootClone ?? resolveOwningClone(input?.gitOptions);
 
   if (typeof rootClone !== "string" || rootClone.length === 0) {
     throw new Error("resolveWorktreeBase: rootClone is required");

--- a/scripts/lib/worktree-base.test.mjs
+++ b/scripts/lib/worktree-base.test.mjs
@@ -8,7 +8,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { dirname, join, resolve, sep } from "node:path";
 
-import { resolveWorktreeBase, WORKTREE_BASE_ENV } from "./worktree-base.mjs";
+import { resolveWorktreeBase, resolveOwningClone, WORKTREE_BASE_ENV } from "./worktree-base.mjs";
 
 const ROOT_CLONE = resolve(`${sep}srv`, "dpf-source-root");
 const DECLARED = resolve(`${sep}srv`, "declared-worktrees");
@@ -74,5 +74,53 @@ describe("resolveWorktreeBase", () => {
       resolveWorktreeBase({ rootClone: ROOT_CLONE, env: {} }).source,
     ];
     assert.deepEqual(sources, ["install-config", "env", "derived"]);
+  });
+});
+
+// Seven worktree bases were found on one host, every one produced by the SAME
+// formula handed a different root. The root must therefore come from the
+// repository, never from wherever the caller happens to be standing
+// (BI-541156EE).
+describe("resolveOwningClone", () => {
+  const fakeGit = (out) => (_cmd, _args, _opts) => out;
+
+  it("returns the clone that owns the worktrees, from the git common dir", () => {
+    assert.equal(
+      resolveOwningClone({ cwd: "/anywhere", exec: fakeGit("/srv/dpf-source-root/.git\n") }),
+      resolve("/srv/dpf-source-root"),
+    );
+  });
+
+  it("gives the SAME answer from inside a linked worktree", () => {
+    // --git-common-dir points at the owning clone even from a worktree, which
+    // is the property that makes the answer unambiguous.
+    assert.equal(
+      resolveOwningClone({ cwd: "/srv/dpf-worktrees/topic", exec: fakeGit("/srv/dpf-source-root/.git") }),
+      resolve("/srv/dpf-source-root"),
+    );
+  });
+
+  it("resolves a relative common dir against the caller's cwd", () => {
+    assert.equal(
+      resolveOwningClone({ cwd: resolve("/srv/dpf-source-root"), exec: fakeGit(".git") }),
+      resolve("/srv/dpf-source-root"),
+    );
+  });
+
+  it("REFUSES outside a repository instead of inventing a base", () => {
+    // This is the actual defect: a client hook derived a base from the
+    // installed instance, which is not a git repository, and produced a pile of
+    // 141 worktrees at a location nothing else agreed on.
+    assert.throws(
+      () => resolveOwningClone({ cwd: "/srv/install", exec: () => { throw new Error("not a git repository"); } }),
+      /cannot own worktrees/,
+    );
+  });
+
+  it("refuses an empty common dir rather than resolving to the filesystem root", () => {
+    assert.throws(
+      () => resolveOwningClone({ cwd: "/srv/x", exec: fakeGit("   ") }),
+      /no common dir/,
+    );
   });
 });


### PR DESCRIPTION
fix(worktree): anchor the worktree base on the repository, not the caller (BI-541156EE)

Founder direction 2026-09-02: "I'm more concerned there is some process that is
supporting 2 locations. Lets stop that."

There is no second process. There is ONE rule fed different roots.

## What was actually happening

Every location decider applies the same formula,
`<dirname(root)>/<basename(root)>-worktrees`:

  * packages/dpf-skill-pack/hooks/worktree-create.mjs — its own comment says
    "D:/DPF -> D:/DPF-worktrees"
  * scripts/new-dev-worktree.sh — dirname/basename of root
  * scripts/lib/local-ci-slot-manifest.mjs — the same derivation

They disagreed only about what `root` is. Handed the INSTALLED INSTANCE they
produced one base; handed the SOURCE CLONE they produced another. The decisive
detail: the installed instance is not a git repository at all, so a base holding
141 worktrees was computed from a directory that cannot own a worktree.

Where the clone IS the install, both roots agree and the ambiguity is invisible.
Any install that separates source from runtime hits it.

Running the new guard on this host found not two bases but SEVEN:

    142  D:\DPF-worktrees
     33  D:\DPF-source-root-worktrees
      2  D:\
      1  D:\DPF-scratch\pet-rescue-final-20260822
      1  D:\DPF-scratch\pet-rescue-final-acceptance-20260822
      1  D:\DPF-scratch\pet-rescue-final-accepted-20260822
      1  D:\DPF-scratch\pet-rescue-final-fixed-20260822

The four scratch entries are worktrees created while standing inside another
worktree. Same rule, same bug, seven times.

## What changed

`resolveOwningClone()` resolves the root from `git rev-parse --git-common-dir`,
which returns the OWNING clone from anywhere — including from inside a linked
worktree — and REFUSES outside a repository instead of inventing a base from a
non-repository. `resolveWorktreeBase()` now anchors on it by default; an
explicit rootClone is still honoured for callers and tests.

The answer is normalised through resolve(), because git does not answer in one
form: on this host the same clone came back as `D:\DPF-source-root` from the
clone and `D:/DPF-source-root` from a worktree. Two spellings of one directory
defeat every downstream comparison, including the guard added here. Verified
identical from both after the change.

`scripts/check-single-worktree-base.mjs` makes the invariant enforceable rather
than merely intended: it groups linked worktrees by parent and reports when more
than one base is in use. The main worktree is excluded — it does not live in a
base, it owns one, and counting it would report a phantom base on every healthy
repo. Advisory by default since an install can legitimately be mid-migration;
--strict for CI once converged.

## A bug this fixes in what shipped in #4987

The resolver added there derived from `rootClone`, which resolves to the pile of
33 — so the reaper would have bounded and reaped the small pile while the pile
of 142 grew untouched. Right shape, wrong anchor.

## The guard nearly shipped inert

Its first run exited 0 with no output: `import.meta.url === file://${argv[1]}`
never matches on Windows, where the URL carries three slashes before the drive
letter. A guard that cannot tell it is being run is the same silent-success
failure this whole line of work exists to remove. It now uses the repo's
existing scripts/lib/entry-module.mjs, which is why entry-module.test.mjs is in
the janitor suite.

## Not in this change

Migration. git tracks 142 under one base, 33 under another, 2 loose in the drive
root and 4 in scratch copies; the filesystem holds 200 directories where git
knows about 142, so ~59 are orphans git will never report and a git-based reaper
structurally cannot reclaim. Adopting or reaping those is a separate decision,
recorded on BI-541156EE and BI-99395B29.

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-09-02-platform-owned-client-configuration-design.md §1
    — the platform owns where work happens; this supplies the anchor it lacked.
  - docs/founder-kernel/wiki/principles/worktree-selection-and-reaping.md — the
    canonical-location rule this makes computable from one source.
  - docs/founder-kernel/wiki/principles/platform-function-never-depends-on-a-client.md
    — a base derived from the client's project directory is precisely the
    dependency that commandment forbids.
- Current code substrate reviewed:
  - packages/dpf-skill-pack/hooks/worktree-create.mjs, scripts/new-dev-worktree.sh,
    scripts/lib/local-ci-slot-manifest.mjs — the three deciders and their shared
    formula.
  - scripts/lib/entry-module.mjs — the existing helper for Windows-safe entry
    detection; used rather than re-invented.
- Source of truth: git's own `--git-common-dir` for the owning clone.
- Decision: anchor on the repository rather than pick a winner between the two
  bases. Choosing a base would have settled this host and left the next
  source/runtime split to produce a third.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
