### PR TITLE
feat(local-ci): the host preflight honours the change scope — a docs-only diff skips only guards that declare code-only inputs (BI-8CDA7F95)

### DIFF
--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -1683,6 +1683,9 @@
       "docs/architecture/theme-aware-styling-runbook.md",
       "docs/design/golden-triangle-design.md"
     ],
+    "scripts/ci-change-scope.mjs": [
+      "docs/testing/pre-pr-gate.md"
+    ],
     "scripts/ci-evidence-plan.mjs": [
       "docs/testing/ci-evidence.md"
     ],
@@ -3030,6 +3033,7 @@
       "scripts/check-label-association.mjs",
       "scripts/check-live-blocker-references.mjs",
       "scripts/check-mobile-jest-pin.mjs",
+      "scripts/ci-change-scope.mjs",
       "scripts/ci-policy-guards.test.mjs",
       "scripts/gate-worktree.mjs",
       "scripts/gate-worktree.sh",

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -249,7 +249,16 @@ to CI/the sandbox to enforce. The Repo Guard Loop runner
 guards and exits with a dedicated runner-failure code so a killed spawn never
 prints `N/24 guard(s) FAILED` naming an innocent guard that had, in fact, run.
 Run it standalone with `pnpm run pregate:preflight`
-(`--plan` prints the guard plan without running it). Emergency skip:
+(`--plan` prints the guard plan without running it, scoped to the diff;
+`--scope` prints the classified change scope and the guards it left out). **The preflight honours the change
+scope (BI-8CDA7F95).** It classifies the diff against `origin/main` with the
+same `scripts/ci-change-scope.mjs` classifier `ci.yml` branches on, and on a
+docs-only diff it leaves out only the guards that **declare** `inputs: ["code"]`
+in `scripts/lib/ci-policy-guards.mjs` — guards that read only source, schema,
+compose or package manifests and so cannot be violated by prose. A guard with
+no declaration always runs; an unknown scope (no merge base) runs everything; a
+static test fails any declared guard whose import closure reads docs. CI still
+runs every guard. Emergency skip:
 `DPF_SKIP_PREGATE_PREFLIGHT_REASON="<why>"` — printed on the gate run, and CI
 still enforces every guard. Routing probes (`--dry-run`) and evidence replays
 (`--finalize-evidence`) skip the preflight automatically.

--- a/scripts/lib/ci-policy-guards.mjs
+++ b/scripts/lib/ci-policy-guards.mjs
@@ -1,12 +1,30 @@
 import { spawnSync } from "node:child_process";
 import { resolveHostCommandInvocation } from "./host-command-invocation.mjs";
 
-function guard(legacyJobId, name, commands) {
+/**
+ * A policy guard entry.
+ *
+ * `options.inputs` (BI-8CDA7F95) DECLARES what class of change can violate the
+ * guard, so the host-side preflight can honour the change scope the cloud
+ * already trusts (scripts/ci-change-scope.mjs): a guard declared
+ * `inputs: ["code"]` reads only source, schema, compose or package manifests,
+ * and a docs-only diff (every changed path classified `docs` by
+ * config/ci-evidence-policy.json) cannot violate it. A guard with NO
+ * declaration always runs — an undeclared scope is never a reason to skip,
+ * because a wrong skip is a false green (the class BI-7B249AFE paid for).
+ * Declare `code` only after reading the guard's own enumeration of inputs;
+ * scripts/pregate-preflight.test.mjs statically checks that a declared guard's
+ * import closure references no docs/markdown inputs.
+ */
+function guard(legacyJobId, name, commands, options = {}) {
   return {
     id: legacyJobId,
     legacyJobId,
     name,
     commands,
+    inputs: Array.isArray(options.inputs) && options.inputs.length > 0
+      ? Object.freeze([...options.inputs])
+      : null,
   };
 }
 
@@ -114,7 +132,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     ]),
     guard("release-compose-pins", "Release Compose Pins", [
       conformanceTest("scripts/check-release-compose-pins.test.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("release-asset-contract", "Release Asset Contract", [
       // The consumer install has no git checkout: whatever the installer copies
       // out of the install dir must ship in the image's /dpf-release-assets.
@@ -139,7 +157,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
       // A guarded install step that skips in silence reads as success, and is
       // then recorded as done by Save-Progress. Optional-script guards must say so.
       conformanceTest("scripts/check-installer-skip-visibility.test.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("installer-state-contract", "Installer State Contract", [
       // Drives real bash: install-dpf.sh runs under `set -euo pipefail`, and the
       // failure mode here is shell exit-status semantics, not source text.
@@ -158,11 +176,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
         "scripts/installer-image-identity.test.mjs",
         "scripts/salvage-sweep.test.mjs",
       ),
-    ]),
+    ], { inputs: ["code"] }),
     guard("governed-teardown-guard", "Governed Teardown Contract", [
       node("--test", "scripts/check-governed-teardown-contract.test.mjs", "scripts/governed-teardown.test.mjs"),
       node("scripts/check-governed-teardown-contract.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("published-image-freshness", "Published Image Freshness", [
       // Decision logic only — the live registry check needs Docker and runs on a
       // schedule (.github/workflows/published-image-freshness.yml).
@@ -236,10 +254,10 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     ]),
     guard("mobile-jest-pin-guard", "Mobile Jest Pin Guard", [
       node("scripts/check-mobile-jest-pin.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("diagram-dependency-pin-guard", "Diagram Dependency Pin Guard", [
       node("scripts/check-diagram-dependency-pins.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("override-provenance-guard", "Workspace Supply-Chain Policy", [
       node("scripts/check-override-comments.mjs"),
       conformanceTest("scripts/check-override-comments.test.mjs"),
@@ -275,13 +293,13 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("application-boundary-guard", "Application Boundary Guard", [
       node("--test", "scripts/check-application-boundaries.test.mjs"),
       node("scripts/check-application-boundaries.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("label-association-guard", "Label Association Guard", [
       // A <label> bound to nothing renders, screenshots and inspects correctly
       // while a screen reader announces an unlabelled field — every human check
       // passes. Ratchet: blocks NET-NEW orphans, retightens as surfaces migrate.
       node("scripts/check-label-association.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("style-drift-guard", "Style Drift Guard", [
       node("scripts/check-style-drift.mjs"),
     ]),
@@ -291,21 +309,21 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("platform-composition-single-home", "Platform Composition Single-Home Guard", [
       node("--test", "scripts/check-platform-composition-single-home.test.mjs"),
       node("scripts/check-platform-composition-single-home.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("compose-env-contract-guard", "Compose Env Contract Guard", [
       node("scripts/check-compose-env-contract.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("compose-resource-budgets-guard", "Compose Resource Budgets Guard", [
       node("--test", "scripts/check-compose-resource-budgets.test.mjs"),
       node("scripts/check-compose-resource-budgets.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("n-minus-one-caller-honesty", "N-1 Caller Honesty", [
       node("--test", "scripts/check-n-minus-one-caller-honesty.test.mjs"),
       node("scripts/check-n-minus-one-caller-honesty.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("module-size-guard", "Module Size Guard", [
       node("scripts/check-module-size.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     // BI-2624B7EA: an EmploymentEvent written outside its canonical writer is a
     // log entry, which is the exact state EP-862820FD exists to remove. The
     // actuator shipped inert once and half-wired once; this closes the class.
@@ -338,7 +356,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("build-studio-surface-guard", "Build Studio Surface Guard", [
       node("--test", "scripts/check-build-studio-surface-budget.test.mjs"),
       node("scripts/check-build-studio-surface-budget.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     // BI-3F17B16B: an EP-/BI- id cited in a CHANGED doc must exist in the live
     // backlog (diff-scoped; grandfather baseline; degrades to warn-pass when no
     // live install is reachable). Closes the unbacked-doc-anchor pattern (P3).
@@ -369,7 +387,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("retention-enrollment-guard", "Retention Enrollment Guard", [
       node("--test", "scripts/check-retention-enrollment.test.mjs"),
       node("scripts/check-retention-enrollment.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     // Diff-scoped by design: repo-wide, the pattern matches 255 fixtures across 125
     // files, nearly all legitimate (far-future sentinels, deliberately-expired rows).
     // Gating on that would need a 125-file baseline — the silent allowlist this is
@@ -377,11 +395,11 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("test-clock-bomb-guard", "Test Clock Bomb Guard", [
       node("--test", "scripts/check-test-clock-bombs.test.mjs"),
       node("scripts/check-test-clock-bombs.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("work-unit-conformance-guard", "WorkUnit Conformance Guard", [
       node("--test", "scripts/check-work-unit-conformance.test.mjs"),
       node("scripts/check-work-unit-conformance.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("instruction-plane-guard", "Instruction Plane Guard", [
       conformanceTest("scripts/check-instruction-plane-size.test.mjs"),
       node("scripts/check-instruction-plane-size.mjs"),
@@ -398,13 +416,13 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("context-economy-guard", "Context Economy Guard", [
       node("--test", "scripts/check-context-economy.test.mjs"),
       node("scripts/check-context-economy.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     // Plane 4 — the standing TOOL registry, same soft shape and reusing plane 3's claim
     // review. Dispatch-time caps are governed elsewhere; this is the part that accretes.
     guard("tool-surface-guard", "Tool Surface Guard", [
       node("--test", "scripts/check-tool-surface.test.mjs"),
       node("scripts/check-tool-surface.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("archetype-completeness-guard", "Archetype Completeness Guard", [
       node("--test", "scripts/check-archetype-completeness.test.mjs"),
       node("scripts/check-archetype-completeness.mjs"),
@@ -412,7 +430,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("stewardship-scope-guard", "Stewardship Scope Guard", [
       node("--test", "scripts/check-stewardship-scope.test.mjs"),
       node("scripts/check-stewardship-scope.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("capability-consumer-guard", "Capability Consumer Guard", [
       node("--test", "scripts/check-capability-consumers.test.mjs"),
       node("scripts/check-capability-consumers.mjs"),
@@ -441,7 +459,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     ]),
     guard("mcp-tool-pack-guard", "MCP Tool Pack Guard", [
       node("scripts/check-mcp-tool-pack.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("package-boundary-guard", "Package Boundary Guard", [
       node("scripts/check-package-boundaries.mjs"),
     ]),
@@ -476,7 +494,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("rendered-backlog-pointers", "Rendered Backlog Pointers", [
       node("--test", "scripts/check-rendered-backlog-pointers.test.mjs"),
       node("scripts/check-rendered-backlog-pointers.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     // An item written to "deferred" with no reason, trigger, review date or owner
     // is not parked, it is gone: nothing fires, nothing comes due, nobody owns
     // it. Seven items sat in exactly that state — including BI-F0715C9C — and a
@@ -485,7 +503,7 @@ export const POLICY_GUARD_PROFILES = Object.freeze({
     guard("unattributable-deferral", "Unattributable Deferral", [
       node("--test", "scripts/check-no-unattributable-deferral.test.mjs"),
       node("scripts/check-no-unattributable-deferral.mjs"),
-    ]),
+    ], { inputs: ["code"] }),
     guard("janitor-tests", "Janitor Tests", [
       node(
         "--test",

--- a/scripts/lib/pregate-preflight.mjs
+++ b/scripts/lib/pregate-preflight.mjs
@@ -104,7 +104,28 @@ function stripSelfTests(entries) {
     .filter((entry) => entry.commands.length > 0);
 }
 
-export function buildPreflightPlan({ profiles = POLICY_GUARD_PROFILES } = {}) {
+/**
+ * BI-8CDA7F95: does this guard apply to the classified change scope?
+ *
+ * The scope comes from scripts/ci-change-scope.mjs — the same classifier
+ * ci.yml branches on — so host and cloud agree on what "docs-only" means. A
+ * guard is skipped ONLY when it DECLARES `inputs` that a docs-only diff cannot
+ * touch (`inputs: ["code"]`, see ci-policy-guards.mjs). No declaration, no
+ * classification, or any non-docs change: the guard runs. Never skip on a
+ * guess — a wrong skip is a false green (BI-7B249AFE).
+ */
+export function guardAppliesToScope(entry, changeScope) {
+  if (!changeScope || changeScope.docsOnly !== true) return true;
+  const inputs = Array.isArray(entry?.inputs) ? entry.inputs : null;
+  if (!inputs) return true;
+  return inputs.includes("docs");
+}
+
+/**
+ * The preflight plan for a change scope: the entries to run, and the entries
+ * left out because their declared inputs cannot be touched by this diff.
+ */
+export function planPreflight({ profiles = POLICY_GUARD_PROFILES, changeScope = null } = {}) {
   const source = stripSelfTests([
     ...(profiles.source ?? []),
     ...(profiles.workspace ?? []),
@@ -114,7 +135,14 @@ export function buildPreflightPlan({ profiles = POLICY_GUARD_PROFILES } = {}) {
       LOCAL_SAFE_PR_GUARD_IDS.includes(entry.id),
     ),
   );
-  return [...source, ...trailer];
+  const all = [...source, ...trailer];
+  const entries = all.filter((entry) => guardAppliesToScope(entry, changeScope));
+  const skippedByScope = all.filter((entry) => !guardAppliesToScope(entry, changeScope));
+  return { entries, skippedByScope, changeScope: changeScope ?? null };
+}
+
+export function buildPreflightPlan({ profiles = POLICY_GUARD_PROFILES, changeScope = null } = {}) {
+  return planPreflight({ profiles, changeScope }).entries;
 }
 
 function defaultExecute(command, args) {

--- a/scripts/pregate-preflight.mjs
+++ b/scripts/pregate-preflight.mjs
@@ -4,28 +4,60 @@
 // scripts/pregate.mjs invoke it automatically before lease admission.
 //
 //   node scripts/pregate-preflight.mjs           # run the preflight
-//   node scripts/pregate-preflight.mjs --plan    # print the plan as JSON
+//   node scripts/pregate-preflight.mjs --plan    # print the plan as JSON (scoped to this diff)
+//   node scripts/pregate-preflight.mjs --scope   # print the classified change scope and what it leaves out
 //
 // Exit codes: 0 = clean (environment-skipped guards are warnings), 1 = at
 // least one guard reported a genuine violation.
 
 import {
   PREFLIGHT_SKIP_ENV,
-  buildPreflightPlan,
+  planPreflight,
   runPreflight,
 } from "./lib/pregate-preflight.mjs";
+import { classifyChangedFiles } from "./ci-change-scope.mjs";
 import { checkStaleRootClone } from "./lib/stale-root-clone.mjs";
 import { isEntryModule } from "./lib/entry-module.mjs";
 import { ensureCompileReady, getChangedFilesAgainstMain } from "./lib/ensure-compile-ready.mjs";
 
+/**
+ * BI-8CDA7F95: classify the diff with the classifier the cloud trusts. When the
+ * changed files cannot be resolved (no merge base — the clone re-shallowed,
+ * BI-4EE2E5C0), the scope is unknown and EVERY guard runs.
+ */
+function resolveChangeScope(worktreePath) {
+  const changedFiles = getChangedFilesAgainstMain(worktreePath);
+  if (!Array.isArray(changedFiles)) return { changeScope: null, changedFiles: null };
+  return { changeScope: classifyChangedFiles(changedFiles), changedFiles };
+}
+
+function describeScope(changeScope) {
+  if (!changeScope) return "unknown (no merge base) — every guard runs";
+  if (changeScope.docsOnly) return "docs-only";
+  if (changeScope.mobileOnly) return "mobile-only";
+  return "full";
+}
+
 export async function main() {
-  if (process.argv.includes("--plan")) {
-    const plan = buildPreflightPlan().map((entry) => ({
+  if (process.argv.includes("--plan") || process.argv.includes("--scope")) {
+    const { changeScope } = resolveChangeScope(process.cwd());
+    const planned = planPreflight({ changeScope });
+    const project = (entry) => ({
       id: entry.id,
       name: entry.name,
       commands: entry.commands.map(([command, args]) => [command, ...args].join(" ")),
-    }));
-    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    });
+    // `--plan` keeps its array contract (the entries that will run, scoped to
+    // this diff); `--scope` explains the classification and what it left out.
+    const payload = process.argv.includes("--scope")
+      ? {
+        changeScope: describeScope(changeScope),
+        run: planned.entries.map((entry) => entry.id),
+        skippedByScope: planned.skippedByScope.map((entry) => ({ id: entry.id, inputs: entry.inputs })),
+      }
+      : planned.entries.map(project);
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}
+`);
     return;
   }
 
@@ -72,8 +104,21 @@ export async function main() {
     );
   }
 
+  const { changeScope } = resolveChangeScope(process.cwd());
+  const planned = planPreflight({ changeScope });
+  if (planned.skippedByScope.length > 0) {
+    process.stdout.write(
+      `[pregate-preflight] change scope ${describeScope(changeScope)}: ${planned.skippedByScope.length} guard(s) ` +
+        `declared inputs a docs-only diff cannot touch are not run (${planned.skippedByScope.map((e) => e.id).join(", ")}); ` +
+        `${planned.entries.length} guard(s) run. CI still runs every guard.\n`,
+    );
+  } else if (!changeScope) {
+    process.stdout.write("[pregate-preflight] change scope unknown (no merge base against origin/main) — every guard runs.\n");
+  }
+
   const startedAt = Date.now();
   const result = await runPreflight({
+    plan: planned.entries,
     // Failure lines are printed from the FINAL classified entries below —
     // an env-degraded guard transiently looks "failed" at finish-time and
     // must not be announced as a failure here.

--- a/scripts/pregate-preflight.test.mjs
+++ b/scripts/pregate-preflight.test.mjs
@@ -9,6 +9,9 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import * as fsSync from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -18,6 +21,8 @@ import {
   LOCAL_SAFE_PR_GUARD_IDS,
   PREFLIGHT_SKIP_ENV,
   buildPreflightPlan,
+  guardAppliesToScope,
+  planPreflight,
   isEnvironmentFailureOutput,
   isRunnerFailureResult,
   runPreflight,
@@ -465,4 +470,105 @@ test("pregate.mjs --dry-run skips the preflight and still reaches gate routing",
   assert.equal(result.status, 0, result.stderr);
   assert.doesNotMatch(result.stdout, /pregate-preflight/);
   assert.match(result.stdout, /gate-worktree dry-run/);
+});
+
+// BI-8CDA7F95: the preflight honours the change scope the cloud trusts. A guard
+// is left out of a docs-only run ONLY when it DECLARES inputs a docs-only diff
+// cannot touch. Undeclared guards, unknown scope, and any non-docs change run
+// everything — a wrong skip is a false green.
+const scopedProfiles = {
+  source: [
+    { id: "code-only", legacyJobId: "code-only", name: "Code Only", commands: [["node", ["scripts/code-only.mjs"]]], inputs: ["code"] },
+    { id: "undeclared", legacyJobId: "undeclared", name: "Undeclared", commands: [["node", ["scripts/undeclared.mjs"]]], inputs: null },
+    { id: "docs-aware", legacyJobId: "docs-aware", name: "Docs Aware", commands: [["node", ["scripts/docs-aware.mjs"]]], inputs: ["code", "docs"] },
+  ],
+  workspace: [],
+  "pull-request": [],
+};
+
+test("a docs-only scope leaves out only guards that declare inputs: [\"code\"]", () => {
+  const planned = planPreflight({ profiles: scopedProfiles, changeScope: { docsOnly: true, mobileOnly: false, heavy: false } });
+  assert.deepEqual(planned.entries.map((e) => e.id), ["undeclared", "docs-aware"]);
+  assert.deepEqual(planned.skippedByScope.map((e) => e.id), ["code-only"]);
+});
+
+test("a full or mobile-only scope, or an unknown scope, runs every guard", () => {
+  for (const changeScope of [
+    { docsOnly: false, mobileOnly: false, heavy: true },
+    { docsOnly: false, mobileOnly: true, heavy: false },
+    null,
+    undefined,
+  ]) {
+    const planned = planPreflight({ profiles: scopedProfiles, changeScope });
+    assert.deepEqual(planned.entries.map((e) => e.id), ["code-only", "undeclared", "docs-aware"], String(changeScope));
+    assert.deepEqual(planned.skippedByScope, []);
+  }
+  assert.equal(guardAppliesToScope({ inputs: ["code"] }, null), true);
+  assert.equal(guardAppliesToScope({ inputs: ["code"] }, { docsOnly: true }), false);
+  assert.equal(guardAppliesToScope({ inputs: null }, { docsOnly: true }), true);
+  assert.equal(guardAppliesToScope({}, { docsOnly: true }), true);
+});
+
+test("buildPreflightPlan without a scope is unchanged (every guard)", () => {
+  assert.deepEqual(
+    buildPreflightPlan({ profiles: scopedProfiles }).map((e) => e.id),
+    ["code-only", "undeclared", "docs-aware"],
+  );
+});
+
+test("the real registry declares the module-size guard code-only and leaves the docs guards undeclared", () => {
+  const all = [...POLICY_GUARD_PROFILES.source, ...POLICY_GUARD_PROFILES.workspace, ...POLICY_GUARD_PROFILES["pull-request"]];
+  const byId = new Map(all.map((e) => [e.id, e]));
+  assert.deepEqual(byId.get("module-size-guard").inputs, ["code"]);
+  for (const id of ["docs-link-integrity", "docs-impact-gate", "prose-lint-guard", "instruction-plane-rule-coverage", "doc-reference-integrity"]) {
+    assert.equal(byId.get(id).inputs, null, `${id} must stay undeclared (it reads docs)`);
+  }
+  const docsOnly = planPreflight({ changeScope: { docsOnly: true, mobileOnly: false, heavy: false } });
+  assert.ok(docsOnly.skippedByScope.length >= 20, `expected a material docs-only saving, got ${docsOnly.skippedByScope.length}`);
+  assert.ok(docsOnly.entries.some((e) => e.id === "docs-link-integrity"));
+});
+
+// Drift detector: a guard declared `inputs: ["code"]` must not read docs or
+// markdown anywhere in its static import closure. This is the check that makes
+// a declaration a claim someone can falsify rather than a comment.
+test("every guard declared code-only has an import closure that references no docs or markdown inputs", () => {
+  const { readFileSync, existsSync } = fsSync;
+  const docsInputRe = /\.mdx?\b|\bdocs\/|markdown|AGENTS\.md|\.adoc|\.rst|memory\/|user-guide/;
+  const importRe = /from\s+["'](\.{1,2}\/[^"']+)["']|import\(\s*["'](\.{1,2}\/[^"']+)["']\s*\)/g;
+  const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+  function closure(file, seen = new Set(), depth = 0) {
+    if (seen.has(file) || depth > 3 || !existsSync(file)) return seen;
+    seen.add(file);
+    const src = readFileSync(file, "utf8");
+    for (const m of src.matchAll(importRe)) {
+      let target = join(dirname(file), m[1] || m[2]);
+      if (!existsSync(target)) {
+        if (existsSync(`${target}.mjs`)) target = `${target}.mjs`;
+        else if (existsSync(`${target}.js`)) target = `${target}.js`;
+        else continue;
+      }
+      closure(target, seen, depth + 1);
+    }
+    return seen;
+  }
+  const all = [...POLICY_GUARD_PROFILES.source, ...POLICY_GUARD_PROFILES.workspace, ...POLICY_GUARD_PROFILES["pull-request"]];
+  const offenders = [];
+  for (const entry of all) {
+    if (!entry.inputs || entry.inputs.includes("docs")) continue;
+    // Self-tests are stripped from the plan (and CI runs them), so only the
+    // commands that actually run host-side are audited: check scripts, plus
+    // conformance-marked --test commands, which the preflight keeps.
+    const scripts = entry.commands.flatMap(([, args, options]) => (
+      args[0] === "--test" && options?.conformance !== true
+        ? []
+        : args.filter((a) => /^scripts\/.*\.mjs$/.test(a))
+    ));
+    assert.ok(scripts.length > 0, `${entry.id}: a code-only declaration needs an auditable script, not a pnpm alias`);
+    const files = new Set();
+    for (const script of scripts) for (const f of closure(join(repoRoot, script))) files.add(f);
+    for (const f of files) {
+      if (docsInputRe.test(readFileSync(f, "utf8"))) offenders.push(`${entry.id} <- ${f.slice(repoRoot.length)}`);
+    }
+  }
+  assert.deepEqual(offenders, [], "declared code-only guards reference docs inputs:\n" + offenders.join("\n"));
 });


### PR DESCRIPTION
## What

AGENTS.md §4: "Tier the gate to the change … docs → lint only." The cloud does it (`scripts/ci-change-scope.mjs`) and the local gate does it (documentation evidence lane), but the host preflight in front of both took no changed-files argument and ran all 63 entries for every diff (BI-8CDA7F95).

Guards never declared what can violate them, so nothing could be skipped honestly. This adds the declaration; nothing undeclared is skipped.

## How

- `scripts/lib/ci-policy-guards.mjs`: `guard()` takes `options.inputs`. `inputs: ["code"]` means the guard reads only source, schema, compose or package manifests, so a docs-only diff cannot violate it. **23 guards declared**, each after reading its own input enumeration (walks filtered to `.ts/.tsx`, named compose/package/prisma/ps1 inputs). Every docs reader stays undeclared and always runs. The Repo Guard Loop stays undeclared: it discovers `check-no-*` guards dynamically, which a static audit cannot vouch for.
- `scripts/lib/pregate-preflight.mjs`: `planPreflight({ changeScope })` / `guardAppliesToScope()`. A guard is left out **only** when the scope is docs-only **and** the guard declares code-only inputs. No declaration, unknown scope (no merge base, BI-4EE2E5C0), mobile-only or full: everything runs.
- `scripts/pregate-preflight.mjs`: classifies the diff with `classifyChangedFiles` — the same classifier `ci.yml` trusts — and says which guards the scope left out. `--plan` keeps its array contract (now scoped); `--scope` explains the classification.
- Drift detector in `scripts/pregate-preflight.test.mjs`: fails any declared code-only guard whose host-run import closure references docs/markdown inputs. A pnpm-alias guard cannot be declared (nothing to audit).

## Measured (this host, gate running concurrently)

| diff | entries | wall-clock |
| --- | --- | --- |
| docs-only probe, scoped | 40 | 141.3s |
| code diff, full (earlier this session) | 63 | 143.5s / 175.0s |

Entry count drops 63 → 40. **Wall-clock did not materially improve on this measurement**: the guards a docs-only diff still needs (Repo Guard Loop, docs-link integrity, prose lint, SBOM, derived-artifact registry) carry most of the time. The saving this slice buys is 23 entries and their failure surface; seconds need per-guard durations in the receipt and then content-addressed guard caching (BI-282AE0BC).

## Design grounding

- Specs reviewed: AGENTS.md §4 tiering rule; `docs/testing/pre-pr-gate.md` guard-parity preflight section (BI-D35433FB, BI-7B249AFE).
- Code substrate: `scripts/ci-change-scope.mjs` + `config/ci-evidence-policy.json` (the docs-only rule), `scripts/lib/ensure-compile-ready.mjs` (`getChangedFilesAgainstMain`, already imported by the preflight), `conformanceTest()` mark from #4837 as the precedent for a registry-level declaration enforced by a test.
- Source of truth: the guard registry declares inputs; the planner consumes them; the cloud classifier defines scope.
- Decision: extend the existing registry rather than build a second preflight or a side table of scopes.

## Tests

Red: with the implementation stashed, the new test file fails to load (missing export). Green: `pregate-preflight`, `ci-change-scope`, `check-guard-conformance-marks`, `check-ci-policy-test-inventory` — 50 tests, 0 failures.

**Backlog item:** BI-8CDA7F95 · Epic EP-ABB3AC9D · Workroom WC-E437F973

🤖 Generated with [Claude Code](https://claude.com/claude-code)
