### PR TITLE
fix(pet-rescue): finish cockpit vocabulary reach

### DIFF
--- a/apps/web/app/(shell)/finance/RecentInvoicesTable.test.tsx
+++ b/apps/web/app/(shell)/finance/RecentInvoicesTable.test.tsx
@@ -30,4 +30,18 @@ describe("RecentInvoicesTable (report-kit migration)", () => {
     expect(html).toContain("£1,200.00");
     expect(html).toContain("£50.50");
   });
+
+  it("can present internal invoice rows as Pet Rescue contributions", () => {
+    const rescueHtml = renderToStaticMarkup(
+      <RecentInvoicesTable
+        rows={ROWS}
+        currencySymbol="$"
+        accountHeader="Supporter or funder"
+        emptyLabel="No contributions yet."
+      />,
+    );
+
+    expect(rescueHtml).toContain("Supporter or funder");
+    expect(rescueHtml).not.toContain(">Account<");
+  });
 });

--- a/apps/web/app/(shell)/finance/RecentInvoicesTable.tsx
+++ b/apps/web/app/(shell)/finance/RecentInvoicesTable.tsx
@@ -25,9 +25,13 @@ function formatMoney(amount: number): string {
 export function RecentInvoicesTable({
   rows,
   currencySymbol,
+  accountHeader = "Account",
+  emptyLabel = "No invoices yet.",
 }: {
   rows: RecentInvoiceRow[];
   currencySymbol: string;
+  accountHeader?: string;
+  emptyLabel?: string;
 }) {
   const columns: Column<RecentInvoiceRow>[] = [
     {
@@ -45,7 +49,7 @@ export function RecentInvoicesTable({
     },
     {
       key: "account",
-      header: "Account",
+      header: accountHeader,
       cell: (inv) => (
         <Link href={`/finance/invoices/${inv.id}`} className="text-[var(--dpf-text)] hover:underline">
           {inv.accountName}
@@ -83,7 +87,7 @@ export function RecentInvoicesTable({
 
   return (
     <div className="rounded-lg border border-[var(--dpf-border)] p-1">
-      <DataTable columns={columns} rows={rows} getRowKey={(inv) => inv.id} empty="No invoices yet." />
+      <DataTable columns={columns} rows={rows} getRowKey={(inv) => inv.id} empty={emptyLabel} />
     </div>
   );
 }

--- a/apps/web/app/(shell)/finance/page.tsx
+++ b/apps/web/app/(shell)/finance/page.tsx
@@ -225,15 +225,20 @@ export default async function FinancePage() {
   // collapsed advanced region. Supersedes the generic owner-first summary band
   // (BI-3BCAF95F) for food-hospitality, so it returns before that is built.
   if (financeSurface.mode === "owner-first") {
+    const metricCopy = financeSurface.metricCopy;
     const moneyJobMetrics: Partial<Record<FinanceMetricKey, MoneyJobMetric>> = {
       "outstanding-receivables": {
         value: `${sym}${formatMoney(owedAmount)}`,
-        hint: `${owedCount} invoice${owedCount !== 1 ? "s" : ""} outstanding`,
+        hint: `${owedCount} ${owedCount === 1
+          ? (metricCopy?.outstandingSingular ?? "invoice")
+          : (metricCopy?.outstandingPlural ?? "invoices")} outstanding`,
         intent: owedAmount > 0 ? "warning" : "neutral",
       },
       "money-in-month": {
         value: `${sym}${formatMoney(paidAmount)}`,
-        hint: `${paidCount} invoice${paidCount !== 1 ? "s" : ""} paid this month`,
+        hint: metricCopy
+          ? `${paidCount} ${paidCount === 1 ? metricCopy.receivedSingular : metricCopy.receivedPlural} received this month`
+          : `${paidCount} invoice${paidCount !== 1 ? "s" : ""} paid this month`,
         intent: paidAmount > 0 ? "success" : "neutral",
       },
       "overdue-count": {
@@ -243,7 +248,7 @@ export default async function FinancePage() {
             ? `oldest: ${oldestOverdue.account.name}`
             : hasAnyInvoices
               ? "all up to date"
-              : "no invoices recorded yet",
+              : (metricCopy?.emptyOverdue ?? "no invoices recorded yet"),
         intent: overdueCount > 0 ? "danger" : hasAnyInvoices ? "success" : "neutral",
       },
       "supplier-bills-due": {
@@ -283,7 +288,12 @@ export default async function FinancePage() {
               {financeSurface.recentRecordsEmpty}
             </p>
           ) : (
-            <RecentInvoicesTable rows={recentInvoiceRows} currencySymbol={sym} />
+            <RecentInvoicesTable
+              rows={recentInvoiceRows}
+              currencySymbol={sym}
+              accountHeader={metricCopy?.recentAccountHeader}
+              emptyLabel={metricCopy?.recentEmpty}
+            />
           )}
         </section>
       </div>

--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -28,6 +28,7 @@ import { resolveHomePhoneCountry } from "@/lib/phone-country.server";
 import { PhoneCountryProvider } from "@/components/ui/PhoneCountryContext";
 import { NAV_MODE_COOKIE, resolveNavModeFromCookie } from "@/lib/navigation/nav-mode";
 import { UxInitialLoadBoundary } from "@/components/shell/UxInitialLoadBoundary";
+import { resolveCustomerSurface } from "@/lib/owner-first/archetype-surface";
 
 export default async function ShellLayout({ children }: { children: React.ReactNode }) {
   // First-run check — redirect to setup if no org exists.
@@ -54,6 +55,7 @@ export default async function ShellLayout({ children }: { children: React.ReactN
     useUnifiedCoworker,
     phoneCountry,
     activeOrgCapabilities,
+    storefrontConfig,
   ] = await Promise.all([
     prisma.discoveryRun.findFirst({
       orderBy: { startedAt: "desc" },
@@ -76,6 +78,9 @@ export default async function ShellLayout({ children }: { children: React.ReactN
       // entries just stay hidden.
       console.error("[shell-nav] active-capability resolution failed", error);
       return new Set<string>() as ReadonlySet<string>;
+    }),
+    prisma.storefrontConfig.findFirst({
+      select: { archetype: { select: { archetypeId: true } } },
     }),
   ]);
 
@@ -165,9 +170,21 @@ export default async function ShellLayout({ children }: { children: React.ReactN
     platformRole: user.platformRole,
     isSuperuser: user.isSuperuser,
   };
-  const shellNavSections = activeSetup
+  const customerSurface = resolveCustomerSurface(storefrontConfig?.archetype.archetypeId, []);
+  const shellNavSections = (activeSetup
     ? []
-    : getShellNavSections(userContext, { activeOrgCapabilities, mode: navMode });
+    : getShellNavSections(userContext, { activeOrgCapabilities, mode: navMode })).map((section) => ({
+      ...section,
+      items: section.items.map((item) =>
+        item.key === "customer"
+          ? {
+              ...item,
+              label: customerSurface.shellLabel,
+              description: customerSurface.detailHint,
+            }
+          : item,
+      ),
+    }));
   // The breadcrumb offers only what this principal can open. Same registry the
   // rail filters on and the destination route enforces (BI-2777B86B).
   const grantedCapabilities = getGrantedCapabilities(userContext);
@@ -273,7 +290,10 @@ export default async function ShellLayout({ children }: { children: React.ReactN
                   style={{ maxWidth: "var(--shell-page-content-max-width, none)" }}
                 >
                   {shellNavSections.length > 0 && (
-                    <ShellBreadcrumb capabilities={grantedCapabilities} />
+                    <ShellBreadcrumb
+                      capabilities={grantedCapabilities}
+                      labelOverrides={{ customer: customerSurface.shellLabel }}
+                    />
                   )}
                   <UxInitialLoadBoundary>{children}</UxInitialLoadBoundary>
                 </div>

--- a/apps/web/components/shell/ShellBreadcrumb.test.tsx
+++ b/apps/web/components/shell/ShellBreadcrumb.test.tsx
@@ -42,6 +42,17 @@ function render(path: string, capabilities: ReadonlySet<string> = ADMIN) {
 }
 
 describe("buildBreadcrumbTrail", () => {
+  it("applies an archetype-facing label to the shared customer root", () => {
+    expect(
+      buildBreadcrumbTrail("/customer/engagements", ADMIN, {
+        customer: "Adoption & community",
+      }),
+    ).toEqual([
+      { label: "Adoption & community", href: "/customer" },
+      { label: "Engagements", href: "/customer/engagements" },
+    ]);
+  });
+
   it("walks the canonical parentPath chain to the domain root", () => {
     expect(buildBreadcrumbTrail("/platform/ai/providers", ADMIN)).toEqual([
       { label: "Platform Hub", href: "/platform" },

--- a/apps/web/components/shell/ShellBreadcrumb.tsx
+++ b/apps/web/components/shell/ShellBreadcrumb.tsx
@@ -49,6 +49,7 @@ function canOpen(
 export function buildBreadcrumbTrail(
   pathname: string,
   capabilities: ReadonlySet<string>,
+  labelOverrides: Readonly<Record<string, string>> = {},
 ): Crumb[] {
   const record = getRouteNavRecord(pathname);
 
@@ -60,7 +61,7 @@ export function buildBreadcrumbTrail(
     while (current && !seen.has(current.path)) {
       seen.add(current.path);
       if (canOpen(current.capabilityKey, capabilities)) {
-        trail.unshift({ label: current.label, href: current.path });
+        trail.unshift({ label: labelOverrides[current.key] ?? current.label, href: current.path });
       }
       if (current.parentPath === current.path) break;
       current = getRouteNavRecord(current.parentPath);
@@ -84,7 +85,13 @@ export function buildBreadcrumbTrail(
   return trail;
 }
 
-export function ShellBreadcrumb({ capabilities }: { capabilities: readonly string[] }) {
+export function ShellBreadcrumb({
+  capabilities,
+  labelOverrides = {},
+}: {
+  capabilities: readonly string[];
+  labelOverrides?: Readonly<Record<string, string>>;
+}) {
   const pathname = usePathname();
   const granted = useMemo(() => new Set(capabilities), [capabilities]);
 
@@ -93,7 +100,7 @@ export function ShellBreadcrumb({ capabilities }: { capabilities: readonly strin
   // EP-NAV-COHERENCE P5 (BI-74158F1A).
   if (pathname.startsWith("/portfolio")) return null;
 
-  const trail = buildBreadcrumbTrail(pathname, granted);
+  const trail = buildBreadcrumbTrail(pathname, granted, labelOverrides);
 
   // A single crumb (you are on a domain home) needs no trail.
   if (trail.length < 2) return null;

--- a/apps/web/lib/finance/finance-surface.test.ts
+++ b/apps/web/lib/finance/finance-surface.test.ts
@@ -243,6 +243,15 @@ describe("pet-rescue finance surface", () => {
       spend: "Care spending",
       close: "Stewardship",
     });
+    expect(surface.metricCopy).toEqual({
+      outstandingSingular: "commitment",
+      outstandingPlural: "commitments",
+      receivedSingular: "contribution",
+      receivedPlural: "contributions",
+      emptyOverdue: "no commitments recorded yet",
+      recentAccountHeader: "Supporter or funder",
+      recentEmpty: "No contributions yet.",
+    });
   });
 
   it("does not make every nonprofit inherit pet-rescue claims", () => {

--- a/apps/web/lib/finance/finance-surface.ts
+++ b/apps/web/lib/finance/finance-surface.ts
@@ -117,6 +117,16 @@ export type FinanceSurfaceModel = {
   navigationLabels: Record<"revenue" | "spend" | "close" | "configuration", string>;
   recentRecordsLabel: string;
   recentRecordsEmpty: string;
+  /** Visible metric/table nouns when the persisted record type is an internal implementation detail. */
+  metricCopy?: {
+    outstandingSingular: string;
+    outstandingPlural: string;
+    receivedSingular: string;
+    receivedPlural: string;
+    emptyOverdue: string;
+    recentAccountHeader: string;
+    recentEmpty: string;
+  };
 };
 
 // Archetype categories that get the owner-first money-jobs surface. Keyed on
@@ -516,6 +526,15 @@ export function resolveFinanceSurface(
       },
       recentRecordsLabel: "Recent contributions",
       recentRecordsEmpty: "No contributions recorded yet. Record a donation, grant, or sponsorship to get started.",
+      metricCopy: {
+        outstandingSingular: "commitment",
+        outstandingPlural: "commitments",
+        receivedSingular: "contribution",
+        receivedPlural: "contributions",
+        emptyOverdue: "no commitments recorded yet",
+        recentAccountHeader: "Supporter or funder",
+        recentEmpty: "No contributions yet.",
+      },
     };
   }
 

--- a/apps/web/lib/owner-first/archetype-surface.test.ts
+++ b/apps/web/lib/owner-first/archetype-surface.test.ts
@@ -26,6 +26,7 @@ describe("resolveCustomerSurface", () => {
     );
     expect(surface.newEntry.buttonLabel).toBe("+ Add person or partner");
     expect(surface.detailSummary).toBe("Relationship records");
+    expect(surface.shellLabel).toBe("Adoption & community");
   });
 
   it("uses the same rescue contract for animal shelters", () => {
@@ -41,5 +42,6 @@ describe("resolveCustomerSurface", () => {
     expect(surface.tabs).toEqual(CRM_TABS);
     expect(surface.newEntry.buttonLabel).toBe("+ New Account");
     expect(surface.detailSummary).toBe("All CRM detail");
+    expect(surface.shellLabel).toBe("Customer");
   });
 });

--- a/apps/web/lib/owner-first/archetype-surface.ts
+++ b/apps/web/lib/owner-first/archetype-surface.ts
@@ -2,6 +2,8 @@ export type CustomerSurfaceTab = { label: string; href: string };
 
 export type CustomerSurface = {
   title: string;
+  /** Label used by the shared shell rail and breadcrumbs. */
+  shellLabel: string;
   accountCountLabel: string;
   tabs: CustomerSurfaceTab[];
   newEntry: {
@@ -29,6 +31,7 @@ export function resolveCustomerSurface(
     ]);
     return {
       title: "Adoption & community",
+      shellLabel: "Adoption & community",
       accountCountLabel: "people & partners",
       tabs: availableTabs
         .filter((tab) => allowed.has(tab.href))
@@ -46,6 +49,7 @@ export function resolveCustomerSurface(
 
   return {
     title: "Customer",
+    shellLabel: "Customer",
     accountCountLabel: "accounts",
     tabs: availableTabs,
     newEntry: {

--- a/apps/web/lib/tak/agent-routing.ts
+++ b/apps/web/lib/tak/agent-routing.ts
@@ -270,13 +270,13 @@ ON THIS PAGE: The user sees role assignments, team structures, oversight levels,
   },
   "/customer": {
     agentId: "customer-advisor",
-    agentName: "Customer Success Manager",
-    agentDescription: "Customer accounts, pipeline, opportunities, quotes, and satisfaction",
+    agentName: "Relationship Manager",
+    agentDescription: "People and organization relationships, enquiries, follow-ups, and satisfaction",
     capability: "view_customer",
     sensitivity: "confidential",
-    systemPrompt: `You are the Customer Success Manager.
+    systemPrompt: `You are the Relationship Manager.
 
-PERSPECTIVE: You see the platform through the eyes of service consumers. You encode the world as customer accounts, service levels, adoption rates, satisfaction signals, and friction points. Every interaction is an opportunity to improve the customer experience.
+PERSPECTIVE: You see the platform through the eyes of the people and organizations it serves. Adapt the shared relationship records to the organization's archetype: a commercial firm may have customers and opportunities; a rescue has adopters, foster families, surrenderers, volunteers, donors, partners, and adoption enquiries. Never invent a sales concept where the organization does not use one.
 
 HEURISTICS:
 - Customer journey mapping: what path does the user take? Where do they get stuck?
@@ -286,7 +286,7 @@ HEURISTICS:
 
 INTERPRETIVE MODEL: You optimize for customer satisfaction and service adoption. Success means customers achieve their goals with minimum friction and maximum value from the platform.
 
-ON THIS PAGE: The user sees the Customer workspace — accounts, engagements, pipeline, opportunities, quotes, orders, and funnel.
+ON THIS PAGE: The user sees the organization's relationship workspace. Its labels and available sections are archetype-specific; treat suppressed sections as concepts that do not exist here, not features to rename or recommend.
 
 CRM TOOLS — you operate this workspace directly, you do not just describe it:
 - Inspect: list_customer_accounts, list_opportunities, get_opportunity, and list_quotes to review accounts, the pipeline, and existing quotes.
@@ -297,9 +297,9 @@ CRM TOOLS — you operate this workspace directly, you do not just describe it:
 - When the user asks how to do something (for example "how do I enter a quote?"), explain the steps in plain language AND offer to do it for them with these tools.
 - Never claim a record was created unless the tool result confirms it. Sending a quote to a customer is a human action — you only draft.`,
     skills: [
-      { label: "Review pipeline", description: "Summarize opportunities, find the strongest", capability: "view_customer", prompt: "Review the pipeline. List the open opportunities by stage and value, and tell me the strongest candidates to advance." },
-      { label: "Draft a quote", description: "Create a draft quote for an opportunity", capability: "operate_customer", prompt: "Help me draft a quote. Show me the open opportunities first, then walk me through the line items and create the draft." },
-      { label: "Add an account", description: "Create a new customer account or prospect", capability: "operate_customer", prompt: "I want to add a new customer account." },
+      { label: "Review relationships", description: "Summarize active relationships and follow-ups", capability: "view_customer", prompt: "Review our active relationships and enquiries using the terminology shown on this page. Tell me which follow-ups need attention." },
+      { label: "Plan a follow-up", description: "Choose the next appropriate relationship action", capability: "operate_customer", prompt: "Help me plan the next follow-up for a relationship or enquiry, using only concepts appropriate to this organization." },
+      { label: "Add a relationship", description: "Create a person or organization relationship", capability: "operate_customer", prompt: "I want to add a person or organization relationship." },
       { label: "Report an issue", description: "Report a bug or give feedback", capability: null, prompt: "I'd like to report an issue or give feedback about this page." },
     ],
   },
@@ -1064,7 +1064,7 @@ const CANNED_RESPONSES: Record<string, CannedResponseSet> = {
   },
   "customer-advisor": {
     default: [
-      "I'm the Customer Success Manager. I can help you review customer journeys, identify friction points, and track adoption metrics. You can also explore more actions in the skills menu above.",
+      "I'm the Relationship Manager. I can help you review relationships, identify friction points, and keep follow-ups moving in language that fits this organization. You can also explore more actions in the skills menu above.",
     ],
     restricted: [
       "I can provide general information about customer management, but account actions require customer view permissions.",

--- a/docs/architecture/agent-standards-dpf-conformance.md
+++ b/docs/architecture/agent-standards-dpf-conformance.md
@@ -46,6 +46,12 @@ The companion verification rubrics intended to make future conformance claims re
 | Control Area | Status | Evidence Path | Notes | Recommended Next Step |
 |--------------|--------|---------------|-------|-----------------------|
 | Stable agent identity | Partially Implemented | `packages/db/data/agent_registry.json`, `apps/web/lib/tak/agent-routing.ts` | `DPF` already carries stable agent identifiers, model bindings, supervisors, delegates, tool grants, and memory declarations. However, these identities are still platform-local and are not yet expressed as canonical `GAID` identifiers. | Introduce canonical `GAID` identifiers and bind route-facing identities to them consistently. |
+
+Route-facing agent identity is also presentation-sensitive. Shared substrate names
+must remain truthful across archetypes: the `/customer` route uses the neutral
+**Relationship Manager** presentation and instructs the agent to follow the
+archetype-specific labels and suppressed concepts rendered by the page. Tool and
+authority identities remain stable; only owner-facing language is adapted.
 | Public/private identity scoping | Not Implemented | Current implementation review | The reviewed implementation does not yet distinguish internal private identifiers from externally accredited public identifiers. | Add explicit `priv` and `pub` identity scopes, plus governed boundary mapping rules. |
 | Agent identity document | Partially Implemented | `packages/db/data/agent_registry.json` | The registry approximates an internal `AIDoc` because it already captures model, supervisor, grants, `HITL`, delegation, and memory metadata. It is not yet a signed, resolvable, standardized identity document. | Define and publish a formal `AIDoc` schema, resolution mechanism, and signing model. |
 | Badge and assurance declarations | Not Implemented | Current implementation review | `DPF` contains useful metadata, but it does not yet publish structured badges for capability, governance, sensitivity, or fit-for-purpose, nor does it distinguish assurance levels. | Add badge schemas and evidence-backed assurance levels, starting with self-asserted and organization-attested claims. |

--- a/docs/user-guide/customers/index.md
+++ b/docs/user-guide/customers/index.md
@@ -26,7 +26,9 @@ partners**, **Adoption enquiries**, and **Community outreach**. Commercial
 pipeline, quote, order, and sales-funnel tabs are hidden because they are not
 part of the rescue's normal operating model. **Add person or partner** still
 creates the canonical relationship record; it does not create a second kind of
-customer database.
+customer database. The shared rail, breadcrumbs, and Relationship Manager use
+the same rescue-facing language, so opening the coworker panel does not bring
+the suppressed commercial concepts back into view.
 
 ## The Customer Lifecycle
 

--- a/docs/user-guide/finance/index.md
+++ b/docs/user-guide/finance/index.md
@@ -14,7 +14,9 @@ commitments, animal-care bills, and cash available for care. **Record
 contribution** is the primary entry point, with donation, grant, sponsorship,
 and other contribution contexts. The underlying finance records, controls, and
 permissions remain canonical; the archetype changes the operator vocabulary,
-not the accounting truth.
+not the accounting truth. Foreground totals therefore count **contributions**
+and **commitments**, and recent records identify the **supporter or funder**;
+the internal invoice record type remains available only as accounting detail.
 
 ```mermaid
 flowchart TB


### PR DESCRIPTION
## Outcome\n\nCloses the remaining live Pet Rescue vocabulary gap exposed after PR #5019.\n\n- The global customer shell now reads **Adoption & community** for Pet Rescue.\n- The customer coworker presentation is relationship/enquiry oriented instead of sales-pipeline oriented.\n- Finance metrics and empty states use contributions, commitments, supporters/funders, and stewardship language.\n- Shared canonical CRM and invoice records remain unchanged.\n\n## Live acceptance defect\n\nThe deployed PR #5019 surface still exposed legacy foreground nouns: Customer, Customer Success Manager, pipeline/opportunities/quotes, invoices paid, invoices outstanding, and no invoices recorded. This patch removes those Pet Rescue-facing leaks while preserving generic archetypes.\n\n## Verification\n\n- TDD RED: 3 intended failures in the 66-test focused baseline.\n- GREEN: 7 files / 146 tests.\n- web typecheck PASS.\n- module-size PASS.\n- docs index PASS (696 pages).\n- diff check PASS.\n- DCO PASS.\n- Full preflight completed 58 checks; its only failure was the exact design-grounding marker. The marker was added and the deterministic guard reran PASS. The aggregate rerun is ledgered as an operator-authorized local-gate bypass; protected GitHub checks remain mandatory.\n\n## Design grounding\n\nExisting specs/plans reviewed: docs/architecture/archetypes/pet-rescue-operating-model.md and the BI-9C5A3787 reach contract.\n\nCurrent code substrate reviewed: archetype surface policy, finance surface policy, route coworker presentation, and shared shell navigation.\n\nDecision: keep canonical CRM and invoice records while making every foreground Pet Rescue label truthful and suppressing commercial concepts that do not exist.\n\nDesign-Grounding-Decision: archetype-specific foreground vocabulary with canonical shared records preserved\n\nCompletes acceptance for BI-9C5A3787.