### PR TITLE
feat(ward): the board, its capacity, and words a shelter actually uses

### DIFF
--- a/apps/web/app/(shell)/workspace/ward/page.tsx
+++ b/apps/web/app/(shell)/workspace/ward/page.tsx
@@ -1,0 +1,214 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { PawPrint, TriangleAlert } from "lucide-react";
+import { prisma } from "@dpf/db";
+
+import { auth } from "@/lib/auth";
+import { OWNER_FIRST_NEXT_ACTION_ATTR } from "@/lib/owner-first/ux-audit";
+import { Surface } from "@/components/ui/Surface";
+import { WardList, type WardListRow } from "@/components/ward/WardList";
+import { loadWardBoard, type WardStoreClient } from "@/lib/ward/ward-store";
+import { summarizeKennelCapacity, type WardUnit } from "@/lib/ward/ward-occupancy";
+
+type Props = { searchParams: Promise<{ view?: string }> };
+
+/**
+ * The ward board. A shelter's operators asked two questions all day that the
+ * product could not answer — where is this animal, and how many kennels are
+ * free — so those are the two things this page says first.
+ *
+ * Occupied and free are drawn, not counted: a free run is a gap you can see
+ * from the doorway, which is how a capacity conversation actually happens.
+ */
+export default async function WardPage({ searchParams }: Props) {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  const asList = (await searchParams).view === "list";
+
+  const config = await prisma.storefrontConfig.findFirst({
+    select: { organizationId: true },
+  });
+  const board = config
+    ? await loadWardBoard({
+        organizationId: config.organizationId,
+        db: prisma as unknown as WardStoreClient,
+      })
+    : null;
+  const capacity = summarizeKennelCapacity(board);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        {/* Lead band: the worker's marked place to start. Short sentences keep the
+            readability budget met with workspace chrome in the measured HTML. */}
+        <div data-dpf-lead>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--dpf-muted)]">
+            Operations
+          </p>
+          <h1 className="mt-1 text-2xl font-semibold text-[var(--dpf-text)]">Ward</h1>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--dpf-muted)]">
+            Where every animal is, and what is free.
+          </p>
+        </div>
+
+        {capacity ? (
+          <div className="flex items-end gap-5">
+            <div>
+              <p className="text-2xl font-semibold tabular-nums text-[var(--dpf-text)]">
+                {capacity.occupied}
+                <span className="text-sm font-normal text-[var(--dpf-muted)]"> of {capacity.total} occupied</span>
+              </p>
+              <p className="text-xs text-[var(--dpf-muted)]">
+                <span className="font-medium text-[var(--dpf-accent)]">{capacity.free} free</span>
+                {capacity.outOfService > 0 ? ` · ${capacity.outOfService} out of service` : ""}
+              </p>
+            </div>
+            <div className="flex rounded-md border border-[var(--dpf-border)] p-0.5">
+              <ViewTab href="/workspace/ward" label="Map" active={!asList} />
+              <ViewTab href="/workspace/ward?view=list" label="List" active={asList} />
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      {board == null ? (
+        <Surface padding="lg">
+          <p className="text-sm font-medium text-[var(--dpf-text)]">No housing recorded yet</p>
+          <p className="mt-1 max-w-2xl text-sm leading-6 text-[var(--dpf-muted)]">
+            Not the same as having no room. Record the kennels first.
+          </p>
+          <Link
+            href="/workspace"
+            className="mt-3 inline-block text-sm font-medium text-[var(--dpf-accent)]"
+            {...{ [OWNER_FIRST_NEXT_ACTION_ATTR]: "true" }}
+          >
+            Back to Operations
+          </Link>
+        </Surface>
+      ) : (
+        <>
+          {board.unplaced.length > 0 ? (
+            <Surface className="flex items-start gap-3">
+              <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-[var(--dpf-muted)]" aria-hidden="true" />
+              <div>
+                <p className="text-sm font-medium text-[var(--dpf-text)]">
+                  {board.unplaced.length} in care with no kennel recorded
+                </p>
+                <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+                  {board.unplaced.map((animal) => animal.name).join(" · ")}. The free count covers
+                  only the animals the board can place.
+                </p>
+              </div>
+            </Surface>
+          ) : null}
+
+          {asList ? <WardList rows={wardListRows(board)} /> : <WardMap board={board} />}
+        </>
+      )}
+    </div>
+  );
+}
+
+function ViewTab({ href, label, active }: { href: string; label: string; active: boolean }) {
+  return (
+    <Link
+      href={href}
+      // The board is read-only, so the view the worker is NOT on is the honest
+      // next step on this page — not a write it cannot yet perform.
+      {...(active ? {} : { [OWNER_FIRST_NEXT_ACTION_ATTR]: "true" })}
+      aria-current={active ? "page" : undefined}
+      className={[
+        "rounded px-3 py-1.5 text-xs font-medium transition-colors",
+        active
+          ? "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]"
+          : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
+      ].join(" ")}
+    >
+      {label}
+    </Link>
+  );
+}
+
+/** A free run is drawn as an outline so it reads as a gap, not as a card. */
+function isDrawnAsCard(state: WardUnit["state"]): boolean {
+  return state !== "free";
+}
+
+function WardMap({ board }: { board: NonNullable<Awaited<ReturnType<typeof loadWardBoard>>> }) {
+  return (
+    <div className="space-y-4">
+      {board.zones.map((zone) => (
+        <Surface as="section" key={zone.area}>
+          <div className="mb-3 flex flex-wrap items-baseline gap-3">
+            <h2 className="text-sm font-semibold text-[var(--dpf-text)]">{zone.area}</h2>
+            <span className="text-xs text-[var(--dpf-muted)]">
+              {zone.free} free of {zone.units.length}
+              {zone.outOfService > 0 ? ` · ${zone.outOfService} out of service` : ""}
+            </span>
+          </div>
+          <ul className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-2">
+            {zone.units.map((unit) => (
+              <UnitCell key={unit.kennelId} unit={unit} />
+            ))}
+          </ul>
+        </Surface>
+      ))}
+    </div>
+  );
+}
+
+function UnitCell({ unit }: { unit: WardUnit }) {
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-xs font-medium tabular-nums text-[var(--dpf-muted)]">{unit.label}</span>
+        {unit.state === "occupied" ? (
+          <PawPrint className="h-3.5 w-3.5 shrink-0 text-[var(--dpf-accent)]" aria-hidden="true" />
+        ) : null}
+      </div>
+      {unit.animalName ? (
+        <p className="mt-1.5 text-sm font-medium leading-tight text-[var(--dpf-text)]">
+          {unit.animalName}
+        </p>
+      ) : (
+        <p className="mt-1.5 text-xs text-[var(--dpf-muted)]">{unit.blockedReason ?? "Free"}</p>
+      )}
+    </>
+  );
+
+  if (isDrawnAsCard(unit.state)) {
+    return (
+      <Surface
+        as="li"
+        padding="sm"
+        rounded="md"
+        level={unit.state === "out-of-service" ? 2 : 1}
+        className="min-h-[74px]"
+      >
+        {body}
+      </Surface>
+    );
+  }
+
+  return (
+    <li className="min-h-[74px] rounded-md border border-dashed border-[var(--dpf-border)] p-3">
+      {body}
+    </li>
+  );
+}
+
+function wardListRows(
+  board: NonNullable<Awaited<ReturnType<typeof loadWardBoard>>>,
+): WardListRow[] {
+  return board.zones.flatMap((zone) =>
+    zone.units.map((unit) => ({
+      kennelId: unit.kennelId,
+      label: unit.label,
+      area: zone.area,
+      animalName: unit.animalName,
+      state: unit.state,
+      blockedReason: unit.blockedReason,
+    })),
+  );
+}

--- a/apps/web/components/ward/WardList.tsx
+++ b/apps/web/components/ward/WardList.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+// The ward as a table. The map answers "how much room is left" at a glance;
+// this answers "what is the state of unit C1-2" without relying on position or
+// colour alone, which is why the board offers both rather than choosing.
+
+import { DataTable, type Column } from "@/components/ui/report-kit";
+
+export interface WardListRow {
+  kennelId: string;
+  label: string;
+  area: string;
+  animalName: string | null;
+  state: "occupied" | "free" | "out-of-service";
+  blockedReason: string | null;
+}
+
+function stateLabel(row: WardListRow): string {
+  if (row.state === "out-of-service") return row.blockedReason ?? "Out of service";
+  if (row.state === "occupied") return "Occupied";
+  return "Free";
+}
+
+const COLUMNS: Column<WardListRow>[] = [
+  {
+    key: "label",
+    header: "Unit",
+    cell: (row) => row.label,
+    // Units are counted, not spelled: D2 sorts before D10.
+    sortAccessor: (row) => Number(row.label.replace(/\D+/g, "")) || row.label,
+    mono: true,
+  },
+  {
+    key: "area",
+    header: "Area",
+    cell: (row) => row.area,
+    sortAccessor: (row) => row.area,
+  },
+  {
+    key: "animal",
+    header: "Animal",
+    cell: (row) => row.animalName ?? "—",
+    sortAccessor: (row) => row.animalName ?? "",
+  },
+  {
+    key: "state",
+    header: "State",
+    cell: stateLabel,
+    sortAccessor: stateLabel,
+  },
+];
+
+export function WardList({ rows }: { rows: WardListRow[] }) {
+  return (
+    <DataTable
+      columns={COLUMNS}
+      rows={rows}
+      getRowKey={(row) => row.kennelId}
+      initialSort={{ key: "label", dir: "asc" }}
+      ariaLabel="Ward units"
+    />
+  );
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -12291,6 +12291,7 @@
         "overview",
         "operations-and-performance",
         "spatial-operations-for-tables-and-rooms",
+        "the-ward-for-a-shelter",
         "confirming-an-operational-suggestion",
         "which-installation-you-are-on",
         "correcting-the-identity",

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 645,
+  "routeCount": 646,
   "routes": [
     {
       "routePath": "/",
@@ -7688,6 +7688,16 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/workspace/my-queue/page.tsx"
+    },
+    {
+      "routePath": "/workspace/ward",
+      "kind": "page",
+      "segments": [
+        "workspace",
+        "ward"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/workspace/ward/page.tsx"
     }
   ]
 }

--- a/apps/web/lib/navigation/route-audience.generated.json
+++ b/apps/web/lib/navigation/route-audience.generated.json
@@ -1,19 +1,19 @@
 {
   "generator": "apps/web/scripts/build-route-audience.ts",
-  "pageRouteCount": 359,
+  "pageRouteCount": 360,
   "summary": {
     "byAudience": {
       "admin": 151,
       "auth-setup": 10,
       "builder": 3,
       "customer": 11,
-      "owner": 161,
+      "owner": 162,
       "public": 21,
       "worker": 2
     },
     "byDestinationKind": {
       "advanced-diagnostic": 103,
-      "detail": 169,
+      "detail": 170,
       "legacy-internal": 34,
       "section-home": 32,
       "settings-config": 12,
@@ -2536,6 +2536,13 @@
       "destinationKind": "detail",
       "confidence": "high",
       "source": "override"
+    },
+    {
+      "routePath": "/workspace/ward",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
     }
   ]
 }

--- a/apps/web/lib/owner-first/domain-summary.ts
+++ b/apps/web/lib/owner-first/domain-summary.ts
@@ -242,7 +242,7 @@ export function buildFinanceOwnerSummary(
 
   return {
     domain: "finance",
-    headline: vocab.isRestaurant ? "Money today" : "Money today",
+    headline: "Money today",
     subhead: vocab.isRestaurant
       ? `What must be paid, collected, or approved — ${vocab.billsLabel}, ${vocab.depositsLabel}, and ${vocab.invoicesLabel}.`
       : "What must be paid, collected, or approved today.",
@@ -285,10 +285,8 @@ export function buildWorkspaceStorefrontSummary(
   return {
     ...summary,
     domain: "workspace",
-    headline: vocab.isRestaurant ? "From your guests" : "From your storefront",
-    subhead: vocab.isRestaurant
-      ? "Reservations, orders, and inquiries waiting on you — before anything else."
-      : "Storefront bookings and inquiries waiting on you — before anything else.",
+    headline: vocab.inboundHeadline,
+    subhead: vocab.inboundSubhead,
   };
 }
 

--- a/apps/web/lib/owner-first/vocabulary.test.ts
+++ b/apps/web/lib/owner-first/vocabulary.test.ts
@@ -39,3 +39,29 @@ describe("resolveOwnerVocabulary", () => {
     expect(v.customerSummarySubhead).not.toMatch(/customer|crm/i);
   });
 });
+
+describe("front-door vocabulary", () => {
+  // The cockpit told an animal rescue about "From your storefront" and "Storefront
+  // bookings". A storefront is what DPF calls the product; it is not what a shelter
+  // calls the people arriving at its door. The headline is vocabulary now, so no
+  // archetype can inherit another's front door by falling through a branch.
+  it("no archetype's worker copy calls its front door a storefront", () => {
+    for (const [category, archetypeId] of [
+      [null, null],
+      ["retail-goods", null],
+      ["nonprofit-community", "pet-rescue"],
+      ["nonprofit-community", "animal-shelter"],
+      [RESTAURANT_ARCHETYPE_CATEGORY, null],
+    ] as const) {
+      const v = resolveOwnerVocabulary(category, archetypeId);
+      const words = `${v.inboundHeadline} ${v.inboundSubhead} ${v.customerSummarySubhead}`;
+      expect(words.toLowerCase()).not.toContain("storefront");
+    }
+  });
+
+  it("the rescue is greeted by its community, in its own nouns", () => {
+    const v = resolveOwnerVocabulary("nonprofit-community", "pet-rescue");
+    expect(v.inboundHeadline).toBe("From your community");
+    expect(v.inboundSubhead).toContain("Adoption enquiries");
+  });
+});

--- a/apps/web/lib/owner-first/vocabulary.ts
+++ b/apps/web/lib/owner-first/vocabulary.ts
@@ -25,6 +25,11 @@ export type OwnerDomainVocabulary = {
   guestFollowUpLabel: string;
   customerSummarySubhead: string;
   reservationsLabel: string;
+  /** The stream of people reaching in, as this business names it. A storefront
+   *  is what DPF calls the product; it is not what a rescue calls its front
+   *  door, so this is vocabulary rather than a branch on one archetype. */
+  inboundHeadline: string;
+  inboundSubhead: string;
   ordersLabel: string;
   inquiriesLabel: string;
   /** People-domain daily work. */
@@ -43,6 +48,8 @@ const RESTAURANT_VOCABULARY: OwnerDomainVocabulary = {
   guestsLabel: "guests",
   guestFollowUpLabel: "Guest follow-up",
   customerSummarySubhead: "Guests waiting on you — reservations, orders, and inquiries first.",
+  inboundHeadline: "From your guests",
+  inboundSubhead: "Reservations, orders, and inquiries waiting on you — before anything else.",
   reservationsLabel: "reservations",
   ordersLabel: "orders",
   inquiriesLabel: "inquiries",
@@ -60,6 +67,8 @@ const DEFAULT_VOCABULARY: OwnerDomainVocabulary = {
   guestsLabel: "customers",
   guestFollowUpLabel: "Customer follow-up",
   customerSummarySubhead: "Customers waiting on you first — the rest of your CRM is below.",
+  inboundHeadline: "From your customers",
+  inboundSubhead: "Bookings, orders, and inquiries waiting on you — before anything else.",
   reservationsLabel: "bookings",
   ordersLabel: "orders",
   inquiriesLabel: "inquiries",
@@ -77,6 +86,8 @@ const PET_RESCUE_VOCABULARY: OwnerDomainVocabulary = {
   guestsLabel: "people & partners",
   guestFollowUpLabel: "Adoption follow-up",
   customerSummarySubhead: "Adopters, foster families, volunteers, donors, and partners waiting on you first.",
+  inboundHeadline: "From your community",
+  inboundSubhead: "Adoption enquiries, visits, and supply requests waiting on you — before anything else.",
   reservationsLabel: "adoption visits",
   ordersLabel: "supply requests",
   inquiriesLabel: "adoption enquiries",

--- a/apps/web/lib/twin/archetype-outcome-facts.test.ts
+++ b/apps/web/lib/twin/archetype-outcome-facts.test.ts
@@ -26,6 +26,7 @@ describe("archetype outcome facts", () => {
     });
 
     expect(facts).toEqual({
+      kennelCapacity: null,
       donationRows: null,
       animalStatusRows: null,
       animalsPlaced: null,

--- a/apps/web/lib/twin/archetype-outcome-facts.ts
+++ b/apps/web/lib/twin/archetype-outcome-facts.ts
@@ -4,6 +4,8 @@ import {
   type AnimalsInCare,
   type DonationTotal,
 } from "./archetype-outcomes";
+import { summarizeKennelCapacity } from "@/lib/ward/ward-occupancy";
+import { loadWardBoard, type WardStoreClient } from "@/lib/ward/ward-store";
 
 type FindMany = (args: unknown) => Promise<unknown>;
 type Count = (args: unknown) => Promise<number>;
@@ -32,6 +34,8 @@ interface DonationRow {
 }
 
 export interface ArchetypeOutcomeFacts {
+  /** `null` when no housing is recorded — never rendered as "0 free". */
+  kennelCapacity: ReturnType<typeof summarizeKennelCapacity>;
   donationRows: DonationRow[] | null;
   animalStatusRows: AnimalStatusGroup[] | null;
   animalsPlaced: number | null;
@@ -45,12 +49,15 @@ function isRescue(archetypeId: string): boolean {
 export async function loadArchetypeOutcomeFacts(input: {
   archetypeId: string;
   storefrontId: string;
+  /** Absent on a caller that cannot resolve it; capacity then reads as
+   *  unrecorded rather than as a confident zero. */
+  organizationId?: string | null;
   since: Date;
   db: ArchetypeOutcomeFactsClient;
   runtime: OutcomeFactsRuntime;
 }): Promise<ArchetypeOutcomeFacts> {
   if (!isRescue(input.archetypeId)) {
-    return { donationRows: null, animalStatusRows: null, animalsPlaced: null };
+    return { kennelCapacity: null, donationRows: null, animalStatusRows: null, animalsPlaced: null };
   }
 
   const [donationRows, animalStatusRows, animalsPlaced] = await Promise.all([
@@ -93,7 +100,24 @@ export async function loadArchetypeOutcomeFacts(input: {
       : (input.runtime.unavailable("adoptions"), Promise.resolve(null)),
   ]);
 
-  return { donationRows, animalStatusRows, animalsPlaced };
+  // Housing is org-scoped, not storefront-scoped: a kennel is not a listing.
+  const board = input.organizationId
+    ? await input.runtime.read(
+        "kennels",
+        loadWardBoard({
+          organizationId: input.organizationId,
+          db: input.db as unknown as WardStoreClient,
+        }),
+        null,
+      )
+    : null;
+
+  return {
+    kennelCapacity: summarizeKennelCapacity(board),
+    donationRows,
+    animalStatusRows,
+    animalsPlaced,
+  };
 }
 
 /**
@@ -172,6 +196,7 @@ export function buildOutcomeProjectionFromFacts(input: {
     deliveredJobs: input.deliveredJobs,
     donationTotals: donations.totals,
     animalsInCare: summarizeAnimalsInCare(input.facts.animalStatusRows),
+    kennelCapacity: input.facts.kennelCapacity,
     animalsPlaced: input.facts.animalsPlaced,
     // There is no governed foster entity yet. Preserve that fact in the UI.
     fostersActive: null,

--- a/apps/web/lib/twin/archetype-outcomes.test.ts
+++ b/apps/web/lib/twin/archetype-outcomes.test.ts
@@ -28,14 +28,15 @@ describe("buildArchetypeOutcomes", () => {
     expect(projection.heading).toBe("Mission impact");
     expect(projection.outcomes.map((outcome) => outcome.label)).toEqual([
       "Animals in care",
+      "Kennels",
       "Donations received",
       "Animals placed",
       "Fosters active",
     ]);
-    expect(projection.outcomes[1]?.value).toContain("$275");
-    expect(projection.outcomes[2]?.value).toBe("2 animals");
-    expect(projection.outcomes[3]?.value).toBe("Unavailable");
-    expect(projection.outcomes[3]?.hint).toMatch(/no foster record source/i);
+    expect(outcome(projection, "donations-received")?.value).toContain("$275");
+    expect(outcome(projection, "animals-placed")?.value).toBe("2 animals");
+    expect(outcome(projection, "fosters-active")?.value).toBe("Unavailable");
+    expect(outcome(projection, "fosters-active")?.hint).toMatch(/no foster record source/i);
   });
 
   it("leads the rescue projection with the animals actually in the shelter", () => {
@@ -188,5 +189,59 @@ describe("buildArchetypeOutcomes", () => {
 
     expect(outcome(projection, "donations-received")?.value).toContain("0");
     expect(outcome(projection, "donations-received")?.hint).toBe("0 gifts · 90 days");
+  });
+});
+
+describe("kennel capacity", () => {
+  const base = {
+    archetypeId: "pet-rescue" as const,
+    currency: "USD",
+    locale: "en-US",
+    paidRevenue: 0,
+    deliveredJobs: 0,
+    donationTotals: [],
+    animalsInCare: { total: 6, onHold: 5, available: 1, pending: 0 },
+    animalsPlaced: 0,
+    fostersActive: null,
+  };
+
+  it("answers the 16:00 question: how many kennels are free", () => {
+    const projection = buildArchetypeOutcomes({
+      ...base,
+      kennelCapacity: { total: 20, free: 13, occupied: 6, outOfService: 1 },
+    });
+
+    const kennels = outcome(projection, "kennels-free");
+    expect(kennels?.value).toBe("13 free");
+    expect(kennels?.hint).toBe("6 occupied · 1 out of service of 20");
+  });
+
+  it("omits out-of-service from the hint when every unit is in service", () => {
+    const projection = buildArchetypeOutcomes({
+      ...base,
+      kennelCapacity: { total: 8, free: 2, occupied: 6, outOfService: 0 },
+    });
+
+    expect(outcome(projection, "kennels-free")?.hint).toBe("6 occupied of 8");
+  });
+
+  it("warns when the shelter is full rather than reading as a healthy zero", () => {
+    const projection = buildArchetypeOutcomes({
+      ...base,
+      kennelCapacity: { total: 6, free: 0, occupied: 6, outOfService: 0 },
+    });
+
+    const kennels = outcome(projection, "kennels-free");
+    expect(kennels?.value).toBe("0 free");
+    expect(kennels?.intent).toBe("warning");
+  });
+
+  it("does not tell a manager they are full when no housing has been recorded", () => {
+    const projection = buildArchetypeOutcomes({ ...base, kennelCapacity: null });
+
+    const kennels = outcome(projection, "kennels-free");
+    expect(kennels?.value).toBe("Not recorded");
+    expect(kennels?.value).not.toBe("0 free");
+    expect(kennels?.hint).toMatch(/no housing recorded/i);
   });
 });

--- a/apps/web/lib/twin/archetype-outcomes.ts
+++ b/apps/web/lib/twin/archetype-outcomes.ts
@@ -31,6 +31,9 @@ export interface ArchetypeOutcomeInput {
   /** `null` means the animal source could not be read; a zero total means an
    *  empty shelter, which is a real and different answer. */
   animalsInCare?: AnimalsInCare | null;
+  /** Housing the shelter has recorded. `null` means none has been recorded at
+   *  all, which is a different answer from having none free. */
+  kennelCapacity?: { total: number; free: number; occupied: number; outOfService: number } | null;
   animalsPlaced?: number | null;
   fostersActive?: number | null;
 }
@@ -128,6 +131,36 @@ function animalsInCareOutcome(inCare: AnimalsInCare | null | undefined): TwinOut
 }
 
 /**
+ * The 16:00 question the operating day could not answer: how many kennels are
+ * free. A shelter that has recorded no housing has not answered "none free" —
+ * it has not been asked yet — so the two states never render the same.
+ */
+function kennelsOutcome(
+  capacity: ArchetypeOutcomeInput["kennelCapacity"],
+): TwinOutcome {
+  if (capacity == null) {
+    return {
+      key: "kennels-free",
+      label: "Kennels",
+      value: "Not recorded",
+      intent: "info",
+      hint: "No housing recorded yet",
+    };
+  }
+
+  const detail = [`${capacity.occupied} occupied`];
+  if (capacity.outOfService > 0) detail.push(`${capacity.outOfService} out of service`);
+
+  return {
+    key: "kennels-free",
+    label: "Kennels",
+    value: `${capacity.free} free`,
+    intent: capacity.free === 0 ? "warning" : "success",
+    hint: `${detail.join(" · ")} of ${capacity.total}`,
+  };
+}
+
+/**
  * Project canonical aggregates into the archetype's outcome language. This is
  * intentionally a small presentation boundary, not a general metric framework:
  * each value must already have a real source, and missing sources stay visible.
@@ -140,6 +173,7 @@ export function buildArchetypeOutcomes(
       heading: "Mission impact",
       outcomes: [
         animalsInCareOutcome(input.animalsInCare),
+        kennelsOutcome(input.kennelCapacity),
         donationsOutcome(input),
         {
           key: "animals-placed",

--- a/apps/web/lib/twin/living-business-snapshot.test.ts
+++ b/apps/web/lib/twin/living-business-snapshot.test.ts
@@ -424,15 +424,17 @@ describe("loadLivingBusinessSnapshot — loader", () => {
     expect(snapshot?.outcomesHeading).toBe("Mission impact");
     expect(snapshot?.outcomes?.map((outcome) => outcome.label)).toEqual([
       "Animals in care",
+      "Kennels",
       "Donations received",
       "Animals placed",
       "Fosters active",
     ]);
     expect(snapshot?.outcomes?.[0]?.value).toBe("4 animals");
     expect(snapshot?.outcomes?.[0]?.hint).toBe("3 on hold · 1 available");
-    expect(snapshot?.outcomes?.[1]?.value).toContain("$275");
-    expect(snapshot?.outcomes?.[2]?.value).toBe("2 animals");
-    expect(snapshot?.outcomes?.[3]).toMatchObject({
+    expect(snapshot?.outcomes?.[1]?.value).toBe("Not recorded");
+    expect(snapshot?.outcomes?.[2]?.value).toContain("$275");
+    expect(snapshot?.outcomes?.[3]?.value).toBe("2 animals");
+    expect(snapshot?.outcomes?.[4]).toMatchObject({
       value: "Unavailable",
       hint: "No foster record source yet",
     });

--- a/apps/web/lib/twin/living-business-snapshot.ts
+++ b/apps/web/lib/twin/living-business-snapshot.ts
@@ -434,11 +434,13 @@ export async function loadLivingBusinessProjection(
   const config = (await db.storefrontConfig.findFirst({
     select: {
       id: true,
+      organizationId: true,
       timezone: true,
       archetype: { select: { archetypeId: true, name: true } },
     },
   })) as {
     id: string;
+    organizationId: string;
     timezone: string;
     archetype: { archetypeId: string; name: string } | null;
   } | null;
@@ -587,6 +589,7 @@ export async function loadLivingBusinessProjection(
     loadArchetypeOutcomeFacts({
       archetypeId,
       storefrontId: config.id,
+      organizationId: config.organizationId,
       since: in90,
       db,
       runtime,

--- a/apps/web/lib/ux-budget/purpose-contracts/index.ts
+++ b/apps/web/lib/ux-budget/purpose-contracts/index.ts
@@ -15,6 +15,7 @@ import { GOVERNED_TEARDOWN_PURPOSE_CONTRACTS } from "./governed-teardown";
 import { WORDPRESS_PURPOSE_CONTRACTS } from "./wordpress";
 import { WORKROOM_PURPOSE_CONTRACTS } from "./workrooms";
 import { INSTALLATION_IDENTITY_PURPOSE_CONTRACTS } from "./installation-identity";
+import { WARD_PURPOSE_CONTRACTS } from "./ward";
 
 const CONTRACT_MODULES: readonly PurposeContractModule[] = [
   ARCHETYPE_READINESS_PURPOSE_CONTRACTS,
@@ -27,6 +28,7 @@ const CONTRACT_MODULES: readonly PurposeContractModule[] = [
   WORDPRESS_PURPOSE_CONTRACTS,
   WORKROOM_PURPOSE_CONTRACTS,
   INSTALLATION_IDENTITY_PURPOSE_CONTRACTS,
+  WARD_PURPOSE_CONTRACTS,
 ];
 
 export function buildPurposeContractSourceIndex(

--- a/apps/web/lib/ux-budget/purpose-contracts/ward.ts
+++ b/apps/web/lib/ux-budget/purpose-contracts/ward.ts
@@ -1,0 +1,163 @@
+// Ratified page-purpose contract for /workspace/ward (BI-F91D0685).
+//
+// A measured operating day found the rescue unable to answer two questions at
+// any point: where is this animal, and how many kennels are free. This route
+// exists to answer exactly those two and nothing else.
+
+import type { PurposeContractModule } from ".";
+
+export const WARD_PURPOSE_CONTRACTS: PurposeContractModule = [
+  {
+    schemaVersion: 1,
+    status: "intent-ratified",
+    routePath: "/workspace/ward",
+    intent: {
+      primaryUser:
+        "A kennel technician or shelter manager walking the wards, often on a tablet held one-handed.",
+      triggeringNeed:
+        "Finding where an animal sleeps, and how much room is left, without asking a colleague or reading a whiteboard.",
+      prerequisites: [
+        "Signed in with access to the Operations family.",
+        "The shelter has recorded its housing units as kennel resources.",
+      ],
+      job: "See every unit in the wards, who is in it, and which units are free.",
+      successOutcome:
+        "The worker can name the unit an animal is in, and say how many units are free, without counting rows.",
+      findability: {
+        parentArea: "Operations",
+        entryPoints: ["/workspace", "Operations > Ward"],
+        navigationLayer: "Workspace primary nav, Operations family",
+        discoveryCue: "A 'Ward' item in the Operations family beside Calendar and Documents.",
+        expectedPath: ["/workspace", "/workspace/ward"],
+      },
+      contentRoles: {
+        defaultVisibleKeys: ["lead-summary", "open-ward-map"],
+        deferredRegions: [
+          {
+            key: "ward-list",
+            role: "The same units as a table, adding area and state per row.",
+            trigger: "Worker chooses List.",
+          },
+        ],
+      },
+      familyConsistency: {
+        terminology:
+          "Speak the shelter's own words: wards, kennels, units, free. Never items, inventory, or slots.",
+        actionLocation:
+          "The map and list views switch from one control beside the occupancy count; the page itself is read-only.",
+        feedbackPrimitive:
+          "Occupancy is read from the drawn units and a stated free count; there are no dialogs or destructive actions.",
+        disclosurePattern:
+          "Occupied of total and free lead the page, then the map. The list is one control away so reading grade and word budgets pass with workspace chrome included.",
+        returnBehavior: "The worker returns to Operations through the same workspace navigation family.",
+      },
+    },
+    stateScenarios: {
+      "housing-recorded": {
+        statePredicate: "The organization has at least one active kennel resource.",
+        stateSource: {
+          oracleKey: "route-owned-read-model",
+          sourceRef: "apps/web/lib/ward/ward-store.ts#loadWardBoard",
+        },
+        essentialEvidenceKeys: ["occupied-of-total", "free-count", "unit-occupant"],
+        primaryExperience: {
+          kind: "informational",
+          messageKey: "ward.housing-recorded",
+        },
+        prohibitedActionKeys: ["delete-kennel"],
+        completionSignal:
+          "Every unit shows either its occupant or that it is free, and the free count matches the units drawn as free.",
+        errorCorrection:
+          "A wrong occupant is corrected by moving the animal, which closes its stay rather than deleting the record.",
+        recovery: {
+          actionKey: "open-workspace",
+          routePath: "/workspace",
+        },
+      },
+      "no-housing-recorded": {
+        statePredicate: "The organization has no active kennel resource.",
+        stateSource: {
+          oracleKey: "route-owned-read-model",
+          sourceRef: "apps/web/lib/ward/ward-store.ts#loadWardBoard",
+        },
+        essentialEvidenceKeys: ["no-housing-notice"],
+        primaryExperience: {
+          kind: "informational",
+          messageKey: "ward.no-housing-recorded",
+        },
+        prohibitedActionKeys: ["show-zero-free"],
+        // A shelter that has told the system about no kennels has not answered
+        // "none free". Rendering a confident zero would be the number a
+        // capacity decision gets made on.
+        completionSignal:
+          "The page says no housing is recorded and does not state a free count at all.",
+        errorCorrection:
+          "The shelter records its kennels; the page does not invent a roster on its behalf.",
+        recovery: {
+          actionKey: "open-workspace",
+          routePath: "/workspace",
+        },
+      },
+      "animals-without-a-unit": {
+        statePredicate:
+          "The organization holds animals in care that have no open kennel stay.",
+        stateSource: {
+          oracleKey: "route-owned-read-model",
+          sourceRef: "apps/web/lib/ward/ward-occupancy.ts#buildWardBoard",
+        },
+        essentialEvidenceKeys: ["unplaced-notice", "free-count"],
+        primaryExperience: {
+          kind: "informational",
+          messageKey: "ward.animals-without-a-unit",
+        },
+        prohibitedActionKeys: ["hide-unplaced-animals"],
+        completionSignal:
+          "Every unplaced animal is named, and the page states that the free count is only true for the animals it can place.",
+        errorCorrection:
+          "The worker places the named animals, which is what makes the free count whole.",
+        recovery: {
+          actionKey: "open-workspace",
+          routePath: "/workspace",
+        },
+      },
+    },
+    taskProtocol: {
+      startRoute: "/workspace/ward",
+      taskPrompt:
+        "Find out where an animal is sleeping, and how many kennels are free.",
+      completionOracle:
+        "The worker names the unit an animal is in and states the free count, without counting rows and without asking a colleague.",
+      falseSuccessConditions: [
+        "A shelter that has recorded no kennels is shown a free count, which reads as a full or empty building it never reported.",
+        "Animals in care with no kennel recorded are omitted, so the free count implies a completeness the board does not have.",
+        "A unit held out of service for cleaning or repair is counted as free.",
+        "A released stay still shows its animal, so an old occupant hides a free run.",
+      ],
+      acceptanceThresholds: [
+        "Occupied-of-total and free are stated before the map.",
+        "Every unit renders either its occupant or that it is free.",
+        "Unplaced animals are named, with the free count qualified.",
+        "The list flip carries the same units as the map and no fewer.",
+      ],
+    },
+    ratifiedBy: {
+      role: "owner",
+      ref: "BI-F91D0685",
+    },
+    reviewRef: "BI-F91D0685",
+    intentEvidenceRefs: [
+      {
+        kind: "operator-request",
+        ref: "BI-E54F7F87",
+        summary:
+          "Owner, looking at the running portal: no notion of the pets currently in the shelter, and asked to know where they are, like a restaurant layout.",
+      },
+      {
+        kind: "design-review",
+        ref: "docs/superpowers/plans/2026-09-02-ward-board-housing-and-occupancy.md",
+        summary:
+          "The plan records the substrate verification behind this route and the four-phase order; the surface shape was scored through principle_decide DI-6E711DA68A9B against list-only and map-only.",
+      },
+    ],
+  },
+];

--- a/apps/web/lib/ux-budget/route-purpose.generated.json
+++ b/apps/web/lib/ux-budget/route-purpose.generated.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "generator": "apps/web/scripts/build-page-purpose.ts",
-  "pageRouteCount": 325,
+  "pageRouteCount": 326,
   "draftCount": 313,
-  "ratifiedCount": 12,
+  "ratifiedCount": 13,
   "quarantinedCount": 0,
   "routes": [
     {
@@ -5710,6 +5710,169 @@
         "confidence": "high",
         "sweepEligible": true
       }
+    },
+    {
+      "schemaVersion": 1,
+      "status": "intent-ratified",
+      "routePath": "/workspace/ward",
+      "derived": {
+        "audience": "owner",
+        "destinationKind": "detail",
+        "shell": "detail",
+        "confidence": "high",
+        "sweepEligible": true
+      },
+      "intent": {
+        "primaryUser": "A kennel technician or shelter manager walking the wards, often on a tablet held one-handed.",
+        "triggeringNeed": "Finding where an animal sleeps, and how much room is left, without asking a colleague or reading a whiteboard.",
+        "prerequisites": [
+          "Signed in with access to the Operations family.",
+          "The shelter has recorded its housing units as kennel resources."
+        ],
+        "job": "See every unit in the wards, who is in it, and which units are free.",
+        "successOutcome": "The worker can name the unit an animal is in, and say how many units are free, without counting rows.",
+        "findability": {
+          "parentArea": "Operations",
+          "entryPoints": [
+            "/workspace",
+            "Operations > Ward"
+          ],
+          "navigationLayer": "Workspace primary nav, Operations family",
+          "discoveryCue": "A 'Ward' item in the Operations family beside Calendar and Documents.",
+          "expectedPath": [
+            "/workspace",
+            "/workspace/ward"
+          ]
+        },
+        "contentRoles": {
+          "defaultVisibleKeys": [
+            "lead-summary",
+            "open-ward-map"
+          ],
+          "deferredRegions": [
+            {
+              "key": "ward-list",
+              "role": "The same units as a table, adding area and state per row.",
+              "trigger": "Worker chooses List."
+            }
+          ]
+        },
+        "familyConsistency": {
+          "terminology": "Speak the shelter's own words: wards, kennels, units, free. Never items, inventory, or slots.",
+          "actionLocation": "The map and list views switch from one control beside the occupancy count; the page itself is read-only.",
+          "feedbackPrimitive": "Occupancy is read from the drawn units and a stated free count; there are no dialogs or destructive actions.",
+          "disclosurePattern": "Occupied of total and free lead the page, then the map. The list is one control away so reading grade and word budgets pass with workspace chrome included.",
+          "returnBehavior": "The worker returns to Operations through the same workspace navigation family."
+        }
+      },
+      "stateScenarios": {
+        "housing-recorded": {
+          "statePredicate": "The organization has at least one active kennel resource.",
+          "stateSource": {
+            "oracleKey": "route-owned-read-model",
+            "sourceRef": "apps/web/lib/ward/ward-store.ts#loadWardBoard"
+          },
+          "essentialEvidenceKeys": [
+            "occupied-of-total",
+            "free-count",
+            "unit-occupant"
+          ],
+          "primaryExperience": {
+            "kind": "informational",
+            "messageKey": "ward.housing-recorded"
+          },
+          "prohibitedActionKeys": [
+            "delete-kennel"
+          ],
+          "completionSignal": "Every unit shows either its occupant or that it is free, and the free count matches the units drawn as free.",
+          "errorCorrection": "A wrong occupant is corrected by moving the animal, which closes its stay rather than deleting the record.",
+          "recovery": {
+            "actionKey": "open-workspace",
+            "routePath": "/workspace"
+          }
+        },
+        "no-housing-recorded": {
+          "statePredicate": "The organization has no active kennel resource.",
+          "stateSource": {
+            "oracleKey": "route-owned-read-model",
+            "sourceRef": "apps/web/lib/ward/ward-store.ts#loadWardBoard"
+          },
+          "essentialEvidenceKeys": [
+            "no-housing-notice"
+          ],
+          "primaryExperience": {
+            "kind": "informational",
+            "messageKey": "ward.no-housing-recorded"
+          },
+          "prohibitedActionKeys": [
+            "show-zero-free"
+          ],
+          "completionSignal": "The page says no housing is recorded and does not state a free count at all.",
+          "errorCorrection": "The shelter records its kennels; the page does not invent a roster on its behalf.",
+          "recovery": {
+            "actionKey": "open-workspace",
+            "routePath": "/workspace"
+          }
+        },
+        "animals-without-a-unit": {
+          "statePredicate": "The organization holds animals in care that have no open kennel stay.",
+          "stateSource": {
+            "oracleKey": "route-owned-read-model",
+            "sourceRef": "apps/web/lib/ward/ward-occupancy.ts#buildWardBoard"
+          },
+          "essentialEvidenceKeys": [
+            "unplaced-notice",
+            "free-count"
+          ],
+          "primaryExperience": {
+            "kind": "informational",
+            "messageKey": "ward.animals-without-a-unit"
+          },
+          "prohibitedActionKeys": [
+            "hide-unplaced-animals"
+          ],
+          "completionSignal": "Every unplaced animal is named, and the page states that the free count is only true for the animals it can place.",
+          "errorCorrection": "The worker places the named animals, which is what makes the free count whole.",
+          "recovery": {
+            "actionKey": "open-workspace",
+            "routePath": "/workspace"
+          }
+        }
+      },
+      "taskProtocol": {
+        "startRoute": "/workspace/ward",
+        "taskPrompt": "Find out where an animal is sleeping, and how many kennels are free.",
+        "completionOracle": "The worker names the unit an animal is in and states the free count, without counting rows and without asking a colleague.",
+        "falseSuccessConditions": [
+          "A shelter that has recorded no kennels is shown a free count, which reads as a full or empty building it never reported.",
+          "Animals in care with no kennel recorded are omitted, so the free count implies a completeness the board does not have.",
+          "A unit held out of service for cleaning or repair is counted as free.",
+          "A released stay still shows its animal, so an old occupant hides a free run."
+        ],
+        "acceptanceThresholds": [
+          "Occupied-of-total and free are stated before the map.",
+          "Every unit renders either its occupant or that it is free.",
+          "Unplaced animals are named, with the free count qualified.",
+          "The list flip carries the same units as the map and no fewer."
+        ]
+      },
+      "ratifiedBy": {
+        "role": "owner",
+        "ref": "BI-F91D0685"
+      },
+      "reviewRef": "BI-F91D0685",
+      "intentEvidenceRefs": [
+        {
+          "kind": "operator-request",
+          "ref": "BI-E54F7F87",
+          "summary": "Owner, looking at the running portal: no notion of the pets currently in the shelter, and asked to know where they are, like a restaurant layout."
+        },
+        {
+          "kind": "design-review",
+          "ref": "docs/superpowers/plans/2026-09-02-ward-board-housing-and-occupancy.md",
+          "summary": "The plan records the substrate verification behind this route and the four-phase order; the surface shape was scored through principle_decide DI-6E711DA68A9B against list-only and map-only."
+        }
+      ]
     }
   ]
 }

--- a/apps/web/lib/ux-budget/route-shells.generated.json
+++ b/apps/web/lib/ux-budget/route-shells.generated.json
@@ -1,11 +1,11 @@
 {
   "generator": "apps/web/scripts/build-route-shells.ts",
-  "pageRouteCount": 325,
+  "pageRouteCount": 326,
   "migratedCount": 1,
   "summary": {
     "cockpit": 17,
     "list": 6,
-    "detail": 252,
+    "detail": 253,
     "settings": 12,
     "form": 17,
     "public": 21,
@@ -4020,6 +4020,18 @@
       "routePath": "/workspace/my-queue",
       "shell": "detail",
       "audience": "worker",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "sweepEligible": true,
+      "confidence": "high"
+    },
+    {
+      "routePath": "/workspace/ward",
+      "shell": "detail",
+      "audience": "owner",
       "migrated": false,
       "exemptChecks": [
         "next-action-marker",

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -496,7 +496,11 @@ describe("generated route-shell registry", () => {
     // case and publishes its path, so a detail surface is measurable at last.
     // Eligibility for a dynamic route is earned by that minting, not asserted —
     // an eligible-but-unresolved route fails the run rather than measuring a 404.
-    expect(registry.routes.filter((route) => route.sweepEligible)).toHaveLength(206);
+    // 206 -> 207: /workspace/ward (BI-F91D0685) — the ward board reads housing and
+    // occupancy from route-owned read models with no wall-clock or live-orchestration
+    // state, so its rendered output is stable and it carries a ratified page-purpose
+    // contract.
+    expect(registry.routes.filter((route) => route.sweepEligible)).toHaveLength(207);
     // 110 -> 113: the three exclusions above. Product Direction then adds seven
     // explicitly classified dynamic routes, bringing the combined total to 120.
     // 120 -> 121: /platform/ai/operations-map.

--- a/apps/web/lib/ward/ward-store.test.ts
+++ b/apps/web/lib/ward/ward-store.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  WARD_RESOURCE_DOMAIN,
+  buildPlacement,
+  buildRelease,
+  isInCare,
+  loadWardBoard,
+  openStayHorizon,
+  planSeedKennels,
+} from "./ward-store";
+
+const KENNELS = [
+  { id: "k1", label: "D1", serviceArea: "Dog ward", capacity: 1, blockedReason: null, lifecycle: "active" },
+  { id: "k2", label: "D2", serviceArea: "Dog ward", capacity: 1, blockedReason: null, lifecycle: "active" },
+];
+
+function client(over: Record<string, unknown> = {}) {
+  return {
+    resource: { findMany: vi.fn(async (_args: unknown) => KENNELS) },
+    resourceCapacityAllocation: {
+      findMany: vi.fn(async (_args: unknown) => [
+        { resourceId: "k1", demandRef: "a1", startsAt: new Date("2026-09-01T08:00:00Z"), releasedAt: null },
+      ]),
+    },
+    adoptableAnimal: {
+      findMany: vi.fn(async (_args: unknown) => [
+        { animalRef: "a1", name: "Ranger", status: "hold" },
+        { animalRef: "a2", name: "Saffron", status: "hold" },
+        { animalRef: "a3", name: "Marbles", status: "adopted" },
+      ]),
+    },
+    ...over,
+  };
+}
+
+describe("loadWardBoard", () => {
+  it("places animals into kennels and leaves the rest unplaced", async () => {
+    const board = await loadWardBoard({ organizationId: "org-1", db: client() });
+
+    expect(board?.totalUnits).toBe(2);
+    expect(board?.occupied).toBe(1);
+    expect(board?.free).toBe(1);
+    // Saffron is in care with no kennel; Marbles has been adopted and is neither.
+    expect(board?.unplaced).toEqual([{ animalRef: "a2", name: "Saffron" }]);
+  });
+
+  it("reads only this organization's active kennels", async () => {
+    const db = client();
+    await loadWardBoard({ organizationId: "org-1", db });
+
+    const [firstCall] = db.resource.findMany.mock.calls;
+    const where = (firstCall?.[0] as { where: Record<string, unknown> } | undefined)?.where;
+    expect(where).toMatchObject({ organizationId: "org-1", kindSlug: "kennel", lifecycle: "active" });
+  });
+
+  it("asks only for open stays — a released one is history, not an occupant", async () => {
+    const db = client();
+    await loadWardBoard({ organizationId: "org-1", db });
+
+    const [firstCall] = db.resourceCapacityAllocation.findMany.mock.calls;
+    const where = (firstCall?.[0] as { where: Record<string, unknown> } | undefined)?.where;
+    expect(where).toMatchObject({ demandSlug: "animal-occupancy", releasedAt: null });
+  });
+
+  it("distinguishes a shelter with no housing recorded from one with none free", async () => {
+    const empty = await loadWardBoard({
+      organizationId: "org-1",
+      db: client({ resource: { findMany: vi.fn(async (_args: unknown) => []) } }),
+    });
+    expect(empty).toBeNull();
+
+    const noClient = await loadWardBoard({ organizationId: "org-1", db: {} });
+    expect(noClient).toBeNull();
+  });
+
+  it("still draws the board when nothing has been placed yet", async () => {
+    const board = await loadWardBoard({
+      organizationId: "org-1",
+      db: client({ resourceCapacityAllocation: { findMany: vi.fn(async (_args: unknown) => []) } }),
+    });
+
+    expect(board?.free).toBe(2);
+    expect(board?.occupied).toBe(0);
+    expect(board?.unplaced.map((row) => row.name).sort()).toEqual(["Ranger", "Saffron"]);
+  });
+});
+
+describe("isInCare", () => {
+  it("counts everything except an animal that has been adopted", () => {
+    expect(isInCare("hold")).toBe(true);
+    expect(isInCare("available")).toBe(true);
+    expect(isInCare("quarantine")).toBe(true);
+    expect(isInCare("adopted")).toBe(false);
+    expect(isInCare("Adopted")).toBe(false);
+  });
+});
+
+describe("planSeedKennels", () => {
+  const resourceKinds = [{ kindSlug: "kennel", capacityUnit: "animals", maxCapacity: 100 }] as const;
+
+  it("turns the archetype's declared housing into a starting roster", () => {
+    const rows = planSeedKennels({
+      organizationId: "org-1",
+      resourceKinds,
+      areas: [
+        { serviceArea: "Dog ward", count: 2, labelPrefix: "D" },
+        { serviceArea: "Isolation", count: 1, labelPrefix: "I" },
+      ],
+    });
+
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({
+      kindSlug: "kennel",
+      capacityUnit: "animals",
+      capacity: 1,
+      domain: WARD_RESOURCE_DOMAIN,
+      label: "D1",
+      serviceArea: "Dog ward",
+    });
+    expect(rows.map((row) => row.label)).toEqual(["D1", "D2", "I1"]);
+  });
+
+  it("derives a stable key so re-seeding cannot double a roster", () => {
+    const once = planSeedKennels({ organizationId: "org-1", resourceKinds, areas: [{ serviceArea: "Dog ward", count: 2, labelPrefix: "D" }] });
+    const twice = planSeedKennels({ organizationId: "org-1", resourceKinds, areas: [{ serviceArea: "Dog ward", count: 2, labelPrefix: "D" }] });
+
+    expect(once.map((row) => row.resourceKey)).toEqual(twice.map((row) => row.resourceKey));
+    expect(new Set(once.map((row) => row.resourceKey)).size).toBe(2);
+  });
+
+  it("seeds nothing for an archetype that does not house its subject", () => {
+    expect(
+      planSeedKennels({
+        organizationId: "org-1",
+        resourceKinds: [{ kindSlug: "table", capacityUnit: "seats", maxCapacity: 12 }],
+        areas: [{ serviceArea: "Dog ward", count: 4, labelPrefix: "D" }],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("buildPlacement", () => {
+  const now = new Date("2026-09-02T09:00:00Z");
+
+  it("places an animal against the kennel on the canonical allocation", () => {
+    expect(buildPlacement({ organizationId: "org-1", kennelId: "k1", animalRef: "a1", now })).toMatchObject({
+      domain: WARD_RESOURCE_DOMAIN,
+      resourceId: "k1",
+      demandSlug: "animal-occupancy",
+      demandRef: "a1",
+      startsAt: now,
+      quantity: 1,
+    });
+  });
+
+  it("gives an open stay a horizon far enough out that it never reads expired", () => {
+    const placement = buildPlacement({ organizationId: "org-1", kennelId: "k1", animalRef: "a1", now });
+    expect(placement.endsAt).toEqual(openStayHorizon(now));
+    expect(placement.endsAt.getFullYear()).toBe(2036);
+  });
+
+  it("makes a repeated place the same move rather than a second animal in the run", () => {
+    const a = buildPlacement({ organizationId: "org-1", kennelId: "k1", animalRef: "a1", now });
+    const b = buildPlacement({ organizationId: "org-1", kennelId: "k1", animalRef: "a1", now });
+    expect(a.idempotencyKey).toBe(b.idempotencyKey);
+
+    const elsewhere = buildPlacement({ organizationId: "org-1", kennelId: "k2", animalRef: "a1", now });
+    expect(elsewhere.idempotencyKey).not.toBe(a.idempotencyKey);
+  });
+});
+
+describe("buildRelease", () => {
+  it("closes a stay with its reason rather than deleting the row", () => {
+    const now = new Date("2026-09-02T17:00:00Z");
+    expect(buildRelease("moved", now)).toEqual({ releasedAt: now, releaseReason: "moved" });
+    expect(buildRelease("left-care", now).releaseReason).toBe("left-care");
+  });
+});

--- a/apps/web/lib/ward/ward-store.ts
+++ b/apps/web/lib/ward/ward-store.ts
@@ -1,0 +1,195 @@
+import {
+  ANIMAL_OCCUPANCY_DEMAND_SLUG,
+  KENNEL_KIND_SLUG,
+  buildWardBoard,
+  type KennelRow,
+  type OccupancyRow,
+  type WardBoard,
+} from "./ward-occupancy";
+
+/**
+ * Reads and writes for the ward board over the canonical capacity substrate.
+ *
+ * The client is narrowed to the calls actually made so the projection can be
+ * exercised without a database, the way the archetype outcome facts already
+ * are. Every read is scoped to one organization by its caller.
+ */
+
+/** `ResourceDomain` is a closed enum with no shelter value. `care` is the
+ *  honest home: the care vertical became subject-agnostic in migration
+ *  20260822164000, and animal welfare is care. Widening the enum is a
+ *  migration and one archetype does not justify it. */
+export const WARD_RESOURCE_DOMAIN = "care";
+
+/**
+ * `ResourceCapacityAllocation.endsAt` is required, and a shelter stay has no
+ * known end — an animal leaves when it is adopted, returned, or transferred.
+ * `releasedAt` is therefore the authoritative close and `endsAt` is only a
+ * horizon far enough out that an open stay never looks expired. The canonical
+ * substrate doc already flags long episodes as the thing that will stress this
+ * model; a stay of years is exactly that case, and it is recorded here rather
+ * than discovered later.
+ */
+export const OPEN_STAY_HORIZON_YEARS = 10;
+
+export function openStayHorizon(from: Date): Date {
+  const horizon = new Date(from);
+  horizon.setFullYear(horizon.getFullYear() + OPEN_STAY_HORIZON_YEARS);
+  return horizon;
+}
+
+interface FindMany<T> {
+  (args: unknown): Promise<T[]>;
+}
+
+export interface WardStoreClient {
+  resource?: { findMany: FindMany<KennelRow & { kindSlug?: string }> };
+  resourceCapacityAllocation?: { findMany: FindMany<OccupancyRow> };
+  adoptableAnimal?: { findMany: FindMany<{ animalRef: string; name: string; status: string }> };
+}
+
+/** Animals that have left are not population and are not placed. */
+export function isInCare(status: string | null | undefined): boolean {
+  return (status ?? "").toLowerCase() !== "adopted";
+}
+
+/**
+ * Load the board. Returns `null` when the organization has no housing recorded
+ * at all — a shelter that has never told the system about a kennel has not
+ * answered "none free", and the caller must be able to tell those apart.
+ */
+export async function loadWardBoard(input: {
+  organizationId: string;
+  db: WardStoreClient;
+}): Promise<WardBoard | null> {
+  const { organizationId, db } = input;
+  if (!db.resource?.findMany) return null;
+
+  const kennels = await db.resource.findMany({
+    where: { organizationId, kindSlug: KENNEL_KIND_SLUG, lifecycle: "active" },
+    select: {
+      id: true,
+      label: true,
+      serviceArea: true,
+      capacity: true,
+      blockedReason: true,
+      lifecycle: true,
+    },
+  });
+  if (kennels.length === 0) return null;
+
+  const [occupancy, animals] = await Promise.all([
+    db.resourceCapacityAllocation?.findMany
+      ? db.resourceCapacityAllocation.findMany({
+          where: {
+            organizationId,
+            demandSlug: ANIMAL_OCCUPANCY_DEMAND_SLUG,
+            releasedAt: null,
+          },
+          select: { resourceId: true, demandRef: true, startsAt: true, releasedAt: true },
+        })
+      : Promise.resolve([] as OccupancyRow[]),
+    db.adoptableAnimal?.findMany
+      ? db.adoptableAnimal.findMany({
+          where: { organizationId },
+          select: { animalRef: true, name: true, status: true },
+        })
+      : Promise.resolve([] as Array<{ animalRef: string; name: string; status: string }>),
+  ]);
+
+  const animalNames = new Map(
+    animals.filter((animal) => isInCare(animal.status)).map((animal) => [animal.animalRef, animal.name]),
+  );
+
+  return buildWardBoard({ kennels, occupancy, animalNames });
+}
+
+/**
+ * The kennels an archetype declares, turned into rows a shelter can use.
+ *
+ * A rescue should not have to invent its own housing model before the board
+ * works, and the archetype already says what its housing is called and what a
+ * unit holds. Labels are the shelter's to rename afterwards; these are a
+ * starting roster, not a fixed layout.
+ */
+export function planSeedKennels(input: {
+  organizationId: string;
+  resourceKinds: ReadonlyArray<{ kindSlug: string; capacityUnit: string; maxCapacity: number }>;
+  areas: ReadonlyArray<{ serviceArea: string; count: number; labelPrefix: string }>;
+}): Array<{
+  organizationId: string;
+  resourceKey: string;
+  domain: string;
+  kindSlug: string;
+  label: string;
+  capacity: number;
+  capacityUnit: string;
+  serviceArea: string;
+}> {
+  const kennelKind = input.resourceKinds.find((kind) => kind.kindSlug === KENNEL_KIND_SLUG);
+  if (!kennelKind) return [];
+
+  const rows: ReturnType<typeof planSeedKennels> = [];
+  for (const area of input.areas) {
+    for (let index = 1; index <= area.count; index += 1) {
+      const label = `${area.labelPrefix}${index}`;
+      rows.push({
+        organizationId: input.organizationId,
+        // Stable and derivable, so re-seeding cannot double a roster.
+        resourceKey: `kennel-${area.labelPrefix.toLowerCase()}${index}`,
+        domain: WARD_RESOURCE_DOMAIN,
+        kindSlug: KENNEL_KIND_SLUG,
+        label,
+        capacity: 1,
+        capacityUnit: kennelKind.capacityUnit,
+        serviceArea: area.serviceArea,
+      });
+    }
+  }
+  return rows;
+}
+
+/** The allocation that places an animal in a kennel. */
+export function buildPlacement(input: {
+  organizationId: string;
+  kennelId: string;
+  animalRef: string;
+  now: Date;
+}): {
+  organizationId: string;
+  domain: string;
+  resourceId: string;
+  demandSlug: string;
+  demandRef: string;
+  startsAt: Date;
+  endsAt: Date;
+  quantity: number;
+  idempotencyKey: string;
+} {
+  return {
+    organizationId: input.organizationId,
+    domain: WARD_RESOURCE_DOMAIN,
+    resourceId: input.kennelId,
+    demandSlug: ANIMAL_OCCUPANCY_DEMAND_SLUG,
+    demandRef: input.animalRef,
+    startsAt: input.now,
+    endsAt: openStayHorizon(input.now),
+    quantity: 1,
+    // One open stay per animal per move: a repeated place is the same move,
+    // not a second animal in the run.
+    idempotencyKey: `animal-occupancy:${input.animalRef}:${input.kennelId}:${input.now.toISOString()}`,
+  };
+}
+
+/**
+ * Moving an animal closes the stay it is leaving before opening the next.
+ * Closing rather than deleting is what keeps housing a timeline, which is the
+ * property contact tracing needs — the row that says an animal shared a ward
+ * with the index case must survive the animal moving out of it.
+ */
+export function buildRelease(reason: "moved" | "left-care" | "corrected", now: Date): {
+  releasedAt: Date;
+  releaseReason: string;
+} {
+  return { releasedAt: now, releaseReason: reason };
+}

--- a/docs/architecture/architecture-counts.generated.md
+++ b/docs/architecture/architecture-counts.generated.md
@@ -12,4 +12,4 @@ this file; never retype them into prose, where they drift (Simplify & Strengthen
 | Prisma enums | 76 | `packages/db/prisma/schema/` |
 | Migrations | 563 | `packages/db/prisma/migrations/` |
 | Kernel principles | 100 | `docs/founder-kernel/wiki/principles/` |
-| App routes | 645 | `apps/web/lib/ea/route-manifest.json` |
+| App routes | 646 | `apps/web/lib/ea/route-manifest.json` |

--- a/docs/superpowers/plans/2026-09-02-ward-board-housing-and-occupancy.md
+++ b/docs/superpowers/plans/2026-09-02-ward-board-housing-and-occupancy.md
@@ -87,7 +87,7 @@ reads, phase 2 lets a shelter record housing without a board to show it, phase 3
 
 ## Phases
 
-### Phase 1 — occupancy projection *(this PR)*
+### Phase 1 — occupancy projection *(delivered)*
 
 `apps/web/lib/ward/ward-occupancy.ts`, pure and fully unit-tested. Given kennels, allocations and
 animal names it produces the board: zones by the shelter's own `serviceArea`, units ordered
@@ -104,23 +104,66 @@ Properties the tests pin, each earned from the operating model rather than inven
 - No housing recorded and no housing free render differently. `summarizeKennelCapacity` returns
   `null` for the first — the same honesty the donation tile and `/performance` already keep.
 
-### Phase 2 — kennel roster and placement writes
+### Phase 2 — kennel roster and placement writes *(delivered: projection-side)*
 
-Create, rename, block and unblock a kennel; place an animal into one and release it. Kennel writes
-take their own path rather than widening the table-coupled admin route. Seed the archetype's
-declared `resourceKinds` on activation so a rescue is not asked to invent its own housing model.
+`planSeedKennels`, `buildPlacement` and `buildRelease` shape the rows: a seed roster derived from
+the archetype's declared `resourceKinds` with a stable `resourceKey` so re-seeding cannot double it,
+an allocation carrying an idempotency key so a repeated place is the same move rather than a second
+animal in the run, and a release that **closes** a stay with its reason instead of deleting the row.
 
-### Phase 3 — the board surface
+Closing rather than deleting is what keeps housing a timeline: the row saying an animal shared a
+ward with the index case has to survive that animal moving out of it.
 
-Map and list, occupancy header, per-unit occupant with photograph, empty unit as the intake
-affordance. `OperationalSceneLayout` supplies position and **tier** — cat condos stack, which is the
-requirement a flat restaurant floor never exercised.
+`ResourceCapacityAllocation.endsAt` is required and a shelter stay has no known end, so `releasedAt`
+is authoritative and `endsAt` is a ten-year horizon. The canonical substrate doc already names long
+episodes as the thing that will stress this model; a stay of years is that case, recorded here
+rather than discovered later.
 
-### Phase 4 — capacity on the cockpit
+**Still to come:** the mutation endpoints and the activation hook that call these. The shapes and
+their invariants are covered; nothing yet writes.
 
-`Kennels — N total · M free` beside the `Animals in care` tile shipped in PR #4972, closing the
-16:00 step. Deliberately last: it reads a model built earlier, and a tile built first correctly
-shows nothing.
+### Phase 3 — the board surface *(delivered)*
+
+`/workspace/ward` renders the map by default with a list flip, grouped by the shelter's own
+`serviceArea`, free units visibly empty. Chosen over list-only and map-only through
+`principle_decide` (`DI-6E711DA68A9B`, composite 9.673, margin 0.804, high confidence): list-only
+scores *negative* on "Do the work; don't task the operator" because it turns a capacity
+conversation back into counting rows, and map-only is opposed by "Every non-text element needs a
+text alternative" — which is why the list is a flip rather than a separate page.
+
+**Still to come:** per-unit photograph, the empty unit as the intake affordance, and
+`OperationalSceneLayout` for position and **tier** — cat condos stack, the requirement a flat
+restaurant floor never exercised.
+
+### Phase 4 — capacity on the cockpit *(delivered)*
+
+`Kennels — N free` beside the `Animals in care` tile from PR #4972, closing the 16:00 step. A full
+shelter reads `warning`, not a healthy zero; a shelter that has recorded no housing reads
+**"Not recorded"**, never `0 free`, because telling a manager they are full when nobody has entered
+a kennel is the failure this tile exists to avoid.
+
+### Phase 5 — the cockpit's front door *(delivered, narrowed)*
+
+Found by the owner on the running portal, in the same sitting as the missing animals: the cockpit
+led with **"From your storefront"** and **"Storefront bookings and inquiries waiting on you"**. A
+storefront is what DPF calls the product. It is not what a rescue calls the people arriving at its
+door.
+
+While this branch was held at the gate, PRs #5026 and #5028 landed on `main` and fixed most of it —
+and fixed it *better* than the version first written here. They key the vocabulary on `archetypeId`
+(`pet-rescue`, `animal-shelter`) rather than on the category, so the rescue reads *adoption
+enquiries*, *donations* and *Care readiness*; keying on `nonprofit-community`, as this branch
+originally did, would have put the same words in front of a food bank and a sports club. That work
+is taken wholesale here and the earlier approach was discarded rather than re-litigated.
+
+What those PRs did not reach is the line the owner actually pointed at. `buildWorkspaceStorefrontSummary`
+still chose its headline with `vocab.isRestaurant ? "From your guests" : "From your storefront"`, so
+every business that was not a restaurant inherited the retail default no matter how good its
+vocabulary row was. The remaining change is small and matches the shape already there:
+`inboundHeadline` and `inboundSubhead` become vocabulary fields on all three tables, the branch
+becomes a lookup, and the rescue reads **"From your community"**. A test asserts that no archetype's
+worker copy contains the product noun, so the next archetype cannot inherit another's front door by
+falling through a branch. One finance branch had identical arms and was collapsed.
 
 ## Definition of done for phase 1
 

--- a/docs/user-guide/workspace/index.md
+++ b/docs/user-guide/workspace/index.md
@@ -77,6 +77,30 @@ operational grammar, not live hotel data. Live assignment, housekeeping, and
 maintenance commands remain unavailable until the business's durable room
 provider is connected.
 
+## The ward, for a shelter
+
+An animal rescue opens **Operations > Ward** to answer the two questions a
+shelter asks all day: where an animal is, and how much room is left.
+
+- The board states **occupied of total** and **free** before anything else, then
+  draws the units grouped by your own ward names. A free run is an outline you
+  can see rather than a number you have to work out.
+- **List** shows the same units as a table when you want the area and state per
+  row. It carries every unit the map does.
+- A unit held out of service — a deep clean, a repair — shows its reason and is
+  **not** counted as free.
+- If the shelter is holding animals with no kennel recorded, the board names
+  them and says the free count covers only the animals it can place.
+
+Two states are deliberately different. A shelter that has recorded **no
+housing** sees "No housing recorded yet" and no free count at all, because
+having told the system about no kennels is not the same as having no room. A
+shelter whose units are all full sees a free count of zero.
+
+The same figures appear on the Operations home as **Animals in care** and
+**Kennels**, so the number you quote in a capacity conversation is the number
+the board is drawing.
+
 ## Confirming an operational suggestion
 
 An AI coworker can suggest an assignment, but the suggestion is not a completed

--- a/docs/ux-fit/2026-09-02-ward-board-map-and-list.ux-fit.json
+++ b/docs/ux-fit/2026-09-02-ward-board-map-and-list.ux-fit.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "decidedOption": "map-with-list-flip",
+  "decisionInteractionId": "DI-6E711DA68A9B",
+  "scope": {
+    "files": [
+      "apps/web/app/(shell)/workspace/ward/page.tsx"
+    ]
+  },
+  "evidence": {
+    "kind": "propose-n-pick",
+    "consideredOptions": [
+      "map-with-list-flip",
+      "list-only",
+      "map-only"
+    ],
+    "note": "A measured operating day could not answer two questions at any point: where is this animal, and how many kennels are free (pet-rescue operating model 6b, steps 08:00 and 16:00). map-with-list-flip won at composite 9.673 with a 0.804 margin, high confidence, autonomy eligible, no commandment conflict. It draws units grouped by the shelter's own service areas so a free run is a gap you see rather than a number you compute, and keeps a list flip for what a map cannot hold. list-only scored 8.869: cheaper and easier to keep correct, but it turns a capacity conversation back into counting rows, and 'Do the work; don't task the operator' scores it NEGATIVE (-0.021) where the map scores +0.101 — the only axis where the two options invert. map-only scored 6.928 and is opposed by 'Every non-text element needs a text alternative' (0.242 against 0.415): a drawn board with no tabular alternative is the accessibility failure, which is why the list is a flip rather than a separate page. Cognitive load was scored as a COST axis per AGENTS.md 11: the map at 0.3 demands less attention than the list at 0.6 because occupancy is read spatially. The page states occupied-of-total and free before anything else, and says plainly when housing has never been recorded rather than rendering a confident zero — a shelter that has told the system about no kennels has not answered 'none free'. Where the board cannot place an animal it is in care with, it names those animals and says the free count is only true for the ones it can place."
+  }
+}

--- a/scripts/check-doc-anchor-existence.mjs
+++ b/scripts/check-doc-anchor-existence.mjs
@@ -128,6 +128,26 @@ export function interpretToolResponse(kind, id, body) {
 }
 
 /** POST one MCP tools/call. Returns the raw response text, or null on failure. */
+/**
+ * True when a catalog response admits it did not return everything. The tool
+ * reports `total`/`fetched`/`truncated`; any of those signalling a short read
+ * means an id absent from the page is not evidence the id does not exist.
+ */
+export function isTruncatedListing(body) {
+  let parsed;
+  try {
+    parsed = typeof body === "string" ? JSON.parse(body) : body;
+  } catch {
+    return true; // unparseable is not proof of completeness
+  }
+  const text = JSON.stringify(parsed?.result ?? parsed ?? null);
+  if (/"truncated"\s*:\s*true/.test(text)) return true;
+  const total = text.match(/"total"\s*:\s*(\d+)/);
+  const fetched = text.match(/"fetched"\s*:\s*(\d+)/);
+  if (total && fetched && Number(fetched[1]) < Number(total[1])) return true;
+  return false;
+}
+
 export async function callTool(endpoint, token, name, args) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
@@ -271,7 +291,17 @@ async function main() {
   const lookup = async (kind, id) => {
     if (kind === "epic") {
       if (epicListing === null) {
-        epicListing = (await callTool(endpoint, token, "list_epics", {})) ?? "unreachable";
+        // list_epics defaults to 100 rows. An install with more epics than that
+        // returned a TRUNCATED catalog, and every id past the cut read as
+        // "missing" — a correctly cited, freshly filed epic failed the guard.
+        // Ask for the documented maximum, and if the catalog is STILL truncated
+        // treat epic lookups as unverifiable rather than absent: everywhere else
+        // this guard fails open on uncertainty, and a partial listing is exactly
+        // that. Absence must be proven, never inferred from a short page.
+        const listing = await callTool(endpoint, token, "list_epics", { limit: 1000 });
+        epicListing = listing == null || isTruncatedListing(listing)
+          ? "unreachable"
+          : listing;
       }
       if (epicListing === "unreachable") return "unknown";
       return interpretToolResponse("epic", id, epicListing);

--- a/scripts/check-doc-anchor-existence.test.mjs
+++ b/scripts/check-doc-anchor-existence.test.mjs
@@ -12,6 +12,7 @@ import {
   classifyId,
   extractAnchorIds,
   interpretToolResponse,
+  isTruncatedListing,
   listChangedFiles,
   parseAnchorBaseline,
   serializeAnchorBaseline,
@@ -209,4 +210,35 @@ test("an unresolvable BASE_SHA must not exit 0 with OK (BI-B6433DC6)", () => {
   assert.doesNotMatch(out, /\bOK\.\s*$/m);
   assert.match(out, /cannot resolve|did not run/i);
   assert.match(out, /git fetch --deepen/);
+});
+
+// A live install with 115 epics returned only the first 100, and the plan citing
+// a correctly filed epic in the tail was failed as "does NOT exist in the live
+// backlog". Absence has to be proven; a short page never proves it.
+test("a truncated epic catalog is not evidence that a cited epic is missing", () => {
+  const truncated = JSON.stringify({
+    result: { epics: [{ epicId: "EP-AAAA1111" }], total: 115, fetched: 100, truncated: true },
+  });
+  assert.equal(isTruncatedListing(truncated), true);
+  // The listing genuinely contains no EP-5102F494, and the old guard called that
+  // missing. Truncation must divert it to "unknown" before that check is reached.
+  assert.equal(interpretToolResponse("epic", "EP-5102F494", truncated), "missing");
+});
+
+test("a complete epic catalog is trusted, so a real miss is still caught", () => {
+  const complete = JSON.stringify({
+    result: { epics: [{ epicId: "EP-AAAA1111" }], total: 1, fetched: 1, truncated: false },
+  });
+  assert.equal(isTruncatedListing(complete), false);
+  assert.equal(interpretToolResponse("epic", "EP-AAAA1111", complete), "exists");
+  assert.equal(interpretToolResponse("epic", "EP-NOTREAL0", complete), "missing");
+});
+
+test("fetched short of total counts as truncated even without the flag", () => {
+  assert.equal(isTruncatedListing(JSON.stringify({ result: { total: 115, fetched: 100 } })), true);
+  assert.equal(isTruncatedListing(JSON.stringify({ result: { total: 100, fetched: 100 } })), false);
+});
+
+test("an unparseable listing is never treated as a complete one", () => {
+  assert.equal(isTruncatedListing("<html>gateway timeout</html>"), true);
 });

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -2455,6 +2455,14 @@
     "longSentences": 0,
     "textMass": 6
   },
+  "apps/web/app/(shell)/workspace/ward/page.tsx": {
+    "vocabulary": 0,
+    "retiredVocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 26
+  },
   "apps/web/app/(storefront)/error.tsx": {
     "vocabulary": 0,
     "retiredVocabulary": 0,
@@ -7967,6 +7975,14 @@
     "longSentences": 0,
     "textMass": 7
   },
+  "apps/web/components/platform/coworker-record/CoworkerProactivityNote.tsx": {
+    "vocabulary": 0,
+    "retiredVocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 32
+  },
   "apps/web/components/platform/coworker-record/CoworkerRecordTabs.tsx": {
     "vocabulary": 0,
     "retiredVocabulary": 0,
@@ -8446,14 +8462,6 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 68
-  },
-  "apps/web/components/platform/coworker-record/CoworkerProactivityNote.tsx": {
-    "vocabulary": 0,
-    "retiredVocabulary": 0,
-    "genericLabels": 0,
-    "readability": 0,
-    "longSentences": 0,
-    "textMass": 32
   },
   "apps/web/components/proactivity/ProactivityLevelControl.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## What this is

The rest of the ward board. [#5000](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/5000) landed the occupancy projection; this is the surface a kennel technician can open, the write shapes that put an animal in a run, the free count on the cockpit, and a fix for the cockpit telling an animal rescue about its *storefront*.

It comes out of a measured operating day on the live install. Running Second Chance Animal Rescue for a day, the portal could not answer two questions at any point: **where is this animal**, and **how many kennels are free**. It knew about people and coworkers — everything secondary to the mission — and nothing about the animals in the building.

## What changed

**`/workspace/ward`** — the map by default, grouped by the shelter's own service areas, free units visibly empty, with a list flip. Chosen over list-only and map-only through `principle_decide` (`DI-6E711DA68A9B`, composite 9.673, margin 0.804, high confidence, no commandment conflict). list-only scores *negative* on "Do the work; don't task the operator" — it turns a capacity conversation back into counting rows. map-only is opposed by "Every non-text element needs a text alternative", which is why the list is a flip rather than a separate page.

**Cockpit capacity** — `Kennels — N free` beside `Animals in care`. A full shelter reads `warning`, not a healthy zero. A shelter that has recorded no housing reads **"Not recorded"**, never `0 free`: telling a manager they are full when nobody has entered a kennel is the failure that tile exists to avoid.

**Write shapes** — a seed roster from the archetype's own declared `resourceKinds` with a stable `resourceKey` so re-seeding cannot double it; an allocation with an idempotency key so a repeated place is the same move, not a second animal in the run; a release that **closes** a stay with its reason instead of deleting the row. Closing rather than deleting is what keeps housing a timeline — the row saying an animal shared a ward with the index case has to survive that animal moving out.

**The cockpit's front door** — the cockpit led with "From your storefront" and "Storefront bookings and inquiries waiting on you". A storefront is what DPF calls the product; it is not what a rescue calls the people at its door.

While this branch was held at the gate, #5026 and #5028 landed and fixed most of it — and fixed it *better* than the version first written here. They key vocabulary on `archetypeId` (`pet-rescue`, `animal-shelter`) rather than on the category, so the rescue reads *adoption enquiries*, *donations*, *Care readiness*. Keying on `nonprofit-community`, as this branch originally did, would have put the same generic words in front of a food bank and a sports club. That work is taken wholesale here; the earlier approach was discarded rather than re-litigated.

What those PRs did not reach is the line the owner actually pointed at. `buildWorkspaceStorefrontSummary` still chose its headline with `vocab.isRestaurant ? "From your guests" : "From your storefront"`, so every business that is not a restaurant inherits the retail default however good its vocabulary row is — which is why the headline survived two pet-rescue copy fixes.

So what is left is small and matches the shape already there: `inboundHeadline` and `inboundSubhead` become vocabulary fields on all three tables, the branch becomes a lookup, and the rescue reads **"From your community"**. A test asserts that no archetype's worker copy contains the product noun, so the next archetype cannot inherit another's front door by falling through a branch. One finance branch had identical arms and was collapsed.

## What it refuses to do

- **No housing recorded ≠ none free.** The projection returns `null`, and the page says so rather than rendering a confident zero.
- **Animals it cannot place are named**, and the page states the free count is only true for the ones it can. A capacity decision against a partial placement is worse than one against none.
- **A unit out of service for cleaning is not free.** A hotel room is empty between guests; a kennel awaiting a deep clean is not.
- **A released stay is history, not an occupant.**

The ratified purpose contract lists all four as false-success conditions.

## Substrate

No new tables. `Resource`, `ResourceCapacityAllocation` and `OperationalSceneLayout` are already generic — the care vertical became subject-agnostic in migration `20260822164000` — and the archetype already declares the `kennel` resource kind. This is reach, not absence.

Deliberately untouched: `/api/storefront/admin/hospitality-resources`, which hardcodes `ADMIN_RESOURCE_KIND = "table"`. Generalising it is BI-2C80E6EA's step 1 and would disturb a shipped vertical.

## Not claimed

The mutation endpoints and activation hook that call these shapes, per-unit photographs, the empty unit as an intake affordance, and `OperationalSceneLayout` position and **tier** — cat condos stack, a requirement a flat restaurant floor never exercised.

**Doc-anchor guard** — found by this PR failing on its own correct citation. `check-doc-anchor-existence.mjs` called `list_epics` with no limit, took the default 100 rows, and declared any epic past that nonexistent. This install has 115, so `EP-5102F494` — correctly filed, carrying five of this PR's items — was reported as *"does NOT exist in the live backlog"*. Every doc citing a recently created epic would hit it.

The guard fails open everywhere else: an unreachable endpoint is "skipped", never "missing", because absence has to be proven. A truncated page was the one case it mistook for a complete answer. It now requests the full catalog and, if the response still admits truncation, treats epic lookups as unverifiable rather than absent. Four tests pin it — including that a *complete* catalog still catches a genuine miss, so the guard is not blunted.

## Verification

- 401 tests across `lib/twin`, `lib/ward`, `lib/owner-first`, `lib/ux-budget`, `components/workspace-home`; 17 in `check-doc-anchor-existence.test.mjs`
- `tsc --noEmit` clean; 63 guards clean in preflight
- **local-CI exact-tree gate PASS** at `db06722e30bd` (evidence `cmtlabqfv02rs01p5egimh56e`) — no override used
- Page-purpose registry regenerated with `/workspace/ward` ratified

Refs BI-FB73D0B5, BI-D58567DC, BI-F91D0685, BI-A67AF6F0, EP-5102F494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
